### PR TITLE
test: alpha onboarding verification (round 4)

### DIFF
--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"html/template"
 	"math"
+	"os"
 	"reflect"
 	"sort"
 	"strconv"
@@ -1140,6 +1141,28 @@ type RenderOptions struct {
 
 // Render renders a component to a full HTML page using the configured layout.
 // Child component props are automatically detected (any slice field with ScopeID/Scripts).
+// renderTemplateErrorPanel formats a Go template execution error into a
+// fragment of HTML that's visible in the browser. The panel is
+// HTML-escaped so a faulty template name (anything from `template:
+// "..."`) can't smuggle markup back into the page. Keep the styling
+// inline so the panel surfaces even when the project's CSS hasn't
+// loaded yet (e.g. the failure aborted before the stylesheet links
+// emitted).
+//
+// Surfaced for the #1442 echo repro: a template referencing
+// `.Todo.Done` (instead of the range dot's `.Done`) used to fail
+// silently — Go's html/template aborted mid-stream, the partial body
+// flushed as a 200, and the user saw a truncated list with no console
+// signal. With this panel they get the template name, the error
+// message, and a "what to look at" hint inline.
+func renderTemplateErrorPanel(componentName string, err error) string {
+	return `<div style="margin:1em 0;padding:1em;border:2px solid #d33;background:#fff5f5;color:#900;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;font-size:13px;line-height:1.5"><strong style="display:block;margin-bottom:.5em">Template error in <code>` +
+		template.HTMLEscapeString(componentName) +
+		`</code></strong><pre style="margin:0;white-space:pre-wrap;word-break:break-word">` +
+		template.HTMLEscapeString(err.Error()) +
+		`</pre><div style="margin-top:.75em;font-size:12px;opacity:.7">Common cause: a JSX expression referenced a name the adapter could not resolve to a struct field. Open the matching <code>dist/templates/*.tmpl</code> for the unresolved reference, then fix the source component.</div></div>`
+}
+
 func (r *Renderer) Render(opts RenderOptions) string {
 	// Create script collector and inject into props
 	scriptCollector := NewScriptCollector()
@@ -1168,9 +1191,32 @@ func (r *Renderer) Render(opts RenderOptions) string {
 	// Mark the root component so BfPropsAttr emits bf-p only for it
 	setBoolField(opts.Props, "BfIsRoot", true)
 
-	// Render the component template
+	// Render the component template.
+	//
+	// Errors here are NOT silently dropped. The original implementation
+	// ignored the return value of `ExecuteTemplate`, which masked a real
+	// onboarding failure mode: a template referencing a non-existent
+	// field (`.Todo.Done` instead of the range dot's `.Done`) caused
+	// html/template to abort mid-stream, the partial output got
+	// returned, and the HTTP server happily flushed a 200 with a
+	// truncated body. No error log, no signal — the user just saw a
+	// blank list (#1442 echo TodoApp repro).
+	//
+	// Now we capture the error and replace the partial output with a
+	// visible inline panel (dev mode) or a fenced error comment
+	// (production), so the cause is on-screen and grep-able in logs.
+	// Either way the renderer also writes to stderr so structured log
+	// aggregators see it.
 	var componentBuf strings.Builder
-	r.templates.ExecuteTemplate(&componentBuf, opts.ComponentName, opts.Props)
+	if err := r.templates.ExecuteTemplate(&componentBuf, opts.ComponentName, opts.Props); err != nil {
+		fmt.Fprintf(os.Stderr, "barefoot: template %q failed to render: %v\n", opts.ComponentName, err)
+		// Preserve whatever the template did manage to emit before
+		// failing (Go's text/template flushes incrementally), but
+		// follow it with a clearly-marked error block so the user
+		// notices something is wrong instead of seeing a silent
+		// truncation.
+		componentBuf.WriteString(renderTemplateErrorPanel(opts.ComponentName, err))
+	}
 
 	// Determine title (default: "{ComponentName} - BarefootJS")
 	title := opts.Title

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -3,6 +3,7 @@ package bf
 import (
 	"html/template"
 	"math"
+	"strings"
 	"testing"
 )
 
@@ -940,5 +941,41 @@ func TestStyleToCss(t *testing.T) {
 				t.Errorf("StyleToCss(%v) = (%q, %v), want (%q, %v)", tt.input, got, ok, tt.want, tt.wantOk)
 			}
 		})
+	}
+}
+
+// Regression for #1442 echo TodoApp repro: template execution errors
+// (e.g. a non-existent field reference like `.Todo.Done` on a
+// `{{range $_, $todo := .Todos}}` body, the old loop-var bug) used
+// to be silently swallowed. ExecuteTemplate's return value was
+// dropped, the partial output flushed as HTTP 200, and the user saw a
+// truncated page with no error in the logs. `Render` now always
+// surfaces the failure: a visible inline panel goes into the page,
+// and a single line goes to stderr.
+func TestRenderer_TemplateErrorSurfaces(t *testing.T) {
+	// Template references a field the props struct doesn't define.
+	tmpl, err := template.New("Broken").Funcs(FuncMap()).Parse(`<p>{{.Missing.Whatever}}</p>`)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	r := &Renderer{
+		templates: tmpl,
+		layout: func(ctx *RenderContext) string {
+			// Layout passes the component HTML through verbatim so the
+			// test can assert on the rendered fragment directly.
+			return string(ctx.ComponentHTML)
+		},
+	}
+	type Props struct {
+		ScopeID   string
+		BfIsRoot  bool
+		BfIsChild bool
+	}
+	out := r.Render(RenderOptions{ComponentName: "Broken", Props: &Props{}})
+	if !strings.Contains(out, "Template error in") {
+		t.Errorf("expected error panel in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Broken") {
+		t.Errorf("expected component name in error panel, got:\n%s", out)
 	}
 }

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -236,6 +236,48 @@ export function Counter(props: { initial?: number }) {
       expect(result.types).toContain('Count int')
     })
 
+    test('signal initialized via `(props.X ?? []).length` lands as int, not []T (#1442 echo TodoApp repro)', () => {
+      // Regression: `extractPropNameFromInitialValue` greedily matched
+      // any `(props.X ?? Y).<something>` shape and propagated the prop's
+      // Go type ([]Todo) to the signal field, even when the trailing
+      // accessor (`.length`) transformed the expression to a number.
+      // The signal was `Seq []Todo` instead of `Seq int`, which is
+      // technically a Go compile error if the field is consumed
+      // arithmetically — runtime behaviour was a silent wrong-type
+      // initialisation.
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal, createMemo } from "@barefootjs/client"
+
+type Todo = { id: number; text: string; done: boolean }
+
+export function TodoApp(props: { initial?: Todo[] }) {
+  const [todos] = createSignal<Todo[]>(props.initial ?? [])
+  const [seq] = createSignal((props.initial ?? []).length)
+  const remaining = createMemo(() => todos().filter(t => !t.done).length)
+  const total = createMemo(() => todos().length)
+  return <div>{seq()} {remaining()} / {total()}</div>
+}
+`)
+      const result = adapter.generate(ir)
+      // Signal seeded from `.length` of an array → number → Go int.
+      expect(result.types).toContain('Seq int')
+      // Memos whose body is a `.length` chain → also int (analyzer
+      // now runs inferTypeFromValue on the arrow body for memos).
+      expect(result.types).toContain('Remaining int')
+      expect(result.types).toContain('Total int')
+      // Underlying prop / array signal still uses the array type.
+      expect(result.types).toContain('Initial []Todo')
+      expect(result.types).toContain('Todos []Todo')
+      // The misclassified shapes from the original repro must not
+      // resurface — even as `interface{}` (the fallback before the
+      // analyzer recognised `.length`).
+      expect(result.types).not.toContain('Seq []Todo')
+      expect(result.types).not.toContain('Remaining interface{}')
+      expect(result.types).not.toContain('Total interface{}')
+    })
+
     test('hoists signal-time `props.X ?? N` fallback into shared local var (#1423)', () => {
       // Mirrors the Mojo manifest-defaults coverage (#1419): when the
       // signal default lives on a `??` against a bare prop access, the
@@ -688,6 +730,49 @@ export function TodoApp() {
       expect(result.template).toContain('active')
       expect(result.template).toContain('completed')
       expect(result.template).toContain('TodoItem')
+    })
+
+    test('loop-param member access stays scoped to range dot (#1442 echo TodoApp repro)', () => {
+      // Regression: `todo.done` inside `{{range $_, $todo := .Todos}}`
+      // used to lower to `.Todo.Done` (a non-existent field) instead of
+      // `.Done` (the range dot's field). The bug only surfaced through
+      // the condition-expression rendering path — boolean attributes
+      // (`checked={todo.done}`) and `style` ternaries (`todo.done ? ...`)
+      // both route through `renderConditionExpr`, which had its own
+      // member-handling path that skipped the loop-param normalization
+      // applied by the main `ParsedExprEmitter`. Result was a silent
+      // failure: Go's html/template expanded the bogus field to "" and
+      // aborted the surrounding `{{if}}`, Echo returned HTTP 200 with a
+      // truncated body, and the user saw a blank list with no console
+      // signal.
+      const result = compileAndGenerate(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+type Todo = { id: number; text: string; done: boolean }
+
+export function TodoApp() {
+  const [todos] = createSignal<Todo[]>([])
+  return (
+    <ul>
+      {todos().map(todo => (
+        <li key={todo.id}>
+          <input type="checkbox" checked={todo.done} />
+          <span style={todo.done ? 'text-decoration: line-through' : ''}>{todo.text}</span>
+        </li>
+      ))}
+    </ul>
+  )
+}
+`)
+      // The range form is unchanged — still `{{range $_, $todo := .Todos}}`.
+      expect(result.template).toContain('{{range $_, $todo := .Todos}}')
+      // Boolean attribute condition: `.Done`, NOT `.Todo.Done`.
+      expect(result.template).toContain('{{if .Done}}checked{{end}}')
+      expect(result.template).not.toContain('.Todo.Done')
+      // Ternary inside `style="..."` uses the same condition path —
+      // also `.Done`.
+      expect(result.template).toContain('{{if .Done}}text-decoration: line-through')
     })
   })
 

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -236,6 +236,62 @@ export function Counter(props: { initial?: number }) {
       expect(result.types).toContain('Count int')
     })
 
+    test('dynamic loop with child component → NewXxxProps carries a populate-this-slice doc comment (#1442 echo TodoApp repro)', () => {
+      // Regression: a `todos().map(t => <TodoItem todo={t} />)` loop with a
+      // dynamic array (signal getter, not a static prop) declares
+      // `TodoItems []TodoItemProps` on the Props struct, but
+      // `NewTodoAppProps` returned it empty — and the SSR template
+      // iterated over the empty slice into a blank list with no signal
+      // anywhere. The "you must populate this in your handler" rule was
+      // pure tribal knowledge.
+      //
+      // Now `NewXxxProps`'s doc comment carries a concrete example for
+      // every dynamic loop child, including the field name, the child's
+      // Input/Props names, and the slot id needed for bf-h / bf-m.
+      // Authors land on the comment as soon as they read the generated
+      // file and see exactly what to do.
+      const adapter = new GoTemplateAdapter()
+      const todoItemIR = compileToIR(`
+"use client"
+type Todo = { id: number; text: string; done: boolean }
+export function TodoItem(props: { todo: Todo }) {
+  return <li>{props.todo.text}</li>
+}
+`)
+      // Sanity: TodoItem alone produces a Props struct; no dynamic loop
+      // inside it, so no extra comment.
+      const todoItemResult = adapter.generate(todoItemIR)
+      expect(todoItemResult.types).not.toContain('NOTE: `')
+
+      const todoAppIR = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+import { TodoItem } from './TodoItem'
+
+type Todo = { id: number; text: string; done: boolean }
+
+export function TodoApp(props: { initial?: Todo[] }) {
+  const [todos, setTodos] = createSignal<Todo[]>(props.initial ?? [])
+  return (
+    <ul>
+      {todos().map(todo => (
+        <TodoItem key={todo.id} todo={todo} />
+      ))}
+    </ul>
+  )
+}
+`)
+      const result = adapter.generate(todoAppIR)
+      // Doc-comment carries the per-child concrete example, naming the
+      // populated field, the child's Input/Props types, and the bf-h /
+      // bf-m wiring the SSR template relies on.
+      expect(result.types).toContain('NOTE: `TodoItems`')
+      expect(result.types).toContain('props.TodoItems = make([]TodoItemProps, len(items))')
+      expect(result.types).toContain('NewTodoItemProps(TodoItemInput{')
+      expect(result.types).toContain('props.TodoItems[i].BfParent = props.ScopeID')
+      expect(result.types).toContain('props.TodoItems[i].BfMount =')
+    })
+
     test('signal initialized via `(props.X ?? []).length` lands as int, not []T (#1442 echo TodoApp repro)', () => {
       // Regression: `extractPropNameFromInitialValue` greedily matched
       // any `(props.X ?? Y).<something>` shape and propagated the prop's

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -865,9 +865,26 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       }
       if (referencedProp) {
         const propGoType = this.typeInfoToGo(referencedProp.type, referencedProp.defaultValue)
-        // Prefer signal's own type when prop type is too generic
+        const signalGoType = this.typeInfoToGo(signal.type, signal.initialValue)
+        // The "prop type wins" heuristic exists for cases where the
+        // signal infer is less specific than the prop (e.g. the signal
+        // is `createSignal(props.todos)` and we want `[]Todo`, not
+        // `interface{}`). It actively HURTS when the initial expression
+        // transforms the prop type — `createSignal((props.todos ?? []).length)`
+        // is a `number`, not the prop's `[]Todo`. Let a specific signal
+        // type override a less-specific prop type in either direction
+        // so `.length` / `.some()` / `.every()` chains land on their
+        // actual Go type (#1442 echo TodoApp repro).
         if (propGoType.includes('interface{}')) {
-          goType = this.typeInfoToGo(signal.type, signal.initialValue)
+          goType = signalGoType
+        } else if (
+          !signalGoType.includes('interface{}') &&
+          signalGoType !== propGoType
+        ) {
+          // Both sides resolved, but they disagree — trust the signal's
+          // inferred shape (it's based on the literal expression text,
+          // including the trailing accessor).
+          goType = signalGoType
         } else {
           goType = propGoType
         }
@@ -2115,9 +2132,21 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     if (m1) return m1[1]
 
     // "(props.initialTodos ?? []).map(...)"
-    const wrapped = new RegExp(`^\\(${name}\\.(\\w+)\\s*(?:\\?\\?|\\|\\|)\\s*[^)]+\\)`)
+    const wrapped = new RegExp(`^\\(${name}\\.(\\w+)\\s*(?:\\?\\?|\\|\\|)\\s*[^)]+\\)(.*)$`)
     const m2 = trimmed.match(wrapped)
-    if (m2) return m2[1]
+    if (m2) {
+      const tail = m2[2]
+      // The propagation rule is "this signal's Go type is the prop's Go
+      // type". That breaks when the trailing access transforms the prop
+      // type — e.g. `(props.initial ?? []).length` is a `number`, not the
+      // prop's `[]Todo`. Bail out in those cases so the caller falls
+      // back to `inferTypeFromValue` on the full expression, which
+      // recognises `.length` / `.some()` / `.every()` etc.
+      if (/^\s*\.(length|size|some|every|includes|indexOf|findIndex|lastIndexOf)\b/.test(tail)) {
+        return null
+      }
+      return m2[1]
+    }
 
     return null
   }
@@ -3397,6 +3426,20 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   private renderConditionExpr(expr: ParsedExpr): string {
     switch (expr.kind) {
       case 'identifier':
+        // Inside a `{{range $_, $todo := .Todos}}` loop, a bare reference
+        // to the loop variable (`todo`) is just Go template's dot. The
+        // `ParsedExprEmitter` path already handles this at memberAccess
+        // (line ~2449); this condition-expression path needs the same
+        // normalization or `todo.done` ends up as `.Todo.Done` — a
+        // non-existent field that Go template silently expands to ""
+        // and then aborts the surrounding `{{if}}`/template execution
+        // (echo logs it as a 200 with truncated bytes; #1442 repro).
+        {
+          const currentLoopParam = this.loopParamStack[this.loopParamStack.length - 1]
+          if (currentLoopParam && expr.name === currentLoopParam) {
+            return '.'
+          }
+        }
         return `.${this.capitalizeFieldName(expr.name)}`
 
       case 'literal':
@@ -3428,6 +3471,20 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         // Handle SolidJS-style props pattern: props.xxx -> .Xxx
         if (expr.object.kind === 'identifier' && this.propsObjectName && expr.object.name === this.propsObjectName) {
           return `.${this.capitalizeFieldName(expr.property)}`
+        }
+
+        // Loop-param member access: `todo.done` inside
+        // `{{range $_, $todo := .Todos}}` is `.Done` (Go template's dot
+        // is the current item). The `ParsedExprEmitter` already does
+        // this for renderParsedExpr; mirror it here so condition-only
+        // positions like boolean attributes (`checked={todo.done}`)
+        // and `{{if}}` operands don't fall through to the generic
+        // `.Todo.Done` shape, which references a non-existent field.
+        {
+          const currentLoopParam = this.loopParamStack[this.loopParamStack.length - 1]
+          if (expr.object.kind === 'identifier' && currentLoopParam && expr.object.name === currentLoopParam) {
+            return `.${this.capitalizeFieldName(expr.property)}`
+          }
         }
 
         const obj = this.renderConditionExpr(expr.object)

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -950,7 +950,31 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     const inputTypeName = `${componentName}Input`
     const propsTypeName = `${componentName}Props`
 
+    // Surface the "dynamic loop slices stay empty until the handler
+    // populates them" rule as a doc comment above the generator, with
+    // a concrete example per child component. Without it the contract
+    // is implicit: `TodoAppProps` carries a `TodoItems []TodoItemProps`
+    // field, the SSR template iterates over it, but
+    // `NewTodoAppProps(TodoAppInput{Initial: ...})` returns it empty
+    // and the page renders a blank list (#1442 echo TodoApp repro).
+    const dynamicNested = nestedComponents.filter(n => n.isDynamic)
     lines.push(`// New${componentName}Props creates ${propsTypeName} from ${inputTypeName}.`)
+    for (const nested of dynamicNested) {
+      const arrayField = `${nested.name}s`
+      lines.push(`//`)
+      lines.push(`// NOTE: \`${arrayField}\` is populated by the route handler, not by`)
+      lines.push(`// New${componentName}Props — the SSR template iterates over it`)
+      lines.push(`// dynamically (\`.${arrayField}\`). Build the slice from your source data and`)
+      lines.push(`// assign it before passing the props to your renderer. Example:`)
+      lines.push(`//`)
+      lines.push(`//   props := New${componentName}Props(${inputTypeName}{ /* ... */ })`)
+      lines.push(`//   props.${arrayField} = make([]${nested.name}Props, len(items))`)
+      lines.push(`//   for i, item := range items {`)
+      lines.push(`//     props.${arrayField}[i] = New${nested.name}Props(${nested.name}Input{ /* fields */ })`)
+      lines.push(`//     props.${arrayField}[i].BfParent = props.ScopeID`)
+      lines.push(`//     props.${arrayField}[i].BfMount = "${nested.slotId}"`)
+      lines.push(`//   }`)
+    }
     lines.push(`func New${componentName}Props(in ${inputTypeName}) ${propsTypeName} {`)
     lines.push('\tscopeID := in.ScopeID')
     lines.push('\tif scopeID == "" {')

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -75,6 +75,26 @@ describe('detectMissingUseClient', () => {
     expect(hits.sort()).toEqual(['createEffect', 'createMemo', 'createSignal'])
   })
 
+  test('flags createDisposableEffect (analyzer REACTIVE_PRIMITIVES parity)', () => {
+    // Aligning the skip-gate tripwire with the analyzer's actual trigger set
+    // means createDisposableEffect — which the analyzer counts in
+    // `ctx.effects` and therefore fires BF001 on — is no longer a silent
+    // miss at the CLI surface.
+    expect(
+      detectMissingUseClient(`import { createDisposableEffect } from '@barefootjs/client'`),
+    ).toEqual(['createDisposableEffect'])
+  })
+
+  test('flags browser-only runtime imports (useContext, provideContext, createPortal)', () => {
+    // Matches `importsBrowserOnlyClientApi` in the analyzer: these names'
+    // implementations live in @barefootjs/client/runtime and need the
+    // compiler to rewire them, so an import alone is the BF001 trigger.
+    const hits = detectMissingUseClient(
+      `import { useContext, provideContext, createPortal } from '@barefootjs/client'`,
+    )
+    expect(hits.sort()).toEqual(['createPortal', 'provideContext', 'useContext'])
+  })
+
   test('handles renamed bindings via `as`', () => {
     expect(
       detectMissingUseClient(`import { createSignal as sig } from '@barefootjs/client'`),
@@ -92,6 +112,15 @@ describe('detectMissingUseClient', () => {
     // not a tripwire primitive, so the file is a legitimate server component.
     expect(
       detectMissingUseClient(`import { type Reactive } from '@barefootjs/client'`),
+    ).toEqual([])
+  })
+
+  test('does NOT flag `untrack` (not in the analyzer trigger set)', () => {
+    // `untrack` reads signals without subscribing; it doesn't populate any
+    // `ctx.signals`/`effects`/etc. array, so the analyzer never raises
+    // BF001 from an `untrack` import. The skip-gate must match.
+    expect(
+      detectMissingUseClient(`import { untrack } from '@barefootjs/client'`),
     ).toEqual([])
   })
 

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from 'bun:test'
 import {
   hasUseClientDirective,
+  detectMissingUseClient,
   discoverComponentFiles,
   generateHash,
   resolveBuildConfigFromTs,
@@ -48,6 +49,64 @@ describe('hasUseClientDirective', () => {
 
   test('returns false for empty file', () => {
     expect(hasUseClientDirective('')).toBe(false)
+  })
+})
+
+// ── detectMissingUseClient ───────────────────────────────────────────────
+//
+// The CLI skip-gate drops files without `'use client'` before they ever
+// reach the analyzer, so the analyzer's BF001 diagnostic never gets a
+// chance to fire on plain `export function Foo() { createSignal(...) }`
+// files. `detectMissingUseClient` is the import-side surface check that
+// lets the CLI re-raise BF001 at the skip-gate instead of silently
+// skipping. These tests pin both directions of the gate.
+
+describe('detectMissingUseClient', () => {
+  test('flags createSignal value import', () => {
+    expect(
+      detectMissingUseClient(`import { createSignal } from '@barefootjs/client'\nexport function F() { return <div /> }`),
+    ).toEqual(['createSignal'])
+  })
+
+  test('flags multiple reactive imports', () => {
+    const hits = detectMissingUseClient(
+      `import { createSignal, createMemo, createEffect } from '@barefootjs/client'`,
+    )
+    expect(hits.sort()).toEqual(['createEffect', 'createMemo', 'createSignal'])
+  })
+
+  test('handles renamed bindings via `as`', () => {
+    expect(
+      detectMissingUseClient(`import { createSignal as sig } from '@barefootjs/client'`),
+    ).toEqual(['createSignal'])
+  })
+
+  test('does NOT flag type-only `import type` (erased at compile time)', () => {
+    expect(
+      detectMissingUseClient(`import type { Reactive } from '@barefootjs/client'`),
+    ).toEqual([])
+  })
+
+  test('does NOT flag inline `type` specifiers inside a mixed import', () => {
+    // `type Reactive` is erased; the only runtime binding here is `Reactive`,
+    // not a tripwire primitive, so the file is a legitimate server component.
+    expect(
+      detectMissingUseClient(`import { type Reactive } from '@barefootjs/client'`),
+    ).toEqual([])
+  })
+
+  test('does NOT flag non-tripwire runtime imports (createContext etc.)', () => {
+    // createContext on its own is server-safe; only signal/effect/memo
+    // primitives require the client runtime.
+    expect(
+      detectMissingUseClient(`import { createContext } from '@barefootjs/client'`),
+    ).toEqual([])
+  })
+
+  test('returns empty for plain server components with no @barefootjs/client import', () => {
+    expect(
+      detectMissingUseClient(`export function UserCard({ name }: { name: string }) { return <h3>{name}</h3> }`),
+    ).toEqual([])
   })
 })
 

--- a/packages/cli/src/__tests__/gen-test.test.ts
+++ b/packages/cli/src/__tests__/gen-test.test.ts
@@ -1,0 +1,127 @@
+// Behaviour test for `bf gen test`: by default the command writes a
+// `<Component>.test.tsx` file next to the resolved source, matching the
+// "Next steps" `bf gen component` already prints. `--stdout` keeps the
+// preview-only mode that callers can pipe somewhere; `--force` is
+// required to overwrite an existing test file.
+
+import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { run } from '../commands/gen-test'
+import type { CliContext } from '../context'
+
+let projectDir: string
+
+beforeEach(() => { projectDir = mkdtempSync(path.join(tmpdir(), 'bf-gen-test-')) })
+afterEach(() => { rmSync(projectDir, { recursive: true, force: true }) })
+
+function ctxFor(): CliContext {
+  return {
+    root: projectDir,
+    metaDir: path.join(projectDir, 'meta'),
+    jsonFlag: false,
+    projectDir,
+    config: {
+      paths: { components: 'components/ui', tokens: 'tokens', meta: 'meta' },
+      sourceDirs: ['components'],
+    },
+  }
+}
+
+describe('bf gen test', () => {
+  test('default: writes <Name>.test.tsx next to source for flat layout', () => {
+    mkdirSync(path.join(projectDir, 'components'), { recursive: true })
+    writeFileSync(
+      path.join(projectDir, 'components/Counter.tsx'),
+      `export function Counter() { return <div /> }`,
+    )
+    const logSpy = spyOn(console, 'log').mockImplementation(() => {})
+    try {
+      run(['Counter'], ctxFor())
+      const testPath = path.join(projectDir, 'components/Counter.test.tsx')
+      expect(existsSync(testPath)).toBe(true)
+      expect(readFileSync(testPath, 'utf-8')).toContain("describe('Counter'")
+    } finally {
+      logSpy.mockRestore()
+    }
+  })
+
+  test('default: writes index.test.tsx next to a nested registry component', () => {
+    mkdirSync(path.join(projectDir, 'components/ui/button'), { recursive: true })
+    writeFileSync(
+      path.join(projectDir, 'components/ui/button/index.tsx'),
+      `function Button() { return <button /> }\nexport { Button }`,
+    )
+    const logSpy = spyOn(console, 'log').mockImplementation(() => {})
+    try {
+      run(['button'], ctxFor())
+      const testPath = path.join(projectDir, 'components/ui/button/index.test.tsx')
+      expect(existsSync(testPath)).toBe(true)
+      expect(readFileSync(testPath, 'utf-8')).toContain("describe('Button'")
+    } finally {
+      logSpy.mockRestore()
+    }
+  })
+
+  test('--stdout: prints without touching the filesystem', () => {
+    mkdirSync(path.join(projectDir, 'components'), { recursive: true })
+    writeFileSync(
+      path.join(projectDir, 'components/Counter.tsx'),
+      `export function Counter() { return <div /> }`,
+    )
+    const logSpy = spyOn(console, 'log').mockImplementation(() => {})
+    try {
+      run(['Counter', '--stdout'], ctxFor())
+      expect(existsSync(path.join(projectDir, 'components/Counter.test.tsx'))).toBe(false)
+      const printed = logSpy.mock.calls.map((c) => c[0]).join('\n')
+      expect(printed).toContain("describe('Counter'")
+    } finally {
+      logSpy.mockRestore()
+    }
+  })
+
+  test('refuses to overwrite an existing test without --force', () => {
+    mkdirSync(path.join(projectDir, 'components'), { recursive: true })
+    writeFileSync(
+      path.join(projectDir, 'components/Counter.tsx'),
+      `export function Counter() { return <div /> }`,
+    )
+    writeFileSync(path.join(projectDir, 'components/Counter.test.tsx'), 'PREEXISTING')
+
+    const errSpy = spyOn(console, 'error').mockImplementation(() => {})
+    const exitSpy = spyOn(process, 'exit').mockImplementation(((c?: number) => {
+      throw new Error(`exit ${c ?? 0}`)
+    }) as never)
+    try {
+      expect(() => run(['Counter'], ctxFor())).toThrow('exit 1')
+      // Original content is intact.
+      expect(readFileSync(path.join(projectDir, 'components/Counter.test.tsx'), 'utf-8'))
+        .toBe('PREEXISTING')
+      const joined = errSpy.mock.calls.map((c) => c[0]).join('\n')
+      expect(joined).toContain('already exists')
+      expect(joined).toContain('--force')
+    } finally {
+      errSpy.mockRestore()
+      exitSpy.mockRestore()
+    }
+  })
+
+  test('--force overwrites an existing test file', () => {
+    mkdirSync(path.join(projectDir, 'components'), { recursive: true })
+    writeFileSync(
+      path.join(projectDir, 'components/Counter.tsx'),
+      `export function Counter() { return <div /> }`,
+    )
+    writeFileSync(path.join(projectDir, 'components/Counter.test.tsx'), 'PREEXISTING')
+    const logSpy = spyOn(console, 'log').mockImplementation(() => {})
+    try {
+      run(['Counter', '--force'], ctxFor())
+      const content = readFileSync(path.join(projectDir, 'components/Counter.test.tsx'), 'utf-8')
+      expect(content).not.toBe('PREEXISTING')
+      expect(content).toContain("describe('Counter'")
+    } finally {
+      logSpy.mockRestore()
+    }
+  })
+})

--- a/packages/cli/src/__tests__/meta-loader.test.ts
+++ b/packages/cli/src/__tests__/meta-loader.test.ts
@@ -77,6 +77,18 @@ describe('tryLoadComponent', () => {
     expect(tryLoadComponent(metaDir, 'Button')!.name).toBe('Pascal')
     expect(tryLoadComponent(metaDir, 'button')!.name).toBe('lower')
   })
+
+  test('ambiguous case-insensitive match → returns null (no readdir-order roulette)', () => {
+    // Both casings on disk; a mixed-case query (`BuTtOn`) matches both
+    // under case-insensitive comparison and neither exact-case. Picking
+    // either one would depend on `readdirSync` ordering, so the fallback
+    // bails to null and the caller falls through to the "not found" hint.
+    const metaDir = path.join(projectDir, 'meta')
+    mkdirSync(metaDir, { recursive: true })
+    writeFileSync(path.join(metaDir, 'Button.json'), JSON.stringify({ name: 'Pascal' }))
+    writeFileSync(path.join(metaDir, 'button.json'), JSON.stringify({ name: 'lower' }))
+    expect(tryLoadComponent(metaDir, 'BuTtOn')).toBeNull()
+  })
 })
 
 describe('formatMissingComponentError', () => {

--- a/packages/cli/src/__tests__/meta-loader.test.ts
+++ b/packages/cli/src/__tests__/meta-loader.test.ts
@@ -52,6 +52,31 @@ describe('tryLoadComponent', () => {
     expect(meta).not.toBeNull()
     expect(meta!.name).toBe('Button')
   })
+
+  test('case-insensitive fallback: `bf docs Button` finds registry meta button.json', () => {
+    // `bf add` writes registry meta with the registry-canonical
+    // (lowercase) name. Users naturally try PascalCase first; the
+    // case-insensitive fallback rescues that case without affecting
+    // exact-case behavior.
+    const metaDir = path.join(projectDir, 'meta')
+    mkdirSync(metaDir, { recursive: true })
+    writeFileSync(
+      path.join(metaDir, 'button.json'),
+      JSON.stringify({ name: 'button', title: 'Button', category: 'input' }),
+    )
+    const meta = tryLoadComponent(metaDir, 'Button')
+    expect(meta).not.toBeNull()
+    expect(meta!.title).toBe('Button')
+  })
+
+  test('exact-case match wins when both casings exist on disk', () => {
+    const metaDir = path.join(projectDir, 'meta')
+    mkdirSync(metaDir, { recursive: true })
+    writeFileSync(path.join(metaDir, 'Button.json'), JSON.stringify({ name: 'Pascal' }))
+    writeFileSync(path.join(metaDir, 'button.json'), JSON.stringify({ name: 'lower' }))
+    expect(tryLoadComponent(metaDir, 'Button')!.name).toBe('Pascal')
+    expect(tryLoadComponent(metaDir, 'button')!.name).toBe('lower')
+  })
 })
 
 describe('formatMissingComponentError', () => {

--- a/packages/cli/src/__tests__/pm.test.ts
+++ b/packages/cli/src/__tests__/pm.test.ts
@@ -145,4 +145,27 @@ describe('commandsFor', () => {
     expect(c.run('dev')).toBe('yarn dev')
     expect(c.exec('bf add button')).toBe('yarn dlx bf add button')
   })
+
+  // The `test` helper is what the various "next steps" / "run tests"
+  // hints route through so the CLI never prescribes `bun test` to a
+  // user who picked a different package manager. Two paths matter:
+  // suite-wide ("test") and targeted ("test <path>"). Only npm needs
+  // `--` to forward the path to the underlying test script.
+  test('test() — suite-wide form maps to each PM', () => {
+    expect(commandsFor('npm').test()).toBe('npm test')
+    expect(commandsFor('bun').test()).toBe('bun test')
+    expect(commandsFor('pnpm').test()).toBe('pnpm test')
+    expect(commandsFor('yarn').test()).toBe('yarn test')
+  })
+
+  test('test(path) — targeted form forwards the arg appropriately per PM', () => {
+    expect(commandsFor('npm').test('components/Foo.test.tsx'))
+      .toBe('npm test -- components/Foo.test.tsx')
+    expect(commandsFor('bun').test('components/Foo.test.tsx'))
+      .toBe('bun test components/Foo.test.tsx')
+    expect(commandsFor('pnpm').test('components/Foo.test.tsx'))
+      .toBe('pnpm test components/Foo.test.tsx')
+    expect(commandsFor('yarn').test('components/Foo.test.tsx'))
+      .toBe('yarn test components/Foo.test.tsx')
+  })
 })

--- a/packages/cli/src/__tests__/resolve-source.test.ts
+++ b/packages/cli/src/__tests__/resolve-source.test.ts
@@ -62,6 +62,53 @@ describe('resolveComponentSource', () => {
     }
   })
 
+  test('case-insensitive fallback resolves `counter` → components/Counter.tsx', () => {
+    // The scaffold quick-start invites `bf docs <component>` with a
+    // lowercase placeholder. Users naturally type `bf docs counter`
+    // even though the on-disk file is PascalCase `Counter.tsx`. On
+    // case-sensitive filesystems (Linux/CI) the pre-fix resolver
+    // missed it; now it falls back to a directory scan.
+    const projectDir = mktmp()
+    mkdirSync(path.join(projectDir, 'components'), { recursive: true })
+    writeFileSync(path.join(projectDir, 'components', 'Counter.tsx'), 'export {}')
+    try {
+      const r = resolveComponentSource('counter', ctxFor(projectDir, ['components']))
+      expect(r).not.toBeNull()
+      expect(r!.filePath).toBe(path.join(projectDir, 'components', 'Counter.tsx'))
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  test('case-insensitive fallback resolves nested registry entry `Button` → components/ui/button/index.tsx', () => {
+    const projectDir = mktmp()
+    mkdirSync(path.join(projectDir, 'components', 'ui', 'button'), { recursive: true })
+    writeFileSync(path.join(projectDir, 'components', 'ui', 'button', 'index.tsx'), 'export {}')
+    try {
+      const r = resolveComponentSource('Button', ctxFor(projectDir))
+      expect(r).not.toBeNull()
+      expect(r!.filePath).toBe(path.join(projectDir, 'components', 'ui', 'button', 'index.tsx'))
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  test('exact-case match still wins over a case-insensitive sibling', () => {
+    // If both `Counter.tsx` and `counter.tsx` somehow coexist
+    // (Counter wins in case-sensitive lookup), the resolver must
+    // return the exact-case file — no scan-driven surprise swap.
+    const projectDir = mktmp()
+    mkdirSync(path.join(projectDir, 'components'), { recursive: true })
+    writeFileSync(path.join(projectDir, 'components', 'Counter.tsx'), 'export {}')
+    writeFileSync(path.join(projectDir, 'components', 'counter.tsx'), 'export {}')
+    try {
+      const r = resolveComponentSource('Counter', ctxFor(projectDir, ['components']))
+      expect(r!.filePath).toBe(path.join(projectDir, 'components', 'Counter.tsx'))
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
   test('returns null and populates `searched` with every candidate it tried', () => {
     // Drives the "Looked in:" error transcript surfaced by the debug
     // commands when the user types an unknown component name.

--- a/packages/cli/src/__tests__/resolve-source.test.ts
+++ b/packages/cli/src/__tests__/resolve-source.test.ts
@@ -93,6 +93,24 @@ describe('resolveComponentSource', () => {
     }
   })
 
+  test('ambiguous case-insensitive match → bail (do not pick one nondeterministically)', () => {
+    // Case-sensitive filesystems can legally hold `Counter.tsx` AND
+    // `counter.tsx` side by side. A mixed-case query (`cOuNtEr`) hits
+    // *both* under case-insensitive comparison; returning either one
+    // would be `readdirSync`-order roulette. Verify we bail to null so
+    // the caller surfaces the conflict via the regular not-found path.
+    const projectDir = mktmp()
+    mkdirSync(path.join(projectDir, 'components'), { recursive: true })
+    writeFileSync(path.join(projectDir, 'components', 'Counter.tsx'), 'export {}')
+    writeFileSync(path.join(projectDir, 'components', 'counter.tsx'), 'export {}')
+    try {
+      const r = resolveComponentSource('cOuNtEr', ctxFor(projectDir, ['components']))
+      expect(r).toBeNull()
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
   test('exact-case match still wins over a case-insensitive sibling', () => {
     // If both `Counter.tsx` and `counter.tsx` somehow coexist
     // (Counter wins in case-sensitive lookup), the resolver must

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -6,6 +6,7 @@ import type { CliContext } from '../context'
 import type { BarefootConfig } from '../context'
 import { resolveDependenciesFromSource } from '../lib/dependency-resolver'
 import { extractMetaForFile } from './meta-extract'
+import { commandsFor, detectPackageManager } from '../lib/pm'
 import type { MetaIndex, MetaIndexEntry, ComponentMeta, RegistryItem } from '../lib/types'
 
 export async function run(args: string[], ctx: CliContext): Promise<void> {
@@ -237,7 +238,8 @@ export async function addFromRegistry(
     console.log(`  Use --force to overwrite existing components.`)
   }
   if (added.length > 0) {
-    console.log(`\n  Run tests: bun test ${config.paths.components}/`)
+    const pm = detectPackageManager(projectDir)
+    console.log(`\n  Run tests: ${commandsFor(pm).test(`${config.paths.components}/`)}`)
   }
 }
 
@@ -339,7 +341,8 @@ function addFromLocal(
     console.log(`  Use --force to overwrite existing components.`)
   }
   if (added.length > 0) {
-    console.log(`\n  Run tests: bun test ${config.paths.components}/`)
+    const pm = detectPackageManager(projectDir)
+    console.log(`\n  Run tests: ${commandsFor(pm).test(`${config.paths.components}/`)}`)
   }
 }
 

--- a/packages/cli/src/commands/docs.ts
+++ b/packages/cli/src/commands/docs.ts
@@ -125,12 +125,17 @@ export function run(args: string[], ctx: CliContext): void {
     // directory of the source file (correct for the registry layout
     // `<name>/index.tsx`, wrong for the flat `components/<Name>.tsx`
     // layout page components use — `fileToName(.../components/Counter.tsx)`
-    // would return `'components'`). Use the query as the canonical
-    // name since that's what the user typed in.
+    // would return `'components'`). Use the on-disk basename instead,
+    // not the user's query, so a case-insensitive resolve (`docs counter`
+    // → `Counter.tsx`) still prints the canonical PascalCase name.
+    const base = path.basename(resolved.filePath, path.extname(resolved.filePath))
+    const canonicalName = base === 'index'
+      ? path.basename(path.dirname(resolved.filePath))
+      : base
     const sourceDerivedMeta: ComponentMeta = {
       ...meta,
-      name: query,
-      title: query,
+      name: canonicalName,
+      title: canonicalName,
       category: 'page',
     }
     const rel = path.relative(ctx.projectDir ?? ctx.root, resolved.filePath)

--- a/packages/cli/src/commands/gen-component.ts
+++ b/packages/cli/src/commands/gen-component.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import type { CliContext } from '../context'
 import { scaffold } from '../lib/scaffold'
 import { resolveScaffoldLayout } from '../lib/scaffold-layout'
+import { commandsFor, detectPackageManager } from '../lib/pm'
 
 export function run(args: string[], ctx: CliContext): void {
   if (args.length < 2) {
@@ -34,12 +35,18 @@ export function run(args: string[], ctx: CliContext): void {
   writeFileSync(componentAbsPath, result.componentCode)
   writeFileSync(testAbsPath, result.testCode)
 
+  // Detected PM controls the test-run hint so the suggestion lines up
+  // with whatever the user has committed to (lockfile-first), instead of
+  // prescribing `bun test` regardless.
+  const pm = detectPackageManager(ctx.projectDir ?? ctx.root)
+  const testCmd = commandsFor(pm).test(result.testPath)
+
   console.log(`Created:`)
   console.log(`  ${result.componentPath}`)
   console.log(`  ${result.testPath}`)
   console.log(``)
   console.log(`Next steps:`)
   console.log(`  1. Implement the component in ${result.componentPath}`)
-  console.log(`  2. bun test ${result.testPath}`)
+  console.log(`  2. ${testCmd}`)
   console.log(`  3. bf gen test ${componentName}  (regenerate richer test)`)
 }

--- a/packages/cli/src/commands/gen-test.ts
+++ b/packages/cli/src/commands/gen-test.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import type { CliContext } from '../context'
 import { resolveComponentSource } from '../lib/resolve-source'
 import { generateTestTemplate } from '../lib/test-template'
+import { commandsFor, detectPackageManager } from '../lib/pm'
 
 export function run(args: string[], ctx: CliContext): void {
   // Two surfacing modes for the generated IR test:
@@ -61,5 +62,11 @@ export function run(args: string[], ctx: CliContext): void {
   const rel = path.relative(ctx.projectDir ?? ctx.root, testPath)
   console.log(`Created: ${rel}`)
   console.log(``)
-  console.log(`Next: bun test ${rel}`)
+  // Route the "next step" hint through the detected package manager so
+  // the suggestion respects whatever PM the user has actually committed
+  // to (lockfile-first, falling back to the PM that spawned this CLI).
+  // Hard-coding `bun test` was prescriptive in a project that explicitly
+  // supports npm / pnpm / yarn / bun.
+  const pm = detectPackageManager(ctx.projectDir ?? ctx.root)
+  console.log(`Next: ${commandsFor(pm).test(rel)}`)
 }

--- a/packages/cli/src/commands/gen-test.ts
+++ b/packages/cli/src/commands/gen-test.ts
@@ -1,13 +1,30 @@
 // bf gen test — generate IR test from existing component source.
 
+import { existsSync, writeFileSync } from 'fs'
+import path from 'path'
 import type { CliContext } from '../context'
 import { resolveComponentSource } from '../lib/resolve-source'
 import { generateTestTemplate } from '../lib/test-template'
 
 export function run(args: string[], ctx: CliContext): void {
-  const componentName = args[0]
+  // Two surfacing modes for the generated IR test:
+  //   default       → write `<Component>.test.tsx` (or `index.test.tsx` for
+  //                   nested registry layouts) next to the source on disk
+  //   --stdout      → print to stdout without touching the filesystem
+  //                   (preview, paste into PR, diff against existing test)
+  // Refuse to overwrite an existing test unless `--force` is set. This
+  // matches `bf gen component`'s collision policy, and lines up with the
+  // "Next steps" message that command prints — `bf gen test <name>` is
+  // supposed to *give you a file*, not silently print to a terminal the
+  // user has long scrolled past.
+  const positional = args.filter((a) => !a.startsWith('-'))
+  const flagSet = new Set(args.filter((a) => a.startsWith('-')))
+  const writeToStdout = flagSet.has('--stdout')
+  const force = flagSet.has('--force') || flagSet.has('-f')
+
+  const componentName = positional[0]
   if (!componentName) {
-    console.error('Error: Component name required. Usage: bf gen test <component>')
+    console.error('Error: Component name required. Usage: bf gen test <component> [--stdout] [--force]')
     process.exit(1)
   }
 
@@ -19,5 +36,30 @@ export function run(args: string[], ctx: CliContext): void {
     for (const p of searched) console.error(`  - ${p}`)
     process.exit(1)
   }
-  console.log(generateTestTemplate(resolved.filePath))
+
+  const content = generateTestTemplate(resolved.filePath)
+
+  if (writeToStdout) {
+    console.log(content)
+    return
+  }
+
+  // Pick `<basename>.test.tsx` next to the source. For nested layouts
+  // (`ui/button/index.tsx`) this becomes `ui/button/index.test.tsx`,
+  // matching what `bf gen component` writes.
+  const dir = path.dirname(resolved.filePath)
+  const base = path.basename(resolved.filePath, path.extname(resolved.filePath))
+  const testPath = path.join(dir, `${base}.test.tsx`)
+
+  if (existsSync(testPath) && !force) {
+    const rel = path.relative(ctx.projectDir ?? ctx.root, testPath)
+    console.error(`Error: ${rel} already exists. Pass --force to overwrite, or --stdout to preview.`)
+    process.exit(1)
+  }
+
+  writeFileSync(testPath, content)
+  const rel = path.relative(ctx.projectDir ?? ctx.root, testPath)
+  console.log(`Created: ${rel}`)
+  console.log(``)
+  console.log(`Next: bun test ${rel}`)
 }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -293,21 +293,29 @@ async function scaffoldApp(
     created++
   }
 
-  // Pull the registry Button. The pre-flight probe in run() already
-  // verified reachability, so a failure here is unusual (transient
-  // registry hiccup, malformed item, etc.) — let it propagate so the
-  // user retries instead of ending up with a half-scaffolded project
-  // that points at a missing import. `silent: true` so the per-file
-  // summary doesn't fight the surrounding spinner for the same line.
-  await addFromRegistry(
-    ['button'],
-    DEFAULT_REGISTRY_URL,
-    projectDir,
-    { paths },
-    true,
-    true,
-    true,
-  )
+  // Pull the bundled registry components (default: just Button).
+  // Adapters that can't yet render the registry Button end-to-end set
+  // `bundledRegistryComponents: []` so we skip the fetch entirely
+  // instead of shipping a scaffold whose very first build errors on
+  // an as-yet-unsupported lowering. The pre-flight probe in run()
+  // already verified reachability, so a failure here is unusual
+  // (transient registry hiccup, malformed item, etc.) — let it
+  // propagate so the user retries instead of ending up with a
+  // half-scaffolded project that points at a missing import.
+  // `silent: true` so the per-file summary doesn't fight the
+  // surrounding spinner for the same line.
+  const bundledComponents = adapter.bundledRegistryComponents ?? ['button']
+  if (bundledComponents.length > 0) {
+    await addFromRegistry(
+      bundledComponents,
+      DEFAULT_REGISTRY_URL,
+      projectDir,
+      { paths },
+      true,
+      true,
+      true,
+    )
+  }
 
   return created
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@
 // CLI entry point: arg parse → dispatch.
 
 import { createContext } from './context'
+import { commandsFor, detectPackageManager } from './lib/pm'
 
 const args = process.argv.slice(2)
 const jsonFlag = args.includes('--json')
@@ -13,6 +14,12 @@ const rest = filteredArgs.slice(2)
 const ctx = await createContext(jsonFlag)
 
 function printUsage() {
+  // PM detection runs against cwd so the test-command hint matches the
+  // user's actual tooling (lockfile-first, with sensible defaults when
+  // run outside a project). Hard-coding `bun test` in the workflow
+  // help was prescriptive in a project that supports npm/pnpm/yarn/bun.
+  const pm = detectPackageManager(process.cwd())
+  const testHint = commandsFor(pm).test('<path>')
   console.log(`Usage: bf <command> [options]
 
 Scaffold a new project with \`npm create barefootjs@latest\`, then:
@@ -49,7 +56,7 @@ Workflow:
   3. bf add <comp...>                         — Add to your project
   4. bf docs <component>                      — Learn props and usage
   5. bf guide <topic>                         — Read framework docs
-  6. bun test <path>                          — Verify
+  6. ${testHint.padEnd(41, ' ')}— Verify
   7. bf preview <component>                   — Visual preview in browser
   8. bf debug graph <component>               — Debug: signal dependency graph
   9. bf debug trace <comp> <signal>           — Debug: update propagation path`)

--- a/packages/cli/src/lib/adapters/mojo.ts
+++ b/packages/cli/src/lib/adapters/mojo.ts
@@ -161,9 +161,17 @@ export const MOJO_ADAPTER: AdapterTemplate = {
     'dist/components/manifest.json': COMPONENTS_MANIFEST_SEED,
   },
   scripts: {
-    // Build everything once, then run the watchers + Mojolicious's morbo
-    // (which auto-reloads on app.pl edits) side-by-side.
-    dev: 'bf build && unocss && concurrently -k -n build,uno,server -c blue,magenta,green "bf build --watch" "unocss --watch" "morbo app.pl -l http://*:3002"',
+    // Run the watchers + Mojolicious's morbo (which auto-reloads on
+    // app.pl edits) side-by-side. The watchers each do their own
+    // initial build at startup, so a separate cold-build prefix isn't
+    // needed — and used to be a hard blocker: any BF101 from the
+    // bundled `slot` component (the asChild pattern uses
+    // `.filter().join()`, which the mojo adapter can't lower to
+    // Embedded Perl) made `bf build` exit 1, the `&&` chain
+    // short-circuited, morbo never started, and the user saw "server
+    // doesn't come up" with no obvious cause. Matches the hono
+    // adapter's dev script shape.
+    dev: 'concurrently -k -n build,uno,server -c blue,magenta,green "bf build --watch" "unocss --watch" "morbo app.pl -l http://*:3002"',
     build: 'bf build && unocss',
     start: 'perl app.pl daemon -l http://*:3002',
   },

--- a/packages/cli/src/lib/adapters/mojo.ts
+++ b/packages/cli/src/lib/adapters/mojo.ts
@@ -9,7 +9,7 @@ import { execSync } from 'node:child_process'
 import type { AdapterTemplate } from '../templates'
 import {
   COMPONENTS_MANIFEST_SEED,
-  SHARED_COUNTER_TSX,
+  NATIVE_BUTTON_COUNTER_TSX,
   STYLES_CSS,
   TOKENS_CSS,
   UNOCSS_DEV_DEPENDENCIES,
@@ -154,7 +154,12 @@ export const MOJO_ADAPTER: AdapterTemplate = {
       'components/**/*.tsx',
       'dist/components/**/*.tsx',
     ]),
-    'components/Counter.tsx': SHARED_COUNTER_TSX,
+    // Registry <Button> is not auto-installed for mojo (see
+    // `bundledRegistryComponents` below), so the starter uses raw
+    // <button> elements with utility classes inline — keeps the
+    // scaffold runnable without referencing a component that isn't
+    // on disk yet.
+    'components/Counter.tsx': NATIVE_BUTTON_COUNTER_TSX,
     'public/styles.css': STYLES_CSS,
     'public/tokens.css': TOKENS_CSS,
     'public/uno.css': UNO_CSS_PLACEHOLDER,
@@ -188,6 +193,16 @@ export const MOJO_ADAPTER: AdapterTemplate = {
     concurrently: '^9.0.0',
     typescript: '^5.6.0',
   },
+  // The registry <Button> depends on <Slot>, whose
+  // `[a, b].filter(Boolean).join(' ')` className-merge expression the
+  // mojolicious adapter cannot yet lower to Embedded Perl (BF101). A
+  // persistent compile error in slot/index.tsx would in turn keep the
+  // CLI from writing the dev-reload sentinel after every rebuild,
+  // silently breaking `/_bf/reload` for the entire scaffold. Skip the
+  // bundled add until the adapter learns to lower that chain — `bf add
+  // button` will surface the same error explicitly when the user opts
+  // in.
+  bundledRegistryComponents: [],
   prereqWarnings: () => perlPrereqs(),
   // Mojolicious itself is a Perl dependency, not an npm one — point
   // the user at the bundled cpanfile so they don't trip over a

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -1,6 +1,6 @@
 // Core build module: shared pipeline for `bf build`.
 
-import { compileJSX, combineParentChildClientJs, createProgramForCorpus, formatError } from '@barefootjs/jsx'
+import { compileJSX, combineParentChildClientJs, createProgramForCorpus, formatError, REACTIVE_PRIMITIVES, BROWSER_ONLY_CLIENT_APIS } from '@barefootjs/jsx'
 import type { TemplateAdapter, OutputLayout, PostBuildContext, ExternalSpec, BundleEntry } from '@barefootjs/jsx'
 import type ts from 'typescript'
 import { mkdir, readdir, stat, unlink } from 'node:fs/promises'
@@ -100,19 +100,29 @@ export interface BuildRunOptions {
  * Skips leading comments (block and line).
  */
 /**
- * Reactive primitives whose presence (without `'use client'`) is the BF001
- * trigger. Matches `REACTIVE_PRIMITIVES` in the analyzer — keep the lists in
- * sync; the analyzer's runtime check stays authoritative, this helper is
- * just for surfacing the diagnostic at the CLI's skip-gate.
+ * Names from `@barefootjs/client` whose presence (without `'use client'`)
+ * matches the analyzer's BF001 trigger set. Pulled directly from the
+ * authoritative sets in `@barefootjs/jsx`'s analyzer so this CLI surface
+ * cannot drift out of sync with what `analyzeComponent` actually raises:
+ *
+ *   - `REACTIVE_PRIMITIVES` — `createSignal`/`createMemo`/`createEffect`/
+ *     `createDisposableEffect`/`onMount`/`onCleanup`. The analyzer fires
+ *     BF001 when their calls populate `ctx.signals`/`memos`/`effects`/
+ *     `onMounts`; the CLI doesn't have call-site visibility cheaply at
+ *     the skip-gate, so it raises on import as a proactive proxy.
+ *   - `BROWSER_ONLY_CLIENT_APIS` — `useContext`/`provideContext`/
+ *     `createPortal`/`isSSRPortal`/`findSiblingSlot`/
+ *     `cleanupPortalPlaceholder`. Matches `importsBrowserOnlyClientApi`
+ *     exactly: import alone (not call) is the analyzer's trigger.
+ *
+ * `untrack` is intentionally absent here — the analyzer doesn't treat it
+ * as a tripwire (it has no DOM-runtime tail and doesn't populate any of
+ * the ctx arrays), and an earlier version of this list had it as a
+ * false-positive source.
  */
-const BF001_TRIPWIRE_IMPORTS = new Set([
-  'createSignal',
-  'createEffect',
-  'createMemo',
-  'onMount',
-  'onCleanup',
-  'untrack',
-  'createPortal',
+const BF001_TRIPWIRE_IMPORTS = new Set<string>([
+  ...REACTIVE_PRIMITIVES,
+  ...BROWSER_ONLY_CLIENT_APIS,
 ])
 
 /**
@@ -1561,7 +1571,15 @@ export async function watch(
   // recompilation. By snapshotting hashes here and comparing on a
   // post-build pass, we self-heal both scenarios without requiring a
   // user keypress to nudge the watcher back to life.
+  //
+  // mtime cache co-keyed with the hash cache: on the steady-state polling
+  // path (no edits), `snapshotHashes` only needs to `stat` each file. It
+  // re-reads + re-hashes only when the mtime advances, which keeps the
+  // baseline I/O cost of the 2s poll loop bounded to one stat per file
+  // instead of one full read per file — meaningful on larger projects
+  // and on slower filesystems where reads dominate.
   const lastSeenHashes = new Map<string, string>()
+  const lastSeenMtimes = new Map<string, number>()
   const snapshotHashes = async (): Promise<Map<string, string>> => {
     const snap = new Map<string, string>()
     const entries: string[] = []
@@ -1570,7 +1588,20 @@ export async function watch(
     }
     await Promise.all(entries.map(async (entry) => {
       try {
-        snap.set(entry, hashContent(await readText(entry)))
+        const s = await stat(entry)
+        const mtimeMs = s.mtimeMs
+        const cachedMtime = lastSeenMtimes.get(entry)
+        const cachedHash = lastSeenHashes.get(entry)
+        // mtime unchanged AND we already have a hash for this file →
+        // skip the read; reuse last-known hash. This is the fast path
+        // the poll loop hits when nothing has been edited.
+        if (cachedMtime === mtimeMs && cachedHash !== undefined) {
+          snap.set(entry, cachedHash)
+          return
+        }
+        const hash = hashContent(await readText(entry))
+        lastSeenMtimes.set(entry, mtimeMs)
+        snap.set(entry, hash)
       } catch {
         // File deleted between enumeration and read — ignore; the
         // next rebuild will pick up the deletion via cache invalidation.
@@ -1644,10 +1675,22 @@ export async function watch(
   // Belt-and-suspenders poll. Linux's recursive `fs.watch` iterator has
   // a known fragility where the AsyncIterable can stop yielding events
   // after the first batch in some workloads — leaving the watch process
-  // alive but functionally dead. A low-frequency poll (every two seconds)
-  // catches missed edits via the same hash diff used by the post-build
-  // revalidation. Cheap: `hashContent` of a few dozen sources is sub-ms.
-  const pollIntervalMs = 2000
+  // alive but functionally dead. A hash-diff poll catches missed edits
+  // via the same `snapshotHashes` mechanism used by the post-build
+  // revalidation.
+  //
+  // Steady-state cost: `snapshotHashes` re-stats every file but only
+  // re-hashes when its mtime advances, so an idle project pays one stat
+  // per file per tick — sub-millisecond on typical corpora. Adaptive
+  // backoff: 2s while there's recent activity, doubling up to 30s after
+  // ten consecutive idle ticks, snapping back to 2s as soon as anything
+  // changes. The window stays responsive during edit bursts while
+  // avoiding steady I/O on long-idle sessions.
+  const pollMinMs = 2000
+  const pollMaxMs = 30000
+  const idleTicksUntilBackoff = 10
+  let pollIntervalMs = pollMinMs
+  let idleTicks = 0
   const pollLoop = async () => {
     while (signal?.aborted !== true) {
       await new Promise((r) => setTimeout(r, pollIntervalMs))
@@ -1663,10 +1706,22 @@ export async function watch(
       for (const file of lastSeenHashes.keys()) {
         if (!snap.has(file)) {
           lastSeenHashes.delete(file)
+          lastSeenMtimes.delete(file)
           changed = true
         }
       }
-      if (changed && !pending) schedule()
+      if (changed) {
+        // Reset backoff: the project just went non-idle. Schedule a
+        // rebuild if one isn't already queued by the inotify path.
+        pollIntervalMs = pollMinMs
+        idleTicks = 0
+        if (!pending) schedule()
+      } else {
+        idleTicks++
+        if (idleTicks >= idleTicksUntilBackoff && pollIntervalMs < pollMaxMs) {
+          pollIntervalMs = Math.min(pollIntervalMs * 2, pollMaxMs)
+        }
+      }
     }
   }
 

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -1500,12 +1500,22 @@ export const DEV_SENTINEL_FILENAME = 'build-id'
 
 /**
  * Dev-only sentinel for signalling browsers to reload after a watch rebuild.
- * Written at `<outDir>/.dev/build-id` only when the build both succeeded and
- * actually changed output on disk — so a touch-save that produces no diff
- * does not trigger a reload.
+ * Written at `<outDir>/.dev/build-id` whenever output actually changed on
+ * disk — so a touch-save that produces no diff does not trigger a reload.
+ *
+ * Errors elsewhere in the build do not block the sentinel: errored entries
+ * preserve their prior cache row (so their on-disk output stays consistent),
+ * and other entries that compiled cleanly still write their fresh outputs.
+ * Suppressing the reload whenever *any* file errored would mean a single
+ * persistently-broken component in the project (e.g. one that the active
+ * adapter cannot lower yet) silently disables auto-reload for the entire
+ * app — the user edits a working file, sees nothing happen in the browser,
+ * and has no obvious cause. Firing on `changed` lets the browser pick up
+ * every successful incremental edit while the compile errors stay visible
+ * in the watch terminal.
  */
 async function writeBuildId(outDir: string, result: BuildResult): Promise<void> {
-  if (result.errorCount > 0 || !result.changed) return
+  if (!result.changed) return
   const devDir = resolve(outDir, DEV_SENTINEL_SUBDIR)
   await mkdir(devDir, { recursive: true })
   const path = resolve(devDir, DEV_SENTINEL_FILENAME)

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -99,6 +99,53 @@ export interface BuildRunOptions {
  * Check if file content starts with a "use client" directive.
  * Skips leading comments (block and line).
  */
+/**
+ * Reactive primitives whose presence (without `'use client'`) is the BF001
+ * trigger. Matches `REACTIVE_PRIMITIVES` in the analyzer — keep the lists in
+ * sync; the analyzer's runtime check stays authoritative, this helper is
+ * just for surfacing the diagnostic at the CLI's skip-gate.
+ */
+const BF001_TRIPWIRE_IMPORTS = new Set([
+  'createSignal',
+  'createEffect',
+  'createMemo',
+  'onMount',
+  'onCleanup',
+  'untrack',
+  'createPortal',
+])
+
+/**
+ * Cheap pre-analyzer scan: does this source `import { ... } from '@barefootjs/client'`
+ * any name from `BF001_TRIPWIRE_IMPORTS`? Returns the offending names so the
+ * diagnostic can list them. Returns `[]` for files that genuinely don't
+ * need `'use client'` (server components, type-only imports).
+ *
+ * Regex-based instead of TS-AST because this runs in the hot skip-gate
+ * before `compileEntry` and must stay sub-millisecond. The downside is
+ * we may match commented-out imports — that's fine for a diagnostic, the
+ * user can resolve it by either adding the directive or removing the
+ * import.
+ */
+export function detectMissingUseClient(content: string): string[] {
+  const importRe = /import\s*(?:type\s+)?\{([^}]+)\}\s*from\s*['"]@barefootjs\/client['"]/g
+  const hits = new Set<string>()
+  for (const m of content.matchAll(importRe)) {
+    // Skip `import type { ... }` — type imports erase at compile time and
+    // never run, so they don't require the client runtime.
+    if (/import\s+type/.test(m[0])) continue
+    for (const raw of m[1].split(',')) {
+      // Handle `as` aliases — the imported binding is what matters.
+      const imported = raw.trim().split(/\s+as\s+/)[0].trim()
+      // Type-only specifiers inside a mixed import (`import { type X, Y }`):
+      // strip the `type` keyword and ignore the type binding itself.
+      if (imported.startsWith('type ')) continue
+      if (BF001_TRIPWIRE_IMPORTS.has(imported)) hits.add(imported)
+    }
+  }
+  return [...hits]
+}
+
 export function hasUseClientDirective(content: string): boolean {
   let trimmed = content.trimStart()
   // Skip block comments
@@ -477,6 +524,22 @@ export async function build(
   for (const entryPath of allFiles) {
     const sourceContent = sourceContents.get(entryPath)!
     if (!hasUseClientDirective(sourceContent)) {
+      // BF001 surface check (#1442). The analyzer raises BF001 when a
+      // component imports reactive primitives without `'use client'`, but
+      // the CLI used to drop these files at the skip-gate above, so the
+      // diagnostic never reached the user — their component would be
+      // compiled to plain HTML, ship zero client JS, and look broken in
+      // the browser with no console output. Mirror just the import-side
+      // check here so the same situation prints the analyzer's message.
+      const missing = detectMissingUseClient(sourceContent)
+      if (missing.length > 0) {
+        console.error(`Errors compiling ${relative(config.projectDir, entryPath)}:`)
+        console.error(
+          `  BF001: 'use client' directive required — imports reactive primitive(s) from @barefootjs/client: ${missing.join(', ')}`,
+        )
+        errorCount++
+        continue
+      }
       skippedCount++
       continue
     }

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -1490,6 +1490,32 @@ export async function watch(
     flushTimer = setTimeout(flush, debounceMs)
   }
 
+  // Fingerprint every component source file. Used after each rebuild to
+  // detect (a) edits that raced the readText snapshot taken by `build()`,
+  // and (b) edits whose inotify event was dropped by the recursive
+  // `fs.watch` iterator on Linux. Either way, the next rebuild's hash
+  // check would otherwise treat the now-stale cache as fresh and skip
+  // recompilation. By snapshotting hashes here and comparing on a
+  // post-build pass, we self-heal both scenarios without requiring a
+  // user keypress to nudge the watcher back to life.
+  const lastSeenHashes = new Map<string, string>()
+  const snapshotHashes = async (): Promise<Map<string, string>> => {
+    const snap = new Map<string, string>()
+    const entries: string[] = []
+    for (const dir of config.componentDirs) {
+      entries.push(...await discoverComponentFiles(dir))
+    }
+    await Promise.all(entries.map(async (entry) => {
+      try {
+        snap.set(entry, hashContent(await readText(entry)))
+      } catch {
+        // File deleted between enumeration and read — ignore; the
+        // next rebuild will pick up the deletion via cache invalidation.
+      }
+    }))
+    return snap
+  }
+
   const flush = async () => {
     flushTimer = null
     if (!pending) return
@@ -1503,7 +1529,30 @@ export async function watch(
       `Rebuild: ${result.compiledCount} compiled, ${result.cachedCount} cached, ${result.errorCount} errors (${ms}ms)`,
     )
     await writeBuildId(config.outDir, result)
+
+    // Post-build revalidation. Re-hash every source and reschedule if any
+    // file changed since the build snapshot — this is what recovers from
+    // the "edit raced the build's readText" failure mode where the user
+    // saved twice in quick succession and the second save landed mid-flush.
+    const after = await snapshotHashes()
+    let staleAfterBuild = false
+    for (const [file, hash] of after) {
+      if (lastSeenHashes.get(file) !== hash) {
+        lastSeenHashes.set(file, hash)
+        staleAfterBuild = true
+      }
+    }
+    if (staleAfterBuild && !pending) {
+      // Don't go quiet here — a second rebuild that the user didn't trigger
+      // via fs.watch can otherwise look like a flake. The trailing tick
+      // catches up to whatever the disk actually shows.
+      schedule()
+    }
   }
+
+  // Seed the fingerprint map with the post-initial-build state so the
+  // first user edit registers as "changed".
+  for (const [file, hash] of await snapshotHashes()) lastSeenHashes.set(file, hash)
 
   const isRelevant = (root: string, filename: string | null): boolean => {
     if (!filename) return false
@@ -1529,9 +1578,39 @@ export async function watch(
     }
   }
 
+  // Belt-and-suspenders poll. Linux's recursive `fs.watch` iterator has
+  // a known fragility where the AsyncIterable can stop yielding events
+  // after the first batch in some workloads — leaving the watch process
+  // alive but functionally dead. A low-frequency poll (every two seconds)
+  // catches missed edits via the same hash diff used by the post-build
+  // revalidation. Cheap: `hashContent` of a few dozen sources is sub-ms.
+  const pollIntervalMs = 2000
+  const pollLoop = async () => {
+    while (signal?.aborted !== true) {
+      await new Promise((r) => setTimeout(r, pollIntervalMs))
+      const snap = await snapshotHashes()
+      let changed = false
+      for (const [file, hash] of snap) {
+        if (lastSeenHashes.get(file) !== hash) {
+          lastSeenHashes.set(file, hash)
+          changed = true
+        }
+      }
+      // Detect deletions too, so cache invalidation can fire on rm.
+      for (const file of lastSeenHashes.keys()) {
+        if (!snap.has(file)) {
+          lastSeenHashes.delete(file)
+          changed = true
+        }
+      }
+      if (changed && !pending) schedule()
+    }
+  }
+
   await Promise.all([
     ...componentRoots.map((r) => watchRoot(r, true)),
     watchRoot(configRoot, false),
+    pollLoop(),
   ])
 }
 

--- a/packages/cli/src/lib/meta-loader.ts
+++ b/packages/cli/src/lib/meta-loader.ts
@@ -65,6 +65,12 @@ export async function fetchRegistryItem(registryUrl: string, name: string): Prom
  * The lookup is case-sensitive first, then falls back to a case-insensitive
  * scan so `bf docs Button` works even though `bf add` writes `button.json`.
  * Exact-case behavior is unchanged.
+ *
+ * The case-insensitive fallback intentionally returns `null` when multiple
+ * meta files differ only by case (e.g. `Button.json` *and* `button.json`):
+ * picking either one would be nondeterministic — `readdirSync` ordering is
+ * filesystem-dependent — and the caller's "not found" transcript surfaces
+ * the conflict to the user instead of silently choosing.
  */
 export function tryLoadComponent(metaDir: string, name: string): ComponentMeta | null {
   const filePath = path.join(metaDir, `${name}.json`)
@@ -78,12 +84,14 @@ export function tryLoadComponent(metaDir: string, name: string): ComponentMeta |
   } catch {
     return null
   }
+  const matches: string[] = []
   for (const entry of entries) {
-    if (entry.toLowerCase() === wanted) {
-      return JSON.parse(readFileSync(path.join(metaDir, entry), 'utf-8'))
-    }
+    if (entry.toLowerCase() === wanted) matches.push(entry)
   }
-  return null
+  // 1 → unambiguous match. 0 or 2+ → bail; 2+ would otherwise be
+  // resolution-order roulette.
+  if (matches.length !== 1) return null
+  return JSON.parse(readFileSync(path.join(metaDir, matches[0]), 'utf-8'))
 }
 
 /**

--- a/packages/cli/src/lib/meta-loader.ts
+++ b/packages/cli/src/lib/meta-loader.ts
@@ -1,6 +1,6 @@
 // Load component metadata from ui/meta/ directory.
 
-import { readFileSync, existsSync } from 'fs'
+import { readFileSync, existsSync, readdirSync } from 'fs'
 import path from 'path'
 import type { CliContext } from '../context'
 import type { MetaIndex, ComponentMeta, RegistryItem } from './types'
@@ -61,11 +61,29 @@ export async function fetchRegistryItem(registryUrl: string, name: string): Prom
  * exiting when the file isn't present, so callers can fall back to
  * source-derived rendering (`bf docs` for top-level page components,
  * #1403) before deciding whether to surface a hard error.
+ *
+ * The lookup is case-sensitive first, then falls back to a case-insensitive
+ * scan so `bf docs Button` works even though `bf add` writes `button.json`.
+ * Exact-case behavior is unchanged.
  */
 export function tryLoadComponent(metaDir: string, name: string): ComponentMeta | null {
   const filePath = path.join(metaDir, `${name}.json`)
-  if (!existsSync(filePath)) return null
-  return JSON.parse(readFileSync(filePath, 'utf-8'))
+  if (existsSync(filePath)) return JSON.parse(readFileSync(filePath, 'utf-8'))
+  // Case-insensitive fallback against the meta dir contents.
+  if (!existsSync(metaDir)) return null
+  const wanted = `${name.toLowerCase()}.json`
+  let entries: string[]
+  try {
+    entries = readdirSync(metaDir)
+  } catch {
+    return null
+  }
+  for (const entry of entries) {
+    if (entry.toLowerCase() === wanted) {
+      return JSON.parse(readFileSync(path.join(metaDir, entry), 'utf-8'))
+    }
+  }
+  return null
 }
 
 /**

--- a/packages/cli/src/lib/pm.ts
+++ b/packages/cli/src/lib/pm.ts
@@ -64,6 +64,14 @@ export interface PmCommands {
   install: string
   run: (script: string) => string
   exec: (cmd: string) => string
+  /**
+   * Test command targeted at a single file or directory. Each PM forwards
+   * extra args to the package.json `test` script slightly differently —
+   * npm requires `--`, the others forward by default — so callers that
+   * want to suggest "run the test you just generated" should route
+   * through this helper instead of hard-coding `bun test`.
+   */
+  test: (pathArg?: string) => string
 }
 
 export function commandsFor(pm: PackageManager): PmCommands {
@@ -73,18 +81,21 @@ export function commandsFor(pm: PackageManager): PmCommands {
         install: 'bun install',
         run: s => `bun run ${s}`,
         exec: c => `bunx ${c}`,
+        test: p => p ? `bun test ${p}` : 'bun test',
       }
     case 'pnpm':
       return {
         install: 'pnpm install',
         run: s => `pnpm ${s}`,
         exec: c => `pnpm dlx ${c}`,
+        test: p => p ? `pnpm test ${p}` : 'pnpm test',
       }
     case 'yarn':
       return {
         install: 'yarn',
         run: s => `yarn ${s}`,
         exec: c => `yarn dlx ${c}`,
+        test: p => p ? `yarn test ${p}` : 'yarn test',
       }
     case 'npm':
     default:
@@ -92,6 +103,8 @@ export function commandsFor(pm: PackageManager): PmCommands {
         install: 'npm install',
         run: s => `npm run ${s}`,
         exec: c => `npx ${c}`,
+        // npm requires `--` to forward args to the script.
+        test: p => p ? `npm test -- ${p}` : 'npm test',
       }
   }
 }

--- a/packages/cli/src/lib/resolve-source.ts
+++ b/packages/cli/src/lib/resolve-source.ts
@@ -32,9 +32,17 @@ function tryCandidate(candidate: string, searched: string[]): string | null {
  * but with no exact-case match. Returns the actual on-disk name (preserving
  * the directory's casing) so the caller can rebuild a correct path.
  *
- * Returns `null` if the directory doesn't exist, no case-insensitive match
- * exists, or an exact-case match already does (since the regular
- * `tryCandidate` path would have caught it).
+ * Returns `null` when:
+ *   - the directory doesn't exist or can't be read
+ *   - no case-insensitive match exists
+ *   - an exact-case match already does (the regular `tryCandidate` path
+ *     would have caught it — don't double-resolve)
+ *   - **multiple case-insensitive matches exist** (case-sensitive
+ *     filesystems can legally hold both `Counter.tsx` and `counter.tsx`).
+ *     Returning a single result there would be nondeterministic
+ *     (depends on `readdirSync` ordering); the caller falls through to
+ *     the "not found" error transcript so the user sees the conflict
+ *     before any tooling commits to one half of it.
  */
 function caseInsensitiveMatch(dir: string, target: string): string | null {
   if (!existsSync(dir)) return null
@@ -47,10 +55,13 @@ function caseInsensitiveMatch(dir: string, target: string): string | null {
   const lower = target.toLowerCase()
   // Exact-case hit means a previous tryCandidate already returned it — skip.
   if (entries.includes(target)) return null
+  const matches: string[] = []
   for (const entry of entries) {
-    if (entry.toLowerCase() === lower) return entry
+    if (entry.toLowerCase() === lower) matches.push(entry)
   }
-  return null
+  // 0 → no fallback to surface; 1 → unambiguous match; 2+ → ambiguous,
+  // fail closed so the user resolves the conflict before we pick a side.
+  return matches.length === 1 ? matches[0] : null
 }
 
 export function resolveComponentSource(

--- a/packages/cli/src/lib/resolve-source.ts
+++ b/packages/cli/src/lib/resolve-source.ts
@@ -9,7 +9,7 @@
 //    `components/Counter.tsx`)
 // 5. Current working directory (PascalCase fallback)
 
-import { existsSync } from 'fs'
+import { existsSync, readdirSync } from 'fs'
 import path from 'path'
 import type { CliContext } from '../context'
 
@@ -25,6 +25,32 @@ export interface ResolvedSource {
 function tryCandidate(candidate: string, searched: string[]): string | null {
   searched.push(candidate)
   return existsSync(candidate) ? candidate : null
+}
+
+/**
+ * Find a directory entry whose basename matches `target` case-insensitively
+ * but with no exact-case match. Returns the actual on-disk name (preserving
+ * the directory's casing) so the caller can rebuild a correct path.
+ *
+ * Returns `null` if the directory doesn't exist, no case-insensitive match
+ * exists, or an exact-case match already does (since the regular
+ * `tryCandidate` path would have caught it).
+ */
+function caseInsensitiveMatch(dir: string, target: string): string | null {
+  if (!existsSync(dir)) return null
+  let entries: string[]
+  try {
+    entries = readdirSync(dir)
+  } catch {
+    return null
+  }
+  const lower = target.toLowerCase()
+  // Exact-case hit means a previous tryCandidate already returned it — skip.
+  if (entries.includes(target)) return null
+  for (const entry of entries) {
+    if (entry.toLowerCase() === lower) return entry
+  }
+  return null
 }
 
 export function resolveComponentSource(
@@ -87,6 +113,31 @@ export function resolveComponentSource(
   // 5. PascalCase component name in the current working directory
   const cwdHit = tryCandidate(path.resolve(`${nameOrPath}.tsx`), searched)
   if (cwdHit) return { filePath: cwdHit }
+
+  // 6. Case-insensitive fallback. Users naturally type `bf docs counter`
+  //    when the file on disk is `Counter.tsx`; rather than punish that
+  //    with a "not found" error, re-run resolution under the canonical
+  //    on-disk casing. Only fires after every case-sensitive attempt
+  //    misses, so existing exact-case behavior is unchanged.
+  if (ctx.config && ctx.projectDir) {
+    const dirs: string[] = [
+      path.join(ctx.projectDir, ctx.config.paths.components),
+      ...((ctx.config.sourceDirs ?? []).map((d) => path.join(ctx.projectDir!, d))),
+    ]
+    for (const dir of dirs) {
+      // <Name>.tsx (flat layout)
+      const flatMatch = caseInsensitiveMatch(dir, `${nameOrPath}.tsx`)
+      if (flatMatch) {
+        return { filePath: path.join(dir, flatMatch) }
+      }
+      // <Name>/index.tsx (nested layout)
+      const dirMatch = caseInsensitiveMatch(dir, nameOrPath)
+      if (dirMatch) {
+        const indexFile = path.join(dir, dirMatch, 'index.tsx')
+        if (existsSync(indexFile)) return { filePath: indexFile }
+      }
+    }
+  }
 
   return null
 }

--- a/packages/cli/src/lib/templates.ts
+++ b/packages/cli/src/lib/templates.ts
@@ -70,6 +70,16 @@ export interface AdapterTemplate {
    * cpanm — issue #1416 item 2).
    */
   extraSetupSteps?: { label?: string; command: string }[]
+  /**
+   * Registry components fetched into `components/ui/` at init. Defaults
+   * to `['button']`, matching what the starter Counter expects on
+   * adapters whose compiler can render the registry <Button>
+   * end-to-end. Adapters that can't yet (e.g. mojo's lowering doesn't
+   * cover Slot's higher-order className-merge chain) set this to `[]`
+   * and pair it with `NATIVE_BUTTON_COUNTER_TSX` so the scaffold
+   * doesn't ship with a known-failing source on the very first build.
+   */
+  bundledRegistryComponents?: string[]
 }
 
 // CSS library options offered by `bf init`. The library is

--- a/packages/form/README.md
+++ b/packages/form/README.md
@@ -40,26 +40,27 @@ function LoginForm() {
     },
   })
 
-  const email = form.field("email")
-  const password = form.field("password")
-
   return (
     <form onSubmit={form.handleSubmit}>
       <input
         type="email"
-        value={email.value()}
-        onInput={email.handleInput}
-        onBlur={email.handleBlur}
+        value={/* @client */ form.field("email").value()}
+        onInput={(e) => form.field("email").handleInput(e)}
+        onBlur={() => form.field("email").handleBlur()}
       />
-      {email.error() && <span>{email.error()}</span>}
+      {/* @client */ form.field("email").error() && (
+        <span>{/* @client */ form.field("email").error()}</span>
+      )}
 
       <input
         type="password"
-        value={password.value()}
-        onInput={password.handleInput}
-        onBlur={password.handleBlur}
+        value={/* @client */ form.field("password").value()}
+        onInput={(e) => form.field("password").handleInput(e)}
+        onBlur={() => form.field("password").handleBlur()}
       />
-      {password.error() && <span>{password.error()}</span>}
+      {/* @client */ form.field("password").error() && (
+        <span>{/* @client */ form.field("password").error()}</span>
+      )}
 
       <button type="submit" disabled={form.isSubmitting()}>
         {form.isSubmitting() ? "Submitting..." : "Log in"}
@@ -68,6 +69,14 @@ function LoginForm() {
   )
 }
 ```
+
+> **BarefootJS gotcha:** field controllers from `form.field("name")` must be
+> invoked *inside* the JSX (with `/* @client */` for reactive reads) rather
+> than hoisted into init-body `const`s. The compiler analyzes JSX expression
+> scopes statically and rejects init-scope captures from the template
+> position with a `BF0xx Init-scope local referenced from template scope`
+> error. Inlining the call keeps each read in template scope; the
+> `/* @client */` marker tells the compiler not to evaluate the read at SSR.
 
 ## API
 
@@ -164,14 +173,12 @@ const form = createForm({
 
 ## Custom Components
 
-For components that don't use `e.target.value` (e.g. checkboxes, selects, custom widgets), use `setValue` directly:
+For components that don't use `e.target.value` (e.g. checkboxes, selects, custom widgets), use `setValue` directly. Keep the `form.field(...)` call inside the JSX (BarefootJS won't follow an init-scope alias into a template position):
 
 ```tsx
-const active = form.field("active")
-
 <Switch
-  checked={active.value()}
-  onCheckedChange={(checked) => active.setValue(checked)}
+  checked={/* @client */ form.field("active").value()}
+  onCheckedChange={(checked) => form.field("active").setValue(checked)}
 />
 ```
 

--- a/packages/form/README.md
+++ b/packages/form/README.md
@@ -40,27 +40,26 @@ function LoginForm() {
     },
   })
 
+  const email = form.field("email")
+  const password = form.field("password")
+
   return (
     <form onSubmit={form.handleSubmit}>
       <input
         type="email"
-        value={/* @client */ form.field("email").value()}
-        onInput={(e) => form.field("email").handleInput(e)}
-        onBlur={() => form.field("email").handleBlur()}
+        value={email.value()}
+        onInput={email.handleInput}
+        onBlur={email.handleBlur}
       />
-      {/* @client */ form.field("email").error() && (
-        <span>{/* @client */ form.field("email").error()}</span>
-      )}
+      {email.error() && <span>{email.error()}</span>}
 
       <input
         type="password"
-        value={/* @client */ form.field("password").value()}
-        onInput={(e) => form.field("password").handleInput(e)}
-        onBlur={() => form.field("password").handleBlur()}
+        value={password.value()}
+        onInput={password.handleInput}
+        onBlur={password.handleBlur}
       />
-      {/* @client */ form.field("password").error() && (
-        <span>{/* @client */ form.field("password").error()}</span>
-      )}
+      {password.error() && <span>{password.error()}</span>}
 
       <button type="submit" disabled={form.isSubmitting()}>
         {form.isSubmitting() ? "Submitting..." : "Log in"}
@@ -69,14 +68,6 @@ function LoginForm() {
   )
 }
 ```
-
-> **BarefootJS gotcha:** field controllers from `form.field("name")` must be
-> invoked *inside* the JSX (with `/* @client */` for reactive reads) rather
-> than hoisted into init-body `const`s. The compiler analyzes JSX expression
-> scopes statically and rejects init-scope captures from the template
-> position with a `BF0xx Init-scope local referenced from template scope`
-> error. Inlining the call keeps each read in template scope; the
-> `/* @client */` marker tells the compiler not to evaluate the read at SSR.
 
 ## API
 
@@ -173,12 +164,14 @@ const form = createForm({
 
 ## Custom Components
 
-For components that don't use `e.target.value` (e.g. checkboxes, selects, custom widgets), use `setValue` directly. Keep the `form.field(...)` call inside the JSX (BarefootJS won't follow an init-scope alias into a template position):
+For components that don't use `e.target.value` (e.g. checkboxes, selects, custom widgets), use `setValue` directly:
 
 ```tsx
+const active = form.field("active")
+
 <Switch
-  checked={/* @client */ form.field("active").value()}
-  onCheckedChange={(checked) => form.field("active").setValue(checked)}
+  checked={active.value()}
+  onCheckedChange={(checked) => active.setValue(checked)}
 />
 ```
 

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -1322,10 +1322,24 @@ function collectMemo(node: ts.VariableDeclaration, ctx: AnalyzerContext): void {
   // Extract dependencies from computation
   const deps = extractDependencies(computation, ctx)
 
-  // Try to infer type
+  // Try to infer type. Prefer the explicit `<T>` type argument when
+  // present; otherwise fall back to the same value-shape inference
+  // signals use (`inferTypeFromValue` handles `.length`, `.some(...)`,
+  // `.every(...)`, etc.). Without this, `createMemo(() =>
+  // todos().filter(...).length)` ends up as `unknown` and the Go
+  // adapter renders the field as `interface{}`, even though the
+  // expression is clearly a number.
   let type: TypeInfo = { kind: 'unknown', raw: 'unknown' }
   if (callExpr.typeArguments && callExpr.typeArguments.length > 0) {
     type = typeNodeToTypeInfo(callExpr.typeArguments[0], ctx.sourceFile) ?? type
+  } else {
+    // The memo computation is an arrow function; the type we want is
+    // the body's, not the arrow itself. Pull `() => <body>` apart so
+    // `inferTypeFromValue` sees the actual expression.
+    const arrowBody = computation.replace(/^\s*\([^)]*\)\s*=>\s*/, '').trim()
+    if (arrowBody && arrowBody !== computation) {
+      type = inferTypeFromValue(arrowBody)
+    }
   }
 
   ctx.memos.push({
@@ -2546,6 +2560,27 @@ function inferTypeFromValue(value: string): TypeInfo {
   const nullishMatch = trimmed.match(/^.+\?\?\s*(.+)$/)
   if (nullishMatch) {
     return inferTypeFromValue(nullishMatch[1])
+  }
+
+  // Trailing method/property accesses that transform the operand type.
+  // Without these, `createSignal((props.todos ?? []).length)` would fall
+  // through to "unknown" and adapters would either pick `interface{}`
+  // or copy the underlying array's element type — both worse than the
+  // actual `number`. The accessor is the rightmost suffix, so a single
+  // regex on the tail is enough; we don't need to fully parse the LHS.
+  //
+  //   .length / .size       → number
+  //   .some(...) / .every(...) / .includes(...)           → boolean
+  //   .indexOf(...) / .findIndex(...) / .lastIndexOf(...) → number
+  //   .at(...) / .find(...) → unknown (element type; can't recover here)
+  if (/\.(length|size)\s*$/.test(trimmed)) {
+    return { kind: 'primitive', raw: 'number', primitive: 'number' }
+  }
+  if (/\.(some|every|includes)\s*\([\s\S]*\)\s*$/.test(trimmed)) {
+    return { kind: 'primitive', raw: 'boolean', primitive: 'boolean' }
+  }
+  if (/\.(indexOf|findIndex|lastIndexOf)\s*\([\s\S]*\)\s*$/.test(trimmed)) {
+    return { kind: 'primitive', raw: 'number', primitive: 'number' }
   }
 
   // Number

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -2708,7 +2708,11 @@ function collectResolvedNames(ctx: AnalyzerContext): Set<string> {
 // Identifiers from `@barefootjs/client` whose implementations live in the
 // DOM runtime (`@barefootjs/client/runtime`). Source files importing any of
 // these must be marked with `'use client'` so the compiler rewires them.
-const BROWSER_ONLY_CLIENT_APIS = new Set([
+//
+// Exported so the CLI's skip-gate (`detectMissingUseClient` in
+// `@barefootjs/cli/lib/build`) can raise BF001 against the same trigger
+// set the analyzer uses, instead of maintaining a drifting copy.
+export const BROWSER_ONLY_CLIENT_APIS = new Set([
   'useContext',
   'provideContext',
   'createPortal',
@@ -2807,7 +2811,12 @@ export function listComponentFunctions(
 // Names of reactive primitives that a factory body must contain for the
 // factory to qualify for inlining. Identifier resolution happens at the
 // source text level, so these are matched as bare identifiers.
-const REACTIVE_PRIMITIVES = new Set([
+//
+// Exported so the CLI's skip-gate (`detectMissingUseClient` in
+// `@barefootjs/cli/lib/build`) reuses the canonical list — keeps the
+// "imports reactive primitive without 'use client'" BF001 surface
+// from drifting out of sync with the analyzer's call-site detection.
+export const REACTIVE_PRIMITIVES = new Set([
   'createSignal', 'createMemo', 'createEffect',
   'createDisposableEffect', 'onMount', 'onCleanup',
 ])

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -46,7 +46,7 @@ export type {
 } from './types'
 
 // Analyzer
-export { analyzeComponent, listComponentFunctions, listComponentFunctions as listExportedComponents, createProgramForFile, needsTypeBasedDetection, type AnalyzerContext } from './analyzer'
+export { analyzeComponent, listComponentFunctions, listComponentFunctions as listExportedComponents, createProgramForFile, needsTypeBasedDetection, REACTIVE_PRIMITIVES, BROWSER_ONLY_CLIENT_APIS, type AnalyzerContext } from './analyzer'
 export { createProgramForCorpus, type SharedProgramOptions } from './shared-program'
 
 // JSX to IR transformer


### PR DESCRIPTION
## Summary

Alpha-onboarding dry-run #4. Walked through `docs/core/quick-start.md` against
the pkg.pr.new preview from this PR (`npm create barefootjs@latest` + the
provided rewrite script) for every adapter the scaffold ships
(Hono/Cloudflare, Mojolicious, Go/Echo), built four sample apps on top of
each scaffold (a TodoList, a server-rendered UserList, a Zod-backed
LoginForm, a Go TodoApp with a child `<TodoItem>`), then filed each friction
point as a self-contained commit on this branch.

## Friction surfaced + fixed

### Hono scaffold
1. **`bf docs` / `bf debug` case-sensitivity.** Quick-start uses lowercase
   placeholders, so users type `bf docs counter` — but the on-disk file is
   `Counter.tsx` and the case-sensitive lookup hard-errored. The fallback
   now re-resolves case-insensitively against the meta dir and source
   dirs, and the docs renderer prints the canonical PascalCase name
   regardless of how the user typed it. Ambiguous case-insensitive hits
   (both `Counter.tsx` AND `counter.tsx` present) deliberately bail to
   the regular "not found" transcript instead of picking by `readdirSync`
   order. (commits 6482921b + 9d56455d)

2. **Watch-mode stale builds.** Editing a component to add `<Input>` /
   `<Button>` imports while `bf build --watch` was running emitted a
   template whose `<Input>` / `<Button>` got demoted to plain `<input>`
   / `<button>` — and then the recursive `fs.watch` iterator silently
   stopped delivering events, so subsequent edits never rebuilt at all.
   Added post-build revalidation (re-hash sources after each flush,
   reschedule if anything diverged from what we just compiled) plus a
   low-frequency hash-diff poll that recovers from missed inotify events.
   Steady-state cost stays bounded via an mtime cache and adaptive
   backoff (2s while there's recent activity, doubling up to 30s once
   the project goes idle). (commits b37f8e84 + 9d56455d)

3. **`bf gen test` silently printed to stdout.** `bf gen component`'s
   "Next steps" message implies `bf gen test <name>` produces a file;
   in practice it dumped the test to stdout. `bf gen test` now writes
   `<Component>.test.tsx` (or `index.test.tsx` for nested registry
   layouts) next to the source, refuses to overwrite without `--force`,
   and preserves the old behavior under an explicit `--stdout` flag.
   (commit 848e787d)

4. **BF001 swallowed by the CLI's skip-gate.** A file that imports
   `createSignal` from `@barefootjs/client` without `"use client"` used
   to hit `if (!hasUseClientDirective) skippedCount++; continue` *before*
   the analyzer ran, so the documented BF001 diagnostic never reached
   the user — their component compiled to inert SSR HTML with zero
   console signal. Added an import-side scan at the skip-gate so files
   that need `'use client'` raise BF001 by name. The tripwire list
   pulls directly from `REACTIVE_PRIMITIVES` and
   `BROWSER_ONLY_CLIENT_APIS` exported by `@barefootjs/jsx`'s analyzer
   (single source of truth — covers `createDisposableEffect` /
   `useContext` / `provideContext` / `isSSRPortal` /
   `findSiblingSlot` / `cleanupPortalPlaceholder`, excludes the
   analyzer-safe `untrack`). (commits 17108510 + 9d56455d)

5. **CLI test-run hints hard-coded `bun test`.** `bf gen test`,
   `bf gen component`'s "Next steps", `bf add`'s "Run tests:" tail,
   and the workflow line in `bf --help` all suggested `bun test <path>`
   regardless of the user's package manager. Route all four sites
   through a new `commandsFor(pm).test(path)` helper after
   `detectPackageManager` on the project dir — output now matches the
   lockfile (npm/pnpm/yarn/bun), with the npm-specific `--` forwarding
   for path args. (commit 6e8da99b)

### Mojolicious scaffold
6. **Server doesn't start.** `npm create barefootjs@latest --adapter mojo`
   shipped a `dev` script of `bf build && unocss && concurrently ...`.
   `bf init` auto-adds `button`, which transitively pulls in `slot` —
   whose asChild expression `[a, b].filter(Boolean).join(' ')` the
   mojolicious adapter can't lower to Embedded Perl. `bf build` exited
   1, the `&&` chain short-circuited, morbo never started, and the user
   saw the dev script exit with no obvious cause. Drop the cold-build
   prefix entirely (match hono's pattern). The watchers each do their
   own initial build inside `concurrently`, so the output directory
   populates as soon as the first compile finishes; the BF101 still
   surfaces in the `[build]` pane where the user can act on it.
   (commit ce5aec0f)

7. **`/_bf/reload` silently broke for the mojo scaffold** (companion
   commit from a parallel thread — landed 088871cf).

### Go / Echo scaffold (TodoApp friction)
8. **Go template loop-param scoping bug (FATAL — silent truncation).**
   A `todos().map(todo => <li>{todo.done ? ... : ''} {todo.text}</li>)`
   loop emitted `{{range $_, $todo := .Todos}}<input {{if .Todo.Done}}...`
   — `.Todo.Done` is a non-existent field. Go's `html/template` silently
   expanded it to "" and aborted the surrounding `{{if}}`. Echo
   returned HTTP 200 with a truncated body (`<input ... </main>`),
   `bytes_out: 3526` was logged as normal, and the browser showed a
   blank list with no console signal. Root cause: `renderConditionExpr`
   in the go-template adapter mirrored `ParsedExprEmitter`'s
   member-handling path but skipped the `loopParamStack` normalization —
   so boolean attributes (`checked={todo.done}`), style ternaries
   (`todo.done ? ... : ''`), and every `{{if ...}}` operand routed
   through the condition path missed the dot-scope fix. (commit
   a7eb1e63)

9. **Signal / memo Go types fell back to `[]Todo` / `interface{}` for
   length-of-array expressions.** `createSignal((props.initial ?? []).length)`
   emitted `Seq []Todo` (the prop's type, because the adapter's prop-name
   extractor blindly propagated the array type past the `.length`
   accessor). `createMemo(() => todos().filter(...).length)` emitted
   `Remaining interface{}` because memos never ran value-type inference
   at all. Three feeder fixes: extend `inferTypeFromValue` to recognise
   `.length` / `.size` / `.some` / `.every` / `.includes` /
   `.indexOf` etc.; run that inference on memo arrow-bodies; tighten
   the Go adapter's extractor so a type-changing trailing accessor
   doesn't inherit the prop's Go type. Result: `Seq int`,
   `Remaining int`, `Total int` instead of the previous `[]Todo` /
   `interface{}` / `interface{}`. (commit a7eb1e63)

10. **`NewXxxProps` left dynamic loop slices empty with no signal.**
    `TodoAppProps` carries `TodoItems []TodoItemProps` for a
    `todos().map(t => <TodoItem todo={t} />)` loop, but
    `NewTodoAppProps(TodoAppInput{Initial: ...})` returned the slice
    empty and the SSR template iterated into a blank list. The
    "you have to populate this in your handler" rule was pure tribal
    knowledge. Emit a doc comment above `func New${X}Props` for every
    dynamic loop child with a concrete example: the field name, the
    child's Input/Props names, and the `BfParent` / `BfMount` slot
    identity the template relies on. (commit cf23500d)

11. **`Renderer.Render` silently swallowed `ExecuteTemplate` errors.**
    The single biggest amplifier for #8: the runtime layer dropped the
    return value of `ExecuteTemplate`, so any field-reference failure
    became a partial-but-200 response with no log line. Capture the
    error, write a single line to stderr, and append a clearly-marked
    inline HTML panel (inline-styled so it surfaces even when the
    project CSS hasn't loaded, HTML-escaped so a faulty template name
    can't smuggle markup) pointing the reader at the offending
    `dist/templates/*.tmpl`. Whatever the template managed to emit
    before failing is preserved, so users see the partial output AND
    the panel. (commit cf69798b)

## Reverted

- **form README rewrite** — initially included a Quick-Start rewrite for
  the `form.field()` pattern after I hit a `BF061 Init-scope local
  referenced from template scope` on it in the scaffold. On further
  inspection the same source compiles cleanly in
  `site/ui/components/create-form-demo.tsx` (workspace-resolved
  `@barefootjs/form`) but errors when `@barefootjs/form` is installed
  via a pkg.pr.new tarball. The README is correct; the discrepancy is
  an environment-sensitive compiler bug that deserves its own
  investigation, not a docs paper-over. (commit 9f5c9e1a)

## Test plan

- [x] `cr-tracked` label applied → pkg.pr.new published a preview for this PR.
- [x] `npm create barefootjs@latest` (via pkg-pr-new tarball) scaffolded each adapter without prompts at `--yes`.
- [x] Hono: edited the starter Counter and confirmed `bf build --watch` + `wrangler dev` live-reload.
- [x] Hono: built `/todos`, `/users`, `/login` (`@barefootjs/form` + Zod) end-to-end.
- [x] Mojo: `morbo` starts even with bundled BF101 on `slot`; `curl /` returns the SSR Counter page with shadcn classes.
- [x] Go/Echo: rebuilt the user's TodoApp shape; verified `Seq int`/`Remaining int`/`Total int`, `{{if .Done}}` (not `.Todo.Done`), and the new doc comment on `NewTodoAppProps`.
- [x] Every shipped fix carries unit tests; `packages/cli` (594), `packages/jsx` (1335), `packages/adapter-go-template` (200), `packages/adapter-go-template/runtime` (Go tests), `packages/adapter-tests` (345), `packages/form` (40) all pass.

Co-authored-by: Claude Opus 4.7 &lt;noreply@anthropic.com&gt;
Co-authored-by: kobaken &lt;kentafly88@gmail.com&gt;