### PR TITLE
fix(jsx/#1443): lower destructured-param and function-keyword filter callbacks

### DIFF
--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -1379,6 +1379,37 @@ export function V({ variant }: { variant: 'a' | 'b' }) {
     })
   })
 
+  describe('destructured / function-keyword filter shapes (#1443)', () => {
+    test('.filter(({done}) => done).map(...) lowers cleanly', () => {
+      // Pre-#1443 the destructured arrow rejected at the parser and the
+      // surrounding `.map()` loop fell back to a BF101 path. With the
+      // parser rewriting `({done}) => done` to `_t => _t.done`, the
+      // adapter's existing IRLoop.filterPredicate path renders the
+      // chain as `bf_filter .Items "Done" true`.
+      const result = compileAndGenerate(`'use client'
+import { createSignal } from '@barefootjs/client'
+export function C() {
+  const [items] = createSignal<any[]>([])
+  return <ul>{items().filter(({done}) => done).map(t => <li key={t.id}>{t.name}</li>)}</ul>
+}`)
+      expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
+      expect(result.template).toContain('bf_filter .Items "Done" true')
+    })
+
+    test('.filter(function (x) { return x.done }).map(...) lowers cleanly', () => {
+      // Function expressions with a single `return <expr>` body
+      // normalise to the arrow-fn IR shape at parse time.
+      const result = compileAndGenerate(`'use client'
+import { createSignal } from '@barefootjs/client'
+export function C() {
+  const [items] = createSignal<any[]>([])
+  return <ul>{items().filter(function (x) { return x.done }).map(t => <li key={t.id}>{t.name}</li>)}</ul>
+}`)
+      expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
+      expect(result.template).toContain('bf_filter .Items "Done" true')
+    })
+  })
+
   describe('registry Slot class-merge chain (#1443)', () => {
     test('[a, b].filter(Boolean).join(\' \') lowers to bf_join (bf_filter_truthy (bf_arr ...)) " "', () => {
       // The registry `<Slot>` merges className via

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -281,12 +281,14 @@ export function C() {
   return ${body}
 }`
 
+    // #1443 follow-up: destructured filter param and function-keyword
+    // filter no longer fall in this BF101 group — they lower cleanly
+    // via parser-side normalisation (see `lowers .filter(({done}) =>
+    // done) ...` parser tests + the Mojo positive-output test below).
     const cases: { name: string; body: string; needle: string }[] = [
       { name: 'reduce',            body: `<div>{items().reduce((s, x) => s + x, 0)}</div>`,                                                          needle: '.reduce(' },
       { name: 'forEach',           body: `<ul>{items().forEach(x => x)}</ul>`,                                                                       needle: '.forEach(' },
       { name: 'flatMap',           body: `<ul>{items().flatMap(x => x.tags).map(t => <li key={t}>{t}</li>)}</ul>`,                                  needle: '.flatMap(' },
-      { name: 'destructured filter param', body: `<ul>{items().filter(({done}) => done).map(t => <li key={t.id}>{t.name}</li>)}</ul>`,              needle: '.filter(' },
-      { name: 'function-keyword filter',   body: `<ul>{items().filter(function(x) { return x.done }).map(t => <li key={t.id}>{t.name}</li>)}</ul>`, needle: '.filter(' },
       { name: 'nested higher-order in filter predicate', body: `<ul>{items().filter(x => x.tags.filter(t => t.active).length > 0).map(t => <li key={t.id}>{t.name}</li>)}</ul>`, needle: 'higher-order' },
     ]
 
@@ -307,6 +309,41 @@ export function C() {
         expect(bf101).toEqual([])
       })
     }
+  })
+
+  test('lowers .filter(({done}) => done).map(...) — destructured filter param (#1443)', () => {
+    // Pre-#1443 the destructured arrow rejected at the parser and the
+    // surrounding `.map()` loop fell back to a BF101 path. With the
+    // parser rewriting `({done}) => done` to `_t => _t.done`, the
+    // adapter's existing `IRLoop.filterPredicate` path renders the
+    // chain as a Perl `for` over `grep { $_->{done} } @{$items}`.
+    const adapter = new MojoAdapter()
+    const result = compileJSX(`'use client'
+import { createSignal } from '@barefootjs/client'
+export function C() {
+  const [items] = createSignal<any[]>([])
+  return <ul>{items().filter(({done}) => done).map(t => <li key={t.id}>{t.name}</li>)}</ul>
+}`, 'C.tsx', { adapter })
+    expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
+    const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
+    expect(template).toContain('grep { $_->{done} } @{$items}')
+  })
+
+  test('lowers .filter(function (x) { return x.done }).map(...) — function-keyword filter (#1443)', () => {
+    // Function expressions with a single `return <expr>` body normalise
+    // to the arrow-fn IR shape at parse time, so the higher-order
+    // detector + adapter lowering paths fire alongside their arrow
+    // counterparts.
+    const adapter = new MojoAdapter()
+    const result = compileJSX(`'use client'
+import { createSignal } from '@barefootjs/client'
+export function C() {
+  const [items] = createSignal<any[]>([])
+  return <ul>{items().filter(function (x) { return x.done }).map(t => <li key={t.id}>{t.name}</li>)}</ul>
+}`, 'C.tsx', { adapter })
+    expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
+    const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
+    expect(template).toContain('grep { $_->{done} } @{$items}')
   })
 
   test('lowers the registry Slot\'s [a, b].filter(Boolean).join(\' \') chain (#1443)', () => {

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -299,6 +299,74 @@ describe('expression-parser', () => {
         ])
       }
     })
+
+    // Destructured filter param (#1443). The parser rewrites the
+    // shorthand binding `({done})` into the equivalent dotted-access
+    // form on a synthetic param (`_t.done`), so adapters can reuse
+    // their existing higher-order paths instead of a separate
+    // residual-object-accessor pipeline (#1384 territory).
+    test('lowers .filter(({done}) => done) to higher-order with synthetic param (#1443)', () => {
+      const result = parseExpression('todos().filter(({done}) => done)')
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') {
+        expect(result.method).toBe('filter')
+        // Synthetic param won't collide with `done` (the destructured
+        // local) or any name in the body.
+        expect(result.param).not.toBe('done')
+        // Predicate is rewritten to `<synthetic>.done`
+        expect(result.predicate.kind).toBe('member')
+        if (result.predicate.kind === 'member') {
+          expect(result.predicate.property).toBe('done')
+          expect(result.predicate.object.kind).toBe('identifier')
+          if (result.predicate.object.kind === 'identifier') {
+            expect(result.predicate.object.name).toBe(result.param)
+          }
+        }
+      }
+    })
+
+    // Renamed destructure: `{ done: isDone }` — the LOCAL name is
+    // `isDone`, the FIELD on the loop var is `done`. The rewrite
+    // substitutes `isDone` (the body reference) with `_t.done` (the
+    // original field name).
+    test('lowers .filter(({done: isDone}) => isDone) to higher-order with renamed destructure (#1443)', () => {
+      const result = parseExpression('todos().filter(({done: isDone}) => isDone)')
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') {
+        expect(result.predicate.kind).toBe('member')
+        if (result.predicate.kind === 'member') {
+          expect(result.predicate.property).toBe('done') // original field, not the local rename
+        }
+      }
+    })
+
+    // Defaults / rest / nested destructure stay unsupported — each
+    // would need its own residual-object accessor pipeline. We accept
+    // only the unrenamed-field and renamed-field forms here.
+    test('rejects .filter(({done = false}) => done) — defaults in destructure are unsupported (#1443)', () => {
+      const result = parseExpression('todos().filter(({done = false}) => done)')
+      // Falls through to plain `call` (not higher-order), so isSupported
+      // will surface BF101 at the adapter via the UNSUPPORTED_METHODS gate.
+      expect(result.kind).toBe('call')
+    })
+
+    // Function-keyword filter callback (#1443): `function (x) { return
+    // x.done }`. Normalised into the arrow-fn IR shape so the
+    // higher-order detector at the call site recognises it alongside
+    // `(x) => x.done`.
+    test('lowers .filter(function(x) { return x.done }) to higher-order (#1443)', () => {
+      const result = parseExpression('todos().filter(function (x) { return x.done })')
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') {
+        expect(result.param).toBe('x')
+        expect(result.predicate.kind).toBe('member')
+      }
+    })
+
+    test('rejects function-keyword filter with multiple statements (#1443)', () => {
+      const result = parseExpression('todos().filter(function (x) { const y = x; return y.done })')
+      expect(result.kind).toBe('call')
+    })
   })
 
   describe('isSupported', () => {

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -292,34 +292,227 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
     return { kind: 'literal', value: node.text, literalType: 'string' }
   }
 
-  // Arrow function: x => expr
+  // Arrow function: x => expr  /  ({field}) => field  /  (x) => expr
   if (ts.isArrowFunction(node)) {
-    // Only support single parameter without destructuring
+    // Only support single parameter
     if (node.parameters.length !== 1) {
       return { kind: 'unsupported', raw, reason: 'Only single parameter arrow functions are supported' }
     }
     const param = node.parameters[0]
-    if (!ts.isIdentifier(param.name)) {
-      return { kind: 'unsupported', raw, reason: 'Destructuring parameters are not supported' }
-    }
-    const paramName = param.name.text
 
-    // Only expression body is supported (not block body)
+    // Only expression body is supported (not block body). Block bodies
+    // route through `parseBlockBody` at the higher-order recognition
+    // call site so the adapter's filter-block path handles them
+    // separately.
     if (ts.isBlock(node.body)) {
       return { kind: 'unsupported', raw, reason: 'Block body arrow functions are not supported' }
     }
-
     const body = convertNode(node.body, raw)
-    return { kind: 'arrow-fn', param: paramName, body }
+
+    // Destructured-object param: `({done}) => done` (#1443).
+    // We synthesise the equivalent dotted-access form so adapters
+    // can reuse their existing higher-order paths instead of needing
+    // a residual-object-accessor pipeline (#1384 territory). Only the
+    // unrenamed-field / renamed-field forms are handled — nested
+    // destructure / rest / defaults stay unsupported.
+    if (ts.isObjectBindingPattern(param.name)) {
+      const fieldMap = new Map<string, string>()
+      for (const el of param.name.elements) {
+        if (!ts.isBindingElement(el)) {
+          return { kind: 'unsupported', raw, reason: 'Unsupported binding element in destructured filter param' }
+        }
+        if (el.dotDotDotToken) {
+          return { kind: 'unsupported', raw, reason: 'Rest patterns in destructured filter param are not supported' }
+        }
+        if (el.initializer) {
+          return { kind: 'unsupported', raw, reason: 'Default values in destructured filter param are not supported' }
+        }
+        if (!ts.isIdentifier(el.name)) {
+          return { kind: 'unsupported', raw, reason: 'Nested destructuring in filter param is not supported' }
+        }
+        const localName = el.name.text
+        const fieldName =
+          el.propertyName && ts.isIdentifier(el.propertyName)
+            ? el.propertyName.text
+            : localName // shorthand: `{done}` ≡ `{done: done}`
+        fieldMap.set(localName, fieldName)
+      }
+      const syntheticParam = pickSyntheticParam(fieldMap, body)
+      const rewritten = substituteDestructuredFields(body, fieldMap, syntheticParam)
+      return { kind: 'arrow-fn', param: syntheticParam, body: rewritten }
+    }
+
+    if (!ts.isIdentifier(param.name)) {
+      return { kind: 'unsupported', raw, reason: 'Destructuring parameters are not supported' }
+    }
+    return { kind: 'arrow-fn', param: param.name.text, body }
   }
 
-  // Function expression (unsupported)
+  // Function expression: `function (x) { return x.done }` (#1443).
+  // Normalise the single-param + single-return shape into the arrow
+  // form so the higher-order detector at the call site recognises it
+  // alongside `(x) => x.done`. Multi-statement / multi-param / nested-
+  // destructure shapes stay unsupported.
   if (ts.isFunctionExpression(node)) {
-    return { kind: 'unsupported', raw, reason: 'Function expressions cannot be evaluated at SSR time' }
+    if (node.parameters.length !== 1) {
+      return { kind: 'unsupported', raw, reason: 'Only single-parameter function expressions are supported' }
+    }
+    const param = node.parameters[0]
+    if (!ts.isIdentifier(param.name)) {
+      return { kind: 'unsupported', raw, reason: 'Destructured params in function expressions are not supported' }
+    }
+    const stmts = node.body.statements
+    if (stmts.length !== 1 || !ts.isReturnStatement(stmts[0]) || !stmts[0].expression) {
+      return { kind: 'unsupported', raw, reason: 'Function expressions must be `function (x) { return <expr> }`' }
+    }
+    return {
+      kind: 'arrow-fn',
+      param: param.name.text,
+      body: convertNode(stmts[0].expression, raw),
+    }
   }
 
   // Default: unsupported
   return { kind: 'unsupported', raw, reason: `Unsupported syntax: ${ts.SyntaxKind[node.kind]}` }
+}
+
+/**
+ * Pick a synthetic param name for a rewritten destructured filter
+ * (`({done}) => done` → `(_t) => _t.done`). The name must NOT collide
+ * with anything the body might reference — a `_t` already on the body
+ * (e.g. a signal getter) would silently capture into the rewrite.
+ *
+ * Start with `_t` and add underscores until no collision exists. The
+ * candidate set is "every name the destructure introduced" + "every
+ * identifier referenced inside the body" (collectIdentifiers). Both
+ * are reachable from the local rewrite context, so we avoid all of
+ * them up-front rather than risk a runtime bug from a missed name.
+ */
+function pickSyntheticParam(fieldMap: Map<string, string>, body: ParsedExpr): string {
+  const used = new Set<string>(fieldMap.keys())
+  collectIdentifiers(body, used)
+  let name = '_t'
+  while (used.has(name)) name = name + '_'
+  return name
+}
+
+function collectIdentifiers(expr: ParsedExpr, out: Set<string>): void {
+  switch (expr.kind) {
+    case 'identifier':
+      out.add(expr.name)
+      return
+    case 'call':
+      out.add('_'); // ensure the synthetic-fallback name is reserved on bare callees
+      collectIdentifiers(expr.callee, out)
+      expr.args.forEach(a => collectIdentifiers(a, out))
+      return
+    case 'member':
+      collectIdentifiers(expr.object, out)
+      return
+    case 'binary':
+    case 'logical':
+      collectIdentifiers(expr.left, out)
+      collectIdentifiers(expr.right, out)
+      return
+    case 'unary':
+      collectIdentifiers(expr.argument, out)
+      return
+    case 'conditional':
+      collectIdentifiers(expr.test, out)
+      collectIdentifiers(expr.consequent, out)
+      collectIdentifiers(expr.alternate, out)
+      return
+    case 'template-literal':
+      for (const part of expr.parts) {
+        if (part.type === 'expression') collectIdentifiers(part.expr, out)
+      }
+      return
+    case 'arrow-fn':
+      collectIdentifiers(expr.body, out)
+      return
+    case 'higher-order':
+      collectIdentifiers(expr.object, out)
+      collectIdentifiers(expr.predicate, out)
+      return
+    case 'array-literal':
+      expr.elements.forEach(e => collectIdentifiers(e, out))
+      return
+    case 'array-method':
+      collectIdentifiers(expr.object, out)
+      expr.args.forEach(e => collectIdentifiers(e, out))
+      return
+    case 'literal':
+    case 'unsupported':
+      return
+  }
+}
+
+/**
+ * Rewrite a parsed body that referenced destructured names (`done`)
+ * into the equivalent dotted-access form against a synthetic param
+ * (`_t.done`). Identifiers not in `fieldMap` are left alone — they're
+ * either closure captures (signals, props) or already-synthetic names.
+ */
+function substituteDestructuredFields(
+  expr: ParsedExpr,
+  fieldMap: Map<string, string>,
+  syntheticParam: string,
+): ParsedExpr {
+  const walk = (e: ParsedExpr): ParsedExpr => {
+    switch (e.kind) {
+      case 'identifier': {
+        const field = fieldMap.get(e.name)
+        if (field === undefined) return e
+        return {
+          kind: 'member',
+          object: { kind: 'identifier', name: syntheticParam },
+          property: field,
+          computed: false,
+        }
+      }
+      case 'call':
+        return { kind: 'call', callee: walk(e.callee), args: e.args.map(walk) }
+      case 'member':
+        return { kind: 'member', object: walk(e.object), property: e.property, computed: e.computed }
+      case 'binary':
+        return { kind: 'binary', op: e.op, left: walk(e.left), right: walk(e.right) }
+      case 'logical':
+        return { kind: 'logical', op: e.op, left: walk(e.left), right: walk(e.right) }
+      case 'unary':
+        return { kind: 'unary', op: e.op, argument: walk(e.argument) }
+      case 'conditional':
+        return { kind: 'conditional', test: walk(e.test), consequent: walk(e.consequent), alternate: walk(e.alternate) }
+      case 'template-literal':
+        return {
+          kind: 'template-literal',
+          parts: e.parts.map(p =>
+            p.type === 'expression' ? { type: 'expression', expr: walk(p.expr) } : p,
+          ),
+        }
+      case 'arrow-fn':
+        // A nested arrow inside the predicate body shadows the outer
+        // param. Leave its body alone — its own param-resolution path
+        // handles closure references against the outer fieldMap on its
+        // own terms. This matches how JS scope rules treat the outer
+        // destructured `done` once a shadowing inner arrow declares a
+        // different name (the inner arrow's body sees the outer
+        // `done` only if it doesn't shadow it, which we can't know
+        // without per-scope tracking). Skipping the rewrite is the
+        // conservative choice — worst case the resulting predicate
+        // doesn't lower and the adapter emits BF101.
+        return e
+      case 'higher-order':
+        return e
+      case 'array-literal':
+        return { kind: 'array-literal', elements: e.elements.map(walk) }
+      case 'array-method':
+        return { kind: 'array-method', method: e.method, object: walk(e.object), args: e.args.map(walk) }
+      case 'literal':
+      case 'unsupported':
+        return e
+    }
+  }
+  return walk(expr)
 }
 
 /**


### PR DESCRIPTION
## Summary

Two more #1443 shapes that previously emitted BF101 on Mojo / Go now lower cleanly via parser-side normalisation. Both adapters reuse their existing `IRLoop.filterPredicate` paths without per-adapter changes — the work is entirely in the parser.

Stacked on top of #1445 (Go side of the Slot chain).

## Shapes addressed

### Destructured filter param — `({done}) => done`

- ObjectBindingPattern with shorthand-or-renamed field bindings is accepted; the body is walked and every identifier matching a destructured local gets rewritten to `<synthetic>.<field>` (the **original** field name, not the rename) against a fresh synthetic param.
- Synthetic name is chosen by scanning the body for any identifier it would collide with (signals, props, the destructured locals themselves) and adding underscores until unique — silent capture by a signal getter would be a sneaky runtime bug.
- Nested destructuring, defaults, and rest patterns stay unsupported (they'd each need their own residual-object-accessor pipeline, #1384 territory).

### Function-keyword filter — `function (x) { return x.done }`

- Only the single-param, single-`return <expr>` shape is normalised. The parser emits an `arrow-fn` IR equivalent, so the higher-order detector at the call site recognises it alongside the arrow form.
- Multi-statement bodies, multi-param, and destructured params stay unsupported.

## Tests

- Parser tests cover the supported shapes and pin the unsupported ones as `call` (so they fall through to the existing BF101 path).
- Mojo adapter: positive output assertions checking the predicate lowers to `grep { $_->{done} } @{$items}` for both shapes.
- Go adapter: positive output assertions checking the predicate lowers to `bf_filter .Items "Done" true` for both shapes.
- The conformance suite previously pinned both shapes as BF101 cases in `'emits BF101 for JS-only filter / array patterns'`; they've been removed from that list.

## Stack

This is **PR 3/N** for #1443.

- ✅ PR1 (#1444): Mojo side of the Slot chain + `array-method` IR refactor
- ✅ PR2 (#1445): Go side of the Slot chain
- 🟢 **PR3 (this)**: destructured filter param + function-keyword filter (both adapters via parser-only changes)
- ⏳ PR4 (planned): nested higher-order in filter predicate
- ⏳ PR5 (optional, needs design): `reduce` / `forEach` / `flatMap`

## Test plan

- [x] `bun test packages/jsx/src/__tests__/expression-parser.test.ts` — 5 new parser tests (3 destructured + 2 function-keyword), 70 pass / 0 fail
- [x] `bun test packages/adapter-mojolicious/` — 176 pass / 0 fail
- [x] `bun test packages/adapter-go-template/` — 199 pass / 0 fail
- [x] `tsc --noEmit` clean for all three affected packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_013cEtcSYt37CdRguejqFeAt)_