### PR TITLE
feat(cli/#1443): wire Mojo scaffold to the registry Button + Slot

### DIFF
--- a/packages/cli/src/lib/adapters/mojo.ts
+++ b/packages/cli/src/lib/adapters/mojo.ts
@@ -9,7 +9,7 @@ import { execSync } from 'node:child_process'
 import type { AdapterTemplate } from '../templates'
 import {
   COMPONENTS_MANIFEST_SEED,
-  NATIVE_BUTTON_COUNTER_TSX,
+  SHARED_COUNTER_TSX,
   STYLES_CSS,
   TOKENS_CSS,
   UNOCSS_DEV_DEPENDENCIES,
@@ -154,12 +154,14 @@ export const MOJO_ADAPTER: AdapterTemplate = {
       'components/**/*.tsx',
       'dist/components/**/*.tsx',
     ]),
-    // Registry <Button> is not auto-installed for mojo (see
-    // `bundledRegistryComponents` below), so the starter uses raw
-    // <button> elements with utility classes inline — keeps the
-    // scaffold runnable without referencing a component that isn't
-    // on disk yet.
-    'components/Counter.tsx': NATIVE_BUTTON_COUNTER_TSX,
+    // Registry <Button> is auto-installed for mojo via the
+    // adapter-default `bundledRegistryComponents` (`['button']`)
+    // now that #1443's chain of PRs taught the Mojo adapter to
+    // lower the registry Slot's `[a, b].filter(Boolean).join(' ')`
+    // className-merge expression to Embedded Perl. The starter uses
+    // the same Button-based Counter the Hono / CSR / Echo scaffolds
+    // use, so the onboarding story is consistent across adapters.
+    'components/Counter.tsx': SHARED_COUNTER_TSX,
     'public/styles.css': STYLES_CSS,
     'public/tokens.css': TOKENS_CSS,
     'public/uno.css': UNO_CSS_PLACEHOLDER,
@@ -168,14 +170,13 @@ export const MOJO_ADAPTER: AdapterTemplate = {
   scripts: {
     // Run the watchers + Mojolicious's morbo (which auto-reloads on
     // app.pl edits) side-by-side. The watchers each do their own
-    // initial build at startup, so a separate cold-build prefix isn't
-    // needed — and used to be a hard blocker: any BF101 from the
-    // bundled `slot` component (the asChild pattern uses
-    // `.filter().join()`, which the mojo adapter can't lower to
-    // Embedded Perl) made `bf build` exit 1, the `&&` chain
-    // short-circuited, morbo never started, and the user saw "server
-    // doesn't come up" with no obvious cause. Matches the hono
-    // adapter's dev script shape.
+    // initial build at startup, so a separate cold-build prefix
+    // isn't needed. Matches the hono adapter's dev script shape.
+    // (A pre-#1443 hard blocker — `bf build` failing BF101 on the
+    // registry slot's `.filter(Boolean).join(' ')` chain and tanking
+    // the whole `&&` sequence so morbo never started — is no longer
+    // a concern now that the adapter lowers that expression
+    // natively.)
     dev: 'concurrently -k -n build,uno,server -c blue,magenta,green "bf build --watch" "unocss --watch" "morbo app.pl -l http://*:3002"',
     build: 'bf build && unocss',
     start: 'perl app.pl daemon -l http://*:3002',
@@ -193,16 +194,14 @@ export const MOJO_ADAPTER: AdapterTemplate = {
     concurrently: '^9.0.0',
     typescript: '^5.6.0',
   },
-  // The registry <Button> depends on <Slot>, whose
-  // `[a, b].filter(Boolean).join(' ')` className-merge expression the
-  // mojolicious adapter cannot yet lower to Embedded Perl (BF101). A
-  // persistent compile error in slot/index.tsx would in turn keep the
-  // CLI from writing the dev-reload sentinel after every rebuild,
-  // silently breaking `/_bf/reload` for the entire scaffold. Skip the
-  // bundled add until the adapter learns to lower that chain — `bf add
-  // button` will surface the same error explicitly when the user opts
-  // in.
-  bundledRegistryComponents: [],
+  // Registry <Button> + its <Slot> dependency now lower to Embedded
+  // Perl cleanly via the #1443 PR stack (`array-method` IR for
+  // `.join`, `bf_filter_truthy` for `.filter(Boolean)`, array-literal
+  // emit, nested-filter `.length`). Auto-installing `button` here
+  // brings the Mojo scaffold in line with the Hono / CSR / Echo
+  // onboarding flow so `npm create barefootjs@latest --adapter mojo`
+  // produces the same Counter shape across adapters. Omit the
+  // explicit empty array so init.ts's default `['button']` applies.
   prereqWarnings: () => perlPrereqs(),
   // Mojolicious itself is a Perl dependency, not an npm one — point
   // the user at the bundled cpanfile so they don't trip over a

--- a/packages/cli/src/lib/adapters/shared.ts
+++ b/packages/cli/src/lib/adapters/shared.ts
@@ -33,53 +33,6 @@ export function Counter(props: CounterProps) {
 }
 `
 
-// Starter Counter (Echo / Mojolicious — temporary): native <button>
-// elements with utility classes inline. The go-template / mojolicious
-// adapters can't yet render the registry <Button> end-to-end (the
-// component's cva-style class derivation requires JS-runtime
-// evaluation that those adapters don't have at SSR time). Once those
-// adapters catch up, every starter switches to SHARED_COUNTER_TSX
-// and this fork goes away. Until then, this keeps Echo/Mojo init
-// scaffolds visually styled and runnable.
-export const NATIVE_BUTTON_COUNTER_TSX = `'use client'
-
-import { createSignal, createMemo } from '@barefootjs/client'
-
-interface CounterProps {
-  initial?: number
-}
-
-export function Counter(props: CounterProps) {
-  const [count, setCount] = createSignal(props.initial ?? 0)
-  const doubled = createMemo(() => count() * 2)
-
-  return (
-    <div className="counter">
-      <p className="counter-value">count: {count()}</p>
-      <p className="counter-doubled">doubled: {doubled()}</p>
-      <div className="counter-buttons">
-        <button
-          type="button"
-          className="inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors bg-primary text-primary-foreground hover:bg-primary/90"
-          onClick={() => setCount(n => n + 1)}
-        >+1</button>
-        <button
-          type="button"
-          className="inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors bg-secondary text-secondary-foreground hover:bg-secondary/80"
-          onClick={() => setCount(n => n - 1)}
-        >-1</button>
-        <button
-          type="button"
-          className="inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors text-foreground hover:bg-accent hover:text-accent-foreground"
-          onClick={() => setCount(0)}
-        >Reset</button>
-      </div>
-    </div>
-  )
-}
-`
-
-
 // Theme tokens (CSS variables) referenced by the registry components'
 // utility classes (`bg-primary`, `text-foreground`, etc.). Mirrors
 // integrations/shared/styles/tokens.css so registry components ship

--- a/packages/cli/src/lib/templates.ts
+++ b/packages/cli/src/lib/templates.ts
@@ -72,12 +72,12 @@ export interface AdapterTemplate {
   extraSetupSteps?: { label?: string; command: string }[]
   /**
    * Registry components fetched into `components/ui/` at init. Defaults
-   * to `['button']`, matching what the starter Counter expects on
-   * adapters whose compiler can render the registry <Button>
-   * end-to-end. Adapters that can't yet (e.g. mojo's lowering doesn't
-   * cover Slot's higher-order className-merge chain) set this to `[]`
-   * and pair it with `NATIVE_BUTTON_COUNTER_TSX` so the scaffold
-   * doesn't ship with a known-failing source on the very first build.
+   * to `['button']`, matching what the starter Counter expects across
+   * every supported adapter (Hono, CSR, Echo, Mojo). Adapters that
+   * later grow an unsupported-lowering blocker for a registry
+   * component can set this to `[]` to skip the auto-install while
+   * the gap closes; today every adapter ships with the registry
+   * `<Button>` ready out of the box.
    */
   bundledRegistryComponents?: string[]
 }

--- a/ui/components/ui/slot/index.tsx
+++ b/ui/components/ui/slot/index.tsx
@@ -70,7 +70,15 @@ function isValidElement(element: unknown): element is { tag: unknown; props: Rec
 function Slot({ children, className, ...props }: SlotProps) {
   if (children && isValidElement(children)) {
     const Tag = children.tag as any
-    const childProps = children.props || {}
+    // The `isValidElement` type guard narrows `children.props` to a
+    // `Record<string, unknown>`, so the historical `|| {}` fallback
+    // was dead code at runtime. Dropping it also keeps branch-local
+    // inlining clean of object-literal nodes — the compiler's
+    // `ParsedExpr` IR has no `array-literal` carve-out for `{}`, so
+    // inlining `childClass` into the className-merge chain would
+    // otherwise drag an unsupported shape into BF101 territory on
+    // the Mojo / Go template adapters (#1443 follow-up).
+    const childProps = children.props
     const childClass = (childProps.className as string) || ''
     const childChildren = childProps.children
 


### PR DESCRIPTION
## Summary

Closes the "registry-as-onboarding-surface" gap that motivated #1443. With #1444 / #1445 / #1446 / #1447 merged, the registry `<Slot>` chain lowers cleanly on both Mojo and Go template adapters — the Mojo scaffold can finally ship the same `<Button>`-based Counter that the Hono / CSR / Echo adapters use.

## Changes

### `packages/cli/src/lib/adapters/mojo.ts`

- Counter source switches from `NATIVE_BUTTON_COUNTER_TSX` (raw `<button>` + inline utility classes) to `SHARED_COUNTER_TSX` (the same `<Button>`-based shape every other adapter uses).
- Drops the explicit `bundledRegistryComponents: []` so the init-time default `['button']` applies. `addFromRegistry` now fetches `components/ui/{button,slot}` into the scaffold the same way it does for Hono / Echo.
- The dev-script comment about morbo's `&&`-chain blocker is rephrased — that failure mode required a persistent BF101 from Slot, which no longer fires.

### `packages/cli/src/lib/adapters/shared.ts`

- `NATIVE_BUTTON_COUNTER_TSX` (the temporary native-button Counter) removed — no remaining call sites.

### `packages/cli/src/lib/templates.ts`

- `bundledRegistryComponents` docstring updated to reflect that every supported adapter now ships with the registry `<Button>` out of the box.

### `ui/components/ui/slot/index.tsx`

- The historical `const childProps = children.props || {}` fallback was already dead code at runtime (the `isValidElement` type guard narrows `children.props` to `Record<string, unknown>`), but **branch-local inlining substituted the `{}` object literal into the className-merge chain** — `[className, (((children.props || {}).className) || '')].filter(Boolean).join(' ')` — which the compiler's `ParsedExpr` IR has no representation for, so the Mojo adapter still hit BF101 on the inlined form even with array-literal IR support in place.
- Dropping the `|| {}` keeps the inlined form free of unsupported shapes.

Discovered by scaffolding `npm create barefootjs@latest --adapter mojo` end-to-end and watching `bf build` complain.

## Verification

Both scaffolds now build cleanly end-to-end:

```
$ bf init --adapter mojo  &&  bf build
Build complete: 2 compiled, 1 cached, 0 skipped, 0 errors

$ bf init --adapter echo  &&  bf build
Build complete: 3 compiled, 0 cached, 0 skipped, 0 errors
```

Mojo Slot template now emits:
```perl
join(' ', @{[grep { $_ } @{[$className, ($children->{props}->{className} || '')]}]})
```

Go Slot template now emits a `{{template "Tag" .TagSlot0}}` delegation backed by `bf_join (bf_filter_truthy (bf_arr ...)) " "`.

## Test plan

- [x] `bun test packages/cli/` — 594 pass / 0 fail (3 pre-existing `init-gate` failures from `runtimes.generated` resolved by `node scripts/embed-runtimes.mjs` — repo-setup, unrelated)
- [x] `bun test ui/components/ui/slot/` — 4 pass / 0 fail
- [x] End-to-end Mojo scaffold: `bf init --adapter mojo --css unocss --yes` followed by `bf build` succeeds with 0 errors and emits the Slot lowering above.
- [x] End-to-end Echo scaffold: same, also 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_013cEtcSYt37CdRguejqFeAt)_