### PR TITLE
test(#1448): shared fixture surface for JS array / string method lowering

### DIFF
--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -132,6 +132,33 @@ runAdapterConformanceTests({
     // lowers to `bf_join (bf_filter_truthy (bf_arr ...)) " "`. No
     // BF101 expected — pinned positively by the
     // `branch-local-filter-join-go` template-output test below.
+    //
+    // #1448 Tier A — JS Array / String methods that the Go template
+    // adapter hasn't lowered yet. Each row drops once the
+    // corresponding method PR lands. Hono / CSR pass these out of
+    // the box (they evaluate JS at runtime) so the pin only applies
+    // here.
+    //
+    // The `.includes()` fixtures land at JSX conditional position
+    // (`{cond ? 'yes' : 'no'}`), which routes through
+    // `convertConditionToGo` and surfaces the existing BF102
+    // ("Condition not supported"); the remaining fixtures land at
+    // expression position and surface BF101 via
+    // `convertExpressionToGo`. Distinct codes for the two paths is
+    // pre-existing adapter behaviour, not something this catalog
+    // should paper over — pinned literally here.
+    'array-includes':      [{ code: 'BF102', severity: 'error' }],
+    'array-indexOf':       [{ code: 'BF101', severity: 'error' }],
+    'array-lastIndexOf':   [{ code: 'BF101', severity: 'error' }],
+    'array-at':            [{ code: 'BF101', severity: 'error' }],
+    'array-concat':        [{ code: 'BF101', severity: 'error' }],
+    'array-slice':         [{ code: 'BF101', severity: 'error' }],
+    'array-reverse':       [{ code: 'BF101', severity: 'error' }],
+    'array-toReversed':    [{ code: 'BF101', severity: 'error' }],
+    'string-toLowerCase':  [{ code: 'BF101', severity: 'error' }],
+    'string-toUpperCase':  [{ code: 'BF101', severity: 'error' }],
+    'string-trim':         [{ code: 'BF101', severity: 'error' }],
+    'string-includes':     [{ code: 'BF102', severity: 'error' }],
   },
   // `JSON_STRINGIFY_VIA_CONST` and `MATH_FLOOR_VIA_CONST` now pass
   // via `GoTemplateAdapter.templatePrimitives` (#1188). The two

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -105,6 +105,23 @@ runAdapterConformanceTests({
     // shape) now lowers to `join(' ', @{[grep { $_ } @{[$a, $b]}]})`.
     // No BF101 expected — pinned positively via the
     // `branch-local-filter-join` template-output test below.
+    //
+    // #1448 Tier A — JS Array / String methods that the Mojo adapter
+    // hasn't lowered yet. Each row drops once the corresponding
+    // method PR lands. Hono / CSR pass these out of the box (they
+    // evaluate JS at runtime) so the pin only applies here.
+    'array-includes':      [{ code: 'BF101', severity: 'error' }],
+    'array-indexOf':       [{ code: 'BF101', severity: 'error' }],
+    'array-lastIndexOf':   [{ code: 'BF101', severity: 'error' }],
+    'array-at':            [{ code: 'BF101', severity: 'error' }],
+    'array-concat':        [{ code: 'BF101', severity: 'error' }],
+    'array-slice':         [{ code: 'BF101', severity: 'error' }],
+    'array-reverse':       [{ code: 'BF101', severity: 'error' }],
+    'array-toReversed':    [{ code: 'BF101', severity: 'error' }],
+    'string-toLowerCase':  [{ code: 'BF101', severity: 'error' }],
+    'string-toUpperCase':  [{ code: 'BF101', severity: 'error' }],
+    'string-trim':         [{ code: 'BF101', severity: 'error' }],
+    'string-includes':     [{ code: 'BF101', severity: 'error' }],
   },
   // `JSON_STRINGIFY_VIA_CONST` and `MATH_FLOOR_VIA_CONST` now pass
   // via `MojoAdapter.templatePrimitives` (#1189). The two remaining

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1139,6 +1139,18 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       return this.convertHigherOrderExpr(expr)
     }
 
+    // #1448 Tier A — JS Array / String methods that the regex
+    // pipeline silently mangles into `${obj}->{<method>}(...)` hash
+    // lookups that fail at render time. Route them through the same
+    // AST path so `isSupported`'s `UNSUPPORTED_METHODS` gate fires
+    // BF101 with the offending expression, matching Go's behaviour.
+    // Each method name drops off the regex as its lowering lands
+    // (the regex stays in sync with `UNSUPPORTED_METHODS` —
+    // `convertHigherOrderExpr` intercepts via `isSupported`).
+    if (/\.\s*(?:includes|indexOf|lastIndexOf|at|concat|slice|reverse|toReversed|toLowerCase|toUpperCase|trim)\s*\(/.test(expr)) {
+      return this.convertHigherOrderExpr(expr)
+    }
+
     // templatePrimitives substitution (#1189): rewrite identifier-path
     // calls like `JSON.stringify(props.config)` / `Math.floor(x)` to
     // their Mojo helper-call form (`bf->json($config)` etc.) BEFORE

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -84,6 +84,24 @@ import { fixture as restDestructureObjectInMap } from './rest-destructure-object
 import { fixture as restDestructureObjectSpreadInMap } from './rest-destructure-object-spread-in-map'
 import { fixture as restDestructureArrayInMap } from './rest-destructure-array-in-map'
 import { fixture as restDestructureNestedInMap } from './rest-destructure-nested-in-map'
+// Priority 11: JS Array / String method lowering (#1448 Tier A).
+// One fixture per method — every adapter starts pinned with BF101 in
+// its own `expectedDiagnostics`, and each method PR removes its row
+// once the lowering lands. Hono / CSR pass these out of the box
+// (they evaluate JS at runtime), so the pinning only applies to the
+// template-language adapters (Mojo, Go).
+import { fixture as arrayIncludes } from './methods/array-includes'
+import { fixture as arrayIndexOf } from './methods/array-indexOf'
+import { fixture as arrayLastIndexOf } from './methods/array-lastIndexOf'
+import { fixture as arrayAt } from './methods/array-at'
+import { fixture as arrayConcat } from './methods/array-concat'
+import { fixture as arraySlice } from './methods/array-slice'
+import { fixture as arrayReverse } from './methods/array-reverse'
+import { fixture as arrayToReversed } from './methods/array-toReversed'
+import { fixture as stringToLowerCase } from './methods/string-toLowerCase'
+import { fixture as stringToUpperCase } from './methods/string-toUpperCase'
+import { fixture as stringTrim } from './methods/string-trim'
+import { fixture as stringIncludes } from './methods/string-includes'
 
 import type { JSXFixture } from '../src/types'
 
@@ -179,4 +197,18 @@ export const jsxFixtures: JSXFixture[] = [
   restDestructureObjectSpreadInMap,
   restDestructureArrayInMap,
   restDestructureNestedInMap,
+  // #1448 Tier A — Array methods.
+  arrayIncludes,
+  arrayIndexOf,
+  arrayLastIndexOf,
+  arrayAt,
+  arrayConcat,
+  arraySlice,
+  arrayReverse,
+  arrayToReversed,
+  // #1448 Tier A — String methods.
+  stringToLowerCase,
+  stringToUpperCase,
+  stringTrim,
+  stringIncludes,
 ]

--- a/packages/adapter-tests/fixtures/methods/array-at.ts
+++ b/packages/adapter-tests/fixtures/methods/array-at.ts
@@ -1,0 +1,24 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `Array.prototype.at(i)` lowering (#1448 Tier A).
+ *
+ * Pins the negative-index case (`-1` → last element) since that's
+ * the canonical reason a JS author reaches for `.at()` over `[i]`
+ * — a lowering that only handles positive indices would still pass
+ * a `.at(0)` test but fail this one.
+ */
+export const fixture = createFixture({
+  id: 'array-at',
+  description: '.at(-1) returns the last element',
+  source: `
+function ArrayAt({ items }: { items: string[] }) {
+  return <div>last: {items.at(-1)}</div>
+}
+export { ArrayAt }
+`,
+  props: { items: ['a', 'b', 'c'] },
+  expectedHtml: `
+    <div bf-s="test" bf="s1">last: <!--bf:s0-->c<!--/--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/methods/array-concat.ts
+++ b/packages/adapter-tests/fixtures/methods/array-concat.ts
@@ -1,0 +1,25 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `Array.prototype.concat(other)` lowering (#1448 Tier A).
+ *
+ * Composes with `.join(' ')` so the rendered output reflects the
+ * concatenation order. Using `.join` (already supported via the
+ * `array-method` IR added in #1443) lets us assert that the
+ * concatenation result is a real iterable, not a stringified
+ * `[object Object]` from a wrong lowering.
+ */
+export const fixture = createFixture({
+  id: 'array-concat',
+  description: '.concat(other) merges two arrays in order',
+  source: `
+function ArrayConcat({ left, right }: { left: string[]; right: string[] }) {
+  return <div>{left.concat(right).join(' ')}</div>
+}
+export { ArrayConcat }
+`,
+  props: { left: ['a', 'b'], right: ['c', 'd'] },
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><!--bf:s0-->a b c d<!--/--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/methods/array-includes.ts
+++ b/packages/adapter-tests/fixtures/methods/array-includes.ts
@@ -21,6 +21,6 @@ export { ArrayIncludes }
 `,
   props: { items: ['a', 'b', 'c'], target: 'b' },
   expectedHtml: `
-    <div bf-s="test" bf="s1">yes</div>
+    <div bf-s="test" bf="s1"><!--bf-cond-start:s0-->yes<!--bf-cond-end:s0--></div>
   `,
 })

--- a/packages/adapter-tests/fixtures/methods/array-includes.ts
+++ b/packages/adapter-tests/fixtures/methods/array-includes.ts
@@ -1,0 +1,26 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `Array.prototype.includes(x)` lowering (#1448 Tier A).
+ *
+ * Renders a yes/no badge driven by whether the target value is in the
+ * input array. The shape is intentionally simple — a single static
+ * `.includes()` against props — so the canonical lowering surface is
+ * the only thing exercised. Anything that lowers the method correctly
+ * (Hono / CSR via runtime; Mojo / Go via per-adapter helper) renders
+ * `<div bf-s="test">yes</div>` against the seeded props below.
+ */
+export const fixture = createFixture({
+  id: 'array-includes',
+  description: '.includes(x) on an array prop renders the matching branch',
+  source: `
+function ArrayIncludes({ items, target }: { items: string[]; target: string }) {
+  return <div>{items.includes(target) ? 'yes' : 'no'}</div>
+}
+export { ArrayIncludes }
+`,
+  props: { items: ['a', 'b', 'c'], target: 'b' },
+  expectedHtml: `
+    <div bf-s="test" bf="s1">yes</div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/methods/array-indexOf.ts
+++ b/packages/adapter-tests/fixtures/methods/array-indexOf.ts
@@ -1,0 +1,23 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `Array.prototype.indexOf(x)` lowering (#1448 Tier A).
+ *
+ * Returns -1 when the value is absent and a 0-based position when
+ * present. Pinning a non-zero positive index avoids ambiguity with
+ * the `-1` not-found sentinel and the `0` first-element case.
+ */
+export const fixture = createFixture({
+  id: 'array-indexOf',
+  description: '.indexOf(x) returns the 0-based position',
+  source: `
+function ArrayIndexOf({ items, target }: { items: string[]; target: string }) {
+  return <div>idx: {items.indexOf(target)}</div>
+}
+export { ArrayIndexOf }
+`,
+  props: { items: ['a', 'b', 'c'], target: 'b' },
+  expectedHtml: `
+    <div bf-s="test" bf="s1">idx: <!--bf:s0-->1<!--/--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/methods/array-lastIndexOf.ts
+++ b/packages/adapter-tests/fixtures/methods/array-lastIndexOf.ts
@@ -1,0 +1,24 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `Array.prototype.lastIndexOf(x)` lowering (#1448 Tier A).
+ *
+ * Pinning a duplicated value with the LAST occurrence at a non-final
+ * index disambiguates `lastIndexOf` from `indexOf` — if a lowering
+ * walks forward instead of backward, the wrong index surfaces in the
+ * rendered output.
+ */
+export const fixture = createFixture({
+  id: 'array-lastIndexOf',
+  description: '.lastIndexOf(x) returns the position of the last match',
+  source: `
+function ArrayLastIndexOf({ items, target }: { items: string[]; target: string }) {
+  return <div>last: {items.lastIndexOf(target)}</div>
+}
+export { ArrayLastIndexOf }
+`,
+  props: { items: ['a', 'b', 'c', 'b', 'd'], target: 'b' },
+  expectedHtml: `
+    <div bf-s="test" bf="s1">last: <!--bf:s0-->3<!--/--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/methods/array-reverse.ts
+++ b/packages/adapter-tests/fixtures/methods/array-reverse.ts
@@ -1,0 +1,25 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `Array.prototype.reverse()` lowering (#1448 Tier A).
+ *
+ * JS's `.reverse()` mutates the receiver and returns it; in SSR
+ * template context the receiver is immaterial (templates render a
+ * snapshot) so adapters can lower it as a non-mutating reversal
+ * without observable divergence. Composed with `.join(' ')` so the
+ * order is visible in the rendered output.
+ */
+export const fixture = createFixture({
+  id: 'array-reverse',
+  description: '.reverse() emits the array in reverse order',
+  source: `
+function ArrayReverse({ items }: { items: string[] }) {
+  return <div>{items.reverse().join(' ')}</div>
+}
+export { ArrayReverse }
+`,
+  props: { items: ['a', 'b', 'c'] },
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><!--bf:s0-->c b a<!--/--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/methods/array-slice.ts
+++ b/packages/adapter-tests/fixtures/methods/array-slice.ts
@@ -1,0 +1,25 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `Array.prototype.slice(start, end)` lowering (#1448 Tier A).
+ *
+ * Pinning the two-argument form (start + exclusive-end) since
+ * that's the most demanding shape — a lowering that only handles
+ * `.slice(start)` still passes a one-arg test but breaks here.
+ * Composes with `.join(' ')` so the slice content is visible in the
+ * rendered output.
+ */
+export const fixture = createFixture({
+  id: 'array-slice',
+  description: '.slice(start, end) carves out the requested sub-range',
+  source: `
+function ArraySlice({ items }: { items: string[] }) {
+  return <div>{items.slice(1, 3).join(' ')}</div>
+}
+export { ArraySlice }
+`,
+  props: { items: ['a', 'b', 'c', 'd', 'e'] },
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><!--bf:s0-->b c<!--/--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/methods/array-toReversed.ts
+++ b/packages/adapter-tests/fixtures/methods/array-toReversed.ts
@@ -1,0 +1,25 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `Array.prototype.toReversed()` lowering (#1448 Tier A).
+ *
+ * The non-mutating sibling of `.reverse()`. Sharing a lowering with
+ * `.reverse()` is fine in SSR template context (where the receiver
+ * is never observed), but the fixture is split so adapters can pin
+ * the surface explicitly and so a future per-method divergence
+ * doesn't require renaming the existing pin.
+ */
+export const fixture = createFixture({
+  id: 'array-toReversed',
+  description: '.toReversed() emits the array in reverse order',
+  source: `
+function ArrayToReversed({ items }: { items: string[] }) {
+  return <div>{items.toReversed().join(' ')}</div>
+}
+export { ArrayToReversed }
+`,
+  props: { items: ['a', 'b', 'c'] },
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><!--bf:s0-->c b a<!--/--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/methods/string-includes.ts
+++ b/packages/adapter-tests/fixtures/methods/string-includes.ts
@@ -20,6 +20,6 @@ export { StringIncludes }
 `,
   props: { value: 'hello world', needle: 'world' },
   expectedHtml: `
-    <div bf-s="test" bf="s1">yes</div>
+    <div bf-s="test" bf="s1"><!--bf-cond-start:s0-->yes<!--bf-cond-end:s0--></div>
   `,
 })

--- a/packages/adapter-tests/fixtures/methods/string-includes.ts
+++ b/packages/adapter-tests/fixtures/methods/string-includes.ts
@@ -1,0 +1,25 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `String.prototype.includes(sub)` lowering (#1448 Tier A).
+ *
+ * Distinct from `array-includes` — the receiver and lowering target
+ * are different (Go's `bf_contains` vs `bf_includes`, Mojo's
+ * `index $s $sub != -1` vs `grep { $_ eq $x } @{$arr}`). Pinning
+ * both keeps adapters from accidentally routing one through the
+ * other's helper.
+ */
+export const fixture = createFixture({
+  id: 'string-includes',
+  description: '.includes(sub) on a string renders the matching branch',
+  source: `
+function StringIncludes({ value, needle }: { value: string; needle: string }) {
+  return <div>{value.includes(needle) ? 'yes' : 'no'}</div>
+}
+export { StringIncludes }
+`,
+  props: { value: 'hello world', needle: 'world' },
+  expectedHtml: `
+    <div bf-s="test" bf="s1">yes</div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/methods/string-toLowerCase.ts
+++ b/packages/adapter-tests/fixtures/methods/string-toLowerCase.ts
@@ -1,0 +1,24 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `String.prototype.toLowerCase()` lowering (#1448 Tier A).
+ *
+ * The Go runtime already registers `bf_lower`; this fixture pins
+ * the JS-method → helper wire-up at the parser / adapter layer.
+ * Mojo's `lc` builtin handles it natively. Using a mixed-case prop
+ * value so a lowering that no-ops still fails the assertion.
+ */
+export const fixture = createFixture({
+  id: 'string-toLowerCase',
+  description: '.toLowerCase() lowercases the receiver string',
+  source: `
+function StringToLowerCase({ value }: { value: string }) {
+  return <div>{value.toLowerCase()}</div>
+}
+export { StringToLowerCase }
+`,
+  props: { value: 'Hello World' },
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><!--bf:s0-->hello world<!--/--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/methods/string-toUpperCase.ts
+++ b/packages/adapter-tests/fixtures/methods/string-toUpperCase.ts
@@ -1,0 +1,23 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `String.prototype.toUpperCase()` lowering (#1448 Tier A).
+ *
+ * The Go runtime already registers `bf_upper`; this fixture pins
+ * the JS-method → helper wire-up at the parser / adapter layer.
+ * Mojo's `uc` builtin handles it natively.
+ */
+export const fixture = createFixture({
+  id: 'string-toUpperCase',
+  description: '.toUpperCase() uppercases the receiver string',
+  source: `
+function StringToUpperCase({ value }: { value: string }) {
+  return <div>{value.toUpperCase()}</div>
+}
+export { StringToUpperCase }
+`,
+  props: { value: 'Hello World' },
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><!--bf:s0-->HELLO WORLD<!--/--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/methods/string-trim.ts
+++ b/packages/adapter-tests/fixtures/methods/string-trim.ts
@@ -1,0 +1,24 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `String.prototype.trim()` lowering (#1448 Tier A).
+ *
+ * The Go runtime already registers `bf_trim`; this fixture pins
+ * the JS-method → helper wire-up. Mojo's regex-style strip is the
+ * native equivalent. Padding both sides of the prop value so a
+ * trim-front-only or trim-back-only lowering fails the assertion.
+ */
+export const fixture = createFixture({
+  id: 'string-trim',
+  description: '.trim() strips leading and trailing whitespace',
+  source: `
+function StringTrim({ value }: { value: string }) {
+  return <div>[{value.trim()}]</div>
+}
+export { StringTrim }
+`,
+  props: { value: '   padded   ' },
+  expectedHtml: `
+    <div bf-s="test" bf="s1">[<!--bf:s0-->padded<!--/-->]</div>
+  `,
+})

--- a/packages/adapter-tests/scripts/generate-expected-html.ts
+++ b/packages/adapter-tests/scripts/generate-expected-html.ts
@@ -12,10 +12,32 @@ import { renderHonoComponent } from '@barefootjs/hono/test-render'
 import { normalizeHTML } from '../src/jsx-runner'
 import { indentHTML } from '../src/indent-html'
 import { jsxFixtures } from '../fixtures'
-import { readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
 const FIXTURES_DIR = resolve(import.meta.dir, '../fixtures')
+
+// Sub-directories under `FIXTURES_DIR` that group related fixtures
+// (e.g. `methods/` for #1448's JS array/string method catalog). Add
+// new groupings here so the auto-update script finds them without
+// having to bake the fixture's location into the fixture itself.
+const FIXTURE_SUBDIRS = ['', 'methods']
+
+/**
+ * Locate a fixture's source file under one of the supported
+ * `FIXTURE_SUBDIRS`. Returns null if no candidate exists — the
+ * caller treats that as a generator-side bug (fixture imported but
+ * file not where we look) rather than silently skipping.
+ */
+function resolveFixturePath(id: string): string | null {
+  for (const sub of FIXTURE_SUBDIRS) {
+    const candidate = sub
+      ? resolve(FIXTURES_DIR, sub, `${id}.ts`)
+      : resolve(FIXTURES_DIR, `${id}.ts`)
+    if (existsSync(candidate)) return candidate
+  }
+  return null
+}
 
 // Fixtures whose expectedHtml is hand-curated (typically because the
 // reference adapter renders the case incorrectly today, and the
@@ -48,8 +70,15 @@ async function main() {
       const indentedHtml = indentHTML(normalizedHtml)
       const expectedHtmlBlock = `  expectedHtml: \`${indentedHtml}\`,`
 
-      // Read the fixture file and update it
-      const filePath = resolve(FIXTURES_DIR, `${fixture.id}.ts`)
+      // Read the fixture file and update it. `resolveFixturePath`
+      // walks the known fixture sub-directories so groupings like
+      // `methods/` work without per-fixture path metadata.
+      const filePath = resolveFixturePath(fixture.id)
+      if (!filePath) {
+        throw new Error(
+          `cannot locate fixture file for id="${fixture.id}" under any of: ${FIXTURE_SUBDIRS.map(s => s || '.').join(', ')}`,
+        )
+      }
       let content = readFileSync(filePath, 'utf-8')
 
       if (content.includes('expectedHtml:')) {

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -70,11 +70,46 @@ export interface SupportResult {
   reason?: string
 }
 
-// Higher-order array methods that are not supported
+// JS Array / String prototype methods that the template-language
+// adapters (Mojo, Go) don't yet lower. The parser routes any
+// `<recv>.<method>(...)` call against one of these names to the
+// `call` arm of `isSupported`, which records BF101 — surfacing a
+// loud refusal at compile time instead of silently emitting a
+// `${obj}->{method}(...)` hash lookup that breaks at render time.
+//
+// A method gets removed from this set when its lowering lands —
+// the same flow the higher-order family used in #1443 (parser
+// intercepts the call shape before it falls through to this gate,
+// see the `higher-order` and `array-method` carve-outs in
+// `convertNode`'s call branch).
+//
+// The Hono / CSR adapters never consult `isSupported` (they
+// evaluate JS at runtime via hono/jsx) so this set only constrains
+// the template-language adapters.
 const UNSUPPORTED_METHODS = new Set([
+  // Higher-order array methods. Five of these (`filter`, `every`,
+  // `some`, `find`, `findIndex`) are intercepted as `higher-order`
+  // IR before reaching this gate; `map` is intercepted as an
+  // IRLoop. The rest stay refused — see #1448 Tier C for the
+  // design questions.
   'filter', 'map', 'reduce', 'reduceRight', 'every', 'some',
   'findLast', 'findLastIndex',
   'forEach', 'flatMap', 'flat',
+  // #1448 Tier A — Array methods. Each method PR adds the lowering
+  // (typically a new `array-method` variant or runtime helper) and
+  // removes its row here. See packages/adapter-tests/fixtures/methods/.
+  'includes',
+  'indexOf', 'lastIndexOf',
+  'at',
+  'concat',
+  'slice',
+  'reverse', 'toReversed',
+  // #1448 Tier A — String methods. `includes` is already listed
+  // above (the method name is shared with the array variant; the
+  // parser refuses both shapes uniformly via this gate, and each
+  // adapter's lowering will branch on the receiver type when the
+  // method is opted in).
+  'toLowerCase', 'toUpperCase', 'trim',
 ])
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Sets up the cross-adapter conformance bed for #1448's Tier A method-lowering work, so each follow-up PR is a one-line `expectedDiagnostics` removal + the actual lowering work — not "also wire up the test infra."

12 fixtures land here (one per canonical shape from the catalog): 8 array methods + 4 string methods.

## Changes

### `packages/adapter-tests/fixtures/methods/*.ts` (new — 12 files)

Array:
- `array-includes`, `array-indexOf`, `array-lastIndexOf`, `array-at`, `array-concat`, `array-slice`, `array-reverse`, `array-toReversed`

String:
- `string-toLowerCase`, `string-toUpperCase`, `string-trim`, `string-includes`

Each fixture picks props that disambiguate trivially-wrong lowerings (negative index for `.at`, duplicated indices for `.lastIndexOf`, mixed-case for `.toLowerCase`, etc.). Where the method returns an array, the fixture composes with `.join(' ')` so rendered HTML reflects order.

### `packages/jsx/src/expression-parser.ts`

`UNSUPPORTED_METHODS` widened to cover the 11 Tier A method names (`includes` covers both array and string positions). The set was previously labelled "Higher-order array methods that are not supported"; relabelled to its actual job — refusing any not-yet-lowered JS prototype method at compile time so template-language adapters don't silently emit `${obj}->{method}(...)` hash lookups that break at render.

Hono / CSR don't consult `isSupported`, so the gate only constrains Mojo + Go.

### `packages/adapter-mojolicious/src/adapter/mojo-adapter.ts`

`convertExpressionToPerl` routes the 11 new method names through the same AST path as the higher-order family, so `isSupported`'s `UNSUPPORTED_METHODS` gate actually fires. Without this the Mojo regex pipeline would silently mangle `arr.includes(x)` into `$arr->{includes}(...)` (an EP hash-lookup-then-call that errors at render time, not compile time).

### Mojo + Go test files — `expectedDiagnostics`

| Adapter | Mojo | Go |
|---|---|---|
| Expression position | `BF101` (all 10) | `BF101` (all 10) |
| Conditional position (`.includes` × 2) | `BF101` | `BF102` ("Condition not supported", pre-existing distinction) |

## Cross-adapter state

- **Hono / CSR**: pass all 12 out of the box (runtime JS).
- **Mojo / Go**: pin 12 `expectedDiagnostics` rows. Each Tier A PR removes its row as the lowering lands.

## Workflow for follow-up Tier A PRs

1. Add the per-method lowering (parser intercept + adapter `array-method` / `string-method` emit + runtime helper if needed)
2. Delete that fixture's row from each adapter's `expectedDiagnostics`
3. The conformance suite flips that fixture from BF101/BF102 → expectedHtml-match across all adapters

No fixture edits, no per-adapter positive assertions needed — the shared bed pins both contracts.

## Test plan

- [x] `bun test packages/adapter-hono/ packages/adapter-mojolicious/ packages/adapter-go-template/` — 679 pass / 0 fail
- [x] `bun test packages/jsx/` — 1614 pass / 4 pre-existing fail (env-dependent `alias-fidelity` tests from `node_modules/@barefootjs/client` self-symlink, unrelated to this PR)
- [x] Type-check on affected packages clean (adapter-tests has 2 pre-existing tsc errors on `TemplateAdapter` import — verified on `main` too, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_013cEtcSYt37CdRguejqFeAt)_