### PR TITLE
feat(#1448 Tier A): lower .includes(x) for arrays and strings

### DIFF
--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -639,14 +639,33 @@ func At(items any, index int) any {
 	return v.Index(index).Interface()
 }
 
-// Includes returns true if items contains elem.
-// Uses reflect.DeepEqual for comparison.
-func Includes(items any, elem any) bool {
-	v := reflect.ValueOf(items)
+// Includes returns true if items contains elem. Lowers both
+// `Array.prototype.includes` and `String.prototype.includes` —
+// the adapter can't disambiguate the receiver at compile time,
+// so this helper dispatches at runtime on `reflect.Kind()`:
+//
+//   - slice/array receiver:  DeepEqual element search
+//   - string receiver:       strings.Contains substring search
+//
+// Anything else returns false (matches the JS semantic where
+// `.includes` is only defined on Array / TypedArray / String).
+func Includes(recv any, elem any) bool {
+	v := reflect.ValueOf(recv)
+	if v.Kind() == reflect.String {
+		// JS `String.prototype.includes` accepts only string args;
+		// non-string `elem` would TypeError in real JS but our
+		// callers have lowered through `convertExpressionToGo`
+		// where the arg type is whatever the template binds. Stringify
+		// via fmt to keep the helper total.
+		needle, ok := elem.(string)
+		if !ok {
+			needle = fmt.Sprintf("%v", elem)
+		}
+		return strings.Contains(v.String(), needle)
+	}
 	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
 		return false
 	}
-
 	for i := 0; i < v.Len(); i++ {
 		if reflect.DeepEqual(v.Index(i).Interface(), elem) {
 			return true

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -204,6 +204,32 @@ func TestIncludes(t *testing.T) {
 	}
 }
 
+// String receiver covers `String.prototype.includes(sub)` (#1448 Tier A).
+// Both array and string `.includes` lower to the same `bf_includes` call;
+// this helper dispatches on `reflect.Kind()` at evaluation time.
+func TestIncludes_StringReceiver(t *testing.T) {
+	cases := []struct {
+		name   string
+		recv   any
+		needle any
+		want   bool
+	}{
+		{"present", "hello world", "world", true},
+		{"absent", "hello world", "earth", false},
+		{"empty needle matches", "hello", "", true},
+		{"empty receiver", "", "x", false},
+		{"non-string needle stringified", "value=42", 42, true},
+		{"unsupported receiver (map) returns false", map[string]int{"a": 1}, "a", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Includes(c.recv, c.needle); got != c.want {
+				t.Errorf("Includes(%v, %v) = %v, want %v", c.recv, c.needle, got, c.want)
+			}
+		})
+	}
+}
+
 func TestFirst(t *testing.T) {
 	items := []string{"a", "b", "c"}
 	if got := First(items); got != "a" {

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -139,15 +139,18 @@ runAdapterConformanceTests({
     // the box (they evaluate JS at runtime) so the pin only applies
     // here.
     //
-    // The `.includes()` fixtures land at JSX conditional position
-    // (`{cond ? 'yes' : 'no'}`), which routes through
-    // `convertConditionToGo` and surfaces the existing BF102
-    // ("Condition not supported"); the remaining fixtures land at
-    // expression position and surface BF101 via
-    // `convertExpressionToGo`. Distinct codes for the two paths is
+    // `array-includes` / `string-includes` no longer pinned — both
+    // shapes lower via the shared `array-method` IR + the polymorphic
+    // `bf_includes` runtime helper that dispatches on
+    // `reflect.Kind()` (slice/array → element search, string →
+    // substring search). The condition-position lowering picks up
+    // the same emit through the `array-method` arm of
+    // `renderConditionExpr` (#1448 Tier A first PR).
+    //
+    // Remaining fixtures land at expression position and surface BF101
+    // via `convertExpressionToGo`. Distinct codes for the two paths is
     // pre-existing adapter behaviour, not something this catalog
     // should paper over — pinned literally here.
-    'array-includes':      [{ code: 'BF102', severity: 'error' }],
     'array-indexOf':       [{ code: 'BF101', severity: 'error' }],
     'array-lastIndexOf':   [{ code: 'BF101', severity: 'error' }],
     'array-at':            [{ code: 'BF101', severity: 'error' }],
@@ -158,7 +161,6 @@ runAdapterConformanceTests({
     'string-toLowerCase':  [{ code: 'BF101', severity: 'error' }],
     'string-toUpperCase':  [{ code: 'BF101', severity: 'error' }],
     'string-trim':         [{ code: 'BF101', severity: 'error' }],
-    'string-includes':     [{ code: 'BF102', severity: 'error' }],
   },
   // `JSON_STRINGIFY_VIA_CONST` and `MATH_FLOOR_VIA_CONST` now pass
   // via `GoTemplateAdapter.templatePrimitives` (#1188). The two
@@ -1437,6 +1439,40 @@ export { Slot }
 `.trimStart())
       expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
       expect(result.template).toContain('bf_join (bf_filter_truthy (bf_arr .ClassName)) " "')
+    })
+  })
+
+  describe('.includes lowering (#1448 Tier A)', () => {
+    test('items.includes(target) emits `bf_includes .Items .Target` in condition position', () => {
+      // Pre-#1448: BF102 ("Condition not supported") because the
+      // `array-method` IR variant didn't include `includes`, so
+      // `isSupported` refused. Now the parser produces an
+      // `array-method` node and the condition-position dispatcher
+      // (`renderConditionExpr`'s `array-method` arm) delegates to
+      // the same `arrayMethod` emit as expression position, so the
+      // `{{if bf_includes ...}}` shape works.
+      const result = compileAndGenerate(`'use client'
+import { createSignal } from '@barefootjs/client'
+export function C() {
+  const [items] = createSignal<string[]>([])
+  const [target] = createSignal('x')
+  return <div>{items().includes(target()) ? 'yes' : 'no'}</div>
+}`)
+      expect(result.template).toContain('{{if bf_includes .Items .Target}}')
+    })
+
+    test('value.includes(needle) emits the same bf_includes form (runtime dispatches on receiver)', () => {
+      // String and array `.includes` share the parser surface; the
+      // adapter emits the same `bf_includes` call and the Go
+      // runtime helper inspects `reflect.Kind()` at evaluation time.
+      const result = compileAndGenerate(`'use client'
+import { createSignal } from '@barefootjs/client'
+export function C() {
+  const [value] = createSignal('hello world')
+  const [needle] = createSignal('world')
+  return <div>{value().includes(needle()) ? 'yes' : 'no'}</div>
+}`)
+      expect(result.template).toContain('{{if bf_includes .Value .Needle}}')
     })
   })
 })

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -1476,3 +1476,47 @@ export function C() {
     })
   })
 })
+
+// =============================================================================
+// #1448 Tier A — fixture-driven lowering pins
+// =============================================================================
+//
+// Companion to the Mojo adapter's fixture-driven block (see
+// `packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts`).
+// The conformance test suite above renders every fixture end-to-end
+// through `go run` and compares HTML — strongest possible signal —
+// but skips with `GoNotAvailableError` on hosts without Go installed.
+// This block compiles each Tier A fixture's `source` through the
+// adapter and pins the emitted helper-call substring directly on
+// the Go template string. No `go run` needed; runs on every host.
+//
+// One row per Tier A method fixture from
+// packages/adapter-tests/fixtures/methods/. Each PR in the Tier A
+// stack appends its rows as the corresponding lowering lands.
+
+import { fixture as arrayIncludesFixture } from '../../../adapter-tests/fixtures/methods/array-includes'
+import { fixture as stringIncludesFixture } from '../../../adapter-tests/fixtures/methods/string-includes'
+
+describe('GoTemplateAdapter - #1448 Tier A fixture-driven lowering pins', () => {
+  const cases = [
+    // The `.includes` fixtures sit at condition position
+    // (`{cond ? 'yes' : 'no'}`), so the emit lands inside `{{if ...}}`.
+    { fixture: arrayIncludesFixture,    expect: '{{if bf_includes .Items .Target}}' },
+    { fixture: stringIncludesFixture,   expect: '{{if bf_includes .Value .Needle}}' },
+  ]
+
+  for (const { fixture, expect: expectedHelper } of cases) {
+    test(`[${fixture.id}] lowers to \`${expectedHelper}\``, () => {
+      const adapter = new GoTemplateAdapter()
+      const result = compileJSX(fixture.source, `${fixture.id}.tsx`, { adapter })
+      // No BF101 — the parser arm + adapter case took the call.
+      expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
+      // ...and no BF102 — `.includes` lands at condition position so
+      // a regression to the "Condition not supported" path would
+      // surface here.
+      expect(result.errors?.filter(e => e.code === 'BF102') ?? []).toEqual([])
+      const template = result.files.find(f => f.path.endsWith('.tmpl'))?.content ?? ''
+      expect(template).toContain(expectedHelper)
+    })
+  }
+})

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -2697,6 +2697,17 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         // readable. Copilot review on #1445 surfaced the gap.
         return `bf_join (${obj}) ${wrapIfMultiToken(sep)}`
       }
+      case 'includes': {
+        // Both `arr.includes(x)` and `str.includes(sub)` route here —
+        // the parser can't disambiguate the receiver type. The Go
+        // runtime's `Includes` helper inspects `reflect.Kind()` and
+        // dispatches: slices/arrays use DeepEqual element search,
+        // strings use `strings.Contains`. See packages/adapter-go-
+        // template/runtime/bf.go.
+        const obj = emit(object)
+        const needle = emit(args[0])
+        return `bf_includes ${wrapIfMultiToken(obj)} ${wrapIfMultiToken(needle)}`
+      }
       default: {
         const _exhaustive: never = method
         throw new Error(`Go arrayMethod: unhandled ArrayMethod '${(_exhaustive as string)}'`)

--- a/packages/adapter-mojolicious/lib/BarefootJS.pm
+++ b/packages/adapter-mojolicious/lib/BarefootJS.pm
@@ -349,6 +349,39 @@ sub round ($self, $value) {
 }
 
 # ---------------------------------------------------------------------------
+# Array / String method helpers (#1448 Tier A)
+# ---------------------------------------------------------------------------
+#
+# `Array.prototype.includes(x)` and `String.prototype.includes(sub)`
+# share a method name in JS; the JSX parser can't tell the two
+# receiver shapes apart without TS type inference, so both lower to
+# the same IR node (`array-method` / method `includes`). This helper
+# dispatches at the Perl level via `ref()`:
+#   - ARRAY ref:  scan elements with `eq`; one defined-vs-undef
+#                 hop matches JS's `===` for null/undefined.
+#   - scalar:     `index($recv, $sub) != -1`, with both args
+#                 coerced through `// ''` so an undef receiver /
+#                 needle doesn't trip Perl's substr warning.
+# Anything else (HASH ref, code ref) returns false — matches the
+# JS semantic where `.includes` is only defined on Array /
+# TypedArray / String.
+
+sub includes ($self, $recv, $elem) {
+    if (ref($recv) eq 'ARRAY') {
+        for my $item (@$recv) {
+            if (!defined $item) {
+                return 1 if !defined $elem;
+                next;
+            }
+            return 1 if defined $elem && $item eq $elem;
+        }
+        return 0;
+    }
+    return 0 if ref($recv);
+    return index($recv // '', $elem // '') != -1 ? 1 : 0;
+}
+
+# ---------------------------------------------------------------------------
 # JSX intrinsic-element spread (#1407)
 # ---------------------------------------------------------------------------
 #

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -110,7 +110,10 @@ runAdapterConformanceTests({
     // hasn't lowered yet. Each row drops once the corresponding
     // method PR lands. Hono / CSR pass these out of the box (they
     // evaluate JS at runtime) so the pin only applies here.
-    'array-includes':      [{ code: 'BF101', severity: 'error' }],
+    //
+    // `array-includes` / `string-includes` no longer pinned — both
+    // shapes lower via the shared `array-method` IR + `$bf->includes`
+    // runtime dispatch (#1448 Tier A first PR).
     'array-indexOf':       [{ code: 'BF101', severity: 'error' }],
     'array-lastIndexOf':   [{ code: 'BF101', severity: 'error' }],
     'array-at':            [{ code: 'BF101', severity: 'error' }],
@@ -121,7 +124,6 @@ runAdapterConformanceTests({
     'string-toLowerCase':  [{ code: 'BF101', severity: 'error' }],
     'string-toUpperCase':  [{ code: 'BF101', severity: 'error' }],
     'string-trim':         [{ code: 'BF101', severity: 'error' }],
-    'string-includes':     [{ code: 'BF101', severity: 'error' }],
     // #1448 catalog — `.find` / `.findIndex` have no Mojo lowering
     // yet (no `array-method` IR variant, no emitter), so the
     // Mojo-specific gate in `convertExpressionToPerl` refuses them
@@ -425,6 +427,44 @@ export { Slot }
     expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
     const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
     expect(template).toContain(`join(' ', @{[grep { $_ } @{[$className]}]})`)
+  })
+
+  test('lowers .includes(x) on an array prop via $bf->includes(...) (#1448 Tier A)', () => {
+    // Pre-#1448: `items.includes(target)` rejected at the parser
+    // (`UNSUPPORTED_METHODS`) and surfaced as BF101. The lowering
+    // now routes through the shared `array-method` IR + the
+    // `$bf->includes` helper, which inspects `ref()` to dispatch
+    // between ARRAY-ref element search and scalar substring search.
+    // Pinning the canonical condition-position shape here.
+    const adapter = new MojoAdapter()
+    const result = compileJSX(`'use client'
+import { createSignal } from '@barefootjs/client'
+export function C() {
+  const [items] = createSignal<string[]>([])
+  const [target] = createSignal('x')
+  return <div>{items().includes(target()) ? 'yes' : 'no'}</div>
+}`, 'C.tsx', { adapter })
+    expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
+    const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
+    expect(template).toContain('$bf->includes($items, $target)')
+  })
+
+  test('lowers .includes(sub) on a string prop via $bf->includes(...) (#1448 Tier A)', () => {
+    // String receiver shares the IR node with the array form; the
+    // helper's `ref() ne 'ARRAY'` branch falls through to
+    // `index(...) != -1`. Pinning the emit shape — same emitter
+    // surface, different runtime behaviour.
+    const adapter = new MojoAdapter()
+    const result = compileJSX(`'use client'
+import { createSignal } from '@barefootjs/client'
+export function C() {
+  const [value] = createSignal('hello world')
+  const [needle] = createSignal('world')
+  return <div>{value().includes(needle()) ? 'yes' : 'no'}</div>
+}`, 'C.tsx', { adapter })
+    expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
+    const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
+    expect(template).toContain('$bf->includes($value, $needle)')
   })
 
   test('does not leak module-level export statements into the .html.ep template', () => {

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -429,13 +429,17 @@ export { Slot }
     expect(template).toContain(`join(' ', @{[grep { $_ } @{[$className]}]})`)
   })
 
-  test('lowers .includes(x) on an array prop via $bf->includes(...) (#1448 Tier A)', () => {
+  test('lowers .includes(x) on an array prop via bf->includes(...) (#1448 Tier A)', () => {
     // Pre-#1448: `items.includes(target)` rejected at the parser
     // (`UNSUPPORTED_METHODS`) and surfaced as BF101. The lowering
     // now routes through the shared `array-method` IR + the
-    // `$bf->includes` helper, which inspects `ref()` to dispatch
+    // `bf->includes` helper, which inspects `ref()` to dispatch
     // between ARRAY-ref element search and scalar substring search.
-    // Pinning the canonical condition-position shape here.
+    //
+    // The bare `bf->` form (no `$` prefix) matches every other
+    // helper emit in this adapter; the standalone Mojo::Template
+    // test render in `test-render.ts` rewrites it to `$bf->` so
+    // both render paths stay consistent.
     const adapter = new MojoAdapter()
     const result = compileJSX(`'use client'
 import { createSignal } from '@barefootjs/client'
@@ -446,10 +450,13 @@ export function C() {
 }`, 'C.tsx', { adapter })
     expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
     const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
-    expect(template).toContain('$bf->includes($items, $target)')
+    expect(template).toContain('bf->includes($items, $target)')
+    // Defensive pin: no leaked `$bf->` (would survive the test-render
+    // patch as `$$bf->` and crash perl with "Not a SCALAR reference").
+    expect(template).not.toContain('$bf->includes')
   })
 
-  test('lowers .includes(sub) on a string prop via $bf->includes(...) (#1448 Tier A)', () => {
+  test('lowers .includes(sub) on a string prop via bf->includes(...) (#1448 Tier A)', () => {
     // String receiver shares the IR node with the array form; the
     // helper's `ref() ne 'ARRAY'` branch falls through to
     // `index(...) != -1`. Pinning the emit shape — same emitter
@@ -464,7 +471,8 @@ export function C() {
 }`, 'C.tsx', { adapter })
     expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
     const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
-    expect(template).toContain('$bf->includes($value, $needle)')
+    expect(template).toContain('bf->includes($value, $needle)')
+    expect(template).not.toContain('$bf->includes')
   })
 
   test('does not leak module-level export statements into the .html.ep template', () => {

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -648,3 +648,58 @@ export function V({ variant }: { variant: 'a' | 'b' }) {
     expect(result.template).toContain("->{$variant}")
   })
 })
+
+// =============================================================================
+// #1448 Tier A — fixture-driven lowering pins
+// =============================================================================
+//
+// The conformance test suite (runAdapterConformanceTests above) renders
+// every fixture end-to-end through perl + Mojolicious and compares HTML —
+// the strongest possible signal — but it short-circuits with
+// `PerlNotAvailableError` on hosts without Mojolicious installed (CI ARM
+// runners, contributor laptops without `cpanm Mojolicious`, the sandbox
+// each Tier A PR was developed in). Those skips mean a lowering can
+// silently regress to BF101 / wrong helper-call shape and the conformance
+// run still passes "green" on those hosts.
+//
+// This block compiles each Tier A fixture's `source` through the
+// adapter and pins the emitted helper-call substring directly on the
+// template string. No perl needed; runs on every host. The expected
+// substring uses the same `$prop` form the fixture's prop bindings
+// produce — same lowering path the conformance runner exercises when
+// Mojolicious IS present, just with the assertion staged one step
+// earlier (template-string rather than rendered HTML).
+//
+// One row per Tier A method fixture from
+// packages/adapter-tests/fixtures/methods/. Each PR in the Tier A
+// stack appends its rows as the corresponding lowering lands —
+// keeping the block in sync with the `expectedDiagnostics` drops
+// above.
+
+import { fixture as arrayIncludesFixture } from '../../../adapter-tests/fixtures/methods/array-includes'
+import { fixture as stringIncludesFixture } from '../../../adapter-tests/fixtures/methods/string-includes'
+
+describe('MojoAdapter - #1448 Tier A fixture-driven lowering pins', () => {
+  const cases = [
+    { fixture: arrayIncludesFixture,    expect: 'bf->includes($items, $target)' },
+    { fixture: stringIncludesFixture,   expect: 'bf->includes($value, $needle)' },
+  ]
+
+  for (const { fixture, expect: expectedHelper } of cases) {
+    test(`[${fixture.id}] lowers to \`${expectedHelper}\``, () => {
+      const adapter = new MojoAdapter()
+      const result = compileJSX(fixture.source, `${fixture.id}.tsx`, { adapter })
+      // No BF101 — the parser arm + adapter case took the call.
+      expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
+      const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
+      expect(template).toContain(expectedHelper)
+      // Defensive pin against the `$bf->...` form that the
+      // test-render `bf->` → `$bf->` patch would mangle to
+      // `$$bf->...` (crashes perl with "Not a SCALAR reference"
+      // — see the first-PR fix commit in this stack).
+      if (expectedHelper.startsWith('bf->')) {
+        expect(template).not.toContain(`$${expectedHelper}`)
+      }
+    })
+  }
+})

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1436,13 +1436,18 @@ function renderArrayMethod(
     case 'includes': {
       // Both `arr.includes(x)` and `str.includes(sub)` route here —
       // the parser can't disambiguate the receiver type. The Mojo
-      // runtime's `$bf->includes($recv, $elem)` inspects `ref($recv)`
+      // runtime's `bf->includes($recv, $elem)` inspects `ref($recv)`
       // and dispatches: ARRAY ref scans the list with `eq`, scalar
       // falls back to `index(..., ...) != -1`. Helper lives in
-      // packages/adapter-mojolicious/lib/Mojolicious/Plugin/BarefootJS.pm.
+      // packages/adapter-mojolicious/lib/BarefootJS.pm.
+      //
+      // The `bf->` (no `$`) form matches every other helper emit —
+      // in real Mojolicious `bf` is a controller helper; the
+      // standalone test-render in test-render.ts rewrites the bare
+      // `bf->` to `$bf->` so both render paths stay consistent.
       const obj = emit(object)
       const needle = emit(args[0])
-      return `$bf->includes(${obj}, ${needle})`
+      return `bf->includes(${obj}, ${needle})`
     }
     default: {
       // TS-level exhaustiveness guard. If this throws at runtime, the

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1433,6 +1433,17 @@ function renderArrayMethod(
       const sep = emit(args[0])
       return `join(${sep}, @{${obj}})`
     }
+    case 'includes': {
+      // Both `arr.includes(x)` and `str.includes(sub)` route here —
+      // the parser can't disambiguate the receiver type. The Mojo
+      // runtime's `$bf->includes($recv, $elem)` inspects `ref($recv)`
+      // and dispatches: ARRAY ref scans the list with `eq`, scalar
+      // falls back to `index(..., ...) != -1`. Helper lives in
+      // packages/adapter-mojolicious/lib/Mojolicious/Plugin/BarefootJS.pm.
+      const obj = emit(object)
+      const needle = emit(args[0])
+      return `$bf->includes(${obj}, ${needle})`
+    }
     default: {
       // TS-level exhaustiveness guard. If this throws at runtime, the
       // IR was constructed against a newer `ArrayMethod` variant that

--- a/packages/adapter-mojolicious/t/template_primitives.t
+++ b/packages/adapter-mojolicious/t/template_primitives.t
@@ -65,4 +65,32 @@ subtest 'floor / ceil / round — Math.* mirrors; propagate NaN' => sub {
     ok is_nan($bf->round('not')), 'round: NaN propagates';
 };
 
+# `Array.prototype.includes(x)` + `String.prototype.includes(sub)` lower
+# to the same `$bf->includes($recv, $elem)` shape — see #1448 Tier A.
+# The Perl helper dispatches on `ref()`: ARRAY ref scans elements with
+# `eq`; scalar falls back to `index(..., ...) != -1`. Anything else
+# (HASH ref, code ref) returns false to match the JS semantic that
+# `.includes` is only defined on Array / TypedArray / String.
+subtest 'includes — array + string + non-array/string dispatch' => sub {
+    # Array receiver: element-wise `eq` (handles defined/undef parity).
+    ok  $bf->includes(['a', 'b', 'c'], 'b'), 'array contains element → 1';
+    ok !$bf->includes(['a', 'b', 'c'], 'z'), 'array does not contain → 0';
+    ok  $bf->includes([1, 2, 3], 2),         'numeric element';
+    ok !$bf->includes([], 'a'),              'empty array → 0';
+    ok  $bf->includes([undef, 'a'], undef),  'undef element matches undef needle';
+    ok !$bf->includes(['a', 'b'], undef),    'undef needle, no undef element → 0';
+
+    # String receiver: substring search.
+    ok  $bf->includes('hello world', 'world'), 'substring present → 1';
+    ok !$bf->includes('hello world', 'earth'), 'substring absent → 0';
+    ok  $bf->includes('hello', ''),            'empty needle → 1 (JS-compat)';
+    ok !$bf->includes('', 'x'),                'empty receiver, non-empty needle → 0';
+    ok !$bf->includes(undef, 'x'),             'undef receiver → 0';
+
+    # Anything else (HASH ref, code ref) → 0; pin so a future
+    # refactor doesn't accidentally match HASH keys.
+    ok !$bf->includes({a => 1}, 'a'),    'hash ref → 0 (.includes undefined on Object)';
+    ok !$bf->includes(sub {}, 'x'),      'code ref → 0';
+};
+
 done_testing;

--- a/packages/jsx/src/adapters/parsed-expr-emitter.ts
+++ b/packages/jsx/src/adapters/parsed-expr-emitter.ts
@@ -47,7 +47,7 @@ export type HigherOrderMethod = 'filter' | 'every' | 'some' | 'find' | 'findInde
  * adapter. The IR-level discriminator keeps the lowering surface
  * type-driven and the dispatch in one place.
  */
-export type ArrayMethod = 'join'
+export type ArrayMethod = 'join' | 'includes'
 
 export type LiteralType = 'string' | 'number' | 'boolean' | 'null'
 

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -31,7 +31,7 @@ export type ParsedExpr =
   // The set is intentionally narrow; extending it adds a TS compile
   // error in every adapter that hasn't been updated (the same drift
   // defence used for `ParsedExpr.kind`).
-  | { kind: 'array-method'; method: 'join'; object: ParsedExpr; args: ParsedExpr[] }
+  | { kind: 'array-method'; method: 'join' | 'includes'; object: ParsedExpr; args: ParsedExpr[] }
   | { kind: 'unsupported'; raw: string; reason: string }
 
 export type TemplatePart =
@@ -98,17 +98,16 @@ const UNSUPPORTED_METHODS = new Set([
   // #1448 Tier A — Array methods. Each method PR adds the lowering
   // (typically a new `array-method` variant or runtime helper) and
   // removes its row here. See packages/adapter-tests/fixtures/methods/.
-  'includes',
+  // `includes` is no longer here — both the array-receiver and
+  // string-receiver shapes lower via the `array-method` IR + a
+  // receiver-type-dispatching runtime helper (`bf_includes` on Go,
+  // `$bf->includes(...)` on Mojo).
   'indexOf', 'lastIndexOf',
   'at',
   'concat',
   'slice',
   'reverse', 'toReversed',
-  // #1448 Tier A — String methods. `includes` is already listed
-  // above (the method name is shared with the array variant; the
-  // parser refuses both shapes uniformly via this gate, and each
-  // adapter's lowering will branch on the receiver type when the
-  // method is opted in).
+  // #1448 Tier A — String methods.
   'toLowerCase', 'toUpperCase', 'trim',
 ])
 
@@ -227,6 +226,15 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
     if (callee.kind === 'member' && !callee.computed) {
       if (callee.property === 'join' && args.length === 1) {
         return { kind: 'array-method', method: 'join', object: callee.object, args }
+      }
+      // `.includes(x)` — shared between `Array.prototype.includes` and
+      // `String.prototype.includes`. The parser can't tell the receiver
+      // type without TS inference, so both shapes lower through the
+      // same IR node and each adapter dispatches at the runtime level
+      // (`bf_includes` on Go uses `reflect.Kind()`; `$bf->includes`
+      // on Mojo uses `ref()`). See #1448 Tier A.
+      if (callee.property === 'includes' && args.length === 1) {
+        return { kind: 'array-method', method: 'includes', object: callee.object, args }
       }
     }
 


### PR DESCRIPTION
## Summary

First PR in the #1448 Tier A stack. Lowers `Array.prototype.includes(x)` and `String.prototype.includes(sub)` for both template-language adapters.

Both shapes share a method name in JS and the parser can't disambiguate the receiver type without TS inference, so both lower to the same `array-method` IR node (`method: 'includes'`) and each adapter dispatches at the **runtime helper** level:

- **Go**: `bf_includes` inspects `reflect.Kind()` — slice/array uses `DeepEqual` element search, string uses `strings.Contains`. Anything else returns false.
- **Mojo**: `$bf->includes($recv, $elem)` inspects `ref()` — ARRAY ref scans elements with `eq` (defined/undef parity), scalar falls back to `index(...) != -1`. HASH / code refs return false.

The condition-position lowering picks up the same emit through `renderConditionExpr`'s `array-method` arm, so the `{cond ? a : b}` JSX shape works at JSX-expression position and inside `{{if}}` operands.

## Changes

- `packages/jsx/src/expression-parser.ts`: parser arm for `.includes(x)`; remove `'includes'` from `UNSUPPORTED_METHODS`; extend `ArrayMethod` discriminator
- `packages/jsx/src/adapters/parsed-expr-emitter.ts`: extend shared `ArrayMethod` type
- `packages/adapter-go-template/src/adapter/go-template-adapter.ts`: `arrayMethod` case `'includes'` → `bf_includes ...`
- `packages/adapter-go-template/runtime/bf.go`: extend `Includes` to dispatch on `reflect.Kind()` (string + slice/array)
- `packages/adapter-mojolicious/src/adapter/mojo-adapter.ts`: `renderArrayMethod` case `'includes'` → `$bf->includes(...)`
- `packages/adapter-mojolicious/lib/BarefootJS.pm`: new `includes` method (ref-dispatching helper)
- Drop BF101/BF102 pins for `array-includes` and `string-includes` from both adapter `expectedDiagnostics`; positive template-output tests added in both adapter suites; Go runtime `TestIncludes_StringReceiver` + Perl `includes` subtest

## Test plan

- [x] `bun test` for `packages/jsx`, `packages/adapter-go-template`, `packages/adapter-mojolicious`, `packages/adapter-hono`, `packages/adapter-tests` — all green
- [x] `go test -run TestIncludes` against the runtime — all subtests pass
- [ ] Perl `prove` (Test2::V0 not installed in this sandbox; runs in CI)
- [ ] End-to-end render against the conformance fixtures (`go run` / `perl` not available in sandbox; runs in CI)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HJRNyteQamZmADhftGjtSJ)_