### PR TITLE
feat(#1448 Tier A): lower .at(i) with negative-index support

### DIFF
--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -1563,6 +1563,7 @@ import { fixture as arrayIncludesFixture } from '../../../adapter-tests/fixtures
 import { fixture as stringIncludesFixture } from '../../../adapter-tests/fixtures/methods/string-includes'
 import { fixture as arrayIndexOfFixture } from '../../../adapter-tests/fixtures/methods/array-indexOf'
 import { fixture as arrayLastIndexOfFixture } from '../../../adapter-tests/fixtures/methods/array-lastIndexOf'
+import { fixture as arrayAtFixture } from '../../../adapter-tests/fixtures/methods/array-at'
 
 describe('GoTemplateAdapter - #1448 Tier A fixture-driven lowering pins', () => {
   const cases = [
@@ -1572,6 +1573,10 @@ describe('GoTemplateAdapter - #1448 Tier A fixture-driven lowering pins', () => 
     { fixture: stringIncludesFixture,   expect: '{{if bf_includes .Value .Needle}}' },
     { fixture: arrayIndexOfFixture,     expect: 'bf_index_of .Items .Target' },
     { fixture: arrayLastIndexOfFixture, expect: 'bf_last_index_of .Items .Target' },
+    // The literal `-1` lowers through `bf_neg 1` — Go template
+    // doesn't accept literal negative numbers in prefix-call
+    // positions. Pre-existing unary-emit pattern.
+    { fixture: arrayAtFixture,          expect: 'bf_at .Items (bf_neg 1)' },
   ]
 
   for (const { fixture, expect: expectedHelper } of cases) {

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -154,7 +154,8 @@ runAdapterConformanceTests({
     // `array-indexOf` / `array-lastIndexOf` no longer pinned —
     // value-equality `bf_index_of` / `bf_last_index_of` Go runtime
     // helpers handle the shape (#1448 Tier A second PR).
-    'array-at':            [{ code: 'BF101', severity: 'error' }],
+    // `array-at` no longer pinned — the pre-existing `bf_at` runtime
+    // helper now lowers `.at(i)` (#1448 Tier A third PR).
     'array-concat':        [{ code: 'BF101', severity: 'error' }],
     'array-slice':         [{ code: 'BF101', severity: 'error' }],
     'array-reverse':       [{ code: 'BF101', severity: 'error' }],
@@ -1508,6 +1509,35 @@ export function C() {
   return <div>last: {items().lastIndexOf(target())}</div>
 }`)
       expect(result.template).toContain('bf_last_index_of .Items .Target')
+    })
+  })
+
+  describe('.at lowering (#1448 Tier A)', () => {
+    test('items.at(-1) emits `bf_at .Items (bf_neg 1)` (negative-index pass-through)', () => {
+      // The Go runtime's `At` already handles negative indices —
+      // `bf_at .Items -1` returns the last element. Go template
+      // syntax doesn't accept literal negative numbers in prefix-
+      // call positions, so the adapter routes the unary minus
+      // through `bf_neg`; the runtime is unchanged.
+      const result = compileAndGenerate(`function A({ items }: { items: string[] }) {
+  return <div>last: {items.at(-1)}</div>
+}
+export { A }`)
+      expect(result.template).toContain('bf_at .Items (bf_neg 1)')
+    })
+
+    test('items.at(i) with a signal index emits `bf_at .Items .I`', () => {
+      // Non-literal index — the inner expression goes through the
+      // standard `emit(arg)` path, so any supported expression form
+      // composes (signal call, prop access, arithmetic, etc.).
+      const result = compileAndGenerate(`'use client'
+import { createSignal } from '@barefootjs/client'
+export function C() {
+  const [items] = createSignal<string[]>([])
+  const [i] = createSignal(0)
+  return <div>el: {items().at(i())}</div>
+}`)
+      expect(result.template).toContain('bf_at .Items .I')
     })
   })
 })

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -2720,6 +2720,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         const needle = emit(args[0])
         return `${fn} ${wrapIfMultiToken(obj)} ${wrapIfMultiToken(needle)}`
       }
+      case 'at': {
+        // `.at(i)` supports negative indices (`.at(-1)` → last
+        // element). The Go `bf_at` helper was already registered in
+        // the FuncMap for the runtime — this PR wires it to the JS
+        // method name at the adapter layer.
+        const obj = emit(object)
+        const idx = emit(args[0])
+        return `bf_at ${wrapIfMultiToken(obj)} ${wrapIfMultiToken(idx)}`
+      }
       default: {
         const _exhaustive: never = method
         throw new Error(`Go arrayMethod: unhandled ArrayMethod '${(_exhaustive as string)}'`)

--- a/packages/adapter-mojolicious/lib/BarefootJS.pm
+++ b/packages/adapter-mojolicious/lib/BarefootJS.pm
@@ -411,6 +411,22 @@ sub last_index_of ($self, $recv, $elem) {
     return _array_index_of($recv, $elem, 1);
 }
 
+# `Array.prototype.at(i)` — supports negative indices (`.at(-1)` is
+# the last element); out-of-bounds returns undef (which Mojo's
+# auto-escape renders as the empty string, matching JS's `undefined`).
+# Non-array receivers return undef. Matches the Go `bf_at` arithmetic
+# (`length + i` for i < 0) so adapter output stays symmetric.
+
+sub at ($self, $recv, $i) {
+    return undef unless ref($recv) eq 'ARRAY';
+    return undef if !defined $i;
+    my $len = scalar @$recv;
+    return undef if $len == 0;
+    my $idx = $i < 0 ? $len + $i : $i;
+    return undef if $idx < 0 || $idx >= $len;
+    return $recv->[$idx];
+}
+
 # ---------------------------------------------------------------------------
 # JSX intrinsic-element spread (#1407)
 # ---------------------------------------------------------------------------

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -734,6 +734,7 @@ import { fixture as arrayIncludesFixture } from '../../../adapter-tests/fixtures
 import { fixture as stringIncludesFixture } from '../../../adapter-tests/fixtures/methods/string-includes'
 import { fixture as arrayIndexOfFixture } from '../../../adapter-tests/fixtures/methods/array-indexOf'
 import { fixture as arrayLastIndexOfFixture } from '../../../adapter-tests/fixtures/methods/array-lastIndexOf'
+import { fixture as arrayAtFixture } from '../../../adapter-tests/fixtures/methods/array-at'
 
 describe('MojoAdapter - #1448 Tier A fixture-driven lowering pins', () => {
   const cases = [
@@ -741,6 +742,7 @@ describe('MojoAdapter - #1448 Tier A fixture-driven lowering pins', () => {
     { fixture: stringIncludesFixture,   expect: 'bf->includes($value, $needle)' },
     { fixture: arrayIndexOfFixture,     expect: 'bf->index_of($items, $target)' },
     { fixture: arrayLastIndexOfFixture, expect: 'bf->last_index_of($items, $target)' },
+    { fixture: arrayAtFixture,          expect: 'bf->at($items, -1)' },
   ]
 
   for (const { fixture, expect: expectedHelper } of cases) {

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -117,7 +117,8 @@ runAdapterConformanceTests({
     // `array-indexOf` / `array-lastIndexOf` no longer pinned —
     // value-equality `bf->index_of` / `bf->last_index_of` helpers
     // handle the shape (#1448 Tier A second PR).
-    'array-at':            [{ code: 'BF101', severity: 'error' }],
+    // `array-at` no longer pinned — `bf->at` (Mojo) / `bf_at` (Go)
+    // handle the negative-index lookup (#1448 Tier A third PR).
     'array-concat':        [{ code: 'BF101', severity: 'error' }],
     'array-slice':         [{ code: 'BF101', severity: 'error' }],
     'array-reverse':       [{ code: 'BF101', severity: 'error' }],
@@ -510,6 +511,22 @@ export function C() {
     expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
     const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
     expect(template).toContain('bf->last_index_of($items, $target)')
+  })
+
+  test('lowers .at(-1) on an array prop via bf->at(...) (#1448 Tier A)', () => {
+    // Negative indices are the canonical reason an author reaches
+    // for `.at` over `[i]`; pinning `.at(-1)` (last element) — a
+    // positive-only lowering would still pass `.at(0)` but fail
+    // here.
+    const adapter = new MojoAdapter()
+    const result = compileJSX(`function A({ items }: { items: string[] }) {
+  return <div>last: {items.at(-1)}</div>
+}
+export { A }`, 'A.tsx', { adapter })
+    expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
+    const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
+    expect(template).toContain('bf->at($items, -1)')
+    expect(template).not.toContain('$bf->at(')
   })
 
   test('does not leak module-level export statements into the .html.ep template', () => {

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1462,6 +1462,15 @@ function renderArrayMethod(
       const needle = emit(args[0])
       return `bf->${fn}(${obj}, ${needle})`
     }
+    case 'at': {
+      // `.at(i)` with negative-index support — `.at(-1)` is the
+      // last element. The Mojo helper wraps the same `length + i`
+      // arithmetic the Go `bf_at` does so the lowering stays
+      // symmetric across adapters.
+      const obj = emit(object)
+      const idx = emit(args[0])
+      return `bf->at(${obj}, ${idx})`
+    }
     default: {
       // TS-level exhaustiveness guard. If this throws at runtime, the
       // IR was constructed against a newer `ArrayMethod` variant that

--- a/packages/adapter-mojolicious/t/template_primitives.t
+++ b/packages/adapter-mojolicious/t/template_primitives.t
@@ -118,4 +118,23 @@ subtest 'index_of / last_index_of — array value-equality search' => sub {
     is $bf->last_index_of([undef, 'x', undef], undef), 2, 'undef matches undef (backward)';
 };
 
+# `Array.prototype.at(i)` — supports negative indices; out-of-bounds
+# returns undef. Non-array receivers return undef. Mirrors the Go
+# `bf_at` arithmetic so adapter output stays symmetric.
+subtest 'at — array indexed access with negative-index support' => sub {
+    my $arr = ['a', 'b', 'c'];
+
+    is $bf->at($arr,  0),  'a',  'first element';
+    is $bf->at($arr,  2),  'c',  'last element via positive index';
+    is $bf->at($arr, -1),  'c',  'last element via -1';
+    is $bf->at($arr, -3),  'a',  'first element via -3 (length - 3)';
+
+    is $bf->at($arr,  3),  undef, 'out of bounds (positive) → undef';
+    is $bf->at($arr, -4),  undef, 'out of bounds (negative) → undef';
+    is $bf->at([],    0),  undef, 'empty array → undef';
+    is $bf->at(undef, 0),  undef, 'undef receiver → undef';
+    is $bf->at('not array', 0), undef, 'scalar receiver → undef';
+    is $bf->at({a => 1},   0),  undef, 'hash ref receiver → undef';
+};
+
 done_testing;

--- a/packages/jsx/src/adapters/parsed-expr-emitter.ts
+++ b/packages/jsx/src/adapters/parsed-expr-emitter.ts
@@ -47,7 +47,7 @@ export type HigherOrderMethod = 'filter' | 'every' | 'some' | 'find' | 'findInde
  * adapter. The IR-level discriminator keeps the lowering surface
  * type-driven and the dispatch in one place.
  */
-export type ArrayMethod = 'join' | 'includes' | 'indexOf' | 'lastIndexOf'
+export type ArrayMethod = 'join' | 'includes' | 'indexOf' | 'lastIndexOf' | 'at'
 
 export type LiteralType = 'string' | 'number' | 'boolean' | 'null'
 

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -33,7 +33,7 @@ export type ParsedExpr =
   // defence used for `ParsedExpr.kind`).
   | {
       kind: 'array-method'
-      method: 'join' | 'includes' | 'indexOf' | 'lastIndexOf'
+      method: 'join' | 'includes' | 'indexOf' | 'lastIndexOf' | 'at'
       object: ParsedExpr
       args: ParsedExpr[]
     }
@@ -109,8 +109,10 @@ const UNSUPPORTED_METHODS = new Set([
   // `$bf->includes(...)` on Mojo).
   // `indexOf` / `lastIndexOf` likewise lower via the `array-method`
   // IR + `bf_index_of` / `bf_last_index_of` (Go) and
-  // `$bf->index_of` / `$bf->last_index_of` (Mojo).
-  'at',
+  // `bf->index_of` / `bf->last_index_of` (Mojo).
+  // `at` lowers via the `array-method` IR + the pre-existing
+  // `bf_at` (Go) and a new `bf->at` (Mojo); both support negative
+  // indices (`.at(-1)` returns the last element).
   'concat',
   'slice',
   'reverse', 'toReversed',
@@ -251,6 +253,13 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
       // higher-order `.find` lowering. See #1448 Tier A.
       if ((callee.property === 'indexOf' || callee.property === 'lastIndexOf') && args.length === 1) {
         return { kind: 'array-method', method: callee.property, object: callee.object, args }
+      }
+      // `.at(i)` — negative-index support (`.at(-1)` is the last
+      // element). Go has `bf_at` registered already (see runtime
+      // FuncMap); Mojo's `bf->at` wraps the same arithmetic.
+      // See #1448 Tier A.
+      if (callee.property === 'at' && args.length === 1) {
+        return { kind: 'array-method', method: 'at', object: callee.object, args }
       }
     }
 


### PR DESCRIPTION
## Summary

Third PR in the #1448 Tier A stack. Stacked on top of #1458 (`.indexOf` / `.lastIndexOf`).

`.at(-1)` is the canonical reason an author reaches for `.at` over `[i]` — the negative index walks from the end. This PR wires the JS method name through to the existing Go `bf_at` helper and a new Mojo `bf->at` helper that mirrors the same `length + i` arithmetic.

## Adapter emit

- **Go**: `bf_at <recv> <idx>` (literal `-1` lowers as `(bf_neg 1)` because Go template doesn't accept literal negative numbers in prefix-call positions — pre-existing unary emit, no special handling)
- **Mojo**: `bf->at($recv, $idx)`

## Runtime helpers

- **Go**: `At` already existed (FuncMap entry `bf_at`) — only the adapter wiring is new.
- **Mojo**: new `at` method on the BarefootJS package; returns `undef` for out-of-bounds / non-array receivers (matches JS's `undefined` — Mojo's auto-escape renders that as the empty string at the call site).

## Test plan

- [x] `bun test` — all green
- [x] `go test -run TestAt` — passes (pre-existing coverage, runtime helper unchanged)
- [ ] Perl `prove` (Test2::V0 not installed in sandbox; runs in CI)
- [ ] End-to-end render (requires Go / Perl; runs in CI)

Drops the BF101 pin for `array-at` in both adapter conformance test files. Positive template-output tests pin the literal-negative shape (`bf_at .Items (bf_neg 1)`) and a signal-indexed shape (`bf_at .Items .I`). Perl tests cover the full out-of-bounds / non-array surface.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HJRNyteQamZmADhftGjtSJ)_