### PR TITLE
feat(#1448 Tier A): lower .concat(other) for arrays

### DIFF
--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -51,6 +51,7 @@ func FuncMap() template.FuncMap {
 		"bf_includes":       Includes,
 		"bf_index_of":       IndexOf,
 		"bf_last_index_of":  LastIndexOf,
+		"bf_concat":         Concat,
 		"bf_first":          First,
 		"bf_last":           Last,
 		"bf_arr":            Arr,
@@ -716,6 +717,36 @@ func LastIndexOf(items any, elem any) int {
 		}
 	}
 	return -1
+}
+
+// Concat merges two arrays (or slices) into a single `[]any`,
+// preserving order: receiver elements first, then `other`'s.
+// Lowers `Array.prototype.concat(other)` (#1448 Tier A). Non-array
+// operands collapse to an empty source — matches the JS semantic
+// where `.concat` on a non-Array reads it as a single element only
+// if its `Symbol.isConcatSpreadable` is true; the template-language
+// path doesn't have user objects with that flag, so treating
+// non-arrays as empty is the conservative lowering. Variadic
+// `.concat(a, b, c)` is out of scope here (parser gates to a single
+// arg); the helper itself stays binary so a future variadic IR can
+// fold via repeated calls without changing this signature.
+func Concat(a, b any) []any {
+	flatten := func(v reflect.Value) []any {
+		if !v.IsValid() {
+			return nil
+		}
+		if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
+			return nil
+		}
+		out := make([]any, v.Len())
+		for i := 0; i < v.Len(); i++ {
+			out[i] = v.Index(i).Interface()
+		}
+		return out
+	}
+	left := flatten(reflect.ValueOf(a))
+	right := flatten(reflect.ValueOf(b))
+	return append(left, right...)
 }
 
 // First returns the first element of a slice, or nil if empty.

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -52,6 +52,7 @@ func FuncMap() template.FuncMap {
 		"bf_index_of":       IndexOf,
 		"bf_last_index_of":  LastIndexOf,
 		"bf_concat":         Concat,
+		"bf_slice":          Slice,
 		"bf_first":          First,
 		"bf_last":           Last,
 		"bf_arr":            Arr,
@@ -747,6 +748,63 @@ func Concat(a, b any) []any {
 	left := flatten(reflect.ValueOf(a))
 	right := flatten(reflect.ValueOf(b))
 	return append(left, right...)
+}
+
+// Slice carves out a sub-range from `items`. Lowers
+// `Array.prototype.slice(start, end?)` (#1448 Tier A). The variadic
+// `end` arg lets Go template's call dispatcher pass either 2 or 3
+// arguments; an absent end means "to length".
+//
+// JS-compat clamping:
+//   - start < 0          → length + start  (e.g. -1 = last index)
+//   - end < 0            → length + end
+//   - start < 0 after clamp → 0
+//   - end > length       → length
+//   - start >= end       → empty slice (no panic)
+//
+// Non-array receivers return an empty `[]any`.
+func Slice(items any, start int, end ...int) []any {
+	v := reflect.ValueOf(items)
+	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
+		return []any{}
+	}
+	length := v.Len()
+
+	// Normalise start (negative = from end).
+	if start < 0 {
+		start = length + start
+	}
+	if start < 0 {
+		start = 0
+	}
+	if start > length {
+		start = length
+	}
+
+	// Normalise end (optional; absent = length).
+	stop := length
+	if len(end) > 0 {
+		stop = end[0]
+		if stop < 0 {
+			stop = length + stop
+		}
+		if stop < 0 {
+			stop = 0
+		}
+		if stop > length {
+			stop = length
+		}
+	}
+
+	if start >= stop {
+		return []any{}
+	}
+
+	out := make([]any, 0, stop-start)
+	for i := start; i < stop; i++ {
+		out = append(out, v.Index(i).Interface())
+	}
+	return out
 }
 
 // First returns the first element of a slice, or nil if empty.

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -264,6 +264,50 @@ func TestConcat(t *testing.T) {
 	}
 }
 
+// `Array.prototype.slice(start, end?)` lowering (#1448 Tier A). The
+// helper accepts the variadic `end` arg from Go template's call
+// dispatcher; an absent `end` means "to length".
+func TestSlice(t *testing.T) {
+	items := []string{"a", "b", "c", "d", "e"}
+
+	// 2-arg form.
+	got := Slice(items, 1, 3)
+	if len(got) != 2 || got[0] != "b" || got[1] != "c" {
+		t.Errorf("Slice(items, 1, 3) = %v, want [b c]", got)
+	}
+
+	// 1-arg form (`end` absent = length).
+	got = Slice(items, 2)
+	if len(got) != 3 || got[0] != "c" || got[2] != "e" {
+		t.Errorf("Slice(items, 2) = %v, want [c d e]", got)
+	}
+
+	// Negative-index normalisation.
+	got = Slice(items, -2)
+	if len(got) != 2 || got[0] != "d" || got[1] != "e" {
+		t.Errorf("Slice(items, -2) = %v, want [d e]", got)
+	}
+	got = Slice(items, 0, -1)
+	if len(got) != 4 || got[3] != "d" {
+		t.Errorf("Slice(items, 0, -1) = %v, want [a b c d]", got)
+	}
+
+	// Clamping (out-of-bounds + start >= end).
+	got = Slice(items, 100)
+	if len(got) != 0 {
+		t.Errorf("Slice(items, 100) = %v, want []", got)
+	}
+	got = Slice(items, 3, 1)
+	if len(got) != 0 {
+		t.Errorf("Slice(items, 3, 1) = %v, want []", got)
+	}
+
+	// Non-array receiver.
+	if got := Slice("not an array", 0, 2); len(got) != 0 {
+		t.Errorf("Slice(scalar, 0, 2) = %v, want []", got)
+	}
+}
+
 // String receiver covers `String.prototype.includes(sub)` (#1448 Tier A).
 // Both array and string `.includes` lower to the same `bf_includes` call;
 // this helper dispatches on `reflect.Kind()` at evaluation time.

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -239,6 +239,31 @@ func TestLastIndexOf(t *testing.T) {
 	}
 }
 
+// `Array.prototype.concat(other)` lowering (#1448 Tier A). Order is
+// preserved (receiver first, then `other`'s elements); non-array
+// operands collapse to empty.
+func TestConcat(t *testing.T) {
+	got := Concat([]string{"a", "b"}, []string{"c", "d"})
+	if len(got) != 4 || got[0] != "a" || got[3] != "d" {
+		t.Errorf("Concat([a,b], [c,d]) = %v, want [a b c d]", got)
+	}
+
+	mixed := Concat([]any{1, "two"}, []int{3, 4})
+	if len(mixed) != 4 {
+		t.Errorf("Concat mixed types: got length %d, want 4", len(mixed))
+	}
+
+	if got := Concat(nil, []string{"a"}); len(got) != 1 || got[0] != "a" {
+		t.Errorf("Concat(nil, [a]) = %v, want [a]", got)
+	}
+	if got := Concat([]string{"a"}, "not an array"); len(got) != 1 || got[0] != "a" {
+		t.Errorf("Concat([a], scalar) = %v, want [a]", got)
+	}
+	if got := Concat([]string{}, []string{}); len(got) != 0 {
+		t.Errorf("Concat([], []) = %v, want []", got)
+	}
+}
+
 // String receiver covers `String.prototype.includes(sub)` (#1448 Tier A).
 // Both array and string `.includes` lower to the same `bf_includes` call;
 // this helper dispatches on `reflect.Kind()` at evaluation time.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -1581,6 +1581,7 @@ import { fixture as stringIncludesFixture } from '../../../adapter-tests/fixture
 import { fixture as arrayIndexOfFixture } from '../../../adapter-tests/fixtures/methods/array-indexOf'
 import { fixture as arrayLastIndexOfFixture } from '../../../adapter-tests/fixtures/methods/array-lastIndexOf'
 import { fixture as arrayAtFixture } from '../../../adapter-tests/fixtures/methods/array-at'
+import { fixture as arrayConcatFixture } from '../../../adapter-tests/fixtures/methods/array-concat'
 
 describe('GoTemplateAdapter - #1448 Tier A fixture-driven lowering pins', () => {
   const cases = [
@@ -1594,6 +1595,7 @@ describe('GoTemplateAdapter - #1448 Tier A fixture-driven lowering pins', () => 
     // doesn't accept literal negative numbers in prefix-call
     // positions. Pre-existing unary-emit pattern.
     { fixture: arrayAtFixture,          expect: 'bf_at .Items (bf_neg 1)' },
+    { fixture: arrayConcatFixture,      expect: 'bf_concat .Left .Right' },
   ]
 
   for (const { fixture, expect: expectedHelper } of cases) {

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -156,7 +156,9 @@ runAdapterConformanceTests({
     // helpers handle the shape (#1448 Tier A second PR).
     // `array-at` no longer pinned — the pre-existing `bf_at` runtime
     // helper now lowers `.at(i)` (#1448 Tier A third PR).
-    'array-concat':        [{ code: 'BF101', severity: 'error' }],
+    // `array-concat` no longer pinned — the new `bf_concat` runtime
+    // helper merges two arrays into a single `[]any` (#1448 Tier A
+    // fourth PR).
     'array-slice':         [{ code: 'BF101', severity: 'error' }],
     'array-reverse':       [{ code: 'BF101', severity: 'error' }],
     'array-toReversed':    [{ code: 'BF101', severity: 'error' }],
@@ -1538,6 +1540,21 @@ export function C() {
   return <div>el: {items().at(i())}</div>
 }`)
       expect(result.template).toContain('bf_at .Items .I')
+    })
+  })
+
+  describe('.concat lowering (#1448 Tier A)', () => {
+    test('left.concat(right).join(\' \') chains through bf_concat → bf_join', () => {
+      // Composition pin: the canonical Tier A fixture
+      // (`packages/adapter-tests/fixtures/methods/array-concat.ts`)
+      // composes `.concat(...).join(' ')` so the concatenation
+      // result must be a real iterable (`[]any` from `bf_concat`),
+      // not a stringified `[object Object]` from a wrong lowering.
+      const result = compileAndGenerate(`function A({ left, right }: { left: string[]; right: string[] }) {
+  return <div>{left.concat(right).join(' ')}</div>
+}
+export { A }`)
+      expect(result.template).toContain('bf_join (bf_concat .Left .Right) " "')
     })
   })
 })

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -159,7 +159,9 @@ runAdapterConformanceTests({
     // `array-concat` no longer pinned — the new `bf_concat` runtime
     // helper merges two arrays into a single `[]any` (#1448 Tier A
     // fourth PR).
-    'array-slice':         [{ code: 'BF101', severity: 'error' }],
+    // `array-slice` no longer pinned — the new `bf_slice` runtime
+    // helper carves out a sub-range with JS-compat clamping
+    // (#1448 Tier A fifth PR).
     'array-reverse':       [{ code: 'BF101', severity: 'error' }],
     'array-toReversed':    [{ code: 'BF101', severity: 'error' }],
     'string-toLowerCase':  [{ code: 'BF101', severity: 'error' }],
@@ -1540,6 +1542,31 @@ export function C() {
   return <div>el: {items().at(i())}</div>
 }`)
       expect(result.template).toContain('bf_at .Items .I')
+    })
+  })
+
+  describe('.slice lowering (#1448 Tier A)', () => {
+    test('items.slice(1, 3).join(\' \') chains through bf_slice → bf_join', () => {
+      // 2-arg form. The canonical Tier A fixture pins the two-arg
+      // start-and-end shape since a lowering that only handled
+      // single-arg `.slice(start)` would still pass `.slice(1)`
+      // but fail here.
+      const result = compileAndGenerate(`function A({ items }: { items: string[] }) {
+  return <div>{items.slice(1, 3).join(' ')}</div>
+}
+export { A }`)
+      expect(result.template).toContain('bf_join (bf_slice .Items 1 3) " "')
+    })
+
+    test('items.slice(start) emits the 1-arg form (no `end`)', () => {
+      // 1-arg form. The Go helper's variadic `end ...int` parameter
+      // distinguishes "absent" from "0"; the absent case slices to
+      // length, the explicit `0` case slices to empty.
+      const result = compileAndGenerate(`function A({ items }: { items: string[] }) {
+  return <div>{items.slice(2).join(' ')}</div>
+}
+export { A }`)
+      expect(result.template).toContain('bf_join (bf_slice .Items 2) " "')
     })
   })
 

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -1609,6 +1609,7 @@ import { fixture as arrayIndexOfFixture } from '../../../adapter-tests/fixtures/
 import { fixture as arrayLastIndexOfFixture } from '../../../adapter-tests/fixtures/methods/array-lastIndexOf'
 import { fixture as arrayAtFixture } from '../../../adapter-tests/fixtures/methods/array-at'
 import { fixture as arrayConcatFixture } from '../../../adapter-tests/fixtures/methods/array-concat'
+import { fixture as arraySliceFixture } from '../../../adapter-tests/fixtures/methods/array-slice'
 
 describe('GoTemplateAdapter - #1448 Tier A fixture-driven lowering pins', () => {
   const cases = [
@@ -1623,6 +1624,7 @@ describe('GoTemplateAdapter - #1448 Tier A fixture-driven lowering pins', () => 
     // positions. Pre-existing unary-emit pattern.
     { fixture: arrayAtFixture,          expect: 'bf_at .Items (bf_neg 1)' },
     { fixture: arrayConcatFixture,      expect: 'bf_concat .Left .Right' },
+    { fixture: arraySliceFixture,       expect: 'bf_slice .Items 1 3' },
   ]
 
   for (const { fixture, expect: expectedHelper } of cases) {

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -2738,6 +2738,21 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         const b = emit(args[0])
         return `bf_concat ${wrapIfMultiToken(a)} ${wrapIfMultiToken(b)}`
       }
+      case 'slice': {
+        // `.slice(start)` / `.slice(start, end)` — both forms route
+        // through `bf_slice`. The runtime helper treats a `nil`
+        // `end` (the variadic-arg absence) as "to length", matching
+        // the JS semantic. Out-of-bounds indices clamp instead of
+        // panicking (also JS-compat); same with `start > end`
+        // returning an empty slice.
+        const recv = emit(object)
+        const start = emit(args[0])
+        if (args.length === 1) {
+          return `bf_slice ${wrapIfMultiToken(recv)} ${wrapIfMultiToken(start)}`
+        }
+        const end = emit(args[1])
+        return `bf_slice ${wrapIfMultiToken(recv)} ${wrapIfMultiToken(start)} ${wrapIfMultiToken(end)}`
+      }
       default: {
         const _exhaustive: never = method
         throw new Error(`Go arrayMethod: unhandled ArrayMethod '${(_exhaustive as string)}'`)

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -2729,6 +2729,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         const idx = emit(args[0])
         return `bf_at ${wrapIfMultiToken(obj)} ${wrapIfMultiToken(idx)}`
       }
+      case 'concat': {
+        // `.concat(other)` merges two arrays. The runtime helper
+        // `bf_concat` reflects over both operands so callers can
+        // mix `[]string` + `[]string` or `[]any` + `[]string` etc.
+        // without per-call-site type-juggling.
+        const a = emit(object)
+        const b = emit(args[0])
+        return `bf_concat ${wrapIfMultiToken(a)} ${wrapIfMultiToken(b)}`
+      }
       default: {
         const _exhaustive: never = method
         throw new Error(`Go arrayMethod: unhandled ArrayMethod '${(_exhaustive as string)}'`)

--- a/packages/adapter-mojolicious/lib/BarefootJS.pm
+++ b/packages/adapter-mojolicious/lib/BarefootJS.pm
@@ -427,6 +427,20 @@ sub at ($self, $recv, $i) {
     return $recv->[$idx];
 }
 
+# `Array.prototype.concat(other)` — merges two arrays in order
+# into a new ARRAY ref. Non-array operands collapse to empty
+# (matches the Go `bf_concat` semantic so cross-adapter output
+# stays symmetric; differs from JS where a non-Array argument
+# with `Symbol.isConcatSpreadable` would be spread, a behaviour
+# the template-language path never observes).
+
+sub concat ($self, $a, $b) {
+    my @out;
+    push @out, @$a if ref($a) eq 'ARRAY';
+    push @out, @$b if ref($b) eq 'ARRAY';
+    return \@out;
+}
+
 # ---------------------------------------------------------------------------
 # JSX intrinsic-element spread (#1407)
 # ---------------------------------------------------------------------------

--- a/packages/adapter-mojolicious/lib/BarefootJS.pm
+++ b/packages/adapter-mojolicious/lib/BarefootJS.pm
@@ -441,6 +441,36 @@ sub concat ($self, $a, $b) {
     return \@out;
 }
 
+# `Array.prototype.slice(start, end?)` — carves out a sub-range
+# into a new ARRAY ref. Mirrors the Go `bf_slice` arithmetic so
+# adapter output stays symmetric:
+#   - start < 0          → length + start  (e.g. -1 = last index)
+#   - end < 0            → length + end
+#   - start < 0 after clamp → 0
+#   - end > length       → length
+#   - start >= end       → empty
+#   - end undef          → "to length"
+# Non-array receivers return an empty ARRAY ref.
+
+sub slice ($self, $recv, $start, $end) {
+    return [] unless ref($recv) eq 'ARRAY';
+    my $len = scalar @$recv;
+    return [] if $len == 0;
+
+    my $s = $start // 0;
+    $s = $len + $s if $s < 0;
+    $s = 0    if $s < 0;
+    $s = $len if $s > $len;
+
+    my $e = defined $end ? $end : $len;
+    $e = $len + $e if $e < 0;
+    $e = 0    if $e < 0;
+    $e = $len if $e > $len;
+
+    return [] if $s >= $e;
+    return [ @{$recv}[$s .. $e - 1] ];
+}
+
 # ---------------------------------------------------------------------------
 # JSX intrinsic-element spread (#1407)
 # ---------------------------------------------------------------------------

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -754,6 +754,7 @@ import { fixture as stringIncludesFixture } from '../../../adapter-tests/fixture
 import { fixture as arrayIndexOfFixture } from '../../../adapter-tests/fixtures/methods/array-indexOf'
 import { fixture as arrayLastIndexOfFixture } from '../../../adapter-tests/fixtures/methods/array-lastIndexOf'
 import { fixture as arrayAtFixture } from '../../../adapter-tests/fixtures/methods/array-at'
+import { fixture as arrayConcatFixture } from '../../../adapter-tests/fixtures/methods/array-concat'
 
 describe('MojoAdapter - #1448 Tier A fixture-driven lowering pins', () => {
   const cases = [
@@ -762,6 +763,7 @@ describe('MojoAdapter - #1448 Tier A fixture-driven lowering pins', () => {
     { fixture: arrayIndexOfFixture,     expect: 'bf->index_of($items, $target)' },
     { fixture: arrayLastIndexOfFixture, expect: 'bf->last_index_of($items, $target)' },
     { fixture: arrayAtFixture,          expect: 'bf->at($items, -1)' },
+    { fixture: arrayConcatFixture,      expect: 'bf->concat($left, $right)' },
   ]
 
   for (const { fixture, expect: expectedHelper } of cases) {

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -119,7 +119,9 @@ runAdapterConformanceTests({
     // handle the shape (#1448 Tier A second PR).
     // `array-at` no longer pinned — `bf->at` (Mojo) / `bf_at` (Go)
     // handle the negative-index lookup (#1448 Tier A third PR).
-    'array-concat':        [{ code: 'BF101', severity: 'error' }],
+    // `array-concat` no longer pinned — `bf->concat` (Mojo) /
+    // `bf_concat` (Go) merge two arrays into a new array
+    // (#1448 Tier A fourth PR).
     'array-slice':         [{ code: 'BF101', severity: 'error' }],
     'array-reverse':       [{ code: 'BF101', severity: 'error' }],
     'array-toReversed':    [{ code: 'BF101', severity: 'error' }],
@@ -527,6 +529,23 @@ export { A }`, 'A.tsx', { adapter })
     const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
     expect(template).toContain('bf->at($items, -1)')
     expect(template).not.toContain('$bf->at(')
+  })
+
+  test('lowers .concat(other).join(\' \') via bf->concat + join (#1448 Tier A)', () => {
+    // Composition pin: the canonical Tier A fixture
+    // (`packages/adapter-tests/fixtures/methods/array-concat.ts`)
+    // chains `.concat(...).join(' ')`. The Mojo helper returns an
+    // ARRAY ref so the downstream `@{...}` dereference in `join(...)`
+    // works without an extra coercion.
+    const adapter = new MojoAdapter()
+    const result = compileJSX(`function A({ left, right }: { left: string[]; right: string[] }) {
+  return <div>{left.concat(right).join(' ')}</div>
+}
+export { A }`, 'A.tsx', { adapter })
+    expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
+    const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
+    expect(template).toContain("join(' ', @{bf->concat($left, $right)})")
+    expect(template).not.toContain('$bf->concat')
   })
 
   test('does not leak module-level export statements into the .html.ep template', () => {

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -122,7 +122,10 @@ runAdapterConformanceTests({
     // `array-concat` no longer pinned — `bf->concat` (Mojo) /
     // `bf_concat` (Go) merge two arrays into a new array
     // (#1448 Tier A fourth PR).
-    'array-slice':         [{ code: 'BF101', severity: 'error' }],
+    // `array-slice` no longer pinned — `bf->slice` (Mojo) /
+    // `bf_slice` (Go) carve out a sub-range with JS-compat
+    // negative-index / out-of-bounds clamping (#1448 Tier A
+    // fifth PR).
     'array-reverse':       [{ code: 'BF101', severity: 'error' }],
     'array-toReversed':    [{ code: 'BF101', severity: 'error' }],
     'string-toLowerCase':  [{ code: 'BF101', severity: 'error' }],
@@ -529,6 +532,32 @@ export { A }`, 'A.tsx', { adapter })
     const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
     expect(template).toContain('bf->at($items, -1)')
     expect(template).not.toContain('$bf->at(')
+  })
+
+  test('lowers .slice(start, end).join(\' \') via bf->slice + join (#1448 Tier A)', () => {
+    // 2-arg form. Canonical Tier A fixture pins the start+end shape.
+    const adapter = new MojoAdapter()
+    const result = compileJSX(`function A({ items }: { items: string[] }) {
+  return <div>{items.slice(1, 3).join(' ')}</div>
+}
+export { A }`, 'A.tsx', { adapter })
+    expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
+    const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
+    expect(template).toContain("join(' ', @{bf->slice($items, 1, 3)})")
+    expect(template).not.toContain('$bf->slice')
+  })
+
+  test('lowers .slice(start) (1-arg) via bf->slice with end=undef', () => {
+    // 1-arg form. The Perl helper treats undef `end` as
+    // "to length", matching the Go variadic-arg-absent case.
+    const adapter = new MojoAdapter()
+    const result = compileJSX(`function A({ items }: { items: string[] }) {
+  return <div>{items.slice(2).join(' ')}</div>
+}
+export { A }`, 'A.tsx', { adapter })
+    expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
+    const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
+    expect(template).toContain("join(' ', @{bf->slice($items, 2, undef)})")
   })
 
   test('lowers .concat(other).join(\' \') via bf->concat + join (#1448 Tier A)', () => {

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -784,6 +784,7 @@ import { fixture as arrayIndexOfFixture } from '../../../adapter-tests/fixtures/
 import { fixture as arrayLastIndexOfFixture } from '../../../adapter-tests/fixtures/methods/array-lastIndexOf'
 import { fixture as arrayAtFixture } from '../../../adapter-tests/fixtures/methods/array-at'
 import { fixture as arrayConcatFixture } from '../../../adapter-tests/fixtures/methods/array-concat'
+import { fixture as arraySliceFixture } from '../../../adapter-tests/fixtures/methods/array-slice'
 
 describe('MojoAdapter - #1448 Tier A fixture-driven lowering pins', () => {
   const cases = [
@@ -793,6 +794,7 @@ describe('MojoAdapter - #1448 Tier A fixture-driven lowering pins', () => {
     { fixture: arrayLastIndexOfFixture, expect: 'bf->last_index_of($items, $target)' },
     { fixture: arrayAtFixture,          expect: 'bf->at($items, -1)' },
     { fixture: arrayConcatFixture,      expect: 'bf->concat($left, $right)' },
+    { fixture: arraySliceFixture,       expect: 'bf->slice($items, 1, 3)' },
   ]
 
   for (const { fixture, expect: expectedHelper } of cases) {

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1471,6 +1471,15 @@ function renderArrayMethod(
       const idx = emit(args[0])
       return `bf->at(${obj}, ${idx})`
     }
+    case 'concat': {
+      // `.concat(other)` merges two arrays. Returns a new ARRAY
+      // ref so the result composes with `.join(...)` / other
+      // array-shape methods downstream (the canonical Tier A
+      // conformance fixture chains `.concat(...).join(' ')`).
+      const a = emit(object)
+      const b = emit(args[0])
+      return `bf->concat(${a}, ${b})`
+    }
     default: {
       // TS-level exhaustiveness guard. If this throws at runtime, the
       // IR was constructed against a newer `ArrayMethod` variant that

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1480,6 +1480,18 @@ function renderArrayMethod(
       const b = emit(args[0])
       return `bf->concat(${a}, ${b})`
     }
+    case 'slice': {
+      // `.slice(start)` / `.slice(start, end)`. The Mojo helper
+      // mirrors the Go arithmetic (negative-index normalisation,
+      // out-of-bounds clamping, empty result on start >= end).
+      // Absent `end` lowers as `undef`, which the helper treats as
+      // "to length". Returns a new ARRAY ref so the result composes
+      // with `.join(...)` downstream.
+      const recv = emit(object)
+      const start = emit(args[0])
+      const end = args.length === 2 ? emit(args[1]) : 'undef'
+      return `bf->slice(${recv}, ${start}, ${end})`
+    }
     default: {
       // TS-level exhaustiveness guard. If this throws at runtime, the
       // IR was constructed against a newer `ArrayMethod` variant that

--- a/packages/adapter-mojolicious/t/template_primitives.t
+++ b/packages/adapter-mojolicious/t/template_primitives.t
@@ -142,23 +142,23 @@ subtest 'at — array indexed access with negative-index support' => sub {
 # to empty (matches the Go `bf_concat` semantic); the result must
 # compose with `.join(...)` etc., hence the ARRAY ref return type.
 subtest 'concat — merges two arrays into a new array ref' => sub {
-    is_deeply $bf->concat(['a','b'], ['c','d']),    ['a','b','c','d'],     'two non-empty arrays';
-    is_deeply $bf->concat([],         ['a']),       ['a'],                 'empty + non-empty';
-    is_deeply $bf->concat(['a'],      []),          ['a'],                 'non-empty + empty';
-    is_deeply $bf->concat([],         []),          [],                    'empty + empty';
+    is $bf->concat(['a','b'], ['c','d']),    ['a','b','c','d'],     'two non-empty arrays';
+    is $bf->concat([],         ['a']),       ['a'],                 'empty + non-empty';
+    is $bf->concat(['a'],      []),          ['a'],                 'non-empty + empty';
+    is $bf->concat([],         []),          [],                    'empty + empty';
 
-    is_deeply $bf->concat(undef,      ['a']),       ['a'],                 'undef left → treats as empty';
-    is_deeply $bf->concat(['a'],      undef),       ['a'],                 'undef right → treats as empty';
-    is_deeply $bf->concat('not an array', ['a']),   ['a'],                 'scalar left → treats as empty';
-    is_deeply $bf->concat({a=>1},     ['a']),       ['a'],                 'hash ref left → treats as empty';
+    is $bf->concat(undef,      ['a']),       ['a'],                 'undef left → treats as empty';
+    is $bf->concat(['a'],      undef),       ['a'],                 'undef right → treats as empty';
+    is $bf->concat('not an array', ['a']),   ['a'],                 'scalar left → treats as empty';
+    is $bf->concat({a=>1},     ['a']),       ['a'],                 'hash ref left → treats as empty';
 
     # Mutation isolation: caller's source arrays must not be modified.
     my $left  = ['a', 'b'];
     my $right = ['c', 'd'];
     my $out   = $bf->concat($left, $right);
     push @$out, 'mutated';
-    is_deeply $left,  ['a', 'b'], 'left source unchanged after mutating result';
-    is_deeply $right, ['c', 'd'], 'right source unchanged after mutating result';
+    is $left,  ['a', 'b'], 'left source unchanged after mutating result';
+    is $right, ['c', 'd'], 'right source unchanged after mutating result';
 };
 
 done_testing;

--- a/packages/adapter-mojolicious/t/template_primitives.t
+++ b/packages/adapter-mojolicious/t/template_primitives.t
@@ -137,4 +137,28 @@ subtest 'at — array indexed access with negative-index support' => sub {
     is $bf->at({a => 1},   0),  undef, 'hash ref receiver → undef';
 };
 
+# `Array.prototype.concat(other)` — merges two arrays in order
+# into a new ARRAY ref (#1448 Tier A). Non-array operands collapse
+# to empty (matches the Go `bf_concat` semantic); the result must
+# compose with `.join(...)` etc., hence the ARRAY ref return type.
+subtest 'concat — merges two arrays into a new array ref' => sub {
+    is_deeply $bf->concat(['a','b'], ['c','d']),    ['a','b','c','d'],     'two non-empty arrays';
+    is_deeply $bf->concat([],         ['a']),       ['a'],                 'empty + non-empty';
+    is_deeply $bf->concat(['a'],      []),          ['a'],                 'non-empty + empty';
+    is_deeply $bf->concat([],         []),          [],                    'empty + empty';
+
+    is_deeply $bf->concat(undef,      ['a']),       ['a'],                 'undef left → treats as empty';
+    is_deeply $bf->concat(['a'],      undef),       ['a'],                 'undef right → treats as empty';
+    is_deeply $bf->concat('not an array', ['a']),   ['a'],                 'scalar left → treats as empty';
+    is_deeply $bf->concat({a=>1},     ['a']),       ['a'],                 'hash ref left → treats as empty';
+
+    # Mutation isolation: caller's source arrays must not be modified.
+    my $left  = ['a', 'b'];
+    my $right = ['c', 'd'];
+    my $out   = $bf->concat($left, $right);
+    push @$out, 'mutated';
+    is_deeply $left,  ['a', 'b'], 'left source unchanged after mutating result';
+    is_deeply $right, ['c', 'd'], 'right source unchanged after mutating result';
+};
+
 done_testing;

--- a/packages/adapter-mojolicious/t/template_primitives.t
+++ b/packages/adapter-mojolicious/t/template_primitives.t
@@ -161,4 +161,41 @@ subtest 'concat — merges two arrays into a new array ref' => sub {
     is $right, ['c', 'd'], 'right source unchanged after mutating result';
 };
 
+# `Array.prototype.slice(start, end?)` — carves out a sub-range
+# into a new ARRAY ref (#1448 Tier A). Mirrors the Go `bf_slice`
+# JS-compat semantics: negative-index normalisation, out-of-bounds
+# clamping, `start >= end` returns empty, undef `end` means "to
+# length". Non-array receivers return an empty ARRAY ref.
+subtest 'slice — array sub-range with negative-index + clamping' => sub {
+    my $arr = ['a', 'b', 'c', 'd', 'e'];
+
+    # 2-arg form.
+    is $bf->slice($arr, 1, 3),     ['b', 'c'],             'start+end carves middle';
+
+    # 1-arg form (undef end = "to length").
+    is $bf->slice($arr, 2, undef), ['c', 'd', 'e'],        'undef end → to length';
+    is $bf->slice($arr, 0, undef), ['a', 'b', 'c', 'd', 'e'], 'start 0, undef end → full copy';
+
+    # Negative-index normalisation.
+    is $bf->slice($arr, -2, undef),['d', 'e'],             '-2 start → last two';
+    is $bf->slice($arr,  0, -1),   ['a', 'b', 'c', 'd'],   '-1 end → drop last';
+    is $bf->slice($arr, -3, -1),   ['c', 'd'],             'both negative';
+
+    # Clamping (out of bounds + start >= end).
+    is $bf->slice($arr, 100, undef), [],                   'start past end → empty';
+    is $bf->slice($arr,   3,   1),   [],                   'start > end → empty';
+    is $bf->slice($arr,   0,   0),   [],                   'start == end → empty';
+
+    # Edge cases.
+    is $bf->slice([],     0, undef), [],                   'empty array → empty';
+    is $bf->slice(undef,  0, undef), [],                   'undef receiver → empty';
+    is $bf->slice('scalar', 0, undef), [],                 'scalar receiver → empty';
+
+    # Mutation isolation.
+    my $src = ['a', 'b', 'c'];
+    my $out = $bf->slice($src, 0, 2);
+    push @$out, 'mutated';
+    is $src, ['a', 'b', 'c'], 'source unchanged after mutating slice result';
+};
+
 done_testing;

--- a/packages/jsx/src/adapters/parsed-expr-emitter.ts
+++ b/packages/jsx/src/adapters/parsed-expr-emitter.ts
@@ -47,7 +47,7 @@ export type HigherOrderMethod = 'filter' | 'every' | 'some' | 'find' | 'findInde
  * adapter. The IR-level discriminator keeps the lowering surface
  * type-driven and the dispatch in one place.
  */
-export type ArrayMethod = 'join' | 'includes' | 'indexOf' | 'lastIndexOf' | 'at' | 'concat'
+export type ArrayMethod = 'join' | 'includes' | 'indexOf' | 'lastIndexOf' | 'at' | 'concat' | 'slice'
 
 export type LiteralType = 'string' | 'number' | 'boolean' | 'null'
 

--- a/packages/jsx/src/adapters/parsed-expr-emitter.ts
+++ b/packages/jsx/src/adapters/parsed-expr-emitter.ts
@@ -47,7 +47,7 @@ export type HigherOrderMethod = 'filter' | 'every' | 'some' | 'find' | 'findInde
  * adapter. The IR-level discriminator keeps the lowering surface
  * type-driven and the dispatch in one place.
  */
-export type ArrayMethod = 'join' | 'includes' | 'indexOf' | 'lastIndexOf' | 'at'
+export type ArrayMethod = 'join' | 'includes' | 'indexOf' | 'lastIndexOf' | 'at' | 'concat'
 
 export type LiteralType = 'string' | 'number' | 'boolean' | 'null'
 

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -33,7 +33,7 @@ export type ParsedExpr =
   // defence used for `ParsedExpr.kind`).
   | {
       kind: 'array-method'
-      method: 'join' | 'includes' | 'indexOf' | 'lastIndexOf' | 'at'
+      method: 'join' | 'includes' | 'indexOf' | 'lastIndexOf' | 'at' | 'concat'
       object: ParsedExpr
       args: ParsedExpr[]
     }
@@ -113,7 +113,8 @@ const UNSUPPORTED_METHODS = new Set([
   // `at` lowers via the `array-method` IR + the pre-existing
   // `bf_at` (Go) and a new `bf->at` (Mojo); both support negative
   // indices (`.at(-1)` returns the last element).
-  'concat',
+  // `concat` lowers via the `array-method` IR + `bf_concat` (Go) /
+  // `bf->concat` (Mojo).
   'slice',
   'reverse', 'toReversed',
   // #1448 Tier A — String methods.
@@ -260,6 +261,13 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
       // See #1448 Tier A.
       if (callee.property === 'at' && args.length === 1) {
         return { kind: 'array-method', method: 'at', object: callee.object, args }
+      }
+      // `.concat(other)` — merges two arrays in order. Go uses
+      // `bf_concat` (reflect-based append into `[]any`); Mojo uses
+      // `bf->concat` (Perl list builder). Variadic shapes (`.concat(a, b)`)
+      // are out of scope for this PR — gated to single-arg here.
+      if (callee.property === 'concat' && args.length === 1) {
+        return { kind: 'array-method', method: 'concat', object: callee.object, args }
       }
     }
 

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -33,7 +33,7 @@ export type ParsedExpr =
   // defence used for `ParsedExpr.kind`).
   | {
       kind: 'array-method'
-      method: 'join' | 'includes' | 'indexOf' | 'lastIndexOf' | 'at' | 'concat'
+      method: 'join' | 'includes' | 'indexOf' | 'lastIndexOf' | 'at' | 'concat' | 'slice'
       object: ParsedExpr
       args: ParsedExpr[]
     }
@@ -115,7 +115,9 @@ const UNSUPPORTED_METHODS = new Set([
   // indices (`.at(-1)` returns the last element).
   // `concat` lowers via the `array-method` IR + `bf_concat` (Go) /
   // `bf->concat` (Mojo).
-  'slice',
+  // `slice` lowers via the `array-method` IR + `bf_slice` (Go) /
+  // `bf->slice` (Mojo); accepts 1- or 2-arg form (`start` only or
+  // `start + end`).
   'reverse', 'toReversed',
   // #1448 Tier A — String methods.
   'toLowerCase', 'toUpperCase', 'trim',
@@ -268,6 +270,12 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
       // are out of scope for this PR — gated to single-arg here.
       if (callee.property === 'concat' && args.length === 1) {
         return { kind: 'array-method', method: 'concat', object: callee.object, args }
+      }
+      // `.slice(start)` / `.slice(start, end)` — both forms route
+      // through `bf_slice` (Go) / `bf->slice` (Mojo); the helpers
+      // treat a missing / undef `end` as "to length".
+      if (callee.property === 'slice' && (args.length === 1 || args.length === 2)) {
+        return { kind: 'array-method', method: 'slice', object: callee.object, args }
       }
     }
 


### PR DESCRIPTION
## Summary

Fourth PR in the #1448 Tier A stack. Stacked on top of #1459 (`.at`).

`.concat(other)` merges two arrays in order. The canonical Tier A fixture (`packages/adapter-tests/fixtures/methods/array-concat.ts`) chains `.concat(...).join(' ')`, so the result must be a real iterable — not a stringified `[object Object]` from the generic call dispatcher.

## Adapter emit

- **Go**: `bf_concat <a> <b>`
- **Mojo**: `bf->concat($a, $b)`

## Runtime helpers

- **Go**: new `Concat(a, b any) []any` — reflects over both operands (slice / array), returns a fresh `[]any` so the result composes with `bf_join` / other slice-shape helpers. Non-array operands collapse to empty (matches the conservative no-spread semantic for the template-language path, where JS's `Symbol.isConcatSpreadable` doesn't surface).
- **Mojo**: new `concat($a, $b)` method — returns a fresh ARRAY ref so downstream `@{...}` dereferencing works. Mutation isolation pinned in the Perl tests (caller's source arrays must not be modified after the result is mutated).

Variadic `.concat(a, b, c)` is out of scope — the parser gates on `args.length === 1`. A future variadic IR can fold via repeated calls without changing either helper's binary signature.

## Test plan

- [x] `bun test` for `packages/adapter-go-template`, `packages/adapter-mojolicious` — all green
- [x] `go test -run TestConcat` — pass
- [ ] Perl `prove` (Test2::V0 not in sandbox; runs in CI)
- [ ] End-to-end render against the conformance fixture (Go / Perl not in sandbox; runs in CI)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HJRNyteQamZmADhftGjtSJ)_