### PR TITLE
feat(#1448 Tier A): lower .slice(start, end?) for arrays

### DIFF
--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -52,6 +52,7 @@ func FuncMap() template.FuncMap {
 		"bf_index_of":       IndexOf,
 		"bf_last_index_of":  LastIndexOf,
 		"bf_concat":         Concat,
+		"bf_slice":          Slice,
 		"bf_first":          First,
 		"bf_last":           Last,
 		"bf_arr":            Arr,
@@ -747,6 +748,63 @@ func Concat(a, b any) []any {
 	left := flatten(reflect.ValueOf(a))
 	right := flatten(reflect.ValueOf(b))
 	return append(left, right...)
+}
+
+// Slice carves out a sub-range from `items`. Lowers
+// `Array.prototype.slice(start, end?)` (#1448 Tier A). The variadic
+// `end` arg lets Go template's call dispatcher pass either 2 or 3
+// arguments; an absent end means "to length".
+//
+// JS-compat clamping:
+//   - start < 0          → length + start  (e.g. -1 = last index)
+//   - end < 0            → length + end
+//   - start < 0 after clamp → 0
+//   - end > length       → length
+//   - start >= end       → empty slice (no panic)
+//
+// Non-array receivers return an empty `[]any`.
+func Slice(items any, start int, end ...int) []any {
+	v := reflect.ValueOf(items)
+	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
+		return []any{}
+	}
+	length := v.Len()
+
+	// Normalise start (negative = from end).
+	if start < 0 {
+		start = length + start
+	}
+	if start < 0 {
+		start = 0
+	}
+	if start > length {
+		start = length
+	}
+
+	// Normalise end (optional; absent = length).
+	stop := length
+	if len(end) > 0 {
+		stop = end[0]
+		if stop < 0 {
+			stop = length + stop
+		}
+		if stop < 0 {
+			stop = 0
+		}
+		if stop > length {
+			stop = length
+		}
+	}
+
+	if start >= stop {
+		return []any{}
+	}
+
+	out := make([]any, 0, stop-start)
+	for i := start; i < stop; i++ {
+		out = append(out, v.Index(i).Interface())
+	}
+	return out
 }
 
 // First returns the first element of a slice, or nil if empty.

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -264,6 +264,50 @@ func TestConcat(t *testing.T) {
 	}
 }
 
+// `Array.prototype.slice(start, end?)` lowering (#1448 Tier A). The
+// helper accepts the variadic `end` arg from Go template's call
+// dispatcher; an absent `end` means "to length".
+func TestSlice(t *testing.T) {
+	items := []string{"a", "b", "c", "d", "e"}
+
+	// 2-arg form.
+	got := Slice(items, 1, 3)
+	if len(got) != 2 || got[0] != "b" || got[1] != "c" {
+		t.Errorf("Slice(items, 1, 3) = %v, want [b c]", got)
+	}
+
+	// 1-arg form (`end` absent = length).
+	got = Slice(items, 2)
+	if len(got) != 3 || got[0] != "c" || got[2] != "e" {
+		t.Errorf("Slice(items, 2) = %v, want [c d e]", got)
+	}
+
+	// Negative-index normalisation.
+	got = Slice(items, -2)
+	if len(got) != 2 || got[0] != "d" || got[1] != "e" {
+		t.Errorf("Slice(items, -2) = %v, want [d e]", got)
+	}
+	got = Slice(items, 0, -1)
+	if len(got) != 4 || got[3] != "d" {
+		t.Errorf("Slice(items, 0, -1) = %v, want [a b c d]", got)
+	}
+
+	// Clamping (out-of-bounds + start >= end).
+	got = Slice(items, 100)
+	if len(got) != 0 {
+		t.Errorf("Slice(items, 100) = %v, want []", got)
+	}
+	got = Slice(items, 3, 1)
+	if len(got) != 0 {
+		t.Errorf("Slice(items, 3, 1) = %v, want []", got)
+	}
+
+	// Non-array receiver.
+	if got := Slice("not an array", 0, 2); len(got) != 0 {
+		t.Errorf("Slice(scalar, 0, 2) = %v, want []", got)
+	}
+}
+
 // String receiver covers `String.prototype.includes(sub)` (#1448 Tier A).
 // Both array and string `.includes` lower to the same `bf_includes` call;
 // this helper dispatches on `reflect.Kind()` at evaluation time.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -159,7 +159,9 @@ runAdapterConformanceTests({
     // `array-concat` no longer pinned — the new `bf_concat` runtime
     // helper merges two arrays into a single `[]any` (#1448 Tier A
     // fourth PR).
-    'array-slice':         [{ code: 'BF101', severity: 'error' }],
+    // `array-slice` no longer pinned — the new `bf_slice` runtime
+    // helper carves out a sub-range with JS-compat clamping
+    // (#1448 Tier A fifth PR).
     'array-reverse':       [{ code: 'BF101', severity: 'error' }],
     'array-toReversed':    [{ code: 'BF101', severity: 'error' }],
     'string-toLowerCase':  [{ code: 'BF101', severity: 'error' }],
@@ -1540,6 +1542,31 @@ export function C() {
   return <div>el: {items().at(i())}</div>
 }`)
       expect(result.template).toContain('bf_at .Items .I')
+    })
+  })
+
+  describe('.slice lowering (#1448 Tier A)', () => {
+    test('items.slice(1, 3).join(\' \') chains through bf_slice → bf_join', () => {
+      // 2-arg form. The canonical Tier A fixture pins the two-arg
+      // start-and-end shape since a lowering that only handled
+      // single-arg `.slice(start)` would still pass `.slice(1)`
+      // but fail here.
+      const result = compileAndGenerate(`function A({ items }: { items: string[] }) {
+  return <div>{items.slice(1, 3).join(' ')}</div>
+}
+export { A }`)
+      expect(result.template).toContain('bf_join (bf_slice .Items 1 3) " "')
+    })
+
+    test('items.slice(start) emits the 1-arg form (no `end`)', () => {
+      // 1-arg form. The Go helper's variadic `end ...int` parameter
+      // distinguishes "absent" from "0"; the absent case slices to
+      // length, the explicit `0` case slices to empty.
+      const result = compileAndGenerate(`function A({ items }: { items: string[] }) {
+  return <div>{items.slice(2).join(' ')}</div>
+}
+export { A }`)
+      expect(result.template).toContain('bf_join (bf_slice .Items 2) " "')
     })
   })
 

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -1609,6 +1609,7 @@ import { fixture as arrayIndexOfFixture } from '../../../adapter-tests/fixtures/
 import { fixture as arrayLastIndexOfFixture } from '../../../adapter-tests/fixtures/methods/array-lastIndexOf'
 import { fixture as arrayAtFixture } from '../../../adapter-tests/fixtures/methods/array-at'
 import { fixture as arrayConcatFixture } from '../../../adapter-tests/fixtures/methods/array-concat'
+import { fixture as arraySliceFixture } from '../../../adapter-tests/fixtures/methods/array-slice'
 
 describe('GoTemplateAdapter - #1448 Tier A fixture-driven lowering pins', () => {
   const cases = [
@@ -1623,6 +1624,7 @@ describe('GoTemplateAdapter - #1448 Tier A fixture-driven lowering pins', () => 
     // positions. Pre-existing unary-emit pattern.
     { fixture: arrayAtFixture,          expect: 'bf_at .Items (bf_neg 1)' },
     { fixture: arrayConcatFixture,      expect: 'bf_concat .Left .Right' },
+    { fixture: arraySliceFixture,       expect: 'bf_slice .Items 1 3' },
   ]
 
   for (const { fixture, expect: expectedHelper } of cases) {

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -2738,6 +2738,21 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         const b = emit(args[0])
         return `bf_concat ${wrapIfMultiToken(a)} ${wrapIfMultiToken(b)}`
       }
+      case 'slice': {
+        // `.slice(start)` / `.slice(start, end)` — both forms route
+        // through `bf_slice`. The runtime helper treats a `nil`
+        // `end` (the variadic-arg absence) as "to length", matching
+        // the JS semantic. Out-of-bounds indices clamp instead of
+        // panicking (also JS-compat); same with `start > end`
+        // returning an empty slice.
+        const recv = emit(object)
+        const start = emit(args[0])
+        if (args.length === 1) {
+          return `bf_slice ${wrapIfMultiToken(recv)} ${wrapIfMultiToken(start)}`
+        }
+        const end = emit(args[1])
+        return `bf_slice ${wrapIfMultiToken(recv)} ${wrapIfMultiToken(start)} ${wrapIfMultiToken(end)}`
+      }
       default: {
         const _exhaustive: never = method
         throw new Error(`Go arrayMethod: unhandled ArrayMethod '${(_exhaustive as string)}'`)

--- a/packages/adapter-mojolicious/lib/BarefootJS.pm
+++ b/packages/adapter-mojolicious/lib/BarefootJS.pm
@@ -441,6 +441,36 @@ sub concat ($self, $a, $b) {
     return \@out;
 }
 
+# `Array.prototype.slice(start, end?)` — carves out a sub-range
+# into a new ARRAY ref. Mirrors the Go `bf_slice` arithmetic so
+# adapter output stays symmetric:
+#   - start < 0          → length + start  (e.g. -1 = last index)
+#   - end < 0            → length + end
+#   - start < 0 after clamp → 0
+#   - end > length       → length
+#   - start >= end       → empty
+#   - end undef          → "to length"
+# Non-array receivers return an empty ARRAY ref.
+
+sub slice ($self, $recv, $start, $end) {
+    return [] unless ref($recv) eq 'ARRAY';
+    my $len = scalar @$recv;
+    return [] if $len == 0;
+
+    my $s = $start // 0;
+    $s = $len + $s if $s < 0;
+    $s = 0    if $s < 0;
+    $s = $len if $s > $len;
+
+    my $e = defined $end ? $end : $len;
+    $e = $len + $e if $e < 0;
+    $e = 0    if $e < 0;
+    $e = $len if $e > $len;
+
+    return [] if $s >= $e;
+    return [ @{$recv}[$s .. $e - 1] ];
+}
+
 # ---------------------------------------------------------------------------
 # JSX intrinsic-element spread (#1407)
 # ---------------------------------------------------------------------------

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -122,7 +122,10 @@ runAdapterConformanceTests({
     // `array-concat` no longer pinned — `bf->concat` (Mojo) /
     // `bf_concat` (Go) merge two arrays into a new array
     // (#1448 Tier A fourth PR).
-    'array-slice':         [{ code: 'BF101', severity: 'error' }],
+    // `array-slice` no longer pinned — `bf->slice` (Mojo) /
+    // `bf_slice` (Go) carve out a sub-range with JS-compat
+    // negative-index / out-of-bounds clamping (#1448 Tier A
+    // fifth PR).
     'array-reverse':       [{ code: 'BF101', severity: 'error' }],
     'array-toReversed':    [{ code: 'BF101', severity: 'error' }],
     'string-toLowerCase':  [{ code: 'BF101', severity: 'error' }],
@@ -529,6 +532,32 @@ export { A }`, 'A.tsx', { adapter })
     const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
     expect(template).toContain('bf->at($items, -1)')
     expect(template).not.toContain('$bf->at(')
+  })
+
+  test('lowers .slice(start, end).join(\' \') via bf->slice + join (#1448 Tier A)', () => {
+    // 2-arg form. Canonical Tier A fixture pins the start+end shape.
+    const adapter = new MojoAdapter()
+    const result = compileJSX(`function A({ items }: { items: string[] }) {
+  return <div>{items.slice(1, 3).join(' ')}</div>
+}
+export { A }`, 'A.tsx', { adapter })
+    expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
+    const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
+    expect(template).toContain("join(' ', @{bf->slice($items, 1, 3)})")
+    expect(template).not.toContain('$bf->slice')
+  })
+
+  test('lowers .slice(start) (1-arg) via bf->slice with end=undef', () => {
+    // 1-arg form. The Perl helper treats undef `end` as
+    // "to length", matching the Go variadic-arg-absent case.
+    const adapter = new MojoAdapter()
+    const result = compileJSX(`function A({ items }: { items: string[] }) {
+  return <div>{items.slice(2).join(' ')}</div>
+}
+export { A }`, 'A.tsx', { adapter })
+    expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
+    const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
+    expect(template).toContain("join(' ', @{bf->slice($items, 2, undef)})")
   })
 
   test('lowers .concat(other).join(\' \') via bf->concat + join (#1448 Tier A)', () => {

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -784,6 +784,7 @@ import { fixture as arrayIndexOfFixture } from '../../../adapter-tests/fixtures/
 import { fixture as arrayLastIndexOfFixture } from '../../../adapter-tests/fixtures/methods/array-lastIndexOf'
 import { fixture as arrayAtFixture } from '../../../adapter-tests/fixtures/methods/array-at'
 import { fixture as arrayConcatFixture } from '../../../adapter-tests/fixtures/methods/array-concat'
+import { fixture as arraySliceFixture } from '../../../adapter-tests/fixtures/methods/array-slice'
 
 describe('MojoAdapter - #1448 Tier A fixture-driven lowering pins', () => {
   const cases = [
@@ -793,6 +794,7 @@ describe('MojoAdapter - #1448 Tier A fixture-driven lowering pins', () => {
     { fixture: arrayLastIndexOfFixture, expect: 'bf->last_index_of($items, $target)' },
     { fixture: arrayAtFixture,          expect: 'bf->at($items, -1)' },
     { fixture: arrayConcatFixture,      expect: 'bf->concat($left, $right)' },
+    { fixture: arraySliceFixture,       expect: 'bf->slice($items, 1, 3)' },
   ]
 
   for (const { fixture, expect: expectedHelper } of cases) {

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1480,6 +1480,18 @@ function renderArrayMethod(
       const b = emit(args[0])
       return `bf->concat(${a}, ${b})`
     }
+    case 'slice': {
+      // `.slice(start)` / `.slice(start, end)`. The Mojo helper
+      // mirrors the Go arithmetic (negative-index normalisation,
+      // out-of-bounds clamping, empty result on start >= end).
+      // Absent `end` lowers as `undef`, which the helper treats as
+      // "to length". Returns a new ARRAY ref so the result composes
+      // with `.join(...)` downstream.
+      const recv = emit(object)
+      const start = emit(args[0])
+      const end = args.length === 2 ? emit(args[1]) : 'undef'
+      return `bf->slice(${recv}, ${start}, ${end})`
+    }
     default: {
       // TS-level exhaustiveness guard. If this throws at runtime, the
       // IR was constructed against a newer `ArrayMethod` variant that

--- a/packages/adapter-mojolicious/t/template_primitives.t
+++ b/packages/adapter-mojolicious/t/template_primitives.t
@@ -161,4 +161,41 @@ subtest 'concat — merges two arrays into a new array ref' => sub {
     is $right, ['c', 'd'], 'right source unchanged after mutating result';
 };
 
+# `Array.prototype.slice(start, end?)` — carves out a sub-range
+# into a new ARRAY ref (#1448 Tier A). Mirrors the Go `bf_slice`
+# JS-compat semantics: negative-index normalisation, out-of-bounds
+# clamping, `start >= end` returns empty, undef `end` means "to
+# length". Non-array receivers return an empty ARRAY ref.
+subtest 'slice — array sub-range with negative-index + clamping' => sub {
+    my $arr = ['a', 'b', 'c', 'd', 'e'];
+
+    # 2-arg form.
+    is $bf->slice($arr, 1, 3),     ['b', 'c'],             'start+end carves middle';
+
+    # 1-arg form (undef end = "to length").
+    is $bf->slice($arr, 2, undef), ['c', 'd', 'e'],        'undef end → to length';
+    is $bf->slice($arr, 0, undef), ['a', 'b', 'c', 'd', 'e'], 'start 0, undef end → full copy';
+
+    # Negative-index normalisation.
+    is $bf->slice($arr, -2, undef),['d', 'e'],             '-2 start → last two';
+    is $bf->slice($arr,  0, -1),   ['a', 'b', 'c', 'd'],   '-1 end → drop last';
+    is $bf->slice($arr, -3, -1),   ['c', 'd'],             'both negative';
+
+    # Clamping (out of bounds + start >= end).
+    is $bf->slice($arr, 100, undef), [],                   'start past end → empty';
+    is $bf->slice($arr,   3,   1),   [],                   'start > end → empty';
+    is $bf->slice($arr,   0,   0),   [],                   'start == end → empty';
+
+    # Edge cases.
+    is $bf->slice([],     0, undef), [],                   'empty array → empty';
+    is $bf->slice(undef,  0, undef), [],                   'undef receiver → empty';
+    is $bf->slice('scalar', 0, undef), [],                 'scalar receiver → empty';
+
+    # Mutation isolation.
+    my $src = ['a', 'b', 'c'];
+    my $out = $bf->slice($src, 0, 2);
+    push @$out, 'mutated';
+    is $src, ['a', 'b', 'c'], 'source unchanged after mutating slice result';
+};
+
 done_testing;

--- a/packages/jsx/src/adapters/parsed-expr-emitter.ts
+++ b/packages/jsx/src/adapters/parsed-expr-emitter.ts
@@ -47,7 +47,7 @@ export type HigherOrderMethod = 'filter' | 'every' | 'some' | 'find' | 'findInde
  * adapter. The IR-level discriminator keeps the lowering surface
  * type-driven and the dispatch in one place.
  */
-export type ArrayMethod = 'join' | 'includes' | 'indexOf' | 'lastIndexOf' | 'at' | 'concat'
+export type ArrayMethod = 'join' | 'includes' | 'indexOf' | 'lastIndexOf' | 'at' | 'concat' | 'slice'
 
 export type LiteralType = 'string' | 'number' | 'boolean' | 'null'
 

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -33,7 +33,7 @@ export type ParsedExpr =
   // defence used for `ParsedExpr.kind`).
   | {
       kind: 'array-method'
-      method: 'join' | 'includes' | 'indexOf' | 'lastIndexOf' | 'at' | 'concat'
+      method: 'join' | 'includes' | 'indexOf' | 'lastIndexOf' | 'at' | 'concat' | 'slice'
       object: ParsedExpr
       args: ParsedExpr[]
     }
@@ -115,7 +115,9 @@ const UNSUPPORTED_METHODS = new Set([
   // indices (`.at(-1)` returns the last element).
   // `concat` lowers via the `array-method` IR + `bf_concat` (Go) /
   // `bf->concat` (Mojo).
-  'slice',
+  // `slice` lowers via the `array-method` IR + `bf_slice` (Go) /
+  // `bf->slice` (Mojo); accepts 1- or 2-arg form (`start` only or
+  // `start + end`).
   'reverse', 'toReversed',
   // #1448 Tier A — String methods.
   'toLowerCase', 'toUpperCase', 'trim',
@@ -268,6 +270,12 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
       // are out of scope for this PR — gated to single-arg here.
       if (callee.property === 'concat' && args.length === 1) {
         return { kind: 'array-method', method: 'concat', object: callee.object, args }
+      }
+      // `.slice(start)` / `.slice(start, end)` — both forms route
+      // through `bf_slice` (Go) / `bf->slice` (Mojo); the helpers
+      // treat a missing / undef `end` as "to length".
+      if (callee.property === 'slice' && (args.length === 1 || args.length === 2)) {
+        return { kind: 'array-method', method: 'slice', object: callee.object, args }
       }
     }
 


### PR DESCRIPTION
## Summary

Fifth PR in the #1448 Tier A stack. Stacked on top of #1460 (`.concat`).

`.slice(start, end?)` carves out a sub-range. The canonical Tier A fixture pins the two-arg start+end shape — a lowering that only handled `.slice(start)` would still pass `.slice(1)` but fail there. Both 1- and 2-arg shapes share the parser arm.

## Adapter emit

- **Go**: `bf_slice <recv> <start>` (1-arg) / `bf_slice <recv> <start> <end>` (2-arg)
- **Mojo**: `bf->slice($recv, $start, undef)` (1-arg) / `bf->slice($recv, $start, $end)` (2-arg). The 1-arg form lowers `end` as the literal `undef` — symmetric with the Go helper's variadic `end ...int` (absent = "to length").

## Runtime helpers

- **Go**: new `Slice(items any, start int, end ...int) []any`. Variadic `end` distinguishes "absent" (slice-to-length) from `0` (slice-to-empty).
- **Mojo**: new `slice($recv, $start, $end)` method.

## JS-compat semantics (both adapters)

- `start < 0` → `length + start` (`-1` = last index)
- `end < 0` → `length + end`
- `start < 0` after clamp → `0`
- `end > length` → `length`
- `start >= end` → empty (no panic)
- non-array receiver → empty

## Test plan

- [x] `bun test` for both adapters — green
- [x] `go test -run TestSlice` — pass (negative-index, clamping, non-array)
- [ ] Perl `prove` (Test2::V0 not in sandbox; runs in CI)
- [ ] End-to-end render (Go / Perl not in sandbox; runs in CI)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HJRNyteQamZmADhftGjtSJ)_