### PR TITLE
feat(#1448 Tier A): lower .reverse() and .toReversed() for arrays

### DIFF
--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -53,6 +53,7 @@ func FuncMap() template.FuncMap {
 		"bf_last_index_of":  LastIndexOf,
 		"bf_concat":         Concat,
 		"bf_slice":          Slice,
+		"bf_reverse":        Reverse,
 		"bf_first":          First,
 		"bf_last":           Last,
 		"bf_arr":            Arr,
@@ -803,6 +804,27 @@ func Slice(items any, start int, end ...int) []any {
 	out := make([]any, 0, stop-start)
 	for i := start; i < stop; i++ {
 		out = append(out, v.Index(i).Interface())
+	}
+	return out
+}
+
+// Reverse returns a new slice with `items`'s elements in reverse
+// order. Lowers both `Array.prototype.reverse()` and
+// `Array.prototype.toReversed()` (#1448 Tier A) — SSR templates
+// render a snapshot, so JS's mutate-receiver vs return-new-array
+// distinction has no template-level meaning, and the safer
+// non-mutating shape is used uniformly.
+//
+// Non-array receivers return an empty `[]any`.
+func Reverse(items any) []any {
+	v := reflect.ValueOf(items)
+	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
+		return []any{}
+	}
+	length := v.Len()
+	out := make([]any, length)
+	for i := 0; i < length; i++ {
+		out[length-1-i] = v.Index(i).Interface()
 	}
 	return out
 }

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -308,6 +308,39 @@ func TestSlice(t *testing.T) {
 	}
 }
 
+// `Array.prototype.reverse()` / `toReversed()` lowering (#1448 Tier A).
+// Both shapes share the runtime helper — SSR template context makes
+// the JS mutate-vs-new distinction immaterial.
+func TestReverse(t *testing.T) {
+	got := Reverse([]string{"a", "b", "c"})
+	if len(got) != 3 || got[0] != "c" || got[1] != "b" || got[2] != "a" {
+		t.Errorf("Reverse([a,b,c]) = %v, want [c b a]", got)
+	}
+
+	if got := Reverse([]int{}); len(got) != 0 {
+		t.Errorf("Reverse([]) = %v, want []", got)
+	}
+
+	// Single-element edge case — same input, distinct slice.
+	one := []string{"only"}
+	got2 := Reverse(one)
+	if len(got2) != 1 || got2[0] != "only" {
+		t.Errorf("Reverse([only]) = %v, want [only]", got2)
+	}
+
+	// Mutation isolation: input must survive.
+	src := []string{"a", "b"}
+	_ = Reverse(src)
+	if src[0] != "a" || src[1] != "b" {
+		t.Errorf("Reverse mutated input slice: %v", src)
+	}
+
+	// Non-array receiver.
+	if got := Reverse("not an array"); len(got) != 0 {
+		t.Errorf("Reverse(scalar) = %v, want []", got)
+	}
+}
+
 // String receiver covers `String.prototype.includes(sub)` (#1448 Tier A).
 // Both array and string `.includes` lower to the same `bf_includes` call;
 // this helper dispatches on `reflect.Kind()` at evaluation time.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -162,8 +162,10 @@ runAdapterConformanceTests({
     // `array-slice` no longer pinned — the new `bf_slice` runtime
     // helper carves out a sub-range with JS-compat clamping
     // (#1448 Tier A fifth PR).
-    'array-reverse':       [{ code: 'BF101', severity: 'error' }],
-    'array-toReversed':    [{ code: 'BF101', severity: 'error' }],
+    // `array-reverse` / `array-toReversed` no longer pinned —
+    // both share the `bf_reverse` helper since SSR templates
+    // render a snapshot and the JS mutate-vs-new distinction has
+    // no template-level meaning (#1448 Tier A sixth PR).
     'string-toLowerCase':  [{ code: 'BF101', severity: 'error' }],
     'string-toUpperCase':  [{ code: 'BF101', severity: 'error' }],
     'string-trim':         [{ code: 'BF101', severity: 'error' }],
@@ -1567,6 +1569,30 @@ export { A }`)
 }
 export { A }`)
       expect(result.template).toContain('bf_join (bf_slice .Items 2) " "')
+    })
+  })
+
+  describe('.reverse / .toReversed lowering (#1448 Tier A)', () => {
+    test('items.reverse().join(\' \') chains through bf_reverse → bf_join', () => {
+      // `Array.prototype.reverse()` mutates the receiver in JS, but
+      // in SSR template context the receiver is never observed,
+      // so the helper returns a new slice. Composes with .join(' ')
+      // to make the reversed order visible in the rendered output.
+      const result = compileAndGenerate(`function A({ items }: { items: string[] }) {
+  return <div>{items.reverse().join(' ')}</div>
+}
+export { A }`)
+      expect(result.template).toContain('bf_join (bf_reverse .Items) " "')
+    })
+
+    test('items.toReversed().join(\' \') routes through the same helper', () => {
+      // `.toReversed()` is the non-mutating sibling. Sharing a
+      // lowering with `.reverse()` is fine in template context.
+      const result = compileAndGenerate(`function A({ items }: { items: string[] }) {
+  return <div>{items.toReversed().join(' ')}</div>
+}
+export { A }`)
+      expect(result.template).toContain('bf_join (bf_reverse .Items) " "')
     })
   })
 

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -1636,6 +1636,8 @@ import { fixture as arrayLastIndexOfFixture } from '../../../adapter-tests/fixtu
 import { fixture as arrayAtFixture } from '../../../adapter-tests/fixtures/methods/array-at'
 import { fixture as arrayConcatFixture } from '../../../adapter-tests/fixtures/methods/array-concat'
 import { fixture as arraySliceFixture } from '../../../adapter-tests/fixtures/methods/array-slice'
+import { fixture as arrayReverseFixture } from '../../../adapter-tests/fixtures/methods/array-reverse'
+import { fixture as arrayToReversedFixture } from '../../../adapter-tests/fixtures/methods/array-toReversed'
 
 describe('GoTemplateAdapter - #1448 Tier A fixture-driven lowering pins', () => {
   const cases = [
@@ -1651,6 +1653,10 @@ describe('GoTemplateAdapter - #1448 Tier A fixture-driven lowering pins', () => 
     { fixture: arrayAtFixture,          expect: 'bf_at .Items (bf_neg 1)' },
     { fixture: arrayConcatFixture,      expect: 'bf_concat .Left .Right' },
     { fixture: arraySliceFixture,       expect: 'bf_slice .Items 1 3' },
+    { fixture: arrayReverseFixture,     expect: 'bf_reverse .Items' },
+    // .toReversed shares the helper with .reverse — pinning both
+    // routings catches a future divergence between them.
+    { fixture: arrayToReversedFixture,  expect: 'bf_reverse .Items' },
   ]
 
   for (const { fixture, expect: expectedHelper } of cases) {

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -2753,6 +2753,17 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         const end = emit(args[1])
         return `bf_slice ${wrapIfMultiToken(recv)} ${wrapIfMultiToken(start)} ${wrapIfMultiToken(end)}`
       }
+      case 'reverse':
+      case 'toReversed': {
+        // SSR templates render a snapshot of state, so JS's
+        // mutate-and-return-receiver (`reverse`) vs return-new-
+        // array (`toReversed`) distinction has no template-level
+        // meaning. Both shapes route through `bf_reverse`, which
+        // always returns a fresh `[]any` (safest interpretation —
+        // the input array is whatever the template binds).
+        const recv = emit(object)
+        return `bf_reverse ${wrapIfMultiToken(recv)}`
+      }
       default: {
         const _exhaustive: never = method
         throw new Error(`Go arrayMethod: unhandled ArrayMethod '${(_exhaustive as string)}'`)

--- a/packages/adapter-mojolicious/lib/BarefootJS.pm
+++ b/packages/adapter-mojolicious/lib/BarefootJS.pm
@@ -471,6 +471,19 @@ sub slice ($self, $recv, $start, $end) {
     return [ @{$recv}[$s .. $e - 1] ];
 }
 
+# `Array.prototype.reverse()` / `Array.prototype.toReversed()` —
+# both shapes share this lowering. SSR templates render a snapshot
+# of state, so JS's mutate-receiver (`reverse`) vs
+# return-new-array (`toReversed`) distinction has no template-
+# level meaning. Always returns a new ARRAY ref to keep callers
+# safe from accidental aliasing. Non-array receivers return an
+# empty ARRAY ref.
+
+sub reverse ($self, $recv) {
+    return [] unless ref($recv) eq 'ARRAY';
+    return [ reverse @$recv ];
+}
+
 # ---------------------------------------------------------------------------
 # JSX intrinsic-element spread (#1407)
 # ---------------------------------------------------------------------------

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -814,6 +814,8 @@ import { fixture as arrayLastIndexOfFixture } from '../../../adapter-tests/fixtu
 import { fixture as arrayAtFixture } from '../../../adapter-tests/fixtures/methods/array-at'
 import { fixture as arrayConcatFixture } from '../../../adapter-tests/fixtures/methods/array-concat'
 import { fixture as arraySliceFixture } from '../../../adapter-tests/fixtures/methods/array-slice'
+import { fixture as arrayReverseFixture } from '../../../adapter-tests/fixtures/methods/array-reverse'
+import { fixture as arrayToReversedFixture } from '../../../adapter-tests/fixtures/methods/array-toReversed'
 
 describe('MojoAdapter - #1448 Tier A fixture-driven lowering pins', () => {
   const cases = [
@@ -824,6 +826,10 @@ describe('MojoAdapter - #1448 Tier A fixture-driven lowering pins', () => {
     { fixture: arrayAtFixture,          expect: 'bf->at($items, -1)' },
     { fixture: arrayConcatFixture,      expect: 'bf->concat($left, $right)' },
     { fixture: arraySliceFixture,       expect: 'bf->slice($items, 1, 3)' },
+    { fixture: arrayReverseFixture,     expect: 'bf->reverse($items)' },
+    // .toReversed shares the helper with .reverse — pinning both
+    // routings catches a future divergence between them.
+    { fixture: arrayToReversedFixture,  expect: 'bf->reverse($items)' },
   ]
 
   for (const { fixture, expect: expectedHelper } of cases) {

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -126,8 +126,11 @@ runAdapterConformanceTests({
     // `bf_slice` (Go) carve out a sub-range with JS-compat
     // negative-index / out-of-bounds clamping (#1448 Tier A
     // fifth PR).
-    'array-reverse':       [{ code: 'BF101', severity: 'error' }],
-    'array-toReversed':    [{ code: 'BF101', severity: 'error' }],
+    // `array-reverse` / `array-toReversed` no longer pinned —
+    // both share the `bf->reverse` / `bf_reverse` helper since
+    // SSR templates render a snapshot and the JS mutate-vs-new
+    // distinction has no template-level meaning (#1448 Tier A
+    // sixth PR).
     'string-toLowerCase':  [{ code: 'BF101', severity: 'error' }],
     'string-toUpperCase':  [{ code: 'BF101', severity: 'error' }],
     'string-trim':         [{ code: 'BF101', severity: 'error' }],
@@ -532,6 +535,32 @@ export { A }`, 'A.tsx', { adapter })
     const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
     expect(template).toContain('bf->at($items, -1)')
     expect(template).not.toContain('$bf->at(')
+  })
+
+  test('lowers .reverse().join(\' \') via bf->reverse + join (#1448 Tier A)', () => {
+    // SSR templates render a snapshot, so `.reverse` and
+    // `.toReversed` share a Mojo lowering — both return a new
+    // ARRAY ref so downstream `.join(...)` composes naturally.
+    const adapter = new MojoAdapter()
+    const result = compileJSX(`function A({ items }: { items: string[] }) {
+  return <div>{items.reverse().join(' ')}</div>
+}
+export { A }`, 'A.tsx', { adapter })
+    expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
+    const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
+    expect(template).toContain("join(' ', @{bf->reverse($items)})")
+    expect(template).not.toContain('$bf->reverse')
+  })
+
+  test('lowers .toReversed().join(\' \') via the same bf->reverse helper', () => {
+    const adapter = new MojoAdapter()
+    const result = compileJSX(`function A({ items }: { items: string[] }) {
+  return <div>{items.toReversed().join(' ')}</div>
+}
+export { A }`, 'A.tsx', { adapter })
+    expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
+    const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
+    expect(template).toContain("join(' ', @{bf->reverse($items)})")
   })
 
   test('lowers .slice(start, end).join(\' \') via bf->slice + join (#1448 Tier A)', () => {

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1492,6 +1492,14 @@ function renderArrayMethod(
       const end = args.length === 2 ? emit(args[1]) : 'undef'
       return `bf->slice(${recv}, ${start}, ${end})`
     }
+    case 'reverse':
+    case 'toReversed': {
+      // Both shapes share a lowering — see the parser arm + Go
+      // emit for the SSR-mutation-rationale. Returns a new ARRAY
+      // ref so the result composes with `.join(...)` downstream.
+      const recv = emit(object)
+      return `bf->reverse(${recv})`
+    }
     default: {
       // TS-level exhaustiveness guard. If this throws at runtime, the
       // IR was constructed against a newer `ArrayMethod` variant that

--- a/packages/adapter-mojolicious/t/template_primitives.t
+++ b/packages/adapter-mojolicious/t/template_primitives.t
@@ -198,4 +198,26 @@ subtest 'slice — array sub-range with negative-index + clamping' => sub {
     is $src, ['a', 'b', 'c'], 'source unchanged after mutating slice result';
 };
 
+# `Array.prototype.reverse()` / `Array.prototype.toReversed()` —
+# both shapes share the lowering (#1448 Tier A). SSR templates
+# render a snapshot, so JS's mutate-vs-new distinction has no
+# template-level meaning. Always returns a new ARRAY ref.
+subtest 'reverse — new array ref in reverse order' => sub {
+    is $bf->reverse(['a', 'b', 'c']), ['c', 'b', 'a'], 'three elements';
+    is $bf->reverse([1, 2, 3, 4]),    [4, 3, 2, 1],    'integers';
+    is $bf->reverse([]),              [],              'empty array';
+    is $bf->reverse(['only']),        ['only'],        'single element';
+
+    # Mutation isolation: input must survive.
+    my $src = ['a', 'b', 'c'];
+    my $out = $bf->reverse($src);
+    push @$out, 'mutated';
+    is $src, ['a', 'b', 'c'], 'source unchanged after mutating reverse result';
+
+    # Non-array receivers.
+    is $bf->reverse(undef),         [], 'undef receiver → empty';
+    is $bf->reverse('not an array'),[], 'scalar receiver → empty';
+    is $bf->reverse({a => 1}),      [], 'hash ref receiver → empty';
+};
+
 done_testing;

--- a/packages/jsx/src/adapters/parsed-expr-emitter.ts
+++ b/packages/jsx/src/adapters/parsed-expr-emitter.ts
@@ -47,7 +47,16 @@ export type HigherOrderMethod = 'filter' | 'every' | 'some' | 'find' | 'findInde
  * adapter. The IR-level discriminator keeps the lowering surface
  * type-driven and the dispatch in one place.
  */
-export type ArrayMethod = 'join' | 'includes' | 'indexOf' | 'lastIndexOf' | 'at' | 'concat' | 'slice'
+export type ArrayMethod =
+  | 'join'
+  | 'includes'
+  | 'indexOf'
+  | 'lastIndexOf'
+  | 'at'
+  | 'concat'
+  | 'slice'
+  | 'reverse'
+  | 'toReversed'
 
 export type LiteralType = 'string' | 'number' | 'boolean' | 'null'
 

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -33,7 +33,16 @@ export type ParsedExpr =
   // defence used for `ParsedExpr.kind`).
   | {
       kind: 'array-method'
-      method: 'join' | 'includes' | 'indexOf' | 'lastIndexOf' | 'at' | 'concat' | 'slice'
+      method:
+        | 'join'
+        | 'includes'
+        | 'indexOf'
+        | 'lastIndexOf'
+        | 'at'
+        | 'concat'
+        | 'slice'
+        | 'reverse'
+        | 'toReversed'
       object: ParsedExpr
       args: ParsedExpr[]
     }
@@ -118,7 +127,12 @@ const UNSUPPORTED_METHODS = new Set([
   // `slice` lowers via the `array-method` IR + `bf_slice` (Go) /
   // `bf->slice` (Mojo); accepts 1- or 2-arg form (`start` only or
   // `start + end`).
-  'reverse', 'toReversed',
+  // `reverse` / `toReversed` lower via the `array-method` IR +
+  // `bf_reverse` (Go) / `bf->reverse` (Mojo). The Mojo helper is
+  // shared by both shapes; in SSR template context the receiver is
+  // never observed so JS's mutation-vs-new-array distinction has
+  // no template-level meaning. Both lowerings always return a new
+  // array — safest interpretation.
   // #1448 Tier A — String methods.
   'toLowerCase', 'toUpperCase', 'trim',
 ])
@@ -276,6 +290,14 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
       // treat a missing / undef `end` as "to length".
       if (callee.property === 'slice' && (args.length === 1 || args.length === 2)) {
         return { kind: 'array-method', method: 'slice', object: callee.object, args }
+      }
+      // `.reverse()` and `.toReversed()` — both zero-arg shapes
+      // share the runtime lowering. SSR templates render a snapshot
+      // of state, so JS's mutate-and-return-receiver (`reverse`)
+      // vs return-new-array (`toReversed`) distinction has no
+      // template-level meaning; both produce a new reversed array.
+      if ((callee.property === 'reverse' || callee.property === 'toReversed') && args.length === 0) {
+        return { kind: 'array-method', method: callee.property, object: callee.object, args }
       }
     }
 


### PR DESCRIPTION
## Summary

Sixth PR in the #1448 Tier A stack. Stacked on top of #1461 (`.slice`).

Both `.reverse()` and `.toReversed()` share the runtime helper — SSR templates render a snapshot of state, so JS's mutate-and-return-receiver (`reverse`) vs return-new-array (`toReversed`) distinction has no template-level meaning. Both lower to a non-mutating new array (safest interpretation; mutation isolation pinned in the runtime tests).

## Adapter emit

- **Go**: `bf_reverse <recv>`
- **Mojo**: `bf->reverse($recv)`

## Runtime helpers

- **Go**: new `Reverse(items any) []any` — reflects over the receiver, builds a fresh `[]any` walking back-to-front. Non-array receivers return empty.
- **Mojo**: new `reverse($recv)` method — Perl's `reverse @$recv` boxed into a new ARRAY ref. Non-array receivers return empty.

Drops the BF101 pin for `array-reverse` AND `array-toReversed` in both adapter conformance test files. Positive tests pin BOTH shapes routing through the same lowering on each adapter (so a future divergence surfaces here, not in the conformance run).

## Test plan

- [x] `bun test` for both adapters — green
- [x] `go test -run TestReverse` — pass (empty / single-element / non-array / mutation-isolation)
- [ ] Perl `prove` (Test2::V0 not in sandbox; runs in CI)
- [ ] End-to-end render (Go / Perl not in sandbox; runs in CI)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HJRNyteQamZmADhftGjtSJ)_