### PR TITLE
feat(#1448 Tier A): lower .toLowerCase() for strings

### DIFF
--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -166,7 +166,9 @@ runAdapterConformanceTests({
     // both share the `bf_reverse` helper since SSR templates
     // render a snapshot and the JS mutate-vs-new distinction has
     // no template-level meaning (#1448 Tier A sixth PR).
-    'string-toLowerCase':  [{ code: 'BF101', severity: 'error' }],
+    // `string-toLowerCase` no longer pinned — the pre-existing
+    // `bf_lower` runtime helper now wires to the JS method name
+    // at the adapter layer (#1448 Tier A seventh PR).
     'string-toUpperCase':  [{ code: 'BF101', severity: 'error' }],
     'string-trim':         [{ code: 'BF101', severity: 'error' }],
   },
@@ -1569,6 +1571,20 @@ export { A }`)
 }
 export { A }`)
       expect(result.template).toContain('bf_join (bf_slice .Items 2) " "')
+    })
+  })
+
+  describe('.toLowerCase lowering (#1448 Tier A)', () => {
+    test('value.toLowerCase() emits `bf_lower .Value`', () => {
+      // Pre-#1448: parser refused `.toLowerCase` via
+      // `UNSUPPORTED_METHODS` and surfaced BF101. The runtime's
+      // `bf_lower` helper has been registered from a prior code
+      // path; this PR wires the JS method name to it.
+      const result = compileAndGenerate(`function A({ value }: { value: string }) {
+  return <div>{value.toLowerCase()}</div>
+}
+export { A }`)
+      expect(result.template).toContain('bf_lower .Value')
     })
   })
 

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -1654,6 +1654,7 @@ import { fixture as arrayConcatFixture } from '../../../adapter-tests/fixtures/m
 import { fixture as arraySliceFixture } from '../../../adapter-tests/fixtures/methods/array-slice'
 import { fixture as arrayReverseFixture } from '../../../adapter-tests/fixtures/methods/array-reverse'
 import { fixture as arrayToReversedFixture } from '../../../adapter-tests/fixtures/methods/array-toReversed'
+import { fixture as stringToLowerCaseFixture } from '../../../adapter-tests/fixtures/methods/string-toLowerCase'
 
 describe('GoTemplateAdapter - #1448 Tier A fixture-driven lowering pins', () => {
   const cases = [
@@ -1673,6 +1674,7 @@ describe('GoTemplateAdapter - #1448 Tier A fixture-driven lowering pins', () => 
     // .toReversed shares the helper with .reverse — pinning both
     // routings catches a future divergence between them.
     { fixture: arrayToReversedFixture,  expect: 'bf_reverse .Items' },
+    { fixture: stringToLowerCaseFixture,expect: 'bf_lower .Value' },
   ]
 
   for (const { fixture, expect: expectedHelper } of cases) {

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -2764,6 +2764,13 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         const recv = emit(object)
         return `bf_reverse ${wrapIfMultiToken(recv)}`
       }
+      case 'toLowerCase': {
+        // The Go runtime registers `bf_lower` from a prior code path;
+        // this PR is purely the adapter wiring of the JS method name
+        // to that helper.
+        const recv = emit(object)
+        return `bf_lower ${wrapIfMultiToken(recv)}`
+      }
       default: {
         const _exhaustive: never = method
         throw new Error(`Go arrayMethod: unhandled ArrayMethod '${(_exhaustive as string)}'`)

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -836,6 +836,7 @@ import { fixture as arrayConcatFixture } from '../../../adapter-tests/fixtures/m
 import { fixture as arraySliceFixture } from '../../../adapter-tests/fixtures/methods/array-slice'
 import { fixture as arrayReverseFixture } from '../../../adapter-tests/fixtures/methods/array-reverse'
 import { fixture as arrayToReversedFixture } from '../../../adapter-tests/fixtures/methods/array-toReversed'
+import { fixture as stringToLowerCaseFixture } from '../../../adapter-tests/fixtures/methods/string-toLowerCase'
 
 describe('MojoAdapter - #1448 Tier A fixture-driven lowering pins', () => {
   const cases = [
@@ -850,6 +851,7 @@ describe('MojoAdapter - #1448 Tier A fixture-driven lowering pins', () => {
     // .toReversed shares the helper with .reverse — pinning both
     // routings catches a future divergence between them.
     { fixture: arrayToReversedFixture,  expect: 'bf->reverse($items)' },
+    { fixture: stringToLowerCaseFixture,expect: 'lc($value)' },
   ]
 
   for (const { fixture, expect: expectedHelper } of cases) {

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -131,7 +131,10 @@ runAdapterConformanceTests({
     // SSR templates render a snapshot and the JS mutate-vs-new
     // distinction has no template-level meaning (#1448 Tier A
     // sixth PR).
-    'string-toLowerCase':  [{ code: 'BF101', severity: 'error' }],
+    // `string-toLowerCase` no longer pinned — Perl's native `lc`
+    // is the obvious lowering (no helper method); Go uses the
+    // pre-existing `bf_lower` runtime helper (#1448 Tier A
+    // seventh PR).
     'string-toUpperCase':  [{ code: 'BF101', severity: 'error' }],
     'string-trim':         [{ code: 'BF101', severity: 'error' }],
     // #1448 catalog — `.find` / `.findIndex` have no Mojo lowering
@@ -535,6 +538,23 @@ export { A }`, 'A.tsx', { adapter })
     const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
     expect(template).toContain('bf->at($items, -1)')
     expect(template).not.toContain('$bf->at(')
+  })
+
+  test('lowers .toLowerCase() via Perl native lc (#1448 Tier A)', () => {
+    // Perl's `lc` is the native lowering — no helper needed.
+    // Defensive: must not emit a `$lc(...)` form (which the
+    // test-render patch would mangle); emit must be the bare
+    // `lc(...)` call so it stays well-formed in both the
+    // standalone test renderer and real Mojolicious.
+    const adapter = new MojoAdapter()
+    const result = compileJSX(`function A({ value }: { value: string }) {
+  return <div>{value.toLowerCase()}</div>
+}
+export { A }`, 'A.tsx', { adapter })
+    expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
+    const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
+    expect(template).toContain('lc($value)')
+    expect(template).not.toContain('$lc(')
   })
 
   test('lowers .reverse().join(\' \') via bf->reverse + join (#1448 Tier A)', () => {

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1500,6 +1500,14 @@ function renderArrayMethod(
       const recv = emit(object)
       return `bf->reverse(${recv})`
     }
+    case 'toLowerCase': {
+      // Perl's native `lc` is the obvious lowering — no helper
+      // method needed. The receiver flows through `emit` so any
+      // upstream coercion (`$value`, `$bf->string(...)`, etc.)
+      // composes naturally.
+      const recv = emit(object)
+      return `lc(${recv})`
+    }
     default: {
       // TS-level exhaustiveness guard. If this throws at runtime, the
       // IR was constructed against a newer `ArrayMethod` variant that

--- a/packages/jsx/src/adapters/parsed-expr-emitter.ts
+++ b/packages/jsx/src/adapters/parsed-expr-emitter.ts
@@ -57,6 +57,7 @@ export type ArrayMethod =
   | 'slice'
   | 'reverse'
   | 'toReversed'
+  | 'toLowerCase'
 
 export type LiteralType = 'string' | 'number' | 'boolean' | 'null'
 

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -43,6 +43,7 @@ export type ParsedExpr =
         | 'slice'
         | 'reverse'
         | 'toReversed'
+        | 'toLowerCase'
       object: ParsedExpr
       args: ParsedExpr[]
     }
@@ -134,7 +135,9 @@ const UNSUPPORTED_METHODS = new Set([
   // no template-level meaning. Both lowerings always return a new
   // array — safest interpretation.
   // #1448 Tier A — String methods.
-  'toLowerCase', 'toUpperCase', 'trim',
+  // `toLowerCase` lowers via the `array-method` IR + `bf_lower`
+  // (Go) and Perl's native `lc` (Mojo).
+  'toUpperCase', 'trim',
 ])
 
 // =============================================================================
@@ -298,6 +301,14 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
       // template-level meaning; both produce a new reversed array.
       if ((callee.property === 'reverse' || callee.property === 'toReversed') && args.length === 0) {
         return { kind: 'array-method', method: callee.property, object: callee.object, args }
+      }
+      // `.toLowerCase()` — string-only (the IR carries a value-builtin
+      // tag, not a receiver-type discriminator, so the `array-method`
+      // label is a misnomer for string methods but the mechanical
+      // pipeline matches). Go uses the existing `bf_lower` helper;
+      // Mojo uses Perl's native `lc`. See #1448 Tier A.
+      if (callee.property === 'toLowerCase' && args.length === 0) {
+        return { kind: 'array-method', method: 'toLowerCase', object: callee.object, args }
       }
     }
 


### PR DESCRIPTION
## Summary

Seventh PR in the #1448 Tier A stack. Stacked on top of #1462 (`.reverse` / `.toReversed`).

`.toLowerCase()` wires through to the existing `bf_lower` Go helper (registered from a prior code path) and to Perl's native `lc` on Mojo. No new runtime helpers needed.

## Adapter emit

- **Go**: `bf_lower <recv>`
- **Mojo**: `lc($recv)` (Perl native — no helper method)

The IR carries `array-method { method: 'toLowerCase', ... }`. The `array-method` label is a misnomer for string methods but the mechanical pipeline matches — extending the discriminator keeps the dispatch type-driven and in one place.

Drops the BF101 pin for `string-toLowerCase` in both adapter conformance test files. Positive tests pin both emit shapes (Go `bf_lower .Value`; Mojo bare `lc($value)` — defensively pinning that no leaked `$lc(` form survives the test-render patch).

## Test plan

- [x] `bun test` for both adapters — green
- [ ] Perl `prove` (Test2::V0 not in sandbox; runs in CI — but no new helper added so nothing new to test here)
- [ ] End-to-end render (Go / Perl not in sandbox; runs in CI)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HJRNyteQamZmADhftGjtSJ)_