### PR TITLE
feat(#1448 Tier A): lower .toUpperCase() for strings

### DIFF
--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -166,10 +166,10 @@ runAdapterConformanceTests({
     // both share the `bf_reverse` helper since SSR templates
     // render a snapshot and the JS mutate-vs-new distinction has
     // no template-level meaning (#1448 Tier A sixth PR).
-    // `string-toLowerCase` no longer pinned — the pre-existing
-    // `bf_lower` runtime helper now wires to the JS method name
-    // at the adapter layer (#1448 Tier A seventh PR).
-    'string-toUpperCase':  [{ code: 'BF101', severity: 'error' }],
+    // `string-toLowerCase` / `string-toUpperCase` no longer pinned —
+    // pre-existing `bf_lower` / `bf_upper` runtime helpers wire to
+    // the JS method names at the adapter layer (#1448 Tier A
+    // seventh + eighth PRs).
     'string-trim':         [{ code: 'BF101', severity: 'error' }],
   },
   // `JSON_STRINGIFY_VIA_CONST` and `MATH_FLOOR_VIA_CONST` now pass
@@ -1574,7 +1574,7 @@ export { A }`)
     })
   })
 
-  describe('.toLowerCase lowering (#1448 Tier A)', () => {
+  describe('.toLowerCase / .toUpperCase lowering (#1448 Tier A)', () => {
     test('value.toLowerCase() emits `bf_lower .Value`', () => {
       // Pre-#1448: parser refused `.toLowerCase` via
       // `UNSUPPORTED_METHODS` and surfaced BF101. The runtime's
@@ -1585,6 +1585,16 @@ export { A }`)
 }
 export { A }`)
       expect(result.template).toContain('bf_lower .Value')
+    })
+
+    test('value.toUpperCase() emits `bf_upper .Value`', () => {
+      // Mirrors toLowerCase — pre-existing `bf_upper` runtime
+      // helper, JS method name wired at the adapter layer.
+      const result = compileAndGenerate(`function A({ value }: { value: string }) {
+  return <div>{value.toUpperCase()}</div>
+}
+export { A }`)
+      expect(result.template).toContain('bf_upper .Value')
     })
   })
 

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -1665,6 +1665,7 @@ import { fixture as arraySliceFixture } from '../../../adapter-tests/fixtures/me
 import { fixture as arrayReverseFixture } from '../../../adapter-tests/fixtures/methods/array-reverse'
 import { fixture as arrayToReversedFixture } from '../../../adapter-tests/fixtures/methods/array-toReversed'
 import { fixture as stringToLowerCaseFixture } from '../../../adapter-tests/fixtures/methods/string-toLowerCase'
+import { fixture as stringToUpperCaseFixture } from '../../../adapter-tests/fixtures/methods/string-toUpperCase'
 
 describe('GoTemplateAdapter - #1448 Tier A fixture-driven lowering pins', () => {
   const cases = [
@@ -1685,6 +1686,7 @@ describe('GoTemplateAdapter - #1448 Tier A fixture-driven lowering pins', () => 
     // routings catches a future divergence between them.
     { fixture: arrayToReversedFixture,  expect: 'bf_reverse .Items' },
     { fixture: stringToLowerCaseFixture,expect: 'bf_lower .Value' },
+    { fixture: stringToUpperCaseFixture,expect: 'bf_upper .Value' },
   ]
 
   for (const { fixture, expect: expectedHelper } of cases) {

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -2771,6 +2771,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         const recv = emit(object)
         return `bf_lower ${wrapIfMultiToken(recv)}`
       }
+      case 'toUpperCase': {
+        // Mirrors `toLowerCase` — pre-existing `bf_upper` runtime
+        // helper, just adapter wiring.
+        const recv = emit(object)
+        return `bf_upper ${wrapIfMultiToken(recv)}`
+      }
       default: {
         const _exhaustive: never = method
         throw new Error(`Go arrayMethod: unhandled ArrayMethod '${(_exhaustive as string)}'`)

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -131,11 +131,10 @@ runAdapterConformanceTests({
     // SSR templates render a snapshot and the JS mutate-vs-new
     // distinction has no template-level meaning (#1448 Tier A
     // sixth PR).
-    // `string-toLowerCase` no longer pinned — Perl's native `lc`
-    // is the obvious lowering (no helper method); Go uses the
-    // pre-existing `bf_lower` runtime helper (#1448 Tier A
-    // seventh PR).
-    'string-toUpperCase':  [{ code: 'BF101', severity: 'error' }],
+    // `string-toLowerCase` / `string-toUpperCase` no longer pinned —
+    // Perl's native `lc` / `uc` (Mojo) and pre-existing
+    // `bf_lower` / `bf_upper` (Go) handle the JS method names
+    // (#1448 Tier A seventh + eighth PRs).
     'string-trim':         [{ code: 'BF101', severity: 'error' }],
     // #1448 catalog — `.find` / `.findIndex` have no Mojo lowering
     // yet (no `array-method` IR variant, no emitter), so the
@@ -555,6 +554,19 @@ export { A }`, 'A.tsx', { adapter })
     const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
     expect(template).toContain('lc($value)')
     expect(template).not.toContain('$lc(')
+  })
+
+  test('lowers .toUpperCase() via Perl native uc (#1448 Tier A)', () => {
+    // Mirrors toLowerCase — Perl's `uc` builtin, no helper.
+    const adapter = new MojoAdapter()
+    const result = compileJSX(`function A({ value }: { value: string }) {
+  return <div>{value.toUpperCase()}</div>
+}
+export { A }`, 'A.tsx', { adapter })
+    expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
+    const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
+    expect(template).toContain('uc($value)')
+    expect(template).not.toContain('$uc(')
   })
 
   test('lowers .reverse().join(\' \') via bf->reverse + join (#1448 Tier A)', () => {

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -849,6 +849,7 @@ import { fixture as arraySliceFixture } from '../../../adapter-tests/fixtures/me
 import { fixture as arrayReverseFixture } from '../../../adapter-tests/fixtures/methods/array-reverse'
 import { fixture as arrayToReversedFixture } from '../../../adapter-tests/fixtures/methods/array-toReversed'
 import { fixture as stringToLowerCaseFixture } from '../../../adapter-tests/fixtures/methods/string-toLowerCase'
+import { fixture as stringToUpperCaseFixture } from '../../../adapter-tests/fixtures/methods/string-toUpperCase'
 
 describe('MojoAdapter - #1448 Tier A fixture-driven lowering pins', () => {
   const cases = [
@@ -864,6 +865,7 @@ describe('MojoAdapter - #1448 Tier A fixture-driven lowering pins', () => {
     // routings catches a future divergence between them.
     { fixture: arrayToReversedFixture,  expect: 'bf->reverse($items)' },
     { fixture: stringToLowerCaseFixture,expect: 'lc($value)' },
+    { fixture: stringToUpperCaseFixture,expect: 'uc($value)' },
   ]
 
   for (const { fixture, expect: expectedHelper } of cases) {

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1508,6 +1508,11 @@ function renderArrayMethod(
       const recv = emit(object)
       return `lc(${recv})`
     }
+    case 'toUpperCase': {
+      // Perl's native `uc` — mirrors `toLowerCase` exactly.
+      const recv = emit(object)
+      return `uc(${recv})`
+    }
     default: {
       // TS-level exhaustiveness guard. If this throws at runtime, the
       // IR was constructed against a newer `ArrayMethod` variant that

--- a/packages/jsx/src/adapters/parsed-expr-emitter.ts
+++ b/packages/jsx/src/adapters/parsed-expr-emitter.ts
@@ -58,6 +58,7 @@ export type ArrayMethod =
   | 'reverse'
   | 'toReversed'
   | 'toLowerCase'
+  | 'toUpperCase'
 
 export type LiteralType = 'string' | 'number' | 'boolean' | 'null'
 

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -44,6 +44,7 @@ export type ParsedExpr =
         | 'reverse'
         | 'toReversed'
         | 'toLowerCase'
+        | 'toUpperCase'
       object: ParsedExpr
       args: ParsedExpr[]
     }
@@ -135,9 +136,9 @@ const UNSUPPORTED_METHODS = new Set([
   // no template-level meaning. Both lowerings always return a new
   // array — safest interpretation.
   // #1448 Tier A — String methods.
-  // `toLowerCase` lowers via the `array-method` IR + `bf_lower`
-  // (Go) and Perl's native `lc` (Mojo).
-  'toUpperCase', 'trim',
+  // `toLowerCase` / `toUpperCase` lower via the `array-method` IR +
+  // `bf_lower` / `bf_upper` (Go) and Perl's native `lc` / `uc` (Mojo).
+  'trim',
 ])
 
 // =============================================================================
@@ -309,6 +310,11 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
       // Mojo uses Perl's native `lc`. See #1448 Tier A.
       if (callee.property === 'toLowerCase' && args.length === 0) {
         return { kind: 'array-method', method: 'toLowerCase', object: callee.object, args }
+      }
+      // `.toUpperCase()` — Go uses the existing `bf_upper` helper;
+      // Mojo uses Perl's native `uc`.
+      if (callee.property === 'toUpperCase' && args.length === 0) {
+        return { kind: 'array-method', method: 'toUpperCase', object: callee.object, args }
       }
     }
 


### PR DESCRIPTION
## Summary

Eighth PR in the #1448 Tier A stack. Stacked on top of #1463 (`.toLowerCase`).

Mirrors the `.toLowerCase()` lowering: wires through to the pre-existing `bf_upper` Go helper and Perl's native `uc` on Mojo. No new runtime helpers needed.

## Adapter emit

- **Go**: `bf_upper <recv>`
- **Mojo**: `uc($recv)` (Perl native — no helper method)

Drops the BF101 pin for `string-toUpperCase` in both adapter conformance test files. Positive tests pin both emit shapes; the Mojo `not.toContain('$uc(')` defensive pin mirrors the `$lc(` guard from the toLowerCase PR.

## Test plan

- [x] `bun test` for both adapters — green
- [ ] End-to-end render (Go / Perl not in sandbox; runs in CI)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HJRNyteQamZmADhftGjtSJ)_