### PR TITLE
feat(#1448 Tier A): lower .trim() for strings — closes out Tier A

### DIFF
--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -1678,6 +1678,7 @@ import { fixture as arrayReverseFixture } from '../../../adapter-tests/fixtures/
 import { fixture as arrayToReversedFixture } from '../../../adapter-tests/fixtures/methods/array-toReversed'
 import { fixture as stringToLowerCaseFixture } from '../../../adapter-tests/fixtures/methods/string-toLowerCase'
 import { fixture as stringToUpperCaseFixture } from '../../../adapter-tests/fixtures/methods/string-toUpperCase'
+import { fixture as stringTrimFixture } from '../../../adapter-tests/fixtures/methods/string-trim'
 
 describe('GoTemplateAdapter - #1448 Tier A fixture-driven lowering pins', () => {
   const cases = [
@@ -1699,6 +1700,7 @@ describe('GoTemplateAdapter - #1448 Tier A fixture-driven lowering pins', () => 
     { fixture: arrayToReversedFixture,  expect: 'bf_reverse .Items' },
     { fixture: stringToLowerCaseFixture,expect: 'bf_lower .Value' },
     { fixture: stringToUpperCaseFixture,expect: 'bf_upper .Value' },
+    { fixture: stringTrimFixture,       expect: 'bf_trim .Value' },
   ]
 
   for (const { fixture, expect: expectedHelper } of cases) {

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -170,7 +170,9 @@ runAdapterConformanceTests({
     // pre-existing `bf_lower` / `bf_upper` runtime helpers wire to
     // the JS method names at the adapter layer (#1448 Tier A
     // seventh + eighth PRs).
-    'string-trim':         [{ code: 'BF101', severity: 'error' }],
+    // `string-trim` no longer pinned — pre-existing `bf_trim`
+    // (wraps `strings.TrimSpace`) handles the strip (#1448 Tier A
+    // ninth PR, closing out Tier A).
   },
   // `JSON_STRINGIFY_VIA_CONST` and `MATH_FLOOR_VIA_CONST` now pass
   // via `GoTemplateAdapter.templatePrimitives` (#1188). The two
@@ -1595,6 +1597,16 @@ export { A }`)
 }
 export { A }`)
       expect(result.template).toContain('bf_upper .Value')
+    })
+
+    test('value.trim() emits `bf_trim .Value`', () => {
+      // Pre-existing `bf_trim` (wraps `strings.TrimSpace`); only
+      // adapter wiring is new.
+      const result = compileAndGenerate(`function A({ value }: { value: string }) {
+  return <div>[{value.trim()}]</div>
+}
+export { A }`)
+      expect(result.template).toContain('bf_trim .Value')
     })
   })
 

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -2777,6 +2777,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         const recv = emit(object)
         return `bf_upper ${wrapIfMultiToken(recv)}`
       }
+      case 'trim': {
+        // Pre-existing `bf_trim` runtime helper (wraps
+        // `strings.TrimSpace`). Adapter wiring only.
+        const recv = emit(object)
+        return `bf_trim ${wrapIfMultiToken(recv)}`
+      }
       default: {
         const _exhaustive: never = method
         throw new Error(`Go arrayMethod: unhandled ArrayMethod '${(_exhaustive as string)}'`)

--- a/packages/adapter-mojolicious/lib/BarefootJS.pm
+++ b/packages/adapter-mojolicious/lib/BarefootJS.pm
@@ -484,6 +484,24 @@ sub reverse ($self, $recv) {
     return [ reverse @$recv ];
 }
 
+# `String.prototype.trim()` — strip leading + trailing whitespace.
+# JS's `String.prototype.trim` matches `\s` in the Unicode sense
+# (any whitespace including non-breaking space U+00A0); Perl's `\s`
+# inside a regex with `/u` flag is the same. Undef receivers return
+# the empty string (matches JS's `String(undefined).trim()` which
+# would be "undefined" → "undefined", but in our template context
+# undef commonly means "missing prop"; rendering the empty string
+# is the safer choice and mirrors the JS-compat divergence we
+# already document for `bf->string(undef) === ""`).
+
+sub trim ($self, $recv) {
+    return '' unless defined $recv;
+    return '' if ref($recv);
+    my $s = "$recv";
+    $s =~ s/^\s+|\s+$//gu;
+    return $s;
+}
+
 # ---------------------------------------------------------------------------
 # JSX intrinsic-element spread (#1407)
 # ---------------------------------------------------------------------------

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -867,6 +867,7 @@ import { fixture as arrayReverseFixture } from '../../../adapter-tests/fixtures/
 import { fixture as arrayToReversedFixture } from '../../../adapter-tests/fixtures/methods/array-toReversed'
 import { fixture as stringToLowerCaseFixture } from '../../../adapter-tests/fixtures/methods/string-toLowerCase'
 import { fixture as stringToUpperCaseFixture } from '../../../adapter-tests/fixtures/methods/string-toUpperCase'
+import { fixture as stringTrimFixture } from '../../../adapter-tests/fixtures/methods/string-trim'
 
 describe('MojoAdapter - #1448 Tier A fixture-driven lowering pins', () => {
   const cases = [
@@ -883,6 +884,7 @@ describe('MojoAdapter - #1448 Tier A fixture-driven lowering pins', () => {
     { fixture: arrayToReversedFixture,  expect: 'bf->reverse($items)' },
     { fixture: stringToLowerCaseFixture,expect: 'lc($value)' },
     { fixture: stringToUpperCaseFixture,expect: 'uc($value)' },
+    { fixture: stringTrimFixture,       expect: 'bf->trim($value)' },
   ]
 
   for (const { fixture, expect: expectedHelper } of cases) {

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -135,7 +135,9 @@ runAdapterConformanceTests({
     // Perl's native `lc` / `uc` (Mojo) and pre-existing
     // `bf_lower` / `bf_upper` (Go) handle the JS method names
     // (#1448 Tier A seventh + eighth PRs).
-    'string-trim':         [{ code: 'BF101', severity: 'error' }],
+    // `string-trim` no longer pinned — pre-existing `bf_trim`
+    // (Go) and new `bf->trim` helper (Mojo) handle the strip
+    // (#1448 Tier A ninth PR, closing out Tier A).
     // #1448 catalog — `.find` / `.findIndex` have no Mojo lowering
     // yet (no `array-method` IR variant, no emitter), so the
     // Mojo-specific gate in `convertExpressionToPerl` refuses them
@@ -567,6 +569,21 @@ export { A }`, 'A.tsx', { adapter })
     const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
     expect(template).toContain('uc($value)')
     expect(template).not.toContain('$uc(')
+  })
+
+  test('lowers .trim() via bf->trim helper (#1448 Tier A)', () => {
+    // No native Perl `trim`; the helper wraps a single regex so an
+    // undef receiver (common for missing-prop case) doesn't trigger
+    // a substitution-on-undef warning.
+    const adapter = new MojoAdapter()
+    const result = compileJSX(`function A({ value }: { value: string }) {
+  return <div>[{value.trim()}]</div>
+}
+export { A }`, 'A.tsx', { adapter })
+    expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
+    const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
+    expect(template).toContain('bf->trim($value)')
+    expect(template).not.toContain('$bf->trim')
   })
 
   test('lowers .reverse().join(\' \') via bf->reverse + join (#1448 Tier A)', () => {

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1513,6 +1513,14 @@ function renderArrayMethod(
       const recv = emit(object)
       return `uc(${recv})`
     }
+    case 'trim': {
+      // No Perl native `trim`; route through the `bf->trim`
+      // helper so the regex stays in one place (and so an undef
+      // receiver doesn't trigger a warning about applying `s///`
+      // to undef).
+      const recv = emit(object)
+      return `bf->trim(${recv})`
+    }
     default: {
       // TS-level exhaustiveness guard. If this throws at runtime, the
       // IR was constructed against a newer `ArrayMethod` variant that

--- a/packages/adapter-mojolicious/t/template_primitives.t
+++ b/packages/adapter-mojolicious/t/template_primitives.t
@@ -220,4 +220,27 @@ subtest 'reverse — new array ref in reverse order' => sub {
     is $bf->reverse({a => 1}),      [], 'hash ref receiver → empty';
 };
 
+# `String.prototype.trim()` — strip leading + trailing whitespace
+# (#1448 Tier A). Padding both sides of the test input so a
+# trim-front-only or trim-back-only regression fails here.
+subtest 'trim — strip leading + trailing whitespace' => sub {
+    is $bf->trim('   padded   '),      'padded',         'leading + trailing spaces';
+    is $bf->trim("\t\nleading"),       'leading',        'leading tab + newline';
+    is $bf->trim('trailing  '),        'trailing',       'trailing spaces only';
+    is $bf->trim('no-pad'),            'no-pad',         'no whitespace passthrough';
+    is $bf->trim('   '),               '',               'all whitespace → empty';
+    is $bf->trim(''),                  '',               'empty input → empty';
+
+    # Inner whitespace is preserved — only the boundaries are stripped.
+    is $bf->trim('  hello  world  '),  'hello  world',   'inner spaces preserved';
+
+    # Non-string receivers.
+    is $bf->trim(undef),               '',               'undef receiver → empty';
+    is $bf->trim({a => 1}),            '',               'hash ref receiver → empty';
+    is $bf->trim(['arr']),             '',               'array ref receiver → empty';
+
+    # Numeric coercion: JS would stringify `42.trim()` first.
+    is $bf->trim(42),                  '42',             'numeric receiver stringifies';
+};
+
 done_testing;

--- a/packages/jsx/src/adapters/parsed-expr-emitter.ts
+++ b/packages/jsx/src/adapters/parsed-expr-emitter.ts
@@ -59,6 +59,7 @@ export type ArrayMethod =
   | 'toReversed'
   | 'toLowerCase'
   | 'toUpperCase'
+  | 'trim'
 
 export type LiteralType = 'string' | 'number' | 'boolean' | 'null'
 

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -45,6 +45,7 @@ export type ParsedExpr =
         | 'toReversed'
         | 'toLowerCase'
         | 'toUpperCase'
+        | 'trim'
       object: ParsedExpr
       args: ParsedExpr[]
     }
@@ -138,7 +139,8 @@ const UNSUPPORTED_METHODS = new Set([
   // #1448 Tier A — String methods.
   // `toLowerCase` / `toUpperCase` lower via the `array-method` IR +
   // `bf_lower` / `bf_upper` (Go) and Perl's native `lc` / `uc` (Mojo).
-  'trim',
+  // `trim` lowers via the `array-method` IR + `bf_trim` (Go) and a
+  // Perl regex strip (Mojo).
 ])
 
 // =============================================================================
@@ -315,6 +317,12 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
       // Mojo uses Perl's native `uc`.
       if (callee.property === 'toUpperCase' && args.length === 0) {
         return { kind: 'array-method', method: 'toUpperCase', object: callee.object, args }
+      }
+      // `.trim()` — Go uses the existing `bf_trim` helper; Mojo uses
+      // a new `bf->trim` method that mirrors JS's "strip leading +
+      // trailing whitespace" semantic via a Perl regex.
+      if (callee.property === 'trim' && args.length === 0) {
+        return { kind: 'array-method', method: 'trim', object: callee.object, args }
       }
     }
 


### PR DESCRIPTION
## Summary

Ninth and final PR in the #1448 Tier A stack. Stacked on top of #1464 (`.toUpperCase`).

With this PR every checkbox in the Tier A section of #1448 has a lowering on both template-language adapters.

`.trim()` wires through to the pre-existing `bf_trim` Go helper and to a new Mojo helper. Perl has no native `trim` builtin — using a helper keeps the regex in one place and lets the receiver be undef without a substitution-on-undef warning at every call site.

## Adapter emit

- **Go**: `bf_trim <recv>`
- **Mojo**: `bf->trim($recv)`

## Runtime helpers

- **Go**: `Trim` already existed (wraps `strings.TrimSpace`).
- **Mojo**: new `trim($recv)` method on BarefootJS. Strips `\s` in the Unicode sense (matches JS's behaviour for non-breaking space / etc.). Undef receivers return the empty string — same documented divergence as `bf->string(undef) === ""`, the safer choice for the missing-prop case in SSR templates.

Drops the BF101 pin for `string-trim` in both adapter conformance test files. Positive tests pin both emit shapes; Perl tests cover the leading-only / trailing-only / all-whitespace / inner-spaces-preserved / numeric-coercion surface.

## Tier A status after merge

| Method | PR |
|---|---|
| `.includes(x)` (array + string) | #1457 |
| `.indexOf(x)` / `.lastIndexOf(x)` | #1458 |
| `.at(i)` | #1459 |
| `.concat(other)` | #1460 |
| `.slice(start, end?)` | #1461 |
| `.reverse()` / `.toReversed()` | #1462 |
| `.toLowerCase()` | #1463 |
| `.toUpperCase()` | #1464 |
| `.trim()` | **this PR (#1465)** |

## Test plan

- [x] `bun test` for both adapters — green
- [ ] Perl `prove` (Test2::V0 not in sandbox; runs in CI)
- [ ] End-to-end render (Go / Perl not in sandbox; runs in CI)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HJRNyteQamZmADhftGjtSJ)_