### PR TITLE
feat(cli/#1454): PM-aware test-runner selection in scaffold + gen test

### DIFF
--- a/docs/core/core-concepts/ai-native.md
+++ b/docs/core/core-concepts/ai-native.md
@@ -58,7 +58,7 @@ search → docs → add → <pm> test → debug
 bf search dialog          # find a component in the registry + docs
 bf docs dialog            # read its API (props, examples, a11y)
 bf add dialog             # copy it into your project
-bun test                  # verify the IR (or `npm test` / `pnpm test` / `yarn test`)
+<pm> test                 # verify the IR (bun test / npm test / pnpm test / yarn test)
 bf debug graph dialog     # inspect reactivity
 ```
 

--- a/docs/core/core-concepts/ai-native.md
+++ b/docs/core/core-concepts/ai-native.md
@@ -14,6 +14,8 @@ BarefootJS is designed so both humans and AI agents can build components without
 
 `renderToTest()` verifies component structure, signals, events, and accessibility against the compiler's IR — in milliseconds, without a browser. Real interactions and visual behavior still need E2E tests, but structural issues are caught before you get there:
 
+> **Test runner**: the snippet below uses `bun:test`. `bf init` picks the runner that matches your package manager — bun users get `bun:test`, everyone else gets [Vitest](https://vitest.dev) (`from 'vitest'`). The surfaces are API-compatible, so swap the import line if you're following along under npm / pnpm / yarn. `bf gen test` and `bf gen component` emit the right line for you.
+
 ```tsx
 import { describe, test, expect } from 'bun:test'
 import { readFileSync } from 'fs'
@@ -49,14 +51,14 @@ Install via `npm create barefootjs@latest`. Run `bf --help` for the full command
 A typical component task is one straight line:
 
 ```
-search → docs → add → bun test → debug
+search → docs → add → <pm> test → debug
 ```
 
 ```bash
 bf search dialog          # find a component in the registry + docs
 bf docs dialog            # read its API (props, examples, a11y)
 bf add dialog             # copy it into your project
-bun test                  # verify the IR
+bun test                  # verify the IR (or `npm test` / `pnpm test` / `yarn test`)
 bf debug graph dialog     # inspect reactivity
 ```
 
@@ -74,7 +76,7 @@ bf docs field --json
 bf docs switch --json
 bf gen component settings-form field switch label
 # edit components/ui/settings-form/index.tsx
-bun test components/ui/settings-form/index.test.tsx
+bun test components/ui/settings-form/index.test.tsx   # or `npm test -- <path>`, `pnpm test <path>`, etc.
 bf debug graph settings-form
 ```
 

--- a/packages/cli/src/__tests__/gen-test.test.ts
+++ b/packages/cli/src/__tests__/gen-test.test.ts
@@ -124,4 +124,51 @@ describe('bf gen test', () => {
       logSpy.mockRestore()
     }
   })
+
+  // PM-aware import selection (issue #1454): the emitted test's
+  // `import { describe, ... } from '<runner>'` line follows the
+  // detected PM. Bun ships an in-runtime runner (`bun:test`); every
+  // other PM gets `vitest` paired with the `vitest run` script that
+  // `bf init` wires up. The lockfile is the strongest detection
+  // signal, so each case below pins one to fix the runner choice.
+  describe('PM-aware test-runner import (issue #1454)', () => {
+    function setup(lockfile: string): void {
+      writeFileSync(path.join(projectDir, lockfile), '')
+      mkdirSync(path.join(projectDir, 'components'), { recursive: true })
+      writeFileSync(
+        path.join(projectDir, 'components/Counter.tsx'),
+        `export function Counter() { return <div /> }`,
+      )
+    }
+
+    test('bun.lock → emits `from \'bun:test\'`', () => {
+      setup('bun.lock')
+      const logSpy = spyOn(console, 'log').mockImplementation(() => {})
+      try {
+        run(['Counter'], ctxFor())
+        const content = readFileSync(path.join(projectDir, 'components/Counter.test.tsx'), 'utf-8')
+        expect(content).toContain(`from 'bun:test'`)
+        expect(content).not.toContain(`from 'vitest'`)
+      } finally {
+        logSpy.mockRestore()
+      }
+    })
+
+    test.each([
+      ['package-lock.json', 'npm'],
+      ['pnpm-lock.yaml', 'pnpm'],
+      ['yarn.lock', 'yarn'],
+    ])('%s (%s) → emits `from \'vitest\'`', (lockfile) => {
+      setup(lockfile)
+      const logSpy = spyOn(console, 'log').mockImplementation(() => {})
+      try {
+        run(['Counter'], ctxFor())
+        const content = readFileSync(path.join(projectDir, 'components/Counter.test.tsx'), 'utf-8')
+        expect(content).toContain(`from 'vitest'`)
+        expect(content).not.toContain(`from 'bun:test'`)
+      } finally {
+        logSpy.mockRestore()
+      }
+    })
+  })
 })

--- a/packages/cli/src/__tests__/pm.test.ts
+++ b/packages/cli/src/__tests__/pm.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
 import { mkdirSync, writeFileSync, rmSync } from 'fs'
 import path from 'path'
 import os from 'os'
-import { detectPackageManager, detectInvokingPackageManager, commandsFor } from '../lib/pm'
+import { detectPackageManager, detectInvokingPackageManager, commandsFor, testRunnerFor } from '../lib/pm'
 
 // Empty env keeps lockfile-detection tests independent of how the test
 // runner itself was launched (e.g. `bun test` sets npm_config_user_agent).
@@ -168,4 +168,42 @@ describe('commandsFor', () => {
     expect(commandsFor('yarn').test('components/Foo.test.tsx'))
       .toBe('yarn test components/Foo.test.tsx')
   })
+})
+
+// `testRunnerFor` centralises the bun-vs-vitest decision used by
+// `bf init` (`package.json#scripts.test`, devDeps, tsconfig types
+// entry) and the `bf gen test` / `bf gen component` code generators
+// (the `import { describe, ... } from '<runner>'` line they emit).
+// Keeping it as a pure data function lets every caller stay in
+// lock-step without re-deriving the branch.
+describe('testRunnerFor', () => {
+  test('bun: ships `bun:test` import + `bun test` script + `@types/bun` + `, "bun-types"` types entry', () => {
+    const r = testRunnerFor('bun')
+    expect(r.importSource).toBe('bun:test')
+    expect(r.scriptValue).toBe('bun test')
+    expect(r.devDeps).toEqual({ '@types/bun': '^1.1.0' })
+    // The slot prefix carries its own separator so the empty case
+    // still resolves to a valid JSON array.
+    expect(r.typesEntry).toBe(', "bun-types"')
+  })
+
+  // npm / pnpm / yarn share the vitest path — none of them ships an
+  // in-runtime test runner, and vitest's surface is API-compatible
+  // with `bun:test` so the same generated file runs unchanged.
+  test.each(['npm', 'pnpm', 'yarn'] as const)(
+    '%s: ships `vitest` import + `vitest run` script + vitest devDep + empty types entry',
+    (pm) => {
+      const r = testRunnerFor(pm)
+      expect(r.importSource).toBe('vitest')
+      // `vitest run` (not bare `vitest`) so CI doesn't hang in watch.
+      expect(r.scriptValue).toBe('vitest run')
+      expect(r.devDeps).toHaveProperty('vitest')
+      // Vitest types come from the `vitest` import; no ambient entry
+      // needed.
+      expect(r.typesEntry).toBe('')
+      // Negative guard: don't accidentally ship bun's type package
+      // to non-bun users.
+      expect(r.devDeps).not.toHaveProperty('@types/bun')
+    },
+  )
 })

--- a/packages/cli/src/__tests__/scaffold-layout.test.ts
+++ b/packages/cli/src/__tests__/scaffold-layout.test.ts
@@ -71,4 +71,22 @@ describe('scaffold (componentsBasePath wiring)', () => {
     expect(result.componentPath).toBe('components/ui/my-card/index.tsx')
     expect(result.testPath).toBe('components/ui/my-card/index.test.tsx')
   })
+
+  // PM-aware import selection (issue #1454): the emitted test's
+  // `import { describe, ... } from '<runner>'` line follows the
+  // runner `bf gen component` picks from `testRunnerFor(pm)`.
+  // Default stays `bun:test` so existing callers behave unchanged.
+  test('defaults the emitted test header to `from \'bun:test\'`', () => {
+    const result = scaffold('my-card', [], '', 'components/ui')
+    expect(result.testCode).toContain(`from 'bun:test'`)
+    expect(result.testCode).not.toContain(`from 'vitest'`)
+  })
+
+  test('testImportSource swaps the header for non-bun scaffolds', () => {
+    const result = scaffold('my-card', [], '', 'components/ui', {
+      testImportSource: 'vitest',
+    })
+    expect(result.testCode).toContain(`import { describe, test, expect } from 'vitest'`)
+    expect(result.testCode).not.toContain(`from 'bun:test'`)
+  })
 })

--- a/packages/cli/src/__tests__/test-template.test.ts
+++ b/packages/cli/src/__tests__/test-template.test.ts
@@ -14,10 +14,12 @@ let workdir: string
 beforeEach(() => { workdir = mkdtempSync(path.join(tmpdir(), 'bf-test-template-')) })
 afterEach(() => { rmSync(workdir, { recursive: true, force: true }) })
 
-function tplFor(source: string, fileName = 'Component.tsx'): string {
+function tplFor(source: string, fileName = 'Component.tsx', importSource?: string): string {
   const filePath = path.join(workdir, fileName)
   writeFileSync(filePath, source)
-  return generateTestTemplate(filePath)
+  return importSource
+    ? generateTestTemplate(filePath, { importSource })
+    : generateTestTemplate(filePath)
 }
 
 describe('generateTestTemplate', () => {
@@ -64,5 +66,25 @@ describe('generateTestTemplate', () => {
     `, 'index.tsx')
     expect(tpl).toContain(`describe('Slot'`)
     expect(tpl).toContain(`expect(result.root.tag).toBe('div')`)
+  })
+
+  // The import source is parameterised so `bf gen test` can emit a
+  // `from 'vitest'` line for non-bun PMs (issue #1454). Defaults to
+  // `bun:test` so existing callers and the snapshot-style tests above
+  // behave unchanged.
+  test('defaults to a `from \'bun:test\'` header', () => {
+    const tpl = tplFor(`export function Foo() { return <div /> }`, 'Foo.tsx')
+    expect(tpl).toContain(`from 'bun:test'`)
+    expect(tpl).not.toContain(`from 'vitest'`)
+  })
+
+  test('importSource: \'vitest\' swaps the header for non-bun scaffolds', () => {
+    const tpl = tplFor(
+      `export function Foo() { return <div /> }`,
+      'Foo.tsx',
+      'vitest',
+    )
+    expect(tpl).toContain(`import { describe, test, expect } from 'vitest'`)
+    expect(tpl).not.toContain(`from 'bun:test'`)
   })
 })

--- a/packages/cli/src/commands/gen-component.ts
+++ b/packages/cli/src/commands/gen-component.ts
@@ -5,7 +5,7 @@ import path from 'path'
 import type { CliContext } from '../context'
 import { scaffold } from '../lib/scaffold'
 import { resolveScaffoldLayout } from '../lib/scaffold-layout'
-import { commandsFor, detectPackageManager } from '../lib/pm'
+import { commandsFor, detectPackageManager, testRunnerFor } from '../lib/pm'
 
 export function run(args: string[], ctx: CliContext): void {
   if (args.length < 2) {
@@ -16,7 +16,15 @@ export function run(args: string[], ctx: CliContext): void {
 
   const [componentName, ...useComponents] = args
   const { writeRoot, componentsBasePath } = resolveScaffoldLayout(ctx)
-  const result = scaffold(componentName, useComponents, ctx.metaDir, componentsBasePath)
+  // PM detection drives both the emitted test file's import source
+  // (`bun:test` vs. `vitest`) and the "Next steps" hint below, so the
+  // generated test matches the runner the project's `test` script is
+  // wired up to. See `testRunnerFor` in `../lib/pm.ts`.
+  const pm = detectPackageManager(ctx.projectDir ?? ctx.root)
+  const runner = testRunnerFor(pm)
+  const result = scaffold(componentName, useComponents, ctx.metaDir, componentsBasePath, {
+    testImportSource: runner.importSource,
+  })
 
   // Write component file
   const componentAbsPath = path.join(writeRoot, result.componentPath)
@@ -38,7 +46,6 @@ export function run(args: string[], ctx: CliContext): void {
   // Detected PM controls the test-run hint so the suggestion lines up
   // with whatever the user has committed to (lockfile-first), instead of
   // prescribing `bun test` regardless.
-  const pm = detectPackageManager(ctx.projectDir ?? ctx.root)
   const testCmd = commandsFor(pm).test(result.testPath)
 
   console.log(`Created:`)

--- a/packages/cli/src/commands/gen-test.ts
+++ b/packages/cli/src/commands/gen-test.ts
@@ -5,7 +5,7 @@ import path from 'path'
 import type { CliContext } from '../context'
 import { resolveComponentSource } from '../lib/resolve-source'
 import { generateTestTemplate } from '../lib/test-template'
-import { commandsFor, detectPackageManager } from '../lib/pm'
+import { commandsFor, detectPackageManager, testRunnerFor } from '../lib/pm'
 
 export function run(args: string[], ctx: CliContext): void {
   // Two surfacing modes for the generated IR test:
@@ -38,7 +38,13 @@ export function run(args: string[], ctx: CliContext): void {
     process.exit(1)
   }
 
-  const content = generateTestTemplate(resolved.filePath)
+  // PM detection drives both the emitted test file's import source
+  // (`bun:test` vs. `vitest`) and the "Next steps" hint below, so the
+  // generated file matches the runner the user's package.json `test`
+  // script is wired up to. See `testRunnerFor` in `../lib/pm.ts`.
+  const pm = detectPackageManager(ctx.projectDir ?? ctx.root)
+  const runner = testRunnerFor(pm)
+  const content = generateTestTemplate(resolved.filePath, { importSource: runner.importSource })
 
   if (writeToStdout) {
     console.log(content)
@@ -67,6 +73,5 @@ export function run(args: string[], ctx: CliContext): void {
   // to (lockfile-first, falling back to the PM that spawned this CLI).
   // Hard-coding `bun test` was prescriptive in a project that explicitly
   // supports npm / pnpm / yarn / bun.
-  const pm = detectPackageManager(ctx.projectDir ?? ctx.root)
   console.log(`Next: ${commandsFor(pm).test(rel)}`)
 }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -23,7 +23,7 @@ import {
   DEFAULT_CSS_LIBRARY,
   type AdapterTemplate,
 } from '../lib/templates'
-import { detectPackageManager, commandsFor, type PackageManager } from '../lib/pm'
+import { detectPackageManager, commandsFor, testRunnerFor, type PackageManager } from '../lib/pm'
 import { select, SelectCancelled } from '../lib/select'
 import { startSpinner } from '../lib/spinner'
 
@@ -233,18 +233,19 @@ async function scaffoldApp(
   const rawName = flags.name || path.basename(projectDir)
   const pkgName = path.basename(rawName).replace(/[^a-z0-9-_]/gi, '-').toLowerCase() || 'barefoot-app'
 
-  // Resolve PM up-front so file substitution and devDep selection both
-  // see the same answer. (Scripts use it too further down.) The
-  // adapter tsconfig templates carry a `{{__PM_TYPES_ENTRY__}}` slot
-  // for PM-specific type packages that need to land in the `types`
-  // array — today only bun contributes (`, "bun-types"` so
-  // `bf gen test`-emitted `import 'bun:test'` lines type-check),
-  // and every other PM resolves the slot to an empty string. If a
-  // future PM / test runner needs its own module declarations, add
-  // a branch to `pmTypesEntry` here rather than threading another
-  // placeholder through the adapter templates.
+  // Resolve PM up-front so file substitution, the test runner choice,
+  // and devDep selection all see the same answer. (Scripts use it too
+  // further down.) `testRunnerFor(pm)` centralises the bun-vs-vitest
+  // branch — it owns the import specifier `bf gen test` writes
+  // (`bun:test` for bun, `vitest` everywhere else), the
+  // `package.json#scripts.test` value, the extra devDeps the scaffold
+  // adds, and the `{{__PM_TYPES_ENTRY__}}` slot the adapter tsconfigs
+  // carry. Keeping the decision in one place means scaffold + the
+  // generators below stay aligned over time without each one
+  // re-deriving the runner.
   const pm = detectPackageManager(projectDir)
-  const pmTypesEntry = pm === 'bun' ? ', "bun-types"' : ''
+  const runner = testRunnerFor(pm)
+  const pmTypesEntry = runner.typesEntry
 
   // Adapter-contributed files (server, components/Counter, barefoot.config.ts, etc.)
   for (const [relPath, contents] of Object.entries(adapter.files)) {
@@ -280,15 +281,14 @@ async function scaffoldApp(
     resolvedAdapterScripts[k] = typeof v === 'function' ? v(pm) : v
   }
 
-  // PM-specific devDependencies. The adapter map keeps these out by
-  // default so a fresh `npm create` project doesn't carry deps that
-  // only make sense under a different runtime. Today only bun pulls
-  // anything in (`@types/bun` to match the `"bun-types"` types
-  // entry pmTypesEntry above contributes); other PMs end up with the
-  // adapter's base devDeps and nothing extra. Pair any new branch
-  // here with the corresponding `pmTypesEntry` arm above.
-  const pmDevDeps: Record<string, string> =
-    pm === 'bun' ? { '@types/bun': '^1.1.0' } : {}
+  // PM-specific devDependencies sourced from the runner config. The
+  // adapter map keeps these out by default so the registered surface
+  // stays PM-agnostic. For bun: `@types/bun` (paired with the
+  // `"bun-types"` entry pmTypesEntry above contributes). For everyone
+  // else: `vitest` — its `describe` / `test` / `expect` surface is
+  // API-compatible with the `bun:test` line `bf gen test` would
+  // otherwise emit, so the same generated file runs under any PM.
+  const pmDevDeps: Record<string, string> = runner.devDeps
 
   const pkgJson = {
     name: pkgName,
@@ -303,13 +303,13 @@ async function scaffoldApp(
       // only needs the BarefootJS asset pipeline to keep pace.
       watch:
         'concurrently -k -n build,uno -c blue,magenta "bf build --watch" "unocss --watch"',
-      // `bf gen component` writes `*.test.tsx` using `bun:test`, and the
-      // AI-native workflow doc (`bf guide core-concepts/ai-native`)
-      // points users at `bun test` as step 4 of the loop. Default the
-      // scaffold's `test` script to the same so `npm test` / `bun run
-      // test` Just Works after the first generated component, instead
-      // of falling back to the "no tests yet" placeholder (#1403).
-      test: 'bun test',
+      // `test` is wired to the runner that matches the user's package
+      // manager — `bun test` for bun, `vitest run` for npm / pnpm /
+      // yarn. The matching `bf gen component` / `bf gen test` output
+      // imports from the same runner (`bun:test` vs. `vitest`), so the
+      // very first generated test file Just Works after `<pm> install`
+      // without manual migration. See `testRunnerFor` in `../lib/pm.ts`.
+      test: runner.scriptValue,
     },
     dependencies: { ...adapter.dependencies },
     devDependencies: { ...adapter.devDependencies, ...pmDevDeps },

--- a/packages/cli/src/lib/adapters/hono.ts
+++ b/packages/cli/src/lib/adapters/hono.ts
@@ -122,8 +122,8 @@ const HONO_TSCONFIG = `{
     // which exposes types via its own package — no \`types\` array
     // entry needed, so the slot collapses to an empty string. The
     // bun-vs-vitest decision lives in \`testRunnerFor\` in
-    // \`init.ts\`'s pm module; future runners plug into the same
-    // slot there rather than baking another placeholder in here.
+    // \`packages/cli/src/lib/pm.ts\`; future runners plug into the
+    // same slot there rather than baking another placeholder in here.
     "types": ["@cloudflare/workers-types"{{__PM_TYPES_ENTRY__}}],
     "strict": true,
     "skipLibCheck": true,

--- a/packages/cli/src/lib/adapters/hono.ts
+++ b/packages/cli/src/lib/adapters/hono.ts
@@ -117,11 +117,13 @@ const HONO_TSCONFIG = `{
     // \`{{__PM_TYPES_ENTRY__}}\` for any extra type packages the
     // user's detected package manager wants pulled in. Today only
     // bun contributes (\`, "bun-types"\` so \`bf gen test\`-emitted
-    // \`import 'bun:test'\` lines type-check); npm / pnpm / yarn
-    // collapse the slot to an empty string and ship a clean
-    // \`types\` array. If a future PM / test runner needs its own
-    // module declarations, plug them into the same slot in
-    // \`init.ts\` rather than baking another placeholder here.
+    // \`import 'bun:test'\` lines type-check); npm / pnpm / yarn get
+    // \`vitest\` as their test runner and import \`from 'vitest'\`,
+    // which exposes types via its own package — no \`types\` array
+    // entry needed, so the slot collapses to an empty string. The
+    // bun-vs-vitest decision lives in \`testRunnerFor\` in
+    // \`init.ts\`'s pm module; future runners plug into the same
+    // slot there rather than baking another placeholder in here.
     "types": ["@cloudflare/workers-types"{{__PM_TYPES_ENTRY__}}],
     "strict": true,
     "skipLibCheck": true,
@@ -232,14 +234,15 @@ export const HONO_ADAPTER: AdapterTemplate = {
     '@cloudflare/workers-types': '^4.20250101.0',
     // `@barefootjs/test` powers `renderToTest()` — the canonical
     // millisecond IR test the docs (and `bf gen test`) point new users
-    // at. Without it the scaffold's `bun test` is a no-op and any
+    // at. Without it the scaffold's `test` script is a no-op and any
     // generated `index.test.tsx` fails with a module-not-found error.
     '@barefootjs/test': 'latest',
-    // `@types/bun` is added by init.ts only when the detected PM is
-    // bun — paired with the conditional `"bun-types"` entry in
-    // tsconfig.json's `types` array. Keeping it out of the static
-    // adapter map avoids shipping a bun-only dep to npm / pnpm / yarn
-    // users who never invoke `bun test`.
+    // PM-specific test-runner deps (today: `@types/bun` for bun,
+    // `vitest` for npm / pnpm / yarn) are added by init.ts via
+    // `testRunnerFor(pm)`. Keeping them out of the static adapter map
+    // means the registered surface stays PM-agnostic — a bun project
+    // doesn't ship vitest, and an npm project doesn't ship a bun-only
+    // type package.
     concurrently: '^9.0.0',
     typescript: '^5.6.0',
   },

--- a/packages/cli/src/lib/pm.ts
+++ b/packages/cli/src/lib/pm.ts
@@ -108,3 +108,60 @@ export function commandsFor(pm: PackageManager): PmCommands {
       }
   }
 }
+
+/**
+ * Per-PM test-runner configuration for the scaffold + `bf gen test` /
+ * `bf gen component` code generators.
+ *
+ * Bun ships an in-runtime test runner (`bun:test`), so a bun-first user
+ * scaffolds with `test: 'bun test'` + `import 'bun:test'` and no extra
+ * devDeps beyond `@types/bun` (for the module declaration). Every other
+ * PM lacks an in-runtime runner, so we default to Vitest — its
+ * `describe` / `test` / `expect` surface is API-compatible with the
+ * `bun:test` line `bf gen test` would otherwise emit, so the generated
+ * file just works after `npm install` without any per-runner config.
+ *
+ * Centralising the decision here keeps scaffold (`init.ts`), `bf gen
+ * test`, and `bf gen component` consistent: each one calls
+ * `testRunnerFor(pm)` and reads the field it needs, instead of duplicating
+ * the bun-vs-vitest branch at every call site (and drifting over time).
+ */
+export interface TestRunner {
+  /** Import specifier the generated `*.test.tsx` puts on its header line. */
+  importSource: string
+  /** `package.json#scripts.test` value `bf init` writes for this PM. */
+  scriptValue: string
+  /**
+   * devDependencies the scaffold adds for this PM. Bun: `@types/bun`
+   * (for the `bun:test` module declaration); others: `vitest`.
+   */
+  devDeps: Record<string, string>
+  /**
+   * Comma-prefixed entry appended into the tsconfig `types` array (the
+   * `{{__PM_TYPES_ENTRY__}}` slot in adapter tsconfigs). Bun needs
+   * `, "bun-types"` so `import 'bun:test'` lines type-check; vitest
+   * surfaces its types via the regular `from 'vitest'` import path, so
+   * the slot collapses to an empty string.
+   */
+  typesEntry: string
+}
+
+export function testRunnerFor(pm: PackageManager): TestRunner {
+  if (pm === 'bun') {
+    return {
+      importSource: 'bun:test',
+      scriptValue: 'bun test',
+      devDeps: { '@types/bun': '^1.1.0' },
+      typesEntry: ', "bun-types"',
+    }
+  }
+  // Vitest's default `vitest` command runs in watch mode; `vitest run`
+  // mirrors `bun test`'s "run once, exit" semantics so `<pm> test` in CI
+  // doesn't hang waiting for stdin.
+  return {
+    importSource: 'vitest',
+    scriptValue: 'vitest run',
+    devDeps: { vitest: '^2.0.0' },
+    typesEntry: '',
+  }
+}

--- a/packages/cli/src/lib/scaffold.ts
+++ b/packages/cli/src/lib/scaffold.ts
@@ -26,6 +26,17 @@ export interface ScaffoldResult {
   testPath: string
 }
 
+export interface ScaffoldOptions {
+  /**
+   * Import specifier the emitted `*.test.tsx` uses for `describe` /
+   * `test` / `expect`. Defaults to `bun:test` so existing callers
+   * behave unchanged; `bf gen component` overrides it via
+   * `testRunnerFor(pm)` so non-bun scaffolds emit a `from 'vitest'`
+   * line that resolves under `npm install`.
+   */
+  testImportSource?: string
+}
+
 /**
  * Generate a component skeleton and basic IR test.
  * @param componentName - Name for the new component (kebab-case, e.g. "settings-form")
@@ -36,12 +47,14 @@ export interface ScaffoldResult {
  *   relative to the project root. Monorepo: `ui/components/ui` (default).
  *   Scaffolded app: pass `barefoot.config.ts`'s `paths.components`
  *   (typically `components/ui`) so files don't land in `node_modules/ui/...`.
+ * @param options - Per-runner overrides for the emitted test file.
  */
 export function scaffold(
   componentName: string,
   useComponents: string[],
   metaDir: string,
   componentsBasePath: string = 'ui/components/ui',
+  options: ScaffoldOptions = {},
 ): ScaffoldResult {
   const metas = useComponents.map(name => ({ name, meta: loadMeta(metaDir, name) }))
   const found = metas.filter(m => m.meta !== null) as { name: string; meta: ComponentMeta }[]
@@ -57,7 +70,7 @@ export function scaffold(
   const componentCode = generateComponentCode(componentName, imports, needsClient, notFound)
 
   // Generate test code
-  const testCode = generateTestCode(componentName, needsClient)
+  const testCode = generateTestCode(componentName, needsClient, options.testImportSource ?? 'bun:test')
 
   const basePath = `${componentsBasePath}/${componentName}`
 
@@ -166,12 +179,12 @@ function generateComponentCode(
   return lines.join('\n')
 }
 
-function generateTestCode(componentName: string, needsClient: boolean): string {
+function generateTestCode(componentName: string, needsClient: boolean, importSource: string): string {
   const pascalName = toPascalCase(componentName)
   const varName = toCamelCase(componentName) + 'Source'
   const lines: string[] = []
 
-  lines.push(`import { describe, test, expect } from 'bun:test'`)
+  lines.push(`import { describe, test, expect } from '${importSource}'`)
   lines.push(`import { readFileSync } from 'fs'`)
   lines.push(`import { resolve } from 'path'`)
   lines.push(`import { renderToTest } from '@barefootjs/test'`)

--- a/packages/cli/src/lib/test-template.ts
+++ b/packages/cli/src/lib/test-template.ts
@@ -5,12 +5,28 @@ import { readFileSync } from 'fs'
 import path from 'path'
 import { parseComponent } from './parse-component'
 
+export interface GenerateTestTemplateOptions {
+  /**
+   * Import specifier the emitted file uses for `describe` / `test` /
+   * `expect`. Defaults to `bun:test` so existing callers behave
+   * unchanged; `bf gen test` overrides it with `testRunnerFor(pm)` so
+   * non-bun scaffolds get a `from 'vitest'` line that resolves under
+   * `npm install`. See `testRunnerFor` in `./pm.ts`.
+   */
+  importSource?: string
+}
+
 /**
  * Generate an IR test file for a component.
  * @param componentPath - Absolute path to the .tsx file
+ * @param options - Per-runner overrides (e.g. `importSource: 'vitest'`).
  * @returns The generated test file content as a string
  */
-export function generateTestTemplate(componentPath: string): string {
+export function generateTestTemplate(
+  componentPath: string,
+  options: GenerateTestTemplateOptions = {},
+): string {
+  const importSource = options.importSource ?? 'bun:test'
   const source = readFileSync(componentPath, 'utf-8')
   const parsed = parseComponent(source)
   const fileName = path.basename(componentPath)
@@ -31,7 +47,7 @@ export function generateTestTemplate(componentPath: string): string {
   const lines: string[] = []
 
   // Header
-  lines.push(`import { describe, test, expect } from 'bun:test'`)
+  lines.push(`import { describe, test, expect } from '${importSource}'`)
   lines.push(`import { readFileSync } from 'fs'`)
   lines.push(`import { resolve } from 'path'`)
   lines.push(`import { renderToTest } from '@barefootjs/test'`)


### PR DESCRIPTION
## Summary

Closes #1454.

Option C from the issue: branch the test-runner choice on the detected package manager so non-bun scaffolds work out of the box.

The scaffold layer used to commit to bun as the test runner regardless of which PM the user selected — `init.ts` hard-coded `test: 'bun test'`, `bf gen test` emitted `import 'bun:test'`, and `bf gen component` wrote the same line into its stub. A non-bun user landed on generated files that didn't type-check or run under their PM until they migrated to Vitest / Jest by hand.

This PR introduces a single `testRunnerFor(pm)` helper in `pm.ts` that returns the import specifier, the `scripts.test` value, the extra devDeps, and the tsconfig `types` entry per PM:

| PM | import | `test` script | extra devDeps | tsconfig types entry |
|----|--------|---------------|---------------|----------------------|
| bun | `bun:test` | `bun test` | `@types/bun` | `, "bun-types"` |
| npm / pnpm / yarn | `vitest` | `vitest run` | `vitest` | (empty) |

Vitest's `describe` / `test` / `expect` surface is API-compatible with `bun:test`, so the generated `*.test.tsx` files Just Work under any PM after `<pm> install` — no manual migration needed. `@barefootjs/test`'s `renderToTest` was already runner-agnostic.

Wiring sites:
- `init.ts` — `pmTypesEntry`, `pmDevDeps`, and the `test` script all flow through `testRunnerFor(pm)` instead of three parallel bun-special-case branches.
- `gen-test.ts` / `gen-component.ts` — detect PM and pass `runner.importSource` into the template generator.
- `test-template.ts` / `scaffold.ts` — accept an optional `importSource`, default to `bun:test` so existing callers behave unchanged.

## Test plan

- [x] `bun test packages/cli/src/__tests__/pm.test.ts` — `testRunnerFor` pinned per PM (bun + the three vitest PMs, including a negative `@types/bun` guard for non-bun).
- [x] `bun test packages/cli/src/__tests__/test-template.test.ts` — default header is `from 'bun:test'`; `importSource: 'vitest'` swaps it.
- [x] `bun test packages/cli/src/__tests__/scaffold-layout.test.ts` — same default + override pin for `scaffold()`'s emitted test code.
- [x] `bun test packages/cli/src/__tests__/gen-test.test.ts` — end-to-end lockfile→import-line cases (`bun.lock` → `bun:test`; `package-lock.json` / `pnpm-lock.yaml` / `yarn.lock` → `vitest`).
- [x] `bun test packages/cli/src/__tests__/templates.test.ts` — PM-agnostic adapter surface still holds (`@types/bun` stays out of the adapter's static devDeps).
- [x] All 5 target test files: 94/94 pass.
- [x] Wider `bun test packages/cli/` baseline improves: 333 → 377 pass (the 19 remaining failures are pre-existing missing-dep issues unrelated to this PR).

## Docs

`docs/core/core-concepts/ai-native.md`: note that `bf init` picks the runner, swap the hard-coded `bun test` workflow line for `<pm> test`, and add a hint that the snippet's `from 'bun:test'` reads as `from 'vitest'` under npm / pnpm / yarn (the API is identical otherwise).

https://claude.ai/code/session_01DKMHZApGGA4qooVCgfypMf

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKMHZApGGA4qooVCgfypMf)_