### PR TITLE
test: alpha onboarding verification (pkg-pr-new)

### DIFF
--- a/docs/core/quick-start.md
+++ b/docs/core/quick-start.md
@@ -97,22 +97,33 @@ export default createConfig({
 
 ```tsx
 'use client'
+
 import { createSignal, createMemo } from '@barefootjs/client'
 import { Button } from '@/components/ui/button'
 
-export function Counter({ initial = 0 }: { initial?: number }) {
-  const [count, setCount] = createSignal(initial)
+interface CounterProps {
+  initial?: number
+}
+
+export function Counter(props: CounterProps) {
+  const [count, setCount] = createSignal(props.initial ?? 0)
   const doubled = createMemo(() => count() * 2)
 
   return (
     <div className="counter">
-      <p>count: {count()}</p>
-      <p>doubled: {doubled()}</p>
-      <Button onClick={() => setCount(n => n + 1)}>+1</Button>
+      <p className="counter-value">count: {count()}</p>
+      <p className="counter-doubled">doubled: {doubled()}</p>
+      <div className="counter-buttons">
+        <Button onClick={() => setCount(n => n + 1)}>+1</Button>
+        <Button onClick={() => setCount(n => n - 1)} variant="secondary">-1</Button>
+        <Button onClick={() => setCount(0)} variant="ghost">Reset</Button>
+      </div>
     </div>
   )
 }
 ```
+
+Props are accessed via `props.initial`, not destructured — destructuring captures the value once and breaks reactivity (the compiler emits warning [`BF043`](./advanced/error-codes.md) when it sees the destructured form). See [Props Reactivity](./reactivity/props-reactivity.md) for the full rule.
 
 Save the file — `bf build --watch` recompiles and `wrangler dev` live-reloads.
 

--- a/packages/adapter-hono/src/adapter/hono-adapter.ts
+++ b/packages/adapter-hono/src/adapter/hono-adapter.ts
@@ -66,6 +66,15 @@ export interface HonoAdapterOptions {
    * Useful for files with multiple components that share a single client JS file.
    */
   clientJsFilename?: string
+
+  /**
+   * Display name surfaced through `JsxAdapter.name` — read by `bf build`
+   * for its `Adapter: …` banner. Defaults to `'hono'`. CSR-mode callers
+   * (`@barefootjs/client/build`) pass `'csr'` so the banner reflects the
+   * mode the user picked at scaffold time instead of leaking the
+   * fact that CSR currently reuses HonoAdapter under the hood.
+   */
+  name?: string
 }
 
 export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderCtx> {
@@ -117,6 +126,7 @@ export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderC
       barefootJsPath: options.barefootJsPath ?? '/static/components/barefoot.js',
       clientJsFilename: options.clientJsFilename,
     }
+    if (options.name) this.name = options.name
   }
 
   generate(ir: ComponentIR, options?: AdapterGenerateOptions): AdapterOutput {

--- a/packages/cli/scripts/build.mjs
+++ b/packages/cli/scripts/build.mjs
@@ -9,7 +9,7 @@
 //   is bundled inline so the published CLI is self-contained.
 
 import { build } from 'esbuild'
-import { chmodSync, cpSync, existsSync, rmSync } from 'node:fs'
+import { chmodSync, copyFileSync, cpSync, existsSync, rmSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 
@@ -23,6 +23,13 @@ const outfile = resolve(pkgDir, 'dist/index.js')
 // checkout. Only `dist` is in `files`, so this path is what ships.
 const docsSrc = resolve(pkgDir, '../../docs/core')
 const docsDst = resolve(pkgDir, 'dist/docs/core')
+// `bf tokens` reads the default token palette from this JSON. The
+// monorepo source lives under `site/shared/tokens/`, but that
+// directory ships nowhere — copy it next to the bundle so
+// `tokens.ts` can fall back to the bundled copy when the user is
+// running inside a scaffolded app instead of the monorepo.
+const tokensSrc = resolve(pkgDir, '../../site/shared/tokens/tokens.json')
+const tokensDst = resolve(pkgDir, 'dist/tokens.json')
 
 await build({
   entryPoints: [entry],
@@ -54,6 +61,15 @@ if (existsSync(docsSrc)) {
   // somewhere unexpected; warn but don't fail — `bf guide` will surface
   // its own error if the dir is missing at runtime.
   console.warn(`Warning: ${docsSrc} not found; bf guide will fail in the built CLI.`)
+}
+
+// Same story for the default token palette — copy it next to the
+// bundle so `bf tokens` can read it in scaffolded apps.
+if (existsSync(tokensSrc)) {
+  copyFileSync(tokensSrc, tokensDst)
+  console.log(`Copied: ${tokensSrc} -> ${tokensDst}`)
+} else {
+  console.warn(`Warning: ${tokensSrc} not found; bf tokens will fail in the built CLI.`)
 }
 
 console.log(`Built: ${outfile}`)

--- a/packages/cli/src/commands/tokens.ts
+++ b/packages/cli/src/commands/tokens.ts
@@ -1,9 +1,23 @@
 // bf tokens — list design tokens by category.
+//
+// Resolution order for the base TokenSet, mirroring `bf guide`:
+//   1. `<projectDir>/<paths.tokens>/tokens.json`   — user's full override
+//   2. `<repoRoot>/site/shared/tokens/tokens.json` — monorepo source
+//   3. `<cli-dist>/tokens.json`                    — bundled default
+//
+// The first two only fire in the matching environments; the third is
+// the fallback that lets `bf tokens` work inside scaffolded apps where
+// neither (1) nor (2) is present.
 
-import { resolve } from 'node:path'
+import { readFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import type { CliContext } from '../context'
 import type { TokenSet, Token, ColorToken } from '../../../../site/shared/tokens/schema'
 import { fileExists } from '../lib/runtime'
+
+const thisFile = fileURLToPath(import.meta.url)
 
 type CategoryName = 'typography' | 'spacing' | 'borderRadius' | 'transitions' | 'layout' | 'colors' | 'shadows'
 
@@ -11,11 +25,99 @@ const CATEGORY_NAMES: CategoryName[] = [
   'typography', 'spacing', 'borderRadius', 'transitions', 'layout', 'colors', 'shadows',
 ]
 
+async function loadTokens(jsonPath: string): Promise<TokenSet> {
+  const content = await readFile(jsonPath, 'utf-8')
+  return JSON.parse(content) as TokenSet
+}
+
+/**
+ * Merge multiple TokenSets. Later sets override earlier ones (by token name).
+ * Mirrors `site/shared/tokens/generate-css.ts#mergeTokenSets` — kept inline
+ * here so the published CLI doesn't need a runtime dependency on the
+ * workspace-only `site/shared` package.
+ */
+function mergeTokenSets(...sets: TokenSet[]): TokenSet {
+  if (sets.length === 0) throw new Error('mergeTokenSets requires at least one TokenSet')
+  if (sets.length === 1) return sets[0]
+
+  const base = structuredClone(sets[0])
+
+  for (let i = 1; i < sets.length; i++) {
+    const ext = sets[i]
+    mergeTokenArray(base.typography.fontFamily, ext.typography.fontFamily)
+    mergeTokenArray(base.typography.letterSpacing, ext.typography.letterSpacing)
+    mergeTokenArray(base.spacing, ext.spacing)
+    mergeTokenArray(base.borderRadius, ext.borderRadius)
+    mergeTokenArray(base.transitions.duration, ext.transitions.duration)
+    mergeTokenArray(base.transitions.easing, ext.transitions.easing)
+    mergeTokenArray(base.layout, ext.layout)
+    mergeTokenArray(base.colors, ext.colors)
+    mergeTokenArray(base.shadows, ext.shadows)
+  }
+
+  return base
+}
+
+function mergeTokenArray<T extends Token>(base: T[], ext: T[]): void {
+  for (const token of ext) {
+    const idx = base.findIndex(t => t.name === token.name)
+    if (idx >= 0) {
+      base[idx] = token
+    } else {
+      base.push(token)
+    }
+  }
+}
+
+/**
+ * Locate the base `tokens.json` to load. Search order:
+ *   1. Monorepo source — `<repoRoot>/site/shared/tokens/tokens.json`
+ *      (this is the canonical version checked into the repo)
+ *   2. Bundled default — `<cli-dist>/tokens.json` (copied next to the
+ *      bundle by `scripts/build.mjs` so the published CLI carries it)
+ *
+ * Returns `null` only when both candidates are missing — the caller
+ * surfaces the user-facing error.
+ */
+function findBaseTokensJson(ctx: CliContext): string | null {
+  const monorepoTokens = resolve(ctx.root, 'site/shared/tokens/tokens.json')
+  if (existsSync(monorepoTokens)) return monorepoTokens
+
+  // In the bundled CLI, `dist/index.js` sits next to `dist/tokens.json`.
+  // In source mode (running TS directly via `bun packages/cli/src/index.ts`)
+  // `import.meta.url` resolves to `.../packages/cli/src/commands/tokens.ts`
+  // and this path won't exist — that's fine, the monorepo fallback above
+  // already handled it.
+  const bundledTokens = resolve(dirname(thisFile), 'tokens.json')
+  if (existsSync(bundledTokens)) return bundledTokens
+
+  return null
+}
+
 async function loadTokenSet(ctx: CliContext): Promise<TokenSet> {
-  const { loadTokens, mergeTokenSets } = await import(
-    resolve(ctx.root, 'site/shared/tokens/index')
-  )
-  const base = await loadTokens(resolve(ctx.root, 'site/shared/tokens/tokens.json'))
+  // 1. User-supplied full override under <paths.tokens>/tokens.json.
+  //    When present we honour it as the *base* (no merging with the
+  //    bundled defaults) so the user has total control — they opted in
+  //    by maintaining the file.
+  if (ctx.projectDir && ctx.config?.paths.tokens) {
+    const userTokens = resolve(ctx.projectDir, ctx.config.paths.tokens, 'tokens.json')
+    if (await fileExists(userTokens)) {
+      return loadTokens(userTokens)
+    }
+  }
+
+  // 2. Default base — monorepo source or bundled CLI fallback.
+  const basePath = findBaseTokensJson(ctx)
+  if (!basePath) {
+    throw new Error(
+      'Cannot locate default tokens.json. Reinstall @barefootjs/cli — the published tarball should include it.',
+    )
+  }
+  const base = await loadTokens(basePath)
+
+  // 3. Monorepo-only: merge in the UI extension layer when present.
+  //    End-user projects don't have `site/ui/tokens.json`; this branch is
+  //    a no-op there.
   const uiJsonPath = resolve(ctx.root, 'site/ui/tokens.json')
   if (await fileExists(uiJsonPath)) {
     const ext = await loadTokens(uiJsonPath)

--- a/packages/client/__tests__/build.test.ts
+++ b/packages/client/__tests__/build.test.ts
@@ -1,0 +1,26 @@
+import { describe, test, expect } from 'bun:test'
+import { HonoAdapter } from '@barefootjs/hono/adapter'
+import { createConfig } from '../src/build'
+
+describe('client/build createConfig', () => {
+  test("default adapter announces itself as 'csr'", () => {
+    const config = createConfig({})
+    expect((config.adapter as HonoAdapter).name).toBe('csr')
+  })
+
+  test('caller-supplied adapter is left untouched', () => {
+    const custom = new HonoAdapter({ name: 'custom-thing' })
+    const config = createConfig({ adapter: custom })
+    expect((config.adapter as HonoAdapter).name).toBe('custom-thing')
+  })
+
+  test('caller-supplied adapterOptions.name wins over the csr default', () => {
+    const config = createConfig({ adapterOptions: { name: 'explicit' } })
+    expect((config.adapter as HonoAdapter).name).toBe('explicit')
+  })
+
+  test('clientOnly is set', () => {
+    const config = createConfig({})
+    expect(config.clientOnly).toBe(true)
+  })
+})

--- a/packages/client/src/build.ts
+++ b/packages/client/src/build.ts
@@ -59,8 +59,15 @@ export interface CSRBuildOptions {
  * a circular dependency between `@barefootjs/client` and `@barefootjs/cli`.
  */
 export function createConfig(options: CSRBuildOptions = {}) {
+  // Tag the default-adapter instance as 'csr' so `bf build`'s
+  // `Adapter: …` banner reflects the mode the user picked at scaffold
+  // time. A caller-supplied `adapter` is left untouched — its own
+  // `name` is authoritative.
+  const adapter =
+    options.adapter ??
+    new HonoAdapter({ name: 'csr', ...options.adapterOptions })
   return {
-    adapter: options.adapter ?? new HonoAdapter(options.adapterOptions),
+    adapter,
     paths: options.paths,
     components: options.components,
     outDir: options.outDir,

--- a/site/core/pages/quick-start.tsx
+++ b/site/core/pages/quick-start.tsx
@@ -104,7 +104,7 @@ export function Counter(props: CounterProps) {
 }
 \`\`\`
 
-See [Client Directive](./rendering/client-directive.md), [\`createSignal\`](./reactivity/create-signal.md), and [\`createMemo\`](./reactivity/create-memo.md) for what each piece does.
+See [Client Directive](./rendering/client-directive.md), [\`createSignal\`](./reactivity/create-signal.md), and [\`createMemo\`](./reactivity/create-memo.md) for what each piece does. Props are read via \`props.initial\`, not destructured — destructuring captures the value once and breaks reactivity, so the compiler emits warning [\`BF043\`](./advanced/error-codes.md) when it sees that form on a \`"use client"\` component. [Props Reactivity](./reactivity/props-reactivity.md) covers the full rule.
 
 The Counter is mounted in \`server.tsx\`:
 


### PR DESCRIPTION
## Summary

Alpha-release onboarding verification PR. Walked the `npm create barefootjs@latest` → install → dev → edit → test path end-to-end against artefacts published via pkg-pr-new, and stacked friction fixes as commits on this branch.

### Paths exercised

| Path | Result |
|---|---|
| `npm create barefootjs@latest --yes` (Hono / CSR / hono-node adapters) | OK |
| `npm install` (with pkg-pr-new overrides) | OK |
| `npm run build` / `npm run dev` → `curl http://localhost:8787/` | SSR HTML + hydration markers + client JS load OK |
| `bf docs button` / `bf docs card` | OK |
| `bf debug graph Counter` / `bf debug trace Counter count` | OK |
| `bf search Card --registry …` / `bf add card` | OK |
| `bf gen component todo-list button` → `bf build` → `npm test` | OK (BF043 fires as designed on the intentional destructuring example, 5/5 tests pass) |
| `bf gen test Counter` → `npm test` | 7/7 pass |
| `bf gen preview button` → `bf preview` | OK |
| `bf guide` (index + individual pages) | OK |
| `bf tokens` (before the fix) | **broken** → OK after the fix |

### Friction fixed on this branch

| # | Friction | Fix | Commit |
|---|---|---|---|
| 1 | The Counter example in `docs/core/quick-start.md` (and the TSX-rendered version at `site/core/pages/quick-start.tsx`) destructured props (`{ initial = 0 }`), tripping the **BF043** warning on `'use client'` components, and the snippet didn't match the actual scaffolded Counter (`+1` only vs. `+1 / -1 / Reset` on disk). A user following the docs would see a warning out of the gate and a different file from the one they edited. | Aligned both quick-start surfaces with the scaffold (`props.initial ?? 0`, all three buttons) and added an inline pointer to the props-reactivity rule + BF043. | `e3373a7`, follow-up |
| 2 | `bf build` printed `Adapter: hono` even when the user picked CSR at scaffold time — `@barefootjs/client/build`'s `createConfig` reuses `HonoAdapter` as the JS generator, and that implementation detail leaked into the build banner, contradicting the prompt answer. | `HonoAdapter` now accepts an optional `name` override; the CSR `createConfig` passes `'csr'` so the banner reflects the mode the user picked. | `e3373a7` |
| 3 | `bf tokens` was unusable from a scaffolded app — it errored with `ERR_MODULE_NOT_FOUND: site/shared/tokens/index` because the command resolved a monorepo-only path through `ctx.root`, and that path doesn't exist in `node_modules` for end users. | Inlined `loadTokens` / `mergeTokenSets` into the CLI and bundled the default `tokens.json` next to the CLI bundle. Resolution order: user override (`<projectDir>/<paths.tokens>/tokens.json`) → monorepo source → bundled fallback. | `06fade6` |

### Verification notes

- Packages are not on npm yet, so verification went through pkg-pr-new (`@1474`) wired via `package.json#overrides` (the rewrite script from the PR brief).
- The first commit (`2d13e15`) is an empty commit whose only role is to trigger the pkg-pr-new build for the `cr-tracked` label.
- After each fix push, I re-scaffolded a fresh app against the freshly-published artefacts and re-confirmed the behaviour.

## Test plan

- [x] pkg-pr-new install URLs appear in the PR thread
- [x] Scaffold (Hono+UnoCSS) → install → dev → Counter renders in the browser (SSR HTML + client JS verified)
- [x] CSR adapter scaffold → `bf build` banner now reads `Adapter: csr`
- [x] hono-node adapter scaffold → install → dev → page renders
- [x] `bf docs` / `bf add` / `bf gen component` / `bf gen test` / `bf gen preview` / `bf guide` / `bf tokens` all work from an installed app
- [x] The deliberate BF043-triggering edit (TodoList) compiles, generated vitest tests pass
- [x] Unit tests on CLI / client packages pass (646 + 281 in their respective suites)
