### PR TITLE
test(ci): smoke `bf` surface against bun-packed tarballs

### DIFF
--- a/.github/workflows/ci-smoke-publish.yml
+++ b/.github/workflows/ci-smoke-publish.yml
@@ -1,0 +1,101 @@
+name: CI — Smoke (published tarballs)
+
+# Packs every publishable workspace via `bun pm pack`, installs the
+# resulting tarballs into a fresh user-style scaffold, and runs a
+# breadth-first sweep of `bf` commands against it.
+#
+# Catches regressions where a command works inside the monorepo but
+# breaks once shipped — e.g. the `bf tokens` failure caused by
+# resolving a workspace-only path through `ctx.root`, which is fine
+# in the repo but lands in `node_modules/` in a real install.
+# pkg-pr-new tests the publish wiring; this job tests the runtime.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      # Re-run on every publishable package + the runner + the workflow itself.
+      - 'packages/shared/**'
+      - 'packages/jsx/**'
+      - 'packages/client/**'
+      - 'packages/streaming/**'
+      - 'packages/test/**'
+      - 'packages/adapter-hono/**'
+      - 'packages/adapter-go-template/**'
+      - 'packages/adapter-mojolicious/**'
+      - 'packages/form/**'
+      - 'packages/chart/**'
+      - 'packages/xyflow/**'
+      - 'packages/cli/**'
+      - 'packages/create-barefootjs/**'
+      - 'scripts/smoke-publish.mjs'
+      - 'scripts/swap-publish-config.mjs'
+      - '.github/workflows/ci-smoke-publish.yml'
+  pull_request:
+    paths:
+      - 'packages/shared/**'
+      - 'packages/jsx/**'
+      - 'packages/client/**'
+      - 'packages/streaming/**'
+      - 'packages/test/**'
+      - 'packages/adapter-hono/**'
+      - 'packages/adapter-go-template/**'
+      - 'packages/adapter-mojolicious/**'
+      - 'packages/form/**'
+      - 'packages/chart/**'
+      - 'packages/xyflow/**'
+      - 'packages/cli/**'
+      - 'packages/create-barefootjs/**'
+      - 'scripts/smoke-publish.mjs'
+      - 'scripts/swap-publish-config.mjs'
+      - '.github/workflows/ci-smoke-publish.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+
+      # Node is required by `create-barefootjs`'s bin — it spawns
+      # `node <cli bin> init`. Bun ships its own Node compat layer but
+      # we exercise the path the user actually walks (`npm create
+      # barefootjs@latest` → `node`).
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: bun install
+
+      # The runner script does its own per-package build via
+      # `bun run --filter '<name>' build`. Embedding adapter runtimes
+      # is part of `@barefootjs/cli` build, so no separate step.
+      - name: Smoke (build + pack + scaffold + bf surface)
+        run: bun run scripts/smoke-publish.mjs
+
+      # Surface the workspace state on failure so the failure mode is
+      # debuggable from the run log. The script writes its own context
+      # to stdout on a failing step, but a `ls -la` snapshot of the
+      # scaffold dir is cheap insurance.
+      - name: Dump scaffold state on failure
+        if: failure()
+        run: |
+          for dir in /tmp/bf-smoke-workspace-*; do
+            [ -d "$dir" ] || continue
+            echo "── $dir ──"
+            ls -la "$dir" || true
+            if [ -f "$dir/app/package.json" ]; then
+              echo "── $dir/app/package.json ──"
+              cat "$dir/app/package.json"
+            fi
+          done

--- a/.github/workflows/ci-smoke-publish.yml
+++ b/.github/workflows/ci-smoke-publish.yml
@@ -70,7 +70,7 @@ jobs:
       # we exercise the path the user actually walks (`npm create
       # barefootjs@latest` → `node`).
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
 

--- a/scripts/smoke-publish.mjs
+++ b/scripts/smoke-publish.mjs
@@ -2,11 +2,12 @@
 //
 // End-to-end smoke test for published tarballs.
 //
-// Runs every publishable `@barefootjs/*` package through `npm pack`,
-// scaffolds a fresh user-style project against the resulting tarballs
-// (no workspace: refs, no monorepo paths), and exercises the `bf` CLI
-// surface that depends on bundled resources or workspace-shaped
-// imports.
+// Runs every publishable `@barefootjs/*` package through `bun pm pack`
+// (see the `Pack tarballs` section below for why bun rather than
+// `npm pack`), scaffolds a fresh user-style project against the
+// resulting tarballs (no workspace: refs, no monorepo paths), and
+// exercises the `bf` CLI surface that depends on bundled resources
+// or workspace-shaped imports.
 //
 // Catches the class of bugs where a command works inside the monorepo
 // but breaks when the same code runs from a `node_modules/@barefootjs/*`
@@ -23,7 +24,6 @@
 
 import { execSync, spawnSync } from 'node:child_process'
 import {
-  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -37,8 +37,12 @@ import { fileURLToPath } from 'node:url'
 const here = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(here, '..')
 
-// Publishable packages, in dependency order so `bun run --filter X build`
-// finds the artefacts it needs. Mirrors `.github/workflows/pkg-pr-new.yml`.
+// Publishable packages — the set must stay in sync with
+// `.github/workflows/pkg-pr-new.yml`'s publish list (which is the
+// source of truth for "what ships"). Order here is the dependency
+// order needed for `bun run --filter X build` to find upstream
+// artefacts; the pkg-pr-new workflow uses its own order (build vs
+// publish), so we deliberately don't mirror that — only the set.
 const PUBLISHABLE = [
   'packages/shared',
   'packages/jsx',

--- a/scripts/smoke-publish.mjs
+++ b/scripts/smoke-publish.mjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+//
+// End-to-end smoke test for published tarballs.
+//
+// Runs every publishable `@barefootjs/*` package through `npm pack`,
+// scaffolds a fresh user-style project against the resulting tarballs
+// (no workspace: refs, no monorepo paths), and exercises the `bf` CLI
+// surface that depends on bundled resources or workspace-shaped
+// imports.
+//
+// Catches the class of bugs where a command works inside the monorepo
+// but breaks when the same code runs from a `node_modules/@barefootjs/*`
+// install — e.g. the `bf tokens` regression that resolved
+// `site/shared/tokens/index` through `ctx.root`, which only exists in
+// the repo. pkg-pr-new verifies the publish wiring; this script
+// verifies the runtime behaviour of those tarballs.
+//
+// Run locally:
+//   bun run scripts/smoke-publish.mjs            # build + pack + scaffold + smoke
+//   bun run scripts/smoke-publish.mjs --no-build # skip the build step (reuse existing dist/)
+//
+// Also wired into CI via `.github/workflows/ci-smoke-publish.yml`.
+
+import { execSync, spawnSync } from 'node:child_process'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { tmpdir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(here, '..')
+
+// Publishable packages, in dependency order so `bun run --filter X build`
+// finds the artefacts it needs. Mirrors `.github/workflows/pkg-pr-new.yml`.
+const PUBLISHABLE = [
+  'packages/shared',
+  'packages/jsx',
+  'packages/client',
+  'packages/streaming',
+  'packages/test',
+  'packages/adapter-hono',
+  'packages/adapter-go-template',
+  'packages/adapter-mojolicious',
+  'packages/form',
+  'packages/chart',
+  'packages/xyflow',
+  'packages/cli',
+  'packages/create-barefootjs',
+]
+
+const args = process.argv.slice(2)
+const skipBuild = args.includes('--no-build')
+const keepWorkspace = args.includes('--keep')
+
+function header(label) {
+  const bar = '━'.repeat(70)
+  console.log(`\n${bar}\n  ${label}\n${bar}`)
+}
+
+function run(cmd, opts = {}) {
+  console.log(`$ ${cmd}`)
+  execSync(cmd, { stdio: 'inherit', encoding: 'utf-8', ...opts })
+}
+
+function runCapture(cmd, opts = {}) {
+  return execSync(cmd, { encoding: 'utf-8', ...opts })
+}
+
+// ── 1. Build every publishable package ──────────────────────────────
+if (!skipBuild) {
+  header('Build publishable packages')
+  for (const pkgDir of PUBLISHABLE) {
+    const pkg = JSON.parse(
+      readFileSync(resolve(repoRoot, pkgDir, 'package.json'), 'utf-8'),
+    )
+    if (!pkg.scripts?.build) {
+      console.log(`(skip) ${pkg.name} has no build script`)
+      continue
+    }
+    run(`bun run --filter '${pkg.name}' build`, { cwd: repoRoot })
+  }
+} else {
+  header('Build (skipped via --no-build)')
+}
+
+// ── 2. `bun pm pack` each publishable package ──────────────────────
+// `bun pm pack` is used in place of `npm pack` because npm (10.x) does
+// not rewrite the `workspace:*` protocol when packing — the resulting
+// tarball still claims `"@barefootjs/shared": "workspace:*"`, which
+// blows up with EUNSUPPORTEDPROTOCOL on `npm install`. Bun replaces it
+// with the resolved version (e.g. `"0.1.0"`), matching what pkg-pr-new
+// publishes. Prepack / postpack hooks still fire.
+header('Pack tarballs')
+const tarballDir = mkdtempSync(join(tmpdir(), 'bf-smoke-tarballs-'))
+const tarballs = {} // pkgName -> absolute tarball path
+for (const pkgDir of PUBLISHABLE) {
+  const pkg = JSON.parse(
+    readFileSync(resolve(repoRoot, pkgDir, 'package.json'), 'utf-8'),
+  )
+  // `--quiet` prints only the tarball path on stdout — keeps the
+  // capture parse trivial across bun versions.
+  const out = runCapture(
+    `bun pm pack --quiet --destination=${tarballDir}`,
+    { cwd: resolve(repoRoot, pkgDir) },
+  )
+  const tarballPath = out.trim().split('\n').pop()
+  tarballs[pkg.name] = tarballPath
+  console.log(`  ${pkg.name.padEnd(34)} → ${tarballPath.split('/').pop()}`)
+}
+
+// ── 3. Scaffold via the create-barefootjs tarball ──────────────────
+header('Scaffold from tarballs')
+const workspace = mkdtempSync(join(tmpdir(), 'bf-smoke-workspace-'))
+
+// Install create-barefootjs + @barefootjs/cli into a throwaway tree so
+// the bin can `require.resolve('@barefootjs/cli/dist/index.js')`. The
+// app being scaffolded gets its own install via the rewrite below.
+const installerDir = join(workspace, '_installer')
+mkdirSync(installerDir, { recursive: true })
+writeFileSync(
+  resolve(installerDir, 'package.json'),
+  JSON.stringify(
+    {
+      name: 'bf-smoke-installer',
+      private: true,
+      dependencies: {
+        'create-barefootjs': `file:${tarballs['create-barefootjs']}`,
+        '@barefootjs/cli': `file:${tarballs['@barefootjs/cli']}`,
+      },
+    },
+    null,
+    2,
+  ) + '\n',
+)
+run('npm install --no-audit --no-fund --loglevel=error', { cwd: installerDir })
+
+// Run the bin against an empty `app/` target. cwd is the parent so the
+// confirmation line ("✔ Target directory app") echoes the same path the
+// user would type.
+const createBin = join(
+  installerDir,
+  'node_modules',
+  'create-barefootjs',
+  'dist',
+  'index.js',
+)
+run(`node ${JSON.stringify(createBin)} app --yes`, { cwd: workspace })
+const appDir = join(workspace, 'app')
+
+// ── 4. Rewrite the scaffolded package.json to point at our tarballs ─
+header('Wire tarballs into the scaffold')
+const appPkgPath = resolve(appDir, 'package.json')
+const appPkg = JSON.parse(readFileSync(appPkgPath, 'utf-8'))
+
+function rewriteSection(section) {
+  for (const [n] of Object.entries(appPkg[section] || {})) {
+    if (n.startsWith('@barefootjs/') && tarballs[n]) {
+      appPkg[section][n] = `file:${tarballs[n]}`
+    }
+  }
+}
+rewriteSection('dependencies')
+rewriteSection('devDependencies')
+
+// Overrides cover transitive deps (e.g. `@barefootjs/hono` is a peer of
+// `@barefootjs/client`) so every workspace package collapses to the
+// same tarball at install time. Skip `create-barefootjs` — it's only
+// the entry point, never a transitive dep.
+appPkg.overrides = appPkg.overrides || {}
+for (const [n, p] of Object.entries(tarballs)) {
+  if (n === 'create-barefootjs') continue
+  appPkg.overrides[n] = `file:${p}`
+}
+writeFileSync(appPkgPath, JSON.stringify(appPkg, null, 2) + '\n')
+
+run('npm install --no-audit --no-fund --loglevel=error', { cwd: appDir })
+
+// ── 5. Smoke commands ──────────────────────────────────────────────
+header('Smoke commands')
+
+const failures = []
+
+function smoke(label, cmd, opts = {}) {
+  console.log(`\n• ${label}`)
+  console.log(`  $ ${cmd}`)
+  const r = spawnSync(cmd, {
+    cwd: appDir,
+    shell: true,
+    encoding: 'utf-8',
+  })
+  const ok = r.status === 0 &&
+    (!opts.expect || (r.stdout ?? '').includes(opts.expect))
+  if (!ok) {
+    failures.push({ label, cmd, status: r.status, expect: opts.expect, stdout: r.stdout, stderr: r.stderr })
+    console.log(`  ✗ failed (exit ${r.status}${opts.expect ? `, expected "${opts.expect}"` : ''})`)
+    const tail = (s) => (s ?? '').slice(-1200)
+    if (r.stdout) console.log(`  stdout:\n${tail(r.stdout)}`)
+    if (r.stderr) console.log(`  stderr:\n${tail(r.stderr)}`)
+    return
+  }
+  console.log(`  ✓ ok`)
+}
+
+// Every line below targets a real failure mode caught (or catchable) by
+// a tarball install. Add new entries here when a regression escapes
+// into a release — this is the dogfood net.
+
+// — bundled-resource access (the `bf tokens` regression class)
+smoke('bf tokens', 'npx --no-install bf tokens', { expect: 'background' })
+smoke('bf tokens --category colors', 'npx --no-install bf tokens --category colors', { expect: 'background' })
+smoke('bf guide (list)', 'npx --no-install bf guide', { expect: 'quick-start' })
+smoke('bf guide quick-start', 'npx --no-install bf guide quick-start', { expect: 'Counter' })
+
+// — meta + registry-shaped commands (scaffold writes `meta/button.json`)
+smoke('bf docs button', 'npx --no-install bf docs button', { expect: 'Category' })
+smoke('bf search button (local)', 'npx --no-install bf search button')
+
+// — compiler + analyzer
+smoke('bf build', 'npx --no-install bf build', { expect: 'Build complete' })
+smoke('bf debug graph Counter', 'npx --no-install bf debug graph Counter', { expect: 'count' })
+smoke('bf debug trace Counter count', 'npx --no-install bf debug trace Counter count', { expect: 'count' })
+
+// — generators
+smoke('bf gen test Counter', 'npx --no-install bf gen test Counter', { expect: 'Counter.test.tsx' })
+smoke('bf gen preview button', 'npx --no-install bf gen preview button')
+smoke('bf gen component widget button', 'npx --no-install bf gen component widget button', { expect: 'components/ui/widget' })
+smoke('bf preview (list after gen)', 'npx --no-install bf preview', { expect: 'button' })
+
+// — full project build + test runner
+smoke('npm run build', 'npm run build', { expect: 'Build complete' })
+// `npm test` dispatches to whichever runner the scaffold picked (`bun
+// test` on bun-detected installs, `vitest run` everywhere else). The
+// matching `bf gen test`-emitted import was wired against the same
+// runner, so the generated `Counter.test.tsx` runs cleanly under
+// either path — exercise it through `npm test` so we don't lock the
+// smoke to one runner.
+smoke('npm test', 'npm test')
+
+// ── 6. Summary ─────────────────────────────────────────────────────
+header(failures.length === 0 ? 'PASS' : 'FAIL')
+if (failures.length === 0) {
+  console.log(`All smoke steps passed.`)
+  if (!keepWorkspace) {
+    rmSync(workspace, { recursive: true, force: true })
+    rmSync(tarballDir, { recursive: true, force: true })
+  } else {
+    console.log(`Workspace kept: ${workspace}`)
+    console.log(`Tarballs kept:  ${tarballDir}`)
+  }
+  process.exit(0)
+}
+
+console.log(`${failures.length} smoke step(s) failed:`)
+for (const f of failures) {
+  console.log(`  - ${f.label} (exit ${f.status}${f.expect ? `, expected "${f.expect}"` : ''})`)
+}
+console.log(`\nWorkspace kept for inspection: ${workspace}`)
+console.log(`Tarballs kept for inspection:  ${tarballDir}`)
+process.exit(1)

--- a/scripts/smoke-publish.mjs
+++ b/scripts/smoke-publish.mjs
@@ -19,6 +19,8 @@
 // Run locally:
 //   bun run scripts/smoke-publish.mjs            # build + pack + scaffold + smoke
 //   bun run scripts/smoke-publish.mjs --no-build # skip the build step (reuse existing dist/)
+//   bun run scripts/smoke-publish.mjs --keep     # preserve the temp workspace + tarball
+//                                                # dir on success (always preserved on failure)
 //
 // Also wired into CI via `.github/workflows/ci-smoke-publish.yml`.
 
@@ -108,15 +110,27 @@ for (const pkgDir of PUBLISHABLE) {
   const pkg = JSON.parse(
     readFileSync(resolve(repoRoot, pkgDir, 'package.json'), 'utf-8'),
   )
-  // `--quiet` prints only the tarball path on stdout — keeps the
-  // capture parse trivial across bun versions.
-  const out = runCapture(
-    `bun pm pack --quiet --destination=${tarballDir}`,
-    { cwd: resolve(repoRoot, pkgDir) },
-  )
-  const tarballPath = out.trim().split('\n').pop()
+  // Log the package up-front so a `bun pm pack` crash names which
+  // workspace was being packed at the time of the failure — without
+  // this, the per-package line only printed on success and CI logs
+  // would surface a bare execSync stack with no package context.
+  process.stdout.write(`  ${pkg.name.padEnd(34)} → `)
+  let tarballPath
+  try {
+    // `--quiet` prints only the tarball path on stdout — keeps the
+    // capture parse trivial across bun versions.
+    const out = runCapture(
+      `bun pm pack --quiet --destination=${tarballDir}`,
+      { cwd: resolve(repoRoot, pkgDir) },
+    )
+    tarballPath = out.trim().split('\n').pop()
+  } catch (err) {
+    console.log('FAILED')
+    err.message = `bun pm pack failed for ${pkg.name} (${pkgDir}): ${err.message}`
+    throw err
+  }
   tarballs[pkg.name] = tarballPath
-  console.log(`  ${pkg.name.padEnd(34)} → ${tarballPath.split('/').pop()}`)
+  console.log(tarballPath.split('/').pop())
 }
 
 // ── 3. Scaffold via the create-barefootjs tarball ──────────────────
@@ -191,6 +205,16 @@ header('Smoke commands')
 
 const failures = []
 
+// `spawnSync` reports termination via `.status` (number) on a normal
+// exit OR `.signal` (e.g. 'SIGSEGV', 'SIGKILL') when the process was
+// killed. `status` is `null` in the signal case, which would render as
+// "exit null" with no diagnostic info — surface the signal name when
+// it's set so a kill is distinguishable from a non-zero exit.
+function describeExit(r) {
+  if (r.signal) return `signal ${r.signal}`
+  return `exit ${r.status}`
+}
+
 function smoke(label, cmd, opts = {}) {
   console.log(`\n• ${label}`)
   console.log(`  $ ${cmd}`)
@@ -199,11 +223,19 @@ function smoke(label, cmd, opts = {}) {
     shell: true,
     encoding: 'utf-8',
   })
-  const ok = r.status === 0 &&
+  const ok = r.status === 0 && !r.signal &&
     (!opts.expect || (r.stdout ?? '').includes(opts.expect))
   if (!ok) {
-    failures.push({ label, cmd, status: r.status, expect: opts.expect, stdout: r.stdout, stderr: r.stderr })
-    console.log(`  ✗ failed (exit ${r.status}${opts.expect ? `, expected "${opts.expect}"` : ''})`)
+    failures.push({
+      label,
+      cmd,
+      status: r.status,
+      signal: r.signal,
+      expect: opts.expect,
+      stdout: r.stdout,
+      stderr: r.stderr,
+    })
+    console.log(`  ✗ failed (${describeExit(r)}${opts.expect ? `, expected "${opts.expect}"` : ''})`)
     const tail = (s) => (s ?? '').slice(-1200)
     if (r.stdout) console.log(`  stdout:\n${tail(r.stdout)}`)
     if (r.stderr) console.log(`  stderr:\n${tail(r.stderr)}`)
@@ -263,7 +295,7 @@ if (failures.length === 0) {
 
 console.log(`${failures.length} smoke step(s) failed:`)
 for (const f of failures) {
-  console.log(`  - ${f.label} (exit ${f.status}${f.expect ? `, expected "${f.expect}"` : ''})`)
+  console.log(`  - ${f.label} (${describeExit(f)}${f.expect ? `, expected "${f.expect}"` : ''})`)
 }
 console.log(`\nWorkspace kept for inspection: ${workspace}`)
 console.log(`Tarballs kept for inspection:  ${tarballDir}`)


### PR DESCRIPTION
## Summary

Adds a CI smoke step that packs every publishable workspace, installs the resulting tarballs into a fresh user-style scaffold, and runs a breadth-first sweep of `bf` commands against it. Targets the "monorepo passes, end-user install crashes" regression class — the bug behind the recent `bf tokens` failure where `ctx.root` resolved a workspace-only path (`site/shared/tokens/index`) that doesn't exist in a real `node_modules/` layout.

pkg-pr-new already verifies the publish wiring; this job verifies the **runtime behaviour** of those tarballs.

## Why `bun pm pack` (not `npm pack`)

npm 10.x does not rewrite the `workspace:*` protocol when packing. A `npm pack` of `@barefootjs/jsx` still ships `"@barefootjs/shared": "workspace:*"` in its dependencies, and `npm install` then refuses the tarball with `EUNSUPPORTEDPROTOCOL`. `bun pm pack` replaces `workspace:*` with the resolved version (matching what pkg-pr-new publishes) and still fires the existing `prepack` / `postpack` hooks (the publishConfig swap on `@barefootjs/jsx` and `@barefootjs/hono`).

## What the smoke runs

After tarball + scaffold + install, it grades each command on exit code plus an `expect` substring on stdout so a silent regression (exits 0 but prints nothing) still fails the job:

- `bf tokens` / `bf tokens --category colors` — bundled `tokens.json` (the original failing case)
- `bf guide` / `bf guide quick-start` — bundled `docs/core`
- `bf docs button` / `bf search button` — meta + registry
- `bf build` — full compile pipeline
- `bf debug graph` / `bf debug trace` — analyzer
- `bf gen test` / `bf gen preview` / `bf gen component` — generators
- `bf preview` — lists output after gen
- `npm run build` — full project build (`bf build && unocss`)
- `npm test` — runs the generated `Counter.test.tsx` through whichever runner the scaffold picked (`bun test` on bun-detected, `vitest run` otherwise)

Failures dump the workspace tarball / app state via the trailing `if: failure()` step so a CI run is debuggable from the log.

## Local invocation

```sh
bun run scripts/smoke-publish.mjs              # full: build + pack + scaffold + smoke
bun run scripts/smoke-publish.mjs --no-build   # reuse existing dist/
bun run scripts/smoke-publish.mjs --keep       # preserve workspace + tarballs on success
```

## Test plan

- [x] Local run with `--no-build` (reusing dist/) — 15/15 smoke steps pass
- [x] Confirmed that with a deliberately broken bundled resource, both the exit-code check **and** the `expect` substring check fire (so silent regressions don't slip through)
- [x] `bun pm pack` rewrites `workspace:*` → `0.1.0` in tarball metadata (`tar -xzO package/package.json | jq`)
- [ ] CI run (this PR) — exercises the workflow on real GH Actions


---
_Generated by [Claude Code](https://claude.ai/code/session_01W3uZz56EJSnp2f1zaB4yfV)_