### PR TITLE
fix(adapter-go-template/#1487): resolve field-sort against map receivers

### DIFF
--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -1153,7 +1153,10 @@ func projectSortKey(item any, keyKind, keyName string) any {
 	return item
 }
 
-// getFieldValue extracts a struct field value using reflection.
+// getFieldValue extracts a struct field value using reflection. For
+// map receivers it falls back to case-variant lookup so JSON-decoded
+// user data (`map[string]any{"price": 30}`) and PascalCase-emitted
+// test data both resolve under a single key name. (#1487)
 func getFieldValue(item any, field string) any {
 	v := reflect.ValueOf(item)
 	if v.Kind() == reflect.Interface {
@@ -1162,6 +1165,27 @@ func getFieldValue(item any, field string) any {
 	if v.Kind() == reflect.Ptr {
 		v = v.Elem()
 	}
+
+	if v.Kind() == reflect.Map {
+		if v.Type().Key().Kind() != reflect.String {
+			return nil
+		}
+		if mv := v.MapIndex(reflect.ValueOf(field)); mv.IsValid() {
+			return mv.Interface()
+		}
+		if cap := capitalize(field); cap != field {
+			if mv := v.MapIndex(reflect.ValueOf(cap)); mv.IsValid() {
+				return mv.Interface()
+			}
+		}
+		if low := decapitalize(field); low != field {
+			if mv := v.MapIndex(reflect.ValueOf(low)); mv.IsValid() {
+				return mv.Interface()
+			}
+		}
+		return nil
+	}
+
 	if v.Kind() != reflect.Struct {
 		return nil
 	}
@@ -1179,6 +1203,17 @@ func capitalize(s string) string {
 		return s
 	}
 	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+// decapitalize lowercases the first character of a string. Used by
+// `getFieldValue`'s map-receiver fallback when the projected key
+// name is PascalCase but the receiver carries lowercase JS-style
+// keys (the inverse of the `capitalize` lookup).
+func decapitalize(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToLower(s[:1]) + s[1:]
 }
 
 // =============================================================================

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -1159,28 +1159,48 @@ func projectSortKey(item any, keyKind, keyName string) any {
 // test data both resolve under a single key name. (#1487)
 func getFieldValue(item any, field string) any {
 	v := reflect.ValueOf(item)
+	// Defensive IsNil guards mirror `SpreadAttrs` — keeps the helper
+	// safe against typed-nil pointer / nil-interface items inside a
+	// `[]any` so a single bad row doesn't crash the whole sort.
 	if v.Kind() == reflect.Interface {
+		if v.IsNil() {
+			return nil
+		}
 		v = v.Elem()
 	}
 	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return nil
+		}
 		v = v.Elem()
 	}
 
 	if v.Kind() == reflect.Map {
-		if v.Type().Key().Kind() != reflect.String {
+		keyType := v.Type().Key()
+		if keyType.Kind() != reflect.String {
 			return nil
 		}
-		if mv := v.MapIndex(reflect.ValueOf(field)); mv.IsValid() {
-			return mv.Interface()
+		// Convert the lookup string to the map's actual key type so
+		// maps keyed by a named string type (`type Key string`) don't
+		// panic with `value of type string is not assignable to type X`.
+		lookup := func(s string) (any, bool) {
+			k := reflect.ValueOf(s).Convert(keyType)
+			if mv := v.MapIndex(k); mv.IsValid() {
+				return mv.Interface(), true
+			}
+			return nil, false
+		}
+		if r, ok := lookup(field); ok {
+			return r
 		}
 		if cap := capitalize(field); cap != field {
-			if mv := v.MapIndex(reflect.ValueOf(cap)); mv.IsValid() {
-				return mv.Interface()
+			if r, ok := lookup(cap); ok {
+				return r
 			}
 		}
 		if low := decapitalize(field); low != field {
-			if mv := v.MapIndex(reflect.ValueOf(low)); mv.IsValid() {
-				return mv.Interface()
+			if r, ok := lookup(low); ok {
+				return r
 			}
 		}
 		return nil

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -913,6 +913,47 @@ func TestSort_FieldString(t *testing.T) {
 	}
 }
 
+// (#1487) `bf_sort` is called with a PascalCase key name (the IR
+// emits `bf_sort .Items "field" "Price" ...`), but user data flows
+// in as a `map[string]any` whose keys may be either lowercase
+// (JS-style — JSON.parse output, test-renderer top-level objects)
+// or PascalCase (Go-side data, test-renderer nested-in-array
+// objects). `getFieldValue`'s map fallback resolves both via a
+// case-variant lookup.
+func TestSort_FieldOnMapReceiver_PascalCaseKeys(t *testing.T) {
+	items := []any{
+		map[string]any{"Name": "c", "Price": 30},
+		map[string]any{"Name": "a", "Price": 10},
+		map[string]any{"Name": "b", "Price": 20},
+	}
+	got := Sort(items, "field", "Price", "numeric", "asc")
+	if len(got) != 3 {
+		t.Fatalf("Sort returned %d items, want 3", len(got))
+	}
+	firstPrice := got[0].(map[string]any)["Price"]
+	lastPrice := got[2].(map[string]any)["Price"]
+	if firstPrice != 10 || lastPrice != 30 {
+		t.Errorf("Sort PascalCase map asc = %v, want first.Price=10 last.Price=30", got)
+	}
+}
+
+func TestSort_FieldOnMapReceiver_LowercaseKeys(t *testing.T) {
+	items := []any{
+		map[string]any{"name": "c", "price": 30},
+		map[string]any{"name": "a", "price": 10},
+		map[string]any{"name": "b", "price": 20},
+	}
+	got := Sort(items, "field", "Price", "numeric", "asc")
+	if len(got) != 3 {
+		t.Fatalf("Sort returned %d items, want 3", len(got))
+	}
+	firstPrice := got[0].(map[string]any)["price"]
+	lastPrice := got[2].(map[string]any)["price"]
+	if firstPrice != 10 || lastPrice != 30 {
+		t.Errorf("Sort lowercase map asc = %v, want first.price=10 last.price=30", got)
+	}
+}
+
 // =============================================================================
 // JS-compat callees (#1188): bf_json / bf_string / bf_number /
 // bf_floor / bf_ceil / bf_round / bf_replace.

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -954,6 +954,46 @@ func TestSort_FieldOnMapReceiver_LowercaseKeys(t *testing.T) {
 	}
 }
 
+// (#1489 review) `MapIndex(reflect.ValueOf(string))` panics on a
+// `map[NamedString]V` because the dynamic key type doesn't match
+// `string`. `getFieldValue` converts the lookup to the map's
+// declared key type so JSON-decoded data with `type Key string`
+// keys still resolves.
+func TestSort_FieldOnMapReceiver_NamedStringKey(t *testing.T) {
+	type Key string
+	items := []any{
+		map[Key]any{"price": 30, "name": "c"},
+		map[Key]any{"price": 10, "name": "a"},
+		map[Key]any{"price": 20, "name": "b"},
+	}
+	got := Sort(items, "field", "Price", "numeric", "asc")
+	if len(got) != 3 {
+		t.Fatalf("Sort returned %d items, want 3", len(got))
+	}
+	firstPrice := got[0].(map[Key]any)["price"]
+	if firstPrice != 10 {
+		t.Errorf("Sort named-key map asc first.price = %v, want 10", firstPrice)
+	}
+}
+
+// (#1489 review) Nil interface entries inside `[]any` must not panic
+// — `getFieldValue`'s IsNil guards keep a single bad row from taking
+// the whole sort down.
+func TestSort_FieldOnMapReceiver_TolerantToNilEntries(t *testing.T) {
+	items := []any{
+		map[string]any{"price": 30},
+		nil,
+		map[string]any{"price": 10},
+	}
+	got := Sort(items, "field", "Price", "numeric", "asc")
+	if len(got) != 3 {
+		t.Fatalf("Sort returned %d items, want 3", len(got))
+	}
+	// nil projects to 0 (toFloat64(nil)) and sorts to the front
+	// alongside any other zero-keyed entries — the assertion here
+	// is that we didn't panic, and the result length is preserved.
+}
+
 // =============================================================================
 // JS-compat callees (#1188): bf_json / bf_string / bf_number /
 // bf_floor / bf_ceil / bf_round / bf_replace.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -76,19 +76,6 @@ runAdapterConformanceTests({
     // hits the identical `template.HTML` interpolation gap as
     // `children-jsx-expression` above.
     'fragment-wrapped-children-jsx-expression',
-    // #1487: #1475's `key → data-key` rewrite landed in this PR
-    // (the Mojo sibling now passes end-to-end), but Go SSR through
-    // the test renderer still can't render the field-based sort
-    // fixtures: `generateTypes` falls back to `Items interface{}`
-    // for nested object arrays, and the test renderer emits
-    // `map[string]any` with lowercase keys → `{{.Name}}` resolves
-    // to the zero value. Sort lowering itself is exercised by the
-    // standalone Tier B fixtures (`array-sort-primitive`,
-    // `array-sort-locale`, `array-toSorted`) and pinned via the
-    // fixture-driven block at the bottom of this file. Drops when
-    // #1487 lands.
-    'array-sort-field-asc',
-    'array-sort-field-desc',
   ],
   // Per-fixture build-time contracts for shapes the Go template
   // adapter intentionally refuses to lower. Lives here (not on the

--- a/packages/adapter-go-template/src/test-render.ts
+++ b/packages/adapter-go-template/src/test-render.ts
@@ -319,21 +319,33 @@ function goArrayLiteralFromArray(arr: unknown[]): string {
     else if (typeof v === 'boolean') entries.push(String(v))
     else if (v === null) entries.push('nil')
     else if (Array.isArray(v)) entries.push(goArrayLiteralFromArray(v))
-    else if (v && typeof v === 'object') entries.push(goMapLiteralFromObject(v as Record<string, unknown>))
+    else if (v && typeof v === 'object') {
+      // Objects inside arrays are accessed via Go-struct-style
+      // template field paths (`{{.Name}}`) and sort projections
+      // (`bf_sort ... "Price" ...`), both of which expect PascalCase
+      // identifiers. html/template does case-sensitive map lookup,
+      // so emit capitalized keys so `{{.Name}}` resolves directly
+      // without relying on the runtime's case-fallback. (#1487)
+      entries.push(goMapLiteralFromObject(v as Record<string, unknown>, true))
+    }
   }
   return `[]any{${entries.join(', ')}}`
 }
 
-function goMapLiteralFromObject(obj: Record<string, unknown>): string {
+function goMapLiteralFromObject(
+  obj: Record<string, unknown>,
+  capitalizeKeys = false,
+): string {
   const entries: string[] = []
   for (const [k, v] of Object.entries(obj)) {
-    const key = JSON.stringify(k)
+    const emittedKey = capitalizeKeys ? k.charAt(0).toUpperCase() + k.slice(1) : k
+    const key = JSON.stringify(emittedKey)
     if (typeof v === 'string') entries.push(`${key}: "${v.replace(/"/g, '\\"')}"`)
     else if (typeof v === 'number') entries.push(`${key}: ${v}`)
     else if (typeof v === 'boolean') entries.push(`${key}: ${v}`)
     else if (v === null) entries.push(`${key}: nil`)
     else if (v && typeof v === 'object' && !Array.isArray(v)) {
-      entries.push(`${key}: ${goMapLiteralFromObject(v as Record<string, unknown>)}`)
+      entries.push(`${key}: ${goMapLiteralFromObject(v as Record<string, unknown>, capitalizeKeys)}`)
     }
   }
   return `map[string]any{${entries.join(', ')}}`


### PR DESCRIPTION
## Summary

Closes #1487. Resolves the `bf_sort` projection gap on `map[string]any` receivers, so the two `array-sort-field-*` fixtures that #1486 had to re-skip on Go alone now render end-to-end.

Two layers fixed, both following the path the issue laid out (approach **B** — the orthogonal **A** "synthesize per-element Go struct in `generateTypes`" is left untouched):

- **Runtime (`bf.go`)** — `getFieldValue` grows a `reflect.Map` branch (string-keyed only) that tries the field name verbatim, then `capitalize(field)`, then `decapitalize(field)`. With the IR emitting PascalCase key names (`bf_sort .Items "field" "Price" …`), this resolves both JSON-decoded user data (lowercase keys) and Go-side / test-renderer nested-in-array data (PascalCase keys) under a single projection. Mirrors the Mojo `bf->sort` `ref($item) eq 'HASH'` branch.
- **Test renderer (`test-render.ts`)** — `goMapLiteralFromObject` accepts a `capitalizeKeys` flag, passed `true` by `goArrayLiteralFromArray` for objects nested in arrays so `{{.Name}}` in the template body resolves directly under html/template's case-sensitive map lookup. Top-level call from `propsToGoStructLiteral` still emits keys verbatim — this preserves the lowercase HTML-attribute semantics that `bf_spread_attrs` consumers (`jsx-spread-rest-prop` etc.) depend on, per the issue's third acceptance criterion.

`array-sort-field-asc` / `array-sort-field-desc` drop from `skipJsx` on the Go adapter; the `#1487` skip-comment block is removed.

## Test plan
- [x] `bun test packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts` — 275 pass / 2 skip (the 2 are the pre-existing `children-jsx-expression` / `fragment-wrapped-children-jsx-expression` skips, unrelated).
- [x] `go test ./...` in `packages/adapter-go-template/runtime/` — passes, including two new `TestSort_FieldOnMapReceiver_*` cases pinning both PascalCase and lowercase map-key directions through `getFieldValue`.
- [ ] CI confirms Go adapter conformance (the local check ran under `GOTOOLCHAIN=go1.25.6`).

## References
- #1448 Tier A/B catalog (parent).
- #1486 — `key → data-key` rewrite that surfaced this gap; the Go skip block referencing #1487 lands at the comment block this PR removes.
- Issue text: https://github.com/piconic-ai/barefootjs/issues/1487


---
_Generated by [Claude Code](https://claude.ai/code/session_01HJRNyteQamZmADhftGjtSJ)_