### PR TITLE
unify shared-component snapshot regen into the auto-update workflow

### DIFF
--- a/.github/workflows/update-fixtures.yml
+++ b/.github/workflows/update-fixtures.yml
@@ -9,6 +9,13 @@ on:
       - 'packages/client/**'
       - 'packages/adapter-tests/src/**'
       - 'packages/adapter-tests/scripts/**'
+      # Shared-component fixture sources (fixture-hydrate corpus inputs).
+      # Editing a `*.tsx` here regenerates the `__snapshots__/<id>.{html,client.js}` pair.
+      - 'integrations/shared/components/**'
+      # Fixture spec files (adding a new fixture, changing its props, or
+      # adjusting `componentName` / `sourceFile` / `additionalComponents`
+      # changes the snapshot output).
+      - 'packages/adapter-tests/fixtures/**'
 
 permissions:
   contents: write

--- a/packages/adapter-tests/scripts/generate-expected-html.ts
+++ b/packages/adapter-tests/scripts/generate-expected-html.ts
@@ -11,6 +11,7 @@ import { HonoAdapter } from '@barefootjs/hono/adapter'
 import { renderHonoComponent } from '@barefootjs/hono/test-render'
 import { normalizeHTML } from '../src/jsx-runner'
 import { indentHTML } from '../src/indent-html'
+import { generateAllSharedComponentSnapshots } from '../src/snapshot-generator'
 import { jsxFixtures } from '../fixtures'
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
@@ -105,6 +106,20 @@ async function main() {
   }
 
   console.log(`\nDone: ${updated} updated, ${failed} failed, ${skipped} skipped`)
+
+  // Shared-component fixtures (fixture-hydrate corpus) write their
+  // expectedHtml + expectedClientJs to `fixtures/__snapshots__/<id>.{html,client.js}`
+  // instead of inline strings in the .ts file. Regenerate them here so a single
+  // auto-update run keeps both fixture flavours in sync — same trigger, same
+  // commit, no separate workflow.
+  console.log('\nRegenerating shared-component snapshots…')
+  try {
+    await generateAllSharedComponentSnapshots()
+  } catch (err) {
+    console.error(`✗ shared-component snapshots: ${(err as Error).message}`)
+    failed++
+  }
+
   if (failed > 0) process.exit(1)
 }
 

--- a/packages/adapter-tests/scripts/snapshot.ts
+++ b/packages/adapter-tests/scripts/snapshot.ts
@@ -1,129 +1,17 @@
 /**
- * Unified snapshot generator for shared-component fixtures.
- *
- * Imports each fixture's `spec` (no snapshot IO at import time —
- * `defineSharedFixture` tolerates missing snapshot files via existsSync),
- * runs SSR via `renderHonoComponent` with a deterministic
- * `${componentName}_test` instanceId, compiles client JS through
- * `compileJSX` (the same multi-component-merged-import path `bf build`
- * consumers use, avoiding the duplicate-`import` crash that raw
- * `generateClientJs` concatenation produces), and writes the frozen pair
- * to `fixtures/__snapshots__/`.
+ * Unified snapshot CLI for shared-component fixtures — thin wrapper
+ * around `src/snapshot-generator.ts`. The auto-update workflow calls
+ * the library directly from `generate-expected-html.ts`; this script
+ * stays for interactive `bun run` invocations.
  *
  * Usage:
  *   bun run packages/adapter-tests/scripts/snapshot.ts             # all fixtures
  *   bun run packages/adapter-tests/scripts/snapshot.ts counter-shared toggle-shared
  */
 
-import { writeFileSync } from 'node:fs'
-import { resolve } from 'node:path'
-import { renderHonoComponent } from '@barefootjs/hono/test-render'
-import { HonoAdapter } from '@barefootjs/hono/adapter'
-import { compileJSX, combineParentChildClientJs } from '@barefootjs/jsx'
-import {
-  SHARED_COMPONENTS_DIR,
-  SNAPSHOT_DIR,
-  loadAllSharedSpecs,
-  sourceFileBasename,
-  type SharedFixtureSpec,
-} from '../fixtures/_helpers'
-
-const allSpecs = await loadAllSharedSpecs()
+import { generateAllSharedComponentSnapshots } from '../src/snapshot-generator'
 
 const requested = process.argv.slice(2)
-const selected =
-  requested.length === 0
-    ? allSpecs
-    : allSpecs.filter(s => requested.includes(s.id))
-
-if (requested.length > 0 && selected.length !== requested.length) {
-  const knownIds = allSpecs.map(s => s.id).join(', ')
-  const unknown = requested.filter(id => !allSpecs.some(s => s.id === id))
-  throw new Error(
-    `Unknown fixture id(s): ${unknown.join(', ')}. Known: ${knownIds}`,
-  )
-}
-
-for (const spec of selected) {
-  await generateSnapshot(spec)
-}
-
-async function compileClientJs(basename: string): Promise<string> {
-  const sourcePath = resolve(SHARED_COMPONENTS_DIR, `${basename}.tsx`)
-  const source = await Bun.file(sourcePath).text()
-  const compiled = compileJSX(source, `${basename}.tsx`, { adapter: new HonoAdapter() })
-  const file = compiled.files.find(f => f.type === 'clientJs')
-  if (!file) {
-    const errs = compiled.errors.map(e => `${e.severity}: ${e.message}`).join('\n')
-    throw new Error(`No clientJs file in compileJSX output for ${basename}.tsx:\n${errs}`)
-  }
-  return file.content
-}
-
-async function generateSnapshot(spec: SharedFixtureSpec): Promise<void> {
-  const sourceBasename = sourceFileBasename(spec)
-  const sourcePath = resolve(SHARED_COMPONENTS_DIR, `${sourceBasename}.tsx`)
-  const source = await Bun.file(sourcePath).text()
-
-  // Pin the root scope's `bf-s` via `__instanceId` so the hydration walker's
-  // scopeName parser (`id.slice(0, id.indexOf('_'))`) resolves the registered
-  // component. The conformance default `__instanceId: 'test'` yields an
-  // underscore-less id the walker cannot dispatch from.
-  const ssrProps = { ...spec.props, __instanceId: `${spec.componentName}_test` }
-
-  // SSR-side child injection. When the parent's template invokes child
-  // components synchronously (no `/* @client */` deferral), the temp file
-  // renderHonoComponent writes can't resolve their `./Child` imports — pass
-  // each child's source through `components` so the helper inlines them.
-  //
-  // Key with the leading `./` so `renderHonoComponent`'s import-strip filter
-  // (which does an exact-string match against the import path) matches the
-  // `import Child from './Child'` line the compiled parent template emits.
-  const components: Record<string, string> = {}
-  for (const extra of spec.additionalComponents ?? []) {
-    const extraSource = await Bun.file(
-      resolve(SHARED_COMPONENTS_DIR, `${extra}.tsx`),
-    ).text()
-    components[`./${extra}.tsx`] = extraSource
-  }
-
-  const ssrHtml = await renderHonoComponent({
-    source,
-    adapter: new HonoAdapter(),
-    props: ssrProps,
-    // Pin the target export — `Object.keys(mod)` iterates alphabetically
-    // for dynamically imported modules in Bun, so multi-component files
-    // can otherwise render the wrong component.
-    componentName: spec.componentName,
-    components: Object.keys(components).length > 0 ? components : undefined,
-  })
-
-  let clientJs: string
-  const extras = spec.additionalComponents ?? []
-  if (extras.length === 0) {
-    clientJs = await compileClientJs(sourceBasename)
-  } else {
-    // Use `combineParentChildClientJs` (same helper `bf build` uses) to
-    // inline child component bundles into the parent and resolve the
-    // `import '/* @bf-child:... */'` placeholders the compiler emits.
-    // Raw concat would leave the placeholders intact and the browser
-    // would 404 on `/* @bf-child:... */` URLs.
-    const files = new Map<string, string>()
-    files.set(sourceBasename, await compileClientJs(sourceBasename))
-    for (const extra of extras) {
-      files.set(extra, await compileClientJs(extra))
-    }
-    const combined = combineParentChildClientJs(files)
-    clientJs = combined.get(sourceBasename) ?? files.get(sourceBasename)!
-  }
-
-  const htmlOut = resolve(SNAPSHOT_DIR, `${spec.id}.html`)
-  const clientJsOut = resolve(SNAPSHOT_DIR, `${spec.id}.client.js`)
-  writeFileSync(htmlOut, ssrHtml.trim() + '\n')
-  writeFileSync(clientJsOut, clientJs.trimEnd() + '\n')
-
-  console.log(
-    `[${spec.id}] wrote ${spec.id}.html (${ssrHtml.length}B) + ` +
-      `${spec.id}.client.js (${clientJs.length}B)`,
-  )
-}
+await generateAllSharedComponentSnapshots(
+  requested.length > 0 ? { ids: requested } : undefined,
+)

--- a/packages/adapter-tests/src/snapshot-generator.ts
+++ b/packages/adapter-tests/src/snapshot-generator.ts
@@ -1,0 +1,129 @@
+/**
+ * Shared-component fixture snapshot generator.
+ *
+ * Library-shaped wrapper around the snapshot pipeline both
+ * `scripts/snapshot.ts` (interactive CLI) and
+ * `scripts/generate-expected-html.ts` (auto-update workflow entry point)
+ * call into, so the fixture-hydrate layer and the inline-expectedHtml
+ * conformance corpus stay in sync from a single source of truth.
+ */
+
+import { writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { renderHonoComponent } from '@barefootjs/hono/test-render'
+import { HonoAdapter } from '@barefootjs/hono/adapter'
+import { compileJSX, combineParentChildClientJs } from '@barefootjs/jsx'
+import {
+  SHARED_COMPONENTS_DIR,
+  SNAPSHOT_DIR,
+  loadAllSharedSpecs,
+  sourceFileBasename,
+  type SharedFixtureSpec,
+} from '../fixtures/_helpers'
+
+async function compileClientJs(basename: string): Promise<string> {
+  const sourcePath = resolve(SHARED_COMPONENTS_DIR, `${basename}.tsx`)
+  const source = await Bun.file(sourcePath).text()
+  const compiled = compileJSX(source, `${basename}.tsx`, { adapter: new HonoAdapter() })
+  const file = compiled.files.find(f => f.type === 'clientJs')
+  if (!file) {
+    const errs = compiled.errors.map(e => `${e.severity}: ${e.message}`).join('\n')
+    throw new Error(`No clientJs file in compileJSX output for ${basename}.tsx:\n${errs}`)
+  }
+  return file.content
+}
+
+export async function generateSharedComponentSnapshot(
+  spec: SharedFixtureSpec,
+): Promise<{ htmlBytes: number; clientJsBytes: number }> {
+  const sourceBasename = sourceFileBasename(spec)
+  const sourcePath = resolve(SHARED_COMPONENTS_DIR, `${sourceBasename}.tsx`)
+  const source = await Bun.file(sourcePath).text()
+
+  // Pin the root scope's `bf-s` via `__instanceId` so the hydration walker's
+  // scopeName parser (`id.slice(0, id.indexOf('_'))`) resolves the registered
+  // component. The conformance default `__instanceId: 'test'` yields an
+  // underscore-less id the walker cannot dispatch from.
+  const ssrProps = { ...spec.props, __instanceId: `${spec.componentName}_test` }
+
+  // SSR-side child injection. When the parent's template invokes child
+  // components synchronously (no `/* @client */` deferral), the temp file
+  // renderHonoComponent writes can't resolve their `./Child` imports — pass
+  // each child's source through `components` so the helper inlines them.
+  //
+  // Key with the leading `./` so `renderHonoComponent`'s import-strip filter
+  // (which does an exact-string match against the import path) matches the
+  // `import Child from './Child'` line the compiled parent template emits.
+  const components: Record<string, string> = {}
+  for (const extra of spec.additionalComponents ?? []) {
+    const extraSource = await Bun.file(
+      resolve(SHARED_COMPONENTS_DIR, `${extra}.tsx`),
+    ).text()
+    components[`./${extra}.tsx`] = extraSource
+  }
+
+  const ssrHtml = await renderHonoComponent({
+    source,
+    adapter: new HonoAdapter(),
+    props: ssrProps,
+    // Pin the target export — `Object.keys(mod)` iterates alphabetically
+    // for dynamically imported modules in Bun, so multi-component files
+    // can otherwise render the wrong component.
+    componentName: spec.componentName,
+    components: Object.keys(components).length > 0 ? components : undefined,
+  })
+
+  let clientJs: string
+  const extras = spec.additionalComponents ?? []
+  if (extras.length === 0) {
+    clientJs = await compileClientJs(sourceBasename)
+  } else {
+    // Use `combineParentChildClientJs` (same helper `bf build` uses) to
+    // inline child component bundles into the parent and resolve the
+    // `import '/* @bf-child:... */'` placeholders the compiler emits.
+    // Raw concat would leave the placeholders intact and the browser
+    // would 404 on `/* @bf-child:... */` URLs.
+    const files = new Map<string, string>()
+    files.set(sourceBasename, await compileClientJs(sourceBasename))
+    for (const extra of extras) {
+      files.set(extra, await compileClientJs(extra))
+    }
+    const combined = combineParentChildClientJs(files)
+    clientJs = combined.get(sourceBasename) ?? files.get(sourceBasename)!
+  }
+
+  const htmlOut = resolve(SNAPSHOT_DIR, `${spec.id}.html`)
+  const clientJsOut = resolve(SNAPSHOT_DIR, `${spec.id}.client.js`)
+  writeFileSync(htmlOut, ssrHtml.trim() + '\n')
+  writeFileSync(clientJsOut, clientJs.trimEnd() + '\n')
+
+  return { htmlBytes: ssrHtml.length, clientJsBytes: clientJs.length }
+}
+
+export async function generateAllSharedComponentSnapshots(
+  filter?: { ids?: ReadonlyArray<string> },
+): Promise<{ generated: number; specs: SharedFixtureSpec[] }> {
+  const all = await loadAllSharedSpecs()
+  const requested = filter?.ids
+  const selected = requested
+    ? all.filter(s => requested.includes(s.id))
+    : all
+
+  if (requested && selected.length !== requested.length) {
+    const knownIds = all.map(s => s.id).join(', ')
+    const unknown = requested.filter(id => !all.some(s => s.id === id))
+    throw new Error(
+      `Unknown fixture id(s): ${unknown.join(', ')}. Known: ${knownIds}`,
+    )
+  }
+
+  for (const spec of selected) {
+    const { htmlBytes, clientJsBytes } = await generateSharedComponentSnapshot(spec)
+    console.log(
+      `[${spec.id}] wrote ${spec.id}.html (${htmlBytes}B) + ` +
+        `${spec.id}.client.js (${clientJsBytes}B)`,
+    )
+  }
+
+  return { generated: selected.length, specs: selected }
+}


### PR DESCRIPTION
## Summary

Closes the gap in the existing fixture auto-update workflow.

`update-fixtures.yml` (and the `generate-expected-html.ts` script it runs) already regenerates inline `expectedHtml` for every conformance corpus fixture on PRs touching the compiler / Hono / client / adapter-tests internals, then commits any drift back to the PR.

Shared-component fixtures (fixture-hydrate corpus) write their `expectedHtml` + `expectedClientJs` to `fixtures/__snapshots__/<id>.{html,client.js}` instead of inline strings — so the existing generator never touched them. Until now they only updated when I ran `scripts/snapshot.ts` by hand and pushed.

## What this PR does

- Lifts the snapshot pipeline out of `scripts/snapshot.ts` into `src/snapshot-generator.ts` (library module both scripts call).
- `scripts/snapshot.ts` shrinks to a thin CLI wrapper that exists for interactive `bun run` invocations.
- `generate-expected-html.ts` calls `generateAllSharedComponentSnapshots()` at the tail of its existing run.
- `update-fixtures.yml` `paths:` filter expands to also fire on:
  - `integrations/shared/components/**` — the .tsx sources whose output the snapshots pin
  - `packages/adapter-tests/fixtures/**` — new specs / prop changes / additionalComponents edits

The commit step already stages `packages/adapter-tests/fixtures/` recursively, so the new `__snapshots__/` deltas ride along without further workflow changes. The "Check for changes" diff gate keeps efficiency intact — clean runs on irrelevant compiler changes complete without committing.

## Test plan

- [x] `bun run packages/adapter-tests/scripts/generate-expected-html.ts` — 98 inline fixtures + 11 shared-component snapshots regenerated, exits clean
- [x] `bun test packages/adapter-tests` — 455/455
- [x] `bunx playwright test --config=packages/adapter-tests/playwright.config.ts` — 11/11

## Stack

base = `claude/fixture-hydrate-dynamic-discovery` (#1490). Reuses `loadAllSharedSpecs` from that PR.

Next: shared-component fixtures → adapter-conformance corpus (#1466).

https://claude.ai/code/session_012E4zrPUxiCMbCKJJKT2rJt

---
_Generated by [Claude Code](https://claude.ai/code/session_012E4zrPUxiCMbCKJJKT2rJt)_