### PR TITLE
fix jsx-compatibility doc: localeCompare is supported, not an error

### DIFF
--- a/docs/core/rendering/jsx-compatibility.md
+++ b/docs/core/rendering/jsx-compatibility.md
@@ -61,12 +61,12 @@ return <div>...</div>
 ))}
 
 // ✅ Filter, sort, then render
-{items().filter(x => x.active).sort((a, b) => a.name > b.name ? 1 : -1).map(item => (
+{items().filter(x => x.active).sort((a, b) => a.name.localeCompare(b.name)).map(item => (
   <Item key={item.id} item={item} />
 ))}
 ```
 
-Some comparators (e.g., `localeCompare`, block bodies) are not supported and will produce a compile error — use `/* @client */` in that case.
+Supported comparator shapes: `(a, b) => a - b`, `(a, b) => a.field - b.field`, `(a, b) => a.localeCompare(b)`, `(a, b) => a.field.localeCompare(b.field)` (reverse the operands for descending order). Other shapes — block bodies, ternary returns, custom helpers — produce a compile error; use `/* @client */` in that case.
 
 
 ## Event Handling
@@ -146,14 +146,14 @@ Some JavaScript expressions cannot be translated into marked template syntax. Wh
 
 ### Patterns that error on all adapters
 
-**Unsupported sort comparators** (`localeCompare`, block bodies):
+**Unsupported sort comparators** (block bodies, ternary returns):
 
 ```tsx
 // ❌ BF021 (all adapters)
-{items().sort((a, b) => a.name.localeCompare(b.name)).map(...)}
+{items().sort((a, b) => a.name > b.name ? 1 : -1).map(...)}
 
 // ✅ Use /* @client */
-{/* @client */ items().sort((a, b) => a.name.localeCompare(b.name)).map(...)}
+{/* @client */ items().sort((a, b) => a.name > b.name ? 1 : -1).map(...)}
 ```
 
 See the [TodoApp example](https://github.com/piconic-ai/barefootjs/blob/main/integrations/shared/components/TodoApp.tsx) for a real-world component using `/* @client */`.

--- a/docs/core/rendering/jsx-compatibility.md
+++ b/docs/core/rendering/jsx-compatibility.md
@@ -97,7 +97,7 @@ Some JavaScript expressions cannot be translated into marked template syntax. Wh
 | `.filter()` with `function` keyword callback | works | **BF101** |
 | `.reduce()`, `.forEach()`, `.flatMap()` | works | **BF101** |
 | Nested higher-order in filter predicate (`x => x.tags.filter(...).length > 0`) | works | **BF101** |
-| Sort comparator using `localeCompare` or a block body | **BF021** (all adapters) | **BF021** |
+| Sort comparator with a block body, ternary return, or other unsupported shape | **BF021** (all adapters) | **BF021** |
 | `typeof` in a filter predicate | **BF021** (all adapters) | **BF021** |
 
 `BF021` is raised at the IR layer and applies to every adapter. `BF101` is raised by adapters that can't lower the expression to their template language. Either way, add [`/* @client */`](./client-directive.md) to opt into client-only evaluation and suppress the error.
@@ -150,10 +150,14 @@ Some JavaScript expressions cannot be translated into marked template syntax. Wh
 
 ```tsx
 // ❌ BF021 (all adapters)
-{items().sort((a, b) => a.name > b.name ? 1 : -1).map(...)}
+{items().sort((a, b) => a.name > b.name ? 1 : -1).map(item => (
+  <Item key={item.id} item={item} />
+))}
 
 // ✅ Use /* @client */
-{/* @client */ items().sort((a, b) => a.name > b.name ? 1 : -1).map(...)}
+{/* @client */ items().sort((a, b) => a.name > b.name ? 1 : -1).map(item => (
+  <Item key={item.id} item={item} />
+))}
 ```
 
 See the [TodoApp example](https://github.com/piconic-ai/barefootjs/blob/main/integrations/shared/components/TodoApp.tsx) for a real-world component using `/* @client */`.

--- a/packages/jsx/src/__tests__/doc-examples-jsx-compatibility.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples-jsx-compatibility.test.ts
@@ -204,6 +204,15 @@ describe('docs/core/rendering/jsx-compatibility.md doc-examples', () => {
               `expected error ${code}, got: ${got}\n--- source ---\n${source}`,
             )
           }
+          const unexpected = fatals.filter(e => e.code !== code)
+          if (unexpected.length > 0) {
+            const dump = unexpected
+              .map(e => `  ${e.code}: ${e.message}`)
+              .join('\n')
+            throw new Error(
+              `expected only ${code}, but got additional fatal errors:\n${dump}\n--- source ---\n${source}`,
+            )
+          }
           return
         }
       }

--- a/packages/jsx/src/__tests__/doc-examples-jsx-compatibility.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples-jsx-compatibility.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Doc Examples — JSX Compatibility (v1, #1439)
+ *
+ * Mechanically validates that the fenced code examples in
+ * `docs/core/rendering/jsx-compatibility.md` still compile (or fail
+ * with the documented BFxxx code) on the current compiler.
+ *
+ * Prompted by #1434 — `.filter().map()` with a block-body predicate
+ * silently dropped the `.filter()` even though that exact shape is
+ * documented as supported. A documented pattern that silently breaks
+ * is the worst case for end-user trust, so this test treats each doc
+ * example as a contract.
+ *
+ * v1 scope (this file): one page (jsx-compatibility.md), one adapter
+ * (TestAdapter — Hono-like baseline). The `// ❌ BFxxx on Go/Mojo;
+ * works on Hono` examples assert *positive* here — the cross-adapter
+ * check (Go / Mojo actually raising BFxxx) is a follow-up once the v1
+ * mechanism is proven.
+ *
+ * Examples containing markdown shorthand are skipped with a recorded
+ * reason and triaged separately:
+ *   - `(...)` placeholder, e.g. `.map(...)`
+ *   - `>...<` text-content placeholder
+ *   - statement-body (first non-ws token isn't `{` or `<`)
+ */
+
+import { describe, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const DOC_PATH = resolve(
+  __dirname,
+  '../../../../docs/core/rendering/jsx-compatibility.md',
+)
+
+type Expected =
+  | { kind: 'positive' }
+  | { kind: 'negative-all-adapters'; code: string }
+  | { kind: 'negative-go-mojo-only'; code: string }
+
+interface DocExample {
+  label: string
+  startLine: number
+  expected: Expected
+  body: string
+  skipReason?: string
+}
+
+function parseExpected(labelLine: string): Expected {
+  const text = labelLine.replace(/^\s*\/\/\s*/, '')
+  const allAdapters = text.match(/❌\s*(BF\d+)\s*\(all adapters\)/)
+  if (allAdapters) return { kind: 'negative-all-adapters', code: allAdapters[1] }
+  const goMojo = text.match(/❌\s*(BF\d+)\s+on Go\/Mojo/)
+  if (goMojo) return { kind: 'negative-go-mojo-only', code: goMojo[1] }
+  const anyNegative = text.match(/❌\s*(BF\d+)/)
+  if (anyNegative) return { kind: 'negative-all-adapters', code: anyNegative[1] }
+  return { kind: 'positive' }
+}
+
+function detectSkipReason(body: string): string | undefined {
+  if (/\(\s*\.\.\.\s*\)/.test(body)) return 'contains `(...)` placeholder'
+  if (/>\s*\.\.\.\s*</.test(body)) return 'contains `>...<` placeholder'
+  const firstChar = body.trim().charAt(0)
+  if (firstChar !== '{' && firstChar !== '<') {
+    return 'statement-body (not an expression / element)'
+  }
+  return undefined
+}
+
+function extractExamples(md: string): DocExample[] {
+  const lines = md.split('\n')
+  const examples: DocExample[] = []
+
+  let i = 0
+  while (i < lines.length) {
+    if (!/^```tsx\s*$/.test(lines[i])) {
+      i++
+      continue
+    }
+
+    const fenceLineNumber = i + 1
+    let j = i + 1
+    while (j < lines.length && !/^```\s*$/.test(lines[j])) j++
+
+    const blockLines = lines.slice(i + 1, j)
+    const segments: Array<{ offset: number; lines: string[] }> = []
+    let cur: { offset: number; lines: string[] } | null = null
+
+    blockLines.forEach((ln, idx) => {
+      if (/^\s*\/\//.test(ln)) {
+        if (cur && cur.lines.some(l => l.trim() !== '')) segments.push(cur)
+        cur = { offset: idx, lines: [ln] }
+      } else {
+        if (!cur) cur = { offset: idx, lines: [] }
+        cur.lines.push(ln)
+      }
+    })
+    if (cur && cur.lines.some(l => l.trim() !== '')) segments.push(cur)
+
+    for (const seg of segments) {
+      const hasLabel = /^\s*\/\//.test(seg.lines[0])
+      const labelLine = hasLabel ? seg.lines[0] : ''
+      const bodyLines = hasLabel ? seg.lines.slice(1) : seg.lines
+      const body = bodyLines.join('\n').trim()
+      if (body === '') continue
+      const label = hasLabel
+        ? labelLine.replace(/^\s*\/\/\s*/, '').trim() || '(empty label)'
+        : '(no label)'
+      const startLine =
+        fenceLineNumber + 1 + seg.offset + (hasLabel ? 1 : 0)
+      const expected = parseExpected(labelLine)
+      const skipReason = detectSkipReason(body)
+      examples.push({ label, startLine, expected, body, skipReason })
+    }
+
+    i = j + 1
+  }
+  return examples
+}
+
+const SCAFFOLD_HEADER = `'use client'
+import { createSignal } from '@barefootjs/client'
+
+function TodoItem(props: { todo: any; key?: any }) { return <li>{String(props.todo)}</li> }
+function Item(props: { item: any; key?: any }) { return <li>{String(props.item)}</li> }
+function Dashboard() { return <div>D</div> }
+
+export function Example() {
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal<Array<{ id: number; done: boolean; name: string }>>([])
+  const [items] = createSignal<Array<{ id: number; active: boolean; done: boolean; price: number; name: string; tags: Array<{ active: boolean }> }>>([])
+  const [filter] = createSignal<'all' | 'active' | 'completed'>('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+  const status: string = 'empty'
+  const handleSubmit = () => {}
+  return (
+    <div>
+`
+
+const SCAFFOLD_FOOTER = `
+    </div>
+  )
+}
+`
+
+function buildSource(example: DocExample): string {
+  return SCAFFOLD_HEADER + example.body + SCAFFOLD_FOOTER
+}
+
+const adapter = new TestAdapter()
+
+function compileOnce(source: string) {
+  const result = compileJSX(source, 'DocExample.tsx', { adapter })
+  return result.errors.filter(e => e.severity === 'error')
+}
+
+describe('docs/core/rendering/jsx-compatibility.md doc-examples', () => {
+  const md = readFileSync(DOC_PATH, 'utf8')
+  const examples = extractExamples(md)
+
+  test('extractor returned a non-empty set of examples', () => {
+    if (examples.length === 0) {
+      throw new Error(
+        'extractor returned zero examples — has the markdown structure changed?',
+      )
+    }
+  })
+
+  for (const ex of examples) {
+    const name = `L${ex.startLine} — ${ex.label}`
+
+    if (ex.skipReason) {
+      test.skip(`${name}  [skip: ${ex.skipReason}]`, () => {})
+      continue
+    }
+
+    test(name, () => {
+      const source = buildSource(ex)
+      const fatals = compileOnce(source)
+
+      switch (ex.expected.kind) {
+        case 'positive':
+        case 'negative-go-mojo-only': {
+          if (fatals.length > 0) {
+            const dump = fatals
+              .map(e => `  ${e.code}: ${e.message}`)
+              .join('\n')
+            throw new Error(
+              `expected no fatal errors on TestAdapter, got:\n${dump}\n--- source ---\n${source}`,
+            )
+          }
+          return
+        }
+        case 'negative-all-adapters': {
+          const code = ex.expected.code
+          const matched = fatals.find(e => e.code === code)
+          if (!matched) {
+            const got = fatals.map(e => e.code).join(', ') || '(none)'
+            throw new Error(
+              `expected error ${code}, got: ${got}\n--- source ---\n${source}`,
+            )
+          }
+          return
+        }
+      }
+    })
+  }
+})


### PR DESCRIPTION
## Summary

`docs/core/rendering/jsx-compatibility.md` had two inverted claims about the sort-comparator restriction:

1. **L64 (the ✅ "do this" example):** used `(a, b) => a.name > b.name ? 1 : -1`, a ternary-return form that BF021 rejects.
2. **L69 + L151:** listed `localeCompare` as unsupported, but the compiler explicitly accepts it (see the BF021 error in `packages/jsx/src/expression-parser.ts:405-410` and the dedicated `localeCompare`-call detection at `expression-parser.ts:670-680`).

### Changes

- **doc**: enumerate the four accepted comparator shapes (`a - b`, `a.field - b.field`, `a.localeCompare(b)`, `a.field.localeCompare(b.field)`, with reversed operands for descending) and replace the negative BF021 example with a ternary comparator, which is genuinely unsupported.
- **test**: add `packages/jsx/src/__tests__/doc-examples-jsx-compatibility.test.ts`, which scrapes every fenced ` ```tsx ` block in the doc, classifies each snippet by the ✅ / ❌ marker on its preceding comment line, and runs it through the compiler. ✅ snippets must compile cleanly; ❌ snippets must surface the expected diagnostic code (e.g. `BF021`). 13 pass / 8 skip (snippets that aren't standalone expressions, e.g. event-handler templates, are deliberately skipped with a recorded reason).

This keeps the prose, the examples, and the compiler from drifting apart again.

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples-jsx-compatibility.test.ts` — 13 pass / 8 skip / 0 fail
- [x] `bun run --filter '@barefootjs/jsx' typecheck:tests` — exit 0
- [x] Full `bun test` in `packages/jsx` — 4 pre-existing unrelated fails (createSignal alias / createMemo / createEffect / onMount resolver-migration tests), confirmed by stash + re-run on the base tree


---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_