### PR TITLE
chore(onboarding): alpha onboarding verification pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ npm run dev
 
 Then open the URL the dev server prints (defaults to `http://localhost:8787`). The starter app ships a Counter component you can edit at `components/Counter.tsx`.
 
-The full walkthrough — adapter / CSS choices, generated layout, and editing the Counter — lives in [`docs/core/quick-start.md`](./docs/core/quick-start.md).
+The full walkthrough — adapter / CSS choices, generated layout, and editing the Counter — lives in [`docs/core/quick-start.mdx`](./docs/core/quick-start.mdx).
 
 ---
 

--- a/docs/core/README.md
+++ b/docs/core/README.md
@@ -51,6 +51,7 @@
 - [Adapter Architecture](./adapters/adapter-architecture.md) — How adapters work, the `TemplateAdapter` interface, and the IR contract
 - [Hono Adapter](./adapters/hono-adapter.md) — Configuration and output format for Hono / JSX-based servers
 - [Go Template Adapter](./adapters/go-template-adapter.md) — Configuration and output format for Go `html/template`
+- [CSR (Client-Side Rendering)](./adapters/csr.md) — Static-hosting renderer: emit client JS only, no SSR template
 - [Writing a Custom Adapter](./adapters/custom-adapter.md) — Step-by-step guide to implementing your own adapter
 
 ### 8. [Advanced](./advanced.md)

--- a/docs/core/README.md
+++ b/docs/core/README.md
@@ -8,7 +8,7 @@
 - Why BarefootJS?
 - Design Philosophy
 
-### 2. [Quick Start](./quick-start.md)
+### 2. [Quick Start](./quick-start.mdx)
 
 - Scaffold an app with `npm create barefootjs@latest`
 - Run the dev server and edit the starter Counter

--- a/docs/core/adapters/csr.md
+++ b/docs/core/adapters/csr.md
@@ -17,16 +17,15 @@ When you do control the server (Hono, Go, etc.), prefer SSR + hydration instead.
 
 ## Configuration
 
-Set `clientOnly: true` in `barefoot.config.ts`. This skips marked template output and emits only client JS plus the runtime bundle:
+Use `createConfig` from `@barefootjs/client/build` in `barefoot.config.ts`. It wires the in-package `CSRAdapter` and skips marked template output automatically — no `clientOnly` flag is needed:
 
 ```typescript
 // barefoot.config.ts
-import { createConfig } from '@barefootjs/hono/build'
+import { createConfig } from '@barefootjs/client/build'
 
 export default createConfig({
   components: ['./components'],
   outDir: 'dist',
-  clientOnly: true,
 })
 ```
 
@@ -42,7 +41,7 @@ dist/
 ## API
 
 ```typescript
-import { render } from '@barefootjs/client'
+import { render } from '@barefootjs/client/runtime'
 
 render(container, componentName, props?)
 ```
@@ -62,13 +61,13 @@ The component must be registered first by importing its `.client.js` file — th
 <html>
 <head>
   <script type="importmap">
-    { "imports": { "@barefootjs/client": "/static/components/barefoot.js" } }
+    { "imports": { "@barefootjs/client/runtime": "/static/components/barefoot.js" } }
   </script>
 </head>
 <body>
   <div id="app"></div>
   <script type="module">
-    import { render } from '@barefootjs/client'
+    import { render } from '@barefootjs/client/runtime'
     await import('/static/components/Counter.client.js')
     render(document.getElementById('app'), 'Counter', { initialCount: 0 })
   </script>

--- a/packages/cli/src/__tests__/add-remote.test.ts
+++ b/packages/cli/src/__tests__/add-remote.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, spyOn, beforeEach, afterEach } from 'bun:test'
 import { fetchRegistryItem } from '../lib/meta-loader'
-import { addFromRegistry } from '../commands/add'
+import { addFromRegistry, toRegistryName } from '../commands/add'
 import type { RegistryItem } from '../lib/types'
 import type { BarefootConfig } from '../context'
 import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'fs'
@@ -316,5 +316,82 @@ describe('addFromRegistry', () => {
 
     // Should log resolved dependencies
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Resolved dependencies'))
+  })
+
+  // Users naturally type PascalCase or camelCase to match the JSX import
+  // (`bf add Combobox`, `bf add RadioGroup`) but the registry stores
+  // entries as kebab-case JSON keys (`combobox.json`, `radio-group.json`),
+  // so before normalization the literal name 404'd and `bf docs <Name>`
+  // (which DOES normalize via meta-loader's case-insensitive fallback)
+  // contradicted `bf add <Name>` on the same case. Mirror the meta-loader
+  // contract by normalizing before the registry round-trip.
+  test('accepts PascalCase / camelCase component names by normalizing to kebab-case', async () => {
+    let fetchedUrl = ''
+    globalThis.fetch = async (url: any) => {
+      fetchedUrl = String(url)
+      return new Response(JSON.stringify(buttonItem), { status: 200 })
+    }
+
+    await addFromRegistry(['Button'], 'https://example.com/r/', tmpDir, config, false)
+    expect(fetchedUrl).toBe('https://example.com/r/button.json')
+  })
+
+  test('normalizes multi-word PascalCase to kebab-case (RadioGroup → radio-group)', async () => {
+    const radioGroup: RegistryItem = {
+      ...buttonItem,
+      name: 'radio-group',
+      files: [
+        { path: 'components/ui/radio-group/index.tsx', type: 'registry:ui', content: 'export function RadioGroup() {}' },
+      ],
+    }
+    const seenUrls: string[] = []
+    globalThis.fetch = async (url: any) => {
+      seenUrls.push(String(url))
+      return new Response(JSON.stringify(radioGroup), { status: 200 })
+    }
+
+    await addFromRegistry(['RadioGroup'], 'https://example.com/r/', tmpDir, config, false)
+    expect(seenUrls).toEqual(['https://example.com/r/radio-group.json'])
+  })
+
+  test('falls back to the literal name when the kebab-case form 404s (staging registries with mixed-case keys)', async () => {
+    const seenUrls: string[] = []
+    globalThis.fetch = async (url: any) => {
+      seenUrls.push(String(url))
+      // Canonical kebab-case → 404; literal `Mixed` → 200. The mixed-case
+      // key only exists in staging-style registries; the retry path keeps
+      // them working without rewriting their layout.
+      if (String(url).endsWith('mixed.json')) return new Response('Not Found', { status: 404 })
+      return new Response(JSON.stringify({ ...buttonItem, name: 'Mixed', files: [{ path: 'components/ui/mixed/index.tsx', type: 'registry:ui', content: '' }] }), { status: 200 })
+    }
+
+    await addFromRegistry(['Mixed'], 'https://example.com/r/', tmpDir, config, false)
+    expect(seenUrls).toEqual([
+      'https://example.com/r/mixed.json',
+      'https://example.com/r/Mixed.json',
+    ])
+  })
+})
+
+// ---------- toRegistryName ----------
+
+describe('toRegistryName', () => {
+  test('lowercases single-word PascalCase', () => {
+    expect(toRegistryName('Button')).toBe('button')
+    expect(toRegistryName('Combobox')).toBe('combobox')
+  })
+  test('kebab-cases multi-word PascalCase', () => {
+    expect(toRegistryName('RadioGroup')).toBe('radio-group')
+    expect(toRegistryName('ToggleGroup')).toBe('toggle-group')
+  })
+  test('handles trailing acronyms', () => {
+    expect(toRegistryName('InputOTP')).toBe('input-otp')
+  })
+  test('leaves already-canonical kebab-case alone', () => {
+    expect(toRegistryName('input-group')).toBe('input-group')
+    expect(toRegistryName('radio-group')).toBe('radio-group')
+  })
+  test('lowercases mixed-case kebab', () => {
+    expect(toRegistryName('Input-Group')).toBe('input-group')
   })
 })

--- a/packages/cli/src/__tests__/test-template.test.ts
+++ b/packages/cli/src/__tests__/test-template.test.ts
@@ -113,4 +113,38 @@ describe('generateTestTemplate', () => {
     expect(tpl).toContain(`n.props['onKeyDown'] != null`)
     expect(tpl).not.toContain(`n.props['onKeydown']`)
   })
+
+  // Components that return another component as their root (e.g. a
+  // thin wrapper `function Form() { return <Input ... /> }`) had
+  // their generated "renders as <Input>" test assert
+  // `result.root.tag === 'Input'`. The IR carries the component on
+  // `root.componentName` and leaves `root.tag` null for non-intrinsic
+  // roots, so the assertion always failed out of the box. Pick the
+  // matching IR field at template-time based on the captured name's
+  // casing — PascalCase ⇒ componentName, lowercase ⇒ tag.
+  test('asserts componentName (not tag) when the root is a child component', () => {
+    const tpl = tplFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { Input } from '@/components/ui/input'
+      export function Form() {
+        const [text, setText] = createSignal('')
+        return <Input value={text()} onInput={(e) => setText((e.target as HTMLInputElement).value)} />
+      }
+    `, 'Form.tsx')
+    expect(tpl).toContain(`expect(result.root.componentName).toBe('Input')`)
+    expect(tpl).not.toContain(`expect(result.root.tag).toBe('Input')`)
+  })
+
+  // Intrinsic-element roots stay on `tag` — the casing-based switch
+  // must not regress the lowercase path.
+  test('still asserts tag for intrinsic-element roots', () => {
+    const tpl = tplFor(`
+      export function Box() {
+        return <div>hi</div>
+      }
+    `, 'Box.tsx')
+    expect(tpl).toContain(`expect(result.root.tag).toBe('div')`)
+    expect(tpl).not.toContain(`expect(result.root.componentName).toBe('div')`)
+  })
 })

--- a/packages/cli/src/__tests__/test-template.test.ts
+++ b/packages/cli/src/__tests__/test-template.test.ts
@@ -87,4 +87,30 @@ describe('generateTestTemplate', () => {
     expect(tpl).toContain(`import { describe, test, expect } from 'vitest'`)
     expect(tpl).not.toContain(`from 'bun:test'`)
   })
+
+  // `onKeyDown` is the React-style prop name preserved on component
+  // nodes; deriving the prop name from the lowercased IR event name
+  // (`'on' + 'K' + 'eydown'`) produced `onKeydown`, so the generated
+  // `props['onKeydown'] != null` arm never matched and the test failed
+  // out of the box on the first user component that listened to
+  // keystrokes (e.g. an Enter-to-submit input wired through `<Input
+  // onKeyDown=…>`).
+  test('emits onKeyDown (not onKeydown) for keydown handlers', () => {
+    const tpl = tplFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { Input } from '@/components/ui/input'
+      export function Form() {
+        const [text, setText] = createSignal('')
+        return (
+          <Input
+            value={text()}
+            onKeyDown={(e) => e.key === 'Enter' && setText('')}
+          />
+        )
+      }
+    `, 'Form.tsx')
+    expect(tpl).toContain(`n.props['onKeyDown'] != null`)
+    expect(tpl).not.toContain(`n.props['onKeydown']`)
+  })
 })

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -71,7 +71,37 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
 const DEFAULT_REGISTRY_URL = 'https://ui.barefootjs.dev/r/'
 
 /**
+ * Normalize a component name to the registry's canonical kebab-case form.
+ * The registry stores entries as `<name>.json` with lowercase kebab-case
+ * names (`radio-group.json`, `input-otp.json`), but users naturally type
+ * PascalCase or camelCase to match the JSX import (`bf add RadioGroup`).
+ * Without normalization the literal name 404s — `bf docs <name>` already
+ * normalizes via `tryLoadComponent`'s case-insensitive fallback; mirror
+ * that here so both paths accept the same surface.
+ *
+ *   Button       → button
+ *   Combobox     → combobox
+ *   RadioGroup   → radio-group
+ *   InputOTP     → input-otp
+ *   input-group  → input-group   (already canonical — no change)
+ */
+export function toRegistryName(name: string): string {
+  return name
+    // `RadioGroup` → `Radio-Group`, `InputOTP` → `InputOTP` (acronym not split here)
+    .replace(/([a-z\d])([A-Z])/g, '$1-$2')
+    // `InputOTP` → `Input-OTP` (split trailing acronym before final word boundary)
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+    .toLowerCase()
+}
+
+/**
  * Fetch a single registry item. Returns null if skipErrors is true and fetch fails.
+ *
+ * Names are normalized through `toRegistryName` so PascalCase / camelCase
+ * inputs hit the registry's canonical kebab-case URL. If the literal name
+ * differs from the normalized one we retry against the literal URL only
+ * when the canonical fetch 404s — staging registries that legitimately
+ * use mixed-case keys keep working.
  */
 async function tryFetchRegistryItem(
   registryUrl: string,
@@ -79,20 +109,29 @@ async function tryFetchRegistryItem(
   skipErrors: boolean,
 ): Promise<RegistryItem | null> {
   const base = registryUrl.endsWith('/') ? registryUrl : `${registryUrl}/`
-  const url = `${base}${name}.json`
-  try {
-    const res = await fetch(url, { signal: AbortSignal.timeout(10_000) })
-    if (!res.ok) {
+  const canonical = toRegistryName(name)
+  const candidates: string[] = canonical === name ? [name] : [canonical, name]
+  let lastUrl = ''
+  let lastStatus = 0
+  for (const candidate of candidates) {
+    const url = `${base}${candidate}.json`
+    lastUrl = url
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(10_000) })
+      if (res.ok) return await res.json()
+      lastStatus = res.status
+      // Only fall through to the literal-name retry on 404 — other
+      // HTTP errors (5xx, auth) shouldn't trigger an extra round-trip.
+      if (res.status !== 404) break
+    } catch (err) {
       if (skipErrors) return null
-      console.error(`Error: Registry returned HTTP ${res.status} for ${url}`)
+      console.error(`Error: Failed to fetch component "${name}" from ${url}: ${err instanceof Error ? err.message : err}`)
       process.exit(1)
     }
-    return await res.json()
-  } catch (err) {
-    if (skipErrors) return null
-    console.error(`Error: Failed to fetch component "${name}" from ${url}: ${err instanceof Error ? err.message : err}`)
-    process.exit(1)
   }
+  if (skipErrors) return null
+  console.error(`Error: Registry returned HTTP ${lastStatus} for ${lastUrl}`)
+  process.exit(1)
 }
 
 /**

--- a/packages/cli/src/lib/test-template.ts
+++ b/packages/cli/src/lib/test-template.ts
@@ -133,12 +133,24 @@ function generateDescribeBlock(
   }
   lines.push(``)
 
-  // Root element
+  // Root element. PascalCase ⇒ child component (the parent renders e.g.
+  // `<Input ...>` as its own root); lowercase ⇒ intrinsic HTML tag.
+  // The IR distinguishes them on different fields — components carry
+  // `componentName`, intrinsic elements carry `tag` — so asserting
+  // `result.root.tag === 'Input'` for a component-rooted parent always
+  // fails (`tag` is null for components). Pick the matching field at
+  // template-time so the generated test reflects the IR shape.
   if (funcInfo.rootTag) {
+    const isComponentRoot = /^[A-Z]/.test(funcInfo.rootTag)
     lines.push(`  test('renders as <${funcInfo.rootTag}>', () => {`)
     if (funcInfo.hasConditionalReturn) {
       lines.push(`    // Component has conditional return (e.g., asChild branch)`)
-      lines.push(`    expect(result.find({ tag: '${funcInfo.rootTag}' })).not.toBeNull()`)
+      const finder = isComponentRoot
+        ? `result.find({ componentName: '${funcInfo.rootTag}' })`
+        : `result.find({ tag: '${funcInfo.rootTag}' })`
+      lines.push(`    expect(${finder}).not.toBeNull()`)
+    } else if (isComponentRoot) {
+      lines.push(`    expect(result.root.componentName).toBe('${funcInfo.rootTag}')`)
     } else {
       lines.push(`    expect(result.root.tag).toBe('${funcInfo.rootTag}')`)
     }

--- a/packages/cli/src/lib/test-template.ts
+++ b/packages/cli/src/lib/test-template.ts
@@ -5,6 +5,18 @@ import { readFileSync } from 'fs'
 import path from 'path'
 import { parseComponent } from './parse-component'
 
+// IR `events` array entries (lowercase event names from intrinsic
+// elements) → JSX prop names preserved on component nodes. Multi-word
+// events break the naive `'on' + event[0].toUpperCase() + event.slice(1)`
+// derivation (`keydown` → `onKeydown`, but the React-style prop is
+// `onKeyDown`), so we keep the mapping explicit.
+const ON_PROP_BY_EVENT: Record<string, string> = {
+  click: 'onClick',
+  input: 'onInput',
+  change: 'onChange',
+  keydown: 'onKeyDown',
+}
+
 export interface GenerateTestTemplateOptions {
   /**
    * Import specifier the emitted file uses for `describe` / `test` /
@@ -198,7 +210,7 @@ function generateDescribeBlock(
     lines.push(`  test('has event handlers', () => {`)
     lines.push(`    const all = result.findAll({})`)
     for (const event of funcInfo.events) {
-      const onProp = 'on' + event.charAt(0).toUpperCase() + event.slice(1)
+      const onProp = ON_PROP_BY_EVENT[event]
       lines.push(`    expect(`)
       lines.push(`      all.some(n => n.events.includes('${event}') || n.props['${onProp}'] != null),`)
       lines.push(`    ).toBe(true)`)
@@ -323,12 +335,16 @@ function analyzeFunction(source: string, componentName: string): FunctionInfo {
   // Conditional return (asChild pattern)
   const hasConditionalReturn = /if\s*\(.*\)\s*\{?\s*return/.test(funcBody)
 
-  // Event handlers in JSX
+  // Event handlers in JSX. Keys here are the lowercased event name
+  // surfaced on the IR's `events` array for intrinsic elements; values
+  // are the JSX prop name preserved on component nodes (`props.onKeyDown`,
+  // not `props.onKeydown`). The two halves diverge for multi-word events
+  // like keydown, so we keep the mapping explicit instead of deriving the
+  // prop name from the event name.
   const events: string[] = []
-  if (/onClick=/.test(funcBody)) events.push('click')
-  if (/onInput=/.test(funcBody)) events.push('input')
-  if (/onChange=/.test(funcBody)) events.push('change')
-  if (/onKeyDown=/.test(funcBody)) events.push('keydown')
+  for (const [event, onProp] of Object.entries(ON_PROP_BY_EVENT)) {
+    if (new RegExp(`${onProp}=`).test(funcBody)) events.push(event)
+  }
 
   // Child components (PascalCase tags in JSX, excluding HTML elements)
   const childCompRegex = /<([A-Z][A-Za-z]+)[\s/>]/g

--- a/packages/jsx/src/__tests__/debug.test.ts
+++ b/packages/jsx/src/__tests__/debug.test.ts
@@ -240,6 +240,51 @@ describe('formatComponentGraph', () => {
     expect(output).toContain('dependency graph:')
     expect(output).toContain('count -> memo:doubled')
   })
+
+  // A handler like `<button onClick={() => setCount(0)}>` is a
+  // legitimate fallback-wrapped binding with zero tracked deps. The
+  // line used to render as `~ event "s0" <- ` with a dangling arrow
+  // + trailing space — readers seeing a one-sided arrow naturally
+  // suspect the analyzer dropped data. Drop the arrow and label the
+  // empty case explicitly. (No trailing whitespace either — easy to
+  // miss in review but breaks diff viewers.)
+  test('formats zero-dep bindings without a dangling arrow or trailing space', () => {
+    // `<Button onClick={() => setCount(0)}>` is the motivating shape
+    // (the registry's bundled Button + a setter-only handler in the
+    // scaffolded Counter). It produces an `attribute`-type binding with
+    // `classification: 'fallback'` and an empty deps list — exactly the
+    // case that used to render as `~ attribute "Button.onClick" <- `
+    // with a dangling arrow + trailing space.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { Button } from '@/components/ui/button'
+      export function Counter() {
+        const [count, setCount] = createSignal(0)
+        return (
+          <div>
+            <p>{count()}</p>
+            <Button onClick={() => setCount(0)}>Reset</Button>
+          </div>
+        )
+      }
+    `
+    const graph = buildComponentGraph(source, 'Counter.tsx')
+    const output = formatComponentGraph(graph)
+    // There IS at least one zero-dep binding (the Reset handler reads
+    // no signal — `setCount(0)` is a setter call, not a tracked read).
+    const zeroDepBindings = graph.domBindings.filter(d => d.deps.length === 0)
+    expect(zeroDepBindings.length).toBeGreaterThan(0)
+    // ... and it's labelled,
+    expect(output).toContain('(no tracked deps)')
+    // does NOT carry the dangling-arrow shape on ANY line.
+    expect(output).not.toMatch(/ <- *$/m)
+    expect(output).not.toMatch(/ -> *$/m)
+    // No line in the output ends with whitespace.
+    for (const line of output.split('\n')) {
+      expect(line).toBe(line.trimEnd())
+    }
+  })
 })
 
 describe('formatUpdatePath', () => {

--- a/packages/jsx/src/debug.ts
+++ b/packages/jsx/src/debug.ts
@@ -362,11 +362,21 @@ export function formatComponentGraph(graph: ComponentGraph): string {
   if (graph.domBindings.length > 0) {
     lines.push(`  dom bindings:`)
     for (const d of graph.domBindings) {
-      const arrow = d.type === 'event' ? ' ->' : ' <-'
-      const depStr = d.deps.join(', ')
       // For attribute bindings use the attr name; for others use slotId
       const id = d.type === 'attribute' ? `"${d.label}"` : `"${d.slotId}"`
       const marker = d.classification === 'fallback' ? '~ ' : '  '
+      // No tracked deps ⇒ drop the arrow entirely instead of emitting
+      // a dangling `<- ` (trailing space). Fallback-wrapped attribute
+      // handlers like `<Button onClick={() => setCount(0)}>` legitimately
+      // read no signal, so an empty deps list is the common case; mark
+      // it explicitly so the reader doesn't wonder if the analyzer
+      // dropped data.
+      if (d.deps.length === 0) {
+        lines.push(`    ${marker}${d.type} ${id} (no tracked deps)`)
+        continue
+      }
+      const arrow = d.type === 'event' ? ' ->' : ' <-'
+      const depStr = d.deps.join(', ')
       lines.push(`    ${marker}${d.type} ${id}${arrow} ${depStr}`)
     }
   }


### PR DESCRIPTION
## Summary

Onboarding verification PR for the alpha release.

Publish this PR via `pkg.pr.new`, then walk through the documented `npm create barefootjs@latest` flow on every adapter against the live alpha bits. Friction surfaced along the way is fixed as commits on this branch.

## Verification matrix

Every cell resolved through pkg-pr-new URLs pinned at this PR:

| Adapter | Scaffold | `npm install` | `npm test` | `npm run dev` |
|---|---|---|---|---|
| hono (default) | ✓ | ✓ | 7/7 pass | `http://localhost:8787` Counter ✓ |
| hono-node | ✓ | ✓ | 7/7 pass | `http://localhost:3000` Counter ✓ |
| csr | ✓ | ✓ | 7/7 pass | `http://localhost:3003` Counter ✓ |
| echo (Go) | ✓ | ✓ | 7/7 pass | `http://localhost:3009` Counter ✓ |
| mojo (Perl) | ✓ | ✓ | 7/7 pass | `http://localhost:3002` Counter ✓ |

Mojo note: the scaffold detects a missing `Mojolicious` runtime and surfaces an actionable `! Mojolicious not installed. Run cpanm --installdeps .` line before the next-steps block. After `apt install libmojolicious-perl` (or `cpanm --installdeps .`) the default Counter renders with `count: 0` / `doubled: 0` via the plugin's manifest-driven stash seeding — no per-route boilerplate needed.

User-shaped tasks beyond the matrix:

- Edited `components/Counter.tsx` per the quick-start walkthrough — added a `×2` button and `<Counter initial={5} />` on the server. Both reflected in the served HTML.
- Wrote a new `ContactForm.tsx` (Label + Input + Textarea + Button + validity memo) from scratch — SSR + hydration both clean.
- `bf add input label textarea` pulled the registry components in transparently.
- `bf gen test ContactForm` — 7/7 pass.

## Friction fixes (commits on this PR)

| Commit | Change |
|---|---|
| [e5ca297](https://github.com/piconic-ai/barefootjs/commit/e5ca297) | `bf gen test` emitted the wrong prop name (`onKeydown`) for `onKeyDown` handlers — `npm test` failed out of the box on the first user component that wired Enter-to-submit through `<Input onKeyDown=…>`. Replaced the derived `'on' + event[0].toUpperCase() + event.slice(1)` heuristic with an explicit event→prop map. |
| [e5ca297](https://github.com/piconic-ai/barefootjs/commit/e5ca297) | `docs/core/adapters/csr.md` referenced the pre-decoupling recipe — `createConfig` from `@barefootjs/hono/build`, a `clientOnly: true` flag the new factory now sets implicitly, and `render` from `@barefootjs/client`. The scaffold and `integrations/csr/` both use `@barefootjs/client/build` + `@barefootjs/client/runtime`. Brought the docs in line. |
| [dd19dd7](https://github.com/piconic-ai/barefootjs/commit/dd19dd7) | `bf add Button` (PascalCase, the React-shaped instinct) used to 404 — the registry stores entries as kebab-case (`button.json`, `radio-group.json`). New `toRegistryName()` normalizes (`Button → button`, `RadioGroup → radio-group`, `InputOTP → input-otp`) to match the case-insensitive contract `bf docs` already has, and falls back to the literal name on 404 so staging registries with mixed-case keys keep working. |
| [8f21291](https://github.com/piconic-ai/barefootjs/commit/8f21291) | Top-level `README.md` and `docs/core/README.md` linked to `quick-start.md`, but the actual file is `quick-start.mdx` — both links 404'd from GitHub. Fixed the extensions; also added a missing CSR adapter entry to `docs/core/README.md`'s index (the doc itself already existed and was indexed in `adapters.md`). |
| [dfbbbcb](https://github.com/piconic-ai/barefootjs/commit/dfbbbcb) | `bf gen test Wrapper`, where `function Wrapper() { return <Input … /> }`, asserted `result.root.tag === 'Input'`. The IR carries non-intrinsic roots on `root.componentName` and leaves `root.tag` null. Picked the matching IR field at template-time based on the captured name's casing: PascalCase ⇒ `componentName`, lowercase ⇒ `tag`. |
| [2df945f](https://github.com/piconic-ai/barefootjs/commit/2df945f) | `bf debug graph` rendered zero-dep bindings (e.g. `<Button onClick={() => setCount(0)}>` — the handler reads no signal) as `~ attribute "Button.onClick" <- ` with a dangling arrow + trailing whitespace. Readers naturally read the one-sided arrow as "deps were dropped"; dropped the arrow entirely and labelled the empty case `(no tracked deps)`. |

All fixes ship with unit tests and were validated end-to-end against the republished pkg-pr-new bits.

## Found during verification but deferred — filed separately

- **#1501** — A `"use client"` parent that composes an externally-imported stateless registry component (Label / Badge / Slot, etc., anything without `"use client"` that uses `{...props}` spread) leaks the compiler's hydration markers (`__instanceId` / `__bfChild` / `__bfParent` / `__bfMount`) onto SSR HTML as raw attributes. Minimal repro + control case (same-file stateless works) + impact analysis + three fix directions (compiler cross-file import resolution / Hono adapter intrinsic-spread allowlist / runtime helper sharing) attached. Compiler-level design change — out of scope for this PR.

## Test plan

- [x] Empty commit + `cr-tracked` label triggers `pkg.pr.new` publish
- [x] Scaffold → install → test → dev across all 5 adapters (hono / hono-node / csr / echo / mojo)
- [x] Hand-wrote an additional small app (ContactForm) as if I were a user
- [x] Filed and fixed 6 friction points as commits
- [x] Filed deferred compiler bug as #1501
