### PR TITLE
doc-examples: add create-effect.md (#1439 stack 2/n)

### DIFF
--- a/docs/core/reactivity/create-effect.md
+++ b/docs/core/reactivity/create-effect.md
@@ -107,13 +107,17 @@ When `query` changes, the previous fetch is aborted before the new one starts.
 
 ### Reactive attributes
 
-The compiler generates effects for reactive attributes:
+The compiler generates effects for reactive attributes.
+
+Source:
 
 ```tsx
-// Source
 <button disabled={loading()}>Submit</button>
+```
 
-// Generated client JS
+Generated client JS:
+
+```js
 const [_s0] = $(__scope, 's0')
 createEffect(() => {
   if (_s0) { _s0.disabled = !!(loading()) }

--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -232,6 +232,7 @@ const PAGES: PageSpec[] = [
   },
   { path: 'core/rendering/fragment.md' },
   { path: 'core/reactivity/create-signal.md' },
+  { path: 'core/reactivity/create-effect.md' },
 ]
 
 const adapter = new TestAdapter()


### PR DESCRIPTION
## Summary

Stack 2/n on top of #1502. Adds `docs/core/reactivity/create-effect.md` to the doc-examples test corpus.

**Note for reviewer:** base is `claude/doc-examples-create-signal` (PR #1502), not `main`. Once #1502 merges, the base will auto-retarget to `main` and this PR shows only the create-effect changes.

### Changes

- Add `core/reactivity/create-effect.md` to `PAGES`.
- **Drive-by doc fix:** the "Reactive attributes" example had source and post-compile output sharing one `tsx` fence with `// Source` / `// Generated client JS` comments. The generated portion uses internal runtime symbols (`$`, `__scope`) that aren't valid in user source — they tripped BF110 on the doc-examples test, and the combined fence was less clear for readers too. Split into a `tsx` source fence and a `js` generated-output fence.

### Coverage

| Page | Tests | Pass | Skip |
|---|---|---|---|
| (existing pages) | 45 | 37 | 8 |
| **`create-effect.md` (new)** | **9** | **9** | **0** |
| **Total** | **54** | **46** | **8** |

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 46 pass / 8 skip / 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_