### PR TITLE
doc-examples: add create-memo.md (#1439 stack 3/n)

### DIFF
--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -233,6 +233,7 @@ const PAGES: PageSpec[] = [
   { path: 'core/rendering/fragment.md' },
   { path: 'core/reactivity/create-signal.md' },
   { path: 'core/reactivity/create-effect.md' },
+  { path: 'core/reactivity/create-memo.md' },
 ]
 
 const adapter = new TestAdapter()


### PR DESCRIPTION
## Summary

Stack 3/n on top of #1503. Adds `docs/core/reactivity/create-memo.md`.

**Note for reviewer:** base is `claude/doc-examples-create-effect` (PR #1503).

### Coverage

| Page | Tests | Pass | Skip |
|---|---|---|---|
| (existing) | 54 | 46 | 8 |
| **`create-memo.md` (new)** | **8** | **8** | **0** |
| **Total** | **62** | **54** | **8** |

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 54 pass / 8 skip / 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_