### PR TITLE
doc-examples: add on-mount.md (#1439 stack 4/n)

### DIFF
--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -234,6 +234,7 @@ const PAGES: PageSpec[] = [
   { path: 'core/reactivity/create-signal.md' },
   { path: 'core/reactivity/create-effect.md' },
   { path: 'core/reactivity/create-memo.md' },
+  { path: 'core/reactivity/on-mount.md' },
 ]
 
 const adapter = new TestAdapter()


### PR DESCRIPTION
## Summary

Stack 4/n on top of #1504. Adds `docs/core/reactivity/on-mount.md`.

**Note for reviewer:** base is `claude/doc-examples-create-memo` (PR #1504).

### Coverage

| Page | Tests | Pass | Skip |
|---|---|---|---|
| (existing) | 62 | 54 | 8 |
| **`on-mount.md` (new)** | **6** | **6** | **0** |
| **Total** | **68** | **60** | **8** |

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 60 pass / 8 skip / 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_