### PR TITLE
doc-examples: add on-cleanup.md (#1439 stack 5/n)

### DIFF
--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -235,6 +235,7 @@ const PAGES: PageSpec[] = [
   { path: 'core/reactivity/create-effect.md' },
   { path: 'core/reactivity/create-memo.md' },
   { path: 'core/reactivity/on-mount.md' },
+  { path: 'core/reactivity/on-cleanup.md' },
 ]
 
 const adapter = new TestAdapter()


### PR DESCRIPTION
## Summary

Stack 5/n on top of #1505. Adds `docs/core/reactivity/on-cleanup.md`.

**Note for reviewer:** base is `claude/doc-examples-on-mount` (PR #1505).

### Coverage

| Page | Tests | Pass | Skip |
|---|---|---|---|
| (existing) | 68 | 60 | 8 |
| **`on-cleanup.md` (new)** | **6** | **6** | **0** |
| **Total** | **74** | **66** | **8** |

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 66 pass / 8 skip / 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_