### PR TITLE
doc-examples: add untrack.md (#1439 stack 6/n)

### DIFF
--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -236,6 +236,7 @@ const PAGES: PageSpec[] = [
   { path: 'core/reactivity/create-memo.md' },
   { path: 'core/reactivity/on-mount.md' },
   { path: 'core/reactivity/on-cleanup.md' },
+  { path: 'core/reactivity/untrack.md' },
 ]
 
 const adapter = new TestAdapter()


### PR DESCRIPTION
## Summary

Stack 6/n on top of #1506. Adds `docs/core/reactivity/untrack.md`.

**Note for reviewer:** base is `claude/doc-examples-on-cleanup` (PR #1506).

### Coverage

| Page | Tests | Pass | Skip |
|---|---|---|---|
| (existing) | 74 | 66 | 8 |
| **`untrack.md` (new)** | **11** | **11** | **0** |
| **Total** | **85** | **77** | **8** |

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 77 pass / 8 skip / 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_