### PR TITLE
doc-examples: add props-reactivity.md (#1439 stack 7/n)

### DIFF
--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -237,6 +237,7 @@ const PAGES: PageSpec[] = [
   { path: 'core/reactivity/on-mount.md' },
   { path: 'core/reactivity/on-cleanup.md' },
   { path: 'core/reactivity/untrack.md' },
+  { path: 'core/reactivity/props-reactivity.md' },
 ]
 
 const adapter = new TestAdapter()


### PR DESCRIPTION
## Summary

Stack 7/n on top of #1507. Adds `docs/core/reactivity/props-reactivity.md` — **completes `docs/core/reactivity/` coverage**.

**Note for reviewer:** base is `claude/doc-examples-untrack` (PR #1507).

### Coverage

| Page | Tests | Pass | Skip |
|---|---|---|---|
| (existing) | 85 | 77 | 8 |
| **`props-reactivity.md` (new)** | **6** | **6** | **0** |
| **Total** | **91** | **83** | **8** |

After this PR, the full `docs/core/reactivity/` (7 pages) is under doc-examples coverage. Next stack-group will be `docs/core/components/`.

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 83 pass / 8 skip / 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_