### PR TITLE
doc-examples: add component-authoring.md (#1439 stack 8/n)

### DIFF
--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -104,6 +104,7 @@ function detectBodyKind(body: string): BodyKind {
 function detectSharedSkipReason(body: string): string | undefined {
   if (/\(\s*\.\.\.\s*\)/.test(body)) return 'contains `(...)` placeholder'
   if (/>\s*\.\.\.\s*</.test(body)) return 'contains `>...<` placeholder'
+  if (/\{\s*\.\.\.\s*\}/.test(body)) return 'contains `{ ... }` placeholder'
   if (/^\s*[a-zA-Z][\w-]*\s*=\s*[{"]/.test(body) && !/^\s*(const|let|var)\b/.test(body)) {
     return 'JSX attribute fragment (not a standalone expression / statement)'
   }
@@ -238,6 +239,7 @@ const PAGES: PageSpec[] = [
   { path: 'core/reactivity/on-cleanup.md' },
   { path: 'core/reactivity/untrack.md' },
   { path: 'core/reactivity/props-reactivity.md' },
+  { path: 'core/components/component-authoring.md' },
 ]
 
 const adapter = new TestAdapter()


### PR DESCRIPTION
## Summary

Stack 8/n on top of #1508. Adds `docs/core/components/component-authoring.md` — starts `docs/core/components/` coverage.

**Note for reviewer:** base is `claude/doc-examples-props-reactivity` (PR #1508).

### Changes

- Add `core/components/component-authoring.md` to `PAGES`.
- **New shared skip rule:** bodies containing `{ ... }` placeholder. Matches prose placeholders like `function Foo() { ... }` and template-literal placeholders like `` `Toggle_${...}` `` used in the page's pseudo-code "Marked template" sample. Doesn't affect any prior page's skip count.

### Coverage

| Page | Tests | Pass | Skip |
|---|---|---|---|
| (existing) | 91 | 83 | 8 |
| **`component-authoring.md` (new)** | **12** | **9** | **3** |
| **Total** | **103** | **92** | **11** |

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 92 pass / 11 skip / 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_