### PR TITLE
doc-examples: add children-slots.md (#1439 stack 9/n)

### DIFF
--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -240,6 +240,7 @@ const PAGES: PageSpec[] = [
   { path: 'core/reactivity/untrack.md' },
   { path: 'core/reactivity/props-reactivity.md' },
   { path: 'core/components/component-authoring.md' },
+  { path: 'core/components/children-slots.md' },
 ]
 
 const adapter = new TestAdapter()


### PR DESCRIPTION
## Summary

Stack 9/n on top of #1509. Adds `docs/core/components/children-slots.md`.

**Note for reviewer:** base is `claude/doc-examples-component-authoring` (PR #1509).

### Coverage

| Page | Tests | Pass | Skip |
|---|---|---|---|
| (existing) | 103 | 92 | 11 |
| **`children-slots.md` (new)** | **12** | **12** | **0** |
| **Total** | **115** | **104** | **11** |

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 104 pass / 11 skip / 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_