### PR TITLE
doc-examples: add context-api.md + column-0 marker rule (#1439 stack 10/n)

### DIFF
--- a/docs/core/components/context-api.md
+++ b/docs/core/components/context-api.md
@@ -8,6 +8,7 @@ description: Share state with deeply nested children without prop drilling using
 Context shares state with deeply nested children without prop drilling. It is the foundation of compound components (Dialog, Accordion, Tabs).
 
 ```tsx
+"use client"
 import { createContext, useContext } from '@barefootjs/client'
 ```
 

--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -127,7 +127,11 @@ function extractExamples(md: string, page: PageSpec): DocExample[] {
     while (j < lines.length && !/^```\s*$/.test(lines[j])) j++
 
     const blockLines = lines.slice(i + 1, j)
-    const hasMarkerLine = blockLines.some(l => /^\s*\/\//.test(l))
+    // Marker comments are at column 0 (e.g. `// ❌ BF021`, `// Source`).
+    // Indented `//` lines are in-code comments and must NOT chop the fence
+    // into segments.
+    const isMarker = (l: string) => /^\/\//.test(l)
+    const hasMarkerLine = blockLines.some(isMarker)
     const segments: Array<{ offset: number; lines: string[] }> = []
     let cur: { offset: number; lines: string[] } | null = null
 
@@ -137,7 +141,7 @@ function extractExamples(md: string, page: PageSpec): DocExample[] {
     }
 
     blockLines.forEach((ln, idx) => {
-      if (/^\s*\/\//.test(ln)) {
+      if (isMarker(ln)) {
         flush()
         cur = { offset: idx, lines: [ln] }
       } else if (ln.trim() === '' && hasMarkerLine) {
@@ -241,6 +245,7 @@ const PAGES: PageSpec[] = [
   { path: 'core/reactivity/props-reactivity.md' },
   { path: 'core/components/component-authoring.md' },
   { path: 'core/components/children-slots.md' },
+  { path: 'core/components/context-api.md' },
 ]
 
 const adapter = new TestAdapter()


### PR DESCRIPTION
## Summary

Stack 10/n on top of #1510. Adds `docs/core/components/context-api.md`.

**Note for reviewer:** base is `claude/doc-examples-children-slots` (PR #1510).

### Changes

Two changes batched because the column-0 rule is a prerequisite for the page to even segment correctly:

1. **Column-0 marker rule.** Previously a leading `//` at any indent was treated as a doc-style label marker, which chopped indented in-code comments out of their function bodies (e.g. `    // ...` inside a function literal). Now only column-0 `//` lines act as markers — matches what doc authors actually write. Existing pages all use column-0 markers; their pass counts are unchanged except `untrack.md` (11 → 6 tests). The drop is not a regression: prior over-segmentation produced many tiny fragments out of one fence; now the fence is one cohesive segment covering the same ground.
2. **Drive-by doc fix.** The standalone `import { createContext, useContext }` snippet at L10-12 tripped BF001 because the compiler flags any module that imports those APIs as requiring `'use client'`. Added the directive — also matches the realistic usage context shown later in the file.

### Coverage

| Page | Tests | Pass | Skip |
|---|---|---|---|
| (existing) | 110 | 99 | 11 |
| **`context-api.md` (new)** | **32** | **32** | **0** |
| **Total** | **142** | **131** | **11** |

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 131 pass / 11 skip / 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_