### PR TITLE
doc-examples: add portals.md (#1439 stack 11/n)

### DIFF
--- a/docs/core/components/portals.md
+++ b/docs/core/components/portals.md
@@ -8,6 +8,7 @@ description: Render elements outside their parent DOM hierarchy for overlays, mo
 Portals render elements outside their parent DOM hierarchy — useful for overlays, modals, and tooltips that need to escape `overflow: hidden` or `z-index` stacking contexts.
 
 ```tsx
+"use client"
 import { createPortal } from '@barefootjs/client'
 ```
 
@@ -89,7 +90,8 @@ export function Tooltip(props: { text: string; children?: Child }) {
 `isSSRPortal` checks whether an element was already portaled during SSR to prevent double-portaling:
 
 ```tsx
-import { isSSRPortal } from '@barefootjs/client'
+"use client"
+import { isSSRPortal, createPortal } from '@barefootjs/client'
 
 const handleMount = (el: HTMLElement) => {
   // Skip if already portaled during SSR
@@ -102,8 +104,10 @@ const handleMount = (el: HTMLElement) => {
 After hydration, remove SSR placeholders:
 
 ```tsx
+"use client"
 import { cleanupPortalPlaceholder } from '@barefootjs/client'
 
+declare const portalId: string
 cleanupPortalPlaceholder(portalId)
 ```
 
@@ -165,6 +169,7 @@ The overlay accesses `DialogContext` from the component tree but is moved to `do
 Combine `portal.unmount()` with `onCleanup`:
 
 ```tsx
+"use client"
 import { createPortal, onCleanup } from '@barefootjs/client'
 
 const handleMount = (el: HTMLElement) => {

--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -246,6 +246,7 @@ const PAGES: PageSpec[] = [
   { path: 'core/components/component-authoring.md' },
   { path: 'core/components/children-slots.md' },
   { path: 'core/components/context-api.md' },
+  { path: 'core/components/portals.md' },
 ]
 
 const adapter = new TestAdapter()


### PR DESCRIPTION
## Summary

Stack 11/n on top of #1511. Adds `docs/core/components/portals.md`.

**Note for reviewer:** base is `claude/doc-examples-context-api` (PR #1511).

### Drive-by doc fixes

Same root cause as the `context-api.md` edit in #1511: four import-style snippets imported reactivity APIs (`createPortal`, `isSSRPortal`, `onCleanup`, `cleanupPortalPlaceholder`) without the `"use client"` directive, tripping BF001. Added the directive — realistic usage is always in a client component. The `cleanupPortalPlaceholder` example also got a `declare const portalId` so the snippet compiles standalone.

### Coverage

| Page | Tests | Pass | Skip |
|---|---|---|---|
| (existing) | 142 | 131 | 11 |
| **`portals.md` (new)** | **11** | **11** | **0** |
| **Total** | **153** | **142** | **11** |

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 142 pass / 11 skip / 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_