### PR TITLE
doc-examples: add props-type-safety.md (#1439 stack 12/n)

### DIFF
--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -129,8 +129,9 @@ function extractExamples(md: string, page: PageSpec): DocExample[] {
     const blockLines = lines.slice(i + 1, j)
     // Marker comments are at column 0 (e.g. `// ❌ BF021`, `// Source`).
     // Indented `//` lines are in-code comments and must NOT chop the fence
-    // into segments.
-    const isMarker = (l: string) => /^\/\//.test(l)
+    // into segments. Compiler directive comments (`// @bf-ignore …`) are
+    // part of the snippet, not a separator.
+    const isMarker = (l: string) => /^\/\//.test(l) && !/^\/\/\s*@/.test(l)
     const hasMarkerLine = blockLines.some(isMarker)
     const segments: Array<{ offset: number; lines: string[] }> = []
     let cur: { offset: number; lines: string[] } | null = null
@@ -247,6 +248,7 @@ const PAGES: PageSpec[] = [
   { path: 'core/components/children-slots.md' },
   { path: 'core/components/context-api.md' },
   { path: 'core/components/portals.md' },
+  { path: 'core/components/props-type-safety.md' },
 ]
 
 const adapter = new TestAdapter()


### PR DESCRIPTION
## Summary

Stack 12/n on top of #1512. Adds `docs/core/components/props-type-safety.md`.

**Note for reviewer:** base is `claude/doc-examples-portals` (PR #1512).

### Changes

- Add `core/components/props-type-safety.md` to `PAGES`.
- **Marker detection excludes `// @`-prefixed comments.** They are compiler directives that belong to the snippet (`// @bf-ignore props-destructuring`) and must stay attached to the function they annotate. Without this exclusion the directive was treated as a doc label and stripped off, causing the doc snippet's intended BF043 suppression to be lost.

### Coverage

| Page | Tests | Pass | Skip |
|---|---|---|---|
| (existing) | 153 | 142 | 11 |
| **`props-type-safety.md` (new)** | **7** | **7** | **0** |
| **Total** | **160** | **149** | **11** |

All prior page counts preserved.

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 149 pass / 11 skip / 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_