### PR TITLE
doc-examples: add styling.md (#1439 stack 13/n)

### DIFF
--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -249,6 +249,7 @@ const PAGES: PageSpec[] = [
   { path: 'core/components/context-api.md' },
   { path: 'core/components/portals.md' },
   { path: 'core/components/props-type-safety.md' },
+  { path: 'core/components/styling.md' },
 ]
 
 const adapter = new TestAdapter()


### PR DESCRIPTION
## Summary

Stack 13/n on top of #1513. Adds `docs/core/components/styling.md` — **completes `docs/core/components/` coverage**.

**Note for reviewer:** base is `claude/doc-examples-props-type-safety` (PR #1513).

### Coverage

| Page | Tests | Pass | Skip |
|---|---|---|---|
| (existing) | 160 | 149 | 11 |
| **`styling.md` (new)** | **3** | **3** | **0** |
| **Total** | **163** | **152** | **11** |

After this PR, the full `docs/core/components/` (6 pages) is under doc-examples coverage. Next stack group: `docs/core/core-concepts/`.

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 152 pass / 11 skip / 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_