### PR TITLE
doc-examples: add how-it-works.md (#1439 stack 14/n)

### DIFF
--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -105,6 +105,9 @@ function detectSharedSkipReason(body: string): string | undefined {
   if (/\(\s*\.\.\.\s*\)/.test(body)) return 'contains `(...)` placeholder'
   if (/>\s*\.\.\.\s*</.test(body)) return 'contains `>...<` placeholder'
   if (/\{\s*\.\.\.\s*\}/.test(body)) return 'contains `{ ... }` placeholder'
+  if (/\bbf[A-Z]\w*\(/.test(body)) {
+    return 'uses compiler-internal helper (bfText/bfComment/bfScopeAttr/...)'
+  }
   if (/^\s*[a-zA-Z][\w-]*\s*=\s*[{"]/.test(body) && !/^\s*(const|let|var)\b/.test(body)) {
     return 'JSX attribute fragment (not a standalone expression / statement)'
   }
@@ -250,6 +253,7 @@ const PAGES: PageSpec[] = [
   { path: 'core/components/portals.md' },
   { path: 'core/components/props-type-safety.md' },
   { path: 'core/components/styling.md' },
+  { path: 'core/core-concepts/how-it-works.md' },
 ]
 
 const adapter = new TestAdapter()


### PR DESCRIPTION
## Summary

Stack 14/n on top of #1514. Adds `docs/core/core-concepts/how-it-works.md` — starts `docs/core/core-concepts/` coverage.

**Note for reviewer:** base is `claude/doc-examples-styling` (PR #1514).

### Changes

- Add `core/core-concepts/how-it-works.md` to `PAGES`.
- **New shared skip rule:** bodies that call compiler-internal helpers (`bfText`, `bfComment`, `bfScopeAttr`, `bfTextEnd`, …). These appear in "Marked template" pseudo-code blocks that demonstrate the compiler output for documentation — they reference runtime symbols not exposed to user code and aren't meant to be compiled standalone. The `component-authoring.md` "Marked template" sample was already getting caught by the `{ ... }` placeholder rule (`` `Toggle_${...}` ``); `how-it-works.md` uses real expressions in its template literal (`` `Counter_${Math.random()...}` ``), so the new bf-helper rule is what catches it.

### Coverage

| Page | Tests | Pass | Skip |
|---|---|---|---|
| (existing) | 163 | 152 | 11 |
| **`how-it-works.md` (new)** | **3** | **2** | **1** |
| **Total** | **166** | **154** | **12** |

All prior page counts preserved exactly.

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 154 pass / 12 skip / 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_