### PR TITLE
doc-examples: add core-concepts/reactivity.md (#1439 stack 15/n)

### DIFF
--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -254,6 +254,7 @@ const PAGES: PageSpec[] = [
   { path: 'core/components/props-type-safety.md' },
   { path: 'core/components/styling.md' },
   { path: 'core/core-concepts/how-it-works.md' },
+  { path: 'core/core-concepts/reactivity.md' },
 ]
 
 const adapter = new TestAdapter()


### PR DESCRIPTION
## Summary

Stack 15/n on top of #1515. Adds `docs/core/core-concepts/reactivity.md`.

**Note for reviewer:** base is `claude/doc-examples-how-it-works` (PR #1515).

### Coverage

| Page | Tests | Pass | Skip |
|---|---|---|---|
| (existing) | 166 | 154 | 12 |
| **`core-concepts/reactivity.md` (new)** | **2** | **2** | **0** |
| **Total** | **168** | **156** | **12** |

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 156 pass / 12 skip / 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_