### PR TITLE
doc-examples: add mpa-style.md (#1439 stack 16/n)

### DIFF
--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -255,6 +255,7 @@ const PAGES: PageSpec[] = [
   { path: 'core/components/styling.md' },
   { path: 'core/core-concepts/how-it-works.md' },
   { path: 'core/core-concepts/reactivity.md' },
+  { path: 'core/core-concepts/mpa-style.md' },
 ]
 
 const adapter = new TestAdapter()


### PR DESCRIPTION
## Summary

Stack 16/n on top of #1516. Adds `docs/core/core-concepts/mpa-style.md`.

**Note for reviewer:** base is `claude/doc-examples-core-concepts-reactivity` (PR #1516).

### Coverage

| Page | Tests | Pass | Skip |
|---|---|---|---|
| (existing) | 168 | 156 | 12 |
| **`mpa-style.md` (new)** | **3** | **3** | **0** |
| **Total** | **171** | **159** | **12** |

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 159 pass / 12 skip / 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_