### PR TITLE
doc-examples: add ai-native.md (#1439 stack 17/n)

### DIFF
--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -256,6 +256,7 @@ const PAGES: PageSpec[] = [
   { path: 'core/core-concepts/how-it-works.md' },
   { path: 'core/core-concepts/reactivity.md' },
   { path: 'core/core-concepts/mpa-style.md' },
+  { path: 'core/core-concepts/ai-native.md' },
 ]
 
 const adapter = new TestAdapter()


### PR DESCRIPTION
## Summary

Stack 17/n on top of #1517. Adds `docs/core/core-concepts/ai-native.md` — **completes `docs/core/core-concepts/` coverage**.

**Note for reviewer:** base is `claude/doc-examples-mpa-style` (PR #1517).

### Coverage

| Page | Tests | Pass | Skip |
|---|---|---|---|
| (existing) | 171 | 159 | 12 |
| **`ai-native.md` (new)** | **2** | **2** | **0** |
| **Total** | **173** | **161** | **12** |

After this PR, the full `docs/core/core-concepts/` (4 pages) is under coverage. Next groups: `docs/core/adapters/`, `docs/core/advanced/`, `docs/core/introduction.md`.

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 161 pass / 12 skip / 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_