### PR TITLE
doc-examples: add hono-adapter.md (#1439 stack 18/n)

### DIFF
--- a/docs/core/adapters/hono-adapter.md
+++ b/docs/core/adapters/hono-adapter.md
@@ -187,13 +187,13 @@ Ternaries with element branches use `bf-c` markers. Text-only ternaries use comm
 **Source:**
 
 ```tsx
-{items().map(item => <li>{item}</li>)}
+{items().map(item => <li key={item}>{item}</li>)}
 ```
 
 **Output:**
 
 ```tsx
-{bfComment('loop')}{items().map((item) => <li>{bfText("s0")}{item}{bfTextEnd()}</li>)}{bfComment('/loop')}
+{bfComment('loop')}{items().map((item) => <li key={item}>{bfText("s0")}{item}{bfTextEnd()}</li>)}{bfComment('/loop')}
 ```
 
 Loop markers (`<!--bf-loop-->...<!--bf-/loop-->`) are used for reconciliation. For child components in loops, the adapter generates unique instance IDs per iteration using the loop index or `key`.

--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -257,6 +257,7 @@ const PAGES: PageSpec[] = [
   { path: 'core/core-concepts/reactivity.md' },
   { path: 'core/core-concepts/mpa-style.md' },
   { path: 'core/core-concepts/ai-native.md' },
+  { path: 'core/adapters/hono-adapter.md' },
 ]
 
 const adapter = new TestAdapter()


### PR DESCRIPTION
## Summary

Stack 18/n on top of #1518. Adds `docs/core/adapters/hono-adapter.md` — starts `docs/core/adapters/` coverage.

**Note for reviewer:** base is `claude/doc-examples-ai-native` (PR #1518).

### Drive-by doc fix

The "Loop Rendering" source snippet `{items().map(item => <li>{item}</li>)}` was missing a `key` prop, tripping BF023. Added `key={item}` to both the source and the generated-output snippet — BF023 is now an error, not a warning.

### Coverage

| Page | Tests | Pass | Skip |
|---|---|---|---|
| (existing) | 173 | 161 | 12 |
| **`hono-adapter.md` (new)** | **12** | **8** | **4** |
| **Total** | **185** | **169** | **16** |

The 4 skips are the page's "Output (.tsx)" pseudo-code blocks that demonstrate compiler output using internal helpers (`bfText`, `bfTextEnd`, `bfComment`) and `{ ... }` placeholders — caught by the existing shared skip rules.

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 169 pass / 16 skip / 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_