### PR TITLE
doc-examples: add go-template-adapter.md (#1439 stack 19/n)

### DIFF
--- a/docs/core/adapters/go-template-adapter.md
+++ b/docs/core/adapters/go-template-adapter.md
@@ -144,7 +144,7 @@ Field names are automatically capitalized to follow Go conventions.
 ### `.map()`
 
 ```tsx
-{items().map(item => <li>{item}</li>)}
+{items().map(item => <li key={item}>{item}</li>)}
 ```
 
 ```go-template
@@ -156,7 +156,7 @@ Field names are automatically capitalized to follow Go conventions.
 ### `.filter().map()`
 
 ```tsx
-{items().filter(item => item.active).map(item => <li>{item.name}</li>)}
+{items().filter(item => item.active).map(item => <li key={item.id}>{item.name}</li>)}
 ```
 
 ```go-template
@@ -170,7 +170,7 @@ For complex filter predicates, the adapter generates template block functions.
 ### `.sort().map()` / `.toSorted().map()`
 
 ```tsx
-{items.toSorted((a, b) => a.priority - b.priority).map(t => <li>{t.name}</li>)}
+{items.toSorted((a, b) => a.priority - b.priority).map(t => <li key={t.id}>{t.name}</li>)}
 ```
 
 ```go-template

--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -258,6 +258,7 @@ const PAGES: PageSpec[] = [
   { path: 'core/core-concepts/mpa-style.md' },
   { path: 'core/core-concepts/ai-native.md' },
   { path: 'core/adapters/hono-adapter.md' },
+  { path: 'core/adapters/go-template-adapter.md' },
 ]
 
 const adapter = new TestAdapter()


### PR DESCRIPTION
## Summary

Stack 19/n on top of #1519. Adds `docs/core/adapters/go-template-adapter.md`.

**Note for reviewer:** base is `claude/doc-examples-hono-adapter` (PR #1519).

### Drive-by doc fix

Three array-method sample snippets (`.map`, `.filter().map`, `.toSorted().map`) were missing `key` props, tripping BF023. Added `key={item}` / `key={item.id}` / `key={t.id}`.

### Coverage

| Page | Tests | Pass | Skip |
|---|---|---|---|
| (existing) | 185 | 169 | 16 |
| **`go-template-adapter.md` (new)** | **8** | **8** | **0** |
| **Total** | **193** | **177** | **16** |

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 177 pass / 16 skip / 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_