### PR TITLE
doc-examples: add custom-adapter.md (#1439 stack 20/n)

### DIFF
--- a/docs/core/adapters/custom-adapter.md
+++ b/docs/core/adapters/custom-adapter.md
@@ -192,12 +192,12 @@ renderLoop(loop: IRLoop): string {
 
 **Input (JSX):**
 ```tsx
-{items.map(item => <li>{item.name}</li>)}
+{items.map(item => <li key={item.id}>{item.name}</li>)}
 ```
 
 **Output (TestAdapter):**
 ```tsx
-{items.map((item) => <li>{item.name}</li>)}
+{items.map((item) => <li key={item.id}>{item.name}</li>)}
 ```
 
 Non-JSX adapters translate to the target iteration syntax (e.g., `{{range .Items}}...{{end}}`).

--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -259,6 +259,7 @@ const PAGES: PageSpec[] = [
   { path: 'core/core-concepts/ai-native.md' },
   { path: 'core/adapters/hono-adapter.md' },
   { path: 'core/adapters/go-template-adapter.md' },
+  { path: 'core/adapters/custom-adapter.md' },
 ]
 
 const adapter = new TestAdapter()


### PR DESCRIPTION
## Summary

Stack 20/n on top of #1520. Adds `docs/core/adapters/custom-adapter.md` — **completes `docs/core/adapters/` coverage**.

**Note for reviewer:** base is `claude/doc-examples-go-template-adapter` (PR #1520).

### Drive-by doc fix

The loop input/output snippets were missing `key` props, tripping BF023. Added `key={item.id}`.

### Coverage

| Page | Tests | Pass | Skip |
|---|---|---|---|
| (existing) | 193 | 177 | 16 |
| **`custom-adapter.md` (new)** | **5** | **5** | **0** |
| **Total** | **198** | **182** | **16** |

After this PR, the full `docs/core/adapters/` (3 pages) is under coverage. Next groups: `docs/core/advanced/`, `docs/core/introduction.md`, top-level `docs/core/reactivity.md`.

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 182 pass / 16 skip / 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_