### PR TITLE
doc-examples: add code-splitting.md (#1439 stack 21/n)

### DIFF
--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -260,6 +260,7 @@ const PAGES: PageSpec[] = [
   { path: 'core/adapters/hono-adapter.md' },
   { path: 'core/adapters/go-template-adapter.md' },
   { path: 'core/adapters/custom-adapter.md' },
+  { path: 'core/advanced/code-splitting.md' },
 ]
 
 const adapter = new TestAdapter()


### PR DESCRIPTION
## Summary

Stack 21/n on top of #1521. Adds `docs/core/advanced/code-splitting.md` — starts `docs/core/advanced/` coverage.

**Note for reviewer:** base is `claude/doc-examples-custom-adapter` (PR #1521).

### Coverage

| Page | Tests | Pass | Skip |
|---|---|---|---|
| (existing) | 198 | 182 | 16 |
| **`code-splitting.md` (new)** | **4** | **4** | **0** |
| **Total** | **202** | **186** | **16** |

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 186 pass / 16 skip / 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_