### PR TITLE
doc-examples: add compiler-internals.md (#1439 stack 22/n)

### DIFF
--- a/docs/core/advanced/compiler-internals.md
+++ b/docs/core/advanced/compiler-internals.md
@@ -124,7 +124,7 @@ Elements receive a `slotId` when they have:
 
 ```tsx
 {todos().filter(t => !t.done).sort((a, b) => a.date - b.date).map(t => (
-  <li>{t.name}</li>
+  <li key={t.id}>{t.name}</li>
 ))}
 ```
 

--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -261,6 +261,7 @@ const PAGES: PageSpec[] = [
   { path: 'core/adapters/go-template-adapter.md' },
   { path: 'core/adapters/custom-adapter.md' },
   { path: 'core/advanced/code-splitting.md' },
+  { path: 'core/advanced/compiler-internals.md' },
 ]
 
 const adapter = new TestAdapter()


### PR DESCRIPTION
## Summary

Stack 22/n on top of #1522. Adds `docs/core/advanced/compiler-internals.md`.

**Note for reviewer:** base is `claude/doc-examples-code-splitting` (PR #1522).

### Drive-by doc fix

The `.filter().sort().map()` chain snippet was missing a `key` prop on its `<li>`, tripping BF023. Added `key={t.id}`.

### Coverage

| Page | Tests | Pass | Skip |
|---|---|---|---|
| (existing) | 202 | 186 | 16 |
| **`compiler-internals.md` (new)** | **6** | **3** | **3** |
| **Total** | **208** | **189** | **19** |

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 189 pass / 19 skip / 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_