### PR TITLE
doc-examples: add error-codes.md (pageSkip all) (#1439 stack 23/n)

### DIFF
--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -262,6 +262,18 @@ const PAGES: PageSpec[] = [
   { path: 'core/adapters/custom-adapter.md' },
   { path: 'core/advanced/code-splitting.md' },
   { path: 'core/advanced/compiler-internals.md' },
+  {
+    // Reference page listing every BFxxx code with illustrative
+    // ❌/✅ snippets. Many depend on file-level context (module vs
+    // function scope, directive position, undefined identifiers like
+    // `Child`/`count`) that the shared scaffold can't reproduce, so
+    // they don't fire the BFxxx the doc claims. The extractor still
+    // walks the page to catch markdown structure changes; a
+    // per-BFxxx-section matcher is tracked as future work in #1439.
+    path: 'core/advanced/error-codes.md',
+    pageSkip: () =>
+      'error-reference page — illustrative snippets depend on file-level context (#1439 future work)',
+  },
 ]
 
 const adapter = new TestAdapter()


### PR DESCRIPTION
## Summary

Stack 23/n on top of #1523. Adds `docs/core/advanced/error-codes.md`.

**Note for reviewer:** base is `claude/doc-examples-compiler-internals` (PR #1523).

### Why blanket skip

`error-codes.md` is a BFxxx reference catalogue rather than a tutorial. Most of its 21 snippets demonstrate failure modes that depend on file-level context (`'use client'` directive position, module-level vs function-level scope, undefined identifiers like `Child` / `count`) that the shared scaffold can't reproduce. Without that context the expected BFxxx codes don't fire, and the snippets either pass spuriously or surface unrelated errors.

Adding the page with a blanket `pageSkip` keeps the extractor running against it (so future markdown structure changes still get caught), but stops false negatives. A per-BFxxx matcher that walks the H3 sections (`### BFxxx — …`) and asserts the labelled snippet emits exactly that code is tracked as v3 work in #1439.

### Coverage

| Page | Tests | Pass | Skip |
|---|---|---|---|
| (existing) | 208 | 189 | 19 |
| **`error-codes.md` (new, all skipped)** | **22** | **1** | **21** |
| **Total** | **230** | **190** | **40** |

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 190 pass / 40 skip / 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_