### PR TITLE
doc-examples: add performance.md (#1439 stack 24/n)

### DIFF
--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -274,6 +274,7 @@ const PAGES: PageSpec[] = [
     pageSkip: () =>
       'error-reference page — illustrative snippets depend on file-level context (#1439 future work)',
   },
+  { path: 'core/advanced/performance.md' },
 ]
 
 const adapter = new TestAdapter()


### PR DESCRIPTION
## Summary

Stack 24/n on top of #1524. Adds `docs/core/advanced/performance.md` — **completes `docs/core/advanced/` coverage**.

**Note for reviewer:** base is `claude/doc-examples-error-codes` (PR #1524).

### Coverage

| Page | Tests | Pass | Skip |
|---|---|---|---|
| (existing) | 230 | 190 | 40 |
| **`performance.md` (new)** | **12** | **11** | **1** |
| **Total** | **242** | **201** | **41** |

After this PR, the full `docs/core/advanced/` (4 pages) is under coverage. Remaining: `docs/core/reactivity.md` (top-level), `docs/core/introduction.md`.

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 201 pass / 41 skip / 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_