### PR TITLE
doc-examples: add top-level reactivity.md (#1439 stack 25/n)

### DIFF
--- a/docs/core/reactivity.md
+++ b/docs/core/reactivity.md
@@ -8,6 +8,7 @@ description: Fine-grained reactive primitives inspired by SolidJS, including sig
 All reactive primitives are imported from `@barefootjs/client`:
 
 ```tsx
+"use client"
 import { createSignal, createEffect, createMemo, onMount, onCleanup, untrack } from '@barefootjs/client'
 ```
 

--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -275,6 +275,7 @@ const PAGES: PageSpec[] = [
       'error-reference page — illustrative snippets depend on file-level context (#1439 future work)',
   },
   { path: 'core/advanced/performance.md' },
+  { path: 'core/reactivity.md' },
 ]
 
 const adapter = new TestAdapter()


### PR DESCRIPTION
## Summary

Stack 25/n on top of #1525. Adds top-level `docs/core/reactivity.md`.

**Note for reviewer:** base is `claude/doc-examples-performance` (PR #1525).

### Drive-by doc fix

The single import snippet listed all reactive APIs without `"use client"`, tripping BF001. Added the directive — same pattern as #1511 / #1512.

### Coverage

| Page | Tests | Pass | Skip |
|---|---|---|---|
| (existing) | 242 | 201 | 41 |
| **`core/reactivity.md` (new)** | **2** | **2** | **0** |
| **Total** | **244** | **203** | **41** |

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 203 pass / 41 skip / 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_