### PR TITLE
doc-examples: add introduction.md (#1439 stack 26/n) — completes docs/core/

### DIFF
--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -276,6 +276,7 @@ const PAGES: PageSpec[] = [
   },
   { path: 'core/advanced/performance.md' },
   { path: 'core/reactivity.md' },
+  { path: 'core/introduction.md' },
 ]
 
 const adapter = new TestAdapter()


### PR DESCRIPTION
## Summary

Stack 26/n on top of #1526. Adds `docs/core/introduction.md` — **FINAL page in the `docs/core/**` sweep**. After this PR every markdown file under `docs/core/` is in the doc-examples corpus.

**Note for reviewer:** base is `claude/doc-examples-top-reactivity` (PR #1526).

### Coverage

| Page | Tests | Pass | Skip |
|---|---|---|---|
| (existing) | 244 | 203 | 41 |
| **`introduction.md` (new)** | **3** | **2** | **1** |
| **Total** | **247** | **205** | **42** |

### Final tally across the entire #1439 stack

- **29 doc pages** covered (rendering ×3, reactivity ×7, components ×6, core-concepts ×4, adapters ×3, advanced ×4, plus top-level `core/reactivity.md` + `introduction.md`)
- **205 contracts** mechanically validated against the compiler
- **42 skips** with recorded reasons (markdown placeholders, marked-template pseudo-code with `bfText`/`bfComment`/`bfScopeAttr`, the error-codes reference page, and a handful of JSX-attribute / `>...<` shorthand fragments)

### Remaining #1439 work (unchanged by this PR)

- [ ] IR / client-JS snapshots for ✅ examples — currently only "no fatal" is asserted, not output stability
- [ ] Per-BFxxx-section matcher for `error-codes.md`
- [ ] Dedicated CI path-filter so doc-examples failures get their own check

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 205 pass / 42 skip / 0 fail


---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_