### PR TITLE
compiler(#1530): allow nested object destructure in filter predicate param

### DIFF
--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -423,6 +423,31 @@ describe('expression-parser', () => {
       }
     })
 
+    // Array binding inside an object destructure (`{a: [x]}`) stays
+    // refused — different shape (numeric indices). Lock in the
+    // refusal here so a future change doesn't accidentally start
+    // lowering it via the object-destructure path (#1530).
+    test('rejects .filter(({a: [x]}) => x) — array binding inside object destructure (#1530)', () => {
+      const result = parseExpression('items().filter(({a: [x]}) => x)')
+      // Falls through to plain `call` — adapter surfaces BF101.
+      expect(result.kind).toBe('call')
+    })
+
+    // Non-identifier property names (`{ 'x': y }`, `{ 0: y }`) used to
+    // silently fall back to the local name, which would rewrite `y`
+    // to `<synthetic>.y` instead of the correct `<synthetic>['x']`.
+    // Refuse explicitly until we can carry computed segments through
+    // the path representation (#1530).
+    test('rejects .filter(({ "x": y }) => y) — string-literal key in destructure (#1530)', () => {
+      const result = parseExpression("items().filter(({ 'x': y }) => y)")
+      expect(result.kind).toBe('call')
+    })
+
+    test('rejects .filter(({ 0: y }) => y) — numeric-literal key in destructure (#1530)', () => {
+      const result = parseExpression('items().filter(({ 0: y }) => y)')
+      expect(result.kind).toBe('call')
+    })
+
     // Synthetic param collision — body references a free `_t` AND the
     // destructure also introduces `_t` as a leaf binding. Both must be
     // avoided when picking the synthetic name (#1530 acceptance).

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -340,14 +340,102 @@ describe('expression-parser', () => {
       }
     })
 
-    // Defaults / rest / nested destructure stay unsupported — each
-    // would need its own residual-object accessor pipeline. We accept
-    // only the unrenamed-field and renamed-field forms here.
+    // Defaults / rest stay unsupported — each would need its own
+    // residual-object accessor pipeline. Nested destructure is
+    // covered separately below (#1530).
     test('rejects .filter(({done = false}) => done) — defaults in destructure are unsupported (#1443)', () => {
       const result = parseExpression('todos().filter(({done = false}) => done)')
       // Falls through to plain `call` (not higher-order), so isSupported
       // will surface BF101 at the adapter via the UNSUPPORTED_METHODS gate.
       expect(result.kind).toBe('call')
+    })
+
+    // Nested destructure (#1530). The parser recurses into the inner
+    // object pattern and threads the property path, so
+    // `({user: {name}}) => name === 'alice'` rewrites to
+    // `(_t) => _t.user.name === 'alice'`. Adapters reuse the
+    // higher-order path with no extra work — the IR is identical to
+    // what the user could have written by hand.
+    test('lowers .filter(({user: {name}}) => …) with nested destructure (#1530)', () => {
+      const result = parseExpression("items().filter(({user: {name}}) => name === 'alice')")
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') {
+        expect(result.method).toBe('filter')
+        expect(result.param).not.toBe('name')
+        // Predicate: <_t>.user.name === 'alice'
+        expect(result.predicate.kind).toBe('binary')
+        if (result.predicate.kind === 'binary') {
+          expect(result.predicate.op).toBe('===')
+          // Walk the left-leaning chain: `_t.user.name`.
+          const lhs = result.predicate.left
+          expect(lhs.kind).toBe('member')
+          if (lhs.kind === 'member') {
+            expect(lhs.property).toBe('name')
+            expect(lhs.object.kind).toBe('member')
+            if (lhs.object.kind === 'member') {
+              expect(lhs.object.property).toBe('user')
+              expect(lhs.object.object.kind).toBe('identifier')
+              if (lhs.object.object.kind === 'identifier') {
+                expect(lhs.object.object.name).toBe(result.param)
+              }
+            }
+          }
+        }
+      }
+    })
+
+    test('lowers .filter(({a: {b: {c}}}) => c) with doubly-nested destructure (#1530)', () => {
+      const result = parseExpression('items().filter(({a: {b: {c}}}) => c)')
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') {
+        // Predicate: `_t.a.b.c`.
+        let node = result.predicate
+        const expected = ['c', 'b', 'a']
+        for (const property of expected) {
+          expect(node.kind).toBe('member')
+          if (node.kind !== 'member') return
+          expect(node.property).toBe(property)
+          node = node.object
+        }
+        expect(node.kind).toBe('identifier')
+        if (node.kind === 'identifier') {
+          expect(node.name).toBe(result.param)
+        }
+      }
+    })
+
+    test('lowers .filter(({user: {name: n}}) => n) with renamed inner field (#1530)', () => {
+      // `name: n` — `name` is the field, `n` is the LOCAL. Rewrite
+      // substitutes `n` (body reference) with `_t.user.name` (original
+      // field path).
+      const result = parseExpression('items().filter(({user: {name: n}}) => n)')
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') {
+        expect(result.param).not.toBe('n')
+        expect(result.predicate.kind).toBe('member')
+        if (result.predicate.kind === 'member') {
+          expect(result.predicate.property).toBe('name') // field, not the rename
+          expect(result.predicate.object.kind).toBe('member')
+          if (result.predicate.object.kind === 'member') {
+            expect(result.predicate.object.property).toBe('user')
+          }
+        }
+      }
+    })
+
+    // Synthetic param collision — body references a free `_t` AND the
+    // destructure also introduces `_t` as a leaf binding. Both must be
+    // avoided when picking the synthetic name (#1530 acceptance).
+    test('picks a non-colliding synthetic param when body references `_t` (#1530)', () => {
+      // `_t` here is a free identifier in the body (closure capture);
+      // the synthetic param must NOT be `_t`, otherwise the rewrite
+      // would silently shadow it.
+      const result = parseExpression('items().filter(({user: {name}}) => name === _t)')
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') {
+        expect(result.param).not.toBe('_t')
+        expect(result.param).toMatch(/^_t_+$/)
+      }
     })
 
     // Function-keyword filter callback (#1443): `function (x) { return

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -766,7 +766,7 @@ function collectDestructureBindings(
       // shorthand `{ { name } }` doesn't exist. Computed / string
       // / numeric property names stay refused.
       if (!el.propertyName || !ts.isIdentifier(el.propertyName)) {
-        return { ok: false, reason: 'Unsupported binding element in destructured filter param' }
+        return { ok: false, reason: 'Non-identifier (computed/string/numeric) keys in destructured filter param are not supported' }
       }
       const inner = collectDestructureBindings(
         el.name,
@@ -781,12 +781,21 @@ function collectDestructureBindings(
       // per #1530 out-of-scope. Filter predicates rarely receive tuples.
       return { ok: false, reason: 'Array binding patterns in destructured filter param are not supported' }
     }
-    const localName = el.name.text
-    const fieldName =
-      el.propertyName && ts.isIdentifier(el.propertyName)
-        ? el.propertyName.text
-        : localName // shorthand: `{done}` ≡ `{done: done}`
-    fieldMap.set(localName, [...pathPrefix, fieldName])
+    // Leaf binding. A non-identifier propertyName (`{ 'x': y }`,
+    // `{ 0: y }`) would silently fall back to `localName` and rewrite
+    // `y` to `<synthetic>.y` instead of `<synthetic>['x']` — a
+    // semantic bug. Refuse explicitly until we extend the path
+    // representation to carry computed segments.
+    let fieldName: string
+    if (el.propertyName) {
+      if (!ts.isIdentifier(el.propertyName)) {
+        return { ok: false, reason: 'Non-identifier (computed/string/numeric) keys in destructured filter param are not supported' }
+      }
+      fieldName = el.propertyName.text
+    } else {
+      fieldName = el.name.text // shorthand: `{done}` ≡ `{done: done}`
+    }
+    fieldMap.set(el.name.text, [...pathPrefix, fieldName])
   }
   return { ok: true }
 }

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -527,33 +527,18 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
     }
     const body = convertNode(node.body, raw)
 
-    // Destructured-object param: `({done}) => done` (#1443).
-    // We synthesise the equivalent dotted-access form so adapters
-    // can reuse their existing higher-order paths instead of needing
-    // a residual-object-accessor pipeline (#1384 territory). Only the
-    // unrenamed-field / renamed-field forms are handled — nested
-    // destructure / rest / defaults stay unsupported.
+    // Destructured-object param: `({done}) => done` (#1443),
+    // `({user: {name}}) => name` (#1530). We synthesise the equivalent
+    // dotted-access form so adapters can reuse their existing
+    // higher-order paths instead of needing a residual-object-accessor
+    // pipeline (#1384 territory). Nested destructure recurses into
+    // the inner pattern and threads a dotted path; rest / defaults /
+    // array binding stay unsupported.
     if (ts.isObjectBindingPattern(param.name)) {
-      const fieldMap = new Map<string, string>()
-      for (const el of param.name.elements) {
-        if (!ts.isBindingElement(el)) {
-          return { kind: 'unsupported', raw, reason: 'Unsupported binding element in destructured filter param' }
-        }
-        if (el.dotDotDotToken) {
-          return { kind: 'unsupported', raw, reason: 'Rest patterns in destructured filter param are not supported' }
-        }
-        if (el.initializer) {
-          return { kind: 'unsupported', raw, reason: 'Default values in destructured filter param are not supported' }
-        }
-        if (!ts.isIdentifier(el.name)) {
-          return { kind: 'unsupported', raw, reason: 'Nested destructuring in filter param is not supported' }
-        }
-        const localName = el.name.text
-        const fieldName =
-          el.propertyName && ts.isIdentifier(el.propertyName)
-            ? el.propertyName.text
-            : localName // shorthand: `{done}` ≡ `{done: done}`
-        fieldMap.set(localName, fieldName)
+      const fieldMap = new Map<string, string[]>()
+      const collect = collectDestructureBindings(param.name, [], fieldMap)
+      if (!collect.ok) {
+        return { kind: 'unsupported', raw, reason: collect.reason }
       }
       const syntheticParam = pickSyntheticParam(fieldMap, body)
       const rewritten = substituteDestructuredFields(body, fieldMap, syntheticParam)
@@ -752,6 +737,61 @@ function classifySortOperand(
 }
 
 /**
+ * Walk an object-binding pattern and populate `fieldMap` with
+ * `localName → [field, field, …]` entries. Nested patterns extend
+ * the path; renamed bindings use the property name (the field on
+ * the source object) rather than the local rename. Returns an
+ * error result for any shape outside the supported set so the
+ * caller can surface an `unsupported` IR node verbatim.
+ */
+function collectDestructureBindings(
+  pattern: ts.ObjectBindingPattern,
+  pathPrefix: readonly string[],
+  fieldMap: Map<string, string[]>,
+): { ok: true } | { ok: false; reason: string } {
+  for (const el of pattern.elements) {
+    if (!ts.isBindingElement(el)) {
+      return { ok: false, reason: 'Unsupported binding element in destructured filter param' }
+    }
+    if (el.dotDotDotToken) {
+      return { ok: false, reason: 'Rest patterns in destructured filter param are not supported' }
+    }
+    if (el.initializer) {
+      return { ok: false, reason: 'Default values in destructured filter param are not supported' }
+    }
+    if (ts.isObjectBindingPattern(el.name)) {
+      // Nested object pattern: `{ user: { name } }`. The outer slot
+      // MUST carry an identifier propertyName — the JS grammar for
+      // nested destructure requires `key: <pattern>`, so the
+      // shorthand `{ { name } }` doesn't exist. Computed / string
+      // / numeric property names stay refused.
+      if (!el.propertyName || !ts.isIdentifier(el.propertyName)) {
+        return { ok: false, reason: 'Unsupported binding element in destructured filter param' }
+      }
+      const inner = collectDestructureBindings(
+        el.name,
+        [...pathPrefix, el.propertyName.text],
+        fieldMap,
+      )
+      if (!inner.ok) return inner
+      continue
+    }
+    if (!ts.isIdentifier(el.name)) {
+      // Array binding pattern (`[a, b]`) and other shapes — kept refused
+      // per #1530 out-of-scope. Filter predicates rarely receive tuples.
+      return { ok: false, reason: 'Array binding patterns in destructured filter param are not supported' }
+    }
+    const localName = el.name.text
+    const fieldName =
+      el.propertyName && ts.isIdentifier(el.propertyName)
+        ? el.propertyName.text
+        : localName // shorthand: `{done}` ≡ `{done: done}`
+    fieldMap.set(localName, [...pathPrefix, fieldName])
+  }
+  return { ok: true }
+}
+
+/**
  * Pick a synthetic param name for a rewritten destructured filter
  * (`({done}) => done` → `(_t) => _t.done`). The name must NOT collide
  * with anything the body might reference — a `_t` already on the body
@@ -762,8 +802,12 @@ function classifySortOperand(
  * identifier referenced inside the body" (collectIdentifiers). Both
  * are reachable from the local rewrite context, so we avoid all of
  * them up-front rather than risk a runtime bug from a missed name.
+ * For nested destructure the map's keys are still just the
+ * locally-introduced leaf names — intermediate property names
+ * (`user` in `{ user: { name } }`) are consumed in the path and
+ * never bound in scope, so they don't need collision avoidance.
  */
-function pickSyntheticParam(fieldMap: Map<string, string>, body: ParsedExpr): string {
+function pickSyntheticParam(fieldMap: Map<string, string[]>, body: ParsedExpr): string {
   const used = new Set<string>(fieldMap.keys())
   collectIdentifiers(body, used)
   let name = '_t'
@@ -830,20 +874,22 @@ function collectIdentifiers(expr: ParsedExpr, out: Set<string>): void {
  */
 function substituteDestructuredFields(
   expr: ParsedExpr,
-  fieldMap: Map<string, string>,
+  fieldMap: Map<string, string[]>,
   syntheticParam: string,
 ): ParsedExpr {
   const walk = (e: ParsedExpr): ParsedExpr => {
     switch (e.kind) {
       case 'identifier': {
-        const field = fieldMap.get(e.name)
-        if (field === undefined) return e
-        return {
-          kind: 'member',
-          object: { kind: 'identifier', name: syntheticParam },
-          property: field,
-          computed: false,
+        const path = fieldMap.get(e.name)
+        if (path === undefined) return e
+        // Build `<syntheticParam>.<path[0]>.<path[1]>…` as a left-leaning
+        // chain of `member` nodes. Single-level destructure produces a
+        // one-hop chain identical to the pre-#1530 shape.
+        let node: ParsedExpr = { kind: 'identifier', name: syntheticParam }
+        for (const segment of path) {
+          node = { kind: 'member', object: node, property: segment, computed: false }
         }
+        return node
       }
       case 'call':
         return { kind: 'call', callee: walk(e.callee), args: e.args.map(walk) }


### PR DESCRIPTION
Closes #1530.

## Summary

Extend the destructured-filter-param rewrite in `expression-parser.ts` to recurse through nested `ObjectBindingPattern`s. The pre-existing rewrite collapsed `({done}) => done` into `(_t) => _t.done`; this PR collapses `({user: {name}}) => name === 'alice'` into `(_t) => _t.user.name === 'alice'`. The IR shape that reaches adapters is identical to a hand-written equivalent, so no adapter changes were needed.

### Implementation

- Introduced `collectDestructureBindings(pattern, pathPrefix, fieldMap)` — a recursive walker that builds `localName → ['user', 'name']` path lists from the binding pattern. Refusal cases (rest, defaults, array-binding) return a tagged-union error that the caller propagates as the parser's existing `unsupported` IR node verbatim.
- Changed `fieldMap` from `Map<string, string>` to `Map<string, string[]>` across both `pickSyntheticParam` (signature only — keys are still the introduced leaf names) and `substituteDestructuredFields` (now builds a left-leaning chain of `member` nodes one segment per path entry).
- Single-level destructure produces the exact same one-hop `member` shape as before (the path has length 1).

### Out of scope (kept refused)

- Array binding patterns `([a, b]) => …` — different shape (numeric indices). Refusal reason updated to be explicit (`Array binding patterns in destructured filter param are not supported`).
- Rest / default values — tracked in sibling issues.

## Test plan

- [x] New parser unit tests in `packages/jsx/src/__tests__/expression-parser.test.ts`:
  - `lowers .filter(({user: {name}}) => …) with nested destructure (#1530)` — single level of nesting + binary predicate
  - `lowers .filter(({a: {b: {c}}}) => c) with doubly-nested destructure (#1530)` — walks a 3-segment chain
  - `lowers .filter(({user: {name: n}}) => n) with renamed inner field (#1530)` — local rename still uses the original field name in the rewrite
  - `picks a non-colliding synthetic param when body references _t (#1530)` — collision-avoidance regression
- [x] `bun test packages/jsx/src/__tests__/expression-parser.test.ts` — 74 pass / 0 fail (was 70 pass / 0 fail)
- [x] `bun test packages/jsx/src/__tests__/` — no new failures (4 pre-existing failures in `primitive-resolver-alias` / `createMemo|createEffect|onMount` resolver-migration tests confirmed against `main` via `git stash`; unrelated to this change)
- [x] `bun test packages/adapter-tests/` — 497 pass / 0 fail (confirms "no adapter impact" from the issue)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AsFHxngTTaooymLjW5zZfb)_