### PR TITLE
ci: auto-regenerate doc-examples snapshots on PR

### DIFF
--- a/.github/workflows/update-doc-snapshots.yml
+++ b/.github/workflows/update-doc-snapshots.yml
@@ -1,0 +1,81 @@
+name: Update Doc Snapshots
+
+# Mirror of `update-fixtures.yml` / `update-meta.yml` but for the
+# `bun test`-managed snapshot file behind the doc-examples test
+# (`packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap`).
+#
+# Without this workflow, every PR that edits a documented `tsx` snippet
+# under `docs/core/**` — or touches compiler codegen under
+# `packages/jsx/**` — has to also hand-regenerate the snap file with
+# `bun test -u` and commit it. Auto-regen lowers the contribution
+# friction and keeps the snapshot artefact honest, the same way
+# `update-fixtures` keeps `packages/adapter-tests/fixtures/` honest.
+#
+# Note: this auto-commits the regenerated snapshot, so reviewers MUST
+# inspect the bot's diff in the same way they inspect `update-fixtures`
+# bot commits — an unintended snap drift is a compiler regression
+# disguised as a passing test, not a "fix forward" signal.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/core/**'
+      - 'packages/jsx/**'
+      - '.github/workflows/update-doc-snapshots.yml'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-doc-snapshots-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  update-doc-snapshots:
+    runs-on: ubuntu-latest
+    # Skip fork PRs (no write permission to push back to the head branch).
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build packages
+        # The doc-examples test compiles via `compileJSX` from
+        # `@barefootjs/jsx` (TestAdapter baseline). Build matches what
+        # `ci.yml`'s `test` job does so the regenerated snapshots come
+        # from the same compiler artefacts.
+        run: |
+          bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/client' build
+
+      - name: Regenerate doc-examples snapshots
+        run: bun test packages/jsx/src/__tests__/doc-examples.test.ts -u
+
+      - name: Check for changes
+        id: diff
+        run: |
+          if git diff --quiet -- packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
+          git commit -m "Update doc-examples snapshots (auto-generated)"
+          git push


### PR DESCRIPTION
## Summary

Mirrors `update-fixtures.yml` / `update-meta.yml` for the `bun test`-managed snapshot file that backs the doc-examples test (`packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap`).

## Why

v4 (#1529) + v5 (#1534) committed **140 client-JS snapshots** derived mechanically from `docs/core/**/*.md` snippets. Without this workflow, every PR that edits a `tsx` snippet under `docs/core/` — or touches compiler codegen under `packages/jsx/` — has to also hand-run

```
bun test packages/jsx/src/__tests__/doc-examples.test.ts -u
```

and commit the regenerated snap. Friction → drift.

## How

On `pull_request` events touching `docs/core/**` or `packages/jsx/**`:

1. install + build (`@barefootjs/jsx` + `@barefootjs/client` — same build steps as `ci.yml`'s `test` job)
2. `bun test packages/jsx/src/__tests__/doc-examples.test.ts -u`
3. `git diff --quiet` on the snap path; if it changed, commit as `github-actions[bot]` and push to the PR head branch

Same fork-PR guard (`head.repo.full_name == github.repository`), same `concurrency` group pattern (cancel in-progress on new pushes), same `permissions: contents: write` scope as the two sibling workflows.

## Safety note

This auto-commits the regenerated snapshot, so reviewers **MUST** inspect the bot's diff the same way they inspect `update-fixtures` bot commits — an unintended snap drift is a compiler regression *disguised as a passing test*, not a "fix forward" signal. This matches the existing convention; the doc-examples test was added precisely to make such drifts loud rather than silent (the #1434 failure mode), so an unexpected auto-commit **is** the loud signal.

## Test plan

- [x] YAML parses cleanly (`python3 -c 'yaml.safe_load(...)'` — 7 steps named, single `update-doc-snapshots` job)
- [x] Locally, `bun test packages/jsx/src/__tests__/doc-examples.test.ts -u` is deterministic across consecutive runs (`md5sum` of the snap unchanged after re-runs) — verified during v5 PR (#1534), and is what the workflow runs
- [ ] First in-the-wild trigger will be this PR itself (it touches `.github/workflows/update-doc-snapshots.yml`, which is in the path filter). Workflow should run, find the snap unchanged, and skip the commit step. If the diff step misfires, a stray bot commit on this PR will be the signal.

https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo

---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_