### PR TITLE
compiler(#1531): support default values in destructured filter param

### DIFF
--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -538,6 +538,61 @@ describe('expression-parser', () => {
       expect(result.kind).toBe('call')
     })
 
+    // Cross-binding default reference (`{ a, b = a }`) — JS resolves
+    // `a` to the destructured field, but our rewrite would emit
+    // `_t.b ?? a` and resolve `a` against the outer scope. To avoid
+    // the silent semantic mismatch, refuse the shape and let users
+    // fold the default inline (#1536 review).
+    test('rejects .filter(({a, b = a}) => b) — default refs another destructured binding (#1536)', () => {
+      const result = parseExpression('items().filter(({a, b = a}) => b)')
+      expect(result.kind).toBe('call')
+    })
+
+    // Side-effecting default (`{ x = getX() }`) — the rewrite duplicates
+    // the default at every reference site, so `x + x` would fire `getX()`
+    // twice. JS evaluates the default at most once per call. Refuse to
+    // avoid the silent multi-eval (#1536 review). Workaround: bind to a
+    // closure var.
+    test('rejects .filter(({x = getX()}) => x + x) — default contains a call (#1536)', () => {
+      const result = parseExpression('items().filter(({x = getX()}) => x + x)')
+      expect(result.kind).toBe('call')
+    })
+
+    test('rejects .filter(({xs = arr.slice()}) => xs) — default contains array-method (#1536)', () => {
+      const result = parseExpression('items().filter(({xs = arr.slice()}) => xs)')
+      expect(result.kind).toBe('call')
+    })
+
+    // Pure shapes that DO compose with the inline rewrite — these
+    // pin the "still works" side of the side-effect restriction.
+    test('lowers .filter(({x = fallback}) => x) — identifier default is pure (#1536)', () => {
+      // `fallback` resolves to outer scope; that's fine — duplicating
+      // a bare identifier read has no semantic cost.
+      const result = parseExpression('items().filter(({x = fallback}) => x)')
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') {
+        expect(result.predicate.kind).toBe('logical')
+        if (result.predicate.kind === 'logical') {
+          expect(result.predicate.op).toBe('??')
+          expect(result.predicate.right.kind).toBe('identifier')
+        }
+      }
+    })
+
+    test('lowers .filter(({x = config.fallback}) => x) — member-access default is pure (#1536)', () => {
+      // `config.fallback` is a property read — assumed pure (no getter
+      // side effects); duplicating across reference sites is harmless
+      // for the common case.
+      const result = parseExpression('items().filter(({x = config.fallback}) => x)')
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') {
+        expect(result.predicate.kind).toBe('logical')
+        if (result.predicate.kind === 'logical') {
+          expect(result.predicate.right.kind).toBe('member')
+        }
+      }
+    })
+
     // Nested destructure (#1530). The parser recurses into the inner
     // object pattern and threads the property path, so
     // `({user: {name}}) => name === 'alice'` rewrites to

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -340,13 +340,201 @@ describe('expression-parser', () => {
       }
     })
 
-    // Defaults / rest stay unsupported — each would need its own
-    // residual-object accessor pipeline. Nested destructure is
-    // covered separately below (#1530).
-    test('rejects .filter(({done = false}) => done) — defaults in destructure are unsupported (#1443)', () => {
+    // Defaults inside destructure (#1531). The parser folds the
+    // default into the rewritten body as `(_t.field ?? <default>)`
+    // so adapters reuse the standard logical-`??` lowering instead
+    // of a residual-undefined accessor pipeline. Rest stays
+    // unsupported. Nested + default combined is also out of scope
+    // (covered separately).
+    test('lowers .filter(({done = false}) => done) to higher-order with `??` default (#1531)', () => {
       const result = parseExpression('todos().filter(({done = false}) => done)')
-      // Falls through to plain `call` (not higher-order), so isSupported
-      // will surface BF101 at the adapter via the UNSUPPORTED_METHODS gate.
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') {
+        expect(result.method).toBe('filter')
+        expect(result.param).not.toBe('done')
+        // Predicate is `<synthetic>.done ?? false`.
+        expect(result.predicate.kind).toBe('logical')
+        if (result.predicate.kind === 'logical') {
+          expect(result.predicate.op).toBe('??')
+          expect(result.predicate.left.kind).toBe('member')
+          if (result.predicate.left.kind === 'member') {
+            expect(result.predicate.left.property).toBe('done')
+            expect(result.predicate.left.object.kind).toBe('identifier')
+            if (result.predicate.left.object.kind === 'identifier') {
+              expect(result.predicate.left.object.name).toBe(result.param)
+            }
+          }
+          expect(result.predicate.right.kind).toBe('literal')
+          if (result.predicate.right.kind === 'literal') {
+            expect(result.predicate.right.value).toBe(false)
+            expect(result.predicate.right.literalType).toBe('boolean')
+          }
+        }
+      }
+    })
+
+    test('lowers .filter(({count = 0}) => count > 5) — numeric default (#1531)', () => {
+      const result = parseExpression('items().filter(({count = 0}) => count > 5)')
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') {
+        // Predicate: `(_t.count ?? 0) > 5`.
+        expect(result.predicate.kind).toBe('binary')
+        if (result.predicate.kind === 'binary') {
+          expect(result.predicate.op).toBe('>')
+          expect(result.predicate.left.kind).toBe('logical')
+          if (result.predicate.left.kind === 'logical') {
+            expect(result.predicate.left.op).toBe('??')
+            expect(result.predicate.left.left.kind).toBe('member')
+            expect(result.predicate.left.right.kind).toBe('literal')
+            if (result.predicate.left.right.kind === 'literal') {
+              expect(result.predicate.left.right.value).toBe(0)
+            }
+          }
+        }
+      }
+    })
+
+    test("lowers .filter(({name = 'anon'}) => name.startsWith('a')) — string default (#1531)", () => {
+      const result = parseExpression("items().filter(({name = 'anon'}) => name.startsWith('a'))")
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') {
+        // Predicate: `(_t.name ?? 'anon').startsWith('a')`.
+        expect(result.predicate.kind).toBe('call')
+        if (result.predicate.kind === 'call') {
+          expect(result.predicate.callee.kind).toBe('member')
+          if (result.predicate.callee.kind === 'member') {
+            expect(result.predicate.callee.property).toBe('startsWith')
+            expect(result.predicate.callee.object.kind).toBe('logical')
+            if (result.predicate.callee.object.kind === 'logical') {
+              expect(result.predicate.callee.object.op).toBe('??')
+              expect(result.predicate.callee.object.right.kind).toBe('literal')
+              if (result.predicate.callee.object.right.kind === 'literal') {
+                expect(result.predicate.callee.object.right.value).toBe('anon')
+              }
+            }
+          }
+        }
+      }
+    })
+
+    test('lowers .filter(({label = `untitled-${suffix}`}) => label) — template-literal default (#1531)', () => {
+      const result = parseExpression('items().filter(({label = `untitled-${suffix}`}) => label)')
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') {
+        // Predicate: `_t.label ?? \`untitled-${suffix}\``.
+        expect(result.predicate.kind).toBe('logical')
+        if (result.predicate.kind === 'logical') {
+          expect(result.predicate.op).toBe('??')
+          expect(result.predicate.right.kind).toBe('template-literal')
+        }
+      }
+    })
+
+    test('lowers .every(({done = true}) => done) — defaults work on .every (#1531)', () => {
+      const result = parseExpression('items().every(({done = true}) => done)')
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') {
+        expect(result.method).toBe('every')
+        expect(result.predicate.kind).toBe('logical')
+      }
+    })
+
+    test('lowers .find(({active = false}) => active) — defaults work on .find (#1531)', () => {
+      const result = parseExpression('items().find(({active = false}) => active)')
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') {
+        expect(result.method).toBe('find')
+        expect(result.predicate.kind).toBe('logical')
+      }
+    })
+
+    // Semantic note (#1531): JS destructure defaults trigger only on
+    // `undefined`, while `??` triggers on `undefined` OR `null`. The
+    // rewrite uses `??` for simplicity, so `null` ALSO produces the
+    // default in lowered code — a one-bit gap from native JS semantics.
+    // Pin the choice with a test that the IR is `logical` `??` (not
+    // a conditional `!== undefined ? … : …`), so a future change to
+    // sentinel-based lowering would be a deliberate decision rather
+    // than a silent semantic shift.
+    test('uses `??` (not sentinel undefined check) — pins the null-triggers-default gap (#1531)', () => {
+      const result = parseExpression('items().filter(({done = false}) => done)')
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') {
+        // `??` => `null` ALSO triggers the default; this is the
+        // documented gap from JS destructure-default semantics, which
+        // only trigger on `undefined`. If this assertion fails, the
+        // rewrite shape changed — re-document the semantic difference.
+        expect(result.predicate.kind).toBe('logical')
+        if (result.predicate.kind === 'logical') {
+          expect(result.predicate.op).toBe('??')
+        }
+      }
+    })
+
+    // The default-with-renamed-field combination: `{ done: isDone = false }`.
+    // Local name is `isDone`, field on the source is `done`, default is
+    // `false`. Body references `isDone`, which rewrites to
+    // `(_t.done ?? false)`.
+    test('lowers .filter(({done: isDone = false}) => isDone) — renamed + default (#1531)', () => {
+      const result = parseExpression('todos().filter(({done: isDone = false}) => isDone)')
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') {
+        expect(result.predicate.kind).toBe('logical')
+        if (result.predicate.kind === 'logical') {
+          expect(result.predicate.op).toBe('??')
+          expect(result.predicate.left.kind).toBe('member')
+          if (result.predicate.left.kind === 'member') {
+            expect(result.predicate.left.property).toBe('done') // field, not the rename
+          }
+        }
+      }
+    })
+
+    // Rest in destructure stays unsupported even with our default work.
+    test('rejects .filter(({a, ...rest}) => a) — rest stays unsupported (#1531)', () => {
+      const result = parseExpression('items().filter(({a, ...rest}) => a)')
+      expect(result.kind).toBe('call')
+    })
+
+    // Nested destructure with a default on an INNER LEAF composes
+    // the two rewrites naturally — the inner leaf is reached through
+    // the threaded property path, and the leaf default wraps the
+    // accessor in `??` like any other leaf-level default. The #1531
+    // issue lists this shape as "out of scope" only because no
+    // special design was needed: the existing nested + leaf-default
+    // mechanics produce a correct lowering for free.
+    test('lowers .filter(({user: {name = "anon"}}) => name) — inner-leaf default composes (#1531)', () => {
+      const result = parseExpression('items().filter(({user: {name = "anon"}}) => name)')
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') {
+        // Predicate: `_t.user.name ?? "anon"`.
+        expect(result.predicate.kind).toBe('logical')
+        if (result.predicate.kind === 'logical') {
+          expect(result.predicate.op).toBe('??')
+          // Walk: `_t.user.name`.
+          const lhs = result.predicate.left
+          expect(lhs.kind).toBe('member')
+          if (lhs.kind === 'member') {
+            expect(lhs.property).toBe('name')
+            expect(lhs.object.kind).toBe('member')
+            if (lhs.object.kind === 'member') {
+              expect(lhs.object.property).toBe('user')
+            }
+          }
+          if (result.predicate.right.kind === 'literal') {
+            expect(result.predicate.right.value).toBe('anon')
+          }
+        }
+      }
+    })
+
+    // Default ON the nested-pattern slot itself (`({ user: { name } = {} })`)
+    // — different from a leaf-level default. The outer slot's default
+    // says "if user is undefined, use {} before destructuring name",
+    // which needs an extra outer-level `??` paired with the inner
+    // walk. Stays refused; out of scope for #1531.
+    test('rejects .filter(({user: {name} = {}}) => name) — default on nested-pattern slot (#1531)', () => {
+      const result = parseExpression('items().filter(({user: {name} = {}}) => name)')
       expect(result.kind).toBe('call')
     })
 

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -543,6 +543,45 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
       if (!collect.ok) {
         return { kind: 'unsupported', raw, reason: collect.reason }
       }
+      // Post-validate defaults (#1536 review). The rewrite inlines the
+      // default at every reference site (`x` → `_t.x ?? <default>`), so
+      // two shapes that JS would handle differently both produce
+      // surprises here:
+      //   1. Cross-binding refs (`({ a, b = a }) => b`): JS resolves
+      //      `a` to the destructured field; our rewrite would resolve
+      //      it to the outer scope (no per-default substitution against
+      //      `fieldMap`). Refuse so the mismatch can't sneak in.
+      //   2. Side-effecting defaults (`({ x = getX() }) => x + x`): JS
+      //      evaluates the default at most once per call; our rewrite
+      //      duplicates the default at every reference site, so a
+      //      side-effecting expression fires N times. Restrict defaults
+      //      to side-effect-free shapes (no `call` / `array-method` /
+      //      `higher-order` / `arrow-fn` subnodes).
+      // Both refusals route back through the standard `unsupported`
+      // path so adapters surface BF101; the workaround is to fold the
+      // default inline at the binding site.
+      for (const [name, entry] of fieldMap) {
+        if (!entry.defaultExpr) continue
+        const refs = new Set<string>()
+        collectIdentifiers(entry.defaultExpr, refs)
+        for (const ref of refs) {
+          if (fieldMap.has(ref)) {
+            return {
+              kind: 'unsupported',
+              raw,
+              reason: `Default value for '${name}' references destructured binding '${ref}'; cross-binding default references are not supported. Workaround: inline the default at the use site.`,
+            }
+          }
+        }
+        const impure = findImpureDefaultNode(entry.defaultExpr)
+        if (impure) {
+          return {
+            kind: 'unsupported',
+            raw,
+            reason: `Default value for '${name}' contains a '${impure}' expression; defaults must be side-effect-free (no function calls) because the rewrite inlines the default at every reference site. Workaround: bind the result to a closure variable and reference that, or fold the default inline at the use site.`,
+          }
+        }
+      }
       const syntheticParam = pickSyntheticParam(fieldMap, body)
       const rewritten = substituteDestructuredFields(body, fieldMap, syntheticParam)
       return { kind: 'arrow-fn', param: syntheticParam, body: rewritten }
@@ -853,6 +892,56 @@ function collectDestructureBindings(
     fieldMap.set(el.name.text, { path: [...pathPrefix, fieldName], defaultExpr })
   }
   return { ok: true }
+}
+
+/**
+ * Walk a default expression and return the first impure subnode's kind,
+ * or `null` if the whole tree is side-effect-free (#1536 review). The
+ * rewrite inlines the default at every reference site, so any node that
+ * could fire a function (`call`, `array-method`, `higher-order`,
+ * `arrow-fn`) breaks JS's "default evaluated at most once per call"
+ * semantic when the bound name is referenced more than once in the body.
+ * Pure shapes (literal / identifier / member / unary / binary / logical /
+ * conditional / template-literal / array-literal with pure parts) duplicate
+ * cleanly.
+ */
+function findImpureDefaultNode(expr: ParsedExpr): string | null {
+  switch (expr.kind) {
+    case 'literal':
+    case 'identifier':
+    case 'unsupported':
+      return null
+    case 'member':
+      return findImpureDefaultNode(expr.object)
+    case 'unary':
+      return findImpureDefaultNode(expr.argument)
+    case 'binary':
+    case 'logical':
+      return findImpureDefaultNode(expr.left) ?? findImpureDefaultNode(expr.right)
+    case 'conditional':
+      return findImpureDefaultNode(expr.test)
+        ?? findImpureDefaultNode(expr.consequent)
+        ?? findImpureDefaultNode(expr.alternate)
+    case 'template-literal':
+      for (const part of expr.parts) {
+        if (part.type === 'expression') {
+          const inner = findImpureDefaultNode(part.expr)
+          if (inner) return inner
+        }
+      }
+      return null
+    case 'array-literal':
+      for (const el of expr.elements) {
+        const inner = findImpureDefaultNode(el)
+        if (inner) return inner
+      }
+      return null
+    case 'call':
+    case 'array-method':
+    case 'higher-order':
+    case 'arrow-fn':
+      return expr.kind
+  }
 }
 
 /**

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -554,9 +554,12 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
       //   2. Side-effecting defaults (`({ x = getX() }) => x + x`): JS
       //      evaluates the default at most once per call; our rewrite
       //      duplicates the default at every reference site, so a
-      //      side-effecting expression fires N times. Restrict defaults
-      //      to side-effect-free shapes (no `call` / `array-method` /
-      //      `higher-order` / `arrow-fn` subnodes).
+      //      function-call-like subnode would fire N times. Restrict
+      //      defaults to shapes with no function-call-like subnodes
+      //      (`call` / `array-method` / `higher-order` / `arrow-fn`).
+      //      `member` access stays allowed even though getters/Proxies
+      //      can technically side-effect — see the docstring on
+      //      `findImpureDefaultNode` for the rationale.
       // Both refusals route back through the standard `unsupported`
       // path so adapters surface BF101; the workaround is to fold the
       // default inline at the binding site.
@@ -578,7 +581,7 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
           return {
             kind: 'unsupported',
             raw,
-            reason: `Default value for '${name}' contains a '${impure}' expression; defaults must be side-effect-free (no function calls) because the rewrite inlines the default at every reference site. Workaround: bind the result to a closure variable and reference that, or fold the default inline at the use site.`,
+            reason: `Default value for '${name}' contains a '${impure}' expression; defaults must have no function-call-like subnodes because the rewrite inlines the default at every reference site. Workaround: bind the result to a closure variable and reference that, or fold the default inline at the use site.`,
           }
         }
       }
@@ -790,13 +793,15 @@ type DestructureBinding = {
   path: string[]
   // Present only when the destructure carried `= <expr>`. The
   // ParsedExpr is captured once here and re-emitted verbatim at every
-  // substitution site for the bound name — its identifiers are NOT
+  // substitution site for the bound name. Its identifiers are NOT
   // re-substituted against `fieldMap`, so a default that references
   // another destructured field (`({ a, b = a }) => b`) would resolve
-  // `a` against the OUTER scope, not `_t.a`. That cross-reference
-  // shape is rare and shares the spirit of the explicit "nested +
-  // default combined" out-of-scope carve-out in #1531; document the
-  // gap if a user hits it.
+  // `a` against the outer scope rather than `_t.a` — a silent
+  // semantic mismatch. The post-collection validation in the
+  // `isObjectBindingPattern` arm of `convertNode` explicitly refuses
+  // any default whose identifier set intersects `fieldMap.keys()`,
+  // so by the time substitution runs every retained default is
+  // guaranteed cross-binding-free (#1536 review).
   defaultExpr?: ParsedExpr
 }
 
@@ -828,15 +833,17 @@ function collectDestructureBindings(
       // shorthand `{ { name } }` doesn't exist. Computed / string
       // / numeric property names stay refused.
       //
-      // Nested + default combined (`({ user: { name = 'anon' } })`)
-      // is out of scope per #1531 — the inner default would need to
-      // compose with the outer-level missing-`user` fallback, which
-      // multiplies the `??` rewrite paths. The inner pattern's
-      // `el.initializer` is rejected by the recursive call below
-      // (defaults on a non-leaf binding element are surfaced when
-      // that nested element is visited).
+      // Default on the NESTED-PATTERN SLOT itself
+      // (`({ user: { name } = {} })`) is out of scope — that shape
+      // says "if user is undefined, substitute {} before
+      // destructuring name", which needs an outer-level `??` paired
+      // with the inner walk and multiplies the rewrite paths.
+      // Inner-LEAF defaults (`({ user: { name = 'anon' } })`) work
+      // fine — they're surfaced by the recursive call below when the
+      // inner leaf element is visited, and compose naturally with
+      // the threaded property path.
       if (el.initializer) {
-        return { ok: false, reason: 'Default values combined with nested destructure are not supported' }
+        return { ok: false, reason: 'Default values on a nested-pattern slot in destructured filter param are not supported' }
       }
       if (!el.propertyName || !ts.isIdentifier(el.propertyName)) {
         return { ok: false, reason: 'Non-identifier (computed/string/numeric) keys in destructured filter param are not supported' }
@@ -895,15 +902,25 @@ function collectDestructureBindings(
 }
 
 /**
- * Walk a default expression and return the first impure subnode's kind,
- * or `null` if the whole tree is side-effect-free (#1536 review). The
- * rewrite inlines the default at every reference site, so any node that
- * could fire a function (`call`, `array-method`, `higher-order`,
- * `arrow-fn`) breaks JS's "default evaluated at most once per call"
- * semantic when the bound name is referenced more than once in the body.
- * Pure shapes (literal / identifier / member / unary / binary / logical /
- * conditional / template-literal / array-literal with pure parts) duplicate
- * cleanly.
+ * Walk a default expression and return the first function-call-like
+ * subnode's kind, or `null` if no such node exists (#1536 review). The
+ * rewrite inlines the default at every reference site, so any node
+ * that obviously fires a function (`call`, `array-method`,
+ * `higher-order`, `arrow-fn`) breaks JS's "default evaluated at most
+ * once per call" semantic when the bound name is referenced more than
+ * once in the body.
+ *
+ * The check is intentionally narrow: it only refuses function-call-like
+ * shapes, not all side effects. `member` access is allowed even though
+ * a getter / Proxy trap can technically run code on every read — pure
+ * struct-field access is the overwhelmingly common shape in template
+ * predicates, and refusing it would lock out idioms like
+ * `{ x = config.fallback }`. Users who pass objects with side-effecting
+ * getters into a filter predicate are outside the spirit of "render a
+ * snapshot of state", so we don't try to defend against them. The
+ * remaining shapes (literal / identifier / member / unary / binary /
+ * logical / conditional / template-literal / array-literal with pure
+ * parts) duplicate cleanly under inlining.
  */
 function findImpureDefaultNode(expr: ParsedExpr): string | null {
   switch (expr.kind) {

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -528,15 +528,18 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
     const body = convertNode(node.body, raw)
 
     // Destructured-object param: `({done}) => done` (#1443),
-    // `({user: {name}}) => name` (#1530). We synthesise the equivalent
-    // dotted-access form so adapters can reuse their existing
-    // higher-order paths instead of needing a residual-object-accessor
-    // pipeline (#1384 territory). Nested destructure recurses into
-    // the inner pattern and threads a dotted path; rest / defaults /
-    // array binding stay unsupported.
+    // `({user: {name}}) => name` (#1530), `({done = false}) => done`
+    // (#1531). We synthesise the equivalent dotted-access form so
+    // adapters can reuse their existing higher-order paths instead of
+    // needing a residual-object-accessor pipeline (#1384 territory).
+    // Nested destructure recurses into the inner pattern and threads
+    // a dotted path; leaf defaults fold into the rewrite as
+    // `(_t.field ?? <default>)`. Rest patterns, array binding
+    // patterns, and defaults at non-leaf (nested-pattern) slots
+    // stay unsupported.
     if (ts.isObjectBindingPattern(param.name)) {
-      const fieldMap = new Map<string, string[]>()
-      const collect = collectDestructureBindings(param.name, [], fieldMap)
+      const fieldMap = new Map<string, DestructureBinding>()
+      const collect = collectDestructureBindings(param.name, [], fieldMap, raw)
       if (!collect.ok) {
         return { kind: 'unsupported', raw, reason: collect.reason }
       }
@@ -737,8 +740,30 @@ function classifySortOperand(
 }
 
 /**
+ * Per-binding entry stored in `fieldMap`: the dotted path from the
+ * synthetic param down to the field, plus an optional default
+ * ParsedExpr captured from `({ field = <default> }) => …` (#1531).
+ * Defaults are folded into the rewrite as `(<path> ?? <default>)` so
+ * adapters reuse the standard logical-`??` lowering instead of
+ * needing a residual-undefined accessor pipeline.
+ */
+type DestructureBinding = {
+  path: string[]
+  // Present only when the destructure carried `= <expr>`. The
+  // ParsedExpr is captured once here and re-emitted verbatim at every
+  // substitution site for the bound name — its identifiers are NOT
+  // re-substituted against `fieldMap`, so a default that references
+  // another destructured field (`({ a, b = a }) => b`) would resolve
+  // `a` against the OUTER scope, not `_t.a`. That cross-reference
+  // shape is rare and shares the spirit of the explicit "nested +
+  // default combined" out-of-scope carve-out in #1531; document the
+  // gap if a user hits it.
+  defaultExpr?: ParsedExpr
+}
+
+/**
  * Walk an object-binding pattern and populate `fieldMap` with
- * `localName → [field, field, …]` entries. Nested patterns extend
+ * `localName → { path, defaultExpr? }` entries. Nested patterns extend
  * the path; renamed bindings use the property name (the field on
  * the source object) rather than the local rename. Returns an
  * error result for any shape outside the supported set so the
@@ -747,7 +772,8 @@ function classifySortOperand(
 function collectDestructureBindings(
   pattern: ts.ObjectBindingPattern,
   pathPrefix: readonly string[],
-  fieldMap: Map<string, string[]>,
+  fieldMap: Map<string, DestructureBinding>,
+  raw: string,
 ): { ok: true } | { ok: false; reason: string } {
   for (const el of pattern.elements) {
     if (!ts.isBindingElement(el)) {
@@ -756,15 +782,23 @@ function collectDestructureBindings(
     if (el.dotDotDotToken) {
       return { ok: false, reason: 'Rest patterns in destructured filter param are not supported' }
     }
-    if (el.initializer) {
-      return { ok: false, reason: 'Default values in destructured filter param are not supported' }
-    }
     if (ts.isObjectBindingPattern(el.name)) {
       // Nested object pattern: `{ user: { name } }`. The outer slot
       // MUST carry an identifier propertyName — the JS grammar for
       // nested destructure requires `key: <pattern>`, so the
       // shorthand `{ { name } }` doesn't exist. Computed / string
       // / numeric property names stay refused.
+      //
+      // Nested + default combined (`({ user: { name = 'anon' } })`)
+      // is out of scope per #1531 — the inner default would need to
+      // compose with the outer-level missing-`user` fallback, which
+      // multiplies the `??` rewrite paths. The inner pattern's
+      // `el.initializer` is rejected by the recursive call below
+      // (defaults on a non-leaf binding element are surfaced when
+      // that nested element is visited).
+      if (el.initializer) {
+        return { ok: false, reason: 'Default values combined with nested destructure are not supported' }
+      }
       if (!el.propertyName || !ts.isIdentifier(el.propertyName)) {
         return { ok: false, reason: 'Non-identifier (computed/string/numeric) keys in destructured filter param are not supported' }
       }
@@ -772,6 +806,7 @@ function collectDestructureBindings(
         el.name,
         [...pathPrefix, el.propertyName.text],
         fieldMap,
+        raw,
       )
       if (!inner.ok) return inner
       continue
@@ -795,7 +830,27 @@ function collectDestructureBindings(
     } else {
       fieldName = el.name.text // shorthand: `{done}` ≡ `{done: done}`
     }
-    fieldMap.set(el.name.text, [...pathPrefix, fieldName])
+    // Leaf default value (`{ done = false }`): parse the initializer
+    // through the standard expression pipeline so the rewrite emits
+    // `(_t.done ?? false)` instead of a bare accessor (#1531). A
+    // default that itself fails to parse surfaces the inner reason
+    // rather than the catch-all "Default values… not supported".
+    //
+    // Semantic gap: JS destructure defaults trigger only on
+    // `undefined`, while `??` triggers on `undefined` OR `null`. The
+    // gap matters only when a field is explicitly set to `null`; for
+    // typed receivers (objects with optional fields) the two are
+    // equivalent. Users hitting the `null` case should fold the
+    // default inline.
+    let defaultExpr: ParsedExpr | undefined
+    if (el.initializer) {
+      const parsed = convertNode(el.initializer, raw)
+      if (parsed.kind === 'unsupported') {
+        return { ok: false, reason: `Default value in destructured filter param failed to parse: ${parsed.reason}` }
+      }
+      defaultExpr = parsed
+    }
+    fieldMap.set(el.name.text, { path: [...pathPrefix, fieldName], defaultExpr })
   }
   return { ok: true }
 }
@@ -816,9 +871,16 @@ function collectDestructureBindings(
  * (`user` in `{ user: { name } }`) are consumed in the path and
  * never bound in scope, so they don't need collision avoidance.
  */
-function pickSyntheticParam(fieldMap: Map<string, string[]>, body: ParsedExpr): string {
+function pickSyntheticParam(fieldMap: Map<string, DestructureBinding>, body: ParsedExpr): string {
   const used = new Set<string>(fieldMap.keys())
   collectIdentifiers(body, used)
+  // Default expressions (`{ name = otherVar }`) become part of the
+  // rewritten body — their free identifiers (`otherVar`) must also
+  // be excluded from the synthetic param candidate set to avoid
+  // silently shadowing a closure capture (#1531).
+  for (const entry of fieldMap.values()) {
+    if (entry.defaultExpr) collectIdentifiers(entry.defaultExpr, used)
+  }
   let name = '_t'
   while (used.has(name)) name = name + '_'
   return name
@@ -883,20 +945,27 @@ function collectIdentifiers(expr: ParsedExpr, out: Set<string>): void {
  */
 function substituteDestructuredFields(
   expr: ParsedExpr,
-  fieldMap: Map<string, string[]>,
+  fieldMap: Map<string, DestructureBinding>,
   syntheticParam: string,
 ): ParsedExpr {
   const walk = (e: ParsedExpr): ParsedExpr => {
     switch (e.kind) {
       case 'identifier': {
-        const path = fieldMap.get(e.name)
-        if (path === undefined) return e
+        const entry = fieldMap.get(e.name)
+        if (entry === undefined) return e
         // Build `<syntheticParam>.<path[0]>.<path[1]>…` as a left-leaning
         // chain of `member` nodes. Single-level destructure produces a
         // one-hop chain identical to the pre-#1530 shape.
         let node: ParsedExpr = { kind: 'identifier', name: syntheticParam }
-        for (const segment of path) {
+        for (const segment of entry.path) {
           node = { kind: 'member', object: node, property: segment, computed: false }
+        }
+        // Default value (#1531): wrap the accessor in `?? <default>` so
+        // a missing field falls back to the user-supplied literal /
+        // expression. Adapters already lower `??` through the standard
+        // logical-operator path, so no per-target work is needed.
+        if (entry.defaultExpr) {
+          return { kind: 'logical', op: '??', left: node, right: entry.defaultExpr }
         }
         return node
       }


### PR DESCRIPTION
## Summary

Fixes #1531 — defaults inside the destructured-object param of `.filter()` / `.every()` / `.some()` / `.find()` / `.findIndex()` (`({ done = false }) => done`) were refused at the parser. Now folded into the substituted body as `(_t.field ?? <default>)` so adapters reuse the standard logical-`??` lowering instead of needing a residual-undefined accessor pipeline.

### Changes

- `packages/jsx/src/expression-parser.ts`
  - New internal type `DestructureBinding = { path: string[]; defaultExpr?: ParsedExpr }`.
  - `collectDestructureBindings` parses leaf-level initializers via `convertNode` and stores them on the per-field entry. Failed-to-parse defaults surface the inner reason rather than the catch-all unsupported text.
  - `substituteDestructuredFields` wraps the rewritten accessor in `{ kind: 'logical', op: '??', left, right: defaultExpr }` when the binding carries a default.
  - `pickSyntheticParam` walks default expressions' identifiers too so a free `_t` inside a default doesn't get silently shadowed.
  - Defaults on a nested-pattern slot (`({ user: { name } = {} })`) explicitly refused — that shape needs an outer-level `??` paired with the inner walk; out of scope.

- `packages/jsx/src/__tests__/expression-parser.test.ts`
  - Replaced the old rejection test with positive coverage: boolean / numeric / string / template-literal defaults, `.every` / `.find` parity, renamed + default combination, inner-leaf default inside nested destructure, semantic pin asserting the rewrite uses `??` (locking in the documented `null`-triggers-default gap), and explicit rejection cases for rest patterns and defaults on a nested-pattern slot.

### Semantic note

JS destructure defaults trigger only on `undefined`, while `??` triggers on `undefined` OR `null`. The gap is documented in the source and pinned by a test. Users hitting the `null` case should fold the default inline.

## Test plan

- [x] `bun test src/__tests__/expression-parser.test.ts` — 87 pass, 0 fail
- [x] Full jsx test suite — no regressions (4 pre-existing failures in `primitive-resolver-*` tests, unrelated and present on main before my change)
- [x] Type check (`bun run --filter '@barefootjs/jsx' build:types`) — clean

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01B43FhmAkVPodhGsrK7RV8F)_