### PR TITLE
compiler: rewrite rest pattern in filter predicate destructure (#1532)

### DIFF
--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -700,6 +700,112 @@ describe('expression-parser', () => {
       expect(result.kind).toBe('call')
     })
 
+    // Default value + rest composition (#1532 review). #1531's leaf
+    // default fold (`_t.done ?? false`) and #1532's rest rewrite must
+    // coexist in the same destructure. Pin the lowering so a future
+    // refactor of either feature can't silently break the cross.
+    test('lowers .filter(({done = false, ...rest}) => done && rest.priority > 0) — default + rest compose (#1532 review)', () => {
+      const result = parseExpression('items().filter(({done = false, ...rest}) => done && rest.priority > 0)')
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') {
+        // Predicate: `(_t.done ?? false) && _t.priority > 0`.
+        expect(result.predicate.kind).toBe('logical')
+        if (result.predicate.kind === 'logical') {
+          // Left: `_t.done ?? false`.
+          expect(result.predicate.left.kind).toBe('logical')
+          if (result.predicate.left.kind === 'logical') {
+            expect(result.predicate.left.op).toBe('??')
+            expect(result.predicate.left.left.kind).toBe('member')
+            if (result.predicate.left.left.kind === 'member') {
+              expect(result.predicate.left.left.property).toBe('done')
+            }
+          }
+          // Right: `_t.priority > 0` — confirms the rest rewrite ran.
+          expect(result.predicate.right.kind).toBe('binary')
+          if (result.predicate.right.kind === 'binary') {
+            expect(result.predicate.right.left.kind).toBe('member')
+            if (result.predicate.right.left.kind === 'member') {
+              expect(result.predicate.right.left.property).toBe('priority')
+            }
+          }
+        }
+      }
+    })
+
+    // Renamed leaf + Mode A rest member access (#1532 review). The
+    // collision negative case (`rest.done` after `done: d`) is
+    // covered above; this is the positive cross — the renamed leaf
+    // uses its local name (`d`) and the rest path uses a different
+    // source key (`priority`). Lowers cleanly.
+    test('lowers .filter(({done: d, ...rest}) => d && rest.priority > 0) — renamed leaf + Mode A (#1532 review)', () => {
+      const result = parseExpression('items().filter(({done: d, ...rest}) => d && rest.priority > 0)')
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') {
+        expect(result.predicate.kind).toBe('logical')
+        if (result.predicate.kind === 'logical') {
+          // Left: `_t.done` (rename rewrites to the SOURCE key).
+          const left = result.predicate.left
+          expect(left.kind).toBe('member')
+          if (left.kind === 'member') {
+            expect(left.property).toBe('done')
+            if (left.object.kind === 'identifier') {
+              expect(left.object.name).toBe(result.param)
+            }
+          }
+          // Right: `_t.priority > 0` — rest member access.
+          expect(result.predicate.right.kind).toBe('binary')
+        }
+      }
+    })
+
+    // Mixed Mode A + Mode B in the same predicate (#1532 review).
+    // `rest.x` is a legal member access; `fn(rest)` passes rest as
+    // a value. The walker must catch the value-use even when other
+    // references are valid — verifies the early-return ordering
+    // doesn't accept the predicate just because Mode A reached the
+    // member walker first.
+    test('rejects .filter(({a, ...rest}) => rest.x === fn(rest)) — Mode A + Mode B mixed (#1532 review)', () => {
+      const result = parseExpression('items().filter(({a, ...rest}) => rest.x === fn(rest))')
+      expect(result.kind).toBe('call')
+    })
+
+    // Synthetic param collision with closure-captured `_t` (#1532
+    // review, parallels the #1530 collision test). The body
+    // references a free `_t` AND uses rest member access. The
+    // synthetic param picker must avoid `_t` so the rewrite doesn't
+    // silently shadow the closure capture.
+    test('picks a non-colliding synthetic param when rest body references `_t` (#1532 review)', () => {
+      const result = parseExpression('items().filter(({a, ...rest}) => rest.x === _t)')
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') {
+        expect(result.param).not.toBe('_t')
+        expect(result.param).toMatch(/^_t_+$/)
+      }
+    })
+
+    // Cross-method coverage for the rest rewrite (#1532). The arrow
+    // handler is generic, but pin each higher-order method so a
+    // future narrowing in the call-site dispatch can't silently
+    // drop one. `.every` is covered above; this group adds the
+    // remaining three.
+    test('lowers .some(({a, ...rest}) => rest.x) — cross-method (#1532 review)', () => {
+      const result = parseExpression('items().some(({a, ...rest}) => rest.x)')
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') expect(result.method).toBe('some')
+    })
+
+    test('lowers .find(({a, ...rest}) => rest.x) — cross-method (#1532 review)', () => {
+      const result = parseExpression('items().find(({a, ...rest}) => rest.x)')
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') expect(result.method).toBe('find')
+    })
+
+    test('lowers .findIndex(({a, ...rest}) => rest.x) — cross-method (#1532 review)', () => {
+      const result = parseExpression('items().findIndex(({a, ...rest}) => rest.x)')
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') expect(result.method).toBe('findIndex')
+    })
+
     // Nested destructure with a default on an INNER LEAF composes
     // the two rewrites naturally — the inner leaf is reached through
     // the threaded property path, and the leaf default wraps the

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -614,37 +614,22 @@ describe('expression-parser', () => {
     })
 
     // Inner-arrow parameter shadowing (#1532 review). The outer
-    // rest binding is `rest`; the inner `.map((rest) => rest)`
-    // declares a NEW `rest` parameter that shadows it. Without
-    // shadow tracking the walker would walk into the inner body,
-    // see `identifier rest`, and emit a spurious BF021. With
-    // shadowing the inner body is skipped and the outer predicate
-    // lowers cleanly via Mode A (only `rest.x` member access).
-    test('lowers .filter(({a, ...rest}) => rest.x.map((rest) => rest)[0]) — inner-arrow param shadows outer rest (#1532 review)', () => {
-      // Note: the inner `.map(...)` body is itself unsupported by
-      // the parser (the inner arrow returns a bare identifier — fine,
-      // but lowering `arr.map(...)[0]` may fall back). What matters
-      // for the review: validateRestUsage doesn't refuse on the
-      // shadowed `rest` reference inside the inner arrow.
-      const result = parseExpression('items().filter(({a, ...rest}) => rest.x === (rest => rest)(rest.y))')
-      // The IIFE-style nested arrow is `(rest => rest)(rest.y)`.
-      // Its param `rest` shadows the outer — the inner identifier
-      // ref is to the inner param, so no spurious refusal. But
-      // `rest.y` (passed as the arg) is still in outer scope and
-      // is a Mode A member access. Whole predicate should pass.
-      // (The call to a parenthesised inline arrow may itself be
-      // unsupported elsewhere in the parser, but rest validation
-      // should NOT refuse this shape.)
-      // We assert: NOT refused-by-rest-validation (would surface as
-      // `call` with a rest-binding reason). Either `higher-order`
-      // (clean) or `call` (refused for a non-rest reason) is fine —
-      // the key signal is the reason string when refused.
-      if (result.kind === 'call') {
-        // If refused for any reason, it must NOT mention the rest
-        // value-use refusal. We can't introspect easily here; the
-        // adapter integration test below covers the no-BF021 path.
-      } else {
-        expect(result.kind).toBe('higher-order')
+    // destructure declares `rest`; the inner `.map((rest) => rest.y)`
+    // declares its OWN `rest` parameter that shadows the outer. The
+    // inner `rest` identifier is bound to the inner param, not the
+    // outer rest binding. Without shadow tracking the walker would
+    // walk into the inner body, see `identifier rest`, and emit a
+    // spurious BF021. With shadowing the inner scope is skipped, and
+    // the outer predicate lowers cleanly because the only outer
+    // reference is `rest.x` (Mode A member access).
+    test('lowers .filter(({a, ...rest}) => rest.x.map((rest) => rest.y).length > 0) — inner-arrow param shadows outer rest (#1532 review)', () => {
+      const result = parseExpression('items().filter(({a, ...rest}) => rest.x.map((rest) => rest.y).length > 0)')
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') {
+        expect(result.method).toBe('filter')
+        // Predicate is the outer body rewritten — confirms validation
+        // didn't refuse on the inner-scope `rest` reference.
+        expect(result.predicate.kind).toBe('binary')
       }
     })
 
@@ -661,13 +646,22 @@ describe('expression-parser', () => {
       expect(result.kind).toBe('call')
     })
 
-    // Mode B via function-expression form (#1532): `return rest` —
-    // rest as the return value of a function-keyword predicate.
-    test('rejects .filter(function ({a, ...rest}) { return rest }) — rest as return value (#1532)', () => {
-      // Function-expression form: parser already refuses destructured
-      // params for `function () { return … }` shapes at the call site.
-      // The arrow-fn equivalent below is the actual #1532 target.
+    // Mode B (#1532): bare `rest` as the arrow's return value. No
+    // member access — `rest` is the value position, which can't
+    // lower to a template-compiled predicate.
+    test('rejects .filter(({a, ...rest}) => rest) — rest as bare return value (#1532)', () => {
       const result = parseExpression('items().filter(({a, ...rest}) => rest)')
+      expect(result.kind).toBe('call')
+    })
+
+    // Function-expression form with a destructured param (#1532).
+    // The function-keyword path refuses destructured params upstream
+    // at the call site in `convertNode` (only single-identifier params
+    // are normalised into the arrow-fn IR shape) — locks in that the
+    // upstream refusal stays in place so the #1532 rest path isn't
+    // accidentally widened to function expressions without explicit work.
+    test('rejects .filter(function ({a, ...rest}) { return rest }) — function-expression form refused upstream (#1532)', () => {
+      const result = parseExpression('items().filter(function ({a, ...rest}) { return rest })')
       expect(result.kind).toBe('call')
     })
 

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -592,6 +592,62 @@ describe('expression-parser', () => {
       expect(result.kind).toBe('call')
     })
 
+    // Mode A typed error via RENAMED key (#1532 review). The rest
+    // exclusion runs against source-object keys, not local binding
+    // names — `done` is consumed even though it's locally named `d`.
+    // Pre-review the check used `fieldMap.has('done')` which keys
+    // on local rename `d` and silently rewrote to `_t.done`.
+    test('rejects .filter(({done: d, ...rest}) => rest.done) — renamed key collision (#1532 review)', () => {
+      const result = parseExpression('items().filter(({done: d, ...rest}) => rest.done)')
+      expect(result.kind).toBe('call')
+    })
+
+    // Mode A typed error via NESTED-PATTERN slot (#1532 review).
+    // The outer `user` key is consumed by the nested pattern even
+    // though no top-level local binding for `user` exists. Same
+    // miss as the renamed-key case — the pre-review check on
+    // `fieldMap` would only see `name` and silently rewrite
+    // `rest.user` to `_t.user`.
+    test('rejects .filter(({user: {name}, ...rest}) => rest.user) — nested-pattern outer key collision (#1532 review)', () => {
+      const result = parseExpression('items().filter(({user: {name}, ...rest}) => rest.user)')
+      expect(result.kind).toBe('call')
+    })
+
+    // Inner-arrow parameter shadowing (#1532 review). The outer
+    // rest binding is `rest`; the inner `.map((rest) => rest)`
+    // declares a NEW `rest` parameter that shadows it. Without
+    // shadow tracking the walker would walk into the inner body,
+    // see `identifier rest`, and emit a spurious BF021. With
+    // shadowing the inner body is skipped and the outer predicate
+    // lowers cleanly via Mode A (only `rest.x` member access).
+    test('lowers .filter(({a, ...rest}) => rest.x.map((rest) => rest)[0]) — inner-arrow param shadows outer rest (#1532 review)', () => {
+      // Note: the inner `.map(...)` body is itself unsupported by
+      // the parser (the inner arrow returns a bare identifier — fine,
+      // but lowering `arr.map(...)[0]` may fall back). What matters
+      // for the review: validateRestUsage doesn't refuse on the
+      // shadowed `rest` reference inside the inner arrow.
+      const result = parseExpression('items().filter(({a, ...rest}) => rest.x === (rest => rest)(rest.y))')
+      // The IIFE-style nested arrow is `(rest => rest)(rest.y)`.
+      // Its param `rest` shadows the outer — the inner identifier
+      // ref is to the inner param, so no spurious refusal. But
+      // `rest.y` (passed as the arg) is still in outer scope and
+      // is a Mode A member access. Whole predicate should pass.
+      // (The call to a parenthesised inline arrow may itself be
+      // unsupported elsewhere in the parser, but rest validation
+      // should NOT refuse this shape.)
+      // We assert: NOT refused-by-rest-validation (would surface as
+      // `call` with a rest-binding reason). Either `higher-order`
+      // (clean) or `call` (refused for a non-rest reason) is fine —
+      // the key signal is the reason string when refused.
+      if (result.kind === 'call') {
+        // If refused for any reason, it must NOT mention the rest
+        // value-use refusal. We can't introspect easily here; the
+        // adapter integration test below covers the no-BF021 path.
+      } else {
+        expect(result.kind).toBe('higher-order')
+      }
+    })
+
     // Mode B (#1532): rest used as a call argument can't be lowered
     // — the residual object isn't a runtime value in the template
     // pipeline. Refuse with BF021 + `/* @client */` hint.

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -490,9 +490,145 @@ describe('expression-parser', () => {
       }
     })
 
-    // Rest in destructure stays unsupported even with our default work.
-    test('rejects .filter(({a, ...rest}) => a) — rest stays unsupported (#1531)', () => {
+    // Rest pattern with no body reference (#1532): the binding is
+    // present but never read, so the rewrite is identical to the
+    // non-rest shape — Mode A trivially holds (zero rest references
+    // to validate).
+    test('lowers .filter(({a, ...rest}) => a) — unused rest is harmless (#1532)', () => {
       const result = parseExpression('items().filter(({a, ...rest}) => a)')
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') {
+        expect(result.predicate.kind).toBe('member')
+        if (result.predicate.kind === 'member') {
+          expect(result.predicate.property).toBe('a')
+        }
+      }
+    })
+
+    // Mode A (#1532): `restName.X` member access rewrites to
+    // `_t.X`. The residual object only omits explicitly-bound keys,
+    // so `_t.priority` returns the same value as `rest.priority`
+    // would whenever `priority !== 'done'`.
+    test('lowers .filter(({done, ...rest}) => done && rest.priority > 0) — rest member access (#1532)', () => {
+      const result = parseExpression('items().filter(({done, ...rest}) => done && rest.priority > 0)')
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') {
+        expect(result.method).toBe('filter')
+        // Predicate: `_t.done && _t.priority > 0`.
+        expect(result.predicate.kind).toBe('logical')
+        if (result.predicate.kind === 'logical') {
+          expect(result.predicate.op).toBe('&&')
+          const left = result.predicate.left
+          expect(left.kind).toBe('member')
+          if (left.kind === 'member') {
+            expect(left.property).toBe('done')
+            if (left.object.kind === 'identifier') {
+              expect(left.object.name).toBe(result.param)
+            }
+          }
+          const right = result.predicate.right
+          expect(right.kind).toBe('binary')
+          if (right.kind === 'binary') {
+            const lhs = right.left
+            expect(lhs.kind).toBe('member')
+            if (lhs.kind === 'member') {
+              expect(lhs.property).toBe('priority')
+              if (lhs.object.kind === 'identifier') {
+                expect(lhs.object.name).toBe(result.param)
+              }
+            }
+          }
+        }
+      }
+    })
+
+    test('lowers .filter(({a, ...r}) => r.x && r.y) — multiple rest accesses share the synthetic param (#1532)', () => {
+      const result = parseExpression('items().filter(({a, ...r}) => r.x && r.y)')
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') {
+        // Predicate: `_t.x && _t.y`.
+        expect(result.predicate.kind).toBe('logical')
+        if (result.predicate.kind === 'logical') {
+          const left = result.predicate.left
+          expect(left.kind).toBe('member')
+          if (left.kind === 'member') {
+            expect(left.property).toBe('x')
+            if (left.object.kind === 'identifier') {
+              expect(left.object.name).toBe(result.param)
+            }
+          }
+          const right = result.predicate.right
+          expect(right.kind).toBe('member')
+          if (right.kind === 'member') {
+            expect(right.property).toBe('y')
+            if (right.object.kind === 'identifier') {
+              expect(right.object.name).toBe(result.param)
+            }
+          }
+        }
+      }
+    })
+
+    test('lowers .every(({a, ...rest}) => rest.x) — rest rewrite applies across higher-order methods (#1532)', () => {
+      const result = parseExpression('items().every(({a, ...rest}) => rest.x)')
+      expect(result.kind).toBe('higher-order')
+      if (result.kind === 'higher-order') {
+        expect(result.method).toBe('every')
+        expect(result.predicate.kind).toBe('member')
+        if (result.predicate.kind === 'member') {
+          expect(result.predicate.property).toBe('x')
+        }
+      }
+    })
+
+    // Mode A typed error (#1532): `rest.X` where `X` is also a
+    // declared field. JS spec excludes named keys from the residual
+    // object, so `rest.done` is statically `undefined`. Refuse so
+    // the user fixes the bug rather than silently get rewritten to
+    // `_t.done` (which would return the value, masking the mistake).
+    test('rejects .filter(({done, ...rest}) => rest.done) — rest key collides with declared field (#1532)', () => {
+      const result = parseExpression('items().filter(({done, ...rest}) => rest.done)')
+      // Falls back to plain `call` — adapter surfaces BF021.
+      expect(result.kind).toBe('call')
+    })
+
+    // Mode B (#1532): rest used as a call argument can't be lowered
+    // — the residual object isn't a runtime value in the template
+    // pipeline. Refuse with BF021 + `/* @client */` hint.
+    test('rejects .filter(({a, ...rest}) => Object.keys(rest).length > 0) — rest passed to call (#1532)', () => {
+      const result = parseExpression('items().filter(({a, ...rest}) => Object.keys(rest).length > 0)')
+      expect(result.kind).toBe('call')
+    })
+
+    test('rejects .filter(({a, ...rest}) => fn(rest)) — rest passed as bare arg (#1532)', () => {
+      const result = parseExpression('items().filter(({a, ...rest}) => fn(rest))')
+      expect(result.kind).toBe('call')
+    })
+
+    // Mode B via function-expression form (#1532): `return rest` —
+    // rest as the return value of a function-keyword predicate.
+    test('rejects .filter(function ({a, ...rest}) { return rest }) — rest as return value (#1532)', () => {
+      // Function-expression form: parser already refuses destructured
+      // params for `function () { return … }` shapes at the call site.
+      // The arrow-fn equivalent below is the actual #1532 target.
+      const result = parseExpression('items().filter(({a, ...rest}) => rest)')
+      expect(result.kind).toBe('call')
+    })
+
+    // Computed rest access with a literal key still refuses (#1532):
+    // the residual-object accessor doesn't exist in template syntax,
+    // and rewriting `rest[0]` to `_t[0]` would silently include the
+    // declared keys' positions in the result. Mode B.
+    test('rejects .filter(({a, ...rest}) => rest[0]) — computed rest access with literal key (#1532)', () => {
+      const result = parseExpression('items().filter(({a, ...rest}) => rest[0])')
+      expect(result.kind).toBe('call')
+    })
+
+    // Rest at a nested destructure level (#1532 out-of-scope) — we
+    // have no "residual object at nested key" template accessor, so
+    // refuse explicitly rather than walk past the outer level.
+    test('rejects .filter(({user: {name, ...rest}}) => rest.email) — nested rest (#1532)', () => {
+      const result = parseExpression('items().filter(({user: {name, ...rest}}) => rest.email)')
       expect(result.kind).toBe('call')
     })
 

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -665,6 +665,24 @@ describe('expression-parser', () => {
       expect(result.kind).toBe('call')
     })
 
+    // Method call on rest (#1532 review). `rest.foo()` would lower
+    // to `_t.foo()`, but JS evaluates the call with `this` bound to
+    // the member receiver — `rest` (residual object) and `_t` (the
+    // original item) are different bindings, and rest also excludes
+    // consumed keys. Both changes are observable, so refuse the
+    // shape rather than silently rewrite.
+    test('rejects .filter(({a, ...rest}) => rest.foo()) — method call on rest (#1532 review)', () => {
+      const result = parseExpression('items().filter(({a, ...rest}) => rest.foo())')
+      expect(result.kind).toBe('call')
+    })
+
+    // Same for method-call-with-args — confirms the dedicated branch
+    // catches it regardless of argument shape.
+    test('rejects .filter(({a, ...rest}) => rest.hasOwnProperty("k")) — method call on rest with args (#1532 review)', () => {
+      const result = parseExpression('items().filter(({a, ...rest}) => rest.hasOwnProperty("k"))')
+      expect(result.kind).toBe('call')
+    })
+
     // Computed rest access with a literal key still refuses (#1532):
     // the residual-object accessor doesn't exist in template syntax,
     // and rewriting `rest[0]` to `_t[0]` would silently include the

--- a/packages/jsx/src/__tests__/unsupported-expression.test.ts
+++ b/packages/jsx/src/__tests__/unsupported-expression.test.ts
@@ -392,4 +392,165 @@ describe('Rest Pattern in Filter Predicate (BF021, #1532)', () => {
     expect(bf021[0].message).toContain('Block body')
     expect(bf021[0].message).toContain('@client')
   })
+
+  // Method-call refusal end-to-end (#1532 review). Parser-level
+  // tests pin `rest.foo()` → `call`, but the IR-layer wiring needs
+  // its own coverage to confirm the reason string propagates from
+  // `validateRestUsage` through `extractFilterPredicate` to the
+  // BF021 diagnostic with the dedicated `'this' receiver` wording.
+  test('emits BF021 for method call on rest binding', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function TodoList() {
+        const [items, setItems] = createSignal<any[]>([])
+        return (
+          <ul>
+            {items().filter(({ a, ...rest }) => rest.foo()).map(t => (
+              <li>{t.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const { errors } = compileToIR(source)
+    const bf021 = errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+    expect(bf021).toHaveLength(1)
+    expect(bf021[0].message).toContain("Method call 'rest.foo()'")
+    expect(bf021[0].message).toContain("'this' receiver")
+    expect(bf021[0].message).toContain('@client')
+  })
+
+  // Computed rest access end-to-end (#1532 review). `rest[0]` is
+  // refused at parser as a value-use; pin BF021 fires at the IR
+  // layer with the rest-binding name.
+  test('emits BF021 for computed rest access', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function TodoList() {
+        const [items, setItems] = createSignal<any[]>([])
+        return (
+          <ul>
+            {items().filter(({ a, ...rest }) => rest[0]).map(t => (
+              <li>{t.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const { errors } = compileToIR(source)
+    const bf021 = errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+    expect(bf021).toHaveLength(1)
+    expect(bf021[0].message).toContain("'rest'")
+  })
+
+  // Renamed-key collision end-to-end (#1532 review). The parser-level
+  // test pins `{done: d, ...rest}` → `call`; pin the IR-layer BF021
+  // surface and the source-key wording (the message phrases the
+  // diagnostic in terms of the SOURCE key 'done', not the local
+  // rename 'd').
+  test('emits BF021 for renamed-key collision (rest.done after {done: d})', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function TodoList() {
+        const [items, setItems] = createSignal<any[]>([])
+        return (
+          <ul>
+            {items().filter(({ done: d, ...rest }) => rest.done).map(t => (
+              <li>{t.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const { errors } = compileToIR(source)
+    const bf021 = errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+    expect(bf021).toHaveLength(1)
+    expect(bf021[0].message).toContain("'rest.done'")
+    expect(bf021[0].message).toContain('source key')
+  })
+
+  // Nested-pattern outer-key collision end-to-end (#1532 review).
+  // The outer `user` key is consumed by the nested pattern; the
+  // collision message must still fire even though there's no local
+  // binding for `user` in user code.
+  test('emits BF021 for nested-pattern outer-key collision (rest.user after {user: {name}})', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function TodoList() {
+        const [items, setItems] = createSignal<any[]>([])
+        return (
+          <ul>
+            {items().filter(({ user: { name }, ...rest }) => rest.user).map(t => (
+              <li>{t.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const { errors } = compileToIR(source)
+    const bf021 = errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+    expect(bf021).toHaveLength(1)
+    expect(bf021[0].message).toContain("'rest.user'")
+  })
+
+  // `@client` suppresses the collision and method-call refusal
+  // categories too — not just the bare value-use Mode B (#1532
+  // review). Pin one case per refusal kind so a future tweak to
+  // the `isClientOnly` gate can't silently start emitting BF021
+  // for one path while suppressing another.
+  test('@client suppresses BF021 for collision', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function TodoList() {
+        const [items, setItems] = createSignal<any[]>([])
+        return (
+          <ul>
+            {/* @client */ items().filter(({ done, ...rest }) => rest.done).map(t => (
+              <li>{t.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const { errors } = compileToIR(source)
+    const bf021 = errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+    expect(bf021).toHaveLength(0)
+  })
+
+  test('@client suppresses BF021 for method call on rest', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function TodoList() {
+        const [items, setItems] = createSignal<any[]>([])
+        return (
+          <ul>
+            {/* @client */ items().filter(({ a, ...rest }) => rest.foo()).map(t => (
+              <li>{t.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const { errors } = compileToIR(source)
+    const bf021 = errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+    expect(bf021).toHaveLength(0)
+  })
 })

--- a/packages/jsx/src/__tests__/unsupported-expression.test.ts
+++ b/packages/jsx/src/__tests__/unsupported-expression.test.ts
@@ -362,4 +362,34 @@ describe('Rest Pattern in Filter Predicate (BF021, #1532)', () => {
     const bf021 = errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
     expect(bf021).toHaveLength(0)
   })
+
+  // Block body + destructured param (#1532 review). Neither
+  // `parseBlockBody` (block-body lowering) nor `parseExpression`
+  // (expression-body destructure rewrite) cover this shape, so
+  // without an explicit refusal the chain would slip through to a
+  // later adapter-level BF101. Surface BF021 at the IR layer with
+  // the `@client` workaround.
+  test('emits BF021 for block-body arrow with destructured param', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function TodoList() {
+        const [items, setItems] = createSignal<any[]>([])
+        return (
+          <ul>
+            {items().filter(({ done, ...rest }) => { return done }).map(t => (
+              <li>{t.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const { errors } = compileToIR(source)
+    const bf021 = errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+    expect(bf021).toHaveLength(1)
+    expect(bf021[0].message).toContain('Block body')
+    expect(bf021[0].message).toContain('@client')
+  })
 })

--- a/packages/jsx/src/__tests__/unsupported-expression.test.ts
+++ b/packages/jsx/src/__tests__/unsupported-expression.test.ts
@@ -237,3 +237,129 @@ describe('Unsupported Sort Comparator (BF021)', () => {
     expect(bf021).toHaveLength(0)
   })
 })
+
+// Rest-pattern destructure in filter predicates (#1532). Mode A
+// (`rest.X` member access) rewrites to `_t.X` and compiles cleanly;
+// Mode B (rest as a value) surfaces BF021 with the rest binding
+// name and the `@client` workaround. These tests pin the full
+// pipeline: parser → IR → ctx.errors → BF021 code + message shape.
+describe('Rest Pattern in Filter Predicate (BF021, #1532)', () => {
+  test('no BF021 for Mode A — `rest.X` member access lowers cleanly', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function TodoList() {
+        const [items, setItems] = createSignal<any[]>([])
+        return (
+          <ul>
+            {items().filter(({ done, ...rest }) => done && rest.priority > 0).map(t => (
+              <li>{t.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const { errors } = compileToIR(source)
+    const bf021 = errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+    expect(bf021).toHaveLength(0)
+  })
+
+  test('emits BF021 for Mode B — rest passed to call (`Object.keys(rest)`)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function TodoList() {
+        const [items, setItems] = createSignal<any[]>([])
+        return (
+          <ul>
+            {items().filter(({ done, ...rest }) => Object.keys(rest).length > 0).map(t => (
+              <li>{t.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const { errors } = compileToIR(source)
+    const bf021 = errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+    expect(bf021).toHaveLength(1)
+    // Reason carries the rest binding name + the `@client` workaround
+    // (the suggestion is attached separately on the error).
+    expect(bf021[0].message).toContain("'rest'")
+    expect(bf021[0].message).toContain('@client')
+    expect(bf021[0].suggestion?.message).toContain('@client')
+  })
+
+  test('emits BF021 for Mode B — `rest` as bare return value', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function TodoList() {
+        const [items, setItems] = createSignal<any[]>([])
+        return (
+          <ul>
+            {items().filter(({ done, ...rest }) => rest).map(t => (
+              <li>{t.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const { errors } = compileToIR(source)
+    const bf021 = errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+    expect(bf021).toHaveLength(1)
+    expect(bf021[0].message).toContain("'rest'")
+  })
+
+  test('emits BF021 with collision message when `rest.X` shadows a declared key', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function TodoList() {
+        const [items, setItems] = createSignal<any[]>([])
+        return (
+          <ul>
+            {items().filter(({ done, ...rest }) => rest.done).map(t => (
+              <li>{t.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const { errors } = compileToIR(source)
+    const bf021 = errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+    expect(bf021).toHaveLength(1)
+    // Reason carries both the rest binding and the shadowed key.
+    expect(bf021[0].message).toContain("'rest.done'")
+    expect(bf021[0].message).toContain("'done'")
+  })
+
+  test('@client suppresses BF021 for Mode B rest usage', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function TodoList() {
+        const [items, setItems] = createSignal<any[]>([])
+        return (
+          <ul>
+            {/* @client */ items().filter(({ done, ...rest }) => Object.keys(rest).length > 0).map(t => (
+              <li>{t.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const { errors } = compileToIR(source)
+    const bf021 = errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+    expect(bf021).toHaveLength(0)
+  })
+})

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -529,13 +529,16 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
 
     // Destructured-object param: `({done}) => done` (#1443),
     // `({user: {name}}) => name` (#1530), `({done = false}) => done`
-    // (#1531). We synthesise the equivalent dotted-access form so
-    // adapters can reuse their existing higher-order paths instead of
-    // needing a residual-object-accessor pipeline (#1384 territory).
-    // Nested destructure recurses into the inner pattern and threads
-    // a dotted path; leaf defaults fold into the rewrite as
-    // `(_t.field ?? <default>)`. Rest patterns, array binding
-    // patterns, and defaults at non-leaf (nested-pattern) slots
+    // (#1531), `({done, ...rest}) => rest.priority` (#1532). We
+    // synthesise the equivalent dotted-access form so adapters can
+    // reuse their existing higher-order paths instead of needing a
+    // residual-object-accessor pipeline (#1384 territory). Nested
+    // destructure recurses into the inner pattern and threads a
+    // dotted path; leaf defaults fold into the rewrite as
+    // `(_t.field ?? <default>)`. Top-level rest is rewritten when
+    // every reference is `restName.X` member access; value-use
+    // shapes refuse with BF021 (#1532). Array binding patterns,
+    // nested rest, and defaults at non-leaf (nested-pattern) slots
     // stay unsupported.
     if (ts.isObjectBindingPattern(param.name)) {
       const fieldMap = new Map<string, DestructureBinding>()
@@ -543,6 +546,7 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
       if (!collect.ok) {
         return { kind: 'unsupported', raw, reason: collect.reason }
       }
+      const restName = collect.restName
       // Post-validate defaults (#1536 review). The rewrite inlines the
       // default at every reference site (`x` → `_t.x ?? <default>`), so
       // two shapes that JS would handle differently both produce
@@ -585,8 +589,23 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
           }
         }
       }
+      // Post-validate rest usage (#1532). Mode A — `restName.X` member
+      // access — rewrites to `_t.X` because the residual object only
+      // omits the explicitly-bound keys, and `_t.X` for any `X` not in
+      // `fieldMap` returns the same value as `restName.X` would. Any
+      // other use of `restName` (call arg, return value, comparison
+      // operand, computed key) can't be lowered to template syntax —
+      // refuse with BF021 so the user can fall back to `/* @client */`.
+      // Also catches `restName.X` where `X` is a declared field — that
+      // shape is always `undefined` per JS spec and is a user bug.
+      if (restName !== undefined) {
+        const check = validateRestUsage(body, restName, fieldMap)
+        if (!check.ok) {
+          return { kind: 'unsupported', raw, reason: check.reason }
+        }
+      }
       const syntheticParam = pickSyntheticParam(fieldMap, body)
-      const rewritten = substituteDestructuredFields(body, fieldMap, syntheticParam)
+      const rewritten = substituteDestructuredFields(body, fieldMap, syntheticParam, restName)
       return { kind: 'arrow-fn', param: syntheticParam, body: rewritten }
     }
 
@@ -818,13 +837,30 @@ function collectDestructureBindings(
   pathPrefix: readonly string[],
   fieldMap: Map<string, DestructureBinding>,
   raw: string,
-): { ok: true } | { ok: false; reason: string } {
+): { ok: true; restName?: string } | { ok: false; reason: string } {
+  let restName: string | undefined
   for (const el of pattern.elements) {
     if (!ts.isBindingElement(el)) {
       return { ok: false, reason: 'Unsupported binding element in destructured filter param' }
     }
     if (el.dotDotDotToken) {
-      return { ok: false, reason: 'Rest patterns in destructured filter param are not supported' }
+      // Top-level rest pattern (#1532) is supported when every
+      // reference to the rest binding is a `restName.X` member access
+      // — that's safe to rewrite to `_t.X`, because the residual
+      // object only omits explicitly-bound keys, and any `X` not
+      // declared in the destructure has the same value via `_t.X` or
+      // `restName.X`. Other shapes (value use, computed key) refuse
+      // at the post-collection validation step. Nested rest
+      // (`pathPrefix.length > 0`) stays refused — we have no
+      // "residual object at nested key" accessor for templates.
+      if (pathPrefix.length > 0) {
+        return { ok: false, reason: 'Rest patterns at nested destructure levels are not supported' }
+      }
+      if (!ts.isIdentifier(el.name)) {
+        return { ok: false, reason: 'Rest patterns must bind to a simple identifier' }
+      }
+      restName = el.name.text
+      continue
     }
     if (ts.isObjectBindingPattern(el.name)) {
       // Nested object pattern: `{ user: { name } }`. The outer slot
@@ -898,7 +934,7 @@ function collectDestructureBindings(
     }
     fieldMap.set(el.name.text, { path: [...pathPrefix, fieldName], defaultExpr })
   }
-  return { ok: true }
+  return { ok: true, restName }
 }
 
 /**
@@ -959,6 +995,121 @@ function findImpureDefaultNode(expr: ParsedExpr): string | null {
     case 'arrow-fn':
       return expr.kind
   }
+}
+
+/**
+ * Walk the predicate body and classify every reference to the
+ * top-level rest binding (#1532). Two outcomes route to BF021 via
+ * the caller's `unsupported` return path:
+ *
+ *  - Value-use of `restName` in any position other than a static
+ *    member-access object (`fn(rest)`, `Object.keys(rest)`, bare
+ *    `return rest`, `rest in obj`, computed `rest[k]`, etc.).
+ *    These shapes need a residual-object value, which Go's template
+ *    runtime has no primitive for at predicate scope.
+ *
+ *  - `restName.X` where `X` is also a declared field in `fieldMap`.
+ *    Per JS spec the rest binding excludes the explicitly-named
+ *    keys, so the read is statically always `undefined` — flag the
+ *    user bug rather than silently rewrite to `_t.X` (which WOULD
+ *    return the value, masking the mistake).
+ *
+ * The walker recurses into nested arrow / higher-order bodies on
+ * purpose: lexical capture means an inner arrow that references
+ * the outer `restName` is still a use of the same binding, and
+ * `substituteDestructuredFields` does NOT recurse through arrows.
+ * Refusing here keeps the substitution path total — every retained
+ * rest reference is a top-level `restName.X` that the substitution
+ * step rewrites correctly. If a future inner-arrow shadowing model
+ * lands, this can relax to track shadowing scopes.
+ */
+function validateRestUsage(
+  expr: ParsedExpr,
+  restName: string,
+  fieldMap: Map<string, DestructureBinding>,
+): { ok: true } | { ok: false; reason: string } {
+  let valueUse = false
+  let collision: string | null = null
+
+  const walk = (e: ParsedExpr): void => {
+    if (valueUse || collision !== null) return
+    switch (e.kind) {
+      case 'identifier':
+        if (e.name === restName) valueUse = true
+        return
+      case 'member':
+        // Static `restName.X` is the only shape we can lower.
+        // Computed `restName[k]` needs runtime evaluation of `k`
+        // against the residual object — refuse as value-use.
+        if (e.object.kind === 'identifier' && e.object.name === restName) {
+          if (e.computed) {
+            valueUse = true
+            return
+          }
+          if (fieldMap.has(e.property)) {
+            collision = e.property
+          }
+          return
+        }
+        walk(e.object)
+        return
+      case 'call':
+        walk(e.callee)
+        for (const a of e.args) walk(a)
+        return
+      case 'binary':
+      case 'logical':
+        walk(e.left)
+        walk(e.right)
+        return
+      case 'unary':
+        walk(e.argument)
+        return
+      case 'conditional':
+        walk(e.test)
+        walk(e.consequent)
+        walk(e.alternate)
+        return
+      case 'template-literal':
+        for (const part of e.parts) {
+          if (part.type === 'expression') walk(part.expr)
+        }
+        return
+      case 'arrow-fn':
+        walk(e.body)
+        return
+      case 'higher-order':
+        walk(e.object)
+        walk(e.predicate)
+        return
+      case 'array-literal':
+        for (const el of e.elements) walk(el)
+        return
+      case 'array-method':
+        walk(e.object)
+        for (const a of e.args) walk(a)
+        return
+      case 'literal':
+      case 'unsupported':
+        return
+    }
+  }
+
+  walk(expr)
+
+  if (collision !== null) {
+    return {
+      ok: false,
+      reason: `Rest binding '${restName}.${collision}' shadows a declared key '${collision}' and is statically undefined. Workaround: reference the declared binding '${collision}' directly, or remove '${collision}' from the destructure.`,
+    }
+  }
+  if (valueUse) {
+    return {
+      ok: false,
+      reason: `Rest binding '${restName}' cannot be passed as a value to a template-compiled predicate (only '${restName}.<key>' member access is supported). Workaround: add /* @client */ to evaluate the predicate on the client, or rewrite to reference individual destructured fields.`,
+    }
+  }
+  return { ok: true }
 }
 
 /**
@@ -1048,11 +1199,18 @@ function collectIdentifiers(expr: ParsedExpr, out: Set<string>): void {
  * into the equivalent dotted-access form against a synthetic param
  * (`_t.done`). Identifiers not in `fieldMap` are left alone — they're
  * either closure captures (signals, props) or already-synthetic names.
+ *
+ * When `restName` is set, `restName.X` member access is rewritten to
+ * `syntheticParam.X` (#1532). The caller has already validated that
+ * every reference to `restName` in the body is a static
+ * `restName.X` shape and `X` does not collide with `fieldMap`, so
+ * this walk just rewires the object position.
  */
 function substituteDestructuredFields(
   expr: ParsedExpr,
   fieldMap: Map<string, DestructureBinding>,
   syntheticParam: string,
+  restName?: string,
 ): ParsedExpr {
   const walk = (e: ParsedExpr): ParsedExpr => {
     switch (e.kind) {
@@ -1078,6 +1236,19 @@ function substituteDestructuredFields(
       case 'call':
         return { kind: 'call', callee: walk(e.callee), args: e.args.map(walk) }
       case 'member':
+        if (
+          restName !== undefined &&
+          e.object.kind === 'identifier' &&
+          e.object.name === restName &&
+          !e.computed
+        ) {
+          return {
+            kind: 'member',
+            object: { kind: 'identifier', name: syntheticParam },
+            property: e.property,
+            computed: false,
+          }
+        }
         return { kind: 'member', object: walk(e.object), property: e.property, computed: e.computed }
       case 'binary':
         return { kind: 'binary', op: e.op, left: walk(e.left), right: walk(e.right) }

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -542,7 +542,14 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
     // stay unsupported.
     if (ts.isObjectBindingPattern(param.name)) {
       const fieldMap = new Map<string, DestructureBinding>()
-      const collect = collectDestructureBindings(param.name, [], fieldMap, raw)
+      // `excludedTopKeys` mirrors the JS rest-binding exclusion set:
+      // the source-object keys explicitly consumed at the top level
+      // (#1532 review). Used by `validateRestUsage` for the
+      // `rest.X is always undefined` collision check — `fieldMap`
+      // keys on local rename / leaf names and would miss
+      // `({done: d, ...rest}) => rest.done` or `({user: {name}, ...rest}) => rest.user`.
+      const excludedTopKeys = new Set<string>()
+      const collect = collectDestructureBindings(param.name, [], fieldMap, raw, excludedTopKeys)
       if (!collect.ok) {
         return { kind: 'unsupported', raw, reason: collect.reason }
       }
@@ -599,7 +606,7 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
       // Also catches `restName.X` where `X` is a declared field — that
       // shape is always `undefined` per JS spec and is a user bug.
       if (restName !== undefined) {
-        const check = validateRestUsage(body, restName, fieldMap)
+        const check = validateRestUsage(body, restName, excludedTopKeys)
         if (!check.ok) {
           return { kind: 'unsupported', raw, reason: check.reason }
         }
@@ -837,6 +844,7 @@ function collectDestructureBindings(
   pathPrefix: readonly string[],
   fieldMap: Map<string, DestructureBinding>,
   raw: string,
+  excludedTopKeys?: Set<string>,
 ): { ok: true; restName?: string } | { ok: false; reason: string } {
   let restName: string | undefined
   for (const el of pattern.elements) {
@@ -884,11 +892,22 @@ function collectDestructureBindings(
       if (!el.propertyName || !ts.isIdentifier(el.propertyName)) {
         return { ok: false, reason: 'Non-identifier (computed/string/numeric) keys in destructured filter param are not supported' }
       }
+      // Track the outer key the nested pattern consumed at this level.
+      // It never becomes a local binding (only the nested leaves do),
+      // but a top-level rest binding still excludes it (#1532 review):
+      // `({ user: { name }, ...rest }) => rest.user` is statically
+      // undefined per JS spec, and was previously silently rewritten
+      // to `_t.user`. The collision check needs the property name set,
+      // not the local-binding `fieldMap` keys.
+      if (excludedTopKeys && pathPrefix.length === 0) {
+        excludedTopKeys.add(el.propertyName.text)
+      }
       const inner = collectDestructureBindings(
         el.name,
         [...pathPrefix, el.propertyName.text],
         fieldMap,
         raw,
+        excludedTopKeys,
       )
       if (!inner.ok) return inner
       continue
@@ -933,6 +952,14 @@ function collectDestructureBindings(
       defaultExpr = parsed
     }
     fieldMap.set(el.name.text, { path: [...pathPrefix, fieldName], defaultExpr })
+    // Top-level leaf: record the consumed source-object key, NOT the
+    // local binding name. `({done: d, ...rest}) => rest.done` is the
+    // canonical miss for `fieldMap.has(...)` collision detection —
+    // `fieldMap` keys on local rename `d`, but JS rest excludes the
+    // source key `done` (#1532 review).
+    if (excludedTopKeys && pathPrefix.length === 0) {
+      excludedTopKeys.add(fieldName)
+    }
   }
   return { ok: true, restName }
 }
@@ -1008,25 +1035,29 @@ function findImpureDefaultNode(expr: ParsedExpr): string | null {
  *    These shapes need a residual-object value, which Go's template
  *    runtime has no primitive for at predicate scope.
  *
- *  - `restName.X` where `X` is also a declared field in `fieldMap`.
- *    Per JS spec the rest binding excludes the explicitly-named
- *    keys, so the read is statically always `undefined` — flag the
- *    user bug rather than silently rewrite to `_t.X` (which WOULD
- *    return the value, masking the mistake).
+ *  - `restName.X` where `X` is a top-level key the destructure
+ *    explicitly consumed (`excludedTopKeys`). Per JS spec the rest
+ *    binding excludes those keys, so the read is statically always
+ *    `undefined` — flag the user bug rather than silently rewrite
+ *    to `_t.X` (which WOULD return the value, masking the mistake).
+ *    `excludedTopKeys` carries source-object property names, not
+ *    local binding names — so renamed (`{done: d}`) and
+ *    nested-pattern (`{user: {name}}`) outer keys are caught
+ *    alongside plain shorthand (`{done}`) (#1532 review).
  *
- * The walker recurses into nested arrow / higher-order bodies on
- * purpose: lexical capture means an inner arrow that references
- * the outer `restName` is still a use of the same binding, and
- * `substituteDestructuredFields` does NOT recurse through arrows.
- * Refusing here keeps the substitution path total — every retained
- * rest reference is a top-level `restName.X` that the substitution
- * step rewrites correctly. If a future inner-arrow shadowing model
- * lands, this can relax to track shadowing scopes.
+ * Recurses into nested arrow / higher-order bodies (lexical capture
+ * still uses the outer `restName`), but short-circuits when an
+ * inner callback's param shadows `restName` — the inner reference
+ * is then a different binding, and walking it would emit a
+ * spurious BF021 (#1532 review). `substituteDestructuredFields`
+ * does NOT recurse through arrows, so the validator's "refuse all
+ * remaining rest references in arrow bodies" stance keeps the
+ * substitution path total.
  */
 function validateRestUsage(
   expr: ParsedExpr,
   restName: string,
-  fieldMap: Map<string, DestructureBinding>,
+  excludedTopKeys: Set<string>,
 ): { ok: true } | { ok: false; reason: string } {
   let valueUse = false
   let collision: string | null = null
@@ -1046,7 +1077,7 @@ function validateRestUsage(
             valueUse = true
             return
           }
-          if (fieldMap.has(e.property)) {
+          if (excludedTopKeys.has(e.property)) {
             collision = e.property
           }
           return
@@ -1076,11 +1107,17 @@ function validateRestUsage(
         }
         return
       case 'arrow-fn':
+        // Inner arrow that re-uses `restName` as its own parameter
+        // shadows the outer rest binding — references inside its
+        // body belong to the inner param, not us (#1532 review).
+        if (e.param === restName) return
         walk(e.body)
         return
       case 'higher-order':
         walk(e.object)
-        walk(e.predicate)
+        // The predicate is the inner-callback body; its `param`
+        // shadows the outer rest binding when names match.
+        if (e.param !== restName) walk(e.predicate)
         return
       case 'array-literal':
         for (const el of e.elements) walk(el)

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -1135,9 +1135,15 @@ function validateRestUsage(
   walk(expr)
 
   if (collision !== null) {
+    // Phrase the diagnostic in terms of the SOURCE key being consumed
+    // by the destructure, not a local binding name. `{ done: d, ...rest }`
+    // and `{ user: {name}, ...rest }` both consume a top-level key
+    // (`done` / `user`) that has no local identifier in user code —
+    // suggesting "reference '<key>' directly" would point at an
+    // undefined identifier (#1532 review).
     return {
       ok: false,
-      reason: `Rest binding '${restName}.${collision}' shadows a declared key '${collision}' and is statically undefined. Workaround: reference the declared binding '${collision}' directly, or remove '${collision}' from the destructure.`,
+      reason: `Rest binding '${restName}.${collision}' reads source key '${collision}' which the destructure already consumed, so the value is statically excluded from '${restName}' and is always undefined. Workaround: read '${collision}' from the iterated item directly (via its destructured binding or by adding it to the destructure), or remove '${collision}' from the destructure so the rest binding includes it.`,
     }
   }
   if (valueUse) {

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -1061,9 +1061,10 @@ function validateRestUsage(
 ): { ok: true } | { ok: false; reason: string } {
   let valueUse = false
   let collision: string | null = null
+  let methodCall: string | null = null
 
   const walk = (e: ParsedExpr): void => {
-    if (valueUse || collision !== null) return
+    if (valueUse || collision !== null || methodCall !== null) return
     switch (e.kind) {
       case 'identifier':
         if (e.name === restName) valueUse = true
@@ -1085,6 +1086,22 @@ function validateRestUsage(
         walk(e.object)
         return
       case 'call':
+        // `restName.foo(...)` method call — the substitution rewrites
+        // `restName.foo` to `_t.foo`, but JS evaluates the call with
+        // `this` bound to the member receiver (`restName` vs `_t`),
+        // and the residual object also excludes consumed keys. So
+        // the lowering would change observable semantics in two
+        // independent ways. Refuse with a dedicated message rather
+        // than silently rewriting (#1532 review).
+        if (
+          e.callee.kind === 'member' &&
+          !e.callee.computed &&
+          e.callee.object.kind === 'identifier' &&
+          e.callee.object.name === restName
+        ) {
+          methodCall = e.callee.property
+          return
+        }
         walk(e.callee)
         for (const a of e.args) walk(a)
         return
@@ -1144,6 +1161,12 @@ function validateRestUsage(
     return {
       ok: false,
       reason: `Rest binding '${restName}.${collision}' reads source key '${collision}' which the destructure already consumed, so the value is statically excluded from '${restName}' and is always undefined. Workaround: read '${collision}' from the iterated item directly (via its destructured binding or by adding it to the destructure), or remove '${collision}' from the destructure so the rest binding includes it.`,
+    }
+  }
+  if (methodCall !== null) {
+    return {
+      ok: false,
+      reason: `Method call '${restName}.${methodCall}()' on a rest binding cannot be lowered — rewriting to '_t.${methodCall}()' would change the call's 'this' receiver (residual object → original item) and also bypass the rest binding's key exclusion. Workaround: bind the method's result to a closure variable outside the predicate, or add /* @client */ to evaluate the predicate on the client.`,
     }
   }
   if (valueUse) {

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1957,7 +1957,18 @@ function extractFilterPredicate(
   // accepts, leaving `result: null` with no reason preserves the
   // existing adapter raw-text lowering path.
   if (!ts.isIdentifier(firstParam.name)) {
-    if (ts.isBlock(callback.body)) return { result: null }
+    // Block body + destructured param: `parseBlockBody` doesn't carry
+    // the destructure rewrite and `parseExpression` only handles
+    // expression-body arrows. Surface BF021 so the user gets a
+    // deterministic pointer at the predicate + `/* @client */` escape
+    // instead of letting it slip through to a later BF101 (#1532 review).
+    if (ts.isBlock(callback.body)) {
+      return {
+        result: null,
+        unsupportedReason:
+          'Block body in a destructured filter param is not supported. Workaround: use an expression-body arrow, or add /* @client */.',
+      }
+    }
     const raw = ctx.getJS(callback)
     const parsed = parseExpression(raw)
     if (parsed.kind === 'unsupported') {

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1941,7 +1941,36 @@ function extractFilterPredicate(
   if (callback.parameters.length < 1) return { result: null }
 
   const firstParam = callback.parameters[0]
-  if (!ts.isIdentifier(firstParam.name)) return { result: null }
+
+  // Destructured filter param (#1443, #1530, #1531, #1532). Reconstruct
+  // the whole arrow source and route through `parseExpression` so the
+  // parser's destructure rewrite path runs end-to-end: synthesised
+  // `_t` param, body rewritten to `_t.field` (with `??` defaults and
+  // rest member-access rewrites). Refusal reasons from the parser —
+  // including #1532 Mode B (`rest` as value) and the rest/declared-key
+  // collision — surface here as `unsupportedReason`, which the caller
+  // turns into BF021.
+  if (!ts.isIdentifier(firstParam.name)) {
+    if (ts.isBlock(callback.body)) {
+      return {
+        result: null,
+        unsupportedReason:
+          'Block body in a destructured filter param is not supported. Workaround: use an expression-body arrow, or add /* @client */.',
+      }
+    }
+    const raw = ctx.getJS(callback)
+    const parsed = parseExpression(raw)
+    if (parsed.kind === 'unsupported') {
+      return { result: null, unsupportedReason: parsed.reason }
+    }
+    if (parsed.kind !== 'arrow-fn') return { result: null }
+    const support = isSupported(parsed.body)
+    if (!support.supported) {
+      return { result: null, unsupportedReason: support.reason }
+    }
+    const bodyRaw = ctx.getJS(callback.body)
+    return { result: { param: parsed.param, predicate: parsed.body, raw: bodyRaw } }
+  }
 
   const param = firstParam.name.getText(ctx.sourceFile)
 

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1942,34 +1942,34 @@ function extractFilterPredicate(
 
   const firstParam = callback.parameters[0]
 
-  // Destructured filter param (#1443, #1530, #1531, #1532). Reconstruct
-  // the whole arrow source and route through `parseExpression` so the
-  // parser's destructure rewrite path runs end-to-end: synthesised
-  // `_t` param, body rewritten to `_t.field` (with `??` defaults and
-  // rest member-access rewrites). Refusal reasons from the parser —
-  // including #1532 Mode B (`rest` as value) and the rest/declared-key
-  // collision — surface here as `unsupportedReason`, which the caller
-  // turns into BF021.
+  // Destructured filter param (#1443, #1530, #1531, #1532).
+  // `extractFilterPredicate` itself doesn't carry destructure rewrites
+  // — those run inside the adapter's `parseExpression` pass over the
+  // raw array text (the surrounding `setArray(mapSource)` keeps the
+  // whole `items().filter(({a, ...rest}) => …)` chain in the array
+  // string, and the adapter's higher-order path lowers it the same
+  // way it would for a hand-written `(_t) => _t.a` shape).
+  //
+  // Validate-only here so refusal reasons from the parser — including
+  // the #1532 Mode B "rest as value" path and the rest/declared-key
+  // collision — surface as `unsupportedReason`. The caller turns that
+  // into BF021 (with the `@client` workaround); for shapes the parser
+  // accepts, leaving `result: null` with no reason preserves the
+  // existing adapter raw-text lowering path.
   if (!ts.isIdentifier(firstParam.name)) {
-    if (ts.isBlock(callback.body)) {
-      return {
-        result: null,
-        unsupportedReason:
-          'Block body in a destructured filter param is not supported. Workaround: use an expression-body arrow, or add /* @client */.',
-      }
-    }
+    if (ts.isBlock(callback.body)) return { result: null }
     const raw = ctx.getJS(callback)
     const parsed = parseExpression(raw)
     if (parsed.kind === 'unsupported') {
       return { result: null, unsupportedReason: parsed.reason }
     }
-    if (parsed.kind !== 'arrow-fn') return { result: null }
-    const support = isSupported(parsed.body)
-    if (!support.supported) {
-      return { result: null, unsupportedReason: support.reason }
+    if (parsed.kind === 'arrow-fn') {
+      const support = isSupported(parsed.body)
+      if (!support.supported) {
+        return { result: null, unsupportedReason: support.reason }
+      }
     }
-    const bodyRaw = ctx.getJS(callback.body)
-    return { result: { param: parsed.param, predicate: parsed.body, raw: bodyRaw } }
+    return { result: null }
   }
 
   const param = firstParam.name.getText(ctx.sourceFile)


### PR DESCRIPTION
## Summary

Implements #1532 — narrow parser rewrite for `({done, ...rest}) => …` in `.filter()` / `.every()` / `.some()` / `.find()` / `.findIndex()` predicates, with a BF021 escape for shapes that can't lower.

### Mode A — `restName.X` member access rewrites to `_t.X`

```tsx
items.filter(({ done, ...rest }) => done && rest.priority > 0)
// → (_t) => _t.done && _t.priority > 0
```

Safe because the residual object only omits explicitly-bound keys; any `X` not in the destructure has the same value via `_t.X` or `restName.X`.

### Mode B — `restName` as a value refuses with BF021

```tsx
items.filter(({ done, ...rest }) => Object.keys(rest).length > 0)
// → BF021: Rest binding 'rest' cannot be passed as a value to a
//   template-compiled predicate (only 'rest.<key>' member access is
//   supported). Workaround: add /* @client */ …
```

Also flags `rest.X` where `X` is a declared field — JS spec excludes named keys from the residual object, so the read is statically `undefined` (programmer bug worth surfacing rather than silently rewriting).

### Wiring

`extractFilterPredicate` previously dropped any non-identifier filter param (`if (!ts.isIdentifier(firstParam.name)) return { result: null }`), so the parser-level destructure rewrite from #1530 / #1531 was never reaching `.filter().map()` chains. The IR layer now routes destructured callbacks through `parseExpression`, so all four issues (#1443 / #1530 / #1531 / #1532) lower end-to-end.

### Out of scope (refused with reasons)

- Nested rest (`{user: {name, ...rest}}`) — no path-aware residual accessor for templates.
- Computed rest access (`rest[k]`) — needs runtime key evaluation.
- Rest with block-body arrow — falls through to standard block-body refusal.

## Test plan

- [x] New parser unit tests in `expression-parser.test.ts`: Mode A single/multiple rest member access, cross-method (`.every`), `rest.X` collision with declared key, `Object.keys(rest)`, `fn(rest)`, bare `return rest`, computed `rest[0]`, nested rest.
- [x] New IR/BF021 tests in `unsupported-expression.test.ts`: Mode A no-error, Mode B BF021 with rest-binding name + `@client` workaround, collision message, `/* @client */` suppression.
- [x] Existing #1530 / #1531 destructure tests still pass.
- [x] Full `packages/jsx` test suite passes (pre-existing failures in `primitive-resolver-*.test.ts` are unrelated and reproduce on `main`).
- [x] `packages/adapter-tests` suite passes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvEGAjkA13gP4BFVdDHiJY)_