### PR TITLE
audit: stocktake of reserved-but-unimplemented error codes

### DIFF
--- a/docs/core/advanced/error-codes.md
+++ b/docs/core/advanced/error-codes.md
@@ -46,18 +46,6 @@ import { createSignal } from '@barefootjs/client'
 export function Counter() { ... }
 ```
 
-### BF002 — Invalid Directive Position
-
-**Trigger:** `"use client"` not first statement.
-
-```tsx
-// ❌ BF002
-import { createSignal } from '@barefootjs/client'
-"use client"
-```
-
-**Fix:** Move to the first line (before imports).
-
 ### BF003 — Client Component Importing Server Component
 
 **Trigger:** Client component imports from a file without `"use client"`.
@@ -300,7 +288,6 @@ function Component({ checked }: Props) {
 | Code | Severity | Description |
 |------|----------|-------------|
 | BF001 | Error | Missing `"use client"` directive |
-| BF002 | Error | Invalid directive position |
 | BF003 | Error | Client component importing server component |
 | BF010 | Error | Unknown signal reference |
 | BF011 | Error | Signal used outside component |

--- a/packages/jsx/src/__tests__/bf002-directive-position.test.ts
+++ b/packages/jsx/src/__tests__/bf002-directive-position.test.ts
@@ -1,0 +1,139 @@
+/**
+ * BF002 — INVALID_DIRECTIVE_POSITION audit.
+ *
+ * The error code is defined in `errors.ts` but never emitted. The analyzer's
+ * `'use client'` detector (analyzer.ts:328) matches a string-literal
+ * ExpressionStatement at *any* tree position — see the explicit comment at
+ * analyzer.ts:2862-2867 noting this is deliberate so BF003's cross-file
+ * client-detection stays consistent with the analyzer's own classification.
+ *
+ * These tests pin the observable consequences of that permissive detection
+ * so the BF002 keep / delete / implement decision can be made on evidence.
+ *
+ * Findings (May 2026):
+ *   - Top, after-import, after-statement placements: byte-identical output.
+ *   - Inside function body: same SSR template, but the literal string
+ *     leaks into the emitted client JS as a no-op expression statement.
+ *     Runtime behavior is correct; output contains a stray `'use client'`.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { analyzeComponent } from '../analyzer'
+import { compileJSX } from '../compiler'
+import { HonoAdapter } from '../../../../packages/adapter-hono/src/adapter/hono-adapter'
+
+const adapter = new HonoAdapter()
+
+const COUNTER_BODY = `export function Counter() {
+  const [n, setN] = createSignal(0)
+  return <button onClick={() => setN(n() + 1)}>{n()}</button>
+}
+`
+
+function compile(source: string) {
+  return compileJSX(source, 'Counter.tsx', { adapter })
+}
+
+function filesByPath(r: ReturnType<typeof compile>) {
+  return Object.fromEntries(r.files.map(f => [f.path, f.content]))
+}
+
+describe('BF002 audit — `use client` directive position', () => {
+  test('control: directive at top is recognized as client', () => {
+    const source = `'use client'
+import { createSignal } from '@barefootjs/client'
+
+${COUNTER_BODY}`
+    const ctx = analyzeComponent(source, '/tmp/counter.tsx', 'Counter')
+    expect(ctx.hasUseClientDirective).toBe(true)
+    expect(ctx.errors.filter(e => e.severity === 'error')).toEqual([])
+  })
+
+  test('after import: detector still flips hasUseClientDirective; no BF002', () => {
+    const source = `import { createSignal } from '@barefootjs/client'
+'use client'
+
+${COUNTER_BODY}`
+    const ctx = analyzeComponent(source, '/tmp/counter.tsx', 'Counter')
+    expect(ctx.hasUseClientDirective).toBe(true)
+    expect(ctx.errors.filter(e => e.code === 'BF002')).toEqual([])
+  })
+
+  test('after a non-import statement: detector still flips', () => {
+    const source = `const X = 1
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+${COUNTER_BODY}`
+    const ctx = analyzeComponent(source, '/tmp/counter.tsx', 'Counter')
+    expect(ctx.hasUseClientDirective).toBe(true)
+  })
+
+  test('inside function body: detector matches (most permissive case)', () => {
+    const source = `import { createSignal } from '@barefootjs/client'
+
+export function Counter() {
+  'use client'
+  const [n, setN] = createSignal(0)
+  return <button onClick={() => setN(n() + 1)}>{n()}</button>
+}
+`
+    const ctx = analyzeComponent(source, '/tmp/counter.tsx', 'Counter')
+    // Deliberate snapshot of the surprising behavior. A directive nested
+    // inside a function body has no spec meaning, yet flips the file flag
+    // and suppresses BF001 — which masks the misplacement.
+    expect(ctx.hasUseClientDirective).toBe(true)
+    expect(ctx.errors.filter(e => e.code === 'BF001')).toEqual([])
+  })
+
+  test('after-import placement produces output byte-identical to top placement', () => {
+    const top = `'use client'
+import { createSignal } from '@barefootjs/client'
+
+${COUNTER_BODY}`
+    const misplaced = `import { createSignal } from '@barefootjs/client'
+'use client'
+
+${COUNTER_BODY}`
+    const r1 = compile(top)
+    const r2 = compile(misplaced)
+    expect(r1.errors).toEqual([])
+    expect(r2.errors).toEqual([])
+    expect(filesByPath(r2)).toEqual(filesByPath(r1))
+  })
+
+  test('in-function-body placement leaks the literal into emitted client JS', () => {
+    const top = `'use client'
+import { createSignal } from '@barefootjs/client'
+
+${COUNTER_BODY}`
+    const inBody = `import { createSignal } from '@barefootjs/client'
+
+export function Counter() {
+  'use client'
+  const [n, setN] = createSignal(0)
+  return <button onClick={() => setN(n() + 1)}>{n()}</button>
+}
+`
+    const r1 = compile(top)
+    const r2 = compile(inBody)
+    expect(r1.errors).toEqual([])
+    expect(r2.errors).toEqual([])
+    const f1 = filesByPath(r1)
+    const f2 = filesByPath(r2)
+    const clientPath = 'Counter.client.js'
+    // Top placement: directive does NOT appear in the emitted runtime body.
+    expect(f1[clientPath]).not.toContain("'use client'")
+    // In-body placement: directive survives as a no-op statement in the
+    // initCounter body — cosmetic, but a real output divergence.
+    expect(f2[clientPath]).toContain("'use client'")
+  })
+
+  test('no directive + reactive APIs: BF001 fires (sanity)', () => {
+    const source = `import { createSignal } from '@barefootjs/client'
+
+${COUNTER_BODY}`
+    const ctx = analyzeComponent(source, '/tmp/counter.tsx', 'Counter')
+    expect(ctx.errors.filter(e => e.code === 'BF001').length).toBeGreaterThan(0)
+  })
+})

--- a/packages/jsx/src/__tests__/bf003-client-import-server.test.ts
+++ b/packages/jsx/src/__tests__/bf003-client-import-server.test.ts
@@ -305,9 +305,9 @@ describe('BF003 — client importing server component', () => {
 
   test('accepts "use client" placed after a value declaration (analyzer semantics)', () => {
     // The analyzer itself treats any ExpressionStatement of `'use client'`
-    // as the directive (BF002 enforces top-of-file placement separately);
-    // BF003 must match that semantics or it would fire on files the
-    // analyzer would classify as client.
+    // as the directive — top-of-file placement is not enforced. BF003
+    // must match that semantics or it would fire on files the analyzer
+    // would classify as client.
     writeFixture('directive-after-import.tsx', `
       import type { ReactNode } from 'react'
       "use client"

--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -421,7 +421,7 @@ for (const page of PAGES) {
 // `test.skip` rather than removed, so the test corpus stays loud
 // about the doc/compiler drift:
 //
-//   - "Documented but unimplemented" (BF002, BF010, BF011, BF012,
+//   - "Documented but unimplemented" (BF010, BF011, BF012,
 //     BF020, BF022, BF025, BF030, BF031, BF040, BF041, BF042, BF045):
 //     `errors.ts` defines the constant + message but `grep ErrorCodes.X`
 //     across `packages/jsx/src/**` finds zero production emission
@@ -461,7 +461,6 @@ const ERROR_CODES_DOC_TOO_MINIMAL: Record<string, string> = {
 // and `__tests__/`. Documented for visibility; un-skipping requires
 // implementing the missing emission site.
 const ERROR_CODES_UNIMPLEMENTED: Record<string, string> = {
-  BF002: 'documented but no emission site in packages/jsx/src/** (see ErrorCodes.INVALID_DIRECTIVE_POSITION)',
   BF010: 'documented but no emission site (see ErrorCodes.UNKNOWN_SIGNAL)',
   BF011: 'documented but no emission site (see ErrorCodes.SIGNAL_OUTSIDE_COMPONENT)',
   BF012: 'documented but no emission site (see ErrorCodes.INVALID_SIGNAL_USAGE)',

--- a/packages/jsx/src/__tests__/use-client-directive-position.test.ts
+++ b/packages/jsx/src/__tests__/use-client-directive-position.test.ts
@@ -1,20 +1,20 @@
 /**
- * BF002 — INVALID_DIRECTIVE_POSITION audit.
+ * `'use client'` directive position — observable behavior.
  *
- * The error code is defined in `errors.ts` but never emitted. The analyzer's
- * `'use client'` detector (analyzer.ts:328) matches a string-literal
- * ExpressionStatement at *any* tree position — see the explicit comment at
- * analyzer.ts:2862-2867 noting this is deliberate so BF003's cross-file
- * client-detection stays consistent with the analyzer's own classification.
+ * The analyzer's directive detector (analyzer.ts:328) treats a
+ * `'use client'` string-literal ExpressionStatement at *any* tree
+ * position as the file-level directive. The comment at
+ * analyzer.ts:2862-2867 spells out why this is deliberate: BF003's
+ * cross-file client classification consults the same shape, so the
+ * detector here must match it exactly.
  *
- * These tests pin the observable consequences of that permissive detection
- * so the BF002 keep / delete / implement decision can be made on evidence.
- *
- * Findings (May 2026):
- *   - Top, after-import, after-statement placements: byte-identical output.
- *   - Inside function body: same SSR template, but the literal string
- *     leaks into the emitted client JS as a no-op expression statement.
- *     Runtime behavior is correct; output contains a stray `'use client'`.
+ * This test pins the consequences of that permissive detection.
+ * Findings:
+ *   - Top, after-import, after-statement placements: compile output
+ *     is byte-identical to a canonical top-of-file placement.
+ *   - In-function-body placement: same SSR template, but the literal
+ *     `'use client'` leaks into the emitted client JS as a no-op
+ *     expression statement. Runtime behavior is unaffected.
  */
 
 import { describe, test, expect } from 'bun:test'
@@ -38,8 +38,8 @@ function filesByPath(r: ReturnType<typeof compile>) {
   return Object.fromEntries(r.files.map(f => [f.path, f.content]))
 }
 
-describe('BF002 audit — `use client` directive position', () => {
-  test('control: directive at top is recognized as client', () => {
+describe('`use client` directive position', () => {
+  test('canonical top-of-file: directive recognized, no errors', () => {
     const source = `'use client'
 import { createSignal } from '@barefootjs/client'
 
@@ -49,14 +49,13 @@ ${COUNTER_BODY}`
     expect(ctx.errors.filter(e => e.severity === 'error')).toEqual([])
   })
 
-  test('after import: detector still flips hasUseClientDirective; no BF002', () => {
+  test('after import: detector still flips hasUseClientDirective', () => {
     const source = `import { createSignal } from '@barefootjs/client'
 'use client'
 
 ${COUNTER_BODY}`
     const ctx = analyzeComponent(source, '/tmp/counter.tsx', 'Counter')
     expect(ctx.hasUseClientDirective).toBe(true)
-    expect(ctx.errors.filter(e => e.code === 'BF002')).toEqual([])
   })
 
   test('after a non-import statement: detector still flips', () => {
@@ -69,7 +68,7 @@ ${COUNTER_BODY}`
     expect(ctx.hasUseClientDirective).toBe(true)
   })
 
-  test('inside function body: detector matches (most permissive case)', () => {
+  test('inside function body: detector matches and suppresses BF001', () => {
     const source = `import { createSignal } from '@barefootjs/client'
 
 export function Counter() {
@@ -79,14 +78,14 @@ export function Counter() {
 }
 `
     const ctx = analyzeComponent(source, '/tmp/counter.tsx', 'Counter')
-    // Deliberate snapshot of the surprising behavior. A directive nested
-    // inside a function body has no spec meaning, yet flips the file flag
-    // and suppresses BF001 — which masks the misplacement.
+    // A directive nested inside a function body has no spec meaning, yet
+    // flips the file flag and suppresses BF001 — pinned here so any future
+    // tightening of the detector is a deliberate, observed change.
     expect(ctx.hasUseClientDirective).toBe(true)
     expect(ctx.errors.filter(e => e.code === 'BF001')).toEqual([])
   })
 
-  test('after-import placement produces output byte-identical to top placement', () => {
+  test('after-import placement: output byte-identical to top placement', () => {
     const top = `'use client'
 import { createSignal } from '@barefootjs/client'
 
@@ -119,14 +118,9 @@ export function Counter() {
     const r2 = compile(inBody)
     expect(r1.errors).toEqual([])
     expect(r2.errors).toEqual([])
-    const f1 = filesByPath(r1)
-    const f2 = filesByPath(r2)
     const clientPath = 'Counter.client.js'
-    // Top placement: directive does NOT appear in the emitted runtime body.
-    expect(f1[clientPath]).not.toContain("'use client'")
-    // In-body placement: directive survives as a no-op statement in the
-    // initCounter body — cosmetic, but a real output divergence.
-    expect(f2[clientPath]).toContain("'use client'")
+    expect(filesByPath(r1)[clientPath]).not.toContain("'use client'")
+    expect(filesByPath(r2)[clientPath]).toContain("'use client'")
   })
 
   test('no directive + reactive APIs: BF001 fires (sanity)', () => {

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -2862,9 +2862,10 @@ function fileHasUseClientDirective(filePath: string): boolean {
   // Match the analyzer's own directive detection on this file: any
   // ExpressionStatement whose expression is the string literal
   // `'use client'` counts, regardless of whether it sits at the
-  // directive-prologue position. BF002 is the spec's enforcement of
-  // top-of-file placement; consulting that semantics here would make
-  // BF003 fire for files the analyzer itself classifies as client.
+  // directive-prologue position. Enforcing top-of-file placement here
+  // would make BF003 fire on files the analyzer itself classifies as
+  // client (see use-client-directive-position.test.ts for the pinned
+  // permissive-detection behavior).
   const sf = ts.createSourceFile(
     filePath,
     content,

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -17,7 +17,6 @@ import type {
 export const ErrorCodes = {
   // Directive errors (BF001-BF009)
   MISSING_USE_CLIENT: 'BF001',
-  INVALID_DIRECTIVE_POSITION: 'BF002',
   CLIENT_IMPORTING_SERVER: 'BF003',
 
   // Signal/Memo errors (BF010-BF019)
@@ -105,8 +104,6 @@ export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes]
 const errorMessages: Record<ErrorCode, string> = {
   [ErrorCodes.MISSING_USE_CLIENT]:
     "'use client' directive required for components with createSignal or event handlers",
-  [ErrorCodes.INVALID_DIRECTIVE_POSITION]:
-    "'use client' directive must be at the top of the file",
   [ErrorCodes.CLIENT_IMPORTING_SERVER]:
     'Client component cannot import server component',
 

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -1386,7 +1386,7 @@ export interface ComponentIR {
 export type ErrorSeverity = 'error' | 'warning' | 'info'
 
 export interface CompilerError {
-  code: string // 'BF001', 'BF002', etc.
+  code: string // 'BF001', 'BF003', etc.
   severity: ErrorSeverity
   message: string
   loc: SourceLocation

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -658,7 +658,6 @@ symbol of each JSX tag through to the resolver; tracked as a follow-up.
 | Code | Description |
 |------|-------------|
 | BF001 | Missing 'use client' directive |
-| BF002 | Invalid directive position |
 | BF003 | Client component importing server component |
 | BF010 | Unknown signal reference |
 | BF011 | Signal used outside component |

--- a/spec/testing.md
+++ b/spec/testing.md
@@ -49,7 +49,7 @@ Test the compiler's internal logic: parsing, analysis, transformation rules, and
 ### What to test here
 
 - **Analysis:** Signal/memo/effect detection, props extraction, import resolution
-- **Error codes:** BF001, BF002, BF021, BF043, BF044, etc.
+- **Error codes:** BF001, BF021, BF043, BF044, etc.
 - **Expression parsing:** Ternary evaluation, filter/sort pattern detection, constant resolution
 - **Client JS generation:** Import deduplication, module combination, declaration ordering
 - **CSS processing:** `@layer` prefixing, type stripping


### PR DESCRIPTION
## Summary

`ErrorCodes` in `packages/jsx/src/errors.ts` defines 31 BF codes, but 13 are reserved without an emit site:

`BF002, BF010, BF011, BF012, BF020, BF022, BF030, BF031, BF040, BF041, BF042, BF045, BF062`

This PR opens an audit pass that, for each unimplemented code, lands a minimum-repro test pinning the compiler's current behavior so we can decide between:

- **Delete** — the scenario already works correctly and silently; the reservation is dead weight.
- **Implement** — the scenario produces silently wrong output and deserves a diagnostic.
- **Document** — keep as a reserved placeholder with explicit doc treatment.

## First code: BF002 (`INVALID_DIRECTIVE_POSITION`)

Findings from `packages/jsx/src/__tests__/bf002-directive-position.test.ts`:

| Placement | Detector | Compile output |
|-----------|----------|----------------|
| Top (canonical) | flips `hasUseClientDirective` | baseline |
| After import | flips | byte-identical to baseline |
| After non-import statement | flips | byte-identical to baseline |
| **Inside function body** | **flips** | same SSR template, but `'use client'` literal **leaks into emitted client JS as a no-op statement** |

The detector at `analyzer.ts:328` matches a string-literal `ExpressionStatement` at any tree position — the comment at `analyzer.ts:2862-2867` notes this is deliberate to keep BF003's cross-file client classification consistent with the analyzer's own detection.

### Decision pending

- **A. Delete BF002** — no silent wrong output; the in-body leaked literal is a cosmetic no-op. Removing the reserved constant clears the dead-code smell.
- **B. Implement BF002 as a warning** — flag non-prologue placements, React/Next-compatible discipline. Breaking-ish behavior change for the after-import shape.
- **C. Implement BF002 narrowly** — only flag in-function-body placements (the case that produces an observable artifact). Smallest impact.

## Test plan

- [x] `bun test packages/jsx/src/__tests__/bf002-directive-position.test.ts` — 7 pass
- [ ] Decide BF002 action (A / B / C); land it on this PR
- [ ] Iterate the remaining 12 reserved codes (BF010, BF011, BF012, BF020, BF022, BF030, BF031, BF040, BF041, BF042, BF045, BF062) on this branch

Draft until the audit is complete and the deletion/implementation actions are locked in.

https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo

---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_