### PR TITLE
feat(jsx): emit BF011 for module-level reactive declarations

### DIFF
--- a/docs/core/advanced/error-codes.md
+++ b/docs/core/advanced/error-codes.md
@@ -73,21 +73,21 @@ export function Counter() {
 const [count, setCount] = createSignal(0)
 ```
 
-### BF011 — Module-Level Reactive Declaration Without `/* @client */`
+### BF011 — Module-Level Reactive Declaration
 
-**Trigger:** A `createSignal` or `createMemo` call at module scope without a leading `/* @client */` directive. The default SSR path cannot host a module-scope reactive declaration (the binding would leak across requests and the codegen drops the declaration silently), so authors must opt in explicitly to scope it to the browser bundle.
+**Trigger:** A `createSignal` or `createMemo` call at module scope. The downstream codegen drops the declaration silently and every reference to the resulting binding becomes a `ReferenceError` at SSR and at hydrate.
 
 ```tsx
 'use client'
 import { createSignal } from '@barefootjs/client'
-// ❌ BF011 — module-level signal without /* @client */
+// ❌ BF011 — module-level signal
 const [count, setCount] = createSignal(0)
 export function Counter() {
   return <button onClick={() => setCount(count() + 1)}>{count()}</button>
 }
 ```
 
-**Fix (option A):** Move the declaration inside the component function so each mount gets its own state.
+**Fix:** Move the declaration inside the component function so each mount gets its own state.
 
 ```tsx
 'use client'
@@ -95,20 +95,6 @@ import { createSignal } from '@barefootjs/client'
 
 export function Counter() {
   const [count, setCount] = createSignal(0)
-  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
-}
-```
-
-**Fix (option B):** Prefix the declaration with `/* @client */` to opt into client-only module-scope state (intended for "global signal" / "store" patterns shared across components in the bundle). The wired-up working path lands in a follow-up; today only the diagnostic side is implemented.
-
-```tsx
-'use client'
-import { createSignal } from '@barefootjs/client'
-
-/* @client */
-const [count, setCount] = createSignal(0)
-
-export function Counter() {
   return <button onClick={() => setCount(count() + 1)}>{count()}</button>
 }
 ```
@@ -308,7 +294,7 @@ function Component({ checked }: Props) {
 | BF001 | Error | Missing `"use client"` directive |
 | BF003 | Error | Client component importing server component |
 | BF010 | Error | Unknown signal reference |
-| BF011 | Error | Module-level reactive declaration without `/* @client */` |
+| BF011 | Error | Module-level reactive declaration |
 | BF012 | Error | Invalid signal usage |
 | BF020 | Error | Invalid JSX expression |
 | BF021 | Error | Unsupported JSX pattern for SSR |

--- a/docs/core/advanced/error-codes.md
+++ b/docs/core/advanced/error-codes.md
@@ -73,25 +73,43 @@ export function Counter() {
 const [count, setCount] = createSignal(0)
 ```
 
-### BF011 — Signal Used Outside Component
+### BF011 — Module-Level Reactive Declaration Without `/* @client */`
 
-**Trigger:** `createSignal` at module level.
+**Trigger:** A `createSignal` or `createMemo` call at module scope without a leading `/* @client */` directive. The default SSR path cannot host a module-scope reactive declaration (the binding would leak across requests and the codegen drops the declaration silently), so authors must opt in explicitly to scope it to the browser bundle.
 
 ```tsx
-// ❌ BF011 — module-level signal
+'use client'
+import { createSignal } from '@barefootjs/client'
+// ❌ BF011 — module-level signal without /* @client */
 const [count, setCount] = createSignal(0)
-
 export function Counter() {
-  return <span>{count()}</span>
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
 }
 ```
 
-**Fix:**
+**Fix (option A):** Move the declaration inside the component function so each mount gets its own state.
 
 ```tsx
+'use client'
+import { createSignal } from '@barefootjs/client'
+
 export function Counter() {
   const [count, setCount] = createSignal(0)
-  return <span>{count()}</span>
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}
+```
+
+**Fix (option B):** Prefix the declaration with `/* @client */` to opt into client-only module-scope state (intended for "global signal" / "store" patterns shared across components in the bundle). The wired-up working path lands in a follow-up; today only the diagnostic side is implemented.
+
+```tsx
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+/* @client */
+const [count, setCount] = createSignal(0)
+
+export function Counter() {
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
 }
 ```
 
@@ -290,7 +308,7 @@ function Component({ checked }: Props) {
 | BF001 | Error | Missing `"use client"` directive |
 | BF003 | Error | Client component importing server component |
 | BF010 | Error | Unknown signal reference |
-| BF011 | Error | Signal used outside component |
+| BF011 | Error | Module-level reactive declaration without `/* @client */` |
 | BF012 | Error | Invalid signal usage |
 | BF020 | Error | Invalid JSX expression |
 | BF021 | Error | Unsupported JSX pattern for SSR |

--- a/docs/core/reactivity/create-memo.md
+++ b/docs/core/reactivity/create-memo.md
@@ -7,7 +7,7 @@ description: Creates a cached derived value that recomputes only when its depend
 
 Creates a cached derived value. Recomputes only when its dependencies change.
 
-```tsx
+```ts
 import { createMemo } from '@barefootjs/client'
 
 const getter = createMemo<T>(fn: () => T): Memo<T>

--- a/docs/core/reactivity/create-signal.md
+++ b/docs/core/reactivity/create-signal.md
@@ -7,7 +7,7 @@ description: Creates a reactive getter/setter pair for managing state.
 
 Creates a reactive value. Returns a getter/setter pair.
 
-```tsx
+```ts
 import { createSignal } from '@barefootjs/client'
 
 const [getter, setter] = createSignal<T>(initialValue: T)

--- a/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
+++ b/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
@@ -995,18 +995,16 @@ describe('discriminated-union props rendering different subtrees per discriminat
 })
 
 describe('default-prop value that itself reads a signal', () => {
-  // Skipped pending Phase 2 of the BF011 work. The source exercises a
-  // module-level `createSignal` (the default-param `global()` reference
-  // can't reach an in-component declaration, so the binding must live at
-  // outer scope). BF011 now correctly rejects module-level reactive
-  // declarations without the `/* @client */` opt-in. Once the working
-  // module-scope codegen lands, re-enable this test with the directive
-  // attached to the declaration.
+  // Skipped pending the planned module-scope client-only state path.
+  // The source exercises a module-level `createSignal` because the
+  // default-param `global()` reference can't reach an in-component
+  // declaration, so the binding must live at outer scope. BF011 now
+  // rejects this shape categorically; re-enable once a working
+  // module-scope opt-in lands.
   test.skip('default value is computed from a signal accessor', () => {
     const src = `
       'use client'
       import { createSignal } from '@barefootjs/client'
-      /* @client */
       const [global, setGlobal] = createSignal('default')
       export function Demo({ label = global() }: { label?: string }) {
         return <button onClick={() => setGlobal('next')}>{label}</button>

--- a/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
+++ b/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
@@ -995,10 +995,18 @@ describe('discriminated-union props rendering different subtrees per discriminat
 })
 
 describe('default-prop value that itself reads a signal', () => {
-  test('default value is computed from a signal accessor', () => {
+  // Skipped pending Phase 2 of the BF011 work. The source exercises a
+  // module-level `createSignal` (the default-param `global()` reference
+  // can't reach an in-component declaration, so the binding must live at
+  // outer scope). BF011 now correctly rejects module-level reactive
+  // declarations without the `/* @client */` opt-in. Once the working
+  // module-scope codegen lands, re-enable this test with the directive
+  // attached to the declaration.
+  test.skip('default value is computed from a signal accessor', () => {
     const src = `
       'use client'
       import { createSignal } from '@barefootjs/client'
+      /* @client */
       const [global, setGlobal] = createSignal('default')
       export function Demo({ label = global() }: { label?: string }) {
         return <button onClick={() => setGlobal('next')}>{label}</button>

--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -421,7 +421,7 @@ for (const page of PAGES) {
 // `test.skip` rather than removed, so the test corpus stays loud
 // about the doc/compiler drift:
 //
-//   - "Documented but unimplemented" (BF010, BF011, BF012,
+//   - "Documented but unimplemented" (BF010, BF012,
 //     BF020, BF022, BF025, BF030, BF031, BF040, BF041, BF042, BF045):
 //     `errors.ts` defines the constant + message but `grep ErrorCodes.X`
 //     across `packages/jsx/src/**` finds zero production emission
@@ -462,7 +462,6 @@ const ERROR_CODES_DOC_TOO_MINIMAL: Record<string, string> = {
 // implementing the missing emission site.
 const ERROR_CODES_UNIMPLEMENTED: Record<string, string> = {
   BF010: 'documented but no emission site (see ErrorCodes.UNKNOWN_SIGNAL)',
-  BF011: 'documented but no emission site (see ErrorCodes.SIGNAL_OUTSIDE_COMPONENT)',
   BF012: 'documented but no emission site (see ErrorCodes.INVALID_SIGNAL_USAGE)',
   BF020: 'documented but no emission site (see ErrorCodes.INVALID_JSX_EXPRESSION)',
   BF022: 'documented but no emission site (see ErrorCodes.INVALID_JSX_ATTRIBUTE)',

--- a/packages/jsx/src/__tests__/module-level-signal.audit.test.ts
+++ b/packages/jsx/src/__tests__/module-level-signal.audit.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Module-level `createSignal` — pinned current (broken) behavior.
+ *
+ * The ErrorCodes table reserves a slot for "signal outside component"
+ * but grep confirms no production emission. This test pins what the
+ * compiler actually does today when a user writes a module-scope
+ * `createSignal` call.
+ *
+ * Observed silent failure:
+ *   - The analyzer reports zero errors.
+ *   - The codegen silently drops the module-level declaration.
+ *   - Every reference to the resulting binding in the emitted SSR
+ *     template AND client init becomes an undeclared identifier,
+ *     producing `ReferenceError` at first render and at hydrate.
+ *
+ * The pinned assertions document the broken output exactly so a future
+ * fix (either implementing a real diagnostic or preserving the
+ * declaration) flips the test loudly.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { analyzeComponent } from '../analyzer'
+import { compileJSX } from '../compiler'
+import { HonoAdapter } from '../../../../packages/adapter-hono/src/adapter/hono-adapter'
+
+const adapter = new HonoAdapter()
+
+function compile(source: string) {
+  return compileJSX(source, 'Counter.tsx', { adapter })
+}
+
+function filesByPath(r: ReturnType<typeof compile>) {
+  return Object.fromEntries(r.files.map(f => [f.path, f.content]))
+}
+
+const MODULE_LEVEL_SIGNAL_SRC = `'use client'
+import { createSignal } from '@barefootjs/client'
+
+const [count, setCount] = createSignal(0)
+
+export function Counter() {
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}
+`
+
+describe('module-level createSignal — pinned broken output', () => {
+  test('analyzer surfaces no diagnostic', () => {
+    const ctx = analyzeComponent(MODULE_LEVEL_SIGNAL_SRC, '/tmp/counter.tsx', 'Counter')
+    expect(ctx.errors).toEqual([])
+  })
+
+  test('compile reports no errors', () => {
+    const r = compile(MODULE_LEVEL_SIGNAL_SRC)
+    expect(r.errors).toEqual([])
+  })
+
+  test('emitted SSR template strips the declaration and leaves references undeclared', () => {
+    const r = compile(MODULE_LEVEL_SIGNAL_SRC)
+    const ssr = filesByPath(r)['Counter.tsx']
+    expect(ssr).toBeDefined()
+    expect(ssr).not.toContain('const [count')
+    expect(ssr).not.toContain('createSignal(0)')
+    expect(ssr).toContain('count()')
+  })
+
+  test('emitted client JS strips the declaration and leaves references undeclared', () => {
+    const r = compile(MODULE_LEVEL_SIGNAL_SRC)
+    const clientJs = filesByPath(r)['Counter.client.js']
+    expect(clientJs).toBeDefined()
+    expect(clientJs).not.toContain('const [count')
+    expect(clientJs).not.toContain('createSignal(0)')
+    expect(clientJs).toContain('count()')
+    expect(clientJs).toContain('setCount(')
+  })
+
+  test('control: in-component signal compiles cleanly', () => {
+    const inComponent = `'use client'
+import { createSignal } from '@barefootjs/client'
+
+export function Counter() {
+  const [count, setCount] = createSignal(0)
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}
+`
+    const r = compile(inComponent)
+    expect(r.errors).toEqual([])
+    const clientJs = filesByPath(r)['Counter.client.js']
+    expect(clientJs).toContain('createSignal(0)')
+  })
+})

--- a/packages/jsx/src/__tests__/module-level-signal.audit.test.ts
+++ b/packages/jsx/src/__tests__/module-level-signal.audit.test.ts
@@ -1,18 +1,16 @@
 /**
  * Module-level `createSignal` / `createMemo` — BF011 enforcement.
  *
- * The default SSR path cannot host a module-scope reactive declaration
- * (the binding would leak across requests and the codegen silently
- * drops it). Authors opt into client-only module-scope state by
- * prefixing the statement with `/* @client *​/`.
+ * Today these declarations are silently dropped by the codegen and
+ * every reference to the resulting binding becomes a ReferenceError at
+ * SSR and at hydrate. The diagnostic surfaces the bug at compile time
+ * for every shape `visitComponentBody` would normally route through a
+ * signal collector.
  *
- * Phase 1 of the BF011 work (this PR): emit the diagnostic when the
- * directive is absent. Phase 2/3 (follow-up): wire the working
- * module-scope path through codegen + cross-file export/import.
- *
- * The directive-present tests below pin the *current* behavior so that
- * when codegen flips to "actually preserve the declaration", the
- * inversions are loud and intentional.
+ * A `/* @client *​/` opt-in for client-only module-scope state is
+ * planned (Phase 2) but intentionally not recognized here — partial
+ * support (suppress the diagnostic, no codegen) would re-introduce the
+ * silent-bug shape this PR exists to surface.
  */
 
 import { describe, test, expect } from 'bun:test'
@@ -31,83 +29,117 @@ function bf011(errors: { code: string }[]) {
   return errors.filter(e => e.code === ErrorCodes.SIGNAL_OUTSIDE_COMPONENT)
 }
 
-const NO_DIRECTIVE_SRC = `'use client'
+describe('module-level reactive declarations — BF011', () => {
+  test('tuple destructure: `const [c, sc] = createSignal(0)`', () => {
+    const src = `'use client'
 import { createSignal } from '@barefootjs/client'
-
 const [count, setCount] = createSignal(0)
-
 export function Counter() {
   return <button onClick={() => setCount(count() + 1)}>{count()}</button>
 }
 `
+    const ctx = analyzeComponent(src, '/tmp/c.tsx', 'Counter')
+    expect(bf011(ctx.errors)).toHaveLength(1)
+  })
 
-const WITH_DIRECTIVE_SRC = `'use client'
+  test('identifier tuple-ref: `const t = createSignal(0); const v = t[0]`', () => {
+    const src = `'use client'
 import { createSignal } from '@barefootjs/client'
-
-/* @client */
-const [count, setCount] = createSignal(0)
-
+const tuple = createSignal(0)
+const count = tuple[0]
+const setCount = tuple[1]
 export function Counter() {
   return <button onClick={() => setCount(count() + 1)}>{count()}</button>
 }
 `
+    const ctx = analyzeComponent(src, '/tmp/c.tsx', 'Counter')
+    // One BF011 per reactive declaration. `tuple` is the createSignal
+    // call; `count` / `setCount` are signal-index-access derivatives
+    // which the detector also catches.
+    expect(bf011(ctx.errors).length).toBeGreaterThanOrEqual(1)
+  })
 
-const MEMO_NO_DIRECTIVE_SRC = `'use client'
+  test('index access: `const c = createSignal(0)[0]`', () => {
+    const src = `'use client'
+import { createSignal } from '@barefootjs/client'
+const count = createSignal(0)[0]
+export function Counter() {
+  return <span>{count()}</span>
+}
+`
+    const ctx = analyzeComponent(src, '/tmp/c.tsx', 'Counter')
+    expect(bf011(ctx.errors)).toHaveLength(1)
+  })
+
+  test('createMemo: `const m = createMemo(() => ...)`', () => {
+    const src = `'use client'
 import { createMemo } from '@barefootjs/client'
-
 const total = createMemo(() => 1 + 1)
-
 export function Display() {
   return <span>{total()}</span>
 }
 `
-
-describe('module-level reactive declarations — BF011', () => {
-  test('createSignal without /* @client */: BF011 fires at the declaration', () => {
-    const ctx = analyzeComponent(NO_DIRECTIVE_SRC, '/tmp/counter.tsx', 'Counter')
-    const errs = bf011(ctx.errors)
-    expect(errs).toHaveLength(1)
-    expect(errs[0].message).toContain('/* @client */')
+    const ctx = analyzeComponent(src, '/tmp/d.tsx', 'Display')
+    expect(bf011(ctx.errors)).toHaveLength(1)
   })
 
-  test('createMemo without /* @client */: BF011 fires at the declaration', () => {
-    const ctx = analyzeComponent(MEMO_NO_DIRECTIVE_SRC, '/tmp/display.tsx', 'Display')
-    const errs = bf011(ctx.errors)
-    expect(errs).toHaveLength(1)
-  })
-
-  test('full compile surfaces BF011 in the result.errors list', () => {
-    const r = compile(NO_DIRECTIVE_SRC)
-    expect(bf011(r.errors)).toHaveLength(1)
-  })
-
-  test('createSignal WITH /* @client */: BF011 does NOT fire', () => {
-    const ctx = analyzeComponent(WITH_DIRECTIVE_SRC, '/tmp/counter.tsx', 'Counter')
-    expect(bf011(ctx.errors)).toEqual([])
-  })
-
-  test('Phase 2/3 pending: WITH /* @client */, codegen still drops the declaration', () => {
-    // Pinned current shape — when the working module-scope path lands,
-    // this test should flip (assert the declaration survives into the
-    // client JS and that SSR uses a placeholder for the reference).
-    const r = compile(WITH_DIRECTIVE_SRC)
-    expect(bf011(r.errors)).toEqual([])
-    const files = Object.fromEntries(r.files.map(f => [f.path, f.content]))
-    const clientJs = files['Counter.client.js']
-    expect(clientJs).toBeDefined()
-    expect(clientJs).not.toContain('const [count')
-  })
-
-  test('control: in-component signal compiles cleanly, no BF011', () => {
-    const inComponent = `'use client'
+  test('`let` declaration is treated the same as `const`', () => {
+    const src = `'use client'
 import { createSignal } from '@barefootjs/client'
+let [count, setCount] = createSignal(0)
+export function Counter() {
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}
+`
+    const ctx = analyzeComponent(src, '/tmp/c.tsx', 'Counter')
+    expect(bf011(ctx.errors)).toHaveLength(1)
+  })
 
+  test('file without `use client`: BF011 still fires', () => {
+    const src = `import { createSignal } from '@barefootjs/client'
+const [count, setCount] = createSignal(0)
+export function Counter() {
+  return <span>{count()}</span>
+}
+`
+    const ctx = analyzeComponent(src, '/tmp/c.tsx', 'Counter')
+    expect(bf011(ctx.errors)).toHaveLength(1)
+  })
+
+  test('full compile surfaces BF011 in `result.errors`', () => {
+    const src = `'use client'
+import { createSignal } from '@barefootjs/client'
+const [count, setCount] = createSignal(0)
+export function Counter() {
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}
+`
+    expect(bf011(compile(src).errors)).toHaveLength(1)
+  })
+
+  test('phase 2 pending: `/* @client */` is not yet honored', () => {
+    // Pinned so that wiring up the opt-in flips this test loudly.
+    const src = `'use client'
+import { createSignal } from '@barefootjs/client'
+/* @client */
+const [count, setCount] = createSignal(0)
+export function Counter() {
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}
+`
+    const ctx = analyzeComponent(src, '/tmp/c.tsx', 'Counter')
+    expect(bf011(ctx.errors)).toHaveLength(1)
+  })
+
+  test('control: in-component signal compiles cleanly', () => {
+    const src = `'use client'
+import { createSignal } from '@barefootjs/client'
 export function Counter() {
   const [count, setCount] = createSignal(0)
   return <button onClick={() => setCount(count() + 1)}>{count()}</button>
 }
 `
-    const r = compile(inComponent)
+    const r = compile(src)
     expect(r.errors).toEqual([])
     const files = Object.fromEntries(r.files.map(f => [f.path, f.content]))
     expect(files['Counter.client.js']).toContain('createSignal(0)')

--- a/packages/jsx/src/__tests__/module-level-signal.audit.test.ts
+++ b/packages/jsx/src/__tests__/module-level-signal.audit.test.ts
@@ -1,27 +1,25 @@
 /**
- * Module-level `createSignal` — pinned current (broken) behavior.
+ * Module-level `createSignal` / `createMemo` — BF011 enforcement.
  *
- * The ErrorCodes table reserves a slot for "signal outside component"
- * but grep confirms no production emission. This test pins what the
- * compiler actually does today when a user writes a module-scope
- * `createSignal` call.
+ * The default SSR path cannot host a module-scope reactive declaration
+ * (the binding would leak across requests and the codegen silently
+ * drops it). Authors opt into client-only module-scope state by
+ * prefixing the statement with `/* @client *​/`.
  *
- * Observed silent failure:
- *   - The analyzer reports zero errors.
- *   - The codegen silently drops the module-level declaration.
- *   - Every reference to the resulting binding in the emitted SSR
- *     template AND client init becomes an undeclared identifier,
- *     producing `ReferenceError` at first render and at hydrate.
+ * Phase 1 of the BF011 work (this PR): emit the diagnostic when the
+ * directive is absent. Phase 2/3 (follow-up): wire the working
+ * module-scope path through codegen + cross-file export/import.
  *
- * The pinned assertions document the broken output exactly so a future
- * fix (either implementing a real diagnostic or preserving the
- * declaration) flips the test loudly.
+ * The directive-present tests below pin the *current* behavior so that
+ * when codegen flips to "actually preserve the declaration", the
+ * inversions are loud and intentional.
  */
 
 import { describe, test, expect } from 'bun:test'
 import { analyzeComponent } from '../analyzer'
 import { compileJSX } from '../compiler'
 import { HonoAdapter } from '../../../../packages/adapter-hono/src/adapter/hono-adapter'
+import { ErrorCodes } from '../errors'
 
 const adapter = new HonoAdapter()
 
@@ -29,11 +27,11 @@ function compile(source: string) {
   return compileJSX(source, 'Counter.tsx', { adapter })
 }
 
-function filesByPath(r: ReturnType<typeof compile>) {
-  return Object.fromEntries(r.files.map(f => [f.path, f.content]))
+function bf011(errors: { code: string }[]) {
+  return errors.filter(e => e.code === ErrorCodes.SIGNAL_OUTSIDE_COMPONENT)
 }
 
-const MODULE_LEVEL_SIGNAL_SRC = `'use client'
+const NO_DIRECTIVE_SRC = `'use client'
 import { createSignal } from '@barefootjs/client'
 
 const [count, setCount] = createSignal(0)
@@ -43,37 +41,64 @@ export function Counter() {
 }
 `
 
-describe('module-level createSignal — pinned broken output', () => {
-  test('analyzer surfaces no diagnostic', () => {
-    const ctx = analyzeComponent(MODULE_LEVEL_SIGNAL_SRC, '/tmp/counter.tsx', 'Counter')
-    expect(ctx.errors).toEqual([])
+const WITH_DIRECTIVE_SRC = `'use client'
+import { createSignal } from '@barefootjs/client'
+
+/* @client */
+const [count, setCount] = createSignal(0)
+
+export function Counter() {
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}
+`
+
+const MEMO_NO_DIRECTIVE_SRC = `'use client'
+import { createMemo } from '@barefootjs/client'
+
+const total = createMemo(() => 1 + 1)
+
+export function Display() {
+  return <span>{total()}</span>
+}
+`
+
+describe('module-level reactive declarations — BF011', () => {
+  test('createSignal without /* @client */: BF011 fires at the declaration', () => {
+    const ctx = analyzeComponent(NO_DIRECTIVE_SRC, '/tmp/counter.tsx', 'Counter')
+    const errs = bf011(ctx.errors)
+    expect(errs).toHaveLength(1)
+    expect(errs[0].message).toContain('/* @client */')
   })
 
-  test('compile reports no errors', () => {
-    const r = compile(MODULE_LEVEL_SIGNAL_SRC)
-    expect(r.errors).toEqual([])
+  test('createMemo without /* @client */: BF011 fires at the declaration', () => {
+    const ctx = analyzeComponent(MEMO_NO_DIRECTIVE_SRC, '/tmp/display.tsx', 'Display')
+    const errs = bf011(ctx.errors)
+    expect(errs).toHaveLength(1)
   })
 
-  test('emitted SSR template strips the declaration and leaves references undeclared', () => {
-    const r = compile(MODULE_LEVEL_SIGNAL_SRC)
-    const ssr = filesByPath(r)['Counter.tsx']
-    expect(ssr).toBeDefined()
-    expect(ssr).not.toContain('const [count')
-    expect(ssr).not.toContain('createSignal(0)')
-    expect(ssr).toContain('count()')
+  test('full compile surfaces BF011 in the result.errors list', () => {
+    const r = compile(NO_DIRECTIVE_SRC)
+    expect(bf011(r.errors)).toHaveLength(1)
   })
 
-  test('emitted client JS strips the declaration and leaves references undeclared', () => {
-    const r = compile(MODULE_LEVEL_SIGNAL_SRC)
-    const clientJs = filesByPath(r)['Counter.client.js']
+  test('createSignal WITH /* @client */: BF011 does NOT fire', () => {
+    const ctx = analyzeComponent(WITH_DIRECTIVE_SRC, '/tmp/counter.tsx', 'Counter')
+    expect(bf011(ctx.errors)).toEqual([])
+  })
+
+  test('Phase 2/3 pending: WITH /* @client */, codegen still drops the declaration', () => {
+    // Pinned current shape — when the working module-scope path lands,
+    // this test should flip (assert the declaration survives into the
+    // client JS and that SSR uses a placeholder for the reference).
+    const r = compile(WITH_DIRECTIVE_SRC)
+    expect(bf011(r.errors)).toEqual([])
+    const files = Object.fromEntries(r.files.map(f => [f.path, f.content]))
+    const clientJs = files['Counter.client.js']
     expect(clientJs).toBeDefined()
     expect(clientJs).not.toContain('const [count')
-    expect(clientJs).not.toContain('createSignal(0)')
-    expect(clientJs).toContain('count()')
-    expect(clientJs).toContain('setCount(')
   })
 
-  test('control: in-component signal compiles cleanly', () => {
+  test('control: in-component signal compiles cleanly, no BF011', () => {
     const inComponent = `'use client'
 import { createSignal } from '@barefootjs/client'
 
@@ -84,7 +109,7 @@ export function Counter() {
 `
     const r = compile(inComponent)
     expect(r.errors).toEqual([])
-    const clientJs = filesByPath(r)['Counter.client.js']
-    expect(clientJs).toContain('createSignal(0)')
+    const files = Object.fromEntries(r.files.map(f => [f.path, f.content]))
+    expect(files['Counter.client.js']).toContain('createSignal(0)')
   })
 })

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -440,26 +440,25 @@ function visit(
   if (ts.isVariableStatement(node) && !ctx.componentNode) {
     const isExported = node.modifiers?.some(m => m.kind === ts.SyntaxKind.ExportKeyword) ?? false
     const isLet = (node.declarationList.flags & ts.NodeFlags.Let) !== 0
-    // BF011: a module-level `createSignal` / `createMemo` declaration is
-    // either client-only opt-in (preceded by `/* @client */`) or a silent
-    // bug. Without the directive the downstream pipeline drops the
-    // declaration and every reference to the resulting binding becomes a
-    // ReferenceError. Fire BF011 here regardless of the binding shape so
-    // the user gets the same diagnostic for tuple destructure, identifier
-    // tuple-ref, and element-access variants.
-    const moduleStmtIsClientOnly = hasLeadingClientDirectiveOnStatement(node, ctx.sourceFile)
     for (const decl of node.declarationList.declarations) {
+      // BF011: a module-level `createSignal` / `createMemo` declaration
+      // is silently dropped by the downstream pipeline today and every
+      // reference to the resulting binding becomes a ReferenceError at
+      // SSR and at hydrate. Fire the diagnostic here for every binding
+      // shape `visitComponentBody` would normally route through a signal
+      // collector (tuple destructure, identifier tuple-ref, element
+      // access, memo) so the surface area matches.
+      //
+      // A future `/* @client */` opt-in (Phase 2) will both suppress the
+      // diagnostic and wire the declaration through the working module-
+      // scope codegen path. Until that pair lands together, no escape
+      // hatch is recognized — partial support would re-introduce the
+      // exact silent-bug shape the diagnostic is here to surface.
       if (declarationIsReactiveFactoryCall(decl, ctx)) {
-        if (!moduleStmtIsClientOnly) {
-          ctx.errors.push(createError(
-            ErrorCodes.SIGNAL_OUTSIDE_COMPONENT,
-            getSourceLocation(decl, ctx.sourceFile, ctx.filePath),
-          ))
-        }
-        // Even when the directive is present, downstream emit work is
-        // still pending — Phase 2/3 lands the working module-scope path.
-        // The declaration is intentionally left uncollected for now so the
-        // existing CSR-broken shape is not silently re-introduced.
+        ctx.errors.push(createError(
+          ErrorCodes.SIGNAL_OUTSIDE_COMPONENT,
+          getSourceLocation(decl, ctx.sourceFile, ctx.filePath),
+        ))
         continue
       }
       if (
@@ -2096,35 +2095,6 @@ function nodeContainsArrow(node: ts.Node): boolean {
   }
   visit(node)
   return found
-}
-
-// =============================================================================
-// Module-level `/* @client */` directive detection
-// =============================================================================
-
-const CLIENT_DIRECTIVE_INTERIOR_RE = /^\s*@client\s*$/
-const BLOCK_COMMENT_RE = /\/\*([\s\S]*?)\*\//g
-
-/**
- * Detect a leading `/* @client *​/` block comment on a Statement node.
- * Mirrors `hasLeadingClientDirective` in jsx-to-ir.ts (which targets
- * Expression nodes inside JSX) so the two surfaces share semantics.
- *
- * Reads the raw trivia between the previous node's end and the
- * statement's first token. The directive must be the entire comment
- * interior (matches `/* @client *​/`, rejects `/* @client-only *​/`).
- */
-function hasLeadingClientDirectiveOnStatement(
-  stmt: ts.Statement,
-  sourceFile: ts.SourceFile,
-): boolean {
-  const trivia = sourceFile.text.slice(stmt.pos, stmt.getStart(sourceFile))
-  BLOCK_COMMENT_RE.lastIndex = 0
-  let m: RegExpExecArray | null
-  while ((m = BLOCK_COMMENT_RE.exec(trivia)) !== null) {
-    if (CLIENT_DIRECTIVE_INTERIOR_RE.test(m[1])) return true
-  }
-  return false
 }
 
 /**

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -440,7 +440,28 @@ function visit(
   if (ts.isVariableStatement(node) && !ctx.componentNode) {
     const isExported = node.modifiers?.some(m => m.kind === ts.SyntaxKind.ExportKeyword) ?? false
     const isLet = (node.declarationList.flags & ts.NodeFlags.Let) !== 0
+    // BF011: a module-level `createSignal` / `createMemo` declaration is
+    // either client-only opt-in (preceded by `/* @client */`) or a silent
+    // bug. Without the directive the downstream pipeline drops the
+    // declaration and every reference to the resulting binding becomes a
+    // ReferenceError. Fire BF011 here regardless of the binding shape so
+    // the user gets the same diagnostic for tuple destructure, identifier
+    // tuple-ref, and element-access variants.
+    const moduleStmtIsClientOnly = hasLeadingClientDirectiveOnStatement(node, ctx.sourceFile)
     for (const decl of node.declarationList.declarations) {
+      if (declarationIsReactiveFactoryCall(decl, ctx)) {
+        if (!moduleStmtIsClientOnly) {
+          ctx.errors.push(createError(
+            ErrorCodes.SIGNAL_OUTSIDE_COMPONENT,
+            getSourceLocation(decl, ctx.sourceFile, ctx.filePath),
+          ))
+        }
+        // Even when the directive is present, downstream emit work is
+        // still pending — Phase 2/3 lands the working module-scope path.
+        // The declaration is intentionally left uncollected for now so the
+        // existing CSR-broken shape is not silently re-introduced.
+        continue
+      }
       if (
         ts.isIdentifier(decl.name) &&
         decl.initializer &&
@@ -2075,6 +2096,53 @@ function nodeContainsArrow(node: ts.Node): boolean {
   }
   visit(node)
   return found
+}
+
+// =============================================================================
+// Module-level `/* @client */` directive detection
+// =============================================================================
+
+const CLIENT_DIRECTIVE_INTERIOR_RE = /^\s*@client\s*$/
+const BLOCK_COMMENT_RE = /\/\*([\s\S]*?)\*\//g
+
+/**
+ * Detect a leading `/* @client *​/` block comment on a Statement node.
+ * Mirrors `hasLeadingClientDirective` in jsx-to-ir.ts (which targets
+ * Expression nodes inside JSX) so the two surfaces share semantics.
+ *
+ * Reads the raw trivia between the previous node's end and the
+ * statement's first token. The directive must be the entire comment
+ * interior (matches `/* @client *​/`, rejects `/* @client-only *​/`).
+ */
+function hasLeadingClientDirectiveOnStatement(
+  stmt: ts.Statement,
+  sourceFile: ts.SourceFile,
+): boolean {
+  const trivia = sourceFile.text.slice(stmt.pos, stmt.getStart(sourceFile))
+  BLOCK_COMMENT_RE.lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = BLOCK_COMMENT_RE.exec(trivia)) !== null) {
+    if (CLIENT_DIRECTIVE_INTERIOR_RE.test(m[1])) return true
+  }
+  return false
+}
+
+/**
+ * True when the VariableDeclaration's initializer is recognized as a
+ * `createSignal(...)` / `createMemo(...)` / signal-tuple-ref /
+ * signal-index-access call. Covers every shape `visitComponentBody`
+ * routes through dedicated collectors so BF011 detection at module
+ * scope catches the same surface area.
+ */
+function declarationIsReactiveFactoryCall(
+  decl: ts.VariableDeclaration,
+  ctx: AnalyzerContext,
+): boolean {
+  if (isSignalDeclaration(decl, ctx)) return true
+  if (isMemoDeclaration(decl, ctx)) return true
+  if (isSignalTupleDeclaration(decl)) return true
+  if (isSignalIndexAccess(decl, ctx) !== null) return true
+  return false
 }
 
 /**

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -109,9 +109,9 @@ const errorMessages: Record<ErrorCode, string> = {
 
   [ErrorCodes.UNKNOWN_SIGNAL]: 'Unknown signal reference',
   [ErrorCodes.SIGNAL_OUTSIDE_COMPONENT]:
-    'Module-level reactive declaration (createSignal / createMemo) requires the /* @client */ directive. ' +
-    'Without it the binding is silently dropped from both SSR and client output and every reference becomes a ReferenceError. ' +
-    'Prefix the declaration with /* @client */ to opt into client-only module-scope state, or move it inside a component function.',
+    'Module-level reactive declaration (createSignal / createMemo) is not allowed. ' +
+    'The downstream codegen drops the declaration silently and every reference becomes a ReferenceError at SSR and at hydrate. ' +
+    'Move the declaration inside a component function so each mount gets its own state.',
   [ErrorCodes.INVALID_SIGNAL_USAGE]: 'Invalid signal usage',
 
   [ErrorCodes.INVALID_JSX_EXPRESSION]: 'Invalid JSX expression',

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -109,7 +109,9 @@ const errorMessages: Record<ErrorCode, string> = {
 
   [ErrorCodes.UNKNOWN_SIGNAL]: 'Unknown signal reference',
   [ErrorCodes.SIGNAL_OUTSIDE_COMPONENT]:
-    'Signal must be used inside a component function',
+    'Module-level reactive declaration (createSignal / createMemo) requires the /* @client */ directive. ' +
+    'Without it the binding is silently dropped from both SSR and client output and every reference becomes a ReferenceError. ' +
+    'Prefix the declaration with /* @client */ to opt into client-only module-scope state, or move it inside a component function.',
   [ErrorCodes.INVALID_SIGNAL_USAGE]: 'Invalid signal usage',
 
   [ErrorCodes.INVALID_JSX_EXPRESSION]: 'Invalid JSX expression',


### PR DESCRIPTION
## Summary
Module-level `createSignal` / `createMemo` declarations are silently dropped by the codegen and every reference becomes a `ReferenceError` at SSR and at hydrate. This PR emits BF011 at compile time for every shape `visitComponentBody` would normally route through a signal collector (tuple destructure, identifier tuple-ref, element-access, `createMemo`).

The error message + docs steer users to the only currently working fix: move the declaration inside the component function. A `/* @client */` opt-in for module-scope client-only state is planned but intentionally not recognized here — partial support (suppress the diagnostic without the codegen path) would re-introduce the silent-bug shape this PR exists to surface. Opt-in lands in a follow-up PR together with the working codegen.

## Behavior change
- BF011 fires on every module-level `createSignal` / `createMemo` declaration (was a documented-but-unimplemented code; the audit test pinned today's broken shape).
- One stress test (`compiler-stress-1244` — "default-prop reads a signal accessor") is skipped pending the planned opt-in; the source legitimately requires module-level scope.
- Docs (`error-codes.md` BF011 section, table row) updated in lockstep.

## Test plan
- [x] `bun test packages/jsx/src/__tests__/module-level-signal.audit.test.ts` — 9 pass (all four signal shapes + `createMemo` + `let` + no-`'use client'` + Phase 2 pin)
- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 204 pass, 27 skip, 0 fail
- [x] `bun test packages/jsx` — 1603 pass, 28 skip, 0 fail
- [x] `bun run meta:extract` — no drift on UI components