### PR TITLE
feat(jsx): module-scope @client signals — Phase 2a + 2b

### DIFF
--- a/docs/core/advanced/error-codes.md
+++ b/docs/core/advanced/error-codes.md
@@ -75,19 +75,19 @@ const [count, setCount] = createSignal(0)
 
 ### BF011 — Module-Level Reactive Declaration
 
-**Trigger:** A `createSignal` or `createMemo` call at module scope. The downstream codegen drops the declaration silently and every reference to the resulting binding becomes a `ReferenceError` at SSR and at hydrate.
+**Trigger:** A `createSignal` or `createMemo` call at module scope without a leading `/* @client */` directive.
 
 ```tsx
 'use client'
 import { createSignal } from '@barefootjs/client'
-// ❌ BF011 — module-level signal
+// ❌ BF011 — module-level signal without opt-in
 const [count, setCount] = createSignal(0)
 export function Counter() {
   return <button onClick={() => setCount(count() + 1)}>{count()}</button>
 }
 ```
 
-**Fix:** Move the declaration inside the component function so each mount gets its own state.
+**Fix (option A):** Move the declaration inside the component function so each mount gets its own state.
 
 ```tsx
 'use client'
@@ -95,6 +95,20 @@ import { createSignal } from '@barefootjs/client'
 
 export function Counter() {
   const [count, setCount] = createSignal(0)
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}
+```
+
+**Fix (option B):** Prefix the declaration with `/* @client */` to opt into client-only module-scope state. The signal is emitted at module scope in the client bundle and SSR renders a placeholder for any reference. Intended for "global signal" / "store" patterns shared across components.
+
+```tsx
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+/* @client */
+const [count, setCount] = createSignal(0)
+
+export function Counter() {
   return <button onClick={() => setCount(count() + 1)}>{count()}</button>
 }
 ```
@@ -294,7 +308,7 @@ function Component({ checked }: Props) {
 | BF001 | Error | Missing `"use client"` directive |
 | BF003 | Error | Client component importing server component |
 | BF010 | Error | Unknown signal reference |
-| BF011 | Error | Module-level reactive declaration |
+| BF011 | Error | Module-level reactive declaration without `/* @client */` |
 | BF012 | Error | Invalid signal usage |
 | BF020 | Error | Invalid JSX expression |
 | BF021 | Error | Unsupported JSX pattern for SSR |

--- a/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
+++ b/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
@@ -995,16 +995,11 @@ describe('discriminated-union props rendering different subtrees per discriminat
 })
 
 describe('default-prop value that itself reads a signal', () => {
-  // Skipped pending the planned module-scope client-only state path.
-  // The source exercises a module-level `createSignal` because the
-  // default-param `global()` reference can't reach an in-component
-  // declaration, so the binding must live at outer scope. BF011 now
-  // rejects this shape categorically; re-enable once a working
-  // module-scope opt-in lands.
-  test.skip('default value is computed from a signal accessor', () => {
+  test('default value is computed from a module-scope @client signal', () => {
     const src = `
       'use client'
       import { createSignal } from '@barefootjs/client'
+      /* @client */
       const [global, setGlobal] = createSignal('default')
       export function Demo({ label = global() }: { label?: string }) {
         return <button onClick={() => setGlobal('next')}>{label}</button>

--- a/packages/jsx/src/__tests__/module-level-signal.audit.test.ts
+++ b/packages/jsx/src/__tests__/module-level-signal.audit.test.ts
@@ -166,6 +166,45 @@ export function Counter() {
     expect(moduleSigs[0].isExported).toBe(true)
   })
 
+  test('full compile: client JS preserves module-level signal', () => {
+    const src = `'use client'
+import { createSignal } from '@barefootjs/client'
+/* @client */
+const [count, setCount] = createSignal(0)
+export function Counter() {
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}
+`
+    const r = compile(src)
+    expect(bf011(r.errors)).toHaveLength(0)
+    const files = Object.fromEntries(r.files.map(f => [f.path, f.content]))
+    const clientJs = files['Counter.client.js']
+    expect(clientJs).toContain('__bf_m_count_tuple')
+    expect(clientJs).toContain('createSignal(0)')
+    // Signal declaration should NOT be inside the init function body
+    const initBody = clientJs.match(/function initCounter[\s\S]*?\n}/)?.[0] ?? ''
+    expect(initBody).not.toContain('createSignal')
+  })
+
+  test('full compile: SSR template uses placeholder for module-signal refs', () => {
+    const src = `'use client'
+import { createSignal } from '@barefootjs/client'
+/* @client */
+const [count, setCount] = createSignal(0)
+export function Counter() {
+  return <span>{count()}</span>
+}
+`
+    const r = compile(src)
+    expect(bf011(r.errors)).toHaveLength(0)
+    const files = Object.fromEntries(r.files.map(f => [f.path, f.content]))
+    const ssr = files['Counter.tsx']
+    // SSR template should NOT declare count as a getter
+    expect(ssr).not.toContain('const count = () =>')
+    // SSR template should have a client-only placeholder (not the value)
+    expect(ssr).toContain('client:s')
+  })
+
   test('control: in-component signal compiles cleanly', () => {
     const src = `'use client'
 import { createSignal } from '@barefootjs/client'

--- a/packages/jsx/src/__tests__/module-level-signal.audit.test.ts
+++ b/packages/jsx/src/__tests__/module-level-signal.audit.test.ts
@@ -117,8 +117,7 @@ export function Counter() {
     expect(bf011(compile(src).errors)).toHaveLength(1)
   })
 
-  test('phase 2 pending: `/* @client */` is not yet honored', () => {
-    // Pinned so that wiring up the opt-in flips this test loudly.
+  test('`/* @client */` suppresses BF011 and collects the signal', () => {
     const src = `'use client'
 import { createSignal } from '@barefootjs/client'
 /* @client */
@@ -128,7 +127,43 @@ export function Counter() {
 }
 `
     const ctx = analyzeComponent(src, '/tmp/c.tsx', 'Counter')
-    expect(bf011(ctx.errors)).toHaveLength(1)
+    expect(bf011(ctx.errors)).toHaveLength(0)
+    const moduleSigs = ctx.signals.filter(s => s.isModule)
+    expect(moduleSigs).toHaveLength(1)
+    expect(moduleSigs[0].getter).toBe('count')
+    expect(moduleSigs[0].setter).toBe('setCount')
+  })
+
+  test('`/* @client */` on createMemo suppresses BF011', () => {
+    const src = `'use client'
+import { createMemo } from '@barefootjs/client'
+/* @client */
+const total = createMemo(() => 1 + 1)
+export function Display() {
+  return <span>{total()}</span>
+}
+`
+    const ctx = analyzeComponent(src, '/tmp/d.tsx', 'Display')
+    expect(bf011(ctx.errors)).toHaveLength(0)
+    const moduleMemos = ctx.memos.filter(m => m.isModule)
+    expect(moduleMemos).toHaveLength(1)
+    expect(moduleMemos[0].name).toBe('total')
+  })
+
+  test('`export /* @client */` marks signal as exported', () => {
+    const src = `'use client'
+import { createSignal } from '@barefootjs/client'
+/* @client */
+export const [count, setCount] = createSignal(0)
+export function Counter() {
+  return <span>{count()}</span>
+}
+`
+    const ctx = analyzeComponent(src, '/tmp/c.tsx', 'Counter')
+    expect(bf011(ctx.errors)).toHaveLength(0)
+    const moduleSigs = ctx.signals.filter(s => s.isModule)
+    expect(moduleSigs).toHaveLength(1)
+    expect(moduleSigs[0].isExported).toBe(true)
   })
 
   test('control: in-component signal compiles cleanly', () => {

--- a/packages/jsx/src/__tests__/module-level-signal.audit.test.ts
+++ b/packages/jsx/src/__tests__/module-level-signal.audit.test.ts
@@ -150,6 +150,39 @@ export function Display() {
     expect(moduleMemos[0].name).toBe('total')
   })
 
+  test('tuple-ref shape under `/* @client */`: BF011 still fires (unsupported)', () => {
+    const src = `'use client'
+import { createSignal } from '@barefootjs/client'
+/* @client */
+const tuple = createSignal(0)
+export function Counter() {
+  return <span>x</span>
+}
+`
+    const ctx = analyzeComponent(src, '/tmp/c.tsx', 'Counter')
+    expect(bf011(ctx.errors)).toHaveLength(1)
+    expect(ctx.errors[0].message).toContain('tuple-ref')
+  })
+
+  test('two module signals in one file', () => {
+    const src = `'use client'
+import { createSignal } from '@barefootjs/client'
+/* @client */
+const [a, setA] = createSignal(0)
+/* @client */
+const [b, setB] = createSignal('x')
+export function Counter() {
+  return <div>{a()}{b()}</div>
+}
+`
+    const r = compile(src)
+    expect(bf011(r.errors)).toHaveLength(0)
+    const files = Object.fromEntries(r.files.map(f => [f.path, f.content]))
+    const clientJs = files['Counter.client.js']
+    expect(clientJs).toContain('__bf_m_a_tuple')
+    expect(clientJs).toContain('__bf_m_b_tuple')
+  })
+
   test('`export /* @client */` marks signal as exported', () => {
     const src = `'use client'
 import { createSignal } from '@barefootjs/client'

--- a/packages/jsx/src/__tests__/module-level-signal.audit.test.ts
+++ b/packages/jsx/src/__tests__/module-level-signal.audit.test.ts
@@ -205,6 +205,24 @@ export function Counter() {
     expect(ssr).toContain('client:s')
   })
 
+  test('full compile: exported signal uses `export const` in client JS', () => {
+    const src = `'use client'
+import { createSignal } from '@barefootjs/client'
+/* @client */
+export const [count, setCount] = createSignal(0)
+export function Counter() {
+  return <span>{count()}</span>
+}
+`
+    const r = compile(src)
+    expect(bf011(r.errors)).toHaveLength(0)
+    const files = Object.fromEntries(r.files.map(f => [f.path, f.content]))
+    const clientJs = files['Counter.client.js']
+    expect(clientJs).toContain('export const [count, setCount] = createSignal(0)')
+    // non-exported var pattern should NOT be used
+    expect(clientJs).not.toContain('__bf_m_count_tuple')
+  })
+
   test('control: in-component signal compiles cleanly', () => {
     const src = `'use client'
 import { createSignal } from '@barefootjs/client'

--- a/packages/jsx/src/adapters/jsx-adapter.ts
+++ b/packages/jsx/src/adapters/jsx-adapter.ts
@@ -79,9 +79,11 @@ export abstract class JsxAdapter extends BaseAdapter {
     // jsxBody + signal initial values + memo computations (these are the "consumers")
     const primaryRefs = [jsxBody]
     for (const signal of ir.metadata.signals) {
+      if (signal.isModule) continue
       primaryRefs.push(signal.initialValue)
     }
     for (const memo of ir.metadata.memos) {
+      if (memo.isModule) continue
       primaryRefs.push(memo.computation)
     }
     const primaryRefText = primaryRefs.join('\n')
@@ -107,6 +109,7 @@ export abstract class JsxAdapter extends BaseAdapter {
     const setterRefText = primaryRefText + '\n' + reachableBodies
 
     for (const signal of ir.metadata.signals) {
+      if (signal.isModule) continue
       // Create a getter that returns the initial value for SSR
       const rawInitialValue = preserveTypes
         ? (signal.typedInitialValue ?? signal.initialValue)
@@ -135,6 +138,7 @@ export abstract class JsxAdapter extends BaseAdapter {
     }
 
     for (const memo of ir.metadata.memos) {
+      if (memo.isModule) continue
       // Evaluate memo computation at SSR time
       const computation = preserveTypes
         ? (memo.typedComputation ?? memo.computation)

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -2162,11 +2162,19 @@ function collectModuleScopeReactive(
     memo.isExported = isExported || undefined
     return
   }
-  // tuple-ref and index-access shapes at module level under @client
-  // are supported in principle but rare — the canonical pattern is
-  // `const [getter, setter] = createSignal(...)`. Collecting
-  // signalTupleRefs / index-access here requires the same flush
-  // logic visitComponentBody uses; defer to a follow-up if needed.
+  // tuple-ref (`const t = createSignal(0)`) and index-access
+  // (`const c = createSignal(0)[0]`) shapes are not yet supported at
+  // module scope — the flush logic they need is tightly coupled to
+  // visitComponentBody. Emit BF011 so the user gets a diagnostic
+  // rather than a silent drop.
+  ctx.errors.push(createError(
+    ErrorCodes.SIGNAL_OUTSIDE_COMPONENT,
+    getSourceLocation(decl, ctx.sourceFile, ctx.filePath),
+    {
+      message: 'Module-level reactive declaration using tuple-ref or index-access pattern is not yet supported. ' +
+        'Use the `const [getter, setter] = createSignal(...)` form with /* @client */ instead.',
+    },
+  ))
 }
 
 /**

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -440,25 +440,21 @@ function visit(
   if (ts.isVariableStatement(node) && !ctx.componentNode) {
     const isExported = node.modifiers?.some(m => m.kind === ts.SyntaxKind.ExportKeyword) ?? false
     const isLet = (node.declarationList.flags & ts.NodeFlags.Let) !== 0
+    const isModuleClientDirective = hasLeadingClientDirectiveOnStatement(node, ctx.sourceFile)
     for (const decl of node.declarationList.declarations) {
-      // BF011: a module-level `createSignal` / `createMemo` declaration
-      // is silently dropped by the downstream pipeline today and every
-      // reference to the resulting binding becomes a ReferenceError at
-      // SSR and at hydrate. Fire the diagnostic here for every binding
-      // shape `visitComponentBody` would normally route through a signal
-      // collector (tuple destructure, identifier tuple-ref, element
-      // access, memo) so the surface area matches.
-      //
-      // A future `/* @client */` opt-in (Phase 2) will both suppress the
-      // diagnostic and wire the declaration through the working module-
-      // scope codegen path. Until that pair lands together, no escape
-      // hatch is recognized — partial support would re-introduce the
-      // exact silent-bug shape the diagnostic is here to surface.
       if (declarationIsReactiveFactoryCall(decl, ctx)) {
-        ctx.errors.push(createError(
-          ErrorCodes.SIGNAL_OUTSIDE_COMPONENT,
-          getSourceLocation(decl, ctx.sourceFile, ctx.filePath),
-        ))
+        if (isModuleClientDirective) {
+          // /* @client */ opt-in: collect as a module-scope signal/memo
+          // so codegen preserves it in the client bundle and SSR emits a
+          // placeholder for any reference.
+          collectModuleScopeReactive(decl, ctx, isExported)
+        } else {
+          // BF011: module-level reactive declaration without opt-in.
+          ctx.errors.push(createError(
+            ErrorCodes.SIGNAL_OUTSIDE_COMPONENT,
+            getSourceLocation(decl, ctx.sourceFile, ctx.filePath),
+          ))
+        }
         continue
       }
       if (
@@ -2113,6 +2109,64 @@ function declarationIsReactiveFactoryCall(
   if (isSignalTupleDeclaration(decl)) return true
   if (isSignalIndexAccess(decl, ctx) !== null) return true
   return false
+}
+
+// =============================================================================
+// Module-level `/* @client */` directive detection + collection
+// =============================================================================
+
+const CLIENT_DIRECTIVE_INTERIOR_RE = /^\s*@client\s*$/
+const BLOCK_COMMENT_RE = /\/\*([\s\S]*?)\*\//g
+
+/**
+ * Detect a leading `/* @client *​/` block comment on a VariableStatement.
+ * Mirrors `hasLeadingClientDirective` in jsx-to-ir.ts (which targets
+ * Expression nodes inside JSX). Reads the raw trivia between the
+ * previous node's end and the statement's first token.
+ */
+function hasLeadingClientDirectiveOnStatement(
+  stmt: ts.Statement,
+  sourceFile: ts.SourceFile,
+): boolean {
+  const trivia = sourceFile.text.slice(stmt.pos, stmt.getStart(sourceFile))
+  BLOCK_COMMENT_RE.lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = BLOCK_COMMENT_RE.exec(trivia)) !== null) {
+    if (CLIENT_DIRECTIVE_INTERIOR_RE.test(m[1])) return true
+  }
+  return false
+}
+
+/**
+ * Collect a module-level reactive declaration that the user opted into
+ * with `/* @client *​/`. Reuses the existing in-component collectors and
+ * marks the result with `isModule: true` so downstream codegen routes
+ * it to module scope in the client bundle and skips it in SSR.
+ */
+function collectModuleScopeReactive(
+  decl: ts.VariableDeclaration,
+  ctx: AnalyzerContext,
+  isExported: boolean,
+): void {
+  if (isSignalDeclaration(decl, ctx)) {
+    collectSignal(decl, ctx)
+    const sig = ctx.signals[ctx.signals.length - 1]
+    sig.isModule = true
+    sig.isExported = isExported || undefined
+    return
+  }
+  if (isMemoDeclaration(decl, ctx)) {
+    collectMemo(decl, ctx)
+    const memo = ctx.memos[ctx.memos.length - 1]
+    memo.isModule = true
+    memo.isExported = isExported || undefined
+    return
+  }
+  // tuple-ref and index-access shapes at module level under @client
+  // are supported in principle but rare — the canonical pattern is
+  // `const [getter, setter] = createSignal(...)`. Collecting
+  // signalTupleRefs / index-access here requires the same flush
+  // logic visitComponentBody uses; defer to a follow-up if needed.
 }
 
 /**

--- a/packages/jsx/src/ir-to-client-js/emit-module-level.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-module-level.ts
@@ -19,7 +19,7 @@
  * them onto the placeholder replacements at the end of emission.
  */
 
-import type { ComponentIR, ConstantInfo, FunctionInfo } from '../types'
+import type { ComponentIR, ConstantInfo, FunctionInfo, SignalInfo, MemoInfo } from '../types'
 import {
   RUNTIME_MODULE,
   collectExternalImports,
@@ -41,26 +41,41 @@ import {
 export function emitModuleLevelDeclarations(
   moduleLevelConstants: readonly ConstantInfo[],
   moduleLevelFunctions: readonly FunctionInfo[],
+  moduleLevelSignals: readonly SignalInfo[] = [],
+  moduleLevelMemos: readonly MemoInfo[] = [],
 ): string {
   const lines: string[] = []
   for (const constant of moduleLevelConstants) {
     if (!constant.value) continue
     lines.push(`var ${constant.name} = ${constant.name} ?? ${constant.value}`)
   }
-  // `export` is intentionally omitted — client JS files are self-contained
-  // entry points, not imported by other modules. Add export when a concrete
-  // cross-module use case arises.
   for (const fn of moduleLevelFunctions) {
     const paramStr = fn.params.map(p => {
       const rest = p.isRest ? '...' : ''
       return p.defaultValue !== undefined ? `${rest}${p.name} = ${p.defaultValue}` : `${rest}${p.name}`
     }).join(', ')
     const asyncKw = fn.isAsync ? 'async ' : ''
-    // Generator functions (`function*`) cannot be lowered to an arrow
-    // form (arrows can't yield) — preserve the `*` here so emit reads
-    // the modifier from IR rather than re-deriving from `fn.body` text.
     const genStar = fn.isGenerator ? '*' : ''
     lines.push(`var ${fn.name} = ${fn.name} ?? ${asyncKw}function${genStar}(${paramStr}) ${fn.body}`)
+  }
+  for (const signal of moduleLevelSignals) {
+    const tupleVar = `__bf_m_${signal.getter}_tuple`
+    if (signal.isExported) {
+      lines.push(`export const [${signal.getter}${signal.setter ? `, ${signal.setter}` : ''}] = createSignal(${signal.initialValue})`)
+    } else {
+      lines.push(`var ${tupleVar} = ${tupleVar} ?? createSignal(${signal.initialValue})`)
+      lines.push(`var ${signal.getter} = ${tupleVar}[0]`)
+      if (signal.setter) {
+        lines.push(`var ${signal.setter} = ${tupleVar}[1]`)
+      }
+    }
+  }
+  for (const memo of moduleLevelMemos) {
+    if (memo.isExported) {
+      lines.push(`export const ${memo.name} = createMemo(${memo.computation})`)
+    } else {
+      lines.push(`var ${memo.name} = ${memo.name} ?? createMemo(${memo.computation})`)
+    }
   }
   return lines.length > 0 ? lines.join('\n') + '\n' : ''
 }

--- a/packages/jsx/src/ir-to-client-js/emit-module-level.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-module-level.ts
@@ -55,6 +55,7 @@ export function emitModuleLevelDeclarations(
       return p.defaultValue !== undefined ? `${rest}${p.name} = ${p.defaultValue}` : `${rest}${p.name}`
     }).join(', ')
     const asyncKw = fn.isAsync ? 'async ' : ''
+    // Generator functions (`function*`) can't be arrows — preserve `*`.
     const genStar = fn.isGenerator ? '*' : ''
     lines.push(`var ${fn.name} = ${fn.name} ?? ${asyncKw}function${genStar}(${paramStr}) ${fn.body}`)
   }

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -88,6 +88,8 @@ export function generateInitFunction(
   const moduleConstantsCode = emitModuleLevelDeclarations(
     classification.moduleLevelConstants,
     classification.moduleLevelFunctions,
+    classification.moduleLevelSignals,
+    classification.moduleLevelMemos,
   )
 
   return generatedCode

--- a/packages/jsx/src/ir-to-client-js/init-declarations.ts
+++ b/packages/jsx/src/ir-to-client-js/init-declarations.ts
@@ -55,6 +55,10 @@ export interface LocalClassification {
   /** Signals whose initial value reads a prop — they need a
    *  createEffect to sync with parent updates. */
   controlledSignals: ControlledSignal[]
+  /** Signals declared at module scope under `/* @client *​/`. */
+  moduleLevelSignals: import('../types').SignalInfo[]
+  /** Memos declared at module scope under `/* @client *​/`. */
+  moduleLevelMemos: import('../types').MemoInfo[]
 }
 
 export function classifyLocalDeclarations(
@@ -94,10 +98,21 @@ export function classifyLocalDeclarations(
   }
 
   const controlledSignals: ControlledSignal[] = []
+  const moduleLevelSignals: import('../types').SignalInfo[] = []
+  const moduleLevelMemos: import('../types').MemoInfo[] = []
   for (const signal of ctx.signals) {
+    if (signal.isModule) {
+      moduleLevelSignals.push(signal)
+      continue
+    }
     const controlledPropName = getControlledPropName(signal, ctx.propsParams, ctx.propsObjectName)
     if (controlledPropName) {
       controlledSignals.push({ signal, propName: controlledPropName })
+    }
+  }
+  for (const memo of ctx.memos) {
+    if (memo.isModule) {
+      moduleLevelMemos.push(memo)
     }
   }
 
@@ -108,6 +123,8 @@ export function classifyLocalDeclarations(
     moduleLevelFunctions,
     neededProps,
     controlledSignals,
+    moduleLevelSignals,
+    moduleLevelMemos,
   }
 }
 
@@ -139,6 +156,7 @@ export function emitSortedDeclarations(
   }
 
   for (const signal of ctx.signals) {
+    if (signal.isModule) continue
     const controlled = controlledSignals.find(c => c.signal === signal)
     declarations.push({
       kind: 'signal',
@@ -149,6 +167,7 @@ export function emitSortedDeclarations(
   }
 
   for (const memo of ctx.memos) {
+    if (memo.isModule) continue
     declarations.push({
       kind: 'memo',
       info: memo,

--- a/packages/jsx/src/ir-to-client-js/init-declarations.ts
+++ b/packages/jsx/src/ir-to-client-js/init-declarations.ts
@@ -23,6 +23,7 @@
 import type {
   ConstantInfo,
   FunctionInfo,
+  MemoInfo,
   ReferencesGraph,
   SignalInfo,
 } from '../types'
@@ -56,9 +57,9 @@ export interface LocalClassification {
    *  createEffect to sync with parent updates. */
   controlledSignals: ControlledSignal[]
   /** Signals declared at module scope under `/* @client *​/`. */
-  moduleLevelSignals: import('../types').SignalInfo[]
+  moduleLevelSignals: SignalInfo[]
   /** Memos declared at module scope under `/* @client *​/`. */
-  moduleLevelMemos: import('../types').MemoInfo[]
+  moduleLevelMemos: MemoInfo[]
 }
 
 export function classifyLocalDeclarations(
@@ -98,8 +99,8 @@ export function classifyLocalDeclarations(
   }
 
   const controlledSignals: ControlledSignal[] = []
-  const moduleLevelSignals: import('../types').SignalInfo[] = []
-  const moduleLevelMemos: import('../types').MemoInfo[] = []
+  const moduleLevelSignals: SignalInfo[] = []
+  const moduleLevelMemos: MemoInfo[] = []
   for (const signal of ctx.signals) {
     if (signal.isModule) {
       moduleLevelSignals.push(signal)

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -68,6 +68,8 @@ interface TransformContext {
   getTemplateJS(node: ts.Node): string
   /** Cached set of reactive getter names (signal getters + memo names) for O(1) lookup */
   _reactiveGetterNames?: Set<string>
+  /** Cached set of module-scope @client signal/memo names. */
+  _moduleClientSignalNames?: Set<string>
   /** Cached set of destructured prop names for AST-based rewriting */
   _destructuredPropNames?: Set<string> | null
   /** Active loop parameter names for slotId assignment to loop-param-dependent expressions */
@@ -189,6 +191,36 @@ function exprCallsReactiveGetters(expr: ts.Expression, ctx: TransformContext): b
     if (ts.isCallExpression(n) && ts.isIdentifier(n.expression)) {
       if (names.has(n.expression.text)) { found = true; return }
     }
+    ts.forEachChild(n, visit)
+  }
+  visit(expr)
+  return found
+}
+
+/**
+ * Walk an expression to check if it calls a module-scope `@client` signal
+ * getter or memo. Such references are automatically `clientOnly` in JSX
+ * so that SSR emits a placeholder and the client init evaluates them live.
+ */
+function exprReferencesModuleClientSignal(expr: ts.Expression, ctx: TransformContext): boolean {
+  if (!ctx._moduleClientSignalNames) {
+    ctx._moduleClientSignalNames = new Set<string>()
+    for (const s of ctx.analyzer.signals) {
+      if (s.isModule) {
+        ctx._moduleClientSignalNames.add(s.getter)
+        if (s.setter) ctx._moduleClientSignalNames.add(s.setter)
+      }
+    }
+    for (const m of ctx.analyzer.memos) {
+      if (m.isModule) ctx._moduleClientSignalNames.add(m.name)
+    }
+  }
+  if (ctx._moduleClientSignalNames.size === 0) return false
+  const names = ctx._moduleClientSignalNames
+  let found = false
+  function visit(n: ts.Node) {
+    if (found) return
+    if (ts.isIdentifier(n) && names.has(n.text)) { found = true; return }
     ts.forEachChild(n, visit)
   }
   visit(expr)
@@ -1212,6 +1244,7 @@ function transformExpression(
   // `getFullText()` would false-positive on string literals or trailing
   // comments containing "@client".
   const isClientOnly = hasLeadingClientDirective(expr, ctx.sourceFile)
+    || exprReferencesModuleClientSignal(expr, ctx)
 
   return transformExpressionInner(expr, ctx, node, isClientOnly)
 }

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -199,17 +199,17 @@ function exprCallsReactiveGetters(expr: ts.Expression, ctx: TransformContext): b
 
 /**
  * Walk an expression to check if it calls a module-scope `@client` signal
- * getter or memo. Such references are automatically `clientOnly` in JSX
- * so that SSR emits a placeholder and the client init evaluates them live.
+ * getter or memo. Only call-expression identifiers are matched (not bare
+ * identifier references) — this avoids false-positives when a local
+ * variable shadows a module-signal name. Setters are excluded because
+ * they only appear inside event-handler callbacks which are already
+ * client-only by construction.
  */
 function exprReferencesModuleClientSignal(expr: ts.Expression, ctx: TransformContext): boolean {
   if (!ctx._moduleClientSignalNames) {
     ctx._moduleClientSignalNames = new Set<string>()
     for (const s of ctx.analyzer.signals) {
-      if (s.isModule) {
-        ctx._moduleClientSignalNames.add(s.getter)
-        if (s.setter) ctx._moduleClientSignalNames.add(s.setter)
-      }
+      if (s.isModule) ctx._moduleClientSignalNames.add(s.getter)
     }
     for (const m of ctx.analyzer.memos) {
       if (m.isModule) ctx._moduleClientSignalNames.add(m.name)
@@ -220,7 +220,10 @@ function exprReferencesModuleClientSignal(expr: ts.Expression, ctx: TransformCon
   let found = false
   function visit(n: ts.Node) {
     if (found) return
-    if (ts.isIdentifier(n) && names.has(n.text)) { found = true; return }
+    if (ts.isCallExpression(n) && ts.isIdentifier(n.expression) && names.has(n.expression.text)) {
+      found = true
+      return
+    }
     ts.forEachChild(n, visit)
   }
   visit(expr)

--- a/packages/jsx/src/ssr-defaults.ts
+++ b/packages/jsx/src/ssr-defaults.ts
@@ -122,13 +122,14 @@ export function extractSsrDefaults(metadata: IRMetadata): Record<string, SsrDefa
   // signals (Counter's `doubled = createMemo(() => count() * 2)`).
   const bindings: Record<string, EvalResult> = {}
   for (const sig of metadata.signals) {
-    if (!sig.getter) continue
+    if (!sig.getter || sig.isModule) continue
     const value = tryStaticEval(sig.initialValue, { bindings, propsLike })
     out[sig.getter] = { value: resultToJsonable(value) }
     bindings[sig.getter] = value
   }
 
   for (const memo of metadata.memos) {
+    if (memo.isModule) continue
     const value = tryStaticEval(memo.computation, { bindings, propsLike })
     out[memo.name] = { value: resultToJsonable(value) }
     bindings[memo.name] = value

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -959,6 +959,15 @@ export interface SignalInfo {
    * if applicable) — emitters substitute it verbatim. See #1414 cell #8.
    */
   branchCondition?: string
+  /**
+   * When true, declared at module level under a `/* @client *​/` directive.
+   * The signal is emitted at module scope in the client bundle and skipped
+   * in the SSR template. Component-body references are treated as implicit
+   * `@client` expressions (placeholder at SSR, live read at hydrate).
+   */
+  isModule?: boolean
+  /** When true, the declaration carries an `export` keyword. */
+  isExported?: boolean
 }
 
 export interface MemoInfo {
@@ -975,6 +984,10 @@ export interface MemoInfo {
    * propagation in `ir-to-client-js` (#1277).
    */
   computationFreeIdentifiers?: ReadonlySet<string>
+  /** Same semantics as `SignalInfo.isModule`. */
+  isModule?: boolean
+  /** When true, the declaration carries an `export` keyword. */
+  isExported?: boolean
 }
 
 export interface EffectInfo {


### PR DESCRIPTION
## Summary
Implements the working `/* @client */` opt-in for module-scope `createSignal` / `createMemo` declarations. Builds on the BF011 diagnostic landed in PR #1540.

### What works now
```tsx
'use client'
import { createSignal } from '@barefootjs/client'

/* @client */
const [count, setCount] = createSignal(0)

export function Counter() {
  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
}
```

- **BF011 suppressed** when `/* @client */` is present
- **Client JS**: declaration preserved at module scope (`var __bf_m_count_tuple = ... ?? createSignal(0)`)
- **SSR template**: declaration skipped (shim's `createSignal` would throw); component-body references to `count()` are auto-promoted to `clientOnly` → SSR renders `<!--bf-client:sN-->` placeholder
- **Hydrate**: module loaded once → one signal instance → shared across components (ESM semantics)
- **Export**: `export /* @client */ const [count, setCount] = createSignal(0)` emits `export const [count, setCount] = createSignal(0)` in the client bundle

### Files changed
| File | Change |
|------|--------|
| `types.ts` | `SignalInfo.isModule`, `SignalInfo.isExported`, `MemoInfo.isModule`, `MemoInfo.isExported` |
| `analyzer.ts` | `hasLeadingClientDirectiveOnStatement` + `collectModuleScopeReactive` — detects `/* @client */` on module-level VariableStatement, routes through existing signal/memo collectors with flags |
| `init-declarations.ts` | Separates module signals/memos into `moduleLevelSignals`/`moduleLevelMemos`; skips them from init body |
| `emit-module-level.ts` | Emits module-level signals/memos (`var ... ?? createSignal(...)` or `export const [...]`) |
| `generate-init.ts` | Passes new classification fields |
| `jsx-adapter.ts` | `generateSignalInitializers` skips `isModule` entries |
| `jsx-to-ir.ts` | `exprReferencesModuleClientSignal` auto-promotes JSX expressions referencing module-@client signals to `clientOnly` |
| `error-codes.md` | BF011 docs updated with Option B (`/* @client */` opt-in) |
| `compiler-stress-1244.test.ts` | Un-skipped "default-prop reads signal accessor" test (now uses `/* @client */`) |

### What's deferred (Phase 3)
Cross-file **import** resolution: `import { count } from './state'` in another `'use client'` file. Requires analyzer import-graph scan + CLI chunk guarantees. Separate PR.

## Test plan
- [x] `bun test packages/jsx/src/__tests__/module-level-signal.audit.test.ts` — 14 pass (analyzer collect, BF011, full compile client JS + SSR, export)
- [x] `bun test packages/jsx/src/__tests__/compiler-stress-1244.test.ts` — 86 pass, 0 skip (un-skipped)
- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 204 pass
- [x] `bun test packages/jsx` — 1643 pass, 27 skip, 0 fail
- [x] `bun run meta:extract` — no drift

---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_