### PR TITLE
fix(cli): prevent duplicate __bf_inline_N declarations

### DIFF
--- a/packages/cli/src/__tests__/inline-imports-stale-combine.test.ts
+++ b/packages/cli/src/__tests__/inline-imports-stale-combine.test.ts
@@ -1,0 +1,123 @@
+// Tests for piconic-ai/barefootjs#1542 — when the combine step pulls in
+// child component content that was already processed by a prior
+// resolveRelativeImports pass, the stale __bf_inline_N identifiers in
+// the combined file must not collide with freshly-assigned ones.
+
+import { describe, test, expect, beforeEach, afterAll } from 'bun:test'
+import { resolveRelativeImports } from '../lib/resolve-imports'
+import { mkdirSync, writeFileSync, rmSync } from 'fs'
+import { resolve } from 'path'
+import { tmpdir } from 'os'
+
+const TEST_DIR = resolve(tmpdir(), `bf-test-stale-combine-${Date.now()}`)
+const DIST_DIR = resolve(TEST_DIR, 'dist')
+const COMPONENTS_DIR = resolve(DIST_DIR, 'components')
+
+beforeEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true })
+  mkdirSync(COMPONENTS_DIR, { recursive: true })
+})
+
+afterAll(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true })
+})
+
+describe('resolveRelativeImports — stale inline identifiers (bf#1542)', () => {
+  test('content with existing __bf_inline_N from combine: new inlines must not collide', async () => {
+    writeFileSync(
+      resolve(COMPONENTS_DIR, 'helper.ts'),
+      `export function helper() { return 'helped' }
+`,
+    )
+
+    const combinedContent = `const __bf_inline_0 = (() => {
+function childHelper() { return 'child-helped' }
+return { childHelper };
+})();
+const { childHelper } = __bf_inline_0;
+
+import { helper } from './helper'
+function init() { return { a: childHelper(), b: helper() } }
+globalThis.__test_init = init
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'App.client.js'), combinedContent)
+
+    const manifest = {
+      App: {
+        clientJs: 'components/App.client.js',
+        markedTemplate: 'components/App.tsx',
+      },
+    }
+
+    await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    const result = await Bun.file(resolve(COMPONENTS_DIR, 'App.client.js')).text()
+
+    const ids = [...result.matchAll(/const (__bf_inline_\d+)\s*=\s*\(\(\) =>/g)].map(m => m[1])
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(() => new Function(result)).not.toThrow()
+
+    const fn = new Function(result + '; return globalThis.__test_init()')
+    const out = fn()
+    expect(out.a).toBe('child-helped')
+    expect(out.b).toBe('helped')
+  })
+
+  test('content with multiple stale __bf_inline_N: new inlines offset correctly', async () => {
+    writeFileSync(
+      resolve(COMPONENTS_DIR, 'modA.ts'),
+      `export const valA = 'a-value'
+`,
+    )
+    writeFileSync(
+      resolve(COMPONENTS_DIR, 'modB.ts'),
+      `export const valB = 'b-value'
+`,
+    )
+
+    const combinedContent = `const __bf_inline_0 = (() => {
+const stale0 = 'stale0';
+return { stale0 };
+})();
+const __bf_inline_1 = (() => {
+const stale1 = 'stale1';
+return { stale1 };
+})();
+const __bf_inline_2 = (() => {
+const stale2 = 'stale2';
+return { stale2 };
+})();
+const { stale0 } = __bf_inline_0;
+const { stale1 } = __bf_inline_1;
+const { stale2 } = __bf_inline_2;
+
+import { valA } from './modA'
+import { valB } from './modB'
+function init() { return { stale0, stale1, stale2, valA, valB } }
+globalThis.__test_init = init
+`
+    writeFileSync(resolve(COMPONENTS_DIR, 'App2.client.js'), combinedContent)
+
+    const manifest = {
+      App2: {
+        clientJs: 'components/App2.client.js',
+        markedTemplate: 'components/App2.tsx',
+      },
+    }
+
+    await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    const result = await Bun.file(resolve(COMPONENTS_DIR, 'App2.client.js')).text()
+
+    const ids = [...result.matchAll(/const (__bf_inline_\d+)\s*=\s*\(\(\) =>/g)].map(m => m[1])
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(ids.length).toBe(5)
+    expect(() => new Function(result)).not.toThrow()
+
+    const fn = new Function(result + '; return globalThis.__test_init()')
+    const out = fn()
+    expect(out.stale0).toBe('stale0')
+    expect(out.valA).toBe('a-value')
+    expect(out.valB).toBe('b-value')
+  })
+})

--- a/packages/cli/src/lib/resolve-imports.ts
+++ b/packages/cli/src/lib/resolve-imports.ts
@@ -747,6 +747,7 @@ async function walkAndCollect(
   loggingPath: string,
   stripped: StrippedImport[],
   stubDeps: Set<string>,
+  nextId: { value: number },
 ): Promise<string> {
   // Parse the body with the TypeScript compiler API and walk every
   // top-level `ImportDeclaration`. Working off the AST — rather than
@@ -968,7 +969,7 @@ async function walkAndCollect(
       const jsCode = transpile(sourceContent, { loader: 'ts' })
       mod = {
         path: result.path,
-        topLevelId: `__bf_inline_${modules.size}`,
+        topLevelId: `__bf_inline_${nextId.value++}`,
         transpiledBody: jsCode,
         originalSource: sourceContent,
         searchDirs: [dirname(result.path), ...searchDirs.slice(1)],
@@ -986,6 +987,7 @@ async function walkAndCollect(
         loggingPath,
         stripped,
         stubDeps,
+        nextId,
       )
       mod.transpiledBody = replacedBody
       visiting.delete(result.path)
@@ -1066,7 +1068,16 @@ async function inlineRelativeImports(
   const modules = new Map<string, InlinedModule>()
   const visiting = new Set<string>()
   const stripped: StrippedImport[] = []
-  let parentContent = await walkAndCollect(content, searchDirs, modules, visiting, loggingPath, stripped, stubDeps)
+  // Scan for __bf_inline_N identifiers already present in the content (e.g.
+  // from a previous resolveRelativeImports pass that was pulled in by the
+  // combineParentChildClientJs step). Start the counter past the highest
+  // existing N so new inlines never collide with stale ones. #1542.
+  let startId = 0
+  for (const m of content.matchAll(/__bf_inline_(\d+)\b/g)) {
+    startId = Math.max(startId, Number(m[1]) + 1)
+  }
+  const nextId = { value: startId }
+  let parentContent = await walkAndCollect(content, searchDirs, modules, visiting, loggingPath, stripped, stubDeps, nextId)
 
   if (modules.size === 0) {
     // No IIFEs to prepend — the parent content already reflects every


### PR DESCRIPTION
## Summary

- Fix `SyntaxError: Identifier '__bf_inline_N' has already been declared` when combined content contains stale inline identifiers from a previous `resolveRelativeImports` pass
- Scan input content for existing `__bf_inline_N` patterns before assigning new IDs, starting the counter past the highest existing N
- Add regression tests covering single and multiple stale identifier scenarios

## Root cause

When `combineParentChildClientJs` (step 6) pulls in a child component whose `.client.js` was already processed by `resolveRelativeImports` on a prior build, the combined content contains stale `__bf_inline_0`, `__bf_inline_1`, etc. The inliner used `modules.size` as its counter — always starting at 0 — so freshly inlined modules received identifiers that collided with the stale ones, producing duplicate top-level `const` declarations that the browser rejected at parse time.

The fix replaces `modules.size` with a `nextId` counter initialized to one past the highest `__bf_inline_N` already present in the content.

## Test plan

- [x] New test: stale `__bf_inline_0` from combine + fresh import → no collision, bundle parses, runtime correct
- [x] New test: stale `__bf_inline_0` through `__bf_inline_2` + two fresh imports → IDs offset to 3/4, all unique
- [x] All 27 existing inline-import tests pass unchanged
- [x] Full CLI test suite: no regressions (pre-existing failures unrelated)

Fixes #1542

https://claude.ai/code/session_018Cm2xLnoUeYD3BtSBN8Hw6

---
_Generated by [Claude Code](https://claude.ai/code/session_018Cm2xLnoUeYD3BtSBN8Hw6)_