### PR TITLE
fix(compiler): rewrite props.X to _p.X inside .map() callback preamble

### DIFF
--- a/packages/jsx/src/__tests__/hydrate-template.test.ts
+++ b/packages/jsx/src/__tests__/hydrate-template.test.ts
@@ -251,4 +251,43 @@ describe('hydrate() template generation for signal-bearing components', () => {
     // Must be wrapped in an IIFE form so bindings stay in scope at template eval time
     expect(template).toMatch(/\(\(\)\s*=>\s*\{[\s\S]*const b =/)
   })
+
+  test('props.X inside .map() callback preamble is rewritten to _p.X (#1545)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function styleForLine(role: string, progress: number): string {
+        return role + progress
+      }
+
+      export function TransitionStage(props: { lines: string[]; progress: number }) {
+        const [active, setActive] = createSignal(false)
+        return (
+          <pre>
+            {props.lines.map((role, i) => {
+              const style = styleForLine(role, props.progress)
+              return (
+                <span key={i} data-style={style}>{role}</span>
+              )
+            })}
+          </pre>
+        )
+      }
+    `
+    const result = compileJSX(source, 'TransitionStage.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const content = clientJs!.content
+
+    const templateMatch = content.match(/hydrate\('TransitionStage',\s*\{[^`]*template:[^`]*`([\s\S]*?)`\s*\}/)
+    expect(templateMatch).toBeTruthy()
+    const template = templateMatch![1]
+
+    // The preamble inside .map() must rewrite props.progress → _p.progress
+    expect(template).toContain('_p.progress')
+    expect(template).not.toMatch(/[^_]props\.progress/)
+  })
 })

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -1403,7 +1403,8 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
       const safeArrayExpr = arrayExpr === UNSAFE_TEMPLATE_EXPR ? '[]' : arrayExpr
       let mapExpr: string
       if (node.mapPreamble) {
-        const preamble = node.templateMapPreamble ?? node.mapPreamble
+        const rawPreamble = node.templateMapPreamble ?? node.mapPreamble
+        const preamble = applyPropsRewrite(rawPreamble, propsObjectName ?? null)
         mapExpr = `\${${safeArrayExpr}.map((${node.param}${indexParam}) => { ${preamble} return \`${childTemplate}\` }).join('')}`
       } else {
         mapExpr = `\${${safeArrayExpr}.map((${node.param}${indexParam}) => \`${childTemplate}\`).join('')}`


### PR DESCRIPTION
## Summary

- Fixes #1545: `props.X` references inside `.map()` callback function arguments (the "preamble" — statements before the `return`) were not rewritten to `_p.X` in the CSR template, causing `ReferenceError: props is not defined` at runtime.
- Root cause: `generateCsrTemplateWithOpts` inserted the map preamble directly into the template string without applying `applyPropsRewrite`. The array expression and child template went through `transformExpr` (which applies the rewrite), but the preamble was skipped.
- Applied `applyPropsRewrite` to the preamble in the `loop` case of `generateCsrTemplateWithOpts` (`html-template.ts`).

## Test plan

- [x] Added regression test in `hydrate-template.test.ts` that compiles a component matching the exact bug pattern (`props.progress` inside a function call argument within a `.map()` callback preamble) and verifies the CSR template contains `_p.progress` instead of `props.progress`
- [x] All 8 hydrate-template tests pass
- [x] All 12 rewrite-props-object tests pass
- [x] All 497 adapter conformance tests pass
- [x] 1598/1602 compiler unit tests pass (4 pre-existing failures in alias resolver tests, unrelated)

Closes #1545

https://claude.ai/code/session_01Nne8PXubatEQBGRBVAvXM2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nne8PXubatEQBGRBVAvXM2)_