### PR TITLE
docs: remove unimplemented error codes from documentation

### DIFF
--- a/docs/core/advanced/error-codes.md
+++ b/docs/core/advanced/error-codes.md
@@ -1,6 +1,6 @@
 ---
 title: Error Codes Reference
-description: Complete list of BF-prefixed compiler error codes with explanations and fixes.
+description: BF-prefixed compiler error codes with explanations and fixes.
 ---
 
 # Error Codes Reference
@@ -216,7 +216,7 @@ function Child({ initialCount }: Props) {
 **Trigger:** Signal/memo getter passed without calling it.
 
 ```tsx
-// ⚠️ BF044
+// ❌ BF044
 <Child count={count} />  // Passing getter function, not the value
 ```
 

--- a/docs/core/advanced/error-codes.md
+++ b/docs/core/advanced/error-codes.md
@@ -54,24 +54,7 @@ export function Counter() { ... }
 
 ---
 
-## Signal Errors (BF010–BF012)
-
-### BF010 — Unknown Signal Reference
-
-**Trigger:** Undeclared signal getter referenced.
-
-```tsx
-"use client"
-export function Counter() {
-  return <span>{count()}</span>  // ❌ count not declared
-}
-```
-
-**Fix:**
-
-```tsx
-const [count, setCount] = createSignal(0)
-```
+## Signal Errors (BF011)
 
 ### BF011 — Module-Level Reactive Declaration
 
@@ -113,17 +96,9 @@ export function Counter() {
 }
 ```
 
-### BF012 — Invalid Signal Usage
-
-**Trigger:** Unsupported signal API pattern.
-
 ---
 
-## JSX Errors (BF020–BF023)
-
-### BF020 — Invalid JSX Expression
-
-**Trigger:** Uncompilable JSX expression.
+## JSX Errors (BF021–BF023)
 
 ### BF021 — Unsupported JSX Pattern
 
@@ -180,10 +155,6 @@ Simple subtraction: `(a, b) => a.field - b.field`:
 ))}
 ```
 
-### BF022 — Invalid JSX Attribute
-
-**Trigger:** Uncompilable attribute value.
-
 ### BF023 — Missing Key in List
 
 **Trigger:** `.map()` loop without `key` prop.
@@ -202,31 +173,7 @@ Simple subtraction: `(a, b) => a.field - b.field`:
 
 ---
 
-## Type Errors (BF030–BF031)
-
-### BF030 — Type Inference Failed
-
-**Trigger:** Type inference failed for signal or expression.
-
-### BF031 — Props Type Mismatch
-
-**Trigger:** Prop value doesn't match declared type.
-
----
-
-## Component Errors (BF040–BF044)
-
-### BF040 — Component Not Found
-
-**Trigger:** Unresolvable child component reference.
-
-### BF041 — Circular Dependency
-
-**Trigger:** Mutual component imports.
-
-### BF042 — Invalid Component Name
-
-**Trigger:** Non-PascalCase component name.
+## Component Errors (BF043–BF044)
 
 ### BF043 — Props Destructuring (Warning)
 
@@ -307,17 +254,8 @@ function Component({ checked }: Props) {
 |------|----------|-------------|
 | BF001 | Error | Missing `"use client"` directive |
 | BF003 | Error | Client component importing server component |
-| BF010 | Error | Unknown signal reference |
 | BF011 | Error | Module-level reactive declaration without `/* @client */` |
-| BF012 | Error | Invalid signal usage |
-| BF020 | Error | Invalid JSX expression |
 | BF021 | Error | Unsupported JSX pattern for SSR |
-| BF022 | Error | Invalid JSX attribute |
 | BF023 | Error | Missing key in list |
-| BF030 | Error | Type inference failed |
-| BF031 | Error | Props type mismatch |
-| BF040 | Error | Component not found |
-| BF041 | Error | Circular dependency |
-| BF042 | Error | Invalid component name |
 | BF043 | Warning | Props destructuring breaks reactivity |
 | BF044 | Error | Signal/memo getter passed without calling it |

--- a/docs/core/llms.txt
+++ b/docs/core/llms.txt
@@ -47,7 +47,7 @@
 
 - [Vendor code-splitting](https://barefootjs.dev/docs/advanced/code-splitting.md): Split large vendor libraries into separately-cached browser chunks via barefoot.config.ts externals
 - [Compiler Internals](https://barefootjs.dev/docs/advanced/compiler-internals.md): How the BarefootJS compiler transforms JSX into marked templates and client JavaScript.
-- [Error Codes Reference](https://barefootjs.dev/docs/advanced/error-codes.md): Complete list of BF-prefixed compiler error codes with explanations and fixes.
+- [Error Codes Reference](https://barefootjs.dev/docs/advanced/error-codes.md): BF-prefixed compiler error codes with explanations and fixes.
 - [IR Schema Reference](https://barefootjs.dev/docs/advanced/ir-schema.md): JSON tree structure of the Intermediate Representation consumed by adapters and client-JS generation.
 - [Performance Optimization](https://barefootjs.dev/docs/advanced/performance.md): Strategies to minimize bundle size, reduce hydration cost, and optimize runtime reactivity
 - [xyflow browser bundle](https://barefootjs.dev/docs/advanced/xyflow-browser-bundle.md): How to serve @barefootjs/xyflow as a pre-built browser chunk via an importmap

--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -417,24 +417,21 @@ for (const page of PAGES) {
 // BFxxx code MUST appear among the diagnostics, but other diagnostics
 // are allowed.
 //
-// Two gap categories surfaced by this matcher are catalogued via
-// `test.skip` rather than removed, so the test corpus stays loud
-// about the doc/compiler drift:
+// One gap category is catalogued via `test.skip` so the test corpus
+// stays loud about the doc/compiler drift:
 //
-//   - "Documented but unimplemented" (BF010, BF012,
-//     BF020, BF022, BF025, BF030, BF031, BF040, BF041, BF042, BF045):
-//     `errors.ts` defines the constant + message but `grep ErrorCodes.X`
-//     across `packages/jsx/src/**` finds zero production emission
-//     sites, so no snippet shape will ever trip it.
 //   - "Implemented but doc snippet too minimal": the code IS emitted
 //     by the compiler in real programs, but the literal snippet in
 //     `error-codes.md` doesn't carry enough context (e.g. BF043 needs
 //     a stateful component; BF044 needs a declared signal getter).
 //     These are doc-edit follow-ups.
 //
-// Both lists live in code so a future PR that wires up the missing
-// emission site / enriches the doc snippet simply removes the entry
-// and the corresponding `test()` starts asserting for real.
+// Previously-documented-but-unimplemented codes (BF010, BF012, BF020,
+// BF022, BF030, BF031, BF040, BF041, BF042) were removed from the
+// doc to keep it honest. The constants remain reserved in `errors.ts`.
+//
+// The skip list lives in code so a future PR that enriches the doc
+// snippet simply removes the entry and the test starts asserting.
 
 interface ErrorCodeContract {
   code: string
@@ -456,21 +453,12 @@ const ERROR_CODES_DOC_TOO_MINIMAL: Record<string, string> = {
 }
 
 // BFxxx codes that `errors.ts` defines but no production code in
-// `packages/jsx/src/**` actually emits. Verified via
-// `grep ErrorCodes.<NAME>` returning zero sites outside `errors.ts`
-// and `__tests__/`. Documented for visibility; un-skipping requires
-// implementing the missing emission site.
-const ERROR_CODES_UNIMPLEMENTED: Record<string, string> = {
-  BF010: 'documented but no emission site (see ErrorCodes.UNKNOWN_SIGNAL)',
-  BF012: 'documented but no emission site (see ErrorCodes.INVALID_SIGNAL_USAGE)',
-  BF020: 'documented but no emission site (see ErrorCodes.INVALID_JSX_EXPRESSION)',
-  BF022: 'documented but no emission site (see ErrorCodes.INVALID_JSX_ATTRIBUTE)',
-  BF030: 'documented but no emission site (see ErrorCodes.TYPE_INFERENCE_FAILED)',
-  BF031: 'documented but no emission site (see ErrorCodes.PROPS_TYPE_MISMATCH)',
-  BF040: 'documented but no emission site (see ErrorCodes.COMPONENT_NOT_FOUND)',
-  BF041: 'documented but no emission site (see ErrorCodes.CIRCULAR_DEPENDENCY)',
-  BF042: 'documented but no emission site (see ErrorCodes.INVALID_COMPONENT_NAME)',
-}
+// `packages/jsx/src/**` actually emits. These were removed from
+// `error-codes.md` to keep the docs honest — the constants remain
+// in `errors.ts` as reserved slots for future implementation.
+// If a code is re-added to the doc, add it here so the test stays
+// loud about the gap until the emission site lands.
+const ERROR_CODES_UNIMPLEMENTED: Record<string, string> = {}
 
 function extractErrorCodeContracts(md: string): ErrorCodeContract[] {
   const lines = md.split('\n')

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -659,15 +659,11 @@ symbol of each JSX tag through to the resolver; tracked as a follow-up.
 |------|-------------|
 | BF001 | Missing 'use client' directive |
 | BF003 | Client component importing server component |
-| BF010 | Unknown signal reference |
 | BF011 | Signal used outside component |
-| BF020 | Invalid JSX expression |
 | BF021 | Unsupported JSX pattern (e.g., filter predicate or sort comparator too complex for template compilation) |
 | BF023 | Missing `key` attribute in `.map()` loop — root JSX element has no `key` prop |
 | BF024 | Missing `key` attribute in nested `.map()` loop — inner loop root JSX element has no `key` prop |
 | BF025 | Unsupported destructure shape in `.map()` callback (rest element or computed property key) |
-| BF030 | Type inference failed |
-| BF031 | Props type mismatch |
 | BF043 | Props destructuring breaks reactivity |
 | BF044 | Signal/memo getter passed without calling it |
 | BF060 | Reactive binding (signal/memo getter) referenced from template scope (staged-IR; opt-in diagnostic) |

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -659,7 +659,7 @@ symbol of each JSX tag through to the resolver; tracked as a follow-up.
 |------|-------------|
 | BF001 | Missing 'use client' directive |
 | BF003 | Client component importing server component |
-| BF011 | Signal used outside component |
+| BF011 | Module-level reactive declaration without `/* @client */` |
 | BF021 | Unsupported JSX pattern (e.g., filter predicate or sort comparator too complex for template compilation) |
 | BF023 | Missing `key` attribute in `.map()` loop — root JSX element has no `key` prop |
 | BF024 | Missing `key` attribute in nested `.map()` loop — inner loop root JSX element has no `key` prop |


### PR DESCRIPTION
## Summary

- Remove 9 error codes (BF010, BF012, BF020, BF022, BF030, BF031, BF040, BF041, BF042) from `error-codes.md` and `spec/compiler.md` — these were documented but have no emission sites in the compiler source
- Clear the `ERROR_CODES_UNIMPLEMENTED` skip list in `doc-examples.test.ts` since the codes no longer appear in the docs
- Constants remain reserved in `errors.ts` for future implementation

Closes #1439 (partial — addresses the "docs shouldn't lie" aspect)

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 204 pass, 27 skip, 0 fail
- [ ] Verify `bf guide advanced/error-codes` renders correctly with the reduced set

https://claude.ai/code/session_01VR1ic4gLfp3FbtuBgceAUx

---
_Generated by [Claude Code](https://claude.ai/code/session_01VR1ic4gLfp3FbtuBgceAUx)_