### PR TITLE
feat(jsx): Phase 3 — cross-file @client signal import + state-only emit

### DIFF
--- a/packages/jsx/src/__tests__/cross-file-client-signal.test.ts
+++ b/packages/jsx/src/__tests__/cross-file-client-signal.test.ts
@@ -57,8 +57,8 @@ export function Counter() {
 }
 `
     const ctx = analyzeComponent(consumerSource, consumerPath, 'Counter')
-    expect(ctx.importedClientSignalNames).toContain('count')
-    expect(ctx.importedClientSignalNames).toContain('setCount')
+    expect(ctx.importedClientSignalNames.has('count')).toBe(true)
+    expect(ctx.importedClientSignalNames.has('setCount')).toBe(true)
   })
 
   test('imported @client memo is detected', () => {
@@ -79,7 +79,7 @@ export function Display() {
   return <span>{total()}</span>
 }
 `, consumerPath, 'Display')
-    expect(ctx.importedClientSignalNames).toContain('total')
+    expect(ctx.importedClientSignalNames.has('total')).toBe(true)
   })
 
   test('full compile: SSR uses placeholder for imported signal ref', () => {

--- a/packages/jsx/src/__tests__/cross-file-client-signal.test.ts
+++ b/packages/jsx/src/__tests__/cross-file-client-signal.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Cross-file `@client` signal import — Phase 3.
+ *
+ * Verifies that a file importing `@client`-exported signals from a
+ * relative module gets the correct compiler output:
+ *   - SSR template: placeholder for signal references
+ *   - Client JS: import preserved
+ *   - State-only file: standalone client JS emitted
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test'
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { analyzeComponent } from '../analyzer'
+import { compileJSX } from '../compiler'
+import { HonoAdapter } from '../../../../packages/adapter-hono/src/adapter/hono-adapter'
+
+const adapter = new HonoAdapter()
+
+let fixtureDir: string
+
+beforeAll(() => {
+  fixtureDir = mkdtempSync(path.join(tmpdir(), 'bf-phase3-'))
+})
+
+afterAll(() => {
+  rmSync(fixtureDir, { recursive: true, force: true })
+})
+
+function writeFixture(name: string, content: string): string {
+  const p = path.join(fixtureDir, name)
+  mkdirSync(path.dirname(p), { recursive: true })
+  writeFileSync(p, content, 'utf8')
+  return p
+}
+
+describe('cross-file @client signal import', () => {
+  test('analyzer detects imported @client signal names', () => {
+    writeFixture('state.tsx', `'use client'
+import { createSignal } from '@barefootjs/client'
+/* @client */
+export const [count, setCount] = createSignal(0)
+`)
+    const consumerPath = writeFixture('counter.tsx', `'use client'
+import { count, setCount } from './state'
+
+export function Counter() {
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}
+`)
+    const consumerSource = `'use client'
+import { count, setCount } from './state'
+
+export function Counter() {
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}
+`
+    const ctx = analyzeComponent(consumerSource, consumerPath, 'Counter')
+    expect(ctx.importedClientSignalNames).toContain('count')
+    expect(ctx.importedClientSignalNames).toContain('setCount')
+  })
+
+  test('imported @client memo is detected', () => {
+    writeFixture('derived.tsx', `'use client'
+import { createMemo } from '@barefootjs/client'
+/* @client */
+export const total = createMemo(() => 42)
+`)
+    const consumerPath = writeFixture('display.tsx', `'use client'
+import { total } from './derived'
+export function Display() {
+  return <span>{total()}</span>
+}
+`)
+    const ctx = analyzeComponent(`'use client'
+import { total } from './derived'
+export function Display() {
+  return <span>{total()}</span>
+}
+`, consumerPath, 'Display')
+    expect(ctx.importedClientSignalNames).toContain('total')
+  })
+
+  test('full compile: SSR uses placeholder for imported signal ref', () => {
+    writeFixture('shared.tsx', `'use client'
+import { createSignal } from '@barefootjs/client'
+/* @client */
+export const [val, setVal] = createSignal('hello')
+`)
+    const consumerPath = writeFixture('viewer.tsx', `'use client'
+import { val } from './shared'
+export function Viewer() {
+  return <span>{val()}</span>
+}
+`)
+    const r = compileJSX(`'use client'
+import { val } from './shared'
+export function Viewer() {
+  return <span>{val()}</span>
+}
+`, consumerPath, { adapter })
+    expect(r.errors.filter(e => e.code === 'BF011')).toHaveLength(0)
+    const files = Object.fromEntries(r.files.map(f => [f.path, f.content]))
+    const ssr = Object.values(files).find(c => c.includes('export function Viewer'))
+    expect(ssr).toBeDefined()
+    expect(ssr).toContain('client:s')
+    expect(ssr).not.toContain("const val = () =>")
+  })
+
+  test('state-only file produces standalone client JS', () => {
+    const statePath = writeFixture('store.tsx', `'use client'
+import { createSignal } from '@barefootjs/client'
+/* @client */
+export const [items, setItems] = createSignal([])
+`)
+    const stateSource = `'use client'
+import { createSignal } from '@barefootjs/client'
+/* @client */
+export const [items, setItems] = createSignal([])
+`
+    const r = compileJSX(stateSource, statePath, { adapter })
+    expect(r.errors.filter(e => e.severity === 'error')).toEqual([])
+    const clientJs = r.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    expect(clientJs!.content).toContain('export const [items, setItems] = createSignal([])')
+    expect(clientJs!.content).toContain('createSignal')
+  })
+
+  test('non-relative import is ignored (no cross-file scan)', () => {
+    const consumerPath = writeFixture('external.tsx', `'use client'
+import { count } from '@some-package/state'
+export function Counter() {
+  return <span>{count()}</span>
+}
+`)
+    const ctx = analyzeComponent(`'use client'
+import { count } from '@some-package/state'
+export function Counter() {
+  return <span>{count()}</span>
+}
+`, consumerPath, 'Counter')
+    expect(ctx.importedClientSignalNames.size).toBe(0)
+  })
+})

--- a/packages/jsx/src/analyzer-context.ts
+++ b/packages/jsx/src/analyzer-context.ts
@@ -166,6 +166,14 @@ export interface AnalyzerContext {
   // Directive
   hasUseClientDirective: boolean
 
+  /**
+   * Names imported from cross-file `@client` signal/memo exports.
+   * Populated by `scanImportedClientSignals` after the initial AST walk.
+   * Consumed by `exprReferencesModuleClientSignal` in jsx-to-ir.ts to
+   * auto-promote JSX references to `clientOnly`.
+   */
+  importedClientSignalNames: Set<string>
+
   // Pre-computed type ranges for type stripping
   typeExcludeRanges: ExcludeRange[]
 
@@ -228,6 +236,7 @@ export function createAnalyzerContext(
     errors: [],
 
     hasUseClientDirective: false,
+    importedClientSignalNames: new Set(),
 
     typeExcludeRanges: collectAllTypeRanges(sourceFile),
     checker: null,

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -2933,9 +2933,9 @@ function collectJsxComponentTags(sourceFile: ts.SourceFile): Set<string> {
  * Captures the binding names.
  */
 const CLIENT_EXPORT_SIGNAL_RE =
-  /\/\*\s*@client\s*\*\/\s*\n?\s*export\s+const\s+\[(\w+)(?:\s*,\s*(\w+))?\]\s*=\s*createSignal\b/g
+  /\/\*\s*@client\s*\*\/\s*\n?\s*export\s+const\s+\[([$\w]+)(?:\s*,\s*([$\w]+))?\]\s*=\s*createSignal\b/g
 const CLIENT_EXPORT_MEMO_RE =
-  /\/\*\s*@client\s*\*\/\s*\n?\s*export\s+const\s+(\w+)\s*=\s*createMemo\b/g
+  /\/\*\s*@client\s*\*\/\s*\n?\s*export\s+const\s+([$\w]+)\s*=\s*createMemo\b/g
 
 /**
  * Scan imported modules for exported `@client` signal/memo bindings.
@@ -2977,7 +2977,7 @@ function scanImportedClientSignals(ctx: AnalyzerContext): void {
     if (exportedClientNames.size === 0) continue
 
     for (const spec of imp.specifiers) {
-      if (spec.isTypeOnly) continue
+      if (spec.isDefault || spec.isNamespace) continue
       const importedName = spec.name
       if (exportedClientNames.has(importedName)) {
         ctx.importedClientSignalNames.add(spec.alias ?? importedName)

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -253,6 +253,9 @@ export function analyzeComponent(
   // Single pass visitor
   visit(sourceFile, ctx, targetComponentName, namedExports)
 
+  // Cross-file: scan imported modules for exported @client signals/memos
+  scanImportedClientSignals(ctx)
+
   // Post-processing validations
   validateContext(ctx)
 
@@ -2918,6 +2921,69 @@ function collectJsxComponentTags(sourceFile: ts.SourceFile): Set<string> {
   }
   visit(sourceFile)
   return tags
+}
+
+// =============================================================================
+// Cross-file @client signal scanning
+// =============================================================================
+
+/**
+ * Regex that matches `/* @client *​/ export const [name1, name2] = createSignal(...)`
+ * or `/* @client *​/ export const name = createMemo(...)` in a single line.
+ * Captures the binding names.
+ */
+const CLIENT_EXPORT_SIGNAL_RE =
+  /\/\*\s*@client\s*\*\/\s*\n?\s*export\s+const\s+\[(\w+)(?:\s*,\s*(\w+))?\]\s*=\s*createSignal\b/g
+const CLIENT_EXPORT_MEMO_RE =
+  /\/\*\s*@client\s*\*\/\s*\n?\s*export\s+const\s+(\w+)\s*=\s*createMemo\b/g
+
+/**
+ * Scan imported modules for exported `@client` signal/memo bindings.
+ * For each relative import in `ctx.imports`, resolve the file path,
+ * read it, and regex-scan for `/* @client *​/ export const [getter, setter]
+ * = createSignal(...)` patterns. Imported names that match are added to
+ * `ctx.importedClientSignalNames`.
+ *
+ * Uses the same `resolveRelativeImportToFile` + `fs.readFileSync`
+ * pattern as the BF003 cross-file directive check.
+ */
+function scanImportedClientSignals(ctx: AnalyzerContext): void {
+  for (const imp of ctx.imports) {
+    if (imp.isTypeOnly) continue
+    if (!imp.source.startsWith('./') && !imp.source.startsWith('../')) continue
+
+    const resolvedPath = resolveRelativeImportToFile(imp.source, ctx.filePath)
+    if (!resolvedPath) continue
+
+    let content: string
+    try {
+      content = fs.readFileSync(resolvedPath, 'utf8')
+    } catch {
+      continue
+    }
+
+    const exportedClientNames = new Set<string>()
+    CLIENT_EXPORT_SIGNAL_RE.lastIndex = 0
+    let m: RegExpExecArray | null
+    while ((m = CLIENT_EXPORT_SIGNAL_RE.exec(content)) !== null) {
+      if (m[1]) exportedClientNames.add(m[1])
+      if (m[2]) exportedClientNames.add(m[2])
+    }
+    CLIENT_EXPORT_MEMO_RE.lastIndex = 0
+    while ((m = CLIENT_EXPORT_MEMO_RE.exec(content)) !== null) {
+      if (m[1]) exportedClientNames.add(m[1])
+    }
+
+    if (exportedClientNames.size === 0) continue
+
+    for (const spec of imp.specifiers) {
+      if (spec.isTypeOnly) continue
+      const importedName = spec.name
+      if (exportedClientNames.has(importedName)) {
+        ctx.importedClientSignalNames.add(spec.alias ?? importedName)
+      }
+    }
+  }
 }
 
 function resolveRelativeImportToFile(source: string, fromFile: string): string | null {

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -493,13 +493,34 @@ export function compileJSX(
     const exportedModuleMemos = ctx.memos.filter(m => m.isModule && m.isExported)
     if (exportedModuleSignals.length > 0 || exportedModuleMemos.length > 0) {
       const body = emitModuleLevelDeclarations([], [], exportedModuleSignals, exportedModuleMemos)
-      const imports = detectUsedImportsFromCode(body)
-      const sortedImports = [...imports].sort()
-      const importLine = sortedImports.length > 0
-        ? `import { ${sortedImports.join(', ')} } from '${RUNTIME_MODULE}'\n\n`
+      const runtimeImports = detectUsedImportsFromCode(body)
+      const sortedRuntimeImports = [...runtimeImports].sort()
+      const runtimeImportLine = sortedRuntimeImports.length > 0
+        ? `import { ${sortedRuntimeImports.join(', ')} } from '${RUNTIME_MODULE}'`
         : ''
+
+      // Preserve non-runtime user imports whose specifiers are referenced
+      // in the generated body (e.g. an initializer that calls an imported
+      // helper: `createSignal(defaultValue())`).
+      const externalImportLines: string[] = []
+      for (const imp of ctx.imports) {
+        if (imp.isTypeOnly) continue
+        if (imp.source === '@barefootjs/client' || imp.source === RUNTIME_MODULE) continue
+        if (imp.specifiers.length === 0) {
+          externalImportLines.push(`import '${imp.source}'`)
+          continue
+        }
+        const used = imp.specifiers
+          .filter(s => !s.isDefault && !s.isNamespace && new RegExp(`\\b${s.alias || s.name}\\b`).test(body))
+          .map(s => s.alias ? `${s.name} as ${s.alias}` : s.name)
+        if (used.length > 0) {
+          externalImportLines.push(`import { ${used.join(', ')} } from '${imp.source}'`)
+        }
+      }
+
+      const allImports = [runtimeImportLine, ...externalImportLines].filter(Boolean).join('\n')
       const clientJsPath = filePath.replace(/\.tsx?$/, '.client.js')
-      files.push({ path: clientJsPath, content: importLine + body, type: 'clientJs' })
+      files.push({ path: clientJsPath, content: allImports + (allImports ? '\n\n' : '') + body, type: 'clientJs' })
     }
 
     return { files, errors }

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -15,6 +15,8 @@ import type { TemplateAdapter } from './adapters/interface'
 import { analyzeComponent, listComponentFunctions, createProgramForFile, needsTypeBasedDetection } from './analyzer'
 import { jsxToIR } from './jsx-to-ir'
 import { generateClientJs, generateClientJsWithSourceMap, analyzeClientNeeds } from './ir-to-client-js'
+import { emitModuleLevelDeclarations } from './ir-to-client-js/emit-module-level'
+import { RUNTIME_MODULE, detectUsedImports as detectUsedImportsFromCode } from './ir-to-client-js/imports'
 import { setActiveComponentScope, computeFileScope } from './ir-to-client-js/component-scope'
 import { generateModuleExports, collectInlineExportedNames } from './module-exports'
 import { applyCssLayerPrefix } from './css-layer-prefixer'
@@ -482,7 +484,24 @@ export function compileJSX(
   const ctx = analyzeComponent(compileSource, filePath, undefined, options.program)
 
   if (!ctx.jsxReturn) {
-    errors.push(...ctx.errors)  // Only analyzer errors
+    errors.push(...ctx.errors)
+
+    // State-only file: no component, but has exported @client signals.
+    // Produce a standalone client JS module so other components can
+    // `import { count, setCount } from './state.client.js'`.
+    const exportedModuleSignals = ctx.signals.filter(s => s.isModule && s.isExported)
+    const exportedModuleMemos = ctx.memos.filter(m => m.isModule && m.isExported)
+    if (exportedModuleSignals.length > 0 || exportedModuleMemos.length > 0) {
+      const body = emitModuleLevelDeclarations([], [], exportedModuleSignals, exportedModuleMemos)
+      const imports = detectUsedImportsFromCode(body)
+      const sortedImports = [...imports].sort()
+      const importLine = sortedImports.length > 0
+        ? `import { ${sortedImports.join(', ')} } from '${RUNTIME_MODULE}'\n\n`
+        : ''
+      const clientJsPath = filePath.replace(/\.tsx?$/, '.client.js')
+      files.push({ path: clientJsPath, content: importLine + body, type: 'clientJs' })
+    }
+
     return { files, errors }
   }
 

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -214,6 +214,9 @@ function exprReferencesModuleClientSignal(expr: ts.Expression, ctx: TransformCon
     for (const m of ctx.analyzer.memos) {
       if (m.isModule) ctx._moduleClientSignalNames.add(m.name)
     }
+    for (const name of ctx.analyzer.importedClientSignalNames) {
+      ctx._moduleClientSignalNames.add(name)
+    }
   }
   if (ctx._moduleClientSignalNames.size === 0) return false
   const names = ctx._moduleClientSignalNames


### PR DESCRIPTION
## Summary
Implements cross-file `@client` signal import resolution and state-only file compilation — the final piece of the BF011 module-scope signal story.

### What works now
```tsx
// state.tsx
'use client'
import { createSignal } from '@barefootjs/client'
/* @client */
export const [count, setCount] = createSignal(0)

// counter.tsx
'use client'
import { count, setCount } from './state'
export function Counter() {
  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
}
```

- **Import resolution**: The analyzer scans relative import targets for `/* @client */ export const [...] = createSignal(...)` patterns using the same `resolveRelativeImportToFile` + `fs.readFileSync` approach as BF003. Matched names are added to `ctx.importedClientSignalNames`.
- **Auto-clientOnly**: `exprReferencesModuleClientSignal` in jsx-to-ir.ts now unions imported signal names, so `{count()}` in JSX is auto-promoted to a `clientOnly` placeholder at SSR.
- **State-only file**: A `'use client'` file with no component but exported `@client` signals produces a standalone `state.client.js` containing just the export declarations + runtime import.
- **Non-relative imports** (e.g. `@some-package/state`) are correctly ignored — no cross-file scanning.

### Files changed
| File | Change |
|------|--------|
| `analyzer-context.ts` | Add `importedClientSignalNames: Set<string>` |
| `analyzer.ts` | Add `scanImportedClientSignals()` — regex-based lightweight scan of import targets |
| `jsx-to-ir.ts` | Union `importedClientSignalNames` into `_moduleClientSignalNames` cache |
| `compiler.ts` | Fallback path: state-only file → standalone client JS emit |
| `cross-file-client-signal.test.ts` | 5 tests covering import resolution, SSR placeholder, state-only emit |

### What's deferred
- **CLI `resolve-imports` integration**: The `.tsx` → `.client.js` import path rewriting in the CLI build pipeline. Today the compiler emits `import { count } from './state'` verbatim; the CLI's bundler/resolver needs to map this to the compiled `.client.js` output. This is a CLI-level concern, not a compiler concern.
- **Chunking guarantee**: Ensuring the bundler keeps the shared signal module as a single chunk (ESM module identity = signal identity).

## Test plan
- [x] `bun test packages/jsx/src/__tests__/cross-file-client-signal.test.ts` — 5 pass
- [x] `bun test packages/jsx` — 1651 pass, 27 skip, 0 fail
- [x] No regressions in existing tests

---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_