### PR TITLE
fix(cli): use pre-resolve compiled content in combine step

### DIFF
--- a/packages/cli/src/lib/build-cache.ts
+++ b/packages/cli/src/lib/build-cache.ts
@@ -22,6 +22,11 @@ export interface CacheEntry {
   /** Adapter-generated types (e.g. Go structs). Restored on cache hit so the
    *  postBuild hook sees types from every component, not just freshly compiled ones. */
   types?: string
+  /** Pre-resolve compiled client JS content. The combine step needs the
+   *  original compiled output (before resolveRelativeImports rewrites it) so
+   *  stale __bf_inline_N identifiers from a prior build's resolution pass
+   *  don't leak into the combined file. See piconic-ai/barefootjs#1542. */
+  compiledClientJs?: string
 }
 
 export interface BuildCache {

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -667,6 +667,7 @@ export async function build(
       manifestEntry: result.manifestEntry,
       typesKey: result.typesKey,
       types: result.types,
+      compiledClientJs: result.compiledClientJs,
     }
   }
 
@@ -754,18 +755,35 @@ export async function build(
   // crash with `SyntaxError`. Normalise everything back to the bare
   // module specifier here so combine merges them under a single key —
   // step 6c then rewrites that one import to the correct per-file path.
+  //
+  // Prefer the cached pre-resolve compiled content (compiledClientJs) over
+  // the on-disk file: on incremental builds a cached child's file on disk
+  // is the FINAL output from the previous build (post-resolveRelativeImports),
+  // which already contains __bf_inline_N IIFEs. Combining that stale content
+  // with a freshly-recompiled parent would introduce colliding identifiers
+  // once step 6b runs. Using the original compiled content avoids the
+  // problem at the source. See piconic-ai/barefootjs#1542.
+  const compiledClientJsByKey = new Map<string, string>()
+  for (const entry of Object.values(nextEntries)) {
+    if (entry.manifestKey && entry.compiledClientJs) {
+      compiledClientJsByKey.set(entry.manifestKey, entry.compiledClientJs)
+    }
+  }
   const RUNTIME_REL_PATH = /from\s+(['"])(?:\.{1,2}\/)+barefoot\.js\1/g
   const clientJsFiles = new Map<string, string>()
   for (const [name, entry] of Object.entries(manifest)) {
     if (!entry.clientJs) continue
-    const filePath = resolve(config.outDir, entry.clientJs)
-    try {
-      const raw = await readText(filePath)
-      const canonical = raw.replace(RUNTIME_REL_PATH, `from '@barefootjs/client/runtime'`)
-      clientJsFiles.set(name, canonical)
-    } catch {
-      // File may not exist (e.g. __barefoot__)
+    let raw = compiledClientJsByKey.get(name)
+    if (!raw) {
+      const filePath = resolve(config.outDir, entry.clientJs)
+      try {
+        raw = await readText(filePath)
+      } catch {
+        continue
+      }
     }
+    const canonical = raw.replace(RUNTIME_REL_PATH, `from '@barefootjs/client/runtime'`)
+    clientJsFiles.set(name, canonical)
   }
 
   if (clientJsFiles.size > 0) {
@@ -1491,6 +1509,7 @@ type CompileEntryOutcome =
       wroteAny: boolean
       types?: string
       typesKey?: string
+      compiledClientJs?: string
     }
 
 async function compileEntry(args: CompileEntryArgs): Promise<CompileEntryOutcome> {
@@ -1683,6 +1702,7 @@ async function compileEntry(args: CompileEntryArgs): Promise<CompileEntryOutcome
     wroteAny,
     types: typesContent,
     typesKey: baseNameNoExt,
+    compiledClientJs: clientJsContent || undefined,
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1544. Addresses the root cause of #1542 in the build pipeline itself rather than relying solely on the counter-offset defense.

- Store the compiled (pre-resolve) client JS content in the build cache via a new `compiledClientJs` field on `CacheEntry`
- In the combine step (step 6), prefer the cached compiled content over reading from disk
- This prevents stale `__bf_inline_N` IIFEs from a prior build's `resolveRelativeImports` pass from leaking into the combined file

## Root cause (deeper)

On incremental/watch builds:
1. Step 4 skips cached components — the `.client.js` on disk is the **final** output from the previous build (post-resolveRelativeImports, with `__bf_inline_N` IIFEs)
2. Step 6 (combine) reads this stale file and inlines it into a freshly-recompiled parent
3. Step 6b (resolveRelativeImports) creates **new** `__bf_inline_N` that collide with the stale ones

#1544 added a counter-offset defense so new IDs skip past existing ones. This PR eliminates the problem at the source: the combine step now uses the original compiled content (before resolution), so there are no stale identifiers to collide with.

## Changes

| File | Change |
|------|--------|
| `build-cache.ts` | Add `compiledClientJs?: string` to `CacheEntry` |
| `build.ts` | Add `compiledClientJs` to `CompileEntryOutcome` and cache entry creation |
| `build.ts` | Build `compiledClientJsByKey` lookup; prefer it over disk reads in step 6 |

## Test plan

- [x] All 29 inline-import tests pass
- [x] All 100 build tests pass
- [x] Full CLI test suite: no regressions (pre-existing failures unrelated)
- [x] Existing #1542 regression tests from #1544 still pass

https://claude.ai/code/session_018Cm2xLnoUeYD3BtSBN8Hw6

---
_Generated by [Claude Code](https://claude.ai/code/session_018Cm2xLnoUeYD3BtSBN8Hw6)_