### PR TITLE
feat(jsx): rewrite @client signal import paths to .client.js

### DIFF
--- a/packages/jsx/src/__tests__/cross-file-client-signal.test.ts
+++ b/packages/jsx/src/__tests__/cross-file-client-signal.test.ts
@@ -108,6 +108,31 @@ export function Viewer() {
     expect(ssr).not.toContain("const val = () =>")
   })
 
+  test('client JS rewrites @client signal import path to .client.js', () => {
+    writeFixture('signals.tsx', `'use client'
+import { createSignal } from '@barefootjs/client'
+/* @client */
+export const [val, setVal] = createSignal('hi')
+`)
+    const consumerPath = writeFixture('consumer.tsx', `'use client'
+import { val } from './signals'
+export function Consumer() {
+  return <span>{val()}</span>
+}
+`)
+    const r = compileJSX(`'use client'
+import { val } from './signals'
+export function Consumer() {
+  return <span>{val()}</span>
+}
+`, consumerPath, { adapter })
+    const files = Object.fromEntries(r.files.map(f => [f.path, f.content]))
+    const clientJs = Object.values(files).find(c => c.includes('initConsumer'))
+    expect(clientJs).toBeDefined()
+    expect(clientJs).toContain("from './signals.client.js'")
+    expect(clientJs).not.toContain("from './signals'")
+  })
+
   test('state-only file produces standalone client JS', () => {
     const statePath = writeFixture('store.tsx', `'use client'
 import { createSignal } from '@barefootjs/client'

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -543,6 +543,25 @@ export function compileJSX(
   // Pre-compute client JS analysis for adapter optimization
   componentIR.metadata.clientAnalysis = analyzeClientNeeds(componentIR)
 
+  // Cross-file @client signal sources: identify which import sources
+  // need `.client.js` path rewriting in the client bundle.
+  if (ctx.importedClientSignalNames.size > 0) {
+    const sources = new Set<string>()
+    for (const imp of ctx.imports) {
+      if (imp.isTypeOnly) continue
+      if (!imp.source.startsWith('./') && !imp.source.startsWith('../')) continue
+      for (const spec of imp.specifiers) {
+        if (ctx.importedClientSignalNames.has(spec.alias ?? spec.name)) {
+          sources.add(imp.source)
+          break
+        }
+      }
+    }
+    if (sources.size > 0) {
+      componentIR.metadata.clientSignalImportSources = sources
+    }
+  }
+
   // Apply CSS layer prefix if configured
   if (options.cssLayerPrefix) {
     applyCssLayerPrefix(componentIR, options.cssLayerPrefix)

--- a/packages/jsx/src/ir-to-client-js/imports.ts
+++ b/packages/jsx/src/ir-to-client-js/imports.ts
@@ -100,7 +100,11 @@ export function collectExternalImports(ir: ComponentIR, generatedCode: string, l
     }
 
     if (usedSpecs.length > 0) {
-      importLines.push(`import { ${usedSpecs.join(', ')} } from '${imp.source}'`)
+      let source = imp.source
+      if (ir.metadata.clientSignalImportSources?.has(source)) {
+        source = source.replace(/\.tsx?$/, '') + '.client.js'
+      }
+      importLines.push(`import { ${usedSpecs.join(', ')} } from '${source}'`)
     }
   }
   return importLines

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -1238,6 +1238,13 @@ export interface IRMetadata {
   localConstants: ConstantInfo[]
   /** Pre-computed client JS analysis for adapter use */
   clientAnalysis?: ClientAnalysis
+  /**
+   * Relative import sources that resolve to a file exporting `@client`
+   * signals/memos. Used by `collectExternalImports` to rewrite the
+   * import path from `./state` → `./state.client.js` so the browser
+   * resolves the compiled module rather than the source `.tsx`.
+   */
+  clientSignalImportSources?: Set<string>
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
Resolves the two remaining CLI-level issues for cross-file `@client` signal imports:

### 1. Import path rewriting (`.tsx` → `.client.js`)
When a component imports `@client` signals from a relative module (`import { count } from './state'`), the client JS output now rewrites the source to `./state.client.js`. Without this, the browser would try to load the source `.tsx` file, which is not valid browser JS.

### 2. Chunk splitting guarantee
CLI's `resolve-imports.ts` already treats `.js` imports as external (line 456). With the import path rewritten to `./state.client.js`, the import is preserved as-is and not IIFE-inlined. ESM module semantics guarantee one module load → one `createSignal` call → one shared signal instance across all consumers.

### Implementation
| File | Change |
|------|--------|
| `types.ts` | Add `IRMetadata.clientSignalImportSources?: Set<string>` |
| `compiler.ts` | Populate from `ctx.importedClientSignalNames` + `ctx.imports` |
| `imports.ts` | `collectExternalImports` applies `.client.js` suffix for matching sources |
| `cross-file-client-signal.test.ts` | New test: client JS contains `from './signals.client.js'` |

No function signature changes needed — the data flows through the existing `ir` parameter in `collectExternalImports`.

## Test plan
- [x] `bun test packages/jsx/src/__tests__/cross-file-client-signal.test.ts` — 6 pass (new: import path rewriting)
- [x] `bun test packages/jsx` — 1652 pass, 27 skip, 0 fail

---
_Generated by [Claude Code](https://claude.ai/code/session_017fuC4bXcw3m6z5UgPwQ7oo)_