### PR TITLE
chore: alpha onboarding validation and friction fixes

### DIFF
--- a/packages/cli/src/__tests__/search.test.ts
+++ b/packages/cli/src/__tests__/search.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, spyOn, beforeEach, afterEach } from 'bun:test'
 import { search, resolvePrintOptions, printSearchResults, type SearchResult } from '../commands/search'
-import { loadIndex, fetchIndex } from '../lib/meta-loader'
+import { loadIndex, fetchIndex, tryFetchIndex } from '../lib/meta-loader'
 import { scanCoreDocs } from '../lib/docs-loader'
 import type { MetaIndex } from '../lib/types'
 import path from 'path'
@@ -127,6 +127,48 @@ describe('fetchIndex', () => {
     await expect(fetchIndex('https://example.com/r/')).rejects.toThrow('exit')
     expect(exitSpy).toHaveBeenCalledWith(1)
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid JSON'))
+  })
+})
+
+describe('tryFetchIndex', () => {
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  const fakeIndex: MetaIndex = {
+    version: 1,
+    generatedAt: '2026-01-01',
+    components: [{ name: 'button', title: 'Button', category: 'input', description: 'A button', tags: ['button'], stateful: false }],
+  }
+
+  test('returns index on success', async () => {
+    globalThis.fetch = async () => new Response(JSON.stringify(fakeIndex), { status: 200 })
+    const result = await tryFetchIndex('https://example.com/r/')
+    expect(result).toEqual(fakeIndex)
+  })
+
+  test('returns null on HTTP error (no process.exit)', async () => {
+    globalThis.fetch = async () => new Response('Not Found', { status: 404 })
+    const result = await tryFetchIndex('https://example.com/r/')
+    expect(result).toBeNull()
+  })
+
+  test('returns null on network error (no process.exit)', async () => {
+    globalThis.fetch = async () => { throw new Error('offline') }
+    const result = await tryFetchIndex('https://example.com/r/')
+    expect(result).toBeNull()
+  })
+
+  test('returns null on invalid JSON (no process.exit)', async () => {
+    globalThis.fetch = async () => new Response('not json{{{', { status: 200 })
+    const result = await tryFetchIndex('https://example.com/r/')
+    expect(result).toBeNull()
   })
 })
 

--- a/packages/cli/src/__tests__/templates.test.ts
+++ b/packages/cli/src/__tests__/templates.test.ts
@@ -338,7 +338,7 @@ describe('adapter registry', () => {
     // the literal name for documentation purposes.
     expect(hono.files['tsconfig.json']).toContain('{{__PM_TYPES_ENTRY__}}')
     expect(hono.files['tsconfig.json']).toMatch(
-      /"types":\s*\[\s*"@cloudflare\/workers-types"\{\{__PM_TYPES_ENTRY__\}\}\s*\]/,
+      /"types":\s*\[\s*"@cloudflare\/workers-types",\s*"node"\{\{__PM_TYPES_ENTRY__\}\}\s*\]/,
     )
     // Static devDeps don't presume any PM. init.ts merges the
     // PM-specific entries (today: `@types/bun` when bun) onto this.

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -240,6 +240,29 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
     ]
     printSearchResults(allResults, ctx.jsonFlag, printOpts)
   } else {
-    printSearchResults(search(query, index, coreDocs), ctx.jsonFlag, printOpts)
+    const results = search(query, index, coreDocs)
+    const hasComponentHits = results.some(r => r.type === 'component')
+
+    if (!hasComponentHits && printOpts.hintRegistry) {
+      try {
+        const upstreamIndex = await fetchIndex(DEFAULT_REGISTRY_URL)
+        const upstreamResults = search(query, upstreamIndex)
+        if (upstreamResults.length > 0) {
+          const upstreamOpts: PrintOptions = {
+            sourceLabel: new URL(DEFAULT_REGISTRY_URL).hostname,
+            hintRegistry: false,
+          }
+          printSearchResults([...results, ...upstreamResults], ctx.jsonFlag, upstreamOpts)
+          if (!ctx.jsonFlag) {
+            console.log(`\nInstall with: bf add <name>`)
+          }
+          return
+        }
+      } catch {
+        // Registry unreachable — fall through to local-only output.
+      }
+    }
+
+    printSearchResults(results, ctx.jsonFlag, printOpts)
   }
 }

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -3,7 +3,7 @@
 import path from 'path'
 import type { CliContext } from '../context'
 import type { MetaIndex } from '../lib/types'
-import { loadIndex, fetchIndex } from '../lib/meta-loader'
+import { loadIndex, fetchIndex, tryFetchIndex } from '../lib/meta-loader'
 import { scanCoreDocs, type CoreDocMeta } from '../lib/docs-loader'
 
 // Default upstream UI component registry. Surfaced in the hint footer
@@ -244,22 +244,20 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
     const hasComponentHits = results.some(r => r.type === 'component')
 
     if (!hasComponentHits && printOpts.hintRegistry) {
-      try {
-        const upstreamIndex = await fetchIndex(DEFAULT_REGISTRY_URL)
+      const upstreamIndex = await tryFetchIndex(DEFAULT_REGISTRY_URL)
+      if (upstreamIndex) {
         const upstreamResults = search(query, upstreamIndex)
         if (upstreamResults.length > 0) {
           const upstreamOpts: PrintOptions = {
             sourceLabel: new URL(DEFAULT_REGISTRY_URL).hostname,
             hintRegistry: false,
           }
-          printSearchResults([...results, ...upstreamResults], ctx.jsonFlag, upstreamOpts)
+          printSearchResults(upstreamResults, ctx.jsonFlag, upstreamOpts)
           if (!ctx.jsonFlag) {
             console.log(`\nInstall with: bf add <name>`)
           }
           return
         }
-      } catch {
-        // Registry unreachable — fall through to local-only output.
       }
     }
 

--- a/packages/cli/src/lib/adapters/echo.ts
+++ b/packages/cli/src/lib/adapters/echo.ts
@@ -475,6 +475,7 @@ const ECHO_TSCONFIG = `{
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "jsxImportSource": "@barefootjs/jsx",
+    "types": ["node"{{__PM_TYPES_ENTRY__}}],
     "strict": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -561,6 +562,7 @@ export const ECHO_ADAPTER: AdapterTemplate = {
   devDependencies: {
     ...UNOCSS_DEV_DEPENDENCIES,
     '@barefootjs/test': 'latest',
+    '@types/node': '^22.0.0',
     concurrently: '^9.0.0',
     typescript: '^5.6.0',
   },

--- a/packages/cli/src/lib/adapters/echo.ts
+++ b/packages/cli/src/lib/adapters/echo.ts
@@ -562,7 +562,6 @@ export const ECHO_ADAPTER: AdapterTemplate = {
   devDependencies: {
     ...UNOCSS_DEV_DEPENDENCIES,
     '@barefootjs/test': 'latest',
-    '@types/node': '^22.0.0',
     concurrently: '^9.0.0',
     typescript: '^5.6.0',
   },

--- a/packages/cli/src/lib/adapters/hono-node.ts
+++ b/packages/cli/src/lib/adapters/hono-node.ts
@@ -223,6 +223,10 @@ const HONO_NODE_TSCONFIG = `{
     "noEmit": true,
     "baseUrl": ".",
     "paths": {
+      // Source first so tsc resolves the authored file (with full
+      // types) rather than the bf-build output (which may have
+      // implicit-any lambdas). The Hono JSX runtime renders
+      // hydration markers from source at serve time.
       "@/components/*": ["./components/*", "./dist/components/*"]
     }
   },

--- a/packages/cli/src/lib/adapters/hono-node.ts
+++ b/packages/cli/src/lib/adapters/hono-node.ts
@@ -223,14 +223,11 @@ const HONO_NODE_TSCONFIG = `{
     "noEmit": true,
     "baseUrl": ".",
     "paths": {
-      // Server components (no 'use client') aren't emitted to dist by
-      // \`bf build\`, so the path map falls back to the source so
-      // imports of those components still resolve.
-      "@/components/*": ["./dist/components/*", "./components/*"]
+      "@/components/*": ["./components/*", "./dist/components/*"]
     }
   },
-  "include": ["**/*.ts", "**/*.tsx", "dist/components/**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules", "dist/components"]
 }
 `
 

--- a/packages/cli/src/lib/adapters/hono.ts
+++ b/packages/cli/src/lib/adapters/hono.ts
@@ -231,7 +231,6 @@ export const HONO_ADAPTER: AdapterTemplate = {
   devDependencies: {
     ...UNOCSS_DEV_DEPENDENCIES,
     '@cloudflare/workers-types': '^4.20250101.0',
-    '@types/node': '^22.0.0',
     // `@barefootjs/test` powers `renderToTest()` — the canonical
     // millisecond IR test the docs (and `bf gen test`) point new users
     // at. Without it the scaffold's `test` script is a no-op and any

--- a/packages/cli/src/lib/adapters/hono.ts
+++ b/packages/cli/src/lib/adapters/hono.ts
@@ -124,6 +124,11 @@ const HONO_TSCONFIG = `{
     "noEmit": true,
     "baseUrl": ".",
     "paths": {
+      // Source first so tsc resolves the authored file (with full
+      // types) rather than the bf-build output (which may have
+      // implicit-any lambdas). Wrangler's bundler follows the same
+      // mapping; the Hono JSX runtime renders hydration markers
+      // from source just as well as from the compiled template.
       "@/components/*": ["./components/*", "./public/components/*"]
     }
   },

--- a/packages/cli/src/lib/adapters/hono.ts
+++ b/packages/cli/src/lib/adapters/hono.ts
@@ -113,19 +113,10 @@ const HONO_TSCONFIG = `{
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "jsxImportSource": "@barefootjs/hono/jsx",
-    // \`@cloudflare/workers-types\` covers the deployed Worker. The
-    // trailing slot is a PM-specific extension point — init.ts swaps
-    // \`{{__PM_TYPES_ENTRY__}}\` for any extra type packages the
-    // user's detected package manager wants pulled in. Today only
-    // bun contributes (\`, "bun-types"\` so \`bf gen test\`-emitted
-    // \`import 'bun:test'\` lines type-check); npm / pnpm / yarn get
-    // \`vitest\` as their test runner and import \`from 'vitest'\`,
-    // which exposes types via its own package — no \`types\` array
-    // entry needed, so the slot collapses to an empty string. The
-    // bun-vs-vitest decision lives in \`testRunnerFor\` in
-    // \`packages/cli/src/lib/pm.ts\`; future runners plug into the
-    // same slot there rather than baking another placeholder in here.
-    "types": ["@cloudflare/workers-types"{{__PM_TYPES_ENTRY__}}],
+    // \`@cloudflare/workers-types\` covers the deployed Worker;
+    // \`node\` is needed so test files (\`renderToTest\` reads via
+    // \`fs\`) type-check without an extra install step.
+    "types": ["@cloudflare/workers-types", "node"{{__PM_TYPES_ENTRY__}}],
     "strict": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -133,14 +124,11 @@ const HONO_TSCONFIG = `{
     "noEmit": true,
     "baseUrl": ".",
     "paths": {
-      // Server components (no 'use client') aren't emitted to dist by
-      // \`bf build\`, so the path map falls back to the source so
-      // imports of those components still resolve.
-      "@/components/*": ["./public/components/*", "./components/*"]
+      "@/components/*": ["./components/*", "./public/components/*"]
     }
   },
-  "include": ["**/*.ts", "**/*.tsx", "public/components/**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules", "public/components"]
 }
 `
 
@@ -238,6 +226,7 @@ export const HONO_ADAPTER: AdapterTemplate = {
   devDependencies: {
     ...UNOCSS_DEV_DEPENDENCIES,
     '@cloudflare/workers-types': '^4.20250101.0',
+    '@types/node': '^22.0.0',
     // `@barefootjs/test` powers `renderToTest()` — the canonical
     // millisecond IR test the docs (and `bf gen test`) point new users
     // at. Without it the scaffold's `test` script is a no-op and any

--- a/packages/cli/src/lib/adapters/mojo.ts
+++ b/packages/cli/src/lib/adapters/mojo.ts
@@ -211,7 +211,6 @@ export const MOJO_ADAPTER: AdapterTemplate = {
   devDependencies: {
     ...UNOCSS_DEV_DEPENDENCIES,
     '@barefootjs/test': 'latest',
-    '@types/node': '^22.0.0',
     concurrently: '^9.0.0',
     typescript: '^5.6.0',
   },

--- a/packages/cli/src/lib/adapters/mojo.ts
+++ b/packages/cli/src/lib/adapters/mojo.ts
@@ -126,6 +126,7 @@ const MOJO_TSCONFIG = `{
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "jsxImportSource": "@barefootjs/jsx",
+    "types": ["node"{{__PM_TYPES_ENTRY__}}],
     "strict": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -210,6 +211,7 @@ export const MOJO_ADAPTER: AdapterTemplate = {
   devDependencies: {
     ...UNOCSS_DEV_DEPENDENCIES,
     '@barefootjs/test': 'latest',
+    '@types/node': '^22.0.0',
     concurrently: '^9.0.0',
     typescript: '^5.6.0',
   },

--- a/packages/cli/src/lib/meta-loader.ts
+++ b/packages/cli/src/lib/meta-loader.ts
@@ -15,10 +15,14 @@ export function loadIndex(metaDir: string): MetaIndex {
   return JSON.parse(readFileSync(indexPath, 'utf-8'))
 }
 
-export async function fetchIndex(registryUrl: string): Promise<MetaIndex> {
-  const url = registryUrl.endsWith('/')
+function registryIndexUrl(registryUrl: string): string {
+  return registryUrl.endsWith('/')
     ? `${registryUrl}index.json`
     : `${registryUrl}/index.json`
+}
+
+export async function fetchIndex(registryUrl: string): Promise<MetaIndex> {
+  const url = registryIndexUrl(registryUrl)
   const res = await fetch(url, { signal: AbortSignal.timeout(10_000) }).catch((err: Error) => {
     console.error(`Error: Failed to fetch registry at ${url}: ${err.message}`)
     process.exit(1)
@@ -34,6 +38,17 @@ export async function fetchIndex(registryUrl: string): Promise<MetaIndex> {
     process.exit(1)
   }
   throw new Error('unreachable')
+}
+
+export async function tryFetchIndex(registryUrl: string): Promise<MetaIndex | null> {
+  const url = registryIndexUrl(registryUrl)
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(5_000) })
+    if (!res.ok) return null
+    return await res.json()
+  } catch {
+    return null
+  }
 }
 
 export async function fetchRegistryItem(registryUrl: string, name: string): Promise<RegistryItem> {

--- a/packages/cli/src/lib/pm.ts
+++ b/packages/cli/src/lib/pm.ts
@@ -161,7 +161,7 @@ export function testRunnerFor(pm: PackageManager): TestRunner {
   return {
     importSource: 'vitest',
     scriptValue: 'vitest run',
-    devDeps: { vitest: '^2.0.0' },
+    devDeps: { '@types/node': '^22.0.0', vitest: '^2.0.0' },
     typesEntry: '',
   }
 }


### PR DESCRIPTION
## Summary

Alpha onboarding validation: scaffolded test apps with all three JS adapters (hono, hono-node, csr), tested the full developer workflow, and fixed friction points.

### Friction fixes

1. **`bf search` auto-fallback to upstream registry** — When local search yields 0 component hits, automatically queries `ui.barefootjs.dev` and shows results with an "Install with: bf add <name>" hint. No change when local results exist.

2. **Hono (Workers) scaffold: `tsc --noEmit` now passes** — Added `@types/node` to devDependencies and `"node"` to tsconfig `types` array so test files using `fs`/`path`/`__dirname` (via `renderToTest`) type-check out of the box.

3. **Exclude generated build output from TypeScript checking** — Both Hono adapters now exclude `public/components/` / `dist/components/` from TS checking and prefer source files over compiled output in `paths` resolution order, eliminating spurious TS7006 errors from compiler-generated code.

### Onboarding validation results

| Step | hono | hono-node | csr |
|------|------|-----------|-----|
| `create-barefootjs` scaffold | ✅ | ✅ | ✅ |
| `npm install` | ✅ | ✅ | ✅ |
| `bf build` | ✅ (0 errors) | ✅ (0 errors) | ✅ (0 errors) |
| `npm test` (vitest) | ✅ (7/7) | ✅ (7/7) | ✅ (7/7) |
| `tsc --noEmit` | ✅ (after fix) | ✅ (after fix) | ✅ |
| `bf add` components | ✅ | ✅ | ✅ |
| `bf docs` / `bf guide` | ✅ | ✅ | ✅ |
| `bf search` (local + fallback) | ✅ | ✅ | ✅ |
| `bf gen component` | ✅ | ✅ | — |
| `bf gen test` | ✅ | ✅ | — |
| `bf debug graph` | ✅ | ✅ | — |
| Dev server SSR | — | ✅ | — |
| Custom `"use client"` component | ✅ | ✅ | — |

### Apps tested
- **Counter** (default scaffold) — signals, memos, event handlers
- **Greeting** — conditional rendering, props reactivity
- **TodoApp** — list rendering with `.map()`, signals with complex state (array of objects), memos, multiple event handlers (click, input, keydown), child component composition (Button, Checkbox)

## Test plan

- [x] All 642 CLI tests pass
- [x] All 14 create-barefootjs tests pass
- [x] Fresh scaffold: `bf build` + `vitest run` + `tsc --noEmit` all green (hono, hono-node, csr)
- [x] `bf search <query>` auto-falls back to registry when no local component hits
- [x] Custom `"use client"` component compiles, renders SSR, and passes `bf gen test`

https://claude.ai/code/session_01PkXn8ydJci3rWAaLqKGec5