### PR TITLE
feat(cli): bf search merges local + registry by default

### DIFF
--- a/packages/cli/src/__tests__/search.test.ts
+++ b/packages/cli/src/__tests__/search.test.ts
@@ -280,10 +280,15 @@ describe('printSearchResults', () => {
     { name: 'button', type: 'component', source: 'local', category: 'input', description: 'A button' },
   ]
 
-  test('prints SOURCE column in table header', () => {
+  test('prints SOURCE column after CATEGORY in table header', () => {
     printSearchResults(oneResult, false)
-    expect(logs[0]).toContain('SOURCE')
-    expect(logs[0]).toContain('NAME')
+    const header = logs[0]
+    expect(header).toContain('SOURCE')
+    const catIdx = header.indexOf('CATEGORY')
+    const srcIdx = header.indexOf('SOURCE')
+    const descIdx = header.indexOf('DESCRIPTION')
+    expect(catIdx).toBeLessThan(srcIdx)
+    expect(srcIdx).toBeLessThan(descIdx)
   })
 
   test('prints source value in each row', () => {

--- a/packages/cli/src/__tests__/search.test.ts
+++ b/packages/cli/src/__tests__/search.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, spyOn, beforeEach, afterEach } from 'bun:test'
-import { search, resolvePrintOptions, printSearchResults, type SearchResult } from '../commands/search'
+import { search, printSearchResults, mergeResults, type SearchResult } from '../commands/search'
 import { loadIndex, fetchIndex, tryFetchIndex } from '../lib/meta-loader'
 import { scanCoreDocs } from '../lib/docs-loader'
 import type { MetaIndex } from '../lib/types'
@@ -12,12 +12,20 @@ describe('search', () => {
   const index = loadIndex(metaDir)
 
   test('finds component by name', () => {
-    const results = search('button', index)
+    const results = search('button', index, 'local')
     expect(results.some(r => r.name === 'button')).toBe(true)
   })
 
+  test('tags results with the given source', () => {
+    const local = search('button', index, 'local')
+    expect(local.filter(r => r.type === 'component').every(r => r.source === 'local')).toBe(true)
+
+    const reg = search('button', index, 'registry')
+    expect(reg.filter(r => r.type === 'component').every(r => r.source === 'registry')).toBe(true)
+  })
+
   test('finds component by category', () => {
-    const results = search('input', index)
+    const results = search('input', index, 'local')
     expect(results.length).toBeGreaterThan(0)
     expect(results.every(r =>
       r.name.includes('input') ||
@@ -27,8 +35,7 @@ describe('search', () => {
   })
 
   test('finds component by tag', () => {
-    const results = search('button', index)
-    // All results should match "button" in name, category, or description
+    const results = search('button', index, 'local')
     expect(results.every(r =>
       r.name.includes('button') ||
       r.category.includes('button') ||
@@ -37,19 +44,18 @@ describe('search', () => {
   })
 
   test('expands category aliases (form → input)', () => {
-    const results = search('form', index)
+    const results = search('form', index, 'local')
     const hasInputCategory = results.some(r => r.category === 'input')
     expect(hasInputCategory).toBe(true)
   })
 
   test('returns empty array for no match', () => {
-    const results = search('zzz_nonexistent_zzz', index)
+    const results = search('zzz_nonexistent_zzz', index, 'local')
     expect(results).toEqual([])
   })
 
   test('--dir override: searches in arbitrary directory', () => {
-    // search() accepts any MetaIndex, verifying --dir plumbing works
-    const results = search('button', index)
+    const results = search('button', index, 'local')
     expect(results.some(r => r.name === 'button')).toBe(true)
   })
 
@@ -177,116 +183,85 @@ describe('search - core docs', () => {
   const coreDocs = scanCoreDocs(docsDir)
 
   test('finds core doc by slug', () => {
-    const results = search('create-signal', index, coreDocs)
+    const results = search('create-signal', index, 'local', coreDocs)
     expect(results.some(r => r.type === 'doc' && r.name.includes('create-signal'))).toBe(true)
   })
 
+  test('doc results have source "doc"', () => {
+    const results = search('create-signal', index, 'local', coreDocs)
+    const docs = results.filter(r => r.type === 'doc')
+    expect(docs.length).toBeGreaterThan(0)
+    expect(docs.every(r => r.source === 'doc')).toBe(true)
+  })
+
   test('finds core doc by description keyword', () => {
-    const results = search('hydration', index, coreDocs)
+    const results = search('hydration', index, 'local', coreDocs)
     expect(results.some(r => r.type === 'doc')).toBe(true)
   })
 
   test('mixed results: components + docs', () => {
-    // "input" matches both input components and possibly some docs
-    const results = search('input', index, coreDocs)
+    const results = search('input', index, 'local', coreDocs)
     expect(results.some(r => r.type === 'component')).toBe(true)
   })
 
   test('category alias: "signal" matches "reactivity" docs', () => {
-    const results = search('signal', index, coreDocs)
+    const results = search('signal', index, 'local', coreDocs)
     const reactivityDocs = results.filter(r => r.type === 'doc' && r.category === 'reactivity')
     expect(reactivityDocs.length).toBeGreaterThan(0)
   })
 
   test('returns empty when no match in either source', () => {
-    const results = search('zzz_nonexistent_zzz', index, coreDocs)
+    const results = search('zzz_nonexistent_zzz', index, 'local', coreDocs)
     expect(results).toEqual([])
   })
 })
 
-describe('resolvePrintOptions — source label + hint trigger', () => {
-  // The hint exists so `bf search` from a fresh scaffold doesn't read
-  // as "this component doesn't exist" when in fact it lives in the
-  // upstream registry the caller hasn't `--registry`'d yet. The hint
-  // SHOULD fire on the default path and SHOULD NOT fire when the
-  // caller already made an explicit scope choice (`--registry` /
-  // `--dir`) or when the metaDir already IS the monorepo registry.
-
-  test('scaffold default: relative path label + registry hint', () => {
-    const opts = resolvePrintOptions({
-      dirFlagUsed: false,
-      metaDir: '/proj/meta',
-      cwd: '/proj',
-      isMonorepoRegistry: false,
-    })
-    expect(opts.sourceLabel).toBe('meta')
-    expect(opts.hintRegistry).toBe(true)
+describe('mergeResults', () => {
+  test('deduplicates by name, local wins', () => {
+    const local: SearchResult[] = [
+      { name: 'button', type: 'component', source: 'local', category: 'input', description: 'local button' },
+    ]
+    const registry: SearchResult[] = [
+      { name: 'button', type: 'component', source: 'registry', category: 'input', description: 'registry button' },
+      { name: 'dialog', type: 'component', source: 'registry', category: 'overlay', description: 'a dialog' },
+    ]
+    const merged = mergeResults(local, registry)
+    expect(merged).toHaveLength(2)
+    expect(merged.find(r => r.name === 'button')!.source).toBe('local')
+    expect(merged.find(r => r.name === 'dialog')!.source).toBe('registry')
   })
 
-  test('cwd === metaDir: label collapses to "."', () => {
-    const opts = resolvePrintOptions({
-      dirFlagUsed: false,
-      metaDir: '/proj/meta',
-      cwd: '/proj/meta',
-      isMonorepoRegistry: false,
-    })
-    expect(opts.sourceLabel).toBe('.')
+  test('preserves doc results from local', () => {
+    const local: SearchResult[] = [
+      { name: 'reactivity/create-signal', type: 'doc', source: 'doc', category: 'reactivity', description: 'signal doc' },
+    ]
+    const registry: SearchResult[] = [
+      { name: 'slider', type: 'component', source: 'registry', category: 'input', description: 'a slider' },
+    ]
+    const merged = mergeResults(local, registry)
+    expect(merged).toHaveLength(2)
+    expect(merged.some(r => r.type === 'doc')).toBe(true)
   })
 
-  test('monorepo registry fallback: shows the real path + suppresses the hint', () => {
-    // `createContext` falls back to `<repo>/ui/meta` when no
-    // barefoot.config.ts is found. The hint pointing at the upstream
-    // registry would be redundant there (that's exactly the data the
-    // upstream is built from), so it's suppressed.
-    const opts = resolvePrintOptions({
-      dirFlagUsed: false,
-      metaDir: '/repo/ui/meta',
-      cwd: '/repo',
-      isMonorepoRegistry: true,
-    })
-    expect(opts.sourceLabel).toBe('ui/meta')
-    expect(opts.hintRegistry).toBe(false)
+  test('empty local returns all registry', () => {
+    const merged = mergeResults([], [
+      { name: 'tooltip', type: 'component', source: 'registry', category: 'overlay', description: 'tooltip' },
+    ])
+    expect(merged).toHaveLength(1)
+    expect(merged[0].source).toBe('registry')
   })
 
-  test('--registry <url>: hostname label, no hint', () => {
-    const opts = resolvePrintOptions({
-      registryUrl: 'https://ui.barefootjs.dev/r/',
-      dirFlagUsed: false,
-      metaDir: '/proj/meta',
-      cwd: '/proj',
-      isMonorepoRegistry: false,
-    })
-    expect(opts.sourceLabel).toBe('ui.barefootjs.dev')
-    expect(opts.hintRegistry).toBe(false)
-  })
-
-  test('--dir <path>: relative path label, no hint', () => {
-    const opts = resolvePrintOptions({
-      dirFlagUsed: true,
-      metaDir: '/proj/custom/meta',
-      cwd: '/proj',
-      isMonorepoRegistry: false,
-    })
-    expect(opts.sourceLabel).toBe('custom/meta')
-    expect(opts.hintRegistry).toBe(false)
-  })
-
-  test('metaDir outside cwd: falls back to absolute path', () => {
-    const opts = resolvePrintOptions({
-      dirFlagUsed: true,
-      metaDir: '/elsewhere/meta',
-      cwd: '/proj',
-      isMonorepoRegistry: false,
-    })
-    // path.relative returns "../elsewhere/meta"; the leading "..\"
-    // triggers the absolute-path fallback so the label can't be
-    // mistaken for a sibling of the project.
-    expect(opts.sourceLabel).toBe('/elsewhere/meta')
-    expect(opts.hintRegistry).toBe(false)
+  test('empty registry returns all local', () => {
+    const local: SearchResult[] = [
+      { name: 'button', type: 'component', source: 'local', category: 'input', description: 'btn' },
+    ]
+    const merged = mergeResults(local, [])
+    expect(merged).toHaveLength(1)
+    expect(merged[0].source).toBe('local')
   })
 })
 
-describe('printSearchResults — registry hint surface', () => {
+describe('printSearchResults', () => {
   let logSpy: ReturnType<typeof spyOn>
   let logs: string[]
 
@@ -302,30 +277,35 @@ describe('printSearchResults — registry hint surface', () => {
   })
 
   const oneResult: SearchResult[] = [
-    { name: 'button', type: 'component', category: 'input', description: 'A button' },
+    { name: 'button', type: 'component', source: 'local', category: 'input', description: 'A button' },
   ]
 
-  test('prints the source label + registry hint on default path', () => {
-    printSearchResults(oneResult, false, { sourceLabel: 'meta', hintRegistry: true })
-    expect(logs[0]).toBe('Searching: meta')
-    expect(logs[1]).toContain('--registry https://ui.barefootjs.dev/r/')
+  test('prints SOURCE column in table header', () => {
+    printSearchResults(oneResult, false)
+    expect(logs[0]).toContain('SOURCE')
+    expect(logs[0]).toContain('NAME')
   })
 
-  test('omits the hint when caller passed --registry', () => {
-    printSearchResults(oneResult, false, { sourceLabel: 'ui.barefootjs.dev', hintRegistry: false })
-    expect(logs[0]).toBe('Searching: ui.barefootjs.dev')
-    expect(logs.some((l) => l.includes('--registry'))).toBe(false)
+  test('prints source value in each row', () => {
+    const mixed: SearchResult[] = [
+      { name: 'button', type: 'component', source: 'local', category: 'input', description: 'local btn' },
+      { name: 'dialog', type: 'component', source: 'registry', category: 'overlay', description: 'reg dialog' },
+    ]
+    printSearchResults(mixed, false)
+    const rows = logs.filter(l => !l.startsWith('NAME') && !l.startsWith('-') && !l.includes('found') && !l.includes('bf'))
+    expect(rows.some(r => r.includes('local'))).toBe(true)
+    expect(rows.some(r => r.includes('registry'))).toBe(true)
   })
 
-  test('hint fires even when the result set is empty (the case the hint exists for)', () => {
-    printSearchResults([], false, { sourceLabel: 'meta', hintRegistry: true })
-    expect(logs.some((l) => l.includes('--registry https://ui.barefootjs.dev/r/'))).toBe(true)
-    expect(logs.some((l) => l === 'No results found.')).toBe(true)
+  test('shows "No results found." for empty results', () => {
+    printSearchResults([], false)
+    expect(logs.some(l => l === 'No results found.')).toBe(true)
   })
 
-  test('--json: header is suppressed (machine output stays just the JSON)', () => {
-    printSearchResults(oneResult, true, { sourceLabel: 'meta', hintRegistry: true })
+  test('--json includes source field', () => {
+    printSearchResults(oneResult, true)
     expect(logs).toHaveLength(1)
-    expect(JSON.parse(logs[0])).toEqual(oneResult)
+    const parsed = JSON.parse(logs[0])
+    expect(parsed[0].source).toBe('local')
   })
 })

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -1,4 +1,6 @@
 // bf search — find components and documentation by name, category, or tags.
+// Default: searches both local meta/ and the upstream registry, tagging
+// each result with its source. --dir or --registry restrict to a single source.
 
 import path from 'path'
 import type { CliContext } from '../context'
@@ -6,10 +8,6 @@ import type { MetaIndex } from '../lib/types'
 import { loadIndex, fetchIndex, tryFetchIndex } from '../lib/meta-loader'
 import { scanCoreDocs, type CoreDocMeta } from '../lib/docs-loader'
 
-// Default upstream UI component registry. Surfaced in the hint footer
-// when search is running against local meta only, so users (and AI
-// agents) discover that the registry exists without having to know to
-// pass --registry. Mirrored from add.ts / init.ts.
 const DEFAULT_REGISTRY_URL = 'https://ui.barefootjs.dev/r/'
 
 // Category aliases for better search (e.g., "form" → "input" components)
@@ -23,15 +21,18 @@ const categoryAliases: Record<string, string[]> = {
   'template': ['adapters'],
 }
 
+export type ResultSource = 'local' | 'registry' | 'doc'
+
 export interface SearchResult {
   name: string
   type: 'component' | 'doc'
+  source: ResultSource
   category: string
   description: string
   stateful?: boolean
 }
 
-export function search(query: string, index: MetaIndex, coreDocs?: CoreDocMeta[]): SearchResult[] {
+export function search(query: string, index: MetaIndex, source: ResultSource, coreDocs?: CoreDocMeta[]): SearchResult[] {
   const q = query.toLowerCase()
   const aliasCategories = categoryAliases[q] || []
 
@@ -46,6 +47,7 @@ export function search(query: string, index: MetaIndex, coreDocs?: CoreDocMeta[]
     .map(c => ({
       name: c.name,
       type: 'component' as const,
+      source,
       category: c.category,
       description: c.description,
       stateful: c.stateful,
@@ -62,6 +64,7 @@ export function search(query: string, index: MetaIndex, coreDocs?: CoreDocMeta[]
     .map(d => ({
       name: d.slug,
       type: 'doc' as const,
+      source: 'doc' as const,
       category: d.category,
       description: d.description,
     }))
@@ -69,90 +72,29 @@ export function search(query: string, index: MetaIndex, coreDocs?: CoreDocMeta[]
   return [...componentResults, ...docResults]
 }
 
-export interface PrintOptions {
-  /** Where component results came from (e.g. `local meta/`, hostname). */
-  sourceLabel: string
-  /**
-   * `true` when search is running against local meta/ and no
-   * `--registry` was given — adds a one-line hint pointing at the
-   * upstream registry so the caller (or an AI agent) doesn't conclude
-   * a component is unavailable just because it hasn't been added to
-   * the project yet.
-   */
-  hintRegistry: boolean
-}
-
-/**
- * Resolve the PrintOptions describing what source `run()` is about to
- * search. Exported so the labelling rules (and the registry hint
- * trigger) are unit-testable without spawning the CLI.
- */
-export function resolvePrintOptions(opts: {
-  registryUrl?: string
-  dirFlagUsed: boolean
-  metaDir: string
-  cwd: string
-  /**
-   * `true` when the metaDir resolves into the BarefootJS monorepo's
-   * own `ui/meta/` registry — i.e. the fallback `createContext` picks
-   * when no `barefoot.config.ts` is found. The hint pointing at
-   * `ui.barefootjs.dev/r/` would be redundant there because that
-   * directory IS the source the published registry is built from.
-   */
-  isMonorepoRegistry: boolean
-}): PrintOptions {
-  if (opts.registryUrl) {
-    return {
-      sourceLabel: new URL(opts.registryUrl).hostname,
-      hintRegistry: false,
-    }
-  }
-  // Always show the actual path so the label can never lie. Default
-  // `metaDir` is the project's own `meta/` when invoked inside a
-  // scaffold, but falls back to the monorepo's `ui/meta/` (~30
-  // components) when no `barefoot.config.ts` is found — a fixed
-  // "local meta/" label hid that distinction and made the hint read
-  // as a contradiction in the monorepo case.
-  const rel = path.relative(opts.cwd, opts.metaDir)
-  const display = rel === '' ? '.' : rel.startsWith('..') ? opts.metaDir : rel
-  return {
-    sourceLabel: display,
-    // Skip the upstream-registry hint when reading from the monorepo's
-    // own registry source — that IS what the published registry mirrors.
-    // `--dir` is an explicit scope choice, so skip the hint there too.
-    hintRegistry: !opts.isMonorepoRegistry && !opts.dirFlagUsed,
-  }
-}
-
-export function printSearchResults(results: SearchResult[], jsonFlag: boolean, opts: PrintOptions) {
+export function printSearchResults(results: SearchResult[], jsonFlag: boolean) {
   if (jsonFlag) {
     console.log(JSON.stringify(results, null, 2))
     return
   }
-
-  console.log(`Searching: ${opts.sourceLabel}`)
-  if (opts.hintRegistry) {
-    console.log(
-      `(run with --registry ${DEFAULT_REGISTRY_URL} to also search the upstream component registry)`,
-    )
-  }
-  console.log()
 
   if (results.length === 0) {
     console.log('No results found.')
     return
   }
 
-  // Table format
   const nameWidth = Math.max(25, ...results.map(r => r.name.length + 2))
+  const sourceWidth = 12
   const typeWidth = 12
   const catWidth = 16
-  const header = `${'NAME'.padEnd(nameWidth)}${'TYPE'.padEnd(typeWidth)}${'CATEGORY'.padEnd(catWidth)}DESCRIPTION`
+  const header = `${'NAME'.padEnd(nameWidth)}${'SOURCE'.padEnd(sourceWidth)}${'TYPE'.padEnd(typeWidth)}${'CATEGORY'.padEnd(catWidth)}DESCRIPTION`
   console.log(header)
   console.log('-'.repeat(header.length))
   for (const r of results) {
     const statefulMark = r.stateful ? ' *' : ''
-    console.log(`${(r.name + statefulMark).padEnd(nameWidth)}${r.type.padEnd(typeWidth)}${r.category.padEnd(catWidth)}${r.description.slice(0, 50)}`)
+    console.log(
+      `${(r.name + statefulMark).padEnd(nameWidth)}${r.source.padEnd(sourceWidth)}${r.type.padEnd(typeWidth)}${r.category.padEnd(catWidth)}${r.description.slice(0, 40)}`
+    )
   }
 
   const componentCount = results.filter(r => r.type === 'component').length
@@ -161,12 +103,23 @@ export function printSearchResults(results: SearchResult[], jsonFlag: boolean, o
   if (componentCount > 0) parts.push(`${componentCount} component(s)`)
   if (docCount > 0) parts.push(`${docCount} doc(s)`)
   console.log(`\n${parts.join(', ')} found. (* = stateful)`)
-  console.log(`Use 'bf docs <name>' or 'bf guide <name>' for details.`)
+  console.log(`Use 'bf docs <name>' or 'bf add <name>' for details / install.`)
+}
+
+/**
+ * Merge local and registry results, deduplicating by name.
+ * Local wins over registry (component is already installed).
+ */
+export function mergeResults(local: SearchResult[], registry: SearchResult[]): SearchResult[] {
+  const localNames = new Set(local.filter(r => r.type === 'component').map(r => r.name))
+  const dedupedRegistry = registry.filter(r => !localNames.has(r.name))
+  return [...local, ...dedupedRegistry]
 }
 
 export async function run(args: string[], ctx: CliContext): Promise<void> {
   // Parse --dir flag
   let metaDir = ctx.metaDir
+  let dirFlagUsed = false
   const dirIdx = args.indexOf('--dir')
   if (dirIdx !== -1) {
     const dirValue = args[dirIdx + 1]
@@ -175,6 +128,7 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
       process.exit(1)
     }
     metaDir = path.resolve(dirValue)
+    dirFlagUsed = true
     args = [...args.slice(0, dirIdx), ...args.slice(dirIdx + 2)]
   }
 
@@ -191,76 +145,58 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
     args = [...args.slice(0, regIdx), ...args.slice(regIdx + 2)]
   }
 
-  // Mutual exclusion
-  if (dirIdx !== -1 && registryUrl) {
+  if (dirFlagUsed && registryUrl) {
     console.error('Error: --dir and --registry cannot be used together.')
     process.exit(1)
   }
-
-  // Load component index from local or remote source
-  const index = registryUrl
-    ? await fetchIndex(registryUrl)
-    : loadIndex(metaDir)
-
-  // Surface the source so callers (and AI agents) don't silently miss
-  // the upstream registry when running against local meta/ only.
-  // `projectDir === null` means `createContext` fell back to the
-  // monorepo's `ui/meta/` (no `barefoot.config.ts` found walking up
-  // from cwd); the upstream hint would point at the same data so we
-  // suppress it there.
-  const printOpts = resolvePrintOptions({
-    registryUrl,
-    dirFlagUsed: dirIdx !== -1,
-    metaDir,
-    cwd: process.cwd(),
-    isMonorepoRegistry: ctx.projectDir === null,
-  })
 
   // Load core docs (skip gracefully if not available)
   const docsDir = path.join(ctx.root, 'docs/core')
   const coreDocs = scanCoreDocs(docsDir)
 
   const query = args.join(' ')
-  if (!query) {
-    // No query: list all
-    const allResults: SearchResult[] = [
-      ...index.components.map(c => ({
-        name: c.name,
-        type: 'component' as const,
-        category: c.category,
-        description: c.description,
-        stateful: c.stateful,
-      })),
-      ...coreDocs.map(d => ({
-        name: d.slug,
-        type: 'doc' as const,
-        category: d.category,
-        description: d.description,
-      })),
-    ]
-    printSearchResults(allResults, ctx.jsonFlag, printOpts)
-  } else {
-    const results = search(query, index, coreDocs)
-    const hasComponentHits = results.some(r => r.type === 'component')
 
-    if (!hasComponentHits && printOpts.hintRegistry) {
-      const upstreamIndex = await tryFetchIndex(DEFAULT_REGISTRY_URL)
-      if (upstreamIndex) {
-        const upstreamResults = search(query, upstreamIndex)
-        if (upstreamResults.length > 0) {
-          const upstreamOpts: PrintOptions = {
-            sourceLabel: new URL(DEFAULT_REGISTRY_URL).hostname,
-            hintRegistry: false,
-          }
-          printSearchResults(upstreamResults, ctx.jsonFlag, upstreamOpts)
-          if (!ctx.jsonFlag) {
-            console.log(`\nInstall with: bf add <name>`)
-          }
-          return
-        }
-      }
-    }
-
-    printSearchResults(results, ctx.jsonFlag, printOpts)
+  // Explicit --registry: search only that registry
+  if (registryUrl) {
+    const index = await fetchIndex(registryUrl)
+    const results = query
+      ? search(query, index, 'registry', coreDocs)
+      : index.components.map(c => ({ name: c.name, type: 'component' as const, source: 'registry' as const, category: c.category, description: c.description, stateful: c.stateful }))
+    printSearchResults(results, ctx.jsonFlag)
+    return
   }
+
+  // Explicit --dir: search only that directory
+  if (dirFlagUsed) {
+    const index = loadIndex(metaDir)
+    const results = query
+      ? search(query, index, 'local', coreDocs)
+      : index.components.map(c => ({ name: c.name, type: 'component' as const, source: 'local' as const, category: c.category, description: c.description, stateful: c.stateful }))
+    printSearchResults(results, ctx.jsonFlag)
+    return
+  }
+
+  // Default: search both local + upstream registry
+  const localIndex = loadIndex(metaDir)
+  const localResults = query
+    ? search(query, localIndex, 'local', coreDocs)
+    : [
+        ...localIndex.components.map(c => ({ name: c.name, type: 'component' as const, source: 'local' as const, category: c.category, description: c.description, stateful: c.stateful })),
+        ...coreDocs.map(d => ({ name: d.slug, type: 'doc' as const, source: 'doc' as const, category: d.category, description: d.description })),
+      ]
+
+  // Skip upstream fetch when inside the monorepo (local IS the registry source)
+  const isMonorepo = ctx.projectDir === null
+  let registryResults: SearchResult[] = []
+  if (!isMonorepo) {
+    const upstreamIndex = await tryFetchIndex(DEFAULT_REGISTRY_URL)
+    if (upstreamIndex) {
+      registryResults = query
+        ? search(query, upstreamIndex, 'registry')
+        : upstreamIndex.components.map(c => ({ name: c.name, type: 'component' as const, source: 'registry' as const, category: c.category, description: c.description, stateful: c.stateful }))
+    }
+  }
+
+  const merged = mergeResults(localResults, registryResults)
+  printSearchResults(merged, ctx.jsonFlag)
 }

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -93,7 +93,7 @@ export function printSearchResults(results: SearchResult[], jsonFlag: boolean) {
   for (const r of results) {
     const statefulMark = r.stateful ? ' *' : ''
     console.log(
-      `${(r.name + statefulMark).padEnd(nameWidth)}${r.type.padEnd(typeWidth)}${r.category.padEnd(catWidth)}${r.source.padEnd(sourceWidth)}${r.description.slice(0, 40)}`
+      `${(r.name + statefulMark).padEnd(nameWidth)}${r.type.padEnd(typeWidth)}${r.category.padEnd(catWidth)}${r.source.padEnd(sourceWidth)}${r.description.slice(0, 50)}`
     )
   }
 
@@ -150,33 +150,31 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
     process.exit(1)
   }
 
-  // Load core docs (skip gracefully if not available)
-  const docsDir = path.join(ctx.root, 'docs/core')
-  const coreDocs = scanCoreDocs(docsDir)
-
   const query = args.join(' ')
 
-  // Explicit --registry: search only that registry
+  // Explicit --registry: search only that registry (no local docs)
   if (registryUrl) {
     const index = await fetchIndex(registryUrl)
     const results = query
-      ? search(query, index, 'registry', coreDocs)
+      ? search(query, index, 'registry')
       : index.components.map(c => ({ name: c.name, type: 'component' as const, source: 'registry' as const, category: c.category, description: c.description, stateful: c.stateful }))
     printSearchResults(results, ctx.jsonFlag)
     return
   }
 
-  // Explicit --dir: search only that directory
+  // Explicit --dir: search only that directory (no local docs)
   if (dirFlagUsed) {
     const index = loadIndex(metaDir)
     const results = query
-      ? search(query, index, 'local', coreDocs)
+      ? search(query, index, 'local')
       : index.components.map(c => ({ name: c.name, type: 'component' as const, source: 'local' as const, category: c.category, description: c.description, stateful: c.stateful }))
     printSearchResults(results, ctx.jsonFlag)
     return
   }
 
   // Default: search both local + upstream registry
+  const docsDir = path.join(ctx.root, 'docs/core')
+  const coreDocs = scanCoreDocs(docsDir)
   const localIndex = loadIndex(metaDir)
   const localResults = query
     ? search(query, localIndex, 'local', coreDocs)

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -84,16 +84,16 @@ export function printSearchResults(results: SearchResult[], jsonFlag: boolean) {
   }
 
   const nameWidth = Math.max(25, ...results.map(r => r.name.length + 2))
-  const sourceWidth = 12
   const typeWidth = 12
   const catWidth = 16
-  const header = `${'NAME'.padEnd(nameWidth)}${'SOURCE'.padEnd(sourceWidth)}${'TYPE'.padEnd(typeWidth)}${'CATEGORY'.padEnd(catWidth)}DESCRIPTION`
+  const sourceWidth = 12
+  const header = `${'NAME'.padEnd(nameWidth)}${'TYPE'.padEnd(typeWidth)}${'CATEGORY'.padEnd(catWidth)}${'SOURCE'.padEnd(sourceWidth)}DESCRIPTION`
   console.log(header)
   console.log('-'.repeat(header.length))
   for (const r of results) {
     const statefulMark = r.stateful ? ' *' : ''
     console.log(
-      `${(r.name + statefulMark).padEnd(nameWidth)}${r.source.padEnd(sourceWidth)}${r.type.padEnd(typeWidth)}${r.category.padEnd(catWidth)}${r.description.slice(0, 40)}`
+      `${(r.name + statefulMark).padEnd(nameWidth)}${r.type.padEnd(typeWidth)}${r.category.padEnd(catWidth)}${r.source.padEnd(sourceWidth)}${r.description.slice(0, 40)}`
     )
   }
 


### PR DESCRIPTION
## Summary

`bf search` now queries both local `meta/` and the upstream registry in a single invocation, with a `SOURCE` column showing where each result came from.

**Before:**
```
$ bf search tooltip
Searching: meta
(run with --registry https://ui.barefootjs.dev/r/ to also search the upstream component registry)

No results found.
```

**After:**
```
$ bf search button
NAME                     TYPE        CATEGORY        SOURCE      DESCRIPTION
----------------------------------------------------------------------------
button                   component   input           local       Button Component A versatile button comp
slot                     component   display         local       Slot Component A polymorphic component t
button-group             component   display         registry    ButtonGroup Component A container that g
toggle *                 component   input           registry    Toggle Component A two-state button that

12 component(s) found. (* = stateful)
Use 'bf docs <name>' or 'bf add <name>' for details / install.
```

### Changes

- `SearchResult` gains a `source` field (`'local'` | `'registry'` | `'doc'`)
- Default search: local + upstream registry merged, local wins on duplicates
- Column order: `NAME | TYPE | CATEGORY | SOURCE | DESCRIPTION`
- `--registry` / `--dir` still restrict to a single source
- Offline: registry portion silently skipped (`tryFetchIndex`)
- Monorepo: upstream fetch skipped (local IS the registry source)
- Removed `Searching:` header and `--registry` hint (no longer needed)
- `mergeResults()` exported + tested (4 dedup cases)

## Test plan

- [x] All 646 CLI tests pass (31 search tests)
- [x] `bf search button` — local button shown as `local`, registry-only results as `registry`, no duplicates
- [x] `bf search tooltip` — no local match, registry results shown with `registry` source
- [x] `bf search signal` — docs (`doc`) + registry components merged with correct source labels
- [x] `--registry` flag still works for explicit single-source search
- [x] Offline fallback: `tryFetchIndex` returns null, local-only results shown

https://claude.ai/code/session_01PkXn8ydJci3rWAaLqKGec5