### PR TITLE
fix: handle multi-line doc comments in Go type deduplication

### DIFF
--- a/integrations/echo/components.go
+++ b/integrations/echo/components.go
@@ -390,6 +390,19 @@ func NewTodoItemProps(in TodoItemInput) TodoItemProps {
 }
 
 // NewTodoAppProps creates TodoAppProps from TodoAppInput.
+//
+// NOTE: `TodoItems` is populated by the route handler, not by
+// NewTodoAppProps — the SSR template iterates over it
+// dynamically (`.TodoItems`). Build the slice from your source data and
+// assign it before passing the props to your renderer. Example:
+//
+//   props := NewTodoAppProps(TodoAppInput{ /* ... */ })
+//   props.TodoItems = make([]TodoItemProps, len(items))
+//   for i, item := range items {
+//     props.TodoItems[i] = NewTodoItemProps(TodoItemInput{ /* fields */ })
+//     props.TodoItems[i].BfParent = props.ScopeID
+//     props.TodoItems[i].BfMount = "s3"
+//   }
 func NewTodoAppProps(in TodoAppInput) TodoAppProps {
 	scopeID := in.ScopeID
 	if scopeID == "" {
@@ -569,6 +582,19 @@ func NewConditionalReturnProps(in ConditionalReturnInput) ConditionalReturnProps
 }
 
 // NewTodoAppSSRProps creates TodoAppSSRProps from TodoAppSSRInput.
+//
+// NOTE: `TodoItems` is populated by the route handler, not by
+// NewTodoAppSSRProps — the SSR template iterates over it
+// dynamically (`.TodoItems`). Build the slice from your source data and
+// assign it before passing the props to your renderer. Example:
+//
+//   props := NewTodoAppSSRProps(TodoAppSSRInput{ /* ... */ })
+//   props.TodoItems = make([]TodoItemProps, len(items))
+//   for i, item := range items {
+//     props.TodoItems[i] = NewTodoItemProps(TodoItemInput{ /* fields */ })
+//     props.TodoItems[i].BfParent = props.ScopeID
+//     props.TodoItems[i].BfMount = "s3"
+//   }
 func NewTodoAppSSRProps(in TodoAppSSRInput) TodoAppSSRProps {
 	scopeID := in.ScopeID
 	if scopeID == "" {

--- a/packages/adapter-go-template/src/__tests__/build.test.ts
+++ b/packages/adapter-go-template/src/__tests__/build.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'bun:test'
+import { deduplicateGoTypes } from '../build'
+
+describe('deduplicateGoTypes', () => {
+  test('deduplicates NewXxxProps with single-line doc comment', () => {
+    const input = [
+      '// NewFooProps creates FooProps from FooInput.',
+      'func NewFooProps(in FooInput) FooProps {',
+      '\treturn FooProps{}',
+      '}',
+      '',
+      '// NewFooProps creates FooProps from FooInput.',
+      'func NewFooProps(in FooInput) FooProps {',
+      '\tscopeID := in.ScopeID',
+      '\treturn FooProps{ScopeID: scopeID}',
+      '}',
+    ].join('\n')
+
+    const result = deduplicateGoTypes(input)
+    const matches = result.match(/func NewFooProps/g)
+    expect(matches).toHaveLength(1)
+    expect(result).toContain('ScopeID')
+  })
+
+  test('deduplicates NewXxxProps with multi-line doc comment', () => {
+    const input = [
+      '// NewBarProps creates BarProps from BarInput.',
+      '//',
+      '// NOTE: `Items` is populated by the route handler.',
+      'func NewBarProps(in BarInput) BarProps {',
+      '\treturn BarProps{}',
+      '}',
+      '',
+      '// NewBarProps creates BarProps from BarInput.',
+      '//',
+      '// NOTE: `Items` is populated by the route handler.',
+      'func NewBarProps(in BarInput) BarProps {',
+      '\tscopeID := in.ScopeID',
+      '\treturn BarProps{ScopeID: scopeID}',
+      '}',
+    ].join('\n')
+
+    const result = deduplicateGoTypes(input)
+    const matches = result.match(/func NewBarProps/g)
+    expect(matches).toHaveLength(1)
+    expect(result).toContain('ScopeID')
+  })
+
+  test('preserves multi-line doc comment in output', () => {
+    const input = [
+      '// NewBazProps creates BazProps from BazInput.',
+      '//',
+      '// NOTE: `Children` is populated by the route handler, not by',
+      '// NewBazProps — the SSR template iterates over it.',
+      'func NewBazProps(in BazInput) BazProps {',
+      '\tscopeID := in.ScopeID',
+      '\treturn BazProps{ScopeID: scopeID}',
+      '}',
+    ].join('\n')
+
+    const result = deduplicateGoTypes(input)
+    expect(result).toContain('NOTE: `Children` is populated by the route handler')
+    expect(result).toContain('func NewBazProps')
+  })
+})

--- a/packages/adapter-go-template/src/build.ts
+++ b/packages/adapter-go-template/src/build.ts
@@ -97,7 +97,7 @@ export function deduplicateGoTypes(combined: string): string {
   result = typeInsertions + '\n\n' + result
 
   // --- Pass 2: Deduplicate NewXxxProps functions (prefer version with ScopeID) ---
-  const funcRegex = /\/\/ (New\w+Props) creates .*\nfunc \1\([^)]*\) \w+ \{[\s\S]*?\n\}/g
+  const funcRegex = /\/\/ (New\w+Props) creates .*(?:\n\/\/.*)*\nfunc \1\([^)]*\) \w+ \{[\s\S]*?\n\}/g
   const bestFuncs = new Map<string, string>()
   while ((match = funcRegex.exec(result)) !== null) {
     const funcName = match[1]


### PR DESCRIPTION
## Summary

- The `funcRegex` in `deduplicateGoTypes` assumed a single-line doc comment (`// NewXxxProps creates ...\nfunc`), so it failed to match constructors with multi-line doc comments (emitted for components with dynamic nested arrays like TodoApp and TodoAppSSR). This caused unstable function ordering on every clean rebuild.
- Added `(?:\n\/\/.*)*` to the regex to allow additional `//` comment lines before `func`.
- Added unit tests for `deduplicateGoTypes` (single-line, multi-line, and comment preservation).
- Regenerated `integrations/echo/components.go`.

## Test plan

- [x] `bun test packages/adapter-go-template/src/__tests__/build.test.ts` — new unit tests pass
- [x] `bun test packages/adapter-go-template/` — all existing adapter tests pass
- [x] `bun run build` — clean build produces stable `components.go` (no ordering diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)