### PR TITLE
fix(publish): point all npm exports to dist/ instead of raw .ts source

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "setup": "bun install && bun run --filter 'barefootjs-echo-example' setup",
-    "build": "bun run --filter '@barefootjs/client' build && bun run --filter '@barefootjs/jsx' build && bun run --filter '@barefootjs/hono' --filter '@barefootjs/go-template' build && bun run --filter '*' build",
+    "build": "bun run --filter '@barefootjs/shared' build && bun run --filter '@barefootjs/streaming' build && bun run --filter '@barefootjs/jsx' build && bun run --filter '@barefootjs/client' build && bun run --filter '@barefootjs/hono' --filter '@barefootjs/go-template' --filter '@barefootjs/mojolicious' build && bun run --filter '*' build",
     "test": "bun test --cwd . __tests__",
     "test:e2e": "bun run --filter '*' test:e2e",
     "clean": "bun run --filter '*' clean",

--- a/packages/adapter-go-template/package.json
+++ b/packages/adapter-go-template/package.json
@@ -22,16 +22,37 @@
       "import": "./src/build.ts"
     }
   },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./adapter": {
+        "types": "./dist/adapter/index.d.ts",
+        "import": "./dist/adapter/index.js"
+      },
+      "./test-render": {
+        "bun": "./src/test-render.ts"
+      },
+      "./build": {
+        "types": "./dist/build.d.ts",
+        "import": "./dist/build.js"
+      }
+    }
+  },
   "files": [
     "dist",
     "src"
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts --outdir ./dist --format esm",
+    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared --external typescript",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "prepack": "node ../../scripts/swap-publish-config.mjs pack",
+    "postpack": "node ../../scripts/swap-publish-config.mjs unpack"
   },
   "keywords": [
     "go",

--- a/packages/adapter-go-template/package.json
+++ b/packages/adapter-go-template/package.json
@@ -47,7 +47,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared --external typescript",
+    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared --external typescript",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist",
@@ -68,11 +68,11 @@
     "directory": "packages/adapter-go-template"
   },
   "peerDependencies": {
-    "@barefootjs/jsx": "workspace:*"
+    "@barefootjs/jsx": "workspace:*",
+    "typescript": "^5.0.0"
   },
   "devDependencies": {
     "@barefootjs/adapter-tests": "workspace:*",
-    "@barefootjs/jsx": "workspace:*",
-    "typescript": "^5.0.0"
+    "@barefootjs/jsx": "workspace:*"
   }
 }

--- a/packages/adapter-hono/package.json
+++ b/packages/adapter-hono/package.json
@@ -76,74 +76,75 @@
   },
   "//publishConfig": "When npm/pkg-pr-new packs this package, swap each subpath's `types` to the dist/*.d.ts produced by `tsgo --emitDeclarationOnly`. Downstream consumers' `tsc --noEmit` then walks pure-declaration files instead of our TS source — which transitively pulled `process` / `fs` references and forced every scaffold to install @types/node. Runtime `import` still points at TS source so existing bun + esbuild paths keep working; a future change can repoint these to dist/*.js once subpath bundles exist.",
   "publishConfig": {
+    "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./src/index.ts"
+        "import": "./dist/index.js"
       },
       "./adapter": {
         "types": "./dist/adapter/index.d.ts",
-        "import": "./src/adapter/index.ts"
+        "import": "./dist/adapter/index.js"
       },
       "./scripts": {
         "types": "./dist/scripts.d.ts",
-        "import": "./src/scripts.tsx"
+        "import": "./dist/scripts.js"
       },
       "./portals": {
         "types": "./dist/portals.d.ts",
-        "import": "./src/portals.tsx"
+        "import": "./dist/portals.js"
       },
       "./portal": {
         "types": "./dist/portal-ssr.d.ts",
-        "import": "./src/portal-ssr.tsx"
+        "import": "./dist/portal-ssr.js"
       },
       "./dialog-context": {
         "types": "./dist/dialog-context.d.ts",
-        "import": "./src/dialog-context.tsx"
+        "import": "./dist/dialog-context.js"
       },
       "./client-shim": {
         "types": "./dist/client-shim.d.ts",
-        "import": "./src/client-shim.ts"
+        "import": "./dist/client-shim.js"
       },
       "./preload": {
         "types": "./dist/preload.d.ts",
-        "import": "./src/preload.tsx"
+        "import": "./dist/preload.js"
       },
       "./dev": {
         "types": "./dist/dev.d.ts",
-        "import": "./src/dev.tsx"
+        "import": "./dist/dev.js"
       },
       "./dev-worker": {
         "types": "./dist/dev-worker.d.ts",
-        "import": "./src/dev-worker.ts"
+        "import": "./dist/dev-worker.js"
       },
       "./jsx/jsx-runtime": {
         "types": "./dist/jsx/jsx-runtime/index.d.ts",
-        "import": "./src/jsx/jsx-runtime/index.ts"
+        "import": "./dist/jsx/jsx-runtime/index.js"
       },
       "./jsx/jsx-dev-runtime": {
         "types": "./dist/jsx/jsx-dev-runtime/index.d.ts",
-        "import": "./src/jsx/jsx-dev-runtime/index.ts"
+        "import": "./dist/jsx/jsx-dev-runtime/index.js"
       },
       "./async": {
         "types": "./dist/async.d.ts",
-        "import": "./src/async.tsx"
+        "import": "./dist/async.js"
       },
       "./utils": {
         "types": "./dist/utils.d.ts",
-        "import": "./src/utils.ts"
+        "import": "./dist/utils.js"
       },
       "./test-render": {
         "bun": "./src/test-render.ts"
       },
       "./build": {
         "types": "./dist/build.d.ts",
-        "import": "./src/build.ts"
+        "import": "./dist/build.js"
       },
       "./app": {
         "types": "./dist/app.d.ts",
-        "import": "./src/app.ts"
+        "import": "./dist/app.js"
       }
     }
   },
@@ -153,7 +154,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts --outdir ./dist --format esm",
+    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/scripts.tsx ./src/portals.tsx ./src/portal-ssr.tsx ./src/dialog-context.tsx ./src/client-shim.ts ./src/preload.tsx ./src/dev.tsx ./src/dev-worker.ts ./src/jsx/jsx-runtime/index.ts ./src/jsx/jsx-dev-runtime/index.ts ./src/async.tsx ./src/utils.ts ./src/build.ts ./src/app.ts --root ./src --outdir ./dist --format esm --external hono --external @barefootjs/client --external @barefootjs/jsx --external @barefootjs/shared",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist",

--- a/packages/adapter-hono/package.json
+++ b/packages/adapter-hono/package.json
@@ -74,7 +74,7 @@
       "import": "./src/app.ts"
     }
   },
-  "//publishConfig": "When npm/pkg-pr-new packs this package, swap each subpath's `types` to the dist/*.d.ts produced by `tsgo --emitDeclarationOnly`. Downstream consumers' `tsc --noEmit` then walks pure-declaration files instead of our TS source — which transitively pulled `process` / `fs` references and forced every scaffold to install @types/node. Runtime `import` still points at TS source so existing bun + esbuild paths keep working; a future change can repoint these to dist/*.js once subpath bundles exist.",
+  "//publishConfig": "At pack time, swap-publish-config.mjs merges these overrides into the top-level so the published tarball resolves all entry points to dist/ instead of src/. Workspace exports stay at src/ so bun resolves source directly during dev.",
   "publishConfig": {
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/packages/adapter-mojolicious/package.json
+++ b/packages/adapter-mojolicious/package.json
@@ -22,6 +22,25 @@
       "import": "./src/build.ts"
     }
   },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./adapter": {
+        "types": "./dist/adapter/index.d.ts",
+        "import": "./dist/adapter/index.js"
+      },
+      "./test-render": {
+        "bun": "./src/test-render.ts"
+      },
+      "./build": {
+        "types": "./dist/build.d.ts",
+        "import": "./dist/build.js"
+      }
+    }
+  },
   "files": [
     "dist",
     "src",
@@ -29,10 +48,12 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts --outdir ./dist --format esm",
+    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "prepack": "node ../../scripts/swap-publish-config.mjs pack",
+    "postpack": "node ../../scripts/swap-publish-config.mjs unpack"
   },
   "keywords": [
     "mojolicious",

--- a/packages/adapter-mojolicious/package.json
+++ b/packages/adapter-mojolicious/package.json
@@ -48,7 +48,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared",
+    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,6 +14,12 @@
     "node": ">=22"
   },
   "author": "kobaken <kentafly88@gmail.com>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/piconic-ai/barefootjs",
+    "directory": "packages/cli"
+  },
   "scripts": {
     "build": "node ./scripts/embed-runtimes.mjs && node ./scripts/build.mjs",
     "embed-runtimes": "node ./scripts/embed-runtimes.mjs",

--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -27,11 +27,11 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./src/index.ts"
+        "import": "./dist/index.js"
       },
       "./scanner": {
         "types": "./dist/scanner/js-scanner.d.ts",
-        "import": "./src/scanner/js-scanner.ts"
+        "import": "./dist/scanner/js-scanner.js"
       },
       "./jsx-runtime": {
         "types": "./src/jsx-runtime/index.d.ts"
@@ -47,7 +47,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts --outdir ./dist --format esm --external typescript",
+    "build:js": "bun build ./src/index.ts ./src/scanner/js-scanner.ts --outdir ./dist --format esm --external typescript --external @barefootjs/shared --external @barefootjs/client",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test && bun run typecheck:tests",
     "typecheck:tests": "tsgo --noEmit -p __tests__/tsconfig.json",

--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -21,8 +21,9 @@
       "types": "./src/jsx-dev-runtime/index.d.ts"
     }
   },
-  "//publishConfig": "When npm/pkg-pr-new packs this package, swap `types` to the built dist/*.d.ts files so downstream `tsc --noEmit` doesn't walk into our TS source (where Node imports like `fs` / `process` would force every consumer to install @types/node). Runtime `import` stays at src — current monorepo + esbuild consumers transpile on the fly, and a future publish-ready dist would point this at dist/index.js once subpath bundles exist (none yet for ./scanner).",
+  "//publishConfig": "At pack time, swap-publish-config.mjs merges these overrides into the top-level so the published tarball resolves all entry points to dist/ instead of src/. Workspace exports stay at src/ so bun resolves source directly during dev.",
   "publishConfig": {
+    "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "exports": {
       ".": {
@@ -47,7 +48,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts ./src/scanner/js-scanner.ts --outdir ./dist --format esm --external typescript --external @barefootjs/shared --external @barefootjs/client",
+    "build:js": "bun build ./src/index.ts ./src/scanner/js-scanner.ts --root ./src --outdir ./dist --format esm --external typescript --external @barefootjs/shared --external @barefootjs/client",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test && bun run typecheck:tests",
     "typecheck:tests": "tsgo --noEmit -p __tests__/tsconfig.json",
@@ -72,10 +73,10 @@
     "@barefootjs/shared": "workspace:*"
   },
   "peerDependencies": {
-    "@barefootjs/client": "workspace:*"
+    "@barefootjs/client": "workspace:*",
+    "typescript": "^5.0.0"
   },
   "devDependencies": {
-    "@happy-dom/global-registrator": "^20.0.11",
-    "typescript": "^5.0.0"
+    "@happy-dom/global-registrator": "^20.0.11"
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -8,9 +8,28 @@
   "exports": {
     ".": "./src/index.ts"
   },
+  "publishConfig": {
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  },
   "files": [
+    "dist",
     "src"
   ],
+  "scripts": {
+    "build": "bun run build:js && bun run build:types",
+    "build:js": "bun build ./src/index.ts --outdir ./dist --format esm",
+    "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
+    "clean": "rm -rf dist",
+    "prepack": "node ../../scripts/swap-publish-config.mjs pack",
+    "postpack": "node ../../scripts/swap-publish-config.mjs unpack"
+  },
   "keywords": [
     "barefoot",
     "shared"

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/packages/streaming/package.json
+++ b/packages/streaming/package.json
@@ -8,9 +8,28 @@
   "exports": {
     ".": "./src/index.ts"
   },
+  "publishConfig": {
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  },
   "files": [
+    "dist",
     "src"
   ],
+  "scripts": {
+    "build": "bun run build:js && bun run build:types",
+    "build:js": "bun build ./src/index.ts --outdir ./dist --format esm --external @barefootjs/shared",
+    "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
+    "clean": "rm -rf dist",
+    "prepack": "node ../../scripts/swap-publish-config.mjs pack",
+    "postpack": "node ../../scripts/swap-publish-config.mjs unpack"
+  },
   "keywords": [
     "barefoot",
     "streaming",


### PR DESCRIPTION
## Summary

Several packages shipped `exports` / `main` pointing to `./src/*.ts` — works in the bun workspace but **crashes Node.js consumers** who `npm install` these packages. This blocks the 0.1.0 alpha publish.

### Changes per package

| Package | Issue | Fix |
|---------|-------|-----|
| `@barefootjs/shared` | No build script, exports → `src/` | Add build + publishConfig + prepack/postpack swap + tsconfig.json |
| `@barefootjs/streaming` | No build script, exports → `src/` | Same as shared |
| `@barefootjs/jsx` | Build exists but exports → `src/`, scanner not built | Add scanner to build entries, externalize deps, publishConfig import → `dist/` |
| `@barefootjs/hono` | All 16 subpath exports → `src/`, 9.8 MB bundle (no externals) | Add all subpath entries + `--root ./src`, externalize peerDeps. **Bundle: 9.8 MB → 25 KB** |
| `@barefootjs/go-template` | `./adapter` and `./build` subpaths → `src/`, 9.8 MB bundle | Add entries + publishConfig + prepack/postpack, externalize deps. **Bundle: 9.8 MB → 96 KB** |
| `@barefootjs/mojolicious` | Same as go-template | Same fix pattern |
| `@barefootjs/cli` | Missing `license` + `repository` | Add fields |
| Root `package.json` | Build order: client before jsx (inverted) | Fix to: shared → streaming → jsx → client → adapters → rest |

### How it works

The codebase uses a **publishConfig + prepack/postpack swap** pattern:
- **In the workspace**: `exports` point to `src/` so bun resolves source directly (no rebuild between edits)
- **During `npm pack`**: `prepack` merges `publishConfig` into the top-level, swapping exports to `dist/`
- **After pack**: `postpack` restores the original

Previously, the `publishConfig` only swapped `types` to `dist/*.d.ts` but left `import` pointing to `src/*.ts`. This PR completes the swap by pointing `import` to `dist/*.js` as well.

### Bundle size improvements

Adding `--external` for peer deps dramatically reduces bundle sizes:

| Package | Before | After |
|---------|--------|-------|
| `@barefootjs/hono` | 9.8 MB | 25 KB |
| `@barefootjs/go-template` | 9.8 MB | 96 KB |
| `@barefootjs/mojolicious` | 9.8 MB | 40 KB |

## Test plan

- [x] `bun run clean && bun run build` succeeds
- [x] All 6 fixed packages import successfully under Node.js (after prepack swap)
- [x] `@barefootjs/jsx` test suite passes
- [x] `@barefootjs/hono` test suite passes (295 pass, 0 fail)
- [x] `@barefootjs/go-template` test suite passes (297 pass, 0 fail)
- [x] `@barefootjs/mojolicious` test suite passes (324 pass, 0 fail)
- [x] Workspace dev loop unchanged (exports still point to `src/` in-tree)
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMBrHRT7UsYrebuVWh1AKT)_