### PR TITLE
docs: add issue templates with contribution policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,55 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this!
+
+        > **Note:** We don't accept external pull requests due to supply-chain and AI-slop concerns.
+        > That said, design discussions and debugging help in issues are very welcome — and your
+        > contributions here will be credited as `Co-authored-by` in the fixing commit.
+        >
+        > Happy hacking!
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal steps to reproduce the behavior.
+      placeholder: |
+        1. Create a component with ...
+        2. Compile with ...
+        3. See error ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Version info and relevant environment details.
+      placeholder: |
+        - BarefootJS version:
+        - Adapter (Hono / Go Template / etc.):
+        - Runtime (Bun / Node / Deno):
+        - OS:
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Contribution Policy
+    url: https://github.com/piconic-ai/barefootjs
+    about: |
+      We don't accept external PRs due to supply-chain and AI-slop concerns,
+      but design discussions in issues are very welcome — and contributions
+      made through issues will be credited as co-authors in commits.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea!
+
+        > **Note:** We don't accept external pull requests due to supply-chain and AI-slop concerns.
+        > That said, design discussions in issues are very welcome — and your contributions here
+        > will be credited as `Co-authored-by` in the implementing commit.
+        >
+        > Happy hacking!
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this solve? What's the use case?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed Solution
+      description: How do you think this should work?
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any other approaches you've thought about?
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- Add GitHub issue templates (bug report, feature request) with contribution policy message
- Communicate that external PRs are not accepted due to supply-chain / AI-slop concerns
- Welcome design discussions in issues, with co-author credit for contributors

## Test plan
- [ ] Visit the repo's "New Issue" page and confirm the template chooser appears
- [ ] Verify the contribution policy note renders in each template
- [ ] Confirm blank issues are still allowed

https://claude.ai/code/session_01RnyVftpV12rax5Mbo58T99

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnyVftpV12rax5Mbo58T99)_