### PR TITLE
ci(release): switch to npm Trusted Publishing (OIDC), drop NPM_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,14 +3,17 @@
 # When .changeset/*.md files are present on main → opens a "Version Packages" PR.
 # When that PR is merged (no changeset files remain) → builds and publishes.
 #
-# Uses `bun publish` (via scripts/changeset-publish.ts) instead of
-# `npm publish` to resolve workspace:* protocol references automatically.
+# Uses a hybrid approach:
+#   - `bun pm pack` to resolve workspace:* protocol references
+#   - `npm publish <tarball> --provenance` for OIDC auth + provenance attestation
 #
-# Prerequisites (one-time setup):
-#   1. Create an npm Automation token scoped to @barefootjs/* packages
-#   2. Add it as repo secret NPM_TOKEN
-#   3. (Optional, recommended) Switch to npm Trusted Publishers + OIDC
-#      for tokenless publishing — see https://docs.npmjs.com/generating-provenance-statements
+# No long-lived NPM_TOKEN needed — uses npm Trusted Publishing (OIDC).
+#
+# Prerequisites (one-time setup on npmjs.com):
+#   For each package (or at org level for @barefootjs):
+#     Package settings → Trusted Publishers → Add GitHub Actions
+#       Repository: piconic-ai/barefootjs
+#       Workflow:   release.yml
 
 name: Release
 
@@ -25,6 +28,7 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release:
@@ -37,7 +41,7 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Setup Node (npm registry auth)
+      - name: Setup Node (npm registry + OIDC)
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
         with:
           node-version: '22'
@@ -52,4 +56,3 @@ jobs:
           publish: bun run build && bun scripts/changeset-publish.ts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/scripts/changeset-publish.ts
+++ b/scripts/changeset-publish.ts
@@ -78,7 +78,7 @@ try {
     console.log(`\n  publish  ${pkg.name}@${pkg.version} (${label})`)
 
     // Step 1: pack with bun (resolves workspace:*)
-    const pack = await $`bun pm pack --destination ${tmpDir}`
+    const pack = await $`bun pm pack --quiet --destination ${tmpDir}`
       .cwd(resolve(repoRoot, pkgDir))
       .quiet()
       .nothrow()

--- a/scripts/changeset-publish.ts
+++ b/scripts/changeset-publish.ts
@@ -87,7 +87,7 @@ try {
       errors.push(`${pkg.name}@${pkg.version} (pack)`)
       continue
     }
-    const tarball = pack.text().trim().split('\n').pop()!
+    const tarball = resolve(pack.text().trim().split('\n').pop()!)
 
     // Step 2: publish tarball with npm (OIDC auth + provenance)
     const pub = await $`npm publish ${tarball} --provenance --access public`.nothrow()

--- a/scripts/changeset-publish.ts
+++ b/scripts/changeset-publish.ts
@@ -2,26 +2,30 @@
 //
 // Publish script for the release workflow (changesets/action).
 //
-// Uses `bun publish` instead of `npm publish` so that workspace:*
-// protocol references are resolved to concrete version numbers.
-// npm publish does NOT resolve workspace:*, which causes consumers to
-// see EUNSUPPORTEDPROTOCOL errors on install.
+// Two-step publish for each package:
+//   1. `bun pm pack` — resolves workspace:* to concrete versions
+//   2. `npm publish <tarball> --provenance` — publishes with OIDC auth + provenance
 //
-// For each publishable package whose local version differs from the
-// npm registry, runs `bun publish --access public` and creates a git
-// tag. changesets/action reads the tags to create GitHub Releases.
+// This hybrid approach gives us:
+//   - workspace:* resolution (bun)
+//   - Trusted Publishing / OIDC auth (npm) — no long-lived NPM_TOKEN needed
+//   - Provenance attestation (npm --provenance)
 //
 // Requires:
 //   - `bun run build` to have completed
-//   - NODE_AUTH_TOKEN env var (set by actions/setup-node with registry-url)
+//   - Trusted Publishers configured on npmjs.com for each package
+//   - Workflow permission: id-token: write
 //
 // Usage:
 //   bun scripts/changeset-publish.ts
 
 import { resolve } from 'node:path'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { $ } from 'bun'
 
 const repoRoot = resolve(import.meta.dir, '..')
+const tmpDir = mkdtempSync(`${tmpdir()}/bf-publish-`)
 
 // Publish order: dependencies before dependents.
 const PUBLISHABLE = [
@@ -40,7 +44,7 @@ const PUBLISHABLE = [
   'packages/create-barefootjs',
 ]
 
-async function npmView(name) {
+async function npmView(name: string): Promise<string | null> {
   const result = await $`npm view ${name} version`.quiet().nothrow()
   if (result.exitCode !== 0) {
     const stderr = result.stderr.toString()
@@ -53,38 +57,54 @@ async function npmView(name) {
 
 let published = 0
 let skipped = 0
-const errors = []
+const errors: string[] = []
 
-for (const pkgDir of PUBLISHABLE) {
-  const pkg = await Bun.file(resolve(repoRoot, pkgDir, 'package.json')).json()
+try {
+  for (const pkgDir of PUBLISHABLE) {
+    const pkg = await Bun.file(resolve(repoRoot, pkgDir, 'package.json')).json()
 
-  if (pkg.private) continue
+    if (pkg.private) continue
 
-  const registryVersion = await npmView(pkg.name)
-  if (registryVersion === pkg.version) {
-    console.log(`  skip  ${pkg.name}@${pkg.version} (already on npm)`)
-    skipped++
-    continue
+    const registryVersion = await npmView(pkg.name)
+    if (registryVersion === pkg.version) {
+      console.log(`  skip  ${pkg.name}@${pkg.version} (already on npm)`)
+      skipped++
+      continue
+    }
+
+    const label = registryVersion
+      ? `${registryVersion} → ${pkg.version}`
+      : 'new'
+    console.log(`\n  publish  ${pkg.name}@${pkg.version} (${label})`)
+
+    // Step 1: pack with bun (resolves workspace:*)
+    const pack = await $`bun pm pack --destination ${tmpDir}`
+      .cwd(resolve(repoRoot, pkgDir))
+      .quiet()
+      .nothrow()
+    if (pack.exitCode !== 0) {
+      console.error(`  bun pm pack failed: ${pack.stderr.toString().trim()}`)
+      errors.push(`${pkg.name}@${pkg.version} (pack)`)
+      continue
+    }
+    const tarball = pack.text().trim().split('\n').pop()!
+
+    // Step 2: publish tarball with npm (OIDC auth + provenance)
+    const pub = await $`npm publish ${tarball} --provenance --access public`.nothrow()
+    if (pub.exitCode !== 0) {
+      errors.push(`${pkg.name}@${pkg.version} (publish)`)
+      continue
+    }
+
+    // Tag for changesets/action to create GitHub Releases
+    const tag = `${pkg.name}@${pkg.version}`
+    const t = await $`git tag ${tag}`.cwd(repoRoot).quiet().nothrow()
+    console.log(`  tagged  ${tag}${t.exitCode !== 0 ? ' (already exists)' : ''}`)
+
+    published++
   }
-
-  const label = registryVersion
-    ? `${registryVersion} → ${pkg.version}`
-    : 'new'
-  console.log(`\n  publish  ${pkg.name}@${pkg.version} (${label})`)
-
-  const pub = await $`bun publish --access public`
-    .cwd(resolve(repoRoot, pkgDir))
-    .nothrow()
-  if (pub.exitCode !== 0) {
-    errors.push(`${pkg.name}@${pkg.version}`)
-    continue
-  }
-
-  const tag = `${pkg.name}@${pkg.version}`
-  const t = await $`git tag ${tag}`.cwd(repoRoot).quiet().nothrow()
-  console.log(`  tagged  ${tag}${t.exitCode !== 0 ? ' (already exists)' : ''}`)
-
-  published++
+} finally {
+  rmSync(tmpDir, { recursive: true, force: true })
 }
 
 console.log(`\n  Done: ${published} published, ${skipped} skipped`)


### PR DESCRIPTION
## Summary

Switch the release workflow from token-based auth (`NPM_TOKEN` secret) to npm Trusted Publishing (OIDC). No long-lived secrets needed.

### Before → After

| | Before | After |
|--|--------|-------|
| **Auth** | `NPM_TOKEN` repo secret | OIDC (Trusted Publishing) |
| **workspace:* resolution** | `bun publish` | `bun pm pack` |
| **Publish** | `bun publish` | `npm publish <tarball> --provenance` |
| **Provenance** | None | Signed attestation on each package |
| **Token management** | Manual rotation | None needed |

### Hybrid approach

```
bun pm pack         → resolves workspace:*, produces tarball
npm publish <tarball> --provenance → OIDC auth + provenance attestation
```

This gives us the best of both: bun's workspace resolution + npm's OIDC + provenance.

### Setup required (npmjs.com, one-time)

For each package (or at `@barefootjs` org level):

1. Go to package settings → **Trusted Publishers** → **Add GitHub Actions**
2. Repository: `piconic-ai/barefootjs`
3. Workflow: `release.yml`

Packages to configure:
`@barefootjs/shared`, `@barefootjs/streaming`, `@barefootjs/jsx`, `@barefootjs/client`, `@barefootjs/test`, `@barefootjs/form`, `@barefootjs/chart`, `@barefootjs/xyflow`, `@barefootjs/hono`, `@barefootjs/go-template`, `@barefootjs/mojolicious`, `@barefootjs/cli`, `create-barefootjs`

## Test plan

- [ ] Trusted Publishers configured on npmjs.com
- [ ] CI green
- [ ] First automated publish succeeds via "Version Packages" PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMBrHRT7UsYrebuVWh1AKT)_