### PR TITLE
chore: hide private packages from bunx changeset prompt

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,11 +9,15 @@
   "updateInternalDependencies": "patch",
   "ignore": [
     "@barefootjs/adapter-tests",
+    "@barefootjs/preview",
+    "@barefootjs/site-shared",
     "@barefootjs/ui",
-    "barefootjs-hono-jsx-example",
-    "barefootjs-mojolicious-example",
-    "barefootjs-echo-example",
+    "barefootjs-components",
     "barefootjs-csr-example",
-    "barefootjs-components"
+    "barefootjs-echo-example",
+    "barefootjs-hono-jsx-example",
+    "barefootjs-integrations-shared",
+    "barefootjs-mojolicious-example",
+    "barefootjs-site"
   ]
 }


### PR DESCRIPTION
## Summary

Add missing private packages to the changeset `ignore` list so they don't appear in the `bunx changeset` interactive prompt.

`private: true` prevents publishing but does NOT hide packages from the prompt — the `ignore` list is what controls visibility.

### Added

- `barefootjs-integrations-shared`
- `barefootjs-site`
- `@barefootjs/site-shared`
- `@barefootjs/preview`

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMBrHRT7UsYrebuVWh1AKT)_