### PR TITLE
fix(release): wrap publish command to avoid && argument leak

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,6 @@ jobs:
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.4.9
         with:
           version: bunx changeset version
-          publish: bun run build && bun scripts/changeset-publish.ts
+          publish: bun run release:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "bun test --cwd . __tests__",
     "test:e2e": "bun run --filter '*' test:e2e",
     "clean": "bun run --filter '*' clean",
+    "release:publish": "bun run build && bun scripts/changeset-publish.ts",
     "dev": "docker compose up",
     "dev:build": "docker compose build",
     "dev:down": "docker compose down",


### PR DESCRIPTION
## Summary

changesets/action splits the `publish` command by spaces and passes tokens as arguments (no shell). This caused `&&` to leak as a literal argument to `tsgo`:

```
tsgo --emitDeclarationOnly --outDir ./dist "&&" bun scripts/changeset-publish.ts
→ error TS5112: tsconfig.json is present but will not be loaded if files are specified on commandline
```

## Fix

Wrap in a package.json script where bun's script runner uses a shell:

```diff
- publish: bun run build && bun scripts/changeset-publish.ts
+ publish: bun run release:publish
```

```json
"release:publish": "bun run build && bun scripts/changeset-publish.ts"
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMBrHRT7UsYrebuVWh1AKT)_