### PR TITLE
fix(release): remove registry-url to let OIDC handle npm auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,10 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Setup Node (npm registry + OIDC)
+      - name: Setup Node
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
         with:
           node-version: '22'
-          registry-url: https://registry.npmjs.org/
 
       - run: bun install
 


### PR DESCRIPTION
## Summary

Fix OIDC auth for npm Trusted Publishing.

### Root cause

`actions/setup-node` with `registry-url` creates `.npmrc`:
```
//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
```

Since `NODE_AUTH_TOKEN` is not set (we use OIDC), this resolves to an **empty string**. npm sends the empty token for auth instead of using OIDC → 404.

### Fix

Remove `registry-url` from `actions/setup-node`. npm's default registry is already `registry.npmjs.org`. Without an `_authToken` in `.npmrc`, `npm publish --provenance` will use the OIDC token (from `id-token: write`) for both authentication and provenance attestation via Trusted Publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMBrHRT7UsYrebuVWh1AKT)_