### PR TITLE
fix(release): use Node 24 for npm OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@
 #   - `npm publish <tarball> --provenance` for OIDC auth + provenance attestation
 #
 # No long-lived NPM_TOKEN needed — uses npm Trusted Publishing (OIDC).
+# Requires npm CLI >= 11.5.1 for OIDC support (Node 22 ships npm 10).
 #
 # Prerequisites (one-time setup on npmjs.com):
 #   For each package (or at org level for @barefootjs):
@@ -44,7 +45,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
         with:
-          node-version: '22'
+          node-version: '24'
 
       - run: bun install
 


### PR DESCRIPTION
## Summary

npm Trusted Publishing (OIDC tokenless auth) requires **npm CLI >= 11.5.1**. Node 22 ships with npm 10.x which doesn't support OIDC auth → the 404 errors we saw.

### Fix

`node-version: '22'` → `node-version: '24'` (Node 24 ships with npm 11)

### Why this fixes the 404

npm 10.x doesn't know about OIDC auth. When `npm publish --provenance` runs:
- npm 10: signs provenance ✅, but uses empty/no token for auth → registry treats as anonymous → **404**
- npm 11: signs provenance ✅, uses OIDC token for auth ✅ → **publish succeeds**

### References

- [npm Trusted Publishing GA announcement](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/)
- [npm Trusted Publishing docs](https://docs.npmjs.com/trusted-publishers/)
- [npm/cli#8976 — OIDC E404 with scoped packages](https://github.com/npm/cli/issues/8976)
- [The "Weird" 404 Error and the Node.js 24 Fix](https://medium.com/@kenricktan11/npm-trusted-publishers-the-weird-404-error-and-the-node-js-24-fix-a9f1d717a5dd)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMBrHRT7UsYrebuVWh1AKT)_