### PR TITLE
fix(cli): resolve build output before source in scaffold tsconfig + bump vitest

### DIFF
--- a/.changeset/fix-scaffold-tsconfig-vitest.md
+++ b/.changeset/fix-scaffold-tsconfig-vitest.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/cli": patch
+---
+
+Fix scaffold tsconfig paths order so wrangler resolves compiled SSR templates (with hydration markers and script collection) instead of raw `'use client'` source files. Also bump vitest from `^2.0.0` to `^4.0.0` to resolve esbuild vulnerability (GHSA-67mh-4wv8-2f99).

--- a/.changeset/fix-scaffold-tsconfig-vitest.md
+++ b/.changeset/fix-scaffold-tsconfig-vitest.md
@@ -2,4 +2,4 @@
 "@barefootjs/cli": patch
 ---
 
-Fix scaffold tsconfig paths order so wrangler resolves compiled SSR templates (with hydration markers and script collection) instead of raw `'use client'` source files. Also bump vitest from `^2.0.0` to `^4.0.0` to resolve esbuild vulnerability (GHSA-67mh-4wv8-2f99).
+Fix scaffold tsconfig paths order in Hono adapters so wrangler resolves compiled SSR templates (with hydration markers and script collection) instead of raw `'use client'` source files. Also bump vitest from `^2.0.0` to `^4.0.0` across all adapters to resolve esbuild vulnerability (GHSA-67mh-4wv8-2f99).

--- a/.changeset/fix-scaffold-tsconfig-vitest.md
+++ b/.changeset/fix-scaffold-tsconfig-vitest.md
@@ -2,4 +2,4 @@
 "@barefootjs/cli": patch
 ---
 
-Fix scaffold tsconfig paths order in Hono adapters so wrangler resolves compiled SSR templates (with hydration markers and script collection) instead of raw `'use client'` source files. Also bump vitest from `^2.0.0` to `^4.0.0` across all adapters to resolve esbuild vulnerability (GHSA-67mh-4wv8-2f99).
+Fix scaffold tsconfig paths order in Hono adapters so wrangler resolves compiled SSR templates (with hydration markers and script collection) instead of raw `'use client'` source files. Also bump vitest from `^2.0.0` to `^4.0.0` for npm/pnpm/yarn scaffolds to resolve esbuild vulnerability (GHSA-67mh-4wv8-2f99).

--- a/packages/cli/src/lib/adapters/hono-node.ts
+++ b/packages/cli/src/lib/adapters/hono-node.ts
@@ -223,11 +223,10 @@ const HONO_NODE_TSCONFIG = `{
     "noEmit": true,
     "baseUrl": ".",
     "paths": {
-      // Source first so tsc resolves the authored file (with full
-      // types) rather than the bf-build output (which may have
-      // implicit-any lambdas). The Hono JSX runtime renders
-      // hydration markers from source at serve time.
-      "@/components/*": ["./components/*", "./dist/components/*"]
+      // Build output first so the server resolves the compiled SSR
+      // template (with hydration markers + script collection).
+      // Source is the fallback for files not yet built.
+      "@/components/*": ["./dist/components/*", "./components/*"]
     }
   },
   "include": ["**/*.ts", "**/*.tsx"],

--- a/packages/cli/src/lib/adapters/hono.ts
+++ b/packages/cli/src/lib/adapters/hono.ts
@@ -124,12 +124,10 @@ const HONO_TSCONFIG = `{
     "noEmit": true,
     "baseUrl": ".",
     "paths": {
-      // Source first so tsc resolves the authored file (with full
-      // types) rather than the bf-build output (which may have
-      // implicit-any lambdas). Wrangler's bundler follows the same
-      // mapping; the Hono JSX runtime renders hydration markers
-      // from source just as well as from the compiled template.
-      "@/components/*": ["./components/*", "./public/components/*"]
+      // Build output first so wrangler resolves the compiled SSR
+      // template (with hydration markers + script collection).
+      // Source is the fallback for files not yet built.
+      "@/components/*": ["./public/components/*", "./components/*"]
     }
   },
   "include": ["**/*.ts", "**/*.tsx"],

--- a/packages/cli/src/lib/pm.ts
+++ b/packages/cli/src/lib/pm.ts
@@ -161,7 +161,7 @@ export function testRunnerFor(pm: PackageManager): TestRunner {
   return {
     importSource: 'vitest',
     scriptValue: 'vitest run',
-    devDeps: { '@types/node': '^22.0.0', vitest: '^2.0.0' },
+    devDeps: { '@types/node': '^22.0.0', vitest: '^4.0.0' },
     typesEntry: '',
   }
 }


### PR DESCRIPTION
## Summary
- **tsconfig paths order**: Flip the `@/components/*` path mapping in the Hono scaffold templates so build output (`./public/components/*` / `./dist/components/*`) is resolved before source (`./components/*`). Wrangler's esbuild bundler was picking up the raw `'use client'` source file instead of the compiled SSR template, so the rendered HTML had no hydration markers, no script-collection injection, and no `<script>` tags for `barefoot.js` or component client bundles — making the Counter (and all client components) non-interactive.
- **vitest version bump**: Update the scaffold devDeps vitest from `^2.0.0` to `^4.0.0`. Vitest 2.x pulls vite <=6.4.1 which depends on esbuild <=0.24.2 (GHSA-67mh-4wv8-2f99, moderate severity). The scaffolded project now installs without `npm audit` warnings.
- Affects both Hono (Cloudflare Workers) and Hono (Node) adapters. Other adapters (Echo, CSR, Mojo) are unaffected — their servers are written in Go/Perl or serve static files, so they never resolve `@/components/*` imports at runtime.

## Reproduction
```bash
npm create barefootjs@latest my-app
cd my-app
npm install        # → 5 moderate vulnerabilities (esbuild via vitest 2.x)
npm run dev        # → Counter increment/decrement buttons don't work
                   # → No <script> tags for barefoot.js in the HTML
```

## Root cause
The scaffold's `tsconfig.json` listed `["./components/*", "./public/components/*"]` for the `@/components/*` path alias. Wrangler resolves imports using tsconfig paths and picks the first match — `./components/Counter.tsx` (the `'use client'` source). This source file has no hydration attributes, no `bfCollectedScripts` injection, and `createSignal()` from `@barefootjs/client` runs as a no-op signal (not the SSR shim). The compiled template at `./public/components/Counter.tsx` carries all of these, but was never reached.

## Test plan
- [x] Manually patched `my-app/tsconfig.json` and confirmed `wrangler dev` now emits `bf-s`/`bf-r` attributes and `<script type="module" src="/components/barefoot.js">` in the HTML
- [ ] Scaffold a fresh project with the updated CLI and verify `npm run dev` produces a working Counter
- [ ] Verify Hono Node adapter (`--adapter hono-node`) works the same way

🤖 Generated with [Claude Code](https://claude.com/claude-code)