### PR TITLE
feat: lower .findLast(p) / .findLastIndex(p) to Go template adapter

### DIFF
--- a/.changeset/find-last-lowering.md
+++ b/.changeset/find-last-lowering.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+"@barefootjs/mojolicious": patch
+---
+
+Add .findLast(p) / .findLastIndex(p) higher-order method lowering (#1448 Tier B). Go template adapter lowers via bf_find_last / bf_find_last_index runtime helpers (equality predicates) and range-based template blocks (complex predicates). Mojo adapter refuses with BF101 (matching existing find/findIndex gap).

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -63,8 +63,10 @@ func FuncMap() template.FuncMap {
 		"bf_every":      Every,
 		"bf_some":       Some,
 		"bf_filter":     Filter,
-		"bf_find":       Find,
-		"bf_find_index": FindIndex,
+		"bf_find":            Find,
+		"bf_find_index":      FindIndex,
+		"bf_find_last":       FindLast,
+		"bf_find_last_index": FindLastIndex,
 		"bf_sort":       Sort,
 
 		// Comment marker (for hydration)
@@ -1046,6 +1048,72 @@ func FindIndex(items any, field string, value any) int {
 
 	capitalizedField := capitalize(field)
 	for i := 0; i < v.Len(); i++ {
+		item := v.Index(i)
+		if item.Kind() == reflect.Interface {
+			item = item.Elem()
+		}
+		if item.Kind() == reflect.Ptr {
+			item = item.Elem()
+		}
+		if item.Kind() != reflect.Struct {
+			continue
+		}
+
+		fieldVal := item.FieldByName(capitalizedField)
+		if !fieldVal.IsValid() {
+			continue
+		}
+
+		if reflect.DeepEqual(fieldVal.Interface(), value) {
+			return i
+		}
+	}
+	return -1
+}
+
+// FindLast returns the last item where item.field == value, or nil if not found.
+// Mirrors JavaScript's Array.prototype.findLast(item => item.field === value).
+func FindLast(items any, field string, value any) any {
+	v := reflect.ValueOf(items)
+	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
+		return nil
+	}
+
+	capitalizedField := capitalize(field)
+	for i := v.Len() - 1; i >= 0; i-- {
+		item := v.Index(i)
+		if item.Kind() == reflect.Interface {
+			item = item.Elem()
+		}
+		if item.Kind() == reflect.Ptr {
+			item = item.Elem()
+		}
+		if item.Kind() != reflect.Struct {
+			continue
+		}
+
+		fieldVal := item.FieldByName(capitalizedField)
+		if !fieldVal.IsValid() {
+			continue
+		}
+
+		if reflect.DeepEqual(fieldVal.Interface(), value) {
+			return v.Index(i).Interface()
+		}
+	}
+	return nil
+}
+
+// FindLastIndex returns the index of the last item where item.field == value, or -1.
+// Mirrors JavaScript's Array.prototype.findLastIndex(item => item.field === value).
+func FindLastIndex(items any, field string, value any) int {
+	v := reflect.ValueOf(items)
+	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
+		return -1
+	}
+
+	capitalizedField := capitalize(field)
+	for i := v.Len() - 1; i >= 0; i-- {
 		item := v.Index(i)
 		if item.Kind() == reflect.Interface {
 			item = item.Elem()

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -1083,9 +1083,15 @@ func FindLast(items any, field string, value any) any {
 	for i := v.Len() - 1; i >= 0; i-- {
 		item := v.Index(i)
 		if item.Kind() == reflect.Interface {
+			if item.IsNil() {
+				continue
+			}
 			item = item.Elem()
 		}
 		if item.Kind() == reflect.Ptr {
+			if item.IsNil() {
+				continue
+			}
 			item = item.Elem()
 		}
 		if item.Kind() != reflect.Struct {
@@ -1116,9 +1122,15 @@ func FindLastIndex(items any, field string, value any) int {
 	for i := v.Len() - 1; i >= 0; i-- {
 		item := v.Index(i)
 		if item.Kind() == reflect.Interface {
+			if item.IsNil() {
+				continue
+			}
 			item = item.Elem()
 		}
 		if item.Kind() == reflect.Ptr {
+			if item.IsNil() {
+				continue
+			}
 			item = item.Elem()
 		}
 		if item.Kind() != reflect.Struct {

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -561,6 +561,85 @@ func TestFindIndex_NotFound(t *testing.T) {
 	}
 }
 
+// =============================================================================
+// FindLast / FindLastIndex Tests
+// =============================================================================
+
+func TestFindLast_ByBooleanField(t *testing.T) {
+	items := []findItem{
+		{Id: 1, Name: "A", Done: true},
+		{Id: 2, Name: "B", Done: false},
+		{Id: 3, Name: "C", Done: true},
+	}
+
+	got := FindLast(items, "done", true)
+	if got == nil {
+		t.Fatal("FindLast by bool: got nil, want item C")
+	}
+	if got.(findItem).Name != "C" {
+		t.Errorf("FindLast by bool: got %v, want C", got.(findItem).Name)
+	}
+}
+
+func TestFindLast_ByIntField(t *testing.T) {
+	items := []findItem{
+		{Id: 1, Name: "A"},
+		{Id: 2, Name: "B"},
+		{Id: 2, Name: "C"},
+	}
+
+	got := FindLast(items, "id", 2)
+	if got == nil {
+		t.Fatal("FindLast by int: got nil, want item C")
+	}
+	if got.(findItem).Name != "C" {
+		t.Errorf("FindLast by int: got %v, want C", got.(findItem).Name)
+	}
+}
+
+func TestFindLast_NotFound(t *testing.T) {
+	items := []findItem{
+		{Id: 1, Name: "A"},
+	}
+
+	got := FindLast(items, "id", 99)
+	if got != nil {
+		t.Errorf("FindLast not found: got %v, want nil", got)
+	}
+}
+
+func TestFindLast_EmptySlice(t *testing.T) {
+	var items []findItem
+	got := FindLast(items, "id", 1)
+	if got != nil {
+		t.Errorf("FindLast empty: got %v, want nil", got)
+	}
+}
+
+func TestFindLastIndex_Found(t *testing.T) {
+	items := []findItem{
+		{Id: 1, Name: "A", Done: true},
+		{Id: 2, Name: "B", Done: false},
+		{Id: 3, Name: "C", Done: true},
+	}
+
+	got := FindLastIndex(items, "done", true)
+	if got != 2 {
+		t.Errorf("FindLastIndex found: got %d, want 2", got)
+	}
+}
+
+func TestFindLastIndex_NotFound(t *testing.T) {
+	items := []findItem{
+		{Id: 1, Name: "A"},
+	}
+
+	got := FindLastIndex(items, "id", 99)
+	if got != -1 {
+		t.Errorf("FindLastIndex not found: got %d, want -1", got)
+	}
+}
+
 func TestComment(t *testing.T) {
 	got := Comment("cond-start:slot_0")
 	want := "<!--bf-cond-start:slot_0-->"

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -1024,6 +1024,74 @@ export function ItemChecker() {
     })
   })
 
+  describe('findLast/findLastIndex - adapter specific', () => {
+    test('renders findLast() with equality predicate via bf_find_last', () => {
+      const result = compileAndGenerate(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+type Item = { name: string; done: boolean }
+
+export function ItemChecker() {
+  const [items, setItems] = createSignal<Item[]>([])
+  return <div>{items().findLast(t => t.done) ? 'Found' : 'Not found'}</div>
+}
+`)
+      expect(result.template).toContain('bf_find_last .Items "Done" true')
+      expect(result.template).toContain('Found')
+    })
+
+    test('renders findLast() with complex predicate via range without break', () => {
+      const result = compileAndGenerate(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+type Item = { price: number; category: string }
+
+export function ItemFinder() {
+  const [items, setItems] = createSignal<Item[]>([])
+  const [type, setType] = createSignal('')
+  return <div>{items().findLast(t => t.price > 100 && t.category === type())}</div>
+}
+`)
+      expect(result.template).toContain('{{range')
+      expect(result.template).toContain('$bf_result')
+      expect(result.template).not.toContain('{{break}}')
+    })
+
+    test('renders findLastIndex() with equality predicate via bf_find_last_index', () => {
+      const result = compileAndGenerate(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+type Item = { name: string; done: boolean }
+
+export function ItemChecker() {
+  const [items, setItems] = createSignal<Item[]>([])
+  return <div>idx: {items().findLastIndex(t => t.done)}</div>
+}
+`)
+      expect(result.template).toContain('bf_find_last_index .Items "Done" true')
+    })
+
+    test('renders findLastIndex() with complex predicate via range', () => {
+      const result = compileAndGenerate(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+type Item = { price: number; active: boolean }
+
+export function ItemFinder() {
+  const [items, setItems] = createSignal<Item[]>([])
+  return <div>{items().findLastIndex(t => t.price > 50 && t.active)}</div>
+}
+`)
+      expect(result.template).toContain('$bf_result := -1')
+      expect(result.template).toContain('$bf_result = $i')
+      expect(result.template).not.toContain('{{break}}')
+    })
+  })
+
   describe('component root scope comment propagation', () => {
     test('component root in client component outputs bfScopeComment', () => {
       const result = compileAndGenerate(`

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -2985,11 +2985,11 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
     if (expr.method === 'findLast') {
       const capture = propertyAccess ? `.${propertyAccess}` : '.'
-      return `{{$bf_result := ""}}{{range ${arrayExpr}}}{{if ${condition}}}{{$bf_result = ${capture}}}{{end}}{{end}}{{$bf_result}}`
+      return `{{if true}}{{$bf_result := ""}}{{range ${arrayExpr}}}{{if ${condition}}}{{$bf_result = ${capture}}}{{end}}{{end}}{{$bf_result}}{{end}}`
     }
 
     if (expr.method === 'findLastIndex') {
-      return `{{$bf_result := -1}}{{range $i, $_ := ${arrayExpr}}}{{if ${condition}}}{{$bf_result = $i}}{{end}}{{end}}{{$bf_result}}`
+      return `{{if true}}{{$bf_result := -1}}{{range $i, $_ := ${arrayExpr}}}{{if ${condition}}}{{$bf_result = $i}}{{end}}{{end}}{{$bf_result}}{{end}}`
     }
 
     return null

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -2530,8 +2530,8 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       if (result) return result
     }
 
-    // find().property → {{with bf_find ...}}{{.Property}}{{end}}
-    if (object.kind === 'higher-order' && object.method === 'find') {
+    // find().property / findLast().property → {{with bf_find ...}}{{.Property}}{{end}}
+    if (object.kind === 'higher-order' && (object.method === 'find' || object.method === 'findLast')) {
       const findResult = this.renderHigherOrderExpr(object, emit)
       if (findResult) {
         return `{{with ${findResult}}}{{.${this.capitalizeFieldName(property)}}}{{end}}`
@@ -2672,7 +2672,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     const reconstructed = { kind: 'higher-order' as const, method, object, param, predicate }
     const result = this.renderHigherOrderExpr(reconstructed, emit)
     if (result) return result
-    if (method === 'find' || method === 'findIndex') {
+    if (method === 'find' || method === 'findIndex' || method === 'findLast' || method === 'findLastIndex') {
       const templateBlock = this.renderFindTemplateBlock(reconstructed, emit)
       if (templateBlock) return templateBlock
     }
@@ -2941,26 +2941,29 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       return `bf_filter ${arrayExpr} "${field}" ${value}`
     }
 
-    if (expr.method === 'find' || expr.method === 'findIndex') {
+    if (expr.method === 'find' || expr.method === 'findIndex' || expr.method === 'findLast' || expr.method === 'findLastIndex') {
       const eqPred = this.extractEqualityPredicate(
         expr.predicate, expr.param, e => this.renderParsedExpr(e)
       )
       if (!eqPred) return null
-      const func = expr.method === 'find' ? 'bf_find' : 'bf_find_index'
-      return `${func} ${arrayExpr} "${eqPred.field}" ${eqPred.value}`
+      const funcMap: Record<string, string> = {
+        find: 'bf_find', findIndex: 'bf_find_index',
+        findLast: 'bf_find_last', findLastIndex: 'bf_find_last_index',
+      }
+      return `${funcMap[expr.method]} ${arrayExpr} "${eqPred.field}" ${eqPred.value}`
     }
 
     return null
   }
 
   /**
-   * Render find()/findIndex() with complex predicates using {{range}}{{if}}...{{break}} blocks.
-   * Falls back from bf_find/bf_find_index when extractEqualityPredicate returns null.
-   * Reuses renderFilterExpr for condition rendering.
+   * Render find/findIndex/findLast/findLastIndex with complex predicates
+   * using range/if blocks. Falls back from bf_find/bf_find_last helpers
+   * when extractEqualityPredicate returns null.
    *
-   * @param expr - The higher-order find/findIndex expression
-   * @param renderArray - Function to render the array expression
-   * @param propertyAccess - Optional property to access on the found element (for find().property)
+   * find/findIndex use break on first match (forward scan).
+   * findLast/findLastIndex iterate forward and keep overwriting a result
+   * variable; the final value is the last match.
    */
   private renderFindTemplateBlock(
     expr: Extract<ParsedExpr, { kind: 'higher-order' }>,
@@ -2978,6 +2981,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
     if (expr.method === 'findIndex') {
       return `{{range $i, $_ := ${arrayExpr}}}{{if ${condition}}}{{$i}}{{break}}{{end}}{{end}}`
+    }
+
+    if (expr.method === 'findLast') {
+      const capture = propertyAccess ? `.${propertyAccess}` : '.'
+      return `{{$bf_result := ""}}{{range ${arrayExpr}}}{{if ${condition}}}{{$bf_result = ${capture}}}{{end}}{{end}}{{$bf_result}}`
+    }
+
+    if (expr.method === 'findLastIndex') {
+      return `{{$bf_result := -1}}{{range $i, $_ := ${arrayExpr}}}{{if ${condition}}}{{$bf_result = $i}}{{end}}{{end}}{{$bf_result}}`
     }
 
     return null

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -162,6 +162,8 @@ runAdapterConformanceTests({
     // text-expression form is routed through the same AST path.
     'array-find':          [{ code: 'BF101', severity: 'error' }],
     'array-findIndex':     [{ code: 'BF101', severity: 'error' }],
+    'array-findLast':      [{ code: 'BF101', severity: 'error' }],
+    'array-findLastIndex': [{ code: 'BF101', severity: 'error' }],
   },
   // `JSON_STRINGIFY_VIA_CONST` and `MATH_FLOOR_VIA_CONST` now pass
   // via `MojoAdapter.templatePrimitives` (#1189). The two remaining

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1184,12 +1184,14 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
   private convertExpressionToPerl(expr: string): string {
     // Handle higher-order array methods via ParsedExpr AST.
     // `filter|every|some` lower to Embedded Perl (grep). The rest
-    // (`reduce|reduceRight|forEach|flatMap|flat|findLast|findLastIndex`)
-    // can't lower to EP at all — route them through the same AST path
-    // so `convertHigherOrderExpr`'s `isSupported` gate emits BF101
+    // (`reduce|reduceRight|forEach|flatMap|flat`) can't lower to EP
+    // at all — route them through the same AST path so
+    // `convertHigherOrderExpr`'s `isSupported` gate emits BF101
     // instead of falling into the regex pipeline that mangles
     // `$items->{reduce}->{...}` etc.
-    if (/\.\s*(?:filter|every|some|reduce|reduceRight|forEach|flatMap|flat|findLast|findLastIndex)\s*\(/.test(expr)) {
+    // `findLast|findLastIndex` are caught by the explicit Mojo-gap
+    // refusal below (alongside `find|findIndex`).
+    if (/\.\s*(?:filter|every|some|reduce|reduceRight|forEach|flatMap|flat)\s*\(/.test(expr)) {
       return this.convertHigherOrderExpr(expr)
     }
 
@@ -1215,13 +1217,13 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       return this.convertHigherOrderExpr(expr)
     }
 
-    // #1448 catalog — Mojo-specific gap: `.find` / `.findIndex`
-    // have no AST lowering yet (no `array-method` IR variant, no
-    // emitter), and the regex pipeline silently mangles them into
-    // `${obj}->{find}(...)` hash lookups. Emit BF101 here until
-    // either a parser-level `array-method` extension or a
-    // `convertHigherOrderExpr` carve-out lands.
-    const mojoOnlyMatch = /\.\s*(?<method>find|findIndex)\s*\(/.exec(expr)
+    // #1448 catalog — Mojo-specific gap: `.find` / `.findIndex` /
+    // `.findLast` / `.findLastIndex` have no AST lowering yet (no
+    // `array-method` IR variant, no emitter), and the regex pipeline
+    // silently mangles them into `${obj}->{find}(...)` hash lookups.
+    // Emit BF101 here until either a parser-level `array-method`
+    // extension or a `convertHigherOrderExpr` carve-out lands.
+    const mojoOnlyMatch = /\.\s*(?<method>find|findIndex|findLast|findLastIndex)\s*\(/.exec(expr)
     if (mojoOnlyMatch) {
       const methodName = mojoOnlyMatch.groups!.method!
       this.errors.push({

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -141,6 +141,8 @@ import { fixture as arrayFind } from './methods/array-find'
 import { fixture as arrayEvery } from './methods/array-every'
 import { fixture as arraySome } from './methods/array-some'
 import { fixture as arrayFindIndex } from './methods/array-findIndex'
+import { fixture as arrayFindLast } from './methods/array-findLast'
+import { fixture as arrayFindLastIndex } from './methods/array-findLastIndex'
 // #1448 Tier B — `.sort` / `.toSorted` lowering. The Tier A
 // fixtures above gated the standalone-method surface; Tier B
 // adds the comparator-bearing variants (field-based numeric,
@@ -277,6 +279,8 @@ export const jsxFixtures: JSXFixture[] = [
   arrayEvery,
   arraySome,
   arrayFindIndex,
+  arrayFindLast,
+  arrayFindLastIndex,
   // #1448 Tier B — sort / toSorted with structured comparator.
   arraySortFieldAsc,
   arraySortFieldDesc,

--- a/packages/adapter-tests/fixtures/methods/array-findLast.ts
+++ b/packages/adapter-tests/fixtures/methods/array-findLast.ts
@@ -1,0 +1,27 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `Array.prototype.findLast(pred)` — positive conformance fixture
+ * (#1448 Tier B).
+ *
+ * Pins the last-match return semantic with a duplicated-value input
+ * so a lowering that returned the first match would surface here.
+ * Predicate is `x => x === 'b'` (literal-equality) for the same
+ * reason as the `array-find` sibling — see that fixture's comment.
+ * Input `['a', 'b', 'c', 'b']` has `'b'` at indices 1 and 3;
+ * `.findLast` must return the occurrence at index 3.
+ */
+export const fixture = createFixture({
+  id: 'array-findLast',
+  description: '.findLast(pred) returns the last matching element',
+  source: `
+function ArrayFindLast({ items }: { items: string[] }) {
+  return <div>found: {items.findLast(x => x === 'b')}</div>
+}
+export { ArrayFindLast }
+`,
+  props: { items: ['a', 'b', 'c', 'b'] },
+  expectedHtml: `
+    <div bf-s="test" bf="s1">found: <!--bf:s0-->b<!--/--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/methods/array-findLastIndex.ts
+++ b/packages/adapter-tests/fixtures/methods/array-findLastIndex.ts
@@ -1,0 +1,26 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `Array.prototype.findLastIndex(pred)` — positive conformance fixture
+ * (#1448 Tier B).
+ *
+ * Predicate is `x => x === 'b'` (literal-equality) for the same
+ * reason as the `array-find` sibling — see that fixture's comment.
+ * Input `['a', 'b', 'c', 'b']` has `'b'` at indices 1 and 3;
+ * `.findLastIndex` must return `3` (the last position), not `1`
+ * (which `.findIndex` returns).
+ */
+export const fixture = createFixture({
+  id: 'array-findLastIndex',
+  description: '.findLastIndex(pred) returns the index of the last match',
+  source: `
+function ArrayFindLastIndex({ items }: { items: string[] }) {
+  return <div>idx: {items.findLastIndex(x => x === 'b')}</div>
+}
+export { ArrayFindLastIndex }
+`,
+  props: { items: ['a', 'b', 'c', 'b'] },
+  expectedHtml: `
+    <div bf-s="test" bf="s1">idx: <!--bf:s0-->3<!--/--></div>
+  `,
+})

--- a/packages/jsx/src/adapters/parsed-expr-emitter.ts
+++ b/packages/jsx/src/adapters/parsed-expr-emitter.ts
@@ -35,7 +35,7 @@
 
 import type { ParsedExpr, SortComparator, TemplatePart } from '../expression-parser'
 
-export type HigherOrderMethod = 'filter' | 'every' | 'some' | 'find' | 'findIndex'
+export type HigherOrderMethod = 'filter' | 'every' | 'some' | 'find' | 'findIndex' | 'findLast' | 'findLastIndex'
 
 /**
  * Non-higher-order array methods (#1443). One discriminator for the

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -2784,7 +2784,7 @@ function inferTypeFromValue(value: string): TypeInfo {
   if (/\.(some|every|includes)\s*\([\s\S]*\)\s*$/.test(trimmed)) {
     return { kind: 'primitive', raw: 'boolean', primitive: 'boolean' }
   }
-  if (/\.(indexOf|findIndex|lastIndexOf)\s*\([\s\S]*\)\s*$/.test(trimmed)) {
+  if (/\.(indexOf|findIndex|findLastIndex|lastIndexOf)\s*\([\s\S]*\)\s*$/.test(trimmed)) {
     return { kind: 'primitive', raw: 'number', primitive: 'number' }
   }
 

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -23,7 +23,7 @@ export type ParsedExpr =
   | { kind: 'logical'; op: '&&' | '||' | '??'; left: ParsedExpr; right: ParsedExpr }
   | { kind: 'template-literal'; parts: TemplatePart[] }
   | { kind: 'arrow-fn'; param: string; body: ParsedExpr }
-  | { kind: 'higher-order'; method: 'filter' | 'every' | 'some' | 'find' | 'findIndex'; object: ParsedExpr; param: string; predicate: ParsedExpr }
+  | { kind: 'higher-order'; method: 'filter' | 'every' | 'some' | 'find' | 'findIndex' | 'findLast' | 'findLastIndex'; object: ParsedExpr; param: string; predicate: ParsedExpr }
   | { kind: 'array-literal'; elements: ParsedExpr[] }
   // Non-higher-order array methods. Discriminated by `method` so each
   // adapter handles the full set via one exhaustive switch instead of
@@ -157,13 +157,12 @@ export interface SupportResult {
 // evaluate JS at runtime via hono/jsx) so this set only constrains
 // the template-language adapters.
 const UNSUPPORTED_METHODS = new Set([
-  // Higher-order array methods. Five of these (`filter`, `every`,
-  // `some`, `find`, `findIndex`) are intercepted as `higher-order`
-  // IR before reaching this gate; `map` is intercepted as an
-  // IRLoop. The rest stay refused — see #1448 Tier C for the
-  // design questions.
+  // Higher-order array methods. Seven of these (`filter`, `every`,
+  // `some`, `find`, `findIndex`, `findLast`, `findLastIndex`) are
+  // intercepted as `higher-order` IR before reaching this gate;
+  // `map` is intercepted as an IRLoop. The rest stay refused — see
+  // #1448 Tier C for the design questions.
   'filter', 'map', 'reduce', 'reduceRight', 'every', 'some',
-  'findLast', 'findLastIndex',
   'forEach', 'flatMap', 'flat',
   // #1448 Tier A — Array methods. Each method PR adds the lowering
   // (typically a new `array-method` variant or runtime helper) and
@@ -268,12 +267,12 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
     const args = node.arguments.map(arg => convertNode(arg, raw))
 
     // Detect higher-order methods: arr.filter(x => pred), arr.every(x => pred), arr.some(x => pred)
-    if (callee.kind === 'member' && ['filter', 'every', 'some', 'find', 'findIndex'].includes(callee.property)) {
+    if (callee.kind === 'member' && ['filter', 'every', 'some', 'find', 'findIndex', 'findLast', 'findLastIndex'].includes(callee.property)) {
       if (args.length === 1 && args[0].kind === 'arrow-fn') {
         const arrowFn = args[0] as { kind: 'arrow-fn'; param: string; body: ParsedExpr }
         return {
           kind: 'higher-order',
-          method: callee.property as 'filter' | 'every' | 'some' | 'find' | 'findIndex',
+          method: callee.property as 'filter' | 'every' | 'some' | 'find' | 'findIndex' | 'findLast' | 'findLastIndex',
           object: callee.object,
           param: arrowFn.param,
           predicate: arrowFn.body,


### PR DESCRIPTION
## Summary

Implements `.findLast(p)` / `.findLastIndex(p)` lowering for the Go template adapter (#1448 Tier B). These are the reverse-search counterparts of the existing `.find` / `.findIndex` higher-order methods.

- **Parser**: Add `findLast` / `findLastIndex` to the `higher-order` IR method union and remove from `UNSUPPORTED_METHODS`
- **Go adapter**: Two lowering paths per method:
  - **Simple equality predicates** → `bf_find_last` / `bf_find_last_index` runtime helpers (backward iteration for efficiency)
  - **Complex predicates** → `{{range}}{{if}}` template blocks that iterate forward and keep overwriting a `$bf_result` variable (the final value is the last match — Go templates lack reverse `{{range}}`)
- **Go runtime**: `FindLast()` and `FindLastIndex()` functions with backward iteration, mirroring the existing `Find()` / `FindIndex()` structure
- **Mojo adapter**: Extended the explicit BF101 refusal regex to cover `findLast` / `findLastIndex` (matching the existing `find` / `findIndex` Mojo gap)
- **Analyzer**: Added `findLastIndex` to the number-return type detection regex
- **Conformance fixtures**: `array-findLast` and `array-findLastIndex` with duplicated-value inputs (`['a', 'b', 'c', 'b']`) that disambiguate last-match from first-match semantics

### Design decision

The issue asked whether to lower as "iterate in reverse" or "find then take last":

| Path | Strategy | Rationale |
|------|----------|-----------|
| Runtime helpers (`bf_find_last`, `bf_find_last_index`) | Iterate in reverse | Efficient — short-circuits on first match from end |
| Template-block fallback (complex predicates) | Iterate forward, keep last | Simpler — Go templates don't support reverse `{{range}}` |

Both produce correct results; the runtime helpers just do it in O(k) instead of O(n) for the average case.

Closes the `.findLast(p)` / `.findLastIndex(p)` checkbox in #1448.

## Test plan

- [x] Go runtime tests: `TestFindLast_*` and `TestFindLastIndex_*` (6 new tests, all pass)
- [x] Go adapter unit tests: 4 new tests covering equality predicates (bf_find_last/bf_find_last_index) and complex predicates (range-based template blocks)
- [x] CSR conformance: `array-findLast` and `array-findLastIndex` fixtures pass
- [x] Mojo adapter: new fixtures produce expected BF101 diagnostics
- [x] Hono adapter: new fixtures pass (runtime JS evaluation)
- [x] Expression parser: existing 114 tests still pass

https://claude.ai/code/session_01MWSBZ7pfKZZmyAT6KmCFfU

---
_Generated by [Claude Code](https://claude.ai/code/session_01MWSBZ7pfKZZmyAT6KmCFfU)_