### PR TITLE
fix(go-template): map JS null to Go nil for correct ?? semantics

### DIFF
--- a/.changeset/fix-go-null-to-nil.md
+++ b/.changeset/fix-go-null-to-nil.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Fix nullish coalescing (`??`) branch selection for unset props: map JS `null` to Go `nil` instead of empty string so `{{if ne .Field nil}}` correctly evaluates to false when the field is unset.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -22,14 +22,6 @@ runAdapterConformanceTests({
   // `<!--bf-cond-start:sN-->` / `<!--bf-cond-end:sN-->` comment pairs)
   // is now collapsed by `normalizeHTML` in adapter-tests (#1266).
   //
-  // `nullish-coalescing-jsx` / `return-nullish-coalescing` have a
-  // separate semantic divergence: the Go template's `{{if ne .Banner
-  // ""}}` condition treats an unset `Banner` (Go nil) as `!= ""` and
-  // takes the truthy branch with empty content, while Hono's JS
-  // `??` operator falls through to the JSX default. That's a Go-
-  // adapter branch-selection bug — fixing it is out of scope for
-  // #1266.
-  //
   // `return-map` uses a `data-key` serialisation shape that differs
   // between Hono (runtime helper) and Go (template variable) in a
   // way that isn't structural — leaving it on `skipJsx` until a
@@ -43,8 +35,6 @@ runAdapterConformanceTests({
   // `BF104` at build time instead of silently emitting invalid
   // template syntax (#1266).
   skipJsx: [
-    'nullish-coalescing-jsx',
-    'return-nullish-coalescing',
     'return-map',
     // #1297 fixed the harness-side IR emission gate (multi-component
     // sources now emit one `ir` file per component, and the harness

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -2471,7 +2471,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
   literal(value: string | number | boolean | null, literalType: LiteralType): string {
     if (literalType === 'string') return `"${value}"`
-    if (literalType === 'null') return '""'
+    if (literalType === 'null') return 'nil'
     return String(value)
   }
 
@@ -3310,7 +3310,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
           return `"${expr.value}"`
         }
         if (expr.literalType === 'null') {
-          return '""'
+          return 'nil'
         }
         return String(expr.value)
 
@@ -3727,7 +3727,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
           return `"${expr.value}"`
         }
         if (expr.literalType === 'null') {
-          return '""'
+          return 'nil'
         }
         return String(expr.value)
 


### PR DESCRIPTION
## Summary

- Fix the Go template adapter's null literal mapping: `""` → `nil` in all three emission paths (`literal()`, `renderFilterExprNode()`, `renderConditionExpr()`)
- This fixes the `??` branch selection bug where `{{if ne .Banner ""}}` treated unset (nil) fields as truthy, rendering empty instead of the JSX default
- Remove `nullish-coalescing-jsx` and `return-nullish-coalescing` from `skipJsx`

## Problem

The IR transforms `props.banner ?? <span>Default</span>` into a conditional with condition `props.banner != null`. The Go adapter rendered `null` as `""`, producing `{{if ne .Banner ""}}`. In Go templates, `nil != ""` evaluates to `true` (nil is not an empty string), so the truthy branch executes — but the nil value renders as empty content. JS `??` would correctly fall through to the default.

## Fix

Map JS `null` to Go `nil` instead of `""`. `{{if ne .Banner nil}}` correctly evaluates to `false` when `.Banner` is unset, matching JS nullish coalescing semantics.

## Test plan

- [x] All 296 Go template adapter tests pass
- [x] All 497 adapter-tests conformance tests pass
- [x] IR nullish coalescing tests pass
- [ ] CI with Go runtime validates the two formerly-skipped fixtures render correctly

Refs #1395

https://claude.ai/code/session_011peDEVjt7F4HKgcEm9DYiY

---
_Generated by [Claude Code](https://claude.ai/code/session_011peDEVjt7F4HKgcEm9DYiY)_