### PR TITLE
ci: require changeset when published package source changes

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -1,0 +1,81 @@
+name: Changeset check
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changeset') }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Check if changeset is required
+        run: |
+          # Published-package source directories that require a changeset
+          # when modified. Derived from the non-private packages under
+          # packages/ (see .changeset/config.json "ignore" for the skip list).
+          PUBLISHED_SRC_PATHS=(
+            packages/adapter-go-template/src
+            packages/adapter-hono/src
+            packages/adapter-mojolicious/src
+            packages/chart/src
+            packages/cli/src
+            packages/client/src
+            packages/create-barefootjs/src
+            packages/form/src
+            packages/jsx/src
+            packages/shared/src
+            packages/streaming/src
+            packages/test/src
+            packages/xyflow/src
+          )
+
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+
+          changed_files=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+
+          needs_changeset=false
+          matched_paths=()
+
+          for file in $changed_files; do
+            # Skip test files — they don't affect published output
+            if echo "$file" | grep -qE '(__tests__|\.test\.|\.spec\.)'; then
+              continue
+            fi
+            for prefix in "${PUBLISHED_SRC_PATHS[@]}"; do
+              if echo "$file" | grep -q "^${prefix}/"; then
+                needs_changeset=true
+                matched_paths+=("$file")
+                break
+              fi
+            done
+          done
+
+          if [ "$needs_changeset" = true ]; then
+            # Check for .changeset/*.md files (excluding README.md)
+            changeset_files=$(find .changeset -maxdepth 1 -name '*.md' ! -name 'README.md' 2>/dev/null)
+
+            if [ -z "$changeset_files" ]; then
+              echo "::error::This PR modifies published package source but has no changeset."
+              echo ""
+              echo "Changed files that require a changeset:"
+              printf '  - %s\n' "${matched_paths[@]}"
+              echo ""
+              echo "Run 'bunx changeset' to add one, or add a 'no-changeset' label if this change doesn't affect consumers."
+              exit 1
+            else
+              echo "Changeset found — OK"
+              echo "$changeset_files"
+            fi
+          else
+            echo "No published source files changed — changeset not required"
+          fi

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -2,6 +2,7 @@ name: Changeset check
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches: [main]
 
 permissions:
@@ -62,8 +63,9 @@ jobs:
           done
 
           if [ "$needs_changeset" = true ]; then
-            # Check for .changeset/*.md files (excluding README.md)
-            changeset_files=$(find .changeset -maxdepth 1 -name '*.md' ! -name 'README.md' 2>/dev/null)
+            # Check the PR diff for new .changeset/*.md files (not find,
+            # which would also see pre-existing changesets on main).
+            changeset_files=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- '.changeset/*.md' | grep -v 'README.md' || true)
 
             if [ -z "$changeset_files" ]; then
               echo "::error::This PR modifies published package source but has no changeset."

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -19,24 +19,25 @@ jobs:
 
       - name: Check if changeset is required
         run: |
-          # Published-package source directories that require a changeset
-          # when modified. Derived from the non-private packages under
-          # packages/ (see .changeset/config.json "ignore" for the skip list).
-          PUBLISHED_SRC_PATHS=(
-            packages/adapter-go-template/src
-            packages/adapter-hono/src
-            packages/adapter-mojolicious/src
-            packages/chart/src
-            packages/cli/src
-            packages/client/src
-            packages/create-barefootjs/src
-            packages/form/src
-            packages/jsx/src
-            packages/shared/src
-            packages/streaming/src
-            packages/test/src
-            packages/xyflow/src
-          )
+          # Derive published-package src/ paths dynamically from:
+          #   - packages/*/package.json (skip private: true)
+          #   - .changeset/config.json ignore list
+          ignore_list=$(jq -r '.ignore[]' .changeset/config.json)
+          PUBLISHED_SRC_PATHS=()
+          for pkg_json in packages/*/package.json; do
+            dir=$(dirname "$pkg_json")
+            name=$(jq -r '.name' "$pkg_json")
+            is_private=$(jq -r '.private // false' "$pkg_json")
+            if [ "$is_private" = "true" ]; then
+              continue
+            fi
+            if echo "$ignore_list" | grep -qxF "$name"; then
+              continue
+            fi
+            if [ -d "$dir/src" ]; then
+              PUBLISHED_SRC_PATHS+=("$dir/src")
+            fi
+          done
 
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
           HEAD_SHA="${{ github.event.pull_request.head.sha }}"


### PR DESCRIPTION
## Summary

- Add `changeset-check.yml` workflow that runs on PRs to main
- **Requires** a changeset when non-test files under published packages' `src/` are modified
- **Skips** for tests (`__tests__/`, `.test.`, `.spec.`), docs, CI config, and private/ignored packages
- **Escape hatch**: add a `no-changeset` label to skip the check entirely

### How it works

The workflow diffs the PR against base, filters out test files, and checks if any remaining file falls under a published package's `src/` directory. If yes, it looks for `.changeset/*.md` files. If none are found, the job fails with a message listing which files triggered the requirement.

### Published packages checked

`adapter-go-template`, `adapter-hono`, `adapter-mojolicious`, `chart`, `cli`, `client`, `create-barefootjs`, `form`, `jsx`, `shared`, `streaming`, `test`, `xyflow`

(Derived from non-private packages, excluding those in `.changeset/config.json` ignore list)

## Test plan

- [ ] PR with only test/doc changes → check passes (no changeset required)
- [ ] PR touching `packages/jsx/src/` without changeset → check fails with helpful error
- [ ] PR touching `packages/jsx/src/` with changeset → check passes
- [ ] PR with `no-changeset` label → job skipped entirely

https://claude.ai/code/session_01SEG1QwvsXVy6LoAFbYXLLS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEG1QwvsXVy6LoAFbYXLLS)_