### PR TITLE
Delete BF020 INVALID_JSX_EXPRESSION — generic catch-all subsumed by BF021

### DIFF
--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -426,8 +426,8 @@ for (const page of PAGES) {
 //     a stateful component; BF044 needs a declared signal getter).
 //     These are doc-edit follow-ups.
 //
-// Previously-documented-but-unimplemented codes (BF020,
-// BF022, BF030, BF031, BF040, BF041, BF042) were removed from the
+// Previously-documented-but-unimplemented codes (BF022, BF030,
+// BF031, BF040, BF041, BF042) were removed from the
 // doc to keep it honest. The constants remain reserved in `errors.ts`.
 //
 // The skip list lives in code so a future PR that enriches the doc

--- a/packages/jsx/src/__tests__/invalid-jsx-expression.audit.test.ts
+++ b/packages/jsx/src/__tests__/invalid-jsx-expression.audit.test.ts
@@ -1,0 +1,44 @@
+/**
+ * BF020 `INVALID_JSX_EXPRESSION` deletion audit.
+ *
+ * BF020 was reserved as a generic "Invalid JSX expression" catch-all.
+ * BF021 (UNSUPPORTED_JSX_PATTERN) already covers every concrete case
+ * where a JSX expression is unsupported by the compiler, and TypeScript
+ * itself catches syntactically invalid JSX.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { analyzeComponent } from '../analyzer'
+import { jsxToIR } from '../jsx-to-ir'
+import { ErrorCodes } from '../errors'
+
+function compileToIR(source: string) {
+  const ctx = analyzeComponent(source, '/tmp/Test.tsx')
+  const ir = jsxToIR(ctx)
+  return { ctx, ir, errors: ctx.errors }
+}
+
+describe('BF020 INVALID_JSX_EXPRESSION — deletion audit', () => {
+  test('valid JSX expressions compile without errors', () => {
+    const src = `'use client'
+import { createSignal } from '@barefootjs/client'
+export function App() {
+  const [show, setShow] = createSignal(true)
+  return <div>{show() ? <span>yes</span> : <span>no</span>}</div>
+}
+`
+    const { errors } = compileToIR(src)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('unsupported JSX patterns are caught by BF021, not BF020', () => {
+    const allCodes = Object.values(ErrorCodes)
+    expect(allCodes).toContain('BF021')
+    expect(allCodes).not.toContain('BF020')
+  })
+
+  test('BF020 code no longer exists in ErrorCodes', () => {
+    const allCodes = Object.values(ErrorCodes)
+    expect(allCodes).not.toContain('BF020')
+  })
+})

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -22,8 +22,7 @@ export const ErrorCodes = {
   // Signal/Memo errors (BF011-BF019)
   SIGNAL_OUTSIDE_COMPONENT: 'BF011',
 
-  // JSX errors (BF020-BF029)
-  INVALID_JSX_EXPRESSION: 'BF020',
+  // JSX errors (BF021-BF029)
   UNSUPPORTED_JSX_PATTERN: 'BF021',
   INVALID_JSX_ATTRIBUTE: 'BF022',
   MISSING_KEY_IN_LIST: 'BF023',
@@ -110,7 +109,6 @@ const errorMessages: Record<ErrorCode, string> = {
     'The downstream codegen drops the declaration silently and every reference becomes a ReferenceError at SSR and at hydrate. ' +
     'Move the declaration inside a component function so each mount gets its own state.',
 
-  [ErrorCodes.INVALID_JSX_EXPRESSION]: 'Invalid JSX expression',
   [ErrorCodes.UNSUPPORTED_JSX_PATTERN]: 'Unsupported JSX pattern',
   [ErrorCodes.INVALID_JSX_ATTRIBUTE]: 'Invalid JSX attribute',
   [ErrorCodes.MISSING_KEY_IN_LIST]:


### PR DESCRIPTION
## Summary

- **Delete** `BF020 INVALID_JSX_EXPRESSION` from `errors.ts` — generic catch-all that was never emitted
- BF021 (`UNSUPPORTED_JSX_PATTERN`) already covers every concrete unsupported JSX case
- TypeScript catches syntactically invalid JSX at the language level

**Stack:** 1/4 — BF020 → BF022 → BF030 → BF031

## Test plan

- [x] `invalid-jsx-expression.audit.test.ts` verifies valid JSX compiles cleanly and BF020 no longer exists
- [x] `doc-examples.test.ts` passes (204 pass, 27 skip)

Closes #1552 (BF020 item only)

https://claude.ai/code/session_01SEG1QwvsXVy6LoAFbYXLLS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEG1QwvsXVy6LoAFbYXLLS)_