### PR TITLE
Delete BF022 INVALID_JSX_ATTRIBUTE — subsumed by TypeScript type-checking

### DIFF
--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -426,8 +426,8 @@ for (const page of PAGES) {
 //     a stateful component; BF044 needs a declared signal getter).
 //     These are doc-edit follow-ups.
 //
-// Previously-documented-but-unimplemented codes (BF022, BF030,
-// BF031, BF040, BF041, BF042) were removed from the
+// Previously-documented-but-unimplemented codes (BF030, BF031,
+// BF040, BF041, BF042) were removed from the
 // doc to keep it honest. The constants remain reserved in `errors.ts`.
 //
 // The skip list lives in code so a future PR that enriches the doc

--- a/packages/jsx/src/__tests__/invalid-jsx-attribute.audit.test.ts
+++ b/packages/jsx/src/__tests__/invalid-jsx-attribute.audit.test.ts
@@ -1,0 +1,47 @@
+/**
+ * BF022 `INVALID_JSX_ATTRIBUTE` deletion audit.
+ *
+ * BF022 was reserved for "Invalid JSX attribute" but was never emitted.
+ * TypeScript's own type-checking catches invalid attribute names and
+ * types at the language level.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { analyzeComponent } from '../analyzer'
+import { jsxToIR } from '../jsx-to-ir'
+import { ErrorCodes } from '../errors'
+
+function compileToIR(source: string) {
+  const ctx = analyzeComponent(source, '/tmp/Test.tsx')
+  const ir = jsxToIR(ctx)
+  return { ctx, ir, errors: ctx.errors }
+}
+
+describe('BF022 INVALID_JSX_ATTRIBUTE — deletion audit', () => {
+  test('valid JSX attributes compile without errors', () => {
+    const src = `'use client'
+import { createSignal } from '@barefootjs/client'
+export function App() {
+  const [name, setName] = createSignal('world')
+  return <input type="text" value={name()} onInput={(e) => setName(e.target.value)} />
+}
+`
+    const { errors } = compileToIR(src)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('spread attributes compile without errors', () => {
+    const src = `
+export function App(props: { class?: string; id?: string }) {
+  return <div {...props}>content</div>
+}
+`
+    const { errors } = compileToIR(src)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('BF022 code no longer exists in ErrorCodes', () => {
+    const allCodes = Object.values(ErrorCodes)
+    expect(allCodes).not.toContain('BF022')
+  })
+})

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -24,7 +24,6 @@ export const ErrorCodes = {
 
   // JSX errors (BF021-BF029)
   UNSUPPORTED_JSX_PATTERN: 'BF021',
-  INVALID_JSX_ATTRIBUTE: 'BF022',
   MISSING_KEY_IN_LIST: 'BF023',
   MISSING_KEY_IN_NESTED_LIST: 'BF024',
   UNSUPPORTED_DESTRUCTURE_REST: 'BF025',
@@ -110,7 +109,6 @@ const errorMessages: Record<ErrorCode, string> = {
     'Move the declaration inside a component function so each mount gets its own state.',
 
   [ErrorCodes.UNSUPPORTED_JSX_PATTERN]: 'Unsupported JSX pattern',
-  [ErrorCodes.INVALID_JSX_ATTRIBUTE]: 'Invalid JSX attribute',
   [ErrorCodes.MISSING_KEY_IN_LIST]:
     'Missing key attribute in list rendering. Add a key prop for efficient updates',
   [ErrorCodes.MISSING_KEY_IN_NESTED_LIST]:


### PR DESCRIPTION
## Summary

- **Delete** `BF022 INVALID_JSX_ATTRIBUTE` from `errors.ts` — never emitted
- TypeScript catches invalid attribute names and types at the language level

**Stack:** 2/4 — base: `claude/bf020-audit`

## Test plan

- [x] `invalid-jsx-attribute.audit.test.ts` verifies valid attributes and spread compile cleanly
- [x] `doc-examples.test.ts` passes

Closes #1552 (BF022 item only)

https://claude.ai/code/session_01SEG1QwvsXVy6LoAFbYXLLS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEG1QwvsXVy6LoAFbYXLLS)_