### PR TITLE
Delete BF030 TYPE_INFERENCE_FAILED — compiler gracefully degrades

### DIFF
--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -426,8 +426,8 @@ for (const page of PAGES) {
 //     a stateful component; BF044 needs a declared signal getter).
 //     These are doc-edit follow-ups.
 //
-// Previously-documented-but-unimplemented codes (BF030, BF031,
-// BF040, BF041, BF042) were removed from the
+// Previously-documented-but-unimplemented codes (BF031, BF040,
+// BF041, BF042) were removed from the
 // doc to keep it honest. The constants remain reserved in `errors.ts`.
 //
 // The skip list lives in code so a future PR that enriches the doc

--- a/packages/jsx/src/__tests__/type-inference-failed.audit.test.ts
+++ b/packages/jsx/src/__tests__/type-inference-failed.audit.test.ts
@@ -1,0 +1,48 @@
+/**
+ * BF030 `TYPE_INFERENCE_FAILED` deletion audit.
+ *
+ * BF030 was reserved for "Failed to infer type" — intended as a
+ * fallback when the compiler's `ts.Program`-based type detection
+ * fails. In practice, the compiler gracefully degrades (treats
+ * unknown types as non-reactive) and TypeScript itself reports
+ * type errors to the developer. No silent bug exists.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { analyzeComponent } from '../analyzer'
+import { jsxToIR } from '../jsx-to-ir'
+import { ErrorCodes } from '../errors'
+
+function compileToIR(source: string) {
+  const ctx = analyzeComponent(source, '/tmp/Test.tsx')
+  const ir = jsxToIR(ctx)
+  return { ctx, ir, errors: ctx.errors }
+}
+
+describe('BF030 TYPE_INFERENCE_FAILED — deletion audit', () => {
+  test('component with typed props compiles without errors', () => {
+    const src = `
+interface Props { count: number; label: string }
+export function Display(props: Props) {
+  return <div>{props.label}: {props.count}</div>
+}
+`
+    const { errors } = compileToIR(src)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('component with generic props compiles without errors', () => {
+    const src = `
+export function List<T extends { id: string }>(props: { items: T[] }) {
+  return <ul>{props.items.map((item) => <li key={item.id}>{item.id}</li>)}</ul>
+}
+`
+    const { errors } = compileToIR(src)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('BF030 code no longer exists in ErrorCodes', () => {
+    const allCodes = Object.values(ErrorCodes)
+    expect(allCodes).not.toContain('BF030')
+  })
+})

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -28,8 +28,7 @@ export const ErrorCodes = {
   MISSING_KEY_IN_NESTED_LIST: 'BF024',
   UNSUPPORTED_DESTRUCTURE_REST: 'BF025',
 
-  // Type errors (BF030-BF039)
-  TYPE_INFERENCE_FAILED: 'BF030',
+  // Type errors (BF031-BF039)
   PROPS_TYPE_MISMATCH: 'BF031',
 
   // Component errors (BF040-BF049)
@@ -122,7 +121,6 @@ const errorMessages: Record<ErrorCode, string> = {
     // stable.
     'Computed property key in .map() callback destructure is not supported. Rewrite the callback to destructure explicit bindings (e.g., `({ a, b }) => ...`) so the compiler can rewrite references to per-item signal accessors.',
 
-  [ErrorCodes.TYPE_INFERENCE_FAILED]: 'Failed to infer type',
   [ErrorCodes.PROPS_TYPE_MISMATCH]: 'Props type mismatch',
 
   [ErrorCodes.COMPONENT_NOT_FOUND]: 'Component not found',


### PR DESCRIPTION
## Summary

- **Delete** `BF030 TYPE_INFERENCE_FAILED` from `errors.ts` — never emitted
- The compiler gracefully degrades when type inference fails (treats unknown types as non-reactive)
- TypeScript itself reports type errors to the developer

**Stack:** 3/4 — base: `claude/bf022-audit`

## Test plan

- [x] `type-inference-failed.audit.test.ts` verifies typed and generic components compile cleanly
- [x] `doc-examples.test.ts` passes

Closes #1552 (BF030 item only)

https://claude.ai/code/session_01SEG1QwvsXVy6LoAFbYXLLS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEG1QwvsXVy6LoAFbYXLLS)_