### PR TITLE
Delete BF031 PROPS_TYPE_MISMATCH — subsumed by TypeScript type-checking

### DIFF
--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -426,8 +426,8 @@ for (const page of PAGES) {
 //     a stateful component; BF044 needs a declared signal getter).
 //     These are doc-edit follow-ups.
 //
-// Previously-documented-but-unimplemented codes (BF031, BF040,
-// BF041, BF042) were removed from the
+// Previously-documented-but-unimplemented codes (BF040, BF041,
+// BF042) were removed from the
 // doc to keep it honest. The constants remain reserved in `errors.ts`.
 //
 // The skip list lives in code so a future PR that enriches the doc

--- a/packages/jsx/src/__tests__/props-type-mismatch.audit.test.ts
+++ b/packages/jsx/src/__tests__/props-type-mismatch.audit.test.ts
@@ -1,0 +1,100 @@
+/**
+ * BF031 `PROPS_TYPE_MISMATCH` deletion audit.
+ *
+ * BF031 was reserved for "Props type mismatch" but was never emitted.
+ * TypeScript's own type-checking catches props type mismatches at the
+ * language level (e.g., passing a string where a number is expected).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import ts from 'typescript'
+import path from 'path'
+import { analyzeComponent } from '../analyzer'
+import { jsxToIR } from '../jsx-to-ir'
+import { ErrorCodes } from '../errors'
+
+function compileToIR(source: string) {
+  const ctx = analyzeComponent(source, '/tmp/Test.tsx')
+  const ir = jsxToIR(ctx)
+  return { ctx, ir, errors: ctx.errors }
+}
+
+function getSemanticDiagnostics(source: string) {
+  const baseDir = path.resolve(__dirname)
+  const filePath = path.join(baseDir, '_props-mismatch-virtual.tsx')
+
+  const virtualFiles = new Map<string, string>()
+  virtualFiles.set(filePath, source)
+
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.Latest,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    jsx: ts.JsxEmit.ReactJSX,
+    jsxImportSource: 'react',
+    strict: true,
+    noEmit: true,
+    skipLibCheck: true,
+  }
+
+  const defaultHost = ts.createCompilerHost(compilerOptions)
+
+  const host: ts.CompilerHost = {
+    ...defaultHost,
+    getSourceFile(fileName, languageVersion) {
+      const resolved = path.resolve(fileName)
+      const content = virtualFiles.get(resolved)
+      if (content !== undefined) {
+        return ts.createSourceFile(fileName, content, languageVersion, true)
+      }
+      return defaultHost.getSourceFile(fileName, languageVersion)
+    },
+    fileExists(fileName) {
+      const resolved = path.resolve(fileName)
+      if (virtualFiles.has(resolved)) return true
+      return defaultHost.fileExists(fileName)
+    },
+    readFile(fileName) {
+      const resolved = path.resolve(fileName)
+      const content = virtualFiles.get(resolved)
+      if (content !== undefined) return content
+      return defaultHost.readFile(fileName)
+    },
+  }
+
+  const program = ts.createProgram([filePath], compilerOptions, host)
+  return program.getSemanticDiagnostics(program.getSourceFile(filePath)!)
+}
+
+describe('BF031 PROPS_TYPE_MISMATCH — deletion audit', () => {
+  test('correct props compile without errors', () => {
+    const src = `
+interface Props { count: number; label: string }
+export function Display(props: Props) {
+  return <div>{props.label}: {props.count}</div>
+}
+`
+    const { errors } = compileToIR(src)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('TypeScript catches props type mismatches', () => {
+    const src = `
+function Child(props: { count: number }) {
+  return <div>{props.count}</div>
+}
+export function Parent() {
+  return <Child count={"not a number"} />
+}
+`
+    const diagnostics = getSemanticDiagnostics(src)
+    expect(diagnostics.length).toBeGreaterThanOrEqual(1)
+    const messages = diagnostics.map(d => ts.flattenDiagnosticMessageText(d.messageText, '\n'))
+    expect(messages.some(m => m.includes('number') || m.includes('not assignable'))).toBe(true)
+  })
+
+  test('BF031 code no longer exists in ErrorCodes', () => {
+    const allCodes = Object.values(ErrorCodes)
+    expect(allCodes).not.toContain('BF031')
+  })
+})

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -28,9 +28,6 @@ export const ErrorCodes = {
   MISSING_KEY_IN_NESTED_LIST: 'BF024',
   UNSUPPORTED_DESTRUCTURE_REST: 'BF025',
 
-  // Type errors (BF031-BF039)
-  PROPS_TYPE_MISMATCH: 'BF031',
-
   // Component errors (BF040-BF049)
   COMPONENT_NOT_FOUND: 'BF040',
   CIRCULAR_DEPENDENCY: 'BF041',
@@ -120,8 +117,6 @@ const errorMessages: Record<ErrorCode, string> = {
     // keeps its name so external consumers' `e.code === 'BF025'` checks remain
     // stable.
     'Computed property key in .map() callback destructure is not supported. Rewrite the callback to destructure explicit bindings (e.g., `({ a, b }) => ...`) so the compiler can rewrite references to per-item signal accessors.',
-
-  [ErrorCodes.PROPS_TYPE_MISMATCH]: 'Props type mismatch',
 
   [ErrorCodes.COMPONENT_NOT_FOUND]: 'Component not found',
   [ErrorCodes.CIRCULAR_DEPENDENCY]: 'Circular dependency detected',


### PR DESCRIPTION
## Summary

- **Delete** `BF031 PROPS_TYPE_MISMATCH` from `errors.ts` — never emitted
- TypeScript catches props type mismatches at the language level (e.g., `ts(2322)`)
- Removes the entire "Type errors (BF030-BF039)" section from `errors.ts` as both codes are now deleted

**Stack:** 4/4 — base: `claude/bf030-audit`

## Test plan

- [x] `props-type-mismatch.audit.test.ts` verifies correct props compile cleanly and TS catches mismatches
- [x] `doc-examples.test.ts` passes (204 pass, 27 skip)

Closes #1552 (BF031 item only)

https://claude.ai/code/session_01SEG1QwvsXVy6LoAFbYXLLS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEG1QwvsXVy6LoAFbYXLLS)_