### PR TITLE
feat: add plugin marketplace for distributable barefootjs skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "barefootjs",
+  "owner": {
+    "name": "Piconic AI",
+    "email": "kentafly88@gmail.com"
+  },
+  "description": "Skills for building UI components with BarefootJS — signal-based reactivity for any backend.",
+  "version": "1.0.0",
+  "plugins": [
+    {
+      "name": "barefootjs",
+      "source": "./plugins/barefootjs",
+      "description": "Build, inspect, and debug UI components using the @barefootjs/cli."
+    }
+  ]
+}

--- a/plugins/barefootjs/.claude-plugin/plugin.json
+++ b/plugins/barefootjs/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "barefootjs",
+  "version": "0.1.2",
+  "description": "Build, inspect, and debug UI components using @barefootjs/cli. Covers component discovery, scaffolding, signal inspection, and previews.",
+  "homepage": "https://github.com/piconic-ai/barefootjs"
+}

--- a/plugins/barefootjs/skills/barefootjs/SKILL.md
+++ b/plugins/barefootjs/skills/barefootjs/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: barefootjs
+description: "Build, inspect, and debug UI components using @barefootjs/cli. Use when: creating/editing/reviewing components, investigating signal dependencies, debugging reactive updates, scaffolding new components, or looking up component APIs."
+---
+# Component Development Skill
+
+Build UI components using `@barefootjs/cli` for component discovery, scaffolding, testing, and signal inspection.
+
+## Setup
+
+Ensure the CLI is available. If the project doesn't already have it installed:
+
+```bash
+npx @barefootjs/cli --help
+```
+
+Or install it as a dev dependency:
+
+```bash
+npm install -D @barefootjs/cli
+# or
+bun add -d @barefootjs/cli
+```
+
+Once installed, use `npx bf` (or `bunx bf`) to run commands.
+
+## Workflow
+
+1. `npx bf search <query>` — Find components and docs by name/category/tags
+2. `npx bf docs <component>` — Get props, examples, accessibility info
+3. `npx bf guide <topic>` — Read framework docs (signals, compiler constraints, etc.)
+4. `npx bf gen component <name> <comp...>` — Generate skeleton + basic IR test
+5. Implement the component
+6. Run tests — Verify compilation
+7. `npx bf gen test <name>` — Regenerate richer IR test
+8. Run tests — Final verification
+9. Create previews and run `npx bf preview <name>` — Visual preview in browser
+10. Ask the user to check the browser for visual/interaction verification
+
+## Signal Inspection & Debugging
+
+Use these commands to understand and debug a component's reactive structure **without running any code**. All analysis is static (from IR).
+
+### `npx bf debug graph <component>`
+
+Show the signal dependency graph for a component. Use this **before modifying** a stateful component to understand its reactive structure: which signals exist, what memos depend on them, and which DOM nodes are bound.
+
+- Add `--json` for machine-readable output.
+- Example: `npx bf debug graph combobox`
+
+### `npx bf debug trace <component> <signal|memo>`
+
+Reverse-lookup: trace the full propagation path from a signal/memo to every DOM binding it affects. Use this to answer "why does this DOM node update?" or to verify that a signal change reaches the expected targets.
+
+- If the signal name is wrong, the CLI lists available signals/memos.
+- Add `--json` for machine-readable output.
+- Example: `npx bf debug trace combobox open`
+
+### `npx bf debug signals <component>`
+
+Show a signal initialization trace: every signal, its initial value, and its effect bindings. Useful for verifying that signals are wired correctly in a newly written or modified component.
+
+- Add `--json` for machine-readable output.
+- Example: `npx bf debug signals select`
+
+### `npx bf debug fallbacks <component>`
+
+Surface fallback-wrapped expressions emitted by Solid-style wrap-by-default. Use this to find candidates for `createMemo` refactor — places where the compiler couldn't statically prove reactivity and fell back to wrapping.
+
+- Add `--json` for machine-readable output.
+- Example: `npx bf debug fallbacks combobox`
+
+### When to use inspection
+
+- **Before editing a stateful component** — run `debug graph` to map the reactive graph.
+- **Unexpected re-renders or missing updates** — run `debug trace` to trace propagation.
+- **After implementing a new component** — run `debug signals` to verify signal wiring.
+- **Reviewing a PR** — run `debug graph --json` to diff the dependency graph before/after.
+
+## Previews
+
+Previews provide visual preview with full hydration support.
+
+### File location
+
+`ui/components/ui/__previews__/<name>.previews.tsx`
+
+### Format
+
+Each `export function` becomes a separate preview. PascalCase names are auto-converted to display titles (e.g., `WithLabel` → "With Label").
+
+```tsx
+"use client"
+
+import { ComponentName } from '../component-name'
+
+/** Default usage */
+export function Default() {
+  return <ComponentName />
+}
+
+/** Show a specific variant or state */
+export function WithProps() {
+  return <ComponentName variant="outline" disabled />
+}
+```
+
+### Guidelines
+
+- Always include a `Default` preview showing basic usage.
+- Add previews for key variants, states, and compositions (e.g., `WithLabel`, `Disabled`, `PreFilled`).
+- Previews that use signals need `"use client"` at the top.
+- Import components via relative path from `../` (e.g., `import { Button } from '../button'`).
+- After creating previews, run `npx bf preview <name>` and ask the user to verify in the browser.
+
+## Rules
+
+- Use `bf search` and `bf docs` for component discovery. Do not read source files to learn component APIs.
+- Use `bf guide error-codes` to check compiler constraints (BF001, BF021, etc.) before writing components.
+- New components go in `ui/components/ui/<name>.tsx`.
+- IR tests go in `ui/components/ui/__tests__/<name>.test.ts`.
+- Stateful components (using signals) must have `"use client"` as the first line.
+- Stateful components must use `props.xxx` (not destructuring) to maintain reactivity.
+- Use `createSignal`, `createMemo`, `createEffect` from `@barefootjs/client` (SolidJS-style, not React hooks).
+- Use `for` attribute on `<Label>` (not `htmlFor`).
+- Event handlers have typed `e.target` — write `onInput={e => setValue(e.target.value)}` directly. Do not cast with `as HTMLInputElement`.
+- Use `className` in JSX (not `class`). `class` is a JS reserved keyword.
+- Signal getters must be called in JSX: `value={name()}` (not `value={name}`).


### PR DESCRIPTION
## Summary

- Add `.claude-plugin/marketplace.json` so this repo works as a Claude Code plugin marketplace
- Add `plugins/barefootjs/` with a standalone skill that uses `npx @barefootjs/cli` instead of workspace-local `bun run bf`
- Users can install via `/plugin marketplace add piconic-ai/barefootjs` then `/plugin install barefootjs@barefootjs`

## Structure

```
.claude-plugin/marketplace.json        # Marketplace catalog
plugins/barefootjs/
├── .claude-plugin/plugin.json          # Plugin manifest
└── skills/barefootjs/SKILL.md          # Distributable skill (npx @barefootjs/cli)
```

## How users install

```bash
/plugin marketplace add piconic-ai/barefootjs
/plugin install barefootjs@barefootjs
```

The skill then provides component discovery, scaffolding, signal debugging, and preview commands powered by `@barefootjs/cli` (published on npm).

## Test plan

- [ ] Verify `/plugin marketplace add piconic-ai/barefootjs` discovers the plugin
- [ ] Verify `/plugin install barefootjs@barefootjs` installs the skill
- [ ] Verify skill triggers correctly when creating/editing components in a separate project