### PR TITLE
Delete BF040 COMPONENT_NOT_FOUND — covered by ESM and TypeScript

### DIFF
--- a/packages/jsx/src/__tests__/component-not-found.audit.test.ts
+++ b/packages/jsx/src/__tests__/component-not-found.audit.test.ts
@@ -1,0 +1,36 @@
+/**
+ * BF040 `COMPONENT_NOT_FOUND` deletion audit.
+ *
+ * BF040 was reserved for "Component not found" but was never emitted.
+ * Missing components are caught by ESM's ReferenceError at runtime
+ * and by TypeScript's undeclared-identifier diagnostics at compile time.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { analyzeComponent } from '../analyzer'
+import { jsxToIR } from '../jsx-to-ir'
+import { ErrorCodes } from '../errors'
+
+function compileToIR(source: string) {
+  const ctx = analyzeComponent(source, '/tmp/Test.tsx')
+  const ir = jsxToIR(ctx)
+  return { ctx, ir, errors: ctx.errors }
+}
+
+describe('BF040 COMPONENT_NOT_FOUND — deletion audit', () => {
+  test('valid component usage compiles without errors', () => {
+    const src = `
+function Child() { return <span>child</span> }
+export function App() {
+  return <div><Child /></div>
+}
+`
+    const { errors } = compileToIR(src)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('BF040 code no longer exists in ErrorCodes', () => {
+    const allCodes = Object.values(ErrorCodes)
+    expect(allCodes).not.toContain('BF040')
+  })
+})

--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -426,7 +426,7 @@ for (const page of PAGES) {
 //     a stateful component; BF044 needs a declared signal getter).
 //     These are doc-edit follow-ups.
 //
-// Previously-documented-but-unimplemented codes (BF040, BF041,
+// Previously-documented-but-unimplemented codes (BF041,
 // BF042) were removed from the
 // doc to keep it honest. The constants remain reserved in `errors.ts`.
 //

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -28,8 +28,7 @@ export const ErrorCodes = {
   MISSING_KEY_IN_NESTED_LIST: 'BF024',
   UNSUPPORTED_DESTRUCTURE_REST: 'BF025',
 
-  // Component errors (BF040-BF049)
-  COMPONENT_NOT_FOUND: 'BF040',
+  // Component errors (BF041-BF049)
   CIRCULAR_DEPENDENCY: 'BF041',
   INVALID_COMPONENT_NAME: 'BF042',
   PROPS_DESTRUCTURING: 'BF043',
@@ -118,7 +117,6 @@ const errorMessages: Record<ErrorCode, string> = {
     // stable.
     'Computed property key in .map() callback destructure is not supported. Rewrite the callback to destructure explicit bindings (e.g., `({ a, b }) => ...`) so the compiler can rewrite references to per-item signal accessors.',
 
-  [ErrorCodes.COMPONENT_NOT_FOUND]: 'Component not found',
   [ErrorCodes.CIRCULAR_DEPENDENCY]: 'Circular dependency detected',
   [ErrorCodes.INVALID_COMPONENT_NAME]:
     'Component name must start with uppercase letter',


### PR DESCRIPTION
## Summary

- **Delete** `BF040 COMPONENT_NOT_FOUND` from `errors.ts` — never emitted
- Missing components are caught by ESM's `ReferenceError` at runtime and by TypeScript's undeclared-identifier diagnostics at compile time

**Stack:** 1/3 — BF040 → BF041 → BF042

## Test plan

- [x] `component-not-found.audit.test.ts` verifies valid component usage compiles cleanly
- [x] `doc-examples.test.ts` passes (204 pass, 27 skip)

Closes #1552 (BF040 item only)

https://claude.ai/code/session_01SEG1QwvsXVy6LoAFbYXLLS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEG1QwvsXVy6LoAFbYXLLS)_