### PR TITLE
Delete BF041 CIRCULAR_DEPENDENCY — handled by ESM and bundlers

### DIFF
--- a/packages/jsx/src/__tests__/circular-dependency.audit.test.ts
+++ b/packages/jsx/src/__tests__/circular-dependency.audit.test.ts
@@ -1,0 +1,19 @@
+/**
+ * BF041 `CIRCULAR_DEPENDENCY` deletion audit.
+ *
+ * BF041 was reserved for "Circular dependency detected" but was never
+ * emitted. ESM handles circular imports via partial initialization,
+ * and bundlers (Vite, esbuild) detect and warn about circular deps.
+ * The barefoot compiler processes one file at a time and has no
+ * cross-file dependency graph to detect cycles.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { ErrorCodes } from '../errors'
+
+describe('BF041 CIRCULAR_DEPENDENCY — deletion audit', () => {
+  test('BF041 code no longer exists in ErrorCodes', () => {
+    const allCodes = Object.values(ErrorCodes)
+    expect(allCodes).not.toContain('BF041')
+  })
+})

--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -426,8 +426,8 @@ for (const page of PAGES) {
 //     a stateful component; BF044 needs a declared signal getter).
 //     These are doc-edit follow-ups.
 //
-// Previously-documented-but-unimplemented codes (BF041,
-// BF042) were removed from the
+// Previously-documented-but-unimplemented codes (BF042)
+// were removed from the
 // doc to keep it honest. The constants remain reserved in `errors.ts`.
 //
 // The skip list lives in code so a future PR that enriches the doc

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -28,8 +28,7 @@ export const ErrorCodes = {
   MISSING_KEY_IN_NESTED_LIST: 'BF024',
   UNSUPPORTED_DESTRUCTURE_REST: 'BF025',
 
-  // Component errors (BF041-BF049)
-  CIRCULAR_DEPENDENCY: 'BF041',
+  // Component errors (BF042-BF049)
   INVALID_COMPONENT_NAME: 'BF042',
   PROPS_DESTRUCTURING: 'BF043',
   SIGNAL_GETTER_NOT_CALLED: 'BF044',
@@ -117,7 +116,6 @@ const errorMessages: Record<ErrorCode, string> = {
     // stable.
     'Computed property key in .map() callback destructure is not supported. Rewrite the callback to destructure explicit bindings (e.g., `({ a, b }) => ...`) so the compiler can rewrite references to per-item signal accessors.',
 
-  [ErrorCodes.CIRCULAR_DEPENDENCY]: 'Circular dependency detected',
   [ErrorCodes.INVALID_COMPONENT_NAME]:
     'Component name must start with uppercase letter',
   [ErrorCodes.PROPS_DESTRUCTURING]:


### PR DESCRIPTION
## Summary

- **Delete** `BF041 CIRCULAR_DEPENDENCY` from `errors.ts` — never emitted
- ESM handles circular imports via partial initialization, and bundlers (Vite, esbuild) detect cycles
- The barefoot compiler processes one file at a time and has no cross-file dependency graph

**Stack:** 2/3 — base: `claude/bf040-audit`

## Test plan

- [x] `circular-dependency.audit.test.ts` verifies BF041 no longer exists
- [x] `doc-examples.test.ts` passes

Closes #1552 (BF041 item only)

https://claude.ai/code/session_01SEG1QwvsXVy6LoAFbYXLLS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEG1QwvsXVy6LoAFbYXLLS)_