### PR TITLE
Delete BF042 INVALID_COMPONENT_NAME — enforced by JSX lowercasing rules

### DIFF
--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -426,9 +426,8 @@ for (const page of PAGES) {
 //     a stateful component; BF044 needs a declared signal getter).
 //     These are doc-edit follow-ups.
 //
-// Previously-documented-but-unimplemented codes (BF042)
-// were removed from the
-// doc to keep it honest. The constants remain reserved in `errors.ts`.
+// Previously-documented-but-unimplemented codes were removed from the
+// doc to keep it honest.
 //
 // The skip list lives in code so a future PR that enriches the doc
 // snippet simply removes the entry and the test starts asserting.

--- a/packages/jsx/src/__tests__/invalid-component-name.audit.test.ts
+++ b/packages/jsx/src/__tests__/invalid-component-name.audit.test.ts
@@ -1,0 +1,38 @@
+/**
+ * BF042 `INVALID_COMPONENT_NAME` deletion audit.
+ *
+ * BF042 was reserved for "Component name must start with uppercase
+ * letter" but was never emitted. JSX's own lowercasing rules already
+ * enforce this: lowercase tags are treated as intrinsic HTML elements,
+ * so `<myComponent />` renders as `<mycomponent>` rather than calling
+ * a component function. TypeScript also errors on the type mismatch.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { analyzeComponent } from '../analyzer'
+import { jsxToIR } from '../jsx-to-ir'
+import { ErrorCodes } from '../errors'
+
+function compileToIR(source: string) {
+  const ctx = analyzeComponent(source, '/tmp/Test.tsx')
+  const ir = jsxToIR(ctx)
+  return { ctx, ir, errors: ctx.errors }
+}
+
+describe('BF042 INVALID_COMPONENT_NAME — deletion audit', () => {
+  test('PascalCase component compiles without errors', () => {
+    const src = `
+function MyButton() { return <button>click</button> }
+export function App() {
+  return <MyButton />
+}
+`
+    const { errors } = compileToIR(src)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('BF042 code no longer exists in ErrorCodes', () => {
+    const allCodes = Object.values(ErrorCodes)
+    expect(allCodes).not.toContain('BF042')
+  })
+})

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -28,8 +28,7 @@ export const ErrorCodes = {
   MISSING_KEY_IN_NESTED_LIST: 'BF024',
   UNSUPPORTED_DESTRUCTURE_REST: 'BF025',
 
-  // Component errors (BF042-BF049)
-  INVALID_COMPONENT_NAME: 'BF042',
+  // Component errors (BF043-BF049)
   PROPS_DESTRUCTURING: 'BF043',
   SIGNAL_GETTER_NOT_CALLED: 'BF044',
   JSX_IN_LOCAL_FUNCTION: 'BF045',
@@ -116,8 +115,6 @@ const errorMessages: Record<ErrorCode, string> = {
     // stable.
     'Computed property key in .map() callback destructure is not supported. Rewrite the callback to destructure explicit bindings (e.g., `({ a, b }) => ...`) so the compiler can rewrite references to per-item signal accessors.',
 
-  [ErrorCodes.INVALID_COMPONENT_NAME]:
-    'Component name must start with uppercase letter',
   [ErrorCodes.PROPS_DESTRUCTURING]:
     'Props destructuring in function parameters breaks reactivity. Use props object directly.',
   [ErrorCodes.SIGNAL_GETTER_NOT_CALLED]:


### PR DESCRIPTION
## Summary

- **Delete** `BF042 INVALID_COMPONENT_NAME` from `errors.ts` — never emitted
- JSX's own lowercasing rules already enforce this: lowercase tags become intrinsic HTML elements (`<myComponent />` → `<mycomponent>`)
- TypeScript also errors on the type mismatch

**Stack:** 3/3 — base: `claude/bf041-audit`

## Test plan

- [x] `invalid-component-name.audit.test.ts` verifies PascalCase component compiles cleanly
- [x] `doc-examples.test.ts` passes (204 pass, 27 skip)

Closes #1552 (BF042 item only)

https://claude.ai/code/session_01SEG1QwvsXVy6LoAFbYXLLS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEG1QwvsXVy6LoAFbYXLLS)_