### PR TITLE
feat(jsx): inline multi-return JSX helper functions as conditional IR

### DIFF
--- a/packages/jsx/src/__tests__/jsx-function-inlining.test.ts
+++ b/packages/jsx/src/__tests__/jsx-function-inlining.test.ts
@@ -658,5 +658,48 @@ describe('JSX function inlining (#569)', () => {
       // Should NOT be registered because discriminant is a call expression
       expect(ctx.jsxMultiReturnFunctions.has('renderByValue')).toBe(false)
     })
+
+    test('switch without default clause is NOT inlined', () => {
+      const source = `
+        'use client'
+
+        export function App(props: { icon: string }) {
+          function renderIcon(name: string) {
+            switch (name) {
+              case 'home': return <span>🏠</span>
+              case 'star': return <span>⭐</span>
+            }
+          }
+
+          return <div>{renderIcon(props.icon)}</div>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'App.tsx')
+      expect(ctx.jsxMultiReturnFunctions.has('renderIcon')).toBe(false)
+    })
+
+    test('if/else with trailing return does not overwrite else fallback', () => {
+      const source = `
+        'use client'
+
+        export function App(props: { mode: string }) {
+          function renderMode(m: string) {
+            if (m === 'a') return <span>A</span>
+            else return <span>B</span>
+          }
+
+          return <div>{renderMode(props.mode)}</div>
+        }
+      `
+
+      const result = compileJSX(source, 'App.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!.content
+      // The else fallback should be <span>B</span>, not overwritten
+      expect(template).toContain('A')
+      expect(template).toContain('B')
+    })
   })
 })

--- a/packages/jsx/src/__tests__/jsx-function-inlining.test.ts
+++ b/packages/jsx/src/__tests__/jsx-function-inlining.test.ts
@@ -559,5 +559,85 @@ describe('JSX function inlining (#569)', () => {
       expect(template).toContain('props.name')
       expect(template).not.toMatch(/\bwho\b/)
     })
+
+    test('switch/case helper is inlined as nested conditional', () => {
+      const source = `
+        'use client'
+
+        export function App(props: { icon: string }) {
+          function renderIcon(name: string) {
+            switch (name) {
+              case 'home': return <span>🏠</span>
+              case 'star': return <span>⭐</span>
+              default: return <span>?</span>
+            }
+          }
+
+          return <div>{renderIcon(props.icon)}</div>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'App.tsx')
+      expect(ctx.jsxMultiReturnFunctions.has('renderIcon')).toBe(true)
+      const info = ctx.jsxMultiReturnFunctions.get('renderIcon')!
+      expect(info.branches).toHaveLength(2)
+      expect(info.fallback).not.toBeNull()
+      expect(info.switchDiscriminant).toBeDefined()
+
+      const result = compileJSX(source, 'App.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!.content
+      expect(template).toContain('🏠')
+      expect(template).toContain('⭐')
+      expect(template).toContain('?')
+      expect(template).not.toMatch(/function renderIcon/)
+    })
+
+    test('switch with null default is handled', () => {
+      const source = `
+        'use client'
+
+        export function App(props: { status: string }) {
+          function renderStatus(s: string) {
+            switch (s) {
+              case 'ok': return <span class="ok">OK</span>
+              default: return null
+            }
+          }
+
+          return <div>{renderStatus(props.status)}</div>
+        }
+      `
+
+      const result = compileJSX(source, 'App.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!.content
+      expect(template).toContain('OK')
+      expect(template).not.toMatch(/function renderStatus/)
+    })
+
+    test('switch with side-effect discriminant is NOT inlined', () => {
+      const source = `
+        'use client'
+
+        export function App() {
+          function getValue(): string { return 'a' }
+          function renderByValue(v: string) {
+            switch (getValue()) {
+              case 'a': return <span>A</span>
+              default: return <span>B</span>
+            }
+          }
+
+          return <div>{renderByValue('x')}</div>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'App.tsx')
+      // Should NOT be registered because discriminant is a call expression
+      expect(ctx.jsxMultiReturnFunctions.has('renderByValue')).toBe(false)
+    })
   })
 })

--- a/packages/jsx/src/__tests__/jsx-function-inlining.test.ts
+++ b/packages/jsx/src/__tests__/jsx-function-inlining.test.ts
@@ -105,7 +105,7 @@ describe('JSX function inlining (#569)', () => {
       expect(fn!.isJsxFunction).toBe(true)
     })
 
-    test('does not set isJsxFunction for functions with multiple returns', () => {
+    test('multi-return function is stored in jsxMultiReturnFunctions (not jsxFunctions)', () => {
       const source = `
         'use client'
 
@@ -121,6 +121,11 @@ describe('JSX function inlining (#569)', () => {
       const ctx = analyzeComponent(source, 'MyComponent.tsx')
 
       expect(ctx.jsxFunctions.has('renderItem')).toBe(false)
+      expect(ctx.jsxMultiReturnFunctions.has('renderItem')).toBe(true)
+      const info = ctx.jsxMultiReturnFunctions.get('renderItem')!
+      expect(info.params).toEqual(['active'])
+      expect(info.branches).toHaveLength(1)
+      expect(info.fallback).not.toBeNull()
     })
 
     test('does not set isJsxFunction for non-JSX returning functions', () => {
@@ -420,6 +425,139 @@ describe('JSX function inlining (#569)', () => {
       expect(template).toBeDefined()
       // Both table instances should appear in the template
       expect(template!.content).toContain('table')
+    })
+  })
+
+  describe('multi-return JSX function inlining', () => {
+    test('if/else helper is inlined as conditional IR', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/client'
+
+        export function StatusDisplay() {
+          const [status, setStatus] = createSignal('ok')
+
+          function renderBadge(s: string) {
+            if (s === 'error') return <span class="error">Error</span>
+            return <span class="ok">OK</span>
+          }
+
+          return <div>{renderBadge(status())}</div>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'StatusDisplay.tsx')
+      expect(ctx.jsxMultiReturnFunctions.has('renderBadge')).toBe(true)
+
+      const ir = jsxToIR(ctx)
+      expect(ir).not.toBeNull()
+
+      const result = compileJSX(source, 'StatusDisplay.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!.content
+      expect(template).toContain('error')
+      expect(template).toContain('OK')
+      // Helper function should NOT appear verbatim — it's inlined
+      expect(template).not.toMatch(/function renderBadge/)
+    })
+
+    test('if/else if/else chain inlines to nested conditionals', () => {
+      const source = `
+        'use client'
+
+        export function Display(props: { level: string }) {
+          function renderLevel(lvl: string) {
+            if (lvl === 'high') return <span class="high">High</span>
+            if (lvl === 'mid') return <span class="mid">Mid</span>
+            return <span class="low">Low</span>
+          }
+
+          return <div>{renderLevel(props.level)}</div>
+        }
+      `
+
+      const result = compileJSX(source, 'Display.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!.content
+      expect(template).toContain('High')
+      expect(template).toContain('Mid')
+      expect(template).toContain('Low')
+      expect(template).not.toMatch(/function renderLevel/)
+    })
+
+    test('guard clause (early return null) is handled', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/client'
+
+        export function App() {
+          const [show, setShow] = createSignal(true)
+
+          function renderOptional(visible: boolean) {
+            if (!visible) return null
+            return <strong>Visible</strong>
+          }
+
+          return <div>{renderOptional(show())}</div>
+        }
+      `
+
+      const result = compileJSX(source, 'App.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!.content
+      expect(template).toContain('Visible')
+      expect(template).not.toMatch(/function renderOptional/)
+    })
+
+    test('arrow function with multi-return is inlined', () => {
+      const source = `
+        'use client'
+
+        export function App(props: { type: string }) {
+          const renderIcon = (t: string) => {
+            if (t === 'star') return <span>★</span>
+            return <span>○</span>
+          }
+
+          return <div>{renderIcon(props.type)}</div>
+        }
+      `
+
+      const ctx = analyzeComponent(source, 'App.tsx')
+      expect(ctx.jsxMultiReturnFunctions.has('renderIcon')).toBe(true)
+
+      const result = compileJSX(source, 'App.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!.content
+      expect(template).toContain('★')
+      expect(template).toContain('○')
+    })
+
+    test('param substitution works in both condition and branches', () => {
+      const source = `
+        'use client'
+
+        export function App(props: { name: string }) {
+          function greet(who: string) {
+            if (who === 'world') return <span>Hello World!</span>
+            return <span>Hi {who}!</span>
+          }
+
+          return <div>{greet(props.name)}</div>
+        }
+      `
+
+      const result = compileJSX(source, 'App.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!.content
+      // The param 'who' should be replaced with 'props.name' in the condition
+      expect(template).toContain('props.name')
+      expect(template).not.toMatch(/\bwho\b/)
     })
   })
 })

--- a/packages/jsx/src/__tests__/jsx-function-inlining.test.ts
+++ b/packages/jsx/src/__tests__/jsx-function-inlining.test.ts
@@ -452,6 +452,19 @@ describe('JSX function inlining (#569)', () => {
       const ir = jsxToIR(ctx)
       expect(ir).not.toBeNull()
 
+      // Verify IR contains a conditional node (not an opaque expression)
+      function findConditional(node: any): any {
+        if (node?.type === 'conditional') return node
+        for (const child of node?.children ?? []) {
+          const found = findConditional(child)
+          if (found) return found
+        }
+        return null
+      }
+      const cond = findConditional(ir)
+      expect(cond).not.toBeNull()
+      expect(cond.type).toBe('conditional')
+
       const result = compileJSX(source, 'StatusDisplay.tsx', { adapter })
       expect(result.errors).toHaveLength(0)
 
@@ -460,6 +473,12 @@ describe('JSX function inlining (#569)', () => {
       expect(template).toContain('OK')
       // Helper function should NOT appear verbatim — it's inlined
       expect(template).not.toMatch(/function renderBadge/)
+
+      // Client JS should not contain the raw helper function with JSX
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      if (clientJs) {
+        expect(clientJs.content).not.toMatch(/function renderBadge/)
+      }
     })
 
     test('if/else if/else chain inlines to nested conditionals', () => {

--- a/packages/jsx/src/analyzer-context.ts
+++ b/packages/jsx/src/analyzer-context.ts
@@ -53,6 +53,28 @@ export interface PendingSignalTuple {
 }
 
 /**
+ * One branch of a multi-return JSX helper function's if/else chain.
+ * `jsxReturn` is null for guard clauses that `return null`.
+ */
+export interface MultiReturnJsxBranch {
+  condition: ts.Expression
+  jsxReturn: ts.JsxElement | ts.JsxSelfClosingElement | ts.JsxFragment | null
+}
+
+/**
+ * Extracted control flow from a multi-return JSX helper function.
+ * Represents `if (c1) return <A/>; if (c2) return <B/>; return <C/>`
+ * as a chain of condition→JSX pairs plus an optional fallback.
+ */
+export interface MultiReturnJsxInfo {
+  branches: MultiReturnJsxBranch[]
+  fallback: ts.JsxElement | ts.JsxSelfClosingElement | ts.JsxFragment | null
+  params: string[]
+  /** For switch-sourced branches, the discriminant expression (e.g. `name` in `switch(name)`) */
+  switchDiscriminant?: ts.Expression
+}
+
+/**
  * Represents an if statement with a JSX return in a component function.
  */
 export interface ConditionalReturn {
@@ -120,6 +142,8 @@ export interface AnalyzerContext {
     jsxReturn: ts.JsxElement | ts.JsxSelfClosingElement | ts.JsxFragment
     params: string[]
   }>
+  /** Maps multi-return JSX helper functions for conditional inlining at call sites. */
+  jsxMultiReturnFunctions: Map<string, MultiReturnJsxInfo>
   /**
    * Maps function names to reactive-factory info (#931). A reactive factory
    * is a same-file helper whose body declares reactive primitives and
@@ -220,6 +244,7 @@ export function createAnalyzerContext(
     jsxConstants: new Map(),
     inlineableJsxConsts: new Map(),
     jsxFunctions: new Map(),
+    jsxMultiReturnFunctions: new Map(),
     reactiveFactories: new Map(),
     signalTupleRefs: new Map(),
 

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -1884,6 +1884,18 @@ function extractMultiReturnJsxBranches(
 
     // switch (expr) { case ...: return <jsx> }
     if (ts.isSwitchStatement(stmt)) {
+      // Reject mixed if+switch bodies — prior if branches would be
+      // incorrectly treated as switch case expressions.
+      if (branches.length > 0) return null
+
+      // Only inline switches whose discriminant is side-effect-free
+      // (identifier or property access). A call expression like
+      // `switch(getValue())` would be re-evaluated per branch in the
+      // generated nested ternary.
+      if (!ts.isIdentifier(stmt.expression) && !ts.isPropertyAccessExpression(stmt.expression)) {
+        return null
+      }
+
       for (const clause of stmt.caseBlock.clauses) {
         const jsxReturn = findJsxReturnInCaseClause(clause)
         const nullReturn = findNullReturnInCaseClause(clause)

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -1857,11 +1857,14 @@ function extractMultiReturnJsxBranches(
       let current: ts.Statement = stmt
       while (ts.isIfStatement(current)) {
         const ifStmt = current
+        // Reject branches with nested control flow — only accept
+        // direct `return <jsx>` / `return null` (or a block with
+        // exactly that as its only return).
+        if (!isDirectReturnBlock(ifStmt.thenStatement)) return null
         const jsxReturn = findJsxReturnInBlock(ifStmt.thenStatement)
         const nullReturn = findNullReturnInBlock(ifStmt.thenStatement)
         if (!jsxReturn && !nullReturn) return null
 
-        // Include both JSX and null-returning branches (guard clauses)
         branches.push({ condition: ifStmt.expression, jsxReturn: jsxReturn ?? null })
 
         if (ifStmt.elseStatement) {
@@ -1869,7 +1872,7 @@ function extractMultiReturnJsxBranches(
             current = ifStmt.elseStatement
             continue
           }
-          // else block
+          if (!isDirectReturnBlock(ifStmt.elseStatement)) return null
           const elseJsx = findJsxReturnInBlock(ifStmt.elseStatement)
           if (elseJsx) {
             fallback = elseJsx
@@ -1928,8 +1931,9 @@ function extractMultiReturnJsxBranches(
       continue
     }
 
-    // Skip variable declarations (they can appear before if/switch)
-    if (ts.isVariableStatement(stmt)) continue
+    // Reject bodies with variable declarations — locals referenced in
+    // conditions or JSX would become undefined after inlining.
+    if (ts.isVariableStatement(stmt)) return null
 
     // Any other statement type → unsupported pattern
     return null
@@ -1937,6 +1941,37 @@ function extractMultiReturnJsxBranches(
 
   if (branches.length === 0) return null
   return { branches, fallback }
+}
+
+/**
+ * Check that a statement is a direct `return ...` or a block whose
+ * only non-variable statements are a single return. Rejects nested
+ * control flow (nested if/switch/for/while) that could cause
+ * `findJsxReturnInBlock` to pick the wrong return.
+ */
+function isDirectReturnBlock(node: ts.Statement): boolean {
+  if (ts.isReturnStatement(node)) return true
+  if (ts.isBlock(node)) {
+    let returnCount = 0
+    for (const stmt of node.statements) {
+      if (ts.isReturnStatement(stmt)) {
+        returnCount++
+      } else if (
+        ts.isIfStatement(stmt) ||
+        ts.isSwitchStatement(stmt) ||
+        ts.isForStatement(stmt) ||
+        ts.isForOfStatement(stmt) ||
+        ts.isForInStatement(stmt) ||
+        ts.isWhileStatement(stmt) ||
+        ts.isDoStatement(stmt) ||
+        ts.isTryStatement(stmt)
+      ) {
+        return false
+      }
+    }
+    return returnCount === 1
+  }
+  return false
 }
 
 function findNullReturnInBlock(node: ts.Statement): boolean {

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -1872,6 +1872,8 @@ function extractMultiReturnJsxBranches(
             current = ifStmt.elseStatement
             continue
           }
+          // Final else block — chain is complete, return immediately
+          // to prevent subsequent statements from overwriting fallback.
           if (!isDirectReturnBlock(ifStmt.elseStatement)) return null
           const elseJsx = findJsxReturnInBlock(ifStmt.elseStatement)
           if (elseJsx) {
@@ -1879,6 +1881,8 @@ function extractMultiReturnJsxBranches(
           } else if (!findNullReturnInBlock(ifStmt.elseStatement)) {
             return null
           }
+          if (branches.length === 0) return null
+          return { branches, fallback }
         }
         break
       }
@@ -1898,6 +1902,11 @@ function extractMultiReturnJsxBranches(
       if (!ts.isIdentifier(stmt.expression) && !ts.isPropertyAccessExpression(stmt.expression)) {
         return null
       }
+
+      // Require an explicit default clause — without one, inlining
+      // adds an implicit `else null` that changes runtime behavior.
+      const hasDefault = stmt.caseBlock.clauses.some(c => ts.isDefaultClause(c))
+      if (!hasDefault) return null
 
       for (const clause of stmt.caseBlock.clauses) {
         const jsxReturn = findJsxReturnInCaseClause(clause)

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -1834,6 +1834,138 @@ function extractSingleJsxReturn(
   return jsxReturn
 }
 
+type JsxReturnNode = ts.JsxElement | ts.JsxSelfClosingElement | ts.JsxFragment
+
+/**
+ * Extract conditional branches from a multi-return JSX helper function body.
+ * Supports if/else if chains and switch statements where every branch
+ * returns JSX or null. Returns null for unsupported patterns.
+ */
+function extractMultiReturnJsxBranches(
+  body: ts.Block
+): { branches: Array<{ condition: ts.Expression; jsxReturn: JsxReturnNode | null }>; fallback: JsxReturnNode | null; switchDiscriminant?: ts.Expression } | null {
+  const branches: Array<{ condition: ts.Expression; jsxReturn: JsxReturnNode | null }> = []
+  let fallback: JsxReturnNode | null = null
+
+  const stmts = body.statements
+  for (let i = 0; i < stmts.length; i++) {
+    const stmt = stmts[i]
+
+    // if (cond) return <jsx> — collect as a branch, continue to next statement
+    if (ts.isIfStatement(stmt)) {
+      // Walk this if/else if/else chain
+      let current: ts.Statement = stmt
+      while (ts.isIfStatement(current)) {
+        const ifStmt = current
+        const jsxReturn = findJsxReturnInBlock(ifStmt.thenStatement)
+        const nullReturn = findNullReturnInBlock(ifStmt.thenStatement)
+        if (!jsxReturn && !nullReturn) return null
+
+        // Include both JSX and null-returning branches (guard clauses)
+        branches.push({ condition: ifStmt.expression, jsxReturn: jsxReturn ?? null })
+
+        if (ifStmt.elseStatement) {
+          if (ts.isIfStatement(ifStmt.elseStatement)) {
+            current = ifStmt.elseStatement
+            continue
+          }
+          // else block
+          const elseJsx = findJsxReturnInBlock(ifStmt.elseStatement)
+          if (elseJsx) {
+            fallback = elseJsx
+          } else if (!findNullReturnInBlock(ifStmt.elseStatement)) {
+            return null
+          }
+        }
+        break
+      }
+      continue
+    }
+
+    // switch (expr) { case ...: return <jsx> }
+    if (ts.isSwitchStatement(stmt)) {
+      for (const clause of stmt.caseBlock.clauses) {
+        const jsxReturn = findJsxReturnInCaseClause(clause)
+        const nullReturn = findNullReturnInCaseClause(clause)
+        if (!jsxReturn && !nullReturn) return null
+
+        if (ts.isCaseClause(clause)) {
+          branches.push({
+            condition: clause.expression,
+            jsxReturn: jsxReturn ?? null,
+          })
+        } else {
+          fallback = jsxReturn ?? null
+        }
+      }
+
+      if (branches.length === 0) return null
+      return { branches, fallback, switchDiscriminant: stmt.expression }
+    }
+
+    // Trailing return <jsx> or return null — this is the fallback
+    if (ts.isReturnStatement(stmt) && stmt.expression) {
+      const expr = unwrapJsxTransparent(stmt.expression)
+      if (ts.isJsxElement(expr) || ts.isJsxSelfClosingElement(expr) || ts.isJsxFragment(expr)) {
+        fallback = expr
+      } else if (expr.kind === ts.SyntaxKind.NullKeyword) {
+        // fallback stays null
+      } else {
+        return null
+      }
+      continue
+    }
+
+    // Skip variable declarations (they can appear before if/switch)
+    if (ts.isVariableStatement(stmt)) continue
+
+    // Any other statement type → unsupported pattern
+    return null
+  }
+
+  if (branches.length === 0) return null
+  return { branches, fallback }
+}
+
+function findNullReturnInBlock(node: ts.Statement): boolean {
+  if (ts.isBlock(node)) {
+    for (const stmt of node.statements) {
+      if (ts.isReturnStatement(stmt) && stmt.expression) {
+        const expr = unwrapJsxTransparent(stmt.expression)
+        if (expr.kind === ts.SyntaxKind.NullKeyword) return true
+      }
+    }
+  }
+  if (ts.isReturnStatement(node) && node.expression) {
+    const expr = unwrapJsxTransparent(node.expression)
+    if (expr.kind === ts.SyntaxKind.NullKeyword) return true
+  }
+  return false
+}
+
+function findJsxReturnInCaseClause(
+  clause: ts.CaseClause | ts.DefaultClause
+): JsxReturnNode | null {
+  for (const stmt of clause.statements) {
+    if (ts.isReturnStatement(stmt) && stmt.expression) {
+      return extractJsxFromExpression(stmt.expression)
+    }
+  }
+  return null
+}
+
+function findNullReturnInCaseClause(
+  clause: ts.CaseClause | ts.DefaultClause
+): boolean {
+  for (const stmt of clause.statements) {
+    if (ts.isReturnStatement(stmt) && stmt.expression) {
+      const expr = unwrapJsxTransparent(stmt.expression)
+      if (expr.kind === ts.SyntaxKind.NullKeyword) return true
+    }
+  }
+  return false
+}
+
 /**
  * Detect a multi-return JSX helper: every top-level exit point is a
  * `return <jsx>` or `return null`, and at least one return is JSX. Used
@@ -2002,6 +2134,15 @@ function collectFunction(
         jsxReturn,
         params: node.parameters.map(p => p.name.getText(ctx.sourceFile)),
       })
+    } else {
+      const multi = extractMultiReturnJsxBranches(node.body)
+      if (multi) {
+        isJsxFunction = true
+        ctx.jsxMultiReturnFunctions.set(name, {
+          ...multi,
+          params: node.parameters.map(p => p.name.getText(ctx.sourceFile)),
+        })
+      }
     }
   }
 
@@ -2382,6 +2523,15 @@ function collectConstant(
             jsxReturn,
             params: init.parameters.map(p => p.name.getText(ctx.sourceFile)),
           })
+        } else {
+          const multi = extractMultiReturnJsxBranches(arrowBody)
+          if (multi) {
+            isJsxFunction = true
+            ctx.jsxMultiReturnFunctions.set(name, {
+              ...multi,
+              params: init.parameters.map(p => p.name.getText(ctx.sourceFile)),
+            })
+          }
         }
       } else {
         // Implicit return: () => <div>...</div>

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1506,17 +1506,27 @@ function transformMultiReturnJsxFunctionCall(
         conditionText = substitutedGetJS(branch.condition)
       }
 
+      // For switch-sourced conditions, merge freeRefs/reactivity from
+      // both the discriminant and case expression so prop rewrites and
+      // reactivity detection cover the full `disc === case` condition.
+      const env = makeBindingEnv(ctx)
+      const caseFreeRefs = resolveFreeRefs(branch.condition, env)
+      const discFreeRefs = info.switchDiscriminant
+        ? resolveFreeRefs(info.switchDiscriminant, env)
+        : []
       const conditionOrigin: OriginInfo = {
         phase: 'tick',
         scope: 'template',
         effect: 'pure',
-        freeRefs: resolveFreeRefs(branch.condition, makeBindingEnv(ctx)),
+        freeRefs: [...discFreeRefs, ...caseFreeRefs],
       }
       const reactive = isReactiveExpression(conditionText, ctx, branch.condition)
         || isReactiveOrigin(conditionOrigin)
       const loopParamReactive = !reactive && referencesLoopParam(conditionText, ctx)
       const callsReactive = exprCallsReactiveGetters(branch.condition, ctx)
+        || (info.switchDiscriminant ? exprCallsReactiveGetters(info.switchDiscriminant, ctx) : false)
       const hasCalls = exprHasFunctionCalls(branch.condition)
+        || (info.switchDiscriminant ? exprHasFunctionCalls(info.switchDiscriminant) : false)
       const needsSlot = reactive || loopParamReactive || callsReactive || hasCalls
       const slotId = needsSlot ? generateSlotId(ctx) : null
 
@@ -1524,10 +1534,26 @@ function transformMultiReturnJsxFunctionCall(
         ? (transformNode(branch.jsxReturn, ctx) ?? nullExpr)
         : nullExpr
 
+      // For switch conditions, build templateCondition from both parts
+      let templateCondition: string | undefined
+      if (info.switchDiscriminant) {
+        const discRewritten = rewriteBarePropRefs(
+          substitutedGetJS(info.switchDiscriminant), info.switchDiscriminant, ctx
+        )
+        const caseRewritten = rewriteBarePropRefs(
+          substitutedGetJS(branch.condition), branch.condition, ctx
+        )
+        const discPart = discRewritten ?? substitutedGetJS(info.switchDiscriminant)
+        const casePart = caseRewritten ?? substitutedGetJS(branch.condition)
+        templateCondition = `${discPart} === ${casePart}`
+      } else {
+        templateCondition = rewriteBarePropRefs(conditionText, branch.condition, ctx)
+      }
+
       const conditional: IRConditional = {
         type: 'conditional',
         condition: conditionText,
-        templateCondition: rewriteBarePropRefs(conditionText, branch.condition, ctx),
+        templateCondition,
         conditionType: null,
         reactive,
         whenTrue,

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -32,7 +32,7 @@ import {
   isReactiveOrigin,
   AttrValueOf,
 } from './types'
-import { type AnalyzerContext, getSourceLocation } from './analyzer-context'
+import { type AnalyzerContext, type MultiReturnJsxInfo, getSourceLocation } from './analyzer-context'
 import { parseExpression, isSupported, parseBlockBody, extractSortComparatorFromTS, type ParsedExpr, type ParsedStatement, type SortComparator } from './expression-parser'
 import { createError, ErrorCodes, internalInvariant } from './errors'
 import { containsReactiveExpression } from './reactivity-checker'
@@ -1446,6 +1446,108 @@ function transformJsxFunctionCall(
   }
 }
 
+function transformMultiReturnJsxFunctionCall(
+  callExpr: ts.CallExpression,
+  info: MultiReturnJsxInfo,
+  ctx: TransformContext,
+): IRNode {
+  // Build substitution map: paramName → argument expression text
+  const substitutions = new Map<string, string>()
+  for (let i = 0; i < info.params.length; i++) {
+    const paramName = info.params[i]
+    const arg = callExpr.arguments[i]
+    if (arg) {
+      substitutions.set(paramName, ctx.getJS(arg))
+    }
+  }
+
+  const baseGetJS = ctx.analyzer.getJS.bind(ctx.analyzer)
+  const originalCtxGetJS = ctx.getJS
+  const originalAnalyzerGetJS = ctx.analyzer.getJS
+
+  const substitutedGetJS = (node: ts.Node) => {
+    let text = baseGetJS(node)
+    for (const [paramName, argExpr] of substitutions) {
+      text = text.replace(new RegExp(`\\b${paramName}\\b`, 'g'), argExpr)
+    }
+    return text
+  }
+
+  ctx.getJS = substitutedGetJS
+  ctx.analyzer.getJS = substitutedGetJS
+
+  try {
+    const loc = getSourceLocation(callExpr, ctx.sourceFile, ctx.filePath)
+    const nullExpr: IRExpression = {
+      type: 'expression',
+      expr: 'null',
+      typeInfo: { kind: 'primitive', raw: 'null', primitive: 'null' },
+      reactive: false,
+      slotId: null,
+      loc,
+      origin: { phase: 'tick', scope: 'template', effect: 'pure', freeRefs: [] },
+    }
+
+    // Build the conditional chain from bottom up (last branch → first branch)
+    let result: IRNode = info.fallback
+      ? (transformNode(info.fallback, ctx) ?? nullExpr)
+      : nullExpr
+
+    for (let i = info.branches.length - 1; i >= 0; i--) {
+      const branch = info.branches[i]
+
+      // Build condition text with param substitution
+      let conditionText: string
+      if (info.switchDiscriminant) {
+        const discText = substitutedGetJS(info.switchDiscriminant)
+        const caseText = substitutedGetJS(branch.condition)
+        conditionText = `${discText} === ${caseText}`
+      } else {
+        conditionText = substitutedGetJS(branch.condition)
+      }
+
+      const conditionOrigin: OriginInfo = {
+        phase: 'tick',
+        scope: 'template',
+        effect: 'pure',
+        freeRefs: resolveFreeRefs(branch.condition, makeBindingEnv(ctx)),
+      }
+      const reactive = isReactiveExpression(conditionText, ctx, branch.condition)
+        || isReactiveOrigin(conditionOrigin)
+      const loopParamReactive = !reactive && referencesLoopParam(conditionText, ctx)
+      const callsReactive = exprCallsReactiveGetters(branch.condition, ctx)
+      const hasCalls = exprHasFunctionCalls(branch.condition)
+      const needsSlot = reactive || loopParamReactive || callsReactive || hasCalls
+      const slotId = needsSlot ? generateSlotId(ctx) : null
+
+      const whenTrue = branch.jsxReturn
+        ? (transformNode(branch.jsxReturn, ctx) ?? nullExpr)
+        : nullExpr
+
+      const conditional: IRConditional = {
+        type: 'conditional',
+        condition: conditionText,
+        templateCondition: rewriteBarePropRefs(conditionText, branch.condition, ctx),
+        conditionType: null,
+        reactive,
+        whenTrue,
+        whenFalse: result,
+        slotId,
+        callsReactiveGetters: callsReactive || undefined,
+        hasFunctionCalls: hasCalls || undefined,
+        loc,
+        origin: conditionOrigin,
+      }
+      result = conditional
+    }
+
+    return result
+  } finally {
+    ctx.getJS = originalCtxGetJS
+    ctx.analyzer.getJS = originalAnalyzerGetJS
+  }
+}
+
 function transformConditional(
   node: ts.ConditionalExpression,
   ctx: TransformContext
@@ -1760,6 +1862,10 @@ function transformJsxExpression(
         const jsxFunc = ctx.analyzer.jsxFunctions.get(callee.text)
         if (jsxFunc) {
           return transformJsxFunctionCall(node, jsxFunc, ctx, isClientOnly)
+        }
+        const multiJsxFunc = ctx.analyzer.jsxMultiReturnFunctions.get(callee.text)
+        if (multiJsxFunc) {
+          return transformMultiReturnJsxFunctionCall(node, multiJsxFunc, ctx)
         }
       }
       return null


### PR DESCRIPTION
## Summary

- Local helper functions with multiple JSX return statements (if/else chains, switch/case, guard clauses) are now inlined at call sites as nested `IRConditional` nodes, instead of falling through to opaque dynamic expressions.
- Adds `jsxMultiReturnFunctions` map to `AnalyzerContext` with `extractMultiReturnJsxBranches` extraction in the analyzer, and `transformMultiReturnJsxFunctionCall` in `jsx-to-ir.ts` for IR-level conditional synthesis with parameter substitution.
- Supported patterns: `if/else`, `if/else if/else` chains, guard clauses (`if (!x) return null`), `switch/case` statements, and arrow function variants.

## Test plan

- [x] Existing 1636 compiler unit tests pass (0 regressions)
- [x] Existing 497 adapter conformance tests pass (0 regressions)
- [x] New analyzer test: multi-return functions stored in `jsxMultiReturnFunctions`
- [x] New IR test: if/else helper inlined as conditional IR
- [x] New IR test: if/else if/else chain produces nested conditionals
- [x] New IR test: guard clause (`return null`) handled correctly
- [x] New IR test: arrow function with multi-return is inlined
- [x] New IR test: parameter substitution works in both conditions and branches

https://claude.ai/code/session_01SEG1QwvsXVy6LoAFbYXLLS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEG1QwvsXVy6LoAFbYXLLS)_