### PR TITLE
fix: compile props.X.map() to mapArray for reactive reconciliation

### DIFF
--- a/.changeset/props-map-reactive.md
+++ b/.changeset/props-map-reactive.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Compile props.X.map() to mapArray for reactive DOM reconciliation instead of static forEach (#1586). Direct prop array references in .map() expressions are now treated as potentially reactive, consistent with the compiler's existing "props are always reactive" design.

--- a/integrations/echo/components.go
+++ b/integrations/echo/components.go
@@ -17,106 +17,6 @@ func randomID(n int) string {
 	return string(b)
 }
 
-// PortalExampleInput is the user-facing input type.
-type PortalExampleInput struct {
-	ScopeID string // Optional: if empty, random ID is generated
-	BfParent string // Optional: parent scope id
-	BfMount string // Optional: slot id in parent
-}
-
-// PortalExampleProps is the props type for the PortalExample component.
-type PortalExampleProps struct {
-	ScopeID string `json:"scopeID"`
-	BfIsRoot bool `json:"-"`
-	BfIsChild bool `json:"-"`
-	BfParent string `json:"-"`
-	BfMount string `json:"-"`
-	Scripts *bf.ScriptCollector `json:"-"`
-	Open bool `json:"open"`
-}
-
-// Todo represents a todo.
-type Todo struct {
-	ID int `json:"id"`
-	Text string `json:"text"`
-	Done bool `json:"done"`
-	Editing bool `json:"editing"`
-}
-
-// TodoItemInput is the user-facing input type.
-type TodoItemInput struct {
-	ScopeID string // Optional: if empty, random ID is generated
-	BfParent string // Optional: parent scope id
-	BfMount string // Optional: slot id in parent
-	Todo Todo
-	OnToggle interface{}
-	OnDelete interface{}
-	OnStartEdit interface{}
-	OnFinishEdit interface{}
-}
-
-// TodoItemProps is the props type for the TodoItem component.
-type TodoItemProps struct {
-	ScopeID string `json:"scopeID"`
-	BfIsRoot bool `json:"-"`
-	BfIsChild bool `json:"-"`
-	BfParent string `json:"-"`
-	BfMount string `json:"-"`
-	Scripts *bf.ScriptCollector `json:"-"`
-	Todo Todo `json:"todo"`
-	OnToggle interface{} `json:"onToggle"`
-	OnDelete interface{} `json:"onDelete"`
-	OnStartEdit interface{} `json:"onStartEdit"`
-	OnFinishEdit interface{} `json:"onFinishEdit"`
-}
-
-// Filter is a string type.
-type Filter = string
-
-// TodoAppInput is the user-facing input type.
-type TodoAppInput struct {
-	ScopeID string // Optional: if empty, random ID is generated
-	BfParent string // Optional: parent scope id
-	BfMount string // Optional: slot id in parent
-	InitialTodos []Todo
-}
-
-// TodoAppProps is the props type for the TodoApp component.
-type TodoAppProps struct {
-	ScopeID string `json:"scopeID"`
-	BfIsRoot bool `json:"-"`
-	BfIsChild bool `json:"-"`
-	BfParent string `json:"-"`
-	BfMount string `json:"-"`
-	Scripts *bf.ScriptCollector `json:"-"`
-	InitialTodos []Todo `json:"initialTodos"`
-	Todos []Todo `json:"todos"`
-	NewText string `json:"newText"`
-	Filter Filter `json:"filter"`
-	TodoItems []TodoItemProps `json:"-"`
-}
-
-// CounterInput is the user-facing input type.
-type CounterInput struct {
-	ScopeID string // Optional: if empty, random ID is generated
-	BfParent string // Optional: parent scope id
-	BfMount string // Optional: slot id in parent
-	Initial int
-}
-
-// CounterProps is the props type for the Counter component.
-type CounterProps struct {
-	ScopeID string `json:"scopeID"`
-	BfIsRoot bool `json:"-"`
-	BfIsChild bool `json:"-"`
-	BfParent string `json:"-"`
-	BfMount string `json:"-"`
-	Scripts *bf.ScriptCollector `json:"-"`
-	Initial int `json:"initial"`
-	Count int `json:"count"`
-	Doubled int `json:"doubled"`
-}
-
 // Message represents a message.
 type Message struct {
 	ID int `json:"id"`
@@ -143,6 +43,78 @@ type AIChatInteractiveProps struct {
 	Input string `json:"input"`
 	StreamingText string `json:"streamingText"`
 	IsStreaming bool `json:"isStreaming"`
+}
+
+// PortalExampleInput is the user-facing input type.
+type PortalExampleInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// PortalExampleProps is the props type for the PortalExample component.
+type PortalExampleProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Open bool `json:"open"`
+}
+
+// ConditionalReturnInput is the user-facing input type.
+type ConditionalReturnInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+	Variant string
+}
+
+// ConditionalReturnProps is the props type for the ConditionalReturn component.
+type ConditionalReturnProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Variant string `json:"variant"`
+	Count int `json:"count"`
+}
+
+// Todo represents a todo.
+type Todo struct {
+	ID int `json:"id"`
+	Text string `json:"text"`
+	Done bool `json:"done"`
+	Editing bool `json:"editing"`
+}
+
+// Filter is a string type.
+type Filter = string
+
+// TodoAppInput is the user-facing input type.
+type TodoAppInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+	InitialTodos []Todo
+}
+
+// TodoAppProps is the props type for the TodoApp component.
+type TodoAppProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	InitialTodos []Todo `json:"initialTodos"`
+	Todos []Todo `json:"todos"`
+	NewText string `json:"newText"`
+	Filter Filter `json:"filter"`
+	TodoItems []TodoItemProps `json:"-"`
 }
 
 // ReactiveChildInput is the user-facing input type.
@@ -253,24 +225,43 @@ type PropsReactivityComparisonProps struct {
 	DestructuredStyleChildSlot4 DestructuredStyleChildProps `json:"-"`
 }
 
-// ConditionalReturnInput is the user-facing input type.
-type ConditionalReturnInput struct {
+// CounterInput is the user-facing input type.
+type CounterInput struct {
 	ScopeID string // Optional: if empty, random ID is generated
 	BfParent string // Optional: parent scope id
 	BfMount string // Optional: slot id in parent
-	Variant string
+	Initial int
 }
 
-// ConditionalReturnProps is the props type for the ConditionalReturn component.
-type ConditionalReturnProps struct {
+// CounterProps is the props type for the Counter component.
+type CounterProps struct {
 	ScopeID string `json:"scopeID"`
 	BfIsRoot bool `json:"-"`
 	BfIsChild bool `json:"-"`
 	BfParent string `json:"-"`
 	BfMount string `json:"-"`
 	Scripts *bf.ScriptCollector `json:"-"`
-	Variant string `json:"variant"`
+	Initial int `json:"initial"`
 	Count int `json:"count"`
+	Doubled int `json:"doubled"`
+}
+
+// FormInput is the user-facing input type.
+type FormInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// FormProps is the props type for the Form component.
+type FormProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Accepted bool `json:"accepted"`
 }
 
 // TodoAppSSRInput is the user-facing input type.
@@ -294,6 +285,33 @@ type TodoAppSSRProps struct {
 	NewText string `json:"newText"`
 	Filter Filter `json:"filter"`
 	TodoItems []TodoItemProps `json:"-"`
+}
+
+// TodoItemInput is the user-facing input type.
+type TodoItemInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+	Todo Todo
+	OnToggle interface{}
+	OnDelete interface{}
+	OnStartEdit interface{}
+	OnFinishEdit interface{}
+}
+
+// TodoItemProps is the props type for the TodoItem component.
+type TodoItemProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Todo Todo `json:"todo"`
+	OnToggle interface{} `json:"onToggle"`
+	OnDelete interface{} `json:"onDelete"`
+	OnStartEdit interface{} `json:"onStartEdit"`
+	OnFinishEdit interface{} `json:"onFinishEdit"`
 }
 
 // ToggleItemInput is the user-facing input type.
@@ -337,22 +355,22 @@ type ToggleProps struct {
 	ToggleItems []ToggleItemProps `json:"toggleItems"`
 }
 
-// FormInput is the user-facing input type.
-type FormInput struct {
-	ScopeID string // Optional: if empty, random ID is generated
-	BfParent string // Optional: parent scope id
-	BfMount string // Optional: slot id in parent
-}
+// NewAIChatInteractiveProps creates AIChatInteractiveProps from AIChatInteractiveInput.
+func NewAIChatInteractiveProps(in AIChatInteractiveInput) AIChatInteractiveProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "AIChatInteractive_" + randomID(6)
+	}
 
-// FormProps is the props type for the Form component.
-type FormProps struct {
-	ScopeID string `json:"scopeID"`
-	BfIsRoot bool `json:"-"`
-	BfIsChild bool `json:"-"`
-	BfParent string `json:"-"`
-	BfMount string `json:"-"`
-	Scripts *bf.ScriptCollector `json:"-"`
-	Accepted bool `json:"accepted"`
+	return AIChatInteractiveProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Messages: nil,
+		Input: "",
+		StreamingText: "",
+		IsStreaming: false,
+	}
 }
 
 // NewPortalExampleProps creates PortalExampleProps from PortalExampleInput.
@@ -370,22 +388,19 @@ func NewPortalExampleProps(in PortalExampleInput) PortalExampleProps {
 	}
 }
 
-// NewTodoItemProps creates TodoItemProps from TodoItemInput.
-func NewTodoItemProps(in TodoItemInput) TodoItemProps {
+// NewConditionalReturnProps creates ConditionalReturnProps from ConditionalReturnInput.
+func NewConditionalReturnProps(in ConditionalReturnInput) ConditionalReturnProps {
 	scopeID := in.ScopeID
 	if scopeID == "" {
-		scopeID = "TodoItem_" + randomID(6)
+		scopeID = "ConditionalReturn_" + randomID(6)
 	}
 
-	return TodoItemProps{
+	return ConditionalReturnProps{
 		ScopeID: scopeID,
 		BfParent: in.BfParent,
 		BfMount: in.BfMount,
-		Todo: in.Todo,
-		OnToggle: in.OnToggle,
-		OnDelete: in.OnDelete,
-		OnStartEdit: in.OnStartEdit,
-		OnFinishEdit: in.OnFinishEdit,
+		Variant: in.Variant,
+		Count: 0,
 	}
 }
 
@@ -417,41 +432,6 @@ func NewTodoAppProps(in TodoAppInput) TodoAppProps {
 		Todos: in.InitialTodos,
 		NewText: "",
 		Filter: "all",
-	}
-}
-
-// NewCounterProps creates CounterProps from CounterInput.
-func NewCounterProps(in CounterInput) CounterProps {
-	scopeID := in.ScopeID
-	if scopeID == "" {
-		scopeID = "Counter_" + randomID(6)
-	}
-
-	return CounterProps{
-		ScopeID: scopeID,
-		BfParent: in.BfParent,
-		BfMount: in.BfMount,
-		Initial: in.Initial,
-		Count: in.Initial,
-		Doubled: in.Initial * 2,
-	}
-}
-
-// NewAIChatInteractiveProps creates AIChatInteractiveProps from AIChatInteractiveInput.
-func NewAIChatInteractiveProps(in AIChatInteractiveInput) AIChatInteractiveProps {
-	scopeID := in.ScopeID
-	if scopeID == "" {
-		scopeID = "AIChatInteractive_" + randomID(6)
-	}
-
-	return AIChatInteractiveProps{
-		ScopeID: scopeID,
-		BfParent: in.BfParent,
-		BfMount: in.BfMount,
-		Messages: nil,
-		Input: "",
-		StreamingText: "",
-		IsStreaming: false,
 	}
 }
 
@@ -565,19 +545,35 @@ func NewPropsReactivityComparisonProps(in PropsReactivityComparisonInput) PropsR
 	}
 }
 
-// NewConditionalReturnProps creates ConditionalReturnProps from ConditionalReturnInput.
-func NewConditionalReturnProps(in ConditionalReturnInput) ConditionalReturnProps {
+// NewCounterProps creates CounterProps from CounterInput.
+func NewCounterProps(in CounterInput) CounterProps {
 	scopeID := in.ScopeID
 	if scopeID == "" {
-		scopeID = "ConditionalReturn_" + randomID(6)
+		scopeID = "Counter_" + randomID(6)
 	}
 
-	return ConditionalReturnProps{
+	return CounterProps{
 		ScopeID: scopeID,
 		BfParent: in.BfParent,
 		BfMount: in.BfMount,
-		Variant: in.Variant,
-		Count: 0,
+		Initial: in.Initial,
+		Count: in.Initial,
+		Doubled: in.Initial * 2,
+	}
+}
+
+// NewFormProps creates FormProps from FormInput.
+func NewFormProps(in FormInput) FormProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "Form_" + randomID(6)
+	}
+
+	return FormProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Accepted: false,
 	}
 }
 
@@ -609,6 +605,25 @@ func NewTodoAppSSRProps(in TodoAppSSRInput) TodoAppSSRProps {
 		Todos: in.InitialTodos,
 		NewText: "",
 		Filter: "all",
+	}
+}
+
+// NewTodoItemProps creates TodoItemProps from TodoItemInput.
+func NewTodoItemProps(in TodoItemInput) TodoItemProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "TodoItem_" + randomID(6)
+	}
+
+	return TodoItemProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Todo: in.Todo,
+		OnToggle: in.OnToggle,
+		OnDelete: in.OnDelete,
+		OnStartEdit: in.OnStartEdit,
+		OnFinishEdit: in.OnFinishEdit,
 	}
 }
 
@@ -648,20 +663,5 @@ func NewToggleProps(in ToggleInput) ToggleProps {
 		BfParent: in.BfParent,
 		BfMount: in.BfMount,
 		ToggleItems: toggleItems,
-	}
-}
-
-// NewFormProps creates FormProps from FormInput.
-func NewFormProps(in FormInput) FormProps {
-	scopeID := in.ScopeID
-	if scopeID == "" {
-		scopeID = "Form_" + randomID(6)
-	}
-
-	return FormProps{
-		ScopeID: scopeID,
-		BfParent: in.BfParent,
-		BfMount: in.BfMount,
-		Accepted: false,
 	}
 }

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -71,6 +71,7 @@ type GoRenderCtx = {
  */
 interface NestedComponentInfo extends IRLoopChildComponent {
   isDynamic: boolean
+  isPropDerived: boolean
 }
 
 interface StaticChildInstance {
@@ -807,8 +808,9 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     lines.push('\tBfParent string // Optional: parent scope id')
     lines.push('\tBfMount string // Optional: slot id in parent')
 
-    // Static nested components appear in Input; dynamic ones are template-only
-    const staticNested = nestedComponents.filter(n => !n.isDynamic)
+    // Static + prop-derived nested components appear in Input;
+    // signal-backed dynamic ones are template-only
+    const inputNested = nestedComponents.filter(n => !n.isDynamic || n.isPropDerived)
 
     // Collect nested component array field names to skip from propsParams
     const nestedArrayFields = new Set(nestedComponents.map(n => `${n.name}s`))
@@ -821,8 +823,8 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       lines.push(`\t${fieldName} ${goType}`)
     }
 
-    // Add nested component input arrays (static only)
-    for (const nested of staticNested) {
+    // Add nested component input arrays
+    for (const nested of inputNested) {
       lines.push(`\t${nested.name}s []${nested.name}Input`)
     }
 
@@ -953,10 +955,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
     // Add array fields for nested components (for template rendering)
     for (const nested of nestedComponents) {
-      if (nested.isDynamic) {
-        // Dynamic (signal) array loops: template-only, not in JSON
+      if (nested.isDynamic && !nested.isPropDerived) {
+        // Dynamic signal array loops: template-only, not in JSON
         lines.push(`\t${nested.name}s []${nested.name}Props \`json:"-"\``)
       } else {
+        // Static arrays and prop-derived dynamic arrays: include in JSON
+        // so the client can hydrate via mapArray or forEach
         const jsonTag = this.toJsonTag(`${nested.name.charAt(0).toLowerCase()}${nested.name.slice(1)}s`)
         lines.push(`\t${nested.name}s []${nested.name}Props \`json:"${jsonTag}"\``)
       }
@@ -1005,9 +1009,9 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // field, the SSR template iterates over it, but
     // `NewTodoAppProps(TodoAppInput{Initial: ...})` returns it empty
     // and the page renders a blank list (#1442 echo TodoApp repro).
-    const dynamicNested = nestedComponents.filter(n => n.isDynamic)
+    const signalDynamicNested = nestedComponents.filter(n => n.isDynamic && !n.isPropDerived)
     lines.push(`// New${componentName}Props creates ${propsTypeName} from ${inputTypeName}.`)
-    for (const nested of dynamicNested) {
+    for (const nested of signalDynamicNested) {
       const arrayField = `${nested.name}s`
       lines.push(`//`)
       lines.push(`// NOTE: \`${arrayField}\` is populated by the route handler, not by`)
@@ -1030,8 +1034,9 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     lines.push('\t}')
     lines.push('')
 
-    // Static nested components only — dynamic ones are set manually by the handler
-    const staticNested = nestedComponents.filter(n => !n.isDynamic)
+    // Static + prop-derived nested components: auto-populate from input.
+    // Signal-backed dynamic arrays are set manually by the handler.
+    const staticNested = nestedComponents.filter(n => !n.isDynamic || n.isPropDerived)
 
     // Handle nested components
     if (staticNested.length > 0) {
@@ -1266,6 +1271,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
           result.push({
             ...loop.childComponent,
             isDynamic: !loop.isStaticArray,
+            isPropDerived: !!loop.isPropDerivedArray,
           })
         }
       }

--- a/packages/adapter-tests/fixtures/__snapshots__/toggle-shared.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/toggle-shared.client.js
@@ -1,4 +1,4 @@
-import { $, $t, __bfSlot, createComponent, createEffect, createSignal, hydrate, initChild, insert, qsaChildScopes, renderChild, styleToCss } from '@barefootjs/client/runtime'
+import { $, $t, __bfSlot, createComponent, createEffect, createSignal, hydrate, initChild, insert, mapArray, renderChild, styleToCss } from '@barefootjs/client/runtime'
 
 export function initToggleItem(__scope, _p = {}) {
   if (!__scope) return
@@ -43,14 +43,10 @@ export function initToggle(__scope, _p = {}) {
 
   const [_s1] = $(__scope, 's1')
 
-  // Initialize static array children (hydrate skips nested instances)
-  if (_s1) {
-    const __childScopes = qsaChildScopes(_s1, `[bf-h="${__scopeId}"][bf-m="s0"], [bf-s$="_s0"]`)
-    __childScopes.forEach((childScope, __idx) => {
-      const item = toggleItems[__idx]
-      initChild('ToggleItem__69f56292', childScope, { get label() { return item.label }, get defaultOn() { return item.defaultOn } })
-    })
-  }
+  mapArray(() => toggleItems, _s1, (item) => String(item.label), (item, __idx, __existing) => {
+    if (__existing) { initChild('ToggleItem__69f56292', __existing, { get label() { return item().label }, get defaultOn() { return item().defaultOn } }); return __existing }
+    return createComponent('ToggleItem__69f56292', { get label() { return item().label }, get defaultOn() { return item().defaultOn } }, item().label)
+  }, 'l0')
 
 }
 

--- a/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
+++ b/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
@@ -4119,7 +4119,7 @@ export function Example(_p, __bfKey) { return createComponent('Example', _p, __b
 `;
 
 exports[`docs/core/adapters/go-template-adapter.md doc-examples L215 — (no label) 1`] = `
-"import { $, createComponent, hydrate, initChild, qsaChildScopes, renderChild } from '@barefootjs/client/runtime'
+"import { $, createComponent, hydrate, initChild, mapArray, renderChild } from '@barefootjs/client/runtime'
 import '/* @bf-child:TodoItem */'
 
 
@@ -4131,14 +4131,10 @@ export function initTodoList(__scope, _p = {}) {
 
   const [_s1] = $(__scope, 's1')
 
-  // Initialize static array children (hydrate skips nested instances)
-  if (_s1) {
-    const __childScopes = qsaChildScopes(_s1, \`[bf-h="\${__scopeId}"][bf-m="s0"], [bf-s$="_s0"]\`)
-    __childScopes.forEach((childScope, __idx) => {
-      const item = items[__idx]
-      initChild('TodoItem', childScope, { get "..."() { return item } })
-    })
-  }
+  mapArray(() => items, _s1, (item) => String(item.id), (item, __idx, __existing) => {
+    if (__existing) { initChild('TodoItem', __existing, { get "..."() { return item() } }); return __existing }
+    return createComponent('TodoItem', { get "..."() { return item() } }, item().id)
+  }, 'l0')
 
 }
 

--- a/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
+++ b/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
@@ -1428,14 +1428,11 @@ describe('ref callback re-invocation on remount under the same key (#1244)', () 
     expect(c.clientJs).toContain('const __el = __existing ??')
   })
 
-  test('static-array .map(): ref callback closing over loop param stays raw (no signal-accessor wrap)', () => {
-    // Static-array loops emit `forEach((param, idx) => ...)` where `param`
-    // is the raw item value, not a signal accessor. A ref callback that
-    // closes over `param` (e.g. `ref={(el) => map.set(it.id, el)}`) must
-    // therefore NOT be wrapped via `wrapLoopParamAsAccessor` — that would
-    // rewrite `it.id` to `it().id`, throwing TypeError at runtime ("it is
-    // not a function"). Mirrors how `reactiveTexts` / `reactiveAttrs` are
-    // already passed through unwrapped on the static path.
+  test('prop-array .map(): ref callback closing over loop param uses signal accessor (#1586)', () => {
+    // Prop arrays compile to `mapArray` where the item param is a signal
+    // accessor. A ref callback closing over the param (e.g.
+    // `ref={(el) => map.set(it.id, el)}`) gets rewritten to `it().id`
+    // because `it` is a signal accessor in the mapArray renderItem body.
     const src = `
       'use client'
       import { createSignal } from '@barefootjs/client'
@@ -1455,8 +1452,7 @@ describe('ref callback re-invocation on remount under the same key (#1244)', () 
     `
     const c = compile(src)
     expectNoFatalErrors(c)
-    expect(c.clientJs).toContain('refMap.set(it.id')
-    expect(c.clientJs).not.toMatch(/refMap\.set\(it\(\)\.id/)
+    expect(c.clientJs).toContain('refMap.set(it().id')
   })
 
   test('static inner .map() under reactive outer: ref callback closing over inner param stays raw', () => {

--- a/packages/jsx/src/__tests__/loop-fallback-wrap.test.ts
+++ b/packages/jsx/src/__tests__/loop-fallback-wrap.test.ts
@@ -110,9 +110,10 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
     expect(clientJs).not.toMatch(/\breconcileList\s*\(/)
   })
 
-  test('static prop array stays static', () => {
-    // `items` is a non-destructured prop; the AST is just an
-    // Identifier, no calls. Should still take the static path.
+  test('prop array compiles to mapArray (#1586)', () => {
+    // `props.items` is a direct prop reference — props are always
+    // potentially reactive (parent may pass signal getters), so the
+    // loop must use mapArray for reconciliation.
     const source = `
       export function List(props: { items: string[] }) {
         return (
@@ -124,8 +125,7 @@ describe('Solid-style wrap-by-default fallback for loops (#943)', () => {
     `
 
     const clientJs = getClientJs(source, 'List.tsx')
-    expect(clientJs).not.toMatch(/\bmapArray\s*\(/)
-    expect(clientJs).not.toMatch(/\breconcileList\s*\(/)
+    expect(clientJs).toMatch(/\bmapArray\s*\(/)
   })
 
   test('unrecognised-call chain with filter now reconciles', () => {

--- a/packages/jsx/src/__tests__/static-loop-csr-materialize.test.ts
+++ b/packages/jsx/src/__tests__/static-loop-csr-materialize.test.ts
@@ -77,9 +77,10 @@ describe('#1247 — static-loop CSR self-heal', () => {
     expect(clientJs).not.toMatch(/if \(!__iterEl\)/)
   })
 
-  test('safe-prop array (no init-scope local) does NOT emit the branch', () => {
-    // `props.items` is directly usable in the CSR template — no fallback
-    // needed.
+  test('direct prop array uses mapArray, not static forEach (#1586)', () => {
+    // `props.items` is a direct prop reference — props are always
+    // potentially reactive, so the compiler promotes to mapArray.
+    // mapArray handles CSR mount natively (no materialize needed).
     const source = `
       'use client'
       import { createSignal } from '@barefootjs/client'
@@ -94,7 +95,8 @@ describe('#1247 — static-loop CSR self-heal', () => {
       }
     `
     const clientJs = getClientJs(source, 'PropList.tsx')
-    expect(clientJs).not.toMatch(/if \(!__iterEl\)/)
+    expect(clientJs).toMatch(/\bmapArray\s*\(/)
+    expect(clientJs).not.toMatch(/\.forEach\s*\(/)
   })
 
   test('materialize branch uses raw destructured param refs (no __bfItem())', () => {

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -2855,7 +2855,7 @@ function transformMapCall(
   // the signal accessor at renderItem body entry. No more skip.
   const callsReactive = exprCallsReactiveGetters(arrayExpr, ctx)
   const hasCalls = exprHasFunctionCalls(arrayExpr)
-  const isDirectPropArray = method !== 'flatMap' && ctx.patterns.props.some(p => p.pattern.test(array))
+  const isDirectPropArray = method !== 'flatMap' && isArrayExprDirectPropRef(arrayExpr, ctx)
   const isStaticArray =
     !isSignalOrMemoArray(array, ctx)
     && !isDirectPropArray
@@ -3872,6 +3872,35 @@ function checkBareSignalOrMemoIdentifier(
       return
     }
   }
+}
+
+/**
+ * Structural AST check: is the array expression a direct prop reference?
+ *
+ * Returns true only when arrayExpr is:
+ * (a) An Identifier that is a destructured prop binding (e.g. `toggleItems`)
+ * (b) A PropertyAccessExpression rooted at the props object (e.g. `props.items`)
+ *
+ * Unlike the regex-based `isPropsReference`, this avoids false positives from
+ * unrelated identifiers that happen to share a prop name (e.g. `state.items`
+ * when `items` is also a prop).
+ */
+function isArrayExprDirectPropRef(arrayExpr: ts.Expression, ctx: TransformContext): boolean {
+  const propNames = new Set(ctx.patterns.props.map(p => p.name))
+  const propsObjName = ctx.analyzer.propsObjectName
+
+  if (ts.isIdentifier(arrayExpr)) {
+    return propNames.has(arrayExpr.text)
+  }
+
+  if (ts.isPropertyAccessExpression(arrayExpr) && propsObjName) {
+    const obj = arrayExpr.expression
+    if (ts.isIdentifier(obj) && obj.text === propsObjName) {
+      return true
+    }
+  }
+
+  return false
 }
 
 /**

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -2855,8 +2855,10 @@ function transformMapCall(
   // the signal accessor at renderItem body entry. No more skip.
   const callsReactive = exprCallsReactiveGetters(arrayExpr, ctx)
   const hasCalls = exprHasFunctionCalls(arrayExpr)
+  const isDirectPropArray = method !== 'flatMap' && ctx.patterns.props.some(p => p.pattern.test(array))
   const isStaticArray =
     !isSignalOrMemoArray(array, ctx)
+    && !isDirectPropArray
     && !hasCalls
 
   // Collect nested components for both static and dynamic arrays.

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -2888,6 +2888,7 @@ function transformMapCall(
     // and ssr-hydration-contract assertions don't shift when loops are added.
     markerId: `l${ctx.loopMarkerCounter++}`,
     isStaticArray,
+    isPropDerivedArray: isDirectPropArray || undefined,
     callsReactiveGetters: callsReactive || undefined,
     hasFunctionCalls: hasCalls || undefined,
     bodyIsMultiRoot: bodyIsMultiRoot || undefined,

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -424,6 +424,14 @@ export interface IRLoop {
   isStaticArray: boolean
 
   /**
+   * True when the array is a direct prop reference promoted to mapArray (#1586).
+   * Adapters use this to include the array in JSON serialization (bf-p)
+   * even though isStaticArray is false — the client's mapArray needs the
+   * initial data for hydration, unlike signal-backed arrays.
+   */
+  isPropDerivedArray?: boolean
+
+  /**
    * When true, array expression calls signal getters or memos (computed from AST).
    * Derived Phase 1 so debug tooling (#944) can classify the wrap decision
    * without re-deriving reactivity from the expression string.

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -417,9 +417,9 @@ export interface IRLoop {
   loc: SourceLocation
 
   /**
-   * True if the array is a static prop (not a signal).
-   * Static arrays don't need reconcileList - SSR elements are hydrated directly.
-   * Dynamic signal arrays need reconcileList to update DOM when signal changes.
+   * True when the array needs no reconciliation (literal arrays, local consts
+   * without prop/signal origin). False for signal arrays, function-call arrays,
+   * and direct prop arrays — all of which compile to mapArray.
    */
   isStaticArray: boolean
 


### PR DESCRIPTION
## Summary

Closes #1586.

- `props.items.map()` was silently compiled to a static `forEach` that only updated text content of existing DOM nodes — it did not add/remove elements when the array changed. No warning was emitted.
- Root cause: `isStaticArray` in `jsx-to-ir.ts` checked `isSignalOrMemoArray` and `hasCalls` but not direct prop references, so `props.X` (an Identifier with no calls and no signal pattern) fell through to the static path.
- Fix: add `isDirectPropArray` check so direct prop access in `.map()` array expressions triggers `mapArray` compilation with keyed reconciliation.
- `.flatMap()` is excluded from this change because its block-body code generation path is not yet compatible with `mapArray`.
- Indirect prop references through constants (`const entries = Object.entries(props.X); entries.map(...)`) remain on the static path with CSR materialize — a separate concern.

## Test plan

- [x] `loop-fallback-wrap.test.ts` — updated "static prop array stays static" → "prop array compiles to mapArray"
- [x] `static-loop-csr-materialize.test.ts` — updated "safe-prop array" → "direct prop array uses mapArray"
- [x] `compiler-stress-1244.test.ts` — updated ref callback test to expect signal accessor (`it().id`)
- [x] Doc-example and adapter snapshots regenerated
- [x] All 507 adapter conformance tests pass
- [x] 1648/1652 compiler unit tests pass (4 pre-existing alias/resolver failures unrelated to this change)

https://claude.ai/code/session_01AfSTbxqyaMzjjY2gxWxAJi

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfSTbxqyaMzjjY2gxWxAJi)_