### PR TITLE
feat(jsx): implement BF062 — AwaitExpression in template scope

### DIFF
--- a/packages/jsx/src/__tests__/staged-ir/10-stage-diagnostics.test.ts
+++ b/packages/jsx/src/__tests__/staged-ir/10-stage-diagnostics.test.ts
@@ -622,3 +622,37 @@ describe('compileJSX surfaces stage-violation diagnostics by default', () => {
     expect(errors.find(e => e.startsWith('[BF061]'))).toBeUndefined()
   })
 })
+
+describe('BF062: AwaitExpression in template scope', () => {
+  test('await in JSX child position emits BF062', () => {
+    const { errors } = compile(`
+      'use client'
+
+      interface Props {}
+
+      export async function Foo(_props: Props) {
+        const result = await fetch('/api')
+        return <div>{await result.json()}</div>
+      }
+    `)
+
+    const bf062 = errors.find(e => e.startsWith('[BF062]'))
+    expect(bf062).toBeDefined()
+    expect(bf062).toContain('AwaitExpression')
+  })
+
+  test('await in component body (not JSX) does NOT emit BF062', () => {
+    const { errors } = compile(`
+      'use client'
+
+      interface Props {}
+
+      export async function Foo(_props: Props) {
+        const data = await fetch('/api')
+        return <div>loaded</div>
+      }
+    `)
+
+    expect(errors.find(e => e.startsWith('[BF062]'))).toBeUndefined()
+  })
+})

--- a/packages/jsx/src/__tests__/staged-ir/10-stage-diagnostics.test.ts
+++ b/packages/jsx/src/__tests__/staged-ir/10-stage-diagnostics.test.ts
@@ -16,7 +16,7 @@
  *
  * BF060: signal/memo getter referenced from template scope
  * BF061: init-scope local referenced from template scope
- * BF062: cross-stage await — emitted at Phase 1 dispatcher (not here)
+ * BF062: cross-stage await — emitted at Phase 1 dispatcher (jsx-to-ir.ts)
  */
 
 import { describe, test, expect } from 'bun:test'
@@ -654,5 +654,38 @@ describe('BF062: AwaitExpression in template scope', () => {
     `)
 
     expect(errors.find(e => e.startsWith('[BF062]'))).toBeUndefined()
+  })
+
+  test('await in JSX attribute position emits BF062', () => {
+    const { errors } = compile(`
+      'use client'
+
+      interface Props {}
+
+      export async function Foo(_props: Props) {
+        return <div data-x={await fetch('/api')}>hi</div>
+      }
+    `)
+
+    const bf062 = errors.find(e => e.startsWith('[BF062]'))
+    expect(bf062).toBeDefined()
+  })
+
+  test('emitted output remains parseable JS after BF062', () => {
+    const { errors, templateBody, initBody } = compile(`
+      'use client'
+
+      interface Props {}
+
+      export async function Foo(_props: Props) {
+        const result = await fetch('/api')
+        return <div>{await result.json()}</div>
+      }
+    `)
+
+    expect(errors.find(e => e.startsWith('[BF062]'))).toBeDefined()
+    // The emitted template/init should not contain bare 'await'
+    expect(templateBody).not.toContain('await')
+    expect(initBody).not.toContain('await')
   })
 })

--- a/packages/jsx/src/__tests__/staged-ir/10-stage-diagnostics.test.ts
+++ b/packages/jsx/src/__tests__/staged-ir/10-stage-diagnostics.test.ts
@@ -24,7 +24,7 @@ import { ErrorCodes } from '../../errors'
 import { recordStageDiagnostics } from '../../ir-to-client-js/compute-inlinability'
 import type { ConstantInfo, CompilerError } from '../../types'
 import type { RelocateDecision } from '../../relocate'
-import { compile } from './helpers'
+import { compile, expectValidJs } from './helpers'
 
 const dummyLoc = {
   file: 'Test.tsx',
@@ -671,8 +671,8 @@ describe('BF062: AwaitExpression in template scope', () => {
     expect(bf062).toBeDefined()
   })
 
-  test('emitted output remains parseable JS after BF062', () => {
-    const { errors, templateBody, initBody } = compile(`
+  test('emitted client JS remains parseable after BF062', () => {
+    const { errors, clientJs } = compile(`
       'use client'
 
       interface Props {}
@@ -684,8 +684,22 @@ describe('BF062: AwaitExpression in template scope', () => {
     `)
 
     expect(errors.find(e => e.startsWith('[BF062]'))).toBeDefined()
-    // The emitted template/init should not contain bare 'await'
-    expect(templateBody).not.toContain('await')
-    expect(initBody).not.toContain('await')
+    expectValidJs(clientJs)
+  })
+
+  test('nested await inside scalar expression emits BF062', () => {
+    const { errors, clientJs } = compile(`
+      'use client'
+
+      interface Props {}
+
+      export async function Foo(_props: Props) {
+        return <div>{String(await fetch('/api'))}</div>
+      }
+    `)
+
+    const bf062 = errors.find(e => e.startsWith('[BF062]'))
+    expect(bf062).toBeDefined()
+    expectValidJs(clientJs)
   })
 })

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -168,7 +168,7 @@ const errorMessages: Record<ErrorCode, string> = {
     'Init-scope local referenced from template scope. The template lambda runs at module scope (via render() / renderChild()) and cannot reach init-body locals. Wrap the JSX expression in /* @client */, or lift the value to a prop or module-scope const.',
 
   [ErrorCodes.STAGE_AWAIT_IN_TEMPLATE]:
-    'AwaitExpression in template scope. The hydrate-time template lambda is synchronous; awaiting here would hang first render. Move the await into a server-side handler and pass the resolved value as a prop.',
+    'AwaitExpression in template scope. The generated template and init functions are synchronous — a bare `await` produces a SyntaxError at parse time. Move the await into the component body (before the return) or into an onMount/effect callback, and pass the resolved value to JSX.',
 
   [ErrorCodes.INLINE_JSX_CALLBACK_CAPTURE]:
     "Inline JSX-returning arrow function captures a non-module identifier. Extract the callback into a top-level 'use client' component (e.g. `function MyNode(n) { return <div/> }` then `renderNode={MyNode}`) or pass captured values via component props.",

--- a/packages/jsx/src/ir-to-client-js/compute-inlinability.ts
+++ b/packages/jsx/src/ir-to-client-js/compute-inlinability.ts
@@ -554,8 +554,8 @@ function collectTemplateRiskyNames(irRoot: IRNode): Set<string> {
  *  - BF061: init-scope local referenced from template scope. Same
  *    fallback shape, different binding kind.
  *
- * BF062 (cross-stage await) belongs at the Phase 1 dispatcher (await
- * is a statement-level concern); not surfaced here.
+ * BF062 (cross-stage await) is emitted at the Phase 1 dispatcher
+ * (jsx-to-ir.ts) for both child and attribute positions; not here.
  *
  * Promoted from warning to error in #1187 phase 6 — the
  * `templateRiskyNames` gate in `toLegacyInlinability` ensures only

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1932,10 +1932,14 @@ function transformJsxExpression(
       return null
 
     // --- Forbidden in render position ---
-    // Spec A.3.3 / A.3.5 reserve BF050 (`AwaitExpression`) and BF051
-    // (`YieldExpression`) for PR 5 once the dispatcher is the single
-    // entry point; for now preserve today's scalar-fallback behaviour.
     case ts.SyntaxKind.AwaitExpression:
+      ctx.analyzer.errors.push(
+        createError(
+          ErrorCodes.STAGE_AWAIT_IN_TEMPLATE,
+          getSourceLocation(node, ctx.sourceFile, ctx.filePath),
+        ),
+      )
+      return null
     case ts.SyntaxKind.YieldExpression:
       return null
 

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1939,7 +1939,15 @@ function transformJsxExpression(
           getSourceLocation(node, ctx.sourceFile, ctx.filePath),
         ),
       )
-      return null
+      return {
+        type: 'expression' as const,
+        expr: 'undefined',
+        typeInfo: null,
+        reactive: false,
+        slotId: null,
+        loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
+        origin: { phase: 'tick', scope: 'template', effect: 'pure', freeRefs: [] },
+      } satisfies IRExpression
     case ts.SyntaxKind.YieldExpression:
       return null
 
@@ -3452,6 +3460,17 @@ function getAttributeValue(attr: ts.JsxAttribute, ctx: TransformContext): AttrVa
       if (branchInit && !initializerShapeContainsJsx(branchInit)) {
         expr = branchInit
       }
+    }
+
+    // BF062: AwaitExpression in attribute position
+    if (ts.isAwaitExpression(expr)) {
+      ctx.analyzer.errors.push(
+        createError(
+          ErrorCodes.STAGE_AWAIT_IN_TEMPLATE,
+          getSourceLocation(expr, ctx.sourceFile, ctx.filePath),
+        ),
+      )
+      return AttrValueOf.literal('undefined')
     }
 
     // Check for bare signal/memo identifier (BF044)

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1333,6 +1333,24 @@ function transformExpressionInner(
   }
 
   // Scalar fallback — unchanged from pre-refactor.
+  // BF062: catch nested await inside scalar expressions (e.g. {foo(await bar)})
+  if (containsAwaitExpression(expr)) {
+    ctx.analyzer.errors.push(
+      createError(
+        ErrorCodes.STAGE_AWAIT_IN_TEMPLATE,
+        getSourceLocation(expr, ctx.sourceFile, ctx.filePath),
+      ),
+    )
+    return {
+      type: 'expression' as const,
+      expr: 'undefined',
+      typeInfo: null,
+      reactive: false,
+      slotId: null,
+      loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
+      origin: { phase: 'tick', scope: 'template', effect: 'pure', freeRefs: [] },
+    } satisfies IRExpression
+  }
   const exprText = ctx.getJS(expr)
   const freeRefs = resolveFreeRefs(expr, makeBindingEnv(ctx))
   const origin: OriginInfo = {
@@ -1680,6 +1698,12 @@ function containsJsxInExpression(node: ts.Node): boolean {
     return true
   }
   return ts.forEachChild(node, containsJsxInExpression) ?? false
+}
+
+function containsAwaitExpression(node: ts.Node): boolean {
+  if (ts.isAwaitExpression(node)) return true
+  if (ts.isFunctionDeclaration(node) || ts.isFunctionExpression(node) || ts.isArrowFunction(node)) return false
+  return ts.forEachChild(node, containsAwaitExpression) ?? false
 }
 
 /**
@@ -3470,7 +3494,7 @@ function getAttributeValue(attr: ts.JsxAttribute, ctx: TransformContext): AttrVa
           getSourceLocation(expr, ctx.sourceFile, ctx.filePath),
         ),
       )
-      return AttrValueOf.literal('undefined')
+      return AttrValueOf.expression('undefined')
     }
 
     // Check for bare signal/memo identifier (BF044)


### PR DESCRIPTION
## Summary

- Implement BF062 diagnostic: emit an error when an `AwaitExpression` appears in JSX child or attribute position (template scope)
- The hydrate-time template lambda is synchronous — `await` here produces a SyntaxError at runtime because the compiler strips the `async` keyword from the component function during template generation
- Previously the expression silently fell through to scalar-fallback, emitting `await` verbatim into both the SSR template and client JS init function (both non-async)
- Closes the last remaining code in the BF error code audit (#1552)

## Test plan

- [x] 1643 compiler unit tests pass (0 regressions)
- [x] New test: `await` in JSX child position emits BF062
- [x] New test: `await` in component body (not JSX) does NOT emit BF062

https://claude.ai/code/session_01SEG1QwvsXVy6LoAFbYXLLS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEG1QwvsXVy6LoAFbYXLLS)_