### PR TITLE
refactor: unify inner-loop reactive-attr emit through emitAttrUpdate

### DIFF
--- a/.changeset/unify-inner-loop-attr-emit.md
+++ b/.changeset/unify-inner-loop-attr-emit.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Unify inner-loop reactive-attribute emit through the centralised emitAttrUpdate helper (#1368). Fixes boolean-attr handling in nested loops (now uses DOM property assignment) and adds missing className/value special-case handling.

--- a/packages/jsx/src/__tests__/nested-loop-reactive-attrs.test.ts
+++ b/packages/jsx/src/__tests__/nested-loop-reactive-attrs.test.ts
@@ -64,7 +64,7 @@ describe('reactive attributes inside a nested .map() body (#135)', () => {
     // Both effects must run inside the inner mapArray's renderItem (so
     // they capture `task` as the inner-loop accessor — `task()` rather
     // than the module-level closure).
-    expect(content).toMatch(/createEffect\(\(\) => \{\s*const __v = styleToCss\([\s\S]*?task\(\)\.id/)
+    expect(content).toMatch(/createEffect\(\(\) => \{[\s\S]*?styleToCss\([\s\S]*?task\(\)\.id/)
   })
 
   test('non-style reactive attribute (className) wires up too', () => {
@@ -141,7 +141,7 @@ describe('reactive attributes inside a nested .map() body (#135)', () => {
 
     // `data-off` uses the truthy-check shape (no `__v != null` for this
     // attribute) so a concrete `false` removes the attribute.
-    expect(content).toMatch(/createEffect\(\(\) => \{ if \([^)]*c\(\)\.isOff[^)]*\)\s*[^.]+\.setAttribute\('data-off',\s*''\)/)
+    expect(content).toMatch(/createEffect\(\(\) => \{[\s\S]*?if \(c\(\)\.isOff\)\s*\S+\.setAttribute\('data-off',\s*''\)/)
     // aria-* keeps the explicit "true" value per WAI-ARIA.
     expect(content).toContain("setAttribute('aria-pressed', 'true')")
   })
@@ -234,7 +234,7 @@ describe('reactive attributes inside a nested .map() body (#135)', () => {
     // to subscribe to the per-item accessor). The bug we're locking
     // down is purely in the createEffect emission, so scope to that.
     const effectMatch = content.match(
-      /createEffect\(\(\) => \{ const __v = styleToCss\(\{[\s\S]*?\}\); if \(__v != null\) __ta_s\d+\.setAttribute\('style'/,
+      /createEffect\(\(\) => \{[\s\S]*?styleToCss\(\{[\s\S]*?\}\)[\s\S]*?__ta_s\d+\.setAttribute\('style'/,
     )
     expect(effectMatch).not.toBeNull()
     const effectBody = effectMatch![0]
@@ -283,7 +283,7 @@ describe('reactive attributes inside a nested .map() body (#135)', () => {
     expect(result.errors).toHaveLength(0)
     const content = result.files.find((f) => f.type === 'clientJs')!.content
     const effectMatch = content.match(
-      /createEffect\(\(\) => \{ const __v = styleToCss\(\{[\s\S]*?\}\); if \(__v != null\) __ta_s\d+\.setAttribute\('style'/,
+      /createEffect\(\(\) => \{[\s\S]*?styleToCss\(\{[\s\S]*?\}\)[\s\S]*?__ta_s\d+\.setAttribute\('style'/,
     )
     expect(effectMatch).not.toBeNull()
     const effectBody = effectMatch![0]

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-inner-loop.ts
@@ -23,7 +23,7 @@ import type {
   IRNode,
   LoopParamBinding,
 } from '../../../types'
-import { AttrValueOf } from '../../../types'
+import { AttrValueOf, pickAttrMeta } from '../../../types'
 import {
   wrapLoopParamAsAccessor,
   attrValueToString,
@@ -67,8 +67,6 @@ import type {
   InnerLoopText,
   InnerLoopsPlan,
 } from './inner-loop'
-import { toHtmlAttrName } from '../../utils'
-import { isBooleanAttr } from '../../../html-constants'
 
 export interface BuildInnerLoopsArgs {
   levels: readonly DepthLevel[]
@@ -200,14 +198,11 @@ function buildReactiveEmit(
 
   const reactiveAttrs: InnerLoopReactiveAttr[] = inner.bindings.reactiveAttrs.map(attr => {
     const wrapped = wrapLoopParamAsAccessor(wrapOuter(attr.expression), inner.param, inner.paramBindings)
-    const isStyleObject = attr.attrName === 'style' && /^\s*\{/.test(attr.expression)
     return {
       slotId: attr.childSlotId,
-      attrName: toHtmlAttrName(attr.attrName),
+      attrName: attr.attrName,
       wrappedExpression: wrapped,
-      isStyleObject,
-      isBoolean: isBooleanAttr(attr.attrName),
-      presenceOrUndefined: !!attr.presenceOrUndefined,
+      meta: pickAttrMeta(attr),
     }
   })
 

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/inner-loop.ts
@@ -12,6 +12,7 @@
 
 import type { LoopChildEvent } from '../../types'
 import type {
+  AttrMeta,
   IRLoopChildComponent,
   LoopParamBinding,
 } from '../../../types'
@@ -48,29 +49,17 @@ export interface InnerLoopText {
  * etc. — every element in the loop body whose attribute reads a signal
  * (or the loop param) gets its own per-item `createEffect`.
  *
- * `attrName` is already in DOM-spelling (kebab for SVG presentation
- * attrs, `class` for `className`) so the stringifier can emit
- * `setAttribute(attrName, ...)` directly.
+ * `attrName` is in JSX form (e.g. `className`, not `class`) — the
+ * stringifier delegates to `emitAttrUpdate` which maps to HTML spelling.
  */
 export interface InnerLoopReactiveAttr {
   slotId: string
-  /** DOM attribute name (already mapped via `toHtmlAttrName`). */
+  /** JSX attribute name (mapped to HTML spelling by `emitAttrUpdate`). */
   attrName: string
   /** Already wrapped via inner+outer loop param accessor. */
   wrappedExpression: string
-  /** True for `style={{...}}` object literals — routed through `styleToCss`. */
-  isStyleObject: boolean
-  /** True for boolean DOM attributes (`disabled`, `checked`, ...). */
-  isBoolean: boolean
-  /**
-   * True for `attr={expr || undefined}` patterns where the compiler
-   * stripped the `|| undefined` and now stores the bare expression.
-   * The emitter must use a truthy check (not `!= null`) — otherwise a
-   * concrete `false` value writes `data-attr="false"` instead of
-   * removing the attribute. Surfaced by the calendar demo's
-   * `data-outside={day.isOutside || undefined}` on a nested map root.
-   */
-  presenceOrUndefined: boolean
+  /** Pre-copied attr metadata used by `emitAttrUpdate`. */
+  meta: AttrMeta
 }
 
 /**

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/inner-loop.ts
@@ -32,6 +32,7 @@
 
 import { keyAttrName } from '../../utils'
 import { emitComponentAndEventSetup } from '../shared'
+import { emitAttrUpdate } from '../../emit-reactive'
 import { emitMultiRootTemplateCloneLines } from './template-parse'
 import { emitLoopChildRefs } from './loop'
 import type {
@@ -109,29 +110,14 @@ function emitReactive(lines: string[], inner: InnerLoopPlan, indent: string): vo
       lines.push(`${indent}  if (__rt) createEffect(() => { __rt.textContent = String(${text.wrappedExpression}) }) }`)
     }
   }
-  // Reactive attribute effects: emit one `createEffect` per attribute
-  // binding so a signal change updates the inner-loop element's DOM
-  // attribute in place (mirrors `collectLoopChildReactiveAttrs` for
-  // top-level loops).
   for (const attr of emit.reactiveAttrs) {
     const targetVar = `__ta_${attr.slotId.replace(/[^a-zA-Z0-9]/g, '_')}`
     lines.push(`${indent}  { const ${targetVar} = qsa(__innerEl${uid}, '[bf="${attr.slotId}"]')`)
-    if (attr.isStyleObject) {
-      lines.push(`${indent}  if (${targetVar}) createEffect(() => { const __v = styleToCss(${attr.wrappedExpression}); if (__v != null) ${targetVar}.setAttribute('style', __v); else ${targetVar}.removeAttribute('style') }) }`)
-    } else if (attr.isBoolean) {
-      lines.push(`${indent}  if (${targetVar}) createEffect(() => { if (${attr.wrappedExpression}) ${targetVar}.setAttribute('${attr.attrName}', ''); else ${targetVar}.removeAttribute('${attr.attrName}') }) }`)
-    } else if (attr.presenceOrUndefined) {
-      // `attr={expr || undefined}` was normalised by jsx-to-ir to the
-      // bare expression + presenceOrUndefined=true. Use a truthy check
-      // so a concrete `false` value removes the attribute instead of
-      // writing `data-foo="false"`. aria-* attributes must keep an
-      // explicit "true" value per WAI-ARIA. Surfaced by calendar's
-      // `data-outside={day.isOutside || undefined}` (#135 follow-up).
-      const ariaVal = attr.attrName.startsWith('aria-') ? "'true'" : "''"
-      lines.push(`${indent}  if (${targetVar}) createEffect(() => { if (${attr.wrappedExpression}) ${targetVar}.setAttribute('${attr.attrName}', ${ariaVal}); else ${targetVar}.removeAttribute('${attr.attrName}') }) }`)
-    } else {
-      lines.push(`${indent}  if (${targetVar}) createEffect(() => { const __v = ${attr.wrappedExpression}; if (__v != null) ${targetVar}.setAttribute('${attr.attrName}', String(__v)); else ${targetVar}.removeAttribute('${attr.attrName}') }) }`)
+    lines.push(`${indent}  if (${targetVar}) createEffect(() => {`)
+    for (const stmt of emitAttrUpdate(targetVar, attr.attrName, attr.wrappedExpression, attr.meta)) {
+      lines.push(`${indent}    ${stmt}`)
     }
+    lines.push(`${indent}  }) }`)
   }
   // Imperative ref callbacks fire on every renderItem invocation, which
   // means every mount: SSR hydration, initial CSR creation, and same-key


### PR DESCRIPTION
## Summary

Closes #1368

- Replace the inner-loop stringifier's inline 4-way dispatch (style / boolean / presenceOrUndefined / generic) with a single call to the existing `emitAttrUpdate` helper, matching every other emit site in the compiler
- Simplify `InnerLoopReactiveAttr` plan type from three ad-hoc booleans (`isStyleObject`, `isBoolean`, `presenceOrUndefined`) to a single `meta: AttrMeta` field
- Stop pre-mapping `attrName` via `toHtmlAttrName` at build time — `emitAttrUpdate` handles the mapping internally
- Fix boolean-attr handling in inner loops: was using `setAttribute/removeAttribute` (incorrect — `setAttribute('disabled', '')` always disables), now uses DOM property assignment (`el.disabled = !!val`) via `emitAttrUpdate`
- Fix `className` and `value` handling in inner loops: were falling through to generic, now get proper special-case treatment

Net result: -30 lines, adding a new attribute kind now requires editing exactly one file (`emitAttrUpdate`).

## Test plan

- [x] Compiler unit tests: 1658 pass (4 pre-existing failures unrelated to this change)
- [x] Adapter conformance: 507 pass / 0 fail
- [x] Client runtime: 284 pass / 0 fail
- [x] Updated test regexes in `nested-loop-reactive-attrs.test.ts` to match the new multi-line `createEffect` output format

https://claude.ai/code/session_01AbQox7jpeo6p4SMUPTWqAP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AbQox7jpeo6p4SMUPTWqAP)_