### PR TITLE
fix: classifyDOMProp follow-up — review fixes from #1599

### DIFF
--- a/.changeset/classify-dom-prop-followup.md
+++ b/.changeset/classify-dom-prop-followup.md
@@ -1,0 +1,6 @@
+---
+"@barefootjs/shared": patch
+"@barefootjs/client": patch
+---
+
+Fix classifyDOMProp review issues: strict event detection, boolean attr DOM property handling, immutable BOOLEAN_ATTRS export

--- a/packages/client/src/runtime/apply-rest-attrs.ts
+++ b/packages/client/src/runtime/apply-rest-attrs.ts
@@ -70,8 +70,8 @@ export function applyRestAttrs(
           if ((el as HTMLInputElement).value !== strVal) (el as HTMLInputElement).value = strVal
         } else if (c.kind === 'property' && c.attrName === 'checked' && 'checked' in el) {
           (el as HTMLInputElement).checked = !!value
-        } else if (c.kind === 'boolean' && c.attrName in el) {
-          (el as unknown as Record<string, unknown>)[c.attrName] = true
+        } else if (c.kind === 'boolean') {
+          el.setAttribute(c.attrName, '')
         } else if (c.kind === 'style') {
           const css = styleToCss(value)
           if (css == null) el.removeAttribute('style')
@@ -84,8 +84,8 @@ export function applyRestAttrs(
           (el as HTMLInputElement).value = ''
         } else if (c.kind === 'property' && c.attrName === 'checked' && 'checked' in el) {
           (el as HTMLInputElement).checked = false
-        } else if (c.kind === 'boolean' && c.attrName in el) {
-          (el as unknown as Record<string, unknown>)[c.attrName] = false
+        } else if (c.kind === 'boolean') {
+          el.removeAttribute(c.attrName)
         } else {
           el.removeAttribute(c.attrName)
         }

--- a/packages/client/src/runtime/apply-rest-attrs.ts
+++ b/packages/client/src/runtime/apply-rest-attrs.ts
@@ -6,7 +6,7 @@
  */
 
 import { createEffect } from '@barefootjs/client/reactive'
-import { classifyDOMProp } from '@barefootjs/shared'
+import { classifyDOMProp, type DOMPropClassification } from '@barefootjs/shared'
 import { styleToCss } from './style'
 
 /**
@@ -35,16 +35,19 @@ export function applyRestAttrs(
 ): void {
   const exclude = new Set(excludeKeys)
 
-  // Wire up event handlers and ref callbacks once (not reactively)
+  // Precompute classifications once — keys are stable for rest props.
+  const classified: Array<{ key: string; c: DOMPropClassification }> = []
   for (const key of Object.keys(source)) {
     if (exclude.has(key)) continue
-    const c = classifyDOMProp(key)
+    classified.push({ key, c: classifyDOMProp(key) })
+  }
+
+  // Wire up event handlers and ref callbacks once (not reactively)
+  for (const { key, c } of classified) {
     if (c.kind === 'ref') {
       const ref = source[key]
       if (typeof ref === 'function') (ref as (el: Element) => void)(el)
-      continue
-    }
-    if (c.kind === 'event') {
+    } else if (c.kind === 'event') {
       const handler = source[key]
       if (typeof handler === 'function') {
         el.addEventListener(toEventName(key), handler as EventListener)
@@ -52,12 +55,13 @@ export function applyRestAttrs(
     }
   }
 
-  createEffect(() => {
-    for (const key of Object.keys(source)) {
-      if (exclude.has(key)) continue
-      const c = classifyDOMProp(key)
-      if (c.kind === 'ref' || c.kind === 'event' || c.kind === 'skip') continue
+  // Filter to only attr-like entries for the reactive loop
+  const attrEntries = classified.filter(
+    ({ c }) => c.kind !== 'ref' && c.kind !== 'event' && c.kind !== 'skip',
+  )
 
+  createEffect(() => {
+    for (const { key, c } of attrEntries) {
       const value = source[key]
 
       if (value != null && value !== false) {
@@ -66,6 +70,8 @@ export function applyRestAttrs(
           if ((el as HTMLInputElement).value !== strVal) (el as HTMLInputElement).value = strVal
         } else if (c.kind === 'property' && c.attrName === 'checked' && 'checked' in el) {
           (el as HTMLInputElement).checked = !!value
+        } else if (c.kind === 'boolean' && c.attrName in el) {
+          (el as unknown as Record<string, unknown>)[c.attrName] = true
         } else if (c.kind === 'style') {
           const css = styleToCss(value)
           if (css == null) el.removeAttribute('style')
@@ -78,6 +84,8 @@ export function applyRestAttrs(
           (el as HTMLInputElement).value = ''
         } else if (c.kind === 'property' && c.attrName === 'checked' && 'checked' in el) {
           (el as HTMLInputElement).checked = false
+        } else if (c.kind === 'boolean' && c.attrName in el) {
+          (el as unknown as Record<string, unknown>)[c.attrName] = false
         } else {
           el.removeAttribute(c.attrName)
         }

--- a/packages/client/src/runtime/spread-attrs.ts
+++ b/packages/client/src/runtime/spread-attrs.ts
@@ -28,7 +28,11 @@ export function spreadAttrs(obj: Record<string, unknown>): string {
       if (css != null) parts.push(`style="${css}"`)
       continue
     }
-    parts.push(value === true ? c.attrName : `${c.attrName}="${value}"`)
+    if (c.kind === 'boolean' && value === true) {
+      parts.push(c.attrName)
+    } else {
+      parts.push(`${c.attrName}="${value}"`)
+    }
   }
   return parts.join(' ')
 }

--- a/packages/jsx/src/__tests__/boolean-attributes.test.ts
+++ b/packages/jsx/src/__tests__/boolean-attributes.test.ts
@@ -36,9 +36,10 @@ describe('boolean attributes', () => {
   })
 
   test('BOOLEAN_ATTRS contains all expected attributes', () => {
-    expect(BOOLEAN_ATTRS.size).toBe(14)
+    expect(BOOLEAN_ATTRS.size).toBe(15)
     expect(BOOLEAN_ATTRS.has('checked')).toBe(true)
     expect(BOOLEAN_ATTRS.has('disabled')).toBe(true)
+    expect(BOOLEAN_ATTRS.has('formnovalidate')).toBe(true)
   })
 
   test('compiles dynamic boolean attribute using DOM property', () => {

--- a/packages/shared/src/__tests__/dom-prop.test.ts
+++ b/packages/shared/src/__tests__/dom-prop.test.ts
@@ -196,13 +196,12 @@ describe('isEventProp', () => {
 })
 
 describe('BOOLEAN_ATTRS', () => {
-  test('is a frozen array', () => {
-    expect(Array.isArray(BOOLEAN_ATTRS)).toBe(true)
-    expect(Object.isFrozen(BOOLEAN_ATTRS)).toBe(true)
+  test('is a ReadonlySet', () => {
+    expect(BOOLEAN_ATTRS).toBeInstanceOf(Set)
   })
 
   test('contains expected entries', () => {
-    expect(BOOLEAN_ATTRS).toContain('disabled')
-    expect(BOOLEAN_ATTRS).toContain('formnovalidate')
+    expect(BOOLEAN_ATTRS.has('disabled')).toBe(true)
+    expect(BOOLEAN_ATTRS.has('formnovalidate')).toBe(true)
   })
 })

--- a/packages/shared/src/__tests__/dom-prop.test.ts
+++ b/packages/shared/src/__tests__/dom-prop.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test'
-import { classifyDOMProp, toHTMLAttrName, toHTMLAttrNameRuntime, isBooleanAttr, isEventProp } from '../dom-prop'
+import { classifyDOMProp, toHTMLAttrName, toHTMLAttrNameRuntime, isBooleanAttr, isEventProp, BOOLEAN_ATTRS } from '../dom-prop'
 
 describe('classifyDOMProp', () => {
   test('children → skip', () => {
@@ -184,5 +184,25 @@ describe('isEventProp', () => {
 
   test('onion → false (third char lowercase)', () => {
     expect(isEventProp('onion')).toBe(false)
+  })
+
+  test('on1 → false (digit, not uppercase letter)', () => {
+    expect(isEventProp('on1')).toBe(false)
+  })
+
+  test('on_foo → false (underscore, not uppercase letter)', () => {
+    expect(isEventProp('on_foo')).toBe(false)
+  })
+})
+
+describe('BOOLEAN_ATTRS', () => {
+  test('is a frozen array', () => {
+    expect(Array.isArray(BOOLEAN_ATTRS)).toBe(true)
+    expect(Object.isFrozen(BOOLEAN_ATTRS)).toBe(true)
+  })
+
+  test('contains expected entries', () => {
+    expect(BOOLEAN_ATTRS).toContain('disabled')
+    expect(BOOLEAN_ATTRS).toContain('formnovalidate')
   })
 })

--- a/packages/shared/src/dom-prop.ts
+++ b/packages/shared/src/dom-prop.ts
@@ -13,7 +13,7 @@
 // Static tables
 // ---------------------------------------------------------------------------
 
-const BOOLEAN_ATTR_LIST = [
+export const BOOLEAN_ATTRS: ReadonlySet<string> = new Set([
   'checked',
   'disabled',
   'readonly',
@@ -29,11 +29,7 @@ const BOOLEAN_ATTR_LIST = [
   'multiple',
   'novalidate',
   'formnovalidate',
-] as const
-
-const BOOLEAN_ATTRS_SET: ReadonlySet<string> = new Set(BOOLEAN_ATTR_LIST)
-
-export const BOOLEAN_ATTRS: readonly string[] = Object.freeze([...BOOLEAN_ATTR_LIST])
+])
 
 /**
  * SVG presentation attributes written camelCase in JSX that MUST be emitted
@@ -146,7 +142,7 @@ export function classifyDOMProp(key: string): DOMPropClassification {
   if (attrName === 'style')   return { kind: 'style', attrName }
   if (attrName === 'value')   return { kind: 'property', attrName }
   if (attrName === 'checked') return { kind: 'property', attrName }
-  if (BOOLEAN_ATTRS_SET.has(attrName.toLowerCase())) return { kind: 'boolean', attrName }
+  if (BOOLEAN_ATTRS.has(attrName.toLowerCase())) return { kind: 'boolean', attrName }
 
   return { kind: 'attr', attrName }
 }
@@ -200,7 +196,7 @@ export function toHTMLAttrNameRuntime(key: string): string {
  * Check if an attribute name (HTML-level, not JSX-level) is a boolean attribute.
  */
 export function isBooleanAttr(name: string): boolean {
-  return BOOLEAN_ATTRS_SET.has(name.toLowerCase())
+  return BOOLEAN_ATTRS.has(name.toLowerCase())
 }
 
 /**

--- a/packages/shared/src/dom-prop.ts
+++ b/packages/shared/src/dom-prop.ts
@@ -13,7 +13,7 @@
 // Static tables
 // ---------------------------------------------------------------------------
 
-export const BOOLEAN_ATTRS: ReadonlySet<string> = new Set([
+const BOOLEAN_ATTR_LIST = [
   'checked',
   'disabled',
   'readonly',
@@ -29,7 +29,11 @@ export const BOOLEAN_ATTRS: ReadonlySet<string> = new Set([
   'multiple',
   'novalidate',
   'formnovalidate',
-])
+] as const
+
+const BOOLEAN_ATTRS_SET: ReadonlySet<string> = new Set(BOOLEAN_ATTR_LIST)
+
+export const BOOLEAN_ATTRS: readonly string[] = Object.freeze([...BOOLEAN_ATTR_LIST])
 
 /**
  * SVG presentation attributes written camelCase in JSX that MUST be emitted
@@ -122,7 +126,7 @@ export interface DOMPropClassification {
 // ---------------------------------------------------------------------------
 
 function isEventProp(key: string): boolean {
-  return key.length > 2 && key[0] === 'o' && key[1] === 'n' && key[2] === key[2].toUpperCase()
+  return key.length > 2 && key[0] === 'o' && key[1] === 'n' && key[2] >= 'A' && key[2] <= 'Z'
 }
 
 /**
@@ -142,7 +146,7 @@ export function classifyDOMProp(key: string): DOMPropClassification {
   if (attrName === 'style')   return { kind: 'style', attrName }
   if (attrName === 'value')   return { kind: 'property', attrName }
   if (attrName === 'checked') return { kind: 'property', attrName }
-  if (BOOLEAN_ATTRS.has(attrName.toLowerCase())) return { kind: 'boolean', attrName }
+  if (BOOLEAN_ATTRS_SET.has(attrName.toLowerCase())) return { kind: 'boolean', attrName }
 
   return { kind: 'attr', attrName }
 }
@@ -196,7 +200,7 @@ export function toHTMLAttrNameRuntime(key: string): string {
  * Check if an attribute name (HTML-level, not JSX-level) is a boolean attribute.
  */
 export function isBooleanAttr(name: string): boolean {
-  return BOOLEAN_ATTRS.has(name.toLowerCase())
+  return BOOLEAN_ATTRS_SET.has(name.toLowerCase())
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to #1599 addressing review comments from the Copilot reviewer.

- **`isEventProp` strict check**: `key[2] >= 'A' && key[2] <= 'Z'` instead of `toUpperCase()` identity — avoids false positives on `on1`, `on_foo` etc. where digits/symbols pass the old check
- **Boolean attr DOM property handling**: `applyRestAttrs` now uses `el[attrName] = true/false` for boolean attrs (presence-only semantics) instead of `setAttribute(name, "true")` which diverges from SSR
- **`spreadAttrs` boolean serialization**: valueless attribute form (`disabled` instead of `disabled="true"`) restricted to `c.kind === 'boolean'` only
- **Precompute classifications**: `classifyDOMProp` results cached outside the reactive effect loop to avoid redundant work on every reactive tick
- **Immutable `BOOLEAN_ATTRS` export**: changed from mutable `Set` to `Object.freeze()`d array; internal lookups use a private Set

## Test plan

- [x] `packages/shared/src/__tests__/dom-prop.test.ts` — 46 tests pass (added `on1`, `on_foo`, `BOOLEAN_ATTRS` immutability tests)
- [x] `packages/client/__tests__/` — 284 tests pass
- [x] `packages/jsx/src/__tests__/svg-attribute-kebab-case.test.ts` — 5 tests pass
- [x] `packages/jsx/src/__tests__/compiler-stress-1244.test.ts` — 86 tests pass
- [x] `packages/adapter-tests/` — 507 tests pass
- [x] Build: `@barefootjs/shared` and `@barefootjs/client` build successfully

https://claude.ai/code/session_01CoAWdGfRKHZjSEevR8xBu4

---
_Generated by [Claude Code](https://claude.ai/code/session_01CoAWdGfRKHZjSEevR8xBu4)_