### PR TITLE
docs: add Claude Code skill installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ The full walkthrough — adapter / CSS choices, generated layout, and editing th
 
 ---
 
+## AI-Assisted Development with Claude Code
+
+BarefootJS ships a [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skill that gives Claude deep knowledge of the compiler, IR, CLI, and component system — so it can build, test, and debug BarefootJS components autonomously.
+
+**Install the skill in two commands:**
+
+```sh
+/plugin marketplace add piconic-ai/barefootjs
+/plugin install barefootjs@barefootjs
+```
+
+Once installed, Claude can use the `bf` CLI, write IR tests, trace signal graphs, and scaffold components — all without reading source files. See [AI-native Development](./docs/core/core-concepts/ai-native.md) for the full workflow.
+
+---
+
 ## Design Principles
 
 - **Backend Freedom** — Same JSX works with Hono, Go, Mojolicious, etc. No Node.js lock-in.

--- a/docs/core/README.mdx
+++ b/docs/core/README.mdx
@@ -19,7 +19,7 @@
 - [Backend Freedom](./core-concepts/backend-freedom.md) — How adapters let the same JSX run on any server
 - [MPA-style Development](./core-concepts/mpa-style.md) — Server-rendering by default, JS only where marked
 - [Fine-grained Reactivity](./core-concepts/reactivity.md) — Signals, effects, memos — no virtual DOM needed
-- [AI-native Development](./core-concepts/ai-native.md) — Testable IR, CLI discovery, AI-assisted workflows
+- [AI-native Development](./core-concepts/ai-native.md) — Testable IR, CLI discovery, Claude Code skill, AI-assisted workflows
 - [How It Works](./core-concepts/how-it-works.mdx) — Two-phase compilation, hydration markers, clean overrides
 
 ### 4. [Reactivity](./reactivity.md)

--- a/docs/core/core-concepts/ai-native.md
+++ b/docs/core/core-concepts/ai-native.md
@@ -66,6 +66,17 @@ When nothing in the registry fits, `bf gen component <name> <comps...>` scaffold
 
 **Visual preview**: hosted previews live at [ui.barefootjs.dev/components/&lt;name&gt;](https://ui.barefootjs.dev). Standalone `bf preview` for npm-installed projects is tracked in [#885](https://github.com/piconic-ai/barefootjs/issues/885).
 
+## Claude Code Skill
+
+BarefootJS publishes a [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skill that gives Claude deep knowledge of the compiler, IR, CLI, and component system. Install it and Claude can build, test, and debug BarefootJS projects autonomously:
+
+```sh
+/plugin marketplace add piconic-ai/barefootjs
+/plugin install barefootjs@barefootjs
+```
+
+With the skill active, Claude understands `bf` CLI commands, IR test patterns, signal graphs, adapter output, and error codes — no manual prompting needed.
+
 ## Agent Loop
 
 The same workflow driven by an AI agent — say, "add a settings form":

--- a/docs/core/quick-start.mdx
+++ b/docs/core/quick-start.mdx
@@ -147,6 +147,7 @@ This runs `bf build`, generates the final `uno.css`, and calls `wrangler deploy`
 
 ## Next steps
 
+- **[Claude Code Skill](./core-concepts/ai-native.md#claude-code-skill)** — Install the BarefootJS skill for Claude Code (`/plugin marketplace add piconic-ai/barefootjs`) and let Claude build components, write IR tests, and debug signals for you.
 - **[Core Concepts](./core-concepts.md)** — the four design principles behind BarefootJS: backend freedom, MPA-style rendering, fine-grained reactivity, and AI-native workflows.
 - **[`createSignal`](./reactivity/create-signal.md)** and **[`createMemo`](./reactivity/create-memo.md)** — the reactivity primitives you just used.
 - **[Client Directive](./rendering/client-directive.md)** — exactly what `"use client"` does and when to reach for it.


### PR DESCRIPTION
## Summary

- **README.md**: Add "AI-Assisted Development with Claude Code" section right after Quick Start — the most visible spot on the repo landing page
- **docs/core/core-concepts/ai-native.md**: Add "Claude Code Skill" section before the Agent Loop
- **docs/core/quick-start.mdx**: Add skill link as the first item in Next Steps
- **docs/core/README.mdx**: Update AI-native TOC entry to mention the Claude Code skill

## Test plan

- [ ] Verify README.md renders correctly on GitHub (no broken formatting)
- [ ] Verify the `#claude-code-skill` anchor link works on the AI-native docs page
- [ ] Verify the Quick Start "Next steps" link navigates to the correct page

https://claude.ai/code/session_01JBqEyFYbivjpV83GaTwGFv