### PR TITLE
docs: add Codex compatibility for barefootjs agent skill

### DIFF
--- a/.claude/skills/barefootjs/SKILL.md
+++ b/.claude/skills/barefootjs/SKILL.md
@@ -1,0 +1,1 @@
+../../../plugins/barefootjs/skills/barefootjs/SKILL.md

--- a/README.md
+++ b/README.md
@@ -39,18 +39,24 @@ The full walkthrough — adapter / CSS choices, generated layout, and editing th
 
 ---
 
-## AI-Assisted Development with Claude Code
+## AI-Assisted Development
 
-BarefootJS ships a [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skill that gives Claude deep knowledge of the compiler, IR, CLI, and component system — so it can build, test, and debug BarefootJS components autonomously.
+BarefootJS ships an agent skill that gives AI deep knowledge of the compiler, IR, CLI, and component system — so it can build, test, and debug BarefootJS components autonomously. Works with both **Claude Code** and **Codex**.
 
-**Install the skill in two commands:**
+**Claude Code:**
 
 ```sh
 /plugin marketplace add piconic-ai/barefootjs
 /plugin install barefootjs@barefootjs
 ```
 
-Once installed, Claude can use the `bf` CLI, write IR tests, trace signal graphs, and scaffold components — all without reading source files. See [AI-native Development](./docs/core/core-concepts/ai-native.md) for the full workflow.
+**Codex:**
+
+```
+install the barefootjs skill from piconic-ai/barefootjs
+```
+
+Once installed, the agent can use the `bf` CLI, write IR tests, trace signal graphs, and scaffold components — all without reading source files. See [AI-native Development](./docs/core/core-concepts/ai-native.md) for the full workflow.
 
 ---
 

--- a/docs/core/README.mdx
+++ b/docs/core/README.mdx
@@ -19,7 +19,7 @@
 - [Backend Freedom](./core-concepts/backend-freedom.md) — How adapters let the same JSX run on any server
 - [MPA-style Development](./core-concepts/mpa-style.md) — Server-rendering by default, JS only where marked
 - [Fine-grained Reactivity](./core-concepts/reactivity.md) — Signals, effects, memos — no virtual DOM needed
-- [AI-native Development](./core-concepts/ai-native.md) — Testable IR, CLI discovery, Claude Code skill, AI-assisted workflows
+- [AI-native Development](./core-concepts/ai-native.md) — Testable IR, CLI discovery, agent skill (Claude Code / Codex), AI-assisted workflows
 - [How It Works](./core-concepts/how-it-works.mdx) — Two-phase compilation, hydration markers, clean overrides
 
 ### 4. [Reactivity](./reactivity.md)

--- a/docs/core/core-concepts/ai-native.md
+++ b/docs/core/core-concepts/ai-native.md
@@ -66,16 +66,24 @@ When nothing in the registry fits, `bf gen component <name> <comps...>` scaffold
 
 **Visual preview**: hosted previews live at [ui.barefootjs.dev/components/&lt;name&gt;](https://ui.barefootjs.dev). Standalone `bf preview` for npm-installed projects is tracked in [#885](https://github.com/piconic-ai/barefootjs/issues/885).
 
-## Claude Code Skill
+## Agent Skill
 
-BarefootJS publishes a [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skill that gives Claude deep knowledge of the compiler, IR, CLI, and component system. Install it and Claude can build, test, and debug BarefootJS projects autonomously:
+BarefootJS publishes an agent skill that gives AI deep knowledge of the compiler, IR, CLI, and component system. Install it and the agent can build, test, and debug BarefootJS projects autonomously.
+
+**Claude Code:**
 
 ```sh
 /plugin marketplace add piconic-ai/barefootjs
 /plugin install barefootjs@barefootjs
 ```
 
-With the skill active, Claude understands `bf` CLI commands, IR test patterns, signal graphs, adapter output, and error codes — no manual prompting needed.
+**Codex:**
+
+```
+install the barefootjs skill from piconic-ai/barefootjs
+```
+
+With the skill active, the agent understands `bf` CLI commands, IR test patterns, signal graphs, adapter output, and error codes — no manual prompting needed.
 
 ## Agent Loop
 

--- a/docs/core/quick-start.mdx
+++ b/docs/core/quick-start.mdx
@@ -147,7 +147,7 @@ This runs `bf build`, generates the final `uno.css`, and calls `wrangler deploy`
 
 ## Next steps
 
-- **[Claude Code Skill](./core-concepts/ai-native.md#claude-code-skill)** — Install the BarefootJS skill for Claude Code (`/plugin marketplace add piconic-ai/barefootjs`) and let Claude build components, write IR tests, and debug signals for you.
+- **[Agent Skill](./core-concepts/ai-native.md#agent-skill)** — Install the BarefootJS skill for Claude Code or Codex and let the agent build components, write IR tests, and debug signals for you.
 - **[Core Concepts](./core-concepts.md)** — the four design principles behind BarefootJS: backend freedom, MPA-style rendering, fine-grained reactivity, and AI-native workflows.
 - **[`createSignal`](./reactivity/create-signal.md)** and **[`createMemo`](./reactivity/create-memo.md)** — the reactivity primitives you just used.
 - **[Client Directive](./rendering/client-directive.md)** — exactly what `"use client"` does and when to reach for it.

--- a/plugins/barefootjs/skills/barefootjs/SKILL.md
+++ b/plugins/barefootjs/skills/barefootjs/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: barefootjs
 description: "Build, inspect, and debug UI components using @barefootjs/cli. Use when: creating/editing/reviewing components, investigating signal dependencies, debugging reactive updates, scaffolding new components, or looking up component APIs."
+metadata:
+  short-description: "BarefootJS component development with bf CLI"
 ---
 # Component Development Skill
 

--- a/plugins/barefootjs/skills/barefootjs/agents/openai.yaml
+++ b/plugins/barefootjs/skills/barefootjs/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "BarefootJS"
+  short_description: "Build, inspect, and debug UI components with the bf CLI"


### PR DESCRIPTION
## Summary

- **Codex skill discovery**: Symlink `.claude/skills/barefootjs/SKILL.md` → `plugins/` path. Codex finds it via the existing `.agents` → `.claude` symlink
- **Codex UI metadata**: Add `agents/openai.yaml` with `display_name` and `short_description`
- **Shared frontmatter**: Add `metadata.short-description` to SKILL.md (used by Codex, ignored by Claude Code)
- **Docs updated**: README, AI-native docs, Quick Start, and TOC now show both Claude Code and Codex install methods

The SKILL.md content is shared (single source of truth via symlink), not duplicated.

## Test plan

- [ ] Verify the symlink resolves correctly: `.agents/skills/barefootjs/SKILL.md` → `.claude/skills/barefootjs/SKILL.md` → `plugins/barefootjs/skills/barefootjs/SKILL.md`
- [ ] Verify Claude Code skill still works: `/plugin marketplace add piconic-ai/barefootjs`
- [ ] Verify README renders both install methods correctly on GitHub

https://claude.ai/code/session_01JBqEyFYbivjpV83GaTwGFv

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBqEyFYbivjpV83GaTwGFv)_