### PR TITLE
docs: clarify Context API constraints, add shared state guide

### DIFF
--- a/docs/core/README.mdx
+++ b/docs/core/README.mdx
@@ -31,6 +31,7 @@
 - [`onCleanup`](./reactivity/on-cleanup.md) — Register cleanup for effects and lifecycle
 - [`untrack`](./reactivity/untrack.md) — Read signals without tracking dependencies
 - [Props Reactivity](./reactivity/props-reactivity.md) — Gotchas with destructuring
+- [Shared State Patterns](./reactivity/shared-state.md) — Cross-file state sharing: consolidation, custom events, server props
 
 ### 5. [Templates & Rendering](./rendering.md)
 

--- a/docs/core/components/context-api.md
+++ b/docs/core/components/context-api.md
@@ -234,3 +234,92 @@ const theme = useContext(ThemeContext)
 ```
 
 Use for optional contexts with a sensible fallback.
+
+
+## Where It Works
+
+`useContext` is a **browser-only API**. It runs during hydration, not on the server. Valid call sites:
+
+| Location | Works? | Notes |
+|----------|--------|-------|
+| Inside `handleMount` (ref callback) | Yes | Most common pattern — recommended |
+| Inside `onMount` | Yes | |
+| Inside `createEffect` | Yes | |
+| Component body level | Yes | Only in `"use client"` components — executes during client initialization |
+| Module scope | No | No component context available |
+| Server component body | No | SSR error — `useContext` is not available on the server |
+
+The ref callback pattern (`handleMount`) is the **recommended convention** because it naturally places context access in the hydration phase and co-locates it with DOM setup. Body-level calls work but can't drive JSX expressions directly — use them when you need the context value in `createMemo` or `createEffect`.
+
+
+## Compilation Unit Scope
+
+Context is scoped to a **single compilation unit** — one `.tsx` file that compiles into one `.client.js` bundle.
+
+This means:
+
+- `createContext()` and all its consumers **must live in the same file**
+- Each `.client.js` bundle gets its own `createContext()` call, producing a unique `Symbol` id
+- If you import a context from another file, the consumer's bundle creates a *different* context object — `useContext` will never find the provider's value
+
+This is why compound components (Accordion, Dialog, Select, Tabs) define all sub-components in a single file:
+
+```tsx
+// accordion/index.tsx — all in one file
+"use client"
+
+const AccordionContext = createContext<AccordionContextValue>()
+
+function Accordion(props) { /* provides context */ }
+function AccordionTrigger(props) { /* consumes context */ }
+function AccordionContent(props) { /* consumes context */ }
+
+export { Accordion, AccordionTrigger, AccordionContent }
+```
+
+For sharing reactive state across components in **separate files**, see [Shared State Patterns](../reactivity/shared-state.md).
+
+
+## Common Mistakes
+
+### Body-level `useContext` in a server component
+
+```tsx
+// ❌ Missing "use client" — function body runs during SSR
+export function Player(props: PlayerProps) {
+  const ctx = useContext(MyContext)  // SSR error: useContext is browser-only
+  // ...
+}
+```
+
+Fix: add `"use client"` as the first line.
+
+### Cross-file context import
+
+```tsx
+// ❌ context.tsx
+"use client"
+export const PlaybackContext = createContext<PlaybackValue>()
+export const usePlayback = () => useContext(PlaybackContext)
+
+// ❌ player.tsx — different compilation unit
+"use client"
+import { usePlayback } from './context'
+// The compiler inlines a NEW createContext() call in player.client.js
+// → different Symbol id → useContext returns undefined
+```
+
+Fix: put the provider and all consumers in the **same file**, or use [custom events / module-level signals](../reactivity/shared-state.md) for cross-file communication.
+
+### Cross-file `src/` utility with `useContext`
+
+```tsx
+// ❌ src/playback.ts — utility file
+import { createContext, useContext } from '@barefootjs/client'
+const PlaybackContext = createContext()
+export const usePlayback = () => useContext(PlaybackContext)
+```
+
+When the compiler inlines `src/` utilities into each component bundle, each bundle gets its own `createContext()` call — producing separate context objects with different identities. `useContext` in one bundle can never find the value provided by another.
+
+Fix: same as above — keep context within a single file, or use a different state-sharing pattern.

--- a/docs/core/components/context-api.md
+++ b/docs/core/components/context-api.md
@@ -284,7 +284,7 @@ For sharing reactive state across components in **separate files**, see [Shared 
 
 ### Body-level `useContext` in a server component
 
-```tsx
+```ts
 // ❌ Missing "use client" — function body runs during SSR
 export function Player(props: PlayerProps) {
   const ctx = useContext(MyContext)  // SSR error: useContext is browser-only
@@ -296,7 +296,7 @@ Fix: add `"use client"` as the first line.
 
 ### Cross-file context import
 
-```tsx
+```ts
 // ❌ context.tsx
 "use client"
 export const PlaybackContext = createContext<PlaybackValue>()
@@ -313,7 +313,7 @@ Fix: put the provider and all consumers in the **same file**, or use [custom eve
 
 ### Cross-file `src/` utility with `useContext`
 
-```tsx
+```ts
 // ❌ src/playback.ts — utility file
 import { createContext, useContext } from '@barefootjs/client'
 const PlaybackContext = createContext()

--- a/docs/core/components/context-api.md
+++ b/docs/core/components/context-api.md
@@ -236,38 +236,8 @@ const theme = useContext(ThemeContext)
 Use for optional contexts with a sensible fallback.
 
 
-## Common Mistakes
+## Cross-File Context Does Not Work
 
-### Missing `"use client"`
+`createContext()` and all components that use it must be in the **same file**. Importing a context from another file does not work — the compiler does not currently support cross-file context sharing.
 
-`useContext` requires `"use client"` — without it, the compiler does not rewrite the import to the runtime implementation, and the SSR shim throws:
-
-```ts
-// ❌ Missing "use client" — the compiler doesn't rewrite the import
-export function Player(props: PlayerProps) {
-  const ctx = useContext(MyContext)  // throws: "useContext() is a browser-only API"
-  // ...
-}
-```
-
-Fix: add `"use client"` as the first line.
-
-### Cross-file context
-
-Context providers and consumers must be in the **same file**. Each `.client.js` bundle gets its own `createContext()` call, producing a different `Symbol` id — so a consumer in one bundle can never find a provider from another:
-
-```ts
-// ❌ context.tsx — a separate compilation unit
-"use client"
-export const PlaybackContext = createContext<PlaybackValue>()
-export const usePlayback = () => useContext(PlaybackContext)
-
-// ❌ player.tsx — different bundle, different Symbol id
-"use client"
-import { usePlayback } from './context'
-// useContext returns undefined — the context ids don't match
-```
-
-The same problem applies to `src/` utilities that call `createContext` — the compiler inlines them into each bundle, creating separate context objects.
-
-Fix: keep context within a single file (this is why Accordion, Dialog, Select define all sub-components together), or use [custom events](../reactivity/shared-state.md) for cross-file communication.
+This is why compound components (Accordion, Dialog, Select, Tabs) define all sub-components in a single file. For sharing state across components in separate files, see [Shared State Patterns](../reactivity/shared-state.md).

--- a/docs/core/components/context-api.md
+++ b/docs/core/components/context-api.md
@@ -309,7 +309,7 @@ import { usePlayback } from './context'
 // → different Symbol id → useContext returns undefined
 ```
 
-Fix: put the provider and all consumers in the **same file**, or use [custom events / module-level signals](../reactivity/shared-state.md) for cross-file communication.
+Fix: put the provider and all consumers in the **same file**, or use [custom events](../reactivity/shared-state.md) for cross-file communication.
 
 ### Cross-file `src/` utility with `useContext`
 

--- a/docs/core/components/context-api.md
+++ b/docs/core/components/context-api.md
@@ -236,90 +236,38 @@ const theme = useContext(ThemeContext)
 Use for optional contexts with a sensible fallback.
 
 
-## Where It Works
-
-`useContext` is a **browser-only API**. It runs during hydration, not on the server. Valid call sites:
-
-| Location | Works? | Notes |
-|----------|--------|-------|
-| Inside `handleMount` (ref callback) | Yes | Most common pattern — recommended |
-| Inside `onMount` | Yes | |
-| Inside `createEffect` | Yes | |
-| Component body level | Yes | Only in `"use client"` components — executes during client initialization |
-| Module scope | No | No component context available |
-| Server component body | No | SSR error — `useContext` is not available on the server |
-
-The ref callback pattern (`handleMount`) is the **recommended convention** because it naturally places context access in the hydration phase and co-locates it with DOM setup. Body-level calls work but can't drive JSX expressions directly — use them when you need the context value in `createMemo` or `createEffect`.
-
-
-## Compilation Unit Scope
-
-Context is scoped to a **single compilation unit** — one `.tsx` file that compiles into one `.client.js` bundle.
-
-This means:
-
-- `createContext()` and all its consumers **must live in the same file**
-- Each `.client.js` bundle gets its own `createContext()` call, producing a unique `Symbol` id
-- If you import a context from another file, the consumer's bundle creates a *different* context object — `useContext` will never find the provider's value
-
-This is why compound components (Accordion, Dialog, Select, Tabs) define all sub-components in a single file:
-
-```tsx
-// accordion/index.tsx — all in one file
-"use client"
-
-const AccordionContext = createContext<AccordionContextValue>()
-
-function Accordion(props) { /* provides context */ }
-function AccordionTrigger(props) { /* consumes context */ }
-function AccordionContent(props) { /* consumes context */ }
-
-export { Accordion, AccordionTrigger, AccordionContent }
-```
-
-For sharing reactive state across components in **separate files**, see [Shared State Patterns](../reactivity/shared-state.md).
-
-
 ## Common Mistakes
 
-### Body-level `useContext` in a server component
+### Missing `"use client"`
+
+`useContext` requires `"use client"` — without it, the compiler does not rewrite the import to the runtime implementation, and the SSR shim throws:
 
 ```ts
-// ❌ Missing "use client" — function body runs during SSR
+// ❌ Missing "use client" — the compiler doesn't rewrite the import
 export function Player(props: PlayerProps) {
-  const ctx = useContext(MyContext)  // SSR error: useContext is browser-only
+  const ctx = useContext(MyContext)  // throws: "useContext() is a browser-only API"
   // ...
 }
 ```
 
 Fix: add `"use client"` as the first line.
 
-### Cross-file context import
+### Cross-file context
+
+Context providers and consumers must be in the **same file**. Each `.client.js` bundle gets its own `createContext()` call, producing a different `Symbol` id — so a consumer in one bundle can never find a provider from another:
 
 ```ts
-// ❌ context.tsx
+// ❌ context.tsx — a separate compilation unit
 "use client"
 export const PlaybackContext = createContext<PlaybackValue>()
 export const usePlayback = () => useContext(PlaybackContext)
 
-// ❌ player.tsx — different compilation unit
+// ❌ player.tsx — different bundle, different Symbol id
 "use client"
 import { usePlayback } from './context'
-// The compiler inlines a NEW createContext() call in player.client.js
-// → different Symbol id → useContext returns undefined
+// useContext returns undefined — the context ids don't match
 ```
 
-Fix: put the provider and all consumers in the **same file**, or use [custom events](../reactivity/shared-state.md) for cross-file communication.
+The same problem applies to `src/` utilities that call `createContext` — the compiler inlines them into each bundle, creating separate context objects.
 
-### Cross-file `src/` utility with `useContext`
-
-```ts
-// ❌ src/playback.ts — utility file
-import { createContext, useContext } from '@barefootjs/client'
-const PlaybackContext = createContext()
-export const usePlayback = () => useContext(PlaybackContext)
-```
-
-When the compiler inlines `src/` utilities into each component bundle, each bundle gets its own `createContext()` call — producing separate context objects with different identities. `useContext` in one bundle can never find the value provided by another.
-
-Fix: same as above — keep context within a single file, or use a different state-sharing pattern.
+Fix: keep context within a single file (this is why Accordion, Dialog, Select define all sub-components together), or use [custom events](../reactivity/shared-state.md) for cross-file communication.

--- a/docs/core/llms.txt
+++ b/docs/core/llms.txt
@@ -18,6 +18,7 @@
 - [onCleanup](https://barefootjs.dev/docs/reactivity/on-cleanup.md): Registers a cleanup function that runs when the owning effect re-runs or the component is destroyed.
 - [onMount](https://barefootjs.dev/docs/reactivity/on-mount.md): Runs a callback once when the component initializes, without tracking signal dependencies.
 - [Props Reactivity](https://barefootjs.dev/docs/reactivity/props-reactivity.md): How prop access patterns determine whether reactive updates propagate in BarefootJS components.
+- [Shared State Patterns](https://barefootjs.dev/docs/reactivity/shared-state.md): Patterns for sharing reactive state between components in separate files, and when to use each.
 - [untrack](https://barefootjs.dev/docs/reactivity/untrack.md): Executes a function without tracking signal dependencies in the current reactive context.
 
 ## Rendering

--- a/docs/core/reactivity.md
+++ b/docs/core/reactivity.md
@@ -26,3 +26,4 @@ import { createSignal, createEffect, createMemo, onMount, onCleanup, untrack } f
 ## Guides
 
 - [Props Reactivity](./reactivity/props-reactivity.md) — How props stay reactive, and when destructuring breaks it
+- [Shared State Patterns](./reactivity/shared-state.md) — Sharing state across components in separate files

--- a/docs/core/reactivity/shared-state.md
+++ b/docs/core/reactivity/shared-state.md
@@ -28,7 +28,6 @@ Player.client.js            →  createContext()  →  Symbol(#2)
 The simplest solution. If components are tightly coupled, put them in the same file:
 
 ```tsx
-// components/Playback.tsx
 "use client"
 import { createContext, useContext, createSignal, createEffect } from '@barefootjs/client'
 
@@ -91,8 +90,9 @@ export function TimelineBar(props: { duration: number }) {
 
 Use the browser's native event system. One component dispatches events, others listen. No shared module state needed.
 
+Player (`components/Player.tsx`):
+
 ```tsx
-// components/Player.tsx
 "use client"
 import { createSignal, createEffect, onCleanup } from '@barefootjs/client'
 
@@ -119,8 +119,9 @@ export function Player() {
 }
 ```
 
+TimelineBar (`components/TimelineBar.tsx`):
+
 ```tsx
-// components/TimelineBar.tsx
 "use client"
 import { onCleanup } from '@barefootjs/client'
 
@@ -161,8 +162,7 @@ export function TimelineBar(props: { duration: number }) {
 
 Define event types in a shared `src/` file to get type safety without sharing runtime state:
 
-```tsx
-// src/playback-events.ts
+```ts
 export interface PlaybackTimeUpdateDetail {
   elapsedMs: number
 }
@@ -187,8 +187,7 @@ export function dispatchSeek(el: Element, detail: PlaybackSeekDetail) {
 
 For state that originates on the server (database, session, URL params), pass it as props from the server route. No client-side sharing needed:
 
-```tsx
-// server.tsx
+```ts
 import { Player } from '@/components/Player'
 import { TimelineBar } from '@/components/TimelineBar'
 

--- a/docs/core/reactivity/shared-state.md
+++ b/docs/core/reactivity/shared-state.md
@@ -34,6 +34,7 @@ import { createContext, useContext, createSignal, createEffect } from '@barefoot
 
 interface PlaybackContextValue {
   elapsedMs: () => number
+  playing: () => boolean
   seek: (ms: number) => void
   toggle: () => void
 }
@@ -48,7 +49,7 @@ export function PlaybackProvider(props: { children?: unknown }) {
   const toggle = () => setPlaying(p => !p)
 
   return (
-    <PlaybackContext.Provider value={{ elapsedMs, seek, toggle }}>
+    <PlaybackContext.Provider value={{ elapsedMs, playing, seek, toggle }}>
       {props.children}
     </PlaybackContext.Provider>
   )
@@ -93,7 +94,7 @@ Use the browser's native event system. One component dispatches events, others l
 ```tsx
 // components/Player.tsx
 "use client"
-import { createSignal, createEffect, onMount, onCleanup } from '@barefootjs/client'
+import { createSignal, createEffect, onCleanup } from '@barefootjs/client'
 
 export function Player() {
   const [elapsedMs, setElapsedMs] = createSignal(0)
@@ -106,9 +107,12 @@ export function Player() {
       }))
     })
 
-    el.addEventListener('playback:seek', ((e: CustomEvent) => {
+    const onSeek = ((e: CustomEvent) => {
       setElapsedMs(e.detail.ms)
-    }) as EventListener)
+    }) as EventListener
+
+    document.addEventListener('playback:seek', onSeek)
+    onCleanup(() => document.removeEventListener('playback:seek', onSeek))
   }
 
   return <div ref={handleMount} />
@@ -118,7 +122,7 @@ export function Player() {
 ```tsx
 // components/TimelineBar.tsx
 "use client"
-import { onMount, onCleanup } from '@barefootjs/client'
+import { onCleanup } from '@barefootjs/client'
 
 export function TimelineBar(props: { duration: number }) {
   const handleMount = (el: HTMLElement) => {

--- a/docs/core/reactivity/shared-state.md
+++ b/docs/core/reactivity/shared-state.md
@@ -1,0 +1,230 @@
+---
+title: Shared State Patterns
+description: Patterns for sharing reactive state between components in separate files, and when to use each.
+---
+
+# Shared State Patterns
+
+The [Context API](../components/context-api.md) shares state between components in the **same file** (compound components like Accordion, Dialog, Tabs). But the compilation model — one `.tsx` file produces one `.client.js` bundle — means context **cannot cross file boundaries**.
+
+This guide covers patterns for sharing reactive state between components in **separate files**.
+
+
+## Why Context Doesn't Work Across Files
+
+Each `.client.js` bundle is independent. When the compiler processes two files that both reference the same `createContext()`, each bundle gets its own call — producing a unique `Symbol` id. The provider's context and the consumer's context are different objects:
+
+```
+PlaybackProvider.client.js  →  createContext()  →  Symbol(#1)
+Player.client.js            →  createContext()  →  Symbol(#2)
+                                                    ↑ different identity
+```
+
+`useContext` in Player walks the DOM looking for `Symbol(#2)`, but PlaybackProvider set `Symbol(#1)`. No match — the value is never found.
+
+
+## Pattern 1: Consolidate Into One File
+
+The simplest solution. If components are tightly coupled, put them in the same file:
+
+```tsx
+// components/Playback.tsx
+"use client"
+import { createContext, useContext, createSignal, createEffect } from '@barefootjs/client'
+
+interface PlaybackContextValue {
+  elapsedMs: () => number
+  seek: (ms: number) => void
+  toggle: () => void
+}
+
+const PlaybackContext = createContext<PlaybackContextValue>()
+
+export function PlaybackProvider(props: { children?: unknown }) {
+  const [elapsedMs, setElapsedMs] = createSignal(0)
+  const [playing, setPlaying] = createSignal(false)
+
+  const seek = (ms: number) => setElapsedMs(ms)
+  const toggle = () => setPlaying(p => !p)
+
+  return (
+    <PlaybackContext.Provider value={{ elapsedMs, seek, toggle }}>
+      {props.children}
+    </PlaybackContext.Provider>
+  )
+}
+
+export function Player(props: { children?: unknown }) {
+  const handleMount = (el: HTMLElement) => {
+    const ctx = useContext(PlaybackContext)
+    createEffect(() => {
+      el.textContent = `${Math.floor(ctx.elapsedMs() / 1000)}s`
+    })
+  }
+  return <div ref={handleMount}>{props.children}</div>
+}
+
+export function TimelineBar(props: { duration: number }) {
+  const handleMount = (el: HTMLElement) => {
+    const ctx = useContext(PlaybackContext)
+    el.addEventListener('click', (e) => {
+      const rect = el.getBoundingClientRect()
+      const ratio = (e.clientX - rect.left) / rect.width
+      ctx.seek(ratio * props.duration)
+    })
+  }
+  return <div ref={handleMount} className="timeline" />
+}
+```
+
+**When to use:** Components share a tight contract and are always used together (like Select + SelectTrigger + SelectContent).
+
+| Pros | Cons |
+|------|------|
+| Full reactivity via signals | All components in one file |
+| Type-safe | File grows with component count |
+| Works with Context API | Not suitable for loosely coupled components |
+
+
+## Pattern 2: Custom DOM Events
+
+Use the browser's native event system. One component dispatches events, others listen. No shared module state needed.
+
+```tsx
+// components/Player.tsx
+"use client"
+import { createSignal, createEffect, onMount, onCleanup } from '@barefootjs/client'
+
+export function Player() {
+  const [elapsedMs, setElapsedMs] = createSignal(0)
+
+  const handleMount = (el: HTMLElement) => {
+    createEffect(() => {
+      el.dispatchEvent(new CustomEvent('playback:timeupdate', {
+        bubbles: true,
+        detail: { elapsedMs: elapsedMs() },
+      }))
+    })
+
+    el.addEventListener('playback:seek', ((e: CustomEvent) => {
+      setElapsedMs(e.detail.ms)
+    }) as EventListener)
+  }
+
+  return <div ref={handleMount} />
+}
+```
+
+```tsx
+// components/TimelineBar.tsx
+"use client"
+import { onMount, onCleanup } from '@barefootjs/client'
+
+export function TimelineBar(props: { duration: number }) {
+  const handleMount = (el: HTMLElement) => {
+    const onTimeUpdate = ((e: CustomEvent) => {
+      const ratio = e.detail.elapsedMs / props.duration
+      el.style.setProperty('--progress', String(ratio))
+    }) as EventListener
+
+    document.addEventListener('playback:timeupdate', onTimeUpdate)
+    onCleanup(() => document.removeEventListener('playback:timeupdate', onTimeUpdate))
+
+    el.addEventListener('click', (e) => {
+      const rect = el.getBoundingClientRect()
+      const ratio = (e.clientX - rect.left) / rect.width
+      el.dispatchEvent(new CustomEvent('playback:seek', {
+        bubbles: true,
+        detail: { ms: ratio * props.duration },
+      }))
+    })
+  }
+
+  return <div ref={handleMount} className="timeline" />
+}
+```
+
+**When to use:** Components are in separate files and communicate through a shared parent in the DOM.
+
+| Pros | Cons |
+|------|------|
+| Works across any file boundary | Not reactive — imperative dispatch/listen |
+| No shared imports needed | No type safety on event payloads (use a shared type file to mitigate) |
+| Familiar browser API | Requires manual cleanup |
+| SSR-safe (listeners only run on client) | Event naming conventions needed |
+
+### Type-safe event helpers
+
+Define event types in a shared `src/` file to get type safety without sharing runtime state:
+
+```tsx
+// src/playback-events.ts
+export interface PlaybackTimeUpdateDetail {
+  elapsedMs: number
+}
+
+export interface PlaybackSeekDetail {
+  ms: number
+}
+
+export function dispatchTimeUpdate(el: Element, detail: PlaybackTimeUpdateDetail) {
+  el.dispatchEvent(new CustomEvent('playback:timeupdate', { bubbles: true, detail }))
+}
+
+export function dispatchSeek(el: Element, detail: PlaybackSeekDetail) {
+  el.dispatchEvent(new CustomEvent('playback:seek', { bubbles: true, detail }))
+}
+```
+
+`src/` utility files are inlined at compile time. Type definitions and `CustomEvent` constructors don't carry mutable state, so inlining is safe — each bundle gets its own copy of the helper functions, but they produce identical events.
+
+
+## Pattern 3: Server-Mediated Props
+
+For state that originates on the server (database, session, URL params), pass it as props from the server route. No client-side sharing needed:
+
+```tsx
+// server.tsx
+import { Player } from '@/components/Player'
+import { TimelineBar } from '@/components/TimelineBar'
+
+app.get('/player/:id', async (c) => {
+  const track = await db.getTrack(c.req.param('id'))
+  return c.render(
+    <main>
+      <Player trackId={track.id} initialPosition={track.lastPosition} />
+      <TimelineBar duration={track.durationMs} />
+    </main>
+  )
+})
+```
+
+Each component hydrates independently with its own signals. User interactions that need to cross components use Pattern 2 (custom events).
+
+**When to use:** Initial state comes from the server; components only need to sync on user-driven actions.
+
+| Pros | Cons |
+|------|------|
+| SSR-friendly — state is in HTML | Real-time sync still needs custom events |
+| No shared client state | Server round-trip for state changes |
+| Each component is independently testable | |
+
+
+## Choosing a Pattern
+
+```
+Is all state server-derived?
+  └─ Yes → Pattern 3 (Server-Mediated Props)
+  └─ No
+      ├─ Are components tightly coupled (always used together)?
+      │   └─ Yes → Pattern 1 (Consolidate Into One File)
+      └─ No → Pattern 2 (Custom DOM Events)
+```
+
+| | Context (same file) | Consolidate | Custom Events | Server Props |
+|---|---|---|---|---|
+| Cross-file | No | No (one file) | Yes | Yes |
+| Reactive | Yes | Yes | No | No (initial only) |
+| Type-safe | Yes | Yes | With helpers | Yes |
+| SSR-safe | Yes | Yes | Yes | Yes |
+| Testable | IR test | IR test | E2E | IR test + E2E |

--- a/docs/core/reactivity/shared-state.md
+++ b/docs/core/reactivity/shared-state.md
@@ -187,7 +187,7 @@ export function dispatchSeek(el: Element, detail: PlaybackSeekDetail) {
 
 For state that originates on the server (database, session, URL params), pass it as props from the server route. No client-side sharing needed:
 
-```ts
+```tsx
 import { Player } from '@/components/Player'
 import { TimelineBar } from '@/components/TimelineBar'
 

--- a/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
+++ b/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
@@ -3181,24 +3181,6 @@ hydrate('StatementExample', { init: initStatementExample, template: (_p) => \`<d
 export function StatementExample(_p, __bfKey) { return createComponent('StatementExample', _p, __bfKey) }"
 `;
 
-exports[`docs/core/components/context-api.md doc-examples L271 — (no label) 1`] = `
-"import { createComponent, hydrate } from '@barefootjs/client/runtime'
-
-function initStatementExample() {}
-
-hydrate('StatementExample', { init: initStatementExample, template: (_p) => \`<div></div>\` })
-export function StatementExample(_p, __bfKey) { return createComponent('StatementExample', _p, __bfKey) }"
-`;
-
-exports[`docs/core/components/context-api.md doc-examples L273 — (no label) 1`] = `
-"import { createComponent, hydrate } from '@barefootjs/client/runtime'
-
-function initStatementExample() {}
-
-hydrate('StatementExample', { init: initStatementExample, template: (_p) => \`<div></div>\` })
-export function StatementExample(_p, __bfKey) { return createComponent('StatementExample', _p, __bfKey) }"
-`;
-
 exports[`docs/core/components/portals.md doc-examples L53 — (no label) 1`] = `
 "import { $, $t, createComponent, createEffect, createPortal, createSignal, hydrate, isSSRPortal } from '@barefootjs/client/runtime'
 

--- a/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
+++ b/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
@@ -3181,6 +3181,24 @@ hydrate('StatementExample', { init: initStatementExample, template: (_p) => \`<d
 export function StatementExample(_p, __bfKey) { return createComponent('StatementExample', _p, __bfKey) }"
 `;
 
+exports[`docs/core/components/context-api.md doc-examples L271 — (no label) 1`] = `
+"import { createComponent, hydrate } from '@barefootjs/client/runtime'
+
+function initStatementExample() {}
+
+hydrate('StatementExample', { init: initStatementExample, template: (_p) => \`<div></div>\` })
+export function StatementExample(_p, __bfKey) { return createComponent('StatementExample', _p, __bfKey) }"
+`;
+
+exports[`docs/core/components/context-api.md doc-examples L273 — (no label) 1`] = `
+"import { createComponent, hydrate } from '@barefootjs/client/runtime'
+
+function initStatementExample() {}
+
+hydrate('StatementExample', { init: initStatementExample, template: (_p) => \`<div></div>\` })
+export function StatementExample(_p, __bfKey) { return createComponent('StatementExample', _p, __bfKey) }"
+`;
+
 exports[`docs/core/components/portals.md doc-examples L53 — (no label) 1`] = `
 "import { $, $t, createComponent, createEffect, createPortal, createSignal, hydrate, isSSRPortal } from '@barefootjs/client/runtime'
 

--- a/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
+++ b/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
@@ -4798,6 +4798,141 @@ hydrate('StatementExample', { init: initStatementExample, template: (_p) => \`<d
 export function StatementExample(_p, __bfKey) { return createComponent('StatementExample', _p, __bfKey) }"
 `;
 
+exports[`docs/core/reactivity/shared-state.md doc-examples L31 — (no label) 1`] = `
+"import { $, createComponent, createContext, createEffect, createSignal, hydrate, provideContext, useContext } from '@barefootjs/client/runtime'
+
+var PlaybackContext = PlaybackContext ?? createContext()
+
+export function initPlaybackProvider(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const [elapsedMs, setElapsedMs] = createSignal(0)
+  const [playing, setPlaying] = createSignal(false)
+  const seek = (ms) => setElapsedMs(ms)
+  const toggle = () => setPlaying(p => !p)
+
+
+  // Provide context for child components
+  provideContext(PlaybackContext, { elapsedMs, playing, seek, toggle })
+}
+
+hydrate('PlaybackProvider', { init: initPlaybackProvider, template: (_p) => \`<div style="display:contents">\${_p.children}</div>\` })
+export function PlaybackProvider(_p, __bfKey) { return createComponent('PlaybackProvider', _p, __bfKey) }
+var PlaybackContext = PlaybackContext ?? createContext()
+
+export function initPlayer(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const handleMount = (el) => {
+    const ctx = useContext(PlaybackContext)
+    createEffect(() => {
+      el.textContent = \`\${Math.floor(ctx.elapsedMs() / 1000)}s\`
+    })
+  }
+
+  const [_s0] = $(__scope, 's0')
+
+  if (_s0) (handleMount)(_s0)
+}
+
+hydrate('Player', { init: initPlayer, template: (_p) => \`<div bf="s0">\${_p.children}</div>\` })
+export function Player(_p, __bfKey) { return createComponent('Player', _p, __bfKey) }
+var PlaybackContext = PlaybackContext ?? createContext()
+
+export function initTimelineBar(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const handleMount = (el) => {
+    const ctx = useContext(PlaybackContext)
+    el.addEventListener('click', (e) => {
+      const rect = el.getBoundingClientRect()
+      const ratio = (e.clientX - rect.left) / rect.width
+      ctx.seek(ratio * _p.duration)
+    })
+  }
+
+  const [_s0] = $(__scope, 's0')
+
+  if (_s0) (handleMount)(_s0)
+}
+
+hydrate('TimelineBar', { init: initTimelineBar, template: (_p) => \`<div class="timeline" bf="s0"></div>\` })
+export function TimelineBar(_p, __bfKey) { return createComponent('TimelineBar', _p, __bfKey) }"
+`;
+
+exports[`docs/core/reactivity/shared-state.md doc-examples L96 — (no label) 1`] = `
+"import { $, createComponent, createEffect, createSignal, hydrate, onCleanup } from '@barefootjs/client/runtime'
+
+
+export function initPlayer(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const [elapsedMs, setElapsedMs] = createSignal(0)
+  const handleMount = (el) => {
+    createEffect(() => {
+      el.dispatchEvent(new CustomEvent('playback:timeupdate', {
+        bubbles: true,
+        detail: { elapsedMs: elapsedMs() },
+      }))
+    })
+
+    const onSeek = ((e) => {
+      setElapsedMs(e.detail.ms)
+    })
+
+    document.addEventListener('playback:seek', onSeek)
+    onCleanup(() => document.removeEventListener('playback:seek', onSeek))
+  }
+
+  const [_s0] = $(__scope, 's0')
+
+  if (_s0) (handleMount)(_s0)
+}
+
+hydrate('Player', { init: initPlayer, template: (_p) => \`<div bf="s0"></div>\` })
+export function Player(_p, __bfKey) { return createComponent('Player', _p, __bfKey) }"
+`;
+
+exports[`docs/core/reactivity/shared-state.md doc-examples L125 — (no label) 1`] = `
+"import { $, createComponent, hydrate, onCleanup } from '@barefootjs/client/runtime'
+
+
+export function initTimelineBar(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const handleMount = (el) => {
+    const onTimeUpdate = ((e) => {
+      const ratio = e.detail.elapsedMs / _p.duration
+      el.style.setProperty('--progress', String(ratio))
+    })
+
+    document.addEventListener('playback:timeupdate', onTimeUpdate)
+    onCleanup(() => document.removeEventListener('playback:timeupdate', onTimeUpdate))
+
+    el.addEventListener('click', (e) => {
+      const rect = el.getBoundingClientRect()
+      const ratio = (e.clientX - rect.left) / rect.width
+      el.dispatchEvent(new CustomEvent('playback:seek', {
+        bubbles: true,
+        detail: { ms: ratio * _p.duration },
+      }))
+    })
+  }
+
+  const [_s0] = $(__scope, 's0')
+
+  if (_s0) (handleMount)(_s0)
+}
+
+hydrate('TimelineBar', { init: initTimelineBar, template: (_p) => \`<div class="timeline" bf="s0"></div>\` })
+export function TimelineBar(_p, __bfKey) { return createComponent('TimelineBar', _p, __bfKey) }"
+`;
+
 exports[`docs/core/introduction.mdx doc-examples L15 — (no label) 1`] = `
 "import { $, $t, createComponent, createEffect, createSignal, hydrate } from '@barefootjs/client/runtime'
 

--- a/packages/jsx/src/__tests__/boolean-attributes.test.ts
+++ b/packages/jsx/src/__tests__/boolean-attributes.test.ts
@@ -36,7 +36,7 @@ describe('boolean attributes', () => {
   })
 
   test('BOOLEAN_ATTRS contains all expected attributes', () => {
-    expect(BOOLEAN_ATTRS.size).toBe(14)
+    expect(BOOLEAN_ATTRS.size).toBe(15)
     expect(BOOLEAN_ATTRS.has('checked')).toBe(true)
     expect(BOOLEAN_ATTRS.has('disabled')).toBe(true)
   })

--- a/packages/jsx/src/__tests__/boolean-attributes.test.ts
+++ b/packages/jsx/src/__tests__/boolean-attributes.test.ts
@@ -39,6 +39,7 @@ describe('boolean attributes', () => {
     expect(BOOLEAN_ATTRS.size).toBe(15)
     expect(BOOLEAN_ATTRS.has('checked')).toBe(true)
     expect(BOOLEAN_ATTRS.has('disabled')).toBe(true)
+    expect(BOOLEAN_ATTRS.has('formnovalidate')).toBe(true)
   })
 
   test('compiles dynamic boolean attribute using DOM property', () => {

--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -314,7 +314,13 @@ const PAGES: PageSpec[] = [
   // tie each ❌ snippet to its parent `### BFxxx —` H3.
   { path: 'core/advanced/performance.md' },
   { path: 'core/reactivity.md' },
-  { path: 'core/reactivity/shared-state.md' },
+  {
+    path: 'core/reactivity/shared-state.md',
+    pageSkip: (body: string) => {
+      if (/\bapp\.get\b/.test(body)) return 'server route example (not a component)'
+      return undefined
+    },
+  },
   { path: 'core/introduction.mdx' },
 ]
 

--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -314,9 +314,7 @@ const PAGES: PageSpec[] = [
   // tie each ❌ snippet to its parent `### BFxxx —` H3.
   { path: 'core/advanced/performance.md' },
   { path: 'core/reactivity.md' },
-  // `core/reactivity/shared-state.md` excluded: its examples show
-  // cross-file patterns (separate components in separate files) that
-  // cannot compile as single-module units.
+  { path: 'core/reactivity/shared-state.md' },
   { path: 'core/introduction.mdx' },
 ]
 

--- a/packages/jsx/src/__tests__/doc-examples.test.ts
+++ b/packages/jsx/src/__tests__/doc-examples.test.ts
@@ -314,6 +314,9 @@ const PAGES: PageSpec[] = [
   // tie each ❌ snippet to its parent `### BFxxx —` H3.
   { path: 'core/advanced/performance.md' },
   { path: 'core/reactivity.md' },
+  // `core/reactivity/shared-state.md` excluded: its examples show
+  // cross-file patterns (separate components in separate files) that
+  // cannot compile as single-module units.
   { path: 'core/introduction.mdx' },
 ]
 

--- a/packages/jsx/src/__tests__/ir-provider.test.ts
+++ b/packages/jsx/src/__tests__/ir-provider.test.ts
@@ -403,3 +403,97 @@ describe('Context.Provider JSX', () => {
     expect(error?.severity).toBe('error')
   })
 })
+
+describe('Context API constraints (#1607)', () => {
+  test('useContext without "use client" triggers BF001', () => {
+    const source = `
+      import { createContext, useContext } from '@barefootjs/client'
+
+      const Ctx = createContext()
+
+      export function Consumer() {
+        const handleMount = (el: HTMLElement) => {
+          const ctx = useContext(Ctx)
+        }
+        return <div ref={handleMount} />
+      }
+    `
+
+    const result = compileJSX(source, 'Consumer.tsx', { adapter })
+    const bf001 = result.errors.find(e => e.code === ErrorCodes.MISSING_USE_CLIENT)
+    expect(bf001).toBeDefined()
+  })
+
+  test('useContext with "use client" compiles without errors', () => {
+    const source = `
+      'use client'
+      import { createContext, useContext } from '@barefootjs/client'
+
+      const Ctx = createContext()
+
+      export function Consumer() {
+        const handleMount = (el: HTMLElement) => {
+          const ctx = useContext(Ctx)
+        }
+        return <div ref={handleMount} />
+      }
+    `
+
+    const result = compileJSX(source, 'Consumer.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+  })
+
+  test('useContext import is rewritten to runtime path in client JS', () => {
+    const source = `
+      'use client'
+      import { createContext, useContext } from '@barefootjs/client'
+
+      const Ctx = createContext()
+
+      export function Consumer() {
+        const handleMount = (el: HTMLElement) => {
+          const ctx = useContext(Ctx)
+        }
+        return <div ref={handleMount} />
+      }
+    `
+
+    const result = compileJSX(source, 'Consumer.tsx', { adapter })
+    const clientJs = result.files.find(f => f.type === 'clientJs')!
+    expect(clientJs).toBeDefined()
+    expect(clientJs.content).toContain("from '@barefootjs/client/runtime'")
+    expect(clientJs.content).toContain('useContext')
+  })
+
+  test('same-file provider + consumer compiles with provideContext before useContext', () => {
+    const source = `
+      'use client'
+      import { createContext, useContext, createSignal } from '@barefootjs/client'
+
+      const ThemeContext = createContext('light')
+
+      export function ThemeProvider(props) {
+        return (
+          <ThemeContext.Provider value={props.theme}>
+            <ThemedButton />
+          </ThemeContext.Provider>
+        )
+      }
+
+      function ThemedButton() {
+        const handleMount = (el: HTMLButtonElement) => {
+          const theme = useContext(ThemeContext)
+          el.className = theme === 'dark' ? 'btn-dark' : 'btn-light'
+        }
+        return <button ref={handleMount}>click</button>
+      }
+    `
+
+    const result = compileJSX(source, 'Theme.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')!
+    expect(clientJs.content).toContain('provideContext(ThemeContext')
+    expect(clientJs.content).toContain('useContext(ThemeContext')
+  })
+})

--- a/packages/jsx/src/__tests__/ir-provider.test.ts
+++ b/packages/jsx/src/__tests__/ir-provider.test.ts
@@ -459,6 +459,7 @@ describe('Context API constraints (#1607)', () => {
     `
 
     const result = compileJSX(source, 'Consumer.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
     const clientJs = result.files.find(f => f.type === 'clientJs')!
     expect(clientJs).toBeDefined()
     expect(clientJs.content).toContain("from '@barefootjs/client/runtime'")
@@ -493,7 +494,10 @@ describe('Context API constraints (#1607)', () => {
     expect(result.errors).toHaveLength(0)
 
     const clientJs = result.files.find(f => f.type === 'clientJs')!
-    expect(clientJs.content).toContain('provideContext(ThemeContext')
-    expect(clientJs.content).toContain('useContext(ThemeContext')
+    const provideIdx = clientJs.content.indexOf('provideContext(ThemeContext')
+    const useIdx = clientJs.content.indexOf('useContext(ThemeContext')
+    expect(provideIdx).toBeGreaterThan(-1)
+    expect(useIdx).toBeGreaterThan(-1)
+    expect(provideIdx).toBeLessThan(useIdx)
   })
 })


### PR DESCRIPTION
## Summary

Closes #1607 and #1608.

### Context API guide (`docs/core/components/context-api.md`)

- Add "Cross-File Context Does Not Work" section — concise warning that `createContext()` and all consumers must be in the same file, with link to shared-state guide for alternatives

### Shared state guide (`docs/core/reactivity/shared-state.md`) — NEW

- **Pattern 1**: Consolidate into one file (full reactivity via Context API)
- **Pattern 2**: Custom DOM events (cross-file, with type-safe helpers)
- **Pattern 3**: Server-mediated props (SSR-friendly initial state)
- Decision flowchart and comparison table
- All 3 compilable tsx blocks are verified by doc-examples test

### Compiler tests (`packages/jsx/src/__tests__/ir-provider.test.ts`)

4 new tests for Context API constraints:
- `useContext` without `"use client"` triggers BF001
- `useContext` with `"use client"` compiles cleanly
- Import is rewritten to `@barefootjs/client/runtime`
- Same-file provider + consumer: `provideContext` appears before `useContext` (indexOf order assertion)

### Other

- Fix `BOOLEAN_ATTRS` size assertion (14→15) and add `has('formnovalidate')` check
- Add shared-state.md to doc-examples corpus with pageSkip for server route example
- Update TOC and reactivity index with links

## Test plan

- [x] `ir-provider.test.ts` — 16 tests pass (4 new)
- [x] `doc-examples.test.ts` — 235 tests pass, shared-state.md blocks compile-verified
- [x] `boolean-attributes.test.ts` — 8 tests pass
- [ ] Verify doc rendering on GitHub

https://claude.ai/code/session_01JBqEyFYbivjpV83GaTwGFv