### PR TITLE
fix(deploy): add explicit export for docs-tabs component

### DIFF
--- a/site/shared/package.json
+++ b/site/shared/package.json
@@ -8,6 +8,7 @@
   "exports": {
     "./styles/*": "./styles/*",
     "./components/*": "./components/*",
+    "./components/docs-tabs": "./components/docs-tabs.tsx",
     "./lib/*": "./lib/*",
     "./lib/theme-init": "./lib/theme-init.ts",
     "./lib/docs-tabs-init": "./lib/docs-tabs-init.ts",


### PR DESCRIPTION
## Summary

- Fix deploy-core job failure caused by wrangler's esbuild bundler unable to resolve `@barefootjs/site-shared/components/docs-tabs` (extensionless import via wildcard export)
- Add explicit export entry `"./components/docs-tabs": "./components/docs-tabs.tsx"` in `site/shared/package.json`, matching the pattern already used for `./lib/*` entries

Fixes the failure at https://github.com/piconic-ai/barefootjs/actions/runs/26453555690/job/77880937240

## Test plan

- [x] Local `bun run build` in `site/core` passes
- [x] `bunx wrangler deploy --dry-run` in `site/core` succeeds (no module resolution errors)
- [ ] CI deploy-core job passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)