### PR TITLE
feat: add `bf debug events` command (#1611 TODO 1)

### DIFF
--- a/.changeset/debug-events-command.md
+++ b/.changeset/debug-events-command.md
@@ -1,0 +1,6 @@
+---
+"@barefootjs/jsx": minor
+"@barefootjs/cli": minor
+---
+
+Add `bf debug events` command for tracing event handler -> setter -> signal -> DOM update paths

--- a/packages/cli/src/commands/debug-events.ts
+++ b/packages/cli/src/commands/debug-events.ts
@@ -16,7 +16,7 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
     process.exit(1)
   }
 
-  const { buildEventSummary, formatEventSummary, buildComponentGraph } = await import('@barefootjs/jsx')
+  const { buildEventSummary, formatEventSummary } = await import('@barefootjs/jsx')
 
   const searched: string[] = []
   const resolved = resolveComponentSource(componentName, ctx, searched)
@@ -31,10 +31,9 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
   const summary = buildEventSummary(source, resolved.filePath, resolved.componentName)
 
   if (ctx.jsonFlag) {
-    console.log(JSON.stringify(summary, null, 2))
+    console.log(JSON.stringify({ componentName: summary.componentName, sourceFile: summary.sourceFile, events: summary.events }, null, 2))
     return
   }
 
-  const graph = buildComponentGraph(source, resolved.filePath, resolved.componentName)
-  console.log(formatEventSummary(summary, graph))
+  console.log(formatEventSummary(summary, summary.graph))
 }

--- a/packages/cli/src/commands/debug-events.ts
+++ b/packages/cli/src/commands/debug-events.ts
@@ -1,0 +1,40 @@
+// bf debug events <component> — Show event handlers and their reactive update paths.
+//
+// Lists every event handler (DOM and component prop), the setters each
+// handler calls, and the downstream signal/memo/DOM updates that result.
+
+import { readFileSync } from 'fs'
+import type { CliContext } from '../context'
+import { resolveComponentSource } from '../lib/resolve-source'
+
+export async function run(args: string[], ctx: CliContext): Promise<void> {
+  const componentName = args[0]
+
+  if (!componentName) {
+    console.error('Error: Component name required.')
+    console.error('Usage: bf debug events <component> [--json]')
+    process.exit(1)
+  }
+
+  const { buildEventSummary, formatEventSummary, buildComponentGraph } = await import('@barefootjs/jsx')
+
+  const searched: string[] = []
+  const resolved = resolveComponentSource(componentName, ctx, searched)
+  if (!resolved) {
+    console.error(`Error: Cannot find component "${componentName}".`)
+    console.error('Looked in:')
+    for (const p of searched) console.error(`  - ${p}`)
+    process.exit(1)
+  }
+
+  const source = readFileSync(resolved.filePath, 'utf-8')
+  const summary = buildEventSummary(source, resolved.filePath, resolved.componentName)
+
+  if (ctx.jsonFlag) {
+    console.log(JSON.stringify(summary, null, 2))
+    return
+  }
+
+  const graph = buildComponentGraph(source, resolved.filePath, resolved.componentName)
+  console.log(formatEventSummary(summary, graph))
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -44,6 +44,7 @@ Tokens:
 Debug:
   debug graph <component>                     Show signal dependency graph
   debug trace <component> <signal>            Trace update propagation for a signal/memo
+  debug events <component>                    Show event handlers and their update paths
   debug fallbacks <component>                 Show wrap-by-default fallback bindings (#937)
   debug signals <component>                   Show signal initialization trace
 
@@ -150,8 +151,11 @@ switch (command) {
     } else if (sub === 'signals') {
       const { run } = await import('./commands/debug-signals')
       await run(rest, ctx)
+    } else if (sub === 'events') {
+      const { run } = await import('./commands/debug-events')
+      await run(rest, ctx)
     } else {
-      console.error('Usage: bf debug <graph|trace|fallbacks|signals> ...')
+      console.error('Usage: bf debug <graph|trace|fallbacks|signals|events> ...')
       process.exit(1)
     }
     break

--- a/packages/jsx/src/__tests__/debug.test.ts
+++ b/packages/jsx/src/__tests__/debug.test.ts
@@ -8,9 +8,12 @@
 import { describe, test, expect } from 'bun:test'
 import {
   buildComponentGraph,
+  buildEventSummary,
+  buildComponentAnalysis,
   traceUpdatePath,
   formatComponentGraph,
   formatUpdatePath,
+  formatEventSummary,
   formatSignalTrace,
   generateStaticTrace,
   graphToJSON,
@@ -640,5 +643,185 @@ describe('DomBinding classification (#944)', () => {
     const countLine = lines.find(l => l.includes('count') && l.includes('text'))
     expect(countLine).toBeDefined()
     expect(countLine!).not.toMatch(/~ text/)
+  })
+})
+
+// =============================================================================
+// Event analysis (bf debug events)
+// =============================================================================
+
+describe('buildEventSummary', () => {
+  test('extracts direct setter calls from event handlers', () => {
+    const summary = buildEventSummary(counterSource, 'Counter.tsx')
+    expect(summary.componentName).toBe('Counter')
+    expect(summary.events.length).toBeGreaterThanOrEqual(1)
+    const clickEvent = summary.events.find(e => e.eventName === 'onClick')
+    expect(clickEvent).toBeDefined()
+    expect(clickEvent!.elementTag).toBe('button')
+    expect(clickEvent!.setterCalls.some(s => s.setter === 'setCount')).toBe(true)
+  })
+
+  test('extracts events from a component with multiple handlers', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function SearchPanel() {
+        const [query, setQuery] = createSignal('')
+        const [category, setCategory] = createSignal('all')
+        return (
+          <div>
+            <input type="search" onInput={(e) => setQuery(e.target.value)} />
+            <select name="category" onChange={(e) => setCategory(e.target.value)}>
+              <option value="all">All</option>
+            </select>
+            <p>{query()}</p>
+          </div>
+        )
+      }
+    `
+    const summary = buildEventSummary(source, 'SearchPanel.tsx')
+    expect(summary.events).toHaveLength(2)
+    const inputEvent = summary.events.find(e => e.elementTag === 'input')
+    expect(inputEvent).toBeDefined()
+    expect(inputEvent!.elementContext).toBe('input search')
+    expect(inputEvent!.setterCalls[0].setter).toBe('setQuery')
+    expect(inputEvent!.setterCalls[0].signal).toBe('query')
+
+    const selectEvent = summary.events.find(e => e.elementTag === 'select')
+    expect(selectEvent).toBeDefined()
+    expect(selectEvent!.elementContext).toBe('select category')
+    expect(selectEvent!.setterCalls[0].setter).toBe('setCategory')
+  })
+
+  test('resolves setters through local functions', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function TodoApp() {
+        const [todos, setTodos] = createSignal([])
+
+        function addTodo(text: string) {
+          setTodos(prev => [...prev, { text, done: false }])
+        }
+
+        return (
+          <button onClick={() => addTodo('new')}>Add</button>
+        )
+      }
+    `
+    const summary = buildEventSummary(source, 'TodoApp.tsx')
+    expect(summary.events).toHaveLength(1)
+    const click = summary.events[0]
+    expect(click.setterCalls).toHaveLength(1)
+    expect(click.setterCalls[0].setter).toBe('setTodos')
+    expect(click.setterCalls[0].signal).toBe('todos')
+    expect(click.setterCalls[0].via).toBe('addTodo')
+  })
+
+  test('includes component prop events (Button.onClick)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { Button } from './Button'
+
+      export function ResetPanel() {
+        const [count, setCount] = createSignal(0)
+        return (
+          <div>
+            <p>{count()}</p>
+            <Button onClick={() => setCount(0)}>Reset</Button>
+          </div>
+        )
+      }
+    `
+    const summary = buildEventSummary(source, 'ResetPanel.tsx')
+    const btnEvent = summary.events.find(e => e.isComponentProp)
+    expect(btnEvent).toBeDefined()
+    expect(btnEvent!.elementTag).toBe('Button')
+    expect(btnEvent!.elementContext).toBe('Reset Button')
+    expect(btnEvent!.setterCalls[0].setter).toBe('setCount')
+  })
+
+  test('returns empty events for stateless component', () => {
+    const source = `
+      export function Card(props: { title: string }) {
+        return <div>{props.title}</div>
+      }
+    `
+    const summary = buildEventSummary(source, 'Card.tsx')
+    expect(summary.events).toHaveLength(0)
+  })
+
+  test('includes source location on events', () => {
+    const summary = buildEventSummary(counterSource, 'Counter.tsx')
+    expect(summary.events.length).toBeGreaterThan(0)
+    const event = summary.events[0]
+    expect(event.loc).toBeDefined()
+    expect(event.loc.start.line).toBeGreaterThan(0)
+  })
+})
+
+describe('formatEventSummary', () => {
+  test('produces readable output with setter and update info', () => {
+    const source = `
+      'use client'
+      import { createSignal, createMemo } from '@barefootjs/client'
+
+      export function Counter() {
+        const [count, setCount] = createSignal(0)
+        const doubled = createMemo(() => count() * 2)
+        return (
+          <div>
+            <button onClick={() => setCount(n => n + 1)}>+</button>
+            <span>{count()}</span>
+            <span>{doubled()}</span>
+          </div>
+        )
+      }
+    `
+    const summary = buildEventSummary(source, 'Counter.tsx')
+    const graph = buildComponentGraph(source, 'Counter.tsx')
+    const output = formatEventSummary(summary, graph)
+
+    expect(output).toContain('Counter')
+    expect(output).toContain('onClick')
+    expect(output).toContain('setCount')
+    expect(output).toContain('updates:')
+  })
+
+  test('shows indirect setter resolution via local functions', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function App() {
+        const [items, setItems] = createSignal([])
+        function addItem(text: string) {
+          setItems(prev => [...prev, text])
+        }
+        return (
+          <div>
+            <button onClick={() => addItem('test')}>Add</button>
+            <ul>{items().map(i => <li>{i}</li>)}</ul>
+          </div>
+        )
+      }
+    `
+    const summary = buildEventSummary(source, 'App.tsx')
+    const graph = buildComponentGraph(source, 'App.tsx')
+    const output = formatEventSummary(summary, graph)
+
+    expect(output).toContain('addItem -> setItems')
+  })
+})
+
+describe('buildComponentAnalysis', () => {
+  test('returns both graph and IR', () => {
+    const analysis = buildComponentAnalysis(counterSource, 'Counter.tsx')
+    expect(analysis.graph.componentName).toBe('Counter')
+    expect(analysis.ir.root).toBeDefined()
+    expect(analysis.ir.metadata.signals).toHaveLength(1)
   })
 })

--- a/packages/jsx/src/debug.ts
+++ b/packages/jsx/src/debug.ts
@@ -12,10 +12,14 @@ import type {
   IRConditional,
   IRElement,
   IRLoop,
+  IRComponent,
+  IRText,
+  IRMetadata,
   AttrValue,
   SignalInfo,
   MemoInfo,
   EffectInfo,
+  SourceLocation,
 } from './types'
 import { analyzeComponent, listComponentFunctions } from './analyzer'
 import { jsxToIR } from './jsx-to-ir'
@@ -116,6 +120,37 @@ export interface UpdatePathEntry {
   label: string
   /** Transitive dependents — memos/effects that depend on this entry */
   children: UpdatePathEntry[]
+}
+
+// -- Event analysis types -----------------------------------------------------
+
+export interface EventBinding {
+  elementTag: string
+  elementContext: string
+  eventName: string
+  handler: string
+  setterCalls: SetterRef[]
+  loc: SourceLocation
+  isComponentProp: boolean
+}
+
+export interface SetterRef {
+  setter: string
+  signal: string | null
+  via?: string
+}
+
+export interface EventSummary {
+  componentName: string
+  sourceFile: string
+  events: EventBinding[]
+}
+
+// -- Component analysis (shared IR + graph) -----------------------------------
+
+export interface ComponentAnalysis {
+  graph: ComponentGraph
+  ir: ComponentIR
 }
 
 // =============================================================================
@@ -260,6 +295,277 @@ export function buildGraphFromIR(ir: ComponentIR): ComponentGraph {
     effects,
     domBindings,
   }
+}
+
+/**
+ * Build both the ComponentIR and the reactive dependency graph in one pass.
+ * Callers that need the raw IR tree (events, loops, why-update) use this
+ * instead of `buildComponentGraph` to avoid a redundant analysis round.
+ */
+export function buildComponentAnalysis(source: string, filePath: string, componentName?: string): ComponentAnalysis {
+  const ctx = analyzeComponent(source, filePath, componentName)
+  const emptyIR: ComponentIR = {
+    version: '0.1',
+    metadata: buildMetadata(ctx),
+    root: { type: 'fragment', children: [], loc: { file: filePath, start: { line: 0, column: 0 }, end: { line: 0, column: 0 } } },
+    errors: [],
+  }
+
+  if (!ctx.jsxReturn) {
+    return { graph: buildGraphFromIR(emptyIR), ir: emptyIR }
+  }
+
+  const root = jsxToIR(ctx)
+  if (!root) {
+    return { graph: buildGraphFromIR(emptyIR), ir: emptyIR }
+  }
+
+  const ir: ComponentIR = { version: '0.1', metadata: buildMetadata(ctx), root, errors: [] }
+  return { graph: buildGraphFromIR(ir), ir }
+}
+
+// =============================================================================
+// Analysis: Event Bindings
+// =============================================================================
+
+/**
+ * Build a complete event summary for a component, including setter resolution
+ * and downstream update paths.
+ */
+export function buildEventSummary(source: string, filePath: string, componentName?: string): EventSummary {
+  const { graph, ir } = buildComponentAnalysis(source, filePath, componentName)
+  const setterToSignal = new Map<string, string>()
+  for (const s of ir.metadata.signals) {
+    if (s.setter) setterToSignal.set(s.setter, s.getter)
+  }
+
+  const fnSetters = buildLocalFunctionSetterMap(ir.metadata, setterToSignal)
+  const events = collectEventBindings(ir.root, setterToSignal, fnSetters)
+
+  return {
+    componentName: graph.componentName,
+    sourceFile: graph.sourceFile,
+    events,
+  }
+}
+
+function buildLocalFunctionSetterMap(
+  meta: IRMetadata,
+  setterToSignal: Map<string, string>,
+): Map<string, string[]> {
+  const result = new Map<string, string[]>()
+  for (const fn of meta.localFunctions) {
+    const setters: string[] = []
+    for (const setter of setterToSignal.keys()) {
+      if (new RegExp(`\\b${setter}\\s*\\(`).test(fn.body)) {
+        setters.push(setter)
+      }
+    }
+    if (setters.length > 0) result.set(fn.name, setters)
+  }
+  return result
+}
+
+function collectEventBindings(
+  node: IRNode,
+  setterToSignal: Map<string, string>,
+  fnSetters: Map<string, string[]>,
+): EventBinding[] {
+  const events: EventBinding[] = []
+  walkForEvents(node, events, setterToSignal, fnSetters)
+  return events
+}
+
+function walkForEvents(
+  node: IRNode,
+  events: EventBinding[],
+  setterToSignal: Map<string, string>,
+  fnSetters: Map<string, string[]>,
+): void {
+  switch (node.type) {
+    case 'element': {
+      for (const event of node.events) {
+        events.push({
+          elementTag: node.tag,
+          elementContext: describeElement(node),
+          eventName: event.originalAttr ?? `on${event.name[0].toUpperCase()}${event.name.slice(1)}`,
+          handler: event.handler,
+          setterCalls: resolveSetters(event.handler, setterToSignal, fnSetters),
+          loc: event.loc,
+          isComponentProp: false,
+        })
+      }
+      for (const child of node.children) {
+        walkForEvents(child, events, setterToSignal, fnSetters)
+      }
+      break
+    }
+    case 'component': {
+      for (const prop of node.props) {
+        if (!/^on[A-Z]/.test(prop.name)) continue
+        const handler = prop.value.kind === 'expression' ? prop.value.expr : null
+        if (!handler) continue
+        events.push({
+          elementTag: node.name,
+          elementContext: describeComponent(node),
+          eventName: prop.name,
+          handler,
+          setterCalls: resolveSetters(handler, setterToSignal, fnSetters),
+          loc: prop.loc,
+          isComponentProp: true,
+        })
+      }
+      for (const child of node.children) {
+        walkForEvents(child, events, setterToSignal, fnSetters)
+      }
+      break
+    }
+    case 'fragment':
+    case 'provider': {
+      for (const child of node.children) {
+        walkForEvents(child, events, setterToSignal, fnSetters)
+      }
+      break
+    }
+    case 'conditional': {
+      walkForEvents(node.whenTrue, events, setterToSignal, fnSetters)
+      walkForEvents(node.whenFalse, events, setterToSignal, fnSetters)
+      break
+    }
+    case 'loop': {
+      for (const child of node.children) {
+        walkForEvents(child, events, setterToSignal, fnSetters)
+      }
+      break
+    }
+    case 'if-statement': {
+      walkForEvents(node.consequent, events, setterToSignal, fnSetters)
+      if (node.alternate) walkForEvents(node.alternate, events, setterToSignal, fnSetters)
+      break
+    }
+  }
+}
+
+function resolveSetters(
+  handler: string,
+  setterToSignal: Map<string, string>,
+  fnSetters: Map<string, string[]>,
+): SetterRef[] {
+  const refs: SetterRef[] = []
+  const seen = new Set<string>()
+
+  for (const [setter, signal] of setterToSignal) {
+    if (new RegExp(`\\b${setter}\\s*\\(`).test(handler)) {
+      if (!seen.has(setter)) {
+        refs.push({ setter, signal })
+        seen.add(setter)
+      }
+    }
+  }
+
+  for (const [fnName, setters] of fnSetters) {
+    if (new RegExp(`\\b${fnName}\\s*\\(`).test(handler)) {
+      for (const setter of setters) {
+        if (!seen.has(setter)) {
+          refs.push({ setter, signal: setterToSignal.get(setter) ?? null, via: fnName })
+          seen.add(setter)
+        }
+      }
+    }
+  }
+
+  return refs
+}
+
+function describeElement(node: IRElement): string {
+  for (const attr of node.attrs) {
+    if (['type', 'name', 'placeholder', 'id'].includes(attr.name) && attr.value.kind === 'literal') {
+      return `${node.tag} ${attr.value.value}`
+    }
+  }
+  const textChild = node.children.find((c): c is IRText => c.type === 'text')
+  if (textChild && textChild.value.trim()) {
+    return `${textChild.value.trim()} ${node.tag}`
+  }
+  return node.tag
+}
+
+function describeComponent(node: IRComponent): string {
+  const textChild = node.children.find((c): c is IRText => c.type === 'text')
+  if (textChild && textChild.value.trim()) {
+    return `${textChild.value.trim()} ${node.name}`
+  }
+  return node.name
+}
+
+/**
+ * Format an event summary as a human-readable string for `bf debug events`.
+ * Uses the graph to trace downstream updates for each setter.
+ */
+export function formatEventSummary(summary: EventSummary, graph: ComponentGraph): string {
+  const lines: string[] = []
+  lines.push(`${summary.componentName} — ${summary.events.length} event handler(s)`)
+
+  if (summary.events.length === 0) return lines.join('\n')
+
+  const fileName = summary.sourceFile.split('/').pop() ?? summary.sourceFile
+
+  for (const event of summary.events) {
+    lines.push('')
+    lines.push(`  ${event.elementContext}`)
+
+    const setterParts = event.setterCalls.map(s => {
+      const chain = s.via ? `${s.via} -> ${s.setter}` : s.setter
+      return chain
+    })
+
+    const setterStr = setterParts.length > 0 ? setterParts.join(', ') : event.handler
+    lines.push(`    ${event.eventName} -> ${setterStr}`)
+
+    const updatedSignals = new Set<string>()
+    for (const sc of event.setterCalls) {
+      if (sc.signal) updatedSignals.add(sc.signal)
+    }
+
+    if (updatedSignals.size > 0) {
+      const targets: string[] = []
+      for (const sig of updatedSignals) {
+        const path = traceUpdatePath(graph, sig)
+        if (path && path.dependents.length > 0) {
+          const downstream = flattenUpdateTargets(path.dependents)
+          targets.push(`${sig} -> ${downstream.join(', ')}`)
+        }
+      }
+      if (targets.length > 0) {
+        lines.push(`    updates: ${targets.join('; ')}`)
+      }
+    }
+
+    const loc = event.loc
+    if (loc.file) {
+      const locFile = loc.file.split('/').pop() ?? loc.file
+      lines.push(`    at ${locFile}:${loc.start.line}`)
+    }
+  }
+
+  return lines.join('\n')
+}
+
+function flattenUpdateTargets(entries: UpdatePathEntry[]): string[] {
+  const targets: string[] = []
+  for (const entry of entries) {
+    if (entry.kind === 'dom') {
+      targets.push(entry.label)
+    } else if (entry.kind === 'memo') {
+      targets.push(entry.name)
+      if (entry.children.length > 0) {
+        targets.push(...flattenUpdateTargets(entry.children))
+      }
+    } else if (entry.kind === 'effect') {
+      targets.push(`effect ${entry.name}`)
+    }
+  }
+  return targets
 }
 
 // =============================================================================

--- a/packages/jsx/src/debug.ts
+++ b/packages/jsx/src/debug.ts
@@ -144,6 +144,7 @@ export interface EventSummary {
   componentName: string
   sourceFile: string
   events: EventBinding[]
+  graph: ComponentGraph
 }
 
 // -- Component analysis (shared IR + graph) -----------------------------------
@@ -307,7 +308,7 @@ export function buildComponentAnalysis(source: string, filePath: string, compone
   const emptyIR: ComponentIR = {
     version: '0.1',
     metadata: buildMetadata(ctx),
-    root: { type: 'fragment', children: [], loc: { file: filePath, start: { line: 0, column: 0 }, end: { line: 0, column: 0 } } },
+    root: { type: 'fragment', children: [], loc: { file: filePath, start: { line: 1, column: 0 }, end: { line: 1, column: 0 } } },
     errors: [],
   }
 
@@ -346,20 +347,32 @@ export function buildEventSummary(source: string, filePath: string, componentNam
     componentName: graph.componentName,
     sourceFile: graph.sourceFile,
     events,
+    graph,
   }
+}
+
+function escapeForIdBoundary(name: string): string {
+  return name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function makeIdCallRegex(name: string): RegExp {
+  return new RegExp(`(?:^|[^\\w$])${escapeForIdBoundary(name)}\\s*\\(`)
+}
+
+function makeIdRefRegex(name: string): RegExp {
+  return new RegExp(`(?:^|[^\\w$])${escapeForIdBoundary(name)}(?:[^\\w$]|$)`)
 }
 
 function buildLocalFunctionSetterMap(
   meta: IRMetadata,
   setterToSignal: Map<string, string>,
 ): Map<string, string[]> {
+  const setterPatterns = [...setterToSignal.keys()].map(s => ({ name: s, re: makeIdCallRegex(s) }))
   const result = new Map<string, string[]>()
   for (const fn of meta.localFunctions) {
     const setters: string[] = []
-    for (const setter of setterToSignal.keys()) {
-      if (new RegExp(`\\b${setter}\\s*\\(`).test(fn.body)) {
-        setters.push(setter)
-      }
+    for (const { name, re } of setterPatterns) {
+      if (re.test(fn.body)) setters.push(name)
     }
     if (setters.length > 0) result.set(fn.name, setters)
   }
@@ -443,6 +456,13 @@ function walkForEvents(
       if (node.alternate) walkForEvents(node.alternate, events, setterToSignal, fnSetters)
       break
     }
+    case 'async': {
+      walkForEvents(node.fallback, events, setterToSignal, fnSetters)
+      for (const child of node.children) {
+        walkForEvents(child, events, setterToSignal, fnSetters)
+      }
+      break
+    }
   }
 }
 
@@ -453,9 +473,10 @@ function resolveSetters(
 ): SetterRef[] {
   const refs: SetterRef[] = []
   const seen = new Set<string>()
+  const trimmed = handler.trim()
 
   for (const [setter, signal] of setterToSignal) {
-    if (new RegExp(`\\b${setter}\\s*\\(`).test(handler)) {
+    if (trimmed === setter || makeIdCallRegex(setter).test(handler)) {
       if (!seen.has(setter)) {
         refs.push({ setter, signal })
         seen.add(setter)
@@ -464,7 +485,7 @@ function resolveSetters(
   }
 
   for (const [fnName, setters] of fnSetters) {
-    if (new RegExp(`\\b${fnName}\\s*\\(`).test(handler)) {
+    if (trimmed === fnName || makeIdCallRegex(fnName).test(handler)) {
       for (const setter of setters) {
         if (!seen.has(setter)) {
           refs.push({ setter, signal: setterToSignal.get(setter) ?? null, via: fnName })
@@ -507,8 +528,6 @@ export function formatEventSummary(summary: EventSummary, graph: ComponentGraph)
   lines.push(`${summary.componentName} — ${summary.events.length} event handler(s)`)
 
   if (summary.events.length === 0) return lines.join('\n')
-
-  const fileName = summary.sourceFile.split('/').pop() ?? summary.sourceFile
 
   for (const event of summary.events) {
     lines.push('')

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -246,15 +246,18 @@ export type { LoopChainInputs } from './loop-chain'
 // Debug analysis
 export {
   buildComponentGraph,
+  buildComponentAnalysis,
   buildGraphFromIR,
+  buildEventSummary,
   traceUpdatePath,
   formatComponentGraph,
   formatUpdatePath,
+  formatEventSummary,
   formatSignalTrace,
   generateStaticTrace,
   graphToJSON,
 } from './debug'
-export type { ComponentGraph, SignalNode, MemoNode, EffectNode, DomBinding, UpdatePath, SignalTrace } from './debug'
+export type { ComponentGraph, ComponentAnalysis, SignalNode, MemoNode, EffectNode, DomBinding, UpdatePath, SignalTrace, EventBinding, SetterRef, EventSummary } from './debug'
 export type { WrapReason } from './ir-to-client-js/reactivity'
 
 // HTML constants


### PR DESCRIPTION
## Summary

- Add `bf debug events <component>` command that shows event handlers, the setters/functions they call, and downstream reactive update paths
- Resolves setters both directly (`setCount`) and through local helper functions (`addTodo -> setTodos`)
- Includes component prop events (e.g. `Button.onClick`) alongside DOM events
- New `buildComponentAnalysis()` shared entry point that returns both IR and graph (avoids redundant analysis for upcoming commands)

Part 1 of #1611 (stacked PRs).

## Example output

```
Counter — 1 event handler(s)

  + button
    onClick -> setCount
    updates: count -> doubled, text "s0", text "s1"
    at Counter.tsx:8
```

## Test plan

- [x] Existing 36 debug tests still pass
- [x] 9 new tests covering: direct setters, multiple handlers, local function resolution, component prop events, stateless components, source locations, format output
- [ ] Manual verification with a real component via `bun run bf debug events <component>`

https://claude.ai/code/session_01CmyVMrRYnJHikzLsm4kJEu


---
_Generated by [Claude Code](https://claude.ai/code/session_01CmyVMrRYnJHikzLsm4kJEu)_