### PR TITLE
feat: add source locations and JSX previews to DOM bindings (#1611 TODO 2)

### DIFF
--- a/packages/jsx/src/__tests__/debug.test.ts
+++ b/packages/jsx/src/__tests__/debug.test.ts
@@ -618,8 +618,6 @@ describe('DomBinding classification (#944)', () => {
   })
 
   test('formatComponentGraph marks fallback bindings with ~ prefix', () => {
-    // The visual marker is the primary UX for `bf debug graph`.
-    // Guard the prefix format so `why-wrap` output doesn't silently drift.
     const source = `
       'use client'
       import { createSignal } from '@barefootjs/client'
@@ -634,15 +632,113 @@ describe('DomBinding classification (#944)', () => {
     const graph = buildComponentGraph(source, 'Page.tsx')
     const output = formatComponentGraph(graph)
     // Fallback text binding for formatTitle(page) — marked with '~'.
-    expect(output).toMatch(/~ text "/)
-    // Reactive text binding for count() — marked with two leading spaces
-    // (no tilde). The exact prefix matters: it's the visual diff.
-    expect(output).toMatch(/dom bindings:[\s\S]*?text "/)
-    // No fallback marker on the reactive binding's line.
+    // New format uses JSX preview: `~ <h1>{formatTitle(page)}</h1>`
+    expect(output).toMatch(/~ .*formatTitle/)
+    // Reactive text binding for count() — no tilde prefix.
+    expect(output).toMatch(/dom bindings:[\s\S]*?count/)
     const lines = output.split('\n')
-    const countLine = lines.find(l => l.includes('count') && l.includes('text'))
+    const countLine = lines.find(l => l.includes('count()') && l.includes('<h1>'))
     expect(countLine).toBeDefined()
-    expect(countLine!).not.toMatch(/~ text/)
+    expect(countLine!).not.toMatch(/^.*~ /)
+  })
+})
+
+// =============================================================================
+// Source locations + JSX previews on DomBinding (#1611 TODO 2)
+// =============================================================================
+
+describe('DomBinding source locations and JSX previews', () => {
+  test('text bindings carry loc and parent-tag JSX preview', () => {
+    const graph = buildComponentGraph(counterSource, 'Counter.tsx')
+    const textBinding = graph.domBindings.find(d => d.type === 'text')
+    expect(textBinding).toBeDefined()
+    expect(textBinding!.loc).toBeDefined()
+    expect(textBinding!.loc!.start.line).toBeGreaterThan(0)
+    expect(textBinding!.jsxPreview).toContain('<button>')
+    expect(textBinding!.jsxPreview).toContain('count()')
+    expect(textBinding!.jsxPreview).toContain('</button>')
+  })
+
+  test('attribute bindings carry loc and element-tag JSX preview', () => {
+    const graph = buildComponentGraph(sliderLikeSource, 'RangeInput.tsx')
+    const styleBinding = graph.domBindings.find(d => d.label === 'style')
+    expect(styleBinding).toBeDefined()
+    expect(styleBinding!.loc).toBeDefined()
+    expect(styleBinding!.jsxPreview).toMatch(/<div style=\{/)
+  })
+
+  test('event bindings carry loc and JSX preview', () => {
+    const graph = buildComponentGraph(counterSource, 'Counter.tsx')
+    const eventBinding = graph.domBindings.find(d => d.type === 'event')
+    expect(eventBinding).toBeDefined()
+    expect(eventBinding!.loc).toBeDefined()
+    expect(eventBinding!.jsxPreview).toContain('<button')
+    expect(eventBinding!.jsxPreview).toContain('onClick')
+  })
+
+  test('loop bindings carry loc and JSX preview with param', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function List() {
+        const [items, setItems] = createSignal([1, 2, 3])
+        return <ul>{items().map(item => <li>{item}</li>)}</ul>
+      }
+    `
+    const graph = buildComponentGraph(source, 'List.tsx')
+    const loopBinding = graph.domBindings.find(d => d.type === 'loop')
+    expect(loopBinding).toBeDefined()
+    expect(loopBinding!.jsxPreview).toContain('.map(item')
+  })
+
+  test('conditional bindings carry loc and JSX preview', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Toggle() {
+        const [show, setShow] = createSignal(true)
+        return <div>{show() ? <span>on</span> : <span>off</span>}</div>
+      }
+    `
+    const graph = buildComponentGraph(source, 'Toggle.tsx')
+    const condBinding = graph.domBindings.find(d => d.type === 'conditional')
+    expect(condBinding).toBeDefined()
+    expect(condBinding!.jsxPreview).toContain('show()')
+    expect(condBinding!.jsxPreview).toContain('? ... : ...')
+  })
+
+  test('component prop bindings carry loc and JSX preview', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { Card } from './Card'
+
+      export function Page() {
+        const [title, setTitle] = createSignal('hello')
+        return <Card title={title()} />
+      }
+    `
+    const graph = buildComponentGraph(source, 'Page.tsx')
+    const propBinding = graph.domBindings.find(d => d.label === 'Card.title')
+    expect(propBinding).toBeDefined()
+    expect(propBinding!.jsxPreview).toContain('<Card title=')
+  })
+
+  test('formatComponentGraph includes source locations', () => {
+    const graph = buildComponentGraph(counterSource, 'Counter.tsx')
+    const output = formatComponentGraph(graph)
+    expect(output).toMatch(/at Counter\.tsx:\d+/)
+  })
+
+  test('graphToJSON includes loc and jsxPreview fields', () => {
+    const graph = buildComponentGraph(counterSource, 'Counter.tsx')
+    const json = graphToJSON(graph) as { domBindings: Array<{ loc?: object; jsxPreview?: string }> }
+    const binding = json.domBindings.find(d => (d as any).type === 'text')
+    expect(binding).toBeDefined()
+    expect(binding!.loc).toBeDefined()
+    expect(binding!.jsxPreview).toBeDefined()
   })
 })
 

--- a/packages/jsx/src/debug.ts
+++ b/packages/jsx/src/debug.ts
@@ -97,6 +97,8 @@ export interface DomBinding {
    * bindings; omitted for event handlers (not subject to the wrap gate).
    */
   wrapReason?: WrapReason
+  loc?: SourceLocation
+  jsxPreview?: string
 }
 
 export interface ComponentGraph {
@@ -671,6 +673,7 @@ export function formatComponentGraph(graph: ComponentGraph): string {
       // For attribute bindings use the attr name; for others use slotId
       const id = d.type === 'attribute' ? `"${d.label}"` : `"${d.slotId}"`
       const marker = d.classification === 'fallback' ? '~ ' : '  '
+      const locSuffix = formatBindingLoc(d)
       // No tracked deps ⇒ drop the arrow entirely instead of emitting
       // a dangling `<- ` (trailing space). Fallback-wrapped attribute
       // handlers like `<Button onClick={() => setCount(0)}>` legitimately
@@ -678,12 +681,20 @@ export function formatComponentGraph(graph: ComponentGraph): string {
       // it explicitly so the reader doesn't wonder if the analyzer
       // dropped data.
       if (d.deps.length === 0) {
-        lines.push(`    ${marker}${d.type} ${id} (no tracked deps)`)
+        if (d.jsxPreview) {
+          lines.push(`    ${marker}${d.jsxPreview} (no tracked deps)${locSuffix}`)
+        } else {
+          lines.push(`    ${marker}${d.type} ${id} (no tracked deps)${locSuffix}`)
+        }
         continue
       }
       const arrow = d.type === 'event' ? ' ->' : ' <-'
       const depStr = d.deps.join(', ')
-      lines.push(`    ${marker}${d.type} ${id}${arrow} ${depStr}`)
+      if (d.jsxPreview) {
+        lines.push(`    ${marker}${depStr} -> ${d.jsxPreview}${locSuffix}`)
+      } else {
+        lines.push(`    ${marker}${d.type} ${id}${arrow} ${depStr}${locSuffix}`)
+      }
     }
   }
 
@@ -716,6 +727,12 @@ export function formatUpdatePath(path: UpdatePath): string {
   }
 
   return lines.join('\n')
+}
+
+function formatBindingLoc(d: DomBinding): string {
+  if (!d.loc) return ''
+  const file = d.loc.file.split('/').pop() ?? d.loc.file
+  return ` at ${file}:${d.loc.start.line}`
 }
 
 function formatEntry(entry: UpdatePathEntry, lines: string[], indent: string): void {
@@ -758,6 +775,8 @@ export function graphToJSON(graph: ComponentGraph): object {
       type: d.type,
       classification: d.classification,
       ...(d.expression !== undefined && { expression: d.expression }),
+      ...(d.loc && { loc: { file: d.loc.file, line: d.loc.start.line } }),
+      ...(d.jsxPreview && { jsxPreview: d.jsxPreview }),
     })),
   }
 }
@@ -884,6 +903,7 @@ function collectDomBindings(
   bindings: DomBinding[],
   signalGetters: Set<string>,
   memoNames: Set<string>,
+  parentTag?: string,
 ): void {
   switch (node.type) {
     case 'element': {
@@ -910,6 +930,8 @@ function collectDomBindings(
             classification: isReactive ? 'reactive' : 'fallback',
             expression: expr,
             wrapReason,
+            loc: attr.loc,
+            jsxPreview: `<${node.tag} ${attr.name}={${truncateExpr(expr)}}>`,
           })
         }
       }
@@ -923,11 +945,13 @@ function collectDomBindings(
           deps: extractSetterRefs(event.handler, signalGetters),
           type: 'event',
           classification: 'reactive',
+          loc: event.loc,
+          jsxPreview: `<${node.tag} ${event.originalAttr ?? `on${event.name[0].toUpperCase()}${event.name.slice(1)}`}={...}>`,
         })
       }
-      // Recurse
+      // Recurse — pass element tag as parent context for text bindings
       for (const child of node.children) {
-        collectDomBindings(child, bindings, signalGetters, memoNames)
+        collectDomBindings(child, bindings, signalGetters, memoNames, node.tag)
       }
       break
     }
@@ -937,6 +961,9 @@ function collectDomBindings(
       const decision = decideWrapFromAstFlags(node)
       if (decision.wrap && node.slotId) {
         const deps = extractReactiveDeps(node.expr, signalGetters, memoNames)
+        const preview = parentTag
+          ? `<${parentTag}>{${truncateExpr(node.expr)}}</${parentTag}>`
+          : `{${truncateExpr(node.expr)}}`
         bindings.push({
           kind: 'dom',
           label: `text "${node.slotId}"`,
@@ -946,6 +973,8 @@ function collectDomBindings(
           classification: decision.reason === 'proven-reactive' ? 'reactive' : 'fallback',
           expression: node.expr,
           wrapReason: decision.reason,
+          loc: node.loc,
+          jsxPreview: preview,
         })
       }
       break
@@ -963,10 +992,12 @@ function collectDomBindings(
           classification: decision.reason === 'proven-reactive' ? 'reactive' : 'fallback',
           expression: node.condition,
           wrapReason: decision.reason,
+          loc: node.loc,
+          jsxPreview: `{${truncateExpr(node.condition)} ? ... : ...}`,
         })
       }
-      collectDomBindings(node.whenTrue, bindings, signalGetters, memoNames)
-      collectDomBindings(node.whenFalse, bindings, signalGetters, memoNames)
+      collectDomBindings(node.whenTrue, bindings, signalGetters, memoNames, parentTag)
+      collectDomBindings(node.whenFalse, bindings, signalGetters, memoNames, parentTag)
       break
     }
     case 'loop': {
@@ -1000,37 +1031,20 @@ function collectDomBindings(
             classification: isReactive ? 'reactive' : 'fallback',
             expression: node.array,
             wrapReason,
+            loc: node.loc,
+            jsxPreview: `{${truncateExpr(node.array)}.map(${node.param} => ...)}`,
           })
         }
       }
       for (const child of node.children) {
-        collectDomBindings(child, bindings, signalGetters, memoNames)
+        collectDomBindings(child, bindings, signalGetters, memoNames, parentTag)
       }
       break
     }
     case 'component': {
       // Child-component prop bindings (#942 DRY-consolidated in #952).
-      // Emitter gate in collect-elements.ts:442 is
-      // `hasPropsRef || needsEffectWrapper(expandedValue) || prop.callsReactiveGetters || prop.hasFunctionCalls`.
-      // `deps.length > 0` + `prop.value.includes('props.')` together
-      // approximate the first two branches (statically-proven reactive);
-      // the AST flags cover the fallback case.
-      //
-      // Before #944 this case fell through silently, so fallback-wrapped
-      // child props like `<Card title={formatTitle(page)} />` — the exact
-      // motivating example for #942 — never reached `why-wrap`'s output.
-      // The switch now iterates props and recurses into children, mirroring
-      // the `case 'element'` structure.
-      //
-      // Label uses `"ComponentName.propName"` so output distinguishes
-      // native-element attributes from child-component props without
-      // introducing a new `DomBinding.type` variant (keeps the existing
-      // type union stable for consumers).
       for (const prop of node.props) {
         if (prop.name === '...' || prop.name.startsWith('...')) continue
-        // Only `expression` / `template` / `spread` carry a runtime expression
-        // worth probing for reactive deps. `jsx-children` is handled via child
-        // traversal below; literal / boolean produce no reactive bindings.
         if (prop.value.kind !== 'expression' && prop.value.kind !== 'template' && prop.value.kind !== 'spread') continue
         const propValue = attrValueToString(prop.value) ?? ''
         if (!propValue) continue
@@ -1048,29 +1062,36 @@ function collectDomBindings(
             classification: isReactive ? 'reactive' : 'fallback',
             expression: propValue,
             wrapReason,
+            loc: prop.loc,
+            jsxPreview: `<${node.name} ${prop.name}={${truncateExpr(propValue)}}>`,
           })
         }
       }
       for (const child of node.children) {
-        collectDomBindings(child, bindings, signalGetters, memoNames)
+        collectDomBindings(child, bindings, signalGetters, memoNames, parentTag)
       }
       break
     }
     case 'fragment':
     case 'provider': {
       for (const child of node.children) {
-        collectDomBindings(child, bindings, signalGetters, memoNames)
+        collectDomBindings(child, bindings, signalGetters, memoNames, parentTag)
       }
       break
     }
     case 'if-statement': {
-      collectDomBindings(node.consequent, bindings, signalGetters, memoNames)
+      collectDomBindings(node.consequent, bindings, signalGetters, memoNames, parentTag)
       if (node.alternate) {
-        collectDomBindings(node.alternate, bindings, signalGetters, memoNames)
+        collectDomBindings(node.alternate, bindings, signalGetters, memoNames, parentTag)
       }
       break
     }
   }
+}
+
+function truncateExpr(expr: string, max: number = 40): string {
+  const s = expr.replace(/\s+/g, ' ').trim()
+  return s.length > max ? s.slice(0, max - 1) + '…' : s
 }
 
 /** Convert an `AttrValue` to a flat string for reactive dep extraction. */

--- a/packages/jsx/src/debug.ts
+++ b/packages/jsx/src/debug.ts
@@ -707,10 +707,13 @@ export function formatComponentGraph(graph: ComponentGraph): string {
         }
         continue
       }
-      const arrow = d.type === 'event' ? ' ->' : ' <-'
       const depStr = d.deps.join(', ')
       if (d.jsxPreview) {
-        lines.push(`    ${marker}${depStr} -> ${d.jsxPreview}${locSuffix}`)
+        if (d.type === 'event') {
+          lines.push(`    ${marker}${d.jsxPreview} -> ${depStr}${locSuffix}`)
+        } else {
+          lines.push(`    ${marker}${depStr} -> ${d.jsxPreview}${locSuffix}`)
+        }
       } else {
         lines.push(`    ${marker}${d.type} ${id}${arrow} ${depStr}${locSuffix}`)
       }
@@ -950,7 +953,9 @@ function collectDomBindings(
             expression: expr,
             wrapReason,
             loc: attr.loc,
-            jsxPreview: `<${node.tag} ${attr.name}={${truncateExpr(expr)}}>`,
+            jsxPreview: attr.value.kind === 'spread'
+              ? `<${node.tag} {...${truncateExpr(expr)}}>`
+              : `<${node.tag} ${attr.name}={${truncateExpr(expr)}}>`,
           })
         }
       }
@@ -1051,7 +1056,7 @@ function collectDomBindings(
             expression: node.array,
             wrapReason,
             loc: node.loc,
-            jsxPreview: `{${truncateExpr(node.array)}.map(${node.param} => ...)}`,
+            jsxPreview: `{${truncateExpr(node.array)}.${node.method === 'flatMap' ? 'flatMap' : 'map'}(${node.param} => ...)}`,
           })
         }
       }
@@ -1082,7 +1087,9 @@ function collectDomBindings(
             expression: propValue,
             wrapReason,
             loc: prop.loc,
-            jsxPreview: `<${node.name} ${prop.name}={${truncateExpr(propValue)}}>`,
+            jsxPreview: prop.value.kind === 'spread'
+              ? `<${node.name} {...${truncateExpr(propValue)}}>`
+              : `<${node.name} ${prop.name}={${truncateExpr(propValue)}}>`,
           })
         }
       }

--- a/packages/jsx/src/debug.ts
+++ b/packages/jsx/src/debug.ts
@@ -715,6 +715,7 @@ export function formatComponentGraph(graph: ComponentGraph): string {
           lines.push(`    ${marker}${depStr} -> ${d.jsxPreview}${locSuffix}`)
         }
       } else {
+        const arrow = d.type === 'event' ? ' ->' : ' <-'
         lines.push(`    ${marker}${d.type} ${id}${arrow} ${depStr}${locSuffix}`)
       }
     }


### PR DESCRIPTION
## Summary

- Add `loc` (SourceLocation) and `jsxPreview` (compact JSX snippet) fields to `DomBinding`
- Text bindings show parent element context: `count -> <button>{count()}</button> at Counter.tsx:7`
- Attribute bindings: `<div style={pct()%}>`, loop bindings: `{items().map(item => ...)}`, etc.
- `formatComponentGraph` now displays JSX previews and source locations instead of bare slot IDs
- `graphToJSON` includes `loc` and `jsxPreview` in JSON output

Stacked on #1612 (TODO 1). Part 2 of #1611.

## Example output (before → after)

**Before:**
```
  dom bindings:
      text "s0" <- count
```

**After:**
```
  dom bindings:
      count -> <button>{count()}</button> at Counter.tsx:7
```

## Test plan

- [x] 8 new tests for loc/jsxPreview on text, attribute, event, loop, conditional, component prop bindings
- [x] Updated existing format test for new JSX preview output
- [x] All 53 tests pass locally

https://claude.ai/code/session_01CmyVMrRYnJHikzLsm4kJEu


---
_Generated by [Claude Code](https://claude.ai/code/session_01CmyVMrRYnJHikzLsm4kJEu)_