### PR TITLE
feat: add `bf debug why-update` command (#1611 TODO 4)

### DIFF
--- a/packages/cli/src/commands/debug-why-update.ts
+++ b/packages/cli/src/commands/debug-why-update.ts
@@ -37,9 +37,19 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
   if (!result) {
     const graph = buildComponentGraph(source, resolved.filePath, resolved.componentName)
     console.error(`Error: Binding "${bindingLabel}" not found in ${graph.componentName}.`)
-    const available = graph.domBindings.map(d => d.label)
+    const available = graph.domBindings.map(d =>
+      d.type === 'attribute' ? d.label : d.slotId,
+    )
     if (available.length > 0) {
-      console.error(`Available bindings: ${available.join(', ')}`)
+      console.error(`Available bindings: ${[...new Set(available)].join(', ')}`)
+    }
+    process.exit(1)
+  }
+
+  if (result.ambiguous) {
+    console.error(`Error: "${bindingLabel}" matches multiple bindings. Disambiguate with a slot ID:`)
+    for (const m of result.ambiguous) {
+      console.error(`  ${m.slotId} (${m.label})`)
     }
     process.exit(1)
   }

--- a/packages/cli/src/commands/debug-why-update.ts
+++ b/packages/cli/src/commands/debug-why-update.ts
@@ -1,0 +1,53 @@
+// bf debug why-update <component> <binding> — Explain why a binding updates.
+//
+// Reverse lookup: given a DOM binding label (attribute name, slot ID, or
+// component.prop), trace back through signals/memos to the event handlers
+// that trigger the update.
+
+import { readFileSync } from 'fs'
+import type { CliContext } from '../context'
+import { resolveComponentSource } from '../lib/resolve-source'
+
+export async function run(args: string[], ctx: CliContext): Promise<void> {
+  const componentName = args[0]
+  const bindingLabel = args[1]
+
+  if (!componentName || !bindingLabel) {
+    console.error('Error: Component name and binding label required.')
+    console.error('Usage: bf debug why-update <component> <binding> [--json]')
+    console.error('  binding: attribute name (e.g. "style"), slot ID (e.g. "s0"),')
+    console.error('           or component prop (e.g. "Button.disabled")')
+    process.exit(1)
+  }
+
+  const { buildWhyUpdate, formatWhyUpdate, buildComponentGraph } = await import('@barefootjs/jsx')
+
+  const searched: string[] = []
+  const resolved = resolveComponentSource(componentName, ctx, searched)
+  if (!resolved) {
+    console.error(`Error: Cannot find component "${componentName}".`)
+    console.error('Looked in:')
+    for (const p of searched) console.error(`  - ${p}`)
+    process.exit(1)
+  }
+
+  const source = readFileSync(resolved.filePath, 'utf-8')
+  const result = buildWhyUpdate(source, resolved.filePath, bindingLabel, resolved.componentName)
+
+  if (!result) {
+    const graph = buildComponentGraph(source, resolved.filePath, resolved.componentName)
+    console.error(`Error: Binding "${bindingLabel}" not found in ${graph.componentName}.`)
+    const available = graph.domBindings.map(d => d.label)
+    if (available.length > 0) {
+      console.error(`Available bindings: ${available.join(', ')}`)
+    }
+    process.exit(1)
+  }
+
+  if (ctx.jsonFlag) {
+    console.log(JSON.stringify(result, null, 2))
+    return
+  }
+
+  console.log(formatWhyUpdate(result))
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -46,6 +46,7 @@ Debug:
   debug trace <component> <signal>            Trace update propagation for a signal/memo
   debug events <component>                    Show event handlers and their update paths
   debug loops <component>                     Show loop bindings grouped by source collection
+  debug why-update <component> <binding>      Explain why a binding updates
   debug fallbacks <component>                 Show wrap-by-default fallback bindings (#937)
   debug signals <component>                   Show signal initialization trace
 
@@ -158,8 +159,11 @@ switch (command) {
     } else if (sub === 'loops') {
       const { run } = await import('./commands/debug-loops')
       await run(rest, ctx)
+    } else if (sub === 'why-update') {
+      const { run } = await import('./commands/debug-why-update')
+      await run(rest, ctx)
     } else {
-      console.error('Usage: bf debug <graph|trace|fallbacks|signals|events|loops> ...')
+      console.error('Usage: bf debug <graph|trace|fallbacks|signals|events|loops|why-update> ...')
       process.exit(1)
     }
     break

--- a/packages/jsx/src/__tests__/debug.test.ts
+++ b/packages/jsx/src/__tests__/debug.test.ts
@@ -1146,6 +1146,51 @@ describe('buildWhyUpdate', () => {
     expect(signalDep).toBeDefined()
     expect(signalDep!.changedBy[0].via).toBe('addItem')
   })
+
+  test('includes classification and wrapReason for fallback bindings', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { formatTitle } from './format'
+
+      export function Page() {
+        const [, setFoo] = createSignal(0)
+        const page = 'home'
+        return <h1 onClick={() => setFoo(1)}>{formatTitle(page)}</h1>
+      }
+    `
+    const graph = buildComponentGraph(source, 'Page.tsx')
+    const fallback = graph.domBindings.find(d => d.classification === 'fallback' && d.type === 'text')
+    expect(fallback).toBeDefined()
+    const result = buildWhyUpdate(source, 'Page.tsx', fallback!.slotId)
+    expect(result).not.toBeNull()
+    expect(result!.classification).toBe('fallback')
+    expect(result!.wrapReason).toBeDefined()
+    expect(result!.deps).toHaveLength(0)
+  })
+
+  test('returns ambiguous result when multiple bindings share the same label', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function TwoStyles() {
+        const [a, setA] = createSignal('red')
+        const [b, setB] = createSignal('blue')
+        return (
+          <div>
+            <div style={a()} />
+            <div style={b()} />
+            <button onClick={() => setA('green')}>A</button>
+          </div>
+        )
+      }
+    `
+    const result = buildWhyUpdate(source, 'TwoStyles.tsx', 'style')
+    expect(result).not.toBeNull()
+    expect(result!.ambiguous).toBeDefined()
+    expect(result!.ambiguous!.length).toBeGreaterThan(1)
+  })
 })
 
 describe('formatWhyUpdate', () => {
@@ -1169,5 +1214,25 @@ describe('formatWhyUpdate', () => {
     expect(output).toContain('style updates because:')
     expect(output).toContain('color changes from:')
     expect(output).toContain('setColor')
+  })
+
+  test('shows fallback note when binding is fallback-wrapped', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { formatTitle } from './format'
+
+      export function Page() {
+        const [, setFoo] = createSignal(0)
+        return <h1 onClick={() => setFoo(1)}>{formatTitle('x')}</h1>
+      }
+    `
+    const graph = buildComponentGraph(source, 'Page.tsx')
+    const fallback = graph.domBindings.find(d => d.classification === 'fallback' && d.type === 'text')
+    expect(fallback).toBeDefined()
+    const result = buildWhyUpdate(source, 'Page.tsx', fallback!.slotId)!
+    const output = formatWhyUpdate(result)
+    expect(output).toContain('fallback-wrapped binding')
+    expect(output).toContain('could not statically prove')
   })
 })

--- a/packages/jsx/src/__tests__/debug.test.ts
+++ b/packages/jsx/src/__tests__/debug.test.ts
@@ -11,11 +11,13 @@ import {
   buildEventSummary,
   buildComponentAnalysis,
   buildLoopSummary,
+  buildWhyUpdate,
   traceUpdatePath,
   formatComponentGraph,
   formatUpdatePath,
   formatEventSummary,
   formatLoopSummary,
+  formatWhyUpdate,
   formatSignalTrace,
   generateStaticTrace,
   graphToJSON,
@@ -1007,5 +1009,119 @@ describe('formatLoopSummary', () => {
     expect(output).toContain('.map(item)')
     expect(output).toContain('key: item.id')
     expect(output).toContain('item')
+  })
+})
+
+// =============================================================================
+// Why-update analysis (bf debug why-update)
+// =============================================================================
+
+describe('buildWhyUpdate', () => {
+  test('traces attribute binding back to signal and event handler', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Panel() {
+        const [color, setColor] = createSignal('red')
+        return (
+          <div>
+            <div style={color()} />
+            <button onClick={() => setColor('blue')}>Change</button>
+          </div>
+        )
+      }
+    `
+    const result = buildWhyUpdate(source, 'Panel.tsx', 'style')
+    expect(result).not.toBeNull()
+    expect(result!.binding).toBe('style')
+    expect(result!.expression).toContain('color()')
+    expect(result!.deps).toHaveLength(1)
+    expect(result!.deps[0].name).toBe('color')
+    expect(result!.deps[0].kind).toBe('signal')
+    expect(result!.deps[0].changedBy.length).toBeGreaterThan(0)
+    expect(result!.deps[0].changedBy[0].setter).toBe('setColor')
+  })
+
+  test('traces through memo dependencies', () => {
+    const source = `
+      'use client'
+      import { createSignal, createMemo } from '@barefootjs/client'
+
+      export function Dashboard() {
+        const [count, setCount] = createSignal(0)
+        const doubled = createMemo(() => count() * 2)
+        return (
+          <div>
+            <span>{doubled()}</span>
+            <button onClick={() => setCount(n => n + 1)}>+</button>
+          </div>
+        )
+      }
+    `
+    const result = buildWhyUpdate(source, 'Dashboard.tsx', 's0')
+    expect(result).not.toBeNull()
+    const memoDep = result!.deps.find(d => d.kind === 'memo')
+    expect(memoDep).toBeDefined()
+    expect(memoDep!.name).toBe('doubled')
+    expect(memoDep!.dependsOn).toContain('count')
+    const signalDep = result!.deps.find(d => d.kind === 'signal')
+    expect(signalDep).toBeDefined()
+    expect(signalDep!.name).toBe('count')
+    expect(signalDep!.changedBy[0].setter).toBe('setCount')
+  })
+
+  test('returns null for unknown binding', () => {
+    const result = buildWhyUpdate(counterSource, 'Counter.tsx', 'nonExistent')
+    expect(result).toBeNull()
+  })
+
+  test('traces indirect setter via local function', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function App() {
+        const [items, setItems] = createSignal([])
+        function addItem(text: string) {
+          setItems(prev => [...prev, text])
+        }
+        return (
+          <div>
+            <span>{items().length}</span>
+            <button onClick={() => addItem('test')}>Add</button>
+          </div>
+        )
+      }
+    `
+    const result = buildWhyUpdate(source, 'App.tsx', 's0')
+    expect(result).not.toBeNull()
+    const signalDep = result!.deps.find(d => d.name === 'items')
+    expect(signalDep).toBeDefined()
+    expect(signalDep!.changedBy[0].via).toBe('addItem')
+  })
+})
+
+describe('formatWhyUpdate', () => {
+  test('produces readable output', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Panel() {
+        const [color, setColor] = createSignal('red')
+        return (
+          <div>
+            <div style={color()} />
+            <button onClick={() => setColor('blue')}>Change</button>
+          </div>
+        )
+      }
+    `
+    const result = buildWhyUpdate(source, 'Panel.tsx', 'style')!
+    const output = formatWhyUpdate(result)
+    expect(output).toContain('style updates because:')
+    expect(output).toContain('color changes from:')
+    expect(output).toContain('setColor')
   })
 })

--- a/packages/jsx/src/debug.ts
+++ b/packages/jsx/src/debug.ts
@@ -173,6 +173,28 @@ export interface LoopSummary {
   loops: LoopInfo[]
 }
 
+// -- Why-update analysis types ------------------------------------------------
+
+export interface WhyUpdateResult {
+  binding: string
+  expression: string | null
+  deps: WhyUpdateDep[]
+}
+
+export interface WhyUpdateDep {
+  name: string
+  kind: 'signal' | 'memo'
+  dependsOn: string[]
+  changedBy: WhyUpdateSource[]
+}
+
+export interface WhyUpdateSource {
+  handler: string
+  setter: string
+  elementContext: string
+  via?: string
+}
+
 // -- Component analysis (shared IR + graph) -----------------------------------
 
 export interface ComponentAnalysis {
@@ -826,6 +848,104 @@ function buildUpdateEntry(consumer: string, graph: ComponentGraph, visited: Set<
   }
 
   return { name: consumer, kind: 'effect', label: consumer, children: [] }
+}
+
+// =============================================================================
+// Analysis: Why-Update (binding → reason)
+// =============================================================================
+
+export function buildWhyUpdate(
+  source: string,
+  filePath: string,
+  bindingLabel: string,
+  componentName?: string,
+): WhyUpdateResult | null {
+  const { graph, ir } = buildComponentAnalysis(source, filePath, componentName)
+
+  const binding = graph.domBindings.find(d =>
+    d.label === bindingLabel ||
+    d.slotId === bindingLabel ||
+    (d.jsxPreview && d.jsxPreview.includes(bindingLabel)),
+  )
+  if (!binding) return null
+
+  const setterToSignal = new Map<string, string>()
+  for (const s of ir.metadata.signals) {
+    if (s.setter) setterToSignal.set(s.setter, s.getter)
+  }
+  const fnSetters = buildLocalFunctionSetterMap(ir.metadata, setterToSignal)
+  const events = collectEventBindings(ir.root, setterToSignal, fnSetters)
+
+  const deps: WhyUpdateDep[] = []
+  const visited = new Set<string>()
+
+  function traceDep(name: string): void {
+    if (visited.has(name)) return
+    visited.add(name)
+
+    const signal = graph.signals.find(s => s.name === name)
+    if (signal) {
+      const changedBy: WhyUpdateSource[] = []
+      for (const ev of events) {
+        for (const sc of ev.setterCalls) {
+          if (sc.signal === name) {
+            changedBy.push({
+              handler: ev.eventName,
+              setter: sc.setter,
+              elementContext: ev.elementContext,
+              via: sc.via,
+            })
+          }
+        }
+      }
+      deps.push({ name, kind: 'signal', dependsOn: [], changedBy })
+      return
+    }
+
+    const memo = graph.memos.find(m => m.name === name)
+    if (memo) {
+      deps.push({ name, kind: 'memo', dependsOn: memo.deps, changedBy: [] })
+      for (const dep of memo.deps) traceDep(dep)
+    }
+  }
+
+  for (const dep of binding.deps) traceDep(dep)
+
+  return {
+    binding: binding.label,
+    expression: binding.expression ?? null,
+    deps,
+  }
+}
+
+export function formatWhyUpdate(result: WhyUpdateResult): string {
+  const lines: string[] = []
+
+  lines.push(`${result.binding} updates because:`)
+  if (result.expression) {
+    lines.push(`  ${result.expression}`)
+  }
+
+  for (const dep of result.deps) {
+    lines.push('')
+    if (dep.kind === 'memo') {
+      lines.push(`${dep.name} depends on:`)
+      for (const d of dep.dependsOn) lines.push(`  ${d}`)
+    } else {
+      lines.push(`${dep.name} changes from:`)
+      if (dep.changedBy.length === 0) {
+        lines.push('  (no event handlers found)')
+      }
+      for (const src of dep.changedBy) {
+        const chain = src.via
+          ? `${src.elementContext} ${src.handler} -> ${src.via} -> ${src.setter}`
+          : `${src.elementContext} ${src.handler} -> ${src.setter}`
+        lines.push(`  ${chain}`)
+      }
+    }
+  }
+
+  return lines.join('\n')
 }
 
 // =============================================================================

--- a/packages/jsx/src/debug.ts
+++ b/packages/jsx/src/debug.ts
@@ -181,6 +181,7 @@ export interface WhyUpdateResult {
   binding: string
   expression: string | null
   deps: WhyUpdateDep[]
+  ambiguous?: Array<{ label: string; slotId: string }>
 }
 
 export interface WhyUpdateDep {
@@ -922,12 +923,20 @@ export function buildWhyUpdate(
 ): WhyUpdateResult | null {
   const { graph, ir } = buildComponentAnalysis(source, filePath, componentName)
 
-  const binding = graph.domBindings.find(d =>
+  const matches = graph.domBindings.filter(d =>
     d.label === bindingLabel ||
-    d.slotId === bindingLabel ||
-    (d.jsxPreview && d.jsxPreview.includes(bindingLabel)),
+    d.slotId === bindingLabel,
   )
-  if (!binding) return null
+  if (matches.length === 0) return null
+  if (matches.length > 1) {
+    return {
+      binding: bindingLabel,
+      expression: null,
+      deps: [],
+      ambiguous: matches.map(d => ({ label: d.label, slotId: d.slotId })),
+    }
+  }
+  const binding = matches[0]
 
   const setterToSignal = new Map<string, string>()
   for (const s of ir.metadata.signals) {
@@ -971,8 +980,9 @@ export function buildWhyUpdate(
 
   for (const dep of binding.deps) traceDep(dep)
 
+  const stableId = binding.type === 'attribute' ? binding.label : binding.slotId
   return {
-    binding: binding.label,
+    binding: stableId,
     expression: binding.expression ?? null,
     deps,
   }

--- a/packages/jsx/src/debug.ts
+++ b/packages/jsx/src/debug.ts
@@ -181,6 +181,8 @@ export interface WhyUpdateResult {
   binding: string
   expression: string | null
   deps: WhyUpdateDep[]
+  classification?: 'reactive' | 'fallback'
+  wrapReason?: WrapReason
   ambiguous?: Array<{ label: string; slotId: string }>
 }
 
@@ -990,6 +992,8 @@ export function buildWhyUpdate(
     binding: stableId,
     expression: binding.expression ?? null,
     deps,
+    ...(binding.classification === 'fallback' && { classification: binding.classification as 'fallback' }),
+    ...(binding.wrapReason && { wrapReason: binding.wrapReason }),
   }
 }
 
@@ -999,6 +1003,12 @@ export function formatWhyUpdate(result: WhyUpdateResult): string {
   lines.push(`${result.binding} updates because:`)
   if (result.expression) {
     lines.push(`  ${result.expression}`)
+  }
+
+  if (result.classification === 'fallback') {
+    lines.push('')
+    lines.push(`note: this is a fallback-wrapped binding (${result.wrapReason ?? 'unknown'})`)
+    lines.push('  the compiler could not statically prove reactivity — deps are determined at runtime')
   }
 
   for (const dep of result.deps) {

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -250,16 +250,18 @@ export {
   buildGraphFromIR,
   buildEventSummary,
   buildLoopSummary,
+  buildWhyUpdate,
   traceUpdatePath,
   formatComponentGraph,
   formatUpdatePath,
   formatEventSummary,
   formatLoopSummary,
+  formatWhyUpdate,
   formatSignalTrace,
   generateStaticTrace,
   graphToJSON,
 } from './debug'
-export type { ComponentGraph, ComponentAnalysis, SignalNode, MemoNode, EffectNode, DomBinding, UpdatePath, SignalTrace, EventBinding, SetterRef, EventSummary, LoopInfo, LoopChildBinding, LoopSummary } from './debug'
+export type { ComponentGraph, ComponentAnalysis, SignalNode, MemoNode, EffectNode, DomBinding, UpdatePath, SignalTrace, EventBinding, SetterRef, EventSummary, LoopInfo, LoopChildBinding, LoopSummary, WhyUpdateResult, WhyUpdateDep, WhyUpdateSource } from './debug'
 export type { WrapReason } from './ir-to-client-js/reactivity'
 
 // HTML constants


### PR DESCRIPTION
## Summary

- Add `bf debug why-update <component> <binding>` command that traces a binding back to its root cause
- Answers "why does this UI update?" by showing: binding → expression → memo deps → signal → event handlers
- Resolves indirect setter calls through local functions
- Binding can be matched by label (`style`), slot ID (`s0`), or component prop (`Button.disabled`)

Stacked on #1614 (TODO 3). Part 4 of #1611.

## Example output

```
style updates because:
  color()

color changes from:
  Change button onClick -> setColor
```

## Test plan

- [x] 5 new tests: direct signal trace, memo chain, unknown binding, indirect setter, format output
- [x] All 62 tests pass locally

https://claude.ai/code/session_01CmyVMrRYnJHikzLsm4kJEu


---
_Generated by [Claude Code](https://claude.ai/code/session_01CmyVMrRYnJHikzLsm4kJEu)_