### PR TITLE
feat: improve `bf debug fallbacks` with source locations and reasons (#1611 TODO 5)

### DIFF
--- a/packages/cli/src/__tests__/debug-fallbacks.test.ts
+++ b/packages/cli/src/__tests__/debug-fallbacks.test.ts
@@ -79,19 +79,16 @@ describe('bf debug fallbacks', () => {
       await run([file], makeCtx(false))
       const output = logSpy.mock.calls.map(c => c[0]).join('\n')
       expect(output).toContain('1 fallback-wrapped expression')
-      // The text binding's slotId appears in the report line.
+      // The text binding's slotId appears in the label.
       expect(output).toMatch(/text "s\d+"/)
-      expect(output).toContain('~')
       // The actual expression text is printed so users can locate the
       // binding in their source without running `inspect` separately.
       expect(output).toContain('formatTitle(page)')
-      // `formatTitle(page)` triggers the AST-level `hasFunctionCalls` flag
-      // but not `callsReactiveGetters` (formatTitle isn't a known signal),
-      // so the emitter's wrap reason is `fallback-function-calls`. Surface
-      // that in the report so users can distinguish it from other fallback
-      // shapes (e.g., signal-like calls on non-reactive sources).
-      expect(output).toContain('[fallback-function-calls]')
-      // Guidance footer — helps the user know what to do next.
+      // Human-readable reason describes why the fallback was triggered.
+      expect(output).toContain('reason:')
+      expect(output).toContain('opaque function call')
+      // Actionable suggestion.
+      expect(output).toContain('suggestion:')
       expect(output).toContain('createMemo')
     } finally {
       logSpy.mockRestore()
@@ -121,11 +118,10 @@ describe('bf debug fallbacks', () => {
       const parsed = JSON.parse(output) as {
         componentName: string
         sourceFile: string
-        fallbacks: Array<{ classification: string; type: string; label: string; deps: string[]; slotId: string; expression?: string; wrapReason?: string }>
+        fallbacks: Array<{ classification: string; type: string; label: string; deps: string[]; slotId: string; expression?: string; wrapReason?: string; reason?: string; suggestion?: string; isEventHandler?: boolean }>
       }
       expect(parsed.componentName).toBe('Tag')
       expect(parsed.fallbacks.length).toBeGreaterThan(0)
-      // All entries must be fallbacks — reactive bindings are filtered out.
       for (const f of parsed.fallbacks) {
         expect(f.classification).toBe('fallback')
       }
@@ -134,11 +130,11 @@ describe('bf debug fallbacks', () => {
       expect(attrFallback!.label).toBe('class')
       expect(attrFallback!.deps).toEqual([])
       expect(attrFallback!.expression).toBe('format(label)')
-      // `format(label)` is an opaque call — AST flag `hasFunctionCalls` is
-      // set but `callsReactiveGetters` is not. Lock in the `wrapReason`
-      // vocabulary so editor integrations can switch on the enum without
-      // re-deriving it from the expression.
       expect(attrFallback!.wrapReason).toBe('fallback-function-calls')
+      // New fields: human-readable reason and suggestion
+      expect(attrFallback!.reason).toContain('opaque function call')
+      expect(attrFallback!.suggestion).toContain('createMemo')
+      expect(attrFallback!.isEventHandler).toBe(false)
     } finally {
       logSpy.mockRestore()
       rmSync(path.dirname(file), { recursive: true, force: true })

--- a/packages/cli/src/commands/debug-fallbacks.ts
+++ b/packages/cli/src/commands/debug-fallbacks.ts
@@ -2,15 +2,8 @@
 //
 // Lists every DOM binding whose `createEffect` came from the Solid-style
 // wrap-by-default fallback (#937) rather than from statically-proven
-// reactivity. These expressions are harmless — the effect runs once at init
-// and subscribes to whatever signals it happens to read at runtime, possibly
-// none — but they are candidates for optimisation: rewriting as
-// `createMemo` or inlining a known-reactive source makes the dependency
-// static and lets the emitter skip the fallback wrap entirely.
-//
-// Output parallels `bf debug trace`: short human-readable report by
-// default, full JSON under `--json`. Exits 0 even when no fallbacks are
-// found (an empty list is a useful signal on its own).
+// reactivity. Each entry shows source location, expression, human-readable
+// reason, runtime dependency analysis, and a suggestion for resolution.
 
 import { readFileSync } from 'fs'
 import type { CliContext } from '../context'
@@ -25,7 +18,7 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
     process.exit(1)
   }
 
-  const { buildComponentGraph } = await import('@barefootjs/jsx')
+  const { buildComponentGraph, describeFallback, formatFallbackExplanations } = await import('@barefootjs/jsx')
 
   const searched: string[] = []
   const resolved = resolveComponentSource(componentName, ctx, searched)
@@ -44,44 +37,26 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
     console.log(JSON.stringify({
       componentName: graph.componentName,
       sourceFile: graph.sourceFile,
-      fallbacks: fallbacks.map(f => ({
-        label: f.label,
-        slotId: f.slotId,
-        deps: f.deps,
-        type: f.type,
-        classification: f.classification,
-        ...(f.expression !== undefined && { expression: f.expression }),
-        ...(f.wrapReason !== undefined && { wrapReason: f.wrapReason }),
-      })),
+      fallbacks: fallbacks.map(f => {
+        const ex = describeFallback(f)
+        return {
+          label: f.label,
+          slotId: f.slotId,
+          deps: f.deps,
+          type: f.type,
+          classification: f.classification,
+          ...(f.expression !== undefined && { expression: f.expression }),
+          ...(f.wrapReason !== undefined && { wrapReason: f.wrapReason }),
+          reason: ex.reason,
+          runtimeDeps: ex.runtimeDeps,
+          suggestion: ex.suggestion,
+          isEventHandler: ex.isEventHandler,
+          ...(ex.loc && { loc: ex.loc }),
+        }
+      }),
     }, null, 2))
     return
   }
 
-  if (fallbacks.length === 0) {
-    console.log(`${graph.componentName} — no fallback-wrapped expressions.`)
-    return
-  }
-
-  console.log(`${graph.componentName} — ${fallbacks.length} fallback-wrapped expression(s)`)
-  // Column-align the `~ expression` column so the eye scans down the
-  // expressions rather than the labels. Width covers the longest
-  // `type "id"` cell across this component's fallbacks.
-  const cells = fallbacks.map(f => {
-    const id = f.type === 'attribute' ? f.label : f.slotId
-    return { f, cell: `${f.type} "${id}"` }
-  })
-  const width = cells.reduce((w, c) => Math.max(w, c.cell.length), 0)
-  for (const { f, cell } of cells) {
-    const expr = f.expression ?? '(expression not captured)'
-    // Reason is appended at EOL so the `~ expression` column stays aligned
-    // for the eye-scan case; debuggers who care about *why* the wrap fired
-    // can read the bracketed tag on the right.
-    const reason = f.wrapReason ? `  [${f.wrapReason}]` : ''
-    console.log(`  ${cell.padEnd(width)}  ~ ${expr}${reason}`)
-  }
-  console.log()
-  console.log('Fallback wraps run one createEffect per expression. Each subscribes to')
-  console.log('whatever signals it happens to read at runtime (possibly none).')
-  console.log('Rewrite the expression as a createMemo to make the dependency static,')
-  console.log('or inline a known-reactive source so the emitter can prove it.')
+  console.log(formatFallbackExplanations(graph.componentName, graph.sourceFile, fallbacks))
 }

--- a/packages/cli/src/commands/debug-fallbacks.ts
+++ b/packages/cli/src/commands/debug-fallbacks.ts
@@ -31,7 +31,9 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
 
   const source = readFileSync(resolved.filePath, 'utf-8')
   const graph = buildComponentGraph(source, resolved.filePath, resolved.componentName)
-  const fallbacks = graph.domBindings.filter(d => d.classification === 'fallback')
+  const isEventHandlerProp = (d: { type: string; label: string }) =>
+    d.type === 'attribute' && /^on[A-Z]/.test(d.label.split('.').pop() ?? '')
+  const fallbacks = graph.domBindings.filter(d => d.classification === 'fallback' && !isEventHandlerProp(d))
 
   if (ctx.jsonFlag) {
     console.log(JSON.stringify({
@@ -58,5 +60,5 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
     return
   }
 
-  console.log(formatFallbackExplanations(graph.componentName, graph.sourceFile, fallbacks))
+  console.log(formatFallbackExplanations(graph.componentName, fallbacks))
 }

--- a/packages/jsx/src/__tests__/debug.test.ts
+++ b/packages/jsx/src/__tests__/debug.test.ts
@@ -1322,7 +1322,7 @@ describe('formatFallbackExplanations', () => {
     `
     const graph = buildComponentGraph(source, 'Page.tsx')
     const fallbacks = graph.domBindings.filter(d => d.classification === 'fallback')
-    const output = formatFallbackExplanations(graph.componentName, graph.sourceFile, fallbacks)
+    const output = formatFallbackExplanations(graph.componentName, fallbacks)
     expect(output).toContain('fallback:')
     expect(output).toContain('expression:')
     expect(output).toContain('reason:')
@@ -1331,7 +1331,7 @@ describe('formatFallbackExplanations', () => {
   })
 
   test('returns clean message for zero fallbacks', () => {
-    const output = formatFallbackExplanations('Counter', 'Counter.tsx', [])
+    const output = formatFallbackExplanations('Counter', [])
     expect(output).toContain('no fallback-wrapped expressions')
   })
 })

--- a/packages/jsx/src/__tests__/debug.test.ts
+++ b/packages/jsx/src/__tests__/debug.test.ts
@@ -21,6 +21,8 @@ import {
   formatSignalTrace,
   generateStaticTrace,
   graphToJSON,
+  describeFallback,
+  formatFallbackExplanations,
 } from '../debug'
 
 const counterSource = `
@@ -1123,5 +1125,102 @@ describe('formatWhyUpdate', () => {
     expect(output).toContain('style updates because:')
     expect(output).toContain('color changes from:')
     expect(output).toContain('setColor')
+  })
+})
+
+// =============================================================================
+// Fallback explanations (bf debug fallbacks improved, #1611 TODO 5)
+// =============================================================================
+
+describe('describeFallback', () => {
+  test('provides human-readable reason for opaque function call', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { formatTitle } from './format'
+
+      export function Page() {
+        const [, setFoo] = createSignal(0)
+        const page = 'home'
+        return <h1 onClick={() => setFoo(1)}>{formatTitle(page)}</h1>
+      }
+    `
+    const graph = buildComponentGraph(source, 'Page.tsx')
+    const fallback = graph.domBindings.find(d => d.classification === 'fallback' && d.type === 'text')
+    expect(fallback).toBeDefined()
+    const ex = describeFallback(fallback!)
+    expect(ex.reason).toContain('opaque function call')
+    expect(ex.reason).toContain('text interpolation')
+    expect(ex.suggestion).toContain('createMemo')
+    expect(ex.isEventHandler).toBe(false)
+  })
+
+  test('identifies event handler props as safe fallbacks', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { Button } from './Button'
+
+      export function Counter() {
+        const [count, setCount] = createSignal(0)
+        return <Button onClick={() => setCount(0)}>Reset</Button>
+      }
+    `
+    const graph = buildComponentGraph(source, 'Counter.tsx')
+    const fallback = graph.domBindings.find(d =>
+      d.classification === 'fallback' && d.label.includes('onClick'),
+    )
+    expect(fallback).toBeDefined()
+    const ex = describeFallback(fallback!)
+    expect(ex.isEventHandler).toBe(true)
+    expect(ex.suggestion).toContain('safe to ignore')
+  })
+
+  test('includes source location', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { format } from './fmt'
+
+      export function Tag() {
+        const [, setFoo] = createSignal(0)
+        return <button class={format('x')} onClick={() => setFoo(1)}>x</button>
+      }
+    `
+    const graph = buildComponentGraph(source, 'Tag.tsx')
+    const fallback = graph.domBindings.find(d => d.classification === 'fallback' && d.type === 'attribute')
+    expect(fallback).toBeDefined()
+    const ex = describeFallback(fallback!)
+    expect(ex.loc).toBeDefined()
+    expect(ex.loc!.line).toBeGreaterThan(0)
+  })
+})
+
+describe('formatFallbackExplanations', () => {
+  test('produces detailed output with reason and suggestion', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { formatTitle } from './format'
+
+      export function Page() {
+        const [, setFoo] = createSignal(0)
+        const page = 'home'
+        return <h1 onClick={() => setFoo(1)}>{formatTitle(page)}</h1>
+      }
+    `
+    const graph = buildComponentGraph(source, 'Page.tsx')
+    const fallbacks = graph.domBindings.filter(d => d.classification === 'fallback')
+    const output = formatFallbackExplanations(graph.componentName, graph.sourceFile, fallbacks)
+    expect(output).toContain('fallback:')
+    expect(output).toContain('expression:')
+    expect(output).toContain('reason:')
+    expect(output).toContain('suggestion:')
+    expect(output).toContain('runtime deps:')
+  })
+
+  test('returns clean message for zero fallbacks', () => {
+    const output = formatFallbackExplanations('Counter', 'Counter.tsx', [])
+    expect(output).toContain('no fallback-wrapped expressions')
   })
 })

--- a/packages/jsx/src/debug.ts
+++ b/packages/jsx/src/debug.ts
@@ -1184,6 +1184,114 @@ export function formatSignalTrace(traces: SignalTrace[]): string {
 }
 
 // =============================================================================
+// Fallback explanation
+// =============================================================================
+
+export interface FallbackExplanation {
+  label: string
+  expression: string
+  reason: string
+  runtimeDeps: string
+  suggestion: string
+  loc?: { file: string; line: number }
+  isEventHandler: boolean
+}
+
+export function describeFallback(binding: DomBinding): FallbackExplanation {
+  const isEventHandler = binding.type === 'event' ||
+    (binding.type === 'attribute' && /^on[A-Z]/.test(binding.label.split('.').pop() ?? ''))
+
+  const reason = describeFallbackReason(binding.wrapReason, binding.type, isEventHandler)
+  const runtimeDeps = binding.deps.length > 0
+    ? binding.deps.join(', ')
+    : isEventHandler
+      ? 'likely none (event handler captures values, does not track reactively)'
+      : 'unknown — subscribes to whatever signals it reads at runtime'
+
+  const suggestion = isEventHandler
+    ? 'event handlers intentionally capture scope values; this fallback is typically safe to ignore'
+    : binding.wrapReason === 'fallback-function-calls'
+      ? 'inline the reactive source or wrap the result in createMemo so the compiler can prove the dependency'
+      : binding.wrapReason === 'fallback-getter-calls'
+        ? 'the call looks like a signal getter but is not a known signal; verify the function is pure or extract as createMemo'
+        : 'rewrite to use a known signal/memo reference so the compiler can statically prove reactivity'
+
+  return {
+    label: binding.label,
+    expression: binding.expression ?? '(expression not captured)',
+    reason,
+    runtimeDeps,
+    suggestion,
+    loc: binding.loc ? { file: binding.loc.file, line: binding.loc.start.line } : undefined,
+    isEventHandler,
+  }
+}
+
+function describeFallbackReason(
+  wrapReason: WrapReason | undefined,
+  bindingType: string,
+  isEventHandler: boolean,
+): string {
+  const context = bindingType === 'attribute'
+    ? 'an attribute expression'
+    : bindingType === 'text'
+      ? 'a text interpolation'
+      : bindingType === 'conditional'
+        ? 'a conditional expression'
+        : bindingType === 'loop'
+          ? 'a loop array expression'
+          : 'an expression'
+
+  switch (wrapReason) {
+    case 'fallback-function-calls':
+      return isEventHandler
+        ? `function call in ${context} (event handler prop)`
+        : `opaque function call in ${context} — the compiler cannot prove it is reactive or pure`
+    case 'fallback-getter-calls':
+      return `call pattern resembles a signal getter in ${context}, but is not a recognized signal`
+    case 'string-reactive':
+      return `string-level match found a signal/memo name in ${context}`
+    case 'props-access':
+      return `props.xxx reference in ${context} — reactive via prop forwarding`
+    case 'proven-reactive':
+      return `statically proven reactive in ${context}`
+    default:
+      return `unknown fallback trigger in ${context}`
+  }
+}
+
+export function formatFallbackExplanations(
+  componentName: string,
+  sourceFile: string,
+  fallbacks: DomBinding[],
+): string {
+  const lines: string[] = []
+
+  if (fallbacks.length === 0) {
+    lines.push(`${componentName} — no fallback-wrapped expressions.`)
+    return lines.join('\n')
+  }
+
+  lines.push(`${componentName} — ${fallbacks.length} fallback-wrapped expression(s)`)
+
+  for (const f of fallbacks) {
+    const ex = describeFallback(f)
+    lines.push('')
+    if (ex.loc) {
+      const locFile = ex.loc.file.split('/').pop() ?? ex.loc.file
+      lines.push(`  ${locFile}:${ex.loc.line}`)
+    }
+    lines.push(`  ${ex.label} fallback:`)
+    lines.push(`    expression: ${ex.expression}`)
+    lines.push(`    reason: ${ex.reason}`)
+    lines.push(`    runtime deps: ${ex.runtimeDeps}`)
+    lines.push(`    suggestion: ${ex.suggestion}`)
+  }
+
+  return lines.join('\n')
+}
+
+// =============================================================================
 // Helpers
 // =============================================================================
 

--- a/packages/jsx/src/debug.ts
+++ b/packages/jsx/src/debug.ts
@@ -1351,7 +1351,6 @@ function describeFallbackReason(
 
 export function formatFallbackExplanations(
   componentName: string,
-  sourceFile: string,
   fallbacks: DomBinding[],
 ): string {
   const lines: string[] = []

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -257,11 +257,13 @@ export {
   formatEventSummary,
   formatLoopSummary,
   formatWhyUpdate,
+  describeFallback,
+  formatFallbackExplanations,
   formatSignalTrace,
   generateStaticTrace,
   graphToJSON,
 } from './debug'
-export type { ComponentGraph, ComponentAnalysis, SignalNode, MemoNode, EffectNode, DomBinding, UpdatePath, SignalTrace, EventBinding, SetterRef, EventSummary, LoopInfo, LoopChildBinding, LoopSummary, WhyUpdateResult, WhyUpdateDep, WhyUpdateSource } from './debug'
+export type { ComponentGraph, ComponentAnalysis, SignalNode, MemoNode, EffectNode, DomBinding, UpdatePath, SignalTrace, EventBinding, SetterRef, EventSummary, LoopInfo, LoopChildBinding, LoopSummary, WhyUpdateResult, WhyUpdateDep, WhyUpdateSource, FallbackExplanation } from './debug'
 export type { WrapReason } from './ir-to-client-js/reactivity'
 
 // HTML constants


### PR DESCRIPTION
## Summary

- Replace terse `[fallback-function-calls]` tags with detailed, actionable explanations
- Each fallback now shows: source location, expression, human-readable reason, runtime deps, suggestion
- Distinguish event handler props (safe to ignore) from render bindings that need attention
- New `describeFallback()` and `formatFallbackExplanations()` API in debug module

Stacked on #1615 (TODO 4). Part 5 of #1611.

## Example output (before → after)

**Before:**
```
  attribute "style"  ~ getStyle(mode)  [fallback-function-calls]
```

**After:**
```
  Page.tsx:9
  style fallback:
    expression: getStyle(mode)
    reason: opaque function call in an attribute expression — the compiler cannot prove it is reactive or pure
    runtime deps: unknown — subscribes to whatever signals it reads at runtime
    suggestion: inline the reactive source or wrap the result in createMemo so the compiler can prove the dependency
```

## Test plan

- [x] 5 new tests: human-readable reasons, event handler detection, source locations, format output, empty case
- [x] All 67 tests pass locally

https://claude.ai/code/session_01CmyVMrRYnJHikzLsm4kJEu


---
_Generated by [Claude Code](https://claude.ai/code/session_01CmyVMrRYnJHikzLsm4kJEu)_