### PR TITLE
feat: add `bf debug summary` command (#1611 TODO 6)

### DIFF
--- a/.changeset/debug-commands-extended.md
+++ b/.changeset/debug-commands-extended.md
@@ -1,0 +1,6 @@
+---
+"@barefootjs/jsx": minor
+"@barefootjs/cli": minor
+---
+
+Add source locations/JSX previews to DOM bindings, `bf debug loops`, `bf debug why-update`, `bf debug summary` commands, and improved `bf debug fallbacks` output

--- a/packages/cli/src/commands/debug-summary.ts
+++ b/packages/cli/src/commands/debug-summary.ts
@@ -1,0 +1,39 @@
+// bf debug summary <component> — Show hydration and size summary.
+//
+// Compact overview of a component's reactive footprint: signal count,
+// memo count, loops, event handlers, dynamic bindings, and hydration status.
+
+import { readFileSync } from 'fs'
+import type { CliContext } from '../context'
+import { resolveComponentSource } from '../lib/resolve-source'
+
+export async function run(args: string[], ctx: CliContext): Promise<void> {
+  const componentName = args[0]
+
+  if (!componentName) {
+    console.error('Error: Component name required.')
+    console.error('Usage: bf debug summary <component> [--json]')
+    process.exit(1)
+  }
+
+  const { buildComponentSummary, formatComponentSummary } = await import('@barefootjs/jsx')
+
+  const searched: string[] = []
+  const resolved = resolveComponentSource(componentName, ctx, searched)
+  if (!resolved) {
+    console.error(`Error: Cannot find component "${componentName}".`)
+    console.error('Looked in:')
+    for (const p of searched) console.error(`  - ${p}`)
+    process.exit(1)
+  }
+
+  const source = readFileSync(resolved.filePath, 'utf-8')
+  const summary = buildComponentSummary(source, resolved.filePath, resolved.componentName)
+
+  if (ctx.jsonFlag) {
+    console.log(JSON.stringify(summary, null, 2))
+    return
+  }
+
+  console.log(formatComponentSummary(summary))
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -47,6 +47,7 @@ Debug:
   debug events <component>                    Show event handlers and their update paths
   debug loops <component>                     Show loop bindings grouped by source collection
   debug why-update <component> <binding>      Explain why a binding updates
+  debug summary <component>                   Show hydration and size summary
   debug fallbacks <component>                 Show wrap-by-default fallback bindings (#937)
   debug signals <component>                   Show signal initialization trace
 
@@ -162,8 +163,11 @@ switch (command) {
     } else if (sub === 'why-update') {
       const { run } = await import('./commands/debug-why-update')
       await run(rest, ctx)
+    } else if (sub === 'summary') {
+      const { run } = await import('./commands/debug-summary')
+      await run(rest, ctx)
     } else {
-      console.error('Usage: bf debug <graph|trace|fallbacks|signals|events|loops|why-update> ...')
+      console.error('Usage: bf debug <graph|trace|fallbacks|signals|events|loops|why-update|summary> ...')
       process.exit(1)
     }
     break

--- a/packages/jsx/src/__tests__/debug.test.ts
+++ b/packages/jsx/src/__tests__/debug.test.ts
@@ -23,6 +23,8 @@ import {
   graphToJSON,
   describeFallback,
   formatFallbackExplanations,
+  buildComponentSummary,
+  formatComponentSummary,
 } from '../debug'
 
 const counterSource = `
@@ -1222,5 +1224,68 @@ describe('formatFallbackExplanations', () => {
   test('returns clean message for zero fallbacks', () => {
     const output = formatFallbackExplanations('Counter', 'Counter.tsx', [])
     expect(output).toContain('no fallback-wrapped expressions')
+  })
+})
+
+// =============================================================================
+// Component summary (bf debug summary, #1611 TODO 6)
+// =============================================================================
+
+describe('buildComponentSummary', () => {
+  test('counts signals, memos, effects, and bindings for a client component', () => {
+    const summary = buildComponentSummary(dashboardSource, 'Dashboard.tsx')
+    expect(summary.componentName).toBe('Dashboard')
+    expect(summary.hydrated).toBe(true)
+    expect(summary.clientBundle).toBe('components/Dashboard.client.js')
+    expect(summary.signals).toBe(1)
+    expect(summary.memos).toBe(1)
+    expect(summary.effects).toBe(1)
+    expect(summary.eventHandlers).toBeGreaterThanOrEqual(1)
+    expect(summary.dynamicTextBindings).toBeGreaterThanOrEqual(1)
+  })
+
+  test('reports non-hydrated for stateless component', () => {
+    const source = `
+      export function Card(props: { title: string }) {
+        return <div>{props.title}</div>
+      }
+    `
+    const summary = buildComponentSummary(source, 'Card.tsx')
+    expect(summary.hydrated).toBe(false)
+    expect(summary.clientBundle).toBeNull()
+    expect(summary.signals).toBe(0)
+  })
+
+  test('counts loops', () => {
+    const summary = buildComponentSummary(todoSource, 'TodoList.tsx')
+    expect(summary.loops).toBeGreaterThanOrEqual(1)
+  })
+
+  test('counts fallbacks', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { formatTitle } from './format'
+
+      export function Page() {
+        const [, setFoo] = createSignal(0)
+        return <h1 onClick={() => setFoo(1)}>{formatTitle('x')}</h1>
+      }
+    `
+    const summary = buildComponentSummary(source, 'Page.tsx')
+    expect(summary.fallbacks).toBeGreaterThanOrEqual(1)
+  })
+})
+
+describe('formatComponentSummary', () => {
+  test('produces readable output', () => {
+    const summary = buildComponentSummary(dashboardSource, 'Dashboard.tsx')
+    const output = formatComponentSummary(summary)
+    expect(output).toContain('Dashboard')
+    expect(output).toContain('hydrated: yes')
+    expect(output).toContain('signals: 1')
+    expect(output).toContain('memos: 1')
+    expect(output).toContain('event handlers:')
+    expect(output).toContain('dynamic text bindings:')
   })
 })

--- a/packages/jsx/src/__tests__/debug.test.ts
+++ b/packages/jsx/src/__tests__/debug.test.ts
@@ -1347,7 +1347,7 @@ describe('buildComponentSummary', () => {
     const summary = buildComponentSummary(dashboardSource, 'Dashboard.tsx')
     expect(summary.componentName).toBe('Dashboard')
     expect(summary.hydrated).toBe(true)
-    expect(summary.clientBundle).toBe('components/Dashboard.client.js')
+    expect(summary.clientBundle).toBe('Dashboard.client.js')
     expect(summary.signals).toBe(1)
     expect(summary.memos).toBe(1)
     expect(summary.effects).toBe(1)

--- a/packages/jsx/src/debug.ts
+++ b/packages/jsx/src/debug.ts
@@ -195,6 +195,24 @@ export interface WhyUpdateSource {
   via?: string
 }
 
+// -- Component summary types --------------------------------------------------
+
+export interface ComponentSummary {
+  componentName: string
+  sourceFile: string
+  hydrated: boolean
+  clientBundle: string | null
+  signals: number
+  memos: number
+  effects: number
+  loops: number
+  eventHandlers: number
+  dynamicTextBindings: number
+  dynamicAttributes: number
+  conditionals: number
+  fallbacks: number
+}
+
 // -- Component analysis (shared IR + graph) -----------------------------------
 
 export interface ComponentAnalysis {
@@ -1288,6 +1306,88 @@ export function formatFallbackExplanations(
     lines.push(`    suggestion: ${ex.suggestion}`)
   }
 
+  return lines.join('\n')
+}
+
+// =============================================================================
+// Component Summary (hydration/size overview)
+// =============================================================================
+
+export function buildComponentSummary(source: string, filePath: string, componentName?: string): ComponentSummary {
+  const { graph, ir } = buildComponentAnalysis(source, filePath, componentName)
+  const meta = ir.metadata
+  const isClient = meta.isClientComponent
+  const baseName = meta.componentName
+
+  let loopCount = 0
+  countNodeType(ir.root, 'loop', () => { loopCount++ })
+
+  let conditionalCount = 0
+  countNodeType(ir.root, 'conditional', () => { conditionalCount++ })
+
+  const eventHandlers = graph.domBindings.filter(d => d.type === 'event').length
+  const textBindings = graph.domBindings.filter(d => d.type === 'text').length
+  const attrBindings = graph.domBindings.filter(d => d.type === 'attribute').length
+  const fallbacks = graph.domBindings.filter(d => d.classification === 'fallback').length
+
+  return {
+    componentName: graph.componentName,
+    sourceFile: graph.sourceFile,
+    hydrated: isClient,
+    clientBundle: isClient ? `components/${baseName}.client.js` : null,
+    signals: graph.signals.length,
+    memos: graph.memos.length,
+    effects: graph.effects.length,
+    loops: loopCount,
+    eventHandlers,
+    dynamicTextBindings: textBindings,
+    dynamicAttributes: attrBindings,
+    conditionals: conditionalCount,
+    fallbacks,
+  }
+}
+
+function countNodeType(node: IRNode, targetType: string, cb: () => void): void {
+  if (node.type === targetType) cb()
+  switch (node.type) {
+    case 'element':
+    case 'fragment':
+    case 'provider':
+      for (const child of node.children) countNodeType(child, targetType, cb)
+      break
+    case 'component':
+      for (const child of node.children) countNodeType(child, targetType, cb)
+      break
+    case 'conditional':
+      countNodeType(node.whenTrue, targetType, cb)
+      countNodeType(node.whenFalse, targetType, cb)
+      break
+    case 'loop':
+      for (const child of node.children) countNodeType(child, targetType, cb)
+      break
+    case 'if-statement':
+      countNodeType(node.consequent, targetType, cb)
+      if (node.alternate) countNodeType(node.alternate, targetType, cb)
+      break
+  }
+}
+
+export function formatComponentSummary(summary: ComponentSummary): string {
+  const lines: string[] = []
+  lines.push(summary.componentName)
+  lines.push(`  hydrated: ${summary.hydrated ? 'yes' : 'no'}`)
+  if (summary.clientBundle) {
+    lines.push(`  client bundle: ${summary.clientBundle}`)
+  }
+  lines.push(`  signals: ${summary.signals}`)
+  lines.push(`  memos: ${summary.memos}`)
+  if (summary.effects > 0) lines.push(`  effects: ${summary.effects}`)
+  lines.push(`  loops: ${summary.loops}`)
+  lines.push(`  event handlers: ${summary.eventHandlers}`)
+  lines.push(`  dynamic text bindings: ${summary.dynamicTextBindings}`)
+  lines.push(`  dynamic attributes: ${summary.dynamicAttributes}`)
+  if (summary.conditionals > 0) lines.push(`  conditionals: ${summary.conditionals}`)
+  if (summary.fallbacks > 0) lines.push(`  fallbacks: ${summary.fallbacks}`)
   return lines.join('\n')
 }
 

--- a/packages/jsx/src/debug.ts
+++ b/packages/jsx/src/debug.ts
@@ -1404,8 +1404,9 @@ export function formatFallbackExplanations(
 export function buildComponentSummary(source: string, filePath: string, componentName?: string): ComponentSummary {
   const { graph, ir } = buildComponentAnalysis(source, filePath, componentName)
   const meta = ir.metadata
-  const isClient = meta.isClientComponent
-  const baseName = meta.componentName
+  const clientNeeds = analyzeClientNeeds(ir)
+  const hasReactiveState = meta.signals.length > 0 || meta.memos.length > 0 || meta.effects.length > 0
+  const needsClient = clientNeeds.needsInit && hasReactiveState
 
   let loopCount = 0
   countNodeType(ir.root, 'loop', () => { loopCount++ })
@@ -1418,11 +1419,17 @@ export function buildComponentSummary(source: string, filePath: string, componen
   const attrBindings = graph.domBindings.filter(d => d.type === 'attribute').length
   const fallbacks = graph.domBindings.filter(d => d.classification === 'fallback').length
 
+  let clientBundle: string | null = null
+  if (needsClient) {
+    const base = filePath.replace(/\.[^.]+$/, '').split('/').pop() ?? meta.componentName
+    clientBundle = `${base}.client.js`
+  }
+
   return {
     componentName: graph.componentName,
     sourceFile: graph.sourceFile,
-    hydrated: isClient,
-    clientBundle: isClient ? `components/${baseName}.client.js` : null,
+    hydrated: needsClient,
+    clientBundle,
     signals: graph.signals.length,
     memos: graph.memos.length,
     effects: graph.effects.length,
@@ -1456,6 +1463,10 @@ function countNodeType(node: IRNode, targetType: string, cb: () => void): void {
     case 'if-statement':
       countNodeType(node.consequent, targetType, cb)
       if (node.alternate) countNodeType(node.alternate, targetType, cb)
+      break
+    case 'async':
+      countNodeType(node.fallback, targetType, cb)
+      for (const child of node.children) countNodeType(child, targetType, cb)
       break
   }
 }

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -259,11 +259,13 @@ export {
   formatWhyUpdate,
   describeFallback,
   formatFallbackExplanations,
+  buildComponentSummary,
+  formatComponentSummary,
   formatSignalTrace,
   generateStaticTrace,
   graphToJSON,
 } from './debug'
-export type { ComponentGraph, ComponentAnalysis, SignalNode, MemoNode, EffectNode, DomBinding, UpdatePath, SignalTrace, EventBinding, SetterRef, EventSummary, LoopInfo, LoopChildBinding, LoopSummary, WhyUpdateResult, WhyUpdateDep, WhyUpdateSource, FallbackExplanation } from './debug'
+export type { ComponentGraph, ComponentAnalysis, SignalNode, MemoNode, EffectNode, DomBinding, UpdatePath, SignalTrace, EventBinding, SetterRef, EventSummary, LoopInfo, LoopChildBinding, LoopSummary, WhyUpdateResult, WhyUpdateDep, WhyUpdateSource, FallbackExplanation, ComponentSummary } from './debug'
 export type { WrapReason } from './ir-to-client-js/reactivity'
 
 // HTML constants


### PR DESCRIPTION
## Summary

- Add `bf debug summary <component>` command showing compact reactive footprint overview
- Reports: hydration status, client bundle path, signal/memo/effect counts, loops, event handlers, dynamic text/attribute bindings, conditionals, fallback count

Stacked on #1616 (TODO 5). Part 6 of #1611 — completes all TODOs.

## Example output

```
Dashboard
  hydrated: yes
  client bundle: components/Dashboard.client.js
  signals: 1
  memos: 1
  effects: 1
  loops: 0
  event handlers: 1
  dynamic text bindings: 2
  dynamic attributes: 0
```

## Test plan

- [x] 5 new tests: client component counts, stateless component, loop counting, fallback counting, format output
- [x] All 77 tests pass locally (across debug.test.ts + debug-fallbacks.test.ts)

## Stack overview (#1611)

1. #1612 — `bf debug events` ✅
2. #1613 — Source locations + JSX previews ✅
3. #1614 — `bf debug loops` ✅
4. #1615 — `bf debug why-update` ✅
5. #1616 — Improved `bf debug fallbacks` ✅
6. This PR — `bf debug summary` ✅

https://claude.ai/code/session_01CmyVMrRYnJHikzLsm4kJEu


---
_Generated by [Claude Code](https://claude.ai/code/session_01CmyVMrRYnJHikzLsm4kJEu)_