### PR TITLE
fix(ci): correct version comments for bumped actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,14 +43,14 @@ jobs:
           bun-version: latest
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24'
 
       - run: bun install
 
       - name: Changesets — version or publish
-        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.4.9
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           version: bunx changeset version
           publish: bun run release:publish


### PR DESCRIPTION
## Summary

- Dependabot PR #1618 updated SHA pins for `actions/setup-node` (→ v6.4.0) and `changesets/action` (→ v1.8.0), but left the inline version comments stale
- `actions/setup-node`: `# v4` → `# v6`
- `changesets/action`: `# v1.4.9` → `# v1.8.0`

## Test plan

- [ ] Verify the version comments match the actual tagged versions for each SHA
- [ ] Confirm release workflow runs correctly after merge

https://claude.ai/code/session_01UzR3vdo7HM778Qkef69wVZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzR3vdo7HM778Qkef69wVZ)_