### PR TITLE
fix: revert accidental 1.0.0 → 0.2.0

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,6 +7,9 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  },
   "ignore": [
     "@barefootjs/adapter-tests",
     "@barefootjs/preview",

--- a/packages/adapter-go-template/CHANGELOG.md
+++ b/packages/adapter-go-template/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @barefootjs/go-template
 
-## 1.0.0
+## 0.2.0
 
 ### Minor Changes
 
@@ -13,7 +13,7 @@
 - Updated dependencies [bff7df6]
 - Updated dependencies [31ce089]
 - Updated dependencies [89a6ad5]
-  - @barefootjs/jsx@1.0.0
+  - @barefootjs/jsx@0.2.0
 
 ## 0.1.3
 

--- a/packages/adapter-go-template/package.json
+++ b/packages/adapter-go-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/go-template",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "description": "Go html/template adapter for BarefootJS - generates Go template files from IR",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/adapter-hono/CHANGELOG.md
+++ b/packages/adapter-hono/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @barefootjs/hono
 
-## 1.0.0
+## 0.2.0
 
 ### Minor Changes
 
@@ -14,9 +14,9 @@
 - Updated dependencies [bff7df6]
 - Updated dependencies [31ce089]
 - Updated dependencies [89a6ad5]
-  - @barefootjs/shared@1.0.0
-  - @barefootjs/client@1.0.0
-  - @barefootjs/jsx@1.0.0
+  - @barefootjs/shared@0.2.0
+  - @barefootjs/client@0.2.0
+  - @barefootjs/jsx@0.2.0
 
 ## 0.1.3
 

--- a/packages/adapter-hono/package.json
+++ b/packages/adapter-hono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/hono",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "description": "Hono integration for BarefootJS",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/adapter-mojolicious/CHANGELOG.md
+++ b/packages/adapter-mojolicious/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @barefootjs/mojolicious
 
-## 1.0.0
+## 0.2.0
 
 ### Minor Changes
 
@@ -14,8 +14,8 @@
 - Updated dependencies [bff7df6]
 - Updated dependencies [31ce089]
 - Updated dependencies [89a6ad5]
-  - @barefootjs/shared@1.0.0
-  - @barefootjs/jsx@1.0.0
+  - @barefootjs/shared@0.2.0
+  - @barefootjs/jsx@0.2.0
 
 ## 0.1.3
 

--- a/packages/adapter-mojolicious/package.json
+++ b/packages/adapter-mojolicious/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/mojolicious",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "description": "Mojolicious EP template adapter for BarefootJS - generates .html.ep files from IR",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/chart/CHANGELOG.md
+++ b/packages/chart/CHANGELOG.md
@@ -1,12 +1,12 @@
 # @barefootjs/chart
 
-## 1.0.0
+## 0.2.0
 
 ### Patch Changes
 
 - Updated dependencies [2313724]
 - Updated dependencies [bac95e6]
-  - @barefootjs/client@1.0.0
+  - @barefootjs/client@0.2.0
 
 ## 0.1.3
 

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/chart",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "description": "SVG chart components for BarefootJS with signal-based reactivity",
   "type": "module",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "directory": "packages/chart"
   },
   "peerDependencies": {
-    "@barefootjs/client": ">=1.0.0"
+    "@barefootjs/client": ">=0.2.0"
   },
   "dependencies": {
     "d3-array": "^3.2.4",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @barefootjs/cli
 
-## 1.0.0
+## 0.2.0
 
 ### Minor Changes
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/cli",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "description": "CLI for agent-driven UI component discovery and scaffolding",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @barefootjs/client
 
-## 1.0.0
+## 0.2.0
 
 ### Patch Changes
 
@@ -12,8 +12,8 @@
 - Updated dependencies [bff7df6]
 - Updated dependencies [31ce089]
 - Updated dependencies [89a6ad5]
-  - @barefootjs/shared@1.0.0
-  - @barefootjs/jsx@1.0.0
+  - @barefootjs/shared@0.2.0
+  - @barefootjs/jsx@0.2.0
 
 ## 0.1.3
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/client",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "description": "BarefootJS client package: reactive primitives (SSR-safe) plus browser runtime under the `/runtime` subpath (compiler target)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/create-barefootjs/CHANGELOG.md
+++ b/packages/create-barefootjs/CHANGELOG.md
@@ -1,12 +1,12 @@
 # create-barefootjs
 
-## 1.0.0
+## 0.2.0
 
 ### Patch Changes
 
 - Updated dependencies [4e4d31a]
 - Updated dependencies [57262dd]
-  - @barefootjs/cli@1.0.0
+  - @barefootjs/cli@0.2.0
 
 ## 0.1.3
 

--- a/packages/create-barefootjs/package.json
+++ b/packages/create-barefootjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-barefootjs",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "description": "Scaffold a new BarefootJS app — `npm create barefootjs@latest <dir>`",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/form/CHANGELOG.md
+++ b/packages/form/CHANGELOG.md
@@ -1,12 +1,12 @@
 # @barefootjs/form
 
-## 1.0.0
+## 0.2.0
 
 ### Patch Changes
 
 - Updated dependencies [2313724]
 - Updated dependencies [bac95e6]
-  - @barefootjs/client@1.0.0
+  - @barefootjs/client@0.2.0
 
 ## 0.1.3
 

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/form",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "description": "Signal-based form management for BarefootJS",
   "type": "module",
   "main": "./dist/index.js",
@@ -36,7 +36,7 @@
     "directory": "packages/form"
   },
   "peerDependencies": {
-    "@barefootjs/client": ">=1.0.0",
+    "@barefootjs/client": ">=0.2.0",
     "@standard-schema/spec": "^1.0.0"
   },
   "dependencies": {

--- a/packages/jsx/CHANGELOG.md
+++ b/packages/jsx/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @barefootjs/jsx
 
-## 1.0.0
+## 0.2.0
 
 ### Minor Changes
 
@@ -14,8 +14,8 @@
 - 31ce089: Fix prop name substitution corrupting string literals in client JS (e.g. `"size-9"` → `"(_p.size ?? 'default')-9"`)
 - Updated dependencies [2313724]
 - Updated dependencies [bac95e6]
-  - @barefootjs/shared@1.0.0
-  - @barefootjs/client@1.0.0
+  - @barefootjs/shared@0.2.0
+  - @barefootjs/client@0.2.0
 
 ## 0.1.3
 

--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/jsx",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "description": "JSX compiler for BarefootJS - transforms JSX to server HTML + client JS",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @barefootjs/shared
 
-## 1.0.0
+## 0.2.0
 
 ### Patch Changes
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/shared",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "description": "Shared constants for BarefootJS compiler and runtime",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/streaming/CHANGELOG.md
+++ b/packages/streaming/CHANGELOG.md
@@ -1,12 +1,12 @@
 # @barefootjs/streaming
 
-## 1.0.0
+## 0.2.0
 
 ### Patch Changes
 
 - Updated dependencies [2313724]
 - Updated dependencies [bac95e6]
-  - @barefootjs/shared@1.0.0
+  - @barefootjs/shared@0.2.0
 
 ## 0.1.3
 

--- a/packages/streaming/package.json
+++ b/packages/streaming/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/streaming",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "description": "Backend-agnostic SSR streaming helpers for BarefootJS",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @barefootjs/test
 
-## 1.0.0
+## 0.2.0
 
 ### Patch Changes
 
@@ -9,7 +9,7 @@
 - Updated dependencies [bff7df6]
 - Updated dependencies [31ce089]
 - Updated dependencies [89a6ad5]
-  - @barefootjs/jsx@1.0.0
+  - @barefootjs/jsx@0.2.0
 
 ## 0.1.3
 

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/test",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "description": "Test utilities for BarefootJS - IR-based component testing without a browser",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/xyflow/CHANGELOG.md
+++ b/packages/xyflow/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @barefootjs/xyflow
 
-## 1.0.0
+## 0.2.0
 
 ### Patch Changes
 
@@ -10,8 +10,8 @@
 - Updated dependencies [bff7df6]
 - Updated dependencies [31ce089]
 - Updated dependencies [89a6ad5]
-  - @barefootjs/client@1.0.0
-  - @barefootjs/jsx@1.0.0
+  - @barefootjs/client@0.2.0
+  - @barefootjs/jsx@0.2.0
 
 ## 0.1.3
 

--- a/packages/xyflow/package.json
+++ b/packages/xyflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barefootjs/xyflow",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "description": "Signal-based xyflow wrapper for BarefootJS",
   "type": "module",
   "main": "./dist/index.js",
@@ -44,8 +44,8 @@
     "directory": "packages/xyflow"
   },
   "peerDependencies": {
-    "@barefootjs/client": ">=1.0.0",
-    "@barefootjs/jsx": ">=1.0.0"
+    "@barefootjs/client": ">=0.2.0",
+    "@barefootjs/jsx": ">=0.2.0"
   },
   "dependencies": {
     "@xyflow/system": "^0.0.76"


### PR DESCRIPTION
## Summary

PR #1598 (Changesets release) bumped all packages from 0.1.3 to 1.0.0 instead of 0.2.0.

**Root cause:** Changesets' default `peerDependency` escalation. When `@barefootjs/jsx` got a `minor` bump, packages with `jsx` as a `peerDependency` (e.g. `@barefootjs/client`) were auto-promoted to `major`. The `fixed` group then applied `major` to all packages → `semver.inc('0.1.3', 'major')` = `1.0.0`.

**Fix:**
- Revert all package versions: `1.0.0` → `0.2.0`
- Revert peerDependency ranges: `>=1.0.0` → `>=0.2.0`
- Fix all CHANGELOGs to reflect `0.2.0`
- Add `onlyUpdatePeerDependentsWhenOutOfRange: true` to `.changeset/config.json` to prevent recurrence

## Remaining manual steps (after merge)

1. `npm unpublish @barefootjs/<pkg>@1.0.0` for each package (must be within 72h of publish)
2. Publish `0.2.0` (either re-run CI or manual `bun run release:publish`)

## Test plan

- [ ] Verify `changeset version` produces correct version with new config
- [ ] Verify npm unpublish succeeds for all 1.0.0 packages
- [ ] Verify 0.2.0 publish succeeds

https://claude.ai/code/session_01DcfPqkDv3b76sChA7vfT6r

---
_Generated by [Claude Code](https://claude.ai/code/session_01DcfPqkDv3b76sChA7vfT6r)_