### PR TITLE
fix: add --tag latest to publish script for version downgrade

### DIFF
--- a/scripts/changeset-publish.ts
+++ b/scripts/changeset-publish.ts
@@ -90,7 +90,7 @@ try {
     const tarball = resolve(pack.text().trim().split('\n').pop()!)
 
     // Step 2: publish tarball with npm (OIDC auth + provenance)
-    const pub = await $`npm publish ${tarball} --provenance --access public`.nothrow()
+    const pub = await $`npm publish ${tarball} --provenance --access public --tag latest`.nothrow()
     if (pub.exitCode !== 0) {
       errors.push(`${pkg.name}@${pkg.version} (publish)`)
       continue


### PR DESCRIPTION
## Summary

- Add `--tag latest` to `npm publish` in `changeset-publish.ts`
- npm 11+ refuses to implicitly assign `latest` when a higher version (1.0.0) exists on the registry
- Without this, `0.2.0` publish fails for the 4 packages where `1.0.0` couldn't be unpublished (shared, jsx, test, cli)

## Context

Follow-up to #1620. After unpublishing 9/13 packages' 1.0.0, the remaining 4 fail to publish 0.2.0 because npm sees the existing 1.0.0 and won't auto-tag.

`--tag latest` is safe for normal releases too (it's redundant when publishing a higher version).

## After merge

1. CI re-run will publish the remaining 4 packages as 0.2.0
2. Then run: `npm deprecate \"<pkg>@1.0.0\" \"Accidental release. Use 0.2.0.\"` for shared, jsx, test, cli

https://claude.ai/code/session_01DcfPqkDv3b76sChA7vfT6r

---
_Generated by [Claude Code](https://claude.ai/code/session_01DcfPqkDv3b76sChA7vfT6r)_