### PR TITLE
feat: add EventHandler wiring to TestNode in renderToTest (#1625)

### DIFF
--- a/.changeset/event-handler-wiring.md
+++ b/.changeset/event-handler-wiring.md
@@ -1,0 +1,6 @@
+---
+"@barefootjs/test": minor
+"@barefootjs/jsx": patch
+---
+
+Add EventHandler wiring to TestNode: onClick, onInput, onChange, onSubmit shorthands and on() fallback

--- a/packages/jsx/src/debug.ts
+++ b/packages/jsx/src/debug.ts
@@ -422,11 +422,11 @@ export function buildEventSummary(source: string, filePath: string, componentNam
   }
 }
 
-function escapeForIdBoundary(name: string): string {
+export function escapeForIdBoundary(name: string): string {
   return name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
-function makeIdCallRegex(name: string): RegExp {
+export function makeIdCallRegex(name: string): RegExp {
   return new RegExp(`(?:^|[^\\w$])${escapeForIdBoundary(name)}\\s*\\(`)
 }
 
@@ -434,7 +434,7 @@ function makeIdRefRegex(name: string): RegExp {
   return new RegExp(`(?:^|[^\\w$])${escapeForIdBoundary(name)}(?:[^\\w$]|$)`)
 }
 
-function buildLocalFunctionSetterMap(
+export function buildLocalFunctionSetterMap(
   meta: IRMetadata,
   setterToSignal: Map<string, string>,
 ): Map<string, string[]> {
@@ -537,7 +537,7 @@ function walkForEvents(
   }
 }
 
-function resolveSetters(
+export function resolveSetters(
   handler: string,
   setterToSignal: Map<string, string>,
   fnSetters: Map<string, string[]>,

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -264,6 +264,9 @@ export {
   formatSignalTrace,
   generateStaticTrace,
   graphToJSON,
+  resolveSetters,
+  buildLocalFunctionSetterMap,
+  makeIdCallRegex,
 } from './debug'
 export type { ComponentGraph, ComponentAnalysis, SignalNode, MemoNode, EffectNode, DomBinding, UpdatePath, SignalTrace, EventBinding, SetterRef, EventSummary, LoopInfo, LoopChildBinding, LoopSummary, WhyUpdateResult, WhyUpdateDep, WhyUpdateSource, FallbackExplanation, ComponentSummary } from './debug'
 export type { WrapReason } from './ir-to-client-js/reactivity'

--- a/packages/test/__tests__/event-handler-wiring.test.ts
+++ b/packages/test/__tests__/event-handler-wiring.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for EventHandler wiring on TestNode (#1625).
+ *
+ * Verifies that renderToTest exposes per-event setter information
+ * so tests can assert which event handler calls which setter.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { renderToTest } from '../src/index'
+
+describe('EventHandler wiring on TestNode', () => {
+  test('onClick exposes direct setter call', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Counter() {
+        const [count, setCount] = createSignal(0)
+        return <button onClick={() => setCount(n => n + 1)}>+</button>
+      }
+    `
+    const result = renderToTest(source, 'Counter.tsx')
+    const btn = result.find({ tag: 'button' })
+    expect(btn).not.toBeNull()
+    expect(btn!.onClick).toBeDefined()
+    expect(btn!.onClick!.setters).toContain('setCount')
+    expect(btn!.onClick!.via).toHaveLength(0)
+  })
+
+  test('onClick exposes indirect setter via local function', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function TodoApp() {
+        const [todos, setTodos] = createSignal([])
+        function addTodo(text: string) {
+          setTodos(prev => [...prev, { text }])
+        }
+        return <button onClick={() => addTodo('new')}>Add</button>
+      }
+    `
+    const result = renderToTest(source, 'TodoApp.tsx')
+    const btn = result.find({ tag: 'button' })
+    expect(btn!.onClick!.setters).toContain('setTodos')
+    expect(btn!.onClick!.via).toContain('addTodo')
+  })
+
+  test('multiple events on same element are resolved independently', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Panel() {
+        const [selected, setSelected] = createSignal(0)
+        const [hovered, setHovered] = createSignal(0)
+        return (
+          <div
+            onClick={() => setSelected(1)}
+            onMouseEnter={() => setHovered(1)}
+          >content</div>
+        )
+      }
+    `
+    const result = renderToTest(source, 'Panel.tsx')
+    const div = result.find({ tag: 'div' })
+    expect(div!.onClick!.setters).toContain('setSelected')
+    expect(div!.onClick!.setters).not.toContain('setHovered')
+    expect(div!.on('mouseenter')!.setters).toContain('setHovered')
+    expect(div!.on('mouseenter')!.setters).not.toContain('setSelected')
+  })
+
+  test('onInput shorthand works', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Search() {
+        const [query, setQuery] = createSignal('')
+        return <input onInput={(e) => setQuery(e.target.value)} />
+      }
+    `
+    const result = renderToTest(source, 'Search.tsx')
+    const input = result.find({ tag: 'input' })
+    expect(input!.onInput).toBeDefined()
+    expect(input!.onInput!.setters).toContain('setQuery')
+  })
+
+  test('onChange shorthand works', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Select() {
+        const [value, setValue] = createSignal('a')
+        return <select onChange={(e) => setValue(e.target.value)}>
+          <option value="a">A</option>
+        </select>
+      }
+    `
+    const result = renderToTest(source, 'Select.tsx')
+    const sel = result.find({ tag: 'select' })
+    expect(sel!.onChange).toBeDefined()
+    expect(sel!.onChange!.setters).toContain('setValue')
+  })
+
+  test('onSubmit shorthand works', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Form() {
+        const [submitted, setSubmitted] = createSignal(false)
+        return <form onSubmit={() => setSubmitted(true)}>
+          <button type="submit">Go</button>
+        </form>
+      }
+    `
+    const result = renderToTest(source, 'Form.tsx')
+    const form = result.find({ tag: 'form' })
+    expect(form!.onSubmit).toBeDefined()
+    expect(form!.onSubmit!.setters).toContain('setSubmitted')
+  })
+
+  test('on() fallback returns handler for non-shorthand events', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Keyboard() {
+        const [key, setKey] = createSignal('')
+        return <input onKeyDown={(e) => setKey(e.key)} />
+      }
+    `
+    const result = renderToTest(source, 'Keyboard.tsx')
+    const input = result.find({ tag: 'input' })
+    expect(input!.on('keydown')).not.toBeNull()
+    expect(input!.on('keydown')!.setters).toContain('setKey')
+  })
+
+  test('on() returns null for unregistered events', () => {
+    const source = `
+      export function Static() {
+        return <button>Click</button>
+      }
+    `
+    const result = renderToTest(source, 'Static.tsx')
+    const btn = result.find({ tag: 'button' })
+    expect(btn!.onClick).toBeUndefined()
+    expect(btn!.on('click')).toBeNull()
+  })
+
+  test('handler with no setter calls returns empty setters', () => {
+    const source = `
+      export function Logger() {
+        return <button onClick={() => console.log('clicked')}>Log</button>
+      }
+    `
+    const result = renderToTest(source, 'Logger.tsx')
+    const btn = result.find({ tag: 'button' })
+    expect(btn!.onClick).toBeDefined()
+    expect(btn!.onClick!.setters).toHaveLength(0)
+  })
+
+  test('stateless component without signals still resolves events', () => {
+    const source = `
+      interface Props { onSort: () => void }
+      export function SortHeader({ onSort }: Props) {
+        return <th onClick={onSort}>Name</th>
+      }
+    `
+    const result = renderToTest(source, 'SortHeader.tsx')
+    const th = result.find({ tag: 'th' })
+    expect(th!.events).toContain('click')
+    expect(th!.onClick).toBeDefined()
+    expect(th!.onClick!.setters).toHaveLength(0)
+  })
+})

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -6,7 +6,7 @@ export { renderToTest } from './render'
 export type { TestResult } from './render'
 
 export { TestNode } from './test-node'
-export type { TestNodeData, TestNodeQuery } from './test-node'
+export type { TestNodeData, TestNodeQuery, EventHandler } from './test-node'
 
 export { toStructure } from './structure'
 

--- a/packages/test/src/ir-to-test-node.ts
+++ b/packages/test/src/ir-to-test-node.ts
@@ -17,42 +17,60 @@ import type {
   IRIfStatement,
   IRProvider,
   IRAsync,
+  IRMetadata,
 } from '@barefootjs/jsx'
+import { resolveSetters, buildLocalFunctionSetterMap, type SetterRef } from '@barefootjs/jsx'
 
 type IRAttribute = IRElement['attrs'][number]
 type AttrValue = IRAttribute['value']
 type TemplateAttr = Extract<AttrValue, { kind: 'template' }>
-import { TestNode } from './test-node'
+import { TestNode, type EventHandler } from './test-node'
 
-export function irNodeToTestNode(node: IRNode, constantMap?: Map<string, string>): TestNode {
-  const cmap = constantMap ?? new Map<string, string>()
-  return convert(node, cmap)
+interface ConvertContext {
+  cmap: Map<string, string>
+  setterToSignal: Map<string, string>
+  fnSetters: Map<string, string[]>
 }
 
-function convert(node: IRNode, cmap: Map<string, string>): TestNode {
+export function irNodeToTestNode(node: IRNode, constantMap?: Map<string, string>, metadata?: IRMetadata): TestNode {
+  const cmap = constantMap ?? new Map<string, string>()
+  const setterToSignal = new Map<string, string>()
+  const fnSetters = new Map<string, string[]>()
+  if (metadata) {
+    for (const s of metadata.signals) {
+      if (s.setter) setterToSignal.set(s.setter, s.getter)
+    }
+    for (const [k, v] of buildLocalFunctionSetterMap(metadata, setterToSignal)) {
+      fnSetters.set(k, v)
+    }
+  }
+  return convert(node, { cmap, setterToSignal, fnSetters })
+}
+
+function convert(node: IRNode, ctx: ConvertContext): TestNode {
   switch (node.type) {
     case 'element':
-      return convertElement(node, cmap)
+      return convertElement(node, ctx)
     case 'text':
       return convertText(node)
     case 'expression':
       return convertExpression(node)
     case 'conditional':
-      return convertConditional(node, cmap)
+      return convertConditional(node, ctx)
     case 'loop':
-      return convertLoop(node, cmap)
+      return convertLoop(node, ctx)
     case 'component':
-      return convertComponent(node, cmap)
+      return convertComponent(node, ctx)
     case 'fragment':
-      return convertFragment(node, cmap)
+      return convertFragment(node, ctx)
     case 'slot':
       return convertSlot(node)
     case 'if-statement':
-      return convertIfStatement(node, cmap)
+      return convertIfStatement(node, ctx)
     case 'provider':
-      return convertProvider(node, cmap)
+      return convertProvider(node, ctx)
     case 'async':
-      return convertAsync(node, cmap)
+      return convertAsync(node, ctx)
     default: {
       const _exhaustive: never = node
       throw new Error(`Unhandled IR node type: ${(_exhaustive as IRNode).type}`)
@@ -64,7 +82,7 @@ function convert(node: IRNode, cmap: Map<string, string>): TestNode {
 // Element
 // ---------------------------------------------------------------------------
 
-function convertElement(node: IRElement, cmap: Map<string, string>): TestNode {
+function convertElement(node: IRElement, ctx: ConvertContext): TestNode {
   const props: Record<string, string | boolean | null> = {}
   const aria: Record<string, string> = {}
   let role: string | null = null
@@ -77,8 +95,8 @@ function convertElement(node: IRElement, cmap: Map<string, string>): TestNode {
     if (attr.name === 'className' || attr.name === 'class') {
       if (typeof value === 'string') {
         const isDynamic = attr.value.kind === 'expression' || attr.value.kind === 'template' || attr.value.kind === 'spread'
-        if (isDynamic && cmap.size > 0) {
-          const resolved = resolveClassValue(value, cmap)
+        if (isDynamic && ctx.cmap.size > 0) {
+          const resolved = resolveClassValue(value, ctx.cmap)
           if (resolved !== null) {
             classes = resolved.split(/\s+/).filter(Boolean)
             continue
@@ -110,7 +128,12 @@ function convertElement(node: IRElement, cmap: Map<string, string>): TestNode {
   }
 
   const events = node.events.map(e => e.name)
-  const children = node.children.map(c => convert(c, cmap))
+  const handlers: Record<string, EventHandler> = {}
+  for (const event of node.events) {
+    const refs = resolveSetters(event.handler, ctx.setterToSignal, ctx.fnSetters)
+    handlers[event.name] = refsToHandler(refs)
+  }
+  const children = node.children.map(c => convert(c, ctx))
 
   return new TestNode({
     tag: node.tag,
@@ -123,6 +146,7 @@ function convertElement(node: IRElement, cmap: Map<string, string>): TestNode {
     aria,
     dataState,
     events,
+    handlers,
     reactive: false,
     componentName: null,
   })
@@ -144,6 +168,7 @@ function convertText(node: IRText): TestNode {
     aria: {},
     dataState: null,
     events: [],
+    handlers: {},
     reactive: false,
     componentName: null,
   })
@@ -165,6 +190,7 @@ function convertExpression(node: IRExpression): TestNode {
     aria: {},
     dataState: null,
     events: [],
+    handlers: {},
     reactive: node.reactive,
     componentName: null,
   })
@@ -174,10 +200,10 @@ function convertExpression(node: IRExpression): TestNode {
 // Conditional
 // ---------------------------------------------------------------------------
 
-function convertConditional(node: IRConditional, cmap: Map<string, string>): TestNode {
-  const children: TestNode[] = [convert(node.whenTrue, cmap)]
+function convertConditional(node: IRConditional, ctx: ConvertContext): TestNode {
+  const children: TestNode[] = [convert(node.whenTrue, ctx)]
   if (node.whenFalse) {
-    children.push(convert(node.whenFalse, cmap))
+    children.push(convert(node.whenFalse, ctx))
   }
 
   return new TestNode({
@@ -191,6 +217,7 @@ function convertConditional(node: IRConditional, cmap: Map<string, string>): Tes
     aria: {},
     dataState: null,
     events: [],
+    handlers: {},
     reactive: node.reactive,
     componentName: null,
   })
@@ -200,8 +227,8 @@ function convertConditional(node: IRConditional, cmap: Map<string, string>): Tes
 // Loop
 // ---------------------------------------------------------------------------
 
-function convertLoop(node: IRLoop, cmap: Map<string, string>): TestNode {
-  const children = node.children.map(c => convert(c, cmap))
+function convertLoop(node: IRLoop, ctx: ConvertContext): TestNode {
+  const children = node.children.map(c => convert(c, ctx))
 
   return new TestNode({
     tag: null,
@@ -214,6 +241,7 @@ function convertLoop(node: IRLoop, cmap: Map<string, string>): TestNode {
     aria: {},
     dataState: null,
     events: [],
+    handlers: {},
     reactive: false,
     componentName: null,
   })
@@ -223,7 +251,7 @@ function convertLoop(node: IRLoop, cmap: Map<string, string>): TestNode {
 // Component
 // ---------------------------------------------------------------------------
 
-function convertComponent(node: IRComponent, cmap: Map<string, string>): TestNode {
+function convertComponent(node: IRComponent, ctx: ConvertContext): TestNode {
   const props: Record<string, string | boolean | null> = {}
   for (const prop of node.props) {
     switch (prop.value.kind) {
@@ -247,7 +275,7 @@ function convertComponent(node: IRComponent, cmap: Map<string, string>): TestNod
     }
   }
 
-  const children = node.children.map(c => convert(c, cmap))
+  const children = node.children.map(c => convert(c, ctx))
 
   return new TestNode({
     tag: null,
@@ -260,6 +288,7 @@ function convertComponent(node: IRComponent, cmap: Map<string, string>): TestNod
     aria: {},
     dataState: null,
     events: [],
+    handlers: {},
     reactive: false,
     componentName: node.name,
   })
@@ -269,8 +298,8 @@ function convertComponent(node: IRComponent, cmap: Map<string, string>): TestNod
 // Fragment
 // ---------------------------------------------------------------------------
 
-function convertFragment(node: IRFragment, cmap: Map<string, string>): TestNode {
-  const children = node.children.map(c => convert(c, cmap))
+function convertFragment(node: IRFragment, ctx: ConvertContext): TestNode {
+  const children = node.children.map(c => convert(c, ctx))
 
   return new TestNode({
     tag: null,
@@ -283,6 +312,7 @@ function convertFragment(node: IRFragment, cmap: Map<string, string>): TestNode 
     aria: {},
     dataState: null,
     events: [],
+    handlers: {},
     reactive: false,
     componentName: null,
   })
@@ -304,6 +334,7 @@ function convertSlot(_node: IRSlot): TestNode {
     aria: {},
     dataState: null,
     events: [],
+    handlers: {},
     reactive: false,
     componentName: null,
   })
@@ -313,10 +344,10 @@ function convertSlot(_node: IRSlot): TestNode {
 // IfStatement
 // ---------------------------------------------------------------------------
 
-function convertIfStatement(node: IRIfStatement, cmap: Map<string, string>): TestNode {
-  const children: TestNode[] = [convert(node.consequent, cmap)]
+function convertIfStatement(node: IRIfStatement, ctx: ConvertContext): TestNode {
+  const children: TestNode[] = [convert(node.consequent, ctx)]
   if (node.alternate) {
-    children.push(convert(node.alternate, cmap))
+    children.push(convert(node.alternate, ctx))
   }
 
   return new TestNode({
@@ -330,6 +361,7 @@ function convertIfStatement(node: IRIfStatement, cmap: Map<string, string>): Tes
     aria: {},
     dataState: null,
     events: [],
+    handlers: {},
     reactive: false,
     componentName: null,
   })
@@ -339,9 +371,9 @@ function convertIfStatement(node: IRIfStatement, cmap: Map<string, string>): Tes
 // Provider
 // ---------------------------------------------------------------------------
 
-function convertProvider(node: IRProvider, cmap: Map<string, string>): TestNode {
+function convertProvider(node: IRProvider, ctx: ConvertContext): TestNode {
   // Transparent — just pass through children
-  const children = node.children.map(c => convert(c, cmap))
+  const children = node.children.map(c => convert(c, ctx))
 
   if (children.length === 1) return children[0]
 
@@ -356,6 +388,7 @@ function convertProvider(node: IRProvider, cmap: Map<string, string>): TestNode 
     aria: {},
     dataState: null,
     events: [],
+    handlers: {},
     reactive: false,
     componentName: null,
   })
@@ -365,9 +398,9 @@ function convertProvider(node: IRProvider, cmap: Map<string, string>): TestNode 
 // Async
 // ---------------------------------------------------------------------------
 
-function convertAsync(node: IRAsync, cmap: Map<string, string>): TestNode {
+function convertAsync(node: IRAsync, ctx: ConvertContext): TestNode {
   // Represent the resolved content as a fragment; tests assert on final state.
-  const children = node.children.map(c => convert(c, cmap))
+  const children = node.children.map(c => convert(c, ctx))
 
   return new TestNode({
     tag: null,
@@ -380,6 +413,7 @@ function convertAsync(node: IRAsync, cmap: Map<string, string>): TestNode {
     aria: {},
     dataState: null,
     events: [],
+    handlers: {},
     reactive: false,
     componentName: null,
   })
@@ -388,6 +422,16 @@ function convertAsync(node: IRAsync, cmap: Map<string, string>): TestNode {
 // ---------------------------------------------------------------------------
 // Constant-based class value resolution
 // ---------------------------------------------------------------------------
+
+function refsToHandler(refs: SetterRef[]): EventHandler {
+  const setters: string[] = []
+  const via: string[] = []
+  for (const ref of refs) {
+    setters.push(ref.setter)
+    if (ref.via && !via.includes(ref.via)) via.push(ref.via)
+  }
+  return { setters, via }
+}
 
 function resolveClassValue(value: string, cmap: Map<string, string>): string | null {
   // Simple identifier lookup

--- a/packages/test/src/render.ts
+++ b/packages/test/src/render.ts
@@ -52,7 +52,7 @@ export function renderToTest(source: string, filePath: string, componentName?: s
 
   const metadata = buildMetadata(ctx)
   const constantMap = resolveConstants(metadata.localConstants)
-  const root = irNodeToTestNode(ir, constantMap)
+  const root = irNodeToTestNode(ir, constantMap, metadata)
   const signals = metadata.signals.map(s => s.getter)
   const memos = metadata.memos.map(m => m.name)
   const effects = metadata.effects.length
@@ -119,6 +119,7 @@ function emptyResult(
     aria: {},
     dataState: null,
     events: [],
+    handlers: {},
     reactive: false,
     componentName: null,
   })

--- a/packages/test/src/test-node.ts
+++ b/packages/test/src/test-node.ts
@@ -20,7 +20,7 @@ export interface TestNodeData {
   aria: Record<string, string>
   dataState: string | null
   events: string[]
-  handlers: Record<string, EventHandler>
+  handlers: Partial<Record<string, EventHandler>>
   reactive: boolean
   componentName: string | null
 }
@@ -42,7 +42,7 @@ export class TestNode implements TestNodeData {
   aria: Record<string, string>
   dataState: string | null
   events: string[]
-  handlers: Record<string, EventHandler>
+  handlers: Partial<Record<string, EventHandler>>
   reactive: boolean
   componentName: string | null
 

--- a/packages/test/src/test-node.ts
+++ b/packages/test/src/test-node.ts
@@ -4,6 +4,11 @@
  * Produced by converting the compiler IR into a flat, assertion-friendly shape.
  */
 
+export interface EventHandler {
+  setters: string[]
+  via: string[]
+}
+
 export interface TestNodeData {
   tag: string | null
   type: 'element' | 'text' | 'expression' | 'conditional' | 'loop' | 'component' | 'fragment'
@@ -15,6 +20,7 @@ export interface TestNodeData {
   aria: Record<string, string>
   dataState: string | null
   events: string[]
+  handlers: Record<string, EventHandler>
   reactive: boolean
   componentName: string | null
 }
@@ -36,8 +42,18 @@ export class TestNode implements TestNodeData {
   aria: Record<string, string>
   dataState: string | null
   events: string[]
+  handlers: Record<string, EventHandler>
   reactive: boolean
   componentName: string | null
+
+  get onClick(): EventHandler | undefined { return this.handlers.click }
+  get onInput(): EventHandler | undefined { return this.handlers.input }
+  get onChange(): EventHandler | undefined { return this.handlers.change }
+  get onSubmit(): EventHandler | undefined { return this.handlers.submit }
+
+  on(event: string): EventHandler | null {
+    return this.handlers[event] ?? null
+  }
 
   constructor(data: TestNodeData) {
     this.tag = data.tag
@@ -50,6 +66,7 @@ export class TestNode implements TestNodeData {
     this.aria = data.aria
     this.dataState = data.dataState
     this.events = data.events
+    this.handlers = data.handlers
     this.reactive = data.reactive
     this.componentName = data.componentName
   }


### PR DESCRIPTION
## Summary

Add per-event setter resolution to `TestNode` so component wiring tests can assert which event handler calls which setter — without running code.

Closes #1625.

## Changes

**`@barefootjs/test`:**
- Add `EventHandler` type: `{ setters: string[], via: string[] }`
- Add 4 shorthand getters on `TestNode`: `onClick`, `onInput`, `onChange`, `onSubmit`
- Add generic `on(event: string): EventHandler | null` fallback
- `ir-to-test-node.ts` resolves setters for each `IREvent` during conversion using metadata
- `renderToTest` now passes `IRMetadata` to the IR-to-TestNode converter

**`@barefootjs/jsx`:**
- Export setter resolution helpers: `resolveSetters`, `buildLocalFunctionSetterMap`, `makeIdCallRegex`

## Example usage

```typescript
const result = renderToTest(counterSource, 'Counter.tsx')
const btn = result.find({ tag: 'button' })

// Wiring assertion: this button calls setCount
expect(btn!.onClick?.setters).toContain('setCount')

// Indirect setter via local function
expect(btn!.onClick?.via).toContain('addTodo')

// Non-shorthand event via on()
expect(div!.on('mouseenter')?.setters).toContain('setHovered')
```

## Design decisions (from #1625 discussion)

- **Why only events?** signals/memos/effects are already exposed. `whyUpdate` is a debug tool, not a test assertion (the dependency is self-evident from source). Event→setter mapping is the gap: not self-evident in complex components.
- **Why 4 shorthands?** Inspired by jQuery 3.x deprecating most shorthands. Form interaction basics (click, input, change, submit) cover daily use. Everything else via `on()`.
- **Why per-event, not flat setters?** Multiple events on one element need independent setter resolution.

## Test plan

- [x] 10 new tests covering: direct setter, indirect via, multiple events, all 4 shorthands, on() fallback, null for unregistered, empty setters, stateless component
- [x] All 22 existing test package tests still pass
- [x] Both `@barefootjs/jsx` and `@barefootjs/test` build successfully

https://claude.ai/code/session_01CmyVMrRYnJHikzLsm4kJEu


---
_Generated by [Claude Code](https://claude.ai/code/session_01CmyVMrRYnJHikzLsm4kJEu)_