### PR TITLE
test: add event wiring assertions to switch/checkbox/toggle

### DIFF
--- a/.changeset/arrow-const-setter-resolution.md
+++ b/.changeset/arrow-const-setter-resolution.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Resolve event handler setters through arrow-function consts (not just function declarations) in setter analysis

--- a/packages/jsx/src/debug.ts
+++ b/packages/jsx/src/debug.ts
@@ -440,13 +440,30 @@ export function buildLocalFunctionSetterMap(
 ): Map<string, string[]> {
   const setterPatterns = [...setterToSignal.keys()].map(s => ({ name: s, re: makeIdCallRegex(s) }))
   const result = new Map<string, string[]>()
-  for (const fn of meta.localFunctions) {
+
+  const scan = (name: string, body: string) => {
     const setters: string[] = []
-    for (const { name, re } of setterPatterns) {
-      if (re.test(fn.body)) setters.push(name)
+    for (const { name: setter, re } of setterPatterns) {
+      if (re.test(body)) setters.push(setter)
     }
-    if (setters.length > 0) result.set(fn.name, setters)
+    if (setters.length > 0) result.set(name, setters)
   }
+
+  // `function foo() {}` declarations
+  for (const fn of meta.localFunctions) {
+    scan(fn.name, fn.body)
+  }
+
+  // `const foo = () => {}` / `const foo = function() {}` — arrow/function
+  // expression handlers assigned to a const land in `localConstants`, not
+  // `localFunctions`. Without this, event handlers written as arrow consts
+  // (the common style for inline-ish handlers) resolve to zero setters.
+  for (const c of meta.localConstants) {
+    if (c.containsArrow && c.value) {
+      scan(c.name, c.value)
+    }
+  }
+
   return result
 }
 

--- a/packages/test/__tests__/event-handler-wiring.test.ts
+++ b/packages/test/__tests__/event-handler-wiring.test.ts
@@ -46,6 +46,28 @@ describe('EventHandler wiring on TestNode', () => {
     expect(btn!.onClick!.via).toContain('addTodo')
   })
 
+  test('resolves setters through arrow-function const handler', () => {
+    // Arrow-function consts (`const handleClick = () => {...}`) land in
+    // localConstants, not localFunctions. The bare-identifier handler
+    // `onClick={handleClick}` must still resolve the setters it calls.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Toggle() {
+        const [on, setOn] = createSignal(false)
+        const handleClick = () => {
+          setOn(!on())
+        }
+        return <button onClick={handleClick}>Toggle</button>
+      }
+    `
+    const result = renderToTest(source, 'Toggle.tsx')
+    const btn = result.find({ tag: 'button' })
+    expect(btn!.onClick!.setters).toContain('setOn')
+    expect(btn!.onClick!.via).toContain('handleClick')
+  })
+
   test('multiple events on same element are resolved independently', () => {
     const source = `
       'use client'

--- a/ui/components/ui/checkbox/index.test.tsx
+++ b/ui/components/ui/checkbox/index.test.tsx
@@ -59,6 +59,14 @@ describe('Checkbox', () => {
     expect(button.events).toContain('click')
   })
 
+  test('click handler wires to checked setters via handleClick', () => {
+    const button = result.find({ role: 'checkbox' })!
+    expect(button.onClick).toBeDefined()
+    expect(button.onClick!.via).toContain('handleClick')
+    expect(button.onClick!.setters).toContain('setInternalChecked')
+    expect(button.onClick!.setters).toContain('setControlledChecked')
+  })
+
   test('contains conditional CheckIcon child (checkmark)', () => {
     const icon = result.find({ componentName: 'CheckIcon' })
     expect(icon).not.toBeNull()

--- a/ui/components/ui/switch/index.test.tsx
+++ b/ui/components/ui/switch/index.test.tsx
@@ -46,6 +46,16 @@ describe('Switch', () => {
     expect(button.events).toContain('click')
   })
 
+  test('click handler wires to checked setters via handleClick', () => {
+    const button = result.find({ role: 'switch' })!
+    // The onClick handler routes through the local `handleClick` function,
+    // which updates either the controlled or uncontrolled checked signal.
+    expect(button.onClick).toBeDefined()
+    expect(button.onClick!.via).toContain('handleClick')
+    expect(button.onClick!.setters).toContain('setInternalChecked')
+    expect(button.onClick!.setters).toContain('setControlledChecked')
+  })
+
   test('has span with data-slot=switch-thumb', () => {
     const thumb = result.find({ tag: 'span' })
     expect(thumb).not.toBeNull()

--- a/ui/components/ui/toggle/index.test.tsx
+++ b/ui/components/ui/toggle/index.test.tsx
@@ -45,6 +45,13 @@ describe('Toggle', () => {
     expect(result.root.events).toContain('click')
   })
 
+  test('click handler wires to pressed setters via handleClick', () => {
+    expect(result.root.onClick).toBeDefined()
+    expect(result.root.onClick!.via).toContain('handleClick')
+    expect(result.root.onClick!.setters).toContain('setInternalPressed')
+    expect(result.root.onClick!.setters).toContain('setControlledPressed')
+  })
+
   test('root classes are dynamic (reactive memo)', () => {
     // classes are wrapped in createMemo for variant/size reactivity,
     // so the IR sees the expression rather than resolved static classes


### PR DESCRIPTION
## Summary

Applies the new `TestNode.onClick` wiring API (#1626) to real component tests, starting with the three simple toggle-pattern components: **switch, checkbox, toggle**.

Each now asserts not just _that_ a click handler exists, but _what it wires to_:

```typescript
expect(button.onClick!.via).toContain('handleClick')
expect(button.onClick!.setters).toContain('setInternalChecked')
expect(button.onClick!.setters).toContain('setControlledChecked')
```

## Root-cause fix included

While wiring these tests, we found `buildLocalFunctionSetterMap` only scanned `function foo() {}` declarations — it missed arrow-function consts (`const handleClick = () => {...}`), which is the actual handler style these components use. Bare-identifier handlers like `onClick={handleClick}` resolved to **zero setters**.

Fixed by also scanning `localConstants` where `containsArrow` is true. This improves **both** the test API and the `bf debug events` CLI.

## Test plan

- [x] 3 new wiring assertions (switch/checkbox/toggle), all green
- [x] New regression test for arrow-const handler resolution in `event-handler-wiring.test.ts`
- [x] All 99 tests across test + jsx debug suites pass
- [x] `@barefootjs/jsx` builds

## Follow-up

If this pattern proves valuable, the more complex components (slider, calendar, scroll-area, tooltip) are the next candidates — they have multi-signal, multi-event wiring worth verifying statically.

https://claude.ai/code/session_01CmyVMrRYnJHikzLsm4kJEu


---
_Generated by [Claude Code](https://claude.ai/code/session_01CmyVMrRYnJHikzLsm4kJEu)_