### PR TITLE
test: add wiring assertions to slider/calendar/scroll-area/tooltip

### DIFF
--- a/.changeset/transitive-setter-resolution.md
+++ b/.changeset/transitive-setter-resolution.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Resolve event handler setters transitively through helper-function call chains; SetterRef.via and WhyUpdateSource.via are now string[] (the call chain)

--- a/.changeset/transitive-setter-resolution.md
+++ b/.changeset/transitive-setter-resolution.md
@@ -1,5 +1,5 @@
 ---
-"@barefootjs/jsx": patch
+"@barefootjs/jsx": minor
 ---
 
-Resolve event handler setters transitively through helper-function call chains; SetterRef.via and WhyUpdateSource.via are now string[] (the call chain)
+Resolve event handler setters transitively through helper-function call chains. BREAKING: SetterRef.via and WhyUpdateSource.via are now string[] (the call chain) instead of string.

--- a/packages/jsx/src/__tests__/debug.test.ts
+++ b/packages/jsx/src/__tests__/debug.test.ts
@@ -821,7 +821,7 @@ describe('buildEventSummary', () => {
     expect(click.setterCalls).toHaveLength(1)
     expect(click.setterCalls[0].setter).toBe('setTodos')
     expect(click.setterCalls[0].signal).toBe('todos')
-    expect(click.setterCalls[0].via).toBe('addTodo')
+    expect(click.setterCalls[0].via).toEqual(['addTodo'])
   })
 
   test('includes component prop events (Button.onClick)', () => {
@@ -1148,7 +1148,7 @@ describe('buildWhyUpdate', () => {
     expect(result).not.toBeNull()
     const signalDep = result!.deps.find(d => d.name === 'items')
     expect(signalDep).toBeDefined()
-    expect(signalDep!.changedBy[0].via).toBe('addItem')
+    expect(signalDep!.changedBy[0].via).toEqual(['addItem'])
   })
 
   test('includes classification and wrapReason for fallback bindings', () => {

--- a/packages/jsx/src/debug.ts
+++ b/packages/jsx/src/debug.ts
@@ -139,7 +139,14 @@ export interface EventBinding {
 export interface SetterRef {
   setter: string
   signal: string | null
-  via?: string
+  /**
+   * Call chain from the handler to the setter, when the setter is reached
+   * through one or more local helper functions. For a handler that calls
+   * the setter directly this is omitted. For `onClick={handlePointerDown}`
+   * where `handlePointerDown` calls `setValue` which calls `setInternalValue`,
+   * this is `['handlePointerDown', 'setValue']`.
+   */
+  via?: string[]
 }
 
 export interface EventSummary {
@@ -197,7 +204,7 @@ export interface WhyUpdateSource {
   handler: string
   setter: string
   elementContext: string
-  via?: string
+  via?: string[]
 }
 
 // -- Component summary types --------------------------------------------------
@@ -434,34 +441,78 @@ function makeIdRefRegex(name: string): RegExp {
   return new RegExp(`(?:^|[^\\w$])${escapeForIdBoundary(name)}(?:[^\\w$]|$)`)
 }
 
+/**
+ * A setter reachable from a local function, with the chain of intermediate
+ * function names between that function and the setter (excluding the function
+ * itself). For a direct call the chain is empty.
+ */
+export interface FnSetterResolution {
+  setter: string
+  chain: string[]
+}
+
 export function buildLocalFunctionSetterMap(
   meta: IRMetadata,
   setterToSignal: Map<string, string>,
-): Map<string, string[]> {
+): Map<string, FnSetterResolution[]> {
   const setterPatterns = [...setterToSignal.keys()].map(s => ({ name: s, re: makeIdCallRegex(s) }))
-  const result = new Map<string, string[]>()
 
-  const scan = (name: string, body: string) => {
+  // Collect every local function-like binding: `function foo() {}` declarations
+  // plus arrow/function-expression consts (`const foo = () => {}`), which land
+  // in localConstants rather than localFunctions.
+  const bodies = new Map<string, string>()
+  for (const fn of meta.localFunctions) bodies.set(fn.name, fn.body)
+  for (const c of meta.localConstants) {
+    if (c.containsArrow && c.value) bodies.set(c.name, c.value)
+  }
+
+  // Direct setters and direct local-function calls per binding.
+  const fnNamePatterns = [...bodies.keys()].map(n => ({ name: n, re: makeIdCallRegex(n) }))
+  const directSetters = new Map<string, string[]>()
+  const directCalls = new Map<string, string[]>()
+  for (const [name, body] of bodies) {
     const setters: string[] = []
     for (const { name: setter, re } of setterPatterns) {
       if (re.test(body)) setters.push(setter)
     }
-    if (setters.length > 0) result.set(name, setters)
-  }
-
-  // `function foo() {}` declarations
-  for (const fn of meta.localFunctions) {
-    scan(fn.name, fn.body)
-  }
-
-  // `const foo = () => {}` / `const foo = function() {}` — arrow/function
-  // expression handlers assigned to a const land in `localConstants`, not
-  // `localFunctions`. Without this, event handlers written as arrow consts
-  // (the common style for inline-ish handlers) resolve to zero setters.
-  for (const c of meta.localConstants) {
-    if (c.containsArrow && c.value) {
-      scan(c.name, c.value)
+    directSetters.set(name, setters)
+    const calls: string[] = []
+    for (const { name: callee, re } of fnNamePatterns) {
+      if (callee !== name && re.test(body)) calls.push(callee)
     }
+    directCalls.set(name, calls)
+  }
+
+  // Resolve transitively: a handler may reach a setter through a chain of
+  // helper functions (handler -> setValue -> setInternalValue). `stack`
+  // guards against cycles (mutual recursion between helpers). Component
+  // helper graphs are tiny, so a plain DFS per binding is fine.
+  const resolve = (name: string, stack: Set<string>): FnSetterResolution[] => {
+    const out: FnSetterResolution[] = []
+    const seen = new Set<string>()
+    for (const setter of directSetters.get(name) ?? []) {
+      if (!seen.has(setter)) {
+        out.push({ setter, chain: [] })
+        seen.add(setter)
+      }
+    }
+    for (const callee of directCalls.get(name) ?? []) {
+      if (stack.has(callee)) continue
+      const sub = resolve(callee, new Set([...stack, callee]))
+      for (const r of sub) {
+        if (!seen.has(r.setter)) {
+          out.push({ setter: r.setter, chain: [callee, ...r.chain] })
+          seen.add(r.setter)
+        }
+      }
+    }
+    return out
+  }
+
+  const result = new Map<string, FnSetterResolution[]>()
+  for (const name of bodies.keys()) {
+    const resolved = resolve(name, new Set([name]))
+    if (resolved.length > 0) result.set(name, resolved)
   }
 
   return result
@@ -470,7 +521,7 @@ export function buildLocalFunctionSetterMap(
 function collectEventBindings(
   node: IRNode,
   setterToSignal: Map<string, string>,
-  fnSetters: Map<string, string[]>,
+  fnSetters: Map<string, FnSetterResolution[]>,
 ): EventBinding[] {
   const events: EventBinding[] = []
   walkForEvents(node, events, setterToSignal, fnSetters)
@@ -481,7 +532,7 @@ function walkForEvents(
   node: IRNode,
   events: EventBinding[],
   setterToSignal: Map<string, string>,
-  fnSetters: Map<string, string[]>,
+  fnSetters: Map<string, FnSetterResolution[]>,
 ): void {
   switch (node.type) {
     case 'element': {
@@ -557,7 +608,7 @@ function walkForEvents(
 export function resolveSetters(
   handler: string,
   setterToSignal: Map<string, string>,
-  fnSetters: Map<string, string[]>,
+  fnSetters: Map<string, FnSetterResolution[]>,
 ): SetterRef[] {
   const refs: SetterRef[] = []
   const seen = new Set<string>()
@@ -572,12 +623,16 @@ export function resolveSetters(
     }
   }
 
-  for (const [fnName, setters] of fnSetters) {
+  for (const [fnName, resolutions] of fnSetters) {
     if (trimmed === fnName || makeIdCallRegex(fnName).test(handler)) {
-      for (const setter of setters) {
-        if (!seen.has(setter)) {
-          refs.push({ setter, signal: setterToSignal.get(setter) ?? null, via: fnName })
-          seen.add(setter)
+      for (const r of resolutions) {
+        if (!seen.has(r.setter)) {
+          refs.push({
+            setter: r.setter,
+            signal: setterToSignal.get(r.setter) ?? null,
+            via: [fnName, ...r.chain],
+          })
+          seen.add(r.setter)
         }
       }
     }
@@ -622,7 +677,7 @@ export function formatEventSummary(summary: EventSummary, graph: ComponentGraph)
     lines.push(`  ${event.elementContext}`)
 
     const setterParts = event.setterCalls.map(s => {
-      const chain = s.via ? `${s.via} -> ${s.setter}` : s.setter
+      const chain = s.via && s.via.length > 0 ? `${s.via.join(' -> ')} -> ${s.setter}` : s.setter
       return chain
     })
 
@@ -1057,8 +1112,8 @@ export function formatWhyUpdate(result: WhyUpdateResult): string {
         lines.push('  (no event handlers found)')
       }
       for (const src of dep.changedBy) {
-        const chain = src.via
-          ? `${src.elementContext} ${src.handler} -> ${src.via} -> ${src.setter}`
+        const chain = src.via && src.via.length > 0
+          ? `${src.elementContext} ${src.handler} -> ${src.via.join(' -> ')} -> ${src.setter}`
           : `${src.elementContext} ${src.handler} -> ${src.setter}`
         lines.push(`  ${chain}`)
       }

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -268,7 +268,7 @@ export {
   buildLocalFunctionSetterMap,
   makeIdCallRegex,
 } from './debug'
-export type { ComponentGraph, ComponentAnalysis, SignalNode, MemoNode, EffectNode, DomBinding, UpdatePath, SignalTrace, EventBinding, SetterRef, EventSummary, LoopInfo, LoopChildBinding, LoopSummary, WhyUpdateResult, WhyUpdateDep, WhyUpdateSource, FallbackExplanation, ComponentSummary } from './debug'
+export type { ComponentGraph, ComponentAnalysis, SignalNode, MemoNode, EffectNode, DomBinding, UpdatePath, SignalTrace, EventBinding, SetterRef, FnSetterResolution, EventSummary, LoopInfo, LoopChildBinding, LoopSummary, WhyUpdateResult, WhyUpdateDep, WhyUpdateSource, FallbackExplanation, ComponentSummary } from './debug'
 export type { WrapReason } from './ir-to-client-js/reactivity'
 
 // HTML constants

--- a/packages/test/src/ir-to-test-node.ts
+++ b/packages/test/src/ir-to-test-node.ts
@@ -19,7 +19,7 @@ import type {
   IRAsync,
   IRMetadata,
 } from '@barefootjs/jsx'
-import { resolveSetters, buildLocalFunctionSetterMap, type SetterRef } from '@barefootjs/jsx'
+import { resolveSetters, buildLocalFunctionSetterMap, type SetterRef, type FnSetterResolution } from '@barefootjs/jsx'
 
 type IRAttribute = IRElement['attrs'][number]
 type AttrValue = IRAttribute['value']
@@ -29,13 +29,13 @@ import { TestNode, type EventHandler } from './test-node'
 interface ConvertContext {
   cmap: Map<string, string>
   setterToSignal: Map<string, string>
-  fnSetters: Map<string, string[]>
+  fnSetters: Map<string, FnSetterResolution[]>
 }
 
 export function irNodeToTestNode(node: IRNode, constantMap?: Map<string, string>, metadata?: IRMetadata): TestNode {
   const cmap = constantMap ?? new Map<string, string>()
   const setterToSignal = new Map<string, string>()
-  const fnSetters = new Map<string, string[]>()
+  const fnSetters = new Map<string, FnSetterResolution[]>()
   if (metadata) {
     for (const s of metadata.signals) {
       if (s.setter) setterToSignal.set(s.setter, s.getter)
@@ -427,8 +427,10 @@ function refsToHandler(refs: SetterRef[]): EventHandler {
   const setters: string[] = []
   const via: string[] = []
   for (const ref of refs) {
-    setters.push(ref.setter)
-    if (ref.via && !via.includes(ref.via)) via.push(ref.via)
+    if (!setters.includes(ref.setter)) setters.push(ref.setter)
+    for (const v of ref.via ?? []) {
+      if (!via.includes(v)) via.push(v)
+    }
   }
   return { setters, via }
 }

--- a/ui/components/ui/calendar/index.test.tsx
+++ b/ui/components/ui/calendar/index.test.tsx
@@ -51,6 +51,32 @@ describe('Calendar', () => {
     expect(root!.events).toContain('click')
   })
 
+  test('day click wires to selection setters through delegated handlers', () => {
+    // The root uses event delegation: a single onClick (handleCalendarClick)
+    // dispatches to handleSingleClick / handleRangeClick, which set the
+    // selection signals.
+    const root = result.find({ tag: 'div' })!
+    const handler = root.on('click')
+    expect(handler).not.toBeNull()
+    expect(handler!.via).toContain('handleCalendarClick')
+    expect(handler!.setters).toContain('setInternalSelected')
+    expect(handler!.setters).toContain('setInternalRange')
+  })
+
+  test('month navigation buttons wire to current month/year setters', () => {
+    const buttons = result.findAll({ tag: 'button' })
+    const navButtons = buttons.filter(b => {
+      const h = b.on('click')
+      return h && (h.via.includes('goToPrevMonth') || h.via.includes('goToNextMonth'))
+    })
+    expect(navButtons.length).toBeGreaterThan(0)
+    for (const btn of navButtons) {
+      const h = btn.on('click')!
+      expect(h.setters).toContain('setCurrentMonth')
+      expect(h.setters).toContain('setCurrentYear')
+    }
+  })
+
   test('toStructure() includes inlined month grids', () => {
     const structure = result.toStructure()
     // #569: renderMonthGrid is inlined at IR level, verify both grids are present

--- a/ui/components/ui/scroll-area/index.test.tsx
+++ b/ui/components/ui/scroll-area/index.test.tsx
@@ -42,6 +42,25 @@ describe('ScrollArea', () => {
     expect(result.root.events).toContain('mouseenter')
   })
 
+  test('hover handlers wire to the hovered signal', () => {
+    expect(result.root.on('mouseenter')!.setters).toContain('setHovered')
+    expect(result.root.on('mouseleave')!.setters).toContain('setHovered')
+  })
+
+  test('scroll handler wires through updateScrollMetrics to thumb signals', () => {
+    // onScroll -> handleScroll -> updateScrollMetrics -> set* (transitive).
+    // The scroll listener sits on the viewport div, not the root.
+    const viewport = result.findAll({ tag: 'div' })
+      .find(d => d.props['data-slot'] === 'scroll-area-viewport')
+    expect(viewport).toBeDefined()
+    const handler = viewport!.on('scroll')
+    expect(handler).not.toBeNull()
+    expect(handler!.via).toContain('handleScroll')
+    expect(handler!.via).toContain('updateScrollMetrics')
+    expect(handler!.setters).toContain('setScrolling')
+    expect(handler!.setters).toContain('setThumbVPos')
+  })
+
   test('contains viewport div with data-slot=scroll-area-viewport', () => {
     const viewport = result.find({ tag: 'div' })
     expect(viewport).not.toBeNull()

--- a/ui/components/ui/slider/index.test.tsx
+++ b/ui/components/ui/slider/index.test.tsx
@@ -48,9 +48,28 @@ describe('Slider', () => {
     expect(result.root.events).toContain('pointerdown')
   })
 
+  test('pointerdown wires to value setters through a transitive helper chain', () => {
+    // The handler reaches the setter via two hops:
+    //   onPointerDown -> handlePointerDown -> setValue -> setInternalValue
+    const handler = result.root.on('pointerdown')
+    expect(handler).not.toBeNull()
+    expect(handler!.via).toContain('handlePointerDown')
+    expect(handler!.via).toContain('setValue')
+    expect(handler!.setters).toContain('setInternalValue')
+    expect(handler!.setters).toContain('setControlledValue')
+  })
+
   test('contains span with role=slider', () => {
     const thumb = result.find({ role: 'slider' })
     expect(thumb).not.toBeNull()
+  })
+
+  test('thumb keydown wires to value setters through the same helper chain', () => {
+    const thumb = result.find({ role: 'slider' })!
+    const handler = thumb.on('keydown')
+    expect(handler).not.toBeNull()
+    expect(handler!.via).toContain('setValue')
+    expect(handler!.setters).toContain('setInternalValue')
   })
 
   test('slider thumb has data-slot=slider-thumb', () => {

--- a/ui/components/ui/tooltip/index.test.tsx
+++ b/ui/components/ui/tooltip/index.test.tsx
@@ -40,6 +40,22 @@ describe('Tooltip', () => {
     expect(result.root.events).toContain('mouseenter')
   })
 
+  test('hover/focus handlers all wire to setOpen', () => {
+    // All four open/close triggers route through their respective handler
+    // function to the single `open` signal setter.
+    for (const [event, via] of [
+      ['mouseenter', 'handleMouseEnter'],
+      ['mouseleave', 'handleMouseLeave'],
+      ['focus', 'handleFocus'],
+      ['blur', 'handleBlur'],
+    ] as const) {
+      const handler = result.root.on(event)
+      expect(handler).not.toBeNull()
+      expect(handler!.via).toContain(via)
+      expect(handler!.setters).toContain('setOpen')
+    }
+  })
+
   test('contains div with role=tooltip', () => {
     const tooltipDiv = result.find({ role: 'tooltip' })
     expect(tooltipDiv).not.toBeNull()


### PR DESCRIPTION
## Summary

Extends event wiring tests to four complex stateful components, and adds **transitive setter resolution** to support them.

## Components covered

| Component | Wiring tested | Pattern |
|-----------|--------------|---------|
| **tooltip** | mouseenter/mouseleave/focus/blur → `setOpen` | direct via |
| **slider** | pointerdown/keydown → `handlePointerDown` → `setValue` → `setInternalValue` | **transitive (2 hops)** |
| **calendar** | day click → `handleCalendarClick` → selection setters; nav buttons → month/year setters | transitive + direct |
| **scroll-area** | hover → `setHovered`; scroll → `handleScroll` → `updateScrollMetrics` → thumb setters | transitive |

## Root-cause change: transitive resolution

Previously `buildLocalFunctionSetterMap` only resolved **one hop** (handler → setter). Components like slider route through a helper (`handlePointerDown → setValue → setInternalValue`), which resolved to **zero setters**.

Setter resolution now follows the full helper call chain with cycle detection. As a result:

- `SetterRef.via` and `WhyUpdateSource.via` change from `string` (single function name) to `string[]` (the call chain), e.g. `['handlePointerDown', 'setValue']`
- Format output (`bf debug events`, `bf debug why-update`) joins the chain with ` -> `

This benefits both the test API and the debug CLIs.

## Note on scroll-area pointerdown

The thumb `pointerdown` handler drives scrolling imperatively (`viewport.scrollTop = ...`) rather than calling a setter — it correctly resolves to empty. Not asserted.

## Test plan

- [x] 4 components' wiring tests added (slider, calendar, scroll-area, tooltip)
- [x] Existing `via`-as-string assertions updated to `via`-as-array
- [x] All 188 tests across affected suites pass
- [x] Both `@barefootjs/jsx` and `@barefootjs/test` build

https://claude.ai/code/session_01CmyVMrRYnJHikzLsm4kJEu


---
_Generated by [Claude Code](https://claude.ai/code/session_01CmyVMrRYnJHikzLsm4kJEu)_