### PR TITLE
docs: document event-handler wiring in testing spec and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ See `spec/testing.md` for full testing specification with APIs, patterns, and ex
 | Layer | Verifies | Location | Speed |
 |-------|----------|----------|-------|
 | Compiler unit | Transformation rules, error codes, analysis | `packages/jsx/src/__tests__/` | ms |
-| Component IR | Structure, a11y, signals, classes | `ui/components/ui/*/index.test.tsx` | ms |
+| Component IR | Structure, a11y, signals, classes, event wiring | `ui/components/ui/*/index.test.tsx` | ms |
 | Adapter conformance | IR → HTML output per adapter | `packages/adapter-tests/fixtures/` | ms |
 | CSR conformance | Client JS → correct DOM output | `packages/adapter-tests/src/__tests__/csr-conformance.test.ts` | ms |
 | Runtime unit | Signals, DOM ops, hydration primitives | `packages/client/__tests__/` | ms |
@@ -35,6 +35,7 @@ Quick decision guide:
 - **Template HTML output** → Adapter conformance fixture
 - **Client JS behavior** → CSR conformance fixture
 - **Click/keyboard behavior** → E2E test
+- **Which handler calls which setter** (event→setter wiring) → Component IR test via `renderToTest().find(...).onClick`. This verifies the compiler-built dependency *path*, not the runtime value — assert the path here, assert the displayed value in E2E.
 - **Static attribute / class / ARIA changes** → Component IR test. Do NOT add an E2E test for static-only changes; that's an anti-pattern (see `spec/testing.md`).
 - **Hydration correctness** is a compiler invariant. Fix in `packages/jsx/`, verify with E2E.
 

--- a/spec/testing.md
+++ b/spec/testing.md
@@ -128,6 +128,7 @@ Verify that a component's JSX produces the correct IR structure — tags, attrib
 - ARIA attributes (`role`, `aria-checked`, `aria-expanded`, etc.)
 - `data-state` attributes
 - Event handlers are present
+- Event-handler wiring (which handler calls which signal setter)
 - Reactive vs static nodes
 - Signal and memo declarations exist
 - Child component composition
@@ -136,7 +137,9 @@ Verify that a component's JSX produces the correct IR structure — tags, attrib
 
 - Adapter-specific HTML output → use Adapter Conformance
 - Client JS code generation → use Compiler Unit
-- Interactive behavior (click → state change) → use E2E
+- Interactive behavior — the runtime *value* after a click (e.g. "count shows 2") → use E2E.
+  Note the boundary: the wiring layer proves the handler *reaches* `setCount` (the path);
+  E2E proves the displayed value is correct.
 
 ### API Reference
 
@@ -167,6 +170,11 @@ interface TestNodeQuery {
   componentName?: string // e.g., 'CheckboxIndicator'
 }
 
+interface EventHandler {
+  setters: string[]      // signal setters the handler ends up calling
+  via: string[]          // helper-function call chain to reach those setters
+}
+
 interface TestNode {
   tag: string | null
   type: 'element' | 'text' | 'expression' | 'conditional' | 'loop' | 'component' | 'fragment'
@@ -177,11 +185,42 @@ interface TestNode {
   role: string | null
   aria: Record<string, string>
   dataState: string | null
-  events: string[]
+  events: string[]                              // event names, e.g. ['click']
+  handlers: Partial<Record<string, EventHandler>> // event name → wiring
   reactive: boolean
   componentName: string | null
+
+  // Event-handler wiring shorthands (resolve to handlers[name]):
+  onClick?: EventHandler
+  onInput?: EventHandler
+  onChange?: EventHandler
+  onSubmit?: EventHandler
+  on(event: string): EventHandler | null        // any other event, e.g. on('keydown')
 }
 ```
+
+### Event-handler wiring
+
+`renderToTest` resolves, statically, which signal setters each event handler
+ends up calling — including through helper functions. This is the
+**component-wiring** layer: it verifies the dependency *path* the compiler
+built (handler → setter), not the runtime *value* (E2E's job).
+
+```typescript
+// <button onClick={() => setCount(n => n + 1)}>
+const btn = result.find({ role: 'button' })
+expect(btn!.onClick!.setters).toContain('setCount')
+
+// Transitive: <div onPointerDown={handlePointerDown}> where
+// handlePointerDown → setValue → setInternalValue
+const root = result.find({ tag: 'div' })
+expect(root!.on('pointerdown')!.via).toContain('setValue')        // call chain
+expect(root!.on('pointerdown')!.setters).toContain('setInternalValue')
+```
+
+Assert the *path*, not the value. "Clicking + shows 2" is an E2E concern; the
+wiring layer only proves "onClick reaches setCount". A handler with no setter
+call (e.g. `onClick={() => console.log(x)}`) resolves to empty `setters`.
 
 ### Pattern
 
@@ -214,6 +253,13 @@ describe('Checkbox', () => {
   test('has click event handler', () => {
     const button = result.find({ role: 'checkbox' })
     expect(button!.events).toContain('click')
+  })
+
+  test('click handler wires to the checked setter', () => {
+    const button = result.find({ role: 'checkbox' })
+    // handleClick → setInternalChecked / setControlledChecked
+    expect(button!.onClick!.via).toContain('handleClick')
+    expect(button!.onClick!.setters).toContain('setInternalChecked')
   })
 })
 ```


### PR DESCRIPTION
## Summary

Documents the event-handler wiring API added in #1626, #1629, and #1630. Docs-only — no published package source changed.

**`spec/testing.md`:**
- Add `EventHandler` to the Component IR API reference, plus the new `TestNode` fields (`handlers`, `onClick`/`onInput`/`onChange`/`onSubmit`, `on()`)
- New "Event-handler wiring" section explaining the path-vs-value boundary with E2E (wiring proves the handler *reaches* `setCount`; E2E proves the displayed value)
- Add a wiring assertion to the Checkbox example
- Clarify "What NOT to test here" — the wiring/E2E boundary

**`CLAUDE.md`:**
- Extend the Component IR test layer row to include "event wiring"
- Add a decision-guide bullet: "which handler calls which setter → Component IR test via `renderToTest().find(...).onClick`"

## Test plan

- [x] No doc-snapshot test validates this content (verified)
- [x] Examples use real handler names (`handleClick` → `setInternalChecked`) consistent with the actual components
- [x] Docs-only; no code or published source touched

https://claude.ai/code/session_01CmyVMrRYnJHikzLsm4kJEu


---
_Generated by [Claude Code](https://claude.ai/code/session_01CmyVMrRYnJHikzLsm4kJEu)_