### PR TITLE
feat: resolve event-handler wiring on component props in renderToTest

### DIFF
--- a/.changeset/component-prop-event-wiring.md
+++ b/.changeset/component-prop-event-wiring.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/test": minor
+---
+
+Resolve event-handler wiring on component props (e.g. `<Button onClick={...}>`, `<Switch onCheckedChange={...}>`), matching the `bf debug events` CLI. Component callback props are keyed by the DOM-style event name (onClick → click, onCheckedChange → checkedChange).

--- a/packages/test/__tests__/event-handler-wiring.test.ts
+++ b/packages/test/__tests__/event-handler-wiring.test.ts
@@ -197,4 +197,63 @@ describe('EventHandler wiring on TestNode', () => {
     expect(th!.onClick).toBeDefined()
     expect(th!.onClick!.setters).toHaveLength(0)
   })
+
+  test('resolves event handler on a component prop (onClick)', () => {
+    // The parent IR sees `<Button onClick={...}>` as a prop, not a DOM event.
+    // It should still resolve the wiring on the component TestNode.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { Button } from './Button'
+
+      export function Panel() {
+        const [count, setCount] = createSignal(0)
+        return <Button onClick={() => setCount(0)}>Reset</Button>
+      }
+    `
+    const result = renderToTest(source, 'Panel.tsx')
+    const btn = result.find({ componentName: 'Button' })
+    expect(btn).not.toBeNull()
+    expect(btn!.events).toContain('click')
+    expect(btn!.onClick).toBeDefined()
+    expect(btn!.onClick!.setters).toContain('setCount')
+  })
+
+  test('resolves custom callback props (onCheckedChange) via on()', () => {
+    // Component callback props are not DOM events; keyed by the prop name with
+    // `on` stripped and first char lowercased: onCheckedChange -> checkedChange.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { Switch } from './Switch'
+
+      export function Form() {
+        const [enabled, setEnabled] = createSignal(false)
+        return <Switch onCheckedChange={(v) => setEnabled(v)} />
+      }
+    `
+    const result = renderToTest(source, 'Form.tsx')
+    const sw = result.find({ componentName: 'Switch' })
+    expect(sw!.events).toContain('checkedChange')
+    expect(sw!.on('checkedChange')).not.toBeNull()
+    expect(sw!.on('checkedChange')!.setters).toContain('setEnabled')
+  })
+
+  test('resolves component prop handler through a local function (via chain)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { Button } from './Button'
+
+      export function Panel() {
+        const [items, setItems] = createSignal([])
+        const reset = () => setItems([])
+        return <Button onClick={reset}>Clear</Button>
+      }
+    `
+    const result = renderToTest(source, 'Panel.tsx')
+    const btn = result.find({ componentName: 'Button' })
+    expect(btn!.onClick!.setters).toContain('setItems')
+    expect(btn!.onClick!.via).toContain('reset')
+  })
 })

--- a/packages/test/src/ir-to-test-node.ts
+++ b/packages/test/src/ir-to-test-node.ts
@@ -253,6 +253,8 @@ function convertLoop(node: IRLoop, ctx: ConvertContext): TestNode {
 
 function convertComponent(node: IRComponent, ctx: ConvertContext): TestNode {
   const props: Record<string, string | boolean | null> = {}
+  const events: string[] = []
+  const handlers: Record<string, EventHandler> = {}
   for (const prop of node.props) {
     switch (prop.value.kind) {
       case 'literal':
@@ -273,6 +275,19 @@ function convertComponent(node: IRComponent, ctx: ConvertContext): TestNode {
         props[prop.name] = null
         break
     }
+
+    // Component callback props that look like event handlers
+    // (`<Button onClick={...}>`). The parent IR sees these as props, but for
+    // wiring they behave like events: when the callback fires, which setters
+    // run. Keyed by the DOM-style event name (`onClick` -> `click`) so the
+    // shorthand getters and `on()` work the same as for native elements.
+    if (/^on[A-Z]/.test(prop.name) && prop.value.kind === 'expression') {
+      const eventName = prop.name.charAt(2).toLowerCase() + prop.name.slice(3)
+      events.push(eventName)
+      handlers[eventName] = refsToHandler(
+        resolveSetters(prop.value.expr, ctx.setterToSignal, ctx.fnSetters),
+      )
+    }
   }
 
   const children = node.children.map(c => convert(c, ctx))
@@ -287,8 +302,8 @@ function convertComponent(node: IRComponent, ctx: ConvertContext): TestNode {
     role: null,
     aria: {},
     dataState: null,
-    events: [],
-    handlers: {},
+    events,
+    handlers,
     reactive: false,
     componentName: node.name,
   })


### PR DESCRIPTION
## Summary

Closes the consistency gap between `bf debug events` (CLI) and the `renderToTest` test API: component callback props were not wiring-resolved in tests, only DOM element events were.

```jsx
// Before: DOM events resolved, component props did NOT
<button onClick={() => setCount(0)}>   // btn.onClick.setters → ['setCount'] ✓
<Button onClick={() => setCount(0)}>   // Button.onClick → undefined ✗

// After: both resolve
<Button onClick={() => setCount(0)}>   // Button.onClick.setters → ['setCount'] ✓
<Switch onCheckedChange={(v) => setEnabled(v)} />  // Switch.on('checkedChange').setters → ['setEnabled'] ✓
```

## How

`convertComponent` now resolves props matching `/^on[A-Z]/` (expression kind), mirroring the CLI's `walkForEvents` component branch. Callback props are keyed by the DOM-style event name (`onClick` → `click`, `onCheckedChange` → `checkedChange`) so the `onClick`/`onInput`/etc. shorthands and `on()` work uniformly across DOM elements and components.

Transitive resolution (handler → helper → setter) works here too, since it reuses the same `resolveSetters`.

## Test plan

- [x] 3 new tests: component `onClick`, custom callback `onCheckedChange` via `on()`, and a via-chain case
- [x] All 61 tests across test package + switch/checkbox/toggle pass
- [x] `@barefootjs/test` builds

https://claude.ai/code/session_01CmyVMrRYnJHikzLsm4kJEu


---
_Generated by [Claude Code](https://claude.ai/code/session_01CmyVMrRYnJHikzLsm4kJEu)_