### PR TITLE
fix(client): render every root of a multi-root (fragment) component in CSR

### DIFF
--- a/.changeset/fix-multi-root-csr-render.md
+++ b/.changeset/fix-multi-root-csr-render.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/client": patch
+---
+
+Fix CSR `render()` dropping all but the first root of a multi-root (fragment) component. `render()` now mounts every root element; for the multi-root case it recreates the SSR fragment layout (a `bf-scope:` comment marker before the sibling roots) so `$c()` resolves sibling child scopes via the comment range. The async hydration walk no longer re-initializes a `render()`'d fragment scope — the comment-scope path now honours `hydratedScopes`, matching the element-scope path — so multi-root components mount every root and initialize exactly once.

--- a/packages/client/__tests__/runtime/render.test.ts
+++ b/packages/client/__tests__/runtime/render.test.ts
@@ -4,6 +4,7 @@ import { createComponent, renderChild } from '../../src/runtime/component'
 import { $c } from '../../src/runtime/query'
 import { registerComponent } from '../../src/runtime/registry'
 import { registerTemplate } from '../../src/runtime/template'
+import { hydrate, flushHydration } from '../../src/runtime/hydrate'
 import { hydratedScopes } from '../../src/runtime/hydration-state'
 import type { ComponentDef } from '../../src/runtime/types'
 import type { InitFn } from '../../src/runtime/types'
@@ -166,6 +167,32 @@ describe('render multi-root (fragment) templates', () => {
     // $c() from init resolved the *second* sibling, not just s0.
     expect(resolved[0]?.getAttribute('data-slot')).toBe('a')
     expect(resolved[1]?.getAttribute('data-slot')).toBe('b')
+  })
+
+  test('does not re-init the fragment when the hydration walker runs', () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    let initCount = 0
+    // Register through hydrate() (the real preview/app path) so the async
+    // document-order walker is scheduled — registerTestComponent bypasses it.
+    // Name must be a single token: the walker derives the component name as
+    // the substring before the first `_` in the scope id.
+    hydrate('RenderFragHydrate', {
+      init: () => {
+        initCount++
+      },
+      template: () => `<h1>a</h1><h2>b</h2>`,
+      comment: true,
+    })
+
+    render(container, 'RenderFragHydrate', {})
+    expect(initCount).toBe(1) // render() initialized it once, synchronously
+
+    // Run the walker synchronously: it visits the bf-scope comment render()
+    // created. Without honouring hydratedScopes it would init a second time.
+    flushHydration()
+    expect(initCount).toBe(1)
   })
 })
 

--- a/packages/client/__tests__/runtime/render.test.ts
+++ b/packages/client/__tests__/runtime/render.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
 import { render } from '../../src/runtime/render'
-import { createComponent } from '../../src/runtime/component'
+import { createComponent, renderChild } from '../../src/runtime/component'
+import { $c } from '../../src/runtime/query'
 import { registerComponent } from '../../src/runtime/registry'
 import { registerTemplate } from '../../src/runtime/template'
 import { hydratedScopes } from '../../src/runtime/hydration-state'
@@ -113,6 +114,58 @@ describe('render', () => {
 
     const element = container.firstElementChild!
     expect(hydratedScopes.has(element)).toBe(true)
+  })
+})
+
+describe('render multi-root (fragment) templates', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('appends every root element, not just the first', () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    registerTestComponent(
+      'RenderTest_MultiRoot',
+      () => {},
+      () => `<h1>one</h1><h2>two</h2><h3>three</h3>`
+    )
+
+    render(container, 'RenderTest_MultiRoot')
+
+    const headings = container.querySelectorAll('h1, h2, h3')
+    expect(headings.length).toBe(3)
+    expect(container.textContent).toBe('onetwothree')
+  })
+
+  test('resolves sibling child scopes via the comment-scope range', () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    registerTestComponent('FragLeafA', () => {}, (p) => `<h1 data-slot="a">${p.children}</h1>`)
+    registerTestComponent('FragLeafB', () => {}, (p) => `<h2 data-slot="b">${p.children}</h2>`)
+
+    const resolved: (Element | null)[] = []
+    registerTestComponent(
+      'RenderTest_Frag',
+      (scope) => {
+        const [s0, s1] = $c(scope, 's0', 's1')
+        resolved.push(s0, s1)
+      },
+      () =>
+        `${renderChild('FragLeafA', { children: 'one' }, undefined, 's0')}` +
+        `${renderChild('FragLeafB', { children: 'two' }, undefined, 's1')}`
+    )
+
+    render(container, 'RenderTest_Frag', {})
+
+    // Both roots mounted (regression: previously only the first sibling).
+    expect(container.querySelector('[data-slot="a"]')?.textContent).toBe('one')
+    expect(container.querySelector('[data-slot="b"]')?.textContent).toBe('two')
+    // $c() from init resolved the *second* sibling, not just s0.
+    expect(resolved[0]?.getAttribute('data-slot')).toBe('a')
+    expect(resolved[1]?.getAttribute('data-slot')).toBe('b')
   })
 })
 

--- a/packages/client/src/runtime/hydrate.ts
+++ b/packages/client/src/runtime/hydrate.ts
@@ -294,6 +294,12 @@ function hydrateCommentScope(comment: Comment): void {
   const proxyEl = nextElementSibling(comment) ?? comment.parentElement
   if (!proxyEl) return
 
+  // A synchronous CSR render() may have already initialized this fragment
+  // scope and claimed its proxy before this async walk runs. Honour the same
+  // `hydratedScopes` signal the element-scope path uses (hydrateElementScope),
+  // so a comment-rooted scope is never re-initialized once claimed.
+  if (hydratedScopes.has(proxyEl)) return
+
   commentScopeRegistry.set(proxyEl, { commentNode: comment, scopeId })
 
   const parsed = parseProps(propsJson || null, `comment scope ${scopeId}`)

--- a/packages/client/src/runtime/render.ts
+++ b/packages/client/src/runtime/render.ts
@@ -6,10 +6,11 @@
  * never import this module.
  */
 
-import { BF_SCOPE } from '@barefootjs/shared'
+import { BF_SCOPE, BF_SCOPE_COMMENT_PREFIX } from '@barefootjs/shared'
 import { setParentScopeId } from './component'
 import { hydratedScopes } from './hydration-state'
 import { getComponentInit } from './registry'
+import { commentScopeRegistry } from './scope'
 import { getTemplate, type TemplateFn } from './template'
 import type { ComponentDef, InitFn } from './types'
 
@@ -86,20 +87,41 @@ export function render(
 
   const tpl = document.createElement('template')
   tpl.innerHTML = html
-  const element = tpl.content.firstChild as HTMLElement
 
-  if (!element) {
+  const rootElements = Array.from(tpl.content.childNodes).filter(
+    (n): n is HTMLElement => n.nodeType === Node.ELEMENT_NODE
+  )
+
+  if (rootElements.length === 0) {
     throw new Error('[BarefootJS] render(): template returned empty HTML')
   }
 
-  if (!element.getAttribute(BF_SCOPE)) {
-    element.setAttribute(BF_SCOPE, scopeId)
+  container.innerHTML = ''
+
+  if (rootElements.length === 1) {
+    const element = rootElements[0]
+    if (!element.getAttribute(BF_SCOPE)) {
+      element.setAttribute(BF_SCOPE, scopeId)
+    }
+    container.appendChild(element)
+    init(element, props)
+    hydratedScopes.add(element)
+    return
   }
 
-  container.innerHTML = ''
-  container.appendChild(element)
+  // Multi-root (fragment) template: the child scopes are siblings, not
+  // descendants of one root, so $c() can't resolve them by subtree walk.
+  // Recreate the SSR fragment layout — a `bf-scope:` comment marker followed
+  // by the sibling roots — and register it so candidatesInScope() walks the
+  // comment range. Without this only the first root would hydrate.
+  const commentNode = document.createComment(`${BF_SCOPE_COMMENT_PREFIX}${scopeId}`)
+  container.appendChild(commentNode)
+  for (const node of Array.from(tpl.content.childNodes)) {
+    container.appendChild(node)
+  }
 
-  init(element, props)
-
-  hydratedScopes.add(element)
+  const proxyEl = rootElements[0]
+  commentScopeRegistry.set(proxyEl, { commentNode, scopeId })
+  init(proxyEl, props)
+  hydratedScopes.add(proxyEl)
 }


### PR DESCRIPTION
## Summary

`render()` (the CSR entry in `@barefootjs/client`) mounted only `tpl.content.firstChild`, so a component whose template produces **multiple sibling roots** (a fragment) rendered just its first element. The rest were silently dropped.

This surfaced via `bf preview` on multi-root previews — e.g. `typography`, whose generated `Default` returns a Fragment of four headings (`<TypographyH1/>…<TypographyH4/>`). Only **Main Heading** rendered; H2/H3/H4 disappeared.

## Fix

`packages/client/src/runtime/render.ts`:

- Collect **all** root element nodes from the template, not just `firstChild`.
- Single-root path is unchanged (sets `bf-s`, appends, inits).
- Multi-root path recreates the SSR fragment layout — a `bf-scope:` comment marker before the sibling roots, registered in `commentScopeRegistry` — so `$c()` resolves the sibling child scopes through `candidatesInScope()`'s comment-range walk (instead of a single-subtree query that can't see siblings). `init()` then runs on the proxy (first root) exactly as the hydration path does.

## Before / after

`bf preview typography`:
- Before: only "Main Heading" renders.
- After: all four headings render (H1–H4), each with its `data-slot`.

## Tests

`packages/client/__tests__/runtime/render.test.ts`:
- `appends every root element, not just the first` — guards the core regression.
- `resolves sibling child scopes via the comment-scope range` — uses `renderChild` + `$c` to verify the second sibling's child scope resolves and inits.

Verified: full `@barefootjs/client` suite (286 pass), CSR conformance (81 pass), and single-root previews (e.g. `field`) still render unchanged. `native-select`'s empty `<select>` is a separate issue (#1633, `{...props}` spread children) and is unaffected.

## Notes

This is a core runtime fix that benefits any CSR consumer of multi-root/fragment components, not just preview. Complements #1624 (which generates the Fragment-wrapped multi-root previews that exposed this).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFWD1EnhMhCyQMoGnrq5NS)_