### PR TITLE
fix(release): stop spurious 1.0.0 bump from workspace:* peerDependencies

### DIFF
--- a/packages/adapter-go-template/package.json
+++ b/packages/adapter-go-template/package.json
@@ -68,7 +68,7 @@
     "directory": "packages/adapter-go-template"
   },
   "peerDependencies": {
-    "@barefootjs/jsx": "workspace:*",
+    "@barefootjs/jsx": ">=0.2.0",
     "typescript": "^5.0.0"
   },
   "devDependencies": {

--- a/packages/adapter-hono/package.json
+++ b/packages/adapter-hono/package.json
@@ -175,9 +175,9 @@
     "directory": "packages/adapter-hono"
   },
   "peerDependencies": {
-    "@barefootjs/client": "workspace:*",
-    "@barefootjs/jsx": "workspace:*",
-    "@barefootjs/shared": "workspace:*",
+    "@barefootjs/client": ">=0.2.0",
+    "@barefootjs/jsx": ">=0.2.0",
+    "@barefootjs/shared": ">=0.2.0",
     "hono": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/adapter-mojolicious/package.json
+++ b/packages/adapter-mojolicious/package.json
@@ -74,7 +74,7 @@
     "@barefootjs/shared": "workspace:*"
   },
   "peerDependencies": {
-    "@barefootjs/jsx": "workspace:*"
+    "@barefootjs/jsx": ">=0.2.0"
   },
   "devDependencies": {
     "@barefootjs/adapter-tests": "workspace:*",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -58,7 +58,7 @@
     "@barefootjs/shared": "workspace:*"
   },
   "peerDependencies": {
-    "@barefootjs/jsx": "workspace:*"
+    "@barefootjs/jsx": ">=0.2.0"
   },
   "peerDependenciesMeta": {
     "@barefootjs/jsx": {

--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -73,7 +73,7 @@
     "@barefootjs/shared": "workspace:*"
   },
   "peerDependencies": {
-    "@barefootjs/client": "workspace:*",
+    "@barefootjs/client": ">=0.2.0",
     "typescript": "^5.0.0"
   },
   "devDependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,8 +7,8 @@
     "build:registry": "bun run build-registry.ts"
   },
   "peerDependencies": {
-    "@barefootjs/jsx": "workspace:*",
-    "@barefootjs/client": "workspace:*"
+    "@barefootjs/jsx": ">=0.2.0",
+    "@barefootjs/client": ">=0.2.0"
   },
   "devDependencies": {
     "@barefootjs/test": "workspace:*"


### PR DESCRIPTION
## Background

The auto-generated "Version Packages" PR from Changesets ([#1623](https://github.com/piconic-ai/barefootjs/pull/1623), previously [#1598](https://github.com/piconic-ai/barefootjs/pull/1598)) keeps trying to bump every package to **1.0.0**, even though only minor/patch changesets exist. npm `latest` is still 0.2.0 for all packages — 1.0.0 was never published (it was manually reverted in `aed2c4b`).

## Root cause

Several internal packages (`jsx`, `client`, `go-template`, `hono`, `mojolicious`, `ui`) declared their internal dependencies in `peerDependencies` using the **`workspace:*`** protocol.

1. `jsx` (etc.) gets a minor bump.
2. For packages that have it as a peer dependency, Changesets uses `onlyUpdatePeerDependentsWhenOutOfRange: true` to check whether the new version is still in range.
3. But **`workspace:*` is not a valid semver range**, so `semver.satisfies("0.3.0", "workspace:*")` is always `false` → treated as out-of-range → the peer dependent is escalated to a **major** bump.
4. The `fixed: [["@barefootjs/*", "create-barefootjs"]]` group in `.changeset/config.json` then **propagates that major across every package** → everything goes to 1.0.0.

## Fix

Change the internal `@barefootjs/*` peer dependency ranges to `>=0.2.0`, matching the convention already used by `chart`/`form`/`xyflow`. The `workspace:*` ranges in `dependencies` are left untouched (publish-time replacement is unaffected, and regular deps don't trigger the escalation).

Verified locally with `changeset version`: the pending release now resolves to **0.3.0 instead of 1.0.0**, and the fix is durable (a later 0.3.0 → 0.4.0 minor still satisfies `>=0.2.0`, so it won't re-escalate).

## After merge

Merging this into `main` will cause the Changesets action to recompute #1623, which should then show 0.3.0.

## Test plan

- [ ] Dry-run `changeset version` and confirm each package resolves to `0.3.0`
- [ ] CI green (typecheck / tests)
- [ ] Confirm #1623 updates to 0.3.0

Co-authored-by: kobaken <kentafly88@gmail.com>