### PR TITLE
fix(ci): use merge-base diff in changeset check so it can't pass spuriously

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -43,7 +43,10 @@ jobs:
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
           HEAD_SHA="${{ github.event.pull_request.head.sha }}"
 
-          changed_files=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          # Use a 3-dot (merge-base) diff so we only consider what this PR
+          # actually changed since it branched from base — not commits that
+          # landed on base afterwards.
+          changed_files=$(git diff --name-only "$BASE_SHA...$HEAD_SHA")
 
           needs_changeset=false
           matched_paths=()
@@ -63,9 +66,11 @@ jobs:
           done
 
           if [ "$needs_changeset" = true ]; then
-            # Check the PR diff for new .changeset/*.md files (not find,
-            # which would also see pre-existing changesets on main).
-            changeset_files=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- '.changeset/*.md' | grep -v 'README.md' || true)
+            # Look for changesets ADDED by this PR. Must be a 3-dot
+            # (merge-base) diff: a 2-dot `git diff BASE HEAD` also surfaces
+            # changesets that exist on HEAD but were since released/removed
+            # from a moving BASE, which would satisfy the gate spuriously.
+            changeset_files=$(git diff --name-only --diff-filter=A "$BASE_SHA...$HEAD_SHA" -- '.changeset/*.md' | grep -v 'README.md' || true)
 
             if [ -z "$changeset_files" ]; then
               echo "::error::This PR modifies published package source but has no changeset."


### PR DESCRIPTION
## Problem

The `Changeset check` job (`.github/workflows/changeset-check.yml`) **runs** on PRs but can pass **spuriously**, so a PR that modifies published-package source without adding a changeset is not flagged.

It detected changesets with a **2-dot** diff:

```bash
git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- '.changeset/*.md'
```

A 2-dot `git diff BASE HEAD` reports any file that exists on `HEAD` but not on `BASE`. When a PR branches from a commit whose changesets were **later released/removed from the moving `main`** (via the Changesets "Version Packages" flow), those now-stale changesets appear as if the PR added them — satisfying the gate even though the PR adds none.

### Concrete case

PR #1634 changes only `packages/client/src/runtime/{render,hydrate}.ts` (+ tests) and adds **no** changeset, yet the gate is green. Reproducing the workflow logic locally:

- `needs_changeset = true` (client src changed) ✓
- 2-dot diff "finds" 13 `.changeset/*.md` → **OK** ✗ (none were added by the PR's own commits; `merge-base...HEAD` shows 0)

## Fix

Switch both the changed-file detection and the changeset-presence check to a **3-dot (merge-base)** diff, and restrict the latter to **added** files:

```bash
changed_files=$(git diff --name-only "$BASE_SHA...$HEAD_SHA")
changeset_files=$(git diff --name-only --diff-filter=A "$BASE_SHA...$HEAD_SHA" -- '.changeset/*.md' | grep -v 'README.md')
```

`A...B` diffs from `merge-base(A,B)` to `B`, i.e. only what the PR introduced since branching — stale changesets on the moving base no longer count. `actions/checkout` already uses `fetch-depth: 0`, so the merge-base is available.

## Verified locally (reproducing the workflow script)

- **Before:** #1634 → "Changeset found — OK" (spurious pass).
- **After:** #1634 → fails with "modifies published package source but has no changeset" (correct), while still detecting the `packages/client/src` change.

## Note

Once this lands, PRs that slipped through the loophole (e.g. #1634) will correctly require a changeset — expected. The fix itself touches only `.github/`, so it needs no changeset.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFWD1EnhMhCyQMoGnrq5NS)_