### PR TITLE
fix(form,chart): externalize @barefootjs/client in dist builds

### DIFF
--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts --outdir ./dist --format esm",
+    "build:js": "bun build ./src/index.ts --outdir ./dist --format esm --external '@barefootjs/client' --external '@barefootjs/client/runtime' --external '@barefootjs/client/reactive'",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist"

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts --outdir ./dist --format esm --external @barefootjs/client --external @standard-schema/*",
+    "build:js": "bun build ./src/index.ts --outdir ./dist --format esm --external @barefootjs/client",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist"

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts --outdir ./dist --format esm",
+    "build:js": "bun build ./src/index.ts --outdir ./dist --format esm --external @barefootjs/client --external @standard-schema/*",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist"


### PR DESCRIPTION
## Summary

Fixes #1637 and applies the same fix to `@barefootjs/chart`.

`@barefootjs/client` carries module-level reactive state (the `Owner`/`Listener` tree) that must be a **singleton** across the importmap. Any package that ships `@barefootjs/client` in its published `dist` instead of leaving it external ends up with a *second* runtime instance inside a compiled `"use client"` island, so signals/context never wire up to `barefoot.js`'s runtime — reactive updates silently break.

This was the case for two packages whose `build:js` did not externalize the peer:

- **`@barefootjs/form`** (#1637): inlined `createSignal`/`createEffect`; `createForm` signals lived in a separate runtime → typing/validation didn't update the DOM.
- **`@barefootjs/chart`**: imports `createContext` from `@barefootjs/client/runtime`; inlining it meant the chart's context resolution ran against a separate `Owner` tree and couldn't see providers set by `barefoot.js`.

## Changes

`packages/form/package.json`:
```
- bun build ./src/index.ts --outdir ./dist --format esm
+ bun build ./src/index.ts --outdir ./dist --format esm --external @barefootjs/client
```

`packages/chart/package.json`:
```
- bun build ./src/index.ts --outdir ./dist --format esm
+ bun build ./src/index.ts --outdir ./dist --format esm --external '@barefootjs/client' --external '@barefootjs/client/runtime' --external '@barefootjs/client/reactive'
```

(chart externalizes the `/runtime` and `/reactive` subpaths too, mirroring the already-correct `@barefootjs/xyflow` build.)

## Scope note

Audited all packages with `@barefootjs/client` as a peer dependency. `@barefootjs/xyflow`, `@barefootjs/jsx`, and `@barefootjs/adapter-hono` already externalize it correctly — only `form` and `chart` needed the fix. `@standard-schema/utils` is intentionally left bundled (stateless helper; keeps importmap surface small) and `@standard-schema/spec` is type-only.

## Verification

- form: `dist` keeps `import { createSignal, createMemo, untrack } from "@barefootjs/client"` bare; `getDotPath` stays inlined.
- chart: `dist` keeps `import { createContext } from "@barefootjs/client/runtime"` bare.

## Follow-up

New `@barefootjs/form` **and** `@barefootjs/chart` releases must be published after this merges for consumers to get the fix.

## Test plan

- [ ] `bun run build` in `packages/form` → `dist/index.js` has bare `@barefootjs/client` import
- [ ] `bun run build` in `packages/chart` → `dist/index.js` has bare `@barefootjs/client/runtime` import
- [ ] `createForm` in a compiled island reactively updates value/error after publish
- [ ] chart context resolves inside an island after publish
