### PR TITLE
fix(hono): let BfImportMap consume barefoot-externals.json

### DIFF
--- a/.changeset/bfimportmap-externals.md
+++ b/.changeset/bfimportmap-externals.md
@@ -1,0 +1,9 @@
+---
+"@barefootjs/hono": patch
+---
+
+`BfImportMap` now consumes `barefoot-externals.json` (#1639):
+
+- Add an optional `externals` prop (the parsed manifest). Its `importmap.imports` merge on top of the built-in `@barefootjs/client*` mappings, so islands importing configured externals (`zod`, `@barefootjs/form`, …) resolve in the browser instead of 404ing on bare specifiers.
+- Emit `<link rel="modulepreload">` for the manifest's `preloads`, toggleable via a new `preload` prop (defaults to `true`).
+- Keeps `app.ts` runtime-agnostic — the caller imports the JSON and passes it through, matching how `BfScripts` already takes `manifest`. Omitting `externals` preserves the prior client-only output.

--- a/packages/adapter-hono/src/__tests__/import-map.test.ts
+++ b/packages/adapter-hono/src/__tests__/import-map.test.ts
@@ -1,0 +1,88 @@
+/**
+ * BfImportMap tests
+ *
+ * Verifies the importmap merges configured externals from
+ * `barefoot-externals.json` (issue #1639) and emits modulepreload
+ * links, while preserving the pre-#1639 `@barefootjs/client*` defaults
+ * when no externals are passed.
+ */
+import { describe, test, expect } from 'bun:test'
+import { BfImportMap, type BarefootExternalsManifest } from '../app'
+
+function parseImportMap(html: string): Record<string, string> {
+  const match = html.match(/<script type="importmap">(.*?)<\/script>/s)
+  if (!match) throw new Error(`no importmap in: ${html}`)
+  return JSON.parse(match[1]).imports
+}
+
+describe('BfImportMap', () => {
+  test('emits @barefootjs/client defaults when no externals passed', () => {
+    const html = String(BfImportMap({ base: '/components' }))
+    expect(parseImportMap(html)).toEqual({
+      '@barefootjs/client': '/components/barefoot.js',
+      '@barefootjs/client/runtime': '/components/barefoot.js',
+    })
+    expect(html).not.toContain('modulepreload')
+  })
+
+  test('strips trailing slash from base', () => {
+    const html = String(BfImportMap({ base: '/components/' }))
+    expect(parseImportMap(html)['@barefootjs/client']).toBe('/components/barefoot.js')
+  })
+
+  test('merges externals importmap on top of the client defaults', () => {
+    const externals: BarefootExternalsManifest = {
+      importmap: {
+        imports: {
+          zod: 'https://esm.sh/zod@4.4.3',
+          '@barefootjs/form': '/components/form.js',
+        },
+      },
+      preloads: [],
+    }
+    const imports = parseImportMap(String(BfImportMap({ base: '/components', externals })))
+    expect(imports).toEqual({
+      '@barefootjs/client': '/components/barefoot.js',
+      '@barefootjs/client/runtime': '/components/barefoot.js',
+      zod: 'https://esm.sh/zod@4.4.3',
+      '@barefootjs/form': '/components/form.js',
+    })
+  })
+
+  test('manifest @barefootjs/client mapping wins over the prop-derived one', () => {
+    const externals: BarefootExternalsManifest = {
+      importmap: { imports: { '@barefootjs/client': '/vendor/barefoot.js' } },
+    }
+    const imports = parseImportMap(String(BfImportMap({ base: '/components', externals })))
+    expect(imports['@barefootjs/client']).toBe('/vendor/barefoot.js')
+  })
+
+  test('emits modulepreload links for manifest preloads', () => {
+    const externals: BarefootExternalsManifest = {
+      importmap: { imports: {} },
+      preloads: ['/components/form.js', 'https://esm.sh/zod@4.4.3'],
+    }
+    const html = String(BfImportMap({ base: '/components', externals }))
+    expect(html).toContain('<link rel="modulepreload" href="/components/form.js">')
+    expect(html).toContain('<link rel="modulepreload" href="https://esm.sh/zod@4.4.3">')
+  })
+
+  test('preload=false suppresses modulepreload links', () => {
+    const externals: BarefootExternalsManifest = {
+      preloads: ['/components/form.js'],
+    }
+    const html = String(BfImportMap({ base: '/components', externals, preload: false }))
+    expect(html).not.toContain('modulepreload')
+    // importmap still emitted
+    expect(parseImportMap(html)['@barefootjs/client']).toBe('/components/barefoot.js')
+  })
+
+  test('escapes double quotes in preload hrefs', () => {
+    const externals: BarefootExternalsManifest = {
+      preloads: ['/components/"onerror=alert(1).js'],
+    }
+    const html = String(BfImportMap({ base: '/components', externals }))
+    expect(html).not.toContain('"onerror=alert(1)')
+    expect(html).toContain('&quot;onerror=alert(1)')
+  })
+})

--- a/packages/adapter-hono/src/app.ts
+++ b/packages/adapter-hono/src/app.ts
@@ -88,25 +88,72 @@ export function relPathFromComponentsBase(p: string): string {
 
 // ── JSX components ─────────────────────────────────────────────────────────
 
+/**
+ * Shape of `barefoot-externals.json`, written by `bf build` when
+ * `externals` / `bundleEntries` are configured. Only the fields
+ * `BfImportMap` consumes are typed here; the build also emits an
+ * `externals` array (the `--external` list) which the importmap
+ * doesn't need. Fields are optional so a partial/hand-written
+ * manifest still type-checks. See issue #1639.
+ */
+export interface BarefootExternalsManifest {
+  /** Entries for the `<script type="importmap">`. */
+  importmap?: { imports?: Record<string, string> }
+  /** URLs to emit as `<link rel="modulepreload">`. */
+  preloads?: string[]
+}
+
 export interface BfImportMapProps {
   /** Base URL where the runtime + component bundles are served. */
   base: string
+  /**
+   * Contents of `barefoot-externals.json` (import it and pass it
+   * through). Its `importmap.imports` are merged on top of the
+   * built-in `@barefootjs/client*` mappings so islands importing
+   * configured externals (e.g. `zod`, `@barefootjs/form`) resolve in
+   * the browser. When omitted, only the `@barefootjs/client*`
+   * mappings are emitted — the pre-#1639 behavior.
+   */
+  externals?: BarefootExternalsManifest
+  /**
+   * Whether to also emit `<link rel="modulepreload">` for the
+   * manifest's `preloads`. Defaults to `true`; set `false` to emit
+   * the importmap only.
+   */
+  preload?: boolean
 }
 
 /**
  * Emits the `<script type="importmap">` that maps the bare
  * `@barefootjs/client` / `@barefootjs/client/runtime` specifiers to
- * the runtime bundle. Place in `<head>`.
+ * the runtime bundle, plus any externals from `barefoot-externals.json`
+ * passed via the `externals` prop. Also emits `<link rel="modulepreload">`
+ * for the manifest's `preloads` unless `preload` is `false`. Place in
+ * `<head>`.
  */
 export function BfImportMap(props: BfImportMapProps): HtmlEscapedString | Promise<HtmlEscapedString> {
   const base = props.base.replace(/\/$/, '')
-  const json = JSON.stringify({
-    imports: {
-      '@barefootjs/client': `${base}/barefoot.js`,
-      '@barefootjs/client/runtime': `${base}/barefoot.js`,
-    },
-  })
-  return html`<script type="importmap">${raw(json)}</script>`
+  // Built-in defaults first, then manifest imports so a configured
+  // `@barefootjs/client` mapping (emitted by `bf build` against the
+  // build's `externalsBasePath`) wins over the prop-derived one.
+  const imports: Record<string, string> = {
+    '@barefootjs/client': `${base}/barefoot.js`,
+    '@barefootjs/client/runtime': `${base}/barefoot.js`,
+    ...(props.externals?.importmap?.imports ?? {}),
+  }
+  const json = JSON.stringify({ imports })
+
+  const preloads = props.preload === false ? [] : props.externals?.preloads ?? []
+  const links = preloads
+    .map((href) => `<link rel="modulepreload" href="${escapeAttr(href)}">`)
+    .join('')
+
+  return html`<script type="importmap">${raw(json)}</script>${raw(links)}`
+}
+
+/** Minimal double-quoted-attribute escaping for config-derived URLs. */
+function escapeAttr(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;')
 }
 
 export interface BfScriptsProps {


### PR DESCRIPTION
## Summary

Fixes #1639. `BfImportMap` previously hardcoded only the `@barefootjs/client` / `@barefootjs/client/runtime` mappings and never consumed the `barefoot-externals.json` manifest that `bf build` emits when `externals`/`bundleEntries` are configured. As a result, islands importing external deps (`zod`, `@barefootjs/form`, …) had no browser resolution and their module scripts 404'd on the bare specifiers.

- Add an optional `externals` prop to `BfImportMap` (the parsed `barefoot-externals.json`). Its `importmap.imports` are merged **on top of** the built-in `@barefootjs/client*` defaults, so a configured client mapping (emitted against the build's `externalsBasePath`) wins over the prop-derived one.
- Emit `<link rel="modulepreload">` for the manifest's `preloads`, toggleable via a new `preload` prop (defaults to `true`).
- Keeps `app.ts` runtime-agnostic — no `node:fs`. The caller imports the JSON and passes it through, exactly like `BfScripts` already takes `manifest`.

### Usage

```tsx
import externals from './public/barefoot-externals.json'
...
<BfImportMap base={componentsBase} externals={externals} />
```

When the `externals` prop is omitted, behavior is unchanged (pre-#1639): only the `@barefootjs/client*` mappings are emitted and no preload links.

## Test plan

- [x] `bun test src/__tests__/import-map.test.ts` (new) — 7 cases: client defaults, trailing-slash base, externals merge, manifest-wins precedence, modulepreload emission, `preload: false` suppression, attribute escaping.
- [x] Full `adapter-hono` suite still passes (the 4 unrelated failures are pre-existing `@barefootjs/client` module-resolution errors in a fresh container, confirmed failing on `main` too).

Co-authored-by: kobaken &lt;kentafly88@gmail.com&gt;

---
_Generated by [Claude Code](https://claude.ai/code/session_015AU8xkxv5FFqX8KBSjSaL2)_