### PR TITLE
fix(jsx): auto-defer reactive brand-package bindings instead of BF061

### DIFF
--- a/.changeset/auto-defer-brand-bindings.md
+++ b/.changeset/auto-defer-brand-bindings.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Auto-defer reactive brand-package bindings (e.g. `@barefootjs/form` field accessors) referenced from template positions instead of raising BF061. `value={field.value()}`, `disabled={form.isSubmitting()}`, and `{field.error() && …}` now compile without a manual `/* @client */` on each binding.

--- a/packages/jsx/src/__tests__/auto-defer-brand.test.ts
+++ b/packages/jsx/src/__tests__/auto-defer-brand.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Auto-defer of reactive brand-package bindings (#1638).
+ *
+ * Controlled bindings to `@barefootjs/form` state — `value={field.value()}`,
+ * `disabled={form.isSubmitting()}`, `{field.error() && …}` — read per-instance
+ * init-scope state (`createForm` calls `createSignal` internally) that the
+ * module-scope SSR template lambda cannot evaluate. Previously each binding
+ * raised BF061 and forced a manual `/* @client *​/`. The compiler now treats
+ * such reads as implicitly client-only: the SSR template skips them and a
+ * hydrate-time effect applies the value — exactly what `/* @client *​/` did.
+ *
+ * These tests need a real TypeChecker that resolves the `Reactive<T>` brand,
+ * so they build a ts.Program with virtual form-library type defs and inject
+ * it into `compileJSX` (the brand is invisible to the regex fallback).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import ts from 'typescript'
+import path from 'path'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+import { extractTemplateBody, extractInitBody } from './staged-ir/helpers'
+
+const adapter = new TestAdapter()
+
+const FORM_DEFS = `
+  export type Reactive<T> = T & { readonly __reactive: true };
+  export type Memo<T> = Reactive<() => T>;
+
+  export interface FieldReturn<V> {
+    value: Reactive<() => V>;
+    error: Reactive<() => string>;
+    setValue: (value: V) => void;
+    handleInput: (e: Event) => void;
+  }
+
+  export interface FormReturn {
+    field: (name: string) => FieldReturn<string>;
+    isSubmitting: Reactive<() => boolean>;
+    handleSubmit: (e: Event) => Promise<void>;
+  }
+
+  export declare function createForm(opts?: unknown): FormReturn;
+`
+
+interface BrandCompileResult {
+  errors: string[]
+  templateBody: string
+  initBody: string
+  clientJs: string
+}
+
+/**
+ * Compile `componentSource` with a TypeChecker that resolves the form brand.
+ * The component must `import { createForm } from './_form-defs'`.
+ */
+function compileWithBrand(componentSource: string): BrandCompileResult {
+  const baseDir = path.resolve(__dirname)
+  const componentPath = path.join(baseDir, '_brand-component.tsx')
+  const defsPath = path.join(baseDir, '_form-defs.ts')
+
+  const virtualFiles = new Map<string, string>([
+    [componentPath, componentSource],
+    [defsPath, FORM_DEFS],
+  ])
+
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.Latest,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    jsx: ts.JsxEmit.ReactJSX,
+    strict: true,
+    skipLibCheck: true,
+    noEmit: true,
+  }
+
+  const defaultHost = ts.createCompilerHost(compilerOptions)
+  const host: ts.CompilerHost = {
+    ...defaultHost,
+    getSourceFile(fileName, languageVersion) {
+      const resolved = path.resolve(fileName)
+      const content = virtualFiles.get(resolved)
+      if (content !== undefined) {
+        const kind = resolved.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+        return ts.createSourceFile(fileName, content, languageVersion, true, kind)
+      }
+      return defaultHost.getSourceFile(fileName, languageVersion)
+    },
+    fileExists(fileName) {
+      return virtualFiles.has(path.resolve(fileName)) || defaultHost.fileExists(fileName)
+    },
+    readFile(fileName) {
+      return virtualFiles.get(path.resolve(fileName)) ?? defaultHost.readFile(fileName)
+    },
+  }
+
+  const program = ts.createProgram([componentPath], compilerOptions, host)
+  const result = compileJSX(componentSource, componentPath, { adapter, program })
+  const clientJs = result.files.find((f) => f.type === 'clientJs')?.content ?? ''
+  return {
+    errors: result.errors.map((e) => `[${e.code}] ${e.message}`),
+    templateBody: extractTemplateBody(clientJs),
+    initBody: extractInitBody(clientJs),
+    clientJs,
+  }
+}
+
+describe('auto-defer brand-package reactive bindings (#1638)', () => {
+  test('sanity: the injected program resolves the Reactive<T> brand', () => {
+    // If the brand did not resolve, the regex fallback would not flag
+    // `email.value()` reactive and nothing below would be meaningful.
+    const { errors } = compileWithBrand(`
+      'use client'
+      import { createForm } from './_form-defs'
+
+      export function Probe() {
+        const form = createForm()
+        const email = form.field('email')
+        return <input value={email.value()} />
+      }
+    `)
+    // No BF050 (we supplied a program) and, crucially, no BF061.
+    expect(errors.find((e) => e.startsWith('[BF061]'))).toBeUndefined()
+  })
+
+  test('element attribute `value={field.value()}` does not raise BF061', () => {
+    const { errors, templateBody, initBody } = compileWithBrand(`
+      'use client'
+      import { createForm } from './_form-defs'
+
+      export function SignupForm() {
+        const form = createForm()
+        const email = form.field('email')
+        return <input value={email.value()} />
+      }
+    `)
+
+    expect(errors.find((e) => e.startsWith('[BF061]'))).toBeUndefined()
+    // SSR template must not carry the deferred attribute...
+    expect(templateBody).not.toContain('value=')
+    // ...but the element keeps a slot marker and init wires the value.
+    expect(templateBody).toMatch(/bf="s\d+"/)
+    expect(initBody).toMatch(/setAttribute\(['"]value['"]|\.value\s*=/)
+  })
+
+  test('multiple controlled bindings each defer (value + disabled)', () => {
+    const { errors, templateBody } = compileWithBrand(`
+      'use client'
+      import { createForm } from './_form-defs'
+
+      export function SignupForm() {
+        const form = createForm()
+        const email = form.field('email')
+        return <input value={email.value()} disabled={form.isSubmitting()} />
+      }
+    `)
+
+    expect(errors.find((e) => e.startsWith('[BF061]'))).toBeUndefined()
+    expect(templateBody).not.toContain('value=')
+    expect(templateBody).not.toContain('disabled=')
+  })
+
+  test('conditional condition `field.error() && <p/>` defers instead of BF061', () => {
+    const { errors } = compileWithBrand(`
+      'use client'
+      import { createForm } from './_form-defs'
+
+      export function SignupForm() {
+        const form = createForm()
+        const email = form.field('email')
+        return (
+          <form>
+            <input value={email.value()} />
+            {email.error() && <p>{email.error()}</p>}
+          </form>
+        )
+      }
+    `)
+
+    expect(errors.find((e) => e.startsWith('[BF061]'))).toBeUndefined()
+    expect(errors.find((e) => e.startsWith('[BF060]'))).toBeUndefined()
+  })
+
+  test('native createSignal getter is NOT deferred (keeps SSR value)', () => {
+    // Same component imports the brand package (so a TypeChecker is present),
+    // but `count()` is a real signal with a derivable initial value — it must
+    // keep rendering server-side, not get stripped to a hydrate-only binding.
+    const { templateBody } = compileWithBrand(`
+      'use client'
+      import { createForm } from './_form-defs'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Mixed() {
+        const form = createForm()
+        const [count, setCount] = createSignal(0)
+        return <input data-count={count()} />
+      }
+    `)
+
+    // The signal-backed attribute is still emitted into the SSR template.
+    expect(templateBody).toContain('data-count=')
+  })
+})

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1323,7 +1323,10 @@ function transformExpressionInner(
     // IRLoop handles `isClientOnly` internally via `transformMapCall`; other
     // shapes (IRElement / IRFragment / IRLoop / IRComponent from inline JSX
     // helpers) are unchanged. Mirror that exactly here.
-    if (isClientOnly && ir.type === 'conditional') {
+    // A reactive brand-package condition (e.g. `form.field('x').error() &&
+    // …`) can't be SSR-evaluated, so defer the whole conditional rather
+    // than raising BF061 — same routing as a manual `/* @client */` (#1638).
+    if ((isClientOnly || shouldAutoDeferReactiveBrand(expr, ctx)) && ir.type === 'conditional') {
       ir.clientOnly = true
       if (!ir.slotId) {
         ir.slotId = generateSlotId(ctx)
@@ -3510,7 +3513,12 @@ function processAttributes(
       // Downstream routing: collect-elements wires this into
       // `reactiveAttrs` for elements; html-template strips it from
       // the SSR template (and from `renderChild` for components).
-      if (hasLeadingClientDirective(attr.initializer.expression, ctx.sourceFile)) {
+      //
+      // Reactive brand-package reads (`value={form.field('x').value()}`)
+      // are auto-deferred the same way: the SSR lambda can't evaluate the
+      // init-scope form state, so defer instead of raising BF061 (#1638).
+      if (hasLeadingClientDirective(attr.initializer.expression, ctx.sourceFile)
+        || shouldAutoDeferReactiveBrand(attr.initializer.expression, ctx)) {
         clientOnly = true
       }
     }
@@ -4227,6 +4235,35 @@ function isReactiveExpression(expr: string, ctx: TransformContext, astNode?: ts.
   }
 
   return false
+}
+
+/**
+ * Decide whether a JSX expression should be auto-deferred to the client
+ * (treated as if it carried `/* @client *​/`) because it reads reactive
+ * brand-package state the SSR template lambda cannot evaluate (#1638).
+ *
+ * The motivating case is `@barefootjs/form`: `const form = createForm(...)`
+ * is per-instance init-scope state, so `form.field('x').value()` /
+ * `form.isSubmitting()` resolve to an init-local with no compiler-derivable
+ * SSR value. Referencing them from a template position (element attribute,
+ * conditional condition) otherwise raises BF061 and forces a manual
+ * `/* @client *​/` on every binding.
+ *
+ * Gated tightly so it never demotes server-renderable reads:
+ *  - Requires the TypeChecker AND a `Reactive<T>` brand on the expression
+ *    (`containsReactiveExpression`), so plain values are untouched.
+ *  - Excludes native `createSignal` / `createMemo` getters (and their
+ *    chained-const aliases): they carry the same brand but DO have a
+ *    derivable initial value, so they must keep rendering server-side.
+ */
+function shouldAutoDeferReactiveBrand(expr: ts.Expression, ctx: TransformContext): boolean {
+  const checker = ctx.analyzer.checker
+  if (!checker) return false
+  if (!containsReactiveExpression(expr, checker)) return false
+  // Native signals/memos (incl. chained-const aliases) are SSR-derivable —
+  // leave them to the normal template path so their initial value renders.
+  if (isSignalOrMemoReference(ctx.getJS(expr), ctx)) return false
+  return true
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #1638.

Controlled bindings to `@barefootjs/form` state — `value={field.value()}`, `disabled={form.isSubmitting()}`, `{field.error() && …}` — read per-instance init-scope state (`const form = createForm(...)` calls `createSignal` internally). The module-scope SSR template lambda can't evaluate that init-local, so each binding raised **BF061** and forced a manual `/* @client */` on every one of them (a 3-field form needed ~6–7 markers, and forgetting one failed the build).

This implements option 1 from the issue (**auto-defer**): a `Reactive<T>`-branded read of un-hoistable init state is now treated as implicitly client-only, routed through the existing `/* @client */` machinery (SSR template skip + hydrate-time effect). No directive needed.

## Approach

- New `shouldAutoDeferReactiveBrand(expr, ctx)` in `packages/jsx/src/jsx-to-ir.ts`. It fires only when the TypeChecker confirms a `Reactive<T>` brand on the expression **and** the read is not a native `createSignal`/`createMemo` getter (those carry the same brand but have a compiler-derivable initial value, so they must keep rendering server-side).
- Wired into the two template positions that previously errored:
  - native element attributes (`processAttributes`)
  - conditional conditions (`transformExpressionInner`)
- Already-safe positions (component props, slotted text expressions) are unchanged.

Because the gate requires a resolved brand, components that don't import a reactive-brand package are completely unaffected — the regex fallback never sees the brand.

## Test plan

- [x] New `packages/jsx/src/__tests__/auto-defer-brand.test.ts` (injects a `ts.Program` with virtual form-library brand defs so the `Reactive<T>` brand actually resolves): element-attribute, multi-binding, and conditional cases no longer raise BF061; native `createSignal` getter still renders into the SSR template.
- [x] Verified red→green: with the fix reverted, all four cases reproduce the exact `[BF061] Init-scope local 'form' referenced from template scope` error from the issue.
- [x] Full `packages/jsx` suite: no new failures (the 4 pre-existing `aliased … resolves via checker` failures also fail on the untouched baseline in this environment).

https://claude.ai/code/session_01BWGbj4sgygcBXZYQmYkWGj

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWGbj4sgygcBXZYQmYkWGj)_