### PR TITLE
fix(cli): stop false-positive externals warning and keep peers external on rebundle

### DIFF
--- a/.changeset/externals-client-dedup-false-positive.md
+++ b/.changeset/externals-client-dedup-false-positive.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/cli": patch
+---
+
+externals: stop the false-positive "not browser-ready" warning for chunks whose only un-resolved imports are the always-importmap-resolved `@barefootjs/client*` dedup keys, and make `rebundle: true` pass those peers (and other configured externals) as `external` to esbuild so the shared reactive runtime is no longer inlined into the chunk (#1646).

--- a/.changeset/externals-client-dedup-false-positive.md
+++ b/.changeset/externals-client-dedup-false-positive.md
@@ -2,4 +2,4 @@
 "@barefootjs/cli": patch
 ---
 
-externals: stop the false-positive "not browser-ready" warning for chunks whose only un-resolved imports are the always-importmap-resolved `@barefootjs/client*` dedup keys, and make `rebundle: true` pass those peers (and other configured externals) as `external` to esbuild so the shared reactive runtime is no longer inlined into the chunk (#1646).
+externals: stop the false-positive "not browser-ready" warning for chunks whose only unresolved imports are the always-importmap-resolved `@barefootjs/client*` dedup keys, and make `rebundle: true` pass those peers (and other configured externals) as `external` to esbuild so the shared reactive runtime is no longer inlined into the chunk (#1646).

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -7,6 +7,7 @@ import {
   resolveBuildConfigFromTs,
   collectRelativeImportDeps,
   vendorChunkFilename,
+  extractBareImports,
   processExternals,
   processBundleEntries,
   computeGlobalHash,
@@ -395,6 +396,52 @@ describe('resolveBuildConfigFromTs with externals', () => {
     const config = resolveBuildConfigFromTs(projectDir, { adapter: mockAdapter })
     expect(config.externals).toBeUndefined()
     expect(config.externalsBasePath).toBeUndefined()
+  })
+})
+
+// ── extractBareImports ───────────────────────────────────────────────────
+
+describe('extractBareImports', () => {
+  test('collects static, side-effect, re-export, and dynamic specifiers', () => {
+    const code = [
+      `import { a } from '@barefootjs/client'`,
+      `import 'side-effect-pkg'`,
+      `export { b } from 'lib0/observable'`,
+      `const m = await import('dynamic-pkg')`,
+    ].join('\n')
+    expect(extractBareImports(code).sort()).toEqual(
+      ['@barefootjs/client', 'dynamic-pkg', 'lib0/observable', 'side-effect-pkg'].sort()
+    )
+  })
+
+  test('excludes relative, absolute, and URL specifiers', () => {
+    const code = [
+      `import a from './local'`,
+      `import b from '../sibling'`,
+      `import c from '/abs/path'`,
+      `import d from 'https://esm.sh/zod'`,
+      `import e from 'bare-pkg'`,
+    ].join('\n')
+    expect(extractBareImports(code)).toEqual(['bare-pkg'])
+  })
+
+  test('ignores specifiers inside comments and string literals (regex would false-positive)', () => {
+    const code = [
+      `// import { x } from 'commented-out-pkg'`,
+      `/* import y from 'block-comment-pkg' */`,
+      `const s = "import z from 'string-literal-pkg'"`,
+      `const t = \`import w from 'template-pkg'\``,
+      `import { real } from 'real-pkg'`,
+    ].join('\n')
+    expect(extractBareImports(code)).toEqual(['real-pkg'])
+  })
+
+  test('dedupes repeated specifiers', () => {
+    const code = [
+      `import { a } from '@barefootjs/client'`,
+      `import { b } from '@barefootjs/client'`,
+    ].join('\n')
+    expect(extractBareImports(code)).toEqual(['@barefootjs/client'])
   })
 })
 

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -671,6 +671,136 @@ describe('processExternals', () => {
       rmSync(outDir, { recursive: true, force: true })
     }
   })
+
+  test('chunk whose only external is @barefootjs/client does NOT warn (#1646)', async () => {
+    const projectDir = makeTmpDir()
+    const outDir = makeTmpDir()
+    try {
+      // import/main fallback, but the only bare import is the always-importmap-
+      // resolved @barefootjs/client dedup key — so the chunk is browser-ready.
+      const pkgDir = resolve(projectDir, 'node_modules', 'client-only-pkg')
+      mkdirSync(pkgDir, { recursive: true })
+      writeFileSync(
+        resolve(pkgDir, 'package.json'),
+        JSON.stringify({ name: 'client-only-pkg', version: '1.0.0', exports: { '.': { import: './index.mjs' } } })
+      )
+      writeFileSync(
+        resolve(pkgDir, 'index.mjs'),
+        `import { createSignal } from '@barefootjs/client'\nexport const x = createSignal(1)`
+      )
+
+      const config = makeConfig(projectDir, outDir, {
+        externals: { 'client-only-pkg': true as const },
+      })
+
+      const warnCalls: string[] = []
+      const originalWarn = console.warn
+      console.warn = (...args: unknown[]) => { warnCalls.push(args.join(' ')) }
+      try {
+        await processExternals(config, 'components', outDir)
+      } finally {
+        console.warn = originalWarn
+      }
+
+      const fallbackWarning = warnCalls.find(m =>
+        m.includes('client-only-pkg') && m.includes('import/main entry')
+      )
+      expect(fallbackWarning).toBeUndefined()
+      // The chunk is still copied and recorded in the importmap.
+      expect(require('fs').existsSync(resolve(outDir, 'client-only-pkg.js'))).toBe(true)
+      const manifest = JSON.parse(
+        require('fs').readFileSync(resolve(outDir, 'barefoot-externals.json'), 'utf8')
+      )
+      expect(manifest.importmap.imports['client-only-pkg']).toBe('/components/client-only-pkg.js')
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+      rmSync(outDir, { recursive: true, force: true })
+    }
+  })
+
+  test('chunk still warns about non-importmap bare imports alongside @barefootjs/client (#1646)', async () => {
+    const projectDir = makeTmpDir()
+    const outDir = makeTmpDir()
+    try {
+      const pkgDir = resolve(projectDir, 'node_modules', 'mixed-pkg')
+      mkdirSync(pkgDir, { recursive: true })
+      writeFileSync(
+        resolve(pkgDir, 'package.json'),
+        JSON.stringify({ name: 'mixed-pkg', version: '1.0.0', exports: { '.': { import: './index.mjs' } } })
+      )
+      writeFileSync(
+        resolve(pkgDir, 'index.mjs'),
+        `import { createSignal } from '@barefootjs/client'\nimport { obs } from 'lib0/observable'\nexport const x = createSignal(obs)`
+      )
+
+      const config = makeConfig(projectDir, outDir, {
+        externals: { 'mixed-pkg': true as const },
+      })
+
+      const warnCalls: string[] = []
+      const originalWarn = console.warn
+      console.warn = (...args: unknown[]) => { warnCalls.push(args.join(' ')) }
+      try {
+        await processExternals(config, 'components', outDir)
+      } finally {
+        console.warn = originalWarn
+      }
+
+      const warningMsg = warnCalls.find(m =>
+        m.includes('mixed-pkg') && m.includes('import/main entry')
+      )
+      expect(warningMsg).toBeDefined()
+      // Only the un-resolved import is reported, not @barefootjs/client.
+      expect(warningMsg).toContain('lib0/observable')
+      expect(warningMsg).not.toContain('@barefootjs/client')
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+      rmSync(outDir, { recursive: true, force: true })
+    }
+  })
+
+  test('rebundle keeps @barefootjs/client external instead of inlining it (#1646)', async () => {
+    const projectDir = makeTmpDir()
+    const outDir = makeTmpDir()
+    try {
+      // A fake @barefootjs/client that WOULD be inlined if not marked external.
+      const clientDir = resolve(projectDir, 'node_modules', '@barefootjs', 'client')
+      mkdirSync(clientDir, { recursive: true })
+      writeFileSync(
+        resolve(clientDir, 'package.json'),
+        JSON.stringify({ name: '@barefootjs/client', version: '1.0.0', main: './index.js' })
+      )
+      writeFileSync(resolve(clientDir, 'index.js'), `export const SHARED_RUNTIME_MARKER = 'do-not-inline'`)
+
+      // The rebundled peer imports @barefootjs/client; it must stay a bare import.
+      const pkgDir = resolve(projectDir, 'node_modules', 'rebundle-peer')
+      mkdirSync(pkgDir, { recursive: true })
+      writeFileSync(
+        resolve(pkgDir, 'package.json'),
+        JSON.stringify({ name: 'rebundle-peer', version: '1.0.0', exports: { '.': { import: './index.mjs' } } })
+      )
+      writeFileSync(
+        resolve(pkgDir, 'index.mjs'),
+        `import { SHARED_RUNTIME_MARKER } from '@barefootjs/client'\nexport const value = SHARED_RUNTIME_MARKER`
+      )
+
+      const config = makeConfig(projectDir, outDir, {
+        externals: { 'rebundle-peer': { rebundle: true } as const },
+      })
+
+      await processExternals(config, 'components', outDir)
+
+      const outFile = resolve(outDir, 'rebundle-peer.js')
+      expect(require('fs').existsSync(outFile)).toBe(true)
+      const content = require('fs').readFileSync(outFile, 'utf8')
+      // @barefootjs/client must NOT be bundled in — it resolves via the importmap.
+      expect(content).not.toContain('do-not-inline')
+      expect(content).toMatch(/from\s*['"]@barefootjs\/client['"]/)
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+      rmSync(outDir, { recursive: true, force: true })
+    }
+  })
 })
 
 // ── minification ────────────────────────────────────────────────────────

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -797,7 +797,7 @@ describe('processExternals', () => {
         m.includes('mixed-pkg') && m.includes('import/main entry')
       )
       expect(warningMsg).toBeDefined()
-      // Only the un-resolved import is reported, not @barefootjs/client.
+      // Only the unresolved import is reported, not @barefootjs/client.
       expect(warningMsg).toContain('lib0/observable')
       expect(warningMsg).not.toContain('@barefootjs/client')
     } finally {

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -1035,9 +1035,13 @@ function unresolvedBareImports(code: string, externals: Record<string, ExternalS
 /**
  * Packages to keep `external` when rebundling a chunk with esbuild: every other
  * configured external plus the always-importmap-resolved `@barefootjs/client*`
- * dedup keys. The chunk's own package is bundled (that is the point of
- * rebundle), so it is excluded. Without this, esbuild inlines the shared
- * reactive runtime into the chunk and bindings silently stop updating (#1646).
+ * dedup keys. The three exact dedup keys cover the listed subpaths, and the
+ * `@barefootjs/client/*` wildcard keeps any other `@barefootjs/client` subpath
+ * a chunk might import external too (esbuild only matches `external` entries
+ * exactly unless they contain `*`). The chunk's own package is bundled (that is
+ * the point of rebundle), so it is excluded. Without this, esbuild inlines the
+ * shared reactive runtime into the chunk and bindings silently stop updating
+ * (#1646).
  */
 function rebundleExternalsFor(pkgName: string, externals: Record<string, ExternalSpec>): string[] {
   return [...new Set<string>([
@@ -1341,7 +1345,7 @@ export async function processExternals(
         // file came from an import/main fallback (no umd/unpkg/jsdelivr), but a
         // chunk whose only externals are the always-importmap-resolved
         // @barefootjs/client* dedup keys is browser-ready in a BarefootJS app —
-        // warning there is a false positive (#1646).
+        // a warning here is a false positive (#1646).
         if (!entry.isBrowserReady) {
           const unresolved = unresolvedBareImports(text, config.externals)
           if (unresolved.length > 0) {

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -2,7 +2,7 @@
 
 import { compileJSX, combineParentChildClientJs, createProgramForCorpus, formatError, REACTIVE_PRIMITIVES, BROWSER_ONLY_CLIENT_APIS } from '@barefootjs/jsx'
 import type { TemplateAdapter, OutputLayout, PostBuildContext, ExternalSpec, BundleEntry } from '@barefootjs/jsx'
-import type ts from 'typescript'
+import ts from 'typescript'
 import { mkdir, readdir, stat, unlink } from 'node:fs/promises'
 import { resolve, basename, relative, dirname, isAbsolute } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -1002,24 +1002,18 @@ const BF_CLIENT_DEDUP_KEYS = [
 ]
 
 /**
- * Extract bare (non-relative, non-absolute, non-URL) module specifiers from
- * `import`/`export … from` statements, side-effect imports, and dynamic
- * `import()` calls in a source file.
+ * Extract bare (non-relative, non-absolute, non-URL) module specifiers from a
+ * source file. Uses TypeScript's lightweight file preprocessor (the same
+ * scanner the compiler uses for dependency discovery), so specifiers inside
+ * comments and string literals are ignored and `import` / `export … from` /
+ * dynamic `import()` / `require()` are all handled without bespoke regexes.
  */
 export function extractBareImports(code: string): string[] {
+  const { importedFiles } = ts.preProcessFile(code, true, true)
   const specifiers = new Set<string>()
-  const patterns = [
-    /(?:^|[^.\w$])(?:import|export)\b[^'";]*?\bfrom\s*['"]([^'"]+)['"]/g,
-    /(?:^|[^.\w$])import\s*['"]([^'"]+)['"]/g,
-    /(?:^|[^.\w$])import\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
-  ]
-  for (const re of patterns) {
-    let m: RegExpExecArray | null
-    while ((m = re.exec(code)) !== null) {
-      const spec = m[1]
-      if (!spec.startsWith('.') && !spec.startsWith('/') && !spec.includes('://')) {
-        specifiers.add(spec)
-      }
+  for (const { fileName } of importedFiles) {
+    if (!fileName.startsWith('.') && !fileName.startsWith('/') && !fileName.includes('://')) {
+      specifiers.add(fileName)
     }
   }
   return [...specifiers]

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -1002,6 +1002,58 @@ const BF_CLIENT_DEDUP_KEYS = [
 ]
 
 /**
+ * Extract bare (non-relative, non-absolute, non-URL) module specifiers from
+ * `import`/`export … from` statements, side-effect imports, and dynamic
+ * `import()` calls in a source file.
+ */
+export function extractBareImports(code: string): string[] {
+  const specifiers = new Set<string>()
+  const patterns = [
+    /(?:^|[^.\w$])(?:import|export)\b[^'";]*?\bfrom\s*['"]([^'"]+)['"]/g,
+    /(?:^|[^.\w$])import\s*['"]([^'"]+)['"]/g,
+    /(?:^|[^.\w$])import\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
+  ]
+  for (const re of patterns) {
+    let m: RegExpExecArray | null
+    while ((m = re.exec(code)) !== null) {
+      const spec = m[1]
+      if (!spec.startsWith('.') && !spec.startsWith('/') && !spec.includes('://')) {
+        specifiers.add(spec)
+      }
+    }
+  }
+  return [...specifiers]
+}
+
+/**
+ * Bare imports in `code` that the emitted importmap cannot resolve. A specifier
+ * is resolvable when it matches an importmap key exactly, or a trailing-slash
+ * key is a prefix of it. The keys are every configured external plus the
+ * always-emitted `@barefootjs/client*` dedup keys (#1646).
+ */
+function unresolvedBareImports(code: string, externals: Record<string, ExternalSpec>): string[] {
+  const keys = new Set<string>([...Object.keys(externals), ...BF_CLIENT_DEDUP_KEYS])
+  const isResolved = (spec: string) =>
+    keys.has(spec) || [...keys].some(k => k.endsWith('/') && spec.startsWith(k))
+  return extractBareImports(code).filter(spec => !isResolved(spec))
+}
+
+/**
+ * Packages to keep `external` when rebundling a chunk with esbuild: every other
+ * configured external plus the always-importmap-resolved `@barefootjs/client*`
+ * dedup keys. The chunk's own package is bundled (that is the point of
+ * rebundle), so it is excluded. Without this, esbuild inlines the shared
+ * reactive runtime into the chunk and bindings silently stop updating (#1646).
+ */
+function rebundleExternalsFor(pkgName: string, externals: Record<string, ExternalSpec>): string[] {
+  return [...new Set<string>([
+    ...Object.keys(externals).filter(k => k !== pkgName),
+    ...BF_CLIENT_DEDUP_KEYS,
+    '@barefootjs/client/*',
+  ])]
+}
+
+/**
  * Derive the output filename for a vendored chunk from its package name.
  * `@barefootjs/xyflow` → `xyflow.js`, `yjs` → `yjs.js`.
  */
@@ -1272,17 +1324,6 @@ export async function processExternals(
 
       const wantRebundle = typeof spec === 'object' && !('url' in spec) && spec.rebundle === true
 
-      // Warn when the resolved file came from an import/main fallback and rebundle is not set.
-      // These files may contain bare external imports (e.g. "lib0/observable") that the browser
-      // cannot resolve without a bundler or importmap. Set rebundle: true to inline them.
-      if (!entry.isBrowserReady && !wantRebundle) {
-        console.warn(
-          `Warning: externals — "${pkgName}" resolved via import/main entry (no umd/unpkg/jsdelivr found). ` +
-          `The copied file may contain external imports that are not browser-ready. ` +
-          `Set rebundle: true to re-bundle it into a self-contained ESM file.`
-        )
-      }
-
       const srcFile = entry.path
       const filename = vendorChunkFilename(pkgName)
       const destPath = resolve(runtimeOutDir, filename)
@@ -1294,13 +1335,33 @@ export async function processExternals(
           format: 'esm',
           bundle: true,
           minify: config.minify ?? false,
+          external: rebundleExternalsFor(pkgName, config.externals),
         })
         anyChanged = true
         console.log(`Generated (bundled): ${runtimeSubdir}/${filename}`)
       } else {
-        let content: string | Uint8Array = await readBytes(srcFile)
+        const bytes = await readBytes(srcFile)
+        const text = new TextDecoder().decode(bytes)
+
+        // Warn only about bare imports the importmap can't resolve. The resolved
+        // file came from an import/main fallback (no umd/unpkg/jsdelivr), but a
+        // chunk whose only externals are the always-importmap-resolved
+        // @barefootjs/client* dedup keys is browser-ready in a BarefootJS app —
+        // warning there is a false positive (#1646).
+        if (!entry.isBrowserReady) {
+          const unresolved = unresolvedBareImports(text, config.externals)
+          if (unresolved.length > 0) {
+            console.warn(
+              `Warning: externals — "${pkgName}" resolved via import/main entry (no umd/unpkg/jsdelivr found) ` +
+              `and imports packages not in the importmap: ${unresolved.join(', ')}. ` +
+              `These are not browser-ready. Set rebundle: true to re-bundle it into a self-contained ESM file.`
+            )
+          }
+        }
+
+        let content: string | Uint8Array = bytes
         if (config.minify) {
-          content = transpile(content instanceof Uint8Array ? new TextDecoder().decode(content) : content, { loader: 'js', minify: true })
+          content = transpile(text, { loader: 'js', minify: true })
         }
         if (await writeIfChanged(destPath, content)) {
           anyChanged = true


### PR DESCRIPTION
## Summary

Fixes the two externals footguns reported in #1646.

**Problem 1 — false-positive warning.** Every build printed `Warning: externals — "@barefootjs/form" … not browser-ready …` even though the chunk's only external import was `@barefootjs/client`, which is *always* in the importmap via the `BF_CLIENT_DEDUP_KEYS` → `barefoot.js`. The warning now inspects the copied chunk's actual bare imports and only fires for specifiers the importmap can't resolve (configured externals + the `@barefootjs/client*` dedup keys). A chunk whose only externals are the dedup keys no longer warns.

**Problem 2 — the suggested fix was harmful.** Following the advice (`rebundle: true`) re-introduced the exact bug #1637 fixed: the rebundle path called esbuild with `bundle: true` but no `external`, so `@barefootjs/client` got inlined into the chunk → the form got its own reactive runtime → bindings silently stopped updating. `rebundle` now passes all configured externals (except the package being bundled) plus the `@barefootjs/client*` dedup keys as `external` to esbuild, so peers stay shared.

## Changes

- `packages/cli/src/lib/build.ts`
  - `extractBareImports()` — pull bare module specifiers from `import` / `export … from` / dynamic `import()`.
  - `unresolvedBareImports()` — filter to specifiers the importmap can't resolve.
  - `rebundleExternalsFor()` — compute the `external` list for the rebundle path.
  - Chunk processing: warn only on genuinely unresolved imports; pass `external` to esbuild on `rebundle`.
- New tests in `packages/cli/src/__tests__/build.test.ts` covering: no warning when the only external is `@barefootjs/client`, still warning for `lib0/observable`-style imports, and `@barefootjs/client` staying external (not inlined) on rebundle.
- Changeset (`@barefootjs/cli` patch).

## Test plan

- [x] `bun test src/__tests__/build.test.ts` (81 pass, incl. 3 new externals tests)
- [x] `tsc --noEmit` on `build.ts` — clean
- [ ] Manual: `externals: { '@barefootjs/form': true }` build prints no warning; app still shares one runtime
- [ ] Manual: `externals: { '@barefootjs/form': { rebundle: true } }` keeps `@barefootjs/client` external and reactivity works

Closes #1646

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1VUfa3pxxokT3Bw9Vgbm7)_