### PR TITLE
fix(hono): emit crossorigin on BfImportMap modulepreload hints

### DIFF
--- a/.changeset/import-map-crossorigin-preload.md
+++ b/.changeset/import-map-crossorigin-preload.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/hono": patch
+---
+
+`BfImportMap` now emits `crossorigin` on its `<link rel="modulepreload">` hints (#1648). Cross-origin (CDN) module imports are CORS fetches, so a preload without `crossorigin` couldn't be matched and the browser would discard it and re-fetch — wasting the preload and logging a "preload was not used" warning. The attribute is harmless for same-origin module preloads (same credentials mode either way).

--- a/packages/adapter-hono/src/__tests__/import-map.test.ts
+++ b/packages/adapter-hono/src/__tests__/import-map.test.ts
@@ -63,8 +63,17 @@ describe('BfImportMap', () => {
       preloads: ['/components/form.js', 'https://esm.sh/zod@4.4.3'],
     }
     const html = String(BfImportMap({ base: '/components', externals }))
-    expect(html).toContain('<link rel="modulepreload" href="/components/form.js">')
-    expect(html).toContain('<link rel="modulepreload" href="https://esm.sh/zod@4.4.3">')
+    expect(html).toContain('<link rel="modulepreload" href="/components/form.js" crossorigin>')
+    expect(html).toContain('<link rel="modulepreload" href="https://esm.sh/zod@4.4.3" crossorigin>')
+  })
+
+  test('emits crossorigin on modulepreload so cross-origin CDN preloads are reused', () => {
+    const externals: BarefootExternalsManifest = {
+      preloads: ['https://esm.sh/zod@4.4.3'],
+    }
+    const html = String(BfImportMap({ base: '/components', externals }))
+    const match = html.match(/<link rel="modulepreload"[^>]*>/)
+    expect(match?.[0]).toContain('crossorigin')
   })
 
   test('preload=false suppresses modulepreload links', () => {

--- a/packages/adapter-hono/src/app.ts
+++ b/packages/adapter-hono/src/app.ts
@@ -144,8 +144,13 @@ export function BfImportMap(props: BfImportMapProps): HtmlEscapedString | Promis
   const json = JSON.stringify({ imports })
 
   const preloads = props.preload === false ? [] : props.externals?.preloads ?? []
+  // `crossorigin` is required so a cross-origin (CDN) preload's request
+  // matches the actual module `import` (always a CORS fetch); without it
+  // the browser discards the preload and re-fetches. It's harmless for
+  // same-origin module preloads, which use the same credentials mode
+  // whether or not the attribute is present. See issue #1648.
   const links = preloads
-    .map((href) => `<link rel="modulepreload" href="${escapeAttr(href)}">`)
+    .map((href) => `<link rel="modulepreload" href="${escapeAttr(href)}" crossorigin>`)
     .join('')
 
   return html`<script type="importmap">${raw(json)}</script>${raw(links)}`


### PR DESCRIPTION
## Summary

Fixes #1648.

`BfImportMap` emitted `<link rel="modulepreload">` hints **without** a `crossorigin` attribute. For cross-origin (CDN) externals — e.g. a `zod` chunk served from esm.sh via `externals: { zod: { url: 'https://esm.sh/...', preload: true } }` — the preload's request mode couldn't be matched to the actual module `import` (always a CORS fetch). The browser discarded the preload and re-fetched the module, wasting the preload and logging a *"preload was found but not used"* warning.

This adds `crossorigin` to the emitted hints:

```js
`<link rel="modulepreload" href="${escapeAttr(href)}" crossorigin>`
```

Emitted unconditionally, matching the issue's recommendation and Vite's behavior. It's harmless for same-origin module preloads — module scripts use the same credentials mode whether or not the attribute is present.

## Changes

- `packages/adapter-hono/src/app.ts` — emit `crossorigin` on `BfImportMap`'s modulepreload links.
- `packages/adapter-hono/src/__tests__/import-map.test.ts` — update existing assertions and add a regression test for the `crossorigin` attribute.
- `.changeset/import-map-crossorigin-preload.md` — patch changeset for `@barefootjs/hono`.

## Test plan

- [x] `bun test packages/adapter-hono/src/__tests__/import-map.test.ts` — 8 pass.
- [ ] Verify in a browser that a CDN external (e.g. zod from esm.sh) preload is reused and the "preload not used" console warning is gone.

Note: 4 pre-existing failures in the full adapter-hono suite (`context-provider` / `ssr-context-bridge`) are unrelated — they require a built `@barefootjs/client` package, which has no `dist` in a fresh container.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BZRC6cMrNiqswSkbRbuK92)_