### PR TITLE
fix(test): converge TestNode#on() on undefined + document setters/via scope

### DIFF
--- a/.changeset/test-on-undefined-sentinel.md
+++ b/.changeset/test-on-undefined-sentinel.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/test": patch
+---
+
+`TestNode#on()` now returns `undefined` (instead of `null`) for unwired events, matching the `onClick`/`onInput`/`onChange`/`onSubmit` shorthand getters — so a single matcher (`toBeUndefined()`) covers either accessor. Also documents that `EventHandler.setters`/`via` resolve only raw signal setters declared in the component and stay empty for library property-access handlers (e.g. `@barefootjs/form`'s `name.handleInput`, `form.handleSubmit`).

--- a/packages/test/__tests__/event-handler-wiring.test.ts
+++ b/packages/test/__tests__/event-handler-wiring.test.ts
@@ -156,11 +156,11 @@ describe('EventHandler wiring on TestNode', () => {
     `
     const result = renderToTest(source, 'Keyboard.tsx')
     const input = result.find({ tag: 'input' })
-    expect(input!.on('keydown')).not.toBeNull()
+    expect(input!.on('keydown')).toBeDefined()
     expect(input!.on('keydown')!.setters).toContain('setKey')
   })
 
-  test('on() returns null for unregistered events', () => {
+  test('on() and shorthand getters agree on undefined for unregistered events', () => {
     const source = `
       export function Static() {
         return <button>Click</button>
@@ -168,8 +168,9 @@ describe('EventHandler wiring on TestNode', () => {
     `
     const result = renderToTest(source, 'Static.tsx')
     const btn = result.find({ tag: 'button' })
+    // Both access paths use the same "not wired" sentinel (undefined).
     expect(btn!.onClick).toBeUndefined()
-    expect(btn!.on('click')).toBeNull()
+    expect(btn!.on('click')).toBeUndefined()
   })
 
   test('handler with no setter calls returns empty setters', () => {
@@ -235,7 +236,7 @@ describe('EventHandler wiring on TestNode', () => {
     const result = renderToTest(source, 'Form.tsx')
     const sw = result.find({ componentName: 'Switch' })
     expect(sw!.events).toContain('checkedChange')
-    expect(sw!.on('checkedChange')).not.toBeNull()
+    expect(sw!.on('checkedChange')).toBeDefined()
     expect(sw!.on('checkedChange')!.setters).toContain('setEnabled')
   })
 

--- a/packages/test/src/test-node.ts
+++ b/packages/test/src/test-node.ts
@@ -4,6 +4,16 @@
  * Produced by converting the compiler IR into a flat, assertion-friendly shape.
  */
 
+/**
+ * Statically-resolved wiring for a single event handler.
+ *
+ * `setters`/`via` are populated only for handlers that reach raw signal setters
+ * declared in the component — directly (`onClick={() => setX(1)}`) or through
+ * local helper functions (`via`). Handlers backed by a library's
+ * property-access method — e.g. `@barefootjs/form`'s `name.handleInput` or
+ * `form.handleSubmit` — register the event but report empty `setters`/`via`,
+ * because the setter calls live inside the library, not the component body.
+ */
 export interface EventHandler {
   setters: string[]
   via: string[]
@@ -51,8 +61,9 @@ export class TestNode implements TestNodeData {
   get onChange(): EventHandler | undefined { return this.handlers.change }
   get onSubmit(): EventHandler | undefined { return this.handlers.submit }
 
-  on(event: string): EventHandler | null {
-    return this.handlers[event] ?? null
+  /** Returns the handler wired to `event`, or `undefined` if none — matching the shorthand getters. */
+  on(event: string): EventHandler | undefined {
+    return this.handlers[event]
   }
 
   constructor(data: TestNodeData) {

--- a/spec/testing.md
+++ b/spec/testing.md
@@ -171,7 +171,7 @@ interface TestNodeQuery {
 }
 
 interface EventHandler {
-  setters: string[]      // signal setters the handler ends up calling
+  setters: string[]      // signal setters the handler ends up calling (empty for library property-access handlers — see note below)
   via: string[]          // helper-function call chain to reach those setters
 }
 
@@ -195,9 +195,13 @@ interface TestNode {
   onInput?: EventHandler
   onChange?: EventHandler
   onSubmit?: EventHandler
-  on(event: string): EventHandler | null        // any other event, e.g. on('keydown')
+  on(event: string): EventHandler | undefined   // any other event, e.g. on('keydown')
 }
 ```
+
+Both access paths agree on the "not wired" sentinel: `on('blur')` and the
+shorthand getters (`onInput`, …) all return `undefined` when no handler is
+wired, so a single matcher (`toBeUndefined()`) covers either accessor.
 
 ### Event-handler wiring
 
@@ -221,6 +225,14 @@ expect(root!.on('pointerdown')!.setters).toContain('setInternalValue')
 Assert the *path*, not the value. "Clicking + shows 2" is an E2E concern; the
 wiring layer only proves "onClick reaches setCount". A handler with no setter
 call (e.g. `onClick={() => console.log(x)}`) resolves to empty `setters`.
+
+`setters`/`via` only resolve **raw signal setters declared in the component**.
+Handlers wired through a library's property-access methods — e.g.
+`@barefootjs/form`'s `name.handleInput` or `form.handleSubmit` — register the
+event (so `on('input')`/`onInput` is defined) but report empty `setters`/`via`,
+because the setter calls live inside the library, not the component body. Assert
+that the event is *wired* (`expect(node.onInput).toBeDefined()`) rather than
+which setter it reaches.
 
 ### Pattern
 


### PR DESCRIPTION
Closes #1653.

Two small DX/docs fixes for the `@barefootjs/test` 0.3.0 event-wiring API.

## 1. `on()` / getter sentinel asymmetry
`TestNode#on()` returned `null` for unwired events while the `onClick`/`onInput`/`onChange`/`onSubmit` getters returned `undefined`, forcing tests to mix `toBeNull()` / `toBeUndefined()` depending on the accessor.

`on()` now returns `EventHandler | undefined`, so "not wired" uses a single sentinel (`undefined`) across both access paths — `toBeUndefined()` covers either.

## 2. `setters` / `via` are empty for library handlers
Documented (on the `EventHandler` type and in `spec/testing.md`) that `setters`/`via` resolve only raw signal setters declared in the component. Handlers wired through a library's property-access methods — e.g. `@barefootjs/form`'s `name.handleInput` / `form.handleSubmit` — register the event but report empty `setters`/`via`, since the setter calls live inside the library. Tests should assert the event is wired (`toBeDefined()`) rather than which setter it reaches.

## Changes
- `packages/test/src/test-node.ts` — `on()` returns `undefined`; JSDoc on `EventHandler` explaining the scope of `setters`/`via`.
- `spec/testing.md` — updated `on()` signature, sentinel-convergence note, and library-handler caveat.
- `packages/test/__tests__/event-handler-wiring.test.ts` — assert the `undefined` convergence; `not.toBeNull()` → `toBeDefined()` on wired cases.
- `.changeset/test-on-undefined-sentinel.md` — patch changeset.

## Test plan
- [x] `bun test packages/test/__tests__/` (26 pass)
- [x] `bun test` for slider / scroll-area / calendar component tests that use `on()` (42 pass)
- [x] `tsgo --noEmit` typecheck of `@barefootjs/test` (clean)


---
_Generated by [Claude Code](https://claude.ai/code/session_01L7qs8KiptnoGcDLZExkGzR)_