### PR TITLE
fix(mojo): plumb destructured rest-spread bag into render_child child scope

### DIFF
--- a/.changeset/mojo-render-child-rest-spread.md
+++ b/.changeset/mojo-render-child-rest-spread.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/mojolicious": patch
+---
+
+Fix the Mojo test renderer (`renderMojoComponent`) so a child component that destructures a rest-spread bag (`function NativeSelect({ children, ...props })`) renders instead of dying on an undeclared `$props`. `buildChildRenderers` now defaults the rest-props identifier to an empty hashref when the caller doesn't supply one, matching the production runtime's manifest-driven `isRestProps` plumbing (#1652).

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -69,21 +69,6 @@ runAdapterConformanceTests({
     'toggle-shared',
     'reactive-props',
     'props-reactivity-comparison',
-    // #1633: child component forwards a destructured rest bag
-    // (`function NativeSelect({ children, ...props })`) onto its
-    // element via `{...props}`. The Mojo child template references
-    // `$props` (`<%== $bf->spread_attrs($props) %>`), but
-    // `render_child` doesn't plumb the rest-spread bag into the child
-    // template's scope, so rendering dies with `Global symbol "$props"
-    // requires explicit package name`. The Go adapter plumbs the same
-    // bag via the `Spread_0`/`Extras map[string]any` Input field, so it
-    // renders fine; Mojo needs the equivalent render_child plumbing.
-    // The fixture exists to pin the CSR layer of #1633 (children
-    // materialization), which Hono / Go / CSR all verify — Mojo's
-    // spread-bag-in-child gap is orthogonal. Same class of spread-bag
-    // limitation that keeps `jsx-spread-rest-prop` /
-    // `jsx-spread-props-object` off the CSR conformance path.
-    'native-select-spread-children',
   ],
   // Per-fixture build-time contracts for shapes the Mojo adapter
   // intentionally refuses to lower. Owned by this adapter test file

--- a/packages/adapter-mojolicious/src/test-render.ts
+++ b/packages/adapter-mojolicious/src/test-render.ts
@@ -305,7 +305,7 @@ function buildChildRenderers(
   const lines: string[] = []
   lines.push(`# Register child component renderers`)
 
-  for (const [componentName] of childTemplates) {
+  for (const [componentName, { ir: childIR }] of childTemplates) {
     const snakeName = toSnakeCase(componentName)
     const childTemplatePath = resolve(tempDir, `${snakeName}.html.ep`)
 
@@ -326,6 +326,21 @@ function buildChildRenderers(
 
     lines.push(`  $bf->register_child_renderer('${snakeName}', sub {`)
     lines.push(`    my ($child_props) = @_;`)
+    // (#1652) A child that destructures a rest-spread bag
+    // (`function NativeSelect({ children, ...props })`) emits a
+    // template referencing `$<restPropsName>`
+    // (`<%== bf->spread_attrs($props) %>`). The parent's render_child
+    // call only forwards the props it explicitly passed (here just
+    // `children`), so the rest bag never reaches the child stash and
+    // Perl strict mode aborts with `Global symbol "$props" requires
+    // explicit package name`. Seed it with an empty hashref when the
+    // caller didn't supply one — mirroring the top-level harness path
+    // (`buildPerlProps`) and the production runtime's
+    // `_derive_stash_from_defaults` `isRestProps` branch, which plumbs
+    // the equivalent of Go's `Spread_0`/`Extras` Input field.
+    if (childIR.metadata.restPropsName) {
+      lines.push(`    $child_props->{${childIR.metadata.restPropsName}} = {} unless defined $child_props->{${childIR.metadata.restPropsName}};`)
+    }
     lines.push(`    ${slotIdsPerl}`)
     lines.push(`    my $child_bf = BarefootJS->new($c, {});`)
     lines.push(`    $child_bf->_scope_id("test_$sid");`)

--- a/packages/adapter-mojolicious/src/test-render.ts
+++ b/packages/adapter-mojolicious/src/test-render.ts
@@ -339,7 +339,8 @@ function buildChildRenderers(
     // `_derive_stash_from_defaults` `isRestProps` branch, which plumbs
     // the equivalent of Go's `Spread_0`/`Extras` Input field.
     if (childIR.metadata.restPropsName) {
-      lines.push(`    $child_props->{${childIR.metadata.restPropsName}} = {} unless defined $child_props->{${childIR.metadata.restPropsName}};`)
+      const rest = childIR.metadata.restPropsName
+      lines.push(`    $child_props->{${rest}} = {} unless defined $child_props->{${rest}};`)
     }
     lines.push(`    ${slotIdsPerl}`)
     lines.push(`    my $child_bf = BarefootJS->new($c, {});`)

--- a/packages/adapter-tests/fixtures/native-select-spread-children.ts
+++ b/packages/adapter-tests/fixtures/native-select-spread-children.ts
@@ -22,15 +22,14 @@ import { createFixture } from '../src/types'
  * entries in csr-conformance's skip set) so the regression it guards
  * (children materialization) is the only thing under test.
  *
- * Adapter coverage: Hono SSR, Go SSR and the CSR template path all
- * render this fixture. The Mojo adapter skips it (`skipJsx` in
- * `mojo-adapter.test.ts`) because `render_child` doesn't plumb the
- * destructured rest bag (`{ children, ...props }`) into the child
- * template scope, so the emitted `$bf->spread_attrs($props)` dies on
- * an undeclared `$props`. Go plumbs the same bag via its
- * `Spread_0`/`Extras map[string]any` Input field. Mojo render_child
- * spread-bag plumbing is tracked as a separate follow-up; #1633 is a
- * CSR-layer bug, so CSR + Hono + Go coverage is sufficient here.
+ * Adapter coverage: Hono SSR, Go SSR, the CSR template path and Mojo
+ * SSR all render this fixture. Go plumbs the destructured rest bag
+ * (`{ children, ...props }`) via its `Spread_0`/`Extras map[string]any`
+ * Input field; the Mojo runtime seeds the same bag into the child
+ * template stash from the manifest's `ssrDefaults` (`isRestProps`), and
+ * the test harness's `buildChildRenderers` defaults it to an empty
+ * hashref so `bf->spread_attrs($props)` reads a defined `$props`
+ * (#1652).
  */
 export const fixture = createFixture({
   id: 'native-select-spread-children',


### PR DESCRIPTION
## Summary

Fixes #1652. The Mojo adapter could not render a **child component**
(invoked via `render_child`) whose body spreads a destructured rest bag
onto an element:

```tsx
function NativeSelect({ children, ...props }: SelectHTMLAttributes) {
  return <select data-slot="native-select" {...props}>{children}</select>
}
```

The child template references `$props`
(`<%== bf->spread_attrs($props) %>`), but the test harness's
`buildChildRenderers` built its own child-renderer closure that never
seeded the rest-spread bag into the child stash, so rendering died at
Perl render time:

```
Global symbol "$props" requires explicit package name (did you forget to declare "my $props"?)
```

The **production** runtime already plumbs this bag via the manifest's
`ssrDefaults` (`extractSsrDefaults` emits `restPropsName → { isRestProps: true, value: {} }`,
consumed by `_derive_stash_from_defaults`) — the gap was purely in the
test harness.

## Changes

- `test-render.ts`: `buildChildRenderers` now reads the child IR's
  `restPropsName` and defaults `$child_props->{<name>}` to an empty
  hashref when the caller didn't supply one — mirroring the top-level
  `buildPerlProps` path and the production `_derive_stash_from_defaults`
  `isRestProps` branch (the equivalent of Go's `Spread_0`/`Extras` Input
  field).
- `mojo-adapter.test.ts`: removed the `native-select-spread-children`
  `skipJsx` entry (the issue's stated acceptance test).
- `native-select-spread-children.ts`: refreshed the fixture docstring to
  reflect Mojo SSR coverage.

## Test plan

- [x] `bun test packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts` — 280 pass / 0 fail (the fixture now renders through Perl/Mojolicious instead of being skipped)
- [x] `bun test packages/adapter-mojolicious/src/__tests__/` — 290 pass / 0 fail
- [x] `tsc --noEmit` on `@barefootjs/mojolicious` — clean
- [x] Verified end-to-end render with Mojolicious 9.35: `<select data-slot="native-select" bf-s="test_s0" bf-r="">…<option>…` normalizes to the fixture's `expectedHtml`

Closes #1652

https://claude.ai/code/session_01XzVXD4U5dbEujB3UaJC3p7

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzVXD4U5dbEujB3UaJC3p7)_