### PR TITLE
refactor: unify importmap manifest type across adapters

### DIFF
--- a/.changeset/unify-importmap-manifest-type.md
+++ b/.changeset/unify-importmap-manifest-type.md
@@ -1,0 +1,14 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/hono": patch
+---
+
+Unify the importmap manifest type across the component and snippet paths.
+
+Both importmap injection paths now describe `barefoot-externals.json` with one
+type. `@barefootjs/jsx` exports a shared `ImportMapManifest` (the optional-field
+subset the renderer needs); `renderImportMapHtml` takes it, and the strict build
+output `ExternalsManifest` remains its all-required superset. Hono's
+`BarefootExternalsManifest` is now a back-compat alias of `ImportMapManifest`
+rather than a separate interface, so the Hono `BfImportMap` prop and the
+`bf build` snippet share the same manifest shape.

--- a/.changeset/unify-importmap-manifest-type.md
+++ b/.changeset/unify-importmap-manifest-type.md
@@ -1,6 +1,6 @@
 ---
 "@barefootjs/jsx": patch
-"@barefootjs/hono": patch
+"@barefootjs/hono": minor
 ---
 
 Unify the importmap manifest type across the component and snippet paths.
@@ -8,7 +8,9 @@ Unify the importmap manifest type across the component and snippet paths.
 Both importmap injection paths now describe `barefoot-externals.json` with one
 type. `@barefootjs/jsx` exports a shared `ImportMapManifest` (the optional-field
 subset the renderer needs); `renderImportMapHtml` takes it, and the strict build
-output `ExternalsManifest` remains its all-required superset. Hono's
-`BarefootExternalsManifest` is now a back-compat alias of `ImportMapManifest`
-rather than a separate interface, so the Hono `BfImportMap` prop and the
-`bf build` snippet share the same manifest shape.
+output `ExternalsManifest` remains its all-required superset.
+
+**Breaking (`@barefootjs/hono`):** the `BarefootExternalsManifest` type export is
+removed. Type a `BfImportMap` `externals` prop with `ImportMapManifest` from
+`@barefootjs/jsx` instead (the runtime prop shape is unchanged, so importing the
+parsed `barefoot-externals.json` and passing it through still works).

--- a/packages/adapter-hono/src/__tests__/import-map.test.ts
+++ b/packages/adapter-hono/src/__tests__/import-map.test.ts
@@ -7,7 +7,8 @@
  * when no externals are passed.
  */
 import { describe, test, expect } from 'bun:test'
-import { BfImportMap, type BarefootExternalsManifest } from '../app'
+import { BfImportMap } from '../app'
+import type { ImportMapManifest } from '@barefootjs/jsx'
 
 function parseImportMap(html: string): Record<string, string> {
   const match = html.match(/<script type="importmap">(.*?)<\/script>/s)
@@ -31,7 +32,7 @@ describe('BfImportMap', () => {
   })
 
   test('merges externals importmap on top of the client defaults', () => {
-    const externals: BarefootExternalsManifest = {
+    const externals: ImportMapManifest = {
       importmap: {
         imports: {
           zod: 'https://esm.sh/zod@4.4.3',
@@ -50,7 +51,7 @@ describe('BfImportMap', () => {
   })
 
   test('manifest @barefootjs/client mapping wins over the prop-derived one', () => {
-    const externals: BarefootExternalsManifest = {
+    const externals: ImportMapManifest = {
       importmap: { imports: { '@barefootjs/client': '/vendor/barefoot.js' } },
     }
     const imports = parseImportMap(String(BfImportMap({ base: '/components', externals })))
@@ -58,7 +59,7 @@ describe('BfImportMap', () => {
   })
 
   test('emits modulepreload links for manifest preloads', () => {
-    const externals: BarefootExternalsManifest = {
+    const externals: ImportMapManifest = {
       importmap: { imports: {} },
       preloads: ['/components/form.js', 'https://esm.sh/zod@4.4.3'],
     }
@@ -68,7 +69,7 @@ describe('BfImportMap', () => {
   })
 
   test('emits crossorigin on modulepreload so cross-origin CDN preloads are reused', () => {
-    const externals: BarefootExternalsManifest = {
+    const externals: ImportMapManifest = {
       preloads: ['https://esm.sh/zod@4.4.3'],
     }
     const html = String(BfImportMap({ base: '/components', externals }))
@@ -77,7 +78,7 @@ describe('BfImportMap', () => {
   })
 
   test('preload=false suppresses modulepreload links', () => {
-    const externals: BarefootExternalsManifest = {
+    const externals: ImportMapManifest = {
       preloads: ['/components/form.js'],
     }
     const html = String(BfImportMap({ base: '/components', externals, preload: false }))
@@ -87,7 +88,7 @@ describe('BfImportMap', () => {
   })
 
   test('escapes double quotes in preload hrefs', () => {
-    const externals: BarefootExternalsManifest = {
+    const externals: ImportMapManifest = {
       preloads: ['/components/"onerror=alert(1).js'],
     }
     const html = String(BfImportMap({ base: '/components', externals }))

--- a/packages/adapter-hono/src/app.ts
+++ b/packages/adapter-hono/src/app.ts
@@ -32,7 +32,7 @@ import type { HtmlEscapedString } from 'hono/utils/html'
 import { useRequestContext } from 'hono/jsx-renderer'
 // Zero-dependency subpath — keeps the compiler (and its `typescript` dep) out
 // of this runtime/Workers-bundled module while sharing one importmap renderer.
-import { renderImportMapHtml } from '@barefootjs/jsx/import-map'
+import { renderImportMapHtml, type ImportMapManifest } from '@barefootjs/jsx/import-map'
 import { createDevReloader } from './dev-worker'
 
 const DEV_RELOAD_ENDPOINT_KEY = 'bfDevReloadEndpoint'
@@ -92,19 +92,15 @@ export function relPathFromComponentsBase(p: string): string {
 // ── JSX components ─────────────────────────────────────────────────────────
 
 /**
- * Shape of `barefoot-externals.json`, written by `bf build` when
- * `externals` / `bundleEntries` are configured. Only the fields
- * `BfImportMap` consumes are typed here; the build also emits an
- * `externals` array (the `--external` list) which the importmap
- * doesn't need. Fields are optional so a partial/hand-written
- * manifest still type-checks. See issue #1639.
+ * Shape of `barefoot-externals.json` (the subset `BfImportMap` consumes):
+ * `importmap.imports` plus `preloads`; fields are optional so a partial /
+ * hand-written manifest still type-checks. See issues #1639 / #1644.
+ *
+ * Alias for the shared {@link ImportMapManifest} from `@barefootjs/jsx` so the
+ * component and the `bf build` snippet path describe the manifest with one
+ * type. Retained as a named export for back-compat.
  */
-export interface BarefootExternalsManifest {
-  /** Entries for the `<script type="importmap">`. */
-  importmap?: { imports?: Record<string, string> }
-  /** URLs to emit as `<link rel="modulepreload">`. */
-  preloads?: string[]
-}
+export type BarefootExternalsManifest = ImportMapManifest
 
 export interface BfImportMapProps {
   /** Base URL where the runtime + component bundles are served. */

--- a/packages/adapter-hono/src/app.ts
+++ b/packages/adapter-hono/src/app.ts
@@ -91,17 +91,6 @@ export function relPathFromComponentsBase(p: string): string {
 
 // ── JSX components ─────────────────────────────────────────────────────────
 
-/**
- * Shape of `barefoot-externals.json` (the subset `BfImportMap` consumes):
- * `importmap.imports` plus `preloads`; fields are optional so a partial /
- * hand-written manifest still type-checks. See issues #1639 / #1644.
- *
- * Alias for the shared {@link ImportMapManifest} from `@barefootjs/jsx` so the
- * component and the `bf build` snippet path describe the manifest with one
- * type. Retained as a named export for back-compat.
- */
-export type BarefootExternalsManifest = ImportMapManifest
-
 export interface BfImportMapProps {
   /** Base URL where the runtime + component bundles are served. */
   base: string
@@ -112,8 +101,12 @@ export interface BfImportMapProps {
    * configured externals (e.g. `zod`, `@barefootjs/form`) resolve in
    * the browser. When omitted, only the `@barefootjs/client*`
    * mappings are emitted — the pre-#1639 behavior.
+   *
+   * Typed with the shared {@link ImportMapManifest} from `@barefootjs/jsx`,
+   * so the component and the `bf build` snippet path describe the manifest
+   * with one type.
    */
-  externals?: BarefootExternalsManifest
+  externals?: ImportMapManifest
   /**
    * Whether to also emit `<link rel="modulepreload">` for the
    * manifest's `preloads`. Defaults to `true`; set `false` to emit

--- a/packages/jsx/src/import-map.ts
+++ b/packages/jsx/src/import-map.ts
@@ -13,9 +13,24 @@
  */
 
 /**
+ * The subset of `barefoot-externals.json` needed to render the importmap
+ * snippet. All fields are optional so a partial or hand-written manifest
+ * (e.g. a Hono `BfImportMap` `externals` prop) still type-checks. The strict
+ * build-output `ExternalsManifest` is structurally assignable to this, so both
+ * the CLI's emitted manifest and a hand-written one feed `renderImportMapHtml`.
+ * This is the one shared manifest type for every importmap injection path.
+ */
+export interface ImportMapManifest {
+  /** Entries for `<script type="importmap">`. */
+  importmap?: { imports?: Record<string, string> }
+  /** URLs to emit as `<link rel="modulepreload">`. */
+  preloads?: string[]
+}
+
+/**
  * Shape of `barefoot-externals.json`, written by `bf build`. This is the build
  * output contract shared by the CLI (which writes it) and the adapters (which
- * consume it).
+ * consume it) — the all-required superset of {@link ImportMapManifest}.
  */
 export interface ExternalsManifest {
   /** Entries for `<script type="importmap">`. */
@@ -41,10 +56,7 @@ function escapeHtmlAttr(value: string): string {
  * script element — the JSON parser decodes that escape back to `<`, keeping the
  * mapping value-identical.
  */
-export function renderImportMapHtml(manifest: {
-  importmap?: { imports?: Record<string, string> }
-  preloads?: string[]
-}): string {
+export function renderImportMapHtml(manifest: ImportMapManifest): string {
   const imports = manifest.importmap?.imports ?? {}
   const json = JSON.stringify({ imports }).replace(/</g, '\\u003c')
   const lines = [`<script type="importmap">${json}</script>`]

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -89,7 +89,7 @@ export { combineParentChildClientJs } from './combine-client-js'
 
 // Externals manifest + importmap snippet renderer (shared by adapters and CLI)
 export { renderImportMapHtml } from './import-map'
-export type { ExternalsManifest } from './import-map'
+export type { ExternalsManifest, ImportMapManifest } from './import-map'
 
 // Build options (shared by adapters and CLI)
 export interface OutputLayout {


### PR DESCRIPTION
## Summary

Follow-up cleanup to #1657. After that PR, Hono's `BfImportMap` already delegates HTML rendering to the shared `renderImportMapHtml`, but the **manifest type** was still described three ways: Hono's `BarefootExternalsManifest` (all-optional), jsx's `ExternalsManifest` (all-required + `externals[]`), and `renderImportMapHtml`'s inline anonymous param. This unifies the type.

- `@barefootjs/jsx` now exports a shared **`ImportMapManifest`** — the optional-field subset the renderer needs (`importmap.imports` + `preloads`). `renderImportMapHtml` takes it instead of an inline type.
- The strict build-output `ExternalsManifest` stays as the all-required **superset** (structurally assignable to `ImportMapManifest`), so the CLI's emitted manifest and a hand-written one both feed the renderer.
- **Breaking (`@barefootjs/hono`):** the `BarefootExternalsManifest` type export is **removed** (no back-compat alias — we're free to break compat this phase). `BfImportMap`'s `externals` prop is now typed directly with `ImportMapManifest` from `@barefootjs/jsx`. The runtime prop shape is unchanged, so importing the parsed `barefoot-externals.json` and passing it through still works; only callers that referenced the type by name need to switch to `ImportMapManifest`.

The `@barefootjs/client*` default synthesis stays in `BfImportMap` (it's genuinely Hono-specific — the component must work with no manifest at all), so this is intentionally type-only unification, not behavioral.

## Test plan

- [x] `packages/jsx/.../import-map.test.ts` (6) and jsx `typecheck:tests` pass.
- [x] `packages/adapter-hono/.../import-map.test.ts` (8) pass — typed via `ImportMapManifest`; hono package typechecks clean apart from the pre-existing `@barefootjs/client` `client-shim.ts` resolution errors (#1641).
- [x] `packages/adapter-tests/.../import-map-injection.contract.test.ts` (4) pass.
