### PR TITLE
feat(#1448 Tier B): lower multi-key, ternary &amp; block-body sort comparators

### DIFF
--- a/.changeset/sort-comparator-tier-b-followups.md
+++ b/.changeset/sort-comparator-tier-b-followups.md
@@ -1,0 +1,15 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+"@barefootjs/mojolicious": patch
+---
+
+Widen `.sort()` / `.toSorted()` comparator lowering with multi-key, relational-ternary, and block-body shapes (#1448 Tier B follow-up).
+
+The comparator parser now builds a structured `SortComparator` as a `keys: SortKey[]` list and accepts three previously-refused shapes (each lowering to both template-language adapters + the Hono/CSR JS path):
+
+- **Multi-key (`||`-chain)** — `(a, b) => a.x - b.x || a.y.localeCompare(b.y)` splits into one comparison key per `||` operand, applied in priority order as tie-breaks. Emits one 4-string `bf_sort` group (Go) / one `keys` hash (Mojo) per key.
+- **Relational ternary** — `(a, b) => a.f > b.f ? 1 : -1`, the 3-way `a.f < b.f ? -1 : a.f > b.f ? 1 : 0`, and the leading-tie `a.f === b.f ? 0 : …` forms lower to a new `auto` compare type: numeric when both keys parse as numbers, else lexical. Both template runtimes share this rule so their output stays byte-equal (diverges from JS `<`/`>` only for numeric strings).
+- **Single-`return` block bodies** — `(a, b) => { return a.f - b.f }` (arrow form; the function-expression form already worked) unwrap to the returned comparator.
+
+Runtime: Go `bf_sort` is now variadic over 4-string key groups with an `auto` branch; Mojo `bf->sort` takes an ordered `keys` list with the same `auto` rule. Function-reference comparators (`sort(myCmp)`), multi-statement block bodies, and `localeCompare(b, locale, opts)` stay refused (BF021) — deferred follow-ups.

--- a/docs/core/rendering/jsx-compatibility.md
+++ b/docs/core/rendering/jsx-compatibility.md
@@ -64,9 +64,19 @@ return <div>...</div>
 {items().filter(x => x.active).sort((a, b) => a.name.localeCompare(b.name)).map(item => (
   <Item key={item.id} item={item} />
 ))}
+
+// ✅ Multi-key: sort by price, break ties by name
+{items().sort((a, b) => a.price - b.price || a.name.localeCompare(b.name)).map(item => (
+  <Item key={item.id} item={item} />
+))}
+
+// ✅ Relational ternary
+{items().toSorted((a, b) => a.price > b.price ? 1 : -1).map(item => (
+  <Item key={item.id} item={item} />
+))}
 ```
 
-Supported comparator shapes: `(a, b) => a - b`, `(a, b) => a.field - b.field`, `(a, b) => a.localeCompare(b)`, `(a, b) => a.field.localeCompare(b.field)` (reverse the operands for descending order). Other shapes — block bodies, ternary returns, custom helpers — produce a compile error; use `/* @client */` in that case.
+Supported comparator shapes: `(a, b) => a - b`, `(a, b) => a.field - b.field`, `(a, b) => a.localeCompare(b)`, `(a, b) => a.field.localeCompare(b.field)`, relational-ternary returns (`(a, b) => a.field > b.field ? 1 : -1`, including the 3-way `a < b ? -1 : a > b ? 1 : 0` form), and any of these `||`-chained for multi-key tie-breaks. A single-`return` block body (`(a, b) => { return a.field - b.field }`) works too. Reverse the operands (or the ternary sign) for descending order. Other shapes — function references (`sort(myCmp)`), multi-statement block bodies, and `localeCompare(b, locale, opts)` — produce a compile error; use `/* @client */` in that case.
 
 
 ## Event Handling
@@ -97,7 +107,7 @@ Some JavaScript expressions cannot be translated into marked template syntax. Wh
 | `.filter()` with `function` keyword callback | works | **BF101** |
 | `.reduce()`, `.forEach()`, `.flatMap()` | works | **BF101** |
 | Nested higher-order in filter predicate (`x => x.tags.filter(...).length > 0`) | works | **BF101** |
-| Sort comparator with a block body, ternary return, or other unsupported shape | **BF021** (all adapters) | **BF021** |
+| Sort comparator that's a function reference, multi-statement block body, or `localeCompare(b, locale, opts)` | **BF021** (all adapters) | **BF021** |
 | `typeof` in a filter predicate | **BF021** (all adapters) | **BF021** |
 
 `BF021` is raised at the IR layer and applies to every adapter. `BF101` is raised by adapters that can't lower the expression to their template language. Either way, add [`/* @client */`](./client-directive.md) to opt into client-only evaluation and suppress the error.
@@ -146,16 +156,16 @@ Some JavaScript expressions cannot be translated into marked template syntax. Wh
 
 ### Patterns that error on all adapters
 
-**Unsupported sort comparators** (block bodies, ternary returns):
+**Unsupported sort comparators** (multi-statement block bodies, function references):
 
 ```tsx
 // ❌ BF021 (all adapters)
-{items().sort((a, b) => a.name > b.name ? 1 : -1).map(item => (
+{items().sort((a, b) => { const an = a.name; return an > b.name ? 1 : -1 }).map(item => (
   <Item key={item.id} item={item} />
 ))}
 
 // ✅ Use /* @client */
-{/* @client */ items().sort((a, b) => a.name > b.name ? 1 : -1).map(item => (
+{/* @client */ items().sort((a, b) => { const an = a.name; return an > b.name ? 1 : -1 }).map(item => (
   <Item key={item.id} item={item} />
 ))}
 ```

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -1149,33 +1149,45 @@ func FindLastIndex(items any, field string, value any) int {
 	return -1
 }
 
+// sortKeySpec is one parsed comparison key. A simple comparator has
+// one; a `||`-chained multi-key comparator has several, applied in
+// order as tie-breakers.
+type sortKeySpec struct {
+	kind        string // "self" | "field"
+	name        string // capitalised field name, or "" for "self"
+	compareType string // "numeric" | "string" | "auto"
+	direction   string // "asc" | "desc"
+}
+
 // Sort returns a new stable-sorted slice. Lowers
 // `Array.prototype.sort` / `Array.prototype.toSorted` (#1448 Tier B).
 // Non-mutating — JS's mutate-vs-new distinction is moot in SSR
 // template context (templates render a snapshot).
 //
-// Call shape (the compiler emits exactly 5 args):
+// Call shape (the compiler emits one 4-string group per key):
 //
-//	bf_sort <items> <keyKind> <keyName> <compareType> <direction>
+//	bf_sort <items> (<keyKind> <keyName> <compareType> <direction>)+
 //
 //	keyKind:      "self" | "field"
 //	keyName:      "" when keyKind == "self"; capitalised struct field
 //	              name (e.g. "Price") otherwise
-//	compareType:  "numeric" | "string"
+//	compareType:  "numeric" | "string" | "auto"
 //	direction:    "asc" | "desc"
 //
-// The 4 string operands cover the accepted comparator catalogue:
-// `(a,b) => a.f - b.f`, `(a,b) => a - b`, and
-// `(a,b) => a[.f].localeCompare(b[.f])`, each with a reversed
-// counterpart for `desc`. Anything outside the catalogue refuses at
-// compile time (BF101 from the JSX compiler) and never reaches this
-// helper.
+// The groups cover the accepted comparator catalogue: `a.f - b.f`,
+// `a - b`, `a[.f].localeCompare(b[.f])`, and relational-ternary keys
+// (`a.f > b.f ? 1 : -1` → "auto"), each `||`-chainable for multi-key
+// tie-breaks. Anything outside refuses at compile time (BF101 from the
+// JSX compiler) and never reaches this helper.
 //
-// A future `nulls => "first" | "last"` knob can land as a 6th arg
-// without rewriting the existing call sites — the keyKind / keyName
-// split already gives the helper everything it needs to project
-// each item's sort key before comparing.
-func Sort(items any, keyKind string, keyName string, compareType string, direction string) []any {
+// "auto" compares numerically when both projected keys parse as
+// numbers, else lexically — mirroring the Perl `bf->sort` helper's
+// `looks_like_number` rule so the two template adapters stay
+// byte-equal. This diverges from JS `<`/`>` only for numeric strings.
+//
+// A future `nulls` knob can extend the per-key group without rewriting
+// existing call sites — each key already projects before comparing.
+func Sort(items any, spec ...string) []any {
 	v := reflect.ValueOf(items)
 	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
 		return nil
@@ -1193,33 +1205,90 @@ func Sort(items any, keyKind string, keyName string, compareType string, directi
 		result[i] = v.Index(i).Interface()
 	}
 
-	desc := direction == "desc"
+	keys := parseSortSpec(spec)
 	sort.SliceStable(result, func(i, j int) bool {
-		ki := projectSortKey(result[i], keyKind, keyName)
-		kj := projectSortKey(result[j], keyKind, keyName)
-		if compareType == "string" {
-			// `toString` maps nil / unknown types to "" — matches
-			// the documented `bf->string(undef) === ""` divergence
-			// from JS and the Perl `bf->sort` helper's `// ''`
-			// undef-coalesce. Using `fmt.Sprint` here would sort
-			// missing fields against the literal string "<nil>".
-			si := toString(ki)
-			sj := toString(kj)
-			if desc {
-				return si > sj
+		for _, k := range keys {
+			ki := projectSortKey(result[i], k.kind, k.name)
+			kj := projectSortKey(result[j], k.kind, k.name)
+			c := compareSortKey(ki, kj, k.compareType)
+			if c == 0 {
+				continue // tie on this key — fall through to the next
 			}
-			return si < sj
+			if k.direction == "desc" {
+				return c > 0
+			}
+			return c < 0
 		}
-		// numeric
-		ni := toFloat64(ki)
-		nj := toFloat64(kj)
-		if desc {
-			return ni > nj
-		}
-		return ni < nj
+		return false
 	})
 
 	return result
+}
+
+// parseSortSpec chunks the variadic operand list into 4-string key
+// groups. A trailing partial group (malformed emit) is ignored rather
+// than panicking — defensive, mirroring the helper's nil-safe stance.
+func parseSortSpec(spec []string) []sortKeySpec {
+	var keys []sortKeySpec
+	for i := 0; i+3 < len(spec); i += 4 {
+		keys = append(keys, sortKeySpec{
+			kind:        spec[i],
+			name:        spec[i+1],
+			compareType: spec[i+2],
+			direction:   spec[i+3],
+		})
+	}
+	return keys
+}
+
+// compareSortKey returns -1 / 0 / 1 for two projected keys under the
+// given compare type (ascending orientation; the caller flips for
+// "desc"). "string" stringifies both (nil → "", matching the
+// documented `bf->string(undef) === ""` divergence). "auto" compares
+// numerically when both parse as numbers, else lexically.
+func compareSortKey(ki, kj any, compareType string) int {
+	switch compareType {
+	case "string":
+		return strings.Compare(toString(ki), toString(kj))
+	case "auto":
+		ni, okI := toFloat64WithOK(ki)
+		nj, okJ := toFloat64WithOK(kj)
+		if okI && okJ {
+			return cmpFloat(ni, nj)
+		}
+		return strings.Compare(toString(ki), toString(kj))
+	default: // numeric
+		return cmpFloat(toFloat64(ki), toFloat64(kj))
+	}
+}
+
+func cmpFloat(a, b float64) int {
+	if a < b {
+		return -1
+	}
+	if a > b {
+		return 1
+	}
+	return 0
+}
+
+// toFloat64WithOK reports a value's numeric float and whether it is
+// number-like. Genuine numeric kinds always qualify; strings qualify
+// when they parse as a float (so the "auto" compare path matches the
+// Perl `looks_like_number` rule). Everything else is non-numeric.
+func toFloat64WithOK(v any) (float64, bool) {
+	switch n := v.(type) {
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
+		return toFloat64(v), true
+	case string:
+		f, err := strconv.ParseFloat(strings.TrimSpace(n), 64)
+		if err != nil {
+			return 0, false
+		}
+		return f, true
+	default:
+		return 0, false
+	}
 }
 
 // projectSortKey reduces an item to the value the comparator

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -992,6 +992,68 @@ func TestSort_FieldString(t *testing.T) {
 	}
 }
 
+// Multi-key (`||`-chain): a tie on the primary key falls through to
+// the next. `(a,b) => a.Priority - b.Priority || a.Name.localeCompare(b.Name)`
+// → two 4-string groups.
+func TestSort_MultiKey_TieBreak(t *testing.T) {
+	items := []sortItem{
+		{Name: "b", Priority: 1},
+		{Name: "a", Priority: 1},
+		{Name: "c", Priority: 0},
+	}
+	got := Sort(items, "field", "Priority", "numeric", "asc", "field", "Name", "string", "asc")
+	names := []string{got[0].(sortItem).Name, got[1].(sortItem).Name, got[2].(sortItem).Name}
+	want := []string{"c", "a", "b"} // Priority 0 first; Priority-1 tie broken by Name asc
+	for i := range want {
+		if names[i] != want[i] {
+			t.Errorf("multi-key sort = %v, want %v", names, want)
+			break
+		}
+	}
+}
+
+// Multi-key with a descending secondary key: all primaries tie, so the
+// secondary `Price desc` orders the result.
+func TestSort_MultiKey_DescSecondary(t *testing.T) {
+	items := []sortItem{
+		{Name: "a", Priority: 1, Price: 10},
+		{Name: "a", Priority: 1, Price: 30},
+		{Name: "a", Priority: 1, Price: 20},
+	}
+	got := Sort(items, "field", "Name", "string", "asc", "field", "Price", "numeric", "desc")
+	prices := []float64{got[0].(sortItem).Price, got[1].(sortItem).Price, got[2].(sortItem).Price}
+	if prices[0] != 30 || prices[1] != 20 || prices[2] != 10 {
+		t.Errorf("multi-key desc secondary = %v, want [30 20 10]", prices)
+	}
+}
+
+// `compareType=auto` (relational-ternary lowering) on a numeric array:
+// both keys parse as numbers → numeric compare.
+func TestSort_Auto_Numeric(t *testing.T) {
+	got := Sort([]int{3, 1, 2}, "self", "", "auto", "asc")
+	if len(got) != 3 || got[0] != 1 || got[1] != 2 || got[2] != 3 {
+		t.Errorf("auto numeric asc = %v, want [1 2 3]", got)
+	}
+}
+
+// `auto` on non-numeric strings → lexical compare.
+func TestSort_Auto_StringFallback(t *testing.T) {
+	got := Sort([]string{"charlie", "alice", "bob"}, "self", "", "auto", "asc")
+	if len(got) != 3 || got[0] != "alice" || got[1] != "bob" || got[2] != "charlie" {
+		t.Errorf("auto string asc = %v, want [alice bob charlie]", got)
+	}
+}
+
+// `auto` treats numeric strings as numbers (Go/Perl parity via
+// `looks_like_number`): "10" sorts after "9", not lexically before it.
+// Documented divergence from JS `<`/`>`, which compares these lexically.
+func TestSort_Auto_NumericStringsCompareNumerically(t *testing.T) {
+	got := Sort([]string{"10", "9", "100"}, "self", "", "auto", "asc")
+	if len(got) != 3 || got[0] != "9" || got[1] != "10" || got[2] != "100" {
+		t.Errorf("auto numeric-string asc = %v, want [9 10 100]", got)
+	}
+}
+
 // (#1487) `bf_sort` is called with a PascalCase key name (the IR
 // emits `bf_sort .Items "field" "Price" ...`), but user data flows
 // in as a `map[string]any` whose keys may be either lowercase

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -1833,6 +1833,8 @@ import { fixture as arraySortFieldAscFixture } from '../../../adapter-tests/fixt
 import { fixture as arraySortFieldDescFixture } from '../../../adapter-tests/fixtures/methods/array-sort-field-desc'
 import { fixture as arraySortPrimitiveFixture } from '../../../adapter-tests/fixtures/methods/array-sort-primitive'
 import { fixture as arraySortLocaleFixture } from '../../../adapter-tests/fixtures/methods/array-sort-locale'
+import { fixture as arraySortMultiKeyFixture } from '../../../adapter-tests/fixtures/methods/array-sort-multikey'
+import { fixture as arraySortTernaryFixture } from '../../../adapter-tests/fixtures/methods/array-sort-ternary'
 import { fixture as arrayToSortedFixture } from '../../../adapter-tests/fixtures/methods/array-toSorted'
 // #1448 Tier B — .entries / .keys / .values iteration shapes.
 import { fixture as arrayEntriesFixture } from '../../../adapter-tests/fixtures/methods/array-entries'
@@ -1867,6 +1869,11 @@ describe('GoTemplateAdapter - #1448 Tier A/B fixture-driven lowering pins', () =
     { fixture: arraySortFieldDescFixture, expect: 'bf_sort .Items "field" "Price" "numeric" "desc"' },
     { fixture: arraySortPrimitiveFixture, expect: 'bf_sort .Nums "self" "" "numeric" "asc"' },
     { fixture: arraySortLocaleFixture,    expect: 'bf_sort .Names "self" "" "string" "asc"' },
+    // Multi-key (`||`-chain): one 4-string group per comparison key,
+    // applied in priority order as tie-breakers.
+    { fixture: arraySortMultiKeyFixture,  expect: 'bf_sort .Items "field" "Price" "numeric" "asc" "field" "Name" "string" "asc"' },
+    // Relational-ternary comparator lowers to a single `auto` key.
+    { fixture: arraySortTernaryFixture,   expect: 'bf_sort .Items "field" "Rank" "auto" "asc"' },
     { fixture: arrayToSortedFixture,      expect: 'bf_sort .Nums "self" "" "numeric" "asc"' },
     // #1448 Tier B — iteration shapes. These are loop-level
     // patterns (range binding order), not helper function calls.

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -179,21 +179,32 @@ function wrapIfMultiToken(rendered: string): string {
  * takes 4 string operands so a future `nulls` knob can grow on the
  * end without rewriting either call site (#1448 Tier B):
  *
- *   bf_sort <recv> <keyKind> <keyName> <compareType> <direction>
+ *   bf_sort <recv> (<keyKind> <keyName> <compareType> <direction>)+
  *
  *   keyKind:      "self" | "field"
  *   keyName:      "" when keyKind=self; capitalised field name otherwise
- *   compareType:  "numeric" | "string"
+ *   compareType:  "numeric" | "string" | "auto"
  *   direction:    "asc" | "desc"
+ *
+ * The 4-string group repeats once per comparison key: a simple
+ * comparator emits one group; a `||`-chained multi-key comparator
+ * emits one per operand, applied in order as tie-breakers by the
+ * variadic `bf_sort` runtime.
  *
  * The capitalisation mirrors the Go-side struct-field convention
  * (`bf_sort .Items "field" "Price" "numeric" "asc"`) so the runtime
  * helper's reflect lookup matches without a recapitalise step.
  */
 function emitBfSort(recv: string, c: SortComparator): string {
-  const keyKind = c.key.kind
-  const keyName = c.key.kind === 'field' ? capitalize(c.key.field) : ''
-  return `bf_sort ${wrapIfMultiToken(recv)} "${keyKind}" "${keyName}" "${c.type}" "${c.direction}"`
+  // One 4-string group per comparison key (keyKind, keyName,
+  // compareType, direction). A single-key comparator emits exactly the
+  // pre-multi-key shape; `||`-chained keys append further groups, which
+  // `bf_sort`'s variadic runtime applies in order as tie-breakers.
+  const groups = c.keys.map((k) => {
+    const keyName = k.key.kind === 'field' ? capitalize(k.key.field) : ''
+    return `"${k.key.kind}" "${keyName}" "${k.type}" "${k.direction}"`
+  })
+  return `bf_sort ${wrapIfMultiToken(recv)} ${groups.join(' ')}`
 }
 
 function capitalize(s: string): string {

--- a/packages/adapter-mojolicious/lib/BarefootJS.pm
+++ b/packages/adapter-mojolicious/lib/BarefootJS.pm
@@ -530,7 +530,8 @@ sub trim ($self, $recv) {
 # lowering (#1448 Tier B). Non-mutating — JS's mutate-vs-new
 # distinction is moot in SSR template context.
 #
-# Opts hash-ref (compiler emits exactly these four keys):
+# Opts hash-ref. The compiler emits a `keys` list of per-key hashes
+# in priority order; each hash carries:
 #
 #   key_kind     => 'self' | 'field'
 #   key          => '' when key_kind eq 'self'; field name verbatim
@@ -539,7 +540,7 @@ sub trim ($self, $recv) {
 #                   applied. Perl hash lookups are case-sensitive so
 #                   the key here must match the actual hash key the
 #                   user populated.
-#   compare_type => 'numeric' | 'string'
+#   compare_type => 'numeric' | 'string' | 'auto'
 #   direction    => 'asc' | 'desc'
 #
 # Accepted comparator catalogue (gated upstream at parse time —
@@ -548,45 +549,71 @@ sub trim ($self, $recv) {
 #   (a,b) => a.f - b.f                       → field, numeric
 #   (a,b) => a - b                           → self,  numeric
 #   (a,b) => a[.f].localeCompare(b[.f])      → field|self, string
+#   (a,b) => a.f > b.f ? 1 : -1              → field|self, auto
+#   any of the above ||-chained              → multi-key tie-breaks
 #   (and reversed-operand variants for `desc`).
 #
-# A future `nulls => 'first' | 'last'` knob can land alongside
-# without churn — the opts hash is the right place to grow.
+# `auto` (relational-ternary lowering) compares numerically when both
+# keys `looks_like_number`, else lexically — Go's `bf_sort` applies the
+# same rule so the two template adapters stay byte-equal.
+#
+# A future `nulls => 'first' | 'last'` knob can land per key without
+# churn — the opts hash is the right place to grow.
 
 sub sort ($self, $recv, $opts = {}) {
     return [] unless ref($recv) eq 'ARRAY';
-    my $key_kind     = $opts->{key_kind}     // 'self';
-    my $key          = $opts->{key}          // '';
-    my $compare_type = $opts->{compare_type} // 'numeric';
-    my $direction    = $opts->{direction}    // 'asc';
 
-    # Schwartzian transform: project each item to its sort key once,
-    # then sort by key, then drop the keys. Cheaper than re-resolving
-    # the field accessor inside every comparison for non-trivial arrays.
+    # Normalise the per-key specs (priority order, length >= 1).
+    my @spec = map {
+        {
+            key_kind     => $_->{key_kind}     // 'self',
+            key          => $_->{key}          // '',
+            compare_type => $_->{compare_type} // 'numeric',
+            direction    => $_->{direction}    // 'asc',
+        }
+    } @{ $opts->{keys} // [] };
+    return [ @$recv ] unless @spec;
+
+    # Schwartzian transform: project each item to all its sort keys
+    # once, then compare projected keys. Cheaper than re-resolving the
+    # field accessors inside every comparison for non-trivial arrays.
     my @keyed = map {
         my $item = $_;
-        my $k = $key_kind eq 'field' && ref($item) eq 'HASH' ? $item->{$key} : $item;
-        [$k, $item]
+        my @ks = map {
+            $_->{key_kind} eq 'field' && ref($item) eq 'HASH' ? $item->{ $_->{key} } : $item;
+        } @spec;
+        [ \@ks, $item ];
     } @$recv;
 
-    my $cmp;
-    if ($compare_type eq 'string') {
-        $cmp = $direction eq 'desc'
-            ? sub { ($b->[0] // '') cmp ($a->[0] // '') }
-            : sub { ($a->[0] // '') cmp ($b->[0] // '') };
-    } else {
-        # Numeric: undef projects to 0 so the sort is total without
-        # warnings on missing fields. Documented divergence from JS
-        # (which would coerce undef → NaN and produce indeterminate
-        # ordering); matching Go's `toFloat64(nil) == 0` keeps the
-        # adapter outputs symmetric.
-        $cmp = $direction eq 'desc'
-            ? sub { ($b->[0] // 0) <=> ($a->[0] // 0) }
-            : sub { ($a->[0] // 0) <=> ($b->[0] // 0) };
-    }
+    my $cmp = sub {
+        for my $i (0 .. $#spec) {
+            my $sp = $spec[$i];
+            my $c  = _compare_sort_key($a->[0][$i], $b->[0][$i], $sp->{compare_type});
+            next if $c == 0;            # tie on this key — try the next
+            return $sp->{direction} eq 'desc' ? -$c : $c;
+        }
+        return 0;
+    };
 
     my @sorted = sort $cmp @keyed;
     return [ map { $_->[1] } @sorted ];
+}
+
+# Compare two projected keys, ascending orientation (-1 / 0 / 1); the
+# caller negates for 'desc'. 'auto' compares numerically when both
+# keys look like numbers, else lexically (matches Go's `bf_sort`).
+# undef coalesces to '' / 0 so the order stays total without warnings.
+sub _compare_sort_key ($av, $bv, $compare_type) {
+    if ($compare_type eq 'string') {
+        return ($av // '') cmp ($bv // '');
+    }
+    if ($compare_type eq 'auto') {
+        if (looks_like_number($av // '') && looks_like_number($bv // '')) {
+            return ($av // 0) <=> ($bv // 0);
+        }
+        return ($av // '') cmp ($bv // '');
+    }
+    return ($av // 0) <=> ($bv // 0);    # numeric
 }
 
 # ---------------------------------------------------------------------------

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -894,6 +894,8 @@ import { fixture as arraySortFieldAscFixture } from '../../../adapter-tests/fixt
 import { fixture as arraySortFieldDescFixture } from '../../../adapter-tests/fixtures/methods/array-sort-field-desc'
 import { fixture as arraySortPrimitiveFixture } from '../../../adapter-tests/fixtures/methods/array-sort-primitive'
 import { fixture as arraySortLocaleFixture } from '../../../adapter-tests/fixtures/methods/array-sort-locale'
+import { fixture as arraySortMultiKeyFixture } from '../../../adapter-tests/fixtures/methods/array-sort-multikey'
+import { fixture as arraySortTernaryFixture } from '../../../adapter-tests/fixtures/methods/array-sort-ternary'
 import { fixture as arrayToSortedFixture } from '../../../adapter-tests/fixtures/methods/array-toSorted'
 // #1448 Tier B — .entries / .keys / .values iteration shapes.
 import { fixture as arrayEntriesFixture } from '../../../adapter-tests/fixtures/methods/array-entries'
@@ -918,12 +920,17 @@ describe('MojoAdapter - #1448 Tier A/B fixture-driven lowering pins', () => {
     { fixture: stringTrimFixture,       expect: 'bf->trim($value)' },
     // #1448 Tier B — sort / toSorted. The loop-chained field cases
     // hoist into a `my $bf_iter_lN = bf->sort(...)` local; the
-    // standalone primitive cases inline the call.
-    { fixture: arraySortFieldAscFixture,  expect: `bf->sort($items, { key_kind => 'field', key => 'price', compare_type => 'numeric', direction => 'asc' })` },
-    { fixture: arraySortFieldDescFixture, expect: `bf->sort($items, { key_kind => 'field', key => 'price', compare_type => 'numeric', direction => 'desc' })` },
-    { fixture: arraySortPrimitiveFixture, expect: `bf->sort($nums, { key_kind => 'self', compare_type => 'numeric', direction => 'asc' })` },
-    { fixture: arraySortLocaleFixture,    expect: `bf->sort($names, { key_kind => 'self', compare_type => 'string', direction => 'asc' })` },
-    { fixture: arrayToSortedFixture,      expect: `bf->sort($nums, { key_kind => 'self', compare_type => 'numeric', direction => 'asc' })` },
+    // standalone primitive cases inline the call. Each comparison key
+    // is one hash under `keys` (a single-key comparator → one element).
+    { fixture: arraySortFieldAscFixture,  expect: `bf->sort($items, { keys => [{ key_kind => 'field', key => 'price', compare_type => 'numeric', direction => 'asc' }] })` },
+    { fixture: arraySortFieldDescFixture, expect: `bf->sort($items, { keys => [{ key_kind => 'field', key => 'price', compare_type => 'numeric', direction => 'desc' }] })` },
+    { fixture: arraySortPrimitiveFixture, expect: `bf->sort($nums, { keys => [{ key_kind => 'self', compare_type => 'numeric', direction => 'asc' }] })` },
+    { fixture: arraySortLocaleFixture,    expect: `bf->sort($names, { keys => [{ key_kind => 'self', compare_type => 'string', direction => 'asc' }] })` },
+    // Multi-key (`||`-chain): one hash per comparison key, in order.
+    { fixture: arraySortMultiKeyFixture,  expect: `bf->sort($items, { keys => [{ key_kind => 'field', key => 'price', compare_type => 'numeric', direction => 'asc' }, { key_kind => 'field', key => 'name', compare_type => 'string', direction => 'asc' }] })` },
+    // Relational-ternary comparator lowers to a single `auto` key.
+    { fixture: arraySortTernaryFixture,   expect: `bf->sort($items, { keys => [{ key_kind => 'field', key => 'rank', compare_type => 'auto', direction => 'asc' }] })` },
+    { fixture: arrayToSortedFixture,      expect: `bf->sort($nums, { keys => [{ key_kind => 'self', compare_type => 'numeric', direction => 'asc' }] })` },
     // #1448 Tier B — iteration shapes. These are loop-level patterns.
     // .entries() → for loop with both $i index var and $v value var
     { fixture: arrayEntriesFixture,       expect: '% my $v = $items->[$i];' },

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1606,10 +1606,11 @@ function renderArrayMethod(
  * plus the loop-hoist path in `renderLoop` — same emit shape across
  * all three so a regression in any one path surfaces consistently.
  *
- * The Perl helper accepts a hash-ref opts bag (room for a future
- * `nulls` knob without arity churn), and returns a fresh ARRAY ref
- * so downstream composition (`@{bf->sort(...)}` in `join(...)`, etc.)
- * stays straightforward.
+ * The Perl helper accepts a hash-ref opts bag whose `keys` entry is
+ * an ordered list of per-key hashes (room for a future `nulls` knob
+ * without arity churn), and returns a fresh ARRAY ref so downstream
+ * composition (`@{bf->sort(...)}` in `join(...)`, etc.) stays
+ * straightforward.
  */
 /**
  * Encode an `IRLoop.markerId` into a Perl-identifier-safe suffix
@@ -1629,11 +1630,18 @@ function perlIdentifierFromMarkerId(markerId: string): string {
 }
 
 function renderSortMethod(recv: string, c: SortComparator): string {
-  const keyEntry =
-    c.key.kind === 'self'
-      ? `key_kind => 'self'`
-      : `key_kind => 'field', key => '${c.key.field}'`
-  return `bf->sort(${recv}, { ${keyEntry}, compare_type => '${c.type}', direction => '${c.direction}' })`
+  // One hash per comparison key, in priority order, under `keys`. A
+  // simple comparator yields a one-element list; a `||`-chained
+  // multi-key comparator yields one per operand. `bf->sort` walks them
+  // in order, falling through to the next on a tie.
+  const keyHashes = c.keys.map((k) => {
+    const keyEntry =
+      k.key.kind === 'self'
+        ? `key_kind => 'self'`
+        : `key_kind => 'field', key => '${k.key.field}'`
+    return `{ ${keyEntry}, compare_type => '${k.type}', direction => '${k.direction}' }`
+  })
+  return `bf->sort(${recv}, { keys => [${keyHashes.join(', ')}] })`
 }
 
 /**

--- a/packages/adapter-mojolicious/t/template_primitives.t
+++ b/packages/adapter-mojolicious/t/template_primitives.t
@@ -244,10 +244,11 @@ subtest 'trim — strip leading + trailing whitespace' => sub {
 };
 
 # `Array.prototype.sort(cmp)` / `Array.prototype.toSorted(cmp)`
-# lowering (#1448 Tier B). The opts hash-ref carries the structured
-# comparator the compiler extracted at parse time — adapter-side
-# emit is a single call shape, runtime branches on `key_kind` /
-# `compare_type` / `direction`.
+# lowering (#1448 Tier B). The opts hash-ref carries a `keys` list of
+# the structured comparison keys the compiler extracted at parse time
+# — adapter-side emit is a single call shape; the runtime walks the
+# keys in priority order, branching on key_kind / compare_type /
+# direction per key.
 subtest 'sort — structured comparator dispatch' => sub {
     my $items = [
         { name => 'c', price => 30 },
@@ -256,28 +257,28 @@ subtest 'sort — structured comparator dispatch' => sub {
     ];
 
     # Numeric field, ascending — the canonical struct-field case.
-    is $bf->sort($items, { key_kind => 'field', key => 'price', compare_type => 'numeric', direction => 'asc' }),
+    is $bf->sort($items, { keys => [{ key_kind => 'field', key => 'price', compare_type => 'numeric', direction => 'asc' }] }),
         [ { name => 'a', price => 10 }, { name => 'b', price => 20 }, { name => 'c', price => 30 } ],
         'numeric field asc';
 
     # Numeric field, descending — reverse direction.
-    is $bf->sort($items, { key_kind => 'field', key => 'price', compare_type => 'numeric', direction => 'desc' }),
+    is $bf->sort($items, { keys => [{ key_kind => 'field', key => 'price', compare_type => 'numeric', direction => 'desc' }] }),
         [ { name => 'c', price => 30 }, { name => 'b', price => 20 }, { name => 'a', price => 10 } ],
         'numeric field desc';
 
     # Primitive numeric — `(a, b) => a - b` shape (key_kind=self).
-    is $bf->sort([3, 1, 2], { key_kind => 'self', compare_type => 'numeric', direction => 'asc' }),
+    is $bf->sort([3, 1, 2], { keys => [{ key_kind => 'self', compare_type => 'numeric', direction => 'asc' }] }),
         [1, 2, 3],
         'numeric self asc';
 
     # Primitive string — `(a, b) => a.localeCompare(b)`. The Perl
     # helper falls back to plain `cmp` (byte-ordering); within the
     # same case it matches lexicographic order.
-    is $bf->sort(['charlie', 'alice', 'bob'], { key_kind => 'self', compare_type => 'string', direction => 'asc' }),
+    is $bf->sort(['charlie', 'alice', 'bob'], { keys => [{ key_kind => 'self', compare_type => 'string', direction => 'asc' }] }),
         ['alice', 'bob', 'charlie'],
         'string self asc';
 
-    is $bf->sort(['charlie', 'alice', 'bob'], { key_kind => 'self', compare_type => 'string', direction => 'desc' }),
+    is $bf->sort(['charlie', 'alice', 'bob'], { keys => [{ key_kind => 'self', compare_type => 'string', direction => 'desc' }] }),
         ['charlie', 'bob', 'alice'],
         'string self desc';
 
@@ -289,24 +290,72 @@ subtest 'sort — structured comparator dispatch' => sub {
         { name => 'second', price => 10 },
         { name => 'third',  price => 10 },
     ];
-    is $bf->sort($stable_input, { key_kind => 'field', key => 'price', compare_type => 'numeric', direction => 'asc' }),
+    is $bf->sort($stable_input, { keys => [{ key_kind => 'field', key => 'price', compare_type => 'numeric', direction => 'asc' }] }),
         $stable_input,
         'stable sort preserves equal-key order';
 
     # Mutation isolation: caller's source array must survive.
     my $src = [{ price => 3 }, { price => 1 }, { price => 2 }];
-    my $out = $bf->sort($src, { key_kind => 'field', key => 'price', compare_type => 'numeric', direction => 'asc' });
+    my $out = $bf->sort($src, { keys => [{ key_kind => 'field', key => 'price', compare_type => 'numeric', direction => 'asc' }] });
     push @$out, { price => 99 };
     is $src, [{ price => 3 }, { price => 1 }, { price => 2 }],
         'source unchanged after mutating sort result';
 
     # Non-array receivers fall back to empty.
-    is $bf->sort(undef, { key_kind => 'self', compare_type => 'numeric', direction => 'asc' }), [], 'undef receiver → []';
-    is $bf->sort('not an array', { key_kind => 'self', compare_type => 'numeric', direction => 'asc' }), [], 'scalar receiver → []';
-    is $bf->sort({a => 1}, { key_kind => 'self', compare_type => 'numeric', direction => 'asc' }), [], 'hash ref receiver → []';
+    is $bf->sort(undef, { keys => [{ key_kind => 'self', compare_type => 'numeric', direction => 'asc' }] }), [], 'undef receiver → []';
+    is $bf->sort('not an array', { keys => [{ key_kind => 'self', compare_type => 'numeric', direction => 'asc' }] }), [], 'scalar receiver → []';
+    is $bf->sort({a => 1}, { keys => [{ key_kind => 'self', compare_type => 'numeric', direction => 'asc' }] }), [], 'hash ref receiver → []';
 
     # Empty array short-circuits.
-    is $bf->sort([], { key_kind => 'field', key => 'price', compare_type => 'numeric', direction => 'asc' }), [], 'empty array → []';
+    is $bf->sort([], { keys => [{ key_kind => 'field', key => 'price', compare_type => 'numeric', direction => 'asc' }] }), [], 'empty array → []';
+};
+
+# Multi-key (`||`-chained) comparator: a tie on the primary key falls
+# through to the next key. (#1448 Tier B follow-up.)
+subtest 'sort — multi-key (||-chain) tie-breaks' => sub {
+    # `(a,b) => a.p - b.p || a.name.localeCompare(b.name)`.
+    my $items = [
+        { p => 1, name => 'b' },
+        { p => 1, name => 'a' },
+        { p => 0, name => 'c' },
+    ];
+    is $bf->sort($items, { keys => [
+            { key_kind => 'field', key => 'p',    compare_type => 'numeric', direction => 'asc' },
+            { key_kind => 'field', key => 'name', compare_type => 'string',  direction => 'asc' },
+        ] }),
+        [ { p => 0, name => 'c' }, { p => 1, name => 'a' }, { p => 1, name => 'b' } ],
+        'tie on primary key broken by secondary asc';
+
+    # Descending secondary key: all primaries tie, so price desc orders.
+    my $items2 = [
+        { name => 'a', price => 10 },
+        { name => 'a', price => 30 },
+        { name => 'a', price => 20 },
+    ];
+    is $bf->sort($items2, { keys => [
+            { key_kind => 'field', key => 'name',  compare_type => 'string',  direction => 'asc' },
+            { key_kind => 'field', key => 'price', compare_type => 'numeric', direction => 'desc' },
+        ] }),
+        [ { name => 'a', price => 30 }, { name => 'a', price => 20 }, { name => 'a', price => 10 } ],
+        'all primary tie → secondary price desc';
+};
+
+# `compare_type => 'auto'` (relational-ternary lowering): numeric when
+# both keys look like numbers, else lexical. Mirrors Go's `bf_sort`.
+subtest 'sort — auto compare (relational ternary)' => sub {
+    is $bf->sort([3, 1, 2], { keys => [{ key_kind => 'self', compare_type => 'auto', direction => 'asc' }] }),
+        [1, 2, 3],
+        'auto numeric asc';
+
+    is $bf->sort(['charlie', 'alice', 'bob'], { keys => [{ key_kind => 'self', compare_type => 'auto', direction => 'asc' }] }),
+        ['alice', 'bob', 'charlie'],
+        'auto non-numeric strings → lexical';
+
+    # Numeric strings parse as numbers under auto (Go/Perl parity):
+    # "10" sorts after "9", not lexically before it.
+    is $bf->sort(['10', '9', '100'], { keys => [{ key_kind => 'self', compare_type => 'auto', direction => 'asc' }] }),
+        ['9', '10', '100'],
+        'auto numeric strings compare numerically';
 };
 
 done_testing;

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -153,6 +153,8 @@ import { fixture as arraySortFieldAsc } from './methods/array-sort-field-asc'
 import { fixture as arraySortFieldDesc } from './methods/array-sort-field-desc'
 import { fixture as arraySortPrimitive } from './methods/array-sort-primitive'
 import { fixture as arraySortLocale } from './methods/array-sort-locale'
+import { fixture as arraySortMultiKey } from './methods/array-sort-multikey'
+import { fixture as arraySortTernary } from './methods/array-sort-ternary'
 import { fixture as arrayToSorted } from './methods/array-toSorted'
 // #1448 Tier B — `.entries()` / `.keys()` / `.values()` iteration shapes.
 // The compiler strips the iterator method from the chain and synthesises
@@ -294,6 +296,8 @@ export const jsxFixtures: JSXFixture[] = [
   arraySortFieldDesc,
   arraySortPrimitive,
   arraySortLocale,
+  arraySortMultiKey,
+  arraySortTernary,
   arrayToSorted,
   arrayEntries,
   arrayKeys,

--- a/packages/adapter-tests/fixtures/methods/array-sort-multikey.ts
+++ b/packages/adapter-tests/fixtures/methods/array-sort-multikey.ts
@@ -1,0 +1,37 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `Array.prototype.sort((a, b) => a.x - b.x || a.y.localeCompare(b.y))`
+ * lowering — multi-key (`||`-chained) comparator (#1448 Tier B
+ * follow-up). Each `||` operand becomes one comparison key applied in
+ * priority order: a tie on `price` falls through to `name`. Lowers to
+ * one 4-string `bf_sort` group per key (Go) / one `keys` hash per key
+ * (Mojo); the Hono / CSR path re-emits the raw `||` comparator into
+ * `.toSorted(...)` so real JS evaluates it.
+ */
+export const fixture = createFixture({
+  id: 'array-sort-multikey',
+  description: '.sort((a,b) => a.price - b.price || a.name.localeCompare(b.name)) sorts by price, then name',
+  source: `
+function ArraySortMultiKey({ items }: { items: { name: string; price: number }[] }) {
+  return <ul>{items.sort((a, b) => a.price - b.price || a.name.localeCompare(b.name)).map(it => <li key={it.name}>{it.name}</li>)}</ul>
+}
+export { ArraySortMultiKey }
+`,
+  props: {
+    items: [
+      { name: 'c', price: 10 },
+      { name: 'a', price: 10 },
+      { name: 'b', price: 20 },
+    ],
+  },
+  // price asc orders [10, 10, 20]; the price=10 tie breaks on name asc
+  // (a before c), so the rendered order is a, c, b.
+  expectedHtml: `
+    <ul bf-s="test" bf="s1">
+      <li data-key="a"><!--bf:s0-->a<!--/--></li>
+      <li data-key="c"><!--bf:s0-->c<!--/--></li>
+      <li data-key="b"><!--bf:s0-->b<!--/--></li>
+    </ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/methods/array-sort-ternary.ts
+++ b/packages/adapter-tests/fixtures/methods/array-sort-ternary.ts
@@ -1,0 +1,35 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `Array.prototype.toSorted((a, b) => a.rank > b.rank ? 1 : -1)`
+ * lowering — relational-ternary comparator (#1448 Tier B follow-up).
+ * The sign-returning ternary lowers to a single `auto` comparison key:
+ * the runtime compares numerically when both keys parse as numbers,
+ * else lexically. With numeric `rank` values all three adapters agree
+ * (Go / Mojo `auto` ⇔ the real JS `>` the Hono / CSR path emits).
+ */
+export const fixture = createFixture({
+  id: 'array-sort-ternary',
+  description: '.toSorted((a,b) => a.rank > b.rank ? 1 : -1) sorts ascending by rank',
+  source: `
+function ArraySortTernary({ items }: { items: { name: string; rank: number }[] }) {
+  return <ul>{items.toSorted((a, b) => a.rank > b.rank ? 1 : -1).map(it => <li key={it.name}>{it.name}</li>)}</ul>
+}
+export { ArraySortTernary }
+`,
+  props: {
+    items: [
+      { name: 'c', rank: 3 },
+      { name: 'a', rank: 1 },
+      { name: 'b', rank: 2 },
+    ],
+  },
+  // `a.rank > b.rank ? 1 : -1` is ascending by rank → a(1), b(2), c(3).
+  expectedHtml: `
+    <ul bf-s="test" bf="s1">
+      <li data-key="a"><!--bf:s0-->a<!--/--></li>
+      <li data-key="b"><!--bf:s0-->b<!--/--></li>
+      <li data-key="c"><!--bf:s0-->c<!--/--></li>
+    </ul>
+  `,
+})

--- a/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
+++ b/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
@@ -474,7 +474,133 @@ hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-
 export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
 `;
 
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L75 — (no label) 1`] = `
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L69 — ✅ Multi-key: sort by price, break ties by name 1`] = `
+"import { $, $t, createComponent, createEffect, createSignal, hydrate, initChild, mapArray, renderChild } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const [_s0] = $t(__scope, 's0')
+
+  createEffect(() => {
+    const __val = String(_p.todo)
+    if (_s0 && !__val?.__isSlot) _s0.nodeValue = String(__val ?? '')
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${String(_p.todo)}<!--/--></li>\` })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const [_s0] = $t(__scope, 's0')
+
+  createEffect(() => {
+    const __val = String(_p.item)
+    if (_s0 && !__val?.__isSlot) _s0.nodeValue = String(__val ?? '')
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${String(_p.item)}<!--/--></li>\` })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\` })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const children = _p.children
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  const [_s1] = $(__scope, 's1')
+
+  mapArray(() => items().toSorted((a, b) => a.price - b.price || a.name.localeCompare(b.name)), _s1, (item) => String(item.id), (item, __idx, __existing) => {
+    if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
+    return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
+  }, 'l0')
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).toSorted((a, b) => a.price - b.price || a.name.localeCompare(b.name)).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L74 — ✅ Relational ternary 1`] = `
+"import { $, $t, createComponent, createEffect, createSignal, hydrate, initChild, mapArray, renderChild } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const [_s0] = $t(__scope, 's0')
+
+  createEffect(() => {
+    const __val = String(_p.todo)
+    if (_s0 && !__val?.__isSlot) _s0.nodeValue = String(__val ?? '')
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${String(_p.todo)}<!--/--></li>\` })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const [_s0] = $t(__scope, 's0')
+
+  createEffect(() => {
+    const __val = String(_p.item)
+    if (_s0 && !__val?.__isSlot) _s0.nodeValue = String(__val ?? '')
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${String(_p.item)}<!--/--></li>\` })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\` })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const children = _p.children
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  const [_s1] = $(__scope, 's1')
+
+  mapArray(() => items().toSorted((a, b) => a.price > b.price ? 1 : -1), _s1, (item) => String(item.id), (item, __idx, __existing) => {
+    if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
+    return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
+  }, 'l0')
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).toSorted((a, b) => a.price > b.price ? 1 : -1).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L85 — (no label) 1`] = `
 "import { $, $t, createComponent, createEffect, createSignal, hydrate } from '@barefootjs/client/runtime'
 
 export function initTodoItem(__scope, _p = {}) {
@@ -536,7 +662,7 @@ hydrate('Example', { init: initExample, template: (_p) => \`<div><button bf="s0"
 export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
 `;
 
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L121 — ❌ BF101 on Go/Mojo; works on Hono 1`] = `
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L131 — ❌ BF101 on Go/Mojo; works on Hono 1`] = `
 "import { $t, createComponent, createEffect, createSignal, hydrate } from '@barefootjs/client/runtime'
 
 export function initTodoItem(__scope, _p = {}) {
@@ -599,7 +725,7 @@ hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:
 export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
 `;
 
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L124 — ✅ Use /* @client */ 1`] = `
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L134 — ✅ Use /* @client */ 1`] = `
 "import { $t, createComponent, createEffect, createSignal, hydrate, updateClientMarker } from '@barefootjs/client/runtime'
 
 export function initTodoItem(__scope, _p = {}) {
@@ -660,7 +786,7 @@ hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-
 export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
 `;
 
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L141 — ❌ BF101 on Go/Mojo; works on Hono 1`] = `
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L151 — ❌ BF101 on Go/Mojo; works on Hono 1`] = `
 "import { $t, createComponent, createEffect, createSignal, hydrate } from '@barefootjs/client/runtime'
 
 export function initTodoItem(__scope, _p = {}) {
@@ -723,7 +849,7 @@ hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:
 export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
 `;
 
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L144 — ✅ Use arrow functions for adapter portability 1`] = `
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L154 — ✅ Use arrow functions for adapter portability 1`] = `
 "import { $t, createComponent, createEffect, createSignal, hydrate } from '@barefootjs/client/runtime'
 
 export function initTodoItem(__scope, _p = {}) {
@@ -786,7 +912,7 @@ hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:
 export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
 `;
 
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L158 — ✅ Use /* @client */ 1`] = `
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L168 — ✅ Use /* @client */ 1`] = `
 "import { $, $t, createComponent, createEffect, createSignal, hydrate, initChild, mapArray, renderChild } from '@barefootjs/client/runtime'
 
 export function initTodoItem(__scope, _p = {}) {
@@ -838,14 +964,14 @@ export function initExample(__scope, _p = {}) {
 
   const [_s1] = $(__scope, 's1')
 
-  mapArray(() => items().sort((a, b) => a.name > b.name ? 1 : -1), _s1, (item) => String(item.id), (item, __idx, __existing) => {
+  mapArray(() => items().sort((a, b) => { const an = a.name; return an > b.name ? 1 : -1 }), _s1, (item) => String(item.id), (item, __idx, __existing) => {
     if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
     return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
   }, 'l0')
 
 }
 
-hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).sort((a, b) => a.name > b.name ? 1 : -1).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).sort((a, b) => { const an = a.name; return an > b.name ? 1 : -1 }).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
 export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
 `;
 

--- a/packages/jsx/src/__tests__/ir-sort-comparator.test.ts
+++ b/packages/jsx/src/__tests__/ir-sort-comparator.test.ts
@@ -31,9 +31,10 @@ describe('sort().map() / toSorted().map()', () => {
       expect(loop).toBeDefined()
       if (loop?.type === 'loop') {
         expect(loop.sortComparator).toBeDefined()
-        expect(loop.sortComparator!.key).toEqual({ kind: 'field', field: 'price' })
-        expect(loop.sortComparator!.type).toBe('numeric')
-        expect(loop.sortComparator!.direction).toBe('asc')
+        expect(loop.sortComparator!.keys).toHaveLength(1)
+        expect(loop.sortComparator!.keys[0].key).toEqual({ kind: 'field', field: 'price' })
+        expect(loop.sortComparator!.keys[0].type).toBe('numeric')
+        expect(loop.sortComparator!.keys[0].direction).toBe('asc')
         expect(loop.sortComparator!.method).toBe('sort')
         expect(loop.sortComparator!.paramA).toBe('a')
         expect(loop.sortComparator!.paramB).toBe('b')
@@ -69,9 +70,10 @@ describe('sort().map() / toSorted().map()', () => {
       expect(loop).toBeDefined()
       if (loop?.type === 'loop') {
         expect(loop.sortComparator).toBeDefined()
-        expect(loop.sortComparator!.key).toEqual({ kind: 'field', field: 'price' })
-        expect(loop.sortComparator!.type).toBe('numeric')
-        expect(loop.sortComparator!.direction).toBe('desc')
+        expect(loop.sortComparator!.keys).toHaveLength(1)
+        expect(loop.sortComparator!.keys[0].key).toEqual({ kind: 'field', field: 'price' })
+        expect(loop.sortComparator!.keys[0].type).toBe('numeric')
+        expect(loop.sortComparator!.keys[0].direction).toBe('desc')
         expect(loop.sortComparator!.method).toBe('toSorted')
       }
     }
@@ -105,9 +107,10 @@ describe('sort().map() / toSorted().map()', () => {
         expect(loop.filterPredicate).toBeDefined()
         expect(loop.filterPredicate!.param).toBe('t')
         expect(loop.sortComparator).toBeDefined()
-        expect(loop.sortComparator!.key).toEqual({ kind: 'field', field: 'priority' })
-        expect(loop.sortComparator!.type).toBe('numeric')
-        expect(loop.sortComparator!.direction).toBe('asc')
+        expect(loop.sortComparator!.keys).toHaveLength(1)
+        expect(loop.sortComparator!.keys[0].key).toEqual({ kind: 'field', field: 'priority' })
+        expect(loop.sortComparator!.keys[0].type).toBe('numeric')
+        expect(loop.sortComparator!.keys[0].direction).toBe('asc')
         expect(loop.chainOrder).toBe('filter-sort')
         expect(loop.array).toBe('todos()')
       }
@@ -143,6 +146,139 @@ describe('sort().map() / toSorted().map()', () => {
         expect(loop.sortComparator).toBeDefined()
         expect(loop.chainOrder).toBe('sort-filter')
         expect(loop.array).toBe('todos()')
+      }
+    }
+  })
+
+  test('multi-key (||-chain) produces one SortKey per operand', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function ProductList() {
+        const [products, setProducts] = createSignal<any[]>([])
+        return (
+          <ul>
+            {products().sort((a, b) => b.price - a.price || a.name.localeCompare(b.name)).map(p => (
+              <li>{p.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'ProductList.tsx')
+    const ir = jsxToIR(ctx)
+
+    expect(ir).not.toBeNull()
+    if (ir!.type === 'element') {
+      const loop = ir!.children.find(c => c.type === 'loop')
+      expect(loop?.type).toBe('loop')
+      if (loop?.type === 'loop') {
+        expect(loop.sortComparator).toBeDefined()
+        expect(loop.sortComparator!.keys).toEqual([
+          { key: { kind: 'field', field: 'price' }, type: 'numeric', direction: 'desc' },
+          { key: { kind: 'field', field: 'name' }, type: 'string', direction: 'asc' },
+        ])
+      }
+    }
+  })
+
+  test('relational ternary comparator lowers to an auto key', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function ProductList() {
+        const [products, setProducts] = createSignal<any[]>([])
+        return (
+          <ul>
+            {products().toSorted((a, b) => a.rank > b.rank ? 1 : -1).map(p => (
+              <li>{p.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'ProductList.tsx')
+    const ir = jsxToIR(ctx)
+
+    expect(ir).not.toBeNull()
+    if (ir!.type === 'element') {
+      const loop = ir!.children.find(c => c.type === 'loop')
+      if (loop?.type === 'loop') {
+        expect(loop.sortComparator).toBeDefined()
+        expect(loop.sortComparator!.keys).toEqual([
+          { key: { kind: 'field', field: 'rank' }, type: 'auto', direction: 'asc' },
+        ])
+      }
+    }
+  })
+
+  test('3-way ternary comparator derives direction from the outer comparison', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function NumList() {
+        const [nums, setNums] = createSignal<number[]>([])
+        return (
+          <ul>
+            {nums().sort((a, b) => a < b ? -1 : a > b ? 1 : 0).map(n => (
+              <li>{n}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'NumList.tsx')
+    const ir = jsxToIR(ctx)
+
+    expect(ir).not.toBeNull()
+    if (ir!.type === 'element') {
+      const loop = ir!.children.find(c => c.type === 'loop')
+      if (loop?.type === 'loop') {
+        expect(loop.sortComparator).toBeDefined()
+        expect(loop.sortComparator!.keys).toEqual([
+          { key: { kind: 'self' }, type: 'auto', direction: 'asc' },
+        ])
+      }
+    }
+  })
+
+  test('arrow block body with single return unwraps to the comparator', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function ProductList() {
+        const [products, setProducts] = createSignal<any[]>([])
+        return (
+          <ul>
+            {products().sort((a, b) => { return a.price - b.price }).map(p => (
+              <li>{p.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'ProductList.tsx')
+    const ir = jsxToIR(ctx)
+
+    expect(ir).not.toBeNull()
+    if (ir!.type === 'element') {
+      const loop = ir!.children.find(c => c.type === 'loop')
+      if (loop?.type === 'loop') {
+        expect(loop.sortComparator).toBeDefined()
+        expect(loop.sortComparator!.keys).toEqual([
+          { key: { kind: 'field', field: 'price' }, type: 'numeric', direction: 'asc' },
+        ])
+        // block body unwraps to the returned expression, keeping the
+        // @client fallback's synthetic `(a, b) => raw` arrow valid.
+        expect(loop.sortComparator!.raw).toBe('a.price - b.price')
       }
     }
   })

--- a/packages/jsx/src/__tests__/ir-sort-comparator.test.ts
+++ b/packages/jsx/src/__tests__/ir-sort-comparator.test.ts
@@ -283,6 +283,73 @@ describe('sort().map() / toSorted().map()', () => {
     }
   })
 
+  test('leading-equality 3-way ternary (a.f === b.f ? 0 : …) lowers to an auto key', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function ProductList() {
+        const [products, setProducts] = createSignal<any[]>([])
+        return (
+          <ul>
+            {products().toSorted((a, b) => a.rank === b.rank ? 0 : a.rank > b.rank ? 1 : -1).map(p => (
+              <li>{p.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'ProductList.tsx')
+    const ir = jsxToIR(ctx)
+
+    expect(ir).not.toBeNull()
+    if (ir!.type === 'element') {
+      const loop = ir!.children.find(c => c.type === 'loop')
+      if (loop?.type === 'loop') {
+        expect(loop.sortComparator).toBeDefined()
+        // The `=== ? 0` arm is a tie; direction comes from the inner
+        // relational ternary (a.rank > b.rank ? 1 : -1 → ascending).
+        expect(loop.sortComparator!.keys).toEqual([
+          { key: { kind: 'field', field: 'rank' }, type: 'auto', direction: 'asc' },
+        ])
+      }
+    }
+  })
+
+  test('multi-key mixing a numeric leaf and an auto (ternary) leaf', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function ProductList() {
+        const [products, setProducts] = createSignal<any[]>([])
+        return (
+          <ul>
+            {products().sort((a, b) => a.price - b.price || (a.rank > b.rank ? 1 : -1)).map(p => (
+              <li>{p.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'ProductList.tsx')
+    const ir = jsxToIR(ctx)
+
+    expect(ir).not.toBeNull()
+    if (ir!.type === 'element') {
+      const loop = ir!.children.find(c => c.type === 'loop')
+      if (loop?.type === 'loop') {
+        expect(loop.sortComparator).toBeDefined()
+        expect(loop.sortComparator!.keys).toEqual([
+          { key: { kind: 'field', field: 'price' }, type: 'numeric', direction: 'asc' },
+          { key: { kind: 'field', field: 'rank' }, type: 'auto', direction: 'asc' },
+        ])
+      }
+    }
+  })
+
   test('complex sort comparator with @client keeps sort in array', () => {
     const source = `
       'use client'

--- a/packages/jsx/src/__tests__/unsupported-expression.test.ts
+++ b/packages/jsx/src/__tests__/unsupported-expression.test.ts
@@ -136,21 +136,22 @@ describe('Unsupported Expression Error (BF021)', () => {
 })
 
 describe('Unsupported Sort Comparator (BF021)', () => {
-  test('emits BF021 for multi-key comparator (||-chained) — outside accepted catalogue', () => {
-    // #1448 Tier B widened the accepted catalogue to include
-    // `.localeCompare` and primitive `(a,b) => a - b`. Multi-key
-    // shapes (`a.x - b.x || a.y - b.y`) are still out of scope —
-    // they refuse here and must be `@client`-marked or rewritten
-    // to a single-key sort.
+  test('emits BF021 for function-reference comparator — outside accepted catalogue', () => {
+    // #1448 Tier B follow-up widened the catalogue to include
+    // multi-key (`a.x - b.x || a.y - b.y`), relational ternary, and
+    // single-`return` block bodies. Function-reference comparators
+    // (`arr.sort(cmp)` where `cmp` is a named function) are still out
+    // of scope — they need scope resolution and refuse here.
     const source = `
       'use client'
       import { createSignal } from '@barefootjs/client'
 
       export function TodoList() {
         const [items, setItems] = createSignal<any[]>([])
+        const cmp = (a, b) => a.priority - b.priority
         return (
           <ul>
-            {items().sort((a, b) => a.priority - b.priority || a.id - b.id).map(t => (
+            {items().sort(cmp).map(t => (
               <li>{t.name}</li>
             ))}
           </ul>
@@ -162,7 +163,6 @@ describe('Unsupported Sort Comparator (BF021)', () => {
     const bf021 = errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
 
     expect(bf021).toHaveLength(1)
-    expect(bf021[0].message).toContain('not a supported shape')
   })
 
   test('@client suppresses BF021 for unsupported sort comparator', () => {
@@ -172,9 +172,10 @@ describe('Unsupported Sort Comparator (BF021)', () => {
 
       export function TodoList() {
         const [items, setItems] = createSignal<any[]>([])
+        const cmp = (a, b) => a.priority - b.priority
         return (
           <ul>
-            {/* @client */ items().sort((a, b) => a.priority - b.priority || a.id - b.id).map(t => (
+            {/* @client */ items().sort(cmp).map(t => (
               <li>{t.name}</li>
             ))}
           </ul>
@@ -188,9 +189,10 @@ describe('Unsupported Sort Comparator (BF021)', () => {
     expect(bf021).toHaveLength(0)
   })
 
-  test('emits BF021 error for block body sort comparator', () => {
-    // Block-body comparators are deferred to a Tier B follow-up
-    // (the extractor only handles expression-body shapes for now).
+  test('emits BF021 error for multi-statement block-body sort comparator', () => {
+    // Single-`return` block bodies now lower (#1448 Tier B follow-up),
+    // but multi-statement / local-var bodies stay refused — generalising
+    // over arbitrary statement sequences isn't tractable in a template.
     const source = `
       'use client'
       import { createSignal } from '@barefootjs/client'
@@ -199,7 +201,7 @@ describe('Unsupported Sort Comparator (BF021)', () => {
         const [items, setItems] = createSignal<any[]>([])
         return (
           <ul>
-            {items().sort((a, b) => { return a.price - b.price }).map(t => (
+            {items().sort((a, b) => { const x = a.price; return x - b.price }).map(t => (
               <li>{t.name}</li>
             ))}
           </ul>

--- a/packages/jsx/src/__tests__/unsupported-expression.test.ts
+++ b/packages/jsx/src/__tests__/unsupported-expression.test.ts
@@ -189,6 +189,33 @@ describe('Unsupported Sort Comparator (BF021)', () => {
     expect(bf021).toHaveLength(0)
   })
 
+  test('emits BF021 for localeCompare with a locale/options argument', () => {
+    // The zero-arg `a.f.localeCompare(b.f)` form lowers, but the
+    // locale/options form needs per-adapter collation plumbing and
+    // stays refused (deferred #1448 Tier B follow-up).
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function TodoList() {
+        const [items, setItems] = createSignal<any[]>([])
+        return (
+          <ul>
+            {items().sort((a, b) => a.name.localeCompare(b.name, 'en', { numeric: true })).map(t => (
+              <li>{t.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const { errors } = compileToIR(source)
+    const bf021 = errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+
+    expect(bf021).toHaveLength(1)
+    expect(bf021[0].message).toContain('not a supported shape')
+  })
+
   test('emits BF021 error for multi-statement block-body sort comparator', () => {
     // Single-`return` block bodies now lower (#1448 Tier B follow-up),
     // but multi-statement / local-var bodies stay refused — generalising

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -69,13 +69,12 @@ export type ParsedExpr =
   | { kind: 'unsupported'; raw: string; reason: string }
 
 /**
- * Structured form of a JS `(a, b) => …` sort comparator. Built once
- * at parse time and consumed by both adapters' arrayMethod emit and
- * (when chained directly before `.map()`) the loop-hoist path in
- * `jsx-to-ir.ts`. The shape is intentionally finite — see
- * `extractSortComparatorFromTS` for the accepted catalogue.
+ * One comparison key inside a sort comparator. A simple
+ * `(a, b) => a.f - b.f` produces a single key; a multi-key
+ * `||`-chained comparator (`a.x - b.x || a.y - b.y`) produces one key
+ * per `||` operand, applied in priority order as tie-breakers.
  */
-export type SortComparator = {
+export type SortKey = {
   // What value to compare on each item:
   //   { kind: 'self' }         → primitive array, compare items directly
   //   { kind: 'field', field } → struct-field accessor
@@ -83,11 +82,33 @@ export type SortComparator = {
   // How to compare:
   //   'numeric' → `a - b` subtraction semantics
   //   'string'  → `localeCompare` semantics
-  type: 'numeric' | 'string'
+  //   'auto'    → relational (`>`/`<`) ternary: compare numerically
+  //               when both keys parse as numbers, else lexically.
+  //               Both template runtimes apply the same rule so their
+  //               output stays byte-equal; this diverges from JS
+  //               `<`/`>` only for numeric *strings* (rare in SSR
+  //               data — JS would compare those lexically).
+  type: 'numeric' | 'string' | 'auto'
   direction: 'asc' | 'desc'
+}
+
+/**
+ * Structured form of a JS `(a, b) => …` sort comparator. Built once
+ * at parse time and consumed by both adapters' arrayMethod emit and
+ * (when chained directly before `.map()`) the loop-hoist path in
+ * `jsx-to-ir.ts`. The shape is intentionally finite — see
+ * `extractSortComparatorFromTS` for the accepted catalogue.
+ */
+export type SortComparator = {
+  // Comparison keys in priority order. A simple comparator has one
+  // key; a `||`-chained multi-key comparator has one per operand.
+  // Always length >= 1.
+  keys: SortKey[]
   // Original JS source of the comparator body; preserved so `@client`
   // fallback can re-emit the user's exact expression if the call site
-  // ever gets relocated to the runtime.
+  // ever gets relocated to the runtime. For block-body comparators
+  // this is the returned expression, not the `{ … }` block — so the
+  // client fallback's synthetic `(a, b) => raw` arrow stays valid.
   raw: string
   // The two parameter names the user wrote (e.g. `a`/`b`, or
   // `lhs`/`rhs`). Only consumed by the client-side `@client`
@@ -379,9 +400,11 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
       // `.sort(cmp)` / `.toSorted(cmp)` (#1448 Tier B). The comparator
       // is extracted into a structured `SortComparator` at parse time;
       // unrecognised shapes fall through to `unsupported` so adapters
-      // surface BF101 (with `@client` as the escape hatch). Block
-      // bodies, multi-key comparators, and function-reference
-      // comparators are out of scope for this PR — see #1448 Tier B
+      // surface BF101 (with `@client` as the escape hatch). Supported:
+      // subtraction / localeCompare / relational-ternary leaves, any
+      // of them `||`-chained (multi-key), and single-`return` block
+      // bodies. Function-reference comparators and `localeCompare`
+      // locale/options args stay out of scope — see #1448 Tier B
       // follow-up.
       if ((callee.property === 'sort' || callee.property === 'toSorted') && node.arguments.length === 1) {
         // Extract from the raw TS AST (not args[0] ParsedExpr) — the
@@ -406,6 +429,8 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
             `  (a, b) => a.field - b.field\n` +
             `  (a, b) => a.localeCompare(b)\n` +
             `  (a, b) => a.field.localeCompare(b.field)\n` +
+            `  (a, b) => a.field > b.field ? 1 : -1   (relational ternary)\n` +
+            `  any of the above ||-chained for multi-key tie-breaks\n` +
             `(reverse the operands for descending order). ` +
             `Wrap the call in /* @client */ to evaluate at hydration.`,
         }
@@ -663,20 +688,28 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
  * match exactly, in which case the caller emits an `unsupported` IR
  * node and adapters surface BF101.
  *
- * Accepted shapes (paired ascending / descending):
+ * Body shapes:
+ *   - expression-bodied arrow (`(a, b) => …`)
+ *   - single-`return` block body — both arrow (`(a, b) => { return …; }`)
+ *     and function expression. Multi-statement / local-var bodies stay
+ *     refused (deferred follow-up).
  *
- *   (a, b) => a.field - b.field            → field, numeric, asc
- *   (a, b) => b.field - a.field            → field, numeric, desc
- *   (a, b) => a - b                        → self,  numeric, asc
- *   (a, b) => b - a                        → self,  numeric, desc
- *   (a, b) => a.field.localeCompare(b.field) → field, string, asc
- *   (a, b) => b.field.localeCompare(a.field) → field, string, desc
- *   (a, b) => a.localeCompare(b)           → self,  string, asc
- *   (a, b) => b.localeCompare(a)           → self,  string, desc
+ * A body is split on top-level `||` into one leaf per operand, giving
+ * a multi-key comparator (`a.x - b.x || a.y - b.y` → sort by x, then y).
+ * Accepted leaf shapes (each paired ascending / descending by operand
+ * order):
  *
- * Anything outside (block bodies, multi-key `a.x-b.x || a.y-b.y`,
- * function-reference comparators, ternary comparators) returns null.
- * Block-body support is deferred to a follow-up.
+ *   a.field - b.field                → field, numeric
+ *   a - b                            → self,  numeric
+ *   a.field.localeCompare(b.field)   → field, string
+ *   a.localeCompare(b)               → self,  string
+ *   a.field > b.field ? 1 : -1       → field, auto (relational ternary)
+ *   a.field < b.field ? -1 : 1       → field, auto
+ *   a < b ? -1 : a > b ? 1 : 0       → self/field, auto (3-way)
+ *   a === b ? 0 : <relational ternary>  → leading-tie 3-way
+ *
+ * Function-reference comparators and `localeCompare(b, locale, opts)`
+ * (the multi-arg form) return null — deferred follow-ups.
  */
 export function extractSortComparatorFromTS(
   node: ts.Node,
@@ -691,38 +724,87 @@ export function extractSortComparatorFromTS(
   const paramA = pA.name.text
   const paramB = pB.name.text
 
-  // Body must be an expression. Arrow-fn carries `.body` directly;
-  // function-expression wraps a single `return <expr>;`. Block bodies
-  // deferred to a follow-up PR.
+  // Resolve the comparator body. Expression-bodied arrows carry it
+  // directly; block bodies (both arrow `=> { … }` and function
+  // expressions) must reduce to exactly one `return <expr>;`. Anything
+  // with locals or multiple statements stays refused — a deferred
+  // follow-up.
   let body: ts.Expression
-  if (ts.isArrowFunction(node)) {
-    if (ts.isBlock(node.body)) return null
+  if (ts.isArrowFunction(node) && !ts.isBlock(node.body)) {
     body = node.body
   } else {
-    const stmts = node.body.statements
+    const block = node.body as ts.Block
+    const stmts = block.statements
     if (stmts.length !== 1 || !ts.isReturnStatement(stmts[0]) || !stmts[0].expression) return null
     body = stmts[0].expression
   }
 
   // Normalise the comparator body source so consumers of
   // `SortComparator.raw` get the same string regardless of whether
-  // the user wrote an arrow expression (`(a, b) => a.x - b.x`) or
-  // a function expression (`function (a, b) { return a.x - b.x }`).
-  // Pre-normalisation the function-expression form leaked the whole
-  // function declaration into `raw`, breaking `@client` fallback
-  // emit that wraps `raw` in a synthetic arrow.
+  // the user wrote an arrow expression (`(a, b) => a.x - b.x`) or a
+  // block body (`(a, b) => { return a.x - b.x }`). For block bodies
+  // this is the returned expression, not the `{ … }` block — so the
+  // `@client` fallback's synthetic `(a, b) => raw` arrow stays valid.
   //
   // `body.getText()` resolves against the node's source file via the
   // parent chain — `ts.createSourceFile`-parsed nodes (the only
   // shape this helper accepts) carry that wiring.
   const raw = body.getText()
 
-  // Subtraction: `a.field - b.field` / `a - b` etc.
+  // A `||`-chain is a multi-key comparator: each operand is an
+  // independent leaf applied as the next tie-breaker. A non-`||` body
+  // is a single-key comparator (one-element chain).
+  const keys: SortKey[] = []
+  for (const operand of flattenLogicalOr(body)) {
+    const key = classifyLeafComparator(operand, paramA, paramB)
+    if (!key) return null
+    keys.push(key)
+  }
+  if (keys.length === 0) return null
+
+  return { keys, raw, paramA, paramB, method }
+}
+
+/** Strip redundant parentheses so the classifiers see the real node. */
+function unwrapParens(expr: ts.Expression): ts.Expression {
+  let e = expr
+  while (ts.isParenthesizedExpression(e)) e = e.expression
+  return e
+}
+
+/**
+ * Flatten a left-associative top-level `||` chain into its operands.
+ * `a || b || c` parses as `((a || b) || c)`; this returns `[a, b, c]`.
+ * A non-`||` expression returns a single-element list.
+ */
+function flattenLogicalOr(expr: ts.Expression): ts.Expression[] {
+  const inner = unwrapParens(expr)
+  if (ts.isBinaryExpression(inner) && inner.operatorToken.kind === ts.SyntaxKind.BarBarToken) {
+    return [...flattenLogicalOr(inner.left), ...flattenLogicalOr(inner.right)]
+  }
+  return [inner]
+}
+
+/**
+ * Classify a single comparator leaf (one `||` operand) into a SortKey.
+ * Accepts subtraction (numeric), `localeCompare` (string), and
+ * relational-ternary (auto) shapes; returns null otherwise.
+ */
+function classifyLeafComparator(
+  expr: ts.Expression,
+  paramA: string,
+  paramB: string,
+): SortKey | null {
+  const body = unwrapParens(expr)
+
+  // Subtraction: `a.field - b.field` / `a - b` → numeric.
   if (ts.isBinaryExpression(body) && body.operatorToken.kind === ts.SyntaxKind.MinusToken) {
-    return classifyComparatorOperands(body.left, body.right, paramA, paramB, 'numeric', method, raw)
+    return classifyComparatorOperands(body.left, body.right, paramA, paramB, 'numeric')
   }
 
-  // localeCompare call: `<lhs>.localeCompare(<rhs>)`.
+  // localeCompare (zero-arg form): `<lhs>.localeCompare(<rhs>)` →
+  // string. The locale/options form (2–3 args) stays refused — it
+  // needs per-adapter collation plumbing (deferred follow-up).
   if (
     ts.isCallExpression(body) &&
     ts.isPropertyAccessExpression(body.expression) &&
@@ -735,9 +817,12 @@ export function extractSortComparatorFromTS(
       paramA,
       paramB,
       'string',
-      method,
-      raw,
     )
+  }
+
+  // Relational-ternary sign comparator → auto.
+  if (ts.isConditionalExpression(body)) {
+    return classifyTernaryComparator(body, paramA, paramB)
   }
 
   return null
@@ -762,9 +847,7 @@ function classifyComparatorOperands(
   paramA: string,
   paramB: string,
   type: 'numeric' | 'string',
-  method: 'sort' | 'toSorted',
-  raw: string,
-): SortComparator | null {
+): SortKey | null {
   const leftRef = classifySortOperand(left, paramA, paramB)
   const rightRef = classifySortOperand(right, paramA, paramB)
   if (!leftRef || !rightRef) return null
@@ -774,15 +857,139 @@ function classifyComparatorOperands(
     return null
   }
   const direction = leftRef.param === 'A' ? 'asc' : 'desc'
-  return {
-    key: leftRef.key,
-    type,
-    direction,
-    raw,
-    paramA,
-    paramB,
-    method,
+  return { key: leftRef.key, type, direction }
+}
+
+/**
+ * Classify a relational-ternary comparator leaf into an `auto` SortKey.
+ * Handles the 2-way sign form (`a.f > b.f ? 1 : -1`), the canonical
+ * 3-way (`a.f < b.f ? -1 : a.f > b.f ? 1 : 0`), and a leading
+ * equality tie (`a.f === b.f ? 0 : <relational ternary>`).
+ *
+ * Direction is derived from (relational op, operand order, sign of the
+ * `whenTrue` branch); the `whenFalse` branch only needs to be a bounded
+ * shape (sign literal or a nested ternary on the same key) so we don't
+ * silently accept arbitrary expressions.
+ */
+function classifyTernaryComparator(
+  node: ts.ConditionalExpression,
+  paramA: string,
+  paramB: string,
+): SortKey | null {
+  const cond = unwrapParens(node.condition)
+
+  // Leading equality tie: `a.f === b.f ? 0 : <ternary>`. The equality
+  // arm returns 0 (tie); the real ordering lives in the else branch.
+  if (
+    ts.isBinaryExpression(cond) &&
+    (cond.operatorToken.kind === ts.SyntaxKind.EqualsEqualsEqualsToken ||
+      cond.operatorToken.kind === ts.SyntaxKind.EqualsEqualsToken) &&
+    sameKeyOperands(cond.left, cond.right, paramA, paramB) &&
+    numericSign(node.whenTrue) === 0
+  ) {
+    const elseBranch = unwrapParens(node.whenFalse)
+    if (ts.isConditionalExpression(elseBranch)) {
+      return classifyTernaryComparator(elseBranch, paramA, paramB)
+    }
+    return null
   }
+
+  // Relational condition: `<left> <op> <right>` with op ∈ {<,>,<=,>=}.
+  if (!ts.isBinaryExpression(cond)) return null
+  const op = cond.operatorToken.kind
+  const isGreater =
+    op === ts.SyntaxKind.GreaterThanToken || op === ts.SyntaxKind.GreaterThanEqualsToken
+  const isLess = op === ts.SyntaxKind.LessThanToken || op === ts.SyntaxKind.LessThanEqualsToken
+  if (!isGreater && !isLess) return null
+
+  const leftRef = classifySortOperand(cond.left, paramA, paramB)
+  const rightRef = classifySortOperand(cond.right, paramA, paramB)
+  if (!leftRef || !rightRef) return null
+  if (leftRef.param === rightRef.param) return null
+  if (leftRef.key.kind !== rightRef.key.kind) return null
+  if (leftRef.key.kind === 'field' && rightRef.key.kind === 'field' && leftRef.key.field !== rightRef.key.field) {
+    return null
+  }
+
+  // whenTrue must be a non-zero sign literal (±1); whenFalse a bounded
+  // shape (sign literal or a nested ternary on the same key).
+  const trueSign = numericSign(node.whenTrue)
+  if (trueSign === null || trueSign === 0) return null
+  if (!isBoundedTernaryElse(node.whenFalse, leftRef.key, paramA, paramB)) return null
+
+  // Rewrite so the condition reads as `aKey <op> bKey` (paramA left).
+  // `b.f > a.f` ⇔ `a.f < b.f`, so a paramB-on-left operand flips it.
+  const greaterForA = leftRef.param === 'A' ? isGreater : !isGreater
+
+  // `a.f > b.f ? +n` → bigger sorts later  → ascending
+  // `a.f < b.f ? +n` → bigger sorts earlier → descending
+  const asc = greaterForA ? trueSign > 0 : trueSign < 0
+  return { key: leftRef.key, type: 'auto', direction: asc ? 'asc' : 'desc' }
+}
+
+/** True when both operands resolve to the same key on opposite params. */
+function sameKeyOperands(
+  left: ts.Expression,
+  right: ts.Expression,
+  paramA: string,
+  paramB: string,
+): boolean {
+  const l = classifySortOperand(left, paramA, paramB)
+  const r = classifySortOperand(right, paramA, paramB)
+  if (!l || !r) return false
+  if (l.param === r.param) return false
+  if (l.key.kind !== r.key.kind) return false
+  if (l.key.kind === 'field' && r.key.kind === 'field' && l.key.field !== r.key.field) return false
+  return true
+}
+
+/**
+ * Sign of a numeric literal with optional unary minus: 1, -1, or 0.
+ * Returns null for anything that isn't a (signed) numeric literal.
+ */
+function numericSign(expr: ts.Expression): number | null {
+  const e = unwrapParens(expr)
+  if (ts.isPrefixUnaryExpression(e) && e.operator === ts.SyntaxKind.MinusToken) {
+    const inner = numericSign(e.operand)
+    return inner === null ? null : -inner
+  }
+  if (ts.isNumericLiteral(e)) {
+    const n = Number(e.text)
+    if (Number.isNaN(n)) return null
+    if (n === 0) return 0
+    return n > 0 ? 1 : -1
+  }
+  return null
+}
+
+/**
+ * The `whenFalse` arm of a relational ternary is bounded if it's a
+ * sign literal (±1 / 0) or a nested ternary on the same key (the
+ * canonical 3-way form). The outer comparison already fixes direction,
+ * so the nested branch only needs to agree on which key it compares.
+ */
+function isBoundedTernaryElse(
+  expr: ts.Expression,
+  key: { kind: 'self' } | { kind: 'field'; field: string },
+  paramA: string,
+  paramB: string,
+): boolean {
+  const e = unwrapParens(expr)
+  if (numericSign(e) !== null) return true
+  if (ts.isConditionalExpression(e)) {
+    const nested = classifyTernaryComparator(e, paramA, paramB)
+    return nested !== null && sortKeyEquals(nested.key, key)
+  }
+  return false
+}
+
+function sortKeyEquals(
+  a: { kind: 'self' } | { kind: 'field'; field: string },
+  b: { kind: 'self' } | { kind: 'field'; field: string },
+): boolean {
+  if (a.kind !== b.kind) return false
+  if (a.kind === 'field' && b.kind === 'field') return a.field === b.field
+  return true
 }
 
 function classifySortOperand(

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -913,6 +913,14 @@ function classifyTernaryComparator(
 
   // whenTrue must be a non-zero sign literal (±1); whenFalse a bounded
   // shape (sign literal or a nested ternary on the same key).
+  //
+  // Direction is derived solely from this outer comparison — the nested
+  // whenFalse branch is only validated for key agreement, not direction
+  // consistency. A contradictory hand-written 3-way (e.g.
+  // `a.f < b.f ? -1 : a.f < b.f ? 1 : 0`) is therefore lowered per the
+  // outer comparison; the JS-runtime (Hono/CSR) path runs the literal
+  // body, so such a degenerate comparator could order differently
+  // there. The canonical asc/desc 3-way forms agree on both paths.
   const trueSign = numericSign(node.whenTrue)
   if (trueSign === null || trueSign === 0) return null
   if (!isBoundedTernaryElse(node.whenFalse, leftRef.key, paramA, paramB)) return null

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -243,7 +243,7 @@ export { ErrorCodes, createError, formatError, generateCodeFrame } from './error
 
 // Expression Parser
 export { parseExpression, isSupported, exprToString, stringifyParsedExpr, identifierPath, parseBlockBody, containsHigherOrder } from './expression-parser'
-export type { ParsedExpr, ParsedStatement, SortComparator, SupportLevel, SupportResult, TemplatePart } from './expression-parser'
+export type { ParsedExpr, ParsedStatement, SortComparator, SortKey, SupportLevel, SupportResult, TemplatePart } from './expression-parser'
 export { buildLoopChainExpr } from './loop-chain'
 export type { LoopChainInputs } from './loop-chain'
 

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -717,22 +717,29 @@ error[BF021]: Expression cannot be compiled to marked template: Higher-order met
    = help: Add /* @client */ to evaluate this expression on the client only
 ```
 
-**Sort comparators**: Only simple `(a, b) => a.field - b.field` patterns are supported. Complex comparators (`.localeCompare()`, block body, multi-field) trigger BF021.
+**Sort comparators**: The comparator body is parsed into a structured `SortComparator` (a `keys: SortKey[]` list). A body is split on top-level `||` into one comparison key per operand (multi-key tie-breaks), and each operand (leaf) must match one of the accepted shapes below. Comparators outside the catalogue — function references (`sort(myCmp)`), multi-statement / local-var block bodies, and `localeCompare(b, locale, opts)` — trigger BF021.
 
 ```
-error[BF021]: Expression cannot be compiled to marked template: Sort comparator 'a.name.localeCompare(b.name)' is not a simple subtraction pattern (a.field - b.field)
+error[BF021]: Expression cannot be compiled to marked template: Sort comparator 'myCmp' is not a supported shape.
 
   --> src/components/List.tsx:9:30
    |
- 9 |             {items().sort((a, b) => a.name.localeCompare(b.name)).map(t => (
-   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 9 |             {items().sort(myCmp).map(t => (
+   |                           ^^^^^
    |
    = help: Add /* @client */ to evaluate this expression on the client only
 ```
 
+**Supported sort comparator leaves** (each `||`-chainable; reverse the operands or the ternary sign for descending):
+- `(a, b) => a.price - b.price` → `numeric` key (`a - b` for primitive arrays)
+- `(a, b) => a.name.localeCompare(b.name)` → `string` key (`a.localeCompare(b)` for primitives)
+- `(a, b) => a.rank > b.rank ? 1 : -1` → `auto` key (relational ternary; also the 3-way `a < b ? -1 : a > b ? 1 : 0` and leading-tie `a === b ? 0 : …` forms). `auto` compares numerically when both keys parse as numbers, else lexically — the two template adapters share this rule (diverges from JS `<`/`>` only for numeric strings).
+
 **Supported sort patterns**:
 - `sort((a, b) => a.price - b.price)` → ascending by `price`
 - `toSorted((a, b) => b.priority - a.priority)` → descending by `priority`
+- `sort((a, b) => a.price - b.price || a.name.localeCompare(b.name))` → multi-key: `price` asc, ties broken by `name`
+- `sort((a, b) => { return a.price - b.price })` → single-`return` block body (unwrapped to the returned comparator)
 - `filter(...).sort(...).map(...)` → filter + sort chaining
 - `sort(...).filter(...).map(...)` → sort + filter chaining
 


### PR DESCRIPTION
## Summary

Picks up three of the deferred `.sort()` / `.toSorted()` follow-ups from #1448 Tier B, lowering each to **both template-language adapters (Go + Mojo)** and the Hono / CSR JS path:

- **Multi-key (`||`-chain)** — `(a, b) => a.x - b.x || a.y.localeCompare(b.y)` splits on top-level `||` into one comparison key per operand, applied in priority order as tie-breaks.
- **Relational ternary** — `(a, b) => a.f > b.f ? 1 : -1`, the 3-way `a.f < b.f ? -1 : a.f > b.f ? 1 : 0`, and the leading-tie `a.f === b.f ? 0 : …` forms lower to a new `auto` compare type.
- **Single-`return` block bodies** — `(a, b) => { return a.f - b.f }` (the arrow form; the function-expression form already worked) unwraps to the returned comparator.

Function-reference comparators (`sort(myCmp)`), multi-statement / local-var block bodies, and `localeCompare(b, locale, opts)` stay refused with BF021 — the remaining Tier B follow-ups.

## Design

- `SortComparator` is now a structured `keys: SortKey[]` list (`{ key, type, direction }`); a simple comparator is a one-element list, a `||`-chain is multi-element. The parser reuses the existing leaf classifier for each `||` operand.
- **`auto` compare type** (relational ternary): compares numerically when **both** keys parse as numbers, else lexically. Both template runtimes apply the same rule (`looks_like_number` on Perl / parse-float on Go) so their output stays **byte-equal**. This diverges from JS `<`/`>` only for numeric *strings* (rare in SSR data) — documented in the helper + spec.
- Direction for ternary is derived from `(relational op, operand order, sign of the whenTrue branch)`, so all the asc/desc operand permutations and the 3-way forms fall out of one rule.

## Adapter emit / runtime

- **Go**: `bf_sort <recv> (<keyKind> <keyName> <compareType> <direction>)+` — variadic over 4-string key groups (single-key output is unchanged from before). New `auto` branch + `toFloat64WithOK`.
- **Mojo**: `bf->sort($recv, { keys => [ { … }, … ] })` — ordered `keys` list with the same `auto` rule.
- **Hono / CSR**: re-emits the raw `||` / ternary comparator into `.toSorted(...)` — real JS, no runtime change.

## Verification

All in-sandbox, both runtimes:

- **End-to-end render** of the two new fixtures through the real **Go (`go run`)** and **Perl (Mojolicious)** runtimes — both produce byte-identical HTML to `expectedHtml`, and the CSR JS path matches too.
- `go test ./...` (new multi-key + `auto` cases), Perl `prove -l t/` (new multi-key + `auto` subtests) — all green.
- `@barefootjs/jsx`, `@barefootjs/adapter-tests` (incl. CSR conformance), Go/Mojo adapter emit-pin suites — all green. The only failures in the wider suite are pre-existing and unrelated (TS-checker resolver env issue in `jsx`; SSR context-bridge in `hono`) — both reproduce with this branch's changes stashed.

## Test plan

- [x] `bun test` — `packages/jsx`, `packages/adapter-tests`, Go/Mojo adapter suites
- [x] `go test ./...` against the Go runtime
- [x] `prove -l t/` against the Mojo runtime (Mojolicious + Test2::Suite)
- [x] End-to-end `go run` + `perl` render of `array-sort-multikey` / `array-sort-ternary` fixtures

https://claude.ai/code/session_01Q7BAZ2eBpEDzQtcHew8mCR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7BAZ2eBpEDzQtcHew8mCR)_