### PR TITLE
test(e2e): duplicate-prefix slot identity on SSR-hydrated board cards (#1371)

### DIFF
--- a/site/ui/e2e/productivity-gallery.spec.ts
+++ b/site/ui/e2e/productivity-gallery.spec.ts
@@ -277,6 +277,53 @@ test.describe('Gallery: Productivity app', () => {
       await expect(doneCard.locator('.move-right')).toHaveCount(1)
     })
 
+    test('board: same-name sibling buttons on an SSR card each wire to their own slot (#1371)', async ({ page }) => {
+      // #1371 DoD — duplicate-prefix scenario at the HYDRATION boundary.
+      // Every task card carries THREE same-name <Button> children
+      // (delete-task, move-left, move-right) plus the column-level add
+      // button, so a card is a cluster of siblings sharing the `Button_`
+      // bf-s name prefix. Slot identity is the (bf-h, bf-m) pair, unique
+      // by construction (#1249): each button must hydrate to its OWN slot
+      // and keep its OWN onClick. If identity had collapsed back to the
+      // name-prefix selector, two of the three would share wiring and a
+      // click would fire the wrong handler.
+      //
+      // Distinct from the "arrow buttons survive moving a task" test
+      // above (which exercises the CSR fresh-insert path, #135): this one
+      // never re-inserts a card — it drives delete / ← / → on cards that
+      // were rendered by SSR and hydrated in place, proving each sibling
+      // resolved to a separate slot from the server-rendered shape alone.
+      await page.goto('/gallery/productivity/board')
+
+      const todoCol = page.locator('[data-col-id="todo"]')
+      const progressCol = page.locator('[data-col-id="progress"]')
+      const doneCol = page.locator('[data-col-id="done"]')
+
+      // → on an SSR card: task 4 (In Progress) moves right into Done.
+      // Proves move-right is wired to moveTask(..., 'right').
+      await expect(progressCol.locator('[data-task-id="4"]')).toHaveCount(1)
+      await progressCol.locator('[data-task-id="4"]').locator('.move-right').click()
+      await expect(doneCol.locator('[data-task-id="4"]')).toHaveCount(1)
+      await expect(progressCol.locator('[data-task-id="4"]')).toHaveCount(0)
+
+      // ← on a different SSR card: task 5 (In Progress) moves left into
+      // To Do. Proves move-left is a DISTINCT slot/handler from
+      // move-right — not the same element reached twice via name prefix.
+      await expect(progressCol.locator('[data-task-id="5"]')).toHaveCount(1)
+      await progressCol.locator('[data-task-id="5"]').locator('.move-left').click()
+      await expect(todoCol.locator('[data-task-id="5"]')).toHaveCount(1)
+      await expect(progressCol.locator('[data-task-id="5"]')).toHaveCount(0)
+
+      // delete (×) on an SSR card: task 3 (To Do) is removed, not moved.
+      // Proves delete-task is its own slot — a collapsed identity would
+      // have made × inherit a move handler (task would relocate, count
+      // unchanged) instead of deleting.
+      const totalBefore = await page.locator('[data-task-id]').count()
+      await todoCol.locator('[data-task-id="3"]').locator('.delete-task').click()
+      await expect(page.locator('[data-task-id="3"]')).toHaveCount(0)
+      await expect(page.locator('[data-task-id]')).toHaveCount(totalBefore - 1)
+    })
+
     test('reading a mail reduces the unread badge count', async ({ page }) => {
       await page.goto('/gallery/productivity/mail')
 


### PR DESCRIPTION
## What

Adds a Layer 6 (E2E) regression in `site/ui/e2e/productivity-gallery.spec.ts` for the duplicate-prefix slot scenario described in #1371.

## Context (investigation summary)

#1371 ("Runtime: slot identity unique by construction", child of #1244) asks that siblings sharing a slot-name prefix be disambiguated structurally rather than via the legacy `[bf-s^="~Foo_"]` name-prefix selector.

Investigating the current code, the **core of this issue is already resolved by #1249**:

- Slot identity is now the **`(bf-h, bf-m)` pair**, unique by construction at SSR emit time (`spec/compiler.md` "Slot identity"). The resolver's primary lookup is `[bf-h="<host>"][bf-m="<slot>"]` — `packages/client/src/runtime/slot-resolver.ts`.
- The `~` prefix and name-prefix fallback have been **removed** (`spec/compiler.md` "`~` child prefix (removed)").
- The **"claimed for another slot" workaround does not exist in the current code** — #1249 replaced it with the `(bf-h, bf-m)` scheme rather than keeping a filter, so DoD item 2 is already satisfied (nothing to remove).
- Hono and go-template adapters emit `bf-h`/`bf-m`.
- Unit coverage exists in `packages/client/__tests__/runtime/upsert-child-multi-same-name.test.ts`.

The remaining DoD gap was the **Layer 6 regression exercising the duplicate-prefix scenario**, cross-referenced to this issue.

## The test

Every task card on the productivity board carries three same-name `<Button>` children (`delete-task`, `move-left`, `move-right`) — a cluster of siblings sharing the `Button_` bf-s prefix.

- The existing *"arrow buttons survive moving a task"* test covers the **CSR fresh-insert** path (#135).
- This new test drives delete / ← / → on cards rendered by **SSR and hydrated in place**, asserting each sibling resolved to a **distinct slot** from the server-rendered shape alone. A collapsed identity would fire the wrong handler (e.g. × would move instead of delete).

## Verification

Ran locally against a production build of the site:

```
5 passed (board E2E, incl. the new #1371 test)
```

https://claude.ai/code/session_01HEv95QKrZmB567pq6h3mS7

---
_Generated by [Claude Code](https://claude.ai/code/session_01HEv95QKrZmB567pq6h3mS7)_