### PR TITLE
fix(compiler): migrate scanForIdentifiers to shared ts.createScanner lexer (#1370)

### DIFF
--- a/.changeset/regex-aware-token-scanner.md
+++ b/.changeset/regex-aware-token-scanner.md
@@ -1,0 +1,18 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Make `tokenContainsIdent` regex-literal aware (#1370).
+
+`scanForIdentifiers` (behind `tokenContainsIdent`) was the last hand-rolled
+char-by-char string-state machine outside the shared `ts.createScanner`
+lexer. It tracked quotes, template literals, and comments by hand but was
+blind to regex literals, so a lone quote inside a regex (`/it's/`) flipped it
+into string state and swallowed real identifier references, and an identifier
+inside a regex body (`/className/`) was wrongly counted as a reference.
+
+It now delegates to the shared `iterateJsTokens` lexer, which recognises
+regex literals, nested template literals, and comments in one place. Prop
+dependency detection on synthesised expression strings is now correct for
+expressions containing regex literals. No change to adapter output for
+existing fixtures.

--- a/packages/jsx/src/__tests__/token-contains-ident.test.ts
+++ b/packages/jsx/src/__tests__/token-contains-ident.test.ts
@@ -129,6 +129,33 @@ describe('tokenContainsIdent', () => {
     })
   })
 
+  // Regex literals were invisible to the previous hand-rolled char scanner:
+  // a lone quote inside the regex flipped it into string state (swallowing
+  // real references), and an identifier inside the regex body was counted as
+  // a reference. The shared ts.createScanner-based lexer recognises regex
+  // literals, so both cases are now correct (#1370).
+  describe('regex literals', () => {
+    test('reference after a regex literal containing an apostrophe', () => {
+      expect(tokenContainsIdent("/it's/.test(className)", 'className')).toBe(true)
+    })
+
+    test('reference after a regex literal containing a quote', () => {
+      expect(tokenContainsIdent('/a"b/.test(className)', 'className')).toBe(true)
+    })
+
+    test('identifier inside a regex body is not a reference', () => {
+      expect(tokenContainsIdent('/className/.test(x)', 'className')).toBe(false)
+    })
+
+    test('regex with escaped slash does not leak into following code', () => {
+      expect(tokenContainsIdent('/a\\/b/.test(className)', 'className')).toBe(true)
+    })
+
+    test('division is not mistaken for a regex literal', () => {
+      expect(tokenContainsIdent('total / className', 'className')).toBe(true)
+    })
+  })
+
   describe('non-matches', () => {
     test('substring is not a match (word boundary)', () => {
       expect(tokenContainsIdent('myClassName', 'className')).toBe(false)

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -7,7 +7,12 @@ import ts from 'typescript'
 import type { AttrValue, IRTemplatePart, LoopParamBinding, FreeReference, IRNode } from '../types'
 import type { TopLevelLoop, BranchLoop } from './types'
 import { buildLoopChainExpr } from '../loop-chain'
-import { replaceInExprContexts } from '../scanner/js-scanner'
+import {
+  iterateJsTokens,
+  isIdentifierLikeToken,
+  isTriviaKind,
+  replaceInExprContexts,
+} from '../scanner/js-scanner'
 import {
   BF_KEY as DATA_KEY,
   BF_KEY_PREFIX as DATA_KEY_PREFIX,
@@ -376,124 +381,33 @@ export function tokenContainsIdent(expr: string, ident: string): boolean {
   return scanForIdentifiers(expr, (token) => token === ident)
 }
 
-const IDENT_START_RE = /[A-Za-z_$]/
-const IDENT_PART_RE = /[A-Za-z0-9_$]/
-
 /**
- * Single-pass scanner over a JS-like expression string. Walks character by
- * character through a small state machine and invokes `predicate` on every
- * identifier-like token it finds in a position where bare identifiers are
- * semantically possible (i.e. not inside a string/comment, not the property
- * name in a member-access expression). Returns true on the first hit.
+ * Walk a JS-like expression string via the shared `ts.createScanner`-based
+ * lexer and invoke `predicate` on every identifier-like token found in a
+ * position where bare identifiers are semantically possible — i.e. not
+ * inside a string / template-string body / comment / regex literal, and
+ * not the property name of a member-access expression. Returns true on the
+ * first hit.
+ *
+ * Delegating to `iterateJsTokens` (rather than a hand-rolled char-by-char
+ * state machine) means regex literals are recognised: `/it's/.test(foo)`
+ * no longer reads the apostrophe as a string opener, and an identifier
+ * inside a regex body (`/className/`) is correctly treated as opaque (#1370).
  */
 function scanForIdentifiers(expr: string, predicate: (token: string) => boolean): boolean {
-  const n = expr.length
-  let i = 0
-  // 0 = code, 1 = single-quote string, 2 = double-quote string,
-  // 3 = template literal text, 4 = template literal expression,
-  // 5 = line comment, 6 = block comment.
-  type State = 0 | 1 | 2 | 3 | 4 | 5 | 6
-  let state: State = 0
-  // For nested template expressions: stack of brace depths at each `${` push.
-  const tmplExprStack: number[] = []
-  // Brace depth tracked only inside template-expression state to detect when
-  // we close back to the surrounding template-literal text.
-  let braceDepth = 0
-
-  while (i < n) {
-    const ch = expr[i]
-
-    switch (state) {
-      case 0: // code
-      case 4: { // template expression — same lexing rules as code
-        // String / template literal openers
-        if (ch === "'") { state = 1; i++; continue }
-        if (ch === '"') { state = 2; i++; continue }
-        if (ch === '`') { state = 3; i++; continue }
-        // Comment openers
-        if (ch === '/' && i + 1 < n) {
-          const next = expr[i + 1]
-          if (next === '/') { state = 5; i += 2; continue }
-          if (next === '*') { state = 6; i += 2; continue }
-        }
-        // Track braces only inside template-expression state, so we know when
-        // we leave `${ ... }` back to the surrounding template text.
-        if (state === 4) {
-          if (ch === '{') { braceDepth++; i++; continue }
-          if (ch === '}') {
-            if (braceDepth === 0) {
-              // Closing `}` of `${ ... }` — pop back to enclosing tmpl state.
-              const restored = tmplExprStack.pop()
-              braceDepth = restored ?? 0
-              state = 3
-              i++
-              continue
-            }
-            braceDepth--
-            i++
-            continue
-          }
-        }
-        // Identifier start
-        if (IDENT_START_RE.test(ch)) {
-          let j = i + 1
-          while (j < n && IDENT_PART_RE.test(expr[j])) j++
-          const token = expr.slice(i, j)
-          // Skip member-access tail: identifier preceded by `.` (ignoring
-          // whitespace).
-          let prev = i - 1
-          while (prev >= 0 && (expr[prev] === ' ' || expr[prev] === '\t' || expr[prev] === '\n' || expr[prev] === '\r')) prev--
-          const isMemberTail = prev >= 0 && expr[prev] === '.' && (prev === 0 || expr[prev - 1] !== '.') // not `..` (spread)
-          if (!isMemberTail && predicate(token)) return true
-          i = j
-          continue
-        }
-        i++
-        continue
-      }
-      case 1: { // single-quote string
-        if (ch === '\\' && i + 1 < n) { i += 2; continue }
-        if (ch === "'") { state = 0; i++; continue }
-        i++
-        continue
-      }
-      case 2: { // double-quote string
-        if (ch === '\\' && i + 1 < n) { i += 2; continue }
-        if (ch === '"') { state = 0; i++; continue }
-        i++
-        continue
-      }
-      case 3: { // template literal text
-        if (ch === '\\' && i + 1 < n) { i += 2; continue }
-        if (ch === '`') {
-          // Closing the template literal; return to whatever code state we
-          // came from (either top-level code or an outer template expression).
-          state = tmplExprStack.length > 0 ? 4 : 0
-          i++
-          continue
-        }
-        if (ch === '$' && i + 1 < n && expr[i + 1] === '{') {
-          // Entering `${ ... }`: save current outer brace depth, reset for new.
-          tmplExprStack.push(braceDepth)
-          braceDepth = 0
-          state = 4
-          i += 2
-          continue
-        }
-        i++
-        continue
-      }
-      case 5: { // line comment
-        if (ch === '\n' || ch === '\r') { state = 0; i++; continue }
-        i++
-        continue
-      }
-      case 6: { // block comment
-        if (ch === '*' && i + 1 < n && expr[i + 1] === '/') { state = 0; i += 2; continue }
-        i++
-        continue
-      }
+  // Previous *significant* (non-trivia) token kind, used to skip the tail
+  // of a member access (`a.foo`, `a?.foo`) while still treating the head
+  // (`foo.bar`) and spread targets (`...foo`) as real references.
+  let prevSignificant: ts.SyntaxKind | undefined
+  for (const tok of iterateJsTokens(expr)) {
+    if (isTriviaKind(tok.kind)) continue
+    if (isIdentifierLikeToken(tok.kind)) {
+      const isMemberTail =
+        prevSignificant === ts.SyntaxKind.DotToken
+        || prevSignificant === ts.SyntaxKind.QuestionDotToken
+      if (!isMemberTail && predicate(expr.slice(tok.pos, tok.end))) return true
     }
+    prevSignificant = tok.kind
   }
   return false
 }

--- a/packages/jsx/src/scanner/js-scanner.ts
+++ b/packages/jsx/src/scanner/js-scanner.ts
@@ -110,7 +110,7 @@ export function* iterateJsTokens(
   }
 }
 
-function isTriviaKind(kind: ts.SyntaxKind): boolean {
+export function isTriviaKind(kind: ts.SyntaxKind): boolean {
   return (
     kind === ts.SyntaxKind.WhitespaceTrivia
     || kind === ts.SyntaxKind.NewLineTrivia
@@ -163,6 +163,21 @@ function canRegexStartHere(prev: ts.SyntaxKind | undefined): boolean {
 
 // ---------------------------------------------------------------------------
 // Token classification helpers used by the consumers below.
+
+/**
+ * Whether `kind` is an identifier-like token — a plain identifier or any
+ * reserved/contextual keyword. Keywords lex to their own token kinds but
+ * still match the `[A-Za-z_$][\w$]*` shape the previous hand-rolled
+ * scanners treated as candidate identifier tokens, so consumers that want
+ * "every bare word in code context" (e.g. `tokenContainsIdent`) include
+ * them and compare the slice text themselves.
+ */
+export function isIdentifierLikeToken(kind: ts.SyntaxKind): boolean {
+  return (
+    kind === ts.SyntaxKind.Identifier
+    || (kind >= ts.SyntaxKind.FirstKeyword && kind <= ts.SyntaxKind.LastKeyword)
+  )
+}
 
 /** A token whose textual content is a non-code region (string body, regex, comment). */
 function isOpaqueContentKind(kind: ts.SyntaxKind): boolean {


### PR DESCRIPTION
## What

Closes the remaining hand-rolled JS source scanner that #1254 left behind, addressing #1370.

`tokenContainsIdent` → `scanForIdentifiers` in `packages/jsx/src/ir-to-client-js/utils.ts` was the last char-by-char string-state machine outside the shared `ts.createScanner` primitive. It tracked quotes / template literals / comments by hand but was **blind to regex literals**, producing two confirmed defects:

| Input | Expected | Before this PR |
|-------|----------|----------------|
| `tokenContainsIdent("/it's/.test(className)", "className")` | `true` | **`false`** — the lone `'` inside the regex flipped the scanner into string state and swallowed `.test(className)` |
| `tokenContainsIdent("/className/.test(x)", "className")` | `false` | **`true`** — the identifier inside the regex body was counted as a reference |

This is the same class of defect #1254 fixed for comments, now closed for regex literals — and the file's own header comment already claimed this scanner had been migrated.

## How

- `scanForIdentifiers` now consumes the shared `iterateJsTokens` lexer (`packages/jsx/src/scanner/js-scanner.ts`), which recognises regex literals, nested template literals and comments in one place. The hand-rolled 100-line state machine and its `IDENT_*` regexes are gone (net −44 lines).
- Member-access tails (`a.foo`, `a?.foo`) are still skipped via the previous-significant-token kind; heads (`foo.bar`) and spread targets (`...foo`) remain references.
- Exported `isTriviaKind` and added `isIdentifierLikeToken` (Identifier + keyword range) from the scanner so consumers stay free of lexer internals.

## Tests

- 5 new regression cases in `token-contains-ident.test.ts`: regex with embedded apostrophe / quote, identifier inside a regex body, escaped slash, and `a / b` division (not mistaken for a regex). All 33 token tests pass.
- Full `packages/jsx` suite: 1774 pass; the only 4 failures are pre-existing on `main` (unrelated checker-path alias-resolution tests — verified by stashing this change).
- Adapter conformance: 519 pass, 0 fail — no observable change in adapter output.
- `bun run build:types` clean.

## Scope / follow-ups

This PR migrates the one scanner with a confirmed live defect. Per #1370's DoD ("no remaining char-by-char string-state machine"), a couple of other hand-rolled walkers still exist and could be follow-ups:
- `splitTemplateInterpolations` (brace-depth counter) in `ir-to-client-js/html-template.ts`
- the paren counters in `adapter-hono/src/build.ts` (operate on whole source files at bundle time)

Neither has a reproduced defect today; happy to fold them in here or track separately — let me know.

Refs #1370

https://claude.ai/code/session_01V97CNmMHhrfrPox3jnJG6Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01V97CNmMHhrfrPox3jnJG6Y)_