### PR TITLE
fix(jsx): emit unique __compEl bindings for multiple inner-loop components

### DIFF
--- a/.changeset/nested-map-compel-collision.md
+++ b/.changeset/nested-map-compel-collision.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix duplicate `__compEl` declaration when a nested `.map()` returns multiple child components (#1664).
+
+An outer `.map()` whose callback returns a wrapping element containing a nested `.map()` that emits more than one child component compiled all of them into a single shared inner `forEach` body. The emitter declared `const __compEl` once per component in that scope, producing a duplicate `const` declaration that threw `SyntaxError: Identifier '__compEl' has already been declared` at hydration. Each binding is now uniquely suffixed (`__compEl0`, `__compEl1`, …) when multiple components share the inner-loop scope; the single-component case keeps the plain `__compEl` name.

--- a/packages/jsx/src/__tests__/child-components-in-map.test.ts
+++ b/packages/jsx/src/__tests__/child-components-in-map.test.ts
@@ -729,4 +729,80 @@ describe('child components inside .map() (#344)', () => {
     expect(content).toContain('children[__idx]')
     expect(content).not.toContain('children[__idx + ')
   })
+
+  test('nested .map() with multiple inner components emits unique __compEl bindings (#1664)', () => {
+    const source = `
+      'use client'
+
+      export function Picker() {
+        const GROUPS = [
+          { id: 'a', items: [{ id: 'x', label: 'X' }] },
+        ]
+        return (
+          <div>
+            {GROUPS.map(group => (
+              <div key={group.id}>
+                {group.items.map(it => (
+                  <div key={it.id}>
+                    <SelectItem value={it.id}>{it.label}</SelectItem>
+                    <SelectIcon name={it.id} />
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        )
+      }
+    `
+    const result = compileJSX(source, 'Picker.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const content = clientJs!.content
+
+    // Both inner-loop components must be initialised.
+    expect(content).toContain("initChild('SelectItem'")
+    expect(content).toContain("initChild('SelectIcon'")
+
+    // No re-declaration of `__compEl` in the shared inner-forEach scope:
+    // each comp must use a uniquely-suffixed binding.
+    expect(content).toContain('__compEl0')
+    expect(content).toContain('__compEl1')
+
+    // The bug threw "Identifier '__compEl' has already been declared" — the
+    // unsuffixed binding must not appear when multiple comps share a scope.
+    expect(content).not.toContain('const __compEl =')
+  })
+
+  test('nested .map() with a single inner component keeps the plain __compEl binding (#1664)', () => {
+    const source = `
+      'use client'
+
+      export function Picker() {
+        const GROUPS = [
+          { id: 'a', items: [{ id: 'x', label: 'X' }] },
+        ]
+        return (
+          <div>
+            {GROUPS.map(group => (
+              <div key={group.id}>
+                {group.items.map(it => (
+                  <SelectItem key={it.id} value={it.id}>{it.label}</SelectItem>
+                ))}
+              </div>
+            ))}
+          </div>
+        )
+      }
+    `
+    const result = compileJSX(source, 'Picker.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const content = result.files.find(f => f.type === 'clientJs')!.content
+    expect(content).toContain("initChild('SelectItem'")
+    // Single comp keeps the unsuffixed name.
+    expect(content).toContain('const __compEl =')
+    expect(content).not.toContain('__compEl0')
+  })
 })

--- a/packages/jsx/src/ir-to-client-js/stringify/static-array-child-init.ts
+++ b/packages/jsx/src/ir-to-client-js/stringify/static-array-child-init.ts
@@ -161,10 +161,14 @@ function emitInnerLoopNested(lines: string[], plan: InnerLoopNestedInitPlan): vo
   for (const stmt of innerPreludeStatements) {
     lines.push(`        ${stmt}`)
   }
-  for (const comp of comps) {
-    lines.push(`        const __compEl = qsaChildScope(__innerEl, ${comp.selector})`)
-    lines.push(`        if (__compEl) initChild('${nameForRegistryRef(comp.componentName)}', __compEl, ${comp.propsExpr})`)
-  }
+  // Each inner-loop component gets a uniquely-suffixed `__compEl` binding.
+  // Multiple comps share one inner `forEach` body, so a fixed name would
+  // re-declare `const __compEl` in the same scope (#1664).
+  comps.forEach((comp, i) => {
+    const compElVar = comps.length > 1 ? `__compEl${i}` : '__compEl'
+    lines.push(`        const ${compElVar} = qsaChildScope(__innerEl, ${comp.selector})`)
+    lines.push(`        if (${compElVar}) initChild('${nameForRegistryRef(comp.componentName)}', ${compElVar}, ${comp.propsExpr})`)
+  })
   lines.push(`      })`)
   lines.push(`    })`)
   lines.push(`  }`)


### PR DESCRIPTION
## Summary

Fixes #1664.

A nested `.map()` whose inner callback returns **multiple child components** compiles all of them into a single shared inner `forEach` body. The emitter (`emitInnerLoopNested` in `static-array-child-init.ts`) declared `const __compEl` once per component in that shared scope, producing duplicate `const` declarations:

```js
group.items.forEach((it, __innerIdx) => {
  const __innerEl = __ic.children[__innerIdx]
  if (!__innerEl) return
  const __compEl = qsaChildScope(__innerEl, ...)   // 1st
  if (__compEl) initChild('SelectItem', __compEl, ...)
  const __compEl = qsaChildScope(__innerEl, ...)   // 2nd — re-declares!
  if (__compEl) initChild('SelectIcon', __compEl, ...)
})
```

This threw `SyntaxError: Identifier '__compEl' has already been declared` at hydration.

## Fix

Suffix each binding (`__compEl0`, `__compEl1`, …) when more than one component is emitted in the same inner-loop scope; keep the plain `__compEl` name for the single-component case so existing output is unchanged.

## Tests

Added two regression tests in `packages/jsx/src/__tests__/child-components-in-map.test.ts`:
- multiple inner components → unique `__compEl0` / `__compEl1` bindings, no unsuffixed `const __compEl =`
- single inner component → plain `__compEl` binding preserved

Full `@barefootjs/jsx` test suite passes (the only failures — `primitive-resolver-*` — are pre-existing and unrelated, confirmed against the base branch).

https://claude.ai/code/session_019krzCumpVjkXmsHDZwMYYw

---
_Generated by [Claude Code](https://claude.ai/code/session_019krzCumpVjkXmsHDZwMYYw)_