### PR TITLE
fix: clear stale conditional slot node and type-safe no-arg props default (#1663 follow-up)

### DIFF
--- a/.changeset/bftext-conditional-slot-and-typed-noarg-default.md
+++ b/.changeset/bftext-conditional-slot-and-typed-noarg-default.md
@@ -1,0 +1,11 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/client": patch
+"@barefootjs/hono": patch
+---
+
+Fix two follow-up issues from the #1663 dynamic-dispatch work.
+
+`__bfText` could render both a stale element and fresh text in a conditional slot: that path re-resolves the anchor via `$t()` each run, which inserts a new text node before an element left by a previous Node-valued run. Writing a primitive now clears any remaining siblings up to the end marker, so switching JSX → text leaves only the text.
+
+The no-arg props default (`= {}`) is now asserted to the param's annotated type (`= {} as T`) in both the test and Hono adapters. `hasRequiredProps` treats a prop with a destructuring default as non-required, but the declared props type may still mark that field required, so a bare `= {}` failed `tsc` ("Property 'x' is missing in type '{}'..."). The destructuring defaults still supply the values at runtime.

--- a/packages/adapter-hono/src/adapter/hono-adapter.ts
+++ b/packages/adapter-hono/src/adapter/hono-adapter.ts
@@ -514,15 +514,18 @@ export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderC
     // props, so a bare no-arg call (`Foo()`) doesn't crash on destructuring
     // `undefined`. This makes a JSX-returning arrow hoisted from an
     // object-literal value (e.g. `THEME_LOGOS[id]()`) renderable at SSR
-    // (#1663). Only safe when no required prop exists — otherwise `{}` would
-    // not satisfy the props type. The SolidJS-style (`propsObjectName`)
-    // branch only opts in when there's no declared props type, since a
-    // declared type may carry required fields that `{}` wouldn't satisfy.
+    // (#1663). `hasRequiredProps` ignores props that carry a destructuring
+    // default, but the declared props type may still mark that field
+    // required — so a bare `= {}` would fail `tsc`. Assert the default to the
+    // param's own annotated type (`{} as T`); the destructuring defaults
+    // supply the values at runtime. The SolidJS-style (`propsObjectName`)
+    // branch opts in whenever the annotation is satisfiable by `{} as T`.
     const hasRequiredProps = ir.metadata.propsParams.some(
       (p: ParamInfo) => !p.optional && p.defaultValue === undefined && !p.isRest,
     )
-    const noArgDefault =
-      (propsObjectName ? !propsTypeName : !hasRequiredProps) ? ' = {}' : ''
+    const wantsNoArgDefault = propsObjectName ? !propsTypeName : !hasRequiredProps
+    const propsTypeExpr = typeAnnotation.replace(/^:\s*/, '')
+    const noArgDefault = wantsNoArgDefault ? ` = {} as ${propsTypeExpr}` : ''
 
     const lines: string[] = []
     // Module-export keyword belongs to the adapter: it knows the target language

--- a/packages/client/__tests__/runtime/dynamic-text.test.ts
+++ b/packages/client/__tests__/runtime/dynamic-text.test.ts
@@ -90,6 +90,28 @@ describe('__bfText', () => {
     expect(host.querySelector('span')).toBeNull()
   })
 
+  test('clears a stale Node when a re-resolved text anchor is written (conditional slot)', () => {
+    // Reproduces the conditional-slot path: a previous run spliced a live
+    // element into the slot; the next run re-resolves the anchor via $t(),
+    // which inserts a fresh text node *before* that stale element. Writing a
+    // primitive through that new anchor must remove the leftover element so
+    // the slot doesn't render both.
+    const el = document.createElement('span')
+    el.textContent = 'node'
+    const start = host.firstChild! // <!--bf:s0-->
+    start.parentNode!.insertBefore(el, start.nextSibling)
+    // Simulate $t() handing back a brand-new text node placed before `el`.
+    const reResolved = document.createTextNode('')
+    start.parentNode!.insertBefore(reResolved, start.nextSibling)
+
+    const result = __bfText(reResolved, 'plain')
+
+    expect(result).toBe(reResolved)
+    expect(host.contains(el)).toBe(false)
+    expect(host.querySelector('span')).toBeNull()
+    expect(host.textContent).toBe('plain')
+  })
+
   test('preserves server-rendered DOM for __isSlot markers', () => {
     const slotMarker = { __isSlot: true } as unknown
     anchor.nodeValue = 'ssr'

--- a/packages/client/src/runtime/dynamic-text.ts
+++ b/packages/client/src/runtime/dynamic-text.ts
@@ -20,17 +20,27 @@
 const END_MARKER = '/'
 
 /** Remove every sibling between `start` (the `<!--bf:sX-->` comment) and the
- *  matching `<!--/-->` end comment, leaving both markers in place. */
-function clearSlotRegion(start: Node): void {
+ *  matching `<!--/-->` end comment, leaving both markers in place. When `keep`
+ *  is supplied that node is left in place (used when writing a primitive
+ *  through a text anchor that must survive while stale siblings are cleared). */
+function clearSlotRegion(start: Node, keep?: Node): void {
   let n = start.nextSibling
   while (
     n &&
     !(n.nodeType === Node.COMMENT_NODE && (n as Comment).nodeValue === END_MARKER)
   ) {
     const next = n.nextSibling
-    n.parentNode?.removeChild(n)
+    if (n !== keep) n.parentNode?.removeChild(n)
     n = next
   }
+}
+
+/** Walk back from `node` to the nearest preceding comment marker (the slot's
+ *  `<!--bf:sX-->` start), skipping any stale element siblings in between. */
+function slotStart(node: Node): Node | null {
+  let n = node.previousSibling
+  while (n && n.nodeType !== Node.COMMENT_NODE) n = n.previousSibling
+  return n
 }
 
 export function __bfText(current: Node | null, value: unknown): Node | null {
@@ -54,6 +64,13 @@ export function __bfText(current: Node | null, value: unknown): Node | null {
   const text = String(value ?? '')
   if (current.nodeType === Node.TEXT_NODE) {
     current.nodeValue = text
+    // The conditional-slot path re-resolves the anchor via `$t()` on every
+    // run, which can hand back a freshly created text node sitting *before* a
+    // stale element left by a previous Node-valued run. Clear any remaining
+    // siblings up to the end marker so switching JSX → text doesn't render
+    // both the old element and the new text.
+    const start = slotStart(current)
+    if (start && start.nodeType === Node.COMMENT_NODE) clearSlotRegion(start, current)
     return current
   }
 

--- a/packages/jsx/src/__tests__/adapter-output.test.ts
+++ b/packages/jsx/src/__tests__/adapter-output.test.ts
@@ -653,4 +653,53 @@ describe('Adapter output', () => {
       expect(template.content).not.toMatch(/\b0\s+as\s+number\b/)
     })
   })
+
+  // The no-arg props default (`= {}`) makes a JSX-returning arrow hoisted from
+  // an object-literal value renderable at SSR (#1663). `hasRequiredProps`
+  // treats a prop with a destructuring default as non-required, but the
+  // declared props type may still mark that field required — so a bare `= {}`
+  // would fail `tsc` ("Property 'x' is missing in type '{}'..."). The default
+  // must be asserted to the param's annotated type (`{} as T`).
+  describe('no-arg props default is type-safe for typed required props (#1663 follow-up)', () => {
+    const cases = [
+      ['TestAdapter', () => new TestAdapter()],
+      ['HonoAdapter', () => new HonoAdapter()],
+    ] as const
+
+    for (const [label, make] of cases) {
+      test(`typed required prop with a default emits \`= {} as T\` (${label})`, () => {
+        // `label` is required in the type but carries a destructuring default,
+        // the exact shape that made a bare `= {}` fail tsc.
+        const source = `
+          export function Badge({ label = 'x' }: { label: string }) {
+            return <span>{label}</span>
+          }
+        `
+        const result = compileJSX(source, 'Badge.tsx', { adapter: make() })
+        expect(result.errors).toHaveLength(0)
+
+        const template = result.files.find(f => f.type === 'markedTemplate')!
+        const sig = template.content.split('\n').find(l => l.includes('function Badge'))!
+        // Asserted to the generated props type, never a bare `= {}`.
+        expect(sig).toContain('= {} as BadgePropsWithHydration')
+        expect(sig).not.toMatch(/=\s*\{\}\s*\)/)
+      })
+    }
+
+    test('untyped props still default to a bare `= {} as <hydration type>` (TestAdapter)', () => {
+      const source = `
+        export function Plain() {
+          return <span>hi</span>
+        }
+      `
+      const result = compileJSX(source, 'Plain.tsx', { adapter: new TestAdapter() })
+      expect(result.errors).toHaveLength(0)
+
+      const template = result.files.find(f => f.type === 'markedTemplate')!
+      const sig = template.content.split('\n').find(l => l.includes('function Plain'))!
+      // No declared props type → default asserted to the hydration-only type.
+      expect(sig).toContain('= {} as {')
+      expect(sig).toContain('__instanceId')
+    })
+  })
 })

--- a/packages/jsx/src/adapters/test-adapter.ts
+++ b/packages/jsx/src/adapters/test-adapter.ts
@@ -142,12 +142,16 @@ export class TestAdapter extends JsxAdapter {
     // props, so a bare no-arg call (`Foo()`) doesn't crash on destructuring
     // `undefined`. This is what makes a JSX-returning arrow hoisted from an
     // object-literal value (e.g. `THEME_LOGOS[id]()`) renderable at SSR
-    // (#1663). Only safe when no required prop exists — otherwise `{}` would
-    // not satisfy the props type.
+    // (#1663). `hasRequiredProps` ignores props that carry a destructuring
+    // default, but the declared props type may still mark that field
+    // required — so a bare `= {}` would fail `tsc` ("Property 'x' is missing
+    // in type '{}'..."). Assert the default to the param's own annotated type
+    // (`{} as T`); the destructuring defaults supply the values at runtime.
     const hasRequiredProps = ir.metadata.propsParams.some(
       (p: ParamInfo) => !p.optional && p.defaultValue === undefined && !p.isRest,
     )
-    const noArgDefault = hasRequiredProps ? '' : ' = {}'
+    const propsTypeExpr = typeAnnotation.replace(/^:\s*/, '')
+    const noArgDefault = hasRequiredProps ? '' : ` = {} as ${propsTypeExpr}`
 
     const lines: string[] = []
     // Module-export keyword belongs to the adapter: it knows the target language


### PR DESCRIPTION
## Summary

Addresses the three Copilot review comments on #1663 (PR #1669, now merged). All three concerned the `#1663` code, not the calendar test fix that was the original scope of #1669 — so they're handled here in a dedicated PR.

### 1. `__bfText` conditional-slot double-render (`dynamic-text.ts`)
The conditional-slot path re-resolves the text anchor via `$t()` on every run. `textNodeAfterComment` creates a fresh text node *before* any element left by a previous `Node`-valued run, and the primitive write only updated that new text node — leaving the stale element in the slot, so switching JSX → text rendered **both**.

Writing a primitive through a text anchor now clears any remaining siblings up to the `<!--/-->` end marker (keeping the live anchor). `clearSlotRegion` gained an optional `keep` parameter and a `slotStart` helper walks back past stale element siblings to the slot's start comment.

### 2 & 3. Type-unsafe `= {}` props default (`test-adapter.ts`, `hono-adapter.ts`)
The no-arg props default (`= {}`, added in #1663 so a bare shim call like `LOGOS[id]()` doesn't crash destructuring `undefined`) is computed from `hasRequiredProps`, which treats a prop carrying a **destructuring default** as non-required. But the declared props type may still mark that field required, so a bare `= {}` failed `tsc`:

```ts
function Badge({ label = 'x' }: { label: string } = {}) // TS2741: 'label' missing in '{}'
```

The default is now asserted to the param's own annotated type — `= {} as BadgePropsWithHydration` — in both adapters. The destructuring defaults still supply the runtime values.

## Tests
- `dynamic-text.test.ts` — new regression reproducing the conditional-slot scenario (re-resolved anchor placed before a stale element; primitive write must remove the leftover).
- `adapter-output.test.ts` — new block asserting `= {} as T` for a typed required-with-default prop in both adapters, plus the untyped-props path.

## Verification
- `@barefootjs/client` — 300 pass.
- `@barefootjs/jsx` — full suite green (1792 pass); `adapter-output` 31 pass.
- `@barefootjs/adapter-tests` — 529 pass.
- `tsc --noEmit` clean for `jsx`, `client`, and `adapter-hono`.
- Confirmed by hand that the pre-fix `= {}` shape fails `tsc` (TS2741) and the `= {} as T` shape compiles.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017obn5d6CAwZRz2moWit7zG)_