### PR TITLE
fix(jsx): wire per-item attr reading an outer signal by index (#1673)

### DIFF
--- a/.changeset/loop-outer-signal-attr-1673.md
+++ b/.changeset/loop-outer-signal-attr-1673.md
@@ -1,0 +1,9 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Per-item attribute reading an outer signal by index now becomes reactive inside `.map()` (#1673).
+
+A per-item attribute/style expression inside a keyed `.map()` only got a `createEffect` when it read the loop item accessor (`it.w`) or a directly-named signal/memo/prop. If it instead read the source array signal through a helper indexed by position — e.g. `style={`width:${widthAt(i)}%`}` where `const widthAt = (i) => items()[i].w` — the compiler emitted no reactive effect and the value froze at its server-rendered value after hydration. The identical binding on a top-level element updated correctly.
+
+`collectLoopChildReactiveAttrs` now applies the same Solid-style wrap-by-default AST-flag fallback (`callsReactiveGetters` / `hasFunctionCalls`) that the top-level attribute path (`decideWrapForAttr`, #940) already used. An opaque function call inside a per-item attribute is wrapped in a per-item `createEffect`, so it tracks whatever signals it reads at runtime and reflects current state after hydration — matching the equivalent top-level binding. The emitted effect resolves the loop index reference to the renderItem index variable, so the closure stays valid.

--- a/packages/jsx/src/__tests__/reactive-attrs-in-map.test.ts
+++ b/packages/jsx/src/__tests__/reactive-attrs-in-map.test.ts
@@ -236,6 +236,46 @@ describe('reactive attributes inside .map() callbacks', () => {
     expect(forEachMatches.length).toBe(1)
   })
 
+  test('per-item attr reading an outer signal via helper+index gets a createEffect (#1673)', () => {
+    // A per-item attribute whose value reads the source array signal through
+    // a helper indexed by position (`widthAt(i)` → `items()[i].w`) used to
+    // emit NO reactive effect — the value was baked into the item template
+    // once and froze at its SSR value. The identical binding on a top-level
+    // element works, because the top-level path wraps opaque function calls
+    // via the Solid-style AST-flag fallback (#940). This test pins that the
+    // loop-child path now applies the same fallback.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function ReproLoopAttr() {
+        const [items, setItems] = createSignal([{ id: 'a', w: 20 }, { id: 'b', w: 50 }])
+        const widthAt = (i) => items()[i].w
+        return (
+          <ul>
+            {items().map((it, i) => (
+              <li key={it.id} data-b style={\`width:\${widthAt(i)}%\`}>{it.id}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const result = compileJSX(source, 'ReproLoopAttr.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')!.content
+    // The per-item style binding must be wired through a createEffect that
+    // re-reads the helper and writes the style attribute, so it tracks the
+    // `items()` signal and updates after hydration.
+    expect(clientJs).toContain('createEffect')
+    expect(clientJs).toContain("setAttribute('style'")
+    // The helper call must survive into the emitted effect (not be baked into
+    // the static template), so the binding re-evaluates on signal change. The
+    // index reference resolves to the loop's renderItem index param, which is
+    // in scope inside the factory.
+    expect(clientJs).toContain('widthAt(')
+  })
+
   test('keyed loop: `key` prop is not emitted as a reactive DOM attribute', () => {
     // Regression guard for the "key duplicate emission" bug:
     // `<li key={item.id}>` used to be both rendered as `data-key=` in the

--- a/packages/jsx/src/__tests__/reactive-attrs-in-map.test.ts
+++ b/packages/jsx/src/__tests__/reactive-attrs-in-map.test.ts
@@ -266,14 +266,15 @@ describe('reactive attributes inside .map() callbacks', () => {
     const clientJs = result.files.find(f => f.type === 'clientJs')!.content
     // The per-item style binding must be wired through a createEffect that
     // re-reads the helper and writes the style attribute, so it tracks the
-    // `items()` signal and updates after hydration.
-    expect(clientJs).toContain('createEffect')
-    expect(clientJs).toContain("setAttribute('style'")
-    // The helper call must survive into the emitted effect (not be baked into
-    // the static template), so the binding re-evaluates on signal change. The
-    // index reference resolves to the loop's renderItem index param, which is
-    // in scope inside the factory.
-    expect(clientJs).toContain('widthAt(')
+    // `items()` signal and updates after hydration. Pin the helper call
+    // *inside* the createEffect alongside the style write — `widthAt(` also
+    // appears in the static template clone, so asserting it independently
+    // could pass even if the effect was missing (the exact regression here).
+    // The index resolves to the loop's renderItem index param, in scope
+    // inside the factory.
+    expect(clientJs).toMatch(
+      /createEffect\(\(\)\s*=>\s*\{[\s\S]*?widthAt\([\s\S]*?setAttribute\('style'/,
+    )
   })
 
   test('keyed loop: `key` prop is not emitted as a reactive DOM attribute', () => {

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -574,7 +574,23 @@ export function collectLoopChildReactiveAttrs(
         // SSR template strips the attribute (html-template) and no
         // hydrate-time binding is emitted, leaving the per-item
         // attribute permanently unset.
-        if (!attr.clientOnly && classifyReactivity(expanded.expr, ctx, loopParam, loopParamBindings, expanded.freeIds).kind === 'none') continue
+        //
+        // `classifyReactivity` only proves reactivity for the loop item
+        // accessor or a *directly* read signal/memo/prop. It does NOT see
+        // through an opaque helper that reads an outer signal by index
+        // (e.g. `widthAt(i)` where `const widthAt = (i) => items()[i].w`).
+        // The top-level attribute path (`decideWrapForAttr`) wraps those
+        // anyway via the Solid-style AST-flag fallback (#940); without the
+        // same fallback here, the identical binding on a per-item element
+        // freezes at its SSR value (#1673). Apply the same `callsReactiveGetters`
+        // / `hasFunctionCalls` fallback so the loop-child path matches the
+        // top-level one — a harmless over-wrap at worst (an effect that
+        // subscribes to nothing runs once).
+        const reactive =
+          classifyReactivity(expanded.expr, ctx, loopParam, loopParamBindings, expanded.freeIds).kind !== 'none'
+          || attr.callsReactiveGetters
+          || attr.hasFunctionCalls
+        if (!attr.clientOnly && !reactive) continue
         attrs.push({
           childSlotId: el.slotId,
           attrName: attr.name,


### PR DESCRIPTION
## Summary

Fixes #1673. A per-item attribute/style expression inside a keyed `.map()` only became reactive when it read the **loop item accessor** (`it.w`) or a **directly-named** signal/memo/prop. If it instead read the source array signal through a **helper indexed by position** — e.g. `style={`width:${widthAt(i)}%`}` where `const widthAt = (i) => items()[i].w` — the compiler emitted **no per-item `createEffect`**, so the value was baked into the item template once and **froze at its SSR value** after hydration. The identical binding on a top-level element updated correctly.

### Root cause

The top-level reactive-attribute path (`decideWrapForAttr`, #940) wraps an attribute in `createEffect` not only when it can prove reactivity, but also via a **Solid-style wrap-by-default fallback** on AST flags (`callsReactiveGetters` / `hasFunctionCalls`) — so an opaque function call like `widthAt(i)` gets an effect that subscribes to whatever it reads at runtime.

The loop-child path (`collectLoopChildReactiveAttrs` → `classifyReactivity`) only checked the loop item accessor + `needsEffectWrapper` (a regex for *directly* read signal getters). It had **no AST-flag fallback**, so an opaque helper call reading an outer signal was dropped entirely — the asymmetry the issue reports.

### Fix

`collectLoopChildReactiveAttrs` now applies the same `callsReactiveGetters` / `hasFunctionCalls` fallback as the top-level path. An opaque function call inside a per-item attribute is collected and wrapped in a per-item `createEffect`, so it tracks whatever signals it reads at runtime and reflects current state after hydration — matching the equivalent top-level binding. The existing emit path (`stringifyReactiveEffects`) already keeps the helper call (`widthAt(i)`) inside the renderItem factory, where the index param is in scope, so the effect closure stays valid. A harmless over-wrap at worst (an effect that subscribes to nothing runs once).

One file changes behaviourally: `packages/jsx/src/ir-to-client-js/reactivity.ts` (`collectLoopChildReactiveAttrs`). Plus a compiler unit test and a changeset. Scope is compiler-only — SSR template output is unchanged; only the generated client JS gains the per-item effect.

## Tests

- New compiler unit test in `packages/jsx/src/__tests__/reactive-attrs-in-map.test.ts` pinning that the per-item style binding emits a `createEffect` calling `setAttribute('style', ...)` with the helper call (`widthAt(...)`) preserved in the effect (not baked into the static template).

> Note: I could **not** run the test suite in this remote session — the environment's `node_modules` is missing the workspace packages (`@barefootjs/shared`, `@barefootjs/jsx`, …) and `typescript`, and `bun install` can't repair it offline. Verification is delegated to CI on this PR. The change is small and mirrors the existing, well-tested top-level `decideWrapForAttr` fallback.

Closes #1673

https://claude.ai/code/session_01J5WPsSuede8qpyfJAbcnMN