### PR TITLE
feat(adapter-go-template): bake typed/scalar signal array literals into SSR data (#1672)

### DIFF
--- a/.changeset/go-signal-array-literal-ssr.md
+++ b/.changeset/go-signal-array-literal-ssr.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Bake typed and scalar signal array-literal initial values into the generated `NewXxxProps` SSR data context, so Go server-renders the initial loop items instead of an empty list (#1672). Untyped object arrays and non-literal initialisers continue to default to `nil`.

--- a/.changeset/go-signal-array-literal-ssr.md
+++ b/.changeset/go-signal-array-literal-ssr.md
@@ -1,5 +1,8 @@
 ---
 "@barefootjs/go-template": patch
+"@barefootjs/jsx": patch
 ---
 
 Bake typed and scalar signal array-literal initial values into the generated `NewXxxProps` SSR data context, so Go server-renders the initial loop items instead of an empty list (#1672). Untyped object arrays and non-literal initialisers continue to default to `nil`.
+
+`TypeDefinition` now carries structured `properties` (`PropertyInfo[]`) for object/interface types, so adapters can consume a type's field set without re-parsing its source text. The go-template adapter uses this to derive struct fields and bake object literals against the real field set.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -47,9 +47,10 @@ runAdapterConformanceTests({
     // leaves it `nil`; (2) the loop body references the outer `sel` signal,
     // which the template emits as `.Sel` — resolved against the loop element
     // inside `range` rather than the root scope (`$.Sel`), a separate codegen
-    // bug masked until now by the previously-empty loop. The anchored SSR shape
-    // with rendered items is covered by Hono + CSR conformance and the runtime
-    // hydration tests. https://github.com/piconic-ai/barefootjs/issues/1672
+    // bug masked until now by the previously-empty loop and now tracked in
+    // #1677. The anchored SSR shape with rendered items is covered by Hono +
+    // CSR conformance and the runtime hydration tests.
+    // https://github.com/piconic-ai/barefootjs/issues/1677
     'loop-item-conditional',
     // #1297 fixed the harness-side IR emission gate (multi-component
     // sources now emit one `ir` file per component, and the harness

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -38,15 +38,18 @@ runAdapterConformanceTests({
     'return-map',
     // #1665 whole-item loop conditional. The Go adapter correctly emits the
     // per-item `<!--bf-loop-i:KEY-->` anchor, `data-key`, and conditional
-    // markers (verified by template-structure tests), but the array signal's
-    // initial value is not baked into the generated `NewXxxProps` constructor
-    // (`Items: nil`, unlike scalar signals such as `Sel: "b"`), so the Go SSR
-    // renders an empty loop. Populating signal-array initial values into the
-    // SSR data context is a separate pre-existing Go limitation — every other
-    // signal-loop fixture sidesteps it with an empty initial array. The
-    // anchored SSR shape with rendered items is covered by Hono + CSR
-    // conformance and the runtime hydration tests. Remove this skip once the
-    // Go limitation is fixed: https://github.com/piconic-ai/barefootjs/issues/1672
+    // markers (verified by template-structure tests). Signal-array initial
+    // values are now baked into `NewXxxProps` for typed and scalar arrays
+    // (#1672), but this fixture stays skipped for two reasons that survive
+    // that change: (1) its `items` signal is an *untyped* object array, which
+    // lands in a `[]interface{}` field whose `map` items the loop body can't
+    // reach via struct field access (`.ID` → <nil>), so the bake intentionally
+    // leaves it `nil`; (2) the loop body references the outer `sel` signal,
+    // which the template emits as `.Sel` — resolved against the loop element
+    // inside `range` rather than the root scope (`$.Sel`), a separate codegen
+    // bug masked until now by the previously-empty loop. The anchored SSR shape
+    // with rendered items is covered by Hono + CSR conformance and the runtime
+    // hydration tests. https://github.com/piconic-ai/barefootjs/issues/1672
     'loop-item-conditional',
     // #1297 fixed the harness-side IR emission gate (multi-component
     // sources now emit one `ir` file per component, and the harness
@@ -529,6 +532,101 @@ export function Score(props: { value?: number }) {
       const floatTypes = adapter.generate(floatIr).types!
       expect(floatTypes).not.toContain('value := in.Value')
       expect(floatTypes).toContain('Value: in.Value,')
+    })
+
+    test('bakes typed struct array-literal initial values into NewXxxProps (#1672)', () => {
+      // A signal typed `Item[]` lands in a `[]Item` field whose template loop
+      // body reaches each element via struct field access (`.ID`). Baking the
+      // inline literal as a Go struct slice — capitalising keys to match the
+      // generated field names — lets the Go SSR render the list. Previously
+      // `convertInitialValue` returned `nil` for any array literal, freezing
+      // SSR loops to empty (the reason whole-item-conditional loop fixtures
+      // had to skip Go render conformance — #1665 / #1672).
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+type Item = { id: string }
+export function List() {
+  const [items] = createSignal<Item[]>([{ id: "a" }, { id: "b" }, { id: "c" }])
+  return <ul>{items().map((t) => <li key={t.id}>{t.id}</li>)}</ul>
+}
+`)
+      const types = adapter.generate(ir).types!
+      expect(types).not.toContain('Items: nil,')
+      expect(types).toContain('Items: []Item{')
+      expect(types).toContain('Item{ID: "a"}')
+      expect(types).toContain('Item{ID: "b"}')
+      expect(types).toContain('Item{ID: "c"}')
+    })
+
+    test('bakes scalar array-literal initial values into NewXxxProps (#1672)', () => {
+      // Scalar loops render each element via `{{.}}`, so an `[]interface{}`
+      // (untyped) or `[]string` (typed) slice literal both render correctly.
+      const adapter = new GoTemplateAdapter()
+      const untypedIr = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+export function Tags() {
+  const [tags] = createSignal(["x", "y", "z"])
+  return <ul>{tags().map((t) => <li key={t}>{t}</li>)}</ul>
+}
+`)
+      expect(adapter.generate(untypedIr).types!).toContain(
+        'Tags: []interface{}{"x", "y", "z"},',
+      )
+
+      const typedIr = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+export function Tags() {
+  const [tags] = createSignal<string[]>(["x", "y", "z"])
+  return <ul>{tags().map((t) => <li key={t}>{t}</li>)}</ul>
+}
+`)
+      expect(adapter.generate(typedIr).types!).toContain(
+        'Tags: []string{"x", "y", "z"},',
+      )
+    })
+
+    test('keeps nil for untyped object-array initial values (#1672)', () => {
+      // Without a struct type the field is `[]interface{}`, but the loop body
+      // reaches items via struct field access (`.ID`) the map form can't
+      // satisfy (`<nil>`). Leave it nil — status quo for the untyped case —
+      // rather than baking a literal that renders empty.
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+export function List() {
+  const [items] = createSignal([{ id: "a" }, { id: "b" }])
+  return <ul>{items().map((t) => <li key={t.id}>{t.id}</li>)}</ul>
+}
+`)
+      expect(adapter.generate(ir).types!).toContain('Items: nil,')
+    })
+
+    test('keeps nil for non-literal array initial values (#1672)', () => {
+      // A signal whose array initial value is a function call / variable
+      // reference cannot be evaluated at codegen time — it must stay nil so
+      // the handler populates it (no behaviour change for these cases).
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+function build(): string[] { return [] }
+export function Dyn() {
+  const [items] = createSignal(build())
+  return <ul>{items().map((t) => <li key={t}>{t}</li>)}</ul>
+}
+`)
+      const types = adapter.generate(ir).types!
+      expect(types).toContain('Items: nil,')
     })
   })
 

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -629,6 +629,44 @@ export function Dyn() {
       const types = adapter.generate(ir).types!
       expect(types).toContain('Items: nil,')
     })
+
+    test('keeps nil for object keys that are not Go-identifier-safe (#1675 review)', () => {
+      // A quoted key like "data-id" capitalises to `Data-id`, which is not a
+      // valid Go struct field identifier — baking it would emit a keyed struct
+      // literal that doesn't compile, so the whole array must stay nil.
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+type Row = { "data-id": string }
+export function Rows() {
+  const [rows] = createSignal<Row[]>([{ "data-id": "a" }])
+  return <ul>{rows().map((r) => <li key={r["data-id"]}>{r["data-id"]}</li>)}</ul>
+}
+`)
+      const types = adapter.generate(ir).types!
+      expect(types).toContain('Rows: nil,')
+    })
+
+    test('collapses whitespace-padded empty array literal to nil (#1675 review)', () => {
+      // The empty-literal fast-path must match `[ ]` too, not only the exact
+      // `[]`, so a padded empty initial value still defaults to nil rather than
+      // baking an empty slice literal.
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+export function Empty() {
+  const [items] = createSignal<string[]>([ ])
+  return <ul>{items().map((t) => <li key={t}>{t}</li>)}</ul>
+}
+`)
+      const types = adapter.generate(ir).types!
+      expect(types).toContain('Items: nil,')
+      expect(types).not.toContain('Items: []string{}')
+    })
   })
 
   describe('JSX children forwarding (#1203)', () => {

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -667,6 +667,36 @@ export function Empty() {
       expect(types).toContain('Items: nil,')
       expect(types).not.toContain('Items: []string{}')
     })
+
+    test('bakes generic Array<T> / ReadonlyArray<T> initial values like T[] (#1675 review)', () => {
+      // `createSignal<Array<T>>` reaches the analyzer as a generic type
+      // reference, not a `T[]` array node. The analyzer normalises both to the
+      // same array TypeInfo, so baking treats them identically — element typing
+      // (and struct-element baking) is preserved rather than degrading to nil.
+      const adapter = new GoTemplateAdapter()
+      const scalarIr = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+export function Tags() {
+  const [tags] = createSignal<Array<string>>(["x", "y"])
+  return <ul>{tags().map((t) => <li key={t}>{t}</li>)}</ul>
+}
+`)
+      expect(adapter.generate(scalarIr).types!).toContain('Tags: []string{"x", "y"},')
+
+      const structIr = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+type Item = { id: string }
+export function List() {
+  const [items] = createSignal<ReadonlyArray<Item>>([{ id: "a" }])
+  return <ul>{items().map((t) => <li key={t.id}>{t.id}</li>)}</ul>
+}
+`)
+      expect(adapter.generate(structIr).types!).toContain('Items: []Item{Item{ID: "a"}},')
+    })
   })
 
   describe('JSX children forwarding (#1203)', () => {

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -1735,14 +1735,23 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       }
     }
 
-    // For arrays, use nil for complex JS expressions
+    // For arrays, bake a fully-literal initial value into a Go slice literal
+    // so the SSR data context carries the items (#1672). Empty / nullish
+    // literals collapse to nil, and any non-literal element (a call, a
+    // variable reference, …) falls back to nil so the handler populates it.
+    //
+    // The baked literal is element-type-aware so it both compiles and renders:
+    //   - scalar elements →  `[]string{…}` / `[]interface{}{…}`  (template `{{.}}`)
+    //   - struct elements →  `[]Item{Item{ID: …}}`               (template `.ID`)
+    // An untyped object array would land in a `[]interface{}` field whose
+    // `map[string]interface{}` items the template can't reach via field access
+    // (`.ID` → <nil>), so `jsLiteralToGo` returns null there and we keep nil.
     if (typeInfo.kind === 'array') {
-      // Simple array literal or empty
       if (value === '[]' || value === 'null' || value === 'undefined') {
         return 'nil'
       }
-      // Complex expression - use nil as placeholder
-      return 'nil'
+      const baked = this.jsLiteralToGo(value, typeInfo)
+      return baked ?? 'nil'
     }
 
     // String alias (e.g., Filter = string) — return string value instead of nil
@@ -1758,6 +1767,105 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
     // Default for complex expressions
     return 'nil'
+  }
+
+  /**
+   * Convert a fully-literal JS expression string into an equivalent Go literal
+   * whose Go type matches `typeInfo` (#1672), used to bake a signal's inline
+   * initial value into the SSR data context:
+   *
+   *   `["x", "y"]`             (string[])  → `[]string{"x", "y"}`
+   *   `["x", "y"]`             (unknown[]) → `[]interface{}{"x", "y"}`
+   *   `[{ id: "a" }]`          (Item[])    → `[]Item{Item{ID: "a"}}`
+   *
+   * Returns `null` — so the caller keeps `nil` — when the expression (or any
+   * nested element) is not a pure literal (a call, identifier, template with
+   * interpolation, …) or cannot be expressed in the target Go type without a
+   * render/compile mismatch (e.g. an object element in a `[]interface{}` field,
+   * which the SSR template reaches via struct field access the map lacks).
+   */
+  private jsLiteralToGo(value: string, typeInfo: TypeInfo): string | null {
+    const sf = ts.createSourceFile(
+      '__lit.ts', `(${value})`, ts.ScriptTarget.Latest, /* setParentNodes */ true,
+    )
+    const stmt = sf.statements[0]
+    if (!stmt || !ts.isExpressionStatement(stmt)) return null
+    let expr: ts.Expression = stmt.expression
+    while (ts.isParenthesizedExpression(expr)) expr = expr.expression
+    return this.tsLiteralToGo(expr, typeInfo)
+  }
+
+  /**
+   * Recursively convert a TS literal AST node to a Go literal typed as
+   * `typeInfo`, or null when the node is not a pure literal / cannot be
+   * represented in that Go type.
+   */
+  private tsLiteralToGo(node: ts.Expression, typeInfo?: TypeInfo): string | null {
+    // Unwrap a leading unary minus on a numeric literal (`-1`).
+    if (
+      ts.isPrefixUnaryExpression(node) &&
+      node.operator === ts.SyntaxKind.MinusToken &&
+      ts.isNumericLiteral(node.operand)
+    ) {
+      return `-${node.operand.text}`
+    }
+    if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+      return JSON.stringify(node.text)
+    }
+    if (ts.isNumericLiteral(node)) return node.text
+    if (node.kind === ts.SyntaxKind.TrueKeyword) return 'true'
+    if (node.kind === ts.SyntaxKind.FalseKeyword) return 'false'
+    if (node.kind === ts.SyntaxKind.NullKeyword) return 'nil'
+
+    if (ts.isArrayLiteralExpression(node)) {
+      // Slice header mirrors the field's Go type (`[]string`, `[]Item`,
+      // `[]interface{}`); elements are converted against the element type.
+      const elemType = typeInfo?.kind === 'array' ? typeInfo.elementType : undefined
+      const sliceHeader = typeInfo?.kind === 'array'
+        ? this.typeInfoToGo(typeInfo)
+        : '[]interface{}'
+      const elems: string[] = []
+      for (const el of node.elements) {
+        const go = this.tsLiteralToGo(el, elemType)
+        if (go === null) return null
+        elems.push(go)
+      }
+      return `${sliceHeader}{${elems.join(', ')}}`
+    }
+
+    if (ts.isObjectLiteralExpression(node)) {
+      // An object can only be baked when the target Go type is a concrete
+      // struct — otherwise it would land in `interface{}` / a map the SSR
+      // template can't reach via field access. Bail (→ nil) in that case.
+      const goType = typeInfo ? this.typeInfoToGo(typeInfo) : 'interface{}'
+      if (!this.localTypeNames.has(goType)) return null
+      const entries: string[] = []
+      for (const prop of node.properties) {
+        // Only plain `key: scalar` pairs are baked; spreads, methods,
+        // shorthand, computed/accessor members, and nested object/array
+        // values (whose struct field types we don't track here) bail to nil.
+        if (!ts.isPropertyAssignment(prop)) return null
+        let key: string
+        if (
+          ts.isIdentifier(prop.name) ||
+          ts.isStringLiteral(prop.name) ||
+          ts.isNumericLiteral(prop.name)
+        ) {
+          key = prop.name.text
+        } else {
+          return null
+        }
+        const init = prop.initializer
+        if (ts.isObjectLiteralExpression(init) || ts.isArrayLiteralExpression(init)) {
+          return null
+        }
+        const go = this.tsLiteralToGo(init)
+        if (go === null) return null
+        entries.push(`${this.capitalizeFieldName(key)}: ${go}`)
+      }
+      return `${goType}{${entries.join(', ')}}`
+    }
+    return null
   }
 
   /**

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -1747,7 +1747,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // `map[string]interface{}` items the template can't reach via field access
     // (`.ID` → <nil>), so `jsLiteralToGo` returns null there and we keep nil.
     if (typeInfo.kind === 'array') {
-      if (value === '[]' || value === 'null' || value === 'undefined') {
+      // Collapse empty / nullish literals to nil before baking. Strip all
+      // whitespace for this compare so an internally-padded empty literal
+      // (`[ ]`, `[  ]`) collapses too, not just the exact `[]` — otherwise it
+      // would bake an empty slice literal (`[]string{}`), which JSON-marshals
+      // as `[]` rather than the `null` a nil slice produces. The original
+      // `value` is still what gets parsed, so element whitespace is untouched.
+      const bare = value.replace(/\s/g, '')
+      if (bare === '[]' || bare === 'null' || bare === 'undefined') {
         return 'nil'
       }
       const baked = this.jsLiteralToGo(value, typeInfo)
@@ -1858,6 +1865,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         } else {
           return null
         }
+        // The key must capitalise to a valid Go struct field identifier.
+        // String/numeric keys can hold names a struct field can't —
+        // `"data-id"`, `0`, `"with space"` — which would emit a keyed literal
+        // that doesn't compile. Bail to nil for anything that isn't a bare
+        // JS identifier (the only shape `capitalizeFieldName` maps cleanly).
+        if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) return null
         const init = prop.initializer
         if (ts.isObjectLiteralExpression(init) || ts.isArrayLiteralExpression(init)) {
           return null

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -1812,6 +1812,9 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
       return JSON.stringify(node.text)
     }
+    // Pass the numeric literal's source spelling through verbatim. Every form
+    // the TS parser accepts here (`1`, `1.5`, `1e3`, `0x10`, `1_000`) is also a
+    // valid Go numeric literal, so no re-formatting is needed.
     if (ts.isNumericLiteral(node)) return node.text
     if (node.kind === ts.SyntaxKind.TrueKeyword) return 'true'
     if (node.kind === ts.SyntaxKind.FalseKeyword) return 'false'
@@ -1861,6 +1864,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         }
         const go = this.tsLiteralToGo(init)
         if (go === null) return null
+        // Field name MUST be capitalised with the same helper the struct
+        // definition uses (see `capitalizeFieldName` call in the struct-field
+        // generation above), or the keyed literal won't match the field and Go
+        // won't compile. Keep these two call sites in sync.
         entries.push(`${this.capitalizeFieldName(key)}: ${go}`)
       }
       return `${goType}{${entries.join(', ')}}`

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -329,6 +329,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   private localTypeNames: Set<string> = new Set()
   /** Local type aliases mapping type name to base type (e.g., Filter → 'string') */
   private localTypeAliases: Map<string, string> = new Map()
+  /**
+   * Per-struct field map (type name → source TS key → Go field name), populated
+   * during generateTypes. The object-literal baker consults this so a baked
+   * struct literal only names fields the generated struct actually declares.
+   */
+  private localStructFields: Map<string, Map<string, string>> = new Map()
 
   /** Set during type generation when any emit references
    *  `template.HTML(...)`; toggles the `"html/template"` import. */
@@ -654,6 +660,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // Build set of locally-defined type names and aliases so typeInfoToGo can resolve them
     this.localTypeNames = new Set<string>()
     this.localTypeAliases = new Map<string, string>()
+    this.localStructFields = new Map<string, Map<string, string>>()
     for (const td of ir.metadata.typeDefinitions) {
       // Skip the Props type itself (it's the component's own props, not a reusable type)
       if (td.name === 'Props' || td.name === `${componentName}Props`) continue
@@ -663,6 +670,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       // Track string literal union aliases (e.g., type Filter = 'all' | 'active')
       if (td.definition.match(/^type \w+ = ('[^']*'(\s*\|\s*'[^']*')*)/)) {
         this.localTypeAliases.set(td.name, 'string')
+      } else {
+        // Record the struct's source-key → Go-field-name map for the baker.
+        const fields = this.parseStructFields(td.definition)
+        if (fields) {
+          this.localStructFields.set(td.name, new Map(fields.map(f => [f.tsName, f.goName])))
+        }
       }
     }
 
@@ -732,28 +745,45 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     }
 
     // Object/interface type: type Todo = { id: number; text: string; ... }
-    const bodyMatch = def.match(/(?:type \w+ = |interface \w+ )\{([\s\S]*)\}/)
-    if (!bodyMatch) return null
+    const fields = this.parseStructFields(def)
+    if (!fields) return null
 
-    const body = bodyMatch[1]
-    const goFields: string[] = []
-
-    // Parse each field: "fieldName: type" or "fieldName?: type"
-    // Handle both semicolon-separated and newline-separated
-    const fieldEntries = body.split(/[;\n]/).map(s => s.trim()).filter(Boolean)
-    for (const entry of fieldEntries) {
-      const fieldMatch = entry.match(/^(\w+)\??\s*:\s*(.+)$/)
-      if (!fieldMatch) continue
-      const [, fieldName, tsType] = fieldMatch
-      const goFieldName = this.capitalizeFieldName(fieldName)
-      const goType = this.tsTypeStringToGo(tsType.trim())
-      const jsonTag = this.toJsonTag(fieldName)
-      goFields.push(`\t${goFieldName} ${goType} \`json:"${jsonTag}"\``)
-    }
-
+    const goFields = fields.map(
+      f => `\t${f.goName} ${this.tsTypeStringToGo(f.tsType)} \`json:"${this.toJsonTag(f.tsName)}"\``,
+    )
     if (goFields.length === 0) return null
 
     return `// ${td.name} represents a ${td.name.toLowerCase()}.\ntype ${td.name} struct {\n${goFields.join('\n')}\n}`
+  }
+
+  /**
+   * Parse an object/interface type definition body into its struct fields.
+   * Returns `null` when `def` isn't an object/interface type (e.g. a
+   * string-union alias). This is the single source of truth for which fields a
+   * generated struct has and what each field's Go name is — both the struct
+   * emitter ({@link typeDefinitionToGo}) and the object-literal baker
+   * ({@link tsLiteralToGo}) consume it, so a literal can never name a field the
+   * struct doesn't actually declare.
+   *
+   * The field-name regex is `\w+`, so a non-identifier source key (`"data-id"`)
+   * is silently absent from both the struct and the field map — the baker then
+   * bails to `nil` for any literal that uses such a key.
+   */
+  private parseStructFields(def: string): Array<{ tsName: string; goName: string; tsType: string }> | null {
+    const bodyMatch = def.match(/(?:type \w+ = |interface \w+ )\{([\s\S]*)\}/)
+    if (!bodyMatch) return null
+
+    const fields: Array<{ tsName: string; goName: string; tsType: string }> = []
+    // Handle both semicolon-separated and newline-separated field lists.
+    const fieldEntries = bodyMatch[1].split(/[;\n]/).map(s => s.trim()).filter(Boolean)
+    for (const entry of fieldEntries) {
+      // "fieldName: type" or "fieldName?: type"
+      const fieldMatch = entry.match(/^(\w+)\??\s*:\s*(.+)$/)
+      if (!fieldMatch) continue
+      const [, tsName, tsType] = fieldMatch
+      fields.push({ tsName, goName: this.capitalizeFieldName(tsName), tsType: tsType.trim() })
+    }
+    return fields
   }
 
   /**
@@ -1747,18 +1777,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // `map[string]interface{}` items the template can't reach via field access
     // (`.ID` → <nil>), so `jsLiteralToGo` returns null there and we keep nil.
     if (typeInfo.kind === 'array') {
-      // Collapse empty / nullish literals to nil before baking. Strip all
-      // whitespace for this compare so an internally-padded empty literal
-      // (`[ ]`, `[  ]`) collapses too, not just the exact `[]` — otherwise it
-      // would bake an empty slice literal (`[]string{}`), which JSON-marshals
-      // as `[]` rather than the `null` a nil slice produces. The original
-      // `value` is still what gets parsed, so element whitespace is untouched.
-      const bare = value.replace(/\s/g, '')
-      if (bare === '[]' || bare === 'null' || bare === 'undefined') {
-        return 'nil'
-      }
-      const baked = this.jsLiteralToGo(value, typeInfo)
-      return baked ?? 'nil'
+      // Bake a fully-literal initial value into a Go slice literal; anything
+      // the parser can't reduce to a literal — a call, an identifier, `null` /
+      // `undefined`, or an empty array — yields null and we keep `nil`.
+      return this.jsLiteralToGo(value, typeInfo) ?? 'nil'
     }
 
     // String alias (e.g., Filter = string) — return string value instead of nil
@@ -1828,6 +1850,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     if (node.kind === ts.SyntaxKind.NullKeyword) return 'nil'
 
     if (ts.isArrayLiteralExpression(node)) {
+      // An empty array literal (`[]`, and — since the TS parser tolerates
+      // whitespace/comments — `[ ]`, `[/* */]`) carries no items, so there's
+      // nothing to bake. Returning null keeps the field `nil`, which JSON-
+      // marshals as `null` rather than the `[]` an empty slice would produce.
+      if (node.elements.length === 0) return null
+
       // Slice header mirrors the field's Go type (`[]string`, `[]Item`,
       // `[]interface{}`); elements are converted against the element type.
       const elemType = typeInfo?.kind === 'array' ? typeInfo.elementType : undefined
@@ -1846,42 +1874,40 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     if (ts.isObjectLiteralExpression(node)) {
       // An object can only be baked when the target Go type is a concrete
       // struct — otherwise it would land in `interface{}` / a map the SSR
-      // template can't reach via field access. Bail (→ nil) in that case.
+      // template can't reach via field access. The struct's field map is the
+      // source of truth: it tells us the exact Go field name for each source
+      // key and, by omission, which keys the struct doesn't declare. Bail
+      // (→ nil) when the type isn't a known struct.
       const goType = typeInfo ? this.typeInfoToGo(typeInfo) : 'interface{}'
-      if (!this.localTypeNames.has(goType)) return null
+      const structFields = this.localStructFields.get(goType)
+      if (!structFields) return null
       const entries: string[] = []
       for (const prop of node.properties) {
         // Only plain `key: scalar` pairs are baked; spreads, methods,
         // shorthand, computed/accessor members, and nested object/array
         // values (whose struct field types we don't track here) bail to nil.
         if (!ts.isPropertyAssignment(prop)) return null
-        let key: string
         if (
-          ts.isIdentifier(prop.name) ||
-          ts.isStringLiteral(prop.name) ||
-          ts.isNumericLiteral(prop.name)
+          !ts.isIdentifier(prop.name) &&
+          !ts.isStringLiteral(prop.name) &&
+          !ts.isNumericLiteral(prop.name)
         ) {
-          key = prop.name.text
-        } else {
           return null
         }
-        // The key must capitalise to a valid Go struct field identifier.
-        // String/numeric keys can hold names a struct field can't —
-        // `"data-id"`, `0`, `"with space"` — which would emit a keyed literal
-        // that doesn't compile. Bail to nil for anything that isn't a bare
-        // JS identifier (the only shape `capitalizeFieldName` maps cleanly).
-        if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) return null
+        // Resolve the Go field name from the struct's own field map rather
+        // than re-deriving it. A key the struct doesn't declare (a typo, or a
+        // non-identifier key like `"data-id"` that never became a field) is
+        // absent here, so we bail to nil instead of emitting a literal that
+        // names a nonexistent field and won't compile.
+        const goField = structFields.get(prop.name.text)
+        if (!goField) return null
         const init = prop.initializer
         if (ts.isObjectLiteralExpression(init) || ts.isArrayLiteralExpression(init)) {
           return null
         }
         const go = this.tsLiteralToGo(init)
         if (go === null) return null
-        // Field name MUST be capitalised with the same helper the struct
-        // definition uses (see `capitalizeFieldName` call in the struct-field
-        // generation above), or the keyed literal won't match the field and Go
-        // won't compile. Keep these two call sites in sync.
-        entries.push(`${this.capitalizeFieldName(key)}: ${go}`)
+        entries.push(`${goField}: ${go}`)
       }
       return `${goType}{${entries.join(', ')}}`
     }

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -21,6 +21,7 @@ import type {
   IRTemplatePart,
   IRProp,
   TypeInfo,
+  TypeDefinition,
   CompilerError,
   SourceLocation,
   ParsedExpr,
@@ -671,9 +672,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       if (td.definition.match(/^type \w+ = ('[^']*'(\s*\|\s*'[^']*')*)/)) {
         this.localTypeAliases.set(td.name, 'string')
       } else {
-        // Record the struct's source-key → Go-field-name map for the baker.
-        const fields = this.parseStructFields(td.definition)
-        if (fields) {
+        // Record the struct's source-key → Go-field-name map for the baker,
+        // from the same field derivation the struct emitter uses.
+        const fields = this.structFieldsFor(td)
+        if (fields.length > 0) {
           this.localStructFields.set(td.name, new Map(fields.map(f => [f.tsName, f.goName])))
         }
       }
@@ -735,53 +737,47 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * Convert a TypeScript type definition to a Go type.
    * Handles object types → Go structs, and union string literals → string alias.
    */
-  private typeDefinitionToGo(td: { kind: string; name: string; definition: string }): string | null {
-    const def = td.definition
-
-    // String literal union: type Filter = 'all' | 'active' | 'completed'
-    if (def.match(/^type \w+ = ('[^']*'(\s*\|\s*'[^']*')*)/)) {
+  private typeDefinitionToGo(td: TypeDefinition): string | null {
+    // String literal union: type Filter = 'all' | 'active' | 'completed'.
+    // These carry no `properties`, so the analyzer leaves the field set empty;
+    // detect the alias from the definition and map it to a Go string.
+    if (td.definition.match(/^type \w+ = ('[^']*'(\s*\|\s*'[^']*')*)/)) {
       // Map to Go string (union of string literals → just string in Go)
       return `// ${td.name} is a string type.\ntype ${td.name} = string`
     }
 
     // Object/interface type: type Todo = { id: number; text: string; ... }
-    const fields = this.parseStructFields(def)
-    if (!fields) return null
+    const fields = this.structFieldsFor(td)
+    if (fields.length === 0) return null
 
     const goFields = fields.map(
-      f => `\t${f.goName} ${this.tsTypeStringToGo(f.tsType)} \`json:"${this.toJsonTag(f.tsName)}"\``,
+      f => `\t${f.goName} ${f.goType} \`json:"${this.toJsonTag(f.tsName)}"\``,
     )
-    if (goFields.length === 0) return null
-
     return `// ${td.name} represents a ${td.name.toLowerCase()}.\ntype ${td.name} struct {\n${goFields.join('\n')}\n}`
   }
 
   /**
-   * Parse an object/interface type definition body into its struct fields.
-   * Returns `null` when `def` isn't an object/interface type (e.g. a
-   * string-union alias). This is the single source of truth for which fields a
-   * generated struct has and what each field's Go name is — both the struct
-   * emitter ({@link typeDefinitionToGo}) and the object-literal baker
-   * ({@link tsLiteralToGo}) consume it, so a literal can never name a field the
-   * struct doesn't actually declare.
+   * Derive a struct's Go fields from the analyzer-provided structured
+   * properties — no string parsing of the definition. This is the single
+   * source of truth for which fields a generated struct has and each field's Go
+   * name/type; both the struct emitter ({@link typeDefinitionToGo}) and the
+   * object-literal baker ({@link tsLiteralToGo}) consume it, so a baked literal
+   * can never name a field the struct doesn't declare.
    *
-   * The field-name regex is `\w+`, so a non-identifier source key (`"data-id"`)
-   * is silently absent from both the struct and the field map — the baker then
-   * bails to `nil` for any literal that uses such a key.
+   * A property whose source key isn't a valid Go identifier (`"data-id"`, a
+   * numeric key, …) can't become a struct field, so it's dropped here — and is
+   * therefore absent from the baker's field map too, which bails to nil for any
+   * literal that uses such a key.
    */
-  private parseStructFields(def: string): Array<{ tsName: string; goName: string; tsType: string }> | null {
-    const bodyMatch = def.match(/(?:type \w+ = |interface \w+ )\{([\s\S]*)\}/)
-    if (!bodyMatch) return null
-
-    const fields: Array<{ tsName: string; goName: string; tsType: string }> = []
-    // Handle both semicolon-separated and newline-separated field lists.
-    const fieldEntries = bodyMatch[1].split(/[;\n]/).map(s => s.trim()).filter(Boolean)
-    for (const entry of fieldEntries) {
-      // "fieldName: type" or "fieldName?: type"
-      const fieldMatch = entry.match(/^(\w+)\??\s*:\s*(.+)$/)
-      if (!fieldMatch) continue
-      const [, tsName, tsType] = fieldMatch
-      fields.push({ tsName, goName: this.capitalizeFieldName(tsName), tsType: tsType.trim() })
+  private structFieldsFor(td: TypeDefinition): Array<{ tsName: string; goName: string; goType: string }> {
+    const fields: Array<{ tsName: string; goName: string; goType: string }> = []
+    for (const prop of td.properties ?? []) {
+      if (!GoTemplateAdapter.GO_IDENTIFIER.test(prop.name)) continue
+      fields.push({
+        tsName: prop.name,
+        goName: this.capitalizeFieldName(prop.name),
+        goType: this.typeInfoToGo(prop.type),
+      })
     }
     return fields
   }
@@ -2399,6 +2395,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
     return null
   }
+
+  /**
+   * A source key that can become a Go struct field — i.e. a valid Go
+   * identifier. TS object keys that aren't (e.g. `"data-id"`, numeric keys)
+   * can't be exported struct fields, so they're excluded from struct generation
+   * and from the baker's field map.
+   */
+  private static GO_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/
 
   /** Go common initialisms that should be fully uppercased (https://go.dev/wiki/CodeReviewComments#initialisms) */
   private static GO_INITIALISMS = new Set([

--- a/packages/jsx/src/analyzer-context.ts
+++ b/packages/jsx/src/analyzer-context.ts
@@ -20,6 +20,7 @@ import type {
   CompilerError,
   SourceLocation,
   ParamInfo,
+  PropertyInfo,
   ReactiveFactoryInfo,
 } from './types'
 import { type ExcludeRange, collectAllTypeRanges, reconstructWithoutTypes } from './strip-types'
@@ -301,6 +302,46 @@ export function getSourceLocation(
 // Type Helpers
 // =============================================================================
 
+/**
+ * Extract structured {@link PropertyInfo} entries from the members of an object
+ * type literal or interface declaration. Shared so the type-literal branch of
+ * {@link typeNodeToTypeInfo} and interface-definition collection produce
+ * identical field shapes.
+ */
+export function membersToProperties(
+  members: ts.NodeArray<ts.TypeElement>,
+  sourceFile: ts.SourceFile
+): PropertyInfo[] {
+  return members
+    .filter(ts.isPropertySignature)
+    .map((member) => ({
+      name: propertyNameText(member.name, sourceFile),
+      type: typeNodeToTypeInfo(member.type, sourceFile) ?? {
+        kind: 'unknown' as const,
+        raw: 'unknown',
+      },
+      optional: !!member.questionToken,
+      readonly: !!member.modifiers?.some(
+        (m) => m.kind === ts.SyntaxKind.ReadonlyKeyword
+      ),
+    }))
+}
+
+/**
+ * The source-level name of an object/interface member. String- and numeric-
+ * literal keys are returned unquoted (`{ "id": ... }` → `id`), so consumers see
+ * the same name whether the key was written as an identifier or a string —
+ * `getText()` would otherwise keep the quotes.
+ */
+function propertyNameText(
+  name: ts.PropertyName | undefined,
+  sourceFile: ts.SourceFile
+): string {
+  if (!name) return ''
+  if (ts.isStringLiteral(name) || ts.isNumericLiteral(name)) return name.text
+  return name.getText(sourceFile)
+}
+
 export function typeNodeToTypeInfo(
   typeNode: ts.TypeNode | undefined,
   sourceFile: ts.SourceFile
@@ -352,19 +393,7 @@ export function typeNodeToTypeInfo(
     return {
       kind: 'object',
       raw,
-      properties: typeNode.members
-        .filter(ts.isPropertySignature)
-        .map((member) => ({
-          name: member.name?.getText(sourceFile) ?? '',
-          type: typeNodeToTypeInfo(member.type, sourceFile) ?? {
-            kind: 'unknown',
-            raw: 'unknown',
-          },
-          optional: !!member.questionToken,
-          readonly: !!member.modifiers?.some(
-            (m) => m.kind === ts.SyntaxKind.ReadonlyKeyword
-          ),
-        })),
+      properties: membersToProperties(typeNode.members, sourceFile),
     }
   }
 

--- a/packages/jsx/src/analyzer-context.ts
+++ b/packages/jsx/src/analyzer-context.ts
@@ -399,6 +399,23 @@ export function typeNodeToTypeInfo(
 
   // Type reference (named type)
   if (ts.isTypeReferenceNode(typeNode)) {
+    // Normalise the generic array forms `Array<T>` / `ReadonlyArray<T>` to the
+    // same `kind: 'array'` shape as `T[]`, so every consumer sees one array
+    // representation regardless of how the source spelled it.
+    const refName = ts.isIdentifier(typeNode.typeName) ? typeNode.typeName.text : ''
+    if (
+      (refName === 'Array' || refName === 'ReadonlyArray') &&
+      typeNode.typeArguments?.length === 1
+    ) {
+      return {
+        kind: 'array',
+        raw,
+        elementType: typeNodeToTypeInfo(typeNode.typeArguments[0], sourceFile) ?? {
+          kind: 'unknown',
+          raw: 'unknown',
+        },
+      }
+    }
     return {
       kind: 'interface',
       raw,

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -16,6 +16,7 @@ import {
   createAnalyzerContext,
   getSourceLocation,
   typeNodeToTypeInfo,
+  membersToProperties,
   isComponentFunction,
   isArrowComponentFunction,
 } from './analyzer-context'
@@ -1782,6 +1783,7 @@ function collectInterfaceDefinition(
     kind: 'interface',
     name: node.name.text,
     definition: node.getText(ctx.sourceFile),
+    properties: membersToProperties(node.members, ctx.sourceFile),
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
   })
 }
@@ -1790,10 +1792,16 @@ function collectTypeAliasDefinition(
   node: ts.TypeAliasDeclaration,
   ctx: AnalyzerContext
 ): void {
+  // Only object-type aliases carry structured fields; other aliases
+  // (string-literal unions, etc.) have no field set to record.
+  const properties = ts.isTypeLiteralNode(node.type)
+    ? membersToProperties(node.type.members, ctx.sourceFile)
+    : undefined
   ctx.typeDefinitions.push({
     kind: 'type',
     name: node.name.text,
     definition: node.getText(ctx.sourceFile),
+    properties,
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
   })
 }

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -40,7 +40,9 @@ export type {
   IRTemplatePart,
   IRProp,
   ParamInfo,
+  PropertyInfo,
   TypeInfo,
+  TypeDefinition,
   SourceLocation,
   CompilerError,
 } from './types'

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -1291,6 +1291,12 @@ export interface TypeDefinition {
   kind: 'interface' | 'type'
   name: string
   definition: string // Original TypeScript definition
+  /**
+   * Structured fields for object/interface shapes, so adapters can consume the
+   * field set (names + types) without re-parsing `definition`. Absent for
+   * type aliases that aren't object types (e.g. string-literal unions).
+   */
+  properties?: PropertyInfo[]
   loc: SourceLocation
 }
 


### PR DESCRIPTION
## What

Signal arrays initialised with an inline literal previously always landed as `Items: nil` in the generated `NewXxxProps` constructor, so the Go SSR rendered an empty loop. Every signal-loop fixture had to sidestep this by starting from an empty array.

`convertInitialValue` now bakes a **fully-literal** array initial value into a Go slice literal whose type matches the generated field, via a new type-aware `jsLiteralToGo` / `tsLiteralToGo` pair:

| Source | Go type | Baked literal |
|---|---|---|
| `["x", "y"]` (`string[]`) | `[]string` | `[]string{"x", "y"}` |
| `["x", "y"]` (untyped) | `[]interface{}` | `[]interface{}{"x", "y"}` |
| `[{ id: "a" }]` (`Item[]`) | `[]Item` | `[]Item{Item{ID: "a"}}` |

Object elements are baked **only** when the target Go type is a concrete local struct (so the template's `.Field` access resolves; keys are capitalised to match field names). Anything that can't be represented safely stays `nil`:

- **Untyped object arrays** → `[]interface{}` field can't be reached via struct field access (`.ID` → `<nil>`), so left `nil` (status quo, non-breaking).
- **Non-literal initialisers** (calls, identifiers, interpolated templates) → left `nil` for the handler to populate.

## Scope (phase 1 of #1672)

This is the **type-aware baking** slice agreed for #1672. It is non-breaking: untyped object arrays and dynamic initialisers behave exactly as before. A follow-up (phase 2) can extend this to untyped object arrays — that requires either synthesising a struct type from the literal shape or teaching the template to use map access (`index . "id"`), which touches loop codegen more broadly.

## Verification

- New adapter unit tests (`#1672`): typed struct, typed/untyped scalar baked; untyped object + non-literal stay `nil`.
- End-to-end against **real Go** (`go1.25.6`): typed-struct, typed-scalar and untyped-scalar loops now render their items.
- Full Go adapter suite: **331 pass / 3 skip / 0 fail**; `tsc --noEmit` clean.

`loop-item-conditional` stays skipped (comment updated): its array is an untyped object array, and it surfaces a separate `range`-scope codegen bug — the outer `sel` signal is emitted as `.Sel` (resolved against the loop element) instead of `$.Sel`. That bug was masked until now by the previously-empty loop.

https://claude.ai/code/session_014HUbvaiJv5iDfq37uVqxCv

---
_Generated by [Claude Code](https://claude.ai/code/session_014HUbvaiJv5iDfq37uVqxCv)_