### PR TITLE
test(adapters): pin /* @client */ escape hatch for unsupported methods (#1448)

### DIFF
--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -1909,3 +1909,172 @@ describe('GoTemplateAdapter - #1448 Tier A/B fixture-driven lowering pins', () =
     })
   }
 })
+
+// =============================================================================
+// #1448 — `/* @client */` escape hatch for STILL-UNSUPPORTED methods
+// =============================================================================
+//
+// The catalogue in #1448 documents `/* @client */` as the universal
+// workaround for any Array/String method shape the template adapters
+// can't lower. This block pins that contract for the Go adapter: for
+// every remaining unsupported entry, wrapping the expression in
+// `/* @client */` must (a) clear the BF021/BF101 build error the bare
+// form raises and (b) emit a client-only placeholder so the Go SSR
+// pass renders valid template that the client runtime fills at
+// hydration.
+//
+// Why this matters beyond "no error": the unsupported *string* methods
+// are a silent footgun. Unlike the unsupported array methods (which
+// surface BF101 at build time), bare `.startsWith` / `.repeat` / …
+// lower to a Go method-call expression (`{{.Name.StartsWith "a"}}`)
+// that passes the adapter's gate with NO diagnostic — then explodes at
+// `go run` time with `can't evaluate field StartsWith in type string`.
+// `/* @client */` is the only escape hatch, so these tests pin it.
+describe('GoTemplateAdapter - #1448 @client escape hatch (unsupported methods)', () => {
+  // Compile a single expression placed in `<div>` text position, with
+  // and without the directive, and return both the build errors and
+  // the emitted template.
+  function emit(expr: string, client: boolean) {
+    const marker = client ? '/* @client */ ' : ''
+    const adapter = new GoTemplateAdapter()
+    const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+export function C() {
+  const [items, setItems] = createSignal<{ name: string; n: number; tags: string[] }[]>([])
+  const [name, setName] = createSignal("x")
+  const myCmp = (a: { n: number }, b: { n: number }) => a.n - b.n
+  return <div>{${marker}${expr}}</div>
+}
+`, adapter)
+    const template = adapter.generate(ir).template ?? ''
+    return { errors: adapter.errors ?? [], template }
+  }
+
+  // Same shape but the expression is a `.map()` chain that renders a
+  // loop (sort follow-ups land here). The client placeholder is a
+  // loop comment rather than a text comment.
+  function emitLoop(chain: string, client: boolean) {
+    const marker = client ? '/* @client */ ' : ''
+    const adapter = new GoTemplateAdapter()
+    const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+export function C() {
+  const [items, setItems] = createSignal<{ name: string; n: number }[]>([])
+  const myCmp = (a: { n: number }, b: { n: number }) => a.n - b.n
+  return <ul>{${marker}${chain}}</ul>
+}
+`, adapter)
+    const template = adapter.generate(ir).template ?? ''
+    return { errors: adapter.errors ?? [], template }
+  }
+
+  // Tier C array methods — bare form raises BF101 at build time.
+  const unsupportedArray: Array<[string, string]> = [
+    ['reduce', `items().reduce((a, b) => a + b.n, 0)`],
+    ['flatMap', `items().flatMap(i => i.tags)`],
+    ['flat', `items().flat()`],
+  ]
+  for (const [name, expr] of unsupportedArray) {
+    test(`array .${name}: bare raises BF101, @client clears it + emits client placeholder`, () => {
+      const bare = emit(expr, false)
+      expect(bare.errors.some(e => e.code === 'BF101')).toBe(true)
+
+      const guarded = emit(expr, true)
+      expect(guarded.errors).toEqual([])
+      // Client-only text slot → `{{bfComment "client:sN"}}` placeholder.
+      expect(guarded.template).toMatch(/bfComment "client:s\d+"/)
+      // The unlowerable expression must NOT survive into the template.
+      expect(guarded.template).not.toContain('.Reduce')
+      expect(guarded.template).not.toContain('.FlatMap')
+    })
+  }
+
+  // Tier B/C string methods — bare form emits an INVALID Go method
+  // call with NO build error (the silent footgun). `@client` is the
+  // only thing that prevents the render-time crash.
+  const unsupportedString: Array<[string, string, string]> = [
+    ['split', `name().split(",")`, '.Name.Split'],
+    ['startsWith', `name().startsWith("a")`, '.Name.StartsWith'],
+    ['endsWith', `name().endsWith("z")`, '.Name.EndsWith'],
+    ['replace', `name().replace("a", "b")`, '.Name.Replace'],
+    ['repeat', `name().repeat(3)`, '.Name.Repeat'],
+    ['padStart', `name().padStart(5, "0")`, '.Name.PadStart'],
+    ['padEnd', `name().padEnd(5, "0")`, '.Name.PadEnd'],
+    ['charAt', `name().charAt(0)`, '.Name.CharAt'],
+  ]
+  for (const [name, expr, badEmit] of unsupportedString) {
+    test(`string .${name}: bare emits invalid Go method call, @client emits client placeholder`, () => {
+      const bare = emit(expr, false)
+      // Documents the footgun: no BF101 guard, invalid template emitted.
+      expect(bare.errors.filter(e => e.code === 'BF101')).toEqual([])
+      expect(bare.template).toContain(badEmit)
+
+      const guarded = emit(expr, true)
+      expect(guarded.errors).toEqual([])
+      expect(guarded.template).toMatch(/bfComment "client:s\d+"/)
+      expect(guarded.template).not.toContain(badEmit)
+    })
+  }
+
+  // Tier B `.sort` / `.toSorted` follow-ups still refused with BF021.
+  const unsupportedSort: Array<[string, string]> = [
+    ['function-reference comparator', `items().toSorted(myCmp).map(x => <li key={x.name}>{x.name}</li>)`],
+    ['localeCompare locale/options arg', `items().toSorted((a, b) => a.name.localeCompare(b.name, "ja", { numeric: true })).map(x => <li key={x.name}>{x.name}</li>)`],
+  ]
+  for (const [label, chain] of unsupportedSort) {
+    test(`sort follow-up (${label}): bare raises BF021, @client clears it`, () => {
+      const bare = compileJSX(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+export function C() {
+  const [items, setItems] = createSignal<{ name: string; n: number }[]>([])
+  const myCmp = (a: { n: number }, b: { n: number }) => a.n - b.n
+  return <ul>{${chain}}</ul>
+}
+`.trimStart(), 'test.tsx', { adapter: new GoTemplateAdapter() })
+      expect(bare.errors?.some(e => e.code === 'BF021')).toBe(true)
+
+      const guarded = emitLoop(chain, true)
+      expect(guarded.errors).toEqual([])
+      // Client-only loop → `{{bfComment "loop:lN"}}…{{bfComment "/loop:lN"}}`.
+      expect(guarded.template).toMatch(/bfComment "loop:l\d+"/)
+    })
+  }
+
+  // End-to-end proof via `go run`: the bare unsupported form crashes
+  // the Go template execution, while the `@client` form renders a
+  // `<!--bf-client:sN-->` placeholder. Skipped on hosts without Go.
+  test('e2e: bare string method crashes go render, @client renders placeholder', async () => {
+    const guarded = `
+"use client"
+import { createSignal } from "@barefootjs/client"
+export function C() {
+  const [name, setName] = createSignal("hello")
+  return <div>{/* @client */ name().repeat(3)}</div>
+}
+`
+    const bareSrc = guarded.replace('/* @client */ ', '')
+    try {
+      const html = await renderGoTemplateComponent({
+        source: guarded.trimStart(),
+        adapter: new GoTemplateAdapter(),
+      })
+      expect(html).toContain('<!--bf-client:s0-->')
+    } catch (err) {
+      if (err instanceof GoNotAvailableError) {
+        console.log('Skipping #1448 @client e2e: go command not found')
+        return
+      }
+      throw err
+    }
+    // Bare form must fail Go template execution (no @client guard).
+    await expect(
+      renderGoTemplateComponent({
+        source: bareSrc.trimStart(),
+        adapter: new GoTemplateAdapter(),
+      }),
+    ).rejects.toThrow(/can't evaluate field Repeat in type string/)
+  })
+})

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -971,3 +971,165 @@ describe('MojoAdapter - #1448 Tier A/B fixture-driven lowering pins', () => {
     })
   }
 })
+
+// =============================================================================
+// #1448 — `/* @client */` escape hatch for STILL-UNSUPPORTED methods
+// =============================================================================
+//
+// Mojo sibling of the Go block: #1448 documents `/* @client */` as the
+// universal workaround for any Array/String method the template
+// adapters can't lower. This pins that contract for the Mojo adapter —
+// wrapping the unsupported expression in the directive must clear the
+// BF021/BF101 build error the bare form raises and emit a client-only
+// placeholder so the Mojo SSR pass renders valid `.html.ep` that the
+// client runtime fills at hydration.
+//
+// Same silent-footgun caveat as Go: the unsupported *string* methods
+// raise NO build diagnostic — bare `.startsWith` / `.repeat` / … lower
+// to a Perl hash-deref-and-call (`$name->{startsWith}('a')`) that
+// passes the adapter gate, then dies at render with
+// `Can't use string (...) as a HASH ref while "strict refs"`.
+// `/* @client */` is the only escape hatch, so these tests pin it.
+describe('MojoAdapter - #1448 @client escape hatch (unsupported methods)', () => {
+  function emit(expr: string, client: boolean) {
+    const marker = client ? '/* @client */ ' : ''
+    const adapter = new MojoAdapter()
+    const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+export function C() {
+  const [items, setItems] = createSignal<{ name: string; n: number; tags: string[] }[]>([])
+  const [name, setName] = createSignal("x")
+  return <div>{${marker}${expr}}</div>
+}
+`, adapter)
+    const template = adapter.generate(ir).template ?? ''
+    return { errors: adapter.errors ?? [], template }
+  }
+
+  function emitLoop(chain: string, client: boolean) {
+    const marker = client ? '/* @client */ ' : ''
+    const adapter = new MojoAdapter()
+    const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+export function C() {
+  const [items, setItems] = createSignal<{ name: string; n: number }[]>([])
+  const myCmp = (a: { n: number }, b: { n: number }) => a.n - b.n
+  return <ul>{${marker}${chain}}</ul>
+}
+`, adapter)
+    const template = adapter.generate(ir).template ?? ''
+    return { errors: adapter.errors ?? [], template }
+  }
+
+  // Tier C array methods — bare form raises BF101 at build time.
+  const unsupportedArray: Array<[string, string]> = [
+    ['reduce', `items().reduce((a, b) => a + b.n, 0)`],
+    ['flatMap', `items().flatMap(i => i.tags)`],
+    ['flat', `items().flat()`],
+  ]
+  for (const [name, expr] of unsupportedArray) {
+    test(`array .${name}: bare raises BF101, @client clears it + emits client placeholder`, () => {
+      const bare = emit(expr, false)
+      expect(bare.errors.some(e => e.code === 'BF101')).toBe(true)
+
+      const guarded = emit(expr, true)
+      expect(guarded.errors).toEqual([])
+      // Client-only text slot → `<%== bf->comment("client:sN") %>`.
+      expect(guarded.template).toMatch(/bf->comment\("client:s\d+"\)/)
+    })
+  }
+
+  // Tier B/C string methods — bare form emits an INVALID Perl
+  // hash-deref-and-call with NO build error (the silent footgun).
+  const unsupportedString: Array<[string, string, string]> = [
+    ['split', `name().split(",")`, '->{split}'],
+    ['startsWith', `name().startsWith("a")`, '->{startsWith}'],
+    ['endsWith', `name().endsWith("z")`, '->{endsWith}'],
+    ['replace', `name().replace("a", "b")`, '->{replace}'],
+    ['repeat', `name().repeat(3)`, '->{repeat}'],
+    ['padStart', `name().padStart(5, "0")`, '->{padStart}'],
+    ['padEnd', `name().padEnd(5, "0")`, '->{padEnd}'],
+    ['charAt', `name().charAt(0)`, '->{charAt}'],
+  ]
+  for (const [name, expr, badEmit] of unsupportedString) {
+    test(`string .${name}: bare emits invalid Perl deref, @client emits client placeholder`, () => {
+      const bare = emit(expr, false)
+      // Documents the footgun: no BF101 guard, invalid template emitted.
+      expect(bare.errors.filter(e => e.code === 'BF101')).toEqual([])
+      expect(bare.template).toContain(badEmit)
+
+      const guarded = emit(expr, true)
+      expect(guarded.errors).toEqual([])
+      expect(guarded.template).toMatch(/bf->comment\("client:s\d+"\)/)
+      expect(guarded.template).not.toContain(badEmit)
+    })
+  }
+
+  // Tier B `.sort` / `.toSorted` follow-ups still refused with BF021.
+  // The Mojo client-only loop placeholder is an empty element (the
+  // client runtime repopulates it via the `bf-s` scope marker), so the
+  // contract here is: no errors + the comparator never lowers + no
+  // rendered `<li>` survives.
+  const unsupportedSort: Array<[string, string]> = [
+    ['function-reference comparator', `items().toSorted(myCmp).map(x => <li key={x.name}>{x.name}</li>)`],
+    ['localeCompare locale/options arg', `items().toSorted((a, b) => a.name.localeCompare(b.name, "ja", { numeric: true })).map(x => <li key={x.name}>{x.name}</li>)`],
+  ]
+  for (const [label, chain] of unsupportedSort) {
+    test(`sort follow-up (${label}): bare raises BF021, @client clears it`, () => {
+      const bare = compileJSX(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+export function C() {
+  const [items, setItems] = createSignal<{ name: string; n: number }[]>([])
+  const myCmp = (a: { n: number }, b: { n: number }) => a.n - b.n
+  return <ul>{${chain}}</ul>
+}
+`.trimStart(), 'test.tsx', { adapter: new MojoAdapter() })
+      expect(bare.errors?.some(e => e.code === 'BF021')).toBe(true)
+
+      const guarded = emitLoop(chain, true)
+      expect(guarded.errors).toEqual([])
+      // Empty client-only loop placeholder — no item rows emitted SSR.
+      expect(guarded.template).not.toContain('<li')
+      expect(guarded.template).not.toContain('localeCompare')
+    })
+  }
+
+  // End-to-end proof via perl + Mojolicious: the bare unsupported form
+  // crashes Mojo template execution, while the `@client` form renders a
+  // `<!--bf-client:sN-->` placeholder. Skipped on hosts without
+  // Mojolicious installed.
+  test('e2e: bare string method crashes perl render, @client renders placeholder', async () => {
+    const guarded = `
+"use client"
+import { createSignal } from "@barefootjs/client"
+export function C() {
+  const [name, setName] = createSignal("hello")
+  return <div>{/* @client */ name().repeat(3)}</div>
+}
+`
+    const bareSrc = guarded.replace('/* @client */ ', '')
+    try {
+      const html = await renderMojoComponent({
+        source: guarded.trimStart(),
+        adapter: new MojoAdapter(),
+      })
+      expect(html).toContain('<!--bf-client:s0-->')
+    } catch (err) {
+      if (err instanceof PerlNotAvailableError) {
+        console.log('Skipping #1448 @client e2e: perl/Mojolicious not found')
+        return
+      }
+      throw err
+    }
+    // Bare form must fail Mojo template execution (no @client guard).
+    await expect(
+      renderMojoComponent({
+        source: bareSrc.trimStart(),
+        adapter: new MojoAdapter(),
+      }),
+    ).rejects.toThrow(/HASH ref/)
+  })
+})


### PR DESCRIPTION
## What

Tests whether the **still-unsupported** Array/String methods catalogued in #1448 can be worked around with the `/* @client */` directive on the **Go** and **Mojolicious (Perl)** template adapters — exactly the question raised in the issue's "Workaround (today)" section.

Answer: **yes — `/* @client */` is a working escape hatch for every unsupported entry on both adapters.** This PR pins that contract with regression tests, and surfaces an important caveat along the way.

## Findings

For each unsupported method, the bare form vs. `/* @client */` form was checked at both the **template-generation** level and the **end-to-end render** level (`go run` / `perl` + Mojolicious, both available and exercised in this run).

| Group | Bare form | `/* @client */` form |
|---|---|---|
| **Tier C array** (`reduce`, `flatMap`, `flat`) | Build error **BF101** | ✅ no error, emits client placeholder |
| **Tier B/C string** (`split`, `startsWith`, `endsWith`, `replace`, `repeat`, `padStart`, `padEnd`, `charAt`) | ⚠️ **no build error** — emits invalid template, crashes at render | ✅ no error, emits client placeholder |
| **Tier B sort follow-ups** (function-reference comparator, `localeCompare` locale/options arg) | Build error **BF021** | ✅ no error, emits client placeholder |

In all cases `/* @client */`:
- Go → `{{bfComment "client:sN"}}` (text) / `{{bfComment "loop:lN"}}` (loop), rendering `<!--bf-client:sN-->`.
- Mojo → `<%== bf->comment("client:sN") %>` (text) / empty client-only element (loop), rendering `<!--bf-client:sN-->`.

### ⚠️ Caveat worth noting on the issue

The unsupported **string methods are a silent footgun**. Unlike the unsupported array methods (which surface **BF101** at build time), bare `.startsWith` / `.repeat` / … lower to a host method/deref expression that passes the adapter gate with **no diagnostic**, then crashes at render:

- Go: `{{.Name.StartsWith "a"}}` → `can't evaluate field StartsWith in type string`
- Mojo: `$name->{startsWith}('a')` → `Can't use string ("hello") as a HASH ref while "strict refs" in use`

So `/* @client */` works as the escape hatch, but a user who forgets it gets no compile-time signal — only a render-time crash. Might be worth a follow-up to raise BF101 for unsupported string methods so the build fails loudly (as it already does for the array methods).

## Tests added

- `packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts` — `GoTemplateAdapter - #1448 @client escape hatch (unsupported methods)` (14 tests)
- `packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts` — `MojoAdapter - #1448 @client escape hatch (unsupported methods)` (14 tests)

Each block asserts the bare-vs-`@client` contract at the template level plus an availability-gated `go run` / `perl + Mojolicious` end-to-end render.

## Verification

- Go adapter suite: **341 pass / 3 skip / 0 fail** (`go run` e2e exercised)
- Mojo adapter suite: **301 pass / 5 skip / 0 fail** (`perl + Mojolicious` e2e exercised)

https://claude.ai/code/session_01EfcSEzojzV2x9e9P2gS7Lh

---
_Generated by [Claude Code](https://claude.ai/code/session_01EfcSEzojzV2x9e9P2gS7Lh)_