### PR TITLE
fix(adapters): raise BF101 for unsupported String methods at build time (#1448)

### DIFF
--- a/.changeset/unsupported-string-methods-bf101.md
+++ b/.changeset/unsupported-string-methods-bf101.md
@@ -1,0 +1,10 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/mojolicious": patch
+---
+
+Raise BF101 at build time for unsupported `String.prototype` methods on the template-language adapters (#1448 follow-up).
+
+Methods that have no SSR lowering — `split`, `startsWith`, `endsWith`, `replace`, `replaceAll`, `repeat`, `padStart`, `padEnd`, `charAt`, `charCodeAt`, `codePointAt`, `normalize`, `substring`, `substr`, `match`, `matchAll`, `search` — were previously absent from the `UNSUPPORTED_METHODS` gate, so `isSupported` reported them supported and the Go / Mojolicious adapters emitted an invalid raw method call (`{{.Name.StartsWith "a"}}` / `$name->{startsWith}('a')`) that produced no build diagnostic and only crashed at template-render time.
+
+They now surface BF101 with an actionable `/* @client */` suggestion (parity with the unsupported array methods), and the adapter degrades to a safe empty slot instead of emitting template that fails at render. The Mojo adapter routes these through the AST path so the shared `isSupported` gate fires rather than the regex pipeline mangling them. The `/* @client */` escape hatch continues to work for any of these expressions.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -1917,19 +1917,20 @@ describe('GoTemplateAdapter - #1448 Tier A/B fixture-driven lowering pins', () =
 // The catalogue in #1448 documents `/* @client */` as the universal
 // workaround for any Array/String method shape the template adapters
 // can't lower. This block pins that contract for the Go adapter: for
-// every remaining unsupported entry, wrapping the expression in
-// `/* @client */` must (a) clear the BF021/BF101 build error the bare
-// form raises and (b) emit a client-only placeholder so the Go SSR
-// pass renders valid template that the client runtime fills at
-// hydration.
+// every remaining unsupported entry, the BARE form must surface a
+// BF021/BF101 build error (so the user is told to act), and wrapping
+// the expression in `/* @client */` must clear that error and emit a
+// client-only placeholder so the Go SSR pass renders valid template
+// the client runtime fills at hydration.
 //
-// Why this matters beyond "no error": the unsupported *string* methods
-// are a silent footgun. Unlike the unsupported array methods (which
-// surface BF101 at build time), bare `.startsWith` / `.repeat` / …
-// lower to a Go method-call expression (`{{.Name.StartsWith "a"}}`)
-// that passes the adapter's gate with NO diagnostic — then explodes at
-// `go run` time with `can't evaluate field StartsWith in type string`.
-// `/* @client */` is the only escape hatch, so these tests pin it.
+// History (#1448 follow-up): the unsupported *string* methods used to
+// be a silent footgun — bare `.startsWith` / `.repeat` / … lowered to
+// a Go method-call expression (`{{.Name.StartsWith "a"}}`) that passed
+// the adapter's gate with NO diagnostic, then exploded at `go run`
+// time with `can't evaluate field StartsWith in type string`. They are
+// now listed in `UNSUPPORTED_METHODS`, so `isSupported` refuses them
+// and `convertExpressionToGo` records BF101 — the same treatment the
+// unsupported array methods already got. These tests pin that parity.
 describe('GoTemplateAdapter - #1448 @client escape hatch (unsupported methods)', () => {
   // Compile a single expression placed in `<div>` text position, with
   // and without the directive, and return both the build errors and
@@ -1970,49 +1971,37 @@ export function C() {
     return { errors: adapter.errors ?? [], template }
   }
 
-  // Tier C array methods — bare form raises BF101 at build time.
-  const unsupportedArray: Array<[string, string]> = [
-    ['reduce', `items().reduce((a, b) => a + b.n, 0)`],
-    ['flatMap', `items().flatMap(i => i.tags)`],
-    ['flat', `items().flat()`],
+  // Unsupported methods that surface as BF101 at build time: Tier C
+  // array methods + Tier B/C string methods. `badEmit` is the invalid
+  // Go fragment that must NOT survive into the template (the pre-fix
+  // silent-footgun output for the string rows).
+  const unsupported: Array<{ name: string; expr: string; badEmit: string }> = [
+    // Tier C array methods.
+    { name: 'reduce', expr: `items().reduce((a, b) => a + b.n, 0)`, badEmit: '.Reduce' },
+    { name: 'flatMap', expr: `items().flatMap(i => i.tags)`, badEmit: '.FlatMap' },
+    { name: 'flat', expr: `items().flat()`, badEmit: '.Flat' },
+    // Tier B/C string methods — previously slipped through with no
+    // diagnostic; now gated by `UNSUPPORTED_METHODS`.
+    { name: 'split', expr: `name().split(",")`, badEmit: '.Name.Split' },
+    { name: 'startsWith', expr: `name().startsWith("a")`, badEmit: '.Name.StartsWith' },
+    { name: 'endsWith', expr: `name().endsWith("z")`, badEmit: '.Name.EndsWith' },
+    { name: 'replace', expr: `name().replace("a", "b")`, badEmit: '.Name.Replace' },
+    { name: 'repeat', expr: `name().repeat(3)`, badEmit: '.Name.Repeat' },
+    { name: 'padStart', expr: `name().padStart(5, "0")`, badEmit: '.Name.PadStart' },
+    { name: 'padEnd', expr: `name().padEnd(5, "0")`, badEmit: '.Name.PadEnd' },
+    { name: 'charAt', expr: `name().charAt(0)`, badEmit: '.Name.CharAt' },
   ]
-  for (const [name, expr] of unsupportedArray) {
-    test(`array .${name}: bare raises BF101, @client clears it + emits client placeholder`, () => {
+  for (const { name, expr, badEmit } of unsupported) {
+    test(`.${name}: bare raises BF101, @client clears it + emits client placeholder`, () => {
       const bare = emit(expr, false)
       expect(bare.errors.some(e => e.code === 'BF101')).toBe(true)
+      // The unlowerable method call must NOT leak into the template;
+      // the adapter degrades to a safe empty slot alongside the error.
+      expect(bare.template).not.toContain(badEmit)
 
       const guarded = emit(expr, true)
       expect(guarded.errors).toEqual([])
       // Client-only text slot → `{{bfComment "client:sN"}}` placeholder.
-      expect(guarded.template).toMatch(/bfComment "client:s\d+"/)
-      // The unlowerable expression must NOT survive into the template.
-      expect(guarded.template).not.toContain('.Reduce')
-      expect(guarded.template).not.toContain('.FlatMap')
-    })
-  }
-
-  // Tier B/C string methods — bare form emits an INVALID Go method
-  // call with NO build error (the silent footgun). `@client` is the
-  // only thing that prevents the render-time crash.
-  const unsupportedString: Array<[string, string, string]> = [
-    ['split', `name().split(",")`, '.Name.Split'],
-    ['startsWith', `name().startsWith("a")`, '.Name.StartsWith'],
-    ['endsWith', `name().endsWith("z")`, '.Name.EndsWith'],
-    ['replace', `name().replace("a", "b")`, '.Name.Replace'],
-    ['repeat', `name().repeat(3)`, '.Name.Repeat'],
-    ['padStart', `name().padStart(5, "0")`, '.Name.PadStart'],
-    ['padEnd', `name().padEnd(5, "0")`, '.Name.PadEnd'],
-    ['charAt', `name().charAt(0)`, '.Name.CharAt'],
-  ]
-  for (const [name, expr, badEmit] of unsupportedString) {
-    test(`string .${name}: bare emits invalid Go method call, @client emits client placeholder`, () => {
-      const bare = emit(expr, false)
-      // Documents the footgun: no BF101 guard, invalid template emitted.
-      expect(bare.errors.filter(e => e.code === 'BF101')).toEqual([])
-      expect(bare.template).toContain(badEmit)
-
-      const guarded = emit(expr, true)
-      expect(guarded.errors).toEqual([])
       expect(guarded.template).toMatch(/bfComment "client:s\d+"/)
       expect(guarded.template).not.toContain(badEmit)
     })
@@ -2043,22 +2032,25 @@ export function C() {
     })
   }
 
-  // End-to-end proof via `go run`: the bare unsupported form crashes
-  // the Go template execution, while the `@client` form renders a
-  // `<!--bf-client:sN-->` placeholder. Skipped on hosts without Go.
-  test('e2e: bare string method crashes go render, @client renders placeholder', async () => {
-    const guarded = `
+  // End-to-end proof via `go run`: the `@client` form renders a
+  // `<!--bf-client:sN-->` placeholder. The bare form is now caught at
+  // build with BF101 and degrades to an empty, render-safe slot (no
+  // more `can't evaluate field …` crash), so we assert the build error
+  // rather than a render crash. Skipped on hosts without Go.
+  test('e2e: @client renders placeholder; bare is caught at build with BF101', async () => {
+    const bare = emit(`name().repeat(3)`, false)
+    expect(bare.errors.some(e => e.code === 'BF101')).toBe(true)
+
+    try {
+      const html = await renderGoTemplateComponent({
+        source: `
 "use client"
 import { createSignal } from "@barefootjs/client"
 export function C() {
   const [name, setName] = createSignal("hello")
   return <div>{/* @client */ name().repeat(3)}</div>
 }
-`
-    const bareSrc = guarded.replace('/* @client */ ', '')
-    try {
-      const html = await renderGoTemplateComponent({
-        source: guarded.trimStart(),
+`.trimStart(),
         adapter: new GoTemplateAdapter(),
       })
       expect(html).toContain('<!--bf-client:s0-->')
@@ -2069,12 +2061,5 @@ export function C() {
       }
       throw err
     }
-    // Bare form must fail Go template execution (no @client guard).
-    await expect(
-      renderGoTemplateComponent({
-        source: bareSrc.trimStart(),
-        adapter: new GoTemplateAdapter(),
-      }),
-    ).rejects.toThrow(/can't evaluate field Repeat in type string/)
   })
 })

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -2007,6 +2007,25 @@ export function C() {
     })
   }
 
+  // Predicate-level use of an unsupported string method also fails the
+  // build loudly (intended): a `.filter(t => t.name.startsWith("a"))`
+  // whose predicate calls one of the gated methods now refuses the whole
+  // loop with BF101 (via the shared `isSupported` predicate gate in
+  // jsx-to-ir) rather than lowering to a broken `.StartsWith` inside the
+  // range. Pinning this so the loud-failure contract can't silently
+  // regress back to the old emit-broken-template behaviour.
+  test('unsupported string method inside a .filter() predicate raises BF101', () => {
+    const result = compileJSX(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+export function C() {
+  const [items, setItems] = createSignal<{ name: string }[]>([])
+  return <ul>{items().filter(t => t.name.startsWith("a")).map(t => <li key={t.name}>{t.name}</li>)}</ul>
+}
+`.trimStart(), 'test.tsx', { adapter: new GoTemplateAdapter() })
+    expect(result.errors?.some(e => e.code === 'BF101')).toBe(true)
+  })
+
   // Tier B `.sort` / `.toSorted` follow-ups still refused with BF021.
   const unsupportedSort: Array<[string, string]> = [
     ['function-reference comparator', `items().toSorted(myCmp).map(x => <li key={x.name}>{x.name}</li>)`],

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -979,17 +979,19 @@ describe('MojoAdapter - #1448 Tier A/B fixture-driven lowering pins', () => {
 // Mojo sibling of the Go block: #1448 documents `/* @client */` as the
 // universal workaround for any Array/String method the template
 // adapters can't lower. This pins that contract for the Mojo adapter —
-// wrapping the unsupported expression in the directive must clear the
-// BF021/BF101 build error the bare form raises and emit a client-only
-// placeholder so the Mojo SSR pass renders valid `.html.ep` that the
-// client runtime fills at hydration.
+// the BARE form must surface a BF021/BF101 build error, and wrapping
+// the expression in the directive must clear it and emit a client-only
+// placeholder so the Mojo SSR pass renders valid `.html.ep` the client
+// runtime fills at hydration.
 //
-// Same silent-footgun caveat as Go: the unsupported *string* methods
-// raise NO build diagnostic — bare `.startsWith` / `.repeat` / … lower
-// to a Perl hash-deref-and-call (`$name->{startsWith}('a')`) that
-// passes the adapter gate, then dies at render with
-// `Can't use string (...) as a HASH ref while "strict refs"`.
-// `/* @client */` is the only escape hatch, so these tests pin it.
+// History (#1448 follow-up): the unsupported *string* methods used to
+// raise NO build diagnostic — bare `.startsWith` / `.repeat` / … fell
+// into the regex pipeline and lowered to a Perl hash-deref-and-call
+// (`$name->{startsWith}('a')`) that passed the gate, then died at
+// render with `Can't use string (...) as a HASH ref while "strict
+// refs"`. They are now routed through the AST path in
+// `convertExpressionToPerl` so `isSupported`'s `UNSUPPORTED_METHODS`
+// gate fires BF101 — parity with the Go adapter. These tests pin it.
 describe('MojoAdapter - #1448 @client escape hatch (unsupported methods)', () => {
   function emit(expr: string, client: boolean) {
     const marker = client ? '/* @client */ ' : ''
@@ -1023,45 +1025,37 @@ export function C() {
     return { errors: adapter.errors ?? [], template }
   }
 
-  // Tier C array methods — bare form raises BF101 at build time.
-  const unsupportedArray: Array<[string, string]> = [
-    ['reduce', `items().reduce((a, b) => a + b.n, 0)`],
-    ['flatMap', `items().flatMap(i => i.tags)`],
-    ['flat', `items().flat()`],
+  // Unsupported methods that surface as BF101 at build time: Tier C
+  // array methods + Tier B/C string methods. `badEmit` is the invalid
+  // Perl fragment that must NOT survive into the template (the pre-fix
+  // silent-footgun output for the string rows).
+  const unsupported: Array<{ name: string; expr: string; badEmit: string }> = [
+    // Tier C array methods.
+    { name: 'reduce', expr: `items().reduce((a, b) => a + b.n, 0)`, badEmit: '->{reduce}' },
+    { name: 'flatMap', expr: `items().flatMap(i => i.tags)`, badEmit: '->{flatMap}' },
+    { name: 'flat', expr: `items().flat()`, badEmit: '->{flat}' },
+    // Tier B/C string methods — previously slipped through with no
+    // diagnostic; now routed through the AST / `isSupported` gate.
+    { name: 'split', expr: `name().split(",")`, badEmit: '->{split}' },
+    { name: 'startsWith', expr: `name().startsWith("a")`, badEmit: '->{startsWith}' },
+    { name: 'endsWith', expr: `name().endsWith("z")`, badEmit: '->{endsWith}' },
+    { name: 'replace', expr: `name().replace("a", "b")`, badEmit: '->{replace}' },
+    { name: 'repeat', expr: `name().repeat(3)`, badEmit: '->{repeat}' },
+    { name: 'padStart', expr: `name().padStart(5, "0")`, badEmit: '->{padStart}' },
+    { name: 'padEnd', expr: `name().padEnd(5, "0")`, badEmit: '->{padEnd}' },
+    { name: 'charAt', expr: `name().charAt(0)`, badEmit: '->{charAt}' },
   ]
-  for (const [name, expr] of unsupportedArray) {
-    test(`array .${name}: bare raises BF101, @client clears it + emits client placeholder`, () => {
+  for (const { name, expr, badEmit } of unsupported) {
+    test(`.${name}: bare raises BF101, @client clears it + emits client placeholder`, () => {
       const bare = emit(expr, false)
       expect(bare.errors.some(e => e.code === 'BF101')).toBe(true)
+      // The invalid deref-and-call must NOT leak into the template;
+      // the adapter degrades to a safe empty slot alongside the error.
+      expect(bare.template).not.toContain(badEmit)
 
       const guarded = emit(expr, true)
       expect(guarded.errors).toEqual([])
       // Client-only text slot → `<%== bf->comment("client:sN") %>`.
-      expect(guarded.template).toMatch(/bf->comment\("client:s\d+"\)/)
-    })
-  }
-
-  // Tier B/C string methods — bare form emits an INVALID Perl
-  // hash-deref-and-call with NO build error (the silent footgun).
-  const unsupportedString: Array<[string, string, string]> = [
-    ['split', `name().split(",")`, '->{split}'],
-    ['startsWith', `name().startsWith("a")`, '->{startsWith}'],
-    ['endsWith', `name().endsWith("z")`, '->{endsWith}'],
-    ['replace', `name().replace("a", "b")`, '->{replace}'],
-    ['repeat', `name().repeat(3)`, '->{repeat}'],
-    ['padStart', `name().padStart(5, "0")`, '->{padStart}'],
-    ['padEnd', `name().padEnd(5, "0")`, '->{padEnd}'],
-    ['charAt', `name().charAt(0)`, '->{charAt}'],
-  ]
-  for (const [name, expr, badEmit] of unsupportedString) {
-    test(`string .${name}: bare emits invalid Perl deref, @client emits client placeholder`, () => {
-      const bare = emit(expr, false)
-      // Documents the footgun: no BF101 guard, invalid template emitted.
-      expect(bare.errors.filter(e => e.code === 'BF101')).toEqual([])
-      expect(bare.template).toContain(badEmit)
-
-      const guarded = emit(expr, true)
-      expect(guarded.errors).toEqual([])
       expect(guarded.template).toMatch(/bf->comment\("client:s\d+"\)/)
       expect(guarded.template).not.toContain(badEmit)
     })
@@ -1097,23 +1091,25 @@ export function C() {
     })
   }
 
-  // End-to-end proof via perl + Mojolicious: the bare unsupported form
-  // crashes Mojo template execution, while the `@client` form renders a
-  // `<!--bf-client:sN-->` placeholder. Skipped on hosts without
-  // Mojolicious installed.
-  test('e2e: bare string method crashes perl render, @client renders placeholder', async () => {
-    const guarded = `
+  // End-to-end proof via perl + Mojolicious: the `@client` form renders
+  // a `<!--bf-client:sN-->` placeholder. The bare form is now caught at
+  // build with BF101 and degrades to an empty, render-safe slot (no
+  // more `HASH ref` crash), so we assert the build error rather than a
+  // render crash. Skipped on hosts without Mojolicious installed.
+  test('e2e: @client renders placeholder; bare is caught at build with BF101', async () => {
+    const bare = emit(`name().repeat(3)`, false)
+    expect(bare.errors.some(e => e.code === 'BF101')).toBe(true)
+
+    try {
+      const html = await renderMojoComponent({
+        source: `
 "use client"
 import { createSignal } from "@barefootjs/client"
 export function C() {
   const [name, setName] = createSignal("hello")
   return <div>{/* @client */ name().repeat(3)}</div>
 }
-`
-    const bareSrc = guarded.replace('/* @client */ ', '')
-    try {
-      const html = await renderMojoComponent({
-        source: guarded.trimStart(),
+`.trimStart(),
         adapter: new MojoAdapter(),
       })
       expect(html).toContain('<!--bf-client:s0-->')
@@ -1124,12 +1120,5 @@ export function C() {
       }
       throw err
     }
-    // Bare form must fail Mojo template execution (no @client guard).
-    await expect(
-      renderMojoComponent({
-        source: bareSrc.trimStart(),
-        adapter: new MojoAdapter(),
-      }),
-    ).rejects.toThrow(/HASH ref/)
   })
 })

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -1086,6 +1086,25 @@ export function C(props: { config: string }) {
     expect(template).not.toContain('$JSON->{stringify}')
   })
 
+  // Predicate-level use of an unsupported string method also fails the
+  // build loudly (intended): a `.filter(t => t.name.startsWith("a"))`
+  // whose predicate calls one of the gated methods now refuses the whole
+  // loop with BF101 (via the shared `isSupported` predicate gate in
+  // jsx-to-ir) rather than lowering to a broken `->{startsWith}` inside
+  // the grep. Pinning this so the loud-failure contract can't silently
+  // regress back to the old emit-broken-template behaviour.
+  test('unsupported string method inside a .filter() predicate raises BF101', () => {
+    const result = compileJSX(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+export function C() {
+  const [items, setItems] = createSignal<{ name: string }[]>([])
+  return <ul>{items().filter(t => t.name.startsWith("a")).map(t => <li key={t.name}>{t.name}</li>)}</ul>
+}
+`.trimStart(), 'test.tsx', { adapter: new MojoAdapter() })
+    expect(result.errors?.some(e => e.code === 'BF101')).toBe(true)
+  })
+
   // Tier B `.sort` / `.toSorted` follow-ups still refused with BF021.
   // The Mojo client-only loop placeholder is an empty element (the
   // client runtime repopulates it via the `bf-s` scope marker), so the

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -1061,6 +1061,31 @@ export function C() {
     })
   }
 
+  // Routing guard regression: the unsupported-string-method regex is an
+  // unanchored substring test, and these names (`replace`, `split`, …)
+  // are ordinary words that also appear inside string literals. A
+  // SUPPORTED expression whose literal merely contains `.replace(` must
+  // NOT be diverted onto the AST path — doing so would bypass
+  // `rewriteTemplatePrimitives` and silently emit broken Perl
+  // (`$JSON->{stringify} + '.replace('`). The `isSupported` gate on the
+  // regex keeps such expressions on the normal pipeline.
+  test('string-method regex does not misroute a supported expr with a method name inside a literal', () => {
+    const adapter = new MojoAdapter()
+    const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+export function C(props: { config: string }) {
+  return <div>{JSON.stringify(props.config) + ".replace("}</div>
+}
+`, adapter)
+    const template = adapter.generate(ir).template ?? ''
+    expect(adapter.errors ?? []).toEqual([])
+    // templatePrimitive lowering preserved...
+    expect(template).toContain('bf->json($config)')
+    // ...and the literal is NOT mangled into a hash-deref.
+    expect(template).not.toContain('$JSON->{stringify}')
+  })
+
   // Tier B `.sort` / `.toSorted` follow-ups still refused with BF021.
   // The Mojo client-only loop placeholder is an empty element (the
   // client runtime repopulates it via the `bf-s` scope marker), so the

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1227,49 +1227,6 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       return this.convertHigherOrderExpr(expr)
     }
 
-    // #1448 follow-up — String methods with NO lowering yet. Same
-    // routing rationale as the row above: without this, the regex
-    // pipeline mangles `name().startsWith('a')` into
-    // `$name->{startsWith}('a')` (a hash-deref-and-call that dies at
-    // render with "Can't use string (...) as a HASH ref"), emitting no
-    // build diagnostic. Routing through the AST path lets
-    // `isSupported`'s `UNSUPPORTED_METHODS` gate fire BF101 instead,
-    // matching Go. Stays in sync with the string-method block in
-    // `UNSUPPORTED_METHODS`; each name drops off as its lowering lands.
-    //
-    // The regex is only a cheap pre-filter: because these method names
-    // (`replace`, `match`, `split`, `search`, …) are ordinary words
-    // that also occur inside string literals, an unanchored substring
-    // match alone would misroute a SUPPORTED expression whose literal
-    // merely contains `.replace(` (e.g. `JSON.stringify(x) + ".replace("`)
-    // onto a path that bypasses the `rewriteTemplatePrimitives` pass
-    // below and emits broken Perl. So confirm against the parsed AST
-    // via `isSupported`: only a genuinely unsupported expression (an
-    // actual unsupported-method call) is refused; supported expressions
-    // fall through to the normal pipeline unchanged. Emit BF101 inline
-    // from the `support` we already have (matching the `find`/`findIndex`
-    // gap branch below) rather than re-parsing inside
-    // `convertHigherOrderExpr`.
-    if (/\.\s*(?:split|startsWith|endsWith|replace|replaceAll|repeat|padStart|padEnd|charAt|charCodeAt|codePointAt|normalize|substring|substr|match|matchAll|search)\s*\(/.test(expr)) {
-      const support = isSupported(parseExpression(expr))
-      if (!support.supported) {
-        this.errors.push({
-          code: 'BF101',
-          severity: 'error',
-          message: `Expression not supported: ${expr.trim()}`,
-          loc: { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
-          suggestion: {
-            message: support.reason
-              ? `${support.reason}\n\nOptions:\n1. Use /* @client */ for client-side evaluation\n2. Pre-compute the value in Perl`
-              : 'Options:\n1. Use /* @client */ for client-side evaluation\n2. Pre-compute the value in Perl',
-          },
-        })
-        return "''"
-      }
-      // Supported (the method name was inside a string literal, not an
-      // actual unsupported call) — fall through to the normal pipeline.
-    }
-
     // #1443/#1448: `.join(sep)` is lifted by the parser to the
     // `array-method` IR kind, and `renderArrayMethod`'s `case 'join'`
     // already emits the correct `join(sep, @{arr})`. Route the
@@ -1299,6 +1256,44 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
         },
       })
       return "''"
+    }
+
+    // #1448 follow-up — generic unsupported-method gate. Any member
+    // method call (`.foo(...)`) that reached here without matching one
+    // of the supported routes above is checked against the parser's
+    // `isSupported`. Methods listed in the parser's `UNSUPPORTED_METHODS`
+    // (e.g. `String.prototype.startsWith` / `.split` / `.replace`, and
+    // any future un-lowered method) report unsupported and are refused
+    // with BF101 here, instead of being mangled by the regex pipeline
+    // below into a `$obj->{method}(...)` hash-deref that dies at render
+    // ("Can't use string (...) as a HASH ref") with no build diagnostic.
+    //
+    // Driving this off `isSupported` rather than a hand-maintained
+    // method-name regex keeps the parser's `UNSUPPORTED_METHODS` the
+    // single source of truth (matching the Go adapter's
+    // `convertExpressionToGo`, which has no such list): new unsupported
+    // methods need no edit here, and a method that gains a lowering
+    // stops being refused the moment the parser recognises it.
+    // Supported calls — templatePrimitives like `JSON.stringify(x)` /
+    // `Math.floor(x)`, and any expression whose only method-name match
+    // is inside a string literal (`name() + ".replace("`) — report
+    // supported and fall through to the normal pipeline unchanged.
+    if (/\.\s*[A-Za-z_$][\w$]*\s*\(/.test(expr)) {
+      const support = isSupported(parseExpression(expr))
+      if (!support.supported) {
+        this.errors.push({
+          code: 'BF101',
+          severity: 'error',
+          message: `Expression not supported: ${expr.trim()}`,
+          loc: { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+          suggestion: {
+            message: support.reason
+              ? `${support.reason}\n\nOptions:\n1. Use /* @client */ for client-side evaluation\n2. Pre-compute the value in Perl`
+              : 'Options:\n1. Use /* @client */ for client-side evaluation\n2. Pre-compute the value in Perl',
+          },
+        })
+        return "''"
+      }
     }
 
     // templatePrimitives substitution (#1189): rewrite identifier-path

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1242,15 +1242,32 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     // that also occur inside string literals, an unanchored substring
     // match alone would misroute a SUPPORTED expression whose literal
     // merely contains `.replace(` (e.g. `JSON.stringify(x) + ".replace("`)
-    // onto the AST path — silently bypassing the `rewriteTemplatePrimitives`
-    // pass below and emitting broken Perl. Confirm against the parsed
-    // AST via `isSupported` before diverting: only a genuinely
-    // unsupported expression (an actual unsupported-method call) is
-    // routed to `convertHigherOrderExpr` for its BF101; supported
-    // expressions fall through to the normal pipeline unchanged.
-    if (/\.\s*(?:split|startsWith|endsWith|replace|replaceAll|repeat|padStart|padEnd|charAt|charCodeAt|codePointAt|normalize|substring|substr|match|matchAll|search)\s*\(/.test(expr)
-        && !isSupported(parseExpression(expr)).supported) {
-      return this.convertHigherOrderExpr(expr)
+    // onto a path that bypasses the `rewriteTemplatePrimitives` pass
+    // below and emits broken Perl. So confirm against the parsed AST
+    // via `isSupported`: only a genuinely unsupported expression (an
+    // actual unsupported-method call) is refused; supported expressions
+    // fall through to the normal pipeline unchanged. Emit BF101 inline
+    // from the `support` we already have (matching the `find`/`findIndex`
+    // gap branch below) rather than re-parsing inside
+    // `convertHigherOrderExpr`.
+    if (/\.\s*(?:split|startsWith|endsWith|replace|replaceAll|repeat|padStart|padEnd|charAt|charCodeAt|codePointAt|normalize|substring|substr|match|matchAll|search)\s*\(/.test(expr)) {
+      const support = isSupported(parseExpression(expr))
+      if (!support.supported) {
+        this.errors.push({
+          code: 'BF101',
+          severity: 'error',
+          message: `Expression not supported: ${expr.trim()}`,
+          loc: { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+          suggestion: {
+            message: support.reason
+              ? `${support.reason}\n\nOptions:\n1. Use /* @client */ for client-side evaluation\n2. Pre-compute the value in Perl`
+              : 'Options:\n1. Use /* @client */ for client-side evaluation\n2. Pre-compute the value in Perl',
+          },
+        })
+        return "''"
+      }
+      // Supported (the method name was inside a string literal, not an
+      // actual unsupported call) — fall through to the normal pipeline.
     }
 
     // #1443/#1448: `.join(sep)` is lifted by the parser to the

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1227,6 +1227,19 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       return this.convertHigherOrderExpr(expr)
     }
 
+    // #1448 follow-up — String methods with NO lowering yet. Same
+    // routing rationale as the row above: without this, the regex
+    // pipeline mangles `name().startsWith('a')` into
+    // `$name->{startsWith}('a')` (a hash-deref-and-call that dies at
+    // render with "Can't use string (...) as a HASH ref"), emitting no
+    // build diagnostic. Routing through the AST path lets
+    // `isSupported`'s `UNSUPPORTED_METHODS` gate fire BF101 instead,
+    // matching Go. Stays in sync with the string-method block in
+    // `UNSUPPORTED_METHODS`; each name drops off as its lowering lands.
+    if (/\.\s*(?:split|startsWith|endsWith|replace|replaceAll|repeat|padStart|padEnd|charAt|charCodeAt|codePointAt|normalize|substring|substr|match|matchAll|search)\s*\(/.test(expr)) {
+      return this.convertHigherOrderExpr(expr)
+    }
+
     // #1443/#1448: `.join(sep)` is lifted by the parser to the
     // `array-method` IR kind, and `renderArrayMethod`'s `case 'join'`
     // already emits the correct `join(sep, @{arr})`. Route the

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1236,7 +1236,20 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     // `isSupported`'s `UNSUPPORTED_METHODS` gate fire BF101 instead,
     // matching Go. Stays in sync with the string-method block in
     // `UNSUPPORTED_METHODS`; each name drops off as its lowering lands.
-    if (/\.\s*(?:split|startsWith|endsWith|replace|replaceAll|repeat|padStart|padEnd|charAt|charCodeAt|codePointAt|normalize|substring|substr|match|matchAll|search)\s*\(/.test(expr)) {
+    //
+    // The regex is only a cheap pre-filter: because these method names
+    // (`replace`, `match`, `split`, `search`, …) are ordinary words
+    // that also occur inside string literals, an unanchored substring
+    // match alone would misroute a SUPPORTED expression whose literal
+    // merely contains `.replace(` (e.g. `JSON.stringify(x) + ".replace("`)
+    // onto the AST path — silently bypassing the `rewriteTemplatePrimitives`
+    // pass below and emitting broken Perl. Confirm against the parsed
+    // AST via `isSupported` before diverting: only a genuinely
+    // unsupported expression (an actual unsupported-method call) is
+    // routed to `convertHigherOrderExpr` for its BF101; supported
+    // expressions fall through to the normal pipeline unchanged.
+    if (/\.\s*(?:split|startsWith|endsWith|replace|replaceAll|repeat|padStart|padEnd|charAt|charCodeAt|codePointAt|normalize|substring|substr|match|matchAll|search)\s*\(/.test(expr)
+        && !isSupported(parseExpression(expr)).supported) {
       return this.convertHigherOrderExpr(expr)
     }
 

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -214,6 +214,21 @@ const UNSUPPORTED_METHODS = new Set([
   // `bf_lower` / `bf_upper` (Go) and Perl's native `lc` / `uc` (Mojo).
   // `trim` lowers via the `array-method` IR + `bf_trim` (Go) and a
   // Perl regex strip (Mojo).
+  //
+  // #1448 follow-up — String methods that have NO lowering yet. These
+  // were previously absent from this gate, so `isSupported` reported
+  // them "supported" and the adapters emitted a raw method call
+  // (`{{.Name.StartsWith "a"}}` on Go, `$name->{startsWith}('a')` on
+  // Mojo) with no build diagnostic — a silent footgun that only
+  // surfaced as a crash at template-render time. Listing them here
+  // makes the build fail loudly with BF101 (the same treatment the
+  // unsupported array methods above get), pointing users at the
+  // `/* @client */` escape hatch. Each name drops off as its lowering
+  // lands. See #1448 "Unsupported string methods" Tier B / Tier C.
+  'split', 'startsWith', 'endsWith', 'replace', 'replaceAll',
+  'repeat', 'padStart', 'padEnd',
+  'charAt', 'charCodeAt', 'codePointAt', 'normalize',
+  'substring', 'substr', 'match', 'matchAll', 'search',
 ])
 
 // =============================================================================
@@ -1724,7 +1739,7 @@ function checkSupport(expr: ParsedExpr): SupportResult {
           return {
             supported: false,
             level: 'L5_UNSUPPORTED',
-            reason: `Higher-order method '${methodName}()' requires client-side evaluation. Use @client directive or pre-compute in Go.`,
+            reason: `Method '${methodName}()' has no template lowering and requires client-side evaluation. Wrap the expression in /* @client */ to defer it to hydration, or pre-compute the value before rendering.`,
           }
         }
       }


### PR DESCRIPTION
## What

Follow-up to #1676. Closes the **silent-footgun** that PR surfaced: the unsupported **String** methods in the #1448 catalogue produced no build diagnostic and only crashed at template-render time. They now raise **BF101** at build time — parity with the unsupported array methods.

## Background (from #1676)

| Method group | Bare form — before this PR | Bare form — after |
|---|---|---|
| Unsupported **array** (`reduce`, `flatMap`, `flat`) | BF101 at build ✅ | unchanged |
| Unsupported **string** (`startsWith`, `repeat`, `split`, …) | ⚠️ **no diagnostic**, lowered to invalid template, crashed at render | **BF101 at build** ✅ |

Render-time crashes that used to occur:
- Go: `{{.Name.StartsWith "a"}}` → `can't evaluate field StartsWith in type string`
- Mojo: `$name->{startsWith}('a')` → `Can't use string (...) as a HASH ref while "strict refs"`

## Root cause

The string method names were absent from the central `UNSUPPORTED_METHODS` gate in `expression-parser.ts`, so `isSupported` reported them "supported" and each adapter emitted a raw method call.

## Fix

- **`packages/jsx/src/expression-parser.ts`** — add the un-lowered string methods (`split`, `startsWith`, `endsWith`, `replace`, `replaceAll`, `repeat`, `padStart`, `padEnd`, `charAt`, `charCodeAt`, `codePointAt`, `normalize`, `substring`, `substr`, `match`, `matchAll`, `search`) to `UNSUPPORTED_METHODS`. The Go adapter's `convertExpressionToGo` already routes every expression through `isSupported`, so it now records BF101 for these automatically. Also generalised the refusal message (was Go/array-specific) to point at `/* @client */`.
- **`packages/adapter-mojolicious/src/adapter/mojo-adapter.ts`** — route the same string methods through the AST path in `convertExpressionToPerl` (they previously fell into the regex pipeline that mangled them), so the shared `isSupported` gate fires BF101 instead of emitting invalid Embedded Perl.

The build now fails loudly with an actionable BF101 + `/* @client */` suggestion, and degrades to a safe empty slot instead of crashing the renderer. The `/* @client */` escape hatch continues to work exactly as #1676 verified.

## Tests

Updated the `#1448 @client escape hatch` blocks in both adapter test suites to pin the new unified behaviour (bare → BF101, `/* @client */` → client placeholder) for array **and** string methods.

## Verification (all run in isolation to avoid load-induced render timeouts)

- Go adapter suite: **341 pass / 0 fail**
- Mojo adapter suite: **301 pass / 0 fail**
- adapter-tests (conformance + CSR): **534 pass / 0 fail**
- jsx unit suite: **1770 pass** — the 4 failures are pre-existing `createMemo`/`createEffect`/`onMount` checker-path alias-resolution tests that also fail on clean `main` (confirmed by stashing this change), unrelated to it.

No regression in real components: the only repo usage of a now-gated string method in source (`slider`'s `.split('.')`) is inside a client-side helper, not template position; every `.filter`/`.map` predicate in components/fixtures uses the still-supported `.includes`.

https://claude.ai/code/session_01EfcSEzojzV2x9e9P2gS7Lh

---
_Generated by [Claude Code](https://claude.ai/code/session_01EfcSEzojzV2x9e9P2gS7Lh)_