### PR TITLE
fix(adapter-go-template): reference outer signals/props via $ root scope inside range (#1677)

### DIFF
--- a/.changeset/go-loop-outer-scope.md
+++ b/.changeset/go-loop-outer-scope.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Reference outer signals/props through Go template's `$` root scope inside a `{{range}}` loop body (#1677). Previously a reference like `sel()` or `props.x` used inside `items().map(...)` emitted `.Sel` / `.Active`, which Go resolves against the iteration element (no such field → `<nil>`); it now emits `$.Sel` / `$.Active`. The loop element's own fields stay element-scoped (`.ID`).

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -737,6 +737,48 @@ export function L(props: { active: string }) {
       expect(template).toContain('eq $.Active .ID')
       expect(template).not.toContain('eq .Active .ID')
     })
+
+    test('references an outer loop variable from a nested loop via its range var, not root', () => {
+      // In nested `{{range}}`s the inner dot is the inner element; the outer
+      // loop value is in scope as the Go range variable `$group` (declared by
+      // the outer `{{range $_, $group := .Groups}}`). A reference to the outer
+      // item from the inner body must use `$group.ID`, not `$.Group.ID` (root)
+      // nor `.ID` (inner element).
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+type Item = { id: string }
+type Group = { id: string; items: Item[] }
+export function L() {
+  const [groups] = createSignal<Group[]>([])
+  return <ul>{groups().map((group) => <li key={group.id}>{group.items.map((item) => <span key={item.id}>{group.id}:{item.id}</span>)}</li>)}</ul>
+}
+`)
+      const template = adapter.generate(ir).template
+      // Outer item referenced from the inner loop body resolves to $group.ID.
+      expect(template).toContain('$group.ID')
+      expect(template).not.toContain('$.Group.ID')
+    })
+
+    test('compares an outer loop variable in a nested loop condition via its range var', () => {
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+type Item = { id: string; groupId: string }
+type Group = { id: string; items: Item[] }
+export function L() {
+  const [groups] = createSignal<Group[]>([])
+  return <ul>{groups().map((group) => <li key={group.id}>{group.items.map((item) => group.id === item.groupId && <span key={item.id}>{item.id}</span>)}</li>)}</ul>
+}
+`)
+      const template = adapter.generate(ir).template
+      expect(template).toContain('eq $group.ID .GroupId')
+      expect(template).not.toContain('eq $.Group.ID')
+    })
   })
 
   describe('JSX children forwarding (#1203)', () => {

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -38,19 +38,17 @@ runAdapterConformanceTests({
     'return-map',
     // #1665 whole-item loop conditional. The Go adapter correctly emits the
     // per-item `<!--bf-loop-i:KEY-->` anchor, `data-key`, and conditional
-    // markers (verified by template-structure tests). Signal-array initial
-    // values are now baked into `NewXxxProps` for typed and scalar arrays
-    // (#1672), but this fixture stays skipped for two reasons that survive
-    // that change: (1) its `items` signal is an *untyped* object array, which
-    // lands in a `[]interface{}` field whose `map` items the loop body can't
-    // reach via struct field access (`.ID` → <nil>), so the bake intentionally
-    // leaves it `nil`; (2) the loop body references the outer `sel` signal,
-    // which the template emits as `.Sel` — resolved against the loop element
-    // inside `range` rather than the root scope (`$.Sel`), a separate codegen
-    // bug masked until now by the previously-empty loop and now tracked in
-    // #1677. The anchored SSR shape with rendered items is covered by Hono +
-    // CSR conformance and the runtime hydration tests.
-    // https://github.com/piconic-ai/barefootjs/issues/1677
+    // markers (verified by template-structure tests). The outer-signal scope
+    // bug that used to leave this skipped — `sel()` emitted as `.Sel` (loop
+    // element) instead of `$.Sel` (root) inside `range` — is now fixed (#1677).
+    // It stays skipped on Go for the one remaining reason: its `items` signal
+    // is an *untyped* object array, which lands in a `[]interface{}` field
+    // whose `map` items the loop body can't reach via struct field access
+    // (`.ID` → <nil>), so the #1672 bake intentionally leaves it `nil` and the
+    // SSR loop renders empty. Typing the signal (`createSignal<Item[]>`) would
+    // unblock it; the untyped path is tracked in #1680. The anchored SSR shape
+    // with rendered items is covered by Hono + CSR conformance and the runtime
+    // hydration tests. https://github.com/piconic-ai/barefootjs/issues/1680
     'loop-item-conditional',
     // #1297 fixed the harness-side IR emission gate (multi-component
     // sources now emit one `ir` file per component, and the harness
@@ -696,6 +694,48 @@ export function List() {
 }
 `)
       expect(adapter.generate(structIr).types!).toContain('Items: []Item{Item{ID: "a"}},')
+    })
+  })
+
+  describe('loop body outer-scope references (#1677)', () => {
+    test('references an outer signal inside a loop via $ root scope, not the element', () => {
+      // Inside `{{range $_, $t := .Items}}` the dot is rebound to the loop
+      // element, so a reference to the outer `sel` signal must reach the root
+      // data through Go template's `$` (`$.Sel`), not `.Sel` — which would
+      // resolve against the element struct (no `Sel` field → <nil>).
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+type Item = { id: string }
+export function L() {
+  const [items] = createSignal<Item[]>([{ id: "a" }, { id: "b" }])
+  const [sel] = createSignal("b")
+  return <ul>{items().map((t) => sel() === t.id && <li key={t.id}>{t.id}</li>)}</ul>
+}
+`)
+      const template = adapter.generate(ir).template
+      // The loop element field stays element-scoped; the outer signal is rooted.
+      expect(template).toContain('eq $.Sel .ID')
+      expect(template).not.toContain('eq .Sel .ID')
+    })
+
+    test('references an outer prop inside a loop via $ root scope', () => {
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+type Item = { id: string }
+export function L(props: { active: string }) {
+  const [items] = createSignal<Item[]>([{ id: "a" }])
+  return <ul>{items().map((t) => props.active === t.id && <li key={t.id}>{t.id}</li>)}</ul>
+}
+`)
+      const template = adapter.generate(ir).template
+      expect(template).toContain('eq $.Active .ID')
+      expect(template).not.toContain('eq .Active .ID')
     })
   })
 

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -2649,8 +2649,26 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   identifier(name: string): string {
     const currentLoopParam = this.loopParamStack[this.loopParamStack.length - 1]
     if (currentLoopParam && name === currentLoopParam) return '.'
+    // An *outer* loop's value variable (we're in a nested loop) is in scope as
+    // the Go range variable `$name` declared by that loop's `{{range … := …}}`;
+    // the inner dot no longer refers to it, and it's not a root field. (#1677)
+    if (this.isOuterLoopParam(name)) return `$${name}`
     if (this.loopVarRefCount.has(name)) return `$${name}`
     return this.rootFieldRef(name)
+  }
+
+  /**
+   * True when `name` is a loop value variable from an enclosing (not the
+   * current) loop — i.e. it sits on `loopParamStack` below the top. Such a
+   * reference resolves to the Go range variable `$name`, not the inner dot or
+   * the root data.
+   */
+  private isOuterLoopParam(name: string): boolean {
+    const top = this.loopParamStack.length - 1
+    for (let i = 0; i < top; i++) {
+      if (this.loopParamStack[i] === name) return true
+    }
+    return false
   }
 
   /**
@@ -3933,6 +3951,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
           const currentLoopParam = this.loopParamStack[this.loopParamStack.length - 1]
           if (currentLoopParam && expr.name === currentLoopParam) {
             return plain('.')
+          }
+          // Outer loop value variable (nested loop) → its range var `$name`.
+          if (this.isOuterLoopParam(expr.name)) {
+            return plain(`$${expr.name}`)
           }
           if (this.loopVarRefCount.has(expr.name)) {
             return plain(`$${expr.name}`)

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -2650,7 +2650,19 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     const currentLoopParam = this.loopParamStack[this.loopParamStack.length - 1]
     if (currentLoopParam && name === currentLoopParam) return '.'
     if (this.loopVarRefCount.has(name)) return `$${name}`
-    return `.${this.capitalizeFieldName(name)}`
+    return this.rootFieldRef(name)
+  }
+
+  /**
+   * A reference to a root-scope field — a signal, a prop, or a derived value
+   * that lives on the component's top-level data struct. Inside a `{{range}}`
+   * the dot is rebound to the iteration element, so root data must be reached
+   * through Go template's `$` (the top-level argument to Execute), which never
+   * rebinds. Outside any loop the root *is* the dot, so we emit `.Field` (#1677).
+   */
+  private rootFieldRef(name: string): string {
+    const prefix = this.loopParamStack.length > 0 ? '$.' : '.'
+    return `${prefix}${this.capitalizeFieldName(name)}`
   }
 
   literal(value: string | number | boolean | null, literalType: LiteralType): string {
@@ -2660,9 +2672,9 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   call(callee: ParsedExpr, args: ParsedExpr[], emit: (e: ParsedExpr) => string): string {
-    // Signal call: count() -> .Count
+    // Signal call: count() -> .Count (or $.Count inside a loop, #1677)
     if (callee.kind === 'identifier' && args.length === 0) {
-      return `.${this.capitalizeFieldName(callee.name)}`
+      return this.rootFieldRef(callee.name)
     }
     // Array methods (`.join` and any others added to ArrayMethod, #1443)
     // are lifted into the `array-method` IR kind at parse time, so
@@ -2726,9 +2738,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       if (templateBlock) return templateBlock
     }
 
-    // SolidJS-style props pattern: props.xxx -> .Xxx
+    // SolidJS-style props pattern: props.xxx -> .Xxx (or $.Xxx inside a loop,
+    // since props live on the root data struct, not the iteration element #1677)
     if (object.kind === 'identifier' && this.propsObjectName && object.name === this.propsObjectName) {
-      return `.${this.capitalizeFieldName(property)}`
+      return this.rootFieldRef(property)
     }
 
     // Inside a loop, the loop param variable refers to the current item
@@ -3925,7 +3938,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
             return plain(`$${expr.name}`)
           }
         }
-        return plain(`.${this.capitalizeFieldName(expr.name)}`)
+        return plain(this.rootFieldRef(expr.name))
 
       case 'literal':
         if (expr.literalType === 'string') return plain(`"${expr.value}"`)
@@ -3934,7 +3947,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
       case 'call': {
         if (expr.callee.kind === 'identifier' && expr.args.length === 0) {
-          return plain(`.${this.capitalizeFieldName(expr.callee.name)}`)
+          return plain(this.rootFieldRef(expr.callee.name))
         }
         return plain(this.renderParsedExpr(expr))
       }
@@ -3950,7 +3963,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         }
 
         if (expr.object.kind === 'identifier' && this.propsObjectName && expr.object.name === this.propsObjectName) {
-          return plain(`.${this.capitalizeFieldName(expr.property)}`)
+          return plain(this.rootFieldRef(expr.property))
         }
 
         {


### PR DESCRIPTION
## What

Fixes #1677. Inside a Go `{{range $_, $t := .Items}}` the dot (`.`) is rebound to the iteration element, so a loop body that referenced an **outer** signal or prop emitted the wrong scope:

```gotemplate
{{range $_, $t := .Items}}{{if eq .Sel .ID}}…{{end}}{{end}}
                                    ^^^^ resolved against $t → no Sel field → <nil>
```

Root-scope references (signal getters `sel()`, props `props.x`, derived values) now go through Go template's `$` — the top-level data argument, which `range`/`with` never rebind — when emitted inside a loop:

```gotemplate
{{range $_, $t := .Items}}{{if eq $.Sel .ID}}…{{end}}{{end}}
```

The loop element's own fields stay element-scoped (`.ID`).

## Why it was masked

Signal arrays always SSR-rendered an empty loop until #1672/#1675 started baking initial items, so the loop body never executed and the mis-scoped reference was never observed.

## Implementation

A shared `rootFieldRef(name)` helper returns `$.Field` inside a loop (`loopParamStack` non-empty) and `.Field` otherwise. Applied to signal calls, `props.x` access, and bare identifier fallbacks in **both** emit paths — the `ParsedExprEmitter` methods (`identifier` / `call` / `member`) and `renderConditionExpr`.

## Verification

- New adapter unit tests (`#1677`): outer signal → `$.Sel`, outer prop → `$.Active`, element field stays `.ID`.
- **Real Go** (`go1.25.6`): `items().map(t => sel() === t.id && <li/>)` now renders only the matching item server-side (`a`/`c` collapse to conditional markers, `b` renders).
- go-template **351 pass**, adapter conformance hono/mojo/go **534 pass** — all 0 fail; tsc clean.

## Follow-up tracked

`loop-item-conditional` stays skipped on Go for the **one remaining** reason — its `items` is an *untyped* object array baked as `nil` (the typed/scalar bake from #1672 can't represent it without a struct type). Filed as #1680. Its skip comment is updated; the scope reason this PR fixes is removed.

https://claude.ai/code/session_014HUbvaiJv5iDfq37uVqxCv

---
_Generated by [Claude Code](https://claude.ai/code/session_014HUbvaiJv5iDfq37uVqxCv)_