### PR TITLE
feat(adapter-go-template): synthesise a struct for untyped object-array signals (#1680)

### DIFF
--- a/.changeset/go-untyped-object-array-synth.md
+++ b/.changeset/go-untyped-object-array-synth.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Synthesise a Go struct for an untyped object-array signal so its inline initial value SSR-renders instead of staying `nil` (#1680). `createSignal([{ id: "a", n: 1 }])` now infers a struct from the literal's shape, types the signal field as a slice of it, and bakes the items — so the loop body's struct field access (`{{.ID}}`) resolves server-side. Synthesis bails to `nil` (prior behaviour) when elements don't share one shape, a value isn't a scalar literal, a key isn't a Go identifier, or the synthesised name would collide with an existing type. This also lets the `loop-item-conditional` conformance fixture render on Go.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -636,6 +636,67 @@ export function List() {
       expect(adapter.generate(ir).types!).toContain('Items: nil,')
     })
 
+    test('widens mixed int/float keys to float64 and keeps negatives (#1680)', () => {
+      // A key seen as both an integer and a fractional literal across elements
+      // can't be `int`; widen it to `float64`. Negative numeric literals keep
+      // their sign in the baked value.
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+export function List() {
+  const [pts] = createSignal([{ x: 1, y: -2 }, { x: 2.5, y: -3 }])
+  return <ul>{pts().map((p) => <li key={p.x}>{p.x}</li>)}</ul>
+}
+`)
+      const types = adapter.generate(ir).types!
+      // x mixes 1 and 2.5 → float64; y stays int (both integer literals).
+      expect(types).toMatch(/X float64[\s\S]*Y int/)
+      expect(types).toContain('{X: 1, Y: -2}')
+      expect(types).toContain('{X: 2.5, Y: -3}')
+    })
+
+    test('keeps nil when the synthesised name collides with a user type (#1680)', () => {
+      // The struct name is `<Component><Signal>Item`. If the user already
+      // declares that exact type, synthesis bails rather than shadowing it.
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+type ListItemsItem = { id: string }
+export function List() {
+  const [items] = createSignal([{ id: "a" }])
+  return <ul>{items().map((t) => <li key={t.id}>{t.id}</li>)}</ul>
+}
+`)
+      expect(adapter.generate(ir).types!).toContain('Items: nil,')
+    })
+
+    test('synthesises a distinct struct per untyped object-array signal (#1680)', () => {
+      // Two untyped signals get component+getter-prefixed names, so their
+      // synthesised structs and fields don't collide.
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+export function List() {
+  const [rows] = createSignal([{ id: "a" }])
+  const [cols] = createSignal([{ label: "x" }])
+  return <ul>{rows().map((r) => <li key={r.id}>{r.id}</li>)}{cols().map((c) => <li key={c.label}>{c.label}</li>)}</ul>
+}
+`)
+      const types = adapter.generate(ir).types!
+      expect(types).toContain('type ListRowsItem struct {')
+      expect(types).toContain('type ListColsItem struct {')
+      expect(types).toMatch(/Rows \[\]ListRowsItem/)
+      expect(types).toMatch(/Cols \[\]ListColsItem/)
+      expect(types).toContain('Rows: []ListRowsItem{ListRowsItem{ID: "a"}}')
+      expect(types).toContain('Cols: []ListColsItem{ListColsItem{Label: "x"}}')
+    })
+
     test('keeps nil for non-literal array initial values (#1672)', () => {
       // A signal whose array initial value is a function call / variable
       // reference cannot be evaluated at codegen time — it must stay nil so

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -36,20 +36,6 @@ runAdapterConformanceTests({
   // template syntax (#1266).
   skipJsx: [
     'return-map',
-    // #1665 whole-item loop conditional. The Go adapter correctly emits the
-    // per-item `<!--bf-loop-i:KEY-->` anchor, `data-key`, and conditional
-    // markers (verified by template-structure tests). The outer-signal scope
-    // bug that used to leave this skipped — `sel()` emitted as `.Sel` (loop
-    // element) instead of `$.Sel` (root) inside `range` — is now fixed (#1677).
-    // It stays skipped on Go for the one remaining reason: its `items` signal
-    // is an *untyped* object array, which lands in a `[]interface{}` field
-    // whose `map` items the loop body can't reach via struct field access
-    // (`.ID` → <nil>), so the #1672 bake intentionally leaves it `nil` and the
-    // SSR loop renders empty. Typing the signal (`createSignal<Item[]>`) would
-    // unblock it; the untyped path is tracked in #1680. The anchored SSR shape
-    // with rendered items is covered by Hono + CSR conformance and the runtime
-    // hydration tests. https://github.com/piconic-ai/barefootjs/issues/1680
-    'loop-item-conditional',
     // #1297 fixed the harness-side IR emission gate (multi-component
     // sources now emit one `ir` file per component, and the harness
     // picks the entry-point IR). The remaining gap is adapter-side:
@@ -591,18 +577,59 @@ export function Tags() {
       )
     })
 
-    test('keeps nil for untyped object-array initial values (#1672)', () => {
-      // Without a struct type the field is `[]interface{}`, but the loop body
-      // reaches items via struct field access (`.ID`) the map form can't
-      // satisfy (`<nil>`). Leave it nil — status quo for the untyped case —
-      // rather than baking a literal that renders empty.
+    test('synthesises a struct for an untyped object array and bakes it (#1680)', () => {
+      // An untyped object array has no element type to bake against. Rather
+      // than leave it nil (empty SSR loop), infer a struct from the literal's
+      // shape, emit it, type the signal field as a slice of it, and bake the
+      // items — so the loop body's struct field access (`.ID`) resolves.
       const adapter = new GoTemplateAdapter()
       const ir = compileToIR(`
 "use client"
 import { createSignal } from "@barefootjs/client"
 
 export function List() {
-  const [items] = createSignal([{ id: "a" }, { id: "b" }])
+  const [items] = createSignal([{ id: "a", n: 1, ok: true }, { id: "b", n: 2, ok: false }])
+  return <ul>{items().map((t) => <li key={t.id}>{t.id}</li>)}</ul>
+}
+`)
+      const types = adapter.generate(ir).types!
+      // A struct is synthesised with one field per inferred key + Go type.
+      expect(types).toMatch(/type \w+ struct \{[\s\S]*ID string[\s\S]*N int[\s\S]*Ok bool[\s\S]*\}/)
+      // The signal field is a slice of the synthesised struct, not []interface{}.
+      expect(types).toMatch(/Items \[\]\w+ `json:"items"`/)
+      expect(types).not.toContain('Items []interface{}')
+      // The initial items are baked, not nil.
+      expect(types).not.toContain('Items: nil,')
+      expect(types).toMatch(/Items: \[\]\w+\{\w+\{ID: "a", N: 1, Ok: true\}, \w+\{ID: "b", N: 2, Ok: false\}\}/)
+    })
+
+    test('keeps nil for an untyped object array with inconsistent shapes (#1680)', () => {
+      // Elements must share one shape to synthesise a struct. A key missing
+      // from some elements (or a type that disagrees across elements) can't map
+      // to a single struct, so we bail to nil rather than guess.
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+export function List() {
+  const [items] = createSignal([{ id: "a" }, { id: "b", extra: 1 }])
+  return <ul>{items().map((t) => <li key={t.id}>{t.id}</li>)}</ul>
+}
+`)
+      expect(adapter.generate(ir).types!).toContain('Items: nil,')
+    })
+
+    test('keeps nil for an untyped object array with non-scalar values (#1680)', () => {
+      // A nested object/array value has no scalar Go type to infer, so the
+      // shape can't be synthesised — bail to nil.
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+export function List() {
+  const [items] = createSignal([{ id: "a", tags: ["x"] }])
   return <ul>{items().map((t) => <li key={t.id}>{t.id}</li>)}</ul>
 }
 `)

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -1983,8 +1983,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     const sf = ts.createSourceFile(
       '__lit.ts', `(${value})`, ts.ScriptTarget.Latest, /* setParentNodes */ true,
     )
+    // Require exactly one expression statement. A value that error-recovers
+    // into multiple statements (e.g. `1; 2`) isn't a single literal — bail
+    // rather than silently baking only the first.
+    if (sf.statements.length !== 1) return null
     const stmt = sf.statements[0]
-    if (!stmt || !ts.isExpressionStatement(stmt)) return null
+    if (!ts.isExpressionStatement(stmt)) return null
     let expr: ts.Expression = stmt.expression
     while (ts.isParenthesizedExpression(expr)) expr = expr.expression
     return expr

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -336,6 +336,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * struct literal only names fields the generated struct actually declares.
    */
   private localStructFields: Map<string, Map<string, string>> = new Map()
+  /**
+   * Synthesised array types for untyped object-array signals (signal getter →
+   * `[]SynthStruct` TypeInfo), populated during generateTypes (#1680). An
+   * untyped `createSignal([{ id: "a" }])` has no element type to bake against;
+   * we infer a struct from the literal's shape so the field can be typed and
+   * the items baked. Consulted by both the signal field-type emitter and the
+   * initial-value baker.
+   */
+  private synthStructTypes: Map<string, TypeInfo> = new Map()
 
   /** Set during type generation when any emit references
    *  `template.HTML(...)`; toggles the `"html/template"` import. */
@@ -692,6 +701,29 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       }
     }
 
+    // Synthesise a struct for each untyped object-array signal (#1680) and emit
+    // it, so the signal field can be typed `[]Synth` and its inline items baked
+    // (the loop body reaches each item via struct field access). Registered in
+    // localTypeNames/localStructFields so the baker resolves the element type.
+    this.synthStructTypes = new Map<string, TypeInfo>()
+    for (const signal of ir.metadata.signals) {
+      const synth = this.synthesizeStructFromSignal(signal, componentName)
+      if (!synth) continue
+      this.localTypeNames.add(synth.name)
+      this.localStructFields.set(synth.name, new Map(synth.fields.map(f => [f.tsName, f.goName])))
+      this.synthStructTypes.set(signal.getter, {
+        kind: 'array',
+        raw: `${synth.name}[]`,
+        elementType: { kind: 'interface', raw: synth.name },
+      })
+      const goFields = synth.fields.map(
+        f => `\t${f.goName} ${f.goType} \`json:"${this.toJsonTag(f.tsName)}"\``,
+      )
+      lines.push(`// ${synth.name} is a synthesised element type for the ${signal.getter} signal.`)
+      lines.push(`type ${synth.name} struct {\n${goFields.join('\n')}\n}`)
+      lines.push('')
+    }
+
     // Find nested components (loops with childComponent)
     const nestedComponents = this.findNestedComponents(ir.root)
 
@@ -780,6 +812,123 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       })
     }
     return fields
+  }
+
+  /**
+   * Synthesise a Go struct from an untyped object-array signal's inline initial
+   * value (#1680). Returns the struct name + fields, or `null` when synthesis
+   * isn't possible so the caller keeps the field `[]interface{}`/`nil`.
+   *
+   * Synthesis applies only when:
+   *   - the signal's type is an array with no usable element type (untyped),
+   *   - the initial value is a non-empty array literal of object literals,
+   *   - every element shares the same set of Go-identifier keys, and
+   *   - every value is a scalar literal whose Go type is consistent per key
+   *     (numeric keys widen int→float64 when mixed).
+   *
+   * Any deviation (heterogeneous shape, a nested object/array value, a
+   * non-literal value, a non-identifier key, or a name collision with an
+   * existing type) returns `null`.
+   */
+  private synthesizeStructFromSignal(
+    signal: { getter: string; type: TypeInfo; initialValue: string },
+    componentName: string,
+  ): { name: string; fields: Array<{ tsName: string; goName: string; goType: string }> } | null {
+    // Only untyped arrays: a typed (`Item[]`) or scalar (`string[]`) element
+    // already bakes through the normal path.
+    if (signal.type.kind !== 'array') return null
+    const elem = signal.type.elementType
+    if (elem && elem.kind !== 'unknown') return null
+
+    const node = this.parseLiteralExpression(signal.initialValue)
+    if (!node || !ts.isArrayLiteralExpression(node) || node.elements.length === 0) return null
+
+    // Collect the field order + per-key Go types from the first element, then
+    // require every other element to match exactly.
+    const order: string[] = []
+    const goTypes = new Map<string, string>()
+    for (let i = 0; i < node.elements.length; i++) {
+      const el = node.elements[i]
+      if (!ts.isObjectLiteralExpression(el)) return null
+      const seen = new Set<string>()
+      for (const prop of el.properties) {
+        if (!ts.isPropertyAssignment(prop)) return null
+        if (
+          !ts.isIdentifier(prop.name) &&
+          !ts.isStringLiteral(prop.name) &&
+          !ts.isNumericLiteral(prop.name)
+        ) {
+          return null
+        }
+        const key = prop.name.text
+        if (!GoTemplateAdapter.GO_IDENTIFIER.test(key)) return null
+        const goType = this.scalarLiteralGoType(prop.initializer)
+        if (!goType) return null
+        seen.add(key)
+        const prev = goTypes.get(key)
+        if (prev === undefined) {
+          if (i !== 0) return null // key absent from the first element → shape differs
+          order.push(key)
+          goTypes.set(key, goType)
+        } else {
+          const merged = this.mergeScalarGoType(prev, goType)
+          if (!merged) return null
+          goTypes.set(key, merged)
+        }
+      }
+      // Every key from the first element must be present in this element too.
+      if (seen.size !== order.length) return null
+    }
+
+    const name = `${componentName}${this.capitalizeFieldName(signal.getter)}Item`
+    // Don't shadow a user-defined or already-synthesised type.
+    if (this.localTypeNames.has(name)) return null
+
+    return {
+      name,
+      fields: order.map(key => ({
+        tsName: key,
+        goName: this.capitalizeFieldName(key),
+        goType: goTypes.get(key)!,
+      })),
+    }
+  }
+
+  /**
+   * The Go type for a scalar JS literal used as a synthesised struct field
+   * value, or `null` for anything non-scalar (objects, arrays, identifiers,
+   * calls, interpolated templates) so the caller bails out of synthesis.
+   */
+  private scalarLiteralGoType(node: ts.Expression): string | null {
+    if (
+      ts.isPrefixUnaryExpression(node) &&
+      node.operator === ts.SyntaxKind.MinusToken &&
+      ts.isNumericLiteral(node.operand)
+    ) {
+      return this.numericLiteralGoType(node.operand.text)
+    }
+    if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) return 'string'
+    if (ts.isNumericLiteral(node)) return this.numericLiteralGoType(node.text)
+    if (node.kind === ts.SyntaxKind.TrueKeyword || node.kind === ts.SyntaxKind.FalseKeyword) {
+      return 'bool'
+    }
+    return null
+  }
+
+  /** `int` for an integer literal, `float64` when the literal has a fraction
+   *  or exponent. */
+  private numericLiteralGoType(text: string): string {
+    return /[.eE]/.test(text) && !text.startsWith('0x') ? 'float64' : 'int'
+  }
+
+  /** Reconcile two inferred Go types for the same key across elements: equal
+   *  types stay; mixed numeric (int/float64) widens to float64; otherwise null
+   *  (incompatible → bail). */
+  private mergeScalarGoType(a: string, b: string): string | null {
+    if (a === b) return a
+    const numeric = new Set(['int', 'float64'])
+    if (numeric.has(a) && numeric.has(b)) return 'float64'
+    return null
   }
 
   /**
@@ -949,6 +1098,13 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       // Skip if a prop field with the same name was already emitted
       if (propFieldNames.has(fieldName)) continue
       const jsonTag = this.toJsonTag(signal.getter)
+      // A synthesised struct type (#1680) wins outright — the signal is an
+      // untyped object array we gave a concrete element type.
+      const synthType = this.synthStructTypes.get(signal.getter)
+      if (synthType) {
+        lines.push(`\t${fieldName} ${this.typeInfoToGo(synthType)} \`json:"${jsonTag}"\``)
+        continue
+      }
       // Infer type from initial value or referenced prop's type
       let goType: string
       let referencedProp = propsParamMap.get(signal.initialValue)
@@ -1160,7 +1316,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       if (hoisted) {
         lines.push(`\t\t${fieldName}: ${hoisted.varName},`)
       } else {
-        const initialValue = this.convertInitialValue(signal.initialValue, signal.type, ir.metadata.propsParams)
+        // Bake against the synthesised struct type when one was inferred for
+        // this untyped object-array signal (#1680), else the signal's own type.
+        const bakeType = this.synthStructTypes.get(signal.getter) ?? signal.type
+        const initialValue = this.convertInitialValue(signal.initialValue, bakeType, ir.metadata.propsParams)
         lines.push(`\t\t${fieldName}: ${initialValue},`)
       }
     }
@@ -1810,6 +1969,17 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * which the SSR template reaches via struct field access the map lacks).
    */
   private jsLiteralToGo(value: string, typeInfo: TypeInfo): string | null {
+    const expr = this.parseLiteralExpression(value)
+    if (!expr) return null
+    return this.tsLiteralToGo(expr, typeInfo)
+  }
+
+  /**
+   * Parse a JS expression string into its TS AST node (parentheses unwrapped),
+   * or `null` when it isn't a single expression. Shared by the literal baker
+   * and the struct-shape synthesiser.
+   */
+  private parseLiteralExpression(value: string): ts.Expression | null {
     const sf = ts.createSourceFile(
       '__lit.ts', `(${value})`, ts.ScriptTarget.Latest, /* setParentNodes */ true,
     )
@@ -1817,7 +1987,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     if (!stmt || !ts.isExpressionStatement(stmt)) return null
     let expr: ts.Expression = stmt.expression
     while (ts.isParenthesizedExpression(expr)) expr = expr.expression
-    return this.tsLiteralToGo(expr, typeInfo)
+    return expr
   }
 
   /**


### PR DESCRIPTION
## What

Closes #1680. An untyped `createSignal([{ id: "a" }])` has no element type, so its Go field was `[]interface{}` and the inline items stayed `nil` (#1672) — the SSR loop rendered empty, because the loop body reaches each item via struct field access (`{{.ID}}`) that a `map[string]interface{}` can't satisfy.

This implements **direction 1 (struct synthesis)** from the issue: infer a Go struct from the literal's shape, type the signal field as a slice of it, and bake the items. Element access in the loop body is unchanged — it already uses `.ID`, which now resolves against a real struct.

```tsx
const [items] = createSignal([{ id: "a", n: 1, ok: true }])
```
```go
// ListItemsItem is a synthesised element type for the items signal.
type ListItemsItem struct {
	ID string `json:"id"`
	N  int    `json:"n"`
	Ok bool   `json:"ok"`
}
// …
Items []ListItemsItem `json:"items"`
// …
Items: []ListItemsItem{ListItemsItem{ID: "a", N: 1, Ok: true}},
```

## Shape inference

- Field order + a per-key Go type are collected from the elements: `string` / `int` / `float64` / `bool`; numeric keys widen `int`→`float64` when mixed.
- The struct is named `<Component><Signal>Item`, registered in the adapter's type/field maps so the existing baker resolves the element type and capitalises field names consistently.

## Bails to `nil` (prior behaviour, client hydrates)

- Elements don't share one shape (a key missing from some, or a type that disagrees).
- A value isn't a scalar literal (nested object/array, call, identifier).
- A key isn't a Go identifier (`"data-id"`, numeric key).
- The synthesised name would collide with an existing type.

The shape-parse + baking reuse the same TS parse (extracted `parseLiteralExpression`).

## Fixture

Unblocks the `loop-item-conditional` conformance fixture on Go — removed from the go-template `skipJsx` list (the #1677 scope fix was the other half; this is the last reason it was skipped).

## Verification

- New unit tests (`#1680`): synthesis + bake for a consistent shape; bail-to-nil for inconsistent shapes and non-scalar values.
- **Real Go** (`go1.25.6`): untyped object arrays render their items (`a:1`, `b:2`); `loop-item-conditional` passes Go conformance.
- go-template **359 pass**, adapter conformance hono/mojo/go **534 pass** — all 0 fail; tsc clean.

https://claude.ai/code/session_014HUbvaiJv5iDfq37uVqxCv

---
_Generated by [Claude Code](https://claude.ai/code/session_014HUbvaiJv5iDfq37uVqxCv)_