### PR TITLE
fix(adapter-mojolicious): use eq/ne for string-typed equality, unskip loop-item-conditional (#1672)

### DIFF
--- a/.changeset/mojo-string-equality-eq.md
+++ b/.changeset/mojo-string-equality-eq.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/mojolicious": patch
+---
+
+Lower JS `===`/`!==` to Perl `eq`/`ne` when an operand is string-typed — a string signal getter (`sel()`) or a string prop (`props.x`), not only a string literal (#1672). Perl's numeric `==` coerces non-numeric strings to 0, so `"b" == "a"` was true and a whole-item loop conditional like `items().map(t => sel() === t.id && …)` rendered every item's true branch server-side. This unblocks the `loop-item-conditional` conformance fixture on Mojo.

--- a/packages/adapter-mojolicious/src/__tests__/evaluate-signal-init.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/evaluate-signal-init.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect } from 'bun:test'
+import { evaluateSignalInit } from '../test-render'
+
+describe('evaluateSignalInit — SSR signal seeding (#1672)', () => {
+  test('parses an inline object-array initial value', () => {
+    // The whole-item loop-conditional fixture seeds `items` from an inline
+    // object array. Without array support this returned null, so `$items` was
+    // undefined in the Mojo SSR render and the loop rendered empty.
+    expect(evaluateSignalInit(`[{ id: 'a' }, { id: 'b' }, { id: 'c' }]`)).toEqual([
+      { id: 'a' },
+      { id: 'b' },
+      { id: 'c' },
+    ])
+  })
+
+  test('parses scalar and mixed arrays, including nested objects', () => {
+    expect(evaluateSignalInit(`['x', 'y']`)).toEqual(['x', 'y'])
+    expect(evaluateSignalInit(`[1, 2, 3]`)).toEqual([1, 2, 3])
+    expect(evaluateSignalInit(`[{ id: 'a', n: 1, ok: true }]`)).toEqual([
+      { id: 'a', n: 1, ok: true },
+    ])
+  })
+
+  test('still parses scalars, empty array, and props passthrough', () => {
+    expect(evaluateSignalInit(`'b'`)).toBe('b')
+    expect(evaluateSignalInit(`5`)).toBe(5)
+    expect(evaluateSignalInit(`[]`)).toEqual([])
+    expect(evaluateSignalInit(`props.value`, { value: 42 })).toBe(42)
+  })
+
+  test('bails to null for arrays with non-literal elements', () => {
+    // A call / identifier element can't be evaluated at seed time.
+    expect(evaluateSignalInit(`[foo(), bar]`)).toBeNull()
+  })
+})

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -69,19 +69,6 @@ runAdapterConformanceTests({
     'toggle-shared',
     'reactive-props',
     'props-reactivity-comparison',
-    // #1665 whole-item loop conditional. The Mojo adapter correctly emits the
-    // per-item `<!--bf-loop-i:KEY-->` anchor, `data-key`, and the conditional
-    // markers (verified by template-structure tests), but the fixture's
-    // `sel() === t.id` string comparison lowers to Perl numeric `==`
-    // (`"b" == "a"` → `0 == 0` → true), so the perl-executed render renders
-    // every item's true branch instead of only the matching one. Selecting
-    // `eq` vs `==` from operand types is a separate pre-existing Mojo
-    // limitation (same family as the skipped `logical-or-jsx` /
-    // `nullish-coalescing-jsx` map shapes); the anchored SSR shape itself is
-    // covered cross-adapter by Hono + CSR conformance and the runtime
-    // hydration tests. Remove this skip once the Mojo limitation is fixed:
-    // https://github.com/piconic-ai/barefootjs/issues/1672
-    'loop-item-conditional',
   ],
   // Per-fixture build-time contracts for shapes the Mojo adapter
   // intentionally refuses to lower. Owned by this adapter test file
@@ -287,6 +274,40 @@ export function List() {
     // Markers are scoped per-call-site (#1087): `bf->comment("loop:<id>")`.
     expect(result.template).toMatch(/bf->comment\("loop:[^"]+"\)/)
     expect(result.template).toMatch(/bf->comment\("\/loop:[^"]+"\)/)
+  })
+
+  test('compares string signals with Perl `eq`, not numeric `==` (#1672)', () => {
+    // `sel() === t.id` where `sel` is a string signal must lower to `eq`.
+    // Perl numeric `==` coerces non-numeric strings to 0, so `"b" == "a"` is
+    // true and every loop item would render its true branch.
+    const result = compileAndGenerate(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+export function LoopItemConditional() {
+  const [items] = createSignal([{ id: "a" }, { id: "b" }, { id: "c" }])
+  const [sel] = createSignal("b")
+  return <ul>{items().map(t => sel() === t.id && <li key={t.id}>{t.id}</li>)}</ul>
+}
+`)
+    expect(result.template).toContain('$sel eq $t->{id}')
+    expect(result.template).not.toContain('$sel == $t->{id}')
+  })
+
+  test('compares number signals with Perl `==` (#1672)', () => {
+    // A numeric signal comparison must stay `==`, not flip to `eq`.
+    const result = compileAndGenerate(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+export function L() {
+  const [items] = createSignal([{ n: 1 }, { n: 2 }])
+  const [sel] = createSignal(2)
+  return <ul>{items().map(t => sel() === t.n && <li key={t.n}>{t.n}</li>)}</ul>
+}
+`)
+    expect(result.template).toContain('$sel == $t->{n}')
+    expect(result.template).not.toContain('$sel eq $t->{n}')
   })
 
   test('generates script registration for client components', () => {

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -22,6 +22,7 @@ import type {
   IRTemplatePart,
   AttrValue,
   CompilerError,
+  TypeInfo,
   TemplatePrimitiveRegistry,
 } from '@barefootjs/jsx'
 import {
@@ -151,6 +152,13 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
    */
   private propsObjectName: string | null = null
   private propsParams: { name: string }[] = []
+  /**
+   * Names (signal getters + props) whose value is a string, so `===`/`!==`
+   * against them lowers to Perl `eq`/`ne` rather than numeric `==`/`!=`.
+   * Perl's numeric `==` coerces non-numeric strings to 0, making `"b" == "a"`
+   * true — selecting the string operator from the operand's type avoids that.
+   */
+  private stringValueNames: Set<string> = new Set()
 
   constructor(options: MojoAdapterOptions = {}) {
     super()
@@ -164,6 +172,20 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     this.componentName = ir.metadata.componentName
     this.propsObjectName = ir.metadata.propsObjectName ?? null
     this.propsParams = ir.metadata.propsParams.map(p => ({ name: p.name }))
+    // Record string-typed signals and props so equality comparisons against
+    // them lower to `eq`/`ne` (#1672). A signal is string-typed when its
+    // inferred type is `string` (the analyzer infers this from a string-literal
+    // initial value) or, defensively, when its initial value is a bare string
+    // literal; a prop when its annotated type is `string`.
+    this.stringValueNames = new Set<string>()
+    for (const s of ir.metadata.signals) {
+      if (isStringTypeInfo(s.type) || isBareStringLiteral(s.initialValue)) {
+        this.stringValueNames.add(s.getter)
+      }
+    }
+    for (const p of ir.metadata.propsParams) {
+      if (isStringTypeInfo(p.type)) this.stringValueNames.add(p.name)
+    }
     this.errors = []
     this.childrenCaptureCounter = 0
 
@@ -960,7 +982,7 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     // those would yield runtime errors in Perl, which is the user's
     // signal to refactor. Wholesale refusal would also block the
     // canonical case the issue exists to enable.
-    return emitParsedExpr(expr, new MojoFilterEmitter(param, localVarMap))
+    return emitParsedExpr(expr, new MojoFilterEmitter(param, localVarMap, n => this._isStringValueName(n)))
   }
 
   /**
@@ -1222,6 +1244,12 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
    * the AST — used for Mojo-specific gaps (`.find` / `.findIndex` have
    * no Embedded-Perl lowering) and templatePrimitive arity errors.
    */
+  /** Whether `name` (a signal getter or prop) holds a string value, so an
+   *  equality comparison against it should use Perl `eq`/`ne` (#1672). */
+  _isStringValueName(name: string): boolean {
+    return this.stringValueNames.has(name)
+  }
+
   _recordExprBF101(message: string, reason?: string): void {
     this.errors.push({
       code: 'BF101',
@@ -1417,6 +1445,38 @@ function renderSortMethod(recv: string, c: SortComparator): string {
   return `bf->sort(${recv}, { keys => [${keyHashes.join(', ')}] })`
 }
 
+/** True when `type` is the `string` primitive. */
+function isStringTypeInfo(type: TypeInfo | undefined): boolean {
+  return type?.kind === 'primitive' && type.primitive === 'string'
+}
+
+/** True when `initialValue` is a bare string-literal expression (`'x'` /
+ *  `"x"`), used as a fallback for signals whose type wasn't inferred. */
+function isBareStringLiteral(initialValue: string | undefined): boolean {
+  if (!initialValue) return false
+  const v = initialValue.trim()
+  return (v.startsWith("'") && v.endsWith("'")) || (v.startsWith('"') && v.endsWith('"'))
+}
+
+/**
+ * Whether a comparison operand is string-typed, so JS `===`/`!==` against it
+ * must lower to Perl `eq`/`ne` instead of numeric `==`/`!=` (#1672). Covers a
+ * string literal, a string-signal getter call (`sel()`), and a string prop
+ * access (`props.x`). `isStringName` reports whether a getter/prop name is
+ * known-string. Loop-element fields (`t.id`) on untyped arrays have no known
+ * type and stay undetected — a separate, narrower gap.
+ */
+function isStringTypedOperand(expr: ParsedExpr, isStringName: (n: string) => boolean): boolean {
+  if (expr.kind === 'literal' && expr.literalType === 'string') return true
+  if (expr.kind === 'call' && expr.callee.kind === 'identifier' && expr.args.length === 0) {
+    return isStringName(expr.callee.name)
+  }
+  if (expr.kind === 'member' && expr.object.kind === 'identifier' && expr.object.name === 'props') {
+    return isStringName(expr.property)
+  }
+  return false
+}
+
 /**
  * Lowering for the predicate body of a filter / every / some / find,
  * plus the same shape used by `renderBlockBodyCondition` for complex
@@ -1434,6 +1494,10 @@ class MojoFilterEmitter implements ParsedExprEmitter {
   constructor(
     private readonly param: string,
     private readonly localVarMap: Map<string, string>,
+    // Reports whether a getter/prop name is string-typed, so `===`/`!==`
+    // against it lowers to `eq`/`ne` (#1672). Defaults to "never" for callers
+    // that don't thread it through.
+    private readonly isStringName: (n: string) => boolean = () => false,
   ) {}
 
   identifier(name: string): string {
@@ -1486,16 +1550,15 @@ class MojoFilterEmitter implements ParsedExprEmitter {
   binary(op: string, left: ParsedExpr, right: ParsedExpr, emit: (e: ParsedExpr) => string): string {
     const l = emit(left)
     const r = emit(right)
-    // String equality: `eq`/`ne` when EITHER operand is a string
-    // literal (`role() === 'admin'` and the reversed `'admin' === role()`).
-    // Falling back to numeric `==`/`!=` for a string literal would make
-    // Perl coerce both sides to 0 and match unrelated non-numeric strings.
-    const leftStr = left.kind === 'literal' && left.literalType === 'string'
-    const rightStr = right.kind === 'literal' && right.literalType === 'string'
-    if ((op === '===' || op === '==') && (leftStr || rightStr)) {
+    // String equality: `eq`/`ne` when EITHER operand is string-typed — a string
+    // literal, a string signal getter, or a string prop. Numeric `==`/`!=`
+    // would coerce both sides to 0 and match unrelated non-numeric strings (#1672).
+    const isStr = (e: ParsedExpr) => isStringTypedOperand(e, this.isStringName)
+    const stringCmp = isStr(left) || isStr(right)
+    if ((op === '===' || op === '==') && stringCmp) {
       return `${l} eq ${r}`
     }
-    if ((op === '!==' || op === '!=') && (leftStr || rightStr)) {
+    if ((op === '!==' || op === '!=') && stringCmp) {
       return `${l} ne ${r}`
     }
     const opMap: Record<string, string> = {
@@ -1524,7 +1587,7 @@ class MojoFilterEmitter implements ParsedExprEmitter {
     // higher-order's own `param` (potentially shadowing the outer one),
     // so we spin up a nested emitter with the inner param.
     const arrayExpr = emit(object)
-    const predBody = emitParsedExpr(predicate, new MojoFilterEmitter(param, this.localVarMap))
+    const predBody = emitParsedExpr(predicate, new MojoFilterEmitter(param, this.localVarMap, this.isStringName))
     const grepBody = predBody.replace(new RegExp(`\\$${param}\\b`, 'g'), '$_')
     if (method === 'filter') return `[grep { ${grepBody} } @{${arrayExpr}}]`
     if (method === 'every') return `!(grep { !(${grepBody}) } @{${arrayExpr}})`
@@ -1664,16 +1727,17 @@ class MojoTopLevelEmitter implements ParsedExprEmitter {
   binary(op: string, left: ParsedExpr, right: ParsedExpr, emit: (e: ParsedExpr) => string): string {
     const l = emit(left)
     const r = emit(right)
-    // String equality: `eq`/`ne` when EITHER operand is a string
-    // literal (`role() === 'admin'` and the reversed `'admin' === role()`).
-    // Falling back to numeric `==`/`!=` for a string literal would make
-    // Perl coerce both sides to 0 and match unrelated non-numeric strings.
-    const leftStr = left.kind === 'literal' && left.literalType === 'string'
-    const rightStr = right.kind === 'literal' && right.literalType === 'string'
-    if ((op === '===' || op === '==') && (leftStr || rightStr)) {
+    // String equality: `eq`/`ne` when EITHER operand is string-typed — a string
+    // literal (`role() === 'admin'`), a string signal getter (`sel()`), or a
+    // string prop (`props.x`). Falling back to numeric `==`/`!=` would make
+    // Perl coerce both sides to 0 and match unrelated non-numeric strings
+    // (`"b" == "a"` → true), so all loop items render their true branch (#1672).
+    const isStr = (e: ParsedExpr) => isStringTypedOperand(e, n => this.adapter._isStringValueName(n))
+    const stringCmp = isStr(left) || isStr(right)
+    if ((op === '===' || op === '==') && stringCmp) {
       return `${l} eq ${r}`
     }
-    if ((op === '!==' || op === '!=') && (leftStr || rightStr)) {
+    if ((op === '!==' || op === '!=') && stringCmp) {
       return `${l} ne ${r}`
     }
     const opMap: Record<string, string> = {

--- a/packages/adapter-mojolicious/src/test-render.ts
+++ b/packages/adapter-mojolicious/src/test-render.ts
@@ -501,7 +501,7 @@ function buildPerlProps(
  * Evaluate a signal initializer expression using provided props.
  * Handles patterns like: props.initial ?? 0, props.value, literal values.
  */
-function evaluateSignalInit(
+export function evaluateSignalInit(
   expr: string,
   props?: Record<string, unknown>,
 ): unknown {
@@ -534,6 +534,29 @@ function parseLiteral(expr: string): unknown {
   if (expr === 'true') return true
   if (expr === 'false') return false
   if (expr === '[]') return []
+
+  // Non-empty array literal (`[{ id: 'a' }, { id: 'b' }]`, `['x', 'y']`).
+  // Each element is parsed recursively; if any element can't be parsed
+  // (identifier, call, member access, …) the whole array bails to null so
+  // the harness falls back to its `undef` behaviour. Mirrors the object-
+  // literal branch below. Needed so signal initial values that are inline
+  // object/scalar arrays seed the Mojo SSR stash (e.g. the whole-item loop
+  // conditional fixture, whose `items` is `[{ id: 'a' }, …]`).
+  {
+    const t = expr.trim()
+    if (t.startsWith('[') && t.endsWith(']')) {
+      const inner = t.slice(1, -1).trim()
+      if (!inner) return []
+      const out: unknown[] = []
+      for (const seg of splitTopLevelCommas(inner)) {
+        if (!seg.trim()) continue
+        const parsed = parseLiteral(seg.trim())
+        if (parsed === null && seg.trim() !== 'null') return null
+        out.push(parsed)
+      }
+      return out
+    }
+  }
   // String literal — require matching opener/closer (the previous
   // regex `^['"]…['"]$` accepted mixed quotes like `'foo"`) and
   // unescape JS-style escape sequences so `'a\\'b'` round-trips as
@@ -559,42 +582,7 @@ function parseLiteral(expr: string): unknown {
     const inner = trimmed.slice(1, -1).trim()
     if (!inner) return {}
     const obj: Record<string, unknown> = {}
-    // Split on commas at depth 0; values may contain `:` so use a
-    // simple state machine instead of a regex.
-    const pairs: string[] = []
-    let depth = 0
-    let start = 0
-    let quote: string | null = null
-    for (let i = 0; i < inner.length; i++) {
-      const c = inner[i]
-      if (quote) {
-        // Quote-termination check: count consecutive backslashes
-        // immediately before the current position. An EVEN count
-        // means each `\\` pair represents a literal backslash and
-        // the quote is unescaped, closing the string. An ODD
-        // count means the trailing `\` escapes the quote, so the
-        // string keeps going. The naive `inner[i-1] !== '\\'`
-        // check mis-classifies even runs (`\\"`) as escaped
-        // (#1413 review).
-        if (c === quote) {
-          let backslashes = 0
-          for (let j = i - 1; j >= 0 && inner[j] === '\\'; j--) backslashes++
-          if (backslashes % 2 === 0) quote = null
-        }
-        continue
-      }
-      if (c === '"' || c === "'") {
-        quote = c
-        continue
-      }
-      if (c === '{' || c === '[') depth++
-      else if (c === '}' || c === ']') depth--
-      else if (c === ',' && depth === 0) {
-        pairs.push(inner.slice(start, i))
-        start = i + 1
-      }
-    }
-    pairs.push(inner.slice(start))
+    const pairs = splitTopLevelCommas(inner)
     for (const pair of pairs) {
       // Skip empty segments — typically a trailing comma's tail
       // (#1413 review).
@@ -615,6 +603,43 @@ function parseLiteral(expr: string): unknown {
     return obj
   }
   return null
+}
+
+/**
+ * Split a comma-separated literal body (object-pair list or array element
+ * list) on top-level commas only — commas nested inside braces, brackets, or
+ * string literals don't split. Backslash-escaped quotes inside strings are
+ * honoured (an odd run of backslashes before a quote keeps the string open).
+ * Shared by the object- and array-literal branches of {@link parseLiteral}.
+ */
+function splitTopLevelCommas(inner: string): string[] {
+  const segments: string[] = []
+  let depth = 0
+  let start = 0
+  let quote: string | null = null
+  for (let i = 0; i < inner.length; i++) {
+    const c = inner[i]
+    if (quote) {
+      if (c === quote) {
+        let backslashes = 0
+        for (let j = i - 1; j >= 0 && inner[j] === '\\'; j--) backslashes++
+        if (backslashes % 2 === 0) quote = null
+      }
+      continue
+    }
+    if (c === '"' || c === "'") {
+      quote = c
+      continue
+    }
+    if (c === '{' || c === '[') depth++
+    else if (c === '}' || c === ']') depth--
+    else if (c === ',' && depth === 0) {
+      segments.push(inner.slice(start, i))
+      start = i + 1
+    }
+  }
+  segments.push(inner.slice(start))
+  return segments
 }
 
 /**


### PR DESCRIPTION
## What

The Mojo adapter chose Perl `eq`/`ne` only when an operand was a string **literal**. A comparison like `sel() === t.id` — where `sel` is a string signal — fell through to numeric `==`, and Perl coerces non-numeric strings to 0:

```perl
% if ($sel == $t->{id}) {   # "b" == "a" → 0 == 0 → true
```

So a whole-item loop conditional (`items().map(t => sel() === t.id && <li/>)`) rendered **every** item's true branch server-side instead of only the matching one — the reason `loop-item-conditional` was skipped on Mojo.

## Fix

Track string-typed names — signal getters whose inferred type is `string` (the analyzer infers this from a string-literal initial value) plus string props — and pick `eq`/`ne` when either operand is:

- a string literal (`'admin'`),
- a string signal getter (`sel()`), or
- a string prop (`props.x`).

```perl
% if ($sel eq $t->{id}) {   # only "b" matches
```

Detection is a shared `isStringTypedOperand` helper applied in **both** expression emitters — the top-level emitter and the filter-predicate emitter (which now receives the string-name predicate so it's consistent inside `.filter()` / `.find()` bodies).

## Scope / remaining gap

Loop-element fields on **untyped** arrays (`t.id`) have no known type, so a comparison between two such fields stays on numeric `==`. That's a narrower, pre-existing gap — harmless for this fixture because the string `sel()` operand already forces `eq` (either-operand-string → `eq`).

## Fixture

Removes the last reason `loop-item-conditional` was skipped on Mojo (its sibling Go skip was cleared by #1677 + #1680).

## Verification

- New unit tests: string-signal comparison lowers to `$sel eq $t->{id}`; a numeric-signal comparison stays `$sel == $t->{n}`.
- mojo adapter **369 pass**, cross-adapter conformance **534 pass**, jsx **1775 pass** — all 0 fail; tsc clean.
- Mojo render conformance executes in CI (Mojolicious isn't installed in the dev sandbox); `eq` selection is verified by the unit tests and is correct by Perl string-comparison semantics.

https://claude.ai/code/session_014HUbvaiJv5iDfq37uVqxCv

---
_Generated by [Claude Code](https://claude.ai/code/session_014HUbvaiJv5iDfq37uVqxCv)_