### PR TITLE
Fix nested child dropped when a static sibling precedes a .map() inside a component (#1688)

### DIFF
--- a/.changeset/fix-loop-sibling-offset-component-container.md
+++ b/.changeset/fix-loop-sibling-offset-component-container.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix a nested child component being dropped during hydration when a static sibling element precedes a `.map()` inside a component (or fragment / provider / async) container (#1688). `computeLoopSiblingOffsets` only counted preceding DOM siblings under element parents, so a loop nested directly inside such a container got a silently-zero `siblingOffset`. The generated `container.children[__idx]` lookup for each item's nested child was then off by one, resolving the first item's child against the static sibling and dropping it. Sibling counting now runs for every container whose children render as a contiguous run of DOM siblings.

--- a/packages/jsx/src/__tests__/child-components-in-map.test.ts
+++ b/packages/jsx/src/__tests__/child-components-in-map.test.ts
@@ -730,6 +730,49 @@ describe('child components inside .map() (#344)', () => {
     expect(content).not.toContain('children[__idx + ')
   })
 
+  test('static array inside a component container with a preceding static sibling uses siblingOffset (#1688)', () => {
+    // The loop is a direct child of the <Portaled> component (not an
+    // element), with a static <span> sibling before it. Before #1688
+    // computeLoopSiblingOffsets only counted siblings under element
+    // parents, so the offset was silently zero and the first item's
+    // nested child component (Counter) was resolved against the wrong
+    // children[idx] — dropping it during hydration.
+    const source = `
+      'use client'
+
+      function Portaled(props: { children?: any }) {
+        return <div>{props.children}</div>
+      }
+      function Wrapper(props: { children?: any }) {
+        return <div class="wrapper">{props.children}</div>
+      }
+      function Counter(props: { id: string }) {
+        const [n, setN] = createSignal(0)
+        return <button data-testid={props.id} onClick={() => setN(v => v + 1)}>{n()}</button>
+      }
+      export function Repro() {
+        return (
+          <Portaled>
+            <span>static sibling</span>
+            {['a', 'b'].map(id => (
+              <Wrapper key={id}><Counter id={id} /></Wrapper>
+            ))}
+          </Portaled>
+        )
+      }
+    `
+    const result = compileJSX(source, 'Repro.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const content = clientJs!.content
+
+    // The nested Counter lookup must skip the preceding static <span>.
+    expect(content).toContain('children[__idx + 1]')
+    expect(content).not.toContain('children[__idx]')
+  })
+
   test('nested .map() with multiple inner components emits unique __compEl bindings (#1664)', () => {
     const source = `
       'use client'

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -20,9 +20,19 @@ function producesDomChild(node: IRNode): boolean {
 
 /**
  * Pre-pass: for every loop node in the IR tree, record the number of non-loop
- * DOM siblings that appear before it in its parent element. Read when
+ * DOM siblings that appear before it in its parent container. Read when
  * constructing TopLevelLoop and NestedLoop so the client JS can offset
  * children[idx] access past statically-rendered siblings.
+ *
+ * Counting must happen for every container whose children render as a
+ * contiguous run of DOM siblings into the same parent — not just `element`.
+ * A loop nested directly inside a component (`<Wrapper><span/>{xs.map(...)}`
+ * </Wrapper>`), fragment, provider, or async boundary has its preceding
+ * static sibling rendered as a sibling of the loop's items too, so
+ * `children[idx]` access is shifted exactly as it is under an element parent
+ * (#1688). Before this, a static sibling before a `.map()` inside a
+ * (self-portaling) component dropped the first item's nested child component
+ * during hydration because the offset was silently zero.
  *
  * Computed once up front (instead of during collection) so the offset data
  * lives in an explicit value rather than a module-level WeakMap mutated by
@@ -30,21 +40,30 @@ function producesDomChild(node: IRNode): boolean {
  */
 export function computeLoopSiblingOffsets(root: IRNode): Map<IRLoop, number> {
   const offsets = new Map<IRLoop, number>()
-  walkIR(root, null, {
-    element: ({ node: el, descend }) => {
-      let nonLoopCount = 0
-      for (const child of el.children) {
-        if (child.type === 'loop') {
-          if (nonLoopCount > 0) offsets.set(child, nonLoopCount)
-        } else if (producesDomChild(child)) {
-          nonLoopCount++
-        }
+  const recordChildren = (children: IRNode[]): void => {
+    let nonLoopCount = 0
+    for (const child of children) {
+      if (child.type === 'loop') {
+        if (nonLoopCount > 0) offsets.set(child, nonLoopCount)
+      } else if (producesDomChild(child)) {
+        nonLoopCount++
       }
-      descend()
-    },
-    // All container kinds (fragment / component / provider / async / loop /
-    // conditional / if-statement) rely on walkIR's default descent with the
-    // same scope. Leaves (text / expression / slot) are no-ops.
+    }
+  }
+  const containerVisit = ({ node, descend }: { node: { children: IRNode[] }; descend: () => void }): void => {
+    recordChildren(node.children)
+    descend()
+  }
+  walkIR(root, null, {
+    element: containerVisit,
+    component: containerVisit,
+    fragment: containerVisit,
+    provider: containerVisit,
+    async: containerVisit,
+    // `loop` / `conditional` / `if-statement` are not flat sibling
+    // containers (their children are item bodies / branches), and leaves
+    // (text / expression / slot) have no children — all rely on walkIR's
+    // default descent with the same scope.
   })
   return offsets
 }


### PR DESCRIPTION
## Summary

Fixes #1688 — during hydration, a nested child component inside a `.map()` item was dropped when a **static sibling element preceded the loop inside a component container** (e.g. a self-portaling `SelectContent` → `<label>` + `items.map(...)` where each item nests a `HoverCard`).

## Root cause

The static-array child-init codegen resolves each item's nested child component by index: `container.children[__idx]`. To skip statically-rendered siblings that appear before the loop, the compiler precomputes a `siblingOffset` per loop in `computeLoopSiblingOffsets`.

That pre-pass only walked **`element`** parents:

```ts
walkIR(root, null, { element: ({ node: el, descend }) => { /* count siblings before loop */ } })
```

When the loop is a direct child of a **component** (or `fragment` / `provider` / `async`) container — as in the issue's `<Portaled><span/>{xs.map(...)}</Portaled>` — the sibling count was never taken, so `siblingOffset` was silently `0`. The generated lookup became `container.children[__idx]` instead of `children[__idx + 1]`, resolving the first item's nested child against the static `<span>` and dropping it.

This explains the issue's "all three conditions required" table:
- **Component container** (vs plain `<div>`): a plain element parent *was* counted, so it worked — the bug only appears under a component container. (The `createPortal` self-move is incidental; the causal factor is that the container is a component.)
- **Static sibling before the map**: creates the offset that must be skipped.
- **Nested child component in the item**: only the index-based nested-child path uses `children[idx]`; a leaf item uses selector-based `qsaChildScopes`, so it was unaffected.

## Fix

Count preceding siblings for every container whose children render as a contiguous run of DOM siblings — `element`, `component`, `fragment`, `provider`, and `async` — so `children[idx]` access is offset past the static siblings.

## Tests

- Added a compiler unit test in `child-components-in-map.test.ts` (mirrors the existing `#810` element-parent sibling-offset tests) asserting the component-container case now emits `children[__idx + 1]`.
- Full `packages/jsx` suite passes (4 pre-existing, unrelated `primitive-resolver` checker-path failures present on `main`).
- `packages/adapter-tests` and `packages/client` runtime suites pass with no regressions.

https://claude.ai/code/session_01S5N35aHhoDXrQEwCDFKoDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5N35aHhoDXrQEwCDFKoDW)_