### PR TITLE
fix(client): escape __bfSlot plain-string path (branch-template text)

### DIFF
--- a/.changeset/branch-slot-text-escape.md
+++ b/.changeset/branch-slot-text-escape.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/client": patch
+---
+
+`__bfSlot` now HTML-escapes its plain-string path, so text rendered inside a conditional `template()` branch is escaped to match the SSR output (closing the branch-text gap left by #1694, where only top-level text slots were escaped). The escape is applied on the string path only — live `Node` values still return raw `<!--bf-slot:N-->` markers for `insert()` to splice, so slotted content is preserved.

--- a/packages/client/__tests__/runtime/branch-slot.test.ts
+++ b/packages/client/__tests__/runtime/branch-slot.test.ts
@@ -1,0 +1,68 @@
+/**
+ * `__bfSlot` branch-template slot helper (#1213, #1694 follow-up).
+ *
+ * `__bfSlot` interpolates Child-position expressions inside conditional
+ * `template()` arrows. Two output paths must coexist:
+ *   - live `Node` values are stashed and replaced by a raw
+ *     `<!--bf-slot:N-->` marker that `insert()` splices back by identity;
+ *   - plain string/number values are emitted inline and (since #1694)
+ *     HTML-escaped so branch text matches the SSR-rendered bytes and can't
+ *     break out as markup under `innerHTML`.
+ *
+ * The escape must NOT touch the marker path — escaping `<!--bf-slot:0-->`
+ * to `&lt;!--bf-slot:0--&gt;` would make `insert()` miss it and drop the
+ * slotted node (the regression that broke `e2e-site-ui` when the text
+ * escape was applied around the whole `__bfSlot(...)` call).
+ */
+import { describe, test, expect, beforeAll } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import { __bfSlot } from '../../src/runtime/branch-slot'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') {
+    GlobalRegistrator.register()
+  }
+})
+
+describe('__bfSlot', () => {
+  test('HTML-escapes plain string values (branch text)', () => {
+    const slots: Node[] = []
+    expect(__bfSlot('a<b>c & "d" \'e\'', slots)).toBe(
+      'a&lt;b&gt;c &amp; &quot;d&quot; &#39;e&#39;',
+    )
+    expect(slots).toHaveLength(0)
+  })
+
+  test('leaves a live Node as a raw, UN-escaped marker', () => {
+    const slots: Node[] = []
+    const el = document.createElement('div')
+    const out = __bfSlot(el, slots)
+    expect(out).toBe('<!--bf-slot:0-->')
+    // The marker must stay raw so insert() can find it.
+    expect(out).not.toContain('&lt;')
+    expect(slots).toEqual([el])
+  })
+
+  test('mixes escaped strings and raw markers in an array', () => {
+    const slots: Node[] = []
+    const el = document.createElement('span')
+    const out = __bfSlot(['x & y', el, '<z>'], slots)
+    expect(out).toBe('x &amp; y<!--bf-slot:0-->&lt;z&gt;')
+    expect(slots).toEqual([el])
+  })
+
+  test('renders nullish / boolean as empty string', () => {
+    const slots: Node[] = []
+    expect(__bfSlot(null, slots)).toBe('')
+    expect(__bfSlot(undefined, slots)).toBe('')
+    expect(__bfSlot(false, slots)).toBe('')
+    expect(__bfSlot(true, slots)).toBe('')
+    expect(slots).toHaveLength(0)
+  })
+
+  test('coerces non-string primitives (no metacharacters → unchanged)', () => {
+    const slots: Node[] = []
+    expect(__bfSlot(0, slots)).toBe('0')
+    expect(__bfSlot(42, slots)).toBe('42')
+  })
+})

--- a/packages/client/src/runtime/branch-slot.ts
+++ b/packages/client/src/runtime/branch-slot.ts
@@ -15,9 +15,16 @@
  * in by identity (no `cloneNode`), preserving event listeners and signal
  * bindings.
  *
- * Non-node values fall through to `String(value)` for the existing
- * inline-string path.
+ * Non-node values fall through to the inline-string path, HTML-escaped
+ * (#1694 follow-up) so a branch-template text value containing `< / &`
+ * surfaces as text — not markup — and matches the SSR-rendered bytes.
+ * Escaping happens here, on the string path only, so the `<!--bf-slot:N-->`
+ * markers returned for live `Node` values are left intact for `insert()`
+ * to splice. (Doing it here rather than wrapping the whole `__bfSlot(...)`
+ * call in `escapeText` is what lets the marker path stay raw.)
  */
+import { escapeText } from './component'
+
 export function __bfSlot(value: unknown, slots: Node[]): string {
   if (value == null || value === false || value === true) return ''
   if (typeof Node !== 'undefined' && value instanceof Node) {
@@ -28,5 +35,5 @@ export function __bfSlot(value: unknown, slots: Node[]): string {
   if (Array.isArray(value)) {
     return value.map((v) => __bfSlot(v, slots)).join('')
   }
-  return String(value)
+  return escapeText(value)
 }

--- a/packages/jsx/src/__tests__/text-slot-escaping.test.ts
+++ b/packages/jsx/src/__tests__/text-slot-escaping.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Text-slot HTML-escaping emit shape (#1694 + follow-up).
+ *
+ * Pins which interpolations the client template wraps in `escapeText`:
+ *   - a plain text slot (`{stringValue}`) IS escaped — it becomes the
+ *     slot's text content under `innerHTML`;
+ *   - a branch-slot expression (Child-position value inside a conditional
+ *     `template()` arrow) is routed through `__bfSlot` and must NOT be
+ *     wrapped in `escapeText`. `__bfSlot` returns raw `<!--bf-slot:N-->`
+ *     markers for live nodes; escaping the whole call corrupts them and
+ *     drops slotted content (the regression that broke `e2e-site-ui`).
+ *     `__bfSlot` escapes its own plain-string path internally instead.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function getClientJs(source: string, filename: string): string {
+  const result = compileJSX(source, filename, { adapter })
+  expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+  const clientJs = result.files.find(f => f.type === 'clientJs')
+  expect(clientJs).toBeDefined()
+  return clientJs!.content
+}
+
+describe('text-slot escaping', () => {
+  test('a plain text slot is wrapped in escapeText', () => {
+    const clientJs = getClientJs(
+      `'use client'
+       export function Label({ text }: { text: string }) {
+         return <span>{text}</span>
+       }`,
+      'Label.tsx',
+    )
+    expect(clientJs).toMatch(/<!--bf:\w+-->\$\{escapeText\(_p\.text\)\}<!--\/-->/)
+  })
+
+  test('a branch-slot expression is NOT wrapped in escapeText', () => {
+    const clientJs = getClientJs(
+      `'use client'
+       import { createSignal } from '@barefootjs/client'
+       export function Branch({ show }: { show: boolean }) {
+         const [t] = createSignal('hi')
+         return <div>{show ? <span>{t()}</span> : null}</div>
+       }`,
+      'Branch.tsx',
+    )
+    // The branch value goes through __bfSlot (raw markers preserved)…
+    expect(clientJs).toMatch(/\$\{__bfSlot\(/)
+    // …and must never be double-wrapped by the text escape.
+    expect(clientJs).not.toMatch(/escapeText\(\s*__bfSlot/)
+  })
+})


### PR DESCRIPTION
Follow-up to #1694 / #1697, addressing the two review findings on #1697.

## Background

#1694 escaped interpolated **text content** in the client template, but only the top-level `<!--bf:sN-->${expr}<!--/-->` slots. Text rendered inside a **conditional `template()` branch** is routed through `__bfSlot` (the branch-slot helper), which was left emitting its plain-string path **raw**. So a branch value containing `<` / `&` (e.g. `{cond ? <p>{user.name}</p> : null}`) still diverged from the SSR-escaped bytes and could break out as markup under `innerHTML`.

(#1697 deliberately did **not** wrap the whole `__bfSlot(...)` call in `escapeText`, because `__bfSlot` returns raw `<!--bf-slot:N-->` markers for live `Node` values that `insert()` splices back — escaping the call corrupted those markers and dropped slotted content, which is what broke `e2e-site-ui`.)

## Change (finding 1 — close the branch-text gap)

Escape inside `__bfSlot`, on the **plain-string path only**:

```ts
if (value instanceof Node) { /* stash + return <!--bf-slot:N--> (raw) */ }
if (Array.isArray(value)) { /* recurse */ }
return escapeText(value)   // ← was String(value)
```

This is the correct layer: the marker path stays raw (slots still work), while branch text gets the same escaping as top-level text and matches the SSR output. No codegen change, no snapshot churn — `__bfSlot` is a runtime helper.

## Change (finding 2 — regression coverage)

The #1697 regression was only caught by `e2e-site-ui`. Added fast tests:
- **Runtime** (`branch-slot.test.ts`): `__bfSlot` escapes plain strings, leaves a live `Node` as a raw un-escaped `<!--bf-slot:N-->` marker, and mixes both correctly in an array.
- **Compiler** (`text-slot-escaping.test.ts`): a branch-slot expression emits `${__bfSlot(...)}` **un-wrapped**, while a plain text slot stays `${escapeText(...)}` — so re-introducing `escapeText(__bfSlot(…))` fails in `bun test`, not just in the browser.

## Scope note

Static literal JSX text (e.g. `Tom & Jerry` written directly in markup) is still emitted as-is; that remains a separate, lower-risk concern (HTML-entity-decoding subtleties) and is out of scope here.

## Verification

| Suite | Result |
|---|---|
| client runtime (incl. `insert` / dispatch that use `__bfSlot`) | 327 pass / 0 fail |
| jsx unit (incl. new regression test) | 1826 pass / 0 fail |
| adapter-tests `src` | 551 pass / 0 fail |

Runtime-only change: codegen, snapshots, and SSR output are untouched, so the adapter (Hono/Go/Mojo) conformance corpora are unaffected. Branch-slot rendering is exercised end-to-end by `e2e-site-ui` (CI).

https://claude.ai/code/session_01FiQUsbdKmBeCiYYfwVM2o2

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiQUsbdKmBeCiYYfwVM2o2)_