### PR TITLE
Flatten transparent containers in the loop sibling-offset pre-pass (#1699)

### DIFF
--- a/.changeset/fix-fragment-loop-offset.md
+++ b/.changeset/fix-fragment-loop-offset.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix a loop wrapped in a transparent fragment losing its parent container's preceding siblings when computing the `children[idx]` hydration offset (#1699, follow-up to #1688/#1693). A fragment (`<>…</>`) renders no DOM element wrapper, so a `.map()` inside it is a direct sibling of the fragment's siblings in the nearest ancestor element — but `computeLoopSiblingOffsets` treated the fragment as its own container boundary and reset the preceding-sibling run, so elements before the fragment were dropped from the offset and the mapped items resolved against the wrong `children[idx]` (their nested child components stayed inert after hydration). The offset pre-pass now flattens transparent containers (fragment / provider / async) into the enclosing run, so `<Box><hr/><hr/><>{xs.map(...)}</></Box>` correctly offsets the items past both `<hr/>`s while fragment-internal siblings keep counting too.

--- a/packages/jsx/src/__tests__/child-components-in-map.test.ts
+++ b/packages/jsx/src/__tests__/child-components-in-map.test.ts
@@ -781,6 +781,77 @@ describe('child components inside .map() (#344)', () => {
     expect(content).not.toContain('children[__idx]')
   })
 
+  test('a transparent fragment wrapping a .map() inherits the parent container preceding siblings (#1699)', () => {
+    // A fragment renders no DOM element wrapper, so a loop inside `<>…</>` is a
+    // direct sibling of the fragment's siblings in the real parent element.
+    // The offset must skip the two <hr/>s that precede the fragment in <Box>,
+    // not reset to the fragment's own (empty) preceding run.
+    const source = `
+      'use client'
+
+      function Box(props: { children?: any }) { return <div>{props.children}</div> }
+      function Wrapper(props: { children?: any }) { return <div>{props.children}</div> }
+      function Counter(props: { id: string }) {
+        const [n, setN] = createSignal(0)
+        return <button onClick={() => setN(v => v + 1)}>{n()}</button>
+      }
+      export function FragGroup() {
+        return (
+          <Box>
+            <hr />
+            <hr />
+            <>
+              {['a', 'b'].map(id => (
+                <Wrapper key={id}><Counter id={id} /></Wrapper>
+              ))}
+            </>
+          </Box>
+        )
+      }
+    `
+    const result = compileJSX(source, 'FragGroup.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const content = result.files.find(f => f.type === 'clientJs')!.content
+    // Items start past both <hr/>s.
+    expect(content).toContain('children[__idx + 2]')
+    expect(content).not.toContain('children[__idx]')
+  })
+
+  test('a static sibling inside the fragment still counts toward the offset (#1699 regression guard)', () => {
+    // The fragment's OWN preceding children must keep counting too — the
+    // parent-inheriting flatten must not drop the fragment-internal <span>.
+    const source = `
+      'use client'
+
+      function Box(props: { children?: any }) { return <div>{props.children}</div> }
+      function Wrapper(props: { children?: any }) { return <div>{props.children}</div> }
+      function Counter(props: { id: string }) {
+        const [n, setN] = createSignal(0)
+        return <button onClick={() => setN(v => v + 1)}>{n()}</button>
+      }
+      export function MixedFrag() {
+        return (
+          <Box>
+            <hr />
+            <>
+              <span>label</span>
+              {['a', 'b'].map(id => (
+                <Wrapper key={id}><Counter id={id} /></Wrapper>
+              ))}
+            </>
+          </Box>
+        )
+      }
+    `
+    const result = compileJSX(source, 'MixedFrag.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const content = result.files.find(f => f.type === 'clientJs')!.content
+    // 1 (parent <hr/>) + 1 (fragment-internal <span>) = 2.
+    expect(content).toContain('children[__idx + 2]')
+  })
+
   test('two static + .map() groups inside a component: 2nd group offset skips the 1st group items (#1693)', () => {
     // Follow-up to #1688. With two `<span/> + {arr.map(...)}` groups inside a
     // self-portaling component, the second group's nested child components

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -120,6 +120,14 @@ function legacyElementCount(node: IRNode): number {
  * siblings rendered as siblings of the loop's items too, so `children[idx]`
  * access is shifted exactly as it is under an element parent (#1688).
  *
+ * Transparent containers (fragment / provider / async) render no DOM element
+ * wrapper, so their children are siblings in the nearest ancestor element —
+ * not in a container of their own. `recordRun` therefore threads ONE
+ * preceding-sibling accumulator through them, so a loop inside a fragment sees
+ * the parent element's earlier siblings too, not just the fragment's own
+ * children (#1699). `<Box><hr/><hr/><>{xs.map(...)}</></Box>` must offset the
+ * items past both `<hr/>`s.
+ *
  * The siblings are stored raw; `resolveLoopOffset` turns each into its element
  * count via `domElementCount`. That generalisation closes the #1688 follow-up
  * (#1693): a preceding `.map()` contributes `array.length` and a preceding
@@ -133,19 +141,32 @@ function legacyElementCount(node: IRNode): number {
  */
 export function computeLoopSiblingOffsets(root: IRNode): Map<IRLoop, IRNode[]> {
   const offsets = new Map<IRLoop, IRNode[]>()
-  const recordChildren = (children: IRNode[]): void => {
-    const preceding: IRNode[] = []
+  // Walk a flat DOM run, flattening transparent containers inline so their
+  // children join the same preceding-sibling accumulator.
+  const recordRun = (children: IRNode[], preceding: IRNode[]): void => {
     for (const child of children) {
-      // Record the preceding run only when something precedes this loop. A
-      // leading loop keeps the bare `children[idx]` access.
-      if (child.type === 'loop' && preceding.length > 0) {
-        offsets.set(child, [...preceding])
+      if (child.type === 'loop') {
+        // Record the preceding run only when something precedes this loop (a
+        // leading loop keeps bare `children[idx]`). `!offsets.has`: the
+        // enclosing run records the loop first, in pre-order, with the full
+        // preceding context; a later standalone visit of the transparent
+        // wrapper (still descended for loops that sit *directly* in a root /
+        // loop-body / branch fragment) must not overwrite it with a shorter
+        // run.
+        if (preceding.length > 0 && !offsets.has(child)) {
+          offsets.set(child, [...preceding])
+        }
+        preceding.push(child)
+      } else if (child.type === 'fragment' || child.type === 'provider' || child.type === 'async') {
+        // Transparent: no element wrapper — its children render into this run.
+        recordRun(child.children, preceding)
+      } else {
+        preceding.push(child)
       }
-      preceding.push(child)
     }
   }
   const containerVisit = ({ node, descend }: { node: { children: IRNode[] }; descend: () => void }): void => {
-    recordChildren(node.children)
+    recordRun(node.children, [])
     descend()
   }
   walkIR(root, null, {


### PR DESCRIPTION
## Summary

Closes #1699 (follow-up to #1688 / #1693). When a `.map()` loop is wrapped in a transparent JSX fragment (`<>…</>`), the loop's `container.children[idx]` hydration offset was computed against the **fragment's own children only**, discarding the preceding siblings that live in the *parent* container. A fragment renders no DOM element wrapper, so its children are siblings in the nearest ancestor element — but `computeLoopSiblingOffsets` treated the fragment as its own boundary and reset the preceding-sibling run.

Result: the mapped items resolved against the wrong `children[idx]`, leaving each item's nested child component inert after hydration — the same failure class as #1693, triggered by a fragment boundary.

```tsx
<Box>
  <hr/>
  <hr/>
  <>{['a','b'].map(p => <Wrapper><Counter p={p} /></Wrapper>)}</>
</Box>
```

`Box`'s `<div>` has children `[hr, hr, Wrapper-a, Wrapper-b]`, so items start at `children[2]` — but the codegen emitted `children[__idx]` (offset 0), resolving the first item against `<hr/>`.

## Fix

The offset pre-pass now **flattens transparent containers** (`fragment` / `provider` / `async` — none render a DOM element wrapper) into the enclosing run. `recordRun` threads one preceding-sibling accumulator through them, so a loop inside a fragment inherits the parent element's earlier siblings while fragment-internal siblings keep counting:

```js
// before:  _box.children[__idx]        ❌ (resolves item 0 against the first <hr/>)
// after:   _box.children[__idx + 2]    ✅ (past both <hr/>s)
```

The enclosing run records each loop first in pre-order; an `!offsets.has` guard keeps the later standalone visit of the wrapper (still descended, for loops that sit *directly* in a root / loop-body / conditional-branch fragment, which have no parent run) from overwriting the correct value with a shorter one.

The `domElementCount` element-counting from #1695 is unchanged — this is purely a traversal-level fix.

## Verification (generated offsets)

| JSX | offset |
|---|---|
| `<Box><hr/><hr/><>{map}</></Box>` | `children[__idx + 2]` ✅ (was `+0`) |
| `<Box><hr/><><span/>{map}</></Box>` | `children[__idx + 2]` ✅ (parent `<hr/>` + fragment `<span>`) |
| `<Box><><span/>{map}</></Box>` | `children[__idx + 1]` (fragment-internal, unchanged) |
| `<Box><span/>{map}</Box>` | `children[__idx + 1]` (no fragment, unchanged) |
| `<Box><>{map}</></Box>` | `children[__idx]` (no preceding, unchanged) |

## Tests

- 2 new compiler unit tests in `child-components-in-map.test.ts` (fragment inherits parent siblings; fragment-internal sibling still counts).
- `child-components-in-map`: 37/37 pass. `tsc --noEmit` clean.
- Full `@barefootjs/jsx` suite: same 4 pre-existing checker-resolver failures as `main` (unrelated); zero new failures. adapter-tests 551/551.

## Note on provider / async

`provider` and `async` are flattened alongside `fragment` on the same rationale (no DOM element wrapper). The full suite passing confirms no regression; if either is later found to render a wrapper element, the flatten set is a one-line change.

https://claude.ai/code/session_01LtX7EH46MXXx5M9x5EZ3B4

---
_Generated by [Claude Code](https://claude.ai/code/session_01LtX7EH46MXXx5M9x5EZ3B4)_