### PR TITLE
fix: keep string-literal contents intact when inlining modules (#1702)

### DIFF
--- a/.changeset/fix-inline-string-literal-mangling.md
+++ b/.changeset/fix-inline-string-literal-mangling.md
@@ -1,0 +1,6 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/cli": patch
+---
+
+`bf build` no longer mangles string-literal contents when inlining a local module into a client component's chunk. The combine and specifier-normalisation passes are now AST-aware, so `import …` lines and `@barefootjs/client` text that merely appear *inside a string value* (e.g. an inlined data module exporting a code snippet) are left untouched. This fixes a hydration break (`ReferenceError: hydrate is not defined`, where the component's real runtime import was relocated into the literal) and a string-corruption bug (`@barefootjs/client` rewritten to `./barefoot.js` inside snippet text).

--- a/packages/cli/src/__tests__/inline-string-literal-1702.test.ts
+++ b/packages/cli/src/__tests__/inline-string-literal-1702.test.ts
@@ -1,0 +1,88 @@
+// Integration test for piconic-ai/barefootjs#1702 — `bf build` must not
+// mangle string-literal contents when inlining a local (non-component)
+// module into a client component's chunk. A data module exporting a code
+// snippet (a string whose *contents* look like real code) used to have its
+// `@barefootjs/client` specifier rewritten to `./barefoot.js` (bug B). This
+// exercises the genuine inline path (`resolveRelativeImports`) followed by
+// the step-6c specifier normalisation.
+
+import { describe, test, expect, beforeEach, afterAll } from 'bun:test'
+import { resolveRelativeImports } from '../lib/resolve-imports'
+import { rewriteBarefootClientSpecifiers } from '../lib/build'
+import { mkdirSync, writeFileSync, rmSync, readFileSync } from 'fs'
+import { resolve } from 'path'
+import { tmpdir } from 'os'
+
+const TEST_DIR = resolve(tmpdir(), `bf-test-1702-${Date.now()}`)
+const DIST_DIR = resolve(TEST_DIR, 'dist')
+const COMPONENTS_DIR = resolve(DIST_DIR, 'components')
+
+beforeEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true })
+  mkdirSync(COMPONENTS_DIR, { recursive: true })
+})
+
+afterAll(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true })
+})
+
+describe('inline string-literal preservation (bf#1702)', () => {
+  test('inlined code-snippet module keeps @barefootjs/client text verbatim', async () => {
+    // The data module: a snippet whose content has a `"use client"` line and
+    // an `import … from '@barefootjs/client'` line.
+    writeFileSync(
+      resolve(COMPONENTS_DIR, 'sample.ts'),
+      [
+        'export const SAMPLE = `"use client"',
+        '',
+        "import { createSignal } from '@barefootjs/client'",
+        '',
+        'export function Counter() {}`',
+      ].join('\n') + '\n',
+    )
+
+    // The compiled client component: a real runtime import plus the data
+    // import that resolveRelativeImports will inline.
+    writeFileSync(
+      resolve(COMPONENTS_DIR, 'Repro.client.js'),
+      [
+        "import { hydrate, createSignal } from '@barefootjs/client/runtime'",
+        "import { SAMPLE } from './sample'",
+        "hydrate('Repro', (el) => { return SAMPLE })",
+      ].join('\n') + '\n',
+    )
+
+    const manifest = {
+      Repro: {
+        clientJs: 'components/Repro.client.js',
+        markedTemplate: 'components/Repro.tsx',
+      },
+    }
+
+    // Step 6b — inline ./sample into Repro.client.js.
+    await resolveRelativeImports({ distDir: DIST_DIR, manifest })
+
+    // Step 6c — normalise @barefootjs/client specifiers to ./barefoot.js.
+    let content = readFileSync(resolve(COMPONENTS_DIR, 'Repro.client.js'), 'utf8')
+    content = rewriteBarefootClientSpecifiers(content, './barefoot.js')
+
+    // The real runtime import is rewritten…
+    expect(content).toContain("from './barefoot.js'")
+    // …but the SAMPLE snippet's contents are untouched: `@barefootjs/client`
+    // survives and the directive/import lines stay inside the string.
+    expect(content).toContain("import { createSignal } from '@barefootjs/client'")
+    expect(content).toContain('"use client"')
+    expect(content).toContain('export function Counter() {}')
+    // The snippet's runtime import was NOT relocated into the string and the
+    // `@barefootjs/client` text was NOT corrupted to ./barefoot.js.
+    expect(content).not.toContain("createSignal } from './barefoot.js'\n\nexport function Counter")
+
+    // And the real runtime import line still binds `hydrate` (it lives below
+    // the inlined `__bf_inline_0` IIFE, not at the very top).
+    const runtimeImport = content
+      .split('\n')
+      .find(l => l.startsWith('import ') && l.includes("from './barefoot.js'"))
+    expect(runtimeImport).toBeDefined()
+    expect(runtimeImport).toContain('hydrate')
+  })
+})

--- a/packages/cli/src/__tests__/merge-imports.test.ts
+++ b/packages/cli/src/__tests__/merge-imports.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test'
-import { mergeDuplicateNamedImports } from '../lib/build'
+import { mergeDuplicateNamedImports, rewriteBarefootClientSpecifiers } from '../lib/build'
 
 describe('mergeDuplicateNamedImports', () => {
   test('no duplicates: content is returned unchanged', () => {
@@ -71,5 +71,77 @@ describe('mergeDuplicateNamedImports', () => {
     const out = mergeDuplicateNamedImports(input)
     // The hybrid line must survive verbatim.
     expect(out).toContain(`import D, { a } from './x'`)
+  })
+
+  test('import-shaped lines inside a string literal are not merged (#1702)', () => {
+    // Two inlined snippets each carrying an `import { a } from '@x'` line
+    // share the same "source" textually, but they live inside template
+    // literals — merging them would drop one and corrupt the string.
+    const input = [
+      `import { hydrate } from './barefoot.js'`,
+      'const __bf_inline_0 = {',
+      "  A: `import { a } from '@x'`,",
+      "  B: `import { a } from '@x'`,",
+      '}',
+    ].join('\n')
+    const out = mergeDuplicateNamedImports(input)
+    // Both snippet strings survive verbatim; nothing is dropped/merged.
+    expect(out).toBe(input)
+  })
+})
+
+describe('rewriteBarefootClientSpecifiers', () => {
+  test('rewrites real import specifiers to the relative runtime path', () => {
+    const input = `import { hydrate } from '@barefootjs/client/runtime'`
+    expect(rewriteBarefootClientSpecifiers(input, './barefoot.js')).toBe(
+      `import { hydrate } from './barefoot.js'`,
+    )
+  })
+
+  test('rewrites bare @barefootjs/client and subpath specifiers', () => {
+    const input = [
+      `import { createSignal } from '@barefootjs/client'`,
+      `import { hydrate } from '@barefootjs/client/runtime'`,
+    ].join('\n')
+    const out = rewriteBarefootClientSpecifiers(input, '../barefoot.js')
+    expect(out).toBe([
+      `import { createSignal } from '../barefoot.js'`,
+      `import { hydrate } from '../barefoot.js'`,
+    ].join('\n'))
+  })
+
+  test('does NOT rewrite @barefootjs/client inside string literals (#1702)', () => {
+    // A code snippet shipped as a string must keep its `@barefootjs/client`
+    // text verbatim; only the real top-level import is rewritten.
+    const input = [
+      `import { hydrate } from '@barefootjs/client/runtime'`,
+      'const __bf_inline_0 = {',
+      "  SAMPLE: `\"use client\"",
+      '',
+      "import { createSignal } from '@barefootjs/client'",
+      '',
+      'export function Counter() {}`,',
+      "  SPECIFIER: \"import { createSignal } from '@barefootjs/client'\",",
+      '}',
+    ].join('\n')
+    const out = rewriteBarefootClientSpecifiers(input, './barefoot.js')
+    // Real import rewritten…
+    expect(out).toContain(`import { hydrate } from './barefoot.js'`)
+    // …string contents untouched.
+    expect(out).toContain("import { createSignal } from '@barefootjs/client'")
+    expect(out).toContain("SPECIFIER: \"import { createSignal } from '@barefootjs/client'\"")
+    expect(out).not.toContain("from './barefoot.js'\n\nexport function Counter")
+  })
+
+  test('rewrites export … from re-exports', () => {
+    const input = `export { createSignal } from '@barefootjs/client'`
+    expect(rewriteBarefootClientSpecifiers(input, './barefoot.js')).toBe(
+      `export { createSignal } from './barefoot.js'`,
+    )
+  })
+
+  test('no-op when @barefootjs/client is absent', () => {
+    const input = `import { foo } from './bar'`
+    expect(rewriteBarefootClientSpecifiers(input, './barefoot.js')).toBe(input)
   })
 })

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -895,12 +895,7 @@ export async function build(
       try {
         let content = await readText(filePath)
         const before = content
-        if (content.includes('@barefootjs/client')) {
-          content = content.replace(
-            /from ['"]@barefootjs\/client(?:\/[^'"]*)?['"]/g,
-            `from '${rel}'`,
-          )
-        }
+        content = rewriteBarefootClientSpecifiers(content, rel)
         content = mergeDuplicateNamedImports(content)
         if (content !== before && await writeIfChanged(filePath, content)) {
           anyOutputChanged = true
@@ -1199,6 +1194,85 @@ export function effectiveOutName(tplPath: string, entryBaseNoExt: string): strin
 }
 
 /**
+ * Line indices (0-based) of `content` that begin a *real* top-level
+ * `import` statement, per the TypeScript parser. Used to keep the
+ * line-based import passes from acting on `import …` text that only
+ * appears inside a string / template literal value. See #1702.
+ */
+function topLevelImportLines(content: string): Set<number> {
+  const lines = new Set<number>()
+  const sourceFile = ts.createSourceFile(
+    'merge.js',
+    content,
+    ts.ScriptTarget.Latest,
+    /*setParentNodes*/ true,
+    ts.ScriptKind.JS,
+  )
+  for (const stmt of sourceFile.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      const { line } = sourceFile.getLineAndCharacterOfPosition(stmt.getStart(sourceFile))
+      lines.add(line)
+    }
+  }
+  return lines
+}
+
+/**
+ * Rewrite `@barefootjs/client*` specifiers to the relative `barefoot.js`
+ * path `rel`, touching only *real* `import` / `export … from` module
+ * specifiers (and dynamic `import('…')` arguments). The predecessor ran a
+ * global regex over the whole file, which also rewrote `@barefootjs/client`
+ * text that merely lived inside a string / template literal value (e.g. an
+ * inlined code-snippet module), corrupting the displayed text. See
+ * piconic-ai/barefootjs#1702.
+ */
+export function rewriteBarefootClientSpecifiers(content: string, rel: string): string {
+  if (!content.includes('@barefootjs/client')) return content
+
+  const sourceFile = ts.createSourceFile(
+    'client.js',
+    content,
+    ts.ScriptTarget.Latest,
+    /*setParentNodes*/ true,
+    ts.ScriptKind.JS,
+  )
+  const isBarefootClient = (s: string) =>
+    s === '@barefootjs/client' || s.startsWith('@barefootjs/client/')
+
+  // Character spans of the specifier string literals to replace.
+  const spans: Array<[number, number]> = []
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+      const ms = node.moduleSpecifier
+      if (ms && ts.isStringLiteral(ms) && isBarefootClient(ms.text)) {
+        spans.push([ms.getStart(sourceFile), ms.getEnd()])
+      }
+    } else if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword
+    ) {
+      const arg = node.arguments[0]
+      if (arg && ts.isStringLiteral(arg) && isBarefootClient(arg.text)) {
+        spans.push([arg.getStart(sourceFile), arg.getEnd()])
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
+
+  if (spans.length === 0) return content
+
+  // Apply replacements back-to-front so earlier offsets stay valid.
+  spans.sort((a, b) => b[0] - a[0])
+  let out = content
+  for (const [start, end] of spans) {
+    out = out.slice(0, start) + `'${rel}'` + out.slice(end)
+  }
+  return out
+}
+
+/**
  * Collapse multiple `import { ... } from 'X'` lines that share the same source
  * into a single line with the union of their names. No-op if every source
  * appears at most once. Only handles the `import { a, b } from 'X'` form —
@@ -1211,7 +1285,15 @@ export function mergeDuplicateNamedImports(content: string): string {
   const dropIndices = new Set<number>()
   let changed = false
 
+  // Restrict merging to lines that are *real* top-level import statements.
+  // An `import { … } from '…'` line living inside a string / template
+  // literal value (e.g. an inlined code-snippet module) matches the regex
+  // too, and merging across such lines would silently rewrite the string's
+  // contents. See piconic-ai/barefootjs#1702.
+  const realImportLines = topLevelImportLines(content)
+
   lines.forEach((line, idx) => {
+    if (!realImportLines.has(idx)) return
     const m = line.match(namedImportRe)
     if (!m) return
     const names = m[1].split(',').map(s => s.trim()).filter(Boolean)

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -1285,6 +1285,22 @@ export function mergeDuplicateNamedImports(content: string): string {
   const dropIndices = new Set<number>()
   let changed = false
 
+  // Cheap pre-scan: are there even two import-shaped lines sharing a source?
+  // Step 6c runs this over every emitted client JS file, so short-circuit
+  // (and skip the TS parse below) for the common case where nothing can
+  // possibly merge.
+  {
+    const seen = new Set<string>()
+    let possibleDuplicate = false
+    for (const line of lines) {
+      const m = line.match(namedImportRe)
+      if (!m) continue
+      if (seen.has(m[3])) { possibleDuplicate = true; break }
+      seen.add(m[3])
+    }
+    if (!possibleDuplicate) return content
+  }
+
   // Restrict merging to lines that are *real* top-level import statements.
   // An `import { … } from '…'` line living inside a string / template
   // literal value (e.g. an inlined code-snippet module) matches the regex

--- a/packages/jsx/src/__tests__/combine-client-js.test.ts
+++ b/packages/jsx/src/__tests__/combine-client-js.test.ts
@@ -204,6 +204,53 @@ describe('combineParentChildClientJs', () => {
     expect(adminCombined).not.toContain('@bf-child:')
   })
 
+  test('does not treat import-shaped lines inside a string literal as real imports (#1702)', () => {
+    // A data module inlined into the parent exports a code snippet whose
+    // *contents* contain a `"use client"` directive and an `import …` line.
+    // The combiner must not relocate the parent's real runtime import into
+    // that string literal, which previously left `hydrate` undefined.
+    const sample = [
+      '`"use client"',
+      '',
+      "import { createSignal } from '@barefootjs/client'",
+      '',
+      'export function Counter() {}`',
+    ].join('\n')
+    const files = new Map([
+      ['Parent', [
+        "import { hydrate, createSignal } from '@barefootjs/client/runtime'",
+        "import '/* @bf-child:Child */'",
+        `const __bf_inline_0 = { SAMPLE: ${sample} };`,
+        "hydrate('Parent', (el) => {})",
+      ].join('\n')],
+      ['Child', [
+        "import { hydrate, createSignal } from '@barefootjs/client/runtime'",
+        "hydrate('Child', (el) => {})",
+      ].join('\n')],
+    ])
+
+    const result = combineParentChildClientJs(files)
+    const combined = result.get('Parent')!
+
+    // The real runtime import survives as the very first line, with `hydrate`.
+    const firstLine = combined.split('\n')[0]
+    expect(firstLine).toContain('hydrate')
+    expect(firstLine).toContain("from '@barefootjs/client/runtime'")
+    // The only real top-level import is the runtime one — the snippet's inner
+    // import line must remain *inside* the `__bf_inline_0` declaration, not
+    // hoisted above it.
+    const inlineIdx = combined.indexOf('const __bf_inline_0')
+    const snippetImportIdx = combined.indexOf("import { createSignal } from '@barefootjs/client'")
+    expect(snippetImportIdx).toBeGreaterThan(inlineIdx)
+
+    // The snippet string is preserved verbatim — its inner import line is
+    // NOT hoisted out, and `@barefootjs/client` stays intact.
+    expect(combined).toContain("import { createSignal } from '@barefootjs/client'")
+    expect(combined).toContain('export function Counter() {}')
+    expect(combined).toContain("hydrate('Parent',")
+    expect(combined).toContain("hydrate('Child',")
+  })
+
   test('deduplicates imports from shared sources', () => {
     const files = new Map([
       ['Parent', [

--- a/packages/jsx/src/combine-client-js.ts
+++ b/packages/jsx/src/combine-client-js.ts
@@ -111,11 +111,14 @@ function parseAndMerge(
   // out of its string relocated the component's real runtime import into
   // the literal and left `hydrate` undefined at call time. See
   // piconic-ai/barefootjs#1702.
+  // Parent pointers aren't needed here — we only read `statements` and each
+  // import's `getStart`/`getEnd` — so skip building them to keep the per-chunk
+  // parse cheap when combining many files.
   const sourceFile = ts.createSourceFile(
     'combine.js',
     content,
     ts.ScriptTarget.Latest,
-    /*setParentNodes*/ true,
+    /*setParentNodes*/ false,
     ts.ScriptKind.JS,
   )
 

--- a/packages/jsx/src/combine-client-js.ts
+++ b/packages/jsx/src/combine-client-js.ts
@@ -8,6 +8,8 @@
  * into the parent's file, eliminating the need for separate HTTP requests.
  */
 
+import ts from 'typescript'
+
 const CHILD_PLACEHOLDER_RE = /import '\/\* @bf-child:(\w+) \*\/'/g
 
 /**
@@ -101,33 +103,72 @@ function parseAndMerge(
   otherImports: string[],
   codeSections: string[]
 ): void {
-  const codeLines: string[] = []
+  // Parse the client JS so we only ever treat *real* top-level
+  // `ImportDeclaration` statements as imports. The predecessor matched
+  // raw lines beginning with `import `, which also caught `import …`
+  // lines that merely live *inside a string / template literal value*
+  // (e.g. a data module exporting a code snippet). Tearing such a line
+  // out of its string relocated the component's real runtime import into
+  // the literal and left `hydrate` undefined at call time. See
+  // piconic-ai/barefootjs#1702.
+  const sourceFile = ts.createSourceFile(
+    'combine.js',
+    content,
+    ts.ScriptTarget.Latest,
+    /*setParentNodes*/ true,
+    ts.ScriptKind.JS,
+  )
 
-  for (const line of content.split('\n')) {
-    if (line.startsWith('import ')) {
-      if (line.includes('@bf-child:')) continue
+  // Character spans of the top-level imports to strip from the emitted
+  // code, so everything that isn't an import (including literals whose
+  // contents look like imports) is preserved verbatim.
+  const importSpans: Array<[number, number]> = []
 
-      const match = line.match(/^import \{ ([^}]+) \} from ['"]([^'"]+)['"]/)
-      if (match) {
-        const names = match[1].split(',').map(n => n.trim())
-        const source = match[2]
-        if (!importsBySource.has(source)) {
-          importsBySource.set(source, new Set())
-        }
-        for (const name of names) {
-          importsBySource.get(source)!.add(name)
-        }
-      } else {
-        if (!otherImports.includes(line)) {
-          otherImports.push(line)
-        }
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isImportDeclaration(stmt)) continue
+    const start = stmt.getStart(sourceFile)
+    const end = stmt.getEnd()
+    importSpans.push([start, end])
+
+    const stmtText = content.slice(start, end)
+    // `@bf-child:` placeholders are resolved by inlining elsewhere; drop
+    // them entirely (neither merged nor kept as code).
+    if (stmtText.includes('@bf-child:')) continue
+
+    const clause = stmt.importClause
+    const bindings = clause?.namedBindings
+    const specifier = ts.isStringLiteral(stmt.moduleSpecifier)
+      ? stmt.moduleSpecifier.text
+      : ''
+    if (clause && !clause.name && bindings && ts.isNamedImports(bindings)) {
+      // Pure named import (`import { a, b as c } from '…'`) — merge by source.
+      if (!importsBySource.has(specifier)) {
+        importsBySource.set(specifier, new Set())
+      }
+      const set = importsBySource.get(specifier)!
+      for (const el of bindings.elements) {
+        const name = el.propertyName
+          ? `${el.propertyName.text} as ${el.name.text}`
+          : el.name.text
+        set.add(name)
       }
     } else {
-      codeLines.push(line)
+      // default / namespace / side-effect import — keep verbatim.
+      if (!otherImports.includes(stmtText)) {
+        otherImports.push(stmtText)
+      }
     }
   }
 
-  const code = codeLines.join('\n').trim()
+  // Reconstruct the code with the import spans removed.
+  let code = ''
+  let cursor = 0
+  for (const [start, end] of importSpans) {
+    code += content.slice(cursor, start)
+    cursor = end
+  }
+  code += content.slice(cursor)
+  code = code.trim()
   if (code) {
     codeSections.push(code)
   }


### PR DESCRIPTION
Fixes #1702.

## Problem

When `bf build` inlines a local (non-component) module into a client component's chunk, the post-processing passes operated on **raw text / lines and ignored string-literal boundaries**. Tokens that merely appeared *inside a string value* were transformed as if they were real code:

- **Bug A — hydration breaks (`ReferenceError: hydrate is not defined`)**: when an inlined string contains an `import …` line, the combine step pulled that line out of the literal and merged it with the component's real runtime import, so `hydrate` was never imported at top level.
- **Bug B — `@barefootjs/client` rewritten to `./barefoot.js` inside strings**: the step-6c specifier-normalisation regex matched `@barefootjs/client` text anywhere, corrupting a displayed code snippet.

Both surfaced in a real theme picker shipping sample code snippets as strings.

## Fix

Make the affected passes **AST-aware** so only real statements / specifiers are touched:

| Pass | File | Change |
|------|------|--------|
| Combine (bug A) | `packages/jsx/src/combine-client-js.ts` | `parseAndMerge` now classifies imports via the TS parser's top-level `ImportDeclaration` statements instead of `line.startsWith('import ')`. Import-shaped lines inside a string/template literal stay put. |
| Step 6c (bug B) | `packages/cli/src/lib/build.ts` | New `rewriteBarefootClientSpecifiers` rewrites only real import / export / dynamic-import module specifiers. |
| Step 6c (same class) | `packages/cli/src/lib/build.ts` | `mergeDuplicateNamedImports` now only merges lines that begin a real top-level import (via the parser), preventing the same corruption across multiple inlined snippets. |

## Tests

- `combine-client-js.test.ts` — import-shaped lines inside a string literal are not hoisted (bug A).
- `merge-imports.test.ts` — `rewriteBarefootClientSpecifiers` rewrites real specifiers but leaves string contents alone (bug B); `mergeDuplicateNamedImports` ignores string-internal import lines.
- `inline-string-literal-1702.test.ts` — integration test running the genuine inline path (`resolveRelativeImports`) + step-6c rewrite, asserting the snippet survives verbatim while the real runtime import is rewritten with `hydrate` intact.

All new tests pass; full `packages/jsx` suite green. (The 4 pre-existing `bf init` failures stem from a missing `runtimes.generated` codegen artifact and are unrelated — they fail on a clean tree too.)

https://claude.ai/code/session_0156UBYwn6BJosPNYjcojVTo

---
_Generated by [Claude Code](https://claude.ai/code/session_0156UBYwn6BJosPNYjcojVTo)_