### PR TITLE
feat(jsx): implement dangerouslySetInnerHTML on the client

### DIFF
--- a/.changeset/client-dangerously-set-inner-html.md
+++ b/.changeset/client-dangerously-set-inner-html.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Implement `dangerouslySetInnerHTML={{ __html }}` on the client. Previously the client codegen treated it as a generic reactive attribute, emitting a bogus `dangerouslySetInnerHTML="[object Object]"` and never setting `innerHTML`, so a `"use client"` component rendered nothing on the client (a silent SSR/CSR mismatch). The client now mirrors the SSR adapters: the `{ __html }` object is suppressed as an attribute, its value is emitted as the element's raw (unescaped) content in the template, and a reactive value also drives an `innerHTML` assignment in init. This is the intentional raw-HTML escape hatch — values are NOT escaped, by design.

--- a/packages/jsx/src/__tests__/dangerously-set-inner-html.test.ts
+++ b/packages/jsx/src/__tests__/dangerously-set-inner-html.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Client-side `dangerouslySetInnerHTML` (the raw-HTML escape hatch).
+ *
+ * The SSR adapters render `dangerouslySetInnerHTML={{ __html: E }}`
+ * natively, but the client codegen used to treat it as a generic reactive
+ * attribute — emitting a bogus `dangerouslySetInnerHTML="[object Object]"`
+ * and never setting `innerHTML`, so a `"use client"` component silently
+ * lost the content on the client. These tests pin the corrected emit:
+ *   - the `{ __html }` object is NEVER serialised as an attribute;
+ *   - the element's raw HTML is emitted as its content (UNescaped — this
+ *     is the intentional escape hatch);
+ *   - a reactive value also drives an `innerHTML` assignment in init.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function getClientJs(source: string, filename: string): string {
+  const result = compileJSX(source, filename, { adapter })
+  expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+  const clientJs = result.files.find(f => f.type === 'clientJs')
+  expect(clientJs).toBeDefined()
+  return clientJs!.content
+}
+
+describe('dangerouslySetInnerHTML (client)', () => {
+  test('reactive value: raw content + innerHTML init, no bogus attribute', () => {
+    const clientJs = getClientJs(
+      `'use client'
+       export function Raw({ html }: { html: string }) {
+         return <div class="x" dangerouslySetInnerHTML={{ __html: html }} />
+       }`,
+      'Raw.tsx',
+    )
+    // Never emitted as an attribute.
+    expect(clientJs).not.toMatch(/dangerouslySetInnerHTML="/)
+    // Raw `.__html` emitted as element content — not via escapeText.
+    expect(clientJs).toMatch(/<div class="x"[^>]*>\$\{.*\.__html.*\}<\/div>/)
+    expect(clientJs).not.toMatch(/escapeText\([^)]*__html/)
+    // Reactive update assigns innerHTML (not setAttribute).
+    expect(clientJs).toMatch(/\.innerHTML = /)
+    expect(clientJs).not.toMatch(/setAttribute\('dangerouslySetInnerHTML'/)
+  })
+
+  test('static value: raw content emitted in the template (no init needed)', () => {
+    const clientJs = getClientJs(
+      `'use client'
+       export function S() {
+         return <div dangerouslySetInnerHTML={{ __html: '<b>hi</b>' }} />
+       }`,
+      'S.tsx',
+    )
+    expect(clientJs).not.toMatch(/dangerouslySetInnerHTML="/)
+    // The literal HTML survives raw in the template content.
+    expect(clientJs).toMatch(/<div[^>]*>\$\{.*__html.*\}<\/div>/)
+    expect(clientJs).not.toMatch(/escapeText\([^)]*__html/)
+  })
+})

--- a/packages/jsx/src/__tests__/dangerously-set-inner-html.test.ts
+++ b/packages/jsx/src/__tests__/dangerously-set-inner-html.test.ts
@@ -45,6 +45,27 @@ describe('dangerouslySetInnerHTML (client)', () => {
     expect(clientJs).not.toMatch(/setAttribute\('dangerouslySetInnerHTML'/)
   })
 
+  test('spread + dangerouslySetInnerHTML: kept out of the spreadAttrs merge', () => {
+    // An element that also carries a spread switches to the
+    // `${spreadAttrs({...})}` merge form; `dangerouslySetInnerHTML` must
+    // not be folded into that object (it would serialise as a bogus
+    // `dangerouslySetInnerHTML="[object Object]"` attribute).
+    const clientJs = getClientJs(
+      `'use client'
+       export function A({ rest, html }: { rest: Record<string, unknown>; html: string }) {
+         return <div {...rest} class="x" dangerouslySetInnerHTML={{ __html: html }} />
+       }`,
+      'A.tsx',
+    )
+    expect(clientJs).toContain('spreadAttrs(')
+    // The merge object must NOT contain a dangerouslySetInnerHTML key…
+    expect(clientJs).not.toMatch(/spreadAttrs\([^)]*dangerouslySetInnerHTML/)
+    expect(clientJs).not.toMatch(/dangerouslySetInnerHTML="/)
+    // …and the raw HTML is still emitted as the element's content.
+    expect(clientJs).toMatch(/<\/div>/)
+    expect(clientJs).toMatch(/\.__html/)
+  })
+
   test('static value: raw content emitted in the template (no init needed)', () => {
     const clientJs = getClientJs(
       `'use client'

--- a/packages/jsx/src/ir-to-client-js/emit-reactive.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-reactive.ts
@@ -17,6 +17,15 @@ import { createTemplateAwareStringProtector } from './html-template'
  */
 export function emitAttrUpdate(target: string, attrName: string, expression: string, meta: AttrMeta): string[] {
   const htmlName = toHtmlAttrName(attrName)
+  if (attrName === 'dangerouslySetInnerHTML' || htmlName === 'dangerouslySetInnerHTML') {
+    // `{ __html }` is not an attribute — it replaces the element's content.
+    // Assign `innerHTML` (raw, intentional escape hatch) to mirror the SSR
+    // adapters' native `dangerouslySetInnerHTML` handling instead of
+    // stringifying the object into a bogus attribute.
+    return [
+      `{ const __v = ${expression}; ${target}.innerHTML = __v != null && __v.__html != null ? String(__v.__html) : '' }`,
+    ]
+  }
   if (htmlName === 'style') {
     return [
       `{ const __v = styleToCss(${expression}); if (__v != null) ${target}.setAttribute('style', __v); else ${target}.removeAttribute('style') }`,

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -380,6 +380,12 @@ export interface MergeContext {
 function isMergeableAttr(a: IRAttribute, ctx: MergeContext): boolean {
   if (ctx.honorClientOnly && a.clientOnly) return false
   if (a.name === 'key') return false
+  // `dangerouslySetInnerHTML` is not an attribute — its `{ __html }` value
+  // becomes the element's raw innerHTML (emitted as content, set via
+  // `innerHTML` in init). Keep it out of the `spreadAttrs({...})` merge so
+  // it isn't serialised back into a bogus `dangerouslySetInnerHTML="…"`
+  // attribute when the element also carries a spread.
+  if (a.name === 'dangerouslySetInnerHTML') return false
   const v = a.value
   if (v.kind === 'jsx-children') return false
   if (v.kind === 'boolean-shorthand') return false

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -192,6 +192,11 @@ const UNSAFE_TEMPLATE_EXPR = 'undefined'
  * @param attr - Attribute metadata (only presenceOrUndefined flag is used)
  */
 function templateAttrExpr(attrName: string, valExpr: string, presenceOrUndefined?: boolean): string {
+  // `dangerouslySetInnerHTML={{ __html }}` is not an attribute — its value
+  // becomes the element's raw innerHTML (emitted as element content). Never
+  // serialise the `{ __html }` object into a `dangerouslySetInnerHTML="…"`
+  // attribute.
+  if (attrName === 'dangerouslySetInnerHTML') return ''
   if (isBooleanAttr(attrName) || presenceOrUndefined) {
     return `\${${valExpr} ? '${attrName}' : ''}`
   }
@@ -238,6 +243,27 @@ function escapeAttrValueExpr(valExpr: string): string {
  */
 function escapeTextSlotExpr(innerExpr: string): string {
   return `escapeText(${innerExpr})`
+}
+
+/**
+ * `dangerouslySetInnerHTML={{ __html: E }}` makes the element's content its
+ * raw innerHTML — the intentional, React-style escape hatch. Returns the
+ * raw-content template expression to use *instead of* the element's normal
+ * children (emitted UNescaped by design, mirroring the SSR adapters'
+ * native handling), or `null` when the element carries no such attribute.
+ * The attribute itself is suppressed in `templateAttrExpr`, and the
+ * matching reactive update is emitted by `emitAttrUpdate` (assigns
+ * `innerHTML`). `toExpr` is the walker's value transform (`wrapExpr` /
+ * `transformExpr`) so the `{ __html }` object is lowered the same way an
+ * attribute value would be.
+ */
+function dangerouslyHtmlChildren(
+  attrs: ReadonlyArray<IRAttribute>,
+  toExpr: (v: { expr: string; templateExpr?: string }) => string,
+): string | null {
+  const attr = attrs.find(a => a.name === 'dangerouslySetInnerHTML')
+  if (!attr || attr.value.kind !== 'expression') return null
+  return `\${((${toExpr(attr.value)}) ?? {}).__html ?? ''}`
 }
 
 /**
@@ -508,7 +534,7 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
 
       const attrs = attrParts.join(' ')
       const childrenRecurse = (n: IRNode): string => irToHtmlTemplate(n, restSpreadNames, loopDepth, loopParams, branchSlotsVar, insideLoop, false)
-      const children = node.children.map(childrenRecurse).join('')
+      const children = dangerouslyHtmlChildren(node.attrs, v => wrapExpr(v.expr)) ?? node.children.map(childrenRecurse).join('')
 
       // Non-void elements must use open+close tags (HTML parsers ignore self-closing on div, span, etc.)
       if (children || !VOID_ELEMENTS.has(node.tag)) {
@@ -696,7 +722,7 @@ export function irToPlaceholderTemplate(node: IRNode, restSpreadNames?: Set<stri
       }
 
       const attrs = attrParts.join(' ')
-      const children = node.children.map(recurse).join('')
+      const children = dangerouslyHtmlChildren(node.attrs, v => wrapExpr(v.expr)) ?? node.children.map(recurse).join('')
 
       if (children || !VOID_ELEMENTS.has(node.tag)) {
         return `<${node.tag}${attrs ? ' ' + attrs : ''}>${children}</${node.tag}>`
@@ -1081,7 +1107,7 @@ function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): str
       }
 
       const attrs = attrParts.join(' ')
-      const children = node.children.map(childrenRecurse).join('')
+      const children = dangerouslyHtmlChildren(node.attrs, v => transformExpr(v.expr, v.templateExpr)) ?? node.children.map(childrenRecurse).join('')
 
       if (children || !VOID_ELEMENTS.has(node.tag)) {
         return `<${node.tag}${attrs ? ' ' + attrs : ''}>${children}</${node.tag}>`
@@ -1457,7 +1483,7 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
       }
 
       const attrs = attrParts.join(' ')
-      const children = node.children.map(childrenRecurse).join('')
+      const children = dangerouslyHtmlChildren(node.attrs, v => transformExpr(v.expr, v.templateExpr)) ?? node.children.map(childrenRecurse).join('')
 
       if (children || !VOID_ELEMENTS.has(node.tag)) {
         return `<${node.tag}${attrs ? ' ' + attrs : ''}>${children}</${node.tag}>`


### PR DESCRIPTION
## Background

While reviewing the escape-hatch story after the #1694/#1697/#1700 text-escaping work, we found that `dangerouslySetInnerHTML={{ __html }}` — the intended way to *deliberately bypass* escaping — **only works on the server**.

The SSR adapters (Hono) render it natively, but the **client codegen treated it as a generic reactive attribute**:

```js
// init:     _s0.setAttribute('dangerouslySetInnerHTML', String({ __html: _p.html }))
//           → dangerouslySetInnerHTML="[object Object]"  (never sets innerHTML)
// template: 'dangerouslySetInnerHTML="' + escapeAttr({ __html: _p.html }) + '"'
```

So a `"use client"` component rendered the raw HTML on the server and then **silently dropped it on the client** (a `[object Object]` attribute, no `innerHTML`, **no diagnostic**) — an un-diagnosed SSR/CSR mismatch, and no working raw-HTML escape hatch on the client.

## Change

Mirror the SSR behaviour in `ir-to-client-js`:

- **`templateAttrExpr`** suppresses the `{ __html }` object — it is never serialised as an attribute.
- **Element content** becomes the raw `.__html` value (emitted **unescaped** — the intentional escape hatch) via a new `dangerouslyHtmlChildren` helper applied in all four element-template walkers. This makes **static** `__html` work without an effect and keeps the client template byte-aligned with the SSR output.
- **`emitAttrUpdate`** assigns `innerHTML` (not `setAttribute`), so a **reactive** value updates the content.

```js
// reactive
template: (_p) => `<div class="x" bf="s0">${(({ __html: _p.html }) ?? {}).__html ?? ''}</div>`
init:     { const __v = { __html: _p.html }; _s0.innerHTML = __v != null && __v.__html != null ? String(__v.__html) : '' }
// static
template: (_p) => `<div>${(({ __html: '<b>hi</b>' }) ?? {}).__html ?? ''}</div>`
```

Non-`dangerouslySetInnerHTML` output is unchanged (the new branches are gated on the attribute name), so there is no snapshot churn.

## Verification

End-to-end: `renderCsrComponent` (client template + init) produces the same raw content as the Hono SSR render, for both reactive and static `__html`:

```
CSR: <div class="x" bf-s="test" bf="s0"><b>bold</b> & <i>x</i></div>
SSR: <div class="x" ... bf="s0"><b>bold</b> & <i>x</i></div>   (diff = SSR-only bf-r/bf-p)
```

| Suite | Result |
|---|---|
| jsx unit (incl. new `dangerously-set-inner-html.test.ts`) | 1831 pass / 0 fail |
| client runtime | 327 pass / 0 fail |
| adapter-tests `src` | 551 pass / 0 fail |

## Scope note

This is the **client codegen** fix. SSR `dangerouslySetInnerHTML` support is per-adapter; Hono handles it natively (verified). Whether the Go-template / Mojolicious adapters render it is a **separate** concern and out of scope here — so this PR intentionally does **not** add a cross-adapter conformance fixture (which would require all SSR adapters to support it). The change is locked by the compiler unit test instead.

⚠️ As with React, `dangerouslySetInnerHTML` renders **unescaped** HTML and is an XSS vector if fed untrusted input — that is the deliberate, documented behaviour of the escape hatch.

https://claude.ai/code/session_01FiQUsbdKmBeCiYYfwVM2o2

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiQUsbdKmBeCiYYfwVM2o2)_