### PR TITLE
fix(client,shared): handle dangerouslySetInnerHTML via spread/rest objects

### DIFF
--- a/.changeset/dsih-spread-rest.md
+++ b/.changeset/dsih-spread-rest.md
@@ -1,0 +1,6 @@
+---
+"@barefootjs/shared": patch
+"@barefootjs/client": patch
+---
+
+Handle `dangerouslySetInnerHTML` arriving through a spread/rest object in the runtime spread helpers (follow-up to the explicit-attribute support in #1704). `classifyDOMProp` now classifies it as a dedicated `innerHTML` kind; `spreadAttrs` skips it (so a spread carrying it no longer serialises a bogus `dangerouslySetInnerHTML="[object Object]"` attribute), and `applyRestAttrs` assigns the raw `el.innerHTML = value.__html` (the escape hatch) instead of `setAttribute`.

--- a/packages/client/__tests__/runtime/apply-rest-attrs.test.ts
+++ b/packages/client/__tests__/runtime/apply-rest-attrs.test.ts
@@ -40,6 +40,24 @@ describe('applyRestAttrs', () => {
     expect(attr).not.toContain('[object Object]')
   })
 
+  test('dangerouslySetInnerHTML from a rest object sets innerHTML, not an attribute', () => {
+    const el = document.createElement('div')
+    document.body.appendChild(el)
+
+    applyRestAttrs(
+      el,
+      { class: 'y', dangerouslySetInnerHTML: { __html: '<b>x</b> & <i>z</i>' } },
+      [],
+    )
+
+    // Raw HTML becomes real child elements (the escape hatch)…
+    expect(el.querySelector('b')?.textContent).toBe('x')
+    expect(el.querySelector('i')?.textContent).toBe('z')
+    expect(el.getAttribute('class')).toBe('y')
+    // …never a bogus `dangerouslySetInnerHTML="[object Object]"` attribute.
+    expect(el.hasAttribute('dangerouslySetInnerHTML')).toBe(false)
+  })
+
   test('multi-property style object is serialized with kebab-case keys', () => {
     const el = document.createElement('div')
     document.body.appendChild(el)
@@ -103,6 +121,18 @@ describe('applyRestAttrs', () => {
 })
 
 describe('spreadAttrs', () => {
+  test('dangerouslySetInnerHTML is skipped (never a bogus attribute)', () => {
+    const out = spreadAttrs({
+      class: 'y',
+      dangerouslySetInnerHTML: { __html: '<b>x</b>' },
+    })
+    // Emitted as an attribute string, it can't carry content — so it must
+    // be dropped, not serialised as `dangerouslySetInnerHTML="[object Object]"`.
+    expect(out).toBe('class="y"')
+    expect(out).not.toContain('dangerouslySetInnerHTML')
+    expect(out).not.toContain('[object Object]')
+  })
+
   test('object-valued `style` becomes a CSS string attribute', () => {
     const out = spreadAttrs({ style: { '--stat-c': 'hsl(142 71% 45%)' } })
     expect(out).toContain('style="--stat-c:hsl(142 71% 45%)"')

--- a/packages/client/src/runtime/apply-rest-attrs.ts
+++ b/packages/client/src/runtime/apply-rest-attrs.ts
@@ -64,7 +64,13 @@ export function applyRestAttrs(
     for (const { key, c } of attrEntries) {
       const value = source[key]
 
-      if (value != null && value !== false) {
+      if (c.kind === 'innerHTML') {
+        // `dangerouslySetInnerHTML={{ __html }}` arriving via a rest object —
+        // set the element's raw innerHTML (the escape hatch), never an
+        // attribute. Reactive: re-runs when `source` changes.
+        const html = value as { __html?: unknown } | null | undefined
+        el.innerHTML = html != null && html.__html != null ? String(html.__html) : ''
+      } else if (value != null && value !== false) {
         if (c.kind === 'property' && c.attrName === 'value' && 'value' in el) {
           const strVal = String(value)
           if ((el as HTMLInputElement).value !== strVal) (el as HTMLInputElement).value = strVal

--- a/packages/client/src/runtime/spread-attrs.ts
+++ b/packages/client/src/runtime/spread-attrs.ts
@@ -23,6 +23,12 @@ export function spreadAttrs(obj: Record<string, unknown>): string {
     if (value == null || value === false) continue
     const c = classifyDOMProp(key)
     if (c.kind === 'event' || c.kind === 'skip' || c.kind === 'ref') continue
+    // `dangerouslySetInnerHTML` is not an attribute — its `{ __html }` is the
+    // element's content, which this attribute-string builder can't emit. Skip
+    // it so a spread carrying it never serialises a bogus
+    // `dangerouslySetInnerHTML="[object Object]"`. (Content is set by the
+    // template for an explicit attr, or by `applyRestAttrs` for a rest object.)
+    if (c.kind === 'innerHTML') continue
     if (c.kind === 'style') {
       const css = styleToCss(value)
       if (css != null) parts.push(`style="${css}"`)

--- a/packages/shared/src/__tests__/dom-prop.test.ts
+++ b/packages/shared/src/__tests__/dom-prop.test.ts
@@ -10,6 +10,13 @@ describe('classifyDOMProp', () => {
     expect(classifyDOMProp('ref')).toEqual({ kind: 'ref', attrName: 'ref' })
   })
 
+  test('dangerouslySetInnerHTML → innerHTML', () => {
+    expect(classifyDOMProp('dangerouslySetInnerHTML')).toEqual({
+      kind: 'innerHTML',
+      attrName: 'dangerouslySetInnerHTML',
+    })
+  })
+
   test('onClick → event', () => {
     const c = classifyDOMProp('onClick')
     expect(c.kind).toBe('event')

--- a/packages/shared/src/dom-prop.ts
+++ b/packages/shared/src/dom-prop.ts
@@ -110,6 +110,7 @@ export type DOMPropKind =
   | 'property'  // value, checked — must use DOM property, not setAttribute
   | 'boolean'   // disabled, hidden, … — presence/absence attribute
   | 'attr'      // regular setAttribute target
+  | 'innerHTML' // dangerouslySetInnerHTML — { __html } sets el.innerHTML, never an attribute
 
 export interface DOMPropClassification {
   kind: DOMPropKind
@@ -135,6 +136,7 @@ function isEventProp(key: string): boolean {
 export function classifyDOMProp(key: string): DOMPropClassification {
   if (key === 'children') return { kind: 'skip', attrName: key }
   if (key === 'ref')      return { kind: 'ref', attrName: key }
+  if (key === 'dangerouslySetInnerHTML') return { kind: 'innerHTML', attrName: key }
   if (isEventProp(key))   return { kind: 'event', attrName: key }
 
   const attrName = toHTMLAttrNameRuntime(key)


### PR DESCRIPTION
Follow-up to #1704, addressing the remaining review comment (the runtime spread/rest path for `dangerouslySetInnerHTML`).

## Problem

#1704 implemented the explicit-attribute form `<div dangerouslySetInnerHTML={{ __html }} />`. But when `dangerouslySetInnerHTML` flows through a **runtime spread/rest object** — e.g. `<div {...rest} />` where `rest` carries it — the shared classifier and the runtime spread helpers still treated it as a normal attribute:

- `spreadAttrs` (template attribute-string builder) → `dangerouslySetInnerHTML="[object Object]"`
- `applyRestAttrs` (init) → `setAttribute('dangerouslySetInnerHTML', '[object Object]')`

So the escape hatch leaked a bogus attribute and never set `innerHTML`.

## Change

- **`classifyDOMProp` (`@barefootjs/shared`)**: classify `dangerouslySetInnerHTML` as a dedicated `innerHTML` kind — one source of truth shared by both runtime helpers.
- **`spreadAttrs`**: skip the `innerHTML` kind. An attribute-string builder can't carry element content, so emitting nothing is the correct outcome — no more bogus `dangerouslySetInnerHTML="[object Object]"`.
- **`applyRestAttrs`**: for the `innerHTML` kind, assign `el.innerHTML = value.__html` (raw — the escape hatch), reactively, instead of `setAttribute`.

## Scope / known limitation

A spread routed **purely** through the `${spreadAttrs(...)}` template form still cannot *render* dSIH **content** — `spreadAttrs` produces an attribute string, not element content, and the compiler can't know a runtime object's keys to emit a content slot. After this change it no longer emits a bogus attribute; the **content-bearing** paths work:
- explicit `dangerouslySetInnerHTML={{ __html }}` (template content + `innerHTML` init) — #1704;
- `applyRestAttrs` rest objects (this PR) — `innerHTML` set in init.

Fully rendering content from a `spreadAttrs`-template-only spread would require coordinated compiler + SSR-adapter work and is out of scope.

## Verification

| Suite | Result |
|---|---|
| `@barefootjs/shared` (incl. classifier test) | 47 pass / 0 fail |
| client runtime (incl. spreadAttrs-skip + applyRestAttrs-innerHTML tests) | 329 pass / 0 fail |
| jsx unit (shared-classifier consumer) | 1832 pass / 0 fail |
| adapter-tests `src` | 551 pass / 0 fail |

⚠️ As with React, `dangerouslySetInnerHTML` renders **unescaped** HTML — an XSS vector if fed untrusted input. Intentional, documented behaviour.

https://claude.ai/code/session_01FiQUsbdKmBeCiYYfwVM2o2

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiQUsbdKmBeCiYYfwVM2o2)_