### PR TITLE
fix(cli): keep dist/components in JSX-transform scope for hono-node scaffold

### DIFF
--- a/.changeset/fix-hono-node-scaffold-tsconfig-jsx.md
+++ b/.changeset/fix-hono-node-scaffold-tsconfig-jsx.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/cli": patch
+---
+
+Fix the Hono (Node) scaffold's `tsconfig.json` excluding `dist/components`, where `bf build` writes the compiled SSR templates the server imports via the `@/components/*` path mapping. `tsx` applies the JSX transform per-file and honours tsconfig `include`/`exclude`, so an excluded `.tsx` lost `jsxImportSource: "@barefootjs/hono/jsx"` and fell back to the classic React runtime — the first SSR render threw `ReferenceError: React is not defined` and every page 500'd. The compiled templates now stay in transform scope. The Cloudflare/wrangler `hono` scaffold is unaffected (wrangler's esbuild applies the JSX option globally during bundling).

--- a/packages/cli/src/__tests__/templates.test.ts
+++ b/packages/cli/src/__tests__/templates.test.ts
@@ -57,6 +57,20 @@ describe('adapter registry', () => {
     expect(honoNode.devDependencies['@types/node']).toBeTruthy()
   })
 
+  test('hono-node tsconfig keeps dist/components in JSX-transform scope', () => {
+    // The server imports the compiled SSR templates from dist/components
+    // (via the @/components/* path mapping). `tsx` applies the JSX
+    // transform per-file, honouring this tsconfig's include/exclude — so
+    // excluding dist/components strips `jsxImportSource` from those .tsx
+    // files and SSR throws `ReferenceError: React is not defined` on the
+    // first render. Pin that they stay in scope.
+    const tsconfig = ADAPTERS['hono-node'].files['tsconfig.json']
+    expect(tsconfig).toContain('"jsxImportSource": "@barefootjs/hono/jsx"')
+    const excludeMatch = tsconfig.match(/"exclude":\s*\[([^\]]*)\]/)
+    expect(excludeMatch).not.toBeNull()
+    expect(excludeMatch![1]).not.toContain('dist/components')
+  })
+
   // Regression guards for the "edits don't reach the browser" class
   // of bug. Each adapter that does SSR has to invalidate *something*
   // per request in dev — otherwise the boot-time render cache buries

--- a/packages/cli/src/lib/adapters/hono-node.ts
+++ b/packages/cli/src/lib/adapters/hono-node.ts
@@ -230,7 +230,13 @@ const HONO_NODE_TSCONFIG = `{
     }
   },
   "include": ["**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules", "dist/components"]
+  // Do NOT exclude dist/components here. The server imports the compiled
+  // SSR templates from there (see the @/components/* paths above), and
+  // tsx applies the JSX transform per-file honouring this include/
+  // exclude — an excluded .tsx loses jsxImportSource and falls back to
+  // the classic React runtime, so SSR throws "ReferenceError: React is
+  // not defined" at the first render. They must stay in scope.
+  "exclude": ["node_modules"]
 }
 `
 


### PR DESCRIPTION
## Problem

While verifying PR #1696's pkg.pr.new build against a fresh **Hono (Node) scaffold**, the first SSR request 500'd:

```
ReferenceError: React is not defined
    at Counter (dist/components/Counter.tsx:48:5)
```

This reproduces against the stock `hono-node` scaffold — it's not specific to #1696.

## Root cause

The `hono-node` starter's `tsconfig.json` excluded `dist/components`, which is exactly where `bf build` writes the compiled SSR templates the server imports (via the `@/components/*` path mapping). `tsx` applies the JSX transform **per-file** and honours tsconfig `include`/`exclude`, so an excluded `.tsx` loses `jsxImportSource: "@barefootjs/hono/jsx"` and falls back to the classic `React.createElement` runtime — which isn't in scope, so every page 500s on the first render.

The Cloudflare/wrangler `hono` scaffold and `integrations/hono` are **unaffected**: wrangler's esbuild applies the JSX option globally during bundling rather than per-file, so the exclude is harmless there.

## Fix

- Drop `dist/components` from the `hono-node` tsconfig `exclude`, with a comment documenting why it must not be re-added.
- Add a `templates.test.ts` regression guard pinning that the exclude list never contains `dist/components`.

## Verification

Controlled A/B in a standalone scaffold consuming the pkg.pr.new packages, with caches cleared each run:

| tsconfig exclude | result |
|---|---|
| `["node_modules", "dist/components"]` (before) | **HTTP 500**, `React is not defined` |
| `["node_modules"]` (after) | **HTTP 200**, Counter renders + hydrates |

Re-ran with the exact scaffold-generated tsconfig → HTTP 200, Counter SSR + client hydration + signal reactivity all work. `bun test src/__tests__/templates.test.ts` → 45 pass.

https://claude.ai/code/session_01QxKtaUd7jY363qDzpokRNu

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxKtaUd7jY363qDzpokRNu)_