### PR TITLE
fix(integrations): clear BF043 warning in TextEscape

### DIFF
--- a/integrations/shared/components/TextEscape.tsx
+++ b/integrations/shared/components/TextEscape.tsx
@@ -12,11 +12,11 @@ import { createSignal } from '@barefootjs/client'
  * path; `<Tag>` inside `label` must surface as literal text, never a real
  * element.
  */
-export function TextEscape({ label }: { label: string }) {
+export function TextEscape(props: { label: string }) {
   const [count, setCount] = createSignal(0)
   return (
     <div class="text-escape">
-      <p class="label">{label}</p>
+      <p class="label">{props.label}</p>
       <button type="button" onClick={() => setCount(count() + 1)}>
         count: {count()}
       </button>

--- a/packages/adapter-tests/fixtures/__snapshots__/text-escape.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/text-escape.client.js
@@ -5,8 +5,6 @@ export function initTextEscape(__scope, _p = {}) {
   if (!__scope) return
   const __scopeId = __scope.getAttribute('bf-s')
 
-  const label = _p.label
-
   const [count, setCount] = createSignal(0)
 
   const [_s3] = $(__scope, 's3')
@@ -14,7 +12,7 @@ export function initTextEscape(__scope, _p = {}) {
 
   let __anchor_s0 = _s0
   createEffect(() => {
-    const __val = label
+    const __val = _p.label
     __anchor_s0 = __bfText(__anchor_s0, __val)
   })
 


### PR DESCRIPTION
## What

`TextEscape` is a stateful component (it owns a `count` signal), so destructuring `{ label }` in its parameter list triggers:

```
warning[BF043]: Props destructuring in function parameters breaks reactivity. Use props object directly.
```

This is a legitimate warning, not a false positive — the codebase documents the same rule in `ReactiveProps.tsx`:

> `props.xxx` access preserves reactivity while destructured props capture the initial value.

## Change

- `TextEscape.tsx`: switch from `({ label }: { label: string })` to `(props: { label: string })` and read `props.label`, matching the framework's recommended pattern.
- Regenerated `text-escape.client.js` snapshot: the label text effect now reads `_p.label` reactively instead of capturing it once via `const label = _p.label`. The `text-escape.html` snapshot is unchanged.

## Verification

- `bun test packages/adapter-tests/` → 551 pass, 0 fail (adapter + CSR conformance).
- Integrations build (`integrations/hono`) compiles cleanly with no BF043 warning.

https://claude.ai/code/session_018boPjEpmwMeMEsXB31sGUB

---
_Generated by [Claude Code](https://claude.ai/code/session_018boPjEpmwMeMEsXB31sGUB)_