### PR TITLE
fix(integrations/h3): deploy to Cloudflare Workers so /integrations/h3 resolves

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,7 @@ on:
           - ui
           - integrations
           - integrations-hono
+          - integrations-h3
           - integrations-echo
           - integrations-mojolicious
 
@@ -153,6 +154,44 @@ jobs:
 
       - name: Deploy to Cloudflare Workers
         run: cd integrations/hono && bunx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+  deploy-integrations-h3:
+    if: >-
+      github.event_name == 'workflow_dispatch' && (github.event.inputs.site == 'all' || github.event.inputs.site == 'integrations' || github.event.inputs.site == 'integrations-h3')
+      || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+
+      # Wrangler 4.x shells out to Node and requires v22+. The runner's
+      # default Node 20 makes `bunx wrangler deploy` exit immediately.
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build packages
+        run: |
+          bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/client' build
+          bun run --filter '@barefootjs/hono' build
+
+      - name: Build integration
+        run: cd integrations/h3 && bun run build
+
+      - name: Deploy to Cloudflare Workers
+        run: cd integrations/h3 && bunx wrangler deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 

--- a/integrations/h3/e2e/ai-chat.spec.ts
+++ b/integrations/h3/e2e/ai-chat.spec.ts
@@ -6,4 +6,4 @@
 
 import { aiChatTests } from '../../shared/e2e/ai-chat.spec'
 
-aiChatTests('http://localhost:3003')
+aiChatTests('http://localhost:3003/integrations/h3')

--- a/integrations/h3/e2e/counter.spec.ts
+++ b/integrations/h3/e2e/counter.spec.ts
@@ -6,4 +6,4 @@
 
 import { counterTests } from '../../shared/e2e/counter.spec'
 
-counterTests('http://localhost:3003')
+counterTests('http://localhost:3003/integrations/h3')

--- a/integrations/h3/e2e/todo-app-ssr.spec.ts
+++ b/integrations/h3/e2e/todo-app-ssr.spec.ts
@@ -6,4 +6,4 @@
 
 import { todoAppTests } from '../../shared/e2e/todo-app.spec'
 
-todoAppTests('http://localhost:3003', '/todos-ssr')
+todoAppTests('http://localhost:3003/integrations/h3', '/todos-ssr')

--- a/integrations/h3/e2e/todo-app.spec.ts
+++ b/integrations/h3/e2e/todo-app.spec.ts
@@ -6,4 +6,4 @@
 
 import { todoAppTests } from '../../shared/e2e/todo-app.spec'
 
-todoAppTests('http://localhost:3003')
+todoAppTests('http://localhost:3003/integrations/h3')

--- a/integrations/h3/e2e/toggle.spec.ts
+++ b/integrations/h3/e2e/toggle.spec.ts
@@ -6,4 +6,4 @@
 
 import { toggleTests } from '../../shared/e2e/toggle.spec'
 
-toggleTests('http://localhost:3003')
+toggleTests('http://localhost:3003/integrations/h3')

--- a/integrations/h3/package.json
+++ b/integrations/h3/package.json
@@ -3,9 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "bun run ../../packages/cli/src/index.ts build",
+    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/assemble-public.ts",
     "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
-    "dev": "bun run build && bun run --watch server.tsx",
+    "dev": "bun run build && wrangler dev",
+    "deploy": "bun run build && wrangler deploy",
     "start": "bun run server.tsx",
     "test:e2e": "bunx playwright test"
   },
@@ -18,6 +19,7 @@
     "hono": "^4"
   },
   "devDependencies": {
-    "bun-types": "^1.1.0"
+    "bun-types": "^1.1.0",
+    "wrangler": "^4"
   }
 }

--- a/integrations/h3/playwright.config.ts
+++ b/integrations/h3/playwright.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
   use: {
-    baseURL: 'http://localhost:3003',
+    baseURL: 'http://localhost:3003/integrations/h3',
     trace: 'on-first-retry',
   },
   projects: [
@@ -25,7 +25,7 @@ export default defineConfig({
     // (barefoot.js) must already exist — built by `@barefootjs/client` in
     // CI before this runs, same as the other integrations.
     command: 'bun run build && bun run start',
-    url: 'http://localhost:3003',
+    url: 'http://localhost:3003/integrations/h3',
     reuseExistingServer: !process.env.CI,
     timeout: 30000,
   },

--- a/integrations/h3/scripts/assemble-public.ts
+++ b/integrations/h3/scripts/assemble-public.ts
@@ -1,0 +1,40 @@
+/**
+ * Assemble ./public/ for Cloudflare Workers Assets.
+ *
+ * Mirrors the URL layout the Worker serves so `env.ASSETS.fetch(request)`
+ * resolves directly:
+ *   /integrations/h3/static/components/*  ← dist/components/*.{js,map} + manifest.json
+ *   /integrations/h3/shared/styles/*      ← ../shared/styles/*
+ */
+
+import { readdir, mkdir, copyFile, rm } from 'node:fs/promises'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const ROOT = join(HERE, '..')
+const BASE = process.env.BASE_PATH ?? '/integrations/h3'
+const PUBLIC_DIR = join(ROOT, 'public')
+
+async function copyDir(src: string, destRel: string, filter?: (name: string) => boolean) {
+  const dest = join(PUBLIC_DIR, destRel)
+  await mkdir(dest, { recursive: true })
+  const entries = await readdir(src, { withFileTypes: true })
+  for (const e of entries) {
+    if (!e.isFile()) continue
+    if (filter && !filter(e.name)) continue
+    await copyFile(join(src, e.name), join(dest, e.name))
+  }
+}
+
+await rm(PUBLIC_DIR, { recursive: true, force: true })
+
+await copyDir(
+  join(ROOT, 'dist/components'),
+  `${BASE}/static/components`,
+  (name) => name.endsWith('.js') || name.endsWith('.map') || name === 'manifest.json',
+)
+
+await copyDir(join(ROOT, '../shared/styles'), `${BASE}/shared/styles`)
+
+console.log(`Assembled ./public${BASE}/`)

--- a/integrations/h3/server.tsx
+++ b/integrations/h3/server.tsx
@@ -29,19 +29,22 @@ import {
   toWebHandler,
   type H3Event,
 } from 'h3'
-import { join, normalize } from 'node:path'
+import { join, normalize, isAbsolute } from 'node:path'
 import { randomUUID } from 'node:crypto'
 import { renderToHtml } from '@barefootjs/hono/render'
 
 // h3's `createEventStream` leaks an `undefined` unhandled rejection when an
 // SSE client disconnects under the web handler (`onClosed` does not fire in
 // web mode), which Bun/Node would treat as fatal and exit the process —
-// taking every later request down with it. Swallow it process-wide so a
-// client closing the AI-chat stream can never crash the server. Guarded
-// because on Cloudflare Workers `process.on` may be a no-op and a
-// per-request rejection doesn't kill the isolate anyway.
+// taking every later request down with it. Swallow *only* that specific
+// leak (reason is nullish) and surface anything else, so real bugs are not
+// hidden. Guarded because on Cloudflare Workers `process.on` may be a no-op
+// and a per-request rejection doesn't kill the isolate anyway.
 if (typeof process !== 'undefined' && typeof process.on === 'function') {
-  process.on('unhandledRejection', () => {})
+  process.on('unhandledRejection', (reason) => {
+    if (reason == null) return // the h3 SSE-disconnect leak — expected
+    console.error('[h3] unhandledRejection:', reason)
+  })
 }
 import { Layout } from './renderer'
 import manifest from './dist/components/manifest.json'
@@ -349,7 +352,11 @@ async function serveFromDisk(pathname: string): Promise<Response> {
     : [join(import.meta.dir, '../shared/styles'), `${BASE}/shared/styles/`]
   // normalize() collapses any `..` so a crafted path can't escape `dir`.
   const rel = normalize(pathname.slice(prefix.length))
-  if (rel.startsWith('..')) return new Response('Not found', { status: 404 })
+  // Reject traversal: `..` segments (normalize floats them to the front) and
+  // absolute paths (a `//` in the request can leave a leading `/`). `join`
+  // doesn't actually let an absolute `rel` escape `dir` — that's `resolve` —
+  // but the explicit guard keeps it safe against future refactors too.
+  if (rel.startsWith('..') || isAbsolute(rel)) return new Response('Not found', { status: 404 })
   const file = Bun.file(join(dir, rel))
   if (!(await file.exists())) return new Response('Not found', { status: 404 })
   return new Response(file) // Bun infers Content-Type from the extension

--- a/integrations/h3/server.tsx
+++ b/integrations/h3/server.tsx
@@ -24,6 +24,7 @@ import {
   setCookie,
   readBody,
   getQuery,
+  createEventStream,
   setResponseStatus,
   toWebHandler,
   type H3Event,
@@ -31,6 +32,17 @@ import {
 import { join, normalize } from 'node:path'
 import { randomUUID } from 'node:crypto'
 import { renderToHtml } from '@barefootjs/hono/render'
+
+// h3's `createEventStream` leaks an `undefined` unhandled rejection when an
+// SSE client disconnects under the web handler (`onClosed` does not fire in
+// web mode), which Bun/Node would treat as fatal and exit the process —
+// taking every later request down with it. Swallow it process-wide so a
+// client closing the AI-chat stream can never crash the server. Guarded
+// because on Cloudflare Workers `process.on` may be a no-op and a
+// per-request rejection doesn't kill the isolate anyway.
+if (typeof process !== 'undefined' && typeof process.on === 'function') {
+  process.on('unhandledRejection', () => {})
+}
 import { Layout } from './renderer'
 import manifest from './dist/components/manifest.json'
 import { Counter } from '@/components/Counter'
@@ -281,44 +293,33 @@ router.get(
     void getQuery(event).q // the user's prompt — ignored by this dummy backend
     const text = FAKE_RESPONSES[Math.floor(Math.random() * FAKE_RESPONSES.length)]
 
-    // A raw SSE ReadableStream rather than h3's createEventStream: the
-    // EventSource closes the connection as soon as it reads `[DONE]` (and on
-    // navigation), and createEventStream under the web handler crashes the
-    // process when the push loop writes to the already-closed stream. With a
-    // ReadableStream we stop on `cancel()` and swallow the enqueue-after-close
-    // error, so a client disconnect can never take the server down. Each frame
-    // is one JSON-encoded character, then a literal `[DONE]` — what the
-    // island's `EventSource.onmessage` expects.
-    let cancelled = false
-    const stream = new ReadableStream({
-      async start(controller) {
-        const enc = new TextEncoder()
-        try {
-          for (const ch of [...text]) {
-            if (cancelled) return
-            controller.enqueue(enc.encode(`data: ${JSON.stringify(ch)}\n\n`))
-            await new Promise((r) => setTimeout(r, 30))
-          }
-          if (!cancelled) {
-            controller.enqueue(enc.encode('data: [DONE]\n\n'))
-            controller.close()
-          }
-        } catch {
-          // client disconnected mid-stream — nothing left to do
+    // h3's native SSE helper. The push loop stops on `onClosed` and the
+    // try/catch handles the push-after-close race; the leaked `undefined`
+    // rejection h3 emits on disconnect (web mode) is swallowed by the
+    // process-level guard at the top of this file. Each frame is one
+    // JSON-encoded character, then a literal `[DONE]` — what the island's
+    // `EventSource.onmessage` expects.
+    const eventStream = createEventStream(event)
+    let closed = false
+    eventStream.onClosed(() => {
+      closed = true
+    })
+    ;(async () => {
+      try {
+        for (const ch of [...text]) {
+          if (closed) break
+          await eventStream.push(JSON.stringify(ch))
+          await new Promise((r) => setTimeout(r, 30))
         }
-      },
-      cancel() {
-        cancelled = true
-      },
-    })
+        if (!closed) await eventStream.push('[DONE]')
+      } catch {
+        // client disconnected mid-stream — nothing left to do
+      } finally {
+        await eventStream.close().catch(() => {})
+      }
+    })()
 
-    return new Response(stream, {
-      headers: {
-        'content-type': 'text/event-stream',
-        'cache-control': 'no-cache',
-        connection: 'keep-alive',
-      },
-    })
+    return eventStream.send()
   }),
 )
 

--- a/integrations/h3/server.tsx
+++ b/integrations/h3/server.tsx
@@ -2,35 +2,33 @@
 //
 // BarefootJS on h3 (UnJS) — SSR + client hydration.
 //
-// h3 is a pure HTTP framework: it has no JSX runtime, you just return a
-// value from a handler. BarefootJS components compiled with the Hono
-// adapter are plain `hono/jsx` components, so we render them to an HTML
-// string with `renderToHtml` (no Hono app involved) and return that
-// string. Static client bundles are served straight off disk.
+// h3 is a pure HTTP framework with no JSX runtime: BarefootJS components
+// compiled with the Hono adapter are plain `hono/jsx` components, rendered
+// to an HTML string with `renderToHtml` (no Hono app) and returned from h3
+// handlers. The render runtime (`@barefootjs/hono`, the hono/jsx engine) is
+// imported the same way the Go `Echo` integration imports the
+// framework-agnostic `bf` runtime from the go-template adapter.
 //
-// This mirrors the Go `Echo` integration: the framework (h3) lives only
-// here, and the render runtime (`@barefootjs/hono`, the hono/jsx engine)
-// is imported the same way Echo imports the framework-agnostic `bf`
-// runtime shipped by the go-template adapter.
+// Deployment mirrors the Hono integration: the default export is a
+// WinterCG `fetch` handler, so the same file runs on Cloudflare Workers
+// (`wrangler deploy`) and Bun (`bun run server.tsx`, used by the dev
+// compose container and the e2e webServer). Static client bundles come
+// from the Workers Assets binding in production and from disk under Bun.
 
 import {
   createApp,
   createRouter,
   eventHandler,
-  getRequestPath,
   getRouterParam,
   getCookie,
   setCookie,
   readBody,
   getQuery,
   createEventStream,
-  setResponseHeader,
   setResponseStatus,
-  toNodeListener,
+  toWebHandler,
   type H3Event,
 } from 'h3'
-import { createServer } from 'node:http'
-import { readFile } from 'node:fs/promises'
 import { join, normalize } from 'node:path'
 import { randomUUID } from 'node:crypto'
 import { renderToHtml } from '@barefootjs/hono/render'
@@ -44,52 +42,18 @@ import { AIChatInteractive } from '@/components/AIChatInteractive'
 
 const PORT = Number(process.env.PORT ?? 3003)
 
-// URL prefix everything is mounted under. Empty for the standalone server
-// (`bun run start`, e2e); `/integrations/h3` behind the dev proxy, which
-// forwards the prefix through unchanged. `link()` builds absolute in-app
-// URLs; client islands fetch the API with *relative* URLs ('api/todos'),
-// which resolve under the prefix automatically.
-const BASE = process.env.BASE_PATH ?? ''
+// URL prefix everything is mounted under. Defaults to `/integrations/h3`
+// (the deploy path) so production works without relying on `[vars]` being
+// surfaced on `process.env` at module-load — Cloudflare populates `[vars]`
+// on the `env` binding, not necessarily `process.env`, so a non-empty
+// default is what makes the Worker route correctly (same pattern as the
+// Hono integration). Override via BASE_PATH to mount elsewhere. Client
+// islands fetch the API with relative URLs ('api/todos'), which resolve
+// under the prefix automatically.
+const BASE = process.env.BASE_PATH ?? '/integrations/h3'
 const link = (path: string) => `${BASE}${path}`
 
-// ── static assets ──────────────────────────────────────────────────────────
-// {BASE}/static/components/* → ./dist/components/*  (barefoot.js + *.client.js)
-// {BASE}/shared/styles/*     → ../shared/styles/*   (demo stylesheets)
-const STATIC_MOUNTS: Array<{ prefix: string; dir: string }> = [
-  { prefix: `${BASE}/static/components/`, dir: join(import.meta.dir, 'dist/components') },
-  { prefix: `${BASE}/shared/styles/`, dir: join(import.meta.dir, '../shared/styles') },
-]
-
-const CONTENT_TYPES: Record<string, string> = {
-  '.js': 'text/javascript; charset=utf-8',
-  '.map': 'application/json; charset=utf-8',
-  '.css': 'text/css; charset=utf-8',
-  '.json': 'application/json; charset=utf-8',
-  '.svg': 'image/svg+xml',
-}
-
-async function tryServeStatic(path: string): Promise<{ body: Buffer; type: string } | null> {
-  for (const { prefix, dir } of STATIC_MOUNTS) {
-    if (!path.startsWith(prefix)) continue
-    // normalize() collapses any `..` so a crafted path can't escape `dir`.
-    const rel = normalize(path.slice(prefix.length))
-    if (rel.startsWith('..')) return null
-    const file = join(dir, rel)
-    try {
-      const body = await readFile(file)
-      const ext = rel.slice(rel.lastIndexOf('.'))
-      return { body, type: CONTENT_TYPES[ext] ?? 'application/octet-stream' }
-    } catch {
-      return null
-    }
-  }
-  return null
-}
-
 // ── per-session todo store ─────────────────────────────────────────────────
-// Each browser gets an opaque id via a cookie; the in-memory map is keyed
-// on it so one visitor's list is never visible to another. Process-local
-// and ephemeral — fine for a demo.
 type Todo = { id: number; text: string; done: boolean }
 type Session = { todos: Todo[]; nextId: number }
 
@@ -147,8 +111,8 @@ const homeHandler = eventHandler(async () =>
   ),
 )
 router.get(`${BASE}/`, homeHandler)
-// Behind the proxy the prefix arrives without a trailing slash too
-// (e.g. the catalog links to `/integrations/h3`), so register that form.
+// Behind the proxy / on Workers the prefix arrives without a trailing slash
+// too (e.g. the catalog links to `/integrations/h3`), so register that form.
 if (BASE) router.get(BASE, homeHandler)
 
 router.get(
@@ -337,19 +301,48 @@ router.get(
 )
 
 const app = createApp()
-
-// Static first: short-circuit asset requests before the router runs.
-app.use(
-  eventHandler(async (event) => {
-    const hit = await tryServeStatic(getRequestPath(event))
-    if (!hit) return // fall through to the router
-    setResponseHeader(event, 'Content-Type', hit.type)
-    return hit.body
-  }),
-)
-
 app.use(router)
+const webHandler = toWebHandler(app)
 
-createServer(toNodeListener(app)).listen(PORT, () => {
-  console.log(`  ➜ http://localhost:${PORT}${BASE || '/'}`)
-})
+// ── static assets ──────────────────────────────────────────────────────────
+// {BASE}/static/components/* → ./dist/components/*  (barefoot.js + *.client.js)
+// {BASE}/shared/styles/*     → ../shared/styles/*   (demo stylesheets)
+//
+// On Workers these are served by the Assets binding (see wrangler.toml);
+// under Bun (dev container, e2e) there's no binding, so read from disk.
+// `import.meta.dir` is undefined on Workers, so the paths are resolved
+// lazily inside serveFromDisk (only reached on the Bun branch) — computing
+// them at module top level would crash the Worker on startup.
+function isStaticPath(pathname: string): boolean {
+  return (
+    pathname.startsWith(`${BASE}/static/components/`) ||
+    pathname.startsWith(`${BASE}/shared/styles/`)
+  )
+}
+
+async function serveFromDisk(pathname: string): Promise<Response> {
+  const [dir, prefix] = pathname.startsWith(`${BASE}/static/components/`)
+    ? [join(import.meta.dir, 'dist/components'), `${BASE}/static/components/`]
+    : [join(import.meta.dir, '../shared/styles'), `${BASE}/shared/styles/`]
+  // normalize() collapses any `..` so a crafted path can't escape `dir`.
+  const rel = normalize(pathname.slice(prefix.length))
+  if (rel.startsWith('..')) return new Response('Not found', { status: 404 })
+  const file = Bun.file(join(dir, rel))
+  if (!(await file.exists())) return new Response('Not found', { status: 404 })
+  return new Response(file) // Bun infers Content-Type from the extension
+}
+
+type Env = { ASSETS?: { fetch: (request: Request) => Promise<Response> } }
+
+export default {
+  port: PORT,
+  async fetch(request: Request, env?: Env): Promise<Response> {
+    const url = new URL(request.url)
+    if (isStaticPath(url.pathname)) {
+      // Production (Workers): serve from the Assets binding. Dev (Bun): disk.
+      if (env?.ASSETS) return env.ASSETS.fetch(request)
+      return serveFromDisk(url.pathname)
+    }
+    return webHandler(request)
+  },
+}

--- a/integrations/h3/server.tsx
+++ b/integrations/h3/server.tsx
@@ -24,7 +24,6 @@ import {
   setCookie,
   readBody,
   getQuery,
-  createEventStream,
   setResponseStatus,
   toWebHandler,
   type H3Event,
@@ -281,22 +280,45 @@ router.get(
   eventHandler((event) => {
     void getQuery(event).q // the user's prompt — ignored by this dummy backend
     const text = FAKE_RESPONSES[Math.floor(Math.random() * FAKE_RESPONSES.length)]
-    const stream = createEventStream(event)
 
-    // Push after `send()` returns the stream — createEventStream keeps the
-    // connection open. Each push frames the payload as `data: <msg>\n\n`,
-    // which is exactly what the island's `EventSource.onmessage` expects:
-    // a JSON-encoded character per token, then a literal `[DONE]`.
-    ;(async () => {
-      for (const ch of [...text]) {
-        await stream.push(JSON.stringify(ch))
-        await new Promise((r) => setTimeout(r, 30))
-      }
-      await stream.push('[DONE]')
-      await stream.close()
-    })()
+    // A raw SSE ReadableStream rather than h3's createEventStream: the
+    // EventSource closes the connection as soon as it reads `[DONE]` (and on
+    // navigation), and createEventStream under the web handler crashes the
+    // process when the push loop writes to the already-closed stream. With a
+    // ReadableStream we stop on `cancel()` and swallow the enqueue-after-close
+    // error, so a client disconnect can never take the server down. Each frame
+    // is one JSON-encoded character, then a literal `[DONE]` — what the
+    // island's `EventSource.onmessage` expects.
+    let cancelled = false
+    const stream = new ReadableStream({
+      async start(controller) {
+        const enc = new TextEncoder()
+        try {
+          for (const ch of [...text]) {
+            if (cancelled) return
+            controller.enqueue(enc.encode(`data: ${JSON.stringify(ch)}\n\n`))
+            await new Promise((r) => setTimeout(r, 30))
+          }
+          if (!cancelled) {
+            controller.enqueue(enc.encode('data: [DONE]\n\n'))
+            controller.close()
+          }
+        } catch {
+          // client disconnected mid-stream — nothing left to do
+        }
+      },
+      cancel() {
+        cancelled = true
+      },
+    })
 
-    return stream.send()
+    return new Response(stream, {
+      headers: {
+        'content-type': 'text/event-stream',
+        'cache-control': 'no-cache',
+        connection: 'keep-alive',
+      },
+    })
   }),
 )
 

--- a/integrations/h3/wrangler.toml
+++ b/integrations/h3/wrangler.toml
@@ -1,0 +1,30 @@
+name = "barefootjs-h3-example"
+main = "server.tsx"
+compatibility_date = "2025-01-01"
+compatibility_flags = ["nodejs_compat"]
+
+[assets]
+directory = "./public"
+binding = "ASSETS"
+# Let the Worker handle routing so basePath requests like `/integrations/h3/`
+# fall through to the h3 app; static files under ./public are served by the
+# Assets binding (the Worker calls env.ASSETS.fetch for /static + /shared).
+run_worker_first = true
+
+# Two patterns because Cloudflare route globs do not match the "/*" suffix as
+# empty — `/integrations/h3/*` matches /integrations/h3/counter and
+# /integrations/h3/, but not the bare /integrations/h3 (no trailing slash),
+# which is the canonical URL the catalog links to.
+[[routes]]
+pattern = "barefootjs.dev/integrations/h3"
+zone_name = "barefootjs.dev"
+
+[[routes]]
+pattern = "barefootjs.dev/integrations/h3/*"
+zone_name = "barefootjs.dev"
+
+[vars]
+BASE_PATH = "/integrations/h3"
+
+[dev]
+port = 3003


### PR DESCRIPTION
## Problem

`https://barefootjs.dev/integrations/h3` returned **404**. The h3 integration (merged in #1705) was wired for **dev** (dev proxy + docker-compose) but never for **production** — it had no `wrangler.toml` and no deploy job, so nothing served that route. My oversight when I "wired" it.

## Fix — align with the Hono integration (Workers-native)

h3 is runtime-agnostic, so it deploys as a Cloudflare Worker just like Hono (no container needed):

- **`server.tsx`**: default export is now a WinterCG `fetch` handler (`toWebHandler(app)`), so the **same file** runs on Workers (`wrangler deploy`) and Bun (`bun run start`, dev compose, e2e). Static assets come from the Workers **Assets binding** (`env.ASSETS`) in prod and from disk under Bun.
- **`BASE_PATH` defaults to `/integrations/h3`**: Cloudflare surfaces `[vars]` on the `env` binding, not necessarily `process.env` at module-load, so a non-empty default is what makes routing work (the same reason Hono defaults its basePath). Confirmed via `wrangler dev` that a `?? ''` default left the Worker serving at root → 404.
- **`wrangler.toml`**: Assets binding (`run_worker_first`), `barefootjs.dev/integrations/h3` + `/*` routes, `BASE_PATH` var.
- **`scripts/assemble-public.ts`**: stages dist bundles + shared styles under `public/` mirroring the URL space (same as Hono's).
- **`deploy.yml`**: `deploy-integrations-h3` job + `workflow_dispatch` option.
- **e2e**: point the shared suites at the `/integrations/h3` prefix (matching Hono's e2e).

## Verified locally under both runtimes

| | `bun run start` (Bun) | `wrangler dev` (Workers) |
|---|---|---|
| pages (counter/todos/ai-chat) | ✅ 200 | ✅ 200 |
| static | ✅ disk | ✅ `env.ASSETS` (`text/javascript`, `text/css`) |
| Todo API + SSE | ✅ | ✅ |
| hydration markers + prefixed script URLs | ✅ | ✅ |

Production goes live on the next deploy (push to `main`).

## Follow-up

The Elysia integration (#1709) has the **same gap** — it's Bun/Node and not yet deploy-wired. I'll apply the same Workers-native treatment there once this lands (or on request).

https://claude.ai/code/session_01Wf6STu3onNiDa2NCt1YFUJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wf6STu3onNiDa2NCt1YFUJ)_