### PR TITLE
fix(integrations/h3): render the shared site header

### DIFF
--- a/integrations/h3/renderer.tsx
+++ b/integrations/h3/renderer.tsx
@@ -11,6 +11,24 @@
 import { BfImportMap, BfScripts } from '@barefootjs/hono/app'
 import type { BarefootBuildManifest } from '@barefootjs/hono/app'
 
+// Shared site header — same markup/classes as the hono, echo and
+// mojolicious integrations (styled by shared/styles/layout.css) so every
+// adapter demo looks identical. The `/integrations` link points at the
+// catalog at the site root, not under this adapter's base path.
+function SiteHeader() {
+  return (
+    <header className="bf-header">
+      <div className="bf-header-inner">
+        <a href="https://barefootjs.dev" className="bf-header-logo" aria-label="Barefoot.js">
+          <span className="bf-header-logo-img" role="img" aria-hidden="true" />
+        </a>
+        <div className="bf-header-sep" />
+        <a href="/integrations" className="bf-header-link">Integrations</a>
+      </div>
+    </header>
+  )
+}
+
 export interface LayoutProps {
   title?: string
   manifest: BarefootBuildManifest
@@ -42,6 +60,7 @@ export function Layout({ title, manifest, base = '', styles, children }: LayoutP
         <BfImportMap base={componentsBase} />
       </head>
       <body>
+        <SiteHeader />
         {children}
         <BfScripts base={componentsBase} manifest={manifest} />
       </body>


### PR DESCRIPTION
## Problem

`https://barefootjs.dev/integrations/h3` was missing the site header (Barefoot.js logo + Integrations link) that the **hono**, **echo**, and **mojolicious** demos all render, so the h3 page looked different from every other adapter.

## Fix

Add the same `bf-header` markup — identical classes to the other integrations, styled by the shared `shared/styles/layout.css` — as the first child of `<body>` in the h3 `Layout`. The `/integrations` link points at the catalog at the site root (not under the adapter base path), matching the others.

Nothing else changes; the header CSS and `logo.svg` were already linked/served by the integration.

## Verified

`bun run start`: every page renders `<header class="bf-header">` as the first body child, the `/integrations` + `barefootjs.dev` links are present, and `logo.svg` serves (`200 image/svg+xml`). Screenshot of `/counter` (clicked +1 ×3, header shown) attached in the session.

https://claude.ai/code/session_01Wf6STu3onNiDa2NCt1YFUJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wf6STu3onNiDa2NCt1YFUJ)_