### PR TITLE
refactor(integrations/h3): bound the session store with LRU eviction

### DIFF
--- a/integrations/h3/server.tsx
+++ b/integrations/h3/server.tsx
@@ -72,6 +72,9 @@ type Todo = { id: number; text: string; done: boolean }
 type Session = { todos: Todo[]; nextId: number }
 
 const SESSION_COOKIE = 'bf_session'
+const SESSION_TTL_SECONDS = 60 * 60 * 24 * 30 // 30d
+const MAX_SESSIONS = 1000
+
 const sessions = new Map<string, Session>()
 
 function seedTodos(): Todo[] {
@@ -82,6 +85,22 @@ function seedTodos(): Todo[] {
   ]
 }
 
+// Bound the in-memory store and evict least-recently-used sessions, like the
+// hono / echo / mojolicious integrations. The Map's insertion order is the
+// recency order — re-inserting on access keeps the oldest key at the front.
+function touchLRU(id: string, session: Session) {
+  sessions.delete(id)
+  sessions.set(id, session)
+}
+
+function evictIfNeeded() {
+  while (sessions.size > MAX_SESSIONS) {
+    const oldest = sessions.keys().next().value
+    if (oldest === undefined) break
+    sessions.delete(oldest)
+  }
+}
+
 function getSession(event: H3Event): Session {
   let id = getCookie(event, SESSION_COOKIE)
   if (!id) {
@@ -90,13 +109,16 @@ function getSession(event: H3Event): Session {
       path: BASE || '/',
       httpOnly: true,
       sameSite: 'lax',
-      maxAge: 60 * 60 * 24 * 30,
+      maxAge: SESSION_TTL_SECONDS,
     })
   }
   let session = sessions.get(id)
   if (!session) {
     session = { todos: seedTodos(), nextId: 4 }
     sessions.set(id, session)
+    evictIfNeeded()
+  } else {
+    touchLRU(id, session)
   }
   return session
 }


### PR DESCRIPTION
## What

Tidy session handling for consistency across the integrations (status quo kept — per-visitor cookie sessions). The session **store** was the last inconsistency: hono / echo / mojolicious cap their in-memory map and evict least-recently-used entries; **h3 and elysia used an unbounded `Map`**.

This adds the same bounded LRU store to **h3** (cap 1000, evict oldest by Map insertion order). The matching elysia change rides along in #1715.

Behavior is otherwise unchanged — the cookie still carries an opaque id, todos stay in the server-side map. Verified the session CRUD round-trip still works.

https://claude.ai/code/session_01Wf6STu3onNiDa2NCt1YFUJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wf6STu3onNiDa2NCt1YFUJ)_