### PR TITLE
feat(#1448 Tier B): lower String.prototype.split(sep)

### DIFF
--- a/.changeset/string-split-tier-b.md
+++ b/.changeset/string-split-tier-b.md
@@ -1,0 +1,15 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+"@barefootjs/mojolicious": patch
+---
+
+Lower `String.prototype.split(sep)` to the template-language adapters (#1448 Tier B).
+
+`value.split(',')` now compiles to both template adapters instead of refusing with BF101. It's the first string method whose result is an *array*, so it composes with the existing array-method surface — `value.split(',').join('|')`, `value.split(',').map(...)`, `value.split(',').length`.
+
+- Parser: new `array-method` variant `split`; `split` drops out of `UNSUPPORTED_METHODS`.
+- Go: new `bf_split` runtime helper (wraps `strings.Split`, normalised to `[]any`).
+- Mojo: new `bf->split` helper that quotemetas the separator (literal-string match, not regex) and passes Perl's `split` a `-1` limit so trailing empty fields survive — keeping output byte-equal with Go and JS.
+
+Full JS arity: `.split()` (no separator) returns the whole string as a single element, `.split(sep)` splits on the literal separator, and `.split(sep, limit)` caps the number of pieces (matching JS — `limit` 0 → empty, negative / `>=` length → all); a third+ argument is ignored. The regex-separator form stays refused (a regex-literal argument parses as `unsupported` and propagates to BF101 — the per-adapter regex-flavour decision is tracked for `.replace`). Verified byte-equal across Hono/CSR, Go, and Mojo.

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -35,6 +35,7 @@ func FuncMap() template.FuncMap {
 		"bf_trim":     Trim,
 		"bf_contains": Contains,
 		"bf_join":     Join,
+		"bf_split":    Split,
 		"bf_string":   String,
 
 		// JSON / numeric primitives — JS-compat callees registered on
@@ -476,6 +477,29 @@ func Trim(s string) string {
 // Contains returns true if s contains substr.
 func Contains(s, substr string) bool {
 	return strings.Contains(s, substr)
+}
+
+// Split lowers `String.prototype.split(sep, limit?)` (#1448 Tier B). It
+// wraps `strings.Split` and normalises the result to `[]any` so the
+// slice composes with the array-method surface downstream (`bf_join`,
+// range loops, `bf_len`, …) the same way `bf_slice` / `bf_reverse`
+// results do. Like JS, an empty separator splits into individual UTF-8
+// characters and trailing empty fields are preserved (`"a,".split(",")`
+// → `["a", ""]`). An optional `limit` caps the number of returned
+// pieces (`"a,b,c".split(",", 2)` → `["a", "b"]`); a negative limit is
+// ignored (JS would also return every piece — its ToUint32 wrap makes
+// the limit effectively unbounded). The no-separator form is handled by
+// the adapter (it emits `bf_arr` for the whole-string single element).
+func Split(s, sep string, limit ...int) []any {
+	parts := strings.Split(s, sep)
+	if len(limit) > 0 && limit[0] >= 0 && limit[0] < len(parts) {
+		parts = parts[:limit[0]]
+	}
+	out := make([]any, len(parts))
+	for i, p := range parts {
+		out[i] = p
+	}
+	return out
 }
 
 // Join concatenates elements of a slice with sep. Accepts both

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -150,6 +150,49 @@ func TestJoin(t *testing.T) {
 	}
 }
 
+func TestSplit(t *testing.T) {
+	// Round-trips with Join so the slice is observable.
+	if got := Join(Split("a,b,c", ","), "|"); got != "a|b|c" {
+		t.Errorf(`Split("a,b,c", ",") joined = %v, want a|b|c`, got)
+	}
+	// JS keeps trailing empty fields (Perl's bare split drops them —
+	// the `bf->split` helper passes -1 to match this).
+	if got := Split("a,", ","); len(got) != 2 || got[0] != "a" || got[1] != "" {
+		t.Errorf(`Split("a,", ",") = %v, want ["a" ""]`, got)
+	}
+	// Empty separator splits into individual characters.
+	if got := Join(Split("abc", ""), "-"); got != "a-b-c" {
+		t.Errorf(`Split("abc", "") joined = %v, want a-b-c`, got)
+	}
+	// No separator match → single-element slice (the whole string).
+	if got := Split("abc", ","); len(got) != 1 || got[0] != "abc" {
+		t.Errorf(`Split("abc", ",") = %v, want ["abc"]`, got)
+	}
+	// Empty input: non-empty separator → single empty field; empty
+	// separator → empty slice. Both match JS (and the `bf->split`
+	// helper special-cases Perl, whose `split` diverges here).
+	if got := Split("", ","); len(got) != 1 || got[0] != "" {
+		t.Errorf(`Split("", ",") = %v, want [""]`, got)
+	}
+	if got := Split("", ""); len(got) != 0 {
+		t.Errorf(`Split("", "") = %v, want []`, got)
+	}
+	// Optional limit caps the pieces (JS `split(sep, limit)`).
+	if got := Split("a,b,c,d", ",", 2); len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Errorf(`Split("a,b,c,d", ",", 2) = %v, want ["a" "b"]`, got)
+	}
+	// limit 0 → empty; limit >= len or negative → all pieces.
+	if got := Split("a,b", ",", 0); len(got) != 0 {
+		t.Errorf(`Split("a,b", ",", 0) = %v, want []`, got)
+	}
+	if got := Split("a,b", ",", 9); len(got) != 2 {
+		t.Errorf(`Split("a,b", ",", 9) = %v, want 2 pieces`, got)
+	}
+	if got := Split("a,b", ",", -1); len(got) != 2 {
+		t.Errorf(`Split("a,b", ",", -1) = %v, want 2 pieces (negative = all)`, got)
+	}
+}
+
 func TestLen(t *testing.T) {
 	tests := []struct {
 		v    any

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -2191,6 +2191,9 @@ import { fixture as arrayToReversedFixture } from '../../../adapter-tests/fixtur
 import { fixture as stringToLowerCaseFixture } from '../../../adapter-tests/fixtures/methods/string-toLowerCase'
 import { fixture as stringToUpperCaseFixture } from '../../../adapter-tests/fixtures/methods/string-toUpperCase'
 import { fixture as stringTrimFixture } from '../../../adapter-tests/fixtures/methods/string-trim'
+// #1448 Tier B — string methods.
+import { fixture as stringSplitFixture } from '../../../adapter-tests/fixtures/methods/string-split'
+import { fixture as stringSplitLimitFixture } from '../../../adapter-tests/fixtures/methods/string-split-limit'
 // #1448 Tier B — .sort / .toSorted fixtures.
 import { fixture as arraySortFieldAscFixture } from '../../../adapter-tests/fixtures/methods/array-sort-field-asc'
 import { fixture as arraySortFieldDescFixture } from '../../../adapter-tests/fixtures/methods/array-sort-field-desc'
@@ -2232,6 +2235,11 @@ describe('GoTemplateAdapter - #1448 Tier A/B fixture-driven lowering pins', () =
     { fixture: stringToLowerCaseFixture,expect: 'bf_lower .Value' },
     { fixture: stringToUpperCaseFixture,expect: 'bf_upper .Value' },
     { fixture: stringTrimFixture,       expect: 'bf_trim .Value' },
+    // #1448 Tier B — string → array. `.split(',')` lowers to
+    // `bf_split`, here chained into `.join('|')` so the slice is
+    // observable (`bf_join (bf_split .Value ",") "|"`).
+    { fixture: stringSplitFixture,      expect: 'bf_split .Value ","' },
+    { fixture: stringSplitLimitFixture, expect: 'bf_split .Value "," 2' },
     // #1448 Tier B — sort / toSorted. Loop-chained shapes wrap the
     // iterable in `bf_sort .Items <kind> <key> <type> <dir>`;
     // standalone shapes inline the helper at the call site.
@@ -2348,8 +2356,10 @@ export function C() {
     { name: 'includes (2-arg fromIndex)', expr: `items().includes("a", 1)`, badEmit: '.Includes' },
     { name: 'concat (variadic)', expr: `items().concat(items(), items())`, badEmit: '.Concat' },
     // Tier B/C string methods — previously slipped through with no
-    // diagnostic; now gated by `UNSUPPORTED_METHODS`.
-    { name: 'split', expr: `name().split(",")`, badEmit: '.Name.Split' },
+    // diagnostic; now gated by `UNSUPPORTED_METHODS`. `split` has since
+    // landed its full-arity lowering (#1448 Tier B) — `.split()`,
+    // `.split(sep)` and `.split(sep, limit)` all lower — so it's pinned
+    // in the positive fixture-pin block above.
     { name: 'startsWith', expr: `name().startsWith("a")`, badEmit: '.Name.StartsWith' },
     { name: 'endsWith', expr: `name().endsWith("z")`, badEmit: '.Name.EndsWith' },
     { name: 'replace', expr: `name().replace("a", "b")`, badEmit: '.Name.Replace' },

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -3212,6 +3212,23 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         const recv = emit(object)
         return `bf_trim ${wrapIfMultiToken(recv)}`
       }
+      case 'split': {
+        // `.split()` / `.split(sep)` / `.split(sep, limit)` — string →
+        // `[]any`. No separator → the whole string as a single element
+        // (`bf_arr`). Otherwise `bf_split` (wraps `strings.Split`,
+        // normalised to `[]any`); a second `limit` argument caps the
+        // pieces. JS ignores a third+ argument. See #1448 Tier B.
+        const recv = emit(object)
+        if (args.length === 0) {
+          return `bf_arr ${wrapIfMultiToken(recv)}`
+        }
+        const sep = emit(args[0])
+        if (args.length === 1) {
+          return `bf_split ${wrapIfMultiToken(recv)} ${wrapIfMultiToken(sep)}`
+        }
+        const limit = emit(args[1])
+        return `bf_split ${wrapIfMultiToken(recv)} ${wrapIfMultiToken(sep)} ${wrapIfMultiToken(limit)}`
+      }
       default: {
         const _exhaustive: never = method
         throw new Error(`Go arrayMethod: unhandled ArrayMethod '${(_exhaustive as string)}'`)

--- a/packages/adapter-mojolicious/lib/BarefootJS.pm
+++ b/packages/adapter-mojolicious/lib/BarefootJS.pm
@@ -526,6 +526,65 @@ sub trim ($self, $recv) {
     return $s;
 }
 
+# `String.prototype.split(sep)` (#1448 Tier B) — string → ARRAY ref.
+#
+# Two JS-parity wrinkles drive the helper (a bare `split` emit would
+# diverge from both JS and Go):
+#
+#   * Perl's `split` treats its first argument as a *regex*, so a
+#     separator like '.' or '|' would match far too much. We
+#     `quotemeta` it to force literal-string matching, mirroring JS's
+#     string-separator semantics (the regex-separator form stays
+#     refused upstream — see the parser arm).
+#   * Perl's `split` drops trailing empty fields by default; JS keeps
+#     them (`"a,".split(",")` is `["a", ""]`). Passing the `-1` limit
+#     preserves them, matching JS and Go's `strings.Split`.
+#
+# An empty separator splits into individual characters (JS + Go agree).
+# Undef receiver renders as the single-element `['']` — the same
+# "missing prop → empty string" convention `bf->trim` uses.
+
+sub split ($self, $recv, $sep = undef, $limit = undef) {
+    my $s = defined $recv && !ref($recv) ? "$recv" : '';
+
+    my @parts;
+    if (!defined $sep) {
+        # No separator → the whole string in a single-element array
+        # (matches JS `"x".split()` / `.split(undefined)`).
+        @parts = ($s);
+    }
+    elsif ("$sep" eq '') {
+        # Empty separator → individual characters. No `-1` limit here:
+        # on an empty pattern Perl's `split` with `-1` appends a spurious
+        # trailing empty field ("abc" → 'a','b','c',''), which JS/Go don't.
+        @parts = split //, $s;
+    }
+    elsif ($s eq '') {
+        # Empty input with a non-empty separator: JS `"".split(",")` is
+        # `[""]` and Go's `strings.Split("", ",")` is `[""]`, but Perl's
+        # `split /,/, ''` returns the empty list — special-case for parity.
+        @parts = ('');
+    }
+    else {
+        # `quotemeta` forces literal-string matching (JS string-separator
+        # semantics); the `-1` keeps trailing empty fields (JS keeps them,
+        # Perl's bare `split` drops them).
+        my $q = quotemeta("$sep");
+        @parts = split /$q/, $s, -1;
+    }
+
+    # Optional `limit` caps the number of pieces (JS `split(sep, limit)`).
+    # 0 → empty; a negative limit keeps all (JS ToUint32 wrap makes it
+    # effectively unbounded) — both match Go's `bf_split`.
+    if (defined $limit) {
+        my $n = int($limit);
+        if ($n == 0) { @parts = () }
+        elsif ($n > 0 && $n < scalar @parts) { @parts = @parts[0 .. $n - 1] }
+    }
+
+    return [@parts];
+}
+
 # `Array.prototype.sort(cmp)` / `Array.prototype.toSorted(cmp)`
 # lowering (#1448 Tier B). Non-mutating — JS's mutate-vs-new
 # distinction is moot in SSR template context.

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -937,6 +937,9 @@ import { fixture as arrayToReversedFixture } from '../../../adapter-tests/fixtur
 import { fixture as stringToLowerCaseFixture } from '../../../adapter-tests/fixtures/methods/string-toLowerCase'
 import { fixture as stringToUpperCaseFixture } from '../../../adapter-tests/fixtures/methods/string-toUpperCase'
 import { fixture as stringTrimFixture } from '../../../adapter-tests/fixtures/methods/string-trim'
+// #1448 Tier B — string methods.
+import { fixture as stringSplitFixture } from '../../../adapter-tests/fixtures/methods/string-split'
+import { fixture as stringSplitLimitFixture } from '../../../adapter-tests/fixtures/methods/string-split-limit'
 // #1448 Tier B — .sort / .toSorted fixtures (loop-chained + standalone).
 import { fixture as arraySortFieldAscFixture } from '../../../adapter-tests/fixtures/methods/array-sort-field-asc'
 import { fixture as arraySortFieldDescFixture } from '../../../adapter-tests/fixtures/methods/array-sort-field-desc'
@@ -972,6 +975,11 @@ describe('MojoAdapter - #1448 Tier A/B fixture-driven lowering pins', () => {
     { fixture: stringToLowerCaseFixture,expect: 'lc($value)' },
     { fixture: stringToUpperCaseFixture,expect: 'uc($value)' },
     { fixture: stringTrimFixture,       expect: 'bf->trim($value)' },
+    // #1448 Tier B — string → array. `.split(',')` lowers to
+    // `bf->split`, here chained into `.join('|')` so the array ref is
+    // observable (`join('|', @{bf->split($value, ',')})`).
+    { fixture: stringSplitFixture,      expect: `bf->split($value, ',')` },
+    { fixture: stringSplitLimitFixture, expect: `bf->split($value, ',', 2)` },
     // #1448 Tier B — sort / toSorted. The loop-chained field cases
     // hoist into a `my $bf_iter_lN = bf->sort(...)` local; the
     // standalone primitive cases inline the call. Each comparison key
@@ -1085,7 +1093,9 @@ export function C() {
     { name: 'concat (variadic)', expr: `items().concat(items(), items())`, badEmit: '->{concat}' },
     // Tier B/C string methods — previously slipped through with no
     // diagnostic; now routed through the AST / `isSupported` gate.
-    { name: 'split', expr: `name().split(",")`, badEmit: '->{split}' },
+    // `split` has since landed its full-arity lowering (#1448 Tier B) —
+    // `.split()`, `.split(sep)` and `.split(sep, limit)` all lower — so
+    // it's pinned in the positive fixture-pin block above.
     { name: 'startsWith', expr: `name().startsWith("a")`, badEmit: '->{startsWith}' },
     { name: 'endsWith', expr: `name().endsWith("z")`, badEmit: '->{endsWith}' },
     { name: 'replace', expr: `name().replace("a", "b")`, badEmit: '->{replace}' },

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1396,6 +1396,25 @@ function renderArrayMethod(
       const recv = emit(object)
       return `bf->trim(${recv})`
     }
+    case 'split': {
+      // `.split()` / `.split(sep)` / `.split(sep, limit)` — string →
+      // ARRAY ref via `bf->split`. With no separator the helper returns
+      // the whole string as a single element; otherwise it quotemetas
+      // the separator (literal match, not regex) and keeps trailing
+      // empties (`-1`), staying byte-equal with Go's `bf_split`. The
+      // optional `limit` caps the pieces; JS ignores a third+ argument.
+      // See #1448 Tier B.
+      const recv = emit(object)
+      if (args.length === 0) {
+        return `bf->split(${recv})`
+      }
+      const sep = emit(args[0])
+      if (args.length === 1) {
+        return `bf->split(${recv}, ${sep})`
+      }
+      const limit = emit(args[1])
+      return `bf->split(${recv}, ${sep}, ${limit})`
+    }
     default: {
       // TS-level exhaustiveness guard. If this throws at runtime, the
       // IR was constructed against a newer `ArrayMethod` variant that

--- a/packages/adapter-mojolicious/t/template_primitives.t
+++ b/packages/adapter-mojolicious/t/template_primitives.t
@@ -243,6 +243,46 @@ subtest 'trim — strip leading + trailing whitespace' => sub {
     is $bf->trim(42),                  '42',             'numeric receiver stringifies';
 };
 
+# `String.prototype.split(sep)` — string → ARRAY ref (#1448 Tier B).
+# Mirrors the Go `bf_split`: literal (quotemeta'd) separator, trailing
+# empties preserved (the `-1` limit), empty-separator char split.
+subtest 'split — string into array of substrings' => sub {
+    is $bf->split('a,b,c', ','),   ['a', 'b', 'c'],   'comma separator';
+    is $bf->split('a-b-c', '-'),   ['a', 'b', 'c'],   'dash separator';
+
+    # Separator is matched literally, not as a regex — '.' and '|'
+    # would otherwise match every position / alternate emptily.
+    is $bf->split('a.b.c', '.'),   ['a', 'b', 'c'],   'dot is literal, not regex any-char';
+    is $bf->split('a|b',   '|'),   ['a', 'b'],        'pipe is literal, not regex alternation';
+
+    # Trailing empty fields survive (JS keeps them; Perl's bare split
+    # drops them — the -1 limit is what preserves parity).
+    is $bf->split('a,',    ','),   ['a', ''],         'trailing empty field preserved';
+    is $bf->split('a,,b',  ','),   ['a', '', 'b'],    'inner empty field preserved';
+    is $bf->split(',a',    ','),   ['', 'a'],         'leading empty field preserved';
+
+    # Empty separator → individual characters.
+    is $bf->split('abc',   ''),    ['a', 'b', 'c'],   'empty separator splits into chars';
+    is $bf->split('',      ''),    [],                'empty string, empty separator → empty';
+
+    # No match → single-element array (the whole string).
+    is $bf->split('abc',   ','),   ['abc'],           'no separator match → whole string';
+
+    # No separator at all → the whole string (JS `"x".split()`).
+    is $bf->split('a,b,c'),        ['a,b,c'],         'no separator → whole string';
+
+    # Optional limit caps the pieces (JS `split(sep, limit)`); 0 → empty,
+    # negative / >= length → all (matches Go bf_split).
+    is $bf->split('a,b,c,d', ',', 2), ['a', 'b'],     'limit caps pieces';
+    is $bf->split('a,b',     ',', 0), [],             'limit 0 → empty';
+    is $bf->split('a,b',     ',', 9), ['a', 'b'],     'limit >= length → all';
+    is $bf->split('a,b',     ',', -1),['a', 'b'],     'negative limit → all';
+
+    # Undef / non-string receivers render as the empty-string element.
+    is $bf->split(undef,   ','),   [''],              'undef receiver renders single empty-string element';
+    is $bf->split(42,      ','),   ['42'],            'numeric receiver stringifies';
+};
+
 # `Array.prototype.sort(cmp)` / `Array.prototype.toSorted(cmp)`
 # lowering (#1448 Tier B). The opts hash-ref carries a `keys` list of
 # the structured comparison keys the compiler extracted at parse time

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -133,6 +133,9 @@ import { fixture as stringToLowerCase } from './methods/string-toLowerCase'
 import { fixture as stringToUpperCase } from './methods/string-toUpperCase'
 import { fixture as stringTrim } from './methods/string-trim'
 import { fixture as stringIncludes } from './methods/string-includes'
+// #1448 Tier B — String methods.
+import { fixture as stringSplit } from './methods/string-split'
+import { fixture as stringSplitLimit } from './methods/string-split-limit'
 // #1448 catalog parity: array methods rendered positively by
 // Hono / CSR (runtime JS) and at least one SSR adapter — pinning
 // the canonical surface so a regression surfaces here instead of
@@ -301,6 +304,9 @@ export const jsxFixtures: JSXFixture[] = [
   stringToUpperCase,
   stringTrim,
   stringIncludes,
+  // #1448 Tier B — String methods.
+  stringSplit,
+  stringSplitLimit,
   // #1448 catalog parity — already-lowered Array methods.
   arrayJoin,
   arrayFind,

--- a/packages/adapter-tests/fixtures/methods/string-split-limit.ts
+++ b/packages/adapter-tests/fixtures/methods/string-split-limit.ts
@@ -1,0 +1,23 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `String.prototype.split(sep, limit)` — the limit form (#1448 Tier B,
+ * full-arity). JS caps the result at `limit` pieces
+ * (`"a,b,c,d".split(",", 2)` → `["a", "b"]`). Chained into `.join('|')`
+ * so the capped array is observable; the conformance harness renders
+ * this through Hono / Go / Mojo and compares to the real-JS output.
+ */
+export const fixture = createFixture({
+  id: 'string-split-limit',
+  description: '.split(sep, limit) caps the number of pieces',
+  source: `
+function StringSplitLimit({ value }: { value: string }) {
+  return <div>{value.split(',', 2).join('|')}</div>
+}
+export { StringSplitLimit }
+`,
+  props: { value: 'a,b,c,d' },
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><!--bf:s0-->a|b<!--/--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/methods/string-split.ts
+++ b/packages/adapter-tests/fixtures/methods/string-split.ts
@@ -1,0 +1,26 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `String.prototype.split(sep)` lowering (#1448 Tier B).
+ *
+ * `split` is the first string method whose result is an *array* rather
+ * than a scalar, so the fixture chains `.split(',').join('|')` to make
+ * the slice observable in rendered output and to pin that the result
+ * composes with the existing `.join` lowering on every adapter. The
+ * `|` join separator differs from the `,` split separator so a lowering
+ * that confused the two would still fail the assertion.
+ */
+export const fixture = createFixture({
+  id: 'string-split',
+  description: '.split(sep) splits a string into an array of substrings',
+  source: `
+function StringSplit({ value }: { value: string }) {
+  return <div>{value.split(',').join('|')}</div>
+}
+export { StringSplit }
+`,
+  props: { value: 'a,b,c' },
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><!--bf:s0-->a|b|c<!--/--></div>
+  `,
+})

--- a/packages/jsx/src/adapters/parsed-expr-emitter.ts
+++ b/packages/jsx/src/adapters/parsed-expr-emitter.ts
@@ -66,6 +66,7 @@ export type ArrayMethod =
   | 'toLowerCase'
   | 'toUpperCase'
   | 'trim'
+  | 'split'
 
 /**
  * Method names handled by the dedicated `sortMethod()` dispatcher

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -46,6 +46,7 @@ export type ParsedExpr =
         | 'toLowerCase'
         | 'toUpperCase'
         | 'trim'
+        | 'split'
       object: ParsedExpr
       args: ParsedExpr[]
     }
@@ -225,7 +226,11 @@ const UNSUPPORTED_METHODS = new Set([
   // unsupported array methods above get), pointing users at the
   // `/* @client */` escape hatch. Each name drops off as its lowering
   // lands. See #1448 "Unsupported string methods" Tier B / Tier C.
-  'split', 'startsWith', 'endsWith', 'replace', 'replaceAll',
+  // `split` is no longer here — `String.prototype.split(sep)` lowers
+  // via the `array-method` IR + `bf_split` (Go) / `bf->split` (Mojo),
+  // returning an array that composes with `.join()` / `.map()` / etc.
+  // See #1448 Tier B.
+  'startsWith', 'endsWith', 'replace', 'replaceAll',
   'repeat', 'padStart', 'padEnd',
   'charAt', 'charCodeAt', 'codePointAt', 'normalize',
   'substring', 'substr', 'match', 'matchAll', 'search',
@@ -440,6 +445,19 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
       // trailing whitespace" semantic via a Perl regex.
       if (callee.property === 'trim') {
         return { kind: 'array-method', method: 'trim', object: callee.object, args }
+      }
+      // `.split()` / `.split(sep)` / `.split(sep, limit)` — string →
+      // array, full JS arity. `.split()` (no separator) returns the
+      // whole string as a single element; `.split(sep)` splits on the
+      // (literal) separator; the optional `limit` caps the number of
+      // pieces. JS ignores a third+ argument. Go uses `bf_split`
+      // (`strings.Split`, optional limit, normalised to `[]any`) and
+      // `bf_arr` for the no-separator whole-string case; Mojo uses
+      // `bf->split`. The regex-separator form stays refused (the parser
+      // never reaches here for it — a regex literal arg is `unsupported`
+      // and propagates). See #1448 Tier B.
+      if (callee.property === 'split') {
+        return { kind: 'array-method', method: 'split', object: callee.object, args }
       }
       // Arity guard for the forms whose EXTRA argument changes the
       // result and is not yet lowered: the `fromIndex` of `.includes` /


### PR DESCRIPTION
## String Tier B (#1448) — PR 1 of 5: `.split(sep)`

First of a **stacked** series implementing the String Tier B methods from #1448, one case per PR.

`value.split(',')` now lowers to both template-language adapters (Go + Mojo) instead of refusing with **BF101**. It's the first string method whose result is an *array*, so it composes with the existing array-method surface:

```jsx
{value.split(',').join('|')}   // a,b,c → a|b|c
{value.split(',').map(...)}
{value.split(',').length}
```

### Changes
- **Parser** (`expression-parser.ts`): new `array-method` variant `split` (+ the `ArrayMethod` type alias in `parsed-expr-emitter.ts`); `split` drops out of `UNSUPPORTED_METHODS`. Single string-separator form only — the regex-separator form stays refused (it would need the per-adapter regex-flavour decision tracked for `.replace`).
- **Go** (`bf.go`): new `bf_split` runtime helper (wraps `strings.Split`, normalised to `[]any` so the slice composes with `bf_join` / range loops).
- **Mojo** (`BarefootJS.pm`): new `bf->split` helper that `quotemeta`s the separator (literal match, not regex) and passes Perl's `split` a `-1` limit so trailing empty fields survive. Two JS-parity edge cases are special-cased so Perl output stays byte-equal with Go and JS:
  - empty separator → char split with **no** spurious trailing field
  - empty input + non-empty separator → `"".split(",")` is `[""]`

### Verification
- `bf_split` Go unit tests (`bf_test.go`)
- `bf->split` Perl `.t` suite under **real Mojolicious**
- Fixture-driven adapter-emit pins (Go + Mojo)
- Cross-adapter SSR/CSR conformance render of the new `string-split` fixture

### Stack
1. **`.split(sep)`** ← this PR (base `main`)
2. `.startsWith` / `.endsWith`
3. `.replace`
4. `.repeat`
5. `.padStart` / `.padEnd`

https://claude.ai/code/session_01WDSuf4wHqvVUkFM23vGZqx

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDSuf4wHqvVUkFM23vGZqx)_