### PR TITLE
feat(#1448 Tier B): lower String.prototype.startsWith / endsWith

### DIFF
--- a/.changeset/string-startswith-endswith-tier-b.md
+++ b/.changeset/string-startswith-endswith-tier-b.md
@@ -1,0 +1,15 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+"@barefootjs/mojolicious": patch
+---
+
+Lower `String.prototype.startsWith(prefix)` / `endsWith(suffix)` to the template-language adapters (#1448 Tier B).
+
+`value.startsWith('a')` / `value.endsWith('z')` now compile to both template adapters instead of refusing with BF101. Both return a boolean, so they slot naturally into condition position (`value.startsWith(p) ? … : …`).
+
+Full JS arity: the optional `position` (`startsWith`) / `endPosition` (`endsWith`) second argument re-anchors the test, clamped to `[0, length]` so it never crashes — `"hello world".startsWith("world", 6)` and `"hello world".endsWith("hello", 5)` both lower. A third+ argument is ignored. The zero-arg form (`.startsWith()`) is refused: JS coerces the missing search to the literal string `"undefined"`, a degenerate result (mirrors the `.includes()` zero-arg refusal). Verified byte-equal across Hono/CSR, Go, and Mojo.
+
+- Parser: two new `array-method` variants `startsWith` / `endsWith`, dropped from `UNSUPPORTED_METHODS`.
+- Go: new `bf_starts_with` / `bf_ends_with` runtime helpers (`strings.HasPrefix` / `strings.HasSuffix`, with the optional clamped position).
+- Mojo: new `bf->starts_with` / `bf->ends_with` helpers doing a `substr`-anchored literal comparison (no regex metachar surprises), with the optional clamped position and empty-prefix/suffix + undef-receiver handling matching JS and Go.

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -32,11 +32,13 @@ func FuncMap() template.FuncMap {
 		// String
 		"bf_lower":    Lower,
 		"bf_upper":    Upper,
-		"bf_trim":     Trim,
-		"bf_contains": Contains,
-		"bf_join":     Join,
-		"bf_split":    Split,
-		"bf_string":   String,
+		"bf_trim":        Trim,
+		"bf_contains":    Contains,
+		"bf_join":        Join,
+		"bf_split":       Split,
+		"bf_starts_with": StartsWith,
+		"bf_ends_with":   EndsWith,
+		"bf_string":      String,
 
 		// JSON / numeric primitives — JS-compat callees registered on
 		// the Go adapter's `templatePrimitives` map (#1188).
@@ -500,6 +502,44 @@ func Split(s, sep string, limit ...int) []any {
 		out[i] = p
 	}
 	return out
+}
+
+// StartsWith lowers `String.prototype.startsWith(prefix, position?)`
+// (#1448 Tier B). Wraps `strings.HasPrefix`; an empty prefix is always
+// true (JS parity). The optional `position` re-anchors the test to start
+// at that index (clamped to `[0, len]` so it never panics), matching JS
+// `"abc".startsWith("b", 1) === true`.
+func StartsWith(s, prefix string, position ...int) bool {
+	if len(position) > 0 {
+		p := position[0]
+		if p < 0 {
+			p = 0
+		}
+		if p > len(s) {
+			p = len(s)
+		}
+		s = s[p:]
+	}
+	return strings.HasPrefix(s, prefix)
+}
+
+// EndsWith lowers `String.prototype.endsWith(suffix, endPosition?)`
+// (#1448 Tier B). Wraps `strings.HasSuffix`; an empty suffix is always
+// true (JS parity). The optional `endPosition` treats the string as if
+// it were only that many bytes long (clamped to `[0, len]`), matching JS
+// `"abc".endsWith("b", 2) === true`.
+func EndsWith(s, suffix string, endPosition ...int) bool {
+	if len(endPosition) > 0 {
+		e := endPosition[0]
+		if e < 0 {
+			e = 0
+		}
+		if e > len(s) {
+			e = len(s)
+		}
+		s = s[:e]
+	}
+	return strings.HasSuffix(s, suffix)
 }
 
 // Join concatenates elements of a slice with sep. Accepts both

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -193,6 +193,63 @@ func TestSplit(t *testing.T) {
 	}
 }
 
+func TestStartsWith(t *testing.T) {
+	if !StartsWith("hello world", "hello") {
+		t.Error(`StartsWith("hello world", "hello") should be true`)
+	}
+	if StartsWith("hello world", "world") {
+		t.Error(`StartsWith("hello world", "world") should be false`)
+	}
+	if !StartsWith("anything", "") {
+		t.Error(`StartsWith(_, "") should be true (empty prefix)`)
+	}
+	// Optional position re-anchors the test (JS `startsWith(p, pos)`).
+	if !StartsWith("abc", "b", 1) {
+		t.Error(`StartsWith("abc", "b", 1) should be true`)
+	}
+	if StartsWith("abc", "a", 1) {
+		t.Error(`StartsWith("abc", "a", 1) should be false`)
+	}
+	// Position clamps to [0, len] — out-of-range never panics.
+	if StartsWith("abc", "a", 99) {
+		t.Error(`StartsWith("abc", "a", 99) should be false (clamped to len)`)
+	}
+	if !StartsWith("abc", "a", -5) {
+		t.Error(`StartsWith("abc", "a", -5) should be true (clamped to 0)`)
+	}
+}
+
+func TestEndsWith(t *testing.T) {
+	if !EndsWith("hello world", "world") {
+		t.Error(`EndsWith("hello world", "world") should be true`)
+	}
+	if EndsWith("hello world", "hello") {
+		t.Error(`EndsWith("hello world", "hello") should be false`)
+	}
+	if !EndsWith("anything", "") {
+		t.Error(`EndsWith(_, "") should be true (empty suffix)`)
+	}
+	// A suffix longer than the string is false (no panic).
+	if EndsWith("hi", "longer-than-string") {
+		t.Error(`EndsWith("hi", "longer-than-string") should be false`)
+	}
+	// Optional endPosition treats the string as that many bytes long
+	// (JS `endsWith(s, endPos)`).
+	if !EndsWith("abc", "b", 2) {
+		t.Error(`EndsWith("abc", "b", 2) should be true`)
+	}
+	if EndsWith("abc", "c", 2) {
+		t.Error(`EndsWith("abc", "c", 2) should be false`)
+	}
+	// endPosition clamps to [0, len] — out-of-range never panics.
+	if !EndsWith("abc", "c", 99) {
+		t.Error(`EndsWith("abc", "c", 99) should be true (clamped to len)`)
+	}
+	if EndsWith("abc", "a", -1) {
+		t.Error(`EndsWith("abc", "a", -1) should be false (clamped to 0 → empty)`)
+	}
+}
+
 func TestLen(t *testing.T) {
 	tests := []struct {
 		v    any

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -2194,6 +2194,10 @@ import { fixture as stringTrimFixture } from '../../../adapter-tests/fixtures/me
 // #1448 Tier B — string methods.
 import { fixture as stringSplitFixture } from '../../../adapter-tests/fixtures/methods/string-split'
 import { fixture as stringSplitLimitFixture } from '../../../adapter-tests/fixtures/methods/string-split-limit'
+import { fixture as stringStartsWithFixture } from '../../../adapter-tests/fixtures/methods/string-startsWith'
+import { fixture as stringStartsWithPositionFixture } from '../../../adapter-tests/fixtures/methods/string-startsWith-position'
+import { fixture as stringEndsWithFixture } from '../../../adapter-tests/fixtures/methods/string-endsWith'
+import { fixture as stringEndsWithPositionFixture } from '../../../adapter-tests/fixtures/methods/string-endsWith-position'
 // #1448 Tier B — .sort / .toSorted fixtures.
 import { fixture as arraySortFieldAscFixture } from '../../../adapter-tests/fixtures/methods/array-sort-field-asc'
 import { fixture as arraySortFieldDescFixture } from '../../../adapter-tests/fixtures/methods/array-sort-field-desc'
@@ -2240,6 +2244,12 @@ describe('GoTemplateAdapter - #1448 Tier A/B fixture-driven lowering pins', () =
     // observable (`bf_join (bf_split .Value ",") "|"`).
     { fixture: stringSplitFixture,      expect: 'bf_split .Value ","' },
     { fixture: stringSplitLimitFixture, expect: 'bf_split .Value "," 2' },
+    // #1448 Tier B — string → boolean at condition position, so the
+    // emit lands inside `{{if ...}}`.
+    { fixture: stringStartsWithFixture, expect: '{{if bf_starts_with .Value .Prefix}}' },
+    { fixture: stringStartsWithPositionFixture, expect: '{{if bf_starts_with .Value "world" 6}}' },
+    { fixture: stringEndsWithFixture,   expect: '{{if bf_ends_with .Value .Suffix}}' },
+    { fixture: stringEndsWithPositionFixture,   expect: '{{if bf_ends_with .Value "hello" 5}}' },
     // #1448 Tier B — sort / toSorted. Loop-chained shapes wrap the
     // iterable in `bf_sort .Items <kind> <key> <type> <dir>`;
     // standalone shapes inline the helper at the call site.
@@ -2356,12 +2366,11 @@ export function C() {
     { name: 'includes (2-arg fromIndex)', expr: `items().includes("a", 1)`, badEmit: '.Includes' },
     { name: 'concat (variadic)', expr: `items().concat(items(), items())`, badEmit: '.Concat' },
     // Tier B/C string methods — previously slipped through with no
-    // diagnostic; now gated by `UNSUPPORTED_METHODS`. `split` has since
-    // landed its full-arity lowering (#1448 Tier B) — `.split()`,
-    // `.split(sep)` and `.split(sep, limit)` all lower — so it's pinned
-    // in the positive fixture-pin block above.
-    { name: 'startsWith', expr: `name().startsWith("a")`, badEmit: '.Name.StartsWith' },
-    { name: 'endsWith', expr: `name().endsWith("z")`, badEmit: '.Name.EndsWith' },
+    // diagnostic; now gated by `UNSUPPORTED_METHODS`. `split`,
+    // `startsWith` and `endsWith` have since landed their full-arity
+    // lowerings (#1448 Tier B) and moved to the positive fixture-pin
+    // block above — `.split()`/`.split(sep)`/`.split(sep, limit)` and
+    // the optional `position` / `endPosition` second argument all lower.
     { name: 'replace', expr: `name().replace("a", "b")`, badEmit: '.Name.Replace' },
     { name: 'repeat', expr: `name().repeat(3)`, badEmit: '.Name.Repeat' },
     { name: 'padStart', expr: `name().padStart(5, "0")`, badEmit: '.Name.PadStart' },
@@ -2385,19 +2394,21 @@ export function C() {
   }
 
   // Predicate-level use of an unsupported string method also fails the
-  // build loudly (intended): a `.filter(t => t.name.startsWith("a"))`
+  // build loudly (intended): a `.filter(t => t.name.charAt(0) === "a")`
   // whose predicate calls one of the gated methods now refuses the whole
   // loop with BF101 (via the shared `isSupported` predicate gate in
-  // jsx-to-ir) rather than lowering to a broken `.StartsWith` inside the
+  // jsx-to-ir) rather than lowering to a broken `.CharAt` inside the
   // range. Pinning this so the loud-failure contract can't silently
-  // regress back to the old emit-broken-template behaviour.
+  // regress back to the old emit-broken-template behaviour. (`charAt`
+  // is a Tier C method that stays refused — earlier this test used
+  // `startsWith`, which has since landed its Tier B lowering.)
   test('unsupported string method inside a .filter() predicate raises BF101', () => {
     const result = compileJSX(`
 "use client"
 import { createSignal } from "@barefootjs/client"
 export function C() {
   const [items, setItems] = createSignal<{ name: string }[]>([])
-  return <ul>{items().filter(t => t.name.startsWith("a")).map(t => <li key={t.name}>{t.name}</li>)}</ul>
+  return <ul>{items().filter(t => t.name.charAt(0) === "a").map(t => <li key={t.name}>{t.name}</li>)}</ul>
 }
 `.trimStart(), 'test.tsx', { adapter: new GoTemplateAdapter() })
     expect(result.errors?.some(e => e.code === 'BF101')).toBe(true)

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -3229,6 +3229,22 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         const limit = emit(args[1])
         return `bf_split ${wrapIfMultiToken(recv)} ${wrapIfMultiToken(sep)} ${wrapIfMultiToken(limit)}`
       }
+      case 'startsWith':
+      case 'endsWith': {
+        // `.startsWith(prefix, position?)` / `.endsWith(suffix,
+        // endPosition?)` — string → boolean via the `bf_starts_with` /
+        // `bf_ends_with` helpers (`strings.HasPrefix` /
+        // `strings.HasSuffix`). The optional second argument re-anchors
+        // the test; JS ignores a third+ argument. See #1448 Tier B.
+        const fn = method === 'startsWith' ? 'bf_starts_with' : 'bf_ends_with'
+        const recv = emit(object)
+        const arg = emit(args[0])
+        const base = `${fn} ${wrapIfMultiToken(recv)} ${wrapIfMultiToken(arg)}`
+        if (args.length >= 2) {
+          return `${base} ${wrapIfMultiToken(emit(args[1]))}`
+        }
+        return base
+      }
       default: {
         const _exhaustive: never = method
         throw new Error(`Go arrayMethod: unhandled ArrayMethod '${(_exhaustive as string)}'`)

--- a/packages/adapter-mojolicious/lib/BarefootJS.pm
+++ b/packages/adapter-mojolicious/lib/BarefootJS.pm
@@ -585,6 +585,47 @@ sub split ($self, $recv, $sep = undef, $limit = undef) {
     return [@parts];
 }
 
+# `String.prototype.startsWith(prefix, position?)` (#1448 Tier B) —
+# string → boolean (1 / 0). `substr`-anchored literal comparison mirrors
+# Go's `strings.HasPrefix`. An empty prefix is always true (JS parity);
+# undef / non-string receivers coerce to the empty string first. The
+# optional `position` re-anchors the test (clamped to `[0, length]`),
+# matching JS `"abc".startsWith("b", 1)`.
+
+sub starts_with ($self, $recv, $prefix, $position = undef) {
+    my $s = defined $recv && !ref($recv) ? "$recv" : '';
+    my $p = defined $prefix ? "$prefix" : '';
+    if (defined $position) {
+        my $n = int($position);
+        $n = 0 if $n < 0;
+        $n = length($s) if $n > length($s);
+        $s = substr($s, $n);
+    }
+    return substr($s, 0, length $p) eq $p ? 1 : 0;
+}
+
+# `String.prototype.endsWith(suffix, endPosition?)` (#1448 Tier B) —
+# string → boolean (1 / 0). Mirrors Go's `strings.HasSuffix`. An empty
+# suffix is always true (JS parity); a suffix longer than the string is
+# false. `substr($s, -length $x)` would mis-read the whole string when
+# `length $x == 0`, so that case short-circuits. The optional
+# `endPosition` treats the string as if it were only that many chars
+# long (clamped to `[0, length]`), matching JS `"abc".endsWith("b", 2)`.
+
+sub ends_with ($self, $recv, $suffix, $end_position = undef) {
+    my $s = defined $recv && !ref($recv) ? "$recv" : '';
+    my $x = defined $suffix ? "$suffix" : '';
+    if (defined $end_position) {
+        my $e = int($end_position);
+        $e = 0 if $e < 0;
+        $e = length($s) if $e > length($s);
+        $s = substr($s, 0, $e);
+    }
+    return 1 if $x eq '';
+    return 0 if length($s) < length($x);
+    return substr($s, -length $x) eq $x ? 1 : 0;
+}
+
 # `Array.prototype.sort(cmp)` / `Array.prototype.toSorted(cmp)`
 # lowering (#1448 Tier B). Non-mutating — JS's mutate-vs-new
 # distinction is moot in SSR template context.

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -940,6 +940,10 @@ import { fixture as stringTrimFixture } from '../../../adapter-tests/fixtures/me
 // #1448 Tier B — string methods.
 import { fixture as stringSplitFixture } from '../../../adapter-tests/fixtures/methods/string-split'
 import { fixture as stringSplitLimitFixture } from '../../../adapter-tests/fixtures/methods/string-split-limit'
+import { fixture as stringStartsWithFixture } from '../../../adapter-tests/fixtures/methods/string-startsWith'
+import { fixture as stringStartsWithPositionFixture } from '../../../adapter-tests/fixtures/methods/string-startsWith-position'
+import { fixture as stringEndsWithFixture } from '../../../adapter-tests/fixtures/methods/string-endsWith'
+import { fixture as stringEndsWithPositionFixture } from '../../../adapter-tests/fixtures/methods/string-endsWith-position'
 // #1448 Tier B — .sort / .toSorted fixtures (loop-chained + standalone).
 import { fixture as arraySortFieldAscFixture } from '../../../adapter-tests/fixtures/methods/array-sort-field-asc'
 import { fixture as arraySortFieldDescFixture } from '../../../adapter-tests/fixtures/methods/array-sort-field-desc'
@@ -980,6 +984,11 @@ describe('MojoAdapter - #1448 Tier A/B fixture-driven lowering pins', () => {
     // observable (`join('|', @{bf->split($value, ',')})`).
     { fixture: stringSplitFixture,      expect: `bf->split($value, ',')` },
     { fixture: stringSplitLimitFixture, expect: `bf->split($value, ',', 2)` },
+    // #1448 Tier B — string → boolean at condition position (`% if`).
+    { fixture: stringStartsWithFixture, expect: 'bf->starts_with($value, $prefix)' },
+    { fixture: stringStartsWithPositionFixture, expect: `bf->starts_with($value, 'world', 6)` },
+    { fixture: stringEndsWithFixture,   expect: 'bf->ends_with($value, $suffix)' },
+    { fixture: stringEndsWithPositionFixture,   expect: `bf->ends_with($value, 'hello', 5)` },
     // #1448 Tier B — sort / toSorted. The loop-chained field cases
     // hoist into a `my $bf_iter_lN = bf->sort(...)` local; the
     // standalone primitive cases inline the call. Each comparison key
@@ -1093,11 +1102,11 @@ export function C() {
     { name: 'concat (variadic)', expr: `items().concat(items(), items())`, badEmit: '->{concat}' },
     // Tier B/C string methods — previously slipped through with no
     // diagnostic; now routed through the AST / `isSupported` gate.
-    // `split` has since landed its full-arity lowering (#1448 Tier B) —
-    // `.split()`, `.split(sep)` and `.split(sep, limit)` all lower — so
-    // it's pinned in the positive fixture-pin block above.
-    { name: 'startsWith', expr: `name().startsWith("a")`, badEmit: '->{startsWith}' },
-    { name: 'endsWith', expr: `name().endsWith("z")`, badEmit: '->{endsWith}' },
+    // `split`, `startsWith` and `endsWith` have since landed their
+    // full-arity lowerings (#1448 Tier B) and moved to the positive
+    // fixture-pin block above — `.split()`/`.split(sep)`/`.split(sep,
+    // limit)` and the optional `position` / `endPosition` second
+    // argument all lower.
     { name: 'replace', expr: `name().replace("a", "b")`, badEmit: '->{replace}' },
     { name: 'repeat', expr: `name().repeat(3)`, badEmit: '->{repeat}' },
     { name: 'padStart', expr: `name().padStart(5, "0")`, badEmit: '->{padStart}' },
@@ -1146,19 +1155,21 @@ export function C(props: { config: string }) {
   })
 
   // Predicate-level use of an unsupported string method also fails the
-  // build loudly (intended): a `.filter(t => t.name.startsWith("a"))`
+  // build loudly (intended): a `.filter(t => t.name.charAt(0) === "a")`
   // whose predicate calls one of the gated methods now refuses the whole
   // loop with BF101 (via the shared `isSupported` predicate gate in
-  // jsx-to-ir) rather than lowering to a broken `->{startsWith}` inside
+  // jsx-to-ir) rather than lowering to a broken `->{charAt}` inside
   // the grep. Pinning this so the loud-failure contract can't silently
-  // regress back to the old emit-broken-template behaviour.
+  // regress back to the old emit-broken-template behaviour. (`charAt`
+  // is a Tier C method that stays refused — earlier this test used
+  // `startsWith`, which has since landed its Tier B lowering.)
   test('unsupported string method inside a .filter() predicate raises BF101', () => {
     const result = compileJSX(`
 "use client"
 import { createSignal } from "@barefootjs/client"
 export function C() {
   const [items, setItems] = createSignal<{ name: string }[]>([])
-  return <ul>{items().filter(t => t.name.startsWith("a")).map(t => <li key={t.name}>{t.name}</li>)}</ul>
+  return <ul>{items().filter(t => t.name.charAt(0) === "a").map(t => <li key={t.name}>{t.name}</li>)}</ul>
 }
 `.trimStart(), 'test.tsx', { adapter: new MojoAdapter() })
     expect(result.errors?.some(e => e.code === 'BF101')).toBe(true)

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1415,6 +1415,23 @@ function renderArrayMethod(
       const limit = emit(args[1])
       return `bf->split(${recv}, ${sep}, ${limit})`
     }
+    case 'startsWith':
+    case 'endsWith': {
+      // `.startsWith(prefix, position?)` / `.endsWith(suffix,
+      // endPosition?)` — string → boolean. The Perl helpers
+      // (`bf->starts_with` / `bf->ends_with`) do a `substr`-anchored
+      // comparison so the search string is matched literally (no regex
+      // metachar surprises) and undef receivers stay quiet. The optional
+      // second argument re-anchors the test; JS ignores a third+
+      // argument. See #1448 Tier B.
+      const fn = method === 'startsWith' ? 'starts_with' : 'ends_with'
+      const recv = emit(object)
+      const arg = emit(args[0])
+      if (args.length >= 2) {
+        return `bf->${fn}(${recv}, ${arg}, ${emit(args[1])})`
+      }
+      return `bf->${fn}(${recv}, ${arg})`
+    }
     default: {
       // TS-level exhaustiveness guard. If this throws at runtime, the
       // IR was constructed against a newer `ArrayMethod` variant that

--- a/packages/adapter-mojolicious/t/template_primitives.t
+++ b/packages/adapter-mojolicious/t/template_primitives.t
@@ -283,6 +283,42 @@ subtest 'split — string into array of substrings' => sub {
     is $bf->split(42,      ','),   ['42'],            'numeric receiver stringifies';
 };
 
+# `String.prototype.startsWith` / `endsWith` — string → boolean (1/0)
+# (#1448 Tier B). Literal substr-anchored comparison; mirrors Go's
+# strings.HasPrefix / HasSuffix.
+subtest 'starts_with / ends_with — boolean prefix/suffix tests' => sub {
+    ok  $bf->starts_with('hello world', 'hello'),  'prefix matches';
+    ok !$bf->starts_with('hello world', 'world'),  'prefix mismatch';
+    ok  $bf->starts_with('anything', ''),          'empty prefix is always true';
+    ok !$bf->starts_with('hi', 'longer-than-str'), 'prefix longer than string → false';
+
+    ok  $bf->ends_with('hello world', 'world'),    'suffix matches';
+    ok !$bf->ends_with('hello world', 'hello'),    'suffix mismatch';
+    ok  $bf->ends_with('anything', ''),            'empty suffix is always true';
+    ok !$bf->ends_with('hi', 'longer-than-str'),   'suffix longer than string → false';
+
+    # Separator/search string is matched literally, not as a regex.
+    ok  $bf->starts_with('a.b.c', 'a.'),           'dot in prefix is literal';
+    ok  $bf->ends_with('a.b.c', '.c'),             'dot in suffix is literal';
+
+    # Undef / non-string receivers coerce to empty string.
+    ok !$bf->starts_with(undef, 'x'),              'undef receiver, non-empty prefix → false';
+    ok  $bf->starts_with(undef, ''),               'undef receiver, empty prefix → true';
+    is  $bf->starts_with('hello', 'he'), 1,        'returns 1, not just truthy';
+    is  $bf->ends_with('hello', 'xx'),   0,        'returns 0, not just falsey';
+
+    # Optional position / endPosition (JS `startsWith(p, pos)` /
+    # `endsWith(s, endPos)`), with clamping to [0, length].
+    ok  $bf->starts_with('abc', 'b', 1),           'starts_with at position';
+    ok !$bf->starts_with('abc', 'a', 1),           'starts_with: wrong char at position → false';
+    ok !$bf->starts_with('abc', 'a', 99),          'starts_with: position past end → false (clamped)';
+    ok  $bf->starts_with('abc', 'a', -5),          'starts_with: negative position → from 0 (clamped)';
+    ok  $bf->ends_with('abc', 'b', 2),             'ends_with at endPosition';
+    ok !$bf->ends_with('abc', 'c', 2),             'ends_with: char beyond endPosition → false';
+    ok  $bf->ends_with('abc', 'c', 99),            'ends_with: endPosition past end → true (clamped)';
+    ok !$bf->ends_with('abc', 'a', -1),            'ends_with: negative endPosition → empty (clamped)';
+};
+
 # `Array.prototype.sort(cmp)` / `Array.prototype.toSorted(cmp)`
 # lowering (#1448 Tier B). The opts hash-ref carries a `keys` list of
 # the structured comparison keys the compiler extracted at parse time

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -136,6 +136,10 @@ import { fixture as stringIncludes } from './methods/string-includes'
 // #1448 Tier B — String methods.
 import { fixture as stringSplit } from './methods/string-split'
 import { fixture as stringSplitLimit } from './methods/string-split-limit'
+import { fixture as stringStartsWith } from './methods/string-startsWith'
+import { fixture as stringStartsWithPosition } from './methods/string-startsWith-position'
+import { fixture as stringEndsWith } from './methods/string-endsWith'
+import { fixture as stringEndsWithPosition } from './methods/string-endsWith-position'
 // #1448 catalog parity: array methods rendered positively by
 // Hono / CSR (runtime JS) and at least one SSR adapter — pinning
 // the canonical surface so a regression surfaces here instead of
@@ -307,6 +311,10 @@ export const jsxFixtures: JSXFixture[] = [
   // #1448 Tier B — String methods.
   stringSplit,
   stringSplitLimit,
+  stringStartsWith,
+  stringStartsWithPosition,
+  stringEndsWith,
+  stringEndsWithPosition,
   // #1448 catalog parity — already-lowered Array methods.
   arrayJoin,
   arrayFind,

--- a/packages/adapter-tests/fixtures/methods/string-endsWith-position.ts
+++ b/packages/adapter-tests/fixtures/methods/string-endsWith-position.ts
@@ -1,0 +1,23 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `String.prototype.endsWith(search, endPosition)` — the endPosition
+ * form (#1448 Tier B, full-arity). The optional second argument treats
+ * the string as if it were only that many characters long
+ * (`"hello world".endsWith("hello", 5) === true`). Boolean-returning,
+ * so it sits at condition position like `string-endsWith`.
+ */
+export const fixture = createFixture({
+  id: 'string-endsWith-position',
+  description: '.endsWith(search, endPosition) re-anchors the suffix test',
+  source: `
+function StringEndsWithPosition({ value }: { value: string }) {
+  return <div>{value.endsWith('hello', 5) ? 'yes' : 'no'}</div>
+}
+export { StringEndsWithPosition }
+`,
+  props: { value: 'hello world' },
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><!--bf-cond-start:s0-->yes<!--bf-cond-end:s0--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/methods/string-endsWith.ts
+++ b/packages/adapter-tests/fixtures/methods/string-endsWith.ts
@@ -1,0 +1,24 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `String.prototype.endsWith(suffix)` lowering (#1448 Tier B).
+ *
+ * Sibling of `string-startsWith` — boolean at condition position. The
+ * suffix matches the end of the value so the truthy branch renders; a
+ * lowering that confused prefix/suffix (or HasPrefix vs HasSuffix)
+ * would render the `no` branch and fail the assertion.
+ */
+export const fixture = createFixture({
+  id: 'string-endsWith',
+  description: '.endsWith(suffix) renders the matching branch',
+  source: `
+function StringEndsWith({ value, suffix }: { value: string; suffix: string }) {
+  return <div>{value.endsWith(suffix) ? 'yes' : 'no'}</div>
+}
+export { StringEndsWith }
+`,
+  props: { value: 'hello world', suffix: 'world' },
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><!--bf-cond-start:s0-->yes<!--bf-cond-end:s0--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/methods/string-startsWith-position.ts
+++ b/packages/adapter-tests/fixtures/methods/string-startsWith-position.ts
@@ -1,0 +1,22 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `String.prototype.startsWith(search, position)` — the position form
+ * (#1448 Tier B, full-arity). The optional second argument re-anchors
+ * the test (`"hello world".startsWith("world", 6) === true`). Boolean-
+ * returning, so it sits at condition position like `string-startsWith`.
+ */
+export const fixture = createFixture({
+  id: 'string-startsWith-position',
+  description: '.startsWith(search, position) re-anchors the prefix test',
+  source: `
+function StringStartsWithPosition({ value }: { value: string }) {
+  return <div>{value.startsWith('world', 6) ? 'yes' : 'no'}</div>
+}
+export { StringStartsWithPosition }
+`,
+  props: { value: 'hello world' },
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><!--bf-cond-start:s0-->yes<!--bf-cond-end:s0--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/methods/string-startsWith.ts
+++ b/packages/adapter-tests/fixtures/methods/string-startsWith.ts
@@ -1,0 +1,24 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `String.prototype.startsWith(prefix)` lowering (#1448 Tier B).
+ *
+ * Boolean-returning, so the fixture sits at condition position
+ * (`{cond ? 'yes' : 'no'}`) like `string-includes` — the emit lands
+ * inside the adapter's `if` branch. The prefix matches the start of
+ * the value so the truthy branch renders.
+ */
+export const fixture = createFixture({
+  id: 'string-startsWith',
+  description: '.startsWith(prefix) renders the matching branch',
+  source: `
+function StringStartsWith({ value, prefix }: { value: string; prefix: string }) {
+  return <div>{value.startsWith(prefix) ? 'yes' : 'no'}</div>
+}
+export { StringStartsWith }
+`,
+  props: { value: 'hello world', prefix: 'hello' },
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><!--bf-cond-start:s0-->yes<!--bf-cond-end:s0--></div>
+  `,
+})

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -398,23 +398,40 @@ describe('expression-parser', () => {
       const result = parseExpression("items().filter(({name = 'anon'}) => name.startsWith('a'))")
       expect(result.kind).toBe('higher-order')
       if (result.kind === 'higher-order') {
-        // Predicate: `(_t.name ?? 'anon').startsWith('a')`.
-        expect(result.predicate.kind).toBe('call')
-        if (result.predicate.kind === 'call') {
-          expect(result.predicate.callee.kind).toBe('member')
-          if (result.predicate.callee.kind === 'member') {
-            expect(result.predicate.callee.property).toBe('startsWith')
-            expect(result.predicate.callee.object.kind).toBe('logical')
-            if (result.predicate.callee.object.kind === 'logical') {
-              expect(result.predicate.callee.object.op).toBe('??')
-              expect(result.predicate.callee.object.right.kind).toBe('literal')
-              if (result.predicate.callee.object.right.kind === 'literal') {
-                expect(result.predicate.callee.object.right.value).toBe('anon')
-              }
+        // Predicate: `(_t.name ?? 'anon').startsWith('a')`. Since #1448
+        // Tier B, `.startsWith` lowers to an `array-method` node (it was
+        // a generic `call` before), so the receiver is on `.object`.
+        expect(result.predicate.kind).toBe('array-method')
+        if (result.predicate.kind === 'array-method') {
+          expect(result.predicate.method).toBe('startsWith')
+          expect(result.predicate.object.kind).toBe('logical')
+          if (result.predicate.object.kind === 'logical') {
+            expect(result.predicate.object.op).toBe('??')
+            expect(result.predicate.object.right.kind).toBe('literal')
+            if (result.predicate.object.right.kind === 'literal') {
+              expect(result.predicate.object.right.value).toBe('anon')
             }
           }
         }
       }
+    })
+
+    test('lowers .startsWith(search, position) — full arity (#1448 Tier B)', () => {
+      const result = parseExpression(`name().startsWith("world", 6)`)
+      expect(result.kind).toBe('array-method')
+      if (result.kind === 'array-method') {
+        expect(result.method).toBe('startsWith')
+        // Both the search string and the position survive as args so the
+        // adapter can emit the re-anchored test.
+        expect(result.args.length).toBe(2)
+      }
+    })
+
+    test('refuses .startsWith() with no search string (#1448 Tier B)', () => {
+      // JS coerces the missing argument to the string "undefined" — a
+      // degenerate result not worth lowering (mirrors `.includes()`).
+      const result = parseExpression(`name().startsWith()`)
+      expect(result.kind).toBe('unsupported')
     })
 
     test('lowers .filter(({label = `untitled-${suffix}`}) => label) — template-literal default (#1531)', () => {

--- a/packages/jsx/src/adapters/parsed-expr-emitter.ts
+++ b/packages/jsx/src/adapters/parsed-expr-emitter.ts
@@ -67,6 +67,8 @@ export type ArrayMethod =
   | 'toUpperCase'
   | 'trim'
   | 'split'
+  | 'startsWith'
+  | 'endsWith'
 
 /**
  * Method names handled by the dedicated `sortMethod()` dispatcher

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -47,6 +47,8 @@ export type ParsedExpr =
         | 'toUpperCase'
         | 'trim'
         | 'split'
+        | 'startsWith'
+        | 'endsWith'
       object: ParsedExpr
       args: ParsedExpr[]
     }
@@ -230,7 +232,10 @@ const UNSUPPORTED_METHODS = new Set([
   // via the `array-method` IR + `bf_split` (Go) / `bf->split` (Mojo),
   // returning an array that composes with `.join()` / `.map()` / etc.
   // See #1448 Tier B.
-  'startsWith', 'endsWith', 'replace', 'replaceAll',
+  // `startsWith` / `endsWith` are no longer here — both lower via the
+  // `array-method` IR + `bf_starts_with` / `bf_ends_with` (Go) and
+  // `bf->starts_with` / `bf->ends_with` (Mojo). See #1448 Tier B.
+  'replace', 'replaceAll',
   'repeat', 'padStart', 'padEnd',
   'charAt', 'charCodeAt', 'codePointAt', 'normalize',
   'substring', 'substr', 'match', 'matchAll', 'search',
@@ -479,6 +484,25 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
           raw,
           reason: `${detail} is not yet lowered to the Go/Mojo template adapters. Use the single-argument \`.${callee.property}(${argName})\` form, or pre-compute the value before the template.`,
         }
+      }
+      // `.startsWith(search, position?)` / `.endsWith(search, endPosition?)`
+      // — string → boolean, full JS arity. Go uses `bf_starts_with` /
+      // `bf_ends_with` (wrapping `strings.HasPrefix` / `strings.HasSuffix`,
+      // with an optional position that re-anchors the comparison); Mojo
+      // uses `bf->starts_with` / `bf->ends_with` (substr comparison). JS
+      // ignores a third+ argument. The zero-arg form (`.startsWith()`) is
+      // refused: JS coerces the missing search to the literal string
+      // "undefined", a degenerate result not worth lowering (mirrors the
+      // `.includes()` zero-arg refusal). See #1448 Tier B.
+      if (callee.property === 'startsWith' || callee.property === 'endsWith') {
+        if (args.length === 0) {
+          return {
+            kind: 'unsupported',
+            raw,
+            reason: `\`.${callee.property}()\` with no search string is not lowered — JS coerces the missing argument to the string "undefined", a degenerate result. Pass an explicit search string, or pre-compute the value before the template.`,
+          }
+        }
+        return { kind: 'array-method', method: callee.property, object: callee.object, args }
       }
       // `.sort(cmp)` / `.toSorted(cmp)` (#1448 Tier B). The comparator
       // is extracted into a structured `SortComparator` at parse time;


### PR DESCRIPTION
## String Tier B (#1448) — `.startsWith` / `.endsWith` (full-arity)

`value.startsWith('a')` / `value.endsWith('z')` now lower to both template-language adapters instead of refusing with **BF101**. Both return a boolean, so they slot into condition position:

```jsx
{value.startsWith(prefix) ? 'yes' : 'no'}
{value.endsWith(suffix, 5) ? 'yes' : 'no'}
```

> Rebased onto `main` now that #1717 (`.split`) has merged. Reworked from the original "single search-string form only" to **full JS arity**, matching the arity philosophy established in #1722.

### Changes
- **Parser**: two new `array-method` variants `startsWith` / `endsWith` (+ `ArrayMethod` type alias); both drop out of `UNSUPPORTED_METHODS`.
- **Full arity**: the optional `position` (`startsWith`) / `endPosition` (`endsWith`) second argument re-anchors the test, clamped to `[0, length]` so it never crashes. A third+ argument is ignored. The zero-arg form (`.startsWith()`) is refused — JS coerces the missing search to the literal string `"undefined"`, a degenerate result (mirrors the `.includes()` zero-arg refusal).
- **Go** (`bf.go`): `bf_starts_with` / `bf_ends_with` (`strings.HasPrefix` / `strings.HasSuffix`, with the optional clamped position).
- **Mojo** (`BarefootJS.pm`): `bf->starts_with` / `bf->ends_with` — `substr`-anchored literal comparison (no regex metachar surprises), with the optional clamped position and empty-prefix/suffix + undef-receiver handling matching JS + Go.

### Verification
- `bf_starts_with` / `bf_ends_with` Go unit tests (incl. position + clamping)
- Perl `.t` suite under **real Mojolicious** (incl. position + clamping)
- Compiler-unit pins: full-arity `array-method` lowering + zero-arg refusal
- Cross-adapter SSR/CSR conformance render of `string-startsWith` / `string-endsWith` + new `-position` fixtures (Hono / Go / Mojo byte-equal)

### Remaining stack
- `.replace` (#1719) · `.repeat` (#1720) · `.padStart` / `.padEnd` (#1721) — each being rebased onto `main` and unified to full-arity.

https://claude.ai/code/session_01WDSuf4wHqvVUkFM23vGZqx

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDSuf4wHqvVUkFM23vGZqx)_