### PR TITLE
feat(#1448 Tier B): lower String.prototype.replace (string-pattern form)

### DIFF
--- a/.changeset/string-replace-tier-b.md
+++ b/.changeset/string-replace-tier-b.md
@@ -1,0 +1,17 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+"@barefootjs/mojolicious": patch
+---
+
+Lower the string-pattern form of `String.prototype.replace(pattern, replacement)` to the template-language adapters (#1448 Tier B).
+
+`value.replace('o', '0')` now compiles to both template adapters, replacing the **first** occurrence (JS string-pattern semantics — not `.replaceAll`).
+
+Full JS arity: a third+ argument is ignored (the adapter reads only the pattern + replacement). The one- and zero-argument forms are refused — JS coerces the missing replacement (and pattern) to the literal string `"undefined"`, a degenerate result (mirrors the `.includes()` / `.startsWith()` zero-arg refusal).
+
+- Parser: new `array-method` variant `replace`, dropped from `UNSUPPORTED_METHODS`. **Regex-pattern** `.replace(/…/, …)` stays refused with BF101 (the Perl `s///` vs Go `regexp.ReplaceAllString` flavour gap is the open design question), and `.replaceAll` stays refused entirely.
+- Go: new `bf_replace` runtime helper (`strings.Replace` with n=1).
+- Mojo: new `bf->replace` helper that splices via `index`/`substr` (not `s///`) so both the pattern and the replacement are literal.
+
+Known divergence (documented in `bf.go`, `BarefootJS.pm`): the replacement string is treated **literally** on both template adapters — special replacement patterns (`$&`, `$1`, …) are not interpreted. Go and Perl agree (byte-equal SSR output); this differs from the Hono/CSR JS path only for replacement strings containing `$`-patterns, which are rare in template position.

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -38,6 +38,7 @@ func FuncMap() template.FuncMap {
 		"bf_split":       Split,
 		"bf_starts_with": StartsWith,
 		"bf_ends_with":   EndsWith,
+		"bf_replace":     Replace,
 		"bf_string":      String,
 
 		// JSON / numeric primitives — JS-compat callees registered on
@@ -540,6 +541,19 @@ func EndsWith(s, suffix string, endPosition ...int) bool {
 		s = s[:e]
 	}
 	return strings.HasSuffix(s, suffix)
+}
+
+// Replace lowers the string-pattern form of `String.prototype.replace`
+// (#1448 Tier B). JS replaces only the FIRST occurrence for a string
+// pattern, so the count is 1 (`strings.Replace` with n=1; n<0 would
+// replace all — that's `.replaceAll`, still refused). The replacement
+// is treated literally: unlike JS, special replacement patterns like
+// `$&` / `$1` are NOT interpreted (Go and Perl agree on literal
+// replacement, keeping the two template adapters byte-equal; this
+// diverges from the Hono/CSR JS path only for replacement strings that
+// contain `$`-patterns, which are rare in template position).
+func Replace(s, old, new string) string {
+	return strings.Replace(s, old, new, 1)
 }
 
 // Join concatenates elements of a slice with sep. Accepts both

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -250,6 +250,26 @@ func TestEndsWith(t *testing.T) {
 	}
 }
 
+func TestReplace(t *testing.T) {
+	// Only the FIRST occurrence is replaced (JS string-pattern
+	// semantics — not `.replaceAll`).
+	if got := Replace("hello world", "o", "0"); got != "hell0 world" {
+		t.Errorf(`Replace("hello world", "o", "0") = %q, want "hell0 world"`, got)
+	}
+	// No match → unchanged.
+	if got := Replace("abc", "z", "Z"); got != "abc" {
+		t.Errorf(`Replace("abc", "z", "Z") = %q, want "abc"`, got)
+	}
+	// Empty pattern inserts at the front (JS + Go parity).
+	if got := Replace("abc", "", "X"); got != "Xabc" {
+		t.Errorf(`Replace("abc", "", "X") = %q, want "Xabc"`, got)
+	}
+	// Replacement is literal — `$1` / `$&` are NOT interpreted.
+	if got := Replace("ab", "a", "$&"); got != "$&b" {
+		t.Errorf(`Replace("ab", "a", "$&") = %q, want "$&b" (literal)`, got)
+	}
+}
+
 func TestLen(t *testing.T) {
 	tests := []struct {
 		v    any

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -2198,6 +2198,7 @@ import { fixture as stringStartsWithFixture } from '../../../adapter-tests/fixtu
 import { fixture as stringStartsWithPositionFixture } from '../../../adapter-tests/fixtures/methods/string-startsWith-position'
 import { fixture as stringEndsWithFixture } from '../../../adapter-tests/fixtures/methods/string-endsWith'
 import { fixture as stringEndsWithPositionFixture } from '../../../adapter-tests/fixtures/methods/string-endsWith-position'
+import { fixture as stringReplaceFixture } from '../../../adapter-tests/fixtures/methods/string-replace'
 // #1448 Tier B — .sort / .toSorted fixtures.
 import { fixture as arraySortFieldAscFixture } from '../../../adapter-tests/fixtures/methods/array-sort-field-asc'
 import { fixture as arraySortFieldDescFixture } from '../../../adapter-tests/fixtures/methods/array-sort-field-desc'
@@ -2250,6 +2251,8 @@ describe('GoTemplateAdapter - #1448 Tier A/B fixture-driven lowering pins', () =
     { fixture: stringStartsWithPositionFixture, expect: '{{if bf_starts_with .Value "world" 6}}' },
     { fixture: stringEndsWithFixture,   expect: '{{if bf_ends_with .Value .Suffix}}' },
     { fixture: stringEndsWithPositionFixture,   expect: '{{if bf_ends_with .Value "hello" 5}}' },
+    // #1448 Tier B — string → string, first-occurrence replace.
+    { fixture: stringReplaceFixture,    expect: 'bf_replace .Value "o" "0"' },
     // #1448 Tier B — sort / toSorted. Loop-chained shapes wrap the
     // iterable in `bf_sort .Items <kind> <key> <type> <dir>`;
     // standalone shapes inline the helper at the call site.
@@ -2367,11 +2370,10 @@ export function C() {
     { name: 'concat (variadic)', expr: `items().concat(items(), items())`, badEmit: '.Concat' },
     // Tier B/C string methods — previously slipped through with no
     // diagnostic; now gated by `UNSUPPORTED_METHODS`. `split`,
-    // `startsWith` and `endsWith` have since landed their full-arity
-    // lowerings (#1448 Tier B) and moved to the positive fixture-pin
-    // block above — `.split()`/`.split(sep)`/`.split(sep, limit)` and
-    // the optional `position` / `endPosition` second argument all lower.
-    { name: 'replace', expr: `name().replace("a", "b")`, badEmit: '.Name.Replace' },
+    // `startsWith`, `endsWith` and the string-pattern form of `replace`
+    // have since landed their full-arity lowerings (#1448 Tier B) and
+    // moved to the positive fixture-pin block above. The regex-pattern
+    // `replace` form is pinned separately below.
     { name: 'repeat', expr: `name().repeat(3)`, badEmit: '.Name.Repeat' },
     { name: 'padStart', expr: `name().padStart(5, "0")`, badEmit: '.Name.PadStart' },
     { name: 'padEnd', expr: `name().padEnd(5, "0")`, badEmit: '.Name.PadEnd' },
@@ -2412,6 +2414,23 @@ export function C() {
 }
 `.trimStart(), 'test.tsx', { adapter: new GoTemplateAdapter() })
     expect(result.errors?.some(e => e.code === 'BF101')).toBe(true)
+  })
+
+  // The string-pattern form of `.replace` lowers (#1448 Tier B), but
+  // the regex-pattern form stays refused with BF101 — the Perl `s///`
+  // vs Go `regexp.ReplaceAllString` flavour gap is the open design
+  // question. Pinning the refusal so the string-form lowering can't
+  // accidentally start emitting a broken `.Replace` for the regex form.
+  test('regex-pattern .replace raises BF101 (string-pattern form is lowered)', () => {
+    const result = compileJSX(`
+function C({ value }: { value: string }) {
+  return <div>{value.replace(/o/g, "0")}</div>
+}
+export { C }
+`.trimStart(), 'test.tsx', { adapter: new GoTemplateAdapter() })
+    expect(result.errors?.some(e => e.code === 'BF101')).toBe(true)
+    const template = result.files?.find(f => f.path.endsWith('.tmpl'))?.content ?? ''
+    expect(template).not.toContain('.Replace')
   })
 
   // Tier B `.sort` / `.toSorted` follow-ups still refused with BF021.

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -3245,6 +3245,16 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         }
         return base
       }
+      case 'replace': {
+        // `.replace(old, new)` — string-pattern form, first occurrence
+        // only, via the new `bf_replace` helper (`strings.Replace` with
+        // n=1). The regex-pattern form is refused upstream at the
+        // parser. See #1448 Tier B.
+        const recv = emit(object)
+        const oldS = emit(args[0])
+        const newS = emit(args[1])
+        return `bf_replace ${wrapIfMultiToken(recv)} ${wrapIfMultiToken(oldS)} ${wrapIfMultiToken(newS)}`
+      }
       default: {
         const _exhaustive: never = method
         throw new Error(`Go arrayMethod: unhandled ArrayMethod '${(_exhaustive as string)}'`)

--- a/packages/adapter-mojolicious/lib/BarefootJS.pm
+++ b/packages/adapter-mojolicious/lib/BarefootJS.pm
@@ -626,6 +626,27 @@ sub ends_with ($self, $recv, $suffix, $end_position = undef) {
     return substr($s, -length $x) eq $x ? 1 : 0;
 }
 
+# `String.prototype.replace(pattern, replacement)` — string-pattern
+# form only (#1448 Tier B), replacing the FIRST occurrence (JS string-
+# pattern semantics). Spliced via index/substr rather than `s///` so
+# BOTH the pattern and the replacement are literal: no Perl regex
+# metacharacters in the pattern and no `$1` / `$&` interpolation in the
+# replacement. Go's `bf_replace` (strings.Replace, n=1) treats the
+# replacement literally too, so the two adapters stay byte-equal — this
+# diverges from JS only for replacement strings containing `$`-patterns
+# (rare in template position). An empty pattern inserts the replacement
+# at the front (`"abc".replace("", "X")` → "Xabc"), matching JS + Go.
+
+sub replace ($self, $recv, $pattern, $replacement) {
+    my $s = defined $recv && !ref($recv) ? "$recv" : '';
+    my $o = defined $pattern ? "$pattern" : '';
+    my $n = defined $replacement ? "$replacement" : '';
+    return $n . $s if $o eq '';
+    my $i = index($s, $o);
+    return $s if $i < 0;
+    return substr($s, 0, $i) . $n . substr($s, $i + length($o));
+}
+
 # `Array.prototype.sort(cmp)` / `Array.prototype.toSorted(cmp)`
 # lowering (#1448 Tier B). Non-mutating — JS's mutate-vs-new
 # distinction is moot in SSR template context.

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -944,6 +944,7 @@ import { fixture as stringStartsWithFixture } from '../../../adapter-tests/fixtu
 import { fixture as stringStartsWithPositionFixture } from '../../../adapter-tests/fixtures/methods/string-startsWith-position'
 import { fixture as stringEndsWithFixture } from '../../../adapter-tests/fixtures/methods/string-endsWith'
 import { fixture as stringEndsWithPositionFixture } from '../../../adapter-tests/fixtures/methods/string-endsWith-position'
+import { fixture as stringReplaceFixture } from '../../../adapter-tests/fixtures/methods/string-replace'
 // #1448 Tier B — .sort / .toSorted fixtures (loop-chained + standalone).
 import { fixture as arraySortFieldAscFixture } from '../../../adapter-tests/fixtures/methods/array-sort-field-asc'
 import { fixture as arraySortFieldDescFixture } from '../../../adapter-tests/fixtures/methods/array-sort-field-desc'
@@ -989,6 +990,8 @@ describe('MojoAdapter - #1448 Tier A/B fixture-driven lowering pins', () => {
     { fixture: stringStartsWithPositionFixture, expect: `bf->starts_with($value, 'world', 6)` },
     { fixture: stringEndsWithFixture,   expect: 'bf->ends_with($value, $suffix)' },
     { fixture: stringEndsWithPositionFixture,   expect: `bf->ends_with($value, 'hello', 5)` },
+    // #1448 Tier B — string → string, first-occurrence replace.
+    { fixture: stringReplaceFixture,    expect: `bf->replace($value, 'o', '0')` },
     // #1448 Tier B — sort / toSorted. The loop-chained field cases
     // hoist into a `my $bf_iter_lN = bf->sort(...)` local; the
     // standalone primitive cases inline the call. Each comparison key
@@ -1102,12 +1105,11 @@ export function C() {
     { name: 'concat (variadic)', expr: `items().concat(items(), items())`, badEmit: '->{concat}' },
     // Tier B/C string methods — previously slipped through with no
     // diagnostic; now routed through the AST / `isSupported` gate.
-    // `split`, `startsWith` and `endsWith` have since landed their
-    // full-arity lowerings (#1448 Tier B) and moved to the positive
-    // fixture-pin block above — `.split()`/`.split(sep)`/`.split(sep,
-    // limit)` and the optional `position` / `endPosition` second
-    // argument all lower.
-    { name: 'replace', expr: `name().replace("a", "b")`, badEmit: '->{replace}' },
+    // `split`, `startsWith`, `endsWith` and the string-pattern form of
+    // `replace` have since landed their full-arity lowerings (#1448
+    // Tier B) and moved to the positive fixture-pin block above (the
+    // regex-pattern `replace` form stays refused — pinned separately
+    // below).
     { name: 'repeat', expr: `name().repeat(3)`, badEmit: '->{repeat}' },
     { name: 'padStart', expr: `name().padStart(5, "0")`, badEmit: '->{padStart}' },
     { name: 'padEnd', expr: `name().padEnd(5, "0")`, badEmit: '->{padEnd}' },
@@ -1173,6 +1175,23 @@ export function C() {
 }
 `.trimStart(), 'test.tsx', { adapter: new MojoAdapter() })
     expect(result.errors?.some(e => e.code === 'BF101')).toBe(true)
+  })
+
+  // The string-pattern form of `.replace` lowers (#1448 Tier B), but
+  // the regex-pattern form stays refused with BF101 — the Perl `s///`
+  // vs Go `regexp.ReplaceAllString` flavour gap is the open design
+  // question. Pinning the refusal so it can't regress into a broken
+  // `->{replace}` emit for the regex form.
+  test('regex-pattern .replace raises BF101 (string-pattern form is lowered)', () => {
+    const result = compileJSX(`
+function C({ value }: { value: string }) {
+  return <div>{value.replace(/o/g, "0")}</div>
+}
+export { C }
+`.trimStart(), 'test.tsx', { adapter: new MojoAdapter() })
+    expect(result.errors?.some(e => e.code === 'BF101')).toBe(true)
+    const template = result.files?.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
+    expect(template).not.toContain('->{replace}')
   })
 
   // Tier B `.sort` / `.toSorted` follow-ups still refused with BF021.

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1432,6 +1432,19 @@ function renderArrayMethod(
       }
       return `bf->${fn}(${recv}, ${arg})`
     }
+    case 'replace': {
+      // `.replace(old, new)` — string-pattern form, first occurrence.
+      // The `bf->replace` helper splices via index/substr (not `s///`)
+      // so both the pattern and the replacement are literal — no Perl
+      // regex metacharacters and no `$1` / `$&` interpolation in the
+      // replacement, keeping it byte-equal with Go's `bf_replace`. The
+      // regex-pattern form is refused upstream at the parser. See
+      // #1448 Tier B.
+      const recv = emit(object)
+      const oldS = emit(args[0])
+      const newS = emit(args[1])
+      return `bf->replace(${recv}, ${oldS}, ${newS})`
+    }
     default: {
       // TS-level exhaustiveness guard. If this throws at runtime, the
       // IR was constructed against a newer `ArrayMethod` variant that

--- a/packages/adapter-mojolicious/t/template_primitives.t
+++ b/packages/adapter-mojolicious/t/template_primitives.t
@@ -319,6 +319,28 @@ subtest 'starts_with / ends_with — boolean prefix/suffix tests' => sub {
     ok !$bf->ends_with('abc', 'a', -1),            'ends_with: negative endPosition → empty (clamped)';
 };
 
+# `String.prototype.replace(pattern, replacement)` — string-pattern
+# form, first occurrence only (#1448 Tier B). Literal splice (no s///),
+# so both pattern and replacement are literal — mirrors Go's
+# strings.Replace with n=1.
+subtest 'replace — first-occurrence string-pattern swap' => sub {
+    is $bf->replace('hello world', 'o', '0'), 'hell0 world', 'first occurrence only';
+    is $bf->replace('aaa', 'a', 'b'),          'baa',         'leftmost of repeats';
+    is $bf->replace('abc', 'z', 'Z'),          'abc',         'no match → unchanged';
+    is $bf->replace('abc', 'b', ''),           'ac',          'empty replacement deletes';
+    is $bf->replace('abc', '', 'X'),           'Xabc',        'empty pattern inserts at front';
+
+    # Pattern is literal, not a regex — '.' matches a literal dot only.
+    is $bf->replace('a.b.c', '.', '-'),        'a-b.c',       'dot in pattern is literal';
+
+    # Replacement is literal — no $1 / $& interpolation.
+    is $bf->replace('ab', 'a', '$&'),          '$&b',         'replacement $& is literal';
+    is $bf->replace('ab', 'a', '$1'),          '$1b',         'replacement $1 is literal';
+
+    # Undef / non-string receivers coerce to empty string.
+    is $bf->replace(undef, 'a', 'b'),          '',            'undef receiver → empty';
+};
+
 # `Array.prototype.sort(cmp)` / `Array.prototype.toSorted(cmp)`
 # lowering (#1448 Tier B). The opts hash-ref carries a `keys` list of
 # the structured comparison keys the compiler extracted at parse time

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -140,6 +140,7 @@ import { fixture as stringStartsWith } from './methods/string-startsWith'
 import { fixture as stringStartsWithPosition } from './methods/string-startsWith-position'
 import { fixture as stringEndsWith } from './methods/string-endsWith'
 import { fixture as stringEndsWithPosition } from './methods/string-endsWith-position'
+import { fixture as stringReplace } from './methods/string-replace'
 // #1448 catalog parity: array methods rendered positively by
 // Hono / CSR (runtime JS) and at least one SSR adapter — pinning
 // the canonical surface so a regression surfaces here instead of
@@ -315,6 +316,7 @@ export const jsxFixtures: JSXFixture[] = [
   stringStartsWithPosition,
   stringEndsWith,
   stringEndsWithPosition,
+  stringReplace,
   // #1448 catalog parity — already-lowered Array methods.
   arrayJoin,
   arrayFind,

--- a/packages/adapter-tests/fixtures/methods/string-replace.ts
+++ b/packages/adapter-tests/fixtures/methods/string-replace.ts
@@ -1,0 +1,26 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `String.prototype.replace(pattern, replacement)` lowering — string
+ * pattern form (#1448 Tier B).
+ *
+ * The value contains two `o`s; JS's string-pattern `.replace` swaps
+ * only the FIRST one (`hello world` → `hell0 world`), so a lowering
+ * that replaced all occurrences (the `.replaceAll` semantic) would
+ * fail the assertion. Renders at text position so the result is
+ * directly observable.
+ */
+export const fixture = createFixture({
+  id: 'string-replace',
+  description: '.replace(old, new) swaps the first occurrence',
+  source: `
+function StringReplace({ value }: { value: string }) {
+  return <div>[{value.replace('o', '0')}]</div>
+}
+export { StringReplace }
+`,
+  props: { value: 'hello world' },
+  expectedHtml: `
+    <div bf-s="test" bf="s1">[<!--bf:s0-->hell0 world<!--/-->]</div>
+  `,
+})

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -434,6 +434,46 @@ describe('expression-parser', () => {
       expect(result.kind).toBe('unsupported')
     })
 
+    test('lowers .replace(pattern, replacement, extra) — ignores 3rd+ arg (#1448 Tier B)', () => {
+      const result = parseExpression(`name().replace("o", "0", "extra")`)
+      expect(result.kind).toBe('array-method')
+      if (result.kind === 'array-method') {
+        expect(result.method).toBe('replace')
+      }
+    })
+
+    test('refuses .replace(pattern) with no replacement (#1448 Tier B)', () => {
+      // JS coerces the missing replacement to the string "undefined".
+      const result = parseExpression(`name().replace("o")`)
+      expect(result.kind).toBe('unsupported')
+    })
+
+    test('refuses .replace() with no arguments (#1448 Tier B)', () => {
+      // The zero-arg form is degenerate too (both pattern and
+      // replacement coerce to "undefined") — pin it alongside the
+      // one-arg case so neither regresses.
+      const result = parseExpression(`name().replace()`)
+      expect(result.kind).toBe('unsupported')
+    })
+
+    test('.replace with a non-regex unsupported arg surfaces its own reason (#1448 Tier B)', () => {
+      // An object-literal replacement must NOT be mislabelled as the
+      // deferred regex form — the guard only special-cases a
+      // regex-literal pattern.
+      const result = parseExpression(`name().replace("a", {x: 1})`)
+      expect(result.kind).toBe('unsupported')
+      if (result.kind === 'unsupported') {
+        expect(result.reason).not.toContain('regex form is deferred')
+      }
+    })
+
+    test('.replace(/re/, repl) refuses the regex form with the deferred reason (#1448 Tier B)', () => {
+      const result = parseExpression(`name().replace(/a/g, "b")`)
+      expect(result.kind).toBe('unsupported')
+      if (result.kind === 'unsupported') {
+        expect(result.reason).toContain('regex form is deferred')
+      }
+    })
     test('lowers .filter(({label = `untitled-${suffix}`}) => label) — template-literal default (#1531)', () => {
       const result = parseExpression('items().filter(({label = `untitled-${suffix}`}) => label)')
       expect(result.kind).toBe('higher-order')

--- a/packages/jsx/src/adapters/parsed-expr-emitter.ts
+++ b/packages/jsx/src/adapters/parsed-expr-emitter.ts
@@ -69,6 +69,7 @@ export type ArrayMethod =
   | 'split'
   | 'startsWith'
   | 'endsWith'
+  | 'replace'
 
 /**
  * Method names handled by the dedicated `sortMethod()` dispatcher

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -49,6 +49,7 @@ export type ParsedExpr =
         | 'split'
         | 'startsWith'
         | 'endsWith'
+        | 'replace'
       object: ParsedExpr
       args: ParsedExpr[]
     }
@@ -235,7 +236,12 @@ const UNSUPPORTED_METHODS = new Set([
   // `startsWith` / `endsWith` are no longer here — both lower via the
   // `array-method` IR + `bf_starts_with` / `bf_ends_with` (Go) and
   // `bf->starts_with` / `bf->ends_with` (Mojo). See #1448 Tier B.
-  'replace', 'replaceAll',
+  // `replace` is no longer here — the string-pattern form lowers via
+  // the `array-method` IR + `bf_replace` (Go) / `bf->replace` (Mojo);
+  // the regex-pattern form is refused at the parse arm below (it would
+  // need the per-adapter regex-flavour decision). `replaceAll` stays
+  // refused. See #1448 Tier B.
+  'replaceAll',
   'repeat', 'padStart', 'padEnd',
   'charAt', 'charCodeAt', 'codePointAt', 'normalize',
   'substring', 'substr', 'match', 'matchAll', 'search',
@@ -503,6 +509,55 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
           }
         }
         return { kind: 'array-method', method: callee.property, object: callee.object, args }
+      }
+      // `.replace(pattern, replacement)` — string-pattern form,
+      // replacing the FIRST occurrence (JS semantics for a string
+      // pattern). Go uses `bf_replace` (`strings.Replace` with n=1);
+      // Mojo uses `bf->replace` (index/substr splice, no regex). A
+      // regex-literal pattern parses as `unsupported` (convertNode has
+      // no regex arm), so it's refused explicitly here rather than
+      // emitting a broken `.Replace` — the Perl `s///` vs Go
+      // `regexp.ReplaceAllString` flavour gap is the open design
+      // question in #1448. `replaceAll` stays refused entirely.
+      //
+      // Full JS arity: a third+ argument is ignored (the adapter reads
+      // only the pattern + replacement). The one- and zero-argument
+      // forms are refused: JS coerces the missing replacement (and
+      // pattern) to the literal string "undefined", a degenerate result
+      // (mirrors the `.includes()` / `.startsWith()` zero-arg refusal).
+      if (callee.property === 'replace') {
+        if (args.length < 2) {
+          return {
+            kind: 'unsupported',
+            raw,
+            reason: `\`.replace(${args.length === 0 ? '' : 'pattern'})\` needs both a pattern and a replacement — JS coerces the missing argument to the string "undefined", a degenerate result. Pass both arguments, or pre-compute the value before the template.`,
+          }
+        }
+        // A regex-literal pattern is the deferred form (the Perl `s///`
+        // vs Go `regexp.ReplaceAllString` flavour gap, #1448) — detect it
+        // on the TS node so the message is accurate. Any OTHER unsupported
+        // pattern/replacement (an object literal, an unsupported call, …)
+        // surfaces ITS OWN reason rather than being mislabelled as the
+        // regex form.
+        const patternNode = node.arguments[0]
+        if (patternNode && ts.isRegularExpressionLiteral(patternNode)) {
+          return {
+            kind: 'unsupported',
+            raw,
+            reason:
+              'String.prototype.replace supports only a string pattern + string replacement (the regex form is deferred); use a string pattern or wrap the expression in /* @client */',
+          }
+        }
+        const badArg =
+          args[0].kind === 'unsupported'
+            ? args[0]
+            : args[1].kind === 'unsupported'
+              ? args[1]
+              : undefined
+        if (badArg && badArg.kind === 'unsupported') {
+          return { kind: 'unsupported', raw, reason: badArg.reason }
+        }
+        return { kind: 'array-method', method: 'replace', object: callee.object, args }
       }
       // `.sort(cmp)` / `.toSorted(cmp)` (#1448 Tier B). The comparator
       // is extracted into a structured `SortComparator` at parse time;


### PR DESCRIPTION
## String Tier B (#1448) — `.replace` (string-pattern, full-arity)

`value.replace('o', '0')` now compiles to both template-language adapters, replacing the **first** occurrence (JS string-pattern semantics — not `.replaceAll`).

> Stacked on #1718 (`.startsWith`/`.endsWith`). Rebased and unified to **full JS arity**, matching the philosophy in #1722.

### Changes
- **Parser**: new `array-method` variant `replace`, dropped from `UNSUPPORTED_METHODS`.
- **Full arity**: a third+ argument is ignored (the adapter reads only pattern + replacement). The one- and zero-argument forms are refused — JS coerces the missing replacement/pattern to the literal string `"undefined"`, a degenerate result (mirrors the `.includes()` / `.startsWith()` zero-arg refusal).
- **Regex-pattern** `.replace(/…/, …)` stays refused with BF101 (the Perl `s///` vs Go `regexp.ReplaceAllString` flavour gap is the open design question); `.replaceAll` stays refused entirely.
- **Go** (`bf.go`): `bf_replace` (`strings.Replace` with n=1).
- **Mojo** (`BarefootJS.pm`): `bf->replace` splices via `index`/`substr` (not `s///`) so pattern + replacement are literal — byte-equal with Go.

### Known divergence
The replacement string is treated **literally** on both template adapters — special replacement patterns (`$&`, `$1`, …) are not interpreted. Go and Perl agree (byte-equal SSR); this differs from the Hono/CSR JS path only for replacement strings containing `$`-patterns, rare in template position.

### Verification
- `bf_replace` Go unit test + Perl `.t` under real Mojolicious
- Compiler-unit pins: full-arity lowering (ignore-extra) + 1-arg refusal + regex-pattern BF101
- Cross-adapter SSR/CSR conformance render of `string-replace` (Hono / Go / Mojo byte-equal)

### Remaining stack
- `.repeat` (#1720) · `.padStart` / `.padEnd` (#1721) — being rebased + unified to full-arity.

https://claude.ai/code/session_01WDSuf4wHqvVUkFM23vGZqx

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDSuf4wHqvVUkFM23vGZqx)_