### PR TITLE
feat(#1448 Tier B): lower String.prototype.repeat(n)

### DIFF
--- a/.changeset/string-repeat-tier-b.md
+++ b/.changeset/string-repeat-tier-b.md
@@ -1,0 +1,15 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+"@barefootjs/mojolicious": patch
+---
+
+Lower `String.prototype.repeat(n)` to the template-language adapters (#1448 Tier B).
+
+`value.repeat(3)` now compiles to both template adapters (the receiver concatenated `n` times).
+
+- Parser: new `array-method` variant `repeat`, dropped from `UNSUPPORTED_METHODS`. Full JS arity: the no-argument form is `repeat(0)` → `""` (JS coerces the missing count to 0, not a `RangeError`), and a second+ argument is ignored.
+- Go: new `bf_repeat` runtime helper (`strings.Repeat`).
+- Mojo: new `bf->repeat` helper (Perl's `x` operator).
+
+JS throws `RangeError` for a negative count; both adapters instead clamp a count `<= 0` to the empty string so SSR templates degrade rather than crash the render, and truncate a fractional count toward zero (matching JS's `ToIntegerOrInfinity`). Go and Perl stay byte-equal.

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -39,6 +39,7 @@ func FuncMap() template.FuncMap {
 		"bf_starts_with": StartsWith,
 		"bf_ends_with":   EndsWith,
 		"bf_replace":     Replace,
+		"bf_repeat":      Repeat,
 		"bf_string":      String,
 
 		// JSON / numeric primitives — JS-compat callees registered on
@@ -554,6 +555,18 @@ func EndsWith(s, suffix string, endPosition ...int) bool {
 // contain `$`-patterns, which are rare in template position).
 func Replace(s, old, new string) string {
 	return strings.Replace(s, old, new, 1)
+}
+
+// Repeat lowers `String.prototype.repeat(n)` (#1448 Tier B): the
+// receiver concatenated n times. JS throws RangeError for a negative
+// count and `strings.Repeat` panics, so a negative count clamps to the
+// empty string — SSR templates degrade rather than crash the render.
+// A zero count is the empty string (JS parity).
+func Repeat(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	return strings.Repeat(s, n)
 }
 
 // Join concatenates elements of a slice with sep. Accepts both

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -270,6 +270,22 @@ func TestReplace(t *testing.T) {
 	}
 }
 
+func TestRepeat(t *testing.T) {
+	if got := Repeat("ab", 3); got != "ababab" {
+		t.Errorf(`Repeat("ab", 3) = %q, want "ababab"`, got)
+	}
+	if got := Repeat("x", 1); got != "x" {
+		t.Errorf(`Repeat("x", 1) = %q, want "x"`, got)
+	}
+	// Zero and negative counts → "" (negative would panic strings.Repeat).
+	if got := Repeat("ab", 0); got != "" {
+		t.Errorf(`Repeat("ab", 0) = %q, want ""`, got)
+	}
+	if got := Repeat("ab", -2); got != "" {
+		t.Errorf(`Repeat("ab", -2) = %q, want "" (clamped, no panic)`, got)
+	}
+}
+
 func TestLen(t *testing.T) {
 	tests := []struct {
 		v    any

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -2199,6 +2199,7 @@ import { fixture as stringStartsWithPositionFixture } from '../../../adapter-tes
 import { fixture as stringEndsWithFixture } from '../../../adapter-tests/fixtures/methods/string-endsWith'
 import { fixture as stringEndsWithPositionFixture } from '../../../adapter-tests/fixtures/methods/string-endsWith-position'
 import { fixture as stringReplaceFixture } from '../../../adapter-tests/fixtures/methods/string-replace'
+import { fixture as stringRepeatFixture } from '../../../adapter-tests/fixtures/methods/string-repeat'
 // #1448 Tier B — .sort / .toSorted fixtures.
 import { fixture as arraySortFieldAscFixture } from '../../../adapter-tests/fixtures/methods/array-sort-field-asc'
 import { fixture as arraySortFieldDescFixture } from '../../../adapter-tests/fixtures/methods/array-sort-field-desc'
@@ -2253,6 +2254,8 @@ describe('GoTemplateAdapter - #1448 Tier A/B fixture-driven lowering pins', () =
     { fixture: stringEndsWithPositionFixture,   expect: '{{if bf_ends_with .Value "hello" 5}}' },
     // #1448 Tier B — string → string, first-occurrence replace.
     { fixture: stringReplaceFixture,    expect: 'bf_replace .Value "o" "0"' },
+    // #1448 Tier B — string → string, repeat n times.
+    { fixture: stringRepeatFixture,     expect: 'bf_repeat .Value 3' },
     // #1448 Tier B — sort / toSorted. Loop-chained shapes wrap the
     // iterable in `bf_sort .Items <kind> <key> <type> <dir>`;
     // standalone shapes inline the helper at the call site.
@@ -2370,11 +2373,10 @@ export function C() {
     { name: 'concat (variadic)', expr: `items().concat(items(), items())`, badEmit: '.Concat' },
     // Tier B/C string methods — previously slipped through with no
     // diagnostic; now gated by `UNSUPPORTED_METHODS`. `split`,
-    // `startsWith`, `endsWith` and the string-pattern form of `replace`
-    // have since landed their full-arity lowerings (#1448 Tier B) and
-    // moved to the positive fixture-pin block above. The regex-pattern
-    // `replace` form is pinned separately below.
-    { name: 'repeat', expr: `name().repeat(3)`, badEmit: '.Name.Repeat' },
+    // `startsWith`, `endsWith`, `repeat` and the string-pattern form of
+    // `replace` have since landed their full-arity lowerings (#1448
+    // Tier B) and moved to the positive fixture-pin block above. The
+    // regex-pattern `replace` form is pinned separately below.
     { name: 'padStart', expr: `name().padStart(5, "0")`, badEmit: '.Name.PadStart' },
     { name: 'padEnd', expr: `name().padEnd(5, "0")`, badEmit: '.Name.PadEnd' },
     { name: 'charAt', expr: `name().charAt(0)`, badEmit: '.Name.CharAt' },
@@ -2464,7 +2466,9 @@ export function C() {
   // more `can't evaluate field …` crash), so we assert the build error
   // rather than a render crash. Skipped on hosts without Go.
   test('e2e: @client renders placeholder; bare is caught at build with BF101', async () => {
-    const bare = emit(`name().repeat(3)`, false)
+    // Uses the Tier C `charAt` (still refused) — earlier this test used
+    // `repeat`, which has since landed its #1448 Tier B lowering.
+    const bare = emit(`name().charAt(0)`, false)
     expect(bare.errors.some(e => e.code === 'BF101')).toBe(true)
 
     try {
@@ -2474,7 +2478,7 @@ export function C() {
 import { createSignal } from "@barefootjs/client"
 export function C() {
   const [name, setName] = createSignal("hello")
-  return <div>{/* @client */ name().repeat(3)}</div>
+  return <div>{/* @client */ name().charAt(0)}</div>
 }
 `.trimStart(),
         adapter: new GoTemplateAdapter(),

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -3255,6 +3255,16 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         const newS = emit(args[1])
         return `bf_replace ${wrapIfMultiToken(recv)} ${wrapIfMultiToken(oldS)} ${wrapIfMultiToken(newS)}`
       }
+      case 'repeat': {
+        // `.repeat(n)` — string repeated `n` times via the `bf_repeat`
+        // helper. The helper clamps a negative count to "" instead of
+        // letting `strings.Repeat` panic. Full JS arity: the no-argument
+        // form is `repeat(0)` → ""; a second+ argument is ignored.
+        // See #1448 Tier B.
+        const recv = emit(object)
+        const count = args.length === 0 ? '0' : emit(args[0])
+        return `bf_repeat ${wrapIfMultiToken(recv)} ${wrapIfMultiToken(count)}`
+      }
       default: {
         const _exhaustive: never = method
         throw new Error(`Go arrayMethod: unhandled ArrayMethod '${(_exhaustive as string)}'`)

--- a/packages/adapter-mojolicious/lib/BarefootJS.pm
+++ b/packages/adapter-mojolicious/lib/BarefootJS.pm
@@ -647,6 +647,19 @@ sub replace ($self, $recv, $pattern, $replacement) {
     return substr($s, 0, $i) . $n . substr($s, $i + length($o));
 }
 
+# `String.prototype.repeat(n)` — the receiver concatenated n times
+# (#1448 Tier B), via Perl's `x` operator. JS throws RangeError for a
+# negative count, but SSR templates degrade to the empty string rather
+# than dying mid-render, so a count <= 0 returns "" (Go's `bf_repeat`
+# applies the same clamp). The count is truncated toward zero
+# (`int`), matching JS's ToIntegerOrInfinity on `"a".repeat(3.7)`.
+
+sub repeat ($self, $recv, $count) {
+    my $s = defined $recv && !ref($recv) ? "$recv" : '';
+    my $n = defined $count ? int($count) : 0;
+    return $n <= 0 ? '' : $s x $n;
+}
+
 # `Array.prototype.sort(cmp)` / `Array.prototype.toSorted(cmp)`
 # lowering (#1448 Tier B). Non-mutating — JS's mutate-vs-new
 # distinction is moot in SSR template context.

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -945,6 +945,7 @@ import { fixture as stringStartsWithPositionFixture } from '../../../adapter-tes
 import { fixture as stringEndsWithFixture } from '../../../adapter-tests/fixtures/methods/string-endsWith'
 import { fixture as stringEndsWithPositionFixture } from '../../../adapter-tests/fixtures/methods/string-endsWith-position'
 import { fixture as stringReplaceFixture } from '../../../adapter-tests/fixtures/methods/string-replace'
+import { fixture as stringRepeatFixture } from '../../../adapter-tests/fixtures/methods/string-repeat'
 // #1448 Tier B — .sort / .toSorted fixtures (loop-chained + standalone).
 import { fixture as arraySortFieldAscFixture } from '../../../adapter-tests/fixtures/methods/array-sort-field-asc'
 import { fixture as arraySortFieldDescFixture } from '../../../adapter-tests/fixtures/methods/array-sort-field-desc'
@@ -992,6 +993,8 @@ describe('MojoAdapter - #1448 Tier A/B fixture-driven lowering pins', () => {
     { fixture: stringEndsWithPositionFixture,   expect: `bf->ends_with($value, 'hello', 5)` },
     // #1448 Tier B — string → string, first-occurrence replace.
     { fixture: stringReplaceFixture,    expect: `bf->replace($value, 'o', '0')` },
+    // #1448 Tier B — string → string, repeat n times.
+    { fixture: stringRepeatFixture,     expect: 'bf->repeat($value, 3)' },
     // #1448 Tier B — sort / toSorted. The loop-chained field cases
     // hoist into a `my $bf_iter_lN = bf->sort(...)` local; the
     // standalone primitive cases inline the call. Each comparison key
@@ -1105,12 +1108,11 @@ export function C() {
     { name: 'concat (variadic)', expr: `items().concat(items(), items())`, badEmit: '->{concat}' },
     // Tier B/C string methods — previously slipped through with no
     // diagnostic; now routed through the AST / `isSupported` gate.
-    // `split`, `startsWith`, `endsWith` and the string-pattern form of
-    // `replace` have since landed their full-arity lowerings (#1448
-    // Tier B) and moved to the positive fixture-pin block above (the
-    // regex-pattern `replace` form stays refused — pinned separately
-    // below).
-    { name: 'repeat', expr: `name().repeat(3)`, badEmit: '->{repeat}' },
+    // `split`, `startsWith`, `endsWith`, `repeat` and the string-pattern
+    // form of `replace` have since landed their full-arity lowerings
+    // (#1448 Tier B) and moved to the positive fixture-pin block above
+    // (the regex-pattern `replace` form stays refused — pinned
+    // separately below).
     { name: 'padStart', expr: `name().padStart(5, "0")`, badEmit: '->{padStart}' },
     { name: 'padEnd', expr: `name().padEnd(5, "0")`, badEmit: '->{padEnd}' },
     { name: 'charAt', expr: `name().charAt(0)`, badEmit: '->{charAt}' },
@@ -1230,7 +1232,9 @@ export function C() {
   // more `HASH ref` crash), so we assert the build error rather than a
   // render crash. Skipped on hosts without Mojolicious installed.
   test('e2e: @client renders placeholder; bare is caught at build with BF101', async () => {
-    const bare = emit(`name().repeat(3)`, false)
+    // Uses the Tier C `charAt` (still refused) — earlier this test used
+    // `repeat`, which has since landed its #1448 Tier B lowering.
+    const bare = emit(`name().charAt(0)`, false)
     expect(bare.errors.some(e => e.code === 'BF101')).toBe(true)
 
     try {
@@ -1240,7 +1244,7 @@ export function C() {
 import { createSignal } from "@barefootjs/client"
 export function C() {
   const [name, setName] = createSignal("hello")
-  return <div>{/* @client */ name().repeat(3)}</div>
+  return <div>{/* @client */ name().charAt(0)}</div>
 }
 `.trimStart(),
         adapter: new MojoAdapter(),

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1445,6 +1445,17 @@ function renderArrayMethod(
       const newS = emit(args[1])
       return `bf->replace(${recv}, ${oldS}, ${newS})`
     }
+    case 'repeat': {
+      // `.repeat(n)` — string repeated `n` times. The `bf->repeat`
+      // helper wraps Perl's `x` operator with the same negative-count
+      // → "" clamp and integer truncation Go's `bf_repeat` applies, so
+      // the two adapters stay byte-equal. Full JS arity: the no-argument
+      // form is `repeat(0)` → ""; a second+ argument is ignored.
+      // See #1448 Tier B.
+      const recv = emit(object)
+      const count = args.length === 0 ? '0' : emit(args[0])
+      return `bf->repeat(${recv}, ${count})`
+    }
     default: {
       // TS-level exhaustiveness guard. If this throws at runtime, the
       // IR was constructed against a newer `ArrayMethod` variant that

--- a/packages/adapter-mojolicious/t/template_primitives.t
+++ b/packages/adapter-mojolicious/t/template_primitives.t
@@ -341,6 +341,19 @@ subtest 'replace — first-occurrence string-pattern swap' => sub {
     is $bf->replace(undef, 'a', 'b'),          '',            'undef receiver → empty';
 };
 
+# `String.prototype.repeat(n)` — receiver concatenated n times
+# (#1448 Tier B). Perl `x` operator; negative count clamps to "" (JS
+# throws but SSR degrades), count truncated toward zero.
+subtest 'repeat — string concatenated n times' => sub {
+    is $bf->repeat('ab', 3),  'ababab', 'three times';
+    is $bf->repeat('x',  1),  'x',      'once → unchanged';
+    is $bf->repeat('ab', 0),  '',       'zero → empty';
+    is $bf->repeat('ab', -2), '',       'negative → empty (JS throws; SSR degrades)';
+    is $bf->repeat('ab', 2.9),'abab',   'fractional count truncates toward zero';
+    is $bf->repeat('',   5),  '',       'empty receiver → empty';
+    is $bf->repeat(undef, 3), '',       'undef receiver → empty';
+};
+
 # `Array.prototype.sort(cmp)` / `Array.prototype.toSorted(cmp)`
 # lowering (#1448 Tier B). The opts hash-ref carries a `keys` list of
 # the structured comparison keys the compiler extracted at parse time

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -141,6 +141,7 @@ import { fixture as stringStartsWithPosition } from './methods/string-startsWith
 import { fixture as stringEndsWith } from './methods/string-endsWith'
 import { fixture as stringEndsWithPosition } from './methods/string-endsWith-position'
 import { fixture as stringReplace } from './methods/string-replace'
+import { fixture as stringRepeat } from './methods/string-repeat'
 // #1448 catalog parity: array methods rendered positively by
 // Hono / CSR (runtime JS) and at least one SSR adapter — pinning
 // the canonical surface so a regression surfaces here instead of
@@ -317,6 +318,7 @@ export const jsxFixtures: JSXFixture[] = [
   stringEndsWith,
   stringEndsWithPosition,
   stringReplace,
+  stringRepeat,
   // #1448 catalog parity — already-lowered Array methods.
   arrayJoin,
   arrayFind,

--- a/packages/adapter-tests/fixtures/methods/string-repeat.ts
+++ b/packages/adapter-tests/fixtures/methods/string-repeat.ts
@@ -1,0 +1,23 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `String.prototype.repeat(n)` lowering (#1448 Tier B).
+ *
+ * Renders at text position. A repeat count > 1 with a 2-char receiver
+ * makes an off-by-one (`n` vs `n-1`) or a no-op lowering visible in the
+ * output (`ab` × 3 = `ababab`).
+ */
+export const fixture = createFixture({
+  id: 'string-repeat',
+  description: '.repeat(n) concatenates the string n times',
+  source: `
+function StringRepeat({ value }: { value: string }) {
+  return <div>[{value.repeat(3)}]</div>
+}
+export { StringRepeat }
+`,
+  props: { value: 'ab' },
+  expectedHtml: `
+    <div bf-s="test" bf="s1">[<!--bf:s0-->ababab<!--/-->]</div>
+  `,
+})

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -474,6 +474,19 @@ describe('expression-parser', () => {
         expect(result.reason).toContain('regex form is deferred')
       }
     })
+
+    test('lowers .repeat() and .repeat(n, extra) — full arity (#1448 Tier B)', () => {
+      // `.repeat()` is `repeat(0)` → "" in JS (not a RangeError); a
+      // second+ argument is ignored. Both stay on the lowering path.
+      for (const expr of [`name().repeat()`, `name().repeat(3, 4)`]) {
+        const result = parseExpression(expr)
+        expect(result.kind).toBe('array-method')
+        if (result.kind === 'array-method') {
+          expect(result.method).toBe('repeat')
+        }
+      }
+    })
+
     test('lowers .filter(({label = `untitled-${suffix}`}) => label) — template-literal default (#1531)', () => {
       const result = parseExpression('items().filter(({label = `untitled-${suffix}`}) => label)')
       expect(result.kind).toBe('higher-order')

--- a/packages/jsx/src/adapters/parsed-expr-emitter.ts
+++ b/packages/jsx/src/adapters/parsed-expr-emitter.ts
@@ -70,6 +70,7 @@ export type ArrayMethod =
   | 'startsWith'
   | 'endsWith'
   | 'replace'
+  | 'repeat'
 
 /**
  * Method names handled by the dedicated `sortMethod()` dispatcher

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -50,6 +50,7 @@ export type ParsedExpr =
         | 'startsWith'
         | 'endsWith'
         | 'replace'
+        | 'repeat'
       object: ParsedExpr
       args: ParsedExpr[]
     }
@@ -241,8 +242,11 @@ const UNSUPPORTED_METHODS = new Set([
   // the regex-pattern form is refused at the parse arm below (it would
   // need the per-adapter regex-flavour decision). `replaceAll` stays
   // refused. See #1448 Tier B.
+  // `repeat` is no longer here — `String.prototype.repeat(n)` lowers via
+  // the `array-method` IR + `bf_repeat` (Go) / `bf->repeat` (Mojo).
+  // See #1448 Tier B.
   'replaceAll',
-  'repeat', 'padStart', 'padEnd',
+  'padStart', 'padEnd',
   'charAt', 'charCodeAt', 'codePointAt', 'normalize',
   'substring', 'substr', 'match', 'matchAll', 'search',
 ])
@@ -558,6 +562,19 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
           return { kind: 'unsupported', raw, reason: badArg.reason }
         }
         return { kind: 'array-method', method: 'replace', object: callee.object, args }
+      }
+      // `.repeat(n)` — string → string (the receiver concatenated `n`
+      // times). Go uses `bf_repeat` (`strings.Repeat`, clamping a
+      // negative count to "" instead of panicking); Mojo uses
+      // `bf->repeat` (Perl's `x` operator). JS throws RangeError for a
+      // negative count, but SSR templates degrade to the empty string
+      // rather than crashing the render. See #1448 Tier B.
+      // Full JS arity: `.repeat()` (no count) is `repeat(0)` → "" (JS
+      // coerces the missing count to 0, not a RangeError), and a
+      // second+ argument is ignored. The adapter supplies the `0` for
+      // the no-argument form. See #1448 Tier B.
+      if (callee.property === 'repeat') {
+        return { kind: 'array-method', method: 'repeat', object: callee.object, args }
       }
       // `.sort(cmp)` / `.toSorted(cmp)` (#1448 Tier B). The comparator
       // is extracted into a structured `SortComparator` at parse time;


### PR DESCRIPTION
## String Tier B (#1448) — `.repeat` (full-arity)

`value.repeat(3)` now compiles to both template-language adapters (the receiver concatenated `n` times).

> Stacked on #1719 (`.replace`). Rebased and unified to **full JS arity**, matching the philosophy in #1722.

### Changes
- **Parser**: new `array-method` variant `repeat`, dropped from `UNSUPPORTED_METHODS`.
- **Full arity**: the no-argument form is `repeat(0)` → `""` (JS coerces the missing count to 0, **not** a `RangeError`); a second+ argument is ignored. The adapter supplies the `0` for the no-argument form.
- **Go** (`bf.go`): `bf_repeat` (`strings.Repeat`).
- **Mojo** (`BarefootJS.pm`): `bf->repeat` (Perl's `x` operator).

### Negative / fractional counts
JS throws `RangeError` for a negative count; both adapters instead clamp a count `<= 0` to the empty string so SSR degrades rather than crashes, and truncate a fractional count toward zero (matching JS `ToIntegerOrInfinity`). Go and Perl stay byte-equal.

### Verification
- `bf_repeat` Go unit test + Perl `.t` under real Mojolicious
- Compiler-unit pins: full-arity lowering (`repeat()` + ignore-extra)
- Cross-adapter SSR/CSR conformance render of `string-repeat` (Hono / Go / Mojo byte-equal)

### Remaining stack
- `.padStart` / `.padEnd` (#1721) — being rebased + unified to full-arity (final PR in the series).

https://claude.ai/code/session_01WDSuf4wHqvVUkFM23vGZqx

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDSuf4wHqvVUkFM23vGZqx)_