### PR TITLE
feat(#1448 Tier B): lower String.prototype.padStart / padEnd

### DIFF
--- a/.changeset/string-padstart-padend-tier-b.md
+++ b/.changeset/string-padstart-padend-tier-b.md
@@ -1,0 +1,15 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+"@barefootjs/mojolicious": patch
+---
+
+Lower `String.prototype.padStart(target, pad?)` / `padEnd(target, pad?)` to the template-language adapters (#1448 Tier B).
+
+`value.padStart(5, '0')` / `value.padEnd(5, '.')` now compile to both template adapters, padding to the target width with the pad string (default a single space) repeated and truncated to fill. This completes the String Tier B set from #1448.
+
+- Parser: two new `array-method` variants `padStart` / `padEnd`, dropped from `UNSUPPORTED_METHODS`. Full JS arity: the no-argument form is `padStart(0)` → the receiver unchanged (JS coerces the missing target to 0), and a third+ argument is ignored. The adapter reads only target + padString.
+- Go: new `bf_pad_start` / `bf_pad_end` runtime helpers (shared `padTo`, rune-counted).
+- Mojo: new `bf->pad_start` / `bf->pad_end` helpers (shared `_pad`, character-counted).
+
+Length is measured in code points (Go runes / Perl chars) so the two adapters stay byte-equal; this differs from JS's UTF-16-unit `.length` only for astral-plane receivers, which are vanishingly rare in numeric / space padding. The target is truncated toward zero, and a receiver already at least `target` long (or an empty pad) is returned unchanged — all matching JS.

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 )
 
 // FuncMap returns a template.FuncMap with all BarefootJS helper functions.
@@ -40,6 +41,8 @@ func FuncMap() template.FuncMap {
 		"bf_ends_with":   EndsWith,
 		"bf_replace":     Replace,
 		"bf_repeat":      Repeat,
+		"bf_pad_start":   PadStart,
+		"bf_pad_end":     PadEnd,
 		"bf_string":      String,
 
 		// JSON / numeric primitives — JS-compat callees registered on
@@ -567,6 +570,57 @@ func Repeat(s string, n int) string {
 		return ""
 	}
 	return strings.Repeat(s, n)
+}
+
+// padTo lowers the shared body of `String.prototype.padStart` /
+// `padEnd` (#1448 Tier B): pad `s` to `target` code points using `pad`
+// repeated and truncated to fill, prepended (atStart) or appended.
+// Length is measured in runes (not bytes) so the result matches the
+// Perl `bf->pad_*` helpers — this diverges from JS's UTF-16-unit length
+// only for astral-plane input. An empty pad, or a receiver already at
+// least `target` long, returns `s` unchanged (JS parity).
+func padTo(s string, target int, pad string, atStart bool) string {
+	if pad == "" {
+		return s
+	}
+	sLen := utf8.RuneCountInString(s)
+	if sLen >= target {
+		return s
+	}
+	need := target - sLen
+	padRunes := []rune(pad)
+	fill := make([]rune, 0, need)
+	for len(fill) < need {
+		for _, r := range padRunes {
+			if len(fill) >= need {
+				break
+			}
+			fill = append(fill, r)
+		}
+	}
+	if atStart {
+		return string(fill) + s
+	}
+	return s + string(fill)
+}
+
+// PadStart lowers `String.prototype.padStart(target, pad?)` (#1448 Tier
+// B). The pad string defaults to a single space when omitted.
+func PadStart(s string, target int, pad ...string) string {
+	p := " "
+	if len(pad) > 0 {
+		p = pad[0]
+	}
+	return padTo(s, target, p, true)
+}
+
+// PadEnd lowers `String.prototype.padEnd(target, pad?)` (#1448 Tier B).
+func PadEnd(s string, target int, pad ...string) string {
+	p := " "
+	if len(pad) > 0 {
+		p = pad[0]
+	}
+	return padTo(s, target, p, false)
 }
 
 // Join concatenates elements of a slice with sep. Accepts both

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -286,6 +286,39 @@ func TestRepeat(t *testing.T) {
 	}
 }
 
+func TestPadStart(t *testing.T) {
+	if got := PadStart("42", 5, "0"); got != "00042" {
+		t.Errorf(`PadStart("42", 5, "0") = %q, want "00042"`, got)
+	}
+	// Default pad is a single space when omitted.
+	if got := PadStart("42", 5); got != "   42" {
+		t.Errorf(`PadStart("42", 5) = %q, want "   42"`, got)
+	}
+	// Multi-char pad is repeated then truncated to fill.
+	if got := PadStart("x", 5, "ab"); got != "ababx" {
+		t.Errorf(`PadStart("x", 5, "ab") = %q, want "ababx"`, got)
+	}
+	// Already >= target → unchanged. Empty pad → unchanged.
+	if got := PadStart("hello", 3, "0"); got != "hello" {
+		t.Errorf(`PadStart("hello", 3, "0") = %q, want "hello"`, got)
+	}
+	if got := PadStart("42", 5, ""); got != "42" {
+		t.Errorf(`PadStart("42", 5, "") = %q, want "42"`, got)
+	}
+}
+
+func TestPadEnd(t *testing.T) {
+	if got := PadEnd("42", 5, "."); got != "42..." {
+		t.Errorf(`PadEnd("42", 5, ".") = %q, want "42..."`, got)
+	}
+	if got := PadEnd("42", 5); got != "42   " {
+		t.Errorf(`PadEnd("42", 5) = %q, want "42   "`, got)
+	}
+	if got := PadEnd("x", 5, "ab"); got != "xabab" {
+		t.Errorf(`PadEnd("x", 5, "ab") = %q, want "xabab"`, got)
+	}
+}
+
 func TestLen(t *testing.T) {
 	tests := []struct {
 		v    any

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -2200,6 +2200,8 @@ import { fixture as stringEndsWithFixture } from '../../../adapter-tests/fixture
 import { fixture as stringEndsWithPositionFixture } from '../../../adapter-tests/fixtures/methods/string-endsWith-position'
 import { fixture as stringReplaceFixture } from '../../../adapter-tests/fixtures/methods/string-replace'
 import { fixture as stringRepeatFixture } from '../../../adapter-tests/fixtures/methods/string-repeat'
+import { fixture as stringPadStartFixture } from '../../../adapter-tests/fixtures/methods/string-padStart'
+import { fixture as stringPadEndFixture } from '../../../adapter-tests/fixtures/methods/string-padEnd'
 // #1448 Tier B — .sort / .toSorted fixtures.
 import { fixture as arraySortFieldAscFixture } from '../../../adapter-tests/fixtures/methods/array-sort-field-asc'
 import { fixture as arraySortFieldDescFixture } from '../../../adapter-tests/fixtures/methods/array-sort-field-desc'
@@ -2256,6 +2258,9 @@ describe('GoTemplateAdapter - #1448 Tier A/B fixture-driven lowering pins', () =
     { fixture: stringReplaceFixture,    expect: 'bf_replace .Value "o" "0"' },
     // #1448 Tier B — string → string, repeat n times.
     { fixture: stringRepeatFixture,     expect: 'bf_repeat .Value 3' },
+    // #1448 Tier B — string → string, padded to a target width.
+    { fixture: stringPadStartFixture,   expect: 'bf_pad_start .Value 5 "0"' },
+    { fixture: stringPadEndFixture,     expect: 'bf_pad_end .Value 5 "."' },
     // #1448 Tier B — sort / toSorted. Loop-chained shapes wrap the
     // iterable in `bf_sort .Items <kind> <key> <type> <dir>`;
     // standalone shapes inline the helper at the call site.
@@ -2372,13 +2377,12 @@ export function C() {
     { name: 'includes (2-arg fromIndex)', expr: `items().includes("a", 1)`, badEmit: '.Includes' },
     { name: 'concat (variadic)', expr: `items().concat(items(), items())`, badEmit: '.Concat' },
     // Tier B/C string methods — previously slipped through with no
-    // diagnostic; now gated by `UNSUPPORTED_METHODS`. `split`,
-    // `startsWith`, `endsWith`, `repeat` and the string-pattern form of
-    // `replace` have since landed their full-arity lowerings (#1448
-    // Tier B) and moved to the positive fixture-pin block above. The
-    // regex-pattern `replace` form is pinned separately below.
-    { name: 'padStart', expr: `name().padStart(5, "0")`, badEmit: '.Name.PadStart' },
-    { name: 'padEnd', expr: `name().padEnd(5, "0")`, badEmit: '.Name.PadEnd' },
+    // diagnostic; now gated by `UNSUPPORTED_METHODS`. The full Tier B
+    // string set (`split`, `startsWith`, `endsWith`, `replace`,
+    // `repeat`, `padStart`, `padEnd`) has since landed its full-arity
+    // lowering and moved to the positive fixture-pin block above. The
+    // regex-pattern `replace` form is pinned separately below; `charAt`
+    // is Tier C and stays refused entirely.
     { name: 'charAt', expr: `name().charAt(0)`, badEmit: '.Name.CharAt' },
   ]
   for (const { name, expr, badEmit } of unsupported) {

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -3265,6 +3265,25 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         const count = args.length === 0 ? '0' : emit(args[0])
         return `bf_repeat ${wrapIfMultiToken(recv)} ${wrapIfMultiToken(count)}`
       }
+      case 'padStart':
+      case 'padEnd': {
+        // `.padStart(target, pad?)` / `.padEnd(target, pad?)` — pad to
+        // `target` runes with `pad` (default a single space, supplied
+        // by the variadic helper when the arg is absent). Full JS arity:
+        // the no-argument form is `padStart(0)` → the receiver
+        // unchanged; a third+ argument is ignored. See #1448 Tier B.
+        const fn = method === 'padStart' ? 'bf_pad_start' : 'bf_pad_end'
+        const recv = emit(object)
+        if (args.length === 0) {
+          return `${fn} ${wrapIfMultiToken(recv)} 0`
+        }
+        const target = emit(args[0])
+        if (args.length === 1) {
+          return `${fn} ${wrapIfMultiToken(recv)} ${wrapIfMultiToken(target)}`
+        }
+        const pad = emit(args[1])
+        return `${fn} ${wrapIfMultiToken(recv)} ${wrapIfMultiToken(target)} ${wrapIfMultiToken(pad)}`
+      }
       default: {
         const _exhaustive: never = method
         throw new Error(`Go arrayMethod: unhandled ArrayMethod '${(_exhaustive as string)}'`)

--- a/packages/adapter-mojolicious/lib/BarefootJS.pm
+++ b/packages/adapter-mojolicious/lib/BarefootJS.pm
@@ -660,6 +660,38 @@ sub repeat ($self, $recv, $count) {
     return $n <= 0 ? '' : $s x $n;
 }
 
+# `String.prototype.padStart` / `padEnd` (#1448 Tier B) — pad the
+# receiver to `$target` characters with `$pad` (default a single space)
+# repeated and truncated to fill, prepended or appended. Length is
+# measured in characters (Perl `length`), matching Go's rune-based
+# `bf_pad_*` — diverges from JS's UTF-16-unit length only for
+# astral-plane input. An empty pad, or a receiver already >= `$target`,
+# returns the receiver unchanged (JS parity). The `$target` is
+# truncated toward zero (JS ToLength on the first arg).
+
+sub _pad ($s, $target, $pad, $at_start) {
+    $pad = ' ' unless defined $pad;
+    $pad = "$pad";
+    return $s if $pad eq '';
+    my $len = length $s;
+    my $t   = int($target // 0);
+    return $s if $len >= $t;
+    my $need = $t - $len;
+    # Repeat enough copies to cover $need, then trim to exactly $need.
+    my $fill = substr($pad x (int($need / length($pad)) + 1), 0, $need);
+    return $at_start ? $fill . $s : $s . $fill;
+}
+
+sub pad_start ($self, $recv, $target, $pad = undef) {
+    my $s = defined $recv && !ref($recv) ? "$recv" : '';
+    return _pad($s, $target, $pad, 1);
+}
+
+sub pad_end ($self, $recv, $target, $pad = undef) {
+    my $s = defined $recv && !ref($recv) ? "$recv" : '';
+    return _pad($s, $target, $pad, 0);
+}
+
 # `Array.prototype.sort(cmp)` / `Array.prototype.toSorted(cmp)`
 # lowering (#1448 Tier B). Non-mutating — JS's mutate-vs-new
 # distinction is moot in SSR template context.

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -946,6 +946,8 @@ import { fixture as stringEndsWithFixture } from '../../../adapter-tests/fixture
 import { fixture as stringEndsWithPositionFixture } from '../../../adapter-tests/fixtures/methods/string-endsWith-position'
 import { fixture as stringReplaceFixture } from '../../../adapter-tests/fixtures/methods/string-replace'
 import { fixture as stringRepeatFixture } from '../../../adapter-tests/fixtures/methods/string-repeat'
+import { fixture as stringPadStartFixture } from '../../../adapter-tests/fixtures/methods/string-padStart'
+import { fixture as stringPadEndFixture } from '../../../adapter-tests/fixtures/methods/string-padEnd'
 // #1448 Tier B — .sort / .toSorted fixtures (loop-chained + standalone).
 import { fixture as arraySortFieldAscFixture } from '../../../adapter-tests/fixtures/methods/array-sort-field-asc'
 import { fixture as arraySortFieldDescFixture } from '../../../adapter-tests/fixtures/methods/array-sort-field-desc'
@@ -995,6 +997,9 @@ describe('MojoAdapter - #1448 Tier A/B fixture-driven lowering pins', () => {
     { fixture: stringReplaceFixture,    expect: `bf->replace($value, 'o', '0')` },
     // #1448 Tier B — string → string, repeat n times.
     { fixture: stringRepeatFixture,     expect: 'bf->repeat($value, 3)' },
+    // #1448 Tier B — string → string, padded to a target width.
+    { fixture: stringPadStartFixture,   expect: `bf->pad_start($value, 5, '0')` },
+    { fixture: stringPadEndFixture,     expect: `bf->pad_end($value, 5, '.')` },
     // #1448 Tier B — sort / toSorted. The loop-chained field cases
     // hoist into a `my $bf_iter_lN = bf->sort(...)` local; the
     // standalone primitive cases inline the call. Each comparison key
@@ -1107,14 +1112,12 @@ export function C() {
     { name: 'includes (2-arg fromIndex)', expr: `items().includes("a", 1)`, badEmit: '->{includes}' },
     { name: 'concat (variadic)', expr: `items().concat(items(), items())`, badEmit: '->{concat}' },
     // Tier B/C string methods — previously slipped through with no
-    // diagnostic; now routed through the AST / `isSupported` gate.
-    // `split`, `startsWith`, `endsWith`, `repeat` and the string-pattern
-    // form of `replace` have since landed their full-arity lowerings
-    // (#1448 Tier B) and moved to the positive fixture-pin block above
-    // (the regex-pattern `replace` form stays refused — pinned
-    // separately below).
-    { name: 'padStart', expr: `name().padStart(5, "0")`, badEmit: '->{padStart}' },
-    { name: 'padEnd', expr: `name().padEnd(5, "0")`, badEmit: '->{padEnd}' },
+    // diagnostic; now routed through the AST / `isSupported` gate. The
+    // full Tier B string set (`split`, `startsWith`, `endsWith`,
+    // `replace`, `repeat`, `padStart`, `padEnd`) has since landed its
+    // full-arity lowering and moved to the positive fixture-pin block
+    // above (the regex-pattern `replace` form stays refused — pinned
+    // separately below). `charAt` is Tier C and stays refused entirely.
     { name: 'charAt', expr: `name().charAt(0)`, badEmit: '->{charAt}' },
   ]
   for (const { name, expr, badEmit } of unsupported) {

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1456,6 +1456,26 @@ function renderArrayMethod(
       const count = args.length === 0 ? '0' : emit(args[0])
       return `bf->repeat(${recv}, ${count})`
     }
+    case 'padStart':
+    case 'padEnd': {
+      // `.padStart(target, pad?)` / `.padEnd(target, pad?)`. The
+      // `bf->pad_*` helpers default the pad to a single space when the
+      // arg is omitted and measure length in characters, matching Go's
+      // rune-based `bf_pad_*`. Full JS arity: the no-argument form is
+      // `padStart(0)` → the receiver unchanged; a third+ argument is
+      // ignored. See #1448 Tier B.
+      const fn = method === 'padStart' ? 'pad_start' : 'pad_end'
+      const recv = emit(object)
+      if (args.length === 0) {
+        return `bf->${fn}(${recv}, 0)`
+      }
+      const target = emit(args[0])
+      if (args.length === 1) {
+        return `bf->${fn}(${recv}, ${target})`
+      }
+      const pad = emit(args[1])
+      return `bf->${fn}(${recv}, ${target}, ${pad})`
+    }
     default: {
       // TS-level exhaustiveness guard. If this throws at runtime, the
       // IR was constructed against a newer `ArrayMethod` variant that

--- a/packages/adapter-mojolicious/t/template_primitives.t
+++ b/packages/adapter-mojolicious/t/template_primitives.t
@@ -354,6 +354,30 @@ subtest 'repeat — string concatenated n times' => sub {
     is $bf->repeat(undef, 3), '',       'undef receiver → empty';
 };
 
+# `String.prototype.padStart` / `padEnd` (#1448 Tier B) — pad to a
+# target width with a repeat-and-truncate fill (default pad = space).
+# Mirrors Go's rune-based `bf_pad_*`.
+subtest 'pad_start / pad_end — pad to target width' => sub {
+    is $bf->pad_start('42', 5, '0'), '00042', 'left-pad with 0';
+    is $bf->pad_end('42', 5, '.'),   '42...', 'right-pad with .';
+
+    # Default pad is a single space when omitted.
+    is $bf->pad_start('42', 5),      '   42', 'default pad = space (start)';
+    is $bf->pad_end('42', 5),        '42   ', 'default pad = space (end)';
+
+    # Multi-char pad repeated then truncated to fill.
+    is $bf->pad_start('x', 5, 'ab'), 'ababx', 'multi-char pad truncated (start)';
+    is $bf->pad_end('x', 5, 'ab'),   'xabab', 'multi-char pad truncated (end)';
+
+    # Already >= target, or empty pad → unchanged.
+    is $bf->pad_start('hello', 3, '0'), 'hello', 'already >= target → unchanged';
+    is $bf->pad_start('42', 5, ''),     '42',    'empty pad → unchanged';
+
+    # Target truncates toward zero; undef receiver coerces to empty.
+    is $bf->pad_start('7', 4.9, '0'),   '0007',  'fractional target truncates';
+    is $bf->pad_start(undef, 3, '0'),   '000',   'undef receiver pads from empty';
+};
+
 # `Array.prototype.sort(cmp)` / `Array.prototype.toSorted(cmp)`
 # lowering (#1448 Tier B). The opts hash-ref carries a `keys` list of
 # the structured comparison keys the compiler extracted at parse time

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -142,6 +142,8 @@ import { fixture as stringEndsWith } from './methods/string-endsWith'
 import { fixture as stringEndsWithPosition } from './methods/string-endsWith-position'
 import { fixture as stringReplace } from './methods/string-replace'
 import { fixture as stringRepeat } from './methods/string-repeat'
+import { fixture as stringPadStart } from './methods/string-padStart'
+import { fixture as stringPadEnd } from './methods/string-padEnd'
 // #1448 catalog parity: array methods rendered positively by
 // Hono / CSR (runtime JS) and at least one SSR adapter — pinning
 // the canonical surface so a regression surfaces here instead of
@@ -319,6 +321,8 @@ export const jsxFixtures: JSXFixture[] = [
   stringEndsWithPosition,
   stringReplace,
   stringRepeat,
+  stringPadStart,
+  stringPadEnd,
   // #1448 catalog parity — already-lowered Array methods.
   arrayJoin,
   arrayFind,

--- a/packages/adapter-tests/fixtures/methods/string-padEnd.ts
+++ b/packages/adapter-tests/fixtures/methods/string-padEnd.ts
@@ -1,0 +1,23 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `String.prototype.padEnd(target, pad)` lowering (#1448 Tier B).
+ *
+ * Sibling of `string-padStart` — pads on the right (`42` → `42...`).
+ * The distinct pad char (`.`) and right side catch a lowering that
+ * shared the wrong helper or padded the wrong end.
+ */
+export const fixture = createFixture({
+  id: 'string-padEnd',
+  description: '.padEnd(target, pad) right-pads to the target width',
+  source: `
+function StringPadEnd({ value }: { value: string }) {
+  return <div>[{value.padEnd(5, '.')}]</div>
+}
+export { StringPadEnd }
+`,
+  props: { value: '42' },
+  expectedHtml: `
+    <div bf-s="test" bf="s1">[<!--bf:s0-->42...<!--/-->]</div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/methods/string-padStart.ts
+++ b/packages/adapter-tests/fixtures/methods/string-padStart.ts
@@ -1,0 +1,24 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `String.prototype.padStart(target, pad)` lowering (#1448 Tier B).
+ *
+ * Renders at text position. A 2-char receiver padded to width 5 with
+ * `0` exercises the repeat-and-truncate fill (`42` → `00042`); a
+ * lowering that padded the wrong side, or off-by-one on the fill
+ * width, would fail the assertion.
+ */
+export const fixture = createFixture({
+  id: 'string-padStart',
+  description: '.padStart(target, pad) left-pads to the target width',
+  source: `
+function StringPadStart({ value }: { value: string }) {
+  return <div>[{value.padStart(5, '0')}]</div>
+}
+export { StringPadStart }
+`,
+  props: { value: '42' },
+  expectedHtml: `
+    <div bf-s="test" bf="s1">[<!--bf:s0-->00042<!--/-->]</div>
+  `,
+})

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -487,6 +487,15 @@ describe('expression-parser', () => {
       }
     })
 
+    test('lowers .padStart() / .padEnd(t, p, extra) — full arity (#1448 Tier B)', () => {
+      // `.padStart()` is `padStart(0)` → the receiver unchanged; a
+      // third+ argument is ignored. Both stay on the lowering path.
+      for (const expr of [`name().padStart()`, `name().padEnd(5, "0", "x")`]) {
+        const result = parseExpression(expr)
+        expect(result.kind).toBe('array-method')
+      }
+    })
+
     test('lowers .filter(({label = `untitled-${suffix}`}) => label) — template-literal default (#1531)', () => {
       const result = parseExpression('items().filter(({label = `untitled-${suffix}`}) => label)')
       expect(result.kind).toBe('higher-order')

--- a/packages/jsx/src/adapters/parsed-expr-emitter.ts
+++ b/packages/jsx/src/adapters/parsed-expr-emitter.ts
@@ -71,6 +71,8 @@ export type ArrayMethod =
   | 'endsWith'
   | 'replace'
   | 'repeat'
+  | 'padStart'
+  | 'padEnd'
 
 /**
  * Method names handled by the dedicated `sortMethod()` dispatcher

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -51,6 +51,8 @@ export type ParsedExpr =
         | 'endsWith'
         | 'replace'
         | 'repeat'
+        | 'padStart'
+        | 'padEnd'
       object: ParsedExpr
       args: ParsedExpr[]
     }
@@ -245,8 +247,10 @@ const UNSUPPORTED_METHODS = new Set([
   // `repeat` is no longer here — `String.prototype.repeat(n)` lowers via
   // the `array-method` IR + `bf_repeat` (Go) / `bf->repeat` (Mojo).
   // See #1448 Tier B.
+  // `padStart` / `padEnd` are no longer here — both lower via the
+  // `array-method` IR + `bf_pad_start` / `bf_pad_end` (Go) and
+  // `bf->pad_start` / `bf->pad_end` (Mojo). See #1448 Tier B.
   'replaceAll',
-  'padStart', 'padEnd',
   'charAt', 'charCodeAt', 'codePointAt', 'normalize',
   'substring', 'substr', 'match', 'matchAll', 'search',
 ])
@@ -575,6 +579,21 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
       // the no-argument form. See #1448 Tier B.
       if (callee.property === 'repeat') {
         return { kind: 'array-method', method: 'repeat', object: callee.object, args }
+      }
+      // `.padStart(target, pad?)` / `.padEnd(target, pad?)` — string →
+      // string, padded to `target` length with `pad` (default a single
+      // space) repeated + truncated to fill. Go uses `bf_pad_start` /
+      // `bf_pad_end`; Mojo uses `bf->pad_start` / `bf->pad_end`. Both
+      // count length in code points (Go runes / Perl chars) so they
+      // stay byte-equal — this differs from JS's UTF-16-unit length
+      // only for astral-plane receivers, which are vanishingly rare in
+      // numeric / space padding. See #1448 Tier B.
+      // Full JS arity: `.padStart()` (no target) is `padStart(0)` → the
+      // receiver unchanged (JS coerces the missing target to 0), and a
+      // third+ argument is ignored. The adapter supplies the `0` for the
+      // no-argument form and reads only target + padString.
+      if (callee.property === 'padStart' || callee.property === 'padEnd') {
+        return { kind: 'array-method', method: callee.property, object: callee.object, args }
       }
       // `.sort(cmp)` / `.toSorted(cmp)` (#1448 Tier B). The comparator
       // is extracted into a structured `SortComparator` at parse time;


### PR DESCRIPTION
## String Tier B (#1448) — `.padStart` / `.padEnd` (full-arity)

`value.padStart(5, '0')` / `value.padEnd(5, '.')` now compile to both template-language adapters, padding to the target width with the pad string (default a single space) repeated and truncated to fill. **This completes the String Tier B set from #1448.**

> Final PR in the stack — stacked on #1720 (`.repeat`). Rebased and unified to **full JS arity**, matching the philosophy in #1722.

### Changes
- **Parser**: two new `array-method` variants `padStart` / `padEnd`, dropped from `UNSUPPORTED_METHODS`.
- **Full arity**: the no-argument form is `padStart(0)` → the receiver unchanged (JS coerces the missing target to 0); a third+ argument is ignored. The adapter supplies the `0` for the no-argument form and reads only target + padString.
- **Go** (`bf.go`): `bf_pad_start` / `bf_pad_end` (shared `padTo`, rune-counted).
- **Mojo** (`BarefootJS.pm`): `bf->pad_start` / `bf->pad_end` (shared `_pad`, character-counted).

### Notes
Length is measured in code points (Go runes / Perl chars) so the two adapters stay byte-equal; this differs from JS's UTF-16-unit `.length` only for astral-plane receivers, vanishingly rare in numeric/space padding. The target is truncated toward zero, and a receiver already ≥ `target` long (or an empty pad) is returned unchanged — all matching JS.

### Verification
- `bf_pad_start` / `bf_pad_end` Go unit tests + Perl `.t` under real Mojolicious
- Compiler-unit pins: full-arity lowering (`padStart()` + ignore-extra)
- Cross-adapter SSR/CSR conformance render of `string-padStart` / `string-padEnd` (Hono / Go / Mojo byte-equal)

https://claude.ai/code/session_01WDSuf4wHqvVUkFM23vGZqx

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDSuf4wHqvVUkFM23vGZqx)_