### PR TITLE
feat(jsx): lower array/string methods at their full JS arity

### DIFF
--- a/.changeset/array-method-arity-guard.md
+++ b/.changeset/array-method-arity-guard.md
@@ -1,0 +1,13 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+"@barefootjs/mojolicious": patch
+---
+
+Lower the Array / String methods at their full JS arity, instead of only a single fixed argument count (#1448).
+
+Previously each `array-method` lowering (`join`, `includes`, `at`, `concat`, `slice`, `reverse`, `toReversed`, `toLowerCase`, `toUpperCase`, `trim`, …) accepted exactly one argument shape; any other arity slipped past the parser and fell through to a generic emit that built with no diagnostic and only crashed at SSR render time. Now:
+
+- **Zero-arg defaults are supported**: `arr.join()` uses the default `,` separator, `arr.slice()` returns a full copy, `arr.at()` is `arr.at(0)`, and `arr.concat()` is a shallow copy — matching JS, no more refusal/crash.
+- **JS-ignored trailing arguments are accepted**: `str.trim(1)`, `arr.at(i, extra)`, `arr.slice(s, e, extra)`, `arr.reverse(extra)`, etc. lower the same as their base form (JS ignores the extras too).
+- **Genuinely-meaningful extra arguments that aren't lowered yet still refuse with BF101** — the `fromIndex` of `.includes` / `.indexOf` / `.lastIndexOf` and the variadic `.concat(a, b, …)` — because silently dropping them would make the SSR output *differ* from the client (worse than a build error). The diagnostic names the specific unsupported form and does **not** push `/* @client */` (the wrong remedy for an arity issue, and it can't be applied in attribute/condition position anyway).

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -2182,6 +2182,10 @@ import { fixture as arrayLastIndexOfFixture } from '../../../adapter-tests/fixtu
 import { fixture as arrayAtFixture } from '../../../adapter-tests/fixtures/methods/array-at'
 import { fixture as arrayConcatFixture } from '../../../adapter-tests/fixtures/methods/array-concat'
 import { fixture as arraySliceFixture } from '../../../adapter-tests/fixtures/methods/array-slice'
+import { fixture as arraySliceCopyFixture } from '../../../adapter-tests/fixtures/methods/array-slice-copy'
+import { fixture as arrayJoinDefaultFixture } from '../../../adapter-tests/fixtures/methods/array-join-default'
+import { fixture as arrayAtDefaultFixture } from '../../../adapter-tests/fixtures/methods/array-at-default'
+import { fixture as arrayConcatCopyFixture } from '../../../adapter-tests/fixtures/methods/array-concat-copy'
 import { fixture as arrayReverseFixture } from '../../../adapter-tests/fixtures/methods/array-reverse'
 import { fixture as arrayToReversedFixture } from '../../../adapter-tests/fixtures/methods/array-toReversed'
 import { fixture as stringToLowerCaseFixture } from '../../../adapter-tests/fixtures/methods/string-toLowerCase'
@@ -2214,6 +2218,13 @@ describe('GoTemplateAdapter - #1448 Tier A/B fixture-driven lowering pins', () =
     { fixture: arrayAtFixture,          expect: 'bf_at .Items (bf_neg 1)' },
     { fixture: arrayConcatFixture,      expect: 'bf_concat .Left .Right' },
     { fixture: arraySliceFixture,       expect: 'bf_slice .Items 1 3' },
+    // #1448 full-arity — zero-arg defaults. `.slice()` → start 0 (full
+    // copy); `.join()` → default `,` separator.
+    { fixture: arraySliceCopyFixture,   expect: 'bf_slice .Items 0' },
+    { fixture: arrayJoinDefaultFixture, expect: 'bf_join (.Items) ","' },
+    // `.at()` → index 0; `.concat()` → the receiver (shallow copy).
+    { fixture: arrayAtDefaultFixture,   expect: 'bf_at .Items 0' },
+    { fixture: arrayConcatCopyFixture,  expect: 'bf_join (.Items) "|"' },
     { fixture: arrayReverseFixture,     expect: 'bf_reverse .Items' },
     // .toReversed shares the helper with .reverse — pinning both
     // routings catches a future divergence between them.
@@ -2327,6 +2338,15 @@ export function C() {
     { name: 'reduce', expr: `items().reduce((a, b) => a + b.n, 0)`, badEmit: '.Reduce' },
     { name: 'flatMap', expr: `items().flatMap(i => i.tags)`, badEmit: '.FlatMap' },
     { name: 'flat', expr: `items().flat()`, badEmit: '.Flat' },
+    // Lowered methods whose MEANINGFUL extra argument isn't lowered yet
+    // (#1448): the `fromIndex` of `.includes`/`.indexOf`/`.lastIndexOf`
+    // and the variadic `.concat`. The parser refuses these (silently
+    // dropping the arg would change the result) rather than emitting a
+    // render-crashing `.Includes` / `.Concat` field access. (The
+    // zero-arg defaults `.join()`/`.slice()` and JS-ignored trailing
+    // args like `.trim(1)` are accepted — pinned in the positive blocks.)
+    { name: 'includes (2-arg fromIndex)', expr: `items().includes("a", 1)`, badEmit: '.Includes' },
+    { name: 'concat (variadic)', expr: `items().concat(items(), items())`, badEmit: '.Concat' },
     // Tier B/C string methods — previously slipped through with no
     // diagnostic; now gated by `UNSUPPORTED_METHODS`.
     { name: 'split', expr: `name().split(",")`, badEmit: '.Name.Split' },

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -3109,7 +3109,9 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     switch (method) {
       case 'join': {
         const obj = emit(object)
-        const sep = emit(args[0])
+        // `.join()` defaults the separator to `,` (JS); any extra
+        // argument is ignored. Only `args[0]` is read.
+        const sep = args.length >= 1 ? emit(args[0]) : '","'
         // Both operands need paren-wrapping when they emit a
         // multi-token prefix-call form (e.g. `sep` lowering to
         // `bf_trim .Raw` would make Go template parse
@@ -3145,30 +3147,36 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         // `.at(i)` supports negative indices (`.at(-1)` → last
         // element). The Go `bf_at` helper was already registered in
         // the FuncMap for the runtime — this PR wires it to the JS
-        // method name at the adapter layer.
+        // method name at the adapter layer. `.at()` with no argument is
+        // `.at(0)` (the first element); extra arguments are ignored.
         const obj = emit(object)
-        const idx = emit(args[0])
+        const idx = args.length >= 1 ? emit(args[0]) : '0'
         return `bf_at ${wrapIfMultiToken(obj)} ${wrapIfMultiToken(idx)}`
       }
       case 'concat': {
         // `.concat(other)` merges two arrays. The runtime helper
         // `bf_concat` reflects over both operands so callers can
         // mix `[]string` + `[]string` or `[]any` + `[]string` etc.
-        // without per-call-site type-juggling.
+        // without per-call-site type-juggling. `.concat()` with no
+        // argument is a shallow copy — indistinguishable from the
+        // receiver in an SSR snapshot, so it lowers to the receiver.
+        if (args.length === 0) {
+          return emit(object)
+        }
         const a = emit(object)
         const b = emit(args[0])
         return `bf_concat ${wrapIfMultiToken(a)} ${wrapIfMultiToken(b)}`
       }
       case 'slice': {
-        // `.slice(start)` / `.slice(start, end)` — both forms route
-        // through `bf_slice`. The runtime helper treats a `nil`
-        // `end` (the variadic-arg absence) as "to length", matching
-        // the JS semantic. Out-of-bounds indices clamp instead of
-        // panicking (also JS-compat); same with `start > end`
-        // returning an empty slice.
+        // `.slice()` / `.slice(start)` / `.slice(start, end)` — route
+        // through `bf_slice`. A missing `start` defaults to 0 (full
+        // copy); the runtime helper treats an absent `end` as "to
+        // length". Out-of-bounds indices clamp instead of panicking
+        // (JS-compat); `start > end` returns an empty slice. JS ignores
+        // a third+ argument, so only `args[0]` / `args[1]` are read.
         const recv = emit(object)
-        const start = emit(args[0])
-        if (args.length === 1) {
+        const start = args.length >= 1 ? emit(args[0]) : '0'
+        if (args.length <= 1) {
           return `bf_slice ${wrapIfMultiToken(recv)} ${wrapIfMultiToken(start)}`
         }
         const end = emit(args[1])

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -928,6 +928,10 @@ import { fixture as arrayLastIndexOfFixture } from '../../../adapter-tests/fixtu
 import { fixture as arrayAtFixture } from '../../../adapter-tests/fixtures/methods/array-at'
 import { fixture as arrayConcatFixture } from '../../../adapter-tests/fixtures/methods/array-concat'
 import { fixture as arraySliceFixture } from '../../../adapter-tests/fixtures/methods/array-slice'
+import { fixture as arraySliceCopyFixture } from '../../../adapter-tests/fixtures/methods/array-slice-copy'
+import { fixture as arrayJoinDefaultFixture } from '../../../adapter-tests/fixtures/methods/array-join-default'
+import { fixture as arrayAtDefaultFixture } from '../../../adapter-tests/fixtures/methods/array-at-default'
+import { fixture as arrayConcatCopyFixture } from '../../../adapter-tests/fixtures/methods/array-concat-copy'
 import { fixture as arrayReverseFixture } from '../../../adapter-tests/fixtures/methods/array-reverse'
 import { fixture as arrayToReversedFixture } from '../../../adapter-tests/fixtures/methods/array-toReversed'
 import { fixture as stringToLowerCaseFixture } from '../../../adapter-tests/fixtures/methods/string-toLowerCase'
@@ -955,6 +959,12 @@ describe('MojoAdapter - #1448 Tier A/B fixture-driven lowering pins', () => {
     { fixture: arrayAtFixture,          expect: 'bf->at($items, -1)' },
     { fixture: arrayConcatFixture,      expect: 'bf->concat($left, $right)' },
     { fixture: arraySliceFixture,       expect: 'bf->slice($items, 1, 3)' },
+    // #1448 full-arity — zero-arg defaults.
+    { fixture: arraySliceCopyFixture,   expect: 'bf->slice($items, 0, undef)' },
+    { fixture: arrayJoinDefaultFixture, expect: `join(',', @{$items})` },
+    // `.at()` → index 0; `.concat()` → the receiver (shallow copy).
+    { fixture: arrayAtDefaultFixture,   expect: 'bf->at($items, 0)' },
+    { fixture: arrayConcatCopyFixture,  expect: `join('|', @{$items})` },
     { fixture: arrayReverseFixture,     expect: 'bf->reverse($items)' },
     // .toReversed shares the helper with .reverse — pinning both
     // routings catches a future divergence between them.
@@ -1065,6 +1075,14 @@ export function C() {
     { name: 'reduce', expr: `items().reduce((a, b) => a + b.n, 0)`, badEmit: '->{reduce}' },
     { name: 'flatMap', expr: `items().flatMap(i => i.tags)`, badEmit: '->{flatMap}' },
     { name: 'flat', expr: `items().flat()`, badEmit: '->{flat}' },
+    // Lowered methods whose MEANINGFUL extra argument isn't lowered yet
+    // (#1448): the `fromIndex` of `.includes`/`.indexOf`/`.lastIndexOf`
+    // and the variadic `.concat`. The parser refuses these (silently
+    // dropping the arg would change the result). (The zero-arg defaults
+    // `.join()`/`.slice()` and JS-ignored trailing args like `.trim(1)`
+    // are accepted — pinned in the positive blocks.)
+    { name: 'includes (2-arg fromIndex)', expr: `items().includes("a", 1)`, badEmit: '->{includes}' },
+    { name: 'concat (variadic)', expr: `items().concat(items(), items())`, badEmit: '->{concat}' },
     // Tier B/C string methods — previously slipped through with no
     // diagnostic; now routed through the AST / `isSupported` gate.
     { name: 'split', expr: `name().split(",")`, badEmit: '->{split}' },

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1295,9 +1295,10 @@ function renderArrayMethod(
       // arr.join(sep) → join(sep, @{arr}). The default `${obj}->{join}`
       // hash-lookup fallback would emit invalid Perl, which is why the
       // IR carves out a dedicated method node instead of routing
-      // through the generic call dispatcher.
+      // through the generic call dispatcher. `.join()` defaults the
+      // separator to `,` (JS) and ignores any extra argument.
       const obj = emit(object)
-      const sep = emit(args[0])
+      const sep = args.length >= 1 ? emit(args[0]) : `','`
       return `join(${sep}, @{${obj}})`
     }
     case 'includes': {
@@ -1333,9 +1334,10 @@ function renderArrayMethod(
       // `.at(i)` with negative-index support — `.at(-1)` is the
       // last element. The Mojo helper wraps the same `length + i`
       // arithmetic the Go `bf_at` does so the lowering stays
-      // symmetric across adapters.
+      // symmetric across adapters. `.at()` with no argument is `.at(0)`
+      // (the first element); extra arguments are ignored.
       const obj = emit(object)
-      const idx = emit(args[0])
+      const idx = args.length >= 1 ? emit(args[0]) : '0'
       return `bf->at(${obj}, ${idx})`
     }
     case 'concat': {
@@ -1343,20 +1345,26 @@ function renderArrayMethod(
       // ref so the result composes with `.join(...)` / other
       // array-shape methods downstream (the canonical Tier A
       // conformance fixture chains `.concat(...).join(' ')`).
+      // `.concat()` with no argument is a shallow copy — indistinguishable
+      // from the receiver in an SSR snapshot, so it lowers to the receiver.
+      if (args.length === 0) {
+        return emit(object)
+      }
       const a = emit(object)
       const b = emit(args[0])
       return `bf->concat(${a}, ${b})`
     }
     case 'slice': {
-      // `.slice(start)` / `.slice(start, end)`. The Mojo helper
-      // mirrors the Go arithmetic (negative-index normalisation,
-      // out-of-bounds clamping, empty result on start >= end).
-      // Absent `end` lowers as `undef`, which the helper treats as
-      // "to length". Returns a new ARRAY ref so the result composes
-      // with `.join(...)` downstream.
+      // `.slice()` / `.slice(start)` / `.slice(start, end)`. The Mojo
+      // helper mirrors the Go arithmetic (negative-index normalisation,
+      // out-of-bounds clamping, empty result on start >= end). A
+      // missing `start` defaults to 0 (full copy); an absent `end`
+      // lowers as `undef`, which the helper treats as "to length". JS
+      // ignores a third+ argument. Returns a new ARRAY ref so the
+      // result composes with `.join(...)` downstream.
       const recv = emit(object)
-      const start = emit(args[0])
-      const end = args.length === 2 ? emit(args[1]) : 'undef'
+      const start = args.length >= 1 ? emit(args[0]) : '0'
+      const end = args.length >= 2 ? emit(args[1]) : 'undef'
       return `bf->slice(${recv}, ${start}, ${end})`
     }
     case 'reverse':

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -122,6 +122,11 @@ import { fixture as arrayLastIndexOf } from './methods/array-lastIndexOf'
 import { fixture as arrayAt } from './methods/array-at'
 import { fixture as arrayConcat } from './methods/array-concat'
 import { fixture as arraySlice } from './methods/array-slice'
+// #1448 full-arity — zero-arg default forms.
+import { fixture as arraySliceCopy } from './methods/array-slice-copy'
+import { fixture as arrayJoinDefault } from './methods/array-join-default'
+import { fixture as arrayAtDefault } from './methods/array-at-default'
+import { fixture as arrayConcatCopy } from './methods/array-concat-copy'
 import { fixture as arrayReverse } from './methods/array-reverse'
 import { fixture as arrayToReversed } from './methods/array-toReversed'
 import { fixture as stringToLowerCase } from './methods/string-toLowerCase'
@@ -285,6 +290,10 @@ export const jsxFixtures: JSXFixture[] = [
   arrayAt,
   arrayConcat,
   arraySlice,
+  arraySliceCopy,
+  arrayJoinDefault,
+  arrayAtDefault,
+  arrayConcatCopy,
   arrayReverse,
   arrayToReversed,
   // #1448 Tier A — String methods.

--- a/packages/adapter-tests/fixtures/methods/array-at-default.ts
+++ b/packages/adapter-tests/fixtures/methods/array-at-default.ts
@@ -1,0 +1,25 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `Array.prototype.at()` with no argument (#1448 full-arity).
+ *
+ * JS `.at()` is `.at(0)` (`ToIntegerOrInfinity(undefined) === 0`), i.e.
+ * the first element. Pins that the adapters default the index to 0
+ * rather than refusing the zero-arg form, and that the result matches
+ * real JS across Hono / Go / Mojo (the conformance harness renders this
+ * through all three).
+ */
+export const fixture = createFixture({
+  id: 'array-at-default',
+  description: '.at() with no argument returns the first element',
+  source: `
+function ArrayAtDefault({ items }: { items: string[] }) {
+  return <div>[{items.at()}]</div>
+}
+export { ArrayAtDefault }
+`,
+  props: { items: ['x', 'y', 'z'] },
+  expectedHtml: `
+    <div bf-s="test" bf="s1">[<!--bf:s0-->x<!--/-->]</div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/methods/array-concat-copy.ts
+++ b/packages/adapter-tests/fixtures/methods/array-concat-copy.ts
@@ -1,0 +1,25 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `Array.prototype.concat()` with no argument (#1448 full-arity).
+ *
+ * JS `.concat()` returns a shallow copy. In an SSR snapshot a copy is
+ * indistinguishable from the receiver, so the adapters lower it to the
+ * receiver. Chained into `.join('|')` so the array is observable; the
+ * conformance harness renders this through Hono / Go / Mojo and compares
+ * to the real-JS `expectedHtml`.
+ */
+export const fixture = createFixture({
+  id: 'array-concat-copy',
+  description: '.concat() with no argument copies the whole array',
+  source: `
+function ArrayConcatCopy({ items }: { items: string[] }) {
+  return <div>{items.concat().join('|')}</div>
+}
+export { ArrayConcatCopy }
+`,
+  props: { items: ['a', 'b', 'c'] },
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><!--bf:s0-->a|b|c<!--/--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/methods/array-join-default.ts
+++ b/packages/adapter-tests/fixtures/methods/array-join-default.ts
@@ -1,0 +1,22 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `Array.prototype.join()` with no separator (#1448 full-arity).
+ *
+ * JS defaults the separator to `,` when omitted. Pins that the adapters
+ * supply the default rather than refusing the zero-arg form.
+ */
+export const fixture = createFixture({
+  id: 'array-join-default',
+  description: '.join() with no argument joins with the default comma',
+  source: `
+function ArrayJoinDefault({ items }: { items: string[] }) {
+  return <div>{items.join()}</div>
+}
+export { ArrayJoinDefault }
+`,
+  props: { items: ['a', 'b', 'c'] },
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><!--bf:s0-->a,b,c<!--/--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/methods/array-slice-copy.ts
+++ b/packages/adapter-tests/fixtures/methods/array-slice-copy.ts
@@ -1,0 +1,23 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `Array.prototype.slice()` with no arguments (#1448 full-arity).
+ *
+ * JS `.slice()` returns a full (shallow) copy. Pins that the adapters
+ * default `start` to 0 rather than refusing the zero-arg form. Chained
+ * into `.join('|')` so the copied array is observable.
+ */
+export const fixture = createFixture({
+  id: 'array-slice-copy',
+  description: '.slice() with no argument copies the whole array',
+  source: `
+function ArraySliceCopy({ items }: { items: string[] }) {
+  return <div>{items.slice().join('|')}</div>
+}
+export { ArraySliceCopy }
+`,
+  props: { items: ['a', 'b', 'c'] },
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><!--bf:s0-->a|b|c<!--/--></div>
+  `,
+})

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -1358,3 +1358,78 @@ describe('expression-parser', () => {
     })
   })
 })
+
+// =============================================================================
+// Full-arity lowering for the array / string methods (#1448)
+// =============================================================================
+//
+// These methods lower at their full JS arity: zero-arg defaults
+// (`.join()` → `,`, `.slice()` → full copy) and JS-ignored trailing
+// arguments (`.trim(1)`, `.at(i, extra)`, `.slice(s, e, extra)`) are all
+// accepted. The only forms still refused are the ones whose EXTRA
+// argument changes the result and isn't lowered yet — the `fromIndex` of
+// `.includes`/`.indexOf`/`.lastIndexOf` and the variadic `.concat(a, b)`
+// — because silently dropping those would make SSR differ from the
+// client (worse than a build error).
+describe('expression-parser — array-method full-arity lowering (#1448)', () => {
+  const supported: Array<[string, string]> = [
+    // base forms
+    ['join(sep)', 'arr.join("-")'],
+    ['includes(x)', 'arr.includes(x)'],
+    ['indexOf(x)', 'arr.indexOf(x)'],
+    ['at(i)', 'arr.at(1)'],
+    ['concat(other)', 'arr.concat(b)'],
+    ['slice(start)', 'arr.slice(1)'],
+    ['slice(start, end)', 'arr.slice(1, 2)'],
+    ['trim()', 's.trim()'],
+    // zero-arg defaults (every one of these escaping both its arm AND
+    // the guard is the footgun the relaxation must NOT reintroduce)
+    ['join() → default ","', 'arr.join()'],
+    ['slice() → full copy', 'arr.slice()'],
+    ['at() → at(0)', 'arr.at()'],
+    ['concat() → shallow copy', 'arr.concat()'],
+    ['reverse() base', 'arr.reverse()'],
+    ['toReversed() base', 'arr.toReversed()'],
+    ['toLowerCase() base', 's.toLowerCase()'],
+    ['toUpperCase() base', 's.toUpperCase()'],
+    ['lastIndexOf(x) base', 'arr.lastIndexOf(x)'],
+    // JS-ignored trailing arguments
+    ['slice(s, e, extra)', 'arr.slice(1, 2, 3)'],
+    ['at(i, extra)', 'arr.at(1, 2)'],
+    ['reverse(extra)', 'arr.reverse(1)'],
+    ['toReversed(extra)', 'arr.toReversed(1)'],
+    ['toLowerCase(extra)', 's.toLowerCase("x")'],
+    ['toUpperCase(extra)', 's.toUpperCase("x")'],
+    ['trim(extra)', 's.trim(1)'],
+  ]
+  for (const [label, expr] of supported) {
+    test(`${label} — lowers to array-method`, () => {
+      expect(parseExpression(expr).kind).toBe('array-method')
+    })
+  }
+
+  // Still refused (the extra argument is meaningful and not yet
+  // lowered), plus the degenerate zero-arg search forms (`includes()`
+  // searches for `undefined` — refused rather than guessed).
+  const refused: Array<[string, string]> = [
+    ['includes(x, fromIndex)', 'arr.includes(x, 1)'],
+    ['indexOf(x, fromIndex)', 'arr.indexOf(x, 1)'],
+    ['lastIndexOf(x, fromIndex)', 'arr.lastIndexOf(x, 1)'],
+    ['concat(a, b) variadic', 'arr.concat(a, b)'],
+    ['includes() zero-arg', 'arr.includes()'],
+    ['indexOf() zero-arg', 'arr.indexOf()'],
+  ]
+  for (const [label, expr] of refused) {
+    test(`${label} — refuses (meaningful extra arg, not yet lowered)`, () => {
+      const result = parseExpression(expr)
+      expect(result.kind).toBe('unsupported')
+      if (result.kind === 'unsupported') {
+        // Must NOT push `@client` (wrong remedy; doesn't work in
+        // attribute / condition position), and must explain it's a
+        // not-yet-lowered argument.
+        expect(result.reason).not.toContain('@client')
+        expect(result.reason).toContain('not yet lowered')
+      }
+    })
+  }
+})

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -231,6 +231,23 @@ const UNSUPPORTED_METHODS = new Set([
   'substring', 'substr', 'match', 'matchAll', 'search',
 ])
 
+// Methods that lower at their single-argument form but whose EXTRA
+// argument is meaningful and NOT yet lowered: the `fromIndex` of
+// `.includes` / `.indexOf` / `.lastIndexOf` (the 2-arg form) and the
+// additional arrays of a variadic `.concat(a, b, …)`. The relaxed
+// per-method arms in `convertNode` accept every method's zero-arg
+// defaults (`.join()` / `.slice()` / `.concat()` / `.at()`) and
+// JS-ignored trailing arguments; this guard catches only the remaining
+// meaningful-extra forms, refusing them with BF101 because silently
+// dropping the argument would make the SSR output differ from the
+// client. See #1448.
+const LOWERED_ARRAY_METHODS = new Set([
+  'includes',
+  'indexOf',
+  'lastIndexOf',
+  'concat',
+])
+
 // =============================================================================
 // Expression Parser
 // =============================================================================
@@ -344,7 +361,10 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
     // etc. later means widening the IR discriminator, not adding more
     // branches to every adapter's call dispatch.
     if (callee.kind === 'member' && !callee.computed) {
-      if (callee.property === 'join' && args.length === 1) {
+      // `.join()` / `.join(sep)` — JS defaults the separator to `,` when
+      // omitted and ignores any extra arguments. Accept every arity; the
+      // adapters supply the default separator and read only `args[0]`.
+      if (callee.property === 'join') {
         return { kind: 'array-method', method: 'join', object: callee.object, args }
       }
       // `.includes(x)` — shared between `Array.prototype.includes` and
@@ -369,20 +389,28 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
       // element). Go has `bf_at` registered already (see runtime
       // FuncMap); Mojo's `bf->at` wraps the same arithmetic.
       // See #1448 Tier A.
-      if (callee.property === 'at' && args.length === 1) {
+      // `.at(i)` — JS ignores any argument past the first, and `.at()`
+      // with no argument is `.at(0)` (the first element). Accept every
+      // arity; the adapters read `args[0]` (defaulting the index to 0).
+      if (callee.property === 'at') {
         return { kind: 'array-method', method: 'at', object: callee.object, args }
       }
-      // `.concat(other)` — merges two arrays in order. Go uses
-      // `bf_concat` (reflect-based append into `[]any`); Mojo uses
-      // `bf->concat` (Perl list builder). Variadic shapes (`.concat(a, b)`)
-      // are out of scope for this PR — gated to single-arg here.
-      if (callee.property === 'concat' && args.length === 1) {
+      // `.concat()` / `.concat(other)` — `.concat()` returns a shallow
+      // copy (indistinguishable from the receiver in an SSR snapshot),
+      // and `.concat(other)` merges the two arrays. Go uses `bf_concat`
+      // (reflect-based append into `[]any`); Mojo uses `bf->concat`
+      // (Perl list builder). The VARIADIC form (`.concat(a, b, …)`) is
+      // not lowered yet — it's refused by the guard below rather than
+      // silently dropping the extra arrays.
+      if (callee.property === 'concat' && args.length <= 1) {
         return { kind: 'array-method', method: 'concat', object: callee.object, args }
       }
-      // `.slice(start)` / `.slice(start, end)` — both forms route
-      // through `bf_slice` (Go) / `bf->slice` (Mojo); the helpers
-      // treat a missing / undef `end` as "to length".
-      if (callee.property === 'slice' && (args.length === 1 || args.length === 2)) {
+      // `.slice()` / `.slice(start)` / `.slice(start, end)` — route
+      // through `bf_slice` (Go) / `bf->slice` (Mojo). A missing `start`
+      // defaults to 0 (full copy), a missing / undef `end` means "to
+      // length", and JS ignores any third+ argument. Accept every arity;
+      // the adapters read only `args[0]` / `args[1]`.
+      if (callee.property === 'slice') {
         return { kind: 'array-method', method: 'slice', object: callee.object, args }
       }
       // `.reverse()` and `.toReversed()` — both zero-arg shapes
@@ -390,7 +418,8 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
       // of state, so JS's mutate-and-return-receiver (`reverse`)
       // vs return-new-array (`toReversed`) distinction has no
       // template-level meaning; both produce a new reversed array.
-      if ((callee.property === 'reverse' || callee.property === 'toReversed') && args.length === 0) {
+      // JS takes no argument and ignores any that are passed.
+      if (callee.property === 'reverse' || callee.property === 'toReversed') {
         return { kind: 'array-method', method: callee.property, object: callee.object, args }
       }
       // `.toLowerCase()` — string-only (the IR carries a value-builtin
@@ -398,19 +427,40 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
       // label is a misnomer for string methods but the mechanical
       // pipeline matches). Go uses the existing `bf_lower` helper;
       // Mojo uses Perl's native `lc`. See #1448 Tier A.
-      if (callee.property === 'toLowerCase' && args.length === 0) {
+      if (callee.property === 'toLowerCase') {
         return { kind: 'array-method', method: 'toLowerCase', object: callee.object, args }
       }
       // `.toUpperCase()` — Go uses the existing `bf_upper` helper;
       // Mojo uses Perl's native `uc`.
-      if (callee.property === 'toUpperCase' && args.length === 0) {
+      if (callee.property === 'toUpperCase') {
         return { kind: 'array-method', method: 'toUpperCase', object: callee.object, args }
       }
       // `.trim()` — Go uses the existing `bf_trim` helper; Mojo uses
       // a new `bf->trim` method that mirrors JS's "strip leading +
       // trailing whitespace" semantic via a Perl regex.
-      if (callee.property === 'trim' && args.length === 0) {
+      if (callee.property === 'trim') {
         return { kind: 'array-method', method: 'trim', object: callee.object, args }
+      }
+      // Arity guard for the forms whose EXTRA argument changes the
+      // result and is not yet lowered: the `fromIndex` of `.includes` /
+      // `.indexOf` / `.lastIndexOf` (the 2-arg form), and the additional
+      // arrays of a variadic `.concat(a, b, …)`. Silently dropping those
+      // would make the SSR output *differ* from the client (worse than a
+      // build error), so they refuse with BF101 until lowered. (The
+      // single-argument forms, zero-arg defaults, and JS-ignored
+      // trailing arguments of every method are accepted by the relaxed
+      // arms above.) See #1448.
+      if (LOWERED_ARRAY_METHODS.has(callee.property)) {
+        const argName = callee.property === 'concat' ? 'other' : 'x'
+        const detail =
+          callee.property === 'concat'
+            ? 'the variadic `.concat(a, b, …)` form'
+            : `\`.${callee.property}(…)\` with ${args.length} argument(s)`
+        return {
+          kind: 'unsupported',
+          raw,
+          reason: `${detail} is not yet lowered to the Go/Mojo template adapters. Use the single-argument \`.${callee.property}(${argName})\` form, or pre-compute the value before the template.`,
+        }
       }
       // `.sort(cmp)` / `.toSorted(cmp)` (#1448 Tier B). The comparator
       // is extracted into a structured `SortComparator` at parse time;


### PR DESCRIPTION
## Lower the Array/String methods at their full JS arity (#1448)

Each `array-method` lowering used to accept **exactly one** argument shape. Because a lowered method is dropped from `UNSUPPORTED_METHODS` when it lands, any other arity slipped past the parser into a generic emit that built with **no diagnostic** and crashed at SSR render time:

```jsx
{items.join()}        // Go: .Items.Join     → render-time panic, no build error
{items.slice()}       // Mojo: $items->{slice} → render-time die, no build error
{str.trim(1)}         // …same silent footgun
```

This PR makes the parser accept each method's **full JS arity** instead, so the common forms users actually write just work.

### What now works (no error)
- **Zero-arg defaults** — `arr.join()` uses the default `,` separator; `arr.slice()` returns a full copy. (matches JS)
- **JS-ignored trailing arguments** — `str.trim(1)`, `arr.at(i, extra)`, `arr.slice(s, e, extra)`, `arr.reverse(extra)`, `s.toLowerCase(x)`, etc. lower the same as their base form (JS ignores the extras too).

The Go/Mojo adapters supply the default separator (`,`) and default slice start (`0`); the `bf_join` / `bf_slice` runtime helpers are unchanged.

### What still refuses (intentionally)
Only the forms whose extra argument is **meaningful and not yet lowered**:
- the `fromIndex` of `.includes(x, i)` / `.indexOf(x, i)` / `.lastIndexOf(x, i)`
- the variadic `.concat(a, b, …)`

Silently dropping these would make the **SSR output differ from the client** — worse than a build error — so they refuse with **BF101**. The diagnostic names the specific unsupported form and **no longer pushes `/* @client */`** (the wrong remedy for an arity issue, and it can't even be applied in attribute/condition position, which surfaces BF102). These land as a follow-up (runtime `fromIndex` / variadic support in Go + Perl).

### Verification
- Parser full-arity tests: 17 supported arities lower to `array-method`, 4 meaningful-extra forms refuse with a no-`@client` reason.
- Per-adapter **BF101 refusal pins** for the still-unsupported `fromIndex` / variadic-`concat` forms (never leak a broken `.Includes` / `->{concat}` emit).
- Two new conformance fixtures (`array-join-default`, `array-slice-copy`) rendered byte-correctly through the **real Go (go1.25) + Mojolicious** runtimes.
- Full adapter + conformance suites green — no valid-arity fixture regressed.

### History
Started life as an *arity guard* that refused every off-arity call; reframed (per review) to **support** the common forms and refuse only the silently-wrong ones. Independent of and intended to merge before the String Tier B stack (#1717–#1721), which adds the same full-arity treatment for the string methods it introduces. Based on `main`.

https://claude.ai/code/session_01WDSuf4wHqvVUkFM23vGZqx