### PR TITLE
fix(compiler): forward non-inlinable component props to renderChild (no dropped props)

### DIFF
--- a/.changeset/fix-renderchild-dropped-props.md
+++ b/.changeset/fix-renderchild-dropped-props.md
@@ -1,0 +1,6 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/client": patch
+---
+
+Fix dropped component props in CSR render. A parent passing a non-statically-inlinable value (e.g. `Array.from(...)` or an init-scope local) as a prop to a child component emitted `renderChild('Child', {})` — silently dropping the prop — so the child's template read it eagerly and threw (`Cannot read properties of undefined`). Such children now defer to a placeholder + `upsertChild` (`createComponent` with the complete getter props), mirroring the existing clientOnly-conditional / loop-placeholder paths. SSR adapters are unaffected.

--- a/packages/client/__tests__/runtime/renderchild-noninlinable-props.test.ts
+++ b/packages/client/__tests__/runtime/renderchild-noninlinable-props.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Runtime regression test for the dropped-prop bug.
+ *
+ * When a parent passes a NON-statically-inlinable value (e.g.
+ * `Array.from(...)`) as a prop to a child component, the prop must still
+ * reach the child. The module-scope CSR template lambda cannot inline
+ * such a value, so the parent must DEFER the child render to init (which
+ * carries the value through a `get propName()` getter) rather than
+ * eagerly calling `renderChild('Child', {})` with the prop dropped — that
+ * makes the child template read `undefined.filter(...)` and throw.
+ *
+ * The 4-case matrix mirrors the repro: {module, local} × {literal,
+ * Array.from}. Literals (A/B) already bake into the template; the
+ * Array.from cases (C/D) are the regression.
+ */
+
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import { compileJSX } from '../../../jsx/src/compiler'
+import { TestAdapter } from '../../../jsx/src/adapters/test-adapter'
+import { writeFileSync, unlinkSync, mkdtempSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') {
+    GlobalRegistrator.register()
+  }
+})
+
+const adapter = new TestAdapter()
+
+async function compileAndEvalClientJs(source: string, filename: string): Promise<void> {
+  const result = compileJSX(source, filename, { adapter })
+  const errors = result.errors.filter(e => e.severity === 'error')
+  if (errors.length > 0) {
+    throw new Error(`Compilation errors in ${filename}:\n${errors.map(e => e.message).join('\n')}`)
+  }
+  const clientJs = result.files.find(f => f.type === 'clientJs')?.content
+  if (!clientJs) throw new Error('No client JS emitted')
+
+  const runtimePath = join(__dirname, '../../src/runtime/index.ts')
+  const rewritten = clientJs
+    .replace(/from\s+['"]@barefootjs\/client\/runtime['"]/g, `from '${runtimePath}'`)
+    .replace(/^import '\/\* @bf-child:\w+ \*\/'\n/gm, '')
+
+  const dir = mkdtempSync(join(tmpdir(), 'bf-dropprop-'))
+  const file = join(dir, `${filename.replace(/\W/g, '_')}_${Math.random().toString(36).slice(2)}.mjs`)
+  writeFileSync(file, rewritten)
+  try {
+    await import(file)
+  } finally {
+    try { unlinkSync(file) } catch {}
+  }
+}
+
+const CHILD_SRC = `
+  'use client'
+  import { createMemo } from '@barefootjs/client'
+  interface Row { id: string }
+  export function DropChild(props: { rows: Row[] }) {
+    const n = createMemo(() => props.rows.filter(r => r.id !== '').length)
+    return <div data-drop-child="true">{n()}</div>
+  }
+`
+
+describe('renderChild — non-inlinable component props are forwarded (no dropped props)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  // The parent's root is a single child component, so `createComponent`
+  // returns the rendered child element directly (a comment-scope parent).
+  // Resolve the child whether it is the returned element itself or a
+  // descendant.
+  function findChild(el: Element): Element | null {
+    if (el.getAttribute('data-drop-child') === 'true') return el
+    return el.querySelector('[data-drop-child="true"]')
+  }
+
+  async function mountParent(label: string, parentSrc: string) {
+    await compileAndEvalClientJs(CHILD_SRC, `DropChild_${label}.tsx`)
+    await compileAndEvalClientJs(parentSrc, `DropParent_${label}.tsx`)
+    const { createComponent } = await import('../../src/runtime')
+    const el = createComponent(`DropParent${label}`, {}) as Element
+    document.body.appendChild(el)
+    return el
+  }
+
+  test('A: module-scope literal array forwards the prop', async () => {
+    const el = await mountParent('A', `
+      'use client'
+      import { DropChild } from './DropChild_A'
+      const rowsA = [{ id: 'a' }, { id: 'b' }]
+      export function DropParentA() { return <DropChild rows={rowsA} /> }
+    `)
+    const child = findChild(el)
+    expect(child).not.toBeNull()
+    expect(child!.textContent).toBe('2')
+  })
+
+  test('B: local literal array forwards the prop', async () => {
+    const el = await mountParent('B', `
+      'use client'
+      import { DropChild } from './DropChild_B'
+      export function DropParentB() {
+        const rowsB = [{ id: 'a' }, { id: 'b' }]
+        return <DropChild rows={rowsB} />
+      }
+    `)
+    const child = findChild(el)
+    expect(child).not.toBeNull()
+    expect(child!.textContent).toBe('2')
+  })
+
+  test('C: module-scope Array.from forwards the prop (regression)', async () => {
+    const el = await mountParent('C', `
+      'use client'
+      import { DropChild } from './DropChild_C'
+      const rowsC = Array.from({ length: 3 }, (_, i) => ({ id: String(i) }))
+      export function DropParentC() { return <DropChild rows={rowsC} /> }
+    `)
+    const child = findChild(el)
+    expect(child).not.toBeNull()
+    expect(child!.textContent).toBe('3')
+  })
+
+  test('D: local Array.from forwards the prop (regression)', async () => {
+    const el = await mountParent('D', `
+      'use client'
+      import { DropChild } from './DropChild_D'
+      export function DropParentD() {
+        const rowsD = Array.from({ length: 3 }, (_, i) => ({ id: String(i) }))
+        return <DropChild rows={rowsD} />
+      }
+    `)
+    const child = findChild(el)
+    expect(child).not.toBeNull()
+    expect(child!.textContent).toBe('3')
+  })
+})

--- a/packages/client/__tests__/runtime/renderchild-noninlinable-props.test.ts
+++ b/packages/client/__tests__/runtime/renderchild-noninlinable-props.test.ts
@@ -67,6 +67,7 @@ const CHILD_SRC = `
 describe('renderChild — non-inlinable component props are forwarded (no dropped props)', () => {
   beforeEach(() => {
     document.body.innerHTML = ''
+    ;(globalThis as any).__parentEffectRuns = 0
   })
 
   // The parent's root is a single child component, so `createComponent`
@@ -137,5 +138,30 @@ describe('renderChild — non-inlinable component props are forwarded (no droppe
     const child = findChild(el)
     expect(child).not.toBeNull()
     expect(child!.textContent).toBe('3')
+  })
+
+  // E guards the root-deferred path's effect lifecycle: when the parent's
+  // entire render is a single deferred child, `createComponent` runs the
+  // parent's init on a placeholder element that is then DISCARDED (replaced
+  // by the materialised child). The parent's own `createEffect` must still
+  // fire — effect ownership lives in the EffectContext tree, not the
+  // discarded DOM scope element — and the child must still receive the
+  // complete props. (Pre-fix this whole shape crashed via the dropped prop;
+  // this case additionally proves the parent stays reactive.)
+  test('E: root-deferred parent keeps its own createEffect AND forwards the prop', async () => {
+    const el = await mountParent('E', `
+      'use client'
+      import { createEffect } from '@barefootjs/client'
+      import { DropChild } from './DropChild_E'
+      export function DropParentE() {
+        const rowsE = Array.from({ length: 5 }, (_, i) => ({ id: String(i) }))
+        createEffect(() => { (globalThis as any).__parentEffectRuns = ((globalThis as any).__parentEffectRuns ?? 0) + 1 })
+        return <DropChild rows={rowsE} />
+      }
+    `)
+    const child = findChild(el)
+    expect(child).not.toBeNull()
+    expect(child!.textContent).toBe('5')
+    expect((globalThis as any).__parentEffectRuns).toBeGreaterThanOrEqual(1)
   })
 })

--- a/packages/client/src/runtime/component.ts
+++ b/packages/client/src/runtime/component.ts
@@ -213,19 +213,18 @@ export function createComponent(
     const materialised = placeholderWrapper.firstElementChild as HTMLElement | null
     if (materialised && !materialised.hasAttribute(BF_PLACEHOLDER)) {
       // The deferred child was created in place of the placeholder.
-      // NOTE: we intentionally do NOT call registerPropsUpdate() here (unlike
-      // the normal path below). `materialised` is the child's own element,
-      // created via upsertChild -> createComponent, which already registered
-      // its own props-update fn keyed to the child. Registering the *parent's*
-      // here would be wrong: the parent's init replaces a `data-bf-ph`
-      // placeholder via upsertChild, and re-running it on `materialised` (whose
-      // placeholder is already gone) would not re-materialise correctly.
-      // This divergence is unreachable in practice: reconcileList reuses items
-      // by recreating them through renderItem (see reconcile-elements.ts), and
-      // getPropsUpdateFn/getComponentProps have no in-repo callers.
+      // `materialised` is the child's OWN element, created via
+      // upsertChild -> createComponent, which already registered itself
+      // (hydratedScopes / propsMap / registerPropsUpdate) keyed to the
+      // child with the child's own props. We must NOT re-register it here:
+      // overwriting propsMap/registerPropsUpdate with the *parent's* props
+      // would mis-key the child (e.g. a later getComponentProps would read
+      // the parent's props), and re-running the parent's init on an element
+      // whose placeholder is already gone could not re-materialise. So just
+      // restore the scope and return the already-registered child.
+      // (Parent-scope effects are unaffected: createEffect ownership lives
+      // in the EffectContext tree, not the discarded placeholder element.)
       setCurrentScope(prevScope)
-      hydratedScopes.add(materialised)
-      propsMap.set(materialised, props)
       return materialised
     }
     // Placeholder was not replaced (no init / no matching child): fall

--- a/packages/client/src/runtime/component.ts
+++ b/packages/client/src/runtime/component.ts
@@ -213,6 +213,16 @@ export function createComponent(
     const materialised = placeholderWrapper.firstElementChild as HTMLElement | null
     if (materialised && !materialised.hasAttribute(BF_PLACEHOLDER)) {
       // The deferred child was created in place of the placeholder.
+      // NOTE: we intentionally do NOT call registerPropsUpdate() here (unlike
+      // the normal path below). `materialised` is the child's own element,
+      // created via upsertChild -> createComponent, which already registered
+      // its own props-update fn keyed to the child. Registering the *parent's*
+      // here would be wrong: the parent's init replaces a `data-bf-ph`
+      // placeholder via upsertChild, and re-running it on `materialised` (whose
+      // placeholder is already gone) would not re-materialise correctly.
+      // This divergence is unreachable in practice: reconcileList reuses items
+      // by recreating them through renderItem (see reconcile-elements.ts), and
+      // getPropsUpdateFn/getComponentProps have no in-repo callers.
       setCurrentScope(prevScope)
       hydratedScopes.add(materialised)
       propsMap.set(materialised, props)

--- a/packages/client/src/runtime/component.ts
+++ b/packages/client/src/runtime/component.ts
@@ -11,7 +11,7 @@ import { getRegisteredDef } from './hydrate'
 import { hydratedScopes } from './hydration-state'
 import { untrack } from '@barefootjs/client/reactive'
 import { setCurrentScope } from './context'
-import { BF_SCOPE, BF_KEY, BF_HOST, BF_AT, BF_PARENT_SCOPE_PLACEHOLDER } from '@barefootjs/shared'
+import { BF_SCOPE, BF_KEY, BF_HOST, BF_AT, BF_PARENT_SCOPE_PLACEHOLDER, BF_PLACEHOLDER } from '@barefootjs/shared'
 import type { ComponentDef } from './types'
 
 // Parent scope ID context for renderChild() inside insert() branch templates.
@@ -186,11 +186,41 @@ export function createComponent(
   // This allows context providers in initFn to store context on this element.
   const prevScope = setCurrentScope(element)
 
+  // 8b. Root-level deferred child (dropped-prop fix): a comment-wrapper
+  // parent whose entire render is a single deferred child renders as a
+  // bare `data-bf-ph` placeholder. The parent's init calls
+  // `upsertChild(__scope, ...)` which replaces the placeholder via
+  // `replaceWith` — but a detached root node can't replace itself in
+  // place. Park it in a throwaway wrapper so the replacement lands
+  // somewhere we can recover, then return the materialised child.
+  const rootIsDeferredPlaceholder = element.hasAttribute(BF_PLACEHOLDER)
+  let placeholderWrapper: HTMLElement | null = null
+  if (rootIsDeferredPlaceholder) {
+    placeholderWrapper = parseHTML('<div></div>').firstChild as HTMLElement
+    placeholderWrapper.appendChild(element)
+  }
+
   // 9. Initialize the component (context providers set up here).
   const initFn = getComponentInit(name)
   if (initFn) {
-    // Pass original props (with getters) for reactivity
+    // Pass original props (with getters) for reactivity. For a root
+    // deferred placeholder, init's `upsertChild(element, ...)` matches the
+    // placeholder element itself and replaces it inside the wrapper.
     initFn(element, props)
+  }
+
+  if (rootIsDeferredPlaceholder && placeholderWrapper) {
+    const materialised = placeholderWrapper.firstElementChild as HTMLElement | null
+    if (materialised && !materialised.hasAttribute(BF_PLACEHOLDER)) {
+      // The deferred child was created in place of the placeholder.
+      setCurrentScope(prevScope)
+      hydratedScopes.add(materialised)
+      propsMap.set(materialised, props)
+      return materialised
+    }
+    // Placeholder was not replaced (no init / no matching child): fall
+    // through with the original placeholder element detached from wrapper.
+    placeholderWrapper.removeChild(element)
   }
 
   // 10. Evaluate getter children and insert them.

--- a/packages/client/src/runtime/registry.ts
+++ b/packages/client/src/runtime/registry.ts
@@ -148,8 +148,14 @@ export function upsertChild(
     return ssr
   }
   // CSR: replace placeholder with a freshly-created component.
+  // The placeholder is normally a descendant of `parent`; but a
+  // comment-scope parent whose root IS the deferred child renders the
+  // placeholder as `parent` itself (no wrapper element), so match the
+  // parent element directly before falling back to a subtree query.
   const phId = slotId ?? name
-  const ph = parent.querySelector(`[data-bf-ph="${phId}"]`) as HTMLElement | null
+  const ph = (parent.getAttribute('data-bf-ph') === phId
+    ? (parent as HTMLElement)
+    : parent.querySelector(`[data-bf-ph="${phId}"]`)) as HTMLElement | null
   if (ph) {
     const slot = slotId ? buildSlotInfo(parent, slotId, anchorScope) : undefined
     const comp = createComponent(name, props, key, slot)

--- a/packages/client/src/runtime/registry.ts
+++ b/packages/client/src/runtime/registry.ts
@@ -5,7 +5,7 @@
  * Each component registers its init function so parents can initialize children with props.
  */
 
-import { BF_SCOPE, BF_HOST } from '@barefootjs/shared'
+import { BF_SCOPE, BF_HOST, BF_PLACEHOLDER } from '@barefootjs/shared'
 import { hydratedScopes } from './hydration-state'
 import { setCurrentScope } from './context'
 import { createComponent } from './component'
@@ -153,9 +153,9 @@ export function upsertChild(
   // placeholder as `parent` itself (no wrapper element), so match the
   // parent element directly before falling back to a subtree query.
   const phId = slotId ?? name
-  const ph = (parent.getAttribute('data-bf-ph') === phId
+  const ph = (parent.getAttribute(BF_PLACEHOLDER) === phId
     ? (parent as HTMLElement)
-    : parent.querySelector(`[data-bf-ph="${phId}"]`)) as HTMLElement | null
+    : parent.querySelector(`[${BF_PLACEHOLDER}="${phId}"]`)) as HTMLElement | null
   if (ph) {
     const slot = slotId ? buildSlotInfo(parent, slotId, anchorScope) : undefined
     const comp = createComponent(name, props, key, slot)

--- a/packages/jsx/src/__tests__/ir-to-client-js/reactivity.test.ts
+++ b/packages/jsx/src/__tests__/ir-to-client-js/reactivity.test.ts
@@ -23,6 +23,7 @@ function makeContext(overrides: Partial<ClientJsContext> = {}): ClientJsContext 
     loopElements: [],
     refElements: [],
     childInits: [],
+    deferredChildSlots: new Set(),
     reactiveProps: [],
     reactiveChildProps: [],
     reactiveAttrs: [],

--- a/packages/jsx/src/__tests__/staged-ir/06-multi-stage-soak.test.ts
+++ b/packages/jsx/src/__tests__/staged-ir/06-multi-stage-soak.test.ts
@@ -80,9 +80,24 @@ describe('Multi-stage soak (DeskCanvas-shape)', () => {
     expect(clientJs).toMatch(/import\s+\{[^}]*useYjs[^}]*\}\s+from\s+['"]\.\/useYjs['"]/)
   })
 
-  test('Module → Template: nodeTypes import IS visible to template', () => {
-    const { templateBody } = compile(DESK_CANVAS_SHAPE, 'DeskCanvas.tsx')
-    expect(templateBody).toMatch(/nodeTypes/)
+  test('Module → Init: nodeTypes is forwarded to the deferred child via init', () => {
+    // The `<Flow>` render carries init-scope-only props (`data-yjs={yjs.id}`
+    // where `yjs` is an init-local; `nodes={items()}`). The module-scope
+    // template lambda can't supply those, so the child render is DEFERRED
+    // to a `data-bf-ph` placeholder and `upsertChild` (→ createComponent)
+    // creates `Flow` with the COMPLETE getter props. The inlinable
+    // `nodeTypes` is therefore forwarded through the init `upsertChild`
+    // getter — never dropped — rather than baked into the template lambda.
+    // (Pre-fix this child was rendered eagerly via `renderChild('Flow', {
+    // nodeTypes })` with the init-scope props silently dropped — the
+    // dropped-prop bug.)
+    const { templateBody, initBody } = compile(DESK_CANVAS_SHAPE, 'DeskCanvas.tsx')
+    // Template defers the child render with a placeholder, not renderChild.
+    expect(templateBody).toMatch(/data-bf-ph="s0"/)
+    expect(templateBody).not.toMatch(/renderChild/)
+    // Init forwards nodeTypes (and every other prop) with complete values.
+    expect(initBody).toMatch(/upsertChild\(__scope,\s*'Flow',\s*'s0'/)
+    expect(initBody).toMatch(/get nodeTypes\(\)\s*\{\s*return nodeTypes\s*\}/)
   })
 
   // TODO(#1138 P3 5/N): `useYjs(...)` (init-local initializer) leaks into

--- a/packages/jsx/src/ir-to-client-js/emit-registration.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-registration.ts
@@ -168,7 +168,7 @@ export function emitRegistrationAndHydration(
     // transformation runs at this layer (#1277).
     const csrInlinableConstants = csrInlinableConstantsFromCtx(ctx)
     const templateHtml = generateCsrTemplate(
-      _ir.root, csrInlinableConstants, ctx, undefined, restSpreadNames, ctx.propsObjectName, unsafeLocalNames
+      _ir.root, csrInlinableConstants, ctx, undefined, restSpreadNames, ctx.propsObjectName, unsafeLocalNames, ctx.deferredChildSlots
     )
     if (templateHtml) {
       defParts.push(`template: (${PROPS_PARAM}) => \`${templateHtml}\``)

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -14,7 +14,8 @@ import { PROPS_PARAM } from './utils'
 import { buildReferencesGraph } from './build-references'
 import { computePropUsage } from './compute-prop-usage'
 import { IMPORT_PLACEHOLDER, MODULE_CONSTANTS_PLACEHOLDER } from './imports'
-import { emitRegistrationAndHydration } from './emit-registration'
+import { emitRegistrationAndHydration, csrInlinableConstantsFromCtx } from './emit-registration'
+import { computeDeferredChildSlots } from './html-template'
 import { emitChildComponentImports } from './child-components'
 import { classifyLocalDeclarations } from './init-declarations'
 import { emitModuleLevelDeclarations, resolveFinalImports } from './emit-module-level'
@@ -54,6 +55,20 @@ export function generateInitFunction(
   // diagnostics into `ctx.warnings`, so calling it twice would surface
   // duplicate warnings (#1247).
   const inlinability = buildInlinableConstants(ctx, graph, ir.root)
+
+  // Decide which direct child components must defer their render to init
+  // because a forwarded prop resolves to an init-scope-only / non-inlinable
+  // local (dropped-prop fix). The child-init phase reads this set to emit
+  // `upsertChild` instead of `initChild`; `emitRegistrationAndHydration`
+  // reads it to emit a `data-bf-ph` placeholder instead of
+  // `renderChild(...)`. Computed here, once `unsafeLocalNames` is known.
+  ctx.deferredChildSlots = computeDeferredChildSlots(
+    ir.root,
+    ctx,
+    csrInlinableConstantsFromCtx(ctx),
+    inlinability.unsafeLocalNames,
+    ctx.propsObjectName,
+  )
 
   // --- Emission: declarative phase pipeline. Each entry in `PHASES`
   //     declares its inputs (dependsOn) and emission action (run); the

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -2,7 +2,7 @@
  * IR → HTML template string generation and validation.
  */
 
-import type { AttrValue, IRAttribute, IRNode } from '../types'
+import type { AttrValue, IRAttribute, IRNode, IRProp } from '../types'
 import { isBooleanAttr } from '../html-constants'
 import { toHtmlAttrName, attrValueToString, quotePropName, PROPS_PARAM, DATA_BF_PH, keyAttrName, loopStartMarker, loopEndMarker, loopItemMarker, freeIdsFromRefs, setIntersects, wrapExprWithLoopParams } from './utils'
 import type { LoopParamSpec } from './utils'
@@ -962,6 +962,20 @@ export interface TemplateOptions {
   loopDepth?: number
   /** Emit `bf-s` placeholder on scoped elements inside a jsx-children prop (#1320). */
   inHoistedChildren?: boolean
+  /**
+   * Slot ids of direct child components whose render must be DEFERRED to
+   * init because at least one forwarded (non-`/* @client *\/`) prop value
+   * references an init-scope-only / non-inlinable local — the module-scope
+   * template lambda can't supply it, so eagerly calling `renderChild` with
+   * the prop dropped would make the child template read `undefined`.
+   *
+   * For these slots the CSR `component` case emits a `data-bf-ph`
+   * placeholder instead of `renderChild(...)`; the parent init replaces it
+   * via `upsertChild` (→ `createComponent` with the complete getter props).
+   * Computed up front by `computeDeferredChildSlots` so the init phase and
+   * the template phase agree on which children defer (dropped-prop fix).
+   */
+  deferredChildSlots?: ReadonlySet<string>
 }
 
 /**
@@ -1353,6 +1367,7 @@ export function generateCsrTemplate(
   restSpreadNames?: Set<string>,
   propsObjectName?: string | null,
   unsafeLocalNames?: Set<string>,
+  deferredChildSlots?: ReadonlySet<string>,
 ): string {
   // Build the substitution env once per component. Signals + memos come
   // from `buildSignalMemoEnv`; inlinable constants layer in here so
@@ -1367,7 +1382,128 @@ export function generateCsrTemplate(
       }
     }
   }
-  return generateCsrTemplateWithOpts(node, { inlinableConstants, restSpreadNames, propsObjectName, csrEnv, insideLoop, unsafeLocalNames, loopDepth: -1 })
+  return generateCsrTemplateWithOpts(node, { inlinableConstants, restSpreadNames, propsObjectName, csrEnv, insideLoop, unsafeLocalNames, deferredChildSlots, loopDepth: -1 })
+}
+
+/**
+ * Build the per-component CSR substitution env (signals + memos + inlinable
+ * constants), matching what `generateCsrTemplate` builds. Shared so the
+ * deferred-child analysis and the template emit agree on substitution
+ * results.
+ */
+function buildCsrEnvForCtx(
+  ctx: ClientJsContext,
+  inlinableConstants: Map<string, string> | undefined,
+  propsObjectName?: string | null,
+): CsrEnv {
+  const base = buildSignalMemoEnv(ctx.signals, ctx.memos, propsObjectName ?? null)
+  const csrEnv: CsrEnv = { substitutions: new Map(base.substitutions), propsObjectName: base.propsObjectName }
+  if (inlinableConstants) {
+    for (const [name, value] of inlinableConstants) {
+      if (!csrEnv.substitutions.has(name)) {
+        csrEnv.substitutions.set(name, { kind: 'identifier', replacement: value, freeIdentifiers: new Set() })
+      }
+    }
+  }
+  return csrEnv
+}
+
+/**
+ * Decide whether a single forwarded component prop value would be DROPPED
+ * by the CSR `component` emit — i.e. after `csrSubstitute` its expression
+ * still references a name in `unsafeLocalNames`. Mirrors the
+ * `transformExpr` UNSAFE gate so the deferral analysis matches the actual
+ * template output exactly.
+ */
+function propResolvesUnsafe(
+  prop: IRProp,
+  env: CsrEnv,
+  unsafeLocalNames: ReadonlySet<string>,
+): boolean {
+  if (unsafeLocalNames.size === 0) return false
+  let source: string | undefined
+  switch (prop.value.kind) {
+    case 'expression':
+    case 'spread':
+      source = prop.value.expr
+      break
+    case 'template':
+      source = attrValueToString(prop.value, { useTemplate: true }) ?? undefined
+      break
+    default:
+      // literal / boolean / jsx-children carry no init-scope identifiers.
+      return false
+  }
+  if (!source) return false
+  const { freeIdentifiers } = csrSubstitute(source, env)
+  return setIntersects(freeIdentifiers, unsafeLocalNames)
+}
+
+/**
+ * Walk the component IR and collect the slot ids of DIRECT child
+ * components whose render must be deferred to init because at least one
+ * forwarded (non-`/* @client *\/`, non-event) prop resolves to an
+ * init-scope-only / non-inlinable local. The module-scope CSR template
+ * lambda can't supply such a value, so `renderChild(...)` would drop the
+ * prop and the child template would read `undefined` and throw.
+ *
+ * Only top-level (non-loop, non-clientOnly-conditional) children are
+ * considered — those are the ones rendered via the `renderChild(...)` form
+ * in the registration template and wired through `ctx.childInits`. Loop /
+ * conditional-branch children already go through their own
+ * placeholder + `createComponent` materialize paths.
+ */
+export function computeDeferredChildSlots(
+  node: IRNode,
+  ctx: ClientJsContext,
+  inlinableConstants: Map<string, string> | undefined,
+  unsafeLocalNames: ReadonlySet<string> | undefined,
+  propsObjectName?: string | null,
+): Set<string> {
+  const deferred = new Set<string>()
+  if (!unsafeLocalNames || unsafeLocalNames.size === 0) return deferred
+  const env = buildCsrEnvForCtx(ctx, inlinableConstants, propsObjectName)
+
+  const visit = (n: IRNode): void => {
+    switch (n.type) {
+      case 'component': {
+        if (n.name === 'Portal') {
+          n.children.forEach(visit)
+          return
+        }
+        if (n.slotId) {
+          const dropped = n.props.some(p => {
+            if (p.name === '...' || p.name.startsWith('...') || p.name === 'key') return false
+            if (p.name.startsWith('on') && p.name.length > 2 && p.name[2] === p.name[2].toUpperCase()) return false
+            if (p.clientOnly) return false
+            return propResolvesUnsafe(p, env, unsafeLocalNames)
+          })
+          if (dropped) deferred.add(n.slotId)
+        }
+        // Do not descend into a component's JSX-children props here: those
+        // children render in the parent scope only when hoisted, and the
+        // deferral concern is the direct child component's own props.
+        return
+      }
+      case 'element':
+        n.children.forEach(visit)
+        return
+      case 'fragment':
+        n.children.forEach(visit)
+        return
+      case 'conditional':
+        // Conditional branch children are handled by the branch
+        // materialize path, not the top-level renderChild form.
+        return
+      case 'loop':
+        // Loop children go through the loop materialize path.
+        return
+      default:
+        return
+    }
+  }
+  visit(node)
+  return deferred
 }
 
 function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): string {
@@ -1540,6 +1676,18 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
     case 'component': {
       if (node.name === 'Portal') {
         return node.children.map(recurse).join('')
+      }
+
+      // Deferred child (dropped-prop fix): at least one forwarded prop
+      // resolves to an init-scope-only local the module-scope template
+      // lambda can't supply. Emitting `renderChild('Child', { /* prop
+      // dropped */ })` would make the child template read `undefined` and
+      // throw. Emit a `data-bf-ph` placeholder instead — the parent init
+      // resolves it via `upsertChild` → `createComponent` with the full
+      // getter props (mirrors the `irToPlaceholderTemplate` deferral and
+      // the clientOnly-conditional empty-marker precedent).
+      if (node.slotId && opts.deferredChildSlots?.has(node.slotId)) {
+        return `<div ${DATA_BF_PH}="${node.slotId}"></div>`
       }
 
       const propsEntries = node.props

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -1473,6 +1473,12 @@ export function computeDeferredChildSlots(
         }
         if (n.slotId) {
           const dropped = n.props.some(p => {
+            // Spread props (`...`) are forwarded via the rest-spread path
+            // (`restSpreadNames`), not the per-prop inline form, so they are
+            // out of scope for this drop check; `key` and event handlers
+            // (`onX`) likewise never carry init-scope render values. This
+            // filter set MUST mirror the `propsEntries` filter in the CSR
+            // `component` emit below so the deferral decision matches output.
             if (p.name === '...' || p.name.startsWith('...') || p.name === 'key') return false
             if (p.name.startsWith('on') && p.name.length > 2 && p.name[2] === p.name[2].toUpperCase()) return false
             if (p.clientOnly) return false

--- a/packages/jsx/src/ir-to-client-js/index.ts
+++ b/packages/jsx/src/ir-to-client-js/index.ts
@@ -176,6 +176,7 @@ function createContext(
     loopElements: [],
     refElements: [],
     childInits: [],
+    deferredChildSlots: new Set(),
     reactiveProps: [],
     reactiveChildProps: [],
     reactiveAttrs: [],

--- a/packages/jsx/src/ir-to-client-js/phases/provider-and-child-inits.ts
+++ b/packages/jsx/src/ir-to-client-js/phases/provider-and-child-inits.ts
@@ -28,8 +28,19 @@ export function emitProviderAndChildInits(lines: string[], ctx: ClientJsContext)
     lines.push('')
     lines.push(`  // Initialize child components with props`)
     for (const child of ctx.childInits) {
+      const registryName = nameForRegistryRef(child.name)
+      // Deferred child (dropped-prop fix): the registration template emits
+      // a `data-bf-ph` placeholder for this slot rather than rendering it.
+      // `upsertChild` resolves both shapes — an existing SSR scope (→
+      // initChild) or the placeholder (→ createComponent with the full
+      // getter props). Use it so the child is created/initialised with
+      // complete props instead of running against a missing prop.
+      if (child.slotId && ctx.deferredChildSlots.has(child.slotId)) {
+        lines.push(`  upsertChild(__scope, '${registryName}', '${child.slotId}', ${child.propsExpr})`)
+        continue
+      }
       const scopeRef = child.slotId ? `_${varSlotId(child.slotId)}` : '__scope'
-      lines.push(`  initChild('${nameForRegistryRef(child.name)}', ${scopeRef}, ${child.propsExpr})`)
+      lines.push(`  initChild('${registryName}', ${scopeRef}, ${child.propsExpr})`)
     }
   }
 }

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -59,6 +59,16 @@ export interface ClientJsContext {
   loopElements: TopLevelLoop[]
   refElements: RefElement[]
   childInits: ChildInit[]
+  /**
+   * Slot ids of direct child components whose render is DEFERRED to init
+   * (dropped-prop fix). For these, the CSR registration template emits a
+   * `data-bf-ph` placeholder instead of `renderChild(...)`, and the init
+   * body uses `upsertChild` (→ `createComponent` with full getter props)
+   * instead of `initChild`. Computed in `generateInitFunction` once
+   * `unsafeLocalNames` is known, then read by the child-init phase and the
+   * registration-template emit so both agree on which children defer.
+   */
+  deferredChildSlots: Set<string>
   reactiveProps: ReactiveComponentProp[]
   reactiveChildProps: ReactiveChildProp[]
   reactiveAttrs: ReactiveAttribute[]


### PR DESCRIPTION
## The bug

When a parent component passed a **non-statically-inlinable** value as a prop to a child component, that prop was **dropped** from the `renderChild(...)` call in the parent's CSR template lambda. The child's template then rendered against missing props and threw at runtime, e.g. `Cannot read properties of undefined (reading 'filter')`.

### Root cause

The module-scope template lambda renders children via `renderChild('Child', <propsObj>)` **before** `init` runs. It can only forward prop values that are statically inlinable (literals baked into the template). A runtime-computed value (e.g. `Array.from(...)`, or an init-scope local) cannot be inlined, and the variable holding it is not in the template lambda's scope, so the prop was emitted as `{}`. The value WAS correctly deferred to `initChild` via a `get prop() { return <expr> }` getter, but the child's template (invoked eagerly by `renderChild`) read the prop first and crashed.

### 4-case repro matrix

`{module, local} x {literal, Array.from}` with a child that reads `props.rows.filter(...)`:

- **A** module-literal → `renderChild('Child', {rows: ([...])})` ✅ (literal baked in)
- **B** local-literal → `renderChild('Child', {rows: ([...])})` ✅
- **C** module-`Array.from` → `renderChild('Child', {})` ❌ dropped → crash
- **D** local-`Array.from` → `renderChild('Child', {})` ❌ dropped → crash

## The fix

When a forwarded (non-`/* @client */`, non-event) prop resolves — after CSR substitution — to a name in `unsafeLocalNames`, the child's render is **deferred** instead of eagerly rendered with partial props:

- The registration template emits a `data-bf-ph` placeholder (the existing deferral marker) instead of `renderChild(...)`.
- The parent `init` uses `upsertChild` (→ `createComponent` with the complete getter props) instead of `initChild`.

This mirrors the established precedent: clientOnly conditionals emit empty markers and let `init` fill them (`html-template.ts`), and loop/branch children already route through a placeholder + `createComponent` materialize path.

`computeDeferredChildSlots` decides the deferred set once `unsafeLocalNames` is known, so the init phase and the template phase agree on which children defer. SSR adapters (Hono, Go) are unaffected — they render child props from the parent's own render scope, never the module-scope CSR lambda.

Two small runtime adjustments support the root case (a comment-scope parent whose entire render is a single deferred child):
- `upsertChild` now matches a `data-bf-ph` placeholder that is the parent element itself.
- `createComponent` parks a root-level deferred placeholder in a throwaway wrapper so init's `upsertChild` replacement can materialise it, then returns the materialised child.

### Result

All four cases now forward the prop (A/B unchanged inline; C/D defer to a placeholder + `upsertChild` with complete getter props, so the child is created with full props and never sees `undefined`).

## Test layer

Per CLAUDE.md / `spec/testing.md`, this is "Client JS → correct DOM output", verified end-to-end as a CSR runtime regression (compile → register via the real runtime → `createComponent` → assert DOM):

`packages/client/__tests__/runtime/renderchild-noninlinable-props.test.ts` — covers the full 4-case matrix. Fails before the fix (C/D throw `_p.rows.filter` on undefined), passes after.

The multi-stage soak test (`06-multi-stage-soak.test.ts`), which uses this exact dropped-prop shape, is updated to assert the corrected deferred behaviour (placeholder template + `upsertChild` forwarding `nodeTypes` with complete props).

## Suite results

- `packages/client`: 333 pass, 0 fail
- `packages/jsx`: 1860 pass, 4 fail — the 4 failures are pre-existing `aliased * resolves via checker` resolver-migration tests that also fail on `main` (unrelated to this change)
- `packages/adapter-tests`: 601 pass, 0 fail
- `tsc --noEmit` clean for both `packages/jsx` and `packages/client`

https://claude.ai/code/session_01TXJixHjqkqNZ22AjhFHhwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01TXJixHjqkqNZ22AjhFHhwA)_