### PR TITLE
fix(compiler): hydrate nested component .map() inside a component-rooted loop item (#1725)

### DIFF
--- a/.changeset/fix-nested-map-component-rooted-loop-item.md
+++ b/.changeset/fix-nested-map-component-rooted-loop-item.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix silent missing hydration for a nested `.map()` of child components inside a **component-rooted** loop item (#1725). When a `.map()`'s item root was itself a child component (a passthrough wrapper like `SelectGroup`) whose JSX `children` contained a nested `.map()` of components (e.g. `SelectItem`), the parent init emitted `initChild()` only for the outer wrapper — never descending into its children to initialize the inner-loop component instances. They rendered from SSR but never hydrated (no error, just inert event handlers).
+
+The compiler now collects inner loops inside a child-component loop item and emits a document-order zip (`qsaChildScopes` + per-component cursor over the flattened `outer.forEach(o => inner.forEach(i => ...))` iteration). This addresses the inner components by their slot selector rather than element offsets, so it works whether the wrapper component's root is an element (`<div>{children}</div>`) or a fragment (`<>{children}</>`) — the latter emits no per-group wrapper element to index.

--- a/packages/client/__tests__/runtime/issue-1725-hydration.test.ts
+++ b/packages/client/__tests__/runtime/issue-1725-hydration.test.ts
@@ -43,7 +43,7 @@ export function Group(props: { children?: any }) { return <>{props.children}</> 
 const DIV_GROUP = `'use client'
 export function Group(props: { children?: any }) { return <div role="group">{props.children}</div> }`
 
-function reproSource(groupImport: string): string {
+function reproSource(): string {
   return `'use client'
 import { Group } from './Group'
 import { Item } from './Item'
@@ -88,7 +88,7 @@ async function setupHydration(groupSource: string): Promise<{ hydrate: () => voi
   const modules: Array<[string, string, string]> = [
     [ITEM, 'Item.tsx', 'Item'],
     [groupSource, 'Group.tsx', 'Group'],
-    [reproSource(groupSource), 'Repro.tsx', 'Repro'],
+    [reproSource(), 'Repro.tsx', 'Repro'],
   ]
   for (const [source, filename, name] of modules) {
     const file = join(dir, `${name}.mjs`)
@@ -99,7 +99,7 @@ async function setupHydration(groupSource: string): Promise<{ hydrate: () => voi
   // Real SSR HTML (Hono adapter) — same markup a server would send.
   const ssrHtml = await renderHonoComponent({
     adapter: new HonoAdapter(),
-    source: reproSource(groupSource),
+    source: reproSource(),
     components: { './Group.tsx': groupSource, './Item.tsx': ITEM },
     // Root scope must carry a `Name_` prefix so the hydration walk resolves
     // it to the registered `Repro` def (`scopeName` splits on the first `_`).

--- a/packages/client/__tests__/runtime/issue-1725-hydration.test.ts
+++ b/packages/client/__tests__/runtime/issue-1725-hydration.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Integration test for #1725: a `.map()` whose item root is a **child
+ * component** (`Group`) whose `children` contain a nested `.map()` of
+ * **child components** (`Item`) must hydrate the inner components.
+ *
+ * Before the fix the parent init emitted `initChild('Group', ...)` for the
+ * outer loop item but never descended into the component's children to
+ * initialize the inner-loop `Item` instances — they rendered from SSR but
+ * never attached their event handlers (silent, no error).
+ *
+ * This test compiles the real components, renders the real SSR HTML via the
+ * Hono adapter, drops it into the document, runs the generated `hydrate`
+ * walk, then clicks an inner `Item` button and asserts its signal-backed
+ * counter increments — observable proof that the inner components hydrated.
+ */
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import { compileJSX } from '../../../jsx/src/compiler'
+import { TestAdapter } from '../../../jsx/src/adapters/test-adapter'
+import { renderHonoComponent } from '../../../adapter-hono/src/test-render'
+import { HonoAdapter } from '../../../adapter-hono/src/adapter/hono-adapter'
+import { writeFileSync, mkdtempSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') GlobalRegistrator.register()
+})
+
+const adapter = new TestAdapter()
+const runtimePath = join(__dirname, '../../src/runtime/index.ts')
+
+const ITEM = `'use client'
+import { createSignal } from '@barefootjs/client'
+export function Item(props: { label: string }) {
+  const [count, setCount] = createSignal(0)
+  return <button onClick={() => setCount(c => c + 1)}>{props.label}: {count()}</button>
+}`
+
+const FRAGMENT_GROUP = `'use client'
+export function Group(props: { children?: any }) { return <>{props.children}</> }`
+
+const DIV_GROUP = `'use client'
+export function Group(props: { children?: any }) { return <div role="group">{props.children}</div> }`
+
+function reproSource(groupImport: string): string {
+  return `'use client'
+import { Group } from './Group'
+import { Item } from './Item'
+const GROUPS = [
+  { id: 'a', items: [{ id: 'a1', label: 'A1' }, { id: 'a2', label: 'A2' }] },
+  { id: 'b', items: [{ id: 'b1', label: 'B1' }, { id: 'b2', label: 'B2' }] },
+]
+export function Repro() {
+  return (
+    <div>
+      {GROUPS.map(group => (
+        <Group key={group.id}>
+          {group.items.map(it => (
+            <Item key={it.id} label={it.label} />
+          ))}
+        </Group>
+      ))}
+    </div>
+  )
+}`
+}
+
+/** Compile a component's client JS with imports re-anchored to the live runtime. */
+function clientJsFor(source: string, filename: string): string {
+  const result = compileJSX(source, filename, { adapter })
+  const errors = result.errors.filter(e => e.severity === 'error')
+  if (errors.length > 0) {
+    throw new Error(`Compile errors in ${filename}:\n${errors.map(e => `${e.code}: ${e.message}`).join('\n')}`)
+  }
+  const clientJs = result.files.find(f => f.type === 'clientJs')?.content
+  if (!clientJs) throw new Error(`No client JS for ${filename}`)
+  return clientJs
+    .replace(/from\s+['"]@barefootjs\/client\/runtime['"]/g, `from '${runtimePath}'`)
+    .replace(/^import '\/\* @bf-child:\w+ \*\/'\n/gm, '')
+}
+
+async function setupHydration(groupSource: string): Promise<{ hydrate: () => void }> {
+  // Register Item + Group + Repro defs (template + init) with the runtime.
+  // Each module is imported separately so their (overlapping) runtime import
+  // lines don't collide in one module scope.
+  const dir = mkdtempSync(join(tmpdir(), 'bf-1725-'))
+  const modules: Array<[string, string, string]> = [
+    [ITEM, 'Item.tsx', 'Item'],
+    [groupSource, 'Group.tsx', 'Group'],
+    [reproSource(groupSource), 'Repro.tsx', 'Repro'],
+  ]
+  for (const [source, filename, name] of modules) {
+    const file = join(dir, `${name}.mjs`)
+    writeFileSync(file, clientJsFor(source, filename))
+    await import(file)
+  }
+
+  // Real SSR HTML (Hono adapter) — same markup a server would send.
+  const ssrHtml = await renderHonoComponent({
+    adapter: new HonoAdapter(),
+    source: reproSource(groupSource),
+    components: { './Group.tsx': groupSource, './Item.tsx': ITEM },
+    // Root scope must carry a `Name_` prefix so the hydration walk resolves
+    // it to the registered `Repro` def (`scopeName` splits on the first `_`).
+    props: { __instanceId: 'Repro_test' },
+  })
+  document.body.innerHTML = ssrHtml
+
+  // The `hydrate()` calls during module import already scheduled (and, after
+  // the awaits, drained) a walk against the then-empty body. Re-trigger a
+  // walk now that the SSR markup is in place, then drain it synchronously.
+  const { rehydrateAll, flushHydration } = await import(runtimePath)
+  return {
+    hydrate: () => {
+      rehydrateAll()
+      flushHydration()
+    },
+  }
+}
+
+describe('#1725 — nested component .map() inside a component-rooted loop item hydrates', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('fragment-rooted passthrough: all four inner Item buttons become interactive', async () => {
+    const { hydrate } = await setupHydration(FRAGMENT_GROUP)
+    hydrate()
+
+    const buttons = Array.from(document.querySelectorAll('button'))
+    expect(buttons.map(b => b.textContent)).toEqual([
+      'A1: 0', 'A2: 0', 'B1: 0', 'B2: 0',
+    ])
+
+    // Click each button once — counters must increment, proving each Item
+    // (including 2nd+ group members) attached its onClick handler.
+    for (const button of buttons) {
+      button.dispatchEvent(new window.Event('click', { bubbles: true }))
+    }
+
+    expect(buttons.map(b => b.textContent)).toEqual([
+      'A1: 1', 'A2: 1', 'B1: 1', 'B2: 1',
+    ])
+  })
+
+  test('element-rooted passthrough: inner Item buttons become interactive', async () => {
+    const { hydrate } = await setupHydration(DIV_GROUP)
+    hydrate()
+
+    const buttons = Array.from(document.querySelectorAll('button'))
+    expect(buttons.map(b => b.textContent)).toEqual([
+      'A1: 0', 'A2: 0', 'B1: 0', 'B2: 0',
+    ])
+
+    buttons[2].dispatchEvent(new window.Event('click', { bubbles: true }))
+
+    expect(buttons.map(b => b.textContent)).toEqual([
+      'A1: 0', 'A2: 0', 'B1: 1', 'B2: 0',
+    ])
+  })
+})

--- a/packages/jsx/src/__tests__/child-components-in-map.test.ts
+++ b/packages/jsx/src/__tests__/child-components-in-map.test.ts
@@ -1181,4 +1181,88 @@ describe('child components inside .map() (#344)', () => {
     expect(content).toContain('const __compEl =')
     expect(content).not.toContain('__compEl0')
   })
+
+  describe('nested .map() inside a component-rooted loop item (#1725)', () => {
+    // The outer loop item root is a *component* (a passthrough wrapper like
+    // `SelectGroup`), not an element. Its JSX children contain a nested
+    // `.map()` of components. The parent init emitted `initChild` for the
+    // outer wrapper but never descended into its children to init the inner
+    // loop's components — they rendered from SSR but never hydrated (silent).
+    test('emits initChild for the inner-loop component (component wrapper)', () => {
+      const source = `
+        'use client'
+
+        export function Repro() {
+          const GROUPS = [
+            { id: 'a', items: [{ id: 'a1', label: 'A1' }] },
+            { id: 'b', items: [{ id: 'b1', label: 'B1' }] },
+          ]
+          return (
+            <div>
+              {GROUPS.map(group => (
+                <Group key={group.id}>
+                  {group.items.map(it => (
+                    <Item key={it.id} label={it.label} />
+                  ))}
+                </Group>
+              ))}
+            </div>
+          )
+        }
+      `
+      const result = compileJSX(source, 'Repro.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const content = result.files.find(f => f.type === 'clientJs')!.content
+      // Both the outer wrapper and the inner-loop component must init.
+      expect(content).toContain("initChild('Group'")
+      expect(content).toContain("initChild('Item'")
+      // The inner component's props read the inner loop param.
+      expect(content).toContain('return it.label')
+      // Document-order zip shape — a flat cursor over the queried scopes
+      // pairs each with its data item across the nested forEach. This shape
+      // is fragment-root safe (no per-group wrapper element to index).
+      expect(content).toContain('qsaChildScopes')
+      expect(content).toMatch(/__compScopes\[__ci\+\+\]/)
+      // No element-offset addressing (`__outerEl = ...children[...]`) — that
+      // would break for a fragment-rooted passthrough.
+      expect(content).not.toContain('__outerEl')
+    })
+
+    test('multiple inner components each get their own document-order cursor', () => {
+      const source = `
+        'use client'
+
+        export function Repro() {
+          const GROUPS = [{ id: 'a', items: [{ id: 'a1', label: 'A1' }] }]
+          return (
+            <div>
+              {GROUPS.map(group => (
+                <Group key={group.id}>
+                  {group.items.map(it => (
+                    <>
+                      <Item key={it.id} label={it.label} />
+                      <Badge text={it.label} />
+                    </>
+                  ))}
+                </Group>
+              ))}
+            </div>
+          )
+        }
+      `
+      const result = compileJSX(source, 'Repro.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const content = result.files.find(f => f.type === 'clientJs')!.content
+      expect(content).toContain("initChild('Item'")
+      expect(content).toContain("initChild('Badge'")
+      // Distinct scope arrays + cursors so each comp consumes its own
+      // document-order stream (no `const __compEl` redeclaration, #1664).
+      expect(content).toContain('__compScopes0')
+      expect(content).toContain('__compScopes1')
+      expect(content).toMatch(/__ci0\+\+/)
+      expect(content).toMatch(/__ci1\+\+/)
+    })
+  })
 })

--- a/packages/jsx/src/ir-to-client-js/collect-elements.ts
+++ b/packages/jsx/src/ir-to-client-js/collect-elements.ts
@@ -428,9 +428,15 @@ function decideLoopRendering(
   ctx: ClientJsContext | undefined,
 ): { useElementReconciliation: boolean; innerLoops: NestedLoop[] | undefined } {
   const hasNestedComps = (loop.nestedComponents?.length ?? 0) > 0
-  const innerLoops = !loop.childComponent
-    ? collectInnerLoops(loop.children, siblingOffsets, loop.param, ctx)
-    : undefined
+  // Collect inner loops even when the outer item is a child component
+  // (#1725): a `.map()` of components living inside the child component's
+  // JSX children (e.g. `<SelectGroup>{items.map(...)}</SelectGroup>`) needs
+  // its own `initChild` pass. `loop.children` is the single child-component
+  // node; `collectInnerLoops` descends into its children to find the nested
+  // loop. These only surface for static arrays (gated at the call site via
+  // `isStaticArray && innerLoops.length`) so dynamic child-component loops —
+  // which render through `createComponent` — are unaffected.
+  const innerLoops = collectInnerLoops(loop.children, siblingOffsets, loop.param, ctx)
   const hasInnerLoops = (innerLoops?.length ?? 0) > 0
   const useElementReconciliation =
     !loop.childComponent && !loop.isStaticArray && (hasNestedComps || hasInnerLoops)

--- a/packages/jsx/src/ir-to-client-js/plan/build-static-array-child-init.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/build-static-array-child-init.ts
@@ -8,6 +8,10 @@
  *   2. `outer-nested` for each depth-0 entry in `elem.nestedComponents`.
  *   3. `inner-loop-nested` for each `elem.innerLoops` entry that has
  *      matching depth-N components.
+ *   4. `component-rooted-inner-loop` instead of (3) when the outer item is
+ *      itself a child component (#1725) — the inner `.map()` lives inside
+ *      the component's JSX children, so it's addressed by a document-order
+ *      zip rather than element offsets.
  *
  * Selector / propsExpr / offset decisions all resolve here. The
  * stringifier never inspects raw IR.
@@ -23,6 +27,7 @@ import { buildCompSelector } from '../control-flow/shared'
 /** The inline prop shape carried on `IRLoopChildComponent.props`. */
 type LoopChildCompProp = IRLoopChildComponent['props'][number]
 import type {
+  ComponentRootedInnerLoopInitPlan,
   InnerLoopComp,
   InnerLoopNestedInitPlan,
   OuterNestedInitPlan,
@@ -56,7 +61,16 @@ export function buildStaticArrayChildInitsPlan(
             (c.loopDepth ?? 0) === innerLoop.depth && c.innerLoopArray === innerLoop.array,
           )
           if (innerComps.length === 0) continue
-          plans.push(buildInnerLoopNestedPlan(elem, innerLoop, innerComps))
+          // Component-rooted outer item (#1725): the inner `.map()` lives
+          // inside the child component's JSX children. The element-offset
+          // addressing of `inner-loop-nested` can't reach a fragment-rooted
+          // passthrough's flattened items, so use the document-order zip
+          // shape instead.
+          plans.push(
+            elem.childComponent
+              ? buildComponentRootedInnerLoopPlan(elem, innerLoop, innerComps)
+              : buildInnerLoopNestedPlan(elem, innerLoop, innerComps),
+          )
         }
       }
     }
@@ -128,6 +142,31 @@ function buildInnerLoopNestedPlan(
     innerArrayExpr: innerLoop.array,
     innerParam: innerLoop.param,
     innerOffsetExpr: buildLoopChildIndexExpr('__innerIdx', innerLoop.offset),
+    innerPreludeStatements: innerLoop.mapPreamble ? [innerLoop.mapPreamble] : [],
+    depth: innerLoop.depth,
+    comps,
+  }
+}
+
+function buildComponentRootedInnerLoopPlan(
+  elem: TopLevelLoop,
+  innerLoop: NestedLoop,
+  innerComps: readonly IRLoopChildComponent[],
+): ComponentRootedInnerLoopInitPlan {
+  const comps: InnerLoopComp[] = innerComps.map(comp => ({
+    componentName: comp.name,
+    selector: buildCompSelector(comp),
+    propsExpr: buildStaticPropsExpr(comp.props),
+  }))
+
+  return {
+    kind: 'component-rooted-inner-loop',
+    containerVar: `_${varSlotId(elem.slotId)}`,
+    outerArrayExpr: elem.array,
+    outerParam: elem.param,
+    outerPreludeStatements: elem.mapPreamble ? [elem.mapPreamble] : [],
+    innerArrayExpr: innerLoop.array,
+    innerParam: innerLoop.param,
     innerPreludeStatements: innerLoop.mapPreamble ? [innerLoop.mapPreamble] : [],
     depth: innerLoop.depth,
     comps,

--- a/packages/jsx/src/ir-to-client-js/plan/build-static-array-child-init.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/build-static-array-child-init.ts
@@ -148,6 +148,21 @@ function buildInnerLoopNestedPlan(
   }
 }
 
+/**
+ * Build the document-order-zip plan for an inner `.map()` of components living
+ * inside a component-rooted loop item (#1725).
+ *
+ * Known limitation (shared with `inner-loop-nested`): the emitted `forEach`
+ * iterates `innerLoop.array` — the *base* inner array. `NestedLoop` doesn't
+ * carry `filterPredicate` / `sortComparator`, so a `.filter()` / `.sort()` on
+ * the inner `.map()` makes the iteration order diverge from the SSR render
+ * order. `inner-loop-nested` masks this per-group (each group re-indexes
+ * `__ic.children` from 0, so a trailing filtered-out item just reads
+ * `undefined`); the zip's single document-order cursor instead misaligns every
+ * later group. Both are wrong for non-trailing filtered items — filter/sort on
+ * a nested static-array loop is unsupported across this family, not a
+ * regression introduced here.
+ */
 function buildComponentRootedInnerLoopPlan(
   elem: TopLevelLoop,
   innerLoop: NestedLoop,

--- a/packages/jsx/src/ir-to-client-js/plan/static-array-child-init.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/static-array-child-init.ts
@@ -1,5 +1,5 @@
 /**
- * Plan types for `emitStaticArrayChildInits` — the three shapes that
+ * Plan types for `emitStaticArrayChildInits` — the shapes that
  * `static array` loops emit for child component initialisation:
  *
  *   - `single-comp`        — `loop.childComponent` ケース。一つの child component
@@ -8,6 +8,13 @@
  *                            `__iterEl.querySelector(...)` 経由で initChild。
  *   - `inner-loop-nested`  — depth > 0 の `nestedComponents`。outer + inner
  *                            forEach の二重ループで initChild。
+ *   - `component-rooted-inner-loop`
+ *                          — outer の loop item root が **child component**
+ *                            (`loop.childComponent`) で、その JSX children に
+ *                            component の nested `.map()` を持つケース (#1725)。
+ *                            element offset では fragment-root passthrough の
+ *                            flatten 済み items に届かないため、document order
+ *                            の zip (`qsaChildScopes` + cursor) で initChild。
  *
  * All decisions (selector, propsExpr, offset expressions) are resolved at
  * build time so the stringifier becomes a deterministic walk.
@@ -129,9 +136,48 @@ export interface InnerLoopNestedInitPlan {
   comps: readonly InnerLoopComp[]
 }
 
+/**
+ * Plan for an inner `.map()` of components living inside a **component-rooted**
+ * outer loop item (#1725). The outer loop body is a single child component
+ * (`loop.childComponent`, e.g. a `SelectGroup` passthrough) whose JSX
+ * `children` contain a nested `.map()` of components (e.g. `SelectItem`).
+ *
+ * `inner-loop-nested` can't be reused here: it addresses inner components via
+ * `containerVar.children[outerOffset]`, which assumes the outer loop item is a
+ * DOM **element**. A fragment-rooted passthrough component (`<>{children}</>`)
+ * emits no wrapper element, so its rendered items are flattened directly under
+ * the parent container with no per-group element to index.
+ *
+ * Instead this shape zips the inner component scopes — found in document order
+ * via `qsaChildScopes(container, <selector>)` — against the flattened
+ * `outer.forEach(o => inner.forEach(i => ...))` iteration. Document order is
+ * the SSR render order, so position `__ci++` pairs each scope with its data
+ * item regardless of whether the outer component root is an element or a
+ * fragment.
+ */
+export interface ComponentRootedInnerLoopInitPlan {
+  kind: 'component-rooted-inner-loop'
+  containerVar: string
+  /** Outer loop's array expression. */
+  outerArrayExpr: string
+  outerParam: string
+  /** Outer `.map()` callback preamble locals (#1064). */
+  outerPreludeStatements: PreludeStatements
+  /** Inner loop's array expression (references the outer param). */
+  innerArrayExpr: string
+  innerParam: string
+  /** Inner `.map()` callback preamble locals (#1064). */
+  innerPreludeStatements: PreludeStatements
+  /** Depth used in the leading comment line. */
+  depth: number
+  /** Per-component initialisers emitted inside the inner forEach body. */
+  comps: readonly InnerLoopComp[]
+}
+
 export type StaticArrayChildInitPlan =
   | SingleCompInitPlan
   | OuterNestedInitPlan
   | InnerLoopNestedInitPlan
+  | ComponentRootedInnerLoopInitPlan
 
 export type StaticArrayChildInitsPlan = readonly StaticArrayChildInitPlan[]

--- a/packages/jsx/src/ir-to-client-js/stringify/static-array-child-init.ts
+++ b/packages/jsx/src/ir-to-client-js/stringify/static-array-child-init.ts
@@ -50,6 +50,7 @@
  */
 
 import type {
+  ComponentRootedInnerLoopInitPlan,
   InnerLoopNestedInitPlan,
   OuterNestedInitPlan,
   SingleCompInitPlan,
@@ -77,6 +78,9 @@ function stringifyOne(lines: string[], plan: StaticArrayChildInitPlan): void {
       break
     case 'inner-loop-nested':
       emitInnerLoopNested(lines, plan)
+      break
+    case 'component-rooted-inner-loop':
+      emitComponentRootedInnerLoop(lines, plan)
       break
   }
 }
@@ -168,6 +172,71 @@ function emitInnerLoopNested(lines: string[], plan: InnerLoopNestedInitPlan): vo
     const compElVar = comps.length > 1 ? `__compEl${i}` : '__compEl'
     lines.push(`        const ${compElVar} = qsaChildScope(__innerEl, ${comp.selector})`)
     lines.push(`        if (${compElVar}) initChild('${nameForRegistryRef(comp.componentName)}', ${compElVar}, ${comp.propsExpr})`)
+  })
+  lines.push(`      })`)
+  lines.push(`    })`)
+  lines.push(`  }`)
+  lines.push('')
+}
+
+/**
+ * Emit shape for `component-rooted-inner-loop` (#1725):
+ *
+ *   <i>// Initialize component-rooted inner-loop components (depth N)
+ *   <i>if (<container>) {
+ *   <i>  const <scopes_c> = qsaChildScopes(<container>, <selector_c>)   // per comp
+ *   <i>  let <cursor_c> = 0
+ *   <i>  <outerArr>.forEach((<outerParam>) => {
+ *   <i>    <outerPreludeStatements*>
+ *   <i>    <innerArr>.forEach((<innerParam>) => {
+ *   <i>      <innerPreludeStatements*>
+ *   <i>      const <compEl_c> = <scopes_c>[<cursor_c>++]              // per comp
+ *   <i>      if (<compEl_c>) initChild('<name>', <compEl_c>, <props>)
+ *   <i>    })
+ *   <i>  })
+ *   <i>}
+ *
+ * The scopes are queried once over the whole container and consumed in
+ * document order by a per-component cursor, so the SSR render order
+ * (outer-then-inner, depth-first) pairs each scope with its data item
+ * whether the outer component root is an element or a fragment.
+ */
+function emitComponentRootedInnerLoop(lines: string[], plan: ComponentRootedInnerLoopInitPlan): void {
+  const {
+    containerVar,
+    outerArrayExpr,
+    outerParam,
+    outerPreludeStatements,
+    innerArrayExpr,
+    innerParam,
+    innerPreludeStatements,
+    depth,
+    comps,
+  } = plan
+  // A single comp uses the bare `__compScopes` / `__ci` names; multiple
+  // comps (e.g. `{items.map(it => <><A/><B/></>)}`) get index suffixes so
+  // each keeps its own document-order cursor.
+  const scopesVar = (i: number) => (comps.length > 1 ? `__compScopes${i}` : '__compScopes')
+  const cursorVar = (i: number) => (comps.length > 1 ? `__ci${i}` : '__ci')
+  const compElVar = (i: number) => (comps.length > 1 ? `__compEl${i}` : '__compEl')
+
+  lines.push(`  // Initialize component-rooted inner-loop components (depth ${depth})`)
+  lines.push(`  if (${containerVar}) {`)
+  comps.forEach((comp, i) => {
+    lines.push(`    const ${scopesVar(i)} = qsaChildScopes(${containerVar}, ${comp.selector})`)
+    lines.push(`    let ${cursorVar(i)} = 0`)
+  })
+  lines.push(`    ${outerArrayExpr}.forEach((${outerParam}) => {`)
+  for (const stmt of outerPreludeStatements) {
+    lines.push(`      ${stmt}`)
+  }
+  lines.push(`      ${innerArrayExpr}.forEach((${innerParam}) => {`)
+  for (const stmt of innerPreludeStatements) {
+    lines.push(`        ${stmt}`)
+  }
+  comps.forEach((comp, i) => {
+    lines.push(`        const ${compElVar(i)} = ${scopesVar(i)}[${cursorVar(i)}++]`)
+    lines.push(`        if (${compElVar(i)}) initChild('${nameForRegistryRef(comp.componentName)}', ${compElVar(i)}, ${comp.propsExpr})`)
   })
   lines.push(`      })`)
   lines.push(`    })`)


### PR DESCRIPTION
Fixes #1725.

## Problem

When a `.map()`'s item root is itself a **child component** (a passthrough wrapper like `SelectGroup`) whose JSX `children` contain a nested `.map()` of **child components** (e.g. `SelectItem`), the parent init emitted `initChild()` only for the outer wrapper — never descending into its children to initialize the inner-loop component instances. They rendered from SSR but **never hydrated**: no compiler error, no console error, just inert event handlers.

```tsx
{GROUPS.map(group => (
  <Group key={group.id}>
    {group.items.map(it => (
      <Item key={it.id} label={it.label} />   {/* ← never got initChild */}
    ))}
  </Group>
))}
```

## Root cause

`decideLoopRendering` skipped inner-loop collection entirely whenever the loop body was a child component (`!loop.childComponent ? collectInnerLoops(...) : undefined`). The inner `.map()`'s components were already present in `nestedComponents` at `loopDepth > 0`, but were then dropped by **both** static-array passes:
- the **outer-nested** pass skips them (`if (comp.loopDepth) continue`)
- the **inner-loop** pass never ran (`elem.innerLoops` was `undefined`)

So `grep -c "initChild('Item'"` → **0**.

## Fix

1. **`collect-elements.ts`** — collect inner loops for component-rooted loop items too. Gated downstream so only *static-array* child-component loops with inner loops flow through; dynamic child-component loops (which render via `createComponent`) are unaffected.
2. **New `component-rooted-inner-loop` plan** — instead of the element-offset addressing of `inner-loop-nested` (which assumes the outer item is a DOM element), it emits a **document-order zip**: `qsaChildScopes(container, <slot selector>)` consumed by a per-component cursor over the flattened `outer.forEach(o => inner.forEach(i => ...))` iteration.

The zip is **fragment-root safe**: a `<>{children}</>` passthrough emits no per-group wrapper element to index, so its items are flattened directly under the parent container. Querying by slot selector + document-order cursor pairs each scope with its data item whether the wrapper's root is an element or a fragment.

Generated output (before → after):
```js
// before: only the outer Group inits
initChild('Group', childScope, {})

// after: inner Items init too
if (_s2) {
  const __compScopes = qsaChildScopes(_s2, `[bf-h="${__scopeId}"][bf-m="s0"], [bf-s$="_s0"]`)
  let __ci = 0
  GROUPS.forEach((group) => {
    group.items.forEach((it) => {
      const __compEl = __compScopes[__ci++]
      if (__compEl) initChild('Item', __compEl, { get label() { return it.label } })
    })
  })
}
```

## Tests

- **`packages/client/__tests__/runtime/issue-1725-hydration.test.ts`** — real SSR render (Hono adapter) → hydrate → click integration test. Asserts all four inner `Item` buttons become interactive (counters increment). Covers both **fragment-rooted** and **element-rooted** wrappers. Confirmed red without the fix, green with it.
- **`packages/jsx/src/__tests__/child-components-in-map.test.ts`** — compiler-unit codegen tests pinning the emitted `initChild('Item')` shape, the document-order zip, and the multi-inner-component per-cursor variant (no `__compEl` redeclaration, ref #1664).

Full `@barefootjs/jsx`, `@barefootjs/client`, and `@barefootjs/adapter-tests` suites pass (the only `jsx` failures are pre-existing, unrelated TypeScript-checker/`onMount` alias tests that fail on the base branch too).

https://claude.ai/code/session_0119oH5E3FsFKrECPwzqTG6K

---
_Generated by [Claude Code](https://claude.ai/code/session_0119oH5E3FsFKrECPwzqTG6K)_