### PR TITLE
Lower Array.prototype.flat(depth?) to Go and Mojo adapters (#1448 Tier C)

### DIFF
--- a/.changeset/flat-tier-c.md
+++ b/.changeset/flat-tier-c.md
@@ -1,0 +1,23 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+"@barefootjs/mojolicious": patch
+---
+
+Lower `Array.prototype.flat(depth?)` to the template-language adapters (#1448 Tier C).
+
+The value-returning `.flat()` now compiles on both template adapters instead of refusing with BF101. The flatten depth is validated to a literal and normalised at parse time:
+
+- `arr.flat()` — flatten one level (the JS default)
+- `arr.flat(n)` — flatten `n` levels (a fractional literal truncates toward zero; a `0` / negative depth normalises to "no flatten" → shallow copy, matching JS)
+- `arr.flat(Infinity)` — flatten fully
+- a **non-literal** depth refuses with BF101 (it can't be resolved at template time) and keeps `/* @client */` as the escape hatch — `@client` is not suggested for this case since the remedy is a literal depth or pre-computing
+
+Non-array nested elements are preserved (JS only flattens nested arrays). This is the first half of the `.flat` / `.flatMap` Tier C row; the value-returning `.flatMap` stays deferred (the JSX-returning `.flatMap` already lowers as an `IRLoop`).
+
+- Parser: new `array-method` variant `flat` carrying a structured `FlatDepth` (`number | 'infinity'`); `flat` is removed from `UNSUPPORTED_METHODS`.
+- Emitter: new `flatMethod()` arm on `ParsedExprEmitter` — adding it makes every adapter implementor a TS compile error until handled (the same drift defence sort / reduce use).
+- Go: new `bf_flat` runtime helper (reflect-based recursive flatten; `-1` is the `Infinity` sentinel).
+- Mojo: new `bf->flat` helper (recursive ARRAY-ref flatten; same `-1` sentinel).
+
+Conformance fixtures (`array-flat`, `array-flat-depth`, `array-flat-infinity`) pin byte-equal output across Hono/CSR, Go, and Mojo.

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -62,6 +62,7 @@ func FuncMap() template.FuncMap {
 		"bf_concat":         Concat,
 		"bf_slice":          Slice,
 		"bf_reverse":        Reverse,
+		"bf_flat":           Flat,
 		"bf_first":          First,
 		"bf_last":           Last,
 		"bf_arr":            Arr,
@@ -973,6 +974,35 @@ func Reverse(items any) []any {
 	out := make([]any, length)
 	for i := 0; i < length; i++ {
 		out[length-1-i] = v.Index(i).Interface()
+	}
+	return out
+}
+
+// Flat flattens nested slices/arrays `depth` levels deep. Lowers
+// `Array.prototype.flat(depth?)` (#1448 Tier C). A `depth` of `-1` is the
+// `Infinity` sentinel (flatten fully); `0` (or negative-from-JS, already
+// normalised to 0 at compile time) returns a shallow copy. Non-array
+// elements are kept as-is (JS only flattens nested arrays). A non-array
+// receiver returns an empty `[]any`.
+func Flat(items any, depth int) []any {
+	v := reflect.ValueOf(items)
+	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
+		return []any{}
+	}
+	out := make([]any, 0, v.Len())
+	for i := 0; i < v.Len(); i++ {
+		el := v.Index(i).Interface()
+		ev := reflect.ValueOf(el)
+		if depth != 0 && (ev.Kind() == reflect.Slice || ev.Kind() == reflect.Array) {
+			// `-1` (Infinity) recurses unbounded; a finite depth spends one level.
+			next := depth
+			if depth > 0 {
+				next = depth - 1
+			}
+			out = append(out, Flat(el, next)...)
+		} else {
+			out = append(out, el)
+		}
 	}
 	return out
 }

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -2339,6 +2339,31 @@ export { C }
   })
 })
 
+describe('GoTemplateAdapter - #1448 Tier C .flat(depth?)', () => {
+  function emitFlat(expr: string): string {
+    const adapter = new GoTemplateAdapter()
+    const ir = compileToIR(`
+function C({ rows }: { rows: number[][] }) {
+  return <div>{${expr}}</div>
+}
+export { C }
+`, adapter)
+    return adapter.generate(ir).template ?? ''
+  }
+
+  test('.flat() emits bf_flat with default depth 1', () => {
+    expect(emitFlat('rows.flat()')).toContain('bf_flat .Rows 1')
+  })
+
+  test('.flat(2) emits the explicit depth', () => {
+    expect(emitFlat('rows.flat(2)')).toContain('bf_flat .Rows 2')
+  })
+
+  test('.flat(Infinity) emits the -1 full-depth sentinel', () => {
+    expect(emitFlat('rows.flat(Infinity)')).toContain('bf_flat .Rows -1')
+  })
+})
+
 describe('GoTemplateAdapter - #1448 @client escape hatch (unsupported methods)', () => {
   // Compile a single expression placed in `<div>` text position, with
   // and without the directive, and return both the build errors and
@@ -2390,7 +2415,6 @@ export function C() {
     // array there, which a template can't mirror.
     { name: 'reduce (no init)', expr: `items().reduce((a, b) => a + b.n)`, badEmit: '.Reduce' },
     { name: 'flatMap', expr: `items().flatMap(i => i.tags)`, badEmit: '.FlatMap' },
-    { name: 'flat', expr: `items().flat()`, badEmit: '.Flat' },
     // Lowered methods whose MEANINGFUL extra argument isn't lowered yet
     // (#1448): the `fromIndex` of `.includes`/`.indexOf`/`.lastIndexOf`
     // and the variadic `.concat`. The parser refuses these (silently

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -28,6 +28,7 @@ import type {
   ParsedStatement,
   SortComparator,
   ReduceOp,
+  FlatDepth,
   TemplatePart,
   IRIfStatement,
   IRProvider,
@@ -3391,6 +3392,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // helper, which folds the receiver into a scalar.
     const direction = method === 'reduceRight' ? 'right' : 'left'
     return emitBfReduce(emit(object), reduceOp, direction)
+  }
+
+  flatMethod(object: ParsedExpr, depth: FlatDepth, emit: (e: ParsedExpr) => string): string {
+    // `.flat(depth?)` → `bf_flat <recv> <depth>`. The `Infinity` form
+    // lowers to the `-1` sentinel (flatten fully); a finite depth flattens
+    // that many levels (`0` = shallow copy). See packages/adapter-go-
+    // template/runtime/bf.go.
+    const d = depth === 'infinity' ? -1 : depth
+    return `bf_flat ${wrapIfMultiToken(emit(object))} ${d}`
   }
 
   unsupported(raw: string, _reason: string): string {

--- a/packages/adapter-mojolicious/lib/BarefootJS.pm
+++ b/packages/adapter-mojolicious/lib/BarefootJS.pm
@@ -508,6 +508,25 @@ sub reverse ($self, $recv) {
     return [ reverse @$recv ];
 }
 
+# `Array.prototype.flat(depth?)` (#1448 Tier C) — flatten nested ARRAY
+# refs `$depth` levels deep. A `$depth` of -1 is the `Infinity` sentinel
+# (flatten fully); 0 returns a shallow copy. Non-ARRAY elements are kept
+# as-is (JS only flattens nested arrays). Non-ARRAY receiver → [].
+sub flat ($self, $recv, $depth = 1) {
+    return [] unless ref($recv) eq 'ARRAY';
+    my @out;
+    for my $el (@$recv) {
+        if ($depth != 0 && ref($el) eq 'ARRAY') {
+            my $next = $depth > 0 ? $depth - 1 : $depth;
+            push @out, @{ $self->flat($el, $next) };
+        }
+        else {
+            push @out, $el;
+        }
+    }
+    return \@out;
+}
+
 # `String.prototype.trim()` — strip leading + trailing whitespace.
 # JS's `String.prototype.trim` matches `\s` in the Unicode sense
 # (any whitespace including non-breaking space U+00A0); Perl's `\s`

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -1062,25 +1062,6 @@ describe('MojoAdapter - #1448 Tier A/B fixture-driven lowering pins', () => {
   }
 })
 
-// =============================================================================
-// #1448 — `/* @client */` escape hatch for STILL-UNSUPPORTED methods
-// =============================================================================
-//
-// Mojo sibling of the Go block: #1448 documents `/* @client */` as the
-// universal workaround for any Array/String method the template
-// adapters can't lower. This pins that contract for the Mojo adapter —
-// the BARE form must surface a BF021/BF101 build error, and wrapping
-// the expression in the directive must clear it and emit a client-only
-// placeholder so the Mojo SSR pass renders valid `.html.ep` the client
-// runtime fills at hydration.
-//
-// History (#1448 follow-up): the unsupported *string* methods used to
-// raise NO build diagnostic — bare `.startsWith` / `.repeat` / … fell
-// into the regex pipeline and lowered to a Perl hash-deref-and-call
-// (`$name->{startsWith}('a')`) that passed the gate, then died at
-// render with `Can't use string (...) as a HASH ref while "strict
-// refs"`. They are now routed through the AST path in
-// `convertExpressionToPerl` so `isSupported`'s `UNSUPPORTED_METHODS`
 describe('MojoAdapter - #1448 Tier C .flat(depth?)', () => {
   function emitFlat(expr: string): string {
     const a = new MojoAdapter()
@@ -1106,6 +1087,25 @@ export { C }
   })
 })
 
+// =============================================================================
+// #1448 — `/* @client */` escape hatch for STILL-UNSUPPORTED methods
+// =============================================================================
+//
+// Mojo sibling of the Go block: #1448 documents `/* @client */` as the
+// universal workaround for any Array/String method the template
+// adapters can't lower. This pins that contract for the Mojo adapter —
+// the BARE form must surface a BF021/BF101 build error, and wrapping
+// the expression in the directive must clear it and emit a client-only
+// placeholder so the Mojo SSR pass renders valid `.html.ep` the client
+// runtime fills at hydration.
+//
+// History (#1448 follow-up): the unsupported *string* methods used to
+// raise NO build diagnostic — bare `.startsWith` / `.repeat` / … fell
+// into the regex pipeline and lowered to a Perl hash-deref-and-call
+// (`$name->{startsWith}('a')`) that passed the gate, then died at
+// render with `Can't use string (...) as a HASH ref while "strict
+// refs"`. They are now routed through the AST path in
+// `convertExpressionToPerl` so `isSupported`'s `UNSUPPORTED_METHODS`
 // gate fires BF101 — parity with the Go adapter. These tests pin it.
 describe('MojoAdapter - #1448 @client escape hatch (unsupported methods)', () => {
   function emit(expr: string, client: boolean) {

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -1081,6 +1081,31 @@ describe('MojoAdapter - #1448 Tier A/B fixture-driven lowering pins', () => {
 // render with `Can't use string (...) as a HASH ref while "strict
 // refs"`. They are now routed through the AST path in
 // `convertExpressionToPerl` so `isSupported`'s `UNSUPPORTED_METHODS`
+describe('MojoAdapter - #1448 Tier C .flat(depth?)', () => {
+  function emitFlat(expr: string): string {
+    const a = new MojoAdapter()
+    const ir = compileToIR(`
+function C({ rows }: { rows: number[][] }) {
+  return <div>{${expr}}</div>
+}
+export { C }
+`, a)
+    return a.generate(ir).template ?? ''
+  }
+
+  test('.flat() emits bf->flat with default depth 1', () => {
+    expect(emitFlat('rows.flat()')).toContain('bf->flat($rows, 1)')
+  })
+
+  test('.flat(2) emits the explicit depth', () => {
+    expect(emitFlat('rows.flat(2)')).toContain('bf->flat($rows, 2)')
+  })
+
+  test('.flat(Infinity) emits the -1 full-depth sentinel', () => {
+    expect(emitFlat('rows.flat(Infinity)')).toContain('bf->flat($rows, -1)')
+  })
+})
+
 // gate fires BF101 — parity with the Go adapter. These tests pin it.
 describe('MojoAdapter - #1448 @client escape hatch (unsupported methods)', () => {
   function emit(expr: string, client: boolean) {
@@ -1126,7 +1151,6 @@ export function C() {
     // array there, which a template can't mirror.
     { name: 'reduce (no init)', expr: `items().reduce((a, b) => a + b.n)`, badEmit: '->{reduce}' },
     { name: 'flatMap', expr: `items().flatMap(i => i.tags)`, badEmit: '->{flatMap}' },
-    { name: 'flat', expr: `items().flat()`, badEmit: '->{flat}' },
     // Lowered methods whose MEANINGFUL extra argument isn't lowered yet
     // (#1448): the `fromIndex` of `.includes`/`.indexOf`/`.lastIndexOf`
     // and the variadic `.concat`. The parser refuses these (silently

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -56,7 +56,7 @@ import { isAriaBooleanAttr, isBooleanResultExpr } from './boolean-result'
  * the `IRNodeEmitter` interface.
  */
 type MojoRenderCtx = Record<string, never>
-import type { ParsedExpr, ParsedStatement, SortComparator, ReduceOp, TemplatePart } from '@barefootjs/jsx'
+import type { ParsedExpr, ParsedStatement, SortComparator, ReduceOp, FlatDepth, TemplatePart } from '@barefootjs/jsx'
 import { BF_SLOT, BF_COND } from '@barefootjs/shared'
 
 interface PrimitiveSpec {
@@ -1565,6 +1565,14 @@ function renderReduceMethod(recv: string, op: ReduceOp, direction: 'left' | 'rig
   return `bf->reduce(${recv}, { op => '${op.op}', ${keyEntry}, type => '${op.type}', init => ${init}, direction => '${direction}' })`
 }
 
+// `.flat(depth?)` → `bf->flat($recv, $depth)`. The `Infinity` form lowers
+// to the `-1` sentinel (flatten fully); a finite depth flattens that many
+// levels (`0` = shallow copy). See `sub flat` in BarefootJS.pm. (#1448)
+function renderFlatMethod(recv: string, depth: FlatDepth): string {
+  const d = depth === 'infinity' ? -1 : depth
+  return `bf->flat(${recv}, ${d})`
+}
+
 /** True when `type` is the `string` primitive. */
 function isStringTypeInfo(type: TypeInfo | undefined): boolean {
   return type?.kind === 'primitive' && type.primitive === 'string'
@@ -1751,6 +1759,10 @@ class MojoFilterEmitter implements ParsedExprEmitter {
     return renderReduceMethod(emit(object), reduceOp, method === 'reduceRight' ? 'right' : 'left')
   }
 
+  flatMethod(object: ParsedExpr, depth: FlatDepth, emit: (e: ParsedExpr) => string): string {
+    return renderFlatMethod(emit(object), depth)
+  }
+
   conditional(_test: ParsedExpr, _consequent: ParsedExpr, _alternate: ParsedExpr): string {
     return '1'
   }
@@ -1934,6 +1946,10 @@ class MojoTopLevelEmitter implements ParsedExprEmitter {
 
   reduceMethod(method: 'reduce' | 'reduceRight', object: ParsedExpr, reduceOp: ReduceOp, emit: (e: ParsedExpr) => string): string {
     return renderReduceMethod(emit(object), reduceOp, method === 'reduceRight' ? 'right' : 'left')
+  }
+
+  flatMethod(object: ParsedExpr, depth: FlatDepth, emit: (e: ParsedExpr) => string): string {
+    return renderFlatMethod(emit(object), depth)
   }
 
   conditional(

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -129,6 +129,10 @@ import { fixture as arrayAtDefault } from './methods/array-at-default'
 import { fixture as arrayConcatCopy } from './methods/array-concat-copy'
 import { fixture as arrayReverse } from './methods/array-reverse'
 import { fixture as arrayToReversed } from './methods/array-toReversed'
+// #1448 Tier C — .flat(depth?).
+import { fixture as arrayFlat } from './methods/array-flat'
+import { fixture as arrayFlatDepth } from './methods/array-flat-depth'
+import { fixture as arrayFlatInfinity } from './methods/array-flat-infinity'
 import { fixture as stringToLowerCase } from './methods/string-toLowerCase'
 import { fixture as stringToUpperCase } from './methods/string-toUpperCase'
 import { fixture as stringTrim } from './methods/string-trim'
@@ -316,6 +320,9 @@ export const jsxFixtures: JSXFixture[] = [
   arrayConcatCopy,
   arrayReverse,
   arrayToReversed,
+  arrayFlat,
+  arrayFlatDepth,
+  arrayFlatInfinity,
   // #1448 Tier A — String methods.
   stringToLowerCase,
   stringToUpperCase,

--- a/packages/adapter-tests/fixtures/methods/array-flat-depth.ts
+++ b/packages/adapter-tests/fixtures/methods/array-flat-depth.ts
@@ -1,0 +1,23 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `Array.prototype.flat(depth)` with an explicit depth (#1448 Tier C).
+ *
+ * A doubly-nested array flattened two levels collapses to scalars.
+ * `.flat()` (depth 1) would leave the inner arrays intact, so the
+ * explicit `2` is the discriminator for the depth-argument path.
+ */
+export const fixture = createFixture({
+  id: 'array-flat-depth',
+  description: '.flat(2) flattens two levels deep',
+  source: `
+function ArrayFlatDepth({ rows }: { rows: number[][][] }) {
+  return <div>{rows.flat(2).join(' ')}</div>
+}
+export { ArrayFlatDepth }
+`,
+  props: { rows: [[[1], [2]], [[3], [4]]] },
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><!--bf:s0-->1 2 3 4<!--/--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/methods/array-flat-infinity.ts
+++ b/packages/adapter-tests/fixtures/methods/array-flat-infinity.ts
@@ -1,0 +1,23 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `Array.prototype.flat(Infinity)` — full-depth flatten (#1448 Tier C).
+ *
+ * `Infinity` lowers to the `-1` sentinel the runtime helpers read as
+ * "flatten fully". The same doubly-nested input as `array-flat-depth`
+ * collapses to scalars regardless of how deep the nesting goes.
+ */
+export const fixture = createFixture({
+  id: 'array-flat-infinity',
+  description: '.flat(Infinity) flattens all levels',
+  source: `
+function ArrayFlatInfinity({ rows }: { rows: number[][][] }) {
+  return <div>{rows.flat(Infinity).join(' ')}</div>
+}
+export { ArrayFlatInfinity }
+`,
+  props: { rows: [[[1], [2]], [[3], [4]]] },
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><!--bf:s0-->1 2 3 4<!--/--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/methods/array-flat.ts
+++ b/packages/adapter-tests/fixtures/methods/array-flat.ts
@@ -1,0 +1,23 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `Array.prototype.flat()` lowering (#1448 Tier C).
+ *
+ * `.flat()` with no argument flattens one level. Composed with
+ * `.join(' ')` so the flattened order is visible in the rendered
+ * output. Go uses `bf_flat`; Mojo uses `bf->flat`.
+ */
+export const fixture = createFixture({
+  id: 'array-flat',
+  description: '.flat() flattens one level',
+  source: `
+function ArrayFlat({ rows }: { rows: number[][] }) {
+  return <div>{rows.flat().join(' ')}</div>
+}
+export { ArrayFlat }
+`,
+  props: { rows: [[1, 2], [3, 4]] },
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><!--bf:s0-->1 2 3 4<!--/--></div>
+  `,
+})

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -1512,3 +1512,37 @@ describe('expression-parser — array-method full-arity lowering (#1448)', () =>
     })
   }
 })
+
+describe('expression-parser — .flat(depth?) lowering (#1448 Tier C)', () => {
+  // Depth literals normalise into a structured `flatDepth` at parse time.
+  const depths: Array<[string, string, number | 'infinity']> = [
+    ['.flat() → depth 1', 'arr.flat()', 1],
+    ['.flat(2) → depth 2', 'arr.flat(2)', 2],
+    ['.flat(Infinity) → "infinity"', 'arr.flat(Infinity)', 'infinity'],
+    ['.flat(0) → depth 0 (shallow copy)', 'arr.flat(0)', 0],
+    ['.flat(-1) → normalised to 0 (JS clamps)', 'arr.flat(-1)', 0],
+    ['.flat(1.9) → truncated to 1', 'arr.flat(1.9)', 1],
+  ]
+  for (const [label, expr, expected] of depths) {
+    test(label, () => {
+      const result = parseExpression(expr)
+      expect(result.kind).toBe('array-method')
+      if (result.kind === 'array-method' && result.method === 'flat') {
+        expect(result.flatDepth).toBe(expected)
+      } else {
+        throw new Error(`expected a flat array-method, got ${result.kind}`)
+      }
+    })
+  }
+
+  test('non-literal depth refuses (must be resolvable at template time)', () => {
+    const result = parseExpression('arr.flat(n)')
+    expect(result.kind).toBe('unsupported')
+    if (result.kind === 'unsupported') {
+      // Wrong remedy `@client` must not be suggested (doesn't work in
+      // attribute / condition position).
+      expect(result.reason).not.toContain('@client')
+      expect(result.reason).toContain('literal')
+    }
+  })
+})

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -1545,4 +1545,13 @@ describe('expression-parser — .flat(depth?) lowering (#1448 Tier C)', () => {
       expect(result.reason).toContain('literal')
     }
   })
+
+  // exprToString (diagnostics / debug output) must preserve the normalised
+  // depth, not collapse every form to `.flat()`.
+  test('exprToString round-trips the normalised depth', () => {
+    expect(exprToString(parseExpression('arr.flat()'))).toBe('arr.flat()')
+    expect(exprToString(parseExpression('arr.flat(2)'))).toBe('arr.flat(2)')
+    expect(exprToString(parseExpression('arr.flat(Infinity)'))).toBe('arr.flat(Infinity)')
+    expect(exprToString(parseExpression('arr.flat(0)'))).toBe('arr.flat(0)')
+  })
 })

--- a/packages/jsx/src/adapters/parsed-expr-emitter.ts
+++ b/packages/jsx/src/adapters/parsed-expr-emitter.ts
@@ -33,7 +33,7 @@
  *     be added in one place.
  */
 
-import type { ParsedExpr, SortComparator, ReduceOp, TemplatePart } from '../expression-parser'
+import type { ParsedExpr, SortComparator, ReduceOp, FlatDepth, TemplatePart } from '../expression-parser'
 
 export type HigherOrderMethod = 'filter' | 'every' | 'some' | 'find' | 'findIndex' | 'findLast' | 'findLastIndex'
 
@@ -157,6 +157,14 @@ export interface ParsedExprEmitter {
     reduceOp: ReduceOp,
     emit: (e: ParsedExpr) => string,
   ): string
+  // `.flat(depth?)` gets its own dispatcher arm (#1448 Tier C): it carries
+  // a structured `FlatDepth` (the validated literal / `'infinity'`) rather
+  // than a `ParsedExpr[]` args list, same rationale as sort / reduce.
+  flatMethod(
+    object: ParsedExpr,
+    depth: FlatDepth,
+    emit: (e: ParsedExpr) => string,
+  ): string
   unsupported(raw: string, reason: string): string
 }
 
@@ -202,6 +210,9 @@ export function emitParsedExpr(expr: ParsedExpr, emitter: ParsedExprEmitter): st
       }
       if (expr.method === 'reduce' || expr.method === 'reduceRight') {
         return emitter.reduceMethod(expr.method, expr.object, expr.reduceOp, emit)
+      }
+      if (expr.method === 'flat') {
+        return emitter.flatMethod(expr.object, expr.flatDepth, emit)
       }
       return emitter.arrayMethod(expr.method, expr.object, expr.args, emit)
     case 'unsupported':

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -89,6 +89,19 @@ export type ParsedExpr =
       args: []
       reduceOp: ReduceOp
     }
+  // `.flat(depth?)` (#1448 Tier C). The flatten depth is validated and
+  // normalised into a structured `FlatDepth` at parse time — the literal
+  // never reaches `args`, so adapters fold via a runtime helper instead of
+  // re-inspecting the depth argument. A non-literal depth refuses with
+  // BF101 (the depth must be known at template time). See the `.flat` arm
+  // in `convertNode`.
+  | {
+      kind: 'array-method'
+      method: 'flat'
+      object: ParsedExpr
+      args: []
+      flatDepth: FlatDepth
+    }
   | { kind: 'unsupported'; raw: string; reason: string }
 
 /**
@@ -195,6 +208,16 @@ export type ReduceOp = {
   paramItem: string
 }
 
+/**
+ * Flatten depth for `.flat(depth?)` (#1448 Tier C). A finite non-negative
+ * integer flattens that many levels (`.flat()` defaults to `1`; a `0` or
+ * negative JS depth means "no flatten" → a shallow copy, normalised to
+ * `0` here); `'infinity'` is the `.flat(Infinity)` full-depth form. The
+ * depth must be a literal — a non-literal argument can't be resolved at
+ * template time and refuses with BF101.
+ */
+export type FlatDepth = number | 'infinity'
+
 export type TemplatePart =
   | { type: 'string'; value: string }
   | { type: 'expression'; expr: ParsedExpr }
@@ -270,8 +293,13 @@ const UNSUPPORTED_METHODS = new Set([
   // message. The rest stay refused — see #1448 Tier C for the design
   // questions. `forEach` carries a tailored reason (see
   // `UNSUPPORTED_METHOD_REASONS`).
+  // `flat` is no longer here — `.flat(depth?)` lowers via the
+  // `array-method` IR (structured `FlatDepth`) + `bf_flat` (Go) /
+  // `bf->flat` (Mojo). The value-returning `.flatMap` stays refused (the
+  // transform layer is the deferred Tier C design question; the
+  // JSX-returning `.flatMap` already lowers as an `IRLoop`). See #1448.
   'filter', 'map', 'reduce', 'reduceRight', 'every', 'some',
-  'forEach', 'flatMap', 'flat',
+  'forEach', 'flatMap',
   // #1448 Tier A — Array methods. Each method PR adds the lowering
   // (typically a new `array-method` variant or runtime helper) and
   // removes its row here. See packages/adapter-tests/fixtures/methods/.
@@ -539,6 +567,45 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
       // JS takes no argument and ignores any that are passed.
       if (callee.property === 'reverse' || callee.property === 'toReversed') {
         return { kind: 'array-method', method: callee.property, object: callee.object, args }
+      }
+      // `.flat(depth?)` — flatten nested arrays `depth` levels deep
+      // (default 1). The depth is validated to a literal and normalised
+      // into a structured `FlatDepth` here: `Infinity` becomes the
+      // full-depth form, a 0 / negative JS depth normalises to 0 ("no
+      // flatten" → shallow copy), and a fractional literal truncates
+      // toward zero (JS ToIntegerOrInfinity). A NON-literal depth can't be
+      // resolved at template time, so it refuses with BF101 rather than
+      // emitting a broken helper call. Go uses `bf_flat`; Mojo uses
+      // `bf->flat`. See #1448 Tier C.
+      if (callee.property === 'flat') {
+        const depthNode = node.arguments[0]
+        let flatDepth: FlatDepth
+        if (depthNode === undefined) {
+          flatDepth = 1
+        } else if (ts.isIdentifier(depthNode) && depthNode.text === 'Infinity') {
+          flatDepth = 'infinity'
+        } else {
+          let n: number | undefined
+          if (ts.isNumericLiteral(depthNode)) {
+            n = Number(depthNode.text)
+          } else if (
+            ts.isPrefixUnaryExpression(depthNode) &&
+            depthNode.operator === ts.SyntaxKind.MinusToken &&
+            ts.isNumericLiteral(depthNode.operand)
+          ) {
+            n = -Number(depthNode.operand.text)
+          }
+          if (n === undefined || Number.isNaN(n)) {
+            return {
+              kind: 'unsupported',
+              raw,
+              reason: `\`.flat(depth)\` needs a literal integer or \`Infinity\` depth — a computed depth can't be resolved at template time. Use a literal depth, or pre-compute the value before the template.`,
+            }
+          }
+          const truncated = Math.trunc(n)
+          flatDepth = truncated < 0 ? 0 : truncated
+        }
+        return { kind: 'array-method', method: 'flat', object: callee.object, args: [], flatDepth }
       }
       // `.toLowerCase()` — string-only (the IR carries a value-builtin
       // tag, not a receiver-type discriminator, so the `array-method`
@@ -2051,6 +2118,11 @@ function substituteDestructuredFields(
           // preserve verbatim, same as the sort comparator above.
           return { kind: 'array-method', method: e.method, object: walk(e.object), args: [], reduceOp: e.reduceOp }
         }
+        if (e.method === 'flat') {
+          // `flatDepth` is a normalised literal — no destructure refs to
+          // substitute. Preserve verbatim, same as sort / reduce above.
+          return { kind: 'array-method', method: 'flat', object: walk(e.object), args: [], flatDepth: e.flatDepth }
+        }
         return { kind: 'array-method', method: e.method, object: walk(e.object), args: e.args.map(walk) }
       case 'literal':
       case 'unsupported':
@@ -2601,6 +2673,13 @@ export function stringifyParsedExpr(expr: ParsedExpr): string {
         const { paramAcc, paramItem, raw, type, init } = expr.reduceOp
         const initSrc = type === 'string' ? JSON.stringify(init) : init
         return `${stringifyParsedExpr(expr.object)}.${expr.method}((${paramAcc},${paramItem}) => ${raw}, ${initSrc})`
+      }
+      if (expr.method === 'flat') {
+        // Round-trip the normalised depth back to JS for the CSR / Hono
+        // path: `'infinity'` → `Infinity`, `1` is left implicit (`.flat()`).
+        const d = expr.flatDepth
+        const depthSrc = d === 'infinity' ? 'Infinity' : String(d)
+        return `${stringifyParsedExpr(expr.object)}.flat(${d === 1 ? '' : depthSrc})`
       }
       return `${stringifyParsedExpr(expr.object)}.${expr.method}(${expr.args.map(stringifyParsedExpr).join(', ')})`
     case 'unsupported':

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -2602,6 +2602,13 @@ export function exprToString(expr: ParsedExpr): string {
         const initSrc = type === 'string' ? JSON.stringify(init) : init
         return `${exprToString(expr.object)}.${expr.method}((${paramAcc},${paramItem}) => ${raw}, ${initSrc})`
       }
+      if (expr.method === 'flat') {
+        // Preserve the normalised depth so diagnostics don't misleadingly
+        // print `.flat()` for a `.flat(2)` / `.flat(Infinity)` source.
+        const d = expr.flatDepth
+        const depthSrc = d === 'infinity' ? 'Infinity' : String(d)
+        return `${exprToString(expr.object)}.flat(${d === 1 ? '' : depthSrc})`
+      }
       return `${exprToString(expr.object)}.${expr.method}(${expr.args.map(exprToString).join(', ')})`
     case 'unsupported':
       return `[UNSUPPORTED: ${expr.raw}]`

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -245,7 +245,7 @@ export { ErrorCodes, createError, formatError, generateCodeFrame } from './error
 
 // Expression Parser
 export { parseExpression, isSupported, exprToString, stringifyParsedExpr, identifierPath, parseBlockBody, containsHigherOrder } from './expression-parser'
-export type { ParsedExpr, ParsedStatement, SortComparator, SortKey, ReduceOp, SupportLevel, SupportResult, TemplatePart } from './expression-parser'
+export type { ParsedExpr, ParsedStatement, SortComparator, SortKey, ReduceOp, FlatDepth, SupportLevel, SupportResult, TemplatePart } from './expression-parser'
 export { buildLoopChainExpr } from './loop-chain'
 export type { LoopChainInputs } from './loop-chain'
 


### PR DESCRIPTION
## Summary

Lands the **`.flat(depth?)` half** of the #1448 Tier C `.flat` / `.flatMap` row. Value-returning `.flat()` now compiles on the template-language adapters (Go, Mojo) instead of refusing with **BF101**.

This is the first phase of the flatMap/flat work — `.flat` is the mechanical, Tier-A-shaped half. The value-returning `.flatMap` (the transform layer) stays deferred; the JSX-returning `.flatMap` already lowers as an `IRLoop`.

## Behaviour

The flatten depth is validated to a **literal** and normalised into a structured `FlatDepth` at parse time:

- `arr.flat()` → flatten one level (JS default)
- `arr.flat(n)` → flatten `n` levels (a fractional literal truncates toward zero; a `0` / negative depth normalises to "no flatten" → shallow copy, matching JS `ToIntegerOrInfinity`)
- `arr.flat(Infinity)` → flatten fully
- a **non-literal** depth refuses with BF101 (it can't be resolved at template time). `@client` is *not* suggested for this case — the remedy is a literal depth or pre-computing.

Non-array nested elements are preserved (JS only flattens nested arrays).

## Changes

- **Parser**: new `array-method` variant `flat` carrying a structured `FlatDepth` (`number | 'infinity'`); `flat` removed from `UNSUPPORTED_METHODS`.
- **Emitter**: new `flatMethod()` arm on `ParsedExprEmitter` — adding it is a TS compile error in every adapter until handled (same drift defence as sort / reduce).
- **Go**: new `bf_flat` runtime helper (reflect-based recursive flatten; `-1` is the `Infinity` sentinel).
- **Mojo**: new `bf->flat` helper (recursive ARRAY-ref flatten; same sentinel).

## Test plan

- [x] Compiler unit: `.flat` depth normalisation (`()`, `(2)`, `(Infinity)`, `(0)`, `(-1)`, `(1.9)`) + non-literal refusal — `expression-parser.test.ts`
- [x] Adapter emit pins: `bf_flat` / `bf->flat` with depth 1 / 2 / `-1` — `go-template-adapter.test.ts`, `mojo-adapter.test.ts`
- [x] Conformance fixtures `array-flat` / `array-flat-depth` / `array-flat-infinity` — pass CSR/Hono (Go/Mojo render gated off here: Go 1.24 < required 1.25)
- [x] `Flat` Go helper verified directly via a throwaway `go test` (depth 1/2/∞/0, typed slice); `bf->flat` recursion verified via a standalone Perl snippet
- [x] `tsgo --noEmit` clean for `jsx`, `adapter-go-template`, `adapter-mojolicious`
- [x] Pre-existing unrelated failures in `primitive-resolver-all.test.ts` (TS-checker alias resolution) confirmed present on clean `main` too

https://claude.ai/code/session_016hsRA9RLzvMgq2YgghQULe

---
_Generated by [Claude Code](https://claude.ai/code/session_016hsRA9RLzvMgq2YgghQULe)_