### PR TITLE
Lower value-returning .flatMap field projection to Go and Mojo (#1448 Tier C)

### DIFF
--- a/.changeset/flatmap-field-tier-c.md
+++ b/.changeset/flatmap-field-tier-c.md
@@ -1,0 +1,24 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+"@barefootjs/mojolicious": patch
+---
+
+Lower value-returning `Array.prototype.flatMap(fn)` field projection to the template-language adapters (#1448 Tier C).
+
+The field-projection form of `.flatMap` now compiles on both template adapters instead of refusing with BF101. The callback is validated and extracted into a structured `FlatMapOp` at parse time (mirroring `.reduce` / `.sort`):
+
+- `arr.flatMap(i => i)` — self projection (equivalent to `.flat(1)`)
+- `arr.flatMap(i => i.field)` — flatten a per-item array field (the dominant real-world case, e.g. `items.flatMap(i => i.tags)`)
+- single-`return` block bodies unwrap to the returned expression
+
+The projected per-item value is flattened one level (`flatMap` = map + `flat(1)`); a non-array projection is kept as-is, matching JS. This composes as a loop base too — `items.flatMap(i => i.tags).map(t => <li>{t}</li>)` now lowers to a loop over the flattened array instead of refusing.
+
+Out-of-catalogue callbacks — array-literal / transform projections (`i => [i.a, i.b]`), deep field access (`i => i.a.b`), and the index/array callback params — stay refused with BF101 and keep `/* @client */` as the escape hatch. The JSX-returning `.flatMap` continues to lower as an `IRLoop` upstream (unchanged).
+
+- Parser: new `array-method` variant `flatMap` carrying a structured `FlatMapOp`; `flatMap` stays in `UNSUPPORTED_METHODS` so the degenerate / out-of-catalogue forms still refuse loudly.
+- Emitter: new `flatMapMethod()` arm on `ParsedExprEmitter` (drift defence, same as sort / reduce / flat).
+- Go: new `bf_flat_map` runtime helper (reflect-based projection + one-level flatten, reusing `getFieldValue` and `Flat`).
+- Mojo: new `bf->flat_map` helper (HASH-ref field projection + `flat(1)`).
+
+Conformance fixtures (`array-flatmap-field`, `array-flatmap-self`) pin byte-equal output across Hono/CSR, Go, and Mojo.

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -63,6 +63,7 @@ func FuncMap() template.FuncMap {
 		"bf_slice":          Slice,
 		"bf_reverse":        Reverse,
 		"bf_flat":           Flat,
+		"bf_flat_map":       FlatMap,
 		"bf_first":          First,
 		"bf_last":           Last,
 		"bf_arr":            Arr,
@@ -1005,6 +1006,29 @@ func Flat(items any, depth int) []any {
 		}
 	}
 	return out
+}
+
+// FlatMap projects each element through a `self` / `field` projection and
+// flattens the result one level. Lowers value-returning
+// `Array.prototype.flatMap(fn)` for the field-projection catalogue
+// (#1448 Tier C): `items.flatMap(i => i)` (self) and
+// `items.flatMap(i => i.field)` (field). A projected non-array value is
+// kept as-is (flatMap = map + flat(1)). Non-array receiver → empty.
+func FlatMap(items any, keyKind, keyName string) []any {
+	v := reflect.ValueOf(items)
+	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
+		return []any{}
+	}
+	projected := make([]any, 0, v.Len())
+	for i := 0; i < v.Len(); i++ {
+		el := v.Index(i).Interface()
+		if keyKind == "field" {
+			projected = append(projected, getFieldValue(el, keyName))
+		} else {
+			projected = append(projected, el)
+		}
+	}
+	return Flat(projected, 1)
 }
 
 // First returns the first element of a slice, or nil if empty.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -2364,6 +2364,27 @@ export { C }
   })
 })
 
+describe('GoTemplateAdapter - #1448 Tier C .flatMap(field projection)', () => {
+  function emitFlatMap(expr: string): string {
+    const adapter = new GoTemplateAdapter()
+    const ir = compileToIR(`
+function C({ rows }: { rows: { tags: string[] }[] }) {
+  return <div>{${expr}}</div>
+}
+export { C }
+`, adapter)
+    return adapter.generate(ir).template ?? ''
+  }
+
+  test('.flatMap(i => i.field) emits bf_flat_map with the Go-capitalised field', () => {
+    expect(emitFlatMap('rows.flatMap(i => i.tags).join(" ")')).toContain('bf_flat_map .Rows "field" "Tags"')
+  })
+
+  test('.flatMap(i => i) emits the self projection', () => {
+    expect(emitFlatMap('rows.flatMap(i => i).join(" ")')).toContain('bf_flat_map .Rows "self" ""')
+  })
+})
+
 describe('GoTemplateAdapter - #1448 @client escape hatch (unsupported methods)', () => {
   // Compile a single expression placed in `<div>` text position, with
   // and without the directive, and return both the build errors and
@@ -2414,7 +2435,9 @@ export function C() {
     // the no-initial-value form stays refused — JS throws on an empty
     // array there, which a template can't mirror.
     { name: 'reduce (no init)', expr: `items().reduce((a, b) => a + b.n)`, badEmit: '.Reduce' },
-    { name: 'flatMap', expr: `items().flatMap(i => i.tags)`, badEmit: '.FlatMap' },
+    // Field-projection `.flatMap(i => i.tags)` now lowers (#1448 Tier C);
+    // the array-literal / transform form stays refused.
+    { name: 'flatMap (array-literal)', expr: `items().flatMap(i => [i.name, i.n])`, badEmit: '.FlatMap' },
     // Lowered methods whose MEANINGFUL extra argument isn't lowered yet
     // (#1448): the `fromIndex` of `.includes`/`.indexOf`/`.lastIndexOf`
     // and the variadic `.concat`. The parser refuses these (silently

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -29,6 +29,7 @@ import type {
   SortComparator,
   ReduceOp,
   FlatDepth,
+  FlatMapOp,
   TemplatePart,
   IRIfStatement,
   IRProvider,
@@ -3401,6 +3402,18 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // template/runtime/bf.go.
     const d = depth === 'infinity' ? -1 : depth
     return `bf_flat ${wrapIfMultiToken(emit(object))} ${d}`
+  }
+
+  flatMapMethod(object: ParsedExpr, op: FlatMapOp, emit: (e: ParsedExpr) => string): string {
+    // `.flatMap(i => i)` / `.flatMap(i => i.field)` → `bf_flat_map <recv>
+    // "<keyKind>" "<keyName>"`. The runtime projects each item (self or a
+    // struct field) then flattens one level. The field name uses the Go
+    // struct-field capitalisation, matching `bf_reduce` / `bf_sort`.
+    const recv = wrapIfMultiToken(emit(object))
+    if (op.key.kind === 'self') {
+      return `bf_flat_map ${recv} "self" ""`
+    }
+    return `bf_flat_map ${recv} "field" "${capitalize(op.key.field)}"`
   }
 
   unsupported(raw: string, _reason: string): string {

--- a/packages/adapter-go-template/src/test-render.ts
+++ b/packages/adapter-go-template/src/test-render.ts
@@ -355,7 +355,14 @@ function goMapLiteralFromObject(
     else if (typeof v === 'number') entries.push(`${key}: ${v}`)
     else if (typeof v === 'boolean') entries.push(`${key}: ${v}`)
     else if (v === null) entries.push(`${key}: nil`)
-    else if (v && typeof v === 'object' && !Array.isArray(v)) {
+    else if (Array.isArray(v)) {
+      // Array-valued field inside an object-in-array (e.g. the `tags`
+      // of `items.flatMap(i => i.tags)`). Without this branch the field
+      // was silently dropped, leaving an empty map so the template
+      // rendered nothing for the projection (#1448 Tier C flatMap).
+      entries.push(`${key}: ${goArrayLiteralFromArray(v)}`)
+    }
+    else if (v && typeof v === 'object') {
       entries.push(`${key}: ${goMapLiteralFromObject(v as Record<string, unknown>, capitalizeKeys)}`)
     }
   }

--- a/packages/adapter-mojolicious/lib/BarefootJS.pm
+++ b/packages/adapter-mojolicious/lib/BarefootJS.pm
@@ -537,7 +537,10 @@ sub flat_map ($self, $recv, $key_kind, $key) {
     my @projected;
     for my $el (@$recv) {
         if ($key_kind eq 'field') {
-            push @projected, ref($el) eq 'HASH' ? $el->{$key} : $el;
+            # JS `i => i.field` on a non-object yields `undefined`, not the
+            # element itself — push `undef` so a scalar element doesn't leak
+            # into the output (matches Go's `getFieldValue` returning nil).
+            push @projected, ref($el) eq 'HASH' ? $el->{$key} : undef;
         }
         else {
             push @projected, $el;

--- a/packages/adapter-mojolicious/lib/BarefootJS.pm
+++ b/packages/adapter-mojolicious/lib/BarefootJS.pm
@@ -527,6 +527,25 @@ sub flat ($self, $recv, $depth = 1) {
     return \@out;
 }
 
+# `Array.prototype.flatMap(fn)` value-returning field projection
+# (#1448 Tier C) — map each element through a self / field projection,
+# then flatten one level. `field` reads a HASH-ref key (the raw JS prop
+# name, as `bf->reduce` does); a projected non-ARRAY value is kept as-is
+# (flatMap = map + flat(1)). Non-ARRAY receiver → [].
+sub flat_map ($self, $recv, $key_kind, $key) {
+    return [] unless ref($recv) eq 'ARRAY';
+    my @projected;
+    for my $el (@$recv) {
+        if ($key_kind eq 'field') {
+            push @projected, ref($el) eq 'HASH' ? $el->{$key} : $el;
+        }
+        else {
+            push @projected, $el;
+        }
+    }
+    return $self->flat(\@projected, 1);
+}
+
 # `String.prototype.trim()` — strip leading + trailing whitespace.
 # JS's `String.prototype.trim` matches `\s` in the Unicode sense
 # (any whitespace including non-breaking space U+00A0); Perl's `\s`

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -401,7 +401,10 @@ export function C() {
       // empty array there, which a template can't mirror.
       { name: 'reduce (no init)',  body: `<div>{items().reduce((s, x) => s + x)}</div>`,                                                             needle: '.reduce(' },
       { name: 'forEach',           body: `<ul>{items().forEach(x => x)}</ul>`,                                                                       needle: '.forEach(' },
-      { name: 'flatMap',           body: `<ul>{items().flatMap(x => x.tags).map(t => <li key={t}>{t}</li>)}</ul>`,                                  needle: '.flatMap(' },
+      // The field-projection `.flatMap(x => x.tags)` now lowers (#1448
+      // Tier C) — even as a loop base — so it moved to the positive test
+      // below. The array-literal / transform form stays refused.
+      { name: 'flatMap (array-literal)', body: `<div>{items().flatMap(x => [x.tags, x.tags])}</div>`,                                              needle: '.flatMap(' },
     ]
 
     for (const { name, body, needle } of cases) {
@@ -1087,6 +1090,40 @@ export { C }
   })
 })
 
+describe('MojoAdapter - #1448 Tier C .flatMap(field projection)', () => {
+  function emitFlatMap(expr: string): string {
+    const a = new MojoAdapter()
+    const ir = compileToIR(`
+function C({ rows }: { rows: { tags: string[] }[] }) {
+  return <div>{${expr}}</div>
+}
+export { C }
+`, a)
+    return a.generate(ir).template ?? ''
+  }
+
+  test('.flatMap(i => i.field) emits bf->flat_map with the raw field key', () => {
+    expect(emitFlatMap('rows.flatMap(i => i.tags).join(" ")')).toContain(`bf->flat_map($rows, 'field', 'tags')`)
+  })
+
+  test('.flatMap(i => i) emits the self projection', () => {
+    expect(emitFlatMap('rows.flatMap(i => i).join(" ")')).toContain(`bf->flat_map($rows, 'self', '')`)
+  })
+
+  test('field-projection flatMap as a loop base lowers (no BF101)', () => {
+    const a = new MojoAdapter()
+    const ir = compileToIR(`'use client'
+import { createSignal } from '@barefootjs/client'
+export function C() {
+  const [items] = createSignal<{ tags: string[] }[]>([])
+  return <ul>{items().flatMap(x => x.tags).map(t => <li key={t}>{t}</li>)}</ul>
+}`, a)
+    const template = a.generate(ir).template ?? ''
+    expect((a.errors ?? []).filter(e => e.code === 'BF101')).toEqual([])
+    expect(template).toContain(`bf->flat_map($items, 'field', 'tags')`)
+  })
+})
+
 // =============================================================================
 // #1448 — `/* @client */` escape hatch for STILL-UNSUPPORTED methods
 // =============================================================================
@@ -1150,7 +1187,9 @@ export function C() {
     // the no-initial-value form stays refused — JS throws on an empty
     // array there, which a template can't mirror.
     { name: 'reduce (no init)', expr: `items().reduce((a, b) => a + b.n)`, badEmit: '->{reduce}' },
-    { name: 'flatMap', expr: `items().flatMap(i => i.tags)`, badEmit: '->{flatMap}' },
+    // Field-projection `.flatMap(i => i.tags)` now lowers (#1448 Tier C);
+    // the array-literal / transform form stays refused.
+    { name: 'flatMap (array-literal)', expr: `items().flatMap(i => [i.name, i.n])`, badEmit: '->{flatMap}' },
     // Lowered methods whose MEANINGFUL extra argument isn't lowered yet
     // (#1448): the `fromIndex` of `.includes`/`.indexOf`/`.lastIndexOf`
     // and the variadic `.concat`. The parser refuses these (silently

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -56,7 +56,7 @@ import { isAriaBooleanAttr, isBooleanResultExpr } from './boolean-result'
  * the `IRNodeEmitter` interface.
  */
 type MojoRenderCtx = Record<string, never>
-import type { ParsedExpr, ParsedStatement, SortComparator, ReduceOp, FlatDepth, TemplatePart } from '@barefootjs/jsx'
+import type { ParsedExpr, ParsedStatement, SortComparator, ReduceOp, FlatDepth, FlatMapOp, TemplatePart } from '@barefootjs/jsx'
 import { BF_SLOT, BF_COND } from '@barefootjs/shared'
 
 interface PrimitiveSpec {
@@ -1573,6 +1573,15 @@ function renderFlatMethod(recv: string, depth: FlatDepth): string {
   return `bf->flat(${recv}, ${d})`
 }
 
+// `.flatMap(i => i)` / `.flatMap(i => i.field)` → `bf->flat_map($recv,
+// 'self'|'field', 'field')`. The runtime projects each item then flattens
+// one level. The field key is the raw JS prop name (Perl hashes are keyed
+// by it), mirroring `bf->reduce`. See `sub flat_map` in BarefootJS.pm.
+function renderFlatMapMethod(recv: string, op: FlatMapOp): string {
+  if (op.key.kind === 'self') return `bf->flat_map(${recv}, 'self', '')`
+  return `bf->flat_map(${recv}, 'field', '${op.key.field}')`
+}
+
 /** True when `type` is the `string` primitive. */
 function isStringTypeInfo(type: TypeInfo | undefined): boolean {
   return type?.kind === 'primitive' && type.primitive === 'string'
@@ -1763,6 +1772,10 @@ class MojoFilterEmitter implements ParsedExprEmitter {
     return renderFlatMethod(emit(object), depth)
   }
 
+  flatMapMethod(object: ParsedExpr, op: FlatMapOp, emit: (e: ParsedExpr) => string): string {
+    return renderFlatMapMethod(emit(object), op)
+  }
+
   conditional(_test: ParsedExpr, _consequent: ParsedExpr, _alternate: ParsedExpr): string {
     return '1'
   }
@@ -1950,6 +1963,10 @@ class MojoTopLevelEmitter implements ParsedExprEmitter {
 
   flatMethod(object: ParsedExpr, depth: FlatDepth, emit: (e: ParsedExpr) => string): string {
     return renderFlatMethod(emit(object), depth)
+  }
+
+  flatMapMethod(object: ParsedExpr, op: FlatMapOp, emit: (e: ParsedExpr) => string): string {
+    return renderFlatMapMethod(emit(object), op)
   }
 
   conditional(

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -133,6 +133,8 @@ import { fixture as arrayToReversed } from './methods/array-toReversed'
 import { fixture as arrayFlat } from './methods/array-flat'
 import { fixture as arrayFlatDepth } from './methods/array-flat-depth'
 import { fixture as arrayFlatInfinity } from './methods/array-flat-infinity'
+import { fixture as arrayFlatMapField } from './methods/array-flatmap-field'
+import { fixture as arrayFlatMapSelf } from './methods/array-flatmap-self'
 import { fixture as stringToLowerCase } from './methods/string-toLowerCase'
 import { fixture as stringToUpperCase } from './methods/string-toUpperCase'
 import { fixture as stringTrim } from './methods/string-trim'
@@ -323,6 +325,8 @@ export const jsxFixtures: JSXFixture[] = [
   arrayFlat,
   arrayFlatDepth,
   arrayFlatInfinity,
+  arrayFlatMapField,
+  arrayFlatMapSelf,
   // #1448 Tier A — String methods.
   stringToLowerCase,
   stringToUpperCase,

--- a/packages/adapter-tests/fixtures/methods/array-flatmap-field.ts
+++ b/packages/adapter-tests/fixtures/methods/array-flatmap-field.ts
@@ -1,0 +1,23 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `Array.prototype.flatMap(i => i.field)` — field projection (#1448 Tier C).
+ *
+ * Each item projects to its array-valued `tags` field, then the result is
+ * flattened one level. Composed with `.join(' ')` so the gathered order is
+ * visible. Go uses `bf_flat_map`; Mojo uses `bf->flat_map`.
+ */
+export const fixture = createFixture({
+  id: 'array-flatmap-field',
+  description: '.flatMap(i => i.tags) gathers and flattens a field',
+  source: `
+function ArrayFlatMapField({ items }: { items: { tags: string[] }[] }) {
+  return <div>{items.flatMap(i => i.tags).join(' ')}</div>
+}
+export { ArrayFlatMapField }
+`,
+  props: { items: [{ tags: ['a', 'b'] }, { tags: ['c'] }, { tags: ['d', 'e'] }] },
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><!--bf:s0-->a b c d e<!--/--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/methods/array-flatmap-self.ts
+++ b/packages/adapter-tests/fixtures/methods/array-flatmap-self.ts
@@ -1,0 +1,22 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `Array.prototype.flatMap(i => i)` — self projection (#1448 Tier C).
+ *
+ * flatMap with the identity callback is equivalent to `.flat(1)`: each
+ * nested array is flattened one level. Composed with `.join(' ')`.
+ */
+export const fixture = createFixture({
+  id: 'array-flatmap-self',
+  description: '.flatMap(i => i) flattens one level (identity)',
+  source: `
+function ArrayFlatMapSelf({ rows }: { rows: number[][] }) {
+  return <div>{rows.flatMap(i => i).join(' ')}</div>
+}
+export { ArrayFlatMapSelf }
+`,
+  props: { rows: [[1, 2], [3], [4, 5]] },
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><!--bf:s0-->1 2 3 4 5<!--/--></div>
+  `,
+})

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -1555,3 +1555,44 @@ describe('expression-parser — .flat(depth?) lowering (#1448 Tier C)', () => {
     expect(exprToString(parseExpression('arr.flat(0)'))).toBe('arr.flat(0)')
   })
 })
+
+describe('expression-parser — .flatMap(fn) field projection (#1448 Tier C)', () => {
+  // Accepted catalogue: self (`i => i`) and single field (`i => i.field`).
+  const accepted: Array<[string, string, { kind: 'self' } | { kind: 'field'; field: string }]> = [
+    ['self (i => i)', 'arr.flatMap(i => i)', { kind: 'self' }],
+    ['field (i => i.tags)', 'arr.flatMap(i => i.tags)', { kind: 'field', field: 'tags' }],
+    ['single-return block body', 'arr.flatMap(i => { return i.tags })', { kind: 'field', field: 'tags' }],
+  ]
+  for (const [label, expr, key] of accepted) {
+    test(`${label} — lowers to a flatMap array-method`, () => {
+      const result = parseExpression(expr)
+      expect(result.kind).toBe('array-method')
+      if (result.kind === 'array-method' && result.method === 'flatMap') {
+        expect(result.flatMapOp.key).toEqual(key)
+      } else {
+        throw new Error(`expected a flatMap array-method, got ${result.kind}`)
+      }
+    })
+  }
+
+  // Out of the field-projection catalogue → refused (BF101 + @client hint).
+  const refused = [
+    ['array-literal projection', 'arr.flatMap(i => [i.a, i.b])'],
+    ['deep field access', 'arr.flatMap(i => i.a.b)'],
+    ['index/array callback params', 'arr.flatMap((i, idx) => i.tags)'],
+  ]
+  for (const [label, expr] of refused) {
+    test(`${label} — refuses`, () => {
+      const result = parseExpression(expr)
+      expect(result.kind).toBe('unsupported')
+      if (result.kind === 'unsupported') {
+        expect(result.reason).toContain('field projection')
+      }
+    })
+  }
+
+  test('exprToString / stringify round-trip the callback', () => {
+    expect(exprToString(parseExpression('arr.flatMap(i => i.tags)'))).toBe('arr.flatMap(i => i.tags)')
+    expect(exprToString(parseExpression('arr.flatMap(t => t)'))).toBe('arr.flatMap(t => t)')
+  })
+})

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -1580,6 +1580,9 @@ describe('expression-parser — .flatMap(fn) field projection (#1448 Tier C)', (
     ['array-literal projection', 'arr.flatMap(i => [i.a, i.b])'],
     ['deep field access', 'arr.flatMap(i => i.a.b)'],
     ['index/array callback params', 'arr.flatMap((i, idx) => i.tags)'],
+    // Wrong-arity forms are intercepted by the same arm (not the generic
+    // "flatMap has no template lowering" gate) so the reason stays tailored.
+    ['2-arg flatMap(fn, thisArg)', 'arr.flatMap(i => i.tags, ctx)'],
   ]
   for (const [label, expr] of refused) {
     test(`${label} — refuses`, () => {

--- a/packages/jsx/src/adapters/parsed-expr-emitter.ts
+++ b/packages/jsx/src/adapters/parsed-expr-emitter.ts
@@ -33,7 +33,7 @@
  *     be added in one place.
  */
 
-import type { ParsedExpr, SortComparator, ReduceOp, FlatDepth, TemplatePart } from '../expression-parser'
+import type { ParsedExpr, SortComparator, ReduceOp, FlatDepth, FlatMapOp, TemplatePart } from '../expression-parser'
 
 export type HigherOrderMethod = 'filter' | 'every' | 'some' | 'find' | 'findIndex' | 'findLast' | 'findLastIndex'
 
@@ -165,6 +165,14 @@ export interface ParsedExprEmitter {
     depth: FlatDepth,
     emit: (e: ParsedExpr) => string,
   ): string
+  // `.flatMap(fn)` value-returning field projection gets its own arm
+  // (#1448 Tier C): it carries a structured `FlatMapOp` rather than a
+  // `ParsedExpr[]` args list, same rationale as sort / reduce / flat.
+  flatMapMethod(
+    object: ParsedExpr,
+    op: FlatMapOp,
+    emit: (e: ParsedExpr) => string,
+  ): string
   unsupported(raw: string, reason: string): string
 }
 
@@ -213,6 +221,9 @@ export function emitParsedExpr(expr: ParsedExpr, emitter: ParsedExprEmitter): st
       }
       if (expr.method === 'flat') {
         return emitter.flatMethod(expr.object, expr.flatDepth, emit)
+      }
+      if (expr.method === 'flatMap') {
+        return emitter.flatMapMethod(expr.object, expr.flatMapOp, emit)
       }
       return emitter.arrayMethod(expr.method, expr.object, expr.args, emit)
     case 'unsupported':

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -102,6 +102,20 @@ export type ParsedExpr =
       args: []
       flatDepth: FlatDepth
     }
+  // `.flatMap(fn)` value-returning field projection (#1448 Tier C). The
+  // callback is extracted into a structured `FlatMapOp` (self / field
+  // projection) at parse time, mirroring sort / reduce. The projected
+  // per-item value is flattened one level (flatMap = map + flat(1)).
+  // Array-literal / complex callbacks fall through to `unsupported`; the
+  // JSX-returning `.flatMap` is handled as an `IRLoop` upstream and never
+  // reaches here. See `extractFlatMapOpFromTS` below.
+  | {
+      kind: 'array-method'
+      method: 'flatMap'
+      object: ParsedExpr
+      args: []
+      flatMapOp: FlatMapOp
+    }
   | { kind: 'unsupported'; raw: string; reason: string }
 
 /**
@@ -218,6 +232,25 @@ export type ReduceOp = {
  */
 export type FlatDepth = number | 'infinity'
 
+/**
+ * Structured form of a value-returning `.flatMap(fn)` callback (#1448
+ * Tier C). The accepted catalogue is the field-projection family only —
+ * the callback maps each item to either itself (`i => i`) or a single
+ * non-computed field (`i => i.tags`), and the projected value is then
+ * flattened one level (flatMap = map + flat(1)). A projected non-array
+ * value is kept as-is, matching JS. Array-literal / transform callbacks
+ * (`i => [i.a, i.b]`) are out of scope and refuse with BF101. See
+ * `extractFlatMapOpFromTS`.
+ */
+export type FlatMapOp = {
+  // What each item projects to before the one-level flatten.
+  key: { kind: 'self' } | { kind: 'field'; field: string }
+  // The callback param name the user wrote (for the `@client` round-trip).
+  param: string
+  // Original JS source of the callback body (for the `@client` fallback).
+  raw: string
+}
+
 export type TemplatePart =
   | { type: 'string'; value: string }
   | { type: 'expression'; expr: ParsedExpr }
@@ -295,9 +328,13 @@ const UNSUPPORTED_METHODS = new Set([
   // `UNSUPPORTED_METHOD_REASONS`).
   // `flat` is no longer here — `.flat(depth?)` lowers via the
   // `array-method` IR (structured `FlatDepth`) + `bf_flat` (Go) /
-  // `bf->flat` (Mojo). The value-returning `.flatMap` stays refused (the
-  // transform layer is the deferred Tier C design question; the
-  // JSX-returning `.flatMap` already lowers as an `IRLoop`). See #1448.
+  // `bf->flat` (Mojo). `flatMap` stays listed as a fallback: the
+  // field-projection form (`i => i` / `i => i.field`) lowers via a
+  // structured `FlatMapOp`, but the convertNode arm intercepts that
+  // shape before this gate — only the degenerate forms (a bare method
+  // reference, a 0- / 2-arg call) reach here and refuse. Array-literal /
+  // transform callbacks refuse with an explicit reason from the arm. The
+  // JSX-returning `.flatMap` lowers as an `IRLoop` upstream. See #1448.
   'filter', 'map', 'reduce', 'reduceRight', 'every', 'some',
   'forEach', 'flatMap',
   // #1448 Tier A — Array methods. Each method PR adds the lowering
@@ -836,6 +873,36 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
       // A `.reduce(fn)` without an initial value can't be lowered: JS
       // throws on an empty array, which a template can't mirror. Fall
       // through to the BF101 gate with the @client escape hatch.
+
+      // `.flatMap(fn)` value-returning field projection (#1448 Tier C).
+      // The callback is extracted into a structured `FlatMapOp` (self /
+      // field projection) from the raw TS AST. The JSX-returning form is
+      // handled as an `IRLoop` upstream and never reaches here; the
+      // array-literal / transform forms aren't lowered, so they refuse
+      // with BF101 + the @client hint. Go uses `bf_flat_map`; Mojo uses
+      // `bf->flat_map`.
+      if (callee.property === 'flatMap' && node.arguments.length === 1) {
+        const flatMapOp = extractFlatMapOpFromTS(node.arguments[0])
+        if (flatMapOp) {
+          return {
+            kind: 'array-method',
+            method: 'flatMap',
+            object: callee.object,
+            args: [],
+            flatMapOp,
+          }
+        }
+        return {
+          kind: 'unsupported',
+          raw,
+          reason:
+            `flatMap shape not supported. Accepted (field projection):\n` +
+            `  arr.flatMap(i => i)         (flatten one level)\n` +
+            `  arr.flatMap(i => i.field)   (flatten a per-item array field)\n` +
+            `Array-literal / transform callbacks aren't lowered yet. ` +
+            `Wrap the call in /* @client */ to evaluate at hydration.`,
+        }
+      }
     }
 
     return { kind: 'call', callee, args }
@@ -1499,6 +1566,51 @@ export function extractReduceOpFromTS(
 }
 
 /**
+ * Recover a `FlatMapOp` from the single-argument callback of a
+ * value-returning `.flatMap(fn)` (#1448 Tier C). Operates on the raw TS
+ * AST, mirroring `extractReduceOpFromTS`.
+ *
+ * The accepted catalogue is the field-projection family only:
+ *
+ *   i => i          → self  (flatMap(identity) === flat(1))
+ *   i => i.field    → field (flatten a per-item array field)
+ *
+ * The callback must take exactly one identifier param (the index / array
+ * params can't be expressed in a template projection), and the body must
+ * be the param itself or a single non-computed field access on it. Block
+ * bodies reduce to a single `return`, like the reduce / sort extractors.
+ * Array-literal and any other body returns null and the caller emits
+ * `unsupported` (BF101).
+ */
+export function extractFlatMapOpFromTS(cbNode: ts.Node): FlatMapOp | null {
+  if (!ts.isArrowFunction(cbNode) && !ts.isFunctionExpression(cbNode)) return null
+  // Exactly `(item)` — a `(item, index)` / `(item, index, array)` callback
+  // can't be lowered to a declarative projection.
+  if (cbNode.parameters.length !== 1) return null
+  const p = cbNode.parameters[0]
+  if (!ts.isIdentifier(p.name)) return null
+  const param = p.name.text
+
+  let body: ts.Expression
+  if (ts.isArrowFunction(cbNode) && !ts.isBlock(cbNode.body)) {
+    body = cbNode.body
+  } else {
+    const block = cbNode.body as ts.Block
+    const stmts = block.statements
+    if (stmts.length !== 1 || !ts.isReturnStatement(stmts[0]) || !stmts[0].expression) return null
+    body = stmts[0].expression
+  }
+  const raw = body.getText()
+
+  // Reuse the reduce key classifier — `i` → self, `i.field` → field, and
+  // null for anything deeper (`i.a.b`, `i[k]`, an array literal, a call).
+  const key = classifyReduceKey(unwrapParens(body), param)
+  if (!key) return null
+
+  return { key, param, raw }
+}
+
+/**
  * Classify a reduce per-item operand into a `ReduceOp` key. Accepts
  * the bare item param (`x` → self) and a single non-computed field
  * access (`x.field` → field); returns null for anything deeper
@@ -2123,6 +2235,11 @@ function substituteDestructuredFields(
           // substitute. Preserve verbatim, same as sort / reduce above.
           return { kind: 'array-method', method: 'flat', object: walk(e.object), args: [], flatDepth: e.flatDepth }
         }
+        if (e.method === 'flatMap') {
+          // `FlatMapOp` references its own callback param, never the
+          // enclosing destructure — preserve verbatim, like reduce / sort.
+          return { kind: 'array-method', method: 'flatMap', object: walk(e.object), args: [], flatMapOp: e.flatMapOp }
+        }
         return { kind: 'array-method', method: e.method, object: walk(e.object), args: e.args.map(walk) }
       case 'literal':
       case 'unsupported':
@@ -2609,6 +2726,10 @@ export function exprToString(expr: ParsedExpr): string {
         const depthSrc = d === 'infinity' ? 'Infinity' : String(d)
         return `${exprToString(expr.object)}.flat(${d === 1 ? '' : depthSrc})`
       }
+      if (expr.method === 'flatMap') {
+        const { param, raw } = expr.flatMapOp
+        return `${exprToString(expr.object)}.flatMap(${param} => ${raw})`
+      }
       return `${exprToString(expr.object)}.${expr.method}(${expr.args.map(exprToString).join(', ')})`
     case 'unsupported':
       return `[UNSUPPORTED: ${expr.raw}]`
@@ -2687,6 +2808,12 @@ export function stringifyParsedExpr(expr: ParsedExpr): string {
         const d = expr.flatDepth
         const depthSrc = d === 'infinity' ? 'Infinity' : String(d)
         return `${stringifyParsedExpr(expr.object)}.flat(${d === 1 ? '' : depthSrc})`
+      }
+      if (expr.method === 'flatMap') {
+        // Round-trip the user's callback param + body so the CSR / Hono
+        // path re-parses valid JS (`raw` references the param verbatim).
+        const { param, raw } = expr.flatMapOp
+        return `${stringifyParsedExpr(expr.object)}.flatMap(${param} => ${raw})`
       }
       return `${stringifyParsedExpr(expr.object)}.${expr.method}(${expr.args.map(stringifyParsedExpr).join(', ')})`
     case 'unsupported':

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -330,11 +330,12 @@ const UNSUPPORTED_METHODS = new Set([
   // `array-method` IR (structured `FlatDepth`) + `bf_flat` (Go) /
   // `bf->flat` (Mojo). `flatMap` stays listed as a fallback: the
   // field-projection form (`i => i` / `i => i.field`) lowers via a
-  // structured `FlatMapOp`, but the convertNode arm intercepts that
-  // shape before this gate — only the degenerate forms (a bare method
-  // reference, a 0- / 2-arg call) reach here and refuse. Array-literal /
-  // transform callbacks refuse with an explicit reason from the arm. The
-  // JSX-returning `.flatMap` lowers as an `IRLoop` upstream. See #1448.
+  // structured `FlatMapOp`. The convertNode arm intercepts EVERY
+  // `.flatMap(...)` call before this gate — matching shapes lower, and the
+  // off-catalogue / wrong-arity forms get a tailored `unsupported` reason
+  // there — so only a bare method *reference* (`arr.flatMap` uncalled)
+  // falls through to this gate. The JSX-returning `.flatMap` lowers as an
+  // `IRLoop` upstream. See #1448.
   'filter', 'map', 'reduce', 'reduceRight', 'every', 'some',
   'forEach', 'flatMap',
   // #1448 Tier A — Array methods. Each method PR adds the lowering
@@ -881,8 +882,13 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
       // array-literal / transform forms aren't lowered, so they refuse
       // with BF101 + the @client hint. Go uses `bf_flat_map`; Mojo uses
       // `bf->flat_map`.
-      if (callee.property === 'flatMap' && node.arguments.length === 1) {
-        const flatMapOp = extractFlatMapOpFromTS(node.arguments[0])
+      // Intercept EVERY `.flatMap(...)` call (not just the 1-arg form) so
+      // the off-catalogue and wrong-arity shapes get this tailored reason
+      // rather than the generic "flatMap has no template lowering" gate
+      // message, which now misleads (the field-projection form does lower).
+      if (callee.property === 'flatMap') {
+        const flatMapOp =
+          node.arguments.length === 1 ? extractFlatMapOpFromTS(node.arguments[0]) : null
         if (flatMapOp) {
           return {
             kind: 'array-method',
@@ -896,10 +902,11 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
           kind: 'unsupported',
           raw,
           reason:
-            `flatMap shape not supported. Accepted (field projection):\n` +
+            `flatMap shape not supported. Accepted (field projection, no thisArg):\n` +
             `  arr.flatMap(i => i)         (flatten one level)\n` +
             `  arr.flatMap(i => i.field)   (flatten a per-item array field)\n` +
-            `Array-literal / transform callbacks aren't lowered yet. ` +
+            `Array-literal / transform callbacks and the 2-arg ` +
+            `\`flatMap(fn, thisArg)\` form aren't lowered. ` +
             `Wrap the call in /* @client */ to evaluate at hydration.`,
         }
       }

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -245,7 +245,7 @@ export { ErrorCodes, createError, formatError, generateCodeFrame } from './error
 
 // Expression Parser
 export { parseExpression, isSupported, exprToString, stringifyParsedExpr, identifierPath, parseBlockBody, containsHigherOrder } from './expression-parser'
-export type { ParsedExpr, ParsedStatement, SortComparator, SortKey, ReduceOp, FlatDepth, SupportLevel, SupportResult, TemplatePart } from './expression-parser'
+export type { ParsedExpr, ParsedStatement, SortComparator, SortKey, ReduceOp, FlatDepth, FlatMapOp, SupportLevel, SupportResult, TemplatePart } from './expression-parser'
 export { buildLoopChainExpr } from './loop-chain'
 export type { LoopChainInputs } from './loop-chain'
 


### PR DESCRIPTION
## Summary

Lands the **`.flatMap` half** of the #1448 Tier C `.flat` / `.flatMap` row (the `.flat(depth?)` half merged in #1733). The **field-projection** form of value-returning `.flatMap` now compiles on the template-language adapters (Go, Mojo) instead of refusing with BF101.

The desugar route (`.flatMap(fn)` → `.map(fn).flat(1)`) is a dead end — value-returning `.map` doesn't lower in template position — so this uses a **structured catalogue** (`FlatMapOp`), mirroring `.reduce` / `.sort`.

## Behaviour

The callback is validated and extracted into a structured `FlatMapOp` at parse time:

- `arr.flatMap(i => i)` — self projection (equivalent to `.flat(1)`)
- `arr.flatMap(i => i.field)` — flatten a per-item array field (the dominant real-world case, e.g. `items.flatMap(i => i.tags)`)
- single-`return` block bodies unwrap to the returned expression

The projected per-item value is flattened one level (`flatMap` = map + `flat(1)`); a non-array projection is kept as-is, matching JS. **It composes as a loop base** too — `items.flatMap(i => i.tags).map(t => <li>{t}</li>)` now lowers to a loop over the flattened array instead of refusing.

Out-of-catalogue callbacks — array-literal / transform projections (`i => [i.a, i.b]`), deep field access (`i => i.a.b`), index/array callback params — stay refused with BF101 and keep `/* @client */` as the escape hatch. The JSX-returning `.flatMap` continues to lower as an `IRLoop` upstream (unchanged).

## Changes

- **Parser**: new `array-method` variant `flatMap` carrying a structured `FlatMapOp` (`self` / `field`); `flatMap` stays in `UNSUPPORTED_METHODS` so degenerate / out-of-catalogue forms refuse loudly. `extractFlatMapOpFromTS` reuses the reduce key classifier.
- **Emitter**: new `flatMapMethod()` arm on `ParsedExprEmitter` (drift defence, same as sort / reduce / flat).
- **Go**: new `bf_flat_map` runtime helper (reflect projection + one-level flatten, reusing `getFieldValue` and `Flat`).
- **Mojo**: new `bf->flat_map` helper (HASH-ref field projection + `flat(1)`).

## Test plan

- [x] Compiler unit: `FlatMapOp` extraction (self / field / block-body) + out-of-catalogue refusals + `exprToString`/`stringify` round-trip — `expression-parser.test.ts`
- [x] Adapter emit pins: `bf_flat_map "field" "Tags"` / `"self" ""` and the loop-base chain — `go-template-adapter.test.ts`, `mojo-adapter.test.ts`
- [x] Conformance fixtures `array-flatmap-field` / `array-flatmap-self` — pass CSR/Hono
- [x] `FlatMap` Go helper verified directly via a throwaway `go test` (struct field, JSON-map field, self, scalar-projection); `bf->flat_map` verified via a standalone Perl snippet
- [x] `tsgo --noEmit` clean for `jsx`, `adapter-go-template`, `adapter-mojolicious`
- [x] Full adapter suites green (Go 431, Mojo 444); the 3 `primitive-resolver-all` failures are pre-existing on `main` (TS-checker alias resolution), unrelated

https://claude.ai/code/session_016hsRA9RLzvMgq2YgghQULe

---
_Generated by [Claude Code](https://claude.ai/code/session_016hsRA9RLzvMgq2YgghQULe)_