### PR TITLE
Lower array-literal (tuple) flatMap projection to Go and Mojo (#1448 Tier C)

### DIFF
--- a/.changeset/flatmap-tuple-tier-c.md
+++ b/.changeset/flatmap-tuple-tier-c.md
@@ -1,0 +1,22 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+"@barefootjs/mojolicious": patch
+---
+
+Lower the array-literal (tuple) form of value-returning `Array.prototype.flatMap(fn)` to the template-language adapters (#1448 Tier C).
+
+Building on the field-projection form (#1734), the array-literal projection now compiles:
+
+- `arr.flatMap(i => [i.a, i.b])` — gather per-item fields into a flat list
+- `arr.flatMap(i => [i, i.tags])` — mixed self / field leaves
+
+Every array-literal element must be a `self` (`i`) or `field` (`i.field`) leaf. flatMap's one-level flatten removes only the array-literal wrapper, so each leaf is appended verbatim — an array-valued leaf is kept as a single element (not spread), matching JS `map(...).flat(1)`. A non-object element under a field leaf yields `undefined` / `nil`.
+
+Richer callbacks — elements with arithmetic / computed or deep access / calls / literals, the spread (`[...xs]`) form, and the 2-arg `flatMap(fn, thisArg)` form — stay refused with BF101 and keep `/* @client */` as the escape hatch.
+
+- Parser: `FlatMapOp.projection` gains a `tuple` variant (a list of `FlatMapLeaf`s); `extractFlatMapOpFromTS` classifies each array-literal element.
+- Go: new `bf_flat_map_tuple` runtime helper (variadic `(kind, name)` leaf specs).
+- Mojo: new `bf->flat_map_tuple` helper (one `[kind, key]` arrayref per leaf).
+
+Conformance fixture `array-flatmap-tuple` pins byte-equal output across Hono/CSR, Go, and Mojo. This completes the `.flat` / `.flatMap` Tier C row.

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -64,6 +64,7 @@ func FuncMap() template.FuncMap {
 		"bf_reverse":        Reverse,
 		"bf_flat":           Flat,
 		"bf_flat_map":       FlatMap,
+		"bf_flat_map_tuple": FlatMapTuple,
 		"bf_first":          First,
 		"bf_last":           Last,
 		"bf_arr":            Arr,
@@ -1029,6 +1030,33 @@ func FlatMap(items any, keyKind, keyName string) []any {
 		}
 	}
 	return Flat(projected, 1)
+}
+
+// FlatMapTuple lowers an array-literal flatMap projection
+// `items.flatMap(i => [i.a, i.b])` (#1448 Tier C). `specs` is a flat list
+// of (kind, name) pairs, one per array-literal leaf: ("self", "") for the
+// item itself, ("field", "<Name>") for a struct field. For each item it
+// appends every leaf's value in order. Unlike the scalar `FlatMap`, the
+// per-item array is flattened only one level (flat(1) removes the literal
+// wrapper), so an array-valued leaf is appended verbatim rather than
+// spread — which is exactly "append each leaf". Non-array receiver → empty.
+func FlatMapTuple(items any, specs ...string) []any {
+	v := reflect.ValueOf(items)
+	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
+		return []any{}
+	}
+	out := make([]any, 0, v.Len())
+	for i := 0; i < v.Len(); i++ {
+		el := v.Index(i).Interface()
+		for j := 0; j+1 < len(specs); j += 2 {
+			if specs[j] == "field" {
+				out = append(out, getFieldValue(el, specs[j+1]))
+			} else {
+				out = append(out, el)
+			}
+		}
+	}
+	return out
 }
 
 // First returns the first element of a slice, or nil if empty.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -2368,7 +2368,7 @@ describe('GoTemplateAdapter - #1448 Tier C .flatMap(field projection)', () => {
   function emitFlatMap(expr: string): string {
     const adapter = new GoTemplateAdapter()
     const ir = compileToIR(`
-function C({ rows }: { rows: { tags: string[] }[] }) {
+function C({ rows }: { rows: { a: string; b: string; tags: string[] }[] }) {
   return <div>{${expr}}</div>
 }
 export { C }
@@ -2382,6 +2382,14 @@ export { C }
 
   test('.flatMap(i => i) emits the self projection', () => {
     expect(emitFlatMap('rows.flatMap(i => i).join(" ")')).toContain('bf_flat_map .Rows "self" ""')
+  })
+
+  test('.flatMap(i => [i.a, i.b]) emits bf_flat_map_tuple with capitalised leaves', () => {
+    expect(emitFlatMap('rows.flatMap(i => [i.a, i.b]).join(" ")')).toContain('bf_flat_map_tuple .Rows "field" "A" "field" "B"')
+  })
+
+  test('tuple self + field leaves', () => {
+    expect(emitFlatMap('rows.flatMap(i => [i, i.a]).join(" ")')).toContain('bf_flat_map_tuple .Rows "self" "" "field" "A"')
   })
 })
 
@@ -2435,9 +2443,9 @@ export function C() {
     // the no-initial-value form stays refused — JS throws on an empty
     // array there, which a template can't mirror.
     { name: 'reduce (no init)', expr: `items().reduce((a, b) => a + b.n)`, badEmit: '.Reduce' },
-    // Field-projection `.flatMap(i => i.tags)` now lowers (#1448 Tier C);
-    // the array-literal / transform form stays refused.
-    { name: 'flatMap (array-literal)', expr: `items().flatMap(i => [i.name, i.n])`, badEmit: '.FlatMap' },
+    // Self / field / field-tuple `.flatMap` now lowers (#1448 Tier C); a
+    // tuple with a non-leaf element (here a string literal) stays refused.
+    { name: 'flatMap (literal element)', expr: `items().flatMap(i => [i.name, "x"])`, badEmit: '.FlatMap' },
     // Lowered methods whose MEANINGFUL extra argument isn't lowered yet
     // (#1448): the `fromIndex` of `.includes`/`.indexOf`/`.lastIndexOf`
     // and the variadic `.concat`. The parser refuses these (silently

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -3405,15 +3405,25 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   flatMapMethod(object: ParsedExpr, op: FlatMapOp, emit: (e: ParsedExpr) => string): string {
-    // `.flatMap(i => i)` / `.flatMap(i => i.field)` → `bf_flat_map <recv>
-    // "<keyKind>" "<keyName>"`. The runtime projects each item (self or a
-    // struct field) then flattens one level. The field name uses the Go
-    // struct-field capitalisation, matching `bf_reduce` / `bf_sort`.
     const recv = wrapIfMultiToken(emit(object))
-    if (op.key.kind === 'self') {
+    const proj = op.projection
+    // Tuple projection `i => [i.a, i.b]` → `bf_flat_map_tuple <recv>
+    // "<kind>" "<name>" ...` (one quoted pair per leaf). flat(1) removes
+    // only the literal's wrapper, so the runtime appends each leaf verbatim.
+    if (proj.kind === 'tuple') {
+      const pairs = proj.elements
+        .map(l => (l.kind === 'self' ? `"self" ""` : `"field" "${capitalize(l.field)}"`))
+        .join(' ')
+      return `bf_flat_map_tuple ${recv} ${pairs}`
+    }
+    // Scalar `.flatMap(i => i)` / `.flatMap(i => i.field)` → `bf_flat_map
+    // <recv> "<kind>" "<name>"`. The runtime projects each item then
+    // flattens one level. The field name uses the Go struct-field
+    // capitalisation, matching `bf_reduce` / `bf_sort`.
+    if (proj.kind === 'self') {
       return `bf_flat_map ${recv} "self" ""`
     }
-    return `bf_flat_map ${recv} "field" "${capitalize(op.key.field)}"`
+    return `bf_flat_map ${recv} "field" "${capitalize(proj.field)}"`
   }
 
   unsupported(raw: string, _reason: string): string {

--- a/packages/adapter-mojolicious/lib/BarefootJS.pm
+++ b/packages/adapter-mojolicious/lib/BarefootJS.pm
@@ -549,6 +549,30 @@ sub flat_map ($self, $recv, $key_kind, $key) {
     return $self->flat(\@projected, 1);
 }
 
+# `Array.prototype.flatMap(i => [i.a, i.b])` — array-literal tuple
+# projection (#1448 Tier C). Each `@specs` entry is a [kind, key] arrayref
+# (['self', ''] or ['field', 'a']). For each element, every leaf's value
+# is appended in order. flat(1) removes only the literal wrapper, so an
+# array-valued leaf is appended verbatim (no spread) — i.e. just append
+# each leaf. A non-HASH element under a `field` leaf yields undef (JS
+# `i.field` on a non-object). Non-ARRAY receiver → [].
+sub flat_map_tuple ($self, $recv, @specs) {
+    return [] unless ref($recv) eq 'ARRAY';
+    my @out;
+    for my $el (@$recv) {
+        for my $spec (@specs) {
+            my ($kind, $key) = @$spec;
+            if ($kind eq 'field') {
+                push @out, ref($el) eq 'HASH' ? $el->{$key} : undef;
+            }
+            else {
+                push @out, $el;
+            }
+        }
+    }
+    return \@out;
+}
+
 # `String.prototype.trim()` — strip leading + trailing whitespace.
 # JS's `String.prototype.trim` matches `\s` in the Unicode sense
 # (any whitespace including non-breaking space U+00A0); Perl's `\s`

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -401,10 +401,10 @@ export function C() {
       // empty array there, which a template can't mirror.
       { name: 'reduce (no init)',  body: `<div>{items().reduce((s, x) => s + x)}</div>`,                                                             needle: '.reduce(' },
       { name: 'forEach',           body: `<ul>{items().forEach(x => x)}</ul>`,                                                                       needle: '.forEach(' },
-      // The field-projection `.flatMap(x => x.tags)` now lowers (#1448
-      // Tier C) — even as a loop base — so it moved to the positive test
-      // below. The array-literal / transform form stays refused.
-      { name: 'flatMap (array-literal)', body: `<div>{items().flatMap(x => [x.tags, x.tags])}</div>`,                                              needle: '.flatMap(' },
+      // Self / field / field-tuple `.flatMap` now lowers (#1448 Tier C) —
+      // even as a loop base — so those moved to positive tests below. A
+      // tuple with a non-leaf element (a string literal) stays refused.
+      { name: 'flatMap (literal element)', body: `<div>{items().flatMap(x => [x.tag, "x"])}</div>`,                                                needle: '.flatMap(' },
     ]
 
     for (const { name, body, needle } of cases) {
@@ -1094,7 +1094,7 @@ describe('MojoAdapter - #1448 Tier C .flatMap(field projection)', () => {
   function emitFlatMap(expr: string): string {
     const a = new MojoAdapter()
     const ir = compileToIR(`
-function C({ rows }: { rows: { tags: string[] }[] }) {
+function C({ rows }: { rows: { a: string; b: string; tags: string[] }[] }) {
   return <div>{${expr}}</div>
 }
 export { C }
@@ -1108,6 +1108,14 @@ export { C }
 
   test('.flatMap(i => i) emits the self projection', () => {
     expect(emitFlatMap('rows.flatMap(i => i).join(" ")')).toContain(`bf->flat_map($rows, 'self', '')`)
+  })
+
+  test('.flatMap(i => [i.a, i.b]) emits bf->flat_map_tuple with leaf specs', () => {
+    expect(emitFlatMap('rows.flatMap(i => [i.a, i.b]).join(" ")')).toContain(`bf->flat_map_tuple($rows, ['field', 'a'], ['field', 'b'])`)
+  })
+
+  test('tuple self + field leaves', () => {
+    expect(emitFlatMap('rows.flatMap(i => [i, i.a]).join(" ")')).toContain(`bf->flat_map_tuple($rows, ['self', ''], ['field', 'a'])`)
   })
 
   test('field-projection flatMap as a loop base lowers (no BF101)', () => {
@@ -1187,9 +1195,9 @@ export function C() {
     // the no-initial-value form stays refused — JS throws on an empty
     // array there, which a template can't mirror.
     { name: 'reduce (no init)', expr: `items().reduce((a, b) => a + b.n)`, badEmit: '->{reduce}' },
-    // Field-projection `.flatMap(i => i.tags)` now lowers (#1448 Tier C);
-    // the array-literal / transform form stays refused.
-    { name: 'flatMap (array-literal)', expr: `items().flatMap(i => [i.name, i.n])`, badEmit: '->{flatMap}' },
+    // Self / field / field-tuple `.flatMap` now lowers (#1448 Tier C); a
+    // tuple with a non-leaf element (here a string literal) stays refused.
+    { name: 'flatMap (literal element)', expr: `items().flatMap(i => [i.name, "x"])`, badEmit: '->{flatMap}' },
     // Lowered methods whose MEANINGFUL extra argument isn't lowered yet
     // (#1448): the `fromIndex` of `.includes`/`.indexOf`/`.lastIndexOf`
     // and the variadic `.concat`. The parser refuses these (silently

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1574,12 +1574,21 @@ function renderFlatMethod(recv: string, depth: FlatDepth): string {
 }
 
 // `.flatMap(i => i)` / `.flatMap(i => i.field)` → `bf->flat_map($recv,
-// 'self'|'field', 'field')`. The runtime projects each item then flattens
-// one level. The field key is the raw JS prop name (Perl hashes are keyed
-// by it), mirroring `bf->reduce`. See `sub flat_map` in BarefootJS.pm.
+// 'self'|'field', 'field')`, and the array-literal tuple form
+// `i => [i.a, i.b]` → `bf->flat_map_tuple($recv, ['field','a'], ...)`
+// (one arrayref per leaf). The field key is the raw JS prop name (Perl
+// hashes are keyed by it), mirroring `bf->reduce`. See `sub flat_map` /
+// `sub flat_map_tuple` in BarefootJS.pm.
 function renderFlatMapMethod(recv: string, op: FlatMapOp): string {
-  if (op.key.kind === 'self') return `bf->flat_map(${recv}, 'self', '')`
-  return `bf->flat_map(${recv}, 'field', '${op.key.field}')`
+  const proj = op.projection
+  if (proj.kind === 'tuple') {
+    const specs = proj.elements
+      .map(l => (l.kind === 'self' ? `['self', '']` : `['field', '${l.field}']`))
+      .join(', ')
+    return `bf->flat_map_tuple(${recv}, ${specs})`
+  }
+  if (proj.kind === 'self') return `bf->flat_map(${recv}, 'self', '')`
+  return `bf->flat_map(${recv}, 'field', '${proj.field}')`
 }
 
 /** True when `type` is the `string` primitive. */

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -135,6 +135,7 @@ import { fixture as arrayFlatDepth } from './methods/array-flat-depth'
 import { fixture as arrayFlatInfinity } from './methods/array-flat-infinity'
 import { fixture as arrayFlatMapField } from './methods/array-flatmap-field'
 import { fixture as arrayFlatMapSelf } from './methods/array-flatmap-self'
+import { fixture as arrayFlatMapTuple } from './methods/array-flatmap-tuple'
 import { fixture as stringToLowerCase } from './methods/string-toLowerCase'
 import { fixture as stringToUpperCase } from './methods/string-toUpperCase'
 import { fixture as stringTrim } from './methods/string-trim'
@@ -327,6 +328,7 @@ export const jsxFixtures: JSXFixture[] = [
   arrayFlatInfinity,
   arrayFlatMapField,
   arrayFlatMapSelf,
+  arrayFlatMapTuple,
   // #1448 Tier A — String methods.
   stringToLowerCase,
   stringToUpperCase,

--- a/packages/adapter-tests/fixtures/methods/array-flatmap-tuple.ts
+++ b/packages/adapter-tests/fixtures/methods/array-flatmap-tuple.ts
@@ -1,0 +1,25 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `Array.prototype.flatMap(i => [i.a, i.b])` — array-literal tuple
+ * projection (#1448 Tier C).
+ *
+ * Each item is mapped to a `[a, b]` pair; flatMap's one-level flatten
+ * gathers all pairs into a single flat list. Composed with `.join(' ')`
+ * so the interleaved order is visible. Go uses `bf_flat_map_tuple`; Mojo
+ * uses `bf->flat_map_tuple`.
+ */
+export const fixture = createFixture({
+  id: 'array-flatmap-tuple',
+  description: '.flatMap(i => [i.a, i.b]) gathers per-item field pairs',
+  source: `
+function ArrayFlatMapTuple({ items }: { items: { a: string; b: string }[] }) {
+  return <div>{items.flatMap(i => [i.a, i.b]).join(' ')}</div>
+}
+export { ArrayFlatMapTuple }
+`,
+  props: { items: [{ a: 'a1', b: 'b1' }, { a: 'a2', b: 'b2' }] },
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><!--bf:s0-->a1 b1 a2 b2<!--/--></div>
+  `,
+})

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test'
 import ts from 'typescript'
-import { parseExpression, isSupported, exprToString, parseBlockBody } from '../expression-parser'
+import { parseExpression, isSupported, exprToString, stringifyParsedExpr, parseBlockBody } from '../expression-parser'
 import { collectAllTypeRanges, reconstructWithoutTypes } from '../strip-types'
 
 describe('expression-parser', () => {
@@ -1606,7 +1606,17 @@ describe('expression-parser — .flatMap(fn) projection (#1448 Tier C)', () => {
   }
 
   test('exprToString / stringify round-trip the callback', () => {
-    expect(exprToString(parseExpression('arr.flatMap(i => i.tags)'))).toBe('arr.flatMap(i => i.tags)')
-    expect(exprToString(parseExpression('arr.flatMap(t => t)'))).toBe('arr.flatMap(t => t)')
+    // Scalar projections, plus the array-literal tuple — the round-trip
+    // relies on the callback `raw`, so a regression in raw capture would
+    // surface here for every projection shape.
+    for (const src of [
+      'arr.flatMap(i => i.tags)',
+      'arr.flatMap(t => t)',
+      'arr.flatMap(i => [i.a, i.b])',
+      'arr.flatMap(i => [i, i.tags])',
+    ]) {
+      expect(exprToString(parseExpression(src))).toBe(src)
+      expect(stringifyParsedExpr(parseExpression(src))).toBe(src)
+    }
   })
 })

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -1588,6 +1588,9 @@ describe('expression-parser — .flatMap(fn) projection (#1448 Tier C)', () => {
     ['tuple with literal element', 'arr.flatMap(i => [i.a, "x"])'],
     ['tuple with deep access', 'arr.flatMap(i => [i.a, i.b.c])'],
     ['tuple with spread', 'arr.flatMap(i => [...i.a])'],
+    // Empty tuple is a degenerate no-op — refused so emitters never
+    // produce a zero-arg `flat_map_tuple` call.
+    ['empty tuple', 'arr.flatMap(i => [])'],
     // Wrong-arity forms are intercepted by the same arm (not the generic
     // "flatMap has no template lowering" gate) so the reason stays tailored.
     ['2-arg flatMap(fn, thisArg)', 'arr.flatMap(i => i.tags, ctx)'],

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -1556,30 +1556,38 @@ describe('expression-parser — .flat(depth?) lowering (#1448 Tier C)', () => {
   })
 })
 
-describe('expression-parser — .flatMap(fn) field projection (#1448 Tier C)', () => {
-  // Accepted catalogue: self (`i => i`) and single field (`i => i.field`).
-  const accepted: Array<[string, string, { kind: 'self' } | { kind: 'field'; field: string }]> = [
+describe('expression-parser — .flatMap(fn) projection (#1448 Tier C)', () => {
+  // Accepted catalogue: self, single field, and array-literal tuples of
+  // self / field leaves.
+  type Proj = { kind: 'self' } | { kind: 'field'; field: string } | { kind: 'tuple'; elements: unknown[] }
+  const accepted: Array<[string, string, Proj]> = [
     ['self (i => i)', 'arr.flatMap(i => i)', { kind: 'self' }],
     ['field (i => i.tags)', 'arr.flatMap(i => i.tags)', { kind: 'field', field: 'tags' }],
     ['single-return block body', 'arr.flatMap(i => { return i.tags })', { kind: 'field', field: 'tags' }],
+    ['tuple of fields', 'arr.flatMap(i => [i.a, i.b])', { kind: 'tuple', elements: [{ kind: 'field', field: 'a' }, { kind: 'field', field: 'b' }] }],
+    ['tuple self + field', 'arr.flatMap(i => [i, i.tags])', { kind: 'tuple', elements: [{ kind: 'self' }, { kind: 'field', field: 'tags' }] }],
   ]
-  for (const [label, expr, key] of accepted) {
+  for (const [label, expr, projection] of accepted) {
     test(`${label} — lowers to a flatMap array-method`, () => {
       const result = parseExpression(expr)
       expect(result.kind).toBe('array-method')
       if (result.kind === 'array-method' && result.method === 'flatMap') {
-        expect(result.flatMapOp.key).toEqual(key)
+        expect(result.flatMapOp.projection).toEqual(projection)
       } else {
         throw new Error(`expected a flatMap array-method, got ${result.kind}`)
       }
     })
   }
 
-  // Out of the field-projection catalogue → refused (BF101 + @client hint).
+  // Out of catalogue → refused (BF101 + @client hint).
   const refused = [
-    ['array-literal projection', 'arr.flatMap(i => [i.a, i.b])'],
     ['deep field access', 'arr.flatMap(i => i.a.b)'],
     ['index/array callback params', 'arr.flatMap((i, idx) => i.tags)'],
+    // Tuple with a non-leaf element (arithmetic / literal / deep access).
+    ['tuple with arithmetic element', 'arr.flatMap(i => [i.a, i.b + 1])'],
+    ['tuple with literal element', 'arr.flatMap(i => [i.a, "x"])'],
+    ['tuple with deep access', 'arr.flatMap(i => [i.a, i.b.c])'],
+    ['tuple with spread', 'arr.flatMap(i => [...i.a])'],
     // Wrong-arity forms are intercepted by the same arm (not the generic
     // "flatMap has no template lowering" gate) so the reason stays tailored.
     ['2-arg flatMap(fn, thisArg)', 'arr.flatMap(i => i.tags, ctx)'],
@@ -1589,7 +1597,7 @@ describe('expression-parser — .flatMap(fn) field projection (#1448 Tier C)', (
       const result = parseExpression(expr)
       expect(result.kind).toBe('unsupported')
       if (result.kind === 'unsupported') {
-        expect(result.reason).toContain('field projection')
+        expect(result.reason).toContain('flatMap shape not supported')
       }
     })
   }

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -1633,6 +1633,10 @@ export function extractFlatMapOpFromTS(cbNode: ts.Node): FlatMapOp | null {
   // lowered). flat(1) removes only the literal's wrapper, so each leaf is
   // appended verbatim — handled by the `bf_flat_map_tuple` runtime.
   if (ts.isArrayLiteralExpression(inner)) {
+    // An empty tuple (`i => []`) is a degenerate no-op projection (always
+    // yields nothing). Refuse it so the emitters never produce a
+    // zero-arg `bf_flat_map_tuple` / `bf->flat_map_tuple(...,)` call.
+    if (inner.elements.length === 0) return null
     const elements: FlatMapLeaf[] = []
     for (const el of inner.elements) {
       // Spread / holes (`[...xs]`, `[, x]`) aren't leaves.

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -233,18 +233,31 @@ export type ReduceOp = {
 export type FlatDepth = number | 'infinity'
 
 /**
+ * A single non-computed projection leaf on the flatMap callback param —
+ * the item itself (`i`) or one of its fields (`i.field`). Shared by the
+ * scalar and tuple `FlatMapOp` projections.
+ */
+export type FlatMapLeaf = { kind: 'self' } | { kind: 'field'; field: string }
+
+/**
  * Structured form of a value-returning `.flatMap(fn)` callback (#1448
- * Tier C). The accepted catalogue is the field-projection family only —
- * the callback maps each item to either itself (`i => i`) or a single
- * non-computed field (`i => i.tags`), and the projected value is then
- * flattened one level (flatMap = map + flat(1)). A projected non-array
- * value is kept as-is, matching JS. Array-literal / transform callbacks
- * (`i => [i.a, i.b]`) are out of scope and refuse with BF101. See
- * `extractFlatMapOpFromTS`.
+ * Tier C). The accepted catalogue:
+ *
+ *   i => i            → self  projection (flatten one level)
+ *   i => i.field      → field projection (flatten a per-item array field)
+ *   i => [i.a, i.b]   → tuple projection (gather per-item leaves)
+ *
+ * The scalar `self` / `field` projections return a value that is then
+ * flattened one level (flatMap = map + flat(1)) — a non-array value is
+ * kept as-is, matching JS. The `tuple` projection returns an array
+ * literal; flat(1) removes only that literal's wrapper, so each leaf is
+ * appended verbatim (an array-valued leaf is NOT spread). Leaves outside
+ * self / field (literals, `i.a + 1`, calls, deep access) refuse with
+ * BF101. See `extractFlatMapOpFromTS`.
  */
 export type FlatMapOp = {
   // What each item projects to before the one-level flatten.
-  key: { kind: 'self' } | { kind: 'field'; field: string }
+  projection: FlatMapLeaf | { kind: 'tuple'; elements: FlatMapLeaf[] }
   // The callback param name the user wrote (for the `@client` round-trip).
   param: string
   // Original JS source of the callback body (for the `@client` fallback).
@@ -875,13 +888,13 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
       // throws on an empty array, which a template can't mirror. Fall
       // through to the BF101 gate with the @client escape hatch.
 
-      // `.flatMap(fn)` value-returning field projection (#1448 Tier C).
-      // The callback is extracted into a structured `FlatMapOp` (self /
-      // field projection) from the raw TS AST. The JSX-returning form is
-      // handled as an `IRLoop` upstream and never reaches here; the
-      // array-literal / transform forms aren't lowered, so they refuse
-      // with BF101 + the @client hint. Go uses `bf_flat_map`; Mojo uses
-      // `bf->flat_map`.
+      // `.flatMap(fn)` value-returning projection (#1448 Tier C). The
+      // callback is extracted into a structured `FlatMapOp` (self / field
+      // scalar projection, or an array-literal tuple of self / field
+      // leaves) from the raw TS AST. The JSX-returning form is handled as
+      // an `IRLoop` upstream and never reaches here; richer callbacks
+      // refuse with BF101 + the @client hint. Go uses `bf_flat_map` /
+      // `bf_flat_map_tuple`; Mojo uses `bf->flat_map` / `bf->flat_map_tuple`.
       // Intercept EVERY `.flatMap(...)` call (not just the 1-arg form) so
       // the off-catalogue and wrong-arity shapes get this tailored reason
       // rather than the generic "flatMap has no template lowering" gate
@@ -902,12 +915,13 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
           kind: 'unsupported',
           raw,
           reason:
-            `flatMap shape not supported. Accepted (field projection, no thisArg):\n` +
-            `  arr.flatMap(i => i)         (flatten one level)\n` +
-            `  arr.flatMap(i => i.field)   (flatten a per-item array field)\n` +
-            `Array-literal / transform callbacks and the 2-arg ` +
-            `\`flatMap(fn, thisArg)\` form aren't lowered. ` +
-            `Wrap the call in /* @client */ to evaluate at hydration.`,
+            `flatMap shape not supported. Accepted (self / field leaves, no thisArg):\n` +
+            `  arr.flatMap(i => i)          (flatten one level)\n` +
+            `  arr.flatMap(i => i.field)    (flatten a per-item array field)\n` +
+            `  arr.flatMap(i => [i.a, i.b]) (gather per-item fields)\n` +
+            `Richer callbacks (computed / nested access, arithmetic, calls, ` +
+            `literal elements) and the 2-arg \`flatMap(fn, thisArg)\` form ` +
+            `aren't lowered. Wrap the call in /* @client */ to evaluate at hydration.`,
         }
       }
     }
@@ -1577,17 +1591,20 @@ export function extractReduceOpFromTS(
  * value-returning `.flatMap(fn)` (#1448 Tier C). Operates on the raw TS
  * AST, mirroring `extractReduceOpFromTS`.
  *
- * The accepted catalogue is the field-projection family only:
+ * The accepted catalogue:
  *
- *   i => i          → self  (flatMap(identity) === flat(1))
- *   i => i.field    → field (flatten a per-item array field)
+ *   i => i            → self  (flatMap(identity) === flat(1))
+ *   i => i.field      → field (flatten a per-item array field)
+ *   i => [i.a, i.b]   → tuple (gather per-item self / field leaves)
  *
  * The callback must take exactly one identifier param (the index / array
  * params can't be expressed in a template projection), and the body must
- * be the param itself or a single non-computed field access on it. Block
- * bodies reduce to a single `return`, like the reduce / sort extractors.
- * Array-literal and any other body returns null and the caller emits
- * `unsupported` (BF101).
+ * be the param itself, a single non-computed field access on it, or an
+ * array literal whose every element is one of those leaves. Block bodies
+ * reduce to a single `return`, like the reduce / sort extractors. Any
+ * other body (deep access, computed members, calls, arithmetic, a
+ * literal element) returns null and the caller emits `unsupported`
+ * (BF101).
  */
 export function extractFlatMapOpFromTS(cbNode: ts.Node): FlatMapOp | null {
   if (!ts.isArrowFunction(cbNode) && !ts.isFunctionExpression(cbNode)) return null
@@ -1608,13 +1625,31 @@ export function extractFlatMapOpFromTS(cbNode: ts.Node): FlatMapOp | null {
     body = stmts[0].expression
   }
   const raw = body.getText()
+  const inner = unwrapParens(body)
 
-  // Reuse the reduce key classifier — `i` → self, `i.field` → field, and
-  // null for anything deeper (`i.a.b`, `i[k]`, an array literal, a call).
-  const key = classifyReduceKey(unwrapParens(body), param)
-  if (!key) return null
+  // Array-literal body → tuple projection. Every element must be a
+  // self / field leaf; a literal / computed / nested element refuses the
+  // whole shape (the per-item evaluation of richer expressions isn't
+  // lowered). flat(1) removes only the literal's wrapper, so each leaf is
+  // appended verbatim — handled by the `bf_flat_map_tuple` runtime.
+  if (ts.isArrayLiteralExpression(inner)) {
+    const elements: FlatMapLeaf[] = []
+    for (const el of inner.elements) {
+      // Spread / holes (`[...xs]`, `[, x]`) aren't leaves.
+      if (ts.isSpreadElement(el) || ts.isOmittedExpression(el)) return null
+      const leaf = classifyReduceKey(unwrapParens(el), param)
+      if (!leaf) return null
+      elements.push(leaf)
+    }
+    return { projection: { kind: 'tuple', elements }, param, raw }
+  }
 
-  return { key, param, raw }
+  // Scalar body. Reuse the reduce key classifier — `i` → self,
+  // `i.field` → field, null for anything deeper (`i.a.b`, `i[k]`, a call).
+  const leaf = classifyReduceKey(inner, param)
+  if (!leaf) return null
+
+  return { projection: leaf, param, raw }
 }
 
 /**

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -245,7 +245,7 @@ export { ErrorCodes, createError, formatError, generateCodeFrame } from './error
 
 // Expression Parser
 export { parseExpression, isSupported, exprToString, stringifyParsedExpr, identifierPath, parseBlockBody, containsHigherOrder } from './expression-parser'
-export type { ParsedExpr, ParsedStatement, SortComparator, SortKey, ReduceOp, FlatDepth, FlatMapOp, SupportLevel, SupportResult, TemplatePart } from './expression-parser'
+export type { ParsedExpr, ParsedStatement, SortComparator, SortKey, ReduceOp, FlatDepth, FlatMapOp, FlatMapLeaf, SupportLevel, SupportResult, TemplatePart } from './expression-parser'
 export { buildLoopChainExpr } from './loop-chain'
 export type { LoopChainInputs } from './loop-chain'
 


### PR DESCRIPTION
## Summary

Lowers the **array-literal (tuple) form** of value-returning `Array.prototype.flatMap(fn)`, the deferred half of the #1448 Tier C `.flatMap` row (field-projection landed in #1734). This **completes the `.flat` / `.flatMap` Tier C row**.

```tsx
items.flatMap(i => [i.a, i.b])   // gather per-item fields into a flat list
items.flatMap(i => [i, i.tags])  // mixed self / field leaves
```

## Behaviour

Every array-literal element must be a `self` (`i`) or `field` (`i.field`) leaf. flatMap's one-level flatten removes only the array-literal wrapper, so **each leaf is appended verbatim** — an array-valued leaf is kept as a single element (not spread), matching JS `map(...).flat(1)`. A non-object element under a field leaf yields `undefined` / `nil`.

Richer callbacks stay refused with BF101 (`/* @client */` escape hatch): elements with arithmetic / computed-or-deep access / calls / **literals**, the spread (`[...xs]`) form, and the 2-arg `flatMap(fn, thisArg)` form.

## Changes

- **Parser**: `FlatMapOp.projection` gains a `tuple` variant (a list of the shared `FlatMapLeaf`); `extractFlatMapOpFromTS` classifies each array-literal element (reusing the reduce key classifier) and refuses spreads / non-leaf elements.
- **Go**: new `bf_flat_map_tuple` runtime helper (variadic `(kind, name)` leaf-spec pairs).
- **Mojo**: new `bf->flat_map_tuple` helper (one `[kind, key]` arrayref per leaf).

## Test plan

- [x] Compiler unit: tuple extraction (fields, mixed self+field) + refusals (arithmetic / literal / deep-access / spread elements, 2-arg) — `expression-parser.test.ts` (13 flatMap tests)
- [x] Adapter emit pins: `bf_flat_map_tuple … "field" "A" "field" "B"` / `bf->flat_map_tuple(…, ['field','a'], …)` — both adapters
- [x] Conformance fixture `array-flatmap-tuple` — passes CSR/Hono **and** Go-rendered (verified locally via `GOTOOLCHAIN=go1.25.6`)
- [x] `FlatMapTuple` Go helper + `flat_map_tuple` Perl verified directly (field pairs, array-leaf-not-spread, non-object→nil/undef)
- [x] `tsgo --noEmit` clean for all three packages; full Go (0 fail) / Mojo (448 pass) suites green
- [x] The 4 `primitive-resolver-*` (TS-checker alias) failures are pre-existing on clean `main`, unrelated

https://claude.ai/code/session_016hsRA9RLzvMgq2YgghQULe

---
_Generated by [Claude Code](https://claude.ai/code/session_016hsRA9RLzvMgq2YgghQULe)_