### PR TITLE
fix(hono): render fallback on async boundary body error (#1375)

### DIFF
--- a/.changeset/async-boundary-error-fallback.md
+++ b/.changeset/async-boundary-error-fallback.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/hono": patch
+---
+
+Render the fallback when an async boundary body fails. A `<Async>` / `BfAsync` body that throws synchronously or rejects during async resolution now surfaces the same `fallback` instead of aborting the stream (sync) or leaking an unhandled rejection (async). The body is wrapped in Hono's `ErrorBoundary` on both the runtime `BfAsync` component and the compiled `<Async>` emit path. `BfAsync` also gains an optional `onError` hook so failures aren't swallowed silently.

--- a/packages/adapter-hono/src/__tests__/async-error-boundary.test.ts
+++ b/packages/adapter-hono/src/__tests__/async-error-boundary.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Hono adapter: compiled `<Async>` boundary wraps its body in ErrorBoundary
+ * for the body error path (#1375).
+ *
+ * The compiler lowers `<Async fallback={…}>…</Async>` to an `IRAsync` node;
+ * the Hono adapter's `renderAsync` emits it into the generated SSR template.
+ * A bare `<Suspense>` mishandles a body that fails at render time: a
+ * synchronous throw aborts the stream with empty output, and a Promise
+ * rejection during async resolution escapes as an unhandled rejection while
+ * the loading fallback is left stranded.
+ *
+ * The fix wraps the streaming body in Hono's `ErrorBoundary` with the same
+ * `fallback`, mirroring the hand-written `BfAsync` runtime component
+ * (`../async.tsx`). The runtime behaviour itself is asserted in
+ * `async.test.tsx`; this test pins the *emit shape* of the compiled path.
+ */
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '@barefootjs/jsx'
+import { HonoAdapter } from '../adapter'
+
+const adapter = new HonoAdapter()
+
+function templateOf(source: string): string {
+  const result = compileJSX(source, 'Page.tsx', { adapter })
+  expect(result.errors.filter((e) => e.severity === 'error')).toEqual([])
+  return result.files.find((f) => f.type === 'markedTemplate')?.content ?? ''
+}
+
+describe('compiled <Async> boundary — ErrorBoundary wrapping (#1375)', () => {
+  test('emits ErrorBoundary enclosing Suspense, sharing the fallback', () => {
+    const template = templateOf(`
+      export function Page() {
+        return (
+          <div>
+            <Async fallback={<p>Loading...</p>}>
+              <span>Resolved</span>
+            </Async>
+          </div>
+        )
+      }
+    `)
+
+    expect(template).toContain('<ErrorBoundary fallback={<>')
+    expect(template).toContain('<Suspense fallback={<>')
+    // ErrorBoundary must enclose Suspense (catch errors raised while the
+    // Suspense body resolves), not the reverse.
+    expect(template.indexOf('<ErrorBoundary')).toBeLessThan(template.indexOf('<Suspense'))
+    expect(template).toContain('</Suspense></ErrorBoundary>')
+  })
+
+  test('injects the ErrorBoundary import alongside Suspense', () => {
+    const template = templateOf(`
+      export function Page() {
+        return (
+          <Async fallback={<p>Loading...</p>}>
+            <span>Resolved</span>
+          </Async>
+        )
+      }
+    `)
+
+    expect(template).toContain(`import { Suspense } from 'hono/jsx/streaming'`)
+    expect(template).toContain(`import { ErrorBoundary } from 'hono/jsx'`)
+  })
+
+  test('each of multiple boundaries gets its own ErrorBoundary wrapper', () => {
+    const template = templateOf(`
+      export function Dashboard() {
+        return (
+          <div>
+            <Async fallback={<p>A...</p>}>
+              <span>A</span>
+            </Async>
+            <Async fallback={<p>B...</p>}>
+              <span>B</span>
+            </Async>
+          </div>
+        )
+      }
+    `)
+
+    const wrappers = template.match(/<ErrorBoundary fallback=\{<>/g) ?? []
+    expect(wrappers.length).toBe(2)
+  })
+})

--- a/packages/adapter-hono/src/__tests__/async-error-boundary.test.ts
+++ b/packages/adapter-hono/src/__tests__/async-error-boundary.test.ts
@@ -40,15 +40,17 @@ describe('compiled <Async> boundary — ErrorBoundary wrapping (#1375)', () => {
       }
     `)
 
-    expect(template).toContain('<ErrorBoundary fallback={<>')
-    expect(template).toContain('<Suspense fallback={<>')
+    // Tags are emitted under `__Bf`-prefixed aliases so they can't collide
+    // with a user component named `ErrorBoundary` / `Suspense` (#1375).
+    expect(template).toContain('<__BfErrorBoundary fallback={<>')
+    expect(template).toContain('<__BfSuspense fallback={<>')
     // ErrorBoundary must enclose Suspense (catch errors raised while the
     // Suspense body resolves), not the reverse.
-    expect(template.indexOf('<ErrorBoundary')).toBeLessThan(template.indexOf('<Suspense'))
-    expect(template).toContain('</Suspense></ErrorBoundary>')
+    expect(template.indexOf('<__BfErrorBoundary')).toBeLessThan(template.indexOf('<__BfSuspense'))
+    expect(template).toContain('</__BfSuspense></__BfErrorBoundary>')
   })
 
-  test('injects the ErrorBoundary import alongside Suspense', () => {
+  test('injects the aliased ErrorBoundary import alongside Suspense', () => {
     const template = templateOf(`
       export function Page() {
         return (
@@ -59,8 +61,32 @@ describe('compiled <Async> boundary — ErrorBoundary wrapping (#1375)', () => {
       }
     `)
 
-    expect(template).toContain(`import { Suspense } from 'hono/jsx/streaming'`)
-    expect(template).toContain(`import { ErrorBoundary } from 'hono/jsx'`)
+    expect(template).toContain(`import { Suspense as __BfSuspense } from 'hono/jsx/streaming'`)
+    expect(template).toContain(`import { ErrorBoundary as __BfErrorBoundary } from 'hono/jsx'`)
+  })
+
+  test('aliasing avoids a duplicate import when the body uses a user component named ErrorBoundary', () => {
+    // Regression for the bare-name collision: a user component literally
+    // named `ErrorBoundary` used inside the boundary must not cause the
+    // injected Hono import to duplicate the user's own `ErrorBoundary`
+    // binding (which would be a "Duplicate identifier" build error).
+    const template = templateOf(`
+      import { ErrorBoundary } from './my-error-boundary'
+      export function Page() {
+        return (
+          <Async fallback={<ErrorBoundary><p>fail</p></ErrorBoundary>}>
+            <span>Resolved</span>
+          </Async>
+        )
+      }
+    `)
+
+    // Exactly one `ErrorBoundary` binding survives — the user's. The Hono
+    // wrapper imports under the `__BfErrorBoundary` alias, so no collision.
+    const bareImports = template.match(/import \{ ErrorBoundary \} from/g) ?? []
+    expect(bareImports.length).toBe(1)
+    expect(template).toContain(`import { ErrorBoundary } from './my-error-boundary'`)
+    expect(template).toContain(`import { ErrorBoundary as __BfErrorBoundary } from 'hono/jsx'`)
   })
 
   test('each of multiple boundaries gets its own ErrorBoundary wrapper', () => {
@@ -79,7 +105,7 @@ describe('compiled <Async> boundary — ErrorBoundary wrapping (#1375)', () => {
       }
     `)
 
-    const wrappers = template.match(/<ErrorBoundary fallback=\{<>/g) ?? []
+    const wrappers = template.match(/<__BfErrorBoundary fallback=\{<>/g) ?? []
     expect(wrappers.length).toBe(2)
   })
 })

--- a/packages/adapter-hono/src/__tests__/async.test.tsx
+++ b/packages/adapter-hono/src/__tests__/async.test.tsx
@@ -33,13 +33,15 @@ describe('BfAsync', () => {
       </BfAsync>
     )
 
-    const chunks = await collectStream(stream)
+    const fullOutput = (await collectStream(stream)).join('')
 
-    // First chunk has fallback
-    expect(chunks[0]).toContain('Loading...')
-    // Later chunk has resolved content
-    const fullOutput = chunks.join('')
+    // Fallback streams first, resolved content swaps in afterwards. The
+    // body is wrapped in an ErrorBoundary (#1375) whose template/swap
+    // markers now lead the stream, so assert ordering across the full
+    // output rather than pinning the fallback to a literal `chunks[0]`.
+    expect(fullOutput).toContain('Loading...')
     expect(fullOutput).toContain('Loaded!')
+    expect(fullOutput.indexOf('Loading...')).toBeLessThan(fullOutput.indexOf('Loaded!'))
   })
 
   it('renders multiple async boundaries independently', async () => {
@@ -89,7 +91,7 @@ describe('BfAsync', () => {
     expect(fullOutput).toContain('bf-p=')
   })
 
-  it('renders synchronous children without streaming', async () => {
+  it('renders synchronous children without a fallback flash', async () => {
     const SyncContent = () => <div>Already here</div>
 
     const stream = renderToReadableStream(
@@ -98,9 +100,126 @@ describe('BfAsync', () => {
       </BfAsync>
     )
 
-    const chunks = await collectStream(stream)
+    const fullOutput = (await collectStream(stream)).join('')
 
-    // Synchronous content should be in the first chunk (no fallback needed)
-    expect(chunks[0]).toContain('Already here')
+    // Synchronous content needs no fallback round-trip: it resolves in the
+    // initial flush and the loading fallback never appears. The
+    // ErrorBoundary wrapper (#1375) routes the content through a
+    // template/swap chunk, so it is no longer literally `chunks[0]`, but
+    // there is still no `Loading...` flash.
+    expect(fullOutput).toContain('Already here')
+    expect(fullOutput).not.toContain('Loading...')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Error paths (#1375): a body that throws — synchronously or asynchronously.
+//
+// A bare `<Suspense>` mishandles both: a synchronous throw aborts the stream
+// with empty output (no fallback), and a rejection during async resolution
+// escapes as an unhandled rejection while the loading fallback is stranded.
+// `BfAsync` wraps the body in Hono's `ErrorBoundary` so the same `fallback`
+// is rendered on either failure and the error never leaks.
+//
+// These are the two cases the Layer 1 / streaming layer can observe directly
+// (a single SSR render). The remaining catalog cases — reset-signal re-mount
+// and throw-during-cleanup — are client-lifecycle behaviours covered by the
+// Layer 6 fixme stubs in `site/ui/e2e/stress-1244.spec.ts`.
+// ---------------------------------------------------------------------------
+
+describe('BfAsync — error paths (#1375)', () => {
+  // A render that errors must not surface a stray unhandled rejection on the
+  // process: install a guard for the duration of each test and assert it
+  // stayed quiet. `BfAsync`'s ErrorBoundary is what keeps it quiet.
+  function trackUnhandledRejections(): { count: () => number; restore: () => void } {
+    let n = 0
+    const onRejection = () => {
+      n++
+    }
+    process.on('unhandledRejection', onRejection)
+    return {
+      count: () => n,
+      restore: () => process.off('unhandledRejection', onRejection),
+    }
+  }
+
+  it('synchronous throw in the body renders the fallback (not empty output)', async () => {
+    const Boom = (): HtmlEscapedString => {
+      throw new Error('sync-boom')
+    }
+
+    const guard = trackUnhandledRejections()
+    let onErrorMessage: string | undefined
+    try {
+      const stream = renderToReadableStream(
+        <BfAsync
+          fallback={<p>Fallback shown</p>}
+          onError={(e) => {
+            onErrorMessage = e.message
+          }}
+        >
+          <Boom />
+        </BfAsync>
+      )
+      const fullOutput = (await collectStream(stream)).join('')
+
+      // The fallback is rendered (a bare <Suspense> would yield empty output).
+      expect(fullOutput).toContain('Fallback shown')
+      // onError observed the failure so it isn't swallowed silently.
+      expect(onErrorMessage).toBe('sync-boom')
+    } finally {
+      guard.restore()
+    }
+  })
+
+  it('async rejection during resolution renders the fallback and leaks no rejection', async () => {
+    const Rejects = (): Promise<HtmlEscapedString> =>
+      new Promise((_resolve, reject) =>
+        setTimeout(() => reject(new Error('async-boom')), 10)
+      )
+
+    const guard = trackUnhandledRejections()
+    let onErrorMessage: string | undefined
+    try {
+      const stream = renderToReadableStream(
+        <BfAsync
+          fallback={<p>Fallback shown</p>}
+          onError={(e) => {
+            onErrorMessage = e.message
+          }}
+        >
+          <Rejects />
+        </BfAsync>
+      )
+      const fullOutput = (await collectStream(stream)).join('')
+
+      // Fallback is the final rendered state; the rejected content never
+      // mutates into the DOM late.
+      expect(fullOutput).toContain('Fallback shown')
+      expect(onErrorMessage).toBe('async-boom')
+
+      // Give any stray rejection a tick to surface, then assert none did.
+      await new Promise((r) => setTimeout(r, 0))
+      expect(guard.count()).toBe(0)
+    } finally {
+      guard.restore()
+    }
+  })
+
+  it('the happy path still streams resolved content past the error boundary', async () => {
+    // Wrapping the body in ErrorBoundary must not regress normal streaming.
+    const AsyncContent = () =>
+      new Promise<HtmlEscapedString>((resolve) =>
+        setTimeout(() => resolve(<div>Loaded past boundary</div>), 10)
+      )
+
+    const stream = renderToReadableStream(
+      <BfAsync fallback={<p>Loading...</p>}>
+        <AsyncContent />
+      </BfAsync>
+    )
+
+    const fullOutput = (await collectStream(stream)).join('')
+    expect(fullOutput).toContain('Loaded past boundary')
   })
 })

--- a/packages/adapter-hono/src/adapter/hono-adapter.ts
+++ b/packages/adapter-hono/src/adapter/hono-adapter.ts
@@ -229,13 +229,16 @@ export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderC
       lines.push(`import { ${utilImports.join(', ')} } from '@barefootjs/hono/utils'`)
     }
 
-    // Import Suspense when async boundaries are used
-    if (componentCode.includes('<Suspense')) {
-      lines.push(`import { Suspense } from 'hono/jsx/streaming'`)
+    // Import Suspense / ErrorBoundary when async boundaries are used. Both
+    // are imported under `__Bf`-prefixed aliases (and emitted as such by
+    // `renderAsync`) so the generated tags can never collide with a user
+    // component literally named `Suspense` or `ErrorBoundary` — a bare-name
+    // import would otherwise duplicate the user's own import binding (#1375).
+    if (componentCode.includes('<__BfSuspense')) {
+      lines.push(`import { Suspense as __BfSuspense } from 'hono/jsx/streaming'`)
     }
-    // Async boundaries also wrap in ErrorBoundary for the body error path (#1375).
-    if (componentCode.includes('<ErrorBoundary')) {
-      lines.push(`import { ErrorBoundary } from 'hono/jsx'`)
+    if (componentCode.includes('<__BfErrorBoundary')) {
+      lines.push(`import { ErrorBoundary as __BfErrorBoundary } from 'hono/jsx'`)
     }
 
     // Re-emit template imports, rewriting `@barefootjs/client` to this
@@ -970,10 +973,14 @@ export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderC
     // a rejected Promise during async resolution falls back to the same
     // `fallback` instead of aborting the stream / leaking an unhandled
     // rejection. Mirrors the runtime `BfAsync` component (#1375).
+    //
+    // Both tags use `__Bf`-prefixed aliases (see the import injection above)
+    // so they can't collide with a user component named `Suspense` /
+    // `ErrorBoundary` in the same module.
     return (
-      `<ErrorBoundary fallback={<>${fallback}</>}>` +
-      `<Suspense fallback={<>${fallback}</>}>${children}</Suspense>` +
-      `</ErrorBoundary>`
+      `<__BfErrorBoundary fallback={<>${fallback}</>}>` +
+      `<__BfSuspense fallback={<>${fallback}</>}>${children}</__BfSuspense>` +
+      `</__BfErrorBoundary>`
     )
   }
 

--- a/packages/adapter-hono/src/adapter/hono-adapter.ts
+++ b/packages/adapter-hono/src/adapter/hono-adapter.ts
@@ -233,6 +233,10 @@ export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderC
     if (componentCode.includes('<Suspense')) {
       lines.push(`import { Suspense } from 'hono/jsx/streaming'`)
     }
+    // Async boundaries also wrap in ErrorBoundary for the body error path (#1375).
+    if (componentCode.includes('<ErrorBoundary')) {
+      lines.push(`import { ErrorBoundary } from 'hono/jsx'`)
+    }
 
     // Re-emit template imports, rewriting `@barefootjs/client` to this
     // adapter's SSR shim AND re-anchoring relative paths from the emit
@@ -962,7 +966,15 @@ export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderC
   renderAsync(node: IRAsync): string {
     const fallback = this.renderNode(node.fallback)
     const children = this.renderChildren(node.children)
-    return `<Suspense fallback={<>${fallback}</>}>${children}</Suspense>`
+    // Wrap the streaming body in an ErrorBoundary so a synchronous throw or
+    // a rejected Promise during async resolution falls back to the same
+    // `fallback` instead of aborting the stream / leaking an unhandled
+    // rejection. Mirrors the runtime `BfAsync` component (#1375).
+    return (
+      `<ErrorBoundary fallback={<>${fallback}</>}>` +
+      `<Suspense fallback={<>${fallback}</>}>${children}</Suspense>` +
+      `</ErrorBoundary>`
+    )
   }
 
   renderComponent(comp: IRComponent, ctx?: { isRootOfClientComponent?: boolean; isInsideLoop?: boolean; isLoopItemRoot?: boolean }): string {

--- a/packages/adapter-hono/src/async.tsx
+++ b/packages/adapter-hono/src/async.tsx
@@ -14,6 +14,16 @@
  * Suspense/streaming. The BarefootJS hydration runtime automatically picks
  * up components rendered inside async boundaries via requestAnimationFrame.
  *
+ * The body is additionally wrapped in Hono's `ErrorBoundary` so that a
+ * failure during render — a synchronous `throw` in a child, or a rejected
+ * Promise during async resolution — surfaces the same `fallback` instead
+ * of producing empty output (sync case) or leaking an unhandled rejection
+ * (async case). Without the boundary a bare `<Suspense>` does neither:
+ * a synchronous throw aborts the stream with no fallback, and a rejection
+ * during streaming escapes as an unhandled rejection while the loading
+ * fallback is left stranded. See `__tests__/async.test.tsx` error-path
+ * cases (#1375).
+ *
  * Usage:
  * ```tsx
  * import { BfAsync } from '@barefootjs/hono/async'
@@ -31,6 +41,7 @@
  */
 
 import { Suspense } from 'hono/jsx/streaming'
+import { ErrorBoundary } from 'hono/jsx'
 import type { Child } from 'hono/jsx'
 
 export interface BfAsyncProps {
@@ -38,18 +49,29 @@ export interface BfAsyncProps {
   fallback: Child
   /** Async children that will be streamed when resolved. */
   children: Child
+  /**
+   * Optional observer invoked when the body throws synchronously or its
+   * async resolution rejects. The `fallback` is rendered either way; this
+   * hook only exists so the error isn't swallowed silently (logging,
+   * metrics). It does not change what is rendered.
+   */
+  onError?: (error: Error) => void
 }
 
 /**
  * Async streaming boundary component.
  *
  * Renders fallback content immediately (sent in the initial HTTP response
- * for fast TTFB), then streams the resolved children when ready.
+ * for fast TTFB), then streams the resolved children when ready. If the
+ * body throws (sync) or rejects (async), the same fallback is rendered via
+ * the surrounding `ErrorBoundary`.
  */
 export function BfAsync(props: BfAsyncProps) {
   return (
-    <Suspense fallback={props.fallback}>
-      {props.children}
-    </Suspense>
+    <ErrorBoundary fallback={props.fallback} onError={props.onError}>
+      <Suspense fallback={props.fallback}>
+        {props.children}
+      </Suspense>
+    </ErrorBoundary>
   )
 }

--- a/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
+++ b/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
@@ -1069,6 +1069,49 @@ describe('.map() inside <Async> — loop body wired after async chunk lands', ()
   })
 })
 
+describe('<Async> body error path — sync throw + async reject (#1375)', () => {
+  // Whether the body throws synchronously or rejects asynchronously is a
+  // runtime property the compiler can't see. The Layer 1 contract is that
+  // neither shape degrades the boundary's compile output: a throwing /
+  // rejecting body still produces a well-formed `<Async>` boundary with the
+  // fallback preserved, so the adapter has something to fall back to.
+  //
+  // The boundary's fallback is wired into an error-catching boundary by the
+  // adapter: the Hono `renderAsync` emit (see
+  // `packages/adapter-hono/src/__tests__/async-error-boundary.test.ts`) and
+  // the runtime `BfAsync` component (see
+  // `packages/adapter-hono/src/__tests__/async.test.tsx`) both wrap the body
+  // in `ErrorBoundary`. The browser-level behaviour (fallback rendered,
+  // reset-signal re-mount, throw-during-cleanup) is covered by the Layer 6
+  // stubs in `site/ui/e2e/stress-1244.spec.ts`.
+
+  test('synchronously-throwing body component compiles to a clean boundary', () => {
+    const src = `
+      export function Demo() {
+        return (
+          <Async fallback={<p>Fallback</p>}>
+            <Throws />
+          </Async>
+        )
+      }
+    `
+    expectNoFatalErrors(compile(src, 'Demo.tsx'))
+  })
+
+  test('async (Promise-returning) body component compiles to a clean boundary', () => {
+    const src = `
+      export function Demo() {
+        return (
+          <Async fallback={<Skeleton />}>
+            <SlowData />
+          </Async>
+        )
+      }
+    `
+    expectNoFatalErrors(compile(src, 'Demo.tsx'))
+  })
+})
+
 describe('createPortal inside .map() — per-item portal owner tracking', () => {
   test('one portal created per loop item', () => {
     const src = `

--- a/packages/jsx/src/__tests__/ir-async.test.ts
+++ b/packages/jsx/src/__tests__/ir-async.test.ts
@@ -147,6 +147,70 @@ describe('<Async> streaming boundary', () => {
     }
   })
 
+  // -------------------------------------------------------------------------
+  // #1375 — body throw, sync + async error paths.
+  //
+  // Whether the body throws (sync) or rejects (async) is a *runtime* property
+  // the compiler can't observe. What Layer 1 can lock in is the structural
+  // prerequisite for the runtime fallback to fire: the boundary keeps a
+  // fallback distinct from its children, with an assigned id, even when the
+  // body is a component that will throw / reject at render time. The adapter
+  // then wires that fallback into an error-catching boundary (`ErrorBoundary`
+  // for Hono — see the adapter `renderAsync` test and
+  // `packages/adapter-hono/src/async.tsx`).
+  // -------------------------------------------------------------------------
+
+  test('body component that throws at render keeps fallback + child wired on the boundary', () => {
+    const source = `
+      export function Page() {
+        return (
+          <Async fallback={<p>Fallback</p>}>
+            <Throws />
+          </Async>
+        )
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Page.tsx')
+    const ir = jsxToIR(ctx)
+
+    expect(ctx.errors.filter(e => e.severity === 'error')).toEqual([])
+
+    const asyncNode = ir as IRAsync
+    expect(asyncNode.type).toBe('async')
+    expect(asyncNode.id).toBe('a0')
+    // Fallback is preserved and distinct from the (throwing) body.
+    expect(asyncNode.fallback.type).toBe('element')
+    if (asyncNode.fallback.type === 'element') {
+      expect(asyncNode.fallback.tag).toBe('p')
+    }
+    expect(asyncNode.children.length).toBe(1)
+    expect(asyncNode.children[0].type).toBe('component')
+  })
+
+  test('async (Promise-returning) body component keeps the boundary intact', () => {
+    const source = `
+      export function Page() {
+        return (
+          <Async fallback={<Skeleton />}>
+            <SlowData />
+          </Async>
+        )
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Page.tsx')
+    const ir = jsxToIR(ctx)
+
+    expect(ctx.errors.filter(e => e.severity === 'error')).toEqual([])
+
+    const asyncNode = ir as IRAsync
+    expect(asyncNode.type).toBe('async')
+    expect(asyncNode.fallback.type).toBe('component')
+    expect(asyncNode.children.length).toBe(1)
+    expect(asyncNode.children[0].type).toBe('component')
+  })
+
   test('compileJSX surfaces BF046 in errors without crashing on multi-child stub', () => {
     // Multi-child + root pins the scope-metadata path: a transparent stub
     // would suppress needsScopeComment and leak ctx.isRoot to only the first

--- a/site/ui/e2e/stress-1244.spec.ts
+++ b/site/ui/e2e/stress-1244.spec.ts
@@ -96,6 +96,57 @@ test.describe('Compiler stress (#1244) — E2E surfaces awaiting demo pages', ()
     },
   )
 
+  // ---- Async boundary error path (#1375) --------------------------------
+  // `<Async>` whose body throws — sync + async error paths. The adapter
+  // wraps the body in an ErrorBoundary (sharing the loading fallback), so
+  // a failing body surfaces the fallback instead of aborting the stream or
+  // leaking an unhandled rejection. The SSR / streaming halves are pinned
+  // by `packages/adapter-hono/src/__tests__/async.test.tsx`; the four
+  // browser-level cases below need a live page to observe.
+
+  test.fixme(
+    'async-error: synchronous throw in body renders the fallback',
+    async ({ page }) => {
+      // Visit `${STRESS_BASE}/async-error-sync`. The boundary body throws
+      // synchronously on first render. Assert the fallback is shown (not
+      // empty / not a crashed page) and the resolved content never appears.
+      await page.goto(`${STRESS_BASE}/async-error-sync`)
+    },
+  )
+
+  test.fixme(
+    'async-error: async throw (Promise rejection) renders fallback, no late DOM mutation',
+    async ({ page }) => {
+      // Visit `${STRESS_BASE}/async-error-async`. The body's async render
+      // rejects after a delay. Assert the fallback stays put, the rejected
+      // content is never swapped in (no late DOM mutation after the
+      // rejection settles), and no exception reaches `window.onerror`.
+      await page.goto(`${STRESS_BASE}/async-error-async`)
+    },
+  )
+
+  test.fixme(
+    'async-error: reset signal re-mounts the body from fallback',
+    async ({ page }) => {
+      // Visit `${STRESS_BASE}/async-error-reset`. After the body has errored
+      // into the fallback, toggling a reset signal re-mounts the boundary;
+      // assert the body attempts to render again (fallback → resolved on a
+      // now-succeeding render), proving the boundary isn't latched.
+      await page.goto(`${STRESS_BASE}/async-error-reset`)
+    },
+  )
+
+  test.fixme(
+    'async-error: throw during cleanup of body subtree still renders fallback cleanly',
+    async ({ page }) => {
+      // Visit `${STRESS_BASE}/async-error-cleanup`. A child registers an
+      // onCleanup that throws; unmount the subtree (or error it). Assert the
+      // fallback still renders cleanly and no orphan DOM / dangling effect
+      // is left behind.
+      await page.goto(`${STRESS_BASE}/async-error-cleanup`)
+    },
+  )
+
   // ---- Value-shape edges ------------------------------------------------
 
   test.fixme(


### PR DESCRIPTION
Closes #1375 (catalog item from #1244: *Async boundary error path — `<Async>` whose body throws*).

## Problem

A defect surfaced while writing the error-path coverage. A bare `<Suspense>` mishandles a `<Async>` boundary whose body fails at render time:

- **Synchronous throw** in the body → the stream aborts with **empty output**; the fallback is never rendered and the error bubbles.
- **Async throw** (Promise rejection during async resolution) → the loading fallback is left stranded **and** the rejection escapes as an **unhandled rejection**.

Both the hand-written `BfAsync` component and the compiler's `<Async>` → Hono `renderAsync` emit had this gap (they lowered to a bare `<Suspense>`).

## Root-cause fix (no workaround)

Wrap the streaming body in Hono's `ErrorBoundary`, sharing the same `fallback`, on **both** async-boundary paths:

- `packages/adapter-hono/src/async.tsx` — `BfAsync` now wraps `<Suspense>` in `<ErrorBoundary>`. Added an optional `onError?: (error: Error) => void` so failures aren't swallowed silently (does not change what renders).
- `packages/adapter-hono/src/adapter/hono-adapter.ts` — `renderAsync` emits the `ErrorBoundary` wrapper and injects `import { ErrorBoundary } from 'hono/jsx'`.

Result: a failing body now surfaces the same `fallback` instead of aborting the stream or leaking a rejection; the happy path (fallback → resolved streaming) is unchanged.

## Tests

| Layer | File | Covers |
|-------|------|--------|
| 1 (IR) | `packages/jsx/src/__tests__/ir-async.test.ts` | boundary keeps fallback + child wired for throwing / async bodies |
| 1 (catalog) | `packages/jsx/src/__tests__/compiler-stress-1244.test.ts` | flips the unchecked catalog item — sync-throw + async body compile to clean boundaries |
| 1 (adapter emit) | `packages/adapter-hono/src/__tests__/async-error-boundary.test.ts` *(new)* | `renderAsync` emits `ErrorBoundary` enclosing `Suspense` + injected import |
| Adapter/runtime | `packages/adapter-hono/src/__tests__/async.test.tsx` | sync-throw → fallback + `onError`; async-reject → fallback, no leaked rejection; happy path past the boundary |
| 6 (E2E) | `site/ui/e2e/stress-1244.spec.ts` | `test.fixme` stubs for the four browser cases (sync throw, async throw, reset-signal re-mount, throw-in-cleanup), matching the existing #1244 stub convention |

Two pre-existing `async.test.tsx` assertions that pinned content to a literal `chunks[0]` were relaxed to full-output ordering, since the `ErrorBoundary` wrapper now leads the stream (content still delivered; no fallback flash for sync content).

### Verification

- `packages/adapter-hono` — 381 pass / 0 fail
- `packages/jsx` — 1927 pass / 0 fail
- `packages/adapter-tests` (conformance) — 676 pass / 0 fail

## Notes / open question for review

`hono/jsx`'s `ErrorBoundary` is marked *experimental* by Hono. It's the canonical Hono mechanism for this and behaves correctly here, but flagging it since it pins us to that API surface. The reset-signal re-mount and throw-during-cleanup cases remain Layer-6 stubs (client-lifecycle behaviour needs a live demo page); say the word if you'd like those built out as runnable E2E pages in this PR.

https://claude.ai/code/session_012ritSuzjTjZerUCRTM37ei

---
_Generated by [Claude Code](https://claude.ai/code/session_012ritSuzjTjZerUCRTM37ei)_