### PR TITLE
List Gin/Chi/net-http on the /integrations page

### DIFF
--- a/site/core/integrations/routes.tsx
+++ b/site/core/integrations/routes.tsx
@@ -23,6 +23,9 @@ const ADAPTERS: Adapter[] = [
   { slug: 'h3',          name: 'h3',          language: 'TypeScript' },
   { slug: 'elysia',      name: 'Elysia',      language: 'TypeScript' },
   { slug: 'echo',        name: 'Echo',        language: 'Go' },
+  { slug: 'gin',         name: 'Gin',         language: 'Go' },
+  { slug: 'chi',         name: 'Chi',         language: 'Go' },
+  { slug: 'nethttp',     name: 'net/http',    language: 'Go' },
   { slug: 'mojolicious', name: 'Mojolicious', language: 'Perl' },
 ]
 
@@ -52,7 +55,7 @@ export function createIntegrationsApp() {
     c.render(<IntegrationsIndex />, {
       title: 'Integrations — Barefoot.js',
       description:
-        'Same JSX components running on Hono (Workers), h3 (UnJS), Elysia (Bun), Echo (Go), and Mojolicious (Perl).',
+        'Same JSX components running on Hono (Workers), h3 (UnJS), Elysia (Bun), Echo, Gin, Chi and net/http (Go), and Mojolicious (Perl).',
     }),
   )
 

--- a/site/core/integrations/routes.tsx
+++ b/site/core/integrations/routes.tsx
@@ -55,7 +55,7 @@ export function createIntegrationsApp() {
     c.render(<IntegrationsIndex />, {
       title: 'Integrations — Barefoot.js',
       description:
-        'Same JSX components running on Hono (Workers), h3 (UnJS), Elysia (Bun), Echo, Gin, Chi and net/http (Go), and Mojolicious (Perl).',
+        'Same JSX components running on Hono, h3 and Elysia (TypeScript), Echo, Gin, Chi and net/http (Go), and Mojolicious (Perl).',
     }),
   )
 


### PR DESCRIPTION
## Summary

The Go integrations (Gin, Chi, net/http) added in #1740 and deployed in #1744 weren't listed on the `/integrations` catalog page. This adds them.

- `site/core/integrations/routes.tsx`: add `gin` (Gin), `chi` (Chi), `nethttp` (net/http) — all `Go` — to the adapter list, next to Echo.
- Update the page `description` to enumerate the new Go frameworks.

Each card links to `/integrations/<slug>`, which is now served in production (the deploys from #1744).

## Verification

- `cd site/core && bun run build` completes successfully.
- Data-only change (array entries + description string); slugs match the deployed routes.


---
_Generated by [Claude Code](https://claude.ai/code/session_015dSBYQnSrUnAXx2AmzaAKv)_