### PR TITLE
test(mojo): enable Button in Mojo adapter conformance

### DIFF
--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -69,16 +69,6 @@ runAdapterConformanceTests({
     'toggle-shared',
     'reactive-props',
     'props-reactivity-comparison',
-    // #1467 Phase 2a: first `site/ui` source-root fixture. Button
-    // compiles cleanly on the Mojo adapter (no diagnostic), but its
-    // variant/size class composition (`Record<…>[key]` indexed object
-    // literals) and `applyRestAttrs` spread haven't been validated for
-    // byte-parity against the Hono reference under Mojo's template
-    // semantics. Cross-adapter parity for the `site/ui` corpus is
-    // explicitly Phase 3 ("cross-adapter parity (Mojo/Go templates)"),
-    // so Button participates only in Hono SSR conformance + the
-    // fixture-hydrate runtime layer for now.
-    'button',
   ],
   // Per-fixture build-time contracts for shapes the Mojo adapter
   // intentionally refuses to lower. Owned by this adapter test file


### PR DESCRIPTION
## Summary

Removes `button` from the **Mojo (Mojolicious/Perl) adapter** `skipJsx` list — the companion to #1746, which did the same for the Go template adapter.

### Why no adapter change was needed (unlike Go)
#1746 had to add a `dynamicTag` IR flag + passthrough lowering because Go's `html/template` **escape-walks every registered template at parse time**, so Slot's dead `{{template "Tag"}}` dynamic-tag reference (`const Tag = children.tag`) crashed the whole render with `no such template "Tag"` — even though Button renders the `asChild:false` `<button>` branch.

`Mojo::Template` evaluates **lazily** and never parses/validates the unexecuted Slot `asChild` branch, so Button's default render produces output byte-identical to the Hono reference with no adapter work. The fix here is purely removing the skip.

### Validation
Run locally end-to-end through **perl 5.38 + Mojolicious 9.35** (installed in the sandbox so the conformance render actually executes rather than `PerlNotAvailableError`-skipping):

- Full Mojo adapter conformance: **386 pass / 5 skip / 0 fail**.
- `button` specifically: **4 pass / 0 skip** (IR + template-output + CSR + the perl-render byte-parity comparison).

### Scope note
True server-side `asChild` prop-merge on Mojo (the Slot dynamic-tag executing its merge branch) remains a deferred concern, same as Go — no current fixture exercises it. This PR only certifies Button's default (`asChild:false`) render.

🤖 https://claude.ai/code/session_01UatvBGZG5csvttdtgcSf7p

---
_Generated by [Claude Code](https://claude.ai/code/session_01UatvBGZG5csvttdtgcSf7p)_