### PR TITLE
feat(go,mojo): inline module pure-string consts — enable Phase 2b label + input conformance

### DIFF
--- a/.changeset/go-mojo-module-string-const-inline.md
+++ b/.changeset/go-mojo-module-string-const-inline.md
@@ -15,5 +15,11 @@ bound it. The adapters now resolve the identifier through the IR's
 template language), matching what the Hono reference produces by
 evaluating the real JS. Only module-scope pure string literals qualify —
 `Record<T,string>` indexed lookups, memos, signals, and function-scope
-locals are deliberately excluded. This unblocks cross-adapter conformance
-for the `site/ui` `label` and `input` primitives.
+locals are deliberately excluded — and inlining is suppressed for any name
+shadowed by an enclosing loop binding (matching the Go adapter's
+loop-shadowing guards). This unblocks cross-adapter conformance for the
+`site/ui` `label` and `input` primitives.
+
+The Mojolicious adapter now relies on `typescript` at runtime (to parse
+const initializers), so it is externalized in the build and declared as a
+peer dependency, consistent with `@barefootjs/go-template`.

--- a/.changeset/go-mojo-module-string-const-inline.md
+++ b/.changeset/go-mojo-module-string-const-inline.md
@@ -1,0 +1,19 @@
+---
+"@barefootjs/go-template": patch
+"@barefootjs/mojolicious": patch
+---
+
+Inline module-scope pure string-literal constants referenced in
+expressions (e.g. `const labelClasses = '...'` used in a `className`
+template literal) on the Go and Mojo template adapters. Previously such
+an identifier lowered to an unpopulated struct-field / stash-variable
+reference (`{{.LabelClasses}}` on Go — failing `can't evaluate field
+LabelClasses`; `$labelClasses` on Mojo — rendering empty), because a
+module const is neither a prop, signal, nor local and no field/var ever
+bound it. The adapters now resolve the identifier through the IR's
+`localConstants` and inline the literal value (escaped for the target
+template language), matching what the Hono reference produces by
+evaluating the real JS. Only module-scope pure string literals qualify —
+`Record<T,string>` indexed lookups, memos, signals, and function-scope
+locals are deliberately excluded. This unblocks cross-adapter conformance
+for the `site/ui` `label` and `input` primitives.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -85,9 +85,7 @@ runAdapterConformanceTests({
     'toggle',
     'switch',
     'checkbox',
-    'input',
     'textarea',
-    'label',
     'kbd',
   ],
   // Per-fixture build-time contracts for shapes the Go template
@@ -299,6 +297,28 @@ export function Counter(props: { initial?: number }) {
       expect(result.types).toContain('ScopeID string')
       expect(result.types).toContain('Initial int')
       expect(result.types).toContain('Count int')
+    })
+
+    test('module pure-string const referenced in className inlines the literal (#1467 Phase 2b)', () => {
+      // A module-scope `const X = 'literal'` used inside a className
+      // template literal must inline its value, NOT emit `{{.X}}` against a
+      // Props field that never exists (Go fails `can't evaluate field X`).
+      // Hono inlines it at runtime; this restores byte-parity.
+      const source = `
+"use client"
+const labelClasses = 'flex items-center group-data-[disabled=true]:opacity-50'
+export function Label({ className = '' }: { className?: string }) {
+  return <label className={\`\${labelClasses} \${className}\`} />
+}
+`
+      const { template, types } = compileAndGenerate(source)
+      // The literal is inlined as a Go string literal, escaped tokens intact.
+      expect(template).toContain(
+        '{{"flex items-center group-data-[disabled=true]:opacity-50"}}',
+      )
+      // No struct-field reference to the const, and no Props field for it.
+      expect(template).not.toContain('.LabelClasses')
+      expect(types).not.toContain('LabelClasses')
     })
 
     test('dynamic loop with child component → NewXxxProps carries a populate-this-slice doc comment (#1442 echo TodoApp repro)', () => {

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -34,6 +34,7 @@ import type {
   IRIfStatement,
   IRProvider,
   IRAsync,
+  IRMetadata,
   TemplatePrimitiveRegistry,
 } from '@barefootjs/jsx'
 import {
@@ -418,6 +419,21 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    *  `template.HTML(...)`; toggles the `"html/template"` import. */
   private usesHtmlTemplate: boolean = false
 
+  /**
+   * Module-scope pure string-literal constants (`const X = 'literal'` at
+   * file top-level), keyed by name → resolved literal value. Populated at
+   * `generate()` entry from `ir.metadata.localConstants`. When an identifier
+   * in an expression resolves to one of these, the adapter inlines the
+   * literal value instead of emitting a struct-field reference
+   * (`{{.X}}`) — the field never exists on the Props struct, so without
+   * inlining Go's template engine fails with `can't evaluate field X`.
+   * Hono inlines it for free (it evaluates real JS); this restores parity.
+   * Only module-scope, pure string literals qualify — function-scope
+   * locals legitimately become template vars/props, and `Record<T,string>`
+   * indexed lookups / memos / signals are deliberately excluded.
+   */
+  private moduleStringConsts: Map<string, string> = new Map()
+
   constructor(options: GoTemplateAdapterOptions = {}) {
     super()
     this.options = {
@@ -438,6 +454,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     this.templateVarCounter = 0
     this.propsObjectName = ir.metadata.propsObjectName
     this.restPropsName = ir.metadata.restPropsName ?? null
+    this.moduleStringConsts = this.collectModuleStringConsts(ir.metadata.localConstants)
 
     // Surface loop-body usages of components imported from sibling
     // .tsx files. The adapter emits `{{template "X" .}}` for these,
@@ -2901,6 +2918,11 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   // ===========================================================================
 
   identifier(name: string): string {
+    // Module pure-string const (e.g. `const baseClasses = '...'` used in a
+    // className template literal): inline the literal value rather than
+    // emit `{{.BaseClasses}}` against a Props field that never exists.
+    const inlined = this.resolveModuleStringConst(name)
+    if (inlined !== null) return inlined
     const currentLoopParam = this.loopParamStack[this.loopParamStack.length - 1]
     if (currentLoopParam && name === currentLoopParam) return '.'
     // An *outer* loop's value variable (we're in a nested loop) is in scope as
@@ -2935,6 +2957,72 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   private rootFieldRef(name: string): string {
     const prefix = this.loopParamStack.length > 0 ? '$.' : '.'
     return `${prefix}${this.capitalizeFieldName(name)}`
+  }
+
+  /**
+   * Build the module pure-string-const map from the IR's localConstants.
+   * A const qualifies only when it is module-scope (`isModule`) and its
+   * initializer parses to a single string literal (`ts.StringLiteral` or
+   * `ts.NoSubstitutionTemplateLiteral` — a backtick string with no `${}`).
+   * Template literals *with* interpolations, numeric/object initializers,
+   * `Record<T,string>` maps, memos, and signals are all excluded: only a
+   * pure compile-time string can be safely inlined byte-for-byte.
+   */
+  private collectModuleStringConsts(constants: IRMetadata['localConstants']): Map<string, string> {
+    const map = new Map<string, string>()
+    for (const c of constants ?? []) {
+      if (!c.isModule) continue
+      if (c.value === undefined) continue
+      const literal = this.parsePureStringLiteral(c.value)
+      if (literal !== null) map.set(c.name, literal)
+    }
+    return map
+  }
+
+  /**
+   * Parse a const initializer's source text. Returns the unescaped string
+   * value when the whole initializer is a single string literal (or a
+   * no-substitution template literal), else `null`. Uses the TS parser so
+   * escapes/quotes are resolved exactly as JS would, matching the value
+   * the Hono reference inlines at runtime.
+   */
+  private parsePureStringLiteral(source: string): string | null {
+    const sf = ts.createSourceFile(
+      '__const.ts',
+      `const __x = (${source});`,
+      ts.ScriptTarget.Latest,
+      /*setParentNodes*/ false,
+    )
+    const stmt = sf.statements[0]
+    if (!stmt || !ts.isVariableStatement(stmt)) return null
+    const decl = stmt.declarationList.declarations[0]
+    let init = decl?.initializer
+    while (init && ts.isParenthesizedExpression(init)) init = init.expression
+    if (!init) return null
+    if (ts.isStringLiteral(init) || ts.isNoSubstitutionTemplateLiteral(init)) {
+      return init.text
+    }
+    return null
+  }
+
+  /**
+   * Resolve an identifier to its inlined Go string literal when it names a
+   * module pure-string const. Returns the Go template literal form
+   * (`"<escaped>"`) so callers can drop it straight into a `{{...}}` action,
+   * or `null` when the name is not such a const (the caller then falls back
+   * to its normal field-ref lowering). The value is escaped for a Go
+   * double-quoted string literal — Go's `html/template` then applies the
+   * same contextual auto-escaping it applies to any literal, matching Hono.
+   */
+  private resolveModuleStringConst(name: string): string | null {
+    if (this.loopParamStack.length > 0 && this.loopParamStack[this.loopParamStack.length - 1] === name) {
+      return null
+    }
+    if (this.loopVarRefCount.has(name)) return null
+    if (this.isOuterLoopParam(name)) return null
+    const value = this.moduleStringConsts.get(name)
+    if (value === undefined) return null
+    return `"${this.escapeGoString(value)}"`
   }
 
   literal(value: string | number | boolean | null, literalType: LiteralType): string {
@@ -4323,6 +4411,8 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     switch (expr.kind) {
       case 'identifier':
         {
+          const inlined = this.resolveModuleStringConst(expr.name)
+          if (inlined !== null) return plain(inlined)
           const currentLoopParam = this.loopParamStack[this.loopParamStack.length - 1]
           if (currentLoopParam && expr.name === currentLoopParam) {
             return plain('.')

--- a/packages/adapter-go-template/src/test-render.ts
+++ b/packages/adapter-go-template/src/test-render.ts
@@ -180,7 +180,7 @@ export async function renderGoTemplateComponent(options: RenderOptions): Promise
     const escapedTemplate = template.replace(/`/g, '` + "`" + `')
 
     // Build props initialization
-    const propsInit = buildGoPropsInit(componentName, props)
+    const propsInit = buildGoPropsInit(componentName, props, ir)
 
     // Honour `__instanceId` from props for the root scope id so
     // shared-component fixtures (which pin `<ComponentName>_test`) match
@@ -280,10 +280,26 @@ ${propsInit}
 function buildGoPropsInit(
   _componentName: string,
   props?: Record<string, unknown>,
+  ir?: ComponentIR,
 ): string {
   if (!props) return ''
 
+  // A `{...props}` rest spread on a component means props that are NOT
+  // declared as named params don't get their own top-level Input struct
+  // field — they flow through the open-ended rest bag (`Props map[string]any`,
+  // the `Capitalize(restPropsName)` field). Without routing them there, a
+  // fixture passing e.g. `placeholder` to the `Input` component (whose only
+  // declared params are `className` / `type`) emits a top-level
+  // `Placeholder:` initializer and Go fails with `unknown field Placeholder
+  // in struct literal of type InputInput`. (#1467 Phase 2b)
+  const declaredParams = new Set((ir?.metadata.propsParams ?? []).map(p => p.name))
+  const restPropsName = ir?.metadata.restPropsName ?? null
+  const restBagField = restPropsName
+    ? restPropsName.charAt(0).toUpperCase() + restPropsName.slice(1)
+    : null
+
   const lines: string[] = []
+  const restBagEntries: Array<[string, unknown]> = []
   for (const [key, value] of Object.entries(props)) {
     // Skip internal hydration markers — `__instanceId` / `__bfScope`
     // / `__bfChild` are routed by the framework (consumed via the
@@ -291,6 +307,15 @@ function buildGoPropsInit(
     // appear on the user-facing input struct). Including them produces
     // `unknown field __instanceId in struct literal of type XxxInput`.
     if (key.startsWith('__')) continue
+    // A prop that isn't a declared named param on a rest-spread component
+    // belongs in the rest bag, not a top-level field. A key that literally
+    // matches `restPropsName` already carries a pre-formed bag object and
+    // maps straight onto the `Capitalize(restPropsName)` field, so it falls
+    // through to the normal (object → map literal) emit below.
+    if (restBagField && key !== restPropsName && !declaredParams.has(key)) {
+      restBagEntries.push([key, value])
+      continue
+    }
     // Capitalize first letter for Go field name
     const goField = key.charAt(0).toUpperCase() + key.slice(1)
     if (typeof value === 'string') {
@@ -318,6 +343,13 @@ function buildGoPropsInit(
       // passes a `Record<string, unknown>`-shaped prop through.
       lines.push(`\t\t${goField}: ${goMapLiteralFromObject(value as Record<string, unknown>)},`)
     }
+  }
+  // Emit the collected rest-bag entries as the open-ended bag field. Skip
+  // when a direct `restPropsName`-keyed prop already populated it above
+  // (merging two sources isn't a shape any fixture needs).
+  if (restBagField && restBagEntries.length > 0 && !(restPropsName! in props)) {
+    const bag = Object.fromEntries(restBagEntries)
+    lines.push(`\t\t${restBagField}: ${goMapLiteralFromObject(bag)},`)
   }
   return lines.join('\n')
 }

--- a/packages/adapter-mojolicious/package.json
+++ b/packages/adapter-mojolicious/package.json
@@ -48,7 +48,7 @@
   ],
   "scripts": {
     "build": "bun run build:js && bun run build:types",
-    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared",
+    "build:js": "bun build ./src/index.ts ./src/adapter/index.ts ./src/build.ts --root ./src --outdir ./dist --format esm --external @barefootjs/jsx --external @barefootjs/shared --external typescript",
     "build:types": "tsgo --emitDeclarationOnly --outDir ./dist",
     "test": "bun test",
     "clean": "rm -rf dist",
@@ -75,11 +75,11 @@
     "@barefootjs/shared": "workspace:*"
   },
   "peerDependencies": {
-    "@barefootjs/jsx": ">=0.2.0"
+    "@barefootjs/jsx": ">=0.2.0",
+    "typescript": "^5.0.0"
   },
   "devDependencies": {
     "@barefootjs/adapter-tests": "workspace:*",
-    "@barefootjs/jsx": "workspace:*",
-    "typescript": "^5.0.0"
+    "@barefootjs/jsx": "workspace:*"
   }
 }

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -78,9 +78,7 @@ runAdapterConformanceTests({
     'toggle',
     'switch',
     'checkbox',
-    'input',
     'textarea',
-    'label',
     'kbd',
   ],
   // Per-fixture build-time contracts for shapes the Mojo adapter
@@ -257,6 +255,26 @@ export function Hello() {
   test('generates .html.ep extension', () => {
     const adapter = new MojoAdapter()
     expect(adapter.extension).toBe('.html.ep')
+  })
+
+  test('module pure-string const referenced in className inlines the literal (#1467 Phase 2b)', () => {
+    // A module-scope `const X = 'literal'` used inside a className template
+    // literal must inline its value, NOT emit `$X` against a stash variable
+    // that is never bound (the value would render empty). Hono inlines it at
+    // runtime; this restores byte-parity.
+    const result = compileAndGenerate(`
+"use client"
+const labelClasses = 'flex items-center group-data-[disabled=true]:opacity-50'
+export function Label({ className = '' }: { className?: string }) {
+  return <label className={\`\${labelClasses} \${className}\`} />
+}
+`)
+    // Inlined as a Perl single-quoted literal, escaped tokens intact.
+    expect(result.template).toContain(
+      "'flex items-center group-data-[disabled=true]:opacity-50'",
+    )
+    // No stash-variable reference to the const.
+    expect(result.template).not.toContain('$labelClasses')
   })
 
   test('generates conditional with Perl if/else', () => {

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -277,6 +277,22 @@ export function Label({ className = '' }: { className?: string }) {
     expect(result.template).not.toContain('$labelClasses')
   })
 
+  test('module pure-string const is NOT inlined when shadowed by a loop variable (#1749 review)', () => {
+    // A loop param whose name matches a module const must keep its loop
+    // binding (`$label`) inside the body — the const literal must not leak
+    // in. `renderLoop` guards module-const inlining for the loop body.
+    const result = compileAndGenerate(`
+"use client"
+const label = 'MODULE_CONST'
+export function List({ items }: { items: string[] }) {
+  return <ul>{items.map(label => <li>{label}</li>)}</ul>
+}
+`)
+    // Inside the loop the param wins — emit the loop variable, not the const.
+    expect(result.template).toContain('$label')
+    expect(result.template).not.toContain('MODULE_CONST')
+  })
+
   test('generates conditional with Perl if/else', () => {
     const result = compileAndGenerate(`
 "use client"

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -198,6 +198,15 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
    * module-scope pure string literals qualify (see `collectModuleStringConsts`).
    */
   private moduleStringConsts: Map<string, string> = new Map()
+  /**
+   * Names currently bound by an enclosing loop body — the `my $<param>` and
+   * `my $<index>` bindings `renderLoop` introduces — ref-counted so nested
+   * loops compose. `resolveModuleStringConst` consults this so a loop
+   * variable whose name happens to match a module string const is NOT
+   * inlined as the const literal (mirrors the Go adapter's loop-param /
+   * loop-var shadowing guards). (#1749 review)
+   */
+  private loopBoundNames: Map<string, number> = new Map()
 
   constructor(options: MojoAdapterOptions = {}) {
     super()
@@ -226,6 +235,7 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       if (isStringTypeInfo(p.type)) this.stringValueNames.add(p.name)
     }
     this.moduleStringConsts = this.collectModuleStringConsts(ir.metadata.localConstants)
+    this.loopBoundNames.clear()
     this.errors = []
     this.childrenCaptureCounter = 0
 
@@ -305,6 +315,9 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
    * literal form `'<escaped>'` ready to drop into an expression.
    */
   resolveModuleStringConst(name: string): string | null {
+    // A loop body introduces `my $<param>` / `my $<index>` bindings that
+    // shadow a module const of the same name — never inline inside one.
+    if (this.loopBoundNames.has(name)) return null
     const value = this.moduleStringConsts.get(name)
     if (value === undefined) return null
     return `'${value.replace(/[\\']/g, m => `\\${m}`)}'`
@@ -659,6 +672,16 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     const indexVar = loop.iterationShape === 'keys'
       ? `$${param}`
       : loop.index ? `$${loop.index}` : '$_i'
+    // Names this loop binds in body scope. Guard module-const inlining for
+    // the whole body (children + key + filter) so a same-named loop variable
+    // isn't replaced by the const literal (#1749 review). Ref-counted for
+    // nested loops; released after the body lines are assembled below.
+    const loopBound = loop.iterationShape === 'keys'
+      ? [param]
+      : [param, loop.index ?? '_i']
+    for (const n of loopBound) {
+      this.loopBoundNames.set(n, (this.loopBoundNames.get(n) ?? 0) + 1)
+    }
     const prevInLoop = this.inLoop
     this.inLoop = true
     const renderedChildren = this.renderChildren(loop.children)
@@ -714,6 +737,13 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       lines.push(`% }`)
     } else {
       lines.push(children)
+    }
+
+    // Body fully rendered — release the loop-bound names.
+    for (const n of loopBound) {
+      const c = (this.loopBoundNames.get(n) ?? 1) - 1
+      if (c <= 0) this.loopBoundNames.delete(n)
+      else this.loopBoundNames.set(n, c)
     }
 
     lines.push(`% }`)

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -4,8 +4,10 @@
  * Generates Mojolicious EP template files (.html.ep) from BarefootJS IR.
  */
 
+import ts from 'typescript'
 import type {
   ComponentIR,
+  IRMetadata,
   IRNode,
   IRElement,
   IRText,
@@ -117,6 +119,32 @@ export interface MojoAdapterOptions {
   barefootJsPath?: string
 }
 
+/**
+ * Parse a const initializer's source text. Returns the unescaped string
+ * value when the whole initializer is a single string literal (or a
+ * no-substitution template literal), else `null`. Uses the TS parser so
+ * escapes/quotes resolve exactly as JS would, matching the value the Hono
+ * reference inlines at runtime.
+ */
+function parsePureStringLiteral(source: string): string | null {
+  const sf = ts.createSourceFile(
+    '__const.ts',
+    `const __x = (${source});`,
+    ts.ScriptTarget.Latest,
+    /*setParentNodes*/ false,
+  )
+  const stmt = sf.statements[0]
+  if (!stmt || !ts.isVariableStatement(stmt)) return null
+  const decl = stmt.declarationList.declarations[0]
+  let init = decl?.initializer
+  while (init && ts.isParenthesizedExpression(init)) init = init.expression
+  if (!init) return null
+  if (ts.isStringLiteral(init) || ts.isNoSubstitutionTemplateLiteral(init)) {
+    return init.text
+  }
+  return null
+}
+
 export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRenderCtx> {
   name = 'mojolicious'
   extension = '.html.ep'
@@ -159,6 +187,17 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
    * true — selecting the string operator from the operand's type avoids that.
    */
   private stringValueNames: Set<string> = new Set()
+  /**
+   * Module-scope pure string-literal constants (`const X = 'literal'` at
+   * file top-level), keyed by name → resolved literal value. Populated at
+   * `generate()` entry from `ir.metadata.localConstants`. When an identifier
+   * in an expression resolves to one of these, the adapter inlines the
+   * literal instead of emitting `$X` against a stash variable that is never
+   * bound (a module const isn't a prop, signal, or local — the value would
+   * render empty). Hono inlines it for free; this restores parity. Only
+   * module-scope pure string literals qualify (see `collectModuleStringConsts`).
+   */
+  private moduleStringConsts: Map<string, string> = new Map()
 
   constructor(options: MojoAdapterOptions = {}) {
     super()
@@ -186,6 +225,7 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     for (const p of ir.metadata.propsParams) {
       if (isStringTypeInfo(p.type)) this.stringValueNames.add(p.name)
     }
+    this.moduleStringConsts = this.collectModuleStringConsts(ir.metadata.localConstants)
     this.errors = []
     this.childrenCaptureCounter = 0
 
@@ -236,6 +276,38 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       sections,
       extension: this.extension,
     }
+  }
+
+  /**
+   * Build the module pure-string-const map from the IR's localConstants.
+   * A const qualifies only when it is module-scope (`isModule`) and its
+   * initializer parses to a single string literal (`ts.StringLiteral` or
+   * `ts.NoSubstitutionTemplateLiteral`). Template literals with `${}`,
+   * numeric/object initializers, `Record<T,string>` maps, memos, and
+   * signals are all excluded — only a pure compile-time string can be
+   * inlined byte-for-byte.
+   */
+  private collectModuleStringConsts(constants: IRMetadata['localConstants']): Map<string, string> {
+    const map = new Map<string, string>()
+    for (const c of constants ?? []) {
+      if (!c.isModule) continue
+      if (c.value === undefined) continue
+      const literal = parsePureStringLiteral(c.value)
+      if (literal !== null) map.set(c.name, literal)
+    }
+    return map
+  }
+
+  /**
+   * Resolve an identifier to its inlined Perl single-quoted string literal
+   * when it names a module pure-string const, else `null` (the caller then
+   * falls back to its normal `$name` stash lowering). Returns the Perl
+   * literal form `'<escaped>'` ready to drop into an expression.
+   */
+  resolveModuleStringConst(name: string): string | null {
+    const value = this.moduleStringConsts.get(name)
+    if (value === undefined) return null
+    return `'${value.replace(/[\\']/g, m => `\\${m}`)}'`
   }
 
   // ===========================================================================
@@ -1817,6 +1889,11 @@ class MojoTopLevelEmitter implements ParsedExprEmitter {
   constructor(private readonly adapter: MojoAdapter) {}
 
   identifier(name: string): string {
+    // Module pure-string const (e.g. `const baseClasses = '...'` used in a
+    // className template literal): inline the literal value rather than emit
+    // `$baseClasses` against a stash variable that is never bound.
+    const inlined = this.adapter.resolveModuleStringConst(name)
+    if (inlined !== null) return inlined
     return `$${name}`
   }
 

--- a/packages/adapter-mojolicious/src/test-render.ts
+++ b/packages/adapter-mojolicious/src/test-render.ts
@@ -433,6 +433,25 @@ function buildPerlProps(
     entries.push(`${param.name} => undef`)
   }
 
+  // A `{...props}` rest spread means props that aren't declared named
+  // params flow through the rest bag (`bf->spread_attrs($<restPropsName>)`),
+  // not their own top-level template var. Route them into the bag hashref so
+  // a fixture passing e.g. `placeholder` to `Input` (whose declared params
+  // are `className` / `type`) renders `placeholder="..."` via the spread
+  // rather than silently dropping it into an unused `my $placeholder`. (#1467
+  // Phase 2b — mirrors the Go harness fix in the sibling `test-render.ts`.)
+  const restPropsName = ir.metadata.restPropsName
+  const declaredParams = new Set(ir.metadata.propsParams.map(p => p.name))
+  const restBagEntries: Array<[string, unknown]> = []
+  if (restPropsName && props) {
+    for (const [key, value] of Object.entries(props)) {
+      if (key.startsWith('__')) continue
+      if (key === restPropsName || declaredParams.has(key)) continue
+      restBagEntries.push([key, value])
+    }
+  }
+  const routedKeys = new Set(restBagEntries.map(([k]) => k))
+
   // (#1407 follow-up) Default the rest-binding identifier to an
   // empty hashref so `bf->spread_attrs($extras)` in the generated
   // Mojo template doesn't trip Perl's strict-mode "Global symbol
@@ -441,13 +460,16 @@ function buildPerlProps(
   // the COMPILE path on Go, where the bag plumbing matters; the
   // runtime is a no-op when the caller leaves the bag unset, which
   // mirrors the empty-spread case on every adapter).
-  if (ir.metadata.restPropsName && !(props && ir.metadata.restPropsName in props)) {
-    entries.push(`${ir.metadata.restPropsName} => {}`)
+  // When the fixture supplied undeclared props, seed the bag with those
+  // routed entries instead of an empty hashref.
+  if (restPropsName && !(props && restPropsName in props)) {
+    entries.push(`${restPropsName} => ${toPerlLiteral(Object.fromEntries(restBagEntries))}`)
   }
 
   // Add user props
   if (props) {
     for (const [key, value] of Object.entries(props)) {
+      if (routedKeys.has(key)) continue
       if (typeof value === 'string') {
         entries.push(`${key} => '${value.replace(/'/g, "\\'")}'`)
       } else if (typeof value === 'number') {


### PR DESCRIPTION
## Summary

First increment of bringing the #1467 Phase 2b `site/ui` primitives into **cross-adapter (Go + Mojo) conformance** instead of skipping them. Stacked on #1739 (which adds the fixtures). Enables `label` and `input`.

### Root cause fixed
A module-scope pure string-literal const referenced in a `className` template literal — e.g. `const labelClasses = 'flex items-center ...'` then `className={`${labelClasses} ${className}`}` — lowered to an **unpopulated** reference on both template adapters:
- Go: `{{.LabelClasses}}` → `can't evaluate field LabelClasses in type main.LabelProps`
- Mojo: `$labelClasses` → renders empty

A module const is neither a prop, signal, nor local, so no struct field / stash var ever binds it. Hono inlines it for free (it evaluates real JS), so the reference output already has the literal.

### Change
Both adapters now resolve such identifiers through the IR's `localConstants` and **inline the literal value** (escaped for the target template language). Strictly gated: only **module-scope pure string literals** qualify — `Record<T,string>` indexed lookups, memos, signals, and function-scope locals are deliberately excluded (those stay the tracked known limitation). Guarded against loop-param/loop-var shadowing on Go.

Also routes undeclared `{...props}` rest-spread props into the rest bag in both adapter test harnesses (`buildGoPropsInit` / `buildPerlProps`), so a fixture passing e.g. `placeholder` to a rest-spread component populates the spread bag rather than emitting a non-existent top-level struct field (`unknown field Placeholder`).

### Unskipped
`label` and `input` removed from the Go and Mojo `skipJsx` lists. Regression tests added to both adapter suites pinning the inline behaviour.

### Deferred (still skipped — tracked follow-ups)
- `toggle` / `switch` — reactive-memo className + `Record<T,string>[key]` variant lookups (documented known limitation)
- `textarea` — conditional inline-object spread `{...(cond ? {…} : {})}` (new lowering)
- `checkbox` — local-const conditional object spread + sibling-type plumbing (new lowering)
- `kbd` — blocked only by a CSR-skip, not adapter conformance

### Validation (all self-re-run, 0 fail)
- Go conformance (perl/go installed so it actually executes): **443 pass / 3 skip / 0 fail**
- Mojo conformance (perl + Mojolicious 9.35 installed): **396 pass / 5 skip / 0 fail**
- `packages/jsx` + `adapter-tests` + `client` + `shared`: **3023 pass / 0 fail**
- No snapshots regenerated; no fixture `.ts` or Hono reference output changed.

🤖 https://claude.ai/code/session_01UatvBGZG5csvttdtgcSf7p

---
_Generated by [Claude Code](https://claude.ai/code/session_01UatvBGZG5csvttdtgcSf7p)_