### PR TITLE
feat(perl): Minilla CPAN packaging for the three Perl dists

### DIFF
--- a/.github/workflows/ci-perl-dist.yml
+++ b/.github/workflows/ci-perl-dist.yml
@@ -1,0 +1,72 @@
+name: CI — Perl CPAN dists (Minilla)
+
+# Verifies the three Perl distributions assemble, test, and build as CPAN
+# tarballs via Minilla (scripts/perl-dist.sh). This is the "buildable/testable"
+# check for the dist packaging — it does not publish to CPAN.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/adapter-perl/**'
+      - 'packages/adapter-xslate/lib/**'
+      - 'packages/adapter-xslate/minil.toml'
+      - 'packages/adapter-xslate/cpanfile'
+      - 'packages/adapter-xslate/t/**'
+      - 'packages/adapter-mojolicious/lib/**'
+      - 'packages/adapter-mojolicious/minil.toml'
+      - 'packages/adapter-mojolicious/cpanfile'
+      - 'packages/adapter-mojolicious/t/**'
+      - 'scripts/perl-dist.sh'
+      - '.github/workflows/ci-perl-dist.yml'
+  pull_request:
+    paths:
+      - 'packages/adapter-perl/**'
+      - 'packages/adapter-xslate/lib/**'
+      - 'packages/adapter-xslate/minil.toml'
+      - 'packages/adapter-xslate/cpanfile'
+      - 'packages/adapter-xslate/t/**'
+      - 'packages/adapter-mojolicious/lib/**'
+      - 'packages/adapter-mojolicious/minil.toml'
+      - 'packages/adapter-mojolicious/cpanfile'
+      - 'packages/adapter-mojolicious/t/**'
+      - 'scripts/perl-dist.sh'
+      - '.github/workflows/ci-perl-dist.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  dist:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Perl
+        uses: shogo82148/actions-setup-perl@a198315ec4e9244f206879ea7b63078003aec8a6 # v1
+        with:
+          perl-version: '5.40'
+
+      # Minilla (build tool) + the dists' runtime/test deps. Minilla does not
+      # auto-install cpanfile deps, so the engines and Test2::Suite are explicit.
+      - name: Install Minilla + dist dependencies
+        run: cpanm --notest Minilla Test2::Suite Text::Xslate Mojolicious
+
+      # Core must be built and installed first so the backend dists can resolve
+      # `requires 'BarefootJS'` from their cpanfile during `minil test`.
+      - name: Build, test & install core (BarefootJS)
+        run: |
+          bash scripts/perl-dist.sh packages/adapter-perl test
+          bash scripts/perl-dist.sh packages/adapter-perl dist
+          cpanm --notest packages/adapter-perl/BarefootJS-*.tar.gz
+
+      - name: Build & test BarefootJS-Backend-Xslate
+        run: |
+          bash scripts/perl-dist.sh packages/adapter-xslate test
+          bash scripts/perl-dist.sh packages/adapter-xslate dist
+
+      - name: Build & test Mojolicious-Plugin-BarefootJS
+        run: |
+          bash scripts/perl-dist.sh packages/adapter-mojolicious test
+          bash scripts/perl-dist.sh packages/adapter-mojolicious dist

--- a/.github/workflows/ci-perl-dist.yml
+++ b/.github/workflows/ci-perl-dist.yml
@@ -51,7 +51,10 @@ jobs:
       # Minilla (build tool) + the dists' runtime/test deps. Minilla does not
       # auto-install cpanfile deps, so the engines and Test2::Suite are explicit.
       - name: Install Minilla + dist dependencies
-        run: cpanm --notest Minilla Test2::Suite Text::Xslate Mojolicious
+        # Software::License::MIT is needed by Minilla to resolve the MIT license
+        # (Minilla bundles only its own Perl_5 license class). Test2::Suite is the
+        # dists' test dep; Text::Xslate / Mojolicious are backend runtime deps.
+        run: cpanm --notest Minilla Software::License Test2::Suite Text::Xslate Mojolicious
 
       # Core must be built and installed first so the backend dists can resolve
       # `requires 'BarefootJS'` from their cpanfile during `minil test`.

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,10 @@ test-results/
 # Render temp files (adapter-tests)
 .render-temp/
 .playwright-mcp/
+
+# Perl CPAN dist build artifacts (Minilla, via scripts/perl-dist.sh)
+packages/adapter-*/*.tar.gz
+packages/adapter-*/.build/
+packages/adapter-*/blib/
+packages/adapter-*/Build
+packages/adapter-*/MYMETA.*

--- a/packages/adapter-mojolicious/Changes
+++ b/packages/adapter-mojolicious/Changes
@@ -1,0 +1,6 @@
+Revision history for Perl extension Mojolicious-Plugin-BarefootJS
+
+{{$NEXT}}
+
+    - Initial version. Mojolicious integration for the BarefootJS runtime:
+      the `bf` helper, BarefootJS::Backend::Mojo, and the DevReload plugin.

--- a/packages/adapter-mojolicious/cpanfile
+++ b/packages/adapter-mojolicious/cpanfile
@@ -6,3 +6,9 @@ on 'test' => sub {
     requires 'Test2::V0';
     requires 'Test::Mojo';
 };
+
+# Authoring tools — building the CPAN dist with Minilla (scripts/perl-dist.sh).
+on 'develop' => sub {
+    requires 'Minilla';
+    requires 'Software::License::MIT';
+};

--- a/packages/adapter-mojolicious/cpanfile
+++ b/packages/adapter-mojolicious/cpanfile
@@ -1,0 +1,8 @@
+requires 'perl', '5.020';
+requires 'BarefootJS';
+requires 'Mojolicious', '9.0';
+
+on 'test' => sub {
+    requires 'Test2::V0';
+    requires 'Test::Mojo';
+};

--- a/packages/adapter-mojolicious/lib/BarefootJS/Backend/Mojo.pm
+++ b/packages/adapter-mojolicious/lib/BarefootJS/Backend/Mojo.pm
@@ -1,4 +1,5 @@
 package BarefootJS::Backend::Mojo;
+our $VERSION = "0.01";
 use Mojo::Base -base, -signatures;
 
 use Mojo::ByteStream qw(b);

--- a/packages/adapter-mojolicious/lib/Mojolicious/Plugin/BarefootJS.pm
+++ b/packages/adapter-mojolicious/lib/Mojolicious/Plugin/BarefootJS.pm
@@ -1,4 +1,5 @@
 package Mojolicious::Plugin::BarefootJS;
+our $VERSION = "0.01";
 use Mojo::Base 'Mojolicious::Plugin', -signatures;
 
 use Mojo::File qw(path);
@@ -102,3 +103,58 @@ sub _load_manifest ($app, $config) {
 }
 
 1;
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+Mojolicious::Plugin::BarefootJS - Mojolicious integration for BarefootJS
+
+=head1 SYNOPSIS
+
+    # Mojolicious application
+    $self->plugin('BarefootJS');
+
+    # In a controller / template, the `bf` helper exposes a per-request
+    # BarefootJS runtime backed by BarefootJS::Backend::Mojo.
+
+=head1 DESCRIPTION
+
+Wires the L<BarefootJS> server runtime into L<Mojolicious>. It registers a
+C<bf> controller helper that lazily instantiates one BarefootJS object per
+request (rendering via L<BarefootJS::Backend::Mojo>), and supports rendering
+compiled marked templates as Mojolicious templates.
+
+For non-Mojolicious / PSGI hosts, see L<BarefootJS::Backend::Xslate>, which
+drives the same runtime with Text::Xslate and no web framework.
+
+=head1 METHODS
+
+L<Mojolicious::Plugin::BarefootJS> inherits all methods from
+L<Mojolicious::Plugin> and implements the following new one.
+
+=head2 register
+
+    $plugin->register(Mojolicious->new, \%conf);
+
+Registers the plugin (the C<bf> helper and supporting hooks) in a Mojolicious
+application.
+
+=head1 SEE ALSO
+
+L<BarefootJS>, L<BarefootJS::Backend::Mojo>, L<BarefootJS::Backend::Xslate>,
+L<Mojolicious>, L<https://github.com/piconic-ai/barefootjs>
+
+=head1 AUTHOR
+
+kobaken E<lt>kentafly88@gmail.comE<gt>
+
+=head1 LICENSE
+
+Copyright (c) 2025-present BarefootJS Contributors.
+
+This library is free software; you can redistribute it and/or modify it under
+the MIT License. See the F<LICENSE> file in the distribution for the full text.
+
+=cut

--- a/packages/adapter-mojolicious/lib/Mojolicious/Plugin/BarefootJS/DevReload.pm
+++ b/packages/adapter-mojolicious/lib/Mojolicious/Plugin/BarefootJS/DevReload.pm
@@ -1,4 +1,5 @@
 package Mojolicious::Plugin::BarefootJS::DevReload;
+our $VERSION = "0.01";
 use Mojo::Base 'Mojolicious::Plugin', -signatures;
 
 =head1 NAME

--- a/packages/adapter-mojolicious/minil.toml
+++ b/packages/adapter-mojolicious/minil.toml
@@ -1,0 +1,6 @@
+name = "Mojolicious-Plugin-BarefootJS"
+license = "MIT"
+
+# Ships the Mojolicious plugin plus BarefootJS::Backend::Mojo and the DevReload
+# plugin. Assembled into an isolated build dir by scripts/perl-dist.sh, so the
+# npm/TS files in this package never reach the CPAN tarball — only lib/ and t/.

--- a/packages/adapter-perl/Changes
+++ b/packages/adapter-perl/Changes
@@ -1,0 +1,6 @@
+Revision history for Perl extension BarefootJS
+
+{{$NEXT}}
+
+    - Initial version. Engine- and framework-agnostic server runtime for
+      BarefootJS marked templates, driven by a pluggable rendering backend.

--- a/packages/adapter-perl/cpanfile
+++ b/packages/adapter-perl/cpanfile
@@ -7,3 +7,9 @@ requires 'perl', '5.020';
 on 'test' => sub {
     requires 'Test2::V0';
 };
+
+# Authoring tools — building the CPAN dist with Minilla (scripts/perl-dist.sh).
+on 'develop' => sub {
+    requires 'Minilla';
+    requires 'Software::License::MIT';
+};

--- a/packages/adapter-perl/cpanfile
+++ b/packages/adapter-perl/cpanfile
@@ -1,0 +1,9 @@
+requires 'perl', '5.020';
+
+# The core runtime uses only core Perl modules (POSIX, Scalar::Util). No
+# template engine or web framework is pulled in here — those live in the
+# backend dists (BarefootJS-Backend-Xslate, Mojolicious-Plugin-BarefootJS).
+
+on 'test' => sub {
+    requires 'Test2::V0';
+};

--- a/packages/adapter-perl/lib/BarefootJS.pm
+++ b/packages/adapter-perl/lib/BarefootJS.pm
@@ -1,4 +1,5 @@
 package BarefootJS;
+our $VERSION = "0.01";
 use strict;
 use warnings;
 use utf8;
@@ -1157,3 +1158,62 @@ sub spread_attrs ($self, $bag) {
 }
 
 1;
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+BarefootJS - Engine- and framework-agnostic server runtime for BarefootJS marked templates
+
+=head1 SYNOPSIS
+
+    use BarefootJS;
+
+    # A host injects a rendering backend (see BarefootJS::Backend::Xslate or
+    # Mojolicious::Plugin::BarefootJS for shipping backends).
+    my $bf = BarefootJS->new($context, { backend => $backend });
+
+    # The compiled marked template calls the runtime as a `bf` object:
+    #   <: $bf.scope_attr() :>  <: $bf.json($data) :>  <: $bf.spread_attrs($h) :>
+
+=head1 DESCRIPTION
+
+BarefootJS compiles JSX/TSX into a marked template plus client JS. This module
+is the server-side runtime the marked templates call into at render time. It is
+deliberately template-engine- and web-framework-agnostic: every operation that
+depends on I<how> a template is rendered — JSON marshalling, raw-string marking,
+JSX-children materialisation, and named-template rendering — is delegated to a
+pluggable C<backend>.
+
+That design lets the one runtime drive any backend. Shipping backends:
+
+=over 4
+
+=item * L<BarefootJS::Backend::Xslate> — Text::Xslate (Kolon); runs under any PSGI/Plack app.
+
+=item * L<BarefootJS::Backend::Mojo> — Mojolicious (via L<Mojolicious::Plugin::BarefootJS>).
+
+=back
+
+The core itself pulls in only core Perl modules (C<POSIX>, C<Scalar::Util>);
+no template engine or web framework is loaded unless a backend that needs one
+is used.
+
+=head1 SEE ALSO
+
+L<BarefootJS::Backend::Xslate>, L<Mojolicious::Plugin::BarefootJS>,
+L<https://github.com/piconic-ai/barefootjs>
+
+=head1 AUTHOR
+
+kobaken E<lt>kentafly88@gmail.comE<gt>
+
+=head1 LICENSE
+
+Copyright (c) 2025-present BarefootJS Contributors.
+
+This library is free software; you can redistribute it and/or modify it under
+the MIT License. See the F<LICENSE> file in the distribution for the full text.
+
+=cut

--- a/packages/adapter-perl/minil.toml
+++ b/packages/adapter-perl/minil.toml
@@ -1,0 +1,7 @@
+name = "BarefootJS"
+license = "MIT"
+
+# Author and license are read from the main module's POD (=head1 AUTHOR /
+# =head1 LICENSE). This dist is assembled into an isolated build dir by
+# scripts/perl-dist.sh, so the npm/TS files in this package never reach the
+# CPAN tarball.

--- a/packages/adapter-xslate/Changes
+++ b/packages/adapter-xslate/Changes
@@ -1,0 +1,6 @@
+Revision history for Perl extension BarefootJS-Backend-Xslate
+
+{{$NEXT}}
+
+    - Initial version. Text::Xslate (Kolon) rendering backend for the
+      BarefootJS runtime; runs under any PSGI/Plack app.

--- a/packages/adapter-xslate/cpanfile
+++ b/packages/adapter-xslate/cpanfile
@@ -6,3 +6,9 @@ requires 'Text::Xslate', '3.4.0';
 on 'test' => sub {
     requires 'Test2::V0';
 };
+
+# Authoring tools — building the CPAN dist with Minilla (scripts/perl-dist.sh).
+on 'develop' => sub {
+    requires 'Minilla';
+    requires 'Software::License::MIT';
+};

--- a/packages/adapter-xslate/cpanfile
+++ b/packages/adapter-xslate/cpanfile
@@ -1,0 +1,8 @@
+requires 'perl', '5.020';
+requires 'BarefootJS';
+requires 'Text::Xslate', '3.4.0';
+# JSON::PP is a core module (default encoder).
+
+on 'test' => sub {
+    requires 'Test2::V0';
+};

--- a/packages/adapter-xslate/lib/BarefootJS/Backend/Xslate.pm
+++ b/packages/adapter-xslate/lib/BarefootJS/Backend/Xslate.pm
@@ -1,4 +1,5 @@
 package BarefootJS::Backend::Xslate;
+our $VERSION = "0.01";
 use strict;
 use warnings;
 use utf8;
@@ -84,3 +85,68 @@ sub render_named ($self, $template_name, $child_bf, $vars) {
 }
 
 1;
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+BarefootJS::Backend::Xslate - Text::Xslate (Kolon) rendering backend for BarefootJS
+
+=head1 SYNOPSIS
+
+    use BarefootJS;
+    use BarefootJS::Backend::Xslate;
+
+    my $backend = BarefootJS::Backend::Xslate->new(path => ['templates']);
+    my $bf = BarefootJS->new(undef, { backend => $backend });
+
+    # Renders templates/counter.tx, binding the runtime as the `bf` object.
+    my $html = $backend->render_named('counter', $bf, { count => 0 });
+
+=head1 DESCRIPTION
+
+A rendering backend that lets the engine-agnostic L<BarefootJS> runtime render
+its marked templates with L<Text::Xslate> (Kolon syntax). Because it has no
+dependency on a web framework, a plain Text::Xslate instance renders templates
+from a path, so it runs under any PSGI / Plack application (or none at all).
+
+Pair it with the C<@barefootjs/xslate> compile-time adapter, which emits Kolon
+C<.tx> templates that call the runtime as a C<bf> object — C<< <: $bf.scope_attr()
+:> >>, C<< <: $bf.json($x) :> >>, C<< <: $bf.spread_attrs($h) :> >>. Kolon
+auto-escapes C<< <: ... :> >> interpolations (the backend builds Text::Xslate
+with C<< type => 'html' >>); helpers that emit markup return C<mark_raw> values,
+mirroring Mojo EP's C<< <%== >> versus C<< <%= >>.
+
+=head1 METHODS
+
+=head2 new(%args)
+
+Constructs a backend. Accepts a pre-built C<xslate> instance, or a C<path>
+(arrayref of template directories) plus optional C<xslate_options> to build a
+Kolon, html-escaping Text::Xslate. C<json_encoder> overrides the default
+canonical L<JSON::PP> encoder.
+
+=head2 encode_json($data) / mark_raw($str) / materialize($value) / render_named($name, $bf, \%vars)
+
+The four engine-specific operations the runtime delegates to. C<mark_raw> uses
+C<Text::Xslate::mark_raw>; C<render_named> renders C<< <name>.tx >> with C<$bf>
+bound as the C<bf> variable plus C<\%vars>.
+
+=head1 SEE ALSO
+
+L<BarefootJS>, L<Text::Xslate>, L<Plack>,
+L<https://github.com/piconic-ai/barefootjs>
+
+=head1 AUTHOR
+
+kobaken E<lt>kentafly88@gmail.comE<gt>
+
+=head1 LICENSE
+
+Copyright (c) 2025-present BarefootJS Contributors.
+
+This library is free software; you can redistribute it and/or modify it under
+the MIT License. See the F<LICENSE> file in the distribution for the full text.
+
+=cut

--- a/packages/adapter-xslate/minil.toml
+++ b/packages/adapter-xslate/minil.toml
@@ -1,0 +1,6 @@
+name = "BarefootJS-Backend-Xslate"
+license = "MIT"
+
+# Assembled into an isolated build dir by scripts/perl-dist.sh, so the npm/TS
+# files in this package (package.json, tsconfig.json, src/) never reach the
+# CPAN tarball — only lib/ and t/.

--- a/packages/adapter-xslate/t/render.t
+++ b/packages/adapter-xslate/t/render.t
@@ -1,0 +1,39 @@
+use Test2::V0;
+use utf8;
+use File::Temp qw(tempdir);
+use File::Spec;
+
+use BarefootJS;
+use BarefootJS::Backend::Xslate;
+
+# Write a Kolon template equivalent to what the @barefootjs/xslate compile-time
+# adapter emits, then render it through the runtime + this backend.
+my $dir = tempdir(CLEANUP => 1);
+open my $fh, '>:encoding(UTF-8)', File::Spec->catfile($dir, 'widget.tx') or die $!;
+print $fh <<'TX';
+<div bf-s="<: $bf.scope_attr() :>" <: $bf.hydration_attrs() | mark_raw :>>count: <: $bf.text_start("s0") | mark_raw :><: $count :><: $bf.text_end() | mark_raw :> <span <: $bf.spread_attrs($attrs) :>><: $label :></span></div>
+TX
+close $fh;
+
+my $backend = BarefootJS::Backend::Xslate->new(path => [$dir]);
+my $bf = BarefootJS->new(undef, { backend => $backend });
+$bf->_scope_id('Widget_test');
+
+my $out = $backend->render_named('widget', $bf, {
+    count => 7,
+    label => '<x>',
+    attrs => { id => 'n', class => 'c' },
+});
+
+like $out, qr/bf-s="Widget_test" bf-r=""/, 'scope + hydration markers (raw)';
+like $out, qr{count: <!--bf:s0-->7<!--/-->}, 'reactive text slot with comment markers';
+like $out, qr/&lt;x&gt;/, 'plain interpolation is auto-escaped';
+like $out, qr/<span class="c" id="n">/, 'spread_attrs renders raw with sorted keys';
+
+# Backend unit operations.
+is $backend->materialize('plain'), 'plain', 'materialize: scalar passthrough';
+is $backend->materialize(sub { 'lazy' }), 'lazy', 'materialize: resolves CODE ref';
+like $backend->encode_json({ b => 2, a => 1 }), qr/^\{"a":1,"b":2\}$/,
+    'encode_json: canonical key order';
+
+done_testing;

--- a/scripts/perl-dist.sh
+++ b/scripts/perl-dist.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Build / test a CPAN distribution from a Perl package nested in this monorepo,
+# using Minilla.
+#
+# Why the indirection: Minilla assumes the distribution root IS the git
+# repository root (it locates the project via `git rev-parse --show-toplevel`).
+# That does not hold for packages nested under packages/ in this JS monorepo —
+# the toplevel is the monorepo root. So we assemble each dist's CPAN-relevant
+# files (lib/, t/, and the dist metadata) into an isolated temp dir with its
+# own throwaway git repo, and run `minil` there. The npm/TS sources in the
+# package (package.json, tsconfig.json, src/, *.ts) are never copied, so the
+# CPAN tarball stays clean.
+#
+# Usage:
+#   scripts/perl-dist.sh <package-dir> [minil-subcommand...]   (default: test)
+#
+# Examples:
+#   scripts/perl-dist.sh packages/adapter-perl test
+#   scripts/perl-dist.sh packages/adapter-perl dist
+#
+set -euo pipefail
+
+pkg="${1:?usage: perl-dist.sh <package-dir> [minil-subcommand...]}"
+shift || true
+
+src="$(cd "$pkg" && pwd)"
+[ -f "$src/minil.toml" ] || { echo "error: no minil.toml in $src" >&2; exit 1; }
+
+command -v minil >/dev/null 2>&1 || { echo "error: minil not found (cpanm Minilla)" >&2; exit 1; }
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# Copy only CPAN-relevant files — never the npm/TS sources.
+cp -R "$src/lib" "$work/lib"
+[ -d "$src/t" ] && cp -R "$src/t" "$work/t"
+for f in minil.toml cpanfile Changes README.md README.pod LICENSE; do
+  [ -f "$src/$f" ] && cp "$src/$f" "$work/$f"
+done
+
+# Minilla lists LICENSE in every MANIFEST but only writes it at `minil new`,
+# not during `dist`. Supply the repo's single MIT LICENSE so `dist` can pack it.
+repo_root="$(git -C "$src" rev-parse --show-toplevel)"
+if [ ! -f "$work/LICENSE" ] && [ -f "$repo_root/LICENSE" ]; then
+  cp "$repo_root/LICENSE" "$work/LICENSE"
+fi
+
+cd "$work"
+git init -q
+git add -A
+git -c user.email='dist@barefootjs.local' -c user.name='barefootjs-dist' \
+    -c commit.gpgsign=false -c tag.gpgsign=false commit -qm 'assemble dist'
+
+minil "${@:-test}"
+
+# If a tarball was produced (e.g. `dist`), surface it next to the source.
+shopt -s nullglob
+for tgz in ./*.tar.gz; do
+  cp "$tgz" "$src/" && echo "dist tarball -> $src/$(basename "$tgz")"
+done


### PR DESCRIPTION
## Goal

Package the Perl side of BarefootJS as standalone **CPAN distributions**, buildable/testable via **Minilla**. Scope this round: build/test (`minil test`, `minil dist`, `cpanm .`) — no CPAN publishing.

## The three dists

| Dist | Main module | From | Deps |
|---|---|---|---|
| `BarefootJS` | `BarefootJS` | `packages/adapter-perl` | core Perl only |
| `BarefootJS-Backend-Xslate` | `BarefootJS::Backend::Xslate` | `packages/adapter-xslate` | BarefootJS, Text::Xslate |
| `Mojolicious-Plugin-BarefootJS` | `Mojolicious::Plugin::BarefootJS` (+ `Backend::Mojo`, `::DevReload`) | `packages/adapter-mojolicious` | BarefootJS, Mojolicious |

Each gains `minil.toml` + `cpanfile` + `Changes`, and the modules get `our $VERSION` + POD (NAME/SYNOPSIS/DESCRIPTION/LICENSE). Dists are **MIT**, matching the repo.

## The monorepo wrinkle

Minilla assumes the **dist root is the git repo root** (it locates the project via `git rev-parse --show-toplevel`) — which doesn't hold for packages nested in this JS monorepo. So **`scripts/perl-dist.sh`** assembles each dist's CPAN files (`lib/`, `t/`, metadata + the repo `LICENSE`) into an isolated temp git repo and runs `minil` there. The npm/TS sources (`package.json`, `tsconfig.json`, `src/`, `*.ts`) are never copied, so the tarball stays clean.

```
scripts/perl-dist.sh packages/adapter-perl test   # or: dist
```

## Also in this PR

- **`t/render.t`** for the Xslate backend (the package had no Perl tests) — renders a Kolon template through the runtime + backend and asserts scope/text-slot/spread markers.
- **`ci-perl-dist.yml`** — installs Minilla + engines, then `minil test` + `dist` for all three (core built/installed first so the backends resolve `requires 'BarefootJS'`).
- `.gitignore` for the dist build artifacts.

## Validation (local)

- ✅ `minil test`: **30 / 7 / 11** tests pass (core / xslate / mojo).
- ✅ `minil dist`: clean tarballs — `lib/` + `t/` + `Build.PL`/`META.json`/`MANIFEST`/`LICENSE`/`Changes`/`cpanfile` only, **no npm cruft**. META license `mit`.
- ✅ `cpanm <tarball>` installs each; `use BarefootJS` etc. importable.

## Notes

- No `src/` changes, so no changeset (the `.pm` edits are version/POD only; they ship in the npm packages unchanged in behavior).
- Actual CPAN release (PAUSE upload, version/Changes automation) is intentionally out of scope.

https://claude.ai/code/session_01Q2ZNcmBJuucbnuyT58b3NZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2ZNcmBJuucbnuyT58b3NZ)_