### PR TITLE
feat(go,mojo): conditional-object spread + nullish attr omission — enable Phase 2b textarea conformance

### DIFF
--- a/.changeset/conditional-object-spread-lowering.md
+++ b/.changeset/conditional-object-spread-lowering.md
@@ -1,0 +1,12 @@
+---
+"@barefootjs/go-template": patch
+"@barefootjs/mojolicious": patch
+---
+
+Lower conditional inline-object spreads on intrinsic elements. A spread of the shape `{...(cond ? { 'aria-describedby': value } : {})}` (either branch possibly `{}`) now compiles on both template adapters instead of raising `BF101`.
+
+The Go adapter builds the spread bag as an immediately-invoked `func() map[string]any { ... }()` in `NewXxxProps` that conditionally returns the populated map or an empty one. The Mojo adapter emits an equivalent Perl inline ternary of hashrefs (`$cond ? { 'aria-describedby' => $value } : {}`) through `bf->spread_attrs`. In both adapters the falsy branch yields an empty bag so the key is omitted rather than rendered as an empty-string attribute (neither `SpreadAttrs` nor `bf->spread_attrs` filters empty strings).
+
+The condition supports a bare prop identifier and its negation; object keys must be static string/identifier names and values resolve prop references (`in.Field` / `$prop`) or string literals. Any other shape still falls through to the existing `BF101` refusal.
+
+Additionally, both adapters now honour Hono-style nullish-attribute omission for dynamic attributes. When an attribute value is a bare reference to a nillable prop (Go: a field whose resolved type is `interface{}`; Mojo: a prop with no destructure default and a non-primitive type), the attribute is guarded so an unset value drops the attribute entirely instead of rendering `attr=""`. Go emits `{{if ne .Rows nil}}rows="{{.Rows}}"{{end}}`; Mojo emits `<% if (defined $rows) { %>rows="<%= $rows %>"<% } %>`. Concrete-typed (`string`/`int`/`bool`) and defaulted props are unaffected and still emit unconditionally (matching Hono's `value=""` / `data-count="0"`). This unblocks the `textarea` fixture's optional `rows?: number` prop on both adapter conformance suites.

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -1100,6 +1100,13 @@ func FilterTruthy(items any) []any {
 	return result
 }
 
+// Truthy is the exported form of isTruthy — JavaScript's `Boolean(x)`
+// semantics — for generated `NewXxxProps` code lowering a conditional
+// inline-object spread condition on an `interface{}` prop (whose runtime
+// value may be a string, number, bool, …). Keeps the spread bag's
+// inclusion test faithful to JS rather than string-biased (#1752).
+func Truthy(v any) bool { return isTruthy(v) }
+
 // isTruthy mirrors JavaScript's `Boolean(x)` for the value shapes the
 // template path actually receives — nil / false / 0 / "" are falsy.
 // Other shapes (non-empty maps, slices, structs, true) are truthy, in

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -80,12 +80,19 @@ runAdapterConformanceTests({
     // parity for the `site/ui` corpus is Phase 3, so these participate only
     // in Hono SSR conformance + the fixture-hydrate runtime layer for now.
     // (`label` and `kbd` are static helpers; `toggle` / `switch` /
-    // `checkbox` carry uncontrolled state; `input` / `textarea` are
-    // pass-through native controls.)
+    // `checkbox` carry uncontrolled state; `input` is a pass-through
+    // native control.)
+    //
+    // `textarea` now participates: its conditional inline-object spread
+    // (`{...(describedBy ? {...} : {})}`) lowers via
+    // `buildConditionalSpreadInitializer`, and its optional
+    // `rows={rows}` attribute is omitted when nil via the nillable-field
+    // guard in `elementAttrEmitter.emitExpression`
+    // (`{{if ne .Rows nil}}rows="{{.Rows}}"{{end}}`), matching Hono's
+    // nullish-attribute omission.
     'toggle',
     'switch',
     'checkbox',
-    'textarea',
     'kbd',
   ],
   // Per-fixture build-time contracts for shapes the Go template
@@ -815,6 +822,90 @@ export function List() {
 }
 `)
       expect(adapter.generate(structIr).types!).toContain('Items: []Item{Item{ID: "a"}},')
+    })
+  })
+
+  describe('conditional inline-object spread (textarea aria-describedby)', () => {
+    // `{...(cond ? { 'aria-describedby': cond } : {})}` lowers to an
+    // IIFE-of-maps in `NewXxxProps` so the falsy branch OMITS the key
+    // (SpreadAttrs does not filter empty strings). The fixture only
+    // exercises the falsy branch; this pins the TRUTHY branch.
+    test('lowers to a conditional map IIFE and keeps the {{bf_spread_attrs}} template', () => {
+      const source = `
+function Box({ describedBy }: { describedBy?: string }) {
+  return <div {...(describedBy ? { 'aria-describedby': describedBy } : {})} />
+}
+`
+      const { template, types } = compileAndGenerate(source)
+      // Template emission is unchanged from the proven {...props} path.
+      expect(template).toContain('{{bf_spread_attrs .Spread_0}}')
+      // The bag value is a conditional map built in NewBoxProps. The
+      // prop type is unresolved (interface{}), so the condition is the
+      // nil/empty-string truthiness guard.
+      expect(types).toContain('Spread_0: func() map[string]any {')
+      expect(types).toContain('if in.DescribedBy != nil && in.DescribedBy != "" {')
+      expect(types).toContain('return map[string]any{"aria-describedby": in.DescribedBy}')
+      expect(types).toContain('return map[string]any{}')
+    })
+
+    test('resolves the object value reference and key for a second prop', () => {
+      const source = `
+function Box({ label }: { label: string }) {
+  return <div {...(label ? { 'data-label': label } : {})} />
+}
+`
+      const { types } = compileAndGenerate(source)
+      // The condition prop and the value reference resolve to `in.<Field>`,
+      // the static key is preserved. (The analyzer surfaces these
+      // destructured props as `unknown`/`interface{}`, so the condition
+      // is the nil/empty-string guard rather than the bare `!= ""` form.)
+      expect(types).toContain('if in.Label != nil && in.Label != "" {')
+      expect(types).toContain('return map[string]any{"data-label": in.Label}')
+    })
+
+    test('refuses a non-identifier condition with BF101 (out-of-shape fallback)', () => {
+      const adapter = new GoTemplateAdapter()
+      const source = `
+function Box({ a, b }: { a?: string; b?: string }) {
+  return <div {...(a === b ? { 'data-x': a } : {})} />
+}
+`
+      const ir = compileToIR(source, adapter)
+      adapter.generate(ir)
+      const errs = (adapter as unknown as { errors: { code: string }[] }).errors
+      expect(errs.some(e => e.code === 'BF101')).toBe(true)
+    })
+  })
+
+  describe('nullish optional-attribute omission (textarea rows)', () => {
+    // An optional, no-default prop whose Go field type resolves to
+    // `interface{}` (nillable) is emitted with a `ne .X nil` guard so an
+    // unset value DROPS the attribute instead of rendering `attr=""` —
+    // matching Hono's nullish-attribute omission. Concrete/defaulted
+    // props are never nil and stay unconditional.
+    test('guards a nillable optional attr with {{if ne .X nil}}', () => {
+      const source = `
+function C({ rows }: { rows?: number }) {
+  return <textarea rows={rows} />
+}
+`
+      const { template } = compileAndGenerate(source)
+      expect(template).toContain('{{if ne .Rows nil}}rows="{{.Rows}}"{{end}}')
+      // Must NOT emit the bare unconditional form.
+      expect(template).not.toMatch(/(?<!if ne \.Rows nil}})rows="\{\{\.Rows\}\}"/)
+    })
+
+    test('leaves a concrete/defaulted attr unconditional (scope did not widen)', () => {
+      const source = `
+function C({ value = '' }: { value?: string }) {
+  return <textarea value={value} />
+}
+`
+      const { template } = compileAndGenerate(source)
+      // `value` has a destructure default → concrete `string` field →
+      // never nil → emitted unconditionally, exactly like Hono's value="".
+      expect(template).toContain('value="{{.Value}}"')
+      expect(template).not.toContain('if ne .Value nil')
     })
   })
 

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -840,10 +840,10 @@ function Box({ describedBy }: { describedBy?: string }) {
       // Template emission is unchanged from the proven {...props} path.
       expect(template).toContain('{{bf_spread_attrs .Spread_0}}')
       // The bag value is a conditional map built in NewBoxProps. The
-      // prop type is unresolved (interface{}), so the condition is the
-      // nil/empty-string truthiness guard.
+      // prop type is unresolved (interface{}), so the condition routes
+      // through `bf.Truthy` for a faithful JS `Boolean(x)` test.
       expect(types).toContain('Spread_0: func() map[string]any {')
-      expect(types).toContain('if in.DescribedBy != nil && in.DescribedBy != "" {')
+      expect(types).toContain('if bf.Truthy(in.DescribedBy) {')
       expect(types).toContain('return map[string]any{"aria-describedby": in.DescribedBy}')
       expect(types).toContain('return map[string]any{}')
     })
@@ -858,8 +858,8 @@ function Box({ label }: { label: string }) {
       // The condition prop and the value reference resolve to `in.<Field>`,
       // the static key is preserved. (The analyzer surfaces these
       // destructured props as `unknown`/`interface{}`, so the condition
-      // is the nil/empty-string guard rather than the bare `!= ""` form.)
-      expect(types).toContain('if in.Label != nil && in.Label != "" {')
+      // routes through `bf.Truthy` for a faithful JS truthiness test.)
+      expect(types).toContain('if bf.Truthy(in.Label) {')
       expect(types).toContain('return map[string]any{"data-label": in.Label}')
     })
 

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -2125,15 +2125,19 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     } else if (prim === 'string') {
       truthy = `${field} != ""`
     } else {
-      // unknown / interface{}: non-nil non-empty-string.
-      truthy = `${field} != nil && ${field} != ""`
+      // unknown / interface{}: the runtime value may be a string, number,
+      // bool, etc., so a string-biased `!= ""` test would diverge from JS
+      // truthiness (e.g. an `interface{}` holding `0` or `false` is falsy in
+      // JS but `!= ""` reads true). Route through `bf.Truthy`, the exported
+      // `Boolean(x)` equivalent, for a faithful check (Copilot review #1752).
+      truthy = `bf.Truthy(${field})`
     }
     if (!negate) return truthy
     // Negation: wrap so `!` applies to the whole truthiness test.
     if (prim === 'boolean') return `!${field}`
     if (prim === 'number') return `${field} == 0`
     if (prim === 'string') return `${field} == ""`
-    return `${field} == nil || ${field} == ""`
+    return `!bf.Truthy(${field})`
   }
 
   /**

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -434,6 +434,21 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    */
   private moduleStringConsts: Map<string, string> = new Map()
 
+  /**
+   * Set of prop NAMES whose resolved Go struct-field type is exactly
+   * `interface{}` — i.e. nillable. Populated at `generate()` entry from
+   * the SAME per-prop Go-type computation `generatePropsStruct` /
+   * `generateInputStruct` use (`propTypeOverrides` + `typeInfoToGo`), so
+   * it can't drift from the actual field types. Used by
+   * `elementAttrEmitter.emitExpression` to omit a dynamic attribute whose
+   * value is a bare reference to a nillable prop when that prop is nil
+   * (Hono-style nullish-attribute omission: an `undefined`-valued
+   * attribute is dropped rather than rendered as `attr=""`). Concrete
+   * (`string`/`int`/`bool`) fields are never in this set and always emit
+   * unconditionally, matching Hono's `value=""` / `data-count="0"`.
+   */
+  private nillablePropNames: Set<string> = new Set()
+
   constructor(options: GoTemplateAdapterOptions = {}) {
     super()
     this.options = {
@@ -455,6 +470,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     this.propsObjectName = ir.metadata.propsObjectName
     this.restPropsName = ir.metadata.restPropsName ?? null
     this.moduleStringConsts = this.collectModuleStringConsts(ir.metadata.localConstants)
+    this.nillablePropNames = this.collectNillablePropNames(ir)
 
     // Surface loop-body usages of components imported from sibling
     // .tsx files. The adapter emits `{{template "X" .}}` for these,
@@ -1066,6 +1082,40 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   /**
+   * Resolve a prop param's Go struct-field type using the SAME logic
+   * `generatePropsStruct` / `generateInputStruct` use for the field
+   * declaration: a `propTypeOverrides` entry (signal-inferred override)
+   * wins, otherwise `typeInfoToGo(param.type, param.defaultValue)`.
+   * Factored out so the nillable-field set (`collectNillablePropNames`)
+   * can't drift from the actual emitted field types.
+   */
+  private resolvePropGoType(
+    param: IRMetadata['propsParams'][number],
+    propTypeOverrides: Map<string, string>,
+  ): string {
+    return propTypeOverrides.get(param.name) ?? this.typeInfoToGo(param.type, param.defaultValue)
+  }
+
+  /**
+   * Build the set of prop NAMES whose resolved Go field type is exactly
+   * `interface{}` (nillable). Uses the same `propTypeOverrides` +
+   * `resolvePropGoType` pipeline as the struct generators, so a prop
+   * that ends up `interface{}` on the Props struct — and only such a
+   * prop — is treated as nillable for Hono-style attribute omission.
+   * Concrete (`string`/`int`/`bool`/`[]T`/struct) types are excluded.
+   */
+  private collectNillablePropNames(ir: ComponentIR): Set<string> {
+    const propTypeOverrides = this.buildPropTypeOverrides(ir)
+    const nillable = new Set<string>()
+    for (const param of ir.metadata.propsParams) {
+      if (this.resolvePropGoType(param, propTypeOverrides) === 'interface{}') {
+        nillable.add(param.name)
+      }
+    }
+    return nillable
+  }
+
+  /**
    * Generate Input struct for a component
    */
   private generateInputStruct(
@@ -1096,7 +1146,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     for (const param of ir.metadata.propsParams) {
       const fieldName = this.capitalizeFieldName(param.name)
       if (nestedArrayFields.has(fieldName)) continue
-      const goType = propTypeOverrides.get(param.name) ?? this.typeInfoToGo(param.type, param.defaultValue)
+      const goType = this.resolvePropGoType(param, propTypeOverrides)
       lines.push(`\t${fieldName} ${goType}`)
     }
 
@@ -1169,7 +1219,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       const fieldName = this.capitalizeFieldName(param.name)
       // Skip if this field will be replaced by a typed array for nested components
       if (nestedArrayFields.has(fieldName)) continue
-      const goType = propTypeOverrides.get(param.name) ?? this.typeInfoToGo(param.type, param.defaultValue)
+      const goType = this.resolvePropGoType(param, propTypeOverrides)
       const jsonTag = this.toJsonTag(param.name)
       lines.push(`\t${fieldName} ${goType} \`json:"${jsonTag}"\``)
       propFieldNames.add(fieldName)
@@ -1922,6 +1972,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     ir: ComponentIR,
   ): string | null {
     const trimmed = spreadExpr.trim()
+    // Conditional inline-object spread:
+    //   `{...(COND ? { 'k': v } : {})}` (either branch possibly `{}`).
+    // Lower to an immediately-invoked func literal that conditionally
+    // builds the bag, so the falsy branch yields an empty map (the key
+    // is OMITTED rather than rendered as `k=""` — `SpreadAttrs` does
+    // NOT filter empty strings). Returns null for any shape it can't
+    // faithfully convert so the caller falls back to BF101 (#textarea).
+    const conditional = this.buildConditionalSpreadInitializer(trimmed, ir)
+    if (conditional !== undefined) return conditional
     // Signal-getter call: `attrs()` — pluck the signal's initialValue
     // and translate the JS object literal to a Go map literal.
     const callMatch = /^([a-zA-Z_][a-zA-Z0-9_]*)\s*\(\s*\)$/.exec(trimmed)
@@ -1972,6 +2031,148 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       }
     }
     return null
+  }
+
+  /**
+   * Lower a conditional inline-object spread bag value:
+   *   `(COND ? { 'aria-describedby': describedBy } : {})`
+   * into an immediately-invoked Go func literal that conditionally
+   * builds the map (so the falsy branch OMITS the key rather than
+   * rendering it as an empty string, which `SpreadAttrs` does not
+   * filter):
+   *
+   *   func() map[string]any {
+   *     if in.DescribedBy != nil && in.DescribedBy != "" {
+   *       return map[string]any{"aria-describedby": in.DescribedBy}
+   *     }
+   *     return map[string]any{}
+   *   }()
+   *
+   * Returns:
+   *   - `undefined` when the expression is NOT a parenthesized ternary
+   *     of object literals — the caller falls through to other shapes.
+   *   - `null` when it IS that shape but a part can't be faithfully
+   *     converted (non-static key, unsupported condition, …) — the
+   *     caller raises BF101.
+   *   - the Go IIFE string when fully convertible.
+   */
+  private buildConditionalSpreadInitializer(
+    spreadExpr: string,
+    ir: ComponentIR,
+  ): string | null | undefined {
+    const expr = this.parseLiteralExpression(spreadExpr)
+    if (!expr || !ts.isConditionalExpression(expr)) return undefined
+    const whenTrue = this.unwrapParens(expr.whenTrue)
+    const whenFalse = this.unwrapParens(expr.whenFalse)
+    if (!ts.isObjectLiteralExpression(whenTrue) || !ts.isObjectLiteralExpression(whenFalse)) {
+      return undefined
+    }
+    // Condition → Go bool against `in.`, type-aware on the prop.
+    const goCond = this.conditionToGoBool(expr.condition, ir)
+    if (goCond === null) return null
+    const trueMap = this.objectLiteralToGoSpreadMap(whenTrue, ir)
+    const falseMap = this.objectLiteralToGoSpreadMap(whenFalse, ir)
+    if (trueMap === null || falseMap === null) return null
+    return (
+      `func() map[string]any {\n` +
+      `\t\tif ${goCond} {\n` +
+      `\t\t\treturn ${trueMap}\n` +
+      `\t\t}\n` +
+      `\t\treturn ${falseMap}\n` +
+      `\t}()`
+    )
+  }
+
+  /** Strip redundant parenthesised wrappers off a TS expression. */
+  private unwrapParens(node: ts.Expression): ts.Expression {
+    let e = node
+    while (ts.isParenthesizedExpression(e)) e = e.expression
+    return e
+  }
+
+  /**
+   * Convert a conditional-spread condition expression to a Go bool in
+   * the `in.` context. Supports a bare prop identifier (`describedBy`)
+   * and its negation (`!describedBy`), type-aware on the prop:
+   *   string  → `in.X != ""`
+   *   boolean → `in.X`
+   *   number  → `in.X != 0`
+   *   unknown / interface{} → `in.X != nil && in.X != ""`
+   *     (faithful JS string-truthiness for an interface holding a
+   *     string — textarea's `describedBy` resolves to interface{}).
+   * Returns null for any other shape (caller → BF101).
+   */
+  private conditionToGoBool(
+    condition: ts.Expression,
+    ir: ComponentIR,
+  ): string | null {
+    let node = this.unwrapParens(condition)
+    let negate = false
+    if (ts.isPrefixUnaryExpression(node) && node.operator === ts.SyntaxKind.ExclamationToken) {
+      negate = true
+      node = this.unwrapParens(node.operand)
+    }
+    if (!ts.isIdentifier(node)) return null
+    const param = ir.metadata.propsParams.find(p => p.name === node.text)
+    if (!param) return null
+    const field = `in.${this.capitalizeFieldName(param.name)}`
+    const prim = param.type.kind === 'primitive' ? param.type.primitive : undefined
+    let truthy: string
+    if (prim === 'boolean') {
+      truthy = field
+    } else if (prim === 'number') {
+      truthy = `${field} != 0`
+    } else if (prim === 'string') {
+      truthy = `${field} != ""`
+    } else {
+      // unknown / interface{}: non-nil non-empty-string.
+      truthy = `${field} != nil && ${field} != ""`
+    }
+    if (!negate) return truthy
+    // Negation: wrap so `!` applies to the whole truthiness test.
+    if (prim === 'boolean') return `!${field}`
+    if (prim === 'number') return `${field} == 0`
+    if (prim === 'string') return `${field} == ""`
+    return `${field} == nil || ${field} == ""`
+  }
+
+  /**
+   * Convert a static object literal (`{ 'aria-describedby': describedBy }`)
+   * into a Go `map[string]any{...}` literal for a conditional spread.
+   * Only static string/identifier keys are allowed; values resolve
+   * prop-identifier references to `in.FieldName` and string literals to
+   * Go string literals. Returns null for any computed/spread/dynamic
+   * key or unsupported value (caller → BF101). Empty object → `map[string]any{}`.
+   */
+  private objectLiteralToGoSpreadMap(
+    obj: ts.ObjectLiteralExpression,
+    ir: ComponentIR,
+  ): string | null {
+    const entries: string[] = []
+    for (const prop of obj.properties) {
+      if (!ts.isPropertyAssignment(prop)) return null
+      let key: string
+      if (ts.isIdentifier(prop.name)) {
+        key = prop.name.text
+      } else if (ts.isStringLiteral(prop.name) || ts.isNoSubstitutionTemplateLiteral(prop.name)) {
+        key = prop.name.text
+      } else {
+        return null
+      }
+      const val = this.unwrapParens(prop.initializer)
+      let goVal: string
+      if (ts.isStringLiteral(val) || ts.isNoSubstitutionTemplateLiteral(val)) {
+        goVal = JSON.stringify(val.text)
+      } else if (ts.isIdentifier(val)) {
+        const param = ir.metadata.propsParams.find(p => p.name === val.text)
+        if (!param) return null
+        goVal = `in.${this.capitalizeFieldName(param.name)}`
+      } else {
+        return null
+      }
+      entries.push(`${JSON.stringify(key)}: ${goVal}`)
+    }
+    return `map[string]any{${entries.join(', ')}}`
   }
 
   /**
@@ -4885,6 +5086,20 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       if (parsed.kind === 'conditional' || parsed.kind === 'template-literal') {
         // Inline Go template syntax with embedded `{{...}}` actions.
         return `${name}="${this.renderParsedExpr(parsed)}"`
+      }
+      // Hono-style nullish-attribute omission (#textarea rows): when the
+      // attribute value is a BARE reference to a nillable (`interface{}`)
+      // prop field, guard emission on `ne .X nil` so an unset optional
+      // prop drops the attribute entirely instead of rendering `attr=""`.
+      // Hono omits `undefined`/`null`-valued attributes; this restores
+      // parity. Scope is deliberately narrow — bare identifiers only — so
+      // member exprs, calls, ternaries, template literals, and
+      // concrete-typed props (which are never nil) are unaffected and
+      // still emit `attr=""` / `attr="0"` exactly as Hono does.
+      const bareId = value.expr.trim()
+      if (this.nillablePropNames.has(bareId)) {
+        const field = `.${this.capitalizeFieldName(bareId)}`
+        return `{{if ne ${field} nil}}${name}="{{${this.convertExpressionToGo(value.expr)}}}"{{end}}`
       }
       return `${name}="{{${this.convertExpressionToGo(value.expr)}}}"`
     },

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -73,12 +73,19 @@ runAdapterConformanceTests({
     // parity for the `site/ui` corpus is Phase 3, so these participate only
     // in Hono SSR conformance + the fixture-hydrate runtime layer for now.
     // (`label` and `kbd` are static helpers; `toggle` / `switch` /
-    // `checkbox` carry uncontrolled state; `input` / `textarea` are
-    // pass-through native controls.)
+    // `checkbox` carry uncontrolled state; `input` is a pass-through
+    // native control.)
+    //
+    // `textarea` now participates: its conditional inline-object spread
+    // (`{...(describedBy ? {...} : {})}`) lowers via
+    // `conditionalSpreadToPerl`, and its optional `rows={rows}`
+    // attribute is omitted when `undef` via the `defined`-guard in
+    // `elementAttrEmitter.emitExpression`
+    // (`<% if (defined $rows) { %>rows="<%= $rows %>"<% } %>`), matching
+    // Hono's nullish-attribute omission.
     'toggle',
     'switch',
     'checkbox',
-    'textarea',
     'kbd',
   ],
   // Per-fixture build-time contracts for shapes the Mojo adapter
@@ -239,6 +246,76 @@ function compileAndGenerate(source: string, adapter?: MojoAdapter) {
 // =============================================================================
 // Mojo-Specific Tests
 // =============================================================================
+
+describe('MojoAdapter - conditional inline-object spread (textarea aria-describedby)', () => {
+  // `{...(cond ? { 'aria-describedby': cond } : {})}` lowers to a Perl
+  // inline ternary of hashrefs so the falsy `{}` branch OMITS the key
+  // (bf->spread_attrs does not filter empty strings). The shared
+  // fixture only exercises the falsy branch; this pins the truthy one.
+  test('emits a Perl inline ternary of hashrefs through bf->spread_attrs', () => {
+    const { template } = compileAndGenerate(`
+function Box({ describedBy }: { describedBy?: string }) {
+  return <div {...(describedBy ? { 'aria-describedby': describedBy } : {})} />
+}
+`)
+    expect(template).toContain(
+      "bf->spread_attrs($describedBy ? { 'aria-describedby' => $describedBy } : {})",
+    )
+  })
+
+  test('resolves the value reference and preserves the static key for a second prop', () => {
+    const { template } = compileAndGenerate(`
+function Box({ label }: { label: string }) {
+  return <div {...(label ? { 'data-label': label } : {})} />
+}
+`)
+    expect(template).toContain(
+      "bf->spread_attrs($label ? { 'data-label' => $label } : {})",
+    )
+  })
+
+  test('falls back to BF101 for a computed (non-static) object key', () => {
+    const adapter = new MojoAdapter()
+    const ir = compileToIR(`
+function Box({ k, v }: { k?: string; v?: string }) {
+  return <div {...(v ? { [k]: v } : {})} />
+}
+`, adapter)
+    adapter.generate(ir)
+    const errs = (adapter as unknown as { errors: { code: string }[] }).errors
+    expect(errs.some(e => e.code === 'BF101')).toBe(true)
+  })
+})
+
+describe('MojoAdapter - nullish optional-attribute omission (textarea rows)', () => {
+  // A no-destructure-default, nillable-typed prop is `undef` when the
+  // caller omits it; guard its bare-reference attribute with Perl
+  // `defined` so it DROPS instead of rendering `attr=""` — matching
+  // Hono's nullish-attribute omission. Concrete/defaulted props are
+  // never `undef` and stay unconditional.
+  test('guards a no-default nillable attr with a Perl defined check', () => {
+    const { template } = compileAndGenerate(`
+function C({ rows }: { rows?: number }) {
+  return <textarea rows={rows} />
+}
+`)
+    expect(template).toContain('<% if (defined $rows) { %>rows="<%= $rows %>"<% } %>')
+    // Must NOT emit the bare unconditional form.
+    expect(template).not.toMatch(/(?<!\{ %>)rows="<%= \$rows %>"/)
+  })
+
+  test('leaves a defaulted attr unconditional (scope did not widen)', () => {
+    const { template } = compileAndGenerate(`
+function C({ value = '' }: { value?: string }) {
+  return <textarea value={value} />
+}
+`)
+    // `value` has a destructure default → never undef → unconditional,
+    // exactly like Hono's value="".
+    expect(template).toContain('value="<%= $value %>"')
+    expect(template).not.toContain('defined $value')
+  })
+})
 
 describe('MojoAdapter - Template Generation', () => {
   test('generates basic element with scope marker', () => {

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -208,15 +208,20 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
    */
   private loopBoundNames: Map<string, number> = new Map()
   /**
-   * Prop names that are OPTIONAL and have NO destructure default, so the
-   * Perl props hash leaves them `undef` when the caller omits them.
-   * Populated at `generate()` entry from `propsParams` (`optional &&
-   * !defaultValue`). Used by `elementAttrEmitter.emitExpression` to guard
-   * a dynamic attribute whose value is a BARE reference to such a prop
-   * with a Perl `defined $x` check — so an unset optional prop DROPS the
-   * attribute (`<textarea>` omits `rows`) instead of rendering `attr=""`,
-   * matching Hono's nullish-attribute omission. Concrete/defaulted props
-   * are excluded and always emit unconditionally.
+   * Prop names whose value is `undef` in the template body when the caller
+   * omits them — so a bare-reference attribute should be dropped rather
+   * than rendered as `attr=""`. The actual population criterion (see
+   * `generate()`) is: NO destructure default (`defaultValue === undefined`)
+   * AND non-rest (`!isRest`) AND non-primitive type (`type.kind !==
+   * 'primitive'`). It deliberately does NOT consult `p.optional`: the
+   * analyzer derives `optional` from the presence of a default initializer,
+   * not the `?` token, so it's not the right witness here. Excluding
+   * concrete primitives (`string`/`number`/`boolean`) mirrors the Go
+   * adapter's scope, which guards only `interface{}` (nillable) fields.
+   * Used by `elementAttrEmitter.emitExpression` to guard such an attribute
+   * with a Perl `defined $x` check (`<textarea>` omits `rows`), matching
+   * Hono's nullish-attribute omission. Concrete/defaulted props are
+   * excluded and always emit unconditionally.
    */
   private nullableOptionalProps: Set<string> = new Set()
 

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -207,6 +207,18 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
    * loop-var shadowing guards). (#1749 review)
    */
   private loopBoundNames: Map<string, number> = new Map()
+  /**
+   * Prop names that are OPTIONAL and have NO destructure default, so the
+   * Perl props hash leaves them `undef` when the caller omits them.
+   * Populated at `generate()` entry from `propsParams` (`optional &&
+   * !defaultValue`). Used by `elementAttrEmitter.emitExpression` to guard
+   * a dynamic attribute whose value is a BARE reference to such a prop
+   * with a Perl `defined $x` check — so an unset optional prop DROPS the
+   * attribute (`<textarea>` omits `rows`) instead of rendering `attr=""`,
+   * matching Hono's nullish-attribute omission. Concrete/defaulted props
+   * are excluded and always emit unconditionally.
+   */
+  private nullableOptionalProps: Set<string> = new Set()
 
   constructor(options: MojoAdapterOptions = {}) {
     super()
@@ -220,6 +232,31 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     this.componentName = ir.metadata.componentName
     this.propsObjectName = ir.metadata.propsObjectName ?? null
     this.propsParams = ir.metadata.propsParams.map(p => ({ name: p.name }))
+    // No-destructure-default props → `undef` when the caller omits them
+    // → guard their bare-reference attribute emission with Perl `defined`
+    // so the attribute drops instead of rendering `attr=""` (Hono-style
+    // nullish omission). A prop WITH a destructure default (`value = ''`)
+    // is never `undef` in the body and must stay unconditional, so it is
+    // excluded. This mirrors the Go adapter's nillable-field guard: there
+    // the witness is the resolved `interface{}` field type; here it is
+    // the absence of a default (the analyzer reports `rows` — a
+    // `TextareaHTMLAttributes` member destructured without a default — as
+    // no-default, `type.kind: 'unknown'`).
+    // Excludes concrete-primitive types (`string`/`number`/`boolean`)
+    // to match the Go adapter's scope, which guards only `interface{}`
+    // (nillable) fields and leaves concrete fields unconditional. So a
+    // required, no-default `string` prop still emits `attr=""` like Hono,
+    // and only nillable (`unknown`/object/array) no-default props guard.
+    this.nullableOptionalProps = new Set(
+      ir.metadata.propsParams
+        .filter(
+          p =>
+            p.defaultValue === undefined &&
+            !p.isRest &&
+            p.type?.kind !== 'primitive',
+        )
+        .map(p => p.name),
+    )
     // Record string-typed signals and props so equality comparisons against
     // them lower to `eq`/`ne` (#1672). A signal is string-typed when its
     // inferred type is `string` (the analyzer infers this from a string-literal
@@ -935,6 +972,32 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       if (this.refuseUnsupportedAttrExpression(value.expr, name)) {
         return ''
       }
+      // Hono-style nullish-attribute omission (#textarea rows): when the
+      // attribute value is a BARE reference to an optional, no-default
+      // prop (which is `undef` when the caller omits it), guard the
+      // attribute with Perl `defined` so it DROPS rather than rendering
+      // `attr=""`. The guarded body reuses the exact normal emission, so
+      // value escaping (`<%= ... %>`) is unchanged; only the presence is
+      // conditional. The `% if`/`% end` line directives surround the
+      // attribute inline — the conformance comparator collapses the
+      // resulting whitespace, exactly like the existing boolean-attr and
+      // hydration-marker patterns. Scope is deliberately narrow (bare
+      // identifiers resolving to an optional-no-default prop) so member
+      // exprs, calls, concrete/defaulted props, and boolean attrs are
+      // unaffected and still emit unconditionally.
+      const bareId = value.expr.trim()
+      if (
+        !isBooleanAttr(name) &&
+        !value.presenceOrUndefined &&
+        this.nullableOptionalProps.has(bareId)
+      ) {
+        const perl = this.convertExpressionToPerl(value.expr)
+        const body =
+          isBooleanResultExpr(value.expr) || isAriaBooleanAttr(name)
+            ? `${name}="<%= bf->bool_str(${perl}) %>"`
+            : `${name}="<%= ${perl} %>"`
+        return `<% if (defined ${perl}) { %>${body}<% } %>`
+      }
       if (isBooleanAttr(name) || value.presenceOrUndefined) {
         // Boolean attributes: render conditionally (present or absent).
         return `<%= ${this.convertExpressionToPerl(value.expr)} ? '${name}' : '' %>`
@@ -1007,6 +1070,17 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
           `${JSON.stringify(p.name)} => $${p.name}`,
         )
         return `<%== bf->spread_attrs({${entries.join(', ')}}) %>`
+      }
+      // Conditional inline-object spread:
+      //   `{...(COND ? { 'aria-describedby': describedBy } : {})}`
+      // Emit a Perl inline ternary of hashrefs — Perl truthiness
+      // handles the condition for free, and the falsy `{}` branch
+      // OMITS the key (`bf->spread_attrs` does NOT filter empty
+      // strings, so we cannot always-include it). Mirrors the Go
+      // adapter's IIFE-of-maps lowering (#textarea).
+      const ternaryHashref = this.conditionalSpreadToPerl(trimmed)
+      if (ternaryHashref !== null) {
+        return `<%== bf->spread_attrs(${ternaryHashref}) %>`
       }
       const perlExpr = this.convertExpressionToPerl(value.expr)
       return `<%== bf->spread_attrs(${perlExpr}) %>`
@@ -1291,6 +1365,77 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       },
     })
     return true
+  }
+
+
+  /**
+   * Lower a conditional inline-object spread expression
+   *   `(COND ? { 'aria-describedby': describedBy } : {})`
+   * (either branch possibly `{}`) into a Perl inline ternary of
+   * hashrefs for `bf->spread_attrs`:
+   *   `$describedBy ? { 'aria-describedby' => $describedBy } : {}`
+   *
+   * The condition is translated via `convertExpressionToPerl` (a bare
+   * prop ident becomes `$describedBy`; Perl truthiness handles the
+   * test). Object literals become Perl hashrefs with `=>`; string-
+   * literal keys are quoted, values resolve via `convertExpressionToPerl`.
+   *
+   * Returns null when the expression is NOT this shape, or when a part
+   * can't be faithfully lowered (non-static key, etc.) so the caller
+   * falls back to the standard `convertExpressionToPerl` path (which
+   * records BF101). Scoped strictly to ternary-of-object-literals so no
+   * other spread shape regresses.
+   */
+  private conditionalSpreadToPerl(expr: string): string | null {
+    const sf = ts.createSourceFile('__spread.ts', `(${expr})`, ts.ScriptTarget.Latest, true)
+    if (sf.statements.length !== 1) return null
+    const stmt = sf.statements[0]
+    if (!ts.isExpressionStatement(stmt)) return null
+    let node: ts.Expression = stmt.expression
+    while (ts.isParenthesizedExpression(node)) node = node.expression
+    if (!ts.isConditionalExpression(node)) return null
+    const unwrap = (e: ts.Expression): ts.Expression => {
+      let n = e
+      while (ts.isParenthesizedExpression(n)) n = n.expression
+      return n
+    }
+    const whenTrue = unwrap(node.whenTrue)
+    const whenFalse = unwrap(node.whenFalse)
+    if (!ts.isObjectLiteralExpression(whenTrue) || !ts.isObjectLiteralExpression(whenFalse)) {
+      return null
+    }
+    const condPerl = this.convertExpressionToPerl(node.condition.getText(sf))
+    const truePerl = this.objectLiteralToPerlHashref(whenTrue, sf)
+    const falsePerl = this.objectLiteralToPerlHashref(whenFalse, sf)
+    if (truePerl === null || falsePerl === null) return null
+    return `${condPerl} ? ${truePerl} : ${falsePerl}`
+  }
+
+  /**
+   * Convert a static object literal into a Perl hashref string for a
+   * conditional spread. Only static string/identifier keys are allowed;
+   * values resolve via `convertExpressionToPerl`. Returns null for any
+   * computed/spread/dynamic key. Empty object → `{}`.
+   */
+  private objectLiteralToPerlHashref(
+    obj: ts.ObjectLiteralExpression,
+    sf: ts.SourceFile,
+  ): string | null {
+    const entries: string[] = []
+    for (const prop of obj.properties) {
+      if (!ts.isPropertyAssignment(prop)) return null
+      let key: string
+      if (ts.isIdentifier(prop.name)) {
+        key = prop.name.text
+      } else if (ts.isStringLiteral(prop.name) || ts.isNoSubstitutionTemplateLiteral(prop.name)) {
+        key = prop.name.text
+      } else {
+        return null
+      }
+      const valPerl = this.convertExpressionToPerl(prop.initializer.getText(sf))
+      entries.push(`'${key.replace(/'/g, "\\'")}' => ${valPerl}`)
+    }
+    return entries.length === 0 ? '{}' : `{ ${entries.join(', ')} }`
   }
 
 


### PR DESCRIPTION
## Summary

Brings the Phase 2b `textarea` primitive into **Go + Mojo adapter conformance** (it was skipped). Two complementary template-adapter codegen changes were both required to flip it green.

### 1. Conditional inline-object spread lowering
`textarea` uses `{...(describedBy ? { 'aria-describedby': describedBy } : {})}` — a JSX spread whose argument is a ternary of object literals. Both adapters previously raised `BF101`.

- **Go**: `buildSpreadInitializer` now builds the bag as an immediately-invoked `func() map[string]any { ... }()` in `NewXxxProps` that conditionally returns the populated map or an empty one.
- **Mojo**: `emitSpread` emits an equivalent Perl inline ternary of hashrefs (`$describedBy ? { 'aria-describedby' => $describedBy } : {}`) through `bf->spread_attrs`.

The falsy branch yields an **empty** bag so the key is omitted rather than rendered as `aria-describedby=""` (neither `SpreadAttrs` nor `bf->spread_attrs` filters empty strings). The template emission (`{{bf_spread_attrs .Spread_0}}` / inline `bf->spread_attrs(...)`) is **unchanged** — byte-parity-safe. Condition supports a bare prop identifier and its negation; object keys must be static and values resolve prop refs or string literals. Any other shape still falls through to `BF101`.

### 2. Hono-style nullish-attribute omission
After the spread fix, one diff remained: `textarea`'s optional `rows?: number` (not passed by the fixture) rendered `rows=""`, but Hono omits `undefined`-valued attributes. When a dynamic attribute's value is a **bare reference to a nillable prop** (Go: a field whose resolved type is `interface{}`; Mojo: a no-default, non-primitive prop), the attribute is now guarded:
- Go: `{{if ne .Rows nil}}rows="{{.Rows}}"{{end}}`
- Mojo: `<% if (defined $rows) { %>rows="<%= $rows %>"<% } %>`

Concrete-typed (`string`/`int`/`bool`) and defaulted props are **unaffected** and still emit unconditionally (matching Hono's `value=""` / `data-count="0"`). The nillable-field set is derived from the **same** per-prop Go-type resolution the Props struct uses, so it can't drift from the actual field types. Whitespace left by an omitted attribute is collapsed by the conformance comparator's `normalizeHTML` (the same path that lets the existing boolean-attr `{{if}}{{end}}` patterns pass).

### Unskipped
`textarea` removed from the Go and Mojo `skipJsx` lists. `toggle`, `switch`, `checkbox` remain skipped (reactive-memo className + `Record<T,string>[key]` / sibling-type plumbing — tracked follow-ups); `kbd` is blocked only by a CSR-skip.

### Tests
Regression tests added to both suites: conditional spread (truthy branch + a `BF101` fallback for a non-identifier condition) and the nullish guard (plus a scope-not-widened pin asserting concrete/defaulted attrs stay unconditional).

### Validation (all self-re-run, 0 fail)
- Go conformance: **449 pass / 3 skip / 0 fail** — textarea passing
- Mojo conformance: **403 pass / 5 skip / 0 fail** — textarea passing
- `packages/jsx` + `adapter-tests` + `client` + `shared`: **3023 pass / 0 fail**
- `tsc --noEmit` clean on both adapter packages
- No snapshot regenerated; the Hono reference output (`fixtures/__snapshots__/textarea.html`) is unchanged.

🤖 https://claude.ai/code/session_01UatvBGZG5csvttdtgcSf7p

---
_Generated by [Claude Code](https://claude.ai/code/session_01UatvBGZG5csvttdtgcSf7p)_