### PR TITLE
feat(perl): framework-agnostic BarefootJS::DevReload (PSGI/Plack)

### DIFF
--- a/.changeset/perl-devreload.md
+++ b/.changeset/perl-devreload.md
@@ -1,0 +1,12 @@
+---
+"@barefootjs/perl": minor
+"@barefootjs/mojolicious": minor
+---
+
+Add `BarefootJS::DevReload` — framework-agnostic dev browser auto-reload. The
+shared module provides the browser snippet, the `<dist>/.dev/build-id` reader,
+and a ready-made PSGI streaming app (`->to_app`) for the SSE endpoint, so plain
+PSGI/Plack hosts (e.g. the Text::Xslate backend) get the same `barefoot build
+--watch` auto-reload as Mojolicious. `Mojolicious::Plugin::BarefootJS::DevReload`
+now delegates its snippet and build-id logic to the shared module (no behaviour
+change).

--- a/packages/adapter-mojolicious/lib/Mojolicious/Plugin/BarefootJS/DevReload.pm
+++ b/packages/adapter-mojolicious/lib/Mojolicious/Plugin/BarefootJS/DevReload.pm
@@ -30,21 +30,12 @@ C<< enabled => 1 >> to force-enable.
 use Mojo::ByteStream qw(b);
 use Mojo::IOLoop;
 use File::Spec;
+use BarefootJS::DevReload ();
 
-# Sentinel path contract with @barefootjs/cli (DEV_SENTINEL_SUBDIR /
-# DEV_SENTINEL_FILENAME in packages/cli/src/lib/build.ts). Duplicated so this
-# package avoids a runtime dep on the CLI — keep in sync with the CLI.
-my $DEV_SUBDIR         = '.dev';
-my $BUILD_ID_FILE      = 'build-id';
-my $SCROLL_STORAGE_KEY = '__bf_devreload_scroll';
-
-# Heartbeat < any reasonable proxy/IOLoop idle timeout so a quiet connection
-# doesn't get reaped between rebuilds.
-my $HEARTBEAT_S = 5;
-
-# Polling instead of Linux::Inotify2 / Mac::FSEvents keeps the runtime
-# dependency-free. Sub-second latency is imperceptible next to browser reload.
-my $POLL_S = 0.5;
+# Engine-agnostic snippet, build-id reading, and timing constants are shared
+# with the PSGI/Plack path in BarefootJS::DevReload — one source of truth.
+my $HEARTBEAT_S = $BarefootJS::DevReload::HEARTBEAT_S;
+my $POLL_S      = $BarefootJS::DevReload::POLL_S;
 
 sub register ($self, $app, $config = {}) {
     my $dist_dir = $config->{dist_dir} // 'dist';
@@ -57,7 +48,7 @@ sub register ($self, $app, $config = {}) {
     # on mode — it simply returns an empty ByteStream when disabled.
     $app->helper(bf_dev_snippet => sub ($c) {
         return b('') unless $enabled;
-        return b(_snippet($endpoint));
+        return b(BarefootJS::DevReload->snippet($endpoint));
     });
 
     return unless $enabled;
@@ -68,9 +59,8 @@ sub register ($self, $app, $config = {}) {
     my $dist_abs = File::Spec->file_name_is_absolute($dist_dir)
         ? $dist_dir
         : $app->home->child($dist_dir)->to_string;
-    my $dev_dir       = File::Spec->catdir($dist_abs, $DEV_SUBDIR);
-    my $build_id_path = File::Spec->catfile($dev_dir, $BUILD_ID_FILE);
-    mkdir $dev_dir unless -d $dev_dir;
+    BarefootJS::DevReload->ensure_dev_dir($dist_abs);
+    my $build_id_path = BarefootJS::DevReload->build_id_path($dist_abs);
 
     $app->routes->get($endpoint => sub ($c) {
         my $last_event_id = $c->req->headers->header('Last-Event-ID') // '';
@@ -83,7 +73,7 @@ sub register ($self, $app, $config = {}) {
 
         $c->write("retry: 1000\n\n");
 
-        my $initial_id = _read_build_id($build_id_path);
+        my $initial_id = BarefootJS::DevReload->read_build_id($build_id_path);
         my $last_sent  = '';
         if (length $initial_id) {
             $last_sent = $initial_id;
@@ -106,7 +96,7 @@ sub register ($self, $app, $config = {}) {
             $c->write(": hb\n\n");
         });
         $poll_id = Mojo::IOLoop->recurring($POLL_S => sub {
-            my $id = _read_build_id($build_id_path);
+            my $id = BarefootJS::DevReload->read_build_id($build_id_path);
             return unless length $id;
             return if $id eq $last_sent;
             $last_sent = $id;
@@ -115,37 +105,6 @@ sub register ($self, $app, $config = {}) {
     });
 
     return;
-}
-
-sub _read_build_id ($path) {
-    return '' unless -f $path;
-    open my $fh, '<', $path or return '';
-    local $/;
-    my $content = <$fh>;
-    close $fh;
-    $content //= '';
-    $content =~ s/^\s+|\s+$//g;
-    return $content;
-}
-
-sub _snippet ($endpoint) {
-    my $ep = _js_str($endpoint);
-    my $sk = _js_str($SCROLL_STORAGE_KEY);
-    # Small IIFE: EventSource subscriber + scrollY preservation. Idempotent
-    # across duplicate mounts (window.__bfDevReload guard).
-    return qq{<script>(function(){if(window.__bfDevReload)return;window.__bfDevReload=1;try{var s=sessionStorage.getItem($sk);if(s){sessionStorage.removeItem($sk);var y=parseInt(s,10);if(!isNaN(y)){var restore=function(){window.scrollTo(0,y)};if(document.readyState==='loading'){addEventListener('DOMContentLoaded',restore,{once:true})}else{restore()}}}}catch(e){}var es=new EventSource($ep);es.addEventListener('reload',function(){try{sessionStorage.setItem($sk,String(window.scrollY))}catch(e){}location.reload()});es.addEventListener('error',function(){})})();</script>};
-}
-
-sub _js_str ($s) {
-    # Minimal JS string escape for the handful of characters that can appear
-    # in a URL path or storage key. Good enough for package-internal + trusted
-    # operator-supplied strings; never interpolate untrusted input here.
-    my $t = $s;
-    $t =~ s/\\/\\\\/g;
-    $t =~ s/"/\\"/g;
-    $t =~ s/\n/\\n/g;
-    $t =~ s/\r/\\r/g;
-    return qq{"$t"};
 }
 
 1;

--- a/packages/adapter-perl/lib/BarefootJS/DevReload.pm
+++ b/packages/adapter-perl/lib/BarefootJS/DevReload.pm
@@ -1,0 +1,175 @@
+package BarefootJS::DevReload;
+our $VERSION = "0.01";
+use strict;
+use warnings;
+use feature 'signatures';
+no warnings 'experimental::signatures';
+
+use File::Spec;
+
+=head1 NAME
+
+BarefootJS::DevReload - Framework-agnostic dev-only browser auto-reload for BarefootJS apps
+
+=head1 SYNOPSIS
+
+    # Plain PSGI / Plack (e.g. the Text::Xslate backend)
+    use BarefootJS::DevReload;
+
+    # Mount the SSE endpoint (dev only):
+    my $reload = BarefootJS::DevReload->to_app(dist_dir => 'dist');
+    # ... route '/_bf/reload' => $reload ...
+
+    # And emit the browser snippet before </body> in your layout:
+    BarefootJS::DevReload->snippet('/_bf/reload');
+
+=head1 DESCRIPTION
+
+Companion to C<barefoot build --watch> in C<@barefootjs/cli>. The CLI drops
+C<< <dist>/.dev/build-id >> after every successful rebuild that changed output;
+a browser snippet subscribes to an SSE endpoint that emits C<< event: reload >>
+when that file changes, so an editor save triggers an automatic reload.
+
+This module holds the engine-agnostic pieces — the browser snippet, the
+build-id reader, and a ready-made PSGI streaming app for the SSE endpoint — so
+both L<Mojolicious::Plugin::BarefootJS::DevReload> (Mojo streaming) and plain
+PSGI/Plack hosts (the Text::Xslate backend) share one implementation.
+
+=cut
+
+# Sentinel path contract with @barefootjs/cli (DEV_SENTINEL_SUBDIR /
+# DEV_SENTINEL_FILENAME in packages/cli/src/lib/build.ts). Duplicated so this
+# package avoids a runtime dep on the CLI — keep in sync with the CLI.
+my $DEV_SUBDIR    = '.dev';
+my $BUILD_ID_FILE = 'build-id';
+
+our $SCROLL_STORAGE_KEY = '__bf_devreload_scroll';
+
+# Heartbeat < any reasonable proxy/IOLoop idle timeout so a quiet connection
+# doesn't get reaped between rebuilds.
+our $HEARTBEAT_S = 5;
+
+# Polling instead of Linux::Inotify2 / Mac::FSEvents keeps the runtime
+# dependency-free. Sub-second latency is imperceptible next to browser reload.
+our $POLL_S = 0.5;
+
+# <dist>/.dev/build-id — the sentinel `barefoot build --watch` rewrites.
+sub build_id_path ($class, $dist_dir) {
+    return File::Spec->catfile($dist_dir, $DEV_SUBDIR, $BUILD_ID_FILE);
+}
+
+# Ensure <dist>/.dev exists so the watcher can write the sentinel even if the
+# server started first. Returns the dir.
+sub ensure_dev_dir ($class, $dist_dir) {
+    my $dev = File::Spec->catdir($dist_dir, $DEV_SUBDIR);
+    mkdir $dev unless -d $dev;
+    return $dev;
+}
+
+sub read_build_id ($class, $path) {
+    return '' unless -f $path;
+    open my $fh, '<', $path or return '';
+    local $/;
+    my $content = <$fh>;
+    close $fh;
+    $content //= '';
+    $content =~ s/^\s+|\s+$//g;
+    return $content;
+}
+
+# The browser snippet: a small IIFE — EventSource subscriber + scrollY
+# preservation across reloads. Idempotent across duplicate mounts (the
+# window.__bfDevReload guard). Returns a plain HTML string; callers mark it raw
+# for their template engine.
+sub snippet ($class, $endpoint) {
+    my $ep = _js_str($endpoint);
+    my $sk = _js_str($SCROLL_STORAGE_KEY);
+    return qq{<script>(function(){if(window.__bfDevReload)return;window.__bfDevReload=1;try{var s=sessionStorage.getItem($sk);if(s){sessionStorage.removeItem($sk);var y=parseInt(s,10);if(!isNaN(y)){var restore=function(){window.scrollTo(0,y)};if(document.readyState==='loading'){addEventListener('DOMContentLoaded',restore,{once:true})}else{restore()}}}}catch(e){}var es=new EventSource($ep);es.addEventListener('reload',function(){try{sessionStorage.setItem($sk,String(window.scrollY))}catch(e){}location.reload()});es.addEventListener('error',function(){})})();</script>};
+}
+
+# A ready-made PSGI app for the SSE endpoint. Streams `event: reload` whenever
+# <dist>/.dev/build-id changes, with `: hb` heartbeats in between.
+#
+# Implemented with the PSGI streaming interface and a blocking poll loop, so it
+# holds one worker per open connection for the connection's lifetime — run it
+# under a prefork PSGI server (Starman / Starlet) in dev, which is the natural
+# choice for an app that also streams (e.g. an AI-chat SSE route). DevReload is
+# automatically a no-op unless you mount it, and you should only mount it in
+# development.
+sub to_app ($class, %opts) {
+    my $dist_dir      = $opts{dist_dir} // 'dist';
+    my $build_id_path = $class->build_id_path($dist_dir);
+    $class->ensure_dev_dir($dist_dir);
+
+    return sub ($env) {
+        return [500, ['Content-Type' => 'text/plain'], ['DevReload needs a psgi.streaming server']]
+            unless $env->{'psgi.streaming'};
+
+        my $last_event_id = $env->{HTTP_LAST_EVENT_ID} // '';
+        $last_event_id =~ s/^\s+|\s+$//g;
+
+        return sub ($responder) {
+            my $writer = $responder->([
+                200,
+                [
+                    'Content-Type'      => 'text/event-stream',
+                    'Cache-Control'     => 'no-cache, no-transform',
+                    'X-Accel-Buffering' => 'no',
+                ],
+            ]);
+
+            # A write to a disconnected client throws (SIGPIPE/EPIPE); the eval
+            # turns that into a clean loop exit.
+            local $SIG{PIPE} = 'IGNORE';
+            eval {
+                $writer->write("retry: 1000\n\n");
+
+                my $initial   = $class->read_build_id($build_id_path);
+                my $last_sent = '';
+                if (length $initial) {
+                    $last_sent = $initial;
+                    # A stale Last-Event-ID means a build happened while the
+                    # client was disconnected — fire `reload` immediately so the
+                    # missed rebuild doesn't stay unpainted.
+                    my $event = (length $last_event_id && $last_event_id ne $initial)
+                        ? 'reload' : 'hello';
+                    $writer->write("event: $event\nid: $initial\ndata: $initial\n\n");
+                }
+
+                my $since_hb = 0;
+                while (1) {
+                    select undef, undef, undef, $POLL_S;
+                    my $id = $class->read_build_id($build_id_path);
+                    if (length $id && $id ne $last_sent) {
+                        $last_sent = $id;
+                        $since_hb  = 0;
+                        $writer->write("event: reload\nid: $id\ndata: $id\n\n");
+                    }
+                    else {
+                        $since_hb += $POLL_S;
+                        if ($since_hb >= $HEARTBEAT_S) {
+                            $since_hb = 0;
+                            $writer->write(": hb\n\n");
+                        }
+                    }
+                }
+                1;
+            };
+            $writer->close;
+        };
+    };
+}
+
+sub _js_str ($s) {
+    # Minimal JS string escape for the handful of characters that can appear in
+    # a URL path or storage key. Good enough for package-internal + trusted
+    # operator-supplied strings; never interpolate untrusted input here.
+    my $t = $s;
+    $t =~ s/\\/\\\\/g;
+    $t =~ s/"/\\"/g;
+    $t =~ s/\n/\\n/g;
+    $t =~ s/\r/\\r/g;
+    return qq{"$t"};
+}
+
+1;

--- a/packages/adapter-perl/t/dev_reload.t
+++ b/packages/adapter-perl/t/dev_reload.t
@@ -1,0 +1,58 @@
+use Test2::V0;
+use File::Temp qw(tempdir);
+
+use BarefootJS::DevReload;
+
+# --- browser snippet ---------------------------------------------------------
+my $snip = BarefootJS::DevReload->snippet('/_bf/reload');
+like $snip, qr/new EventSource\("\/_bf\/reload"\)/, 'snippet wires EventSource to the endpoint';
+like $snip, qr/window\.__bfDevReload/, 'snippet is idempotent across duplicate mounts';
+like $snip, qr/location\.reload\(\)/, 'snippet reloads on the `reload` event';
+
+# --- build-id sentinel -------------------------------------------------------
+my $dir  = tempdir(CLEANUP => 1);
+my $path = BarefootJS::DevReload->build_id_path($dir);
+like $path, qr/\.dev.+build-id$/, 'build_id_path points at <dist>/.dev/build-id';
+is(BarefootJS::DevReload->read_build_id($path), '', 'missing sentinel reads as empty');
+
+BarefootJS::DevReload->ensure_dev_dir($dir);
+open my $fh, '>', $path or die $!;
+print $fh "abc123\n";
+close $fh;
+is(BarefootJS::DevReload->read_build_id($path), 'abc123', 'sentinel is read and trimmed');
+
+# --- PSGI streaming app ------------------------------------------------------
+# Drive the streaming coderef with a fake responder/writer; break the otherwise
+# infinite poll loop by throwing from write() after the initial events.
+{
+    package FakeWriter;
+    sub new   { bless { n => 0, lines => [] }, shift }
+    sub write { my ($s, $d) = @_; push @{ $s->{lines} }, $d; die "stop\n" if ++$s->{n} >= 2 }
+    sub close { }
+}
+
+my $app = BarefootJS::DevReload->to_app(dist_dir => $dir);
+
+is $app->({ 'psgi.streaming' => 0 })->[0], 500, 'requires a psgi.streaming server';
+
+my $stream = $app->({ 'psgi.streaming' => 1, HTTP_LAST_EVENT_ID => '' });
+is ref $stream, 'CODE', 'streaming response is a delayed coderef';
+
+my $writer = FakeWriter->new;
+my ($status, $headers);
+$stream->(sub { ($status, $headers) = @{ $_[0] }[0, 1]; return $writer });
+
+is $status, 200, 'streams 200';
+my %h = @$headers;
+is $h{'Content-Type'}, 'text/event-stream', 'SSE content-type';
+my $out = join '', @{ $writer->{lines} };
+like $out, qr/retry: 1000/,  'sets the SSE retry hint';
+like $out, qr/event: hello/, 'emits hello with the current build-id at connect';
+
+# A stale Last-Event-ID means a rebuild was missed → reload immediately.
+my $stream2 = $app->({ 'psgi.streaming' => 1, HTTP_LAST_EVENT_ID => 'STALE' });
+my $w2 = FakeWriter->new;
+$stream2->(sub { return $w2 });
+like join('', @{ $w2->{lines} }), qr/event: reload/, 'stale Last-Event-ID triggers reload';
+
+done_testing;


### PR DESCRIPTION
## Goal

Make BarefootJS's dev browser auto-reload **framework-agnostic**, so the Text::Xslate / plain-PSGI path gets the same `barefoot build --watch` auto-reload that Mojolicious has. (Enabler for the upcoming `integrations/xslate` demo.)

## What

- **New `BarefootJS::DevReload`** (in `@barefootjs/perl`) holds the engine-agnostic pieces:
  - `->snippet($endpoint)` — the EventSource + scroll-preserving browser `<script>` (idempotent across mounts).
  - `->read_build_id($path)` / `->build_id_path($dist)` / `->ensure_dev_dir($dist)` — the `<dist>/.dev/build-id` sentinel contract with `@barefootjs/cli`.
  - `->to_app(dist_dir => ...)` — a **ready-made PSGI streaming app** for the SSE endpoint: emits `event: reload` when build-id changes, with `: hb` heartbeats, and replays a missed rebuild on stale `Last-Event-ID`. Blocking poll loop → run under a prefork server (Starman/Starlet) in dev.
- **`Mojolicious::Plugin::BarefootJS::DevReload`** now delegates its snippet + build-id logic to the shared module — **no behaviour change**.

## Validation

- ✅ New `t/dev_reload.t` (13 assertions): snippet wiring, build-id read/trim, PSGI `hello`/`reload`/heartbeat, stale-`Last-Event-ID` replay, non-streaming → 500.
- ✅ **Live Plack curl** of `->to_app` SSE endpoint → `retry: 1000` + `event: hello` with the right `id`/`data`.
- ✅ Mojo `dev_reload.t` still green (delegation is transparent); `adapter-perl` prove 43 tests; core + mojo `minil test` pass.

## Notes

This is **PR A** of three for the "Xslate on the site" work the maintainer requested:
- **A (this):** framework-agnostic DevReload.
- **B:** Perl adapter docs (`/docs/adapters`).
- **C:** `integrations/xslate` full demo + deploy wiring (uses `->to_app` here).

https://claude.ai/code/session_01Q2ZNcmBJuucbnuyT58b3NZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2ZNcmBJuucbnuyT58b3NZ)_