### PR TITLE
feat(release): add adapter-perl and adapter-xslate to publish list

### DIFF
--- a/scripts/changeset-publish.ts
+++ b/scripts/changeset-publish.ts
@@ -39,6 +39,8 @@ const PUBLISHABLE = [
   'packages/xyflow',
   'packages/adapter-hono',
   'packages/adapter-go-template',
+  'packages/adapter-perl',
+  'packages/adapter-xslate',
   'packages/adapter-mojolicious',
   'packages/cli',
   'packages/create-barefootjs',


### PR DESCRIPTION
## Summary

- Add `@barefootjs/perl` and `@barefootjs/xslate` to the `PUBLISHABLE` array in `changeset-publish.ts`
- Both packages were bumped to 0.7.0 but were missing from the list, causing npm publish to be skipped
- `adapter-mojolicious` was already included and remains unchanged

## Test plan

- [ ] Merge this PR into `main`
- [ ] `release.yml` workflow runs and publishes `@barefootjs/perl@0.7.0` to npm (first release)
- [ ] `release.yml` workflow runs and publishes `@barefootjs/xslate@0.7.0` to npm (first release)