### PR TITLE
docs(adapters): add Perl Adapter page (Mojolicious + Text::Xslate)

### DIFF
--- a/docs/core/README.mdx
+++ b/docs/core/README.mdx
@@ -52,6 +52,7 @@
 - [Adapter Architecture](./adapters/adapter-architecture.md) — How adapters work, the `TemplateAdapter` interface, and the IR contract
 - [Hono Adapter](./adapters/hono-adapter.md) — Configuration and output format for Hono / JSX-based servers
 - [Go Template Adapter](./adapters/go-template-adapter.md) — Configuration and output format for Go `html/template`
+- [Perl Adapter](./adapters/perl-adapter.md) — Mojolicious and Text::Xslate (PSGI/Plack) backends, sharing one runtime
 - [CSR (Client-Side Rendering)](./adapters/csr.md) — Static-hosting renderer: emit client JS only, no SSR template
 - [Writing a Custom Adapter](./adapters/custom-adapter.md) — Step-by-step guide to implementing your own adapter
 

--- a/docs/core/adapters.md
+++ b/docs/core/adapters.md
@@ -22,11 +22,14 @@ JSX Source
 |---------|--------|---------|---------|
 | [`HonoAdapter`](./adapters/hono-adapter.md) | `.tsx` | Hono / JSX-based servers | `@barefootjs/hono` |
 | [`GoTemplateAdapter`](./adapters/go-template-adapter.md) | `.tmpl` + `_types.go` | Go `html/template` | `@barefootjs/go-template` |
+| [Perl](./adapters/perl-adapter.md) | `.ep` / `.tx` | Mojolicious, Text::Xslate (PSGI/Plack) | `@barefootjs/mojolicious`, `@barefootjs/xslate` |
 | [CSR](./adapters/csr.md) | — (client-rendered) | None (browser-only) | `@barefootjs/client` |
 
 > CSR is not an IR→template adapter. It renders components directly in the browser using client-side template functions — use it when the server can't (or shouldn't) emit the initial HTML.
 
 The `GoTemplateAdapter` is web-framework-agnostic: its `html/template` output runs on any Go server. `npm create barefootjs@latest` ships scaffolds for Echo, Gin, Chi, and net/http (via `--adapter`) — see [Go Template Adapter → Server integration](./adapters/go-template-adapter.md#server-integration).
+
+The Perl adapters share one engine-agnostic runtime (`BarefootJS`): `@barefootjs/mojolicious` targets Mojolicious EP, and `@barefootjs/xslate` targets Text::Xslate (Kolon) and runs under any PSGI/Plack app. See the [Perl Adapter](./adapters/perl-adapter.md) page.
 
 ## Pages
 
@@ -35,5 +38,6 @@ The `GoTemplateAdapter` is web-framework-agnostic: its `html/template` output ru
 | [Adapter Architecture](./adapters/adapter-architecture.md) | How adapters work, the `TemplateAdapter` interface, and the IR contract |
 | [Hono Adapter](./adapters/hono-adapter.md) | Configuration and output format for Hono / JSX-based servers |
 | [Go Template Adapter](./adapters/go-template-adapter.md) | Configuration and output format for Go `html/template` |
+| [Perl Adapter](./adapters/perl-adapter.md) | Mojolicious and Text::Xslate (PSGI/Plack) backends, sharing one runtime |
 | [CSR](./adapters/csr.md) | Client-side rendering without a server-rendered template |
 | [Writing a Custom Adapter](./adapters/custom-adapter.md) | Step-by-step guide to implementing your own adapter |

--- a/docs/core/adapters/perl-adapter.md
+++ b/docs/core/adapters/perl-adapter.md
@@ -1,0 +1,171 @@
+---
+title: Perl Adapter
+description: Render BarefootJS components from Perl — one engine-agnostic runtime with Mojolicious and Text::Xslate (PSGI/Plack) backends.
+---
+
+# Perl Adapter
+
+Run the same JSX components on a Perl backend. BarefootJS compiles your JSX into
+a **marked template** plus **client JS**; on the server, a small Perl runtime
+renders those templates. The runtime is deliberately **template-engine- and
+web-framework-agnostic**, so one implementation drives multiple stacks.
+
+```
+JSX → IR → marked template (.ep / .tx) + Component.client.js
+                 │
+                 ▼
+   BarefootJS runtime  ──delegates──▶  pluggable backend
+   (@barefootjs/perl)                  (Mojolicious | Text::Xslate)
+```
+
+## Two backends, one runtime
+
+| Backend | Template syntax | Compile-time package | Runtime | Where it runs |
+|---------|-----------------|----------------------|---------|---------------|
+| Mojolicious | EP (`<%= %>`) | `@barefootjs/mojolicious` | `Mojolicious::Plugin::BarefootJS` + `BarefootJS::Backend::Mojo` | Mojolicious apps |
+| Text::Xslate | Kolon (`<: :>`) | `@barefootjs/xslate` | `BarefootJS::Backend::Xslate` | **any PSGI / Plack app** (no framework) |
+
+Both compile-time packages emit per-component template files and the shared
+client JS, and both render through the same engine-agnostic Perl runtime
+(`BarefootJS`, shipped by `@barefootjs/perl`). The only thing that differs is
+the **backend**: a tiny object that implements the four operations the runtime
+delegates to.
+
+### The backend contract
+
+Everything that depends on *how* a template renders — JSON marshalling,
+raw-string marking, JSX-children materialisation, and named-template
+rendering — lives behind a `backend` object with four methods:
+
+| Method | Purpose |
+|--------|---------|
+| `encode_json($data)` | Serialize a value for `bf-p` props / inline JSON |
+| `mark_raw($str)` | Mark already-safe HTML so the engine won't re-escape it |
+| `materialize($value)` | Resolve captured JSX children to a string |
+| `render_named($name, $bf, \%vars)` | Render a child component's template |
+
+Because that is the *only* engine-specific surface, the EP→Kolon mapping is
+mechanical and the runtime is reused unchanged:
+
+| Mojolicious EP | Text::Xslate Kolon |
+|----------------|--------------------|
+| `<%= EXPR %>` (escaped) | `<: EXPR :>` (Kolon auto-escapes) |
+| `<%== EXPR %>` (raw) | `<: EXPR \| mark_raw :>` |
+| `bf->method(args)` | `$bf.method(args)` |
+| `% if (C) { … % }` | `: if (C) { … : }` |
+
+## Mojolicious
+
+```
+npm install @barefootjs/mojolicious
+```
+
+Scaffold a runnable starter:
+
+```
+npm create barefootjs@latest -- --adapter mojo
+```
+
+Configure the build (`barefoot.config.ts`):
+
+```typescript
+import { createConfig } from '@barefootjs/mojolicious/build'
+
+export default createConfig({
+  components: ['./components'],
+  outDir: 'dist',
+})
+```
+
+In your app, load the plugin — it registers a `bf` helper that gives each
+request a `BarefootJS` runtime backed by `BarefootJS::Backend::Mojo`:
+
+```perl
+use Mojolicious::Lite -signatures;
+
+plugin 'BarefootJS';
+
+get '/counter' => sub ($c) {
+    $c->render(template => 'Counter', layout => 'default');
+};
+
+app->start;
+```
+
+The generated `.html.ep` templates call the runtime through the `bf` helper
+(`<%== bf->scope_attr %>`, `<%= bf->json($data) %>`, …).
+
+## Text::Xslate (PSGI / Plack)
+
+```
+npm install @barefootjs/xslate
+```
+
+```typescript
+import { createConfig } from '@barefootjs/xslate/build'
+
+export default createConfig({
+  components: ['./components'],
+  outDir: 'dist',
+})
+```
+
+The build emits Kolon `.tx` templates. The backend is just a plain
+`Text::Xslate` instance, so it runs under **any PSGI/Plack app** — no
+Mojolicious required:
+
+```perl
+use BarefootJS;
+use BarefootJS::Backend::Xslate;
+
+my $backend = BarefootJS::Backend::Xslate->new(path => ['dist/templates']);
+
+my $app = sub {
+    my $env = shift;
+    my $bf  = BarefootJS->new(undef, { backend => $backend });
+    $bf->_scope_id('Counter_' . int(rand(1e6)));
+    my $body = $backend->render_named('Counter', $bf, { count => 0 });
+    my $html = "<!doctype html><body>$body" . $bf->scripts . '</body>';
+    return [200, ['Content-Type' => 'text/html; charset=utf-8'], [$html]];
+};
+```
+
+The generated Kolon templates call the runtime as a `bf` object
+(`<: $bf.scope_attr() :>`, `<: $bf.json($data) :>`, …). Kolon auto-escapes
+`<: … :>` interpolations; helpers that emit markup return `mark_raw` values.
+
+## CPAN distributions
+
+The Perl side is packaged as standalone CPAN distributions (built with
+[Minilla](https://metacpan.org/pod/Minilla)), so a Perl app can depend on them
+without the JS toolchain at runtime:
+
+| Distribution | Main module | Depends on |
+|--------------|-------------|------------|
+| `BarefootJS` | `BarefootJS` | core Perl only |
+| `BarefootJS-Backend-Xslate` | `BarefootJS::Backend::Xslate` | `BarefootJS`, `Text::Xslate` |
+| `Mojolicious-Plugin-BarefootJS` | `Mojolicious::Plugin::BarefootJS` | `BarefootJS`, `Mojolicious` |
+
+## Dev auto-reload
+
+`barefoot build --watch` writes a sentinel after each rebuild; the browser can
+subscribe to a small SSE endpoint and reload automatically. The logic is
+framework-agnostic (`BarefootJS::DevReload`):
+
+- **Mojolicious:** `plugin 'BarefootJS::DevReload'`, then emit `%== bf_dev_snippet` before `</body>`.
+- **PSGI / Plack:** mount `BarefootJS::DevReload->to_app(dist_dir => 'dist')` at the SSE endpoint, and emit `BarefootJS::DevReload->snippet($endpoint)` in your layout. Run under a prefork server (Starman / Starlet) in dev.
+
+Both are no-ops in production.
+
+## Examples
+
+Runnable end-to-end apps that render the same shared components on a Perl
+backend live under
+[`integrations/`](https://github.com/piconic-ai/barefootjs/tree/main/integrations) —
+including SSR, fine-grained reactivity, a REST todo API, and SSE streaming.
+
+## See also
+
+- [Adapter Architecture](./adapter-architecture.md) — the `TemplateAdapter` interface and IR contract
+- [Backend Freedom](../core-concepts/backend-freedom.md) — why the same JSX runs on any stack
+- [Writing a Custom Adapter](./custom-adapter.md)

--- a/docs/core/llms.txt
+++ b/docs/core/llms.txt
@@ -44,6 +44,7 @@
 - [Writing a Custom Adapter](https://barefootjs.dev/docs/adapters/custom-adapter.md): Step-by-step guide to building a custom adapter using the TestAdapter as a reference.
 - [Go Template Adapter](https://barefootjs.dev/docs/adapters/go-template-adapter.md): Generate Go html/template files and type definitions from the compiler's IR.
 - [Hono Adapter](https://barefootjs.dev/docs/adapters/hono-adapter.md): Generate Hono JSX templates from the compiler's IR for Hono-based servers.
+- [Perl Adapter](https://barefootjs.dev/docs/adapters/perl-adapter.md): Render BarefootJS components from Perl — one engine-agnostic runtime with Mojolicious and Text::Xslate (PSGI/Plack) backends.
 
 ## Advanced
 

--- a/site/core/lib/navigation.ts
+++ b/site/core/lib/navigation.ts
@@ -99,6 +99,7 @@ export const navigation: NavItem[] = [
       { title: 'Adapter Architecture', slug: 'adapters/adapter-architecture' },
       { title: 'Hono Adapter', slug: 'adapters/hono-adapter' },
       { title: 'Go Template Adapter', slug: 'adapters/go-template-adapter' },
+      { title: 'Perl Adapter', slug: 'adapters/perl-adapter' },
       { title: 'Custom Adapter', slug: 'adapters/custom-adapter' },
     ],
   },


### PR DESCRIPTION
## Goal

Document the Perl adapter at `/docs/adapters` — it wasn't covered there at all (only Hono, Go, CSR were).

## What

New **`docs/core/adapters/perl-adapter.md`** covering:
- The engine-agnostic **`BarefootJS` runtime** + **pluggable backend** model.
- Both backends: **`@barefootjs/mojolicious`** (EP) and **`@barefootjs/xslate`** (Kolon, runs under any PSGI/Plack app).
- The **four-method backend contract** (`encode_json` / `mark_raw` / `materialize` / `render_named`) and the mechanical **EP→Kolon mapping**.
- Mojolicious usage (`plugin 'BarefootJS'`, `--adapter mojo` scaffold) and Text::Xslate/PSGI usage (a plain Plack app snippet).
- The **CPAN distributions** (`BarefootJS`, `BarefootJS-Backend-Xslate`, `Mojolicious-Plugin-BarefootJS`).
- **Dev auto-reload** for both Mojolicious and PSGI/Plack.

Wired into the adapters index (`adapters.md`), the `README.mdx` TOC, and the site nav (**Adapters → Perl Adapter**).

## Validation

- ✅ `site/core` mdx/docs test: 20 pass.
- Accurate to current state: `--adapter mojo` scaffold exists; Xslate ships as a package (its scaffold + `integrations/xslate` demo are separate follow-ups).

## Notes

**PR B** of three for the "Xslate on the site" work:
- A: framework-agnostic DevReload (#1753).
- **B (this):** Perl adapter docs.
- C: `integrations/xslate` full demo + deploy + catalog entry.

https://claude.ai/code/session_01Q2ZNcmBJuucbnuyT58b3NZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2ZNcmBJuucbnuyT58b3NZ)_