### PR TITLE
feat(go,mojo): local-const & Record-indexed spreads + props-object enumeration — enable Phase 2b checkbox conformance

### DIFF
--- a/.changeset/local-const-record-indexed-spread.md
+++ b/.changeset/local-const-record-indexed-spread.md
@@ -1,0 +1,22 @@
+---
+"@barefootjs/go-template": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/jsx": patch
+---
+
+Resolve local-const conditional spreads and `Record`-indexed spread values on intrinsic elements. Two related spread shapes that previously raised `BF101` now compile on both template adapters.
+
+Local-const conditional spread: a function-scope const holding a `cond ? { ... } : {}` ternary, spread as a bare identifier (`const sizeAttrs = size ? { ... } : {}; <svg {...sizeAttrs} />`), now resolves to that initializer and routes through the existing conditional-spread lowering. Only function-scope (non-module) consts qualify, and a const that aliases another bare identifier is not forwarded (loop guard) — it falls through to the standard path.
+
+`Record<staticKeys, scalar>[propKey]` spread value: a spread-object value of the form `IDENT[KEY]`, where `IDENT` is a module-scope `Record<staticKeys, scalar>` object literal (all scalar number/string values under static keys) and `KEY` is a bare prop identifier, now lowers to an inline indexed map. Go emits `map[string]any{"sm": 16, ...}[fmt.Sprint(in.Size)]` (adding the `"fmt"` import only when this fires); Mojo emits `{ 'sm' => 16, ... }->{$size}`. Any non-scalar value, non-static key, or non-prop index still falls through to `BF101`.
+
+Together these let the `CheckIcon` sibling (`ui/components/ui/icon`) — `const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}` spread onto its `<svg>` — compile standalone with zero `BF101` on both adapters.
+
+Additionally, unblock the Phase 2b `checkbox` conformance fixture end-to-end on both template adapters (Go + Mojolicious), which composes `CheckIcon` and uses the SolidJS props-object pattern:
+
+- **Sibling import survival (Go test harness).** The Go conformance harness strips each merged sibling type block's `import (...)`; it now re-adds standard-library imports a merged block still needs (today `"fmt"`, used by `CheckIcon`'s `fmt.Sprint(...)` `Record[key]` lookup) so the combined unit resolves the symbol. The harness also now emits only the child components a parent transitively references — a child *file* exporting many components (`../icon`'s 30+ icons) no longer drags in dead components whose own codegen wouldn't compile (e.g. an icon's `strokePaths['chevron-down']` lowering to an invalid `{{.StrokePaths.Chevron-down}}`).
+- **Cross-component child rest-bag routing.** A child component attribute whose name isn't a declared child param and isn't a valid identifier (`<CheckIcon data-slot="checkbox-indicator" />`) now routes into the child's rest bag — Go's `Props map[string]any` field / Mojo's quoted `'data-slot' => ...` `render_child` arg — instead of an invalid hyphenated field (`Data-slot:`) or Perl bareword.
+- **Props-object inherited-attribute enumeration.** A component written as `function C(props: P)` only enumerates `P`'s own members; inherited `*HTMLAttributes` members it actually reads (`props.className`, `props.id`, `props.disabled`) are now enumerated as Input/Props fields (Go) / declared stash vars + `defined`-guarded attributes (Mojo), so a caller's `className` / `id` / `disabled` bind and unset optionals are omitted (Hono parity).
+- **Template-literal className memo + boolean memo SSR value.** The Go adapter computes a template-literal `classes` memo's SSR initial value by inlining module string consts (including `[…].join(' ')` consts) and resolving `props.className ?? ''`; a boolean ternary memo (`isChecked`) now renders its zero as `false` (not `0`). The `@barefootjs/jsx` `extractSsrDefaults` (Mojo's SSR seed) gains module-const seeding and `.join()` evaluation so the same `classes` memo resolves to a concrete string instead of empty.
+
+With these, `checkbox` is unskipped on both adapter conformance suites at byte parity with the Hono reference. `toggle` / `switch` share the inherited-attr fix but remain skipped (they carry an additional `Record[key]`-in-memo-className blocker).

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -76,35 +76,15 @@ runAdapterConformanceTests({
     // option fixed on the Hono side. Separate follow-up.
     'toggle-shared',
     'props-reactivity-comparison',
-    // #1467 Phase 2b: basic interactive `site/ui` primitives. Cross-adapter
-    // parity for the `site/ui` corpus is Phase 3, so these participate only
-    // in Hono SSR conformance + the fixture-hydrate runtime layer for now.
-    // (`label` and `kbd` are static helpers; `toggle` / `switch` /
-    // `checkbox` carry uncontrolled state; `input` is a pass-through
-    // native control.)
-    //
-    // `textarea` now participates: its conditional inline-object spread
-    // (`{...(describedBy ? {...} : {})}`) lowers via
-    // `buildConditionalSpreadInitializer`, and its optional
-    // `rows={rows}` attribute is omitted when nil via the nillable-field
-    // guard in `elementAttrEmitter.emitExpression`
-    // (`{{if ne .Rows nil}}rows="{{.Rows}}"{{end}}`), matching Hono's
-    // nullish-attribute omission.
+    // #1467 Phase 2b `site/ui` primitives still pending cross-adapter parity
+    // (label / input / textarea / checkbox now participate):
+    //   toggle / switch — the reactive `classes` memo interpolates
+    //     `Record<T,string>[variant|size]` lookups, which have no SSR
+    //     lowering yet (known limitation).
+    //   kbd — multi-export source (Kbd / KbdGroup); the harness renders the
+    //     last-registered export rather than the pinned Kbd.
     'toggle',
     'switch',
-    // `checkbox` now participates: it composes `CheckIcon` and uses the
-    // SolidJS props-object pattern. Unblocked by (a) re-adding the merged
-    // sibling's `"fmt"` import + emitting only referenced child components in
-    // the harness; (b) routing the non-param `<CheckIcon data-slot=.../>`
-    // attribute into the child's rest bag instead of an invalid `Data-slot`
-    // field; (c) enumerating inherited props-object accesses
-    // (`className`/`id`/`disabled`) as Input/Props fields, computing the
-    // template-literal `classes` memo's SSR value, and rendering boolean
-    // ternary memos (`isChecked`) as `false`. See the
-    // `props-object inherited-attribute enumeration` / `cross-component child
-    // rest-bag routing` unit tests below. `toggle`/`switch` share the
-    // inherited-attr fix but stay skipped on an additional
-    // `Record[key]`-in-memo-className blocker.
     'kbd',
   ],
   // Per-fixture build-time contracts for shapes the Go template

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -92,7 +92,19 @@ runAdapterConformanceTests({
     // nullish-attribute omission.
     'toggle',
     'switch',
-    'checkbox',
+    // `checkbox` now participates: it composes `CheckIcon` and uses the
+    // SolidJS props-object pattern. Unblocked by (a) re-adding the merged
+    // sibling's `"fmt"` import + emitting only referenced child components in
+    // the harness; (b) routing the non-param `<CheckIcon data-slot=.../>`
+    // attribute into the child's rest bag instead of an invalid `Data-slot`
+    // field; (c) enumerating inherited props-object accesses
+    // (`className`/`id`/`disabled`) as Input/Props fields, computing the
+    // template-literal `classes` memo's SSR value, and rendering boolean
+    // ternary memos (`isChecked`) as `false`. See the
+    // `props-object inherited-attribute enumeration` / `cross-component child
+    // rest-bag routing` unit tests below. `toggle`/`switch` share the
+    // inherited-attr fix but stay skipped on an additional
+    // `Record[key]`-in-memo-className blocker.
     'kbd',
   ],
   // Per-fixture build-time contracts for shapes the Go template
@@ -874,6 +886,195 @@ function Box({ a, b }: { a?: string; b?: string }) {
       adapter.generate(ir)
       const errs = (adapter as unknown as { errors: { code: string }[] }).errors
       expect(errs.some(e => e.code === 'BF101')).toBe(true)
+    })
+  })
+
+  describe('local-const conditional-spread resolution (#checkbox icon)', () => {
+    // A FUNCTION-scope const holding a `cond ? {…} : {}` ternary, then
+    // spread as a bare identifier (`{...sizeAttrs}`), resolves through the
+    // same conditional-spread lowering as the inline form. CheckIcon's
+    // `const sizeAttrs = size ? {…} : {}` is exactly this shape.
+    test('resolves a bare-identifier spread of a function-scope conditional const', () => {
+      const source = `
+function Box({ flag }: { flag?: boolean }) {
+  const attrs = flag ? { 'data-on': 'yes' } : {}
+  return <div {...attrs} />
+}
+`
+      const { template, types } = compileAndGenerate(source)
+      expect(template).toContain('{{bf_spread_attrs .Spread_0}}')
+      expect(types).toContain('Spread_0: func() map[string]any {')
+      expect(types).toContain('return map[string]any{"data-on": "yes"}')
+      expect(types).toContain('return map[string]any{}')
+    })
+
+    // A const that resolves to another bare identifier must NOT be
+    // forwarded (loop guard) — it falls through to BF101 like any other
+    // unsupported spread identifier.
+    test('does not forward a const that aliases another identifier (loop guard)', () => {
+      const adapter = new GoTemplateAdapter()
+      const source = `
+function Box({ other }: { other?: object }) {
+  const attrs = other
+  return <div {...attrs} />
+}
+`
+      const ir = compileToIR(source, adapter)
+      adapter.generate(ir)
+      const errs = (adapter as unknown as { errors: { code: string }[] }).errors
+      expect(errs.some(e => e.code === 'BF101')).toBe(true)
+    })
+  })
+
+  describe('Record<staticKeys,scalar>[propKey] spread value (#checkbox icon)', () => {
+    // `const sizeMap: Record<IconSize, number> = { sm: 16, ... }` indexed
+    // by a prop inside a conditional-spread object value lowers to an
+    // inline indexed Go map keyed via `fmt.Sprint(in.<Field>)`. This is
+    // CheckIcon's `{ width: sizeMap[size], height: sizeMap[size] }` shape.
+    test('lowers an indexed module-const map to an inline fmt.Sprint-keyed map and adds the fmt import', () => {
+      const source = `
+const sizeMap: Record<string, number> = { sm: 16, md: 20, lg: 24, xl: 32 }
+function Box({ size }: { size?: string }) {
+  const attrs = size ? { width: sizeMap[size] } : {}
+  return <div {...attrs} />
+}
+`
+      const { types } = compileAndGenerate(source)
+      expect(types).toContain(
+        'map[string]any{"sm": 16, "md": 20, "lg": 24, "xl": 32}[fmt.Sprint(in.Size)]',
+      )
+      // The `"fmt"` import is emitted only when this lowering fires.
+      expect(types).toContain('\t"fmt"')
+    })
+
+    test('lowers string-valued record maps too', () => {
+      const source = `
+const labelMap: Record<string, string> = { a: 'Alpha', b: 'Beta' }
+function Box({ k }: { k?: string }) {
+  const attrs = k ? { 'data-label': labelMap[k] } : {}
+  return <div {...attrs} />
+}
+`
+      const { types } = compileAndGenerate(source)
+      expect(types).toContain('map[string]any{"a": "Alpha", "b": "Beta"}[fmt.Sprint(in.K)]')
+    })
+
+    // A non-scalar record value (object / array / call) is out of shape:
+    // the spread object value can't lower, so the whole spread falls back
+    // to BF101 rather than emitting an invalid map.
+    test('refuses a non-scalar record value with BF101 (out-of-shape fallback)', () => {
+      const adapter = new GoTemplateAdapter()
+      const source = `
+const sizeMap: Record<string, object> = { sm: { w: 1 } }
+function Box({ size }: { size?: string }) {
+  const attrs = size ? { width: sizeMap[size] } : {}
+  return <div {...attrs} />
+}
+`
+      const ir = compileToIR(source, adapter)
+      adapter.generate(ir)
+      const errs = (adapter as unknown as { errors: { code: string }[] }).errors
+      expect(errs.some(e => e.code === 'BF101')).toBe(true)
+    })
+  })
+
+  describe('props-object inherited-attribute enumeration (#checkbox)', () => {
+    // A SolidJS props-object component (`function C(props: P)`) that reads
+    // inherited attributes (`props.className` in a memo, `props.id` /
+    // `props.disabled` on the root) must expose Input/Props fields for them,
+    // even though `propsParams` only enumerates `P`'s own members. Without
+    // this the caller's `className: ''` has no field — `unknown field
+    // ClassName in struct literal of type CInput`.
+    test('reads of props.className / props.id / props.disabled become Input fields', () => {
+      const adapter = new GoTemplateAdapter()
+      const source = `
+"use client"
+import { createMemo } from "@barefootjs/client"
+interface P { tone?: string }
+export function Widget(props: P) {
+  const classes = createMemo(() => \`base \${props.className ?? ''}\`)
+  return <button id={props.id} disabled={props.disabled ?? false} class={classes()}>x</button>
+}
+`
+      const ir = compileToIR(source, adapter)
+      const types = adapter.generateTypes(ir)!
+      expect(types).toContain('ClassName string')
+      // `id` is a bare-reference optional → interface{} (nillable, omittable).
+      expect(types).toContain('ID interface{}')
+      expect(types).toContain('Disabled bool')
+    })
+
+    // The className memo's SSR initial value must inline module string consts
+    // (incl. `[...].join(' ')`) and resolve `props.className ?? ''` to the
+    // ClassName field — not render the historical `0` placeholder.
+    test('template-literal className memo inlines consts + props.className field', () => {
+      const adapter = new GoTemplateAdapter()
+      const source = `
+"use client"
+import { createMemo } from "@barefootjs/client"
+const base = 'a b'
+const states = ['c', 'd'].join(' ')
+interface P { tone?: string }
+export function Widget(props: P) {
+  const classes = createMemo(() => \`\${base} \${states} \${props.className ?? ''} tail\`)
+  return <button class={classes()}>x</button>
+}
+`
+      const types = adapter.generateTypes(compileToIR(source, adapter))!
+      expect(types).toContain('Classes: "a b" + " " + "c d" + " " + in.ClassName + " tail"')
+    })
+
+    // A boolean ternary memo (`isChecked = ctrl() ? c() : i()`) renders its
+    // SSR zero as `false`, not the int `0`, so `aria-checked={isChecked()}`
+    // matches Hono's `aria-checked="false"`.
+    test('boolean ternary memo defaults to false, not 0', () => {
+      const adapter = new GoTemplateAdapter()
+      const source = `
+"use client"
+import { createSignal, createMemo } from "@barefootjs/client"
+export function Toggle(props: { checked?: boolean; defaultChecked?: boolean }) {
+  const [internal] = createSignal(props.defaultChecked ?? false)
+  const [controlled] = createSignal<boolean | undefined>(props.checked)
+  const isControlled = createMemo(() => props.checked !== undefined)
+  const isChecked = createMemo(() => isControlled() ? controlled() : internal())
+  return <button aria-checked={isChecked()}>x</button>
+}
+`
+      const types = adapter.generateTypes(compileToIR(source, adapter))!
+      expect(types).toContain('IsChecked bool')
+      expect(types).toContain('IsChecked: false,')
+    })
+  })
+
+  describe('cross-component child rest-bag routing (#checkbox)', () => {
+    // A parent rendering a child with a non-param attribute whose name isn't a
+    // valid Go identifier (`<CheckIcon data-slot="..."/>`) must route it into
+    // the child's rest bag (`Props: map[string]any{...}`), not a hyphenated
+    // top-level field (`Data-slot:`), when the child has a `...props` rest
+    // spread. Requires the child's shape registered first.
+    test('routes a hyphenated non-param child attr into the child rest bag', () => {
+      const adapter = new GoTemplateAdapter()
+      const childSource = `
+"use client"
+export function Leaf({ size, ...props }: { size?: string }) {
+  return <span {...props}>{size}</span>
+}
+`
+      const childIr = compileToIR(childSource, adapter)
+      adapter.registerChildComponentShape(childIr)
+      const parentSource = `
+"use client"
+import { Leaf } from './leaf'
+export function Host() {
+  return <div><Leaf data-slot="indicator" size="sm" /></div>
+}
+`
+      const types = adapter.generateTypes(compileToIR(parentSource, adapter))!
+      // Non-param hyphenated attr lands in the rest bag, not a Data-slot field.
+      expect(types).not.toContain('Data-slot:')
+      expect(types).toContain('Props: map[string]any{"data-slot": "indicator"}')
+      // A declared param (`size`) still binds as a top-level field.
+      expect(types).toContain('Size: "sm"')
     })
   })
 

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -103,6 +103,17 @@ interface StaticChildInstance {
 }
 
 /**
+ * Cross-component shape of a child component the parent renders (#checkbox).
+ * `paramNames` are the child's declared `propsParams`; `restBagField` is the
+ * Go field name of the child's open-ended rest bag (`Capitalize(restPropsName)`),
+ * or null when the child has no `...props` rest spread.
+ */
+interface ChildComponentShape {
+  paramNames: Set<string>
+  restBagField: string | null
+}
+
+/**
  * Top-level (non-loop) JSX intrinsic-element spread slot (#1407).
  * Collected by `collectSpreadSlots` so the adapter can emit one
  * `Spread_<slotId> map[string]any` field on the component's Props
@@ -419,6 +430,24 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    *  `template.HTML(...)`; toggles the `"html/template"` import. */
   private usesHtmlTemplate: boolean = false
 
+  /** Set during type generation when any emit references
+   *  `fmt.Sprint(...)` — e.g. a `Record<staticKeys, scalar>[propKey]`
+   *  indexed-map spread value (#checkbox); toggles the `"fmt"` import. */
+  private usesFmt: boolean = false
+
+  /**
+   * Cross-component child shapes (#checkbox), keyed by child component name.
+   * Populated out-of-band via `registerChildComponentShape` before the parent
+   * component's `generateTypes` runs, so the static-child-init codegen can
+   * route an attribute that is NOT a declared param of the child
+   * (`<CheckIcon data-slot=.../>`) into the child's rest bag
+   * (`Capitalize(restPropsName)` map field) instead of emitting an invalid
+   * hyphenated top-level field (`Data-slot:`). A child with no rest bag and
+   * an unknown attr is left as-is so the existing field path / Go compile
+   * error still surfaces.
+   */
+  private childComponentShapes: Map<string, ChildComponentShape> = new Map()
+
   /**
    * Module-scope pure string-literal constants (`const X = 'literal'` at
    * file top-level), keyed by name → resolved literal value. Populated at
@@ -470,6 +499,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     this.propsObjectName = ir.metadata.propsObjectName
     this.restPropsName = ir.metadata.restPropsName ?? null
     this.moduleStringConsts = this.collectModuleStringConsts(ir.metadata.localConstants)
+    // (#checkbox) Enumerate inherited-attribute accesses (props-object pattern)
+    // before computing the nillable set / rendering, so the synthetic params
+    // participate in attribute omission and field binding uniformly.
+    this.augmentInheritedPropAccesses(ir)
     this.nillablePropNames = this.collectNillablePropNames(ir)
 
     // Surface loop-body usages of components imported from sibling
@@ -762,8 +795,32 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     return `{{if .Scripts}}${registrations.join('')}{{end}}\n`
   }
 
+  /**
+   * Register a child component's shape (#checkbox) so a parent's
+   * static-child-init codegen can route non-param attributes into the child's
+   * rest bag rather than emitting an invalid hyphenated top-level field. Call
+   * once per known child IR (siblings in the same source, auto-inferred
+   * `../<name>` imports) before generating the parent's types. Idempotent.
+   */
+  registerChildComponentShape(ir: ComponentIR): void {
+    const name = ir.metadata.componentName
+    if (!name) return
+    const paramNames = new Set((ir.metadata.propsParams ?? []).map(p => p.name))
+    const restPropsName = ir.metadata.restPropsName ?? null
+    const restBagField = restPropsName ? this.capitalizeFieldName(restPropsName) : null
+    this.childComponentShapes.set(name, { paramNames, restBagField })
+  }
+
   generateTypes(ir: ComponentIR): string | null {
     this.usesHtmlTemplate = false
+    this.usesFmt = false
+    // (#checkbox) Mirror `generate()`: enumerate inherited-attribute accesses
+    // so the Input/Props structs expose `ClassName`/`ID`/`Disabled` fields the
+    // template + caller bind against. `generateTypes` runs on a separately
+    // round-tripped IR, so this must be applied here too; the method is
+    // idempotent. `propsObjectName` is needed by the scan.
+    this.propsObjectName = ir.metadata.propsObjectName
+    this.augmentInheritedPropAccesses(ir)
     const lines: string[] = []
 
     const componentName = ir.metadata.componentName
@@ -856,6 +913,9 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     header.push(`package ${this.options.packageName}`)
     header.push('')
     header.push('import (')
+    // Go's import block is conventionally sorted; emit in lexical order
+    // (`fmt` < `html/template` < `math/rand`).
+    if (this.usesFmt) header.push('\t"fmt"')
     if (this.usesHtmlTemplate) header.push('\t"html/template"')
     header.push('\t"math/rand"')
     header.push('')
@@ -1113,6 +1173,100 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       }
     }
     return nillable
+  }
+
+  /**
+   * (#checkbox) Enumerate inherited-attribute accesses for the SolidJS
+   * props-object pattern.
+   *
+   * `function Checkbox(props: CheckboxProps)` only lists `CheckboxProps`'s own
+   * members in `propsParams`; the inherited `ButtonHTMLAttributes` members the
+   * component actually reads (`props.className` in the classes memo,
+   * `props.id`, `props.disabled` on the root element) are never enumerated, so
+   * the generated Input/Props structs have no field to bind a caller's
+   * `className: ''` / `id` / `disabled` to — Go fails with `unknown field
+   * ClassName`. This scans the component's expressions for `props.<name>`
+   * accesses (where `props` is the resolved `propsObjectName`) and appends any
+   * not-already-a-param as a synthetic prop param, with a type inferred from
+   * how the access is used:
+   *   - rendered as a bare-reference attribute (`id={props.id}`) → `interface{}`
+   *     (nillable, so the attribute is omitted when unset — Hono parity);
+   *   - a boolean attribute (`disabled`) → `bool`;
+   *   - otherwise (`className`, read in a string memo) → `string`.
+   *
+   * Idempotent: re-running (e.g. once in `generate`, again in `generateTypes`
+   * on the round-tripped IR) is a no-op once the params are present. Mutates
+   * `ir.metadata.propsParams` in place so every downstream emitter — struct
+   * fields, nillable set, memo init, template — sees one consistent param list.
+   */
+  private augmentInheritedPropAccesses(ir: ComponentIR): void {
+    const propsObj = ir.metadata.propsObjectName
+    if (!propsObj) return // only the props-object pattern is affected
+
+    const existing = new Set(ir.metadata.propsParams.map(p => p.name))
+
+    // Collect bare-reference attribute exprs (`attr={props.id}`) and boolean
+    // attributes from the template so we can classify accessed props by use.
+    const bareRefProps = new Set<string>()
+    const booleanAttrProps = new Set<string>()
+    const accessed = new Set<string>()
+    const accessRe = new RegExp(`(?:^|[^\\w$.])${propsObj}\\.([A-Za-z_$][\\w$]*)`, 'g')
+    const scan = (s: string | undefined): void => {
+      if (!s) return
+      for (const m of s.matchAll(accessRe)) accessed.add(m[1])
+    }
+
+    // Memos, signals, init statements, effects: any `props.X` read.
+    for (const memo of ir.metadata.memos) scan(memo.computation)
+    for (const signal of ir.metadata.signals) scan(signal.initialValue)
+    for (const stmt of ir.metadata.initStatements ?? []) scan(stmt.body)
+    for (const eff of ir.metadata.effects ?? []) scan((eff as { body?: string }).body)
+
+    // Template attribute exprs — also note bare-ref / boolean usage.
+    const walk = (node: IRNode | undefined): void => {
+      if (!node) return
+      const el = node as unknown as IRElement
+      for (const attr of el.attrs ?? []) {
+        const v = attr.value as { kind?: string; expr?: string; presenceOrUndefined?: boolean }
+        if (v?.kind === 'expression' && typeof v.expr === 'string') {
+          scan(v.expr)
+          const expr = v.expr.trim()
+          const prefix = `${propsObj}.`
+          // A boolean HTML attribute (`disabled={props.disabled ?? false}`)
+          // marks the referenced prop as boolean even when wrapped in a
+          // `?? false` default — extract the prop name from the expr.
+          if (isBooleanAttr(attr.name) || v.presenceOrUndefined) {
+            const m = expr.match(new RegExp(`^${propsObj}\\.([A-Za-z_$][\\w$]*)`))
+            if (m) booleanAttrProps.add(m[1])
+          } else if (expr.startsWith(prefix)) {
+            const rest = expr.slice(prefix.length)
+            // A pure bare-reference attribute (`id={props.id}`) → nillable.
+            if (/^[A-Za-z_$][\w$]*$/.test(rest)) bareRefProps.add(rest)
+          }
+        }
+      }
+      for (const child of (el.children ?? []) as unknown[]) {
+        const c = child as { element?: IRNode }
+        walk((c.element ?? child) as IRNode)
+      }
+    }
+    walk(ir.root)
+
+    for (const name of accessed) {
+      if (existing.has(name)) continue
+      let raw: string
+      if (booleanAttrProps.has(name)) raw = 'boolean'
+      else if (bareRefProps.has(name)) raw = 'unknown' // → interface{} (nillable, omittable)
+      else raw = 'string' // read in a memo / string context (e.g. className)
+      const type: TypeInfo =
+        raw === 'boolean'
+          ? { kind: 'primitive', raw: 'boolean', primitive: 'boolean' }
+          : raw === 'string'
+            ? { kind: 'primitive', raw: 'string', primitive: 'string' }
+            : { kind: 'unknown', raw: 'unknown' }
+      ir.metadata.propsParams.push({ name, type, optional: true })
+      existing.add(name)
+    }
   }
 
   /**
@@ -1466,9 +1620,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     }
 
     // Add memo initial values (computed from signal initial values)
+    const memoPropsParamMap = new Map(ir.metadata.propsParams.map(p => [p.name, p]))
     for (const memo of ir.metadata.memos) {
       const fieldName = this.capitalizeFieldName(memo.name)
-      const memoValue = this.computeMemoInitialValue(memo, ir.metadata.signals, ir.metadata.propsParams, propFallbackVars)
+      // (#checkbox) Pass the memo's inferred Go type so an unresolved
+      // computation falls back to that type's zero value (`false` for a
+      // boolean memo like `isChecked`), not the int `0`.
+      const goType = this.inferMemoType(memo, ir.metadata.signals, memoPropsParamMap)
+      const memoValue = this.computeMemoInitialValue(memo, ir.metadata.signals, ir.metadata.propsParams, propFallbackVars, goType)
       lines.push(`\t\t${fieldName}: ${memoValue},`)
     }
 
@@ -1481,15 +1640,37 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       // own NewProps (BfParent/BfMount fields).
       lines.push(`\t\t\tBfParent: scopeID,`)
       lines.push(`\t\t\tBfMount: "${child.slotId}",`)
+      // (#checkbox) Cross-component shape lookup: an attribute that is NOT a
+      // declared param of the child but the child has a `...props` rest bag
+      // (`<CheckIcon data-slot=.../>`, where CheckIcon's params are
+      // `size`/`className` and the rest binding is `props`) must be routed
+      // into the child's rest-bag map field — emitting `Data-slot:` as a
+      // top-level Go field is a syntax error (hyphen). `restBagEntries`
+      // collects `"jsx-attr-name": goValue` pairs for that map.
+      const childShape = this.childComponentShapes.get(child.name)
+      const restBagEntries: string[] = []
+      // Emit a child input field, OR collect it as a rest-bag entry when the
+      // attr isn't a declared child param and a rest bag exists.
+      const emitChildField = (jsxName: string, goValue: string): void => {
+        if (
+          childShape &&
+          childShape.restBagField &&
+          !childShape.paramNames.has(jsxName)
+        ) {
+          restBagEntries.push(`${JSON.stringify(jsxName)}: ${goValue}`)
+          return
+        }
+        lines.push(`\t\t\t${this.capitalizeFieldName(jsxName)}: ${goValue},`)
+      }
       // Add prop values
       for (const prop of child.props) {
         switch (prop.value.kind) {
           case 'literal':
-            lines.push(`\t\t\t${this.capitalizeFieldName(prop.name)}: ${this.goLiteral(prop.value.value)},`)
+            emitChildField(prop.name, this.goLiteral(prop.value.value))
             break
           case 'boolean-shorthand':
           case 'boolean-attr':
-            lines.push(`\t\t\t${this.capitalizeFieldName(prop.name)}: true,`)
+            emitChildField(prop.name, 'true')
             break
           case 'expression':
           case 'spread':
@@ -1508,7 +1689,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
               const goExpr = this.templatePartsToGoCode(parts, ir.metadata.propsParams)
               if (goExpr !== null) {
                 // Parts path succeeded — emit and move on.
-                lines.push(`\t\t\t${this.capitalizeFieldName(prop.name)}: ${goExpr},`)
+                emitChildField(prop.name, goExpr)
                 break
               }
               // Parts exist but templatePartsToGoCode opted out (unsupported
@@ -1526,7 +1707,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
               ir.metadata.propsParams
             )
             if (resolvedValue !== null) {
-              lines.push(`\t\t\t${this.capitalizeFieldName(prop.name)}: ${resolvedValue},`)
+              emitChildField(prop.name, resolvedValue)
             }
             break
           }
@@ -1534,6 +1715,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
             // Handled separately via `child.childrenText` / `child.childrenHtml` below.
             break
         }
+      }
+      // (#checkbox) Emit the collected rest-bag entries as the child's
+      // open-ended bag field (`Props: map[string]any{...}`), matching how the
+      // child's `NewXxxProps` maps `in.Props` onto its `Spread_<N>` field.
+      if (childShape?.restBagField && restBagEntries.length > 0) {
+        lines.push(
+          `\t\t\t${childShape.restBagField}: map[string]any{${restBagEntries.join(', ')}},`,
+        )
       }
       // Pass through JSX children as the child slot's `Children` input.
       // Two paths:
@@ -2029,6 +2218,30 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       if (ir.metadata.restPropsName === trimmed) {
         return `in.${this.capitalizeFieldName(trimmed)}`
       }
+      // 4. Function-scope local const holding a conditional inline-object
+      //    spread: `const sizeAttrs = size ? {…} : {}` then `{...sizeAttrs}`
+      //    (#checkbox / icon). Resolve the identifier to its initializer
+      //    text and route through the conditional-spread lowering. Only
+      //    function-scope (`!isModule`) consts qualify — a module const is
+      //    a different shape, and the resolved initializer must itself be a
+      //    conditional-of-object-literals (else `buildConditionalSpreadInitializer`
+      //    returns undefined and we fall through to BF101). Guard against a
+      //    const that resolves to another bare identifier (loop / non-literal).
+      const localConst = (ir.metadata.localConstants ?? []).find(
+        c => c.name === trimmed && !c.isModule,
+      )
+      if (localConst?.value !== undefined) {
+        const initTrimmed = localConst.value.trim()
+        // Reject a const resolving to a bare identifier to avoid an
+        // unbounded resolution loop / non-literal forwarding.
+        if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(initTrimmed)) {
+          const resolved = this.buildConditionalSpreadInitializer(initTrimmed, ir)
+          // `undefined` → not a conditional-spread shape; fall through to
+          // BF101. `null` → that shape but unconvertible; also BF101.
+          if (resolved) return resolved
+          if (resolved === null) return null
+        }
+      }
     }
     return null
   }
@@ -2172,11 +2385,77 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         if (!param) return null
         goVal = `in.${this.capitalizeFieldName(param.name)}`
       } else {
-        return null
+        const indexed = this.recordIndexAccessToGoMap(val, ir)
+        if (indexed === null) return null
+        goVal = indexed
       }
       entries.push(`${JSON.stringify(key)}: ${goVal}`)
     }
     return `map[string]any{${entries.join(', ')}}`
+  }
+
+  /**
+   * Lower a spread-object VALUE of the form `IDENT[KEY]` where:
+   *   - `IDENT` resolves via `localConstants` to a MODULE-scope object
+   *     literal whose property values are all scalar (number/string)
+   *     literals under static (string-literal or identifier) keys
+   *     (a `Record<staticKeys, scalar>` map like `sizeMap`), AND
+   *   - `KEY` is a bare identifier that is a prop.
+   * Emits an inline indexed Go map:
+   *   `map[string]any{"sm": 16, ...}[fmt.Sprint(in.Size)]`
+   * (`fmt.Sprint` coerces the `interface{}`/typed prop to the map's
+   * string key space — sets `usesFmt` so the `"fmt"` import is added).
+   *
+   * Returns the Go string when convertible, else `null` (caller → BF101)
+   * for any non-scalar value, non-static key, or non-prop index so
+   * unrelated shapes don't regress. (#checkbox / icon `sizeMap[size]`.)
+   */
+  private recordIndexAccessToGoMap(
+    val: ts.Expression,
+    ir: ComponentIR,
+  ): string | null {
+    if (!ts.isElementAccessExpression(val)) return null
+    const obj = val.expression
+    const arg = val.argumentExpression
+    if (!ts.isIdentifier(obj) || !ts.isIdentifier(arg)) return null
+    // KEY must be a prop.
+    const keyParam = ir.metadata.propsParams.find(p => p.name === arg.text)
+    if (!keyParam) return null
+    // IDENT must resolve to a module-scope object-literal const.
+    const constInfo = (ir.metadata.localConstants ?? []).find(
+      c => c.name === obj.text && c.isModule,
+    )
+    if (constInfo?.value === undefined) return null
+    const parsed = this.parseLiteralExpression(constInfo.value)
+    if (!parsed || !ts.isObjectLiteralExpression(parsed)) return null
+    const entries: string[] = []
+    for (const prop of parsed.properties) {
+      if (!ts.isPropertyAssignment(prop)) return null
+      let mapKey: string
+      if (ts.isIdentifier(prop.name)) {
+        mapKey = prop.name.text
+      } else if (
+        ts.isStringLiteral(prop.name) ||
+        ts.isNoSubstitutionTemplateLiteral(prop.name)
+      ) {
+        mapKey = prop.name.text
+      } else {
+        return null
+      }
+      const v = this.unwrapParens(prop.initializer)
+      let mapVal: string
+      if (ts.isNumericLiteral(v)) {
+        mapVal = v.text
+      } else if (ts.isStringLiteral(v) || ts.isNoSubstitutionTemplateLiteral(v)) {
+        mapVal = JSON.stringify(v.text)
+      } else {
+        return null
+      }
+      entries.push(`${JSON.stringify(mapKey)}: ${mapVal}`)
+    }
+    this.usesFmt = true
+    const field = `in.${this.capitalizeFieldName(keyParam.name)}`
+    return `map[string]any{${entries.join(', ')}}[fmt.Sprint(${field})]`
   }
 
   /**
@@ -2588,11 +2867,129 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * referenced prop, substitute it for `in.FieldName` so the memo
    * inherits the signal-time `??` fallback.
    */
+  /**
+   * (#checkbox) Compute the SSR initial value of a template-literal memo as a
+   * Go `string` expression. The memo computation looks like
+   * `() => `${a} ${b} ${props.className ?? ''} grid place-content-center``.
+   *
+   * Each quasi (literal text span) becomes a Go string literal; each
+   * interpolation is resolved:
+   *   - an identifier naming a module string const → its inlined literal
+   *     (covers both pure-string and `[...].join(' ')` consts);
+   *   - `props.<name> ?? '<fallback>'` or bare `props.<name>` → `in.<Field>`
+   *     when `<name>` is a known prop param (typed `string`); the `?? ''`
+   *     fallback maps to Go's zero value for an unset string field, matching
+   *     the Hono reference's empty-string result.
+   *
+   * Returns the `"a" + in.Field + " grid..."` concatenation, or null when the
+   * computation isn't a single template literal or any interpolation isn't
+   * representable (so the caller keeps its existing pattern matching).
+   */
+  private computeTemplateLiteralMemoInitialValue(
+    computation: string,
+    propsParams: { name: string; type?: TypeInfo; defaultValue?: string }[],
+  ): string | null {
+    const sf = ts.createSourceFile(
+      '__memo.ts',
+      `const __x = (${computation});`,
+      ts.ScriptTarget.Latest,
+      /*setParentNodes*/ false,
+    )
+    const stmt = sf.statements[0]
+    if (!stmt || !ts.isVariableStatement(stmt)) return null
+    let init = stmt.declarationList.declarations[0]?.initializer
+    while (init && ts.isParenthesizedExpression(init)) init = init.expression
+    if (!init || !ts.isArrowFunction(init)) return null
+    let body = init.body as ts.Node
+    while (ts.isParenthesizedExpression(body as ts.Expression)) {
+      body = (body as ts.ParenthesizedExpression).expression
+    }
+    if (!ts.isTemplateExpression(body) && !ts.isNoSubstitutionTemplateLiteral(body)) {
+      return null
+    }
+    const propNames = new Set(propsParams.map(p => p.name))
+    const escGo = (s: string) => `"${this.escapeGoString(s)}"`
+    const segments: string[] = []
+
+    if (ts.isNoSubstitutionTemplateLiteral(body)) {
+      return escGo(body.text)
+    }
+    // head + each span
+    if (body.head.text) segments.push(escGo(body.head.text))
+    for (const span of body.templateSpans) {
+      const resolved = this.resolveTemplateInterpolation(span.expression, propNames)
+      if (resolved === null) return null
+      segments.push(resolved)
+      if (span.literal.text) segments.push(escGo(span.literal.text))
+    }
+    if (segments.length === 0) return '""'
+    return segments.join(' + ')
+  }
+
+  /**
+   * (#checkbox) Resolve one `${expr}` interpolation of a template-literal memo
+   * to a Go string expression, or null when unsupported. See
+   * `computeTemplateLiteralMemoInitialValue` for the supported shapes.
+   */
+  private resolveTemplateInterpolation(
+    expr: ts.Expression,
+    propNames: Set<string>,
+  ): string | null {
+    let node: ts.Expression = expr
+    while (ts.isParenthesizedExpression(node)) node = node.expression
+
+    // Identifier → module string const inline.
+    if (ts.isIdentifier(node)) {
+      const inlined = this.resolveModuleStringConst(node.text)
+      if (inlined !== null) return inlined
+      return null
+    }
+
+    // `props.X ?? '...'` — string-typed prop with an empty-string fallback.
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken
+    ) {
+      const right = node.right
+      const isEmptyStr =
+        (ts.isStringLiteral(right) || ts.isNoSubstitutionTemplateLiteral(right)) &&
+        right.text === ''
+      const propName = this.propsAccessName(node.left)
+      if (propName && propNames.has(propName) && isEmptyStr) {
+        // Unset string field is "" in Go — same as `?? ''`.
+        return `in.${this.capitalizeFieldName(propName)}`
+      }
+      return null
+    }
+
+    // Bare `props.X` (string-typed prop).
+    const propName = this.propsAccessName(node)
+    if (propName && propNames.has(propName)) {
+      return `in.${this.capitalizeFieldName(propName)}`
+    }
+    return null
+  }
+
+  /**
+   * If `node` is a `<propsObjectName>.<name>` access, return `<name>`, else
+   * null. Used to recognize props-object reads inside memo interpolations.
+   */
+  private propsAccessName(node: ts.Expression): string | null {
+    if (!ts.isPropertyAccessExpression(node)) return null
+    if (!ts.isIdentifier(node.expression)) return null
+    if (!this.propsObjectName || node.expression.text !== this.propsObjectName) return null
+    return node.name.text
+  }
+
   private computeMemoInitialValue(
     memo: { name: string; computation: string; deps: string[] },
     signals: { getter: string; initialValue: string }[],
     propsParams: { name: string; type?: TypeInfo; defaultValue?: string }[],
     propFallbackVars: ReadonlyMap<string, PropFallbackVar> = GoTemplateAdapter.EMPTY_PROP_FALLBACK_VARS,
+    // (#checkbox) Go type of the memo field; used to pick the zero-value
+    // fallback for an unresolved computation (`false` for `bool`, `""` for
+    // `string`, else the historical `0`).
+    goType?: string,
   ): string {
     const computation = memo.computation
     // Helper to pick the hoisted var (if any) or fall back to `in.X`.
@@ -2601,6 +2998,16 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       if (hoisted) return hoisted.varName
       return `in.${this.capitalizeFieldName(propName)}`
     }
+
+    // (#checkbox) Pattern: () => `...${expr}...` — a template-literal memo
+    // (the classes memo: `${baseClasses} ${focusClasses} ... ${props.className
+    // ?? ''} grid place-content-center`). Build a Go string concatenation that
+    // inlines module string consts (incl. `[...].join(' ')` consts resolved by
+    // `resolveModuleStringConst`) and resolves `props.X ?? ''` / bare `props.X`
+    // to the corresponding `in.Field`. Returns null when any interpolation
+    // isn't representable, so the existing patterns below still apply.
+    const tmplMemo = this.computeTemplateLiteralMemoInitialValue(computation, propsParams)
+    if (tmplMemo !== null) return tmplMemo
 
     // Pattern: () => dep() * N or () => dep() + N etc.
     const arithmeticMatch = computation.match(/\(\)\s*=>\s*(\w+)\(\)\s*([*+\-/])\s*(\d+)/)
@@ -2680,7 +3087,11 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       }
     }
 
-    // Default: return 0 for unknown computations
+    // Default: zero value for the memo's Go type (#checkbox). A boolean memo
+    // (`isChecked`) renders `false`, a string memo `""`; otherwise the
+    // historical int `0`.
+    if (goType === 'bool') return 'false'
+    if (goType === 'string') return '""'
     return '0'
   }
 
@@ -2719,8 +3130,56 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       }
     }
 
+    // (#checkbox) Boolean memo: a comparison/negation/ternary whose dependency
+    // signals are all boolean (`isChecked = isControlled() ? controlledChecked()
+    // : internalChecked()`). Inferring `bool` makes the field render `false`
+    // (not the int `0`) for `aria-checked={isChecked()}`, matching Hono's SSR
+    // initial value. Only fires when the declared memo type is unknown so an
+    // explicitly-typed memo still wins.
+    if (this.typeInfoToGo(memo.type) === 'interface{}' && this.isBooleanMemo(memo, signals, propsParamMap)) {
+      return 'bool'
+    }
+
     // Default to the memo's declared type
     return this.typeInfoToGo(memo.type)
+  }
+
+  /**
+   * (#checkbox) Heuristic: does this memo evaluate to a boolean? True when its
+   * computation is a comparison (`!==`/`===`/`!=`/`==`), a negation (`!x`), or
+   * a ternary whose branches are all boolean signals/props. Used to pick `bool`
+   * (zero value `false`) over the int `0` default for the SSR initial value.
+   */
+  private isBooleanMemo(
+    memo: { computation: string; deps: string[] },
+    signals: { getter: string; initialValue: string; type: TypeInfo }[],
+    propsParamMap: Map<string, { name: string; type: TypeInfo; defaultValue?: string }>,
+  ): boolean {
+    const c = memo.computation
+    if (/(!==|===|!=(?!=)|==(?!=))/.test(c)) return true
+    if (/=>\s*!/.test(c)) return true
+    // Ternary `() => cond() ? a() : b()` — boolean when both branches are
+    // boolean-resolving getters (signals whose value is boolean, or boolean
+    // props).
+    const isBoolGetter = (name: string): boolean => {
+      const sig = signals.find(s => s.getter === name)
+      if (sig) {
+        if (this.typeInfoToGo(sig.type) === 'bool') return true
+        // Signal initialised from `props.X ?? false` / a boolean prop.
+        if (/\?\?\s*(true|false)\b/.test(sig.initialValue)) return true
+        const propName = this.extractPropNameFromInitialValue(sig.initialValue) ?? sig.initialValue
+        const prop = propsParamMap.get(propName)
+        if (prop && this.typeInfoToGo(prop.type, prop.defaultValue) === 'bool') return true
+        return false
+      }
+      const prop = propsParamMap.get(name)
+      return !!prop && this.typeInfoToGo(prop.type, prop.defaultValue) === 'bool'
+    }
+    const ternary = c.match(/=>\s*\w+\(\)\s*\?\s*(\w+)\(\)\s*:\s*(\w+)\(\)/)
+    if (ternary) {
+      return isBoolGetter(ternary[1]) && isBoolGetter(ternary[2])
+    }
+    return false
   }
 
   /**
@@ -3207,7 +3666,47 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     if (ts.isStringLiteral(init) || ts.isNoSubstitutionTemplateLiteral(init)) {
       return init.text
     }
+    // (#checkbox) `[...string literals].join(SEP)` — a const that flattens an
+    // array of pure string literals to a single string at module load (e.g.
+    // Checkbox's `stateClasses = [...].join(' ')`). Evaluate it statically so
+    // the const inlines byte-for-byte like the Hono reference. Only fires when
+    // every array element is a string/no-substitution-template literal and the
+    // separator is a string-literal argument (or omitted → default `,`).
+    const joined = this.evalStringArrayJoin(init)
+    if (joined !== null) return joined
     return null
+  }
+
+  /**
+   * (#checkbox) Statically evaluate `[<string literals>].join(<sep?>)`.
+   * Returns the joined string, or null when the shape doesn't match (non-call,
+   * non-`.join`, non-array receiver, any non-string-literal element, or a
+   * non-string-literal separator). Comments/whitespace between elements are
+   * irrelevant — the TS parser already discarded them.
+   */
+  private evalStringArrayJoin(node: ts.Expression): string | null {
+    if (!ts.isCallExpression(node)) return null
+    const callee = node.expression
+    if (!ts.isPropertyAccessExpression(callee)) return null
+    if (callee.name.text !== 'join') return null
+    let recv: ts.Expression = callee.expression
+    while (ts.isParenthesizedExpression(recv)) recv = recv.expression
+    if (!ts.isArrayLiteralExpression(recv)) return null
+    const parts: string[] = []
+    for (const el of recv.elements) {
+      if (ts.isStringLiteral(el) || ts.isNoSubstitutionTemplateLiteral(el)) {
+        parts.push(el.text)
+      } else {
+        return null
+      }
+    }
+    let sep = ','
+    if (node.arguments.length >= 1) {
+      const arg = node.arguments[0]
+      if (ts.isStringLiteral(arg) || ts.isNoSubstitutionTemplateLiteral(arg)) sep = arg.text
+      else return null
+    }
+    return parts.join(sep)
   }
 
   /**
@@ -5101,8 +5600,16 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       // concrete-typed props (which are never nil) are unaffected and
       // still emit `attr=""` / `attr="0"` exactly as Hono does.
       const bareId = value.expr.trim()
-      if (this.nillablePropNames.has(bareId)) {
-        const field = `.${this.capitalizeFieldName(bareId)}`
+      // Normalize a props-object access (`props.id`) to its bare prop name
+      // (`id`) so the nillable set — which is keyed by bare prop name —
+      // matches the SolidJS-style props-object pattern too, not just
+      // destructured params (#checkbox `id={props.id}`).
+      const propName =
+        this.propsObjectName && bareId.startsWith(`${this.propsObjectName}.`)
+          ? bareId.slice(this.propsObjectName.length + 1)
+          : bareId
+      if (/^[A-Za-z_$][\w$]*$/.test(propName) && this.nillablePropNames.has(propName)) {
+        const field = `.${this.capitalizeFieldName(propName)}`
         return `{{if ne ${field} nil}}${name}="{{${this.convertExpressionToGo(value.expr)}}}"{{end}}`
       }
       return `${name}="{{${this.convertExpressionToGo(value.expr)}}}"`

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -58,6 +58,8 @@ import {
   emitParsedExpr,
   emitIRNode,
   emitAttrValue,
+  augmentInheritedPropAccesses,
+  parseRecordIndexAccess,
 } from '@barefootjs/jsx'
 import { findInterpolationEnd } from '@barefootjs/jsx/scanner'
 
@@ -501,8 +503,9 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     this.moduleStringConsts = this.collectModuleStringConsts(ir.metadata.localConstants)
     // (#checkbox) Enumerate inherited-attribute accesses (props-object pattern)
     // before computing the nillable set / rendering, so the synthetic params
-    // participate in attribute omission and field binding uniformly.
-    this.augmentInheritedPropAccesses(ir)
+    // participate in attribute omission and field binding uniformly. Shared
+    // with the Mojo adapter (single source of truth in `@barefootjs/jsx`).
+    augmentInheritedPropAccesses(ir)
     this.nillablePropNames = this.collectNillablePropNames(ir)
 
     // Surface loop-body usages of components imported from sibling
@@ -820,7 +823,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // round-tripped IR, so this must be applied here too; the method is
     // idempotent. `propsObjectName` is needed by the scan.
     this.propsObjectName = ir.metadata.propsObjectName
-    this.augmentInheritedPropAccesses(ir)
+    augmentInheritedPropAccesses(ir)
     const lines: string[] = []
 
     const componentName = ir.metadata.componentName
@@ -1173,100 +1176,6 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       }
     }
     return nillable
-  }
-
-  /**
-   * (#checkbox) Enumerate inherited-attribute accesses for the SolidJS
-   * props-object pattern.
-   *
-   * `function Checkbox(props: CheckboxProps)` only lists `CheckboxProps`'s own
-   * members in `propsParams`; the inherited `ButtonHTMLAttributes` members the
-   * component actually reads (`props.className` in the classes memo,
-   * `props.id`, `props.disabled` on the root element) are never enumerated, so
-   * the generated Input/Props structs have no field to bind a caller's
-   * `className: ''` / `id` / `disabled` to — Go fails with `unknown field
-   * ClassName`. This scans the component's expressions for `props.<name>`
-   * accesses (where `props` is the resolved `propsObjectName`) and appends any
-   * not-already-a-param as a synthetic prop param, with a type inferred from
-   * how the access is used:
-   *   - rendered as a bare-reference attribute (`id={props.id}`) → `interface{}`
-   *     (nillable, so the attribute is omitted when unset — Hono parity);
-   *   - a boolean attribute (`disabled`) → `bool`;
-   *   - otherwise (`className`, read in a string memo) → `string`.
-   *
-   * Idempotent: re-running (e.g. once in `generate`, again in `generateTypes`
-   * on the round-tripped IR) is a no-op once the params are present. Mutates
-   * `ir.metadata.propsParams` in place so every downstream emitter — struct
-   * fields, nillable set, memo init, template — sees one consistent param list.
-   */
-  private augmentInheritedPropAccesses(ir: ComponentIR): void {
-    const propsObj = ir.metadata.propsObjectName
-    if (!propsObj) return // only the props-object pattern is affected
-
-    const existing = new Set(ir.metadata.propsParams.map(p => p.name))
-
-    // Collect bare-reference attribute exprs (`attr={props.id}`) and boolean
-    // attributes from the template so we can classify accessed props by use.
-    const bareRefProps = new Set<string>()
-    const booleanAttrProps = new Set<string>()
-    const accessed = new Set<string>()
-    const accessRe = new RegExp(`(?:^|[^\\w$.])${propsObj}\\.([A-Za-z_$][\\w$]*)`, 'g')
-    const scan = (s: string | undefined): void => {
-      if (!s) return
-      for (const m of s.matchAll(accessRe)) accessed.add(m[1])
-    }
-
-    // Memos, signals, init statements, effects: any `props.X` read.
-    for (const memo of ir.metadata.memos) scan(memo.computation)
-    for (const signal of ir.metadata.signals) scan(signal.initialValue)
-    for (const stmt of ir.metadata.initStatements ?? []) scan(stmt.body)
-    for (const eff of ir.metadata.effects ?? []) scan((eff as { body?: string }).body)
-
-    // Template attribute exprs — also note bare-ref / boolean usage.
-    const walk = (node: IRNode | undefined): void => {
-      if (!node) return
-      const el = node as unknown as IRElement
-      for (const attr of el.attrs ?? []) {
-        const v = attr.value as { kind?: string; expr?: string; presenceOrUndefined?: boolean }
-        if (v?.kind === 'expression' && typeof v.expr === 'string') {
-          scan(v.expr)
-          const expr = v.expr.trim()
-          const prefix = `${propsObj}.`
-          // A boolean HTML attribute (`disabled={props.disabled ?? false}`)
-          // marks the referenced prop as boolean even when wrapped in a
-          // `?? false` default — extract the prop name from the expr.
-          if (isBooleanAttr(attr.name) || v.presenceOrUndefined) {
-            const m = expr.match(new RegExp(`^${propsObj}\\.([A-Za-z_$][\\w$]*)`))
-            if (m) booleanAttrProps.add(m[1])
-          } else if (expr.startsWith(prefix)) {
-            const rest = expr.slice(prefix.length)
-            // A pure bare-reference attribute (`id={props.id}`) → nillable.
-            if (/^[A-Za-z_$][\w$]*$/.test(rest)) bareRefProps.add(rest)
-          }
-        }
-      }
-      for (const child of (el.children ?? []) as unknown[]) {
-        const c = child as { element?: IRNode }
-        walk((c.element ?? child) as IRNode)
-      }
-    }
-    walk(ir.root)
-
-    for (const name of accessed) {
-      if (existing.has(name)) continue
-      let raw: string
-      if (booleanAttrProps.has(name)) raw = 'boolean'
-      else if (bareRefProps.has(name)) raw = 'unknown' // → interface{} (nillable, omittable)
-      else raw = 'string' // read in a memo / string context (e.g. className)
-      const type: TypeInfo =
-        raw === 'boolean'
-          ? { kind: 'primitive', raw: 'boolean', primitive: 'boolean' }
-          : raw === 'string'
-            ? { kind: 'primitive', raw: 'string', primitive: 'string' }
-            : { kind: 'unknown', raw: 'unknown' }
-      ir.metadata.propsParams.push({ name, type, optional: true })
-      existing.add(name)
-    }
   }
 
   /**
@@ -2414,47 +2323,20 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     val: ts.Expression,
     ir: ComponentIR,
   ): string | null {
-    if (!ts.isElementAccessExpression(val)) return null
-    const obj = val.expression
-    const arg = val.argumentExpression
-    if (!ts.isIdentifier(obj) || !ts.isIdentifier(arg)) return null
-    // KEY must be a prop.
-    const keyParam = ir.metadata.propsParams.find(p => p.name === arg.text)
-    if (!keyParam) return null
-    // IDENT must resolve to a module-scope object-literal const.
-    const constInfo = (ir.metadata.localConstants ?? []).find(
-      c => c.name === obj.text && c.isModule,
+    // Shared structural parse (single source of truth in `@barefootjs/jsx`);
+    // this wrapper only does the Go-specific emit from the structured result.
+    const parsed = parseRecordIndexAccess(
+      val,
+      ir.metadata.localConstants ?? [],
+      ir.metadata.propsParams,
     )
-    if (constInfo?.value === undefined) return null
-    const parsed = this.parseLiteralExpression(constInfo.value)
-    if (!parsed || !ts.isObjectLiteralExpression(parsed)) return null
-    const entries: string[] = []
-    for (const prop of parsed.properties) {
-      if (!ts.isPropertyAssignment(prop)) return null
-      let mapKey: string
-      if (ts.isIdentifier(prop.name)) {
-        mapKey = prop.name.text
-      } else if (
-        ts.isStringLiteral(prop.name) ||
-        ts.isNoSubstitutionTemplateLiteral(prop.name)
-      ) {
-        mapKey = prop.name.text
-      } else {
-        return null
-      }
-      const v = this.unwrapParens(prop.initializer)
-      let mapVal: string
-      if (ts.isNumericLiteral(v)) {
-        mapVal = v.text
-      } else if (ts.isStringLiteral(v) || ts.isNoSubstitutionTemplateLiteral(v)) {
-        mapVal = JSON.stringify(v.text)
-      } else {
-        return null
-      }
-      entries.push(`${JSON.stringify(mapKey)}: ${mapVal}`)
-    }
+    if (!parsed) return null
+    const entries = parsed.entries.map(e => {
+      const mapVal = e.value.kind === 'number' ? e.value.text : JSON.stringify(e.value.text)
+      return `${JSON.stringify(e.key)}: ${mapVal}`
+    })
     this.usesFmt = true
-    const field = `in.${this.capitalizeFieldName(keyParam.name)}`
+    const field = `in.${this.capitalizeFieldName(parsed.indexPropName)}`
     return `map[string]any{${entries.join(', ')}}[fmt.Sprint(${field})]`
   }
 

--- a/packages/adapter-go-template/src/test-render.ts
+++ b/packages/adapter-go-template/src/test-render.ts
@@ -68,9 +68,22 @@ export async function renderGoTemplateComponent(options: RenderOptions): Promise
     throw new Error('Go Template adapter must implement generateTypes()')
   }
 
-  // Compile child components first
-  const childTemplates: string[] = []
-  const childTypeBlocks: string[] = []
+  // Compile child components first, keeping per-component template defines /
+  // type blocks keyed by component name. A child *file* can export many
+  // components (e.g. `../icon` exports 30+ icons); only the ones the parent
+  // transitively references are emitted into the combined unit. Emitting all
+  // of them concatenates dead components whose own codegen may not compile
+  // (e.g. `ChevronDownIcon`'s `strokePaths['chevron-down']` lowers to an
+  // invalid `{{.StrokePaths.Chevron-down}}` field reference), which would
+  // break the whole template parse even though the parent never uses them.
+  // (#checkbox)
+  interface ChildComponentArtifacts {
+    define: string
+    typeBlock: string | null
+    /** Component names this child component imports from sibling files. */
+    importedNames: string[]
+  }
+  const childArtifacts = new Map<string, ChildComponentArtifacts>()
   if (components) {
     for (const [filename, childSource] of Object.entries(components)) {
       const childResult = compileJSX(childSource, filename, { adapter, outputIR: true })
@@ -80,19 +93,30 @@ export async function renderGoTemplateComponent(options: RenderOptions): Promise
       }
       const childTemplate = childResult.files.find(f => f.type === 'markedTemplate')
       if (!childTemplate) throw new Error(`No marked template for ${filename}`)
-      childTemplates.push(childTemplate.content)
+      const defineBlocks = splitTemplateDefines(childTemplate.content)
 
       const childIrFiles = childResult.files.filter(f => f.type === 'ir')
       for (const childIrFile of childIrFiles) {
         const childIR = JSON.parse(childIrFile.content) as ComponentIR
-        let childTypes = adapter.generateTypes!(childIR)
-        if (childTypes) {
+        const name = childIR.metadata.componentName
+        // (#checkbox) Register each child's cross-component shape so the
+        // parent's static-child-init codegen can route a non-param attribute
+        // (`<CheckIcon data-slot=.../>`) into the child's rest bag instead of
+        // an invalid hyphenated Go field. No-op on adapters without the hook.
+        registerChildShape(adapter, childIR)
+        let typeBlock: string | null = adapter.generateTypes!(childIR)
+        if (typeBlock) {
           // Strip package declaration and imports — will be merged into main types
-          childTypes = childTypes.replace(/^package \w+\n*/, '')
-          childTypes = childTypes.replace(/import\s*\([^)]*\)\n*/g, '')
-          childTypes = childTypes.replace(/\t"math\/rand"\n/g, '')
-          childTypeBlocks.push(childTypes.trim())
+          typeBlock = typeBlock.replace(/^package \w+\n*/, '')
+          typeBlock = typeBlock.replace(/import\s*\([^)]*\)\n*/g, '')
+          typeBlock = typeBlock.replace(/\t"math\/rand"\n/g, '')
+          typeBlock = typeBlock.trim()
         }
+        childArtifacts.set(name, {
+          define: defineBlocks.get(name) ?? '',
+          typeBlock,
+          importedNames: collectImportedComponentNames(childIR),
+        })
       }
     }
   }
@@ -119,6 +143,37 @@ export async function renderGoTemplateComponent(options: RenderOptions): Promise
     irs.find(i => i.metadata.hasDefaultExport) ??
     irs.find(i => i.metadata.isExported) ??
     irs[0]
+
+  // (#checkbox) Register each in-source sibling's shape too, so a parent
+  // rendering an inline sibling routes non-param attributes into the
+  // sibling's rest bag (same fix as the auto-inferred `../<name>` children).
+  for (const siblingIR of irs) registerChildShape(adapter, siblingIR)
+
+  // (#checkbox) Resolve which child components the combined unit actually
+  // needs: start from the entry component's cross-file imports, then close
+  // transitively over each included child's own imports. Components a child
+  // *file* exports but nobody references are dropped (see comment at the
+  // child-collection loop above).
+  const reachableChildNames = new Set<string>()
+  {
+    const queue = [...collectImportedComponentNames(ir)]
+    while (queue.length > 0) {
+      const name = queue.shift()!
+      if (reachableChildNames.has(name)) continue
+      const artifact = childArtifacts.get(name)
+      if (!artifact) continue // not a compiled child (e.g. an in-source sibling)
+      reachableChildNames.add(name)
+      for (const dep of artifact.importedNames) queue.push(dep)
+    }
+  }
+  const childTemplates: string[] = []
+  const childTypeBlocks: string[] = []
+  for (const name of reachableChildNames) {
+    const artifact = childArtifacts.get(name)
+    if (!artifact) continue
+    if (artifact.define) childTemplates.push(artifact.define)
+    if (artifact.typeBlock) childTypeBlocks.push(artifact.typeBlock)
+  }
 
   // Generate types for the entry-point component first, then append
   // types for every sibling component in the same source file so the
@@ -148,6 +203,18 @@ export async function renderGoTemplateComponent(options: RenderOptions): Promise
   if (childTypeBlocks.length > 0) {
     goTypes += '\n\n' + childTypeBlocks.join('\n\n')
   }
+
+  // Sibling / child type blocks have their own `import (...)` stripped above
+  // (their package decl + imports are merged into the entry component's
+  // single `types.go` block). When a sibling's generated constructor uses a
+  // standard-library symbol the entry component doesn't — e.g. CheckIcon's
+  // `NewCheckIconProps` calls `fmt.Sprint(...)` for a `Record[key]` spread
+  // lookup (#checkbox icon) — that import would be lost, producing
+  // `undefined: fmt`. Re-add any such import to the entry component's import
+  // block so the combined compilation unit resolves the symbol. Only `fmt`
+  // is needed today; extend `MERGED_STDLIB_IMPORTS` if a future sibling pulls
+  // in another stdlib package.
+  goTypes = ensureMergedStdlibImports(goTypes)
 
   const componentName = ir.metadata.componentName
   // Concatenate all templates (child define blocks + parent)
@@ -272,6 +339,118 @@ ${propsInit}
   } finally {
     await rm(tempDir, { recursive: true, force: true }).catch(() => {})
   }
+}
+
+/**
+ * Split a marked-template file's content into per-component `{{define "X"}}…
+ * {{end}}` blocks, keyed by component name. A child file that exports multiple
+ * components yields one entry per component so the harness can emit only the
+ * referenced ones (#checkbox). Non-define preamble (e.g. `export type {...}`)
+ * is ignored — it isn't valid Go template text and the entry component carries
+ * its own.
+ */
+function splitTemplateDefines(content: string): Map<string, string> {
+  const out = new Map<string, string>()
+  // Block actions that open a scope closed by `{{end}}`. A `{{define}}` body
+  // can contain nested `{{if}}` / `{{range}}` / `{{with}}` / `{{block}}`, so a
+  // non-greedy `.*?{{end}}` would stop at the first inner `{{end}}`. Track
+  // nesting depth and capture from each `{{define}}` to its matching `{{end}}`.
+  const actionRe = /\{\{[-\s]*(define|if|range|with|block|end)\b/g
+  let m: RegExpExecArray | null
+  let openName: string | null = null
+  let openStart = 0
+  let depth = 0
+  while ((m = actionRe.exec(content)) !== null) {
+    const kw = m[1]
+    if (kw === 'end') {
+      if (openName !== null) {
+        depth--
+        if (depth === 0) {
+          // Extend to the close of this `{{...end...}}` action.
+          const closeIdx = content.indexOf('}}', m.index)
+          const end = closeIdx === -1 ? content.length : closeIdx + 2
+          out.set(openName, content.slice(openStart, end))
+          openName = null
+        }
+      }
+      continue
+    }
+    if (kw === 'define' && openName === null) {
+      const nameMatch = content.slice(m.index).match(/^\{\{[-\s]*define\s+"([^"]+)"/)
+      openName = nameMatch ? nameMatch[1] : null
+      openStart = m.index
+      depth = 1
+      continue
+    }
+    // Any opening action while inside a define deepens the nesting.
+    if (openName !== null) depth++
+  }
+  return out
+}
+
+/**
+ * Component names a component IR imports from sibling source files — i.e.
+ * non-type imports from relative (`./` / `../`) specifiers. Used to compute
+ * the transitive set of child components the combined Go unit needs.
+ */
+function collectImportedComponentNames(ir: ComponentIR): string[] {
+  const names: string[] = []
+  for (const imp of ir.metadata.imports ?? []) {
+    if (imp.isTypeOnly) continue
+    if (!imp.source.startsWith('.')) continue
+    for (const spec of imp.specifiers ?? []) {
+      if (spec.isNamespace) continue
+      // Imported binding name (the local alias is what JSX references, but the
+      // generated `{{define}}`/types are keyed by the exported component name —
+      // which equals the specifier name when un-aliased; aliased component
+      // imports aren't exercised by the UI fixtures).
+      names.push(spec.alias ?? spec.name)
+    }
+  }
+  return names
+}
+
+/**
+ * Register a child/sibling component's cross-component shape on the adapter
+ * when it supports the `registerChildComponentShape` hook (Go template). A
+ * no-op on adapters without it. Lets the parent's static-child-init codegen
+ * route a non-param attribute into the child's rest bag (#checkbox).
+ */
+function registerChildShape(adapter: TemplateAdapter, ir: ComponentIR): void {
+  const hook = (adapter as { registerChildComponentShape?: (ir: ComponentIR) => void })
+    .registerChildComponentShape
+  if (typeof hook === 'function') hook.call(adapter, ir)
+}
+
+/**
+ * Standard-library packages that a merged sibling/child type block may
+ * reference but the entry component's own import block omits. Each entry maps
+ * the import path to a `<pkg>.` usage probe.
+ */
+const MERGED_STDLIB_IMPORTS: Array<{ path: string; usage: RegExp }> = [
+  { path: 'fmt', usage: /\bfmt\./ },
+]
+
+/**
+ * Ensure any standard-library import a merged sibling/child block needs is
+ * present in the entry component's `import (...)` block. Sibling/child blocks
+ * have their own imports stripped during merge, so a symbol they reference
+ * (e.g. `fmt.Sprint`) is otherwise `undefined` in the combined unit.
+ */
+function ensureMergedStdlibImports(goTypes: string): string {
+  const importMatch = goTypes.match(/import\s*\(([^)]*)\)/)
+  if (!importMatch) return goTypes
+  const block = importMatch[1]
+  const additions: string[] = []
+  for (const { path, usage } of MERGED_STDLIB_IMPORTS) {
+    if (!usage.test(goTypes)) continue
+    // Already imported? (quoted path present in the import block)
+    if (block.includes(`"${path}"`)) continue
+    additions.push(`\t"${path}"`)
+  }
+  if (additions.length === 0) return goTypes
+  const newBlock = `import (\n${additions.join('\n')}\n${block.replace(/^\n+/, '')})`
+  return goTypes.replace(/import\s*\([^)]*\)/, newBlock)
 }
 
 /**

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -72,8 +72,8 @@ runAdapterConformanceTests({
     // #1467 Phase 2b: basic interactive `site/ui` primitives. Cross-adapter
     // parity for the `site/ui` corpus is Phase 3, so these participate only
     // in Hono SSR conformance + the fixture-hydrate runtime layer for now.
-    // (`label` and `kbd` are static helpers; `toggle` / `switch` /
-    // `checkbox` carry uncontrolled state; `input` is a pass-through
+    // (`label` and `kbd` are static helpers; `toggle` / `switch`
+    // carry uncontrolled state; `input` is a pass-through
     // native control.)
     //
     // `textarea` now participates: its conditional inline-object spread
@@ -83,9 +83,17 @@ runAdapterConformanceTests({
     // `elementAttrEmitter.emitExpression`
     // (`<% if (defined $rows) { %>rows="<%= $rows %>"<% } %>`), matching
     // Hono's nullish-attribute omission.
+    //
+    // `checkbox` now participates too: it composes `CheckIcon` and uses the
+    // SolidJS props-object pattern. Unblocked by quoting hyphenated child
+    // attribute names in `render_child` (`'data-slot' => ...`), declaring +
+    // `defined`-guarding inherited props-object accesses (`$id` / `$disabled`
+    // / `$className`), and seeding module-const + `.join()` values into
+    // `extractSsrDefaults` so the `classes` memo resolves to the full class
+    // string. `toggle`/`switch` share the inherited-attr fix but stay skipped
+    // on an additional `Record[key]`-in-memo-className blocker.
     'toggle',
     'switch',
-    'checkbox',
     'kbd',
   ],
   // Per-fixture build-time contracts for shapes the Mojo adapter
@@ -284,6 +292,120 @@ function Box({ k, v }: { k?: string; v?: string }) {
     adapter.generate(ir)
     const errs = (adapter as unknown as { errors: { code: string }[] }).errors
     expect(errs.some(e => e.code === 'BF101')).toBe(true)
+  })
+})
+
+describe('MojoAdapter - local-const conditional-spread resolution (#checkbox icon)', () => {
+  // A FUNCTION-scope const holding a `cond ? {…} : {}` ternary, spread as
+  // a bare identifier (`{...attrs}`), resolves through the same Perl
+  // ternary-of-hashrefs lowering as the inline form. CheckIcon's
+  // `const sizeAttrs = size ? {…} : {}` is exactly this shape.
+  test('resolves a bare-identifier spread of a function-scope conditional const', () => {
+    const { template } = compileAndGenerate(`
+function Box({ flag }: { flag?: boolean }) {
+  const attrs = flag ? { 'data-on': 'yes' } : {}
+  return <div {...attrs} />
+}
+`)
+    expect(template).toContain(
+      "bf->spread_attrs($flag ? { 'data-on' => 'yes' } : {})",
+    )
+  })
+
+  // A const that aliases another bare identifier must NOT be forwarded
+  // (loop guard): the resolver bails, so the spread falls through to the
+  // standard `convertExpressionToPerl` path emitting the bare `$attrs`
+  // variable rather than recursively resolving the alias into a hashref.
+  test('does not forward a const that aliases another identifier (loop guard)', () => {
+    const { template } = compileAndGenerate(`
+function Box({ other }: { other?: object }) {
+  const attrs = other
+  return <div {...attrs} />
+}
+`)
+    expect(template).toContain('bf->spread_attrs($attrs)')
+  })
+})
+
+describe('MojoAdapter - Record<staticKeys,scalar>[propKey] spread value (#checkbox icon)', () => {
+  // `const sizeMap: Record<IconSize, number> = { sm: 16, ... }` indexed by
+  // a prop inside a conditional-spread object value lowers to an inline
+  // indexed Perl hashref `{ ... }->{$key}`. This is CheckIcon's
+  // `{ width: sizeMap[size], height: sizeMap[size] }` shape.
+  test('lowers an indexed module-const map to an inline hashref index', () => {
+    const { template } = compileAndGenerate(`
+const sizeMap: Record<string, number> = { sm: 16, md: 20, lg: 24, xl: 32 }
+function Box({ size }: { size?: string }) {
+  const attrs = size ? { width: sizeMap[size] } : {}
+  return <div {...attrs} />
+}
+`)
+    expect(template).toContain(
+      "{ 'sm' => 16, 'md' => 20, 'lg' => 24, 'xl' => 32 }->{$size}",
+    )
+  })
+
+  test('lowers string-valued record maps too', () => {
+    const { template } = compileAndGenerate(`
+const labelMap: Record<string, string> = { a: 'Alpha', b: 'Beta' }
+function Box({ k }: { k?: string }) {
+  const attrs = k ? { 'data-label': labelMap[k] } : {}
+  return <div {...attrs} />
+}
+`)
+    expect(template).toContain("{ 'a' => 'Alpha', 'b' => 'Beta' }->{$k}")
+  })
+
+  // A non-scalar record value (object) is out of shape: the spread object
+  // value can't lower, so the whole spread falls back to BF101.
+  test('refuses a non-scalar record value with BF101 (out-of-shape fallback)', () => {
+    const adapter = new MojoAdapter()
+    const ir = compileToIR(`
+const sizeMap: Record<string, object> = { sm: { w: 1 } }
+function Box({ size }: { size?: string }) {
+  const attrs = size ? { width: sizeMap[size] } : {}
+  return <div {...attrs} />
+}
+`, adapter)
+    adapter.generate(ir)
+    const errs = (adapter as unknown as { errors: { code: string }[] }).errors
+    expect(errs.some(e => e.code === 'BF101')).toBe(true)
+  })
+})
+
+describe('MojoAdapter - props-object inherited-attribute enumeration (#checkbox)', () => {
+  // A SolidJS props-object component reads inherited attributes (`props.id`)
+  // not enumerated in `propsParams`. The bare optional attribute must be
+  // guarded with Perl `defined` so it's omitted when unset (Hono parity),
+  // even though `id` isn't a declared param.
+  test('guards a props-object bare optional attr (props.id) with defined', () => {
+    const { template } = compileAndGenerate(`
+"use client"
+interface P { tone?: string }
+export function Widget(props: P) {
+  return <button id={props.id}>x</button>
+}
+`)
+    expect(template).toContain('<% if (defined $id) { %>id="<%= $id %>"<% } %>')
+  })
+})
+
+describe('MojoAdapter - hyphenated child attr hash key (#checkbox)', () => {
+  // A child component prop whose JSX name isn't a bare Perl identifier
+  // (`<CheckIcon data-slot="..."/>`) must be quoted in the `render_child`
+  // named-arg list — an unquoted `data-slot => ...` parses as `data - slot`.
+  test('quotes a hyphenated child attribute name in render_child', () => {
+    const { template } = compileAndGenerate(`
+"use client"
+import { Leaf } from './leaf'
+export function Host() {
+  return <div><Leaf data-slot="indicator" size="sm" /></div>
+}
+`)
+    expect(template).toContain("'data-slot' => 'indicator'")
+    // A bare-identifier name stays unquoted.
+    expect(template).toContain('size => ')
+    expect(template).not.toContain('data-slot => ')
   })
 })
 

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -69,29 +69,13 @@ runAdapterConformanceTests({
     'toggle-shared',
     'reactive-props',
     'props-reactivity-comparison',
-    // #1467 Phase 2b: basic interactive `site/ui` primitives. Cross-adapter
-    // parity for the `site/ui` corpus is Phase 3, so these participate only
-    // in Hono SSR conformance + the fixture-hydrate runtime layer for now.
-    // (`label` and `kbd` are static helpers; `toggle` / `switch`
-    // carry uncontrolled state; `input` is a pass-through
-    // native control.)
-    //
-    // `textarea` now participates: its conditional inline-object spread
-    // (`{...(describedBy ? {...} : {})}`) lowers via
-    // `conditionalSpreadToPerl`, and its optional `rows={rows}`
-    // attribute is omitted when `undef` via the `defined`-guard in
-    // `elementAttrEmitter.emitExpression`
-    // (`<% if (defined $rows) { %>rows="<%= $rows %>"<% } %>`), matching
-    // Hono's nullish-attribute omission.
-    //
-    // `checkbox` now participates too: it composes `CheckIcon` and uses the
-    // SolidJS props-object pattern. Unblocked by quoting hyphenated child
-    // attribute names in `render_child` (`'data-slot' => ...`), declaring +
-    // `defined`-guarding inherited props-object accesses (`$id` / `$disabled`
-    // / `$className`), and seeding module-const + `.join()` values into
-    // `extractSsrDefaults` so the `classes` memo resolves to the full class
-    // string. `toggle`/`switch` share the inherited-attr fix but stay skipped
-    // on an additional `Record[key]`-in-memo-className blocker.
+    // #1467 Phase 2b `site/ui` primitives still pending cross-adapter parity
+    // (label / input / textarea / checkbox now participate):
+    //   toggle / switch — the reactive `classes` memo interpolates
+    //     `Record<T,string>[variant|size]` lookups, which have no SSR
+    //     lowering yet (known limitation).
+    //   kbd — multi-export source (Kbd / KbdGroup); the harness renders the
+    //     last-registered export rather than the pinned Kbd.
     'toggle',
     'switch',
     'kbd',

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -145,6 +145,17 @@ function parsePureStringLiteral(source: string): string | null {
   return null
 }
 
+/**
+ * (#checkbox) Quote a `render_child` named-arg / hashref key when it isn't a
+ * bare Perl identifier. A JSX attribute name like `data-slot` would otherwise
+ * emit `data-slot => '...'`, which Perl parses as the subtraction
+ * `data - slot`. Identifier-safe names (`className`, `size`, `_bf_slot`) pass
+ * through unquoted to keep the generated template readable.
+ */
+function perlHashKey(name: string): string {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(name) ? name : `'${name.replace(/'/g, "\\'")}'`
+}
+
 export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRenderCtx> {
   name = 'mojolicious'
   extension = '.html.ep'
@@ -199,6 +210,14 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
    */
   private moduleStringConsts: Map<string, string> = new Map()
   /**
+   * Full local-constant metadata from the entry IR, kept so spread
+   * lowering can resolve a bare-identifier spread (`{...sizeAttrs}`) to
+   * its initializer text and a `Record[propKey]` spread value to the
+   * module-const object literal it indexes (#checkbox / icon). Populated
+   * at `generate()` entry alongside `moduleStringConsts`.
+   */
+  private localConstants: IRMetadata['localConstants'] = []
+  /**
    * Names currently bound by an enclosing loop body — the `my $<param>` and
    * `my $<index>` bindings `renderLoop` introduces — ref-counted so nested
    * loops compose. `resolveModuleStringConst` consults this so a loop
@@ -233,9 +252,87 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     }
   }
 
+  /**
+   * (#checkbox) Enumerate inherited-attribute accesses for the SolidJS
+   * props-object pattern, appending any `props.<name>` the component reads but
+   * that isn't in `propsParams` (inherited `ButtonHTMLAttributes` members like
+   * `className` / `id` / `disabled`). Mutates `ir.metadata.propsParams` in
+   * place so `nullableOptionalProps` (and the template emission) treat them
+   * uniformly. Idempotent. See the Go adapter's identically-named method.
+   *
+   * Types: a bare-reference attribute (`id={props.id}`) → `unknown` (no
+   * default → guarded with Perl `defined`, so the attribute is omitted when
+   * the caller doesn't pass it — Hono parity); a boolean attribute
+   * (`disabled`) → `boolean`; otherwise (`className`) → `string`.
+   */
+  private augmentInheritedPropAccesses(ir: ComponentIR): void {
+    const propsObj = ir.metadata.propsObjectName
+    if (!propsObj) return
+    const existing = new Set(ir.metadata.propsParams.map(p => p.name))
+
+    const accessed = new Set<string>()
+    const bareRefProps = new Set<string>()
+    const booleanAttrProps = new Set<string>()
+    const accessRe = new RegExp(`(?:^|[^\\w$.])${propsObj}\\.([A-Za-z_$][\\w$]*)`, 'g')
+    const scan = (s: string | undefined): void => {
+      if (!s) return
+      for (const m of s.matchAll(accessRe)) accessed.add(m[1])
+    }
+    for (const memo of ir.metadata.memos) scan(memo.computation)
+    for (const sig of ir.metadata.signals) scan(sig.initialValue)
+    for (const stmt of ir.metadata.initStatements ?? []) scan(stmt.body)
+
+    const prefix = `${propsObj}.`
+    const walk = (node: unknown): void => {
+      if (!node || typeof node !== 'object') return
+      const el = node as {
+        attrs?: Array<{ name: string; value?: { kind?: string; expr?: string; presenceOrUndefined?: boolean } }>
+        children?: unknown[]
+      }
+      for (const attr of el.attrs ?? []) {
+        const v = attr.value
+        if (v?.kind === 'expression' && typeof v.expr === 'string') {
+          scan(v.expr)
+          const expr = v.expr.trim()
+          if (isBooleanAttr(attr.name) || v.presenceOrUndefined) {
+            const m = expr.match(new RegExp(`^${propsObj}\\.([A-Za-z_$][\\w$]*)`))
+            if (m) booleanAttrProps.add(m[1])
+          } else if (expr.startsWith(prefix)) {
+            const rest = expr.slice(prefix.length)
+            if (/^[A-Za-z_$][\w$]*$/.test(rest)) bareRefProps.add(rest)
+          }
+        }
+      }
+      for (const child of el.children ?? []) {
+        const c = child as { element?: unknown }
+        walk(c.element ?? child)
+      }
+    }
+    walk(ir.root)
+
+    for (const name of accessed) {
+      if (existing.has(name)) continue
+      const type: TypeInfo = booleanAttrProps.has(name)
+        ? { kind: 'primitive', raw: 'boolean', primitive: 'boolean' }
+        : bareRefProps.has(name)
+          ? { kind: 'unknown', raw: 'unknown' }
+          : { kind: 'primitive', raw: 'string', primitive: 'string' }
+      ir.metadata.propsParams.push({ name, type, optional: true })
+      existing.add(name)
+    }
+  }
+
   generate(ir: ComponentIR, options?: AdapterGenerateOptions): AdapterOutput {
     this.componentName = ir.metadata.componentName
     this.propsObjectName = ir.metadata.propsObjectName ?? null
+    // (#checkbox) Enumerate inherited-attribute accesses for the props-object
+    // pattern (`function Checkbox(props: CheckboxProps)`) before deriving
+    // `nullableOptionalProps`, so a bare optional attribute like
+    // `id={props.id}` gets the Perl `defined`-guard (Hono-style omission).
+    // Mirrors the Go adapter's `augmentInheritedPropAccesses`. The harness
+    // separately declares the matching stash vars (Pass-1 IR serialization
+    // happens before `generate`, so this mutation doesn't reach it).
+    this.augmentInheritedPropAccesses(ir)
     this.propsParams = ir.metadata.propsParams.map(p => ({ name: p.name }))
     // No-destructure-default props → `undef` when the caller omits them
     // → guard their bare-reference attribute emission with Perl `defined`
@@ -277,6 +374,7 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       if (isStringTypeInfo(p.type)) this.stringValueNames.add(p.name)
     }
     this.moduleStringConsts = this.collectModuleStringConsts(ir.metadata.localConstants)
+    this.localConstants = ir.metadata.localConstants ?? []
     this.loopBoundNames.clear()
     this.errors = []
     this.childrenCaptureCounter = 0
@@ -808,7 +906,7 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
    * `render_child` named-arg list.
    */
   private readonly componentPropEmitter: AttrValueEmitter = {
-    emitLiteral: (value, name) => `${name} => '${value.value}'`,
+    emitLiteral: (value, name) => `${perlHashKey(name)} => '${value.value}'`,
     emitExpression: (value, name) => {
       // The IR producer collapses component-prop `template` kinds
       // into `expression` for client-runtime reasons but preserves
@@ -817,9 +915,9 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       // `${MAP[KEY]}` shapes (the JS object literal leaks into the
       // Perl template).
       if (value.parts) {
-        return `${name} => ${this.convertTemplateLiteralPartsToPerl(value.parts)}`
+        return `${perlHashKey(name)} => ${this.convertTemplateLiteralPartsToPerl(value.parts)}`
       }
-      return `${name} => ${this.convertExpressionToPerl(value.expr)}`
+      return `${perlHashKey(name)} => ${this.convertExpressionToPerl(value.expr)}`
     },
     emitSpread: (value) => {
       // Perl has no JS-style spread — emit the source as a hash
@@ -832,9 +930,9 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       return perlExpr.startsWith('%') ? perlExpr : `%{${perlExpr}}`
     },
     emitTemplate: (value, name) =>
-      `${name} => ${this.convertTemplateLiteralPartsToPerl(value.parts)}`,
-    emitBooleanAttr: (_value, name) => `${name} => 1`,
-    emitBooleanShorthand: (_value, name) => `${name} => 1`,
+      `${perlHashKey(name)} => ${this.convertTemplateLiteralPartsToPerl(value.parts)}`,
+    emitBooleanAttr: (_value, name) => `${perlHashKey(name)} => 1`,
+    emitBooleanShorthand: (_value, name) => `${perlHashKey(name)} => 1`,
     // JSX children flow through Mojo's `begin %>…<% end` capture
     // below; they're not part of the named-arg list.
     emitJsxChildren: () => '',
@@ -991,10 +1089,19 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       // exprs, calls, concrete/defaulted props, and boolean attrs are
       // unaffected and still emit unconditionally.
       const bareId = value.expr.trim()
+      // Normalize a props-object access (`props.id`) to its bare prop name
+      // (`id`) so the nullable-optional set — keyed by bare name — matches the
+      // SolidJS props-object pattern, not just destructured params (#checkbox
+      // `id={props.id}`).
+      const normalizedBareId =
+        this.propsObjectName && bareId.startsWith(`${this.propsObjectName}.`)
+          ? bareId.slice(this.propsObjectName.length + 1)
+          : bareId
       if (
         !isBooleanAttr(name) &&
         !value.presenceOrUndefined &&
-        this.nullableOptionalProps.has(bareId)
+        /^[A-Za-z_$][\w$]*$/.test(normalizedBareId) &&
+        this.nullableOptionalProps.has(normalizedBareId)
       ) {
         const perl = this.convertExpressionToPerl(value.expr)
         const body =
@@ -1086,6 +1193,26 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       const ternaryHashref = this.conditionalSpreadToPerl(trimmed)
       if (ternaryHashref !== null) {
         return `<%== bf->spread_attrs(${ternaryHashref}) %>`
+      }
+      // Function-scope local const holding a conditional inline-object
+      //   `const sizeAttrs = size ? {…} : {}` then `{...sizeAttrs}`
+      // (#checkbox / icon). Resolve the bare identifier to its
+      // initializer text and route through the same conditional-spread
+      // lowering. Only function-scope (`!isModule`) consts whose value is
+      // NOT itself a bare identifier (loop guard) are considered.
+      if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(trimmed)) {
+        const localConst = this.localConstants.find(
+          c => c.name === trimmed && !c.isModule,
+        )
+        if (localConst?.value !== undefined) {
+          const initTrimmed = localConst.value.trim()
+          if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(initTrimmed)) {
+            const resolved = this.conditionalSpreadToPerl(initTrimmed)
+            if (resolved !== null) {
+              return `<%== bf->spread_attrs(${resolved}) %>`
+            }
+          }
+        }
       }
       const perlExpr = this.convertExpressionToPerl(value.expr)
       return `<%== bf->spread_attrs(${perlExpr}) %>`
@@ -1437,10 +1564,82 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       } else {
         return null
       }
-      const valPerl = this.convertExpressionToPerl(prop.initializer.getText(sf))
+      const initNode = (() => {
+        let n: ts.Expression = prop.initializer
+        while (ts.isParenthesizedExpression(n)) n = n.expression
+        return n
+      })()
+      const indexed = this.recordIndexAccessToPerl(initNode)
+      const valPerl =
+        indexed !== null
+          ? indexed
+          : this.convertExpressionToPerl(prop.initializer.getText(sf))
       entries.push(`'${key.replace(/'/g, "\\'")}' => ${valPerl}`)
     }
     return entries.length === 0 ? '{}' : `{ ${entries.join(', ')} }`
+  }
+
+  /**
+   * Lower a spread-object VALUE of the form `IDENT[KEY]` where:
+   *   - `IDENT` resolves via `localConstants` to a MODULE-scope object
+   *     literal whose property values are all scalar (number/string)
+   *     literals under static (string-literal or identifier) keys
+   *     (a `Record<staticKeys, scalar>` map like `sizeMap`), AND
+   *   - `KEY` is a bare identifier that is a prop.
+   * Emits an inline indexed Perl hashref:
+   *   `{ 'sm' => 16, 'md' => 20, ... }->{$size}`
+   *
+   * Returns the Perl string when convertible, else `null` so the caller
+   * falls back to its normal value lowering (which records BF101 for an
+   * unsupported shape). Mirror of the Go adapter's `recordIndexAccessToGoMap`.
+   */
+  private recordIndexAccessToPerl(val: ts.Expression): string | null {
+    if (!ts.isElementAccessExpression(val)) return null
+    const obj = val.expression
+    const arg = val.argumentExpression
+    if (!ts.isIdentifier(obj) || !ts.isIdentifier(arg)) return null
+    // KEY must be a prop.
+    if (!this.propsParams.some(p => p.name === arg.text)) return null
+    // IDENT must resolve to a module-scope object-literal const.
+    const constInfo = this.localConstants.find(
+      c => c.name === obj.text && c.isModule,
+    )
+    if (constInfo?.value === undefined) return null
+    const sf = ts.createSourceFile(
+      '__rec.ts', `(${constInfo.value})`, ts.ScriptTarget.Latest, true,
+    )
+    const stmt = sf.statements[0]
+    if (!stmt || !ts.isExpressionStatement(stmt)) return null
+    let parsed: ts.Expression = stmt.expression
+    while (ts.isParenthesizedExpression(parsed)) parsed = parsed.expression
+    if (!ts.isObjectLiteralExpression(parsed)) return null
+    const entries: string[] = []
+    for (const prop of parsed.properties) {
+      if (!ts.isPropertyAssignment(prop)) return null
+      let mapKey: string
+      if (ts.isIdentifier(prop.name)) {
+        mapKey = prop.name.text
+      } else if (
+        ts.isStringLiteral(prop.name) ||
+        ts.isNoSubstitutionTemplateLiteral(prop.name)
+      ) {
+        mapKey = prop.name.text
+      } else {
+        return null
+      }
+      let v: ts.Expression = prop.initializer
+      while (ts.isParenthesizedExpression(v)) v = v.expression
+      let mapVal: string
+      if (ts.isNumericLiteral(v)) {
+        mapVal = v.text
+      } else if (ts.isStringLiteral(v) || ts.isNoSubstitutionTemplateLiteral(v)) {
+        mapVal = `'${v.text.replace(/'/g, "\\'")}'`
+      } else {
+        return null
+      }
+      entries.push(`'${mapKey.replace(/'/g, "\\'")}' => ${mapVal}`)
+    }
+    return `{ ${entries.join(', ')} }->{$${arg.text}}`
   }
 
 

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -47,6 +47,8 @@ import {
   emitParsedExpr,
   emitIRNode,
   emitAttrValue,
+  augmentInheritedPropAccesses,
+  parseRecordIndexAccess,
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr } from './boolean-result'
 
@@ -252,76 +254,6 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     }
   }
 
-  /**
-   * (#checkbox) Enumerate inherited-attribute accesses for the SolidJS
-   * props-object pattern, appending any `props.<name>` the component reads but
-   * that isn't in `propsParams` (inherited `ButtonHTMLAttributes` members like
-   * `className` / `id` / `disabled`). Mutates `ir.metadata.propsParams` in
-   * place so `nullableOptionalProps` (and the template emission) treat them
-   * uniformly. Idempotent. See the Go adapter's identically-named method.
-   *
-   * Types: a bare-reference attribute (`id={props.id}`) → `unknown` (no
-   * default → guarded with Perl `defined`, so the attribute is omitted when
-   * the caller doesn't pass it — Hono parity); a boolean attribute
-   * (`disabled`) → `boolean`; otherwise (`className`) → `string`.
-   */
-  private augmentInheritedPropAccesses(ir: ComponentIR): void {
-    const propsObj = ir.metadata.propsObjectName
-    if (!propsObj) return
-    const existing = new Set(ir.metadata.propsParams.map(p => p.name))
-
-    const accessed = new Set<string>()
-    const bareRefProps = new Set<string>()
-    const booleanAttrProps = new Set<string>()
-    const accessRe = new RegExp(`(?:^|[^\\w$.])${propsObj}\\.([A-Za-z_$][\\w$]*)`, 'g')
-    const scan = (s: string | undefined): void => {
-      if (!s) return
-      for (const m of s.matchAll(accessRe)) accessed.add(m[1])
-    }
-    for (const memo of ir.metadata.memos) scan(memo.computation)
-    for (const sig of ir.metadata.signals) scan(sig.initialValue)
-    for (const stmt of ir.metadata.initStatements ?? []) scan(stmt.body)
-
-    const prefix = `${propsObj}.`
-    const walk = (node: unknown): void => {
-      if (!node || typeof node !== 'object') return
-      const el = node as {
-        attrs?: Array<{ name: string; value?: { kind?: string; expr?: string; presenceOrUndefined?: boolean } }>
-        children?: unknown[]
-      }
-      for (const attr of el.attrs ?? []) {
-        const v = attr.value
-        if (v?.kind === 'expression' && typeof v.expr === 'string') {
-          scan(v.expr)
-          const expr = v.expr.trim()
-          if (isBooleanAttr(attr.name) || v.presenceOrUndefined) {
-            const m = expr.match(new RegExp(`^${propsObj}\\.([A-Za-z_$][\\w$]*)`))
-            if (m) booleanAttrProps.add(m[1])
-          } else if (expr.startsWith(prefix)) {
-            const rest = expr.slice(prefix.length)
-            if (/^[A-Za-z_$][\w$]*$/.test(rest)) bareRefProps.add(rest)
-          }
-        }
-      }
-      for (const child of el.children ?? []) {
-        const c = child as { element?: unknown }
-        walk(c.element ?? child)
-      }
-    }
-    walk(ir.root)
-
-    for (const name of accessed) {
-      if (existing.has(name)) continue
-      const type: TypeInfo = booleanAttrProps.has(name)
-        ? { kind: 'primitive', raw: 'boolean', primitive: 'boolean' }
-        : bareRefProps.has(name)
-          ? { kind: 'unknown', raw: 'unknown' }
-          : { kind: 'primitive', raw: 'string', primitive: 'string' }
-      ir.metadata.propsParams.push({ name, type, optional: true })
-      existing.add(name)
-    }
-  }
-
   generate(ir: ComponentIR, options?: AdapterGenerateOptions): AdapterOutput {
     this.componentName = ir.metadata.componentName
     this.propsObjectName = ir.metadata.propsObjectName ?? null
@@ -329,10 +261,10 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     // pattern (`function Checkbox(props: CheckboxProps)`) before deriving
     // `nullableOptionalProps`, so a bare optional attribute like
     // `id={props.id}` gets the Perl `defined`-guard (Hono-style omission).
-    // Mirrors the Go adapter's `augmentInheritedPropAccesses`. The harness
-    // separately declares the matching stash vars (Pass-1 IR serialization
-    // happens before `generate`, so this mutation doesn't reach it).
-    this.augmentInheritedPropAccesses(ir)
+    // Shared with the Go adapter (single source of truth in `@barefootjs/jsx`).
+    // The harness separately declares the matching stash vars (Pass-1 IR
+    // serialization happens before `generate`, so this mutation doesn't reach it).
+    augmentInheritedPropAccesses(ir)
     this.propsParams = ir.metadata.propsParams.map(p => ({ name: p.name }))
     // No-destructure-default props → `undef` when the caller omits them
     // → guard their bare-reference attribute emission with Perl `defined`
@@ -1594,52 +1526,17 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
    * unsupported shape). Mirror of the Go adapter's `recordIndexAccessToGoMap`.
    */
   private recordIndexAccessToPerl(val: ts.Expression): string | null {
-    if (!ts.isElementAccessExpression(val)) return null
-    const obj = val.expression
-    const arg = val.argumentExpression
-    if (!ts.isIdentifier(obj) || !ts.isIdentifier(arg)) return null
-    // KEY must be a prop.
-    if (!this.propsParams.some(p => p.name === arg.text)) return null
-    // IDENT must resolve to a module-scope object-literal const.
-    const constInfo = this.localConstants.find(
-      c => c.name === obj.text && c.isModule,
-    )
-    if (constInfo?.value === undefined) return null
-    const sf = ts.createSourceFile(
-      '__rec.ts', `(${constInfo.value})`, ts.ScriptTarget.Latest, true,
-    )
-    const stmt = sf.statements[0]
-    if (!stmt || !ts.isExpressionStatement(stmt)) return null
-    let parsed: ts.Expression = stmt.expression
-    while (ts.isParenthesizedExpression(parsed)) parsed = parsed.expression
-    if (!ts.isObjectLiteralExpression(parsed)) return null
-    const entries: string[] = []
-    for (const prop of parsed.properties) {
-      if (!ts.isPropertyAssignment(prop)) return null
-      let mapKey: string
-      if (ts.isIdentifier(prop.name)) {
-        mapKey = prop.name.text
-      } else if (
-        ts.isStringLiteral(prop.name) ||
-        ts.isNoSubstitutionTemplateLiteral(prop.name)
-      ) {
-        mapKey = prop.name.text
-      } else {
-        return null
-      }
-      let v: ts.Expression = prop.initializer
-      while (ts.isParenthesizedExpression(v)) v = v.expression
-      let mapVal: string
-      if (ts.isNumericLiteral(v)) {
-        mapVal = v.text
-      } else if (ts.isStringLiteral(v) || ts.isNoSubstitutionTemplateLiteral(v)) {
-        mapVal = `'${v.text.replace(/'/g, "\\'")}'`
-      } else {
-        return null
-      }
-      entries.push(`'${mapKey.replace(/'/g, "\\'")}' => ${mapVal}`)
-    }
-    return `{ ${entries.join(', ')} }->{$${arg.text}}`
+    // Shared structural parse (single source of truth in `@barefootjs/jsx`);
+    // this wrapper only does the Perl-specific emit (single-quote escaping)
+    // from the structured result.
+    const parsed = parseRecordIndexAccess(val, this.localConstants, this.propsParams)
+    if (!parsed) return null
+    const entries = parsed.entries.map(e => {
+      const mapVal =
+        e.value.kind === 'number' ? e.value.text : `'${e.value.text.replace(/'/g, "\\'")}'`
+      return `'${e.key.replace(/'/g, "\\'")}' => ${mapVal}`
+    })
+    return `{ ${entries.join(', ')} }->{$${parsed.indexPropName}}`
   }
 
 

--- a/packages/adapter-mojolicious/src/test-render.ts
+++ b/packages/adapter-mojolicious/src/test-render.ts
@@ -433,6 +433,26 @@ function buildPerlProps(
     entries.push(`${param.name} => undef`)
   }
 
+  // (#checkbox) SolidJS props-object pattern: `function Checkbox(props:
+  // CheckboxProps)` only enumerates `CheckboxProps`'s own members in
+  // `propsParams`; inherited `ButtonHTMLAttributes` members the component
+  // reads as bare template vars (`$id`, `$disabled`, `$className`) are not.
+  // The generated template references them, so the stash must declare them or
+  // Perl strict mode aborts with `Global symbol "$id" requires explicit
+  // package name`. Scan the IR for `props.<name>` accesses and seed any not
+  // already declared (and not supplied by the caller below) as `undef`.
+  // Mirrors the Go adapter's `augmentInheritedPropAccesses`.
+  if (ir.metadata.propsObjectName) {
+    const propsObj = ir.metadata.propsObjectName
+    const declared = new Set(ir.metadata.propsParams.map(p => p.name))
+    for (const name of collectPropsObjectAccesses(ir, propsObj)) {
+      if (declared.has(name)) continue
+      if (props && name in props) continue // emitted by the user-props loop
+      entries.push(`${name} => undef`)
+      declared.add(name)
+    }
+  }
+
   // A `{...props}` rest spread means props that aren't declared named
   // params flow through the rest bag (`bf->spread_attrs($<restPropsName>)`),
   // not their own top-level template var. Route them into the bag hashref so
@@ -522,6 +542,38 @@ function buildPerlProps(
   }
 
   return `{${entries.join(', ')}}`
+}
+
+/**
+ * (#checkbox) Collect `<propsObj>.<name>` accesses across a component's memos,
+ * signal initializers, init statements, and template attribute expressions —
+ * the inherited-attribute reads (`props.className`, `props.id`, `props.disabled`)
+ * a SolidJS props-object component makes but that aren't enumerated in
+ * `propsParams`. Used to declare matching stash variables.
+ */
+function collectPropsObjectAccesses(ir: ComponentIR, propsObj: string): Set<string> {
+  const out = new Set<string>()
+  const re = new RegExp(`(?:^|[^\\w$.])${propsObj}\\.([A-Za-z_$][\\w$]*)`, 'g')
+  const scan = (s: string | undefined): void => {
+    if (!s) return
+    for (const m of s.matchAll(re)) out.add(m[1])
+  }
+  for (const memo of ir.metadata.memos) scan(memo.computation)
+  for (const sig of ir.metadata.signals) scan(sig.initialValue)
+  for (const stmt of ir.metadata.initStatements ?? []) scan(stmt.body)
+  const walk = (node: unknown): void => {
+    if (!node || typeof node !== 'object') return
+    const el = node as { attrs?: Array<{ value?: { kind?: string; expr?: string } }>; children?: unknown[] }
+    for (const attr of el.attrs ?? []) {
+      if (attr.value?.kind === 'expression') scan(attr.value.expr)
+    }
+    for (const child of el.children ?? []) {
+      const c = child as { element?: unknown }
+      walk(c.element ?? child)
+    }
+  }
+  walk(ir.root)
+  return out
 }
 
 /**

--- a/packages/jsx/src/__tests__/augment-inherited-props.test.ts
+++ b/packages/jsx/src/__tests__/augment-inherited-props.test.ts
@@ -1,0 +1,97 @@
+import { describe, test, expect } from 'bun:test'
+
+import { augmentInheritedPropAccesses } from '../augment-inherited-props'
+import type { ComponentIR, IRMetadata, ParamInfo } from '../index'
+
+/**
+ * Build a minimal `ComponentIR` exercising the SolidJS props-object pattern.
+ * Only the fields `augmentInheritedPropAccesses` reads are populated; the rest
+ * are cast through `as` so the test stays focused on the scanned inputs.
+ */
+function makeIR(opts: {
+  propsObjectName: string | null
+  propsParams: ParamInfo[]
+  memos?: Array<{ computation: string }>
+  effects?: Array<{ body: string }>
+  initStatements?: Array<{ body: string }>
+  root?: unknown
+}): ComponentIR {
+  const metadata = {
+    componentName: 'Checkbox',
+    propsObjectName: opts.propsObjectName,
+    propsParams: opts.propsParams,
+    memos: opts.memos ?? [],
+    signals: [],
+    effects: opts.effects ?? [],
+    initStatements: opts.initStatements ?? [],
+  } as unknown as IRMetadata
+
+  return {
+    root: (opts.root ?? { type: 'element', tag: 'div', attrs: [], children: [] }) as never,
+    metadata,
+    errors: [],
+  } as unknown as ComponentIR
+}
+
+describe('augmentInheritedPropAccesses', () => {
+  test('adds inherited accessed props from memos, effects, and template attrs', () => {
+    const ir = makeIR({
+      propsObjectName: 'props',
+      propsParams: [{ name: 'checked', type: { kind: 'primitive', raw: 'boolean', primitive: 'boolean' }, optional: false }],
+      // className read in a classes memo → string
+      memos: [{ computation: '`base ${props.className}`' }],
+      // size read only in an effect → string (default classification)
+      effects: [{ body: 'console.log(props.size)' }],
+      root: {
+        type: 'element',
+        tag: 'button',
+        attrs: [
+          // bare-reference attribute → nillable (unknown)
+          { name: 'id', value: { kind: 'expression', expr: 'props.id' } },
+          // boolean attribute → boolean
+          { name: 'disabled', value: { kind: 'expression', expr: 'props.disabled ?? false' } },
+        ],
+        children: [],
+      },
+    })
+
+    augmentInheritedPropAccesses(ir)
+
+    const byName = new Map(ir.metadata.propsParams.map(p => [p.name, p]))
+    // Pre-existing param untouched.
+    expect(byName.get('checked')?.type.kind).toBe('primitive')
+
+    // className → string (memo / string context)
+    expect(byName.get('className')?.type).toMatchObject({ kind: 'primitive', primitive: 'string' })
+    // size → string, accessed ONLY in an effect (the intentional Mojo-unification path)
+    expect(byName.get('size')?.type).toMatchObject({ kind: 'primitive', primitive: 'string' })
+    // id → unknown (bare-reference, nillable/omittable)
+    expect(byName.get('id')?.type).toMatchObject({ kind: 'unknown' })
+    // disabled → boolean (boolean HTML attribute, even with `?? false`)
+    expect(byName.get('disabled')?.type).toMatchObject({ kind: 'primitive', primitive: 'boolean' })
+
+    // Synthetic params are marked optional.
+    for (const name of ['className', 'size', 'id', 'disabled']) {
+      expect(byName.get(name)?.optional).toBe(true)
+    }
+  })
+
+  test('is idempotent — re-running adds nothing', () => {
+    const ir = makeIR({
+      propsObjectName: 'props',
+      propsParams: [],
+      memos: [{ computation: 'props.className' }],
+    })
+    augmentInheritedPropAccesses(ir)
+    const afterFirst = ir.metadata.propsParams.length
+    augmentInheritedPropAccesses(ir)
+    expect(ir.metadata.propsParams.length).toBe(afterFirst)
+    expect(afterFirst).toBe(1)
+  })
+
+  test('no-op when there is no props-object pattern', () => {
+    const ir = makeIR({ propsObjectName: null, propsParams: [], memos: [{ computation: 'props.className' }] })
+    augmentInheritedPropAccesses(ir)
+    expect(ir.metadata.propsParams.length).toBe(0)
+  })
+})

--- a/packages/jsx/src/__tests__/ssr-defaults.test.ts
+++ b/packages/jsx/src/__tests__/ssr-defaults.test.ts
@@ -115,4 +115,28 @@ describe('extractSsrDefaults', () => {
     expect(defaults?.count).toEqual({ value: 3 })
     expect(defaults?.squared).toEqual({ value: 9 })
   })
+
+  // (#checkbox) A className memo interpolating module string consts — incl. a
+  // `[...].join(' ')` const — plus `props.className ?? ''` resolves to a
+  // concrete string so the SSR `class="..."` renders the full token list
+  // (Checkbox's `classes` memo). Without seeding module consts / evaluating
+  // `.join`, the memo collapsed to `null` and the class attribute rendered
+  // empty.
+  test('module-const + join template-literal className memo resolves to a string', () => {
+    const metadata = metadataFor(`
+      'use client'
+      import { createMemo } from '@barefootjs/client'
+      const base = 'a b'
+      const states = ['c', 'd'].join(' ')
+      function Box(props: { tone?: string }) {
+        const classes = createMemo(() => \`\${base} \${states} \${props.className ?? ''} tail\`)
+        return <button class={classes()}>x</button>
+      }
+    `)
+
+    const defaults = extractSsrDefaults(metadata)
+    // props.className is undefined → `?? ''` → '' → 'a b c d  tail' (the double
+    // space mirrors Hono's empty-className interpolation).
+    expect(defaults?.classes).toEqual({ value: 'a b c d  tail' })
+  })
 })

--- a/packages/jsx/src/augment-inherited-props.ts
+++ b/packages/jsx/src/augment-inherited-props.ts
@@ -1,0 +1,208 @@
+/**
+ * Shared adapter helpers for the SolidJS props-object pattern (#checkbox).
+ *
+ * These two functions are the SINGLE SOURCE OF TRUTH for logic that the
+ * Go-template and Mojolicious template adapters previously carried as
+ * near-identical private copies. They live in `@barefootjs/jsx` (the IR
+ * layer) so the two adapters can share one implementation; they are
+ * deliberately NOT wired into the core IR-construction pipeline — only the
+ * Go and Mojo adapters call them, so every other IR consumer (Hono, the
+ * client codegen, etc.) is unaffected.
+ */
+
+import ts from 'typescript'
+
+import type { ComponentIR, IRNode, IRElement, TypeInfo } from './types'
+import { isBooleanAttr } from './html-constants'
+
+/**
+ * (#checkbox) Enumerate inherited-attribute accesses for the SolidJS
+ * props-object pattern.
+ *
+ * `function Checkbox(props: CheckboxProps)` only lists `CheckboxProps`'s own
+ * members in `propsParams`; the inherited `ButtonHTMLAttributes` members the
+ * component actually reads (`props.className` in the classes memo, `props.id`,
+ * `props.disabled` on the root element) are never enumerated, so the generated
+ * Input/Props structs (Go) or stash vars (Mojo) have no field to bind a
+ * caller's `className: ''` / `id` / `disabled` to. This scans the component's
+ * expressions for `props.<name>` accesses (where `props` is the resolved
+ * `propsObjectName`) and appends any not-already-a-param as a synthetic prop
+ * param, with a type inferred from how the access is used:
+ *   - a boolean attribute (`disabled={props.disabled ?? false}`) → `boolean`;
+ *   - a pure bare-reference attribute (`id={props.id}`) → `unknown`
+ *     (nillable, so the attribute is omitted when unset — Hono parity);
+ *   - otherwise (`className`, read in a string memo) → `string`.
+ *
+ * Scans memos, signals, init statements, effects, and template attribute
+ * expressions. (The Mojo adapter previously omitted `effects` from its scan;
+ * unifying on the Go behaviour of also scanning `effects` is intentional — the
+ * function only ever ADDS a param, and it changes no fixture output.)
+ *
+ * Idempotent: re-running (e.g. once in `generate`, again in `generateTypes` on
+ * a round-tripped IR) is a no-op once the params are present. Mutates
+ * `ir.metadata.propsParams` in place so every downstream emitter sees one
+ * consistent param list.
+ *
+ * The single source of truth for BOTH the Go and Mojo adapters — change here,
+ * not in an adapter copy.
+ */
+export function augmentInheritedPropAccesses(ir: ComponentIR): void {
+  const propsObj = ir.metadata.propsObjectName
+  if (!propsObj) return // only the props-object pattern is affected
+
+  const existing = new Set(ir.metadata.propsParams.map(p => p.name))
+
+  // Collect bare-reference attribute exprs (`attr={props.id}`) and boolean
+  // attributes from the template so we can classify accessed props by use.
+  const bareRefProps = new Set<string>()
+  const booleanAttrProps = new Set<string>()
+  const accessed = new Set<string>()
+  const accessRe = new RegExp(`(?:^|[^\\w$.])${propsObj}\\.([A-Za-z_$][\\w$]*)`, 'g')
+  const scan = (s: string | undefined): void => {
+    if (!s) return
+    for (const m of s.matchAll(accessRe)) accessed.add(m[1])
+  }
+
+  // Memos, signals, init statements, effects: any `props.X` read.
+  for (const memo of ir.metadata.memos) scan(memo.computation)
+  for (const signal of ir.metadata.signals) scan(signal.initialValue)
+  for (const stmt of ir.metadata.initStatements ?? []) scan(stmt.body)
+  for (const eff of ir.metadata.effects ?? []) scan((eff as { body?: string }).body)
+
+  // Template attribute exprs — also note bare-ref / boolean usage.
+  const walk = (node: IRNode | undefined): void => {
+    if (!node) return
+    const el = node as unknown as IRElement
+    for (const attr of el.attrs ?? []) {
+      const v = attr.value as { kind?: string; expr?: string; presenceOrUndefined?: boolean }
+      if (v?.kind === 'expression' && typeof v.expr === 'string') {
+        scan(v.expr)
+        const expr = v.expr.trim()
+        const prefix = `${propsObj}.`
+        // A boolean HTML attribute (`disabled={props.disabled ?? false}`)
+        // marks the referenced prop as boolean even when wrapped in a
+        // `?? false` default — extract the prop name from the expr.
+        if (isBooleanAttr(attr.name) || v.presenceOrUndefined) {
+          const m = expr.match(new RegExp(`^${propsObj}\\.([A-Za-z_$][\\w$]*)`))
+          if (m) booleanAttrProps.add(m[1])
+        } else if (expr.startsWith(prefix)) {
+          const rest = expr.slice(prefix.length)
+          // A pure bare-reference attribute (`id={props.id}`) → nillable.
+          if (/^[A-Za-z_$][\w$]*$/.test(rest)) bareRefProps.add(rest)
+        }
+      }
+    }
+    for (const child of (el.children ?? []) as unknown[]) {
+      const c = child as { element?: IRNode }
+      walk((c.element ?? child) as IRNode)
+    }
+  }
+  walk(ir.root)
+
+  for (const name of accessed) {
+    if (existing.has(name)) continue
+    let raw: string
+    if (booleanAttrProps.has(name)) raw = 'boolean'
+    else if (bareRefProps.has(name)) raw = 'unknown' // → interface{} (nillable, omittable)
+    else raw = 'string' // read in a memo / string context (e.g. className)
+    const type: TypeInfo =
+      raw === 'boolean'
+        ? { kind: 'primitive', raw: 'boolean', primitive: 'boolean' }
+        : raw === 'string'
+          ? { kind: 'primitive', raw: 'string', primitive: 'string' }
+          : { kind: 'unknown', raw: 'unknown' }
+    ir.metadata.propsParams.push({ name, type, optional: true })
+    existing.add(name)
+  }
+}
+
+/** A minimal `{ name }` shape — both adapters pass their own param/const lists. */
+interface NamedConst {
+  name: string
+  value?: string
+  isModule?: boolean
+}
+
+/** A parsed `Record<staticKeys, scalar>[propKey]` map entry. */
+export interface RecordIndexEntry {
+  key: string
+  value: { kind: 'number' | 'string'; text: string }
+}
+
+/** The structured result of a `Record<staticKeys, scalar>[propKey]` access. */
+export interface RecordIndexAccess {
+  /** The bare prop identifier used as the index key (`size` in `sizeMap[size]`). */
+  indexPropName: string
+  /** The map's entries in source order — each a static key + scalar literal value. */
+  entries: RecordIndexEntry[]
+}
+
+/**
+ * Structural parse of a spread-object VALUE of the form `IDENT[KEY]` where:
+ *   - `IDENT` resolves via `localConstants` to a MODULE-scope (`isModule`)
+ *     object literal whose every property has a static (string-literal or
+ *     identifier) key and a scalar (number or string) literal value
+ *     (a `Record<staticKeys, scalar>` map like `sizeMap`), AND
+ *   - `KEY` is a bare identifier that is a prop (`propsParams`).
+ *
+ * Returns the structured `{ indexPropName, entries }` when convertible, else
+ * `null` for any unsupported shape (non-element-access, non-identifier
+ * object/index, non-prop index, non-module const, non-object-literal const,
+ * computed/spread/dynamic key, or non-scalar value) so the caller falls back
+ * to its normal lowering / BF101.
+ *
+ * The single source of truth for BOTH adapters' `recordIndexAccessTo*` emitters
+ * — only the final language-specific emit differs (Go inline `map[string]any{…}
+ * [fmt.Sprint(in.Field)]`; Mojo `{ … }->{$key}`). (#checkbox / icon `sizeMap[size]`.)
+ */
+export function parseRecordIndexAccess(
+  val: ts.Expression,
+  localConstants: readonly NamedConst[],
+  propsParams: ReadonlyArray<{ name: string }>,
+): RecordIndexAccess | null {
+  if (!ts.isElementAccessExpression(val)) return null
+  const obj = val.expression
+  const arg = val.argumentExpression
+  if (!ts.isIdentifier(obj) || !ts.isIdentifier(arg)) return null
+  // KEY must be a prop.
+  if (!propsParams.some(p => p.name === arg.text)) return null
+  // IDENT must resolve to a module-scope object-literal const.
+  const constInfo = localConstants.find(c => c.name === obj.text && c.isModule)
+  if (constInfo?.value === undefined) return null
+
+  const sf = ts.createSourceFile(
+    '__rec.ts', `(${constInfo.value})`, ts.ScriptTarget.Latest, /* setParentNodes */ true,
+  )
+  if (sf.statements.length !== 1) return null
+  const stmt = sf.statements[0]
+  if (!ts.isExpressionStatement(stmt)) return null
+  let parsed: ts.Expression = stmt.expression
+  while (ts.isParenthesizedExpression(parsed)) parsed = parsed.expression
+  if (!ts.isObjectLiteralExpression(parsed)) return null
+
+  const entries: RecordIndexEntry[] = []
+  for (const prop of parsed.properties) {
+    if (!ts.isPropertyAssignment(prop)) return null
+    let key: string
+    if (ts.isIdentifier(prop.name)) {
+      key = prop.name.text
+    } else if (
+      ts.isStringLiteral(prop.name) ||
+      ts.isNoSubstitutionTemplateLiteral(prop.name)
+    ) {
+      key = prop.name.text
+    } else {
+      return null
+    }
+    let v: ts.Expression = prop.initializer
+    while (ts.isParenthesizedExpression(v)) v = v.expression
+    if (ts.isNumericLiteral(v)) {
+      entries.push({ key, value: { kind: 'number', text: v.text } })
+    } else if (ts.isStringLiteral(v) || ts.isNoSubstitutionTemplateLiteral(v)) {
+      entries.push({ key, value: { kind: 'string', text: v.text } })
+    } else {
+      return null
+    }
+  }
+  return { indexPropName: arg.text, entries }
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -280,6 +280,10 @@ export type { WrapReason } from './ir-to-client-js/reactivity'
 // HTML constants
 export { BOOLEAN_ATTRS, isBooleanAttr } from './html-constants'
 
+// Shared props-object-pattern helpers for the Go / Mojo template adapters
+export { augmentInheritedPropAccesses, parseRecordIndexAccess } from './augment-inherited-props'
+export type { RecordIndexAccess, RecordIndexEntry } from './augment-inherited-props'
+
 // HTML element attribute types
 export type {
   // Event types

--- a/packages/jsx/src/ssr-defaults.ts
+++ b/packages/jsx/src/ssr-defaults.ts
@@ -121,6 +121,20 @@ export function extractSsrDefaults(metadata: IRMetadata): Record<string, SsrDefa
   // fed into the bindings map so subsequent memos can reference earlier
   // signals (Counter's `doubled = createMemo(() => count() * 2)`).
   const bindings: Record<string, EvalResult> = {}
+
+  // (#checkbox) Seed module-scope constants so a memo template-literal that
+  // references them resolves to a concrete string. Checkbox's `classes` memo
+  // interpolates `baseClasses` / `focusClasses` / `errorClasses` (pure string
+  // consts) and `stateClasses` (`[...].join(' ')`). Without these in scope the
+  // memo evaluates to `null` and the SSR `class="..."` renders empty, diverging
+  // from Hono. Only module-scope consts are seeded (component-scope locals can
+  // depend on signals/props and are evaluated lazily elsewhere).
+  for (const c of metadata.localConstants ?? []) {
+    if (!c.isModule || c.value === undefined) continue
+    if (c.name in bindings) continue
+    const v = tryStaticEval(c.value, { bindings, propsLike })
+    if (v !== UNRESOLVED) bindings[c.name] = v
+  }
   for (const sig of metadata.signals) {
     if (!sig.getter || sig.isModule) continue
     const value = tryStaticEval(sig.initialValue, { bindings, propsLike })
@@ -263,6 +277,25 @@ function evalNode(node: ts.Expression, ctx: EvalContext): EvalResult {
       node.expression.text in ctx.bindings
     ) {
       return ctx.bindings[node.expression.text]
+    }
+    // `<array>.join(<sep?>)` — evaluate when the receiver resolves to an array
+    // and the separator (default `,`) is a string. Covers `stateClasses =
+    // [...].join(' ')` (#checkbox). Other array methods stay unresolved.
+    if (
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === 'join'
+    ) {
+      const recv = evalNode(node.expression.expression, ctx)
+      if (Array.isArray(recv)) {
+        let sep = ','
+        if (node.arguments.length >= 1) {
+          const sepVal = evalNode(node.arguments[0], ctx)
+          if (typeof sepVal !== 'string') return UNRESOLVED
+          sep = sepVal
+        }
+        return recv.map(x => (x === null || x === undefined ? '' : `${x}`)).join(sep)
+      }
+      return UNRESOLVED
     }
     return UNRESOLVED
   }


### PR DESCRIPTION
## Summary

Brings the Phase 2b `checkbox` primitive into **Go + Mojo adapter conformance** (it was skipped). `checkbox` is the hardest of the Phase 2b fixtures: it composes the `CheckIcon` sibling from `ui/components/ui/icon` AND uses the SolidJS props-object pattern, so it needed both new spread lowering and several cross-component / props-object fixes.

### Spread lowering (both adapters)
- **Local-const conditional spread** — a function-scope const holding a `cond ? {…} : {}` ternary, spread as a bare identifier (`const sizeAttrs = size ? {…} : {}; <svg {...sizeAttrs} />`), resolves to its initializer and routes through the conditional-spread lowering added in #1752. Loop-guarded against identifier aliases.
- **`Record<staticKeys,scalar>[propKey]` spread value** — `IDENT[KEY]` where `IDENT` is a module `Record` object literal and `KEY` a prop lowers to an inline indexed map: Go `map[string]any{"sm": 16, …}[fmt.Sprint(in.Size)]` (adds the `"fmt"` import only when used), Mojo `{ 'sm' => 16, … }->{$size}`. Unsupported shapes still `BF101`.

Together these make the `CheckIcon` sibling (`const sizeAttrs = size ? { width: sizeMap[size], height: sizeMap[size] } : {}`) compile standalone.

### Checkbox end-to-end blockers
- **Go test harness** — re-adds stdlib imports a merged sibling type block needs (`"fmt"`), and emits only the child components a parent **transitively references** (a child file exporting 30+ icons no longer drags in dead components whose codegen wouldn't compile, e.g. an icon's `strokePaths['chevron-down']` → invalid `{{.StrokePaths.Chevron-down}}`).
- **Cross-component child rest-bag routing** — a child attr whose name isn't a declared param / valid identifier (`<CheckIcon data-slot="checkbox-indicator" />`) routes into the child's rest bag (Go `Props map[string]any` / Mojo quoted `render_child` arg) instead of an invalid `Data-slot:` field.
- **Props-object inherited-attribute enumeration** — a `function C(props: P)` component now enumerates the inherited `*HTMLAttributes` members it actually reads (`props.className`/`id`/`disabled`) as Input fields (Go) / guarded stash attrs (Mojo), so a caller's `className`/`id`/`disabled` bind and unset optionals are omitted (Hono parity). *Scoped to the props-object pattern, additive, idempotent.*
- **Template-literal `classes` memo + boolean memo SSR value** — the Go adapter inlines module string consts (incl. `[…].join(' ')`) and resolves `props.className ?? ''` for the memo's initial value, and renders a boolean memo's zero as `false`; `extractSsrDefaults` (`@barefootjs/jsx`, Mojo's SSR seed) gains module-const seeding + `.join()` evaluation (both additive, only when statically evaluable).

### Unskipped
`checkbox` removed from both `skipJsx` lists. `toggle`/`switch` **share** the inherited-attr fix but keep an additional `Record[key]`-in-memo-className blocker, so they stay skipped; `kbd` is blocked only by a CSR-skip.

### Tests
Regression tests added across all three suites (props-object enumeration, cross-component rest-bag routing, hyphenated `render_child` keys, `ssr-defaults` module-const + `.join` resolution) on top of the spread-lowering tests.

### Validation (all self-re-run, 0 fail)
- Go conformance: **459 pass / 3 skip / 0 fail** — checkbox passing
- Mojo conformance: **411 pass / 5 skip / 0 fail** — checkbox passing
- `packages/jsx` + `adapter-tests` + `client` + `shared`: **3065 tests / 0 fail**
- `tsc --noEmit` clean on go-template, mojolicious, jsx
- No snapshot regenerated; the Hono reference output is unchanged.

🤖 https://claude.ai/code/session_01UatvBGZG5csvttdtgcSf7p

---
_Generated by [Claude Code](https://claude.ai/code/session_01UatvBGZG5csvttdtgcSf7p)_