### PR TITLE
feat(integrations): Text::Xslate demo (Plack) — full-parity + deploy wiring

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,7 @@ on:
           - integrations-chi
           - integrations-nethttp
           - integrations-mojolicious
+          - integrations-xslate
 
 permissions:
   contents: read
@@ -439,5 +440,46 @@ jobs:
       # ubuntu-latest ships with a running Docker daemon by default.
       - name: Deploy to Cloudflare Workers
         run: cd integrations/mojolicious && bunx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+  deploy-integrations-xslate:
+    if: >-
+      github.event_name == 'workflow_dispatch' && (github.event.inputs.site == 'all' || github.event.inputs.site == 'integrations' || github.event.inputs.site == 'integrations-xslate')
+      || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+
+      # Wrangler 4.x shells out to Node and requires v22+. The runner's
+      # default Node 20 makes `bunx wrangler deploy` exit immediately.
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build packages
+        run: |
+          bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/client' build
+          bun run --filter '@barefootjs/xslate' build
+
+      - name: Build integration
+        run: cd integrations/xslate && bun run build
+
+      # wrangler deploy builds the Cloudflare Container image from the
+      # integration's Dockerfile, which needs Docker on the runner.
+      # ubuntu-latest ships with a running Docker daemon by default.
+      - name: Deploy to Cloudflare Workers
+        run: cd integrations/xslate && bunx wrangler deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ packages/adapter-*/.build/
 packages/adapter-*/blib/
 packages/adapter-*/Build
 packages/adapter-*/MYMETA.*
+
+# Perl integration runtime libs (assembled by scripts/assemble-deps.ts)
+integrations/*/lib

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,6 +138,19 @@ services:
       - ./packages/adapter-perl/lib:/workspace/packages/adapter-perl/lib
       - ./packages/adapter-mojolicious/lib:/workspace/packages/adapter-mojolicious/lib
 
+  xslate:
+    build:
+      context: .
+      dockerfile: integrations/xslate/Dockerfile.dev
+    working_dir: /workspace/integrations/xslate
+    environment:
+      BASE_PATH: /integrations/xslate
+      PLACK_ENV: development
+    volumes:
+      - ./integrations/xslate:/workspace/integrations/xslate
+      - ./packages/adapter-perl/lib:/workspace/packages/adapter-perl/lib
+      - ./packages/adapter-xslate/lib:/workspace/packages/adapter-xslate/lib
+
   site-core:
     build:
       context: .

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -13,6 +13,7 @@ same JSX components on a different stack:
 | `chi` | Go / Chi | 8082 | container |
 | `nethttp` | Go / net/http (stdlib) | 8083 | container |
 | `mojolicious` | Perl / Mojolicious::Lite | 3000 (morbo default) | container |
+| `xslate` | Perl / Text::Xslate (Plack / Starman) | 3007 | container |
 | `csr` | TypeScript (no SSR) | 3002 | host (manual) |
 
 Plus `site/core` (the docs / landing / catalog site) on internal port 4001
@@ -41,6 +42,7 @@ host:                                  containers (docker compose):
                                          - chi          (golang + air)
                                          - nethttp      (golang + air)
                                          - mojolicious  (perl + morbo)
+                                         - xslate       (perl + starman)
                                          - site-core    (bun + Hono)
 ```
 
@@ -55,6 +57,7 @@ The proxy routes by path prefix:
 :4000/integrations/chi/*         → chi service
 :4000/integrations/nethttp/*     → nethttp service
 :4000/integrations/mojolicious/* → mojolicious service
+:4000/integrations/xslate/*      → xslate service
 :4000/*                          → site-core (landing / docs / catalog)
 ```
 
@@ -111,7 +114,7 @@ HONO_TARGET=http://host.docker.internal:3001 docker compose up proxy
 
 The same env var pattern works for `H3_TARGET`, `ELYSIA_TARGET`,
 `ECHO_TARGET`, `GIN_TARGET`, `CHI_TARGET`, `NETHTTP_TARGET`,
-`MOJOLICIOUS_TARGET`, and `SITE_CORE_TARGET`.
+`MOJOLICIOUS_TARGET`, `XSLATE_TARGET`, and `SITE_CORE_TARGET`.
 
 ### Why dev images are separate from `Dockerfile`
 
@@ -124,9 +127,9 @@ production image and lets dev tooling evolve independently.
 The TypeScript adapters (`hono`, `h3`, `elysia`) have **no production
 `Dockerfile`** — they deploy straight to Cloudflare Workers via
 `wrangler deploy` (Elysia uses its official Cloudflare adapter). The Go
-adapters (`echo`, `gin`, `chi`, `nethttp`) and `mojolicious` ship a
-production container image (`Dockerfile`) deployed as a Cloudflare
-Container. Every adapter still has a `Dockerfile.dev` for the local
+adapters (`echo`, `gin`, `chi`, `nethttp`) and the Perl adapters
+(`mojolicious`, `xslate`) ship a production container image (`Dockerfile`)
+deployed as a Cloudflare Container. Every adapter still has a `Dockerfile.dev` for the local
 compose network.
 
 Each Go adapter is its own Cloudflare Worker + Container, routed on the

--- a/integrations/xslate/Dockerfile
+++ b/integrations/xslate/Dockerfile
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1
+#
+# Build & runtime image for the Text::Xslate example, intended to be executed
+# inside a Cloudflare Container. Requires `bun run build` to have been run on
+# the host first so dist/ (templates, client JS, styles) and lib/ (BarefootJS
+# runtime + Xslate backend) exist alongside app.psgi.
+
+FROM perl:5.40-slim AS deps
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends make gcc libc-dev \
+ && rm -rf /var/lib/apt/lists/*
+# Install CPAN deps into a self-contained prefix the runtime stage copies whole.
+# Text::Xslate is XS (needs the compiler above); Starman is the PSGI server
+# (prefork, so the SSE routes — AI chat, dev reload — don't block other workers).
+RUN cpanm --notest --local-lib=/opt/perl-deps Text::Xslate Plack Starman
+
+FROM perl:5.40-slim
+RUN useradd -m -r -s /bin/false app
+WORKDIR /app
+
+COPY --from=deps /opt/perl-deps /opt/perl-deps
+ENV PERL5LIB=/opt/perl-deps/lib/perl5
+ENV PATH=/opt/perl-deps/bin:$PATH
+
+COPY app.psgi ./
+COPY lib ./lib
+COPY dist ./dist
+
+ENV BASE_PATH=/integrations/xslate
+ENV PLACK_ENV=production
+EXPOSE 8080
+USER app
+CMD ["starman", "--listen", ":8080", "--workers", "5", "app.psgi"]

--- a/integrations/xslate/Dockerfile.dev
+++ b/integrations/xslate/Dockerfile.dev
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+#
+# Development image for the Text::Xslate integration. app.psgi and the
+# host-built dist/ are bind-mounted in; plackup (Starman backend) restarts on
+# app.psgi / lib changes. Templates re-render on each request because the
+# dev-mode Text::Xslate cache is disabled (see app.psgi: PLACK_ENV).
+
+FROM perl:5.40-slim
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends make gcc libc-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN cpanm --notest Text::Xslate Plack Starman
+
+WORKDIR /workspace/integrations/xslate
+
+EXPOSE 3007
+
+# Starman (prefork) so the SSE routes work; plackup -R restarts on changes to
+# app.psgi and the bind-mounted runtime/backend lib.
+CMD ["plackup", "-s", "Starman", "--workers", "5", "-p", "3007", \
+     "-R", "app.psgi,lib,/workspace/packages/adapter-perl/lib,/workspace/packages/adapter-xslate/lib", \
+     "app.psgi"]

--- a/integrations/xslate/app.psgi
+++ b/integrations/xslate/app.psgi
@@ -1,0 +1,394 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use utf8;
+use feature 'signatures';
+no warnings 'experimental::signatures';
+
+# `lib` is populated by scripts/assemble-deps.ts at build time (used in the
+# container); the workspace source dirs are listed too so local dev resolves
+# without the assemble step. Either location works.
+use lib 'lib', '../../packages/adapter-perl/lib', '../../packages/adapter-xslate/lib';
+
+use Plack::Request;
+use Plack::Builder;
+use Plack::App::File;
+use JSON::PP ();
+
+use BarefootJS;
+use BarefootJS::Backend::Xslate;
+use BarefootJS::DevReload;
+
+# URL prefix the app is mounted under. Defaults to /integrations/xslate so the
+# app is deploy-ready for barefootjs.dev/integrations/xslate.
+my $BASE = $ENV{BASE_PATH} // '/integrations/xslate';
+my $DEV  = ($ENV{PLACK_ENV} // 'development') ne 'production';
+
+my $J = JSON::PP->new->canonical->allow_nonref->utf8;
+sub jbool ($v) { $v ? JSON::PP::true : JSON::PP::false }
+
+# One Text::Xslate backend renders every component from dist/templates. In dev
+# the template cache is disabled so edits picked up by `bun run build:watch`
+# render on the next request without a server restart.
+my $backend = BarefootJS::Backend::Xslate->new(
+    path           => ['dist/templates'],
+    json_encoder   => sub ($data) { $J->encode($data) },
+    xslate_options => { cache => $DEV ? 0 : 1 },
+);
+
+# ---------------------------------------------------------------------------
+# Per-session in-memory todo storage (mirrors the Mojolicious example): each
+# browser gets an opaque id via a $BASE-scoped cookie; %sessions keys on it so
+# one visitor's list is never visible to another. LRU-bounded.
+# ---------------------------------------------------------------------------
+use constant {
+    SESSION_COOKIE    => 'bf_session',
+    SESSION_TTL_SEC   => 60 * 60 * 24 * 30,
+    SESSION_STORE_MAX => 1000,
+};
+my %sessions;
+my @session_order;
+
+sub seed_todos () {
+    return [
+        { id => 1, text => 'Setup project',     done => jbool(0), editing => jbool(0) },
+        { id => 2, text => 'Create components', done => jbool(0), editing => jbool(0) },
+        { id => 3, text => 'Write tests',       done => jbool(1), editing => jbool(0) },
+    ];
+}
+
+sub new_session_id () {
+    if (open my $fh, '<:raw', '/dev/urandom') {
+        read $fh, my $bytes, 16;
+        close $fh;
+        return unpack 'H*', $bytes if length $bytes == 16;
+    }
+    return sprintf '%d-%d', time, int(rand(2**31));
+}
+
+# Returns ($session, $set_cookie_header_value_or_undef).
+sub get_session ($req) {
+    my $id = $req->cookies->{ SESSION_COOKIE() };
+    my $set_cookie;
+    if (!defined $id || !length $id) {
+        $id = new_session_id();
+        $set_cookie = sprintf(
+            '%s=%s; Path=%s; HttpOnly; SameSite=Lax; Max-Age=%d',
+            SESSION_COOKIE, $id, $BASE, SESSION_TTL_SEC,
+        );
+    }
+    if (!exists $sessions{$id}) {
+        $sessions{$id} = { todos => seed_todos(), next_id => 4 };
+        push @session_order, $id;
+        while (@session_order > SESSION_STORE_MAX) {
+            delete $sessions{ shift @session_order };
+        }
+    }
+    else {
+        @session_order = grep { $_ ne $id } @session_order;
+        push @session_order, $id;
+    }
+    return ($sessions{$id}, $set_cookie);
+}
+
+# ---------------------------------------------------------------------------
+# Rendering: build a per-request runtime, register child renderers, render the
+# component template, and wrap the result in the page layout.
+# ---------------------------------------------------------------------------
+sub rand_suffix () { return substr(sprintf('%f', rand()) =~ s/^0\.//r, 0, 6) }
+
+sub render_component ($component, %opts) {
+    my $bf = BarefootJS->new(undef, { backend => $backend });
+    my $scope_id = $component . '_' . rand_suffix();
+    $bf->_scope_id($scope_id);
+    $bf->_props($opts{props}) if $opts{props};
+
+    my $children    = $opts{children}    // {};
+    my $signal_init = $opts{signal_init} // {};
+    for my $child_name (keys %$children) {
+        my $child_template = $children->{$child_name};
+        my $child_init     = $signal_init->{$child_name};
+        $bf->register_child_renderer($child_name, sub ($props) {
+            my $child_bf = BarefootJS->new(undef, { backend => $backend });
+            # Loop children carry no _bf_slot; fall back to template + suffix so
+            # each instance gets a distinct scope id (client JS finds children
+            # by scope). Slot children pin to <parent>_<slot>.
+            my $slot_id = delete $props->{_bf_slot};
+            $child_bf->_scope_id($slot_id ? "${scope_id}_${slot_id}"
+                                          : "${child_template}_" . rand_suffix());
+            $child_bf->_is_child(1);
+            # Share the parent's script collector so a child's register_script
+            # de-dupes against the page's existing <script> set.
+            $child_bf->_scripts($bf->_scripts);
+            $child_bf->_script_seen($bf->_script_seen);
+            my %extra = $child_init ? $child_init->($props) : ();
+            return $backend->render_named($child_template, $child_bf, { %$props, %extra });
+        });
+    }
+
+    my $body = $backend->render_named($component, $bf, $opts{stash} // {});
+    return layout(
+        title     => $opts{title}   // "$component - BarefootJS",
+        heading   => $opts{heading} // '',
+        body      => $body,
+        scripts   => $bf->scripts,
+        extra_css => $opts{extra_css} // '',
+    );
+}
+
+sub layout (%a) {
+    my $heading_html = $a{heading} ? "<h1>$a{heading}</h1>" : '';
+    my $dev_snippet  = $DEV ? BarefootJS::DevReload->snippet("$BASE/_bf/reload") : '';
+    return <<"HTML";
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>$a{title}</title>
+    <link rel="stylesheet" href="$BASE/styles/tokens.css">
+    <link rel="stylesheet" href="$BASE/styles/layout.css">
+    <link rel="stylesheet" href="$BASE/styles/components.css">
+    <link rel="stylesheet" href="$BASE/styles/todo-app.css">
+    $a{extra_css}
+</head>
+<body>
+    <header class="bf-header">
+        <div class="bf-header-inner">
+            <a href="https://barefootjs.dev" class="bf-header-logo" aria-label="Barefoot.js">
+                <span class="bf-header-logo-img" role="img" aria-hidden="true"></span>
+            </a>
+            <div class="bf-header-sep"></div>
+            <nav class="bf-header-crumbs" aria-label="Breadcrumb">
+                <a href="/integrations" class="bf-header-link">Integrations</a>
+                <span class="bf-header-crumb-sep" aria-hidden="true">/</span>
+                <span class="bf-header-current" aria-current="page">Text::Xslate</span>
+            </nav>
+        </div>
+    </header>
+    $heading_html
+    <div id="app">$a{body}</div>
+    <p><a href="$BASE/">&larr; Back</a></p>
+    $a{scripts}
+    $dev_snippet
+</body>
+</html>
+HTML
+}
+
+sub html_response ($html, @extra_headers) {
+    return [
+        200,
+        ['Content-Type' => 'text/html; charset=utf-8', @extra_headers],
+        [ Encode_utf8($html) ],
+    ];
+}
+sub json_response ($data, $status = 200, @extra_headers) {
+    return [ $status, ['Content-Type' => 'application/json; charset=utf-8', @extra_headers], [ $J->encode($data) ] ];
+}
+sub Encode_utf8 ($s) { require Encode; return Encode::encode_utf8($s) }
+
+# ---------------------------------------------------------------------------
+# AI Chat dummy responses (streamed char-by-char over SSE).
+# ---------------------------------------------------------------------------
+my @ai_responses = (
+    "[Dummy response] This text is streaming one character at a time via SSE. In production, replace /api/ai-chat with a real LLM API.",
+    "[Dummy response] BarefootJS compiles JSX to Text::Xslate templates + client JS. Signals drive reactivity on any backend.",
+    "[Dummy response] SSE (Server-Sent Events) lets the server push data to the client over a single HTTP connection.",
+    "[Dummy response] The Xslate backend runs under any PSGI/Plack server — here Starman streams each character with a 30ms delay.",
+    "[Dummy response] Out-of-Order Streaming SSR and interactive SSE streaming are two different features of BarefootJS.",
+);
+
+# ---------------------------------------------------------------------------
+# Routes — PATH_INFO here is already stripped of $BASE by Plack::Builder mount.
+# ---------------------------------------------------------------------------
+my $routes = sub ($env) {
+    my $req    = Plack::Request->new($env);
+    my $path   = $req->path_info;
+    $path = '/' if $path eq '';
+    my $method = $req->method;
+
+    # --- pages ---
+    if ($method eq 'GET') {
+        return html_response(home_page()) if $path eq '/';
+
+        return html_response(render_component('Counter', heading => 'Counter Component'))
+            if $path eq '/counter';
+
+        if ($path eq '/toggle') {
+            my $items = [
+                { label => 'Setting 1', defaultOn => jbool(1) },
+                { label => 'Setting 2', defaultOn => jbool(0) },
+                { label => 'Setting 3', defaultOn => jbool(0) },
+            ];
+            return html_response(render_component('Toggle',
+                heading     => 'Toggle Component',
+                children    => { toggle_item => 'ToggleItem' },
+                signal_init => { toggle_item => sub ($p) { (on => ($p->{defaultOn} ? 1 : 0)) } },
+                props       => { toggleItems => $items },
+                stash       => { toggleItems => $items },
+            ));
+        }
+
+        return html_response(render_component('Form',
+            heading => 'Form Example', props => {}, stash => { accepted => 0 }))
+            if $path eq '/form';
+
+        return html_response(render_component('ReactiveProps',
+            heading  => 'Reactive Props Test',
+            children => { reactive_child => 'ReactiveChild' },
+            props    => {}, stash => { count => 0, doubled => 0 }))
+            if $path eq '/reactive-props';
+
+        if ($path eq '/conditional-return' || $path eq '/conditional-return-link') {
+            my $variant = $path =~ /link/ ? 'link' : '';
+            return html_response(render_component('ConditionalReturn',
+                heading => 'Conditional Return Example' . ($variant ? ' (Link)' : ''),
+                props   => { variant => $variant },
+                stash   => { variant => $variant, count => 0 }));
+        }
+
+        if ($path eq '/todos' || $path eq '/todos-ssr') {
+            my ($session, $set_cookie) = get_session($req);
+            my @todos = map { {%$_} } @{ $session->{todos} };
+            my $done  = grep { $_->{done} } @todos;
+            my $component = $path eq '/todos-ssr' ? 'TodoAppSSR' : 'TodoApp';
+            my $html = render_component($component,
+                children => { todo_item => 'TodoItem' },
+                props    => { initialTodos => \@todos },
+                stash    => { todos => \@todos, newText => '', filter => 'all', doneCount => $done });
+            return html_response($html, $set_cookie ? ('Set-Cookie' => $set_cookie) : ());
+        }
+
+        if ($path eq '/props-reactivity') {
+            my $mk = sub ($p) { (displayValue => ($p->{value} // 0) * 10) };
+            return html_response(render_component('PropsReactivityComparison',
+                heading     => 'Props Reactivity Comparison',
+                children    => { props_style_child => 'PropsStyleChild', destructured_style_child => 'DestructuredStyleChild' },
+                signal_init => { props_style_child => $mk, destructured_style_child => $mk },
+                props => {}, stash => { count => 1 }));
+        }
+
+        return html_response(render_component('PortalExample',
+            heading => 'Portal Example', props => {}, stash => { open => 0 }))
+            if $path eq '/portal';
+
+        if ($path eq '/ai-chat') {
+            return html_response(render_component('AIChatInteractive',
+                title     => 'AI Chat — SSE Streaming (Text::Xslate)',
+                heading   => 'AI Chat — SSE Streaming',
+                stash     => { messages => [], input => '', streamingText => '', isStreaming => 0 },
+                extra_css => qq{<link rel="stylesheet" href="$BASE/styles/ai-chat.css">}));
+        }
+
+        # --- todo API (GET) ---
+        if ($path eq '/api/todos') {
+            my ($session) = get_session($req);
+            return json_response($session->{todos});
+        }
+
+        # --- AI chat SSE stream ---
+        return ai_chat_stream($env) if $path eq '/api/ai-chat';
+    }
+
+    # --- todo API (writes) ---
+    if ($path eq '/api/todos' && $method eq 'POST') {
+        my ($session, $set_cookie) = get_session($req);
+        my $input = eval { $J->decode($req->content) } // {};
+        my $todo = { id => $session->{next_id}++, text => $input->{text}, done => jbool(0), editing => jbool(0) };
+        push @{ $session->{todos} }, $todo;
+        return json_response($todo, 201, $set_cookie ? ('Set-Cookie' => $set_cookie) : ());
+    }
+    if (my ($id) = $path =~ m{^/api/todos/(\d+)$}) {
+        my ($session) = get_session($req);
+        if ($method eq 'PUT') {
+            my $input = eval { $J->decode($req->content) } // {};
+            for my $todo (@{ $session->{todos} }) {
+                next unless $todo->{id} == $id;
+                $todo->{text} = $input->{text} if exists $input->{text};
+                $todo->{done} = jbool($input->{done}) if exists $input->{done};
+                return json_response($todo);
+            }
+            return json_response({ error => 'not found' }, 404);
+        }
+        if ($method eq 'DELETE') {
+            $session->{todos} = [ grep { $_->{id} != $id } @{ $session->{todos} } ];
+            return [204, [], []];
+        }
+    }
+    if ($path eq '/api/todos/reset' && $method eq 'POST') {
+        my ($session) = get_session($req);
+        $session->{todos}   = seed_todos();
+        $session->{next_id} = 4;
+        return [200, ['Content-Type' => 'text/plain'], ['ok']];
+    }
+
+    return [404, ['Content-Type' => 'text/plain'], ['Not Found']];
+};
+
+sub home_page () {
+    return layout(
+        title   => 'BarefootJS + Text::Xslate Example',
+        heading => 'BarefootJS + Text::Xslate Example',
+        scripts => '',
+        body    => <<"HTML",
+<p>This example renders the same shared JSX components with Text::Xslate (Kolon)
+under a plain Plack/PSGI app — no web framework required.</p>
+<ul>
+    <li><a href="$BASE/counter">Counter</a></li>
+    <li><a href="$BASE/toggle">Toggle</a></li>
+    <li><a href="$BASE/form">Form</a></li>
+    <li><a href="$BASE/reactive-props">Reactive Props</a></li>
+    <li><a href="$BASE/conditional-return">Conditional Return</a></li>
+    <li><a href="$BASE/props-reactivity">Props Reactivity</a></li>
+    <li><a href="$BASE/portal">Portal</a></li>
+    <li><a href="$BASE/todos">Todo (\@client)</a></li>
+    <li><a href="$BASE/todos-ssr">Todo (no \@client markers)</a></li>
+    <li><a href="$BASE/ai-chat">AI Chat (SSE Streaming)</a></li>
+</ul>
+HTML
+    );
+}
+
+# Char-by-char SSE stream. Streaming PSGI response with a blocking 30ms loop —
+# fine under a prefork server (Starman), which the demo runs.
+sub ai_chat_stream ($env) {
+    return [500, ['Content-Type' => 'text/plain'], ['streaming server required']]
+        unless $env->{'psgi.streaming'};
+    my $text  = $ai_responses[ int(rand(@ai_responses)) ];
+    my @chars = split //, $text;
+    return sub ($responder) {
+        my $w = $responder->([200, [
+            'Content-Type'  => 'text/event-stream',
+            'Cache-Control' => 'no-cache',
+        ]]);
+        local $SIG{PIPE} = 'IGNORE';
+        eval {
+            for my $ch (@chars) {
+                $w->write('data: ' . $J->encode($ch) . "\n\n");
+                select undef, undef, undef, 0.03;
+            }
+            $w->write("data: [DONE]\n\n");
+            1;
+        };
+        $w->close;
+    };
+}
+
+# ---------------------------------------------------------------------------
+# PSGI app: static assets + (dev) reload endpoint + the routed app, all under
+# $BASE. A bare-root request redirects into the base path.
+# ---------------------------------------------------------------------------
+builder {
+    enable 'Plack::Middleware::ContentLength';
+
+    mount "$BASE/client"  => Plack::App::File->new(root => 'dist/client')->to_app;
+    mount "$BASE/styles"  => Plack::App::File->new(root => 'dist/styles')->to_app;
+
+    if ($DEV) {
+        mount "$BASE/_bf/reload" => BarefootJS::DevReload->to_app(dist_dir => 'dist');
+    }
+
+    mount $BASE => $routes;
+    mount '/'   => sub ($env) { [302, [Location => "$BASE/"], []] };
+};

--- a/integrations/xslate/app.psgi
+++ b/integrations/xslate/app.psgi
@@ -202,127 +202,156 @@ my @ai_responses = (
 # ---------------------------------------------------------------------------
 # Routes — PATH_INFO here is already stripped of $BASE by Plack::Builder mount.
 # ---------------------------------------------------------------------------
+# --- page handlers: one sub per route, each returns a PSGI response ---
+sub home_route ($req) { html_response(home_page()) }
+
+sub counter_route ($req) {
+    html_response(render_component('Counter', heading => 'Counter Component'));
+}
+
+sub toggle_route ($req) {
+    my $items = [
+        { label => 'Setting 1', defaultOn => jbool(1) },
+        { label => 'Setting 2', defaultOn => jbool(0) },
+        { label => 'Setting 3', defaultOn => jbool(0) },
+    ];
+    html_response(render_component('Toggle',
+        heading     => 'Toggle Component',
+        children    => { toggle_item => 'ToggleItem' },
+        signal_init => { toggle_item => sub ($p) { (on => ($p->{defaultOn} ? 1 : 0)) } },
+        props       => { toggleItems => $items },
+        stash       => { toggleItems => $items },
+    ));
+}
+
+sub form_route ($req) {
+    html_response(render_component('Form',
+        heading => 'Form Example', props => {}, stash => { accepted => 0 }));
+}
+
+sub reactive_props_route ($req) {
+    html_response(render_component('ReactiveProps',
+        heading  => 'Reactive Props Test',
+        children => { reactive_child => 'ReactiveChild' },
+        props    => {}, stash => { count => 0, doubled => 0 }));
+}
+
+sub conditional_return_route ($req, $suffix = '') {
+    my $variant = $suffix eq '-link' ? 'link' : '';
+    html_response(render_component('ConditionalReturn',
+        heading => 'Conditional Return Example' . ($variant ? ' (Link)' : ''),
+        props   => { variant => $variant },
+        stash   => { variant => $variant, count => 0 }));
+}
+
+sub props_reactivity_route ($req) {
+    my $mk = sub ($p) { (displayValue => ($p->{value} // 0) * 10) };
+    html_response(render_component('PropsReactivityComparison',
+        heading     => 'Props Reactivity Comparison',
+        children    => { props_style_child => 'PropsStyleChild', destructured_style_child => 'DestructuredStyleChild' },
+        signal_init => { props_style_child => $mk, destructured_style_child => $mk },
+        props => {}, stash => { count => 1 }));
+}
+
+sub portal_route ($req) {
+    html_response(render_component('PortalExample',
+        heading => 'Portal Example', props => {}, stash => { open => 0 }));
+}
+
+sub ai_chat_route ($req) {
+    html_response(render_component('AIChatInteractive',
+        title     => 'AI Chat — SSE Streaming (Text::Xslate)',
+        heading   => 'AI Chat — SSE Streaming',
+        stash     => { messages => [], input => '', streamingText => '', isStreaming => 0 },
+        extra_css => qq{<link rel="stylesheet" href="$BASE/styles/ai-chat.css">}));
+}
+
+sub todos_route ($req, $suffix = '') {
+    my ($session, $set_cookie) = get_session($req);
+    my @todos = map { {%$_} } @{ $session->{todos} };
+    my $done  = grep { $_->{done} } @todos;
+    my $component = $suffix eq '-ssr' ? 'TodoAppSSR' : 'TodoApp';
+    my $html = render_component($component,
+        children => { todo_item => 'TodoItem' },
+        props    => { initialTodos => \@todos },
+        stash    => { todos => \@todos, newText => '', filter => 'all', doneCount => $done });
+    html_response($html, $set_cookie ? ('Set-Cookie' => $set_cookie) : ());
+}
+
+# --- todo REST API handlers ---
+sub api_todos_list ($req) {
+    my ($session) = get_session($req);
+    json_response($session->{todos});
+}
+
+sub api_todos_create ($req) {
+    my ($session, $set_cookie) = get_session($req);
+    my $input = eval { $J->decode($req->content) } // {};
+    my $todo = { id => $session->{next_id}++, text => $input->{text}, done => jbool(0), editing => jbool(0) };
+    push @{ $session->{todos} }, $todo;
+    json_response($todo, 201, $set_cookie ? ('Set-Cookie' => $set_cookie) : ());
+}
+
+sub api_todos_update ($req, $id) {
+    my ($session) = get_session($req);
+    my $input = eval { $J->decode($req->content) } // {};
+    for my $todo (@{ $session->{todos} }) {
+        next unless $todo->{id} == $id;
+        $todo->{text} = $input->{text} if exists $input->{text};
+        $todo->{done} = jbool($input->{done}) if exists $input->{done};
+        return json_response($todo);
+    }
+    json_response({ error => 'not found' }, 404);
+}
+
+sub api_todos_delete ($req, $id) {
+    my ($session) = get_session($req);
+    $session->{todos} = [ grep { $_->{id} != $id } @{ $session->{todos} } ];
+    [204, [], []];
+}
+
+sub api_todos_reset ($req) {
+    my ($session) = get_session($req);
+    $session->{todos}   = seed_todos();
+    $session->{next_id} = 4;
+    [200, ['Content-Type' => 'text/plain'], ['ok']];
+}
+
+# Route table: [ METHOD, path pattern, handler ]. First match wins; any regex
+# captures (e.g. /api/todos/(\d+), /todos(-ssr)?) are passed to the handler
+# after the request.
+my @ROUTES = (
+    [ GET    => qr{^/$}                           => \&home_route ],
+    [ GET    => qr{^/counter$}                    => \&counter_route ],
+    [ GET    => qr{^/toggle$}                     => \&toggle_route ],
+    [ GET    => qr{^/form$}                       => \&form_route ],
+    [ GET    => qr{^/reactive-props$}             => \&reactive_props_route ],
+    [ GET    => qr{^/conditional-return(-link)?$} => \&conditional_return_route ],
+    [ GET    => qr{^/props-reactivity$}           => \&props_reactivity_route ],
+    [ GET    => qr{^/portal$}                     => \&portal_route ],
+    [ GET    => qr{^/todos(-ssr)?$}               => \&todos_route ],
+    [ GET    => qr{^/ai-chat$}                    => \&ai_chat_route ],
+    [ GET    => qr{^/api/todos$}                  => \&api_todos_list ],
+    [ POST   => qr{^/api/todos$}                  => \&api_todos_create ],
+    [ POST   => qr{^/api/todos/reset$}            => \&api_todos_reset ],
+    [ PUT    => qr{^/api/todos/(\d+)$}            => \&api_todos_update ],
+    [ DELETE => qr{^/api/todos/(\d+)$}            => \&api_todos_delete ],
+    [ GET    => qr{^/api/ai-chat$}                => \&ai_chat_stream ],
+);
+
 my $routes = sub ($env) {
     my $req    = Plack::Request->new($env);
+    my $method = $req->method;
     my $path   = $req->path_info;
     $path = '/' if $path eq '';
-    my $method = $req->method;
 
-    # --- pages ---
-    if ($method eq 'GET') {
-        return html_response(home_page()) if $path eq '/';
-
-        return html_response(render_component('Counter', heading => 'Counter Component'))
-            if $path eq '/counter';
-
-        if ($path eq '/toggle') {
-            my $items = [
-                { label => 'Setting 1', defaultOn => jbool(1) },
-                { label => 'Setting 2', defaultOn => jbool(0) },
-                { label => 'Setting 3', defaultOn => jbool(0) },
-            ];
-            return html_response(render_component('Toggle',
-                heading     => 'Toggle Component',
-                children    => { toggle_item => 'ToggleItem' },
-                signal_init => { toggle_item => sub ($p) { (on => ($p->{defaultOn} ? 1 : 0)) } },
-                props       => { toggleItems => $items },
-                stash       => { toggleItems => $items },
-            ));
-        }
-
-        return html_response(render_component('Form',
-            heading => 'Form Example', props => {}, stash => { accepted => 0 }))
-            if $path eq '/form';
-
-        return html_response(render_component('ReactiveProps',
-            heading  => 'Reactive Props Test',
-            children => { reactive_child => 'ReactiveChild' },
-            props    => {}, stash => { count => 0, doubled => 0 }))
-            if $path eq '/reactive-props';
-
-        if ($path eq '/conditional-return' || $path eq '/conditional-return-link') {
-            my $variant = $path =~ /link/ ? 'link' : '';
-            return html_response(render_component('ConditionalReturn',
-                heading => 'Conditional Return Example' . ($variant ? ' (Link)' : ''),
-                props   => { variant => $variant },
-                stash   => { variant => $variant, count => 0 }));
-        }
-
-        if ($path eq '/todos' || $path eq '/todos-ssr') {
-            my ($session, $set_cookie) = get_session($req);
-            my @todos = map { {%$_} } @{ $session->{todos} };
-            my $done  = grep { $_->{done} } @todos;
-            my $component = $path eq '/todos-ssr' ? 'TodoAppSSR' : 'TodoApp';
-            my $html = render_component($component,
-                children => { todo_item => 'TodoItem' },
-                props    => { initialTodos => \@todos },
-                stash    => { todos => \@todos, newText => '', filter => 'all', doneCount => $done });
-            return html_response($html, $set_cookie ? ('Set-Cookie' => $set_cookie) : ());
-        }
-
-        if ($path eq '/props-reactivity') {
-            my $mk = sub ($p) { (displayValue => ($p->{value} // 0) * 10) };
-            return html_response(render_component('PropsReactivityComparison',
-                heading     => 'Props Reactivity Comparison',
-                children    => { props_style_child => 'PropsStyleChild', destructured_style_child => 'DestructuredStyleChild' },
-                signal_init => { props_style_child => $mk, destructured_style_child => $mk },
-                props => {}, stash => { count => 1 }));
-        }
-
-        return html_response(render_component('PortalExample',
-            heading => 'Portal Example', props => {}, stash => { open => 0 }))
-            if $path eq '/portal';
-
-        if ($path eq '/ai-chat') {
-            return html_response(render_component('AIChatInteractive',
-                title     => 'AI Chat — SSE Streaming (Text::Xslate)',
-                heading   => 'AI Chat — SSE Streaming',
-                stash     => { messages => [], input => '', streamingText => '', isStreaming => 0 },
-                extra_css => qq{<link rel="stylesheet" href="$BASE/styles/ai-chat.css">}));
-        }
-
-        # --- todo API (GET) ---
-        if ($path eq '/api/todos') {
-            my ($session) = get_session($req);
-            return json_response($session->{todos});
-        }
-
-        # --- AI chat SSE stream ---
-        return ai_chat_stream($env) if $path eq '/api/ai-chat';
+    for my $route (@ROUTES) {
+        my ($m, $pattern, $handler) = @$route;
+        next if $method ne $m;
+        next unless $path =~ $pattern;
+        # @{^CAPTURE} holds just this match's capture groups (empty for none).
+        return $handler->($req, @{^CAPTURE});
     }
-
-    # --- todo API (writes) ---
-    if ($path eq '/api/todos' && $method eq 'POST') {
-        my ($session, $set_cookie) = get_session($req);
-        my $input = eval { $J->decode($req->content) } // {};
-        my $todo = { id => $session->{next_id}++, text => $input->{text}, done => jbool(0), editing => jbool(0) };
-        push @{ $session->{todos} }, $todo;
-        return json_response($todo, 201, $set_cookie ? ('Set-Cookie' => $set_cookie) : ());
-    }
-    if (my ($id) = $path =~ m{^/api/todos/(\d+)$}) {
-        my ($session) = get_session($req);
-        if ($method eq 'PUT') {
-            my $input = eval { $J->decode($req->content) } // {};
-            for my $todo (@{ $session->{todos} }) {
-                next unless $todo->{id} == $id;
-                $todo->{text} = $input->{text} if exists $input->{text};
-                $todo->{done} = jbool($input->{done}) if exists $input->{done};
-                return json_response($todo);
-            }
-            return json_response({ error => 'not found' }, 404);
-        }
-        if ($method eq 'DELETE') {
-            $session->{todos} = [ grep { $_->{id} != $id } @{ $session->{todos} } ];
-            return [204, [], []];
-        }
-    }
-    if ($path eq '/api/todos/reset' && $method eq 'POST') {
-        my ($session) = get_session($req);
-        $session->{todos}   = seed_todos();
-        $session->{next_id} = 4;
-        return [200, ['Content-Type' => 'text/plain'], ['ok']];
-    }
-
     return [404, ['Content-Type' => 'text/plain'], ['Not Found']];
 };
 
@@ -352,7 +381,8 @@ HTML
 
 # Char-by-char SSE stream. Streaming PSGI response with a blocking 30ms loop —
 # fine under a prefork server (Starman), which the demo runs.
-sub ai_chat_stream ($env) {
+sub ai_chat_stream ($req) {
+    my $env = $req->env;
     return [500, ['Content-Type' => 'text/plain'], ['streaming server required']]
         unless $env->{'psgi.streaming'};
     my $text  = $ai_responses[ int(rand(@ai_responses)) ];

--- a/integrations/xslate/barefoot.config.ts
+++ b/integrations/xslate/barefoot.config.ts
@@ -1,0 +1,14 @@
+import { createConfig } from '@barefootjs/xslate/build'
+
+const basePath = process.env.BASE_PATH ?? '/integrations/xslate'
+const clientBase = `${basePath}/client/`
+
+export default createConfig({
+  components: ['../shared/components'],
+  outDir: 'dist',
+  minify: true,
+  adapterOptions: {
+    clientJsBasePath: clientBase,
+    barefootJsPath: `${clientBase}barefoot.js`,
+  },
+})

--- a/integrations/xslate/container.ts
+++ b/integrations/xslate/container.ts
@@ -1,0 +1,23 @@
+/**
+ * Worker shim that forwards every request under /integrations/xslate/* to
+ * the Text::Xslate (Plack) app running inside a Cloudflare Container.
+ */
+
+import { Container } from '@cloudflare/containers'
+
+type Env = {
+  XSLATE_CONTAINER: DurableObjectNamespace
+}
+
+export class XslateContainer extends Container<Env> {
+  defaultPort = 8080
+  sleepAfter = '10m'
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const id = env.XSLATE_CONTAINER.idFromName('singleton')
+    const stub = env.XSLATE_CONTAINER.get(id) as unknown as { fetch: typeof fetch }
+    return stub.fetch(request)
+  },
+} satisfies ExportedHandler<Env>

--- a/integrations/xslate/e2e/ai-chat.spec.ts
+++ b/integrations/xslate/e2e/ai-chat.spec.ts
@@ -1,0 +1,9 @@
+/**
+ * AI Chat E2E tests for Text::Xslate example
+ *
+ * Uses shared test suite from integrations/shared/e2e
+ */
+
+import { aiChatTests } from '../../shared/e2e/ai-chat.spec'
+
+aiChatTests('http://localhost:3007/integrations/xslate')

--- a/integrations/xslate/e2e/conditional-return.spec.ts
+++ b/integrations/xslate/e2e/conditional-return.spec.ts
@@ -1,0 +1,9 @@
+/**
+ * ConditionalReturn E2E tests for Text::Xslate example
+ *
+ * Uses shared test suite from integrations/shared/e2e
+ */
+
+import { conditionalReturnTests } from '../../shared/e2e/conditional-return.spec'
+
+conditionalReturnTests('http://localhost:3007/integrations/xslate')

--- a/integrations/xslate/e2e/counter.spec.ts
+++ b/integrations/xslate/e2e/counter.spec.ts
@@ -1,0 +1,9 @@
+/**
+ * Counter E2E tests for Text::Xslate example
+ *
+ * Uses shared test suite from integrations/shared/e2e
+ */
+
+import { counterTests } from '../../shared/e2e/counter.spec'
+
+counterTests('http://localhost:3007/integrations/xslate')

--- a/integrations/xslate/e2e/form.spec.ts
+++ b/integrations/xslate/e2e/form.spec.ts
@@ -1,0 +1,9 @@
+/**
+ * Form E2E tests for Text::Xslate example
+ *
+ * Uses shared test suite from integrations/shared/e2e
+ */
+
+import { formTests } from '../../shared/e2e/form.spec'
+
+formTests('http://localhost:3007/integrations/xslate')

--- a/integrations/xslate/e2e/portal.spec.ts
+++ b/integrations/xslate/e2e/portal.spec.ts
@@ -1,0 +1,9 @@
+/**
+ * Portal E2E tests for Text::Xslate example
+ *
+ * Uses shared test suite from integrations/shared/e2e
+ */
+
+import { portalTests } from '../../shared/e2e/portal.spec'
+
+portalTests('http://localhost:3007/integrations/xslate')

--- a/integrations/xslate/e2e/reactive-props.spec.ts
+++ b/integrations/xslate/e2e/reactive-props.spec.ts
@@ -1,0 +1,9 @@
+/**
+ * ReactiveProps E2E tests for Text::Xslate example
+ *
+ * Uses shared test suite from integrations/shared/e2e
+ */
+
+import { reactivePropsTests } from '../../shared/e2e/reactive-props.spec'
+
+reactivePropsTests('http://localhost:3007/integrations/xslate')

--- a/integrations/xslate/e2e/todo-app-ssr.spec.ts
+++ b/integrations/xslate/e2e/todo-app-ssr.spec.ts
@@ -1,0 +1,9 @@
+/**
+ * TodoAppSSR E2E tests for Text::Xslate example
+ *
+ * Tests TodoApp without @client markers
+ */
+
+import { todoAppTests } from '../../shared/e2e/todo-app.spec'
+
+todoAppTests('http://localhost:3007/integrations/xslate', '/todos-ssr')

--- a/integrations/xslate/e2e/todo-app.spec.ts
+++ b/integrations/xslate/e2e/todo-app.spec.ts
@@ -1,0 +1,9 @@
+/**
+ * TodoApp E2E tests for Text::Xslate example
+ *
+ * Uses shared test suite from integrations/shared/e2e
+ */
+
+import { todoAppTests } from '../../shared/e2e/todo-app.spec'
+
+todoAppTests('http://localhost:3007/integrations/xslate')

--- a/integrations/xslate/e2e/toggle.spec.ts
+++ b/integrations/xslate/e2e/toggle.spec.ts
@@ -1,0 +1,9 @@
+/**
+ * Toggle E2E tests for Text::Xslate example
+ *
+ * Uses shared test suite from integrations/shared/e2e
+ */
+
+import { toggleTests } from '../../shared/e2e/toggle.spec'
+
+toggleTests('http://localhost:3007/integrations/xslate')

--- a/integrations/xslate/package.json
+++ b/integrations/xslate/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "barefootjs-xslate-example",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/assemble-deps.ts",
+    "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
+    "dev": "BASE_PATH=/integrations/xslate plackup -s Starman --workers 5 -p 3007 app.psgi",
+    "deploy": "bun run build && wrangler deploy",
+    "test:e2e": "bunx playwright test",
+    "test:e2e:ui": "bunx playwright test --ui"
+  },
+  "devDependencies": {
+    "@barefootjs/jsx": "workspace:*",
+    "@barefootjs/xslate": "workspace:*",
+    "@cloudflare/containers": "^0.3.2",
+    "@cloudflare/workers-types": "^4",
+    "@playwright/test": "^1.41.0",
+    "bun-types": "^1.1.0",
+    "wrangler": "^4"
+  }
+}

--- a/integrations/xslate/playwright.config.ts
+++ b/integrations/xslate/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 5000,
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  // Use single worker to avoid conflicts with shared server state (/api/todos/reset)
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3007',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'BASE_PATH=/integrations/xslate plackup -s Starman --workers 3 -p 3007 app.psgi',
+    url: 'http://localhost:3007/integrations/xslate/',
+    reuseExistingServer: !process.env.CI,
+    timeout: 30000,
+  },
+})

--- a/integrations/xslate/scripts/assemble-deps.ts
+++ b/integrations/xslate/scripts/assemble-deps.ts
@@ -1,0 +1,42 @@
+/**
+ * Post-build step that stages Perl sources and shared styles under the
+ * xslate example directory so the same layout works in local dev and
+ * inside the container image.
+ *
+ *   ./lib          ← packages/adapter-perl/lib (engine-agnostic BarefootJS runtime)
+ *                  + packages/adapter-xslate/lib (Xslate backend)
+ *                    merged into one @INC dir so `use BarefootJS` and
+ *                    `use BarefootJS::Backend::Xslate` both resolve.
+ *   ./dist/styles  ← integrations/shared/styles  (design-system stylesheets)
+ */
+
+import { cp, mkdir, rm } from 'node:fs/promises'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const ROOT = join(HERE, '..')
+
+async function mirror(src: string, dest: string) {
+  await rm(dest, { recursive: true, force: true })
+  await mkdir(dirname(dest), { recursive: true })
+  await cp(src, dest, { recursive: true })
+  console.log(`Copied ${src} → ${dest.replace(ROOT + '/', '')}`)
+}
+
+// Merge both packages' `lib/` into a single ./lib @INC root. Unlike `mirror`,
+// `merge` must not `rm` between copies so the core runtime (BarefootJS.pm from
+// @barefootjs/perl) and the Mojo binding (BarefootJS/Backend/Mojo.pm +
+// Mojolicious/Plugin/* from @barefootjs/mojolicious) coexist in one tree.
+async function merge(src: string, dest: string) {
+  await mkdir(dest, { recursive: true })
+  await cp(src, dest, { recursive: true })
+  console.log(`Merged ${src} → ${dest.replace(ROOT + '/', '')}`)
+}
+
+const LIB_DEST = join(ROOT, 'lib')
+await rm(LIB_DEST, { recursive: true, force: true })
+await merge(join(ROOT, '../../packages/adapter-perl/lib'), LIB_DEST)
+await merge(join(ROOT, '../../packages/adapter-xslate/lib'), LIB_DEST)
+
+await mirror(join(ROOT, '../shared/styles'), join(ROOT, 'dist/styles'))

--- a/integrations/xslate/tsconfig.json
+++ b/integrations/xslate/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ESNext",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["bun-types", "@cloudflare/workers-types"]
+  },
+  "include": ["*.ts", "*.tsx", "e2e/**/*.ts", "scripts/**/*.ts"],
+  "exclude": ["node_modules", "dist", "lib"]
+}

--- a/integrations/xslate/wrangler.toml
+++ b/integrations/xslate/wrangler.toml
@@ -1,0 +1,31 @@
+name = "barefootjs-xslate-example"
+main = "container.ts"
+compatibility_date = "2025-01-01"
+compatibility_flags = ["nodejs_compat"]
+
+[[containers]]
+class_name = "XslateContainer"
+image = "./Dockerfile"
+max_instances = 1
+
+[[durable_objects.bindings]]
+name = "XSLATE_CONTAINER"
+class_name = "XslateContainer"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["XslateContainer"]
+
+# Two patterns: `/integrations/xslate/*` matches /integrations/xslate/...
+# but not the bare /integrations/xslate, so add the no-slash variant
+# explicitly.
+[[routes]]
+pattern = "barefootjs.dev/integrations/xslate"
+zone_name = "barefootjs.dev"
+
+[[routes]]
+pattern = "barefootjs.dev/integrations/xslate/*"
+zone_name = "barefootjs.dev"
+
+[vars]
+BASE_PATH = "/integrations/xslate"

--- a/scripts/dev-all.ts
+++ b/scripts/dev-all.ts
@@ -40,6 +40,7 @@ const routes: readonly Route[] = [
   { prefix: '/integrations/chi',         target: process.env.CHI_TARGET         ?? 'http://chi:8082',         label: 'Chi (Go)' },
   { prefix: '/integrations/nethttp',     target: process.env.NETHTTP_TARGET     ?? 'http://nethttp:8083',     label: 'net/http (Go)' },
   { prefix: '/integrations/mojolicious', target: process.env.MOJOLICIOUS_TARGET ?? 'http://mojolicious:3000', label: 'Mojolicious (Perl)' },
+  { prefix: '/integrations/xslate',      target: process.env.XSLATE_TARGET      ?? 'http://xslate:3007',      label: 'Text::Xslate (Perl)' },
 ] as const
 
 const DEFAULT_TARGET = process.env.SITE_CORE_TARGET ?? 'http://site-core:4001'

--- a/site/core/integrations/routes.tsx
+++ b/site/core/integrations/routes.tsx
@@ -27,6 +27,7 @@ const ADAPTERS: Adapter[] = [
   { slug: 'chi',         name: 'Chi',         language: 'Go' },
   { slug: 'nethttp',     name: 'net/http',    language: 'Go' },
   { slug: 'mojolicious', name: 'Mojolicious', language: 'Perl' },
+  { slug: 'xslate',      name: 'Text::Xslate', language: 'Perl' },
 ]
 
 function IntegrationsIndex() {
@@ -55,7 +56,7 @@ export function createIntegrationsApp() {
     c.render(<IntegrationsIndex />, {
       title: 'Integrations — Barefoot.js',
       description:
-        'Same JSX components running on Hono, h3 and Elysia (TypeScript), Echo, Gin, Chi and net/http (Go), and Mojolicious (Perl).',
+        'Same JSX components running on Hono, h3 and Elysia (TypeScript), Echo, Gin, Chi and net/http (Go), and Mojolicious and Text::Xslate (Perl).',
     }),
   )
 


### PR DESCRIPTION
## Goal

Add a **Text::Xslate** example to the integrations showcase (the third of the maintainer's asks, after #1753 DevReload and #1755 docs) — the same shared JSX components running on a **plain Plack/PSGI app** with the Xslate (Kolon) backend, at full parity with the Mojolicious demo and wired for deployment.

This was unblocked by #1757 (the `.filter`/`.find` adapter work): **all 11 shared components now compile to Kolon, 0 errors**.

## What

**`integrations/xslate/`** — a port of the Mojolicious example to Plack + Text::Xslate:
- **`app.psgi`** — every route (counter, toggle, form, reactive-props, conditional-return(+link), todos, todos-ssr, props-reactivity, portal, ai-chat), per-request runtime + child-renderer registration (incl. `signal_init`), the per-session **todo REST API**, char-by-char **AI-chat SSE**, and **dev auto-reload** via `BarefootJS::DevReload->to_app`. No web framework — runs under any PSGI server.
- `barefoot.config.ts` (`@barefootjs/xslate/build`), `scripts/assemble-deps.ts` (stages `adapter-perl` + `adapter-xslate` lib).

**Deploy parity:**
- `Dockerfile` (Starman prefork, production) + `Dockerfile.dev` (plackup `-R` reload), installing Text::Xslate + Plack + Starman.
- `container.ts` (`XslateContainer`) + `wrangler.toml` (`barefootjs.dev/integrations/xslate`).
- `docker-compose` **`xslate` service** + dev **proxy route** (`scripts/dev-all.ts` → `xslate:3007`).
- `deploy.yml`: `deploy-integrations-xslate` job + `workflow_dispatch` option.
- Playwright config + e2e specs (reuse the **shared** suites) at `:3007`.

**Catalog + docs:** site integrations index gets the Text::Xslate card; `integrations/README.md` updated (ports table, compose diagram, proxy routes, env-target list).

## Validation (Starman, live curl)

- ✅ Build: **11 compiled, 0 errors**.
- ✅ `/counter` scope + reactive text slots + client JS; `/toggle` → 3 `ToggleItem` children (`signal_init`); `/todos` → `TodoApp` + `bf-p` + child `TodoItem`; `/props-reactivity` → 2 child types.
- ✅ `/api/todos` JSON REST; `/api/ai-chat` SSE char-stream; `/_bf/reload` SSE (`retry: 1000`).
- ✅ Static `client/*.js` + `styles/*.css` → 200.
- ✅ `docker compose config` validates the `xslate` service.

## Notes

- Local e2e (Playwright browsers) not run here — the shared specs are reused unchanged; CI/deploy exercises them.
- `dist/` and assembled `lib/` are gitignored (build output), matching the other integrations.

https://claude.ai/code/session_01Q2ZNcmBJuucbnuyT58b3NZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2ZNcmBJuucbnuyT58b3NZ)_