### PR TITLE
fix(integrations): list every route on each example's index page

### DIFF
--- a/integrations/chi/main.go
+++ b/integrations/chi/main.go
@@ -306,10 +306,15 @@ func indexHandler(w http.ResponseWriter, _ *http.Request) {
     <ul>
         <li><a href="%s/counter">Counter</a></li>
         <li><a href="%s/toggle">Toggle</a></li>
+        <li><a href="%s/form">Form</a></li>
+        <li><a href="%s/reactive-props">Reactive Props</a></li>
+        <li><a href="%s/conditional-return">Conditional Return</a></li>
+        <li><a href="%s/props-reactivity">Props Reactivity</a></li>
+        <li><a href="%s/portal">Portal</a></li>
         <li><a href="%s/todos">Todo (@client)</a></li>
         <li><a href="%s/todos-ssr">Todo (no @client markers)</a></li>
         <li><a href="%s/ai-chat">AI Chat (SSE Streaming)</a></li>
-    </ul>`, basePath, basePath, basePath, basePath, basePath)
+    </ul>`, basePath, basePath, basePath, basePath, basePath, basePath, basePath, basePath, basePath, basePath)
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	fmt.Fprintf(w, `<!DOCTYPE html>

--- a/integrations/echo/main.go
+++ b/integrations/echo/main.go
@@ -283,10 +283,15 @@ func indexHandler(c echo.Context) error {
     <ul>
         <li><a href="%s/counter">Counter</a></li>
         <li><a href="%s/toggle">Toggle</a></li>
+        <li><a href="%s/form">Form</a></li>
+        <li><a href="%s/reactive-props">Reactive Props</a></li>
+        <li><a href="%s/conditional-return">Conditional Return</a></li>
+        <li><a href="%s/props-reactivity">Props Reactivity</a></li>
+        <li><a href="%s/portal">Portal</a></li>
         <li><a href="%s/todos">Todo (@client)</a></li>
         <li><a href="%s/todos-ssr">Todo (no @client markers)</a></li>
         <li><a href="%s/ai-chat">AI Chat (SSE Streaming)</a></li>
-    </ul>`, basePath, basePath, basePath, basePath, basePath)
+    </ul>`, basePath, basePath, basePath, basePath, basePath, basePath, basePath, basePath, basePath, basePath)
 
 	return c.HTML(http.StatusOK, fmt.Sprintf(`<!DOCTYPE html>
 <html lang="en" class="dark">

--- a/integrations/gin/main.go
+++ b/integrations/gin/main.go
@@ -282,10 +282,15 @@ func indexHandler(c *gin.Context) {
     <ul>
         <li><a href="%s/counter">Counter</a></li>
         <li><a href="%s/toggle">Toggle</a></li>
+        <li><a href="%s/form">Form</a></li>
+        <li><a href="%s/reactive-props">Reactive Props</a></li>
+        <li><a href="%s/conditional-return">Conditional Return</a></li>
+        <li><a href="%s/props-reactivity">Props Reactivity</a></li>
+        <li><a href="%s/portal">Portal</a></li>
         <li><a href="%s/todos">Todo (@client)</a></li>
         <li><a href="%s/todos-ssr">Todo (no @client markers)</a></li>
         <li><a href="%s/ai-chat">AI Chat (SSE Streaming)</a></li>
-    </ul>`, basePath, basePath, basePath, basePath, basePath)
+    </ul>`, basePath, basePath, basePath, basePath, basePath, basePath, basePath, basePath, basePath, basePath)
 
 	c.Data(http.StatusOK, "text/html; charset=utf-8", []byte(fmt.Sprintf(`<!DOCTYPE html>
 <html lang="en" class="dark">

--- a/integrations/hono/server.tsx
+++ b/integrations/hono/server.tsx
@@ -108,6 +108,11 @@ app.get('/', (c) => {
         <ul>
           <li><a href={link('/counter')}>Counter</a></li>
           <li><a href={link('/toggle')}>Toggle</a></li>
+          <li><a href={link('/form')}>Form</a></li>
+          <li><a href={link('/reactive-props')}>Reactive Props</a></li>
+          <li><a href={link('/conditional-return')}>Conditional Return</a></li>
+          <li><a href={link('/props-reactivity')}>Props Reactivity</a></li>
+          <li><a href={link('/portal')}>Portal</a></li>
           <li><a href={link('/todos')}>Todo (@client)</a></li>
           <li><a href={link('/todos-ssr')}>Todo (no @client markers)</a></li>
           <li><a href={link('/ai-chat')}>AI Chat (SSE Streaming)</a></li>

--- a/integrations/mojolicious/app.pl
+++ b/integrations/mojolicious/app.pl
@@ -466,6 +466,11 @@ __DATA__
 <ul>
     <li><a href="<%= $bp %>/counter">Counter</a></li>
     <li><a href="<%= $bp %>/toggle">Toggle</a></li>
+    <li><a href="<%= $bp %>/form">Form</a></li>
+    <li><a href="<%= $bp %>/reactive-props">Reactive Props</a></li>
+    <li><a href="<%= $bp %>/conditional-return">Conditional Return</a></li>
+    <li><a href="<%= $bp %>/props-reactivity">Props Reactivity</a></li>
+    <li><a href="<%= $bp %>/portal">Portal</a></li>
     <li><a href="<%= $bp %>/todos">Todo (@client)</a></li>
     <li><a href="<%= $bp %>/todos-ssr">Todo (no @client markers)</a></li>
     <li><a href="<%= $bp %>/ai-chat">AI Chat (SSE Streaming)</a></li>

--- a/integrations/nethttp/main.go
+++ b/integrations/nethttp/main.go
@@ -312,10 +312,15 @@ func indexHandler(w http.ResponseWriter, _ *http.Request) {
     <ul>
         <li><a href="%s/counter">Counter</a></li>
         <li><a href="%s/toggle">Toggle</a></li>
+        <li><a href="%s/form">Form</a></li>
+        <li><a href="%s/reactive-props">Reactive Props</a></li>
+        <li><a href="%s/conditional-return">Conditional Return</a></li>
+        <li><a href="%s/props-reactivity">Props Reactivity</a></li>
+        <li><a href="%s/portal">Portal</a></li>
         <li><a href="%s/todos">Todo (@client)</a></li>
         <li><a href="%s/todos-ssr">Todo (no @client markers)</a></li>
         <li><a href="%s/ai-chat">AI Chat (SSE Streaming)</a></li>
-    </ul>`, basePath, basePath, basePath, basePath, basePath)
+    </ul>`, basePath, basePath, basePath, basePath, basePath, basePath, basePath, basePath, basePath, basePath)
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	fmt.Fprintf(w, `<!DOCTYPE html>


### PR DESCRIPTION
## Problem

The integration examples serve `form`, `reactive-props`, `conditional-return`, `props-reactivity` and `portal` routes (all with shared e2e coverage), but their **home/index page only linked** `counter` / `toggle` / `todos` / `todos-ssr` / `ai-chat`. So five pages were reachable and tested but **invisible to users**.

(Spotted on the Mojolicious example index.)

## Fix

Add the missing links so each index lists its **full route set**, in the same order/labels as the Text::Xslate example:

> Counter · Toggle · **Form** · **Reactive Props** · **Conditional Return** · **Props Reactivity** · **Portal** · Todo (@client) · Todo (no @client markers) · AI Chat (SSE Streaming)

Updated: **hono, echo, gin, chi, nethttp, mojolicious** (the 6 that serve the full route set). For the Go apps the home page is an `fmt.Sprintf`, so each added `%s` link gets a matching `basePath` arg (`go vet`/`go build` clean — verified 10 links = 10 args).

## Out of scope

`h3` and `elysia` implement **only** the 5 listed routes, so their index already reflects every endpoint they have — nothing hidden. (Happy to add the remaining 5 routes to them too for full parity if you'd like.) `xslate` already listed all 10.

## Validation

- Menu now shows 10 items on all 6 updated examples (verified per file).
- `go build ./...` passes for echo/gin/chi/nethttp; `go vet` shows no Printf arg-count issues.

https://claude.ai/code/session_01Q2ZNcmBJuucbnuyT58b3NZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2ZNcmBJuucbnuyT58b3NZ)_