### PR TITLE
fix(integrations/xslate): trim home index to the curated short list

### DIFF
--- a/integrations/xslate/app.psgi
+++ b/integrations/xslate/app.psgi
@@ -366,11 +366,6 @@ under a plain Plack/PSGI app — no web framework required.</p>
 <ul>
     <li><a href="$BASE/counter">Counter</a></li>
     <li><a href="$BASE/toggle">Toggle</a></li>
-    <li><a href="$BASE/form">Form</a></li>
-    <li><a href="$BASE/reactive-props">Reactive Props</a></li>
-    <li><a href="$BASE/conditional-return">Conditional Return</a></li>
-    <li><a href="$BASE/props-reactivity">Props Reactivity</a></li>
-    <li><a href="$BASE/portal">Portal</a></li>
     <li><a href="$BASE/todos">Todo (\@client)</a></li>
     <li><a href="$BASE/todos-ssr">Todo (no \@client markers)</a></li>
     <li><a href="$BASE/ai-chat">AI Chat (SSE Streaming)</a></li>


### PR DESCRIPTION
## What

Trim the Text::Xslate example's home index to the **curated short list** — matching the other integrations (hono, mojolicious, …):

> Counter · Toggle · Todo (@client) · Todo (no @client markers) · AI Chat (SSE Streaming)

The `form`, `reactive-props`, `conditional-return`, `props-reactivity` and `portal` routes still exist and keep their e2e coverage — they're just **not surfaced in the nav**, consistent with how the other examples curate their index.

(My earlier #1761 went the wrong direction — adding those links to every example — and is closed in favour of this.)

## Validation

- `perl -c app.psgi` OK.
- Home list now shows the same 5 items as the Mojolicious example.

https://claude.ai/code/session_01Q2ZNcmBJuucbnuyT58b3NZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2ZNcmBJuucbnuyT58b3NZ)_