### PR TITLE
feat(xslate): conditional spread + nullish omission + props-object enumeration — Mojo parity on textarea/checkbox

### DIFF
--- a/.changeset/xslate-textarea-checkbox-parity.md
+++ b/.changeset/xslate-textarea-checkbox-parity.md
@@ -1,0 +1,15 @@
+---
+"@barefootjs/xslate": patch
+---
+
+Bring the Text::Xslate (Kolon) adapter to parity with the Mojolicious adapter on the Phase 2b `textarea` and `checkbox` conformance fixtures, which it previously skipped.
+
+Ported (in Kolon form) from the Mojo adapter:
+
+- **Conditional inline-object spread** — `{...(cond ? { 'aria-describedby': x } : {})}` (and the function-scope local-const form `const sizeAttrs = size ? { ... } : {}; {...sizeAttrs}`) now lowers to a Kolon inline ternary of hashrefs through `$bf.spread_attrs(...)` instead of raising `BF101`.
+- **`Record<staticKeys, scalar>[propKey]` spread value** — CheckIcon's `sizeMap[size]` lowers via the shared `parseRecordIndexAccess` to an inline bracket-indexed Kolon hashref `{ 'sm' => 16, ... }[$size]`. Note: Kolon indexes a hashref literal with bracket syntax `{…}[$key]`, not Perl's arrow-deref `{…}->{$key}` (which Kolon's parser rejects).
+- **Nullish optional-attribute omission** — an optional, no-default, nillable prop (e.g. textarea's `rows`) is now guarded with a Kolon `: if (defined $rows) { … : }` block so the attribute drops when unset rather than rendering `rows=""`.
+- **Props-object inherited-attribute enumeration** — `function Checkbox(props: CheckboxProps)` now calls the shared `augmentInheritedPropAccesses(ir)` so inherited bare optional attributes (`id={props.id}`) get the `defined`-guard.
+- **Hyphenated child rest-bag routing** — a hyphenated child prop name (`<CheckIcon data-slot="checkbox-indicator" />`) is now quoted in the `render_child` hashref (`'data-slot' => …`); an unquoted key parses as subtraction in Kolon.
+
+The test renderer now defers the child-compile error gate and re-checks only the components a fixture transitively references, so a sibling source file that exports an unreferenced component which legitimately can't lower to Kolon (e.g. `../icon`'s generic `Icon`, which splats `{...props}` onto child components — no Kolon form) no longer blocks a fixture that never renders it.

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -46,14 +46,17 @@ runAdapterConformanceTests({
     // `reactive-props` passes. (Same pair mojo skips.)
     'toggle-shared',
     'props-reactivity-comparison',
-    // #1467 Phase 2b interactive `site/ui` primitives. Cross-adapter SSR
-    // parity for this corpus is a later phase (they participate in Hono SSR
-    // conformance + the fixture-hydrate runtime layer for now); mojo skips
-    // them identically. Confirmed render-mismatch, not a hard error.
+    // #1467 Phase 2b interactive `site/ui` primitives. `textarea` and
+    // `checkbox` now PASS (conditional inline-object spread, nullish
+    // optional-attribute omission, `Record[propKey]` spread values,
+    // props-object inherited-attr enumeration, and hyphenated child hash keys
+    // were ported from the Mojo adapter in Kolon form). The remaining three
+    // stay skipped: cross-adapter SSR parity for them is a later phase (they
+    // participate in Hono SSR conformance + the fixture-hydrate runtime layer
+    // for now); mojo skips the same three. Confirmed render-mismatch, not a
+    // hard error.
     'toggle',
     'switch',
-    'checkbox',
-    'textarea',
     'kbd',
   ],
   // Per-fixture build-time contracts for shapes the Xslate adapter

--- a/packages/adapter-xslate/src/__tests__/xslate-spread-attrs.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-spread-attrs.test.ts
@@ -1,0 +1,218 @@
+/**
+ * XslateAdapter — conditional-spread / nullish-omission / hyphenated-key
+ * regression tests (#textarea / #checkbox Phase 2b parity).
+ *
+ * Mirrors the Mojo adapter's same-named suites
+ * (`packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts`), pinning
+ * the Kolon form of each ported shape. The shared adapter-conformance fixtures
+ * (`textarea`, `checkbox`) only exercise the falsy branch of the conditional
+ * spread and the unset branch of the optional attr, so these unit tests pin the
+ * truthy / present branches the fixtures can't reach.
+ */
+
+import { test, expect, describe } from 'bun:test'
+import { compileJSX } from '@barefootjs/jsx'
+import type { ComponentIR } from '@barefootjs/jsx'
+import { XslateAdapter } from '../adapter'
+
+function compileToIR(source: string, adapter?: XslateAdapter): ComponentIR {
+  const result = compileJSX(source.trimStart(), 'test.tsx', {
+    adapter: adapter ?? new XslateAdapter(),
+    outputIR: true,
+  })
+  const irFile = result.files.find(f => f.type === 'ir')
+  if (!irFile) throw new Error('No IR output')
+  return JSON.parse(irFile.content) as ComponentIR
+}
+
+function compileAndGenerate(source: string, adapter?: XslateAdapter) {
+  const a = adapter ?? new XslateAdapter()
+  const ir = compileToIR(source, a)
+  return a.generate(ir)
+}
+
+describe('XslateAdapter - conditional inline-object spread (textarea aria-describedby)', () => {
+  // `{...(cond ? { 'aria-describedby': cond } : {})}` lowers to a Kolon inline
+  // ternary of hashrefs so the falsy `{}` branch OMITS the key
+  // ($bf.spread_attrs does not emit empty entries). The shared fixture only
+  // exercises the falsy branch; this pins the truthy one.
+  test('emits a Kolon inline ternary of hashrefs through $bf.spread_attrs', () => {
+    const { template } = compileAndGenerate(`
+function Box({ describedBy }: { describedBy?: string }) {
+  return <div {...(describedBy ? { 'aria-describedby': describedBy } : {})} />
+}
+`)
+    expect(template).toContain(
+      "$bf.spread_attrs($describedBy ? { 'aria-describedby' => $describedBy } : {})",
+    )
+  })
+
+  test('resolves the value reference and preserves the static key for a second prop', () => {
+    const { template } = compileAndGenerate(`
+function Box({ label }: { label: string }) {
+  return <div {...(label ? { 'data-label': label } : {})} />
+}
+`)
+    expect(template).toContain(
+      "$bf.spread_attrs($label ? { 'data-label' => $label } : {})",
+    )
+  })
+
+  test('falls back to BF101 for a computed (non-static) object key', () => {
+    const adapter = new XslateAdapter()
+    const ir = compileToIR(`
+function Box({ k, v }: { k?: string; v?: string }) {
+  return <div {...(v ? { [k]: v } : {})} />
+}
+`, adapter)
+    adapter.generate(ir)
+    const errs = (adapter as unknown as { errors: { code: string }[] }).errors
+    expect(errs.some(e => e.code === 'BF101')).toBe(true)
+  })
+})
+
+describe('XslateAdapter - local-const conditional-spread resolution (#checkbox icon)', () => {
+  // A FUNCTION-scope const holding a `cond ? {…} : {}` ternary, spread as a bare
+  // identifier (`{...attrs}`), resolves through the same Kolon
+  // ternary-of-hashrefs lowering as the inline form. CheckIcon's
+  // `const sizeAttrs = size ? {…} : {}` is exactly this shape.
+  test('resolves a bare-identifier spread of a function-scope conditional const', () => {
+    const { template } = compileAndGenerate(`
+function Box({ flag }: { flag?: boolean }) {
+  const attrs = flag ? { 'data-on': 'yes' } : {}
+  return <div {...attrs} />
+}
+`)
+    expect(template).toContain(
+      "$bf.spread_attrs($flag ? { 'data-on' => 'yes' } : {})",
+    )
+  })
+
+  // A const that aliases another bare identifier must NOT be forwarded (loop
+  // guard): the resolver bails, so the spread falls through to the standard
+  // lowering emitting the bare `$attrs` variable.
+  test('does not forward a const that aliases another identifier (loop guard)', () => {
+    const { template } = compileAndGenerate(`
+function Box({ other }: { other?: object }) {
+  const attrs = other
+  return <div {...attrs} />
+}
+`)
+    expect(template).toContain('$bf.spread_attrs($attrs)')
+  })
+})
+
+describe('XslateAdapter - Record<staticKeys,scalar>[propKey] spread value (#checkbox icon)', () => {
+  // `const sizeMap: Record<IconSize, number> = { sm: 16, ... }` indexed by a
+  // prop inside a conditional-spread object value lowers to an inline indexed
+  // Kolon hashref `{ ... }[$key]` (bracket index — Kolon rejects Perl's
+  // `->{$key}` arrow-deref). This is CheckIcon's
+  // `{ width: sizeMap[size], height: sizeMap[size] }` shape.
+  test('lowers an indexed module-const map to an inline bracket-indexed hashref', () => {
+    const { template } = compileAndGenerate(`
+const sizeMap: Record<string, number> = { sm: 16, md: 20, lg: 24, xl: 32 }
+function Box({ size }: { size?: string }) {
+  const attrs = size ? { width: sizeMap[size] } : {}
+  return <div {...attrs} />
+}
+`)
+    expect(template).toContain(
+      "{ 'sm' => 16, 'md' => 20, 'lg' => 24, 'xl' => 32 }[$size]",
+    )
+    // Must NOT emit the Perl arrow-deref form (Kolon rejects it).
+    expect(template).not.toContain('->{$size}')
+  })
+
+  test('lowers string-valued record maps too', () => {
+    const { template } = compileAndGenerate(`
+const labelMap: Record<string, string> = { a: 'Alpha', b: 'Beta' }
+function Box({ k }: { k?: string }) {
+  const attrs = k ? { 'data-label': labelMap[k] } : {}
+  return <div {...attrs} />
+}
+`)
+    expect(template).toContain("{ 'a' => 'Alpha', 'b' => 'Beta' }[$k]")
+  })
+
+  // A non-scalar record value (object) is out of shape: the spread object value
+  // can't lower, so the whole spread falls back to BF101.
+  test('refuses a non-scalar record value with BF101 (out-of-shape fallback)', () => {
+    const adapter = new XslateAdapter()
+    const ir = compileToIR(`
+const sizeMap: Record<string, object> = { sm: { w: 1 } }
+function Box({ size }: { size?: string }) {
+  const attrs = size ? { width: sizeMap[size] } : {}
+  return <div {...attrs} />
+}
+`, adapter)
+    adapter.generate(ir)
+    const errs = (adapter as unknown as { errors: { code: string }[] }).errors
+    expect(errs.some(e => e.code === 'BF101')).toBe(true)
+  })
+})
+
+describe('XslateAdapter - props-object inherited-attribute enumeration (#checkbox)', () => {
+  // A SolidJS props-object component reads inherited attributes (`props.id`)
+  // not enumerated in `propsParams`. The bare optional attribute must be guarded
+  // with Kolon `defined` so it's omitted when unset (Hono parity), even though
+  // `id` isn't a declared param.
+  test('guards a props-object bare optional attr (props.id) with defined', () => {
+    const { template } = compileAndGenerate(`
+"use client"
+interface P { tone?: string }
+export function Widget(props: P) {
+  return <button id={props.id}>x</button>
+}
+`)
+    expect(template).toContain(': if (defined $id) {')
+    expect(template).toContain('id="<: $id :>"')
+  })
+})
+
+describe('XslateAdapter - hyphenated child attr hash key (#checkbox)', () => {
+  // A child component prop whose JSX name isn't a bare Kolon identifier
+  // (`<CheckIcon data-slot="..."/>`) must be quoted in the `render_child`
+  // hashref — an unquoted `data-slot => ...` parses as `data - slot`.
+  test('quotes a hyphenated child attribute name in render_child', () => {
+    const { template } = compileAndGenerate(`
+"use client"
+import { Leaf } from './leaf'
+export function Host() {
+  return <div><Leaf data-slot="indicator" size="sm" /></div>
+}
+`)
+    expect(template).toContain("'data-slot' => 'indicator'")
+    // A bare-identifier name stays unquoted.
+    expect(template).toContain('size => ')
+    expect(template).not.toContain('data-slot => ')
+  })
+})
+
+describe('XslateAdapter - nullish optional-attribute omission (textarea rows)', () => {
+  // A no-destructure-default, nillable-typed prop is `undef` when the caller
+  // omits it; guard its bare-reference attribute with Kolon `defined` so it
+  // DROPS instead of rendering `attr=""` — matching Hono's nullish-attribute
+  // omission. Concrete/defaulted props are never `undef` and stay
+  // unconditional.
+  test('guards a no-default nillable attr with a Kolon defined check', () => {
+    const { template } = compileAndGenerate(`
+function C({ rows }: { rows?: number }) {
+  return <textarea rows={rows} />
+}
+`)
+    expect(template).toContain(': if (defined $rows) {')
+    expect(template).toContain('rows="<: $rows :>"')
+  })
+
+  test('leaves a defaulted attr unconditional (scope did not widen)', () => {
+    const { template } = compileAndGenerate(`
+function C({ value = '' }: { value?: string }) {
+  return <textarea value={value} />
+}
+`)
+    // `value` has a destructure default → never undef → unconditional, exactly
+    // like Hono's value="".
+    expect(template).toContain('value="<: $value :>"')
+    expect(template).not.toContain('defined $value')
+  })
+})

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -116,8 +116,7 @@ const XSLATE_PRIMITIVE_EMIT_MAP: Record<string, (args: string[]) => string> =
  * Quote a hashref KEY for Kolon when it isn't a bare-identifier-safe name.
  * Kolon parses `data-slot` as `data - slot` (subtraction) and faults on the
  * undefined `data` symbol, so a hyphenated key (`data-slot`, `aria-label`)
- * must be single-quoted: `'data-slot'`. Mirrors the Mojo adapter's
- * `perlHashKey`. Bare identifiers pass through unquoted.
+ * must be single-quoted: `'data-slot'`. Bare identifiers pass through unquoted.
  */
 function kolonHashKey(name: string): string {
   return /^[A-Za-z_][A-Za-z0-9_]*$/.test(name) ? name : `'${name.replace(/'/g, "\\'")}'`
@@ -196,8 +195,8 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
    * Optional, no-default props that are `undef` when the caller omits them.
    * Their bare-reference attribute emission is guarded with Kolon `defined` so
    * the attribute DROPS rather than rendering `attr=""` (Hono-style nullish
-   * omission, e.g. textarea's `rows`). Mirrors the Mojo adapter's set; the
-   * filter excludes destructure-defaulted, rest, and concrete-primitive props.
+   * omission, e.g. textarea's `rows`). The filter excludes destructure-
+   * defaulted, rest, and concrete-primitive props.
    */
   private nullableOptionalProps: Set<string> = new Set()
 
@@ -949,8 +948,7 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
       //   `{...(COND ? { 'aria-describedby': describedBy } : {})}`
       // Emit a Kolon inline ternary of hashrefs — Perl truthiness handles the
       // condition for free, and the falsy `{}` branch OMITS the key
-      // (`spread_attrs` does NOT emit empty hashref entries). Mirrors the Mojo
-      // adapter's `conditionalSpreadToPerl`.
+      // (`spread_attrs` does NOT emit empty hashref entries).
       const ternaryHashref = this.conditionalSpreadToKolon(trimmed)
       if (ternaryHashref !== null) {
         return `<: $bf.spread_attrs(${ternaryHashref}) | mark_raw :>`
@@ -960,7 +958,7 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
       // (#checkbox / icon). Resolve the bare identifier to its initializer text
       // and route through the same conditional-spread lowering. Only
       // function-scope (`!isModule`) consts whose value is NOT itself a bare
-      // identifier (loop guard) are considered. Mirrors the Mojo adapter.
+      // identifier (loop guard) are considered.
       if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(trimmed)) {
         const localConst = (this.localConstants ?? []).find(
           c => c.name === trimmed && !c.isModule,

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -212,24 +212,15 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
   generate(ir: ComponentIR, options?: AdapterGenerateOptions): AdapterOutput {
     this.componentName = ir.metadata.componentName
     this.propsObjectName = ir.metadata.propsObjectName ?? null
-    // (#checkbox) Enumerate inherited-attribute accesses for the props-object
-    // pattern (`function Checkbox(props: CheckboxProps)`) before deriving
-    // `nullableOptionalProps`, so a bare optional attribute like `id={props.id}`
-    // gets the Kolon `defined`-guard (Hono-style omission). Shared with the Go /
-    // Mojo adapters (single source of truth in `@barefootjs/jsx`). The harness
-    // separately declares the matching stash vars (Pass-1 IR serialization runs
-    // before `generate`, so this mutation doesn't reach it).
+    // (#checkbox) Enumerate the props-object pattern's inherited attribute
+    // accesses (`props.className`/`id`/`disabled`) into propsParams via the
+    // shared helper, before deriving `nullableOptionalProps` below.
     augmentInheritedPropAccesses(ir)
     this.propsParams = ir.metadata.propsParams.map(p => ({ name: p.name }))
     this.localConstants = ir.metadata.localConstants ?? []
-    // No-destructure-default props → `undef` when the caller omits them → guard
-    // their bare-reference attribute emission with Kolon `defined` so the
-    // attribute drops instead of rendering `attr=""` (Hono-style nullish
-    // omission). Mirrors the Mojo adapter's `nullableOptionalProps`: a prop WITH
-    // a destructure default (`value = ''`) is never `undef`, so it's excluded;
-    // concrete-primitive types (`string`/`number`/`boolean`) are excluded too,
-    // matching the Go adapter's nillable-field scope (only `unknown`/object/array
-    // no-default props guard, e.g. `rows` reported as no-default `unknown`).
+    // Bare references to optional, no-default, non-primitive props (e.g.
+    // textarea's `rows`) are `undef` when omitted → `defined`-guarded in
+    // `emitExpression`. See the `nullableOptionalProps` field docstring.
     this.nullableOptionalProps = new Set(
       ir.metadata.propsParams
         .filter(
@@ -894,17 +885,11 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
       if (this.refuseUnsupportedAttrExpression(value.expr, name)) {
         return ''
       }
-      // Hono-style nullish-attribute omission (#textarea rows): when the
-      // attribute value is a BARE reference to an optional, no-default prop
-      // (which is `undef` when the caller omits it), guard the attribute with
-      // Kolon `defined` so it DROPS rather than rendering `attr=""`. The guarded
-      // body reuses the exact normal emission, so escaping is unchanged; only
-      // the presence is conditional. The `: if`/`: }` line directives surround
-      // the attribute inline — `normalizeHTML` collapses the resulting
-      // whitespace, exactly like the boolean-attr and hydration-marker patterns.
-      // Scope is deliberately narrow (bare identifiers resolving to an
-      // optional-no-default prop) so member exprs, calls, concrete/defaulted
-      // props, and boolean attrs are unaffected and still emit unconditionally.
+      // Hono-style nullish omission: a bare reference to an optional,
+      // no-default prop (`nullableOptionalProps`) is `defined`-guarded so the
+      // attribute drops instead of rendering `attr=""`. Narrowly scoped to bare
+      // identifiers — member exprs, calls, and concrete/defaulted props are
+      // unaffected.
       const bareId = value.expr.trim()
       // Normalize a props-object access (`props.id`) to its bare prop name
       // (`id`) so the nullable-optional set — keyed by bare name — matches the
@@ -924,11 +909,8 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
           isBooleanResultExpr(value.expr) || isAriaBooleanAttr(name)
             ? `${name}="<: $bf.bool_str(${perl}) :>"`
             : `${name}="<: ${perl} :>"`
-        // Kolon `:` line directives must each stand alone on their own line
-        // (unlike Mojo's inline `<% if %>` block tags), so wrap the guarded
-        // attribute in leading/trailing newlines. `renderAttributes` joins
-        // attrs with a single space; the surrounding newlines keep `: if` and
-        // `: }` line-isolated while `normalizeHTML` collapses the whitespace.
+        // Kolon `:` line directives must each stand alone on their own line, so
+        // wrap in newlines (`normalizeHTML` collapses the surrounding space).
         return `\n: if (defined ${perl}) {\n${body}\n: }\n`
       }
       if (isBooleanAttr(name) || value.presenceOrUndefined) {

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -113,13 +113,22 @@ const XSLATE_PRIMITIVE_EMIT_MAP: Record<string, (args: string[]) => string> =
  * shape evolves.
  */
 /**
+ * Escape a string for a Kolon/Perl single-quoted literal: backslash first
+ * (so it doesn't double-escape the quote we add next), then the quote. Used
+ * by every `'…'` hashref key/value emitter below.
+ */
+function escapeKolonSingleQuoted(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
+}
+
+/**
  * Quote a hashref KEY for Kolon when it isn't a bare-identifier-safe name.
  * Kolon parses `data-slot` as `data - slot` (subtraction) and faults on the
  * undefined `data` symbol, so a hyphenated key (`data-slot`, `aria-label`)
  * must be single-quoted: `'data-slot'`. Bare identifiers pass through unquoted.
  */
 function kolonHashKey(name: string): string {
-  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(name) ? name : `'${name.replace(/'/g, "\\'")}'`
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(name) ? name : `'${escapeKolonSingleQuoted(name)}'`
 }
 
 function resolveJsxChildrenProp(props: readonly IRProp[]): IRNode[] {
@@ -959,13 +968,13 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
       // and route through the same conditional-spread lowering. Only
       // function-scope (`!isModule`) consts whose value is NOT itself a bare
       // identifier (loop guard) are considered.
-      if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(trimmed)) {
+      if (/^[A-Za-z_$][\w$]*$/.test(trimmed)) {
         const localConst = (this.localConstants ?? []).find(
           c => c.name === trimmed && !c.isModule,
         )
         if (localConst?.value !== undefined) {
           const initTrimmed = localConst.value.trim()
-          if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(initTrimmed)) {
+          if (!/^[A-Za-z_$][\w$]*$/.test(initTrimmed)) {
             const resolved = this.conditionalSpreadToKolon(initTrimmed)
             if (resolved !== null) {
               return `<: $bf.spread_attrs(${resolved}) | mark_raw :>`
@@ -1273,7 +1282,7 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
         indexed !== null
           ? indexed
           : this.convertExpressionToKolon(prop.initializer.getText(sf))
-      entries.push(`'${key.replace(/'/g, "\\'")}' => ${valPerl}`)
+      entries.push(`'${escapeKolonSingleQuoted(key)}' => ${valPerl}`)
     }
     return entries.length === 0 ? '{}' : `{ ${entries.join(', ')} }`
   }
@@ -1293,8 +1302,8 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     if (!parsed) return null
     const entries = parsed.entries.map(e => {
       const mapVal =
-        e.value.kind === 'number' ? e.value.text : `'${e.value.text.replace(/'/g, "\\'")}'`
-      return `'${e.key.replace(/'/g, "\\'")}' => ${mapVal}`
+        e.value.kind === 'number' ? e.value.text : `'${escapeKolonSingleQuoted(e.value.text)}'`
+      return `'${escapeKolonSingleQuoted(e.key)}' => ${mapVal}`
     })
     return `{ ${entries.join(', ')} }[$${parsed.indexPropName}]`
   }

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -60,8 +60,11 @@ import {
   emitParsedExpr,
   emitIRNode,
   emitAttrValue,
+  augmentInheritedPropAccesses,
+  parseRecordIndexAccess,
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr } from './boolean-result'
+import ts from 'typescript'
 
 /**
  * Xslate adapter's IRNode render context. Like the Mojo adapter, Kolon's
@@ -109,6 +112,17 @@ const XSLATE_PRIMITIVE_EMIT_MAP: Record<string, (args: string[]) => string> =
  * AttrValue `kind` discriminator so adapter code stays type-safe if the IR
  * shape evolves.
  */
+/**
+ * Quote a hashref KEY for Kolon when it isn't a bare-identifier-safe name.
+ * Kolon parses `data-slot` as `data - slot` (subtraction) and faults on the
+ * undefined `data` symbol, so a hyphenated key (`data-slot`, `aria-label`)
+ * must be single-quoted: `'data-slot'`. Mirrors the Mojo adapter's
+ * `perlHashKey`. Bare identifiers pass through unquoted.
+ */
+function kolonHashKey(name: string): string {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(name) ? name : `'${name.replace(/'/g, "\\'")}'`
+}
+
 function resolveJsxChildrenProp(props: readonly IRProp[]): IRNode[] {
   const prop = props.find(p => p.name === 'children')
   if (!prop) return []
@@ -170,6 +184,23 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
    */
   private moduleStringConsts: Map<string, string> = new Map()
 
+  /**
+   * Local + module constants from the IR, used by the conditional-spread and
+   * `Record<staticKeys, scalar>[propKey]` lowering paths (#textarea / #checkbox).
+   * Stashed at `generate()` entry so `emitSpread` can resolve a bare local
+   * const (`const sizeAttrs = size ? {…} : {}`) to its initializer text.
+   */
+  private localConstants: IRMetadata['localConstants'] = []
+
+  /**
+   * Optional, no-default props that are `undef` when the caller omits them.
+   * Their bare-reference attribute emission is guarded with Kolon `defined` so
+   * the attribute DROPS rather than rendering `attr=""` (Hono-style nullish
+   * omission, e.g. textarea's `rows`). Mirrors the Mojo adapter's set; the
+   * filter excludes destructure-defaulted, rest, and concrete-primitive props.
+   */
+  private nullableOptionalProps: Set<string> = new Set()
+
   constructor(options: XslateAdapterOptions = {}) {
     super()
     this.options = {
@@ -181,7 +212,34 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
   generate(ir: ComponentIR, options?: AdapterGenerateOptions): AdapterOutput {
     this.componentName = ir.metadata.componentName
     this.propsObjectName = ir.metadata.propsObjectName ?? null
+    // (#checkbox) Enumerate inherited-attribute accesses for the props-object
+    // pattern (`function Checkbox(props: CheckboxProps)`) before deriving
+    // `nullableOptionalProps`, so a bare optional attribute like `id={props.id}`
+    // gets the Kolon `defined`-guard (Hono-style omission). Shared with the Go /
+    // Mojo adapters (single source of truth in `@barefootjs/jsx`). The harness
+    // separately declares the matching stash vars (Pass-1 IR serialization runs
+    // before `generate`, so this mutation doesn't reach it).
+    augmentInheritedPropAccesses(ir)
     this.propsParams = ir.metadata.propsParams.map(p => ({ name: p.name }))
+    this.localConstants = ir.metadata.localConstants ?? []
+    // No-destructure-default props → `undef` when the caller omits them → guard
+    // their bare-reference attribute emission with Kolon `defined` so the
+    // attribute drops instead of rendering `attr=""` (Hono-style nullish
+    // omission). Mirrors the Mojo adapter's `nullableOptionalProps`: a prop WITH
+    // a destructure default (`value = ''`) is never `undef`, so it's excluded;
+    // concrete-primitive types (`string`/`number`/`boolean`) are excluded too,
+    // matching the Go adapter's nillable-field scope (only `unknown`/object/array
+    // no-default props guard, e.g. `rows` reported as no-default `unknown`).
+    this.nullableOptionalProps = new Set(
+      ir.metadata.propsParams
+        .filter(
+          p =>
+            p.defaultValue === undefined &&
+            !p.isRest &&
+            p.type?.kind !== 'primitive',
+        )
+        .map(p => p.name),
+    )
     // Record string-typed signals and props so equality comparisons against
     // them lower to `eq`/`ne`. A signal is string-typed when its inferred
     // type is `string` (or, defensively, when its initial value is a bare
@@ -665,12 +723,12 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
    * below, not threaded through the hashref entry list.
    */
   private readonly componentPropEmitter: AttrValueEmitter = {
-    emitLiteral: (value, name) => `${name} => '${value.value}'`,
+    emitLiteral: (value, name) => `${kolonHashKey(name)} => '${value.value}'`,
     emitExpression: (value, name) => {
       if (value.parts) {
-        return `${name} => ${this.convertTemplateLiteralPartsToKolon(value.parts)}`
+        return `${kolonHashKey(name)} => ${this.convertTemplateLiteralPartsToKolon(value.parts)}`
       }
-      return `${name} => ${this.convertExpressionToKolon(value.expr)}`
+      return `${kolonHashKey(name)} => ${this.convertExpressionToKolon(value.expr)}`
     },
     emitSpread: (value) => {
       // Kolon hashrefs can't be splatted into the entry list the way Perl
@@ -682,9 +740,9 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
       return this.convertExpressionToKolon(value.expr)
     },
     emitTemplate: (value, name) =>
-      `${name} => ${this.convertTemplateLiteralPartsToKolon(value.parts)}`,
-    emitBooleanAttr: (_value, name) => `${name} => 1`,
-    emitBooleanShorthand: (_value, name) => `${name} => 1`,
+      `${kolonHashKey(name)} => ${this.convertTemplateLiteralPartsToKolon(value.parts)}`,
+    emitBooleanAttr: (_value, name) => `${kolonHashKey(name)} => 1`,
+    emitBooleanShorthand: (_value, name) => `${kolonHashKey(name)} => 1`,
     // JSX children flow through the Kolon macro capture below; they're not
     // part of the hashref entry list.
     emitJsxChildren: () => '',
@@ -836,6 +894,43 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
       if (this.refuseUnsupportedAttrExpression(value.expr, name)) {
         return ''
       }
+      // Hono-style nullish-attribute omission (#textarea rows): when the
+      // attribute value is a BARE reference to an optional, no-default prop
+      // (which is `undef` when the caller omits it), guard the attribute with
+      // Kolon `defined` so it DROPS rather than rendering `attr=""`. The guarded
+      // body reuses the exact normal emission, so escaping is unchanged; only
+      // the presence is conditional. The `: if`/`: }` line directives surround
+      // the attribute inline — `normalizeHTML` collapses the resulting
+      // whitespace, exactly like the boolean-attr and hydration-marker patterns.
+      // Scope is deliberately narrow (bare identifiers resolving to an
+      // optional-no-default prop) so member exprs, calls, concrete/defaulted
+      // props, and boolean attrs are unaffected and still emit unconditionally.
+      const bareId = value.expr.trim()
+      // Normalize a props-object access (`props.id`) to its bare prop name
+      // (`id`) so the nullable-optional set — keyed by bare name — matches the
+      // SolidJS props-object pattern, not just destructured params.
+      const normalizedBareId =
+        this.propsObjectName && bareId.startsWith(`${this.propsObjectName}.`)
+          ? bareId.slice(this.propsObjectName.length + 1)
+          : bareId
+      if (
+        !isBooleanAttr(name) &&
+        !value.presenceOrUndefined &&
+        /^[A-Za-z_$][\w$]*$/.test(normalizedBareId) &&
+        this.nullableOptionalProps.has(normalizedBareId)
+      ) {
+        const perl = this.convertExpressionToKolon(value.expr)
+        const body =
+          isBooleanResultExpr(value.expr) || isAriaBooleanAttr(name)
+            ? `${name}="<: $bf.bool_str(${perl}) :>"`
+            : `${name}="<: ${perl} :>"`
+        // Kolon `:` line directives must each stand alone on their own line
+        // (unlike Mojo's inline `<% if %>` block tags), so wrap the guarded
+        // attribute in leading/trailing newlines. `renderAttributes` joins
+        // attrs with a single space; the surrounding newlines keep `: if` and
+        // `: }` line-isolated while `normalizeHTML` collapses the whitespace.
+        return `\n: if (defined ${perl}) {\n${body}\n: }\n`
+      }
       if (isBooleanAttr(name) || value.presenceOrUndefined) {
         // Boolean attributes: render conditionally (present or absent).
         return `<: ${this.convertExpressionToKolon(value.expr)} ? '${name}' : '' :>`
@@ -867,6 +962,36 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
           `${JSON.stringify(p.name)} => $${p.name}`,
         )
         return `<: $bf.spread_attrs({${entries.join(', ')}}) | mark_raw :>`
+      }
+      // Conditional inline-object spread (#textarea):
+      //   `{...(COND ? { 'aria-describedby': describedBy } : {})}`
+      // Emit a Kolon inline ternary of hashrefs — Perl truthiness handles the
+      // condition for free, and the falsy `{}` branch OMITS the key
+      // (`spread_attrs` does NOT emit empty hashref entries). Mirrors the Mojo
+      // adapter's `conditionalSpreadToPerl`.
+      const ternaryHashref = this.conditionalSpreadToKolon(trimmed)
+      if (ternaryHashref !== null) {
+        return `<: $bf.spread_attrs(${ternaryHashref}) | mark_raw :>`
+      }
+      // Function-scope local const holding a conditional inline-object
+      //   `const sizeAttrs = size ? {…} : {}` then `{...sizeAttrs}`
+      // (#checkbox / icon). Resolve the bare identifier to its initializer text
+      // and route through the same conditional-spread lowering. Only
+      // function-scope (`!isModule`) consts whose value is NOT itself a bare
+      // identifier (loop guard) are considered. Mirrors the Mojo adapter.
+      if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(trimmed)) {
+        const localConst = (this.localConstants ?? []).find(
+          c => c.name === trimmed && !c.isModule,
+        )
+        if (localConst?.value !== undefined) {
+          const initTrimmed = localConst.value.trim()
+          if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(initTrimmed)) {
+            const resolved = this.conditionalSpreadToKolon(initTrimmed)
+            if (resolved !== null) {
+              return `<: $bf.spread_attrs(${resolved}) | mark_raw :>`
+            }
+          }
+        }
       }
       const perlExpr = this.convertExpressionToKolon(value.expr)
       return `<: $bf.spread_attrs(${perlExpr}) | mark_raw :>`
@@ -1100,6 +1225,98 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
       },
     })
     return true
+  }
+
+  /**
+   * Lower a conditional inline-object spread
+   *   `COND ? { 'aria-describedby': describedBy } : {}`
+   * to a Kolon inline ternary of hashrefs
+   *   `$describedBy ? { 'aria-describedby' => $describedBy } : {}`.
+   * Both branches must be object literals; the condition + values route through
+   * `convertExpressionToKolon`. Returns `null` for any other shape so the caller
+   * falls back to its normal lowering. Mirror of `conditionalSpreadToPerl`.
+   */
+  private conditionalSpreadToKolon(expr: string): string | null {
+    const sf = ts.createSourceFile('__spread.ts', `(${expr})`, ts.ScriptTarget.Latest, true)
+    if (sf.statements.length !== 1) return null
+    const stmt = sf.statements[0]
+    if (!ts.isExpressionStatement(stmt)) return null
+    let node: ts.Expression = stmt.expression
+    while (ts.isParenthesizedExpression(node)) node = node.expression
+    if (!ts.isConditionalExpression(node)) return null
+    const unwrap = (e: ts.Expression): ts.Expression => {
+      let n = e
+      while (ts.isParenthesizedExpression(n)) n = n.expression
+      return n
+    }
+    const whenTrue = unwrap(node.whenTrue)
+    const whenFalse = unwrap(node.whenFalse)
+    if (!ts.isObjectLiteralExpression(whenTrue) || !ts.isObjectLiteralExpression(whenFalse)) {
+      return null
+    }
+    const condPerl = this.convertExpressionToKolon(node.condition.getText(sf))
+    const truePerl = this.objectLiteralToKolonHashref(whenTrue, sf)
+    const falsePerl = this.objectLiteralToKolonHashref(whenFalse, sf)
+    if (truePerl === null || falsePerl === null) return null
+    return `${condPerl} ? ${truePerl} : ${falsePerl}`
+  }
+
+  /**
+   * Convert a static object literal into a Kolon hashref string for a
+   * conditional spread. Only static string/identifier keys are allowed; values
+   * resolve via `convertExpressionToKolon` (or the `Record[propKey]` index
+   * lowering). Returns `null` for any computed/spread/dynamic key. Empty object
+   * → `{}`. Mirror of `objectLiteralToPerlHashref`.
+   */
+  private objectLiteralToKolonHashref(
+    obj: ts.ObjectLiteralExpression,
+    sf: ts.SourceFile,
+  ): string | null {
+    const entries: string[] = []
+    for (const prop of obj.properties) {
+      if (!ts.isPropertyAssignment(prop)) return null
+      let key: string
+      if (ts.isIdentifier(prop.name)) {
+        key = prop.name.text
+      } else if (ts.isStringLiteral(prop.name) || ts.isNoSubstitutionTemplateLiteral(prop.name)) {
+        key = prop.name.text
+      } else {
+        return null
+      }
+      const initNode = (() => {
+        let n: ts.Expression = prop.initializer
+        while (ts.isParenthesizedExpression(n)) n = n.expression
+        return n
+      })()
+      const indexed = this.recordIndexAccessToKolon(initNode)
+      const valPerl =
+        indexed !== null
+          ? indexed
+          : this.convertExpressionToKolon(prop.initializer.getText(sf))
+      entries.push(`'${key.replace(/'/g, "\\'")}' => ${valPerl}`)
+    }
+    return entries.length === 0 ? '{}' : `{ ${entries.join(', ')} }`
+  }
+
+  /**
+   * Lower a spread-object VALUE of the form `IDENT[KEY]` (CheckIcon's
+   * `sizeMap[size]`) to an inline indexed Kolon hashref
+   *   `{ 'sm' => 16, 'md' => 20, ... }[$size]`.
+   * Reuses the shared structural parse (`parseRecordIndexAccess`); this wrapper
+   * only does the single-quote escaping + Kolon index emit. NB: Kolon indexes a
+   * hashref literal with bracket syntax `{…}[$key]`, NOT Perl's arrow-deref
+   * `{…}->{$key}` (which Kolon's parser rejects) — this is the one divergence
+   * from the Mojo `recordIndexAccessToPerl` emit.
+   */
+  private recordIndexAccessToKolon(val: ts.Expression): string | null {
+    const parsed = parseRecordIndexAccess(val, this.localConstants ?? [], this.propsParams)
+    if (!parsed) return null
+    const entries = parsed.entries.map(e => {
+      const mapVal =
+        e.value.kind === 'number' ? e.value.text : `'${e.value.text.replace(/'/g, "\\'")}'`
+      return `'${e.key.replace(/'/g, "\\'")}' => ${mapVal}`
+    })
+    return `{ ${entries.join(', ')} }[$${parsed.indexPropName}]`
   }
 
   private convertExpressionToKolon(expr: string): string {

--- a/packages/adapter-xslate/src/test-render.ts
+++ b/packages/adapter-xslate/src/test-render.ts
@@ -188,9 +188,17 @@ export async function renderXslateComponent(options: RenderOptions): Promise<str
     for (const name of reachable) {
       const entry = childTemplates.get(name)
       if (!entry) continue
-      const probe = adapter.generate(entry.ir, { siblingTemplatesRegistered: true })
-      void probe
-      const childErrors = (entry.ir.errors ?? []).filter(e => e.severity === 'error')
+      // The child was first compiled WITHOUT `siblingTemplatesRegistered`, so
+      // `entry.ir.errors` may already carry suppressible BF103s (cross-template
+      // loop references the harness DOES register). Re-generate with siblings
+      // registered and inspect ONLY the errors that pass appends — `generate`
+      // resets its own error list and appends to `ir.errors`, so anything after
+      // the pre-existing count is the authoritative siblings-registered result.
+      const before = entry.ir.errors?.length ?? 0
+      adapter.generate(entry.ir, { siblingTemplatesRegistered: true })
+      const childErrors = (entry.ir.errors ?? [])
+        .slice(before)
+        .filter(e => e.severity === 'error')
       if (childErrors.length > 0) {
         throw new Error(
           `Compilation errors in reachable child ${name}:\n${childErrors.map(e => e.message).join('\n')}`,

--- a/packages/adapter-xslate/src/test-render.ts
+++ b/packages/adapter-xslate/src/test-render.ts
@@ -93,14 +93,22 @@ export async function renderXslateComponent(options: RenderOptions): Promise<str
   const { source, adapter, props, components } = options
 
   // Compile child components first.
+  //
+  // A child SOURCE FILE may export more components than the parent actually
+  // references (e.g. `../icon` exports ~30 icons + a generic `Icon`, but
+  // `Checkbox` only imports `CheckIcon`). Some of those unreferenced
+  // components legitimately can't lower to Kolon — the generic `Icon` spreads
+  // `{...props}` onto CHILD components (`<GitHubIcon {...props}/>`), which has
+  // no Kolon form (`%{$props}` flatten is Perl-only; same engine divergence as
+  // the `button` fixture). Throwing on those would block a fixture that never
+  // renders them. So defer the per-file error gate: collect every component's
+  // template + IR up front, then (after the parent compile pins the reachable
+  // set) re-generate ONLY the reachable children and throw if any of THOSE
+  // error. Mirrors the Go harness's reachable-children emission (#checkbox).
   const childTemplates: Map<string, { template: string; ir: ComponentIR }> = new Map()
   if (components) {
     for (const [filename, childSource] of Object.entries(components)) {
       const childResult = compileJSX(childSource, filename, { adapter, outputIR: true })
-      const childErrors = childResult.errors.filter(e => e.severity === 'error')
-      if (childErrors.length > 0) {
-        throw new Error(`Compilation errors in ${filename}:\n${childErrors.map(e => e.message).join('\n')}`)
-      }
       const childTemplateFiles = childResult.files.filter(f => f.type === 'markedTemplate')
       if (childTemplateFiles.length === 0) throw new Error(`No marked template for ${filename}`)
       const childIrFiles = childResult.files.filter(f => f.type === 'ir')
@@ -157,6 +165,39 @@ export async function renderXslateComponent(options: RenderOptions): Promise<str
     }
   }
   if (!templateFile) throw new Error('No marked template in compile output')
+
+  // Reachable-children error gate (#checkbox). Now that the entry-point `ir` is
+  // pinned, close transitively over its cross-file component imports and verify
+  // each reachable child lowers without error — re-generating the child IR
+  // through a fresh adapter to attribute errors per component (the aggregate
+  // compile errors aren't component-tagged). A child file may export
+  // unreferenced components that legitimately can't lower (e.g. `../icon`'s
+  // generic `Icon`); those are dropped silently rather than failing a fixture
+  // that never renders them.
+  {
+    const reachable = new Set<string>()
+    const queue = [...collectImportedComponentNames(ir)]
+    while (queue.length > 0) {
+      const name = queue.shift()!
+      if (reachable.has(name)) continue
+      const entry = childTemplates.get(name)
+      if (!entry) continue // in-source sibling or non-compiled import
+      reachable.add(name)
+      queue.push(...collectImportedComponentNames(entry.ir))
+    }
+    for (const name of reachable) {
+      const entry = childTemplates.get(name)
+      if (!entry) continue
+      const probe = adapter.generate(entry.ir, { siblingTemplatesRegistered: true })
+      void probe
+      const childErrors = (entry.ir.errors ?? []).filter(e => e.severity === 'error')
+      if (childErrors.length > 0) {
+        throw new Error(
+          `Compilation errors in reachable child ${name}:\n${childErrors.map(e => e.message).join('\n')}`,
+        )
+      }
+    }
+  }
 
   const componentName = ir.metadata.componentName
 
@@ -243,6 +284,25 @@ print \$html;
   } finally {
     await rm(tempDir, { recursive: true, force: true }).catch(() => {})
   }
+}
+
+/**
+ * Component names a component IR imports from sibling source files — i.e.
+ * non-type imports from relative (`./` / `../`) specifiers. Used to compute the
+ * transitive set of child components a fixture actually references (#checkbox).
+ * Mirrors the Go harness helper of the same name.
+ */
+function collectImportedComponentNames(ir: ComponentIR): string[] {
+  const names: string[] = []
+  for (const imp of ir.metadata.imports ?? []) {
+    if (imp.isTypeOnly) continue
+    if (!imp.source.startsWith('.')) continue
+    for (const spec of imp.specifiers ?? []) {
+      if (spec.isNamespace) continue
+      names.push(spec.alias ?? spec.name)
+    }
+  }
+  return names
 }
 
 /**


### PR DESCRIPTION
## Summary

First step toward aligning the two Perl-targeting adapters: brings the **Text::Xslate (Kolon)** adapter up to the **Mojolicious** adapter on the Phase 2b `textarea` and `checkbox` conformance fixtures (both were skipped on xslate, already pass on Go + Mojo). Both are now **unskipped and byte-parity green** with the Hono reference.

No compiler changes — this reuses the shared `@barefootjs/jsx` helpers that the Go/Mojo work introduced (`augmentInheritedPropAccesses`, `parseRecordIndexAccess`, `extractSsrDefaults`) and ports the adapter-side lowering to Kolon syntax.

### Ported (Kolon form, mirroring the Mojo adapter)
- **Conditional inline-object spread** — `{...(cond ? { 'aria-describedby': x } : {})}` and the function-scope local-const form `const sizeAttrs = size ? {…} : {}; {...sizeAttrs}` now lower to a Kolon inline ternary of hashrefs through `$bf.spread_attrs(...)` instead of `BF101`.
- **`Record<staticKeys,scalar>[propKey]` spread value** — CheckIcon's `sizeMap[size]` lowers via the shared `parseRecordIndexAccess` to `{ 'sm' => 16, ... }[$size]`. *Kolon indexes a hashref literal with bracket syntax `{…}[$key]`, not Perl's arrow-deref `{…}->{$key}` (which Kolon's parser rejects) — the one emit divergence from the Mojo helper.*
- **Nullish optional-attribute omission** — textarea's optional `rows` guards with a Kolon `: if (defined $rows) { … : }` block so it drops when unset rather than rendering `rows=""`.
- **Props-object inherited-attribute enumeration** — `function Checkbox(props: CheckboxProps)` calls the shared `augmentInheritedPropAccesses(ir)`.
- **Hyphenated child rest-bag key quoting** — `<CheckIcon data-slot="checkbox-indicator" />` quotes the key in `render_child` (`'data-slot' => …`); an unquoted hyphenated key parses as subtraction in Kolon.

### The `{...props}`-on-`<svg>` question
It turned out **not** to be on the `<svg>` (a rest param `{...props}` lowers fine to `$bf.spread_attrs($props)`). The refusal came from the generic `Icon` component splatting `{...props}` onto **child icon components** — a documented engine divergence (no Kolon list-flatten, same as the `button` fixture). Since `Checkbox` only references `CheckIcon`, the fix was the harness's transitively-referenced-children gate, not a lowering change; `Icon`'s refusal stays correct.

### Validation (all self-re-run, 0 fail)
- Xslate conformance: **297 pass / 5 skip / 0 fail** (+textarea +checkbox vs 295 baseline)
- Xslate full package incl. new regression suite: **311 pass / 0 fail**
- Mojo **411** / Go **459** / `packages/jsx` **1935** / adapter-tests+client+shared **1105** — all 0 fail, unaffected (change is xslate-only)
- `tsc --noEmit` clean; Hono reference unchanged.

### Follow-up
After this, xslate trails Mojo only on the older #971-era gaps (`logical-or-jsx`, `nullish-coalescing-jsx`, `branch-map`, `return-logical-or/-map/-nullish-coalescing`, `style-object-dynamic`, `reactive-props`) — which Mojo skips but xslate passes. A separate PR will close those on Mojo to fully align the two adapters.

🤖 https://claude.ai/code/session_01UatvBGZG5csvttdtgcSf7p

---
_Generated by [Claude Code](https://claude.ai/code/session_01UatvBGZG5csvttdtgcSf7p)_