### PR TITLE
test(mojo): remove stale #971-era skips — align with xslate on 7 fixtures

### DIFF
--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -17,41 +17,7 @@ runAdapterConformanceTests({
   name: 'mojo',
   factory: () => new MojoAdapter(),
   render: renderMojoComponent,
-  // Dynamic style objects (non-static values) require Perl template
-  // interpolation support for JS object literals, not yet implemented.
-  // Mojo currently emits invalid Perl silently for this shape — the
-  // Go adapter records BF101 via `convertExpressionToGo()` for the
-  // same fixture (now contracted via `expectedDiagnostics`), but the
-  // Mojo adapter's expression gate doesn't yet lift the same
-  // failure into a `CompilerError`, so the fixture stays on `skipJsx`
-  // until that gate is extended (#1266 follow-up).
-  // `logical-or-jsx`, `nullish-coalescing-jsx`, `branch-map` reference
-  // a prop directly inside a conditional branch (`$label`, `$banner`,
-  // `$active`). The Mojo adapter emits these as bare Perl variables
-  // (`% if ($label) { ... }`) without a corresponding
-  // `my $label = ...;` declaration, so Perl rejects the template with
-  // "Global symbol requires explicit package name". Same class of
-  // Perl-scoping divergence that motivates the existing skips —
-  // out of scope for the #971 refactor.
-  // Return-position variants of the same divergence —
-  // `return-logical-or` / `return-nullish-coalescing` reference
-  // `$label` / `$banner` directly; `return-map` iterates over `$items`
-  // without a `my` declaration.
-  //
-  // `static-array-children` / `static-array-from-props` /
-  // `static-array-from-props-with-component` are no longer here —
-  // they're covered by `expectedDiagnostics` below, asserting that
-  // the adapter emits `BF103` / `BF104` at build time instead of
-  // silently emitting invalid Perl / unresolved cross-template
-  // references (#1266).
   skipJsx: [
-    'style-object-dynamic',
-    'logical-or-jsx',
-    'nullish-coalescing-jsx',
-    'branch-map',
-    'return-logical-or',
-    'return-nullish-coalescing',
-    'return-map',
     // #1297 fixed the harness-side IR emission gate. The remaining
     // gap is adapter-side: the Mojo adapter has no SSR context-
     // propagation mechanism, so `<Ctx.Provider value="dark">` doesn't
@@ -122,6 +88,11 @@ runAdapterConformanceTests({
     // surfaces BF101 with a wrap-in-`/* @client */` suggestion, matching
     // the Go adapter's behaviour.
     'style-3-signals': [{ code: 'BF101', severity: 'error' }],
+    // Dynamic JS object literal in `style={{ … }}` — same no-EP-form
+    // refusal as `style-3-signals`; `refuseUnsupportedAttrExpression`
+    // surfaces BF101 (mirrors the xslate + Go adapters). Was a stale
+    // `skipJsx` entry claiming the gate didn't lift to a CompilerError.
+    'style-object-dynamic': [{ code: 'BF101', severity: 'error' }],
     // #1244 stress catalog #12 (#1323): tagged-template-literal call
     // (`cn\`base \${tone()}\``) — same family as #1322 above and refused
     // via the same gate.


### PR DESCRIPTION
## Summary

Continues aligning the two Perl-targeting adapters: closes 7 of the 8 fixtures the **Mojolicious** adapter skipped but the **Text::Xslate** adapter already passes. **Test-file only — no adapter or compiler change.**

A difficulty spike found the `skipJsx` rationale for these fixtures was **stale** — it described a pre-#971 state where bare `$label`/`$banner`/`$items` references tripped Perl strict mode. They render correctly today:
- `buildPerlProps` seeds optional params as `undef`, so `Mojo::Template`'s `vars => 1` auto-declares `my $label` / `my $items` from the props hash.
- Loop bodies emit their own `% my $n = $items->[$_i];`.

### Changes
- **Unskips 6 fixtures that already pass on Mojo with zero code change**: `logical-or-jsx`, `nullish-coalescing-jsx`, `branch-map`, `return-logical-or`, `return-nullish-coalescing`, `return-map`.
- **Reclassifies `style-object-dynamic`** from `skipJsx` to `expectedDiagnostics` as `BF101` — the adapter already records that diagnostic via `refuseUnsupportedAttrExpression` (same as the existing `style-3-signals` entry, and the xslate/Go adapters). The old skip comment claiming the gate "emits invalid Perl silently / doesn't lift to a CompilerError" was stale.
- Removes the now-incorrect rationale comment block.

### Validation
- Mojo conformance: **418 pass / 5 skip / 0 fail** (was 411 pass — the 6 unskipped fixtures now run + pass; `style-object-dynamic` is now a positive BF101 contract).

### Remaining gap
After this, Mojo trails xslate on exactly **one** fixture — `reactive-props` — which is a **test-harness child-scope-id** issue (Mojo's `buildChildRenderers` hardcodes `test_<sN>` instead of deriving `<parentScope>_<slotId>` from the `_bf_slot` the production adapter already passes; xslate's harness does this correctly). It's a separate, moderate harness fix tracked as a follow-up to fully align the two adapters.

🤖 https://claude.ai/code/session_01UatvBGZG5csvttdtgcSf7p

---
_Generated by [Claude Code](https://claude.ai/code/session_01UatvBGZG5csvttdtgcSf7p)_