### PR TITLE
fix(mojo): derive child scope id from parent — enable reactive-props parity with xslate

### DIFF
--- a/.changeset/mojo-child-scope-id-reactive-props.md
+++ b/.changeset/mojo-child-scope-id-reactive-props.md
@@ -1,0 +1,12 @@
+---
+"@barefootjs/mojolicious": patch
+---
+
+Fix the Mojolicious test renderer's child component scope id: it hardcoded a
+literal `test_<slotId>` prefix, so a composed child rendered
+`bf-s="test_s5"` instead of `<parentScope>_<slotId>` (e.g.
+`ReactiveProps_test_s5`) like Hono / CSR. Children now derive their scope id
+from the parent's live `$bf->_scope_id`, mirroring the xslate adapter's
+`rootChildScopePrefix`. This unblocks the `reactive-props` conformance fixture
+on Mojo (xslate already passed it), bringing the two Perl-targeting adapters
+to parity on it.

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -26,14 +26,13 @@ runAdapterConformanceTests({
     // never receives a `theme` key. Provider SSR coverage on Mojo
     // waits on that adapter feature; see #1297 follow-up.
     'context-provider',
-    // Multi-component fixtures still diverge because Mojo's child
-    // template emitter pins the child's `bf-s` to the literal
-    // `test_<sN>` (`_scope_id("test_$sid")` in `test-render.ts`)
-    // instead of `<ChildName>_<id>_<sN>` like Hono / CSR. Same family
-    // of test-harness scope-id plumbing the `componentName` option
-    // fixed on the Hono side. Separate follow-up.
+    // Multi-component shared fixtures with per-item loop state. The child
+    // scope-id plumbing is now fixed (children derive `<parentScope>_<sN>`
+    // from `$bf->_scope_id` in `test-render.ts`, which unblocked
+    // `reactive-props`); these two still diverge on additional per-item
+    // loop-state seeding the Mojo harness doesn't yet replicate. (xslate
+    // skips the same pair.)
     'toggle-shared',
-    'reactive-props',
     'props-reactivity-comparison',
     // #1467 Phase 2b `site/ui` primitives still pending cross-adapter parity
     // (label / input / textarea / checkbox now participate):

--- a/packages/adapter-mojolicious/src/test-render.ts
+++ b/packages/adapter-mojolicious/src/test-render.ts
@@ -349,7 +349,12 @@ function buildChildRenderers(
     }
     lines.push(`    ${slotIdsPerl}`)
     lines.push(`    my $child_bf = BarefootJS->new($c, {});`)
-    lines.push(`    $child_bf->_scope_id("test_$sid");`)
+    // Child scope id derives from the PARENT's live scope id, not a literal
+    // `test_` prefix — so `<ReactiveProps_test>_s5` matches Hono / CSR (and
+    // survives an explicit `__instanceId`). Mirrors xslate's
+    // `rootChildScopePrefix` (`$bf->_scope_id`); `$bf` is the parent instance
+    // captured by this renderer closure.
+    lines.push(`    $child_bf->_scope_id($bf->_scope_id . "_$sid");`)
     lines.push(`    my $rendered = $child_mt->render($child_tmpl, { %$child_props, bf => $child_bf });`)
     lines.push(`    die $rendered->to_string if ref $rendered;`)
     lines.push(`    chomp $rendered;`)


### PR DESCRIPTION
## Summary

The final piece of Mojo ↔ Xslate alignment: unblocks the **last** fixture the Mojolicious adapter skipped but Text::Xslate passes — `reactive-props`. Stacked on #1764. **Test-harness only — no production adapter or compiler change.**

### Root cause
Mojo's test renderer (`packages/adapter-mojolicious/src/test-render.ts`, `buildChildRenderers`) hardcoded a literal `test_<slotId>` prefix for composed child components, so a child rendered `bf-s="test_s5"` instead of `<parentScope>_<slotId>` — e.g. the expected `ReactiveProps_test_s5`. The production adapter is correct (it passes `_bf_slot`); only the harness's scope-id derivation was wrong.

### Fix
Children now derive their scope id from the parent's live `$bf->_scope_id` (captured by the renderer closure), mirroring the xslate adapter's `rootChildScopePrefix`. One line:

```diff
- $child_bf->_scope_id("test_$sid");
+ $child_bf->_scope_id($bf->_scope_id . "_$sid");
```

### Unskipped
`reactive-props` removed from Mojo's `skipJsx`. The remaining shared-component skips (`toggle-shared`, `props-reactivity-comparison`) need additional per-item loop-state seeding and stay skipped — **xslate skips the same pair**, so after this the two Perl adapters' skip sets are identical.

### Validation
- Mojo conformance: **419 pass / 5 skip / 0 fail** (+reactive-props vs the 418 of #1764).
- Other adapters unaffected (harness change is Mojo-only).

### Result: Mojo and Xslate are now aligned
Both skip exactly: `context-provider`, `toggle-shared`, `props-reactivity-comparison`, `toggle`, `switch`, `kbd`.

🤖 https://claude.ai/code/session_01UatvBGZG5csvttdtgcSf7p

---
_Generated by [Claude Code](https://claude.ai/code/session_01UatvBGZG5csvttdtgcSf7p)_