### PR TITLE
test(adapters): drop stale skips — Go +return-map/+kbd, Mojo +kbd, xslate pins kbd BF101

### DIFF
--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -35,7 +35,6 @@ runAdapterConformanceTests({
   // `BF104` at build time instead of silently emitting invalid
   // template syntax (#1266).
   skipJsx: [
-    'return-map',
     // #1297 fixed the harness-side IR emission gate (multi-component
     // sources now emit one `ir` file per component, and the harness
     // picks the entry-point IR). The remaining gap is adapter-side:
@@ -76,16 +75,12 @@ runAdapterConformanceTests({
     // option fixed on the Hono side. Separate follow-up.
     'toggle-shared',
     'props-reactivity-comparison',
-    // #1467 Phase 2b `site/ui` primitives still pending cross-adapter parity
-    // (label / input / textarea / checkbox now participate):
+    // #1467 Phase 2b `site/ui` primitives still pending cross-adapter parity:
     //   toggle / switch — the reactive `classes` memo interpolates
     //     `Record<T,string>[variant|size]` lookups, which have no SSR
     //     lowering yet (known limitation).
-    //   kbd — multi-export source (Kbd / KbdGroup); the harness renders the
-    //     last-registered export rather than the pinned Kbd.
     'toggle',
     'switch',
-    'kbd',
   ],
   // Per-fixture build-time contracts for shapes the Go template
   // adapter intentionally refuses to lower. Lives here (not on the

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -34,16 +34,12 @@ runAdapterConformanceTests({
     // skips the same pair.)
     'toggle-shared',
     'props-reactivity-comparison',
-    // #1467 Phase 2b `site/ui` primitives still pending cross-adapter parity
-    // (label / input / textarea / checkbox now participate):
+    // #1467 Phase 2b `site/ui` primitives still pending cross-adapter parity:
     //   toggle / switch — the reactive `classes` memo interpolates
     //     `Record<T,string>[variant|size]` lookups, which have no SSR
     //     lowering yet (known limitation).
-    //   kbd — multi-export source (Kbd / KbdGroup); the harness renders the
-    //     last-registered export rather than the pinned Kbd.
     'toggle',
     'switch',
-    'kbd',
   ],
   // Per-fixture build-time contracts for shapes the Mojo adapter
   // intentionally refuses to lower. Owned by this adapter test file

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -47,17 +47,13 @@ runAdapterConformanceTests({
     'toggle-shared',
     'props-reactivity-comparison',
     // #1467 Phase 2b interactive `site/ui` primitives. `textarea` and
-    // `checkbox` now PASS (conditional inline-object spread, nullish
-    // optional-attribute omission, `Record[propKey]` spread values,
-    // props-object inherited-attr enumeration, and hyphenated child hash keys
-    // were ported from the Mojo adapter in Kolon form). The remaining three
-    // stay skipped: cross-adapter SSR parity for them is a later phase (they
-    // participate in Hono SSR conformance + the fixture-hydrate runtime layer
-    // for now); mojo skips the same three. Confirmed render-mismatch, not a
-    // hard error.
+    // `checkbox` now PASS. `toggle` / `switch` stay skipped: their reactive
+    // `classes` memo interpolates `Record<T,string>[variant|size]` lookups
+    // with no SSR lowering yet (mojo skips the same pair). `kbd` is NOT a
+    // render-mismatch — it's a BF101 refusal (Kolon can't splat the Slot's
+    // `{...props}`), so it's pinned in `expectedDiagnostics` below.
     'toggle',
     'switch',
-    'kbd',
   ],
   // Per-fixture build-time contracts for shapes the Xslate adapter
   // intentionally refuses to lower. Mirrors mojo's set — the lowering
@@ -98,6 +94,10 @@ runAdapterConformanceTests({
     // lowers the same shape; this is a genuine engine divergence, pinned
     // declaratively here.
     'button': [{ code: 'BF101', severity: 'error' }],
+    // `kbd` auto-infers the same `<Slot>` `{...props}` spread as `button`
+    // above — refused with BF101 for the identical Kolon engine reason, not a
+    // render-mismatch (so it's pinned here, not in `skipJsx`).
+    'kbd': [{ code: 'BF101', severity: 'error' }],
     // JS object literal in an attribute value (`style={{ … }}`) has no
     // Kolon form — refused via the same gate as mojo (BF101).
     'style-3-signals': [{ code: 'BF101', severity: 'error' }],


### PR DESCRIPTION
## Summary

First increment of the cross-adapter **Hono-compatibility cleanup**: removes stale / mis-filed `skipJsx` entries across all three SSR template adapters. **Test-file only — no adapter or compiler change.** An audit flagged these as no longer real blockers; each was verified by running the adapter's conformance with the entry removed (Go with the proper `GOTOOLCHAIN=go1.25.6` env, so renders actually execute rather than silently skip).

| Adapter | Change | Verified |
|---------|--------|----------|
| **Go** | Remove `return-map` + `kbd` from `skipJsx` — both pass today (the data-key / multi-export-harness concerns the comments described no longer reproduce) | **461 pass / 3 skip / 0 fail** |
| **Mojo** | Remove `kbd` from `skipJsx` — passes today | **420 pass / 5 skip / 0 fail** |
| **Xslate** | Move `kbd` from `skipJsx` to `expectedDiagnostics: BF101` — it's NOT a render-mismatch but a genuine refusal (Kolon can't splat the auto-inferred `<Slot>`'s `{...props}`, the same engine divergence already pinned for `button`) | **298 pass / 5 skip / 0 fail** |

### Context
This is the quick-wins step from a cross-adapter audit aimed at making the adapters as Hono-compatible as possible. The real remaining gaps — `toggle` / `switch` (reactive `Record<T,string>[variant|size]` className memo with no SSR lowering) and `context-provider` (no SSR context propagation) — are tracked for the next increments; this PR just clears the noise so those stand out.

🤖 https://claude.ai/code/session_01UatvBGZG5csvttdtgcSf7p

---
_Generated by [Claude Code](https://claude.ai/code/session_01UatvBGZG5csvttdtgcSf7p)_