### PR TITLE
fix(cli): sort discoverComponentFiles for deterministic Go type ordering

### DIFF
--- a/.changeset/fix-deterministic-go-type-ordering.md
+++ b/.changeset/fix-deterministic-go-type-ordering.md
@@ -1,0 +1,9 @@
+---
+"@barefootjs/cli": patch
+---
+
+Fix non-deterministic Go type ordering when building under Bun.
+
+`discoverComponentFiles` relied on the OS `readdir` order, which differs between runtimes: Bun returns APFS hash order while Node.js returns alphabetical order. This caused Go integrations' `components.go` to regenerate with a different type/function ordering on every build even when no source files changed.
+
+Sort entries in `discoverComponentFiles` by name so the component processing order is always alphabetical, regardless of JS runtime or filesystem.

--- a/integrations/chi/components.go
+++ b/integrations/chi/components.go
@@ -45,24 +45,6 @@ type AIChatInteractiveProps struct {
 	IsStreaming bool `json:"isStreaming"`
 }
 
-// PortalExampleInput is the user-facing input type.
-type PortalExampleInput struct {
-	ScopeID string // Optional: if empty, random ID is generated
-	BfParent string // Optional: parent scope id
-	BfMount string // Optional: slot id in parent
-}
-
-// PortalExampleProps is the props type for the PortalExample component.
-type PortalExampleProps struct {
-	ScopeID string `json:"scopeID"`
-	BfIsRoot bool `json:"-"`
-	BfIsChild bool `json:"-"`
-	BfParent string `json:"-"`
-	BfMount string `json:"-"`
-	Scripts *bf.ScriptCollector `json:"-"`
-	Open bool `json:"open"`
-}
-
 // ConditionalReturnInput is the user-facing input type.
 type ConditionalReturnInput struct {
 	ScopeID string // Optional: if empty, random ID is generated
@@ -83,38 +65,61 @@ type ConditionalReturnProps struct {
 	Count int `json:"count"`
 }
 
-// Todo represents a todo.
-type Todo struct {
-	ID int `json:"id"`
-	Text string `json:"text"`
-	Done bool `json:"done"`
-	Editing bool `json:"editing"`
-}
-
-// Filter is a string type.
-type Filter = string
-
-// TodoAppInput is the user-facing input type.
-type TodoAppInput struct {
+// CounterInput is the user-facing input type.
+type CounterInput struct {
 	ScopeID string // Optional: if empty, random ID is generated
 	BfParent string // Optional: parent scope id
 	BfMount string // Optional: slot id in parent
-	InitialTodos []Todo
+	Initial int
 }
 
-// TodoAppProps is the props type for the TodoApp component.
-type TodoAppProps struct {
+// CounterProps is the props type for the Counter component.
+type CounterProps struct {
 	ScopeID string `json:"scopeID"`
 	BfIsRoot bool `json:"-"`
 	BfIsChild bool `json:"-"`
 	BfParent string `json:"-"`
 	BfMount string `json:"-"`
 	Scripts *bf.ScriptCollector `json:"-"`
-	InitialTodos []Todo `json:"initialTodos"`
-	Todos []Todo `json:"todos"`
-	NewText string `json:"newText"`
-	Filter Filter `json:"filter"`
-	TodoItems []TodoItemProps `json:"-"`
+	Initial int `json:"initial"`
+	Count int `json:"count"`
+	Doubled int `json:"doubled"`
+}
+
+// FormInput is the user-facing input type.
+type FormInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// FormProps is the props type for the Form component.
+type FormProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Accepted bool `json:"accepted"`
+}
+
+// PortalExampleInput is the user-facing input type.
+type PortalExampleInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// PortalExampleProps is the props type for the PortalExample component.
+type PortalExampleProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Open bool `json:"open"`
 }
 
 // ReactiveChildInput is the user-facing input type.
@@ -245,43 +250,38 @@ type TextEscapeProps struct {
 	Count int `json:"count"`
 }
 
-// CounterInput is the user-facing input type.
-type CounterInput struct {
+// Todo represents a todo.
+type Todo struct {
+	ID int `json:"id"`
+	Text string `json:"text"`
+	Done bool `json:"done"`
+	Editing bool `json:"editing"`
+}
+
+// Filter is a string type.
+type Filter = string
+
+// TodoAppInput is the user-facing input type.
+type TodoAppInput struct {
 	ScopeID string // Optional: if empty, random ID is generated
 	BfParent string // Optional: parent scope id
 	BfMount string // Optional: slot id in parent
-	Initial int
+	InitialTodos []Todo
 }
 
-// CounterProps is the props type for the Counter component.
-type CounterProps struct {
+// TodoAppProps is the props type for the TodoApp component.
+type TodoAppProps struct {
 	ScopeID string `json:"scopeID"`
 	BfIsRoot bool `json:"-"`
 	BfIsChild bool `json:"-"`
 	BfParent string `json:"-"`
 	BfMount string `json:"-"`
 	Scripts *bf.ScriptCollector `json:"-"`
-	Initial int `json:"initial"`
-	Count int `json:"count"`
-	Doubled int `json:"doubled"`
-}
-
-// FormInput is the user-facing input type.
-type FormInput struct {
-	ScopeID string // Optional: if empty, random ID is generated
-	BfParent string // Optional: parent scope id
-	BfMount string // Optional: slot id in parent
-}
-
-// FormProps is the props type for the Form component.
-type FormProps struct {
-	ScopeID string `json:"scopeID"`
-	BfIsRoot bool `json:"-"`
-	BfIsChild bool `json:"-"`
-	BfParent string `json:"-"`
-	BfMount string `json:"-"`
-	Scripts *bf.ScriptCollector `json:"-"`
-	Accepted bool `json:"accepted"`
+	InitialTodos []Todo `json:"initialTodos"`
+	Todos []Todo `json:"todos"`
+	NewText string `json:"newText"`
+	Filter Filter `json:"filter"`
+	TodoItems []TodoItemProps `json:"-"`
 }
 
 // TodoAppSSRInput is the user-facing input type.
@@ -393,21 +393,6 @@ func NewAIChatInteractiveProps(in AIChatInteractiveInput) AIChatInteractiveProps
 	}
 }
 
-// NewPortalExampleProps creates PortalExampleProps from PortalExampleInput.
-func NewPortalExampleProps(in PortalExampleInput) PortalExampleProps {
-	scopeID := in.ScopeID
-	if scopeID == "" {
-		scopeID = "PortalExample_" + randomID(6)
-	}
-
-	return PortalExampleProps{
-		ScopeID: scopeID,
-		BfParent: in.BfParent,
-		BfMount: in.BfMount,
-		Open: false,
-	}
-}
-
 // NewConditionalReturnProps creates ConditionalReturnProps from ConditionalReturnInput.
 func NewConditionalReturnProps(in ConditionalReturnInput) ConditionalReturnProps {
 	scopeID := in.ScopeID
@@ -424,34 +409,50 @@ func NewConditionalReturnProps(in ConditionalReturnInput) ConditionalReturnProps
 	}
 }
 
-// NewTodoAppProps creates TodoAppProps from TodoAppInput.
-//
-// NOTE: `TodoItems` is populated by the route handler, not by
-// NewTodoAppProps — the SSR template iterates over it
-// dynamically (`.TodoItems`). Build the slice from your source data and
-// assign it before passing the props to your renderer. Example:
-//
-//   props := NewTodoAppProps(TodoAppInput{ /* ... */ })
-//   props.TodoItems = make([]TodoItemProps, len(items))
-//   for i, item := range items {
-//     props.TodoItems[i] = NewTodoItemProps(TodoItemInput{ /* fields */ })
-//     props.TodoItems[i].BfParent = props.ScopeID
-//     props.TodoItems[i].BfMount = "s3"
-//   }
-func NewTodoAppProps(in TodoAppInput) TodoAppProps {
+// NewCounterProps creates CounterProps from CounterInput.
+func NewCounterProps(in CounterInput) CounterProps {
 	scopeID := in.ScopeID
 	if scopeID == "" {
-		scopeID = "TodoApp_" + randomID(6)
+		scopeID = "Counter_" + randomID(6)
 	}
 
-	return TodoAppProps{
+	return CounterProps{
 		ScopeID: scopeID,
 		BfParent: in.BfParent,
 		BfMount: in.BfMount,
-		InitialTodos: in.InitialTodos,
-		Todos: in.InitialTodos,
-		NewText: "",
-		Filter: "all",
+		Initial: in.Initial,
+		Count: in.Initial,
+		Doubled: in.Initial * 2,
+	}
+}
+
+// NewFormProps creates FormProps from FormInput.
+func NewFormProps(in FormInput) FormProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "Form_" + randomID(6)
+	}
+
+	return FormProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Accepted: false,
+	}
+}
+
+// NewPortalExampleProps creates PortalExampleProps from PortalExampleInput.
+func NewPortalExampleProps(in PortalExampleInput) PortalExampleProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "PortalExample_" + randomID(6)
+	}
+
+	return PortalExampleProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Open: false,
 	}
 }
 
@@ -581,35 +582,34 @@ func NewTextEscapeProps(in TextEscapeInput) TextEscapeProps {
 	}
 }
 
-// NewCounterProps creates CounterProps from CounterInput.
-func NewCounterProps(in CounterInput) CounterProps {
+// NewTodoAppProps creates TodoAppProps from TodoAppInput.
+//
+// NOTE: `TodoItems` is populated by the route handler, not by
+// NewTodoAppProps — the SSR template iterates over it
+// dynamically (`.TodoItems`). Build the slice from your source data and
+// assign it before passing the props to your renderer. Example:
+//
+//   props := NewTodoAppProps(TodoAppInput{ /* ... */ })
+//   props.TodoItems = make([]TodoItemProps, len(items))
+//   for i, item := range items {
+//     props.TodoItems[i] = NewTodoItemProps(TodoItemInput{ /* fields */ })
+//     props.TodoItems[i].BfParent = props.ScopeID
+//     props.TodoItems[i].BfMount = "s3"
+//   }
+func NewTodoAppProps(in TodoAppInput) TodoAppProps {
 	scopeID := in.ScopeID
 	if scopeID == "" {
-		scopeID = "Counter_" + randomID(6)
+		scopeID = "TodoApp_" + randomID(6)
 	}
 
-	return CounterProps{
+	return TodoAppProps{
 		ScopeID: scopeID,
 		BfParent: in.BfParent,
 		BfMount: in.BfMount,
-		Initial: in.Initial,
-		Count: in.Initial,
-		Doubled: in.Initial * 2,
-	}
-}
-
-// NewFormProps creates FormProps from FormInput.
-func NewFormProps(in FormInput) FormProps {
-	scopeID := in.ScopeID
-	if scopeID == "" {
-		scopeID = "Form_" + randomID(6)
-	}
-
-	return FormProps{
-		ScopeID: scopeID,
-		BfParent: in.BfParent,
-		BfMount: in.BfMount,
-		Accepted: false,
+		InitialTodos: in.InitialTodos,
+		Todos: in.InitialTodos,
+		NewText: "",
+		Filter: "all",
 	}
 }
 

--- a/integrations/echo/components.go
+++ b/integrations/echo/components.go
@@ -45,24 +45,6 @@ type AIChatInteractiveProps struct {
 	IsStreaming bool `json:"isStreaming"`
 }
 
-// PortalExampleInput is the user-facing input type.
-type PortalExampleInput struct {
-	ScopeID string // Optional: if empty, random ID is generated
-	BfParent string // Optional: parent scope id
-	BfMount string // Optional: slot id in parent
-}
-
-// PortalExampleProps is the props type for the PortalExample component.
-type PortalExampleProps struct {
-	ScopeID string `json:"scopeID"`
-	BfIsRoot bool `json:"-"`
-	BfIsChild bool `json:"-"`
-	BfParent string `json:"-"`
-	BfMount string `json:"-"`
-	Scripts *bf.ScriptCollector `json:"-"`
-	Open bool `json:"open"`
-}
-
 // ConditionalReturnInput is the user-facing input type.
 type ConditionalReturnInput struct {
 	ScopeID string // Optional: if empty, random ID is generated
@@ -83,38 +65,61 @@ type ConditionalReturnProps struct {
 	Count int `json:"count"`
 }
 
-// Todo represents a todo.
-type Todo struct {
-	ID int `json:"id"`
-	Text string `json:"text"`
-	Done bool `json:"done"`
-	Editing bool `json:"editing"`
-}
-
-// Filter is a string type.
-type Filter = string
-
-// TodoAppInput is the user-facing input type.
-type TodoAppInput struct {
+// CounterInput is the user-facing input type.
+type CounterInput struct {
 	ScopeID string // Optional: if empty, random ID is generated
 	BfParent string // Optional: parent scope id
 	BfMount string // Optional: slot id in parent
-	InitialTodos []Todo
+	Initial int
 }
 
-// TodoAppProps is the props type for the TodoApp component.
-type TodoAppProps struct {
+// CounterProps is the props type for the Counter component.
+type CounterProps struct {
 	ScopeID string `json:"scopeID"`
 	BfIsRoot bool `json:"-"`
 	BfIsChild bool `json:"-"`
 	BfParent string `json:"-"`
 	BfMount string `json:"-"`
 	Scripts *bf.ScriptCollector `json:"-"`
-	InitialTodos []Todo `json:"initialTodos"`
-	Todos []Todo `json:"todos"`
-	NewText string `json:"newText"`
-	Filter Filter `json:"filter"`
-	TodoItems []TodoItemProps `json:"-"`
+	Initial int `json:"initial"`
+	Count int `json:"count"`
+	Doubled int `json:"doubled"`
+}
+
+// FormInput is the user-facing input type.
+type FormInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// FormProps is the props type for the Form component.
+type FormProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Accepted bool `json:"accepted"`
+}
+
+// PortalExampleInput is the user-facing input type.
+type PortalExampleInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// PortalExampleProps is the props type for the PortalExample component.
+type PortalExampleProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Open bool `json:"open"`
 }
 
 // ReactiveChildInput is the user-facing input type.
@@ -225,43 +230,58 @@ type PropsReactivityComparisonProps struct {
 	DestructuredStyleChildSlot4 DestructuredStyleChildProps `json:"-"`
 }
 
-// CounterInput is the user-facing input type.
-type CounterInput struct {
+// TextEscapeInput is the user-facing input type.
+type TextEscapeInput struct {
 	ScopeID string // Optional: if empty, random ID is generated
 	BfParent string // Optional: parent scope id
 	BfMount string // Optional: slot id in parent
-	Initial int
+	Label string
 }
 
-// CounterProps is the props type for the Counter component.
-type CounterProps struct {
+// TextEscapeProps is the props type for the TextEscape component.
+type TextEscapeProps struct {
 	ScopeID string `json:"scopeID"`
 	BfIsRoot bool `json:"-"`
 	BfIsChild bool `json:"-"`
 	BfParent string `json:"-"`
 	BfMount string `json:"-"`
 	Scripts *bf.ScriptCollector `json:"-"`
-	Initial int `json:"initial"`
+	Label string `json:"label"`
 	Count int `json:"count"`
-	Doubled int `json:"doubled"`
 }
 
-// FormInput is the user-facing input type.
-type FormInput struct {
+// Todo represents a todo.
+type Todo struct {
+	ID int `json:"id"`
+	Text string `json:"text"`
+	Done bool `json:"done"`
+	Editing bool `json:"editing"`
+}
+
+// Filter is a string type.
+type Filter = string
+
+// TodoAppInput is the user-facing input type.
+type TodoAppInput struct {
 	ScopeID string // Optional: if empty, random ID is generated
 	BfParent string // Optional: parent scope id
 	BfMount string // Optional: slot id in parent
+	InitialTodos []Todo
 }
 
-// FormProps is the props type for the Form component.
-type FormProps struct {
+// TodoAppProps is the props type for the TodoApp component.
+type TodoAppProps struct {
 	ScopeID string `json:"scopeID"`
 	BfIsRoot bool `json:"-"`
 	BfIsChild bool `json:"-"`
 	BfParent string `json:"-"`
 	BfMount string `json:"-"`
 	Scripts *bf.ScriptCollector `json:"-"`
-	Accepted bool `json:"accepted"`
+	InitialTodos []Todo `json:"initialTodos"`
+	Todos []Todo `json:"todos"`
+	NewText string `json:"newText"`
+	Filter Filter `json:"filter"`
+	TodoItems []TodoItemProps `json:"-"`
 }
 
 // TodoAppSSRInput is the user-facing input type.
@@ -373,21 +393,6 @@ func NewAIChatInteractiveProps(in AIChatInteractiveInput) AIChatInteractiveProps
 	}
 }
 
-// NewPortalExampleProps creates PortalExampleProps from PortalExampleInput.
-func NewPortalExampleProps(in PortalExampleInput) PortalExampleProps {
-	scopeID := in.ScopeID
-	if scopeID == "" {
-		scopeID = "PortalExample_" + randomID(6)
-	}
-
-	return PortalExampleProps{
-		ScopeID: scopeID,
-		BfParent: in.BfParent,
-		BfMount: in.BfMount,
-		Open: false,
-	}
-}
-
 // NewConditionalReturnProps creates ConditionalReturnProps from ConditionalReturnInput.
 func NewConditionalReturnProps(in ConditionalReturnInput) ConditionalReturnProps {
 	scopeID := in.ScopeID
@@ -404,34 +409,50 @@ func NewConditionalReturnProps(in ConditionalReturnInput) ConditionalReturnProps
 	}
 }
 
-// NewTodoAppProps creates TodoAppProps from TodoAppInput.
-//
-// NOTE: `TodoItems` is populated by the route handler, not by
-// NewTodoAppProps — the SSR template iterates over it
-// dynamically (`.TodoItems`). Build the slice from your source data and
-// assign it before passing the props to your renderer. Example:
-//
-//   props := NewTodoAppProps(TodoAppInput{ /* ... */ })
-//   props.TodoItems = make([]TodoItemProps, len(items))
-//   for i, item := range items {
-//     props.TodoItems[i] = NewTodoItemProps(TodoItemInput{ /* fields */ })
-//     props.TodoItems[i].BfParent = props.ScopeID
-//     props.TodoItems[i].BfMount = "s3"
-//   }
-func NewTodoAppProps(in TodoAppInput) TodoAppProps {
+// NewCounterProps creates CounterProps from CounterInput.
+func NewCounterProps(in CounterInput) CounterProps {
 	scopeID := in.ScopeID
 	if scopeID == "" {
-		scopeID = "TodoApp_" + randomID(6)
+		scopeID = "Counter_" + randomID(6)
 	}
 
-	return TodoAppProps{
+	return CounterProps{
 		ScopeID: scopeID,
 		BfParent: in.BfParent,
 		BfMount: in.BfMount,
-		InitialTodos: in.InitialTodos,
-		Todos: in.InitialTodos,
-		NewText: "",
-		Filter: "all",
+		Initial: in.Initial,
+		Count: in.Initial,
+		Doubled: in.Initial * 2,
+	}
+}
+
+// NewFormProps creates FormProps from FormInput.
+func NewFormProps(in FormInput) FormProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "Form_" + randomID(6)
+	}
+
+	return FormProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Accepted: false,
+	}
+}
+
+// NewPortalExampleProps creates PortalExampleProps from PortalExampleInput.
+func NewPortalExampleProps(in PortalExampleInput) PortalExampleProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "PortalExample_" + randomID(6)
+	}
+
+	return PortalExampleProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Open: false,
 	}
 }
 
@@ -545,35 +566,50 @@ func NewPropsReactivityComparisonProps(in PropsReactivityComparisonInput) PropsR
 	}
 }
 
-// NewCounterProps creates CounterProps from CounterInput.
-func NewCounterProps(in CounterInput) CounterProps {
+// NewTextEscapeProps creates TextEscapeProps from TextEscapeInput.
+func NewTextEscapeProps(in TextEscapeInput) TextEscapeProps {
 	scopeID := in.ScopeID
 	if scopeID == "" {
-		scopeID = "Counter_" + randomID(6)
+		scopeID = "TextEscape_" + randomID(6)
 	}
 
-	return CounterProps{
+	return TextEscapeProps{
 		ScopeID: scopeID,
 		BfParent: in.BfParent,
 		BfMount: in.BfMount,
-		Initial: in.Initial,
-		Count: in.Initial,
-		Doubled: in.Initial * 2,
+		Label: in.Label,
+		Count: 0,
 	}
 }
 
-// NewFormProps creates FormProps from FormInput.
-func NewFormProps(in FormInput) FormProps {
+// NewTodoAppProps creates TodoAppProps from TodoAppInput.
+//
+// NOTE: `TodoItems` is populated by the route handler, not by
+// NewTodoAppProps — the SSR template iterates over it
+// dynamically (`.TodoItems`). Build the slice from your source data and
+// assign it before passing the props to your renderer. Example:
+//
+//   props := NewTodoAppProps(TodoAppInput{ /* ... */ })
+//   props.TodoItems = make([]TodoItemProps, len(items))
+//   for i, item := range items {
+//     props.TodoItems[i] = NewTodoItemProps(TodoItemInput{ /* fields */ })
+//     props.TodoItems[i].BfParent = props.ScopeID
+//     props.TodoItems[i].BfMount = "s3"
+//   }
+func NewTodoAppProps(in TodoAppInput) TodoAppProps {
 	scopeID := in.ScopeID
 	if scopeID == "" {
-		scopeID = "Form_" + randomID(6)
+		scopeID = "TodoApp_" + randomID(6)
 	}
 
-	return FormProps{
+	return TodoAppProps{
 		ScopeID: scopeID,
 		BfParent: in.BfParent,
 		BfMount: in.BfMount,
-		Accepted: false,
+		InitialTodos: in.InitialTodos,
+		Todos: in.InitialTodos,
+		NewText: "",
+		Filter: "all",
 	}
 }
 

--- a/integrations/gin/components.go
+++ b/integrations/gin/components.go
@@ -45,24 +45,6 @@ type AIChatInteractiveProps struct {
 	IsStreaming bool `json:"isStreaming"`
 }
 
-// PortalExampleInput is the user-facing input type.
-type PortalExampleInput struct {
-	ScopeID string // Optional: if empty, random ID is generated
-	BfParent string // Optional: parent scope id
-	BfMount string // Optional: slot id in parent
-}
-
-// PortalExampleProps is the props type for the PortalExample component.
-type PortalExampleProps struct {
-	ScopeID string `json:"scopeID"`
-	BfIsRoot bool `json:"-"`
-	BfIsChild bool `json:"-"`
-	BfParent string `json:"-"`
-	BfMount string `json:"-"`
-	Scripts *bf.ScriptCollector `json:"-"`
-	Open bool `json:"open"`
-}
-
 // ConditionalReturnInput is the user-facing input type.
 type ConditionalReturnInput struct {
 	ScopeID string // Optional: if empty, random ID is generated
@@ -83,38 +65,61 @@ type ConditionalReturnProps struct {
 	Count int `json:"count"`
 }
 
-// Todo represents a todo.
-type Todo struct {
-	ID int `json:"id"`
-	Text string `json:"text"`
-	Done bool `json:"done"`
-	Editing bool `json:"editing"`
-}
-
-// Filter is a string type.
-type Filter = string
-
-// TodoAppInput is the user-facing input type.
-type TodoAppInput struct {
+// CounterInput is the user-facing input type.
+type CounterInput struct {
 	ScopeID string // Optional: if empty, random ID is generated
 	BfParent string // Optional: parent scope id
 	BfMount string // Optional: slot id in parent
-	InitialTodos []Todo
+	Initial int
 }
 
-// TodoAppProps is the props type for the TodoApp component.
-type TodoAppProps struct {
+// CounterProps is the props type for the Counter component.
+type CounterProps struct {
 	ScopeID string `json:"scopeID"`
 	BfIsRoot bool `json:"-"`
 	BfIsChild bool `json:"-"`
 	BfParent string `json:"-"`
 	BfMount string `json:"-"`
 	Scripts *bf.ScriptCollector `json:"-"`
-	InitialTodos []Todo `json:"initialTodos"`
-	Todos []Todo `json:"todos"`
-	NewText string `json:"newText"`
-	Filter Filter `json:"filter"`
-	TodoItems []TodoItemProps `json:"-"`
+	Initial int `json:"initial"`
+	Count int `json:"count"`
+	Doubled int `json:"doubled"`
+}
+
+// FormInput is the user-facing input type.
+type FormInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// FormProps is the props type for the Form component.
+type FormProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Accepted bool `json:"accepted"`
+}
+
+// PortalExampleInput is the user-facing input type.
+type PortalExampleInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// PortalExampleProps is the props type for the PortalExample component.
+type PortalExampleProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Open bool `json:"open"`
 }
 
 // ReactiveChildInput is the user-facing input type.
@@ -245,43 +250,38 @@ type TextEscapeProps struct {
 	Count int `json:"count"`
 }
 
-// CounterInput is the user-facing input type.
-type CounterInput struct {
+// Todo represents a todo.
+type Todo struct {
+	ID int `json:"id"`
+	Text string `json:"text"`
+	Done bool `json:"done"`
+	Editing bool `json:"editing"`
+}
+
+// Filter is a string type.
+type Filter = string
+
+// TodoAppInput is the user-facing input type.
+type TodoAppInput struct {
 	ScopeID string // Optional: if empty, random ID is generated
 	BfParent string // Optional: parent scope id
 	BfMount string // Optional: slot id in parent
-	Initial int
+	InitialTodos []Todo
 }
 
-// CounterProps is the props type for the Counter component.
-type CounterProps struct {
+// TodoAppProps is the props type for the TodoApp component.
+type TodoAppProps struct {
 	ScopeID string `json:"scopeID"`
 	BfIsRoot bool `json:"-"`
 	BfIsChild bool `json:"-"`
 	BfParent string `json:"-"`
 	BfMount string `json:"-"`
 	Scripts *bf.ScriptCollector `json:"-"`
-	Initial int `json:"initial"`
-	Count int `json:"count"`
-	Doubled int `json:"doubled"`
-}
-
-// FormInput is the user-facing input type.
-type FormInput struct {
-	ScopeID string // Optional: if empty, random ID is generated
-	BfParent string // Optional: parent scope id
-	BfMount string // Optional: slot id in parent
-}
-
-// FormProps is the props type for the Form component.
-type FormProps struct {
-	ScopeID string `json:"scopeID"`
-	BfIsRoot bool `json:"-"`
-	BfIsChild bool `json:"-"`
-	BfParent string `json:"-"`
-	BfMount string `json:"-"`
-	Scripts *bf.ScriptCollector `json:"-"`
-	Accepted bool `json:"accepted"`
+	InitialTodos []Todo `json:"initialTodos"`
+	Todos []Todo `json:"todos"`
+	NewText string `json:"newText"`
+	Filter Filter `json:"filter"`
+	TodoItems []TodoItemProps `json:"-"`
 }
 
 // TodoAppSSRInput is the user-facing input type.
@@ -393,21 +393,6 @@ func NewAIChatInteractiveProps(in AIChatInteractiveInput) AIChatInteractiveProps
 	}
 }
 
-// NewPortalExampleProps creates PortalExampleProps from PortalExampleInput.
-func NewPortalExampleProps(in PortalExampleInput) PortalExampleProps {
-	scopeID := in.ScopeID
-	if scopeID == "" {
-		scopeID = "PortalExample_" + randomID(6)
-	}
-
-	return PortalExampleProps{
-		ScopeID: scopeID,
-		BfParent: in.BfParent,
-		BfMount: in.BfMount,
-		Open: false,
-	}
-}
-
 // NewConditionalReturnProps creates ConditionalReturnProps from ConditionalReturnInput.
 func NewConditionalReturnProps(in ConditionalReturnInput) ConditionalReturnProps {
 	scopeID := in.ScopeID
@@ -424,34 +409,50 @@ func NewConditionalReturnProps(in ConditionalReturnInput) ConditionalReturnProps
 	}
 }
 
-// NewTodoAppProps creates TodoAppProps from TodoAppInput.
-//
-// NOTE: `TodoItems` is populated by the route handler, not by
-// NewTodoAppProps — the SSR template iterates over it
-// dynamically (`.TodoItems`). Build the slice from your source data and
-// assign it before passing the props to your renderer. Example:
-//
-//   props := NewTodoAppProps(TodoAppInput{ /* ... */ })
-//   props.TodoItems = make([]TodoItemProps, len(items))
-//   for i, item := range items {
-//     props.TodoItems[i] = NewTodoItemProps(TodoItemInput{ /* fields */ })
-//     props.TodoItems[i].BfParent = props.ScopeID
-//     props.TodoItems[i].BfMount = "s3"
-//   }
-func NewTodoAppProps(in TodoAppInput) TodoAppProps {
+// NewCounterProps creates CounterProps from CounterInput.
+func NewCounterProps(in CounterInput) CounterProps {
 	scopeID := in.ScopeID
 	if scopeID == "" {
-		scopeID = "TodoApp_" + randomID(6)
+		scopeID = "Counter_" + randomID(6)
 	}
 
-	return TodoAppProps{
+	return CounterProps{
 		ScopeID: scopeID,
 		BfParent: in.BfParent,
 		BfMount: in.BfMount,
-		InitialTodos: in.InitialTodos,
-		Todos: in.InitialTodos,
-		NewText: "",
-		Filter: "all",
+		Initial: in.Initial,
+		Count: in.Initial,
+		Doubled: in.Initial * 2,
+	}
+}
+
+// NewFormProps creates FormProps from FormInput.
+func NewFormProps(in FormInput) FormProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "Form_" + randomID(6)
+	}
+
+	return FormProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Accepted: false,
+	}
+}
+
+// NewPortalExampleProps creates PortalExampleProps from PortalExampleInput.
+func NewPortalExampleProps(in PortalExampleInput) PortalExampleProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "PortalExample_" + randomID(6)
+	}
+
+	return PortalExampleProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Open: false,
 	}
 }
 
@@ -581,35 +582,34 @@ func NewTextEscapeProps(in TextEscapeInput) TextEscapeProps {
 	}
 }
 
-// NewCounterProps creates CounterProps from CounterInput.
-func NewCounterProps(in CounterInput) CounterProps {
+// NewTodoAppProps creates TodoAppProps from TodoAppInput.
+//
+// NOTE: `TodoItems` is populated by the route handler, not by
+// NewTodoAppProps — the SSR template iterates over it
+// dynamically (`.TodoItems`). Build the slice from your source data and
+// assign it before passing the props to your renderer. Example:
+//
+//   props := NewTodoAppProps(TodoAppInput{ /* ... */ })
+//   props.TodoItems = make([]TodoItemProps, len(items))
+//   for i, item := range items {
+//     props.TodoItems[i] = NewTodoItemProps(TodoItemInput{ /* fields */ })
+//     props.TodoItems[i].BfParent = props.ScopeID
+//     props.TodoItems[i].BfMount = "s3"
+//   }
+func NewTodoAppProps(in TodoAppInput) TodoAppProps {
 	scopeID := in.ScopeID
 	if scopeID == "" {
-		scopeID = "Counter_" + randomID(6)
+		scopeID = "TodoApp_" + randomID(6)
 	}
 
-	return CounterProps{
+	return TodoAppProps{
 		ScopeID: scopeID,
 		BfParent: in.BfParent,
 		BfMount: in.BfMount,
-		Initial: in.Initial,
-		Count: in.Initial,
-		Doubled: in.Initial * 2,
-	}
-}
-
-// NewFormProps creates FormProps from FormInput.
-func NewFormProps(in FormInput) FormProps {
-	scopeID := in.ScopeID
-	if scopeID == "" {
-		scopeID = "Form_" + randomID(6)
-	}
-
-	return FormProps{
-		ScopeID: scopeID,
-		BfParent: in.BfParent,
-		BfMount: in.BfMount,
-		Accepted: false,
+		InitialTodos: in.InitialTodos,
+		Todos: in.InitialTodos,
+		NewText: "",
+		Filter: "all",
 	}
 }
 

--- a/integrations/nethttp/components.go
+++ b/integrations/nethttp/components.go
@@ -45,24 +45,6 @@ type AIChatInteractiveProps struct {
 	IsStreaming bool `json:"isStreaming"`
 }
 
-// PortalExampleInput is the user-facing input type.
-type PortalExampleInput struct {
-	ScopeID string // Optional: if empty, random ID is generated
-	BfParent string // Optional: parent scope id
-	BfMount string // Optional: slot id in parent
-}
-
-// PortalExampleProps is the props type for the PortalExample component.
-type PortalExampleProps struct {
-	ScopeID string `json:"scopeID"`
-	BfIsRoot bool `json:"-"`
-	BfIsChild bool `json:"-"`
-	BfParent string `json:"-"`
-	BfMount string `json:"-"`
-	Scripts *bf.ScriptCollector `json:"-"`
-	Open bool `json:"open"`
-}
-
 // ConditionalReturnInput is the user-facing input type.
 type ConditionalReturnInput struct {
 	ScopeID string // Optional: if empty, random ID is generated
@@ -83,38 +65,61 @@ type ConditionalReturnProps struct {
 	Count int `json:"count"`
 }
 
-// Todo represents a todo.
-type Todo struct {
-	ID int `json:"id"`
-	Text string `json:"text"`
-	Done bool `json:"done"`
-	Editing bool `json:"editing"`
-}
-
-// Filter is a string type.
-type Filter = string
-
-// TodoAppInput is the user-facing input type.
-type TodoAppInput struct {
+// CounterInput is the user-facing input type.
+type CounterInput struct {
 	ScopeID string // Optional: if empty, random ID is generated
 	BfParent string // Optional: parent scope id
 	BfMount string // Optional: slot id in parent
-	InitialTodos []Todo
+	Initial int
 }
 
-// TodoAppProps is the props type for the TodoApp component.
-type TodoAppProps struct {
+// CounterProps is the props type for the Counter component.
+type CounterProps struct {
 	ScopeID string `json:"scopeID"`
 	BfIsRoot bool `json:"-"`
 	BfIsChild bool `json:"-"`
 	BfParent string `json:"-"`
 	BfMount string `json:"-"`
 	Scripts *bf.ScriptCollector `json:"-"`
-	InitialTodos []Todo `json:"initialTodos"`
-	Todos []Todo `json:"todos"`
-	NewText string `json:"newText"`
-	Filter Filter `json:"filter"`
-	TodoItems []TodoItemProps `json:"-"`
+	Initial int `json:"initial"`
+	Count int `json:"count"`
+	Doubled int `json:"doubled"`
+}
+
+// FormInput is the user-facing input type.
+type FormInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// FormProps is the props type for the Form component.
+type FormProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Accepted bool `json:"accepted"`
+}
+
+// PortalExampleInput is the user-facing input type.
+type PortalExampleInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// PortalExampleProps is the props type for the PortalExample component.
+type PortalExampleProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Open bool `json:"open"`
 }
 
 // ReactiveChildInput is the user-facing input type.
@@ -245,43 +250,38 @@ type TextEscapeProps struct {
 	Count int `json:"count"`
 }
 
-// CounterInput is the user-facing input type.
-type CounterInput struct {
+// Todo represents a todo.
+type Todo struct {
+	ID int `json:"id"`
+	Text string `json:"text"`
+	Done bool `json:"done"`
+	Editing bool `json:"editing"`
+}
+
+// Filter is a string type.
+type Filter = string
+
+// TodoAppInput is the user-facing input type.
+type TodoAppInput struct {
 	ScopeID string // Optional: if empty, random ID is generated
 	BfParent string // Optional: parent scope id
 	BfMount string // Optional: slot id in parent
-	Initial int
+	InitialTodos []Todo
 }
 
-// CounterProps is the props type for the Counter component.
-type CounterProps struct {
+// TodoAppProps is the props type for the TodoApp component.
+type TodoAppProps struct {
 	ScopeID string `json:"scopeID"`
 	BfIsRoot bool `json:"-"`
 	BfIsChild bool `json:"-"`
 	BfParent string `json:"-"`
 	BfMount string `json:"-"`
 	Scripts *bf.ScriptCollector `json:"-"`
-	Initial int `json:"initial"`
-	Count int `json:"count"`
-	Doubled int `json:"doubled"`
-}
-
-// FormInput is the user-facing input type.
-type FormInput struct {
-	ScopeID string // Optional: if empty, random ID is generated
-	BfParent string // Optional: parent scope id
-	BfMount string // Optional: slot id in parent
-}
-
-// FormProps is the props type for the Form component.
-type FormProps struct {
-	ScopeID string `json:"scopeID"`
-	BfIsRoot bool `json:"-"`
-	BfIsChild bool `json:"-"`
-	BfParent string `json:"-"`
-	BfMount string `json:"-"`
-	Scripts *bf.ScriptCollector `json:"-"`
-	Accepted bool `json:"accepted"`
+	InitialTodos []Todo `json:"initialTodos"`
+	Todos []Todo `json:"todos"`
+	NewText string `json:"newText"`
+	Filter Filter `json:"filter"`
+	TodoItems []TodoItemProps `json:"-"`
 }
 
 // TodoAppSSRInput is the user-facing input type.
@@ -393,21 +393,6 @@ func NewAIChatInteractiveProps(in AIChatInteractiveInput) AIChatInteractiveProps
 	}
 }
 
-// NewPortalExampleProps creates PortalExampleProps from PortalExampleInput.
-func NewPortalExampleProps(in PortalExampleInput) PortalExampleProps {
-	scopeID := in.ScopeID
-	if scopeID == "" {
-		scopeID = "PortalExample_" + randomID(6)
-	}
-
-	return PortalExampleProps{
-		ScopeID: scopeID,
-		BfParent: in.BfParent,
-		BfMount: in.BfMount,
-		Open: false,
-	}
-}
-
 // NewConditionalReturnProps creates ConditionalReturnProps from ConditionalReturnInput.
 func NewConditionalReturnProps(in ConditionalReturnInput) ConditionalReturnProps {
 	scopeID := in.ScopeID
@@ -424,34 +409,50 @@ func NewConditionalReturnProps(in ConditionalReturnInput) ConditionalReturnProps
 	}
 }
 
-// NewTodoAppProps creates TodoAppProps from TodoAppInput.
-//
-// NOTE: `TodoItems` is populated by the route handler, not by
-// NewTodoAppProps — the SSR template iterates over it
-// dynamically (`.TodoItems`). Build the slice from your source data and
-// assign it before passing the props to your renderer. Example:
-//
-//   props := NewTodoAppProps(TodoAppInput{ /* ... */ })
-//   props.TodoItems = make([]TodoItemProps, len(items))
-//   for i, item := range items {
-//     props.TodoItems[i] = NewTodoItemProps(TodoItemInput{ /* fields */ })
-//     props.TodoItems[i].BfParent = props.ScopeID
-//     props.TodoItems[i].BfMount = "s3"
-//   }
-func NewTodoAppProps(in TodoAppInput) TodoAppProps {
+// NewCounterProps creates CounterProps from CounterInput.
+func NewCounterProps(in CounterInput) CounterProps {
 	scopeID := in.ScopeID
 	if scopeID == "" {
-		scopeID = "TodoApp_" + randomID(6)
+		scopeID = "Counter_" + randomID(6)
 	}
 
-	return TodoAppProps{
+	return CounterProps{
 		ScopeID: scopeID,
 		BfParent: in.BfParent,
 		BfMount: in.BfMount,
-		InitialTodos: in.InitialTodos,
-		Todos: in.InitialTodos,
-		NewText: "",
-		Filter: "all",
+		Initial: in.Initial,
+		Count: in.Initial,
+		Doubled: in.Initial * 2,
+	}
+}
+
+// NewFormProps creates FormProps from FormInput.
+func NewFormProps(in FormInput) FormProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "Form_" + randomID(6)
+	}
+
+	return FormProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Accepted: false,
+	}
+}
+
+// NewPortalExampleProps creates PortalExampleProps from PortalExampleInput.
+func NewPortalExampleProps(in PortalExampleInput) PortalExampleProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "PortalExample_" + randomID(6)
+	}
+
+	return PortalExampleProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Open: false,
 	}
 }
 
@@ -581,35 +582,34 @@ func NewTextEscapeProps(in TextEscapeInput) TextEscapeProps {
 	}
 }
 
-// NewCounterProps creates CounterProps from CounterInput.
-func NewCounterProps(in CounterInput) CounterProps {
+// NewTodoAppProps creates TodoAppProps from TodoAppInput.
+//
+// NOTE: `TodoItems` is populated by the route handler, not by
+// NewTodoAppProps — the SSR template iterates over it
+// dynamically (`.TodoItems`). Build the slice from your source data and
+// assign it before passing the props to your renderer. Example:
+//
+//   props := NewTodoAppProps(TodoAppInput{ /* ... */ })
+//   props.TodoItems = make([]TodoItemProps, len(items))
+//   for i, item := range items {
+//     props.TodoItems[i] = NewTodoItemProps(TodoItemInput{ /* fields */ })
+//     props.TodoItems[i].BfParent = props.ScopeID
+//     props.TodoItems[i].BfMount = "s3"
+//   }
+func NewTodoAppProps(in TodoAppInput) TodoAppProps {
 	scopeID := in.ScopeID
 	if scopeID == "" {
-		scopeID = "Counter_" + randomID(6)
+		scopeID = "TodoApp_" + randomID(6)
 	}
 
-	return CounterProps{
+	return TodoAppProps{
 		ScopeID: scopeID,
 		BfParent: in.BfParent,
 		BfMount: in.BfMount,
-		Initial: in.Initial,
-		Count: in.Initial,
-		Doubled: in.Initial * 2,
-	}
-}
-
-// NewFormProps creates FormProps from FormInput.
-func NewFormProps(in FormInput) FormProps {
-	scopeID := in.ScopeID
-	if scopeID == "" {
-		scopeID = "Form_" + randomID(6)
-	}
-
-	return FormProps{
-		ScopeID: scopeID,
-		BfParent: in.BfParent,
-		BfMount: in.BfMount,
-		Accepted: false,
+		InitialTodos: in.InitialTodos,
+		Todos: in.InitialTodos,
+		NewText: "",
+		Filter: "all",
 	}
 }
 

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -200,7 +200,9 @@ export async function discoverComponentFiles(
 
   let entries: { name: string; isDirectory(): boolean }[]
   try {
-    entries = await readdir(dir, { withFileTypes: true })
+    entries = (await readdir(dir, { withFileTypes: true })).sort((a, b) =>
+      String(a.name).localeCompare(String(b.name))
+    )
   } catch {
     return results
   }


### PR DESCRIPTION
## Problem

`bun run build` regenerates Go integrations' `components.go` with a different type/function ordering on every build, even when no source files changed.

## Root cause

Bun's `readdir` returns directory entries in filesystem order (APFS hash order), while Node.js returns them alphabetically. `discoverComponentFiles` relied on the OS `readdir` order directly, so the component processing sequence varied between JS runtimes and environments. Since `deduplicateGoTypes` emits types in first-encounter order, any change in processing sequence produced a differently-ordered `components.go`.

## Fix

Sort entries in `discoverComponentFiles` by name (`localeCompare`) before iterating, making the output alphabetical and stable regardless of runtime or filesystem.

Also regenerates the four Go integration `components.go` files to reflect the new canonical alphabetical ordering.

## Test

Run `bun run build` twice — `components.go` files are identical on the second run (no diff).