### PR TITLE
test(adapters): tighten SSR conformance skips toward Hono parity (switch / toggle / context-provider)

### DIFF
--- a/.changeset/context-provider-go-ssr.md
+++ b/.changeset/context-provider-go-ssr.md
@@ -1,0 +1,16 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+---
+
+Implement SSR context propagation for the Go template adapter, bringing the `context-provider` conformance fixture to parity with the Hono reference (the Perl backends stay deferred).
+
+Template engines have no JS runtime context stack like the Hono adapter's `provideContextSSR`, so a `useContext` value has to be threaded in at the data-construction layer:
+
+- **`collectContextConsumers` (`@barefootjs/jsx`)** — a shared helper that, for a component, finds every `const x = useContext(Ctx)` consumer and resolves each `Ctx` to its `createContext(<default>)` default value (string / number / boolean literal). Single source of truth for the SSR-context adapters.
+
+- **Go consumer side** — each `useContext` consumer becomes a struct field on the component's `Input` / `Props` (named after the local binding, e.g. `theme` → `Theme`), defaulted in `NewXxxProps` to the `createContext` default when the caller doesn't set it. The template already lowers the `useContext` local to a `{{.Theme}}` root-field read; it now resolves against a real field instead of emitting `.Theme` against a struct that has none (the prior compile failure).
+
+- **Go provider side** — `collectStaticChildInstances` threads the active `<Ctx.Provider value>` bindings (literal values lowered to Go literals) down the IR tree. When a static child slot consumes a context an enclosing provider supplies, its `NewXxxProps(...Input{ ... })` construction sets the matching field to the provider value (cross-component consumer lookup via the existing `registerChildComponentShape` channel), so `useContext(Ctx)` resolves to the provided value at template-eval time.
+
+`context-provider` is unskipped on the Go conformance suite. It stays skipped on the Mojolicious / Xslate suites (their stash-seed render path would port the same way — tracked as a follow-up); their skip rationales are updated to reflect that the Go path now exists. Hono reference snapshots are unchanged.

--- a/.changeset/switch-ssr-conformance-parity.md
+++ b/.changeset/switch-ssr-conformance-parity.md
@@ -1,0 +1,16 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+---
+
+Bring the `switch` site/ui primitive to SSR conformance parity across the Go, Mojolicious, and Xslate template adapters.
+
+`switch` assembles its track/thumb classes in function-scope plain consts (`trackClasses`, `thumbClasses`) rather than a `Record`-indexed memo, so it needs no `Record` SSR lowering — only two gaps blocked cross-adapter parity:
+
+- **Function-scope const prop enumeration.** `augmentInheritedPropAccesses` (`@barefootjs/jsx`) previously scanned memos, signals, init statements, effects, and template attributes for inherited `props.X` reads, but not function-scope const initializers. The `props.className` read inside `const trackClasses = \`… ${props.className ?? ''}\`` was therefore never enumerated, so the generated struct/stash had no field to bind a caller's `className` to. It now also scans non-module local consts (module consts can't reference the function-scoped `props`, so they're skipped).
+
+- **`[...].join(' ')` module-const inlining on the Perl adapters.** Module consts assembled as `const stateClasses = ['[&[data-state=…]]:…', …].join(' ')` were emitted as references (`$trackStateClasses`) to bindings that don't exist server-side. A new shared `evalStringArrayJoin` helper statically evaluates the join and inlines the flattened string byte-for-byte, matching the Hono reference and the Go adapter's existing private behaviour. Wired into the Mojolicious and Xslate `parsePureStringLiteral` module-const collectors.
+
+`switch` is unskipped on all three adapter conformance suites. Hono reference snapshots are unchanged.

--- a/.changeset/toggle-ssr-conformance-parity.md
+++ b/.changeset/toggle-ssr-conformance-parity.md
@@ -1,0 +1,20 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+---
+
+Bring the `toggle` site/ui primitive to SSR conformance parity across the Go, Mojolicious, and Xslate template adapters.
+
+`toggle`'s `classes` is a block-bodied `createMemo` that indexes module-scope `Record<T, string>` maps by a memo-local key with a default: `const variant = props.variant ?? 'default'; … ${variantClasses[variant]} ${sizeClasses[size]} …`. Lowering it to an SSR value required three extensions:
+
+- **`parseRecordIndexAccess` (`@barefootjs/jsx`)** gains an optional key resolver so the index key can be a memo-local const (resolved to its underlying prop + `?? '<lit>'` default), not only a bare prop. The result now carries that `defaultKey`. The resolver takes precedence over the same-named prop, since only the local binding carries the fallback.
+
+- **Go adapter** template-literal memo path now handles block-bodied arrows (collecting leading `const X = props.Y ?? 'lit'` key bindings, then resolving the single returned template literal) and emits `recordConst[key]` as an inline `map[string]string{…}[fmt.Sprint(in.Field)]`. When the key has a `'default'` fallback, the map also maps the empty key `""` to that default entry's value, so an unset prop (Go zero value `""`) renders the default instead of an empty string — matching Hono's `props.X ?? 'default'` runtime evaluation. `inferMemoType` recognises a template-literal memo as `string` (so the class-string `/` in `ring-ring/50` no longer trips the arithmetic-int heuristic).
+
+- **`extractSsrDefaults` (`@barefootjs/jsx`)**, the Mojo / Xslate SSR stash seed, now statically evaluates block-bodied arrows (leading `const` declarations into a local scope, then the `return` expression) and indexes a resolved object / array with a resolved scalar key, so the seeded `classes` is a concrete string. The Xslate adapter consumes this through the same SSR-seed path as Mojo.
+
+Also adds an HTML character-reference canonicalisation to the shared `normalizeHTML` conformance helper: a literal `"` in an attribute value (the `[class*="size-"]` in `toggle`'s base classes) is escaped as the named `&quot;` by Hono but as the numeric `&#34;` by Go's `html/template`. Both decode to the same character, so the interchangeable numeric (decimal + hex) forms are now collapsed to one canonical named form on both sides of the comparison — adapter-neutral, same motivation as the existing boolean-attribute / void-element canonicalisation.
+
+`toggle` is unskipped on all three adapter conformance suites. Hono reference snapshots are unchanged.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -65,16 +65,6 @@ runAdapterConformanceTests({
     // option fixed on the Hono side. Separate follow-up.
     'toggle-shared',
     'props-reactivity-comparison',
-    // #1467 Phase 2b `site/ui` primitives (`toggle`, `switch`) are no longer
-    // skipped. `switch` assembles classes in function-scope plain consts;
-    // `toggle`'s `classes` memo interpolates `Record<T,string>[variant|size]`
-    // lookups keyed by a memo-local `const variant = props.variant ?? 'default'`.
-    // The compiler now lowers both: `augmentInheritedPropAccesses` scans
-    // function-scope const initializers for `props.className`; `[...].join(' ')`
-    // module consts inline via the shared `evalStringArrayJoin`; and the
-    // template-literal memo path resolves block-bodied arrows + `recordConst[key]`
-    // to an inline `map[string]string{…, "": <default>}[fmt.Sprint(in.Field)]`
-    // (the `""` entry renders the `?? 'default'` fallback for an unset prop).
   ],
   // Per-fixture build-time contracts for shapes the Go template
   // adapter intentionally refuses to lower. Lives here (not on the

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -35,16 +35,6 @@ runAdapterConformanceTests({
   // `BF104` at build time instead of silently emitting invalid
   // template syntax (#1266).
   skipJsx: [
-    // #1297 fixed the harness-side IR emission gate (multi-component
-    // sources now emit one `ir` file per component, and the harness
-    // picks the entry-point IR). The remaining gap is adapter-side:
-    // the go-template adapter has no SSR context-propagation
-    // mechanism, so `<Ctx.Provider value="dark">` doesn't make
-    // `useContext(Ctx)` resolve to `"dark"` at template-eval time —
-    // the template emits `.Theme` against a struct that has no
-    // `Theme` field. Provider SSR coverage on go-template waits on
-    // that adapter feature; see #1297 follow-up.
-    'context-provider',
     // #1244 stress catalog (#1326): `children={<span/>}` — the IR
     // hoists the span with `needsScope: true` so the Hono reference
     // emits `bf-s` on the inner `<span>`. The Go adapter renders the

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -76,11 +76,18 @@ runAdapterConformanceTests({
     'toggle-shared',
     'props-reactivity-comparison',
     // #1467 Phase 2b `site/ui` primitives still pending cross-adapter parity:
-    //   toggle / switch — the reactive `classes` memo interpolates
+    //   toggle — the reactive `classes` memo interpolates
     //     `Record<T,string>[variant|size]` lookups, which have no SSR
     //     lowering yet (known limitation).
+    //
+    //   `switch` no longer skipped: its track/thumb classes assemble in
+    //     function-scope plain consts (`trackClasses`, `thumbClasses`), not a
+    //     `Record`-indexed memo. The remaining gaps were that
+    //     `augmentInheritedPropAccesses` didn't scan function-scope const
+    //     initializers for `props.className`, and Mojo/Xslate didn't inline
+    //     `[...].join(' ')` module consts (Go already did via
+    //     `evalStringArrayJoin`). Both are now fixed in `@barefootjs/jsx`.
     'toggle',
-    'switch',
   ],
   // Per-fixture build-time contracts for shapes the Go template
   // adapter intentionally refuses to lower. Lives here (not on the

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -75,19 +75,16 @@ runAdapterConformanceTests({
     // option fixed on the Hono side. Separate follow-up.
     'toggle-shared',
     'props-reactivity-comparison',
-    // #1467 Phase 2b `site/ui` primitives still pending cross-adapter parity:
-    //   toggle — the reactive `classes` memo interpolates
-    //     `Record<T,string>[variant|size]` lookups, which have no SSR
-    //     lowering yet (known limitation).
-    //
-    //   `switch` no longer skipped: its track/thumb classes assemble in
-    //     function-scope plain consts (`trackClasses`, `thumbClasses`), not a
-    //     `Record`-indexed memo. The remaining gaps were that
-    //     `augmentInheritedPropAccesses` didn't scan function-scope const
-    //     initializers for `props.className`, and Mojo/Xslate didn't inline
-    //     `[...].join(' ')` module consts (Go already did via
-    //     `evalStringArrayJoin`). Both are now fixed in `@barefootjs/jsx`.
-    'toggle',
+    // #1467 Phase 2b `site/ui` primitives (`toggle`, `switch`) are no longer
+    // skipped. `switch` assembles classes in function-scope plain consts;
+    // `toggle`'s `classes` memo interpolates `Record<T,string>[variant|size]`
+    // lookups keyed by a memo-local `const variant = props.variant ?? 'default'`.
+    // The compiler now lowers both: `augmentInheritedPropAccesses` scans
+    // function-scope const initializers for `props.className`; `[...].join(' ')`
+    // module consts inline via the shared `evalStringArrayJoin`; and the
+    // template-literal memo path resolves block-bodied arrows + `recordConst[key]`
+    // to an inline `map[string]string{…, "": <default>}[fmt.Sprint(in.Field)]`
+    // (the `""` entry renders the `?? 'default'` fallback for an unset prop).
   ],
   // Per-fixture build-time contracts for shapes the Go template
   // adapter intentionally refuses to lower. Lives here (not on the

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -105,11 +105,10 @@ interface StaticChildInstance {
    *  the existing drop path. */
   childrenHtml: string | null
   /**
-   * (#1297 follow-up) Context values supplied by enclosing `<Ctx.Provider
-   * value>` ancestors: `createContext` identifier → Go value literal. The
-   * static-child init reads these against the child's own context-consumer
-   * fields to wire `<Provider value>` into the child slot's input. Empty when
-   * the child isn't under any provider.
+   * Context values from enclosing `<Ctx.Provider value>` ancestors
+   * (`createContext` identifier → Go value literal), wired into this child
+   * slot's input against its own context-consumer fields. Empty/undefined when
+   * the child isn't under any provider. (#1297)
    */
   contextBindings?: ReadonlyMap<string, string>
 }
@@ -484,11 +483,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   private localConstants: IRMetadata['localConstants'] = []
 
   /**
-   * `useContext(...)` consumers in the component being generated (#1297
-   * follow-up). Each becomes a struct field defaulted to the context's
-   * `createContext` default, which an enclosing `<Ctx.Provider value>`
-   * overwrites for descendant child slots. Reset at `generate()` /
-   * `generateTypes()` entry.
+   * `useContext(...)` consumers in the component being generated. Each becomes
+   * a struct field defaulted to the `createContext` default, which an enclosing
+   * `<Ctx.Provider value>` overwrites for descendant child slots. Reset at
+   * `generate()` / `generateTypes()` entry. (#1297)
    */
   private contextConsumers: ContextConsumer[] = []
 
@@ -844,9 +842,8 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     const restPropsName = ir.metadata.restPropsName ?? null
     const restBagField = restPropsName ? this.capitalizeFieldName(restPropsName) : null
     this.childComponentShapes.set(name, { paramNames, restBagField })
-    // (#1297 follow-up) Record the contexts this child consumes so a parent
-    // wrapping it in `<Ctx.Provider value>` can set the matching field on the
-    // child's slot input.
+    // Record the contexts this child consumes so a parent wrapping it in
+    // `<Ctx.Provider value>` can set the matching field on the child's slot input.
     this.childContextConsumers.set(name, collectContextConsumers(ir.metadata))
   }
 
@@ -1289,8 +1286,8 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       lines.push(`\t${nested.name}s []${nested.name}Input`)
     }
 
-    // (#1297 follow-up) `useContext` consumer fields — settable by an enclosing
-    // provider on the parent's side; default applied in NewXxxProps.
+    // `useContext` consumer fields — settable by an enclosing provider on the
+    // parent's side; default applied in NewXxxProps.
     const takenInput = new Set(ir.metadata.propsParams.map(p => this.capitalizeFieldName(p.name)))
     for (const c of this.nonCollidingContextConsumers(takenInput)) {
       lines.push(`\t${this.contextFieldName(c)} ${this.contextConsumerGoType(c)}`)
@@ -1428,8 +1425,8 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       lines.push(`\t${fieldName} ${goType} \`json:"${jsonTag}"\``)
     }
 
-    // (#1297 follow-up) `useContext` consumer fields (skip names already taken
-    // by a prop / signal / memo field).
+    // `useContext` consumer fields (skip names already taken by a prop /
+    // signal / memo field).
     const takenProps = new Set<string>([
       ...ir.metadata.propsParams.map(p => this.capitalizeFieldName(p.name)),
       ...ir.metadata.signals.map(s => this.capitalizeFieldName(s.getter)),
@@ -1630,8 +1627,8 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       lines.push(`\t\t${fieldName}: ${memoValue},`)
     }
 
-    // (#1297 follow-up) `useContext` consumer fields: default to the
-    // `createContext` default when the caller (a provider) didn't set them.
+    // `useContext` consumer fields: default to the `createContext` default
+    // when the caller (a provider) didn't set them.
     const takenInit = new Set<string>([
       ...ir.metadata.propsParams.map(p => this.capitalizeFieldName(p.name)),
       ...ir.metadata.signals.map(s => this.capitalizeFieldName(s.getter)),
@@ -1656,11 +1653,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       // own NewProps (BfParent/BfMount fields).
       lines.push(`\t\t\tBfParent: scopeID,`)
       lines.push(`\t\t\tBfMount: "${child.slotId}",`)
-      // (#1297 follow-up) SSR context propagation: if this child is wrapped in
-      // a `<Ctx.Provider value>` and consumes that context, set its
-      // context-consumer field to the provider value so `useContext(Ctx)`
-      // resolves to the provided value at template-eval time (else the child's
-      // own NewProps applies the `createContext` default).
+      // SSR context propagation: if this child is wrapped in a `<Ctx.Provider
+      // value>` it consumes, set its context-consumer field to the provider
+      // value (else the child's own NewProps applies the `createContext`
+      // default). (#1297)
       if (child.contextBindings) {
         for (const consumer of this.childContextConsumers.get(child.name) ?? []) {
           const goVal = child.contextBindings.get(consumer.contextName)
@@ -1963,10 +1959,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         this.collectStaticChildInstancesRecursive(cond.whenFalse, result, inLoop, providerCtx)
       }
     } else if (node.type === 'provider') {
-      // SSR context propagation (#1297 follow-up): record the provider's
-      // value against its context name and extend the active binding map
-      // for descendants. A literal `value="dark"` lowers to a Go literal;
-      // a non-literal value is left unbound (the consumer keeps its default).
+      // SSR context propagation: record the provider's value against its
+      // context name and extend the active binding map for descendants. A
+      // literal value lowers to a Go literal; a non-literal is left unbound
+      // (the consumer keeps its default). (#1297)
       const p = node as IRProvider
       const childCtx = this.extendProviderContext(providerCtx, p)
       for (const child of p.children) {
@@ -1985,11 +1981,9 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   /**
-   * Extend the active provider-context map with one `<Ctx.Provider value>`.
-   * The value is lowered to a Go literal when it's a string / number / boolean
-   * literal; any other shape is skipped (the descendant consumer keeps its
-   * `createContext` default), since a non-literal provider value has no
-   * SSR-template form yet.
+   * Extend the active provider-context map with one `<Ctx.Provider value>`. A
+   * string/number/boolean literal value is lowered to a Go literal; any other
+   * shape is skipped (the descendant consumer keeps its `createContext` default).
    */
   private extendProviderContext(
     current: ReadonlyMap<string, string>,
@@ -3067,19 +3061,13 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   /**
-   * Lower a `recordConst[key]` interpolation of a template-literal memo to an
-   * inline indexed Go map. `recordConst` must be a module-scope
-   * `Record<staticKeys, scalar>` object literal; `key` is either a bare prop or
-   * a memo-local const bound to `props.X ?? 'default'` (resolved via
-   * `localKeyBindings`). When the key carries a `'default'` fallback, the map
-   * also maps the empty key `""` to that default entry's value, so an unset
-   * prop (Go zero value `""`) renders the default instead of an empty string —
-   * matching the Hono reference's `props.X ?? 'default'` runtime evaluation.
-   *
-   * Emits `map[string]string{…}[fmt.Sprint(in.Field)]` when every entry value
-   * is a string (composable with `+` in the surrounding concatenation), else
-   * `map[string]any{…}`. Returns null for any non-record / non-resolvable key
-   * so the caller falls through.
+   * Lower a `recordConst[key]` interpolation to an inline indexed Go map,
+   * emitting `map[string]string{…}[fmt.Sprint(in.Field)]` (or `map[string]any`
+   * for mixed values). `key` is a bare prop or a memo-local const bound to
+   * `props.X ?? 'default'` (resolved via `localKeyBindings`); a `'default'`
+   * fallback also maps `""` to that entry, so an unset prop (Go zero value `""`)
+   * renders the default — matching Hono's `props.X ?? 'default'`. Returns null
+   * for any non-record / non-resolvable key so the caller falls through.
    */
   private recordIndexInterpolationToGo(
     node: ts.ElementAccessExpression,
@@ -3232,10 +3220,8 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   /**
-   * Whether a memo computation is an arrow whose result is a template literal —
-   * either a concise body (`() => \`…\``) or a block body whose `return` is a
-   * template literal (`() => { const v = …; return \`…\` }`). Used by both
-   * `inferMemoType` (→ `string`) and (indirectly) the SSR-value computation.
+   * Whether a memo is an arrow whose result is a template literal — either a
+   * concise body (`() => \`…\``) or a block body whose `return` is one.
    */
   private isTemplateLiteralMemo(computation: string): boolean {
     const sf = ts.createSourceFile(
@@ -3269,10 +3255,9 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     signals: { getter: string; initialValue: string; type: TypeInfo }[],
     propsParamMap: Map<string, { name: string; type: TypeInfo; defaultValue?: string }>
   ): string {
-    // A template-literal memo (concise `() => \`…\`` or block-bodied
-    // `() => { …; return \`…\` }`, e.g. the Toggle/Switch `classes` memo) always
-    // produces a string. Decide this first so the class-string `/` in
-    // `ring-ring/50` doesn't trip the arithmetic heuristic below into `int`.
+    // A template-literal memo always produces a string. Decide this first so a
+    // class-string `/` (e.g. `ring-ring/50`) doesn't trip the arithmetic
+    // heuristic below into `int`.
     if (this.isTemplateLiteralMemo(memo.computation)) return 'string'
 
     // Check if computation involves multiplication (*) - likely number

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -466,6 +466,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   private moduleStringConsts: Map<string, string> = new Map()
 
   /**
+   * All local constants (module + function-scope) from the IR, retained for
+   * the lifetime of `generate()` so the memo-computation path can resolve
+   * `Record`-index lookups (`variantClasses[variant]`) without re-threading the
+   * full `ir` through every helper. Reset at `generate()` entry.
+   */
+  private localConstants: IRMetadata['localConstants'] = []
+
+  /**
    * Set of prop NAMES whose resolved Go struct-field type is exactly
    * `interface{}` — i.e. nillable. Populated at `generate()` entry from
    * the SAME per-prop Go-type computation `generatePropsStruct` /
@@ -501,6 +509,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     this.propsObjectName = ir.metadata.propsObjectName
     this.restPropsName = ir.metadata.restPropsName ?? null
     this.moduleStringConsts = this.collectModuleStringConsts(ir.metadata.localConstants)
+    this.localConstants = ir.metadata.localConstants ?? []
     // (#checkbox) Enumerate inherited-attribute accesses (props-object pattern)
     // before computing the nillable set / rendering, so the synthetic params
     // participate in attribute omission and field binding uniformly. Shared
@@ -824,6 +833,11 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // idempotent. `propsObjectName` is needed by the scan.
     this.propsObjectName = ir.metadata.propsObjectName
     augmentInheritedPropAccesses(ir)
+    // Mirror `generate()`: the `NewXxxProps` initializer computes memo SSR
+    // values, which inline module string consts and resolve `Record`-index
+    // lookups — both need the const tables populated on this standalone entry.
+    this.moduleStringConsts = this.collectModuleStringConsts(ir.metadata.localConstants)
+    this.localConstants = ir.metadata.localConstants ?? []
     const lines: string[] = []
 
     const componentName = ir.metadata.componentName
@@ -2786,6 +2800,36 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     while (ts.isParenthesizedExpression(body as ts.Expression)) {
       body = (body as ts.ParenthesizedExpression).expression
     }
+
+    // Block-bodied arrow (the Toggle `classes` memo): collect leading
+    // `const X = props.Y ?? 'lit'` key bindings, then resolve against the
+    // single returned template literal. The bindings let `variantClasses[variant]`
+    // resolve `variant` to prop `variant` with its `'default'` fallback key.
+    const localKeyBindings = new Map<string, { propName: string; defaultLiteral?: string }>()
+    if (ts.isBlock(body)) {
+      let returned: ts.Node | null = null
+      for (const s of body.statements) {
+        if (ts.isVariableStatement(s)) {
+          for (const d of s.declarationList.declarations) {
+            if (!ts.isIdentifier(d.name) || !d.initializer) continue
+            const binding = this.parseLocalKeyBinding(d.initializer)
+            if (binding) localKeyBindings.set(d.name.text, binding)
+          }
+        } else if (ts.isReturnStatement(s) && s.expression) {
+          returned = s.expression
+        } else if (ts.isExpressionStatement(s) || ts.isEmptyStatement(s)) {
+          // ignore
+        } else {
+          return null // unsupported statement shape — bail to existing patterns
+        }
+      }
+      if (!returned) return null
+      body = returned
+      while (ts.isParenthesizedExpression(body as ts.Expression)) {
+        body = (body as ts.ParenthesizedExpression).expression
+      }
+    }
+
     if (!ts.isTemplateExpression(body) && !ts.isNoSubstitutionTemplateLiteral(body)) {
       return null
     }
@@ -2799,7 +2843,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // head + each span
     if (body.head.text) segments.push(escGo(body.head.text))
     for (const span of body.templateSpans) {
-      const resolved = this.resolveTemplateInterpolation(span.expression, propNames)
+      const resolved = this.resolveTemplateInterpolation(span.expression, propNames, localKeyBindings)
       if (resolved === null) return null
       segments.push(resolved)
       if (span.literal.text) segments.push(escGo(span.literal.text))
@@ -2816,6 +2860,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   private resolveTemplateInterpolation(
     expr: ts.Expression,
     propNames: Set<string>,
+    localKeyBindings: ReadonlyMap<string, { propName: string; defaultLiteral?: string }> = new Map(),
   ): string | null {
     let node: ts.Expression = expr
     while (ts.isParenthesizedExpression(node)) node = node.expression
@@ -2824,6 +2869,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     if (ts.isIdentifier(node)) {
       const inlined = this.resolveModuleStringConst(node.text)
       if (inlined !== null) return inlined
+      return null
+    }
+
+    // `recordConst[key]` → inline indexed Go map (the Toggle `classes` memo's
+    // `variantClasses[variant]` / `sizeClasses[size]`).
+    if (ts.isElementAccessExpression(node)) {
+      const indexed = this.recordIndexInterpolationToGo(node, propNames, localKeyBindings)
+      if (indexed !== null) return indexed
       return null
     }
 
@@ -2850,6 +2903,76 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       return `in.${this.capitalizeFieldName(propName)}`
     }
     return null
+  }
+
+  /**
+   * Parse a memo-local `const X = …` initializer into a `Record`-index key
+   * binding: `props.Y ?? 'lit'` → `{ propName: 'Y', defaultLiteral: 'lit' }`,
+   * or bare `props.Y` → `{ propName: 'Y' }`. Returns null for any other shape
+   * (a literal const, a call, etc.) so it simply isn't registered as a key.
+   */
+  private parseLocalKeyBinding(
+    init: ts.Expression,
+  ): { propName: string; defaultLiteral?: string } | null {
+    let node: ts.Expression = init
+    while (ts.isParenthesizedExpression(node)) node = node.expression
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken
+    ) {
+      const propName = this.propsAccessName(node.left)
+      const right = node.right
+      if (
+        propName &&
+        (ts.isStringLiteral(right) || ts.isNoSubstitutionTemplateLiteral(right))
+      ) {
+        return { propName, defaultLiteral: right.text }
+      }
+      return null
+    }
+    const propName = this.propsAccessName(node)
+    if (propName) return { propName }
+    return null
+  }
+
+  /**
+   * Lower a `recordConst[key]` interpolation of a template-literal memo to an
+   * inline indexed Go map. `recordConst` must be a module-scope
+   * `Record<staticKeys, scalar>` object literal; `key` is either a bare prop or
+   * a memo-local const bound to `props.X ?? 'default'` (resolved via
+   * `localKeyBindings`). When the key carries a `'default'` fallback, the map
+   * also maps the empty key `""` to that default entry's value, so an unset
+   * prop (Go zero value `""`) renders the default instead of an empty string —
+   * matching the Hono reference's `props.X ?? 'default'` runtime evaluation.
+   *
+   * Emits `map[string]string{…}[fmt.Sprint(in.Field)]` when every entry value
+   * is a string (composable with `+` in the surrounding concatenation), else
+   * `map[string]any{…}`. Returns null for any non-record / non-resolvable key
+   * so the caller falls through.
+   */
+  private recordIndexInterpolationToGo(
+    node: ts.ElementAccessExpression,
+    propNames: Set<string>,
+    localKeyBindings: ReadonlyMap<string, { propName: string; defaultLiteral?: string }>,
+  ): string | null {
+    const parsed = parseRecordIndexAccess(
+      node,
+      this.localConstants ?? [],
+      [...propNames].map(name => ({ name })),
+      name => localKeyBindings.get(name) ?? null,
+    )
+    if (!parsed) return null
+    const goVal = (v: { kind: 'number' | 'string'; text: string }) =>
+      v.kind === 'number' ? v.text : JSON.stringify(v.text)
+    const entries = parsed.entries.map(e => `${JSON.stringify(e.key)}: ${goVal(e.value)}`)
+    if (parsed.defaultKey !== undefined) {
+      const def = parsed.entries.find(e => e.key === parsed.defaultKey)
+      if (def) entries.unshift(`"": ${goVal(def.value)}`)
+    }
+    const allString = parsed.entries.every(e => e.value.kind === 'string')
+    const mapType = allString ? 'map[string]string' : 'map[string]any'
+    this.usesFmt = true
+    return `${mapType}{${entries.join(', ')}}[fmt.Sprint(in.${this.capitalizeFieldName(parsed.indexPropName)})]`
   }
 
   /**
@@ -2978,6 +3101,36 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   /**
+   * Whether a memo computation is an arrow whose result is a template literal —
+   * either a concise body (`() => \`…\``) or a block body whose `return` is a
+   * template literal (`() => { const v = …; return \`…\` }`). Used by both
+   * `inferMemoType` (→ `string`) and (indirectly) the SSR-value computation.
+   */
+  private isTemplateLiteralMemo(computation: string): boolean {
+    const sf = ts.createSourceFile(
+      '__memo.ts', `const __x = (${computation});`, ts.ScriptTarget.Latest, /*setParentNodes*/ false,
+    )
+    const stmt = sf.statements[0]
+    if (!stmt || !ts.isVariableStatement(stmt)) return false
+    let init = stmt.declarationList.declarations[0]?.initializer
+    while (init && ts.isParenthesizedExpression(init)) init = init.expression
+    if (!init || !ts.isArrowFunction(init)) return false
+    let body = init.body as ts.Node
+    while (ts.isParenthesizedExpression(body as ts.Expression)) {
+      body = (body as ts.ParenthesizedExpression).expression
+    }
+    if (ts.isBlock(body)) {
+      const ret = body.statements.find(ts.isReturnStatement)
+      if (!ret || !ret.expression) return false
+      body = ret.expression
+      while (ts.isParenthesizedExpression(body as ts.Expression)) {
+        body = (body as ts.ParenthesizedExpression).expression
+      }
+    }
+    return ts.isTemplateExpression(body) || ts.isNoSubstitutionTemplateLiteral(body)
+  }
+
+  /**
    * Infer the Go type for a memo based on its computation and dependencies.
    */
   private inferMemoType(
@@ -2985,6 +3138,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     signals: { getter: string; initialValue: string; type: TypeInfo }[],
     propsParamMap: Map<string, { name: string; type: TypeInfo; defaultValue?: string }>
   ): string {
+    // A template-literal memo (concise `() => \`…\`` or block-bodied
+    // `() => { …; return \`…\` }`, e.g. the Toggle/Switch `classes` memo) always
+    // produces a string. Decide this first so the class-string `/` in
+    // `ring-ring/50` doesn't trip the arithmetic heuristic below into `int`.
+    if (this.isTemplateLiteralMemo(memo.computation)) return 'string'
+
     // Check if computation involves multiplication (*) - likely number
     if (memo.computation.includes('*') || memo.computation.includes('/') ||
         memo.computation.includes('+') || memo.computation.includes('-')) {

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -60,6 +60,8 @@ import {
   emitAttrValue,
   augmentInheritedPropAccesses,
   parseRecordIndexAccess,
+  collectContextConsumers,
+  type ContextConsumer,
 } from '@barefootjs/jsx'
 import { findInterpolationEnd } from '@barefootjs/jsx/scanner'
 
@@ -102,6 +104,14 @@ interface StaticChildInstance {
    *  through the parent's `{{.Children}}` read; those cases stay on
    *  the existing drop path. */
   childrenHtml: string | null
+  /**
+   * (#1297 follow-up) Context values supplied by enclosing `<Ctx.Provider
+   * value>` ancestors: `createContext` identifier → Go value literal. The
+   * static-child init reads these against the child's own context-consumer
+   * fields to wire `<Provider value>` into the child slot's input. Empty when
+   * the child isn't under any provider.
+   */
+  contextBindings?: ReadonlyMap<string, string>
 }
 
 /**
@@ -474,6 +484,18 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   private localConstants: IRMetadata['localConstants'] = []
 
   /**
+   * `useContext(...)` consumers in the component being generated (#1297
+   * follow-up). Each becomes a struct field defaulted to the context's
+   * `createContext` default, which an enclosing `<Ctx.Provider value>`
+   * overwrites for descendant child slots. Reset at `generate()` /
+   * `generateTypes()` entry.
+   */
+  private contextConsumers: ContextConsumer[] = []
+
+  /** Child component name → the contexts it consumes (cross-component, for provider wiring). */
+  private childContextConsumers: Map<string, ContextConsumer[]> = new Map()
+
+  /**
    * Set of prop NAMES whose resolved Go struct-field type is exactly
    * `interface{}` — i.e. nillable. Populated at `generate()` entry from
    * the SAME per-prop Go-type computation `generatePropsStruct` /
@@ -510,6 +532,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     this.restPropsName = ir.metadata.restPropsName ?? null
     this.moduleStringConsts = this.collectModuleStringConsts(ir.metadata.localConstants)
     this.localConstants = ir.metadata.localConstants ?? []
+    this.contextConsumers = collectContextConsumers(ir.metadata)
     // (#checkbox) Enumerate inherited-attribute accesses (props-object pattern)
     // before computing the nillable set / rendering, so the synthetic params
     // participate in attribute omission and field binding uniformly. Shared
@@ -821,6 +844,39 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     const restPropsName = ir.metadata.restPropsName ?? null
     const restBagField = restPropsName ? this.capitalizeFieldName(restPropsName) : null
     this.childComponentShapes.set(name, { paramNames, restBagField })
+    // (#1297 follow-up) Record the contexts this child consumes so a parent
+    // wrapping it in `<Ctx.Provider value>` can set the matching field on the
+    // child's slot input.
+    this.childContextConsumers.set(name, collectContextConsumers(ir.metadata))
+  }
+
+  /** Go field name for a `useContext` consumer (the capitalized local binding). */
+  private contextFieldName(c: ContextConsumer): string {
+    return this.capitalizeFieldName(c.localName)
+  }
+
+  /** Go type for a context-consumer field, from its `createContext` default's type. */
+  private contextConsumerGoType(c: ContextConsumer): string {
+    if (typeof c.defaultValue === 'number') return 'int'
+    if (typeof c.defaultValue === 'boolean') return 'bool'
+    return 'string'
+  }
+
+  /** Go literal for a context-consumer's default value (the `createContext` arg). */
+  private contextConsumerGoDefault(c: ContextConsumer): string {
+    if (typeof c.defaultValue === 'number') return String(c.defaultValue)
+    if (typeof c.defaultValue === 'boolean') return String(c.defaultValue)
+    if (typeof c.defaultValue === 'string') return `"${this.escapeGoString(c.defaultValue)}"`
+    return '""'
+  }
+
+  /**
+   * Context-consumer fields that don't collide with an already-emitted prop /
+   * signal / memo field. The template reads them as `{{.Field}}` (the local
+   * `useContext` binding lowered to a root field); the struct must carry them.
+   */
+  private nonCollidingContextConsumers(taken: ReadonlySet<string>): ContextConsumer[] {
+    return this.contextConsumers.filter(c => !taken.has(this.contextFieldName(c)))
   }
 
   generateTypes(ir: ComponentIR): string | null {
@@ -838,6 +894,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // lookups — both need the const tables populated on this standalone entry.
     this.moduleStringConsts = this.collectModuleStringConsts(ir.metadata.localConstants)
     this.localConstants = ir.metadata.localConstants ?? []
+    this.contextConsumers = collectContextConsumers(ir.metadata)
     const lines: string[] = []
 
     const componentName = ir.metadata.componentName
@@ -1232,6 +1289,13 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       lines.push(`\t${nested.name}s []${nested.name}Input`)
     }
 
+    // (#1297 follow-up) `useContext` consumer fields — settable by an enclosing
+    // provider on the parent's side; default applied in NewXxxProps.
+    const takenInput = new Set(ir.metadata.propsParams.map(p => this.capitalizeFieldName(p.name)))
+    for (const c of this.nonCollidingContextConsumers(takenInput)) {
+      lines.push(`\t${this.contextFieldName(c)} ${this.contextConsumerGoType(c)}`)
+    }
+
     // (#1407 follow-up) Input-side bag field for restPropsName spreads.
     // The destructured-rest pattern
     // (`function({a, ...rest}: P) { <el {...rest}/> }`) surfaces
@@ -1362,6 +1426,18 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       // Memos that depend on number signals are usually numbers
       const goType = this.inferMemoType(memo, ir.metadata.signals, propsParamMap)
       lines.push(`\t${fieldName} ${goType} \`json:"${jsonTag}"\``)
+    }
+
+    // (#1297 follow-up) `useContext` consumer fields (skip names already taken
+    // by a prop / signal / memo field).
+    const takenProps = new Set<string>([
+      ...ir.metadata.propsParams.map(p => this.capitalizeFieldName(p.name)),
+      ...ir.metadata.signals.map(s => this.capitalizeFieldName(s.getter)),
+      ...ir.metadata.memos.map(m => this.capitalizeFieldName(m.name)),
+    ])
+    for (const c of this.nonCollidingContextConsumers(takenProps)) {
+      const jsonTag = this.toJsonTag(c.localName)
+      lines.push(`\t${this.contextFieldName(c)} ${this.contextConsumerGoType(c)} \`json:"${jsonTag}"\``)
     }
 
     // Add array fields for nested components (for template rendering)
@@ -1554,6 +1630,23 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       lines.push(`\t\t${fieldName}: ${memoValue},`)
     }
 
+    // (#1297 follow-up) `useContext` consumer fields: default to the
+    // `createContext` default when the caller (a provider) didn't set them.
+    const takenInit = new Set<string>([
+      ...ir.metadata.propsParams.map(p => this.capitalizeFieldName(p.name)),
+      ...ir.metadata.signals.map(s => this.capitalizeFieldName(s.getter)),
+      ...ir.metadata.memos.map(m => this.capitalizeFieldName(m.name)),
+    ])
+    for (const c of this.nonCollidingContextConsumers(takenInit)) {
+      const field = this.contextFieldName(c)
+      const def = this.contextConsumerGoDefault(c)
+      const defaulted =
+        c.defaultValue === null || def === '""' || def === '0' || def === 'false'
+          ? `in.${field}`
+          : this.applyGoFallback(`in.${field}`, def)
+      lines.push(`\t\t${field}: ${defaulted},`)
+    }
+
     // Add static child component instances
     const staticChildren = this.collectStaticChildInstances(ir.root)
     for (const child of staticChildren) {
@@ -1563,6 +1656,19 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       // own NewProps (BfParent/BfMount fields).
       lines.push(`\t\t\tBfParent: scopeID,`)
       lines.push(`\t\t\tBfMount: "${child.slotId}",`)
+      // (#1297 follow-up) SSR context propagation: if this child is wrapped in
+      // a `<Ctx.Provider value>` and consumes that context, set its
+      // context-consumer field to the provider value so `useContext(Ctx)`
+      // resolves to the provided value at template-eval time (else the child's
+      // own NewProps applies the `createContext` default).
+      if (child.contextBindings) {
+        for (const consumer of this.childContextConsumers.get(child.name) ?? []) {
+          const goVal = child.contextBindings.get(consumer.contextName)
+          if (goVal !== undefined) {
+            lines.push(`\t\t\t${this.contextFieldName(consumer)}: ${goVal},`)
+          }
+        }
+      }
       // (#checkbox) Cross-component shape lookup: an attribute that is NOT a
       // declared param of the child but the child has a `...props` rest bag
       // (`<CheckIcon data-slot=.../>`, where CheckIcon's params are
@@ -1758,7 +1864,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    */
   private collectStaticChildInstances(node: IRNode): Array<StaticChildInstance> {
     const result: StaticChildInstance[] = []
-    this.collectStaticChildInstancesRecursive(node, result, false)
+    this.collectStaticChildInstancesRecursive(node, result, false, new Map())
     return result
   }
 
@@ -1799,7 +1905,8 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   private collectStaticChildInstancesRecursive(
     node: IRNode,
     result: StaticChildInstance[],
-    inLoop: boolean
+    inLoop: boolean,
+    providerCtx: ReadonlyMap<string, string>,
   ): void {
     if (node.type === 'component') {
       const comp = node as IRComponent
@@ -1809,7 +1916,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       // child components nested inside still get their slot fields.
       if (comp.dynamicTag) {
         for (const child of comp.children) {
-          this.collectStaticChildInstancesRecursive(child, result, inLoop)
+          this.collectStaticChildInstancesRecursive(child, result, inLoop, providerCtx)
         }
         return
       }
@@ -1824,55 +1931,79 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
           fieldName: `${comp.name}${suffix}`,
           childrenText: this.extractTextChildren(comp.children),
           childrenHtml: this.extractHtmlChildren(comp.children),
+          contextBindings: providerCtx.size > 0 ? providerCtx : undefined,
         })
       }
       // Recurse into Portal's children to find nested components
       if (comp.name === 'Portal' && comp.children) {
         for (const child of comp.children) {
-          this.collectStaticChildInstancesRecursive(child, result, inLoop)
+          this.collectStaticChildInstancesRecursive(child, result, inLoop, providerCtx)
         }
       }
     } else if (node.type === 'loop') {
       const loop = node as IRLoop
       // Mark children as inside loop
       for (const child of loop.children) {
-        this.collectStaticChildInstancesRecursive(child, result, true)
+        this.collectStaticChildInstancesRecursive(child, result, true, providerCtx)
       }
     } else if (node.type === 'element') {
       const element = node as IRElement
       for (const child of element.children) {
-        this.collectStaticChildInstancesRecursive(child, result, inLoop)
+        this.collectStaticChildInstancesRecursive(child, result, inLoop, providerCtx)
       }
     } else if (node.type === 'fragment') {
       const fragment = node as IRFragment
       for (const child of fragment.children) {
-        this.collectStaticChildInstancesRecursive(child, result, inLoop)
+        this.collectStaticChildInstancesRecursive(child, result, inLoop, providerCtx)
       }
     } else if (node.type === 'conditional') {
       const cond = node as IRConditional
-      this.collectStaticChildInstancesRecursive(cond.whenTrue, result, inLoop)
+      this.collectStaticChildInstancesRecursive(cond.whenTrue, result, inLoop, providerCtx)
       if (cond.whenFalse) {
-        this.collectStaticChildInstancesRecursive(cond.whenFalse, result, inLoop)
+        this.collectStaticChildInstancesRecursive(cond.whenFalse, result, inLoop, providerCtx)
       }
     } else if (node.type === 'provider') {
-      // Provider is a transparent wrapper at the SSR layer — context
-      // propagation is purely a client-runtime concern. Recurse into
-      // its children so any static <Child/> nested under <Ctx.Provider>
-      // still gets a slot field generated on the parent's props type.
+      // SSR context propagation (#1297 follow-up): record the provider's
+      // value against its context name and extend the active binding map
+      // for descendants. A literal `value="dark"` lowers to a Go literal;
+      // a non-literal value is left unbound (the consumer keeps its default).
       const p = node as IRProvider
+      const childCtx = this.extendProviderContext(providerCtx, p)
       for (const child of p.children) {
-        this.collectStaticChildInstancesRecursive(child, result, inLoop)
+        this.collectStaticChildInstancesRecursive(child, result, inLoop, childCtx)
       }
     } else if (node.type === 'async') {
       // Async fallback + children render server-side via the OOS
       // protocol; static child components inside them still need slot
       // fields on the parent struct.
       const a = node as IRAsync
-      this.collectStaticChildInstancesRecursive(a.fallback, result, inLoop)
+      this.collectStaticChildInstancesRecursive(a.fallback, result, inLoop, providerCtx)
       for (const child of a.children) {
-        this.collectStaticChildInstancesRecursive(child, result, inLoop)
+        this.collectStaticChildInstancesRecursive(child, result, inLoop, providerCtx)
       }
     }
+  }
+
+  /**
+   * Extend the active provider-context map with one `<Ctx.Provider value>`.
+   * The value is lowered to a Go literal when it's a string / number / boolean
+   * literal; any other shape is skipped (the descendant consumer keeps its
+   * `createContext` default), since a non-literal provider value has no
+   * SSR-template form yet.
+   */
+  private extendProviderContext(
+    current: ReadonlyMap<string, string>,
+    p: IRProvider,
+  ): ReadonlyMap<string, string> {
+    const v = p.valueProp?.value as { kind?: string; value?: unknown } | undefined
+    if (!v || v.kind !== 'literal') return current
+    let goLit: string | null = null
+    if (typeof v.value === 'string') goLit = `"${this.escapeGoString(v.value)}"`
+    else if (typeof v.value === 'number' || typeof v.value === 'boolean') goLit = String(v.value)
+    if (goLit === null) return current
+    const next = new Map(current)
+    next.set(p.contextName, goLit)
+    return next
   }
 
   /**

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -34,17 +34,15 @@ runAdapterConformanceTests({
     // skips the same pair.)
     'toggle-shared',
     'props-reactivity-comparison',
-    // #1467 Phase 2b `site/ui` primitives still pending cross-adapter parity:
-    //   toggle — the reactive `classes` memo interpolates
-    //     `Record<T,string>[variant|size]` lookups, which have no SSR
-    //     lowering yet (known limitation).
-    //
-    //   `switch` no longer skipped: it assembles classes in function-scope
-    //     plain consts whose `[...].join(' ')` module consts now inline via the
-    //     shared `evalStringArrayJoin` (Go parity), and
-    //     `augmentInheritedPropAccesses` now scans those consts for
-    //     `props.className`. Both fixes live in `@barefootjs/jsx`.
-    'toggle',
+    // #1467 Phase 2b `site/ui` primitives (`toggle`, `switch`) are no longer
+    // skipped. `switch` assembles classes in function-scope plain consts whose
+    // `[...].join(' ')` module consts inline via the shared `evalStringArrayJoin`;
+    // `toggle`'s block-bodied `classes` memo interpolates `variantClasses[variant]`
+    // / `sizeClasses[size]`. `extractSsrDefaults` (the Mojo SSR stash seed) now
+    // evaluates block-bodied arrows and indexes seeded module-const objects with a
+    // resolved key, so the seeded `classes` is a concrete string; and
+    // `augmentInheritedPropAccesses` scans function-scope consts for
+    // `props.className`. All fixes live in `@barefootjs/jsx`.
   ],
   // Per-fixture build-time contracts for shapes the Mojo adapter
   // intentionally refuses to lower. Owned by this adapter test file

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -18,13 +18,15 @@ runAdapterConformanceTests({
   factory: () => new MojoAdapter(),
   render: renderMojoComponent,
   skipJsx: [
-    // #1297 fixed the harness-side IR emission gate. The remaining
-    // gap is adapter-side: the Mojo adapter has no SSR context-
-    // propagation mechanism, so `<Ctx.Provider value="dark">` doesn't
-    // make `useContext(Ctx)` resolve to `"dark"` at template-eval
-    // time — the template emits `<%= $theme %>` against a hash that
-    // never receives a `theme` key. Provider SSR coverage on Mojo
-    // waits on that adapter feature; see #1297 follow-up.
+    // SSR context propagation: `<Ctx.Provider value="dark">` doesn't make
+    // `useContext(Ctx)` resolve to `"dark"` at template-eval time — the
+    // template emits `<%= $theme %>` against a hash that never receives a
+    // `theme` key. The Go adapter now implements this (consumer-side field
+    // defaulted to the `createContext` default + provider-side child-slot
+    // wiring via `collectContextConsumers`); porting it to the Mojo stash-seed
+    // path (`extractSsrDefaults` would need to seed the consumer var and the
+    // provider would set it through `render_child`) is a follow-up — Mojo
+    // stays skipped for now (#1297 follow-up).
     'context-provider',
     // Multi-component shared fixtures with per-item loop state. The child
     // scope-id plumbing is now fixed (children derive `<parentScope>_<sN>`

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -18,15 +18,9 @@ runAdapterConformanceTests({
   factory: () => new MojoAdapter(),
   render: renderMojoComponent,
   skipJsx: [
-    // SSR context propagation: `<Ctx.Provider value="dark">` doesn't make
-    // `useContext(Ctx)` resolve to `"dark"` at template-eval time — the
-    // template emits `<%= $theme %>` against a hash that never receives a
-    // `theme` key. The Go adapter now implements this (consumer-side field
-    // defaulted to the `createContext` default + provider-side child-slot
-    // wiring via `collectContextConsumers`); porting it to the Mojo stash-seed
-    // path (`extractSsrDefaults` would need to seed the consumer var and the
-    // provider would set it through `render_child`) is a follow-up — Mojo
-    // stays skipped for now (#1297 follow-up).
+    // SSR context propagation (`<Ctx.Provider value>` → `useContext`): the
+    // template reads a stash key that's never seeded. Implemented on Go; the
+    // Perl stash-seed path is a follow-up port, so Mojo stays skipped (#1297).
     'context-provider',
     // Multi-component shared fixtures with per-item loop state. The child
     // scope-id plumbing is now fixed (children derive `<parentScope>_<sN>`
@@ -36,15 +30,6 @@ runAdapterConformanceTests({
     // skips the same pair.)
     'toggle-shared',
     'props-reactivity-comparison',
-    // #1467 Phase 2b `site/ui` primitives (`toggle`, `switch`) are no longer
-    // skipped. `switch` assembles classes in function-scope plain consts whose
-    // `[...].join(' ')` module consts inline via the shared `evalStringArrayJoin`;
-    // `toggle`'s block-bodied `classes` memo interpolates `variantClasses[variant]`
-    // / `sizeClasses[size]`. `extractSsrDefaults` (the Mojo SSR stash seed) now
-    // evaluates block-bodied arrows and indexes seeded module-const objects with a
-    // resolved key, so the seeded `classes` is a concrete string; and
-    // `augmentInheritedPropAccesses` scans function-scope consts for
-    // `props.className`. All fixes live in `@barefootjs/jsx`.
   ],
   // Per-fixture build-time contracts for shapes the Mojo adapter
   // intentionally refuses to lower. Owned by this adapter test file

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -35,11 +35,16 @@ runAdapterConformanceTests({
     'toggle-shared',
     'props-reactivity-comparison',
     // #1467 Phase 2b `site/ui` primitives still pending cross-adapter parity:
-    //   toggle / switch — the reactive `classes` memo interpolates
+    //   toggle — the reactive `classes` memo interpolates
     //     `Record<T,string>[variant|size]` lookups, which have no SSR
     //     lowering yet (known limitation).
+    //
+    //   `switch` no longer skipped: it assembles classes in function-scope
+    //     plain consts whose `[...].join(' ')` module consts now inline via the
+    //     shared `evalStringArrayJoin` (Go parity), and
+    //     `augmentInheritedPropAccesses` now scans those consts for
+    //     `props.className`. Both fixes live in `@barefootjs/jsx`.
     'toggle',
-    'switch',
   ],
   // Per-fixture build-time contracts for shapes the Mojo adapter
   // intentionally refuses to lower. Owned by this adapter test file

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -49,6 +49,7 @@ import {
   emitAttrValue,
   augmentInheritedPropAccesses,
   parseRecordIndexAccess,
+  evalStringArrayJoin,
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr } from './boolean-result'
 
@@ -144,7 +145,11 @@ function parsePureStringLiteral(source: string): string | null {
   if (ts.isStringLiteral(init) || ts.isNoSubstitutionTemplateLiteral(init)) {
     return init.text
   }
-  return null
+  // `[<string literals>].join(' ')` — a module const that flattens an array of
+  // pure string literals at module load (e.g. Switch's `trackStateClasses`).
+  // Inline the joined string so it lands byte-for-byte like the Hono reference
+  // instead of emitting a `$trackStateClasses` ref to a non-existent binding.
+  return evalStringArrayJoin(source)
 }
 
 /**

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -145,10 +145,8 @@ function parsePureStringLiteral(source: string): string | null {
   if (ts.isStringLiteral(init) || ts.isNoSubstitutionTemplateLiteral(init)) {
     return init.text
   }
-  // `[<string literals>].join(' ')` — a module const that flattens an array of
-  // pure string literals at module load (e.g. Switch's `trackStateClasses`).
-  // Inline the joined string so it lands byte-for-byte like the Hono reference
-  // instead of emitting a `$trackStateClasses` ref to a non-existent binding.
+  // `[<literals>].join(' ')` module consts (e.g. Switch's `trackStateClasses`)
+  // → inline the flattened string byte-for-byte. See `evalStringArrayJoin`.
   return evalStringArrayJoin(source)
 }
 

--- a/packages/adapter-tests/src/jsx-runner.ts
+++ b/packages/adapter-tests/src/jsx-runner.ts
@@ -202,15 +202,12 @@ export function normalizeHTML(html: string): string {
       /\s(disabled|hidden|checked|readonly|required|selected|autofocus|multiple|defer|async|controls|loop|muted|open|reversed|ismap|formnovalidate|nomodule|playsinline|inert|novalidate|allowfullscreen)=""/g,
       ' $1',
     )
-    // HTML character-reference canonicalisation. A literal special char
-    // inside an attribute value — e.g. the `"` in the Toggle `baseClasses`
-    // `[class*="size-"]` — is escaped as a NAMED entity (`&quot;`) by Hono's
-    // JSX serializer but as a NUMERIC reference (`&#34;`) by Go's
-    // `html/template`. Both decode to the identical character, so the choice
-    // is HTML-semantically irrelevant; collapse the interchangeable numeric
-    // (decimal + hex) forms to one canonical named form on BOTH sides so the
-    // byte comparison stays adapter-neutral (same motivation as the boolean-
-    // attribute and void-element canonicalisation above).
+    // HTML character-reference canonicalisation. A special char in an attribute
+    // value (e.g. the `"` in `[class*="size-"]`) is escaped as a NAMED entity by
+    // Hono but a NUMERIC reference by Go's `html/template`. Both decode to the
+    // same char, so collapse the interchangeable numeric (decimal + hex) forms
+    // to one canonical form on both sides — adapter-neutral, same motivation as
+    // the boolean-attribute / void-element canonicalisation above.
     .replace(/&#0*34;|&#[xX]0*22;/g, '&quot;')
     .replace(/&#0*38;|&#[xX]0*26;/g, '&amp;')
     .replace(/&#0*60;|&#[xX]0*3[cC];/g, '&lt;')

--- a/packages/adapter-tests/src/jsx-runner.ts
+++ b/packages/adapter-tests/src/jsx-runner.ts
@@ -202,6 +202,20 @@ export function normalizeHTML(html: string): string {
       /\s(disabled|hidden|checked|readonly|required|selected|autofocus|multiple|defer|async|controls|loop|muted|open|reversed|ismap|formnovalidate|nomodule|playsinline|inert|novalidate|allowfullscreen)=""/g,
       ' $1',
     )
+    // HTML character-reference canonicalisation. A literal special char
+    // inside an attribute value — e.g. the `"` in the Toggle `baseClasses`
+    // `[class*="size-"]` — is escaped as a NAMED entity (`&quot;`) by Hono's
+    // JSX serializer but as a NUMERIC reference (`&#34;`) by Go's
+    // `html/template`. Both decode to the identical character, so the choice
+    // is HTML-semantically irrelevant; collapse the interchangeable numeric
+    // (decimal + hex) forms to one canonical named form on BOTH sides so the
+    // byte comparison stays adapter-neutral (same motivation as the boolean-
+    // attribute and void-element canonicalisation above).
+    .replace(/&#0*34;|&#[xX]0*22;/g, '&quot;')
+    .replace(/&#0*38;|&#[xX]0*26;/g, '&amp;')
+    .replace(/&#0*60;|&#[xX]0*3[cC];/g, '&lt;')
+    .replace(/&#0*62;|&#[xX]0*3[eE];/g, '&gt;')
+    .replace(/&#0*39;|&#[xX]0*27;/g, '&#39;')
     // Normalize void element self-closing: <br/> or <br /> → <br>
     .replace(new RegExp(`<(${VOID_ELEMENTS})(\\s[^>]*?)?\\s*/>`, 'g'), '<$1$2>')
     // Remove trailing whitespace before >

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -33,10 +33,12 @@ runAdapterConformanceTests({
   // fixtures than mojo. Each entry below was confirmed to fail with
   // skipJsx emptied.
   skipJsx: [
-    // No SSR context propagation: `<Ctx.Provider value="dark">` doesn't make
+    // SSR context propagation: `<Ctx.Provider value="dark">` doesn't make
     // `useContext(Ctx)` resolve at template-eval time (the template reads a
-    // `theme` key that's never seeded). A real adapter feature, not yet
-    // implemented on either Perl backend. (Compiles clean; render-mismatches.)
+    // `theme` key that's never seeded). The Go adapter now implements this
+    // (consumer-side default + provider-side child-slot wiring); the Perl
+    // backends share the stash-seed render path and would port it the same
+    // way as Mojo — deferred, so Xslate stays skipped (#1297 follow-up).
     'context-provider',
     // Multi-component shared-state pairs whose children render inside a keyed
     // `.map` (loop children, no `_bf_slot`): the test harness derives a

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -47,13 +47,15 @@ runAdapterConformanceTests({
     'toggle-shared',
     'props-reactivity-comparison',
     // #1467 Phase 2b interactive `site/ui` primitives. `textarea` and
-    // `checkbox` now PASS. `toggle` / `switch` stay skipped: their reactive
-    // `classes` memo interpolates `Record<T,string>[variant|size]` lookups
-    // with no SSR lowering yet (mojo skips the same pair). `kbd` is NOT a
-    // render-mismatch — it's a BF101 refusal (Kolon can't splat the Slot's
-    // `{...props}`), so it's pinned in `expectedDiagnostics` below.
+    // `checkbox` now PASS. `toggle` stays skipped: its reactive `classes` memo
+    // interpolates `Record<T,string>[variant|size]` lookups with no SSR
+    // lowering yet (mojo skips the same). `switch` no longer skipped — it
+    // assembles classes in function-scope plain consts whose `[...].join(' ')`
+    // module consts now inline via the shared `evalStringArrayJoin`, and
+    // `augmentInheritedPropAccesses` scans those consts for `props.className`.
+    // `kbd` is NOT a render-mismatch — it's a BF101 refusal (Kolon can't splat
+    // the Slot's `{...props}`), so it's pinned in `expectedDiagnostics` below.
     'toggle',
-    'switch',
   ],
   // Per-fixture build-time contracts for shapes the Xslate adapter
   // intentionally refuses to lower. Mirrors mojo's set — the lowering

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -46,16 +46,14 @@ runAdapterConformanceTests({
     // `reactive-props` passes. (Same pair mojo skips.)
     'toggle-shared',
     'props-reactivity-comparison',
-    // #1467 Phase 2b interactive `site/ui` primitives. `textarea` and
-    // `checkbox` now PASS. `toggle` stays skipped: its reactive `classes` memo
-    // interpolates `Record<T,string>[variant|size]` lookups with no SSR
-    // lowering yet (mojo skips the same). `switch` no longer skipped — it
-    // assembles classes in function-scope plain consts whose `[...].join(' ')`
-    // module consts now inline via the shared `evalStringArrayJoin`, and
-    // `augmentInheritedPropAccesses` scans those consts for `props.className`.
+    // #1467 Phase 2b interactive `site/ui` primitives. `textarea`, `checkbox`,
+    // `switch`, and `toggle` now PASS — `switch`/`toggle` via the shared
+    // `@barefootjs/jsx` lowerings (function-scope const prop enumeration,
+    // `[...].join(' ')` inlining, and `extractSsrDefaults` evaluating the
+    // block-bodied `classes` memo + `variantClasses[variant]` index, which the
+    // Xslate adapter consumes through the same SSR-seed path as mojo).
     // `kbd` is NOT a render-mismatch — it's a BF101 refusal (Kolon can't splat
     // the Slot's `{...props}`), so it's pinned in `expectedDiagnostics` below.
-    'toggle',
   ],
   // Per-fixture build-time contracts for shapes the Xslate adapter
   // intentionally refuses to lower. Mirrors mojo's set — the lowering

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -33,12 +33,9 @@ runAdapterConformanceTests({
   // fixtures than mojo. Each entry below was confirmed to fail with
   // skipJsx emptied.
   skipJsx: [
-    // SSR context propagation: `<Ctx.Provider value="dark">` doesn't make
-    // `useContext(Ctx)` resolve at template-eval time (the template reads a
-    // `theme` key that's never seeded). The Go adapter now implements this
-    // (consumer-side default + provider-side child-slot wiring); the Perl
-    // backends share the stash-seed render path and would port it the same
-    // way as Mojo — deferred, so Xslate stays skipped (#1297 follow-up).
+    // SSR context propagation (`<Ctx.Provider value>` → `useContext`): the
+    // template reads a stash key that's never seeded. Implemented on Go; the
+    // Perl stash-seed path is a follow-up port, so Xslate stays skipped (#1297).
     'context-provider',
     // Multi-component shared-state pairs whose children render inside a keyed
     // `.map` (loop children, no `_bf_slot`): the test harness derives a
@@ -48,14 +45,8 @@ runAdapterConformanceTests({
     // `reactive-props` passes. (Same pair mojo skips.)
     'toggle-shared',
     'props-reactivity-comparison',
-    // #1467 Phase 2b interactive `site/ui` primitives. `textarea`, `checkbox`,
-    // `switch`, and `toggle` now PASS — `switch`/`toggle` via the shared
-    // `@barefootjs/jsx` lowerings (function-scope const prop enumeration,
-    // `[...].join(' ')` inlining, and `extractSsrDefaults` evaluating the
-    // block-bodied `classes` memo + `variantClasses[variant]` index, which the
-    // Xslate adapter consumes through the same SSR-seed path as mojo).
-    // `kbd` is NOT a render-mismatch — it's a BF101 refusal (Kolon can't splat
-    // the Slot's `{...props}`), so it's pinned in `expectedDiagnostics` below.
+    // (`kbd` is not skipped here — it's a BF101 refusal pinned in
+    // `expectedDiagnostics` below, not a render-mismatch.)
   ],
   // Per-fixture build-time contracts for shapes the Xslate adapter
   // intentionally refuses to lower. Mirrors mojo's set — the lowering

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -62,6 +62,7 @@ import {
   emitAttrValue,
   augmentInheritedPropAccesses,
   parseRecordIndexAccess,
+  evalStringArrayJoin,
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr } from './boolean-result'
 import ts from 'typescript'
@@ -1604,7 +1605,11 @@ function parsePureStringLiteral(source: string): string | null {
     if (containsUnescaped(body, '`')) return null
     return unescapeStringLiteralBody(body)
   }
-  return null
+  // `[<string literals>].join(' ')` — a module const that flattens an array of
+  // pure string literals at module load (e.g. Switch's `trackStateClasses`).
+  // Inline the joined string byte-for-byte like the Hono reference instead of
+  // emitting a `$trackStateClasses` ref to a binding that doesn't exist.
+  return evalStringArrayJoin(source)
 }
 
 /** Whether `s` contains an unescaped occurrence of `ch`. */

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -1605,10 +1605,8 @@ function parsePureStringLiteral(source: string): string | null {
     if (containsUnescaped(body, '`')) return null
     return unescapeStringLiteralBody(body)
   }
-  // `[<string literals>].join(' ')` — a module const that flattens an array of
-  // pure string literals at module load (e.g. Switch's `trackStateClasses`).
-  // Inline the joined string byte-for-byte like the Hono reference instead of
-  // emitting a `$trackStateClasses` ref to a binding that doesn't exist.
+  // `[<literals>].join(' ')` module consts (e.g. Switch's `trackStateClasses`)
+  // → inline the flattened string byte-for-byte. See `evalStringArrayJoin`.
   return evalStringArrayJoin(source)
 }
 

--- a/packages/jsx/src/augment-inherited-props.ts
+++ b/packages/jsx/src/augment-inherited-props.ts
@@ -69,6 +69,17 @@ export function augmentInheritedPropAccesses(ir: ComponentIR): void {
   for (const stmt of ir.metadata.initStatements ?? []) scan(stmt.body)
   for (const eff of ir.metadata.effects ?? []) scan((eff as { body?: string }).body)
 
+  // Function-scope plain-const initializers (the Switch pattern): the classes
+  // string is assembled in a top-of-body `const trackClasses = \`… ${props.className
+  // ?? ''}\`` rather than a memo, so the `props.className` read only lives here.
+  // Module-level consts can't reference `props` (it's function-scoped), so the
+  // `isModule` filter avoids scanning unrelated module literals. Reads land in a
+  // string context, so the default `string` classification is correct.
+  for (const c of ir.metadata.localConstants ?? []) {
+    if (c.isModule) continue
+    scan(c.value)
+  }
+
   // Template attribute exprs — also note bare-ref / boolean usage.
   const walk = (node: IRNode | undefined): void => {
     if (!node) return
@@ -114,6 +125,59 @@ export function augmentInheritedPropAccesses(ir: ComponentIR): void {
     ir.metadata.propsParams.push({ name, type, optional: true })
     existing.add(name)
   }
+}
+
+/**
+ * Statically evaluate `[<string literals>].join(<sep?>)` to its joined string.
+ *
+ * Module-scope class consts are frequently assembled as
+ * `const stateClasses = ['[&[data-state=on]]:…', …].join(' ')` so the source
+ * stays readable. The Hono reference inlines the flattened string at runtime;
+ * the SSR adapters must inline the same byte-for-byte literal instead of
+ * emitting a `$stateClasses` / `.StateClasses` reference to a binding that
+ * doesn't exist server-side.
+ *
+ * Returns the joined string, or `null` when the shape doesn't match (non-call,
+ * non-`.join`, non-array receiver, any non-string-literal element, or a
+ * non-string-literal separator). Comments / whitespace between elements are
+ * irrelevant — the TS parser already discarded them. The default separator is
+ * `,` to match JS `Array.prototype.join` with no argument.
+ *
+ * The single source of truth for the Mojo + Xslate adapters' module-const
+ * inlining (Go keeps an equivalent private copy). `source` is the const
+ * initializer's text; the function parses it with the TS parser so escapes
+ * resolve exactly as JS would.
+ */
+export function evalStringArrayJoin(source: string): string | null {
+  const sf = ts.createSourceFile(
+    '__join.ts', `const __x = (${source});`, ts.ScriptTarget.Latest, /*setParentNodes*/ false,
+  )
+  const stmt = sf.statements[0]
+  if (!stmt || !ts.isVariableStatement(stmt)) return null
+  let node = stmt.declarationList.declarations[0]?.initializer
+  while (node && ts.isParenthesizedExpression(node)) node = node.expression
+  if (!node || !ts.isCallExpression(node)) return null
+  const callee = node.expression
+  if (!ts.isPropertyAccessExpression(callee)) return null
+  if (callee.name.text !== 'join') return null
+  let recv: ts.Expression = callee.expression
+  while (ts.isParenthesizedExpression(recv)) recv = recv.expression
+  if (!ts.isArrayLiteralExpression(recv)) return null
+  const parts: string[] = []
+  for (const el of recv.elements) {
+    if (ts.isStringLiteral(el) || ts.isNoSubstitutionTemplateLiteral(el)) {
+      parts.push(el.text)
+    } else {
+      return null
+    }
+  }
+  let sep = ','
+  if (node.arguments.length >= 1) {
+    const arg = node.arguments[0]
+    if (ts.isStringLiteral(arg) || ts.isNoSubstitutionTemplateLiteral(arg)) sep = arg.text
+    else return null
+  }
+  return parts.join(sep)
 }
 
 /** A minimal `{ name }` shape — both adapters pass their own param/const lists. */

--- a/packages/jsx/src/augment-inherited-props.ts
+++ b/packages/jsx/src/augment-inherited-props.ts
@@ -12,8 +12,93 @@
 
 import ts from 'typescript'
 
-import type { ComponentIR, IRNode, IRElement, TypeInfo } from './types'
+import type { ComponentIR, IRMetadata, IRNode, IRElement, TypeInfo } from './types'
 import { isBooleanAttr } from './html-constants'
+
+/**
+ * A `const x = useContext(SomeContext)` consumer in a component body.
+ *
+ * SSR template adapters (Go / Mojo / Xslate) have no JS runtime context
+ * stack the way the Hono adapter does (`provideContextSSR`), so a consumer's
+ * value has to be threaded in at the data-construction layer. This records,
+ * per component, the local binding name, the `createContext` identifier it
+ * reads, and that context's default value — enough for an adapter to (a)
+ * expose a struct field / stash var with the default and (b) let an enclosing
+ * `<Ctx.Provider value>` overwrite it for descendant child slots.
+ */
+export interface ContextConsumer {
+  /** The local const bound to the `useContext` call (e.g. `theme`). */
+  localName: string
+  /** The `createContext` identifier read (e.g. `ThemeContext`). */
+  contextName: string
+  /**
+   * The `createContext(<default>)` argument as a JS literal, or `null` when
+   * absent / not a literal (the consumer then defaults to the empty value).
+   */
+  defaultValue: string | number | boolean | null
+}
+
+/**
+ * Collect every `const x = useContext(Ctx)` consumer in a component, resolving
+ * each `Ctx` to its `createContext(<default>)` default via the component's
+ * module-scope `createContext` constants. Returns `[]` when the component
+ * consumes no context. Single source of truth for the SSR-context adapters.
+ */
+export function collectContextConsumers(metadata: IRMetadata): ContextConsumer[] {
+  const constants = metadata.localConstants ?? []
+  // Map each createContext const name → its default-arg literal value.
+  const contextDefaults = new Map<string, string | number | boolean | null>()
+  for (const c of constants) {
+    if (c.systemConstructKind !== 'createContext' || c.value === undefined) continue
+    contextDefaults.set(c.name, parseCreateContextDefault(c.value))
+  }
+  if (contextDefaults.size === 0) return []
+
+  const consumers: ContextConsumer[] = []
+  for (const c of constants) {
+    if (c.value === undefined) continue
+    const ctxName = parseUseContextArg(c.value)
+    if (ctxName === null || !contextDefaults.has(ctxName)) continue
+    consumers.push({
+      localName: c.name,
+      contextName: ctxName,
+      defaultValue: contextDefaults.get(ctxName) ?? null,
+    })
+  }
+  return consumers
+}
+
+/** Parse `useContext(Ident)` → `Ident`, else `null`. */
+function parseUseContextArg(source: string): string | null {
+  const expr = parseSingleExpression(source)
+  if (!expr || !ts.isCallExpression(expr)) return null
+  if (!ts.isIdentifier(expr.expression) || expr.expression.text !== 'useContext') return null
+  if (expr.arguments.length !== 1) return null
+  const arg = expr.arguments[0]
+  return ts.isIdentifier(arg) ? arg.text : null
+}
+
+/** Parse `createContext(<literal>)` → the default value, else `null`. */
+function parseCreateContextDefault(source: string): string | number | boolean | null {
+  const expr = parseSingleExpression(source)
+  if (!expr || !ts.isCallExpression(expr)) return null
+  if (expr.arguments.length === 0) return null
+  const arg = expr.arguments[0]
+  if (ts.isStringLiteral(arg) || ts.isNoSubstitutionTemplateLiteral(arg)) return arg.text
+  if (ts.isNumericLiteral(arg)) return Number(arg.text)
+  if (arg.kind === ts.SyntaxKind.TrueKeyword) return true
+  if (arg.kind === ts.SyntaxKind.FalseKeyword) return false
+  return null
+}
+
+function parseSingleExpression(source: string): ts.Expression | null {
+  const sf = ts.createSourceFile('__ctx.ts', `(${source})`, ts.ScriptTarget.Latest, false)
+  const stmt = sf.statements[0]
+  if (!stmt || !ts.isExpressionStatement(stmt)) return null
+  let e: ts.Expression = stmt.expression
+  while (ts.isParenthesizedExpression(e)) e = e.expression
+  return e
+}
 
 /**
  * (#checkbox) Enumerate inherited-attribute accesses for the SolidJS

--- a/packages/jsx/src/augment-inherited-props.ts
+++ b/packages/jsx/src/augment-inherited-props.ts
@@ -16,15 +16,11 @@ import type { ComponentIR, IRMetadata, IRNode, IRElement, TypeInfo } from './typ
 import { isBooleanAttr } from './html-constants'
 
 /**
- * A `const x = useContext(SomeContext)` consumer in a component body.
- *
- * SSR template adapters (Go / Mojo / Xslate) have no JS runtime context
- * stack the way the Hono adapter does (`provideContextSSR`), so a consumer's
- * value has to be threaded in at the data-construction layer. This records,
- * per component, the local binding name, the `createContext` identifier it
- * reads, and that context's default value — enough for an adapter to (a)
- * expose a struct field / stash var with the default and (b) let an enclosing
- * `<Ctx.Provider value>` overwrite it for descendant child slots.
+ * A `const x = useContext(SomeContext)` consumer in a component body. SSR
+ * template adapters have no JS runtime context stack, so a consumer's value is
+ * threaded in at the data-construction layer: the adapter exposes a field/stash
+ * var defaulted to the context default, which an enclosing `<Ctx.Provider
+ * value>` overwrites for descendant child slots.
  */
 export interface ContextConsumer {
   /** The local const bound to the `useContext` call (e.g. `theme`). */
@@ -154,12 +150,10 @@ export function augmentInheritedPropAccesses(ir: ComponentIR): void {
   for (const stmt of ir.metadata.initStatements ?? []) scan(stmt.body)
   for (const eff of ir.metadata.effects ?? []) scan((eff as { body?: string }).body)
 
-  // Function-scope plain-const initializers (the Switch pattern): the classes
-  // string is assembled in a top-of-body `const trackClasses = \`… ${props.className
-  // ?? ''}\`` rather than a memo, so the `props.className` read only lives here.
-  // Module-level consts can't reference `props` (it's function-scoped), so the
-  // `isModule` filter avoids scanning unrelated module literals. Reads land in a
-  // string context, so the default `string` classification is correct.
+  // Function-scope plain-const initializers (the Switch pattern): a
+  // `const trackClasses = \`… ${props.className ?? ''}\`` holds the only
+  // `props.X` read. Skip module consts — they can't reference function-scoped
+  // `props`. Reads land in string context, so the default `string` type holds.
   for (const c of ir.metadata.localConstants ?? []) {
     if (c.isModule) continue
     scan(c.value)
@@ -213,25 +207,13 @@ export function augmentInheritedPropAccesses(ir: ComponentIR): void {
 }
 
 /**
- * Statically evaluate `[<string literals>].join(<sep?>)` to its joined string.
- *
- * Module-scope class consts are frequently assembled as
- * `const stateClasses = ['[&[data-state=on]]:…', …].join(' ')` so the source
- * stays readable. The Hono reference inlines the flattened string at runtime;
- * the SSR adapters must inline the same byte-for-byte literal instead of
- * emitting a `$stateClasses` / `.StateClasses` reference to a binding that
- * doesn't exist server-side.
- *
- * Returns the joined string, or `null` when the shape doesn't match (non-call,
- * non-`.join`, non-array receiver, any non-string-literal element, or a
- * non-string-literal separator). Comments / whitespace between elements are
- * irrelevant — the TS parser already discarded them. The default separator is
- * `,` to match JS `Array.prototype.join` with no argument.
- *
- * The single source of truth for the Mojo + Xslate adapters' module-const
- * inlining (Go keeps an equivalent private copy). `source` is the const
- * initializer's text; the function parses it with the TS parser so escapes
- * resolve exactly as JS would.
+ * Statically evaluate `[<string literals>].join(<sep?>)` (e.g. a module-scope
+ * `const stateClasses = ['…', …].join(' ')`) to its joined string, so SSR
+ * adapters inline the flattened literal byte-for-byte like the Hono reference
+ * instead of referencing a binding that doesn't exist server-side. Default
+ * separator `,` matches JS `Array.prototype.join`. Returns `null` for any
+ * other shape (non-`.join` call, non-array receiver, non-string-literal element
+ * or separator). Shared by the Mojo + Xslate adapters; Go keeps a private copy.
  */
 export function evalStringArrayJoin(source: string): string | null {
   const sf = ts.createSourceFile(
@@ -316,12 +298,10 @@ export function parseRecordIndexAccess(
   localConstants: readonly NamedConst[],
   propsParams: ReadonlyArray<{ name: string }>,
   /**
-   * Optional resolver for an index key that isn't a bare prop. The Toggle
-   * `classes` memo indexes by a memo-local const (`variantClasses[variant]`
-   * where `const variant = props.variant ?? 'default'`); the caller passes its
-   * block-scoped binding map here so the structural parse stays generic. When
-   * provided and the key isn't a prop, it's resolved to the underlying prop
-   * plus an optional default-key literal. Returns `null` to reject.
+   * Resolves an index key that isn't a bare prop (a memo-local const like
+   * `const variant = props.variant ?? 'default'`) to its underlying prop + an
+   * optional default-key literal; returns `null` to reject. Keeps the parse
+   * generic — the caller owns the block-scoped binding map.
    */
   resolveKey?: (name: string) => { propName: string; defaultLiteral?: string } | null,
 ): RecordIndexAccess | null {

--- a/packages/jsx/src/augment-inherited-props.ts
+++ b/packages/jsx/src/augment-inherited-props.ts
@@ -199,6 +199,13 @@ export interface RecordIndexAccess {
   indexPropName: string
   /** The map's entries in source order — each a static key + scalar literal value. */
   entries: RecordIndexEntry[]
+  /**
+   * When the index key is a local const with a `props.X ?? '<lit>'` default
+   * (the Toggle `classes` memo's `const variant = props.variant ?? 'default'`),
+   * the `<lit>` fallback key — so a caller can render the default entry's value
+   * when the prop is unset. Absent when the key is a bare prop with no default.
+   */
+  defaultKey?: string
 }
 
 /**
@@ -223,13 +230,35 @@ export function parseRecordIndexAccess(
   val: ts.Expression,
   localConstants: readonly NamedConst[],
   propsParams: ReadonlyArray<{ name: string }>,
+  /**
+   * Optional resolver for an index key that isn't a bare prop. The Toggle
+   * `classes` memo indexes by a memo-local const (`variantClasses[variant]`
+   * where `const variant = props.variant ?? 'default'`); the caller passes its
+   * block-scoped binding map here so the structural parse stays generic. When
+   * provided and the key isn't a prop, it's resolved to the underlying prop
+   * plus an optional default-key literal. Returns `null` to reject.
+   */
+  resolveKey?: (name: string) => { propName: string; defaultLiteral?: string } | null,
 ): RecordIndexAccess | null {
   if (!ts.isElementAccessExpression(val)) return null
   const obj = val.expression
   const arg = val.argumentExpression
   if (!ts.isIdentifier(obj) || !ts.isIdentifier(arg)) return null
-  // KEY must be a prop.
-  if (!propsParams.some(p => p.name === arg.text)) return null
+  // KEY resolution. A caller-supplied local key wins first — the Toggle memo's
+  // `const variant = props.variant ?? 'default'` shadows the same-named
+  // `variant` prop, and only the local binding carries the `'default'` fallback.
+  // Otherwise the key must be a bare prop (`sizeMap[size]`).
+  let indexPropName: string
+  let defaultKey: string | undefined
+  const resolved = resolveKey?.(arg.text)
+  if (resolved) {
+    indexPropName = resolved.propName
+    defaultKey = resolved.defaultLiteral
+  } else if (propsParams.some(p => p.name === arg.text)) {
+    indexPropName = arg.text
+  } else {
+    return null
+  }
   // IDENT must resolve to a module-scope object-literal const.
   const constInfo = localConstants.find(c => c.name === obj.text && c.isModule)
   if (constInfo?.value === undefined) return null
@@ -268,5 +297,5 @@ export function parseRecordIndexAccess(
       return null
     }
   }
-  return { indexPropName: arg.text, entries }
+  return { indexPropName, entries, defaultKey }
 }

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -281,8 +281,8 @@ export type { WrapReason } from './ir-to-client-js/reactivity'
 export { BOOLEAN_ATTRS, isBooleanAttr } from './html-constants'
 
 // Shared props-object-pattern helpers for the Go / Mojo template adapters
-export { augmentInheritedPropAccesses, parseRecordIndexAccess, evalStringArrayJoin } from './augment-inherited-props'
-export type { RecordIndexAccess, RecordIndexEntry } from './augment-inherited-props'
+export { augmentInheritedPropAccesses, parseRecordIndexAccess, evalStringArrayJoin, collectContextConsumers } from './augment-inherited-props'
+export type { RecordIndexAccess, RecordIndexEntry, ContextConsumer } from './augment-inherited-props'
 
 // HTML element attribute types
 export type {

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -281,7 +281,7 @@ export type { WrapReason } from './ir-to-client-js/reactivity'
 export { BOOLEAN_ATTRS, isBooleanAttr } from './html-constants'
 
 // Shared props-object-pattern helpers for the Go / Mojo template adapters
-export { augmentInheritedPropAccesses, parseRecordIndexAccess } from './augment-inherited-props'
+export { augmentInheritedPropAccesses, parseRecordIndexAccess, evalStringArrayJoin } from './augment-inherited-props'
 export type { RecordIndexAccess, RecordIndexEntry } from './augment-inherited-props'
 
 // HTML element attribute types

--- a/packages/jsx/src/ssr-defaults.ts
+++ b/packages/jsx/src/ssr-defaults.ts
@@ -192,12 +192,33 @@ function evalNode(node: ts.Expression, ctx: EvalContext): EvalResult {
   if (ts.isNonNullExpression(node)) return evalNode(node.expression, ctx)
 
   // `createMemo(() => count() * 2)` stores the full arrow expression
-  // string. For evaluation, we only care about the body — and only the
-  // expression-bodied form (`() => expr`). Block-bodied arrows
-  // (`() => { ... }`) would need branch tracking we don't attempt.
+  // string. For evaluation, we only care about the body. The
+  // expression-bodied form (`() => expr`) evaluates its body directly; a
+  // block-bodied arrow (`() => { const v = …; return \`…\` }`, the Toggle
+  // `classes` memo) evaluates its leading `const` declarations into a local
+  // binding scope and then its single `return` expression. We don't attempt
+  // branch tracking — any control flow before the `return` leaves it
+  // unresolved.
   if (ts.isArrowFunction(node)) {
-    if (node.parameters.length === 0 && !ts.isBlock(node.body)) {
-      return evalNode(node.body as ts.Expression, ctx)
+    if (node.parameters.length !== 0) return UNRESOLVED
+    if (!ts.isBlock(node.body)) return evalNode(node.body as ts.Expression, ctx)
+    const localBindings: Record<string, EvalResult> = { ...ctx.bindings }
+    const localCtx: EvalContext = { ...ctx, bindings: localBindings }
+    for (const stmt of node.body.statements) {
+      if (ts.isVariableStatement(stmt)) {
+        for (const d of stmt.declarationList.declarations) {
+          if (!ts.isIdentifier(d.name) || !d.initializer) continue
+          const v = evalNode(d.initializer, localCtx)
+          // Leave unresolved locals unbound; only the `return` referencing
+          // one would then surface UNRESOLVED.
+          if (v !== UNRESOLVED) localBindings[d.name.text] = v
+        }
+      } else if (ts.isReturnStatement(stmt)) {
+        return stmt.expression ? evalNode(stmt.expression, localCtx) : UNRESOLVED
+      } else {
+        // Any other statement (a branch, a side-effecting call) — bail.
+        return UNRESOLVED
+      }
     }
     return UNRESOLVED
   }
@@ -259,10 +280,27 @@ function evalNode(node: ts.Expression, ctx: EvalContext): EvalResult {
     return arr
   }
 
-  if (ts.isPropertyAccessExpression(node) || ts.isElementAccessExpression(node)) {
-    // `props.X` / `props?.X` / `props['X']` — read of a binding we know
-    // nothing about, so resolve to `undefined`. Chained access (`a.b.c`)
-    // collapses the same way because the base read is already undefined.
+  if (ts.isElementAccessExpression(node)) {
+    // Index into a resolved object / array with a resolved scalar key — the
+    // Toggle `classes` memo's `variantClasses[variant]` where `variantClasses`
+    // is a seeded module-const object and `variant` resolved to `'default'`.
+    const base = evalNode(node.expression, ctx)
+    if (base === undefined) return undefined // `props['X']` → undefined
+    if (base === UNRESOLVED || base === null || typeof base !== 'object') return UNRESOLVED
+    if (!node.argumentExpression) return UNRESOLVED
+    const key = evalNode(node.argumentExpression, ctx)
+    if (key === UNRESOLVED || key === undefined || key === null) return UNRESOLVED
+    const k = String(key as string | number)
+    // Missing key → JS `undefined` (the `??`/`||` defaulting flows through it).
+    return Object.prototype.hasOwnProperty.call(base, k)
+      ? (base as Record<string, unknown>)[k]
+      : undefined
+  }
+
+  if (ts.isPropertyAccessExpression(node)) {
+    // `props.X` / `props?.X` — read of a binding we know nothing about, so
+    // resolve to `undefined`. Chained access (`a.b.c`) collapses the same way
+    // because the base read is already undefined.
     const baseResult = evalNode(node.expression, ctx)
     if (baseResult === undefined) return undefined
     return UNRESOLVED


### PR DESCRIPTION
## Goal

Audit and tighten the `skipJsx` / `expectedDiagnostics` sets in the three SSR adapter conformance suites (go-template / mojolicious / xslate) so they track Hono parity, dropping skips made stale by new SSR lowering. Each fixture was unskipped, measured against **real engine rendering**, and either turned green via a compiler/adapter fix or left skipped with a refreshed, accurate rationale.

Verification: `PATH=/usr/local/go/bin GOTOOLCHAIN=go1.25.6` (real Go 1.25.6), real Mojolicious 9.46, real Text::Xslate v3.5.9. Hono reference snapshots unchanged throughout.

## Increments

### 1. `switch` — ✅ all 3 adapters
No `Record` lowering needed (classes assemble in function-scope plain consts). Two gaps closed:
- `augmentInheritedPropAccesses` now scans function-scope const initializers for `props.className`.
- New shared `evalStringArrayJoin` inlines `[...].join(' ')` module consts byte-for-byte on Mojo/Xslate (Go already did).

### 2. `toggle` — ✅ all 3 adapters
Block-bodied `classes` memo indexing `Record<T,string>` by a memo-local key with a default:
- `parseRecordIndexAccess` gains an optional key resolver (memo-local key → prop + `?? '<lit>'` default → `defaultKey`).
- Go: template-literal memo path handles block-bodied arrows, emits `recordConst[key]` as `map[string]string{…, "": <default>}[fmt.Sprint(in.Field)]`; `inferMemoType` treats template-literal memos as `string`.
- `extractSsrDefaults` (Mojo/Xslate seed) evaluates block-bodied arrows + object indexing.
- Shared `normalizeHTML` canonicalises interchangeable numeric/named HTML entities (`&#34;` vs `&quot;`).

### 3. `context-provider` — ✅ Go only (Mojo/Xslate deferred)
SSR context propagation (no JS runtime context stack in template engines):
- `collectContextConsumers` (`@barefootjs/jsx`): finds `useContext` consumers + resolves `createContext` defaults.
- Go consumer side: `useContext` locals become Input/Props fields defaulted to the context default.
- Go provider side: `<Ctx.Provider value>` literals thread down the IR tree and set the matching field on descendant child-slot inputs (cross-component lookup via `registerChildComponentShape`).
- Mojo/Xslate stay skipped (their stash-seed path would port the same way — follow-up); rationales refreshed.

## Test status (all local, real engines)
- go-template: 464 pass / 3 skip / **0 fail**
- mojolicious: 422 pass / 5 skip / **0 fail**
- xslate: 300 pass / 5 skip / **0 fail**
- adapter-tests: 722 pass / **0 fail**
- jsx: 4 pre-existing failures (resolver-migration alias tests, present on base — unrelated)
- tsc: clean on `jsx` + `adapter-go-template` (pre-existing adapter-tests dev-harness type errors unrelated)

True constraints (destructure-in-map, JS-object-in-attr, cross-template loop, Xslate `button`/`kbd` Slot spread, etc.) remain pinned in `expectedDiagnostics`.

https://claude.ai/code/session_01GfGYuNsqkDe7J4f57V2SqC