### PR TITLE
fix(jsr): drop vestigial @barefootjs/perl dep so JSR manifests are correct

### DIFF
--- a/.changeset/drop-vestigial-perl-dep.md
+++ b/.changeset/drop-vestigial-perl-dep.md
@@ -1,0 +1,8 @@
+---
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+---
+
+Drop the vestigial `@barefootjs/perl` npm dependency from the Mojolicious and Xslate adapters. The TS adapters never import the Perl runtime as JS — `BarefootJS.pm` is resolved at the Perl layer (each `cpanfile`'s `requires 'BarefootJS'` for CPAN consumers, and `prove -I ../adapter-perl/lib` / a cpanm-installed core in CI), while the TS `test-render` locates it through a relative `../../adapter-perl/lib` path. Version lock-step is already guaranteed by the changesets `fixed` group, so the npm dependency carried no weight. Keeping it made the generated JSR manifests reference a `jsr:@barefootjs/perl` that will never exist on JSR (the Perl distribution ships `lib/*.pm`, no TS exports) and pulled a JS-less package into npm installs.
+
+The JSR publish script (`scripts/jsr-publish.ts`) now also only emits a `jsr:` specifier for scoped siblings that are themselves JSR-published, so a future cross-language sibling can't silently re-introduce a dangling import.

--- a/packages/adapter-mojolicious/package.json
+++ b/packages/adapter-mojolicious/package.json
@@ -71,7 +71,6 @@
     "directory": "packages/adapter-mojolicious"
   },
   "dependencies": {
-    "@barefootjs/perl": "workspace:*",
     "@barefootjs/shared": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/adapter-xslate/package.json
+++ b/packages/adapter-xslate/package.json
@@ -74,7 +74,6 @@
     "directory": "packages/adapter-xslate"
   },
   "dependencies": {
-    "@barefootjs/perl": "workspace:*",
     "@barefootjs/shared": "workspace:*"
   },
   "peerDependencies": {

--- a/scripts/jsr-publish.ts
+++ b/scripts/jsr-publish.ts
@@ -19,10 +19,12 @@
 //          JSR is source-first and can't publish those.
 //        - version: taken live from package.json (the Changesets bump),
 //          so the manifest never drifts.
-//        - imports: workspace `@barefootjs/*` deps → `jsr:` specifiers
-//          at the dependency's current version; other deps → `npm:`
-//          specifiers; the package's own export subpaths → local `src`
-//          (covers internal self-imports like `@barefootjs/client/reactive`).
+//        - imports: workspace `@barefootjs/*` deps that are themselves
+//          published to JSR → `jsr:` specifiers at the dependency's current
+//          version (a scoped sibling published elsewhere, e.g. the Perl
+//          runtime `@barefootjs/perl`, is dropped — never a dangling `jsr:`);
+//          other deps → `npm:` specifiers; the package's own export subpaths
+//          → local `src` (covers self-imports like `@barefootjs/client/reactive`).
 //   2. Skip it if that exact version is already live on JSR (idempotent —
 //      a Changesets release only bumps a subset, the rest no-op).
 //   3. `deno publish` the package (unless `--dry-run`).
@@ -127,20 +129,46 @@ function resolveExportTarget(dir: string, entry: unknown): string | null {
   return null
 }
 
-function buildManifest(dir: string, pkg: PkgJson) {
-  // exports ----------------------------------------------------------------
+// Resolve a package's `exports` map to the `src` TS files JSR would publish,
+// dropping entries with no source sibling.
+function resolveExports(dir: string, pkg: PkgJson): Record<string, string> {
   const exportsIn = pkg.exports ?? { '.': './src/index.ts' }
   const exportsOut: Record<string, string> = {}
   for (const [key, entry] of Object.entries(exportsIn)) {
     const target = resolveExportTarget(dir, entry)
     if (target) exportsOut[key] = target
   }
+  return exportsOut
+}
+
+// ── Which scoped packages actually land on JSR ────────────────────────
+// A `@barefootjs/*` package is JSR-publishable only if it is eligible AND
+// carries at least one resolvable `src` export. A scoped sibling that
+// publishes to a *different* registry — e.g. the Perl runtime
+// `@barefootjs/perl` (`lib/*.pm`, a CPAN dist with no TS exports) — is NOT in
+// this set, so it must never be emitted as a `jsr:` import of a dependent:
+// that would point the manifest at a package that never exists on JSR. The
+// TS sources don't import such siblings anyway — the relationship is a
+// cross-language / release-coordination one expressed elsewhere (the
+// dependent's `cpanfile`, and changesets' `fixed` group), not a code import.
+const jsrExports = new Map<string, Record<string, string>>()
+for (const { dir, pkg } of candidates) jsrExports.set(pkg.name, resolveExports(dir, pkg))
+const jsrPublishable = new Set(
+  [...jsrExports].filter(([, e]) => Object.keys(e).length > 0).map(([name]) => name),
+)
+
+function buildManifest(dir: string, pkg: PkgJson) {
+  // exports ----------------------------------------------------------------
+  const exportsOut = jsrExports.get(pkg.name) ?? resolveExports(dir, pkg)
 
   // imports ----------------------------------------------------------------
   const importsOut: Record<string, string> = {}
   const deps = { ...(pkg.dependencies ?? {}), ...(pkg.peerDependencies ?? {}) }
   for (const [name, range] of Object.entries(deps)) {
     if (name.startsWith('@barefootjs/')) {
+      // Only scoped siblings that are themselves JSR-published get a `jsr:`
+      // specifier; a non-JSR sibling (the Perl runtime) is dropped.
+      if (!jsrPublishable.has(name)) continue
       const v = versions.get(name)
       importsOut[name] = v ? `jsr:${name}@^${v}` : `jsr:${name}`
     } else {


### PR DESCRIPTION
## Problem

A JSR `--dry-run` showed `@barefootjs/mojolicious` and `@barefootjs/xslate` generating this import in their manifests:

```json
"@barefootjs/perl": "jsr:@barefootjs/perl@^0.8.0"
```

But `@barefootjs/perl` is **never published to JSR** — it's the engine-agnostic **Perl/CPAN distribution** (`packages/adapter-perl`: `lib/*.pm`, `cpanfile`, `minil.toml`, no TS sources/exports), so the publish script correctly skips it (`warn … no publishable src exports — skipping`). The result is a dangling `jsr:` import pointing at a package that will never exist on JSR.

## Root cause

The two TS adapters declared `@barefootjs/perl: workspace:*` in their npm `dependencies`, and `jsr-publish.ts` faithfully translated every `@barefootjs/*` dep into a `jsr:` specifier. That dependency was **vestigial** — needed by none of the layers that matter:

| Concern | Needs the npm dep? | Where it's actually wired |
|---|---|---|
| JS code import | ❌ no (`@barefootjs/perl` appears only in comments) | — |
| npm install payload | ❌ no (perl ships `lib/*.pm`, no JS entry) | — |
| Perl runtime dep | ✅ yes | each `cpanfile`: `requires 'BarefootJS'` |
| In-repo Perl tests | ✅ yes | CI: `prove -I ../adapter-perl/lib` / cpanm-installed core; TS `test-render` uses a relative `../../adapter-perl/lib` path |
| Version lock-step | ✅ yes | `.changeset/config.json` `fixed: [["@barefootjs/*", …]]` |

The Perl `@INC` never reads `node_modules`, so the npm dependency contributed nothing to letting the adapters use `BarefootJS.pm`.

## Change

1. **Remove `@barefootjs/perl` from `dependencies`** of `adapter-mojolicious` and `adapter-xslate`. The `jsr:@barefootjs/perl` import disappears from both manifests automatically, and npm installs no longer drag in a JS-less package. Perl wiring (relative path + `cpanfile` + CI `-I`) is untouched.
2. **Harden `jsr-publish.ts`**: precompute the set of scoped packages that actually land on JSR (eligible **and** carrying ≥1 resolvable `src` export) and only emit a `jsr:` specifier for those. A future cross-language sibling (more "Perl framework integrations" are anticipated) can't silently re-introduce a dangling import.

## Verification

- `bun scripts/jsr-publish.ts --dry-run`: `jsr:@barefootjs/perl` is gone from **all** manifests; `mojo`/`xslate` keep their real deps (`jsr:@barefootjs/shared`, `jsr:@barefootjs/jsx`, `npm:typescript`); `@barefootjs/perl` is still skipped as before.
- **Perl wiring intact**: `perl -I ../adapter-perl/lib -e 'use BarefootJS'` → `BarefootJS OK: 0.01`. (The in-repo `prove` run otherwise fails only because `Test2::V0` / `Mojolicious` aren't installed in this sandbox — CI installs them via cpanm; unrelated to this change.)
- `bun test packages/adapter-mojolicious packages/adapter-xslate`: **795 pass, 0 fail** (live Text::Xslate render skips gracefully when Perl deps absent).
- `bun install`: lockfile unchanged (perl had no transitive deps to unlink).

https://claude.ai/code/session_01WTN6vQYDwQBiJQT1s3DbjR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTN6vQYDwQBiJQT1s3DbjR)_