### PR TITLE
Design bf debug profile + scaffold static reactivity budget (#1690)

### DIFF
--- a/.changeset/profile-static-budget.md
+++ b/.changeset/profile-static-budget.md
@@ -1,0 +1,18 @@
+---
+"@barefootjs/jsx": minor
+"@barefootjs/cli": minor
+---
+
+Add `bf debug profile` — reactive performance profiler (#1690), static half.
+
+New CLI subcommand `bf debug profile <component>` prints a per-component static
+reactivity budget (no run required): signal/memo/effect/loop counts, total
+subscriptions, the longest memo→memo chain, and per-signal fan-out with a `hot`
+threshold. `--diff <ref>` compiles the component at a git ref and flags
+structural reactivity regressions (CI-able, exits non-zero on growth). Human
+table and `--json` output, consistent with the `bf debug *` family.
+
+`@barefootjs/jsx` gains the supporting static-analysis API: `buildStaticBudget`,
+`diffStaticBudget`, `formatStaticBudget`, `formatBudgetDiff`, and the
+`buildProfileReport` seam for the dynamic (scenario-driven) half specified in
+`spec/profiler.md`.

--- a/packages/cli/src/commands/debug-profile.ts
+++ b/packages/cli/src/commands/debug-profile.ts
@@ -1,0 +1,128 @@
+// bf debug profile <component> — reactive performance profiler (#1690).
+//
+// Three modes:
+//   bf debug profile <component>              Static reactivity budget (SR5, no run)
+//   bf debug profile <component> --diff <ref> Compile-diff regression (SR6, no run)
+//   bf debug profile --scenario <file>        Dynamic measured run (SR1–SR4) — not yet implemented
+//
+// The static modes are pure functions of the IR (reuse @barefootjs/jsx's
+// shipped static analysis). The dynamic mode is specified in spec/profiler.md
+// and prints a pointer until the measurement substrate lands.
+
+import { execFileSync } from 'child_process'
+import { readFileSync } from 'fs'
+import path from 'path'
+import type { CliContext } from '../context'
+import { resolveComponentSource } from '../lib/resolve-source'
+
+interface ProfileFlags {
+  scenario?: string
+  diff?: string
+  fanOutThreshold?: number
+  positional: string[]
+}
+
+function parseFlags(args: string[]): ProfileFlags {
+  const flags: ProfileFlags = { positional: [] }
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]
+    if (a === '--scenario') flags.scenario = args[++i]
+    else if (a === '--diff') flags.diff = args[++i]
+    else if (a === '--fanout') flags.fanOutThreshold = Number(args[++i])
+    else flags.positional.push(a)
+  }
+  return flags
+}
+
+export async function run(args: string[], ctx: CliContext): Promise<void> {
+  const flags = parseFlags(args)
+
+  const {
+    buildStaticBudget,
+    formatStaticBudget,
+    diffStaticBudget,
+    formatBudgetDiff,
+    buildProfileReport,
+  } = await import('@barefootjs/jsx')
+
+  // -- Dynamic mode (SR1–SR4): specified, not yet implemented ---------------
+  if (flags.scenario) {
+    try {
+      buildProfileReport(flags.scenario)
+    } catch (err) {
+      console.error((err as Error).message)
+      process.exit(1)
+    }
+    return
+  }
+
+  const componentName = flags.positional[0]
+  if (!componentName) {
+    console.error('Error: Component name required.')
+    console.error('Usage: bf debug profile <component> [--diff <ref>] [--fanout <n>] [--json]')
+    console.error('       bf debug profile --scenario <file>   (dynamic run — see spec/profiler.md)')
+    process.exit(1)
+  }
+
+  const searched: string[] = []
+  const resolved = resolveComponentSource(componentName, ctx, searched)
+  if (!resolved) {
+    console.error(`Error: Cannot find component "${componentName}".`)
+    console.error('Looked in:')
+    for (const p of searched) console.error(`  - ${p}`)
+    process.exit(1)
+  }
+
+  const source = readFileSync(resolved.filePath, 'utf-8')
+  const head = buildStaticBudget(source, resolved.filePath, resolved.componentName, {
+    fanOutThreshold: flags.fanOutThreshold,
+  })
+
+  // -- Compile-diff regression (SR6) ----------------------------------------
+  if (flags.diff) {
+    const baseSource = readFileAtRef(resolved.filePath, flags.diff)
+    if (baseSource === null) {
+      console.error(`Error: Cannot read "${resolved.filePath}" at ref "${flags.diff}".`)
+      process.exit(1)
+    }
+    const base = buildStaticBudget(baseSource, resolved.filePath, resolved.componentName, {
+      fanOutThreshold: flags.fanOutThreshold,
+    })
+    const diff = diffStaticBudget(base, head)
+
+    if (ctx.jsonFlag) {
+      console.log(JSON.stringify(diff, null, 2))
+    } else {
+      console.log(formatBudgetDiff(diff))
+    }
+    if (diff.regressed) process.exit(1)
+    return
+  }
+
+  // -- Static budget (SR5) --------------------------------------------------
+  if (ctx.jsonFlag) {
+    console.log(JSON.stringify(head, null, 2))
+    return
+  }
+  console.log(formatStaticBudget(head))
+}
+
+/**
+ * Read a file's contents at a git ref via `git show <ref>:<relpath>`. Returns
+ * null when the ref or path can't be resolved (e.g. file didn't exist there).
+ */
+function readFileAtRef(filePath: string, ref: string): string | null {
+  try {
+    const root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      cwd: path.dirname(filePath),
+      encoding: 'utf-8',
+    }).trim()
+    const rel = path.relative(root, path.resolve(filePath))
+    return execFileSync('git', ['show', `${ref}:${rel}`], {
+      cwd: root,
+      encoding: 'utf-8',
+    })
+  } catch {
+    return null
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -50,6 +50,7 @@ Debug:
   debug summary <component>                   Show hydration and size summary
   debug fallbacks <component>                 Show wrap-by-default fallback bindings (#937)
   debug signals <component>                   Show signal initialization trace
+  debug profile <component> [--diff <ref>]    Reactive perf budget; --diff flags regressions (#1690)
 
 Options:
   --json                                      Output in JSON format
@@ -166,8 +167,11 @@ switch (command) {
     } else if (sub === 'summary') {
       const { run } = await import('./commands/debug-summary')
       await run(rest, ctx)
+    } else if (sub === 'profile') {
+      const { run } = await import('./commands/debug-profile')
+      await run(rest, ctx)
     } else {
-      console.error('Usage: bf debug <graph|trace|fallbacks|signals|events|loops|why-update|summary> ...')
+      console.error('Usage: bf debug <graph|trace|fallbacks|signals|events|loops|why-update|summary|profile> ...')
       process.exit(1)
     }
     break

--- a/packages/jsx/src/__tests__/profiler.test.ts
+++ b/packages/jsx/src/__tests__/profiler.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Reactive performance profiler — static half (SR5 budget, SR6 compile-diff).
+ *
+ * Covers the run-free parts of `bf debug profile` (#1690). The dynamic half
+ * (--scenario / SR1–SR4) is specified in spec/profiler.md and not exercised
+ * here; `buildProfileReport` is asserted to throw its pointer-to-spec error.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import {
+  buildStaticBudget,
+  diffStaticBudget,
+  formatStaticBudget,
+  formatBudgetDiff,
+  buildProfileReport,
+} from '../profiler'
+
+const memoChainSource = `
+  'use client'
+  import { createSignal, createMemo, createEffect } from '@barefootjs/client'
+
+  export function Calc() {
+    const [count, setCount] = createSignal(0)
+    const a = createMemo(() => count() * 2)
+    const b = createMemo(() => a() + 1)
+    const c = createMemo(() => b() + 1)
+    createEffect(() => console.log(c()))
+    return <button onClick={() => setCount(n => n + 1)}>{c()}</button>
+  }
+`
+
+const counterSource = `
+  'use client'
+  import { createSignal } from '@barefootjs/client'
+
+  export function Counter() {
+    const [count, setCount] = createSignal(0)
+    return <button onClick={() => setCount(n => n + 1)}>Count: {count()}</button>
+  }
+`
+
+describe('buildStaticBudget (SR5)', () => {
+  test('counts reactive nodes and subscriptions', () => {
+    const b = buildStaticBudget(counterSource, 'Counter.tsx', 'Counter')
+    expect(b.kind).toBe('static-budget')
+    expect(b.componentName).toBe('Counter')
+    expect(b.signals).toBe(1)
+    expect(b.memos).toBe(0)
+    // The text binding `{count()}` subscribes to `count`.
+    expect(b.subscriptions).toBeGreaterThan(0)
+    expect(b.memoChainDepth).toBe(0)
+  })
+
+  test('measures the longest memo chain', () => {
+    const b = buildStaticBudget(memoChainSource, 'Calc.tsx', 'Calc')
+    expect(b.memos).toBe(3)
+    expect(b.memoChainDepth).toBe(3)
+    expect(b.memoChainLongest).toEqual(['a', 'b', 'c'])
+  })
+
+  test('reports per-signal fan-out, hottest first', () => {
+    const b = buildStaticBudget(memoChainSource, 'Calc.tsx', 'Calc')
+    const count = b.fanOut.find(f => f.signal === 'count')
+    expect(count).toBeDefined()
+    // count fans out through a → b → c → effect/text, i.e. several subscribers.
+    expect(count!.subscribers).toBeGreaterThanOrEqual(3)
+    // Sorted descending.
+    for (let i = 1; i < b.fanOut.length; i++) {
+      expect(b.fanOut[i - 1].subscribers).toBeGreaterThanOrEqual(b.fanOut[i].subscribers)
+    }
+  })
+
+  test('honors the fan-out threshold for the hot flag', () => {
+    const hot = buildStaticBudget(memoChainSource, 'Calc.tsx', 'Calc', { fanOutThreshold: 1 })
+    expect(hot.fanOut.find(f => f.signal === 'count')!.hot).toBe(true)
+    const cold = buildStaticBudget(memoChainSource, 'Calc.tsx', 'Calc', { fanOutThreshold: 999 })
+    expect(cold.fanOut.every(f => f.hot === false)).toBe(true)
+  })
+
+  test('formats a human-readable budget', () => {
+    const out = formatStaticBudget(buildStaticBudget(memoChainSource, 'Calc.tsx', 'Calc'))
+    expect(out).toContain('static reactivity budget')
+    expect(out).toContain('memo-chain depth: 3')
+    expect(out).toContain('predictive only')
+  })
+})
+
+describe('diffStaticBudget (SR6)', () => {
+  test('flags an added memo + deeper chain as a regression', () => {
+    const base = buildStaticBudget(counterSource, 'Counter.tsx', 'Counter')
+    const head = buildStaticBudget(memoChainSource, 'Calc.tsx', 'Calc')
+    const diff = diffStaticBudget(base, head)
+    expect(diff.memos).toBe(3)
+    expect(diff.memoChainDepth).toBe(3)
+    expect(diff.regressed).toBe(true)
+  })
+
+  test('reports no regression for identical compiles', () => {
+    const a = buildStaticBudget(memoChainSource, 'Calc.tsx', 'Calc')
+    const b = buildStaticBudget(memoChainSource, 'Calc.tsx', 'Calc')
+    const diff = diffStaticBudget(a, b)
+    expect(diff.regressed).toBe(false)
+    expect(formatBudgetDiff(diff)).toContain('no structural reactivity change')
+  })
+})
+
+describe('buildProfileReport (dynamic seam, SR1–SR4)', () => {
+  test('points at the spec until the substrate lands', () => {
+    expect(() => buildProfileReport('./scenarios/x.ts')).toThrow(/spec\/profiler\.md/)
+  })
+})

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -285,7 +285,7 @@ export {
   diffStaticBudget,
   formatBudgetDiff,
   buildProfileReport,
-} from './profiler'
+} from "./profiler.ts"
 export type {
   StaticBudget,
   StaticBudgetOptions,
@@ -293,7 +293,7 @@ export type {
   BudgetDiff,
   FanOutChange,
   ProfileReport,
-} from './profiler'
+} from "./profiler.ts"
 
 // HTML constants
 export { BOOLEAN_ATTRS, isBooleanAttr } from './html-constants.ts'

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -277,6 +277,24 @@ export {
 export type { ComponentGraph, ComponentAnalysis, SignalNode, MemoNode, EffectNode, DomBinding, UpdatePath, SignalTrace, EventBinding, SetterRef, FnSetterResolution, EventSummary, LoopInfo, LoopChildBinding, LoopSummary, WhyUpdateResult, WhyUpdateDep, WhyUpdateSource, FallbackExplanation, ComponentSummary } from './debug.ts'
 export type { WrapReason } from './ir-to-client-js/reactivity.ts'
 
+// Reactive performance profiler — static half (SR5 budget, SR6 compile-diff).
+// Dynamic half (--scenario) is specified in spec/profiler.md (#1690).
+export {
+  buildStaticBudget,
+  formatStaticBudget,
+  diffStaticBudget,
+  formatBudgetDiff,
+  buildProfileReport,
+} from './profiler'
+export type {
+  StaticBudget,
+  StaticBudgetOptions,
+  FanOutEntry,
+  BudgetDiff,
+  FanOutChange,
+  ProfileReport,
+} from './profiler'
+
 // HTML constants
 export { BOOLEAN_ATTRS, isBooleanAttr } from './html-constants.ts'
 

--- a/packages/jsx/src/profiler.ts
+++ b/packages/jsx/src/profiler.ts
@@ -1,0 +1,279 @@
+/**
+ * Reactive performance profiler — static half (SR5 / SR6).
+ *
+ * See `spec/profiler.md` and issue #1690. This module implements the
+ * **run-free** parts of `bf debug profile`: the static reactivity budget
+ * (SR5) and the compile-diff regression (SR6). Both are pure functions of
+ * the IR — no instrumented run is required — so they reuse the static
+ * analysis already shipped in `debug.ts`:
+ *
+ *   - `buildComponentAnalysis` → `{ graph, ir }`
+ *   - `buildComponentSummary`  → node counts
+ *   - `traceUpdatePath`        → transitive dependents (fan-out + chain depth)
+ *
+ * The dynamic half (SR1–SR4: instrumented runtime, turn markers, IR join,
+ * Hot-subscribers / Wasted-re-runs / Batch-advisor analyses) is specified in
+ * `spec/profiler.md` and not yet implemented — `buildProfileReport` is the
+ * placeholder seam where it will land.
+ */
+
+import {
+  buildComponentAnalysis,
+  buildComponentSummary,
+  traceUpdatePath,
+  type ComponentGraph,
+  type UpdatePathEntry,
+} from './debug'
+
+// -- Static budget (SR5) ------------------------------------------------------
+
+export interface FanOutEntry {
+  /** Signal name (the reactive source whose change fans out). */
+  signal: string
+  /** Distinct transitive subscribers (memos + effects + DOM bindings). */
+  subscribers: number
+  /** True when `subscribers` exceeds the configured threshold. */
+  hot: boolean
+  loc: { file: string; line: number }
+}
+
+export interface StaticBudget {
+  componentName: string
+  sourceFile: string
+  kind: 'static-budget'
+  signals: number
+  memos: number
+  effects: number
+  loops: number
+  /** Σ over signals of `consumers.length` — total reactive subscriptions. */
+  subscriptions: number
+  /** Longest memo→memo dependency path length (0 = no memos). */
+  memoChainDepth: number
+  /** The memo names forming `memoChainDepth`, head-first. */
+  memoChainLongest: string[]
+  /** Per-signal fan-out, descending, hottest first. */
+  fanOut: FanOutEntry[]
+}
+
+export interface StaticBudgetOptions {
+  /** Fan-out threshold above which a signal is flagged `hot`. Default 8. */
+  fanOutThreshold?: number
+}
+
+const DEFAULT_FANOUT_THRESHOLD = 8
+
+/**
+ * Build the static reactivity budget for one component (SR5).
+ *
+ * Predictive only — it names likely hot spots before any run. Pair with
+ * `--scenario` (the dynamic half) to confirm actual cost.
+ */
+export function buildStaticBudget(
+  source: string,
+  filePath: string,
+  componentName?: string,
+  options: StaticBudgetOptions = {},
+): StaticBudget {
+  const threshold = options.fanOutThreshold ?? DEFAULT_FANOUT_THRESHOLD
+  const { graph } = buildComponentAnalysis(source, filePath, componentName)
+  // `graph` is the authority for reactive-node counts; the summary is consulted
+  // only for `loops`, which needs the IR tree walk (`countNodeType`) that the
+  // graph doesn't expose.
+  const summary = buildComponentSummary(source, filePath, componentName)
+
+  const subscriptions = graph.signals.reduce((n, s) => n + s.consumers.length, 0)
+
+  const fanOut: FanOutEntry[] = graph.signals
+    .map(s => {
+      const subscribers = transitiveSubscriberCount(graph, s.name)
+      return { signal: s.name, subscribers, hot: subscribers >= threshold, loc: s.loc }
+    })
+    .sort((a, b) => b.subscribers - a.subscribers)
+
+  const { depth, chain } = longestMemoChain(graph)
+
+  return {
+    componentName: summary.componentName,
+    sourceFile: summary.sourceFile,
+    kind: 'static-budget',
+    signals: graph.signals.length,
+    memos: graph.memos.length,
+    effects: graph.effects.length,
+    loops: summary.loops,
+    subscriptions,
+    memoChainDepth: depth,
+    memoChainLongest: chain,
+    fanOut,
+  }
+}
+
+/**
+ * Distinct transitive subscribers of a signal/memo. Walks the same tagged
+ * `consumers` tree `traceUpdatePath` builds (`debug.ts`), deduplicating across
+ * branches so a diamond dependency counts each subscriber once.
+ */
+function transitiveSubscriberCount(graph: ComponentGraph, name: string): number {
+  const path = traceUpdatePath(graph, name)
+  if (!path) return 0
+  const seen = new Set<string>()
+  const walk = (entries: UpdatePathEntry[]): void => {
+    for (const e of entries) {
+      seen.add(`${e.kind}:${e.name}`)
+      walk(e.children)
+    }
+  }
+  walk(path.dependents)
+  return seen.size
+}
+
+/**
+ * Longest chain of memo→memo dependencies across the whole component. Starting
+ * from every memo (so a head memo whose deps are signals seeds the full chain)
+ * and taking the max captures the true longest path.
+ */
+function longestMemoChain(graph: ComponentGraph): { depth: number; chain: string[] } {
+  const memoChainFrom = (entry: UpdatePathEntry): string[] => {
+    if (entry.kind !== 'memo') return []
+    let best: string[] = []
+    for (const child of entry.children) {
+      const c = memoChainFrom(child)
+      if (c.length > best.length) best = c
+    }
+    return [entry.name, ...best]
+  }
+
+  let best: string[] = []
+  for (const memo of graph.memos) {
+    const path = traceUpdatePath(graph, memo.name)
+    let downstream: string[] = []
+    for (const dep of path?.dependents ?? []) {
+      const c = memoChainFrom(dep)
+      if (c.length > downstream.length) downstream = c
+    }
+    const chain = [memo.name, ...downstream]
+    if (chain.length > best.length) best = chain
+  }
+
+  return { depth: best.length, chain: best }
+}
+
+export function formatStaticBudget(b: StaticBudget): string {
+  const lines: string[] = []
+  lines.push(`${b.componentName} — static reactivity budget`)
+  lines.push(`  signals: ${b.signals}   memos: ${b.memos}   effects: ${b.effects}   loops: ${b.loops}`)
+  lines.push(`  subscriptions: ${b.subscriptions}`)
+  if (b.memoChainDepth > 0) {
+    lines.push(`  memo-chain depth: ${b.memoChainDepth}   (${b.memoChainLongest.join(' → ')})`)
+  }
+  const shown = b.fanOut.filter(f => f.subscribers > 0).slice(0, 5)
+  if (shown.length > 0) {
+    lines.push('  fan-out (top):')
+    for (const f of shown) {
+      lines.push(`    ${f.signal.padEnd(12)} → ${f.subscribers} subscribers${f.hot ? '   ⚠ high' : ''}`)
+    }
+  }
+  lines.push('  note: run with --scenario to measure actual cost; static budget is predictive only.')
+  return lines.join('\n')
+}
+
+// -- Compile-diff regression (SR6) --------------------------------------------
+
+export interface FanOutChange {
+  signal: string
+  before: number
+  after: number
+}
+
+export interface BudgetDiff {
+  componentName: string
+  signals: number
+  memos: number
+  effects: number
+  loops: number
+  subscriptions: number
+  memoChainDepth: number
+  /** Signals whose fan-out changed (added/removed signals included as 0↔n). */
+  fanOut: FanOutChange[]
+  /** True when any tracked metric regressed (grew) past zero. */
+  regressed: boolean
+}
+
+/**
+ * Structural reactivity delta between two compiles of the same component (SR6).
+ * Each numeric field is `after − before`; positive = grew. CI can fail when
+ * `regressed` is true (or gate on a specific metric threshold).
+ */
+export function diffStaticBudget(base: StaticBudget, head: StaticBudget): BudgetDiff {
+  const baseFan = new Map(base.fanOut.map(f => [f.signal, f.subscribers]))
+  const headFan = new Map(head.fanOut.map(f => [f.signal, f.subscribers]))
+  const signals = new Set([...baseFan.keys(), ...headFan.keys()])
+
+  const fanOut: FanOutChange[] = []
+  for (const sig of signals) {
+    const before = baseFan.get(sig) ?? 0
+    const after = headFan.get(sig) ?? 0
+    if (before !== after) fanOut.push({ signal: sig, before, after })
+  }
+  fanOut.sort((a, b) => (b.after - b.before) - (a.after - a.before))
+
+  const d: Omit<BudgetDiff, 'regressed'> = {
+    componentName: head.componentName,
+    signals: head.signals - base.signals,
+    memos: head.memos - base.memos,
+    effects: head.effects - base.effects,
+    loops: head.loops - base.loops,
+    subscriptions: head.subscriptions - base.subscriptions,
+    memoChainDepth: head.memoChainDepth - base.memoChainDepth,
+    fanOut,
+  }
+
+  const regressed =
+    d.signals > 0 || d.memos > 0 || d.effects > 0 || d.subscriptions > 0 ||
+    d.memoChainDepth > 0 || fanOut.some(f => f.after > f.before)
+
+  return { ...d, regressed }
+}
+
+export function formatBudgetDiff(d: BudgetDiff): string {
+  const lines: string[] = []
+  lines.push(`${d.componentName} — reactivity diff`)
+  const metric = (label: string, v: number) => {
+    if (v !== 0) lines.push(`  ${v > 0 ? '+' : ''}${v} ${label}`)
+  }
+  metric('signals', d.signals)
+  metric('memos', d.memos)
+  metric('effects', d.effects)
+  metric('loops', d.loops)
+  metric('subscriptions', d.subscriptions)
+  if (d.memoChainDepth !== 0) {
+    lines.push(`  memo chain ${d.memoChainDepth > 0 ? 'deepened' : 'shortened'} by ${Math.abs(d.memoChainDepth)}`)
+  }
+  for (const f of d.fanOut) {
+    lines.push(`  signal \`${f.signal}\` fan-out ${f.before}→${f.after}`)
+  }
+  if (lines.length === 1) lines.push('  no structural reactivity change')
+  else lines.push(d.regressed ? '  ⚠ reactivity regressed' : '  ✓ no regression')
+  return lines.join('\n')
+}
+
+// -- Dynamic report (SR1–SR4) — placeholder seam ------------------------------
+
+export interface ProfileReport {
+  kind: 'profile'
+  scenario: string
+  // subscribers, findings, coverage — see spec/profiler.md §6.3.
+}
+
+/**
+ * Dynamic, scenario-driven profile (SR1–SR4 + analyses). Not yet implemented —
+ * the instrumented runtime, compiler turn markers, and IR join are specified in
+ * `spec/profiler.md`. This seam keeps the public surface stable for the CLI
+ * while the dynamic half is built.
+ */
+export function buildProfileReport(_scenario: string): ProfileReport {
+  throw new Error(
+    'bf debug profile --scenario is not implemented yet. ' +
+      'The dynamic measurement substrate (SR1–SR4) is specified in spec/profiler.md. ' +
+      'Run `bf debug profile <component>` for the static reactivity budget (SR5).',
+  )
+}

--- a/packages/jsx/src/profiler.ts
+++ b/packages/jsx/src/profiler.ts
@@ -23,7 +23,7 @@ import {
   traceUpdatePath,
   type ComponentGraph,
   type UpdatePathEntry,
-} from './debug'
+} from "./debug.ts"
 
 // -- Static budget (SR5) ------------------------------------------------------
 

--- a/spec/profiler.md
+++ b/spec/profiler.md
@@ -1,0 +1,434 @@
+# Reactive Performance Profiler — Design (`bf debug profile`)
+
+> Tracking issue: [#1690](https://github.com/piconic-ai/barefootjs/issues/1690).
+> Parent: #1244 (Performance / scale). Related: #1374 (batching), #1373 (deep-tree).
+>
+> **Status:** design. v1 substrate is being scaffolded incrementally; the
+> static half (SR5 budget, SR6 compile-diff) lands first because it needs no
+> run. The dynamic half (SR1–SR4) is specified here and stubbed in code.
+
+## 1. Goal
+
+Help a developer or AI agent **find and fix the reactive performance problems in
+their app** — wasted re-runs, redundant subscriber work in one interaction,
+expensive fan-out, deep/hot memo chains, list churn. Success is the user's: less
+wasted reactive work, and a fix that was easy and safe to apply. Everything in
+this document, the IR integration included, is a **means** to that end.
+
+A **good finding**:
+
+1. names the costliest reactive work on a *real scenario* (measured, ranked),
+2. says **why** and **where** (source-mapped to the IR),
+3. proposes a **concrete fix**, and
+4. flags whether the fix is **safe** (statically checkable).
+
+A finding that can't be attributed back to a source location is a *gap to close*,
+not a finding.
+
+## 2. Why build it on the IR
+
+The measurement half — counting and timing reactions on a real run — is
+well-trodden (React DevTools, MobX `spy`/`trace`, Solid/Vue DevTools). What
+BarefootJS adds, because it has a compile phase + IR, is a sharper loop:
+
+| Makes tuning… | …because the IR provides |
+|---|---|
+| **precise** | exact source attribution from the graph the compiler already built (`buildComponentGraph`, `debug.ts`) |
+| **predictive** | batch / fan-out / chain-depth opportunities visible *before* a run (SR5) |
+| **safe** | "is this fix safe?" (e.g. post-write derived read) answerable statically (SR4 safety) |
+| **regression-proof** | structural reactivity diff between two compiles, no run needed (SR6) |
+| **actionable** | source-mapped fixes the compiler can re-verify |
+
+The static half already exists: `analyzer.ts` builds the graph;
+`bf debug graph/trace/events/why-update/summary` expose it. The profiler adds the
+**dynamic half** (measured runs) and **joins** the two. The IR serves the tuning,
+not the reverse — a runtime-only profiler would still help; the IR is what makes
+the loop precise, predictive, safe, and actionable.
+
+## 3. Where this sits in the existing toolchain
+
+```
+            STATIC (no run)                         DYNAMIC (scenario run)
+  ┌───────────────────────────────┐      ┌──────────────────────────────────┐
+  │ analyzer.ts → ComponentIR      │      │ instrumented runtime (SR1–SR3)   │
+  │ debug.ts:                      │      │   reactive.ts choke points       │
+  │   buildComponentGraph          │      │   compiler-emitted turn markers  │
+  │   buildComponentAnalysis       │      │     ↓ raw event stream           │
+  │   traceUpdatePath              │      └──────────────┬───────────────────┘
+  │   buildEventSummary            │                     │
+  └───────────────┬───────────────┘                     │
+                  │            SR4 IR join (source loc, edges, DOM target)
+                  └──────────────────┬──────────────────┘
+                                     ▼
+                         profiler.ts  →  ProfileReport
+                                     ▼
+                   bf debug profile  (human table │ --json)
+```
+
+`bf debug *` answers **"where to look"** (static). `bf debug profile` answers
+**"what actually cost, and what to change"** (dynamic, joined to static). They
+compose: a profiler finding cites the same source locations the static commands
+already print.
+
+### 3.1 Reusable static building blocks (already shipped)
+
+All in `packages/jsx/src/debug.ts`, re-exported from `packages/jsx/src/index.ts`:
+
+| Function | Returns | Profiler use |
+|---|---|---|
+| `buildComponentAnalysis(src, file, name)` | `{ graph, ir }` in one pass | base for SR5 budget + SR4 join |
+| `buildComponentGraph(...)` | `ComponentGraph` (signals/memos/effects/domBindings with `loc`) | node inventory, source attribution |
+| `traceUpdatePath(graph, name)` | `UpdatePath` (transitive `dependents` tree) | fan-out count + memo-chain depth |
+| `buildEventSummary(...)` | `EventSummary` (handlers → setters → signals, with `via` chains) | turn → setter attribution; batch advisor |
+| `graphToJSON(graph)` | plain object, `loc` simplified to `{file,line}` | `--json` precedent |
+
+`ComponentGraph` node shapes carry the data the profiler needs (see
+`debug.ts:35–111`):
+
+- `SignalNode { name, setter, initialValue, consumers: string[], loc }`
+- `MemoNode  { name, deps, consumers: string[], computation, loc }`
+- `EffectNode { label, deps, body, loc }`
+- `DomBinding { label, slotId, deps, type, classification, wrapReason, loc }`
+
+`consumers` entries are tagged strings — `"memo:x"`, `"effect:y"`, `"dom:z"` —
+which is exactly what `traceUpdatePath`/`buildUpdateEntry` (`debug.ts:962–1009`)
+already walk to produce a transitive dependents tree. Fan-out = breadth of that
+tree; chain depth = its maximum memo→memo depth.
+
+## 4. Requirements
+
+### 4.1 Measurement substrate (SR)
+
+#### SR1 — Instrumentation hooks (dev-only)
+
+Counters/timestamps at the reactive choke points in
+`packages/client/src/reactive.ts`. The current runtime has **zero**
+instrumentation and **no** id/loc on its internal `EffectContext`
+(`reactive.ts:26–34`), so SR1 introduces a single dev-only sink the runtime
+calls at each choke point.
+
+Choke points (exact sites today):
+
+| Event | Site (`reactive.ts`) | Payload |
+|---|---|---|
+| `signal:set` | `set`, line 67 — after the `Object.is` bail (line 72), before notify (78–87) | signal id, batched? |
+| `subscribe:add` | `get`, lines 60–63 (`subscribers.add(Listener)`) | signal id, subscriber id |
+| `subscribe:remove` | `runEffect` 140–143; `disposeSubtree` 182–185 | signal id, subscriber id |
+| `effect:enter`/`exit` | `runEffect`, around `effect.fn()` 150–159 (wall time) | subscriber id, triggering signal, turn |
+| `effect:create` | `createEffect` 105–124; `createDisposableEffect`; `createMemo` 401 | subscriber id, kind |
+| `effect:dispose` | `disposeEffect`/`disposeSubtree` 168–208 | subscriber id |
+| `batch:begin`/`flush` | `batch` 343–353; `flushEffects` 355–363 | depth, flushed count |
+| `map:reconcile` | `runtime/map-array.ts` reconcile loop | key count, +added/−removed/moved |
+| `mount`/`dispose` | `createRoot` 220–244 (per-item scope) | scope id |
+
+**Memos are effects.** `createMemo` (`reactive.ts:401–410`) is a `createEffect`
+writing a private `createSignal`. At runtime a memo therefore surfaces as an
+*effect enter/exit* plus a *signal set*. SR1 must tag the memo's internal effect
+and signal with the memo's identity so SR4 can collapse the pair back into one
+`MemoNode`, otherwise every memo double-counts (one effect run + one signal set).
+
+**Identity.** Runtime primitives carry no id today. SR1 adds an optional id
+parameter, **emitted by the compiler** at each creation site (SR3-adjacent), so a
+runtime event resolves to an IR node deterministically:
+
+```ts
+// dev build only — id is a stable compiler-assigned handle, e.g. "Cart#memo:total"
+createMemo(fn, /* __bfId */ "Cart#memo:total")
+createEffect(fn, /* __bfId */ "Cart#effect:55")
+const [v, setV] = createSignal(0, /* __bfId */ "Cart#signal:coupon")
+```
+
+The id namespace matches the IR: `"<Component>#<kind>:<name|line>"`. Production
+builds pass no id (the param is `undefined`) and the sink is absent (SR8).
+
+#### SR2 — Event attributes
+
+Each emitted event carries: `dur` (ms, effects only), `subscriber` (id), `signal`
+(triggering id), `turn` (id), and `kind`. This is the minimum to answer
+"hot subscriber" (sum `dur` by subscriber) and "wasted re-run" (effect ran but
+produced identical DOM/output — see §4.2.2).
+
+#### SR3 — Turn boundaries via compiler-emitted markers
+
+A "turn" is one user interaction — one handler invocation and the synchronous
+reactive work it triggers. Microtask sniffing is imprecise; instead the compiler,
+which **knows every handler site**, emits `beginTurn(handlerId, loc)` /
+`endTurn()` around the handler body in a dev build.
+
+- **Measurement-only.** Must NOT change `set()`'s synchronous semantics
+  (`reactive.ts:67–88`). `beginTurn`/`endTurn` only stamp a turn id onto events
+  emitted between them.
+- **Must cover all CSR emit paths** (#1244 risk-A). Handlers are codegen'd at
+  several sites today:
+  - top-level: `ir-to-client-js/phases/event-handlers.ts:15–33`
+  - delegation (loops): `control-flow/stringify/event-delegation.ts`
+  - conditional-branch arms: `control-flow/stringify/insert.ts`
+  - loop-child arms: `control-flow/stringify/loop-child-arm.ts`
+  - shared listener line: `control-flow/stringify/event-listener.ts`
+- **Design:** a single `wrapHandlerForTurn(handlerId, loc, handlerExpr) → expr`
+  helper, gated by the dev flag, consumed by **every** emit site — mirroring the
+  #1244 §A refactor direction (one helper, no per-site omissions). The wrap is the
+  existing `wrapHandlerInBlock` (`utils.ts:228`) extended to inject
+  `beginTurn(...)`/`try { … } finally { endTurn() }`. A missing site = an
+  unattributable turn = an SR4 gap; the conformance test for SR3 asserts every
+  handler in a fixture is wrapped.
+
+#### SR4 — IR join
+
+Resolve each runtime event to its IR node — source location, dependency edges,
+DOM target — by loading the static graph (`buildComponentAnalysis`) alongside the
+run. This is what turns a raw measurement into an explained, fixable finding.
+
+- **Join key:** the compiler-assigned id (SR1/SR3) `→` IR node. The profiler
+  builds an id→node index from `buildComponentGraph` output (every node already
+  has `loc`).
+- **Safety oracle (the "is this fix safe?" half).** Some fixes are statically
+  provable-safe; SR4 answers them from the IR without a run. The first oracle the
+  batch advisor needs: **post-write derived read** — within a turn, after the last
+  `set()`, does any code *read* a memo/signal that the batch would leave stale
+  until flush? `buildEventSummary` already resolves a handler's setter calls and
+  `via` chains (`debug.ts:414–642`); the oracle walks the handler body for a read
+  of any signal/memo downstream of those setters *after* the last write. No such
+  read ⇒ wrapping the body in `batch()` is safe.
+- **Unattributable events** are surfaced as a coverage gap (SR4 invariant), never
+  silently dropped.
+
+#### SR5 — Static reactivity budget (no run required)
+
+From the IR alone, a per-component profile — an extension of
+`buildComponentSummary` (`debug.ts:1476`):
+
+- effect/binding count (already in `ComponentSummary`),
+- **memo-chain depth** — longest memo→memo dependency path (via `traceUpdatePath`
+  over each signal/memo, max memo depth in the `dependents` tree),
+- **subscription count** — Σ `consumers.length` over signals,
+- **fan-out** — per signal, the transitive dependent count (breadth of
+  `traceUpdatePath`), flagging signals whose fan-out exceeds a threshold.
+
+SR5 is the **predictive** layer: it names likely hot spots *before* any run, and
+gives `bf debug profile` a useful answer even with no scenario. It is the first
+thing implemented (run-free, pure reuse of shipped static analysis).
+
+#### SR6 — Compile-diff regression (no run required)
+
+IR is deterministic from source, so two compiles of the same component compare
+structurally. Flag reactivity regressions:
+
+```
++12 effects; signal `count` fan-out 3→9; memo chain deepened 2→4
+```
+
+CI-able: `bf debug profile --diff <baseRef>` compiles the component at `baseRef`
+and at working tree, diffs the SR5 budgets, exits non-zero past a threshold. No
+runtime needed — it's two `buildStaticBudget` calls and a structural delta.
+
+#### SR7 — Session + output
+
+Record a scenario run → report. Human table + `--json`, consistent with the
+`bf debug *` family (each command does `JSON.stringify(result, null, 2)`; the
+profiler follows suit, see §6). A session is reproducible: same scenario + same
+compile ⇒ same ranked findings (timings vary, ranks and structural findings do
+not).
+
+#### SR8 — Zero production overhead
+
+Instrumentation is dev-only, gated, and stripped from prod builds:
+
+- The runtime sink (SR1) is behind a build-time flag; the prod bundle contains no
+  sink and no id params (dead-code-eliminated).
+- `beginTurn`/`endTurn` and `__bfId` args are emitted **only** when the compiler
+  runs in profile/dev mode; the default emit path is byte-for-byte unchanged.
+- Conformance: a prod-mode compile of every fixture must equal its current output
+  (golden test) — the profiler must not perturb the shipping bundle.
+
+### 4.2 Analyses (the tuning insights)
+
+Each analysis consumes the joined stream (SR4) and/or the static budget (SR5) and
+emits ranked findings meeting the §1 "good finding" bar.
+
+#### 4.2.1 Hot subscribers (v1)
+
+Most runs / most total time, joined to IR source loc.
+
+- **Input:** SR2 events grouped by `subscriber`.
+- **Metric:** `runs`, `totalMs`, `runs/turn`.
+- **Finding:** top-N by `totalMs`, each with `loc`, plus a "hot: N runs/turn" note
+  when `runs/turn` exceeds a threshold.
+- **Fix hint:** if the subscriber reads signals it doesn't gate on, suggest a
+  finer signal/memo split (links to 4.2.2).
+
+#### 4.2.2 Wasted re-runs (v1)
+
+Effect re-ran but output/DOM identical ⇒ finer signal/memo split candidate.
+
+- **Input:** SR2 enter/exit + a cheap output fingerprint (DOM mutation count, or
+  the written memo value via `Object.is` against prior).
+- **Metric:** `wasted = runsWithIdenticalOutput / totalRuns`.
+- **Finding:** effects with high `wasted`, e.g. `priceLabel: 150/180 produced
+  identical DOM`.
+- **Fix hint:** name the unrelated signal in the effect's `deps`
+  (`EffectNode.deps`) that triggered the no-op run; suggest splitting it out of
+  the reactive read or memoizing the sub-expression.
+
+#### 4.2.3 Batch advisor (v1)
+
+BarefootJS chose **explicit** `batch()` (auto-batching is off — `set()` notifies
+synchronously, `reactive.ts:78–87`; `batch()` defers via `PendingEffects`,
+343–363). So unbatched multi-write turns are a real, common cost here that
+auto-batching runtimes don't have (#1374).
+
+- **Input (measured):** per turn, `totalRuns` (effect runs) and
+  `distinctSubscribers` (unique effects).
+- **Metric:** `savings = totalRuns − distinctSubscribers` (runs collapsed if the
+  turn's writes were batched).
+- **Gate (static, SR4):** only advise when the **post-write-derived-read** oracle
+  proves batching is safe. An advisory that could change behavior is not emitted
+  as "safe".
+- **Finding:** `onSubmit: batch candidate 20→1, safe (Checkout.tsx:40–48)`.
+- **Fix:** wrap the handler body in `batch()`; the compiler can re-verify the wrap
+  preserves the no-stale-read property.
+
+#### 4.2.4 Fan-out / chain depth (v2)
+
+Predicted statically (SR5), confirmed at runtime (SR2). Static says "signal
+`count` fans out to 9 subscribers, memo chain depth 4"; the run confirms how often
+that fan-out actually fired and what it cost. Divergence (high static fan-out,
+never exercised) is itself reported, pointing at the coverage caveat.
+
+#### 4.2.5 Coverage (v2)
+
+Exercised handlers/edges vs the full IR set (every handler in `buildEventSummary`,
+every edge in the graph). Lists unmeasured candidates so a finding's scope is
+honest:
+
+```
+⚠ coverage: 2/7 handlers exercised; unmeasured: onApplyCoupon (Cart.tsx:31)
+```
+
+#### 4.2.6 Later
+
+List/reconcile churn (SR1 `map:reconcile`), mount/hydration cost, subscription
+growth / leak (subscribe add−remove imbalance over a churn scenario).
+
+### 4.3 Cross-cutting
+
+- **CLI / JSON-first.** Suggestions are source-mapped and AI-actionable.
+- **Scenario driving.** E2E harness / scripted / tests drive the instrumented
+  build; the coverage caveat is always printed (§4.2.5).
+- **Threshold config.** Flags (`--hot-ms`, `--wasted-pct`, `--fanout`) keep noise
+  low; defaults are conservative.
+- **Composition.** Static = "where to look"; profiler = "what cost, what to
+  change". Findings cite the same `loc`s as `bf debug graph/why-update`.
+
+## 5. Scope / phasing
+
+| Phase | Substrate | Analyses |
+|---|---|---|
+| **v1** | SR1–SR5, SR7, SR8 | Hot subscribers · Wasted re-runs · Batch advisor |
+| **v2** | SR6 (compile-diff) | Fan-out/chain · Coverage |
+| **later** | — | Churn · Mount/hydration · Leak · optional profiler→compiler auto-fixes |
+
+**Implementation order (front-loads the run-free value):**
+
+1. **SR5 static budget** + `bf debug profile` (no `--scenario`) — pure reuse of
+   shipped static analysis, immediately useful, zero runtime risk. *(scaffolded)*
+2. **SR6 compile-diff** — two SR5 budgets + structural delta; CI-able. *(static)*
+3. **SR1/SR3 substrate** — runtime sink + compiler turn markers behind the dev
+   flag (SR8 golden test first, so prod output can't drift).
+4. **SR2/SR4 join** + Hot subscribers / Wasted re-runs / Batch advisor.
+5. v2 analyses, then later.
+
+## 6. CLI & output
+
+```
+bf debug profile <component>                     # SR5 static budget (no run)
+bf debug profile <component> --diff <ref>        # SR6 compile-diff regression
+bf debug profile --scenario ./scenarios/x.ts     # full dynamic run (v1 analyses)
+  [--json] [--hot-ms <n>] [--wasted-pct <n>] [--fanout <n>] [--top <n>]
+```
+
+Dispatch follows the existing `case 'debug'` chain in
+`packages/cli/src/index.ts:144–174`; the command module mirrors
+`commands/debug-summary.ts` (resolve source → build → human|`--json`).
+
+### 6.1 Human output (dynamic run)
+
+```
+$ bf debug profile --scenario ./scenarios/checkout.ts
+Subscriber / Handler     Loc               runs  total ms  note
+recomputeTotals (effect) Checkout.tsx:71   180   42.0      hot: 60 runs/interaction
+priceLabel (effect)      Cart.tsx:55       180   8.0       wasted: 150/180 produced identical DOM
+onSubmit (handler)       Checkout.tsx:42   3     —         batch candidate: 20→1, safe
+
+→ fixes:
+   • split recomputeTotals so it doesn't re-run on unrelated `coupon` changes (Checkout.tsx:71)
+   • wrap onSubmit body in batch() (Checkout.tsx:40–48) — collapses 20→1, safe
+⚠ coverage: 2/7 handlers exercised; unmeasured: onApplyCoupon (Cart.tsx:31)
+```
+
+### 6.2 Human output (static budget, no run)
+
+```
+$ bf debug profile Checkout
+Checkout — static reactivity budget
+  signals: 6   memos: 4   effects: 9   loops: 1
+  subscriptions: 21
+  memo-chain depth: 4   (total → withTax → withShipping → grandTotal)
+  fan-out (top):
+    coupon       → 9 subscribers   ⚠ high
+    cartItems    → 5 subscribers
+  note: run with --scenario to measure actual cost; static budget is predictive only.
+```
+
+### 6.3 JSON schema (`--json`)
+
+Consistent with `graphToJSON` (`loc` simplified to `{file,line}`):
+
+```jsonc
+// static budget
+{
+  "componentName": "Checkout",
+  "sourceFile": "…/Checkout.tsx",
+  "kind": "static-budget",
+  "signals": 6, "memos": 4, "effects": 9, "loops": 1,
+  "subscriptions": 21,
+  "memoChainDepth": 4,
+  "memoChainLongest": ["total","withTax","withShipping","grandTotal"],
+  "fanOut": [ { "signal": "coupon", "subscribers": 9, "hot": true, "loc": {"file":"…","line":12} } ]
+}
+```
+
+```jsonc
+// dynamic report
+{
+  "kind": "profile",
+  "scenario": "./scenarios/checkout.ts",
+  "subscribers": [ { "id":"Checkout#effect:71", "label":"recomputeTotals", "kind":"effect",
+                     "runs":180, "totalMs":42.0, "runsPerTurn":60, "loc":{"file":"…","line":71},
+                     "notes":["hot"] } ],
+  "findings": [ { "type":"batch-advisor", "handler":"onSubmit", "loc":{"file":"…","line":42},
+                  "savings":19, "safe":true, "fix":"wrap body in batch()" } ],
+  "coverage": { "handlers": {"exercised":2,"total":7}, "unmeasured":[ {"handler":"onApplyCoupon","loc":{…}} ] }
+}
+```
+
+## 7. Definition of Done (per phase)
+
+- Requirements agreed (#1690) before implementation. *(this doc)*
+- Per phase: the SRs + analyses above, **dev-only**, with `--json`, docs, and
+  tests, each finding meeting the §1 "good finding" bar (real cost, ranked,
+  explained, safe fix where one exists).
+- SR8 golden test guards prod output from the first runtime-touching change.
+
+## 8. Open questions
+
+- **Scenario format.** Reuse the Playwright E2E harness (`site/ui/e2e/`) as the
+  default driver, or a lighter scripted `(page)=>…` form? Coverage caveat applies
+  either way.
+- **Cross-component runs.** v1 profiles one component's scenario; a multi-component
+  page run needs an id namespace that's unique across components (the
+  `"<Component>#…"` prefix is chosen to allow this later).
+- **Wasted-run fingerprint cost.** DOM-mutation counting vs memo-value `Object.is`
+  — the latter is free for memos, the former needs a MutationObserver scoped to
+  the component root. v1 starts with memo-value identity, adds DOM fingerprinting
+  behind a flag.


### PR DESCRIPTION
Designs the reactive performance profiler from #1690 and lands the **run-free v1 half** so `bf debug profile` is useful today. Requirements-gathering / design step per the issue's DoD ("Requirements agreed before implementation").

## Design — `spec/profiler.md`

Full-phase design grounded in the existing code:

- **Goal & the "good finding" bar** — names the costliest reactive work on a real scenario, says why/where (source), proposes a concrete fix, flags whether it's safe.
- **Why the IR** — how the compile phase makes tuning precise / predictive / safe / regression-proof / actionable, and how the profiler joins the static half (`analyzer.ts`, `debug.ts`, `bf debug graph/trace/events/why-update/summary`) with a new dynamic half.
- **SR1–SR8 substrate** — instrumentation choke points mapped to exact sites in `packages/client/src/reactive.ts`; compiler-emitted turn boundaries across *all* CSR handler emit paths (#1244 risk-A) via a single `wrapHandlerForTurn` helper (§A refactor direction); IR join + the static "is this fix safe?" oracle; static budget; compile-diff; session/output; zero-prod-overhead gating.
- **Analyses** — hot subscribers, wasted re-runs, batch advisor (with the static post-write-derived-read safety gate), fan-out/chain, coverage.
- **Phasing, CLI/JSON schema, DoD, open questions.**

A key finding the design pins down: the runtime carries **no id/loc** on its internal `EffectContext`, and **memos are effects-writing-signals** — so SR1/SR3 must have the compiler emit stable ids at creation sites for the SR4 join, and collapse each memo's effect+signal pair back into one node.

## Scaffold — static (no-run) half of v1

- **SR5 static reactivity budget** (`packages/jsx/src/profiler.ts` → `buildStaticBudget`): per-component signal/memo/effect/loop counts, total subscriptions, longest memo→memo chain, and per-signal fan-out with a `hot` threshold — pure reuse of `buildComponentAnalysis` + `traceUpdatePath`.
- **SR6 compile-diff regression** (`diffStaticBudget`): `bf debug profile <c> --diff <ref>` compiles the component at a git ref, diffs the budgets, prints the structural delta and exits non-zero on growth (CI-able).
- **CLI**: `bf debug profile` command + dispatch + help; human table and `--json`, consistent with the `bf debug *` family.
- **Dynamic seam**: `buildProfileReport` (SR1–SR4) throws a pointer to the spec until the measurement substrate lands; `--scenario` surfaces it.

## Example (real component)

```
$ bf debug profile calendar
Calendar — static reactivity budget
  signals: 4   memos: 9   effects: 0   loops: 6
  subscriptions: 14
  memo-chain depth: 1   (selectedDate)
  fan-out (top):
    currentYear  → 11 subscribers   ⚠ high
    currentMonth → 11 subscribers   ⚠ high
    ...
  note: run with --scenario to measure actual cost; static budget is predictive only.
```

## Tests

`packages/jsx/src/__tests__/profiler.test.ts` — budget metrics, fan-out ordering/threshold, memo-chain depth, the diff regression flag, and the dynamic seam's not-implemented error. 8/8 pass; jsx + cli typecheck clean.

## Status / next

Static half is implemented and tested. The dynamic substrate (SR1–SR4) and the v1 analyses (hot subscribers / wasted re-runs / batch advisor) are specified and stubbed — kept as a draft for design review of `spec/profiler.md` before building the runtime instrumentation.

https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN)_