### PR TITLE
fix(release): output "New tag:" so changesets/action sets published=true

### DIFF
--- a/scripts/changeset-publish.ts
+++ b/scripts/changeset-publish.ts
@@ -102,7 +102,13 @@ try {
     // The action parses stdout for "New tag: <name>@<version>" lines to set
     // its `published` output and to create GitHub Releases.
     const tag = `${pkg.name}@${pkg.version}`
-    await $`git tag ${tag}`.cwd(repoRoot).quiet().nothrow()
+    const t = await $`git tag ${tag}`.cwd(repoRoot).quiet().nothrow()
+    const tagAlreadyExists = t.exitCode !== 0 && t.stderr.toString().includes('already exists')
+    if (t.exitCode !== 0 && !tagAlreadyExists) {
+      console.error(`  git tag failed: ${t.stderr.toString().trim()}`)
+      errors.push(`${tag} (tag)`)
+      continue
+    }
     console.log(`New tag: ${tag}`)
 
     published++

--- a/scripts/changeset-publish.ts
+++ b/scripts/changeset-publish.ts
@@ -98,10 +98,12 @@ try {
       continue
     }
 
-    // Tag for changesets/action to create GitHub Releases
+    // Create a local git tag so changesets/action can detect the publish.
+    // The action parses stdout for "New tag: <name>@<version>" lines to set
+    // its `published` output and to create GitHub Releases.
     const tag = `${pkg.name}@${pkg.version}`
-    const t = await $`git tag ${tag}`.cwd(repoRoot).quiet().nothrow()
-    console.log(`  tagged  ${tag}${t.exitCode !== 0 ? ' (already exists)' : ''}`)
+    await $`git tag ${tag}`.cwd(repoRoot).quiet().nothrow()
+    console.log(`New tag: ${tag}`)
 
     published++
   }


### PR DESCRIPTION
## Summary

- `changesets/action` parses the publish script's stdout for lines matching `/New tag:\s+<name>@<version>/` to set its `published` output and trigger GitHub Release creation
- Our script was printing `  tagged  <name>@<version>` which the regex did not match, so `published` stayed `false` despite 15 packages being published
- This caused the JSR and `cpan-release` jobs to be skipped on every publish run

## Root cause

From the Changesets action source (`src/run.ts`):
```js
let newTagRegex = /New tag:\s+(@[^/]+\/[^@]+|[^/]+)@([^\s]+)/;
for (let line of changesetPublishOutput.stdout.split("\n")) {
  let match = line.match(newTagRegex);
  if (match === null) continue;
  releasedPackages.push(packagesByName.get(match[1]));
}
```

## Fix

Change the tag log line in `scripts/changeset-publish.ts` from `  tagged  <tag>` to `New tag: <tag>` so the action's regex matches and correctly sets `published=true`.

## Test plan
- [ ] Merge this PR
- [ ] Wait for the release workflow to run
- [ ] Verify "Publish to JSR" and `cpan-release` jobs no longer skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)