### PR TITLE
Use `deno x` and `@barefootjs/cli` for one-shot CLI commands

### DIFF
--- a/.changeset/deno-x-cli-exec.md
+++ b/.changeset/deno-x-cli-exec.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/cli": patch
+---
+
+Fix Deno one-shot command hints and adopt `deno x`. `commandsFor('deno').exec` now emits `deno x npm:<pkg>` (Deno 2.6+, the `npx` equivalent that defaults to `--allow-all`) instead of `deno run -A npm:<pkg>`. Generated Deno project scripts (e.g. `wrangler dev`/`deploy`) therefore use `deno x` and now require Deno 2.6+.
+
+Component install snippets are also corrected to reference the published package `@barefootjs/cli` rather than the bare bin name `bf` — the latter resolves to an unrelated npm package when run cold (outside a project that already has the CLI installed).

--- a/packages/cli/scripts/build.mjs
+++ b/packages/cli/scripts/build.mjs
@@ -19,7 +19,7 @@ import { builtinModules } from 'node:module'
 // (`from 'node:fs'`) builtins; esbuild preserves whichever the source
 // used. Deno only resolves Node builtins through the `node:` form, so
 // without this the published bundle fails to load under
-// `deno run -A npm:bf`. Node 22 and Bun both accept `node:`, so the
+// `deno x npm:@barefootjs/cli`. Node 22 and Bun both accept `node:`, so the
 // rewrite is a no-op for them — it only unlocks the Deno runtime.
 const nodeProtocolPlugin = {
   name: 'node-protocol',

--- a/packages/cli/scripts/deno-smoke.ts
+++ b/packages/cli/scripts/deno-smoke.ts
@@ -33,7 +33,7 @@ import {
 assert.ok(process.versions.deno, 'expected to run under the Deno runtime')
 
 // 2. With no lockfile, the live Deno runtime version makes the invoking
-//    PM resolve to `deno` (the `deno run -A npm:bf` in an empty dir case).
+//    PM resolve to `deno` (the `deno x npm:@barefootjs/cli` in an empty dir case).
 assert.equal(
   detectInvokingPackageManager(),
   'deno',
@@ -57,7 +57,7 @@ try {
 const deno = commandsFor('deno')
 assert.equal(deno.install, 'deno install')
 assert.equal(deno.run('dev'), 'deno task dev')
-assert.equal(deno.exec('bf add button'), 'deno run -A npm:bf add button')
+assert.equal(deno.exec('@barefootjs/cli add button'), 'deno x npm:@barefootjs/cli add button')
 assert.equal(deno.test('Foo.test.tsx'), 'deno task test Foo.test.tsx')
 
 console.log('✓ Deno smoke passed: bf package-manager layer is Deno-native')

--- a/packages/cli/src/__tests__/pm.test.ts
+++ b/packages/cli/src/__tests__/pm.test.ts
@@ -81,7 +81,7 @@ describe('detectPackageManager', () => {
     expect(detectPackageManager(tmpDir, EMPTY_ENV, EMPTY_VERSIONS)).toBe('bun')
   })
 
-  test('falls back to deno runtime when env has no UA (e.g. `deno run npm:bf`)', () => {
+  test('falls back to deno runtime when env has no UA (e.g. `deno x npm:@barefootjs/cli`)', () => {
     expect(detectPackageManager(tmpDir, EMPTY_ENV, { deno: '2.0.0' })).toBe('deno')
   })
 
@@ -151,7 +151,7 @@ describe('detectInvokingPackageManager', () => {
   })
 
   // Deno does not set `npm_config_user_agent`, so the runtime version
-  // is the signal that catches `deno run -A npm:bf` in an empty dir.
+  // is the signal that catches `deno x npm:@barefootjs/cli` in an empty dir.
   test('detects deno runtime when UA is absent', () => {
     expect(detectInvokingPackageManager(EMPTY_ENV, { deno: '2.0.0' })).toBe('deno')
   })
@@ -162,37 +162,38 @@ describe('commandsFor', () => {
     const c = commandsFor('npm')
     expect(c.install).toBe('npm install')
     expect(c.run('dev')).toBe('npm run dev')
-    expect(c.exec('bf add button')).toBe('npx bf add button')
+    expect(c.exec('@barefootjs/cli add button')).toBe('npx @barefootjs/cli add button')
   })
 
   test('bun commands', () => {
     const c = commandsFor('bun')
     expect(c.install).toBe('bun install')
     expect(c.run('dev')).toBe('bun run dev')
-    expect(c.exec('bf add button')).toBe('bunx bf add button')
+    expect(c.exec('@barefootjs/cli add button')).toBe('bunx @barefootjs/cli add button')
   })
 
   test('pnpm commands', () => {
     const c = commandsFor('pnpm')
     expect(c.install).toBe('pnpm install')
     expect(c.run('dev')).toBe('pnpm dev')
-    expect(c.exec('bf add button')).toBe('pnpm dlx bf add button')
+    expect(c.exec('@barefootjs/cli add button')).toBe('pnpm dlx @barefootjs/cli add button')
   })
 
   test('yarn commands', () => {
     const c = commandsFor('yarn')
     expect(c.install).toBe('yarn')
     expect(c.run('dev')).toBe('yarn dev')
-    expect(c.exec('bf add button')).toBe('yarn dlx bf add button')
+    expect(c.exec('@barefootjs/cli add button')).toBe('yarn dlx @barefootjs/cli add button')
   })
 
   test('deno commands', () => {
     const c = commandsFor('deno')
     expect(c.install).toBe('deno install')
     expect(c.run('dev')).toBe('deno task dev')
-    // The `npm:` specifier is what makes `deno run -A npm:bf ...` the
-    // Deno equivalent of `bunx bf ...` / `npx bf ...`.
-    expect(c.exec('bf add button')).toBe('deno run -A npm:bf add button')
+    // `deno x` (Deno 2.6+) with the `npm:` specifier is the Deno
+    // equivalent of `bunx ...` / `npx ...`; it defaults to `--allow-all`,
+    // so no `-A` is emitted.
+    expect(c.exec('@barefootjs/cli add button')).toBe('deno x npm:@barefootjs/cli add button')
   })
 
   // The `test` helper is what the various "next steps" / "run tests"

--- a/packages/cli/src/lib/pm.ts
+++ b/packages/cli/src/lib/pm.ts
@@ -4,8 +4,8 @@
 //   1. A lockfile in `dir` — the user has already committed to a tool.
 //   2. The package manager that spawned this CLI, read from
 //      `npm_config_user_agent` (set by npm/bun/pnpm/yarn). Catches the
-//      common `bunx bf init` in an empty directory case where there
-//      is no lockfile yet but the user clearly wants bun.
+//      common `bunx @barefootjs/cli init` in an empty directory case
+//      where there is no lockfile yet but the user clearly wants bun.
 //
 // Falls back to 'npm' when neither signal is available.
 
@@ -13,7 +13,7 @@
 // unchanged under every runtime `bf` may execute on — Node, Bun, and
 // Deno. Deno only resolves builtins through the `node:` specifier, so
 // the prefix is what lets `detectPackageManager` run under
-// `deno run npm:bf ...` without a bundler rewrite.
+// `deno x npm:@barefootjs/cli ...` without a bundler rewrite.
 import { existsSync } from 'node:fs'
 import path from 'node:path'
 
@@ -55,12 +55,12 @@ export function detectPackageManager(
 //   - `process.versions.bun` / `process.versions.deno`: present
 //     whenever the bun / Deno runtime is in use (covers local-path and
 //     `npm:`-specifier invocations like `bun ./dist/cli.js`,
-//     `deno run -A npm:bf`, or a `#!/usr/bin/env bun` shebang, where the
-//     UA is not set). pnpm and yarn share node's runtime, so they fall
-//     through to the UA path only.
+//     `deno x npm:@barefootjs/cli`, or a `#!/usr/bin/env bun` shebang,
+//     where the UA is not set). pnpm and yarn share node's runtime, so
+//     they fall through to the UA path only.
 //
-// Deno is unusual: it does not set `npm_config_user_agent` and runs
-// `bf` via `deno run npm:bf`, so the runtime version is the only
+// Deno is unusual: it does not set `npm_config_user_agent` and runs the
+// CLI via `deno x npm:@barefootjs/cli`, so the runtime version is the only
 // reliable signal — checked after the UA so an explicit
 // `pnpm dlx`/`npx` wrapper (which would set the UA) still wins.
 export function detectInvokingPackageManager(
@@ -126,10 +126,11 @@ export function commandsFor(pm: PackageManager): PmCommands {
         // package.json scripts surface as Deno tasks, so `deno task
         // <script>` mirrors `bun run <script>` / `pnpm <script>`.
         run: s => `deno task ${s}`,
-        // One-shot binaries run straight from npm via the `npm:`
-        // specifier; `-A` grants the filesystem/network access `bf`
-        // needs to download and write components.
-        exec: c => `deno run -A npm:${c}`,
+        // One-shot binaries run straight from npm via `deno x` (Deno
+        // 2.6+, the `npx` equivalent) with the `npm:` specifier. `deno x`
+        // defaults to `--allow-all`, so no explicit `-A` is needed for
+        // the filesystem/network access the CLI uses to write components.
+        exec: c => `deno x npm:${c}`,
         // The scaffold's `test` task forwards extra args without a `--`
         // separator (like bun/pnpm/yarn), so the targeted form just
         // appends the path.

--- a/plugins/barefootjs/skills/barefootjs/SKILL.md
+++ b/plugins/barefootjs/skills/barefootjs/SKILL.md
@@ -24,53 +24,53 @@ npm install -D @barefootjs/cli
 bun add -d @barefootjs/cli
 ```
 
-Once installed, use `npx bf` (or `bunx bf`) to run commands.
+Once installed, use `npx @barefootjs/cli` (or `bunx @barefootjs/cli`) to run commands.
 
 ## Workflow
 
-1. `npx bf search <query>` — Find components and docs by name/category/tags
-2. `npx bf docs <component>` — Get props, examples, accessibility info
-3. `npx bf guide <topic>` — Read framework docs (signals, compiler constraints, etc.)
-4. `npx bf gen component <name> <comp...>` — Generate skeleton + basic IR test
+1. `npx @barefootjs/cli search <query>` — Find components and docs by name/category/tags
+2. `npx @barefootjs/cli docs <component>` — Get props, examples, accessibility info
+3. `npx @barefootjs/cli guide <topic>` — Read framework docs (signals, compiler constraints, etc.)
+4. `npx @barefootjs/cli gen component <name> <comp...>` — Generate skeleton + basic IR test
 5. Implement the component
 6. Run tests — Verify compilation
-7. `npx bf gen test <name>` — Regenerate richer IR test
+7. `npx @barefootjs/cli gen test <name>` — Regenerate richer IR test
 8. Run tests — Final verification
-9. Create previews and run `npx bf preview <name>` — Visual preview in browser
+9. Create previews and run `npx @barefootjs/cli preview <name>` — Visual preview in browser
 10. Ask the user to check the browser for visual/interaction verification
 
 ## Signal Inspection & Debugging
 
 Use these commands to understand and debug a component's reactive structure **without running any code**. All analysis is static (from IR).
 
-### `npx bf debug graph <component>`
+### `npx @barefootjs/cli debug graph <component>`
 
 Show the signal dependency graph for a component. Use this **before modifying** a stateful component to understand its reactive structure: which signals exist, what memos depend on them, and which DOM nodes are bound.
 
 - Add `--json` for machine-readable output.
-- Example: `npx bf debug graph combobox`
+- Example: `npx @barefootjs/cli debug graph combobox`
 
-### `npx bf debug trace <component> <signal|memo>`
+### `npx @barefootjs/cli debug trace <component> <signal|memo>`
 
 Reverse-lookup: trace the full propagation path from a signal/memo to every DOM binding it affects. Use this to answer "why does this DOM node update?" or to verify that a signal change reaches the expected targets.
 
 - If the signal name is wrong, the CLI lists available signals/memos.
 - Add `--json` for machine-readable output.
-- Example: `npx bf debug trace combobox open`
+- Example: `npx @barefootjs/cli debug trace combobox open`
 
-### `npx bf debug signals <component>`
+### `npx @barefootjs/cli debug signals <component>`
 
 Show a signal initialization trace: every signal, its initial value, and its effect bindings. Useful for verifying that signals are wired correctly in a newly written or modified component.
 
 - Add `--json` for machine-readable output.
-- Example: `npx bf debug signals select`
+- Example: `npx @barefootjs/cli debug signals select`
 
-### `npx bf debug fallbacks <component>`
+### `npx @barefootjs/cli debug fallbacks <component>`
 
 Surface fallback-wrapped expressions emitted by Solid-style wrap-by-default. Use this to find candidates for `createMemo` refactor — places where the compiler couldn't statically prove reactivity and fell back to wrapping.
 
 - Add `--json` for machine-readable output.
-- Example: `npx bf debug fallbacks combobox`
+- Example: `npx @barefootjs/cli debug fallbacks combobox`
 
 ### When to use inspection
 
@@ -113,7 +113,7 @@ export function WithProps() {
 - Add previews for key variants, states, and compositions (e.g., `WithLabel`, `Disabled`, `PreFilled`).
 - Previews that use signals need `"use client"` at the top.
 - Import components via relative path from `../` (e.g., `import { Button } from '../button'`).
-- After creating previews, run `npx bf preview <name>` and ask the user to verify in the browser.
+- After creating previews, run `npx @barefootjs/cli preview <name>` and ask the user to verify in the browser.
 
 ## Rules
 

--- a/scripts/jsr-publish.ts
+++ b/scripts/jsr-publish.ts
@@ -66,7 +66,7 @@ const ignore: string[] = JSON.parse(
 // JSR is the home for the *libraries* consumers `import`. The
 // *executables* — the `bf` CLI and the `create-barefootjs` scaffolder —
 // stay npm-only and Deno users invoke them via the `npm:` specifier
-// (`deno run -A npm:bf …` / `deno run -A npm:create-barefootjs`), so
+// (`deno x npm:@barefootjs/cli …` / `deno x npm:create-barefootjs`), so
 // they're filtered out here. Eligibility:
 //   - scoped `@barefootjs/*` (JSR requires a scope; `create-barefootjs`
 //     is unscoped anyway),

--- a/site/shared/components/package-manager-tabs.tsx
+++ b/site/shared/components/package-manager-tabs.tsx
@@ -34,17 +34,18 @@ export function PackageManagerTabs(props: PackageManagerTabsProps) {
       if (pm === 'bun') return `bun create ${stripped}`
       if (pm === 'pnpm') return `pnpm create ${stripped}`
       // Deno has no `create` shorthand — it runs the `create-*` package
-      // straight from npm via the `npm:` specifier (e.g.
-      // `create barefootjs@latest` → `deno run -A npm:create-barefootjs`).
-      if (pm === 'deno') return `deno run -A npm:create-${stripped}`
+      // straight from npm via `deno x` + the `npm:` specifier (e.g.
+      // `create barefootjs@latest` → `deno x npm:create-barefootjs`).
+      if (pm === 'deno') return `deno x npm:create-${stripped}`
       return `yarn create ${stripped}`
     }
     if (pm === 'bun') return `bunx --bun ${props.command}`
     if (pm === 'pnpm') return `pnpm dlx ${props.command}`
     if (pm === 'yarn') return `yarn dlx ${props.command}`
-    // `deno run -A npm:<cmd>` is Deno's one-shot-binary form (mirrors
-    // `npx <cmd>`); `-A` grants the access `bf` needs to write files.
-    if (pm === 'deno') return `deno run -A npm:${props.command}`
+    // `deno x npm:<cmd>` (Deno 2.6+) is Deno's one-shot-binary form
+    // (mirrors `npx <cmd>`); `deno x` defaults to `--allow-all`, so it
+    // already has the access the CLI needs to write files.
+    if (pm === 'deno') return `deno x npm:${props.command}`
     return `npx ${props.command}`
   })
 

--- a/site/ui/README.md
+++ b/site/ui/README.md
@@ -5,7 +5,7 @@ Beautifully designed components built with BarefootJS and UnoCSS.
 ## Installation
 
 ```bash
-bunx bf add button
+bunx @barefootjs/cli add button
 ```
 
 ## Usage

--- a/site/ui/e2e/installation-tabs.spec.ts
+++ b/site/ui/e2e/installation-tabs.spec.ts
@@ -23,7 +23,7 @@ test.describe('Installation Tabs (PackageManagerTabs)', () => {
   })
 
   test('shows npm command by default', async ({ page }) => {
-    await expect(page.locator('text=npx bf add checkbox')).toBeVisible()
+    await expect(page.locator('text=npx @barefootjs/cli add checkbox')).toBeVisible()
   })
 
   test('clicking bun tab switches content', async ({ page }) => {
@@ -33,7 +33,7 @@ test.describe('Installation Tabs (PackageManagerTabs)', () => {
     await bunTab.click()
 
     await expect(bunTab).toHaveAttribute('aria-selected', 'true')
-    await expect(page.locator('text=bunx --bun bf add checkbox')).toBeVisible()
+    await expect(page.locator('text=bunx --bun @barefootjs/cli add checkbox')).toBeVisible()
   })
 
   test('clicking pnpm tab switches content', async ({ page }) => {
@@ -43,7 +43,7 @@ test.describe('Installation Tabs (PackageManagerTabs)', () => {
     await pnpmTab.click()
 
     await expect(pnpmTab).toHaveAttribute('aria-selected', 'true')
-    await expect(page.locator('text=pnpm dlx bf add checkbox')).toBeVisible()
+    await expect(page.locator('text=pnpm dlx @barefootjs/cli add checkbox')).toBeVisible()
   })
 
   test('clicking yarn tab switches content', async ({ page }) => {
@@ -53,7 +53,7 @@ test.describe('Installation Tabs (PackageManagerTabs)', () => {
     await yarnTab.click()
 
     await expect(yarnTab).toHaveAttribute('aria-selected', 'true')
-    await expect(page.locator('text=yarn dlx bf add checkbox')).toBeVisible()
+    await expect(page.locator('text=yarn dlx @barefootjs/cli add checkbox')).toBeVisible()
   })
 
   test('clicking deno tab switches content', async ({ page }) => {
@@ -63,7 +63,7 @@ test.describe('Installation Tabs (PackageManagerTabs)', () => {
     await denoTab.click()
 
     await expect(denoTab).toHaveAttribute('aria-selected', 'true')
-    await expect(page.locator('text=deno run -A npm:bf add checkbox')).toBeVisible()
+    await expect(page.locator('text=deno x npm:@barefootjs/cli add checkbox')).toBeVisible()
   })
 
   test('switching tabs updates aria-selected correctly', async ({ page }) => {

--- a/site/ui/pages/components/accordion.tsx
+++ b/site/ui/pages/components/accordion.tsx
@@ -205,7 +205,7 @@ export function AccordionRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add accordion" />
+          <PackageManagerTabs command="@barefootjs/cli add accordion" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/alert-dialog.tsx
+++ b/site/ui/pages/components/alert-dialog.tsx
@@ -224,7 +224,7 @@ export function AlertDialogRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add alert-dialog" />
+          <PackageManagerTabs command="@barefootjs/cli add alert-dialog" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/alert.tsx
+++ b/site/ui/pages/components/alert.tsx
@@ -125,7 +125,7 @@ export function AlertRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add alert" />
+          <PackageManagerTabs command="@barefootjs/cli add alert" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/aspect-ratio.tsx
+++ b/site/ui/pages/components/aspect-ratio.tsx
@@ -113,7 +113,7 @@ export function AspectRatioRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add aspect-ratio" />
+          <PackageManagerTabs command="@barefootjs/cli add aspect-ratio" />
         </Section>
 
         {/* Examples */}

--- a/site/ui/pages/components/avatar.tsx
+++ b/site/ui/pages/components/avatar.tsx
@@ -121,7 +121,7 @@ export function AvatarRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add avatar" />
+          <PackageManagerTabs command="@barefootjs/cli add avatar" />
         </Section>
 
         {/* Examples */}

--- a/site/ui/pages/components/badge.tsx
+++ b/site/ui/pages/components/badge.tsx
@@ -111,7 +111,7 @@ export function BadgeRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add badge" />
+          <PackageManagerTabs command="@barefootjs/cli add badge" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/breadcrumb.tsx
+++ b/site/ui/pages/components/breadcrumb.tsx
@@ -216,7 +216,7 @@ export function BreadcrumbRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add breadcrumb" />
+          <PackageManagerTabs command="@barefootjs/cli add breadcrumb" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/button-group.tsx
+++ b/site/ui/pages/components/button-group.tsx
@@ -127,7 +127,7 @@ export function ButtonGroupRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add button-group" />
+          <PackageManagerTabs command="@barefootjs/cli add button-group" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/button.tsx
+++ b/site/ui/pages/components/button.tsx
@@ -110,7 +110,7 @@ export function ButtonRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add button" />
+          <PackageManagerTabs command="@barefootjs/cli add button" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/calendar.tsx
+++ b/site/ui/pages/components/calendar.tsx
@@ -249,7 +249,7 @@ export function CalendarRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add calendar" />
+          <PackageManagerTabs command="@barefootjs/cli add calendar" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/card.tsx
+++ b/site/ui/pages/components/card.tsx
@@ -370,7 +370,7 @@ export function CardRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add card" />
+          <PackageManagerTabs command="@barefootjs/cli add card" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/carousel.tsx
+++ b/site/ui/pages/components/carousel.tsx
@@ -160,7 +160,7 @@ export function CarouselRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add carousel" />
+          <PackageManagerTabs command="@barefootjs/cli add carousel" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/checkbox.tsx
+++ b/site/ui/pages/components/checkbox.tsx
@@ -270,7 +270,7 @@ export function CheckboxRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add checkbox" />
+          <PackageManagerTabs command="@barefootjs/cli add checkbox" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/collapsible.tsx
+++ b/site/ui/pages/components/collapsible.tsx
@@ -211,7 +211,7 @@ export function CollapsibleRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add collapsible" />
+          <PackageManagerTabs command="@barefootjs/cli add collapsible" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/combobox.tsx
+++ b/site/ui/pages/components/combobox.tsx
@@ -238,7 +238,7 @@ export function ComboboxRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add combobox" />
+          <PackageManagerTabs command="@barefootjs/cli add combobox" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/command.tsx
+++ b/site/ui/pages/components/command.tsx
@@ -267,7 +267,7 @@ export function CommandRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add command" />
+          <PackageManagerTabs command="@barefootjs/cli add command" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/context-menu.tsx
+++ b/site/ui/pages/components/context-menu.tsx
@@ -283,7 +283,7 @@ export function ContextMenuRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add context-menu" />
+          <PackageManagerTabs command="@barefootjs/cli add context-menu" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/data-table.tsx
+++ b/site/ui/pages/components/data-table.tsx
@@ -342,7 +342,7 @@ export function DataTableRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add data-table" />
+          <PackageManagerTabs command="@barefootjs/cli add data-table" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/date-picker.tsx
+++ b/site/ui/pages/components/date-picker.tsx
@@ -308,7 +308,7 @@ export function DatePickerRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add date-picker" />
+          <PackageManagerTabs command="@barefootjs/cli add date-picker" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/dialog.tsx
+++ b/site/ui/pages/components/dialog.tsx
@@ -298,7 +298,7 @@ export function DialogRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add dialog" />
+          <PackageManagerTabs command="@barefootjs/cli add dialog" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/direction.tsx
+++ b/site/ui/pages/components/direction.tsx
@@ -132,7 +132,7 @@ export function DirectionRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add direction" />
+          <PackageManagerTabs command="@barefootjs/cli add direction" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/drawer.tsx
+++ b/site/ui/pages/components/drawer.tsx
@@ -280,7 +280,7 @@ export function DrawerRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add drawer" />
+          <PackageManagerTabs command="@barefootjs/cli add drawer" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/dropdown-menu.tsx
+++ b/site/ui/pages/components/dropdown-menu.tsx
@@ -301,7 +301,7 @@ export function DropdownMenuRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add dropdown-menu" />
+          <PackageManagerTabs command="@barefootjs/cli add dropdown-menu" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/empty.tsx
+++ b/site/ui/pages/components/empty.tsx
@@ -208,7 +208,7 @@ export function EmptyRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add empty" />
+          <PackageManagerTabs command="@barefootjs/cli add empty" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/field.tsx
+++ b/site/ui/pages/components/field.tsx
@@ -285,7 +285,7 @@ export function FieldRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add field" />
+          <PackageManagerTabs command="@barefootjs/cli add field" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/hover-card.tsx
+++ b/site/ui/pages/components/hover-card.tsx
@@ -130,7 +130,7 @@ export function HoverCardRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add hover-card" />
+          <PackageManagerTabs command="@barefootjs/cli add hover-card" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/input-group.tsx
+++ b/site/ui/pages/components/input-group.tsx
@@ -293,7 +293,7 @@ export function InputGroupRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add input-group" />
+          <PackageManagerTabs command="@barefootjs/cli add input-group" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/input-otp.tsx
+++ b/site/ui/pages/components/input-otp.tsx
@@ -253,7 +253,7 @@ export function InputOTPRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add input-otp" />
+          <PackageManagerTabs command="@barefootjs/cli add input-otp" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/input.tsx
+++ b/site/ui/pages/components/input.tsx
@@ -179,7 +179,7 @@ export function InputRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add input" />
+          <PackageManagerTabs command="@barefootjs/cli add input" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/item.tsx
+++ b/site/ui/pages/components/item.tsx
@@ -144,7 +144,7 @@ export function ItemRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add item" />
+          <PackageManagerTabs command="@barefootjs/cli add item" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/kbd.tsx
+++ b/site/ui/pages/components/kbd.tsx
@@ -119,7 +119,7 @@ export function KbdRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add kbd" />
+          <PackageManagerTabs command="@barefootjs/cli add kbd" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/label.tsx
+++ b/site/ui/pages/components/label.tsx
@@ -103,7 +103,7 @@ export function LabelRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add label" />
+          <PackageManagerTabs command="@barefootjs/cli add label" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/menubar.tsx
+++ b/site/ui/pages/components/menubar.tsx
@@ -325,7 +325,7 @@ export function MenubarRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add menubar" />
+          <PackageManagerTabs command="@barefootjs/cli add menubar" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/native-select.tsx
+++ b/site/ui/pages/components/native-select.tsx
@@ -256,7 +256,7 @@ export function NativeSelectRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add native-select" />
+          <PackageManagerTabs command="@barefootjs/cli add native-select" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/navigation-menu.tsx
+++ b/site/ui/pages/components/navigation-menu.tsx
@@ -176,7 +176,7 @@ export function NavigationMenuRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add navigation-menu" />
+          <PackageManagerTabs command="@barefootjs/cli add navigation-menu" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/pagination.tsx
+++ b/site/ui/pages/components/pagination.tsx
@@ -221,7 +221,7 @@ export function PaginationRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add pagination" />
+          <PackageManagerTabs command="@barefootjs/cli add pagination" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/popover.tsx
+++ b/site/ui/pages/components/popover.tsx
@@ -186,7 +186,7 @@ export function PopoverRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add popover" />
+          <PackageManagerTabs command="@barefootjs/cli add popover" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/portal.tsx
+++ b/site/ui/pages/components/portal.tsx
@@ -141,7 +141,7 @@ export function PortalRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add portal" />
+          <PackageManagerTabs command="@barefootjs/cli add portal" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/progress.tsx
+++ b/site/ui/pages/components/progress.tsx
@@ -223,7 +223,7 @@ export function ProgressRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add progress" />
+          <PackageManagerTabs command="@barefootjs/cli add progress" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/radio-group.tsx
+++ b/site/ui/pages/components/radio-group.tsx
@@ -267,7 +267,7 @@ export function RadioGroupRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add radio-group" />
+          <PackageManagerTabs command="@barefootjs/cli add radio-group" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/resizable.tsx
+++ b/site/ui/pages/components/resizable.tsx
@@ -262,7 +262,7 @@ export function ResizableRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add resizable" />
+          <PackageManagerTabs command="@barefootjs/cli add resizable" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/scroll-area.tsx
+++ b/site/ui/pages/components/scroll-area.tsx
@@ -133,7 +133,7 @@ export function ScrollAreaRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add scroll-area" />
+          <PackageManagerTabs command="@barefootjs/cli add scroll-area" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/select.tsx
+++ b/site/ui/pages/components/select.tsx
@@ -242,7 +242,7 @@ export function SelectRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add select" />
+          <PackageManagerTabs command="@barefootjs/cli add select" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/separator.tsx
+++ b/site/ui/pages/components/separator.tsx
@@ -162,7 +162,7 @@ export function SeparatorRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add separator" />
+          <PackageManagerTabs command="@barefootjs/cli add separator" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/sheet.tsx
+++ b/site/ui/pages/components/sheet.tsx
@@ -282,7 +282,7 @@ export function SheetRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add sheet" />
+          <PackageManagerTabs command="@barefootjs/cli add sheet" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/skeleton.tsx
+++ b/site/ui/pages/components/skeleton.tsx
@@ -81,7 +81,7 @@ export function SkeletonRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add skeleton" />
+          <PackageManagerTabs command="@barefootjs/cli add skeleton" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/slider.tsx
+++ b/site/ui/pages/components/slider.tsx
@@ -268,7 +268,7 @@ export function SliderRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add slider" />
+          <PackageManagerTabs command="@barefootjs/cli add slider" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/spinner.tsx
+++ b/site/ui/pages/components/spinner.tsx
@@ -102,7 +102,7 @@ export function SpinnerRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add spinner" />
+          <PackageManagerTabs command="@barefootjs/cli add spinner" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/switch.tsx
+++ b/site/ui/pages/components/switch.tsx
@@ -234,7 +234,7 @@ export function SwitchRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add switch" />
+          <PackageManagerTabs command="@barefootjs/cli add switch" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/table.tsx
+++ b/site/ui/pages/components/table.tsx
@@ -223,7 +223,7 @@ export function TableRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add table" />
+          <PackageManagerTabs command="@barefootjs/cli add table" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/tabs.tsx
+++ b/site/ui/pages/components/tabs.tsx
@@ -252,7 +252,7 @@ export function TabsRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add tabs" />
+          <PackageManagerTabs command="@barefootjs/cli add tabs" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/textarea.tsx
+++ b/site/ui/pages/components/textarea.tsx
@@ -149,7 +149,7 @@ export function TextareaRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add textarea" />
+          <PackageManagerTabs command="@barefootjs/cli add textarea" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/toast.tsx
+++ b/site/ui/pages/components/toast.tsx
@@ -209,7 +209,7 @@ export function ToastRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add toast" />
+          <PackageManagerTabs command="@barefootjs/cli add toast" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/toggle-group.tsx
+++ b/site/ui/pages/components/toggle-group.tsx
@@ -211,7 +211,7 @@ export function ToggleGroupRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add toggle-group" />
+          <PackageManagerTabs command="@barefootjs/cli add toggle-group" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/toggle.tsx
+++ b/site/ui/pages/components/toggle.tsx
@@ -183,7 +183,7 @@ export function ToggleRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add toggle" />
+          <PackageManagerTabs command="@barefootjs/cli add toggle" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/tooltip.tsx
+++ b/site/ui/pages/components/tooltip.tsx
@@ -185,7 +185,7 @@ export function TooltipRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add tooltip" />
+          <PackageManagerTabs command="@barefootjs/cli add tooltip" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/components/typography.tsx
+++ b/site/ui/pages/components/typography.tsx
@@ -146,7 +146,7 @@ export function TypographyRefPage() {
 
         {/* Installation */}
         <Section id="installation" title="Installation">
-          <PackageManagerTabs command="bf add typography" />
+          <PackageManagerTabs command="@barefootjs/cli add typography" />
         </Section>
 
         {/* Usage */}

--- a/site/ui/pages/xyflow/introduction.tsx
+++ b/site/ui/pages/xyflow/introduction.tsx
@@ -166,7 +166,7 @@ export function XyflowIntroductionPage() {
             </p>
           </div>
 
-          <PackageManagerTabs command="bf add xyflow" />
+          <PackageManagerTabs command="@barefootjs/cli add xyflow" />
         </Section>
 
         {/* Quick Start */}


### PR DESCRIPTION
## Summary

While exploring whether `deno run -A npm:bf add button` could be shortened with Deno 2.6's new `deno x` (the `npx` equivalent), testing surfaced a real bug: **the documented one-shot commands reference the bare bin name `bf` as if it were an npm package.** `bf` resolves to an unrelated package on npm ("bufferfile"), so the documented `deno run -A npm:bf …` / `bunx bf …` forms fail when run cold (outside a project that already has `@barefootjs/cli` installed and exposing the local `bf` bin).

This PR fixes the package reference and adopts `deno x` for the Deno path.

### Changes

- **`commandsFor('deno').exec`** now emits `deno x npm:<pkg>` (Deno 2.6+, defaults to `--allow-all`) instead of `deno run -A npm:<pkg>`. Generated Deno project scripts (`wrangler dev`/`deploy`) follow suit.
- **All runner-prefixed one-shot forms** (`npx` / `bunx` / `pnpm dlx` / `yarn dlx` / `deno x`) now reference `@barefootjs/cli` instead of `bf`:
  - `PackageManagerTabs` component (dlx + create deno branches)
  - 58 `ui.barefootjs.dev` component pages
  - the agent skill (`SKILL.md`)
  - `site/ui/README.md`
- Bare `bf <cmd>` forms (local-bin invocations after install) are **left untouched** — `bf` is the correct bin name there.
- Updated `pm.test.ts`, `deno-smoke.ts`, and the `installation-tabs` e2e spec.
- Added a changeset.

### ⚠️ Compatibility note

Switching the Deno path to `deno x` raises the minimum Deno version for **generated projects** to **2.6+** (the `deno x` subcommand does not exist before 2.6).

### Verification

Tested end-to-end on a freshly downloaded Deno 2.6.3:

- `deno x npm:bf …` → fails (resolves unrelated `bf` package, no bins) — confirms the bug.
- `deno x npm:@barefootjs/cli add card` → scaffolds + writes `components/ui/card/index.tsx` ✅
- `deno x npm:create-barefootjs <dir>` → scaffolds an app ✅
- `pm.test.ts` (38) + `init-gate.test.ts` (3) green; `deno-smoke.ts` green under Deno 2.6.3.

(The pre-existing `@barefootjs/jsx` module-resolution failures in the `debug-*` CLI tests are unrelated — they require the workspace `jsx` package to be built.)

https://claude.ai/code/session_01XzdZ458Sg7EsV7NSdeM39M

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzdZ458Sg7EsV7NSdeM39M)_