### PR TITLE
test(adapters): honour componentName in SSR test-renders; graduate props-reactivity on Go

### DIFF
--- a/.changeset/gallant-lovelace-componentname.md
+++ b/.changeset/gallant-lovelace-componentname.md
@@ -1,0 +1,13 @@
+---
+"@barefootjs/go-template": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+---
+
+Honour the fixture `componentName` in the Go / Mojolicious / Xslate SSR test-render harnesses, and graduate the `props-reactivity-comparison` conformance fixture on the Go adapter.
+
+The three SSR test-renderers picked their entry-point IR by default-export → first-exported → first IR, ignoring the requested `componentName`. For a multi-export source (`ReactiveProps.tsx` exports both `ReactiveProps` and `PropsReactivityComparison`) this always rendered the first export, so the `PropsReactivityComparison` fixture compared the wrong component against the Hono reference. Each renderer now selects the IR whose `componentName` matches the requested name first (mirroring the Hono reference's selection), falling back to the previous heuristics for single-export sources.
+
+With the correct component selected, `props-reactivity-comparison` renders byte-for-byte against the Hono reference on **Go** (the generated child constructors compute the `displayValue = props.value * 10` memo from the passed prop), so it is unskipped there.
+
+It stays skipped on **Mojolicious / Xslate**: the child memo `displayValue = props.value * 10` is prop-derived, so `extractSsrDefaults` yields `null` and the Perl SSR model — which seeds child memos from those static defaults — never declares `$displayValue` (Kolon renders it empty; Mojo aborts under strict mode). The skip rationales are refreshed to describe this real failure mode, and the stale `toggle-shared` / `children-jsx-expression` rationales are corrected to match current behaviour (Go drops a hoisted `children={<span/>}` body rather than emitting it as literal text; `toggle-shared`'s loop-child slice types as `[]any` not `[]ToggleItemInput`). Hono reference snapshots are unchanged.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -37,34 +37,38 @@ runAdapterConformanceTests({
   skipJsx: [
     // #1244 stress catalog (#1326): `children={<span/>}` — the IR
     // hoists the span with `needsScope: true` so the Hono reference
-    // emits `bf-s` on the inner `<span>`. The Go adapter renders the
-    // span up front as a compile-time HTML fragment containing the
-    // `{{bfScopeAttr .}}` action, then passes it via `template.HTML`
-    // through the parent's `{{.Children}}` interpolation — but
-    // `template.HTML` is marked-as-safe-output, not recursively
-    // parsed, so the action survives as literal text in the rendered
-    // HTML. Fixing this requires either (a) re-emitting the inner
-    // span as its own named template definition the outer template
-    // can pass its struct to, or (b) embedding the resolved scope ID
-    // at compile time. Neither lands in this PR; the Mojo sibling
-    // case is handled by routing the hoisted JSX through the same
-    // `begin %>…<% end` capture as nested children (see #1326 fix).
+    // emits `bf-s` on the inner `<span>`. The Go adapter has no path to
+    // render a hoisted-JSX child handed in through the `children`
+    // attribute, so the child is DROPPED: the parent renders
+    // `<div bf-s="test_s0"></div>` with an empty body (verified — no
+    // compile error, no literal `{{bfScopeAttr}}` text either; that
+    // older literal-survives-in-output failure mode no longer occurs).
+    // Closing the gap needs the inner span re-emitted as its own named
+    // template definition the outer template can pass its struct to, or
+    // the resolved scope id embedded at compile time. Neither lands
+    // here; the Mojo / Xslate siblings already pass by routing the
+    // hoisted JSX through the same nested-children capture.
     'children-jsx-expression',
-    // #1335: fragment-wrapped form of the same shape. Now that the IR
-    // unwraps `<><span/></>` into the bare-element form, the Go adapter
-    // hits the identical `template.HTML` interpolation gap as
-    // `children-jsx-expression` above.
+    // #1335: fragment-wrapped form of the same shape. Once the IR
+    // unwraps `<><span/></>` into the bare-element form the Go adapter
+    // hits the identical drop as `children-jsx-expression` above.
     'fragment-wrapped-children-jsx-expression',
-    // Shared-component multi-component fixtures (#1466). Boolean
-    // attribute divergence is now collapsed by `normalizeHTML`, so
-    // single-root variants (`conditional-return-*`, `form`, `portal`,
-    // `reactive-props`) participate again. These two still diverge
-    // because the harness's child renderer pins child `bf-s` to a
-    // `test_<sN>` literal rather than `<ChildName>_<id>_<sN>`. Same
-    // class of test-harness scope-id plumbing the `componentName`
-    // option fixed on the Hono side. Separate follow-up.
+    // `toggle-shared`: the parent maps a `ToggleItemProps[]` prop into
+    // sibling `ToggleItem` children inside a keyed `.map`. The Go
+    // child-slice init types the loop input as `[]any` rather than
+    // `[]ToggleItemInput`, so the generated `NewToggleProps` struct
+    // literal fails to compile (`cannot use []any{…} as
+    // []ToggleItemInput value in struct literal`). Separate follow-up —
+    // needs the loop-child init to emit the typed element slice, plus
+    // per-item `defaultOn` seeding and the `data-key` attribute shape.
+    //
+    // `props-reactivity-comparison` graduated: the Go test-render now
+    // honours the fixture's `componentName` (`PropsReactivityComparison`,
+    // the second export of `ReactiveProps.tsx`) instead of always
+    // rendering the first export, and the generated child constructors
+    // compute the `displayValue = props.value * 10` memo from the
+    // passed prop — so SSR matches Hono byte-for-byte.
     'toggle-shared',
-    'props-reactivity-comparison',
   ],
   // Per-fixture build-time contracts for shapes the Go template
   // adapter intentionally refuses to lower. Lives here (not on the

--- a/packages/adapter-go-template/src/test-render.ts
+++ b/packages/adapter-go-template/src/test-render.ts
@@ -59,10 +59,17 @@ export interface RenderOptions {
   props?: Record<string, unknown>
   /** Additional component files (filename → source) */
   components?: Record<string, string>
+  /**
+   * Explicit component to render when `source` declares multiple
+   * exports (e.g. `ReactiveProps.tsx` → `PropsReactivityComparison`).
+   * Mirrors the Hono reference's `componentName`; omitted for
+   * single-export fixtures, which fall back to the default/first export.
+   */
+  componentName?: string
 }
 
 export async function renderGoTemplateComponent(options: RenderOptions): Promise<string> {
-  const { source, adapter, props, components } = options
+  const { source, adapter, props, components, componentName: requestedName } = options
 
   if (!adapter.generateTypes) {
     throw new Error('Go Template adapter must implement generateTypes()')
@@ -139,7 +146,13 @@ export async function renderGoTemplateComponent(options: RenderOptions): Promise
   const irFiles = result.files.filter(f => f.type === 'ir')
   if (irFiles.length === 0) throw new Error('No IR output (set outputIR: true)')
   const irs = irFiles.map(f => JSON.parse(f.content) as ComponentIR)
+  // Explicit `componentName` wins (multi-export sources pin which export
+  // is the render target); otherwise default-export, then first inline-
+  // exported, then first IR. Mirrors the Hono reference's selection so
+  // multi-component fixtures (e.g. `ReactiveProps.tsx`) render the same
+  // export across adapters.
   const ir =
+    (requestedName ? irs.find(i => i.metadata.componentName === requestedName) : undefined) ??
     irs.find(i => i.metadata.hasDefaultExport) ??
     irs.find(i => i.metadata.isExported) ??
     irs[0]

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -22,13 +22,32 @@ runAdapterConformanceTests({
     // template reads a stash key that's never seeded. Implemented on Go; the
     // Perl stash-seed path is a follow-up port, so Mojo stays skipped (#1297).
     'context-provider',
-    // Multi-component shared fixtures with per-item loop state. The child
-    // scope-id plumbing is now fixed (children derive `<parentScope>_<sN>`
-    // from `$bf->_scope_id` in `test-render.ts`, which unblocked
-    // `reactive-props`); these two still diverge on additional per-item
-    // loop-state seeding the Mojo harness doesn't yet replicate. (xslate
-    // skips the same pair.)
+    // `toggle-shared`: the parent maps a `ToggleItemProps[]` prop into
+    // sibling `ToggleItem` children inside a keyed `.map`. Each child's
+    // `on = props.defaultOn ?? false` signal is never seeded into the
+    // loop-child stash, so the rendered child template trips Perl strict
+    // mode (`Global symbol "$on" requires explicit package name`). The
+    // harness child renderer forwards only the explicitly-passed props;
+    // it does not run the `_derive_stash_from_defaults` seeding the
+    // production runtime applies. Plus the loop-child scope id is
+    // `toggle_item_<rand>` (snake-case template name) rather than the
+    // `ToggleItem_*` PascalCase the reference pins, and the `key=` →
+    // `data-key` attribute isn't emitted. Separate follow-up. (xslate
+    // skips this for the same reasons.)
     'toggle-shared',
+    // `props-reactivity-comparison` (the `PropsReactivityComparison`
+    // export of `ReactiveProps.tsx`): componentName selection is now
+    // honoured (the test-render picks the requested export), but the
+    // child `PropsStyleChild` has a `displayValue = props.value * 10`
+    // memo. `extractSsrDefaults` cannot statically evaluate a
+    // prop-derived expression (it yields `null`), and the Perl SSR model
+    // seeds child memos from those *static* defaults — so `$displayValue`
+    // is never declared and the child render aborts under strict mode.
+    // Go matches only because it generates a child constructor that
+    // computes the memo from the passed prop at render time; the Perl
+    // adapters have no equivalent runtime memo-init in the static path
+    // (an opt-in `signal_init` sub would be required). (xslate skips this
+    // for the same reason.)
     'props-reactivity-comparison',
   ],
   // Per-fixture build-time contracts for shapes the Mojo adapter

--- a/packages/adapter-mojolicious/src/test-render.ts
+++ b/packages/adapter-mojolicious/src/test-render.ts
@@ -89,10 +89,17 @@ export interface RenderOptions {
   props?: Record<string, unknown>
   /** Additional component files (filename → source) */
   components?: Record<string, string>
+  /**
+   * Explicit component to render when `source` declares multiple
+   * exports (e.g. `ReactiveProps.tsx` → `PropsReactivityComparison`).
+   * Mirrors the Hono reference's `componentName`; omitted for
+   * single-export fixtures, which fall back to the default/first export.
+   */
+  componentName?: string
 }
 
 export async function renderMojoComponent(options: RenderOptions): Promise<string> {
-  const { source, adapter, props, components } = options
+  const { source, adapter, props, components, componentName: requestedName } = options
 
   // Compile child components first
   const childTemplates: Map<string, { template: string; ir: ComponentIR }> = new Map()
@@ -152,7 +159,12 @@ export async function renderMojoComponent(options: RenderOptions): Promise<strin
   const irFiles = result.files.filter(f => f.type === 'ir')
   if (irFiles.length === 0) throw new Error('No IR output (set outputIR: true)')
   const irs = irFiles.map(f => JSON.parse(f.content) as ComponentIR)
+  // Explicit `componentName` wins (multi-export sources pin the render
+  // target); otherwise default-export, first inline-exported, first IR.
+  // Mirrors the Hono reference so multi-component fixtures render the
+  // same export across adapters.
   const ir =
+    (requestedName ? irs.find(i => i.metadata.componentName === requestedName) : undefined) ??
     irs.find(i => i.metadata.hasDefaultExport) ??
     irs.find(i => i.metadata.isExported) ??
     irs[0]

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -37,13 +37,27 @@ runAdapterConformanceTests({
     // template reads a stash key that's never seeded. Implemented on Go; the
     // Perl stash-seed path is a follow-up port, so Xslate stays skipped (#1297).
     'context-provider',
-    // Multi-component shared-state pairs whose children render inside a keyed
-    // `.map` (loop children, no `_bf_slot`): the test harness derives a
-    // non-deterministic `<child>_<rand>` scope id instead of the canonical
-    // `<ChildName>_*` the reference HTML pins, and per-item loop state isn't
-    // seeded server-side. Harness-level scope-id plumbing; single-component
-    // `reactive-props` passes. (Same pair mojo skips.)
+    // `toggle-shared`: the parent maps a `ToggleItemProps[]` prop into
+    // sibling `ToggleItem` children inside a keyed `.map`. Three gaps
+    // remain (same as mojo): the loop-child `on = props.defaultOn ??
+    // false` signal isn't seeded server-side (so every item renders OFF
+    // instead of honouring per-item `defaultOn`), the child scope id is
+    // the snake-case `toggle_item_<rand>` rather than the `ToggleItem_*`
+    // PascalCase the reference pins, and `key=` → `data-key` isn't
+    // emitted. Kolon resolves the unseeded vars to nil rather than
+    // aborting, so this surfaces as a render mismatch (not a hard error).
+    // Separate follow-up.
     'toggle-shared',
+    // `props-reactivity-comparison` (the `PropsReactivityComparison`
+    // export of `ReactiveProps.tsx`): componentName selection is now
+    // honoured, but the child `PropsStyleChild`'s `displayValue =
+    // props.value * 10` memo has no static SSR default
+    // (`extractSsrDefaults` → `null` for a prop-derived expression) and
+    // the Perl SSR model seeds child memos from static defaults. Kolon
+    // renders the unseeded `$displayValue` as empty, so `child-computed-
+    // value` is blank where Hono / Go emit `10` (Go computes it in a
+    // generated child constructor — the Perl static path has no
+    // equivalent). (Same reason mojo skips.)
     'props-reactivity-comparison',
     // (`kbd` is not skipped here — it's a BF101 refusal pinned in
     // `expectedDiagnostics` below, not a render-mismatch.)

--- a/packages/adapter-xslate/src/test-render.ts
+++ b/packages/adapter-xslate/src/test-render.ts
@@ -87,10 +87,17 @@ export interface RenderOptions {
   props?: Record<string, unknown>
   /** Additional component files (filename → source) */
   components?: Record<string, string>
+  /**
+   * Explicit component to render when `source` declares multiple
+   * exports (e.g. `ReactiveProps.tsx` → `PropsReactivityComparison`).
+   * Mirrors the Hono reference's `componentName`; omitted for
+   * single-export fixtures, which fall back to the default/first export.
+   */
+  componentName?: string
 }
 
 export async function renderXslateComponent(options: RenderOptions): Promise<string> {
-  const { source, adapter, props, components } = options
+  const { source, adapter, props, components, componentName: requestedName } = options
 
   // Compile child components first.
   //
@@ -142,7 +149,12 @@ export async function renderXslateComponent(options: RenderOptions): Promise<str
   const irFiles = result.files.filter(f => f.type === 'ir')
   if (irFiles.length === 0) throw new Error('No IR output (set outputIR: true)')
   const irs = irFiles.map(f => JSON.parse(f.content) as ComponentIR)
+  // Explicit `componentName` wins (multi-export sources pin the render
+  // target); otherwise default-export, first inline-exported, first IR.
+  // Mirrors the Hono reference so multi-component fixtures render the
+  // same export across adapters.
   const ir =
+    (requestedName ? irs.find(i => i.metadata.componentName === requestedName) : undefined) ??
     irs.find(i => i.metadata.hasDefaultExport) ??
     irs.find(i => i.metadata.isExported) ??
     irs[0]


### PR DESCRIPTION
## Goal

Continue the PR #1768 audit of the `skipJsx` / `expectedDiagnostics` sets in the three SSR adapter conformance suites (go-template / mojolicious / xslate), driving them toward Hono parity. Each remaining `skipJsx` fixture was unskipped, measured against **real engine rendering**, and either graduated via a fix or left skipped with a refreshed, accurate rationale.

Verification: real Go 1.25.6 (`PATH=/usr/local/go/bin GOTOOLCHAIN=go1.25.6`), real Mojolicious 9.46, real Text::Xslate v3.5.9. Hono reference snapshots unchanged throughout.

## Change

The three SSR test-renderers picked their entry-point IR by default-export → first-exported → first IR, **ignoring the requested `componentName`**. For a multi-export source (`ReactiveProps.tsx` exports both `ReactiveProps` and `PropsReactivityComparison`) this always rendered the first export, so `props-reactivity-comparison` compared the wrong component against the Hono reference. Each renderer now selects the IR whose `componentName` matches the requested name first (mirroring the Hono reference), falling back to the previous heuristics for single-export sources.

- **`props-reactivity-comparison` → graduated on Go.** With the correct component selected it renders byte-for-byte against Hono (the generated child constructors compute the `displayValue = props.value * 10` memo from the passed prop).

## Skips audited and left skipped (rationales refreshed to match reality)

- **`props-reactivity-comparison` (Mojo / Xslate)** — the child memo `displayValue = props.value * 10` is prop-derived, so `extractSsrDefaults` yields `null` and the Perl SSR model (which seeds child memos from static defaults) never declares `$displayValue`. Kolon renders it empty; Mojo aborts under strict mode. Go matches only because it generates a child constructor computing the memo at render time. The old rationale wrongly blamed "per-item loop-state seeding" (this fixture has no loop).
- **`toggle-shared` (all three)** — parent maps a `ToggleItemProps[]` into sibling `ToggleItem`s inside a keyed `.map`. Go types the loop-child slice as `[]any` not `[]ToggleItemInput` (struct-literal compile error); Mojo/Xslate never seed the child `on = props.defaultOn ?? false` signal (strict-mode abort / empty render), plus the loop-child scope id is snake-case `toggle_item_<rand>` not `ToggleItem_*` and `key=` → `data-key` isn't emitted. Multiple independent gaps — separate follow-up.
- **`children-jsx-expression` / `fragment-wrapped-children-jsx-expression` (Go)** — Go drops a hoisted `children={<span/>}` body (renders an empty `<div>`); the old rationale's "survives as literal text" failure mode no longer occurs. Mojo/Xslate already pass these.
- **`context-provider` (Mojo / Xslate)** — unchanged; existing rationale (#1297, Perl stash-seed port is a follow-up) is still accurate.

## Test status (all local, real engines)

- go-template: **465 pass / 3 skip / 0 fail** (+1 vs base — props-reactivity graduated)
- mojolicious: 422 pass / 5 skip / 0 fail
- xslate: 300 pass / 5 skip / 0 fail
- tsc: clean on the three adapter packages' `test-render.ts`

True constraints (prop-derived child memos, loop-child typed slices, Perl SSR context) remain skipped with refreshed rationales. Hono reference snapshots unchanged.

https://claude.ai/code/session_01UJmwXazkaukGZyNbq4khPU

---
_Generated by [Claude Code](https://claude.ai/code/session_01UJmwXazkaukGZyNbq4khPU)_