### PR TITLE
test(adapters): graduate children-jsx-expression on Go (hoisted JSX children)

### DIFF
--- a/.changeset/go-hoisted-jsx-children.md
+++ b/.changeset/go-hoisted-jsx-children.md
@@ -1,0 +1,9 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Render hoisted `children={<…/>}` JSX on the Go template adapter, graduating the `children-jsx-expression` and `fragment-wrapped-children-jsx-expression` conformance fixtures to Hono parity.
+
+A `children` value passed as a JSX-expression attribute (`<Box children={<span>x</span>} />`) lands as a `jsx-children` prop, and its root carries `needsScope: true`. The Go adapter previously had no path to render such a hoisted child — it was dropped, so the parent rendered an empty `<div bf-s="…"></div>`.
+
+The adapter now treats a `jsx-children` prop as the child slot's effective children when no nested children exist, and bakes them into the child's `Children` input. Because the hoisted root's `bf-s` must resolve to the **parent** scope at render time (mirroring the client `__BF_PARENT_SCOPE__` placeholder and Mojo's begin/end capture), the bake splices the runtime parent `scopeID` into the rendered fragment (`extractScopedHtmlChildren` → `template.HTML("<span bf-s=\"" + scopeID + "\">x</span>")`) rather than emitting a static string. Genuinely dynamic fragments (surviving `{{…}}` actions) stay on the existing drop path. Hono reference snapshots are unchanged.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -35,24 +35,13 @@ runAdapterConformanceTests({
   // `BF104` at build time instead of silently emitting invalid
   // template syntax (#1266).
   skipJsx: [
-    // #1244 stress catalog (#1326): `children={<span/>}` — the IR
-    // hoists the span with `needsScope: true` so the Hono reference
-    // emits `bf-s` on the inner `<span>`. The Go adapter has no path to
-    // render a hoisted-JSX child handed in through the `children`
-    // attribute, so the child is DROPPED: the parent renders
-    // `<div bf-s="test_s0"></div>` with an empty body (verified — no
-    // compile error, no literal `{{bfScopeAttr}}` text either; that
-    // older literal-survives-in-output failure mode no longer occurs).
-    // Closing the gap needs the inner span re-emitted as its own named
-    // template definition the outer template can pass its struct to, or
-    // the resolved scope id embedded at compile time. Neither lands
-    // here; the Mojo / Xslate siblings already pass by routing the
-    // hoisted JSX through the same nested-children capture.
-    'children-jsx-expression',
-    // #1335: fragment-wrapped form of the same shape. Once the IR
-    // unwraps `<><span/></>` into the bare-element form the Go adapter
-    // hits the identical drop as `children-jsx-expression` above.
-    'fragment-wrapped-children-jsx-expression',
+    // `children-jsx-expression` / `fragment-wrapped-children-jsx-expression`
+    // graduated: `children={<span/>}` hoists the span with `needsScope:
+    // true`, so it lands as a `jsx-children` prop rather than nested
+    // children. The adapter now bakes that fragment into the child slot's
+    // `Children` with the runtime parent scopeID spliced into the root
+    // `bf-s` (`extractScopedHtmlChildren`), matching Hono / Mojo / Xslate.
+    //
     // `toggle-shared`: the parent maps a `ToggleItemProps[]` prop into
     // sibling `ToggleItem` children inside a keyed `.map`. The Go
     // child-slice init types the loop input as `[]any` rather than
@@ -1214,6 +1203,33 @@ export function Page() {
       const types = adapter.generateTypes(ir)!
       expect(types).not.toContain('Children:')
       expect(types).not.toContain('template.HTML')
+    })
+
+    test('bakes hoisted children={<span/>} with the parent scopeID spliced into bf-s (#1326 / #1335)', () => {
+      // `children` passed as an attribute lands as a `jsx-children` prop and
+      // its span carries `needsScope: true`. The root `bf-s` must resolve to
+      // the *parent* scope at render time, so the bake splices `scopeID`
+      // (matching the client `__BF_PARENT_SCOPE__` placeholder) rather than
+      // emitting a static string or dropping the child.
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+export function Host() { return <Box children={<span>x</span>} /> }
+function Box({ children }: { children: any }) { return <div>{children}</div> }
+`)
+      const types = adapter.generateTypes(ir)!
+      expect(types).toContain('Children: template.HTML("<span bf-s=\\"" + scopeID + "\\">x</span>")')
+      expect(types).toContain('"html/template"')
+    })
+
+
+    test('fragment-wrapped hoisted children bake to the same scoped shape (#1335)', () => {
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+export function Host() { return <Box children={<><span>x</span></>} /> }
+function Box({ children }: { children: any }) { return <div>{children}</div> }
+`)
+      const types = adapter.generateTypes(ir)!
+      expect(types).toContain('Children: template.HTML("<span bf-s=\\"" + scopeID + "\\">x</span>")')
     })
 
     test('drops dynamic children that would emit Go template actions', () => {

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -104,6 +104,16 @@ interface StaticChildInstance {
    *  through the parent's `{{.Children}}` read; those cases stay on
    *  the existing drop path. */
   childrenHtml: string | null
+  /** Go string-concat expression for hoisted-JSX children that carry a
+   *  `needsScope` root (`children={<span/>}` — #1326 / #1335). The root's
+   *  `bf-s` resolves to the PARENT scope (mirroring the client
+   *  `__BF_PARENT_SCOPE__` placeholder + Mojo's begin/end capture), so the
+   *  fragment can't bake to a static string — the runtime `scopeID` is
+   *  spliced in (`"<span bf-s=\"" + scopeID + "\">x</span>"`). Null when the
+   *  static `childrenHtml` path already covers the children, or when any
+   *  other template action survives (genuinely dynamic — kept on the drop
+   *  path). */
+  childrenScopedHtmlExpr: string | null
   /**
    * Context values from enclosing `<Ctx.Provider value>` ancestors
    * (`createContext` identifier → Go value literal), wired into this child
@@ -342,6 +352,11 @@ const GO_TEMPLATE_PRIMITIVES: Record<string, PrimitiveSpec> = {
 export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter, IRNodeEmitter<GoRenderCtx> {
   name = 'go-template'
   extension = '.tmpl'
+
+  // Sentinel marking a parent-scope `bf-s` slot inside a hoisted-JSX
+  // children bake (see `extractScopedHtmlChildren`). The token can't appear
+  // in real HTML text, so splitting on it is unambiguous.
+  private static readonly SCOPE_SENTINEL = '__BF_SCOPE_SENTINEL__'
   // Template-string target with no component layer: `bf build` emits a static
   // `barefoot-importmap.html` to `{{ template }}` into the page <head> (#1644).
   importMapInjection = 'html-snippet' as const
@@ -1764,6 +1779,11 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       } else if (child.childrenHtml !== null) {
         this.usesHtmlTemplate = true
         lines.push(`\t\t\tChildren: template.HTML(${JSON.stringify(child.childrenHtml)}),`)
+      } else if (child.childrenScopedHtmlExpr !== null) {
+        // Hoisted-JSX children with a needsScope root (#1326 / #1335): the
+        // root `bf-s` is the runtime parent scopeID, spliced into the bake.
+        this.usesHtmlTemplate = true
+        lines.push(`\t\t\tChildren: template.HTML(${child.childrenScopedHtmlExpr}),`)
       }
       lines.push(`\t\t}),`)
     }
@@ -1890,12 +1910,55 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    *     "drop children" fallback. Dynamic / component-bearing children
    *     stay on the drop path until a re-evaluation hook lands.
    */
+  /**
+   * Pull the IR nodes out of a `children={<…/>}` attribute (a `jsx-children`
+   * prop value). Empty when the component takes no such prop. (#1326 / #1335)
+   */
+  private jsxChildrenPropNodes(props: IRProp[]): IRNode[] {
+    for (const p of props) {
+      if (p.value.kind === 'jsx-children') return p.value.children
+    }
+    return []
+  }
+
   private extractHtmlChildren(children: IRNode[]): string | null {
     if (children.length === 0) return null
     if (children.every(c => c.type === 'text')) return null
     const html = this.renderChildren(children)
     if (html.includes('{{')) return null
     return html
+  }
+
+  /**
+   * Build a Go string-concat expression for hoisted-JSX children whose root
+   * carries `needsScope` (`children={<span/>}` — #1326 / #1335). Such roots
+   * render in the PARENT's scope, so their `bf-s` is the runtime parent
+   * `scopeID`, not a bake-time constant. We render the fragment, swap the
+   * parent-scope hydration marker for a sentinel, and splice `scopeID` back
+   * in. Returns null when the plain static `childrenHtml` path already
+   * applies, or when any other template action survives (genuinely dynamic —
+   * those stay on the drop path).
+   */
+  private extractScopedHtmlChildren(children: IRNode[]): string | null {
+    if (children.length === 0) return null
+    if (children.every(c => c.type === 'text')) return null
+    const html = this.renderChildren(children)
+    // The needsScope marker renders parent-scope hydration attrs; in a
+    // hoisted fragment every needsScope root resolves to the parent scopeID,
+    // so collapse the whole marker to a bare `bf-s` sentinel (the empty
+    // bf-h / bf-m attrs are dropped — same shape the client emits).
+    const marker = this.renderScopeMarker('.ScopeID')
+    const withSentinel = html
+      .split(marker)
+      .join(`bf-s="${GoTemplateAdapter.SCOPE_SENTINEL}"`)
+    // No sentinel → no needsScope root → the static childrenHtml path covers it.
+    if (!withSentinel.includes(GoTemplateAdapter.SCOPE_SENTINEL)) return null
+    // Any surviving action means the fragment is genuinely dynamic.
+    if (withSentinel.includes('{{')) return null
+    return withSentinel
+      .split(GoTemplateAdapter.SCOPE_SENTINEL)
+      .map(seg => JSON.stringify(seg))
+      .join(' + scopeID + ')
   }
 
   private collectStaticChildInstancesRecursive(
@@ -1920,13 +1983,21 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       // Skip components inside loops (handled by nestedComponents)
       if (comp.name !== 'Portal' && !inLoop && comp.slotId) {
         const suffix = slotIdToFieldSuffix(comp.slotId)
+        // Children handed in as a `children={<…/>}` attribute (#1326 / #1335)
+        // land as a `jsx-children` prop rather than nested between the tags;
+        // treat them as the child's effective children when no nested ones
+        // exist, so the bake paths below see them.
+        const effectiveChildren = comp.children.length > 0
+          ? comp.children
+          : this.jsxChildrenPropNodes(comp.props)
         result.push({
           name: comp.name,
           slotId: comp.slotId,
           props: comp.props,
           fieldName: `${comp.name}${suffix}`,
-          childrenText: this.extractTextChildren(comp.children),
-          childrenHtml: this.extractHtmlChildren(comp.children),
+          childrenText: this.extractTextChildren(effectiveChildren),
+          childrenHtml: this.extractHtmlChildren(effectiveChildren),
+          childrenScopedHtmlExpr: this.extractScopedHtmlChildren(effectiveChildren),
           contextBindings: providerCtx.size > 0 ? providerCtx : undefined,
         })
       }


### PR DESCRIPTION
## Goal

Continue the PR #1768 effort: drive the SSR adapter (`go-template` / `mojolicious` / `xslate`) `skipJsx` + `expectedDiagnostics` sets toward **Hono parity**, one fixture at a time, each unskipped → measured against the **real engine** → fixed and graduated, or left skipped with a refreshed rationale. This is the first in a stack of increments.

Verification engines: real Go 1.25.6 (`PATH=/usr/local/go/bin GOTOOLCHAIN=go1.25.6`), real Mojolicious 9.35, real Text::Xslate v3.5.9. Hono reference snapshots unchanged.

## Increment: `children-jsx-expression` + `fragment-wrapped-children-jsx-expression` — ✅ Go

A `children` value passed as a JSX-expression attribute (`<Box children={<span>x</span>} />`) lands as a `jsx-children` prop, and its root carries `needsScope: true`. The Go adapter previously had no path to render such a hoisted child — it was dropped, so the parent rendered an empty `<div bf-s="…"></div>` (the skip's old rationale, re-measured and confirmed before the fix).

The adapter now:
- treats a `jsx-children` prop as the child slot's effective children when no nested children exist (`jsxChildrenPropNodes`), and
- bakes them into the child's `Children` input. Because the hoisted root's `bf-s` must resolve to the **parent** scope at render time (mirroring the client `__BF_PARENT_SCOPE__` placeholder + Mojo's begin/end capture), `extractScopedHtmlChildren` splices the runtime parent `scopeID` into the rendered fragment — `Children: template.HTML("<span bf-s=\"" + scopeID + "\">x</span>")` — rather than baking a static string. Genuinely dynamic fragments (surviving `{{…}}` actions) stay on the existing drop path.

Both fixtures now render byte-for-byte against the Hono reference on Go.

## Test status (real Go 1.25.6)
- `adapter-go-template`: **469 pass / 3 skip / 0 fail** (was 463/3/2 — the 2 prior failures were cold-cache timeouts; +2 conformance + 2 new adapter unit tests)
- `tsc` clean on `adapter-go-template`

Remaining Go skip: `toggle-shared` (next in the stack).

https://claude.ai/code/session_01LaP8KV6yASUT37PzDMvYbW

---
_Generated by [Claude Code](https://claude.ai/code/session_01LaP8KV6yASUT37PzDMvYbW)_