### PR TITLE
Reactive instrumentation sink for bf debug profile (#1690, SR1/SR8)

### DIFF
--- a/.changeset/profiler-sr1-instrumentation.md
+++ b/.changeset/profiler-sr1-instrumentation.md
@@ -1,0 +1,18 @@
+---
+"@barefootjs/client": minor
+---
+
+Add dev-only reactive instrumentation hooks for `bf debug profile` (#1690, SR1).
+
+The runtime gains a single, gated measurement sink installed via
+`setProfilerSink(sink | null)`. When a sink is set, the reactive choke points in
+`reactive.ts` emit events — `signalSet`, `subscribeAdd`/`subscribeRemove`,
+`effectCreate`/`effectEnter`/`effectExit`/`effectDispose`, and
+`batchBegin`/`batchFlush` — carrying node ids, timing, and batch state. A memo's
+effect-run and its private signal-set share one id so the profiler can collapse
+them into a single node.
+
+The sink is null by default (production), so every choke point stays a single
+null-check branch with no allocation and no behavior change — reactive
+semantics are unaffected (SR8). The `ProfilerEventSink` / `SubscriberKind` types
+and `setProfilerSink` are exported from `@barefootjs/client`.

--- a/packages/client/__tests__/profiler-instrumentation.test.ts
+++ b/packages/client/__tests__/profiler-instrumentation.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Dev-only reactive instrumentation (SR1 / SR8, #1690).
+ *
+ * Verifies that `setProfilerSink` observes the reactive choke points without
+ * changing semantics, that a memo's effect-run and signal-set share one id
+ * (so the IR join can collapse them), and that clearing the sink stops events
+ * (the production default is zero events).
+ */
+
+import { describe, test, expect, afterEach } from 'bun:test'
+import {
+  createSignal,
+  createEffect,
+  createMemo,
+  createRoot,
+  batch,
+  setProfilerSink,
+  type ProfilerEventSink,
+  type SubscriberKind,
+} from '../src/reactive'
+
+type Event = [string, ...unknown[]]
+
+function recorder(): { events: Event[]; sink: ProfilerEventSink } {
+  const events: Event[] = []
+  const sink: ProfilerEventSink = {
+    signalSet: (id, batched) => events.push(['signalSet', id, batched]),
+    subscribeAdd: (s, sub) => events.push(['subscribeAdd', s, sub]),
+    subscribeRemove: (s, sub) => events.push(['subscribeRemove', s, sub]),
+    effectCreate: (id, kind) => events.push(['effectCreate', id, kind]),
+    effectEnter: (id) => events.push(['effectEnter', id]),
+    effectExit: (id, dur) => events.push(['effectExit', id, dur]),
+    effectDispose: (id) => events.push(['effectDispose', id]),
+    batchBegin: (depth) => events.push(['batchBegin', depth]),
+    batchFlush: (n) => events.push(['batchFlush', n]),
+  }
+  return { events, sink }
+}
+
+const names = (events: Event[]) => events.map(e => e[0])
+
+afterEach(() => setProfilerSink(null))
+
+describe('reactive instrumentation (SR1)', () => {
+  test('signalSet fires on a real change, not on a no-op set', () => {
+    const { events, sink } = recorder()
+    setProfilerSink(sink)
+    const [, setCount] = createSignal(0)
+    setCount(1)
+    setCount(1) // Object.is bail — no event
+    expect(names(events).filter(n => n === 'signalSet')).toEqual(['signalSet'])
+    expect(events.find(e => e[0] === 'signalSet')![2]).toBe(false) // not batched
+  })
+
+  test('subscribeAdd fires when an effect reads a signal; effect enter/exit bracket the run', () => {
+    const { events, sink } = recorder()
+    setProfilerSink(sink)
+    const [count] = createSignal(0)
+    createEffect(() => { count() })
+    // create → enter → subscribeAdd (during the read) → exit
+    const order = names(events)
+    expect(order).toContain('effectCreate')
+    expect(order.indexOf('effectEnter')).toBeLessThan(order.indexOf('subscribeAdd'))
+    expect(order.indexOf('subscribeAdd')).toBeLessThan(order.indexOf('effectExit'))
+    const exit = events.find(e => e[0] === 'effectExit')!
+    expect(typeof exit[2]).toBe('number')
+    expect(exit[2] as number).toBeGreaterThanOrEqual(0)
+  })
+
+  test('effectCreate carries the right kind for effect / memo / root', () => {
+    const { events, sink } = recorder()
+    setProfilerSink(sink)
+    createEffect(() => {})
+    createMemo(() => 1)
+    createRoot(() => {})
+    const kinds = events.filter(e => e[0] === 'effectCreate').map(e => e[2] as SubscriberKind)
+    expect(kinds).toContain('effect')
+    expect(kinds).toContain('memo')
+    expect(kinds).toContain('root')
+  })
+
+  test("a memo's effect run and signal set share one id (IR-join collapse)", () => {
+    const { events, sink } = recorder()
+    setProfilerSink(sink)
+    const [count, setCount] = createSignal(1)
+    createMemo(() => count() * 2)
+    const memoCreate = events.find(e => e[0] === 'effectCreate' && e[2] === 'memo')!
+    const memoId = memoCreate[1] as string
+    // The memo's body wrote its private signal under the same id.
+    expect(events.some(e => e[0] === 'signalSet' && e[1] === memoId)).toBe(true)
+    expect(events.some(e => e[0] === 'effectEnter' && e[1] === memoId)).toBe(true)
+    // Recompute on dependency change re-enters under the same id.
+    const before = events.length
+    setCount(5)
+    expect(events.slice(before).some(e => e[0] === 'effectEnter' && e[1] === memoId)).toBe(true)
+  })
+
+  test('batch brackets writes with begin + a single flush', () => {
+    const { events, sink } = recorder()
+    setProfilerSink(sink)
+    const [, setA] = createSignal(0)
+    const [, setB] = createSignal(0)
+    createEffect(() => {}) // not subscribed; keep flush observable via counts
+    batch(() => { setA(1); setB(2) })
+    expect(names(events)).toContain('batchBegin')
+    // signalSet inside batch is flagged batched
+    expect(events.filter(e => e[0] === 'signalSet').every(e => e[2] === true)).toBe(true)
+  })
+
+  test('subscribeRemove fires when a disposed scope drops its edges', () => {
+    const { events, sink } = recorder()
+    setProfilerSink(sink)
+    const [count] = createSignal(0)
+    let dispose!: () => void
+    createRoot((d) => {
+      dispose = d
+      createEffect(() => { count() })
+    })
+    const before = events.length
+    dispose()
+    const after = events.slice(before)
+    expect(after.some(e => e[0] === 'subscribeRemove')).toBe(true)
+    expect(after.some(e => e[0] === 'effectDispose')).toBe(true)
+  })
+})
+
+describe('instrumentation is off by default (SR8)', () => {
+  test('clearing the sink stops events and never changes reactive results', () => {
+    const { events, sink } = recorder()
+    setProfilerSink(sink)
+    const [count, setCount] = createSignal(0)
+    const doubled = createMemo(() => count() * 2)
+    let seen = -1
+    createEffect(() => { seen = doubled() })
+    setCount(3)
+    expect(seen).toBe(6) // semantics intact while instrumented
+
+    setProfilerSink(null)
+    const mark = events.length
+    setCount(10)
+    expect(seen).toBe(20) // semantics intact after clearing
+    expect(events.length).toBe(mark) // no new events recorded
+  })
+})

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -11,11 +11,14 @@ export {
   onMount,
   untrack,
   batch,
+  setProfilerSink,
   type Reactive,
   type Signal,
   type Memo,
   type CleanupFn,
   type EffectFn,
+  type ProfilerEventSink,
+  type SubscriberKind,
 } from '@barefootjs/client/reactive'
 
 export { splitProps } from './split-props.ts'

--- a/packages/client/src/reactive.ts
+++ b/packages/client/src/reactive.ts
@@ -23,14 +23,73 @@ export type CleanupFn = () => void
 export type EffectFn = () => void | CleanupFn
 export type Memo<T> = Reactive<() => T>
 
+// -- Dev-only instrumentation (SR1 / SR8, #1690) ------------------------------
+//
+// A single, gated sink the reactive choke points call when profiling is on.
+// When `profilerSink` is null (the production default) every choke point is a
+// single null-check branch with no allocation — see `spec/profiler.md` SR8.
+// The sink, its state, and the identity bookkeeping all live in this module
+// because `reactive.ts` is published as one physical entry
+// (`@barefootjs/client/reactive`); splitting the sink into a sibling file
+// would bundle a second copy into this entry and break the live binding.
+
+export type SubscriberKind = 'effect' | 'memo' | 'root'
+
+/**
+ * Reactive measurement hooks. Every method is a measurement-only notification —
+ * implementations MUST NOT mutate reactive state or throw (a throw would change
+ * `set()`'s synchronous semantics). Ids are stable handles; `''` means the
+ * node was created while profiling was off. The compiler will later emit
+ * IR-aligned ids (SR3); until then ids are runtime-assigned counters.
+ */
+export interface ProfilerEventSink {
+  /** A signal's value changed (post `Object.is` bail). `batched` = inside `batch()`. */
+  signalSet(signalId: string, batched: boolean): void
+  /** A subscriber began reading a signal (dependency edge added). */
+  subscribeAdd(signalId: string, subscriberId: string): void
+  /** A subscriber stopped reading a signal (edge removed on re-run / dispose). */
+  subscribeRemove(signalId: string, subscriberId: string): void
+  /** An effect / memo / root scope was created. */
+  effectCreate(subscriberId: string, kind: SubscriberKind): void
+  /** An effect/memo body is about to run. */
+  effectEnter(subscriberId: string): void
+  /** An effect/memo body finished. `durationMs` is wall time. */
+  effectExit(subscriberId: string, durationMs: number): void
+  /** An effect / memo / root scope was disposed. */
+  effectDispose(subscriberId: string): void
+  /** A `batch()` block opened at the given (post-increment) depth. */
+  batchBegin(depth: number): void
+  /** A batch flush ran `flushed` effects. */
+  batchFlush(flushed: number): void
+}
+
+/** A signal's subscriber set, tagged with the signal's id for edge-removal events. */
+type SubscriberSet = Set<EffectContext> & { __bfSignalId?: string }
+
+let profilerSink: ProfilerEventSink | null = null
+let signalSeq = 0
+let subscriberSeq = 0
+
+/**
+ * Install (or clear) the dev-only reactive measurement sink. Pass `null` to
+ * disable. Calling this before a scenario runs lets `bf debug profile` collect
+ * the event stream; production code never calls it, so the sink stays null and
+ * the choke points stay free. See `spec/profiler.md`.
+ */
+export function setProfilerSink(sink: ProfilerEventSink | null): void {
+  profilerSink = sink
+}
+
 type EffectContext = {
   fn: EffectFn
   cleanup: CleanupFn | null
-  dependencies: Set<Set<EffectContext>>
+  dependencies: Set<SubscriberSet>
   owner: EffectContext | null   // Parent scope for hierarchical disposal
   children: EffectContext[]     // Owned child effects/roots
   disposed: boolean
   runCount: number              // Per-effect re-entry counter for circular dependency detection
+  id: string                    // Dev instrumentation id ('' when profiling is off)
+  kind: SubscriberKind          // effect | memo | root
 }
 
 let Owner: EffectContext | null = null
@@ -52,14 +111,19 @@ const PendingEffects = new Set<EffectContext>()
  * setCount(5)          // Update to 5
  * setCount(n => n + 1) // Update with function (becomes 6)
  */
-export function createSignal<T>(initialValue: T): Signal<T> {
+export function createSignal<T>(initialValue: T, __bfId?: string): Signal<T> {
   let value = initialValue
-  const subscribers = new Set<EffectContext>()
+  const subscribers: SubscriberSet = new Set<EffectContext>()
+  // Tag the subscriber set so edge-removal events (which only see the set) can
+  // name the signal. Resolved once per creation; '' when profiling is off.
+  const id = __bfId ?? (profilerSink ? `s${++signalSeq}` : '')
+  subscribers.__bfSignalId = id
 
   const get = () => {
     if (Listener) {
       subscribers.add(Listener)
       Listener.dependencies.add(subscribers)
+      if (profilerSink) profilerSink.subscribeAdd(id, Listener.id)
     }
     return value
   }
@@ -74,6 +138,8 @@ export function createSignal<T>(initialValue: T): Signal<T> {
     }
 
     value = newValue
+
+    if (profilerSink) profilerSink.signalSet(id, BatchDepth > 0)
 
     if (BatchDepth > 0) {
       for (const effect of subscribers) {
@@ -102,7 +168,7 @@ export function createSignal<T>(initialValue: T): Signal<T> {
  * })
  * setCount(1)  // Logs "count changed: 1"
  */
-export function createEffect(fn: EffectFn): void {
+export function createEffect(fn: EffectFn, __bfId?: string, __bfKind: SubscriberKind = 'effect'): void {
   // Note: Nested effects are now allowed. runEffect() properly saves/restores
   // prevEffect, so nested effects correctly track their own dependencies.
   // This enables synchronous component initialization in reconcileList.
@@ -115,7 +181,11 @@ export function createEffect(fn: EffectFn): void {
     children: [],
     disposed: false,
     runCount: 0,
+    id: __bfId ?? (profilerSink ? `e${++subscriberSeq}` : ''),
+    kind: __bfKind,
   }
+
+  if (profilerSink) profilerSink.effectCreate(effect.id, effect.kind)
 
   // Register with parent owner for hierarchical disposal
   if (Owner) Owner.children.push(effect)
@@ -139,6 +209,7 @@ function runEffect(effect: EffectContext): void {
 
   for (const dep of effect.dependencies) {
     dep.delete(effect)
+    if (profilerSink) profilerSink.subscribeRemove(dep.__bfSignalId ?? '', effect.id)
   }
   effect.dependencies.clear()
 
@@ -146,6 +217,9 @@ function runEffect(effect: EffectContext): void {
   const prevListener = Listener
   Owner = effect
   Listener = effect
+
+  const start = profilerSink ? performance.now() : 0
+  if (profilerSink) profilerSink.effectEnter(effect.id)
 
   try {
     const result = effect.fn()
@@ -156,6 +230,7 @@ function runEffect(effect: EffectContext): void {
     Owner = prevOwner
     Listener = prevListener
     effect.runCount--
+    if (profilerSink) profilerSink.effectExit(effect.id, performance.now() - start)
   }
 }
 
@@ -181,8 +256,11 @@ function disposeSubtree(effect: EffectContext): void {
 
   for (const dep of effect.dependencies) {
     dep.delete(effect)
+    if (profilerSink) profilerSink.subscribeRemove(dep.__bfSignalId ?? '', effect.id)
   }
   effect.dependencies.clear()
+
+  if (profilerSink) profilerSink.effectDispose(effect.id)
 
   effect.owner = null
 }
@@ -226,7 +304,11 @@ export function createRoot<T>(fn: (dispose: () => void) => T): T {
     children: [],
     disposed: false,
     runCount: 0,
+    id: profilerSink ? `r${++subscriberSeq}` : '',
+    kind: 'root',
   }
+
+  if (profilerSink) profilerSink.effectCreate(root.id, 'root')
 
   if (Owner) Owner.children.push(root)
 
@@ -249,7 +331,7 @@ export function createRoot<T>(fn: (dispose: () => void) => T): T {
  *
  * @returns A dispose function that stops the effect and removes it from all signal dependencies.
  */
-export function createDisposableEffect(fn: EffectFn): () => void {
+export function createDisposableEffect(fn: EffectFn, __bfId?: string): () => void {
   let disposed = false
 
   const effect: EffectContext = {
@@ -263,7 +345,11 @@ export function createDisposableEffect(fn: EffectFn): () => void {
     children: [],
     disposed: false,
     runCount: 0,
+    id: __bfId ?? (profilerSink ? `e${++subscriberSeq}` : ''),
+    kind: 'effect',
   }
+
+  if (profilerSink) profilerSink.effectCreate(effect.id, effect.kind)
 
   if (Owner) Owner.children.push(effect)
 
@@ -342,6 +428,7 @@ export function untrack<T>(fn: () => T): T {
  */
 export function batch<T>(fn: () => T): T {
   BatchDepth++
+  if (profilerSink) profilerSink.batchBegin(BatchDepth)
   try {
     return fn()
   } finally {
@@ -356,6 +443,7 @@ function flushEffects(): void {
   while (PendingEffects.size > 0) {
     const effects = [...PendingEffects]
     PendingEffects.clear()
+    if (profilerSink) profilerSink.batchFlush(effects.length)
     for (const effect of effects) {
       runEffect(effect)
     }
@@ -398,13 +486,17 @@ export function onMount(fn: () => void): void {
  * setCount(5)
  * doubled()    // 10
  */
-export function createMemo<T>(fn: () => T): Memo<T> {
-  const [value, setValue] = createSignal<T>(undefined as T)
+export function createMemo<T>(fn: () => T, __bfId?: string): Memo<T> {
+  // A memo is an effect that writes a private signal. Share one id across both
+  // so the profiler's IR join can collapse the effect-run + signal-set pair
+  // back into a single memo node (spec/profiler.md SR1).
+  const id = __bfId ?? (profilerSink ? `m${++subscriberSeq}` : '')
+  const [value, setValue] = createSignal<T>(undefined as T, id)
 
   createEffect(() => {
     const result = fn()
     setValue(() => result)
-  })
+  }, id, 'memo')
 
   return value
 }


### PR DESCRIPTION
**Stacked on #1770** (base: `claude/modest-ride-hpYIx`). Part of the `bf debug profile` design (#1690) — implements the **SR1** measurement substrate + **SR8** gating from `spec/profiler.md`.

## What

Adds a single, dev-only reactive measurement sink to the runtime. Installed via `setProfilerSink(sink | null)`; when set, the choke points in `packages/client/src/reactive.ts` emit events the profiler will consume.

Events: `signalSet`, `subscribeAdd`/`subscribeRemove`, `effectCreate`/`effectEnter`/`effectExit`/`effectDispose`, `batchBegin`/`batchFlush` — carrying node ids, wall-time durations, and batch state.

## Design notes

- **Single physical module.** Sink state lives in `reactive.ts` (not a sibling file) because it's published as one entry (`@barefootjs/client/reactive`); a separate file would bundle a second copy into this entry and break the live binding. `setProfilerSink` + `ProfilerEventSink`/`SubscriberKind` are re-exported from `@barefootjs/client`.
- **Memo collapse (SR1).** A memo is an effect writing a private signal. `createMemo` now shares one id across both, so the later IR join (SR4) collapses the effect-run + signal-set into a single memo node instead of double-counting.
- **Identity seam (for SR3).** `createSignal`/`createEffect`/`createMemo`/`createDisposableEffect` accept an optional compiler-assigned `__bfId`; until the compiler emits ids (next stack PR), a runtime counter fills in when profiling is active.
- **Zero production overhead (SR8).** The sink is null by default, so each choke point is one null-check branch with no allocation and no semantic change. Edge-removal events name their signal via an id tag on the subscriber set.

## Tests

`packages/client/__tests__/profiler-instrumentation.test.ts` — event firing per choke point, no-op `set` bail, memo id sharing, batch bracketing, dispose edge-removal, and that clearing the sink stops events while reactive results stay correct. Full client suite green (343 pass), typecheck clean, `reactive.js` builds with the new export.

## Stack

1. #1770 — design + SR5 budget + SR6 compile-diff + CLI
2. **this PR** — SR1 runtime instrumentation + SR8 gating
3. next — SR3 compiler turn markers + `__bfId` emission across all CSR handler paths
4. then — SR2/SR4 IR join + v1 analyses (hot subscribers / wasted re-runs / batch advisor)

https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN)_