### PR TITLE
test(adapters): graduate context-provider on Mojolicious + Xslate

### DIFF
--- a/.changeset/perl-context-provider.md
+++ b/.changeset/perl-context-provider.md
@@ -1,0 +1,17 @@
+---
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+"@barefootjs/perl": patch
+---
+
+Propagate SSR context (`<Ctx.Provider value>` → `useContext`) on the Mojolicious and Text::Xslate adapters, graduating the `context-provider` conformance fixture to Hono parity.
+
+Both adapters previously emitted a child template that read an un-seeded consumer variable (`$theme`), so the provider value never reached the descendant — the fixture was skipped (Go already implemented this in #1768; the Perl side was a deferred follow-up).
+
+The Perl runtime now mirrors the client `provideContext` / `useContext`:
+
+- `BarefootJS.pm` gains `provide_context` / `revoke_context` / `use_context`, backed by a package-level value stack. SSR rendering is synchronous and the provider's push/pop are perfectly balanced, so the stack always unwinds at the end of each provider subtree — and a package global (rather than `$c->stash` or the backend) is the one store reliably shared between a parent template and the child templates it renders via `render_child` (the Xslate backend runs with `c => undef`; the Mojo path lazily builds a backend per instance).
+- **Mojo**: `emitProvider` brackets the children with `<% bf->provide_context('Ctx', <value>); %>` … `<% bf->revoke_context('Ctx'); %>`, and each `useContext` consumer is seeded with `% my $x = bf->use_context('Ctx', <default>);`.
+- **Xslate**: same, using the inline `<: $bf.provide_context(...) :>` / `<: $bf.revoke_context(...) :>` form (both return `''`, so the interpolation emits nothing) and a `: my $x = $bf.use_context('Ctx', <default>);` line-statement seed.
+
+Verified end-to-end against real Mojolicious and Text::Xslate. Hono reference snapshots unchanged.

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -18,10 +18,12 @@ runAdapterConformanceTests({
   factory: () => new MojoAdapter(),
   render: renderMojoComponent,
   skipJsx: [
-    // SSR context propagation (`<Ctx.Provider value>` → `useContext`): the
-    // template reads a stash key that's never seeded. Implemented on Go; the
-    // Perl stash-seed path is a follow-up port, so Mojo stays skipped (#1297).
-    'context-provider',
+    // `context-provider` graduated: SSR context propagation now mirrors the
+    // client `provideContext` / `useContext`. `<Ctx.Provider value>` brackets
+    // its children with `bf->provide_context` / `bf->revoke_context` (a
+    // package-level value stack), and each `useContext` consumer is seeded at
+    // the top of its template with `% my $x = bf->use_context('Ctx', <default>)`.
+    // Renders byte-for-byte against Hono on real Mojolicious. (#1297)
     // `toggle-shared`: the parent maps a `ToggleItemProps[]` prop into
     // sibling `ToggleItem` children inside a keyed `.map`. Each child's
     // `on = props.defaultOn ?? false` signal is never seeded into the
@@ -395,6 +397,39 @@ function C({ value = '' }: { value?: string }) {
     // exactly like Hono's value="".
     expect(template).toContain('value="<%= $value %>"')
     expect(template).not.toContain('defined $value')
+  })
+})
+
+describe('MojoAdapter - SSR context propagation (#1297)', () => {
+  // `<Ctx.Provider value>` brackets its children with a provide/revoke pair
+  // on the shared package-level context stack; descendant `useContext`
+  // consumers read it during the same render (mirrors the client
+  // `provideContext` / `useContext`).
+  test('provider brackets children with provide_context / revoke_context', () => {
+    const { template } = compileAndGenerate(`
+'use client'
+import { createContext, useContext } from '@barefootjs/client'
+const ThemeContext = createContext('light')
+export function ThemeRoot() {
+  return <div><ThemeContext.Provider value="dark"><ThemeLabel /></ThemeContext.Provider></div>
+}
+function ThemeLabel() { const theme = useContext(ThemeContext); return <span>{theme}</span> }
+`)
+    expect(template).toContain("bf->provide_context('ThemeContext', 'dark');")
+    expect(template).toContain("bf->revoke_context('ThemeContext');")
+    // The provide precedes the child render, the revoke follows it.
+    expect(template.indexOf('provide_context')).toBeLessThan(template.indexOf('render_child'))
+    expect(template.indexOf('render_child')).toBeLessThan(template.indexOf('revoke_context'))
+  })
+
+  test('consumer seeds its local from use_context with the createContext default', () => {
+    const { template } = compileAndGenerate(`
+'use client'
+import { createContext, useContext } from '@barefootjs/client'
+const ThemeContext = createContext('light')
+export function ThemeLabel() { const theme = useContext(ThemeContext); return <span>{theme}</span> }
+`)
+    expect(template).toContain("% my $theme = bf->use_context('ThemeContext', 'light');")
   })
 })
 

--- a/packages/adapter-mojolicious/src/__tests__/mojo-streaming.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-streaming.test.ts
@@ -119,11 +119,14 @@ describe('MojoAdapter - Streaming SSR', () => {
     expect(output).toContain('Please wait...')
   })
 
-  test('renderNode dispatches provider type (transparent)', () => {
+  test('renderNode dispatches provider type (brackets children with provide/revoke)', () => {
+    // SSR context propagation (#1297): the provider is no longer transparent —
+    // it pushes its value before the children and pops it after so a
+    // descendant `useContext` consumer reads it during the same render.
     const providerNode = {
       type: 'provider' as const,
       contextName: 'ThemeContext',
-      valueProp: { name: 'value', value: 'dark', dynamic: false },
+      valueProp: { name: 'value', value: { kind: 'literal' as const, value: 'dark' } },
       children: [
         { type: 'text' as const, value: 'child content', loc: { file: '', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } } },
       ],
@@ -131,6 +134,8 @@ describe('MojoAdapter - Streaming SSR', () => {
     }
 
     const output = adapter.renderNode(providerNode)
-    expect(output).toBe('child content')
+    expect(output).toBe(
+      "<% bf->provide_context('ThemeContext', 'dark'); %>child content<% bf->revoke_context('ThemeContext'); %>",
+    )
   })
 })

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -50,6 +50,8 @@ import {
   augmentInheritedPropAccesses,
   parseRecordIndexAccess,
   evalStringArrayJoin,
+  collectContextConsumers,
+  type ContextConsumer,
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr } from './boolean-result'
 
@@ -338,7 +340,13 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       ? ''
       : this.generateScriptRegistrations(ir, options?.scriptBaseName)
 
-    const template = `${scriptReg}${templateBody}\n`
+    // SSR context consumers (`const x = useContext(Ctx)`): seed each local
+    // from the active provider value (or the `createContext` default) so the
+    // body's `$x` resolves. The provider side pushes the value via
+    // `emitProvider`; here the consumer reads it. (#1297)
+    const ctxSeed = this.generateContextConsumerSeed(ir)
+
+    const template = `${scriptReg}${ctxSeed}${templateBody}\n`
 
     // Merge collected errors into IR errors
     if (this.errors.length > 0) {
@@ -480,7 +488,61 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
   }
 
   emitProvider(node: IRProvider, _ctx: MojoRenderCtx, _emit: EmitIRNode<MojoRenderCtx>): string {
-    return this.renderChildren(node.children)
+    // SSR context propagation (#1297): push the provider value onto the
+    // shared controller-stash context stack, render the children (descendant
+    // `useContext` consumers read it via `bf->use_context`), then pop. The
+    // push/pop bracket the children in the same render so the value scopes
+    // exactly to the subtree — mirroring the client `provideContext`.
+    const value = this.providerValuePerl(node.valueProp)
+    const children = this.renderChildren(node.children)
+    const name = node.contextName
+    return (
+      `<% bf->provide_context('${name}', ${value}); %>` +
+      children +
+      `<% bf->revoke_context('${name}'); %>`
+    )
+  }
+
+  /** Lower a `<Ctx.Provider value>` value prop to a Perl expression. */
+  private providerValuePerl(valueProp: IRProvider['valueProp']): string {
+    const v = valueProp.value
+    if (v.kind === 'literal') {
+      return typeof v.value === 'string'
+        ? `'${v.value.replace(/[\\']/g, m => `\\${m}`)}'`
+        : String(v.value)
+    }
+    if (v.kind === 'expression') return this.convertExpressionToPerl(v.expr)
+    if (v.kind === 'template') return this.convertTemplateLiteralPartsToPerl(v.parts)
+    // Out-of-shape value (spread / jsx-children) — render as undef rather
+    // than emit invalid Perl; the consumer falls back to its default.
+    return 'undef'
+  }
+
+  /** Perl literal for a context-consumer's `createContext` default. */
+  private contextDefaultPerl(c: ContextConsumer): string {
+    const d = c.defaultValue
+    if (d === null || d === undefined) return 'undef'
+    if (typeof d === 'string') return `'${d.replace(/[\\']/g, m => `\\${m}`)}'`
+    if (typeof d === 'boolean') return d ? '1' : '0'
+    return String(d)
+  }
+
+  /**
+   * Emit one `% my $<local> = bf->use_context(...)` seed line per context
+   * consumer so the template body's bare `$<local>` resolves to the active
+   * provider value (or the `createContext` default). (#1297)
+   */
+  private generateContextConsumerSeed(ir: ComponentIR): string {
+    const consumers = collectContextConsumers(ir.metadata)
+    if (consumers.length === 0) return ''
+    return (
+      consumers
+        .map(
+          c =>
+            `% my $${c.localName} = bf->use_context('${c.contextName}', ${this.contextDefaultPerl(c)});`,
+        )
+        .join('\n') + '\n'
+    )
   }
 
   emitAsync(node: IRAsync, _ctx: MojoRenderCtx, _emit: EmitIRNode<MojoRenderCtx>): string {

--- a/packages/adapter-perl/lib/BarefootJS.pm
+++ b/packages/adapter-perl/lib/BarefootJS.pm
@@ -141,6 +141,45 @@ sub props_attr ($self) {
 }
 
 # ---------------------------------------------------------------------------
+# Context (SSR mirror of the client `provideContext` / `useContext`)
+# ---------------------------------------------------------------------------
+#
+# A `<Ctx.Provider value>` seeds a value that descendant `useContext(Ctx)`
+# consumers read during the same render. Dynamic scoping mirrors the client:
+# the provider pushes the value before rendering its children and pops it
+# after, and `use_context` reads the innermost active value (or the
+# `createContext` default when none is active).
+#
+# The value stacks live in a package-level store rather than per-instance or
+# on `$c->stash`: a parent template and the child templates it renders via
+# `render_child` are separate bf instances that don't reliably share a
+# controller (the Xslate backend runs with `c => undef`) nor a backend (the
+# Mojo path lazily builds one per instance). SSR rendering is synchronous —
+# nothing awaits between a provider's push and its matching pop — and the
+# push/pop are perfectly balanced, so the per-name stack always unwinds to
+# empty at the end of each provider subtree, keeping concurrent root renders
+# isolated. provide/revoke return '' so they drop cleanly into an inline
+# `<: … :>` (Kolon) or `% … ;` (EP) emit.
+
+my %CONTEXT_STACKS;
+
+sub provide_context ($self, $name, $value) {
+    push @{ $CONTEXT_STACKS{$name} //= [] }, $value;
+    return '';
+}
+
+sub revoke_context ($self, $name) {
+    pop @{ $CONTEXT_STACKS{$name} } if $CONTEXT_STACKS{$name} && @{ $CONTEXT_STACKS{$name} };
+    return '';
+}
+
+sub use_context ($self, $name, $default = undef) {
+    my $stack = $CONTEXT_STACKS{$name};
+    return $default unless $stack && @$stack;
+    return $stack->[-1];
+}
+
+# ---------------------------------------------------------------------------
 # Comment Markers
 # ---------------------------------------------------------------------------
 

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -12,12 +12,14 @@
  * genuinely differs. Every divergence carries a one-line rationale.
  */
 
+import { describe, test, expect } from 'bun:test'
 import {
   runAdapterConformanceTests,
   TemplatePrimitiveCaseId,
 } from '@barefootjs/adapter-tests'
 import { XslateAdapter } from '../adapter'
 import { renderXslateComponent, XslateNotAvailableError } from '../test-render'
+import { compileJSX, type ComponentIR } from '@barefootjs/jsx'
 
 runAdapterConformanceTests({
   name: 'xslate',
@@ -33,10 +35,13 @@ runAdapterConformanceTests({
   // fixtures than mojo. Each entry below was confirmed to fail with
   // skipJsx emptied.
   skipJsx: [
-    // SSR context propagation (`<Ctx.Provider value>` → `useContext`): the
-    // template reads a stash key that's never seeded. Implemented on Go; the
-    // Perl stash-seed path is a follow-up port, so Xslate stays skipped (#1297).
-    'context-provider',
+    // `context-provider` graduated: SSR context propagation now mirrors the
+    // client `provideContext` / `useContext`. `<Ctx.Provider value>` brackets
+    // its children with inline `$bf.provide_context` / `$bf.revoke_context`
+    // (a package-level value stack; both return '' so the `<: … :>` discards
+    // them), and each `useContext` consumer is seeded with
+    // `: my $x = $bf.use_context('Ctx', <default>)`. Renders byte-for-byte
+    // against Hono on real Text::Xslate. (#1297)
     // `toggle-shared`: the parent maps a `ToggleItemProps[]` prop into
     // sibling `ToggleItem` children inside a keyed `.map`. Three gaps
     // remain (same as mojo): the loop-child `on = props.defaultOn ??
@@ -142,4 +147,57 @@ runAdapterConformanceTests({
     }
     return false
   },
+})
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function compileToIR(source: string): ComponentIR {
+  const result = compileJSX(source.trimStart(), 'test.tsx', {
+    adapter: new XslateAdapter(),
+    outputIR: true,
+  })
+  const irFile = result.files.find(f => f.type === 'ir')
+  if (!irFile) throw new Error('No IR output')
+  return JSON.parse(irFile.content) as ComponentIR
+}
+
+function compileAndGenerate(source: string) {
+  return new XslateAdapter().generate(compileToIR(source))
+}
+
+// =============================================================================
+// Xslate-Specific Tests
+// =============================================================================
+
+describe('XslateAdapter - SSR context propagation (#1297)', () => {
+  // `<Ctx.Provider value>` brackets its children with inline provide/revoke
+  // calls (both return '' so the `<: … :>` discards them); descendant
+  // `useContext` consumers read the value during the same render.
+  test('provider brackets children with provide_context / revoke_context', () => {
+    const { template } = compileAndGenerate(`
+'use client'
+import { createContext, useContext } from '@barefootjs/client'
+const ThemeContext = createContext('light')
+export function ThemeRoot() {
+  return <div><ThemeContext.Provider value="dark"><ThemeLabel /></ThemeContext.Provider></div>
+}
+function ThemeLabel() { const theme = useContext(ThemeContext); return <span>{theme}</span> }
+`)
+    expect(template).toContain("$bf.provide_context('ThemeContext', 'dark')")
+    expect(template).toContain("$bf.revoke_context('ThemeContext')")
+    expect(template.indexOf('provide_context')).toBeLessThan(template.indexOf('render_child'))
+    expect(template.indexOf('render_child')).toBeLessThan(template.indexOf('revoke_context'))
+  })
+
+  test('consumer seeds its local from use_context with the createContext default', () => {
+    const { template } = compileAndGenerate(`
+'use client'
+import { createContext, useContext } from '@barefootjs/client'
+const ThemeContext = createContext('light')
+export function ThemeLabel() { const theme = useContext(ThemeContext); return <span>{theme}</span> }
+`)
+    expect(template).toContain(": my $theme = $bf.use_context('ThemeContext', 'light');")
+  })
 })

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -63,6 +63,8 @@ import {
   augmentInheritedPropAccesses,
   parseRecordIndexAccess,
   evalStringArrayJoin,
+  collectContextConsumers,
+  type ContextConsumer,
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr } from './boolean-result'
 import ts from 'typescript'
@@ -276,7 +278,12 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
       ? ''
       : this.generateScriptRegistrations(ir, options?.scriptBaseName)
 
-    const template = `${scriptReg}${templateBody}\n`
+    // SSR context consumers (`const x = useContext(Ctx)`): seed each local
+    // from the active provider value (or the `createContext` default). The
+    // provider side pushes the value via `emitProvider`. (#1297)
+    const ctxSeed = this.generateContextConsumerSeed(ir)
+
+    const template = `${scriptReg}${ctxSeed}${templateBody}\n`
 
     // Merge collected errors into IR errors
     if (this.errors.length > 0) {
@@ -389,7 +396,61 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
   }
 
   emitProvider(node: IRProvider, _ctx: XslateRenderCtx, _emit: EmitIRNode<XslateRenderCtx>): string {
-    return this.renderChildren(node.children)
+    // SSR context propagation (#1297): bracket the children with a
+    // provide/revoke pair on the shared controller-stash context stack so a
+    // descendant `useContext` consumer reads the value during the same
+    // render. Both helpers return '' (empty), so the inline `<: … :>`
+    // expression form discards their output cleanly — no extra whitespace,
+    // no line-statement needed inside the element body.
+    const value = this.providerValueKolon(node.valueProp)
+    const children = this.renderChildren(node.children)
+    const name = node.contextName
+    return (
+      `<: $bf.provide_context('${name}', ${value}) :>` +
+      children +
+      `<: $bf.revoke_context('${name}') :>`
+    )
+  }
+
+  /** Lower a `<Ctx.Provider value>` value prop to a Kolon expression. */
+  private providerValueKolon(valueProp: IRProvider['valueProp']): string {
+    const v = valueProp.value
+    if (v.kind === 'literal') {
+      return typeof v.value === 'string'
+        ? `'${v.value.replace(/[\\']/g, m => `\\${m}`)}'`
+        : String(v.value)
+    }
+    if (v.kind === 'expression') return this.convertExpressionToKolon(v.expr)
+    if (v.kind === 'template') return this.convertTemplateLiteralPartsToKolon(v.parts)
+    // Out-of-shape value (spread / jsx-children) — nil; consumer defaults.
+    return 'nil'
+  }
+
+  /** Kolon literal for a context-consumer's `createContext` default. */
+  private contextDefaultKolon(c: ContextConsumer): string {
+    const d = c.defaultValue
+    if (d === null || d === undefined) return 'nil'
+    if (typeof d === 'string') return `'${d.replace(/[\\']/g, m => `\\${m}`)}'`
+    if (typeof d === 'boolean') return d ? '1' : '0'
+    return String(d)
+  }
+
+  /**
+   * Emit one `: my $<local> = $bf.use_context(...)` line-statement per
+   * context consumer so the body's bare `$<local>` resolves to the active
+   * provider value (or the `createContext` default). (#1297)
+   */
+  private generateContextConsumerSeed(ir: ComponentIR): string {
+    const consumers = collectContextConsumers(ir.metadata)
+    if (consumers.length === 0) return ''
+    return (
+      consumers
+        .map(
+          c =>
+            `: my $${c.localName} = $bf.use_context('${c.contextName}', ${this.contextDefaultKolon(c)});`,
+        )
+        .join('\n') + '\n'
+    )
   }
 
   emitAsync(node: IRAsync, _ctx: XslateRenderCtx, _emit: EmitIRNode<XslateRenderCtx>): string {


### PR DESCRIPTION
**Stacked on #1779** (base = `claude/relaxed-pasteur-QdHNT`).

## Increment: `context-provider` — ✅ Mojolicious + Xslate

SSR context propagation (`<Ctx.Provider value>` → `useContext`) — the deferred Perl follow-up to the Go implementation in #1768.

Before: both adapters emitted a child template reading an un-seeded `$theme`, so the provider value never reached the descendant (re-measured against the real engines to confirm the skip's rationale before fixing).

The Perl runtime now mirrors the client `provideContext` / `useContext`:

- **`BarefootJS.pm`** gains `provide_context` / `revoke_context` / `use_context`, backed by a **package-level value stack**. It's the one store reliably shared between a parent template and the child templates it renders via `render_child` — the Xslate backend runs with `c => undef`, and the Mojo path lazily builds a backend per instance, so neither `$c->stash` nor the backend is universal. SSR render is synchronous and the provider push/pop are balanced, so each provider subtree unwinds the stack cleanly (concurrent root renders stay isolated).
- **Mojo**: `emitProvider` brackets the children with `<% bf->provide_context('Ctx', <value>); %>` … `<% bf->revoke_context('Ctx'); %>`; each `useContext` consumer is seeded with `% my $x = bf->use_context('Ctx', <default>);`.
- **Xslate**: same, using inline `<: $bf.provide_context(...) :>` / `<: $bf.revoke_context(...) :>` (both return `''`, so the interpolation emits nothing) + a `: my $x = $bf.use_context('Ctx', <default>);` line-statement seed.

## Test status (real Mojolicious 9.35 + Text::Xslate v3.5.9)
- `adapter-mojolicious`: **426 pass / 4 skip / 0 fail**
- `adapter-xslate`: **304 pass / 4 skip / 0 fail**
- `tsc` clean on both packages

Remaining Perl skips: `toggle-shared`, `props-reactivity-comparison` (next in the stack). Hono reference snapshots unchanged.

https://claude.ai/code/session_01LaP8KV6yASUT37PzDMvYbW

---
_Generated by [Claude Code](https://claude.ai/code/session_01LaP8KV6yASUT37PzDMvYbW)_