### PR TITLE
feat(adapters): graduate toggle-shared on Mojolicious + Xslate

### DIFF
--- a/.changeset/perl-toggle-shared.md
+++ b/.changeset/perl-toggle-shared.md
@@ -1,0 +1,15 @@
+---
+"@barefootjs/perl": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+---
+
+Graduate the `toggle-shared` conformance fixture to Hono parity on the Mojolicious and Text::Xslate adapters — a keyed `.map` of sibling `ToggleItem` children, each with a per-item prop-derived signal. Three gaps were closed (#1297):
+
+1. **Prop-derived signal SSR seeding.** A signal whose init derives from a prop (`createSignal(props.defaultOn ?? false)`) is now seeded in-template from the passed prop (`% my $on = ($defaultOn // 0);` / `: my $on = ($defaultOn // 0);`), so a loop child honours its own per-item prop instead of the static default. The lowering is gated by `isSupported` (object/array/constant inits never reach `convertExpression*`, so they don't record a spurious BF101 and keep their existing ssr-defaults seeding) and skipped on Text::Xslate for a same-name signal (Kolon can't express `: my $x = … $x …`; those stay on the harness/manifest seeding, which already resolves them from the prop).
+
+2. **Loop-child scope id.** A loop child now gets a fresh `<ComponentName>_<rand>` scope id (the PascalCase component name) instead of a parent-slot id, matching the Hono reference (`normalizeHTML` canonicalises `<ComponentName>_<rand>` → `<ComponentName>_*`).
+
+3. **`data-key`.** The JSX `key` (a reserved prop) now lands as `data-key="…"` on the child scope root, for keyed-loop reconciliation parity. `BarefootJS.pm` gains a `_data_key` field + `data_key_attr` helper; `render_child` sets it from the `key` prop; the component root emits it (`bf->data_key_attr` / `$bf.data_key_attr()`), so non-keyed renders add nothing.
+
+Note: prop-derived signals/memos are now computed in-template from the props they derive from, so a host seeds the *prop* (e.g. `initial`) rather than the signal value directly. Verified end-to-end against real Mojolicious and Text::Xslate. Hono reference snapshots unchanged.

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -17,28 +17,10 @@ runAdapterConformanceTests({
   name: 'mojo',
   factory: () => new MojoAdapter(),
   render: renderMojoComponent,
-  skipJsx: [
-    // `context-provider` graduated: SSR context propagation now mirrors the
-    // client `provideContext` / `useContext`. `<Ctx.Provider value>` brackets
-    // its children with `bf->provide_context` / `bf->revoke_context` (a
-    // package-level value stack), and each `useContext` consumer is seeded at
-    // the top of its template with `% my $x = bf->use_context('Ctx', <default>)`.
-    // Renders byte-for-byte against Hono on real Mojolicious. (#1297)
-    // `toggle-shared` graduated: a keyed `.map` of sibling `ToggleItem`
-    // children, each with a prop-derived `on = props.defaultOn ?? false`
-    // signal. Three gaps were closed (#1297): (1) prop-derived signals are now
-    // seeded in-template from the passed prop (`% my $on = $defaultOn // 0;`)
-    // so each item honours its own `defaultOn`; (2) loop children get a
-    // `ToggleItem_<rand>` scope id (component name, not the parent slot); and
-    // (3) the JSX `key` lands as `data-key` on the child scope root. Renders
-    // byte-for-byte against Hono on real Mojolicious.
-    // `props-reactivity-comparison` graduated: the child `PropsStyleChild`'s
-    // `displayValue = props.value * 10` memo has a `null` static SSR default
-    // (`extractSsrDefaults` can't fold a prop-derived expression). The adapter
-    // now computes such memos in-template from the seeded prop var
-    // (`% my $displayValue = $value * 10;`) — mirroring Go's generated child
-    // constructor — so the child renders `10` to match Hono. (#1297)
-  ],
+  // No JSX-render skips: every shared conformance fixture renders to Hono
+  // parity on real Mojolicious. Shapes the adapter intentionally refuses at
+  // build time are pinned in `expectedDiagnostics` below.
+  skipJsx: [],
   // Per-fixture build-time contracts for shapes the Mojo adapter
   // intentionally refuses to lower. Owned by this adapter test file
   // (not by the shared fixtures) so adding a new adapter doesn't

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -24,19 +24,14 @@ runAdapterConformanceTests({
     // package-level value stack), and each `useContext` consumer is seeded at
     // the top of its template with `% my $x = bf->use_context('Ctx', <default>)`.
     // Renders byte-for-byte against Hono on real Mojolicious. (#1297)
-    // `toggle-shared`: the parent maps a `ToggleItemProps[]` prop into
-    // sibling `ToggleItem` children inside a keyed `.map`. Each child's
-    // `on = props.defaultOn ?? false` signal is never seeded into the
-    // loop-child stash, so the rendered child template trips Perl strict
-    // mode (`Global symbol "$on" requires explicit package name`). The
-    // harness child renderer forwards only the explicitly-passed props;
-    // it does not run the `_derive_stash_from_defaults` seeding the
-    // production runtime applies. Plus the loop-child scope id is
-    // `toggle_item_<rand>` (snake-case template name) rather than the
-    // `ToggleItem_*` PascalCase the reference pins, and the `key=` →
-    // `data-key` attribute isn't emitted. Separate follow-up. (xslate
-    // skips this for the same reasons.)
-    'toggle-shared',
+    // `toggle-shared` graduated: a keyed `.map` of sibling `ToggleItem`
+    // children, each with a prop-derived `on = props.defaultOn ?? false`
+    // signal. Three gaps were closed (#1297): (1) prop-derived signals are now
+    // seeded in-template from the passed prop (`% my $on = $defaultOn // 0;`)
+    // so each item honours its own `defaultOn`; (2) loop children get a
+    // `ToggleItem_<rand>` scope id (component name, not the parent slot); and
+    // (3) the JSX `key` lands as `data-key` on the child scope root. Renders
+    // byte-for-byte against Hono on real Mojolicious.
     // `props-reactivity-comparison` graduated: the child `PropsStyleChild`'s
     // `displayValue = props.value * 10` memo has a `null` static SSR default
     // (`extractSsrDefaults` can't fold a prop-derived expression). The adapter
@@ -451,6 +446,47 @@ export function Child({ value }: { value: number }) {
 }
 `)
     expect(template).toContain('% my $displayValue = $value * 10;')
+  })
+})
+
+describe('MojoAdapter - prop-derived signal SSR seeding + data-key (#1297, toggle-shared)', () => {
+  // A prop-derived signal (`createSignal(props.defaultOn ?? false)`) is seeded
+  // in-template from the passed prop, so a loop child honours its own
+  // per-item prop instead of the static default.
+  test('seeds a prop-derived signal from the prop var', () => {
+    const { template } = compileAndGenerate(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function Item(props: { defaultOn?: boolean }) {
+  const [on, setOn] = createSignal(props.defaultOn ?? false)
+  return <button>{on() ? 'ON' : 'OFF'}</button>
+}
+`)
+    expect(template).toContain('% my $on = ($defaultOn // 0);')
+  })
+
+  // An object/array-valued signal can't lower to Perl and must NOT be seeded
+  // in-template (it would record a BF101) — it keeps the existing ssr-defaults
+  // seeding.
+  test('does not in-template-seed an object-valued signal', () => {
+    const { template } = compileAndGenerate(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function Spread() {
+  const [attrs, setAttrs] = createSignal<Record<string, string>>({ id: 'a' })
+  return <div {...attrs()} />
+}
+`)
+    expect(template).not.toContain('my $attrs =')
+  })
+
+  // The component root carries data-key, emitted from the bf instance
+  // (render_child sets it from the JSX key); non-keyed renders add nothing.
+  test('emits data_key_attr on the component root', () => {
+    const { template } = compileAndGenerate(`
+export function Item() { return <div className="x">hi</div> }
+`)
+    expect(template).toContain('bf->data_key_attr')
   })
 })
 

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -488,6 +488,19 @@ export function Item() { return <div className="x">hi</div> }
 `)
     expect(template).toContain('bf->data_key_attr')
   })
+
+  // An early-return (if-statement) root has no single root element; data-key
+  // must land on each branch's top element so a keyed loop item still stamps it.
+  test('emits data_key_attr on each branch root of an if-statement root', () => {
+    const { template } = compileAndGenerate(`
+export function Item({ on }: { on?: boolean }) {
+  if (on) return <div className="a">A</div>
+  return <div className="b">B</div>
+}
+`)
+    const count = (template.match(/bf->data_key_attr/g) ?? []).length
+    expect(count).toBe(2)
+  })
 })
 
 describe('MojoAdapter - Template Generation', () => {

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -166,6 +166,34 @@ function perlHashKey(name: string): string {
 }
 
 /**
+ * Collect the component's root scope element node(s) — the elements that
+ * become the rendered root and so carry `data-key` for a keyed loop item. A
+ * plain element root is itself; an `if-statement` (early-return) root
+ * contributes the top element of each branch (`consequent` + the `alternate`
+ * chain), since exactly one branch renders at runtime. Non-element branch
+ * tops (fragments / nested shapes) are walked one level so an
+ * `if (…) return <A/>` still resolves to `<A>`. (#1297)
+ */
+function collectRootScopeNodes(node: IRNode): Set<IRNode> {
+  const out = new Set<IRNode>()
+  const visit = (n: IRNode | null): void => {
+    if (!n) return
+    if (n.type === 'element') { out.add(n); return }
+    if (n.type === 'if-statement') {
+      const s = n as IRIfStatement
+      visit(s.consequent)
+      visit(s.alternate)
+      return
+    }
+    if (n.type === 'fragment') {
+      for (const c of (n as IRFragment).children) visit(c)
+    }
+  }
+  visit(node)
+  return out
+}
+
+/**
  * True when every `$var` the lowered (Perl / Kolon) expression references is
  * in the available set — i.e. the template already has that var in scope.
  * Guards in-template memo seeding from referencing an out-of-scope binding
@@ -201,9 +229,12 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
   templatePrimitives: TemplatePrimitiveRegistry = MOJO_PRIMITIVE_EMIT_MAP
 
   private componentName: string = ''
-  /** The component's root IR node — its scope root carries `data-key` for a
-   *  keyed loop item (set by `render_child` from the JSX `key` prop). */
-  private rootNode: IRNode | null = null
+  /** The component's root scope element(s) — each carries `data-key` for a
+   *  keyed loop item (set by the child renderer from the JSX `key` prop). A
+   *  plain element root is a single node; an `if-statement` (early-return) root
+   *  contributes the top element of every branch, since any one of them can be
+   *  the rendered root at runtime. */
+  private rootScopeNodes: Set<IRNode> = new Set()
   private options: Required<MojoAdapterOptions>
   private errors: CompilerError[] = []
   private inLoop: boolean = false
@@ -349,7 +380,7 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       this.checkImportedLoopChildComponents(ir)
     }
 
-    this.rootNode = ir.root
+    this.rootScopeNodes = collectRootScopeNodes(ir.root)
     const templateBody = ir.root.type === 'if-statement'
       ? this.renderIfStatement(ir.root as IRIfStatement)
       : this.renderNode(ir.root)
@@ -659,11 +690,12 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     if (element.needsScope) {
       hydrationAttrs += ` ${this.renderScopeMarker('')}`
     }
-    // The component root carries `data-key` for a keyed loop item — emitted
-    // from the bf instance (`render_child` sets it from the JSX `key` prop),
-    // so a non-keyed render adds nothing. Mirrors Hono stamping data-key on
-    // each loop item's scope root. (#1297)
-    if (element === this.rootNode && element.needsScope) {
+    // A root scope element carries `data-key` for a keyed loop item — emitted
+    // from the bf instance (the child renderer sets it from the JSX `key`
+    // prop), so a non-keyed render adds nothing. Mirrors Hono stamping
+    // data-key on each loop item's scope root, including early-return
+    // (if-statement) roots where every branch's top element qualifies. (#1297)
+    if (this.rootScopeNodes.has(element) && element.needsScope) {
       hydrationAttrs += ` <%== bf->data_key_attr %>`
     }
     if (element.slotId) {

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -201,6 +201,9 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
   templatePrimitives: TemplatePrimitiveRegistry = MOJO_PRIMITIVE_EMIT_MAP
 
   private componentName: string = ''
+  /** The component's root IR node — its scope root carries `data-key` for a
+   *  keyed loop item (set by `render_child` from the JSX `key` prop). */
+  private rootNode: IRNode | null = null
   private options: Required<MojoAdapterOptions>
   private errors: CompilerError[] = []
   private inLoop: boolean = false
@@ -346,6 +349,7 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       this.checkImportedLoopChildComponents(ir)
     }
 
+    this.rootNode = ir.root
     const templateBody = ir.root.type === 'if-statement'
       ? this.renderIfStatement(ir.root as IRIfStatement)
       : this.renderNode(ir.root)
@@ -579,14 +583,30 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
    * tripping Perl strict mode. (#1297)
    */
   private generateDerivedMemoSeed(ir: ComponentIR): string {
-    const memos = ir.metadata.memos
-    if (!memos || memos.length === 0) return ''
+    const memos = ir.metadata.memos ?? []
+    const signals = ir.metadata.signals ?? []
+    if (memos.length === 0 && signals.length === 0) return ''
     const ssrDefaults = extractSsrDefaults(ir.metadata) ?? {}
-    const available = new Set<string>([
-      ...ir.metadata.propsParams.map(p => p.name),
-      ...ir.metadata.signals.map(s => s.getter),
-    ])
+    // Props seed first; each signal/memo adds its own name as it lands so a
+    // later one can reference an earlier one.
+    const available = new Set<string>(ir.metadata.propsParams.map(p => p.name))
     const lines: string[] = []
+
+    // Prop/signal-derived signals (`createSignal(props.defaultOn ?? false)`):
+    // a loop-child render receives no stash seed for the signal, so its `$on`
+    // would trip strict mode; and even when an entry render seeds it, the
+    // static default can't capture the per-call prop. Seed it in-template from
+    // the passed prop — but ONLY when the init lowers cleanly AND references an
+    // in-scope var (i.e. it's genuinely derived). Object/array/constant inits
+    // (`createSignal({…})`, `createSignal([…])`, `createSignal('b')`) keep the
+    // existing ssr-defaults seeding, so the spread / loop fixtures are
+    // untouched.
+    for (const signal of signals) {
+      const perl = this.tryLowerToPerl(signal.initialValue, available)
+      if (perl !== null) lines.push(`% my $${signal.getter} = ${perl};`)
+      available.add(signal.getter)
+    }
+
     for (const memo of memos) {
       const def = ssrDefaults[memo.name]
       const isNull = !def || (typeof def === 'object' && 'value' in def && def.value === null)
@@ -597,13 +617,29 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       const body = extractArrowBodyExpression(memo.computation)
       // Block-bodied arrows / non-expression shapes stay on the null path.
       if (body === null) continue
-      const perl = this.convertExpressionToPerl(body)
-      // Only emit when every `$var` the lowering references is in scope.
-      if (!referencedVarsAreAvailable(perl, available)) continue
-      lines.push(`% my $${memo.name} = ${perl};`)
+      const perl = this.tryLowerToPerl(body, available)
+      if (perl !== null) lines.push(`% my $${memo.name} = ${perl};`)
       available.add(memo.name)
     }
     return lines.length > 0 ? lines.join('\n') + '\n' : ''
+  }
+
+  /**
+   * Lower a signal init / memo body to Perl for an in-template SSR seed, or
+   * `null` when it shouldn't be seeded this way. Returns null — without
+   * recording a BF101 — when the expression isn't a supported shape
+   * (`isSupported` pre-check, so object/array literals don't fail the build),
+   * when the lowering references no in-scope var (a constant — keep the
+   * existing ssr-defaults seeding), or when it references an out-of-scope
+   * binding. (#1297)
+   */
+  private tryLowerToPerl(expr: string, available: ReadonlySet<string>): string | null {
+    const trimmed = expr.trim()
+    if (!trimmed) return null
+    if (!isSupported(parseExpression(trimmed)).supported) return null
+    const perl = this.convertExpressionToPerl(trimmed)
+    if (perl === '' || !/\$[A-Za-z_]\w*/.test(perl)) return null
+    return referencedVarsAreAvailable(perl, available) ? perl : null
   }
 
   emitAsync(node: IRAsync, _ctx: MojoRenderCtx, _emit: EmitIRNode<MojoRenderCtx>): string {
@@ -622,6 +658,13 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     let hydrationAttrs = ''
     if (element.needsScope) {
       hydrationAttrs += ` ${this.renderScopeMarker('')}`
+    }
+    // The component root carries `data-key` for a keyed loop item — emitted
+    // from the bf instance (`render_child` sets it from the JSX `key` prop),
+    // so a non-keyed render adds nothing. Mirrors Hono stamping data-key on
+    // each loop item's scope root. (#1297)
+    if (element === this.rootNode && element.needsScope) {
+      hydrationAttrs += ` <%== bf->data_key_attr %>`
     }
     if (element.slotId) {
       hydrationAttrs += ` ${this.renderSlotMarker(element.slotId)}`

--- a/packages/adapter-mojolicious/src/test-render.ts
+++ b/packages/adapter-mojolicious/src/test-render.ts
@@ -314,7 +314,7 @@ print $output;
  */
 function buildChildRenderers(
   childTemplates: Map<string, { template: string; ir: ComponentIR }>,
-  parentIR: ComponentIR,
+  _parentIR: ComponentIR,
   tempDir: string,
 ): string {
   if (childTemplates.size === 0) return ''
@@ -326,20 +326,11 @@ function buildChildRenderers(
     const snakeName = toSnakeCase(componentName)
     const childTemplatePath = resolve(tempDir, `${snakeName}.html.ep`)
 
-    // Compute child scope ID from parent IR
-    const childSlotIds = findChildSlotIds(parentIR, componentName)
-
     lines.push(`{`)
     lines.push(`  open my $child_fh, '<:utf8', '${childTemplatePath}' or die "Cannot open child template: $!";`)
     lines.push(`  my $child_tmpl = do { local $/; <$child_fh> };`)
     lines.push(`  close $child_fh;`)
     lines.push(`  my $child_mt = Mojo::Template->new(vars => 1, auto_escape => 1);`)
-
-    // Track instance counter for multiple-instances support
-    lines.push(`  my $instance_idx = 0;`)
-    const slotIdsPerl = childSlotIds.length > 0
-      ? `my @slot_ids = (${childSlotIds.map(id => `'${id}'`).join(', ')}); my $sid = $slot_ids[$instance_idx] // $slot_ids[-1]; $instance_idx++;`
-      : `my $sid = '${snakeName}';`
 
     lines.push(`  $bf->register_child_renderer('${snakeName}', sub {`)
     lines.push(`    my ($child_props) = @_;`)
@@ -359,14 +350,22 @@ function buildChildRenderers(
       const rest = childIR.metadata.restPropsName
       lines.push(`    $child_props->{${rest}} = {} unless defined $child_props->{${rest}};`)
     }
-    lines.push(`    ${slotIdsPerl}`)
     lines.push(`    my $child_bf = BarefootJS->new($c, {});`)
-    // Child scope id derives from the PARENT's live scope id, not a literal
-    // `test_` prefix — so `<ReactiveProps_test>_s5` matches Hono / CSR (and
-    // survives an explicit `__instanceId`). Mirrors xslate's
-    // `rootChildScopePrefix` (`$bf->_scope_id`); `$bf` is the parent instance
-    // captured by this renderer closure.
-    lines.push(`    $child_bf->_scope_id($bf->_scope_id . "_$sid");`)
+    // JSX `key` (reserved prop) → data-key on the child's scope root, for
+    // keyed-loop reconciliation parity with Hono.
+    lines.push(`    my $data_key = delete $child_props->{key};`)
+    lines.push(`    $child_bf->_data_key($data_key) if defined $data_key;`)
+    // Scope id: a slotted child (`_bf_slot` passed) derives from the PARENT's
+    // live scope id (`<Parent_test>_s5`); a loop child (no slot) gets a fresh
+    // `<ComponentName>_<rand>` id per iteration, matching Hono — the
+    // PascalCase component name is what `normalizeHTML` canonicalises to
+    // `<ComponentName>_*`.
+    lines.push(`    my $slot = delete $child_props->{_bf_slot};`)
+    lines.push(`    if (defined $slot) {`)
+    lines.push(`      $child_bf->_scope_id($bf->_scope_id . "_$slot");`)
+    lines.push(`    } else {`)
+    lines.push(`      $child_bf->_scope_id('${componentName}_' . substr(rand() =~ s/^0\\.//r, 0, 6));`)
+    lines.push(`    }`)
     lines.push(`    my $rendered = $child_mt->render($child_tmpl, { %$child_props, bf => $child_bf });`)
     lines.push(`    die $rendered->to_string if ref $rendered;`)
     lines.push(`    chomp $rendered;`)
@@ -377,27 +376,6 @@ function buildChildRenderers(
   }
 
   return lines.join('\n')
-}
-
-/**
- * Find slot IDs assigned to a child component in the parent IR.
- */
-function findChildSlotIds(parentIR: ComponentIR, childName: string): string[] {
-  const ids: string[] = []
-  function walk(node: import('@barefootjs/jsx').IRNode): void {
-    if (node.type === 'component' && node.name === childName && node.slotId) {
-      ids.push(node.slotId)
-    }
-    if ('children' in node && Array.isArray(node.children)) {
-      for (const child of node.children) walk(child)
-    }
-    if (node.type === 'conditional') {
-      walk(node.whenTrue)
-      walk(node.whenFalse)
-    }
-  }
-  walk(parentIR.root)
-  return ids
 }
 
 /**

--- a/packages/adapter-perl/lib/BarefootJS.pm
+++ b/packages/adapter-perl/lib/BarefootJS.pm
@@ -52,10 +52,11 @@ my %ATTR_DEFAULT = (
 # _scope_id    — addressable scope id
 # _bf_parent / _bf_mount — slot identity when this scope is slot-attached
 # _props       — props serialised into bf-p / the scope comment
+# _data_key    — keyed-loop-item key, emitted as data-key on the scope root
 for my $attr (qw(
     c config backend
     _scripts _script_seen _scope_id _is_child _bf_parent _bf_mount _props
-    _child_renderers
+    _data_key _child_renderers
 )) {
     no strict 'refs';
     *{"BarefootJS::$attr"} = sub {
@@ -129,6 +130,19 @@ sub hydration_attrs ($self) {
         push @parts, q{bf-r=""};
     }
     return join(' ', @parts);
+}
+
+# Emits ` data-key="<key>"` for a keyed loop item, else ''. The client
+# runtime uses data-key for list reconciliation; SSR must match the Hono
+# reference, which stamps it on each loop item's scope root. The value is set
+# by `render_child` from the JSX `key` prop (a reserved prop, never a real
+# template variable).
+sub data_key_attr ($self) {
+    my $k = $self->_data_key;
+    return '' unless defined $k;
+    $k =~ s/&/&amp;/g;
+    $k =~ s/"/&quot;/g;
+    return qq{ data-key="$k"};
 }
 
 sub props_attr ($self) {

--- a/packages/adapter-perl/lib/BarefootJS.pm
+++ b/packages/adapter-perl/lib/BarefootJS.pm
@@ -135,8 +135,9 @@ sub hydration_attrs ($self) {
 # Emits ` data-key="<key>"` for a keyed loop item, else ''. The client
 # runtime uses data-key for list reconciliation; SSR must match the Hono
 # reference, which stamps it on each loop item's scope root. The value is set
-# by `render_child` from the JSX `key` prop (a reserved prop, never a real
-# template variable).
+# on the child instance by the child renderer (`register_child_renderer` /
+# `register_components_from_manifest`) from the JSX `key` prop — a reserved
+# prop, never a real template variable.
 sub data_key_attr ($self) {
     my $k = $self->_data_key;
     return '' unless defined $k;
@@ -352,6 +353,10 @@ sub register_components_from_manifest ($self, $manifest, %opts) {
             # closure adds no edge to the per-request reference cycle.
             my $child_bf = BarefootJS->new($parent->c, { backend => $parent->backend });
             my $slot_id = delete $props->{_bf_slot};
+            # JSX `key` (a reserved prop) → data-key on the child's scope root
+            # for keyed-loop reconciliation (see `data_key_attr`).
+            my $data_key = delete $props->{key};
+            $child_bf->_data_key($data_key) if defined $data_key;
             $child_bf->_scope_id(
                 $slot_id ? $parent_scope . '_' . $slot_id
                          : $template_name . '_' . substr(rand() =~ s/^0\.//r, 0, 6)

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -42,17 +42,13 @@ runAdapterConformanceTests({
     // them), and each `useContext` consumer is seeded with
     // `: my $x = $bf.use_context('Ctx', <default>)`. Renders byte-for-byte
     // against Hono on real Text::Xslate. (#1297)
-    // `toggle-shared`: the parent maps a `ToggleItemProps[]` prop into
-    // sibling `ToggleItem` children inside a keyed `.map`. Three gaps
-    // remain (same as mojo): the loop-child `on = props.defaultOn ??
-    // false` signal isn't seeded server-side (so every item renders OFF
-    // instead of honouring per-item `defaultOn`), the child scope id is
-    // the snake-case `toggle_item_<rand>` rather than the `ToggleItem_*`
-    // PascalCase the reference pins, and `key=` → `data-key` isn't
-    // emitted. Kolon resolves the unseeded vars to nil rather than
-    // aborting, so this surfaces as a render mismatch (not a hard error).
-    // Separate follow-up.
-    'toggle-shared',
+    // `toggle-shared` graduated (same three fixes as mojo, #1297): (1) the
+    // prop-derived `on = props.defaultOn ?? false` signal is seeded in-template
+    // (`: my $on = $defaultOn // 0;`) so each item honours its own `defaultOn`
+    // instead of all rendering OFF; (2) loop children get a `ToggleItem_<rand>`
+    // scope id (component name, not the snake-case template name); and (3) the
+    // JSX `key` lands as `data-key` on the child scope root. Renders
+    // byte-for-byte against Hono on real Text::Xslate.
     // `props-reactivity-comparison` graduated: the child `PropsStyleChild`'s
     // `displayValue = props.value * 10` memo has a `null` static SSR default.
     // The adapter now computes such memos in-template from the seeded prop var
@@ -222,5 +218,40 @@ export function Child({ value }: { value: number }) {
 }
 `)
     expect(template).toContain(': my $displayValue = $value * 10;')
+  })
+})
+
+describe('XslateAdapter - prop-derived signal SSR seeding + data-key (#1297, toggle-shared)', () => {
+  test('seeds a prop-derived (different-name) signal from the prop var', () => {
+    const { template } = compileAndGenerate(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function Item(props: { defaultOn?: boolean }) {
+  const [on, setOn] = createSignal(props.defaultOn ?? false)
+  return <button>{on() ? 'ON' : 'OFF'}</button>
+}
+`)
+    expect(template).toContain(': my $on = ($defaultOn // 0);')
+  })
+
+  // Kolon can't `: my $x = … $x …`; a same-name signal stays on the existing
+  // (harness/manifest) seeding rather than an in-template seed.
+  test('does NOT in-template-seed a same-name signal', () => {
+    const { template } = compileAndGenerate(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function C(props: { x?: number }) {
+  const [x, setX] = createSignal(props.x ?? 7)
+  return <span>{x()}</span>
+}
+`)
+    expect(template).not.toContain(': my $x =')
+  })
+
+  test('emits data_key_attr on the component root', () => {
+    const { template } = compileAndGenerate(`
+export function Item() { return <div class="x">hi</div> }
+`)
+    expect(template).toContain('$bf.data_key_attr()')
   })
 })

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -254,4 +254,15 @@ export function Item() { return <div class="x">hi</div> }
 `)
     expect(template).toContain('$bf.data_key_attr()')
   })
+
+  test('emits data_key_attr on each branch root of an if-statement root', () => {
+    const { template } = compileAndGenerate(`
+export function Item({ on }: { on?: boolean }) {
+  if (on) return <div class="a">A</div>
+  return <div class="b">B</div>
+}
+`)
+    const count = (template.match(/\$bf\.data_key_attr\(\)/g) ?? []).length
+    expect(count).toBe(2)
+  })
 })

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -25,38 +25,10 @@ runAdapterConformanceTests({
   name: 'xslate',
   factory: () => new XslateAdapter(),
   render: renderXslateComponent,
-  // Skips here are VERIFIED, not inherited from mojo. Notably, the six
-  // fixtures mojo skips for Perl-EP scoping faults — `logical-or-jsx`,
-  // `nullish-coalescing-jsx`, `branch-map`, `return-logical-or`,
-  // `return-nullish-coalescing`, `return-map` (bare `$label` / `$items`
-  // without a `my` binding) — all PASS on Xslate, because Kolon resolves
-  // `$label` from the per-render vars rather than a Perl lexical, so there
-  // is no undefined-symbol fault. Xslate therefore skips strictly fewer
-  // fixtures than mojo. Each entry below was confirmed to fail with
-  // skipJsx emptied.
-  skipJsx: [
-    // `context-provider` graduated: SSR context propagation now mirrors the
-    // client `provideContext` / `useContext`. `<Ctx.Provider value>` brackets
-    // its children with inline `$bf.provide_context` / `$bf.revoke_context`
-    // (a package-level value stack; both return '' so the `<: … :>` discards
-    // them), and each `useContext` consumer is seeded with
-    // `: my $x = $bf.use_context('Ctx', <default>)`. Renders byte-for-byte
-    // against Hono on real Text::Xslate. (#1297)
-    // `toggle-shared` graduated (same three fixes as mojo, #1297): (1) the
-    // prop-derived `on = props.defaultOn ?? false` signal is seeded in-template
-    // (`: my $on = $defaultOn // 0;`) so each item honours its own `defaultOn`
-    // instead of all rendering OFF; (2) loop children get a `ToggleItem_<rand>`
-    // scope id (component name, not the snake-case template name); and (3) the
-    // JSX `key` lands as `data-key` on the child scope root. Renders
-    // byte-for-byte against Hono on real Text::Xslate.
-    // `props-reactivity-comparison` graduated: the child `PropsStyleChild`'s
-    // `displayValue = props.value * 10` memo has a `null` static SSR default.
-    // The adapter now computes such memos in-template from the seeded prop var
-    // (`: my $displayValue = $value * 10;`) — mirroring Go's generated child
-    // constructor — so `child-computed-value` renders `10` to match Hono. (#1297)
-    // (`kbd` is not skipped here — it's a BF101 refusal pinned in
-    // `expectedDiagnostics` below, not a render-mismatch.)
-  ],
+  // No JSX-render skips: every shared conformance fixture renders to Hono
+  // parity on real Text::Xslate. Shapes the adapter intentionally refuses at
+  // build time are pinned in `expectedDiagnostics` below (e.g. `kbd`, `button`).
+  skipJsx: [],
   // Per-fixture build-time contracts for shapes the Xslate adapter
   // intentionally refuses to lower. Mirrors mojo's set — the lowering
   // gates are shared code paths in the ported adapter.

--- a/packages/adapter-xslate/src/__tests__/xslate-counter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-counter.test.ts
@@ -96,7 +96,10 @@ my $bf = BarefootJS->new(undef, { backend => $backend });
 $bf->_scope_id('Counter_test');
 
 binmode(STDOUT, ':utf8');
-my \$html = \$backend->render_named('counter', \$bf, { count => 3, doubled => 6 });
+# The count signal is seeded in-template from the prop it derives from (#1297),
+# so the host seeds initial (not the count signal value directly); doubled is a
+# memo with a non-null static default and stays a directly-seeded stash var.
+my \$html = \$backend->render_named('counter', \$bf, { initial => 3, doubled => 6 });
 print \$html;
 # The template's register_script calls populated \$bf's script list during
 # render; emit the resulting <script> tags so the test can assert them.

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -144,6 +144,32 @@ function resolveJsxChildrenProp(props: readonly IRProp[]): IRNode[] {
 }
 
 /**
+ * Collect the component's root scope element node(s) — the elements that
+ * become the rendered root and so carry `data-key` for a keyed loop item. A
+ * plain element root is itself; an `if-statement` (early-return) root
+ * contributes the top element of each branch, since exactly one renders at
+ * runtime. (#1297)
+ */
+function collectRootScopeNodes(node: IRNode): Set<IRNode> {
+  const out = new Set<IRNode>()
+  const visit = (n: IRNode | null): void => {
+    if (!n) return
+    if (n.type === 'element') { out.add(n); return }
+    if (n.type === 'if-statement') {
+      const s = n as IRIfStatement
+      visit(s.consequent)
+      visit(s.alternate)
+      return
+    }
+    if (n.type === 'fragment') {
+      for (const c of (n as IRFragment).children) visit(c)
+    }
+  }
+  visit(node)
+  return out
+}
+
+/**
  * True when every `$var` the lowered Kolon expression references is already in
  * scope — guards in-template memo seeding against an out-of-scope binding. (#1297)
  */
@@ -179,9 +205,11 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
   templatePrimitives: TemplatePrimitiveRegistry = XSLATE_PRIMITIVE_EMIT_MAP
 
   private componentName: string = ''
-  /** Component root IR node — its scope root carries `data-key` for a keyed
-   *  loop item (set by `render_child` from the JSX `key` prop). */
-  private rootNode: IRNode | null = null
+  /** Component root scope element(s) — each carries `data-key` for a keyed loop
+   *  item (set by the child renderer from the JSX `key` prop). A plain element
+   *  root is one node; an `if-statement` (early-return) root contributes the
+   *  top element of every branch. */
+  private rootScopeNodes: Set<IRNode> = new Set()
   private options: Required<XslateAdapterOptions>
   private errors: CompilerError[] = []
   private inLoop: boolean = false
@@ -285,7 +313,7 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
       this.checkImportedLoopChildComponents(ir)
     }
 
-    this.rootNode = ir.root
+    this.rootScopeNodes = collectRootScopeNodes(ir.root)
     const templateBody = ir.root.type === 'if-statement'
       ? this.renderIfStatement(ir.root as IRIfStatement)
       : this.renderNode(ir.root)
@@ -560,10 +588,11 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     if (element.needsScope) {
       hydrationAttrs += ` ${this.renderScopeMarker('')}`
     }
-    // Component root carries `data-key` for a keyed loop item (set on the bf
-    // instance by render_child from the JSX `key` prop); non-keyed renders add
-    // nothing. Mirrors Hono stamping data-key on each loop item's root. (#1297)
-    if (element === this.rootNode && element.needsScope) {
+    // A root scope element carries `data-key` for a keyed loop item (set on the
+    // bf instance by the child renderer from the JSX `key` prop); non-keyed
+    // renders add nothing. Mirrors Hono stamping data-key on each loop item's
+    // root, including early-return (if-statement) roots. (#1297)
+    if (this.rootScopeNodes.has(element) && element.needsScope) {
       hydrationAttrs += ` <: $bf.data_key_attr() | mark_raw :>`
     }
     if (element.slotId) {

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -179,6 +179,9 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
   templatePrimitives: TemplatePrimitiveRegistry = XSLATE_PRIMITIVE_EMIT_MAP
 
   private componentName: string = ''
+  /** Component root IR node — its scope root carries `data-key` for a keyed
+   *  loop item (set by `render_child` from the JSX `key` prop). */
+  private rootNode: IRNode | null = null
   private options: Required<XslateAdapterOptions>
   private errors: CompilerError[] = []
   private inLoop: boolean = false
@@ -282,6 +285,7 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
       this.checkImportedLoopChildComponents(ir)
     }
 
+    this.rootNode = ir.root
     const templateBody = ir.root.type === 'if-statement'
       ? this.renderIfStatement(ir.root as IRIfStatement)
       : this.renderNode(ir.root)
@@ -481,14 +485,32 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
    * lowering references is already in scope. (#1297)
    */
   private generateDerivedMemoSeed(ir: ComponentIR): string {
-    const memos = ir.metadata.memos
-    if (!memos || memos.length === 0) return ''
+    const memos = ir.metadata.memos ?? []
+    const signals = ir.metadata.signals ?? []
+    if (memos.length === 0 && signals.length === 0) return ''
     const ssrDefaults = extractSsrDefaults(ir.metadata) ?? {}
-    const available = new Set<string>([
-      ...ir.metadata.propsParams.map(p => p.name),
-      ...ir.metadata.signals.map(s => s.getter),
-    ])
+    // Props seed first; each signal/memo adds its own name as it lands.
+    const available = new Set<string>(ir.metadata.propsParams.map(p => p.name))
     const lines: string[] = []
+
+    // Prop/signal-derived signals (`createSignal(props.defaultOn ?? false)`):
+    // a loop-child render gets no stash seed, so its `$on` would render nil;
+    // and the static default can't capture the per-call prop. Seed it
+    // in-template when the init lowers cleanly AND references an in-scope var.
+    // Object/array/constant inits keep the existing ssr-defaults seeding.
+    for (const signal of signals) {
+      const kolon = this.tryLowerToKolon(signal.initialValue, available)
+      // Kolon can't express `: my $x = … $x …` — declaring `my $x` makes the
+      // RHS `$x` an undefined lexical rather than the render var. A same-name
+      // signal (`createSignal(props.x ?? d)`, getter == prop) is just the prop
+      // with a default, which the harness already seeds correctly from the
+      // passed prop — skip the in-template seed for it. (Different-name
+      // prop-derived signals like toggle's `on` from `defaultOn` are unaffected.)
+      const refsSelf = kolon !== null && new RegExp(`\\$${signal.getter}\\b`).test(kolon)
+      if (kolon !== null && !refsSelf) lines.push(`: my $${signal.getter} = ${kolon};`)
+      available.add(signal.getter)
+    }
+
     for (const memo of memos) {
       const def = ssrDefaults[memo.name]
       const isNull = !def || (typeof def === 'object' && 'value' in def && def.value === null)
@@ -498,12 +520,27 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
       }
       const body = extractArrowBodyExpression(memo.computation)
       if (body === null) continue
-      const kolon = this.convertExpressionToKolon(body)
-      if (!referencedVarsAreAvailable(kolon, available)) continue
-      lines.push(`: my $${memo.name} = ${kolon};`)
+      const kolon = this.tryLowerToKolon(body, available)
+      if (kolon !== null) lines.push(`: my $${memo.name} = ${kolon};`)
       available.add(memo.name)
     }
     return lines.length > 0 ? lines.join('\n') + '\n' : ''
+  }
+
+  /**
+   * Lower a signal init / memo body to Kolon for an in-template SSR seed, or
+   * `null` when it shouldn't be seeded this way: not a supported shape
+   * (`isSupported` pre-check, so object/array literals don't fail the build),
+   * references no in-scope var (a constant — keep ssr-defaults seeding), or
+   * references an out-of-scope binding. (#1297)
+   */
+  private tryLowerToKolon(expr: string, available: ReadonlySet<string>): string | null {
+    const trimmed = expr.trim()
+    if (!trimmed) return null
+    if (!isSupported(parseExpression(trimmed)).supported) return null
+    const kolon = this.convertExpressionToKolon(trimmed)
+    if (kolon === '' || !/\$[A-Za-z_]\w*/.test(kolon)) return null
+    return referencedVarsAreAvailable(kolon, available) ? kolon : null
   }
 
   emitAsync(node: IRAsync, _ctx: XslateRenderCtx, _emit: EmitIRNode<XslateRenderCtx>): string {
@@ -522,6 +559,12 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     let hydrationAttrs = ''
     if (element.needsScope) {
       hydrationAttrs += ` ${this.renderScopeMarker('')}`
+    }
+    // Component root carries `data-key` for a keyed loop item (set on the bf
+    // instance by render_child from the JSX `key` prop); non-keyed renders add
+    // nothing. Mirrors Hono stamping data-key on each loop item's root. (#1297)
+    if (element === this.rootNode && element.needsScope) {
+      hydrationAttrs += ` <: $bf.data_key_attr() | mark_raw :>`
     }
     if (element.slotId) {
       hydrationAttrs += ` ${this.renderSlotMarker(element.slotId)}`

--- a/packages/adapter-xslate/src/test-render.ts
+++ b/packages/adapter-xslate/src/test-render.ts
@@ -367,7 +367,14 @@ function buildChildRenderers(
     }
     lines.push(`    my $slot_id = delete $child_props->{_bf_slot};`)
     lines.push(`    my $child_bf = BarefootJS->new(undef, { backend => $backend });`)
-    lines.push(`    $child_bf->_scope_id($slot_id ? '${rootChildScopePrefix(snakeName)}' . '_' . $slot_id : '${snakeName}_' . substr(rand() =~ s/^0\\.//r, 0, 6));`)
+    // JSX `key` (reserved prop) → data-key on the child scope root, for keyed
+    // loop reconciliation parity with Hono.
+    lines.push(`    my $data_key = delete $child_props->{key};`)
+    lines.push(`    $child_bf->_data_key($data_key) if defined $data_key;`)
+    // A loop child (no slot) gets a fresh `<ComponentName>_<rand>` id per
+    // iteration — the PascalCase name is what `normalizeHTML` canonicalises to
+    // `<ComponentName>_*`; a slotted child derives from the parent scope.
+    lines.push(`    $child_bf->_scope_id($slot_id ? '${rootChildScopePrefix(snakeName)}' . '_' . $slot_id : '${componentName}_' . substr(rand() =~ s/^0\\.//r, 0, 6));`)
     lines.push(`    $child_bf->_is_child(1);`)
     lines.push(`    if ($slot_id) { $child_bf->_bf_parent('${rootChildScopePrefix(snakeName)}'); $child_bf->_bf_mount($slot_id); }`)
     lines.push(`    $child_bf->_scripts($bf->_scripts);`)


### PR DESCRIPTION
Graduates the last cross-adapter `skipJsx` entry, **`toggle-shared`**, to Hono parity on Mojolicious and Text::Xslate. (Supersedes the earlier "keep skipped + refresh rationale" version of this PR — the user asked to actually close the gaps, including the cross-cutting signal-seeding work.)

`toggle-shared` is a keyed `.map` of sibling `ToggleItem` children, each with a per-item prop-derived `on = createSignal(props.defaultOn ?? false)` signal. Three independent gaps were closed (#1297):

### 1. Prop-derived signal SSR seeding
A signal whose init derives from a prop is now seeded **in-template** from the passed prop so a loop child honours its own per-item prop instead of the static default:
- Mojo: `% my $on = ($defaultOn // 0);`
- Xslate: `: my $on = ($defaultOn // 0);`

Guards (the part that was fragile in the first attempt):
- Gated by `isSupported` so object/array/constant inits (`createSignal({…})`, `createSignal([…])`) never reach `convertExpression*` — they would otherwise record a spurious `BF101` and fail the build (this is what regressed `jsx-spread-*` before). They keep their existing ssr-defaults seeding.
- Only seeded when the lowering references an in-scope var (a constant keeps ssr-defaults seeding).
- On Text::Xslate, **same-name** signals (`createSignal(props.x ?? 7)`, getter == prop) are skipped — Kolon can't express `: my $x = … $x …`; they resolve from the prop via the existing harness/manifest seeding (Perl handles `my $x = $x` fine, so Mojo seeds them in-template).

### 2. Loop-child scope id
A loop child now gets a fresh `<ComponentName>_<rand>` id (PascalCase component name) instead of a parent-slot id, matching Hono (`normalizeHTML` canonicalises it to `<ComponentName>_*`).

### 3. `data-key`
The JSX `key` (reserved prop) lands as `data-key="…"` on the child scope root for keyed-loop reconciliation parity. `BarefootJS.pm` gains `_data_key` + `data_key_attr`; `render_child` sets it from `key`; the component root emits it (`bf->data_key_attr` / `$bf.data_key_attr()`), so non-keyed renders add nothing.

**Behavior note:** prop-derived signals/memos are now computed in-template from the props they derive from, so a host seeds the **prop** (e.g. `initial`) rather than the signal value directly — the `xslate-counter` render test is updated to match.

## Test status (real Mojolicious 9.35 + Text::Xslate v3.5.9)
- `adapter-mojolicious`: **495 pass / 19 skip / 0 fail** (all 6 files)
- `adapter-xslate`: **321 pass / 5 skip / 0 fail** (all 3 files)
- `tsc` clean on jsx / mojolicious / xslate

This clears `toggle-shared` from `skipJsx` on **all** adapters that had it (Mojo + Xslate). Go's `toggle-shared` remains skipped for its separate `[]ToggleItemInput` typing reason. Hono reference snapshots unchanged.

https://claude.ai/code/session_01LaP8KV6yASUT37PzDMvYbW