### PR TITLE
Profile-mode __bfId emission in client-JS codegen (#1690, SR3)

### DIFF
--- a/.changeset/profiler-sr3-bfid.md
+++ b/.changeset/profiler-sr3-bfid.md
@@ -1,0 +1,16 @@
+---
+"@barefootjs/jsx": minor
+---
+
+Add profile-mode `__bfId` emission to client-JS codegen (#1690, SR3).
+
+A new `CompileOptions.profile` flag makes the client-JS generator append
+IR-aligned id arguments at reactive creation sites — `createSignal(init,
+"Comp#signal:x")`, `createMemo(expr, "Comp#memo:y")`, `createEffect(body,
+"Comp#effect:line")`, including controlled-signal sync effects. The runtime
+(`@barefootjs/client`) already accepts these ids, so a profiling run can join
+its event stream to IR nodes.
+
+Off by default: when `profile` is unset the emitted code is byte-for-byte
+unchanged (SR8). Ids are threaded purely through the declaration-emit plan and
+the effects phase; the stringifiers stay `ctx`-free.

--- a/packages/jsx/src/__tests__/profile-bfid-emission.test.ts
+++ b/packages/jsx/src/__tests__/profile-bfid-emission.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Profile-mode `__bfId` emission (#1690, SR3).
+ *
+ * In profile mode the client-JS codegen appends IR-aligned id arguments at
+ * reactive creation sites so a profiling run can join runtime events to IR
+ * nodes. Off by default the emitted code is byte-for-byte unchanged (SR8).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+const source = `
+  'use client'
+  import { createSignal, createMemo, createEffect } from '@barefootjs/client'
+
+  export function Counter() {
+    const [count, setCount] = createSignal(0)
+    const doubled = createMemo(() => count() * 2)
+    createEffect(() => { console.log(doubled()) })
+    return <button onClick={() => setCount(n => n + 1)}>{doubled()}</button>
+  }
+`
+
+function clientJs(profile: boolean): string {
+  const result = compileJSX(source, 'Counter.tsx', { adapter, profile })
+  const file = result.files.find(f => f.type === 'clientJs')
+  expect(file).toBeDefined()
+  return file!.content
+}
+
+describe('profile mode off (default, SR8)', () => {
+  test('emits no __bfId arguments — output is unchanged', () => {
+    const off = clientJs(false)
+    expect(off).toContain('createSignal(0)')
+    expect(off).not.toContain('#signal:')
+    expect(off).not.toContain('#memo:')
+    expect(off).not.toContain('#effect:')
+  })
+
+  test('omitting the flag matches profile:false byte-for-byte', () => {
+    const implicit = compileJSX(source, 'Counter.tsx', { adapter })
+      .files.find(f => f.type === 'clientJs')!.content
+    expect(implicit).toBe(clientJs(false))
+  })
+})
+
+describe('profile mode on (SR3)', () => {
+  test('appends IR-aligned ids to createSignal / createMemo / createEffect', () => {
+    const on = clientJs(true)
+    expect(on).toContain('createSignal(0, "Counter#signal:count")')
+    expect(on).toContain('createMemo(() => count() * 2, "Counter#memo:doubled")')
+    expect(on).toMatch(/createEffect\(.*"Counter#effect:/)
+  })
+
+  test('does not change the signal/memo initial expressions', () => {
+    // The id is purely additive — the first argument is identical to off mode.
+    const on = clientJs(true)
+    expect(on).toContain('createMemo(() => count() * 2,')
+  })
+})

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -719,6 +719,7 @@ export function compileJSX(
         },
         undefined,
         adapterCaps,
+        options.profile,
       )
       errors.push(...componentIR.errors)
       if (result.code) {
@@ -734,6 +735,7 @@ export function compileJSX(
         options.localImportPrefixes,
         undefined,
         adapterCaps,
+        options.profile,
       )
       errors.push(...componentIR.errors)
       if (clientJs) {

--- a/packages/jsx/src/ir-to-client-js/index.ts
+++ b/packages/jsx/src/ir-to-client-js/index.ts
@@ -58,6 +58,7 @@ export function generateClientJs(
   localImportPrefixes?: string[],
   scope?: ScopeInfo,
   adapterCapabilities?: AdapterCapabilities,
+  profile?: boolean,
 ): string {
   return generateClientJsWithSourceMap(
     ir,
@@ -66,6 +67,7 @@ export function generateClientJs(
     undefined,
     scope,
     adapterCapabilities,
+    profile,
   ).code
 }
 
@@ -80,8 +82,9 @@ export function generateClientJsWithSourceMap(
   options?: { sourceMaps?: boolean; generatedFileName?: string },
   scope?: ScopeInfo,
   adapterCapabilities?: AdapterCapabilities,
+  profile?: boolean,
 ): ClientJsResult {
-  const ctx = createContext(ir, scope, adapterCapabilities)
+  const ctx = createContext(ir, scope, adapterCapabilities, profile)
   const siblingOffsets = computeLoopSiblingOffsets(ir.root)
   collectElements(ir.root, ctx, siblingOffsets)
 
@@ -154,11 +157,13 @@ function createContext(
   ir: ComponentIR,
   scope?: ScopeInfo,
   adapterCapabilities?: AdapterCapabilities,
+  profile?: boolean,
 ): ClientJsContext {
   return {
     componentName: ir.metadata.componentName,
     fileScope: scope?.fileScope ?? '',
     nonExportedSiblings: scope?.nonExportedSiblings ?? new Set(),
+    profile: profile ?? false,
     signals: ir.metadata.signals,
     memos: ir.metadata.memos,
     effects: ir.metadata.effects,

--- a/packages/jsx/src/ir-to-client-js/phases/effects-and-on-mounts.ts
+++ b/packages/jsx/src/ir-to-client-js/phases/effects-and-on-mounts.ts
@@ -10,13 +10,19 @@
 import type { ClientJsContext } from '../types.ts'
 
 export function emitEffectsAndOnMounts(lines: string[], ctx: ClientJsContext): void {
-  for (const effect of ctx.effects) {
+  ctx.effects.forEach((effect, i) => {
+    // Profile mode (#1690): IR-aligned id so runtime effect-run events join to
+    // this effect node. Keyed by captureName when present, else the source line
+    // (stable across compiles), falling back to source order.
+    const idArg = ctx.profile
+      ? `, ${JSON.stringify(`${ctx.componentName}#effect:${effect.captureName ?? effect.loc?.start.line ?? i}`)}`
+      : ''
     if (effect.captureName) {
-      lines.push(`  const ${effect.captureName} = createEffect(${effect.body})`)
+      lines.push(`  const ${effect.captureName} = createEffect(${effect.body}${idArg})`)
     } else {
-      lines.push(`  createEffect(${effect.body})`)
+      lines.push(`  createEffect(${effect.body}${idArg})`)
     }
-  }
+  })
   for (const onMount of ctx.onMounts) {
     lines.push(`  onMount(${onMount.body})`)
   }

--- a/packages/jsx/src/ir-to-client-js/plan/build-declaration-emit.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/build-declaration-emit.ts
@@ -62,6 +62,7 @@ export function buildDeclarationEmitPlan(
         kind: 'memo',
         name: decl.info.name,
         computationExpr: decl.info.computation,
+        bfId: ctx.profile ? `${ctx.componentName}#memo:${decl.info.name}` : undefined,
       }
     case 'function': {
       const fn = decl.info
@@ -84,13 +85,18 @@ function buildSignalPlan(
   ctx: ClientJsContext,
   lookups: DeclarationEmitLookups,
 ): SignalEmitPlan {
+  const controlledEffect = buildControlledSignalEffect(signal, lookups)
+  if (controlledEffect && ctx.profile) {
+    controlledEffect.bfId = `${ctx.componentName}#effect:controlled:${signal.setter}`
+  }
   return {
     kind: 'signal',
     getter: signal.getter,
     setter: signal.setter,
     initialValueExpr: resolveSignalInitialValue(signal, ctx, lookups),
-    controlledEffect: buildControlledSignalEffect(signal, lookups),
+    controlledEffect,
     branchCondition: signal.branchCondition,
+    bfId: ctx.profile ? `${ctx.componentName}#signal:${signal.getter}` : undefined,
   }
 }
 

--- a/packages/jsx/src/ir-to-client-js/plan/declaration-emit.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/declaration-emit.ts
@@ -52,6 +52,8 @@ export interface SignalEmitPlan {
    * cell #8.
    */
   branchCondition?: string
+  /** Profile-mode IR-aligned id, appended as the `createSignal` 2nd arg (#1690). */
+  bfId?: string
 }
 
 export interface ControlledSignalEffectPlan {
@@ -59,6 +61,8 @@ export interface ControlledSignalEffectPlan {
   setter: string
   /** Fully-resolved accessor expression read inside the effect. */
   accessorExpr: string
+  /** Profile-mode IR-aligned id, appended as the `createEffect` 2nd arg (#1690). */
+  bfId?: string
 }
 
 export interface MemoEmitPlan {
@@ -66,6 +70,8 @@ export interface MemoEmitPlan {
   name: string
   /** Source expression passed to `createMemo(...)`. */
   computationExpr: string
+  /** Profile-mode IR-aligned id, appended as the `createMemo` 2nd arg (#1690). */
+  bfId?: string
 }
 
 export interface FunctionEmitPlan {

--- a/packages/jsx/src/ir-to-client-js/stringify/declaration-emit.ts
+++ b/packages/jsx/src/ir-to-client-js/stringify/declaration-emit.ts
@@ -59,7 +59,13 @@ function emitConstant(lines: string[], plan: ConstantEmitPlan): void {
   }
 }
 
+/** Profile-mode trailing `__bfId` argument (`, "Comp#signal:x"`), or '' when off. */
+function bfIdArg(bfId: string | undefined): string {
+  return bfId ? `, ${JSON.stringify(bfId)}` : ''
+}
+
 function emitSignal(lines: string[], plan: SignalEmitPlan): void {
+  const id = bfIdArg(plan.bfId)
   if (plan.branchCondition) {
     // #1414 cell #8: signal declared inside an early-return `if`-block.
     // Hoist as `let` so closures and event handlers hoisted to outer
@@ -70,12 +76,12 @@ function emitSignal(lines: string[], plan: SignalEmitPlan): void {
     if (plan.setter) {
       lines.push(`  let ${plan.getter}, ${plan.setter}`)
       lines.push(`  if (${plan.branchCondition}) {`)
-      lines.push(`    ;[${plan.getter}, ${plan.setter}] = createSignal(${plan.initialValueExpr})`)
+      lines.push(`    ;[${plan.getter}, ${plan.setter}] = createSignal(${plan.initialValueExpr}${id})`)
       lines.push(`  }`)
     } else {
       lines.push(`  let ${plan.getter}`)
       lines.push(`  if (${plan.branchCondition}) {`)
-      lines.push(`    ;[${plan.getter}] = createSignal(${plan.initialValueExpr})`)
+      lines.push(`    ;[${plan.getter}] = createSignal(${plan.initialValueExpr}${id})`)
       lines.push(`  }`)
     }
     // Controlled effects don't apply to branch-conditioned signals — a
@@ -84,9 +90,9 @@ function emitSignal(lines: string[], plan: SignalEmitPlan): void {
     return
   }
   if (plan.setter) {
-    lines.push(`  const [${plan.getter}, ${plan.setter}] = createSignal(${plan.initialValueExpr})`)
+    lines.push(`  const [${plan.getter}, ${plan.setter}] = createSignal(${plan.initialValueExpr}${id})`)
   } else {
-    lines.push(`  const [${plan.getter}] = createSignal(${plan.initialValueExpr})`)
+    lines.push(`  const [${plan.getter}] = createSignal(${plan.initialValueExpr}${id})`)
   }
   if (plan.controlledEffect) {
     emitControlledEffect(lines, plan.controlledEffect)
@@ -97,11 +103,11 @@ function emitControlledEffect(lines: string[], plan: ControlledSignalEffectPlan)
   lines.push(`  createEffect(() => {`)
   lines.push(`    const __val = ${plan.accessorExpr}`)
   lines.push(`    if (__val !== undefined) ${plan.setter}(__val)`)
-  lines.push(`  })`)
+  lines.push(`  }${bfIdArg(plan.bfId)})`)
 }
 
 function emitMemo(lines: string[], plan: MemoEmitPlan): void {
-  lines.push(`  const ${plan.name} = createMemo(${plan.computationExpr})`)
+  lines.push(`  const ${plan.name} = createMemo(${plan.computationExpr}${bfIdArg(plan.bfId)})`)
 }
 
 function emitFunction(lines: string[], plan: FunctionEmitPlan): void {

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -40,6 +40,11 @@ export interface ClientJsContext {
    * collide with same-named exports from other modules.
    */
   nonExportedSiblings: Set<string>
+  /**
+   * Profile mode (#1690, SR3). When true, emit IR-aligned `__bfId` args at
+   * reactive creation sites. Off by default → byte-identical output (SR8).
+   */
+  profile: boolean
   signals: SignalInfo[]
   memos: MemoInfo[]
   effects: EffectInfo[]

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -1570,6 +1570,14 @@ export interface CompileOptions {
    * starting with `.`.
    */
   rewriteRelativeImport?: (importPath: string) => string
+  /**
+   * Profile mode (#1690, SR3). When true, the client-JS codegen emits
+   * IR-aligned `__bfId` arguments at reactive creation sites
+   * (`createSignal`/`createMemo`/`createEffect`) so a profiling run can join
+   * runtime events to IR nodes. Off by default — the emitted code is then
+   * byte-for-byte unchanged (SR8). Dev/profiling builds only.
+   */
+  profile?: boolean
 }
 
 export interface FileOutput {


### PR DESCRIPTION
**Stacked on #1780** (base: `claude/profiler-sr1-instrumentation`). Part of `bf debug profile` (#1690) — implements the compiler half of **SR3** from `spec/profiler.md`: IR-aligned `__bfId` emission at reactive creation sites.

## What

A new `CompileOptions.profile` flag (threaded to `ClientJsContext.profile`) makes the client-JS codegen append IR-aligned id arguments at reactive creation sites:

```js
// profile: true
const [count, setCount] = createSignal(0, "Counter#signal:count")
const doubled = createMemo(() => count() * 2, "Counter#memo:doubled")
createEffect(() => { ... }, "Counter#effect:7")
```

The runtime (`@barefootjs/client`, #1780) already accepts these ids, so a profiling run can join its event stream to IR nodes — turning a raw measurement into a source-mapped finding (SR4, next stack PR).

Covers init-scope signals/memos, controlled-signal sync effects, and top-level effects. Id format `<Component>#<kind>:<name|line>` matches the runtime's id namespace.

## Design

- Ids are computed at **declaration-plan build time** (`build-declaration-emit.ts`), where `ctx` + `componentName` + `loc` are available, and appended by the stringifiers via a single `bfIdArg` helper — the stringifiers stay `ctx`-free (preserves the plan/stringify split).
- The `profile` flag is a trailing optional param on `generateClientJs(WithSourceMap)` → `createContext`, so all existing callers are unaffected.

## SR8 — zero default change

Off by default the emitted code is **byte-for-byte unchanged**. The unit test asserts the no-flag output contains no ids and equals `profile: false` exactly.

## Scope note

This PR covers `__bfId` emission. The **turn-boundary markers** (`beginTurn`/`endTurn` wrapping handlers — the other half of SR3, which needs a new runtime import + the delegation/branch/loop handler paths) land in the next stack PR alongside the SR4 IR join.

## Tests

`packages/jsx/src/__tests__/profile-bfid-emission.test.ts` (4 pass). Full jsx suite: the only failures are 4 pre-existing `resolver-via-checker` tests that require `packages/client/dist` to be built (CI builds first; verified they pass after `bun run build:types`) — unrelated to this change.

## Stack

1. #1770 — design + SR5 budget + SR6 compile-diff + CLI
2. #1780 — SR1 runtime instrumentation + SR8 gating
3. **this PR** — SR3 `__bfId` emission (compiler)
4. next — SR3 turn markers (all handler paths) + SR4 IR join
5. then — v1 analyses (hot subscribers / wasted re-runs / batch advisor)

https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN)_