### PR TITLE
Profile turn markers on loop event-delegation (#1690, SR3)

### DIFF
--- a/.changeset/profiler-sr4-delegation-turns.md
+++ b/.changeset/profiler-sr4-delegation-turns.md
@@ -1,0 +1,18 @@
+---
+"@barefootjs/jsx": minor
+---
+
+Extend profile-mode turn markers (#1690, SR3) to the loop event-delegation path.
+
+A dynamic list delegates child events to one container listener. In profile
+mode each delegated handler call is now bracketed with `beginTurn`/`endTurn`
+(id `<Component>#handler:<childSlotId>:<eventName>`), so the reactive work a
+list-row interaction triggers is attributed to one turn — the same id namespace
+as direct handlers. The marker is a single-statement `beginTurn(id); try { … }
+finally { endTurn() }` wrap, dropped into every item-lookup shape.
+
+Threaded via `EventDelegationPlan.profileComponentName`, set by the top-level
+and static-array delegation builders (which have `ctx`). Off by default the
+dispatcher is byte-for-byte unchanged (SR8). Branch-scoped delegation (a loop
+nested inside a conditional branch) does not yet carry markers — tracked as a
+follow-up.

--- a/packages/jsx/src/__tests__/profile-turn-markers-delegation.test.ts
+++ b/packages/jsx/src/__tests__/profile-turn-markers-delegation.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Profile-mode turn markers on the loop event-delegation path (#1690, SR3).
+ *
+ * A dynamic list delegates its child events to a single container listener.
+ * In profile mode each delegated handler call is bracketed with
+ * `beginTurn`/`endTurn` so the reactive work it triggers is attributed to one
+ * turn, with the same id namespace as direct handlers. Off by default the
+ * dispatcher is unchanged (SR8).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+const source = `
+  'use client'
+  import { createSignal } from '@barefootjs/client'
+
+  export function TodoList() {
+    const [items, setItems] = createSignal([{ id: 1, label: 'a' }])
+    return (
+      <ul>
+        {items().map(item => (
+          <li key={item.id} onClick={() => setItems(xs => xs.filter(x => x.id !== item.id))}>
+            {item.label}
+          </li>
+        ))}
+      </ul>
+    )
+  }
+`
+
+function clientJs(profile: boolean): string {
+  return compileJSX(source, 'TodoList.tsx', { adapter, profile })
+    .files.find(f => f.type === 'clientJs')!.content
+}
+
+describe('loop delegation — profile off (SR8)', () => {
+  test('dispatcher carries no turn markers', () => {
+    const off = clientJs(false)
+    expect(off).toContain('addEventListener') // sanity: delegation present
+    expect(off).not.toContain('beginTurn')
+    expect(off).not.toContain('endTurn')
+  })
+})
+
+describe('loop delegation — profile on (SR3)', () => {
+  test('brackets the delegated handler call with a try/finally turn', () => {
+    const on = clientJs(true)
+    expect(on).toContain('beginTurn("TodoList#handler:')
+    expect(on).toContain('try {')
+    expect(on).toContain('finally { endTurn() }')
+  })
+
+  test('auto-wires the beginTurn/endTurn runtime import', () => {
+    const on = clientJs(true)
+    const importLine = on.split('\n').find(l => l.includes('@barefootjs/client/runtime'))
+    expect(importLine).toContain('beginTurn')
+    expect(importLine).toContain('endTurn')
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow.ts
@@ -66,7 +66,7 @@ export function emitLoopUpdates(lines: string[], ctx: ClientJsContext, unsafeLoc
   for (const elem of ctx.loopElements) {
     const plan = buildLoopPlan(elem, { unsafeLocalNames })
     stringifyLoop(lines, plan)
-    emitLoopEventDelegation(lines, elem, plan.kind)
+    emitLoopEventDelegation(lines, elem, plan.kind, ctx.profile ? ctx.componentName : undefined)
   }
 }
 
@@ -74,13 +74,14 @@ function emitLoopEventDelegation(
   lines: string[],
   elem: TopLevelLoop,
   kind: 'plain' | 'component' | 'composite' | 'static',
+  profileComponentName?: string,
 ): void {
   if (kind === 'static') {
     // Event delegation for plain elements in static arrays (#537). Static
     // arrays have no data-key/bf-i markers, so walk up from target to the
     // container's direct child and use indexOf for index lookup.
     if (!elem.childComponent && elem.bindings.events.length > 0) {
-      stringifyEventDelegation(lines, buildStaticArrayDelegationPlan(elem))
+      stringifyEventDelegation(lines, buildStaticArrayDelegationPlan(elem, profileComponentName))
     }
     return
   }
@@ -99,6 +100,6 @@ function emitLoopEventDelegation(
     && !elem.useElementReconciliation
     && elem.bindings.events.length > 0
   ) {
-    stringifyEventDelegation(lines, buildDynamicLoopDelegationPlan(elem))
+    stringifyEventDelegation(lines, buildDynamicLoopDelegationPlan(elem, profileComponentName))
   }
 }

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-event-delegation.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-event-delegation.ts
@@ -16,11 +16,15 @@ import type {
   ItemLookup,
 } from './types.ts'
 
-export function buildDynamicLoopDelegationPlan(elem: TopLevelLoop): EventDelegationPlan {
+export function buildDynamicLoopDelegationPlan(
+  elem: TopLevelLoop,
+  profileComponentName?: string,
+): EventDelegationPlan {
   return {
     kind: 'event-delegation',
     containerVar: `_${varSlotId(elem.slotId)}`,
     events: elem.bindings.events,
+    profileComponentName,
     itemLookup: buildKeyedOrIndexLookup({
       // Chain `.filter()` / `.toSorted()` so the index-based lookup walks
       // the same array shape mapArray reconciled into the DOM (#1434).
@@ -35,6 +39,11 @@ export function buildDynamicLoopDelegationPlan(elem: TopLevelLoop): EventDelegat
   }
 }
 
+// NOTE: branch-scoped delegation (a dynamic loop nested inside a conditional
+// branch) does not yet thread `profileComponentName` — `buildBranchLoopPlan`
+// is reached via `branch.loops.map(...)` without `ctx`. Turn markers on this
+// nested path are tracked as a follow-up; top-level + static-array delegation
+// (the common dynamic-list case) carry markers below.
 export function buildBranchLoopDelegationPlan(loop: BranchLoop, cv: string): EventDelegationPlan {
   return {
     kind: 'event-delegation',
@@ -56,11 +65,15 @@ export function buildBranchLoopDelegationPlan(loop: BranchLoop, cv: string): Eve
  * no `data-key` markers, so the lookup walks up to the container's direct
  * child and uses `indexOf` (with optional sibling offset).
  */
-export function buildStaticArrayDelegationPlan(elem: TopLevelLoop): EventDelegationPlan {
+export function buildStaticArrayDelegationPlan(
+  elem: TopLevelLoop,
+  profileComponentName?: string,
+): EventDelegationPlan {
   return {
     kind: 'event-delegation',
     containerVar: `_${varSlotId(elem.slotId)}`,
     events: elem.bindings.events,
+    profileComponentName,
     itemLookup: {
       kind: 'static-index',
       // Static arrays render through the same `.filter()`/`.toSorted()`

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/event-delegation.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/event-delegation.ts
@@ -26,6 +26,13 @@ export interface EventDelegationPlan {
   containerVar: string
   events: LoopChildEvent[]
   itemLookup: ItemLookup
+  /**
+   * Profile mode (#1690, SR3): the owning component name. When set, the
+   * stringifier brackets each delegated handler call with `beginTurn`/`endTurn`
+   * (id `<Component>#handler:<childSlotId>:<eventName>`). Undefined when
+   * profiling is off, so the emitted dispatcher is unchanged (SR8).
+   */
+  profileComponentName?: string
 }
 
 /**

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/event-delegation.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/event-delegation.ts
@@ -48,8 +48,20 @@ const NON_BUBBLING_EVENTS = new Set([
   'pointerenter', 'pointerleave',
 ])
 
+/**
+ * Profile mode (#1690, SR3): bracket a delegated handler call with turn
+ * markers so a profiling run attributes the reactive work it triggers to one
+ * turn. `call` is the inline invocation (e.g. `(handler)(__bfEvt)`); the
+ * wrapper keeps it a single statement so it drops into every lookup shape.
+ */
+function withTurn(call: string, componentName: string | undefined, childSlotId: string, eventName: string): string {
+  if (!componentName) return call
+  const id = JSON.stringify(`${componentName}#handler:${childSlotId}:${eventName}`)
+  return `beginTurn(${id}); try { ${call} } finally { endTurn() }`
+}
+
 export function stringifyEventDelegation(lines: string[], plan: EventDelegationPlan): void {
-  const { containerVar, events, itemLookup } = plan
+  const { containerVar, events, itemLookup, profileComponentName } = plan
   const eventsByName = new Map<string, LoopChildEvent[]>()
   for (const ev of events) {
     if (!eventsByName.has(ev.eventName)) eventsByName.set(ev.eventName, [])
@@ -70,7 +82,7 @@ export function stringifyEventDelegation(lines: string[], plan: EventDelegationP
       const childVar = varSlotId(ev.childSlotId)
       lines.push(`    const ${childVar}El = target.closest('[bf="${ev.childSlotId}"]')`)
       lines.push(`    if (${childVar}El) {`)
-      const handlerCall = `(${ev.handler.trim()})(__bfEvt)`
+      const handlerCall = withTurn(`(${ev.handler.trim()})(__bfEvt)`, profileComponentName, ev.childSlotId, ev.eventName)
       switch (itemLookup.kind) {
         case 'keyed':
           emitKeyedLookup(lines, ev, handlerCall, itemLookup)


### PR DESCRIPTION
**Stacked on #1785** (base: `claude/profiler-sr3-turns`). Continues **SR3** turn-marker coverage onto the loop event-delegation path.

## What

A dynamic list delegates its child events to one container listener (`closest()` dispatch). In profile mode each delegated handler call is now bracketed with turn markers:

```js
if (liEl) {
  const item = items().find(...)
  if (item) { beginTurn("TodoList#handler:s3:click"); try { (() => setItems(...))(__bfEvt) } finally { endTurn() } }
}
```

A single-statement `beginTurn(id); try { … } finally { endTurn() }` wrap drops into every item-lookup shape (keyed / dynamic-index / static-index, single + nested). Same id namespace as direct handlers: `<Component>#handler:<childSlotId>:<eventName>`.

## Design

- Threaded via `EventDelegationPlan.profileComponentName`, set by `buildDynamicLoopDelegationPlan` / `buildStaticArrayDelegationPlan` — both reached from `control-flow.ts` where `ctx` is in scope. The stringifier stays otherwise ctx-free; it just reads the optional name off the plan.
- Off by default `profileComponentName` is undefined → `withTurn()` returns the call unchanged → dispatcher is **byte-for-byte identical** (SR8).

## Coverage / known gap

Covered: top-level direct handlers (#1785) + **top-level & static-array loop delegation** (this PR) — the dominant dynamic-list interaction path.

**Not yet wrapped** (tracked in **#1786**, `known-limitation`): branch-scoped delegation (loop nested in a conditional branch — reached via `branch.loops.map(...)` without `ctx`) and branch-arm direct listeners (`emitListenerLine`). The follow-up threads the component name through those plan builders and adds an all-paths conformance test. Documented inline at `buildBranchLoopDelegationPlan`.

## Tests

`packages/jsx/src/__tests__/profile-turn-markers-delegation.test.ts` — delegated handler is try/finally-wrapped + import auto-wired; off → unchanged. Delegation regression slice (23 tests) green; typecheck clean.

## Stack

1. #1770 — design + SR5 + SR6 + CLI
2. #1780 — SR1 runtime instrumentation
3. #1784 — SR3 `__bfId` emission
4. #1785 — SR3 turn markers (top-level handlers)
5. **this PR** — SR3 turn markers (loop delegation); remaining paths → #1786
6. next — SR2/SR4 profiler runtime + IR join → v1 analyses

https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN)_