### PR TITLE
SR2 event collector + SR4 IR join (#1690)

### DIFF
--- a/.changeset/profiler-sr4-join.md
+++ b/.changeset/profiler-sr4-join.md
@@ -1,0 +1,24 @@
+---
+"@barefootjs/shared": minor
+"@barefootjs/client": minor
+"@barefootjs/jsx": minor
+---
+
+Add the SR2 event collector and SR4 IR join for `bf debug profile` (#1690).
+
+- **`@barefootjs/shared`**: `ProfilerEvent` / `ProfilerEventType` — the
+  normalized event wire contract shared by the runtime producer and the jsx
+  consumer. It lives in `shared` (built first, depended on by both) so the
+  jsx↔client peer relationship stays free of a build-order cycle.
+- **`@barefootjs/client`**: `createRecordingSink()` (SR2) — turns the raw
+  `ProfilerEventSink` callbacks (SR1) into a flat, ordered, **turn-stamped**
+  event log. It tracks the `beginTurn`/`endTurn` stack (SR3) and stamps every
+  event with the handler id in scope, so per-turn metrics need no microtask
+  guesswork.
+- **`@barefootjs/jsx`**: `buildIdIndex(graph)` + `joinProfilerEvents(events,
+  index)` (SR4) — resolve each event's compiler-assigned id to its source-mapped
+  IR node (signals/memos/effects, including controlled-signal sync effects).
+  Unresolved ids are surfaced as coverage gaps, never dropped (SR4 invariant).
+
+These are the substrate the v1 analyses (hot subscribers / wasted re-runs /
+batch advisor) consume next. Dev-only; no effect on production builds (SR8).

--- a/packages/client/__tests__/profiler-events.test.ts
+++ b/packages/client/__tests__/profiler-events.test.ts
@@ -1,0 +1,67 @@
+/**
+ * SR2 event collection (#1690): `createRecordingSink` turns the raw sink
+ * callbacks into a flat, ordered, turn-stamped log.
+ */
+
+import { describe, test, expect, afterEach } from 'bun:test'
+import { createSignal, createEffect, createRoot, beginTurn, endTurn, setProfilerSink } from '../src/reactive'
+import { createRecordingSink } from '../src/profiler-events'
+
+afterEach(() => setProfilerSink(null))
+
+describe('createRecordingSink', () => {
+  test('stamps events with the turn in scope and orders them by seq', () => {
+    const rec = createRecordingSink()
+    setProfilerSink(rec.sink)
+
+    createRoot(() => {
+      const [n, setN] = createSignal(0, 'C#signal:n')
+      createEffect(() => { n() }, 'C#effect:5')
+      beginTurn('C#handler:s0:click', 'C.tsx:5')
+      setN(1)
+      endTurn()
+    })
+
+    const seqs = rec.events.map(e => e.seq)
+    expect(seqs).toEqual([...seqs].sort((a, b) => a - b)) // strictly ordered
+
+    const set = rec.events.find(e => e.type === 'signalSet')!
+    expect(set.signal).toBe('C#signal:n')
+    expect(set.turn).toBe('C#handler:s0:click') // attributed to the open turn
+
+    const begin = rec.events.find(e => e.type === 'turnBegin')!
+    expect(begin.handlerId).toBe('C#handler:s0:click')
+    expect(begin.loc).toBe('C.tsx:5')
+    expect(begin.turn).toBeNull() // the marker itself carries the parent turn
+  })
+
+  test('events fired outside a turn have turn=null', () => {
+    const rec = createRecordingSink()
+    setProfilerSink(rec.sink)
+    createRoot(() => {
+      const [, setN] = createSignal(0, 'C#signal:n')
+      setN(1)
+    })
+    expect(rec.events.find(e => e.type === 'signalSet')!.turn).toBeNull()
+  })
+
+  test('reset clears the log and the turn stack', () => {
+    const rec = createRecordingSink()
+    setProfilerSink(rec.sink)
+    createRoot(() => {
+      const [, setN] = createSignal(0, 'C#signal:n')
+      beginTurn('C#handler:s0:click')
+      setN(1)
+      // intentionally no endTurn — reset must drop the dangling turn
+    })
+    rec.reset()
+    expect(rec.events).toHaveLength(0)
+
+    createRoot(() => {
+      const [, setN] = createSignal(0, 'C#signal:n')
+      setN(2)
+    })
+    // After reset the stack is empty, so this set is outside any turn.
+    expect(rec.events.find(e => e.type === 'signalSet')!.turn).toBeNull()
+  })
+})

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -23,6 +23,13 @@ export {
   type SubscriberKind,
 } from '@barefootjs/client/reactive'
 
+export {
+  createRecordingSink,
+  type ProfilerEvent,
+  type ProfilerEventType,
+  type RecordingSink,
+} from './profiler-events.ts'
+
 export { splitProps } from './split-props.ts'
 
 export { __slot, type SlotMarker } from './slot.ts'

--- a/packages/client/src/profiler-events.ts
+++ b/packages/client/src/profiler-events.ts
@@ -1,0 +1,84 @@
+/**
+ * Profiler event collection (#1690, SR2).
+ *
+ * The reactive runtime (`reactive.ts`) reports raw instrumentation through a
+ * `ProfilerEventSink` (SR1). This module turns that callback stream into a
+ * flat, ordered, **turn-stamped** event log — the normalized SR2 contract the
+ * analyses (hot subscribers / wasted re-runs / batch advisor) and the SR4 IR
+ * join consume.
+ *
+ * The collector is the one place that knows the *current turn*: it tracks the
+ * `beginTurn`/`endTurn` stack (SR3) and stamps every event with the handler id
+ * in scope when it fired, so per-turn metrics (batch savings, runs/turn) need
+ * no microtask guesswork.
+ *
+ * Dev-only (SR8): nothing here runs unless `setProfilerSink` is handed a
+ * recording sink, which only the instrumented/profile build does.
+ */
+
+import type { ProfilerEventSink } from "./reactive.ts"
+import type { ProfilerEvent } from '@barefootjs/shared'
+
+// The event wire contract lives in `@barefootjs/shared` (built first, depended
+// on by both this runtime and the jsx analyses) — see that module for why.
+export type { ProfilerEvent, ProfilerEventType } from '@barefootjs/shared'
+
+export interface RecordingSink {
+  /** The sink to hand to `setProfilerSink(...)`. */
+  sink: ProfilerEventSink
+  /** The collected event log, in emission order. */
+  events: ProfilerEvent[]
+  /** Clear the log and the internal turn stack (start a fresh scenario). */
+  reset(): void
+}
+
+/**
+ * Build a recording sink (SR2). Hand `.sink` to `setProfilerSink`, drive a
+ * scenario, then read `.events` — a turn-stamped, ordered log ready for the
+ * SR4 join and the analyses. Turns may nest (a handler that dispatches another
+ * handler); the stack's top is the attributed turn.
+ */
+export function createRecordingSink(): RecordingSink {
+  const events: ProfilerEvent[] = []
+  const turnStack: string[] = []
+  let seq = 0
+
+  const currentTurn = (): string | null =>
+    turnStack.length > 0 ? turnStack[turnStack.length - 1] : null
+
+  const push = (e: Omit<ProfilerEvent, 'seq' | 'turn'>): void => {
+    events.push({ seq: seq++, turn: currentTurn(), ...e })
+  }
+
+  const sink: ProfilerEventSink = {
+    signalSet: (id, batched) => push({ type: 'signalSet', signal: id, batched }),
+    subscribeAdd: (signal, subscriber) => push({ type: 'subscribeAdd', signal, subscriber }),
+    subscribeRemove: (signal, subscriber) => push({ type: 'subscribeRemove', signal, subscriber }),
+    effectCreate: (id, kind) => push({ type: 'effectCreate', subscriber: id, kind }),
+    effectEnter: (id) => push({ type: 'effectEnter', subscriber: id }),
+    effectExit: (id, dur) => push({ type: 'effectExit', subscriber: id, dur }),
+    effectDispose: (id) => push({ type: 'effectDispose', subscriber: id }),
+    batchBegin: (depth) => push({ type: 'batchBegin', depth }),
+    batchFlush: (flushed) => push({ type: 'batchFlush', flushed }),
+    turnBegin: (handlerId, loc) => {
+      // Record before pushing so the marker carries the *parent* turn, then
+      // open the new turn for everything that follows.
+      push({ type: 'turnBegin', handlerId, loc })
+      turnStack.push(handlerId)
+    },
+    turnEnd: () => {
+      turnStack.pop()
+      push({ type: 'turnEnd' })
+    },
+  }
+
+  return {
+    sink,
+    events,
+    reset() {
+      events.length = 0
+      turnStack.length = 0
+      seq = 0
+    },
+  }
+}

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -30,6 +30,13 @@ export {
   type SubscriberKind,
 } from '@barefootjs/client/reactive'
 
+export {
+  createRecordingSink,
+  type ProfilerEvent,
+  type ProfilerEventType,
+  type RecordingSink,
+} from '../profiler-events.ts'
+
 export { splitProps } from '../split-props.ts'
 export { __slot, type SlotMarker } from '../slot.ts'
 export { forwardProps } from '../forward-props.ts'

--- a/packages/jsx/src/__tests__/profiler.test.ts
+++ b/packages/jsx/src/__tests__/profiler.test.ts
@@ -13,7 +13,12 @@ import {
   formatStaticBudget,
   formatBudgetDiff,
   buildProfileReport,
+  parseProfilerId,
+  buildIdIndex,
+  joinProfilerEvents,
 } from '../profiler'
+import { buildComponentAnalysis } from '../debug'
+import type { ProfilerEvent } from '@barefootjs/shared'
 
 const memoChainSource = `
   'use client'
@@ -101,6 +106,64 @@ describe('diffStaticBudget (SR6)', () => {
     const diff = diffStaticBudget(a, b)
     expect(diff.regressed).toBe(false)
     expect(formatBudgetDiff(diff)).toContain('no structural reactivity change')
+  })
+})
+
+describe('parseProfilerId (SR4)', () => {
+  test('splits <Component>#<kind>:<rest>', () => {
+    expect(parseProfilerId('Calc#memo:doubled')).toEqual({ component: 'Calc', kind: 'memo', rest: 'doubled' })
+  })
+  test('keeps the full rest for controlled-effect ids', () => {
+    expect(parseProfilerId('Calc#effect:controlled:setCount')).toEqual({
+      component: 'Calc', kind: 'effect', rest: 'controlled:setCount',
+    })
+  })
+  test('returns null for non-profiler strings', () => {
+    expect(parseProfilerId('not-an-id')).toBeNull()
+    expect(parseProfilerId('Calc#memo')).toBeNull()
+  })
+})
+
+describe('buildIdIndex + joinProfilerEvents (SR4 join)', () => {
+  const { graph } = buildComponentAnalysis(memoChainSource, 'Calc.tsx')
+  const index = buildIdIndex(graph)
+
+  const ev = (type: ProfilerEvent['type'], fields: Partial<ProfilerEvent> = {}): ProfilerEvent =>
+    ({ type, seq: 0, turn: null, ...fields })
+
+  test('indexes signals and memos by their compiler id, with source loc', () => {
+    const sig = index.get('Calc#signal:count')
+    expect(sig).toMatchObject({ kind: 'signal', name: 'count' })
+    expect(sig!.loc.line).toBeGreaterThan(0)
+
+    const memo = index.get('Calc#memo:a')
+    expect(memo).toMatchObject({ kind: 'memo', name: 'a' })
+  })
+
+  test('indexes the controlled-signal sync effect under its setter', () => {
+    expect(index.get('Calc#effect:controlled:setCount')).toMatchObject({ kind: 'effect' })
+  })
+
+  test('resolves an event stream to source-mapped nodes', () => {
+    const events = [
+      ev('signalSet', { signal: 'Calc#signal:count' }),
+      ev('effectEnter', { subscriber: 'Calc#memo:a' }),
+    ]
+    const { joined, unattributed } = joinProfilerEvents(events, index)
+    expect(joined[0].signal).toMatchObject({ kind: 'signal', name: 'count' })
+    expect(joined[1].subscriber).toMatchObject({ kind: 'memo', name: 'a' })
+    expect(unattributed).toHaveLength(0)
+  })
+
+  test('surfaces unresolved ids as a coverage gap, never dropping events', () => {
+    const events = [
+      ev('effectEnter', { subscriber: 'Calc#effect:does-not-exist' }),
+      ev('effectExit', { subscriber: 'Calc#effect:does-not-exist', dur: 1 }),
+    ]
+    const { joined, unattributed } = joinProfilerEvents(events, index)
+    expect(joined).toHaveLength(2) // events preserved
+    expect(joined[0].subscriber).toBeUndefined()
+    expect(unattributed).toEqual([{ id: 'Calc#effect:does-not-exist', count: 2 }])
   })
 })
 

--- a/packages/jsx/src/profiler.ts
+++ b/packages/jsx/src/profiler.ts
@@ -23,7 +23,8 @@ import {
   traceUpdatePath,
   type ComponentGraph,
   type UpdatePathEntry,
-} from "./debug.ts"
+} from './debug.ts'
+import type { ProfilerEvent } from '@barefootjs/shared'
 
 // -- Static budget (SR5) ------------------------------------------------------
 
@@ -254,6 +255,133 @@ export function formatBudgetDiff(d: BudgetDiff): string {
   if (lines.length === 1) lines.push('  no structural reactivity change')
   else lines.push(d.regressed ? '  ⚠ reactivity regressed' : '  ✓ no regression')
   return lines.join('\n')
+}
+
+// -- SR4 IR join --------------------------------------------------------------
+
+/** An IR node a compiler-assigned profiler id resolves to. */
+export interface ResolvedNode {
+  kind: 'signal' | 'memo' | 'effect'
+  /** Display name/label of the resolved IR node. */
+  name: string
+  loc: { file: string; line: number }
+}
+
+/** id (`<Component>#<kind>:<rest>`) → resolved IR node. */
+export type IdIndex = Map<string, ResolvedNode>
+
+export interface ParsedProfilerId {
+  component: string
+  kind: string
+  /** Everything after `<kind>:` — a name, a line, or `controlled:<setter>`. */
+  rest: string
+}
+
+/**
+ * Parse a compiler-assigned profiler id `<Component>#<kind>:<rest>` (SR1/SR3).
+ * Returns `null` for anything that isn't shaped like one, so a stray id in the
+ * event stream is surfaced as a coverage gap rather than mis-parsed.
+ */
+export function parseProfilerId(id: string): ParsedProfilerId | null {
+  const hash = id.indexOf('#')
+  if (hash < 0) return null
+  const colon = id.indexOf(':', hash)
+  if (colon < 0) return null
+  const component = id.slice(0, hash)
+  const kind = id.slice(hash + 1, colon)
+  const rest = id.slice(colon + 1)
+  if (!component || !kind || !rest) return null
+  return { component, kind, rest }
+}
+
+/**
+ * Build the id→IR-node index that the SR4 join keys on. Every graph node
+ * already carries `loc`, so this turns a raw runtime id into a source-mapped
+ * node. Effects are registered under both their source line and their label
+ * (the two shapes `effects-and-on-mounts.ts` emits), and controlled-signal
+ * sync effects under `effect:controlled:<setter>`, mirroring the compiler's
+ * id namespace (`build-declaration-emit.ts`).
+ */
+export function buildIdIndex(graph: ComponentGraph): IdIndex {
+  const comp = graph.componentName
+  const index: IdIndex = new Map()
+
+  for (const s of graph.signals) {
+    index.set(`${comp}#signal:${s.name}`, { kind: 'signal', name: s.name, loc: s.loc })
+    if (s.setter) {
+      index.set(`${comp}#effect:controlled:${s.setter}`, {
+        kind: 'effect',
+        name: `controlled:${s.setter}`,
+        loc: s.loc,
+      })
+    }
+  }
+  for (const m of graph.memos) {
+    index.set(`${comp}#memo:${m.name}`, { kind: 'memo', name: m.name, loc: m.loc })
+  }
+  for (const e of graph.effects) {
+    const node: ResolvedNode = { kind: 'effect', name: e.label, loc: e.loc }
+    index.set(`${comp}#effect:${e.loc.line}`, node)
+    index.set(`${comp}#effect:${e.label}`, node)
+  }
+  return index
+}
+
+/** A profiler id that no IR node could be found for (SR4 coverage gap). */
+export interface UnattributedId {
+  id: string
+  /** Distinct events that referenced this id. */
+  count: number
+}
+
+export interface JoinedEvent {
+  event: ProfilerEvent
+  /** Resolved node for `event.subscriber` (effect/memo), if any. */
+  subscriber?: ResolvedNode
+  /** Resolved node for `event.signal`, if any. */
+  signal?: ResolvedNode
+}
+
+export interface JoinResult {
+  joined: JoinedEvent[]
+  /**
+   * Ids referenced by the stream that the IR did not resolve — surfaced, never
+   * dropped (SR4 invariant). A non-empty list is the honest coverage caveat the
+   * analyses print.
+   */
+  unattributed: UnattributedId[]
+}
+
+/**
+ * Join a recorded event stream (SR2) to a component's IR (SR4). Each event's
+ * `subscriber` / `signal` id is resolved to its source-mapped node; ids with no
+ * match are collected as coverage gaps. This is the seam that turns a raw
+ * measurement into an explained, fixable finding.
+ */
+export function joinProfilerEvents(events: readonly ProfilerEvent[], index: IdIndex): JoinResult {
+  const joined: JoinedEvent[] = []
+  const gaps = new Map<string, number>()
+
+  const resolve = (id: string | undefined): ResolvedNode | undefined => {
+    if (id === undefined) return undefined
+    const node = index.get(id)
+    if (!node) gaps.set(id, (gaps.get(id) ?? 0) + 1)
+    return node
+  }
+
+  for (const event of events) {
+    joined.push({
+      event,
+      subscriber: resolve(event.subscriber),
+      signal: resolve(event.signal),
+    })
+  }
+
+  const unattributed = [...gaps.entries()]
+    .map(([id, count]) => ({ id, count }))
+    .sort((a, b) => b.count - a.count)
+
+  return { joined, unattributed }
 }
 
 // -- Dynamic report (SR1–SR4) — placeholder seam ------------------------------

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -35,3 +35,9 @@ export {
   BOOLEAN_ATTRS,
 } from './dom-prop.ts'
 export type { DOMPropKind, DOMPropClassification } from './dom-prop.ts'
+
+export type {
+  ProfilerEvent,
+  ProfilerEventType,
+  ProfilerSubscriberKind,
+} from './profiler-events.ts'

--- a/packages/shared/src/profiler-events.ts
+++ b/packages/shared/src/profiler-events.ts
@@ -1,0 +1,60 @@
+/**
+ * Profiler event wire contract (#1690, SR2).
+ *
+ * This is the shared shape between the *producer* (the client runtime's
+ * `createRecordingSink`, which collects instrumentation into this log) and the
+ * *consumer* (the `@barefootjs/jsx` analyses + SR4 IR join). It lives in
+ * `@barefootjs/shared` — the leaf both packages depend on and which builds
+ * first — so neither side owns the other's type and the jsx↔client peer
+ * relationship stays free of a build-order cycle.
+ *
+ * Pure data: no runtime, dev-only by construction (only an instrumented run
+ * ever produces these).
+ */
+
+/** Subscriber kinds the reactive instrumentation reports (SR1). */
+export type ProfilerSubscriberKind = 'effect' | 'memo' | 'root'
+
+/** The instrumentation points, as a discriminated `type` tag. */
+export type ProfilerEventType =
+  | 'signalSet'
+  | 'subscribeAdd'
+  | 'subscribeRemove'
+  | 'effectCreate'
+  | 'effectEnter'
+  | 'effectExit'
+  | 'effectDispose'
+  | 'batchBegin'
+  | 'batchFlush'
+  | 'turnBegin'
+  | 'turnEnd'
+
+/**
+ * One normalized instrumentation event (SR2). Flat with optional fields rather
+ * than a per-type union so the analyses can scan a homogeneous log; `type`
+ * discriminates which fields are populated.
+ */
+export interface ProfilerEvent {
+  type: ProfilerEventType
+  /** Monotonic order of emission — stable across runs for a fixed scenario. */
+  seq: number
+  /** Handler id of the turn in scope when this fired, or `null` outside a turn. */
+  turn: string | null
+  /** Triggering signal id (`signalSet`) or the subscribed-to signal (`subscribe*`). */
+  signal?: string
+  /** The effect/memo id (`effect*`) or the subscriber side of a subscription. */
+  subscriber?: string
+  /** Effect run duration in ms (`effectExit` only). */
+  dur?: number
+  /** Subscriber kind (`effectCreate` only). */
+  kind?: ProfilerSubscriberKind
+  /** Whether the set happened inside a `batch()` (`signalSet` only). */
+  batched?: boolean
+  /** Open batch depth (`batchBegin` only). */
+  depth?: number
+  /** Effects flushed by a batch (`batchFlush` only). */
+  flushed?: number
+  /** Turn handler id + optional source loc (`turnBegin` only). */
+  handlerId?: string
+  loc?: string
+}


### PR DESCRIPTION
**Stacked on #1787** (base: `claude/profiler-sr3-deleg-turns`). Builds the **dynamic measurement substrate** — the SR2 event log and the SR4 IR join — that the v1 analyses consume. Pure data + pure functions, fully unit-tested with synthetic and real-graph inputs (no browser run needed).

## What

### `@barefootjs/shared` — wire contract
`ProfilerEvent` / `ProfilerEventType` (SR2). The normalized event shape shared by the runtime *producer* and the jsx *consumer*.

> **Why `shared`, not `client`:** build order is `shared → jsx → client`, and `@barefootjs/client` is a **peer** of jsx. A jsx→client type import is a build-order cycle (jsx compiles before client's `dist` exists — I hit exactly this: client's `build:types` started pulling `jsx/src/profiler.ts` and failing). `shared` is the leaf both depend on and builds first, so neither side owns the other's type.

### `@barefootjs/client` — SR2 collector
`createRecordingSink()` turns the raw `ProfilerEventSink` callbacks (SR1) into a flat, ordered, **turn-stamped** log. It owns the `beginTurn`/`endTurn` stack (SR3) and stamps every event with the handler id in scope — so per-turn metrics (batch savings, runs/turn) need no microtask guesswork. `.reset()` starts a fresh scenario.

### `@barefootjs/jsx` — SR4 IR join
- `buildIdIndex(graph)` — id → source-mapped IR node, keyed on the compiler-assigned ids (`Comp#signal:x`, `#memo:y`, `#effect:<line|label>`, `#effect:controlled:<setter>`). Every graph node already carries `loc`.
- `joinProfilerEvents(events, index)` — resolves each event's `subscriber`/`signal` id to its node; **unresolved ids are surfaced as coverage gaps, never dropped** (SR4 invariant — the honest caveat the analyses print).
- `parseProfilerId(id)` — robust `<Component>#<kind>:<rest>` split.

## What's deferred
Turn/handler-id → loc resolution needs `slotId` on the event-summary side (today `EventBinding` lacks it); it lands with the **batch advisor** (stack-6), which is the first consumer that cites handler loc. This PR resolves the graph-backed nodes the hot-subscriber / wasted-re-run analyses key on.

## Tests
- `packages/client/__tests__/profiler-events.test.ts` — turn stamping, ordering, outside-turn `null`, `reset`.
- `packages/jsx/src/__tests__/profiler.test.ts` — `parseProfilerId`, index build (incl. controlled effect), resolution against a real compiled graph, and the coverage-gap path.

shared 47 · client 348 · jsx profiler/profile 25 — all green. `build:types` for shared→client→jsx all exit 0; typecheck clean across the three packages.

## Stack

1. #1770 — design + SR5 + SR6 + CLI
2. #1780 — SR1 runtime instrumentation
3. #1784 — SR3 `__bfId` emission
4. #1785 — SR3 turn markers (top-level)
5. #1787 — SR3 turn markers (loop delegation)
6. **this PR** — SR2 collector + SR4 IR join
7. next — v1 analyses (hot subscribers · wasted re-runs · batch advisor) on this substrate

https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN)_