### PR TITLE
Hot-subscribers analysis (#1690, §4.2.1)

### DIFF
--- a/.changeset/profiler-hot-subscribers.md
+++ b/.changeset/profiler-hot-subscribers.md
@@ -1,0 +1,19 @@
+---
+"@barefootjs/jsx": minor
+---
+
+Add the hot-subscribers analysis (#1690, §4.2.1) — the first v1 profiler insight.
+
+`analyzeHotSubscribers(events, index, options)` consumes the SR2 event stream
+and the SR4 id index and ranks effects/memos by total run time, each joined to
+its IR source loc:
+
+- `runs` (`effectEnter` count), `totalMs` (Σ `effectExit.dur`),
+- `runsPerTurn` — average runs per active turn, the re-run-pressure signal that
+  flags batch / over-subscription candidates,
+- `hot` when `runsPerTurn` meets a configurable threshold (default 2),
+- `topN` to keep only the costliest.
+
+Pure and deterministic: the same stream yields the same ranking (timings vary,
+ranks/structure do not). Unresolved subscriber ids are surfaced as coverage
+gaps, never dropped. `formatHotSubscribers` renders the human report.

--- a/packages/jsx/src/__tests__/profiler-hot-subscribers.test.ts
+++ b/packages/jsx/src/__tests__/profiler-hot-subscribers.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Hot subscribers analysis (#1690, §4.2.1).
+ *
+ * Pure over the SR2 event stream + SR4 id index: ranks effects/memos by total
+ * run time, surfaces re-run pressure (`runsPerTurn`), and joins each to source
+ * loc. Deterministic — same stream ⇒ same ranking.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { analyzeHotSubscribers, buildIdIndex, formatHotSubscribers } from '../profiler'
+import { buildComponentAnalysis } from '../debug'
+import type { ProfilerEvent } from '@barefootjs/shared'
+
+const source = `
+  'use client'
+  import { createSignal, createMemo, createEffect } from '@barefootjs/client'
+
+  export function Calc() {
+    const [count, setCount] = createSignal(0)
+    const a = createMemo(() => count() * 2)
+    createEffect(() => console.log(a()))
+    return <button onClick={() => setCount(n => n + 1)}>{a()}</button>
+  }
+`
+
+const { graph } = buildComponentAnalysis(source, 'Calc.tsx')
+const index = buildIdIndex(graph)
+
+let seq = 0
+const ev = (type: ProfilerEvent['type'], f: Partial<ProfilerEvent> = {}): ProfilerEvent =>
+  ({ type, seq: seq++, turn: null, ...f })
+
+describe('analyzeHotSubscribers', () => {
+  test('ranks by total ms, sums dur, counts runs, and joins loc', () => {
+    seq = 0
+    const memo = 'Calc#memo:a'
+    const events: ProfilerEvent[] = [
+      ev('effectEnter', { subscriber: memo, turn: 'Calc#handler:s0:click' }),
+      ev('effectExit', { subscriber: memo, dur: 5, turn: 'Calc#handler:s0:click' }),
+      ev('effectEnter', { subscriber: memo, turn: 'Calc#handler:s0:click' }),
+      ev('effectExit', { subscriber: memo, dur: 7, turn: 'Calc#handler:s0:click' }),
+    ]
+    const r = analyzeHotSubscribers(events, index)
+    expect(r.subscribers).toHaveLength(1)
+    const top = r.subscribers[0]
+    expect(top.subscriber).toBe(memo)
+    expect(top.runs).toBe(2)
+    expect(top.totalMs).toBe(12)
+    expect(top.name).toBe('a')
+    expect(top.kind).toBe('memo')
+    expect(top.loc!.line).toBeGreaterThan(0)
+  })
+
+  test('runsPerTurn flags re-run pressure within a turn', () => {
+    seq = 0
+    const id = 'Calc#memo:a'
+    // 3 runs, all in the same turn → 3 runs/turn → hot at default threshold 2.
+    const events: ProfilerEvent[] = [
+      ev('effectEnter', { subscriber: id, turn: 't1' }),
+      ev('effectEnter', { subscriber: id, turn: 't1' }),
+      ev('effectEnter', { subscriber: id, turn: 't1' }),
+    ]
+    const r = analyzeHotSubscribers(events, index)
+    expect(r.subscribers[0].turns).toBe(1)
+    expect(r.subscribers[0].runsPerTurn).toBe(3)
+    expect(r.subscribers[0].hot).toBe(true)
+  })
+
+  test('one run per turn across turns is not hot', () => {
+    seq = 0
+    const id = 'Calc#memo:a'
+    const events: ProfilerEvent[] = [
+      ev('effectEnter', { subscriber: id, turn: 't1' }),
+      ev('effectEnter', { subscriber: id, turn: 't2' }),
+    ]
+    const r = analyzeHotSubscribers(events, index)
+    expect(r.subscribers[0].runsPerTurn).toBe(1)
+    expect(r.subscribers[0].hot).toBe(false)
+  })
+
+  test('ranks hottest-by-time first and honors topN', () => {
+    seq = 0
+    const events: ProfilerEvent[] = [
+      ev('effectEnter', { subscriber: 'Calc#memo:a' }),
+      ev('effectExit', { subscriber: 'Calc#memo:a', dur: 1 }),
+      ev('effectEnter', { subscriber: 'Calc#signal:count' }), // not a real subscriber id but indexed
+      ev('effectExit', { subscriber: 'Calc#signal:count', dur: 99 }),
+    ]
+    const r = analyzeHotSubscribers(events, index, { topN: 1 })
+    expect(r.subscribers).toHaveLength(1)
+    expect(r.subscribers[0].totalMs).toBe(99)
+  })
+
+  test('unresolved subscriber ids surface as coverage gaps, events not dropped', () => {
+    seq = 0
+    const ghost = 'Calc#effect:does-not-exist'
+    const events: ProfilerEvent[] = [
+      ev('effectEnter', { subscriber: ghost }),
+      ev('effectExit', { subscriber: ghost, dur: 3 }),
+    ]
+    const r = analyzeHotSubscribers(events, index)
+    expect(r.subscribers[0].loc).toBeUndefined()
+    expect(r.subscribers[0].runs).toBe(1)
+    expect(r.unattributed.map(u => u.id)).toContain(ghost)
+  })
+
+  test('formats a readable report with a hot note', () => {
+    seq = 0
+    const events: ProfilerEvent[] = [
+      ev('effectEnter', { subscriber: 'Calc#memo:a', turn: 't1' }),
+      ev('effectEnter', { subscriber: 'Calc#memo:a', turn: 't1' }),
+      ev('effectExit', { subscriber: 'Calc#memo:a', dur: 4 }),
+    ]
+    const out = formatHotSubscribers(analyzeHotSubscribers(events, index))
+    expect(out).toContain('hot subscribers')
+    expect(out).toContain('runs/turn')
+  })
+})

--- a/packages/jsx/src/profiler.ts
+++ b/packages/jsx/src/profiler.ts
@@ -384,6 +384,140 @@ export function joinProfilerEvents(events: readonly ProfilerEvent[], index: IdIn
   return { joined, unattributed }
 }
 
+// -- Analysis: hot subscribers (v1, §4.2.1) -----------------------------------
+
+export interface HotSubscriber {
+  /** The compiler-assigned subscriber id (effect/memo). */
+  subscriber: string
+  /** Source-mapped node from the SR4 join; absent ⇒ a coverage gap. */
+  loc?: { file: string; line: number }
+  name?: string
+  kind?: 'signal' | 'memo' | 'effect'
+  /** Number of times this subscriber ran (`effectEnter` count). */
+  runs: number
+  /** Total run time in ms (Σ `effectExit.dur`). */
+  totalMs: number
+  /** Distinct turns in which it ran at least once. */
+  turns: number
+  /** `runs / turns` — average runs per active turn (re-run pressure). */
+  runsPerTurn: number
+  /** True when `runsPerTurn` meets the configured threshold. */
+  hot: boolean
+}
+
+export interface HotSubscribersResult {
+  kind: 'hot-subscribers'
+  /** Ranked by `totalMs` descending, then `runs` descending. */
+  subscribers: HotSubscriber[]
+  /** SR4 coverage gaps — subscriber ids the IR could not resolve. */
+  unattributed: UnattributedId[]
+}
+
+export interface HotSubscribersOptions {
+  /** `runsPerTurn` at/above which a subscriber is flagged `hot`. Default 2. */
+  hotRunsPerTurn?: number
+  /** Keep only the top-N by `totalMs` (after ranking). Default: all. */
+  topN?: number
+}
+
+const DEFAULT_HOT_RUNS_PER_TURN = 2
+
+/**
+ * Hot subscribers (§4.2.1): which effects/memos ran most and cost most, joined
+ * to IR source loc. Pure over the SR2 stream + SR4 index — same scenario ⇒ same
+ * ranking (timings vary, ranks/structure do not).
+ *
+ * `runsPerTurn` is the re-run-pressure signal: an effect that runs many times
+ * within a single turn is a batch / over-subscription candidate (links to the
+ * batch advisor and wasted-re-runs analyses).
+ */
+export function analyzeHotSubscribers(
+  events: readonly ProfilerEvent[],
+  index: IdIndex,
+  options: HotSubscribersOptions = {},
+): HotSubscribersResult {
+  const threshold = options.hotRunsPerTurn ?? DEFAULT_HOT_RUNS_PER_TURN
+
+  interface Acc {
+    runs: number
+    totalMs: number
+    turns: Set<string>
+  }
+  const byId = new Map<string, Acc>()
+  const acc = (id: string): Acc => {
+    let a = byId.get(id)
+    if (!a) {
+      a = { runs: 0, totalMs: 0, turns: new Set() }
+      byId.set(id, a)
+    }
+    return a
+  }
+
+  for (const e of events) {
+    if (e.subscriber === undefined) continue
+    if (e.type === 'effectEnter') {
+      const a = acc(e.subscriber)
+      a.runs++
+      // `turn` is the handler in scope; '' keys the no-turn bucket so a
+      // subscriber that only runs outside any turn still has turns ≥ 1.
+      a.turns.add(e.turn ?? '')
+    } else if (e.type === 'effectExit' && e.dur !== undefined) {
+      acc(e.subscriber).totalMs += e.dur
+    }
+  }
+
+  const { joined, unattributed } = joinProfilerEvents(events, index)
+  const nodeFor = new Map<string, JoinedEvent['subscriber']>()
+  for (const j of joined) {
+    if (j.event.subscriber !== undefined && j.subscriber) nodeFor.set(j.event.subscriber, j.subscriber)
+  }
+
+  let subscribers: HotSubscriber[] = [...byId.entries()].map(([subscriber, a]) => {
+    const node = nodeFor.get(subscriber)
+    const turns = a.turns.size
+    const runsPerTurn = turns > 0 ? a.runs / turns : a.runs
+    return {
+      subscriber,
+      loc: node?.loc,
+      name: node?.name,
+      kind: node?.kind,
+      runs: a.runs,
+      totalMs: a.totalMs,
+      turns,
+      runsPerTurn,
+      hot: runsPerTurn >= threshold,
+    }
+  })
+
+  subscribers.sort((x, y) => y.totalMs - x.totalMs || y.runs - x.runs)
+  if (options.topN !== undefined) subscribers = subscribers.slice(0, options.topN)
+
+  // Only subscriber ids matter for this analysis — filter the join's gaps to
+  // ids that actually appeared as a subscriber.
+  const subscriberIds = new Set(byId.keys())
+  const gaps = unattributed.filter(u => subscriberIds.has(u.id))
+
+  return { kind: 'hot-subscribers', subscribers, unattributed: gaps }
+}
+
+export function formatHotSubscribers(r: HotSubscribersResult): string {
+  const lines: string[] = []
+  lines.push('hot subscribers — most run / most time')
+  if (r.subscribers.length === 0) {
+    lines.push('  (no effect/memo runs recorded)')
+  }
+  for (const s of r.subscribers) {
+    const where = s.loc ? `${s.loc.file}:${s.loc.line}` : '(unresolved)'
+    const label = s.name ?? s.subscriber
+    const note = s.hot ? `   ⚠ hot: ${s.runsPerTurn.toFixed(1)} runs/turn` : ''
+    lines.push(`  ${label.padEnd(16)} ${s.runs} runs, ${s.totalMs.toFixed(1)}ms  (${where})${note}`)
+  }
+  if (r.unattributed.length > 0) {
+    lines.push(`  ⚠ coverage: ${r.unattributed.length} unresolved subscriber id(s)`)
+  }
+  return lines.join('\n')
+}
+
 // -- Dynamic report (SR1–SR4) — placeholder seam ------------------------------
 
 export interface ProfileReport {


### PR DESCRIPTION
**Stacked on #1788** (base: `claude/profiler-sr4-join`). The first **v1 analysis** on the SR2/SR4 substrate — the payoff layer that turns the event log into a ranked, source-mapped finding.

## What

`analyzeHotSubscribers(events, index, options)` — pure over the SR2 stream + SR4 id index:

| field | meaning |
|---|---|
| `runs` | `effectEnter` count |
| `totalMs` | Σ `effectExit.dur` |
| `turns` | distinct turns it ran in |
| `runsPerTurn` | `runs / turns` — **re-run pressure** |
| `hot` | `runsPerTurn ≥ threshold` (default 2) |
| `loc`/`name`/`kind` | from the SR4 join |

Ranked by `totalMs` desc (then `runs`), `topN`-sliceable. `formatHotSubscribers` renders:

```
hot subscribers — most run / most time
  a                3 runs, 12.0ms  (Calc.tsx:7)   ⚠ hot: 3.0 runs/turn
```

`runsPerTurn` is the key signal: an effect that runs many times *within one turn* is exactly a batch / over-subscription candidate — it links the user from "this is expensive" to the batch-advisor and wasted-re-runs fixes.

## Properties

- **Deterministic** (SR7): same stream ⇒ same ranking. Timings vary, ranks/structure don't — tests assert on `runs`/`turns`/`runsPerTurn`/order, not wall-clock.
- **Honest coverage** (SR4 invariant): an unresolved subscriber id still counts its runs but reports `loc: undefined` and shows up in `unattributed`; events are never dropped.

## Not in this PR

`--scenario` CLI wiring needs the run **driver** (an instrumented harness that produces the event log); that's a separate piece. `buildProfileReport` still points at the spec. This PR ships the analysis as an independently-tested pure function the driver will call.

## Tests

`packages/jsx/src/__tests__/profiler-hot-subscribers.test.ts` (6) — ranking + `dur` sum + run count + loc join; `runsPerTurn` hot vs not-hot; `topN`; coverage-gap; format. jsx typecheck clean; profiler suite 21 green.

## Stack

1. #1770 · 2. #1780 · 3. #1784 · 4. #1785 · 5. #1787 · 6. #1788 (SR2/SR4 substrate)
7. **this PR** — hot subscribers
8. next — batch advisor (+ post-write-derived-read safety oracle, handler-loc join) · wasted re-runs (+ output fingerprint instrumentation)

https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN)_