### PR TITLE
Batch-advisor analysis — measured half (#1690, §4.2.3)

### DIFF
--- a/.changeset/profiler-batch-advisor.md
+++ b/.changeset/profiler-batch-advisor.md
@@ -1,0 +1,17 @@
+---
+"@barefootjs/jsx": minor
+---
+
+Add the batch-advisor analysis — measured half (#1690, §4.2.3).
+
+`analyzeBatchAdvisor(events)` groups the SR2 stream by turn and, per turn,
+measures effect `totalRuns` vs `distinctSubscribers`; `savings = totalRuns −
+distinctSubscribers` is the runs a `batch()` wrap would collapse. Turns with
+`savings > 0` are reported, ranked by savings. This is the cost BarefootJS's
+explicit-batching model uniquely incurs (`set()` notifies synchronously).
+
+Measured half only: every candidate is `safety: 'unverified'`. The static
+post-write-derived-read oracle that proves a `batch()` wrap is behavior-
+preserving (and the handler-loc join for the finding's source location) lands
+in a follow-up (#1790) — an advisory that could change behavior is never
+labeled `'safe'` (§4.2.3). `formatBatchAdvisor` renders the report.

--- a/packages/jsx/src/__tests__/profiler-batch-advisor.test.ts
+++ b/packages/jsx/src/__tests__/profiler-batch-advisor.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Batch advisor analysis (#1690, §4.2.3).
+ *
+ * Per turn, measures effect `totalRuns` vs `distinctSubscribers`; the gap is
+ * what a `batch()` wrap would collapse. Measured half — every candidate is
+ * `safety: 'unverified'` until the static oracle lands.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { analyzeBatchAdvisor, formatBatchAdvisor } from '../profiler'
+import type { ProfilerEvent } from '@barefootjs/shared'
+
+let seq = 0
+const ev = (type: ProfilerEvent['type'], f: Partial<ProfilerEvent> = {}): ProfilerEvent =>
+  ({ type, seq: seq++, turn: null, ...f })
+
+describe('analyzeBatchAdvisor', () => {
+  test('savings = totalRuns - distinctSubscribers for a multi-write turn', () => {
+    seq = 0
+    // Turn t1: two writes each re-run effects e1 and e2 → 4 runs, 2 distinct.
+    const events: ProfilerEvent[] = [
+      ev('effectEnter', { subscriber: 'C#effect:e1', turn: 't1' }),
+      ev('effectEnter', { subscriber: 'C#effect:e2', turn: 't1' }),
+      ev('effectEnter', { subscriber: 'C#effect:e1', turn: 't1' }),
+      ev('effectEnter', { subscriber: 'C#effect:e2', turn: 't1' }),
+    ]
+    const r = analyzeBatchAdvisor(events)
+    expect(r.candidates).toHaveLength(1)
+    expect(r.candidates[0]).toMatchObject({
+      turn: 't1', totalRuns: 4, distinctSubscribers: 2, savings: 2, safety: 'unverified',
+    })
+  })
+
+  test('a turn where every effect runs once is not a candidate', () => {
+    seq = 0
+    const events: ProfilerEvent[] = [
+      ev('effectEnter', { subscriber: 'C#effect:e1', turn: 't1' }),
+      ev('effectEnter', { subscriber: 'C#effect:e2', turn: 't1' }),
+    ]
+    expect(analyzeBatchAdvisor(events).candidates).toHaveLength(0)
+  })
+
+  test('runs outside any turn are ignored', () => {
+    seq = 0
+    const events: ProfilerEvent[] = [
+      ev('effectEnter', { subscriber: 'C#effect:e1' }), // turn null
+      ev('effectEnter', { subscriber: 'C#effect:e1' }),
+    ]
+    expect(analyzeBatchAdvisor(events).candidates).toHaveLength(0)
+  })
+
+  test('ranks turns by savings descending', () => {
+    seq = 0
+    const events: ProfilerEvent[] = [
+      // t1 saves 1
+      ev('effectEnter', { subscriber: 'C#effect:e1', turn: 't1' }),
+      ev('effectEnter', { subscriber: 'C#effect:e1', turn: 't1' }),
+      // t2 saves 3
+      ev('effectEnter', { subscriber: 'C#effect:e1', turn: 't2' }),
+      ev('effectEnter', { subscriber: 'C#effect:e1', turn: 't2' }),
+      ev('effectEnter', { subscriber: 'C#effect:e1', turn: 't2' }),
+      ev('effectEnter', { subscriber: 'C#effect:e1', turn: 't2' }),
+    ]
+    const r = analyzeBatchAdvisor(events)
+    expect(r.candidates.map(c => c.turn)).toEqual(['t2', 't1'])
+    expect(r.candidates[0].savings).toBe(3)
+  })
+
+  test('formats candidates and never claims safety in the measured half', () => {
+    seq = 0
+    const events: ProfilerEvent[] = [
+      ev('effectEnter', { subscriber: 'C#effect:e1', turn: 'Checkout#handler:s0:submit' }),
+      ev('effectEnter', { subscriber: 'C#effect:e1', turn: 'Checkout#handler:s0:submit' }),
+    ]
+    const out = formatBatchAdvisor(analyzeBatchAdvisor(events))
+    expect(out).toContain('batch candidate 2→1')
+    expect(out).toContain('safety unverified')
+    expect(out).not.toContain(', safe)')
+  })
+})

--- a/packages/jsx/src/profiler.ts
+++ b/packages/jsx/src/profiler.ts
@@ -518,6 +518,96 @@ export function formatHotSubscribers(r: HotSubscribersResult): string {
   return lines.join('\n')
 }
 
+// -- Analysis: batch advisor (v1, §4.2.3) -------------------------------------
+
+export type BatchSafety = 'safe' | 'unsafe' | 'unverified'
+
+export interface BatchCandidate {
+  /** The turn's handler id (`<Component>#handler:<slot>:<event>`). */
+  turn: string
+  /** Total effect runs in the turn. */
+  totalRuns: number
+  /** Distinct effects that ran (the floor a batched turn would collapse to). */
+  distinctSubscribers: number
+  /** `totalRuns − distinctSubscribers` — runs a `batch()` wrap would remove. */
+  savings: number
+  /**
+   * Whether wrapping the handler in `batch()` is provably behavior-preserving.
+   * `'unverified'` until the static post-write-derived-read oracle (SR4) runs —
+   * a savings opportunity is surfaced, but never advised as `'safe'` without
+   * proof (§4.2.3).
+   */
+  safety: BatchSafety
+}
+
+export interface BatchAdvisorResult {
+  kind: 'batch-advisor'
+  /** Turns with `savings > 0`, ranked by `savings` descending. */
+  candidates: BatchCandidate[]
+}
+
+/**
+ * Batch advisor (§4.2.3). BarefootJS uses **explicit** `batch()` — `set()`
+ * notifies synchronously — so a turn that writes several signals re-runs shared
+ * effects once per write. Per turn this measures `totalRuns` (effect runs) vs
+ * `distinctSubscribers` (unique effects); `savings = totalRuns −
+ * distinctSubscribers` is what a `batch()` wrap would collapse.
+ *
+ * Measured half only: every candidate is reported `safety: 'unverified'`. The
+ * static safety oracle that upgrades a candidate to `'safe'`/`'unsafe'` lands
+ * in a follow-up — an advisory that could change behavior must not be labeled
+ * safe (§4.2.3).
+ */
+export function analyzeBatchAdvisor(events: readonly ProfilerEvent[]): BatchAdvisorResult {
+  interface TurnAcc {
+    totalRuns: number
+    subscribers: Set<string>
+  }
+  const byTurn = new Map<string, TurnAcc>()
+
+  for (const e of events) {
+    if (e.type !== 'effectEnter' || e.turn === null) continue
+    let acc = byTurn.get(e.turn)
+    if (!acc) {
+      acc = { totalRuns: 0, subscribers: new Set() }
+      byTurn.set(e.turn, acc)
+    }
+    acc.totalRuns++
+    if (e.subscriber !== undefined) acc.subscribers.add(e.subscriber)
+  }
+
+  const candidates: BatchCandidate[] = []
+  for (const [turn, acc] of byTurn) {
+    const distinctSubscribers = acc.subscribers.size
+    const savings = acc.totalRuns - distinctSubscribers
+    if (savings > 0) {
+      candidates.push({
+        turn,
+        totalRuns: acc.totalRuns,
+        distinctSubscribers,
+        savings,
+        safety: 'unverified',
+      })
+    }
+  }
+  candidates.sort((a, b) => b.savings - a.savings || b.totalRuns - a.totalRuns)
+
+  return { kind: 'batch-advisor', candidates }
+}
+
+export function formatBatchAdvisor(r: BatchAdvisorResult): string {
+  const lines: string[] = []
+  lines.push('batch advisor — unbatched multi-write turns')
+  if (r.candidates.length === 0) {
+    lines.push('  (no turn would benefit from batching)')
+  }
+  for (const c of r.candidates) {
+    const safe = c.safety === 'safe' ? ', safe' : c.safety === 'unsafe' ? ', UNSAFE' : ', safety unverified'
+    lines.push(`  ${c.turn.padEnd(28)} batch candidate ${c.totalRuns}→${c.distinctSubscribers} (saves ${c.savings}${safe})`)
+  }
+  return lines.join('\n')
+}
+
 // -- Dynamic report (SR1–SR4) — placeholder seam ------------------------------
 
 export interface ProfileReport {


### PR DESCRIPTION
**Stacked on #1789** (base: `claude/profiler-hot-subscribers`). The second v1 analysis — and the one most specific to BarefootJS.

## Why this one matters here
BarefootJS chose **explicit** `batch()` (auto-batching off — `set()` notifies synchronously). So a turn that writes several signals re-runs shared effects once *per write* — a real, common cost that auto-batching runtimes don't have (#1374). This analysis finds exactly those turns.

## What

`analyzeBatchAdvisor(events)` groups the SR2 stream by turn:

- `totalRuns` — effect runs in the turn
- `distinctSubscribers` — unique effects (the floor a batched turn collapses to)
- `savings = totalRuns − distinctSubscribers`

Turns with `savings > 0` are reported, ranked. `formatBatchAdvisor`:

```
batch advisor — unbatched multi-write turns
  Checkout#handler:s0:submit   batch candidate 4→1 (saves 3, safety unverified)
```

## Safety: deliberately not claimed yet

Per §4.2.3 an advisory that could change behavior must **not** be labeled safe. This PR is the **measured half** — every candidate is `safety: 'unverified'`. The static **post-write-derived-read oracle** (proves a `batch()` wrap preserves behavior) and the **handler-loc join** (so the finding cites `Checkout.tsx:40`, currently blocked because `EventBinding` has no `slotId`) are tracked in **#1790**. The format test asserts the measured half never prints `safe`.

## Tests

`packages/jsx/src/__tests__/profiler-batch-advisor.test.ts` (5) — savings math, single-run turn is not a candidate, out-of-turn runs ignored, ranking by savings, and the no-false-safety format check. Typecheck clean.

## Stack

1–6. design + substrate (#1770 → #1788) · 7. #1789 hot subscribers
8. **this PR** — batch advisor (measured); safety oracle + handler-loc → #1790
9. next — wasted re-runs (+ output-fingerprint instrumentation), then the `--scenario` run driver + CLI wiring

https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN)_