### PR TITLE
Profiler end-to-end verification + per-turn metric refinement (#1690)

### DIFF
--- a/.changeset/profiler-cli-scenario.md
+++ b/.changeset/profiler-cli-scenario.md
@@ -1,0 +1,22 @@
+---
+"@barefootjs/jsx": minor
+"@barefootjs/cli": minor
+---
+
+Wire `bf debug profile <component> --scenario auto` — the dynamic run (#1690).
+
+The CLI now mounts a component's instrumented build in happy-dom, fires each
+interactive element once, and prints the joined report (hot subscribers + batch
+advisor + coverage). `buildProfileReport(input)` becomes a real pure function
+(graph + SR4 join + analyses → ranked findings) and `formatProfileReport`
+renders it; `@barefootjs/jsx` now also exports the analysis functions and the
+dependency-free `testAdapter` for tooling.
+
+Also fixes a real bug found while dogfooding: the **multi-component** compile
+path did not thread `options.profile` to `generateClientJs`, so profile-mode
+ids were silently dropped for any file exporting more than one component. Now
+threaded — single- and multi-component files both emit ids (profile-off output
+is unchanged).
+
+happy-dom is a CLI devDependency, imported lazily so the static modes
+(`bf debug profile <component>` / `--diff`) carry no DOM cost.

--- a/.changeset/profiler-e2e-metric-refine.md
+++ b/.changeset/profiler-e2e-metric-refine.md
@@ -1,0 +1,18 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Refine the hot-subscribers per-turn metric and add end-to-end profiling proof
+(#1690).
+
+Running the full substrate end-to-end (real `reactive.ts` instrumentation +
+`createRecordingSink` + SR4 join + analyses) surfaced that `runsPerTurn`
+conflated the one-time mount run (`turn=null`) with interaction turns — an
+effect a click re-runs 5× read as a diluted `3.0`. Hot subscribers now split
+`mountRuns` out and compute `runsPerTurn = (runs − mountRuns) / interactionTurns`,
+matching the batch advisor's mount-excluding turn handling, and the report
+shows each subscriber's `kind` (memo vs effect).
+
+Adds `profiler-e2e.test.ts`: drives a mirrored Cart graph (exact compiler ids)
+through the live runtime and asserts the joined story — an unbatched 3-write
+click re-runs `total` 5×/turn; a `batch()` collapses 14 effect runs to 5.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,10 +28,14 @@
   },
   "dependencies": {
     "esbuild": "^0.25.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "@barefootjs/client": "workspace:*",
+    "@barefootjs/shared": "workspace:*"
   },
   "devDependencies": {
     "@barefootjs/jsx": "workspace:*",
-    "@types/node": "^22.0.0"
+    "@types/node": "^22.0.0",
+    "@happy-dom/global-registrator": "^20.0.11",
+    "happy-dom": "^20.0.11"
   }
 }

--- a/packages/cli/src/__tests__/scenario-driver.test.ts
+++ b/packages/cli/src/__tests__/scenario-driver.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Scenario driver (#1690, SR2/SR7) — the dynamic half of `bf debug profile`.
+ *
+ * Mounts a component's instrumented build in happy-dom, fires its interactive
+ * elements, and records the reactive event stream. This exercises the real
+ * runtime end-to-end (the unit tests in @barefootjs/jsx feed synthetic streams).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { runAutoScenario } from '../lib/scenario-driver'
+
+const COUNTER = `
+  'use client'
+  import { createSignal, createMemo } from '@barefootjs/client'
+  export function Counter() {
+    const [count, setCount] = createSignal(0)
+    const doubled = createMemo(() => count() * 2)
+    return <button onClick={() => setCount(count() + 1)}>{doubled()}</button>
+  }
+`
+
+describe('runAutoScenario', () => {
+  test('mounts, fires the handler, and records a turn-stamped stream', async () => {
+    const r = await runAutoScenario(COUNTER, 'Counter.tsx', 'Counter')
+    expect(r.rootTag).toBe('button')
+    expect(r.fired).toBeGreaterThanOrEqual(1)
+    expect(r.events.length).toBeGreaterThan(0)
+
+    // The auto-click drove the compiled handler's beginTurn/endTurn wrapper.
+    const turn = r.events.find(e => e.type === 'turnBegin')
+    expect(turn?.handlerId).toMatch(/^Counter#handler:s\d+:click$/)
+
+    // The set landed inside that turn, and the memo re-ran with its real id.
+    const set = r.events.find(e => e.type === 'signalSet' && e.signal === 'Counter#signal:count')
+    expect(set?.turn).toBe(turn!.handlerId)
+    expect(r.events.some(e => e.type === 'effectEnter' && e.subscriber === 'Counter#memo:doubled')).toBe(true)
+  })
+
+  test('a component with no handler records no interaction turns', async () => {
+    const DISPLAY = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Display() { const [n] = createSignal(5); return <div>{n()}</div> }
+    `
+    const r = await runAutoScenario(DISPLAY, 'Display.tsx', 'Display')
+    expect(r.events.some(e => e.type === 'turnBegin')).toBe(false)
+  })
+})

--- a/packages/cli/src/commands/debug-profile.ts
+++ b/packages/cli/src/commands/debug-profile.ts
@@ -1,13 +1,15 @@
 // bf debug profile <component> — reactive performance profiler (#1690).
 //
 // Three modes:
-//   bf debug profile <component>              Static reactivity budget (SR5, no run)
-//   bf debug profile <component> --diff <ref> Compile-diff regression (SR6, no run)
-//   bf debug profile --scenario <file>        Dynamic measured run (SR1–SR4) — not yet implemented
+//   bf debug profile <component>                Static reactivity budget (SR5, no run)
+//   bf debug profile <component> --diff <ref>   Compile-diff regression (SR6, no run)
+//   bf debug profile <component> --scenario auto Dynamic measured run (SR1–SR4): mount
+//                                                the instrumented build, fire each handler,
+//                                                rank hot subscribers + batch candidates
 //
 // The static modes are pure functions of the IR (reuse @barefootjs/jsx's
-// shipped static analysis). The dynamic mode is specified in spec/profiler.md
-// and prints a pointer until the measurement substrate lands.
+// shipped static analysis). The dynamic mode drives the component in happy-dom
+// and joins the recorded event stream to the IR.
 
 import { execFileSync } from 'child_process'
 import { readFileSync } from 'fs'
@@ -43,24 +45,13 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
     diffStaticBudget,
     formatBudgetDiff,
     buildProfileReport,
+    formatProfileReport,
   } = await import('@barefootjs/jsx')
-
-  // -- Dynamic mode (SR1–SR4): specified, not yet implemented ---------------
-  if (flags.scenario) {
-    try {
-      buildProfileReport(flags.scenario)
-    } catch (err) {
-      console.error((err as Error).message)
-      process.exit(1)
-    }
-    return
-  }
 
   const componentName = flags.positional[0]
   if (!componentName) {
     console.error('Error: Component name required.')
-    console.error('Usage: bf debug profile <component> [--diff <ref>] [--fanout <n>] [--json]')
-    console.error('       bf debug profile --scenario <file>   (dynamic run — see spec/profiler.md)')
+    console.error('Usage: bf debug profile <component> [--diff <ref>] [--scenario auto] [--fanout <n>] [--json]')
     process.exit(1)
   }
 
@@ -74,6 +65,37 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
   }
 
   const source = readFileSync(resolved.filePath, 'utf-8')
+
+  // -- Dynamic mode (SR1–SR4): mount the instrumented build and measure -----
+  if (flags.scenario) {
+    if (flags.scenario !== 'auto') {
+      console.error(`Error: only --scenario auto is supported (got "${flags.scenario}").`)
+      console.error('  auto = mount the component and fire each interactive element once.')
+      process.exit(1)
+    }
+    try {
+      const { runAutoScenario } = await import('../lib/scenario-driver')
+      const { events, fired } = await runAutoScenario(source, resolved.filePath, resolved.componentName)
+      const report = buildProfileReport({
+        source,
+        filePath: resolved.filePath,
+        componentName: resolved.componentName,
+        scenario: 'auto',
+        events,
+      })
+      if (ctx.jsonFlag) {
+        console.log(JSON.stringify(report, null, 2))
+      } else {
+        console.log(formatProfileReport(report))
+        if (fired === 0) console.log('  note: no interactive elements were found to fire.')
+      }
+    } catch (err) {
+      console.error(`Error: ${(err as Error).message}`)
+      process.exit(1)
+    }
+    return
+  }
+
   const head = buildStaticBudget(source, resolved.filePath, resolved.componentName, {
     fanOutThreshold: flags.fanOutThreshold,
   })

--- a/packages/cli/src/lib/scenario-driver.ts
+++ b/packages/cli/src/lib/scenario-driver.ts
@@ -1,0 +1,126 @@
+// Scenario driver for `bf debug profile --scenario` (#1690, SR2/SR7).
+//
+// Drives a component's *instrumented* build through a real DOM and records the
+// reactive event stream the analyses consume. The "auto" scenario mounts the
+// component and fires every interactive element once — a zero-config profile
+// that needs no scenario file, so a component can be profiled the moment it has
+// a handler.
+//
+// happy-dom + the client runtime are imported lazily, so the static modes
+// (`bf debug profile <component>` / `--diff`) carry no DOM dependency.
+
+import { writeFileSync, mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import type { ProfilerEvent } from '@barefootjs/shared'
+
+export interface ScenarioResult {
+  events: ProfilerEvent[]
+  /** Tag of the mounted root element. */
+  rootTag: string
+  /** Interactive elements the auto scenario fired. */
+  fired: number
+}
+
+/** Component names the compiled client JS registers, in emission order. */
+function registeredNames(clientJs: string): string[] {
+  const names: string[] = []
+  for (const m of clientJs.matchAll(/hydrate\(\s*['"]([A-Za-z_]\w*)['"]/g)) names.push(m[1])
+  return names
+}
+
+/**
+ * Pick which registered component to mount. Prefer the requested name (exact,
+ * then case-insensitive — `collapsible` → `Collapsible`); otherwise the first
+ * registered component (the file's primary export).
+ */
+function pickMountName(requested: string | undefined, registered: string[]): string | undefined {
+  if (registered.length === 0) return undefined
+  if (requested) {
+    const exact = registered.find(n => n === requested)
+    if (exact) return exact
+    const ci = registered.find(n => n.toLowerCase() === requested.toLowerCase())
+    if (ci) return ci
+  }
+  return registered[0]
+}
+
+/** Unique interactive descendants (root included) to exercise in the auto scenario. */
+function collectClickables(root: HTMLElement): HTMLElement[] {
+  const set = new Set<HTMLElement>()
+  const SELECTOR = 'button, a, [role="button"], [onclick]'
+  if (root.matches(SELECTOR)) set.add(root)
+  for (const el of Array.from(root.querySelectorAll<HTMLElement>(SELECTOR))) set.add(el)
+  // Fall back to the root itself so a wrapper component still gets one event.
+  return set.size > 0 ? [...set] : [root]
+}
+
+/**
+ * Compile `source` in profile mode, mount it in happy-dom, fire every
+ * interactive element once, and return the recorded event stream (SR2).
+ */
+export async function runAutoScenario(
+  source: string,
+  filePath: string,
+  componentName?: string,
+): Promise<ScenarioResult> {
+  // 1. DOM — lazy so static modes don't pay for it.
+  const { GlobalRegistrator } = await import('@happy-dom/global-registrator')
+  if (typeof (globalThis as { window?: unknown }).window === 'undefined') {
+    GlobalRegistrator.register()
+  }
+
+  // 2. Instrumented client JS (adapter-independent — testAdapter is enough).
+  const { compileJSX, testAdapter } = await import('@barefootjs/jsx')
+  const out = compileJSX(source, filePath, { adapter: testAdapter, profile: true })
+  const clientJs = out.files.find((f: { type: string }) => f.type === 'clientJs')?.content as
+    | string
+    | undefined
+  if (!clientJs) {
+    throw new Error(
+      'No client JS emitted — the component is stateless (no signals/handlers), so there is nothing to profile dynamically. Use the static budget instead.',
+    )
+  }
+
+  // 3. Rewrite the runtime import to an absolute URL so the temp module (which
+  //    sits outside any node_modules) resolves it, and so the sink we install
+  //    is the *same* physical reactive module the component imports. Use the
+  //    bundler's resolver (`import.meta.resolve`) — Node's `createRequire`
+  //    doesn't see workspace links here.
+  const runtimePath = import.meta.resolve('@barefootjs/client/runtime')
+  const rewritten = clientJs
+    .replace(/from\s+['"]@barefootjs\/client\/runtime['"]/g, `from ${JSON.stringify(runtimePath)}`)
+    .replace(/^import '\/\* @bf-child:\w+ \*\/'\n/gm, '')
+
+  const dir = mkdtempSync(join(tmpdir(), 'bf-profile-'))
+  const file = join(dir, 'component.mjs')
+  writeFileSync(file, rewritten)
+
+  try {
+    await import(file) // registers the component via hydrate(...)
+    const rt = (await import(runtimePath)) as {
+      createRecordingSink: () => { sink: unknown; events: ProfilerEvent[] }
+      setProfilerSink: (s: unknown) => void
+      createComponent: (name: string, props: Record<string, unknown>) => HTMLElement
+    }
+
+    const name = pickMountName(componentName, registeredNames(clientJs))
+    if (!name) throw new Error('Could not determine the component name to mount (none registered).')
+
+    const rec = rt.createRecordingSink()
+    rt.setProfilerSink(rec.sink)
+    try {
+      const el = rt.createComponent(name, {})
+      document.body.appendChild(el)
+      const targets = collectClickables(el)
+      for (const t of targets) {
+        t.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }))
+      }
+      return { events: rec.events, rootTag: el.tagName.toLowerCase(), fired: targets.length }
+    } finally {
+      rt.setProfilerSink(null)
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}

--- a/packages/jsx/src/__tests__/profiler-e2e.test.ts
+++ b/packages/jsx/src/__tests__/profiler-e2e.test.ts
@@ -1,0 +1,103 @@
+/**
+ * End-to-end profiling on the real substrate (#1690).
+ *
+ * Unlike the per-analysis unit tests (which feed synthetic event streams),
+ * this drives the **actual** instrumented runtime — `reactive.ts` (SR1),
+ * `createRecordingSink` (SR2) — over a reactive graph that mirrors the
+ * compiler's profile-mode output 1:1, using the exact ids it emits
+ * (`Cart#signal:qty`, `Cart#memo:total`, `Cart#effect:<line>`,
+ * `Cart#handler:s1:click`). It then joins to the real IR graph (SR4) and runs
+ * the v1 analyses, asserting the end-to-end story holds:
+ *
+ *   an unbatched 3-write click re-runs `total` 5×/turn; a `batch()` would
+ *   collapse 14 effect runs to 5.
+ *
+ * This is the executable proof of the pipeline until the `--scenario` run
+ * driver lands; it also pins the mount-vs-interaction metric split surfaced by
+ * running it.
+ */
+
+import { describe, test, expect, afterEach } from 'bun:test'
+import {
+  createSignal, createMemo, createEffect, createRoot,
+  beginTurn, endTurn, setProfilerSink,
+} from '../../../client/src/reactive'
+import { createRecordingSink } from '../../../client/src/profiler-events'
+import { buildIdIndex, analyzeHotSubscribers, analyzeBatchAdvisor } from '../profiler'
+import { buildComponentAnalysis } from '../debug'
+
+const CART = `
+  'use client'
+  import { createSignal, createMemo, createEffect } from '@barefootjs/client'
+  export function Cart() {
+    const [qty, setQty] = createSignal(1)
+    const [price, setPrice] = createSignal(100)
+    const [coupon, setCoupon] = createSignal(0)
+    const subtotal = createMemo(() => qty() * price())
+    const tax = createMemo(() => subtotal() * 0.1)
+    const total = createMemo(() => subtotal() + tax() - coupon())
+    createEffect(() => { console.log('total', total()) })
+    createEffect(() => { console.log('subtotal', subtotal()) })
+    return <button onClick={() => { setQty(qty() + 1); setPrice(price() + 10); setCoupon(5) }}>{total()}</button>
+  }
+`
+
+afterEach(() => setProfilerSink(null))
+
+/** Run the mirrored Cart graph under the recording sink and return the log. */
+function profileCartClick() {
+  const rec = createRecordingSink()
+  setProfilerSink(rec.sink)
+  createRoot(() => {
+    const [qty, setQty] = createSignal(1, 'Cart#signal:qty')
+    const [price, setPrice] = createSignal(100, 'Cart#signal:price')
+    const [coupon, setCoupon] = createSignal(0, 'Cart#signal:coupon')
+    const subtotal = createMemo(() => qty() * price(), 'Cart#memo:subtotal')
+    const tax = createMemo(() => subtotal() * 0.1, 'Cart#memo:tax')
+    const total = createMemo(() => subtotal() + tax() - coupon(), 'Cart#memo:total')
+    createEffect(() => { void total() }, 'Cart#effect:11')
+    createEffect(() => { void subtotal() }, 'Cart#effect:12')
+    // The compiled handler wrapper: beginTurn → handler body → endTurn.
+    beginTurn('Cart#handler:s1:click')
+    try { setQty(qty() + 1); setPrice(price() + 10); setCoupon(5) } finally { endTurn() }
+  })
+  setProfilerSink(null)
+  return rec.events
+}
+
+describe('profiler end-to-end (real substrate)', () => {
+  test('hot subscribers ranks `total` worst and source-maps it, mount excluded', () => {
+    const { graph } = buildComponentAnalysis(CART, 'Cart.tsx')
+    const index = buildIdIndex(graph)
+    const events = profileCartClick()
+
+    const hot = analyzeHotSubscribers(events, index)
+    const total = hot.subscribers.find(s => s.name === 'total')!
+    expect(total).toBeDefined()
+    expect(total.kind).toBe('memo')
+    expect(total.loc!.file).toBe('Cart.tsx')
+    // The unbatched 3-write turn re-runs `total` 5× — and mount (1 run) is
+    // excluded, so the per-turn figure is 5.0, not the diluted 3.0.
+    expect(total.mountRuns).toBe(1)
+    expect(total.turns).toBe(1)
+    expect(total.runsPerTurn).toBe(5)
+    expect(total.hot).toBe(true)
+
+    // Every hot subscriber resolved to a real source line.
+    for (const s of hot.subscribers) {
+      if (s.subscriber.startsWith('Cart#')) expect(s.loc).toBeDefined()
+    }
+  })
+
+  test('batch advisor reports the multi-write turn as a real saving', () => {
+    const events = profileCartClick()
+    const batch = analyzeBatchAdvisor(events)
+    const cand = batch.candidates.find(c => c.turn === 'Cart#handler:s1:click')!
+    expect(cand).toBeDefined()
+    // 3 unbatched writes cascade the memo chain: 14 effect runs, 5 distinct.
+    expect(cand.totalRuns).toBe(14)
+    expect(cand.distinctSubscribers).toBe(5)
+    expect(cand.savings).toBe(9)
+    expect(cand.safety).toBe('unverified')
+  })
+})

--- a/packages/jsx/src/__tests__/profiler-hot-subscribers.test.ts
+++ b/packages/jsx/src/__tests__/profiler-hot-subscribers.test.ts
@@ -66,6 +66,38 @@ describe('analyzeHotSubscribers', () => {
     expect(r.subscribers[0].hot).toBe(true)
   })
 
+  test('mount runs (turn=null) are excluded from runsPerTurn, kept as mountRuns', () => {
+    seq = 0
+    const id = 'Calc#memo:a'
+    // 1 mount run + 5 runs in one interaction turn = the worst case the e2e
+    // surfaced: per-turn pressure is 5.0, not (6 runs / 2 buckets) = 3.0.
+    const events: ProfilerEvent[] = [
+      ev('effectEnter', { subscriber: id }), // mount (turn null)
+      ev('effectEnter', { subscriber: id, turn: 't1' }),
+      ev('effectEnter', { subscriber: id, turn: 't1' }),
+      ev('effectEnter', { subscriber: id, turn: 't1' }),
+      ev('effectEnter', { subscriber: id, turn: 't1' }),
+      ev('effectEnter', { subscriber: id, turn: 't1' }),
+    ]
+    const top = analyzeHotSubscribers(events, index).subscribers[0]
+    expect(top.runs).toBe(6)
+    expect(top.mountRuns).toBe(1)
+    expect(top.turns).toBe(1)
+    expect(top.runsPerTurn).toBe(5)
+    expect(top.hot).toBe(true)
+  })
+
+  test('a subscriber that only ran at mount has runsPerTurn 0 (not hot)', () => {
+    seq = 0
+    const id = 'Calc#memo:a'
+    const events: ProfilerEvent[] = [ev('effectEnter', { subscriber: id })]
+    const top = analyzeHotSubscribers(events, index).subscribers[0]
+    expect(top.mountRuns).toBe(1)
+    expect(top.turns).toBe(0)
+    expect(top.runsPerTurn).toBe(0)
+    expect(top.hot).toBe(false)
+  })
+
   test('one run per turn across turns is not hot', () => {
     seq = 0
     const id = 'Calc#memo:a'

--- a/packages/jsx/src/__tests__/profiler.test.ts
+++ b/packages/jsx/src/__tests__/profiler.test.ts
@@ -13,6 +13,7 @@ import {
   formatStaticBudget,
   formatBudgetDiff,
   buildProfileReport,
+  formatProfileReport,
   parseProfilerId,
   buildIdIndex,
   joinProfilerEvents,
@@ -167,8 +168,39 @@ describe('buildIdIndex + joinProfilerEvents (SR4 join)', () => {
   })
 })
 
-describe('buildProfileReport (dynamic seam, SR1–SR4)', () => {
-  test('points at the spec until the substrate lands', () => {
-    expect(() => buildProfileReport('./scenarios/x.ts')).toThrow(/spec\/profiler\.md/)
+describe('buildProfileReport (dynamic, SR1–SR4 + analyses)', () => {
+  const src = `
+    'use client'
+    import { createSignal, createMemo } from '@barefootjs/client'
+    export function Calc() {
+      const [count, setCount] = createSignal(0)
+      const a = createMemo(() => count() * 2)
+      return <button onClick={() => setCount(count() + 1)}>{a()}</button>
+    }
+  `
+  let n = 0
+  const ev = (type: ProfilerEvent['type'], f: Partial<ProfilerEvent> = {}): ProfilerEvent =>
+    ({ type, seq: n++, turn: null, ...f })
+
+  test('assembles hot subscribers, batch advisor, and coverage from a stream', () => {
+    n = 0
+    const events: ProfilerEvent[] = [
+      ev('effectEnter', { subscriber: 'Calc#memo:a' }), // mount
+      ev('turnBegin', { handlerId: 'Calc#handler:s0:click' }),
+      ev('effectEnter', { subscriber: 'Calc#memo:a', turn: 'Calc#handler:s0:click' }),
+      ev('effectExit', { subscriber: 'Calc#memo:a', dur: 2, turn: 'Calc#handler:s0:click' }),
+      ev('turnEnd', {}),
+    ]
+    const r = buildProfileReport({ source: src, filePath: 'Calc.tsx', scenario: 'auto', events })
+    expect(r.kind).toBe('profile')
+    expect(r.componentName).toBe('Calc')
+    expect(r.turns).toBe(1)
+    expect(r.hotSubscribers.subscribers[0].name).toBe('a')
+    expect(r.coverage.handlersFired).toBe(1)
+    expect(r.coverage.handlersTotal).toBeGreaterThanOrEqual(1)
+    const out = formatProfileReport(r)
+    expect(out).toContain('Calc — profile')
+    expect(out).toContain('hot subscribers')
+    expect(out).toContain('coverage:')
   })
 })

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -251,6 +251,7 @@ function compileMultipleComponents(
         options.localImportPrefixes,
         undefined,
         multiAdapterCaps,
+        options.profile,
       ) || undefined,
       adapterTypes: adapterOutput.types || undefined,
     })

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -59,6 +59,9 @@ export { generateModuleExports, extractFunctionParams, formatParamWithType, find
 
 // Adapters
 export { BaseAdapter } from './adapters/interface.ts'
+// Dependency-free adapter for tooling that only needs client JS (e.g. the
+// profiler scenario driver) — the client output is adapter-independent.
+export { TestAdapter, testAdapter } from './adapters/test-adapter.ts'
 export type {
   TemplateAdapter,
   AdapterOutput,
@@ -277,15 +280,23 @@ export {
 export type { ComponentGraph, ComponentAnalysis, SignalNode, MemoNode, EffectNode, DomBinding, UpdatePath, SignalTrace, EventBinding, SetterRef, FnSetterResolution, EventSummary, LoopInfo, LoopChildBinding, LoopSummary, WhyUpdateResult, WhyUpdateDep, WhyUpdateSource, FallbackExplanation, ComponentSummary } from './debug.ts'
 export type { WrapReason } from './ir-to-client-js/reactivity.ts'
 
-// Reactive performance profiler — static half (SR5 budget, SR6 compile-diff).
-// Dynamic half (--scenario) is specified in spec/profiler.md (#1690).
+// Reactive performance profiler (#1690). Static half (SR5 budget, SR6 diff) +
+// dynamic half (SR2/SR4 join, SR7 report, v1 analyses).
 export {
   buildStaticBudget,
   formatStaticBudget,
   diffStaticBudget,
   formatBudgetDiff,
   buildProfileReport,
-} from "./profiler.ts"
+  formatProfileReport,
+  buildIdIndex,
+  joinProfilerEvents,
+  parseProfilerId,
+  analyzeHotSubscribers,
+  formatHotSubscribers,
+  analyzeBatchAdvisor,
+  formatBatchAdvisor,
+} from './profiler.ts'
 export type {
   StaticBudget,
   StaticBudgetOptions,
@@ -293,7 +304,20 @@ export type {
   BudgetDiff,
   FanOutChange,
   ProfileReport,
-} from "./profiler.ts"
+  ProfileReportInput,
+  ProfileCoverage,
+  IdIndex,
+  ResolvedNode,
+  JoinResult,
+  JoinedEvent,
+  UnattributedId,
+  HotSubscribersResult,
+  HotSubscriber,
+  HotSubscribersOptions,
+  BatchAdvisorResult,
+  BatchCandidate,
+  BatchSafety,
+} from './profiler.ts'
 
 // HTML constants
 export { BOOLEAN_ATTRS, isBooleanAttr } from './html-constants.ts'

--- a/packages/jsx/src/profiler.ts
+++ b/packages/jsx/src/profiler.ts
@@ -20,6 +20,7 @@
 import {
   buildComponentAnalysis,
   buildComponentSummary,
+  buildEventSummary,
   traceUpdatePath,
   type ComponentGraph,
   type UpdatePathEntry,
@@ -618,24 +619,96 @@ export function formatBatchAdvisor(r: BatchAdvisorResult): string {
   return lines.join('\n')
 }
 
-// -- Dynamic report (SR1–SR4) — placeholder seam ------------------------------
+// -- Dynamic report (SR1–SR4 + analyses, SR7) ---------------------------------
+
+export interface ProfileCoverage {
+  /** Distinct handlers exercised (turns observed). */
+  handlersFired: number
+  /** Handlers the IR knows about (`buildEventSummary`). */
+  handlersTotal: number
+  /** SR4 ids the IR could not resolve — the honest gap. */
+  unattributed: UnattributedId[]
+}
 
 export interface ProfileReport {
   kind: 'profile'
+  componentName: string
+  sourceFile: string
+  /** Scenario label (e.g. `'auto'` or a scenario file name). */
   scenario: string
-  // subscribers, findings, coverage — see spec/profiler.md §6.3.
+  /** Total recorded events. */
+  events: number
+  /** Distinct interaction turns. */
+  turns: number
+  hotSubscribers: HotSubscribersResult
+  batchAdvisor: BatchAdvisorResult
+  coverage: ProfileCoverage
+}
+
+export interface ProfileReportInput {
+  source: string
+  filePath: string
+  componentName?: string
+  scenario: string
+  /** The recorded event log from driving the instrumented component (SR2). */
+  events: readonly ProfilerEvent[]
 }
 
 /**
- * Dynamic, scenario-driven profile (SR1–SR4 + analyses). Not yet implemented —
- * the instrumented runtime, compiler turn markers, and IR join are specified in
- * `spec/profiler.md`. This seam keeps the public surface stable for the CLI
- * while the dynamic half is built.
+ * Assemble a dynamic profile (SR1–SR4 + analyses, SR7) from a recorded event
+ * stream. Pure: the DOM run that *produces* `events` lives in the driver (the
+ * CLI's scenario harness); this joins them to the IR and ranks findings.
+ * Deterministic — same stream + same source ⇒ same report.
  */
-export function buildProfileReport(_scenario: string): ProfileReport {
-  throw new Error(
-    'bf debug profile --scenario is not implemented yet. ' +
-      'The dynamic measurement substrate (SR1–SR4) is specified in spec/profiler.md. ' +
-      'Run `bf debug profile <component>` for the static reactivity budget (SR5).',
-  )
+export function buildProfileReport(input: ProfileReportInput): ProfileReport {
+  const { source, filePath, componentName, scenario, events } = input
+  const { graph } = buildComponentAnalysis(source, filePath, componentName)
+  const index = buildIdIndex(graph)
+
+  const hotSubscribers = analyzeHotSubscribers(events, index)
+  const batchAdvisor = analyzeBatchAdvisor(events)
+  const { unattributed } = joinProfilerEvents(events, index)
+
+  const turnIds = new Set<string>()
+  for (const e of events) if (e.turn !== null) turnIds.add(e.turn)
+
+  let handlersTotal = 0
+  try {
+    handlersTotal = buildEventSummary(source, filePath, componentName).events.length
+  } catch {
+    handlersTotal = 0
+  }
+
+  return {
+    kind: 'profile',
+    componentName: graph.componentName,
+    sourceFile: graph.sourceFile,
+    scenario,
+    events: events.length,
+    turns: turnIds.size,
+    hotSubscribers,
+    batchAdvisor,
+    coverage: {
+      handlersFired: turnIds.size,
+      handlersTotal,
+      unattributed,
+    },
+  }
+}
+
+export function formatProfileReport(r: ProfileReport): string {
+  const lines: string[] = []
+  lines.push(`${r.componentName} — profile (scenario: ${r.scenario})`)
+  lines.push(`  ${r.events} events across ${r.turns} turn(s)`)
+  lines.push('')
+  lines.push(formatHotSubscribers(r.hotSubscribers))
+  lines.push('')
+  lines.push(formatBatchAdvisor(r.batchAdvisor))
+  lines.push('')
+  const c = r.coverage
+  lines.push(`coverage: ${c.handlersFired}/${c.handlersTotal} handlers exercised`)
+  if (c.unattributed.length > 0) {
+    lines.push(`  ⚠ ${c.unattributed.length} unattributed id(s): ${c.unattributed.slice(0, 3).map(u => u.id).join(', ')}`)
+  }
+  return lines.join('\n')
 }

--- a/packages/jsx/src/profiler.ts
+++ b/packages/jsx/src/profiler.ts
@@ -393,13 +393,19 @@ export interface HotSubscriber {
   loc?: { file: string; line: number }
   name?: string
   kind?: 'signal' | 'memo' | 'effect'
-  /** Number of times this subscriber ran (`effectEnter` count). */
+  /** Total times this subscriber ran (`effectEnter` count), mount included. */
   runs: number
+  /** Runs during initial mount (outside any turn) — the unavoidable baseline. */
+  mountRuns: number
   /** Total run time in ms (Σ `effectExit.dur`). */
   totalMs: number
-  /** Distinct turns in which it ran at least once. */
+  /** Distinct *interaction* turns it ran in (mount excluded). */
   turns: number
-  /** `runs / turns` — average runs per active turn (re-run pressure). */
+  /**
+   * Interaction runs per active turn — `(runs − mountRuns) / turns`, the
+   * re-run-pressure signal. Mount is excluded so a click that re-runs an effect
+   * 5× reads as `5.0`, not diluted by the one-time mount run.
+   */
   runsPerTurn: number
   /** True when `runsPerTurn` meets the configured threshold. */
   hot: boolean
@@ -440,6 +446,7 @@ export function analyzeHotSubscribers(
 
   interface Acc {
     runs: number
+    mountRuns: number
     totalMs: number
     turns: Set<string>
   }
@@ -447,7 +454,7 @@ export function analyzeHotSubscribers(
   const acc = (id: string): Acc => {
     let a = byId.get(id)
     if (!a) {
-      a = { runs: 0, totalMs: 0, turns: new Set() }
+      a = { runs: 0, mountRuns: 0, totalMs: 0, turns: new Set() }
       byId.set(id, a)
     }
     return a
@@ -458,9 +465,10 @@ export function analyzeHotSubscribers(
     if (e.type === 'effectEnter') {
       const a = acc(e.subscriber)
       a.runs++
-      // `turn` is the handler in scope; '' keys the no-turn bucket so a
-      // subscriber that only runs outside any turn still has turns ≥ 1.
-      a.turns.add(e.turn ?? '')
+      // Runs outside any turn are the one-time mount/setup baseline — kept
+      // separate so they don't dilute the per-interaction `runsPerTurn`.
+      if (e.turn === null) a.mountRuns++
+      else a.turns.add(e.turn)
     } else if (e.type === 'effectExit' && e.dur !== undefined) {
       acc(e.subscriber).totalMs += e.dur
     }
@@ -475,13 +483,15 @@ export function analyzeHotSubscribers(
   let subscribers: HotSubscriber[] = [...byId.entries()].map(([subscriber, a]) => {
     const node = nodeFor.get(subscriber)
     const turns = a.turns.size
-    const runsPerTurn = turns > 0 ? a.runs / turns : a.runs
+    const interactionRuns = a.runs - a.mountRuns
+    const runsPerTurn = turns > 0 ? interactionRuns / turns : 0
     return {
       subscriber,
       loc: node?.loc,
       name: node?.name,
       kind: node?.kind,
       runs: a.runs,
+      mountRuns: a.mountRuns,
       totalMs: a.totalMs,
       turns,
       runsPerTurn,
@@ -508,9 +518,9 @@ export function formatHotSubscribers(r: HotSubscribersResult): string {
   }
   for (const s of r.subscribers) {
     const where = s.loc ? `${s.loc.file}:${s.loc.line}` : '(unresolved)'
-    const label = s.name ?? s.subscriber
+    const label = `${s.name ?? s.subscriber}${s.kind ? ` (${s.kind})` : ''}`
     const note = s.hot ? `   ⚠ hot: ${s.runsPerTurn.toFixed(1)} runs/turn` : ''
-    lines.push(`  ${label.padEnd(16)} ${s.runs} runs, ${s.totalMs.toFixed(1)}ms  (${where})${note}`)
+    lines.push(`  ${label.padEnd(20)} ${s.runs} runs, ${s.totalMs.toFixed(1)}ms  (${where})${note}`)
   }
   if (r.unattributed.length > 0) {
     lines.push(`  ⚠ coverage: ${r.unattributed.length} unresolved subscriber id(s)`)


### PR DESCRIPTION
**Stacked on #1791** (base: `claude/profiler-batch-advisor`). Answers "does it actually profile correctly?" by running the **whole substrate end-to-end on the live runtime**, and fixes the one metric distortion that surfaced.

## End-to-end run (real substrate, no mocks)

A `Cart` component (3 signals → `subtotal`→`tax`→`total` memo chain → 2 effects, a click that writes all 3 signals **unbatched**) compiled in profile mode emits exactly:

```js
const [qty, setQty] = createSignal(1, "Cart#signal:qty")
const total = createMemo(() => subtotal() + tax() - coupon(), "Cart#memo:total")
createEffect(() => {…}, "Cart#effect:11")
_s1.addEventListener('click', (...__bfa) => { beginTurn("Cart#handler:s1:click"); try { return (…)(...__bfa) } finally { endTurn() } })
```

`profiler-e2e.test.ts` drives that exact graph (same ids) through the real `reactive.ts` instrumentation + `createRecordingSink`, joins to the real IR graph, and runs the analyses. **Result:**

```
hot subscribers — most run / most time
  total (memo)     6 runs, …  (Cart.tsx:10)   ⚠ hot: 5.0 runs/turn
  e0 (effect)      4 runs, …  (Cart.tsx:11)   ⚠ hot: 3.0 runs/turn
  …
batch advisor — unbatched multi-write turns
  Cart#handler:s1:click   batch candidate 14→5 (saves 9, safety unverified)
```

The two findings agree and are correct: the unbatched 3-write click re-runs `total` 5× when it should run once; a `batch()` collapses 14 effect runs to 5. **The pipeline works.**

## The fix it surfaced

Running it exposed that hot-subscribers' `runsPerTurn` counted the one-time **mount** run (`turn=null`) as a turn — so `total` read a diluted `3.0` instead of the true `5.0`. The batch advisor already excluded mount; hot-subscribers now does too:
- split `mountRuns` out; `runsPerTurn = (runs − mountRuns) / interactionTurns`
- a mount-only subscriber is `0` runs/turn (not hot)
- the report shows `kind` (memo vs effect) for actionability

## Information-design findings (for the broader review)

Confirmed good: the `N→M (saves K)` batch finding and source-mapped hot list are immediately actionable. Improvements still open (tracked / noted), surfaced by this run:
- **Batch advisor cites the raw turn id**, not `Cart.tsx:14` — the handler-loc join (#1790) matters in practice.
- **Framework root `r1` (createRoot owner)** shows as an "unattributed" coverage gap — should be filtered so real gaps stand out.
- **Memo-internal `set`s** inflate the `signalSet` count (13 for 3 user writes); fine for v1 (headline metrics key on `effectEnter`), but a future write-count analysis must filter by id namespace.

## Tests
`profiler-e2e.test.ts` (2, live runtime) + updated hot-subscribers unit tests (mount-exclusion cases). Full profiler suite 30 green; typecheck clean.

https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN)_