### PR TITLE
bf debug profile --scenario auto: the CLI dynamic run (#1690)

### DIFF
--- a/.changeset/profiler-cli-scenario.md
+++ b/.changeset/profiler-cli-scenario.md
@@ -1,0 +1,22 @@
+---
+"@barefootjs/jsx": minor
+"@barefootjs/cli": minor
+---
+
+Wire `bf debug profile <component> --scenario auto` — the dynamic run (#1690).
+
+The CLI now mounts a component's instrumented build in happy-dom, fires each
+interactive element once, and prints the joined report (hot subscribers + batch
+advisor + coverage). `buildProfileReport(input)` becomes a real pure function
+(graph + SR4 join + analyses → ranked findings) and `formatProfileReport`
+renders it; `@barefootjs/jsx` now also exports the analysis functions and the
+dependency-free `testAdapter` for tooling.
+
+Also fixes a real bug found while dogfooding: the **multi-component** compile
+path did not thread `options.profile` to `generateClientJs`, so profile-mode
+ids were silently dropped for any file exporting more than one component. Now
+threaded — single- and multi-component files both emit ids (profile-off output
+is unchanged).
+
+happy-dom is a CLI devDependency, imported lazily so the static modes
+(`bf debug profile <component>` / `--diff`) carry no DOM cost.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,10 +28,14 @@
   },
   "dependencies": {
     "esbuild": "^0.25.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "@barefootjs/client": "workspace:*",
+    "@barefootjs/shared": "workspace:*"
   },
   "devDependencies": {
     "@barefootjs/jsx": "workspace:*",
-    "@types/node": "^22.0.0"
+    "@types/node": "^22.0.0",
+    "@happy-dom/global-registrator": "^20.0.11",
+    "happy-dom": "^20.0.11"
   }
 }

--- a/packages/cli/src/__tests__/scenario-driver.test.ts
+++ b/packages/cli/src/__tests__/scenario-driver.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Scenario driver (#1690, SR2/SR7) — the dynamic half of `bf debug profile`.
+ *
+ * Mounts a component's instrumented build in happy-dom, fires its interactive
+ * elements, and records the reactive event stream. This exercises the real
+ * runtime end-to-end (the unit tests in @barefootjs/jsx feed synthetic streams).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { runAutoScenario } from '../lib/scenario-driver'
+
+const COUNTER = `
+  'use client'
+  import { createSignal, createMemo } from '@barefootjs/client'
+  export function Counter() {
+    const [count, setCount] = createSignal(0)
+    const doubled = createMemo(() => count() * 2)
+    return <button onClick={() => setCount(count() + 1)}>{doubled()}</button>
+  }
+`
+
+describe('runAutoScenario', () => {
+  test('mounts, fires the handler, and records a turn-stamped stream', async () => {
+    const r = await runAutoScenario(COUNTER, 'Counter.tsx', 'Counter')
+    expect(r.rootTag).toBe('button')
+    expect(r.fired).toBeGreaterThanOrEqual(1)
+    expect(r.events.length).toBeGreaterThan(0)
+
+    // The auto-click drove the compiled handler's beginTurn/endTurn wrapper.
+    const turn = r.events.find(e => e.type === 'turnBegin')
+    expect(turn?.handlerId).toMatch(/^Counter#handler:s\d+:click$/)
+
+    // The set landed inside that turn, and the memo re-ran with its real id.
+    const set = r.events.find(e => e.type === 'signalSet' && e.signal === 'Counter#signal:count')
+    expect(set?.turn).toBe(turn!.handlerId)
+    expect(r.events.some(e => e.type === 'effectEnter' && e.subscriber === 'Counter#memo:doubled')).toBe(true)
+  })
+
+  test('a component with no handler records no interaction turns', async () => {
+    const DISPLAY = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Display() { const [n] = createSignal(5); return <div>{n()}</div> }
+    `
+    const r = await runAutoScenario(DISPLAY, 'Display.tsx', 'Display')
+    expect(r.events.some(e => e.type === 'turnBegin')).toBe(false)
+  })
+})

--- a/packages/cli/src/commands/debug-profile.ts
+++ b/packages/cli/src/commands/debug-profile.ts
@@ -1,13 +1,15 @@
 // bf debug profile <component> — reactive performance profiler (#1690).
 //
 // Three modes:
-//   bf debug profile <component>              Static reactivity budget (SR5, no run)
-//   bf debug profile <component> --diff <ref> Compile-diff regression (SR6, no run)
-//   bf debug profile --scenario <file>        Dynamic measured run (SR1–SR4) — not yet implemented
+//   bf debug profile <component>                Static reactivity budget (SR5, no run)
+//   bf debug profile <component> --diff <ref>   Compile-diff regression (SR6, no run)
+//   bf debug profile <component> --scenario auto Dynamic measured run (SR1–SR4): mount
+//                                                the instrumented build, fire each handler,
+//                                                rank hot subscribers + batch candidates
 //
 // The static modes are pure functions of the IR (reuse @barefootjs/jsx's
-// shipped static analysis). The dynamic mode is specified in spec/profiler.md
-// and prints a pointer until the measurement substrate lands.
+// shipped static analysis). The dynamic mode drives the component in happy-dom
+// and joins the recorded event stream to the IR.
 
 import { execFileSync } from 'child_process'
 import { readFileSync } from 'fs'
@@ -43,24 +45,13 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
     diffStaticBudget,
     formatBudgetDiff,
     buildProfileReport,
+    formatProfileReport,
   } = await import('@barefootjs/jsx')
-
-  // -- Dynamic mode (SR1–SR4): specified, not yet implemented ---------------
-  if (flags.scenario) {
-    try {
-      buildProfileReport(flags.scenario)
-    } catch (err) {
-      console.error((err as Error).message)
-      process.exit(1)
-    }
-    return
-  }
 
   const componentName = flags.positional[0]
   if (!componentName) {
     console.error('Error: Component name required.')
-    console.error('Usage: bf debug profile <component> [--diff <ref>] [--fanout <n>] [--json]')
-    console.error('       bf debug profile --scenario <file>   (dynamic run — see spec/profiler.md)')
+    console.error('Usage: bf debug profile <component> [--diff <ref>] [--scenario auto] [--fanout <n>] [--json]')
     process.exit(1)
   }
 
@@ -74,6 +65,37 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
   }
 
   const source = readFileSync(resolved.filePath, 'utf-8')
+
+  // -- Dynamic mode (SR1–SR4): mount the instrumented build and measure -----
+  if (flags.scenario) {
+    if (flags.scenario !== 'auto') {
+      console.error(`Error: only --scenario auto is supported (got "${flags.scenario}").`)
+      console.error('  auto = mount the component and fire each interactive element once.')
+      process.exit(1)
+    }
+    try {
+      const { runAutoScenario } = await import('../lib/scenario-driver')
+      const { events, fired } = await runAutoScenario(source, resolved.filePath, resolved.componentName)
+      const report = buildProfileReport({
+        source,
+        filePath: resolved.filePath,
+        componentName: resolved.componentName,
+        scenario: 'auto',
+        events,
+      })
+      if (ctx.jsonFlag) {
+        console.log(JSON.stringify(report, null, 2))
+      } else {
+        console.log(formatProfileReport(report))
+        if (fired === 0) console.log('  note: no interactive elements were found to fire.')
+      }
+    } catch (err) {
+      console.error(`Error: ${(err as Error).message}`)
+      process.exit(1)
+    }
+    return
+  }
+
   const head = buildStaticBudget(source, resolved.filePath, resolved.componentName, {
     fanOutThreshold: flags.fanOutThreshold,
   })

--- a/packages/cli/src/lib/scenario-driver.ts
+++ b/packages/cli/src/lib/scenario-driver.ts
@@ -1,0 +1,126 @@
+// Scenario driver for `bf debug profile --scenario` (#1690, SR2/SR7).
+//
+// Drives a component's *instrumented* build through a real DOM and records the
+// reactive event stream the analyses consume. The "auto" scenario mounts the
+// component and fires every interactive element once — a zero-config profile
+// that needs no scenario file, so a component can be profiled the moment it has
+// a handler.
+//
+// happy-dom + the client runtime are imported lazily, so the static modes
+// (`bf debug profile <component>` / `--diff`) carry no DOM dependency.
+
+import { writeFileSync, mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import type { ProfilerEvent } from '@barefootjs/shared'
+
+export interface ScenarioResult {
+  events: ProfilerEvent[]
+  /** Tag of the mounted root element. */
+  rootTag: string
+  /** Interactive elements the auto scenario fired. */
+  fired: number
+}
+
+/** Component names the compiled client JS registers, in emission order. */
+function registeredNames(clientJs: string): string[] {
+  const names: string[] = []
+  for (const m of clientJs.matchAll(/hydrate\(\s*['"]([A-Za-z_]\w*)['"]/g)) names.push(m[1])
+  return names
+}
+
+/**
+ * Pick which registered component to mount. Prefer the requested name (exact,
+ * then case-insensitive — `collapsible` → `Collapsible`); otherwise the first
+ * registered component (the file's primary export).
+ */
+function pickMountName(requested: string | undefined, registered: string[]): string | undefined {
+  if (registered.length === 0) return undefined
+  if (requested) {
+    const exact = registered.find(n => n === requested)
+    if (exact) return exact
+    const ci = registered.find(n => n.toLowerCase() === requested.toLowerCase())
+    if (ci) return ci
+  }
+  return registered[0]
+}
+
+/** Unique interactive descendants (root included) to exercise in the auto scenario. */
+function collectClickables(root: HTMLElement): HTMLElement[] {
+  const set = new Set<HTMLElement>()
+  const SELECTOR = 'button, a, [role="button"], [onclick]'
+  if (root.matches(SELECTOR)) set.add(root)
+  for (const el of Array.from(root.querySelectorAll<HTMLElement>(SELECTOR))) set.add(el)
+  // Fall back to the root itself so a wrapper component still gets one event.
+  return set.size > 0 ? [...set] : [root]
+}
+
+/**
+ * Compile `source` in profile mode, mount it in happy-dom, fire every
+ * interactive element once, and return the recorded event stream (SR2).
+ */
+export async function runAutoScenario(
+  source: string,
+  filePath: string,
+  componentName?: string,
+): Promise<ScenarioResult> {
+  // 1. DOM — lazy so static modes don't pay for it.
+  const { GlobalRegistrator } = await import('@happy-dom/global-registrator')
+  if (typeof (globalThis as { window?: unknown }).window === 'undefined') {
+    GlobalRegistrator.register()
+  }
+
+  // 2. Instrumented client JS (adapter-independent — testAdapter is enough).
+  const { compileJSX, testAdapter } = await import('@barefootjs/jsx')
+  const out = compileJSX(source, filePath, { adapter: testAdapter, profile: true })
+  const clientJs = out.files.find((f: { type: string }) => f.type === 'clientJs')?.content as
+    | string
+    | undefined
+  if (!clientJs) {
+    throw new Error(
+      'No client JS emitted — the component is stateless (no signals/handlers), so there is nothing to profile dynamically. Use the static budget instead.',
+    )
+  }
+
+  // 3. Rewrite the runtime import to an absolute URL so the temp module (which
+  //    sits outside any node_modules) resolves it, and so the sink we install
+  //    is the *same* physical reactive module the component imports. Use the
+  //    bundler's resolver (`import.meta.resolve`) — Node's `createRequire`
+  //    doesn't see workspace links here.
+  const runtimePath = import.meta.resolve('@barefootjs/client/runtime')
+  const rewritten = clientJs
+    .replace(/from\s+['"]@barefootjs\/client\/runtime['"]/g, `from ${JSON.stringify(runtimePath)}`)
+    .replace(/^import '\/\* @bf-child:\w+ \*\/'\n/gm, '')
+
+  const dir = mkdtempSync(join(tmpdir(), 'bf-profile-'))
+  const file = join(dir, 'component.mjs')
+  writeFileSync(file, rewritten)
+
+  try {
+    await import(file) // registers the component via hydrate(...)
+    const rt = (await import(runtimePath)) as {
+      createRecordingSink: () => { sink: unknown; events: ProfilerEvent[] }
+      setProfilerSink: (s: unknown) => void
+      createComponent: (name: string, props: Record<string, unknown>) => HTMLElement
+    }
+
+    const name = pickMountName(componentName, registeredNames(clientJs))
+    if (!name) throw new Error('Could not determine the component name to mount (none registered).')
+
+    const rec = rt.createRecordingSink()
+    rt.setProfilerSink(rec.sink)
+    try {
+      const el = rt.createComponent(name, {})
+      document.body.appendChild(el)
+      const targets = collectClickables(el)
+      for (const t of targets) {
+        t.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }))
+      }
+      return { events: rec.events, rootTag: el.tagName.toLowerCase(), fired: targets.length }
+    } finally {
+      rt.setProfilerSink(null)
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}

--- a/packages/jsx/src/__tests__/profiler.test.ts
+++ b/packages/jsx/src/__tests__/profiler.test.ts
@@ -13,6 +13,7 @@ import {
   formatStaticBudget,
   formatBudgetDiff,
   buildProfileReport,
+  formatProfileReport,
   parseProfilerId,
   buildIdIndex,
   joinProfilerEvents,
@@ -167,8 +168,39 @@ describe('buildIdIndex + joinProfilerEvents (SR4 join)', () => {
   })
 })
 
-describe('buildProfileReport (dynamic seam, SR1–SR4)', () => {
-  test('points at the spec until the substrate lands', () => {
-    expect(() => buildProfileReport('./scenarios/x.ts')).toThrow(/spec\/profiler\.md/)
+describe('buildProfileReport (dynamic, SR1–SR4 + analyses)', () => {
+  const src = `
+    'use client'
+    import { createSignal, createMemo } from '@barefootjs/client'
+    export function Calc() {
+      const [count, setCount] = createSignal(0)
+      const a = createMemo(() => count() * 2)
+      return <button onClick={() => setCount(count() + 1)}>{a()}</button>
+    }
+  `
+  let n = 0
+  const ev = (type: ProfilerEvent['type'], f: Partial<ProfilerEvent> = {}): ProfilerEvent =>
+    ({ type, seq: n++, turn: null, ...f })
+
+  test('assembles hot subscribers, batch advisor, and coverage from a stream', () => {
+    n = 0
+    const events: ProfilerEvent[] = [
+      ev('effectEnter', { subscriber: 'Calc#memo:a' }), // mount
+      ev('turnBegin', { handlerId: 'Calc#handler:s0:click' }),
+      ev('effectEnter', { subscriber: 'Calc#memo:a', turn: 'Calc#handler:s0:click' }),
+      ev('effectExit', { subscriber: 'Calc#memo:a', dur: 2, turn: 'Calc#handler:s0:click' }),
+      ev('turnEnd', {}),
+    ]
+    const r = buildProfileReport({ source: src, filePath: 'Calc.tsx', scenario: 'auto', events })
+    expect(r.kind).toBe('profile')
+    expect(r.componentName).toBe('Calc')
+    expect(r.turns).toBe(1)
+    expect(r.hotSubscribers.subscribers[0].name).toBe('a')
+    expect(r.coverage.handlersFired).toBe(1)
+    expect(r.coverage.handlersTotal).toBeGreaterThanOrEqual(1)
+    const out = formatProfileReport(r)
+    expect(out).toContain('Calc — profile')
+    expect(out).toContain('hot subscribers')
+    expect(out).toContain('coverage:')
   })
 })

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -251,6 +251,7 @@ function compileMultipleComponents(
         options.localImportPrefixes,
         undefined,
         multiAdapterCaps,
+        options.profile,
       ) || undefined,
       adapterTypes: adapterOutput.types || undefined,
     })

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -59,6 +59,9 @@ export { generateModuleExports, extractFunctionParams, formatParamWithType, find
 
 // Adapters
 export { BaseAdapter } from './adapters/interface.ts'
+// Dependency-free adapter for tooling that only needs client JS (e.g. the
+// profiler scenario driver) — the client output is adapter-independent.
+export { TestAdapter, testAdapter } from './adapters/test-adapter.ts'
 export type {
   TemplateAdapter,
   AdapterOutput,
@@ -277,15 +280,23 @@ export {
 export type { ComponentGraph, ComponentAnalysis, SignalNode, MemoNode, EffectNode, DomBinding, UpdatePath, SignalTrace, EventBinding, SetterRef, FnSetterResolution, EventSummary, LoopInfo, LoopChildBinding, LoopSummary, WhyUpdateResult, WhyUpdateDep, WhyUpdateSource, FallbackExplanation, ComponentSummary } from './debug.ts'
 export type { WrapReason } from './ir-to-client-js/reactivity.ts'
 
-// Reactive performance profiler — static half (SR5 budget, SR6 compile-diff).
-// Dynamic half (--scenario) is specified in spec/profiler.md (#1690).
+// Reactive performance profiler (#1690). Static half (SR5 budget, SR6 diff) +
+// dynamic half (SR2/SR4 join, SR7 report, v1 analyses).
 export {
   buildStaticBudget,
   formatStaticBudget,
   diffStaticBudget,
   formatBudgetDiff,
   buildProfileReport,
-} from "./profiler.ts"
+  formatProfileReport,
+  buildIdIndex,
+  joinProfilerEvents,
+  parseProfilerId,
+  analyzeHotSubscribers,
+  formatHotSubscribers,
+  analyzeBatchAdvisor,
+  formatBatchAdvisor,
+} from './profiler.ts'
 export type {
   StaticBudget,
   StaticBudgetOptions,
@@ -293,7 +304,20 @@ export type {
   BudgetDiff,
   FanOutChange,
   ProfileReport,
-} from "./profiler.ts"
+  ProfileReportInput,
+  ProfileCoverage,
+  IdIndex,
+  ResolvedNode,
+  JoinResult,
+  JoinedEvent,
+  UnattributedId,
+  HotSubscribersResult,
+  HotSubscriber,
+  HotSubscribersOptions,
+  BatchAdvisorResult,
+  BatchCandidate,
+  BatchSafety,
+} from './profiler.ts'
 
 // HTML constants
 export { BOOLEAN_ATTRS, isBooleanAttr } from './html-constants.ts'

--- a/packages/jsx/src/profiler.ts
+++ b/packages/jsx/src/profiler.ts
@@ -20,6 +20,7 @@
 import {
   buildComponentAnalysis,
   buildComponentSummary,
+  buildEventSummary,
   traceUpdatePath,
   type ComponentGraph,
   type UpdatePathEntry,
@@ -618,24 +619,96 @@ export function formatBatchAdvisor(r: BatchAdvisorResult): string {
   return lines.join('\n')
 }
 
-// -- Dynamic report (SR1–SR4) — placeholder seam ------------------------------
+// -- Dynamic report (SR1–SR4 + analyses, SR7) ---------------------------------
+
+export interface ProfileCoverage {
+  /** Distinct handlers exercised (turns observed). */
+  handlersFired: number
+  /** Handlers the IR knows about (`buildEventSummary`). */
+  handlersTotal: number
+  /** SR4 ids the IR could not resolve — the honest gap. */
+  unattributed: UnattributedId[]
+}
 
 export interface ProfileReport {
   kind: 'profile'
+  componentName: string
+  sourceFile: string
+  /** Scenario label (e.g. `'auto'` or a scenario file name). */
   scenario: string
-  // subscribers, findings, coverage — see spec/profiler.md §6.3.
+  /** Total recorded events. */
+  events: number
+  /** Distinct interaction turns. */
+  turns: number
+  hotSubscribers: HotSubscribersResult
+  batchAdvisor: BatchAdvisorResult
+  coverage: ProfileCoverage
+}
+
+export interface ProfileReportInput {
+  source: string
+  filePath: string
+  componentName?: string
+  scenario: string
+  /** The recorded event log from driving the instrumented component (SR2). */
+  events: readonly ProfilerEvent[]
 }
 
 /**
- * Dynamic, scenario-driven profile (SR1–SR4 + analyses). Not yet implemented —
- * the instrumented runtime, compiler turn markers, and IR join are specified in
- * `spec/profiler.md`. This seam keeps the public surface stable for the CLI
- * while the dynamic half is built.
+ * Assemble a dynamic profile (SR1–SR4 + analyses, SR7) from a recorded event
+ * stream. Pure: the DOM run that *produces* `events` lives in the driver (the
+ * CLI's scenario harness); this joins them to the IR and ranks findings.
+ * Deterministic — same stream + same source ⇒ same report.
  */
-export function buildProfileReport(_scenario: string): ProfileReport {
-  throw new Error(
-    'bf debug profile --scenario is not implemented yet. ' +
-      'The dynamic measurement substrate (SR1–SR4) is specified in spec/profiler.md. ' +
-      'Run `bf debug profile <component>` for the static reactivity budget (SR5).',
-  )
+export function buildProfileReport(input: ProfileReportInput): ProfileReport {
+  const { source, filePath, componentName, scenario, events } = input
+  const { graph } = buildComponentAnalysis(source, filePath, componentName)
+  const index = buildIdIndex(graph)
+
+  const hotSubscribers = analyzeHotSubscribers(events, index)
+  const batchAdvisor = analyzeBatchAdvisor(events)
+  const { unattributed } = joinProfilerEvents(events, index)
+
+  const turnIds = new Set<string>()
+  for (const e of events) if (e.turn !== null) turnIds.add(e.turn)
+
+  let handlersTotal = 0
+  try {
+    handlersTotal = buildEventSummary(source, filePath, componentName).events.length
+  } catch {
+    handlersTotal = 0
+  }
+
+  return {
+    kind: 'profile',
+    componentName: graph.componentName,
+    sourceFile: graph.sourceFile,
+    scenario,
+    events: events.length,
+    turns: turnIds.size,
+    hotSubscribers,
+    batchAdvisor,
+    coverage: {
+      handlersFired: turnIds.size,
+      handlersTotal,
+      unattributed,
+    },
+  }
+}
+
+export function formatProfileReport(r: ProfileReport): string {
+  const lines: string[] = []
+  lines.push(`${r.componentName} — profile (scenario: ${r.scenario})`)
+  lines.push(`  ${r.events} events across ${r.turns} turn(s)`)
+  lines.push('')
+  lines.push(formatHotSubscribers(r.hotSubscribers))
+  lines.push('')
+  lines.push(formatBatchAdvisor(r.batchAdvisor))
+  lines.push('')
+  const c = r.coverage
+  lines.push(`coverage: ${c.handlersFired}/${c.handlersTotal} handlers exercised`)
+  if (c.unattributed.length > 0) {
+    lines.push(`  ⚠ ${c.unattributed.length} unattributed id(s): ${c.unattributed.slice(0, 3).map(u => u.id).join(', ')}`)
+  }
+  return lines.join('\n')
 }


### PR DESCRIPTION
**Stacked on #1793** (base: `claude/profiler-e2e-verification`). Closes the loop — you can now point the CLI at a real component and get a measured, source-mapped report.

```
$ bf debug profile switch --scenario auto
Switch — profile (scenario: auto)
  41 events across 1 turn(s)

hot subscribers — most run / most time
  isChecked (memo)     2 runs, 0.4ms  (…/switch/index.tsx:93)
  isControlled (memo)  1 runs, 0.1ms  (…/switch/index.tsx:90)
  controlled:setControlledChecked (effect) 1 runs, …  (…/switch/index.tsx:87)
  e1 / e2              (unresolved)               ← binding effects, #1795

batch advisor — unbatched multi-write turns
  (no turn would benefit from batching)

coverage: 1/1 handlers exercised
```

## What

- **CLI** `bf debug profile <component> --scenario auto`: compiles the component in profile mode, mounts the **real** instrumented build in happy-dom (`createComponent`), fires each interactive element once, records the SR2 stream, and prints the joined report. `--json` supported. happy-dom is a **lazy** CLI devDependency, so the static modes (`<component>` / `--diff`) carry no DOM cost.
- **jsx** `buildProfileReport(input)` is now a real pure function (graph + SR4 join + hot-subscribers + batch-advisor + coverage); `formatProfileReport` renders it. The analysis functions and the dependency-free `testAdapter` are now exported.

## Bug fixed while dogfooding 🐛

`bf debug profile collapsible --scenario auto` first reported **no ids at all** — because the **multi-component** compile path (`compiler.ts:184`) never passed `options.profile` to `generateClientJs`, while the single-component path did. So profile mode silently no-op'd for any file exporting >1 component (a large fraction of real components). One-line thread-through; profile-off output stays byte-identical (verified by the existing SR8 + 710 CLI + 30 profiler tests).

## Dogfooding outcome (the two questions)

**Does it work?** Yes — end-to-end on real components. `switch` fires its handler, source-maps both memos and the **controlled-signal sync effect** (SR4 controlled-effect indexing confirmed on real code), and reports coverage.

**Is the information design good?** The core (`N→M saves K`, ranked source-mapped hot list, honest coverage) lands. Gaps surfaced and tracked:
- **#1795** — DOM-binding effects (text/attr updates) lack `__bfId` → show as `e1/e2 (unresolved)`. Often the *most* re-run subscribers, so the hot list understates until they're attributed.
- **#1796** — `--scenario auto` on a **compound** component doesn't reach child-component handlers (`collapsible` → `0/0`); needs subtree mounting or a custom scenario file.

## Tests
`packages/cli/src/__tests__/scenario-driver.test.ts` (2, live happy-dom mount): handler fires with the right turn id, set is turn-stamped, memo re-runs with its real id; no-handler component records no turns. CLI 710 · profiler 30 · compiler-profile 7 — all green; CLI builds clean.

## Full stack (9 PRs)
#1770 design+static · #1780 SR1 · #1784 SR3 ids · #1785 / #1787 SR3 turns · #1788 SR2/SR4 · #1789 hot subs · #1791 batch advisor · #1793 e2e+refine · **#1797 this — CLI dynamic run**. Tracking: #1786 #1790 #1795 #1796.

https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN)_