### PR TITLE
Attribute DOM-binding effects in the profiler (#1690, #1795)

### DIFF
--- a/.changeset/profiler-binding-ids.md
+++ b/.changeset/profiler-binding-ids.md
@@ -1,0 +1,18 @@
+---
+"@barefootjs/jsx": minor
+---
+
+Attribute DOM-binding effects in the profiler (#1690, closes #1795).
+
+Top-level reactive bindings — text (`{total()}`), attribute (`class={…}`,
+`data-state`), client-only markers, and component/child prop syncs — now emit
+`createEffect(…, "<Component>#binding:<slotId>")` in profile mode, and
+`buildIdIndex` resolves those ids from the graph's `domBindings` (slot + loc).
+
+Previously these showed in the hot-subscribers list as bare, unresolved runtime
+ids (`e1`, `e2`) and inflated the coverage gap — yet they are often the *most*
+re-run subscribers. Now every binding re-run is attributed to a source line, so
+`bf debug profile <component> --scenario auto` reports zero coverage gaps for a
+typical component (e.g. `switch`: both attribute syncs map to `index.tsx:146`
+and `:151`). Off by default the emitted effects are byte-for-byte unchanged
+(SR8). Loop/branch-scoped binding effects remain a follow-up under #1795.

--- a/packages/jsx/src/__tests__/profile-binding-ids.test.ts
+++ b/packages/jsx/src/__tests__/profile-binding-ids.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Profile-mode ids on DOM-binding effects (#1690, SR3/SR4, issue #1795).
+ *
+ * Text / attribute updates emit `createEffect(…, "<Component>#binding:<slotId>")`
+ * in profile mode, and `buildIdIndex` resolves those ids from the graph's
+ * `domBindings` (slot + loc). Off by default the effect is unchanged (SR8).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+import { buildIdIndex } from '../profiler'
+import { buildComponentAnalysis } from '../debug'
+
+const adapter = new TestAdapter()
+
+const source = `
+  'use client'
+  import { createSignal } from '@barefootjs/client'
+  export function Widget() {
+    const [n, setN] = createSignal(0)
+    return <button class={n() > 0 ? 'on' : 'off'} onClick={() => setN(n() + 1)}>{n()}</button>
+  }
+`
+
+function clientJs(profile: boolean): string {
+  return compileJSX(source, 'Widget.tsx', { adapter, profile })
+    .files.find(f => f.type === 'clientJs')!.content
+}
+
+describe('binding-effect ids', () => {
+  test('profile off: binding effects carry no id (SR8)', () => {
+    expect(clientJs(false)).not.toContain('#binding:')
+  })
+
+  test('profile on: text/attribute binding effects carry a #binding id', () => {
+    const on = clientJs(true)
+    expect(on).toMatch(/Widget#binding:s\d+/)
+  })
+
+  test('buildIdIndex resolves #binding ids from domBindings to source loc', () => {
+    const { graph } = buildComponentAnalysis(source, 'Widget.tsx')
+    const index = buildIdIndex(graph)
+    const bindingKeys = [...index.keys()].filter(k => k.startsWith('Widget#binding:'))
+    expect(bindingKeys.length).toBeGreaterThan(0)
+    const node = index.get(bindingKeys[0])!
+    expect(node.kind).toBe('effect')
+    expect(node.loc.file).toBe('Widget.tsx')
+    expect(node.loc.line).toBeGreaterThan(0)
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/emit-reactive.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-reactive.ts
@@ -11,6 +11,18 @@ import { toHtmlAttrName, varSlotId, PROPS_PARAM } from './utils.ts'
 import { createTemplateAwareStringProtector } from './html-template.ts'
 
 /**
+ * Profile mode (#1690, SR3/SR4): the id appended to a DOM-binding effect so the
+ * profiler attributes its re-runs to a source location. Keyed by `slotId` (the
+ * `bf="sN"` marker) — `buildIdIndex` resolves `<Component>#binding:<slotId>`
+ * from `graph.domBindings`, which carry the same slot + loc. Empty when
+ * profiling is off, so the emitted effect is byte-for-byte unchanged (SR8).
+ */
+function bindingIdArg(ctx: ClientJsContext, slotId: string | undefined): string {
+  if (!ctx.profile || !slotId) return ''
+  return `, ${JSON.stringify(`${ctx.componentName}#binding:${slotId}`)}`
+}
+
+/**
  * Generate JS statements to update a DOM attribute reactively.
  * Centralizes the attribute-type dispatch (value, class, boolean, presence, generic)
  * so that new AttrMeta flags are handled in one place.
@@ -110,6 +122,7 @@ export function emitDynamicTextUpdates(lines: string[], ctx: ClientJsContext): v
         const v = varSlotId(elem.slotId)
         lines.push(`  let __anchor_${v} = _${v}`)
       }
+      const __textSlot = (normalElems[0] ?? conditionalElems[0])?.slotId
       lines.push(`  createEffect(() => {`)
       if (normalElems.length > 0) {
         // Expression is always evaluated for non-conditional elements
@@ -139,7 +152,7 @@ export function emitDynamicTextUpdates(lines: string[], ctx: ClientJsContext): v
           lines.push(`    __bfText(__el_${v}, __val)`)
         }
       }
-      lines.push(`  })`)
+      lines.push(`  }${bindingIdArg(ctx, __textSlot)})`)
       lines.push('')
     }
   }
@@ -151,7 +164,7 @@ export function emitClientOnlyExpressions(lines: string[], ctx: ClientJsContext)
     lines.push(`  // @client: ${elem.slotId}`)
     lines.push(`  createEffect(() => {`)
     lines.push(`    updateClientMarker(__scope, '${elem.slotId}', ${elem.expression})`)
-    lines.push(`  })`)
+    lines.push(`  }${bindingIdArg(ctx, elem.slotId)})`)
     lines.push('')
   }
 }
@@ -178,7 +191,7 @@ export function emitReactiveAttributeUpdates(lines: string[], ctx: ClientJsConte
         }
       }
       lines.push(`    }`)
-      lines.push(`  })`)
+      lines.push(`  }${bindingIdArg(ctx, slotId)})`)
       lines.push('')
     }
   }
@@ -236,7 +249,7 @@ export function emitReactivePropBindings(lines: string[], ctx: ClientJsContext):
       lines.push(`    }`)
     }
 
-    lines.push(`  })`)
+    lines.push(`  }${bindingIdArg(ctx, ctx.reactiveProps[0]?.slotId)})`)
   }
 }
 
@@ -271,6 +284,6 @@ export function emitReactiveChildProps(lines: string[], ctx: ClientJsContext): v
       lines.push(`    }`)
     }
 
-    lines.push(`  })`)
+    lines.push(`  }${bindingIdArg(ctx, ctx.reactiveChildProps[0]?.slotId ?? undefined)})`)
   }
 }

--- a/packages/jsx/src/profiler.ts
+++ b/packages/jsx/src/profiler.ts
@@ -325,6 +325,18 @@ export function buildIdIndex(graph: ComponentGraph): IdIndex {
     index.set(`${comp}#effect:${e.loc.line}`, node)
     index.set(`${comp}#effect:${e.label}`, node)
   }
+  // DOM-binding effects (#1690, SR3/SR4): text/attribute/conditional/loop
+  // updates emit `createEffect(…, "<Component>#binding:<slotId>")`. Resolve
+  // each from its `domBinding` (slotId + loc). Event bindings are handlers, not
+  // re-running effects — skip them.
+  for (const b of graph.domBindings) {
+    if (b.type === 'event' || !b.loc) continue
+    index.set(`${comp}#binding:${b.slotId}`, {
+      kind: 'effect',
+      name: `${b.slotId} (${b.type})`,
+      loc: { file: b.loc.file, line: b.loc.start.line },
+    })
+  }
   return index
 }
 
@@ -519,7 +531,9 @@ export function formatHotSubscribers(r: HotSubscribersResult): string {
   }
   for (const s of r.subscribers) {
     const where = s.loc ? `${s.loc.file}:${s.loc.line}` : '(unresolved)'
-    const label = `${s.name ?? s.subscriber}${s.kind ? ` (${s.kind})` : ''}`
+    const base = s.name ?? s.subscriber
+    // Binding names already carry their type (`s1 (attribute)`); don't double up.
+    const label = s.kind && !base.endsWith(')') ? `${base} (${s.kind})` : base
     const note = s.hot ? `   ⚠ hot: ${s.runsPerTurn.toFixed(1)} runs/turn` : ''
     lines.push(`  ${label.padEnd(20)} ${s.runs} runs, ${s.totalMs.toFixed(1)}ms  (${where})${note}`)
   }


### PR DESCRIPTION
**Stacked on #1797** (base: `claude/profiler-cli-scenario`). Closes **#1795** — the highest-value gap dogfooding surfaced: DOM-binding effects were unattributed.

## Before → after (real `bf debug profile switch --scenario auto`)

```
  before                                    after
  e1 (attribute)  (unresolved)              s1 (attribute)  …/switch/index.tsx:146
  e2 (attribute)  (unresolved)              s0 (attribute)  …/switch/index.tsx:151
  ⚠ coverage: 2 unresolved subscriber ids   coverage: 1/1 handlers exercised   ← zero gaps
```

## What

Top-level reactive bindings — text (`{total()}`), attribute (`class={…}`, `data-state`), client-only markers, and component/child prop syncs — now emit `createEffect(…, "<Component>#binding:<slotId>")` in profile mode (one `bindingIdArg(ctx, slotId)` helper at each emit site in `emit-reactive.ts`). `buildIdIndex` resolves those ids from the graph's `domBindings`, which already carry `slotId` + `loc`.

These binding effects are often the **most** re-run subscribers (one per reactive text/attr), so leaving them unattributed both understated the hot list and inflated the coverage gap. Now every re-run maps to a source line.

Also a small format fix: `s1 (attribute) (effect)` → `s1 (attribute)` (don't append `kind` when the name already carries a type).

## Safety

Off by default `bindingIdArg` returns `''`, so the emitted effect closes `})` exactly as before — **byte-for-byte unchanged** (SR8). Verified: CSR conformance 124 ✓, reactive-binding compiler tests 141 ✓ (snapshot unchanged), profiler suite 37 ✓, typecheck clean.

## Scope

Covers the top-level binding emitters (`emit-reactive.ts`) — the common non-loop case. Loop/branch-scoped binding effects (the `control-flow/stringify/*` emitters) remain a follow-up, tracked under #1795.

## Tests
`profile-binding-ids.test.ts` — off: no `#binding:`; on: `Widget#binding:s\d+` emitted; `buildIdIndex` resolves the binding id to source loc.

https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN)_