### PR TITLE
Batch advisor: cite handler source location (#1690, #1790)

### DIFF
--- a/.changeset/profiler-handler-loc.md
+++ b/.changeset/profiler-handler-loc.md
@@ -1,0 +1,16 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Resolve handler turn ids to source loc in the batch advisor (#1690, #1790).
+
+`buildIdIndex` now also registers handler turn ids
+(`<Component>#handler:<slotId>:<eventName>`) from the graph's `event`
+domBindings, and `analyzeBatchAdvisor(events, index?)` uses them so a candidate
+carries the handler's `loc` + friendly name. The report now reads
+
+    click@s1   batch candidate 14→5 (saves 9, safety unverified)  (Cart.tsx:14)
+
+instead of citing the raw turn id. This is the handler-loc half of #1790; the
+post-write-derived-read safety oracle (upgrading `unverified` → `safe`/`unsafe`)
+is still tracked there.

--- a/packages/jsx/src/__tests__/profiler-batch-advisor.test.ts
+++ b/packages/jsx/src/__tests__/profiler-batch-advisor.test.ts
@@ -7,7 +7,8 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { analyzeBatchAdvisor, formatBatchAdvisor } from '../profiler'
+import { analyzeBatchAdvisor, formatBatchAdvisor, buildIdIndex } from '../profiler'
+import { buildComponentAnalysis } from '../debug'
 import type { ProfilerEvent } from '@barefootjs/shared'
 
 let seq = 0
@@ -64,6 +65,32 @@ describe('analyzeBatchAdvisor', () => {
     const r = analyzeBatchAdvisor(events)
     expect(r.candidates.map(c => c.turn)).toEqual(['t2', 't1'])
     expect(r.candidates[0].savings).toBe(3)
+  })
+
+  test('resolves the handler turn id to source loc when given an id index', () => {
+    seq = 0
+    const src = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Form() {
+        const [a, setA] = createSignal(0)
+        const [b, setB] = createSignal(0)
+        return <button onClick={() => { setA(1); setB(2) }}>{a() + b()}</button>
+      }
+    `
+    const { graph } = buildComponentAnalysis(src, 'Form.tsx')
+    const index = buildIdIndex(graph)
+    // Find the handler turn id the compiler/runtime would emit for the button.
+    const turn = [...index.keys()].find(k => k.startsWith('Form#handler:'))!
+    expect(turn).toBeDefined()
+    const events: ProfilerEvent[] = [
+      ev('effectEnter', { subscriber: 'Form#binding:s0', turn }),
+      ev('effectEnter', { subscriber: 'Form#binding:s0', turn }),
+    ]
+    const c = analyzeBatchAdvisor(events, index).candidates[0]
+    expect(c.loc?.file).toBe('Form.tsx')
+    expect(c.loc?.line).toBeGreaterThan(0)
+    expect(formatBatchAdvisor(analyzeBatchAdvisor(events, index))).toMatch(/\(Form\.tsx:\d+\)/)
   })
 
   test('formats candidates and never claims safety in the measured half', () => {

--- a/packages/jsx/src/profiler.ts
+++ b/packages/jsx/src/profiler.ts
@@ -262,7 +262,7 @@ export function formatBudgetDiff(d: BudgetDiff): string {
 
 /** An IR node a compiler-assigned profiler id resolves to. */
 export interface ResolvedNode {
-  kind: 'signal' | 'memo' | 'effect'
+  kind: 'signal' | 'memo' | 'effect' | 'handler'
   /** Display name/label of the resolved IR node. */
   name: string
   loc: { file: string; line: number }
@@ -330,12 +330,22 @@ export function buildIdIndex(graph: ComponentGraph): IdIndex {
   // each from its `domBinding` (slotId + loc). Event bindings are handlers, not
   // re-running effects — skip them.
   for (const b of graph.domBindings) {
-    if (b.type === 'event' || !b.loc) continue
-    index.set(`${comp}#binding:${b.slotId}`, {
-      kind: 'effect',
-      name: `${b.slotId} (${b.type})`,
-      loc: { file: b.loc.file, line: b.loc.start.line },
-    })
+    if (!b.loc) continue
+    const loc = { file: b.loc.file, line: b.loc.start.line }
+    if (b.type === 'event') {
+      // Handler turn ids (`<Component>#handler:<slotId>:<eventName>`, SR3). The
+      // event name is embedded in the label (`click handler "s1"`).
+      const eventName = b.label.match(/^(\w+)\s+handler/)?.[1]
+      if (eventName) {
+        index.set(`${comp}#handler:${b.slotId}:${eventName}`, {
+          kind: 'handler',
+          name: `${eventName}@${b.slotId}`,
+          loc,
+        })
+      }
+      continue
+    }
+    index.set(`${comp}#binding:${b.slotId}`, { kind: 'effect', name: `${b.slotId} (${b.type})`, loc })
   }
   return index
 }
@@ -405,7 +415,7 @@ export interface HotSubscriber {
   /** Source-mapped node from the SR4 join; absent ⇒ a coverage gap. */
   loc?: { file: string; line: number }
   name?: string
-  kind?: 'signal' | 'memo' | 'effect'
+  kind?: ResolvedNode['kind']
   /** Total times this subscriber ran (`effectEnter` count), mount included. */
   runs: number
   /** Runs during initial mount (outside any turn) — the unavoidable baseline. */
@@ -550,6 +560,10 @@ export type BatchSafety = 'safe' | 'unsafe' | 'unverified'
 export interface BatchCandidate {
   /** The turn's handler id (`<Component>#handler:<slot>:<event>`). */
   turn: string
+  /** Handler source location, when the id index resolves it. */
+  loc?: { file: string; line: number }
+  /** Friendly handler name (`click@s1`), when resolved. */
+  handler?: string
   /** Total effect runs in the turn. */
   totalRuns: number
   /** Distinct effects that ran (the floor a batched turn would collapse to). */
@@ -583,7 +597,10 @@ export interface BatchAdvisorResult {
  * in a follow-up — an advisory that could change behavior must not be labeled
  * safe (§4.2.3).
  */
-export function analyzeBatchAdvisor(events: readonly ProfilerEvent[]): BatchAdvisorResult {
+export function analyzeBatchAdvisor(
+  events: readonly ProfilerEvent[],
+  index?: IdIndex,
+): BatchAdvisorResult {
   interface TurnAcc {
     totalRuns: number
     subscribers: Set<string>
@@ -606,8 +623,11 @@ export function analyzeBatchAdvisor(events: readonly ProfilerEvent[]): BatchAdvi
     const distinctSubscribers = acc.subscribers.size
     const savings = acc.totalRuns - distinctSubscribers
     if (savings > 0) {
+      const node = index?.get(turn)
       candidates.push({
         turn,
+        loc: node?.loc,
+        handler: node?.name,
         totalRuns: acc.totalRuns,
         distinctSubscribers,
         savings,
@@ -628,7 +648,9 @@ export function formatBatchAdvisor(r: BatchAdvisorResult): string {
   }
   for (const c of r.candidates) {
     const safe = c.safety === 'safe' ? ', safe' : c.safety === 'unsafe' ? ', UNSAFE' : ', safety unverified'
-    lines.push(`  ${c.turn.padEnd(28)} batch candidate ${c.totalRuns}→${c.distinctSubscribers} (saves ${c.savings}${safe})`)
+    const where = c.loc ? `  (${c.loc.file}:${c.loc.line})` : ''
+    const label = (c.handler ?? c.turn).padEnd(20)
+    lines.push(`  ${label} batch candidate ${c.totalRuns}→${c.distinctSubscribers} (saves ${c.savings}${safe})${where}`)
   }
   return lines.join('\n')
 }
@@ -680,7 +702,7 @@ export function buildProfileReport(input: ProfileReportInput): ProfileReport {
   const index = buildIdIndex(graph)
 
   const hotSubscribers = analyzeHotSubscribers(events, index)
-  const batchAdvisor = analyzeBatchAdvisor(events)
+  const batchAdvisor = analyzeBatchAdvisor(events, index)
   const { unattributed } = joinProfilerEvents(events, index)
 
   const turnIds = new Set<string>()


### PR DESCRIPTION
**Stacked on #1798** (base: `claude/profiler-binding-ids`). The handler-location half of **#1790** — batch-advisor findings now cite source instead of a raw turn id.

## Before → after

```
before:  Cart#handler:s1:click   batch candidate 14→5 (saves 9, safety unverified)
after:   click@s1                batch candidate 14→5 (saves 9, safety unverified)  (Cart.tsx:14)
```

## What

- `buildIdIndex` now also registers handler turn ids (`<Component>#handler:<slotId>:<eventName>`) — resolved from the graph's `event` domBindings (slot + loc; the event name is parsed from the binding label `click handler "s1"`). `ResolvedNode.kind` gains `'handler'`.
- `analyzeBatchAdvisor(events, index?)` takes an optional index; each candidate now carries `loc` + a friendly `handler` name (`click@s1`). `buildProfileReport` passes the index through, so the dynamic report cites the handler's source line.

This was the most visible rough edge in the working report — the spec's own example (`onSubmit: batch candidate 20→1, safe (Checkout.tsx:40)`) needs this loc.

## Still open in #1790

The **post-write-derived-read safety oracle** (upgrading `safety: 'unverified'` → `'safe'`/`'unsafe'`) remains tracked there — that's the static-analysis half. This PR is purely the source-mapping half and changes no safety semantics.

## Tests
`profiler-batch-advisor.test.ts` gains a case compiling a 2-write handler, building the index, and asserting the candidate resolves to `Form.tsx:<line>` and the formatted line matches `(Form.tsx:\d+)`. Profiler suite 34 ✓, typecheck clean, `switch` real-CLI regression clean.

https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN)_