### PR TITLE
fix(adapters): add override modifier to renderAsync for Deno strict mode

### DIFF
--- a/.changeset/adapter-override-renderasync.md
+++ b/.changeset/adapter-override-renderasync.md
@@ -1,0 +1,12 @@
+---
+"@barefootjs/go-template": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+---
+
+Add `override` modifier to `renderAsync` in the Go-template, Mojolicious
+and Xslate adapters. Required by Deno's stricter `noImplicitOverride`
+default — without it `deno publish` (and `deno check`) fail with TS4114
+since `renderAsync` is provided as a concrete fallback on `BaseAdapter`,
+not declared abstract. No runtime change — `override` is a type-only
+annotation.

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -5782,7 +5782,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     return `{{block "${slotName}" .}}{{end}}`
   }
 
-  renderAsync(node: IRAsync): string {
+  override renderAsync(node: IRAsync): string {
     const fallback = this.renderNode(node.fallback)
     const children = this.renderChildren(node.children)
     // Go templates use the OOS protocol: render a placeholder with fallback,

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1092,7 +1092,7 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     return `<%= content %>`
   }
 
-  renderAsync(node: IRAsync): string {
+  override renderAsync(node: IRAsync): string {
     const fallback = this.renderNode(node.fallback)
     const children = this.renderChildren(node.children)
     // Use the BarefootJS.pm streaming helpers for OOS streaming.

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -982,7 +982,7 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     return `<: $children | mark_raw :>`
   }
 
-  renderAsync(node: IRAsync): string {
+  override renderAsync(node: IRAsync): string {
     const fallback = this.renderNode(node.fallback)
     const children = this.renderChildren(node.children)
     // Capture the fallback into a Kolon macro and pass its rendered HTML to


### PR DESCRIPTION
Stacked on #1792.

## Summary

Adds the `override` modifier to `renderAsync` in three adapter
implementations so Deno's default `noImplicitOverride: true` accepts
them. Without this `deno check` / `deno publish` fail with **TS4114**:

> This member must have an 'override' modifier because it overrides a member in the base class 'BaseAdapter'.

`BaseAdapter.renderAsync` is a *concrete* fallback (not abstract), so
overriding it must be annotated. Affected packages:

- `@barefootjs/go-template`
- `@barefootjs/mojolicious`
- `@barefootjs/xslate`

`override` is a type-only annotation — no runtime change.

## Why not also `@barefootjs/hono`?

The Hono adapter has the same TS4114 issue but also a much larger
Deno-compatibility surface — Hono's JSX `IntrinsicElements` index
signature clashes with its per-element types (~30 TS2411), `Bun.spawn`
/ `import.meta.dir` are referenced in some entries (TS2867, TS2339),
etc. Fixing all of that without forking off `hono/jsx`'s real types
is non-trivial, so it is deliberately deferred. The follow-up CI PR
will exclude `adapter-hono` from the `deno check` gate (with a
tracking issue link) to keep the rest of the matrix green while that
work is scoped.

## Test plan

- [x] `deno check src/index.ts` passes for go-template, mojolicious, xslate (verified locally via generated `deno.json` from `bun scripts/jsr-publish.ts --dry-run --keep`)
- [x] `bun run build:types` (tsgo) unaffected — `override` is preserved in `.d.ts` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)