### PR TITLE
Attribute the loop reconcile effect in the profiler (#1690, #1795)

### DIFF
--- a/.changeset/profiler-loop-ids.md
+++ b/.changeset/profiler-loop-ids.md
@@ -1,0 +1,18 @@
+---
+"@barefootjs/client": minor
+"@barefootjs/jsx": patch
+---
+
+Attribute the loop reconcile effect in the profiler (#1690, #1795).
+
+`mapArray` / `mapArrayAnchored` gain an optional `bfId` forwarded to their
+internal reconcile `createEffect`, and the loop emitter passes
+`<Component>#binding:<slotId>` for it in profile mode. `buildIdIndex` already
+resolves that id from the graph's `loop` domBinding (slot + loc).
+
+Dogfooding a list component showed the loop's reconcile effect is typically the
+**single costliest subscriber** (it re-renders the list on every change) yet was
+unattributed — it dominated the hot list as a bare `e1`. Now it reads
+`s7 (loop)  3 runs, 4.8ms  (TodoApp.tsx:29)`. Off by default the `mapArray`
+call is byte-for-byte unchanged (SR8). Per-item loop-child text effects remain
+a follow-up under #1795.

--- a/packages/client/src/runtime/map-array.ts
+++ b/packages/client/src/runtime/map-array.ts
@@ -222,6 +222,7 @@ export function mapArray<T>(
   getKey: ((item: T, index: number) => string) | null,
   renderItem: (item: () => T, index: number, existing?: HTMLElement) => HTMLElement,
   markerId?: string,
+  bfId?: string,
 ): void {
   if (!container) return
 
@@ -389,7 +390,7 @@ export function mapArray<T>(
         insertScope(scope, container, anchor)
       }
     }
-  })
+  }, bfId)
 }
 
 // ---------------------------------------------------------------------------
@@ -521,6 +522,7 @@ export function mapArrayAnchored<T>(
   getKey: ((item: T, index: number) => string) | null,
   renderItem: (item: () => T, index: number, existing?: Comment) => DocumentFragment | Comment,
   markerId?: string,
+  bfId?: string,
 ): void {
   if (!container) return
 
@@ -615,5 +617,5 @@ export function mapArrayAnchored<T>(
         placeAnchorScope(scope, container, end, end)
       }
     }
-  })
+  }, bfId)
 }

--- a/packages/jsx/src/__tests__/profile-binding-ids.test.ts
+++ b/packages/jsx/src/__tests__/profile-binding-ids.test.ts
@@ -28,6 +28,35 @@ function clientJs(profile: boolean): string {
     .files.find(f => f.type === 'clientJs')!.content
 }
 
+const loopSource = `
+  'use client'
+  import { createSignal } from '@barefootjs/client'
+  export function List() {
+    const [items] = createSignal([{ id: 1, t: 'a' }, { id: 2, t: 'b' }])
+    return <ul>{items().map(it => <li key={it.id}>{it.t}</li>)}</ul>
+  }
+`
+
+describe('loop-effect id (mapArray bfId)', () => {
+  test('profile on: mapArray carries the loop binding id; off: it does not', () => {
+    const on = compileJSX(loopSource, 'List.tsx', { adapter, profile: true })
+      .files.find(f => f.type === 'clientJs')!.content
+    const off = compileJSX(loopSource, 'List.tsx', { adapter, profile: false })
+      .files.find(f => f.type === 'clientJs')!.content
+    expect(on).toMatch(/mapArray\(.*List#binding:s\d+/s)
+    expect(off).not.toContain('#binding:')
+  })
+
+  test('buildIdIndex resolves the loop binding to source loc', () => {
+    const { graph } = buildComponentAnalysis(loopSource, 'List.tsx')
+    const index = buildIdIndex(graph)
+    const loopBinding = graph.domBindings.find(b => b.type === 'loop')!
+    const node = index.get(`List#binding:${loopBinding.slotId}`)
+    expect(node?.kind).toBe('effect')
+    expect(node?.loc.file).toBe('List.tsx')
+  })
+})
+
 describe('binding-effect ids', () => {
   test('profile off: binding effects carry no id (SR8)', () => {
     expect(clientJs(false)).not.toContain('#binding:')

--- a/packages/jsx/src/ir-to-client-js/control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow.ts
@@ -64,7 +64,10 @@ export function emitClientOnlyConditionals(lines: string[], ctx: ClientJsContext
  */
 export function emitLoopUpdates(lines: string[], ctx: ClientJsContext, unsafeLocalNames: Set<string>): void {
   for (const elem of ctx.loopElements) {
-    const plan = buildLoopPlan(elem, { unsafeLocalNames })
+    const plan = buildLoopPlan(elem, {
+      unsafeLocalNames,
+      profileComponentName: ctx.profile ? ctx.componentName : undefined,
+    })
     stringifyLoop(lines, plan)
     emitLoopEventDelegation(lines, elem, plan.kind, ctx.profile ? ctx.componentName : undefined)
   }

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop.ts
@@ -50,6 +50,8 @@ import type {
 export interface BuildLoopPlanOptions {
   /** Local names whose CSR-time substitution forces the static-array self-heal path (#1247). */
   unsafeLocalNames: Set<string>
+  /** Owning component name when compiling in profile mode (#1690) — else undefined. */
+  profileComponentName?: string
 }
 
 /**
@@ -64,7 +66,7 @@ export function buildLoopPlan(elem: TopLevelLoop, opts: BuildLoopPlanOptions): L
   // array's per-item conditional still toggles reactively instead of freezing
   // in the SSR-time `forEach` (which has no conditional handling at all).
   if (elem.bodyIsItemConditional) {
-    return buildPlainLoopPlan(elem)
+    return buildPlainLoopPlan(elem, opts.profileComponentName)
   }
   if (elem.isStaticArray) {
     return buildStaticLoopPlan(elem, opts.unsafeLocalNames)
@@ -77,11 +79,11 @@ export function buildLoopPlan(elem: TopLevelLoop, opts: BuildLoopPlanOptions): L
   if (elem.childComponent) {
     return buildComponentLoopPlan(elem)
   }
-  return buildPlainLoopPlan(elem)
+  return buildPlainLoopPlan(elem, opts.profileComponentName)
 }
 
 /** @internal — prefer `buildLoopPlan`. Exported for the branch-loop wrapper only. */
-export function buildPlainLoopPlan(elem: TopLevelLoop): PlainLoopPlan {
+export function buildPlainLoopPlan(elem: TopLevelLoop, profileComponentName?: string): PlainLoopPlan {
   const wrap = (expr: string) => wrapLoopParamAsAccessor(expr, elem.param, elem.paramBindings)
   const { head: paramHead, unwrap: paramUnwrap } = destructureLoopParam(elem.param, elem.paramBindings)
   const hasReactive = elem.bindings.reactiveAttrs.length > 0
@@ -92,6 +94,7 @@ export function buildPlainLoopPlan(elem: TopLevelLoop): PlainLoopPlan {
     kind: 'plain',
     containerVar: `_${varSlotId(elem.slotId)}`,
     markerId: elem.markerId,
+    profileLoopId: profileComponentName ? `${profileComponentName}#binding:${elem.slotId}` : undefined,
     arrayExpr: buildChainedArrayExpr(elem),
     keyFn: loopKeyFn(elem),
     paramHead,

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/loop.ts
@@ -50,6 +50,13 @@ interface LoopPlanCommon {
 interface DynamicLoopCommon extends LoopPlanCommon {
   /** Loop marker id — passed to mapArray so sibling loops disambiguate (#1087). */
   markerId: string
+  /**
+   * Profile mode (#1690, SR4): the loop's binding id
+   * (`<Component>#binding:<slotId>`), passed to `mapArray` as the `bfId` so its
+   * internal reconcile effect — typically the costliest subscriber in a list —
+   * is attributed to source. Undefined when profiling is off.
+   */
+  profileLoopId?: string
   /** Key function source — `null` when the loop has no explicit key. */
   keyFn: string
   /** renderItem param identifier (after destructure unwrap rename). */

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
@@ -136,13 +136,14 @@ export function stringifyPlainLoop(
   // `childRefs` need `__el` as a handle to invoke the user's callback inside
   // the factory, so non-empty refs force the multi-line layout the same way
   // reactive effects do (#1244).
+  const loopBfId = plan.profileLoopId ? `, ${JSON.stringify(plan.profileLoopId)}` : ''
   if (reactiveEffects === null && !bodyIsMultiRoot && childRefs.length === 0) {
     // Single-line renderItem (no reactive effects, single root, no refs).
     const unwrapInline = paramUnwrap ? `${paramUnwrap} ` : ''
     const preamble = mapPreambleWrapped ? `${mapPreambleWrapped}; ` : ''
     const cloneExpr = emitTemplateCloneInline(template)
     lines.push(
-      `${topIndent}mapArray(() => ${arrayExpr}, ${containerVar}, ${keyFn}, (${paramHead}, ${indexParam}, __existing) => { ${unwrapInline}${preamble}if (__existing) return __existing; ${cloneExpr} }, '${markerId}')`,
+      `${topIndent}mapArray(() => ${arrayExpr}, ${containerVar}, ${keyFn}, (${paramHead}, ${indexParam}, __existing) => { ${unwrapInline}${preamble}if (__existing) return __existing; ${cloneExpr} }, '${markerId}'${loopBfId})`,
     )
     return
   }
@@ -163,7 +164,7 @@ export function stringifyPlainLoop(
   }
   emitLoopChildRefs(lines, childRefs, { indent: bodyIndent, elVar: '__el', bodyIsMultiRoot })
   lines.push(`${bodyIndent}return __el`)
-  lines.push(`${topIndent}}, '${markerId}')`)
+  lines.push(`${topIndent}}, '${markerId}'${loopBfId})`)
 }
 
 /**
@@ -212,7 +213,8 @@ function stringifyAnchoredLoop(
     stringifyReactiveEffects(lines, reactiveEffects, { indent: bodyIndent, elVar: '__anchor', bodyIsMultiRoot: false })
   }
   lines.push(`${bodyIndent}return __frag ?? __anchor`)
-  lines.push(`${topIndent}}, '${markerId}')`)
+  const loopBfId = plan.profileLoopId ? `, ${JSON.stringify(plan.profileLoopId)}` : ''
+  lines.push(`${topIndent}}, '${markerId}'${loopBfId})`)
 }
 
 export function stringifyStaticLoop(lines: string[], plan: StaticLoopPlan): void {


### PR DESCRIPTION
**Stacked on #1799** (base: `claude/profiler-handler-loc`). Found by continuing to dogfood a more complex component.

## Dogfooding a list component (TodoApp: loop + 3 memos + multi-write handler)

Profiling it surfaced that the **loop's reconcile effect** — which re-renders the list on every change — is typically the **single costliest subscriber**, yet was unattributed (a bare `e1`, 4.8 ms, top of the hot list). It's created *inside* the runtime's `mapArray`, so the compiler couldn't id it without a runtime hook.

```
before:  e1           3 runs, 4.8ms  (unresolved)        ← top cost, invisible
after:   s7 (loop)    3 runs, 4.8ms  (TodoApp.tsx:29)
```

## What

- **runtime**: `mapArray` / `mapArrayAnchored` gain an optional `bfId`, forwarded to their internal reconcile `createEffect`.
- **compiler**: the loop emitter threads `LoopPlan.profileLoopId = <Component>#binding:<slotId>` (set in `buildPlainLoopPlan` from `ctx`, emitted as `mapArray(…, '<marker>', '<id>')`) in profile mode. `buildIdIndex` already resolves it from the graph's `loop` domBinding (slot + loc).

## Also validated while dogfooding (no code change needed)

- **Batch advisor is correct on real multi-write handlers**: it did *not* flag `addTwo` when its second write was `setFilter('all')` and filter was already `'all'` (a no-op set BarefootJS skips). With an effective second write it fires: `click@s0 batch candidate 10→8 (saves 2) (todoapp.tsx:25)`.
- **Coverage is honest**: the list-item (`<li>`) `onClick` isn't reached by the auto scenario (it fires `button`/`a`/`[role=button]`), so the report correctly reads `2/3 handlers exercised` rather than pretending.

## Safety

Off by default `profileLoopId` is undefined → the `mapArray` call closes exactly as before — **byte-for-byte unchanged** (SR8). Verified: map-array runtime 21 ✓, CSR conformance 124 ✓, loop compiler tests 123 ✓, profiler suite ✓, typecheck clean.

## Scope

Covers the **plain** loop plan (the common list case). Per-item loop-child text effects (`{t.text}` → `e2/e4/…`, tiny) and other loop variants remain a follow-up under #1795.

https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN)_