### PR TITLE
ci(jsr): gate PRs on deno check; drop dev-tooling exports from JSR

### DIFF
--- a/.changeset/jsr-skip-dev-tooling-exports.md
+++ b/.changeset/jsr-skip-dev-tooling-exports.md
@@ -1,0 +1,21 @@
+---
+"@barefootjs/go-template": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+"@barefootjs/hono": patch
+---
+
+`scripts/jsr-publish.ts`: drop dev-tooling-only export keys (`./build`,
+`./test-render`) and `bun:`-only conditions from the generated JSR
+manifests.
+
+These entries are Bun-runtime-shaped (test-render uses `Bun.*` /
+`import.meta.dir` directly; the per-adapter build helpers are wired
+for the `bf` CLI which ships as an npm executable) and never load
+cleanly under Deno's type-checker. They were the residual cause of
+`deno publish` type-check failures even after #1792 fixed import
+extensions — JSR was being asked to publish files it had no business
+type-checking against Deno's runtime.
+
+The npm-published surface is unchanged — these exports remain
+available to Bun / Node consumers exactly as before.

--- a/.github/workflows/ci-jsr-check.yml
+++ b/.github/workflows/ci-jsr-check.yml
@@ -74,13 +74,13 @@ jobs:
           # carry a tracking issue link so the exclusion is visible and
           # owned.
           #
-          # - @barefootjs/hono: blocked on adapter-hono Deno-compatibility
-          #   work — Hono's JSX IntrinsicElements indexer collides with
-          #   per-element types (TS2411), and a handful of entries
-          #   reference Bun globals (Bun.spawn, import.meta.dir). Fixing
-          #   these without forking off hono/jsx's real types is a larger
-          #   refactor than this gate's scope. See:
-          #   https://github.com/piconic-ai/barefootjs/labels/known-limitation
+          # - @barefootjs/hono: Hono JSX's `IntrinsicElements` indexer
+          #   (`[k: string]: HTMLBaseAttributes`) collides structurally
+          #   with its per-element types (~30 TS2411), plus the usual
+          #   TS2874/TS7026 JSX-globals plumbing. Fixing these without
+          #   forking off `hono/jsx`'s real types is outside this
+          #   gate's scope.
+          #   Tracking: https://github.com/piconic-ai/barefootjs/issues/1804
           declare -A SKIP=(
             ["@barefootjs/hono"]=1
           )

--- a/.github/workflows/ci-jsr-check.yml
+++ b/.github/workflows/ci-jsr-check.yml
@@ -1,0 +1,113 @@
+# CI — JSR type-check
+#
+# Runs `deno check` on every JSR-publishable package's exported entries
+# *before* merge, so the JSR invariants the release-time `deno publish`
+# enforces (explicit `.ts`/`.tsx` extensions on relative imports,
+# `node:` prefix on Node built-ins, `noImplicitOverride`, DOM lib
+# resolution) are caught at PR time rather than after-the-fact when
+# `release.yml` tries to publish.
+#
+# Pipeline mirrors what `release.yml`'s "Publish to JSR" step does, sans
+# the publish:
+#   1. `bun scripts/jsr-publish.ts --dry-run --keep` generates each
+#      eligible package's `deno.json` from its `package.json` (single
+#      source of truth — same as release).
+#   2. For each generated manifest, `deno check` runs against the
+#      `exports`-resolved `src/*.ts` entries — the surface JSR's
+#      publisher type-checks.
+#
+# Why not `deno publish --dry-run`? It additionally requires the
+# `jsr:@barefootjs/*` sibling versions referenced in `imports` to
+# already be live on JSR. That holds on `main` post-release but not on
+# a feature branch that bumps a sibling — `deno check` against the
+# locally generated manifests is the closer fit for PR-time gating.
+name: CI — JSR type-check
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/*/src/**'
+      - 'packages/*/package.json'
+      - 'packages/*/tsconfig.json'
+      - 'scripts/jsr-publish.ts'
+      - '.github/workflows/ci-jsr-check.yml'
+  pull_request:
+    paths:
+      - 'packages/*/src/**'
+      - 'packages/*/package.json'
+      - 'packages/*/tsconfig.json'
+      - 'scripts/jsr-publish.ts'
+      - '.github/workflows/ci-jsr-check.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  deno-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+        with:
+          deno-version: v2.x
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Generate deno.json manifests (dry-run)
+        run: bun scripts/jsr-publish.ts --dry-run --keep
+
+      - name: deno check each JSR-publishable package
+        run: |
+          set -uo pipefail
+
+          # Packages temporarily excluded from the gate. Each entry should
+          # carry a tracking issue link so the exclusion is visible and
+          # owned.
+          #
+          # - @barefootjs/hono: blocked on adapter-hono Deno-compatibility
+          #   work — Hono's JSX IntrinsicElements indexer collides with
+          #   per-element types (TS2411), and a handful of entries
+          #   reference Bun globals (Bun.spawn, import.meta.dir). Fixing
+          #   these without forking off hono/jsx's real types is a larger
+          #   refactor than this gate's scope. See:
+          #   https://github.com/piconic-ai/barefootjs/labels/known-limitation
+          declare -A SKIP=(
+            ["@barefootjs/hono"]=1
+          )
+
+          failed=()
+          skipped=()
+          for manifest in packages/*/deno.json; do
+            pkg_dir=$(dirname "$manifest")
+            pkg_name=$(jq -r '.name' "$manifest")
+            if [ -n "${SKIP[$pkg_name]:-}" ]; then
+              echo "::notice::skipping ${pkg_name} (excluded — see workflow comments)"
+              skipped+=("$pkg_name")
+              continue
+            fi
+            mapfile -t entries < <(jq -r '.exports | if type == "object" then values[] else . end' "$manifest")
+            echo "::group::deno check ${pkg_name} (${#entries[@]} entries)"
+            if ! ( cd "$pkg_dir" && deno check "${entries[@]}" ); then
+              failed+=("$pkg_name")
+            fi
+            echo "::endgroup::"
+          done
+
+          if [ "${#failed[@]}" -gt 0 ]; then
+            echo "::error::deno check failed for ${#failed[@]} package(s): ${failed[*]}"
+            exit 1
+          fi
+          echo "deno check passed for all gated JSR-publishable packages."
+          if [ "${#skipped[@]}" -gt 0 ]; then
+            echo "Skipped (tracked separately): ${skipped[*]}"
+          fi

--- a/scripts/jsr-publish.ts
+++ b/scripts/jsr-publish.ts
@@ -107,15 +107,33 @@ for (const dir of pkgDirs) {
   candidates.push({ dir, pkg })
 }
 
+// Export keys that are dev-tooling helpers, not consumer-runtime API:
+//   ./build       — the package's barefoot.config.ts build-config factory.
+//                   Consumers run their build under Bun/Node (the `bf`
+//                   CLI ships as an npm executable), so a Deno-shaped
+//                   build entry has no audience, and its node:fs/Buffer
+//                   typings trip Deno's stricter check (e.g. TS2367 on
+//                   `Buffer !== string` comparisons that tsgo lets pass).
+//   ./test-render — IR test-render harness; only ever defined via the
+//                   `bun:` export condition and uses Bun.* globals
+//                   directly. Genuinely Bun-only.
+// Both are intentionally absent from the JSR surface — npm consumers
+// still get them unchanged.
+const JSR_SKIP_EXPORT_KEYS = new Set(['./build', './test-render'])
+
 // ── Resolve a single export entry to a publishable `src` TS file ──────
 function resolveExportTarget(dir: string, entry: unknown): string | null {
   // Gather candidate targets across conditions, most source-like first.
+  // `bun:` is deliberately omitted — an export whose only resolution is
+  // the `bun:` condition is Bun-runtime-specific by its package.json
+  // author's own declaration and has no business on JSR. (Mixed entries
+  // like `{ bun: …, import: … }` still resolve via `import`/`default`.)
   const targets: string[] = []
   if (typeof entry === 'string') {
     targets.push(entry)
   } else if (entry && typeof entry === 'object') {
     const e = entry as Record<string, string>
-    for (const cond of [e.bun, e.import, e.default, e.types]) {
+    for (const cond of [e.import, e.default, e.types]) {
       if (cond) targets.push(cond)
     }
   }
@@ -142,11 +160,13 @@ function resolveExportTarget(dir: string, entry: unknown): string | null {
 }
 
 // Resolve a package's `exports` map to the `src` TS files JSR would publish,
-// dropping entries with no source sibling.
+// dropping entries with no source sibling or that are listed as dev-tooling
+// keys (see `JSR_SKIP_EXPORT_KEYS`).
 function resolveExports(dir: string, pkg: PkgJson): Record<string, string> {
   const exportsIn = pkg.exports ?? { '.': './src/index.ts' }
   const exportsOut: Record<string, string> = {}
   for (const [key, entry] of Object.entries(exportsIn)) {
+    if (JSR_SKIP_EXPORT_KEYS.has(key)) continue
     const target = resolveExportTarget(dir, entry)
     if (target) exportsOut[key] = target
   }


### PR DESCRIPTION
Stacked on #1800 (which is stacked on #1792).

## Summary

Two changes that together make \`deno publish\` actually pass for every gated package and add a PR-time gate that catches regressions:

1. **\`scripts/jsr-publish.ts\`** stops emitting dev-tooling-only exports into JSR manifests:
   - \`./build\` and \`./test-render\` keys are dropped. These are Bun-runtime-shaped helpers (\`test-render.ts\` uses \`Bun.*\` / \`import.meta.dir\` directly; the per-adapter build helpers are wired for the \`bf\` CLI which ships as an npm executable). They were the residual cause of \`deno publish\` type-check failures even after #1792 fixed import extensions — JSR was being asked to publish files it had no business type-checking against Deno's runtime.
   - \`bun:\`-only conditions are dropped from the candidate list (an export whose only resolution is the \`bun:\` condition is Bun-specific by its author's own declaration).

   The npm surface is unchanged — these exports remain available to Bun / Node consumers exactly as before.

2. **\`.github/workflows/ci-jsr-check.yml\`** runs \`deno check\` per JSR-publishable package on PRs, mirroring what \`release.yml\`'s JSR-publish step type-checks.

## Why this PR depends on #1800

#1800 adds the \`override\` modifier to \`renderAsync\` on three adapters; without it, the workflow added here fails for those three packages.

## Why \`@barefootjs/hono\` is skipped in the workflow

Even after dropping dev-tooling exports, \`adapter-hono\` still fails \`deno check\` with ~50 errors driven by Hono JSX's \`IntrinsicElements\` indexer (\`[k: string]: HTMLBaseAttributes\`) being structurally incompatible with its per-element types (TS2411), plus JSX globals not resolving (TS2874 / TS7026). Fixing these without forking \`hono/jsx\`'s real types is a larger refactor than this gate's scope, so \`adapter-hono\` is excluded via an in-workflow skip list with an inline comment. A tracking issue will be opened separately.

## Test plan

- [x] \`bun scripts/jsr-publish.ts --dry-run --keep\` emits manifests without \`./build\` / \`./test-render\` for adapter-* and client (verified locally)
- [x] \`deno check\` passes for all 11 non-hono gated packages locally
- [x] \`deno publish --dry-run --allow-slow-types --allow-dirty\` succeeds for \`adapter-go-template\` (sample of the previously-failing surface)
- [x] adapter-hono still has independent failures (confirmed scope is unchanged by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)