### PR TITLE
Turn markers on conditional-branch handlers (#1690, #1786)

### DIFF
--- a/.changeset/profiler-branch-turns.md
+++ b/.changeset/profiler-branch-turns.md
@@ -1,0 +1,20 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Extend profile-mode turn markers to conditional-branch handlers (#1690, #1786).
+
+`profileComponentName` is now threaded through `buildInsertPlan` so the two
+remaining handler paths get `beginTurn`/`endTurn` like the top-level and
+top-level-loop paths:
+
+- **branch-arm direct listeners** — `emitListenerLine` takes an optional turn id
+  and wraps via `wrapHandlerForTurn`; arm events carry it (`ArmEventBind.turnId`).
+- **branch-scoped loop delegation** — `buildBranchLoopDelegationPlan` now sets
+  `EventDelegationPlan.profileComponentName`, so a loop nested inside a
+  conditional wraps its delegated handlers too.
+
+Off by default the emitted code carries no markers (SR8). With three handler
+sites — top-level, branch-arm, branch-loop — a profile build now emits exactly
+three `beginTurn`s. The loop-cond arm path (`BranchEventBindingsPlan`) remains a
+minor follow-up under #1786.

--- a/packages/jsx/src/__tests__/profile-turn-markers-branch.test.ts
+++ b/packages/jsx/src/__tests__/profile-turn-markers-branch.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Profile-mode turn markers on conditional-branch handler paths (#1690, SR3,
+ * issue #1786): branch-arm direct listeners and branch-scoped loop delegation.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+const source = `
+  'use client'
+  import { createSignal } from '@barefootjs/client'
+  export function Panel() {
+    const [open, setOpen] = createSignal(false)
+    const [items] = createSignal([{ id: 1 }])
+    return (
+      <div>
+        <button onClick={() => setOpen(!open())}>toggle</button>
+        {open() && (
+          <div>
+            <button onClick={() => setOpen(false)}>close</button>
+            <ul>{items().map(i => <li key={i.id} onClick={() => setOpen(false)}>x</li>)}</ul>
+          </div>
+        )}
+      </div>
+    )
+  }
+`
+
+function clientJs(profile: boolean): string {
+  return compileJSX(source, 'Panel.tsx', { adapter, profile })
+    .files.find(f => f.type === 'clientJs')!.content
+}
+
+describe('branch handler turn markers', () => {
+  test('profile off: no turn markers anywhere (SR8)', () => {
+    expect(clientJs(false)).not.toContain('beginTurn')
+  })
+
+  test('profile on: branch-arm listener and branch-loop delegation are wrapped', () => {
+    const on = clientJs(true)
+    // One per handler site: top-level toggle, branch-arm close, branch-loop li.
+    expect((on.match(/beginTurn\("Panel#handler:/g) ?? []).length).toBe(3)
+    // The branch-arm direct listener (addEventListener inside an arm).
+    expect(on).toMatch(/addEventListener\('click', \(\.\.\.__bfa\) => \{ beginTurn\("Panel#handler:s\d+:click"\)/)
+    // The branch-scoped loop's delegated handler (inline try/finally form).
+    expect(on).toMatch(/beginTurn\("Panel#handler:s\d+:click"\); try \{ \(\(\) => setOpen\(false\)\)\(__bfEvt\)/)
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow.ts
@@ -33,8 +33,9 @@ import { stringifyEventDelegation } from './control-flow/stringify/event-delegat
 
 /** Emit insert() calls for server-rendered reactive conditionals with branch configs. */
 export function emitConditionalUpdates(lines: string[], ctx: ClientJsContext): void {
+  const profileComponentName = ctx.profile ? ctx.componentName : undefined
   for (const elem of ctx.conditionalElements) {
-    const plan = buildInsertPlan(elem, { scope: { kind: 'top' }, eventNameMode: 'dom' })
+    const plan = buildInsertPlan(elem, { scope: { kind: 'top' }, eventNameMode: 'dom', profileComponentName })
     stringifyInsert(lines, plan, { leadingIndent: '  ', bodyIndent: '      ' })
     lines.push('')
   }
@@ -42,8 +43,9 @@ export function emitConditionalUpdates(lines: string[], ctx: ClientJsContext): v
 
 /** Emit insert() calls for client-only conditionals (not server-rendered). */
 export function emitClientOnlyConditionals(lines: string[], ctx: ClientJsContext): void {
+  const profileComponentName = ctx.profile ? ctx.componentName : undefined
   for (const elem of ctx.clientOnlyConditionals) {
-    const plan = buildInsertPlan(elem, { scope: { kind: 'top' }, eventNameMode: 'raw' })
+    const plan = buildInsertPlan(elem, { scope: { kind: 'top' }, eventNameMode: 'raw', profileComponentName })
     lines.push(`  // @client conditional: ${elem.slotId}`)
     stringifyInsert(lines, plan, { leadingIndent: '  ', bodyIndent: '      ' })
     lines.push('')

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-branch-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-branch-loop.ts
@@ -22,7 +22,7 @@ import type {
   BranchPlainLoopPlan,
 } from './branch-loop.ts'
 
-export function buildBranchLoopPlan(loop: BranchLoop): BranchLoopPlan {
+export function buildBranchLoopPlan(loop: BranchLoop, profileComponentName?: string): BranchLoopPlan {
   const containerSlotId = loop.containerSlotId
   const cv = varSlotId(containerSlotId)
   const containerVar = `__loop_${cv}`
@@ -67,7 +67,7 @@ export function buildBranchLoopPlan(loop: BranchLoop): BranchLoopPlan {
           loopParamBindings: loop.paramBindings,
         })
       : null,
-    eventDelegation: buildBranchLoopDelegationPlan(loop, cv),
+    eventDelegation: buildBranchLoopDelegationPlan(loop, cv, profileComponentName),
     childRefs: buildChildRefBindings(loop.bindings.refs, loop.param, loop.paramBindings),
     bodyIsMultiRoot: loop.bodyIsMultiRoot ?? false,
   }

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-event-delegation.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-event-delegation.ts
@@ -39,16 +39,19 @@ export function buildDynamicLoopDelegationPlan(
   }
 }
 
-// NOTE: branch-scoped delegation (a dynamic loop nested inside a conditional
-// branch) does not yet thread `profileComponentName` — `buildBranchLoopPlan`
-// is reached via `branch.loops.map(...)` without `ctx`. Turn markers on this
-// nested path are tracked as a follow-up; top-level + static-array delegation
-// (the common dynamic-list case) carry markers below.
-export function buildBranchLoopDelegationPlan(loop: BranchLoop, cv: string): EventDelegationPlan {
+// Branch-scoped delegation (a dynamic loop nested inside a conditional branch):
+// `profileComponentName` is threaded from `buildInsertPlan` → `buildBranchLoopPlan`
+// so its delegated handlers get turn markers like every other path (#1786).
+export function buildBranchLoopDelegationPlan(
+  loop: BranchLoop,
+  cv: string,
+  profileComponentName?: string,
+): EventDelegationPlan {
   return {
     kind: 'event-delegation',
     containerVar: `__loop_${cv}`,
     events: loop.bindings.events,
+    profileComponentName,
     itemLookup: buildKeyedOrIndexLookup({
       // See note on `buildDynamicLoopDelegationPlan` above (#1434).
       array: buildChainedArrayExpr(loop),

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-insert.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-insert.ts
@@ -24,6 +24,8 @@ import type {
 export interface BuildInsertOptions {
   scope: ScopeRef
   eventNameMode: 'dom' | 'raw'
+  /** Owning component name in profile mode (#1690, SR3) — else undefined. */
+  profileComponentName?: string
 }
 
 export function buildInsertPlan(
@@ -56,11 +58,15 @@ function buildArm(
 }
 
 function buildArmBody(branch: BranchSummary, options: BuildInsertOptions): ArmBody {
+  const pc = options.profileComponentName
   return {
     events: branch.events.map(e => ({
       slotId: e.slotId,
       eventName: e.eventName,
       handler: e.handler,
+      // Profile mode (#1690, SR3): turn id so the arm listener is wrapped with
+      // beginTurn/endTurn, matching the top-level/delegation paths.
+      turnId: pc ? `${pc}#handler:${e.slotId}:${e.eventName}` : undefined,
     })),
     refs: branch.refs.map(r => ({
       slotId: r.slotId,
@@ -81,13 +87,13 @@ function buildArmBody(branch: BranchSummary, options: BuildInsertOptions): ArmBo
       expression: t.expression,
     })),
     // Branch-scoped loops, fully Plan-built (Item 2 final migration).
-    loops: branch.loops.map(buildBranchLoopPlan),
+    loops: branch.loops.map(l => buildBranchLoopPlan(l, pc)),
     // Nested conditionals are themselves InsertPlans — built recursively so
     // the same stringifier handles arbitrary depth. Their scope is always
     // `__branchScope` (the parent arm's bindEvents argument), regardless of
     // the outer scope; only the eventNameMode is inherited.
     conditionals: branch.conditionals.map(c =>
-      buildInsertPlan(c, { scope: { kind: 'branchScope' }, eventNameMode: options.eventNameMode }),
+      buildInsertPlan(c, { scope: { kind: 'branchScope' }, eventNameMode: options.eventNameMode, profileComponentName: pc }),
     ),
   }
 }

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/insert.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/insert.ts
@@ -79,6 +79,8 @@ export interface ArmEventBind {
   eventName: string
   /** Handler source expression (already trimmed). The stringifier wraps it. */
   handler: string
+  /** Profile-mode turn id (#1690, SR3); when set the listener is turn-wrapped. */
+  turnId?: string
 }
 
 export interface ArmRefBind {

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/event-listener.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/event-listener.ts
@@ -13,7 +13,7 @@
  * by `@client` conditionals).
  */
 
-import { toDomEventName, wrapHandlerInBlock } from '../../utils.ts'
+import { toDomEventName, wrapHandlerInBlock, wrapHandlerForTurn } from '../../utils.ts'
 
 export type EventNameMode = 'dom' | 'raw'
 
@@ -31,8 +31,11 @@ export function emitListenerLine(
   eventName: string,
   handler: string,
   mode: EventNameMode = 'dom',
+  turnId?: string,
 ): void {
-  const wrapped = wrapHandlerInBlock(handler)
+  // Profile mode (#1690, SR3): when a turn id is supplied the handler is
+  // bracketed with beginTurn/endTurn instead of the plain block wrap.
+  const wrapped = turnId ? wrapHandlerForTurn(handler, turnId) : wrapHandlerInBlock(handler)
   const name = mode === 'dom' ? toDomEventName(eventName) : eventName
   lines.push(`${indent}if (${elementVar}) ${elementVar}.addEventListener('${name}', ${wrapped})`)
 }

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/insert.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/insert.ts
@@ -105,7 +105,7 @@ function emitArmBody(
   for (const [slotId, slotEvents] of eventsBySlot) {
     const v = varSlotId(slotId)
     for (const ev of slotEvents) {
-      emitListenerLine(lines, indent, `_${v}`, ev.eventName, ev.handler, mode)
+      emitListenerLine(lines, indent, `_${v}`, ev.eventName, ev.handler, mode, ev.turnId)
     }
   }
 


### PR DESCRIPTION
**Stacked on #1802** (base: `claude/profiler-safety-oracle`). Addresses **#1786** — turn-marker coverage on the conditional-branch handler paths.

## What

`profileComponentName` is threaded through `buildInsertPlan` so the two remaining handler paths get `beginTurn`/`endTurn`, matching top-level and top-level-loop:

- **branch-arm direct listeners** — `emitListenerLine` gains an optional turn id and wraps via `wrapHandlerForTurn`; arm events carry `ArmEventBind.turnId`.
- **branch-scoped loop delegation** — `buildBranchLoopDelegationPlan` now sets `EventDelegationPlan.profileComponentName` (the field already existed from the top-level delegation PR), so a loop nested inside a conditional wraps its delegated handlers too. This also retires the "NOTE: …not yet threaded" comment that PR left.

## Verified

A `Panel` with a top-level toggle, a conditional arm containing a `close` button, and a branch-scoped loop with an `<li onClick>`:

```
profile=false  beginTurn count: 0          ← byte-identical (SR8)
profile=true   beginTurn count: 3
  _s0.addEventListener('click', (...__bfa) => { beginTurn("Panel#handler:s0:click") …   ← top-level
  _s2.addEventListener('click', (...__bfa) => { beginTurn("Panel#handler:s2:click") …   ← branch-arm (new)
  if (i) beginTurn("Panel#handler:s3:click"); try { (() => setOpen(false))(__bfEvt) …   ← branch loop (new)
```

## Scope

Covers the `InsertPlan` conditional path (the common conditional-branch case). The loop-cond arm path (`BranchEventBindingsPlan`, a conditional *inside a loop item*) remains a minor follow-up noted on #1786.

## Tests
`profile-turn-markers-branch.test.ts` — off: no markers; on: exactly 3 `beginTurn`s with the branch-arm and branch-loop forms asserted. Conditional compiler tests 99 ✓, CSR conformance 124 ✓, typecheck clean.

https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN)_