### PR TITLE
Auto-scenario fires all IR-known handlers, not just buttons (#1690, #1796)

### DIFF
--- a/.changeset/profiler-auto-fire-handlers.md
+++ b/.changeset/profiler-auto-fire-handlers.md
@@ -1,0 +1,14 @@
+---
+"@barefootjs/cli": patch
+---
+
+Auto-scenario fires every IR-known handler, not just buttons (#1690, #1796).
+
+`bf debug profile --scenario auto` now drives interactions from the component
+graph: for each `event` domBinding it dispatches the right event
+(`MouseEvent`/`KeyboardEvent`/`Event`) on each `[bf="<slotId>"]` element —
+including **delegated list-item handlers** and branch handlers — falling back to
+the button/link sweep only when nothing resolves.
+
+A list component whose only interaction is `<li onClick>` now reports
+`coverage: N/N` and measures the row toggle, where before it read `0` turns.

--- a/packages/cli/src/__tests__/scenario-driver.test.ts
+++ b/packages/cli/src/__tests__/scenario-driver.test.ts
@@ -36,6 +36,28 @@ describe('runAutoScenario', () => {
     expect(r.events.some(e => e.type === 'effectEnter' && e.subscriber === 'Counter#memo:doubled')).toBe(true)
   })
 
+  test('fires list-item (delegated) handlers, not just buttons (#1796)', async () => {
+    const LIST = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function List() {
+        const [items, setItems] = createSignal([{ id: 1 }, { id: 2 }])
+        return (
+          <ul>
+            {items().map(it => (
+              <li key={it.id} onClick={() => setItems(items().filter(x => x.id !== it.id))}>row</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const r = await runAutoScenario(LIST, 'List.tsx', 'List')
+    // The delegated li handler fired (a turn opened) even though there's no button.
+    const turn = r.events.find(e => e.type === 'turnBegin')
+    expect(turn?.handlerId).toMatch(/^List#handler:s\d+:click$/)
+    expect(r.fired).toBeGreaterThanOrEqual(2) // one per rendered row
+  })
+
   test('a component with no handler records no interaction turns', async () => {
     const DISPLAY = `
       'use client'

--- a/packages/cli/src/lib/scenario-driver.ts
+++ b/packages/cli/src/lib/scenario-driver.ts
@@ -45,14 +45,55 @@ function pickMountName(requested: string | undefined, registered: string[]): str
   return registered[0]
 }
 
-/** Unique interactive descendants (root included) to exercise in the auto scenario. */
-function collectClickables(root: HTMLElement): HTMLElement[] {
-  const set = new Set<HTMLElement>()
-  const SELECTOR = 'button, a, [role="button"], [onclick]'
-  if (root.matches(SELECTOR)) set.add(root)
-  for (const el of Array.from(root.querySelectorAll<HTMLElement>(SELECTOR))) set.add(el)
-  // Fall back to the root itself so a wrapper component still gets one event.
-  return set.size > 0 ? [...set] : [root]
+/** A handler the IR knows about: which slot it's on and which event fires it. */
+interface HandlerSlot {
+  slotId: string
+  eventName: string
+}
+
+/** Build a bubbling DOM event of the right class for `eventName`. */
+function makeEvent(eventName: string): Event {
+  if (/^(click|dblclick|mouse|pointer|contextmenu)/.test(eventName)) {
+    return new window.MouseEvent(eventName, { bubbles: true, cancelable: true })
+  }
+  if (/^key/.test(eventName)) {
+    return new window.KeyboardEvent(eventName, { bubbles: true, cancelable: true })
+  }
+  return new window.Event(eventName, { bubbles: true, cancelable: true })
+}
+
+/**
+ * Fire every handler the IR knows about (`graph.domBindings` of type `event`)
+ * on its `[bf="<slotId>"]` element(s) — including list items (delegated) and
+ * branch handlers — so coverage reflects real interactions, not just buttons.
+ * Falls back to clicking buttons/links when no handler slots resolve.
+ */
+function fireHandlers(root: HTMLElement, handlers: HandlerSlot[]): number {
+  let fired = 0
+  const seen = new Set<HTMLElement>()
+  for (const h of handlers) {
+    const targets: HTMLElement[] = []
+    if (root.matches(`[bf="${h.slotId}"]`)) targets.push(root)
+    for (const el of Array.from(root.querySelectorAll<HTMLElement>(`[bf="${h.slotId}"]`))) targets.push(el)
+    for (const el of targets) {
+      el.dispatchEvent(makeEvent(h.eventName))
+      seen.add(el)
+      fired++
+    }
+  }
+  if (fired === 0) {
+    // No IR-resolved targets in the live DOM (e.g. wrapper component) — fall
+    // back to the generic clickable sweep.
+    const SELECTOR = 'button, a, [role="button"], [onclick]'
+    const set = new Set<HTMLElement>()
+    if (root.matches(SELECTOR)) set.add(root)
+    for (const el of Array.from(root.querySelectorAll<HTMLElement>(SELECTOR))) set.add(el)
+    for (const el of (set.size > 0 ? [...set] : [root])) {
+      el.dispatchEvent(makeEvent('click'))
+      fired++
+    }
+  }
+  return fired
 }
 
 /**
@@ -107,16 +148,28 @@ export async function runAutoScenario(
     const name = pickMountName(componentName, registeredNames(clientJs))
     if (!name) throw new Error('Could not determine the component name to mount (none registered).')
 
+    // Handler slots the IR knows about (slotId + event), so the auto scenario
+    // fires real interactions — list items, branch handlers — not just buttons.
+    let handlers: HandlerSlot[] = []
+    try {
+      const { graph } = (await import('@barefootjs/jsx')).buildComponentAnalysis(source, filePath, name)
+      handlers = graph.domBindings
+        .filter((b: { type: string }) => b.type === 'event')
+        .map((b: { slotId: string; label: string }) => ({
+          slotId: b.slotId,
+          eventName: b.label.match(/^(\w+)\s+handler/)?.[1] ?? 'click',
+        }))
+    } catch {
+      handlers = []
+    }
+
     const rec = rt.createRecordingSink()
     rt.setProfilerSink(rec.sink)
     try {
       const el = rt.createComponent(name, {})
       document.body.appendChild(el)
-      const targets = collectClickables(el)
-      for (const t of targets) {
-        t.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }))
-      }
-      return { events: rec.events, rootTag: el.tagName.toLowerCase(), fired: targets.length }
+      const fired = fireHandlers(el, handlers)
+      return { events: rec.events, rootTag: el.tagName.toLowerCase(), fired }
     } finally {
       rt.setProfilerSink(null)
     }


### PR DESCRIPTION
**Stacked on #1805** (base: `claude/profiler-branch-turns`). Addresses the broadly-useful half of **#1796** — the auto scenario only clicked buttons, so list and branch interactions went unmeasured.

## What

`runAutoScenario` now drives interactions from the **component graph**: for each `event` domBinding it dispatches the right event class (`MouseEvent` / `KeyboardEvent` / `Event`, bubbling) on every `[bf="<slotId>"]` element — so **delegated list-item handlers** and branch handlers fire too. It falls back to the button/link sweep only when nothing resolves (e.g. a wrapper component).

## Dogfood result

`TodoApp` (a list whose rows toggle via `<li onClick>`):

```
before:  2/3 handlers exercised   (the <li> toggle never fired)
after:   3/3 handlers exercised   — turns: s0 (addTwo), s1 (filter), s6 (li toggle)
```

A list whose *only* interaction is `<li onClick>` went from `0` turns to `coverage: N/N`.

## Still open in #1796

The compound/headless case (`Collapsible` = `Collapsible` + `CollapsibleTrigger` + `CollapsibleContent`, composed by the user with children) still can't be auto-profiled — mounting the bare parent yields no interactive tree. That needs custom-scenario-file support (a composition story), which remains tracked on #1796.

## Tests
`scenario-driver.test.ts` gains a list-only component asserting the delegated `<li>` handler opens a turn (`List#handler:s\d+:click`) with `fired ≥ 2` (one per row). All 3 driver tests pass.

https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN)_