### PR TITLE
fix(adapter-hono): resolve self-owned deno check errors

### DIFF
--- a/.changeset/adapter-hono-deno-check.md
+++ b/.changeset/adapter-hono-deno-check.md
@@ -1,0 +1,11 @@
+---
+"@barefootjs/hono": patch
+---
+
+Fix the two `deno check` errors in `@barefootjs/hono` that originate in our
+own code: add the `override` modifier to `HonoAdapter.renderAsync` (TS4114,
+matching the other adapters), and decode `readFile` output via `TextDecoder`
+in the dev reloader instead of the positional string-encoding overload,
+which Deno's `node:fs/promises` types resolve to a buffer without `.trim`
+(TS2769 + TS2339). `override` is a type-only annotation and the dev-reloader
+change is behaviorally equivalent.

--- a/.github/workflows/ci-jsr-check.yml
+++ b/.github/workflows/ci-jsr-check.yml
@@ -70,17 +70,21 @@ jobs:
         run: |
           set -uo pipefail
 
-          # Packages temporarily excluded from the gate. Each entry should
-          # carry a tracking issue link so the exclusion is visible and
-          # owned.
+          # Packages excluded from the gate. The exclusion is documented
+          # inline here rather than via a tracking issue: it's bounded by an
+          # upstream constraint, not pending in-repo work.
           #
-          # - @barefootjs/hono: Hono JSX's `IntrinsicElements` indexer
-          #   (`[k: string]: HTMLBaseAttributes`) collides structurally
-          #   with its per-element types (~30 TS2411), plus the usual
-          #   TS2874/TS7026 JSX-globals plumbing. Fixing these without
-          #   forking off `hono/jsx`'s real types is outside this
-          #   gate's scope.
-          #   Tracking: https://github.com/piconic-ai/barefootjs/issues/1804
+          # - @barefootjs/hono: `deno check` also type-checks `hono/jsx`'s
+          #   own declarations, where the `IntrinsicElements` indexer
+          #   (`[k: string]: HTMLBaseAttributes`) is structurally
+          #   incompatible with its per-element types (~30 TS2411). The JSX
+          #   globals only resolve under an explicit `jsxImportSource`
+          #   recipe that then surfaces that same wall (TS2874/TS7026). We
+          #   won't ship our own JSX type shims to satisfy the checker —
+          #   that would fork @barefootjs/hono off the real `hono/jsx` types
+          #   consumers depend on. Our own checker-facing errors (missing
+          #   `override`, the `readFile` encoding overload) are fixed; what
+          #   remains is upstream's to resolve. npm publish is unaffected.
           declare -A SKIP=(
             ["@barefootjs/hono"]=1
           )

--- a/packages/adapter-hono/src/adapter/hono-adapter.ts
+++ b/packages/adapter-hono/src/adapter/hono-adapter.ts
@@ -966,7 +966,7 @@ export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderC
     return lines.join('\n')
   }
 
-  renderAsync(node: IRAsync): string {
+  override renderAsync(node: IRAsync): string {
     const fallback = this.renderNode(node.fallback)
     const children = this.renderChildren(node.children)
     // Wrap the streaming body in an ErrorBoundary so a synchronous throw or

--- a/packages/adapter-hono/src/dev.tsx
+++ b/packages/adapter-hono/src/dev.tsx
@@ -75,7 +75,12 @@ export function createDevReloader(
 
     const readBuildId = async (): Promise<string> => {
       try {
-        return (await readFile(buildIdPath, 'utf8')).trim()
+        // Decode the bytes explicitly rather than relying on `readFile`'s
+        // string-encoding overload: Deno's `node:fs/promises` types resolve
+        // the positional-encoding call to `NonSharedBuffer` (no `.trim`),
+        // which breaks `deno check`. `TextDecoder` is portable across Node,
+        // Deno, and Workers and mirrors the `TextEncoder` use just below.
+        return new TextDecoder().decode(await readFile(buildIdPath)).trim()
       } catch {
         return ''
       }

--- a/packages/adapter-hono/src/dev.tsx
+++ b/packages/adapter-hono/src/dev.tsx
@@ -75,11 +75,14 @@ export function createDevReloader(
 
     const readBuildId = async (): Promise<string> => {
       try {
-        // Decode the bytes explicitly rather than relying on `readFile`'s
-        // string-encoding overload: Deno's `node:fs/promises` types resolve
-        // the positional-encoding call to `NonSharedBuffer` (no `.trim`),
-        // which breaks `deno check`. `TextDecoder` is portable across Node,
-        // Deno, and Workers and mirrors the `TextEncoder` use just below.
+        // `readFile(path, 'utf8')` is the obvious call, but Deno's
+        // `node:fs/promises` types resolve that positional-encoding
+        // overload to `NonSharedBuffer` rather than `string`, so `.trim()`
+        // is missing and `deno check` fails (TS2769 + TS2339). Read raw
+        // bytes and decode with `TextDecoder` instead: it defaults to
+        // UTF-8 (same result as before), sidesteps the broken overload
+        // entirely, and is portable across Node/Deno/Workers — matching
+        // the `TextEncoder` used just below.
         return new TextDecoder().decode(await readFile(buildIdPath)).trim()
       } catch {
         return ''


### PR DESCRIPTION
Closes #1804 (intentionally — see below; this does **not** make the JSR gate fully green for `@barefootjs/hono`).

## Scope

Per discussion, this fixes only the **self-owned** `deno check` failures in `@barefootjs/hono` — the ones rooted in our own code, with zero divergence from `hono/jsx`. The structural wall is deliberately *not* worked around.

### Fixed (A1)
- **TS4114** — `HonoAdapter.renderAsync` was missing `override` (`noImplicitOverride`). Added it, matching the sibling go-template / mojolicious / xslate adapters.
- **TS2769 + TS2339** — `readFile(path, 'utf8')` in `dev.tsx` resolves to `NonSharedBuffer` under Deno's `node:fs/promises` types (positional string-encoding overload), so `.trim()` is missing. Now decodes the bytes via `TextDecoder` (portable across Node/Deno/Workers, mirrors the `TextEncoder` use just below).

### Deliberately not fixed (A2 / B)
- **TS2411 (~30)** — `hono/jsx`'s own `IntrinsicElements` indexer (`[k: string]: HTMLBaseAttributes`) is structurally incompatible with its per-element types. This is upstream's, only surfaced because `deno check` type-checks the dependency's lib.
- **TS2874 / TS7026** — JSX-globals plumbing; resolving it requires an explicit `jsxImportSource` recipe that then re-exposes the TS2411 wall.

Working around these would mean shipping our own JSX type shims and forking `@barefootjs/hono` off the real `hono/jsx` types consumers depend on — not worth it for a narrow PR-time check.

### Tracking change
`@barefootjs/hono` **stays in the `SKIP` map** of `ci-jsr-check.yml`. The exclusion is now documented **inline** in the workflow (it's bounded by an upstream constraint, not pending in-repo work) rather than pointing at a tracking issue, so #1804 is closed as not planned.

`@barefootjs/hono`'s **npm publish is unaffected** throughout.

## Verification
- `bun test` for `dev` / `async` / `async-error-boundary` — 17 pass.
- `deno` is unavailable in this environment, so `deno check` was not re-run here; the two fixes target the exact error shapes from the issue's histogram and the `override` change matches the verified sibling-adapter pattern.

https://claude.ai/code/session_01GWUqqxR9x2j1tEhgiXE5Jt

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWUqqxR9x2j1tEhgiXE5Jt)_