### PR TITLE
ci(lint): enforce JSR import conventions with Biome

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -1,0 +1,56 @@
+# CI — Lint
+#
+# PR gate for the JSR import conventions the sources were aligned to in
+# PRs #1792 / #1800 / #1803. Biome enforces exactly two rules over the
+# TypeScript sources JSR publishes (see biome.jsonc for the scope and the
+# rationale):
+#   - useImportExtensions    → explicit `.ts` / `.tsx` on relative imports
+#   - useNodejsImportProtocol → `node:` prefix on Node built-ins
+#
+# This is the authoritative gate; the simple-git-hooks pre-commit
+# (`biome check --staged`) is the same check run locally for fast
+# feedback. `deno check` (ci-jsr-check.yml) is the runtime proof these
+# conventions hold; this lint gate is what keeps new code from drifting
+# in the first place.
+name: CI — Lint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/*/src/**/*.ts'
+      - 'packages/*/src/**/*.tsx'
+      - 'biome.jsonc'
+      - 'package.json'
+      - '.github/workflows/ci-lint.yml'
+  pull_request:
+    paths:
+      - 'packages/*/src/**/*.ts'
+      - 'packages/*/src/**/*.tsx'
+      - 'biome.jsonc'
+      - 'package.json'
+      - '.github/workflows/ci-lint.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  biome:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        # Git hooks are a local-dev concern; skip their installation in CI.
+        env:
+          SKIP_INSTALL_SIMPLE_GIT_HOOKS: '1'
+        run: bun install
+
+      - name: Biome check (JSR import conventions)
+        run: bunx biome check

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  // Biome's only job in this repo (for now) is to ENFORCE the two JSR
+  // import conventions the source was aligned to in PRs #1792 / #1800 /
+  // #1803, so new code can't silently drift back:
+  //   - useImportExtensions   → explicit `.ts` / `.tsx` on relative imports
+  //   - useNodejsImportProtocol → `node:` prefix on Node built-ins
+  // Everything else (formatter, the rest of the recommended ruleset) is
+  // intentionally left off — this is a lint *gate*, not a formatting pass.
+  "formatter": { "enabled": false },
+  "assist": { "enabled": false },
+  // Scope: the TypeScript SOURCES that JSR actually publishes.
+  //   - `packages/*/src/**` only — never config, scripts, or built output.
+  //   - cli / create-barefootjs are npm-only (never published to JSR), so
+  //     the JSR import rules don't apply to them.
+  //   - adapter-tests is `private` + in `.changeset/config.json`'s ignore
+  //     list → never published; its `src` is test scaffolding.
+  //   - `__tests__` and `*.d.ts` are outside JSR's published surface
+  //     (`deno check` only reaches exported entries + their non-test, non
+  //     -`.d.ts` imports — see scripts/jsr-publish.ts), so the convention
+  //     never applied to them and they are not gated here.
+  "files": {
+    "includes": [
+      "packages/*/src/**/*.ts",
+      "packages/*/src/**/*.tsx",
+      "!packages/cli/**",
+      "!packages/create-barefootjs/**",
+      "!packages/adapter-tests/**",
+      "!**/__tests__/**",
+      "!**/*.d.ts"
+    ]
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": false,
+      "correctness": {
+        "useImportExtensions": "error"
+      },
+      "style": {
+        "useNodejsImportProtocol": "error"
+      }
+    }
+  },
+  "overrides": [
+    {
+      // Package self-references (`@barefootjs/client/reactive`, resolved
+      // through the package `exports` map / the JSR import map that
+      // jsr-publish.ts generates) are deliberately extension-less and
+      // `deno check` accepts them as-is. Biome's resolver follows the
+      // workspace symlink to the real `src/*.ts` and false-positives,
+      // wanting a `.ts` that would actually BREAK the JSR/exports
+      // resolution. There's no per-specifier opt-out, so disable the
+      // extension rule for just the files carrying such self-imports.
+      // (`useNodejsImportProtocol` stays on.)
+      "includes": [
+        "packages/client/src/index.ts",
+        "packages/client/src/runtime/index.ts",
+        "packages/client/src/runtime/insert.ts",
+        "packages/client/src/runtime/map-array.ts",
+        "packages/client/src/runtime/component.ts",
+        "packages/client/src/runtime/apply-rest-attrs.ts"
+      ],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "useImportExtensions": "off"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -26,9 +26,15 @@
     "dev:all": "bun run dev:clean && concurrently -k -n proxy,site,hono,echo,mojo -c blue,yellow,cyan,green,magenta 'bun run scripts/dev-all.ts' 'bun run --filter barefootjs-site dev' 'bun run --filter barefootjs-hono-jsx-example dev' 'bun run --filter barefootjs-echo-example dev' 'bun run --filter barefootjs-mojolicious-example dev'",
     "dev:clean": "bun run scripts/dev-clean.ts",
     "meta:extract": "bun run packages/cli/src/index.ts meta extract",
-    "bf": "bun run packages/cli/src/index.ts"
+    "bf": "bun run packages/cli/src/index.ts",
+    "lint": "biome check",
+    "prepare": "simple-git-hooks"
+  },
+  "simple-git-hooks": {
+    "pre-commit": "bunx biome check --staged --no-errors-on-unmatched"
   },
   "devDependencies": {
+    "@biomejs/biome": "2.4.16",
     "@changesets/cli": "^2.31.0",
     "@happy-dom/global-registrator": "^20.0.11",
     "@playwright/test": "^1.57.0",
@@ -42,11 +48,13 @@
     "pkg-pr-new": "^0.0.67",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "simple-git-hooks": "^2.13.1",
     "solid-js": "^1.9.12",
     "typescript": "^5.9.3"
   },
   "dependencies": {
     "embla-carousel": "^8.6.0",
     "shiki": "^3.21.0"
-  }
+  },
+  "trustedDependencies": []
 }


### PR DESCRIPTION
## Why

The `.ts`/`.tsx` relative-extension and `node:` builtin-prefix conventions aligned in #1792 / #1800 / #1803 have no teeth without enforcement, so new code drifts back the moment it's written. This adds [Biome](https://biomejs.dev/) as a focused lint **gate** for exactly those two conventions — nothing more.

## What

**`biome.jsonc`** enables only two rules (`recommended: false`, no formatter, no other rules):
- `useImportExtensions` → explicit `.ts` / `.tsx` on relative imports
- `useNodejsImportProtocol` → `node:` prefix on Node built-ins

**Scope** = the TypeScript sources JSR actually publishes: `packages/*/src/**/*.{ts,tsx}` minus
- `cli` / `create-barefootjs` — npm-only, never published to JSR
- `adapter-tests` — `private` + changeset-ignored, never published
- `__tests__` and `*.d.ts` — outside JSR's published surface (`deno check` only reaches exported entries + their non-test, non-`.d.ts` imports)

An `overrides` entry disables `useImportExtensions` for the handful of `client` files carrying package self-references like `@barefootjs/client/reactive`. Those resolve through the package `exports` / the JSR import map `scripts/jsr-publish.ts` generates, and `deno check` accepts them extension-less — but Biome's resolver false-positives and would suggest a `.ts` that *breaks* resolution. (`useNodejsImportProtocol` stays on for those files.)

**With this scope, Biome hits nothing in existing code** — confirming #1792–1803 did their job for the deno-checked surface. The literal scope `packages/*/src/**` was narrowed to match the published surface precisely (it otherwise swept in 513 `__tests__` hits + 32 in the private `adapter-tests` + the self-reference false positives — none of them genuine drift in shippable code).

## Enforcement (two-tier)

- **simple-git-hooks pre-commit** → `biome check --staged` for fast local feedback.
- **`ci-lint.yml`** → the authoritative PR gate, matching existing workflow style (SHA-pinned `actions/checkout`, `oven-sh/setup-bun`).

`deno check` (`ci-jsr-check.yml`) remains the runtime *proof* the conventions hold; this lint gate is what stops new code from drifting in the first place.

### Note on `trustedDependencies: []`

`simple-git-hooks`' own postinstall miscomputes the project root under bun's isolated `node_modules/.bun/` layout and **aborts `bun install`**. An empty allow-list stops bun from running it — the toolchain needs no install scripts (Biome ships its binary via `optionalDependencies`) — and the `prepare` script installs the hook correctly instead. Validated with a from-scratch `bun install` (no node_modules / no lockfile): install succeeds, the hook is registered, and a core-package build + test suite pass.

## Verification

- `bunx biome check` → `Checked 222 files … No fixes applied.` (zero hits)
- Injected probes confirm **both** rules fire on resolvable violations and the `overrides` suppression works.
- Pre-commit hook blocks a staged in-scope violation (exit 1) and passes when nothing in-scope is staged (exit 0).

https://claude.ai/code/session_016T2tBkseG2BNAxaa98PMns

---
_Generated by [Claude Code](https://claude.ai/code/session_016T2tBkseG2BNAxaa98PMns)_