### PR TITLE
Scenario-file composition for bf debug profile (#1690, #1796)

### DIFF
--- a/.changeset/profiler-scenario-files.md
+++ b/.changeset/profiler-scenario-files.md
@@ -1,0 +1,25 @@
+---
+"@barefootjs/cli": minor
+"@barefootjs/jsx": minor
+---
+
+Add scenario-file support to `bf debug profile` (#1690, #1796).
+
+`bf debug profile <component> --scenario <story.tsx>` now compiles a "story"
+file and its local relative imports, mounts the composition, and fires every
+handler — so a component composed from sub-components (the common case) is
+profiled as it's actually used, not as a bare mount.
+
+- driver: `loadStory` resolves the story's relative imports (dependency-first);
+  `runScenario` compiles each in profile mode, dedupes the concatenated runtime
+  imports into one, mounts the story, and fires all IR-known handlers across
+  every component in every source.
+- jsx: `buildProfileReport` accepts `extraSources` and enumerates every
+  component per source (`listComponentFunctions`), merging their id indexes and
+  handler bindings — so events from composed sub-components resolve and the
+  safety oracle reasons over the right component's graph.
+
+Verified end-to-end: a story composing `Switch` reports `1/1` coverage with its
+memos, attribute bindings, and controlled-signal effect source-mapped. Fully
+headless components whose handlers/bindings are wired through context remain
+limited by analyzer binding-coverage (the same gap as #1795), tracked on #1796.

--- a/packages/cli/src/__tests__/scenario-driver.test.ts
+++ b/packages/cli/src/__tests__/scenario-driver.test.ts
@@ -7,7 +7,10 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import { runAutoScenario } from '../lib/scenario-driver'
+import { writeFileSync, mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { runAutoScenario, runFileScenario } from '../lib/scenario-driver'
 
 const COUNTER = `
   'use client'
@@ -66,5 +69,34 @@ describe('runAutoScenario', () => {
     `
     const r = await runAutoScenario(DISPLAY, 'Display.tsx', 'Display')
     expect(r.events.some(e => e.type === 'turnBegin')).toBe(false)
+  })
+})
+
+describe('runFileScenario (composition, #1796)', () => {
+  test('compiles a story + its local import, mounts the composition, fires it', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'bf-story-'))
+    try {
+      writeFileSync(join(dir, 'toggle.tsx'), `
+        'use client'
+        import { createSignal } from '@barefootjs/client'
+        export function Toggle() {
+          const [on, setOn] = createSignal(false)
+          return <button onClick={() => setOn(!on())}>{on() ? 'on' : 'off'}</button>
+        }
+      `)
+      writeFileSync(join(dir, 'story.tsx'), `
+        import { Toggle } from './toggle'
+        export function Story() { return <div><Toggle /></div> }
+      `)
+
+      const r = await runFileScenario(join(dir, 'story.tsx'))
+      // Both files were loaded (dependency first, story last).
+      expect(r.sources.map(s => s.filePath.split('/').pop())).toEqual(['toggle.tsx', 'story.tsx'])
+      // The composed Toggle's handler fired through the Story wrapper.
+      const turn = r.events.find(e => e.type === 'turnBegin')
+      expect(turn?.handlerId).toMatch(/^Toggle#handler:s\d+:click$/)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/cli/src/commands/debug-profile.ts
+++ b/packages/cli/src/commands/debug-profile.ts
@@ -68,20 +68,23 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
 
   // -- Dynamic mode (SR1–SR4): mount the instrumented build and measure -----
   if (flags.scenario) {
-    if (flags.scenario !== 'auto') {
-      console.error(`Error: only --scenario auto is supported (got "${flags.scenario}").`)
-      console.error('  auto = mount the component and fire each interactive element once.')
-      process.exit(1)
-    }
     try {
-      const { runAutoScenario } = await import('../lib/scenario-driver')
-      const { events, fired } = await runAutoScenario(source, resolved.filePath, resolved.componentName)
+      const { runAutoScenario, runFileScenario } = await import('../lib/scenario-driver')
+      const isAuto = flags.scenario === 'auto'
+      const { events, fired, sources } = isAuto
+        ? await runAutoScenario(source, resolved.filePath, resolved.componentName)
+        : await runFileScenario(flags.scenario)
+      // The story (the last source — deps are loaded first) drives
+      // componentName/sourceFile; the rest merge into the id index.
+      const primary = isAuto ? { source, filePath: resolved.filePath } : sources[sources.length - 1]
+      const extraSources = isAuto ? [] : sources.slice(0, -1)
       const report = buildProfileReport({
-        source,
-        filePath: resolved.filePath,
-        componentName: resolved.componentName,
-        scenario: 'auto',
+        source: primary.source,
+        filePath: primary.filePath,
+        componentName: isAuto ? resolved.componentName : undefined,
+        scenario: isAuto ? 'auto' : flags.scenario,
         events,
+        extraSources,
       })
       if (ctx.jsonFlag) {
         console.log(JSON.stringify(report, null, 2))

--- a/packages/cli/src/lib/scenario-driver.ts
+++ b/packages/cli/src/lib/scenario-driver.ts
@@ -9,10 +9,16 @@
 // happy-dom + the client runtime are imported lazily, so the static modes
 // (`bf debug profile <component>` / `--diff`) carry no DOM dependency.
 
-import { writeFileSync, mkdtempSync, rmSync } from 'fs'
-import { join } from 'path'
+import { writeFileSync, mkdtempSync, rmSync, readFileSync, existsSync, statSync } from 'fs'
+import { join, dirname } from 'path'
 import { tmpdir } from 'os'
 import type { ProfilerEvent } from '@barefootjs/shared'
+
+/** One compiled source in the scenario (a story file or one of its imports). */
+export interface SourceFile {
+  source: string
+  filePath: string
+}
 
 export interface ScenarioResult {
   events: ProfilerEvent[]
@@ -20,6 +26,12 @@ export interface ScenarioResult {
   rootTag: string
   /** Interactive elements the auto scenario fired. */
   fired: number
+  /**
+   * Every source compiled for this run (story + its local imports). The report
+   * builds a merged id index over these so events from composed sub-components
+   * resolve.
+   */
+  sources: SourceFile[]
 }
 
 /** Component names the compiled client JS registers, in emission order. */
@@ -96,72 +108,129 @@ function fireHandlers(root: HTMLElement, handlers: HandlerSlot[]): number {
   return fired
 }
 
+/** Resolve a relative import specifier to a `.tsx`/`.ts`/`index` file, or null. */
+function resolveLocalFile(spec: string): string | null {
+  for (const cand of [spec, `${spec}.tsx`, `${spec}.ts`, join(spec, 'index.tsx'), join(spec, 'index.ts')]) {
+    if (existsSync(cand) && statSync(cand).isFile()) return cand
+  }
+  return null
+}
+
 /**
- * Compile `source` in profile mode, mount it in happy-dom, fire every
- * interactive element once, and return the recorded event stream (SR2).
+ * Load a scenario "story" file and its local (relative) imports into a flat,
+ * dependency-first source list — so a story composing a headless component
+ * (`<Collapsible><CollapsibleTrigger/>…`) brings every piece it needs.
  */
-export async function runAutoScenario(
-  source: string,
-  filePath: string,
-  componentName?: string,
-): Promise<ScenarioResult> {
-  // 1. DOM — lazy so static modes don't pay for it.
+function loadStory(storyPath: string): SourceFile[] {
+  const out: SourceFile[] = []
+  const visited = new Set<string>()
+  const visit = (p: string): void => {
+    const resolved = resolveLocalFile(p)
+    if (!resolved || visited.has(resolved)) return
+    visited.add(resolved)
+    const source = readFileSync(resolved, 'utf-8')
+    // Visit local imports first so their components register before the story's.
+    for (const m of source.matchAll(/from\s+['"](\.[^'"]+)['"]/g)) {
+      visit(join(dirname(resolved), m[1]))
+    }
+    out.push({ source, filePath: resolved })
+  }
+  visit(storyPath)
+  return out
+}
+
+/**
+ * Mount a set of compiled sources in happy-dom, fire every IR-known handler,
+ * and record the event stream (SR2). The last source's primary component is the
+ * mount root (the others register so composition resolves). Shared by the
+ * `auto` and scenario-file modes.
+ */
+async function runScenario(sources: SourceFile[], mountName?: string): Promise<ScenarioResult> {
   const { GlobalRegistrator } = await import('@happy-dom/global-registrator')
   if (typeof (globalThis as { window?: unknown }).window === 'undefined') {
     GlobalRegistrator.register()
   }
 
-  // 2. Instrumented client JS (adapter-independent — testAdapter is enough).
-  const { compileJSX, testAdapter } = await import('@barefootjs/jsx')
-  const out = compileJSX(source, filePath, { adapter: testAdapter, profile: true })
-  const clientJs = out.files.find((f: { type: string }) => f.type === 'clientJs')?.content as
-    | string
-    | undefined
-  if (!clientJs) {
+  const jsx = await import('@barefootjs/jsx')
+  const { compileJSX, testAdapter } = jsx
+
+  // Compile each source in profile mode; concatenate (deps first) so every
+  // hydrate(...) registration is present before mount.
+  const clientChunks: string[] = []
+  let rootClientJs = ''
+  for (const s of sources) {
+    const out = compileJSX(s.source, s.filePath, { adapter: testAdapter, profile: true })
+    const js = out.files.find((f: { type: string }) => f.type === 'clientJs')?.content as string | undefined
+    if (js) {
+      clientChunks.push(js)
+      rootClientJs = js
+    }
+  }
+  if (clientChunks.length === 0) {
     throw new Error(
-      'No client JS emitted — the component is stateless (no signals/handlers), so there is nothing to profile dynamically. Use the static budget instead.',
+      'No client JS emitted — nothing reactive to profile. Use the static budget instead.',
     )
   }
 
-  // 3. Rewrite the runtime import to an absolute URL so the temp module (which
-  //    sits outside any node_modules) resolves it, and so the sink we install
-  //    is the *same* physical reactive module the component imports. Use the
-  //    bundler's resolver (`import.meta.resolve`) — Node's `createRequire`
-  //    doesn't see workspace links here.
+  // Merge handler slots from every component in every source (a file may hold
+  // several, e.g. a headless set) so all interactions fire.
+  const handlers: HandlerSlot[] = []
+  for (const s of sources) {
+    let names: string[] = []
+    try {
+      names = jsx.listComponentFunctions(s.source, s.filePath)
+    } catch {
+      names = []
+    }
+    for (const name of names.length > 0 ? names : [undefined]) {
+      try {
+        const { graph } = jsx.buildComponentAnalysis(s.source, s.filePath, name)
+        for (const b of graph.domBindings) {
+          if (b.type === 'event') {
+            handlers.push({ slotId: b.slotId, eventName: b.label.match(/^(\w+)\s+handler/)?.[1] ?? 'click' })
+          }
+        }
+      } catch {
+        /* skip a component the analyzer can't read */
+      }
+    }
+  }
+
   const runtimePath = import.meta.resolve('@barefootjs/client/runtime')
-  const rewritten = clientJs
-    .replace(/from\s+['"]@barefootjs\/client\/runtime['"]/g, `from ${JSON.stringify(runtimePath)}`)
+  // Concatenating multiple compiled chunks duplicates their runtime imports
+  // (`import { createComponent, hydrate, … }`). Collect the union of imported
+  // names, strip every per-chunk runtime import, and prepend a single one.
+  const RUNTIME_IMPORT = /^import\s*\{([^}]*)\}\s*from\s*['"]@barefootjs\/client\/runtime['"];?\s*$/gm
+  const names = new Set<string>()
+  for (const chunk of clientChunks) {
+    for (const m of chunk.matchAll(RUNTIME_IMPORT)) {
+      for (const n of m[1].split(',')) {
+        const t = n.trim()
+        if (t) names.add(t)
+      }
+    }
+  }
+  const body = clientChunks
+    .join('\n')
+    .replace(RUNTIME_IMPORT, '')
+    .replace(/^import\s+['"]@barefootjs\/client\/runtime['"];?\s*$/gm, '')
     .replace(/^import '\/\* @bf-child:\w+ \*\/'\n/gm, '')
+  const rewritten = `import { ${[...names].join(', ')} } from ${JSON.stringify(runtimePath)}\n${body}`
 
   const dir = mkdtempSync(join(tmpdir(), 'bf-profile-'))
   const file = join(dir, 'component.mjs')
   writeFileSync(file, rewritten)
 
   try {
-    await import(file) // registers the component via hydrate(...)
+    await import(file)
     const rt = (await import(runtimePath)) as {
       createRecordingSink: () => { sink: unknown; events: ProfilerEvent[] }
       setProfilerSink: (s: unknown) => void
       createComponent: (name: string, props: Record<string, unknown>) => HTMLElement
     }
 
-    const name = pickMountName(componentName, registeredNames(clientJs))
+    const name = pickMountName(mountName, registeredNames(rootClientJs))
     if (!name) throw new Error('Could not determine the component name to mount (none registered).')
-
-    // Handler slots the IR knows about (slotId + event), so the auto scenario
-    // fires real interactions — list items, branch handlers — not just buttons.
-    let handlers: HandlerSlot[] = []
-    try {
-      const { graph } = (await import('@barefootjs/jsx')).buildComponentAnalysis(source, filePath, name)
-      handlers = graph.domBindings
-        .filter((b: { type: string }) => b.type === 'event')
-        .map((b: { slotId: string; label: string }) => ({
-          slotId: b.slotId,
-          eventName: b.label.match(/^(\w+)\s+handler/)?.[1] ?? 'click',
-        }))
-    } catch {
-      handlers = []
-    }
 
     const rec = rt.createRecordingSink()
     rt.setProfilerSink(rec.sink)
@@ -169,11 +238,35 @@ export async function runAutoScenario(
       const el = rt.createComponent(name, {})
       document.body.appendChild(el)
       const fired = fireHandlers(el, handlers)
-      return { events: rec.events, rootTag: el.tagName.toLowerCase(), fired }
+      return { events: rec.events, rootTag: el.tagName.toLowerCase(), fired, sources }
     } finally {
       rt.setProfilerSink(null)
     }
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }
+}
+
+/**
+ * Auto scenario: compile one component in profile mode, mount it, and fire its
+ * handlers. Zero-config — no scenario file needed.
+ */
+export async function runAutoScenario(
+  source: string,
+  filePath: string,
+  componentName?: string,
+): Promise<ScenarioResult> {
+  return runScenario([{ source, filePath }], componentName)
+}
+
+/**
+ * Scenario-file mode: `<file>` is a story `.tsx` that composes the target
+ * (importing it + its sub-components). The driver compiles the story and every
+ * local import, mounts the story, and fires all handlers — so headless/compound
+ * components (whose handlers live in user-composed children) get exercised.
+ */
+export async function runFileScenario(storyPath: string): Promise<ScenarioResult> {
+  const sources = loadStory(storyPath)
+  if (sources.length === 0) throw new Error(`Cannot read scenario file: ${storyPath}`)
+  return runScenario(sources)
 }

--- a/packages/jsx/src/profiler.ts
+++ b/packages/jsx/src/profiler.ts
@@ -27,6 +27,7 @@ import {
   type EventBinding,
   type UpdatePathEntry,
 } from './debug.ts'
+import { listComponentFunctions } from './analyzer.ts'
 import type { ProfilerEvent } from '@barefootjs/shared'
 
 // -- Static budget (SR5) ------------------------------------------------------
@@ -793,6 +794,12 @@ export interface ProfileReportInput {
   scenario: string
   /** The recorded event log from driving the instrumented component (SR2). */
   events: readonly ProfilerEvent[]
+  /**
+   * Other sources compiled for the same run — the composed sub-components of a
+   * scenario-file story. Their graphs are merged into the id index so events
+   * from those components resolve too.
+   */
+  extraSources?: readonly { source: string; filePath: string }[]
 }
 
 /**
@@ -803,52 +810,71 @@ export interface ProfileReportInput {
  */
 export function buildProfileReport(input: ProfileReportInput): ProfileReport {
   const { source, filePath, componentName, scenario, events } = input
-  const { graph } = buildComponentAnalysis(source, filePath, componentName)
-  const index = buildIdIndex(graph)
+
+  const primary = buildComponentAnalysis(source, filePath, componentName).graph
+  // All sources contributing to the merged index (primary first).
+  const allSources = [{ source, filePath }, ...(input.extraSources ?? [])]
+
+  const index: IdIndex = new Map()
+  // turn id → the handler binding + the component graph that owns it (so the
+  // safety oracle reasons over the right component's memos).
+  const turnBindings = new Map<string, { binding: EventBinding; graph: ComponentGraph }>()
+  let handlersTotal = 0
+
+  for (const s of allSources) {
+    // A source file may declare several components (e.g. a headless set:
+    // Collapsible + CollapsibleTrigger + CollapsibleContent). Index each.
+    let componentNames: string[]
+    try {
+      componentNames = listComponentFunctions(s.source, s.filePath)
+    } catch {
+      componentNames = []
+    }
+    if (componentNames.length === 0) componentNames = [undefined as unknown as string]
+    for (const name of componentNames) {
+      let graph: ComponentGraph
+      try {
+        graph = buildComponentAnalysis(s.source, s.filePath, name).graph
+      } catch {
+        continue
+      }
+      for (const [k, v] of buildIdIndex(graph)) index.set(k, v)
+      try {
+        const summary = buildEventSummary(s.source, s.filePath, name)
+        handlersTotal += summary.events.length
+        for (const [turn, binding] of turnToEventBinding(graph, summary.events)) {
+          turnBindings.set(turn, { binding, graph })
+        }
+      } catch {
+        /* a component the analyzer can't summarize contributes no handlers */
+      }
+    }
+  }
 
   const hotSubscribers = analyzeHotSubscribers(events, index)
   const batchAdvisor = analyzeBatchAdvisor(events, index)
   const { unattributed } = joinProfilerEvents(events, index)
 
-  // Safety oracle (§4.2.3): upgrade each batch candidate from 'unverified' to
-  // 'safe'/'unsafe' by static analysis of its handler body.
-  if (batchAdvisor.candidates.length > 0) {
-    let summary: ReturnType<typeof buildEventSummary> | null = null
-    try {
-      summary = buildEventSummary(source, filePath, componentName)
-    } catch {
-      summary = null
-    }
-    if (summary) {
-      const turnBindings = turnToEventBinding(graph, summary.events)
-      for (const c of batchAdvisor.candidates) {
-        const binding = turnBindings.get(c.turn)
-        if (!binding) continue
-        c.safety = assessBatchSafety({
-          handler: binding.handler,
-          setterNames: binding.setterCalls.map(s => s.setter),
-          hasIndirectSetters: binding.setterCalls.some(s => s.via && s.via.length > 0),
-          writtenSignals: binding.setterCalls.map(s => s.signal).filter((s): s is string => s !== null),
-          graph,
-        })
-      }
-    }
+  // Safety oracle (§4.2.3): upgrade each candidate from 'unverified'.
+  for (const c of batchAdvisor.candidates) {
+    const hit = turnBindings.get(c.turn)
+    if (!hit) continue
+    c.safety = assessBatchSafety({
+      handler: hit.binding.handler,
+      setterNames: hit.binding.setterCalls.map(s => s.setter),
+      hasIndirectSetters: hit.binding.setterCalls.some(s => s.via && s.via.length > 0),
+      writtenSignals: hit.binding.setterCalls.map(s => s.signal).filter((s): s is string => s !== null),
+      graph: hit.graph,
+    })
   }
 
   const turnIds = new Set<string>()
   for (const e of events) if (e.turn !== null) turnIds.add(e.turn)
 
-  let handlersTotal = 0
-  try {
-    handlersTotal = buildEventSummary(source, filePath, componentName).events.length
-  } catch {
-    handlersTotal = 0
-  }
-
   return {
     kind: 'profile',
-    componentName: graph.componentName,
-    sourceFile: graph.sourceFile,
+    componentName: primary.componentName,
+    sourceFile: primary.sourceFile,
     scenario,
     events: events.length,
     turns: turnIds.size,


### PR DESCRIPTION
**Stacked on #1806** (base: `claude/profiler-auto-fire-handlers`). Addresses **#1796** — profiling a component *as it's actually composed*, via a scenario file.

## What

`bf debug profile <component> --scenario <story.tsx>` where the story composes the target:

```tsx
// switch.story.tsx
import { Switch } from './ui/components/ui/switch'
export function Story() { return <Switch /> }
```

- **driver**: `loadStory` resolves the story's local relative imports (dependency-first); `runScenario` compiles each in profile mode, **dedupes the concatenated runtime imports** into one (multiple chunks each `import { createComponent, hydrate, … }`), mounts the story, and fires every IR-known handler across **every component in every source**.
- **jsx**: `buildProfileReport` gains `extraSources` and enumerates each source's components (`listComponentFunctions`), merging their id indexes + handler bindings — so events from composed sub-components resolve and the safety oracle reasons over the *right* component's graph.

## Verified end-to-end

A story composing `Switch` mounts the composition, fires the toggle through the `Story` wrapper, and reports:

```
Story — profile (scenario: story)   41 events across 1 turn(s)
  s1 (attribute)   …/switch/index.tsx:146
  isChecked (memo) …/switch/index.tsx:93
  controlled:setControlledChecked (effect) …/switch/index.tsx:87
coverage: 1/1 handlers exercised
```

## Known limit (tracked on #1796)

Fully **headless** components (e.g. `Collapsible`, whose trigger handler + bindings are wired through `createContext`) still come back unresolved — but the cause is the **analyzer's binding coverage** (the graph doesn't expose those context-wired bindings/handlers — the same gap as #1795), which affects `--scenario auto` too, *not* the scenario-file mechanism. Confirmed: `listComponentFunctions` finds all 3 collapsible components, but `buildIdIndex` produces no ids for any because their graphs carry no located bindings. That analyzer work stays tracked on #1796/#1795.

## Tests
`scenario-driver.test.ts` gains a file-scenario case: a story importing a `Toggle` component loads both files (deps first), mounts the composition, and fires the composed handler (`Toggle#handler:s\d+:click`). Driver 4 ✓, profiler 15 ✓, lint clean, typecheck clean.

https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN)_