### PR TITLE
fix(jsx): unblock JSR publish by suppressing spurious TS2411 in jsx-runtime shim

### DIFF
--- a/.changeset/jsx-intrinsic-index-hono-align.md
+++ b/.changeset/jsx-intrinsic-index-hono-align.md
@@ -1,0 +1,15 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix the `@barefootjs/hono` JSR publish, which failed with 31 `TS2411`
+errors in `jsx-runtime/index.d.ts`. The `IntrinsicElements` catch-all
+`[tagName: string]: HTMLBaseAttributes` forced every explicitly-typed
+element to be assignable to `HTMLBaseAttributes`, which TypeScript rejects
+because the per-element types narrow `ref` to a concrete subtype and
+re-declare event handlers (not assignable under `strictFunctionTypes`).
+`tsc` hid this with `skipLibCheck`, but `deno publish` always type-checks
+`.d.ts`. Switch the index signature to `Record<string, any>`, mirroring
+hono/jsx (`[tagName: string]: Props`, `Props = Record<string, any>`).
+Explicitly-typed elements are unaffected; the index only governs unlisted
+tag names.

--- a/.changeset/jsx-intrinsic-index-hono-align.md
+++ b/.changeset/jsx-intrinsic-index-hono-align.md
@@ -4,12 +4,16 @@
 
 Fix the `@barefootjs/hono` JSR publish, which failed with 31 `TS2411`
 errors in `jsx-runtime/index.d.ts`. The `IntrinsicElements` catch-all
-`[tagName: string]: HTMLBaseAttributes` forced every explicitly-typed
-element to be assignable to `HTMLBaseAttributes`, which TypeScript rejects
-because the per-element types narrow `ref` to a concrete subtype and
+`[tagName: string]: HTMLBaseAttributes` is incompatible with the
+explicitly-typed elements under TS's index-signature rule, because the
+per-element types intentionally narrow `ref` to a concrete subtype and
 re-declare event handlers (not assignable under `strictFunctionTypes`).
-`tsc` hid this with `skipLibCheck`, but `deno publish` always type-checks
-`.d.ts`. Switch the index signature to `Record<string, any>`, mirroring
-hono/jsx (`[tagName: string]: Props`, `Props = Record<string, any>`).
-Explicitly-typed elements are unaffected; the index only governs unlisted
-tag names.
+The diagnostic is spurious for JSX — a tag name always resolves to its
+explicit entry, never the index signature. `tsc` never surfaced it
+(`skipLibCheck`), but `deno publish` always type-checks `.d.ts`.
+
+Suppress the self-check of this one declarative shim with `@ts-nocheck`
+instead of widening the catch-all to `Record<string, any>`. Widening
+would silently drop attribute checking for custom / web-component tags;
+`@ts-nocheck` keeps the types fully strict at every use site (it only
+disables errors *within* the shim file) while letting the publish through.

--- a/packages/jsx/src/jsx-runtime/index.d.ts
+++ b/packages/jsx/src/jsx-runtime/index.d.ts
@@ -1,3 +1,24 @@
+// @ts-nocheck — suppress TS2411 in THIS shim only; types stay strong for consumers.
+//
+// `IntrinsicElements` pairs explicitly-typed elements (input, button, svg, …)
+// with a `[tagName: string]: HTMLBaseAttributes` catch-all for unknown tags.
+// TS2411 ("Property 'input' … is not assignable to 'string' index type
+// 'HTMLBaseAttributes'") fires because the per-element types intentionally
+// narrow `ref` to a concrete subtype (`HTMLInputElement`, …) and re-declare
+// event handlers — neither assignable to the `HTMLElement`-typed base under
+// `strictFunctionTypes`. The diagnostic is spurious *for JSX*: a tag name
+// always resolves to its explicit entry, never to the index signature, so the
+// "incompatible index access" TS2411 guards against cannot happen here.
+//
+// `tsc` never surfaced it (the repo builds with `skipLibCheck`), but
+// `deno publish` (JSR) always type-checks `.d.ts` and broke the
+// `@barefootjs/hono` release with 31 of these. We suppress the self-check of
+// this one declarative shim rather than widen the catch-all to
+// `Record<string, any>` — widening would silently drop attribute checking for
+// custom/web-component tags (`<my-widget foo>` would stop erroring). Consumers
+// are unaffected: `@ts-nocheck` only disables errors *within* this file; its
+// declarations (and their full strictness) still apply at every use site.
+//
 /**
  * BarefootJS JSX Runtime - Type Definitions Only
  *
@@ -324,20 +345,11 @@ export declare namespace JSX {
       ref?: (element: SVGForeignObjectElement) => void
     }
 
-    // Catch-all for any other (custom / unknown) element.
-    //
-    // Mirrors hono/jsx, whose `IntrinsicElements` index signature is
-    // `[tagName: string]: Props` with `Props = Record<string, any>`
-    // (see hono `src/jsx/base.ts`). Using `HTMLBaseAttributes` here instead
-    // would force every explicitly-typed element above to be assignable to
-    // it, which TS rejects with TS2411: the per-element types narrow `ref`
-    // to a concrete subtype (`HTMLInputElement`, …) and re-declare event
-    // handlers, neither assignable to the `HTMLElement`-typed base under
-    // `strictFunctionTypes`. `tsc` only surfaced this with `skipLibCheck`
-    // off; `deno publish` (JSR) always type-checks `.d.ts`, so it broke the
-    // release. `Record<string, any>` accepts every named entry and keeps us
-    // aligned with hono. Known elements stay fully typed via their explicit
-    // entries above — the index only governs unlisted tag names.
-    [tagName: string]: Record<string, any>
+    // Catch-all for any other (custom / unknown) element. Typed as
+    // `HTMLBaseAttributes` so unknown tags (e.g. web components) still get
+    // base-attribute checking instead of `any`. See the file-level
+    // `@ts-nocheck` note for why this trips TS2411 under `deno publish` and
+    // why suppressing it (rather than widening to `any`) is correct.
+    [tagName: string]: HTMLBaseAttributes
   }
 }

--- a/packages/jsx/src/jsx-runtime/index.d.ts
+++ b/packages/jsx/src/jsx-runtime/index.d.ts
@@ -324,7 +324,20 @@ export declare namespace JSX {
       ref?: (element: SVGForeignObjectElement) => void
     }
 
-    // Allow any other elements
-    [tagName: string]: HTMLBaseAttributes
+    // Catch-all for any other (custom / unknown) element.
+    //
+    // Mirrors hono/jsx, whose `IntrinsicElements` index signature is
+    // `[tagName: string]: Props` with `Props = Record<string, any>`
+    // (see hono `src/jsx/base.ts`). Using `HTMLBaseAttributes` here instead
+    // would force every explicitly-typed element above to be assignable to
+    // it, which TS rejects with TS2411: the per-element types narrow `ref`
+    // to a concrete subtype (`HTMLInputElement`, …) and re-declare event
+    // handlers, neither assignable to the `HTMLElement`-typed base under
+    // `strictFunctionTypes`. `tsc` only surfaced this with `skipLibCheck`
+    // off; `deno publish` (JSR) always type-checks `.d.ts`, so it broke the
+    // release. `Record<string, any>` accepts every named entry and keeps us
+    // aligned with hono. Known elements stay fully typed via their explicit
+    // entries above — the index only governs unlisted tag names.
+    [tagName: string]: Record<string, any>
   }
 }


### PR DESCRIPTION
## Problem

The `@barefootjs/hono@0.9.3` JSR publish [failed](https://github.com/piconic-ai/barefootjs/actions/runs/27083353172/job/79933118941) with **31 × TS2411** errors, all in `packages/jsx/src/jsx-runtime/index.d.ts`:

```
TS2411 [ERROR]: Property 'input' of type 'InputHTMLAttributes' is not assignable
to 'string' index type 'HTMLBaseAttributes'.
... (input, textarea, select, button, form, label, option, a, img + every SVG element)
```

### Root cause

`IntrinsicElements` pairs explicitly-typed elements with a catch-all string index signature for unknown tags:

```ts
[tagName: string]: HTMLBaseAttributes
```

TS2411 requires every named property to be assignable to the index type. The per-element types deliberately:

- narrow `ref` to a concrete subtype — `ref?: (el: HTMLInputElement) => void` is **not** assignable to the base `ref?: (el: HTMLElement) => void` under `strictFunctionTypes` (parameter contravariance), and
- `Omit` + re-declare event handlers with element-specific targets.

The diagnostic is **spurious for JSX**: a tag name always resolves to its explicit entry, never to the index signature, so the incompatible index-access TS2411 guards against can't happen here. `tsc` never surfaced it because the repo builds with `skipLibCheck`, but **`deno publish` (JSR) always type-checks `.d.ts`** — hence the break. (Only `@barefootjs/hono` pulls this shim in; `go-template`, `form`, `test`, `xyflow` published fine.)

## Fix — suppress the spurious error, **without weakening types**

Keep the `[tagName: string]: HTMLBaseAttributes` catch-all and add a file-level `// @ts-nocheck` to the declarative type shim.

I first tried widening the catch-all to `Record<string, any>` (mirroring hono's `Props`), but that **weakens types**: I verified that custom / web-component tags would stop being checked — `<my-widget foo="x" />` errors today (`foo` not on `HTMLBaseAttributes`) but `any` would silently accept it. Standard elements were unaffected either way. Per the request to not weaken types for deno's sake, `@ts-nocheck` is the right tool: it suppresses errors **only within the shim file**, while its declarations keep full strictness at every use site.

### Verified

| Check | Result |
|---|---|
| `tsc --skipLibCheck false` on the `.d.ts` (simulates `deno publish`) | 31 errors → **0** |
| `<input bogusProp>` (standard element, bad prop) | still **errors** |
| `<my-widget foo>` (custom tag, bad prop) | still **errors** — strictness preserved |
| `packages/jsx/__tests__/tsconfig.json` (SVG `ref` narrowing test) | **passes** |

Also added a patch changeset for `@barefootjs/jsx` (the `check` CI gate requires one when published source changes).

## Out of scope (FYI)

The same workflow run also reported `@barefootjs/xslate@0.9.3` failing with *"package doesn't exist, create it"* (`https://jsr.io/new?scope=barefootjs&package=xslate`). That's a one-time manual step — the `xslate` package must be created in the `@barefootjs` JSR scope on jsr.io. Not a code issue, so not part of this PR.

https://claude.ai/code/session_01SaiuzNsuALVnbHfgafzwob