### PR TITLE
feat(mojolicious): lower Array.prototype.find family (expectedDiagnostics audit)

### DIFF
--- a/.changeset/mojo-array-find.md
+++ b/.changeset/mojo-array-find.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/mojolicious": patch
+---
+
+Lower `Array.prototype.find` / `.findIndex` / `.findLast` / `.findLastIndex` on the Mojolicious adapter, graduating the `array-find` / `array-findIndex` / `array-findLast` / `array-findLastIndex` conformance fixtures (previously pinned to BF101).
+
+The runtime helpers (`bf->find` / `find_index` / `find_last` / `find_last_index`) already existed and the Xslate adapter already lowered these via a Kolon lambda; only the Mojo `higherOrder` emitter still refused them. It now emits `bf->find($arr, sub { my $x = $_[0]; <pred> })` (a per-element coderef predicate, the same shape as `.filter` / `.some` / `.every`), with the camelCase JS names mapping to the snake_case helpers. Verified against real Mojolicious; Hono reference snapshots unchanged.

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -109,17 +109,11 @@ runAdapterConformanceTests({
     // `string-trim` no longer pinned — pre-existing `bf_trim`
     // (Go) and new `bf->trim` helper (Mojo) handle the strip
     // (#1448 Tier A ninth PR, closing out Tier A).
-    // #1448 catalog — `.find` / `.findIndex` have no Mojo lowering
-    // yet (no `array-method` IR variant, no emitter), so the
-    // Mojo-specific gate in `convertExpressionToPerl` refuses them
-    // up front. `.join` is NOT pinned here — it's lifted to the
-    // `array-method` IR by the parser and `renderArrayMethod`'s
-    // `case 'join'` emits `join(sep, @{arr})` correctly; the
-    // text-expression form is routed through the same AST path.
-    'array-find':          [{ code: 'BF101', severity: 'error' }],
-    'array-findIndex':     [{ code: 'BF101', severity: 'error' }],
-    'array-findLast':      [{ code: 'BF101', severity: 'error' }],
-    'array-findLastIndex': [{ code: 'BF101', severity: 'error' }],
+    // `.find` / `.findIndex` / `.findLast` / `.findLastIndex` are no longer
+    // pinned — the Mojo `higherOrder` emitter now lowers them to the runtime
+    // `bf->find` / `find_index` / `find_last` / `find_last_index` helpers
+    // (per-element coderef predicate), matching Xslate. `.join` was never
+    // pinned (handled by `renderArrayMethod`'s `case 'join'`).
   },
   // `JSON_STRINGIFY_VIA_CONST` and `MATH_FLOOR_VIA_CONST` now pass
   // via `MojoAdapter.templatePrimitives` (#1189). The two remaining
@@ -938,6 +932,29 @@ export { A }`, 'A.tsx', { adapter })
     const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
     expect(template).toContain('bf->trim($value)')
     expect(template).not.toContain('$bf->trim')
+  })
+
+  test('lowers .find / .findIndex / .findLast / .findLastIndex via runtime helpers', () => {
+    // The runtime `bf->find` / `find_index` / `find_last` / `find_last_index`
+    // call the predicate as a per-element coderef; the camelCase JS names map
+    // to the snake_case helpers (matching Xslate's Kolon-lambda lowering).
+    const cases: Array<[string, string]> = [
+      ['find', 'find'],
+      ['findIndex', 'find_index'],
+      ['findLast', 'find_last'],
+      ['findLastIndex', 'find_last_index'],
+    ]
+    for (const [js, helper] of cases) {
+      const adapter = new MojoAdapter()
+      const result = compileJSX(`function A({ items }: { items: string[] }) {
+  return <div>{items.${js}(x => x === 'b')}</div>
+}
+export { A }`, 'A.tsx', { adapter })
+      expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
+      const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
+      expect(template).toContain(`bf->${helper}($items, sub { my $x = $_[0]; $x eq 'b' })`)
+      expect(template).not.toContain(`$bf->${helper}`)
+    }
   })
 
   test('lowers .reverse().join(\' \') via bf->reverse + join (#1448 Tier A)', () => {

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -2474,22 +2474,26 @@ class MojoTopLevelEmitter implements ParsedExprEmitter {
     predicate: ParsedExpr,
     emit: (e: ParsedExpr) => string,
   ): string {
-    // Mojo-specific gap: `.find` / `.findIndex` / `.findLast` /
-    // `.findLastIndex` have no Embedded-Perl lowering yet. `isSupported`
-    // accepts them (it's adapter-agnostic), so the refusal lands here
-    // rather than at the support gate. BF101 until a lowering lands.
-    if (method === 'find' || method === 'findIndex' || method === 'findLast' || method === 'findLastIndex') {
-      this.adapter._recordExprBF101(
-        `Mojo adapter has not lowered Array.prototype.${method} yet`,
-      )
-      return "''"
-    }
     const arrayExpr = emit(object)
     const predBody = this.adapter._renderPerlFilterExprPublic(predicate, param)
     const grepBody = predBody.replace(new RegExp(`\\$${param}\\b`, 'g'), '$_')
     if (method === 'filter') return `[grep { ${grepBody} } @{${arrayExpr}}]`
     if (method === 'every') return `!(grep { !(${grepBody}) } @{${arrayExpr}})`
     if (method === 'some') return `!!(grep { ${grepBody} } @{${arrayExpr}})`
+    // `.find` / `.findIndex` / `.findLast` / `.findLastIndex` → the runtime
+    // helpers (`bf->find` / `find_index` / `find_last` / `find_last_index`),
+    // which call the predicate as a per-element coderef — same shape Xslate
+    // emits via a Kolon lambda. The JS camelCase names map to the snake_case
+    // helpers (like index_of / last_index_of).
+    const findHelper: Record<string, string> = {
+      find: 'find',
+      findIndex: 'find_index',
+      findLast: 'find_last',
+      findLastIndex: 'find_last_index',
+    }
+    if (findHelper[method]) {
+      return `bf->${findHelper[method]}(${arrayExpr}, sub { my $${param} = $_[0]; ${predBody} })`
+    }
     return arrayExpr
   }
 


### PR DESCRIPTION
Continuing toward Hono parity, now auditing the `expectedDiagnostics` (build-time refusal) sets: for each pinned diagnostic, check whether the shape has become lowerable, and if so graduate it (render to parity) instead of refusing. First increment.

## Increment: `array-find` family — ✅ Mojolicious

`Array.prototype.find` / `.findIndex` / `.findLast` / `.findLastIndex` were pinned to **BF101** on the Mojo adapter. But:
- the runtime helpers already exist (`bf->find` / `find_index` / `find_last` / `find_last_index` in `BarefootJS.pm`), and
- the **Xslate** adapter already lowers these (via a Kolon lambda).

Only Mojo's `higherOrder` emitter still refused them. It now emits `bf->find($arr, sub { my $x = $_[0]; <pred> })` — a per-element coderef predicate, the same shape as the already-supported `.filter` / `.some` / `.every` — with the camelCase JS names mapping to the snake_case helpers.

- Dropped the four `array-find*` entries from Mojo's `expectedDiagnostics`.
- Added a positive lowering unit test.

## Test status (real Mojolicious 9.35)
- `adapter-mojolicious`: **497 pass / 19 skip / 0 fail** (the 4 fixtures now render instead of asserting BF101)
- `tsc` clean

Hono reference snapshots unchanged. More `expectedDiagnostics` audits (style-object lowering, etc.) to follow as separate increments.

https://claude.ai/code/session_01LaP8KV6yASUT37PzDMvYbW

---
_Generated by [Claude Code](https://claude.ai/code/session_01LaP8KV6yASUT37PzDMvYbW)_