### PR TITLE
feat(adapters): lower style={{…}} object literals to CSS (expectedDiagnostics audit)

### DIFF
--- a/.changeset/rest-destructure-object.md
+++ b/.changeset/rest-destructure-object.md
@@ -1,4 +1,5 @@
 ---
+"@barefootjs/jsx": patch
 "@barefootjs/go-template": patch
 "@barefootjs/mojolicious": patch
 "@barefootjs/xslate": patch
@@ -17,4 +18,4 @@ Only the object-rest-via-member shape is graduated. The other three rest-destruc
 - `rest-destructure-array-in-map` (`[a, ...t]`) needs index/slice,
 - `rest-destructure-nested-in-map` (`{ cells: [h, ...r] }`) needs nested index paths.
 
-A shared supportability gate (`destructureBindingsSupportable`) checks the IR's `paramBindings` (simple `.field` paths + object-rest, no rest-spread) so unsupported shapes keep the existing diagnostic. Verified against real Go 1.25.6 / Mojolicious 9.35 / Text::Xslate v3.5.9; Hono reference snapshots unchanged.
+A shared IR-level gate (`isLowerableObjectRestDestructure`, exported from `@barefootjs/jsx`) keeps every other shape on the existing BF104 diagnostic. It walks the whole loop subtree (elements, components, conditionals, async, providers, template literals) and refuses when the rest binding is spread or used as a bare value (`String(rest)`, `{rest}`) — those need a residual object — as well as when the loop also has a `.filter()` predicate. The Go adapter suffixes its synthetic range var with the nesting depth (`$bfItem0`, `$bfItem1`) so nested destructure loops don't shadow each other. Verified against real Go 1.25.6 / Mojolicious 9.35 / Text::Xslate v3.5.9; Hono reference snapshots unchanged.

--- a/.changeset/rest-destructure-object.md
+++ b/.changeset/rest-destructure-object.md
@@ -1,0 +1,20 @@
+---
+"@barefootjs/go-template": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+---
+
+Lower the object-rest `.map()` destructure param read via member access on all three SSR adapters, graduating the `rest-destructure-object-in-map` conformance fixture (previously pinned to BF104).
+
+`tasks().map(({ id, title, ...rest }) => <li>{title}:{rest.flag}</li>)` now resolves each binding against a per-item loop variable instead of refusing the destructure pattern:
+
+- **Go**: `{{range $_, $bfItem := …}}` with `$bfItem.Title` / `$bfItem.Flag` (the `rest` binding maps to the bare range var so the member emitter renders `rest.flag` → `$bfItem.Flag`).
+- **Mojo**: a per-binding Perl `my` local off the item (`my $rest = $bfItem;` so `$rest->{flag}` resolves).
+- **Xslate**: the equivalent Kolon `: my` binding locals.
+
+Only the object-rest-via-member shape is graduated. The other three rest-destructure fixtures stay refused (BF104), because they need machinery the SSR `range`/`for` can't express inline:
+- `rest-destructure-object-spread-in-map` (`{...rest}`) needs a residual object excluding the consumed keys,
+- `rest-destructure-array-in-map` (`[a, ...t]`) needs index/slice,
+- `rest-destructure-nested-in-map` (`{ cells: [h, ...r] }`) needs nested index paths.
+
+A shared supportability gate (`destructureBindingsSupportable`) checks the IR's `paramBindings` (simple `.field` paths + object-rest, no rest-spread) so unsupported shapes keep the existing diagnostic. Verified against real Go 1.25.6 / Mojolicious 9.35 / Text::Xslate v3.5.9; Hono reference snapshots unchanged.

--- a/.changeset/style-object-lowering.md
+++ b/.changeset/style-object-lowering.md
@@ -1,0 +1,16 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+---
+
+Lower JSX `style={{ … }}` object literals to a CSS string on all three SSR adapters, graduating the `style-object-dynamic` and `style-3-signals` conformance fixtures (previously pinned to BF101 because a bare object literal in attribute position had no template form).
+
+A new shared `parseStyleObjectEntries` helper (`@barefootjs/jsx`) parses the object literal (wrapping in parens to force expression context, since a bare `{…}` parses as a block), kebab-cases each key (`backgroundColor` → `background-color`), and classifies each value as a static string literal or a JS expression. Each adapter assembles the CSS string with its own interpolation for dynamic values:
+
+- **Go**: `background-color:{{.Color}};padding:8px`
+- **Mojo**: `background-color:<%= $color %>;padding:8px`
+- **Xslate**: `background-color:<: $color :>;padding:8px`
+
+Each value expression is pre-checked with `isSupported`, so an unsupported value (or an unsupported object shape — spread, shorthand, computed key) keeps the existing BF101 refusal rather than emitting partial output. Verified against real Go 1.25.6 / Mojolicious 9.35 / Text::Xslate v3.5.9; Hono reference snapshots unchanged.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -44,10 +44,10 @@ runAdapterConformanceTests({
   // any cross-adapter file — every adapter declares its own
   // refusal set against the canonical fixture corpus.
   expectedDiagnostics: {
-    // JS object literal in attribute position: `convertExpressionToGo`
-    // can't lower into Go template syntax — surfaces as BF101 with an
-    // @client suggestion.
-    'style-object-dynamic': [{ code: 'BF101', severity: 'error' }],
+    // `style-object-dynamic` / `style-3-signals` no longer pinned — a
+    // `style={{ … }}` object literal now lowers to a CSS string with dynamic
+    // values interpolated (`background-color:{{.Color}};padding:8px`) via
+    // `tryLowerStyleObject` (#1322).
     // Sibling-imported child component inside a loop body: the adapter
     // emits `{{template "X" .}}` which only resolves if the user has
     // compiled the sibling file and registered the template on the
@@ -71,11 +71,8 @@ runAdapterConformanceTests({
       { code: 'BF103', severity: 'error' },
       { code: 'BF104', severity: 'error' },
     ],
-    // #1244 stress catalog: same `convertExpressionToGo` refusal shape
-    // as `style-object-dynamic` above — a JS object literal in
-    // attribute position can't lower into Go template syntax, so the
-    // adapter surfaces BF101 instead of emitting invalid template.
-    'style-3-signals': [{ code: 'BF101', severity: 'error' }],
+    // (`style-3-signals` graduated alongside `style-object-dynamic` — see note
+    // above; the `style={{ … }}` object now lowers to a CSS string.)
     // #1244 stress catalog: tagged-template-literal callees
     // (`cn\`base \${tone()}\``) likewise can't lower into Go template
     // syntax — same BF101 refusal.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -77,18 +77,13 @@ runAdapterConformanceTests({
     // (`cn\`base \${tone()}\``) likewise can't lower into Go template
     // syntax — same BF101 refusal.
     'tagged-template-classname': [{ code: 'BF101', severity: 'error' }],
-    // #1310: rest destructure in .map() callback. Hono / CSR lower
-    // these via the inline residual-object accessor (#1309), but the
-    // Go template adapter has no analogous lowering — `paramBindings`
-    // is non-empty so the generic destructure-refusal at
-    // `go-template-adapter.ts` fires BF104 regardless of whether the
-    // binding is rest or plain. Pinning the contract here makes the
-    // limitation declarative: when the Go adapter grows a native
-    // rest-lowering, dropping these entries flips the contract on.
-    'rest-destructure-object-in-map': [{ code: 'BF104', severity: 'error' }],
-    // #1244 catalog: rest spread back onto the root element. Same
-    // refusal shape as the read-only variant above — `paramBindings`
-    // is non-empty so BF104 fires regardless of how `rest` is used.
+    // #1310: rest destructure in .map() callback. The object-rest shape read
+    // via member access (`rest-destructure-object-in-map`) now lowers — each
+    // binding resolves to a field on a synthetic `$bfItem` range var and
+    // `rest.flag` → `$bfItem.Flag` (`destructureBindingsSupportable`). The
+    // other three stay refused: rest SPREAD (`{...rest}`) needs a residual
+    // object, and array-index / nested paths (`[a, ...t]`, `{ cells: [h] }`)
+    // need index/slice machinery Go's `{{range}}` can't express inline.
     'rest-destructure-object-spread-in-map': [{ code: 'BF104', severity: 'error' }],
     'rest-destructure-array-in-map': [{ code: 'BF104', severity: 'error' }],
     'rest-destructure-nested-in-map': [{ code: 'BF104', severity: 'error' }],

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -52,6 +52,7 @@ import {
   type SupportResult,
   isBooleanAttr,
   parseExpression,
+  parseStyleObjectEntries,
   isSupported,
   exprToString,
   identifierPath,
@@ -5880,6 +5881,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   private readonly elementAttrEmitter: AttrValueEmitter = {
     emitLiteral: (value, name) => `${name}="${value.value}"`,
     emitExpression: (value, name) => {
+      // `style={{ … }}` object literal → a CSS string with dynamic values
+      // interpolated, instead of refusing the bare object with BF101.
+      if (name === 'style') {
+        const css = this.tryLowerStyleObject(value.expr)
+        if (css !== null) return `style="${css}"`
+      }
       if (isBooleanAttr(name) || value.presenceOrUndefined) {
         const { condition: goCond, preamble } = this.convertConditionToGo(value.expr)
         return `${preamble}{{if ${goCond}}}${name}{{end}}`
@@ -5972,6 +5979,31 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // Neither variant is legal on intrinsic elements.
     emitBooleanShorthand: () => '',
     emitJsxChildren: () => '',
+  }
+
+  /**
+   * Lower a `style={{ … }}` object-literal value to a CSS string with dynamic
+   * values interpolated as Go template actions, e.g.
+   * `{ backgroundColor: color, padding: '8px' }` →
+   * `background-color:{{.Color}};padding:8px`. Returns null when the object
+   * shape is unsupported or any value expression can't be lowered (the caller
+   * then falls through to the generic BF101 path). (#1322)
+   */
+  private tryLowerStyleObject(expr: string): string | null {
+    const entries = parseStyleObjectEntries(expr)
+    if (!entries) return null
+    // Pre-check every dynamic value so an unsupported one bails the whole
+    // object (rather than recording a partial BF101 mid-build).
+    for (const e of entries) {
+      if (e.kind === 'expr' && !isSupported(parseExpression(e.expr)).supported) return null
+    }
+    return entries
+      .map(e =>
+        e.kind === 'literal'
+          ? `${e.cssKey}:${e.value}`
+          : `${e.cssKey}:{{${this.convertExpressionToGo(e.expr)}}}`,
+      )
+      .join(';')
   }
 
   private renderAttributes(element: IRElement): string {

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -62,6 +62,7 @@ import {
   augmentInheritedPropAccesses,
   parseRecordIndexAccess,
   collectContextConsumers,
+  isLowerableObjectRestDestructure,
   type ContextConsumer,
 } from '@barefootjs/jsx'
 import { findInterpolationEnd } from '@barefootjs/jsx/scanner'
@@ -3890,14 +3891,16 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // Module pure-string const (e.g. `const baseClasses = '...'` used in a
     // className template literal): inline the literal value rather than
     // emit `{{.BaseClasses}}` against a Props field that never exists.
-    const inlined = this.resolveModuleStringConst(name)
-    if (inlined !== null) return inlined
     // Destructure-param bindings (`.map(({ id, ...rest }) => …)`): resolve the
-    // binding name to its accessor on the range var. Innermost loop wins. (#1310)
+    // binding name to its accessor on the range var. Innermost loop wins, and
+    // this runs *before* module-const inlining so a binding whose name collides
+    // with a module string const still resolves to the loop item. (#1310)
     for (let i = this.loopBindingStack.length - 1; i >= 0; i--) {
       const acc = this.loopBindingStack[i].get(name)
       if (acc !== undefined) return acc
     }
+    const inlined = this.resolveModuleStringConst(name)
+    if (inlined !== null) return inlined
     const currentLoopParam = this.loopParamStack[this.loopParamStack.length - 1]
     if (currentLoopParam && name === currentLoopParam) return '.'
     // An *outer* loop's value variable (we're in a nested loop) is in scope as
@@ -5612,45 +5615,6 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   /**
-   * True when a destructure loop param is the lowerable object-rest shape:
-   * every binding is either a simple `.field` access or an object-rest, and the
-   * rest binding (if any) is only read via member access — not spread `{...rest}`
-   * (which needs a residual object) and not an array-index / nested path. (#1310)
-   */
-  private destructureBindingsSupportable(loop: IRLoop): boolean {
-    const bindings = loop.paramBindings
-    if (!bindings || bindings.length === 0) return false
-    for (const b of bindings) {
-      if (b.rest) {
-        if (b.rest.kind !== 'object') return false // array-rest → index/slice
-      } else if (!/^\.[A-Za-z_$][\w$]*$/.test(b.path)) {
-        return false // only a single `.field` path (no `[0]` / `.cells[0]`)
-      }
-    }
-    const restNames = bindings.filter(b => b.rest).map(b => b.name)
-    if (restNames.length > 0 && this.loopBodySpreadsAny(loop.children, restNames)) {
-      return false
-    }
-    return true
-  }
-
-  /** True when any element in the subtree spreads one of `names` (`{...rest}`). */
-  private loopBodySpreadsAny(nodes: IRNode[], names: string[]): boolean {
-    for (const n of nodes) {
-      if (n.type === 'element') {
-        const el = n as IRElement
-        for (const a of el.attrs) {
-          if (a.value.kind === 'spread' && names.includes(a.value.expr.trim())) return true
-        }
-        if (this.loopBodySpreadsAny(el.children, names)) return true
-      } else if ('children' in n && Array.isArray((n as { children?: IRNode[] }).children)) {
-        if (this.loopBodySpreadsAny((n as { children: IRNode[] }).children, names)) return true
-      }
-    }
-    return false
-  }
-
-  /**
    * Map each destructure binding to its Go accessor on the range var: a named
    * binding → `$<rangeVar>.<Field>`, an object-rest binding → the bare
    * `$<rangeVar>` so the member emitter renders `rest.flag` → `$<rangeVar>.Flag`.
@@ -5696,7 +5660,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // / nested / rest-spread shapes (`[a, ...t]`, `{ cells: [h] }`, `{...rest}`)
     // still need machinery Go's `{{range}}` can't express inline → BF104. (#1310)
     const destructure = !!(loop.paramBindings && loop.paramBindings.length > 0)
-    const supportableDestructure = destructure && this.destructureBindingsSupportable(loop)
+    const supportableDestructure = destructure && isLowerableObjectRestDestructure(loop)
     if (destructure && !supportableDestructure) {
       this.errors.push({
         code: 'BF104',
@@ -5722,9 +5686,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // `{{range $k, $_ := .Arr}}` makes `$k` the 0-based index.
     let rangeIndex = index
     // A supported destructure param can't be the Go range var verbatim
-    // (`$bfItem` is a synthetic single name; bindings resolve against it via
-    // `loopBindingStack`); otherwise the value var is the param itself.
-    let rangeValue = supportableDestructure ? 'bfItem' : param
+    // (`$bfItemN` is a synthetic single name; bindings resolve against it via
+    // `loopBindingStack`); otherwise the value var is the param itself. The
+    // suffix is the current nesting depth so an inner destructure loop doesn't
+    // shadow an outer one's range var (a binding referenced across levels keeps
+    // resolving against its own item).
+    let rangeValue = supportableDestructure ? `bfItem${this.loopBindingStack.length}` : param
     if (loop.iterationShape === 'keys') {
       rangeIndex = param
       rangeValue = '_'

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -468,6 +468,11 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   private inLoop: boolean = false
   private loopParamStack: string[] = []
   private loopVarRefCount: Map<string, number> = new Map()
+  /** Stack of destructure-param binding maps (binding name → Go accessor on the
+   *  range var, e.g. `id` → `$bfItem.Id`, `rest` → `$bfItem`). Innermost last.
+   *  Lets `.map(({ id, ...rest }) => …)` resolve `id` / `rest.flag` instead of
+   *  refusing with BF104. (#1310) */
+  private loopBindingStack: Array<Map<string, string>> = []
   private errors: CompilerError[] = []
   private propsObjectName: string | null = null
   /**
@@ -3887,6 +3892,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // emit `{{.BaseClasses}}` against a Props field that never exists.
     const inlined = this.resolveModuleStringConst(name)
     if (inlined !== null) return inlined
+    // Destructure-param bindings (`.map(({ id, ...rest }) => …)`): resolve the
+    // binding name to its accessor on the range var. Innermost loop wins. (#1310)
+    for (let i = this.loopBindingStack.length - 1; i >= 0; i--) {
+      const acc = this.loopBindingStack[i].get(name)
+      if (acc !== undefined) return acc
+    }
     const currentLoopParam = this.loopParamStack[this.loopParamStack.length - 1]
     if (currentLoopParam && name === currentLoopParam) return '.'
     // An *outer* loop's value variable (we're in a nested loop) is in scope as
@@ -5600,6 +5611,63 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     }
   }
 
+  /**
+   * True when a destructure loop param is the lowerable object-rest shape:
+   * every binding is either a simple `.field` access or an object-rest, and the
+   * rest binding (if any) is only read via member access — not spread `{...rest}`
+   * (which needs a residual object) and not an array-index / nested path. (#1310)
+   */
+  private destructureBindingsSupportable(loop: IRLoop): boolean {
+    const bindings = loop.paramBindings
+    if (!bindings || bindings.length === 0) return false
+    for (const b of bindings) {
+      if (b.rest) {
+        if (b.rest.kind !== 'object') return false // array-rest → index/slice
+      } else if (!/^\.[A-Za-z_$][\w$]*$/.test(b.path)) {
+        return false // only a single `.field` path (no `[0]` / `.cells[0]`)
+      }
+    }
+    const restNames = bindings.filter(b => b.rest).map(b => b.name)
+    if (restNames.length > 0 && this.loopBodySpreadsAny(loop.children, restNames)) {
+      return false
+    }
+    return true
+  }
+
+  /** True when any element in the subtree spreads one of `names` (`{...rest}`). */
+  private loopBodySpreadsAny(nodes: IRNode[], names: string[]): boolean {
+    for (const n of nodes) {
+      if (n.type === 'element') {
+        const el = n as IRElement
+        for (const a of el.attrs) {
+          if (a.value.kind === 'spread' && names.includes(a.value.expr.trim())) return true
+        }
+        if (this.loopBodySpreadsAny(el.children, names)) return true
+      } else if ('children' in n && Array.isArray((n as { children?: IRNode[] }).children)) {
+        if (this.loopBodySpreadsAny((n as { children: IRNode[] }).children, names)) return true
+      }
+    }
+    return false
+  }
+
+  /**
+   * Map each destructure binding to its Go accessor on the range var: a named
+   * binding → `$<rangeVar>.<Field>`, an object-rest binding → the bare
+   * `$<rangeVar>` so the member emitter renders `rest.flag` → `$<rangeVar>.Flag`.
+   * (#1310)
+   */
+  private buildDestructureBindingMap(loop: IRLoop, rangeVar: string): Map<string, string> {
+    const m = new Map<string, string>()
+    for (const b of loop.paramBindings ?? []) {
+      if (b.rest) {
+        m.set(b.name, `$${rangeVar}`)
+      } else {
+        m.set(b.name, `$${rangeVar}.${this.capitalizeFieldName(b.path.slice(1))}`)
+      }
+    }
+    return m
+  }
+
   renderLoop(loop: IRLoop): string {
     // clientOnly loops: emit SSR markers so client can insert DOM nodes.
     // The marker id disambiguates sibling `.map()` calls under the same parent (#1087).
@@ -5621,7 +5689,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // iff the param is a destructure pattern (array or object); a
     // simple identifier leaves it `undefined`. The structured check is
     // robust to whitespace / formatting variants in the source.
-    if (loop.paramBindings && loop.paramBindings.length > 0) {
+    // A destructure loop param is lowerable only for the object-rest /
+    // simple-field shape (`.map(({ id, title, ...rest }) => …)`, where `rest`
+    // is read via member access): each binding resolves to a field on a named
+    // range var (`$bfItem.Id`, and `rest.flag` → `$bfItem.Flag`). Array-index
+    // / nested / rest-spread shapes (`[a, ...t]`, `{ cells: [h] }`, `{...rest}`)
+    // still need machinery Go's `{{range}}` can't express inline → BF104. (#1310)
+    const destructure = !!(loop.paramBindings && loop.paramBindings.length > 0)
+    const supportableDestructure = destructure && this.destructureBindingsSupportable(loop)
+    if (destructure && !supportableDestructure) {
       this.errors.push({
         code: 'BF104',
         severity: 'error',
@@ -5645,7 +5721,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // the value. Swap into the Go range's first binding slot so
     // `{{range $k, $_ := .Arr}}` makes `$k` the 0-based index.
     let rangeIndex = index
-    let rangeValue = param
+    // A supported destructure param can't be the Go range var verbatim
+    // (`$bfItem` is a synthetic single name; bindings resolve against it via
+    // `loopBindingStack`); otherwise the value var is the param itself.
+    let rangeValue = supportableDestructure ? 'bfItem' : param
     if (loop.iterationShape === 'keys') {
       rangeIndex = param
       rangeValue = '_'
@@ -5673,7 +5752,18 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // same index var name don't clobber the outer loop's entry on
     // cleanup.
     const addedLoopVars: string[] = []
-    if (loop.iterationShape === 'keys') {
+    let pushedBindingMap = false
+    if (supportableDestructure) {
+      // Bindings resolve against the synthetic `$bfItem` range var; don't push
+      // a loop param (the param is a pattern, not a name).
+      this.loopBindingStack.push(this.buildDestructureBindingMap(loop, rangeValue))
+      pushedBindingMap = true
+      this.loopParamStack.push('')
+      if (rangeIndex !== '_') {
+        this.loopVarRefCount.set(rangeIndex, (this.loopVarRefCount.get(rangeIndex) ?? 0) + 1)
+        addedLoopVars.push(rangeIndex)
+      }
+    } else if (loop.iterationShape === 'keys') {
       this.loopParamStack.push('')
       this.loopVarRefCount.set(param, (this.loopVarRefCount.get(param) ?? 0) + 1)
       addedLoopVars.push(param)
@@ -5696,6 +5786,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       else this.loopVarRefCount.set(v, rc)
     }
     this.loopParamStack.pop()
+    if (pushedBindingMap) this.loopBindingStack.pop()
     this.inLoop = false
 
     // Apply sort if present: wrap array with bf_sort pipeline. The

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -45,15 +45,12 @@ runAdapterConformanceTests({
       { code: 'BF103', severity: 'error' },
       { code: 'BF104', severity: 'error' },
     ],
-    // #1310: rest destructure in .map() callback. Hono / CSR lower
-    // these via the inline residual-object accessor (#1309); the Mojo
-    // adapter's loop emitter raises the generic BF104 destructure
-    // refusal regardless of whether the binding is rest or plain.
-    // Pinning the contract here makes the limitation declarative.
-    'rest-destructure-object-in-map': [{ code: 'BF104', severity: 'error' }],
-    // #1244 catalog: rest spread back onto the root element. Same
-    // refusal shape as the read-only variant above — `paramBindings`
-    // is non-empty so BF104 fires regardless of how `rest` is used.
+    // #1310: rest destructure in .map() callback. The object-rest shape read
+    // via member access (`rest-destructure-object-in-map`) now lowers — each
+    // binding becomes a Perl `my` local off the per-item var (`$rest` aliases
+    // the item so `$rest->{flag}` resolves). The other three stay refused:
+    // rest SPREAD (`{...rest}`) needs a residual hash, and array-index /
+    // nested paths can't unpack into scalar `my`s.
     'rest-destructure-object-spread-in-map': [{ code: 'BF104', severity: 'error' }],
     'rest-destructure-array-in-map': [{ code: 'BF104', severity: 'error' }],
     'rest-destructure-nested-in-map': [{ code: 'BF104', severity: 'error' }],

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -57,17 +57,10 @@ runAdapterConformanceTests({
     'rest-destructure-object-spread-in-map': [{ code: 'BF104', severity: 'error' }],
     'rest-destructure-array-in-map': [{ code: 'BF104', severity: 'error' }],
     'rest-destructure-nested-in-map': [{ code: 'BF104', severity: 'error' }],
-    // #1244 stress catalog #11 (#1322): JS object literal in an
-    // attribute value (`style={{ background: bg(), color: fg() }}`) has
-    // no idiomatic Mojo template form. `refuseUnsupportedAttrExpression`
-    // surfaces BF101 with a wrap-in-`/* @client */` suggestion, matching
-    // the Go adapter's behaviour.
-    'style-3-signals': [{ code: 'BF101', severity: 'error' }],
-    // Dynamic JS object literal in `style={{ … }}` — same no-EP-form
-    // refusal as `style-3-signals`; `refuseUnsupportedAttrExpression`
-    // surfaces BF101 (mirrors the xslate + Go adapters). Was a stale
-    // `skipJsx` entry claiming the gate didn't lift to a CompilerError.
-    'style-object-dynamic': [{ code: 'BF101', severity: 'error' }],
+    // `style-3-signals` / `style-object-dynamic` no longer pinned — a
+    // `style={{ … }}` object literal now lowers to a CSS string with dynamic
+    // values interpolated (`background-color:<%= $color %>;padding:8px`) via
+    // `tryLowerStyleObject` (#1322).
     // #1244 stress catalog #12 (#1323): tagged-template-literal call
     // (`cn\`base \${tone()}\``) — same family as #1322 above and refused
     // via the same gate.

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -889,6 +889,44 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
   // Loop Rendering
   // ===========================================================================
 
+  /**
+   * True when a destructure loop param is the lowerable object-rest shape:
+   * every binding is a simple `.field` or an object-rest read via member access
+   * (not spread `{...rest}`, not an array-index / nested path). (#1310)
+   */
+  private destructureBindingsSupportable(loop: IRLoop): boolean {
+    const bindings = loop.paramBindings
+    if (!bindings || bindings.length === 0) return false
+    for (const b of bindings) {
+      if (b.rest) {
+        if (b.rest.kind !== 'object') return false
+      } else if (!/^\.[A-Za-z_$][\w$]*$/.test(b.path)) {
+        return false
+      }
+    }
+    const restNames = bindings.filter(b => b.rest).map(b => b.name)
+    if (restNames.length > 0 && this.loopBodySpreadsAny(loop.children, restNames)) {
+      return false
+    }
+    return true
+  }
+
+  /** True when any element in the subtree spreads one of `names` (`{...rest}`). */
+  private loopBodySpreadsAny(nodes: IRNode[], names: string[]): boolean {
+    for (const n of nodes) {
+      if (n.type === 'element') {
+        const el = n as IRElement
+        for (const a of el.attrs) {
+          if (a.value.kind === 'spread' && names.includes(a.value.expr.trim())) return true
+        }
+        if (this.loopBodySpreadsAny(el.children, names)) return true
+      } else if ('children' in n && Array.isArray((n as { children?: IRNode[] }).children)) {
+        if (this.loopBodySpreadsAny((n as { children: IRNode[] }).children, names)) return true
+      }
+    }
+    return false
+  }
+
   renderLoop(loop: IRLoop): string {
     // Client-only loops: skip SSR rendering entirely
     if (loop.clientOnly) return ''
@@ -905,7 +943,14 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     // iff the param is a destructure pattern (array or object); a
     // simple identifier leaves it `undefined`. The structured check is
     // robust to whitespace / formatting variants in the source.
-    if (loop.paramBindings && loop.paramBindings.length > 0) {
+    // A destructure loop param is lowerable for the object-rest / simple-field
+    // shape (`.map(({ id, title, ...rest }) => …)`, `rest` read via member
+    // access): each binding becomes a Perl `my` local off the per-item var, so
+    // the body's `$id` / `$rest->{flag}` resolve natively. Array-index / nested
+    // / rest-spread shapes still can't unpack into scalar `my`s → BF104. (#1310)
+    const destructure = !!(loop.paramBindings && loop.paramBindings.length > 0)
+    const supportableDestructure = destructure && this.destructureBindingsSupportable(loop)
+    if (destructure && !supportableDestructure) {
       this.errors.push({
         code: 'BF104',
         severity: 'error',
@@ -952,7 +997,9 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     // nested loops; released after the body lines are assembled below.
     const loopBound = loop.iterationShape === 'keys'
       ? [param]
-      : [param, loop.index ?? '_i']
+      : supportableDestructure
+        ? [...(loop.paramBindings ?? []).map(b => b.name), loop.index ?? '_i']
+        : [param, loop.index ?? '_i']
     for (const n of loopBound) {
       this.loopBoundNames.set(n, (this.loopBoundNames.get(n) ?? 0) + 1)
     }
@@ -980,7 +1027,20 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     }
     lines.push(`% for my ${indexVar} (0..$#{${array}}) {`)
     if (loop.iterationShape !== 'keys') {
-      lines.push(`% my $${param} = ${array}->[${indexVar}];`)
+      if (supportableDestructure) {
+        // Per-item var + one `my` local per binding; `rest` aliases the item
+        // so `$rest->{flag}` resolves (object-rest read via member access).
+        lines.push(`% my $bfItem = ${array}->[${indexVar}];`)
+        for (const b of loop.paramBindings ?? []) {
+          lines.push(
+            b.rest
+              ? `% my $${b.name} = $bfItem;`
+              : `% my $${b.name} = $bfItem->{${b.path.slice(1)}};`,
+          )
+        }
+      } else {
+        lines.push(`% my $${param} = ${array}->[${indexVar}];`)
+      }
     }
 
     // Handle filter().map() pattern by wrapping children in if-condition

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -41,6 +41,7 @@ import {
   type AttrValueEmitter,
   isBooleanAttr,
   parseExpression,
+  parseStyleObjectEntries,
   isSupported,
   exprToString,
   identifierPath,
@@ -1196,15 +1197,20 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
   private readonly elementAttrEmitter: AttrValueEmitter = {
     emitLiteral: (value, name) => `${name}="${value.value}"`,
     emitExpression: (value, name) => {
+      // `style={{ … }}` object literal → a CSS string with dynamic values
+      // interpolated, instead of refusing the bare object with BF101 (#1322).
+      if (name === 'style') {
+        const css = this.tryLowerStyleObject(value.expr)
+        if (css !== null) return `style="${css}"`
+      }
       // Refuse shapes that the regex pipeline silently mangles into
-      // invalid Perl (#1322). Object literals (`style={{...}}`) and
-      // tagged-template-literal call expressions (`cn\`base \${tone()}\``)
-      // have no idiomatic Mojo template form; the Go adapter raises
-      // BF101 here via `convertExpressionToGo` + `isSupported`. Lift the
-      // same gate so the user gets a clear diagnostic instead of broken
-      // output. The check runs before `convertExpressionToPerl` so the
-      // regex pipeline never produces template-text fragments for a
-      // shape we've already rejected.
+      // invalid Perl (#1322). Tagged-template-literal call expressions
+      // (`cn\`base \${tone()}\``) have no idiomatic Mojo template form; the Go
+      // adapter raises BF101 here via `convertExpressionToGo` + `isSupported`.
+      // Lift the same gate so the user gets a clear diagnostic instead of
+      // broken output. The check runs before `convertExpressionToPerl` so the
+      // regex pipeline never produces template-text fragments for a shape
+      // we've already rejected.
       if (this.refuseUnsupportedAttrExpression(value.expr, name)) {
         return ''
       }
@@ -1353,6 +1359,28 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     // Neither variant is legal on intrinsic elements.
     emitBooleanShorthand: () => '',
     emitJsxChildren: () => '',
+  }
+
+  /**
+   * Lower a `style={{ … }}` object literal to a CSS string with dynamic values
+   * interpolated as EP actions, e.g. `{ backgroundColor: color, padding: '8px' }`
+   * → `background-color:<%= $color %>;padding:8px`. Returns null when the shape
+   * is unsupported or any value can't be lowered (caller then falls through to
+   * the BF101 refusal). (#1322)
+   */
+  private tryLowerStyleObject(expr: string): string | null {
+    const entries = parseStyleObjectEntries(expr)
+    if (!entries) return null
+    for (const e of entries) {
+      if (e.kind === 'expr' && !isSupported(parseExpression(e.expr)).supported) return null
+    }
+    return entries
+      .map(e =>
+        e.kind === 'literal'
+          ? `${e.cssKey}:${e.value}`
+          : `${e.cssKey}:<%= ${this.convertExpressionToPerl(e.expr)} %>`,
+      )
+      .join(';')
   }
 
   private renderAttributes(element: IRElement): string {

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -53,6 +53,7 @@ import {
   evalStringArrayJoin,
   extractArrowBodyExpression,
   collectContextConsumers,
+  isLowerableObjectRestDestructure,
   type ContextConsumer,
   extractSsrDefaults,
 } from '@barefootjs/jsx'
@@ -889,44 +890,6 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
   // Loop Rendering
   // ===========================================================================
 
-  /**
-   * True when a destructure loop param is the lowerable object-rest shape:
-   * every binding is a simple `.field` or an object-rest read via member access
-   * (not spread `{...rest}`, not an array-index / nested path). (#1310)
-   */
-  private destructureBindingsSupportable(loop: IRLoop): boolean {
-    const bindings = loop.paramBindings
-    if (!bindings || bindings.length === 0) return false
-    for (const b of bindings) {
-      if (b.rest) {
-        if (b.rest.kind !== 'object') return false
-      } else if (!/^\.[A-Za-z_$][\w$]*$/.test(b.path)) {
-        return false
-      }
-    }
-    const restNames = bindings.filter(b => b.rest).map(b => b.name)
-    if (restNames.length > 0 && this.loopBodySpreadsAny(loop.children, restNames)) {
-      return false
-    }
-    return true
-  }
-
-  /** True when any element in the subtree spreads one of `names` (`{...rest}`). */
-  private loopBodySpreadsAny(nodes: IRNode[], names: string[]): boolean {
-    for (const n of nodes) {
-      if (n.type === 'element') {
-        const el = n as IRElement
-        for (const a of el.attrs) {
-          if (a.value.kind === 'spread' && names.includes(a.value.expr.trim())) return true
-        }
-        if (this.loopBodySpreadsAny(el.children, names)) return true
-      } else if ('children' in n && Array.isArray((n as { children?: IRNode[] }).children)) {
-        if (this.loopBodySpreadsAny((n as { children: IRNode[] }).children, names)) return true
-      }
-    }
-    return false
-  }
-
   renderLoop(loop: IRLoop): string {
     // Client-only loops: skip SSR rendering entirely
     if (loop.clientOnly) return ''
@@ -949,7 +912,7 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     // the body's `$id` / `$rest->{flag}` resolve natively. Array-index / nested
     // / rest-spread shapes still can't unpack into scalar `my`s → BF104. (#1310)
     const destructure = !!(loop.paramBindings && loop.paramBindings.length > 0)
-    const supportableDestructure = destructure && this.destructureBindingsSupportable(loop)
+    const supportableDestructure = destructure && isLowerableObjectRestDestructure(loop)
     if (destructure && !supportableDestructure) {
       this.errors.push({
         code: 'BF104',
@@ -998,7 +961,7 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     const loopBound = loop.iterationShape === 'keys'
       ? [param]
       : supportableDestructure
-        ? [...(loop.paramBindings ?? []).map(b => b.name), loop.index ?? '_i']
+        ? ['bfItem', ...(loop.paramBindings ?? []).map(b => b.name), loop.index ?? '_i']
         : [param, loop.index ?? '_i']
     for (const n of loopBound) {
       this.loopBoundNames.set(n, (this.loopBoundNames.get(n) ?? 0) + 1)

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -72,14 +72,10 @@ runAdapterConformanceTests({
     // above — refused with BF101 for the identical Kolon engine reason, not a
     // render-mismatch (so it's pinned here, not in `skipJsx`).
     'kbd': [{ code: 'BF101', severity: 'error' }],
-    // JS object literal in an attribute value (`style={{ … }}`) has no
-    // Kolon form — refused via the same gate as mojo (BF101).
-    'style-3-signals': [{ code: 'BF101', severity: 'error' }],
-    // Dynamic `style={{ … }}` object: the Xslate adapter cleanly refuses it
-    // with BF101 (no idiomatic Kolon form). mojo *skips* this fixture because
-    // its EP path emits invalid Perl silently — Xslate's build-time diagnostic
-    // is the stronger contract, so it's pinned here rather than skipped.
-    'style-object-dynamic': [{ code: 'BF101', severity: 'error' }],
+    // `style-3-signals` / `style-object-dynamic` no longer pinned — a
+    // `style={{ … }}` object literal now lowers to a CSS string with dynamic
+    // values interpolated (`background-color:<: $color :>;padding:8px`) via
+    // `tryLowerStyleObject` (#1322).
     // Tagged-template-literal call in a className — same family, same
     // refusal (BF101).
     'tagged-template-classname': [{ code: 'BF101', severity: 'error' }],

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -52,10 +52,11 @@ runAdapterConformanceTests({
       { code: 'BF103', severity: 'error' },
       { code: 'BF104', severity: 'error' },
     ],
-    // Rest-destructure `.map()` callbacks — the loop emitter raises the
-    // generic BF104 destructure refusal regardless of rest-vs-plain
-    // (same surface as mojo).
-    'rest-destructure-object-in-map': [{ code: 'BF104', severity: 'error' }],
+    // Rest-destructure `.map()` callbacks — the object-rest shape read via
+    // member access (`rest-destructure-object-in-map`) now lowers via Kolon
+    // `: my` binding locals (`$rest` aliases the item). The other three stay
+    // refused: rest SPREAD needs a residual object, array-index / nested paths
+    // can't unpack a tuple (same surface as mojo).
     'rest-destructure-object-spread-in-map': [{ code: 'BF104', severity: 'error' }],
     'rest-destructure-array-in-map': [{ code: 'BF104', severity: 'error' }],
     'rest-destructure-nested-in-map': [{ code: 'BF104', severity: 'error' }],

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -66,6 +66,7 @@ import {
   evalStringArrayJoin,
   extractArrowBodyExpression,
   collectContextConsumers,
+  isLowerableObjectRestDestructure,
   type ContextConsumer,
   extractSsrDefaults,
 } from '@barefootjs/jsx'
@@ -782,44 +783,6 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
   // Loop Rendering
   // ===========================================================================
 
-  /**
-   * True when a destructure loop param is the lowerable object-rest shape:
-   * every binding is a simple `.field` or an object-rest read via member access
-   * (not spread `{...rest}`, not an array-index / nested path). (#1310)
-   */
-  private destructureBindingsSupportable(loop: IRLoop): boolean {
-    const bindings = loop.paramBindings
-    if (!bindings || bindings.length === 0) return false
-    for (const b of bindings) {
-      if (b.rest) {
-        if (b.rest.kind !== 'object') return false
-      } else if (!/^\.[A-Za-z_$][\w$]*$/.test(b.path)) {
-        return false
-      }
-    }
-    const restNames = bindings.filter(b => b.rest).map(b => b.name)
-    if (restNames.length > 0 && this.loopBodySpreadsAny(loop.children, restNames)) {
-      return false
-    }
-    return true
-  }
-
-  /** True when any element in the subtree spreads one of `names` (`{...rest}`). */
-  private loopBodySpreadsAny(nodes: IRNode[], names: string[]): boolean {
-    for (const n of nodes) {
-      if (n.type === 'element') {
-        const el = n as IRElement
-        for (const a of el.attrs) {
-          if (a.value.kind === 'spread' && names.includes(a.value.expr.trim())) return true
-        }
-        if (this.loopBodySpreadsAny(el.children, names)) return true
-      } else if ('children' in n && Array.isArray((n as { children?: IRNode[] }).children)) {
-        if (this.loopBodySpreadsAny((n as { children: IRNode[] }).children, names)) return true
-      }
-    }
-    return false
-  }
-
   renderLoop(loop: IRLoop): string {
     // Client-only loops: skip SSR rendering entirely
     if (loop.clientOnly) return ''
@@ -834,7 +797,7 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     // so the body's `$id` / `$rest.flag` resolve. Array-index / nested /
     // rest-spread shapes still can't unpack a tuple → BF104. (#1310)
     const destructure = !!(loop.paramBindings && loop.paramBindings.length > 0)
-    const supportableDestructure = destructure && this.destructureBindingsSupportable(loop)
+    const supportableDestructure = destructure && isLowerableObjectRestDestructure(loop)
     if (destructure && !supportableDestructure) {
       this.errors.push({
         code: 'BF104',

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -55,6 +55,7 @@ import {
   type AttrValueEmitter,
   isBooleanAttr,
   parseExpression,
+  parseStyleObjectEntries,
   isSupported,
   identifierPath,
   emitParsedExpr,
@@ -1074,9 +1075,15 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
   private readonly elementAttrEmitter: AttrValueEmitter = {
     emitLiteral: (value, name) => `${name}="${value.value}"`,
     emitExpression: (value, name) => {
+      // `style={{ … }}` object literal → a CSS string with dynamic values
+      // interpolated, instead of refusing the bare object with BF101 (#1322).
+      if (name === 'style') {
+        const css = this.tryLowerStyleObject(value.expr)
+        if (css !== null) return `style="${css}"`
+      }
       // Refuse shapes that the lowering pipeline can't represent in Kolon —
-      // object literals (`style={{...}}`) and tagged-template-literal call
-      // expressions (`cn\`base \${tone()}\``). Same gate as the Mojo adapter.
+      // tagged-template-literal call expressions (`cn\`base \${tone()}\``).
+      // Same gate as the Mojo adapter.
       if (this.refuseUnsupportedAttrExpression(value.expr, name)) {
         return ''
       }
@@ -1175,6 +1182,27 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     // Neither variant is legal on intrinsic elements.
     emitBooleanShorthand: () => '',
     emitJsxChildren: () => '',
+  }
+
+  /**
+   * Lower a `style={{ … }}` object literal to a CSS string with dynamic values
+   * interpolated as Kolon actions, e.g. `{ backgroundColor: color }` →
+   * `background-color:<: $color :>`. Returns null when the shape is unsupported
+   * or any value can't be lowered (caller falls through to BF101). (#1322)
+   */
+  private tryLowerStyleObject(expr: string): string | null {
+    const entries = parseStyleObjectEntries(expr)
+    if (!entries) return null
+    for (const e of entries) {
+      if (e.kind === 'expr' && !isSupported(parseExpression(e.expr)).supported) return null
+    }
+    return entries
+      .map(e =>
+        e.kind === 'literal'
+          ? `${e.cssKey}:${e.value}`
+          : `${e.cssKey}:<: ${this.convertExpressionToKolon(e.expr)} :>`,
+      )
+      .join(';')
   }
 
   private renderAttributes(element: IRElement): string {

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -782,6 +782,44 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
   // Loop Rendering
   // ===========================================================================
 
+  /**
+   * True when a destructure loop param is the lowerable object-rest shape:
+   * every binding is a simple `.field` or an object-rest read via member access
+   * (not spread `{...rest}`, not an array-index / nested path). (#1310)
+   */
+  private destructureBindingsSupportable(loop: IRLoop): boolean {
+    const bindings = loop.paramBindings
+    if (!bindings || bindings.length === 0) return false
+    for (const b of bindings) {
+      if (b.rest) {
+        if (b.rest.kind !== 'object') return false
+      } else if (!/^\.[A-Za-z_$][\w$]*$/.test(b.path)) {
+        return false
+      }
+    }
+    const restNames = bindings.filter(b => b.rest).map(b => b.name)
+    if (restNames.length > 0 && this.loopBodySpreadsAny(loop.children, restNames)) {
+      return false
+    }
+    return true
+  }
+
+  /** True when any element in the subtree spreads one of `names` (`{...rest}`). */
+  private loopBodySpreadsAny(nodes: IRNode[], names: string[]): boolean {
+    for (const n of nodes) {
+      if (n.type === 'element') {
+        const el = n as IRElement
+        for (const a of el.attrs) {
+          if (a.value.kind === 'spread' && names.includes(a.value.expr.trim())) return true
+        }
+        if (this.loopBodySpreadsAny(el.children, names)) return true
+      } else if ('children' in n && Array.isArray((n as { children?: IRNode[] }).children)) {
+        if (this.loopBodySpreadsAny((n as { children: IRNode[] }).children, names)) return true
+      }
+    }
+    return false
+  }
+
   renderLoop(loop: IRLoop): string {
     // Client-only loops: skip SSR rendering entirely
     if (loop.clientOnly) return ''
@@ -790,7 +828,14 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     // `({ name, age }) => ...`) lowers to invalid Kolon — Kolon's `for LIST
     // -> $item` binds a single scalar and can't unpack a tuple. Surface this
     // at build time instead of shipping a broken template line.
-    if (loop.paramBindings && loop.paramBindings.length > 0) {
+    // A destructure loop param is lowerable for the object-rest / simple-field
+    // shape (`.map(({ id, title, ...rest }) => …)`, `rest` read via member
+    // access): each binding becomes a Kolon `: my` local off the per-item var,
+    // so the body's `$id` / `$rest.flag` resolve. Array-index / nested /
+    // rest-spread shapes still can't unpack a tuple → BF104. (#1310)
+    const destructure = !!(loop.paramBindings && loop.paramBindings.length > 0)
+    const supportableDestructure = destructure && this.destructureBindingsSupportable(loop)
+    if (destructure && !supportableDestructure) {
       this.errors.push({
         code: 'BF104',
         severity: 'error',
@@ -823,16 +868,29 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     // For `keys`-shape iterations the callback param IS the index. We iterate
     // the array but bind the loop var to a throwaway and expose the index as
     // `$param`. Kolon's `$~loopvar.index` provides the 0-based index.
-    const loopVar = loop.iterationShape === 'keys' ? '__bf_item' : param
+    const loopVar = loop.iterationShape === 'keys'
+      ? '__bf_item'
+      : supportableDestructure ? 'bfItem' : param
 
     // Index alias: when an explicit `index` param is present (`.map((x, i) =>
     // ...)`) or the iteration is `keys`-shaped, expose it via a `: my` Kolon
-    // local bound to the loop variable's `.index` accessor.
+    // local bound to the loop variable's `.index` accessor. A supported
+    // destructure param adds one `: my` local per binding (`rest` aliases the
+    // item so `$rest.flag` resolves).
     const indexLocalLines: string[] = []
     if (loop.iterationShape === 'keys') {
       indexLocalLines.push(`: my $${param} = $~${loopVar}.index;`)
     } else if (loop.index) {
       indexLocalLines.push(`: my $${loop.index} = $~${loopVar}.index;`)
+    }
+    if (supportableDestructure) {
+      for (const b of loop.paramBindings ?? []) {
+        indexLocalLines.push(
+          b.rest
+            ? `: my $${b.name} = $${loopVar};`
+            : `: my $${b.name} = $${loopVar}${b.path};`,
+        )
+      }
     }
 
     const prevInLoop = this.inLoop

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test'
 import ts from 'typescript'
-import { parseExpression, isSupported, exprToString, stringifyParsedExpr, parseBlockBody, extractArrowBodyExpression } from '../expression-parser'
+import { parseExpression, isSupported, exprToString, stringifyParsedExpr, parseBlockBody, extractArrowBodyExpression, parseStyleObjectEntries } from '../expression-parser'
 import { collectAllTypeRanges, reconstructWithoutTypes } from '../strip-types'
 
 describe('expression-parser', () => {
@@ -1647,5 +1647,43 @@ describe('extractArrowBodyExpression', () => {
 
   test('returns null when the source is more than one statement', () => {
     expect(extractArrowBodyExpression('() => 1; sideEffect()')).toBeNull()
+  })
+})
+
+describe('parseStyleObjectEntries', () => {
+  test('kebab-cases keys and splits literal vs expression values', () => {
+    expect(parseStyleObjectEntries("{ backgroundColor: color, padding: '8px' }")).toEqual([
+      { cssKey: 'background-color', kind: 'expr', expr: 'color' },
+      { cssKey: 'padding', kind: 'literal', value: '8px' },
+    ])
+  })
+
+  test('handles signal-getter call values as expressions', () => {
+    expect(parseStyleObjectEntries('{ background: bg(), color: fg() }')).toEqual([
+      { cssKey: 'background', kind: 'expr', expr: 'bg()' },
+      { cssKey: 'color', kind: 'expr', expr: 'fg()' },
+    ])
+  })
+
+  test('quoted keys are honoured', () => {
+    expect(parseStyleObjectEntries("{ 'z-index': '1' }")).toEqual([
+      { cssKey: 'z-index', kind: 'literal', value: '1' },
+    ])
+  })
+
+  test('vendor-prefixed keys keep the leading dash', () => {
+    expect(parseStyleObjectEntries("{ WebkitTransform: 'none' }")).toEqual([
+      { cssKey: '-webkit-transform', kind: 'literal', value: 'none' },
+    ])
+  })
+
+  test('returns null for unsupported shapes (spread / shorthand / computed)', () => {
+    expect(parseStyleObjectEntries('{ ...rest }')).toBeNull()
+    expect(parseStyleObjectEntries('{ color }')).toBeNull()
+    expect(parseStyleObjectEntries('{ [k]: v }')).toBeNull()
+  })
+
+  test('returns null for a non-object source', () => {
+    expect(parseStyleObjectEntries('color')).toBeNull()
   })
 })

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -477,6 +477,56 @@ export function extractArrowBodyExpression(source: string): string | null {
 }
 
 /**
+ * A single entry of a JSX `style={{ … }}` object, lowered for SSR. The key is
+ * already CSS-cased (`backgroundColor` → `background-color`); the value is
+ * either a static string literal or a raw JS expression for the adapter to
+ * lower (`color` → its template interpolation).
+ */
+export type StyleObjectEntry =
+  | { cssKey: string; kind: 'literal'; value: string }
+  | { cssKey: string; kind: 'expr'; expr: string }
+
+/** camelCase → kebab-case for CSS property names (`backgroundColor` →
+ *  `background-color`, `WebkitTransform` → `-webkit-transform`). */
+function cssKebabCase(name: string): string {
+  return name.replace(/[A-Z]/g, m => '-' + m.toLowerCase())
+}
+
+/**
+ * Parse a JSX `style={{ … }}` object-literal source into CSS entries, or
+ * `null` when the shape isn't a plain object of static-keyed properties
+ * (spread, computed key, shorthand, method, getter) — the adapter then keeps
+ * refusing it. A bare `{…}` parses as a block statement, so the source is
+ * wrapped in parens to force expression context. Used by the template adapters
+ * to lower `style={{ backgroundColor: color, padding: '8px' }}` to a CSS
+ * string instead of emitting BF101.
+ */
+export function parseStyleObjectEntries(source: string): StyleObjectEntry[] | null {
+  const sf = ts.createSourceFile('__style__.ts', `(${source})`, ts.ScriptTarget.Latest, true)
+  const stmt = sf.statements[0]
+  if (!stmt || !ts.isExpressionStatement(stmt) || sf.statements.length !== 1) return null
+  let expr: ts.Expression = stmt.expression
+  while (ts.isParenthesizedExpression(expr)) expr = expr.expression
+  if (!ts.isObjectLiteralExpression(expr)) return null
+  const entries: StyleObjectEntry[] = []
+  for (const prop of expr.properties) {
+    if (!ts.isPropertyAssignment(prop)) return null // shorthand/spread/method/getter
+    let key: string
+    if (ts.isIdentifier(prop.name)) key = prop.name.text
+    else if (ts.isStringLiteral(prop.name)) key = prop.name.text
+    else return null // computed / numeric key
+    const cssKey = cssKebabCase(key)
+    const init = prop.initializer
+    if (ts.isStringLiteral(init) || ts.isNoSubstitutionTemplateLiteral(init)) {
+      entries.push({ cssKey, kind: 'literal', value: init.text })
+    } else {
+      entries.push({ cssKey, kind: 'expr', expr: init.getText(sf).trim() })
+    }
+  }
+  return entries.length > 0 ? entries : null
+}
+
+/**
  * Parse a JavaScript expression string into a ParsedExpr tree.
  */
 export function parseExpression(expr: string): ParsedExpr {

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -244,7 +244,8 @@ export {
 export { ErrorCodes, createError, formatError, generateCodeFrame } from './errors.ts'
 
 // Expression Parser
-export { parseExpression, isSupported, exprToString, stringifyParsedExpr, identifierPath, parseBlockBody, containsHigherOrder, extractArrowBodyExpression } from './expression-parser.ts'
+export { parseExpression, isSupported, exprToString, stringifyParsedExpr, identifierPath, parseBlockBody, containsHigherOrder, extractArrowBodyExpression, parseStyleObjectEntries } from './expression-parser.ts'
+export type { StyleObjectEntry } from './expression-parser.ts'
 export type { ParsedExpr, ParsedStatement, SortComparator, SortKey, ReduceOp, FlatDepth, FlatMapOp, FlatMapLeaf, SupportLevel, SupportResult, TemplatePart } from './expression-parser.ts'
 export { buildLoopChainExpr } from './loop-chain.ts'
 export type { LoopChainInputs } from './loop-chain.ts'

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -249,6 +249,7 @@ export type { StyleObjectEntry } from './expression-parser.ts'
 export type { ParsedExpr, ParsedStatement, SortComparator, SortKey, ReduceOp, FlatDepth, FlatMapOp, FlatMapLeaf, SupportLevel, SupportResult, TemplatePart } from './expression-parser.ts'
 export { buildLoopChainExpr } from './loop-chain.ts'
 export type { LoopChainInputs } from './loop-chain.ts'
+export { isLowerableObjectRestDestructure } from './loop-destructure.ts'
 
 // Debug analysis
 export {

--- a/packages/jsx/src/loop-destructure.ts
+++ b/packages/jsx/src/loop-destructure.ts
@@ -1,0 +1,143 @@
+import type { IRLoop, IRNode, AttrValue, IRTemplatePart } from './types.ts'
+
+const SIMPLE_FIELD = /^\.[A-Za-z_$][\w$]*$/
+
+/**
+ * True when a loop's destructure param is the single shape the non-JS SSR
+ * adapters (Go template / Mojolicious / Xslate) can lower today:
+ *
+ *   `arr.map(({ id, title, ...rest }) => …)`
+ *
+ * where every binding is a simple `.field` access or an **object-rest read only
+ * via member access** (`rest.flag`). The adapters lower the rest binding as an
+ * alias to the whole iteration item, which matches JS rest semantics only for
+ * member reads of non-consumed keys — so any other use must be refused:
+ *
+ *   - array-rest / array-index / nested paths (`[a, ...t]`, `{ cells: [h] }`)
+ *     need index/slice the `range`/`for` can't express inline;
+ *   - spread (`{...rest}`) and bare value uses (`String(rest)`, `{rest}`,
+ *     `fn(rest)`) would observe the consumed keys too — they need a residual
+ *     object the templates can't build inline;
+ *   - a chained `.filter().map(destructure)` would need the filter-param
+ *     rewrite to target the synthetic per-item var, so it's refused as well.
+ *
+ * Unsupported shapes fall through to the adapters' BF104 diagnostic. The scan
+ * is conservative: an ambiguous use refuses (false-negative is safe — it keeps
+ * the existing build-time error rather than shipping wrong output).
+ */
+export function isLowerableObjectRestDestructure(loop: IRLoop): boolean {
+  const bindings = loop.paramBindings
+  if (!bindings || bindings.length === 0) return false
+  if (loop.filterPredicate) return false
+  for (const b of bindings) {
+    if (b.rest) {
+      if (b.rest.kind !== 'object') return false
+    } else if (!SIMPLE_FIELD.test(b.path)) {
+      return false
+    }
+  }
+  const restNames = bindings.filter(b => b.rest).map(b => b.name)
+  if (restNames.length === 0) return true
+  return !restNamesMisused(loop.children, restNames)
+}
+
+/**
+ * Walks the whole loop subtree (every node type, every expression-bearing
+ * field) and reports whether any rest name is referenced as something other
+ * than a member-access base (`rest.flag` / `rest?.flag`). A spread expr
+ * (`{...rest}` → expr `"rest"`) and bare value uses are caught by the same
+ * regex; a property of an unrelated object (`foo.rest`) is excluded by the
+ * lookbehind.
+ */
+function restNamesMisused(nodes: IRNode[], names: string[]): boolean {
+  const valueUse = names.map(
+    n => new RegExp(`(?<![\\w.$])${escapeRe(n)}(?!\\s*\\??\\.)(?![\\w$])`),
+  )
+  let misused = false
+  const check = (s: string | undefined | null): void => {
+    if (!s || misused) return
+    for (const re of valueUse) {
+      if (re.test(s)) {
+        misused = true
+        return
+      }
+    }
+  }
+  const attr = (v: AttrValue): void => {
+    if (v.kind === 'expression' || v.kind === 'spread') {
+      check(v.expr)
+      check(v.templateExpr)
+    } else if (v.kind === 'template') {
+      v.parts.forEach(part)
+    }
+  }
+  const part = (p: IRTemplatePart): void => {
+    if (p.type === 'ternary') {
+      check(p.condition)
+      check(p.templateCondition)
+      check(p.whenTrue)
+      check(p.whenFalse)
+    } else if (p.type === 'lookup') {
+      check(p.key)
+      check(p.templateKey)
+    }
+  }
+  const visit = (node: IRNode): void => {
+    if (misused) return
+    switch (node.type) {
+      case 'expression':
+        check(node.expr)
+        check(node.templateExpr)
+        break
+      case 'conditional':
+        check(node.condition)
+        check(node.templateCondition)
+        visit(node.whenTrue)
+        visit(node.whenFalse)
+        break
+      case 'if-statement':
+        check(node.condition)
+        check(node.templateCondition)
+        for (const sv of node.scopeVariables) {
+          check(sv.initializer)
+          check(sv.templateInitializer)
+        }
+        visit(node.consequent)
+        if (node.alternate) visit(node.alternate)
+        break
+      case 'element':
+        node.attrs.forEach(a => attr(a.value))
+        node.children.forEach(visit)
+        break
+      case 'component':
+        node.props.forEach(p => attr(p.value))
+        node.children.forEach(visit)
+        break
+      case 'provider':
+        attr(node.valueProp.value)
+        node.children.forEach(visit)
+        break
+      case 'fragment':
+        node.children.forEach(visit)
+        break
+      case 'async':
+        visit(node.fallback)
+        node.children.forEach(visit)
+        break
+      case 'loop':
+        check(node.array)
+        check(node.key)
+        node.children.forEach(visit)
+        break
+      case 'text':
+      case 'slot':
+        break
+    }
+  }
+  nodes.forEach(visit)
+  return misused
+}
+
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}


### PR DESCRIPTION
**Stacked on #1813** (base = `claude/expected-diagnostics-audit`).

## Increment: `style-object-dynamic` / `style-3-signals` — ✅ Go + Mojolicious + Xslate

A JSX `style={{ backgroundColor: color, padding: '8px' }}` object literal was pinned to **BF101** on all three SSR adapters — a bare object literal in attribute position had no template form. It now lowers to a CSS string.

New shared **`parseStyleObjectEntries`** (`@barefootjs/jsx`):
- parses the object literal (wrapped in parens to force expression context, since a bare `{…}` parses as a block statement),
- kebab-cases each key (`backgroundColor` → `background-color`, `WebkitTransform` → `-webkit-transform`),
- classifies each value as a static string literal or a JS expression.

Each adapter assembles the CSS string, interpolating dynamic values in its own syntax:
- **Go**: `background-color:{{.Color}};padding:8px`
- **Mojo**: `background-color:<%= $color %>;padding:8px`
- **Xslate**: `background-color:<: $color :>;padding:8px`

Each value expression is pre-checked with `isSupported`, so an unsupported value — or an unsupported object shape (spread / shorthand / computed key) — keeps the existing BF101 refusal rather than emitting partial output. Dropped the two `style-*` entries from all three adapters' `expectedDiagnostics`.

## Test status
- Adapters (real Go 1.25.6 / Mojolicious 9.35 / Text::Xslate v3.5.9): **1301 pass / 27 skip / 0 fail**
- jsx: new `parseStyleObjectEntries` unit tests pass (the only jsx failures are the 4 pre-existing resolver-migration alias tests, present on base)
- `tsc` clean on all four packages

Hono reference snapshots unchanged.

https://claude.ai/code/session_01LaP8KV6yASUT37PzDMvYbW

---
_Generated by [Claude Code](https://claude.ai/code/session_01LaP8KV6yASUT37PzDMvYbW)_