### PR TITLE
fix(release): install Perl backends' declared prereqs so CPAN backends publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,8 @@ jobs:
           perl-version: '5.40'
 
       - name: Install Perl build tools
+        # Workflow tooling only; each dist's prereqs come from its cpanfile
+        # via `cpanm --installdeps` below.
         run: cpanm --notest Module::CPANfile CPAN::Uploader
 
       - name: Publish to CPAN
@@ -128,7 +130,13 @@ jobs:
           if echo "$published" | grep -qx '@barefootjs/perl'; then
             echo "Publishing packages/adapter-perl to CPAN..."
             cd packages/adapter-perl
-            perl Makefile.PL && make test && make dist
+            # installdeps from the cpanfile; keep these on separate lines (not
+            # `&&`) so a failure aborts under `set -e` rather than silently
+            # skipping the upload.
+            cpanm --notest --installdeps .
+            perl Makefile.PL
+            make test
+            make dist
             cpan-upload -u "$PAUSE_ID" -p "$PAUSE_PASSWORD" ./*.tar.gz
             cpanm --notest ./*.tar.gz
             cd -
@@ -141,7 +149,11 @@ jobs:
             echo "$published" | grep -qx "$name" || continue
             echo "Publishing $dir to CPAN..."
             cd "$dir"
-            perl Makefile.PL && make test && make dist
+            # `requires 'BarefootJS'` resolves against the core dist installed above.
+            cpanm --notest --installdeps .
+            perl Makefile.PL
+            make test
+            make dist
             cpan-upload -u "$PAUSE_ID" -p "$PAUSE_PASSWORD" ./*.tar.gz
             cd -
           done


### PR DESCRIPTION
## Problem

The CPAN side of the release publishes the **core** `BarefootJS` dist fine, but the two **backends** (`BarefootJS-Backend-Xslate`, `Mojolicious-Plugin-BarefootJS`) silently never publish — while the `cpan-release` job stays green.

From the latest release run's "Publish to CPAN" step:
```
Publishing packages/adapter-perl to CPAN...      → PAUSE add message sent ok [200]   ✅
Publishing packages/adapter-mojolicious to CPAN...
  Can't locate Test/Mojo.pm / Mojo/File.pm → make test Error 2 → skipping non-file ./*.tar.gz   ❌
Publishing packages/adapter-xslate to CPAN...
  Can't locate Text/Xslate.pm → make test Error 2 → skipping non-file ./*.tar.gz   ❌
```

### Two compounding bugs

1. **Declared prereqs were never installed.** The job ran `perl Makefile.PL && make test` directly. The `Makefile.PL` files are *correct* — they read each `cpanfile` via `Module::CPANfile` and declare `PREREQ_PM` / `TEST_REQUIRES` (so `Text::Xslate`, `Mojolicious`, `Test::Mojo`, `Test2::V0` are all declared) — but `make test` doesn't auto-install prereqs; that's the installer's job. The workflow never invoked one for the dist deps, so the backends' tests failed to compile.

2. **Silent-failure masking.** `perl Makefile.PL && make test && make dist` hid it: under `bash -e`, a non-final term of an `&&` list is exempt from `set -e`, so the failing `make test` was ignored, `make dist` was skipped, and `cpan-upload` no-op'd on the missing tarball (`skipping non-file ./*.tar.gz`) — leaving the job green.

## Fix

- Install each dist's **declared** prereqs with `cpanm --installdeps .` before building. Single source of truth = the `cpanfile`; no hardcoded dep list in the workflow to drift out of sync (the drift is what caused this). The backends' `requires 'BarefootJS'` resolves against the core dist that's built+installed first.
- Split `perl Makefile.PL && make test && make dist` into separate statements so any `installdeps`/build/test failure **aborts the job** instead of silently skipping the upload.

> Note (vs. an earlier revision of this PR): I first hardcoded `Text::Xslate Mojolicious Test2::Suite` in the install step, but that just re-duplicates the cpanfiles and can drift again. Per review feedback, switched to `cpanm --installdeps .` which reads the declared metadata.

## Validation (local, perl 5.38, fresh lib)

Reproduced the failure, then proved the new flow from scratch — with only `Module::CPANfile` + `CPAN::Uploader` preinstalled:

| Dist | `cpanm --installdeps .` | `make test` | `make dist` |
|---|---|---|---|
| `BarefootJS` (core) | Test2::V0 | ✅ 43 tests | ✅ tarball |
| `BarefootJS-Backend-Xslate` | Text::Xslate (+XS deps), BarefootJS✓ | ✅ 7 tests | ✅ tarball |
| `Mojolicious-Plugin-BarefootJS` | Mojolicious / Test::Mojo, BarefootJS✓ | ✅ 11 tests | ✅ tarball |

No changeset needed (CI workflow change, not published package source). The actual CPAN upload only runs on a real release with the `PAUSE_*` secrets, so final confirmation is the next release — but the build/test path that was failing is now proven to pass.

https://claude.ai/code/session_01SaiuzNsuALVnbHfgafzwob