### PR TITLE
feat(create-barefootjs): install Mojo deps from CPAN + add Text::Xslate scaffold

### DIFF
--- a/.changeset/xslate-scaffold-mojo-cpan.md
+++ b/.changeset/xslate-scaffold-mojo-cpan.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/cli": minor
+---
+
+create-barefootjs: install the Mojolicious scaffold's BarefootJS deps from CPAN (declared in `cpanfile` via `Mojolicious::Plugin::BarefootJS` + `BarefootJS`) instead of vendoring `.pm` copies under `lib/`, and add a new `xslate` adapter (`--adapter xslate`) that scaffolds a plain Plack/PSGI app rendering Kolon `.tx` templates through `BarefootJS::Backend::Xslate`.

--- a/docs/core/adapters/perl-adapter.md
+++ b/docs/core/adapters/perl-adapter.md
@@ -101,6 +101,12 @@ The generated `.html.ep` templates call the runtime through the `bf` helper
 npm install @barefootjs/xslate
 ```
 
+Scaffold a runnable starter (a plain Plack/PSGI app served by Starman):
+
+```
+npm create barefootjs@latest -- --adapter xslate
+```
+
 ```typescript
 import { createConfig } from '@barefootjs/xslate/build'
 

--- a/packages/adapter-mojolicious/src/__tests__/scaffold.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/scaffold.test.ts
@@ -10,8 +10,8 @@
 //     (Mojolicious's built-in dispatcher does not honour URL prefixes,
 //     so the explicit routes are load-bearing — without them every
 //     stylesheet and client bundle 404s in the browser).
-//   - `lib/BarefootJS.pm` is vendored, `cpanfile` lists Mojolicious,
-//     and `app.pl` uses `register_components_from_manifest` so the
+//   - the `cpanfile` declares the BarefootJS Perl deps + Mojolicious
+//     (installed from CPAN, not vendored under `lib/`), and the plugin's
 //     manifest-driven child rendering works without per-component wire-up.
 //
 //   BAREFOOT_CREATE_INTEGRATION=1 bun test src/__tests__/scaffold.test.ts
@@ -143,24 +143,24 @@ describe.skipIf(!INTEGRATION)(
     // -------------------------------------------------------------------------
 
     describe('mojo wiring', () => {
-      test('lib/BarefootJS.pm is vendored', () => {
-        expect(existsSync(path.join(projectDir, 'lib', 'BarefootJS.pm'))).toBe(true)
+      test('does not vendor BarefootJS .pm copies under lib/', () => {
+        // The Perl modules ship on CPAN now, so the scaffold pulls them
+        // via `cpanm --installdeps .` instead of vendoring copies. A
+        // stray lib/ would shadow the installed dist (app.pl no longer
+        // adds it to @INC anyway).
+        expect(existsSync(path.join(projectDir, 'lib', 'BarefootJS.pm'))).toBe(false)
       })
 
-      test('lib/Mojolicious/Plugin/BarefootJS/DevReload.pm is vendored', () => {
-        // The dev-reload plugin lives under a nested namespace so
-        // `plugin 'BarefootJS::DevReload'` resolves to its file. A
-        // missing vendor copy would crash app.pl at boot.
-        expect(
-          existsSync(
-            path.join(projectDir, 'lib', 'Mojolicious', 'Plugin', 'BarefootJS', 'DevReload.pm'),
-          ),
-        ).toBe(true)
-      })
-
-      test('cpanfile lists Mojolicious', () => {
+      test('cpanfile declares the BarefootJS Perl deps + Mojolicious', () => {
+        // `Mojolicious::Plugin::BarefootJS` (the plugin + dev-reload
+        // plugin + BarefootJS::Backend::Mojo) and `BarefootJS` (core)
+        // are declared so `cpanm --installdeps .` installs everything
+        // `plugin 'BarefootJS'` / `plugin 'BarefootJS::DevReload'` need
+        // at boot.
         const cp = readFileSync(path.join(projectDir, 'cpanfile'), 'utf-8')
-        expect(cp).toMatch(/Mojolicious/)
+        expect(cp).toMatch(/^requires 'BarefootJS'/m)
+        expect(cp).toMatch(/^requires 'Mojolicious::Plugin::BarefootJS'/m)
+        expect(cp).toMatch(/^requires 'Mojolicious'/m)
       })
 
       test('plugin auto-loads manifest — no per-route register_components_from_manifest call', () => {

--- a/packages/cli/scripts/embed-runtimes.mjs
+++ b/packages/cli/scripts/embed-runtimes.mjs
@@ -21,18 +21,16 @@ const repoRoot = resolve(cliPkg, '../..')
 
 // We deliberately don't embed the upstream `go.mod` files — the
 // scaffold rewrites them to relax the Go version pin. Adapter source
-// files (Go / Perl) are embedded as-is.
+// files (Go) are embedded as-is.
+//
+// The Perl adapters (Mojolicious / Text::Xslate) are NOT embedded: their
+// runtime modules ship on CPAN (BarefootJS, Mojolicious::Plugin::BarefootJS,
+// BarefootJS::Backend::Xslate), so those scaffolds declare CPAN
+// dependencies in a `cpanfile` instead of vendoring `.pm` copies.
 const sources = {
   bfGoSource: 'packages/adapter-go-template/runtime/bf.go',
   streamingGoSource: 'packages/adapter-go-template/runtime/streaming.go',
   bfdevGoSource: 'packages/adapter-go-template/runtime/bfdev/bfdev.go',
-  // The engine-agnostic core runtime now lives in @barefootjs/perl; the
-  // Mojo-specific backend + plugin stay in @barefootjs/mojolicious.
-  barefootPmSource: 'packages/adapter-perl/lib/BarefootJS.pm',
-  barefootBackendMojoPmSource: 'packages/adapter-mojolicious/lib/BarefootJS/Backend/Mojo.pm',
-  barefootPluginPmSource: 'packages/adapter-mojolicious/lib/Mojolicious/Plugin/BarefootJS.pm',
-  barefootDevReloadPmSource:
-    'packages/adapter-mojolicious/lib/Mojolicious/Plugin/BarefootJS/DevReload.pm',
 }
 
 // Pre-flight: surface a clear error when a source file is missing

--- a/packages/cli/src/__tests__/templates.test.ts
+++ b/packages/cli/src/__tests__/templates.test.ts
@@ -10,7 +10,7 @@ describe('adapter registry', () => {
     expect(DEFAULT_ADAPTER).toBe('hono')
   })
 
-  test.each(['hono', 'hono-node', 'echo', 'gin', 'chi', 'nethttp', 'mojo', 'csr'])(
+  test.each(['hono', 'hono-node', 'echo', 'gin', 'chi', 'nethttp', 'mojo', 'xslate', 'csr'])(
     '%s adapter is registered',
     id => {
       expect(ADAPTERS[id]).toBeDefined()
@@ -243,6 +243,12 @@ describe('adapter registry', () => {
         /href="\/static\/styles\.css"/,
         /href="\/static\/uno\.css"/,
       ]],
+      // xslate embeds the layout inline in app.psgi (a Perl heredoc).
+      ['xslate', 'app.psgi', [
+        /href="\/static\/tokens\.css"/,
+        /href="\/static\/styles\.css"/,
+        /href="\/static\/uno\.css"/,
+      ]],
       ['csr', 'pages/index.html', [
         /href="\/static\/tokens\.css"/,
         /href="\/static\/styles\.css"/,
@@ -283,14 +289,45 @@ describe('adapter registry', () => {
     expect(echo.files['go.mod']).toMatch(/replace github\.com\/barefootjs\/runtime\/bf => \.\/bf-runtime/)
   })
 
-  test('mojo bundles the vendored Perl plugin', () => {
+  test('mojo declares its BarefootJS Perl deps via cpanfile (not vendored lib/)', () => {
     const mojo = ADAPTERS.mojo
-    expect(mojo.files['lib/BarefootJS.pm']).toMatch(/^package BarefootJS;/m)
-    // The Mojo rendering backend the runtime lazily requires must be bundled
-    // too, otherwise `BarefootJS->new($c)` dies at request time.
-    expect(mojo.files['lib/BarefootJS/Backend/Mojo.pm']).toMatch(/^package BarefootJS::Backend::Mojo;/m)
-    expect(mojo.files['lib/Mojolicious/Plugin/BarefootJS.pm']).toMatch(/^package Mojolicious::Plugin::BarefootJS;/m)
-    expect(mojo.files['cpanfile']).toMatch(/^requires 'Mojolicious'/m)
+    // The Perl modules ship on CPAN now, so the scaffold pulls them via
+    // `cpanm --installdeps .` rather than vendoring `.pm` copies under lib/.
+    // `Mojolicious::Plugin::BarefootJS` ships the plugin, the dev-reload
+    // plugin, and `BarefootJS::Backend::Mojo`; `BarefootJS` is the core
+    // runtime. Both are declared explicitly alongside Mojolicious.
+    const cpanfile = mojo.files['cpanfile']
+    expect(cpanfile).toMatch(/^requires 'BarefootJS'/m)
+    expect(cpanfile).toMatch(/^requires 'Mojolicious::Plugin::BarefootJS'/m)
+    expect(cpanfile).toMatch(/^requires 'Mojolicious'/m)
+    // Nothing vendored: the scaffold ships no .pm files, and app.pl no
+    // longer prepends a local lib/ dir to @INC.
+    const vendored = Object.keys(mojo.files).filter(f => f.endsWith('.pm'))
+    expect(vendored).toEqual([])
+    expect(mojo.files['app.pl']).not.toContain("use lib 'lib'")
+  })
+
+  test('xslate scaffolds a Plack/PSGI app rendering via Text::Xslate', () => {
+    const xslate = ADAPTERS.xslate
+    // Plain Plack/PSGI entry — no web framework. Renders the runtime via
+    // BarefootJS::Backend::Xslate.
+    expect(xslate.files['app.psgi']).toMatch(/use Plack::Builder/)
+    expect(xslate.files['app.psgi']).toContain('BarefootJS::Backend::Xslate')
+    // Dev-reload SSE endpoint, gated to dev, with the snippet in <body>.
+    expect(xslate.files['app.psgi']).toContain('/_bf/reload')
+    expect(xslate.files['app.psgi']).toContain('BarefootJS::DevReload->snippet')
+    // CPAN deps declared (not vendored): the Xslate backend, Text::Xslate,
+    // and Plack/Starman for serving.
+    const cpanfile = xslate.files['cpanfile']
+    expect(cpanfile).toMatch(/^requires 'BarefootJS::Backend::Xslate'/m)
+    expect(cpanfile).toMatch(/^requires 'Text::Xslate'/m)
+    expect(cpanfile).toMatch(/^requires 'Starman'/m)
+    expect(Object.keys(xslate.files).filter(f => f.endsWith('.pm'))).toEqual([])
+    // Config targets the xslate build factory.
+    expect(xslate.files['barefoot.config.ts']).toContain("from '@barefootjs/xslate/build'")
+    // Starter Counter is self-contained (native buttons, no registry fetch).
+    expect(xslate.bundledRegistryComponents).toEqual([])
+    expect(xslate.files['components/Counter.tsx']).toContain('<button')
   })
 
   test('csr scaffolds a static HTML page + node:http server (no Bun runtime)', () => {
@@ -400,7 +437,7 @@ describe('adapter registry', () => {
   // for the Hono target; the contract extends to every adapter
   // since each one carries its own outDir + dev-state directories.
   // See onboarding round 5 / PR #1450.
-  test.each(['hono', 'hono-node', 'csr', 'mojo', 'echo'])(
+  test.each(['hono', 'hono-node', 'csr', 'mojo', 'xslate', 'echo'])(
     '%s adapter ships a .gitignore that covers the shared base',
     (id) => {
       const gitignore = ADAPTERS[id].files['.gitignore']
@@ -431,7 +468,7 @@ describe('adapter registry', () => {
     expect(gitignore).not.toMatch(/^public\/?\s*$/m)
   })
 
-  test.each(['hono-node', 'csr', 'mojo', 'echo'])(
+  test.each(['hono-node', 'csr', 'mojo', 'xslate', 'echo'])(
     '%s adapter .gitignore ignores `dist/` as the build output root',
     (id) => {
       expect(ADAPTERS[id].files['.gitignore']!).toMatch(/^dist\/?\s*$/m)

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -81,35 +81,44 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
   const cssLibrary = CSS_LIBRARIES[cssId]
 
   // Pre-flight: confirm the UI registry is reachable BEFORE writing
-  // anything to disk. The runnable starter requires the registry's
-  // Button component, and a vanilla fallback would force the user
-  // through a painful migration to UnoCSS + barefootjs UI later.
-  // Better to fail fast and have them retry online with no partial
-  // state to clean up.
-  // Surface the host the scaffold is reaching out to so the spinner
-  // reads like a concrete action ("Fetching starter components from
-  // ui.barefootjs.dev...") rather than a vague "checking a registry".
-  const registryHost = new URL(DEFAULT_REGISTRY_URL).host
-  const probeSpinner = startSpinner({
-    text: `Fetching starter components from ${registryHost}...`,
-  })
-  try {
-    await probeRegistry(DEFAULT_REGISTRY_URL)
-    probeSpinner.stop()
-  } catch (err) {
-    probeSpinner.fail(`Cannot reach ${registryHost} (BarefootJS UI registry)`)
-    const msg = err instanceof Error ? err.message : String(err)
-    console.error(`  ${msg}`)
-    console.error(``)
-    console.error(`Project init pulls the starter's Button component from`)
-    console.error(`${DEFAULT_REGISTRY_URL} (which the renderer wires through UnoCSS).`)
-    console.error(``)
-    console.error(`Things to try:`)
-    console.error(`  1. Open ${DEFAULT_REGISTRY_URL}button.json in a browser to`)
-    console.error(`     confirm ${registryHost} is reachable from this network.`)
-    console.error(`  2. If you're behind a corporate proxy, set HTTPS_PROXY.`)
-    console.error(`  3. Re-run the create-barefootjs command once you're connected.`)
-    process.exit(1)
+  // anything to disk. The runnable starter pulls the registry's Button
+  // component, and a vanilla fallback would force the user through a
+  // painful migration to UnoCSS + barefootjs UI later. Better to fail
+  // fast and have them retry online with no partial state to clean up.
+  //
+  // Skip the probe entirely for adapters that bundle no registry
+  // components (`bundledRegistryComponents: []`, e.g. the xslate
+  // scaffold ships a self-contained Counter): there's nothing to fetch,
+  // so reaching out — and failing offline with a Button-specific error —
+  // would be both pointless and misleading. Mirror scaffoldApp's
+  // `?? ['button']` default so the two stay in lockstep.
+  const bundledComponents = adapter.bundledRegistryComponents ?? ['button']
+  if (bundledComponents.length > 0) {
+    // Surface the host the scaffold is reaching out to so the spinner
+    // reads like a concrete action ("Fetching starter components from
+    // ui.barefootjs.dev...") rather than a vague "checking a registry".
+    const registryHost = new URL(DEFAULT_REGISTRY_URL).host
+    const probeSpinner = startSpinner({
+      text: `Fetching starter components from ${registryHost}...`,
+    })
+    try {
+      await probeRegistry(DEFAULT_REGISTRY_URL)
+      probeSpinner.stop()
+    } catch (err) {
+      probeSpinner.fail(`Cannot reach ${registryHost} (BarefootJS UI registry)`)
+      const msg = err instanceof Error ? err.message : String(err)
+      console.error(`  ${msg}`)
+      console.error(``)
+      console.error(`Project init pulls the starter's Button component from`)
+      console.error(`${DEFAULT_REGISTRY_URL} (which the renderer wires through UnoCSS).`)
+      console.error(``)
+      console.error(`Things to try:`)
+      console.error(`  1. Open ${DEFAULT_REGISTRY_URL}button.json in a browser to`)
+      console.error(`     confirm ${registryHost} is reachable from this network.`)
+      console.error(`  2. If you're behind a corporate proxy, set HTTPS_PROXY.`)
+      console.error(`  3. Re-run the create-barefootjs command once you're connected.`)
+      process.exit(1)
+    }
   }
 
   const warnings = adapter.prereqWarnings()

--- a/packages/cli/src/lib/adapters/mojo.ts
+++ b/packages/cli/src/lib/adapters/mojo.ts
@@ -1,9 +1,11 @@
 // Mojolicious (Perl) adapter starter.
 //
-// Scaffolds a Mojolicious::Lite app with the BarefootJS Perl plugin
-// vendored under `./lib`. The plugin sources are inlined into the CLI
-// bundle by `scripts/embed-runtimes.mjs` so the scaffold runs without
-// depending on a CPAN release of the plugin.
+// Scaffolds a Mojolicious::Lite app that pulls the BarefootJS Perl
+// runtime + Mojolicious integration from CPAN (declared in `cpanfile`,
+// installed via `cpanm --installdeps .`). The `Mojolicious::Plugin::BarefootJS`
+// distribution ships the plugin, the dev-reload plugin, and the
+// `BarefootJS::Backend::Mojo` rendering backend; `BarefootJS` ships the
+// engine-agnostic core runtime — so nothing is vendored into the project.
 
 import { execSync } from 'node:child_process'
 import type { AdapterTemplate } from '../templates'
@@ -18,12 +20,6 @@ import {
   UNO_CSS_PLACEHOLDER,
   unoConfigTs,
 } from './shared'
-import {
-  barefootBackendMojoPmSource,
-  barefootDevReloadPmSource,
-  barefootPluginPmSource,
-  barefootPmSource,
-} from './runtimes.generated'
 
 const MOJO_BAREFOOT_CONFIG_TS = `import { createConfig } from '@barefootjs/mojolicious/build'
 
@@ -44,10 +40,9 @@ export default createConfig({
 
 const MOJO_APP_PL = `#!/usr/bin/env perl
 use Mojolicious::Lite -signatures;
-use lib 'lib';
 
-# Load the BarefootJS plugin (vendored under ./lib so the app runs
-# without a CPAN release of the plugin yet).
+# Load the BarefootJS plugin (installed from CPAN — see cpanfile).
+# Provides the \`bf\` helper + manifest-driven child rendering.
 plugin 'BarefootJS';
 
 # Dev-only browser auto-reload over SSE. The plugin polls
@@ -116,8 +111,18 @@ __DATA__
 </html>
 `
 
+// The BarefootJS Perl modules are published to CPAN, so the scaffold
+// declares them as ordinary dependencies rather than vendoring copies
+// under ./lib. `Mojolicious::Plugin::BarefootJS` ships the plugin, the
+// dev-reload plugin, and `BarefootJS::Backend::Mojo`; it pulls in
+// `BarefootJS` (the engine-agnostic core) and `Mojolicious`
+// transitively. Both are listed explicitly so `cpanm --installdeps .`
+// resolves a known-good set even if a transitive pin drifts.
 const MOJO_CPANFILE = `# Required Perl deps. Install with: cpanm --installdeps .
-requires 'Mojolicious', '>= 9.34';
+requires 'perl', '5.020';
+requires 'BarefootJS', '0.9.6';
+requires 'Mojolicious::Plugin::BarefootJS', '0.9.6';
+requires 'Mojolicious', '9.0';
 `
 
 const MOJO_TSCONFIG = `{
@@ -139,7 +144,7 @@ const MOJO_TSCONFIG = `{
     }
   },
   "include": ["**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules", "dist", "lib"]
+  "exclude": ["node_modules", "dist"]
 }
 `
 
@@ -164,10 +169,6 @@ export const MOJO_ADAPTER: AdapterTemplate = {
   files: {
     'app.pl': MOJO_APP_PL,
     'cpanfile': MOJO_CPANFILE,
-    'lib/BarefootJS.pm': barefootPmSource,
-    'lib/BarefootJS/Backend/Mojo.pm': barefootBackendMojoPmSource,
-    'lib/Mojolicious/Plugin/BarefootJS.pm': barefootPluginPmSource,
-    'lib/Mojolicious/Plugin/BarefootJS/DevReload.pm': barefootDevReloadPmSource,
     'barefoot.config.ts': MOJO_BAREFOOT_CONFIG_TS,
     'tsconfig.json': MOJO_TSCONFIG,
     'uno.config.ts': unoConfigTs([

--- a/packages/cli/src/lib/adapters/xslate.ts
+++ b/packages/cli/src/lib/adapters/xslate.ts
@@ -370,6 +370,16 @@ function perlPrereqs(): string[] {
     )
   }
   try {
+    // The dev/start scripts invoke `plackup` (shipped with Plack) to run
+    // the PSGI app, so a missing Plack surfaces as a bare "command not
+    // found" rather than a module error — check it explicitly.
+    execSync('perl -MPlack -e1', { stdio: 'ignore' })
+  } catch {
+    warnings.push(
+      'Plack not installed (provides `plackup`). Run `cpanm --installdeps .` before starting the dev server.',
+    )
+  }
+  try {
     execSync('perl -MStarman -e1', { stdio: 'ignore' })
   } catch {
     warnings.push(

--- a/packages/cli/src/lib/adapters/xslate.ts
+++ b/packages/cli/src/lib/adapters/xslate.ts
@@ -1,0 +1,380 @@
+// Text::Xslate (Perl) adapter starter.
+//
+// Scaffolds a plain Plack/PSGI app that renders BarefootJS marked
+// templates with Text::Xslate (Kolon syntax) — no web framework
+// required. The runtime modules come from CPAN (declared in `cpanfile`,
+// installed via `cpanm --installdeps .`): `BarefootJS::Backend::Xslate`
+// supplies the Xslate rendering backend and pulls in `BarefootJS` (the
+// engine-agnostic core + dev-reload runtime) and `Text::Xslate`. The app
+// is served under Starman, whose prefork model lets the dev-reload SSE
+// endpoint stream without blocking the whole server.
+
+import { execSync } from 'node:child_process'
+import type { AdapterTemplate } from '../templates'
+import {
+  buildGitignore,
+  COMPONENTS_MANIFEST_SEED,
+  STYLES_CSS,
+  TOKENS_CSS,
+  UNOCSS_DEV_DEPENDENCIES,
+  UNO_CSS_PLACEHOLDER,
+  unoConfigTs,
+} from './shared'
+
+const XSLATE_BAREFOOT_CONFIG_TS = `import { createConfig } from '@barefootjs/xslate/build'
+
+export default createConfig({
+  paths: {
+    components: 'components/ui',
+    tokens: 'tokens',
+    meta: 'meta',
+  },
+  components: ['components'],
+  outDir: 'dist',
+  adapterOptions: {
+    clientJsBasePath: '/static/components/',
+    barefootJsPath: '/static/components/barefoot.js',
+  },
+})
+`
+
+// Plain Plack/PSGI app. The Text::Xslate backend has no framework
+// dependency, so the whole server is a single PSGI coderef plus a
+// Plack::Builder mount table for static assets + the dev-reload SSE
+// endpoint. `bf build` writes Kolon `.tx` templates to dist/templates
+// and the client bundles to dist/client; the handwritten stylesheets
+// live under public/.
+const XSLATE_APP_PSGI = `#!/usr/bin/env perl
+use strict;
+use warnings;
+use utf8;
+use feature 'signatures';
+no warnings 'experimental::signatures';
+
+# All three modules ship on CPAN (see cpanfile). BarefootJS::Backend::Xslate
+# pulls in BarefootJS (the engine-agnostic core + dev-reload runtime) and
+# Text::Xslate.
+use Plack::Builder;
+use Plack::Request;
+use Plack::App::File;
+use Encode ();
+use JSON::PP ();
+
+use BarefootJS;
+use BarefootJS::Backend::Xslate;
+use BarefootJS::DevReload;
+
+my $DEV = ($ENV{PLACK_ENV} // 'development') ne 'production';
+
+# Canonical JSON keeps SSR output deterministic (matching the runtime's
+# sorted-key policy) and round-trips utf8 cleanly.
+my $J = JSON::PP->new->canonical->allow_nonref->utf8;
+
+# One Text::Xslate backend renders every component from dist/templates.
+# In dev the template cache is disabled so \`bf build --watch\` edits render
+# on the next request without restarting the server.
+my $backend = BarefootJS::Backend::Xslate->new(
+    path           => ['dist/templates'],
+    json_encoder   => sub ($data) { $J->encode($data) },
+    xslate_options => { cache => $DEV ? 0 : 1 },
+);
+
+sub rand_suffix () { return substr(sprintf('%f', rand()) =~ s/^0\\.//r, 0, 6) }
+
+# Render a top-level component template and wrap it in the page layout.
+sub render_component ($component, %stash) {
+    my $bf = BarefootJS->new(undef, { backend => $backend });
+    $bf->_scope_id($component . '_' . rand_suffix());
+    my $body = $backend->render_named($component, $bf, \\%stash);
+    return layout(body => $body, scripts => $bf->scripts);
+}
+
+sub layout (%a) {
+    # Dev-only SSE reload subscriber. Self-suppressed in production (the
+    # \`/_bf/reload\` mount below is gated too).
+    my $dev_snippet = $DEV ? BarefootJS::DevReload->snippet('/_bf/reload') : '';
+    return <<"HTML";
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>BarefootJS app</title>
+    <!-- Link all three sheets so the browser fetches them in parallel.
+         tokens first so its CSS variables exist before any rule uses them. -->
+    <link rel="stylesheet" href="/static/tokens.css">
+    <link rel="stylesheet" href="/static/styles.css">
+    <link rel="stylesheet" href="/static/uno.css">
+</head>
+<body>
+    <main>$a{body}</main>
+    $a{scripts}
+    $dev_snippet
+</body>
+</html>
+HTML
+}
+
+my $app = sub ($env) {
+    my $req  = Plack::Request->new($env);
+    my $path = $req->path_info;
+    if ($req->method eq 'GET' && ($path eq '/' || $path eq '')) {
+        my $html = Encode::encode_utf8(render_component('Counter'));
+        return [200, ['Content-Type' => 'text/html; charset=utf-8'], [$html]];
+    }
+    return [404, ['Content-Type' => 'text/plain'], ['Not Found']];
+};
+
+# Mount table. Plack::App::URLMap matches the longest path prefix, so the
+# nested /static/components mount wins over /static for client bundles.
+#   - /static/components/* -> dist/client/*  (clientJsBasePath)
+#   - /static/*            -> public/*        (handwritten stylesheets)
+builder {
+    enable 'Plack::Middleware::ContentLength';
+
+    mount '/static/components' => Plack::App::File->new(root => 'dist/client')->to_app;
+    mount '/static'            => Plack::App::File->new(root => 'public')->to_app;
+
+    if ($DEV) {
+        mount '/_bf/reload' => BarefootJS::DevReload->to_app(dist_dir => 'dist');
+    }
+
+    mount '/' => $app;
+};
+`
+
+// The BarefootJS Perl modules are published to CPAN, so the scaffold
+// declares them as ordinary dependencies. `BarefootJS::Backend::Xslate`
+// ships the Xslate rendering backend and pulls in `BarefootJS` (the
+// engine-agnostic core + dev-reload runtime) and `Text::Xslate`
+// transitively; all are listed explicitly so `cpanm --installdeps .`
+// resolves a known-good set. Plack provides the PSGI plumbing; Starman's
+// prefork model is what lets the dev-reload SSE endpoint stream without
+// blocking the whole server.
+const XSLATE_CPANFILE = `# Required Perl deps. Install with: cpanm --installdeps .
+requires 'perl', '5.020';
+requires 'BarefootJS', '0.9.6';
+requires 'BarefootJS::Backend::Xslate', '0.9.6';
+requires 'Text::Xslate', '3.4.0';
+requires 'Plack';
+requires 'Starman';
+`
+
+const XSLATE_TSCONFIG = `{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "jsxImportSource": "@barefootjs/jsx",
+    "types": ["node"{{__PM_TYPES_ENTRY__}}],
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": ["./components/*"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules", "dist"]
+}
+`
+
+// Self-contained starter Counter. Unlike the Hono / Mojo / CSR scaffolds
+// it does NOT use the registry <Button>: the engine-agnostic
+// `register_components_from_manifest` strips the Mojo `.html.ep` template
+// suffix, not Xslate's `.tx`, so manifest-driven child rendering isn't on
+// the Xslate path yet. A native-button Counter keeps the starter
+// runnable end-to-end without that wiring (see `bundledRegistryComponents: []`).
+const XSLATE_COUNTER_TSX = `'use client'
+
+import { createSignal, createMemo } from '@barefootjs/client'
+
+interface CounterProps {
+  initial?: number
+}
+
+export function Counter(props: CounterProps) {
+  const [count, setCount] = createSignal(props.initial ?? 0)
+  const doubled = createMemo(() => count() * 2)
+
+  return (
+    <div className="counter">
+      <p className="counter-value">count: {count()}</p>
+      <p className="counter-doubled">doubled: {doubled()}</p>
+      <div className="counter-buttons">
+        <button
+          className="px-4 py-2 rounded-md bg-primary text-primary-foreground"
+          onClick={() => setCount((n) => n + 1)}
+        >
+          +1
+        </button>
+        <button
+          className="px-4 py-2 rounded-md bg-secondary text-secondary-foreground"
+          onClick={() => setCount((n) => n - 1)}
+        >
+          -1
+        </button>
+        <button
+          className="px-4 py-2 rounded-md bg-muted text-muted-foreground"
+          onClick={() => setCount(0)}
+        >
+          Reset
+        </button>
+      </div>
+    </div>
+  )
+}
+`
+
+// IR test paired with XSLATE_COUNTER_TSX. Mirrors the cross-adapter
+// starter test, minus the registry-<Button> child assertion (the Xslate
+// starter uses native <button> elements). `{{__TEST_RUNNER_IMPORT__}}`
+// is filled by init.ts with the detected PM's runner.
+const XSLATE_COUNTER_TEST_TSX = `import { describe, test, expect } from '{{__TEST_RUNNER_IMPORT__}}'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { renderToTest } from '@barefootjs/test'
+
+const CounterSource = readFileSync(resolve(__dirname, 'Counter.tsx'), 'utf-8')
+
+describe('Counter', () => {
+  const result = renderToTest(CounterSource, 'Counter.tsx')
+
+  test('has no compiler errors', () => {
+    expect(result.errors).toEqual([])
+  })
+
+  test('componentName is Counter', () => {
+    expect(result.componentName).toBe('Counter')
+  })
+
+  test('has expected signals', () => {
+    expect(result.signals).toContain('count')
+  })
+
+  test('renders as <div>', () => {
+    expect(result.root.tag).toBe('div')
+  })
+
+  test('has event handlers', () => {
+    const all = result.findAll({})
+    expect(
+      all.some((n) => n.events.includes('click') || n.props['onClick'] != null),
+    ).toBe(true)
+  })
+
+  test('renders native <button> controls', () => {
+    const all = result.findAll({})
+    expect(all.some((n) => n.tag === 'button')).toBe(true)
+  })
+
+  test('toStructure() shows expected tree', () => {
+    const structure = result.toStructure()
+    expect(structure.length).toBeGreaterThan(0)
+    expect(structure).toContain('div')
+  })
+})
+`
+
+// Xslate scaffold: `dist/` is the bf build output. `local/` is where
+// `carton install` (cpanfile-driven) drops vendored CPAN modules; `log/`
+// + `*.tmp` cover dev-server scratch.
+const XSLATE_GITIGNORE = buildGitignore([
+  {
+    heading: 'bf build outputs (regenerated by `bf build` / `bf build --watch`)',
+    entries: ['dist/'],
+  },
+  {
+    heading: 'Perl dependencies + runtime scratch',
+    entries: ['local/', 'log/', '*.tmp'],
+  },
+])
+
+const XSLATE_PORT = 3003
+
+export const XSLATE_ADAPTER: AdapterTemplate = {
+  label: 'Text::Xslate (Perl, Plack/PSGI SSR)',
+  port: XSLATE_PORT,
+  files: {
+    'app.psgi': XSLATE_APP_PSGI,
+    'cpanfile': XSLATE_CPANFILE,
+    'barefoot.config.ts': XSLATE_BAREFOOT_CONFIG_TS,
+    'tsconfig.json': XSLATE_TSCONFIG,
+    'uno.config.ts': unoConfigTs([
+      'components/**/*.tsx',
+      'dist/components/**/*.tsx',
+    ]),
+    'components/Counter.tsx': XSLATE_COUNTER_TSX,
+    'components/Counter.test.tsx': XSLATE_COUNTER_TEST_TSX,
+    'public/styles.css': STYLES_CSS,
+    'public/tokens.css': TOKENS_CSS,
+    'public/uno.css': UNO_CSS_PLACEHOLDER,
+    'dist/components/manifest.json': COMPONENTS_MANIFEST_SEED,
+    '.gitignore': XSLATE_GITIGNORE,
+  },
+  scripts: {
+    // Watchers + Starman side-by-side. The build/uno watchers do their own
+    // initial build at startup, so no separate cold-build prefix is needed.
+    // Starman (not plackup's default single-process server) so the
+    // dev-reload SSE endpoint can stream while requests are served.
+    dev: `concurrently -k -n build,uno,server -c blue,magenta,green "bf build --watch" "unocss --watch" "plackup -s Starman --workers 5 -p ${XSLATE_PORT} app.psgi"`,
+    build: 'bf build && unocss',
+    start: `PLACK_ENV=production plackup -s Starman --workers 5 -p ${XSLATE_PORT} app.psgi`,
+  },
+  dependencies: {
+    '@barefootjs/client': 'latest',
+    '@barefootjs/xslate': 'latest',
+    '@barefootjs/jsx': 'latest',
+    '@barefootjs/shared': 'latest',
+  },
+  devDependencies: {
+    ...UNOCSS_DEV_DEPENDENCIES,
+    '@barefootjs/cli': 'latest',
+    '@barefootjs/test': 'latest',
+    concurrently: '^9.0.0',
+    typescript: '^5.6.0',
+  },
+  // The starter Counter uses native <button> elements, not the registry
+  // <Button>, so no registry component needs to be fetched at init. See
+  // XSLATE_COUNTER_TSX for why manifest-driven child rendering isn't on
+  // the Xslate path yet.
+  bundledRegistryComponents: [],
+  prereqWarnings: () => perlPrereqs(),
+  // Text::Xslate / Plack / Starman are Perl dependencies, not npm ones —
+  // point the user at the cpanfile so they don't trip over a missing
+  // `plackup` after `npm install`.
+  extraSetupSteps: [
+    {
+      label: 'Install Perl deps for the Text::Xslate runtime (see cpanfile):',
+      command: 'cpanm --installdeps .',
+    },
+  ],
+}
+
+function perlPrereqs(): string[] {
+  const warnings: string[] = []
+  try {
+    execSync('perl --version', { stdio: 'ignore' })
+  } catch {
+    warnings.push('Perl not found on PATH. Install Perl 5.20+ before starting the dev server.')
+  }
+  try {
+    execSync('perl -MText::Xslate -e1', { stdio: 'ignore' })
+  } catch {
+    warnings.push(
+      'Text::Xslate not installed. Run `cpanm --installdeps .` before starting the dev server.',
+    )
+  }
+  try {
+    execSync('perl -MStarman -e1', { stdio: 'ignore' })
+  } catch {
+    warnings.push(
+      'Starman not installed (the dev server). Run `cpanm --installdeps .` before starting the dev server.',
+    )
+  }
+  return warnings
+}

--- a/packages/cli/src/lib/templates.ts
+++ b/packages/cli/src/lib/templates.ts
@@ -12,6 +12,7 @@ import { HONO_ADAPTER } from './adapters/hono'
 import { HONO_NODE_ADAPTER } from './adapters/hono-node'
 import { MOJO_ADAPTER } from './adapters/mojo'
 import { NETHTTP_ADAPTER } from './adapters/nethttp'
+import { XSLATE_ADAPTER } from './adapters/xslate'
 import type { PackageManager } from './pm'
 
 /**
@@ -113,6 +114,7 @@ export const ADAPTERS: Record<string, AdapterTemplate> = {
   chi: CHI_ADAPTER,
   nethttp: NETHTTP_ADAPTER,
   mojo: MOJO_ADAPTER,
+  xslate: XSLATE_ADAPTER,
   csr: CSR_ADAPTER,
 }
 


### PR DESCRIPTION
## Why

Two issues reported against `create-barefootjs`:

1. **Mojo cpanfile was inappropriate** — it declared only `Mojolicious` and didn't list `BarefootJS` / `BarefootJS::Backend::Mojo`. The scaffold vendored `.pm` copies under `lib/` instead, from a time before those modules had a CPAN release.
2. **Text::Xslate templates weren't selectable** in `bf init`, even though the `@barefootjs/xslate` adapter + `BarefootJS::Backend::Xslate` already exist.

The three Perl modules are now published to CPAN (v0.9.6): `BarefootJS`, `Mojolicious::Plugin::BarefootJS`, `BarefootJS::Backend::Xslate` — so the scaffolds can declare real dependencies.

## What changed

### Mojolicious: vendoring → CPAN dependencies
- `cpanfile` now declares `BarefootJS`, `Mojolicious::Plugin::BarefootJS` (which ships the plugin, the dev-reload plugin, and `BarefootJS::Backend::Mojo`), and `Mojolicious` — installed via the existing `cpanm --installdeps .` step.
- Removed the four vendored `lib/**/*.pm` files from the scaffold and the `use lib 'lib'` prepend in `app.pl`.
- Dropped the Perl runtime sources from the CLI embed step (`embed-runtimes.mjs` is Go-only now).

### New `xslate` adapter
- Selectable via `npm create barefootjs@latest -- --adapter xslate` (and the interactive menu).
- Scaffolds a plain **Plack/PSGI** app served by **Starman**, rendering Kolon `.tx` templates through `BarefootJS::Backend::Xslate` — no web framework. Dev-reload over SSE, gated to dev.
- Starter `Counter` uses native `<button>` elements (`bundledRegistryComponents: []`): the engine-agnostic `register_components_from_manifest` strips the Mojo `.html.ep` suffix, not Xslate's `.tx`, so manifest-driven registry-child rendering isn't on the Xslate path yet. A native-button Counter keeps the starter runnable end-to-end.

### Tests / docs
- `templates.test.ts`: Mojo test now asserts CPAN deps (no vendored `.pm`); added an `xslate` registration + wiring test; added `xslate` to the registry / gitignore / CSS-link `test.each` lists.
- `adapter-mojolicious/scaffold.test.ts` (integration-gated): vendoring assertions → cpanfile-declares-deps.
- `perl-adapter.md`: documented the `--adapter xslate` scaffold command.

## Verification
- `bun test src/__tests__/templates.test.ts` → 92 pass.
- Full `bun test` failures are pre-existing `Cannot find module '@barefootjs/jsx'` (workspace deps not installed in this env), unrelated to this change.
- Could not run the live Perl scaffolds end-to-end (no Perl/CPAN toolchain here); the `app.psgi` is modeled directly on the proven `integrations/xslate/app.psgi`.

https://claude.ai/code/session_01HqrAV1DxLm3yaFyer3E9MQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqrAV1DxLm3yaFyer3E9MQ)_