### PR TITLE
fix: seed prop-derived SSR signals so Mojo/Xslate scaffolds render

### DIFF
--- a/.changeset/fix-prop-derived-ssr-seeding.md
+++ b/.changeset/fix-prop-derived-ssr-seeding.md
@@ -1,0 +1,6 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/cli": patch
+---
+
+Fix SSR render crash for components whose signal/memo reads an optional prop (`createSignal(props.initial ?? 0)`). The bare-props-arg form now seeds those referenced props into the manifest `ssrDefaults`, so template-stash adapters no longer abort with `Global symbol "$initial" requires explicit package name` at top-level render. The Text::Xslate scaffold's `app.psgi` also seeds each component's `ssrDefaults` from the build manifest (a plain PSGI app has no plugin to do it automatically), so `<: $count :>` and friends resolve.

--- a/packages/cli/src/__tests__/templates.test.ts
+++ b/packages/cli/src/__tests__/templates.test.ts
@@ -323,6 +323,14 @@ describe('adapter registry', () => {
     expect(cpanfile).toMatch(/^requires 'Text::Xslate'/m)
     expect(cpanfile).toMatch(/^requires 'Starman'/m)
     expect(Object.keys(xslate.files).filter(f => f.endsWith('.pm'))).toEqual([])
+    // Plain PSGI has no plugin to auto-seed the SSR stash (the Mojo
+    // adapter's plugin does), so app.psgi must read each component's
+    // `ssrDefaults` from the build manifest and bind them as render vars —
+    // otherwise `<: $count :>` / `my $count = ($initial // 0)` reference
+    // unbound variables.
+    expect(xslate.files['app.psgi']).toContain('dist/templates/manifest.json')
+    expect(xslate.files['app.psgi']).toContain('ssrDefaults')
+    expect(xslate.files['app.psgi']).toMatch(/sub ssr_defaults/)
     // Config targets the xslate build factory.
     expect(xslate.files['barefoot.config.ts']).toContain("from '@barefootjs/xslate/build'")
     // Starter Counter is self-contained (native buttons, no registry fetch).

--- a/packages/cli/src/lib/adapters/xslate.ts
+++ b/packages/cli/src/lib/adapters/xslate.ts
@@ -79,12 +79,46 @@ my $backend = BarefootJS::Backend::Xslate->new(
     xslate_options => { cache => $DEV ? 0 : 1 },
 );
 
+# Load the build manifest (\`bf build\` writes dist/templates/manifest.json).
+# It carries each component's \`ssrDefaults\` — the static fallback for every
+# template variable (signals, memos, and the props they read). A plain PSGI
+# app has no plugin to seed those automatically (unlike the Mojolicious
+# integration), so we read them here and bind them as render vars. Without
+# this, \`<: \$count :>\` / \`<: my \$count = (\$initial // 0) :>\` reference
+# unbound variables.
+sub load_manifest () {
+    open my $fh, '<:raw', 'dist/templates/manifest.json' or return {};
+    local $/;
+    my $json = <$fh>;
+    close $fh;
+    my $m = eval { $J->decode($json) };
+    return (ref $m eq 'HASH') ? $m : {};
+}
+# Cache the manifest in production; re-read each request in dev so a
+# \`bf build --watch\` rebuild surfaces new defaults without a restart.
+my $MANIFEST = $DEV ? undef : load_manifest();
+sub manifest () { return $DEV ? load_manifest() : $MANIFEST }
+
+# Build the SSR stash for a component from its manifest \`ssrDefaults\`.
+sub ssr_defaults ($component) {
+    my $entry = manifest()->{$component} or return ();
+    my $defaults = $entry->{ssrDefaults} or return ();
+    my %stash;
+    for my $name (keys %$defaults) {
+        my $d = $defaults->{$name};
+        $stash{$name} = ref($d) eq 'HASH' ? $d->{value} : $d;
+    }
+    return %stash;
+}
+
 sub rand_suffix () { return substr(sprintf('%f', rand()) =~ s/^0\\.//r, 0, 6) }
 
 # Render a top-level component template and wrap it in the page layout.
-sub render_component ($component, %stash) {
+# Manifest defaults seed the stash; any caller-supplied \`%override\` wins.
+sub render_component ($component, %override) {
     my $bf = BarefootJS->new(undef, { backend => $backend });
     $bf->_scope_id($component . '_' . rand_suffix());
+    my %stash = (ssr_defaults($component), %override);
     my $body = $backend->render_named($component, $bf, \\%stash);
     return layout(body => $body, scripts => $bf->scripts);
 }

--- a/packages/jsx/src/__tests__/ssr-defaults.test.ts
+++ b/packages/jsx/src/__tests__/ssr-defaults.test.ts
@@ -58,6 +58,30 @@ describe('extractSsrDefaults', () => {
     expect(defaults?.count).toEqual({ value: 99 })
   })
 
+  test('seeds a bare-props prop a signal initializer reads (`props.initial`)', () => {
+    // The #1297 prop-derived seeding lowers `createSignal(props.initial ?? 0)`
+    // to a *bare scalar* recompute in the template (`my $count = ($initial
+    // // 0)`), so `$initial` must be a stash var or Perl strict aborts with
+    // `Global symbol "$initial" requires explicit package name`. The
+    // bare-props-arg form previously skipped all props; this regression
+    // guards that the referenced prop is now seeded (as undef → the
+    // recompute's `?? 0` supplies the real fallback).
+    const metadata = metadataFor(`
+      'use client'
+      import { createSignal, createMemo } from '@barefootjs/client'
+      function Counter(props: { initial?: number }) {
+        const [count, setCount] = createSignal(props.initial ?? 0)
+        const doubled = createMemo(() => count() * 2)
+        return <p>{count()}{doubled()}</p>
+      }
+    `)
+
+    const defaults = extractSsrDefaults(metadata)
+    expect(defaults?.count).toEqual({ value: 0 })
+    expect(defaults?.doubled).toEqual({ value: 0 })
+    expect(defaults?.initial).toEqual({ propName: 'initial', value: null })
+  })
+
   test('memo derived from a signal evaluates through the chain', () => {
     const metadata = metadataFor(`
       'use client'

--- a/packages/jsx/src/ssr-defaults.ts
+++ b/packages/jsx/src/ssr-defaults.ts
@@ -182,12 +182,13 @@ export function extractSsrDefaults(metadata: IRMetadata): Record<string, SsrDefa
 }
 
 /**
- * Collect the property names a `props.X` access reads off `propsObjectName`
+ * Collect the first-level property name of every `propsObjectName.X` access
  * within `expr` (e.g. `props.initial ?? 0` → `initial`). Used to seed the
  * stash vars a template-stash adapter's bare-scalar signal/memo recompute
- * references. Only direct single-level accesses
- * (`<propsObjectName>.<name>`) are collected — deeper chains
- * (`props.a.b`) don't lower to a bare scalar and are left alone.
+ * references. A deeper chain (`props.a.b`) still contributes its *base*
+ * prop `a`: adapters lower that to `$a->{b}`, so the bare `$a` needs
+ * seeding just the same — the walk stops at the first
+ * `propsObjectName.<name>` match and collects `a` (not `b`).
  */
 function collectPropRefs(
   expr: string | undefined,
@@ -204,9 +205,11 @@ function collectPropRefs(
       n.expression.text === propsObjectName &&
       ts.isIdentifier(n.name)
     ) {
+      // `propsObjectName.<name>` — collect <name> and stop. For a deeper
+      // chain (`props.a.b`) this node is the inner `props.a`, so we collect
+      // the base prop `a` (which lowers to `$a->{b}`); the outer `.b`
+      // access has no further `props.` reference to find.
       out.add(n.name.text)
-      // Don't descend into the matched access; its `.name` isn't a
-      // further reference. (The base identifier has no children to scan.)
       return
     }
     ts.forEachChild(n, visit)

--- a/packages/jsx/src/ssr-defaults.ts
+++ b/packages/jsx/src/ssr-defaults.ts
@@ -149,7 +149,69 @@ export function extractSsrDefaults(metadata: IRMetadata): Record<string, SsrDefa
     bindings[memo.name] = value
   }
 
+  // Bare-props-arg form (`function Foo(props: Props)`): a signal / memo
+  // whose initializer reads `props.X` is lowered by template-stash
+  // adapters to a *bare scalar* recompute (`my $count = ($initial // 0)`,
+  // the #1297 prop-derived seeding) — not a `$props->{X}` hash read. That
+  // bare `$initial` has to exist in the stash or Perl's strict mode aborts
+  // the render with `Global symbol "$initial" requires explicit package
+  // name`. The top block skips bare-props props on the assumption they're
+  // only ever read via `$props->{X}`, which the prop-derived seeding
+  // violates — so seed every prop a signal / memo initializer references.
+  // Value is `null` (→ undef): the recompute's own `?? <literal>` supplies
+  // the real fallback, and a caller-passed prop still wins via `propName`.
+  if (metadata.propsObjectName !== null) {
+    const referenced = new Set<string>()
+    for (const sig of metadata.signals) {
+      if (!sig.getter || sig.isModule) continue
+      collectPropRefs(sig.initialValue, metadata.propsObjectName, referenced)
+    }
+    for (const memo of metadata.memos) {
+      if (memo.isModule) continue
+      collectPropRefs(memo.computation, metadata.propsObjectName, referenced)
+    }
+    for (const name of referenced) {
+      // Don't clobber a signal / memo (or already-seeded prop) of the same
+      // name — those carry a resolved value the recompute relies on.
+      if (name in out) continue
+      out[name] = { propName: name, value: null }
+    }
+  }
+
   return Object.keys(out).length === 0 ? undefined : out
+}
+
+/**
+ * Collect the property names a `props.X` access reads off `propsObjectName`
+ * within `expr` (e.g. `props.initial ?? 0` → `initial`). Used to seed the
+ * stash vars a template-stash adapter's bare-scalar signal/memo recompute
+ * references. Only direct single-level accesses
+ * (`<propsObjectName>.<name>`) are collected — deeper chains
+ * (`props.a.b`) don't lower to a bare scalar and are left alone.
+ */
+function collectPropRefs(
+  expr: string | undefined,
+  propsObjectName: string,
+  out: Set<string>,
+): void {
+  if (!expr || !expr.trim()) return
+  const node = parseExpression(expr)
+  if (!node) return
+  const visit = (n: ts.Node): void => {
+    if (
+      ts.isPropertyAccessExpression(n) &&
+      ts.isIdentifier(n.expression) &&
+      n.expression.text === propsObjectName &&
+      ts.isIdentifier(n.name)
+    ) {
+      out.add(n.name.text)
+      // Don't descend into the matched access; its `.name` isn't a
+      // further reference. (The base identifier has no children to scan.)
+      return
+    }
+    ts.forEachChild(n, visit)
+  }
+  visit(node)
 }
 
 function resultToJsonable(v: EvalResult): unknown {


### PR DESCRIPTION
## Why

Follow-up to #1824. Two render bugs reported against the Perl scaffolds:

1. **Mojo** — `bun run dev` → the page errors with:
   ```
   Global symbol "$initial" requires explicit package name (did you forget to declare "my $initial"?) at template Counter.html.ep line 3.
   ```
2. **Xslate** — once Perl deps are installed, the same class of problem (the SSR stash is never seeded by a plain PSGI app).

### Root cause

The starter `Counter` does `createSignal(props.initial ?? 0)`. The Mojo/Xslate adapters lower that to a **bare-scalar** in-template recompute (the `#1297` prop-derived seeding): `% my $count = ($initial // 0);`. But `extractSsrDefaults` skipped **all** props for the bare-props-arg form (`function Counter(props: Props)`), on the assumption they're only ever read via `$props->{X}`. So `$initial` was never seeded into the stash, and a top-level render aborts under Perl strict.

## Fix

- **`@barefootjs/jsx` (`ssr-defaults.ts`)** — for the bare-props-arg form, scan signal/memo initializers for `props.X` reads and seed each referenced prop into `ssrDefaults` (`{ propName, value: null }` → `$initial = undef`; the recompute's own `?? 0` supplies the real fallback). Fixes Mojo and any template-stash adapter.
- **`@barefootjs/cli` (xslate `app.psgi`)** — a plain PSGI app has no plugin (unlike the Mojo one) to auto-seed the stash, so `app.psgi` now reads each component's `ssrDefaults` from the build manifest and binds them as render vars.

## Verification (real engines)

Installed real Mojolicious 9.46 and Text::Xslate and rendered the starter Counter end-to-end:

- **Mojo** (real Mojolicious + the BarefootJS plugin): renders `count: 0` / `doubled: 0`. Removing the seeded `initial` reproduces the **exact** reported error (`Global symbol "$initial" ... at template Counter.html.ep line 3`).
- **Xslate** (real Text::Xslate + the backend, seeding from the manifest like `app.psgi`): renders `count: 0` / `doubled: 0`.
- Real `bf build` writes `initial` into `dist/templates/manifest.json`'s `ssrDefaults`.

Tests: `@barefootjs/jsx` full suite ✓, `ssr-defaults` (+ new regression test) ✓, `adapter-mojolicious` 497 ✓, `adapter-xslate` ✓, **cross-adapter conformance 722 ✓** (covers Go adapters that also consume `ssrDefaults`), `cli` templates 92 ✓, biome clean.

## Note on the Xslate create warnings

The reported `! Plack not installed` / `! Starman not installed` lines during `bun create` are intentional pre-flight warnings (same pattern as the Mojo adapter's Perl checks), not failures — the `Get started` guide's `cpanm --installdeps .` step resolves them. Happy to soften/consolidate them if you'd prefer.

https://claude.ai/code/session_01HqrAV1DxLm3yaFyer3E9MQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqrAV1DxLm3yaFyer3E9MQ)_