### PR TITLE
fix(integrations): drop self-linking Back on example list pages

### DIFF
--- a/integrations/mojolicious/app.pl
+++ b/integrations/mojolicious/app.pl
@@ -185,8 +185,9 @@ $r->get('/styles/*asset' => sub ($c) {
 
 $r->get('/' => sub ($c) {
     $c->stash(
-        title   => 'BarefootJS + Mojolicious Example',
-        heading => 'BarefootJS + Mojolicious Example',
+        title     => 'BarefootJS + Mojolicious Example',
+        heading   => 'BarefootJS + Mojolicious Example',
+        back_href => '',
     );
     $c->render(template => 'home', layout => 'default');
 });
@@ -439,7 +440,13 @@ __DATA__
     <h1><%= $heading %></h1>
     % }
     <div id="app"><%= content %></div>
-    <p><a href="<%= $bp %>/">← Back</a></p>
+    % # Subpages link back to the example list ($bp/); the list page itself
+    % # passes back_href => '' to suppress the link (the header breadcrumb
+    % # already navigates up to /integrations).
+    % my $back_href = stash('back_href') // "$bp/";
+    % if ($back_href ne '') {
+    <p><a href="<%= $back_href %>">← Back</a></p>
+    % }
     <%== bf->scripts %>
     <%== bf_dev_snippet %>
 </body>

--- a/integrations/xslate/app.psgi
+++ b/integrations/xslate/app.psgi
@@ -138,6 +138,11 @@ sub render_component ($component, %opts) {
 
 sub layout (%a) {
     my $heading_html = $a{heading} ? "<h1>$a{heading}</h1>" : '';
+    # Subpages link back to the example list ($BASE/); the list page itself
+    # passes back => '' to suppress the link (the header breadcrumb already
+    # navigates up to /integrations).
+    my $back_href    = $a{back} // "$BASE/";
+    my $back_html    = $back_href ne '' ? qq{<p><a href="$back_href">&larr; Back</a></p>} : '';
     my $dev_snippet  = $DEV ? BarefootJS::DevReload->snippet("$BASE/_bf/reload") : '';
     return <<"HTML";
 <!DOCTYPE html>
@@ -168,7 +173,7 @@ sub layout (%a) {
     </header>
     $heading_html
     <div id="app">$a{body}</div>
-    <p><a href="$BASE/">&larr; Back</a></p>
+    $back_html
     $a{scripts}
     $dev_snippet
 </body>
@@ -359,6 +364,7 @@ sub home_page () {
     return layout(
         title   => 'BarefootJS + Text::Xslate Example',
         heading => 'BarefootJS + Text::Xslate Example',
+        back    => '',
         scripts => '',
         body    => <<"HTML",
 <p>This example renders the same shared JSX components with Text::Xslate (Kolon)


### PR DESCRIPTION
## What

On the Xslate and Mojolicious integration **example list (home) pages**
(`/integrations/xslate/`, `/integrations/mojolicious/`), the bottom "Back"
link pointed at the integration's own base path — i.e. a link back to the
very page you're on.

The other integrations don't have this problem: Hono / h3 / Elysia (TS) and
Echo / Gin / Chi / net/http (Go) render the "Back" link **only on the example
subpages** (where it returns to the list), and have no Back link on the list
page at all.

This unifies Xslate and Mojolicious onto that same behavior: **remove the Back
link from the list page**. Navigating up to `/integrations` is already covered
by the breadcrumb in the page header.

## How

The shared `layout` still defaults the Back link to the example list, so the
example subpages (Counter, Toggle, Todo, …) are unchanged. The list page now
passes an empty back target to suppress the link:

- **Xslate** (`integrations/xslate/app.psgi`): `layout` only emits the Back
  `<p>` when `back` is non-empty (default `$BASE/`); `home_page()` passes
  `back => ''`.
- **Mojolicious** (`integrations/mojolicious/app.pl`): the default layout only
  renders the Back link when `back_href` is non-empty (default `$bp/`); the
  `/` route sets `back_href => ''`.

## Notes

No e2e specs assert on the Back link, so none required updating.

https://claude.ai/code/session_01XVRVu7rpaSqwT4jrk3P9He