### PR TITLE
Attribute conditional binding effects in the profiler (#1690, #1795 Phase 1)

### DIFF
--- a/.changeset/profiler-cond-binding-ids.md
+++ b/.changeset/profiler-cond-binding-ids.md
@@ -1,0 +1,27 @@
+---
+"@barefootjs/client": minor
+"@barefootjs/jsx": minor
+---
+
+Attribute conditional-branch DOM-binding effects in the profiler (#1690, #1795 Phase 1).
+
+A conditional's `insert()` effect and the attribute / text binding effects
+emitted inside its branch `bindEvents` now carry a
+`<Component>#binding:<slotId>` id in profile mode, and `buildIdIndex` resolves
+them from the graph's `domBindings` (conditional / attribute / text slot + loc):
+
+- **`insert()` runtime** — takes an optional trailing `bfId` and forwards it to
+  the internal conditional re-eval `createEffect`, so a conditional's re-runs are
+  attributed to its source line instead of showing as a bare runtime id.
+- **branch attribute effects** — `createDisposableEffect(…, "<Comp>#binding:<slotId>")`
+  for `class={…}` / reactive attrs written inside a branch swap.
+- **branch text effects** — the `__bfText` re-splice effect carries the id too.
+
+`profileComponentName` is threaded through `buildInsertPlan` → `InsertPlan` →
+`stringifyInsert`, including recursively into nested conditionals. Previously
+these branch-scoped re-runs surfaced in the hot-subscribers list as
+unattributed runtime ids and inflated the coverage gap, even though a toggled
+conditional is often the *most* re-run subscriber.
+
+Off by default the emitted effects are byte-for-byte unchanged (SR8). Loop-child
+text/attribute binding effects remain a follow-up (#1795 Phase 2).

--- a/packages/client/src/runtime/insert.ts
+++ b/packages/client/src/runtime/insert.ts
@@ -182,7 +182,8 @@ export function insert(
   id: string,
   conditionFn: () => boolean,
   whenTrue: BranchConfig,
-  whenFalse: BranchConfig
+  whenFalse: BranchConfig,
+  bfId?: string
 ): void {
   if (!scope) return
 
@@ -325,7 +326,7 @@ export function insert(
 
     // Auto-focus elements with autofocus attribute (for dynamically created elements)
     autoFocusConditionalElement(region, id)
-  })
+  }, bfId)
 }
 
 

--- a/packages/jsx/src/__tests__/profile-cond-binding-ids.test.ts
+++ b/packages/jsx/src/__tests__/profile-cond-binding-ids.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Profile-mode ids on conditional-branch DOM-binding effects (#1690, SR3/SR4,
+ * issue #1795 Phase 1).
+ *
+ * A conditional's `insert()` effect, and the attribute / text binding effects
+ * emitted inside its branch `bindEvents`, carry a `<Component>#binding:<slotId>`
+ * id in profile mode so the profiler attributes their re-runs to source.
+ * `buildIdIndex` resolves those ids from the graph's `domBindings`
+ * (conditional / attribute / text slot + loc). Off by default the emitted
+ * effects are byte-identical (SR8).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+import { buildIdIndex } from '../profiler'
+import { buildComponentAnalysis } from '../debug'
+
+const adapter = new TestAdapter()
+
+// `open() &&` produces a conditional (s1); inside its branch the `class={...}`
+// is a reactive attribute (s3) and `{n()}` is a reactive text effect (s2).
+const source = `
+  'use client'
+  import { createSignal } from '@barefootjs/client'
+  export function Disclosure() {
+    const [open, setOpen] = createSignal(false)
+    const [n] = createSignal(0)
+    return (
+      <div>
+        <button onClick={() => setOpen(!open())}>toggle</button>
+        {open() && <p class={open() ? 'a' : 'b'}>count: {n()}</p>}
+      </div>
+    )
+  }
+`
+
+function clientJs(profile: boolean): string {
+  return compileJSX(source, 'Disclosure.tsx', { adapter, profile })
+    .files.find(f => f.type === 'clientJs')!.content
+}
+
+describe('conditional binding-effect ids (#1795 Phase 1)', () => {
+  test('profile off: no #binding ids anywhere (SR8)', () => {
+    expect(clientJs(false)).not.toContain('#binding:')
+  })
+
+  test('profile on: the conditional insert() effect carries a #binding id', () => {
+    const on = clientJs(true)
+    // The id is the last argument to the `insert(...)` call, which closes on
+    // its own line as `}, "<id>")` (single paren — distinct from the branch
+    // effects' `}, "<id>"))`). Anchor the line so this can't match a nested
+    // effect's close instead.
+    expect(on).toMatch(/^\s*}, "Disclosure#binding:s\d+"\)$/m)
+    // And it really is an insert() call that opened the block.
+    expect(on).toContain("insert(__scope, 's1'")
+  })
+
+  test('profile on: branch attribute and text effects carry #binding ids', () => {
+    const on = clientJs(true)
+    // Branch reactive attribute effect (createDisposableEffect with the class write).
+    expect(on).toMatch(/setAttribute\('class'[\s\S]*?}, "Disclosure#binding:s\d+"\)\)/)
+    // Branch reactive text effect (__bfText path).
+    expect(on).toMatch(/__bfText\([\s\S]*?}, "Disclosure#binding:s\d+"\)\)/)
+  })
+
+  test('buildIdIndex resolves conditional / attribute / text binding ids to source loc', () => {
+    const { graph } = buildComponentAnalysis(source, 'Disclosure.tsx')
+    const index = buildIdIndex(graph)
+
+    for (const type of ['conditional', 'attribute', 'text'] as const) {
+      const binding = graph.domBindings.find(b => b.type === type)
+      expect(binding, `expected a ${type} domBinding`).toBeTruthy()
+      const node = index.get(`Disclosure#binding:${binding!.slotId}`)
+      expect(node?.kind, `${type} binding should resolve to an effect`).toBe('effect')
+      expect(node?.loc.file).toBe('Disclosure.tsx')
+      expect(node?.loc.line).toBeGreaterThan(0)
+    }
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-insert.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-insert.ts
@@ -38,6 +38,7 @@ export function buildInsertPlan(
     slotId: elem.slotId,
     condition: elem.condition,
     eventNameMode: options.eventNameMode,
+    profileComponentName: options.profileComponentName,
     arms: [
       buildArm(elem.whenTrueHtml, elem.slotId, elem.whenTrue, options),
       buildArm(elem.whenFalseHtml, elem.slotId, elem.whenFalse, options),

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/insert.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/insert.ts
@@ -29,6 +29,12 @@ export interface InsertPlan {
    * keeps the original event name (used by `@client` conditionals).
    */
   eventNameMode: 'dom' | 'raw'
+  /**
+   * Owning component name in profile mode (#1690, SR4). When set, the
+   * conditional's `insert()` effect and its branch binding effects carry a
+   * `<Component>#binding:<slotId>` id so the profiler attributes them.
+   */
+  profileComponentName?: string
 }
 
 /** A single branch arm of an insert(). */

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/insert.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/insert.ts
@@ -51,11 +51,17 @@ export function stringifyInsert(
   const scopeVar = scopeRefToVar(plan.scope)
   const armIndent = leadingIndent + '  '
 
+  // Profile mode (#1690, SR4): give the conditional's `insert()` effect an id
+  // so the profiler attributes its re-runs to source (resolved from the
+  // `conditional` domBinding). Empty when off → byte-identical (SR8).
+  const condBfId = plan.profileComponentName
+    ? `, ${JSON.stringify(`${plan.profileComponentName}#binding:${plan.slotId}`)}`
+    : ''
   lines.push(`${leadingIndent}insert(${scopeVar}, '${plan.slotId}', () => ${plan.condition}, {`)
-  emitArm(lines, plan.arms[0], plan.eventNameMode, armIndent, bodyIndent)
+  emitArm(lines, plan.arms[0], plan.eventNameMode, armIndent, bodyIndent, plan.profileComponentName)
   lines.push(`${leadingIndent}}, {`)
-  emitArm(lines, plan.arms[1], plan.eventNameMode, armIndent, bodyIndent)
-  lines.push(`${leadingIndent}})`)
+  emitArm(lines, plan.arms[1], plan.eventNameMode, armIndent, bodyIndent, plan.profileComponentName)
+  lines.push(`${leadingIndent}}${condBfId})`)
 }
 
 function emitArm(
@@ -64,6 +70,7 @@ function emitArm(
   mode: 'dom' | 'raw',
   armIndent: string,
   bodyIndent: string,
+  profileComponentName?: string,
 ): void {
   // `__slots` accumulates live `Node` returns captured by `__bfSlot` so
   // the `insert()` runtime can splice them into the parsed fragment
@@ -72,7 +79,7 @@ function emitArm(
   // wrappers around Child-position interpolations under this var name.
   lines.push(`${armIndent}template: () => { const __slots = []; return { html: \`${arm.templateHtml}\`, slots: __slots } },`)
   lines.push(`${armIndent}bindEvents: (__branchScope, { isFirstRun: __bfFirstRun = false } = {}) => {`)
-  emitArmBody(lines, arm.body, mode, bodyIndent)
+  emitArmBody(lines, arm.body, mode, bodyIndent, profileComponentName)
   lines.push(`${armIndent}}`)
 }
 
@@ -81,7 +88,12 @@ function emitArmBody(
   body: ArmBody,
   mode: 'dom' | 'raw',
   indent: string,
+  profileComponentName?: string,
 ): void {
+  // Profile mode (#1690, SR4): a branch binding effect's id, resolved from its
+  // text/attribute `domBinding`. Empty when off → byte-identical (SR8).
+  const bindingBfId = (slotId: string): string =>
+    profileComponentName ? `, ${JSON.stringify(`${profileComponentName}#binding:${slotId}`)}` : ''
   // 1. Combine event-bearing slots and ref slots into a single `$()` query.
   //    Order: events-first, then refs (matches legacy emitter).
   const allSlotIds = new Set<string>()
@@ -156,7 +168,7 @@ function emitArmBody(
       for (const stmt of emitAttrUpdate(elVar, attr.attrName, attr.expression, attr)) {
         lines.push(`${indent}    ${stmt}`)
       }
-      lines.push(`${indent}  }))`)
+      lines.push(`${indent}  }${bindingBfId(slotId)}))`)
     }
     lines.push(`${indent}} }`)
   }
@@ -172,7 +184,7 @@ function emitArmBody(
     lines.push(`${indent}__disposers.push(createDisposableEffect(() => {`)
     lines.push(`${indent}  const __val = ${te.expression}`)
     lines.push(`${indent}  __anchor_${v} = __bfText(__anchor_${v}, __val)`)
-    lines.push(`${indent}}))`)
+    lines.push(`${indent}}${bindingBfId(te.slotId)}))`)
   }
 
   // Branch loops, now fully Plan-built. The stringifier writes its own


### PR DESCRIPTION
## What

Phase 1 of #1795: give a conditional's `insert()` effect and the attribute / text binding effects emitted inside its branch `bindEvents` a `<Component>#binding:<slotId>` id in profile mode, so the profiler attributes their re-runs to source instead of bare runtime ids.

Previously these branch-scoped re-runs surfaced in the hot-subscribers list as unattributed runtime ids and inflated the coverage gap — even though a toggled conditional is often the *most* re-run subscriber.

## How

- **`insert()` runtime** (`@barefootjs/client`) — takes an optional trailing `bfId` and forwards it to the internal conditional re-eval `createEffect`.
- **`profileComponentName` threading** — through `BuildInsertOptions` → `buildInsertPlan` → `InsertPlan` → `stringifyInsert`, including recursively into nested conditionals.
- **branch attribute effects** — `createDisposableEffect(…, "<Comp>#binding:<slotId>")` for `class={…}` / reactive attrs written inside a branch swap.
- **branch text effects** — the `__bfText` re-splice effect carries the id too.
- **`buildIdIndex`** already resolves `#binding:<slotId>` from `domBindings`; conditional / attribute / text slots now all map to an `effect` node + source loc.

## Verification

- New test `profile-cond-binding-ids.test.ts` (4 tests): profile-off has no `#binding:` (SR8); profile-on emits the id on the `insert()` call and on branch attr/text effects; `buildIdIndex` resolves conditional/attribute/text slots to source loc.
- Regression: insert runtime + integration, conditional codegen, profile turn markers + bfid emission, CSR conformance (124), jsx/client typecheck, biome lint — all green.
- Off by default the emitted effects are byte-for-byte unchanged (SR8).

Loop-child text/attribute binding effects remain a follow-up — **#1795 Phase 2**, stacked on this PR.

https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN)_