### PR TITLE
ci: wrap Bun setup in retry to survive GitHub Releases 504s

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -1,25 +1,71 @@
 name: 'Setup Bun (resilient)'
 description: >
-  Installs Bun via oven-sh/setup-bun, wrapped in a retry loop so transient
-  GitHub Releases 504s (the CDN that serves the bun binary) retry instead of
-  failing the whole job. The version is pinned by default so the runner tool
-  cache is reused across runs and re-downloads happen less often. Override the
-  `bun-version` input if a job needs a different version.
+  Installs a pinned Bun directly from GitHub Releases using curl with HTTP-level
+  retries, so transient GitHub Releases 504s (the CDN that serves the bun binary)
+  retry instead of failing the whole job. The download is also cached across runs
+  via actions/cache so most runs skip the network entirely. Uses only first-party
+  GitHub actions (no third-party action dependency). Override the `bun-version`
+  input if a job needs a different version.
 
 inputs:
   bun-version:
-    description: 'Bun version to install. Pinned default for tool-cache reuse.'
+    description: 'Bun version to install (no leading "v"). Pinned default for cache reuse.'
     required: false
     default: '1.3.14'
 
 runs:
   using: 'composite'
   steps:
-    - name: Setup Bun (with retry)
-      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+    - name: Cache Bun
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
-        action: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        attempt_limit: 5
-        attempt_delay: 10000
-        with: |
-          bun-version: ${{ inputs.bun-version }}
+        path: ~/.bun
+        key: bun-${{ inputs.bun-version }}-${{ runner.os }}-${{ runner.arch }}
+
+    - name: Install Bun (with retry)
+      shell: bash
+      env:
+        BUN_VERSION: ${{ inputs.bun-version }}
+      run: |
+        set -euo pipefail
+
+        bin="$HOME/.bun/bin"
+        mkdir -p "$bin"
+
+        # Map uname output to Bun's release asset naming.
+        os="$(uname -s)"; arch="$(uname -m)"
+        case "$os" in
+          Linux) os_tag="linux" ;;
+          Darwin) os_tag="darwin" ;;
+          *) echo "::error::Unsupported OS for Bun setup: $os"; exit 1 ;;
+        esac
+        case "$arch" in
+          x86_64|amd64) arch_tag="x64" ;;
+          aarch64|arm64) arch_tag="aarch64" ;;
+          *) echo "::error::Unsupported architecture for Bun setup: $arch"; exit 1 ;;
+        esac
+        target="${os_tag}-${arch_tag}"
+
+        if [ -x "$bin/bun" ] && [ "$("$bin/bun" --version 2>/dev/null || true)" = "$BUN_VERSION" ]; then
+          echo "Bun $BUN_VERSION restored from cache — skipping download."
+        else
+          url="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-${target}.zip"
+          tmp="$(mktemp -d)"
+          echo "Downloading $url"
+          # --retry-all-errors retries transient HTTP errors (incl. 504) at the
+          # transport layer — the whole point of this action.
+          curl --fail --location --show-error --silent \
+               --retry 6 --retry-delay 10 --retry-all-errors --retry-connrefused \
+               --connect-timeout 30 \
+               --output "$tmp/bun.zip" "$url"
+          unzip -oq "$tmp/bun.zip" -d "$tmp"
+          mv "$tmp/bun-${target}/bun" "$bin/bun"
+          chmod +x "$bin/bun"
+          rm -rf "$tmp"
+        fi
+
+        # `bunx` is shipped as a symlink to `bun`; recreate it (cache may predate it).
+        ln -sf "$bin/bun" "$bin/bunx"
+
+        echo "$bin" >> "$GITHUB_PATH"
+        echo "Bun $("$bin/bun" --version) ready at $bin"

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -2,26 +2,20 @@ name: 'Setup Bun (resilient)'
 description: >
   Installs a pinned Bun directly from GitHub Releases using curl with HTTP-level
   retries, so transient GitHub Releases 504s (the CDN that serves the bun binary)
-  retry instead of failing the whole job. The download is also cached across runs
-  via actions/cache so most runs skip the network entirely. Uses only first-party
-  GitHub actions (no third-party action dependency). Override the `bun-version`
-  input if a job needs a different version.
+  retry instead of failing the whole job. Downloads fresh on every run — no
+  cross-run cache is used, so a poisoned cache can never substitute the binary.
+  Has no third-party action dependency. Override the `bun-version` input if a job
+  needs a different version.
 
 inputs:
   bun-version:
-    description: 'Bun version to install (no leading "v"). Pinned default for cache reuse.'
+    description: 'Bun version to install (no leading "v").'
     required: false
     default: '1.3.14'
 
 runs:
   using: 'composite'
   steps:
-    - name: Cache Bun
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      with:
-        path: ~/.bun
-        key: bun-${{ inputs.bun-version }}-${{ runner.os }}-${{ runner.arch }}
-
     - name: Install Bun (with retry)
       shell: bash
       env:
@@ -46,8 +40,10 @@ runs:
         esac
         target="${os_tag}-${arch_tag}"
 
+        # Re-runs of this step on the same runner reuse an already-good binary;
+        # otherwise (the normal case) we download fresh.
         if [ -x "$bin/bun" ] && [ "$("$bin/bun" --version 2>/dev/null || true)" = "$BUN_VERSION" ]; then
-          echo "Bun $BUN_VERSION restored from cache — skipping download."
+          echo "Bun $BUN_VERSION already present — skipping download."
         else
           url="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-${target}.zip"
           tmp="$(mktemp -d)"

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -1,11 +1,8 @@
 name: 'Setup Bun (resilient)'
 description: >
-  Installs a pinned Bun directly from GitHub Releases using curl with HTTP-level
-  retries, so transient GitHub Releases 504s (the CDN that serves the bun binary)
-  retry instead of failing the whole job. Downloads fresh on every run — no
-  cross-run cache is used, so a poisoned cache can never substitute the binary.
-  Has no third-party action dependency. Override the `bun-version` input if a job
-  needs a different version.
+  Installs a pinned Bun from GitHub Releases with curl retries, so transient
+  504s from the release CDN retry instead of failing the job. No third-party
+  action and no cross-run cache (which could be poisoned).
 
 inputs:
   bun-version:
@@ -22,46 +19,14 @@ runs:
         BUN_VERSION: ${{ inputs.bun-version }}
       run: |
         set -euo pipefail
-
+        # All workflows run on ubuntu-latest, so the target is always linux-x64.
         bin="$HOME/.bun/bin"
         mkdir -p "$bin"
-
-        # Map uname output to Bun's release asset naming.
-        os="$(uname -s)"; arch="$(uname -m)"
-        case "$os" in
-          Linux) os_tag="linux" ;;
-          Darwin) os_tag="darwin" ;;
-          *) echo "::error::Unsupported OS for Bun setup: $os"; exit 1 ;;
-        esac
-        case "$arch" in
-          x86_64|amd64) arch_tag="x64" ;;
-          aarch64|arm64) arch_tag="aarch64" ;;
-          *) echo "::error::Unsupported architecture for Bun setup: $arch"; exit 1 ;;
-        esac
-        target="${os_tag}-${arch_tag}"
-
-        # Re-runs of this step on the same runner reuse an already-good binary;
-        # otherwise (the normal case) we download fresh.
-        if [ -x "$bin/bun" ] && [ "$("$bin/bun" --version 2>/dev/null || true)" = "$BUN_VERSION" ]; then
-          echo "Bun $BUN_VERSION already present — skipping download."
-        else
-          url="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-${target}.zip"
-          tmp="$(mktemp -d)"
-          echo "Downloading $url"
-          # --retry-all-errors retries transient HTTP errors (incl. 504) at the
-          # transport layer — the whole point of this action.
-          curl --fail --location --show-error --silent \
-               --retry 6 --retry-delay 10 --retry-all-errors --retry-connrefused \
-               --connect-timeout 30 \
-               --output "$tmp/bun.zip" "$url"
-          unzip -oq "$tmp/bun.zip" -d "$tmp"
-          mv "$tmp/bun-${target}/bun" "$bin/bun"
-          chmod +x "$bin/bun"
-          rm -rf "$tmp"
-        fi
-
-        # `bunx` is shipped as a symlink to `bun`; recreate it (cache may predate it).
-        ln -sf "$bin/bun" "$bin/bunx"
-
+        url="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-x64.zip"
+        curl --fail --location --show-error --retry 6 --retry-delay 10 --retry-all-errors \
+             --output /tmp/bun.zip "$url"
+        unzip -oq /tmp/bun.zip -d /tmp
+        install -m755 /tmp/bun-linux-x64/bun "$bin/bun"
+        ln -sf "$bin/bun" "$bin/bunx"   # bunx ships as a symlink to bun
         echo "$bin" >> "$GITHUB_PATH"
-        echo "Bun $("$bin/bun" --version) ready at $bin"
+        "$bin/bun" --version

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -1,0 +1,25 @@
+name: 'Setup Bun (resilient)'
+description: >
+  Installs Bun via oven-sh/setup-bun, wrapped in a retry loop so transient
+  GitHub Releases 504s (the CDN that serves the bun binary) retry instead of
+  failing the whole job. The version is pinned by default so the runner tool
+  cache is reused across runs and re-downloads happen less often. Override the
+  `bun-version` input if a job needs a different version.
+
+inputs:
+  bun-version:
+    description: 'Bun version to install. Pinned default for tool-cache reuse.'
+    required: false
+    default: '1.3.14'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Bun (with retry)
+      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+      with:
+        action: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        attempt_limit: 5
+        attempt_delay: 10000
+        with: |
+          bun-version: ${{ inputs.bun-version }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,9 +19,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -28,9 +28,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/ci-create-barefootjs.yml
+++ b/.github/workflows/ci-create-barefootjs.yml
@@ -24,9 +24,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/ci-elysia.yml
+++ b/.github/workflows/ci-elysia.yml
@@ -30,9 +30,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/ci-form.yml
+++ b/.github/workflows/ci-form.yml
@@ -24,9 +24,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/ci-go-template.yml
+++ b/.github/workflows/ci-go-template.yml
@@ -37,9 +37,7 @@ jobs:
           go-version: '1.25'
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       - name: Install dependencies
         run: bun install
@@ -69,9 +67,7 @@ jobs:
           go-version: '1.25'
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/ci-h3.yml
+++ b/.github/workflows/ci-h3.yml
@@ -30,9 +30,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/ci-hono.yml
+++ b/.github/workflows/ci-hono.yml
@@ -32,9 +32,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       - name: Install dependencies
         run: bun install
@@ -56,9 +54,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       # Wrangler (invoked by Playwright's webServer below) shells out to
       # Node and requires v22+. The runner's default Node 20 makes

--- a/.github/workflows/ci-jsr-check.yml
+++ b/.github/workflows/ci-jsr-check.yml
@@ -51,9 +51,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       - name: Setup Deno
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -42,9 +42,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       - name: Install dependencies
         # Git hooks are a local-dev concern; skip their installation in CI.

--- a/.github/workflows/ci-mojolicious.yml
+++ b/.github/workflows/ci-mojolicious.yml
@@ -40,9 +40,7 @@ jobs:
         run: cpanm --notest Mojolicious
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/ci-smoke-publish.yml
+++ b/.github/workflows/ci-smoke-publish.yml
@@ -63,9 +63,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       # Node is required by `create-barefootjs`'s bin — it spawns
       # `node <cli bin> init`. Bun ships its own Node compat layer but

--- a/.github/workflows/ci-xslate.yml
+++ b/.github/workflows/ci-xslate.yml
@@ -40,9 +40,7 @@ jobs:
         run: cpanm --notest Text::Xslate
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       - name: Install dependencies
         run: bun install
@@ -72,9 +70,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       - name: Install dependencies
         run: bun install
@@ -99,9 +95,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,9 +51,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       # Wrangler 4.x shells out to Node and requires v22+. The runner's
       # default Node 20 makes `bunx wrangler deploy` exit immediately.
@@ -88,9 +86,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       # Wrangler 4.x shells out to Node and requires v22+. The runner's
       # default Node 20 makes `bunx wrangler deploy` exit immediately.
@@ -134,9 +130,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       # Wrangler 4.x shells out to Node and requires v22+. The runner's
       # default Node 20 makes `bunx wrangler deploy` exit immediately.
@@ -172,9 +166,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       # Wrangler 4.x shells out to Node and requires v22+. The runner's
       # default Node 20 makes `bunx wrangler deploy` exit immediately.
@@ -210,9 +202,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       # Wrangler 4.x shells out to Node and requires v22+. The runner's
       # default Node 20 makes `bunx wrangler deploy` exit immediately.
@@ -248,9 +238,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       # Wrangler 4.x shells out to Node and requires v22+. The runner's
       # default Node 20 makes `bunx wrangler deploy` exit immediately.
@@ -289,9 +277,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       # Wrangler 4.x shells out to Node and requires v22+. The runner's
       # default Node 20 makes `bunx wrangler deploy` exit immediately.
@@ -330,9 +316,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       # Wrangler 4.x shells out to Node and requires v22+. The runner's
       # default Node 20 makes `bunx wrangler deploy` exit immediately.
@@ -371,9 +355,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       # Wrangler 4.x shells out to Node and requires v22+. The runner's
       # default Node 20 makes `bunx wrangler deploy` exit immediately.
@@ -412,9 +394,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       # Wrangler 4.x shells out to Node and requires v22+. The runner's
       # default Node 20 makes `bunx wrangler deploy` exit immediately.
@@ -453,9 +433,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       # Wrangler 4.x shells out to Node and requires v22+. The runner's
       # default Node 20 makes `bunx wrangler deploy` exit immediately.

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -27,9 +27,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,9 +49,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -92,9 +90,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       - name: Sync Perl versions and commit
         run: |

--- a/.github/workflows/update-doc-snapshots.yml
+++ b/.github/workflows/update-doc-snapshots.yml
@@ -43,9 +43,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/update-fixtures.yml
+++ b/.github/workflows/update-fixtures.yml
@@ -36,9 +36,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/update-meta.yml
+++ b/.github/workflows/update-meta.yml
@@ -39,9 +39,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+        uses: ./.github/actions/setup-bun
 
       - name: Install dependencies
         run: bun install


### PR DESCRIPTION
## Background

`oven-sh/setup-bun` downloads the bun binary from **GitHub Releases (CDN)** on every run. When GitHub is unstable the CDN returns 504s, and setup-bun's built-in retries (2 attempts, fixed delay) aren't enough, so the whole job fails:

```
Downloading a new version of Bun: .../bun-linux-x64.zip
Unexpected HTTP response: 504
Waiting 17 seconds before trying again
Unexpected HTTP response: 504
Waiting 10 seconds before trying again
Error: Error: Unexpected HTTP response: 504
```

This has been happening frequently.

## Changes

- **Add a local composite action (`.github/actions/setup-bun`)** that installs a pinned Bun directly from GitHub Releases via `curl --retry-all-errors --retry 6 --retry-delay 10`. `curl` retries transient HTTP errors (including 504) at the transport layer, which is far more resilient than setup-bun's built-in retries.
- **Replace the duplicated `setup-bun` blocks across all 20 workflows (35 spots)** with a single `uses: ./.github/actions/setup-bun` reference, so future tweaks live in one place.
- **Pin the Bun version** (`1.3.14`, overridable via the `bun-version` input) instead of `latest`.

## Design notes

- **No third-party action.** The action depends only on first-party tooling (`curl`, `unzip`, `install`) — no community actions like `Wandalen/wretry.action` in the critical path.
- **No cross-run cache.** We deliberately do not use `actions/cache` for the binary: a cache is writable from other branches/PRs and a poisoned entry could substitute the build toolchain. We download fresh every run; the `curl` retries already provide 504 resilience without trusting a shared cache.
- **linux-x64 hardcoded.** All workflows run on `ubuntu-latest`, so OS/arch detection was dropped for simplicity (noted in a comment — add detection back if other runners are introduced).

## Verification

- All workflow YAML validated; `actions/checkout` runs before the setup step in every job (the local composite action requires the repo to be checked out first).
- Triggered across all workflows (this PR touches every workflow file): CI is green and bun installs successfully everywhere, confirming the curl-based install works.

https://claude.ai/code/session_01FHAGRXJ6nZGDeX2jKkY6He