### PR TITLE
Attribute loop-child binding effects in the profiler (#1690, #1795 Phase 2)

### DIFF
--- a/.changeset/profiler-loop-binding-ids.md
+++ b/.changeset/profiler-loop-binding-ids.md
@@ -1,0 +1,28 @@
+---
+"@barefootjs/jsx": minor
+---
+
+Attribute loop-child DOM-binding effects in the profiler (#1690, #1795 Phase 2).
+
+Inside a `{items().map(it => …)}` body the emitter wraps every loop-param read
+(`{it.t}`, `class={it.n > 0 ? …}`) in a per-item `createEffect`. In profile
+mode each of those loop-child attribute / outer-text effects now carries a
+`<Component>#binding:<slotId>` id, so the profiler attributes their re-runs to a
+source line instead of bare runtime ids:
+
+- **analyzer** — `collectDomBindings` now threads loop-param context, so a
+  binding that reads a loop param (or index) registers as a reactive
+  `domBinding` with its slot + loc. Detection uses the analyzer's lexer-resolved
+  metadata (`origin.freeRefs` for text, `freeIdentifiers` for attributes), not a
+  raw-string scan, so a param name appearing only inside a string literal
+  (`i` vs `'i'`) is not mistaken for a read. `key={…}` is skipped (it is the
+  loop's keyFn, never an effect). `buildIdIndex` then resolves every loop-child
+  text/attribute slot to `<Component>#binding:<slotId>`.
+- **emit** — `ReactiveEffectsPlan` carries `profileComponentName`;
+  `stringifyReactiveEffects` emits the id on each loop-child attribute and
+  outer-text `createEffect`.
+
+Previously loop-child re-runs (often the hottest subscribers in a list view)
+surfaced unattributed and inflated the coverage gap. Off by default the emitted
+effects are byte-for-byte unchanged (SR8). Loop-child *conditional-branch* texts
+remain a follow-up.

--- a/packages/jsx/src/__tests__/profile-loop-binding-ids.test.ts
+++ b/packages/jsx/src/__tests__/profile-loop-binding-ids.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Profile-mode ids on loop-child DOM-binding effects (#1690, SR3/SR4,
+ * issue #1795 Phase 2).
+ *
+ * Inside a `map(it => …)` body the emitter wraps every loop-param read in a
+ * `createEffect`. In profile mode each of those per-item attribute / text
+ * effects now carries a `<Component>#binding:<slotId>` id, and `buildIdIndex`
+ * resolves it from the graph's loop-child `domBindings` (slot + loc) — the
+ * analyzer now threads loop-param context so `{it.t}` / `class={it.n…}` reads
+ * register as reactive bindings. Off by default the effects are byte-identical
+ * (SR8).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+import { buildIdIndex } from '../profiler'
+import { buildComponentAnalysis } from '../debug'
+
+const adapter = new TestAdapter()
+
+// `{it.t}` and `: {it.n}` are loop-child text effects (s0, s1); `class={…}` is
+// a loop-child attribute effect (s2); the loop itself is s3.
+const source = `
+  'use client'
+  import { createSignal } from '@barefootjs/client'
+  export function List() {
+    const [items] = createSignal([{ id: 1, t: 'a', n: 0 }])
+    return (
+      <ul>
+        {items().map(it => (
+          <li key={it.id} class={it.n > 0 ? 'hot' : 'cold'}>
+            <span>{it.t}</span>: {it.n}
+          </li>
+        ))}
+      </ul>
+    )
+  }
+`
+
+function clientJs(profile: boolean): string {
+  return compileJSX(source, 'List.tsx', { adapter, profile })
+    .files.find(f => f.type === 'clientJs')!.content
+}
+
+describe('loop-child binding-effect ids (#1795 Phase 2)', () => {
+  test('profile off: no #binding ids anywhere (SR8)', () => {
+    expect(clientJs(false)).not.toContain('#binding:')
+  })
+
+  test('profile on: loop-child text effects carry #binding ids', () => {
+    const on = clientJs(true)
+    // Both `{it.t}` and `{it.n}` text effects.
+    expect(on).toMatch(/__rt_s\d+\.textContent = String\(it\(\)\.t\) }, "List#binding:s\d+"\)/)
+    expect(on).toMatch(/__rt_s\d+\.textContent = String\(it\(\)\.n\) }, "List#binding:s\d+"\)/)
+  })
+
+  test('profile on: the loop-child attribute effect carries a #binding id', () => {
+    const on = clientJs(true)
+    expect(on).toMatch(/setAttribute\('class'[\s\S]*?}, "List#binding:s\d+"\)/)
+  })
+
+  test('profile on: the `key` attribute is NOT emitted as a binding effect', () => {
+    const on = clientJs(true)
+    // `key` becomes the loop keyFn / data-key, never a createEffect.
+    expect(on).not.toContain('it().id) }, "List#binding')
+  })
+
+  test('analyzer registers loop-child text/attribute bindings (not `key`)', () => {
+    const { graph } = buildComponentAnalysis(source, 'List.tsx')
+    const loopChild = graph.domBindings.filter(b => b.type !== 'loop')
+    // class (attribute) + two texts = 3; `key` is excluded.
+    expect(loopChild.map(b => b.label).sort()).toEqual(['class', 'text "s0"', 'text "s1"'])
+    expect(loopChild.every(b => b.classification === 'reactive')).toBe(true)
+  })
+
+  test('a loop-param name inside a string literal is NOT mistaken for a read', () => {
+    // Index param `i`; `data-lit={'i'}` references no identifier — only the
+    // string literal `'i'`. Lexer-aware detection (freeIdentifiers / freeRefs)
+    // must not register it as a reactive binding, where a raw-string regex would.
+    const litSource = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function L() {
+        const [items] = createSignal([{ id: 1 }])
+        return <ul>{items().map((it, i) => <li key={it.id} data-lit={'i'} data-idx={i === 0 ? 'a' : 'b'}>x</li>)}</ul>
+      }
+    `
+    const { graph } = buildComponentAnalysis(litSource, 'L.tsx')
+    const labels = graph.domBindings.filter(b => b.type === 'attribute').map(b => b.label)
+    // `data-idx` reads the index identifier → reactive; `data-lit` is literal-only → not.
+    expect(labels).toContain('data-idx')
+    expect(labels).not.toContain('data-lit')
+  })
+
+  test('buildIdIndex resolves every loop-child binding to source loc', () => {
+    const { graph } = buildComponentAnalysis(source, 'List.tsx')
+    const index = buildIdIndex(graph)
+    for (const b of graph.domBindings) {
+      const node = index.get(`List#binding:${b.slotId}`)
+      expect(node?.kind, `binding ${b.slotId} (${b.type})`).toBe('effect')
+      expect(node?.loc.file).toBe('List.tsx')
+      expect(node?.loc.line).toBeGreaterThan(0)
+    }
+  })
+})

--- a/packages/jsx/src/debug.ts
+++ b/packages/jsx/src/debug.ts
@@ -1610,7 +1610,25 @@ function collectDomBindings(
   signalGetters: Set<string>,
   memoNames: Set<string>,
   parentTag?: string,
+  // Loop-param names in scope (#1690, #1795 Phase 2). Inside a `map(it => …)`
+  // body the emitter rewrites every `it.x` read into a reactive accessor and
+  // wraps the binding in `createEffect`, yet `it` is neither a signal nor a
+  // memo — so without this context loop-child text / attribute bindings are
+  // invisible to the graph. When a binding expression references one of these
+  // names it is treated as reactive (matching the emitter's gate), giving the
+  // profiler a `domBinding` (slotId + loc) to resolve `<Comp>#binding:<slotId>`.
+  loopParams: Set<string> = new Set(),
 ): void {
+  // Does a loop-child binding read a loop param (or index)? Use the analyzer's
+  // lexer-resolved metadata, NOT a raw-string regex — so a param name that only
+  // appears inside a string literal (index `i` vs `'i'`) is not mistaken for a
+  // reactive read. Text expressions carry `origin.freeRefs` (a `render-item`
+  // kind == map-callback param); attributes carry `freeIdentifiers` (bare
+  // identifier set). This matches the emitter's actual loop-param gate.
+  const exprReadsLoopParam = (n: IRExpression): boolean =>
+    loopParams.size > 0 && (n.origin?.freeRefs?.some(r => loopParams.has(r.name)) ?? false)
+  const attrReadsLoopParam = (free: ReadonlySet<string> | undefined): boolean =>
+    loopParams.size > 0 && free !== undefined && [...loopParams].some(p => free.has(p))
   switch (node.type) {
     case 'element': {
       // Dynamic attribute bindings (style, class, aria-*, data-*, etc.)
@@ -1621,10 +1639,14 @@ function collectDomBindings(
       // deps list is the statically-proven-reactive case.
       for (const attr of node.attrs) {
         if (attr.value.kind !== 'expression' && attr.value.kind !== 'template' && attr.value.kind !== 'spread') continue
+        // `key` is consumed by the loop's keyFn, never emitted as an attribute
+        // effect — skip it inside loops so a `key={it.id}` read isn't mistaken
+        // for a reactive binding (matches `collectLoopChildBindings`).
+        if (attr.name === 'key' && loopParams.size > 0) continue
         const expr = attrValueToString(attr.value)
         if (!expr) continue
         const deps = extractReactiveDeps(expr, signalGetters, memoNames)
-        const isReactive = deps.length > 0
+        const isReactive = deps.length > 0 || attrReadsLoopParam(attr.freeIdentifiers)
         const wrapReason = inferWrapReasonForAttrLike(isReactive, false, attr)
         if (wrapReason) {
           bindings.push({
@@ -1659,7 +1681,7 @@ function collectDomBindings(
       }
       // Recurse — pass element tag as parent context for text bindings
       for (const child of node.children) {
-        collectDomBindings(child, bindings, signalGetters, memoNames, node.tag)
+        collectDomBindings(child, bindings, signalGetters, memoNames, node.tag, loopParams)
       }
       break
     }
@@ -1667,7 +1689,8 @@ function collectDomBindings(
       // Widened to match emitter gate in collect-elements.ts:
       // `node.reactive || node.callsReactiveGetters || node.hasFunctionCalls`.
       const decision = decideWrapFromAstFlags(node)
-      if (decision.wrap && node.slotId) {
+      const loopReactive = exprReadsLoopParam(node)
+      if ((decision.wrap || loopReactive) && node.slotId) {
         const deps = extractReactiveDeps(node.expr, signalGetters, memoNames)
         const preview = parentTag
           ? `<${parentTag}>{${truncateExpr(node.expr)}}</${parentTag}>`
@@ -1678,9 +1701,12 @@ function collectDomBindings(
           slotId: node.slotId,
           deps,
           type: 'text',
-          classification: decision.reason === 'proven-reactive' ? 'reactive' : 'fallback',
+          classification:
+            (decision.wrap && decision.reason === 'proven-reactive') || loopReactive
+              ? 'reactive'
+              : 'fallback',
           expression: node.expr,
-          wrapReason: decision.reason,
+          wrapReason: decision.wrap ? decision.reason : 'string-reactive',
           loc: node.loc,
           jsxPreview: preview,
         })
@@ -1704,8 +1730,8 @@ function collectDomBindings(
           jsxPreview: `{${truncateExpr(node.condition)} ? ... : ...}`,
         })
       }
-      collectDomBindings(node.whenTrue, bindings, signalGetters, memoNames, parentTag)
-      collectDomBindings(node.whenFalse, bindings, signalGetters, memoNames, parentTag)
+      collectDomBindings(node.whenTrue, bindings, signalGetters, memoNames, parentTag, loopParams)
+      collectDomBindings(node.whenFalse, bindings, signalGetters, memoNames, parentTag, loopParams)
       break
     }
     case 'loop': {
@@ -1744,8 +1770,12 @@ function collectDomBindings(
           })
         }
       }
+      // Loop-param names enter scope for the children (#1690, #1795 Phase 2).
+      const childLoopParams = new Set(loopParams)
+      for (const p of extractLoopParamNames(node.param, node)) childLoopParams.add(p)
+      if (node.index) childLoopParams.add(node.index)
       for (const child of node.children) {
-        collectDomBindings(child, bindings, signalGetters, memoNames, parentTag)
+        collectDomBindings(child, bindings, signalGetters, memoNames, parentTag, childLoopParams)
       }
       break
     }
@@ -1778,21 +1808,21 @@ function collectDomBindings(
         }
       }
       for (const child of node.children) {
-        collectDomBindings(child, bindings, signalGetters, memoNames, parentTag)
+        collectDomBindings(child, bindings, signalGetters, memoNames, parentTag, loopParams)
       }
       break
     }
     case 'fragment':
     case 'provider': {
       for (const child of node.children) {
-        collectDomBindings(child, bindings, signalGetters, memoNames, parentTag)
+        collectDomBindings(child, bindings, signalGetters, memoNames, parentTag, loopParams)
       }
       break
     }
     case 'if-statement': {
-      collectDomBindings(node.consequent, bindings, signalGetters, memoNames, parentTag)
+      collectDomBindings(node.consequent, bindings, signalGetters, memoNames, parentTag, loopParams)
       if (node.alternate) {
-        collectDomBindings(node.alternate, bindings, signalGetters, memoNames, parentTag)
+        collectDomBindings(node.alternate, bindings, signalGetters, memoNames, parentTag, loopParams)
       }
       break
     }

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-reactive-effects.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-reactive-effects.ts
@@ -143,6 +143,7 @@ export function buildReactiveEffectsPlan(
     attrSlots,
     outerTexts,
     conditionals: conditionalPlans,
+    profileComponentName,
   }
 }
 

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/reactive-effects.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/reactive-effects.ts
@@ -62,4 +62,11 @@ export interface ReactiveEffectsPlan {
   /** Text effects scoped to the outer renderItem (not inside any conditional). */
   outerTexts: readonly ReactiveTextEffect[]
   conditionals: readonly NestedConditionalPlan[]
+  /**
+   * Owning component name in profile mode (#1690, SR4, #1795 Phase 2). When
+   * set, each loop-child attribute / outer-text `createEffect` carries a
+   * `<Component>#binding:<slotId>` id so the profiler attributes its per-item
+   * re-runs to source. Undefined off → byte-identical (SR8).
+   */
+  profileComponentName?: string
 }

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/reactive-effects.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/reactive-effects.ts
@@ -50,6 +50,14 @@ export function stringifyReactiveEffects(
   const { indent, elVar, bodyIsMultiRoot } = opts
   const lookup = bodyIsMultiRoot ? 'qsaItem' : 'qsa'
 
+  // Profile mode (#1690, SR4, #1795 Phase 2): a loop-child binding effect's id,
+  // resolved from its text/attribute `domBinding` (slot + loc). Empty when off
+  // → byte-identical (SR8).
+  const bindingBfId = (slotId: string): string =>
+    plan.profileComponentName
+      ? `, ${JSON.stringify(`${plan.profileComponentName}#binding:${slotId}`)}`
+      : ''
+
   // 1. Reactive attribute effects (one qsa per slot, then per-attr createEffect).
   for (const slot of plan.attrSlots) {
     const varName = `__ra_${varSlotId(slot.slotId)}`
@@ -60,14 +68,14 @@ export function stringifyReactiveEffects(
       for (const stmt of emitAttrUpdate(varName, attr.attrName, attr.wrappedExpression, attr.meta)) {
         lines.push(`${indent}    ${stmt}`)
       }
-      lines.push(`${indent}  })`)
+      lines.push(`${indent}  }${bindingBfId(slot.slotId)})`)
     }
     lines.push(`${indent}} }`)
   }
 
   // 2. Outer text effects (slots NOT inside any conditional branch).
   for (const text of plan.outerTexts) {
-    emitOuterText(lines, indent, elVar, text)
+    emitOuterText(lines, indent, elVar, text, bindingBfId(text.slotId))
   }
 
   // 3. Reactive conditionals — each emits an insert(...) over `elVar` whose
@@ -82,10 +90,11 @@ function emitOuterText(
   indent: string,
   elVar: string,
   text: ReactiveTextEffect,
+  bfId: string = '',
 ): void {
   const varName = `__rt_${varSlotId(text.slotId)}`
   lines.push(`${indent}{ const [${varName}] = $t(${elVar}, '${text.slotId}')`)
-  lines.push(`${indent}if (${varName}) createEffect(() => { ${varName}.textContent = String(${text.wrappedExpression}) }) }`)
+  lines.push(`${indent}if (${varName}) createEffect(() => { ${varName}.textContent = String(${text.wrappedExpression}) }${bfId}) }`)
 }
 
 function emitOuterConditional(


### PR DESCRIPTION
## What

Phase 2 of #1795, **stacked on #1832** (Phase 1). Gives loop-child binding effects a `<Component>#binding:<slotId>` id in profile mode.

Inside a `{items().map(it => …)}` body the emitter wraps every loop-param read (`{it.t}`, `class={it.n > 0 ? …}`) in a per-item `createEffect`. Those per-item re-runs are often the *hottest* subscribers in a list view, yet they previously surfaced as unattributed runtime ids and inflated the coverage gap.

## How

- **analyzer** (`debug.ts`) — `collectDomBindings` threads loop-param context. A binding expression that references a loop param (or index) now registers as a reactive `domBinding` with its slot + loc; `key={…}` is skipped (it is the loop's keyFn, never an effect). `buildIdIndex` already resolves any non-event binding, so each loop-child text/attribute slot maps to `<Component>#binding:<slotId>`.
- **emit** — `ReactiveEffectsPlan` carries `profileComponentName` (already threaded into `buildReactiveEffectsPlan`); `stringifyReactiveEffects` emits the id on each loop-child attribute and outer-text `createEffect`.

## Verification

- New test `profile-loop-binding-ids.test.ts` (6 tests): profile-off has no `#binding:` (SR8); profile-on emits ids on loop-child text + attribute effects; `key` is NOT emitted as a binding; analyzer registers exactly `class` + two texts (not `key`); `buildIdIndex` resolves every loop-child slot to source loc.
- Regression: full `@barefootjs/jsx` suite (2050 pass), `@barefootjs/client` (349 pass), CSR conformance (124), debug suite, jsx/client typecheck, biome lint — all green.
- Off by default the emitted effects are byte-for-byte unchanged (SR8).

Loop-child *conditional-branch* texts (`emitArmText`) remain a follow-up.

> **Note for review:** the base of this PR is `claude/profiler-cond-binding-ids` (#1832). The "Files changed" tab shows only the Phase 2 diff. Merge #1832 first; this PR will then auto-retarget to `main`.

https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN)_