### PR TITLE
Attribute deeply-nested loop binding effects in the profiler (#1690, #1795 Phase 3)

### DIFF
--- a/.changeset/profiler-nested-binding-ids.md
+++ b/.changeset/profiler-nested-binding-ids.md
@@ -1,0 +1,29 @@
+---
+"@barefootjs/jsx": minor
+---
+
+Attribute deeply-nested loop binding effects in the profiler (#1690, closes #1795).
+
+Phases 1–2 attributed top-level, conditional-branch, and direct loop-child
+binding effects. Phase 3 closes the remaining nested emit paths so every binding
+effect a loop produces carries a `<Component>#binding:<slotId>` id and every
+emitted id resolves via `buildIdIndex` — `bf debug profile` now reports zero
+coverage gap for nested list/conditional structures:
+
+- **analyzer** (`collectDomBindings`) — loop-param awareness now extends to the
+  `conditional` case (`origin.freeRefs`) and the inner-`loop` case
+  (`arrayFreeIdentifiers`), so a loop-child conditional (`{r.on ? …}`) and an
+  inner loop reading the outer param (`{r.tags.map(…)}`) register as reactive
+  `domBindings` with slot + loc.
+- **emit** — `profileComponentName` is threaded through the remaining loop
+  stringifiers, each emitting the id via a shared `profileBindingId` helper:
+  loop-child conditional `insert()` + branch text (`reactive-effects` /
+  `loop-child-arm`), inner / nested loop `mapArray` + child text/attr
+  (`inner-loop`), branch-scoped loop `mapArray` (`branch-loop`), static-array
+  loop child effects (`loop`), composite and component loop `mapArray`
+  (`composite-loop` / `component-loop`).
+
+Off by default the emitted effects are byte-for-byte unchanged (SR8). The one
+remaining residual is a child component's reactive *children* text inside a
+component loop (`<Row>{it.label}</Row>`), which is a component-children binding
+rather than a DOM binding and is not yet resolved by the analyzer.

--- a/packages/jsx/src/__tests__/profile-nested-binding-ids.test.ts
+++ b/packages/jsx/src/__tests__/profile-nested-binding-ids.test.ts
@@ -21,6 +21,7 @@ import { compileJSX } from '../compiler'
 import { TestAdapter } from '../adapters/test-adapter'
 import { buildIdIndex } from '../profiler'
 import { buildComponentAnalysis } from '../debug'
+import { profileBindingId } from '../ir-to-client-js/utils'
 
 const adapter = new TestAdapter()
 
@@ -134,5 +135,19 @@ describe('nested loop binding ids (#1795 Phase 3)', () => {
   test('component loop attributes its mapArray', () => {
     const emitted = assertNoCoverageGap(componentLoopSource, 'CompLoop')
     expect(emitted).toContain('CompLoop#binding:s1')
+  })
+
+  test('a slot-less inner loop ("?") emits no id — never an unresolvable #binding:?', () => {
+    // An inner loop whose container element has no `bf` slot yields slotId '?'.
+    // buildIdIndex keys on real domBinding slots, so `#binding:?` could never
+    // resolve; the helper must suppress it (the analyzer emits no binding for a
+    // slot-less loop either, so both sides stay silent). Guards the single
+    // chokepoint every loop/binding emit site routes through.
+    expect(profileBindingId('Comp', '?')).toBe('')
+    expect(profileBindingId('Comp', 's3')).toBe(', "Comp#binding:s3"')
+    expect(profileBindingId(undefined, 's3')).toBe('')
+    // The nested case is the only matrix shape with an inner loop; confirm it
+    // never emits a `:?` id end-to-end.
+    expect(clientJs(nestedSource, 'Nested', true)).not.toContain('#binding:?')
   })
 })

--- a/packages/jsx/src/__tests__/profile-nested-binding-ids.test.ts
+++ b/packages/jsx/src/__tests__/profile-nested-binding-ids.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Profile-mode ids on deeply-nested loop binding effects (#1690, SR3/SR4,
+ * issue #1795 Phase 3).
+ *
+ * Phases 1–2 covered top-level, conditional-branch, and direct loop-child
+ * bindings. Phase 3 closes the remaining nested emit paths so every binding
+ * effect a loop produces carries a `<Component>#binding:<slotId>` id and every
+ * emitted id resolves via `buildIdIndex`:
+ *
+ *   - loop-child conditional `insert()` + its branch text (`emitArmText`)
+ *   - inner / nested loop `mapArray` + inner-loop child text/attr effects
+ *   - branch-scoped loop `mapArray` (loop inside a conditional)
+ *   - static-array loop child text/attr effects
+ *   - component loop `mapArray`
+ *
+ * Off by default the emitted effects are byte-for-byte unchanged (SR8).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+import { buildIdIndex } from '../profiler'
+import { buildComponentAnalysis } from '../debug'
+
+const adapter = new TestAdapter()
+
+function clientJs(source: string, name: string, profile: boolean): string {
+  return compileJSX(source, `${name}.tsx`, { adapter, profile })
+    .files.find(f => f.type === 'clientJs')!.content
+}
+
+/** Every emitted `<Comp>#binding:sN` id must resolve via buildIdIndex (no gap). */
+function assertNoCoverageGap(source: string, name: string): string[] {
+  const on = clientJs(source, name, true)
+  const { graph } = buildComponentAnalysis(source, `${name}.tsx`)
+  const index = buildIdIndex(graph)
+  const emitted = [...new Set([...on.matchAll(new RegExp(`"(${name}#binding:s\\d+)"`, 'g'))].map(m => m[1]))]
+  const unresolved = emitted.filter(id => !index.has(id))
+  expect(unresolved).toEqual([])
+  return emitted
+}
+
+// A loop item with BOTH a conditional (with a branch text) AND an inner loop —
+// exercises emitOuterConditional, emitArmText, and the inner-loop mapArray.
+const nestedSource = `
+  'use client'
+  import { createSignal } from '@barefootjs/client'
+  export function Nested() {
+    const [rows] = createSignal([{ id: 1, on: true, label: 'a', tags: ['x'] }])
+    return (
+      <ul>
+        {rows().map(r => (
+          <li key={r.id}>
+            {r.on ? <span>{r.label}</span> : <em>off</em>}
+            <ul>{r.tags.map(t => <li key={t}>{t}</li>)}</ul>
+          </li>
+        ))}
+      </ul>
+    )
+  }
+`
+
+const branchLoopSource = `
+  'use client'
+  import { createSignal } from '@barefootjs/client'
+  export function BranchLoop() {
+    const [open] = createSignal(true)
+    const [items] = createSignal([{ id: 1, t: 'a' }])
+    return <div>{open() && <ul>{items().map(it => <li key={it.id}>{it.t}</li>)}</ul>}</div>
+  }
+`
+
+const staticLoopSource = `
+  'use client'
+  import { createSignal } from '@barefootjs/client'
+  export function StaticLoop() {
+    const [n] = createSignal(0)
+    const tabs = [{ id: 1 }, { id: 2 }]
+    return <ul>{tabs.map(tab => <li key={tab.id}>{n()}</li>)}</ul>
+  }
+`
+
+const componentLoopSource = `
+  'use client'
+  import { createSignal } from '@barefootjs/client'
+  import { Row } from './Row'
+  export function CompLoop() {
+    const [items] = createSignal([{ id: 1, label: 'a' }])
+    return <div>{items().map(it => <Row key={it.id} label={it.label} />)}</div>
+  }
+`
+
+describe('nested loop binding ids (#1795 Phase 3)', () => {
+  test('profile off: no #binding ids in any nested shape (SR8)', () => {
+    for (const [src, name] of [
+      [nestedSource, 'Nested'],
+      [branchLoopSource, 'BranchLoop'],
+      [staticLoopSource, 'StaticLoop'],
+      [componentLoopSource, 'CompLoop'],
+    ] as const) {
+      expect(clientJs(src, name, false)).not.toContain('#binding:')
+    }
+  })
+
+  test('loop-child conditional + inner loop: every binding resolves', () => {
+    const emitted = assertNoCoverageGap(nestedSource, 'Nested')
+    // conditional + arm text + inner-loop text + inner loop + outer loop = 5.
+    expect(emitted.length).toBe(5)
+  })
+
+  test('loop-child conditional insert() and its branch text carry ids', () => {
+    const on = clientJs(nestedSource, 'Nested', true)
+    // The branch-arm text (`{r.label}` inside the conditional's true arm).
+    expect(on).toMatch(/__rt_s\d+\.textContent = String\(r\(\)\.label\) }, "Nested#binding:s\d+"\)/)
+    // The inner loop's child text (`{t}`).
+    expect(on).toMatch(/String\(t\(\)\) }, "Nested#binding:s\d+"\)/)
+  })
+
+  test('branch-scoped loop (loop inside a conditional) attributes its mapArray', () => {
+    const emitted = assertNoCoverageGap(branchLoopSource, 'BranchLoop')
+    // conditional + branch loop + loop-child text = 3.
+    expect(emitted.length).toBe(3)
+    const on = clientJs(branchLoopSource, 'BranchLoop', true)
+    expect(on).toMatch(/mapArray\([\s\S]*?"BranchLoop#binding:s\d+"\)/)
+  })
+
+  test('static-array loop child effects carry ids', () => {
+    const emitted = assertNoCoverageGap(staticLoopSource, 'StaticLoop')
+    expect(emitted.length).toBeGreaterThanOrEqual(1)
+    const on = clientJs(staticLoopSource, 'StaticLoop', true)
+    expect(on).toMatch(/textContent = String\(n\(\)\) }, "StaticLoop#binding:s\d+"\)/)
+  })
+
+  test('component loop attributes its mapArray', () => {
+    const emitted = assertNoCoverageGap(componentLoopSource, 'CompLoop')
+    expect(emitted).toContain('CompLoop#binding:s1')
+  })
+})

--- a/packages/jsx/src/debug.ts
+++ b/packages/jsx/src/debug.ts
@@ -1715,7 +1715,12 @@ function collectDomBindings(
     }
     case 'conditional': {
       const decision = decideWrapFromAstFlags(node)
-      if (decision.wrap && node.slotId) {
+      // A loop-child conditional whose condition reads a loop param is reactive
+      // (the emitter wraps its `insert()` in a per-item effect) even though the
+      // param is neither signal nor memo. Use the resolved `origin.freeRefs`.
+      const loopReactive =
+        loopParams.size > 0 && (node.origin?.freeRefs?.some(r => loopParams.has(r.name)) ?? false)
+      if ((decision.wrap || loopReactive) && node.slotId) {
         const deps = extractReactiveDeps(node.condition, signalGetters, memoNames)
         bindings.push({
           kind: 'dom',
@@ -1723,9 +1728,12 @@ function collectDomBindings(
           slotId: node.slotId,
           deps,
           type: 'conditional',
-          classification: decision.reason === 'proven-reactive' ? 'reactive' : 'fallback',
+          classification:
+            (decision.wrap && decision.reason === 'proven-reactive') || loopReactive
+              ? 'reactive'
+              : 'fallback',
           expression: node.condition,
-          wrapReason: decision.reason,
+          wrapReason: decision.wrap ? decision.reason : 'string-reactive',
           loc: node.loc,
           jsxPreview: `{${truncateExpr(node.condition)} ? ... : ...}`,
         })
@@ -1742,7 +1750,13 @@ function collectDomBindings(
       // (e.g. `getItems().map(...)` with an opaque helper).
       if (node.slotId) {
         const deps = extractReactiveDeps(node.array, signalGetters, memoNames)
-        const isReactive = deps.length > 0 || node.callsReactiveGetters === true
+        // An inner loop whose array reads an outer loop param (`r.tags.map(...)`)
+        // is reactive per item — use the resolved `arrayFreeIdentifiers`.
+        const loopReactive =
+          loopParams.size > 0 &&
+          node.arrayFreeIdentifiers !== undefined &&
+          [...loopParams].some(p => node.arrayFreeIdentifiers!.has(p))
+        const isReactive = deps.length > 0 || node.callsReactiveGetters === true || loopReactive
         const isFallback = !isReactive && node.hasFunctionCalls === true
         if (isReactive || isFallback) {
           // IRLoop has no `.reactive` flag (unlike IRExpression/IRConditional),
@@ -1751,7 +1765,7 @@ function collectDomBindings(
           // getter (`items()` where `items` is a signal) is proven-reactive,
           // not fallback — flip the string evidence before handing the AST
           // flags to the helper.
-          const wrapReason: WrapReason = deps.length > 0
+          const wrapReason: WrapReason = deps.length > 0 || loopReactive
             ? 'string-reactive'
             : node.callsReactiveGetters
               ? 'proven-reactive'

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/branch-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/branch-loop.ts
@@ -70,6 +70,12 @@ export interface BranchPlainLoopPlan {
    * multi-line renderItem with multi-root template clone (#1212).
    */
   bodyIsMultiRoot: boolean
+  /**
+   * Profile-mode loop id (#1690, #1795 Phase 3): `<Component>#binding:<slotId>`
+   * for the branch loop's `mapArray` (the loop node shares its container slot).
+   * Undefined off → byte-identical (SR8).
+   */
+  profileLoopId?: string
 }
 
 export interface BranchCompositeLoopPlan {

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-branch-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-branch-loop.ts
@@ -30,7 +30,7 @@ export function buildBranchLoopPlan(loop: BranchLoop, profileComponentName?: str
   if (loop.useElementReconciliation && (loop.nestedComponents?.length || loop.innerLoops?.length)) {
     const composite: BranchCompositeLoopPlan = {
       kind: 'composite',
-      composite: buildBranchCompositePlan(loop, cv),
+      composite: buildBranchCompositePlan(loop, cv, profileComponentName),
       containerSlotId,
       containerVar,
     }
@@ -71,6 +71,7 @@ export function buildBranchLoopPlan(loop: BranchLoop, profileComponentName?: str
     eventDelegation: buildBranchLoopDelegationPlan(loop, cv, profileComponentName),
     childRefs: buildChildRefBindings(loop.bindings.refs, loop.param, loop.paramBindings),
     bodyIsMultiRoot: loop.bodyIsMultiRoot ?? false,
+    profileLoopId: profileComponentName ? `${profileComponentName}#binding:${containerSlotId}` : undefined,
   }
   return plan
 }

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-component-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-component-loop.ts
@@ -31,7 +31,7 @@ import { buildReactiveEffectsPlan } from './build-reactive-effects.ts'
 import type { ComponentLoopPlan, NestedComponentInit } from './types.ts'
 
 /** @internal — prefer `buildLoopPlan`. */
-export function buildComponentLoopPlan(elem: TopLevelLoop): ComponentLoopPlan {
+export function buildComponentLoopPlan(elem: TopLevelLoop, profileComponentName?: string): ComponentLoopPlan {
   const { name } = elem.childComponent!
   const propsExpr = buildComponentPropsExpr(elem.childComponent!, elem.param)
   const keyExpr = wrapLoopParamAsAccessor(elem.key || '__idx', elem.param, elem.paramBindings)
@@ -77,6 +77,7 @@ export function buildComponentLoopPlan(elem: TopLevelLoop): ComponentLoopPlan {
     // by the type so the structural invariant (every variant has a
     // `childRefs`) is preserved; populated as empty.
     childRefs: buildChildRefBindings(elem.bindings.refs, elem.param, elem.paramBindings),
+    profileLoopId: profileComponentName ? `${profileComponentName}#binding:${elem.slotId}` : undefined,
     childConditionalEffects: hasChildConds
       ? buildReactiveEffectsPlan({
           attrs: [],
@@ -84,6 +85,7 @@ export function buildComponentLoopPlan(elem: TopLevelLoop): ComponentLoopPlan {
           conditionals: elem.bindings.conditionals,
           loopParam: elem.param,
           loopParamBindings: elem.paramBindings,
+          profileComponentName,
         })
       : null,
   }

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-composite-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-composite-loop.ts
@@ -26,7 +26,7 @@ import { buildInnerLoopsPlan } from './build-inner-loop.ts'
 import type { CompositeLoopPlan } from './types.ts'
 
 /** @internal — prefer `buildLoopPlan`. */
-export function buildTopLevelCompositePlan(elem: TopLevelLoop): CompositeLoopPlan {
+export function buildTopLevelCompositePlan(elem: TopLevelLoop, profileComponentName?: string): CompositeLoopPlan {
   const nestedComps = elem.nestedComponents!
   const depthLevels = buildDepthLevels(elem.innerLoops ?? [], nestedComps, elem.bindings.events)
   const { head: paramHead, unwrap: paramUnwrap } = destructureLoopParam(elem.param, elem.paramBindings)
@@ -63,16 +63,19 @@ export function buildTopLevelCompositePlan(elem: TopLevelLoop): CompositeLoopPla
           conditionals: elem.bindings.conditionals,
           loopParam: elem.param,
           loopParamBindings: elem.paramBindings,
+          profileComponentName,
         })
       : null,
     branchClearChildren: false,
     topIndent: '  ',
     bodyIndent: '    ',
     bodyIsMultiRoot: elem.bodyIsMultiRoot ?? false,
+    profileLoopId: profileComponentName ? `${profileComponentName}#binding:${elem.slotId}` : undefined,
+    profileComponentName,
   }
 }
 
-export function buildBranchCompositePlan(loop: BranchLoop, cv: string): CompositeLoopPlan {
+export function buildBranchCompositePlan(loop: BranchLoop, cv: string, profileComponentName?: string): CompositeLoopPlan {
   const nestedComps = loop.nestedComponents!
   const innerLoops = loop.innerLoops ?? []
   const childEvents = loop.bindings.events
@@ -114,12 +117,15 @@ export function buildBranchCompositePlan(loop: BranchLoop, cv: string): Composit
           conditionals: loop.bindings.conditionals,
           loopParam: loop.param,
           loopParamBindings: loop.paramBindings,
+          profileComponentName,
         })
       : null,
     branchClearChildren: true,
     topIndent: '      ',
     bodyIndent: '        ',
     bodyIsMultiRoot: loop.bodyIsMultiRoot ?? false,
+    profileLoopId: profileComponentName ? `${profileComponentName}#binding:${loop.containerSlotId}` : undefined,
+    profileComponentName,
   }
 }
 

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-inner-loop.ts
@@ -131,6 +131,8 @@ export function buildInnerLoopsPlan(args: BuildInnerLoopsArgs): InnerLoopsPlan {
     plan.push({
       uidSuffix,
       markerId: inner.markerId,
+      // The loop node shares its container element's slot (#1795 Phase 3).
+      slotId: inner.containerSlotId ?? '?',
       containerExpr,
       arrayExpr,
       arraySrc: inner.array,

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop-child-arm.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop-child-arm.ts
@@ -278,6 +278,9 @@ export function buildBranchInnerLoopsPlan(
     plan.push({
       uidSuffix: `br_${i}`,
       markerId: inner.markerId,
+      // The loop node shares its container element's slot, so `containerSlotId`
+      // is the IR slot the analyzer's `loop` domBinding uses (#1795 Phase 3).
+      slotId: csl ?? '?',
       containerExpr,
       arrayExpr: wrapOuter(inner.array),
       keyFn: loopKeyFn(inner),

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop.ts
@@ -69,15 +69,15 @@ export function buildLoopPlan(elem: TopLevelLoop, opts: BuildLoopPlanOptions): L
     return buildPlainLoopPlan(elem, opts.profileComponentName)
   }
   if (elem.isStaticArray) {
-    return buildStaticLoopPlan(elem, opts.unsafeLocalNames)
+    return buildStaticLoopPlan(elem, opts.unsafeLocalNames, opts.profileComponentName)
   }
   const hasInnerStructure = (elem.nestedComponents?.length ?? 0) > 0
     || (elem.innerLoops?.length ?? 0) > 0
   if (elem.useElementReconciliation && hasInnerStructure) {
-    return buildTopLevelCompositePlan(elem)
+    return buildTopLevelCompositePlan(elem, opts.profileComponentName)
   }
   if (elem.childComponent) {
-    return buildComponentLoopPlan(elem)
+    return buildComponentLoopPlan(elem, opts.profileComponentName)
   }
   return buildPlainLoopPlan(elem, opts.profileComponentName)
 }
@@ -117,7 +117,7 @@ export function buildPlainLoopPlan(elem: TopLevelLoop, profileComponentName?: st
 }
 
 /** @internal — prefer `buildLoopPlan`. */
-export function buildStaticLoopPlan(elem: TopLevelLoop, unsafeLocalNames: Set<string>): StaticLoopPlan {
+export function buildStaticLoopPlan(elem: TopLevelLoop, unsafeLocalNames: Set<string>, profileComponentName?: string): StaticLoopPlan {
   // Group reactive attrs by their child slot id, preserving the legacy
   // declaration-order Map-iteration semantics.
   const attrsBySlotMap = new Map<string, LoopChildReactiveAttr[]>()
@@ -142,6 +142,7 @@ export function buildStaticLoopPlan(elem: TopLevelLoop, unsafeLocalNames: Set<st
     param: elem.param,
     indexParam,
     childIndexExpr,
+    profileComponentName,
     attrsBySlot: [...attrsBySlotMap].map(([slotId, attrs]) => [slotId, attrs] as const),
     texts: elem.bindings.reactiveTexts,
     // Static path: forEach binds `param` as the raw value. Passing through

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/inner-loop.ts
@@ -83,6 +83,13 @@ export interface InnerLoopPlan {
   uidSuffix: string
   /** Loop marker id — passed to mapArray so sibling loops disambiguate (#1087). */
   markerId: string
+  /**
+   * IR slot id for this inner loop (#1690, #1795 Phase 3). The loop node shares
+   * its container element's slot, so this is `containerSlotId`. Used to emit the
+   * `<Component>#binding:<slotId>` profile id on the inner `mapArray`; resolves
+   * via the `loop` `domBinding`. `'?'` when the IR carried no slot.
+   */
+  slotId: string
   /** Container resolution expression — already includes scope / selectors. */
   containerExpr: string
   /** Array expression as wrapped (reactive) or as written in source (static). */

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/loop-child-arm.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/loop-child-arm.ts
@@ -92,6 +92,12 @@ export interface BranchInnerLoop {
   uidSuffix: string
   /** Loop marker id — passed to mapArray so sibling loops disambiguate (#1087). */
   markerId: string
+  /**
+   * IR slot id for the inner loop (#1690, #1795 Phase 3). Used to emit the
+   * `<Component>#binding:<slotId>` profile id on the inner `mapArray`; resolves
+   * via the `loop` `domBinding`. `'?'` when the IR carried no slot.
+   */
+  slotId: string
   /** Container resolution expression — already includes scope and selectors. */
   containerExpr: string
   /** Wrapped array expression (`wrapOuter(inner.array)`). */

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/loop.ts
@@ -141,6 +141,11 @@ interface ComponentLoopVariant extends DynamicLoopCommon {
   nestedComps: NestedComponentInit[]
   /** Reactive-effects plan for `childConditionals` inside the loop body. */
   childConditionalEffects: ReactiveEffectsPlan | null
+  /**
+   * Profile-mode loop id (#1690, #1795 Phase 3) for the component loop's
+   * `mapArray`. Undefined off → byte-identical (SR8).
+   */
+  profileLoopId?: string
 }
 
 /**
@@ -184,6 +189,16 @@ interface CompositeLoopVariant extends DynamicLoopCommon {
    * `qsa(__el, ...)` → `qsaItem(__el, ...)` for reactive lookups (#1212).
    */
   bodyIsMultiRoot: boolean
+  /**
+   * Profile-mode loop id (#1690, #1795 Phase 3): `<Component>#binding:<slotId>`
+   * for the composite `mapArray`. Undefined off → byte-identical (SR8).
+   */
+  profileLoopId?: string
+  /**
+   * Owning component name in profile mode — threaded to `stringifyInnerLoops`
+   * so per-item inner-loop / text / attribute effects carry binding ids.
+   */
+  profileComponentName?: string
 }
 
 /**
@@ -208,6 +223,12 @@ interface StaticLoopVariant extends LoopPlanCommon {
    * Null for the SSR-then-hydrate-only common case.
    */
   csrMaterialize: StaticLoopMaterializePlan | null
+  /**
+   * Owning component name in profile mode (#1690, #1795 Phase 3). When set,
+   * each static-loop child attribute / text `createEffect` carries a
+   * `<Component>#binding:<slotId>` id. Undefined off → byte-identical (SR8).
+   */
+  profileComponentName?: string
 }
 
 /**

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/branch-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/branch-loop.ts
@@ -57,8 +57,10 @@ function emitPlain(lines: string[], plan: BranchPlainLoopPlan): void {
     eventDelegation,
     childRefs,
     bodyIsMultiRoot,
+    profileLoopId,
   } = plan
 
+  const loopBfId = profileLoopId ? `, ${JSON.stringify(profileLoopId)}` : ''
   const unwrapInline = paramUnwrap ? `${paramUnwrap} ` : ''
 
   // Wrap the mapArray() in a disposable effect so the inner createEffect
@@ -73,9 +75,9 @@ function emitPlain(lines: string[], plan: BranchPlainLoopPlan): void {
     // Simple case: single-line renderItem (single root, no reactive effects).
     const cloneExpr = emitTemplateCloneInline(template)
     if (mapPreambleWrapped) {
-      lines.push(`        if (${containerVar}) mapArray(() => ${arrayExpr}, ${containerVar}, ${keyFn}, (${paramHead}, ${indexParam}, __existing) => { ${unwrapInline}if (__existing) return __existing; ${mapPreambleWrapped}; ${cloneExpr} }, '${markerId}')`)
+      lines.push(`        if (${containerVar}) mapArray(() => ${arrayExpr}, ${containerVar}, ${keyFn}, (${paramHead}, ${indexParam}, __existing) => { ${unwrapInline}if (__existing) return __existing; ${mapPreambleWrapped}; ${cloneExpr} }, '${markerId}'${loopBfId})`)
     } else {
-      lines.push(`        if (${containerVar}) mapArray(() => ${arrayExpr}, ${containerVar}, ${keyFn}, (${paramHead}, ${indexParam}, __existing) => { ${unwrapInline}if (__existing) return __existing; ${cloneExpr} }, '${markerId}')`)
+      lines.push(`        if (${containerVar}) mapArray(() => ${arrayExpr}, ${containerVar}, ${keyFn}, (${paramHead}, ${indexParam}, __existing) => { ${unwrapInline}if (__existing) return __existing; ${cloneExpr} }, '${markerId}'${loopBfId})`)
     }
   } else {
     // Multi-line renderItem (reactive effects and/or multi-root and/or refs).
@@ -97,7 +99,7 @@ function emitPlain(lines: string[], plan: BranchPlainLoopPlan): void {
     }
     emitLoopChildRefs(lines, childRefs, { indent: '          ', elVar: '__el', bodyIsMultiRoot })
     lines.push(`          return __el`)
-    lines.push(`        }, '${markerId}')`)
+    lines.push(`        }, '${markerId}'${loopBfId})`)
   }
   lines.push(`      }))`)
 

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/component-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/component-loop.ts
@@ -48,8 +48,10 @@ export function stringifyComponentLoop(lines: string[], plan: ComponentLoopPlan)
     keyExpr,
     nestedComps,
     childConditionalEffects,
+    profileLoopId,
   } = plan
 
+  const loopBfId = profileLoopId ? `, ${JSON.stringify(profileLoopId)}` : ''
   lines.push(`  mapArray(() => ${arrayExpr}, ${containerVar}, ${keyFn}, (${paramHead}, ${indexParam}, __existing) => {`)
   if (paramUnwrap) lines.push(`    ${paramUnwrap}`)
 
@@ -58,7 +60,7 @@ export function stringifyComponentLoop(lines: string[], plan: ComponentLoopPlan)
   if (nestedComps.length === 0) {
     lines.push(`    if (__existing) { initChild('${scopedComp}', __existing, ${componentPropsExpr}); return __existing }`)
     lines.push(`    return createComponent('${scopedComp}', ${componentPropsExpr}, ${keyExpr})`)
-    lines.push(`  }, '${markerId}')`)
+    lines.push(`  }, '${markerId}'${loopBfId})`)
     return
   }
 
@@ -79,7 +81,7 @@ export function stringifyComponentLoop(lines: string[], plan: ComponentLoopPlan)
     stringifyReactiveEffects(lines, childConditionalEffects, { indent: '    ', elVar: '__csrEl' })
   }
   lines.push(`    return __csrEl`)
-  lines.push(`  }, '${markerId}')`)
+  lines.push(`  }, '${markerId}'${loopBfId})`)
 }
 
 function emitNestedInit(lines: string[], indent: string, parentVar: string, nc: NestedComponentInit): void {

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/composite-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/composite-loop.ts
@@ -59,6 +59,8 @@ export function stringifyCompositeLoop(lines: string[], plan: CompositeLoopPlan)
     topIndent,
     bodyIndent: rawBodyIndent,
     bodyIsMultiRoot,
+    profileComponentName: pc,
+    profileLoopId,
   } = plan
 
   // When wrapping the mapArray in createDisposableEffect (branch case), the
@@ -120,7 +122,7 @@ export function stringifyCompositeLoop(lines: string[], plan: CompositeLoopPlan)
   })
   emitComponentAndEventSetup(lines, bodyIndent, '__el', compsArr, eventsArr, loopParam, loopParamBindings, bodyIsMultiRoot)
   if (innerLoops.length > 0) {
-    stringifyInnerLoops(lines, innerLoops, bodyIndent)
+    stringifyInnerLoops(lines, innerLoops, bodyIndent, pc)
   }
 
   if (reactiveEffects) {
@@ -130,11 +132,12 @@ export function stringifyCompositeLoop(lines: string[], plan: CompositeLoopPlan)
   emitLoopChildRefs(lines, childRefs, { indent: bodyIndent, elVar: '__el', bodyIsMultiRoot })
 
   lines.push(`${bodyIndent}return __el`)
+  const loopBfId = profileLoopId ? `, ${JSON.stringify(profileLoopId)}` : ''
   if (branchClearChildren) {
     // Close inner mapArray + createDisposableEffect wrapper.
-    lines.push(`${mapArrayIndent}}, '${markerId}')`)
+    lines.push(`${mapArrayIndent}}, '${markerId}'${loopBfId})`)
     lines.push(`${topIndent}}))`)
   } else {
-    lines.push(`${topIndent}}, '${markerId}')`)
+    lines.push(`${topIndent}}, '${markerId}'${loopBfId})`)
   }
 }

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/inner-loop.ts
@@ -30,7 +30,7 @@
  *     <indent>}) }
  */
 
-import { keyAttrName } from '../../utils.ts'
+import { keyAttrName, profileBindingId } from '../../utils.ts'
 import { emitComponentAndEventSetup } from '../shared.ts'
 import { emitAttrUpdate } from '../../emit-reactive.ts'
 import { emitMultiRootTemplateCloneLines } from './template-parse.ts'
@@ -44,17 +44,18 @@ export function stringifyInnerLoops(
   lines: string[],
   plan: InnerLoopsPlan,
   indent: string,
+  pc?: string,
 ): void {
   for (const inner of plan) {
     if (inner.emit.mode === 'reactive') {
-      emitReactive(lines, inner, indent)
+      emitReactive(lines, inner, indent, pc)
     } else {
-      emitStatic(lines, inner, indent)
+      emitStatic(lines, inner, indent, pc)
     }
   }
 }
 
-function emitReactive(lines: string[], inner: InnerLoopPlan, indent: string): void {
+function emitReactive(lines: string[], inner: InnerLoopPlan, indent: string, pc: string | undefined): void {
   const uid = inner.uidSuffix
   const emit = inner.emit
   if (emit.mode !== 'reactive') return // narrow
@@ -98,16 +99,17 @@ function emitReactive(lines: string[], inner: InnerLoopPlan, indent: string): vo
     )
   }
   if (inner.childLevels.length > 0) {
-    stringifyInnerLoops(lines, inner.childLevels, `${indent}  `)
+    stringifyInnerLoops(lines, inner.childLevels, `${indent}  `, pc)
   }
   for (const text of emit.reactiveTexts) {
+    const bf = profileBindingId(pc, text.slotId)
     if (text.insideConditional) {
       // Re-query $t inside the effect: insert() may swap the text node so a
       // captured reference would silently stop updating.
-      lines.push(`${indent}  createEffect(() => { const [__rt] = $t(__innerEl${uid}, '${text.slotId}'); if (__rt) __rt.textContent = String(${text.wrappedExpression}) })`)
+      lines.push(`${indent}  createEffect(() => { const [__rt] = $t(__innerEl${uid}, '${text.slotId}'); if (__rt) __rt.textContent = String(${text.wrappedExpression}) }${bf})`)
     } else {
       lines.push(`${indent}  { const [__rt] = $t(__innerEl${uid}, '${text.slotId}')`)
-      lines.push(`${indent}  if (__rt) createEffect(() => { __rt.textContent = String(${text.wrappedExpression}) }) }`)
+      lines.push(`${indent}  if (__rt) createEffect(() => { __rt.textContent = String(${text.wrappedExpression}) }${bf}) }`)
     }
   }
   for (const attr of emit.reactiveAttrs) {
@@ -117,7 +119,7 @@ function emitReactive(lines: string[], inner: InnerLoopPlan, indent: string): vo
     for (const stmt of emitAttrUpdate(targetVar, attr.attrName, attr.wrappedExpression, attr.meta)) {
       lines.push(`${indent}    ${stmt}`)
     }
-    lines.push(`${indent}  }) }`)
+    lines.push(`${indent}  }${profileBindingId(pc, attr.slotId)}) }`)
   }
   // Imperative ref callbacks fire on every renderItem invocation, which
   // means every mount: SSR hydration, initial CSR creation, and same-key
@@ -128,10 +130,10 @@ function emitReactive(lines: string[], inner: InnerLoopPlan, indent: string): vo
     bodyIsMultiRoot: emit.bodyIsMultiRoot,
   })
   lines.push(`${indent}  return __innerEl${uid}`)
-  lines.push(`${indent}}, '${inner.markerId}') }`)
+  lines.push(`${indent}}, '${inner.markerId}'${profileBindingId(pc, inner.slotId)}) }`)
 }
 
-function emitStatic(lines: string[], inner: InnerLoopPlan, indent: string): void {
+function emitStatic(lines: string[], inner: InnerLoopPlan, indent: string, pc: string | undefined): void {
   const uid = inner.uidSuffix
   const emit = inner.emit
   if (emit.mode !== 'static') return
@@ -161,7 +163,7 @@ function emitStatic(lines: string[], inner: InnerLoopPlan, indent: string): void
     inner.outerLoopParamBindings,
   )
   if (inner.childLevels.length > 0) {
-    stringifyInnerLoops(lines, inner.childLevels, `${indent}  `)
+    stringifyInnerLoops(lines, inner.childLevels, `${indent}  `, pc)
   }
   // Imperative ref callbacks for static inner loops — fire once per
   // forEach iteration (#1244). Static arrays don't reactively re-iterate,

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop-child-arm.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop-child-arm.ts
@@ -11,7 +11,7 @@
  * every nesting depth.
  */
 
-import { varSlotId, DATA_BF_PH, keyAttrName } from '../../utils.ts'
+import { varSlotId, DATA_BF_PH, keyAttrName, profileBindingId } from '../../utils.ts'
 import { emitComponentAndEventSetup } from '../shared.ts'
 import { templateRootIsSvg } from './template-parse.ts'
 import { emitListenerLine } from './event-listener.ts'
@@ -80,6 +80,7 @@ export function stringifyBranchInnerLoops(
   lines: string[],
   plan: BranchInnerLoopsPlan,
   indent: string,
+  pc?: string,
 ): void {
   for (const inner of plan) {
     const uid = inner.uidSuffix
@@ -110,20 +111,21 @@ export function stringifyBranchInnerLoops(
       )
     }
     for (const text of inner.reactiveTexts) {
+      const bf = profileBindingId(pc, text.slotId)
       if (text.insideConditional) {
         // Re-query $t inside the effect: insert() may swap the text node so a
         // captured reference would silently stop updating.
-        lines.push(`${indent}  createEffect(() => { const [__rt] = $t(__bel${uid}, '${text.slotId}'); if (__rt) __rt.textContent = String(${text.wrappedExpression}) })`)
+        lines.push(`${indent}  createEffect(() => { const [__rt] = $t(__bel${uid}, '${text.slotId}'); if (__rt) __rt.textContent = String(${text.wrappedExpression}) }${bf})`)
       } else {
         lines.push(`${indent}  { const [__rt] = $t(__bel${uid}, '${text.slotId}')`)
-        lines.push(`${indent}  if (__rt) createEffect(() => { __rt.textContent = String(${text.wrappedExpression}) }) }`)
+        lines.push(`${indent}  if (__rt) createEffect(() => { __rt.textContent = String(${text.wrappedExpression}) }${bf}) }`)
       }
     }
     if (inner.nestedConditionals.length > 0) {
-      stringifyLoopChildConditionals(lines, inner.nestedConditionals, `${indent}  `)
+      stringifyLoopChildConditionals(lines, inner.nestedConditionals, `${indent}  `, pc)
     }
     lines.push(`${indent}  return __bel${uid}`)
-    lines.push(`${indent}}, '${inner.markerId}') }`)
+    lines.push(`${indent}}, '${inner.markerId}'${profileBindingId(pc, inner.slotId)}) }`)
   }
 }
 
@@ -138,9 +140,10 @@ export function stringifyLoopChildConditionals(
   lines: string[],
   conditionals: readonly LoopChildConditionalPlan[],
   indent: string,
+  pc?: string,
 ): void {
   for (const cond of conditionals) {
-    stringifyLoopChildConditional(lines, cond, indent)
+    stringifyLoopChildConditional(lines, cond, indent, pc)
   }
 }
 
@@ -148,6 +151,7 @@ function stringifyLoopChildConditional(
   lines: string[],
   cond: LoopChildConditionalPlan,
   indent: string,
+  pc: string | undefined,
 ): void {
   const armIndent = `${indent}    `
   // Body-form arrows wire `__bfSlot` captures into the runtime so live
@@ -157,28 +161,29 @@ function stringifyLoopChildConditional(
   lines.push(`${indent}insert(${cond.scopeVar}, '${cond.slotId}', () => ${cond.wrappedCondition}, {`)
   lines.push(`${indent}  template: () => { const __slots = []; return { html: \`${cond.whenTrueTemplateHtml}\`, slots: __slots } },`)
   lines.push(`${indent}  bindEvents: (__branchScope, { isFirstRun: __bfFirstRun = false } = {}) => {`)
-  stringifyLoopChildArm(lines, cond.whenTrueArm, armIndent)
+  stringifyLoopChildArm(lines, cond.whenTrueArm, armIndent, pc)
   lines.push(`${indent}  }`)
   lines.push(`${indent}}, {`)
   lines.push(`${indent}  template: () => { const __slots = []; return { html: \`${cond.whenFalseTemplateHtml}\`, slots: __slots } },`)
   lines.push(`${indent}  bindEvents: (__branchScope, { isFirstRun: __bfFirstRun = false } = {}) => {`)
-  stringifyLoopChildArm(lines, cond.whenFalseArm, armIndent)
+  stringifyLoopChildArm(lines, cond.whenFalseArm, armIndent, pc)
   lines.push(`${indent}  }`)
-  lines.push(`${indent}})`)
+  lines.push(`${indent}}${profileBindingId(pc, cond.slotId)})`)
 }
 
 function stringifyLoopChildArm(
   lines: string[],
   arm: LoopChildArmPlan,
   armIndent: string,
+  pc: string | undefined,
 ): void {
   stringifyBranchEventBindings(lines, arm.events, armIndent)
   stringifyBranchChildComponentInits(lines, arm.childComponents, armIndent)
-  stringifyBranchInnerLoops(lines, arm.innerLoops, armIndent)
-  stringifyLoopChildConditionals(lines, arm.nestedConditionals, armIndent)
+  stringifyBranchInnerLoops(lines, arm.innerLoops, armIndent, pc)
+  stringifyLoopChildConditionals(lines, arm.nestedConditionals, armIndent, pc)
   for (const text of arm.texts) {
     const varName = `__rt_${varSlotId(text.slotId)}`
     lines.push(`${armIndent}{ const [${varName}] = $t(__branchScope, '${text.slotId}')`)
-    lines.push(`${armIndent}if (${varName}) createEffect(() => { ${varName}.textContent = String(${text.wrappedExpression}) }) }`)
+    lines.push(`${armIndent}if (${varName}) createEffect(() => { ${varName}.textContent = String(${text.wrappedExpression}) }${profileBindingId(pc, text.slotId)}) }`)
   }
 }

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
@@ -24,7 +24,7 @@
  * passed in via `topIndent`.
  */
 
-import { emitRefCall, varSlotId } from '../../utils.ts'
+import { emitRefCall, varSlotId, profileBindingId } from '../../utils.ts'
 import { emitAttrUpdate } from '../../emit-reactive.ts'
 import { stringifyReactiveEffects } from './reactive-effects.ts'
 import { emitTemplateCloneInline, emitLoopItemElementSetup } from './template-parse.ts'
@@ -218,7 +218,7 @@ function stringifyAnchoredLoop(
 }
 
 export function stringifyStaticLoop(lines: string[], plan: StaticLoopPlan): void {
-  const { containerVar, arrayExpr, param, indexParam, childIndexExpr, attrsBySlot, texts, childRefs, csrMaterialize } = plan
+  const { containerVar, arrayExpr, param, indexParam, childIndexExpr, attrsBySlot, texts, childRefs, csrMaterialize, profileComponentName: pc } = plan
   const hasAttrs = attrsBySlot.length > 0
   const hasTexts = texts.length > 0
   const hasRefs = childRefs.length > 0
@@ -300,14 +300,14 @@ export function stringifyStaticLoop(lines: string[], plan: StaticLoopPlan): void
       for (const stmt of emitAttrUpdate(varName, attr.attrName, attr.expression, attr)) {
         lines.push(`            ${stmt}`)
       }
-      lines.push(`          })`)
+      lines.push(`          }${profileBindingId(pc, slotId)})`)
     }
     lines.push(`        }`)
   }
   for (const text of texts) {
     const vn = `__rt_${varSlotId(text.slotId)}`
     lines.push(`        { const [${vn}] = $t(__iterEl, '${text.slotId}')`)
-    lines.push(`        if (${vn}) createEffect(() => { ${vn}.textContent = String(${text.expression}) }) }`)
+    lines.push(`        if (${vn}) createEffect(() => { ${vn}.textContent = String(${text.expression}) }${profileBindingId(pc, text.slotId)}) }`)
   }
   // Ref callbacks fire on every forEach iteration — initial mount and any
   // future array-change-driven re-iteration (#1244). For static arrays the

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/reactive-effects.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/reactive-effects.ts
@@ -8,7 +8,7 @@
  * `loop-child-arm.ts` — no legacy passthrough remains.
  */
 
-import { varSlotId } from '../../utils.ts'
+import { varSlotId, profileBindingId } from '../../utils.ts'
 import { emitAttrUpdate } from '../../emit-reactive.ts'
 import {
   stringifyBranchChildComponentInits,
@@ -49,14 +49,8 @@ export function stringifyReactiveEffects(
 ): void {
   const { indent, elVar, bodyIsMultiRoot } = opts
   const lookup = bodyIsMultiRoot ? 'qsaItem' : 'qsa'
-
-  // Profile mode (#1690, SR4, #1795 Phase 2): a loop-child binding effect's id,
-  // resolved from its text/attribute `domBinding` (slot + loc). Empty when off
-  // → byte-identical (SR8).
-  const bindingBfId = (slotId: string): string =>
-    plan.profileComponentName
-      ? `, ${JSON.stringify(`${plan.profileComponentName}#binding:${slotId}`)}`
-      : ''
+  const pc = plan.profileComponentName
+  const bindingBfId = (slotId: string): string => profileBindingId(pc, slotId)
 
   // 1. Reactive attribute effects (one qsa per slot, then per-attr createEffect).
   for (const slot of plan.attrSlots) {
@@ -81,7 +75,7 @@ export function stringifyReactiveEffects(
   // 3. Reactive conditionals — each emits an insert(...) over `elVar` whose
   //    arm bodies dispatch through the per-arm stringifiers.
   for (const cond of plan.conditionals) {
-    emitOuterConditional(lines, indent, elVar, cond)
+    emitOuterConditional(lines, indent, elVar, cond, pc)
   }
 }
 
@@ -102,6 +96,7 @@ function emitOuterConditional(
   indent: string,
   elVar: string,
   cond: NestedConditionalPlan,
+  pc: string | undefined,
 ): void {
   const armIndent = `${indent}    `
 
@@ -110,28 +105,28 @@ function emitOuterConditional(
   lines.push(`${indent}insert(${elVar}, '${cond.slotId}', () => ${cond.wrappedCondition}, {`)
   lines.push(`${indent}  template: () => { const __slots = []; return { html: \`${cond.whenTrueTemplateHtml}\`, slots: __slots } },`)
   lines.push(`${indent}  bindEvents: (__branchScope, { isFirstRun: __bfFirstRun = false } = {}) => {`)
-  emitArmBody(lines, cond.whenTrueArm, armIndent)
+  emitArmBody(lines, cond.whenTrueArm, armIndent, pc)
   lines.push(`${indent}  }`)
   lines.push(`${indent}}, {`)
   lines.push(`${indent}  template: () => { const __slots = []; return { html: \`${cond.whenFalseTemplateHtml}\`, slots: __slots } },`)
   lines.push(`${indent}  bindEvents: (__branchScope, { isFirstRun: __bfFirstRun = false } = {}) => {`)
-  emitArmBody(lines, cond.whenFalseArm, armIndent)
+  emitArmBody(lines, cond.whenFalseArm, armIndent, pc)
   lines.push(`${indent}  }`)
-  lines.push(`${indent}})`)
+  lines.push(`${indent}}${profileBindingId(pc, cond.slotId)})`)
 }
 
-function emitArmBody(lines: string[], arm: LoopChildArmPlan, armIndent: string): void {
+function emitArmBody(lines: string[], arm: LoopChildArmPlan, armIndent: string, pc: string | undefined): void {
   stringifyBranchEventBindings(lines, arm.events, armIndent)
   stringifyBranchChildComponentInits(lines, arm.childComponents, armIndent)
-  stringifyBranchInnerLoops(lines, arm.innerLoops, armIndent)
-  stringifyLoopChildConditionals(lines, arm.nestedConditionals, armIndent)
+  stringifyBranchInnerLoops(lines, arm.innerLoops, armIndent, pc)
+  stringifyLoopChildConditionals(lines, arm.nestedConditionals, armIndent, pc)
   for (const text of arm.texts) {
-    emitArmText(lines, armIndent, text)
+    emitArmText(lines, armIndent, text, pc)
   }
 }
 
-function emitArmText(lines: string[], indent: string, text: LoopChildArmText): void {
+function emitArmText(lines: string[], indent: string, text: LoopChildArmText, pc: string | undefined): void {
   const varName = `__rt_${varSlotId(text.slotId)}`
   lines.push(`${indent}{ const [${varName}] = $t(__branchScope, '${text.slotId}')`)
-  lines.push(`${indent}if (${varName}) createEffect(() => { ${varName}.textContent = String(${text.wrappedExpression}) }) }`)
+  lines.push(`${indent}if (${varName}) createEffect(() => { ${varName}.textContent = String(${text.wrappedExpression}) }${profileBindingId(pc, text.slotId)}) }`)
 }

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -51,6 +51,18 @@ export function varSlotId(slotId: string): string {
 }
 
 /**
+ * Profile-mode DOM-binding id suffix (#1690, SR4). Returns the trailing
+ * `, "<Component>#binding:<slotId>"` argument for a binding effect's
+ * `createEffect` / `createDisposableEffect` / `insert` / `mapArray` call when
+ * `componentName` is set (profile on), else `''` so the emitted code stays
+ * byte-identical (SR8). Centralised so every binding emit site — top-level,
+ * conditional branch, loop child, inner loop — uses one id convention.
+ */
+export function profileBindingId(componentName: string | undefined, slotId: string): string {
+  return componentName ? `, ${JSON.stringify(`${componentName}#binding:${slotId}`)}` : ''
+}
+
+/**
  * Convert a `template` variant's parts into a JS template-literal string.
  * Shared by both `attrValueToString` and any consumer that wants to flatten
  * a structured template into JS-level concatenation.

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -57,9 +57,16 @@ export function varSlotId(slotId: string): string {
  * `componentName` is set (profile on), else `''` so the emitted code stays
  * byte-identical (SR8). Centralised so every binding emit site — top-level,
  * conditional branch, loop child, inner loop — uses one id convention.
+ *
+ * A `'?'` slotId (an inner loop whose container element carries no `bf` slot
+ * marker) is NOT emittable: `buildIdIndex` keys on real `domBinding` slotIds, so
+ * `#binding:?` could never resolve and would be a guaranteed coverage gap. The
+ * analyzer likewise emits no `domBinding` for a slot-less loop, so suppressing
+ * the id here keeps both sides silent and consistent.
  */
 export function profileBindingId(componentName: string | undefined, slotId: string): string {
-  return componentName ? `, ${JSON.stringify(`${componentName}#binding:${slotId}`)}` : ''
+  if (!componentName || slotId === '?') return ''
+  return `, ${JSON.stringify(`${componentName}#binding:${slotId}`)}`
 }
 
 /**


### PR DESCRIPTION
## What

Phase 3 of #1795 — closes the remaining nested loop binding-effect emit paths. After this, every binding effect a loop produces carries a `<Component>#binding:<slotId>` id and every emitted id resolves via `buildIdIndex`, so `bf debug profile` reports **zero coverage gap** for nested list/conditional structures.

Phases 1–2 (merged) covered top-level, conditional-branch, and direct loop-child bindings. The residuals this closes:
- loop-child conditional `insert()` + its branch text (`emitArmText`)
- inner / nested loop `mapArray` + inner-loop child text/attr effects
- branch-scoped loop `mapArray` (a loop inside a conditional)
- static-array loop child text/attr effects
- composite & component loop `mapArray`

## How

- **analyzer** (`collectDomBindings`) — loop-param awareness extends to the `conditional` case (via `origin.freeRefs`) and the inner-`loop` case (via `arrayFreeIdentifiers`), so `{r.on ? …}` and `{r.tags.map(…)}` register as reactive `domBindings` with slot + loc. (Continues the lexer-aware approach from Phase 2 — no raw-string scans.)
- **emit** — `profileComponentName` threaded through the remaining loop stringifiers; every binding emit site now uses one shared `profileBindingId(pc, slotId)` helper (added to `utils.ts`), replacing the per-file inline id builders.
- Inner-loop / composite / component / branch / static loop plans gained the `slotId` / `profileLoopId` they needed (the loop node shares its container element's slot).

## Verification

- New test `profile-nested-binding-ids.test.ts` (6): profile-off has no `#binding:` across all nested shapes (SR8); a deeply-nested loop+conditional+inner-loop emits 5 ids all resolving; branch-scoped loop, static loop, and component loop each attribute their effects with **zero unresolved**.
- Full `@barefootjs/jsx` suite **2051 pass / 0 fail** (snapshots unchanged → SR8 holds), CSR conformance **124**, `@barefootjs/client` **349**, typecheck + biome clean.

## Residual

One case remains out of scope: a child component's reactive *children* text inside a component loop (`<Row>{it.label}</Row>`) — that's a component-children binding, not a DOM binding, and isn't resolved by the analyzer. Noted in the changeset.

Follow-ups from the same discussion: a **profiler coverage-conformance test** (CI guard that asserts unattributed = 0, so a future emit path that forgets instrumentation fails loudly) and **#1796** (auto-scenario driver reaching child-component handlers) — both queued next.

https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN)_