### PR TITLE
Auto-scenario reaches compound child-component handlers (#1690, closes #1796)

### DIFF
--- a/.changeset/profiler-auto-scenario-compound.md
+++ b/.changeset/profiler-auto-scenario-compound.md
@@ -1,0 +1,17 @@
+---
+"@barefootjs/cli": minor
+---
+
+`bf debug profile <component> --scenario auto` now reaches compound / child-component handlers (#1690, closes #1796).
+
+Auto mode previously compiled only the target's own file. For a compound
+component whose interactive handler lives in a separately-registered child
+(`<Collapsible><CollapsibleTrigger/>…`), the child was never compiled, so it
+never registered, the mount couldn't wire it, and handler discovery read
+`0 turns, 0/0 handlers` even though the composition has handlers.
+
+Auto mode now walks the target's local (relative) import graph — the same
+dependency-first resolution the `--scenario <story.tsx>` path already used —
+so every child component registers via `hydrate(...)` before the root mounts,
+its handlers enter the discovery set, and the toggle/click fires through the
+composition. No story file required.

--- a/packages/cli/src/__tests__/scenario-driver.test.ts
+++ b/packages/cli/src/__tests__/scenario-driver.test.ts
@@ -61,6 +61,41 @@ describe('runAutoScenario', () => {
     expect(r.fired).toBeGreaterThanOrEqual(2) // one per rendered row
   })
 
+  test('reaches a separately-imported child component handler (#1796)', async () => {
+    // The compound case: the target file has no handler of its own; the toggle
+    // lives in a child component imported from a sibling file. Auto mode must
+    // load the import graph (like a story) so the child registers, the mount
+    // wires it, and its handler fires — instead of silently reading 0/0.
+    const dir = mkdtempSync(join(tmpdir(), 'bf-compound-'))
+    try {
+      writeFileSync(join(dir, 'trigger.tsx'), `
+        'use client'
+        import { createSignal } from '@barefootjs/client'
+        export function Trigger() {
+          const [n, setN] = createSignal(0)
+          return <button onClick={() => setN(n() + 1)}>{n()}</button>
+        }
+      `)
+      const panelPath = join(dir, 'panel.tsx')
+      const panelSrc = `
+        'use client'
+        import { Trigger } from './trigger'
+        export function Panel() { return <div><Trigger /></div> }
+      `
+      writeFileSync(panelPath, panelSrc)
+
+      const r = await runAutoScenario(panelSrc, panelPath, 'Panel')
+      // The child source was pulled in (dependency first, target last).
+      expect(r.sources.map(s => s.filePath.split('/').pop())).toEqual(['trigger.tsx', 'panel.tsx'])
+      // The child's handler fired and opened a real turn — not 0/0.
+      expect(r.fired).toBeGreaterThanOrEqual(1)
+      const turn = r.events.find(e => e.type === 'turnBegin')
+      expect(turn?.handlerId).toMatch(/^Trigger#handler:s\d+:click$/)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
   test('a component with no handler records no interaction turns', async () => {
     const DISPLAY = `
       'use client'

--- a/packages/cli/src/__tests__/scenario-driver.test.ts
+++ b/packages/cli/src/__tests__/scenario-driver.test.ts
@@ -149,4 +149,38 @@ describe('runFileScenario (composition, #1796)', () => {
       rmSync(dir, { recursive: true, force: true })
     }
   })
+
+  test('a missing scenario file throws the specific "Cannot read" error', async () => {
+    // `loadWithLocalImports` must return [] for an unresolvable entry so the
+    // file path surfaces this error rather than the generic "No client JS".
+    await expect(runFileScenario('/nope/does-not-exist.tsx')).rejects.toThrow(/Cannot read scenario file/)
+  })
+
+  test('a directory entry (→ index.tsx) resolves imports from the index file dir', async () => {
+    // The entry spec is a directory; it maps to `<dir>/index.tsx`. Its relative
+    // imports must resolve from the index file's directory, not the spec's.
+    const dir = mkdtempSync(join(tmpdir(), 'bf-index-'))
+    try {
+      writeFileSync(join(dir, 'knob.tsx'), `
+        'use client'
+        import { createSignal } from '@barefootjs/client'
+        export function Knob() {
+          const [n, setN] = createSignal(0)
+          return <button onClick={() => setN(n() + 1)}>{n()}</button>
+        }
+      `)
+      writeFileSync(join(dir, 'index.tsx'), `
+        import { Knob } from './knob'
+        export function Root() { return <section><Knob /></section> }
+      `)
+
+      // Pass the directory as the scenario "file" — resolveLocalFile maps it to index.tsx.
+      const r = await runFileScenario(dir)
+      expect(r.sources.map(s => s.filePath.split('/').pop())).toEqual(['knob.tsx', 'index.tsx'])
+      const turn = r.events.find(e => e.type === 'turnBegin')
+      expect(turn?.handlerId).toMatch(/^Knob#handler:s\d+:click$/)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
 })

--- a/packages/cli/src/lib/scenario-driver.ts
+++ b/packages/cli/src/lib/scenario-driver.ts
@@ -117,26 +117,49 @@ function resolveLocalFile(spec: string): string | null {
 }
 
 /**
- * Load a scenario "story" file and its local (relative) imports into a flat,
- * dependency-first source list — so a story composing a headless component
- * (`<Collapsible><CollapsibleTrigger/>…`) brings every piece it needs.
+ * Walk a file's transitive local (relative) imports into a flat,
+ * dependency-first source list — so a component (or story) that composes
+ * separately-registered children (`<Collapsible><CollapsibleTrigger/>…`)
+ * brings every piece it needs: each child registers via `hydrate(...)` before
+ * the root mounts, and its handlers enter the discovery set.
+ *
+ * `seedSource` lets the caller supply already-read content for the entry file
+ * (the `bf debug profile <component>` path reads it before resolving), avoiding
+ * a redundant disk read and honouring any in-memory override.
  */
-function loadStory(storyPath: string): SourceFile[] {
+function loadWithLocalImports(entryPath: string, seedSource?: string): SourceFile[] {
   const out: SourceFile[] = []
   const visited = new Set<string>()
-  const visit = (p: string): void => {
+  const visitImport = (p: string): void => {
     const resolved = resolveLocalFile(p)
     if (!resolved || visited.has(resolved)) return
     visited.add(resolved)
     const source = readFileSync(resolved, 'utf-8')
-    // Visit local imports first so their components register before the story's.
     for (const m of source.matchAll(/from\s+['"](\.[^'"]+)['"]/g)) {
-      visit(join(dirname(resolved), m[1]))
+      visitImport(join(dirname(resolved), m[1]))
     }
     out.push({ source, filePath: resolved })
   }
-  visit(storyPath)
+  // The entry is always included from its seed (or disk). Its filePath may be
+  // synthetic (in-memory tests, stdin) and need not exist on disk; only its
+  // local imports are resolved against the filesystem — missing ones are
+  // skipped so a partial/standalone component still profiles.
+  const entryResolved = resolveLocalFile(entryPath)
+  if (entryResolved) visited.add(entryResolved)
+  const entrySource = seedSource ?? (entryResolved ? readFileSync(entryResolved, 'utf-8') : '')
+  for (const m of entrySource.matchAll(/from\s+['"](\.[^'"]+)['"]/g)) {
+    visitImport(join(dirname(entryPath), m[1]))
+  }
+  out.push({ source: entrySource, filePath: entryResolved ?? entryPath })
   return out
+}
+
+/**
+ * Load a scenario "story" file and its local imports (see
+ * `loadWithLocalImports`).
+ */
+function loadStory(storyPath: string): SourceFile[] {
+  return loadWithLocalImports(storyPath)
 }
 
 /**
@@ -268,7 +291,15 @@ export async function runAutoScenario(
   filePath: string,
   componentName?: string,
 ): Promise<ScenarioResult> {
-  return runScenario([{ source, filePath }], componentName)
+  // Pull in the target's local child-component imports (#1796): a compound
+  // component (`<Collapsible><CollapsibleTrigger/>…`) keeps its toggle handler
+  // in a separately-registered child. Without the child's source compiled, the
+  // child never registers, the mount can't wire it, and handler discovery reads
+  // 0/0 even though the composition has handlers. Loading the import graph
+  // (dependency-first, root last) registers every child and surfaces their
+  // handlers — matching what `--scenario <story.tsx>` does, with no story file.
+  const sources = loadWithLocalImports(filePath, source)
+  return runScenario(sources, componentName)
 }
 
 /**

--- a/packages/cli/src/lib/scenario-driver.ts
+++ b/packages/cli/src/lib/scenario-driver.ts
@@ -140,15 +140,23 @@ function loadWithLocalImports(entryPath: string, seedSource?: string): SourceFil
     }
     out.push({ source, filePath: resolved })
   }
-  // The entry is always included from its seed (or disk). Its filePath may be
-  // synthetic (in-memory tests, stdin) and need not exist on disk; only its
-  // local imports are resolved against the filesystem — missing ones are
-  // skipped so a partial/standalone component still profiles.
+  // Resolve the entry on disk. With no seed AND no on-disk file there is
+  // nothing to load — return empty so `runFileScenario` still surfaces its
+  // specific "Cannot read scenario file" error for a missing story path
+  // (the auto path always supplies `seedSource`, so it is unaffected).
   const entryResolved = resolveLocalFile(entryPath)
+  if (seedSource === undefined && !entryResolved) return out
+  // The entry is included from its seed (or disk). Its `filePath` may be
+  // synthetic (in-memory tests, stdin) and need not exist on disk. Resolve its
+  // local imports against the *resolved* file's directory (so a directory spec
+  // that maps to `…/index.tsx` resolves siblings correctly), falling back to the
+  // entry spec's dir when synthetic; missing imports are skipped so a
+  // partial/standalone component still profiles.
   if (entryResolved) visited.add(entryResolved)
-  const entrySource = seedSource ?? (entryResolved ? readFileSync(entryResolved, 'utf-8') : '')
+  const entrySource = seedSource ?? readFileSync(entryResolved!, 'utf-8')
+  const entryDir = dirname(entryResolved ?? entryPath)
   for (const m of entrySource.matchAll(/from\s+['"](\.[^'"]+)['"]/g)) {
-    visitImport(join(dirname(entryPath), m[1]))
+    visitImport(join(entryDir, m[1]))
   }
   out.push({ source: entrySource, filePath: entryResolved ?? entryPath })
   return out


### PR DESCRIPTION
## What

Task ③ — closes #1796. `bf debug profile <component> --scenario auto` now reaches **compound / child-component handlers** instead of reporting `0 turns, 0/0 handlers`.

This is an independent CLI/driver change (base `main`), not part of the compiler binding-id stack.

## Problem

Auto mode compiled **only the target's own file**. For a compound component whose interactive handler lives in a separately-registered child (`<Collapsible><CollapsibleTrigger/>…`), the child source was never compiled → never registered via `hydrate(...)` → the mount couldn't wire it → handler discovery found nothing → `0/0`, even though the composition clearly has handlers.

## Fix (issue option 1)

`runAutoScenario` now walks the target's local (relative) **import graph** — the exact dependency-first resolution the `--scenario <story.tsx>` path already used, factored out into a shared `loadWithLocalImports` helper. Every child component registers before the root mounts, its handlers enter the discovery set, and the toggle/click fires through the composition. No story file required.

The entry file is always included from its in-memory seed (its `filePath` may be synthetic, e.g. tests/stdin); only its imports are resolved against the filesystem, with missing ones skipped so a standalone component still profiles.

## Verification

- New test: a `Panel` that imports a sibling `Trigger` (with the only `onClick`) — auto mode now loads both (`['trigger.tsx', 'panel.tsx']`), fires the child handler, and opens a real `Trigger#handler:s…:click` turn. Reproduced the old `0/0` → now `fired ≥ 1`.
- Full `@barefootjs/cli` suite **759 pass / 0 fail** (existing synthetic-path tests still green after the seed-vs-disk fix).

## Scope note

This covers the canonical case from the issue (handler in a separately-registered child with a JSX event). One residual remains: a component that wires its toggle via an **imperative** `el.addEventListener` in user code (e.g. a ref-based pattern) — the generic clickable sweep still clicks it, but no turn is recorded because user-imperative listeners aren't turn-wrapped by the compiler. That's a distinct limitation from #1796's "child in a separate file" report and would be its own follow-up.

https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKoFBMV1qnLrNNd1fRNMPN)_