### PR TITLE
test(e2e): de-flake dashboard chart bar selection test

### DIFF
--- a/site/ui/e2e/dashboard-builder.spec.ts
+++ b/site/ui/e2e/dashboard-builder.spec.ts
@@ -174,13 +174,24 @@ test.describe('Dashboard Builder Block', () => {
       await s.locator('.add-chart-btn').click()
 
       const newChart = s.locator('.chart-widget').last()
-      const before = await newChart.locator('.chart-selected-label').textContent()
+      const label = newChart.locator('.chart-selected-label')
+      const firstBar = newChart.locator('.chart-bar').first()
 
-      // Clicking a bar selects it and updates the label
-      await newChart.locator('.chart-bar').first().click()
+      // No bar is selected initially, so the label shows the default 'Total'.
+      await expect(label).toHaveText('Total')
 
-      const after = await newChart.locator('.chart-selected-label').textContent()
-      expect(after).not.toBe(before)
+      // The widget mounts dynamically, so its first click can race hydration.
+      // Re-click until the bar reports selected (aria-pressed guards against
+      // toggling an already-selected bar back off).
+      await expect(async () => {
+        if ((await firstBar.getAttribute('aria-pressed')) !== 'true') {
+          await firstBar.click()
+        }
+        await expect(firstBar).toHaveAttribute('aria-pressed', 'true')
+      }).toPass()
+
+      // Selecting a bar swaps the label away from the 'Total' default.
+      await expect(label).not.toHaveText('Total')
     })
   })
 


### PR DESCRIPTION
## Problem

`e2e/dashboard-builder.spec.ts` › "new chart widget responds to its own bar selection" is flaky:

```
Error: expect(received).not.toBe(expected) // Object.is equality
Expected: not "Total"
> 183 |       expect(after).not.toBe(before)
```

The test added a chart widget, then read `.chart-selected-label` via `textContent()` **once** and compared with a **non-retrying** `expect`. None of the chart presets use the label `"Total"` (they're `Mon`/`Q1`/`A`/…), so this is not a logic bug — it's a race:

- The widget mounts **dynamically**, so its first bar click can land before hydration completes (click dropped), or
- the reactive label update can lag the single `textContent()` snapshot read.

Either way the label stays at its `'Total'` default and the assertion fails.

## Fix

- Use Playwright **web-first auto-retrying** assertions instead of one-shot `textContent()` snapshots.
- Re-click the bar until it reports `aria-pressed="true"`, guarded so an already-selected bar is never toggled back off.
- Then assert the label moves off the `'Total'` default.

## Testing

Browser binaries can't be downloaded in this container (network policy), so the E2E suite couldn't be run here. The spec file type-checks cleanly. The change is logic-preserving — it only swaps non-retrying reads/assertions for auto-retrying ones plus a hydration-safe re-click.

https://claude.ai/code/session_015cY5y1c9YQxdbDksF66zGD

---
_Generated by [Claude Code](https://claude.ai/code/session_015cY5y1c9YQxdbDksF66zGD)_