### PR TITLE
fix(cli): attribute imported components and quiet runtime-id coverage noise in auto profile

### DIFF
--- a/.changeset/profiler-auto-imports-coverage.md
+++ b/.changeset/profiler-auto-imports-coverage.md
@@ -1,6 +1,6 @@
 ---
 "@barefootjs/cli": patch
-"@barefootjs/jsx": patch
+"@barefootjs/jsx": minor
 ---
 
 `bf debug profile --scenario auto` now attributes imported child components and quiets runtime-bookkeeping coverage noise (#1840).

--- a/.changeset/profiler-auto-imports-coverage.md
+++ b/.changeset/profiler-auto-imports-coverage.md
@@ -1,0 +1,22 @@
+---
+"@barefootjs/cli": patch
+"@barefootjs/jsx": patch
+---
+
+`bf debug profile --scenario auto` now attributes imported child components and quiets runtime-bookkeeping coverage noise (#1840).
+
+Two related attribution/coverage fixes:
+
+- **Imported child sources reach the id index.** Auto mode loaded a target's
+  local imports to drive the run, but did not pass them into
+  `buildProfileReport`, so events from composed children (e.g. `DatePicker`
+  importing `Calendar`) resolved to `((unresolved))`. Auto mode now forwards
+  those imported sources the same way the `--scenario <story.tsx>` path does,
+  so `Calendar#binding:*` subscribers map back to their source location.
+
+- **Anonymous runtime ids no longer masquerade as coverage gaps.** The reactive
+  runtime assigns fallback `s<n>`/`e<n>`/`m<n>`/`r<n>` ids to nodes with no
+  compiler `__bfId`. These can never map to a source node, so reporting them as
+  `coverage.unattributed` made healthy reports look broken. `joinProfilerEvents`
+  now routes them to a separate non-actionable `diagnostics` bucket (surfaced,
+  never dropped), leaving `unattributed` for actionable gaps only.

--- a/packages/cli/src/commands/debug-profile.ts
+++ b/packages/cli/src/commands/debug-profile.ts
@@ -74,10 +74,13 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
       const { events, fired, sources } = isAuto
         ? await runAutoScenario(source, resolved.filePath, resolved.componentName)
         : await runFileScenario(flags.scenario)
-      // The story (the last source — deps are loaded first) drives
-      // componentName/sourceFile; the rest merge into the id index.
+      // Both modes load the entry/story last (its local imports are loaded
+      // first), so the entry drives componentName/sourceFile and its imported
+      // children merge into the id index. Auto mode must pass those imports too
+      // (#1840): a compound component like DatePicker imports Calendar, whose
+      // `Calendar#binding:*` subscribers otherwise resolve to `((unresolved))`.
       const primary = isAuto ? { source, filePath: resolved.filePath } : sources[sources.length - 1]
-      const extraSources = isAuto ? [] : sources.slice(0, -1)
+      const extraSources = sources.slice(0, -1)
       const report = buildProfileReport({
         source: primary.source,
         filePath: primary.filePath,

--- a/packages/jsx/src/__tests__/profiler.test.ts
+++ b/packages/jsx/src/__tests__/profiler.test.ts
@@ -184,6 +184,22 @@ describe('buildIdIndex + joinProfilerEvents (SR4 join)', () => {
     expect(joined[0].subscriber).toBeUndefined()
     expect(unattributed).toEqual([{ id: 'Calc#effect:does-not-exist', count: 2 }])
   })
+
+  test('routes anonymous runtime ids to diagnostics, not the actionable gap list (#1840)', () => {
+    const events = [
+      // Compiler id the IR can't place → actionable gap.
+      ev('effectEnter', { subscriber: 'Calc#effect:does-not-exist' }),
+      // Anonymous runtime bookkeeping ids (no compiler __bfId) → non-actionable.
+      ev('signalSet', { signal: 's9' }),
+      ev('signalSet', { signal: 's10' }),
+      ev('effectEnter', { subscriber: 'r10' }),
+      ev('effectEnter', { subscriber: 'e3' }),
+    ]
+    const { joined, unattributed, diagnostics } = joinProfilerEvents(events, index)
+    expect(joined).toHaveLength(5) // nothing dropped
+    expect(unattributed.map(u => u.id)).toEqual(['Calc#effect:does-not-exist'])
+    expect(diagnostics.map(u => u.id).sort()).toEqual(['e3', 'r10', 's10', 's9'])
+  })
 })
 
 describe('buildProfileReport (dynamic, SR1–SR4 + analyses)', () => {

--- a/packages/jsx/src/profiler.ts
+++ b/packages/jsx/src/profiler.ts
@@ -394,11 +394,33 @@ export interface JoinedEvent {
 export interface JoinResult {
   joined: JoinedEvent[]
   /**
-   * Ids referenced by the stream that the IR did not resolve — surfaced, never
+   * Actionable coverage gaps: ids shaped like a compiler profiler id
+   * (`<Component>#<kind>:<rest>`) that the IR did not resolve — surfaced, never
    * dropped (SR4 invariant). A non-empty list is the honest coverage caveat the
-   * analyses print.
+   * analyses print: something the IR *should* have explained but didn't.
    */
   unattributed: UnattributedId[]
+  /**
+   * Non-actionable runtime bookkeeping ids (`s9`, `e3`, `m7`, `r10`) — anonymous
+   * reactive nodes the compiler never named (see `isRuntimeBookkeepingId`).
+   * Kept separate from `unattributed` so the coverage report focuses on real,
+   * fixable gaps instead of internal slot/ref noise, but still surfaced (never
+   * dropped) so the SR4 "account for every id" invariant holds.
+   */
+  diagnostics: UnattributedId[]
+}
+
+/**
+ * True for the reactive runtime's *fallback* ids — the synthetic `s<n>`
+ * (signal), `e<n>` (effect), `m<n>` (memo), and `r<n>` (root) sequences
+ * `reactive.ts` assigns when a node carries no compiler `__bfId`. These name
+ * anonymous internal machinery, never a source location, so they can never be
+ * attributed to an IR node. Treating them as coverage gaps makes a healthy
+ * report look broken (#1840); they belong in the non-actionable diagnostics
+ * bucket instead. Compiler ids always carry a `#`, so they never match.
+ */
+function isRuntimeBookkeepingId(id: string): boolean {
+  return /^[serm]\d+$/.test(id)
 }
 
 /**
@@ -426,11 +448,16 @@ export function joinProfilerEvents(events: readonly ProfilerEvent[], index: IdIn
     })
   }
 
-  const unattributed = [...gaps.entries()]
-    .map(([id, count]) => ({ id, count }))
-    .sort((a, b) => b.count - a.count)
+  const unattributed: UnattributedId[] = []
+  const diagnostics: UnattributedId[] = []
+  for (const [id, count] of gaps.entries()) {
+    ;(isRuntimeBookkeepingId(id) ? diagnostics : unattributed).push({ id, count })
+  }
+  const byCount = (a: UnattributedId, b: UnattributedId): number => b.count - a.count
+  unattributed.sort(byCount)
+  diagnostics.sort(byCount)
 
-  return { joined, unattributed }
+  return { joined, unattributed, diagnostics }
 }
 
 // -- Analysis: hot subscribers (v1, §4.2.1) -----------------------------------
@@ -852,8 +879,14 @@ export interface ProfileCoverage {
   handlersFired: number
   /** Handlers the IR knows about (`buildEventSummary`). */
   handlersTotal: number
-  /** SR4 ids the IR could not resolve — the honest gap. */
+  /** SR4 ids the IR could not resolve — the honest, actionable gap. */
   unattributed: UnattributedId[]
+  /**
+   * Anonymous runtime bookkeeping ids (`s*`/`e*`/`m*`/`r*`) that have no source
+   * node — non-actionable noise, kept out of `unattributed` so the gap list
+   * stays meaningful, but reported here so nothing is silently dropped.
+   */
+  diagnostics: UnattributedId[]
 }
 
 export interface ProfileReport {
@@ -940,7 +973,7 @@ export function buildProfileReport(input: ProfileReportInput): ProfileReport {
 
   const hotSubscribers = analyzeHotSubscribers(events, index)
   const batchAdvisor = analyzeBatchAdvisor(events, index)
-  const { unattributed } = joinProfilerEvents(events, index)
+  const { unattributed, diagnostics } = joinProfilerEvents(events, index)
 
   // Safety oracle (§4.2.3): upgrade each candidate from 'unverified'.
   for (const c of batchAdvisor.candidates) {
@@ -979,6 +1012,7 @@ export function buildProfileReport(input: ProfileReportInput): ProfileReport {
       handlersFired: handlerIds.size,
       handlersTotal,
       unattributed,
+      diagnostics,
     },
   }
 }
@@ -1007,6 +1041,11 @@ export function formatProfileReport(r: ProfileReport): string {
   lines.push(`coverage: ${c.handlersFired}/${c.handlersTotal} handlers exercised`)
   if (c.unattributed.length > 0) {
     lines.push(`  ⚠ ${c.unattributed.length} unattributed id(s): ${c.unattributed.slice(0, 3).map(u => u.id).join(', ')}`)
+  }
+  // Anonymous runtime bookkeeping ids (s*/e*/m*/r*) are noted but flagged
+  // non-actionable, so the report is honest about coverage without crying wolf.
+  if (c.diagnostics.length > 0) {
+    lines.push(`  · ${c.diagnostics.length} anonymous runtime id(s) (non-actionable bookkeeping)`)
   }
   return lines.join('\n')
 }


### PR DESCRIPTION
Closes #1840.

Dogfooding `bf debug profile --scenario auto` surfaced two related attribution/coverage problems. This PR fixes both.

## 1. Auto mode dropped imported child component sources

`runAutoScenario` already loads a target's local imports (dependency-first, entry last) to drive the run, but `debug-profile.ts` passed `extraSources: []` to `buildProfileReport` in auto mode:

```ts
const extraSources = isAuto ? [] : sources.slice(0, -1)
```

So events from composed children never got an id-index entry and resolved to `((unresolved))` — e.g. `DatePicker` imports `Calendar`, but every `Calendar#binding:*` subscriber was unattributed. Now auto mode forwards `sources.slice(0, -1)` the same way the `--scenario <story.tsx>` path does, so those subscribers map back to their source location.

## 2. Raw runtime bookkeeping ids masqueraded as coverage gaps

The reactive runtime (`reactive.ts`) assigns fallback `s<n>` / `e<n>` / `m<n>` / `r<n>` ids to anonymous nodes that have no compiler `__bfId`. These can never map to a source node, yet they landed in `coverage.unattributed`, making a healthy report look much more broken than it is (`s9`, `s10`, `r10`, …).

`joinProfilerEvents` now classifies a gap id:

- shaped like a compiler id (`<Component>#<kind>:<rest>`) → `unattributed` (actionable)
- anonymous runtime id (`^[serm]\d+$`) → new `diagnostics` bucket (non-actionable, surfaced but separated)

Nothing is dropped (SR4 invariant holds); the report just stops crying wolf. `ProfileCoverage` gains a `diagnostics` field and `formatProfileReport` prints it as a quiet `· N anonymous runtime id(s) (non-actionable bookkeeping)` line.

## Before / after (`calendar --scenario auto`)

Before: hot subscribers unresolved, `coverage.unattributed` full of `s9`, `s10`, `s11`, `r10`, …

After:
```
coverage: 1/5 handlers exercised
  ⚠ 2 unattributed id(s): Calendar#binding:s25, ChevronLeftIcon#binding:s0
  · 181 anonymous runtime id(s) (non-actionable bookkeeping)
```

## Tests

- New unit test in `profiler.test.ts`: anonymous runtime ids route to `diagnostics`, compiler-shaped gaps stay in `unattributed`, no events dropped.
- Existing profiler / hot-subscribers / coverage-conformance suites pass (71 tests).
- Verified end-to-end against `date-picker` and `calendar` with `--scenario auto` (text + `--json`).


---
_Generated by [Claude Code](https://claude.ai/code/session_014jcqQ28ZRpDw8utqdbaAYm)_