### PR TITLE
feat(cli): robust profile flags + actionable build hint (#1690)

### DIFF
--- a/.changeset/profiler-cli-flags-build-hint.md
+++ b/.changeset/profiler-cli-flags-build-hint.md
@@ -1,0 +1,24 @@
+---
+"@barefootjs/cli": patch
+"@barefootjs/jsx": patch
+---
+
+Profiler CLI ergonomics: robust flags + actionable build hint (#1690).
+
+Dogfooding `bf debug profile` surfaced three agent-facing rough edges:
+
+- **Flags leaked into the component name.** Unknown / mis-typed flags were
+  pushed onto the positional list, so `bf debug profile --hot-ms 10 foo` read
+  `--hot-ms` as the component and failed with `Cannot find component
+  "--hot-ms"`. `parseFlags` now rejects unknown `--flags` and validates numeric
+  ones with an actionable message + usage, instead of silently mis-parsing.
+- **`--top` / `--hot-ms` are now wired.** `--top <n>` caps the hot-subscriber
+  list (the `--json` set is unchanged); `--hot-ms <n>` drops sub-threshold
+  subscribers so a grid component's long tail collapses to what is worth a fix.
+  Threaded through `buildProfileReport` → `analyzeHotSubscribers` (new
+  `minMs` option).
+- **Opaque "Cannot find module" on a fresh checkout.** The dynamic profiler
+  imports the built client runtime (`@barefootjs/client/runtime`), so a checkout
+  that ran `bun install` but not `bun run build` failed here with a raw module
+  error. The scenario driver now catches it and points at `bun run build`,
+  noting the static budget needs no build.

--- a/packages/cli/src/commands/debug-profile.ts
+++ b/packages/cli/src/commands/debug-profile.ts
@@ -35,25 +35,47 @@ interface ProfileFlags {
  * Parse `debug profile` flags. Unknown `--flags` are rejected (rather than
  * silently swallowed into `positional`, where they would be mistaken for the
  * component name — e.g. `bf debug profile --hot-ms 10 foo` reading the flag as
- * the component). A numeric flag with a non-numeric/absent value is also an
- * error, so an agent gets an actionable message instead of a silent NaN.
+ * the component). Every value-taking flag validates its argument so an agent
+ * gets an actionable message instead of silent surprising behavior:
+ *
+ * - a missing value, or a value that is itself a flag, is rejected — so
+ *   `--scenario --fanout 8` can't make `scenario='--fanout'` and silently drop
+ *   `--fanout`;
+ * - numeric flags enforce sensible ranges — `--top`/`--fanout` are positive
+ *   integers (a negative `--top` would slice from the end, a negative
+ *   `--fanout` would mark everything hot), `--hot-ms` is a non-negative number.
  */
 function parseFlags(args: string[]): ProfileFlags {
   const flags: ProfileFlags = { positional: [] }
-  const num = (raw: string | undefined, name: string): number => {
-    const n = Number(raw)
-    if (raw === undefined || raw === '' || Number.isNaN(n)) {
-      fail(`${name} requires a number (got ${raw === undefined ? 'nothing' : `"${raw}"`}).`)
+  // Consume the next token as a flag value, rejecting a missing value or one
+  // that is itself a flag (a common typo that would otherwise be swallowed).
+  const value = (args: string[], i: number, name: string): string => {
+    const raw = args[i]
+    if (raw === undefined || raw.startsWith('-')) {
+      fail(`${name} requires a value${raw === undefined ? '' : ` (got the flag "${raw}")`}.`)
     }
+    return raw
+  }
+  const num = (
+    args: string[],
+    i: number,
+    name: string,
+    opts: { integer?: boolean; min?: number },
+  ): number => {
+    const raw = value(args, i, name)
+    const n = Number(raw)
+    if (Number.isNaN(n)) fail(`${name} requires a number (got "${raw}").`)
+    if (opts.integer && !Number.isInteger(n)) fail(`${name} must be a whole number (got "${raw}").`)
+    if (opts.min !== undefined && n < opts.min) fail(`${name} must be ≥ ${opts.min} (got "${raw}").`)
     return n
   }
   for (let i = 0; i < args.length; i++) {
     const a = args[i]
-    if (a === '--scenario') flags.scenario = args[++i]
-    else if (a === '--diff') flags.diff = args[++i]
-    else if (a === '--fanout') flags.fanOutThreshold = num(args[++i], '--fanout')
-    else if (a === '--top') flags.topN = num(args[++i], '--top')
-    else if (a === '--hot-ms') flags.minMs = num(args[++i], '--hot-ms')
+    if (a === '--scenario') flags.scenario = value(args, ++i, '--scenario')
+    else if (a === '--diff') flags.diff = value(args, ++i, '--diff')
+    else if (a === '--fanout') flags.fanOutThreshold = num(args, ++i, '--fanout', { integer: true, min: 1 })
+    else if (a === '--top') flags.topN = num(args, ++i, '--top', { integer: true, min: 1 })
+    else if (a === '--hot-ms') flags.minMs = num(args, ++i, '--hot-ms', { min: 0 })
     else if (a.startsWith('-')) fail(`Unknown flag "${a}".`)
     else flags.positional.push(a)
   }

--- a/packages/cli/src/commands/debug-profile.ts
+++ b/packages/cli/src/commands/debug-profile.ts
@@ -17,23 +17,53 @@ import path from 'path'
 import type { CliContext } from '../context'
 import { resolveComponentSource } from '../lib/resolve-source'
 
+const USAGE =
+  'Usage: bf debug profile <component> [--diff <ref>] [--scenario auto|<file>] [--fanout <n>] [--top <n>] [--hot-ms <n>] [--json]'
+
 interface ProfileFlags {
   scenario?: string
   diff?: string
   fanOutThreshold?: number
+  /** `--top <n>`: keep only the N hottest subscribers (dynamic mode). */
+  topN?: number
+  /** `--hot-ms <n>`: drop subscribers below this totalMs floor (dynamic mode). */
+  minMs?: number
   positional: string[]
 }
 
+/**
+ * Parse `debug profile` flags. Unknown `--flags` are rejected (rather than
+ * silently swallowed into `positional`, where they would be mistaken for the
+ * component name — e.g. `bf debug profile --hot-ms 10 foo` reading the flag as
+ * the component). A numeric flag with a non-numeric/absent value is also an
+ * error, so an agent gets an actionable message instead of a silent NaN.
+ */
 function parseFlags(args: string[]): ProfileFlags {
   const flags: ProfileFlags = { positional: [] }
+  const num = (raw: string | undefined, name: string): number => {
+    const n = Number(raw)
+    if (raw === undefined || raw === '' || Number.isNaN(n)) {
+      fail(`${name} requires a number (got ${raw === undefined ? 'nothing' : `"${raw}"`}).`)
+    }
+    return n
+  }
   for (let i = 0; i < args.length; i++) {
     const a = args[i]
     if (a === '--scenario') flags.scenario = args[++i]
     else if (a === '--diff') flags.diff = args[++i]
-    else if (a === '--fanout') flags.fanOutThreshold = Number(args[++i])
+    else if (a === '--fanout') flags.fanOutThreshold = num(args[++i], '--fanout')
+    else if (a === '--top') flags.topN = num(args[++i], '--top')
+    else if (a === '--hot-ms') flags.minMs = num(args[++i], '--hot-ms')
+    else if (a.startsWith('-')) fail(`Unknown flag "${a}".`)
     else flags.positional.push(a)
   }
   return flags
+}
+
+function fail(message: string): never {
+  console.error(`Error: ${message}`)
+  console.error(USAGE)
+  process.exit(1)
 }
 
 export async function run(args: string[], ctx: CliContext): Promise<void> {
@@ -51,7 +81,7 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
   const componentName = flags.positional[0]
   if (!componentName) {
     console.error('Error: Component name required.')
-    console.error('Usage: bf debug profile <component> [--diff <ref>] [--scenario auto] [--fanout <n>] [--json]')
+    console.error(USAGE)
     process.exit(1)
   }
 
@@ -88,6 +118,8 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
         scenario: isAuto ? 'auto' : flags.scenario,
         events,
         extraSources,
+        topN: flags.topN,
+        minMs: flags.minMs,
       })
       if (ctx.jsonFlag) {
         console.log(JSON.stringify(report, null, 2))

--- a/packages/cli/src/lib/scenario-driver.ts
+++ b/packages/cli/src/lib/scenario-driver.ts
@@ -227,7 +227,21 @@ async function runScenario(sources: SourceFile[], mountName?: string): Promise<S
     }
   }
 
-  const runtimePath = import.meta.resolve('@barefootjs/client/runtime')
+  // The dynamic profiler imports the real client runtime. In-tree, that package
+  // resolves to its built `dist/` (unlike `@barefootjs/jsx`, which exports src),
+  // so a fresh checkout that ran `bun install` but not `bun run build` fails here
+  // with an opaque "Cannot find module" — turn it into an actionable message.
+  let runtimePath: string
+  try {
+    runtimePath = import.meta.resolve('@barefootjs/client/runtime')
+  } catch {
+    throw new Error(
+      "The client runtime (@barefootjs/client/runtime) isn't built — the dynamic " +
+        'profiler needs it. Build the client package first (e.g. `bun run build`, or ' +
+        '`bun run --filter @barefootjs/client build`), then re-run with --scenario. ' +
+        'The static budget (`bf debug profile <component>`) needs no build.',
+    )
+  }
   // Concatenating multiple compiled chunks duplicates their runtime imports
   // (`import { createComponent, hydrate, … }`). Collect the union of imported
   // names, strip every per-chunk runtime import, and prepend a single one.

--- a/packages/jsx/src/__tests__/profiler-hot-subscribers.test.ts
+++ b/packages/jsx/src/__tests__/profiler-hot-subscribers.test.ts
@@ -125,6 +125,36 @@ describe('analyzeHotSubscribers', () => {
     expect(r.subscribers[0].subscriber).toBe('Calc#memo:a') // 99ms > 1ms
   })
 
+  test('minMs drops sub-threshold subscribers (--hot-ms noise floor)', () => {
+    seq = 0
+    // One costly subscriber and a long tail of cheap ones — `--hot-ms` keeps
+    // only what is worth a fix.
+    const events: ProfilerEvent[] = [
+      ev('effectEnter', { subscriber: 'Calc#memo:a' }),
+      ev('effectExit', { subscriber: 'Calc#memo:a', dur: 5 }),
+      ev('effectEnter', { subscriber: 'Calc#memo:b' }),
+      ev('effectExit', { subscriber: 'Calc#memo:b', dur: 0.04 }), // rounds to 0.0ms
+    ]
+    const r = analyzeHotSubscribers(events, index, { minMs: 1 })
+    expect(r.subscribers).toHaveLength(1)
+    expect(r.subscribers[0].subscriber).toBe('Calc#memo:a')
+  })
+
+  test('minMs and topN compose (filter floor, then cap)', () => {
+    seq = 0
+    const events: ProfilerEvent[] = [
+      ev('effectEnter', { subscriber: 'Calc#memo:a' }),
+      ev('effectExit', { subscriber: 'Calc#memo:a', dur: 10 }),
+      ev('effectEnter', { subscriber: 'Calc#memo:b' }),
+      ev('effectExit', { subscriber: 'Calc#memo:b', dur: 5 }),
+      ev('effectEnter', { subscriber: 'Calc#memo:c' }),
+      ev('effectExit', { subscriber: 'Calc#memo:c', dur: 0.01 }), // below floor
+    ]
+    const r = analyzeHotSubscribers(events, index, { minMs: 1, topN: 1 })
+    expect(r.subscribers).toHaveLength(1)
+    expect(r.subscribers[0].subscriber).toBe('Calc#memo:a')
+  })
+
   test('same-cost subscribers tiebreak by runs then id — stable across timing noise', () => {
     seq = 0
     // Both round to the same displayed 0.1ms cost; runs (equal) then id decide.

--- a/packages/jsx/src/profiler.ts
+++ b/packages/jsx/src/profiler.ts
@@ -500,6 +500,13 @@ export interface HotSubscribersOptions {
   hotRunsPerTurn?: number
   /** Keep only the top-N by `totalMs` (after ranking). Default: all. */
   topN?: number
+  /**
+   * Drop subscribers whose `totalMs` is below this threshold (after ranking,
+   * before `topN`). Noise filter for `--hot-ms`: a component with a long tail of
+   * sub-millisecond effects (e.g. a calendar grid) collapses to the few that
+   * actually cost. Default: keep all.
+   */
+  minMs?: number
 }
 
 const DEFAULT_HOT_RUNS_PER_TURN = 2
@@ -587,6 +594,9 @@ export function analyzeHotSubscribers(
       y.runs - x.runs ||
       (x.subscriber < y.subscriber ? -1 : x.subscriber > y.subscriber ? 1 : 0),
   )
+  // `minMs` is a noise floor applied at the displayed 0.1ms precision so a
+  // subscriber on the line is filtered consistently with how it would render.
+  if (options.minMs !== undefined) subscribers = subscribers.filter(s => roundMs(s.totalMs) >= options.minMs!)
   if (options.topN !== undefined) subscribers = subscribers.slice(0, options.topN)
 
   // Only subscriber ids matter for this analysis — filter the join's gaps to
@@ -917,6 +927,10 @@ export interface ProfileReportInput {
    * from those components resolve too.
    */
   extraSources?: readonly { source: string; filePath: string }[]
+  /** Keep only the top-N hot subscribers by `totalMs` (`--top`). Default: all. */
+  topN?: number
+  /** Drop hot subscribers below this `totalMs` floor (`--hot-ms`). Default: all. */
+  minMs?: number
 }
 
 /**
@@ -971,7 +985,10 @@ export function buildProfileReport(input: ProfileReportInput): ProfileReport {
     }
   }
 
-  const hotSubscribers = analyzeHotSubscribers(events, index)
+  const hotSubscribers = analyzeHotSubscribers(events, index, {
+    topN: input.topN,
+    minMs: input.minMs,
+  })
   const batchAdvisor = analyzeBatchAdvisor(events, index)
   const { unattributed, diagnostics } = joinProfilerEvents(events, index)
 


### PR DESCRIPTION
## What

Dogfooded the new `bf debug profile` profiler across the whole UI library (static budget, `--scenario auto`, `--diff`, `--json`). It works well and produces genuinely actionable findings — e.g. `calendar`'s prev/next-month click surfaces `batch candidate 558→9 (saves 549)` and an attribute binding running **924×/turn**. This PR fixes three agent-facing rough edges found along the way; a fuller findings report (with a couple of deeper bugs left for follow-up) is in the session summary.

## Fixes

- **Flags leaked into the component name.** Unknown/mis-typed flags were pushed onto the positional list, so `bf debug profile --hot-ms 10 foo` read `--hot-ms` as the component and failed with `Cannot find component "--hot-ms"`. `parseFlags` now rejects unknown `--flags` and validates numeric ones with an actionable message + usage.
- **`--top` / `--hot-ms` are now wired** (both documented in `spec/profiler.md` §6 but previously unparsed). `--top <n>` caps the hot-subscriber list (the `--json` set is unchanged); `--hot-ms <n>` drops sub-threshold subscribers so a grid component's long tail collapses to what's worth a fix. Threaded through `buildProfileReport` → `analyzeHotSubscribers` (new `minMs` option).
- **Opaque "Cannot find module" on a fresh checkout.** The dynamic profiler imports the built client runtime (`@barefootjs/client/runtime`); a checkout that ran `bun install` but not `bun run build` failed here with a raw module error. The scenario driver now catches it and points at `bun run build`, noting the static budget needs no build.

## Tests

- New `analyzeHotSubscribers` unit tests for `minMs` (noise floor) and `minMs`+`topN` composition.
- All 92 profiler-related tests pass (`profiler*`, `scenario-driver`). The 4 unrelated `bf init` failures in this environment are a missing generated artifact (`runtimes.generated`), not touched here.

## Follow-ups (reported, not fixed here — higher risk)

- **`#binding:<slot>` ids resolve to `(unresolved)`** when a slot's binding is a *prop-only* attribute effect (root cause: the compiler emits `#binding:` for prop-derived attribute effects, but the analyzer doesn't surface them in `graph.domBindings`, so `buildIdIndex` has no node). Repros: `Slider#binding:s2`, `Accordion#binding:s0`, `Tabs#binding:s0`, `Collapsible#binding:s0`. The coverage-conformance MATRIX is missing this shape.
- **Static budget shows `subscriptions: 0` / empty fan-out for compound components** (`select`, `combobox`, `carousel`) because their bindings live in child components — arguably needs a "partial/compound" note.
- **`@barefootjs/client` exports point at `dist/` in-tree** (unlike `jsx`/`shared`, which export `src/` and swap to `dist/` via `publishConfig`) — the root reason the dynamic profiler needs a build.

https://claude.ai/code/session_01CfkY3mem7y9teigXYVkj9g

---
_Generated by [Claude Code](https://claude.ai/code/session_01CfkY3mem7y9teigXYVkj9g)_