### PR TITLE
feat(profiler): wasted re-runs analysis (#1843, §4.2.2)

### DIFF
--- a/.changeset/profiler-wasted-re-runs.md
+++ b/.changeset/profiler-wasted-re-runs.md
@@ -1,0 +1,25 @@
+---
+"@barefootjs/client": minor
+"@barefootjs/jsx": minor
+"@barefootjs/shared": minor
+"@barefootjs/cli": patch
+---
+
+Add the wasted-re-runs analysis — v1 (#1690, §4.2.2).
+
+A reactive effect/memo that re-ran but produced output identical to its
+previous run did removable work — the complement to hot subscribers (where the
+cost is, vs. how much of it is removable).
+
+- **Fingerprint (SR1, dev-only/SR8):** new optional `effectOutput(id, changed)`
+  sink method on the SR2 stream. The runtime aggregates a per-run output verdict
+  via `__bfReportOutput` (flushed once at run exit): memos compare the recomputed
+  value by `Object.is`; text bindings (`__bfText`) compare the written string —
+  and a stale-element cleanup counts as a real DOM change. A run with no
+  fingerprint emits no event and isn't counted. `effectOutput` is optional on the
+  exported `ProfilerEventSink`, so a pre-existing custom sink stays valid.
+- **Analysis (SR2 + SR4):** `analyzeWastedReReruns` / `formatWastedReReruns`,
+  `wasted = wastedRuns / totalRuns`, joined to IR source loc and ranked by
+  removable cost then ratio (deterministic). Surfaced in `buildProfileReport` /
+  `formatProfileReport` (text + `--json`) behind the new `--wasted-pct` flag
+  (default 50%).

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -59,7 +59,8 @@
         "packages/client/src/runtime/insert.ts",
         "packages/client/src/runtime/map-array.ts",
         "packages/client/src/runtime/component.ts",
-        "packages/client/src/runtime/apply-rest-attrs.ts"
+        "packages/client/src/runtime/apply-rest-attrs.ts",
+        "packages/client/src/runtime/dynamic-text.ts"
       ],
       "linter": {
         "rules": {

--- a/packages/cli/src/commands/debug-profile.ts
+++ b/packages/cli/src/commands/debug-profile.ts
@@ -18,7 +18,7 @@ import type { CliContext } from '../context'
 import { resolveComponentSource } from '../lib/resolve-source'
 
 const USAGE =
-  'Usage: bf debug profile <component> [--diff <ref>] [--scenario auto|<file>] [--fanout <n>] [--top <n>] [--hot-ms <n>] [--json]'
+  'Usage: bf debug profile <component> [--diff <ref>] [--scenario auto|<file>] [--fanout <n>] [--top <n>] [--hot-ms <n>] [--wasted-pct <n>] [--json]'
 
 interface ProfileFlags {
   scenario?: string
@@ -28,6 +28,8 @@ interface ProfileFlags {
   topN?: number
   /** `--hot-ms <n>`: drop subscribers below this totalMs floor (dynamic mode). */
   minMs?: number
+  /** `--wasted-pct <n>`: flag a subscriber whose runs are ≥ n% identical output. */
+  wastedPct?: number
   positional: string[]
 }
 
@@ -76,6 +78,7 @@ function parseFlags(args: string[]): ProfileFlags {
     else if (a === '--fanout') flags.fanOutThreshold = num(args, ++i, '--fanout', { integer: true, min: 1 })
     else if (a === '--top') flags.topN = num(args, ++i, '--top', { integer: true, min: 1 })
     else if (a === '--hot-ms') flags.minMs = num(args, ++i, '--hot-ms', { min: 0 })
+    else if (a === '--wasted-pct') flags.wastedPct = num(args, ++i, '--wasted-pct', { min: 0 })
     else if (a.startsWith('-')) fail(`Unknown flag "${a}".`)
     else flags.positional.push(a)
   }
@@ -142,6 +145,8 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
         extraSources,
         topN: flags.topN,
         minMs: flags.minMs,
+        // `--wasted-pct` is a percentage on the CLI; the analysis takes a [0,1] fraction.
+        wastedRatio: flags.wastedPct !== undefined ? flags.wastedPct / 100 : undefined,
       })
       if (ctx.jsonFlag) {
         console.log(JSON.stringify(report, null, 2))

--- a/packages/client/__tests__/profiler-instrumentation.test.ts
+++ b/packages/client/__tests__/profiler-instrumentation.test.ts
@@ -17,6 +17,7 @@ import {
   beginTurn,
   endTurn,
   setProfilerSink,
+  __bfReportOutput,
   type ProfilerEventSink,
   type SubscriberKind,
 } from '../src/reactive'
@@ -32,6 +33,7 @@ function recorder(): { events: Event[]; sink: ProfilerEventSink } {
     effectCreate: (id, kind) => events.push(['effectCreate', id, kind]),
     effectEnter: (id) => events.push(['effectEnter', id]),
     effectExit: (id, dur) => events.push(['effectExit', id, dur]),
+    effectOutput: (id, changed) => events.push(['effectOutput', id, changed]),
     effectDispose: (id) => events.push(['effectDispose', id]),
     batchBegin: (depth) => events.push(['batchBegin', depth]),
     batchFlush: (n) => events.push(['batchFlush', n]),
@@ -145,6 +147,74 @@ describe('turn boundaries (SR3)', () => {
   test('beginTurn/endTurn are no-ops when profiling is off', () => {
     setProfilerSink(null)
     expect(() => { beginTurn('x'); endTurn() }).not.toThrow()
+  })
+})
+
+describe('output fingerprint (SR1, §4.2.2)', () => {
+  // The effectOutput change flags for one subscriber id, in order.
+  const outputs = (events: Event[], id: string): boolean[] =>
+    events.filter(e => e[0] === 'effectOutput' && e[1] === id).map(e => e[2] as boolean)
+
+  test('a memo emits effectOutput: changed on a new value, unchanged on an Object.is-equal recompute', () => {
+    const { events, sink } = recorder()
+    setProfilerSink(sink)
+    const [count, setCount] = createSignal(0)
+    const parity = createMemo(() => count() % 2)
+    const memoId = events.find(e => e[0] === 'effectCreate' && e[2] === 'memo')![1] as string
+
+    expect(parity()).toBe(0)
+    setCount(2) // recomputes to 0 — same value → wasted run
+    expect(parity()).toBe(0)
+    setCount(3) // recomputes to 1 — new value → real output
+    expect(parity()).toBe(1)
+
+    // mount(true), set2(false, identical), set3(true).
+    expect(outputs(events, memoId)).toEqual([true, false, true])
+  })
+
+  test('effectOutput rides right after effectExit for the same run', () => {
+    const { events, sink } = recorder()
+    setProfilerSink(sink)
+    const [n, setN] = createSignal(1)
+    createMemo(() => n() * 0) // always 0 → every recompute after mount is wasted
+    setN(2)
+    // For the memo's recompute: …effectEnter, effectExit, effectOutput…
+    const memoId = events.find(e => e[0] === 'effectCreate' && e[2] === 'memo')![1] as string
+    const idxExit = events.findLastIndex(e => e[0] === 'effectExit' && e[1] === memoId)
+    expect(events[idxExit + 1]).toEqual(['effectOutput', memoId, false])
+  })
+
+  test('__bfReportOutput attributes to the running effect and ORs several writes per run', () => {
+    const { events, sink } = recorder()
+    setProfilerSink(sink)
+    let runs = 0
+    const [tick, setTick] = createSignal(0)
+    createEffect(() => {
+      tick()
+      // Two writes in one run: one unchanged, one changed → the run is "changed".
+      __bfReportOutput(false)
+      __bfReportOutput(runs > 0) // mount: false+false → unchanged; after: false+true → changed
+      runs++
+    })
+    const id = events.find(e => e[0] === 'effectCreate')![1] as string
+    setTick(1)
+    expect(outputs(events, id)).toEqual([false, true])
+  })
+
+  test('__bfReportOutput is a no-op outside any run', () => {
+    const { events, sink } = recorder()
+    setProfilerSink(sink)
+    __bfReportOutput(true)
+    expect(events.some(e => e[0] === 'effectOutput')).toBe(false)
+  })
+
+  test('a plain effect that reports no output emits no effectOutput', () => {
+    const { events, sink } = recorder()
+    setProfilerSink(sink)
+    const [v, setV] = createSignal(0)
+    createEffect(() => { v() }) // never calls __bfReportOutput
+    setV(1)
+    expect(events.some(e => e[0] === 'effectOutput')).toBe(false)
   })
 })
 

--- a/packages/client/__tests__/runtime/dynamic-text.test.ts
+++ b/packages/client/__tests__/runtime/dynamic-text.test.ts
@@ -185,4 +185,33 @@ describe('__bfText output fingerprint (profiler)', () => {
     // mount(true), 550(false), 640(true), 660(false)
     expect(outputs(events, id)).toEqual([true, false, true, false])
   })
+
+  test('clearing a stale element counts as changed even when the written text is unchanged', () => {
+    const events: [string, ...unknown[]][] = []
+    const sink = {
+      signalSet: () => {}, subscribeAdd: () => {}, subscribeRemove: () => {},
+      effectCreate: (id: string) => events.push(['effectCreate', id]),
+      effectEnter: () => {}, effectExit: () => {},
+      effectOutput: (id: string, changed: boolean) => events.push(['effectOutput', id, changed]),
+      effectDispose: () => {}, batchBegin: () => {}, batchFlush: () => {},
+      turnBegin: () => {}, turnEnd: () => {},
+    } satisfies ProfilerEventSink
+    setProfilerSink(sink)
+
+    // A stale element left by a previous Node-valued run sits in the slot; the
+    // fresh text anchor already holds the empty string we're about to write, so
+    // the text is unchanged — but removing the stale element IS a DOM change, so
+    // the run must report `changed`, not be misclassified as wasted (§4.2.2).
+    const stale = document.createElement('span')
+    stale.textContent = 'old'
+    host.insertBefore(stale, host.lastChild) // between the anchor and the <!--/--> end
+
+    createEffect(() => {
+      __bfText(anchor, '') // anchor.nodeValue is already '' → text unchanged
+    })
+    const id = events.find(e => e[0] === 'effectCreate')![1] as string
+
+    expect(host.querySelector('span')).toBeNull() // stale element removed
+    expect(outputs(events, id)).toEqual([true]) // DOM changed via cleanup, not wasted
+  })
 })

--- a/packages/client/__tests__/runtime/dynamic-text.test.ts
+++ b/packages/client/__tests__/runtime/dynamic-text.test.ts
@@ -1,5 +1,11 @@
-import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { describe, test, expect, beforeAll, beforeEach, afterEach } from 'bun:test'
 import { __bfText } from '../../src/runtime/dynamic-text'
+import {
+  createSignal,
+  createEffect,
+  setProfilerSink,
+  type ProfilerEventSink,
+} from '../../src/reactive'
 import { GlobalRegistrator } from '@happy-dom/global-registrator'
 
 beforeAll(() => {
@@ -122,5 +128,61 @@ describe('__bfText', () => {
 
   test('is a no-op when the anchor is null', () => {
     expect(__bfText(null, 'x')).toBeNull()
+  })
+})
+
+/**
+ * Output fingerprint (#1690, §4.2.2). A text binding wrapped in `createEffect`
+ * reports whether the slot actually changed; a re-run that writes the same text
+ * is a *wasted* re-run the profiler can flag. Verified end-to-end here: the
+ * runtime sink sees one `effectOutput` per run, with the right `changed` flag.
+ */
+describe('__bfText output fingerprint (profiler)', () => {
+  let host: HTMLElement
+  let anchor: Text
+
+  const outputs = (events: [string, ...unknown[]][], id: string): boolean[] =>
+    events.filter(e => e[0] === 'effectOutput' && e[1] === id).map(e => e[2] as boolean)
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    host = document.createElement('div')
+    host.appendChild(document.createComment('bf:s0'))
+    anchor = document.createTextNode('')
+    host.appendChild(anchor)
+    host.appendChild(document.createComment('/'))
+    document.body.appendChild(host)
+  })
+
+  afterEach(() => setProfilerSink(null))
+
+  test('reports changed on a new value and unchanged on an identical re-write', () => {
+    const events: [string, ...unknown[]][] = []
+    const sink = {
+      signalSet: () => {}, subscribeAdd: () => {}, subscribeRemove: () => {},
+      effectCreate: (id: string) => events.push(['effectCreate', id]),
+      effectEnter: () => {}, effectExit: () => {},
+      effectOutput: (id: string, changed: boolean) => events.push(['effectOutput', id, changed]),
+      effectDispose: () => {}, batchBegin: () => {}, batchFlush: () => {},
+      turnBegin: () => {}, turnEnd: () => {},
+    } satisfies ProfilerEventSink
+    setProfilerSink(sink)
+
+    // A price label that formats only the dollars of a cents signal: changing
+    // cents within the same dollar re-runs the binding but renders identical text.
+    const [cents, setCents] = createSignal(500)
+    let current: Node | null = anchor
+    createEffect(() => {
+      current = __bfText(current, `$${Math.floor(cents() / 100)}`)
+    })
+    const id = events.find(e => e[0] === 'effectCreate')![1] as string
+
+    setCents(550) // still "$5" → wasted
+    setCents(640) // "$6" → real change
+    setCents(660) // still "$6" → wasted
+
+    expect(host.textContent).toBe('$6')
+    // mount(true), 550(false), 640(true), 660(false)
+    expect(outputs(events, id)).toEqual([true, false, true, false])
   })
 })

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -14,6 +14,7 @@ export {
   setProfilerSink,
   beginTurn,
   endTurn,
+  __bfReportOutput,
   type Reactive,
   type Signal,
   type Memo,

--- a/packages/client/src/profiler-events.ts
+++ b/packages/client/src/profiler-events.ts
@@ -60,6 +60,7 @@ export function createRecordingSink(): RecordingSink {
     effectCreate: (id, kind) => push({ type: 'effectCreate', subscriber: id, kind }),
     effectEnter: (id) => push({ type: 'effectEnter', subscriber: id }),
     effectExit: (id, dur) => push({ type: 'effectExit', subscriber: id, dur }),
+    effectOutput: (id, changed) => push({ type: 'effectOutput', subscriber: id, changed }),
     effectDispose: (id) => push({ type: 'effectDispose', subscriber: id }),
     batchBegin: (depth) => push({ type: 'batchBegin', depth }),
     batchFlush: (flushed) => push({ type: 'batchFlush', flushed }),

--- a/packages/client/src/reactive.ts
+++ b/packages/client/src/reactive.ts
@@ -63,8 +63,12 @@ export interface ProfilerEventSink {
    * *wasted* re-run. Emitted at most once per run, only for runs whose output
    * is fingerprintable (memo recompute / instrumented DOM write); a run that
    * reports no output emits no event and isn't counted as wasted.
+   *
+   * Optional: it was added after the initial sink contract, so a pre-existing
+   * custom sink that omits it stays valid (the call site guards with `?.`). A
+   * sink without it simply opts out of the wasted-re-runs analysis.
    */
-  effectOutput(subscriberId: string, changed: boolean): void
+  effectOutput?(subscriberId: string, changed: boolean): void
   /** An effect / memo / root scope was disposed. */
   effectDispose(subscriberId: string): void
   /** A `batch()` block opened at the given (post-increment) depth. */
@@ -296,7 +300,7 @@ function runEffect(effect: EffectContext): void {
     effect.runCount--
     if (profilerSink) {
       profilerSink.effectExit(effect.id, performance.now() - start)
-      if (effect.outputReported) profilerSink.effectOutput(effect.id, effect.outputChanged)
+      if (effect.outputReported) profilerSink.effectOutput?.(effect.id, effect.outputChanged)
     }
   }
 }

--- a/packages/client/src/reactive.ts
+++ b/packages/client/src/reactive.ts
@@ -55,6 +55,16 @@ export interface ProfilerEventSink {
   effectEnter(subscriberId: string): void
   /** An effect/memo body finished. `durationMs` is wall time. */
   effectExit(subscriberId: string, durationMs: number): void
+  /**
+   * An effect/memo run produced an output fingerprint (#1690, §4.2.2).
+   * `changed` is `true` when the run produced new output (a memo value that
+   * differs by `Object.is`, or a DOM write that changed the node) and `false`
+   * when it recomputed but produced output identical to its previous run — a
+   * *wasted* re-run. Emitted at most once per run, only for runs whose output
+   * is fingerprintable (memo recompute / instrumented DOM write); a run that
+   * reports no output emits no event and isn't counted as wasted.
+   */
+  effectOutput(subscriberId: string, changed: boolean): void
   /** An effect / memo / root scope was disposed. */
   effectDispose(subscriberId: string): void
   /** A `batch()` block opened at the given (post-increment) depth. */
@@ -105,6 +115,23 @@ export function endTurn(): void {
   if (profilerSink) profilerSink.turnEnd()
 }
 
+/**
+ * Report the current run's output fingerprint (#1690, §4.2.2). Called from the
+ * places that produce an effect's observable output — a memo recompute (the
+ * written value's `Object.is` identity) and instrumented DOM writes (whether the
+ * node actually changed). Accumulated onto the running effect (`Owner`) and
+ * flushed as one `effectOutput` event at run exit, so several writes in one run
+ * collapse to a single "did this run change anything" verdict.
+ *
+ * No-op when profiling is off or called outside a run — the wasted-re-runs
+ * analysis is the only consumer and it lives behind the dev-only sink (SR8).
+ */
+export function __bfReportOutput(changed: boolean): void {
+  if (!profilerSink || !Owner) return
+  Owner.outputReported = true
+  if (changed) Owner.outputChanged = true
+}
+
 type EffectContext = {
   fn: EffectFn
   cleanup: CleanupFn | null
@@ -115,6 +142,12 @@ type EffectContext = {
   runCount: number              // Per-effect re-entry counter for circular dependency detection
   id: string                    // Dev instrumentation id ('' when profiling is off)
   kind: SubscriberKind          // effect | memo | root
+  // Per-run output fingerprint accumulator (SR1, §4.2.2). Reset at the start of
+  // every run; set by `__bfReportOutput` (memo recompute / DOM write) during the
+  // body; flushed as one `effectOutput` event at exit. Dev-only — untouched when
+  // profiling is off.
+  outputReported: boolean
+  outputChanged: boolean
 }
 
 let Owner: EffectContext | null = null
@@ -208,6 +241,8 @@ export function createEffect(fn: EffectFn, __bfId?: string, __bfKind: Subscriber
     runCount: 0,
     id: __bfId ?? (profilerSink ? `e${++subscriberSeq}` : ''),
     kind: __bfKind,
+    outputReported: false,
+    outputChanged: false,
   }
 
   if (profilerSink) profilerSink.effectCreate(effect.id, effect.kind)
@@ -243,6 +278,10 @@ function runEffect(effect: EffectContext): void {
   Owner = effect
   Listener = effect
 
+  // Fresh output fingerprint for this run (§4.2.2); `__bfReportOutput` fills it.
+  effect.outputReported = false
+  effect.outputChanged = false
+
   const start = profilerSink ? performance.now() : 0
   if (profilerSink) profilerSink.effectEnter(effect.id)
 
@@ -255,7 +294,10 @@ function runEffect(effect: EffectContext): void {
     Owner = prevOwner
     Listener = prevListener
     effect.runCount--
-    if (profilerSink) profilerSink.effectExit(effect.id, performance.now() - start)
+    if (profilerSink) {
+      profilerSink.effectExit(effect.id, performance.now() - start)
+      if (effect.outputReported) profilerSink.effectOutput(effect.id, effect.outputChanged)
+    }
   }
 }
 
@@ -331,6 +373,8 @@ export function createRoot<T>(fn: (dispose: () => void) => T): T {
     runCount: 0,
     id: profilerSink ? `r${++subscriberSeq}` : '',
     kind: 'root',
+    outputReported: false,
+    outputChanged: false,
   }
 
   if (profilerSink) profilerSink.effectCreate(root.id, 'root')
@@ -372,6 +416,8 @@ export function createDisposableEffect(fn: EffectFn, __bfId?: string): () => voi
     runCount: 0,
     id: __bfId ?? (profilerSink ? `e${++subscriberSeq}` : ''),
     kind: 'effect',
+    outputReported: false,
+    outputChanged: false,
   }
 
   if (profilerSink) profilerSink.effectCreate(effect.id, effect.kind)
@@ -518,8 +564,19 @@ export function createMemo<T>(fn: () => T, __bfId?: string): Memo<T> {
   const id = __bfId ?? (profilerSink ? `m${++subscriberSeq}` : '')
   const [value, setValue] = createSignal<T>(undefined as T, id)
 
+  // Memo output fingerprint (§4.2.2): a recompute that yields an `Object.is`-equal
+  // value is a wasted re-run. Tracked here (not via the private signal's bail)
+  // so the first run reads as a genuine output, never as "unchanged".
+  let prev: T
+  let hasPrev = false
+
   createEffect(() => {
     const result = fn()
+    if (profilerSink) {
+      __bfReportOutput(!hasPrev || !Object.is(prev, result))
+      prev = result
+      hasPrev = true
+    }
     setValue(() => result)
   }, id, 'memo')
 

--- a/packages/client/src/runtime/dynamic-text.ts
+++ b/packages/client/src/runtime/dynamic-text.ts
@@ -10,12 +10,19 @@
  * returned by `createComponent`. Stringifying it produced
  * `"[object HTMLElement]"` (and clobbered the server-rendered subtree).
  *
+ * Profiler note (#1690, §4.2.2): each write reports an output fingerprint via
+ * `__bfReportOutput` — `false` when the slot already held the same text/node, so
+ * the wasted-re-runs analysis can flag a text binding that re-ran without
+ * changing the DOM. Dev-only: `__bfReportOutput` is a no-op when profiling is off.
+ *
  * `__bfText` mirrors `__bfSlot` (the branch-template equivalent): when the
  * value is a `Node`, it replaces the slot region with that node by identity;
  * otherwise it behaves exactly like the previous text assignment. It returns
  * the node that now occupies the slot so the caller can track it across
  * reactive re-runs (the previous node is detached once replaced).
  */
+
+import { __bfReportOutput } from '@barefootjs/client/reactive'
 
 const END_MARKER = '/'
 
@@ -49,8 +56,12 @@ export function __bfText(current: Node | null, value: unknown): Node | null {
   if (value != null && (value as { __isSlot?: boolean }).__isSlot) return current
 
   if (typeof Node !== 'undefined' && value instanceof Node) {
-    if (value === current) return current
+    if (value === current) {
+      __bfReportOutput(false) // same node already in the slot — nothing changed
+      return current
+    }
     const start = current.previousSibling
+    __bfReportOutput(true)
     if (start && start.nodeType === Node.COMMENT_NODE) {
       clearSlotRegion(start)
       start.parentNode?.insertBefore(value, start.nextSibling)
@@ -63,6 +74,7 @@ export function __bfText(current: Node | null, value: unknown): Node | null {
 
   const text = String(value ?? '')
   if (current.nodeType === Node.TEXT_NODE) {
+    __bfReportOutput(current.nodeValue !== text)
     current.nodeValue = text
     // The conditional-slot path re-resolves the anchor via `$t()` on every
     // run, which can hand back a freshly created text node sitting *before* a
@@ -76,6 +88,7 @@ export function __bfText(current: Node | null, value: unknown): Node | null {
 
   // Switching back from a Node value to text: drop the element and restore a
   // text node in the slot region.
+  __bfReportOutput(true)
   const start = current.previousSibling
   const textNode = (current.ownerDocument ?? document).createTextNode(text)
   if (start && start.nodeType === Node.COMMENT_NODE) {

--- a/packages/client/src/runtime/dynamic-text.ts
+++ b/packages/client/src/runtime/dynamic-text.ts
@@ -29,17 +29,25 @@ const END_MARKER = '/'
 /** Remove every sibling between `start` (the `<!--bf:sX-->` comment) and the
  *  matching `<!--/-->` end comment, leaving both markers in place. When `keep`
  *  is supplied that node is left in place (used when writing a primitive
- *  through a text anchor that must survive while stale siblings are cleared). */
-function clearSlotRegion(start: Node, keep?: Node): void {
+ *  through a text anchor that must survive while stale siblings are cleared).
+ *  Returns whether it actually removed any node, so the profiler fingerprint
+ *  (§4.2.2) can treat a stale-element cleanup as a real DOM change even when the
+ *  written text is unchanged. */
+function clearSlotRegion(start: Node, keep?: Node): boolean {
+  let removed = false
   let n = start.nextSibling
   while (
     n &&
     !(n.nodeType === Node.COMMENT_NODE && (n as Comment).nodeValue === END_MARKER)
   ) {
     const next = n.nextSibling
-    if (n !== keep) n.parentNode?.removeChild(n)
+    if (n !== keep) {
+      n.parentNode?.removeChild(n)
+      removed = true
+    }
     n = next
   }
+  return removed
 }
 
 /** Walk back from `node` to the nearest preceding comment marker (the slot's
@@ -74,7 +82,7 @@ export function __bfText(current: Node | null, value: unknown): Node | null {
 
   const text = String(value ?? '')
   if (current.nodeType === Node.TEXT_NODE) {
-    __bfReportOutput(current.nodeValue !== text)
+    const textChanged = current.nodeValue !== text
     current.nodeValue = text
     // The conditional-slot path re-resolves the anchor via `$t()` on every
     // run, which can hand back a freshly created text node sitting *before* a
@@ -82,7 +90,11 @@ export function __bfText(current: Node | null, value: unknown): Node | null {
     // siblings up to the end marker so switching JSX → text doesn't render
     // both the old element and the new text.
     const start = slotStart(current)
-    if (start && start.nodeType === Node.COMMENT_NODE) clearSlotRegion(start, current)
+    const clearedStale =
+      start != null && start.nodeType === Node.COMMENT_NODE && clearSlotRegion(start, current)
+    // Removing a stale element is a real DOM change even when the text matched,
+    // so the run isn't wasted in that case (§4.2.2).
+    __bfReportOutput(textChanged || clearedStale)
     return current
   }
 

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -21,6 +21,7 @@ export {
   setProfilerSink,
   beginTurn,
   endTurn,
+  __bfReportOutput,
   type Reactive,
   type Signal,
   type Memo,

--- a/packages/jsx/src/__tests__/profiler-wasted-re-runs.test.ts
+++ b/packages/jsx/src/__tests__/profiler-wasted-re-runs.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Wasted re-runs analysis (#1690, §4.2.2).
+ *
+ * Pure over the SR2 stream's `effectOutput` fingerprints + SR4 id index: counts
+ * runs that recomputed but produced output identical to the previous run, ranks
+ * by removable cost, and joins each to source loc. Deterministic — same stream ⇒
+ * same ranking.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { analyzeWastedReReruns, buildIdIndex, formatWastedReReruns } from '../profiler'
+import { buildComponentAnalysis } from '../debug'
+import type { ProfilerEvent } from '@barefootjs/shared'
+
+const source = `
+  'use client'
+  import { createSignal, createMemo, createEffect } from '@barefootjs/client'
+
+  export function Calc() {
+    const [count, setCount] = createSignal(0)
+    const a = createMemo(() => count() * 2)
+    createEffect(() => console.log(a()))
+    return <button onClick={() => setCount(n => n + 1)}>{a()}</button>
+  }
+`
+
+const { graph } = buildComponentAnalysis(source, 'Calc.tsx')
+const index = buildIdIndex(graph)
+
+let seq = 0
+const ev = (type: ProfilerEvent['type'], f: Partial<ProfilerEvent> = {}): ProfilerEvent =>
+  ({ type, seq: seq++, turn: null, ...f })
+
+const out = (subscriber: string, changed: boolean, turn: string | null = null): ProfilerEvent =>
+  ev('effectOutput', { subscriber, changed, turn })
+
+describe('analyzeWastedReReruns', () => {
+  test('counts identical-output runs, computes ratio, and joins loc', () => {
+    seq = 0
+    const memo = 'Calc#memo:a'
+    // 4 runs: first changed (real output), 3 identical → 3/4 wasted.
+    const events: ProfilerEvent[] = [
+      out(memo, true),
+      out(memo, false),
+      out(memo, false),
+      out(memo, false),
+    ]
+    const r = analyzeWastedReReruns(events, index)
+    expect(r.subscribers).toHaveLength(1)
+    const top = r.subscribers[0]
+    expect(top.subscriber).toBe(memo)
+    expect(top.totalRuns).toBe(4)
+    expect(top.wastedRuns).toBe(3)
+    expect(top.wastedRatio).toBeCloseTo(0.75)
+    expect(top.name).toBe('a')
+    expect(top.kind).toBe('memo')
+    expect(top.loc!.line).toBeGreaterThan(0)
+    expect(top.wasted).toBe(true) // 0.75 ≥ default 0.5
+  })
+
+  test('subscribers with zero wasted runs are not findings', () => {
+    seq = 0
+    const events: ProfilerEvent[] = [out('Calc#memo:a', true), out('Calc#memo:a', true)]
+    const r = analyzeWastedReReruns(events, index)
+    expect(r.subscribers).toHaveLength(0)
+  })
+
+  test('wastedRatio threshold flags only subscribers at/above it', () => {
+    seq = 0
+    // a: 1/4 wasted (0.25); b: 3/4 wasted (0.75). At threshold 0.5 only b is flagged.
+    const events: ProfilerEvent[] = [
+      out('Calc#memo:a', true), out('Calc#memo:a', true), out('Calc#memo:a', true), out('Calc#memo:a', false),
+      out('Calc#memo:b', false), out('Calc#memo:b', false), out('Calc#memo:b', false), out('Calc#memo:b', true),
+    ]
+    const r = analyzeWastedReReruns(events, index, { wastedRatio: 0.5 })
+    const flagged = r.subscribers.filter(s => s.wasted).map(s => s.subscriber)
+    expect(flagged).toEqual(['Calc#memo:b'])
+    // both still appear as findings (each has ≥1 wasted run)
+    expect(r.subscribers.map(s => s.subscriber).sort()).toEqual(['Calc#memo:a', 'Calc#memo:b'])
+  })
+
+  test('ranks by removable cost (wastedRuns), then ratio, then id — deterministic', () => {
+    seq = 0
+    // a: 2 wasted of 10 (0.2). b: 5 wasted of 10 (0.5). c: 5 wasted of 6 (~0.83).
+    const mk = (id: string, wasted: number, total: number): ProfilerEvent[] => {
+      const es: ProfilerEvent[] = []
+      for (let i = 0; i < total; i++) es.push(out(id, i >= wasted))
+      return es
+    }
+    const events = [...mk('Calc#memo:a', 2, 10), ...mk('Calc#memo:b', 5, 10), ...mk('Calc#memo:c', 5, 6)]
+    const order = analyzeWastedReReruns(events, index).subscribers.map(s => s.subscriber)
+    // b (5 wasted, 0.5) and c (5 wasted, 0.83) tie on wastedRuns → ratio breaks it → c first.
+    expect(order).toEqual(['Calc#memo:c', 'Calc#memo:b', 'Calc#memo:a'])
+  })
+
+  test('honors topN after ranking', () => {
+    seq = 0
+    const events: ProfilerEvent[] = [
+      out('Calc#memo:a', false), out('Calc#memo:a', false), // 2 wasted
+      out('Calc#memo:b', false), // 1 wasted
+    ]
+    const r = analyzeWastedReReruns(events, index, { topN: 1 })
+    expect(r.subscribers).toHaveLength(1)
+    expect(r.subscribers[0].subscriber).toBe('Calc#memo:a')
+  })
+
+  test('runs without a fingerprint (no effectOutput) are not counted', () => {
+    seq = 0
+    // effectEnter/Exit without effectOutput → the run is unfingerprintable, ignored.
+    const events: ProfilerEvent[] = [
+      ev('effectEnter', { subscriber: 'Calc#memo:a' }),
+      ev('effectExit', { subscriber: 'Calc#memo:a', dur: 3 }),
+      out('Calc#memo:a', false),
+    ]
+    const r = analyzeWastedReReruns(events, index)
+    expect(r.subscribers[0].totalRuns).toBe(1) // only the one effectOutput
+    expect(r.subscribers[0].wastedRuns).toBe(1)
+  })
+
+  test('unresolved subscriber ids surface as coverage gaps, runs still counted', () => {
+    seq = 0
+    const ghost = 'Calc#effect:does-not-exist'
+    const events: ProfilerEvent[] = [out(ghost, false), out(ghost, false)]
+    const r = analyzeWastedReReruns(events, index)
+    expect(r.subscribers[0].loc).toBeUndefined()
+    expect(r.subscribers[0].wastedRuns).toBe(2)
+    expect(r.unattributed.map(u => u.id)).toContain(ghost)
+  })
+
+  test('formats the priceLabel-style finding with a proportional bar and fix hint', () => {
+    seq = 0
+    const events: ProfilerEvent[] = []
+    events.push(out('Calc#memo:a', true))
+    for (let i = 0; i < 150; i++) events.push(out('Calc#memo:a', false))
+    const txt = formatWastedReReruns(analyzeWastedReReruns(events, index))
+    expect(txt).toContain('wasted re-runs')
+    expect(txt).toMatch(/wasted: 150\/151 produced identical value/)
+    expect(txt).toContain('█') // proportional bar
+    expect(txt).toContain('split so it doesn') // fix hint on a flagged subscriber
+  })
+
+  test('empty stream formats a clean no-op report', () => {
+    seq = 0
+    const txt = formatWastedReReruns(analyzeWastedReReruns([], index))
+    expect(txt).toContain('(no wasted re-runs recorded)')
+  })
+})

--- a/packages/jsx/src/__tests__/profiler.test.ts
+++ b/packages/jsx/src/__tests__/profiler.test.ts
@@ -220,9 +220,11 @@ describe('buildProfileReport (dynamic, SR1–SR4 + analyses)', () => {
     n = 0
     const events: ProfilerEvent[] = [
       ev('effectEnter', { subscriber: 'Calc#memo:a' }), // mount
+      ev('effectOutput', { subscriber: 'Calc#memo:a', changed: true }), // mount: real output
       ev('turnBegin', { handlerId: 'Calc#handler:s0:click' }),
       ev('effectEnter', { subscriber: 'Calc#memo:a', turn: 'Calc#handler:s0:click' }),
       ev('effectExit', { subscriber: 'Calc#memo:a', dur: 2, turn: 'Calc#handler:s0:click' }),
+      ev('effectOutput', { subscriber: 'Calc#memo:a', changed: false, turn: 'Calc#handler:s0:click' }), // wasted
       ev('turnEnd', {}),
     ]
     const r = buildProfileReport({ source: src, filePath: 'Calc.tsx', scenario: 'auto', events })
@@ -230,11 +232,14 @@ describe('buildProfileReport (dynamic, SR1–SR4 + analyses)', () => {
     expect(r.componentName).toBe('Calc')
     expect(r.turns).toBe(1)
     expect(r.hotSubscribers.subscribers[0].name).toBe('a')
+    expect(r.wastedReReruns.subscribers[0].name).toBe('a')
+    expect(r.wastedReReruns.subscribers[0].wastedRuns).toBe(1)
     expect(r.coverage.handlersFired).toBe(1)
     expect(r.coverage.handlersTotal).toBeGreaterThanOrEqual(1)
     const out = formatProfileReport(r)
     expect(out).toContain('Calc — profile')
     expect(out).toContain('hot subscribers')
+    expect(out).toContain('wasted re-runs')
     expect(out).toContain('coverage:')
   })
 

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -296,6 +296,8 @@ export {
   parseProfilerId,
   analyzeHotSubscribers,
   formatHotSubscribers,
+  analyzeWastedReReruns,
+  formatWastedReReruns,
   analyzeBatchAdvisor,
   formatBatchAdvisor,
 } from './profiler.ts'
@@ -316,6 +318,9 @@ export type {
   HotSubscribersResult,
   HotSubscriber,
   HotSubscribersOptions,
+  WastedReRunsResult,
+  WastedSubscriber,
+  WastedReRunsOptions,
   BatchAdvisorResult,
   BatchCandidate,
   BatchSafety,

--- a/packages/jsx/src/profiler.ts
+++ b/packages/jsx/src/profiler.ts
@@ -12,9 +12,9 @@
  *   - `traceUpdatePath`        → transitive dependents (fan-out + chain depth)
  *
  * The dynamic half (SR1–SR4: instrumented runtime, turn markers, IR join,
- * Hot-subscribers / Wasted-re-runs / Batch-advisor analyses) is specified in
- * `spec/profiler.md` and not yet implemented — `buildProfileReport` is the
- * placeholder seam where it will land.
+ * Hot-subscribers / Wasted-re-runs / Batch-advisor analyses) is assembled by
+ * `buildProfileReport` from a recorded SR2 event stream — see those analyses
+ * below and `spec/profiler.md`.
  */
 
 import ts from 'typescript'
@@ -663,6 +663,156 @@ export function formatHotSubscribers(r: HotSubscribersResult, limit = 12): strin
   return lines.join('\n')
 }
 
+// -- Analysis: wasted re-runs (v1, §4.2.2) ------------------------------------
+
+export interface WastedSubscriber {
+  /** The compiler-assigned subscriber id (effect/memo/binding). */
+  subscriber: string
+  /** Source-mapped node from the SR4 join; absent ⇒ a coverage gap. */
+  loc?: { file: string; line: number }
+  name?: string
+  kind?: ResolvedNode['kind']
+  /** Runs that emitted an output fingerprint (`effectOutput` count). */
+  totalRuns: number
+  /** Fingerprinted runs whose output was identical to the previous run. */
+  wastedRuns: number
+  /** `wastedRuns / totalRuns` — the share of recompute that produced no change. */
+  wastedRatio: number
+  /** True when `wastedRatio` meets the configured threshold. */
+  wasted: boolean
+}
+
+export interface WastedReRunsResult {
+  kind: 'wasted-re-runs'
+  /** Subscribers with ≥1 wasted run, ranked by `wastedRuns` then `wastedRatio`. */
+  subscribers: WastedSubscriber[]
+  /** SR4 coverage gaps — fingerprinted subscriber ids the IR could not resolve. */
+  unattributed: UnattributedId[]
+}
+
+export interface WastedReRunsOptions {
+  /**
+   * `wastedRatio` at/above which a subscriber is flagged `wasted`. A fraction in
+   * `[0,1]` (e.g. `0.5` = half its runs produced identical output). Default 0.5.
+   */
+  wastedRatio?: number
+  /** Keep only the top-N by `wastedRuns` (after ranking). Default: all. */
+  topN?: number
+}
+
+const DEFAULT_WASTED_RATIO = 0.5
+
+/**
+ * Wasted re-runs (§4.2.2): effects/memos that re-ran but produced output
+ * identical to their previous run — the computation happened, the DOM/value did
+ * not change, so the re-run was removable. The complement to hot subscribers:
+ * hot says *where the cost is*, wasted says *how much of it is removable*.
+ *
+ * Pure over the SR2 stream's `effectOutput` fingerprints (memo-value `Object.is`
+ * + instrumented DOM writes) joined to IR source loc — same scenario ⇒ same
+ * ranking. A high ratio means the subscriber reads at a coarser grain than its
+ * output needs; the fix is a finer signal/memo split.
+ */
+export function analyzeWastedReReruns(
+  events: readonly ProfilerEvent[],
+  index: IdIndex,
+  options: WastedReRunsOptions = {},
+): WastedReRunsResult {
+  const threshold = options.wastedRatio ?? DEFAULT_WASTED_RATIO
+
+  interface Acc {
+    total: number
+    wasted: number
+  }
+  const byId = new Map<string, Acc>()
+
+  for (const e of events) {
+    if (e.type !== 'effectOutput' || e.subscriber === undefined || e.changed === undefined) continue
+    let a = byId.get(e.subscriber)
+    if (!a) {
+      a = { total: 0, wasted: 0 }
+      byId.set(e.subscriber, a)
+    }
+    a.total++
+    if (!e.changed) a.wasted++
+  }
+
+  const { unattributed } = joinProfilerEvents(events, index)
+  const nodeFor = new Map<string, ResolvedNode>()
+  for (const [id] of byId) {
+    const node = index.get(id)
+    if (node) nodeFor.set(id, node)
+  }
+
+  let subscribers: WastedSubscriber[] = [...byId.entries()]
+    .map(([subscriber, a]) => {
+      const node = nodeFor.get(subscriber)
+      const wastedRatio = a.total > 0 ? a.wasted / a.total : 0
+      return {
+        subscriber,
+        loc: node?.loc,
+        name: node?.name,
+        kind: node?.kind,
+        totalRuns: a.total,
+        wastedRuns: a.wasted,
+        wastedRatio,
+        wasted: wastedRatio >= threshold,
+      }
+    })
+    // Only subscribers that actually wasted work are findings.
+    .filter(s => s.wastedRuns > 0)
+
+  // Rank by *removable* cost first — absolute wasted runs is what a finer split
+  // would eliminate; ratio (the severity) and id break ties, keeping the order
+  // deterministic across runs (SR7).
+  subscribers.sort(
+    (x, y) =>
+      y.wastedRuns - x.wastedRuns ||
+      y.wastedRatio - x.wastedRatio ||
+      (x.subscriber < y.subscriber ? -1 : x.subscriber > y.subscriber ? 1 : 0),
+  )
+  if (options.topN !== undefined) subscribers = subscribers.slice(0, options.topN)
+
+  // Only fingerprinted subscriber ids matter — filter the join's gaps to ids
+  // that actually appeared as a fingerprinted subscriber.
+  const subscriberIds = new Set(byId.keys())
+  const gaps = unattributed.filter(u => subscriberIds.has(u.id))
+
+  return { kind: 'wasted-re-runs', subscribers, unattributed: gaps }
+}
+
+/** The noun for a subscriber's identical output, keyed by kind (memo vs DOM). */
+function wastedOutputNoun(kind?: ResolvedNode['kind']): string {
+  return kind === 'memo' ? 'identical value' : 'identical DOM'
+}
+
+export function formatWastedReReruns(r: WastedReRunsResult, limit = 12): string {
+  const lines: string[] = []
+  lines.push('wasted re-runs — re-ran but produced identical output')
+  if (r.subscribers.length === 0) {
+    lines.push('  (no wasted re-runs recorded)')
+  }
+  const shown = r.subscribers.slice(0, limit)
+  const maxWasted = shown.reduce((m, s) => Math.max(m, s.wastedRuns), 0)
+  for (const s of shown) {
+    const where = s.loc ? `${s.loc.file}:${s.loc.line}` : '(unresolved)'
+    const base = s.name ?? s.subscriber
+    const label = s.kind && !base.endsWith(')') ? `${base} (${s.kind})` : base
+    const pct = Math.round(s.wastedRatio * 100)
+    const note = s.wasted ? '  ⚠ split so it doesn’t re-run on unrelated changes' : ''
+    lines.push(
+      `  ${fitLabel(label, 24)} ${bar(s.wastedRuns, maxWasted, 14)} wasted: ${s.wastedRuns}/${s.totalRuns} produced ${wastedOutputNoun(s.kind)} (${pct}%)  (${where})${note}`,
+    )
+  }
+  if (r.subscribers.length > shown.length) {
+    lines.push(`  … and ${r.subscribers.length - shown.length} more`)
+  }
+  if (r.unattributed.length > 0) {
+    lines.push(`  ⚠ coverage: ${r.unattributed.length} unresolved subscriber id(s)`)
+  }
+  return lines.join('\n')
+}
+
 // -- Analysis: batch advisor (v1, §4.2.3) -------------------------------------
 
 export type BatchSafety = 'safe' | 'unsafe' | 'unverified'
@@ -910,6 +1060,7 @@ export interface ProfileReport {
   /** Distinct interaction turns. */
   turns: number
   hotSubscribers: HotSubscribersResult
+  wastedReReruns: WastedReRunsResult
   batchAdvisor: BatchAdvisorResult
   coverage: ProfileCoverage
 }
@@ -931,6 +1082,11 @@ export interface ProfileReportInput {
   topN?: number
   /** Drop hot subscribers below this `totalMs` floor (`--hot-ms`). Default: all. */
   minMs?: number
+  /**
+   * `wastedRatio` threshold (`--wasted-pct`) for the wasted-re-runs analysis, a
+   * fraction in `[0,1]`. Default 0.5.
+   */
+  wastedRatio?: number
 }
 
 /**
@@ -989,6 +1145,7 @@ export function buildProfileReport(input: ProfileReportInput): ProfileReport {
     topN: input.topN,
     minMs: input.minMs,
   })
+  const wastedReReruns = analyzeWastedReReruns(events, index, { wastedRatio: input.wastedRatio })
   const batchAdvisor = analyzeBatchAdvisor(events, index)
   const { unattributed, diagnostics } = joinProfilerEvents(events, index)
 
@@ -1024,6 +1181,7 @@ export function buildProfileReport(input: ProfileReportInput): ProfileReport {
     events: events.length,
     turns: turnSeqs.size,
     hotSubscribers,
+    wastedReReruns,
     batchAdvisor,
     coverage: {
       handlersFired: handlerIds.size,
@@ -1051,6 +1209,8 @@ export function formatProfileReport(r: ProfileReport): string {
   }
   lines.push('')
   lines.push(formatHotSubscribers(r.hotSubscribers))
+  lines.push('')
+  lines.push(formatWastedReReruns(r.wastedReReruns))
   lines.push('')
   lines.push(formatBatchAdvisor(r.batchAdvisor))
   lines.push('')

--- a/packages/shared/src/profiler-events.ts
+++ b/packages/shared/src/profiler-events.ts
@@ -23,6 +23,7 @@ export type ProfilerEventType =
   | 'effectCreate'
   | 'effectEnter'
   | 'effectExit'
+  | 'effectOutput'
   | 'effectDispose'
   | 'batchBegin'
   | 'batchFlush'
@@ -53,6 +54,15 @@ export interface ProfilerEvent {
   subscriber?: string
   /** Effect run duration in ms (`effectExit` only). */
   dur?: number
+  /**
+   * Output fingerprint for the run (`effectOutput` only): `true` when the run
+   * produced new output (a memo value that differs by `Object.is`, or a DOM
+   * write that changed the node), `false` when the run recomputed but produced
+   * output identical to its previous run — a *wasted* re-run (§4.2.2). Emitted
+   * only for runs whose output is fingerprintable; a run with no `effectOutput`
+   * event simply isn't counted by the wasted-re-runs analysis.
+   */
+  changed?: boolean
   /** Subscriber kind (`effectCreate` only). */
   kind?: ProfilerSubscriberKind
   /** Whether the set happened inside a `batch()` (`signalSet` only). */

--- a/spec/profiler.md
+++ b/spec/profiler.md
@@ -257,15 +257,22 @@ Most runs / most total time, joined to IR source loc.
 - **Fix hint:** if the subscriber reads signals it doesn't gate on, suggest a
   finer signal/memo split (links to 4.2.2).
 
-#### 4.2.2 Wasted re-runs (v1)
+#### 4.2.2 Wasted re-runs (v1) — *implemented*
 
 Effect re-ran but output/DOM identical ⇒ finer signal/memo split candidate.
+`analyzeWastedReReruns` (`packages/jsx/src/profiler.ts`) over the SR2 stream's
+`effectOutput` fingerprints, joined to IR loc via the SR4 id index.
 
-- **Input:** SR2 enter/exit + a cheap output fingerprint (DOM mutation count, or
-  the written memo value via `Object.is` against prior).
+- **Input:** SR2 `effectOutput` fingerprint events. The runtime emits one per
+  fingerprintable run (`reactive.ts` → `__bfReportOutput`, aggregated and flushed
+  at run exit, dev-only/SR8): memos compare the recomputed value via `Object.is`;
+  text bindings compare the written string in `__bfText` (DOM identity). A run
+  with no fingerprint emits no event and isn't counted. Attribute/class binding
+  fingerprints reuse the same `__bfReportOutput` seam and are follow-up work.
 - **Metric:** `wasted = runsWithIdenticalOutput / totalRuns`.
 - **Finding:** effects with high `wasted`, e.g. `priceLabel: 150/180 produced
-  identical DOM`.
+  identical DOM`; ranked by removable cost (absolute wasted runs), then ratio.
+  `--wasted-pct <n>` sets the flag threshold (default 50%).
 - **Fix hint:** name the unrelated signal in the effect's `deps`
   (`EffectNode.deps`) that triggered the no-op run; suggest splitting it out of
   the reactive read or memoizing the sub-expression.
@@ -430,5 +437,8 @@ Consistent with `graphToJSON` (`loc` simplified to `{file,line}`):
   `"<Component>#…"` prefix is chosen to allow this later).
 - **Wasted-run fingerprint cost.** DOM-mutation counting vs memo-value `Object.is`
   — the latter is free for memos, the former needs a MutationObserver scoped to
-  the component root. v1 starts with memo-value identity, adds DOM fingerprinting
-  behind a flag.
+  the component root. *Resolved (v1):* memo-value identity ships free; text
+  bindings fingerprint synchronously by comparing the written string in
+  `__bfText` (no MutationObserver) — both feed `__bfReportOutput`. Attribute/class
+  bindings extend the same seam as follow-up; a component-root MutationObserver is
+  unnecessary given the synchronous per-write compare.


### PR DESCRIPTION
Closes #1843.

Implements the last remaining **v1** profiler analysis — **Wasted re-runs** (`spec/profiler.md` §4.2.2). The substrate (SR1–SR8), Hot subscribers (§4.2.1), Batch advisor (§4.2.3) and Coverage were already in place; this adds the output-fingerprint signal + the analysis that consumes it.

## What it answers

The complement to Hot subscribers: where Hot says *where the cost is*, Wasted says *how much of that cost is removable*. A reactive effect/memo that **re-ran but produced output identical to its previous run** is a finer signal/memo split candidate.

## Fingerprint (SR1, dev-only / SR8)

New `effectOutput(subscriberId, changed)` sink event rides the existing SR2 stream — no new run.

- **`reactive.ts`** accumulates a per-run output verdict on the running effect (`__bfReportOutput`, OR-ed across writes, flushed as one event at run exit). Reset + emit are gated on the profiler sink, so production is untouched.
- **Memos** compare the recomputed value via `Object.is` (free, deterministic — the spec's v1 default).
- **Text bindings** (`__bfText`) compare the written string synchronously — covers the flagship `priceLabel: 150/180 produced identical DOM` case without a MutationObserver. Attribute/class bindings reuse the same `__bfReportOutput` seam as follow-up.
- A run with no fingerprint emits no event and isn't counted.

## Analysis (SR2 + SR4)

- `analyzeWastedReReruns` / `formatWastedReReruns` in `packages/jsx/src/profiler.ts`: `wasted = wastedRuns / totalRuns`, joined to IR source loc via `buildIdIndex`, ranked by removable cost (absolute wasted runs) then ratio — deterministic (same scenario ⇒ same ranking).
- Surfaced in `buildProfileReport` / `formatProfileReport` (text + `--json`).
- Wired the `--wasted-pct <n>` threshold flag in `debug-profile.ts` (default 50%).

## Tests

- `packages/jsx/src/__tests__/profiler-wasted-re-runs.test.ts` — analysis unit tests (ranking, threshold, gaps, format).
- `packages/client/__tests__/profiler-instrumentation.test.ts` — `effectOutput` fingerprint for memos + `__bfReportOutput` attribution.
- `packages/client/__tests__/runtime/dynamic-text.test.ts` — CSR fingerprint for a text binding.
- `packages/jsx/src/__tests__/profiler.test.ts` — report integration.

All targeted suites pass; full `client` suite (355) and `jsx` profiler suites green. The 4 failures in the full `jsx` run are pre-existing (TS-checker import-alias resolution) and reproduce on a clean tree — unrelated to this change. Type-checks (`tsgo`) clean for `shared`/`client`/`jsx`.

`spec/profiler.md` §4.2.2 moved from *specified* to *implemented*, and the fingerprint open-question resolved.

https://claude.ai/code/session_01HGeTs83muzyQvNaYAh5u7C

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGeTs83muzyQvNaYAh5u7C)_