### PR TITLE
fix(profiler): resolve `#binding` ids for prop-driven attributes (#1844 follow-up)

### DIFF
--- a/.changeset/profiler-prop-attr-binding-resolution.md
+++ b/.changeset/profiler-prop-attr-binding-resolution.md
@@ -1,0 +1,22 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Profiler: resolve `#binding:<slot>` ids for prop-driven attributes (#1844 follow-up).
+
+The compiler wraps a prop-driven attribute (``id={props.id}``,
+``class={`…${props.className}`}``) in a `createEffect` and emits a
+`<Component>#binding:<slot>` profiler id for it — but the debug-side graph
+collector (`collectDomBindings`) only tracked signal/memo dependencies, so those
+bindings were absent from `graph.domBindings` and `buildIdIndex` had no node for
+them. The effect then showed as `(unresolved)` in `bf debug profile` even though
+the id was prefixed with the component's own name (e.g. `Slider#binding:s2`,
+`Accordion#binding:s0`, and imported children like `CheckIcon#binding:s0`).
+
+`collectDomBindings` now detects prop references on attribute expressions,
+mirroring the emitter's `needsEffectWrapper` prop gate exactly (prop names as
+lexer-aware bare identifiers plus the `<propsObject>.x` member pattern, both
+excluding `children`). Such bindings carry no signal/memo `deps`, so fan-out and
+subscription counts are unchanged — only the previously-missing source
+attribution is added. A `PropAttr` shape is added to the SR4 coverage-conformance
+matrix so the emit↔analyzer symmetry is guarded against regression.

--- a/packages/jsx/src/__tests__/profiler-coverage-conformance.test.ts
+++ b/packages/jsx/src/__tests__/profiler-coverage-conformance.test.ts
@@ -116,6 +116,21 @@ const MATRIX: ReadonlyArray<{ name: string; desc: string; source: string }> = [
       }`,
   },
   {
+    name: 'PropAttr',
+    desc: 'prop-driven attribute bindings (with and without a co-located handler)',
+    source: `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function PropAttr(props: { id?: string; disabled?: boolean; className?: string }) {
+        const [n, setN] = createSignal(0)
+        return (
+          <div id={props.id} class={\`base \${props.className ?? ''}\`}>
+            <button onClick={() => setN(n() + 1)} class={\`btn \${props.className ?? ''}\`}>{n()}</button>
+          </div>
+        )
+      }`,
+  },
+  {
     name: 'SignalMemoEffect',
     desc: 'signal + memo + user effect + keyboard handler',
     source: `

--- a/packages/jsx/src/debug.ts
+++ b/packages/jsx/src/debug.ts
@@ -5,7 +5,7 @@
  * paths, and component reactive structure — all without running any code.
  */
 
-import type ts from 'typescript'
+import ts from 'typescript'
 import type {
   ComponentIR,
   IRNode,
@@ -28,6 +28,7 @@ import { buildMetadata } from './compiler.ts'
 import { analyzeClientNeeds } from './ir-to-client-js/index.ts'
 import type { WrapReason } from './ir-to-client-js/reactivity.ts'
 import { decideWrapFromAstFlags } from './ir-to-client-js/reactivity.ts'
+import { tokenContainsIdent } from './ir-to-client-js/utils.ts'
 
 // =============================================================================
 // Types
@@ -292,9 +293,36 @@ export function buildGraphFromIR(ir: ComponentIR): ComponentGraph {
   const memoNames = new Set(meta.memos.map(m => m.name))
   const signalSetters = new Map(meta.signals.filter(s => s.setter).map(s => [s.setter!, s.getter]))
 
+  // Does an attribute expression read a component prop? Mirrors the emitter's
+  // `needsEffectWrapper` prop gate (`reactivity.ts`):
+  //   - any individual destructured prop name (`{ className }` → `class={className}`),
+  //   - or a `<propsObject>.x` member access (`class={props.className}`),
+  // both excluding `children` (server-rendered, never wrapped). Detection is
+  // structural, not a raw-string regex: destructured names use the IR's
+  // lexer-resolved `freeIdentifiers` (falling back to the lexer-aware
+  // `tokenContainsIdent`), and the props-object case parses the expression and
+  // walks for a real `props.member` access — so a `props.` inside a string
+  // literal / comment can't false-match, and bare `props` (`id={props}`) or
+  // `props.children` are correctly NOT treated as reactive (matching the
+  // emitter, which only wraps `<propsObject>.<non-children>`).
+  //
+  // Prop-driven attribute bindings are wrapped in a `createEffect` by the
+  // emitter (and so emit a `#binding:<slot>` profiler id), but the debug-side
+  // collector only tracked signal/memo deps before — so those ids resolved to
+  // `(unresolved)` in `bf debug profile` (#1844 follow-up). Detecting prop reads
+  // here closes that emit↔analyzer gap.
+  const destructuredPropNames = new Set(meta.propsParams.map(p => p.name).filter(n => n !== 'children'))
+  const propsObjectName = meta.propsObjectName
+  const exprReadsProp = (expr: string, freeIds?: ReadonlySet<string>): boolean => {
+    for (const name of destructuredPropNames) {
+      if (freeIds ? freeIds.has(name) : tokenContainsIdent(expr, name)) return true
+    }
+    return propsObjectName ? exprReadsPropMember(expr, propsObjectName) : false
+  }
+
   // Collect DOM bindings from IR tree
   const domBindings: DomBinding[] = []
-  collectDomBindings(ir.root, domBindings, signalGetters, memoNames)
+  collectDomBindings(ir.root, domBindings, signalGetters, memoNames, undefined, new Set(), exprReadsProp)
 
   // Build consumer lists for signals
   const signalConsumers = new Map<string, string[]>()
@@ -1618,6 +1646,11 @@ function collectDomBindings(
   // names it is treated as reactive (matching the emitter's gate), giving the
   // profiler a `domBinding` (slotId + loc) to resolve `<Comp>#binding:<slotId>`.
   loopParams: Set<string> = new Set(),
+  // Predicate: does an attribute expression read a component prop? Mirrors the
+  // emitter's `needsEffectWrapper` prop detection so a prop-driven attribute
+  // (wrapped in `createEffect` at codegen, hence emitting `#binding:<slot>`) is
+  // tracked here too — otherwise its profiler id resolves to `(unresolved)`.
+  readsProp: (expr: string, freeIds?: ReadonlySet<string>) => boolean = () => false,
 ): void {
   // Does a loop-child binding read a loop param (or index)? Use the analyzer's
   // lexer-resolved metadata, NOT a raw-string regex — so a param name that only
@@ -1647,7 +1680,11 @@ function collectDomBindings(
         if (!expr) continue
         const deps = extractReactiveDeps(expr, signalGetters, memoNames)
         const isReactive = deps.length > 0 || attrReadsLoopParam(attr.freeIdentifiers)
-        const wrapReason = inferWrapReasonForAttrLike(isReactive, false, attr)
+        // A prop-driven attribute (`id={props.id}`, `class={`…${props.x}`}`) is
+        // wrapped in a `createEffect` by the emitter even with no signal/memo
+        // dep — match that gate so its `#binding:<slot>` id resolves.
+        const hasPropsRef = readsProp(expr, attr.freeIdentifiers)
+        const wrapReason = inferWrapReasonForAttrLike(isReactive, hasPropsRef, attr)
         if (wrapReason) {
           bindings.push({
             kind: 'dom',
@@ -1655,7 +1692,7 @@ function collectDomBindings(
             slotId: node.slotId ?? '?',
             deps,
             type: 'attribute',
-            classification: isReactive ? 'reactive' : 'fallback',
+            classification: isReactive || hasPropsRef ? 'reactive' : 'fallback',
             expression: expr,
             wrapReason,
             loc: attr.loc,
@@ -1681,7 +1718,7 @@ function collectDomBindings(
       }
       // Recurse — pass element tag as parent context for text bindings
       for (const child of node.children) {
-        collectDomBindings(child, bindings, signalGetters, memoNames, node.tag, loopParams)
+        collectDomBindings(child, bindings, signalGetters, memoNames, node.tag, loopParams, readsProp)
       }
       break
     }
@@ -1738,8 +1775,8 @@ function collectDomBindings(
           jsxPreview: `{${truncateExpr(node.condition)} ? ... : ...}`,
         })
       }
-      collectDomBindings(node.whenTrue, bindings, signalGetters, memoNames, parentTag, loopParams)
-      collectDomBindings(node.whenFalse, bindings, signalGetters, memoNames, parentTag, loopParams)
+      collectDomBindings(node.whenTrue, bindings, signalGetters, memoNames, parentTag, loopParams, readsProp)
+      collectDomBindings(node.whenFalse, bindings, signalGetters, memoNames, parentTag, loopParams, readsProp)
       break
     }
     case 'loop': {
@@ -1789,7 +1826,7 @@ function collectDomBindings(
       for (const p of extractLoopParamNames(node.param, node)) childLoopParams.add(p)
       if (node.index) childLoopParams.add(node.index)
       for (const child of node.children) {
-        collectDomBindings(child, bindings, signalGetters, memoNames, parentTag, childLoopParams)
+        collectDomBindings(child, bindings, signalGetters, memoNames, parentTag, childLoopParams, readsProp)
       }
       break
     }
@@ -1822,21 +1859,21 @@ function collectDomBindings(
         }
       }
       for (const child of node.children) {
-        collectDomBindings(child, bindings, signalGetters, memoNames, parentTag, loopParams)
+        collectDomBindings(child, bindings, signalGetters, memoNames, parentTag, loopParams, readsProp)
       }
       break
     }
     case 'fragment':
     case 'provider': {
       for (const child of node.children) {
-        collectDomBindings(child, bindings, signalGetters, memoNames, parentTag, loopParams)
+        collectDomBindings(child, bindings, signalGetters, memoNames, parentTag, loopParams, readsProp)
       }
       break
     }
     case 'if-statement': {
-      collectDomBindings(node.consequent, bindings, signalGetters, memoNames, parentTag, loopParams)
+      collectDomBindings(node.consequent, bindings, signalGetters, memoNames, parentTag, loopParams, readsProp)
       if (node.alternate) {
-        collectDomBindings(node.alternate, bindings, signalGetters, memoNames, parentTag, loopParams)
+        collectDomBindings(node.alternate, bindings, signalGetters, memoNames, parentTag, loopParams, readsProp)
       }
       break
     }
@@ -1846,6 +1883,40 @@ function collectDomBindings(
 function truncateExpr(expr: string, max: number = 40): string {
   const s = expr.replace(/\s+/g, ' ').trim()
   return s.length > max ? s.slice(0, max - 1) + '…' : s
+}
+
+/**
+ * True when `expr` contains a genuine `<propsObject>.<member>` property access
+ * with `member !== 'children'` — the emitter's prop gate for the props object
+ * (`needsEffectWrapper`, `reactivity.ts`). Parses the expression rather than
+ * regex-matching the raw string, so a `props.` inside a string literal/comment
+ * doesn't false-match, and bare `props` / `props.children` are excluded. Parse
+ * failures (e.g. an attribute expression carrying JSX) fall back to `false` —
+ * conservative: we never invent a binding the emitter wouldn't wrap.
+ */
+function exprReadsPropMember(expr: string, propsObjectName: string): boolean {
+  let sf: ts.SourceFile
+  try {
+    sf = ts.createSourceFile('__attr.tsx', `(${expr})`, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
+  } catch {
+    return false
+  }
+  let found = false
+  const visit = (n: ts.Node): void => {
+    if (found) return
+    if (
+      ts.isPropertyAccessExpression(n) &&
+      ts.isIdentifier(n.expression) &&
+      n.expression.text === propsObjectName &&
+      n.name.text !== 'children'
+    ) {
+      found = true
+      return
+    }
+    ts.forEachChild(n, visit)
+  }
+  visit(sf)
+  return found
 }
 
 /** Convert an `AttrValue` to a flat string for reactive dep extraction. */


### PR DESCRIPTION
## What

Fixes the headline follow-up from #1844: `bf debug profile` showed `(unresolved)` for binding effects prefixed with the **component's own name** — e.g. `Slider#binding:s2`, `Accordion#binding:s0`, and even imported children like `CheckIcon#binding:s0` / `ChevronLeftIcon#binding:s0`.

## Root cause

The compiler wraps a **prop-driven** attribute (`id={props.id}`, `class={`…${props.className}`}`) in a `createEffect` and emits a `#binding:` profiler id for it. But the debug-side graph collector `collectDomBindings` only tracked **signal/memo** dependencies (`extractReactiveDeps`) and hard-coded `hasPropsRef = false`. So a prop-only attribute never became a `domBinding`, `buildIdIndex` had no node for it, and the runtime effect resolved to `(unresolved)`. The SR4 coverage-conformance matrix had no prop-attribute shape, so the gap was invisible.

## Fix

`collectDomBindings` now detects prop references on attribute expressions, **mirroring the emitter's `needsEffectWrapper` prop gate exactly**: prop names as lexer-aware bare identifiers (`tokenContainsIdent` / `freeIdentifiers`) plus the `<propsObject>.x` member pattern, both excluding `children`. Because the detection runs on the same (non-expanded) string the emitter checks, it never adds a binding the emitter didn't wrap.

These bindings carry no signal/memo `deps`, so **fan-out / subscription / static-budget numbers are unchanged** — only the missing source attribution is added. Added a `PropAttr` shape to the SR4 conformance matrix to guard emit↔analyzer symmetry.

## Verified

Before → after, all `#binding:` ids now resolve:

```
slider     unattributed: Slider#binding:s2          → none
accordion  unattributed: Accordion#binding:s0       → none
tabs/collapsible  …#binding:s0                       → none
checkbox   CheckIcon#binding:s0                       → none
calendar   Calendar#binding:s25, ChevronLeftIcon…    → none
```

(The remaining `e1 (unresolved)` on some components is an anonymous runtime bookkeeping id — correctly bucketed as non-actionable, not a `#binding:` gap.)

- Full `packages/jsx` unit suite green: **2071 pass / 0 fail** (145 snapshots) — no graph/summary/IR count regressions.
- Profiler + conformance suites green, new `PropAttr` matrix entry included.

## Stacking

Originally stacked on #1846 → #1845; both have now merged, so this is **rebased onto `main` as a single clean commit**. The compound-budget note (#1848) stacks on top of this one.

Part of the #1844 follow-up set, split into meaningful units per request.

https://claude.ai/code/session_01CfkY3mem7y9teigXYVkj9g