### PR TITLE
fix(profile): never truncate hotSubscribers in --json mode (#1849 B1)

### DIFF
--- a/.changeset/profile-b1-top-json.md
+++ b/.changeset/profile-b1-top-json.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/cli": patch
+---
+
+fix(profile): never truncate `hotSubscribers` in `--json` mode (#1849 B1)
+
+`--top N` is a display cap on the dynamic hot-subscribers table; `--json` is documented as never truncated. The profile command now skips the slice in JSON mode so the serialized subscriber list is complete.

--- a/packages/cli/src/commands/debug-profile.ts
+++ b/packages/cli/src/commands/debug-profile.ts
@@ -230,7 +230,12 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
         scenario: isAuto ? 'auto' : flags.scenario,
         events,
         extraSources,
-        topN: flags.topN,
+        // `--top` is a *display* cap on the dynamic table, not a data filter.
+        // In JSON mode the help promises the full list ("--json is never
+        // truncated"), so skip the slice — applying it here would truncate the
+        // serialized `hotSubscribers.subscribers` too (#1849 B1). Text mode
+        // still passes it so the rendered table honors `--top`.
+        topN: ctx.jsonFlag ? undefined : flags.topN,
         minMs: flags.minMs,
         // `--wasted-pct` is a percentage on the CLI; the analysis takes a [0,1] fraction.
         wastedRatio: flags.wastedPct !== undefined ? flags.wastedPct / 100 : undefined,

--- a/packages/jsx/src/__tests__/profiler.test.ts
+++ b/packages/jsx/src/__tests__/profiler.test.ts
@@ -303,4 +303,35 @@ describe('buildProfileReport (dynamic, SR1–SR4 + analyses)', () => {
     expect(noHandlers.turns).toBe(0)
     expect(formatProfileReport(noHandlers)).toContain('no event handlers')
   })
+
+  test('omitting topN keeps the full subscriber list (the JSON path, #1849 B1)', () => {
+    n = 0
+    // Five distinct subscribers — more than a small `--top`. The CLI passes
+    // `topN: undefined` in JSON mode so the serialized list is never truncated;
+    // pinning the contract here guards that the data layer returns everything
+    // when no cap is requested.
+    const manySrc = `
+      'use client'
+      import { createSignal, createMemo } from '@barefootjs/client'
+      export function Many() {
+        const [count, setCount] = createSignal(0)
+        const a = createMemo(() => count() + 1)
+        const b = createMemo(() => count() + 2)
+        const c = createMemo(() => count() + 3)
+        const d = createMemo(() => count() + 4)
+        const e = createMemo(() => count() + 5)
+        return <button onClick={() => setCount(count() + 1)}>{a()}{b()}{c()}{d()}{e()}</button>
+      }
+    `
+    const events: ProfilerEvent[] = []
+    for (const name of ['a', 'b', 'c', 'd', 'e']) {
+      events.push(ev('effectEnter', { subscriber: `Many#memo:${name}` }))
+      events.push(ev('effectExit', { subscriber: `Many#memo:${name}`, dur: 1 }))
+    }
+    const full = buildProfileReport({ source: manySrc, filePath: 'Many.tsx', scenario: 'auto', events })
+    expect(full.hotSubscribers.subscribers).toHaveLength(5)
+    // With a cap the table truncates — what JSON mode deliberately avoids.
+    const capped = buildProfileReport({ source: manySrc, filePath: 'Many.tsx', scenario: 'auto', events, topN: 2 })
+    expect(capped.hotSubscribers.subscribers).toHaveLength(2)
+  })
 })


### PR DESCRIPTION
Part of the #1849 bug omnibus — **stacked PR 1/8** (B1). Base: `main`.

## B1 — `--top N --json` truncates JSON output (contradicts help text)

`--top` is documented as a *display* cap on the dynamic hot-subscribers table, with `--json` explicitly "never truncated". But `topN` was passed to `buildProfileReport` unconditionally, so `analyzeHotSubscribers` sliced the list before serialization — JSON consumers silently got only N subscribers.

### Fix
Pass `topN: undefined` in JSON mode (`packages/cli/src/commands/debug-profile.ts`), so the slice happens only on the text-formatter path. Text mode still honors `--top`.

### Tests
- `profiler.test.ts`: omitting `topN` keeps the full subscriber list; a cap truncates — pinning the data-layer contract the JSON fix relies on.

https://claude.ai/code/session_01M99qXUrALTzUdG29vjddaV

---
_Generated by [Claude Code](https://claude.ai/code/session_01M99qXUrALTzUdG29vjddaV)_