### PR TITLE
fix(profile): add "diff" kind discriminator to BudgetDiff JSON (#1849 B2)

### DIFF
--- a/.changeset/profile-b2-diff-kind.md
+++ b/.changeset/profile-b2-diff-kind.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/jsx": patch
+---
+
+fix(profile): add `kind: "diff"` discriminator to compile-diff JSON (#1849 B2)
+
+`BudgetDiff` now carries a `kind: "diff"` field so JSON consumers can distinguish a zero-delta diff ("no change") from a pure-static component with no reactive state.

--- a/packages/jsx/src/__tests__/profiler.test.ts
+++ b/packages/jsx/src/__tests__/profiler.test.ts
@@ -173,6 +173,16 @@ describe('diffStaticBudget (SR6)', () => {
     expect(diff.regressed).toBe(false)
     expect(formatBudgetDiff(diff)).toContain('no structural reactivity change')
   })
+
+  test('carries a "diff" kind discriminator (#1849 B2)', () => {
+    // The three JSON modes must be distinguishable: a zero-delta diff
+    // (signals: 0 = "no change") must not look like a static budget
+    // (signals: 0 = "no signals"). `kind` is the discriminator.
+    const a = buildStaticBudget(memoChainSource, 'Calc.tsx', 'Calc')
+    const diff = diffStaticBudget(a, a)
+    expect(diff.kind).toBe('diff')
+    expect(diff.signals).toBe(0)
+  })
 })
 
 describe('parseProfilerId (SR4)', () => {

--- a/packages/jsx/src/profiler.ts
+++ b/packages/jsx/src/profiler.ts
@@ -246,6 +246,13 @@ export interface FanOutChange {
 }
 
 export interface BudgetDiff {
+  /**
+   * Discriminator so a JSON consumer can tell the three `bf debug profile`
+   * modes apart (`static-budget` / `profile` / `diff`). Without it an all-zero
+   * diff (no structural change) was indistinguishable from a pure-static
+   * component with no reactive state (#1849 B2).
+   */
+  kind: 'diff'
   componentName: string
   signals: number
   memos: number
@@ -278,6 +285,7 @@ export function diffStaticBudget(base: StaticBudget, head: StaticBudget): Budget
   fanOut.sort((a, b) => (b.after - b.before) - (a.after - a.before))
 
   const d: Omit<BudgetDiff, 'regressed'> = {
+    kind: 'diff',
     componentName: head.componentName,
     signals: head.signals - base.signals,
     memos: head.memos - base.memos,


### PR DESCRIPTION
Part of the #1849 bug omnibus — **stacked PR 2/8** (B2). Base: `claude/profile-b1-top-json` (B1).

## B2 — `--diff --json` missing `"kind"` discriminator

The static-budget and dynamic-profile JSON each carry a `kind` (`static-budget` / `profile`), but the compile-diff JSON had none. An agent seeing `"signals": 0` in a diff could not tell "no change in signal count" from "0 signals in this component" — the same shape a pure-static component produces.

### Fix
Add `kind: "diff"` to the `BudgetDiff` interface and emit it from `diffStaticBudget` (`packages/jsx/src/profiler.ts`).

### Tests
- `profiler.test.ts`: a zero-delta diff carries `kind === "diff"`.

https://claude.ai/code/session_01M99qXUrALTzUdG29vjddaV

---
_Generated by [Claude Code](https://claude.ai/code/session_01M99qXUrALTzUdG29vjddaV)_