### PR TITLE
fix(profile): actionable error for external @barefootjs/client imports (#1849 B3)

### DIFF
--- a/.changeset/profile-b3-xyflow-error.md
+++ b/.changeset/profile-b3-xyflow-error.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/cli": patch
+---
+
+fix(profile): actionable error for external `@barefootjs/client` imports under `--scenario auto` (#1849 B3)
+
+When a component depends on an external `@barefootjs` package whose compiled output imports `@barefootjs/client` directly (e.g. the cached `@barefootjs/xyflow` build), `--scenario auto` now explains the failure and points at a pre-bundled `--scenario <story.tsx>` or the static budget, instead of surfacing a raw module-resolution stack.

--- a/packages/cli/src/__tests__/scenario-driver-external-import.test.ts
+++ b/packages/cli/src/__tests__/scenario-driver-external-import.test.ts
@@ -1,0 +1,33 @@
+// `isExternalClientImportError` classifies the one failure mode the auto
+// scenario can't fix: a transitive external @barefootjs package whose compiled
+// dist imports `@barefootjs/client` directly (#1849 B3). When it matches, the
+// driver swaps bun's raw module-resolution stack for an actionable message
+// pointing at `--scenario <story.tsx>`.
+
+import { describe, test, expect } from 'bun:test'
+import { isExternalClientImportError } from '../lib/scenario-driver'
+
+describe('isExternalClientImportError', () => {
+  test('matches the cached-package failure from the issue (xyflow)', () => {
+    // The verbatim message `bf debug profile xyflow --scenario auto` surfaced.
+    const msg =
+      "Cannot find module '@barefootjs/client' from " +
+      "'/root/.bun/install/cache/@barefootjs/xyflow@0.10.1@@@1/dist/index.js'"
+    expect(isExternalClientImportError(msg)).toBe(true)
+  })
+
+  test('matches the "Cannot find package" phrasing too', () => {
+    expect(isExternalClientImportError("Cannot find package '@barefootjs/client' from x")).toBe(true)
+  })
+
+  test('does NOT match the runtime sub-path (that import is rewritten in-tree)', () => {
+    // `@barefootjs/client/runtime` is handled by the rewrite pass + its own
+    // "isn't built" guard — it must not be mistaken for the external-package case.
+    expect(isExternalClientImportError("Cannot find module '@barefootjs/client/runtime'")).toBe(false)
+  })
+
+  test('does NOT match unrelated resolution failures', () => {
+    expect(isExternalClientImportError("Cannot find module './component.mjs'")).toBe(false)
+    expect(isExternalClientImportError('some other error')).toBe(false)
+  })
+})

--- a/packages/cli/src/lib/scenario-driver.ts
+++ b/packages/cli/src/lib/scenario-driver.ts
@@ -34,6 +34,18 @@ export interface ScenarioResult {
   sources: SourceFile[]
 }
 
+/**
+ * True when a dynamic-import error is bun failing to resolve `@barefootjs/
+ * client` (without `/runtime`) — the signature of a transitive external
+ * @barefootjs package whose compiled dist imports the client runtime directly
+ * (e.g. the cached `@barefootjs/xyflow` npm build). The import-rewriting pass
+ * only fixes `@barefootjs/client/runtime` in *this* component's chunks, not
+ * inside external bundles, so those fail at `import(file)` (#1849 B3).
+ */
+export function isExternalClientImportError(message: string): boolean {
+  return /Cannot find (?:module|package) ['"]@barefootjs\/client['"]/.test(message)
+}
+
 /** Component names the compiled client JS registers, in emission order. */
 function registeredNames(clientJs: string): string[] {
   const names: string[] = []
@@ -267,7 +279,27 @@ async function runScenario(sources: SourceFile[], mountName?: string): Promise<S
   writeFileSync(file, rewritten)
 
   try {
-    await import(file)
+    try {
+      await import(file)
+    } catch (err) {
+      // A transitive external @barefootjs package (e.g. the cached `@barefootjs/
+      // xyflow` npm build) imports `@barefootjs/client` directly in its compiled
+      // dist. The import-rewriting pass above only rewrites `@barefootjs/client/
+      // runtime` in *this* component's chunks, not inside external bundles, so
+      // bun fails to resolve `@barefootjs/client` from the package's cache dir.
+      // Surface an actionable message instead of the raw module-resolution stack
+      // (#1849 B3).
+      if (isExternalClientImportError((err as Error).message)) {
+        throw new Error(
+          `"${mountName ?? 'component'}" depends on an external @barefootjs package whose ` +
+            'compiled output imports `@barefootjs/client` directly — the dynamic scenario ' +
+            "runner cannot resolve that from the package's cache directory. Profile it with a " +
+            'pre-bundled `--scenario <story.tsx>`, or use the static budget ' +
+            '(`bf debug profile <component>`), which needs no run.',
+        )
+      }
+      throw err
+    }
     const rt = (await import(runtimePath)) as {
       createRecordingSink: () => { sink: unknown; events: ProfilerEvent[] }
       setProfilerSink: (s: unknown) => void


### PR DESCRIPTION
Part of the #1849 bug omnibus — **stacked PR 3/8** (B3). Base: `claude/profile-b2-diff-kind` (B2).

## B3 — `xyflow --scenario auto` crashes with raw, unactionable error

`bf debug profile xyflow --scenario auto` crashed with a raw `Cannot find module '@barefootjs/client'` stack. The component imports a cached npm package (`@barefootjs/xyflow`) whose compiled dist imports `@barefootjs/client` directly; the driver's import-rewriting pass only rewrites `@barefootjs/client/runtime` inside the component's own chunks, not inside transitive external bundles, so bun fails to resolve it at `import(file)`.

### Fix
Detect that specific failure at the `import(file)` boundary (`packages/cli/src/lib/scenario-driver.ts`) and replace it with a message pointing at `--scenario <story.tsx>` (pre-bundled) or the static budget. The classification lives in the exported `isExternalClientImportError` helper so it's unit-testable against the verbatim error.

### Tests
- `scenario-driver-external-import.test.ts`: matches the cached-package failure (and the "Cannot find package" phrasing); does **not** match the `/runtime` sub-path (handled by the existing build guard) or unrelated failures.

https://claude.ai/code/session_01M99qXUrALTzUdG29vjddaV

---
_Generated by [Claude Code](https://claude.ai/code/session_01M99qXUrALTzUdG29vjddaV)_