### PR TITLE
fix(profile): reject --scenario combined with --diff (#1849 B4)

### DIFF
--- a/.changeset/profile-b4-scenario-diff.md
+++ b/.changeset/profile-b4-scenario-diff.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/cli": patch
+---
+
+fix(profile): reject `--scenario` combined with `--diff` (#1849 B4)
+
+`--scenario` (measure a run) and `--diff` (compare two compiles) are mutually exclusive modes. Combining them previously ran the scenario and silently dropped `--diff`; it now errors up front with an explanatory message.

--- a/packages/cli/src/__tests__/debug-profile-flags.test.ts
+++ b/packages/cli/src/__tests__/debug-profile-flags.test.ts
@@ -1,0 +1,28 @@
+// `bf debug profile` mode flags. `--scenario` (measure a run) and `--diff`
+// (compare two compiles) are mutually exclusive; combining them used to
+// silently run the scenario and drop `--diff` (#1849 B4). We spawn the CLI so
+// the guard is exercised exactly as a user hits it — and the check fires before
+// any run, so no built client runtime is required.
+
+import { describe, test, expect } from 'bun:test'
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const CLI_ENTRY = path.join(fileURLToPath(new URL('.', import.meta.url)), '..', 'index.ts')
+
+function runCli(args: string[]): { exitCode: number | null; stderr: string } {
+  const r = spawnSync('bun', [CLI_ENTRY, ...args], {
+    encoding: 'utf-8',
+    cwd: path.join(fileURLToPath(new URL('.', import.meta.url)), '..', '..', '..', '..'),
+  })
+  return { exitCode: r.status, stderr: r.stderr }
+}
+
+describe('bf debug profile — --scenario + --diff are mutually exclusive (#1849 B4)', () => {
+  test('combining them exits non-zero with an explanatory error', () => {
+    const r = runCli(['debug', 'profile', 'button', '--scenario', 'auto', '--diff', 'HEAD~1'])
+    expect(r.exitCode).toBe(1)
+    expect(r.stderr).toContain('--scenario and --diff cannot be combined')
+  })
+})

--- a/packages/cli/src/commands/debug-profile.ts
+++ b/packages/cli/src/commands/debug-profile.ts
@@ -181,6 +181,14 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
 
   const flags = parseFlags(args)
 
+  // `--scenario` (measure a run) and `--diff` (compare two compiles) are
+  // mutually exclusive modes. The dynamic block returns before the diff check,
+  // so combining them silently ran the scenario and dropped `--diff` (#1849 B4).
+  // Reject it instead of returning the wrong output without warning.
+  if (flags.scenario && flags.diff) {
+    fail('--scenario and --diff cannot be combined: --scenario measures a run, --diff compares two compiles. Pick one.')
+  }
+
   const {
     buildStaticBudget,
     formatStaticBudget,


### PR DESCRIPTION
Part of the #1849 bug omnibus — **stacked PR 4/8** (B4). B1–B3 are merged; this is now the bottom of the remaining stack (base: `main`).

## B4 — `--scenario auto --diff` silently ignores `--diff`

The dynamic `--scenario` block returned before the `--diff` check, so `bf debug profile  --scenario auto --diff ` silently ran the scenario and dropped `--diff` — returning a plain dynamic profile with no warning.

### Fix
These are mutually exclusive modes (measure a run vs. compare two compiles). Reject the combination up front with an explanatory error (`packages/cli/src/commands/debug-profile.ts`).

### Tests
- `debug-profile-flags.test.ts`: spawns the CLI; combining the flags exits non-zero with the explanatory message. (Guard fires before any run, so no built runtime is needed.)

https://claude.ai/code/session_01M99qXUrALTzUdG29vjddaV

---
_Generated by [Claude Code](https://claude.ai/code/session_01M99qXUrALTzUdG29vjddaV)_