### PR TITLE
fix(profile): resolve preview-only components via index.preview.tsx (#1849 B5)

### DIFF
--- a/.changeset/profile-b5-settings-form.md
+++ b/.changeset/profile-b5-settings-form.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/cli": patch
+---
+
+fix(profile): resolve preview-only components via `index.preview.tsx` (#1849 B5)
+
+A monorepo component directory that ships only `index.preview.tsx` (no `index.tsx`, e.g. `settings-form`) now resolves to the preview — noted on stderr, never polluting `--json` stdout — instead of erroring with "Cannot find component". `index.tsx` still wins when both exist.

--- a/packages/cli/src/__tests__/resolve-source.test.ts
+++ b/packages/cli/src/__tests__/resolve-source.test.ts
@@ -127,6 +127,39 @@ describe('resolveComponentSource', () => {
     }
   })
 
+  test('falls back to index.preview.tsx for a preview-only monorepo entry (#1849 B5)', () => {
+    // `settings-form` ships only index.preview.tsx (no index.tsx). The resolver
+    // must resolve it to the preview and flag `isPreview` so the caller can note
+    // it, rather than erroring with "Cannot find component".
+    const projectDir = mktmp()
+    const compDir = path.join(projectDir, 'ui/components/ui/settings-form')
+    mkdirSync(compDir, { recursive: true })
+    writeFileSync(path.join(compDir, 'index.preview.tsx'), 'export function Default() { return null }')
+    try {
+      const r = resolveComponentSource('settings-form', ctxFor(projectDir))
+      expect(r).not.toBeNull()
+      expect(r!.filePath).toBe(path.join(compDir, 'index.preview.tsx'))
+      expect(r!.isPreview).toBe(true)
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  test('prefers index.tsx over index.preview.tsx when both exist', () => {
+    const projectDir = mktmp()
+    const compDir = path.join(projectDir, 'ui/components/ui/dialog')
+    mkdirSync(compDir, { recursive: true })
+    writeFileSync(path.join(compDir, 'index.tsx'), 'export {}')
+    writeFileSync(path.join(compDir, 'index.preview.tsx'), 'export {}')
+    try {
+      const r = resolveComponentSource('dialog', ctxFor(projectDir))
+      expect(r!.filePath).toBe(path.join(compDir, 'index.tsx'))
+      expect(r!.isPreview).toBeUndefined()
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
   test('returns null and populates `searched` with every candidate it tried', () => {
     // Drives the "Looked in:" error transcript surfaced by the debug
     // commands when the user types an unknown component name.

--- a/packages/cli/src/commands/debug-profile.ts
+++ b/packages/cli/src/commands/debug-profile.ts
@@ -214,6 +214,12 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
     process.exit(1)
   }
 
+  // A preview-only component (index.preview.tsx, no index.tsx) was resolved —
+  // note it on stderr so it never pollutes --json stdout (#1849 B5).
+  if (resolved.isPreview) {
+    console.error(`Note: "${componentName}" has no index.tsx — profiling its preview (index.preview.tsx).`)
+  }
+
   const source = readFileSync(resolved.filePath, 'utf-8')
 
   // -- Dynamic mode (SR1–SR4): mount the instrumented build and measure -----

--- a/packages/cli/src/lib/resolve-source.ts
+++ b/packages/cli/src/lib/resolve-source.ts
@@ -16,6 +16,12 @@ import type { CliContext } from '../context'
 export interface ResolvedSource {
   filePath: string
   componentName?: string
+  /**
+   * True when the only entry on disk was `index.preview.tsx` (no `index.tsx`) —
+   * a preview-only component dir like `settings-form` (#1849 B5). Callers should
+   * note that they resolved a preview rather than a real component entry.
+   */
+  isPreview?: boolean
 }
 
 /**
@@ -87,6 +93,16 @@ export function resolveComponentSource(
       searched,
     )
     if (monoHit) return { filePath: monoHit }
+
+    // Preview-only entry: the dir exists with `index.preview.tsx` but no
+    // `index.tsx` (e.g. `settings-form`). Fall back to the preview so the
+    // command works instead of erroring with "Cannot find component" (#1849 B5);
+    // `isPreview` lets the caller note it resolved a preview, not a real entry.
+    const monoPreview = tryCandidate(
+      path.join(ctx.root, 'ui/components/ui', nameOrPath, 'index.preview.tsx'),
+      searched,
+    )
+    if (monoPreview) return { filePath: monoPreview, isPreview: true }
   }
 
   // 3. paths.components from barefoot.config.ts (registry-item layout)


### PR DESCRIPTION
Part of the #1849 bug omnibus — **stacked PR 5/8** (B5). B1–B4 are merged; this is now the bottom of the remaining stack (base: `main`).

## B5 — `settings-form` component not found despite directory existing

`bf debug profile settings-form` errored with &#34;Cannot find component&#34; even though the directory exists — it ships only `index.preview.tsx`, and the resolver looked for `index.tsx` exclusively. Agents iterating every UI component hit a spurious failure.

### Fix
Fall back to `index.preview.tsx` for a monorepo component dir that has no `index.tsx`, flagging `isPreview` on the result (`packages/cli/src/lib/resolve-source.ts`). The profile command notes the preview source on **stderr** (never polluting `--json` stdout). `index.tsx` still wins when both exist.

### Tests
- `resolve-source.test.ts`: a preview-only entry resolves to the preview with `isPreview: true`; `index.tsx` is preferred when both exist.

https://claude.ai/code/session_01M99qXUrALTzUdG29vjddaV

---
_Generated by [Claude Code](https://claude.ai/code/session_01M99qXUrALTzUdG29vjddaV)_