### PR TITLE
fix(profile): summarize coverage.diagnostics in JSON (#1849 B7)

### DIFF
--- a/.changeset/profile-b7-diagnostics-json.md
+++ b/.changeset/profile-b7-diagnostics-json.md
@@ -1,0 +1,9 @@
+---
+"@barefootjs/jsx": patch
+---
+
+fix(profile): summarize `coverage.diagnostics` in JSON (#1849 B7)
+
+The JSON `coverage.diagnostics` field is now a compact `{ count, sample }` summary instead of a per-id array that could run to hundreds of non-actionable entries for loop-heavy components. The text report is unchanged (it only ever printed the count).
+
+Note: `ProfileReport.coverage.diagnostics` is now an object rather than an array.

--- a/packages/jsx/src/__tests__/profiler.test.ts
+++ b/packages/jsx/src/__tests__/profiler.test.ts
@@ -315,6 +315,23 @@ describe('buildProfileReport (dynamic, SR1–SR4 + analyses)', () => {
     expect(formatProfileReport(noHandlers)).toContain('no event handlers')
   })
 
+  test('coverage.diagnostics is a compact summary, not a full id array (#1849 B7)', () => {
+    n = 0
+    // A long tail of anonymous runtime bookkeeping ids (loop-generated binding
+    // ids on a grid component). JSON consumers get a count + a small sample
+    // instead of hundreds of `{id,count}` objects.
+    const events: ProfilerEvent[] = []
+    for (let i = 0; i < 50; i++) {
+      events.push(ev('signalSet', { signal: `s${i}` }))
+    }
+    const r = buildProfileReport({ source: src, filePath: 'Calc.tsx', scenario: 'auto', events })
+    expect(r.coverage.diagnostics.count).toBe(50)
+    expect(r.coverage.diagnostics.sample.length).toBeLessThanOrEqual(3)
+    expect(Array.isArray(r.coverage.diagnostics.sample)).toBe(true)
+    // The text report still summarizes by count.
+    expect(formatProfileReport(r)).toContain('50 anonymous runtime id(s)')
+  })
+
   test('omitting topN keeps the full subscriber list (the JSON path, #1849 B1)', () => {
     n = 0
     // Five distinct subscribers — more than a small `--top`. The CLI passes

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -311,6 +311,7 @@ export type {
   ProfileReport,
   ProfileReportInput,
   ProfileCoverage,
+  DiagnosticsSummary,
   EffectCandidate,
   IdIndex,
   ResolvedNode,

--- a/packages/jsx/src/profiler.ts
+++ b/packages/jsx/src/profiler.ts
@@ -1175,6 +1175,21 @@ function turnToEventBinding(graph: ComponentGraph, events: EventBinding[]): Map<
 
 // -- Dynamic report (SR1–SR4 + analyses, SR7) ---------------------------------
 
+/**
+ * Compact rollup of the non-actionable runtime bookkeeping ids — a count plus a
+ * small sample. The full per-id list could run to hundreds of entries for a
+ * loop-heavy component (a calendar's 6-week grid emits ~90 binding ids × mount
+ * + interaction ≈ 180), drowning a JSON consumer in noise it can't act on
+ * (#1849 B7). The text report only ever printed the count, so the array carried
+ * no information the summary doesn't.
+ */
+export interface DiagnosticsSummary {
+  /** Total distinct anonymous runtime bookkeeping ids encountered. */
+  count: number
+  /** A few example ids (hottest first) for a sanity check — not exhaustive. */
+  sample: string[]
+}
+
 export interface ProfileCoverage {
   /** Distinct handlers exercised (turns observed). */
   handlersFired: number
@@ -1185,9 +1200,9 @@ export interface ProfileCoverage {
   /**
    * Anonymous runtime bookkeeping ids (`s*`/`e*`/`m*`/`r*`) that have no source
    * node — non-actionable noise, kept out of `unattributed` so the gap list
-   * stays meaningful, but reported here so nothing is silently dropped.
+   * stays meaningful, but summarized here so nothing is silently dropped.
    */
-  diagnostics: UnattributedId[]
+  diagnostics: DiagnosticsSummary
 }
 
 export interface ProfileReport {
@@ -1348,7 +1363,10 @@ export function buildProfileReport(input: ProfileReportInput): ProfileReport {
       handlersFired: handlerIds.size,
       handlersTotal,
       unattributed,
-      diagnostics,
+      // Roll the (potentially hundreds of) bookkeeping ids up to a count + a
+      // small sample so JSON consumers aren't flooded (#1849 B7). `diagnostics`
+      // is already sorted hottest-first by `joinProfilerEvents`.
+      diagnostics: { count: diagnostics.length, sample: diagnostics.slice(0, 3).map(d => d.id) },
     },
   }
 }
@@ -1382,8 +1400,8 @@ export function formatProfileReport(r: ProfileReport): string {
   }
   // Anonymous runtime bookkeeping ids (s*/e*/m*/r*) are noted but flagged
   // non-actionable, so the report is honest about coverage without crying wolf.
-  if (c.diagnostics.length > 0) {
-    lines.push(`  · ${c.diagnostics.length} anonymous runtime id(s) (non-actionable bookkeeping)`)
+  if (c.diagnostics.count > 0) {
+    lines.push(`  · ${c.diagnostics.count} anonymous runtime id(s) (non-actionable bookkeeping)`)
   }
   return lines.join('\n')
 }


### PR DESCRIPTION
Part of the #1849 bug omnibus (**B7**). B1–B6 are merged; this now targets `main` directly as a standalone PR.

## B7 — `coverage.diagnostics` JSON is extremely large for loop-heavy components

For loop-heavy components the JSON `coverage.diagnostics` array held every anonymous runtime bookkeeping id individually — a calendar's 6-week grid produced ~180 `{id,count}` objects, kilobytes of non-actionable noise. The text report only ever printed the count, so the array carried no information a compact rollup doesn't.

### Fix
Replace the array with a `DiagnosticsSummary` (`{ count, sample }`) (`packages/jsx/src/profiler.ts`, exported from `packages/jsx/src/index.ts`). The text formatter reads `.count`; JSON consumers get the count plus a small hottest-first sample instead of the full list.

> Schema change: `ProfileReport.coverage.diagnostics` is now an object, not an array.

### Tests
- `profiler.test.ts`: a 50-id tail rolls up to `{ count: 50, sample: [...≤3] }`, and the text report still summarizes by count.

> Note: this branch was rebuilt cleanly on `main` after a stacked-PR mishap that had briefly collapsed B6/B7/B8 onto one commit. It now contains B7 only. The Copilot review note about B8/scope no longer applies; the `isFallbackEffectId` and double-paren/scan suggestions moved to the dedicated follow-up PR.

https://claude.ai/code/session_01M99qXUrALTzUdG29vjddaV