### PR TITLE
fix(profile): address #1856 Copilot review — de-dup parens, gate uninstrumented scan, align candidate loc

### DIFF
--- a/.changeset/profile-b6-review-followup.md
+++ b/.changeset/profile-b6-review-followup.md
@@ -1,0 +1,11 @@
+---
+"@barefootjs/jsx": patch
+---
+
+fix(profile): de-dup parens, gate the uninstrumented-effect scan, align candidate loc (#1849 B6 review)
+
+Follow-up to the B6 hot-subscribers work:
+
+- The hot-subscribers report no longer renders doubled parentheses (`((unresolved))` / `((uninstrumented — …))`) — the location is wrapped exactly once.
+- `buildProfileReport` skips the per-source `createEffect` candidate scan entirely unless a runtime fallback `e<n>` id is present, so the common fully-instrumented case does no extra work.
+- Candidate call-site line numbers are computed from the call node's start to match the compiler's effect locations exactly.

--- a/packages/jsx/src/__tests__/profiler-hot-subscribers.test.ts
+++ b/packages/jsx/src/__tests__/profiler-hot-subscribers.test.ts
@@ -217,6 +217,9 @@ describe('analyzeHotSubscribers', () => {
     const out = formatHotSubscribers(r)
     expect(out).toContain('(uninstrumented — createEffect in non-JSX scope)')
     expect(out).toContain('candidates: collapsible/index.tsx:82, :126')
+    // Exactly one pair of parens around the label — the `where` string and the
+    // row formatter must not both add them (regression: `((uninstrumented …))`).
+    expect(out).not.toContain('((')
   })
 
   test('caps the formatted list and summarizes the overflow', () => {

--- a/packages/jsx/src/profiler.ts
+++ b/packages/jsx/src/profiler.ts
@@ -465,6 +465,19 @@ function isRuntimeBookkeepingId(id: string): boolean {
 }
 
 /**
+ * A runtime *fallback effect* id (`e1`, `e2`, …) — the subset of bookkeeping
+ * ids the runtime assigns to a `createEffect` the compiler never named (one in
+ * a ref callback / helper, not top-level reactive init). Narrower than
+ * {@link isRuntimeBookkeepingId} on purpose: only these surface as
+ * `uninstrumented` hot rows with candidate sites (#1849 B6), so the hot-table
+ * label and the candidate-scan gate share this one definition rather than each
+ * re-spelling `^e\d+$`.
+ */
+function isFallbackEffectId(id: string): boolean {
+  return /^e\d+$/.test(id)
+}
+
+/**
  * Join a recorded event stream (SR2) to a component's IR (SR4). Each event's
  * `subscriber` / `signal` id is resolved to its source-mapped node; ids with no
  * match are collected as coverage gaps. This is the seam that turns a raw
@@ -527,7 +540,10 @@ export function findUninstrumentedEffects(
   const out: EffectCandidate[] = []
   const visit = (node: ts.Node): void => {
     if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === 'createEffect') {
-      const line = sf.getLineAndCharacterOfPosition(node.expression.getStart(sf)).line + 1
+      // Use the call node's start (not the callee identifier's) to match the
+      // compiler's `EffectInfo.loc`, which is `getSourceLocation(node)` over the
+      // CallExpression — so an instrumented effect's line never mismatches here.
+      const line = sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1
       if (!instrumentedLines.has(line)) out.push({ file: filePath, line })
     }
     ts.forEachChild(node, visit)
@@ -671,7 +687,7 @@ export function analyzeHotSubscribers(
     // helper). Keep it in the table — its cost is real — but label *why* it has
     // no location and surface candidate source lines so the reader needn't hunt
     // for it (#1849 B6). Other bookkeeping ids (`s*`/`m*`/`r*`) stay plain.
-    const uninstrumented = !node && /^e\d+$/.test(subscriber)
+    const uninstrumented = !node && isFallbackEffectId(subscriber)
     return {
       subscriber,
       loc: node?.loc,
@@ -775,13 +791,14 @@ export function formatHotSubscribers(r: HotSubscribersResult, limit = 12): strin
   const maxMs = shown.reduce((m, s) => Math.max(m, s.totalMs), 0)
   for (const s of shown) {
     // An uninstrumented `e<n>` id has no loc by design (the compiler never named
-    // it); say so explicitly instead of the bare `(unresolved)` that reads like
-    // a broken profiler (#1849 B6).
+    // it); say so explicitly instead of the bare `unresolved` that reads like
+    // a broken profiler (#1849 B6). These strings carry no parens of their own —
+    // the row formatter wraps `where` in a single `(…)` below.
     const where = s.loc
       ? `${s.loc.file}:${s.loc.line}`
       : s.resolution === 'uninstrumented'
-        ? '(uninstrumented — createEffect in non-JSX scope)'
-        : '(unresolved)'
+        ? 'uninstrumented — createEffect in non-JSX scope'
+        : 'unresolved'
     const base = s.name ?? s.subscriber
     // Binding names already carry their type (`s1 (attribute)`); don't double up.
     const label = s.kind && !base.endsWith(')') ? `${base} (${s.kind})` : base
@@ -1308,12 +1325,20 @@ export function buildProfileReport(input: ProfileReportInput): ProfileReport {
 
   // Candidate sites for uninstrumented `createEffect` ids, across every source
   // in the run (a compound scenario spans several files), so an `e<n>` row can
-  // cite where to look (#1849 B6).
+  // cite where to look (#1849 B6). The per-file AST scan is only ever consumed
+  // when a runtime fallback `e<n>` id is in the stream, so skip it entirely in
+  // the common case (every effect compiler-instrumented) where it would be
+  // wasted work.
+  const hasFallbackEffectId = events.some(
+    e => e.subscriber !== undefined && isFallbackEffectId(e.subscriber),
+  )
   const uninstrumentedCandidates: EffectCandidate[] = []
-  for (const s of allSources) {
-    uninstrumentedCandidates.push(
-      ...findUninstrumentedEffects(s.source, s.filePath, instrumentedEffectLines.get(s.filePath) ?? new Set()),
-    )
+  if (hasFallbackEffectId) {
+    for (const s of allSources) {
+      uninstrumentedCandidates.push(
+        ...findUninstrumentedEffects(s.source, s.filePath, instrumentedEffectLines.get(s.filePath) ?? new Set()),
+      )
+    }
   }
 
   const hotSubscribers = analyzeHotSubscribers(events, index, {


### PR DESCRIPTION
Follow-up to **#1856 (B6)**, which merged before its Copilot review was addressed. These three fixes land directly on `main` (the B6 code they touch is already merged).

## Fixes (Copilot review of #1856)

- **Double parentheses** — `formatHotSubscribers` wrapped the location in `(…)`, but the uninstrumented/unresolved `where` strings already carried their own parens, rendering `((unresolved))` / `((uninstrumented — …))`. The strings now carry no parens; the row formatter adds the single pair. Regression assertion (`not.toContain('((')`) added.
- **Unconditional AST scan** — `buildProfileReport` scanned every source for uninstrumented `createEffect` sites even when no runtime fallback `e<n>` id was in the stream. The scan is now gated on a fallback id actually appearing, so the common (fully-instrumented) case pays nothing.
- **Candidate line off-by-trivia** — `findUninstrumentedEffects` computed the line from the callee identifier's start; it now uses the call node's start to mirror the compiler's `getSourceLocation(node)` exactly.

## Also (Copilot review of #1857)

- Extracted a narrow `isFallbackEffectId` (`/^e\d+$/`) helper shared by the hot-table label and the scan gate, instead of re-spelling the regex in both. Deliberately *not* reusing `isRuntimeBookkeepingId` (`/^[serm]\d+$/`), which is broader and would scan for non-effect bookkeeping ids too.

### Tests
`profiler-hot-subscribers.test.ts`: the uninstrumented row keeps a single paren pair and lists candidates; real compiler ids unaffected.

> Context: these fixes briefly rode the wrong branch during a stacked-PR mishap (see #1858). This PR re-lands them cleanly on `main`.

https://claude.ai/code/session_01M99qXUrALTzUdG29vjddaV

---
_Generated by [Claude Code](https://claude.ai/code/session_01M99qXUrALTzUdG29vjddaV)_