### PR TITLE
fix(profile): stop git stderr leaking on a bad --diff ref (#1849 B8)

### DIFF
--- a/.changeset/profile-b8-git-stderr.md
+++ b/.changeset/profile-b8-git-stderr.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/cli": patch
+---
+
+fix(profile): stop git stderr leaking on a bad `--diff` ref (#1849 B8)
+
+`readFileAtRef` now captures git's stderr (`stdio: pipe`) and folds its message into a single CLI error line, instead of letting git's raw `fatal: invalid object name …` leak ahead of the CLI's own message.

--- a/packages/cli/src/__tests__/debug-profile-flags.test.ts
+++ b/packages/cli/src/__tests__/debug-profile-flags.test.ts
@@ -1,8 +1,8 @@
-// `bf debug profile` mode flags. `--scenario` (measure a run) and `--diff`
-// (compare two compiles) are mutually exclusive; combining them used to
-// silently run the scenario and drop `--diff` (#1849 B4). We spawn the CLI so
-// the guard is exercised exactly as a user hits it — and the check fires before
-// any run, so no built client runtime is required.
+// `bf debug profile` mode flags and error surfaces. We spawn the CLI so the
+// behavior is exercised exactly as a user hits it — these paths fire before any
+// run, so no built client runtime is required. Covers:
+//   - B4: `--scenario` + `--diff` are mutually exclusive
+//   - B8: git's stderr doesn't leak ahead of the CLI error on a bad --diff ref
 
 import { describe, test, expect } from 'bun:test'
 import { spawnSync } from 'node:child_process'
@@ -24,5 +24,23 @@ describe('bf debug profile — --scenario + --diff are mutually exclusive (#1849
     const r = runCli(['debug', 'profile', 'button', '--scenario', 'auto', '--diff', 'HEAD~1'])
     expect(r.exitCode).toBe(1)
     expect(r.stderr).toContain('--scenario and --diff cannot be combined')
+  })
+})
+
+describe('bf debug profile — git stderr does not leak on a bad --diff ref (#1849 B8)', () => {
+  test('git diagnostics fold into the CLI error, no raw "fatal:" line leaks', () => {
+    const r = runCli(['debug', 'profile', 'button', '--diff', 'nonexistent-ref'])
+    expect(r.exitCode).toBe(1)
+    // Our message explains the failure, names the ref we asked for, and folds in
+    // git's own diagnostic. We avoid asserting git's exact phrasing (e.g.
+    // "invalid object name"), which varies across git versions/locales — only
+    // that the requested ref and *some* git text were incorporated.
+    expect(r.stderr).toContain('Cannot read')
+    expect(r.stderr).toContain('nonexistent-ref')
+    expect(r.stderr).toContain('fatal:')
+    // …but git's raw stderr must never appear on its own line ahead of ours: the
+    // `fatal:` text is folded inline, so no line may *start* with it.
+    const leaked = r.stderr.split('\n').some(line => line.startsWith('fatal:'))
+    expect(leaked).toBe(false)
   })
 })

--- a/packages/cli/src/commands/debug-profile.ts
+++ b/packages/cli/src/commands/debug-profile.ts
@@ -273,11 +273,15 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
 
   // -- Compile-diff regression (SR6) ----------------------------------------
   if (flags.diff) {
-    const baseSource = readFileAtRef(resolved.filePath, flags.diff)
-    if (baseSource === null) {
-      console.error(`Error: Cannot read "${resolved.filePath}" at ref "${flags.diff}".`)
+    const baseRead = readFileAtRef(resolved.filePath, flags.diff)
+    if ('error' in baseRead) {
+      // Fold git's own message into ours (it was already suppressed from
+      // leaking to stderr) so the failure is explained in one line (#1849 B8).
+      const detail = baseRead.error ? ` (${baseRead.error})` : ''
+      console.error(`Error: Cannot read "${resolved.filePath}" at ref "${flags.diff}".${detail}`)
       process.exit(1)
     }
+    const baseSource = baseRead.content
     const base = buildStaticBudget(baseSource, resolved.filePath, resolved.componentName, {
       fanOutThreshold: flags.fanOutThreshold,
     })
@@ -302,20 +306,33 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
 
 /**
  * Read a file's contents at a git ref via `git show <ref>:<relpath>`. Returns
- * null when the ref or path can't be resolved (e.g. file didn't exist there).
+ * `{ content }` on success, or `{ error }` (git's own stderr, trimmed) when the
+ * ref or path can't be resolved. Git's stderr is captured rather than inherited
+ * so its raw "fatal: invalid object name …" never leaks ahead of the CLI's own
+ * message (#1849 B8) — the caller folds `error` into a single line instead.
  */
-function readFileAtRef(filePath: string, ref: string): string | null {
+function readFileAtRef(filePath: string, ref: string): { content: string } | { error: string } {
+  // `stdio: pipe` on stderr keeps git's diagnostics out of the process stderr;
+  // on failure the captured text is available as `err.stderr`.
+  const capture = { stdio: ['ignore', 'pipe', 'pipe'] as const, encoding: 'utf-8' as const }
+  const gitError = (err: unknown): { error: string } => {
+    const stderr = (err as { stderr?: string | Buffer }).stderr
+    const msg = stderr ? String(stderr).trim() : (err as Error).message
+    return { error: msg }
+  }
+  let root: string
   try {
-    const root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+    root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      ...capture,
       cwd: path.dirname(filePath),
-      encoding: 'utf-8',
     }).trim()
-    const rel = path.relative(root, path.resolve(filePath))
-    return execFileSync('git', ['show', `${ref}:${rel}`], {
-      cwd: root,
-      encoding: 'utf-8',
-    })
-  } catch {
-    return null
+  } catch (err) {
+    return gitError(err)
+  }
+  const rel = path.relative(root, path.resolve(filePath))
+  try {
+    return { content: execFileSync('git', ['show', `${ref}:${rel}`], { ...capture, cwd: root }) }
+  } catch (err) {
+    return gitError(err)
   }
 }


### PR DESCRIPTION
Re-lands **B8** (part of the #1849 omnibus) on `main`. Replaces **#1858**, which GitHub auto-closed as "merged" due to a stacked-branch mishap — B8's fix never actually reached `main`. This PR is standalone on `main` (B8's CLI change is independent of B6/B7).

## B8 — Raw git error leaks to stderr before the CLI error message

`bf debug profile … --diff <badref>` printed git's raw `fatal: invalid object name …` to stderr *before* the CLI's own error, cluttering agent logs with two messages for one failure.

### Fix
`readFileAtRef` (`packages/cli/src/commands/debug-profile.ts`) now captures git's stderr (`stdio: pipe`) instead of letting it inherit the process stderr, and returns `{ error }` carrying git's trimmed message. The caller folds it into a single `Cannot read … (fatal: …)` line.

### Tests
`debug-profile-flags.test.ts`: a nonexistent ref yields one CLI error that names the requested ref and folds in git's diagnostic, with **no** standalone `fatal:` line leaking ahead of it. Assertions avoid git's exact phrasing (version/locale-dependent) per review — they check the requested ref and that some git text was incorporated inline.

https://claude.ai/code/session_01M99qXUrALTzUdG29vjddaV

---
_Generated by [Claude Code](https://claude.ai/code/session_01M99qXUrALTzUdG29vjddaV)_