### PR TITLE
PoC: DPU-based OOS streaming swap

### DIFF
--- a/experiments/dpu-oos-poc/README.md
+++ b/experiments/dpu-oos-poc/README.md
@@ -1,0 +1,90 @@
+# PoC: DPU を使った OOS streaming swap
+
+Barefoot の現行 Out-of-Order Streaming（OOS）は、クライアント JS による手書き swap です：
+
+```html
+<div bf-async="a0">…fallback…</div>
+<template bf-async-resolve="a0">…resolved…</template>
+<script>__bf_swap("a0")</script>
+```
+
+`__bf_swap`（`packages/client/src/runtime/streaming.ts`）が `querySelector` →
+`replaceChildren` → template 除去を手動でやっています。
+
+[Declarative Partial Updates (DPU)](https://developer.chrome.com/blog/declarative-partial-updates)
+は、これを **ブラウザネイティブ・JS なし** で行う提案です：
+
+```html
+<?start name="a0">…fallback…<?end>
+<template for="a0">…resolved…</template>
+```
+
+この PoC は「**同一マークアップが、DPU 対応ブラウザではネイティブに、非対応では
+コメント範囲ベースの JS フォールバックで、同じ結果になる**」ことを検証します。
+
+## 実行
+
+```bash
+bun run experiments/dpu-oos-poc/server.ts
+# → http://localhost:8787
+```
+
+サーバは out-of-order に時間差でチャンクを流します（検証済み）：
+
+```
++0.02s  HEAD/body flushed       … 初期レスポンス（プレースホルダ2つ）
++1.21s  a1 resolved chunk       … <template for="a1"> を後追いで flush
++2.01s  a0 resolved chunk       … <template for="a0"> を後追いで flush
+```
+
+## 観測ポイント
+
+ページ上部の「適用経路」バッジが、どちらの経路で swap されたかを示します。
+
+### (A) ネイティブ DPU 経路
+
+- **Chrome 148+**（Canary 推奨）で `chrome://flags/#enable-experimental-web-platform-features`
+  を **Enabled** にして再起動。
+- プレースホルダが JS を介さずパッチされ、バッジが **`native DPU (no JS swap)`**（緑）。
+- `<?start>/<?end>` は `ProcessingInstruction` ノードとしてパースされ、`<template for>`
+  到着時にブラウザが範囲を置換します。フォールバック script は
+  `data-bf-fallback` センチネルが既に消えているので **no-op**。
+
+### (B) JS フォールバック経路
+
+- フラグ OFF、または Firefox / Safari / 旧 Chrome。
+- `<?start name="a0">` は **bogus comment** `<!--?start name="a0"-->` に降格。
+- 各 `<template for>` 直後の `<script>__bf_dpu_fallback("a0")</script>` が、
+  `<!--?start-->` … `<!--?end-->` の**コメント範囲**を走査して template 内容で置換。
+  バッジは **`JS fallback (comment-range swap)`**（黄）。
+
+両経路で最終 DOM は同一になります。
+
+## なぜこれが Barefoot にとって意味があるか
+
+このフォールバックのコメント範囲走査は、Barefoot が既に持っている仕組みと**同型**です：
+
+- ループ境界 `<!--bf-loop:id-->` … `<!--bf-/loop:id-->`（`packages/shared/src/markers.ts`）
+- OOS swap の `__bf_swap`（`packages/client/src/runtime/streaming.ts`）
+
+つまり Barefoot は DPU 標準化より前に同じ設計に到達しており、DPU 対応ブラウザでは
+この層を**ネイティブに肩代わりさせられる**可能性がある、というのが本 PoC の主旨です。
+
+## スコープ（できること / できないこと）
+
+- ✅ サーバ push 型の OOS swap（本 PoC が対象）
+- ❌ 制御構文（for / if）の生成責務 — これはバックエンドテンプレ側に残る
+- ❌ シグナルによるクライアントローカルな局所更新 — サーバ往復が要るため DPU 対象外
+
+## ブラウザ状況（2026-06 時点）
+
+- Chrome 148+ のフラグ裏のみ。Firefox / Safari のシグナルなし。**production 不可**。
+- したがって採用するなら **progressive enhancement**（capability があればネイティブ、
+  なければ現行 `__bf_swap` フォールバック）が前提。本 PoC のマークアップは
+  そのまま両対応になっている。
+
+## 参考
+
+- [Declarative partial updates — Chrome for Developers](https://developer.chrome.com/blog/declarative-partial-updates)
+- [WICG/declarative-partial-updates patching-explainer.md](https://github.com/WICG/declarative-partial-updates/blob/main/patching-explainer.md)
+- [chromestatus: Declarative Document Patching](https://chromestatus.com/feature/5111042975465472)

--- a/experiments/dpu-oos-poc/server.ts
+++ b/experiments/dpu-oos-poc/server.ts
@@ -1,0 +1,175 @@
+/**
+ * PoC: Declarative Partial Updates (DPU) を使った Out-of-Order Streaming swap
+ *
+ * 目的:
+ *   Barefoot の現行 OOS ストリーミング（`<div bf-async>` + `<template bf-async-resolve>`
+ *   + `<script>__bf_swap()</script>` の手書き swap）を、ブラウザネイティブの
+ *   Declarative Partial Updates で「JS なしで」置き換えられるかを検証する。
+ *
+ * 検証する命題:
+ *   同一マークアップが
+ *     (A) DPU 対応ブラウザでは <?start>/<?end> + <template for> によりネイティブに、
+ *     (B) 非対応ブラウザでは <?start>/<?end> が bogus comment に降格 → それを
+ *         コメント範囲として JS が swap する（= Barefoot の bf-loop / __bf_swap と同型）、
+ *   の両方で同じ結果になること。
+ *
+ * 実行:  bun run experiments/dpu-oos-poc/server.ts
+ * 観測:  http://localhost:8787 を開く
+ *   - Chrome 148+ で chrome://flags/#enable-experimental-web-platform-features を ON
+ *     → JS フォールバックは発火せず（バッジが "native DPU"）パッチが当たる
+ *   - フラグ OFF / 他ブラウザ
+ *     → コメント範囲フォールバックが発火（バッジが "JS fallback"）して同じ結果になる
+ *
+ * curl で「ストリームが時間差で届く」ことだけ確認したい場合:
+ *   curl --no-buffer http://localhost:8787
+ */
+
+const PORT = 8787
+
+const enc = new TextEncoder()
+
+/** 1つの非同期境界の「解決」チャンク（時間差で flush される本体）。 */
+function resolvedChunk(name: string, label: string): string {
+  const serverTime = new Date().toISOString()
+  return (
+    // <template for="<name>"> が DPU の本体。name でプレースホルダに対応づく。
+    `<template for="${name}">` +
+    `<div class="resolved" data-resolved="${name}">` +
+    `<strong>${label} resolved ✅</strong> ` +
+    `<small>server time ${serverTime}</small>` +
+    `</div>` +
+    `</template>` +
+    // 非対応ブラウザ向けの保険。DPU が当たっていれば no-op になる。
+    // Barefoot の `<script>__bf_swap("a0")</script>` と同じ役割。
+    `<script>window.__bf_dpu_fallback && window.__bf_dpu_fallback(${JSON.stringify(name)})</script>\n`
+  )
+}
+
+/** プレースホルダ（範囲マーカー + フォールバック内容）。 */
+function placeholder(name: string, label: string): string {
+  // <?start name>/<?end> は DPU 対応ブラウザでは ProcessingInstruction、
+  // 非対応では bogus comment <!--?start name="a0"--> ... <!--?end--> に降格する。
+  // data-bf-fallback は「まだ解決されていない」ことを示すセンチネル。
+  // DPU が範囲を置換すれば消えるので、フォールバック発火条件の判定に使う。
+  return (
+    `<?start name="${name}">` +
+    `<span class="pending" data-bf-fallback="${name}">⏳ ${label} loading…</span>` +
+    `<?end>`
+  )
+}
+
+const head = `<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>DPU OOS swap PoC</title>
+<style>
+  body { font: 16px/1.6 system-ui, sans-serif; max-width: 40rem; margin: 2rem auto; padding: 0 1rem; }
+  section { border: 1px solid #ccc; border-radius: 8px; padding: 1rem; margin: 1rem 0; }
+  .pending { color: #b45309; }
+  .resolved { color: #166534; }
+  #mode { padding: .25rem .5rem; border-radius: 4px; background: #eee; font-size: .85rem; }
+  .native { background: #dcfce7 !important; }
+  .fallback { background: #fef9c3 !important; }
+</style>
+</head>
+<body>
+<h1>DPU で OOS streaming swap</h1>
+<p>適用経路: <span id="mode">measuring…</span></p>
+`
+
+/**
+ * フォールバック実装。
+ *
+ * - DPU が効いていれば data-bf-fallback のセンチネルは消えているので no-op。
+ * - 効いていなければ、bogus comment に降格した <!--?start name="x"--> ...
+ *   <!--?end--> の範囲を走査し、<template for="x"> の内容で置換する。
+ *   これは Barefoot の bf-loop コメント範囲スキャンと同じ走査パターン。
+ */
+const fallbackScript = `<script>
+(function () {
+  var usedFallback = false;
+
+  function findComment(pred) {
+    var w = document.createTreeWalker(document.body, NodeFilter.SHOW_COMMENT);
+    var n;
+    while ((n = w.nextNode())) { if (pred(n)) return n; }
+    return null;
+  }
+
+  window.__bf_dpu_fallback = function (name) {
+    // センチネルが残っている = DPU は適用されなかった。
+    var pending = document.querySelector('[data-bf-fallback="' + name + '"]');
+    if (!pending) return; // ネイティブ DPU が既に置換済み → 何もしない
+
+    var tmpl = document.querySelector('template[for="' + name + '"]');
+    if (!tmpl) return;
+
+    // bogus comment に降格した範囲マーカーを探す。
+    var startData = '?start name="' + name + '"';
+    var start = findComment(function (c) { return c.nodeValue.trim() === startData; });
+    var end = findComment(function (c) { return c.nodeValue.trim() === '?end'; });
+
+    if (start && end && start.parentNode === end.parentNode) {
+      // start と end の間のノードを撤去して template 内容を差し込む。
+      var node = start.nextSibling;
+      while (node && node !== end) { var next = node.nextSibling; node.remove(); node = next; }
+      end.parentNode.insertBefore(tmpl.content.cloneNode(true), end);
+    } else {
+      // 範囲が取れない場合はセンチネル位置で素朴に置換。
+      pending.replaceWith(tmpl.content.cloneNode(true));
+    }
+    tmpl.remove();
+    usedFallback = true;
+    setMode();
+  };
+
+  function setMode() {
+    var el = document.getElementById('mode');
+    if (!el) return;
+    if (usedFallback) { el.textContent = 'JS fallback (comment-range swap)'; el.className = 'fallback'; }
+    else { el.textContent = 'native DPU (no JS swap)'; el.className = 'native'; }
+  }
+
+  // 全チャンク到着後、フォールバックを一度も使っていなければネイティブ判定。
+  window.addEventListener('load', function () { if (!usedFallback) setMode(); });
+})();
+</script>
+`
+
+function stream(): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    async start(controller) {
+      const push = (s: string) => controller.enqueue(enc.encode(s))
+      const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+      // 1) 初期レスポンス: head + フォールバックscript + 2つのプレースホルダ。
+      push(head)
+      push(fallbackScript)
+      push(`<section>${placeholder('a0', 'Product detail')}</section>\n`)
+      push(`<section>${placeholder('a1', 'Reviews')}</section>\n`)
+
+      // 2) 解決を out-of-order に流す（a1 が先に解決するケースを再現）。
+      await sleep(1200)
+      push(resolvedChunk('a1', 'Reviews'))
+
+      await sleep(800)
+      push(resolvedChunk('a0', 'Product detail'))
+
+      // 3) 終端。
+      push(`</body></html>`)
+      controller.close()
+    },
+  })
+}
+
+Bun.serve({
+  port: PORT,
+  fetch() {
+    return new Response(stream(), {
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    })
+  },
+})
+
+console.log(`DPU OOS PoC: http://localhost:${PORT}`)


### PR DESCRIPTION
## What

A runnable proof-of-concept exploring whether [Declarative Partial Updates (DPU)](https://developer.chrome.com/blog/declarative-partial-updates) can take over Barefoot's Out-of-Order Streaming (OOS) swap natively.

Today OOS swap is hand-written client JS:

```html
<div bf-async="a0">…fallback…</div>
<template bf-async-resolve="a0">…resolved…</template>
<script>__bf_swap("a0")</script>
```

DPU does the same thing JS-free:

```html
<?start name="a0">…fallback…<?end>
<template for="a0">…resolved…</template>
```

## Thesis being tested

**One markup, two paths, same final DOM** — progressive enhancement:

- **DPU-capable (Chrome 148+ w/ flag):** browser patches the `<?start>/<?end>` range natively when `<template for>` arrives; the fallback `<script>` no-ops because the `data-bf-fallback` sentinel is already gone.
- **Otherwise:** `<?start>` degrades to a bogus comment `<!--?start name="a0"-->`; the fallback script swaps the **comment range** with the template content — the exact same scanning pattern as Barefoot's `bf-loop` markers and `__bf_swap`.

This is why DPU is relevant to Barefoot: we independently arrived at comment-range markers, and DPU-capable browsers could offload that layer.

## Verified

Server-side out-of-order timed streaming, via `curl --no-buffer`:

```
+0.02s  HEAD/body flushed
+1.21s  a1 resolved chunk
+2.01s  a0 resolved chunk
```

Native DPU rendering must be checked manually in Chrome 148+ with `chrome://flags/#enable-experimental-web-platform-features` — see `experiments/dpu-oos-poc/README.md`.

## Scope

- ✅ server-push OOS swap
- ❌ control flow (for/if) generation — stays in backend templates
- ❌ signal-driven client-local updates — out of DPU's model

## Run

```bash
bun run experiments/dpu-oos-poc/server.ts   # http://localhost:8787
```

Not production-ready: DPU is Chrome-flag-only with no Firefox/Safari signals as of 2026-06.

https://claude.ai/code/session_01UBzKsTynJtqhFijuJtxvhx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBzKsTynJtqhFijuJtxvhx)_