### PR TITLE
fix(profile): detect external @barefootjs/* runtime imports pre-flight (#1849 B3 follow-up)

### DIFF
--- a/.changeset/profile-chart-external-import.md
+++ b/.changeset/profile-chart-external-import.md
@@ -1,0 +1,13 @@
+---
+"@barefootjs/cli": patch
+---
+
+fix(profile): actionable error for external `@barefootjs/client/runtime` imports (#1849 B3 follow-up)
+
+`bf debug profile chart --scenario auto` leaked a raw `Cannot find module
+'@barefootjs/client/runtime'` stack. The B3 classifier only matched a bare
+`@barefootjs/client` import, but the cached `@barefootjs/chart` dist imports the
+`/runtime` subpath. `isExternalClientImportError` now also matches the subpath
+when the failing importer is a third-party bundle (bun cache / node_modules), so
+these surface the same actionable "use `--scenario <story.tsx>` or the static
+budget" message as xyflow instead of a raw module-resolution stack.

--- a/.changeset/profile-chart-external-import.md
+++ b/.changeset/profile-chart-external-import.md
@@ -2,12 +2,18 @@
 "@barefootjs/cli": patch
 ---
 
-fix(profile): actionable error for external `@barefootjs/client/runtime` imports (#1849 B3 follow-up)
+fix(profile): detect external `@barefootjs/*` runtime imports before the run (#1849 B3 follow-up)
 
 `bf debug profile chart --scenario auto` leaked a raw `Cannot find module
-'@barefootjs/client/runtime'` stack. The B3 classifier only matched a bare
-`@barefootjs/client` import, but the cached `@barefootjs/chart` dist imports the
-`/runtime` subpath. `isExternalClientImportError` now also matches the subpath
-when the failing importer is a third-party bundle (bun cache / node_modules), so
-these surface the same actionable "use `--scenario <story.tsx>` or the static
-budget" message as xyflow instead of a raw module-resolution stack.
+'@barefootjs/client/runtime'` stack: the cached `@barefootjs/chart` /
+`@barefootjs/xyflow` dists import the client runtime directly, which the
+import-rewriting pass can't reach inside an external bundle.
+
+Detection now happens *pre-flight* against the driver's own compiled client JS
+(`externalRuntimeImport`): any `@barefootjs/*` import the compiler leaves in the
+emitted client JS other than the handled `@barefootjs/client[/...]` /
+`@barefootjs/jsx[/...]` families is an un-rewritable external runtime package, so
+the run is skipped with an actionable message that names the offending package
+and points at `--scenario <story.tsx>` or the static budget. This replaces the
+previous error-message classifier, which matched bun's resolution stack text and
+was fragile to bun version and importer-path formatting.

--- a/packages/cli/src/__tests__/scenario-driver-external-import.test.ts
+++ b/packages/cli/src/__tests__/scenario-driver-external-import.test.ts
@@ -20,9 +20,19 @@ describe('isExternalClientImportError', () => {
     expect(isExternalClientImportError("Cannot find package '@barefootjs/client' from x")).toBe(true)
   })
 
-  test('does NOT match the runtime sub-path (that import is rewritten in-tree)', () => {
-    // `@barefootjs/client/runtime` is handled by the rewrite pass + its own
-    // "isn't built" guard — it must not be mistaken for the external-package case.
+  test('matches a /runtime sub-path failure from an external package bundle (chart)', () => {
+    // The verbatim message `bf debug profile chart --scenario auto` surfaced: a
+    // cached @barefootjs package whose dist imports `@barefootjs/client/runtime`
+    // directly. The subpath only counts because the importer is a cache bundle.
+    const msg =
+      "Cannot find module '@barefootjs/client/runtime' from " +
+      "'/root/.bun/install/cache/@barefootjs/chart@0.10.1@@@1/dist/index.js'"
+    expect(isExternalClientImportError(msg)).toBe(true)
+  })
+
+  test('does NOT match a bare /runtime sub-path with no external importer', () => {
+    // Without a third-party `from` path this is the in-tree rewrite / "isn't
+    // built" case, handled by its own guard — not the external-package case.
     expect(isExternalClientImportError("Cannot find module '@barefootjs/client/runtime'")).toBe(false)
   })
 

--- a/packages/cli/src/__tests__/scenario-driver-external-import.test.ts
+++ b/packages/cli/src/__tests__/scenario-driver-external-import.test.ts
@@ -25,6 +25,15 @@ describe('externalRuntimeImport', () => {
     expect(externalRuntimeImport(js)).toBe('@barefootjs/chart')
   })
 
+  test('flags a bare side-effect import (`import \'@barefootjs/<pkg>\'`)', () => {
+    // The compiler emits side-effect imports without a `from` clause (see
+    // `collectExternalImports`); they must not slip past detection.
+    const js =
+      "import { hydrate } from '@barefootjs/client/runtime'\n" +
+      "import '@barefootjs/chart'\n"
+    expect(externalRuntimeImport(js)).toBe('@barefootjs/chart')
+  })
+
   test('scans across multiple chunks', () => {
     const chunks = [
       "import { hydrate } from '@barefootjs/client/runtime'\n",

--- a/packages/cli/src/__tests__/scenario-driver-external-import.test.ts
+++ b/packages/cli/src/__tests__/scenario-driver-external-import.test.ts
@@ -1,43 +1,54 @@
-// `isExternalClientImportError` classifies the one failure mode the auto
-// scenario can't fix: a transitive external @barefootjs package whose compiled
-// dist imports `@barefootjs/client` directly (#1849 B3). When it matches, the
-// driver swaps bun's raw module-resolution stack for an actionable message
-// pointing at `--scenario <story.tsx>`.
+// `externalRuntimeImport` detects — before the dynamic run, from the driver's
+// own compiled client JS — the one failure mode the auto scenario can't fix: a
+// component that imports an external published `@barefootjs/*` runtime package
+// whose prebuilt dist imports `@barefootjs/client` directly (#1849 B3). When it
+// matches, the driver swaps bun's raw module-resolution stack for an actionable
+// message pointing at `--scenario <story.tsx>`. Reading our own import graph
+// (rather than classifying bun's error message) keeps detection stable across
+// bun versions and importer-path formatting.
 
 import { describe, test, expect } from 'bun:test'
-import { isExternalClientImportError } from '../lib/scenario-driver'
+import { externalRuntimeImport } from '../lib/scenario-driver'
 
-describe('isExternalClientImportError', () => {
-  test('matches the cached-package failure from the issue (xyflow)', () => {
-    // The verbatim message `bf debug profile xyflow --scenario auto` surfaced.
-    const msg =
-      "Cannot find module '@barefootjs/client' from " +
-      "'/root/.bun/install/cache/@barefootjs/xyflow@0.10.1@@@1/dist/index.js'"
-    expect(isExternalClientImportError(msg)).toBe(true)
+describe('externalRuntimeImport', () => {
+  test('flags an external runtime package (xyflow) and names it', () => {
+    const js =
+      "import { hydrate } from '@barefootjs/client/runtime';\n" +
+      "import { ReactFlow } from '@barefootjs/xyflow';\n"
+    expect(externalRuntimeImport(js)).toBe('@barefootjs/xyflow')
   })
 
-  test('matches the "Cannot find package" phrasing too', () => {
-    expect(isExternalClientImportError("Cannot find package '@barefootjs/client' from x")).toBe(true)
+  test('flags chart too', () => {
+    const js =
+      "import { createSignal } from '@barefootjs/client/runtime'\n" +
+      "import { LineChart } from '@barefootjs/chart'\n"
+    expect(externalRuntimeImport(js)).toBe('@barefootjs/chart')
   })
 
-  test('matches a /runtime sub-path failure from an external package bundle (chart)', () => {
-    // The verbatim message `bf debug profile chart --scenario auto` surfaced: a
-    // cached @barefootjs package whose dist imports `@barefootjs/client/runtime`
-    // directly. The subpath only counts because the importer is a cache bundle.
-    const msg =
-      "Cannot find module '@barefootjs/client/runtime' from " +
-      "'/root/.bun/install/cache/@barefootjs/chart@0.10.1@@@1/dist/index.js'"
-    expect(isExternalClientImportError(msg)).toBe(true)
+  test('scans across multiple chunks', () => {
+    const chunks = [
+      "import { hydrate } from '@barefootjs/client/runtime'\n",
+      "import { BarChart } from '@barefootjs/chart'\n",
+    ]
+    expect(externalRuntimeImport(chunks)).toBe('@barefootjs/chart')
   })
 
-  test('does NOT match a bare /runtime sub-path with no external importer', () => {
-    // Without a third-party `from` path this is the in-tree rewrite / "isn't
-    // built" case, handled by its own guard — not the external-package case.
-    expect(isExternalClientImportError("Cannot find module '@barefootjs/client/runtime'")).toBe(false)
+  test('does NOT flag the handled @barefootjs/client[/...] family', () => {
+    const js =
+      "import { createSignal, hydrate } from '@barefootjs/client/runtime'\n" +
+      "import { something } from '@barefootjs/client'\n"
+    expect(externalRuntimeImport(js)).toBeNull()
   })
 
-  test('does NOT match unrelated resolution failures', () => {
-    expect(isExternalClientImportError("Cannot find module './component.mjs'")).toBe(false)
-    expect(isExternalClientImportError('some other error')).toBe(false)
+  test('does NOT flag the compile-time @barefootjs/jsx family', () => {
+    const js =
+      "import { jsx } from '@barefootjs/jsx/jsx-runtime'\n" +
+      "import { Fragment } from '@barefootjs/jsx'\n"
+    expect(externalRuntimeImport(js)).toBeNull()
+  })
+
+  test('returns null when nothing reactive imports an external package', () => {
+    expect(externalRuntimeImport("import { hydrate } from '@barefootjs/client/runtime'\n")).toBeNull()
+    expect(externalRuntimeImport('const x = 1\n')).toBeNull()
   })
 })

--- a/packages/cli/src/lib/scenario-driver.ts
+++ b/packages/cli/src/lib/scenario-driver.ts
@@ -36,14 +36,30 @@ export interface ScenarioResult {
 
 /**
  * True when a dynamic-import error is bun failing to resolve `@barefootjs/
- * client` (without `/runtime`) — the signature of a transitive external
- * @barefootjs package whose compiled dist imports the client runtime directly
- * (e.g. the cached `@barefootjs/xyflow` npm build). The import-rewriting pass
- * only fixes `@barefootjs/client/runtime` in *this* component's chunks, not
- * inside external bundles, so those fail at `import(file)` (#1849 B3).
+ * client` from inside a transitive external @barefootjs package whose compiled
+ * dist imports the client runtime directly (e.g. the cached `@barefootjs/xyflow`
+ * or `@barefootjs/chart` npm builds). The import-rewriting pass only fixes
+ * `@barefootjs/client/runtime` in *this* component's chunks, not inside external
+ * bundles, so those fail at `import(file)` (#1849 B3).
+ *
+ * Two shapes reach here:
+ *   - bare `@barefootjs/client` — our own chunks never import the package root
+ *     (only `@barefootjs/client/runtime`, rewritten to an absolute path), so a
+ *     bare-root failure is the external signature outright.
+ *   - a subpath like `@barefootjs/client/runtime` — this only counts when the
+ *     failing importer is a third-party bundle (bun cache / node_modules). Our
+ *     chunks are rewritten and the "isn't built" guard fires before `import()`,
+ *     so an external importer is the only way a subpath failure lands here
+ *     (the `chart` component surfaces exactly this).
  */
 export function isExternalClientImportError(message: string): boolean {
-  return /Cannot find (?:module|package) ['"]@barefootjs\/client['"]/.test(message)
+  const m = /Cannot find (?:module|package) ['"]@barefootjs\/client(\/[^'"]*)?['"](?:\s+from\s+['"]([^'"]+)['"])?/.exec(
+    message,
+  )
+  if (!m) return false
+  const [, subpath, importer] = m
+  if (!subpath) return true
+  return importer != null && /[\\/](?:\.bun[\\/]install[\\/]cache|node_modules)[\\/]/.test(importer)
 }
 
 /** Component names the compiled client JS registers, in emission order. */

--- a/packages/cli/src/lib/scenario-driver.ts
+++ b/packages/cli/src/lib/scenario-driver.ts
@@ -57,11 +57,16 @@ export interface ScenarioResult {
  * absolute path before the run and the package root is never emitted; `@barefootjs/
  * jsx[/...]` because it is a compile-time-only dependency the compiler transforms
  * away (it never reaches the runtime import).
+ *
+ * Both import forms the compiler can emit are matched: a named/default `import …
+ * from '<pkg>'` and a bare side-effect `import '<pkg>'` (see
+ * `collectExternalImports` in `@barefootjs/jsx`), so a side-effect-only external
+ * import can't slip past pre-flight detection.
  */
 export function externalRuntimeImport(clientJs: string | string[]): string | null {
   const chunks = Array.isArray(clientJs) ? clientJs : [clientJs]
   for (const chunk of chunks) {
-    for (const m of chunk.matchAll(/import[^;\n]*from\s*['"](@barefootjs\/[^'"]+)['"]/g)) {
+    for (const m of chunk.matchAll(/import\s+(?:[^'"\n]*from\s*)?['"](@barefootjs\/[^'"]+)['"]/g)) {
       const spec = m[1]
       if (spec === '@barefootjs/client' || spec.startsWith('@barefootjs/client/')) continue
       if (spec === '@barefootjs/jsx' || spec.startsWith('@barefootjs/jsx/')) continue

--- a/packages/cli/src/lib/scenario-driver.ts
+++ b/packages/cli/src/lib/scenario-driver.ts
@@ -35,31 +35,40 @@ export interface ScenarioResult {
 }
 
 /**
- * True when a dynamic-import error is bun failing to resolve `@barefootjs/
- * client` from inside a transitive external @barefootjs package whose compiled
- * dist imports the client runtime directly (e.g. the cached `@barefootjs/xyflow`
- * or `@barefootjs/chart` npm builds). The import-rewriting pass only fixes
- * `@barefootjs/client/runtime` in *this* component's chunks, not inside external
- * bundles, so those fail at `import(file)` (#1849 B3).
+ * The compiled client JS of an external published `@barefootjs/*` runtime
+ * package the auto runner can't profile (e.g. `@barefootjs/chart`,
+ * `@barefootjs/xyflow`), or null when there is none.
  *
- * Two shapes reach here:
- *   - bare `@barefootjs/client` — our own chunks never import the package root
- *     (only `@barefootjs/client/runtime`, rewritten to an absolute path), so a
- *     bare-root failure is the external signature outright.
- *   - a subpath like `@barefootjs/client/runtime` — this only counts when the
- *     failing importer is a third-party bundle (bun cache / node_modules). Our
- *     chunks are rewritten and the "isn't built" guard fires before `import()`,
- *     so an external importer is the only way a subpath failure lands here
- *     (the `chart` component surfaces exactly this).
+ * Such a package ships a prebuilt dist that imports `@barefootjs/client`
+ * directly. The driver's import-rewriting pass only fixes *this* component's own
+ * `@barefootjs/client/runtime` imports, not the ones buried in an external
+ * bundle, so a dynamic run can't resolve the client runtime from the package's
+ * cache directory and bun throws an opaque module-resolution stack (#1849 B3).
+ *
+ * We detect the condition *before* the run, from our own deterministic compiler
+ * output: any `@barefootjs/*` import the compiler leaves in the emitted client JS
+ * other than the handled `@barefootjs/client[/...]` and `@barefootjs/jsx[/...]`
+ * families is an un-rewritable external runtime package. Reading the import graph
+ * we generate — rather than classifying bun's resolution *error message* — keeps
+ * this stable across bun versions and importer-path formatting, which the old
+ * message-matching heuristic was fragile to.
+ *
+ * `@barefootjs/client[/...]` is excluded because `/runtime` is rewritten to an
+ * absolute path before the run and the package root is never emitted; `@barefootjs/
+ * jsx[/...]` because it is a compile-time-only dependency the compiler transforms
+ * away (it never reaches the runtime import).
  */
-export function isExternalClientImportError(message: string): boolean {
-  const m = /Cannot find (?:module|package) ['"]@barefootjs\/client(\/[^'"]*)?['"](?:\s+from\s+['"]([^'"]+)['"])?/.exec(
-    message,
-  )
-  if (!m) return false
-  const [, subpath, importer] = m
-  if (!subpath) return true
-  return importer != null && /[\\/](?:\.bun[\\/]install[\\/]cache|node_modules)[\\/]/.test(importer)
+export function externalRuntimeImport(clientJs: string | string[]): string | null {
+  const chunks = Array.isArray(clientJs) ? clientJs : [clientJs]
+  for (const chunk of chunks) {
+    for (const m of chunk.matchAll(/import[^;\n]*from\s*['"](@barefootjs\/[^'"]+)['"]/g)) {
+      const spec = m[1]
+      if (spec === '@barefootjs/client' || spec.startsWith('@barefootjs/client/')) continue
+      if (spec === '@barefootjs/jsx' || spec.startsWith('@barefootjs/jsx/')) continue
+      return spec
+    }
+  }
+  return null
 }
 
 /** Component names the compiled client JS registers, in emission order. */
@@ -231,6 +240,23 @@ async function runScenario(sources: SourceFile[], mountName?: string): Promise<S
     )
   }
 
+  // Bail out before the run if any chunk still imports an external published
+  // `@barefootjs/*` runtime package: its prebuilt dist imports `@barefootjs/
+  // client` directly and the import-rewriting pass below can't reach inside it,
+  // so the dynamic run would fail with an opaque module-resolution stack from
+  // the package's cache directory. Surface an actionable message instead, named
+  // for the actual package (#1849 B3).
+  const external = externalRuntimeImport(clientChunks)
+  if (external) {
+    throw new Error(
+      `"${mountName ?? 'component'}" imports the external package ${external}, whose compiled ` +
+        'output imports `@barefootjs/client` directly — the dynamic scenario runner cannot ' +
+        "resolve that from the package's cache directory. Profile it with a pre-bundled " +
+        '`--scenario <story.tsx>`, or use the static budget (`bf debug profile <component>`), ' +
+        'which needs no run.',
+    )
+  }
+
   // Merge handler slots from every component in every source (a file may hold
   // several, e.g. a headless set) so all interactions fire.
   const handlers: HandlerSlot[] = []
@@ -295,27 +321,9 @@ async function runScenario(sources: SourceFile[], mountName?: string): Promise<S
   writeFileSync(file, rewritten)
 
   try {
-    try {
-      await import(file)
-    } catch (err) {
-      // A transitive external @barefootjs package (e.g. the cached `@barefootjs/
-      // xyflow` npm build) imports `@barefootjs/client` directly in its compiled
-      // dist. The import-rewriting pass above only rewrites `@barefootjs/client/
-      // runtime` in *this* component's chunks, not inside external bundles, so
-      // bun fails to resolve `@barefootjs/client` from the package's cache dir.
-      // Surface an actionable message instead of the raw module-resolution stack
-      // (#1849 B3).
-      if (isExternalClientImportError((err as Error).message)) {
-        throw new Error(
-          `"${mountName ?? 'component'}" depends on an external @barefootjs package whose ` +
-            'compiled output imports `@barefootjs/client` directly — the dynamic scenario ' +
-            "runner cannot resolve that from the package's cache directory. Profile it with a " +
-            'pre-bundled `--scenario <story.tsx>`, or use the static budget ' +
-            '(`bf debug profile <component>`), which needs no run.',
-        )
-      }
-      throw err
-    }
+    // External-package imports are caught pre-flight (see `externalRuntimeImport`
+    // above), so a failure here is a genuine run error worth surfacing as-is.
+    await import(file)
     const rt = (await import(runtimePath)) as {
       createRecordingSink: () => { sink: unknown; events: ProfilerEvent[] }
       setProfilerSink: (s: unknown) => void


### PR DESCRIPTION
## Found by dogfooding `bf debug profile` across all 63 UI components

`bf debug profile chart --scenario auto` (and `xyflow`) leaked a **raw, unactionable** stack:
```
Error: Cannot find module '@barefootjs/client/runtime' from '.../@barefootjs/chart@0.10.1.../dist/index.js'
```
The cached `@barefootjs/chart` / `@barefootjs/xyflow` dists import the client runtime **directly**, which the import-rewriting pass can't reach inside an external bundle.

### Why not just match the error message (review feedback)
The first cut of this PR widened the `isExternalClientImportError` regex to also match the `/runtime` subpath. Review flagged that as a workaround: matching bun's module-resolution **stack text** is fragile — a missed case means tuning the regex again, and the failure is environment-specific. Investigation confirmed this:
- resolution differs by **caller location** (the same specifier resolves to the workspace build from inside the repo, but to the global-cache published build from the `/tmp` run file);
- bun's resolve APIs (`import.meta.resolve` / `Bun.resolveSync`) **disagree** with actual `import()` for these auto-installed cache packages, so pre-resolving the specifier is unreliable too.

### Fix — deterministic pre-flight detection
Detect the condition from the driver's **own compiled client JS**, before the run, instead of reacting to bun's error:

```ts
externalRuntimeImport(clientChunks) // → '@barefootjs/chart' | '@barefootjs/xyflow' | … | null
```
Any `@barefootjs/*` import the compiler leaves in the emitted client JS, other than the handled `@barefootjs/client[/...]` (rewritten to an absolute path) and `@barefootjs/jsx[/...]` (compile-time-only) families, is an un-rewritable external runtime package. When found, the run is **skipped** with an actionable message that **names the offending package** and points at `--scenario <story.tsx>` or the static budget.

This is stable across bun versions and importer-path formatting, and the post-`import()` try/catch classifier is gone — a failure at `import(file)` is now a genuine run error surfaced as-is.

Observed output:
```
Error: "component" imports the external package @barefootjs/chart, whose compiled output
imports `@barefootjs/client` directly — the dynamic scenario runner cannot resolve that
from the package's cache directory. Profile it with a pre-bundled `--scenario <story.tsx>`,
or use the static budget (`bf debug profile <component>`), which needs no run.
```

### Tests
`scenario-driver-external-import.test.ts` rewritten to target the detector: flags `chart`/`xyflow`, scans across chunks, and does **not** flag the handled `@barefootjs/client[/...]` / `@barefootjs/jsx[/...]` families. 6 pass. Full lint clean.

### Verification
- `chart` / `xyflow` `--scenario auto` → actionable, package-named message (pre-flight) ✓
- `button` still profiles normally ✓
- The 3 unrelated `bf init` test failures in this package are pre-existing (missing `./runtimes.generated` codegen artifact), not touched here.

### Dogfooding scope
A separate, deeper finding — Slot-composed components surfacing `#binding:sN` as `(unresolved)` — is filed as **#1863** (known-limitation), not in this PR.

https://claude.ai/code/session_01M99qXUrALTzUdG29vjddaV

---
_Generated by [Claude Code](https://claude.ai/code/session_01M99qXUrALTzUdG29vjddaV)_