### PR TITLE
fix(profile): attribute prop-derived-const bindings forwarded into child components (#1863)

### DIFF
--- a/.changeset/profile-slot-binding-attribution.md
+++ b/.changeset/profile-slot-binding-attribution.md
@@ -1,0 +1,24 @@
+---
+"@barefootjs/jsx": patch
+---
+
+fix(profile): attribute prop-derived-const bindings forwarded into child components (#1863)
+
+`bf debug profile button --scenario auto` (and `badge`/`avatar`/`kbd`) surfaced
+`Button#binding:s0`/`s1` as `(unresolved)` hot rows plus a coverage warning, even
+though those `createEffect`s have a real source location.
+
+Root cause: the binding reads a prop *indirectly* through a local const —
+`const classes = `…${variant}…${className}``, then `<button class={classes}>` /
+`<Slot className={classes}>`. The emitter inlines `classes`, sees the prop reads,
+and wraps both in a `createEffect` emitting `#binding:<slot>`; but the analyzer's
+prop check only inspected direct references, so the expression's lone free
+identifier `classes` matched nothing and the id never made it into `buildIdIndex`.
+
+`buildGraphFromIR` now precomputes the local consts whose value transitively
+derives from a prop and treats reading one as reading a prop. The `component`
+case of `collectDomBindings` also switches from the naive `includes('props.')`
+check to the shared prop predicate, so a prop (or prop-derived const) forwarded
+into a child component (`<Slot className={classes}>`) is tracked too. Both
+`#binding:<slot>` ids now resolve to their JSX source line in the hot table
+instead of `(unresolved)`.

--- a/packages/jsx/src/__tests__/profile-binding-ids.test.ts
+++ b/packages/jsx/src/__tests__/profile-binding-ids.test.ts
@@ -57,6 +57,49 @@ describe('loop-effect id (mapArray bfId)', () => {
   })
 })
 
+// A prop-derived local const forwarded into a child component — the
+// Slot-composed-button shape (#1863). `classes` reads props (`variant`,
+// `className`) and is used both on a host element and as a child-component
+// prop; the emitter inlines it, sees the prop reads, and wraps both in a
+// `createEffect` emitting `#binding:<slot>`. The analyzer must follow the const
+// indirection so those ids resolve instead of surfacing as `(unresolved)`.
+const slotForwardSource = `
+  'use client'
+  import { Slot } from './slot'
+  export function Btn({ className = '', variant = 'default', asChild = false, ...props }) {
+    const classes = \`base \${variant} \${className}\`
+    if (asChild) return <Slot className={classes} {...props} />
+    return <button className={classes} {...props} />
+  }
+`
+
+describe('prop-derived local const binding ids (Slot composition, #1863)', () => {
+  test('buildIdIndex resolves both the host-element and child-prop #binding ids', () => {
+    const { graph } = buildComponentAnalysis(slotForwardSource, 'Btn.tsx')
+    const index = buildIdIndex(graph)
+    const bindingKeys = [...index.keys()].filter(k => k.startsWith('Btn#binding:'))
+    // Both the `<button class={classes}>` host attr and the `<Slot
+    // className={classes}>` child prop must resolve.
+    expect(bindingKeys.length).toBe(2)
+    for (const key of bindingKeys) {
+      const node = index.get(key)!
+      expect(node.kind).toBe('effect')
+      expect(node.loc.file).toBe('Btn.tsx')
+      expect(node.loc.line).toBeGreaterThan(0)
+    }
+  })
+
+  test('every emitted #binding id resolves — no unattributed gap', () => {
+    const on = compileJSX(slotForwardSource, 'Btn.tsx', { adapter, profile: true })
+      .files.find(f => f.type === 'clientJs')!.content
+    const emitted = [...new Set([...on.matchAll(/"(Btn#binding:s\d+)"/g)].map(m => m[1]))]
+    expect(emitted.length).toBeGreaterThan(0)
+    const { graph } = buildComponentAnalysis(slotForwardSource, 'Btn.tsx')
+    const index = buildIdIndex(graph)
+    for (const id of emitted) expect(index.has(id)).toBe(true)
+  })
+})
+
 describe('binding-effect ids', () => {
   test('profile off: binding effects carry no id (SR8)', () => {
     expect(clientJs(false)).not.toContain('#binding:')

--- a/packages/jsx/src/debug.ts
+++ b/packages/jsx/src/debug.ts
@@ -313,8 +313,45 @@ export function buildGraphFromIR(ir: ComponentIR): ComponentGraph {
   // here closes that emit↔analyzer gap.
   const destructuredPropNames = new Set(meta.propsParams.map(p => p.name).filter(n => n !== 'children'))
   const propsObjectName = meta.propsObjectName
+
+  // A binding often reads a prop *indirectly* through a local const:
+  // `const classes = `…${variant}…${size}…${className}``, then
+  // `<button class={classes}>` / `<Slot className={classes}>`. The emitter
+  // inlines `classes`, sees the prop reads, and wraps the binding in a
+  // `createEffect` (emitting `#binding:<slot>`) — but the expression's only free
+  // identifier is the local `classes`, so the direct prop check above misses it
+  // and the id resolves to `(unresolved)` (the Slot-composed-button case, #1863).
+  // Precompute every local const whose value transitively derives from a prop,
+  // so reading such a const counts as reading a prop. Module-level consts can't
+  // reach component props, so they fall out naturally.
+  const constByName = new Map(meta.localConstants.map(c => [c.name, c]))
+  const propDerivedConsts = new Set<string>()
+  {
+    const onStack = new Set<string>()
+    const derivesFromProp = (name: string): boolean => {
+      if (propDerivedConsts.has(name)) return true
+      const c = constByName.get(name)
+      if (!c?.freeIdentifiers || onStack.has(name)) return false
+      onStack.add(name)
+      let derived = false
+      for (const free of c.freeIdentifiers) {
+        if (destructuredPropNames.has(free) || free === propsObjectName || derivesFromProp(free)) {
+          derived = true
+          break
+        }
+      }
+      onStack.delete(name)
+      if (derived) propDerivedConsts.add(name)
+      return derived
+    }
+    for (const c of meta.localConstants) derivesFromProp(c.name)
+  }
+
   const exprReadsProp = (expr: string, freeIds?: ReadonlySet<string>): boolean => {
     for (const name of destructuredPropNames) {
+      if (freeIds ? freeIds.has(name) : tokenContainsIdent(expr, name)) return true
+    }
+    for (const name of propDerivedConsts) {
       if (freeIds ? freeIds.has(name) : tokenContainsIdent(expr, name)) return true
     }
     return propsObjectName ? exprReadsPropMember(expr, propsObjectName) : false
@@ -1838,7 +1875,13 @@ function collectDomBindings(
         const propValue = attrValueToString(prop.value) ?? ''
         if (!propValue) continue
         const deps = extractReactiveDeps(propValue, signalGetters, memoNames)
-        const hasPropsRef = propValue.includes('props.')
+        // Mirror the element-attr gate: a child prop is wrapped (and emits
+        // `#binding:<slot>`) when it reads a prop directly or via a prop-derived
+        // local const (`<Slot className={classes}>`). The previous
+        // `includes('props.')` check missed both destructured props and the
+        // local-const indirection, leaving the forwarded binding `(unresolved)`
+        // (#1863).
+        const hasPropsRef = readsProp(propValue, prop.freeIdentifiers)
         const isReactive = deps.length > 0 || hasPropsRef
         const wrapReason = inferWrapReasonForAttrLike(deps.length > 0, hasPropsRef, prop)
         if (wrapReason) {


### PR DESCRIPTION
Closes #1863.

## Problem
`bf debug profile button --scenario auto` (and `badge`/`avatar`/`kbd`) showed the headline hot-subscribers table dominated by `(unresolved)` rows plus a coverage warning, even though those binding effects have a real source location:

```
hot subscribers — most run / most time
  Button#binding:s1   ██████████████ 0.3ms  1×  (unresolved)
  Button#binding:s0   ███████▉       0.2ms  1×  (unresolved)
  ⚠ coverage: 2 unresolved subscriber id(s)
```

## Root cause
The binding reads a prop **indirectly through a local const**:
```tsx
const classes = `${baseClasses} ${variantClasses[variant]} ${sizeClasses[size]} ${className}`
if (asChild) return <Slot className={classes} {...props}>{children}</Slot>
return <button className={classes} {...props}>{children}</button>
```
The emitter inlines `classes`, sees the prop reads (`variant`/`size`/`className`), and wraps **both** the host-element attr and the child-component prop in a `createEffect` emitting `Button#binding:s0`/`s1`. But the analyzer's prop check (`exprReadsProp`) only inspected *direct* references — the expression's lone free identifier is the local `classes`, which matched no prop — so the ids never entered `buildIdIndex` and `joinProfilerEvents` couldn't resolve them. This is the same emit↔analyzer gap the existing `debug.ts` comment describes (closed for direct prop refs in #1844), just one level of const indirection deeper.

A second gap: the `component` case of `collectDomBindings` detected prop refs with a naive `propValue.includes('props.')`, which misses both destructured props and the const indirection — so the `<Slot className={classes}>` forwarded binding was never tracked.

## Fix
- `buildGraphFromIR` precomputes the set of local consts whose value **transitively** derives from a prop (closure over `ConstantInfo.freeIdentifiers`, with a cycle guard), and `exprReadsProp` treats reading one as reading a prop.
- The `component` case now uses the shared `readsProp` predicate instead of `includes('props.')`, so a prop (or prop-derived const) forwarded into a child component is tracked.

Both ids now resolve to their JSX source line:
```
  s1 (attribute)   ██████████████ 0.3ms  1×  (ui/components/ui/button/index.tsx:114)
  s0 (attribute)   ██████▍        0.1ms  1×  (ui/components/ui/button/index.tsx:116)
```

**Codegen is untouched** — the change is debug/analysis-side only, so emitted JS/HTML stays byte-identical (SR8). The `e1` (uninstrumented ref-callback effect) row is the separate B6 case and is unaffected.

## Tests
- New regression in `profile-binding-ids.test.ts`: a prop-derived-const className forwarded into a `<Slot>` — asserts both the host-element and child-prop `#binding` ids resolve to source, and that *every* emitted `#binding` id resolves (no unattributed gap).
- Full `@barefootjs/jsx` suite: **2083 pass, 0 fail**. Affected profiler/debug suites (166) green. All component IR tests: **1240 pass, 0 fail**. Lint clean.
- Verified end-to-end on `button`/`badge`/`avatar`/`kbd` via `bf debug profile <c> --scenario auto`.

https://claude.ai/code/session_01M99qXUrALTzUdG29vjddaV

---
_Generated by [Claude Code](https://claude.ai/code/session_01M99qXUrALTzUdG29vjddaV)_