### PR TITLE
fix(profile): gate the dynamic batch advisor on real handler writes

### DIFF
--- a/.changeset/profile-batch-advisor-write-gate.md
+++ b/.changeset/profile-batch-advisor-write-gate.md
@@ -1,0 +1,28 @@
+---
+"@barefootjs/jsx": patch
+---
+
+fix(profile): stop the dynamic batch advisor flagging single-write turns
+
+`bf debug profile <component> --scenario` measures a run and advises wrapping
+*multi-write* handlers in `batch()`. It inferred "multi-write" from repeated
+effect runs (`savings = totalRuns − distinctSubscribers`), which over-counted
+two ways:
+
+- a single `set()` that fans out to a loop re-runs one binding id once per item
+  (e.g. a 42-cell calendar grid → one id, hundreds of runs), and
+- a memo recompute writes its own private signal (a memo is an effect that
+  writes a signal sharing its id), so each cascade step looked like another
+  write.
+
+Together these produced confident false positives like Calendar's day-click
+reported as `batch candidate 558→9 (saves 549)` and Slider's pointer drag as
+`5→4` — turns that each make exactly one handler write, where `batch()` saves
+nothing.
+
+The advisor now counts only `signalSet`s made directly in the handler body
+(effect-nesting depth 0, tracked via `effectEnter`/`effectExit`) and requires a
+turn to make ≥ 2 such writes before it is a candidate. Genuine multi-write turns
+still surface. `BatchCandidate` gains a `writes` field, and `savings` is
+documented as an upper bound (a loop's per-item runs share one id and are not
+collapsed by a batch).

--- a/.changeset/profile-batch-advisor-write-gate.md
+++ b/.changeset/profile-batch-advisor-write-gate.md
@@ -1,5 +1,5 @@
 ---
-"@barefootjs/jsx": patch
+"@barefootjs/jsx": minor
 ---
 
 fix(profile): stop the dynamic batch advisor flagging single-write turns

--- a/packages/client/__tests__/profiler-instrumentation.test.ts
+++ b/packages/client/__tests__/profiler-instrumentation.test.ts
@@ -73,6 +73,34 @@ describe('reactive instrumentation (SR1)', () => {
     expect(exit[2] as number).toBeGreaterThanOrEqual(0)
   })
 
+  test('a set() inside an effect cleanup is bracketed by the run (depth > 0, #1865)', () => {
+    const { events, sink } = recorder()
+    setProfilerSink(sink)
+    const [dep, setDep] = createSignal(0)
+    const [, setOther] = createSignal(0)
+    // The effect reads `dep` (so it re-runs when dep changes) and returns a
+    // cleanup that writes `other`. On the re-run, cleanup() fires before the
+    // body — and must be recorded *inside* the effect's enter/exit so the batch
+    // advisor doesn't mistake it for a direct (depth-0) handler write.
+    createEffect(() => {
+      dep()
+      return () => { setOther(v => v + 1) }
+    })
+    const before = events.length
+    setDep(1)
+    // `re` opens with setDep's own `signalSet` (for `dep`, at depth 0), then the
+    // effect's re-run. The cleanup's write to `other` must land *inside* that
+    // re-run's enter/exit — strictly between them — not at depth 0 alongside the
+    // setDep write.
+    const re = events.slice(before)
+    const enter = re.findIndex(e => e[0] === 'effectEnter')
+    const exit = re.findIndex(e => e[0] === 'effectExit')
+    const cleanupSetInside = re.some((e, i) => e[0] === 'signalSet' && i > enter && i < exit)
+    expect(enter).toBeGreaterThanOrEqual(0)
+    expect(exit).toBeGreaterThan(enter)
+    expect(cleanupSetInside).toBe(true)
+  })
+
   test('effectCreate carries the right kind for effect / memo / root', () => {
     const { events, sink } = recorder()
     setProfilerSink(sink)

--- a/packages/client/src/reactive.ts
+++ b/packages/client/src/reactive.ts
@@ -267,6 +267,14 @@ function runEffect(effect: EffectContext): void {
     throw new Error(`Circular dependency detected: effect re-entered itself ${MAX_EFFECT_RUNS} times.`)
   }
 
+  // `effectEnter` is emitted *before* cleanup so the whole run — cleanup
+  // included — is bracketed by enter/exit. A `set()` performed inside a cleanup
+  // is then recorded at effect-stack depth > 0 (a cascade write) rather than
+  // depth 0 (a direct handler write), which keeps the batch advisor's write
+  // gate sound (#1865). Dev-only: in production `profilerSink` is null and this
+  // is a no-op, so the run is byte-identical to the un-instrumented path.
+  if (profilerSink) profilerSink.effectEnter(effect.id)
+
   if (effect.cleanup) {
     effect.cleanup()
     effect.cleanup = null
@@ -287,8 +295,9 @@ function runEffect(effect: EffectContext): void {
   effect.outputReported = false
   effect.outputChanged = false
 
+  // `start` stays here (after cleanup) so the reported duration measures the
+  // effect body only, unchanged by moving `effectEnter` above.
   const start = profilerSink ? performance.now() : 0
-  if (profilerSink) profilerSink.effectEnter(effect.id)
 
   try {
     const result = effect.fn()

--- a/packages/jsx/src/__tests__/profiler-batch-advisor.test.ts
+++ b/packages/jsx/src/__tests__/profiler-batch-advisor.test.ts
@@ -44,8 +44,12 @@ describe('assessBatchSafety (post-write-derived-read oracle, §4.2.3)', () => {
 })
 
 let seq = 0
+// `turn`/`turnSeq` are both always present on a real SR2 event (`number | null`).
+// Default them here so fixtures match the wire contract; per-turn helpers below
+// stamp a concrete `turn`, and grouping falls back to `turn` when `turnSeq` is
+// null, so distinct turn ids stay distinct.
 const ev = (type: ProfilerEvent['type'], f: Partial<ProfilerEvent> = {}): ProfilerEvent =>
-  ({ type, seq: seq++, turn: null, ...f })
+  ({ type, seq: seq++, turn: null, turnSeq: null, ...f })
 
 // A signal write the handler makes directly (depth 0). The recording sink only
 // stamps the turn while one is open, so `turn` is always set for these.

--- a/packages/jsx/src/__tests__/profiler-batch-advisor.test.ts
+++ b/packages/jsx/src/__tests__/profiler-batch-advisor.test.ts
@@ -50,8 +50,10 @@ const ev = (type: ProfilerEvent['type'], f: Partial<ProfilerEvent> = {}): Profil
 describe('analyzeBatchAdvisor', () => {
   test('savings = totalRuns - distinctSubscribers for a multi-write turn', () => {
     seq = 0
-    // Turn t1: two writes each re-run effects e1 and e2 → 4 runs, 2 distinct.
+    // Turn t1: two writes (a, b) each re-run effects e1 and e2 → 4 runs, 2 distinct.
     const events: ProfilerEvent[] = [
+      ev('signalSet', { signal: 'C#signal:a', turn: 't1' }),
+      ev('signalSet', { signal: 'C#signal:b', turn: 't1' }),
       ev('effectEnter', { subscriber: 'C#effect:e1', turn: 't1' }),
       ev('effectEnter', { subscriber: 'C#effect:e2', turn: 't1' }),
       ev('effectEnter', { subscriber: 'C#effect:e1', turn: 't1' }),
@@ -60,13 +62,30 @@ describe('analyzeBatchAdvisor', () => {
     const r = analyzeBatchAdvisor(events)
     expect(r.candidates).toHaveLength(1)
     expect(r.candidates[0]).toMatchObject({
-      turn: 't1', totalRuns: 4, distinctSubscribers: 2, savings: 2, safety: 'unverified',
+      turn: 't1', totalRuns: 4, distinctSubscribers: 2, writes: 2, savings: 2, safety: 'unverified',
     })
+  })
+
+  test('a single-write turn is never a candidate, however wide it fans out', () => {
+    seq = 0
+    // One `set()` repaints a 4-cell loop: one binding id, four runs. `batch()`
+    // would collapse nothing (there is only one write), so this is not a
+    // candidate — the pre-#1690 model wrongly read it as "saves 3".
+    const events: ProfilerEvent[] = [
+      ev('signalSet', { signal: 'Grid#signal:selected', turn: 't1' }),
+      ev('effectEnter', { subscriber: 'Grid#binding:s9', turn: 't1' }),
+      ev('effectEnter', { subscriber: 'Grid#binding:s9', turn: 't1' }),
+      ev('effectEnter', { subscriber: 'Grid#binding:s9', turn: 't1' }),
+      ev('effectEnter', { subscriber: 'Grid#binding:s9', turn: 't1' }),
+    ]
+    expect(analyzeBatchAdvisor(events).candidates).toHaveLength(0)
   })
 
   test('a turn where every effect runs once is not a candidate', () => {
     seq = 0
     const events: ProfilerEvent[] = [
+      ev('signalSet', { signal: 'C#signal:a', turn: 't1' }),
+      ev('signalSet', { signal: 'C#signal:b', turn: 't1' }),
       ev('effectEnter', { subscriber: 'C#effect:e1', turn: 't1' }),
       ev('effectEnter', { subscriber: 'C#effect:e2', turn: 't1' }),
     ]
@@ -76,6 +95,8 @@ describe('analyzeBatchAdvisor', () => {
   test('runs outside any turn are ignored', () => {
     seq = 0
     const events: ProfilerEvent[] = [
+      ev('signalSet', { signal: 'C#signal:a' }), // turn null
+      ev('signalSet', { signal: 'C#signal:b' }),
       ev('effectEnter', { subscriber: 'C#effect:e1' }), // turn null
       ev('effectEnter', { subscriber: 'C#effect:e1' }),
     ]
@@ -85,10 +106,14 @@ describe('analyzeBatchAdvisor', () => {
   test('ranks turns by savings descending', () => {
     seq = 0
     const events: ProfilerEvent[] = [
-      // t1 saves 1
+      // t1 saves 1 (two writes, e1 runs twice)
+      ev('signalSet', { signal: 'C#signal:a', turn: 't1' }),
+      ev('signalSet', { signal: 'C#signal:b', turn: 't1' }),
       ev('effectEnter', { subscriber: 'C#effect:e1', turn: 't1' }),
       ev('effectEnter', { subscriber: 'C#effect:e1', turn: 't1' }),
-      // t2 saves 3
+      // t2 saves 3 (two writes, e1 runs four times)
+      ev('signalSet', { signal: 'C#signal:a', turn: 't2' }),
+      ev('signalSet', { signal: 'C#signal:b', turn: 't2' }),
       ev('effectEnter', { subscriber: 'C#effect:e1', turn: 't2' }),
       ev('effectEnter', { subscriber: 'C#effect:e1', turn: 't2' }),
       ev('effectEnter', { subscriber: 'C#effect:e1', turn: 't2' }),
@@ -116,6 +141,8 @@ describe('analyzeBatchAdvisor', () => {
     const turn = [...index.keys()].find(k => k.startsWith('Form#handler:'))!
     expect(turn).toBeDefined()
     const events: ProfilerEvent[] = [
+      ev('signalSet', { signal: 'Form#signal:a', turn }),
+      ev('signalSet', { signal: 'Form#signal:b', turn }),
       ev('effectEnter', { subscriber: 'Form#binding:s0', turn }),
       ev('effectEnter', { subscriber: 'Form#binding:s0', turn }),
     ]
@@ -128,6 +155,8 @@ describe('analyzeBatchAdvisor', () => {
   test('formats candidates and never claims safety in the measured half', () => {
     seq = 0
     const events: ProfilerEvent[] = [
+      ev('signalSet', { signal: 'Checkout#signal:a', turn: 'Checkout#handler:s0:submit' }),
+      ev('signalSet', { signal: 'Checkout#signal:b', turn: 'Checkout#handler:s0:submit' }),
       ev('effectEnter', { subscriber: 'C#effect:e1', turn: 'Checkout#handler:s0:submit' }),
       ev('effectEnter', { subscriber: 'C#effect:e1', turn: 'Checkout#handler:s0:submit' }),
     ]

--- a/packages/jsx/src/__tests__/profiler-batch-advisor.test.ts
+++ b/packages/jsx/src/__tests__/profiler-batch-advisor.test.ts
@@ -47,17 +47,37 @@ let seq = 0
 const ev = (type: ProfilerEvent['type'], f: Partial<ProfilerEvent> = {}): ProfilerEvent =>
   ({ type, seq: seq++, turn: null, ...f })
 
+// A signal write the handler makes directly (depth 0). The recording sink only
+// stamps the turn while one is open, so `turn` is always set for these.
+const set = (signal: string, turn: string): ProfilerEvent => ev('signalSet', { signal, turn })
+
+// One effect run, modeled the way the real sink records it: an `effectEnter`
+// bracketed by its `effectExit`. Pairing them is what returns the effect-stack
+// depth to 0 between runs, so a later `set()` in the same turn is still seen as
+// a direct (depth-0) handler write. `nested` events (e.g. a memo writing its
+// private signal) are emitted *between* the enter/exit, i.e. at depth > 0.
+const run = (
+  subscriber: string,
+  turn: string,
+  nested: ProfilerEvent[] = [],
+): ProfilerEvent[] => [
+  ev('effectEnter', { subscriber, turn }),
+  ...nested,
+  ev('effectExit', { subscriber, turn, dur: 0 }),
+]
+
 describe('analyzeBatchAdvisor', () => {
   test('savings = totalRuns - distinctSubscribers for a multi-write turn', () => {
     seq = 0
-    // Turn t1: two writes (a, b) each re-run effects e1 and e2 → 4 runs, 2 distinct.
+    // Turn t1: write a, its cascade re-runs e1+e2, then (depth back to 0) write
+    // b re-runs e1+e2 again → 4 runs, 2 distinct, 2 handler writes.
     const events: ProfilerEvent[] = [
-      ev('signalSet', { signal: 'C#signal:a', turn: 't1' }),
-      ev('signalSet', { signal: 'C#signal:b', turn: 't1' }),
-      ev('effectEnter', { subscriber: 'C#effect:e1', turn: 't1' }),
-      ev('effectEnter', { subscriber: 'C#effect:e2', turn: 't1' }),
-      ev('effectEnter', { subscriber: 'C#effect:e1', turn: 't1' }),
-      ev('effectEnter', { subscriber: 'C#effect:e2', turn: 't1' }),
+      set('C#signal:a', 't1'),
+      ...run('C#effect:e1', 't1'),
+      ...run('C#effect:e2', 't1'),
+      set('C#signal:b', 't1'),
+      ...run('C#effect:e1', 't1'),
+      ...run('C#effect:e2', 't1'),
     ]
     const r = analyzeBatchAdvisor(events)
     expect(r.candidates).toHaveLength(1)
@@ -68,15 +88,18 @@ describe('analyzeBatchAdvisor', () => {
 
   test('a single-write turn is never a candidate, however wide it fans out', () => {
     seq = 0
-    // One `set()` repaints a 4-cell loop: one binding id, four runs. `batch()`
-    // would collapse nothing (there is only one write), so this is not a
-    // candidate — the pre-#1690 model wrongly read it as "saves 3".
+    // One `set()` recomputes a memo (which writes its own private signal — a
+    // nested, depth-1 set that must NOT count as a handler write) and then
+    // repaints a 4-cell loop: one binding id, four runs. `batch()` would
+    // collapse nothing (one handler write), so this is not a candidate — the
+    // pre-#1690 model wrongly read it as "saves 4".
     const events: ProfilerEvent[] = [
-      ev('signalSet', { signal: 'Grid#signal:selected', turn: 't1' }),
-      ev('effectEnter', { subscriber: 'Grid#binding:s9', turn: 't1' }),
-      ev('effectEnter', { subscriber: 'Grid#binding:s9', turn: 't1' }),
-      ev('effectEnter', { subscriber: 'Grid#binding:s9', turn: 't1' }),
-      ev('effectEnter', { subscriber: 'Grid#binding:s9', turn: 't1' }),
+      set('Grid#signal:selected', 't1'),
+      ...run('Grid#memo:rows', 't1', [set('Grid#memo:rows', 't1')]),
+      ...run('Grid#binding:s9', 't1'),
+      ...run('Grid#binding:s9', 't1'),
+      ...run('Grid#binding:s9', 't1'),
+      ...run('Grid#binding:s9', 't1'),
     ]
     expect(analyzeBatchAdvisor(events).candidates).toHaveLength(0)
   })
@@ -84,10 +107,10 @@ describe('analyzeBatchAdvisor', () => {
   test('a turn where every effect runs once is not a candidate', () => {
     seq = 0
     const events: ProfilerEvent[] = [
-      ev('signalSet', { signal: 'C#signal:a', turn: 't1' }),
-      ev('signalSet', { signal: 'C#signal:b', turn: 't1' }),
-      ev('effectEnter', { subscriber: 'C#effect:e1', turn: 't1' }),
-      ev('effectEnter', { subscriber: 'C#effect:e2', turn: 't1' }),
+      set('C#signal:a', 't1'),
+      ...run('C#effect:e1', 't1'),
+      set('C#signal:b', 't1'),
+      ...run('C#effect:e2', 't1'),
     ]
     expect(analyzeBatchAdvisor(events).candidates).toHaveLength(0)
   })
@@ -98,7 +121,9 @@ describe('analyzeBatchAdvisor', () => {
       ev('signalSet', { signal: 'C#signal:a' }), // turn null
       ev('signalSet', { signal: 'C#signal:b' }),
       ev('effectEnter', { subscriber: 'C#effect:e1' }), // turn null
+      ev('effectExit', { subscriber: 'C#effect:e1' }),
       ev('effectEnter', { subscriber: 'C#effect:e1' }),
+      ev('effectExit', { subscriber: 'C#effect:e1' }),
     ]
     expect(analyzeBatchAdvisor(events).candidates).toHaveLength(0)
   })
@@ -106,18 +131,18 @@ describe('analyzeBatchAdvisor', () => {
   test('ranks turns by savings descending', () => {
     seq = 0
     const events: ProfilerEvent[] = [
-      // t1 saves 1 (two writes, e1 runs twice)
-      ev('signalSet', { signal: 'C#signal:a', turn: 't1' }),
-      ev('signalSet', { signal: 'C#signal:b', turn: 't1' }),
-      ev('effectEnter', { subscriber: 'C#effect:e1', turn: 't1' }),
-      ev('effectEnter', { subscriber: 'C#effect:e1', turn: 't1' }),
+      // t1 saves 1 (two writes, e1 runs once per write)
+      set('C#signal:a', 't1'),
+      ...run('C#effect:e1', 't1'),
+      set('C#signal:b', 't1'),
+      ...run('C#effect:e1', 't1'),
       // t2 saves 3 (two writes, e1 runs four times)
-      ev('signalSet', { signal: 'C#signal:a', turn: 't2' }),
-      ev('signalSet', { signal: 'C#signal:b', turn: 't2' }),
-      ev('effectEnter', { subscriber: 'C#effect:e1', turn: 't2' }),
-      ev('effectEnter', { subscriber: 'C#effect:e1', turn: 't2' }),
-      ev('effectEnter', { subscriber: 'C#effect:e1', turn: 't2' }),
-      ev('effectEnter', { subscriber: 'C#effect:e1', turn: 't2' }),
+      set('C#signal:a', 't2'),
+      ...run('C#effect:e1', 't2'),
+      ...run('C#effect:e1', 't2'),
+      set('C#signal:b', 't2'),
+      ...run('C#effect:e1', 't2'),
+      ...run('C#effect:e1', 't2'),
     ]
     const r = analyzeBatchAdvisor(events)
     expect(r.candidates.map(c => c.turn)).toEqual(['t2', 't1'])
@@ -141,10 +166,10 @@ describe('analyzeBatchAdvisor', () => {
     const turn = [...index.keys()].find(k => k.startsWith('Form#handler:'))!
     expect(turn).toBeDefined()
     const events: ProfilerEvent[] = [
-      ev('signalSet', { signal: 'Form#signal:a', turn }),
-      ev('signalSet', { signal: 'Form#signal:b', turn }),
-      ev('effectEnter', { subscriber: 'Form#binding:s0', turn }),
-      ev('effectEnter', { subscriber: 'Form#binding:s0', turn }),
+      set('Form#signal:a', turn),
+      ...run('Form#binding:s0', turn),
+      set('Form#signal:b', turn),
+      ...run('Form#binding:s0', turn),
     ]
     const c = analyzeBatchAdvisor(events, index).candidates[0]
     expect(c.loc?.file).toBe('Form.tsx')
@@ -154,11 +179,12 @@ describe('analyzeBatchAdvisor', () => {
 
   test('formats candidates and never claims safety in the measured half', () => {
     seq = 0
+    const turn = 'Checkout#handler:s0:submit'
     const events: ProfilerEvent[] = [
-      ev('signalSet', { signal: 'Checkout#signal:a', turn: 'Checkout#handler:s0:submit' }),
-      ev('signalSet', { signal: 'Checkout#signal:b', turn: 'Checkout#handler:s0:submit' }),
-      ev('effectEnter', { subscriber: 'C#effect:e1', turn: 'Checkout#handler:s0:submit' }),
-      ev('effectEnter', { subscriber: 'C#effect:e1', turn: 'Checkout#handler:s0:submit' }),
+      set('Checkout#signal:a', turn),
+      ...run('C#effect:e1', turn),
+      set('Checkout#signal:b', turn),
+      ...run('C#effect:e1', turn),
     ]
     const out = formatBatchAdvisor(analyzeBatchAdvisor(events))
     expect(out).toContain('batch candidate 2→1')

--- a/packages/jsx/src/__tests__/profiler-e2e.test.ts
+++ b/packages/jsx/src/__tests__/profiler-e2e.test.ts
@@ -95,6 +95,7 @@ describe('profiler end-to-end (real substrate)', () => {
     const cand = batch.candidates.find(c => c.turn === 'Cart#handler:s1:click')!
     expect(cand).toBeDefined()
     // 3 unbatched writes cascade the memo chain: 14 effect runs, 5 distinct.
+    expect(cand.writes).toBe(3)
     expect(cand.totalRuns).toBe(14)
     expect(cand.distinctSubscribers).toBe(5)
     expect(cand.savings).toBe(9)

--- a/packages/jsx/src/profiler.ts
+++ b/packages/jsx/src/profiler.ts
@@ -986,7 +986,20 @@ export interface BatchCandidate {
   totalRuns: number
   /** Distinct effects that ran (the floor a batched turn would collapse to). */
   distinctSubscribers: number
-  /** `totalRuns − distinctSubscribers` — runs a `batch()` wrap would remove. */
+  /**
+   * Signal writes (`set()` calls) the turn performed. A `batch()` wrap can only
+   * collapse re-runs when there are *several* writes notifying the same effect,
+   * so this is always ≥ 2 for a candidate — a single-write turn benefits not at
+   * all and is never surfaced (see {@link analyzeBatchAdvisor}).
+   */
+  writes: number
+  /**
+   * Upper bound on the runs a `batch()` wrap would remove (`totalRuns −
+   * distinctSubscribers`). It is an upper bound, not an exact count: distinct
+   * effects are counted by *id*, so a loop binding whose single id maps to many
+   * per-item DOM instances reads as one "distinct subscriber" even though each
+   * instance must still run once under a batch. Treat it as "up to N".
+   */
   savings: number
   /**
    * Whether wrapping the handler in `batch()` is provably behavior-preserving.
@@ -1008,7 +1021,22 @@ export interface BatchAdvisorResult {
  * notifies synchronously — so a turn that writes several signals re-runs shared
  * effects once per write. Per turn this measures `totalRuns` (effect runs) vs
  * `distinctSubscribers` (unique effects); `savings = totalRuns −
- * distinctSubscribers` is what a `batch()` wrap would collapse.
+ * distinctSubscribers` is an upper bound on what a `batch()` wrap would collapse.
+ *
+ * A candidate must be a genuine **multi-write** turn (`writes ≥ 2`). `batch()`
+ * only fuses the notifications of *several* writes; it does nothing to a single
+ * write, even one that fans out widely. A loop binding re-running once per item
+ * from one `set()` (e.g. a 42-cell calendar grid: one id, 42 runs) is *not* a
+ * batch opportunity — without the write gate its 42 runs collapse to "saves 41"
+ * against a single distinct id, a confident false positive.
+ *
+ * `writes` counts only `signalSet`s made *directly in the handler body* —
+ * `effectEnter`/`effectExit` track effect-nesting depth, and a write is a
+ * genuine handler write only at depth 0. This excludes the writes a memo makes
+ * to its own private signal when it recomputes (a memo is an effect that writes
+ * a signal sharing its id), and any other downstream cascade write, since those
+ * fire *inside* the effects the direct writes triggered and are not something a
+ * `batch()` around the handler could fuse.
  *
  * Measured half only: every candidate is reported `safety: 'unverified'`. The
  * static safety oracle that upgrades a candidate to `'safe'`/`'unsafe'` lands
@@ -1024,26 +1052,53 @@ export function analyzeBatchAdvisor(
   interface TurnAcc {
     handlerId: string
     totalRuns: number
+    writes: number
+    /** Effect-nesting depth in this turn: a `signalSet` is a direct handler
+     *  write only at depth 0; deeper sets are memo/cascade recomputes. */
+    depth: number
     subscribers: Set<string>
   }
   const byInvocation = new Map<string, TurnAcc>()
 
-  for (const e of events) {
-    if (e.type !== 'effectEnter' || e.turn === null) continue
+  const get = (e: ProfilerEvent): TurnAcc | undefined => {
+    if (e.turn === null) return undefined
     const key = String(e.turnSeq ?? e.turn)
     let acc = byInvocation.get(key)
     if (!acc) {
-      acc = { handlerId: e.turn, totalRuns: 0, subscribers: new Set() }
+      acc = { handlerId: e.turn, totalRuns: 0, writes: 0, depth: 0, subscribers: new Set() }
       byInvocation.set(key, acc)
     }
-    acc.totalRuns++
-    if (e.subscriber !== undefined) acc.subscribers.add(e.subscriber)
+    return acc
+  }
+
+  for (const e of events) {
+    // `signalSet` at depth 0 is a write the handler made itself — the ground
+    // truth for whether batching can fuse anything. `effectEnter`/`effectExit`
+    // bracket the runs those writes (plus loop fan-out and memo recomputes)
+    // produced; a set fired while one of those runs is on the stack (depth > 0)
+    // is a downstream cascade write, not a handler write.
+    if (e.type === 'signalSet') {
+      const acc = get(e)
+      if (acc && acc.depth === 0) acc.writes++
+    } else if (e.type === 'effectEnter') {
+      const acc = get(e)
+      if (!acc) continue
+      acc.totalRuns++
+      acc.depth++
+      if (e.subscriber !== undefined) acc.subscribers.add(e.subscriber)
+    } else if (e.type === 'effectExit') {
+      const acc = get(e)
+      if (acc && acc.depth > 0) acc.depth--
+    }
   }
 
   // Collapse invocations to one candidate per handler — the worst (max-savings)
   // invocation represents the handler's batch opportunity.
   const byHandler = new Map<string, BatchCandidate>()
   for (const acc of byInvocation.values()) {
+    // A turn that writes at most one signal cannot benefit from `batch()`, no
+    // matter how many effect runs that single write fanned out to (#1690).
+    if (acc.writes < 2) continue
     const distinctSubscribers = acc.subscribers.size
     const savings = acc.totalRuns - distinctSubscribers
     if (savings <= 0) continue
@@ -1056,6 +1111,7 @@ export function analyzeBatchAdvisor(
       handler: node?.name,
       totalRuns: acc.totalRuns,
       distinctSubscribers,
+      writes: acc.writes,
       savings,
       safety: 'unverified',
     })


### PR DESCRIPTION
## Dogfooding `bf debug profile`

Ran the new profiler across the whole `ui/components/ui/` library in all three modes (static budget, `--diff`, `--scenario auto`). Findings:

- **Static budget** and **dynamic `--scenario auto`** are robust — no crashes or malformed output across all 60+ components.
- The static "compound" heuristic is correct (e.g. `Carousel` is *not* flagged because its `orientation` memo feeds a real DOM binding, while `Combobox`'s memos feed only composed children).
- Dogfooding surfaced one real bug in the **dynamic batch advisor**, fixed here.

## The bug

`bf debug profile <component> --scenario` measures a run and advises wrapping *multi-write* handlers in `batch()`. It inferred "multi-write" from repeated effect runs:

```
savings = totalRuns − distinctSubscribers
```

That over-counts two ways:

1. A single `set()` that fans out to a **loop** re-runs one binding id once per item (a 42-cell calendar grid → one id, hundreds of runs).
2. A **memo recompute writes its own private signal** (a memo is an effect that writes a signal sharing its id), so every cascade step looked like another write.

Result: confident false positives on turns that make **exactly one** handler write, where `batch()` saves nothing:

| component | turn | before |
|---|---|---|
| `calendar` | day-click / month nav | `batch candidate 558→9 (saves 549)` |
| `slider` | pointer drag | `batch candidate 5→4 (saves 1)` |

## The fix

`analyzeBatchAdvisor` now counts only `signalSet`s made **directly in the handler body** — `effectEnter`/`effectExit` track effect-nesting depth, and a write counts only at depth 0. Memo recomputes and downstream cascade writes fire *inside* the triggered effects (depth > 0) and are excluded, because a `batch()` around the handler can't fuse them. A turn must make **≥ 2** such writes to be a candidate.

- `BatchCandidate` gains a `writes` field.
- `savings` is documented as an *upper* bound (a loop's per-item runs share one id and aren't collapsed by a batch).

After the fix, `calendar` and `slider` correctly report *"(no turn would benefit from batching)"*, while a genuine 3-write turn still surfaces (`savings 9`, covered by the real-substrate e2e test).

## Tests

- New regression: a single write fanning out to a loop is **not** a candidate.
- Existing batch-advisor fixtures updated to include realistic `signalSet` events; e2e real-substrate test asserts `writes: 3`.
- Full `@barefootjs/jsx` suite green: **2086 pass / 0 fail**.

https://claude.ai/code/session_017ntfvqk2FBJ7jXEeEaQYNK

---
_Generated by [Claude Code](https://claude.ai/code/session_017ntfvqk2FBJ7jXEeEaQYNK)_