### PR TITLE
feat(profile): split fan-out into direct vs via-memo, flag hot on direct

### DIFF
--- a/.changeset/profile-fanout-direct-indirect.md
+++ b/.changeset/profile-fanout-direct-indirect.md
@@ -1,0 +1,21 @@
+---
+"@barefootjs/jsx": minor
+---
+
+feat(profile): split fan-out into direct vs via-memo, flag `⚠ high` on direct
+
+The static reactivity budget reported a single per-signal fan-out — the
+*transitive* subscriber count — and flagged `⚠ high` off it. That conflated two
+very different things: subscribers a write re-runs directly, and subscribers
+sitting behind a memo barrier (which only re-run when the memo's value actually
+changes). It also made memo-barrier refactors look like regressions: routing N
+reads through a new memo *lowers* real re-run pressure but *raises* the
+transitive total (more nodes become statically attributable), so the number
+went up after an optimization.
+
+`FanOutEntry` now carries `direct` alongside `subscribers` (the transitive
+total). The text output shows the split — `currentYear → 11 subscribers
+(6 direct · 5 via memo)` — and `⚠ high` keys off **direct** fan-out, the real
+per-write pressure. `bf debug profile --diff` likewise tracks direct fan-out, so
+a memo-barrier refactor reads as the improvement it is rather than a false
+regression.

--- a/packages/jsx/src/__tests__/profiler.test.ts
+++ b/packages/jsx/src/__tests__/profiler.test.ts
@@ -103,6 +103,30 @@ describe('buildStaticBudget (SR5)', () => {
     expect(cold.fanOut.every(f => f.hot === false)).toBe(true)
   })
 
+  test('splits fan-out into direct vs via-memo and keys `hot` off direct', () => {
+    // count → a → b → c → {effect, text}: exactly ONE direct subscriber (memo
+    // a); the rest are reached only through memo barriers.
+    const b = buildStaticBudget(memoChainSource, 'Calc.tsx', 'Calc')
+    const count = b.fanOut.find(f => f.signal === 'count')!
+    expect(count.direct).toBe(1)
+    expect(count.subscribers).toBeGreaterThanOrEqual(4)
+    // The transitive total clears a threshold of 3, but direct (1) does not — so
+    // the signal is NOT hot. `hot` tracks real per-write pressure, not the total.
+    const mid = buildStaticBudget(memoChainSource, 'Calc.tsx', 'Calc', { fanOutThreshold: 3 })
+    const c = mid.fanOut.find(f => f.signal === 'count')!
+    expect(c.subscribers).toBeGreaterThanOrEqual(3)
+    expect(c.hot).toBe(false)
+  })
+
+  test('formats the direct/via-memo split only when a memo barrier routes', () => {
+    // Memo chain → the split is shown.
+    const withMemo = formatStaticBudget(buildStaticBudget(memoChainSource, 'Calc.tsx', 'Calc'))
+    expect(withMemo).toMatch(/count\s+→ \d+ subscribers \(1 direct · \d+ via memo\)/)
+    // Counter reads its signal directly (no memo) → no parenthetical.
+    const direct = formatStaticBudget(buildStaticBudget(counterSource, 'Counter.tsx', 'Counter'))
+    expect(direct).not.toContain('via memo')
+  })
+
   test('formats a human-readable budget', () => {
     const out = formatStaticBudget(buildStaticBudget(memoChainSource, 'Calc.tsx', 'Calc'))
     expect(out).toContain('static reactivity budget')
@@ -173,6 +197,40 @@ describe('diffStaticBudget (SR6)', () => {
     const diff = diffStaticBudget(a, b)
     expect(diff.regressed).toBe(false)
     expect(formatBudgetDiff(diff)).toContain('no structural reactivity change')
+  })
+
+  test('a memo barrier that lowers direct fan-out is not a fan-out regression', () => {
+    // Before: `count` is read directly by an effect AND a text binding (direct 2).
+    const before = `
+      'use client'
+      import { createSignal, createEffect } from '@barefootjs/client'
+      export function R() {
+        const [count, setCount] = createSignal(0)
+        createEffect(() => console.log(count()))
+        return <button>{count()}</button>
+      }
+    `
+    // After: both reads go through a memo, so `count`'s direct fan-out drops to 1
+    // (the memo) even though a memo was added and the transitive total rose.
+    const after = `
+      'use client'
+      import { createSignal, createMemo, createEffect } from '@barefootjs/client'
+      export function R() {
+        const [count, setCount] = createSignal(0)
+        const m = createMemo(() => count())
+        createEffect(() => console.log(m()))
+        return <button>{m()}</button>
+      }
+    `
+    const base = buildStaticBudget(before, 'R.tsx', 'R')
+    const head = buildStaticBudget(after, 'R.tsx', 'R')
+    expect(base.fanOut.find(f => f.signal === 'count')!.direct).toBe(2)
+    expect(head.fanOut.find(f => f.signal === 'count')!.direct).toBe(1)
+    // The fan-out delta reads the refactor as the improvement it is: direct
+    // fan-out shrank, so the recorded change is a decrease, not growth.
+    const diff = diffStaticBudget(base, head)
+    const ch = diff.fanOut.find(f => f.signal === 'count')!
+    expect(ch.after).toBeLessThan(ch.before)
   })
 
   test('carries a "diff" kind discriminator (#1849 B2)', () => {

--- a/packages/jsx/src/profiler.ts
+++ b/packages/jsx/src/profiler.ts
@@ -39,7 +39,17 @@ export interface FanOutEntry {
   signal: string
   /** Distinct transitive subscribers (memos + effects + DOM bindings). */
   subscribers: number
-  /** True when `subscribers` exceeds the configured threshold. */
+  /**
+   * Distinct subscribers that read the signal *directly* (not through a memo).
+   * This is the real per-write re-run pressure: a direct write re-runs exactly
+   * these. The remaining `subscribers − direct` sit behind a memo barrier and
+   * only re-run when that memo's value actually changes — so adding a memo
+   * barrier *lowers* `direct` while it can *raise* `subscribers` (more nodes
+   * become statically attributable). Read `direct`, not `subscribers`, to judge
+   * cost.
+   */
+  direct: number
+  /** True when *direct* fan-out (not the transitive total) meets the threshold. */
   hot: boolean
   loc: { file: string; line: number }
 }
@@ -107,8 +117,10 @@ export function buildStaticBudget(
 
   const fanOut: FanOutEntry[] = graph.signals
     .map(s => {
-      const subscribers = transitiveSubscriberCount(graph, s.name)
-      return { signal: s.name, subscribers, hot: subscribers >= threshold, loc: s.loc }
+      const { direct, total } = subscriberCounts(graph, s.name)
+      // `hot` keys off *direct* fan-out — a signal driving 12 nodes through one
+      // memo (direct 1) isn't hot; one driving 12 nodes directly is.
+      return { signal: s.name, subscribers: total, direct, hot: direct >= threshold, loc: s.loc }
     })
     .sort((a, b) => b.subscribers - a.subscribers)
 
@@ -161,23 +173,35 @@ function isEventHandlerConsumer(consumer: string): boolean {
 }
 
 /**
- * Distinct transitive subscribers of a signal/memo. Walks the same tagged
- * `consumers` tree `traceUpdatePath` builds (`debug.ts`), deduplicating across
- * branches so a diamond dependency counts each subscriber once. Event handlers
- * are excluded — they read but don't react.
+ * Subscriber counts for a signal/memo: `direct` (read it without a memo in
+ * between — the top level of the dependent tree) and `total` (every distinct
+ * transitive subscriber). Walks the same tagged `consumers` tree
+ * `traceUpdatePath` builds (`debug.ts`), deduplicating across branches so a
+ * diamond dependency counts each subscriber once. Event handlers are excluded —
+ * they read but don't react. `total − direct` are the nodes reached only
+ * through a memo barrier.
  */
-function transitiveSubscriberCount(graph: ComponentGraph, name: string): number {
+function subscriberCounts(graph: ComponentGraph, name: string): { direct: number; total: number } {
   const path = traceUpdatePath(graph, name)
-  if (!path) return 0
+  if (!path) return { direct: 0, total: 0 }
   const seen = new Set<string>()
-  const walk = (entries: UpdatePathEntry[]): void => {
+  const directSeen = new Set<string>()
+  const walk = (entries: UpdatePathEntry[], depth: number): void => {
     for (const e of entries) {
-      if (!isEventHandlerEntry(e.kind, e.name)) seen.add(`${e.kind}:${e.name}`)
-      walk(e.children)
+      if (!isEventHandlerEntry(e.kind, e.name)) {
+        seen.add(`${e.kind}:${e.name}`)
+        if (depth === 0) directSeen.add(`${e.kind}:${e.name}`)
+      }
+      walk(e.children, depth + 1)
     }
   }
-  walk(path.dependents)
-  return seen.size
+  walk(path.dependents, 0)
+  return { direct: directSeen.size, total: seen.size }
+}
+
+/** Distinct transitive subscribers — the `total` of {@link subscriberCounts}. */
+function transitiveSubscriberCount(graph: ComponentGraph, name: string): number {
+  return subscriberCounts(graph, name).total
 }
 
 /**
@@ -223,7 +247,11 @@ export function formatStaticBudget(b: StaticBudget): string {
   if (shown.length > 0) {
     lines.push('  fan-out (top):')
     for (const f of shown) {
-      lines.push(`    ${f.signal.padEnd(12)} → ${f.subscribers} subscribers${f.hot ? '   ⚠ high' : ''}`)
+      // Show the direct/indirect split only when a memo barrier routes some of
+      // the subscribers — otherwise the bare count is already the direct count.
+      const indirect = f.subscribers - f.direct
+      const detail = indirect > 0 ? ` (${f.direct} direct · ${indirect} via memo)` : ''
+      lines.push(`    ${f.signal.padEnd(12)} → ${f.subscribers} subscribers${detail}${f.hot ? '   ⚠ high' : ''}`)
     }
   }
   if (b.crossComponentOnly) {
@@ -260,7 +288,7 @@ export interface BudgetDiff {
   loops: number
   subscriptions: number
   memoChainDepth: number
-  /** Signals whose fan-out changed (added/removed signals included as 0↔n). */
+  /** Signals whose *direct* fan-out changed (added/removed signals as 0↔n). */
   fanOut: FanOutChange[]
   /** True when any tracked metric regressed (grew) past zero. */
   regressed: boolean
@@ -272,8 +300,12 @@ export interface BudgetDiff {
  * `regressed` is true (or gate on a specific metric threshold).
  */
 export function diffStaticBudget(base: StaticBudget, head: StaticBudget): BudgetDiff {
-  const baseFan = new Map(base.fanOut.map(f => [f.signal, f.subscribers]))
-  const headFan = new Map(head.fanOut.map(f => [f.signal, f.subscribers]))
+  // Track *direct* fan-out: a refactor that routes subscribers through a new
+  // memo lowers direct fan-out (less re-run pressure) even as it can raise the
+  // transitive total, so a direct-fan-out delta reads such a change as the
+  // improvement it is instead of a false regression.
+  const baseFan = new Map(base.fanOut.map(f => [f.signal, f.direct]))
+  const headFan = new Map(head.fanOut.map(f => [f.signal, f.direct]))
   const signals = new Set([...baseFan.keys(), ...headFan.keys()])
 
   const fanOut: FanOutChange[] = []
@@ -318,7 +350,7 @@ export function formatBudgetDiff(d: BudgetDiff): string {
     lines.push(`  memo chain ${d.memoChainDepth > 0 ? 'deepened' : 'shortened'} by ${Math.abs(d.memoChainDepth)}`)
   }
   for (const f of d.fanOut) {
-    lines.push(`  signal \`${f.signal}\` fan-out ${f.before}→${f.after}`)
+    lines.push(`  signal \`${f.signal}\` direct fan-out ${f.before}→${f.after}`)
   }
   if (lines.length === 1) lines.push('  no structural reactivity change')
   else lines.push(d.regressed ? '  ⚠ reactivity regressed' : '  ✓ no regression')


### PR DESCRIPTION
## Motivation

Dogfooding feedback (from another agent's optimization session, echoing my own observation) flagged that the static budget's per-signal **fan-out was unintuitive**: after adding a `createMemo` barrier to fix fallbacks, `spec → 13 subscribers ⚠ high` *grew* to `16` — even though the refactor *reduced* real re-run pressure. The number went up because previously-unattributable nodes became countable, and the report didn't distinguish **direct** subscribers from those sitting **behind a memo barrier**.

## Change

`bf debug profile` now splits fan-out into direct vs via-memo:

```
fan-out (top):
  currentYear  → 11 subscribers (6 direct · 5 via memo)
  internalSelected → 5 subscribers (1 direct · 4 via memo)
```

- **`FanOutEntry.direct`** (new field) — subscribers that read the signal directly (depth 0). `subscribers` stays the transitive total. `subscriberCounts()` computes both in one tree walk.
- **`⚠ high` now keys off `direct`** — the real per-write pressure. A signal driving 12 nodes through one memo (direct 1) is no longer flagged; one driving 12 directly is.
- **`--diff` tracks direct fan-out**, so a memo-barrier refactor (direct ↓, transitive ↑) reads as the improvement it is instead of a false regression. (`subscriptions` was already a direct metric, so the diff is now internally consistent.)
- `--json` carries `direct` automatically.

Scope confirmed with the maintainer: split **and** move `⚠ high` to direct fan-out.

## Tests
- New: direct/via-memo split, `hot` keyed off direct (transitive ≥ threshold but direct below → not hot), format shows the split only when a memo routes, and a memo-barrier refactor is not a fan-out regression in `--diff`.
- Full `@barefootjs/jsx` suite: **2089 pass / 0 fail**; typecheck + biome clean.

Follow-up to the profiler work in #1865.

https://claude.ai/code/session_017ntfvqk2FBJ7jXEeEaQYNK

---
_Generated by [Claude Code](https://claude.ai/code/session_017ntfvqk2FBJ7jXEeEaQYNK)_