### PR TITLE
ci(release): add timeout-minutes so a hung publish can't block the queue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,10 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    # Backstop so a hung step (e.g. a stalled JSR/npm publish) can't keep the
+    # job — and with it the `release-main` concurrency slot — open for the
+    # default 6h, blocking every queued release run behind it.
+    timeout-minutes: 30
     outputs:
       published: ${{ steps.changesets.outputs.published }}
       publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
@@ -80,12 +84,19 @@ jobs:
       # publish so version-PR runs don't touch JSR.
       - name: Publish to JSR
         if: steps.changesets.outputs.published == 'true'
+        # Tighter cap on the known hang point: a JSR publish that stalls (e.g.
+        # waiting on auth/network) fails the step instead of running for hours.
+        # npm has already published by this step, and jsr-publish.ts self-skips
+        # versions already live, so a re-run safely finishes the JSR mirror.
+        timeout-minutes: 10
         run: bun scripts/jsr-publish.ts
 
   cpan-release:
     needs: release
     if: needs.release.outputs.published == 'true'
     runs-on: ubuntu-latest
+    # Same backstop: a stalled CPAN upload shouldn't hold the run open for 6h.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 


### PR DESCRIPTION
## Problem

The Release workflow serializes pushes to `main` via:

```yaml
concurrency:
  group: release-${{ github.ref }}
  cancel-in-progress: false
```

When a publish step **hangs**, its job holds the concurrency slot for the GitHub default job timeout (6h), so every queued release run sits `pending`. This actually happened today: the #1830 Version Packages run hung on **`Publish to JSR`** (~1h40m, after npm had already published), which kept the #1867 release run queued and prevented the next "Version Packages" PR from being created. (Unblocked by cancelling the stuck run.)

## Fix — cap the runtime so a hang can't block the queue

- **`release` job** `timeout-minutes: 30` — backstop for any hung step.
- **`Publish to JSR` step** `timeout-minutes: 10` — tighter cap on the known hang point. npm has already published by this step and `jsr-publish.ts` self-skips versions already live, so a timeout fails only the JSR mirror and a re-run safely completes it.
- **`cpan-release` job** `timeout-minutes: 30` — same backstop for stalled CPAN uploads.

A timed-out step/job ends the job, which frees the `release-main` concurrency slot so the next queued release run proceeds.

YAML validated.

https://claude.ai/code/session_017ntfvqk2FBJ7jXEeEaQYNK

---
_Generated by [Claude Code](https://claude.ai/code/session_017ntfvqk2FBJ7jXEeEaQYNK)_