### PR TITLE
feat(profile): expose static handlers list + schemaVersion on JSON output (#1841)

### DIFF
--- a/.changeset/profile-static-handlers-schema-version.md
+++ b/.changeset/profile-static-handlers-schema-version.md
@@ -1,0 +1,23 @@
+---
+"@barefootjs/jsx": minor
+---
+
+feat(profile): expose handlers in the static budget + `schemaVersion` on every JSON mode (#1841)
+
+The static reactivity budget exposed signal/memo/effect counts and fan-out, but
+**not the handlers `--scenario auto` would fire** — so an agent couldn't see
+"what gets fired" or "which handlers are uncovered" without an actual run. The
+remaining coverage gap (e.g. `coverage: 1/5 handlers exercised`) named a count
+but never the handler names or locations.
+
+`StaticBudget` now carries a `handlers` array — `{ name: "click@s1", loc: { file,
+line } }` — built from the same `graph.domBindings` event slots the auto scenario
+fires, so the static list and the dynamic coverage share one identity (the
+slotId). The text output gains an optional `handlers (N):` section when handlers
+exist. This lets an agent predict the coverage gap and reference handler names
+before any run.
+
+All three `bf debug profile --json` modes (`static-budget` / `profile` / `diff`)
+now include a top-level `schemaVersion` (exported as `PROFILE_SCHEMA_VERSION`) so
+a machine consumer can branch on the output contract; the same major version is
+additive-only.

--- a/packages/cli/src/commands/debug-profile.ts
+++ b/packages/cli/src/commands/debug-profile.ts
@@ -39,6 +39,8 @@ THREE MODES
       it works the moment a component compiles. Predicts hot spots before you
       measure: signal/memo/effect/loop counts, total subscriptions, the longest
       memo→memo chain, and per-signal fan-out (flagged ⚠ high past --fanout).
+      Also lists the handlers --scenario auto would fire (name + source line),
+      so you can read the coverage gap statically before any run.
 
   bf debug profile <component> --diff <ref>
       Compile-diff regression — compiles the component at <ref> (any git ref)
@@ -80,10 +82,11 @@ FLAGS
                       for grid components with a long cheap tail (number ≥ 0).
   --wasted-pct <n>    Flag a subscriber whose runs are ≥ n% identical output
                       (0–100, default 50).
-  --json              Machine-readable output (every mode). Stable schema with
-                      deterministic tie-breaking; structural findings reproduce
-                      run-to-run (wall-clock-timed ranks can shift near rounding
-                      boundaries).
+  --json              Machine-readable output (every mode). Carries a top-level
+                      \`schemaVersion\` an agent can branch on; same major version
+                      is additive-only. Stable schema with deterministic
+                      tie-breaking; structural findings reproduce run-to-run
+                      (wall-clock-timed ranks can shift near rounding boundaries).
 
 EXAMPLES
   bf debug profile calendar                       # static budget, no run

--- a/packages/jsx/src/__tests__/profiler.test.ts
+++ b/packages/jsx/src/__tests__/profiler.test.ts
@@ -9,6 +9,7 @@
 
 import { describe, test, expect } from 'bun:test'
 import {
+  PROFILE_SCHEMA_VERSION,
   buildStaticBudget,
   diffStaticBudget,
   formatStaticBudget,
@@ -179,6 +180,73 @@ describe('buildStaticBudget (SR5)', () => {
     expect(b.subscriptions).toBe(0)
     expect(b.crossComponentOnly).toBe(false)
   })
+
+  test('exposes the handlers --scenario auto would fire, name + loc (#1841 A1)', () => {
+    // Two handlers on distinct elements/events. The static list is the coverage
+    // gap an agent can read before any run.
+    const src = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Form() {
+        const [q, setQ] = createSignal('')
+        return (
+          <div>
+            <input onInput={(e) => setQ(e.currentTarget.value)} />
+            <button onClick={() => setQ('')}>Clear</button>
+          </div>
+        )
+      }
+    `
+    const b = buildStaticBudget(src, 'Form.tsx', 'Form')
+    expect(b.handlers.length).toBe(2)
+    // `name` is `<event>@<slotId>` — the slotId joins to dynamic coverage.
+    expect(b.handlers.every(h => /^\w+@\w+$/.test(h.name))).toBe(true)
+    const events = b.handlers.map(h => h.name.split('@')[0]).sort()
+    expect(events).toEqual(['click', 'input'])
+    // Each handler carries a source location.
+    for (const h of b.handlers) {
+      expect(h.loc.file).toContain('Form.tsx')
+      expect(h.loc.line).toBeGreaterThan(0)
+    }
+  })
+
+  test('handlers is empty when the component binds none', () => {
+    const src = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Display() {
+        const [n] = createSignal(0)
+        return <div>{n()}</div>
+      }
+    `
+    const b = buildStaticBudget(src, 'Display.tsx', 'Display')
+    expect(b.handlers).toEqual([])
+  })
+
+  test('renders a handlers section in text output when present, omits it otherwise', () => {
+    const withHandler = formatStaticBudget(buildStaticBudget(counterSource, 'Counter.tsx', 'Counter'))
+    expect(withHandler).toMatch(/handlers \(1\):/)
+    expect(withHandler).toMatch(/click@\w+\s+Counter\.tsx:\d+/)
+
+    const noHandler = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Display() {
+        const [n] = createSignal(0)
+        return <div>{n()}</div>
+      }
+    `
+    expect(formatStaticBudget(buildStaticBudget(noHandler, 'Display.tsx', 'Display'))).not.toContain('handlers (')
+  })
+})
+
+describe('schemaVersion (#1841)', () => {
+  test('every JSON mode carries the schema version', () => {
+    const budget = buildStaticBudget(counterSource, 'Counter.tsx', 'Counter')
+    expect(budget.schemaVersion).toBe(PROFILE_SCHEMA_VERSION)
+    const diff = diffStaticBudget(budget, buildStaticBudget(memoChainSource, 'Calc.tsx', 'Calc'))
+    expect(diff.schemaVersion).toBe(PROFILE_SCHEMA_VERSION)
+  })
 })
 
 describe('diffStaticBudget (SR6)', () => {
@@ -345,6 +413,7 @@ describe('buildProfileReport (dynamic, SR1–SR4 + analyses)', () => {
     ]
     const r = buildProfileReport({ source: src, filePath: 'Calc.tsx', scenario: 'auto', events })
     expect(r.kind).toBe('profile')
+    expect(r.schemaVersion).toBe(PROFILE_SCHEMA_VERSION)
     expect(r.componentName).toBe('Calc')
     expect(r.turns).toBe(1)
     expect(r.hotSubscribers.subscribers[0].name).toBe('a')

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -285,6 +285,7 @@ export type { WrapReason } from './ir-to-client-js/reactivity.ts'
 // Reactive performance profiler (#1690). Static half (SR5 budget, SR6 diff) +
 // dynamic half (SR2/SR4 join, SR7 report, v1 analyses).
 export {
+  PROFILE_SCHEMA_VERSION,
   buildStaticBudget,
   formatStaticBudget,
   diffStaticBudget,
@@ -306,6 +307,7 @@ export type {
   StaticBudget,
   StaticBudgetOptions,
   FanOutEntry,
+  BudgetHandler,
   BudgetDiff,
   FanOutChange,
   ProfileReport,

--- a/packages/jsx/src/profiler.ts
+++ b/packages/jsx/src/profiler.ts
@@ -161,14 +161,15 @@ export function buildStaticBudget(
   // the static list and the dynamic coverage share one identity (slotId).
   const handlers: BudgetHandler[] = graph.domBindings
     .filter(b => b.type === 'event')
-    .map(b => {
+    // Event bindings always carry `loc` (IREvent.loc is required), and coverage's
+    // turn→binding join keys on it too — so skip any loc-less binding rather than
+    // emit an invalid (line 0) location that a consumer would have to special-case.
+    .flatMap(b => {
+      if (!b.loc) return []
       // Label is `<event> handler "<slot>"` — the same parse the scenario driver
       // and coverage join use. Fall back to a neutral `event` if it ever drifts.
       const eventName = b.label.match(/^(\w+)\s+handler/)?.[1] ?? 'event'
-      return {
-        name: `${eventName}@${b.slotId}`,
-        loc: { file: b.loc?.file ?? summary.sourceFile, line: b.loc?.start.line ?? 0 },
-      }
+      return [{ name: `${eventName}@${b.slotId}`, loc: { file: b.loc.file, line: b.loc.start.line } }]
     })
 
   const { depth, chain } = longestMemoChain(graph)

--- a/packages/jsx/src/profiler.ts
+++ b/packages/jsx/src/profiler.ts
@@ -32,7 +32,29 @@ import {
 import { listComponentFunctions, createProgramForFile } from './analyzer.ts'
 import type { ProfilerEvent } from '@barefootjs/shared'
 
+/**
+ * Schema version for the machine-readable `bf debug profile --json` output
+ * (#1841). Bumped when the shape of `StaticBudget` / `ProfileReport` /
+ * `BudgetDiff` changes in a way a consumer must notice. An agent can branch on
+ * this before trusting any other field — the contract is "same major version =
+ * additive only".
+ */
+export const PROFILE_SCHEMA_VERSION = 1
+
 // -- Static budget (SR5) ------------------------------------------------------
+
+/** An event handler the IR knows about — the unit `--scenario auto` fires. */
+export interface BudgetHandler {
+  /**
+   * `<eventName>@<slotId>` (e.g. `click@s1`). The slotId is the stable join
+   * key: it is the element marker `--scenario auto` dispatches against and the
+   * id the coverage report counts, so an agent can map a handler listed here to
+   * its dynamic coverage without running first.
+   */
+  name: string
+  /** Source location of the handler binding (1-indexed line). */
+  loc: { file: string; line: number }
+}
 
 export interface FanOutEntry {
   /** Signal name (the reactive source whose change fans out). */
@@ -55,6 +77,8 @@ export interface FanOutEntry {
 }
 
 export interface StaticBudget {
+  /** Machine-readable output contract version (#1841). See `PROFILE_SCHEMA_VERSION`. */
+  schemaVersion: number
   componentName: string
   sourceFile: string
   kind: 'static-budget'
@@ -70,6 +94,14 @@ export interface StaticBudget {
   memoChainLongest: string[]
   /** Per-signal fan-out, descending, hottest first. */
   fanOut: FanOutEntry[]
+  /**
+   * Event handlers the IR knows about — the exact set `--scenario auto` would
+   * fire — as name + source location (#1841). Exposed statically so an agent
+   * can predict the coverage gap and reference handler names *before* any run.
+   * Empty when this component binds no handlers (they may live in composed
+   * children — see `crossComponentOnly`).
+   */
+  handlers: BudgetHandler[]
   /**
    * True when the component declares reactive state (signals/memos) but nothing
    * in *this* component subscribes to it — every consumer is in a composed child
@@ -124,6 +156,21 @@ export function buildStaticBudget(
     })
     .sort((a, b) => b.subscribers - a.subscribers)
 
+  // Event handlers, in source order — the same `graph.domBindings` event slots
+  // the auto scenario fires (scenario-driver discovers handlers from here), so
+  // the static list and the dynamic coverage share one identity (slotId).
+  const handlers: BudgetHandler[] = graph.domBindings
+    .filter(b => b.type === 'event')
+    .map(b => {
+      // Label is `<event> handler "<slot>"` — the same parse the scenario driver
+      // and coverage join use. Fall back to a neutral `event` if it ever drifts.
+      const eventName = b.label.match(/^(\w+)\s+handler/)?.[1] ?? 'event'
+      return {
+        name: `${eventName}@${b.slotId}`,
+        loc: { file: b.loc?.file ?? summary.sourceFile, line: b.loc?.start.line ?? 0 },
+      }
+    })
+
   const { depth, chain } = longestMemoChain(graph)
 
   // Reactive state exists, yet nothing in *this* component observes it. The
@@ -141,6 +188,7 @@ export function buildStaticBudget(
   const crossComponentOnly = hasReactiveState && !observedInComponent
 
   return {
+    schemaVersion: PROFILE_SCHEMA_VERSION,
     componentName: summary.componentName,
     sourceFile: summary.sourceFile,
     kind: 'static-budget',
@@ -152,6 +200,7 @@ export function buildStaticBudget(
     memoChainDepth: depth,
     memoChainLongest: chain,
     fanOut,
+    handlers,
     crossComponentOnly,
   }
 }
@@ -254,6 +303,13 @@ export function formatStaticBudget(b: StaticBudget): string {
       lines.push(`    ${f.signal.padEnd(12)} → ${f.subscribers} subscribers${detail}${f.hot ? '   ⚠ high' : ''}`)
     }
   }
+  if (b.handlers.length > 0) {
+    lines.push(`  handlers (${b.handlers.length}):`)
+    for (const h of b.handlers) {
+      const file = h.loc.file.split('/').pop() ?? h.loc.file
+      lines.push(`    ${h.name.padEnd(16)} ${file}:${h.loc.line}`)
+    }
+  }
   if (b.crossComponentOnly) {
     lines.push(
       `  ⓘ compound: ${b.signals} signal(s) / ${b.memos} memo(s) but 0 in-component subscriptions —`,
@@ -281,6 +337,8 @@ export interface BudgetDiff {
    * component with no reactive state (#1849 B2).
    */
   kind: 'diff'
+  /** Machine-readable output contract version (#1841). See `PROFILE_SCHEMA_VERSION`. */
+  schemaVersion: number
   componentName: string
   signals: number
   memos: number
@@ -318,6 +376,7 @@ export function diffStaticBudget(base: StaticBudget, head: StaticBudget): Budget
 
   const d: Omit<BudgetDiff, 'regressed'> = {
     kind: 'diff',
+    schemaVersion: PROFILE_SCHEMA_VERSION,
     componentName: head.componentName,
     signals: head.signals - base.signals,
     memos: head.memos - base.memos,
@@ -1312,6 +1371,8 @@ export interface ProfileCoverage {
 
 export interface ProfileReport {
   kind: 'profile'
+  /** Machine-readable output contract version (#1841). See `PROFILE_SCHEMA_VERSION`. */
+  schemaVersion: number
   componentName: string
   sourceFile: string
   /** Scenario label (e.g. `'auto'` or a scenario file name). */
@@ -1464,6 +1525,7 @@ export function buildProfileReport(input: ProfileReportInput): ProfileReport {
 
   return {
     kind: 'profile',
+    schemaVersion: PROFILE_SCHEMA_VERSION,
     componentName: primary.componentName,
     sourceFile: primary.sourceFile,
     scenario,


### PR DESCRIPTION
## Summary

First slice (Tier 1) of #1841 — the agent-oriented profiling work. This lands the two **foundational, low-risk** pieces the rest of the issue builds on:

1. **A1 — expose the handler list in the static budget** (per [this comment](https://github.com/piconic-ai/barefootjs/issues/1841#issuecomment-4660871149)). `StaticBudget` now carries a `handlers` array built from the same `graph.domBindings` event slots `--scenario auto` fires, so the static list and the dynamic coverage share one identity (the `slotId`).
2. **`schemaVersion`** on every `--json` mode (`static-budget` / `profile` / `diff`), so a machine consumer can branch on the output contract.

## Why this first

- The data already exists in the IR (`DomBinding.loc` on event bindings) — no new analysis, low risk.
- The issue's A1 comment frames the handler list as the prerequisite for `nextCommands` generation (the issue's stated "main purpose") and for a "dry-run"-style coverage check.
- Independently useful today: an agent can read the coverage gap and reference handler names **before** any run.

## What changed

- `StaticBudget.handlers: BudgetHandler[]` — `{ name: "click@s1", loc: { file, line } }`. `name` is `<eventName>@<slotId>`; the `slotId` is the join key to dynamic coverage.
- Optional `handlers (N):` section in the text output (omitted when there are none).
- `PROFILE_SCHEMA_VERSION = 1`, added to `StaticBudget` / `ProfileReport` / `BudgetDiff` and exported from `@barefootjs/jsx`.
- `bf debug profile --help` updated (it is the single source of truth for the JSON shape).

### Example

```
Calendar — static reactivity budget
  signals: 4   memos: 9   effects: 0   loops: 6
  ...
  handlers (5):
    click@s25        index.tsx:582
    click@s1         index.tsx:526
    click@s5         index.tsx:534
    click@s14        index.tsx:526
    click@s18        index.tsx:534
```

(Previously the 5 handlers were only revealed by running `--scenario auto`.)

## Tests

- New unit tests in `packages/jsx/src/__tests__/profiler.test.ts`: handler list (name + loc), empty case, text section render/omit, and `schemaVersion` across modes. `bun test packages/jsx/src/__tests__/profiler.test.ts` → 33 pass.
- Full `packages/jsx` suite green; `tsc --noEmit` clean. (The 6 failing `scenario-driver` dynamic tests fail identically on a clean tree — they require the built client runtime — and are unrelated to this change.)
- Changeset added (`@barefootjs/jsx`: minor).

## Not in this PR (follow-ups from #1841)

`severity`/`actionable` normalization, `--fail-on` / `--min-coverage` gates, `nextCommands`, scenario guidance, baseline workflow.

---

Closes part of #1841 (A1 + `schemaVersion`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ss41Cnnmp38i1jg8oR9EQx)_