### PR TITLE
fix(cli): define require via createRequire so the ESM bundle's CJS deps load (#1871)

### DIFF
--- a/.changeset/cli-bundle-dynamic-require.md
+++ b/.changeset/cli-bundle-dynamic-require.md
@@ -1,0 +1,14 @@
+---
+"@barefootjs/cli": patch
+---
+
+fix(cli): `bf debug profile --scenario` crashed with `Dynamic require of "node:events" is not supported` (#1871)
+
+The published CLI is a single-file ESM bundle, but the dynamic profiler's
+lazily-imported DOM stack (happy-dom, whose `ws` dependency is CJS) calls
+`require('node:events')` and friends at runtime. esbuild routes those through a
+`__require` shim that throws under both Node and Bun unless a real `require`
+exists in module scope. The bundle now defines one via
+`createRequire(import.meta.url)` in the build banner, and the published-tarball
+smoke suite runs `bf debug profile --scenario auto` so this interop class can't
+regress silently again.

--- a/packages/cli/scripts/build.mjs
+++ b/packages/cli/scripts/build.mjs
@@ -76,7 +76,15 @@ await build({
   // Rewrite bare Node builtins to the `node:` specifier so the bundle
   // loads under Deno as well as Node/Bun.
   plugins: [nodeProtocolPlugin],
-  // Source index.ts carries the shebang; esbuild preserves it. No banner needed.
+  // Bundled CJS deps (happy-dom's ws, via `bf debug profile --scenario`)
+  // call `require('node:events')` etc. at runtime. In ESM output esbuild
+  // routes those through a `__require` shim that throws "Dynamic require
+  // of … is not supported" unless a real `require` exists in module scope
+  // — so define one via `createRequire`. Deno also supports this (#1871).
+  // esbuild keeps the entry's shebang above the banner.
+  banner: {
+    js: "import { createRequire as __bfCreateRequire } from 'node:module';\nconst require = __bfCreateRequire(import.meta.url);",
+  },
   legalComments: 'none',
   logLevel: 'info',
 })

--- a/scripts/smoke-publish.mjs
+++ b/scripts/smoke-publish.mjs
@@ -263,6 +263,15 @@ smoke('bf search button (local)', 'npx --no-install bf search button')
 smoke('bf build', 'npx --no-install bf build', { expect: 'Build complete' })
 smoke('bf debug graph Counter', 'npx --no-install bf debug graph Counter', { expect: 'count' })
 smoke('bf debug trace Counter count', 'npx --no-install bf debug trace Counter count', { expect: 'count' })
+// The dynamic profiler lazily imports happy-dom, whose CJS deps hit the
+// bundle's `require` shim — broken ESM interop only surfaces from the
+// published bundle, not `bun test` over src (#1871: "Dynamic require of
+// node:events is not supported").
+smoke(
+  'bf debug profile Counter --scenario auto',
+  'npx --no-install bf debug profile Counter --scenario auto',
+  { expect: 'profile (scenario: auto)' },
+)
 
 // — generators
 // `bf init` now scaffolds `components/Counter.test.tsx` alongside


### PR DESCRIPTION
Fixes #1871.

## Problem

`bf debug profile <component> --scenario auto` crashed immediately under both Node and Bun:

```
Error: Dynamic require of "node:events" is not supported
```

## Cause

The published CLI is a single-file **ESM** bundle (`scripts/build.mjs`, `format: 'esm'`). The dynamic profiler lazily imports `@happy-dom/global-registrator`, whose `ws` dependency is CJS and calls `require('node:events')`, `require('node:stream')`, etc. at runtime. When esbuild bundles CJS code into ESM output, those calls go through a `__require` shim that throws "Dynamic require of … is not supported" unless a real `require` exists in module scope. The bundle contained 21 such call sites (all from the happy-dom/ws subtree).

The static modes (`bf debug profile <component>` / `--diff`) were unaffected because the DOM stack is only imported on the `--scenario` path.

## Fix

Add an esbuild `banner` that defines `require` via `createRequire(import.meta.url)` at the top of the bundle — esbuild's `__require` shim picks it up. esbuild keeps the entry's shebang above the banner, and `node:module`'s `createRequire` is supported by Deno, so the existing Node/Bun/Deno runtime matrix is unaffected.

## Regression guard

This interop class only surfaces from the built bundle — `bun test` over `src/` never loads it. Added `bf debug profile Counter --scenario auto` to the published-tarball smoke suite (`scripts/smoke-publish.mjs`), which is the designated dogfood net for regressions that escape into a release.

## Verification

- Reproduced the crash with the pre-fix bundle (`node dist/index.js debug profile collapsible --scenario auto`)
- Post-fix: dynamic, static, and `--diff` modes all work under both `node` and `bun`
- `bun test` in `packages/cli`: 772 pass / 0 fail
- Full `scripts/smoke-publish.mjs` run: PASS, including the new entry

https://claude.ai/code/session_01K2h2kQqtcUPVmaxyPEMLfu

---
_Generated by [Claude Code](https://claude.ai/code/session_01K2h2kQqtcUPVmaxyPEMLfu)_