### PR TITLE
fix(cli): debug profile --scenario fails on components importing local helper modules

### DIFF
--- a/.changeset/profile-scenario-local-helper-imports.md
+++ b/.changeset/profile-scenario-local-helper-imports.md
@@ -1,0 +1,17 @@
+---
+"@barefootjs/cli": patch
+---
+
+fix(cli): `bf debug profile --scenario` failed with a raw `Cannot find module`
+for any component importing a local plain (non-component) module (#1873)
+
+The scenario driver writes the joined client chunks to a temp file before
+importing them, but a plain `.ts` helper emits no client JS — its compiled
+result is discarded while the `import { x } from '../lib/helper'` line survives
+verbatim and resolves (and fails) against the temp directory. Relative imports
+in each chunk are now rewritten before the run: an import of a file whose
+compiled client JS is already concatenated into the run is dropped (the chunks
+share one module scope), and an import of a plain local module is rewritten to
+the absolute path of the original source, which bun loads directly. A relative
+specifier that resolves to no file at all now throws an actionable error
+instead of bun's raw module-resolution stack.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ See `spec/compiler.md` for the full pipeline architecture, IR schema, transforma
   - **Source files (.tsx/.ts)**: the IR's parsed metadata (`ir.metadata.imports`, built by the analyzer's TS AST walk — see `collectImport` in `packages/jsx/src/analyzer.ts`).
   - **Compiled client JS**: a TS AST walk over top-level statements (`ts.isImportDeclaration` + span-based splicing). Precedents: `packages/cli/src/lib/resolve-imports.ts` (migrated from regex to AST for exactly this reason — see `shapeFromDecl`) and `packages/jsx/src/combine-client-js.ts`.
   - Do not add a second parsing library (e.g. es-module-lexer) — `typescript` is already a direct dependency and the AST walk is the repo-wide idiom.
+- **Never add compiler options/hooks for tool-specific output rewriting** (e.g. a rewrite callback on `CompileOptions`). Once such a hook exists it reads as a sanctioned extension point and accretes callers. Tools that need to adjust emitted client JS post-process it themselves with the TS AST walk above; an extra `ts.createSourceFile` parse is acceptable off the build hot path (e.g. `bf debug profile`), not in `bf build`.
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,13 @@ This project primarily uses TypeScript with Go template adapters. Use `bun` inst
 
 See `spec/compiler.md` for the full pipeline architecture, IR schema, transformation rules, adapter interface, and error codes.
 
+## Code Conventions
+
+- **Never parse imports (or any JS/TS syntax) with regex or string matching.** Regexes false-match inside string/template literals and comments, and miss multi-line clauses, trailing commas, and `import type`. Use the established structural patterns instead:
+  - **Source files (.tsx/.ts)**: the IR's parsed metadata (`ir.metadata.imports`, built by the analyzer's TS AST walk — see `collectImport` in `packages/jsx/src/analyzer.ts`).
+  - **Compiled client JS**: a TS AST walk over top-level statements (`ts.isImportDeclaration` + span-based splicing). Precedents: `packages/cli/src/lib/resolve-imports.ts` (migrated from regex to AST for exactly this reason — see `shapeFromDecl`) and `packages/jsx/src/combine-client-js.ts`.
+  - Do not add a second parsing library (e.g. es-module-lexer) — `typescript` is already a direct dependency and the AST walk is the repo-wide idiom.
+
 ## Testing
 
 See `spec/testing.md` for full testing specification with APIs, patterns, and examples.

--- a/packages/cli/src/__tests__/scenario-driver.test.ts
+++ b/packages/cli/src/__tests__/scenario-driver.test.ts
@@ -192,6 +192,35 @@ describe('runAutoScenario', () => {
     }
   })
 
+  test('an import-shaped line inside a template literal is not treated as an import (#1873)', async () => {
+    // A code-sample component embeds `import … from './…'` text in a template
+    // literal. The emitted client JS carries that literal verbatim, with the
+    // line at column 0 — a line-anchored regex would resolve it as a real
+    // import (and fail); the top-level AST walk must ignore it.
+    const dir = mkdtempSync(join(tmpdir(), 'bf-snippet-'))
+    try {
+      const compPath = join(dir, 'CodeSample.tsx')
+      const compSrc = `
+        'use client'
+        import { createSignal } from '@barefootjs/client'
+        export function CodeSample() {
+          const [n, setN] = createSignal(0)
+          const snippet = \`
+import { x } from './not-on-disk'
+\`
+          return <button onClick={() => setN(n() + 1)}>{snippet + n()}</button>
+        }
+      `
+      writeFileSync(compPath, compSrc)
+
+      const r = await runAutoScenario(compSrc, compPath, 'CodeSample')
+      const turn = r.events.find(e => e.type === 'turnBegin')
+      expect(turn?.handlerId).toMatch(/^CodeSample#handler:s\d+:click$/)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
   test('a component with no handler records no interaction turns', async () => {
     const DISPLAY = `
       'use client'

--- a/packages/cli/src/__tests__/scenario-driver.test.ts
+++ b/packages/cli/src/__tests__/scenario-driver.test.ts
@@ -96,6 +96,102 @@ describe('runAutoScenario', () => {
     }
   })
 
+  test('profiles a component that imports a sibling plain helper module (#1873)', async () => {
+    // A plain .ts helper emits no clientJs, so its compiled chunk is discarded
+    // — but the `import { shout } from './repro-helper'` line survives in the
+    // component's chunk and used to resolve (and fail) against the temp dir.
+    const dir = mkdtempSync(join(tmpdir(), 'bf-helper-'))
+    try {
+      writeFileSync(join(dir, 'repro-helper.ts'), `
+        export function shout(s: string): string { return s.toUpperCase() }
+      `)
+      const compPath = join(dir, 'ProfileRepro.tsx')
+      const compSrc = `
+        'use client'
+        import { createSignal } from '@barefootjs/client'
+        import { shout } from './repro-helper'
+        export function ProfileRepro() {
+          const [code, setCode] = createSignal('hi')
+          return (
+            <div>
+              <span>{shout(code())}</span>
+              <button onClick={() => setCode('bye')}>change</button>
+            </div>
+          )
+        }
+      `
+      writeFileSync(compPath, compSrc)
+
+      const r = await runAutoScenario(compSrc, compPath, 'ProfileRepro')
+      expect(r.rootTag).toBe('div')
+      expect(r.fired).toBeGreaterThanOrEqual(1)
+      const turn = r.events.find(e => e.type === 'turnBegin')
+      expect(turn?.handlerId).toMatch(/^ProfileRepro#handler:s\d+:click$/)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('profiles a component whose helper lives above the component dir (#1873)', async () => {
+    // `../src/lib/helper`-style imports resolved against $TMPDIR before the
+    // rewrite; the helper itself has a transitive relative import to cover
+    // resolution from the helper's own directory.
+    const dir = mkdtempSync(join(tmpdir(), 'bf-helper-up-'))
+    try {
+      const libDir = join(dir, 'src', 'lib')
+      const compDir = join(dir, 'components')
+      const { mkdirSync } = await import('fs')
+      mkdirSync(libDir, { recursive: true })
+      mkdirSync(compDir, { recursive: true })
+      writeFileSync(join(libDir, 'words.ts'), `
+        export const WORD = 'tick'
+      `)
+      writeFileSync(join(libDir, 'helper.ts'), `
+        import { WORD } from './words'
+        export function label(n: number): string { return WORD + ':' + n }
+      `)
+      const compPath = join(compDir, 'Timeline.tsx')
+      const compSrc = `
+        'use client'
+        import { createSignal } from '@barefootjs/client'
+        import { label } from '../src/lib/helper'
+        export function Timeline() {
+          const [n, setN] = createSignal(0)
+          return <button onClick={() => setN(n() + 1)}>{label(n())}</button>
+        }
+      `
+      writeFileSync(compPath, compSrc)
+
+      const r = await runAutoScenario(compSrc, compPath, 'Timeline')
+      const turn = r.events.find(e => e.type === 'turnBegin')
+      expect(turn?.handlerId).toMatch(/^Timeline#handler:s\d+:click$/)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('an unresolvable local import yields an actionable error, not a raw module stack (#1873)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'bf-helper-missing-'))
+    try {
+      const compPath = join(dir, 'Broken.tsx')
+      const compSrc = `
+        'use client'
+        import { createSignal } from '@barefootjs/client'
+        import { gone } from './does-not-exist'
+        export function Broken() {
+          const [n, setN] = createSignal(0)
+          return <button onClick={() => setN(n() + 1)}>{gone(n())}</button>
+        }
+      `
+      writeFileSync(compPath, compSrc)
+      await expect(runAutoScenario(compSrc, compPath, 'Broken')).rejects.toThrow(
+        /does not resolve to a local file|static budget/,
+      )
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
   test('a component with no handler records no interaction turns', async () => {
     const DISPLAY = `
       'use client'

--- a/packages/cli/src/__tests__/scenario-driver.test.ts
+++ b/packages/cli/src/__tests__/scenario-driver.test.ts
@@ -221,6 +221,72 @@ import { x } from './not-on-disk'
     }
   })
 
+  test('drops the import of a sibling client-signal file whose chunk is already inlined (#1873)', async () => {
+    // Cross-file @client signal: the consumer's emitted JS imports
+    // `./state.client.js`, whose compiled chunk is concatenated into the same
+    // run — the import must be dropped, not rewritten, and the shared signal
+    // must still drive the consumer's handler.
+    const dir = mkdtempSync(join(tmpdir(), 'bf-state-'))
+    try {
+      writeFileSync(join(dir, 'state.tsx'), `
+        'use client'
+        import { createSignal } from '@barefootjs/client'
+        /* @client */
+        export const [count, setCount] = createSignal(0)
+      `)
+      const compPath = join(dir, 'Counter.tsx')
+      const compSrc = `
+        'use client'
+        import { count, setCount } from './state'
+        export function Counter() {
+          return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+        }
+      `
+      writeFileSync(compPath, compSrc)
+
+      const r = await runAutoScenario(compSrc, compPath, 'Counter')
+      expect(r.sources.map(s => s.filePath.split('/').pop())).toEqual(['state.tsx', 'Counter.tsx'])
+      const turn = r.events.find(e => e.type === 'turnBegin')
+      expect(turn?.handlerId).toMatch(/^Counter#handler:s\d+:click$/)
+      // The click went through the shared signal's setter.
+      expect(r.events.some(e => e.type === 'signalSet' && e.turn === turn!.handlerId)).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('an aliased import of an inlined client-signal file gets a binding shim (#1873)', async () => {
+    // `import { setCount as update }` — dropping the statement alone would
+    // leave `update` undefined in the joined scope while the chunk's handler
+    // calls it. The rewrite must emit `var update = setCount` in its place.
+    const dir = mkdtempSync(join(tmpdir(), 'bf-state-alias-'))
+    try {
+      writeFileSync(join(dir, 'state.tsx'), `
+        'use client'
+        import { createSignal } from '@barefootjs/client'
+        /* @client */
+        export const [count, setCount] = createSignal(0)
+      `)
+      const compPath = join(dir, 'Aliased.tsx')
+      const compSrc = `
+        'use client'
+        import { count, setCount as update } from './state'
+        export function Aliased() {
+          return <button onClick={() => update(count() + 1)}>{count()}</button>
+        }
+      `
+      writeFileSync(compPath, compSrc)
+
+      const r = await runAutoScenario(compSrc, compPath, 'Aliased')
+      const turn = r.events.find(e => e.type === 'turnBegin')
+      expect(turn?.handlerId).toMatch(/^Aliased#handler:s\d+:click$/)
+      // The aliased setter resolved and the set landed inside the turn.
+      expect(r.events.some(e => e.type === 'signalSet' && e.turn === turn!.handlerId)).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
   test('a component with no handler records no interaction turns', async () => {
     const DISPLAY = `
       'use client'

--- a/packages/cli/src/lib/scenario-driver.ts
+++ b/packages/cli/src/lib/scenario-driver.ts
@@ -10,7 +10,7 @@
 // (`bf debug profile <component>` / `--diff`) carry no DOM dependency.
 
 import { writeFileSync, mkdtempSync, rmSync, readFileSync, existsSync, statSync } from 'fs'
-import { join, dirname } from 'path'
+import { join, dirname, resolve } from 'path'
 import { tmpdir } from 'os'
 import type { ProfilerEvent } from '@barefootjs/shared'
 
@@ -159,6 +159,43 @@ function resolveLocalFile(spec: string): string | null {
 }
 
 /**
+ * Rewrite the relative imports a compiled chunk still carries before it is
+ * written to the temp file (#1873). The compiler preserves imports of plain
+ * (non-component) local modules verbatim — `import { x } from '../lib/helper'`
+ * — and those specifiers would otherwise resolve against the temp directory
+ * and fail with a raw "Cannot find module".
+ *
+ * - An import of a file whose compiled client JS is already concatenated into
+ *   this run is dropped: chunks share one module scope, so its declarations
+ *   are already visible (this covers the `./x.client.js` rewrites of
+ *   cross-file signal imports too).
+ * - An import of a plain local module is rewritten to the absolute path of
+ *   the original source file, which bun imports directly (`.ts` included).
+ * - An unresolvable specifier throws an actionable error instead of letting
+ *   the run die in bun's module resolver.
+ */
+function rewriteLocalImports(js: string, chunkPath: string, inlined: Set<string>): string {
+  const chunkDir = dirname(chunkPath)
+  return js.replace(
+    /^(import\s+(?:[^'"\n]*from\s*)?)['"](\.[^'"]+)['"];?\s*$/gm,
+    (_line, head: string, spec: string) => {
+      // A `.client.js` specifier is the compiled output of a sibling client
+      // file — resolve it through that file's source.
+      const resolved = resolveLocalFile(join(chunkDir, spec.replace(/\.client\.js$/, '')))
+      if (!resolved) {
+        throw new Error(
+          `"${spec}" (imported by ${chunkPath}) does not resolve to a local file, so the ` +
+            'dynamic scenario runner cannot load it. Check the import path, or use the ' +
+            'static budget (`bf debug profile <component>`), which needs no run.',
+        )
+      }
+      const abs = resolve(resolved)
+      return inlined.has(abs) ? '' : `${head}${JSON.stringify(abs)}`
+    },
+  )
+}
+
+/**
  * Walk a file's transitive local (relative) imports into a flat,
  * dependency-first source list — so a component (or story) that composes
  * separately-registered children (`<Collapsible><CollapsibleTrigger/>…`)
@@ -228,14 +265,18 @@ async function runScenario(sources: SourceFile[], mountName?: string): Promise<S
   const { compileJSX, testAdapter } = jsx
 
   // Compile each source in profile mode; concatenate (deps first) so every
-  // hydrate(...) registration is present before mount.
-  const clientChunks: string[] = []
+  // hydrate(...) registration is present before mount. Track which source
+  // files produced a chunk so `rewriteLocalImports` can tell an
+  // already-inlined client file from a plain helper module.
+  const clientChunks: { js: string; filePath: string }[] = []
+  const inlined = new Set<string>()
   let rootClientJs = ''
   for (const s of sources) {
     const out = compileJSX(s.source, s.filePath, { adapter: testAdapter, profile: true })
     const js = out.files.find((f: { type: string }) => f.type === 'clientJs')?.content as string | undefined
     if (js) {
-      clientChunks.push(js)
+      clientChunks.push({ js, filePath: s.filePath })
+      inlined.add(resolve(s.filePath))
       rootClientJs = js
     }
   }
@@ -251,7 +292,7 @@ async function runScenario(sources: SourceFile[], mountName?: string): Promise<S
   // so the dynamic run would fail with an opaque module-resolution stack from
   // the package's cache directory. Surface an actionable message instead, named
   // for the actual package (#1849 B3).
-  const external = externalRuntimeImport(clientChunks)
+  const external = externalRuntimeImport(clientChunks.map(c => c.js))
   if (external) {
     throw new Error(
       `"${mountName ?? 'component'}" imports the external package ${external}, whose compiled ` +
@@ -307,7 +348,7 @@ async function runScenario(sources: SourceFile[], mountName?: string): Promise<S
   const RUNTIME_IMPORT = /^import\s*\{([^}]*)\}\s*from\s*['"]@barefootjs\/client\/runtime['"];?\s*$/gm
   const names = new Set<string>()
   for (const chunk of clientChunks) {
-    for (const m of chunk.matchAll(RUNTIME_IMPORT)) {
+    for (const m of chunk.js.matchAll(RUNTIME_IMPORT)) {
       for (const n of m[1].split(',')) {
         const t = n.trim()
         if (t) names.add(t)
@@ -315,6 +356,7 @@ async function runScenario(sources: SourceFile[], mountName?: string): Promise<S
     }
   }
   const body = clientChunks
+    .map(c => rewriteLocalImports(c.js, c.filePath, inlined))
     .join('\n')
     .replace(RUNTIME_IMPORT, '')
     .replace(/^import\s+['"]@barefootjs\/client\/runtime['"];?\s*$/gm, '')

--- a/packages/cli/src/lib/scenario-driver.ts
+++ b/packages/cli/src/lib/scenario-driver.ts
@@ -12,6 +12,7 @@
 import { writeFileSync, mkdtempSync, rmSync, readFileSync, existsSync, statSync } from 'fs'
 import { join, dirname, resolve } from 'path'
 import { tmpdir } from 'os'
+import ts from 'typescript'
 import type { ProfilerEvent } from '@barefootjs/shared'
 
 /** One compiled source in the scenario (a story file or one of its imports). */
@@ -176,23 +177,43 @@ function resolveLocalFile(spec: string): string | null {
  */
 function rewriteLocalImports(js: string, chunkPath: string, inlined: Set<string>): string {
   const chunkDir = dirname(chunkPath)
-  return js.replace(
-    /^(import\s+(?:[^'"\n]*from\s*)?)['"](\.[^'"]+)['"];?\s*$/gm,
-    (_line, head: string, spec: string) => {
-      // A `.client.js` specifier is the compiled output of a sibling client
-      // file — resolve it through that file's source.
-      const resolved = resolveLocalFile(join(chunkDir, spec.replace(/\.client\.js$/, '')))
-      if (!resolved) {
-        throw new Error(
-          `"${spec}" (imported by ${chunkPath}) does not resolve to a local file, so the ` +
-            'dynamic scenario runner cannot load it. Check the import path, or use the ' +
-            'static budget (`bf debug profile <component>`), which needs no run.',
-        )
-      }
-      const abs = resolve(resolved)
-      return inlined.has(abs) ? '' : `${head}${JSON.stringify(abs)}`
-    },
-  )
+  // Walk top-level statements of the chunk (a `ts.createSourceFile` parse, no
+  // type checking) instead of regex-matching lines: emitted code carries user
+  // template literals verbatim, and an import-shaped line inside one must not
+  // be rewritten. Off the build hot path, so the extra parse is fine.
+  const sf = ts.createSourceFile('chunk.mjs', js, ts.ScriptTarget.Latest, false, ts.ScriptKind.JS)
+  const edits: { start: number; end: number; text: string }[] = []
+  for (const stmt of sf.statements) {
+    if (!ts.isImportDeclaration(stmt)) continue
+    if (!ts.isStringLiteral(stmt.moduleSpecifier)) continue
+    const spec = stmt.moduleSpecifier.text
+    if (!spec.startsWith('.')) continue
+    // A `.client.js` specifier is the compiled output of a sibling client
+    // file — resolve it through that file's source.
+    const resolved = resolveLocalFile(join(chunkDir, spec.replace(/\.client\.js$/, '')))
+    if (!resolved) {
+      throw new Error(
+        `"${spec}" (imported by ${chunkPath}) does not resolve to a local file, so the ` +
+          'dynamic scenario runner cannot load it. Check the import path, or use the ' +
+          'static budget (`bf debug profile <component>`), which needs no run.',
+      )
+    }
+    const abs = resolve(resolved)
+    if (inlined.has(abs)) {
+      // Its compiled client JS is already concatenated into this run — drop
+      // the whole statement; the declarations share the joined module scope.
+      edits.push({ start: stmt.getStart(sf), end: stmt.getEnd(), text: '' })
+    } else {
+      edits.push({
+        start: stmt.moduleSpecifier.getStart(sf),
+        end: stmt.moduleSpecifier.getEnd(),
+        text: JSON.stringify(abs),
+      })
+    }
+  }
+  let out = js
+  for (const e of edits.reverse()) out = out.slice(0, e.start) + e.text + out.slice(e.end)
+  return out
 }
 
 /**

--- a/packages/cli/src/lib/scenario-driver.ts
+++ b/packages/cli/src/lib/scenario-driver.ts
@@ -200,9 +200,29 @@ function rewriteLocalImports(js: string, chunkPath: string, inlined: Set<string>
     }
     const abs = resolve(resolved)
     if (inlined.has(abs)) {
-      // Its compiled client JS is already concatenated into this run — drop
-      // the whole statement; the declarations share the joined module scope.
-      edits.push({ start: stmt.getStart(sf), end: stmt.getEnd(), text: '' })
+      // Its compiled client JS is already concatenated into this run, so the
+      // exported declarations share the joined module scope. Drop the
+      // statement — but an aliased binding (`import { setCount as update }`)
+      // needs a shim, because the joined scope declares the exported name,
+      // not the alias. `var` (not `const`) so two chunks aliasing the same
+      // local name don't turn into a redeclaration SyntaxError, matching the
+      // `var x = x ?? …` idiom of emitted module-level code.
+      const clause = stmt.importClause
+      if (clause && (clause.name || (clause.namedBindings && ts.isNamespaceImport(clause.namedBindings)))) {
+        throw new Error(
+          `"${spec}" (imported by ${chunkPath}) uses a default or namespace import of a ` +
+            'sibling client file, which the dynamic scenario runner cannot bind after ' +
+            'inlining that file into the run. Import its exports by name, or use the ' +
+            'static budget (`bf debug profile <component>`), which needs no run.',
+        )
+      }
+      const shims: string[] = []
+      if (clause?.namedBindings && ts.isNamedImports(clause.namedBindings)) {
+        for (const el of clause.namedBindings.elements) {
+          if (el.propertyName) shims.push(`var ${el.name.text} = ${el.propertyName.text}`)
+        }
+      }
+      edits.push({ start: stmt.getStart(sf), end: stmt.getEnd(), text: shims.join('\n') })
     } else {
       edits.push({
         start: stmt.moduleSpecifier.getStart(sf),


### PR DESCRIPTION
Fixes #1873

## Problem

`bf debug profile --scenario auto` (and file scenarios) crashed with a raw `Cannot find module` for any component that imports a local **non-component** module — whether a sibling (`./helper`) or above the component dir (`../src/model/timeline`).

The scenario driver joins the compiled client chunks and writes them to a temp file (`$TMPDIR/bf-profile-XXXX/component.mjs`) before importing. `loadWithLocalImports` does follow and compile the helper, but a plain `.ts` module emits no `clientJs`, so its compilation result is discarded — while the `import { x } from '../lib/helper'` line survives verbatim in the component's chunk and then resolves (and fails) against the temp directory. Only `@barefootjs/client/runtime` imports were rewritten before the run.

## Fix

A new `rewriteLocalImports` pass runs per chunk (each chunk's specifiers resolve against its own source file's directory) before the chunks are joined. It walks the chunk's top-level statements with a `ts.createSourceFile` parse (no regex — emitted code carries user template literals verbatim, and an import-shaped line inside one must not be rewritten; this is the repo-wide idiom for reading compiled client JS, per `resolve-imports.ts` / `combine-client-js.ts`):

- An import of a file whose compiled client JS is **already concatenated** into the run is dropped — the chunks share one module scope, so its declarations are already visible. Aliased bindings (`import { setCount as update }`) get a `var update = setCount` shim in place of the dropped statement; default/namespace imports of an inlined sibling throw an actionable error. This also covers the `./x.client.js` rewrites of cross-file signal imports (resolved through the source file).
- An import of a **plain local module** is rewritten to the absolute path of the original source file, which bun imports directly (`.ts` included).
- An **unresolvable** relative specifier now throws an actionable error (pointing at the static budget) instead of bun's raw module-resolution stack — matching the guarded error for external `@barefootjs/*` packages (#1849 B3).

The PR also records two design conventions in CLAUDE.md that came out of review: parse imports structurally (TS AST / IR metadata), never with regex; and never add compiler options/hooks for tool-specific output rewriting — tools post-process emitted client JS themselves, off the build hot path.

## Tests

Six new tests in `scenario-driver.test.ts` (each fix verified red without it, green with it):

- the issue's exact repro: a sibling plain helper (`./repro-helper`)
- a helper above the component dir (`../src/lib/helper`) with a transitive relative import of its own
- an unresolvable local import → actionable error
- an import-shaped line inside a template literal is not treated as an import (the regex→AST motivation)
- the drop path: a cross-file `/* @client */` signal file whose chunk is inlined into the run
- an aliased import of an inlined client-signal file gets a binding shim

Full CLI suite: 778 pass, 0 fail. Changeset included (`@barefootjs/cli` patch).

https://claude.ai/code/session_01DnnSLyqAXccf2zW5y5k23D