### PR TITLE
ci: extract JSR publish into reusable workflow with manual dispatch

### DIFF
--- a/.github/workflows/jsr-publish.yml
+++ b/.github/workflows/jsr-publish.yml
@@ -1,0 +1,72 @@
+# JSR publish — one implementation, two entry points.
+#
+# This workflow is the single home for the JSR-mirror step. It runs
+# `bun scripts/jsr-publish.ts`, which derives a deno.json per eligible
+# `@barefootjs/*` package and `deno publish`es it, self-skipping any version
+# already live on JSR — so every run is idempotent.
+#
+# Triggers (no duplicated logic between them):
+#   - workflow_call:     release.yml invokes this right after a real npm
+#                        publish, keeping the two registries in lock-step.
+#   - workflow_dispatch: manual re-run. The JSR API occasionally stalls (the
+#                        publish hangs after printing "Publishing …"); when the
+#                        step timeout trips, npm has already shipped, so this
+#                        lets you finish the JSR mirror WITHOUT re-running the
+#                        whole release pipeline (a plain job re-run would find
+#                        npm already published, emit no "New tag:" lines, and
+#                        Changesets would report published=false → the JSR step
+#                        would be skipped, never actually mirroring).
+#
+#                        No inputs by design: the script publishes whatever
+#                        versions the checked-out package.json files declare,
+#                        so dispatch this against the REF of the release you're
+#                        mirroring — e.g. the `@barefootjs/<pkg>@<version>` tag,
+#                        not a moved-on `main` — to avoid mirroring the wrong
+#                        version and breaking lock-step with npm.
+#
+# Needs `id-token: write` for JSR's OIDC auth and Deno to drive the publish.
+
+name: Publish to JSR
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+# Serialize JSR publishes so a manual re-run can't race the release-driven
+# call. cancel-in-progress: false → the second run queues rather than
+# clobbering an in-flight publish (the script is idempotent either way).
+concurrency:
+  group: jsr-publish
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  jsr:
+    runs-on: ubuntu-latest
+    # Backstop for the whole job; the publish step below carries the tighter,
+    # meaningful cap on the known hang point.
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
+      # Deno drives the JSR publish. (No Node/bun install needed: the script
+      # only reads package.json + src and shells out to `deno publish`, which
+      # resolves deps from JSR/npm via the generated manifest's specifiers.)
+      - name: Setup Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+        with:
+          deno-version: v2.x
+
+      - name: Publish to JSR
+        # Tighter cap on the known hang point: a JSR publish that stalls (e.g.
+        # waiting on auth/network) fails the step instead of running for the
+        # full job timeout. jsr-publish.ts self-skips versions already live,
+        # so a re-run safely finishes the mirror.
+        timeout-minutes: 10
+        run: bun scripts/jsr-publish.ts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,12 +60,6 @@ jobs:
         with:
           node-version: '24'
 
-      # Deno drives the JSR publish step below.
-      - name: Setup Deno
-        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
-        with:
-          deno-version: v2.x
-
       - run: bun install
 
       - name: Changesets — version or publish
@@ -77,19 +71,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Mirror whatever Changesets just published to npm onto JSR. The
-      # script self-skips packages whose version is already live on JSR,
-      # so an unconditional run only ever publishes the freshly-bumped
-      # set — keeping the two registries in lock-step. Gated on a real
-      # publish so version-PR runs don't touch JSR.
-      - name: Publish to JSR
-        if: steps.changesets.outputs.published == 'true'
-        # Tighter cap on the known hang point: a JSR publish that stalls (e.g.
-        # waiting on auth/network) fails the step instead of running for hours.
-        # npm has already published by this step, and jsr-publish.ts self-skips
-        # versions already live, so a re-run safely finishes the JSR mirror.
-        timeout-minutes: 10
-        run: bun scripts/jsr-publish.ts
+  # Mirror whatever Changesets just published to npm onto JSR. Delegates to
+  # the reusable jsr-publish.yml so the release-driven path and the manual
+  # workflow_dispatch re-run share one implementation. The script self-skips
+  # versions already live on JSR, so an unconditional run only publishes the
+  # freshly-bumped set — keeping the two registries in lock-step. Gated on a
+  # real publish so version-PR runs don't touch JSR.
+  jsr-release:
+    needs: release
+    if: needs.release.outputs.published == 'true'
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/jsr-publish.yml
 
   cpan-release:
     needs: release


### PR DESCRIPTION
## Why

[Release run #27262299779](https://github.com/piconic-ai/barefootjs/actions/runs/27262299779/job/80510728585) timed out during the JSR publish. The npm publish (15 packages @ 0.12.0) and git tags fully succeeded, but the `Publish to JSR` step hung on the first package, `@barefootjs/shared@0.12.0`, right after printing `Publishing …`, and was killed by the `timeout-minutes: 10` backstop. The cause is a stall on JSR's API — not a code or manifest-generation error.

The real problem is that **a plain job re-run can't fix JSR**:
- A re-run replays the `release` job from the top.
- npm already has 0.12.0 → `changeset-publish.ts` skips everything and emits no `New tag:` lines.
- Changesets' action then reports `published=false`.
- `Publish to JSR` is gated on `if: ... published == 'true'`, so it's skipped → **the run goes green but JSR is never mirrored.**

## What

Extract the JSR publish logic into a reusable workflow `jsr-publish.yml` (`workflow_call` + `workflow_dispatch`).

- **Release path:** `release.yml` now calls it from a new `jsr-release` job (`needs: release`, `if: published == 'true'`) via `uses: ./.github/workflows/jsr-publish.yml`.
- **Manual path:** when JSR stalls, re-run `jsr-publish.yml` via `workflow_dispatch`, **selecting the release tag as the ref** — no need to replay the whole pipeline.
- Both paths share one implementation (`bun scripts/jsr-publish.ts`, Setup Bun + Deno), so there's no duplication. `jsr-publish.ts` self-skips versions already live on JSR, so it's idempotent.
- Removed the now-unused `Setup Deno` step from the `release` job.

## Note on the input-less design

`jsr-publish.ts` reads each `package.json`'s `version` live from the checked-out ref. A manual re-run **must be dispatched against the ref of the release being mirrored** (e.g. the `@barefootjs/<pkg>@<version>` tag). Dispatching from `main` after it has moved on would publish an unintended version and break lock-step with npm. This operational note is also documented in the workflow's header comment.

## Verification

- Both YAML files parse cleanly via `yaml.safe_load`.
- Behavior is based on reading the existing scripts/workflow; verification against a real run is pending.

https://claude.ai/code/session_01S5Jw3X6myHXUArjLceFByR