### PR TITLE
ci: run bun install in jsr-publish workflow before deno publish

### DIFF
--- a/.github/workflows/jsr-publish.yml
+++ b/.github/workflows/jsr-publish.yml
@@ -55,13 +55,19 @@ jobs:
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
 
-      # Deno drives the JSR publish. (No Node/bun install needed: the script
-      # only reads package.json + src and shells out to `deno publish`, which
-      # resolves deps from JSR/npm via the generated manifest's specifiers.)
+      # Deno drives the JSR publish.
       - name: Setup Deno
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version: v2.x
+
+      # Populate node_modules. `deno publish` type-checks each package's src,
+      # and sources that import an npm dependency directly (e.g. jsx imports
+      # `typescript`) resolve it through node_modules — without it Deno fails
+      # with "Could not find \"<pkg>\" in a node_modules folder". The original
+      # inline JSR step inherited the release job's install; the standalone
+      # workflow must do it itself.
+      - run: bun install
 
       - name: Publish to JSR
         # Tighter cap on the known hang point: a JSR publish that stalls (e.g.

--- a/.github/workflows/jsr-publish.yml
+++ b/.github/workflows/jsr-publish.yml
@@ -61,12 +61,8 @@ jobs:
         with:
           deno-version: v2.x
 
-      # Populate node_modules. `deno publish` type-checks each package's src,
-      # and sources that import an npm dependency directly (e.g. jsx imports
-      # `typescript`) resolve it through node_modules — without it Deno fails
-      # with "Could not find \"<pkg>\" in a node_modules folder". The original
-      # inline JSR step inherited the release job's install; the standalone
-      # workflow must do it itself.
+      # deno publish type-checks each package's src; packages that import an
+      # npm dep directly (e.g. jsx → `typescript`) need it in node_modules.
       - run: bun install
 
       - name: Publish to JSR


### PR DESCRIPTION
## Why

Follow-up fix to #1877. The manual `workflow_dispatch` run [#27287824368](https://github.com/piconic-ai/barefootjs/actions/runs/27287824368/job/80599838162) (mirroring 0.12.0) failed:

```
skip  @barefootjs/shared@0.12.0 (already on JSR)
publish  @barefootjs/jsx@0.12.0 → JSR
error: Could not find "typescript" in a node_modules folder. Deno expects
the node_modules/ directory to be up to date. Did you forget to run `deno install`?
    at .../packages/jsx/src/preprocess-inline-jsx-callbacks.ts:33:16
```

`deno publish` type-checks each package's `src`, and packages whose sources import an npm dependency **directly** — `jsx` imports `typescript` — resolve it through `node_modules`. `shared`/`client` import only DOM/Deno builtins and `jsr:` workspace siblings, so they published fine; `jsx` is the first package to need a real npm dep, which is why it surfaced there.

The standalone `jsr-publish.yml` (added in #1877) omitted `bun install` on the assumption that the generated manifest's `npm:`/`jsr:` specifiers cover all deps. That assumption was wrong for direct npm imports. The original *inline* JSR step inherited `node_modules` from the `release` job's `bun install`; the extracted workflow has no such ambient state.

## What

Add `- run: bun install` to `jsr-publish.yml` before the publish step, restoring the environment the original working flow had.

## Verification

- YAML parses via `yaml.safe_load`.
- Confirmed `typescript` is a dependency of `@barefootjs/jsx`.
- Real verification: once merged, re-dispatch `jsr-publish.yml` on `main` (still at 0.12.0) to finish mirroring 0.12.0.

https://claude.ai/code/session_01S5Jw3X6myHXUArjLceFByR

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5Jw3X6myHXUArjLceFByR)_