### PR TITLE
ci: stream deno publish debug log to diagnose JSR hang (temporary)

### DIFF
--- a/.github/workflows/jsr-publish.yml
+++ b/.github/workflows/jsr-publish.yml
@@ -70,5 +70,10 @@ jobs:
         # waiting on auth/network) fails the step instead of running for the
         # full job timeout. jsr-publish.ts self-skips versions already live,
         # so a re-run safely finishes the mirror.
+        # TEMPORARY: JSR_DEBUG streams Deno's debug log to pinpoint where the
+        # publish stalls (suspected provenance/Sigstore step). Remove once the
+        # hang is diagnosed.
+        env:
+          JSR_DEBUG: '1'
         timeout-minutes: 10
         run: bun scripts/jsr-publish.ts

--- a/scripts/jsr-publish.ts
+++ b/scripts/jsr-publish.ts
@@ -306,7 +306,10 @@ try {
     // libraries export resolve cleanly. --allow-slow-types lets JSR extract the
     // public API for docs/.d.ts through its (benign) slow-types warning;
     // --allow-dirty permits the in-tree generated manifest.
-    const pub = await $`deno publish --allow-slow-types --allow-dirty`
+    // JSR_DEBUG streams Deno's debug log so a stalled publish reveals the step
+    // it's stuck on (e.g. provenance / Sigstore vs the JSR publishing task).
+    const debug = process.env.JSR_DEBUG ? ['--log-level=debug'] : []
+    const pub = await $`deno publish --allow-slow-types --allow-dirty ${debug}`
       .cwd(dir)
       .nothrow()
     if (pub.exitCode !== 0) {


### PR DESCRIPTION
## Why

The JSR publish keeps stalling **silently** after `Publishing …` and is killed by the 10-minute backstop. Evidence shows the package actually lands on JSR (e.g. `@barefootjs/shared@0.12.0` became live despite its run hanging), so the deno client never returns from a **post-publish step** — strongly suspected to be provenance/Sigstore (cf. [denoland/deno#29671](https://github.com/denoland/deno/issues/29671)), not the upload itself.

This also reproduced on the automatic **0.13.0** release (run #257): `release` (npm) and `cpan-release` succeeded, but the `jsr-release / jsr` job's "Publish to JSR" step ran ~10 min and **failed** at the same spot. So 0.13.0 is on npm but not yet mirrored to JSR.

We want to confirm the exact stalling step/endpoint before deciding the fix (e.g. `--no-provenance`).

## What

- `scripts/jsr-publish.ts`: when `JSR_DEBUG` is set, append `--log-level=debug` to `deno publish` so Deno's debug log streams live (revealing the step/endpoint it stalls on).
- `jsr-publish.yml`: set `JSR_DEBUG: '1'` on the publish step.

**Temporary diagnostic** — to be reverted once the hang is pinpointed.

## Plan after merge

Re-dispatch `jsr-publish.yml` on `main` (now at 0.13.0). The first unpublished package will hang again, but the streamed debug log should show whether it's stuck in provenance (Sigstore/Rekor) or the JSR publishing-task poll. Then apply the targeted fix.

## Verification

- YAML parses via `yaml.safe_load`; script builds via `bun build`.

https://claude.ai/code/session_01S5Jw3X6myHXUArjLceFByR

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5Jw3X6myHXUArjLceFByR)_