### PR TITLE
ci: raise JSR publish timeout to 15m, drop debug logging

### DIFF
--- a/.github/workflows/jsr-publish.yml
+++ b/.github/workflows/jsr-publish.yml
@@ -66,14 +66,13 @@ jobs:
       - run: bun install
 
       - name: Publish to JSR
-        # Tighter cap on the known hang point: a JSR publish that stalls (e.g.
-        # waiting on auth/network) fails the step instead of running for the
-        # full job timeout. jsr-publish.ts self-skips versions already live,
-        # so a re-run safely finishes the mirror.
-        # TEMPORARY: JSR_DEBUG streams Deno's debug log to pinpoint where the
-        # publish stalls (suspected provenance/Sigstore step). Remove once the
-        # hang is diagnosed.
-        env:
-          JSR_DEBUG: '1'
-        timeout-minutes: 10
+        # JSR completes the publish server-side, but `deno publish` then polls
+        # the publishing task and can outlast a tight cap (the version still
+        # lands — confirmed live on jsr.io — so each run advances at least one
+        # package). A modest cap gives Deno room to observe completion and move
+        # on to the next package, without burning excessive minutes when a
+        # single package's server-side processing is genuinely slow.
+        # jsr-publish.ts self-skips versions already live, so a re-run safely
+        # continues the mirror.
+        timeout-minutes: 15
         run: bun scripts/jsr-publish.ts

--- a/scripts/jsr-publish.ts
+++ b/scripts/jsr-publish.ts
@@ -306,10 +306,7 @@ try {
     // libraries export resolve cleanly. --allow-slow-types lets JSR extract the
     // public API for docs/.d.ts through its (benign) slow-types warning;
     // --allow-dirty permits the in-tree generated manifest.
-    // JSR_DEBUG streams Deno's debug log so a stalled publish reveals the step
-    // it's stuck on (e.g. provenance / Sigstore vs the JSR publishing task).
-    const debug = process.env.JSR_DEBUG ? ['--log-level=debug'] : []
-    const pub = await $`deno publish --allow-slow-types --allow-dirty ${debug}`
+    const pub = await $`deno publish --allow-slow-types --allow-dirty`
       .cwd(dir)
       .nothrow()
     if (pub.exitCode !== 0) {


### PR DESCRIPTION
## Diagnosis (from the JSR_DEBUG run)

The `JSR_DEBUG` run (#1879) pinned the hang precisely, and it is **NOT** provenance/Sigstore as previously suspected:

- The debug log showed `deno publish` polling **`jsr.io`** every ~2 seconds for the **publishing task** to complete, getting a fast `200` each time, never seeing "complete" → killed at the 10-min cap.
- **Zero** Sigstore / Fulcio / Rekor / provenance traffic in the entire log (`--no-provenance` would not have helped — that step is never reached).
- Crucially, **the publish completes server-side regardless**: `@barefootjs/jsx@0.13.0` is now **live on jsr.io** despite its run timing out. So this matches the known JSR pattern ([jsr-io/jsr#642](https://github.com/jsr-io/jsr/issues/642), [fedify-dev/fedify#468](https://github.com/fedify-dev/fedify/issues/468)) where the server-side publishing task is slow to finalize while the CLI waits.

**Implication:** each dispatch advances at least one package (the upload lands), so the mirror converges; deno's client just outlasts a tight cap waiting for the completion signal.

### Current JSR vs npm (from the scope dashboard)

| package | JSR | npm |
|---|---|---|
| shared, jsx | 0.13.0 ✅ | 0.13.0 |
| client | 0.12.0 | 0.13.0 |
| chart, form, go-template, hono, streaming, test, xyflow | 0.10.1 | 0.13.0 |

## What

- `jsr-publish.yml`: raise the publish step cap **10 → 15 min** to give Deno room to observe completion and continue to the next package — deliberately modest (not 30m) to avoid burning minutes when a single package's server-side processing is genuinely slow.
- `scripts/jsr-publish.ts`: remove the temporary `JSR_DEBUG` / `--log-level=debug` plumbing now that the hang is understood.

## Plan after merge

Dispatch `jsr-publish.yml` on `main`. If Deno starts printing `Successfully published …` and advancing through packages, 15m is enough and the mirror catches up quickly. If it still gets killed per package without advancing, we switch to a per-package soft-timeout in the script (treat upload-submitted as async success, since the version lands regardless).

## Verification

- YAML parses via `yaml.safe_load`; script builds via `bun build`.

https://claude.ai/code/session_01S5Jw3X6myHXUArjLceFByR

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5Jw3X6myHXUArjLceFByR)_