### PR TITLE
ci: confirm JSR publishes against JSR, not deno's hung poll

### DIFF
--- a/.github/workflows/jsr-publish.yml
+++ b/.github/workflows/jsr-publish.yml
@@ -46,9 +46,9 @@ permissions:
 jobs:
   jsr:
     runs-on: ubuntu-latest
-    # Backstop for the whole job; the publish step below carries the tighter,
-    # meaningful cap on the known hang point.
-    timeout-minutes: 20
+    # Backstop for the whole job; the publish step below carries the
+    # meaningful cap.
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -66,13 +66,9 @@ jobs:
       - run: bun install
 
       - name: Publish to JSR
-        # JSR completes the publish server-side, but `deno publish` then polls
-        # the publishing task and can outlast a tight cap (the version still
-        # lands — confirmed live on jsr.io — so each run advances at least one
-        # package). A modest cap gives Deno room to observe completion and move
-        # on to the next package, without burning excessive minutes when a
-        # single package's server-side processing is genuinely slow.
-        # jsr-publish.ts self-skips versions already live, so a re-run safely
-        # continues the mirror.
-        timeout-minutes: 15
+        # jsr-publish.ts now bounds each `deno publish` itself (it caps Deno's
+        # never-returning post-upload poll and confirms success against JSR
+        # directly), so this is only an outer backstop. It self-skips versions
+        # already live, so a re-run safely continues the mirror.
+        timeout-minutes: 30
         run: bun scripts/jsr-publish.ts

--- a/scripts/jsr-publish.ts
+++ b/scripts/jsr-publish.ts
@@ -345,12 +345,20 @@ try {
       published++
       continue
     }
-    // Upload submitted but JSR is still finishing server-side. Stop here rather
-    // than publish a dependent before this dep is resolvable — a re-dispatch
-    // skips the now-live packages and continues from here.
-    console.log(`  pend  ${pkg.name}@${pkg.version} submitted; not live within ${VERIFY_TIMEOUT_MS / 60_000}m — stopping, re-dispatch to continue`)
-    pending.push(`${pkg.name}@${pkg.version}`)
-    break
+    if (cutShort) {
+      // We cut Deno's poll short and JSR is still finishing server-side —
+      // the expected pending case. Stop here rather than publish a dependent
+      // before this dep is resolvable; a re-dispatch skips the now-live
+      // packages and continues from here.
+      console.log(`  pend  ${pkg.name}@${pkg.version} submitted; not live within ${VERIFY_TIMEOUT_MS / 60_000}m — stopping, re-dispatch to continue`)
+      pending.push(`${pkg.name}@${pkg.version}`)
+      break
+    }
+    // Deno exited 0 — it observed the publishing task complete — yet the
+    // version never appeared in meta.json. That's a registry propagation
+    // problem or a lookup bug, not routine slowness; surface it as an error
+    // instead of masking it as pending.
+    errors.push(`${pkg.name}@${pkg.version} (deno exited 0 but version not on JSR after ${VERIFY_TIMEOUT_MS / 60_000}m)`)
   }
 } finally {
   if (!keep) for (const f of generated) rmSync(f, { force: true })

--- a/scripts/jsr-publish.ts
+++ b/scripts/jsr-publish.ts
@@ -273,6 +273,18 @@ const generated: string[] = []
 let published = 0
 let skipped = 0
 const errors: string[] = []
+const pending: string[] = []
+
+// `deno publish` uploads in seconds, then polls JSR until the server-side
+// publishing task (module-graph + slow-types doc generation) finishes — but on
+// these slow-typed packages that task can run far past any CI cap while the
+// version itself still goes live (confirmed on jsr.io). So we don't wait on
+// Deno's never-returning poll: cap it at the upload window, then treat JSR as
+// the source of truth and poll jsrHasVersion until the version appears.
+// Background: jsr-io/jsr#642, fedify-dev/fedify#468.
+const DENO_PUBLISH_TIMEOUT_S = 240 // generous: type-check + upload take seconds
+const VERIFY_TIMEOUT_MS = 6 * 60_000
+const VERIFY_INTERVAL_MS = 15_000
 
 try {
   for (const { dir, pkg } of selected) {
@@ -306,14 +318,39 @@ try {
     // libraries export resolve cleanly. --allow-slow-types lets JSR extract the
     // public API for docs/.d.ts through its (benign) slow-types warning;
     // --allow-dirty permits the in-tree generated manifest.
-    const pub = await $`deno publish --allow-slow-types --allow-dirty`
+    // `timeout` cuts Deno's post-upload poll short (see DENO_PUBLISH_TIMEOUT_S
+    // note above); the verify loop below is what actually confirms success.
+    const pub = await $`timeout --kill-after=10s ${DENO_PUBLISH_TIMEOUT_S} deno publish --allow-slow-types --allow-dirty`
       .cwd(dir)
       .nothrow()
-    if (pub.exitCode !== 0) {
-      errors.push(`${pkg.name}@${pkg.version}`)
+    // 124 (TERM) / 137 (KILL) mean our timeout fired while Deno was still
+    // polling — expected, not a failure. Any other non-zero is a genuine
+    // publish error (type error, auth, unresolvable dep, …).
+    const cutShort = pub.exitCode === 124 || pub.exitCode === 137
+    if (pub.exitCode !== 0 && !cutShort) {
+      errors.push(`${pkg.name}@${pkg.version} (deno exit ${pub.exitCode})`)
       continue
     }
-    published++
+
+    // JSR is the source of truth: poll until the version is live, regardless of
+    // whether Deno returned cleanly or we cut its hung poll short.
+    let live = await jsrHasVersion(pkg.name, pkg.version)
+    const deadline = Date.now() + VERIFY_TIMEOUT_MS
+    while (!live && Date.now() < deadline) {
+      await Bun.sleep(VERIFY_INTERVAL_MS)
+      live = await jsrHasVersion(pkg.name, pkg.version)
+    }
+    if (live) {
+      console.log(`  ok    ${pkg.name}@${pkg.version} live on JSR${cutShort ? ' (deno poll cut short)' : ''}`)
+      published++
+      continue
+    }
+    // Upload submitted but JSR is still finishing server-side. Stop here rather
+    // than publish a dependent before this dep is resolvable — a re-dispatch
+    // skips the now-live packages and continues from here.
+    console.log(`  pend  ${pkg.name}@${pkg.version} submitted; not live within ${VERIFY_TIMEOUT_MS / 60_000}m — stopping, re-dispatch to continue`)
+    pending.push(`${pkg.name}@${pkg.version}`)
+    break
   }
 } finally {
   if (!keep) for (const f of generated) rmSync(f, { force: true })
@@ -322,7 +359,14 @@ try {
 if (dryRun) {
   console.log(`\n  Dry run: ${selected.length} package(s) would be considered`)
 } else {
-  console.log(`\n  Done: ${published} published, ${skipped} skipped`)
+  console.log(`\n  Done: ${published} published, ${skipped} skipped${pending.length ? `, ${pending.length} pending` : ''}`)
+}
+
+if (pending.length > 0) {
+  // Not a failure — the upload is submitted and JSR is finishing it
+  // server-side. Surface it clearly and exit 0 so a re-dispatch can continue.
+  console.warn(`\n  ${pending.length} pending (submitted, server-side processing — re-dispatch to continue):`)
+  for (const p of pending) console.warn(`    - ${p}`)
 }
 
 if (errors.length > 0) {


### PR DESCRIPTION
## Root cause (answering "what's actually going on")

`deno publish` does: ① local type-check → ② upload tarball (seconds) → ③ **poll JSR until the server-side publishing task finishes** (module-graph build + **slow-types documentation/type-API generation**). The `JSR_DEBUG` run showed deno stuck in ③, polling `jsr.io` every ~2s forever — **no** Sigstore/provenance traffic at all. Meanwhile the version's files go live regardless.

So the real problem is **JSR's server-side publishing task running far past any CI cap** on our slow-typed, large-internal-graph packages (every package prints the `slow types … may affect documentation generation` warning — and that doc generation is exactly what deno waits on). Same symptom as [jsr-io/jsr#642](https://github.com/jsr-io/jsr/issues/642) and root-caused in [fedify-dev/fedify#468](https://github.com/fedify-dev/fedify/issues/468) (slow/circular types). Confirmed empirically: bumping the cap 10→15m didn't help — `client@0.13.0` polled the full 15m and was killed, yet still uploaded; `shared@0.13.0`/`jsx@0.13.0` are already live on jsr.io.

**The genuine fix is eliminating slow types** (annotate public APIs so JSR's fast-check/doc-gen completes promptly) — a large, separate source effort, which is the very reason `--allow-slow-types` is used. This PR is the pragmatic workaround.

## What

Stop waiting on deno's never-returning poll; make **JSR the source of truth**:

- Cap each `deno publish` with `timeout` at the upload window (`DENO_PUBLISH_TIMEOUT_S = 240`). Exit `124`/`137` from the cap is expected, not a failure.
- Then poll `jsrHasVersion` until the version is live (up to 6 min). Live → success (`ok …`), whether deno returned cleanly or we cut its poll short.
- If uploaded but not live when the verify window elapses → stop (don't publish a dependent before its dep resolves) and report `pending`; a re-dispatch skips now-live packages and continues. Exit 0 (pending is not a failure).
- Workflow: the script self-bounds each publish now, so the step is just an outer backstop → step `15→30m`, job `20→35m`.

Converges in **one run** when JSR is quick; degrades gracefully (no worse than the old crawl, minus the wasted idle minutes) when slow.

## Verification

- YAML parses (`yaml.safe_load`); script builds (`bun build`).
- Behavior to be confirmed on the next dispatch (how many of client/chart/form/go-template/hono/streaming/test/xyflow clear in one run).

https://claude.ai/code/session_01S5Jw3X6myHXUArjLceFByR

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5Jw3X6myHXUArjLceFByR)_