### PR TITLE
ci: cache-bust JSR meta.json lookups to stop stale skip/verify reads

### DIFF
--- a/scripts/jsr-publish.ts
+++ b/scripts/jsr-publish.ts
@@ -256,9 +256,18 @@ function topoSort(cands: Candidate[]): Candidate[] {
 }
 
 // ── Has this exact version already been published to JSR? ─────────────
+// jsr.io/<pkg>/meta.json is served through a CDN whose edge caches are
+// eventually consistent — the same version can read as present on one fetch
+// and absent on the next (observed: a version skipped as "already on JSR" in
+// one run, then reported missing in the next). Since we use this as the source
+// of truth for both skip and post-publish verification, bypass the cache: a
+// unique query string forces a fresh origin read, plus no-store on our side.
 async function jsrHasVersion(name: string, version: string): Promise<boolean> {
   try {
-    const res = await fetch(`https://jsr.io/${name}/meta.json`)
+    const res = await fetch(`https://jsr.io/${name}/meta.json?_=${Date.now()}`, {
+      cache: 'no-store',
+      headers: { 'cache-control': 'no-cache', pragma: 'no-cache' },
+    })
     if (!res.ok) return false
     const meta = (await res.json()) as { versions?: Record<string, unknown> }
     return Boolean(meta.versions && version in meta.versions)


### PR DESCRIPTION
## Why

While crawling the 0.13.0 mirror, a run failed with a contradictory error:

```
1 error(s):
  - @barefootjs/client@0.13.0 (deno exited 0 but version not on JSR after 6m)
1 pending: @barefootjs/form@0.13.0
```

`client@0.13.0` was **skipped as "already on JSR"** in the previous run (06:02), then the next run (06:46) read it as **missing**, re-published it (deno exited 0 — it observed the task complete), and the verify loop still couldn't see it within 6 min → flagged an error.

Versions don't disappear from JSR. The cause is that **`jsr.io/<pkg>/meta.json` is CDN-cached and eventually consistent** — different fetches hit edges with different staleness, so the same version reads present on one request and absent on another. Since `jsrHasVersion` is now the source of truth for **both** the skip check and post-publish verification (#1882), that flakiness produces false skips, false re-publishes, and false errors.

## What

Bypass the CDN in `jsrHasVersion`: append a unique `?_=<timestamp>` (forces a fresh cache key / origin read) and send `cache: no-store` + no-cache headers. Every lookup now reads fresh.

## Verification

- `bun build` passes.
- Effect confirmed on the next crawl dispatches (no more present↔absent flapping between runs).

https://claude.ai/code/session_01S5Jw3X6myHXUArjLceFByR

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5Jw3X6myHXUArjLceFByR)_