### PR TITLE
Add golden-vector conformance harness for template helpers

### DIFF
--- a/.github/workflows/ci-go-template.yml
+++ b/.github/workflows/ci-go-template.yml
@@ -51,6 +51,11 @@ jobs:
       - name: Pre-warm Go build cache
         run: cd packages/adapter-go-template/runtime && GOTOOLCHAIN=local go build ./...
 
+      - name: Run Go runtime unit tests
+        # Includes the golden-vector conformance harness (vectors_test.go,
+        # see spec/template-helpers.md).
+        run: cd packages/adapter-go-template/runtime && GOTOOLCHAIN=local go test ./...
+
       - name: Run unit tests
         run: bun test packages/adapter-go-template
 

--- a/packages/adapter-go-template/runtime/vectors_test.go
+++ b/packages/adapter-go-template/runtime/vectors_test.go
@@ -1,0 +1,178 @@
+package bf
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// vectorsPath points at the golden vectors generated from the JS
+// reference implementations (spec/template-helpers.md). The file only
+// exists in the monorepo checkout — consumers of the published Go
+// module don't receive it, so TestHelperVectors skips there.
+const vectorsPath = "../../adapter-tests/helper-vectors/vectors.json"
+
+type helperVector struct {
+	Fn     string            `json:"fn"`
+	Args   []json.RawMessage `json:"args"`
+	Expect json.RawMessage   `json:"expect"`
+	Note   string            `json:"note"`
+}
+
+type vectorFile struct {
+	Version int            `json:"version"`
+	Cases   []helperVector `json:"cases"`
+}
+
+// vectorBindings maps a canonical helper id from the spec catalogue to
+// the Go implementation the compiled templates call. Per the spec, a
+// vector whose fn has no binding here FAILS the test — the Go backend
+// is not allowed to silently fall behind the catalogue.
+var vectorBindings = map[string]func(args []any) any{
+	"add": func(args []any) any { return Add(args[0], args[1]) },
+}
+
+func TestHelperVectors(t *testing.T) {
+	data, err := os.ReadFile(vectorsPath)
+	if os.IsNotExist(err) {
+		t.Skipf("golden vectors not available outside the monorepo checkout (%s)", vectorsPath)
+	}
+	if err != nil {
+		t.Fatalf("read %s: %v", vectorsPath, err)
+	}
+
+	var file vectorFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		t.Fatalf("parse %s: %v", vectorsPath, err)
+	}
+	if len(file.Cases) == 0 {
+		t.Fatal("vectors.json contains no cases")
+	}
+
+	for i, c := range file.Cases {
+		t.Run(fmt.Sprintf("%s/%s", c.Fn, c.Note), func(t *testing.T) {
+			bind, ok := vectorBindings[c.Fn]
+			if !ok {
+				t.Fatalf("no Go binding for helper %q — add it to vectorBindings", c.Fn)
+			}
+			args := make([]any, len(c.Args))
+			for j, raw := range c.Args {
+				v, err := decodeVectorValue(raw)
+				if err != nil {
+					t.Fatalf("case %d: decode arg %d: %v", i, j, err)
+				}
+				args[j] = v
+			}
+			expect, err := decodeVectorValue(c.Expect)
+			if err != nil {
+				t.Fatalf("case %d: decode expect: %v", i, err)
+			}
+			got := bind(args)
+			if !vectorEqual(got, expect) {
+				t.Errorf("%s(%s) = %v (%T), want %v (%T)", c.Fn, string(mustJoinRaw(c.Args)), got, got, expect, expect)
+			}
+		})
+	}
+}
+
+func mustJoinRaw(raws []json.RawMessage) []byte {
+	parts := make([][]byte, len(raws))
+	for i, r := range raws {
+		parts[i] = []byte(r)
+	}
+	return bytes.Join(parts, []byte(", "))
+}
+
+// decodeVectorValue decodes a JSON value with integral numbers mapped
+// to Go int — template data is typically int-typed (struct fields,
+// range indices), so this exercises the int-preserving helper paths —
+// and all other numbers to float64.
+func decodeVectorValue(raw json.RawMessage) (any, error) {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	var v any
+	if err := dec.Decode(&v); err != nil {
+		return nil, err
+	}
+	return normalizeVectorValue(v), nil
+}
+
+func normalizeVectorValue(v any) any {
+	switch x := v.(type) {
+	case json.Number:
+		if !strings.ContainsAny(x.String(), ".eE") {
+			if n, err := strconv.ParseInt(x.String(), 10, 64); err == nil {
+				return int(n)
+			}
+		}
+		f, _ := x.Float64()
+		return f
+	case []any:
+		for i := range x {
+			x[i] = normalizeVectorValue(x[i])
+		}
+		return x
+	case map[string]any:
+		for k := range x {
+			x[k] = normalizeVectorValue(x[k])
+		}
+		return x
+	}
+	return v
+}
+
+// vectorEqual implements the spec's value-compat contract: numbers
+// compare numerically regardless of Go type (int 3 == float64 3),
+// everything else compares structurally.
+func vectorEqual(got, expect any) bool {
+	if expect == nil {
+		return got == nil
+	}
+	if isNumericValue(expect) {
+		return isNumericValue(got) && toFloat64(got) == toFloat64(expect)
+	}
+	switch e := expect.(type) {
+	case string:
+		s, ok := got.(string)
+		return ok && s == e
+	case bool:
+		b, ok := got.(bool)
+		return ok && b == e
+	case []any:
+		g, ok := got.([]any)
+		if !ok || len(g) != len(e) {
+			return false
+		}
+		for i := range e {
+			if !vectorEqual(g[i], e[i]) {
+				return false
+			}
+		}
+		return true
+	case map[string]any:
+		g, ok := got.(map[string]any)
+		if !ok || len(g) != len(e) {
+			return false
+		}
+		for k := range e {
+			gv, present := g[k]
+			if !present || !vectorEqual(gv, e[k]) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func isNumericValue(v any) bool {
+	switch v.(type) {
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
+		return true
+	}
+	return false
+}

--- a/packages/adapter-perl/MANIFEST
+++ b/packages/adapter-perl/MANIFEST
@@ -8,5 +8,6 @@ Makefile.PL
 README.md
 t/controller_cycle.t
 t/dev_reload.t
+t/helper_vectors.t
 t/spread_attrs.t
 t/template_primitives.t

--- a/packages/adapter-perl/t/helper_vectors.t
+++ b/packages/adapter-perl/t/helper_vectors.t
@@ -1,0 +1,68 @@
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+use File::Spec;
+use JSON::PP ();
+use Scalar::Util qw(looks_like_number);
+
+# Golden helper vectors generated from the JS reference implementations
+# (spec/template-helpers.md in the monorepo). The file is not shipped in
+# the CPAN dist — packages/adapter-tests only exists in a monorepo
+# checkout — so skip everywhere else.
+my $vectors_path = File::Spec->catfile(
+    $FindBin::Bin, '..', '..', 'adapter-tests', 'helper-vectors', 'vectors.json'
+);
+plan skip_all => 'golden vectors not available outside the monorepo checkout'
+    unless -e $vectors_path;
+
+my $doc = do {
+    open my $fh, '<:raw', $vectors_path or die "open $vectors_path: $!";
+    local $/;
+    JSON::PP->new->decode(<$fh>);
+};
+
+# One binding per canonical helper id in the spec catalogue, bound to
+# the exact code shape compiled templates execute on the Perl backends.
+# Where the adapters lower an operation to a native Perl operator
+# (mojo-adapter.ts maps JSX `+` straight to Perl `+`), the binding IS
+# that operator rather than a BarefootJS.pm method. Per the spec, a
+# vector with no binding here fails the test — the Perl backend must
+# not silently fall behind the catalogue.
+my %bindings = (
+    add => sub { $_[0] + $_[1] },
+);
+
+for my $case (@{ $doc->{cases} }) {
+    my ($fn, $note) = @{$case}{qw(fn note)};
+    my $bind = $bindings{$fn};
+    if (!$bind) {
+        fail("no Perl binding for helper '$fn' — add it to %bindings in $0");
+        next;
+    }
+    vector_ok($bind->(@{ $case->{args} }), $case->{expect}, "$fn: $note");
+}
+
+done_testing;
+
+# Spec value-compat contract: numbers compare numerically (JSON::PP
+# decodes vector numbers to IV/NV, `==` compares the values), booleans
+# by truthiness, everything else structurally. Arrays currently go
+# through is_deeply (string compare per element) — refine to a
+# recursive numeric walk when the first float-array vector lands.
+sub vector_ok {
+    my ($got, $expect, $label) = @_;
+    if (!defined $expect) {
+        return is($got, undef, $label);
+    }
+    if (JSON::PP::is_bool($expect)) {
+        return is(!!$got, !!$expect, $label);
+    }
+    if (ref $expect) {
+        return is_deeply($got, $expect, $label);
+    }
+    if (looks_like_number($expect)) {
+        return cmp_ok($got, '==', $expect, $label);
+    }
+    return is($got, $expect, $label);
+}

--- a/packages/adapter-tests/helper-vectors/cases.ts
+++ b/packages/adapter-tests/helper-vectors/cases.ts
@@ -1,0 +1,39 @@
+/**
+ * Golden-vector case definitions for the template helper catalogue
+ * (spec/template-helpers.md).
+ *
+ * Each case names a canonical helper id and its arguments; the expected
+ * value is COMPUTED by running the JS reference implementation below
+ * (see generate.ts), never transcribed by hand — JS parity is
+ * mechanical. Every case should pin a rule stated in the spec entry,
+ * named by its `note`.
+ */
+
+export interface HelperCase {
+  /** Canonical helper id from the spec catalogue (no bf_ prefix). */
+  fn: string
+  args: unknown[]
+  /** Which spec rule this case pins. Copied into vectors.json. */
+  note: string
+}
+
+/**
+ * JS reference implementations — the semantic source of truth per
+ * spec/template-helpers.md. These are deliberately the literal JS
+ * expression each helper lowers (`a + b`, not a reimplementation), so
+ * the vectors encode real JS engine behavior.
+ */
+export const reference: Record<string, (...args: never[]) => unknown> = {
+  add: (a: number, b: number) => a + b,
+}
+
+export const cases: HelperCase[] = [
+  { fn: 'add', args: [1, 2], note: 'int + int' },
+  { fn: 'add', args: [10, -5], note: 'negative operand' },
+  { fn: 'add', args: [0, 0], note: 'zero identity' },
+  { fn: 'add', args: [1.5, 2.5], note: 'float + float with integral result value' },
+  { fn: 'add', args: [1, 2.5], note: 'mixed int/float operands' },
+  { fn: 'add', args: [0.1, 0.2], note: 'IEEE-754 double rounding' },
+  { fn: 'add', args: [-1.5, -2.25], note: 'negative floats' },
+  { fn: 'add', args: [9007199254740991, 1], note: 'upper edge of the safe-integer domain (2^53)' },
+]

--- a/packages/adapter-tests/helper-vectors/generate.ts
+++ b/packages/adapter-tests/helper-vectors/generate.ts
@@ -1,0 +1,71 @@
+/**
+ * Golden-vector generator (spec/template-helpers.md).
+ *
+ * Runs every case in cases.ts through its JS reference implementation
+ * and writes vectors.json — the language-independent conformance data
+ * consumed by the Go (runtime/vectors_test.go) and Perl
+ * (t/helper_vectors.t) harnesses.
+ *
+ *   cd packages/adapter-tests && bun run generate:helper-vectors
+ *
+ * The freshness test in src/__tests__/helper-vectors.test.ts fails CI
+ * when vectors.json is out of date with cases.ts.
+ */
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { cases, reference } from './cases'
+
+export const VECTORS_PATH = join(dirname(fileURLToPath(import.meta.url)), 'vectors.json')
+
+export interface VectorFile {
+  version: number
+  generator: string
+  spec: string
+  cases: Array<{ fn: string; args: unknown[]; expect: unknown; note: string }>
+}
+
+/**
+ * Vectors are plain JSON: finite numbers, strings, booleans, null, and
+ * arrays/objects thereof. NaN / ±Infinity / undefined have no JSON
+ * encoding — per the spec, a sentinel scheme lands together with the
+ * first catalogue entry that needs one, so until then refuse loudly
+ * instead of letting JSON.stringify silently emit `null`.
+ */
+function assertEncodable(value: unknown, context: string): void {
+  if (value === undefined) throw new Error(`${context}: undefined is not encodable in vectors.json`)
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    throw new Error(`${context}: non-finite number ${value} is not encodable in vectors.json`)
+  }
+  if (Array.isArray(value)) {
+    value.forEach((v, i) => assertEncodable(v, `${context}[${i}]`))
+  } else if (value !== null && typeof value === 'object') {
+    for (const [k, v] of Object.entries(value)) assertEncodable(v, `${context}.${k}`)
+  }
+}
+
+export function buildVectors(): VectorFile {
+  return {
+    version: 1,
+    generator: 'packages/adapter-tests/helper-vectors/generate.ts',
+    spec: 'spec/template-helpers.md',
+    cases: cases.map((c) => {
+      const ref = reference[c.fn]
+      if (!ref) throw new Error(`no JS reference implementation for helper "${c.fn}" in cases.ts`)
+      const context = `${c.fn}(${JSON.stringify(c.args)})`
+      assertEncodable(c.args, context)
+      const expect = (ref as (...args: unknown[]) => unknown)(...c.args)
+      assertEncodable(expect, `${context} → expect`)
+      return { fn: c.fn, args: c.args, expect, note: c.note }
+    }),
+  }
+}
+
+export function serializeVectors(): string {
+  return JSON.stringify(buildVectors(), null, 2) + '\n'
+}
+
+if (import.meta.main) {
+  const { writeFileSync } = await import('node:fs')
+  writeFileSync(VECTORS_PATH, serializeVectors())
+  console.log(`wrote ${VECTORS_PATH} (${cases.length} cases)`)
+}

--- a/packages/adapter-tests/helper-vectors/vectors.json
+++ b/packages/adapter-tests/helper-vectors/vectors.json
@@ -1,0 +1,79 @@
+{
+  "version": 1,
+  "generator": "packages/adapter-tests/helper-vectors/generate.ts",
+  "spec": "spec/template-helpers.md",
+  "cases": [
+    {
+      "fn": "add",
+      "args": [
+        1,
+        2
+      ],
+      "expect": 3,
+      "note": "int + int"
+    },
+    {
+      "fn": "add",
+      "args": [
+        10,
+        -5
+      ],
+      "expect": 5,
+      "note": "negative operand"
+    },
+    {
+      "fn": "add",
+      "args": [
+        0,
+        0
+      ],
+      "expect": 0,
+      "note": "zero identity"
+    },
+    {
+      "fn": "add",
+      "args": [
+        1.5,
+        2.5
+      ],
+      "expect": 4,
+      "note": "float + float with integral result value"
+    },
+    {
+      "fn": "add",
+      "args": [
+        1,
+        2.5
+      ],
+      "expect": 3.5,
+      "note": "mixed int/float operands"
+    },
+    {
+      "fn": "add",
+      "args": [
+        0.1,
+        0.2
+      ],
+      "expect": 0.30000000000000004,
+      "note": "IEEE-754 double rounding"
+    },
+    {
+      "fn": "add",
+      "args": [
+        -1.5,
+        -2.25
+      ],
+      "expect": -3.75,
+      "note": "negative floats"
+    },
+    {
+      "fn": "add",
+      "args": [
+        9007199254740991,
+        1
+      ],
+      "expect": 9007199254740992,
+      "note": "upper edge of the safe-integer domain (2^53)"
+    }
+  ]
+}

--- a/packages/adapter-tests/package.json
+++ b/packages/adapter-tests/package.json
@@ -9,6 +9,7 @@
     }
   },
   "scripts": {
+    "generate:helper-vectors": "bun helper-vectors/generate.ts",
     "test:fixture-hydrate": "bunx playwright test --config=playwright.config.ts"
   },
   "dependencies": {

--- a/packages/adapter-tests/src/__tests__/helper-vectors.test.ts
+++ b/packages/adapter-tests/src/__tests__/helper-vectors.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Freshness + shape guard for the golden helper vectors
+ * (spec/template-helpers.md).
+ *
+ * vectors.json is generated from helper-vectors/cases.ts and committed;
+ * the Go and Perl harnesses consume the committed file. This test fails
+ * when the file drifts from the case definitions, so "edited cases.ts
+ * but forgot to regenerate" (or hand-edited vectors.json) can't land.
+ */
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { buildVectors, serializeVectors, VECTORS_PATH } from '../../helper-vectors/generate'
+import { reference } from '../../helper-vectors/cases'
+
+describe('helper golden vectors', () => {
+  test('vectors.json is up to date with cases.ts (run `bun run generate:helper-vectors`)', () => {
+    expect(readFileSync(VECTORS_PATH, 'utf8')).toBe(serializeVectors())
+  })
+
+  test('every case has a JS reference implementation', () => {
+    for (const c of buildVectors().cases) {
+      expect(reference).toHaveProperty(c.fn)
+    }
+  })
+})

--- a/spec/template-helpers.md
+++ b/spec/template-helpers.md
@@ -1,0 +1,144 @@
+# Template Helper Conformance Spec
+
+Language-independent specification for the **pure value helpers** that
+adapters use to lower JavaScript expressions into template languages —
+the functions registered as `bf_*` in the Go adapter's
+`runtime/bf.go` FuncMap, implemented as `BarefootJS.pm` methods in the
+Perl adapters, or lowered to native host operators where the host
+language already has JS-compatible semantics.
+
+The goal is that a template expression compiled from JSX produces the
+**same value** on every backend as the JS reference (Hono/CSR) path.
+This spec, together with the golden vectors described below, is the
+contract a new language adapter (Python, Ruby, …) implements against:
+write the helpers idiomatically, pass the vectors, done. No FFI, no
+shared binary — each backend stays pure host-language.
+
+## Scope
+
+In scope: helpers that are **pure functions of their arguments** —
+arithmetic, string, array, and coercion operations (`add`, `slice`,
+`pad_start`, `number`, …).
+
+Out of scope: helpers coupled to render state (`bfScripts`,
+`bfPropsAttr`, `bfHydrationAttrs`, `bfPortalHTML`, context, streaming).
+Those are covered by the adapter conformance fixtures in
+`packages/adapter-tests/fixtures/`, which exercise full IR → HTML
+rendering per adapter.
+
+## Reference semantics
+
+**JavaScript is normative.** Every catalogue entry has a JS reference
+implementation in `packages/adapter-tests/helper-vectors/cases.ts`.
+Expected values in the golden vectors are **computed by executing that
+reference**, not transcribed by hand — JS parity is mechanical.
+
+### Compatibility contract
+
+- **Value-compat, not type-compat.** Backends may use a different
+  runtime type as long as the value is equal. Example: Go's `bf.Add`
+  returns `int` when both operands are int-like; JS has only `number`.
+  Harnesses compare numbers numerically, never by type or by printed
+  representation.
+- **Numbers are IEEE-754 doubles.** Arithmetic follows double
+  semantics, including rounding (`0.1 + 0.2` →
+  `0.30000000000000004`).
+- **Integer domain is the JS safe range** (|n| ≤ 2^53 − 1, with exact
+  results up to 2^53). Outside that range behavior is
+  **adapter-defined**: Perl lowers arithmetic to native ops whose IV
+  arithmetic is 64-bit exact, while JS and Go (which round-trips
+  through `float64`) lose precision identically. Vectors never test
+  outside the safe range.
+- Divergences a backend cannot reasonably avoid are documented per
+  catalogue entry and excluded from the vectors.
+
+## Golden vectors
+
+`packages/adapter-tests/helper-vectors/vectors.json` — generated,
+committed, and consumed by one thin harness per backend.
+
+```json
+{
+  "version": 1,
+  "cases": [
+    { "fn": "add", "args": [0.1, 0.2], "expect": 0.30000000000000004,
+      "note": "IEEE-754 double rounding" }
+  ]
+}
+```
+
+- `fn` is the **canonical helper id** from this catalogue (no `bf_`
+  prefix, no host-language casing).
+- `args` / `expect` are plain JSON values: finite numbers, strings,
+  booleans, `null`, and arrays/objects thereof. `NaN`, `±Infinity`,
+  and `undefined` are not representable in JSON; the generator
+  **refuses** cases producing them. A sentinel encoding will be added
+  together with the first catalogue entry that needs one (e.g.
+  `number`).
+- Each case carries a human-readable `note` naming the spec rule it
+  pins.
+
+### Regenerating
+
+```sh
+cd packages/adapter-tests && bun run generate:helper-vectors
+```
+
+A freshness test (`src/__tests__/helper-vectors.test.ts`, run by
+`ci.yml`'s `bun test packages/adapter-tests`) fails when
+`vectors.json` is out of date with `cases.ts`.
+
+### Harnesses
+
+| Backend | Harness | CI |
+|---------|---------|----|
+| JS (reference) | `helper-vectors/generate.ts` computes `expect` by executing the reference | `ci.yml` (freshness test) |
+| Go `html/template` | `packages/adapter-go-template/runtime/vectors_test.go` | `ci-go-template.yml` (`go test`) |
+| Perl (Mojolicious / Xslate) | `packages/adapter-perl/t/helper_vectors.t` | `ci-perl-dist.yml` (`make test`) |
+
+Harnesses **fail loudly on an unknown `fn`** — adding a case for a
+helper without binding it in every harness is a CI failure, so the
+backends cannot silently fall behind the catalogue. The Go and Perl
+harnesses skip when `vectors.json` is absent (published Go module /
+CPAN dist consumers don't receive the monorepo file).
+
+Each harness binds a canonical id to **the exact code shape the
+compiled templates execute**: where an adapter lowers an operation to
+a native host operator instead of a helper function (see the lowering
+tables below), the harness binds the native operator, so the vectors
+test what production templates actually run.
+
+## Adding a catalogue entry
+
+1. Add the entry to the catalogue below: semantics, lowering per
+   adapter, edge-case rules, documented divergences.
+2. Add the JS reference implementation and cases to
+   `helper-vectors/cases.ts` — cover each edge-case rule with at least
+   one vector.
+3. Regenerate `vectors.json`.
+4. Bind the id in `vectors_test.go` (Go) and `helper_vectors.t`
+   (Perl). Run both harnesses; fix implementations (or document a
+   divergence and drop the case) until green.
+
+## Catalogue
+
+### add
+
+JS numeric addition: `a + b`.
+
+| Backend | Lowering |
+|---------|----------|
+| Hono / CSR | native JS `+` |
+| Go template | `{{bf_add a b}}` → `bf.Add` |
+| Mojolicious / Xslate | native Perl `+` |
+
+Rules:
+
+- Operands are **numbers**. String-operand `+` (JS concatenation) is
+  not part of this entry; template-side string building is lowered
+  through interpolation, and feeding strings to `add` is
+  adapter-defined.
+- IEEE-754 double semantics for the result value (see contract above).
+- Go's int-preserving return (`Add(1, 2)` → `int 3`) is value-equal
+  and allowed under value-compat; the round-trip through `float64`
+  keeps it within double semantics.


### PR DESCRIPTION
## Summary

Per-backend helper implementations (`bf_add` in Go's `runtime/bf.go`, native operators / `BarefootJS.pm` methods on the Perl side) duplicate JS semantics with no shared, mechanical parity check. Instead of an FFI-based shared implementation (rejected for marshaling cost, cgo/XS distribution burden, and the host-coupled half of the helper surface — see discussion), this PR establishes a **spec + golden-vector conformance pipeline**, proven end to end with `add` only. Further catalogue entries follow in subsequent PRs.

## What's in the pipeline

- **`spec/template-helpers.md`** — language-independent catalogue of the pure value helpers: value-compat (not type-compat) contract, IEEE-754 double semantics, safe-integer domain (with the documented Perl IV vs JS double divergence outside ±2^53), vector format, and the workflow for adding entries.
- **`packages/adapter-tests/helper-vectors/`** — `cases.ts` defines cases against a **JS reference implementation that is executed to compute the expected values** (JS parity is mechanical, never hand-transcribed); `generate.ts` writes the committed `vectors.json` (`bun run generate:helper-vectors`).
- **Freshness guard** — `src/__tests__/helper-vectors.test.ts` (runs in `ci.yml`'s adapter-tests suite) fails when `vectors.json` drifts from `cases.ts`.
- **Go harness** — `runtime/vectors_test.go` binds canonical ids to the helpers compiled templates call (`add` → `bf.Add`), compares values numerically, and fails loudly on an unbound id. `ci-go-template.yml` gains a `go test ./...` step (the runtime's Go unit tests were previously not run in CI; the full suite passes).
- **Perl harness** — `t/helper_vectors.t` binds ids to the exact lowering the Perl backends execute (the Mojolicious adapter lowers JSX `+` to native Perl `+`, so that's what's bound), runs under `make test` in `ci-perl-dist.yml`, and skips outside the monorepo so CPAN dist consumers aren't affected. Added to `MANIFEST`.

## Verification

- `bun test packages/adapter-tests/src/__tests__/helper-vectors.test.ts` — 2 pass
- `go test ./...` in `packages/adapter-go-template/runtime` — all pass incl. 8 vector subtests
- `perl t/helper_vectors.t` in `packages/adapter-perl` — 8/8 ok
- `bunx biome check` clean on the new TS files

## Next steps

Grow the catalogue per the workflow in the spec (sub/mul/div, string ops, array ops …), adding the sentinel encoding for NaN/±Infinity together with the first entry that needs it (`number`).

https://claude.ai/code/session_01VcfG8tUF8e5mRpccw38xZq

---
_Generated by [Claude Code](https://claude.ai/code/session_01VcfG8tUF8e5mRpccw38xZq)_