### PR TITLE
Helper catalogue: arithmetic (sub/mul/div/mod/neg)

### DIFF
--- a/packages/adapter-go-template/runtime/vectors_test.go
+++ b/packages/adapter-go-template/runtime/vectors_test.go
@@ -34,6 +34,11 @@ type vectorFile struct {
 // is not allowed to silently fall behind the catalogue.
 var vectorBindings = map[string]func(args []any) any{
 	"add": func(args []any) any { return Add(args[0], args[1]) },
+	"sub": func(args []any) any { return Sub(args[0], args[1]) },
+	"mul": func(args []any) any { return Mul(args[0], args[1]) },
+	"div": func(args []any) any { return Div(args[0], args[1]) },
+	"mod": func(args []any) any { return Mod(args[0], args[1]) },
+	"neg": func(args []any) any { return Neg(args[0]) },
 }
 
 func TestHelperVectors(t *testing.T) {

--- a/packages/adapter-perl/t/helper_vectors.t
+++ b/packages/adapter-perl/t/helper_vectors.t
@@ -31,6 +31,11 @@ my $doc = do {
 # not silently fall behind the catalogue.
 my %bindings = (
     add => sub { $_[0] + $_[1] },
+    sub => sub { $_[0] - $_[1] },
+    mul => sub { $_[0] * $_[1] },
+    div => sub { $_[0] / $_[1] },
+    mod => sub { $_[0] % $_[1] },
+    neg => sub { -$_[0] },
 );
 
 for my $case (@{ $doc->{cases} }) {

--- a/packages/adapter-tests/helper-vectors/cases.ts
+++ b/packages/adapter-tests/helper-vectors/cases.ts
@@ -25,6 +25,11 @@ export interface HelperCase {
  */
 export const reference: Record<string, (...args: never[]) => unknown> = {
   add: (a: number, b: number) => a + b,
+  sub: (a: number, b: number) => a - b,
+  mul: (a: number, b: number) => a * b,
+  div: (a: number, b: number) => a / b,
+  mod: (a: number, b: number) => a % b,
+  neg: (a: number) => -a,
 }
 
 export const cases: HelperCase[] = [
@@ -36,4 +41,33 @@ export const cases: HelperCase[] = [
   { fn: 'add', args: [0.1, 0.2], note: 'IEEE-754 double rounding' },
   { fn: 'add', args: [-1.5, -2.25], note: 'negative floats' },
   { fn: 'add', args: [9007199254740991, 1], note: 'upper edge of the safe-integer domain (2^53)' },
+
+  { fn: 'sub', args: [5, 3], note: 'int - int' },
+  { fn: 'sub', args: [3, 5], note: 'negative result' },
+  { fn: 'sub', args: [0.3, 0.1], note: 'IEEE-754 double rounding' },
+  { fn: 'sub', args: [1.5, 0.25], note: 'float operands' },
+  { fn: 'sub', args: [0, 0], note: 'zero identity' },
+
+  { fn: 'mul', args: [3, 4], note: 'int * int' },
+  { fn: 'mul', args: [-3, 4], note: 'negative operand' },
+  { fn: 'mul', args: [0.1, 0.2], note: 'IEEE-754 double rounding' },
+  { fn: 'mul', args: [1.5, 2], note: 'float * int with integral result value' },
+  { fn: 'mul', args: [0, 5], note: 'zero annihilator' },
+
+  { fn: 'div', args: [7, 2], note: 'integer operands divide as doubles (3.5)' },
+  { fn: 'div', args: [10, 5], note: 'exact integer quotient' },
+  { fn: 'div', args: [1, 3], note: 'repeating fraction at double precision' },
+  { fn: 'div', args: [-9, 3], note: 'negative dividend' },
+  { fn: 'div', args: [0.3, 0.1], note: 'IEEE-754 double rounding (not exactly 3)' },
+  { fn: 'div', args: [0, 7], note: 'zero dividend' },
+
+  { fn: 'mod', args: [7, 3], note: 'basic remainder' },
+  { fn: 'mod', args: [10, 5], note: 'zero remainder' },
+  { fn: 'mod', args: [9, 4], note: 'remainder of one' },
+  { fn: 'mod', args: [0, 3], note: 'zero dividend' },
+
+  { fn: 'neg', args: [5], note: 'positive int' },
+  { fn: 'neg', args: [-3], note: 'negative int negates back' },
+  { fn: 'neg', args: [1.5], note: 'float' },
+  { fn: 'neg', args: [0], note: 'zero (sign of float zero not observable in JSON)' },
 ]

--- a/packages/adapter-tests/helper-vectors/vectors.json
+++ b/packages/adapter-tests/helper-vectors/vectors.json
@@ -74,6 +74,218 @@
       ],
       "expect": 9007199254740992,
       "note": "upper edge of the safe-integer domain (2^53)"
+    },
+    {
+      "fn": "sub",
+      "args": [
+        5,
+        3
+      ],
+      "expect": 2,
+      "note": "int - int"
+    },
+    {
+      "fn": "sub",
+      "args": [
+        3,
+        5
+      ],
+      "expect": -2,
+      "note": "negative result"
+    },
+    {
+      "fn": "sub",
+      "args": [
+        0.3,
+        0.1
+      ],
+      "expect": 0.19999999999999998,
+      "note": "IEEE-754 double rounding"
+    },
+    {
+      "fn": "sub",
+      "args": [
+        1.5,
+        0.25
+      ],
+      "expect": 1.25,
+      "note": "float operands"
+    },
+    {
+      "fn": "sub",
+      "args": [
+        0,
+        0
+      ],
+      "expect": 0,
+      "note": "zero identity"
+    },
+    {
+      "fn": "mul",
+      "args": [
+        3,
+        4
+      ],
+      "expect": 12,
+      "note": "int * int"
+    },
+    {
+      "fn": "mul",
+      "args": [
+        -3,
+        4
+      ],
+      "expect": -12,
+      "note": "negative operand"
+    },
+    {
+      "fn": "mul",
+      "args": [
+        0.1,
+        0.2
+      ],
+      "expect": 0.020000000000000004,
+      "note": "IEEE-754 double rounding"
+    },
+    {
+      "fn": "mul",
+      "args": [
+        1.5,
+        2
+      ],
+      "expect": 3,
+      "note": "float * int with integral result value"
+    },
+    {
+      "fn": "mul",
+      "args": [
+        0,
+        5
+      ],
+      "expect": 0,
+      "note": "zero annihilator"
+    },
+    {
+      "fn": "div",
+      "args": [
+        7,
+        2
+      ],
+      "expect": 3.5,
+      "note": "integer operands divide as doubles (3.5)"
+    },
+    {
+      "fn": "div",
+      "args": [
+        10,
+        5
+      ],
+      "expect": 2,
+      "note": "exact integer quotient"
+    },
+    {
+      "fn": "div",
+      "args": [
+        1,
+        3
+      ],
+      "expect": 0.3333333333333333,
+      "note": "repeating fraction at double precision"
+    },
+    {
+      "fn": "div",
+      "args": [
+        -9,
+        3
+      ],
+      "expect": -3,
+      "note": "negative dividend"
+    },
+    {
+      "fn": "div",
+      "args": [
+        0.3,
+        0.1
+      ],
+      "expect": 2.9999999999999996,
+      "note": "IEEE-754 double rounding (not exactly 3)"
+    },
+    {
+      "fn": "div",
+      "args": [
+        0,
+        7
+      ],
+      "expect": 0,
+      "note": "zero dividend"
+    },
+    {
+      "fn": "mod",
+      "args": [
+        7,
+        3
+      ],
+      "expect": 1,
+      "note": "basic remainder"
+    },
+    {
+      "fn": "mod",
+      "args": [
+        10,
+        5
+      ],
+      "expect": 0,
+      "note": "zero remainder"
+    },
+    {
+      "fn": "mod",
+      "args": [
+        9,
+        4
+      ],
+      "expect": 1,
+      "note": "remainder of one"
+    },
+    {
+      "fn": "mod",
+      "args": [
+        0,
+        3
+      ],
+      "expect": 0,
+      "note": "zero dividend"
+    },
+    {
+      "fn": "neg",
+      "args": [
+        5
+      ],
+      "expect": -5,
+      "note": "positive int"
+    },
+    {
+      "fn": "neg",
+      "args": [
+        -3
+      ],
+      "expect": 3,
+      "note": "negative int negates back"
+    },
+    {
+      "fn": "neg",
+      "args": [
+        1.5
+      ],
+      "expect": -1.5,
+      "note": "float"
+    },
+    {
+      "fn": "neg",
+      "args": [
+        0
+      ],
+      "expect": 0,
+      "note": "zero (sign of float zero not observable in JSON)"
     }
   ]
 }

--- a/spec/template-helpers.md
+++ b/spec/template-helpers.md
@@ -142,3 +142,75 @@ Rules:
 - Go's int-preserving return (`Add(1, 2)` → `int 3`) is value-equal
   and allowed under value-compat; the round-trip through `float64`
   keeps it within double semantics.
+
+### sub / mul
+
+JS numeric subtraction / multiplication: `a - b`, `a * b`.
+
+| Backend | Lowering |
+|---------|----------|
+| Hono / CSR | native JS `-` / `*` |
+| Go template | `bf_sub` / `bf_mul` → `bf.Sub` / `bf.Mul` |
+| Mojolicious / Xslate | native Perl `-` / `*` |
+
+Same rules as `add`: numeric operands, double semantics (including
+rounding artifacts like `0.3 - 0.1` → `0.19999999999999998`),
+int-preserving Go returns allowed under value-compat.
+
+### div
+
+JS numeric division: `a / b`. Always double division — `7 / 2` is
+`3.5` even for integer operands.
+
+| Backend | Lowering |
+|---------|----------|
+| Hono / CSR | native JS `/` |
+| Go template | `bf_div` → `bf.Div` |
+| Mojolicious / Xslate | native Perl `/` |
+
+Rules:
+
+- Domain: **divisor ≠ 0**. JS yields `±Infinity` / `NaN` for a zero
+  divisor; Go's `bf.Div` deliberately returns `0` so a template render
+  degrades instead of emitting `+Inf`, and Perl `/` dies. Zero-divisor
+  behavior is adapter-defined, documented here, and excluded from the
+  vectors.
+- Double semantics for the quotient (`1 / 3` →
+  `0.3333333333333333`).
+
+### mod
+
+JS remainder: `a % b`.
+
+| Backend | Lowering |
+|---------|----------|
+| Hono / CSR | native JS `%` |
+| Go template | `bf_mod` → `bf.Mod` |
+| Mojolicious / Xslate | native Perl `%` |
+
+Rules:
+
+- Domain: **non-negative integer operands with divisor > 0**. Outside
+  that the backends genuinely disagree and behavior is
+  adapter-defined:
+  - Negative operands: JS remainder takes the **dividend's** sign
+    (`-7 % 3` → `-1`); Perl's `%` takes the **divisor's** sign
+    (`-7 % 3` → `2`); Go's `%` matches JS.
+  - Float operands: JS `%` is a float remainder (`7.5 % 2` → `1.5`);
+    Go `bf.Mod` and Perl integer-context `%` truncate to integers.
+  - Zero divisor: JS yields `NaN`; Go returns `0`; Perl dies.
+- Within the domain, the result is the common integer remainder.
+
+### neg
+
+JS unary minus: `-a`.
+
+| Backend | Lowering |
+|---------|----------|
+| Hono / CSR | native JS unary `-` |
+| Go template | `bf_neg` → `bf.Neg` |
+| Mojolicious / Xslate | native Perl unary `-` |
+
+Numeric operand, double semantics. (`-0` is value-equal to `0` under
+the vectors' numeric comparison; JSON cannot carry the sign of a
+floating-point zero.)


### PR DESCRIPTION
**Stacked on #1884** (golden-vector pipeline). Second PR in the stack growing the catalogue per the workflow in `spec/template-helpers.md`.

Adds the remaining arithmetic lowerings to the catalogue with 24 new vectors (32 total), all green on the three harnesses (bun freshness / `go test` / `perl t/helper_vectors.t`).

Spec entries document the adapter-defined edges that are excluded from the vector domain rather than papered over:

- **div**: zero divisor — JS `±Infinity`/`NaN`, Go `bf.Div` degrades to `0`, Perl dies.
- **mod**: domain restricted to non-negative integers with positive divisor — JS `%` is a dividend-sign float remainder, Perl `%` is a divisor-sign integer modulo (`-7 % 3`: JS `-1`, Perl `2`), Go matches JS.
- **neg**: `-0` is value-equal to `0` under the numeric comparison (JSON can't carry float-zero sign).

https://claude.ai/code/session_01VcfG8tUF8e5mRpccw38xZq

---
_Generated by [Claude Code](https://claude.ai/code/session_01VcfG8tUF8e5mRpccw38xZq)_