### PR TITLE
Helper catalogue: coercion (string/json/number/floor/ceil/round) + NaN sentinel

### DIFF
--- a/packages/adapter-go-template/runtime/vectors_test.go
+++ b/packages/adapter-go-template/runtime/vectors_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -39,6 +40,20 @@ var vectorBindings = map[string]func(args []any) any{
 	"div": func(args []any) any { return Div(args[0], args[1]) },
 	"mod": func(args []any) any { return Mod(args[0], args[1]) },
 	"neg": func(args []any) any { return Neg(args[0]) },
+	"string": func(args []any) any { return String(args[0]) },
+	"json": func(args []any) any {
+		s, err := JSON(args[0])
+		if err != nil {
+			// Surface the error as the compared value so the mismatch
+			// message shows what went wrong.
+			return err
+		}
+		return s
+	},
+	"number": func(args []any) any { return Number(args[0]) },
+	"floor":  func(args []any) any { return Floor(args[0]) },
+	"ceil":   func(args []any) any { return Ceil(args[0]) },
+	"round":  func(args []any) any { return Round(args[0]) },
 }
 
 func TestHelperVectors(t *testing.T) {
@@ -122,6 +137,20 @@ func normalizeVectorValue(v any) any {
 		}
 		return x
 	case map[string]any:
+		// Reserved non-finite sentinel (spec/template-helpers.md):
+		// {"$num": "NaN" | "Infinity" | "-Infinity"}.
+		if len(x) == 1 {
+			if s, ok := x["$num"].(string); ok {
+				switch s {
+				case "NaN":
+					return math.NaN()
+				case "Infinity":
+					return math.Inf(1)
+				case "-Infinity":
+					return math.Inf(-1)
+				}
+			}
+		}
 		for k := range x {
 			x[k] = normalizeVectorValue(x[k])
 		}
@@ -138,7 +167,14 @@ func vectorEqual(got, expect any) bool {
 		return got == nil
 	}
 	if isNumericValue(expect) {
-		return isNumericValue(got) && toFloat64(got) == toFloat64(expect)
+		if !isNumericValue(got) {
+			return false
+		}
+		ef, gf := toFloat64(expect), toFloat64(got)
+		if math.IsNaN(ef) {
+			return math.IsNaN(gf)
+		}
+		return gf == ef
 	}
 	switch e := expect.(type) {
 	case string:

--- a/packages/adapter-perl/t/helper_vectors.t
+++ b/packages/adapter-perl/t/helper_vectors.t
@@ -6,6 +6,24 @@ use File::Spec;
 use JSON::PP ();
 use Scalar::Util qw(looks_like_number);
 
+use lib "$FindBin::Bin/../lib";
+use BarefootJS;
+
+# Pure-Perl backend (core JSON::PP only) so this test runs with zero
+# Mojo present — same pattern as t/template_primitives.t.
+{
+    package PureBackend;
+    use JSON::PP ();
+    my $J = JSON::PP->new->canonical->allow_nonref;
+    sub new          { bless {}, shift }
+    sub encode_json  { $J->encode($_[1]) }
+    sub mark_raw     { $_[1] }
+    sub materialize  { ref($_[1]) eq 'CODE' ? $_[1]->() : $_[1] }
+    sub render_named { '' }
+}
+
+my $bf = bless { c => undef, config => {}, backend => PureBackend->new }, 'BarefootJS';
+
 # Golden helper vectors generated from the JS reference implementations
 # (spec/template-helpers.md in the monorepo). The file is not shipped in
 # the CPAN dist — packages/adapter-tests only exists in a monorepo
@@ -36,6 +54,13 @@ my %bindings = (
     div => sub { $_[0] / $_[1] },
     mod => sub { $_[0] % $_[1] },
     neg => sub { -$_[0] },
+
+    string => sub { $bf->string($_[0]) },
+    json   => sub { $bf->json($_[0]) },
+    number => sub { $bf->number($_[0]) },
+    floor  => sub { $bf->floor($_[0]) },
+    ceil   => sub { $bf->ceil($_[0]) },
+    round  => sub { $bf->round($_[0]) },
 );
 
 for my $case (@{ $doc->{cases} }) {
@@ -45,7 +70,8 @@ for my $case (@{ $doc->{cases} }) {
         fail("no Perl binding for helper '$fn' — add it to %bindings in $0");
         next;
     }
-    vector_ok($bind->(@{ $case->{args} }), $case->{expect}, "$fn: $note");
+    my @args = map { normalize_arg($_) } @{ $case->{args} };
+    vector_ok($bind->(@args), $case->{expect}, "$fn: $note");
 }
 
 done_testing;
@@ -55,10 +81,30 @@ done_testing;
 # by truthiness, everything else structurally. Arrays currently go
 # through is_deeply (string compare per element) — refine to a
 # recursive numeric walk when the first float-array vector lands.
+# Production Perl template data has no boolean type — the adapters pass
+# 1/0 where JS has true/false — so JSON::PP boolean objects in vector
+# ARGS are lowered to 1/0 before reaching a binding. Expects keep their
+# boolean identity (vector_ok compares those by truthiness).
+sub normalize_arg {
+    my ($v) = @_;
+    return [ map { normalize_arg($_) } @$v ] if ref $v eq 'ARRAY';
+    return { map { $_ => normalize_arg($v->{$_}) } keys %$v } if ref $v eq 'HASH';
+    return JSON::PP::is_bool($v) ? ($v ? 1 : 0) : $v;
+}
+
 sub vector_ok {
     my ($got, $expect, $label) = @_;
     if (!defined $expect) {
         return is($got, undef, $label);
+    }
+    # Reserved non-finite sentinel (spec/template-helpers.md):
+    # {"$num": "NaN" | "Infinity" | "-Infinity"}. NaN is the only value
+    # for which `$x != $x` holds.
+    if (ref $expect eq 'HASH' && exists $expect->{'$num'}) {
+        my $kind = $expect->{'$num'};
+        return ok($got != $got, "$label (NaN)") if $kind eq 'NaN';
+        my $inf = 9**9**9;
+        return cmp_ok($got, '==', $kind eq 'Infinity' ? $inf : -$inf, $label);
     }
     if (JSON::PP::is_bool($expect)) {
         return is(!!$got, !!$expect, $label);

--- a/packages/adapter-tests/helper-vectors/cases.ts
+++ b/packages/adapter-tests/helper-vectors/cases.ts
@@ -30,6 +30,12 @@ export const reference: Record<string, (...args: never[]) => unknown> = {
   div: (a: number, b: number) => a / b,
   mod: (a: number, b: number) => a % b,
   neg: (a: number) => -a,
+  string: (v: unknown) => String(v),
+  json: (v: unknown) => JSON.stringify(v),
+  number: (v: unknown) => Number(v),
+  floor: (v: unknown) => Math.floor(Number(v)),
+  ceil: (v: unknown) => Math.ceil(Number(v)),
+  round: (v: unknown) => Math.round(Number(v)),
 }
 
 export const cases: HelperCase[] = [
@@ -70,4 +76,46 @@ export const cases: HelperCase[] = [
   { fn: 'neg', args: [-3], note: 'negative int negates back' },
   { fn: 'neg', args: [1.5], note: 'float' },
   { fn: 'neg', args: [0], note: 'zero (sign of float zero not observable in JSON)' },
+
+  { fn: 'string', args: [42], note: 'integer' },
+  { fn: 'string', args: [3.14], note: 'float within 15 significant digits' },
+  { fn: 'string', args: [-7], note: 'negative integer' },
+  { fn: 'string', args: ['hi'], note: 'string passthrough' },
+  { fn: 'string', args: [''], note: 'empty string passthrough' },
+  { fn: 'string', args: [0.5], note: 'fraction below one' },
+
+  { fn: 'json', args: [42], note: 'top-level number' },
+  { fn: 'json', args: ['hi'], note: 'top-level string is quoted' },
+  { fn: 'json', args: [null], note: 'null serializes as "null"' },
+  { fn: 'json', args: [[1, 2, 3]], note: 'array of ints' },
+  { fn: 'json', args: [[1.5, 'x']], note: 'mixed array' },
+  { fn: 'json', args: [{ a: 1 }], note: 'single-key object' },
+  { fn: 'json', args: [{ a: 1, b: 'two' }], note: 'object with alphabetical insertion order' },
+  { fn: 'json', args: [{ a: [1, { b: 'x' }] }], note: 'nested array/object' },
+
+  { fn: 'number', args: [42], note: 'integer passthrough' },
+  { fn: 'number', args: [3.14], note: 'float passthrough' },
+  { fn: 'number', args: ['3.14'], note: 'numeric string' },
+  { fn: 'number', args: ['42'], note: 'integer string' },
+  { fn: 'number', args: ['1e3'], note: 'exponent notation string' },
+  { fn: 'number', args: ['-0.5'], note: 'negative fraction string' },
+  { fn: 'number', args: [true], note: 'true coerces to 1' },
+  { fn: 'number', args: [false], note: 'false coerces to 0' },
+  { fn: 'number', args: ['not a num'], note: 'non-numeric string is NaN (sentinel)' },
+  { fn: 'number', args: ['NaN'], note: 'the literal string "NaN" parses to NaN on all backends' },
+
+  { fn: 'floor', args: [3.7], note: 'positive truncation' },
+  { fn: 'floor', args: [-3.7], note: 'negative rounds away from zero' },
+  { fn: 'floor', args: [5], note: 'integral passthrough' },
+  { fn: 'floor', args: ['2.9'], note: 'numeric-string operand routes through number coercion' },
+
+  { fn: 'ceil', args: [3.2], note: 'positive rounds up' },
+  { fn: 'ceil', args: [-3.2], note: 'negative rounds toward zero' },
+  { fn: 'ceil', args: [5], note: 'integral passthrough' },
+
+  { fn: 'round', args: [2.5], note: 'positive half rounds up on all backends' },
+  { fn: 'round', args: [2.4], note: 'below half rounds down' },
+  { fn: 'round', args: [-2.4], note: 'negative below half rounds toward zero' },
+  { fn: 'round', args: [7], note: 'integral passthrough' },
+  { fn: 'round', args: ['6.6'], note: 'numeric-string operand routes through number coercion' },
 ]

--- a/packages/adapter-tests/helper-vectors/generate.ts
+++ b/packages/adapter-tests/helper-vectors/generate.ts
@@ -26,10 +26,11 @@ export interface VectorFile {
 
 /**
  * Vectors are plain JSON: finite numbers, strings, booleans, null, and
- * arrays/objects thereof. NaN / ±Infinity / undefined have no JSON
- * encoding — per the spec, a sentinel scheme lands together with the
- * first catalogue entry that needs one, so until then refuse loudly
- * instead of letting JSON.stringify silently emit `null`.
+ * arrays/objects thereof. Per the spec, a non-finite number in an
+ * EXPECT value is encoded as the reserved sentinel
+ * `{"$num": "NaN" | "Infinity" | "-Infinity"}`; `undefined` is never
+ * encodable. Args must stay finite (refused loudly) until a
+ * composition case needs otherwise.
  */
 function assertEncodable(value: unknown, context: string): void {
   if (value === undefined) throw new Error(`${context}: undefined is not encodable in vectors.json`)
@@ -43,6 +44,23 @@ function assertEncodable(value: unknown, context: string): void {
   }
 }
 
+function encodeExpect(value: unknown, context: string): unknown {
+  if (value === undefined) throw new Error(`${context}: undefined is not encodable in vectors.json`)
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    return { $num: Number.isNaN(value) ? 'NaN' : value > 0 ? 'Infinity' : '-Infinity' }
+  }
+  if (Array.isArray(value)) {
+    return value.map((v, i) => encodeExpect(v, `${context}[${i}]`))
+  }
+  if (value !== null && typeof value === 'object') {
+    if ('$num' in value) throw new Error(`${context}: the "$num" key is reserved for the sentinel`)
+    return Object.fromEntries(
+      Object.entries(value).map(([k, v]) => [k, encodeExpect(v, `${context}.${k}`)]),
+    )
+  }
+  return value
+}
+
 export function buildVectors(): VectorFile {
   return {
     version: 1,
@@ -53,8 +71,10 @@ export function buildVectors(): VectorFile {
       if (!ref) throw new Error(`no JS reference implementation for helper "${c.fn}" in cases.ts`)
       const context = `${c.fn}(${JSON.stringify(c.args)})`
       assertEncodable(c.args, context)
-      const expect = (ref as (...args: unknown[]) => unknown)(...c.args)
-      assertEncodable(expect, `${context} → expect`)
+      const expect = encodeExpect(
+        (ref as (...args: unknown[]) => unknown)(...c.args),
+        `${context} → expect`,
+      )
       return { fn: c.fn, args: c.args, expect, note: c.note }
     }),
   }

--- a/packages/adapter-tests/helper-vectors/vectors.json
+++ b/packages/adapter-tests/helper-vectors/vectors.json
@@ -286,6 +286,317 @@
       ],
       "expect": 0,
       "note": "zero (sign of float zero not observable in JSON)"
+    },
+    {
+      "fn": "string",
+      "args": [
+        42
+      ],
+      "expect": "42",
+      "note": "integer"
+    },
+    {
+      "fn": "string",
+      "args": [
+        3.14
+      ],
+      "expect": "3.14",
+      "note": "float within 15 significant digits"
+    },
+    {
+      "fn": "string",
+      "args": [
+        -7
+      ],
+      "expect": "-7",
+      "note": "negative integer"
+    },
+    {
+      "fn": "string",
+      "args": [
+        "hi"
+      ],
+      "expect": "hi",
+      "note": "string passthrough"
+    },
+    {
+      "fn": "string",
+      "args": [
+        ""
+      ],
+      "expect": "",
+      "note": "empty string passthrough"
+    },
+    {
+      "fn": "string",
+      "args": [
+        0.5
+      ],
+      "expect": "0.5",
+      "note": "fraction below one"
+    },
+    {
+      "fn": "json",
+      "args": [
+        42
+      ],
+      "expect": "42",
+      "note": "top-level number"
+    },
+    {
+      "fn": "json",
+      "args": [
+        "hi"
+      ],
+      "expect": "\"hi\"",
+      "note": "top-level string is quoted"
+    },
+    {
+      "fn": "json",
+      "args": [
+        null
+      ],
+      "expect": "null",
+      "note": "null serializes as \"null\""
+    },
+    {
+      "fn": "json",
+      "args": [
+        [
+          1,
+          2,
+          3
+        ]
+      ],
+      "expect": "[1,2,3]",
+      "note": "array of ints"
+    },
+    {
+      "fn": "json",
+      "args": [
+        [
+          1.5,
+          "x"
+        ]
+      ],
+      "expect": "[1.5,\"x\"]",
+      "note": "mixed array"
+    },
+    {
+      "fn": "json",
+      "args": [
+        {
+          "a": 1
+        }
+      ],
+      "expect": "{\"a\":1}",
+      "note": "single-key object"
+    },
+    {
+      "fn": "json",
+      "args": [
+        {
+          "a": 1,
+          "b": "two"
+        }
+      ],
+      "expect": "{\"a\":1,\"b\":\"two\"}",
+      "note": "object with alphabetical insertion order"
+    },
+    {
+      "fn": "json",
+      "args": [
+        {
+          "a": [
+            1,
+            {
+              "b": "x"
+            }
+          ]
+        }
+      ],
+      "expect": "{\"a\":[1,{\"b\":\"x\"}]}",
+      "note": "nested array/object"
+    },
+    {
+      "fn": "number",
+      "args": [
+        42
+      ],
+      "expect": 42,
+      "note": "integer passthrough"
+    },
+    {
+      "fn": "number",
+      "args": [
+        3.14
+      ],
+      "expect": 3.14,
+      "note": "float passthrough"
+    },
+    {
+      "fn": "number",
+      "args": [
+        "3.14"
+      ],
+      "expect": 3.14,
+      "note": "numeric string"
+    },
+    {
+      "fn": "number",
+      "args": [
+        "42"
+      ],
+      "expect": 42,
+      "note": "integer string"
+    },
+    {
+      "fn": "number",
+      "args": [
+        "1e3"
+      ],
+      "expect": 1000,
+      "note": "exponent notation string"
+    },
+    {
+      "fn": "number",
+      "args": [
+        "-0.5"
+      ],
+      "expect": -0.5,
+      "note": "negative fraction string"
+    },
+    {
+      "fn": "number",
+      "args": [
+        true
+      ],
+      "expect": 1,
+      "note": "true coerces to 1"
+    },
+    {
+      "fn": "number",
+      "args": [
+        false
+      ],
+      "expect": 0,
+      "note": "false coerces to 0"
+    },
+    {
+      "fn": "number",
+      "args": [
+        "not a num"
+      ],
+      "expect": {
+        "$num": "NaN"
+      },
+      "note": "non-numeric string is NaN (sentinel)"
+    },
+    {
+      "fn": "number",
+      "args": [
+        "NaN"
+      ],
+      "expect": {
+        "$num": "NaN"
+      },
+      "note": "the literal string \"NaN\" parses to NaN on all backends"
+    },
+    {
+      "fn": "floor",
+      "args": [
+        3.7
+      ],
+      "expect": 3,
+      "note": "positive truncation"
+    },
+    {
+      "fn": "floor",
+      "args": [
+        -3.7
+      ],
+      "expect": -4,
+      "note": "negative rounds away from zero"
+    },
+    {
+      "fn": "floor",
+      "args": [
+        5
+      ],
+      "expect": 5,
+      "note": "integral passthrough"
+    },
+    {
+      "fn": "floor",
+      "args": [
+        "2.9"
+      ],
+      "expect": 2,
+      "note": "numeric-string operand routes through number coercion"
+    },
+    {
+      "fn": "ceil",
+      "args": [
+        3.2
+      ],
+      "expect": 4,
+      "note": "positive rounds up"
+    },
+    {
+      "fn": "ceil",
+      "args": [
+        -3.2
+      ],
+      "expect": -3,
+      "note": "negative rounds toward zero"
+    },
+    {
+      "fn": "ceil",
+      "args": [
+        5
+      ],
+      "expect": 5,
+      "note": "integral passthrough"
+    },
+    {
+      "fn": "round",
+      "args": [
+        2.5
+      ],
+      "expect": 3,
+      "note": "positive half rounds up on all backends"
+    },
+    {
+      "fn": "round",
+      "args": [
+        2.4
+      ],
+      "expect": 2,
+      "note": "below half rounds down"
+    },
+    {
+      "fn": "round",
+      "args": [
+        -2.4
+      ],
+      "expect": -2,
+      "note": "negative below half rounds toward zero"
+    },
+    {
+      "fn": "round",
+      "args": [
+        7
+      ],
+      "expect": 7,
+      "note": "integral passthrough"
+    },
+    {
+      "fn": "round",
+      "args": [
+        "6.6"
+      ],
+      "expect": 7,
+      "note": "numeric-string operand routes through number coercion"
     }
   ]
 }

--- a/spec/template-helpers.md
+++ b/spec/template-helpers.md
@@ -70,11 +70,13 @@ committed, and consumed by one thin harness per backend.
 - `fn` is the **canonical helper id** from this catalogue (no `bf_`
   prefix, no host-language casing).
 - `args` / `expect` are plain JSON values: finite numbers, strings,
-  booleans, `null`, and arrays/objects thereof. `NaN`, `±Infinity`,
-  and `undefined` are not representable in JSON; the generator
-  **refuses** cases producing them. A sentinel encoding will be added
-  together with the first catalogue entry that needs one (e.g.
-  `number`).
+  booleans, `null`, and arrays/objects thereof.
+- **Non-finite sentinel**: a non-finite number in `expect` is encoded
+  as `{"$num": "NaN" | "Infinity" | "-Infinity"}` (the `$num` key is
+  reserved; helper data must not use it). Arguments must stay finite —
+  the generator refuses non-finite `args`; composition cases (e.g.
+  `floor(number("x"))`) can lift that later if needed. `undefined` is
+  never representable.
 - Each case carries a human-readable `note` naming the spec rule it
   pins.
 
@@ -214,3 +216,97 @@ JS unary minus: `-a`.
 Numeric operand, double semantics. (`-0` is value-equal to `0` under
 the vectors' numeric comparison; JSON cannot carry the sign of a
 floating-point zero.)
+
+### string
+
+JS `String(v)`.
+
+| Backend | Lowering |
+|---------|----------|
+| Hono / CSR | native `String(v)` |
+| Go template | `bf_string` → `bf.String` |
+| Mojolicious / Xslate | `bf->string` |
+
+Rules:
+
+- Numbers stringify in shortest round-trip form (`String(3.14)` →
+  `"3.14"`); Go's `%v` matches JS. **Documented divergence**: Perl
+  stringifies via `%.15g`, so doubles needing 16–17 significant
+  digits differ (`String(0.1 + 0.2)`: JS `"0.30000000000000004"`,
+  Perl `"0.3"`). Vectors stay within 15 significant digits.
+- **Documented divergence**: `null`/`undefined` render as `""` on the
+  template backends (deliberate SSR ergonomics — an unset prop must
+  not surface as literal `"null"`/`"undefined"`), while JS
+  `String(null)` is `"null"`. Excluded from vectors.
+- **Documented divergence**: booleans — JS `String(true)` is
+  `"true"`; Perl has no boolean type (template data carries `1`/`0`),
+  so the Perl backends render `"1"`/`""`. Excluded from vectors.
+
+### json
+
+JS `JSON.stringify(v)` (single-argument form; no `replacer`/`space`).
+
+| Backend | Lowering |
+|---------|----------|
+| Hono / CSR | native `JSON.stringify` |
+| Go template | `bf_json` → `bf.JSON` |
+| Mojolicious / Xslate | `bf->json` (backend JSON encoder) |
+
+Rules:
+
+- Value-compat, **not order-compat** (#1187): object key order is
+  backend-defined (Go maps and JSON::PP-canonical sort
+  alphabetically; JS preserves insertion order). Vectors use objects
+  whose insertion order IS alphabetical so the serialized strings
+  compare equal.
+- `json(null)` → `"null"` on all backends.
+- **Documented divergence**: booleans inside the value — Perl
+  template data has no boolean type, so `true` round-trips as `1` on
+  the Perl backends. Excluded from vectors.
+- Top-level `NaN`/`±Infinity` serialize as `"null"` (JS behavior; Go
+  carves this out explicitly). Nested non-finite values error on Go —
+  adapter-defined, excluded.
+
+### number
+
+JS `Number(v)`.
+
+| Backend | Lowering |
+|---------|----------|
+| Hono / CSR | native `Number(v)` |
+| Go template | `bf_number` → `bf.Number` |
+| Mojolicious / Xslate | `bf->number` |
+
+Rules:
+
+- Numeric input passes through; trimmed numeric strings parse
+  (`"3.14"`, `"1e3"`, `"NaN"` → `NaN`); booleans coerce to `1`/`0`;
+  non-numeric strings yield `NaN` (the first sentinel-encoded
+  vectors).
+- **Documented divergence**: JS `Number("")` and `Number(null)` are
+  `0`; both template backends deliberately return `NaN` so silently
+  zeroed empty input doesn't mis-shape downstream arithmetic.
+  Excluded from vectors.
+- **Documented divergence**: JS trims surrounding whitespace
+  (`Number(" 8 ")` → `8`); Go's `strconv.ParseFloat` does not (→
+  `NaN`). Domain is pre-trimmed strings; whitespace cases excluded.
+
+### floor / ceil / round
+
+JS `Math.floor(v)` / `Math.ceil(v)` / `Math.round(v)`.
+
+| Backend | Lowering |
+|---------|----------|
+| Hono / CSR | native `Math.*` |
+| Go template | `bf_floor` / `bf_ceil` / `bf_round` |
+| Mojolicious / Xslate | `bf->floor` / `bf->ceil` / `bf->round` |
+
+Rules:
+
+- The operand routes through `number` coercion first (numeric strings
+  accepted); results follow double semantics.
+- `round` rounds half toward **+Infinity** in JS (`Math.round(-1.5)`
+  → `-1`). Perl's `floor(n + 0.5)` matches JS exactly.
+  **Documented divergence**: Go's `math.Round` rounds half away from
+  zero (`-1.5` → `-2`); negative-half cases are excluded from
+  vectors. Positive halves agree on all backends.


### PR DESCRIPTION
**Stacked on #1885** (arithmetic). Third PR in the stack.

Adds the `templatePrimitives` coercion surface to the catalogue (36 new vectors, 68 total) and introduces the **reserved non-finite sentinel** `{"$num": "NaN" | "Infinity" | "-Infinity"}` for expect values, implemented in the generator and both harnesses — first exercised by `number("not a num") → NaN`.

Harness changes:
- Perl: instantiates `BarefootJS` with the `PureBackend` pattern from `t/template_primitives.t` (still zero Mojo dependency), and lowers JSON booleans in vector **args** to `1`/`0` to mirror production Perl template data.
- Go: sentinel decoding + NaN-aware numeric comparison; `json` binding surfaces marshal errors as the compared value.

Notable spec findings while writing the entries:
- Perl's `round` (`floor(n + 0.5)`) matches JS's half-toward-+Infinity **exactly**; Go's `math.Round` is the one that diverges on negative halves (documented, excluded).
- `Number("")`/`Number(null)`: JS says `0`; both template backends deliberately return `NaN` (documented divergence).
- Perl stringifies floats via `%.15g`, so 16–17-significant-digit doubles diverge from JS/Go shortest-round-trip form (documented; vectors stay ≤15 digits).

All three harnesses green (68/68).

https://claude.ai/code/session_01VcfG8tUF8e5mRpccw38xZq

---
_Generated by [Claude Code](https://claude.ai/code/session_01VcfG8tUF8e5mRpccw38xZq)_