### PR TITLE
Helper catalogue: array operations

### DIFF
--- a/packages/adapter-go-template/runtime/vectors_test.go
+++ b/packages/adapter-go-template/runtime/vectors_test.go
@@ -89,6 +89,23 @@ var vectorBindings = map[string]func(args []any) any{
 		}
 		return Split(args[0].(string), args[1].(string))
 	},
+	"len":           func(args []any) any { return Len(args[0]) },
+	"at":            func(args []any) any { return At(args[0], args[1].(int)) },
+	"includes":      func(args []any) any { return Includes(args[0], args[1]) },
+	"index_of":      func(args []any) any { return IndexOf(args[0], args[1]) },
+	"last_index_of": func(args []any) any { return LastIndexOf(args[0], args[1]) },
+	"concat":        func(args []any) any { return Concat(args[0], args[1]) },
+	"slice": func(args []any) any {
+		if len(args) > 2 {
+			return Slice(args[0], args[1].(int), args[2].(int))
+		}
+		return Slice(args[0], args[1].(int))
+	},
+	"reverse":       func(args []any) any { return Reverse(args[0]) },
+	"flat":          func(args []any) any { return Flat(args[0], args[1].(int)) },
+	"join":          func(args []any) any { return Join(args[0], args[1].(string)) },
+	"arr":           func(args []any) any { return Arr(args...) },
+	"filter_truthy": func(args []any) any { return FilterTruthy(args[0]) },
 }
 
 func TestHelperVectors(t *testing.T) {

--- a/packages/adapter-perl/t/helper_vectors.t
+++ b/packages/adapter-perl/t/helper_vectors.t
@@ -75,6 +75,23 @@ my %bindings = (
     pad_start   => sub { $bf->pad_start(@_) },
     pad_end     => sub { $bf->pad_end(@_) },
     split       => sub { $bf->split(@_) },
+
+    len           => sub { $bf->length($_[0]) },
+    at            => sub { $bf->at(@_) },
+    includes      => sub { $bf->includes(@_) },
+    index_of      => sub { $bf->index_of(@_) },
+    last_index_of => sub { $bf->last_index_of(@_) },
+    concat        => sub { $bf->concat(@_) },
+    # The Mojo emit always passes three value args (`undef` for an
+    # absent end) — mirror that exact shape.
+    slice   => sub { $bf->slice($_[0], $_[1], $_[2]) },
+    reverse => sub { $bf->reverse($_[0]) },
+    flat    => sub { $bf->flat(@_) },
+    join    => sub { $bf->join(@_) },
+    # Array literals are native arrayrefs on the Perl backends.
+    arr => sub { [@_] },
+    # Mirrors the Mojo inline `[grep { $_ } @{...}]` for filter(Boolean).
+    filter_truthy => sub { [grep { $_ } @{ $_[0] }] },
 );
 
 for my $case (@{ $doc->{cases} }) {

--- a/packages/adapter-tests/helper-vectors/cases.ts
+++ b/packages/adapter-tests/helper-vectors/cases.ts
@@ -46,6 +46,19 @@ export const reference: Record<string, (...args: never[]) => unknown> = {
   pad_start: (s: string, target: number, pad?: string) => s.padStart(target, pad),
   pad_end: (s: string, target: number, pad?: string) => s.padEnd(target, pad),
   split: (s: string, sep: string, limit?: number) => s.split(sep, limit),
+  len: (v: string | unknown[]) => v.length,
+  at: (a: unknown[], i: number) => a.at(i),
+  includes: (recv: string | unknown[], x: never) => recv.includes(x),
+  index_of: (a: unknown[], x: unknown) => a.indexOf(x),
+  last_index_of: (a: unknown[], x: unknown) => a.lastIndexOf(x),
+  concat: (a: unknown[], b: unknown[]) => a.concat(b),
+  slice: (a: unknown[], start: number, end?: number) => a.slice(start, end),
+  reverse: (a: unknown[]) => [...a].reverse(),
+  // Depth -1 is the compiled Infinity sentinel (spec entry).
+  flat: (a: unknown[], depth: number) => a.flat(depth === -1 ? Infinity : depth),
+  join: (a: unknown[], sep: string) => a.join(sep),
+  arr: (...elements: unknown[]) => elements,
+  filter_truthy: (a: unknown[]) => a.filter(Boolean),
 }
 
 export const cases: HelperCase[] = [
@@ -185,4 +198,61 @@ export const cases: HelperCase[] = [
   { fn: 'split', args: ['', ','], note: 'empty receiver yields one empty field' },
   { fn: 'split', args: ['', ''], note: 'empty receiver with empty separator yields []' },
   { fn: 'split', args: ['a,b,c', ',', 0], note: 'zero limit yields []' },
+
+  { fn: 'len', args: [[10, 20, 30]], note: 'array element count' },
+  { fn: 'len', args: [[]], note: 'empty array' },
+  { fn: 'len', args: ['hello'], note: 'ASCII string character count' },
+  { fn: 'len', args: [''], note: 'empty string' },
+
+  { fn: 'at', args: [[10, 20, 30], 1], note: 'positive index' },
+  { fn: 'at', args: [[10, 20, 30], -1], note: 'negative index counts from the end' },
+  { fn: 'at', args: [[10, 20, 30], 5], note: 'out of range yields undefined ≡ null' },
+  { fn: 'at', args: [[10, 20, 30], -5], note: 'negative out of range yields undefined ≡ null' },
+  { fn: 'at', args: [[], 0], note: 'empty array yields undefined ≡ null' },
+
+  { fn: 'includes', args: [[1, 2, 3], 2], note: 'array contains number' },
+  { fn: 'includes', args: [[1, 2, 3], 5], note: 'array missing number' },
+  { fn: 'includes', args: [['a', 'b'], 'a'], note: 'array contains string' },
+  { fn: 'includes', args: ['hello', 'ell'], note: 'string receiver does substring test' },
+  { fn: 'includes', args: ['hello', 'z'], note: 'string receiver, absent substring' },
+
+  { fn: 'index_of', args: [[1, 2, 1], 1], note: 'first match wins' },
+  { fn: 'index_of', args: [['a', 'b'], 'b'], note: 'string element' },
+  { fn: 'index_of', args: [[1, 2, 3], 9], note: 'not found is -1' },
+  { fn: 'last_index_of', args: [[1, 2, 1], 1], note: 'last match wins' },
+  { fn: 'last_index_of', args: [[1, 2, 3], 9], note: 'not found is -1' },
+
+  { fn: 'concat', args: [[1, 2], [3]], note: 'order preserved, receiver first' },
+  { fn: 'concat', args: [[], [1]], note: 'empty receiver' },
+  { fn: 'concat', args: [['a'], []], note: 'empty argument' },
+
+  { fn: 'slice', args: [[1, 2, 3, 4], 1], note: 'start only runs to the end' },
+  { fn: 'slice', args: [[1, 2, 3, 4], 1, 3], note: 'start and end' },
+  { fn: 'slice', args: [[1, 2, 3, 4], -2], note: 'negative start counts from the end' },
+  { fn: 'slice', args: [[1, 2, 3, 4], 0, -1], note: 'negative end drops the tail' },
+  { fn: 'slice', args: [[1, 2, 3, 4], 2, 1], note: 'start past end yields []' },
+  { fn: 'slice', args: [[1, 2, 3, 4], 0, 99], note: 'end clamps to length' },
+
+  { fn: 'reverse', args: [[1, 2, 3]], note: 'basic reversal' },
+  { fn: 'reverse', args: [[]], note: 'empty array' },
+  { fn: 'reverse', args: [['only']], note: 'single element' },
+
+  { fn: 'flat', args: [[[1, 2], [3]], 1], note: 'one level' },
+  { fn: 'flat', args: [[1, [2, [3]]], 1], note: 'deeper nesting survives depth 1' },
+  { fn: 'flat', args: [[1, [2, [3, [4]]]], -1], note: 'depth -1 is the Infinity sentinel' },
+  { fn: 'flat', args: [[1, [2]], 0], note: 'depth 0 is a shallow copy' },
+
+  { fn: 'join', args: [[1, 2, 3], ','], note: 'numeric elements stringify' },
+  { fn: 'join', args: [['a', 'b'], ' - '], note: 'multi-char separator' },
+  { fn: 'join', args: [[], ','], note: 'empty array joins to empty string' },
+  { fn: 'join', args: [[1, null, 2], ','], note: 'null elements render as empty' },
+  { fn: 'join', args: [['solo'], ','], note: 'single element has no separator' },
+
+  { fn: 'arr', args: [1, 'x'], note: 'variadic elements in order' },
+  { fn: 'arr', args: [], note: 'empty literal' },
+  { fn: 'arr', args: [5], note: 'single element' },
+
+  { fn: 'filter_truthy', args: [[0, 1, '', 2, null, 'a']], note: 'drops the JS falsy set' },
+  { fn: 'filter_truthy', args: [['x', 'y']], note: 'all truthy passes through' },
+  { fn: 'filter_truthy', args: [[0, '', null]], note: 'all falsy yields []' },
 ]

--- a/packages/adapter-tests/helper-vectors/generate.ts
+++ b/packages/adapter-tests/helper-vectors/generate.ts
@@ -45,7 +45,10 @@ function assertEncodable(value: unknown, context: string): void {
 }
 
 function encodeExpect(value: unknown, context: string): unknown {
-  if (value === undefined) throw new Error(`${context}: undefined is not encodable in vectors.json`)
+  // JS distinguishes undefined from null; the template backends have a
+  // single absent value (Go nil / Perl undef). Per the spec, an
+  // undefined EXPECT encodes as null (value-compat).
+  if (value === undefined) return null
   if (typeof value === 'number' && !Number.isFinite(value)) {
     return { $num: Number.isNaN(value) ? 'NaN' : value > 0 ? 'Infinity' : '-Infinity' }
   }

--- a/packages/adapter-tests/helper-vectors/vectors.json
+++ b/packages/adapter-tests/helper-vectors/vectors.json
@@ -1066,6 +1066,629 @@
       ],
       "expect": [],
       "note": "zero limit yields []"
+    },
+    {
+      "fn": "len",
+      "args": [
+        [
+          10,
+          20,
+          30
+        ]
+      ],
+      "expect": 3,
+      "note": "array element count"
+    },
+    {
+      "fn": "len",
+      "args": [
+        []
+      ],
+      "expect": 0,
+      "note": "empty array"
+    },
+    {
+      "fn": "len",
+      "args": [
+        "hello"
+      ],
+      "expect": 5,
+      "note": "ASCII string character count"
+    },
+    {
+      "fn": "len",
+      "args": [
+        ""
+      ],
+      "expect": 0,
+      "note": "empty string"
+    },
+    {
+      "fn": "at",
+      "args": [
+        [
+          10,
+          20,
+          30
+        ],
+        1
+      ],
+      "expect": 20,
+      "note": "positive index"
+    },
+    {
+      "fn": "at",
+      "args": [
+        [
+          10,
+          20,
+          30
+        ],
+        -1
+      ],
+      "expect": 30,
+      "note": "negative index counts from the end"
+    },
+    {
+      "fn": "at",
+      "args": [
+        [
+          10,
+          20,
+          30
+        ],
+        5
+      ],
+      "expect": null,
+      "note": "out of range yields undefined ≡ null"
+    },
+    {
+      "fn": "at",
+      "args": [
+        [
+          10,
+          20,
+          30
+        ],
+        -5
+      ],
+      "expect": null,
+      "note": "negative out of range yields undefined ≡ null"
+    },
+    {
+      "fn": "at",
+      "args": [
+        [],
+        0
+      ],
+      "expect": null,
+      "note": "empty array yields undefined ≡ null"
+    },
+    {
+      "fn": "includes",
+      "args": [
+        [
+          1,
+          2,
+          3
+        ],
+        2
+      ],
+      "expect": true,
+      "note": "array contains number"
+    },
+    {
+      "fn": "includes",
+      "args": [
+        [
+          1,
+          2,
+          3
+        ],
+        5
+      ],
+      "expect": false,
+      "note": "array missing number"
+    },
+    {
+      "fn": "includes",
+      "args": [
+        [
+          "a",
+          "b"
+        ],
+        "a"
+      ],
+      "expect": true,
+      "note": "array contains string"
+    },
+    {
+      "fn": "includes",
+      "args": [
+        "hello",
+        "ell"
+      ],
+      "expect": true,
+      "note": "string receiver does substring test"
+    },
+    {
+      "fn": "includes",
+      "args": [
+        "hello",
+        "z"
+      ],
+      "expect": false,
+      "note": "string receiver, absent substring"
+    },
+    {
+      "fn": "index_of",
+      "args": [
+        [
+          1,
+          2,
+          1
+        ],
+        1
+      ],
+      "expect": 0,
+      "note": "first match wins"
+    },
+    {
+      "fn": "index_of",
+      "args": [
+        [
+          "a",
+          "b"
+        ],
+        "b"
+      ],
+      "expect": 1,
+      "note": "string element"
+    },
+    {
+      "fn": "index_of",
+      "args": [
+        [
+          1,
+          2,
+          3
+        ],
+        9
+      ],
+      "expect": -1,
+      "note": "not found is -1"
+    },
+    {
+      "fn": "last_index_of",
+      "args": [
+        [
+          1,
+          2,
+          1
+        ],
+        1
+      ],
+      "expect": 2,
+      "note": "last match wins"
+    },
+    {
+      "fn": "last_index_of",
+      "args": [
+        [
+          1,
+          2,
+          3
+        ],
+        9
+      ],
+      "expect": -1,
+      "note": "not found is -1"
+    },
+    {
+      "fn": "concat",
+      "args": [
+        [
+          1,
+          2
+        ],
+        [
+          3
+        ]
+      ],
+      "expect": [
+        1,
+        2,
+        3
+      ],
+      "note": "order preserved, receiver first"
+    },
+    {
+      "fn": "concat",
+      "args": [
+        [],
+        [
+          1
+        ]
+      ],
+      "expect": [
+        1
+      ],
+      "note": "empty receiver"
+    },
+    {
+      "fn": "concat",
+      "args": [
+        [
+          "a"
+        ],
+        []
+      ],
+      "expect": [
+        "a"
+      ],
+      "note": "empty argument"
+    },
+    {
+      "fn": "slice",
+      "args": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        1
+      ],
+      "expect": [
+        2,
+        3,
+        4
+      ],
+      "note": "start only runs to the end"
+    },
+    {
+      "fn": "slice",
+      "args": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        1,
+        3
+      ],
+      "expect": [
+        2,
+        3
+      ],
+      "note": "start and end"
+    },
+    {
+      "fn": "slice",
+      "args": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        -2
+      ],
+      "expect": [
+        3,
+        4
+      ],
+      "note": "negative start counts from the end"
+    },
+    {
+      "fn": "slice",
+      "args": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        0,
+        -1
+      ],
+      "expect": [
+        1,
+        2,
+        3
+      ],
+      "note": "negative end drops the tail"
+    },
+    {
+      "fn": "slice",
+      "args": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        2,
+        1
+      ],
+      "expect": [],
+      "note": "start past end yields []"
+    },
+    {
+      "fn": "slice",
+      "args": [
+        [
+          1,
+          2,
+          3,
+          4
+        ],
+        0,
+        99
+      ],
+      "expect": [
+        1,
+        2,
+        3,
+        4
+      ],
+      "note": "end clamps to length"
+    },
+    {
+      "fn": "reverse",
+      "args": [
+        [
+          1,
+          2,
+          3
+        ]
+      ],
+      "expect": [
+        3,
+        2,
+        1
+      ],
+      "note": "basic reversal"
+    },
+    {
+      "fn": "reverse",
+      "args": [
+        []
+      ],
+      "expect": [],
+      "note": "empty array"
+    },
+    {
+      "fn": "reverse",
+      "args": [
+        [
+          "only"
+        ]
+      ],
+      "expect": [
+        "only"
+      ],
+      "note": "single element"
+    },
+    {
+      "fn": "flat",
+      "args": [
+        [
+          [
+            1,
+            2
+          ],
+          [
+            3
+          ]
+        ],
+        1
+      ],
+      "expect": [
+        1,
+        2,
+        3
+      ],
+      "note": "one level"
+    },
+    {
+      "fn": "flat",
+      "args": [
+        [
+          1,
+          [
+            2,
+            [
+              3
+            ]
+          ]
+        ],
+        1
+      ],
+      "expect": [
+        1,
+        2,
+        [
+          3
+        ]
+      ],
+      "note": "deeper nesting survives depth 1"
+    },
+    {
+      "fn": "flat",
+      "args": [
+        [
+          1,
+          [
+            2,
+            [
+              3,
+              [
+                4
+              ]
+            ]
+          ]
+        ],
+        -1
+      ],
+      "expect": [
+        1,
+        2,
+        3,
+        4
+      ],
+      "note": "depth -1 is the Infinity sentinel"
+    },
+    {
+      "fn": "flat",
+      "args": [
+        [
+          1,
+          [
+            2
+          ]
+        ],
+        0
+      ],
+      "expect": [
+        1,
+        [
+          2
+        ]
+      ],
+      "note": "depth 0 is a shallow copy"
+    },
+    {
+      "fn": "join",
+      "args": [
+        [
+          1,
+          2,
+          3
+        ],
+        ","
+      ],
+      "expect": "1,2,3",
+      "note": "numeric elements stringify"
+    },
+    {
+      "fn": "join",
+      "args": [
+        [
+          "a",
+          "b"
+        ],
+        " - "
+      ],
+      "expect": "a - b",
+      "note": "multi-char separator"
+    },
+    {
+      "fn": "join",
+      "args": [
+        [],
+        ","
+      ],
+      "expect": "",
+      "note": "empty array joins to empty string"
+    },
+    {
+      "fn": "join",
+      "args": [
+        [
+          1,
+          null,
+          2
+        ],
+        ","
+      ],
+      "expect": "1,,2",
+      "note": "null elements render as empty"
+    },
+    {
+      "fn": "join",
+      "args": [
+        [
+          "solo"
+        ],
+        ","
+      ],
+      "expect": "solo",
+      "note": "single element has no separator"
+    },
+    {
+      "fn": "arr",
+      "args": [
+        1,
+        "x"
+      ],
+      "expect": [
+        1,
+        "x"
+      ],
+      "note": "variadic elements in order"
+    },
+    {
+      "fn": "arr",
+      "args": [],
+      "expect": [],
+      "note": "empty literal"
+    },
+    {
+      "fn": "arr",
+      "args": [
+        5
+      ],
+      "expect": [
+        5
+      ],
+      "note": "single element"
+    },
+    {
+      "fn": "filter_truthy",
+      "args": [
+        [
+          0,
+          1,
+          "",
+          2,
+          null,
+          "a"
+        ]
+      ],
+      "expect": [
+        1,
+        2,
+        "a"
+      ],
+      "note": "drops the JS falsy set"
+    },
+    {
+      "fn": "filter_truthy",
+      "args": [
+        [
+          "x",
+          "y"
+        ]
+      ],
+      "expect": [
+        "x",
+        "y"
+      ],
+      "note": "all truthy passes through"
+    },
+    {
+      "fn": "filter_truthy",
+      "args": [
+        [
+          0,
+          "",
+          null
+        ]
+      ],
+      "expect": [],
+      "note": "all falsy yields []"
     }
   ]
 }

--- a/spec/template-helpers.md
+++ b/spec/template-helpers.md
@@ -75,8 +75,11 @@ committed, and consumed by one thin harness per backend.
   as `{"$num": "NaN" | "Infinity" | "-Infinity"}` (the `$num` key is
   reserved; helper data must not use it). Arguments must stay finite —
   the generator refuses non-finite `args`; composition cases (e.g.
-  `floor(number("x"))`) can lift that later if needed. `undefined` is
-  never representable.
+  `floor(number("x"))`) can lift that later if needed.
+- A JS `undefined` **expect** encodes as `null`: the template
+  backends have a single absent value (Go `nil` / Perl `undef`), so
+  `undefined` ≡ `null` under value-compat (e.g. `at(arr, 99)`).
+  `undefined` arguments stay unrepresentable.
 - Each case carries a human-readable `note` naming the spec rule it
   pins.
 
@@ -446,3 +449,158 @@ Rules:
   `[]`; a negative limit keeps everything.
 - The no-separator form (`s.split()`) lowers separately
   (whole-string single element) and is not part of the vectors.
+
+### len
+
+JS `.length` — both array element count and string character count
+(the parser can't always disambiguate the receiver).
+
+| Backend | Lowering |
+|---------|----------|
+| Hono / CSR | native `.length` |
+| Go template | `bf_len` (also plain `len` in some positions) |
+| Mojolicious | `scalar(@{...})` for known arrays; `bf->length` otherwise |
+| Xslate | `$bf.length` |
+
+String length is bytes on Go, characters on Perl, UTF-16 units in JS
+— identical for ASCII; non-ASCII is out of contract (vectors stay
+ASCII).
+
+### at
+
+JS `Array.prototype.at(i)` — supports negative indices; out-of-range
+yields `undefined` (≡ `null` in vectors).
+
+| Backend | Lowering |
+|---------|----------|
+| Hono / CSR | native `.at` |
+| Go template | `bf_at` |
+| Mojolicious / Xslate | `bf->at` |
+
+### includes
+
+JS `Array.prototype.includes(x)` AND `String.prototype.includes(sub)`
+— one canonical id; the backends dispatch on the receiver type at
+runtime.
+
+| Backend | Lowering |
+|---------|----------|
+| Hono / CSR | native `.includes` |
+| Go template | `bf_includes` (reflect.Kind dispatch) |
+| Mojolicious / Xslate | `bf->includes` (`ref()` dispatch) |
+
+Rules:
+
+- Array search is strict-equality in JS and Go (`DeepEqual`);
+  **documented divergence**: Perl scans with `eq` (string equality),
+  so cross-type probes (`[1].includes("1")`: JS `false`, Perl `true`)
+  diverge. Domain: needle and elements of the same primitive type.
+- String receiver does a substring test.
+
+### index_of / last_index_of
+
+JS `Array.prototype.indexOf(x)` / `.lastIndexOf(x)` → first/last
+position or `-1`. Same equality contract (and Perl `eq` divergence
+domain) as `includes`.
+
+| Backend | Lowering |
+|---------|----------|
+| Hono / CSR | native methods |
+| Go template | `bf_index_of` / `bf_last_index_of` |
+| Mojolicious / Xslate | `bf->index_of` / `bf->last_index_of` |
+
+### concat
+
+JS `Array.prototype.concat(other)` — binary form only (variadic
+`.concat(a, b)` is refused upstream).
+
+| Backend | Lowering |
+|---------|----------|
+| Hono / CSR | native `.concat` |
+| Go template | `bf_concat` |
+| Mojolicious / Xslate | `bf->concat` |
+
+### slice
+
+JS `Array.prototype.slice(start, end?)` with full negative-index
+clamping (`slice(-2)`, `slice(0, -1)`, `start >= end` → `[]`).
+
+| Backend | Lowering |
+|---------|----------|
+| Hono / CSR | native `.slice` |
+| Go template | `bf_slice` |
+| Mojolicious / Xslate | `bf->slice` |
+
+### reverse
+
+JS `Array.prototype.reverse()` / `.toReversed()` — non-mutating on
+the template backends (SSR renders a snapshot, so the JS
+mutate-vs-copy distinction has no template-level meaning).
+
+| Backend | Lowering |
+|---------|----------|
+| Hono / CSR | native methods |
+| Go template | `bf_reverse` |
+| Mojolicious / Xslate | `bf->reverse` |
+
+### flat
+
+JS `Array.prototype.flat(depth?)`. Canonical args use the compiled
+representation: depth `-1` is the `Infinity` sentinel (flatten
+fully); the no-arg JS form lowers as depth `1`.
+
+| Backend | Lowering |
+|---------|----------|
+| Hono / CSR | native `.flat` |
+| Go template | `bf_flat` |
+| Mojolicious / Xslate | `bf->flat` |
+
+### join
+
+JS `Array.prototype.join(sep)`. `null`/`undefined` elements render as
+empty (`[1, null, 2].join(",")` → `"1,,2"`); the separator defaults
+to `","` at the lowering site (canonical vectors always pass it
+explicitly).
+
+| Backend | Lowering |
+|---------|----------|
+| Hono / CSR | native `.join` |
+| Go template | `bf_join` |
+| Mojolicious | native `join($sep, @{...})` |
+| Xslate | `$bf.join` |
+
+Number elements stringify per the `string` entry — Perl's `%.15g`
+divergence applies; vectors keep elements within 15 significant
+digits.
+
+### arr
+
+Array-literal lowering `[a, b, …]` (#1443) — template languages
+without array-literal syntax route through a variadic constructor.
+
+| Backend | Lowering |
+|---------|----------|
+| Hono / CSR | native `[a, b]` |
+| Go template | `bf_arr a b` |
+| Mojolicious / Xslate | native `[$a, $b]` |
+
+### filter_truthy
+
+JS `arr.filter(Boolean)` (#1443 class-merge pattern) — keep elements
+that are truthy under JS `Boolean(x)`.
+
+| Backend | Lowering |
+|---------|----------|
+| Hono / CSR | native `.filter(Boolean)` |
+| Go template | `bf_filter_truthy` |
+| Mojolicious | inline `[grep { $_ } @{...}]` |
+| Xslate | Kolon lambda filter |
+
+**Documented divergence**: Perl truthiness drops the string `"0"`
+(falsy in Perl, truthy in JS). The intended domain is class-string
+merging where `"0"` is not a meaningful class name; excluded from
+vectors.
+
+Not in the catalogue: `bf_first` / `bf_last` / `bf_contains` exist in
+the Go FuncMap as conveniences but are never emitted by the compiler;
+they are Go-internal and carry no cross-backend contract.


### PR DESCRIPTION
**Stacked on #1887** (strings). Fifth PR in the stack.

Adds the array surface to the catalogue: `len`, `at`, `includes` (polymorphic array/string receiver), `index_of`/`last_index_of`, `concat`, `slice`, `reverse`, `flat` (incl. the `-1` Infinity sentinel the compiler emits), `join`, `arr` (#1443 array-literal lowering), `filter_truthy`. 46 new vectors (163 total), all green on the three harnesses.

Vector-format addition: JS `undefined` expects encode as `null` — the template backends have a single absent value (Go `nil` / Perl `undef`) — first exercised by out-of-range `at`.

Documented divergences excluded from the domain:
- Perl scans arrays with `eq`, so cross-type probes (`[1].includes("1")`: JS `false`, Perl `true`) are out of contract; vectors keep needle and elements the same primitive type.
- Perl truthiness drops the string `"0"` in `filter(Boolean)` (truthy in JS); the intended class-merge domain never contains `"0"`.

The spec also records that `bf_first`/`bf_last`/`bf_contains` are Go-internal FuncMap conveniences the compiler never emits — no cross-backend contract.

https://claude.ai/code/session_01VcfG8tUF8e5mRpccw38xZq

---
_Generated by [Claude Code](https://claude.ai/code/session_01VcfG8tUF8e5mRpccw38xZq)_