### PR TITLE
Helper catalogue: higher-order methods + Go map-item support

### DIFF
--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -1143,61 +1143,43 @@ func isTruthy(v any) bool {
 // Higher-order Array Methods
 // =============================================================================
 
-// Every returns true if all items have the specified field set to true.
-// Mirrors JavaScript's Array.prototype.every(item => item.field).
+// fieldValue projects item.field for the higher-order predicate
+// helpers. The field name arrives in JS casing; structs resolve via
+// the capitalized Go convention (FieldByName inside getFieldValue),
+// maps via getFieldValue's case-variant lookup — the same dual
+// support Sort/Reduce gained in #1487, extended here so JSON-decoded
+// data (map items) participates instead of being silently skipped.
+// nil-safe: missing fields and nil items project to nil.
+func fieldValue(item any, field string) any {
+	return getFieldValue(item, capitalize(field))
+}
+
+// Every returns true if every item's field is truthy under JS
+// `Boolean(item.field)` semantics. Mirrors JavaScript's
+// Array.prototype.every(item => item.field) — including being
+// vacuously true for an empty receiver.
 func Every(items any, field string) bool {
 	v := reflect.ValueOf(items)
 	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
 		return false
 	}
-
-	capitalizedField := capitalize(field)
 	for i := 0; i < v.Len(); i++ {
-		item := v.Index(i)
-		if item.Kind() == reflect.Interface {
-			item = item.Elem()
-		}
-		if item.Kind() == reflect.Ptr {
-			item = item.Elem()
-		}
-		if item.Kind() != reflect.Struct {
-			continue
-		}
-
-		fieldVal := item.FieldByName(capitalizedField)
-		if !fieldVal.IsValid() {
-			return false
-		}
-		if fieldVal.Kind() == reflect.Bool && !fieldVal.Bool() {
+		if !isTruthy(fieldValue(v.Index(i).Interface(), field)) {
 			return false
 		}
 	}
 	return true
 }
 
-// Some returns true if at least one item has the specified field set to true.
-// Mirrors JavaScript's Array.prototype.some(item => item.field).
+// Some returns true if at least one item's field is truthy. Mirrors
+// JavaScript's Array.prototype.some(item => item.field).
 func Some(items any, field string) bool {
 	v := reflect.ValueOf(items)
 	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
 		return false
 	}
-
-	capitalizedField := capitalize(field)
 	for i := 0; i < v.Len(); i++ {
-		item := v.Index(i)
-		if item.Kind() == reflect.Interface {
-			item = item.Elem()
-		}
-		if item.Kind() == reflect.Ptr {
-			item = item.Elem()
-		}
-		if item.Kind() != reflect.Struct {
-			continue
-		}
-
-		fieldVal := item.FieldByName(capitalizedField)
-		if fieldVal.IsValid() && fieldVal.Kind() == reflect.Bool && fieldVal.Bool() {
+		if isTruthy(fieldValue(v.Index(i).Interface(), field)) {
 			return true
 		}
 	}
@@ -1212,30 +1194,11 @@ func Filter(items any, field string, value any) []any {
 	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
 		return nil
 	}
-
-	capitalizedField := capitalize(field)
 	var result []any
-
 	for i := 0; i < v.Len(); i++ {
-		item := v.Index(i)
-		if item.Kind() == reflect.Interface {
-			item = item.Elem()
-		}
-		if item.Kind() == reflect.Ptr {
-			item = item.Elem()
-		}
-		if item.Kind() != reflect.Struct {
-			continue
-		}
-
-		fieldVal := item.FieldByName(capitalizedField)
-		if !fieldVal.IsValid() {
-			continue
-		}
-
-		// Compare field value with target value
-		if reflect.DeepEqual(fieldVal.Interface(), value) {
-			result = append(result, v.Index(i).Interface())
+		item := v.Index(i).Interface()
+		if reflect.DeepEqual(fieldValue(item, field), value) {
+			result = append(result, item)
 		}
 	}
 	return result
@@ -1248,27 +1211,10 @@ func Find(items any, field string, value any) any {
 	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
 		return nil
 	}
-
-	capitalizedField := capitalize(field)
 	for i := 0; i < v.Len(); i++ {
-		item := v.Index(i)
-		if item.Kind() == reflect.Interface {
-			item = item.Elem()
-		}
-		if item.Kind() == reflect.Ptr {
-			item = item.Elem()
-		}
-		if item.Kind() != reflect.Struct {
-			continue
-		}
-
-		fieldVal := item.FieldByName(capitalizedField)
-		if !fieldVal.IsValid() {
-			continue
-		}
-
-		if reflect.DeepEqual(fieldVal.Interface(), value) {
-			return v.Index(i).Interface()
+		item := v.Index(i).Interface()
+		if reflect.DeepEqual(fieldValue(item, field), value) {
+			return item
 		}
 	}
 	return nil
@@ -1281,26 +1227,8 @@ func FindIndex(items any, field string, value any) int {
 	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
 		return -1
 	}
-
-	capitalizedField := capitalize(field)
 	for i := 0; i < v.Len(); i++ {
-		item := v.Index(i)
-		if item.Kind() == reflect.Interface {
-			item = item.Elem()
-		}
-		if item.Kind() == reflect.Ptr {
-			item = item.Elem()
-		}
-		if item.Kind() != reflect.Struct {
-			continue
-		}
-
-		fieldVal := item.FieldByName(capitalizedField)
-		if !fieldVal.IsValid() {
-			continue
-		}
-
-		if reflect.DeepEqual(fieldVal.Interface(), value) {
+		if reflect.DeepEqual(fieldValue(v.Index(i).Interface(), field), value) {
 			return i
 		}
 	}
@@ -1314,33 +1242,10 @@ func FindLast(items any, field string, value any) any {
 	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
 		return nil
 	}
-
-	capitalizedField := capitalize(field)
 	for i := v.Len() - 1; i >= 0; i-- {
-		item := v.Index(i)
-		if item.Kind() == reflect.Interface {
-			if item.IsNil() {
-				continue
-			}
-			item = item.Elem()
-		}
-		if item.Kind() == reflect.Ptr {
-			if item.IsNil() {
-				continue
-			}
-			item = item.Elem()
-		}
-		if item.Kind() != reflect.Struct {
-			continue
-		}
-
-		fieldVal := item.FieldByName(capitalizedField)
-		if !fieldVal.IsValid() {
-			continue
-		}
-
-		if reflect.DeepEqual(fieldVal.Interface(), value) {
-			return v.Index(i).Interface()
+		item := v.Index(i).Interface()
+		if reflect.DeepEqual(fieldValue(item, field), value) {
+			return item
 		}
 	}
 	return nil
@@ -1353,32 +1258,8 @@ func FindLastIndex(items any, field string, value any) int {
 	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
 		return -1
 	}
-
-	capitalizedField := capitalize(field)
 	for i := v.Len() - 1; i >= 0; i-- {
-		item := v.Index(i)
-		if item.Kind() == reflect.Interface {
-			if item.IsNil() {
-				continue
-			}
-			item = item.Elem()
-		}
-		if item.Kind() == reflect.Ptr {
-			if item.IsNil() {
-				continue
-			}
-			item = item.Elem()
-		}
-		if item.Kind() != reflect.Struct {
-			continue
-		}
-
-		fieldVal := item.FieldByName(capitalizedField)
-		if !fieldVal.IsValid() {
-			continue
-		}
-
-		if reflect.DeepEqual(fieldVal.Interface(), value) {
+		if reflect.DeepEqual(fieldValue(v.Index(i).Interface(), field), value) {
 			return i
 		}
 	}

--- a/packages/adapter-go-template/runtime/vectors_test.go
+++ b/packages/adapter-go-template/runtime/vectors_test.go
@@ -106,6 +106,32 @@ var vectorBindings = map[string]func(args []any) any{
 	"join":          func(args []any) any { return Join(args[0], args[1].(string)) },
 	"arr":           func(args []any) any { return Arr(args...) },
 	"filter_truthy": func(args []any) any { return FilterTruthy(args[0]) },
+	"every":         func(args []any) any { return Every(args[0], args[1].(string)) },
+	"some":          func(args []any) any { return Some(args[0], args[1].(string)) },
+	"filter":        func(args []any) any { return Filter(args[0], args[1].(string), args[2]) },
+	"find":          func(args []any) any { return Find(args[0], args[1].(string), args[2]) },
+	"find_index":    func(args []any) any { return FindIndex(args[0], args[1].(string), args[2]) },
+	"find_last":     func(args []any) any { return FindLast(args[0], args[1].(string), args[2]) },
+	"find_last_index": func(args []any) any {
+		return FindLastIndex(args[0], args[1].(string), args[2])
+	},
+	"sort": func(args []any) any { return Sort(args[0], toStringSlice(args[1:])...) },
+	"reduce": func(args []any) any {
+		return Reduce(args[0], args[1].(string), args[2].(string), args[3].(string),
+			args[4].(string), args[5].(string), args[6].(string))
+	},
+	"flat_map": func(args []any) any { return FlatMap(args[0], args[1].(string), args[2].(string)) },
+	"flat_map_tuple": func(args []any) any {
+		return FlatMapTuple(args[0], toStringSlice(args[1:])...)
+	},
+}
+
+func toStringSlice(args []any) []string {
+	out := make([]string, len(args))
+	for i, a := range args {
+		out[i] = a.(string)
+	}
+	return out
 }
 
 func TestHelperVectors(t *testing.T) {

--- a/packages/adapter-perl/t/helper_vectors.t
+++ b/packages/adapter-perl/t/helper_vectors.t
@@ -92,7 +92,69 @@ my %bindings = (
     arr => sub { [@_] },
     # Mirrors the Mojo inline `[grep { $_ } @{...}]` for filter(Boolean).
     filter_truthy => sub { [grep { $_ } @{ $_[0] }] },
+
+    # Higher-order entries arrive in the canonical projection form
+    # (spec: items + field [+ value]); the closures below rebuild the
+    # predicate the adapters compile (`i => i.field === value`,
+    # `i => i.field`), choosing eq vs == by the probe's string-typing
+    # the same way the Mojo emitter does.
+    every  => sub { $bf->every($_[0],  _truthy_pred($_[1])) },
+    some   => sub { $bf->some($_[0],   _truthy_pred($_[1])) },
+    filter => sub { $bf->filter($_[0], _field_eq_pred($_[1], $_[2])) },
+    find   => sub { $bf->find($_[0],   _field_eq_pred($_[1], $_[2])) },
+    find_index      => sub { $bf->find_index($_[0],      _field_eq_pred($_[1], $_[2])) },
+    find_last       => sub { $bf->find_last($_[0],       _field_eq_pred($_[1], $_[2])) },
+    find_last_index => sub { $bf->find_last_index($_[0], _field_eq_pred($_[1], $_[2])) },
+
+    sort => sub {
+        my ($recv, @spec) = @_;
+        my @keys;
+        while (@spec >= 4) {
+            my ($kind, $name, $ct, $dir) = splice(@spec, 0, 4);
+            push @keys, {
+                key_kind     => $kind,
+                key          => $name,
+                compare_type => $ct,
+                direction    => $dir,
+            };
+        }
+        return $bf->sort($recv, { keys => \@keys });
+    },
+    reduce => sub {
+        my ($recv, $op, $key_kind, $key, $type, $init, $direction) = @_;
+        return $bf->reduce($recv, {
+            op        => $op,
+            key_kind  => $key_kind,
+            key       => $key,
+            type      => $type,
+            init      => $init,
+            direction => $direction,
+        });
+    },
+    flat_map       => sub { $bf->flat_map(@_) },
+    flat_map_tuple => sub {
+        my ($recv, @flat) = @_;
+        my @specs;
+        while (@flat >= 2) {
+            my ($kind, $name) = splice(@flat, 0, 2);
+            push @specs, [$kind, $name];
+        }
+        return $bf->flat_map_tuple($recv, @specs);
+    },
 );
+
+sub _truthy_pred {
+    my ($field) = @_;
+    return sub { ref $_[0] eq 'HASH' ? $_[0]{$field} : undef };
+}
+
+sub _field_eq_pred {
+    my ($field, $value) = @_;
+    my $get = sub { ref $_[0] eq 'HASH' ? $_[0]{$field} : undef };
+    return looks_like_number($value)
+        ? sub { my $v = $get->($_[0]); defined $v && $v == $value }
+        : sub { my $v = $get->($_[0]); defined $v && $v eq $value };
+}
 
 for my $case (@{ $doc->{cases} }) {
     my ($fn, $note) = @{$case}{qw(fn note)};

--- a/packages/adapter-tests/helper-vectors/cases.ts
+++ b/packages/adapter-tests/helper-vectors/cases.ts
@@ -59,6 +59,70 @@ export const reference: Record<string, (...args: never[]) => unknown> = {
   join: (a: unknown[], sep: string) => a.join(sep),
   arr: (...elements: unknown[]) => elements,
   filter_truthy: (a: unknown[]) => a.filter(Boolean),
+
+  // Higher-order entries use the compiled projection catalogue as the
+  // canonical argument form (spec: "canonical projection form") — the
+  // references run the REAL JS array methods over predicates built
+  // from those projections.
+  every: (a: Record<string, unknown>[], field: string) => a.every((i) => i[field]),
+  some: (a: Record<string, unknown>[], field: string) => a.some((i) => i[field]),
+  filter: (a: Record<string, unknown>[], field: string, value: unknown) =>
+    a.filter((i) => i[field] === value),
+  find: (a: Record<string, unknown>[], field: string, value: unknown) =>
+    a.find((i) => i[field] === value),
+  find_index: (a: Record<string, unknown>[], field: string, value: unknown) =>
+    a.findIndex((i) => i[field] === value),
+  find_last: (a: Record<string, unknown>[], field: string, value: unknown) =>
+    a.findLast((i) => i[field] === value),
+  find_last_index: (a: Record<string, unknown>[], field: string, value: unknown) =>
+    a.findLastIndex((i) => i[field] === value),
+  sort: (items: unknown[], ...spec: string[]) => {
+    const keys: Array<{ kind: string; name: string; type: string; dir: string }> = []
+    for (let i = 0; i + 3 < spec.length; i += 4) {
+      keys.push({ kind: spec[i], name: spec[i + 1], type: spec[i + 2], dir: spec[i + 3] })
+    }
+    const proj = (x: unknown, k: (typeof keys)[number]) =>
+      k.kind === 'field' ? (x as Record<string, unknown>)[k.name] : x
+    return [...items].sort((a, b) => {
+      for (const k of keys) {
+        const ka = proj(a, k)
+        const kb = proj(b, k)
+        let c: number
+        if (k.type === 'string') c = String(ka).localeCompare(String(kb))
+        else if (k.type === 'auto') c = (ka as never) > (kb as never) ? 1 : (ka as never) < (kb as never) ? -1 : 0
+        else c = Number(ka) - Number(kb)
+        if (c !== 0) return k.dir === 'desc' ? -c : c
+      }
+      return 0
+    })
+  },
+  reduce: (
+    items: unknown[],
+    op: string,
+    keyKind: string,
+    key: string,
+    type: string,
+    init: string,
+    direction: string,
+  ) => {
+    const proj = (x: unknown) => (keyKind === 'field' ? (x as Record<string, unknown>)[key] : x)
+    const arr = direction === 'right' ? [...items].reverse() : items
+    if (type === 'string') return arr.reduce<string>((acc, x) => acc + String(proj(x)), init)
+    return arr.reduce<number>(
+      (acc, x) => (op === '*' ? acc * Number(proj(x)) : acc + Number(proj(x))),
+      Number(init),
+    )
+  },
+  flat_map: (items: unknown[], keyKind: string, key: string) =>
+    items.flatMap((x) => (keyKind === 'field' ? (x as Record<string, unknown>)[key] : x)),
+  flat_map_tuple: (items: unknown[], ...specs: string[]) =>
+    items.flatMap((x) => {
+      const leaves: unknown[] = []
+      for (let i = 0; i + 1 < specs.length; i += 2) {
+        leaves.push(specs[i] === 'field' ? (x as Record<string, unknown>)[specs[i + 1]] : x)
+      }
+      return leaves
+    }),
 }
 
 export const cases: HelperCase[] = [
@@ -255,4 +319,120 @@ export const cases: HelperCase[] = [
   { fn: 'filter_truthy', args: [[0, 1, '', 2, null, 'a']], note: 'drops the JS falsy set' },
   { fn: 'filter_truthy', args: [['x', 'y']], note: 'all truthy passes through' },
   { fn: 'filter_truthy', args: [[0, '', null]], note: 'all falsy yields []' },
+
+  { fn: 'every', args: [[{ done: true }, { done: true }], 'done'], note: 'all truthy fields' },
+  { fn: 'every', args: [[{ done: true }, { done: false }], 'done'], note: 'one falsy field fails' },
+  { fn: 'every', args: [[], 'done'], note: 'empty receiver is vacuously true' },
+  { fn: 'some', args: [[{ done: false }, { done: true }], 'done'], note: 'one truthy field passes' },
+  { fn: 'some', args: [[{ done: false }], 'done'], note: 'no truthy field fails' },
+  { fn: 'some', args: [[], 'done'], note: 'empty receiver is false' },
+
+  {
+    fn: 'filter',
+    args: [[{ s: 'a', n: 1 }, { s: 'b', n: 2 }, { s: 'a', n: 3 }], 's', 'a'],
+    note: 'string field equality keeps matching items',
+  },
+  {
+    fn: 'filter',
+    args: [[{ s: 'a', n: 1 }, { s: 'b', n: 2 }], 'n', 2],
+    note: 'numeric field equality',
+  },
+  { fn: 'filter', args: [[{ s: 'a' }], 's', 'z'], note: 'no match yields []' },
+
+  {
+    fn: 'find',
+    args: [[{ id: 1, v: 'x' }, { id: 2, v: 'y' }], 'id', 2],
+    note: 'returns the first matching element',
+  },
+  { fn: 'find', args: [[{ id: 1 }], 'id', 9], note: 'no match yields undefined ≡ null' },
+  {
+    fn: 'find_index',
+    args: [[{ id: 1 }, { id: 2 }, { id: 2 }], 'id', 2],
+    note: 'first matching index',
+  },
+  { fn: 'find_index', args: [[{ id: 1 }], 'id', 9], note: 'no match is -1' },
+  {
+    fn: 'find_last',
+    args: [[{ id: 2, v: 'first' }, { id: 2, v: 'last' }], 'id', 2],
+    note: 'returns the last matching element',
+  },
+  {
+    fn: 'find_last_index',
+    args: [[{ id: 1 }, { id: 2 }, { id: 2 }], 'id', 2],
+    note: 'last matching index',
+  },
+  { fn: 'find_last_index', args: [[{ id: 1 }], 'id', 9], note: 'no match is -1' },
+
+  { fn: 'sort', args: [[3, 1, 2], 'self', '', 'numeric', 'asc'], note: 'numeric self ascending' },
+  { fn: 'sort', args: [[3, 1, 2], 'self', '', 'numeric', 'desc'], note: 'numeric self descending' },
+  {
+    fn: 'sort',
+    args: [[{ p: 30 }, { p: 10 }, { p: 20 }], 'field', 'p', 'numeric', 'asc'],
+    note: 'numeric field key',
+  },
+  {
+    fn: 'sort',
+    args: [['banana', 'apple', 'cherry'], 'self', '', 'string', 'asc'],
+    note: 'string compare on same-case ASCII',
+  },
+  {
+    fn: 'sort',
+    args: [[{ p: 2.5 }, { p: 1.5 }], 'field', 'p', 'auto', 'asc'],
+    note: 'auto compare with real numbers',
+  },
+  {
+    fn: 'sort',
+    args: [
+      [{ a: 1, b: 2 }, { a: 1, b: 1 }, { a: 0, b: 9 }],
+      'field', 'a', 'numeric', 'asc',
+      'field', 'b', 'numeric', 'asc',
+    ],
+    note: 'multi-key tie-break',
+  },
+  { fn: 'sort', args: [[], 'self', '', 'numeric', 'asc'], note: 'empty receiver' },
+
+  { fn: 'reduce', args: [[1, 2, 3], '+', 'self', '', 'numeric', '0', 'left'], note: 'sum fold' },
+  { fn: 'reduce', args: [[2, 3, 4], '*', 'self', '', 'numeric', '1', 'left'], note: 'product fold' },
+  {
+    fn: 'reduce',
+    args: [[{ d: 5 }, { d: 7 }], '+', 'field', 'd', 'numeric', '10', 'left'],
+    note: 'field projection with non-zero init',
+  },
+  {
+    fn: 'reduce',
+    args: [['a', 'b', 'c'], '+', 'self', '', 'string', 'x', 'left'],
+    note: 'string concatenation seeds with init',
+  },
+  {
+    fn: 'reduce',
+    args: [['a', 'b', 'c'], '+', 'self', '', 'string', 'x', 'right'],
+    note: 'reduceRight is observable for string concat',
+  },
+  {
+    fn: 'reduce',
+    args: [[], '+', 'self', '', 'numeric', '5', 'left'],
+    note: 'empty receiver returns the init',
+  },
+
+  { fn: 'flat_map', args: [[[1, 2], [3]], 'self', ''], note: 'self projection spreads one level' },
+  {
+    fn: 'flat_map',
+    args: [[{ t: [1, 2] }, { t: [3] }], 'field', 't'],
+    note: 'array-valued field spreads one level',
+  },
+  {
+    fn: 'flat_map',
+    args: [[{ t: 1 }, { t: 2 }], 'field', 't'],
+    note: 'scalar field values are kept as-is',
+  },
+  {
+    fn: 'flat_map_tuple',
+    args: [[{ a: 1, b: 2 }, { a: 3, b: 4 }], 'field', 'a', 'field', 'b'],
+    note: 'tuple leaves append in order per item',
+  },
+  {
+    fn: 'flat_map_tuple',
+    args: [[{ a: 1 }], 'self', '', 'field', 'a'],
+    note: 'self leaf appends the element itself',
+  },
 ]

--- a/packages/adapter-tests/helper-vectors/vectors.json
+++ b/packages/adapter-tests/helper-vectors/vectors.json
@@ -1689,6 +1689,675 @@
       ],
       "expect": [],
       "note": "all falsy yields []"
+    },
+    {
+      "fn": "every",
+      "args": [
+        [
+          {
+            "done": true
+          },
+          {
+            "done": true
+          }
+        ],
+        "done"
+      ],
+      "expect": true,
+      "note": "all truthy fields"
+    },
+    {
+      "fn": "every",
+      "args": [
+        [
+          {
+            "done": true
+          },
+          {
+            "done": false
+          }
+        ],
+        "done"
+      ],
+      "expect": false,
+      "note": "one falsy field fails"
+    },
+    {
+      "fn": "every",
+      "args": [
+        [],
+        "done"
+      ],
+      "expect": true,
+      "note": "empty receiver is vacuously true"
+    },
+    {
+      "fn": "some",
+      "args": [
+        [
+          {
+            "done": false
+          },
+          {
+            "done": true
+          }
+        ],
+        "done"
+      ],
+      "expect": true,
+      "note": "one truthy field passes"
+    },
+    {
+      "fn": "some",
+      "args": [
+        [
+          {
+            "done": false
+          }
+        ],
+        "done"
+      ],
+      "expect": false,
+      "note": "no truthy field fails"
+    },
+    {
+      "fn": "some",
+      "args": [
+        [],
+        "done"
+      ],
+      "expect": false,
+      "note": "empty receiver is false"
+    },
+    {
+      "fn": "filter",
+      "args": [
+        [
+          {
+            "s": "a",
+            "n": 1
+          },
+          {
+            "s": "b",
+            "n": 2
+          },
+          {
+            "s": "a",
+            "n": 3
+          }
+        ],
+        "s",
+        "a"
+      ],
+      "expect": [
+        {
+          "s": "a",
+          "n": 1
+        },
+        {
+          "s": "a",
+          "n": 3
+        }
+      ],
+      "note": "string field equality keeps matching items"
+    },
+    {
+      "fn": "filter",
+      "args": [
+        [
+          {
+            "s": "a",
+            "n": 1
+          },
+          {
+            "s": "b",
+            "n": 2
+          }
+        ],
+        "n",
+        2
+      ],
+      "expect": [
+        {
+          "s": "b",
+          "n": 2
+        }
+      ],
+      "note": "numeric field equality"
+    },
+    {
+      "fn": "filter",
+      "args": [
+        [
+          {
+            "s": "a"
+          }
+        ],
+        "s",
+        "z"
+      ],
+      "expect": [],
+      "note": "no match yields []"
+    },
+    {
+      "fn": "find",
+      "args": [
+        [
+          {
+            "id": 1,
+            "v": "x"
+          },
+          {
+            "id": 2,
+            "v": "y"
+          }
+        ],
+        "id",
+        2
+      ],
+      "expect": {
+        "id": 2,
+        "v": "y"
+      },
+      "note": "returns the first matching element"
+    },
+    {
+      "fn": "find",
+      "args": [
+        [
+          {
+            "id": 1
+          }
+        ],
+        "id",
+        9
+      ],
+      "expect": null,
+      "note": "no match yields undefined ≡ null"
+    },
+    {
+      "fn": "find_index",
+      "args": [
+        [
+          {
+            "id": 1
+          },
+          {
+            "id": 2
+          },
+          {
+            "id": 2
+          }
+        ],
+        "id",
+        2
+      ],
+      "expect": 1,
+      "note": "first matching index"
+    },
+    {
+      "fn": "find_index",
+      "args": [
+        [
+          {
+            "id": 1
+          }
+        ],
+        "id",
+        9
+      ],
+      "expect": -1,
+      "note": "no match is -1"
+    },
+    {
+      "fn": "find_last",
+      "args": [
+        [
+          {
+            "id": 2,
+            "v": "first"
+          },
+          {
+            "id": 2,
+            "v": "last"
+          }
+        ],
+        "id",
+        2
+      ],
+      "expect": {
+        "id": 2,
+        "v": "last"
+      },
+      "note": "returns the last matching element"
+    },
+    {
+      "fn": "find_last_index",
+      "args": [
+        [
+          {
+            "id": 1
+          },
+          {
+            "id": 2
+          },
+          {
+            "id": 2
+          }
+        ],
+        "id",
+        2
+      ],
+      "expect": 2,
+      "note": "last matching index"
+    },
+    {
+      "fn": "find_last_index",
+      "args": [
+        [
+          {
+            "id": 1
+          }
+        ],
+        "id",
+        9
+      ],
+      "expect": -1,
+      "note": "no match is -1"
+    },
+    {
+      "fn": "sort",
+      "args": [
+        [
+          3,
+          1,
+          2
+        ],
+        "self",
+        "",
+        "numeric",
+        "asc"
+      ],
+      "expect": [
+        1,
+        2,
+        3
+      ],
+      "note": "numeric self ascending"
+    },
+    {
+      "fn": "sort",
+      "args": [
+        [
+          3,
+          1,
+          2
+        ],
+        "self",
+        "",
+        "numeric",
+        "desc"
+      ],
+      "expect": [
+        3,
+        2,
+        1
+      ],
+      "note": "numeric self descending"
+    },
+    {
+      "fn": "sort",
+      "args": [
+        [
+          {
+            "p": 30
+          },
+          {
+            "p": 10
+          },
+          {
+            "p": 20
+          }
+        ],
+        "field",
+        "p",
+        "numeric",
+        "asc"
+      ],
+      "expect": [
+        {
+          "p": 10
+        },
+        {
+          "p": 20
+        },
+        {
+          "p": 30
+        }
+      ],
+      "note": "numeric field key"
+    },
+    {
+      "fn": "sort",
+      "args": [
+        [
+          "banana",
+          "apple",
+          "cherry"
+        ],
+        "self",
+        "",
+        "string",
+        "asc"
+      ],
+      "expect": [
+        "apple",
+        "banana",
+        "cherry"
+      ],
+      "note": "string compare on same-case ASCII"
+    },
+    {
+      "fn": "sort",
+      "args": [
+        [
+          {
+            "p": 2.5
+          },
+          {
+            "p": 1.5
+          }
+        ],
+        "field",
+        "p",
+        "auto",
+        "asc"
+      ],
+      "expect": [
+        {
+          "p": 1.5
+        },
+        {
+          "p": 2.5
+        }
+      ],
+      "note": "auto compare with real numbers"
+    },
+    {
+      "fn": "sort",
+      "args": [
+        [
+          {
+            "a": 1,
+            "b": 2
+          },
+          {
+            "a": 1,
+            "b": 1
+          },
+          {
+            "a": 0,
+            "b": 9
+          }
+        ],
+        "field",
+        "a",
+        "numeric",
+        "asc",
+        "field",
+        "b",
+        "numeric",
+        "asc"
+      ],
+      "expect": [
+        {
+          "a": 0,
+          "b": 9
+        },
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "note": "multi-key tie-break"
+    },
+    {
+      "fn": "sort",
+      "args": [
+        [],
+        "self",
+        "",
+        "numeric",
+        "asc"
+      ],
+      "expect": [],
+      "note": "empty receiver"
+    },
+    {
+      "fn": "reduce",
+      "args": [
+        [
+          1,
+          2,
+          3
+        ],
+        "+",
+        "self",
+        "",
+        "numeric",
+        "0",
+        "left"
+      ],
+      "expect": 6,
+      "note": "sum fold"
+    },
+    {
+      "fn": "reduce",
+      "args": [
+        [
+          2,
+          3,
+          4
+        ],
+        "*",
+        "self",
+        "",
+        "numeric",
+        "1",
+        "left"
+      ],
+      "expect": 24,
+      "note": "product fold"
+    },
+    {
+      "fn": "reduce",
+      "args": [
+        [
+          {
+            "d": 5
+          },
+          {
+            "d": 7
+          }
+        ],
+        "+",
+        "field",
+        "d",
+        "numeric",
+        "10",
+        "left"
+      ],
+      "expect": 22,
+      "note": "field projection with non-zero init"
+    },
+    {
+      "fn": "reduce",
+      "args": [
+        [
+          "a",
+          "b",
+          "c"
+        ],
+        "+",
+        "self",
+        "",
+        "string",
+        "x",
+        "left"
+      ],
+      "expect": "xabc",
+      "note": "string concatenation seeds with init"
+    },
+    {
+      "fn": "reduce",
+      "args": [
+        [
+          "a",
+          "b",
+          "c"
+        ],
+        "+",
+        "self",
+        "",
+        "string",
+        "x",
+        "right"
+      ],
+      "expect": "xcba",
+      "note": "reduceRight is observable for string concat"
+    },
+    {
+      "fn": "reduce",
+      "args": [
+        [],
+        "+",
+        "self",
+        "",
+        "numeric",
+        "5",
+        "left"
+      ],
+      "expect": 5,
+      "note": "empty receiver returns the init"
+    },
+    {
+      "fn": "flat_map",
+      "args": [
+        [
+          [
+            1,
+            2
+          ],
+          [
+            3
+          ]
+        ],
+        "self",
+        ""
+      ],
+      "expect": [
+        1,
+        2,
+        3
+      ],
+      "note": "self projection spreads one level"
+    },
+    {
+      "fn": "flat_map",
+      "args": [
+        [
+          {
+            "t": [
+              1,
+              2
+            ]
+          },
+          {
+            "t": [
+              3
+            ]
+          }
+        ],
+        "field",
+        "t"
+      ],
+      "expect": [
+        1,
+        2,
+        3
+      ],
+      "note": "array-valued field spreads one level"
+    },
+    {
+      "fn": "flat_map",
+      "args": [
+        [
+          {
+            "t": 1
+          },
+          {
+            "t": 2
+          }
+        ],
+        "field",
+        "t"
+      ],
+      "expect": [
+        1,
+        2
+      ],
+      "note": "scalar field values are kept as-is"
+    },
+    {
+      "fn": "flat_map_tuple",
+      "args": [
+        [
+          {
+            "a": 1,
+            "b": 2
+          },
+          {
+            "a": 3,
+            "b": 4
+          }
+        ],
+        "field",
+        "a",
+        "field",
+        "b"
+      ],
+      "expect": [
+        1,
+        2,
+        3,
+        4
+      ],
+      "note": "tuple leaves append in order per item"
+    },
+    {
+      "fn": "flat_map_tuple",
+      "args": [
+        [
+          {
+            "a": 1
+          }
+        ],
+        "self",
+        "",
+        "field",
+        "a"
+      ],
+      "expect": [
+        {
+          "a": 1
+        },
+        1
+      ],
+      "note": "self leaf appends the element itself"
     }
   ]
 }

--- a/spec/template-helpers.md
+++ b/spec/template-helpers.md
@@ -604,3 +604,123 @@ vectors.
 Not in the catalogue: `bf_first` / `bf_last` / `bf_contains` exist in
 the Go FuncMap as conveniences but are never emitted by the compiler;
 they are Go-internal and carry no cross-backend contract.
+
+### Higher-order predicates: canonical projection form
+
+JS closures can't ride in JSON, so the higher-order entries use the
+**compiled projection catalogue** as their canonical argument form —
+the same shapes the JSX parser accepts (anything else refuses with
+BF101 upstream):
+
+- `filter` / `find` / `find_index` / `find_last` / `find_last_index`:
+  `(items, field, value)` ≡ `i => i.field === value`.
+- `every` / `some`: `(items, field)` ≡ `i => i.field` (truthiness).
+
+Field names appear in JS casing (`"done"`, `"price"`). Go resolves
+struct fields via the capitalized convention and map keys via
+case-variant lookup (#1487 — extended to the predicate helpers
+together with this entry, so JSON-decoded `map` items participate
+instead of being silently skipped).
+
+Equality in the predicate follows the `includes` contract: strict on
+JS/Go, `eq`/`==` chosen by operand string-typing on Perl — vectors
+keep field values and probes the same primitive type.
+
+### every / some
+
+| Backend | Lowering |
+|---------|----------|
+| Hono / CSR | native `.every` / `.some` |
+| Go template | `bf_every` / `bf_some` |
+| Mojolicious | inline `!(grep { !(...) })` / `!!(grep { ... })` |
+| Xslate | `$bf.every` / `$bf.some` (Kolon lambda) |
+
+`every([])` is vacuously `true`; `some([])` is `false` (JS parity).
+Field truthiness is JS `Boolean(x)` — the Perl `"0"` divergence from
+`filter_truthy` applies; vectors use boolean fields.
+
+### filter / find / find_index / find_last / find_last_index
+
+| Backend | Lowering |
+|---------|----------|
+| Hono / CSR | native methods |
+| Go template | `bf_filter` / `bf_find` / `bf_find_index` / `bf_find_last` / `bf_find_last_index` |
+| Mojolicious | `filter` inlines to `[grep {...}]`; the find family calls `bf->find` etc. with a closure |
+| Xslate | `$bf.filter` / `$bf.find` / … (Kolon lambda) |
+
+`find`/`find_last` yield the matching element or `undefined` ≡
+`null`; the index forms yield `-1` when absent; `filter` with no
+matches yields `[]`.
+
+### sort
+
+JS `Array.prototype.sort(cmp)` / `.toSorted(cmp)` for the accepted
+comparator catalogue (`a.f - b.f`, `a - b`, `localeCompare`,
+relational ternary, each `||`-chainable for multi-key tie-breaks).
+Canonical args: `(items, kind, name, compareType, direction, …)` —
+one 4-tuple per key, `kind` ∈ `self`/`field`, `compareType` ∈
+`numeric`/`string`/`auto`, `direction` ∈ `asc`/`desc`.
+
+| Backend | Lowering |
+|---------|----------|
+| Hono / CSR | native `.sort(cmp)` |
+| Go template | `bf_sort` (variadic 4-tuples) |
+| Mojolicious / Xslate | `bf->sort($recv, { keys => [...] })` |
+
+Rules:
+
+- Non-mutating on the template backends; stable.
+- **Documented divergence** (`string`): JS `localeCompare` is
+  ICU-collated (case-insensitive-ish: `"a" < "B"`); Go
+  `strings.Compare` and Perl `cmp` are byte order. Vectors use
+  same-case ASCII keys.
+- **Documented divergence** (`auto`): both template backends compare
+  numerically when both keys `looks_like_number`; JS relational `>`
+  compares numeric *strings* lexically. Vectors use real numbers or
+  non-numeric strings.
+
+### reduce
+
+JS `reduce((acc, x) => acc <op> x[.field], init)` /
+`reduceRight(...)`. Canonical args:
+`(items, op, key_kind, key, type, init, direction)` with `op` ∈
+`+`/`*`, `type` ∈ `numeric`/`string`, `init` as a string (the
+compiler emits the decoded seed), `direction` ∈ `left`/`right`.
+
+| Backend | Lowering |
+|---------|----------|
+| Hono / CSR | native `.reduce` / `.reduceRight` |
+| Go template | `bf_reduce` |
+| Mojolicious / Xslate | `bf->reduce($recv, { op => …, … })` |
+
+Rules:
+
+- Empty receiver returns the init unchanged.
+- `direction` is only observable for string concatenation (numeric
+  folds commute).
+- **Documented divergences** (mirroring `sort`'s `auto` caveat):
+  numeric-*string* keys fold numerically on the template backends but
+  string-concatenate in JS; float stringification differences apply
+  to string folds of inexact sums. Vectors use genuine numbers /
+  plain strings.
+
+### flat_map / flat_map_tuple
+
+JS `Array.prototype.flatMap(fn)` for the projection catalogue:
+`i => i` / `i => i.field` (canonical `(items, kind, name)`), and the
+array-literal tuple form `i => [i.a, i.b]` (canonical
+`(items, kind1, name1, kind2, name2, …)`).
+
+| Backend | Lowering |
+|---------|----------|
+| Hono / CSR | native `.flatMap` |
+| Go template | `bf_flat_map` / `bf_flat_map_tuple` |
+| Mojolicious / Xslate | `bf->flat_map` / `bf->flat_map_tuple` (pair arrayrefs) |
+
+Rules:
+
+- `flatMap` = map + `flat(1)`: a projected array value spreads one
+  level for the scalar form; the tuple form appends each leaf
+  verbatim (the `flat(1)` only removes the literal wrapper).
+- A `field` projection of a non-object element yields `undefined` ≡
+  `null` (matches `getFieldValue` returning nil).


### PR DESCRIPTION
**Stacked on #1888** (arrays). Final PR in the stack — this completes the catalogue for every helper the compiler emits.

Adds the higher-order surface: `every`/`some`, `filter`/`find`/`find_index`/`find_last`/`find_last_index` (canonical projection form `(items, field, value)` ≡ `i => i.field === value`, since closures can't ride in JSON), `sort` (multi-key 4-tuple spec), `reduce` (arithmetic-fold catalogue incl. `reduceRight` string concat), `flat_map`, `flat_map_tuple`. 34 new vectors, **197 total**, green on all three harnesses; the JS references run the real `Array.prototype` methods over predicates rebuilt from the projections.

**Go runtime change** (review focus): the predicate helpers (`Every`/`Some`/`Filter`/`Find*`) previously resolved fields with struct-only `FieldByName` and **silently skipped map items** — JSON-decoded data never matched. They now project via `getFieldValue`, the same dual struct/map path `Sort`/`Reduce` gained in #1487. Two behavior refinements ride along, both toward JS parity:
- map items participate (previously skipped);
- `Every`/`Some` apply JS `Boolean(x)` truthiness to the projected field (previously only bool-typed struct fields counted; e.g. a missing field now fails `every` instead of passing it).

Full `go test ./...` (including the pre-existing struct-based `bf_test.go` cases) passes unchanged.

Documented divergences excluded from the vector domain: ICU `localeCompare` vs byte-order comparison (vectors use same-case ASCII), numeric-string keys under `sort`'s `auto` compare / `reduce`'s numeric fold (template backends fold numerically, JS concatenates/compares lexically).

https://claude.ai/code/session_01VcfG8tUF8e5mRpccw38xZq

---
_Generated by [Claude Code](https://claude.ai/code/session_01VcfG8tUF8e5mRpccw38xZq)_