### PR TITLE
feat(client): subtree-scoped re-hydration + precise per-scope disposal

### DIFF
--- a/.changeset/scoped-hydrate.md
+++ b/.changeset/scoped-hydrate.md
@@ -1,0 +1,9 @@
+---
+"@barefootjs/client": minor
+---
+
+Add subtree-scoped re-hydration and precise per-scope disposal to the runtime.
+
+- `rehydrateScope(root)` runs a synchronous hydration walk over just `root`'s subtree (cost O(scopes in `root`)), beside the existing whole-document `rehydrateAll()`. Lets a caller that knows which region changed — a client router after a content swap, a streaming chunk, a conditional/loop that just inserted a branch — hydrate only that region instead of re-walking the document.
+- `disposeScope(root)` tears down the reactive graphs (effects, memos, `onCleanup`) of every scope inside `root`. Each scope's `init` now runs inside a `createRoot` so its bindings have a disposable owner. This is additive: nothing disposes a root unless `disposeScope` is called, so existing component lifetimes are unchanged.
+- Both are exposed on `window` via `setupStreaming` as `__bf_hydrate_within` / `__bf_dispose_within`.

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -57,6 +57,7 @@
         "packages/client/src/index.ts",
         "packages/client/src/runtime/index.ts",
         "packages/client/src/runtime/insert.ts",
+        "packages/client/src/runtime/hydrate.ts",
         "packages/client/src/runtime/map-array.ts",
         "packages/client/src/runtime/component.ts",
         "packages/client/src/runtime/apply-rest-attrs.ts",

--- a/packages/client/__tests__/runtime/scoped-hydrate.test.ts
+++ b/packages/client/__tests__/runtime/scoped-hydrate.test.ts
@@ -95,3 +95,30 @@ test('disposeScope allows the same element to be re-hydrated later', () => {
   rehydrateScope(root)
   expect(inits).toBe(2)
 })
+
+test('disposeScope resets comment-scope flags so the same nodes re-hydrate', () => {
+  let inits = 0
+  hydrate('SCmtScope', {
+    name: 'SCmtScope',
+    comment: true,
+    init: () => {
+      inits += 1
+    },
+  })
+  flushHydration()
+
+  // A comment-rooted scope: <!--bf-scope:Name_id--> + a proxy element.
+  const root = mount('<div id="c"><!--bf-scope:SCmtScope_1--><div class="proxy"></div></div>')
+  rehydrateScope(root)
+  expect(inits).toBe(1)
+
+  // A second walk without disposal must not re-init.
+  rehydrateScope(root)
+  expect(inits).toBe(1)
+
+  // disposeScope must clear the comment's __bfInitialized flag (not just the
+  // proxy element's mark) so re-hydration re-runs init.
+  disposeScope(root)
+  rehydrateScope(root)
+  expect(inits).toBe(2)
+})

--- a/packages/client/__tests__/runtime/scoped-hydrate.test.ts
+++ b/packages/client/__tests__/runtime/scoped-hydrate.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Subtree-scoped re-hydration + disposal (P0 for the IR-driven router).
+ *
+ * - `rehydrateScope(root)` inits only the scopes inside `root` (O(root)),
+ *   not the whole document like `rehydrateAll()`.
+ * - `disposeScope(root)` tears down those scopes' reactive graphs, so a
+ *   router can release the islands leaving a page instead of leaking.
+ */
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import { createSignal, createEffect } from '../../src/reactive'
+import { hydrate, rehydrateScope, disposeScope, flushHydration } from '../../src/runtime/hydrate'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') GlobalRegistrator.register()
+})
+
+beforeEach(() => {
+  document.body.innerHTML = ''
+})
+
+function mount(html: string): HTMLElement {
+  const host = document.createElement('div')
+  host.innerHTML = html
+  document.body.appendChild(host)
+  return host
+}
+
+test('rehydrateScope inits only the scopes inside the given root', () => {
+  const seen: string[] = []
+  hydrate('SWidget', {
+    name: 'SWidget',
+    init: (scope) => {
+      seen.push(scope.getAttribute('bf-s')!)
+    },
+  })
+  // Drain the walk that hydrate() scheduled so it can't hydrate our DOM.
+  flushHydration()
+
+  const a = mount('<div id="a"><div bf-s="SWidget_a1"></div></div>')
+  mount('<div id="b"><div bf-s="SWidget_b2"></div></div>')
+
+  rehydrateScope(a)
+
+  // Only the scope inside `a` was initialized.
+  expect(seen).toEqual(['SWidget_a1'])
+})
+
+test('disposeScope tears down a scope effect so it stops reacting', () => {
+  const [n, setN] = createSignal(0)
+  hydrate('SCounter', {
+    name: 'SCounter',
+    init: (scope) => {
+      createEffect(() => {
+        scope.textContent = String(n())
+      })
+    },
+  })
+  flushHydration()
+
+  const root = mount('<section id="r"><div bf-s="SCounter_x"></div></section>')
+  const el = root.querySelector('[bf-s]')!
+
+  rehydrateScope(root)
+  expect(el.textContent).toBe('0')
+
+  setN(1)
+  expect(el.textContent).toBe('1') // effect is live
+
+  disposeScope(root)
+  setN(2)
+  expect(el.textContent).toBe('1') // disposed — effect no longer runs
+})
+
+test('disposeScope allows the same element to be re-hydrated later', () => {
+  let inits = 0
+  hydrate('SReinit', {
+    name: 'SReinit',
+    init: () => {
+      inits += 1
+    },
+  })
+  flushHydration()
+
+  const root = mount('<div id="re"><div bf-s="SReinit_1"></div></div>')
+  rehydrateScope(root)
+  expect(inits).toBe(1)
+
+  // Without disposal, a second walk must NOT re-init (hydratedScopes guard).
+  rehydrateScope(root)
+  expect(inits).toBe(1)
+
+  // After disposal the mark is cleared, so it can hydrate again.
+  disposeScope(root)
+  rehydrateScope(root)
+  expect(inits).toBe(2)
+})

--- a/packages/client/src/runtime/hydrate.ts
+++ b/packages/client/src/runtime/hydrate.ts
@@ -218,15 +218,32 @@ export function rehydrateScope(root: Element): void {
  * content region, so the outgoing islands release timers/listeners/
  * subscriptions instead of leaking.
  *
- * Also clears the `hydratedScopes` mark so the same element could be
- * re-hydrated if it is ever re-inserted.
+ * Also resets the per-scope hydration marks so the *same* DOM nodes could
+ * be re-hydrated if they are ever re-inserted:
+ *   - element scopes: their `hydratedScopes` entry (via `disposeOneScope`),
+ *   - `bf-h` child scopes: their `hydratedScopes` entry (they have no own
+ *     disposer — their reactive graph is owned by an ancestor root being
+ *     disposed here),
+ *   - comment scopes: the `__bfInitialized` flag on the `<!--bf-scope:-->`
+ *     anchor (otherwise `hydrateCommentScope` short-circuits on the stale
+ *     flag and never re-initializes the scope).
  */
 export function disposeScope(root: Element): void {
   if (typeof document === 'undefined') return
   disposeOneScope(root)
-  const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT)
+  clearChildScopeMark(root)
+  const walker = document.createTreeWalker(
+    root,
+    NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_COMMENT,
+  )
   while (walker.nextNode()) {
-    disposeOneScope(walker.currentNode as Element)
+    const node = walker.currentNode
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      disposeOneScope(node as Element)
+      clearChildScopeMark(node as Element)
+    } else if (node.nodeType === Node.COMMENT_NODE) {
+      clearCommentScopeFlag(node as Comment)
+    }
   }
 }
 
@@ -237,6 +254,28 @@ function disposeOneScope(el: Element): void {
     hydratedScopes.delete(el)
     dispose()
   }
+}
+
+/**
+ * `bf-h` child scopes are initialized via `initChild` (not the walker), so
+ * they carry a `hydratedScopes` mark but no own disposer — their effects
+ * belong to an ancestor root that `disposeScope` is tearing down. Clear the
+ * mark so the same node can re-init if re-inserted.
+ */
+function clearChildScopeMark(el: Element): void {
+  if (el.hasAttribute(BF_HOST)) hydratedScopes.delete(el)
+}
+
+/**
+ * Comment-rooted scopes flag their init on the `<!--bf-scope:-->` comment
+ * node (`__bfInitialized`); the proxy element's `hydratedScopes` entry and
+ * disposer are cleared by `disposeOneScope`, but the comment flag must be
+ * reset here or re-hydration short-circuits.
+ */
+function clearCommentScopeFlag(comment: Comment): void {
+  if (!comment.nodeValue?.startsWith(BF_SCOPE_COMMENT_PREFIX)) return
+  const flagged = comment as unknown as { __bfInitialized?: boolean }
+  if (flagged.__bfInitialized) flagged.__bfInitialized = false
 }
 
 /**

--- a/packages/client/src/runtime/hydrate.ts
+++ b/packages/client/src/runtime/hydrate.ts
@@ -43,6 +43,7 @@ import { hydratedScopes } from './hydration-state.ts'
 import { registerComponent } from './registry.ts'
 import { registerTemplate } from './template.ts'
 import { BF_SCOPE, BF_PROPS, BF_HOST, BF_SCOPE_COMMENT_PREFIX } from '@barefootjs/shared'
+import { createRoot } from '@barefootjs/client/reactive'
 import type { ComponentDef } from './types.ts'
 
 /**
@@ -186,6 +187,59 @@ export function flushHydration(): void {
 }
 
 /**
+ * Re-hydrate only the scopes inside `root` (and `root` itself), in
+ * document order. Unlike `rehydrateAll()` — which schedules a walk over
+ * the *whole document* — this is a synchronous, subtree-scoped walk: its
+ * cost is O(scopes in `root`), not O(document).
+ *
+ * Intended for a client router that has just swapped a content region:
+ * the component registry is already populated from the initial load, so
+ * no deferral is needed; only the freshly inserted islands need to init.
+ */
+export function rehydrateScope(root: Element): void {
+  if (typeof document === 'undefined') return
+  // The TreeWalker visits descendants only, so handle the root itself first.
+  hydrateElementScope(root)
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_COMMENT)
+  while (walker.nextNode()) {
+    const node = walker.currentNode
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      hydrateElementScope(node as Element)
+    } else if (node.nodeType === Node.COMMENT_NODE) {
+      hydrateCommentScope(node as Comment)
+    }
+  }
+}
+
+/**
+ * Dispose every hydrated scope inside `root` (and `root` itself): runs
+ * each scope's `createRoot` dispose fn, tearing down its effects, memos,
+ * and `onCleanup` callbacks. Used by a client router before it removes a
+ * content region, so the outgoing islands release timers/listeners/
+ * subscriptions instead of leaking.
+ *
+ * Also clears the `hydratedScopes` mark so the same element could be
+ * re-hydrated if it is ever re-inserted.
+ */
+export function disposeScope(root: Element): void {
+  if (typeof document === 'undefined') return
+  disposeOneScope(root)
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT)
+  while (walker.nextNode()) {
+    disposeOneScope(walker.currentNode as Element)
+  }
+}
+
+function disposeOneScope(el: Element): void {
+  const dispose = scopeDisposers.get(el)
+  if (dispose) {
+    scopeDisposers.delete(el)
+    hydratedScopes.delete(el)
+    dispose()
+  }
+}
+
+/**
  * Single document-order walk visiting element scopes (`[bf-s]`) and
  * comment scopes (`<!--bf-scope:Name_xxx-->`) interleaved by their
  * actual DOM position. The parent's init — whichever scope shape it
@@ -232,10 +286,29 @@ function parseProps(json: string | null, where: string): Record<string, unknown>
   }
 }
 
+/**
+ * Per-scope disposal registry. Each scope's `init` runs inside a
+ * `createRoot`, so all the effects/memos it (and its `initChild`-mounted
+ * descendants) create are owned by one root. `disposeScope(root)` calls
+ * the stored dispose fn to tear them down — enabling a client router to
+ * release the islands leaving the page precisely, instead of leaking
+ * timers/listeners or relying on GC (see `disposeScope`).
+ *
+ * Keyed by the scope element; a `WeakMap` so detached scopes are
+ * reclaimed even if `disposeScope` is never called.
+ */
+const scopeDisposers = new WeakMap<Element, () => void>()
+
 function runInit(scope: Element, def: ComponentDef, props: Record<string, unknown>): void {
   const prevScope = setCurrentScope(scope)
   try {
-    def.init(scope, props)
+    // Wrap in createRoot so the scope's reactive graph has an owner that
+    // can be disposed later. This is additive: nothing disposes the root
+    // unless `disposeScope` is called, so existing lifetimes are unchanged.
+    createRoot((dispose) => {
+      scopeDisposers.set(scope, dispose)
+      def.init(scope, props)
+    })
   } finally {
     setCurrentScope(prevScope)
   }

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -92,7 +92,7 @@ export { styleToCss } from './style.ts'
 
 // Runtime helpers
 export { findScope, find, $, $c, $t, qsa, qsaChildScope, qsaChildScopes, cssEscape } from './query.ts'
-export { hydrate, rehydrateAll, flushHydration, getRegisteredDef } from './hydrate.ts'
+export { hydrate, rehydrateAll, rehydrateScope, disposeScope, flushHydration, getRegisteredDef } from './hydrate.ts'
 export { registerComponent, getComponentInit, initChild, upsertChild } from './registry.ts'
 export { insert, type BranchConfig, type BranchTemplateResult } from './insert.ts'
 export { __bfSlot } from './branch-slot.ts'

--- a/packages/client/src/runtime/streaming.ts
+++ b/packages/client/src/runtime/streaming.ts
@@ -14,7 +14,7 @@
  */
 
 import { BF_ASYNC, BF_ASYNC_RESOLVE } from '@barefootjs/shared'
-import { rehydrateAll } from './hydrate.ts'
+import { rehydrateAll, rehydrateScope, disposeScope } from './hydrate.ts'
 
 /**
  * Swap a streaming fallback placeholder with its resolved content.
@@ -52,7 +52,11 @@ export function __bf_swap(id: string): void {
  * Makes `__bf_swap` available as `window.__bf_swap` so that inline
  * `<script>__bf_swap("a0")</script>` tags in streaming chunks can call it.
  *
- * Also exposes `window.__bf_hydrate` for manual re-hydration triggers.
+ * Also exposes re-hydration / disposal seams for an out-of-tree client
+ * router (`@barefootjs/router`):
+ *   - `window.__bf_hydrate`        — re-hydrate the whole document
+ *   - `window.__bf_hydrate_within` — re-hydrate only a swapped subtree
+ *   - `window.__bf_dispose_within` — dispose the islands in a subtree
  *
  * Call this once, early in the page (before any streaming chunks arrive).
  */
@@ -62,4 +66,6 @@ export function setupStreaming(): void {
   const w = window as unknown as Record<string, unknown>
   w.__bf_swap = __bf_swap
   w.__bf_hydrate = rehydrateAll
+  w.__bf_hydrate_within = rehydrateScope
+  w.__bf_dispose_within = disposeScope
 }


### PR DESCRIPTION
## What

Two additive capabilities for the `@barefootjs/client` runtime. This is a **general runtime improvement, independent of any router** — extracted from the router exploration (PRs #1889/#1891) because it stands on its own and benefits multiple subsystems.

### 1. `rehydrateScope(root)` — subtree-scoped hydration
Today `rehydrateAll()` schedules `walkAllInDocumentOrder()`, which runs `document.createTreeWalker(document, …)` over the **whole document** on every call — cost O(total DOM), even when a small region changed.

`rehydrateScope(root)` runs a synchronous hydration walk over just `root`'s subtree (handles `root` itself + descendants), reusing the same per-node init logic. Cost O(scopes in `root`). Synchronous because by the time it's called the component registry is already populated.

### 2. `disposeScope(root)` — precise per-scope disposal
Each scope's `init` now runs inside a `createRoot`, so the effects/memos it (and its `initChild`-mounted descendants) create have a disposable owner; the dispose fn is stored in a `WeakMap<Element, () => void>`. `disposeScope(root)` walks `root` + descendants and runs each scope's dispose (tearing down effects/memos/`onCleanup`), and clears the `hydratedScopes` mark so an element can re-hydrate if re-inserted.

**Additive & safe:** nothing disposes a root unless `disposeScope` is called, so existing component lifetimes are unchanged.

Both are exposed on `window` via `setupStreaming` as `__bf_hydrate_within` / `__bf_dispose_within`.

## Why it's general (not router-specific)

This gives the runtime a proper **subtree lifecycle** (hydrate a region / dispose a region) for the first time at top-level-scope granularity. Consumers:

- **Client router** (PR #1889): O(document) → O(outlet) re-hydration; leak-free disposal of the islands leaving a page.
- **Loops** already do per-item `createRoot` disposal (`map-array.ts`); this generalises the same pattern to top-level scopes.
- **Conditionals / streaming swaps** can dispose a replaced branch / fallback precisely.

## Bench (motivation)

From the router exploration's `bench.ts` (happy-dom, growing shell, fixed 8-island outlet): a whole-document walk grows O(document) — `0.13ms → 9.5ms` from 50 → 4000 shell nodes — while a subtree walk stays flat at ~`0.01ms`. The scaling is engine-independent.

## Tests

`packages/client/__tests__/runtime/scoped-hydrate.test.ts` — subtree-only hydration, effect teardown on dispose, re-hydration after dispose. Full client suite (360) and adapter CSR conformance (722) stay green; typecheck clean.

## Stacking

This is the base of the router exploration stack: **#1889** (router prototype) is stacked on this PR, and **#1891** (reference app + design) on #1889.

https://claude.ai/code/session_01SAkUPtiKEw2m6xKggAjNj2

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAkUPtiKEw2m6xKggAjNj2)_