### PR TITLE
chore: snapshot housekeeping — linguist-generated + ui/demo source-root triggers (#1467)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Frozen fixture-hydrate snapshots (#1467): every file under
+# `__snapshots__/` is machine-written — by
+# `packages/adapter-tests/scripts/snapshot.ts` locally and by the
+# update-fixtures workflow in CI — from the fixture spec + component
+# sources. Mark them generated so PR diffs collapse them by default and
+# they stay out of language stats. Intentionally NOT `-diff`/binary:
+# when the compiler changes, the snapshot diff is the review signal
+# (expected output change vs regression), so it must stay expandable.
+packages/adapter-tests/fixtures/__snapshots__/** linguist-generated=true

--- a/.github/workflows/update-fixtures.yml
+++ b/.github/workflows/update-fixtures.yml
@@ -12,6 +12,14 @@ on:
       # Shared-component fixture sources (fixture-hydrate corpus inputs).
       # Editing a `*.tsx` here regenerates the `__snapshots__/<id>.{html,client.js}` pair.
       - 'integrations/shared/components/**'
+      # #1467 Phase 2 source roots: `ui` fixtures lift from
+      # `ui/components/ui/<name>/index.tsx` and `demo` fixtures from
+      # `site/ui/components/<name>.tsx` (sibling graphs live under the ui
+      # root). Editing either must regenerate the frozen snapshots — the
+      # Hono SSR conformance comparison would otherwise go red with no
+      # auto-fix run to repair it.
+      - 'ui/components/ui/**'
+      - 'site/ui/components/**'
       # Fixture spec files (adding a new fixture, changing its props, or
       # adjusting `componentName` / `sourceFile` / `additionalComponents`
       # changes the snapshot output).


### PR DESCRIPTION
## Summary

Two housekeeping follow-ups to the #1467 Phase 2 corpus, surfaced while reviewing how the snapshot pipeline is maintained.

## 1. Auto-update workflow: missing source-root triggers

`update-fixtures.yml`'s path triggers predate the `ui` / `demo` source roots — editing `ui/components/ui/**` or `site/ui/components/**` (the sources every Phase 2a–2e fixture is lifted from, including the transitive sibling graphs) never ran the regeneration job. The frozen snapshots would silently go stale until the Hono SSR conformance comparison (which renders the source live against the frozen `expectedHtml`) failed — correctly red, but with no auto-fix run to repair it. Both roots now trigger the workflow.

## 2. `.gitattributes`: snapshots are `linguist-generated`

Everything under `packages/adapter-tests/fixtures/__snapshots__/` is machine-written — `scripts/snapshot.ts` locally, the update-fixtures workflow in CI — from the hand-written fixture spec + component sources. Marking the tree `linguist-generated=true`:

- collapses them by default in PR review (still expandable), which matters now that they dominate fixture PRs (+24k lines on #1900, mostly snapshot bytes);
- keeps them out of language stats.

Deliberately **not** `-diff`/binary: a snapshot diff is the review signal when compiler output changes (expected output change vs regression), so it must stay inspectable both on GitHub and in local `git diff`. The hand-written `fixtures/<id>.ts` specs are unaffected (verified with `git check-attr`).

## Verification

- `yaml.safe_load` parses the workflow.
- `git check-attr linguist-generated` → `true` for `__snapshots__/command.client.js` / `button.slot.ssr.tsx`, `unspecified` for `fixtures/command.ts`.

https://claude.ai/code/session_01SLhVU7vHcwmDiQNFu8LG1y

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLhVU7vHcwmDiQNFu8LG1y)_