### PR TITLE
feat(adapter-go-template): render JSX children of imported components (#1896)

### DIFF
--- a/.changeset/go-children-plumbing.md
+++ b/.changeset/go-children-plumbing.md
@@ -1,0 +1,10 @@
+---
+"@barefootjs/go-template": minor
+---
+
+JSX children passed to imported child components now render on Go (#1896) instead of silently dropping. Action-bearing children (nested components, dynamic text) lower to a per-call-site companion define executed with the parent's data and injected into the child's props:
+
+- New runtime helpers: `bf.TemplateFuncMap(t)` (provides `bf_tmpl`, a closure over the executing template set — register it alongside `bf.FuncMap()` before parsing) and `bf.WithChildren` (registered as `bf_with_children`).
+- The adapter emits `{{template "Child" (bf_with_children .ChildSlotN (bf_tmpl "<Parent>__children_<slot>" .))}}` for such call sites, and collects component instances / keyed loops nested inside children onto the parent's props.
+
+A long tail of codegen fixes rode along, surfaced by the composed `site/ui` demo corpus (all verified to byte parity with the Hono reference): multi-component-file `restPropsName` staleness in `generateTypes` (`in.Props undefined`), memo-vs-prop struct field collisions (`ClassName redeclared`), reference-typed zero values (`0` into `map`/`bool` fields), compile-time resolution of module-const record lookups (`strokePaths['chevron-down']`, `variantClasses.ghost`) and literal consts, template-literal ternary double-wrapping (`{{{{if`), parenthesised compound args (`eq (or .X "top") "left"`, `bf_string (…)`), string-tolerant equality (`eq (bf_string .Sorted) "asc"` for union-typed props), ARIA presence attributes rendering as `aria-x="true"`, and `attr={cond ? value : undefined}` omitting the attribute like Hono.

--- a/.changeset/jsx-augment-template-parts.md
+++ b/.changeset/jsx-augment-template-parts.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/jsx": patch
+---
+
+`augmentInheritedPropAccesses` (shared by the Go and Mojo adapters) now sees `props.X` reads inside template-literal attribute *parts* and inside if-statement/conditional branches. Previously a `className={`… ${props.className ?? ''}`}` or an asChild early-return branch could reference a prop in the emitted template that the generated props type never declared.

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -105,6 +105,12 @@ func FuncMap() template.FuncMap {
 		// Portal HTML rendering (parses and executes template string)
 		"bfPortalHTML": PortalHTML,
 
+		// JSX children passed to an imported child component (#1896):
+		// the parent renders the children fragment via a companion
+		// define (executed through bf_tmpl from TemplateFuncMap) and
+		// injects the result into the child's Children field.
+		"bf_with_children": WithChildren,
+
 		// Scope comment for fragment roots
 		"bfScopeComment": ScopeComment,
 
@@ -1640,6 +1646,67 @@ func ScopeComment(props interface{}) (template.HTML, error) {
 		propsJSON = "|" + string(pJSON)
 	}
 	return template.HTML("<!--bf-scope:" + scopeID + hostSegment + propsJSON + "-->"), nil
+}
+
+// TemplateFuncMap returns the helpers that need access to the executing
+// template set itself, closed over the *template.Template the component
+// defines are parsed into. Register it alongside FuncMap BEFORE parsing:
+//
+//	t := template.New("")
+//	t.Funcs(bf.FuncMap()).Funcs(bf.TemplateFuncMap(t))
+//	template.Must(t.Parse(src))
+//
+// bf_tmpl executes a named define from the same set and returns its
+// output — used for the per-call-site children defines the Go adapter
+// emits when JSX children passed to an imported component contain
+// template actions (nested components, dynamic text) and therefore
+// cannot be baked to a static HTML string (#1896). Reentrant execution
+// of an html/template set from inside a FuncMap function is safe: the
+// escape analysis over every define completes before the outer
+// Execute begins evaluating.
+func TemplateFuncMap(t *template.Template) template.FuncMap {
+	return template.FuncMap{
+		"bf_tmpl": func(name string, data interface{}) (template.HTML, error) {
+			var buf bytes.Buffer
+			if err := t.ExecuteTemplate(&buf, name, data); err != nil {
+				return "", err
+			}
+			return template.HTML(buf.String()), nil
+		},
+	}
+}
+
+// WithChildren returns a shallow copy of a component Props struct with its
+// Children field replaced by the given pre-rendered fragment (#1896). The
+// props value stays by-value semantics: callers' originals are untouched.
+// A props type without a Children field passes through unchanged — the
+// child template then simply has no children to render, matching the
+// pre-#1896 behaviour.
+func WithChildren(props interface{}, children template.HTML) (interface{}, error) {
+	v := reflect.ValueOf(props)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return props, nil
+	}
+	field := v.FieldByName("Children")
+	if !field.IsValid() {
+		return props, nil
+	}
+	copyPtr := reflect.New(v.Type())
+	copyPtr.Elem().Set(v)
+	target := copyPtr.Elem().FieldByName("Children")
+	switch {
+	case target.Kind() == reflect.Interface:
+		target.Set(reflect.ValueOf(children))
+	case target.Kind() == reflect.String:
+		// Covers both `string` and `template.HTML`-typed fields.
+		target.SetString(string(children))
+	default:
+		return props, fmt.Errorf("bf_with_children: unsupported Children field type %s", target.Type())
+	}
+	return copyPtr.Elem().Interface(), nil
 }
 
 // PortalHTML parses and executes a template string with the provided data.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -2141,6 +2141,22 @@ export function V({ variant }: { variant: 'a' | 'b' }) {
       expect(goCode).toContain('case "b": return "class-b"')
     })
 
+    test('string-tolerant eq keeps a compound operand grouped (#1903 review)', () => {
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+export function T(props: { placement?: 'top' | 'left' }) {
+  return <div data-side={(props.placement ?? 'top') === 'left' ? 'l' : 'o'}>x</div>
+}
+`, adapter)
+      const out = adapter.generate(ir)
+      // The non-literal side routes through bf_string as ONE argument:
+      // `(bf_string (or .Placement "top"))`. Stripping the inner parens
+      // would hand the parser three arguments and fail at runtime with
+      // `bf_string: want 1 got 3`.
+      expect(out.template).toContain('eq (bf_string (or .Placement "top")) "left"')
+      expect(out.template).not.toContain('bf_string or ')
+    })
+
     test('intermediate-const composition (Button shape) carries through', () => {
       const adapter = new GoTemplateAdapter()
       const ir = compileToIR(`

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -35,47 +35,20 @@ runAdapterConformanceTests({
   // `BF104` at build time instead of silently emitting invalid
   // template syntax (#1266).
   // JSX-render skips: every other shared conformance fixture renders to
-  // Hono parity on real Go. Shapes the adapter intentionally refuses at
+  // Hono parity on real Go — including the composed `site/ui` demo
+  // corpus (#1467 / #1896): JSX children passed to imported components
+  // now render through per-call-site companion defines executed via
+  // `bf_tmpl` + `bf_with_children` (see the bf runtime's
+  // `TemplateFuncMap`). Shapes the adapter intentionally refuses at
   // build time are pinned in `expectedDiagnostics` below.
   //
-  // `radio-group` (#1467 demo corpus): the adapter drops JSX children
-  // passed to an *imported* child component — the generated constructor
-  // builds `RadioGroupSlot3` without children, so the radiogroup
-  // container renders empty (silently) instead of Hono's inline items.
-  // Cross-adapter parity for the composed `site/ui` demo corpus is the
-  // #1467 Phase 3 follow-up; see
-  // https://github.com/piconic-ai/barefootjs/issues/1896. Hono SSR
-  // conformance + the real-browser fixture-hydrate layer keep the
-  // fixture fully covered.
-  // `accordion` / `tabs` (#1467 demo corpus): beyond the children gap,
-  // their `{ className = '', ...props }` destructure-with-rest shape
-  // breaks the merged constructor emission (`in.Props undefined`,
-  // `ClassName redeclared`). Same Phase 3 bucket, same issue.
-  // `dialog` / `popover` / `tooltip` (#1467 Phase 2c overlay): same
-  // Phase 3 bucket — dialog hits the destructure-with-rest constructor
-  // emission (`in.Props undefined` for DialogHeader/Title/…), popover
-  // renders but diverges from Hono, and tooltip's generated template
-  // fails Go's template parse (`unexpected "{" in command`).
-  // `select` / `dropdown-menu` / `combobox` / `command` (#1467 Phase
-  // 2d): same Phase 3 bucket again — destructure-with-rest constructor
-  // emission (`in.Props undefined`) and generated-template parse
-  // failures (`unexpected "{" in command`).
-  skipJsx: [
-    'radio-group',
-    'accordion',
-    'tabs',
-    'dialog',
-    'popover',
-    'tooltip',
-    'select',
-    'dropdown-menu',
-    'combobox',
-    'command',
-    // `pagination` / `data-table` (#1467 Phase 2e): same Phase 3 bucket
-    // (constructor emission / template parse on the composed shapes).
-    'pagination',
-    'data-table',
-  ],
+  // `data-table` is the one remaining #1896 gap: its table body is a
+  // keyed `.map` over a `/* @client */`-sorted MEMO whose data is a
+  // module-const object array — a memo-derived dynamic loop of imported
+  // components, which the nested-component slice constructor can't bake
+  // yet (`item.ID` is on the loop datum, not the child's Input). Full
+  // coverage remains at the Hono SSR + fixture-hydrate layers.
+  skipJsx: ['data-table'],
   // Per-fixture build-time contracts for shapes the Go template
   // adapter intentionally refuses to lower. Lives here (not on the
   // shared fixtures) so adding a new adapter doesn't require touching
@@ -2157,9 +2130,13 @@ export function V({ variant }: { variant: 'a' | 'b' }) {
       // The ClassName field MUST be set on the SlotInput literal.
       expect(goCode).toContain('ClassName:')
       // The IIFE shape: a self-invoking func that switches on the
-      // variant key and returns the matching case.
+      // variant key and returns the matching case. The switch key goes
+      // through `fmt.Sprint` (not a `.(string)` assertion) so it
+      // compiles for both `interface{}`-typed fields and the `string`
+      // fields the shared inherited-prop augmentation synthesises
+      // (#1896).
       expect(goCode).toContain('func() string {')
-      expect(goCode).toContain('in.Variant.(string)')
+      expect(goCode).toContain('switch fmt.Sprint(in.Variant)')
       expect(goCode).toContain('case "a": return "class-a"')
       expect(goCode).toContain('case "b": return "class-b"')
     })

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -412,7 +412,11 @@ function wrapGoArg(arg: string): string {
 function stringTolerantEqOperands(l: string, r: string): [string, string] {
   const isStrLit = (x: string) => /^"(?:[^"\\]|\\.)*"$/.test(x)
   if (isStrLit(l) === isStrLit(r)) return [l, r]
-  const wrap = (x: string) => (isStrLit(x) ? x : `(bf_string ${wrapGoArg(x).replace(/^\((.*)\)$/, '$1')})`)
+  // Keep `wrapGoArg`'s parentheses: a compound operand must reach
+  // `bf_string` as ONE argument — `(bf_string (or .Placement "top"))`,
+  // not `(bf_string or .Placement "top")` (which the template parser
+  // reads as three arguments and fails at runtime).
+  const wrap = (x: string) => (isStrLit(x) ? x : `(bf_string ${wrapGoArg(x)})`)
   return [wrap(l), wrap(r)]
 }
 

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -388,13 +388,41 @@ function buildUnsupportedSuggestion(support: SupportResult): string {
   return `${support.reason}\n\n${GO_REMEDIATION_OPTIONS}`
 }
 
+/**
+ * Parenthesize a compound Go template argument (`or .Checked false`) so a
+ * primitive call reads it as ONE argument — unwrapped, the parser splits
+ * it into three and `bf_string` fails with "want 1 got 3" (#1896,
+ * DropdownMenuCheckboxItem's `String(props.checked ?? false)`).
+ */
+function wrapGoArg(arg: string): string {
+  if (!/\s/.test(arg)) return arg
+  if (arg.startsWith('(') && arg.endsWith(')')) return arg
+  return `(${arg})`
+}
+
+/**
+ * Make an equality comparison string-tolerant when exactly one side is a
+ * Go string literal (#1896): JS `sorted === 'asc'` is loosely false for
+ * `sorted = false`, but Go's template `eq` ERRORS on bool-vs-string
+ * (`incompatible types for comparison` — DataTableColumnHeader's
+ * `'asc' | 'desc' | false` union prop). Routing the non-literal side
+ * through `bf_string` preserves JS comparison semantics for every
+ * concrete type while keeping same-kind comparisons untouched.
+ */
+function stringTolerantEqOperands(l: string, r: string): [string, string] {
+  const isStrLit = (x: string) => /^"(?:[^"\\]|\\.)*"$/.test(x)
+  if (isStrLit(l) === isStrLit(r)) return [l, r]
+  const wrap = (x: string) => (isStrLit(x) ? x : `(bf_string ${wrapGoArg(x).replace(/^\((.*)\)$/, '$1')})`)
+  return [wrap(l), wrap(r)]
+}
+
 const GO_TEMPLATE_PRIMITIVES: Record<string, PrimitiveSpec> = {
-  'JSON.stringify': { arity: 1, emit: (args) => `bf_json ${args[0]}` },
-  'String':         { arity: 1, emit: (args) => `bf_string ${args[0]}` },
-  'Number':         { arity: 1, emit: (args) => `bf_number ${args[0]}` },
-  'Math.floor':     { arity: 1, emit: (args) => `bf_floor ${args[0]}` },
-  'Math.ceil':      { arity: 1, emit: (args) => `bf_ceil ${args[0]}` },
-  'Math.round':     { arity: 1, emit: (args) => `bf_round ${args[0]}` },
+  'JSON.stringify': { arity: 1, emit: (args) => `bf_json ${wrapGoArg(args[0])}` },
+  'String':         { arity: 1, emit: (args) => `bf_string ${wrapGoArg(args[0])}` },
+  'Number':         { arity: 1, emit: (args) => `bf_number ${wrapGoArg(args[0])}` },
+  'Math.floor':     { arity: 1, emit: (args) => `bf_floor ${wrapGoArg(args[0])}` },
+  'Math.ceil':      { arity: 1, emit: (args) => `bf_ceil ${wrapGoArg(args[0])}` },
+  'Math.round':     { arity: 1, emit: (args) => `bf_round ${wrapGoArg(args[0])}` },
 }
 
 export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter, IRNodeEmitter<GoRenderCtx> {
@@ -467,6 +495,17 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   private componentName: string = ''
   private options: Required<GoTemplateAdapterOptions>
   private inLoop: boolean = false
+  /**
+   * Companion `{{define "<Component>__children_<slot>"}}` blocks queued
+   * while rendering the template body (#1896): JSX children passed to an
+   * imported child component that contain template actions (nested
+   * components, dynamic text) can't be baked to a static `Children`
+   * string — they render through a per-call-site define executed via
+   * `bf_tmpl` with the PARENT's data, and the result is injected into
+   * the child props with `bf_with_children`. Flushed after the main
+   * define in `generate()`.
+   */
+  private pendingChildrenDefines: Array<{ name: string; content: string }> = []
   private loopParamStack: string[] = []
   private loopVarRefCount: Map<string, number> = new Map()
   /** Stack of destructure-param binding maps (binding name → Go accessor on the
@@ -475,6 +514,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    *  refusing with BF104. (#1310) */
   private loopBindingStack: Array<Map<string, string>> = []
   private errors: CompilerError[] = []
+  /** The current IR's memos, stashed like `localConstants` so nested memo
+   *  resolution (a ternary memo whose condition is another memo, #1896)
+   *  can recurse without threading the list through every signature. */
+  private currentMemos: Array<{ name: string; computation: string; deps: string[] }> = []
   private propsObjectName: string | null = null
   /**
    * Component-scoped rest binding identifier (`function({ a, ...rest }: P)`
@@ -598,10 +641,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     this.componentName = ir.metadata.componentName
     this.errors = []
     this.templateVarCounter = 0
+    this.pendingChildrenDefines = []
     this.propsObjectName = ir.metadata.propsObjectName
     this.restPropsName = ir.metadata.restPropsName ?? null
     this.moduleStringConsts = this.collectModuleStringConsts(ir.metadata.localConstants)
     this.localConstants = ir.metadata.localConstants ?? []
+    this.currentMemos = ir.metadata.memos ?? []
     this.contextConsumers = collectContextConsumers(ir.metadata)
     // (#checkbox) Enumerate inherited-attribute accesses (props-object pattern)
     // before computing the nillable set / rendering, so the synthetic params
@@ -648,7 +693,13 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       ? ''
       : this.generateScriptRegistrations(ir, options?.scriptBaseName)
 
-    const template = `{{define "${this.componentName}"}}\n${scriptRegistrations}${templateBody}\n{{end}}\n`
+    let template = `{{define "${this.componentName}"}}\n${scriptRegistrations}${templateBody}\n{{end}}\n`
+    // Flush the companion children defines (#1896) — they execute with
+    // the parent's data via `bf_tmpl`, so they belong to this
+    // component's template output.
+    for (const d of this.pendingChildrenDefines) {
+      template += `{{define "${d.name}"}}${d.content}{{end}}\n`
+    }
     const types = this.generateTypes(ir)
 
     // Merge collected errors into IR errors
@@ -958,12 +1009,22 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // round-tripped IR, so this must be applied here too; the method is
     // idempotent. `propsObjectName` is needed by the scan.
     this.propsObjectName = ir.metadata.propsObjectName
+    // Mirror `generate()` for the rest binding too (#1896):
+    // `classifySpreadBagSource` decides whether a `{...props}` slot is an
+    // Input-side bag by comparing against `this.restPropsName`. Without
+    // this line the stash holds whichever component `generate()` ran
+    // LAST — in a multi-component file (`tabs/index.tsx`) that is a
+    // different component, so the Input struct dropped its `Props`
+    // bag field while `NewXxxProps` (which reads the per-IR metadata)
+    // still emitted `Spread_N: in.Props` — `in.Props undefined`.
+    this.restPropsName = ir.metadata.restPropsName ?? null
     augmentInheritedPropAccesses(ir)
     // Mirror `generate()`: the `NewXxxProps` initializer computes memo SSR
     // values, which inline module string consts and resolve `Record`-index
     // lookups — both need the const tables populated on this standalone entry.
     this.moduleStringConsts = this.collectModuleStringConsts(ir.metadata.localConstants)
     this.localConstants = ir.metadata.localConstants ?? []
+    this.currentMemos = ir.metadata.memos ?? []
     this.contextConsumers = collectContextConsumers(ir.metadata)
     const lines: string[] = []
 
@@ -1048,7 +1109,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     this.generatePropsStruct(lines, ir, componentName, nestedComponents, propTypeOverrides, spreadSlots)
 
     // Generate NewXxxProps function
-    this.generateNewPropsFunction(lines, ir, componentName, nestedComponents, spreadSlots)
+    this.generateNewPropsFunction(lines, ir, componentName, nestedComponents, spreadSlots, propTypeOverrides)
 
     // Imports come at the top, but `usesHtmlTemplate` is only known
     // after the body has been generated. Compose package + imports +
@@ -1492,9 +1553,17 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       lines.push(`\t${fieldName} ${goType} \`json:"${jsonTag}"\``)
     }
 
-    // Add memos to Props (they are computed values needed for SSR)
+    // Add memos to Props (they are computed values needed for SSR).
+    // Skip a memo whose name collides with an already-emitted prop field
+    // (#1896): `const className = createMemo(() => props.className ?? '')`
+    // — common in site/ui (AccordionContent, PaginationLink) — would
+    // otherwise redeclare `ClassName`. Both readers (the memo usage and
+    // the inherited `props.className` access) lower to the same `.Field`,
+    // so the prop field carries the value; the memo's `?? fallback` is
+    // folded into the prop's initializer in `generateNewPropsFunction`.
     for (const memo of ir.metadata.memos) {
       const fieldName = this.capitalizeFieldName(memo.name)
+      if (propFieldNames.has(fieldName)) continue
       const jsonTag = this.toJsonTag(memo.name)
       // Memos that depend on number signals are usually numbers
       const goType = this.inferMemoType(memo, ir.metadata.signals, propsParamMap)
@@ -1557,7 +1626,8 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     ir: ComponentIR,
     componentName: string,
     nestedComponents: NestedComponentInfo[],
-    spreadSlots: SpreadSlotInfo[]
+    spreadSlots: SpreadSlotInfo[],
+    propTypeOverrides: Map<string, string>,
   ): void {
     const inputTypeName = `${componentName}Input`
     const propsTypeName = `${componentName}Props`
@@ -1654,6 +1724,31 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // doesn't silently shadow the JSX-side default. The same logic
     // applies for signal-side fallbacks (`createSignal(props.X ?? N)`)
     // via the hoisted variable from `propFallbackVars` (#1423).
+    // (#1896) A memo that shadows a prop of the same name
+    // (`const className = createMemo(() => props.className ?? '')`)
+    // shares the prop's struct field (see `generatePropsStruct`). Fold
+    // the memo's `?? fallback` into the prop's own initializer so the
+    // SSR value matches the memo semantics when the caller omits it.
+    const memoFallbacks = new Map<string, { goFallback: string; goType: string }>()
+    for (const memo of ir.metadata.memos) {
+      const stripped = memo.computation.replace(/^\(\)\s*=>\s*/, '')
+      const m = this.extractPropFallback(stripped)
+      if (!m) continue
+      if (this.capitalizeFieldName(m.propName) !== this.capitalizeFieldName(memo.name)) continue
+      // `applyGoFallback` emits a string-typed zero-value check; folding
+      // onto a prop whose Input field resolved to `interface{}` (e.g. a
+      // string-literal-union type the resolver can't narrow —
+      // PaginationLink's `size`) would not compile. Such props keep the
+      // plain `in.<Field>` assignment.
+      const param = ir.metadata.propsParams.find(
+        p => this.capitalizeFieldName(p.name) === this.capitalizeFieldName(memo.name),
+      )
+      if (!param) continue
+      const goType = this.resolvePropGoType(param, propTypeOverrides)
+      if (goType !== 'string' && goType !== 'interface{}') continue
+      memoFallbacks.set(this.capitalizeFieldName(memo.name), { goFallback: m.goFallback, goType })
+    }
+
     const propFieldNames = new Set<string>()
     for (const param of ir.metadata.propsParams) {
       const fieldName = this.capitalizeFieldName(param.name)
@@ -1662,9 +1757,19 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       if (hoisted) {
         lines.push(`\t\t${fieldName}: ${hoisted.varName},`)
       } else {
-        const fallback = this.goPropDefault(param.defaultValue)
-        if (fallback !== null) {
-          lines.push(`\t\t${fieldName}: ${this.applyGoFallback(`in.${fieldName}`, fallback)},`)
+        const paramDefault = this.goPropDefault(param.defaultValue)
+        const memoFold = memoFallbacks.get(fieldName)
+        if (paramDefault !== null) {
+          lines.push(`\t\t${fieldName}: ${this.applyGoFallback(`in.${fieldName}`, paramDefault)},`)
+        } else if (memoFold !== undefined && memoFold.goType === 'string') {
+          lines.push(`\t\t${fieldName}: ${this.applyGoFallback(`in.${fieldName}`, memoFold.goFallback)},`)
+        } else if (memoFold !== undefined) {
+          // interface{} field (#1896, PaginationLink's `size ?? 'icon'`):
+          // applyGoFallback's string zero-check doesn't compile here, so
+          // emit a nil/empty-tolerant wrapper instead.
+          lines.push(
+            `\t\t${fieldName}: func() interface{} { v := interface{}(in.${fieldName}); if v == nil || v == "" { return ${memoFold.goFallback} }; return v }(),`,
+          )
         } else {
           lines.push(`\t\t${fieldName}: in.${fieldName},`)
         }
@@ -1698,10 +1803,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       lines.push(`\t\t${nested.name}s: ${varName},`)
     }
 
-    // Add memo initial values (computed from signal initial values)
+    // Add memo initial values (computed from signal initial values).
+    // Prop-shadowing memos were folded into the prop field above (#1896).
     const memoPropsParamMap = new Map(ir.metadata.propsParams.map(p => [p.name, p]))
     for (const memo of ir.metadata.memos) {
       const fieldName = this.capitalizeFieldName(memo.name)
+      if (propFieldNames.has(fieldName)) continue
       // (#checkbox) Pass the memo's inferred Go type so an unresolved
       // computation falls back to that type's zero value (`false` for a
       // boolean memo like `isChecked`), not the int `0`.
@@ -1768,6 +1875,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
           restBagEntries.push(`${JSON.stringify(jsxName)}: ${goValue}`)
           return
         }
+        // A hyphenated attribute (`aria-label`) can't be a Go struct
+        // field, and with no rest bag on the child there is nowhere to
+        // route it — the child has no `{...props}` spread, so the Hono
+        // reference drops it on the child's root too. Skip rather than
+        // emit invalid Go (#1896, data-table's selection sibling).
+        if (jsxName.includes('-')) return
         lines.push(`\t\t\t${this.capitalizeFieldName(jsxName)}: ${goValue},`)
       }
       // Add prop values
@@ -1935,6 +2048,22 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       if (cond.whenFalse) {
         this.collectNestedComponents(cond.whenFalse, result)
       }
+    } else if (node.type === 'if-statement') {
+      const stmt = node as IRIfStatement
+      this.collectNestedComponents(stmt.consequent, result)
+      if (stmt.alternate) {
+        this.collectNestedComponents(stmt.alternate, result)
+      }
+    } else if (node.type === 'component') {
+      // (#1896) JSX children passed to an imported component render via
+      // a companion define with the PARENT's data, so a keyed loop
+      // nested inside them (DataTablePreviewDemo's `sortedData().map(…)`
+      // inside `<TableBody>`) needs its `<Name>s` slice on THIS
+      // component's props like any other nested loop.
+      const comp = node as IRComponent
+      for (const child of comp.children) {
+        this.collectNestedComponents(child, result)
+      }
     }
   }
 
@@ -2070,6 +2199,16 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
           childrenScopedHtmlExpr: this.extractScopedHtmlChildren(effectiveChildren),
           contextBindings: providerCtx.size > 0 ? providerCtx : undefined,
         })
+        // (#1896) Action-bearing JSX children render through a companion
+        // define with the PARENT's data (see `queueDynamicChildrenDefine`),
+        // so component instances nested inside them need their own
+        // `<Name>SlotN` fields + constructor inits on THIS component's
+        // props. Statically-baked children never contain components
+        // (any nested component renders a `{{template}}` action, which
+        // the bake extractors reject), so recursing is a no-op for them.
+        for (const child of effectiveChildren) {
+          this.collectStaticChildInstancesRecursive(child, result, inLoop, providerCtx)
+        }
       }
       // Recurse into Portal's children to find nested components
       if (comp.name === 'Portal' && comp.children) {
@@ -2098,6 +2237,16 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       this.collectStaticChildInstancesRecursive(cond.whenTrue, result, inLoop, providerCtx)
       if (cond.whenFalse) {
         this.collectStaticChildInstancesRecursive(cond.whenFalse, result, inLoop, providerCtx)
+      }
+    } else if (node.type === 'if-statement') {
+      // (#1896) An early-return if-statement root (AccordionTrigger's
+      // asChild split) keeps its subtrees in consequent/alternate — the
+      // non-asChild branch's ChevronDownIcon needs its slot field like
+      // any other static child.
+      const stmt = node as IRIfStatement
+      this.collectStaticChildInstancesRecursive(stmt.consequent, result, inLoop, providerCtx)
+      if (stmt.alternate) {
+        this.collectStaticChildInstancesRecursive(stmt.alternate, result, inLoop, providerCtx)
       }
     } else if (node.type === 'provider') {
       // SSR context propagation: record the provider's value against its
@@ -2974,8 +3123,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         }
         const lines: string[] = []
         lines.push('func() string {')
-        lines.push(`\t\t\tk, _ := in.${fieldName}.(string)`)
-        lines.push('\t\t\tswitch k {')
+        // `fmt.Sprint` is type-tolerant: the key field is `interface{}`
+        // when the analyzer typed the prop, but a `string` when the
+        // shared inherited-prop augmentation synthesised it (#1896) — a
+        // `.(string)` assertion compiles for the former only.
+        this.usesFmt = true
+        lines.push(`\t\t\tswitch fmt.Sprint(in.${fieldName}) {`)
         for (const [k, v] of caseEntries) {
           lines.push(`\t\t\tcase ${JSON.stringify(k)}: return ${JSON.stringify(v)}`)
         }
@@ -2999,6 +3152,31 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     memos: { name: string; computation: string; deps: string[] }[],
     propsParams: { name: string }[]
   ): string | null {
+    // `getter() === 'lit'` / `!==` as a child-instance prop value
+    // (#1896 — accordion's `open={openItem() === 'item-1'}`): resolves
+    // to a Go bool when the signal's initial value is a string literal.
+    const cmpMatch = expr.match(
+      /^(\w+)\(\)\s*([!=]==?)\s*(?:'([^']*)'|(-?\d+(?:\.\d+)?))\s*$/,
+    )
+    if (cmpMatch) {
+      const [, depName, op, strLit, numLit] = cmpMatch
+      const signal = signals.find(sg => sg.getter === depName)
+      const init = signal?.initialValue.trim()
+      const initMatch = init !== undefined
+        ? /^(?:'([^'\\]*)'|(-?\d+(?:\.\d+)?))$/.exec(init)
+        : null
+      if (initMatch) {
+        const initVal = initMatch[1] ?? initMatch[2]
+        const litVal = strLit ?? numLit
+        // Same-kind comparison only (string vs string, number vs number).
+        const sameKind = (initMatch[1] !== undefined) === (strLit !== undefined)
+        if (sameKind) {
+          const equal = initVal === litVal
+          return String(op.startsWith('!') ? !equal : equal)
+        }
+      }
+    }
+
     // Match signal/memo getter calls like count(), doubled()
     const getterMatch = expr.match(/^([a-zA-Z_][a-zA-Z0-9_]*)\(\)$/)
     if (getterMatch) {
@@ -3010,10 +3188,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         return this.convertInitialValue(signal.initialValue, signal.type, propsParams)
       }
 
-      // Check if it's a memo
+      // Check if it's a memo. Use the pattern-matching core: when no
+      // pattern applies, return null so the caller OMITS the field and
+      // Go's typed zero value applies (#1896).
       const memo = memos.find(m => m.name === getterName)
       if (memo) {
-        return this.computeMemoInitialValue(memo, signals, propsParams)
+        return this.computeMemoInitialValueOrNull(memo, signals, propsParams)
       }
     }
 
@@ -3256,6 +3436,47 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // `string`, else the historical `0`).
     goType?: string,
   ): string {
+    const resolved = this.computeMemoInitialValueOrNull(
+      memo, signals, propsParams, propFallbackVars,
+    )
+    if (resolved !== null) return resolved
+    // Default: zero value for the memo's Go type (#checkbox). A boolean memo
+    // (`isChecked`) renders `false`, a string memo `""`; reference types
+    // (map / slice / interface / pointer) take `nil` — `0` is not
+    // assignable to them and broke the struct literal for a
+    // block-bodied string-building memo whose type inferred to
+    // `map[string]any` (#1896, select-demo's `summary`). Other types
+    // keep the historical int `0`.
+    if (goType === 'bool') return 'false'
+    if (goType === 'string') return '""'
+    if (
+      goType !== undefined &&
+      (goType.startsWith('map[') ||
+        goType.startsWith('[]') ||
+        goType.startsWith('*') ||
+        goType.includes('interface{}') ||
+        goType === 'any')
+    ) {
+      return 'nil'
+    }
+    return '0'
+  }
+
+  /**
+   * Pattern-matching core of `computeMemoInitialValue`: returns the
+   * memo's SSR initial value as a Go expression, or `null` when no
+   * pattern applies. Callers that have a typed field to fill use the
+   * zero-value-defaulting wrapper above; callers that can simply OMIT
+   * the field (a child-instance prop init — Go's zero values then apply
+   * with the right type for free) use this directly (#1896,
+   * data-table's `Checked: 0` into a bool field).
+   */
+  private computeMemoInitialValueOrNull(
+    memo: { name: string; computation: string; deps: string[] },
+    signals: { getter: string; initialValue: string }[],
+    propsParams: { name: string; type?: TypeInfo; defaultValue?: string }[],
+    propFallbackVars: ReadonlyMap<string, PropFallbackVar> = GoTemplateAdapter.EMPTY_PROP_FALLBACK_VARS,
+  ): string | null {
     const computation = memo.computation
     // Helper to pick the hoisted var (if any) or fall back to `in.X`.
     const propRef = (propName: string): string => {
@@ -3273,6 +3494,71 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // isn't representable, so the existing patterns below still apply.
     const tmplMemo = this.computeTemplateLiteralMemoInitialValue(computation, propsParams)
     if (tmplMemo !== null) return tmplMemo
+
+    // Pattern: () => getter() === 'lit' / !== 'lit' — a selection memo
+    // (#1896, tabs' `isAccountSelected = createMemo(() => activeTab() ===
+    // 'account')`). Resolves to a Go bool when the signal's initial value
+    // is itself a string literal.
+    const eqMatch = computation.match(
+      /^\(\)\s*=>\s*(\w+)\(\)\s*([!=]==?)\s*'([^']*)'\s*$/,
+    )
+    if (eqMatch) {
+      const [, depName, op, lit] = eqMatch
+      const signal = signals.find(sg => sg.getter === depName)
+      const initLit = signal ? /^'([^'\\]*)'$/.exec(signal.initialValue.trim()) : null
+      if (initLit) {
+        const equal = initLit[1] === lit
+        return String(op.startsWith('!') ? !equal : equal)
+      }
+    }
+
+    // Pattern: () => props.X ?? false — a boolean passthrough memo
+    // (#1896, SelectItem's `isDisabled`). Go's bool zero value IS the
+    // `?? false` fallback, so the raw input field carries the memo
+    // semantics exactly.
+    const boolPassthrough = computation.match(
+      /^\(\)\s*=>\s*props\.(\w+)\s*\?\?\s*false\s*$/,
+    )
+    if (boolPassthrough) {
+      return propRef(boolPassthrough[1])
+    }
+
+    // Pattern: () => cond() ? A : B where each branch is a module string
+    // const or a string literal, and `cond` is a signal/memo this
+    // resolver can already evaluate (#1896, SelectItem's
+    // `stateClasses`). Emits a Go conditional so the SSR value tracks
+    // the caller's input rather than a baked branch.
+    const ternMatch = computation.match(
+      /^\(\)\s*=>\s*(\w+)\(\)\s*\?\s*([\w$]+|'[^']*')\s*:\s*([\w$]+|'[^']*')\s*$/,
+    )
+    if (ternMatch) {
+      const [, condName, whenTrue, whenFalse] = ternMatch
+      const resolveBranch = (b: string): string | null => {
+        const lit = /^'([^']*)'$/.exec(b)
+        if (lit) return JSON.stringify(lit[1])
+        const constVal = this.moduleStringConsts.get(b)
+        return constVal !== undefined ? JSON.stringify(constVal) : null
+      }
+      const t = resolveBranch(whenTrue)
+      const f = resolveBranch(whenFalse)
+      if (t !== null && f !== null) {
+        let condGo: string | null = null
+        const condSignal = signals.find(sg => sg.getter === condName)
+        if (condSignal) {
+          condGo = this.getSignalInitialValueAsGo(condSignal.initialValue, propsParams, propFallbackVars)
+        } else {
+          const condMemo = (this.currentMemos ?? []).find(m => m.name === condName)
+          if (condMemo) {
+            condGo = this.computeMemoInitialValueOrNull(condMemo, signals, propsParams, propFallbackVars)
+          }
+        }
+        if (condGo === 'true') return t
+        if (condGo === 'false') return f
+        if (condGo !== null) {
+          return `func() string { if ${condGo} { return ${t} }; return ${f} }()`
+        }
+      }
+    }
 
     // Pattern: () => dep() * N or () => dep() + N etc.
     const arithmeticMatch = computation.match(/\(\)\s*=>\s*(\w+)\(\)\s*([*+\-/])\s*(\d+)/)
@@ -3352,12 +3638,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       }
     }
 
-    // Default: zero value for the memo's Go type (#checkbox). A boolean memo
-    // (`isChecked`) renders `false`, a string memo `""`; otherwise the
-    // historical int `0`.
-    if (goType === 'bool') return 'false'
-    if (goType === 'string') return '""'
-    return '0'
+    return null
   }
 
   /**
@@ -3888,6 +4169,11 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   // ===========================================================================
 
   identifier(name: string): string {
+    // `undefined` / `null` inside a larger expression tree (a ternary
+    // branch like `props.isActive ? 'page' : undefined`, #1896
+    // pagination) renders as the empty string — the top-level
+    // `convertExpressionToGo` short-circuit doesn't see nested ones.
+    if (name === 'undefined' || name === 'null') return '""'
     // Module pure-string const (e.g. `const baseClasses = '...'` used in a
     // className template literal): inline the literal value rather than
     // emit `{{.BaseClasses}}` against a Props field that never exists.
@@ -3948,13 +4234,60 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    */
   private collectModuleStringConsts(constants: IRMetadata['localConstants']): Map<string, string> {
     const map = new Map<string, string>()
-    for (const c of constants ?? []) {
-      if (!c.isModule) continue
-      if (c.value === undefined) continue
-      const literal = this.parsePureStringLiteral(c.value)
-      if (literal !== null) map.set(c.name, literal)
+    const candidates = (constants ?? []).filter(
+      c => c.isModule && c.value !== undefined,
+    )
+    // Fixed-point: a module string const may be COMPOSED of other module
+    // string consts via a template literal (#1896 — radio-group's
+    // `itemClasses = \`\${itemBaseClasses} \${itemFocusClasses} …\``).
+    // Each pass resolves the consts whose dependencies resolved in an
+    // earlier pass; terminates when a pass adds nothing.
+    let progressed = true
+    while (progressed) {
+      progressed = false
+      for (const c of candidates) {
+        if (map.has(c.name)) continue
+        const literal =
+          this.parsePureStringLiteral(c.value!) ??
+          this.evalTemplateOfStringConsts(c.value!, map)
+        if (literal !== null) {
+          map.set(c.name, literal)
+          progressed = true
+        }
+      }
     }
     return map
+  }
+
+  /**
+   * Evaluate a template literal whose every interpolation is a bare
+   * identifier already present in `resolved` (a module string const) to
+   * its flat string value, else `null`. Companion to
+   * `parsePureStringLiteral` for the composed-const shape (#1896).
+   */
+  private evalTemplateOfStringConsts(
+    source: string,
+    resolved: ReadonlyMap<string, string>,
+  ): string | null {
+    const sf = ts.createSourceFile(
+      '__const.ts',
+      `const __x = (${source});`,
+      ts.ScriptTarget.Latest,
+      /*setParentNodes*/ false,
+    )
+    const stmt = sf.statements[0]
+    if (!stmt || !ts.isVariableStatement(stmt)) return null
+    let init = stmt.declarationList.declarations[0]?.initializer
+    while (init && ts.isParenthesizedExpression(init)) init = init.expression
+    if (!init || !ts.isTemplateExpression(init)) return null
+    let out = init.head.text
+    for (const span of init.templateSpans) {
+      if (!ts.isIdentifier(span.expression)) return null
+      const value = resolved.get(span.expression.text)
+      if (value === undefined) return null
+      out += value + span.literal.text
+    }
+    return out
   }
 
   /**
@@ -4122,6 +4455,18 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       return this.rootFieldRef(property)
     }
 
+    // Static property access on a module object-literal const
+    // (`variantClasses.ghost` in a class template literal, #1896
+    // pagination) resolves at compile time — same lookup as the
+    // bracket-index form in `resolveStaticRecordLiteralIndex`, reached
+    // here when the access is nested inside a larger ParsedExpr tree.
+    if (object.kind === 'identifier') {
+      const staticValue = this.resolveStaticRecordLiteralIndex(
+        `${object.name}.${property}`,
+      )
+      if (staticValue !== null) return staticValue
+    }
+
     // Inside a loop, the loop param variable refers to the current item
     // (dot). e.g. `msg.role` inside `{{range $_, $msg := .Messages}}` → `.Role`
     const currentLoopParam = this.loopParamStack[this.loopParamStack.length - 1]
@@ -4139,11 +4484,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     const r = emit(right)
     switch (op) {
       case '===':
-      case '==':
-        return `eq ${l} ${r}`
+      case '==': {
+        const [el, er] = stringTolerantEqOperands(l, r)
+        return `eq ${el} ${er}`
+      }
       case '!==':
-      case '!=':
-        return `ne ${l} ${r}`
+      case '!=': {
+        const [el, er] = stringTolerantEqOperands(l, r)
+        return `ne ${el} ${er}`
+      }
       case '>':
         return `gt ${l} ${r}`
       case '<':
@@ -4212,7 +4561,13 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       if (part.type === 'string') {
         result += part.value
       } else {
-        result += `{{${emit(part.expr)}}}`
+        // A nested ternary emits a complete `{{if …}}…{{end}}` action
+        // chain (see `conditional` above) — wrapping it again produces
+        // `{{{{if …}}` and a template parse error (#1896, the tooltip
+        // open/closed class ternary with module-const branches). Same
+        // guard as `renderExpression`.
+        const e = emit(part.expr)
+        result += e.startsWith('{{') ? e : `{{${e}}}`
       }
     }
     return result
@@ -5266,6 +5621,33 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       return '""'
     }
 
+    // `IDENT['key']` over a module object-literal const with a STRING
+    // LITERAL key is a fully static lookup — resolve it at compile time
+    // (#1896). The generic member lowering below would otherwise
+    // capitalize the bracket access into a field reference and emit an
+    // invalid hyphenated path (`strokePaths['chevron-down']` →
+    // `.StrokePaths.Chevron-down`, a template parse error).
+    const staticIndexed = this.resolveStaticRecordLiteralIndex(trimmed)
+    if (staticIndexed !== null) {
+      return staticIndexed
+    }
+
+    // A bare identifier bound to a literal const inlines at compile time
+    // (#1896 — pagination's `Page {currentPage()} of {totalPages}`:
+    // `totalPages` is a function-scope `const totalPages = 5`, not a
+    // prop, so the generic lowering would reference a nonexistent
+    // `.TotalPages` field). Only pure numeric / single-quoted-string
+    // initializers qualify; anything else may be runtime-dependent.
+    if (/^[A-Za-z_$][\w$]*$/.test(trimmed)) {
+      const litConst = (this.localConstants ?? []).find(c => c.name === trimmed)
+      if (litConst?.value !== undefined) {
+        const v = litConst.value.trim()
+        if (/^-?\d+(\.\d+)?$/.test(v)) return v
+        const strLit = /^'([^'\\]*)'$/.exec(v) ?? /^"([^"\\]*)"$/.exec(v)
+        if (strLit) return JSON.stringify(strLit[1])
+      }
+    }
+
     const parsed = parseExpression(trimmed)
     const support = isSupported(parsed)
 
@@ -5285,6 +5667,62 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     }
 
     return this.renderParsedExpr(parsed)
+  }
+
+  /**
+   * Resolve `IDENT['key']` / `IDENT["key"]` where `IDENT` is a
+   * module-scope object-literal const and the key is a string literal —
+   * a compile-time-static lookup (the icon registry's
+   * `strokePaths['chevron-down']`, #1896). Returns the looked-up value
+   * as a Go literal (quoted string / bare number) usable inside a
+   * template action, or `null` for any other shape so the caller falls
+   * through to the generic lowering. The prop-keyed variant of the same
+   * pattern lives in `parseRecordIndexAccess` (shared with Mojo); this
+   * helper covers the literal-key case that parse rejects.
+   */
+  private resolveStaticRecordLiteralIndex(jsExpr: string): string | null {
+    const m =
+      /^([A-Za-z_$][\w$]*)\[\s*(?:'([^']*)'|"([^"]*)")\s*\]$/.exec(jsExpr) ??
+      // Property-access form of the same static lookup
+      // (`variantClasses.ghost`, #1896 pagination) — only when the base
+      // resolves to a module object-literal const below, so ordinary
+      // props/locals never match.
+      /^([A-Za-z_$][\w$]*)\.([A-Za-z_$][\w$]*)$/.exec(jsExpr)
+    if (!m) return null
+    const key = m[2] ?? m[3]
+    const constInfo = (this.localConstants ?? []).find(
+      c => c.name === m[1] && c.isModule,
+    )
+    if (constInfo?.value === undefined) return null
+    const sf = ts.createSourceFile(
+      '__rec.ts',
+      `(${constInfo.value})`,
+      ts.ScriptTarget.Latest,
+      /* setParentNodes */ true,
+    )
+    if (sf.statements.length !== 1) return null
+    const stmt = sf.statements[0]
+    if (!ts.isExpressionStatement(stmt)) return null
+    let parsed: ts.Expression = stmt.expression
+    while (ts.isParenthesizedExpression(parsed)) parsed = parsed.expression
+    if (!ts.isObjectLiteralExpression(parsed)) return null
+    for (const prop of parsed.properties) {
+      if (!ts.isPropertyAssignment(prop)) continue
+      const name = prop.name
+      const propKey =
+        ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNoSubstitutionTemplateLiteral(name)
+          ? name.text
+          : null
+      if (propKey !== key) continue
+      let v: ts.Expression = prop.initializer
+      while (ts.isParenthesizedExpression(v)) v = v.expression
+      if (ts.isNumericLiteral(v)) return v.text
+      if (ts.isStringLiteral(v) || ts.isNoSubstitutionTemplateLiteral(v)) {
+        return JSON.stringify(v.text)
+      }
+      return null
+    }
+    return null
   }
 
   /**
@@ -5539,11 +5977,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         let result: string
         switch (expr.op) {
           case '===':
-          case '==':
-            result = `eq ${left} ${right}`; break
+          case '==': {
+            const [el, er] = stringTolerantEqOperands(left, right)
+            result = `eq ${el} ${er}`; break
+          }
           case '!==':
-          case '!=':
-            result = `ne ${left} ${right}`; break
+          case '!=': {
+            const [el, er] = stringTolerantEqOperands(left, right)
+            result = `ne ${el} ${er}`; break
+          }
           case '>':
             result = `gt ${left} ${right}`; break
           case '<':
@@ -5831,6 +6273,33 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     return null
   }
 
+  /**
+   * When `comp`'s JSX children contain template actions (nested
+   * components, dynamic text) — i.e. none of the static bake paths in
+   * `collectStaticChildInstances` apply — render them into a companion
+   * define and return its name; `renderComponent` then routes the child
+   * call through `bf_with_children` + `bf_tmpl` (#1896). Returns null
+   * for childless or statically-bakeable children, which keep the
+   * constructor-baked `Children` value.
+   */
+  private queueDynamicChildrenDefine(comp: IRComponent): string | null {
+    const effectiveChildren = comp.children.length > 0
+      ? comp.children
+      : this.jsxChildrenPropNodes(comp.props)
+    if (effectiveChildren.length === 0) return null
+    if (this.extractTextChildren(effectiveChildren) !== null) return null
+    if (this.extractHtmlChildren(effectiveChildren) !== null) return null
+    if (this.extractScopedHtmlChildren(effectiveChildren) !== null) return null
+    const name = `${this.componentName}__children_${comp.slotId}`
+    if (!this.pendingChildrenDefines.some(d => d.name === name)) {
+      this.pendingChildrenDefines.push({
+        name,
+        content: this.renderChildren(effectiveChildren),
+      })
+    }
+    return name
+  }
+
   renderComponent(comp: IRComponent, ctx?: { isRootOfClientComponent?: boolean }): string {
     // Handle Portal component specially - collect content for body end
     if (comp.name === 'Portal') {
@@ -5857,7 +6326,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     } else if (comp.slotId) {
       // Static children with slotId: use unique field name based on slotId
       const suffix = slotIdToFieldSuffix(comp.slotId)
-      templateCall = `{{template "${comp.name}" .${comp.name}${suffix}}}`
+      const childrenDefine = this.queueDynamicChildrenDefine(comp)
+      templateCall = childrenDefine
+        ? `{{template "${comp.name}" (bf_with_children .${comp.name}${suffix} (bf_tmpl "${childrenDefine}" .))}}`
+        : `{{template "${comp.name}" .${comp.name}${suffix}}}`
     } else {
       // Static children without slotId: fallback to .ComponentName
       templateCall = `{{template "${comp.name}" .${comp.name}}}`
@@ -5948,10 +6420,38 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       }
       if (isBooleanAttr(name) || value.presenceOrUndefined) {
         const { condition: goCond, preamble } = this.convertConditionToGo(value.expr)
-        return `${preamble}{{if ${goCond}}}${name}{{end}}`
+        // ARIA attributes are string-valued ("true"/"false"), not HTML5
+        // presence booleans — Hono renders the truthy presence form as
+        // `aria-x="true"` (#1896, SelectItem's
+        // `aria-disabled={isDisabled() || undefined}`).
+        const body = name.startsWith('aria-') ? `${name}="true"` : name
+        return `${preamble}{{if ${goCond}}}${body}{{end}}`
       }
       const parsed = parseExpression(value.expr.trim())
-      if (parsed.kind === 'conditional' || parsed.kind === 'template-literal') {
+      if (parsed.kind === 'conditional') {
+        // A ternary whose falsy branch is `undefined` / `null` OMITS the
+        // attribute entirely on Hono (`aria-current={props.isActive ?
+        // 'page' : undefined}`, #1896 pagination) — wrap the whole
+        // attribute in the condition instead of rendering `attr=""`.
+        const undef = (e: ParsedExpr): boolean =>
+          (e.kind === 'identifier' && (e.name === 'undefined' || e.name === 'null')) ||
+          (e.kind === 'literal' && (e.value === null || e.value === undefined))
+        const test = parsed.test
+        if (undef(parsed.alternate) && !undef(parsed.consequent)) {
+          const { condition: goCond, preamble } = this.convertConditionToGo(
+            // Re-render the test from its source span via the parsed tree.
+            this.renderParsedExpr(test).startsWith('{{')
+              ? value.expr
+              : value.expr.slice(0, value.expr.indexOf('?')).trim(),
+          )
+          const valueExpr = this.renderParsedExpr(parsed.consequent)
+          const body = `${name}="{{${valueExpr}}}"`
+          return `${preamble}{{if ${goCond}}}${body}{{end}}`
+        }
+        // Inline Go template syntax with embedded `{{...}}` actions.
+        return `${name}="${this.renderParsedExpr(parsed)}"`
+      }
+      if (parsed.kind === 'template-literal') {
         // Inline Go template syntax with embedded `{{...}}` actions.
         return `${name}="${this.renderParsedExpr(parsed)}"`
       }
@@ -6127,7 +6627,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       }
       const inner = s.slice(open + 2, close).trim()
       if (inner) {
-        out += `{{${this.convertExpressionToGo(inner)}}}`
+        // Same double-wrap guard as `renderExpression` / `templateLiteral`
+        // (#1896): a ternary lowers to a complete action chain.
+        const goExpr = this.convertExpressionToGo(inner)
+        out += goExpr.startsWith('{{') ? goExpr : `{{${goExpr}}}`
       } else {
         out += s.slice(open, close + 1)
       }
@@ -6174,7 +6677,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         // case matches; consumers shouldn't rely on a default fallback
         // here (the JSX-side `variant = 'default'` default already
         // shows up via the per-prop fallback in `NewXxxProps`).
-        const keyExpr = this.convertExpressionToGo(part.key)
+        const rawKeyExpr = this.convertExpressionToGo(part.key)
+        // A compound key (`props.placement ?? 'top'` → `or .Placement
+        // "top"`) must be parenthesized inside `eq` — unwrapped, Go's
+        // template parser reads `eq or .Placement "top" "left"` as four
+        // arguments with a zero-arg `or` (#1896, tooltip placement).
+        const keyExpr = /\s/.test(rawKeyExpr) ? `(${rawKeyExpr})` : rawKeyExpr
         const caseEntries = Object.entries(part.cases)
         if (caseEntries.length === 0) continue
         const branches = caseEntries.map(([k, v], i) => {

--- a/packages/adapter-go-template/src/test-render.ts
+++ b/packages/adapter-go-template/src/test-render.ts
@@ -75,6 +75,14 @@ export interface RenderOptions {
   /** Additional component files (filename → source) */
   components?: Record<string, string>
   /**
+   * Pre-compiled child SSR modules (import specifier → path) — consumed
+   * by the Hono renderer; here only the KEYS matter (#1896): they carry
+   * EVERY specifier a sibling is reachable by (`@ui/components/ui/icon`
+   * and `../icon`), whereas `components` keys carry one per sibling, so
+   * the sibling-import recognition uses both.
+   */
+  componentModules?: Record<string, string>
+  /**
    * Explicit component to render when `source` declares multiple
    * exports (e.g. `ReactiveProps.tsx` → `PropsReactivityComparison`).
    * Mirrors the Hono reference's `componentName`; omitted for
@@ -84,7 +92,7 @@ export interface RenderOptions {
 }
 
 export async function renderGoTemplateComponent(options: RenderOptions): Promise<string> {
-  const { source, adapter, props, components, componentName: requestedName } = options
+  const { source, adapter, props, components, componentModules, componentName: requestedName } = options
 
   if (!adapter.generateTypes) {
     throw new Error('Go Template adapter must implement generateTypes()')
@@ -109,8 +117,19 @@ export async function renderGoTemplateComponent(options: RenderOptions): Promise
   // Import specifiers the harness holds child sources for — recognised as
   // sibling imports alongside relative ones (see
   // `collectImportedComponentNames`).
-  const childSpecifiers = new Set(Object.keys(components ?? {}))
+  const childSpecifiers = new Set([
+    ...Object.keys(components ?? {}),
+    ...Object.keys(componentModules ?? {}),
+  ])
   if (components) {
+    // Two passes (#1896): a child file may itself render a component from a
+    // *sibling* child file (data-table's `checkbox` renders `<CheckIcon
+    // data-slot=.../>` from `icon`). `generateTypes` routes such non-param
+    // attributes through the target's registered shape, so EVERY child's
+    // shape must be registered before ANY child's types are generated —
+    // otherwise processing order decides whether the attribute lands in
+    // the rest bag or becomes an invalid hyphenated Go field.
+    const compiledChildIrs: Array<{ ir: ComponentIR; defines: Map<string, string> }> = []
     for (const [filename, childSource] of Object.entries(components)) {
       const childResult = compileJSX(childSource, filename, { adapter, outputIR: true })
       const childErrors = childResult.errors.filter(e => e.severity === 'error')
@@ -124,26 +143,29 @@ export async function renderGoTemplateComponent(options: RenderOptions): Promise
       const childIrFiles = childResult.files.filter(f => f.type === 'ir')
       for (const childIrFile of childIrFiles) {
         const childIR = JSON.parse(childIrFile.content) as ComponentIR
-        const name = childIR.metadata.componentName
         // (#checkbox) Register each child's cross-component shape so the
         // parent's static-child-init codegen can route a non-param attribute
         // (`<CheckIcon data-slot=.../>`) into the child's rest bag instead of
         // an invalid hyphenated Go field. No-op on adapters without the hook.
         registerChildShape(adapter, childIR)
-        let typeBlock: string | null = adapter.generateTypes!(childIR)
-        if (typeBlock) {
-          // Strip package declaration and imports — will be merged into main types
-          typeBlock = typeBlock.replace(/^package \w+\n*/, '')
-          typeBlock = typeBlock.replace(/import\s*\([^)]*\)\n*/g, '')
-          typeBlock = typeBlock.replace(/\t"math\/rand"\n/g, '')
-          typeBlock = typeBlock.trim()
-        }
-        childArtifacts.set(name, {
-          define: defineBlocks.get(name) ?? '',
-          typeBlock,
-          importedNames: collectImportedComponentNames(childIR, childSpecifiers),
-        })
+        compiledChildIrs.push({ ir: childIR, defines: defineBlocks })
       }
+    }
+    for (const { ir: childIR, defines } of compiledChildIrs) {
+      const name = childIR.metadata.componentName
+      let typeBlock: string | null = adapter.generateTypes!(childIR)
+      if (typeBlock) {
+        // Strip package declaration and imports — will be merged into main types
+        typeBlock = typeBlock.replace(/^package \w+\n*/, '')
+        typeBlock = typeBlock.replace(/import\s*\([^)]*\)\n*/g, '')
+        typeBlock = typeBlock.replace(/\t"math\/rand"\n/g, '')
+        typeBlock = typeBlock.trim()
+      }
+      childArtifacts.set(name, {
+        define: defines.get(name) ?? '',
+        typeBlock,
+        importedNames: collectImportedComponentNames(childIR, childSpecifiers),
+      })
     }
   }
 
@@ -188,7 +210,13 @@ export async function renderGoTemplateComponent(options: RenderOptions): Promise
   // child-collection loop above).
   const reachableChildNames = new Set<string>()
   {
-    const queue = [...collectImportedComponentNames(ir, childSpecifiers)]
+    // Seed from EVERY component of the parent source, not just the entry:
+    // the siblings' type blocks are merged into the unit too, and their
+    // constructors reference their own child components' Props types
+    // (#1896 — dropdown-menu-demo's profile sibling uses SettingsIcon,
+    // which the entry export never imports... the import list is per-file,
+    // but per-IR metadata can differ after analysis; union them all).
+    const queue = irs.flatMap(i => collectImportedComponentNames(i, childSpecifiers))
     while (queue.length > 0) {
       const name = queue.shift()!
       if (reachableChildNames.has(name)) continue
@@ -220,7 +248,8 @@ export async function renderGoTemplateComponent(options: RenderOptions): Promise
   // Remove "math/rand" import from types (randomID is defined in main.go)
   goTypes = goTypes.replace(/\t"math\/rand"\n/, '')
 
-  // Append sibling-component type definitions (multi-component source).
+  // Collect sibling-component type definitions (multi-component source).
+  const siblingTypeBlocks: string[] = []
   for (const siblingIR of irs) {
     if (siblingIR === ir) continue
     let siblingTypes = adapter.generateTypes(siblingIR)
@@ -228,19 +257,27 @@ export async function renderGoTemplateComponent(options: RenderOptions): Promise
     siblingTypes = siblingTypes.replace(/^package \w+\n*/, '')
     siblingTypes = siblingTypes.replace(/import\s*\([^)]*\)\n*/g, '')
     siblingTypes = siblingTypes.replace(/\t"math\/rand"\n/g, '')
-    goTypes += '\n\n' + siblingTypes.trim()
+    siblingTypeBlocks.push(siblingTypes.trim())
   }
 
-  // Append child type definitions. A multi-component child file (e.g.
-  // `radio-group` exporting RadioGroup + RadioGroupItem) emits its
-  // module-scope shared types (the context-value struct) once per
-  // component IR — deduplicate across the child blocks with the same
-  // helper `bf build` uses, or the merged unit fails with
-  // `redeclared in this block`. Scoped to the child blocks (not the
-  // whole `goTypes`): the dedup helper re-inserts types at the top of
-  // its input, which must not jump above the entry's `package` clause.
-  if (childTypeBlocks.length > 0) {
-    goTypes += '\n\n' + deduplicateGoTypes(childTypeBlocks.join('\n\n'))
+  // Merge entry + sibling + child type blocks through the same
+  // `deduplicateGoTypes` helper `bf build` uses. Duplicates arise in two
+  // ways (#1896): a multi-component file emits its module-scope shared
+  // types (a context-value struct, a data `type Payment = …`) once per
+  // component IR — both across the entry source's own sibling exports
+  // (data-table-demo's `Payment redeclared`) and across a child file's
+  // components (radio-group's context value). The dedup helper re-inserts
+  // type definitions at the top of its input, so the entry's
+  // `package main` + import header is split off first and re-prepended.
+  if (siblingTypeBlocks.length > 0 || childTypeBlocks.length > 0) {
+    const headerMatch = goTypes.match(/^package main\n+import \([\s\S]*?\)\n+/)
+    const header = headerMatch ? headerMatch[0] : ''
+    const body = goTypes.slice(header.length)
+    goTypes =
+      header +
+      deduplicateGoTypes(
+        [body, ...siblingTypeBlocks, ...childTypeBlocks].join('\n\n'),
+      )
   }
 
   // Sibling / child type blocks have their own `import (...)` stripped above
@@ -334,7 +371,11 @@ func randomID(n int) string {
 }
 
 func main() {
-	tmpl := template.Must(template.New("").Funcs(bfTestFuncMap()).Parse(tmplContent))
+	// Two-step Funcs: bf_tmpl (children defines, #1896) needs a closure
+	// over the same template set the defines are parsed into.
+	root := template.New("").Funcs(bfTestFuncMap())
+	root = root.Funcs(bf.TemplateFuncMap(root))
+	tmpl := template.Must(root.Parse(tmplContent))
 	props := New${componentName}Props(${componentName}Input{
 		ScopeID: ${JSON.stringify(rootScopeId)},
 ${propsInit}
@@ -372,7 +413,23 @@ ${propsInit}
 
     const exitCode = await proc.exited
     if (exitCode !== 0) {
-      throw new Error(`go run failed (exit ${exitCode}):\n${stderr}`)
+      // Append the offending `types.go` lines (with two lines of context)
+      // for each `./types.go:NN` the compiler reported — the temp dir is
+      // deleted in `finally`, so without this the merged unit that
+      // actually failed is unrecoverable (#1896 debugging aid).
+      const typeLines = goTypes.split('\n')
+      const context: string[] = []
+      const seen = new Set<number>()
+      for (const m of stderr.matchAll(/\.\/types\.go:(\d+)/g)) {
+        const n = Number(m[1])
+        for (let i = Math.max(1, n - 2); i <= Math.min(typeLines.length, n + 2); i++) {
+          if (seen.has(i)) continue
+          seen.add(i)
+          context.push(`${i === n ? '>' : ' '} types.go:${i}: ${typeLines[i - 1]}`)
+        }
+      }
+      const detail = context.length > 0 ? `\n${context.join('\n')}` : ''
+      throw new Error(`go run failed (exit ${exitCode}):\n${stderr}${detail}`)
     }
 
     return stdout
@@ -478,6 +535,10 @@ function registerChildShape(adapter: TemplateAdapter, ir: ComponentIR): void {
  */
 const MERGED_STDLIB_IMPORTS: Array<{ path: string; usage: RegExp }> = [
   { path: 'fmt', usage: /\bfmt\./ },
+  // A child whose constructor bakes static JSX children references
+  // `template.HTML(...)` (#1896 — the `command` demo's Kbd child); the
+  // entry component may not use html/template itself.
+  { path: 'html/template', usage: /\btemplate\.HTML\(/ },
 ]
 
 /**

--- a/packages/adapter-tests/src/jsx-runner.ts
+++ b/packages/adapter-tests/src/jsx-runner.ts
@@ -213,6 +213,11 @@ export function normalizeHTML(html: string): string {
     .replace(/&#0*60;|&#[xX]0*3[cC];/g, '&lt;')
     .replace(/&#0*62;|&#[xX]0*3[eE];/g, '&gt;')
     .replace(/&#0*39;|&#[xX]0*27;/g, '&#39;')
+    // Raw apostrophes too (#1896 / #1897): Hono escapes `'` in text nodes
+    // as `&#39;`, Go's html/template (and Xslate) leave it raw — both
+    // decode to the same DOM text, so canonicalise to the entity form on
+    // both sides like the numeric references above.
+    .replace(/'/g, '&#39;')
     // Normalize void element self-closing: <br/> or <br /> → <br>
     .replace(new RegExp(`<(${VOID_ELEMENTS})(\\s[^>]*?)?\\s*/>`, 'g'), '<$1$2>')
     // Remove trailing whitespace before >

--- a/packages/jsx/src/augment-inherited-props.ts
+++ b/packages/jsx/src/augment-inherited-props.ts
@@ -164,7 +164,31 @@ export function augmentInheritedPropAccesses(ir: ComponentIR): void {
     if (!node) return
     const el = node as unknown as IRElement
     for (const attr of el.attrs ?? []) {
-      const v = attr.value as { kind?: string; expr?: string; presenceOrUndefined?: boolean }
+      const v = attr.value as {
+        kind?: string
+        expr?: string
+        presenceOrUndefined?: boolean
+        parts?: Array<
+          | { type: 'string'; value: string }
+          | { type: 'ternary'; condition: string; whenTrue: string; whenFalse: string }
+          | { type: 'lookup'; key: string }
+        >
+      }
+      // Template-literal attr values (`className={\`… \${props.className ??
+      // ''}\`}`) carry their `props.X` reads inside the parts structure,
+      // not a flat expr string (#1896 — TabsContent's template referenced
+      // `.ClassName` while the Props struct never declared it). Scan every
+      // textual field of every part shape.
+      if (v?.parts) {
+        for (const part of v.parts) {
+          if (part.type === 'string') scan(part.value)
+          else if (part.type === 'ternary') {
+            scan(part.condition)
+            scan(part.whenTrue)
+            scan(part.whenFalse)
+          } else if (part.type === 'lookup') scan(part.key)
+        }
+      }
       if (v?.kind === 'expression' && typeof v.expr === 'string') {
         scan(v.expr)
         const expr = v.expr.trim()
@@ -186,6 +210,20 @@ export function augmentInheritedPropAccesses(ir: ComponentIR): void {
       const c = child as { element?: IRNode }
       walk((c.element ?? child) as IRNode)
     }
+    // Conditional / if-statement nodes keep their subtrees in branch
+    // fields, not `children` (#1896 — DialogTrigger's asChild
+    // if-statement hid the button branch's `id={props.id}` from this
+    // scan, so the template referenced `.ID` without a Props field).
+    const branchy = node as unknown as {
+      whenTrue?: IRNode
+      whenFalse?: IRNode
+      consequent?: IRNode
+      alternate?: IRNode
+    }
+    walk(branchy.whenTrue)
+    walk(branchy.whenFalse)
+    walk(branchy.consequent)
+    walk(branchy.alternate)
   }
   walk(ir.root)
 


### PR DESCRIPTION
## Summary

Fixes the **#1896 headline gap**: JSX children passed to an imported child component silently rendered as an empty container on the Go template adapter. With this PR, **11 of the 12 composed `site/ui` demo fixtures render to byte parity with the Hono reference** and come off `skipJsx` — they now run real Go SSR conformance in CI.

## Mechanism

Children carrying template actions (nested components, dynamic text) can't bake to a static `Children` string, so they render through a **per-call-site companion define** executed with the *parent's* data and injected into the child's props:

```gotemplate
{{template "Child" (bf_with_children .ChildSlotN (bf_tmpl "<Parent>__children_<slot>" .))}}
```

- **runtime**: `bf.TemplateFuncMap(t)` — a `bf_tmpl` closure over the executing template set (registered alongside `bf.FuncMap()` before parsing; reentrant execution is safe because html/template's escape analysis completes before the outer Execute) — plus `bf.WithChildren` (reflection, registered as `bf_with_children`). Statically-bakeable children keep the existing constructor-baked path.
- **adapter**: `queueDynamicChildrenDefine` + define flush in `generate()`; static-instance and nested-loop collection now recurse into component children and if-statement branches (instances inside children need their slot fields on the parent).
- **shared `@barefootjs/jsx`**: `augmentInheritedPropAccesses` (Go+Mojo) scans template-literal attr *parts* and conditional *branches*, so emitted `.ClassName` / `.ID` refs always have a matching props field.

## The long tail

Executing children for the first time surfaced ~a dozen latent codegen bugs, all fixed and verified at parity: stale `restPropsName` in multi-component `generateTypes` (`in.Props undefined`), memo-vs-prop field collisions (`ClassName redeclared`), reference-typed zero values (`0` into map/bool), compile-time resolution of module-const record lookups (`strokePaths['chevron-down']`, `variantClasses.ghost`) and literal consts, `{{{{if` double-wrapping in template-literal ternaries, missing parens on compound args (`eq (or .Placement "top") "left"`), **string-tolerant equality** for union-typed props (`eq (bf_string .Sorted) "asc"` — Go's `eq` errors on bool-vs-string where JS is loosely false), ARIA presence attributes as `aria-x="true"`, and `attr={cond ? v : undefined}` omitting the attribute like Hono.

Harness fixes: two-pass child-shape registration (sibling files referencing each other's components no longer depend on processing order), unified type dedup across entry/sibling/child blocks, `componentModules` keys recognised as sibling specifiers, `html/template` in the merged stdlib imports, and `go run` failures now quote the offending `types.go` lines.

One deliberate test-pin update: the record-index IIFE now switches on `fmt.Sprint(in.Variant)` instead of `in.Variant.(string)` (compiles for both `interface{}` and augmented `string` fields).

## Remaining

`data-table` stays on `skipJsx` with a narrowed docstring — its body is a keyed `.map` over a `/* @client */`-sorted **memo** of module-const object data, a memo-derived dynamic loop of imported components the nested-slice constructor can't bake yet. #1896 stays open for that (and the issue's note about a loud diagnostic is moot for the 11 now at parity).

## Verification

| Suite | Result |
|---|---|
| Go adapter (real Go 1.25.6, 11 demo fixtures un-skipped) | 505 / 0 |
| Go runtime `go test ./...` | ok |
| adapter-tests + adapter-hono | 1185 / 0 |
| jsx / client | 2164 / 0 · 361 / 0 |
| Mojo + Xslate (real perl; shared-helper change covered) | 860 / 0 |
| fixture-hydrate (Playwright, real browser) | 30 / 0 |
| `generate-expected-html` | idempotent (no churn) |

Changesets: `@barefootjs/go-template` minor, `@barefootjs/jsx` patch.

Part of #1467 Phase 3. Next: #1897 (Mojo/Xslate parity).

https://claude.ai/code/session_01SLhVU7vHcwmDiQNFu8LG1y

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLhVU7vHcwmDiQNFu8LG1y)_