### PR TITLE
fix(jsr): mirror tsconfig JSX settings into generated deno.json (Deno 2.8.3 pragma regression)

### DIFF
--- a/scripts/jsr-publish.ts
+++ b/scripts/jsr-publish.ts
@@ -244,10 +244,18 @@ function buildManifest(dir: string, pkg: PkgJson) {
   const tsconfigPath = join(dir, 'tsconfig.json')
   if (existsSync(tsconfigPath)) {
     // tsconfig is JSONC — parse with the TS helper, not JSON.parse.
-    const { config } = ts.parseConfigFileTextToJson(
+    const { config, error } = ts.parseConfigFileTextToJson(
       tsconfigPath,
       readFileSync(tsconfigPath, 'utf8'),
     )
+    if (error) {
+      // Don't fail the whole mirror over it, but don't drop the JSX settings
+      // silently either — without them a .tsx-bearing package resurfaces as
+      // opaque TS2874/TS7026 publish errors.
+      console.warn(
+        `  warn  ${pkg.name}: tsconfig.json parse failed (${ts.flattenDiagnosticMessageText(error.messageText, ' ')}) — JSX settings not mirrored into deno.json`,
+      )
+    }
     const tsOpts = (config?.compilerOptions ?? {}) as Record<string, unknown>
     if (tsOpts.jsx) {
       compilerOptions.jsx = tsOpts.jsx

--- a/scripts/jsr-publish.ts
+++ b/scripts/jsr-publish.ts
@@ -52,6 +52,7 @@
 import { resolve, join } from 'node:path'
 import { existsSync, readdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs'
 import { $ } from 'bun'
+import ts from 'typescript'
 
 const repoRoot = resolve(import.meta.dir, '..')
 const argv = process.argv.slice(2)
@@ -229,9 +230,31 @@ function buildManifest(dir: string, pkg: PkgJson) {
   // sources rely on (notably `process`, used in jsx/hono/go-template) while
   // letting `dom` layer the browser types on top without the duplicate-
   // identifier clash a bare `dom`-only or `/// <reference lib>` would cause.
-  manifest.compilerOptions = {
+  const compilerOptions: Record<string, unknown> = {
     lib: ['deno.window', 'dom', 'dom.iterable', 'dom.asynciterable'],
   }
+  // JSX-bearing packages (adapter-hono's `.tsx` sources) author against the
+  // package tsconfig's `jsx`/`jsxImportSource`, with matching per-file
+  // `// @jsxImportSource` pragmas that must stay line comments for esbuild
+  // (see adapter-hono/src/scripts.tsx). Deno ≤2.8.2 honored those pragmas
+  // during `deno publish` type-checking; 2.8.3 ignores them and falls back
+  // to the classic React transform — TS2874/TS7026 on every tag. Mirror the
+  // tsconfig's JSX settings into the manifest, which every Deno version
+  // respects regardless of pragma handling.
+  const tsconfigPath = join(dir, 'tsconfig.json')
+  if (existsSync(tsconfigPath)) {
+    // tsconfig is JSONC — parse with the TS helper, not JSON.parse.
+    const { config } = ts.parseConfigFileTextToJson(
+      tsconfigPath,
+      readFileSync(tsconfigPath, 'utf8'),
+    )
+    const tsOpts = (config?.compilerOptions ?? {}) as Record<string, unknown>
+    if (tsOpts.jsx) {
+      compilerOptions.jsx = tsOpts.jsx
+      if (tsOpts.jsxImportSource) compilerOptions.jsxImportSource = tsOpts.jsxImportSource
+    }
+  }
+  manifest.compilerOptions = compilerOptions
   manifest.publish = { include: ['src', 'README.md', 'LICENSE', 'deno.json'] }
   return manifest
 }


### PR DESCRIPTION
## Summary

The JSR mirror for `@barefootjs/hono` has been failing `deno publish` type-checking with 18 errors (TS2874 "This JSX tag requires 'React' to be in scope" / TS7026 "no interface 'JSX.IntrinsicElements' exists") across `portals.tsx`, `preload.tsx`, `scripts.tsx`, `portal-ssr.tsx`, and `async.tsx` — see the [failed run](https://github.com/piconic-ai/barefootjs/actions/runs/27388982603).

**Root cause:** the runners picked up Deno 2.8.3 (released this week; `setup-deno` tracks `v2.x`), whose publish-time type-check no longer honors the per-file `// @jsxImportSource hono/jsx` line-comment pragmas that 2.8.2 honored. Those pragmas must stay line comments for esbuild (rationale at the top of `adapter-hono/src/scripts.tsx`), so the fix belongs in the generated manifest instead.

**Fix:** `scripts/jsr-publish.ts` now mirrors the package tsconfig's `jsx` / `jsxImportSource` into the generated `deno.json`'s `compilerOptions`, which every Deno version respects regardless of pragma handling.

## Verification

- `deno publish --dry-run --allow-slow-types --allow-dirty` on `packages/adapter-hono` with the generated manifest: **fails on 2.8.3 / passes on 2.8.2 before the fix; passes on both after**.
- `@barefootjs/xyflow` (the only other publishable package with `jsx` in its tsconfig, but no `.tsx` sources) still passes — the mirrored settings are inert there.
- Other packages' manifests are byte-identical (no `jsx` in their tsconfigs).

https://claude.ai/code/session_015XQDufpcRxH2magvwfW3rf

---
_Generated by [Claude Code](https://claude.ai/code/session_015XQDufpcRxH2magvwfW3rf)_