### PR TITLE
feat(adapter-perl): full Xslate corpus parity + Mojo child var seeding (#1897)

### DIFF
--- a/.changeset/perl-composed-corpus-parity.md
+++ b/.changeset/perl-composed-corpus-parity.md
@@ -1,0 +1,12 @@
+---
+"@barefootjs/xslate": minor
+"@barefootjs/mojolicious": minor
+"@barefootjs/jsx": minor
+"@barefootjs/go-template": patch
+---
+
+Composed `site/ui` demo-corpus parity for the perl adapters (#1897):
+
+- **Xslate now renders the ENTIRE shared conformance corpus to Hono parity** (`skipJsx` is empty). `tabs` / `accordion` / `pagination` came off via: ARIA `aria-selected`/`aria-expanded` and boolean-TYPED prop routing through `bool_str`, compile-time resolution of module object-literal const property access (`variantClasses.ghost`), composed template-literal module consts, `attr={cond ? v : undefined}` attribute omission, and literal-const inlining (`totalPages`).
+- **Mojolicious closes the strict-vars seeding gap**: child renders now seed declared props (JSX default or `undef`), inherited `props.<x>` accesses (via the shared augmentation pass), signal initials, and memo `ssrDefaults` under the caller's props — `tabs` / `tooltip` / `pagination` render to parity and `skipJsx` is empty. The remaining composed fixtures stay pinned on the context-provider object-literal lowering (BF101), the tracked #1897 feature.
+- `@barefootjs/jsx` exports the shared static-const machinery all three SSR adapters now use: `collectModuleStringConsts` (fixed-point, incl. composed template-literal consts and `[...].join(sep)`) and `lookupStaticRecordLiteral` (module object-literal property/index lookup). The Go adapter delegates to it (no behavior change).

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -64,6 +64,7 @@ import {
   collectContextConsumers,
   isLowerableObjectRestDestructure,
   type ContextConsumer,
+  collectModuleStringConsts as collectModuleStringConstsShared
 } from '@barefootjs/jsx'
 import { findInterpolationEnd } from '@barefootjs/jsx/scanner'
 
@@ -4237,96 +4238,13 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * pure compile-time string can be safely inlined byte-for-byte.
    */
   private collectModuleStringConsts(constants: IRMetadata['localConstants']): Map<string, string> {
-    const map = new Map<string, string>()
-    const candidates = (constants ?? []).filter(
-      c => c.isModule && c.value !== undefined,
-    )
-    // Fixed-point: a module string const may be COMPOSED of other module
-    // string consts via a template literal (#1896 — radio-group's
-    // `itemClasses = \`\${itemBaseClasses} \${itemFocusClasses} …\``).
-    // Each pass resolves the consts whose dependencies resolved in an
-    // earlier pass; terminates when a pass adds nothing.
-    let progressed = true
-    while (progressed) {
-      progressed = false
-      for (const c of candidates) {
-        if (map.has(c.name)) continue
-        const literal =
-          this.parsePureStringLiteral(c.value!) ??
-          this.evalTemplateOfStringConsts(c.value!, map)
-        if (literal !== null) {
-          map.set(c.name, literal)
-          progressed = true
-        }
-      }
-    }
-    return map
+    // Single source of truth shared with the Mojo / Xslate adapters
+    // (fixed-point resolution incl. composed template-literal consts and
+    // `[...].join(sep)` — #1896 / #1897).
+    return collectModuleStringConstsShared(constants)
   }
 
-  /**
-   * Evaluate a template literal whose every interpolation is a bare
-   * identifier already present in `resolved` (a module string const) to
-   * its flat string value, else `null`. Companion to
-   * `parsePureStringLiteral` for the composed-const shape (#1896).
-   */
-  private evalTemplateOfStringConsts(
-    source: string,
-    resolved: ReadonlyMap<string, string>,
-  ): string | null {
-    const sf = ts.createSourceFile(
-      '__const.ts',
-      `const __x = (${source});`,
-      ts.ScriptTarget.Latest,
-      /*setParentNodes*/ false,
-    )
-    const stmt = sf.statements[0]
-    if (!stmt || !ts.isVariableStatement(stmt)) return null
-    let init = stmt.declarationList.declarations[0]?.initializer
-    while (init && ts.isParenthesizedExpression(init)) init = init.expression
-    if (!init || !ts.isTemplateExpression(init)) return null
-    let out = init.head.text
-    for (const span of init.templateSpans) {
-      if (!ts.isIdentifier(span.expression)) return null
-      const value = resolved.get(span.expression.text)
-      if (value === undefined) return null
-      out += value + span.literal.text
-    }
-    return out
-  }
 
-  /**
-   * Parse a const initializer's source text. Returns the unescaped string
-   * value when the whole initializer is a single string literal (or a
-   * no-substitution template literal), else `null`. Uses the TS parser so
-   * escapes/quotes are resolved exactly as JS would, matching the value
-   * the Hono reference inlines at runtime.
-   */
-  private parsePureStringLiteral(source: string): string | null {
-    const sf = ts.createSourceFile(
-      '__const.ts',
-      `const __x = (${source});`,
-      ts.ScriptTarget.Latest,
-      /*setParentNodes*/ false,
-    )
-    const stmt = sf.statements[0]
-    if (!stmt || !ts.isVariableStatement(stmt)) return null
-    const decl = stmt.declarationList.declarations[0]
-    let init = decl?.initializer
-    while (init && ts.isParenthesizedExpression(init)) init = init.expression
-    if (!init) return null
-    if (ts.isStringLiteral(init) || ts.isNoSubstitutionTemplateLiteral(init)) {
-      return init.text
-    }
-    // (#checkbox) `[...string literals].join(SEP)` — a const that flattens an
-    // array of pure string literals to a single string at module load (e.g.
-    // Checkbox's `stateClasses = [...].join(' ')`). Evaluate it statically so
-    // the const inlines byte-for-byte like the Hono reference. Only fires when
-    // every array element is a string/no-substitution-template literal and the
-    // separator is a string-literal argument (or omitted → default `,`).
-    const joined = this.evalStringArrayJoin(init)
-    if (joined !== null) return joined
-    return null
-  }
 
   /**
    * (#checkbox) Statically evaluate `[<string literals>].join(<sep?>)`.
@@ -4335,31 +4253,6 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * non-string-literal separator). Comments/whitespace between elements are
    * irrelevant — the TS parser already discarded them.
    */
-  private evalStringArrayJoin(node: ts.Expression): string | null {
-    if (!ts.isCallExpression(node)) return null
-    const callee = node.expression
-    if (!ts.isPropertyAccessExpression(callee)) return null
-    if (callee.name.text !== 'join') return null
-    let recv: ts.Expression = callee.expression
-    while (ts.isParenthesizedExpression(recv)) recv = recv.expression
-    if (!ts.isArrayLiteralExpression(recv)) return null
-    const parts: string[] = []
-    for (const el of recv.elements) {
-      if (ts.isStringLiteral(el) || ts.isNoSubstitutionTemplateLiteral(el)) {
-        parts.push(el.text)
-      } else {
-        return null
-      }
-    }
-    let sep = ','
-    if (node.arguments.length >= 1) {
-      const arg = node.arguments[0]
-      if (ts.isStringLiteral(arg) || ts.isNoSubstitutionTemplateLiteral(arg)) sep = arg.text
-      else return null
-    }
-    return parts.join(sep)
-  }
-
   /**
    * Resolve an identifier to its inlined Go string literal when it names a
    * module pure-string const. Returns the Go template literal form

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -17,27 +17,18 @@ runAdapterConformanceTests({
   name: 'mojo',
   factory: () => new MojoAdapter(),
   render: renderMojoComponent,
-  // JSX-render skips: every other shared conformance fixture renders to
-  // Hono parity on real Mojolicious. Shapes the adapter intentionally
-  // refuses at build time are pinned in `expectedDiagnostics` below.
-  //
-  // `tabs` (#1467 demo corpus): compiles clean but fails at render time
-  // inside `BarefootJS::render_child` (Mojo::Template exception) for the
-  // composed `{{template}}`-equivalent child call. Cross-adapter parity
-  // for the composed `site/ui` demo corpus is the #1467 Phase 3
-  // follow-up; see https://github.com/piconic-ai/barefootjs/issues/1897.
-  // Hono SSR conformance + the real-browser fixture-hydrate layer keep
-  // the fixture fully covered.
-  // `tooltip` (#1467 Phase 2c overlay): compiles, and `render_child`
-  // even passes the JSX children through — but the child template
-  // references its props as undeclared Perl lexicals (`Global symbol
-  // "$open" requires explicit package name`), the adapter's known
-  // Perl-scoping limitation surfacing at render time. Same #1897
-  // bucket.
-  // `pagination` (#1467 Phase 2e): compiles clean but the EP render
-  // dies in perl (exit 2) on the composed link shape — same #1897
-  // bucket as `tabs`/`tooltip`.
-  skipJsx: ['tabs', 'tooltip', 'pagination'],
+  // No JSX-render skips: every shared conformance fixture — including
+  // the renderable members of the composed `site/ui` demo corpus
+  // (#1467 / #1897) — renders to Hono parity on real Mojolicious.
+  // `tabs` / `tooltip` / `pagination` came off via the harness's
+  // child-defaults seeding (declared props, inherited accesses, signal
+  // initials, memo ssrDefaults — closing the strict-vars `Global
+  // symbol "$id"` gap), boolean-typed prop routing through
+  // `bf->bool_str`, `attr={cond ? v : undefined}` omission, and
+  // literal-const inlining. The remaining demo fixtures are pinned in
+  // `expectedDiagnostics` below — they need the context-provider
+  // object-literal lowering, an adapter feature tracked in #1897.
+  skipJsx: [],
   // Per-fixture build-time contracts for shapes the Mojo adapter
   // intentionally refuses to lower. Owned by this adapter test file
   // (not by the shared fixtures) so adding a new adapter doesn't

--- a/packages/adapter-mojolicious/src/adapter/boolean-result.ts
+++ b/packages/adapter-mojolicious/src/adapter/boolean-result.ts
@@ -112,6 +112,11 @@ const ARIA_BOOLEAN_ATTRS = new Set([
   'aria-multiselectable',
   'aria-readonly',
   'aria-required',
+  // true | false | undefined (absent) — selection / disclosure state
+  // (#1897: tabs' `aria-selected={props.selected ?? false}` rendered the
+  // Perl-native `1`/`0` without this).
+  'aria-selected',
+  'aria-expanded',
   // Tri-state (true | false | mixed). The `bool_str` helper only
   // maps Perl truthy / falsy to true / false — a fixture that wants
   // the literal `"mixed"` would bind a string-valued JSX attr

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -56,6 +56,8 @@ import {
   isLowerableObjectRestDestructure,
   type ContextConsumer,
   extractSsrDefaults,
+  collectModuleStringConsts,
+  lookupStaticRecordLiteral
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr } from './boolean-result.ts'
 
@@ -249,6 +251,7 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
    */
   private propsObjectName: string | null = null
   private propsParams: { name: string }[] = []
+  private booleanTypedProps: Set<string> = new Set()
   /**
    * Names (signal getters + props) whose value is a string, so `===`/`!==`
    * against them lowers to Perl `eq`/`ne` rather than numeric `==`/`!=`.
@@ -322,6 +325,15 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     // serialization happens before `generate`, so this mutation doesn't reach it).
     augmentInheritedPropAccesses(ir)
     this.propsParams = ir.metadata.propsParams.map(p => ({ name: p.name }))
+    // Props whose declared TS type is boolean — a bare binding of one
+    // (`data-active={props.isActive}`) must stringify as JS
+    // `String(boolean)` ("true"/"false"), not Perl's native `1`/`''`
+    // (#1897, pagination's data-active).
+    this.booleanTypedProps = new Set(
+      ir.metadata.propsParams
+        .filter(prop => prop.type?.primitive === 'boolean' || prop.type?.raw === 'boolean')
+        .map(prop => prop.name),
+    )
     // No-destructure-default props → `undef` when the caller omits them
     // → guard their bare-reference attribute emission with Perl `defined`
     // so the attribute drops instead of rendering `attr=""` (Hono-style
@@ -361,7 +373,7 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     for (const p of ir.metadata.propsParams) {
       if (isStringTypeInfo(p.type)) this.stringValueNames.add(p.name)
     }
-    this.moduleStringConsts = this.collectModuleStringConsts(ir.metadata.localConstants)
+    this.moduleStringConsts = collectModuleStringConsts(ir.metadata.localConstants)
     this.localConstants = ir.metadata.localConstants ?? []
     this.loopBoundNames.clear()
     this.errors = []
@@ -430,25 +442,6 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     }
   }
 
-  /**
-   * Build the module pure-string-const map from the IR's localConstants.
-   * A const qualifies only when it is module-scope (`isModule`) and its
-   * initializer parses to a single string literal (`ts.StringLiteral` or
-   * `ts.NoSubstitutionTemplateLiteral`). Template literals with `${}`,
-   * numeric/object initializers, `Record<T,string>` maps, memos, and
-   * signals are all excluded — only a pure compile-time string can be
-   * inlined byte-for-byte.
-   */
-  private collectModuleStringConsts(constants: IRMetadata['localConstants']): Map<string, string> {
-    const map = new Map<string, string>()
-    for (const c of constants ?? []) {
-      if (!c.isModule) continue
-      if (c.value === undefined) continue
-      const literal = parsePureStringLiteral(c.value)
-      if (literal !== null) map.set(c.name, literal)
-    }
-    return map
-  }
 
   /**
    * Resolve an identifier to its inlined Perl single-quoted string literal
@@ -456,6 +449,74 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
    * falls back to its normal `$name` stash lowering). Returns the Perl
    * literal form `'<escaped>'` ready to drop into an expression.
    */
+  /**
+   * Resolve `IDENT.key` over a module object-literal const to its Perl
+   * literal (`variantClasses.ghost` in a class template literal —
+   * #1897). Same compile-time inlining family as
+   * `resolveModuleStringConst`; returns `null` for any non-static shape.
+   */
+  /**
+   * Whether `expr` is a bare reference to a boolean-TYPED prop
+   * (`props.isActive` / destructured `isActive`) — used to route the
+   * binding through `bool_str` even though the expression itself is
+   * structurally opaque (#1897).
+   */
+  isBooleanTypedPropRef(expr: string): boolean {
+    let bare = expr.trim()
+    if (this.propsObjectName && bare.startsWith(`${this.propsObjectName}.`)) {
+      bare = bare.slice(this.propsObjectName.length + 1)
+    }
+    if (!/^[A-Za-z_$][\w$]*$/.test(bare)) return false
+    return this.booleanTypedProps.has(bare)
+  }
+
+  /**
+   * Parse `cond ? value : undefined` (or `: null`), returning the
+   * condition/consequent source spans, else `null`. Used for the
+   * attribute-omission rule (#1897); mirrors the Xslate adapter.
+   */
+  parseUndefinedAlternateTernary(
+    expr: string,
+  ): { condition: string; consequent: string } | null {
+    const parsed = parseExpression(expr.trim())
+    if (parsed?.kind !== 'conditional') return null
+    const alt = parsed.alternate
+    const isUndef =
+      (alt.kind === 'identifier' && (alt.name === 'undefined' || alt.name === 'null')) ||
+      (alt.kind === 'literal' && (alt.value === null || alt.value === undefined))
+    if (!isUndef) return null
+    const q = expr.indexOf('?')
+    const c = expr.lastIndexOf(':')
+    if (q === -1 || c === -1 || c < q) return null
+    return { condition: expr.slice(0, q).trim(), consequent: expr.slice(q + 1, c).trim() }
+  }
+
+  /**
+   * Inline a const (any scope) whose initializer is a pure numeric or
+   * quoted string literal (`const totalPages = 5`, #1897 pagination) —
+   * function-scope consts never reach the per-render stash, so a bare
+   * `$totalPages` faults under strict mode.
+   */
+  resolveLiteralConst(name: string): string | null {
+    if (this.loopBoundNames?.has?.(name)) return null
+    const c = (this.localConstants ?? []).find(lc => lc.name === name)
+    if (c?.value === undefined) return null
+    const v = c.value.trim()
+    if (/^-?\d+(\.\d+)?$/.test(v)) return v
+    const strLit = /^'([^'\\]*)'$/.exec(v) ?? /^"([^"\\]*)"$/.exec(v)
+    if (strLit) return `'${strLit[1].replace(/[\\']/g, m => `\\${m}`)}'`
+    return null
+  }
+
+  resolveStaticRecordLiteral(objectName: string, key: string): string | null {
+    if (this.loopBoundNames?.has?.(objectName)) return null
+    const hit = lookupStaticRecordLiteral(objectName, key, this.localConstants)
+    if (!hit) return null
+    return hit.kind === 'number'
+      ? hit.text
+      : `'${hit.text.replace(/[\\']/g, m => `\\${m}`)}'`
+  }
+
   resolveModuleStringConst(name: string): string | null {
     // A loop body introduces `my $<param>` / `my $<index>` bindings that
     // shadow a module const of the same name — never inline inside one.
@@ -1267,7 +1328,7 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       ) {
         const perl = this.convertExpressionToPerl(value.expr)
         const body =
-          isBooleanResultExpr(value.expr) || isAriaBooleanAttr(name)
+          isBooleanResultExpr(value.expr) || isAriaBooleanAttr(name) || this.isBooleanTypedPropRef(value.expr)
             ? `${name}="<%= bf->bool_str(${perl}) %>"`
             : `${name}="<%= ${perl} %>"`
         return `<% if (defined ${perl}) { %>${body}<% } %>`
@@ -1294,8 +1355,21 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       // Hono's / Go's `attr="false"` / `attr="true"`. Routing through
       // the `bf->bool_str` Perl helper realigns the wire bytes with
       // JS `String(boolean)` semantics.
+      // `attr={cond ? value : undefined}` OMITS the attribute on the
+      // falsy branch (Hono drops undefined-valued attributes) — wrap the
+      // whole attribute in the condition instead of rendering `attr=""`
+      // (#1897, pagination's `aria-current={props.isActive ? 'page' :
+      // undefined}`). Same parity rule as the Go / Xslate adapters.
+      {
+        const m = this.parseUndefinedAlternateTernary(value.expr)
+        if (m) {
+          const cond = this.convertExpressionToPerl(m.condition)
+          const val = this.convertExpressionToPerl(m.consequent)
+          return `<% if (${cond}) { %>${name}="<%= ${val} %>"<% } %>`
+        }
+      }
       const perl = this.convertExpressionToPerl(value.expr)
-      if (isBooleanResultExpr(value.expr) || isAriaBooleanAttr(name)) {
+      if (isBooleanResultExpr(value.expr) || isAriaBooleanAttr(name) || this.isBooleanTypedPropRef(value.expr)) {
         return `${name}="<%= bf->bool_str(${perl}) %>"`
       }
       return `${name}="<%= ${perl} %>"`
@@ -2431,11 +2505,19 @@ class MojoTopLevelEmitter implements ParsedExprEmitter {
   constructor(private readonly adapter: MojoAdapter) {}
 
   identifier(name: string): string {
+    // `undefined` / `null` nested inside a larger expression tree
+    // (#1897, pagination's `props.isActive ? 'page' : undefined`) — the
+    // top-level short-circuits don't see them.
+    if (name === 'undefined' || name === 'null') return 'undef'
     // Module pure-string const (e.g. `const baseClasses = '...'` used in a
     // className template literal): inline the literal value rather than emit
     // `$baseClasses` against a stash variable that is never bound.
     const inlined = this.adapter.resolveModuleStringConst(name)
     if (inlined !== null) return inlined
+    // Same for a literal const of any scope (`const totalPages = 5`,
+    // #1897 pagination's `Page {currentPage()} of {totalPages}`).
+    const literalConst = this.adapter.resolveLiteralConst(name)
+    if (literalConst !== null) return literalConst
     return `$${name}`
   }
 
@@ -2452,6 +2534,14 @@ class MojoTopLevelEmitter implements ParsedExprEmitter {
     // `$props` hashref).
     if (object.kind === 'identifier' && object.name === 'props') {
       return `$${property}`
+    }
+    // Static property access on a module object-literal const
+    // (`variantClasses.ghost`, #1897) resolves at compile time — the
+    // generic hash lowering below would dereference a Perl var that
+    // doesn't exist server-side.
+    if (object.kind === 'identifier') {
+      const staticValue = this.adapter.resolveStaticRecordLiteral(object.name, property)
+      if (staticValue !== null) return staticValue
     }
     const obj = emit(object)
     if (property === 'length') return `scalar(@{${obj}})`

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -485,10 +485,14 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       (alt.kind === 'identifier' && (alt.name === 'undefined' || alt.name === 'null')) ||
       (alt.kind === 'literal' && (alt.value === null || alt.value === undefined))
     if (!isUndef) return null
-    const q = expr.indexOf('?')
-    const c = expr.lastIndexOf(':')
-    if (q === -1 || c === -1 || c < q) return null
-    return { condition: expr.slice(0, q).trim(), consequent: expr.slice(q + 1, c).trim() }
+    // Serialise the parsed sub-expressions back to JS source rather than
+    // slicing `expr` text — `indexOf('?')` / `lastIndexOf(':')` would
+    // mis-split when the consequent itself contains `?` / `:` inside a
+    // string or nested ternary (`cond ? 'a:b' : undefined`).
+    return {
+      condition: exprToString(parsed.test),
+      consequent: exprToString(parsed.consequent),
+    }
   }
 
   /**

--- a/packages/adapter-mojolicious/src/test-render.ts
+++ b/packages/adapter-mojolicious/src/test-render.ts
@@ -5,7 +5,7 @@
  * Used by adapter-tests conformance runner.
  */
 
-import { compileJSX, extractSsrDefaults } from '@barefootjs/jsx'
+import { compileJSX, extractSsrDefaults, augmentInheritedPropAccesses } from '@barefootjs/jsx'
 import type { ComponentIR } from '@barefootjs/jsx'
 import { mkdir, rm } from 'node:fs/promises'
 import { resolve } from 'node:path'
@@ -332,6 +332,7 @@ function buildChildRenderers(
     lines.push(`  close $child_fh;`)
     lines.push(`  my $child_mt = Mojo::Template->new(vars => 1, auto_escape => 1);`)
 
+    lines.push(`  my $defaults_${snakeName} = ${buildChildDefaultsPerl(childIR)};`)
     lines.push(`  $bf->register_child_renderer('${snakeName}', sub {`)
     // `$caller_bf` is the instance whose template invoked render_child
     // (#1897) — nested children chain their scope identity off it.
@@ -352,6 +353,20 @@ function buildChildRenderers(
     if (childIR.metadata.restPropsName) {
       const rest = childIR.metadata.restPropsName
       lines.push(`    $child_props->{${rest}} = {} unless defined $child_props->{${rest}};`)
+      // (#1897) Route non-param props into the rest bag (JSX rest
+      // semantics): a caller prop the child didn't destructure belongs
+      // in the bag, not as a top-level stash var. Mirrors the Xslate
+      // harness and the production isRestProps branch.
+      const paramNames = (childIR.metadata.propsParams ?? []).map(p => p.name)
+      const keepList = [...new Set([...paramNames, rest, 'children', 'key', '_bf_slot'])]
+        .map(n => `'${n.replace(/[\\']/g, m => `\\${m}`)}'`)
+        .join(', ')
+      lines.push(`    {`)
+      lines.push(`      my %keep = map { $_ => 1 } (${keepList});`)
+      lines.push(`      for my $k (grep { !$keep{$_} } keys %$child_props) {`)
+      lines.push(`        $child_props->{${rest}}{$k} = delete $child_props->{$k};`)
+      lines.push(`      }`)
+      lines.push(`    }`)
     }
     lines.push(`    my $child_bf = BarefootJS->new($c, {});`)
     // (#1897) Nested `render_child` calls (a child template rendering
@@ -373,7 +388,9 @@ function buildChildRenderers(
     lines.push(`    } else {`)
     lines.push(`      $child_bf->_scope_id('${componentName}_' . substr(rand() =~ s/^0\\.//r, 0, 6));`)
     lines.push(`    }`)
-    lines.push(`    my $rendered = $child_mt->render($child_tmpl, { %$child_props, bf => $child_bf });`)
+    // Seed statically-derived defaults under the caller's props (#1897)
+    // so undeclared optional props / signals don't abort strict vars.
+    lines.push(`    my $rendered = $child_mt->render($child_tmpl, { %$defaults_${snakeName}, %$child_props, bf => $child_bf });`)
     lines.push(`    die $rendered->to_string if ref $rendered;`)
     lines.push(`    chomp $rendered;`)
     lines.push(`    return $rendered;`)
@@ -398,6 +415,59 @@ function toSnakeCase(name: string): string {
 /**
  * Build a Perl hash literal from props.
  */
+/**
+ * Statically-derived default template vars for a CHILD component
+ * (#1897): every declared prop (its JSX default or `undef`), inherited
+ * `props.<x>` accesses, signal initial values, and memo ssrDefaults.
+ * Without these, a child template referencing an optional prop the
+ * caller didn't pass (`$id`, `$className`) or its own signal (`$open`)
+ * aborts under Mojo::Template's strict vars. Caller-passed props win at
+ * merge time (`{ %$defaults, %$child_props }`). Mirrors the root-side
+ * seeding in `buildPerlProps` and the production plugin's
+ * `ssrDefaults` consumption.
+ */
+function buildChildDefaultsPerl(ir: ComponentIR): string {
+  // Surface inherited `props.<x>` reads hidden inside template-literal
+  // attr parts / conditional branches as propsParams (idempotent; the
+  // same shared pass the adapters apply — without it TabsContent's
+  // `${props.className ?? ''}` class read never seeds `$className`).
+  augmentInheritedPropAccesses(ir)
+  const entries: string[] = []
+  const declared = new Set<string>()
+  for (const param of ir.metadata.propsParams) {
+    declared.add(param.name)
+    if (param.defaultValue) {
+      const perlValue = jsToPerlValue(param.defaultValue)
+      if (perlValue !== null) {
+        entries.push(`${param.name} => ${perlValue}`)
+        continue
+      }
+    }
+    entries.push(`${param.name} => undef`)
+  }
+  if (ir.metadata.propsObjectName) {
+    for (const name of collectPropsObjectAccesses(ir, ir.metadata.propsObjectName)) {
+      if (declared.has(name)) continue
+      declared.add(name)
+      entries.push(`${name} => undef`)
+    }
+  }
+  for (const signal of ir.metadata.signals) {
+    const value = evaluateSignalInit(signal.initialValue.trim(), undefined)
+    entries.push(`${signal.getter} => ${value !== null ? toPerlLiteral(value) : 'undef'}`)
+  }
+  const ssrDefaults = extractSsrDefaults(ir.metadata) ?? {}
+  for (const memo of ir.metadata.memos) {
+    const entry = ssrDefaults[memo.name]
+    const value =
+      entry && typeof entry === 'object' && 'value' in entry ? entry.value : undefined
+    entries.push(
+      `${memo.name} => ${value !== undefined && value !== null ? toPerlLiteral(value) : 'undef'}`,
+    )
+  }
+  return `{${entries.join(', ')}}`
+}
+
 function buildPerlProps(
   _componentName: string,
   props: Record<string, unknown> | undefined,

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -25,24 +25,18 @@ runAdapterConformanceTests({
   name: 'xslate',
   factory: () => new XslateAdapter(),
   render: renderXslateComponent,
-  // JSX-render skips: every other shared conformance fixture renders to
-  // Hono parity on real Text::Xslate — `dialog` / `popover` / `tooltip`
-  // joined after #1903's shared-helper fixes (inherited-prop scanning of
-  // template parts + branch walks) and the nested child-renderer
-  // registry propagation below. Shapes the adapter intentionally
-  // refuses at build time are pinned in `expectedDiagnostics`.
-  //
-  // #1467 demo corpus — remaining #1897 gaps:
-  //   - `tabs`: prop-driven ARIA booleans stringify as Perl `1`/`0` vs
-  //     Hono's `true`/`false`.
-  //   - `accordion`: the trigger's nested ChevronDownIcon renders empty
-  //     (the Kolon render of the icon template silently yields '' —
-  //     unlike the registry gap, the renderer IS registered), and the
-  //     composed module-const class strings resolve empty.
-  //   - `pagination`: composed module-const class strings
-  //     (`${buttonBaseClasses} ${variantClasses.ghost} …`) resolve
-  //     empty on the Kolon side.
-  skipJsx: ['accordion', 'tabs', 'pagination'],
+  // No JSX-render skips: every shared conformance fixture — including
+  // the composed `site/ui` demo corpus (#1467 / #1897) — renders to
+  // Hono parity on real Text::Xslate. The last three (`tabs`,
+  // `accordion`, `pagination`) came off via: shared module-const
+  // resolution (composed template-literal consts), compile-time
+  // record-property lookup (`variantClasses.ghost`), ARIA
+  // `aria-selected`/`aria-expanded` + boolean-TYPED prop routing
+  // through `bool_str`, `attr={cond ? v : undefined}` omission, and
+  // literal-const inlining (`totalPages`). Shapes the adapter
+  // intentionally refuses at build time stay pinned in
+  // `expectedDiagnostics` below.
+  skipJsx: [],
   // Per-fixture build-time contracts for shapes the Xslate adapter
   // intentionally refuses to lower. Mirrors mojo's set — the lowering
   // gates are shared code paths in the ported adapter.

--- a/packages/adapter-xslate/src/adapter/boolean-result.ts
+++ b/packages/adapter-xslate/src/adapter/boolean-result.ts
@@ -112,6 +112,11 @@ const ARIA_BOOLEAN_ATTRS = new Set([
   'aria-multiselectable',
   'aria-readonly',
   'aria-required',
+  // true | false | undefined (absent) — selection / disclosure state
+  // (#1897: tabs' `aria-selected={props.selected ?? false}` rendered the
+  // Perl-native `1`/`0` without this).
+  'aria-selected',
+  'aria-expanded',
   // Tri-state (true | false | mixed). The `bool_str` helper only
   // maps Perl truthy / falsy to true / false — a fixture that wants
   // the literal `"mixed"` would bind a string-valued JSX attr

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -55,6 +55,7 @@ import {
   type AttrValueEmitter,
   isBooleanAttr,
   parseExpression,
+  exprToString,
   parseStyleObjectEntries,
   isSupported,
   identifierPath,
@@ -1660,13 +1661,14 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
       (alt.kind === 'identifier' && (alt.name === 'undefined' || alt.name === 'null')) ||
       (alt.kind === 'literal' && (alt.value === null || alt.value === undefined))
     if (!isUndef) return null
-    // Re-derive the source spans textually: condition is everything
-    // before the first top-level `?`, consequent between it and the
-    // final `:`. The parse above guarantees the top-level shape.
-    const q = expr.indexOf('?')
-    const c = expr.lastIndexOf(':')
-    if (q === -1 || c === -1 || c < q) return null
-    return { condition: expr.slice(0, q).trim(), consequent: expr.slice(q + 1, c).trim() }
+    // Serialise the parsed sub-expressions back to JS source rather than
+    // slicing `expr` text — `indexOf('?')` / `lastIndexOf(':')` would
+    // mis-split when the consequent itself contains `?` / `:` inside a
+    // string or nested ternary (`cond ? 'a:b' : undefined`).
+    return {
+      condition: exprToString(parsed.test),
+      consequent: exprToString(parsed.consequent),
+    }
   }
 
   isBooleanTypedPropRef(expr: string): boolean {

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -64,11 +64,13 @@ import {
   augmentInheritedPropAccesses,
   parseRecordIndexAccess,
   evalStringArrayJoin,
+  collectModuleStringConsts,
   extractArrowBodyExpression,
   collectContextConsumers,
   isLowerableObjectRestDestructure,
   type ContextConsumer,
   extractSsrDefaults,
+  lookupStaticRecordLiteral
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr } from './boolean-result.ts'
 import ts from 'typescript'
@@ -223,6 +225,7 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
    */
   private propsObjectName: string | null = null
   private propsParams: { name: string }[] = []
+  private booleanTypedProps: Set<string> = new Set()
   /**
    * Names (signal getters + props) whose value is a string, so `===`/`!==`
    * against them lowers to Perl `eq`/`ne` rather than numeric `==`/`!=`.
@@ -274,6 +277,15 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     // shared helper, before deriving `nullableOptionalProps` below.
     augmentInheritedPropAccesses(ir)
     this.propsParams = ir.metadata.propsParams.map(p => ({ name: p.name }))
+    // Props whose declared TS type is boolean — a bare binding of one
+    // (`data-active={props.isActive}`) must stringify as JS
+    // `String(boolean)` ("true"/"false"), not Perl's native `1`/`''`
+    // (#1897, pagination's data-active).
+    this.booleanTypedProps = new Set(
+      ir.metadata.propsParams
+        .filter(prop => prop.type?.primitive === 'boolean' || prop.type?.raw === 'boolean')
+        .map(prop => prop.name),
+    )
     this.localConstants = ir.metadata.localConstants ?? []
     // Bare references to optional, no-default, non-primitive props (e.g.
     // textarea's `rows`) are `undef` when omitted → `defined`-guarded in
@@ -1129,7 +1141,7 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
       ) {
         const perl = this.convertExpressionToKolon(value.expr)
         const body =
-          isBooleanResultExpr(value.expr) || isAriaBooleanAttr(name)
+          isBooleanResultExpr(value.expr) || isAriaBooleanAttr(name) || this.isBooleanTypedPropRef(value.expr)
             ? `${name}="<: $bf.bool_str(${perl}) :>"`
             : `${name}="<: ${perl} :>"`
         // Kolon `:` line directives must each stand alone on their own line, so
@@ -1140,10 +1152,23 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
         // Boolean attributes: render conditionally (present or absent).
         return `<: ${this.convertExpressionToKolon(value.expr)} ? '${name}' : '' :>`
       }
+      // `attr={cond ? value : undefined}` OMITS the attribute on the
+      // falsy branch (Hono drops undefined-valued attributes) — wrap the
+      // whole attribute in the condition instead of rendering `attr=""`
+      // (#1897, pagination's `aria-current={props.isActive ? 'page' :
+      // undefined}`). Same parity rule the Go adapter applies.
+      {
+        const m = this.parseUndefinedAlternateTernary(value.expr)
+        if (m) {
+          const cond = this.convertExpressionToKolon(m.condition)
+          const val = this.convertExpressionToKolon(m.consequent)
+          return `\n: if (${cond}) {\n${name}="<: ${val} :>"\n: }\n`
+        }
+      }
       // Boolean-result handling: route boolean-shaped values through
       // `$bf.bool_str` so the wire bytes match JS `String(boolean)`.
       const perl = this.convertExpressionToKolon(value.expr)
-      if (isBooleanResultExpr(value.expr) || isAriaBooleanAttr(name)) {
+      if (isBooleanResultExpr(value.expr) || isAriaBooleanAttr(name) || this.isBooleanTypedPropRef(value.expr)) {
         return `${name}="<: $bf.bool_str(${perl}) :>"`
       }
       return `${name}="<: ${perl} :>"`
@@ -1608,6 +1633,75 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
    * normal `$name` stash lowering). Loop-bound names shadow module consts, so
    * never inline inside a loop body. Returns `'<escaped>'`.
    */
+  /**
+   * Resolve `IDENT.key` over a module object-literal const to its Kolon
+   * literal (`variantClasses.ghost` in a class template literal —
+   * #1897). Same compile-time inlining family as
+   * `_resolveModuleStringConst`; returns `null` for any non-static shape.
+   */
+  /**
+   * Whether `expr` is a bare reference to a boolean-TYPED prop
+   * (`props.isActive` / destructured `isActive`) — used to route the
+   * binding through `bool_str` even though the expression itself is
+   * structurally opaque (#1897).
+   */
+  /**
+   * Parse `cond ? value : undefined` (or `: null`), returning the
+   * condition/consequent source spans, else `null`. Used for the
+   * attribute-omission rule (#1897).
+   */
+  parseUndefinedAlternateTernary(
+    expr: string,
+  ): { condition: string; consequent: string } | null {
+    const parsed = parseExpression(expr.trim())
+    if (parsed?.kind !== 'conditional') return null
+    const alt = parsed.alternate
+    const isUndef =
+      (alt.kind === 'identifier' && (alt.name === 'undefined' || alt.name === 'null')) ||
+      (alt.kind === 'literal' && (alt.value === null || alt.value === undefined))
+    if (!isUndef) return null
+    // Re-derive the source spans textually: condition is everything
+    // before the first top-level `?`, consequent between it and the
+    // final `:`. The parse above guarantees the top-level shape.
+    const q = expr.indexOf('?')
+    const c = expr.lastIndexOf(':')
+    if (q === -1 || c === -1 || c < q) return null
+    return { condition: expr.slice(0, q).trim(), consequent: expr.slice(q + 1, c).trim() }
+  }
+
+  isBooleanTypedPropRef(expr: string): boolean {
+    let bare = expr.trim()
+    if (this.propsObjectName && bare.startsWith(`${this.propsObjectName}.`)) {
+      bare = bare.slice(this.propsObjectName.length + 1)
+    }
+    if (!/^[A-Za-z_$][\w$]*$/.test(bare)) return false
+    return this.booleanTypedProps.has(bare)
+  }
+
+  /**
+   * Inline a const (any scope) whose initializer is a pure numeric or
+   * single-quoted string literal (`const totalPages = 5`, #1897
+   * pagination) — function-scope consts never reach the per-render
+   * stash, so a bare `$totalPages` renders empty.
+   */
+  _resolveLiteralConst(name: string): string | null {
+    const c = (this.localConstants ?? []).find(lc => lc.name === name)
+    if (c?.value === undefined) return null
+    const v = c.value.trim()
+    if (/^-?\d+(\.\d+)?$/.test(v)) return v
+    const strLit = /^'([^'\\]*)'$/.exec(v) ?? /^"([^"\\]*)"$/.exec(v)
+    if (strLit) return `'${strLit[1].replace(/[\\']/g, m => `\\${m}`)}'`
+    return null
+  }
+
+  _resolveStaticRecordLiteral(objectName: string, key: string): string | null {
+    const hit = lookupStaticRecordLiteral(objectName, key, this.localConstants)
+    if (!hit) return null
+    return hit.kind === 'number'
+      ? hit.text
+      : `'${hit.text.replace(/[\\']/g, m => `\\${m}`)}'`
+  }
+
   _resolveModuleStringConst(name: string): string | null {
     // A loop body may bind `my $<param>` that shadows a module const of the
     // same name; never inline inside one (conservative — drop to `$name`).
@@ -1881,21 +1975,6 @@ function unescapeStringLiteralBody(s: string): string {
   })
 }
 
-/**
- * Build the module pure-string-const map from the IR's localConstants. A const
- * qualifies only when module-scope (`isModule`) and its initializer parses to a
- * single pure string literal.
- */
-function collectModuleStringConsts(constants: IRMetadata['localConstants'] | undefined): Map<string, string> {
-  const map = new Map<string, string>()
-  for (const c of constants ?? []) {
-    if (!c.isModule) continue
-    if (c.value === undefined) continue
-    const literal = parsePureStringLiteral(c.value)
-    if (literal !== null) map.set(c.name, literal)
-  }
-  return map
-}
 
 /** True when `type` is the `string` primitive. */
 function isStringTypeInfo(type: TypeInfo | undefined): boolean {
@@ -2088,10 +2167,17 @@ class XslateTopLevelEmitter implements ParsedExprEmitter {
   constructor(private readonly adapter: XslateAdapter) {}
 
   identifier(name: string): string {
+    // `undefined` / `null` nested inside a larger expression tree —
+    // Kolon `nil` (#1897).
+    if (name === 'undefined' || name === 'null') return 'nil'
     // Inline a module-scope pure-string const (`const x = 'literal'`) — it
     // never reaches the per-render stash, so a bare `$x` would render empty.
     const inlined = this.adapter._resolveModuleStringConst(name)
     if (inlined !== null) return inlined
+    // Same for a literal const of any scope (`const totalPages = 5`,
+    // #1897 pagination's `Page {currentPage()} of {totalPages}`).
+    const literalConst = this.adapter._resolveLiteralConst(name)
+    if (literalConst !== null) return literalConst
     return `$${name}`
   }
 
@@ -2107,6 +2193,14 @@ class XslateTopLevelEmitter implements ParsedExprEmitter {
     // (props arrive as individual top-level vars, not a `$props` hashref).
     if (object.kind === 'identifier' && object.name === 'props') {
       return `$${property}`
+    }
+    // Static property access on a module object-literal const
+    // (`variantClasses.ghost`, #1897) resolves at compile time — the
+    // generic dot lowering below would reference a Kolon var that
+    // doesn't exist server-side and silently render ''.
+    if (object.kind === 'identifier') {
+      const staticValue = this.adapter._resolveStaticRecordLiteral(object.name, property)
+      if (staticValue !== null) return staticValue
     }
     const obj = emit(object)
     // `.length` → `$bf.length` (array count or string char count, JS-compat);

--- a/packages/adapter-xslate/src/test-render.ts
+++ b/packages/adapter-xslate/src/test-render.ts
@@ -367,6 +367,20 @@ function buildChildRenderers(
     // one so Kolon's var lookup doesn't fault.
     if (restPropsName) {
       lines.push(`    $child_props->{${restPropsName}} = {} unless defined $child_props->{${restPropsName}};`)
+      // (#1897) Route non-param props into the rest bag, mirroring the
+      // production runtime's `_derive_stash_from_defaults` isRestProps
+      // branch and JSX rest semantics: a caller prop the child didn't
+      // destructure (`href` on PaginationPrevious's `{...props}` anchor)
+      // belongs in the bag, not as a top-level stash var the template
+      // never reads.
+      const paramNames = (childIR.metadata.propsParams ?? []).map(p => p.name)
+      const keep = JSON.stringify([...new Set([...paramNames, restPropsName, 'children', 'key', '_bf_slot'])])
+      lines.push(`    {`)
+      lines.push(`      my %keep = map { $_ => 1 } @{ ${perlArrayLiteral(keep)} };`)
+      lines.push(`      for my $k (grep { !$keep{$_} } keys %$child_props) {`)
+      lines.push(`        $child_props->{${restPropsName}}{$k} = delete $child_props->{$k};`)
+      lines.push(`      }`)
+      lines.push(`    }`)
     }
     lines.push(`    my $slot_id = delete $child_props->{_bf_slot};`)
     lines.push(`    my $child_bf = BarefootJS->new(undef, { backend => $backend });`)
@@ -401,6 +415,13 @@ function buildChildRenderers(
   return lines.join('\n')
 }
 
+
+
+/** Render a JSON string-array as a Perl arrayref literal (['a','b']). */
+function perlArrayLiteral(jsonArray: string): string {
+  const names = JSON.parse(jsonArray) as string[]
+  return `[${names.map(n => `'${n.replace(/[\\']/g, m => `\\${m}`)}'`).join(', ')}]`
+}
 
 /** Serialise an ssrDefaults map to a Perl hashref literal. */
 function ssrDefaultsToPerl(defaults: Record<string, unknown>): string {

--- a/packages/jsx/src/augment-inherited-props.ts
+++ b/packages/jsx/src/augment-inherited-props.ts
@@ -245,15 +245,6 @@ export function augmentInheritedPropAccesses(ir: ComponentIR): void {
 }
 
 /**
- * Statically evaluate `[<string literals>].join(<sep?>)` (e.g. a module-scope
- * `const stateClasses = ['…', …].join(' ')`) to its joined string, so SSR
- * adapters inline the flattened literal byte-for-byte like the Hono reference
- * instead of referencing a binding that doesn't exist server-side. Default
- * separator `,` matches JS `Array.prototype.join`. Returns `null` for any
- * other shape (non-`.join` call, non-array receiver, non-string-literal element
- * or separator). Shared by the Mojo + Xslate adapters; Go keeps a private copy.
- */
-/**
  * Parse a const initializer to its static string value: a string literal,
  * a no-substitution template literal, or a `[<string literals>].join(sep)`
  * call. Returns `null` for anything else. The TS parser resolves escapes
@@ -381,6 +372,17 @@ export function lookupStaticRecordLiteral(
   return null
 }
 
+/**
+ * Statically evaluate `[<string literals>].join(<sep?>)` (e.g. a module-scope
+ * `const stateClasses = ['…', …].join(' ')`) to its joined string, so SSR
+ * adapters inline the flattened literal byte-for-byte like the Hono reference
+ * instead of referencing a binding that doesn't exist server-side. Default
+ * separator `,` matches JS `Array.prototype.join`. Returns `null` for any
+ * other shape (non-`.join` call, non-array receiver, non-string-literal element
+ * or separator). Shared by the Go, Mojo, and Xslate adapters (all three
+ * resolve module consts through `collectModuleStringConsts` above, which
+ * folds these joins during its fixed-point pass).
+ */
 export function evalStringArrayJoin(source: string): string | null {
   const sf = ts.createSourceFile(
     '__join.ts', `const __x = (${source});`, ts.ScriptTarget.Latest, /*setParentNodes*/ false,

--- a/packages/jsx/src/augment-inherited-props.ts
+++ b/packages/jsx/src/augment-inherited-props.ts
@@ -253,6 +253,134 @@ export function augmentInheritedPropAccesses(ir: ComponentIR): void {
  * other shape (non-`.join` call, non-array receiver, non-string-literal element
  * or separator). Shared by the Mojo + Xslate adapters; Go keeps a private copy.
  */
+/**
+ * Parse a const initializer to its static string value: a string literal,
+ * a no-substitution template literal, or a `[<string literals>].join(sep)`
+ * call. Returns `null` for anything else. The TS parser resolves escapes
+ * and quoting exactly as JS would, matching the value the Hono reference
+ * inlines at runtime. Shared by the Go, Mojo, and Xslate adapters.
+ */
+export function parseStaticStringConst(source: string): string | null {
+  const sf = ts.createSourceFile(
+    '__const.ts', `const __x = (${source});`, ts.ScriptTarget.Latest, /*setParentNodes*/ false,
+  )
+  const stmt = sf.statements[0]
+  if (!stmt || !ts.isVariableStatement(stmt)) return null
+  let init = stmt.declarationList.declarations[0]?.initializer
+  while (init && ts.isParenthesizedExpression(init)) init = init.expression
+  if (!init) return null
+  if (ts.isStringLiteral(init) || ts.isNoSubstitutionTemplateLiteral(init)) {
+    return init.text
+  }
+  return evalStringArrayJoin(source)
+}
+
+/**
+ * Statically evaluate a template literal whose every interpolation is a
+ * bare identifier present in `resolved` to its flat string, else `null`.
+ * Companion to `parseStaticStringConst` for COMPOSED module consts
+ * (#1896 / #1897 — radio-group's
+ * `itemClasses = \`\${itemBaseClasses} \${itemFocusClasses} …\``).
+ */
+export function evalTemplateOfStringConsts(
+  source: string,
+  resolved: ReadonlyMap<string, string>,
+): string | null {
+  const sf = ts.createSourceFile(
+    '__const.ts', `const __x = (${source});`, ts.ScriptTarget.Latest, /*setParentNodes*/ false,
+  )
+  const stmt = sf.statements[0]
+  if (!stmt || !ts.isVariableStatement(stmt)) return null
+  let init = stmt.declarationList.declarations[0]?.initializer
+  while (init && ts.isParenthesizedExpression(init)) init = init.expression
+  if (!init || !ts.isTemplateExpression(init)) return null
+  let out = init.head.text
+  for (const span of init.templateSpans) {
+    if (!ts.isIdentifier(span.expression)) return null
+    const value = resolved.get(span.expression.text)
+    if (value === undefined) return null
+    out += value + span.literal.text
+  }
+  return out
+}
+
+/**
+ * Build the module string-const map from the IR's localConstants —
+ * the SINGLE SOURCE OF TRUTH for all three SSR template adapters.
+ * A const qualifies when module-scope and statically resolvable as:
+ *   - a pure string / no-substitution-template literal,
+ *   - `[<string literals>].join(sep)`,
+ *   - a template literal COMPOSED of other qualifying module consts
+ *     (resolved to a fixed point, so composition order doesn't matter).
+ */
+export function collectModuleStringConsts(
+  constants: IRMetadata['localConstants'] | undefined,
+): Map<string, string> {
+  const map = new Map<string, string>()
+  const candidates = (constants ?? []).filter(
+    c => c.isModule && c.value !== undefined,
+  )
+  let progressed = true
+  while (progressed) {
+    progressed = false
+    for (const c of candidates) {
+      if (map.has(c.name)) continue
+      const literal =
+        parseStaticStringConst(c.value!) ??
+        evalTemplateOfStringConsts(c.value!, map)
+      if (literal !== null) {
+        map.set(c.name, literal)
+        progressed = true
+      }
+    }
+  }
+  return map
+}
+
+/**
+ * Resolve `IDENT.key` / `IDENT['key']` where `IDENT` is a module-scope
+ * object-literal const and the key/value are static literals — a fully
+ * compile-time lookup (the icon registry's `strokePaths['chevron-down']`,
+ * pagination's `variantClasses.ghost`; #1896 / #1897). Returns the
+ * looked-up scalar, or `null` for any other shape so callers fall back
+ * to their generic lowering. Shared by all three SSR template adapters;
+ * the prop-KEYED variant of the pattern lives in `parseRecordIndexAccess`.
+ */
+export function lookupStaticRecordLiteral(
+  objectName: string,
+  key: string,
+  constants: IRMetadata['localConstants'] | undefined,
+): { kind: 'string' | 'number'; text: string } | null {
+  const constInfo = (constants ?? []).find(c => c.name === objectName && c.isModule)
+  if (constInfo?.value === undefined) return null
+  const sf = ts.createSourceFile(
+    '__rec.ts', `(${constInfo.value})`, ts.ScriptTarget.Latest, /*setParentNodes*/ true,
+  )
+  if (sf.statements.length !== 1) return null
+  const stmt = sf.statements[0]
+  if (!ts.isExpressionStatement(stmt)) return null
+  let parsed: ts.Expression = stmt.expression
+  while (ts.isParenthesizedExpression(parsed)) parsed = parsed.expression
+  if (!ts.isObjectLiteralExpression(parsed)) return null
+  for (const prop of parsed.properties) {
+    if (!ts.isPropertyAssignment(prop)) continue
+    const name = prop.name
+    const propKey =
+      ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNoSubstitutionTemplateLiteral(name)
+        ? name.text
+        : null
+    if (propKey !== key) continue
+    let v: ts.Expression = prop.initializer
+    while (ts.isParenthesizedExpression(v)) v = v.expression
+    if (ts.isNumericLiteral(v)) return { kind: 'number', text: v.text }
+    if (ts.isStringLiteral(v) || ts.isNoSubstitutionTemplateLiteral(v)) {
+      return { kind: 'string', text: v.text }
+    }
+    return null
+  }
+  return null
+}
+
 export function evalStringArrayJoin(source: string): string | null {
   const sf = ts.createSourceFile(
     '__join.ts', `const __x = (${source});`, ts.ScriptTarget.Latest, /*setParentNodes*/ false,

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -354,7 +354,7 @@ export type {
 export { BOOLEAN_ATTRS, isBooleanAttr } from './html-constants.ts'
 
 // Shared props-object-pattern helpers for the Go / Mojo template adapters
-export { augmentInheritedPropAccesses, parseRecordIndexAccess, evalStringArrayJoin, collectContextConsumers } from './augment-inherited-props.ts'
+export { augmentInheritedPropAccesses, parseRecordIndexAccess, evalStringArrayJoin, collectModuleStringConsts, lookupStaticRecordLiteral, collectContextConsumers } from './augment-inherited-props.ts'
 export type { RecordIndexAccess, RecordIndexEntry, ContextConsumer } from './augment-inherited-props.ts'
 
 // HTML element attribute types


### PR DESCRIPTION
Second increment for #1897 (follows #1904).

## Xslate: full corpus parity — `skipJsx` is now empty

The last three composed `site/ui` fixtures (`tabs`, `accordion`, `pagination`) now render to Hono parity on real Text::Xslate:

- **ARIA boolean routing** — `aria-selected` / `aria-expanded` added to `ARIA_BOOLEAN_ATTRS`, and bindings to boolean-**typed** props (witnessed by the IR's `TypeInfo`) route through `bf->bool_str`, so Perl-native `1`/`''` serialise as `"true"`/`"false"`.
- **Static record property access** — `variantClasses.ghost` resolves at compile time against module object-literal consts via the new shared `lookupStaticRecordLiteral`.
- **Literal-const inlining** — numeric/string consts (`totalPages`) inline at emit time instead of referencing an undeclared template var.
- **`attr={cond ? v : undefined}`** lowers to conditional attribute *omission* rather than emitting the string `"undefined"`; bare `undefined`/`null` identifiers lower to `nil`.
- Non-param props in composed calls route into the child's rest-prop bag.

Shapes the adapter intentionally refuses at build time stay pinned in `expectedDiagnostics`.

## Mojolicious: strict-vars child seeding — `skipJsx` is now empty

`buildChildDefaultsPerl` seeds each child render under the caller's props: declared props (JSX default or `undef`), inherited `props.<x>` accesses (via the shared `augmentInheritedPropAccesses` pass), signal initials, and memo `ssrDefaults`. `tabs` / `tooltip` / `pagination` render to parity. The remaining composed fixtures stay pinned (BF101) on context-provider object-literal lowering — the next tracked #1897 feature.

## Shared machinery in `@barefootjs/jsx`

`collectModuleStringConsts` (fixed-point, incl. composed template-literal consts and `[...].join(sep)`) and `lookupStaticRecordLiteral` are now exported from `@barefootjs/jsx`; both Perl adapters use them and the Go adapter delegates its private copy to the shared one (no behavior change).

## Verification

- `bun test packages/adapter-xslate packages/adapter-mojolicious`: 893 pass / 0 fail
- `bun test packages/jsx`: 2164 pass / 0 fail
- `bun test packages/adapter-go-template` (go1.25.6): 502 pass / 4 skip / 0 fail
- `prove -l` (adapter-perl 259, mojolicious, xslate): PASS
- Playwright fixture-hydrate: 30 pass / 0 fail

https://claude.ai/code/session_01SLhVU7vHcwmDiQNFu8LG1y