### PR TITLE
feat(adapter-perl): context-provider object-literal lowering (#1897)

### DIFF
--- a/.changeset/provider-object-literal-lowering.md
+++ b/.changeset/provider-object-literal-lowering.md
@@ -1,0 +1,13 @@
+---
+"@barefootjs/jsx": minor
+"@barefootjs/mojolicious": minor
+"@barefootjs/xslate": minor
+---
+
+Context-provider object-literal lowering for the Perl adapters (#1897):
+
+- `@barefootjs/jsx` exports `parseProviderObjectLiteral`, a structural (TS AST) classifier for `<Ctx.Provider value={{ … }}>` members: zero-param expression-body arrows are getters (SSR snapshot of the body), other function shapes are client-only behavior, everything else is a plain expression.
+- The Mojolicious and Xslate adapters lower object-literal provider values to Perl/Kolon hashrefs instead of refusing with BF101: getter members snapshot their body's SSR value, handler (`on[A-Z]`) and function-shaped members lower to `undef`/`nil`. Keys keep their JS names so consumer-side accesses map onto the same hashref keys.
+- `ref={fn}` props on imported components are skipped at SSR like `on*` handlers (Hono renders neither; client JS wires them at hydration).
+
+This un-pins the composed `site/ui` demo fixtures that were BF101-blocked on their context providers (`radio-group`, `accordion`, `dialog`, `popover`, `select`, `dropdown-menu`, `combobox`, `command`).

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -70,33 +70,20 @@ runAdapterConformanceTests({
     // (`cn\`base \${tone()}\``) — same family as #1322 above and refused
     // via the same gate.
     'tagged-template-classname': [{ code: 'BF101', severity: 'error' }],
-    // #1467 demo corpus: the composed RadioGroup sibling builds its
-    // context-provider value as an object literal carrying arrow-function
-    // members (`{ value: currentValue, onValueChange: (v) => {…} }`),
-    // which has no EP lowering — refused via the same `isSupported`
-    // expression gate as `tagged-template-classname` above. Hono / Go
-    // render the fixture to parity; the real composed hydration runs in
-    // the fixture-hydrate layer.
-    'radio-group': [{ code: 'BF101', severity: 'error' }],
-    // #1467 demo corpus: the AccordionItem context-provider value is the
-    // same object-literal-with-arrow-members shape as `radio-group`
-    // above (`{ open: () => props.open ?? false, ... }`) — refused via
-    // the identical `isSupported` gate.
-    'accordion': [{ code: 'BF101', severity: 'error' }],
-    // #1467 Phase 2c overlay: Dialog and Popover provide the same
-    // object-literal-with-arrow-members context value — same BF101 gate.
-    'dialog': [{ code: 'BF101', severity: 'error' }],
-    'popover': [{ code: 'BF101', severity: 'error' }],
-    // #1467 Phase 2d: the selection/menu primitives (and the command
-    // demo source itself) all carry expression shapes the EP gate
-    // refuses — context-provider object literals and function props.
-    'select': [{ code: 'BF101', severity: 'error' }],
-    'dropdown-menu': [{ code: 'BF101', severity: 'error' }],
-    'combobox': [{ code: 'BF101', severity: 'error' }],
-    'command': [{ code: 'BF101', severity: 'error' }],
+    // #1467 demo-corpus context providers (`radio-group`, `accordion`,
+    // `dialog`, `popover`, `select`, `dropdown-menu`, `combobox`,
+    // `command`) are no longer pinned — an object-literal provider value
+    // (`{ open: () => props.open ?? false, onOpenChange: (v) => {…} }`)
+    // lowers to a Perl hashref via `parseProviderObjectLiteral` (#1897):
+    // getter members snapshot their body's SSR value, handler /
+    // function-shaped members lower to `undef`. The command demo's
+    // `ref={(el) => {…}}` function prop on an imported component is
+    // skipped at SSR like `on*` handlers.
+    //
     // #1467 Phase 2e: the data-table demo source's `/* @client */`
-    // comparator sort has no EP lowering — refused at the demo-source
-    // compile, same gate.
+    // comparator sort (`selected()[index]` signal-call indexing) has no
+    // EP lowering — refused at the demo-source compile via the
+    // `isSupported` gate.
     'data-table': [{ code: 'BF101', severity: 'error' }],
     // #1443: `[a, b].filter(Boolean).join(' ')` (the registry Slot's
     // shape) now lowers to `join(' ', @{[grep { $_ } @{[$a, $b]}]})`.

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -668,9 +668,12 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     const members = parseProviderObjectLiteral(expr.trim())
     if (members === null) return null
     const entries = members.map(m => {
-      if (m.kind === 'function' || /^on[A-Z]/.test(m.name)) return `'${m.name}' => undef`
+      // String-literal JS keys can carry `'` / `\` — escape for the
+      // single-quoted Perl key string.
+      const key = `'${m.name.replace(/[\\']/g, c => `\\${c}`)}'`
+      if (m.kind === 'function' || /^on[A-Z]/.test(m.name)) return `${key} => undef`
       const src = m.kind === 'getter' ? m.body : m.expr
-      return `'${m.name}' => ${this.convertExpressionToPerl(src)}`
+      return `${key} => ${this.convertExpressionToPerl(src)}`
     })
     return `{ ${entries.join(', ')} }`
   }
@@ -1242,6 +1245,10 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
 
   private childrenCaptureCounter = 0
 
+  /** Uniquifies the `presenceOrUndefined` temp binding (`$bf_puN`) so two
+   *  presence-folded attrs in one template don't collide. */
+  private presenceVarCounter = 0
+
   private toTemplateName(componentName: string): string {
     // Convert PascalCase to snake_case for Mojo template naming
     return componentName
@@ -1384,12 +1391,15 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
         // → `aria-disabled="true"`), so bare presence would diverge.
         // Route through `bool_str` when the name/shape witnesses a
         // boolean value, same as the unconditional path below (#1897).
+        // Bind to a temp first so the expression evaluates once, not in
+        // both the guard and the value.
         const perl = this.convertExpressionToPerl(value.expr)
+        const tmp = `$bf_pu${this.presenceVarCounter++}`
         const body =
           isBooleanResultExpr(value.expr) || isAriaBooleanAttr(name) || this.isBooleanTypedPropRef(value.expr)
-            ? `${name}="<%= bf->bool_str(${perl}) %>"`
-            : `${name}="<%= ${perl} %>"`
-        return `<% if (${perl}) { %>${body}<% } %>`
+            ? `${name}="<%= bf->bool_str(${tmp}) %>"`
+            : `${name}="<%= ${tmp} %>"`
+        return `<% my ${tmp} = ${perl}; if (${tmp}) { %>${body}<% } %>`
       }
       // Boolean-result handling (#1466 follow-up). Two trigger paths:
       //

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -44,6 +44,7 @@ import {
   parseStyleObjectEntries,
   isSupported,
   exprToString,
+  parseProviderObjectLiteral,
   identifierPath,
   emitParsedExpr,
   emitIRNode,
@@ -55,7 +56,6 @@ import {
   collectContextConsumers,
   isLowerableObjectRestDestructure,
   type ContextConsumer,
-  extractSsrDefaults,
   collectModuleStringConsts,
   lookupStaticRecordLiteral
 } from '@barefootjs/jsx'
@@ -635,11 +635,44 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
         ? `'${v.value.replace(/[\\']/g, m => `\\${m}`)}'`
         : String(v.value)
     }
-    if (v.kind === 'expression') return this.convertExpressionToPerl(v.expr)
+    if (v.kind === 'expression') {
+      const hashref = this.providerObjectLiteralPerl(v.expr)
+      if (hashref !== null) return hashref
+      return this.convertExpressionToPerl(v.expr)
+    }
     if (v.kind === 'template') return this.convertTemplateLiteralPartsToPerl(v.parts)
     // Out-of-shape value (spread / jsx-children) — render as undef rather
     // than emit invalid Perl; the consumer falls back to its default.
     return 'undef'
+  }
+
+  /**
+   * Lower an object-literal provider value (`value={{ open: () => props.open
+   * ?? false, onOpenChange: … }}`) to a Perl hashref (#1897). The SSR
+   * lowering is a per-member snapshot of what a consumer would READ during
+   * the same render:
+   *
+   * - zero-param expression-body arrows are getters — lower the body (the
+   *   value is fixed for the render, so the call-time indirection drops out)
+   * - `on[A-Z]`-named members and function-shaped values are client-only
+   *   behavior SSR never invokes — lower to `undef`
+   * - anything else lowers through the normal expression pipeline (so an
+   *   unsupported getter body still refuses loudly with BF101)
+   *
+   * Keys keep their JS names verbatim so a consumer-side `ctx.open` access
+   * maps onto the same key. Returns `null` when the expression is not a
+   * plain object literal (spread / computed key) — the caller falls back to
+   * the whole-expression path, which refuses those shapes with BF101.
+   */
+  private providerObjectLiteralPerl(expr: string): string | null {
+    const members = parseProviderObjectLiteral(expr.trim())
+    if (members === null) return null
+    const entries = members.map(m => {
+      if (m.kind === 'function' || /^on[A-Z]/.test(m.name)) return `'${m.name}' => undef`
+      const src = m.kind === 'getter' ? m.body : m.expr
+      return `'${m.name}' => ${this.convertExpressionToPerl(src)}`
+    })
+    return `{ ${entries.join(', ')} }`
   }
 
   /** Perl literal for a context-consumer's `createContext` default. */
@@ -684,7 +717,6 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     const memos = ir.metadata.memos ?? []
     const signals = ir.metadata.signals ?? []
     if (memos.length === 0 && signals.length === 0) return ''
-    const ssrDefaults = extractSsrDefaults(ir.metadata) ?? {}
     // Props seed first; each signal/memo adds its own name as it lands so a
     // later one can reference an earlier one.
     const available = new Set<string>(ir.metadata.propsParams.map(p => p.name))
@@ -706,17 +738,20 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     }
 
     for (const memo of memos) {
-      const def = ssrDefaults[memo.name]
-      const isNull = !def || (typeof def === 'object' && 'value' in def && def.value === null)
-      if (!isNull) {
-        available.add(memo.name)
-        continue
-      }
+      // Seed every memo whose body lowers cleanly — not just the ones whose
+      // static SSR default is null. A statically-foldable prop-derived memo
+      // (`createMemo(() => props.disabled ?? false)` → default `false`)
+      // still depends on the per-call prop: the static stash seed bakes in
+      // the absent-prop fold, so a caller passing `disabled => 1` would
+      // render the default branch (#1897, select's disabled item). The
+      // in-template recomputation reads the prop lexical the stash already
+      // seeded, so it's correct per call; block-bodied arrows /
+      // out-of-scope references fall back to the static ssr-defaults seed.
       const body = extractArrowBodyExpression(memo.computation)
-      // Block-bodied arrows / non-expression shapes stay on the null path.
-      if (body === null) continue
-      const perl = this.tryLowerToPerl(body, available)
-      if (perl !== null) lines.push(`% my $${memo.name} = ${perl};`)
+      if (body !== null) {
+        const perl = this.tryLowerToPerl(body, available)
+        if (perl !== null) lines.push(`% my $${memo.name} = ${perl};`)
+      }
       available.add(memo.name)
     }
     return lines.length > 0 ? lines.join('\n') + '\n' : ''
@@ -1163,8 +1198,9 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
   renderComponent(comp: IRComponent): string {
     const propParts: string[] = []
     for (const p of comp.props) {
-      // Skip callback props (onXxx) — event handlers are client-only for SSR.
-      if (p.name.match(/^on[A-Z]/) && p.value.kind === 'expression') continue
+      // Skip callback props (onXxx) and `ref` — both are client-only for
+      // SSR (Hono renders neither; the client JS wires them at hydration).
+      if ((p.name.match(/^on[A-Z]/) || p.name === 'ref') && p.value.kind === 'expression') continue
       const lowered = emitAttrValue(p.value, this.componentPropEmitter, p.name)
       if (lowered) propParts.push(lowered)
     }
@@ -1337,9 +1373,23 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
             : `${name}="<%= ${perl} %>"`
         return `<% if (defined ${perl}) { %>${body}<% } %>`
       }
-      if (isBooleanAttr(name) || value.presenceOrUndefined) {
+      if (isBooleanAttr(name)) {
         // Boolean attributes: render conditionally (present or absent).
         return `<%= ${this.convertExpressionToPerl(value.expr)} ? '${name}' : '' %>`
+      }
+      if (value.presenceOrUndefined) {
+        // `attr={expr || undefined}` on a NON-boolean attribute: Hono
+        // renders the attr with its stringified value when truthy and
+        // omits it otherwise (`aria-disabled={isDisabled() || undefined}`
+        // → `aria-disabled="true"`), so bare presence would diverge.
+        // Route through `bool_str` when the name/shape witnesses a
+        // boolean value, same as the unconditional path below (#1897).
+        const perl = this.convertExpressionToPerl(value.expr)
+        const body =
+          isBooleanResultExpr(value.expr) || isAriaBooleanAttr(name) || this.isBooleanTypedPropRef(value.expr)
+            ? `${name}="<%= bf->bool_str(${perl}) %>"`
+            : `${name}="<%= ${perl} %>"`
+        return `<% if (${perl}) { %>${body}<% } %>`
       }
       // Boolean-result handling (#1466 follow-up). Two trigger paths:
       //

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -81,27 +81,19 @@ runAdapterConformanceTests({
     // above — refused with BF101 for the identical Kolon engine reason, not a
     // render-mismatch (so it's pinned here, not in `skipJsx`).
     'kbd': [{ code: 'BF101', severity: 'error' }],
-    // #1467 demo corpus: the composed RadioGroup sibling builds its
-    // context-provider value as an object literal carrying arrow-function
-    // members (`{ value: currentValue, onValueChange: (v) => {…} }`),
-    // which has no Kolon lowering — same `isSupported` expression gate as
-    // mojo's pin for this fixture. (Locally-green-without-perl caveat:
-    // the BF101 fires at child compile, before the perl-availability
-    // check, so this pin is what keeps perl-equipped CI green too.)
-    'radio-group': [{ code: 'BF101', severity: 'error' }],
-    // #1467 Phase 2d: same Kolon expression gate — every selection/menu
-    // primitive (and the command demo source itself) emits BF101 at
-    // compile time, so the contract is pinned here rather than letting
-    // the partially-degraded render drift against Hono (unlike
-    // `accordion`/`tabs` above, where the *render-level* divergences
-    // were the more durable signal).
-    'select': [{ code: 'BF101', severity: 'error' }],
-    'dropdown-menu': [{ code: 'BF101', severity: 'error' }],
-    'combobox': [{ code: 'BF101', severity: 'error' }],
-    'command': [{ code: 'BF101', severity: 'error' }],
+    // #1467 demo-corpus context providers (`radio-group`, `select`,
+    // `dropdown-menu`, `combobox`, `command`) are no longer pinned — an
+    // object-literal provider value (`{ value: currentValue,
+    // onValueChange: (v) => {…} }`) lowers to a Kolon hashref via
+    // `parseProviderObjectLiteral` (#1897): getter members snapshot
+    // their body's SSR value, handler / function-shaped members lower
+    // to `nil`. The command demo's `ref={(el) => {…}}` function prop on
+    // an imported component is skipped at SSR like `on*` handlers.
+    //
     // #1467 Phase 2e: the data-table demo source's `/* @client */`
-    // comparator sort has no Kolon lowering — refused at the
-    // demo-source compile, same gate as mojo.
+    // comparator sort (`selected()[index]` signal-call indexing) has no
+    // Kolon lowering — refused at the demo-source compile, same gate as
+    // mojo.
     'data-table': [{ code: 'BF101', severity: 'error' }],
     // `style-3-signals` / `style-object-dynamic` no longer pinned — a
     // `style={{ … }}` object literal now lowers to a CSS string with dynamic

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -518,9 +518,12 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     const members = parseProviderObjectLiteral(expr.trim())
     if (members === null) return null
     const entries = members.map(m => {
-      if (m.kind === 'function' || /^on[A-Z]/.test(m.name)) return `'${m.name}' => nil`
+      // String-literal JS keys can carry `'` / `\` — escape for the
+      // single-quoted Kolon key string.
+      const key = `'${m.name.replace(/[\\']/g, c => `\\${c}`)}'`
+      if (m.kind === 'function' || /^on[A-Z]/.test(m.name)) return `${key} => nil`
       const src = m.kind === 'getter' ? m.body : m.expr
-      return `'${m.name}' => ${this.convertExpressionToKolon(src)}`
+      return `${key} => ${this.convertExpressionToKolon(src)}`
     })
     return `{ ${entries.join(', ')} }`
   }
@@ -1071,6 +1074,10 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
 
   private childrenCaptureCounter = 0
 
+  /** Uniquifies the `presenceOrUndefined` temp binding (`$bf_puN`) so two
+   *  presence-folded attrs in one template don't collide. */
+  private presenceVarCounter = 0
+
   private toTemplateName(componentName: string): string {
     // Convert PascalCase to snake_case for template naming.
     return componentName
@@ -1199,12 +1206,15 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
         // → `aria-disabled="true"`), so bare presence would diverge.
         // Route through `bool_str` when the name/shape witnesses a
         // boolean value, same as the unconditional path below (#1897).
+        // Bind to a temp first so the expression evaluates once, not in
+        // both the guard and the value.
         const perl = this.convertExpressionToKolon(value.expr)
+        const tmp = `$bf_pu${this.presenceVarCounter++}`
         const body =
           isBooleanResultExpr(value.expr) || isAriaBooleanAttr(name) || this.isBooleanTypedPropRef(value.expr)
-            ? `${name}="<: $bf.bool_str(${perl}) :>"`
-            : `${name}="<: ${perl} :>"`
-        return `\n: if (${perl}) {\n${body}\n: }\n`
+            ? `${name}="<: $bf.bool_str(${tmp}) :>"`
+            : `${name}="<: ${tmp} :>"`
+        return `\n: my ${tmp} = ${perl};\n: if (${tmp}) {\n${body}\n: }\n`
       }
       // `attr={cond ? value : undefined}` OMITS the attribute on the
       // falsy branch (Hono drops undefined-valued attributes) — wrap the

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -56,6 +56,7 @@ import {
   isBooleanAttr,
   parseExpression,
   exprToString,
+  parseProviderObjectLiteral,
   parseStyleObjectEntries,
   isSupported,
   identifierPath,
@@ -70,7 +71,6 @@ import {
   collectContextConsumers,
   isLowerableObjectRestDestructure,
   type ContextConsumer,
-  extractSsrDefaults,
   lookupStaticRecordLiteral
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr } from './boolean-result.ts'
@@ -486,10 +486,43 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
         ? `'${v.value.replace(/[\\']/g, m => `\\${m}`)}'`
         : String(v.value)
     }
-    if (v.kind === 'expression') return this.convertExpressionToKolon(v.expr)
+    if (v.kind === 'expression') {
+      const hashref = this.providerObjectLiteralKolon(v.expr)
+      if (hashref !== null) return hashref
+      return this.convertExpressionToKolon(v.expr)
+    }
     if (v.kind === 'template') return this.convertTemplateLiteralPartsToKolon(v.parts)
     // Out-of-shape value (spread / jsx-children) — nil; consumer defaults.
     return 'nil'
+  }
+
+  /**
+   * Lower an object-literal provider value (`value={{ open: () => props.open
+   * ?? false, onOpenChange: … }}`) to a Kolon hashref literal (#1897). The
+   * SSR lowering is a per-member snapshot of what a consumer would READ
+   * during the same render:
+   *
+   * - zero-param expression-body arrows are getters — lower the body (the
+   *   value is fixed for the render, so the call-time indirection drops out)
+   * - `on[A-Z]`-named members and function-shaped values are client-only
+   *   behavior SSR never invokes — lower to `nil`
+   * - anything else lowers through the normal expression pipeline (so an
+   *   unsupported getter body still refuses loudly with BF101)
+   *
+   * Keys keep their JS names verbatim so a consumer-side `ctx.open` access
+   * maps onto the same key. Returns `null` when the expression is not a
+   * plain object literal (spread / computed key) — the caller falls back to
+   * the whole-expression path, which refuses those shapes with BF101.
+   */
+  private providerObjectLiteralKolon(expr: string): string | null {
+    const members = parseProviderObjectLiteral(expr.trim())
+    if (members === null) return null
+    const entries = members.map(m => {
+      if (m.kind === 'function' || /^on[A-Z]/.test(m.name)) return `'${m.name}' => nil`
+      const src = m.kind === 'getter' ? m.body : m.expr
+      return `'${m.name}' => ${this.convertExpressionToKolon(src)}`
+    })
+    return `{ ${entries.join(', ')} }`
   }
 
   /** Kolon literal for a context-consumer's `createContext` default. */
@@ -531,7 +564,6 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     const memos = ir.metadata.memos ?? []
     const signals = ir.metadata.signals ?? []
     if (memos.length === 0 && signals.length === 0) return ''
-    const ssrDefaults = extractSsrDefaults(ir.metadata) ?? {}
     // Props seed first; each signal/memo adds its own name as it lands.
     const available = new Set<string>(ir.metadata.propsParams.map(p => p.name))
     const lines: string[] = []
@@ -555,16 +587,22 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     }
 
     for (const memo of memos) {
-      const def = ssrDefaults[memo.name]
-      const isNull = !def || (typeof def === 'object' && 'value' in def && def.value === null)
-      if (!isNull) {
-        available.add(memo.name)
-        continue
-      }
+      // Seed every memo whose body lowers cleanly — not just the ones whose
+      // static SSR default is null. A statically-foldable prop-derived memo
+      // (`createMemo(() => props.disabled ?? false)` → default `false`)
+      // still depends on the per-call prop: the static stash seed bakes in
+      // the absent-prop fold, so a caller passing `disabled => 1` would
+      // render the default branch (#1897, select's disabled item). The
+      // in-template recomputation reads the prop lexical already in scope;
+      // block-bodied arrows / out-of-scope references fall back to the
+      // static ssr-defaults seed. Same self-reference guard as the signal
+      // loop above — Kolon's `my` shadows the render var on the RHS.
       const body = extractArrowBodyExpression(memo.computation)
-      if (body === null) continue
-      const kolon = this.tryLowerToKolon(body, available)
-      if (kolon !== null) lines.push(`: my $${memo.name} = ${kolon};`)
+      if (body !== null) {
+        const kolon = this.tryLowerToKolon(body, available)
+        const refsSelf = kolon !== null && new RegExp(`\\$${memo.name}\\b`).test(kolon)
+        if (kolon !== null && !refsSelf) lines.push(`: my $${memo.name} = ${kolon};`)
+      }
       available.add(memo.name)
     }
     return lines.length > 0 ? lines.join('\n') + '\n' : ''
@@ -972,8 +1010,9 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
   renderComponent(comp: IRComponent): string {
     const propParts: string[] = []
     for (const p of comp.props) {
-      // Skip callback props (onXxx) — event handlers are client-only for SSR.
-      if (p.name.match(/^on[A-Z]/) && p.value.kind === 'expression') continue
+      // Skip callback props (onXxx) and `ref` — both are client-only for
+      // SSR (Hono renders neither; the client JS wires them at hydration).
+      if ((p.name.match(/^on[A-Z]/) || p.name === 'ref') && p.value.kind === 'expression') continue
       // Spread props: enumerate the analyzer's props params into hashref
       // entries (the propsObject case) — Kolon can't flatten a hashref into
       // the entry list. Other spread shapes are refused with BF101.
@@ -1149,9 +1188,23 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
         // wrap in newlines (`normalizeHTML` collapses the surrounding space).
         return `\n: if (defined ${perl}) {\n${body}\n: }\n`
       }
-      if (isBooleanAttr(name) || value.presenceOrUndefined) {
+      if (isBooleanAttr(name)) {
         // Boolean attributes: render conditionally (present or absent).
         return `<: ${this.convertExpressionToKolon(value.expr)} ? '${name}' : '' :>`
+      }
+      if (value.presenceOrUndefined) {
+        // `attr={expr || undefined}` on a NON-boolean attribute: Hono
+        // renders the attr with its stringified value when truthy and
+        // omits it otherwise (`aria-disabled={isDisabled() || undefined}`
+        // → `aria-disabled="true"`), so bare presence would diverge.
+        // Route through `bool_str` when the name/shape witnesses a
+        // boolean value, same as the unconditional path below (#1897).
+        const perl = this.convertExpressionToKolon(value.expr)
+        const body =
+          isBooleanResultExpr(value.expr) || isAriaBooleanAttr(name) || this.isBooleanTypedPropRef(value.expr)
+            ? `${name}="<: $bf.bool_str(${perl}) :>"`
+            : `${name}="<: ${perl} :>"`
+        return `\n: if (${perl}) {\n${body}\n: }\n`
       }
       // `attr={cond ? value : undefined}` OMITS the attribute on the
       // falsy branch (Hono drops undefined-valued attributes) — wrap the

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test'
 import ts from 'typescript'
-import { parseExpression, isSupported, exprToString, stringifyParsedExpr, parseBlockBody, extractArrowBodyExpression, parseStyleObjectEntries } from '../expression-parser'
+import { parseExpression, isSupported, exprToString, stringifyParsedExpr, parseBlockBody, extractArrowBodyExpression, parseStyleObjectEntries, parseProviderObjectLiteral } from '../expression-parser'
 import { collectAllTypeRanges, reconstructWithoutTypes } from '../strip-types'
 
 describe('expression-parser', () => {
@@ -1647,6 +1647,69 @@ describe('extractArrowBodyExpression', () => {
 
   test('returns null when the source is more than one statement', () => {
     expect(extractArrowBodyExpression('() => 1; sideEffect()')).toBeNull()
+  })
+})
+
+describe('parseProviderObjectLiteral', () => {
+  test('classifies the composed-corpus provider shape (accordion/dialog)', () => {
+    const members = parseProviderObjectLiteral(
+      `{ open: () => props.open ?? false, onOpenChange: props.onOpenChange ?? (() => {}) }`,
+    )
+    expect(members).toEqual([
+      { name: 'open', kind: 'getter', body: 'props.open ?? false' },
+      { name: 'onOpenChange', kind: 'function' },
+    ])
+  })
+
+  test('shorthand members lower as identifier expressions (command)', () => {
+    const members = parseProviderObjectLiteral(
+      `{ search, onSearchChange: setSearch, filter: filterFn() }`,
+    )
+    expect(members).toEqual([
+      { name: 'search', kind: 'expression', expr: 'search' },
+      { name: 'onSearchChange', kind: 'expression', expr: 'setSearch' },
+      { name: 'filter', kind: 'expression', expr: 'filterFn()' },
+    ])
+  })
+
+  test('parameterised and block-bodied arrows are functions, not getters', () => {
+    const members = parseProviderObjectLiteral(
+      `{ registerItem: (el) => items.add(el), onSelect: (value) => { setValue(value) }, value: () => { return v } }`,
+    )
+    expect(members).toEqual([
+      { name: 'registerItem', kind: 'function' },
+      { name: 'onSelect', kind: 'function' },
+      { name: 'value', kind: 'function' },
+    ])
+  })
+
+  test('?? / || fallback chains with a function operand are functions', () => {
+    const members = parseProviderObjectLiteral(`{ a: f ?? (() => {}), b: g || fallbackFn }`)
+    expect(members).toEqual([
+      { name: 'a', kind: 'function' },
+      // `g || fallbackFn` — neither side is a function literal, so it
+      // stays an expression (the parser can't see identifier types).
+      { name: 'b', kind: 'expression', expr: 'g || fallbackFn' },
+    ])
+  })
+
+  test('string-literal keys keep their text', () => {
+    expect(parseProviderObjectLiteral(`{ 'data-x': 1 }`)).toEqual([
+      { name: 'data-x', kind: 'expression', expr: '1' },
+    ])
+  })
+
+  test('returns null for spread entries, computed keys, and non-objects', () => {
+    expect(parseProviderObjectLiteral(`{ ...rest }`)).toBeNull()
+    expect(parseProviderObjectLiteral(`{ [key]: 1 }`)).toBeNull()
+    expect(parseProviderObjectLiteral(`someValue`)).toBeNull()
+    expect(parseProviderObjectLiteral(`[1, 2]`)).toBeNull()
+  })
+
+  test('unwraps parentheses around the literal and member values', () => {
+    expect(parseProviderObjectLiteral(`({ v: (() => (x)) })`)).toEqual([
+      { name: 'v', kind: 'getter', body: '(x)' },
+    ])
   })
 })
 

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -1699,6 +1699,13 @@ describe('parseProviderObjectLiteral', () => {
     ])
   })
 
+  test('method members classify as functions, like block-bodied arrows', () => {
+    expect(parseProviderObjectLiteral(`{ open() { return v }, count: 1 }`)).toEqual([
+      { name: 'open', kind: 'function' },
+      { name: 'count', kind: 'expression', expr: '1' },
+    ])
+  })
+
   test('returns null for spread entries, computed keys, and non-objects', () => {
     expect(parseProviderObjectLiteral(`{ ...rest }`)).toBeNull()
     expect(parseProviderObjectLiteral(`{ [key]: 1 }`)).toBeNull()

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -507,7 +507,9 @@ export type ProviderObjectMember =
  * contains a shape with no per-member story (spread entry, computed key,
  * get/set accessor) — callers fall back to their existing whole-expression
  * path (typically a BF101 refusal). Shorthand members (`{ search }`) yield
- * an `expression` member with the identifier as the expression.
+ * an `expression` member with the identifier as the expression; method
+ * members (`{ open() {…} }`) classify as `function` like block-bodied
+ * arrows.
  */
 export function parseProviderObjectLiteral(source: string): ProviderObjectMember[] | null {
   const sf = ts.createSourceFile(
@@ -544,7 +546,17 @@ export function parseProviderObjectLiteral(source: string): ProviderObjectMember
       members.push({ name: prop.name.text, kind: 'expression', expr: prop.name.text })
       continue
     }
-    if (!ts.isPropertyAssignment(prop)) return null // spread / accessor / method
+    if (ts.isMethodDeclaration(prop)) {
+      // `{ open() {…} }` — function-shaped behavior, same as a
+      // block-bodied arrow member.
+      const name = ts.isIdentifier(prop.name) || ts.isStringLiteral(prop.name)
+        ? prop.name.text
+        : null
+      if (name === null) return null // computed key
+      members.push({ name, kind: 'function' })
+      continue
+    }
+    if (!ts.isPropertyAssignment(prop)) return null // spread / accessor
     const name = ts.isIdentifier(prop.name) || ts.isStringLiteral(prop.name)
       ? prop.name.text
       : null

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -477,6 +477,94 @@ export function extractArrowBodyExpression(source: string): string | null {
 }
 
 /**
+ * One member of a context-provider object-literal value
+ * (`<Ctx.Provider value={{ open: () => …, onOpenChange: … }}>`), classified
+ * for SSR lowering:
+ *
+ * - `getter` — a ZERO-parameter arrow with an expression body. At SSR time
+ *   the provider value is fixed for the render, so the getter is equivalent
+ *   to its body's value snapshot (`open: () => props.open ?? false` reads as
+ *   `props.open ?? false`). Arrows with parameters are NOT getters — their
+ *   body references the parameter, which has no SSR value.
+ * - `function` — any other function shape (parameterised / block-bodied
+ *   arrow, function expression, or a `??` / `||` chain with a function
+ *   operand). These are behavior, not data: SSR never invokes them, so
+ *   adapters lower them to their nil value (`undef` / `nil`).
+ * - `expression` — everything else; lowers through the adapter's normal
+ *   expression pipeline (so signal getters, props, memo calls keep their
+ *   existing SSR seeding semantics).
+ */
+export type ProviderObjectMember =
+  | { name: string; kind: 'getter'; body: string }
+  | { name: string; kind: 'function' }
+  | { name: string; kind: 'expression'; expr: string }
+
+/**
+ * Structurally parse a `<Ctx.Provider value={{ … }}>` object literal into
+ * per-member SSR lowering classifications (see `ProviderObjectMember`).
+ *
+ * Returns `null` when the source is not a plain object literal, or when it
+ * contains a shape with no per-member story (spread entry, computed key,
+ * get/set accessor) — callers fall back to their existing whole-expression
+ * path (typically a BF101 refusal). Shorthand members (`{ search }`) yield
+ * an `expression` member with the identifier as the expression.
+ */
+export function parseProviderObjectLiteral(source: string): ProviderObjectMember[] | null {
+  const sf = ts.createSourceFile(
+    '__provider__.ts',
+    `const __x = (${source});`,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+  )
+  const stmt = sf.statements[0]
+  if (!stmt || !ts.isVariableStatement(stmt)) return null
+  let init = stmt.declarationList.declarations[0]?.initializer
+  while (init && ts.isParenthesizedExpression(init)) init = init.expression
+  if (!init || !ts.isObjectLiteralExpression(init)) return null
+
+  const isFunctionShaped = (e: ts.Expression): boolean => {
+    let v: ts.Expression = e
+    while (ts.isParenthesizedExpression(v)) v = v.expression
+    if (ts.isArrowFunction(v) || ts.isFunctionExpression(v)) return true
+    // `props.onX ?? (() => {})` — a fallback chain with a function operand
+    // is function-typed regardless of which side wins at runtime.
+    if (
+      ts.isBinaryExpression(v) &&
+      (v.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken ||
+        v.operatorToken.kind === ts.SyntaxKind.BarBarToken)
+    ) {
+      return isFunctionShaped(v.left) || isFunctionShaped(v.right)
+    }
+    return false
+  }
+
+  const members: ProviderObjectMember[] = []
+  for (const prop of init.properties) {
+    if (ts.isShorthandPropertyAssignment(prop)) {
+      members.push({ name: prop.name.text, kind: 'expression', expr: prop.name.text })
+      continue
+    }
+    if (!ts.isPropertyAssignment(prop)) return null // spread / accessor / method
+    const name = ts.isIdentifier(prop.name) || ts.isStringLiteral(prop.name)
+      ? prop.name.text
+      : null
+    if (name === null) return null // computed key
+    let v: ts.Expression = prop.initializer
+    while (ts.isParenthesizedExpression(v)) v = v.expression
+    if (ts.isArrowFunction(v) && v.parameters.length === 0 && !ts.isBlock(v.body)) {
+      members.push({ name, kind: 'getter', body: v.body.getText(sf).trim() })
+      continue
+    }
+    if (isFunctionShaped(v)) {
+      members.push({ name, kind: 'function' })
+      continue
+    }
+    members.push({ name, kind: 'expression', expr: v.getText(sf).trim() })
+  }
+  return members
+}
+
+/**
  * A single entry of a JSX `style={{ … }}` object, lowered for SSR. The key is
  * already CSS-cased (`backgroundColor` → `background-color`); the value is
  * either a static string literal or a raw JS expression for the adapter to

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -247,7 +247,7 @@ export {
 export { ErrorCodes, createError, formatError, generateCodeFrame } from './errors.ts'
 
 // Expression Parser
-export { parseExpression, isSupported, exprToString, stringifyParsedExpr, identifierPath, parseBlockBody, containsHigherOrder, extractArrowBodyExpression, parseStyleObjectEntries } from './expression-parser.ts'
+export { parseExpression, isSupported, exprToString, stringifyParsedExpr, identifierPath, parseBlockBody, containsHigherOrder, extractArrowBodyExpression, parseStyleObjectEntries, parseProviderObjectLiteral, type ProviderObjectMember } from './expression-parser.ts'
 export type { StyleObjectEntry } from './expression-parser.ts'
 export type { ParsedExpr, ParsedStatement, SortComparator, SortKey, ReduceOp, FlatDepth, FlatMapOp, FlatMapLeaf, SupportLevel, SupportResult, TemplatePart } from './expression-parser.ts'
 export { buildLoopChainExpr } from './loop-chain.ts'


### PR DESCRIPTION
Third increment for #1897 (follows #1907). Closes the context-provider gap — the eight composed `site/ui` demo fixtures that were BF101-pinned on their providers (`radio-group`, `accordion`, `dialog`, `popover`, `select`, `dropdown-menu`, `combobox`, `command`) now render to Hono parity on real Mojolicious and Text::Xslate. The only remaining pinned demo fixture on both adapters is `data-table` (the `/* @client */` comparator's `selected()[index]` signal-call indexing — a separate feature).

## Provider object-literal lowering

`@barefootjs/jsx` gains `parseProviderObjectLiteral`, a TS-AST classifier for `<Ctx.Provider value={{ … }}>` members. The SSR insight: the provider value is fixed for the duration of a render, so what matters is what a consumer would *read* —

- **getters** (zero-param expression-body arrows, `open: () => props.open ?? false`) lower to their body's SSR snapshot;
- **handlers / function shapes** (`onOpenChange: (v) => {…}`, `props.onX ?? (() => {})`, parameterised arrows like `registerItem: (el) => items.add(el)`) are client-only behavior SSR never invokes — they lower to `undef` / `nil`;
- **plain expressions** (shorthand signal getters like `search`, memo calls like `filterFn()`) lower through the adapters' normal expression pipeline, keeping existing seeding semantics. An unsupported getter body still refuses loudly with BF101.

Both Perl adapters emit the result as a hashref with JS-named keys, pushed through the existing `provide_context` / `use_context` runtime plumbing.

## Render-parity fixes surfaced by un-pinning

- **`ref={fn}` props on imported components** are skipped at SSR like `on*` handlers (the command demo's `ref={(el) => …}` on `Button`; Hono renders neither).
- **Derived-memo template seeds no longer gate on a null static default.** A statically-foldable prop-derived memo (`createMemo(() => props.disabled ?? false)`) still depends on the per-call prop — the static stash seed baked in the absent-prop fold, so select's `disabled` item rendered the enabled variant. The in-template recomputation reads the prop lexical already in scope; non-lowerable shapes keep the static fallback. (Xslate keeps its self-reference guard — Kolon's `my` shadows the render var on the RHS.)
- **`attr={expr || undefined}` on non-boolean attributes** emits the attribute with its (`bool_str`-routed) value when truthy instead of bare presence: `aria-disabled={isDisabled() || undefined}` renders `aria-disabled="true"` like Hono, not bare `aria-disabled`. True HTML boolean attrs keep the presence form.

## Verification

- `bun test packages/adapter-mojolicious packages/adapter-xslate`: 868 pass / 0 fail (real Mojolicious 9.46 / Text::Xslate 3.5.9)
- `bun test packages/jsx`: 2171 pass / 0 fail (includes new `parseProviderObjectLiteral` unit tests)
- `prove -l` (adapter-perl 259, mojolicious 11, xslate 7): PASS

https://claude.ai/code/session_01SLhVU7vHcwmDiQNFu8LG1y

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLhVU7vHcwmDiQNFu8LG1y)_