### PR TITLE
feat(jsx): variable element-access + .toFixed + @client memo SSR folding (#1897)

### DIFF
--- a/.changeset/variable-element-access-tofixed.md
+++ b/.changeset/variable-element-access-tofixed.md
@@ -1,0 +1,16 @@
+---
+"@barefootjs/jsx": minor
+"@barefootjs/mojolicious": minor
+"@barefootjs/xslate": minor
+"@barefootjs/go-template": minor
+"@barefootjs/perl": minor
+---
+
+Variable element-access + `.toFixed`, and `/* @client */`-guarded memo SSR folding (#1897, data-table):
+
+- `@barefootjs/jsx`: new `index-access` `ParsedExpr` kind for element access with a non-literal index (`selected()[index]`, `rows[i + 1]`). Previously refused as "Complex computed property access"; now supported and dispatched through a new `ParsedExprEmitter.indexAccess` arm. The Perl adapters disambiguate array (`->[$i]`) from hash (`->{$k}`) deref by the index's type; Xslate/Hono use the language's polymorphic `[]`; Go emits the `index` builtin.
+- `@barefootjs/jsx`: `.toFixed(digits?)` lowers as a new `array-method` across all adapters — `bf->to_fixed` / `$bf.to_fixed` (new Perl runtime helper), `bf_to_fixed` (new Go runtime helper, `fmt.Sprintf("%.*f", …)`), native `.toFixed` on Hono.
+- `@barefootjs/jsx`: `extractSsrDefaults` now folds a block-body memo through a statically-resolvable `if (cond) return …` guard, so a `/* @client */`-guarded memo (`const key = sortKey(); if (!key) return rows; … sort …`) seeds its default-state early-return value instead of `null`.
+- `@barefootjs/mojolicious`: the test harness seeds a root signal whose initial is `null` / unevaluable as `undef` (rather than skipping it), so a getter read only in a child-prop expression doesn't fault strict vars.
+
+With these, the composed `data-table` demo compiles clean on both Perl adapters and renders structurally byte-identical to Hono on real Mojolicious / Text::Xslate. It stays pinned in `skipJsx` on a single remaining divergence — the scope-ID of imported components inside the keyed `.map` (a hydration-scope concern tracked with #1896), not an expression-lowering gap.

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -753,8 +753,20 @@ func ToFixed(v any, digits int) string {
 	if digits < 0 {
 		digits = 0
 	}
+	n := Number(v)
+	// JS toFixed returns the strings "NaN" / "Infinity" / "-Infinity" for
+	// non-finite inputs; fmt would render "NaN"/"+Inf"/"-Inf".
+	if math.IsNaN(n) {
+		return "NaN"
+	}
+	if math.IsInf(n, 1) {
+		return "Infinity"
+	}
+	if math.IsInf(n, -1) {
+		return "-Infinity"
+	}
 	factor := math.Pow(10, float64(digits))
-	rounded := math.Floor(Number(v)*factor + 0.5)
+	rounded := math.Floor(n*factor + 0.5)
 	return fmt.Sprintf("%.*f", digits, rounded/factor)
 }
 

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -50,9 +50,10 @@ func FuncMap() template.FuncMap {
 		// the Go adapter's `templatePrimitives` map (#1188).
 		"bf_json":   JSON,
 		"bf_number": Number,
-		"bf_floor":  Floor,
-		"bf_ceil":   Ceil,
-		"bf_round":  Round,
+		"bf_floor":    Floor,
+		"bf_ceil":     Ceil,
+		"bf_round":    Round,
+		"bf_to_fixed": ToFixed,
 
 		// Array/Slice
 		"bf_len":            Len,
@@ -740,6 +741,21 @@ func Number(v any) float64 {
 // (`bf_floor` then `bf_string`) line up with JS's number type.
 func Floor(v any) float64 {
 	return math.Floor(Number(v))
+}
+
+// ToFixed formats v with exactly `digits` decimal places, mirroring JS
+// `Number.prototype.toFixed` (zero-padding + half-toward-+Infinity
+// rounding). JS rounds the scaled integer half up (`(2.5).toFixed(0)`
+// is "3"); bare `fmt.Sprintf("%.*f")` rounds half-to-even ("2"), so we
+// scale, round with `Floor(x + 0.5)` (matching `Round`), then format
+// the exact multiple. #1897.
+func ToFixed(v any, digits int) string {
+	if digits < 0 {
+		digits = 0
+	}
+	factor := math.Pow(10, float64(digits))
+	rounded := math.Floor(Number(v)*factor + 0.5)
+	return fmt.Sprintf("%.*f", digits, rounded/factor)
 }
 
 // Ceil returns the smallest integer ≥ v as a float64. Mirrors JS

--- a/packages/adapter-go-template/runtime/vectors_test.go
+++ b/packages/adapter-go-template/runtime/vectors_test.go
@@ -53,6 +53,12 @@ var vectorBindings = map[string]func(args []any) any{
 	"floor":  func(args []any) any { return Floor(args[0]) },
 	"ceil":   func(args []any) any { return Ceil(args[0]) },
 	"round":  func(args []any) any { return Round(args[0]) },
+	"to_fixed": func(args []any) any {
+		if len(args) > 1 {
+			return ToFixed(args[0], args[1].(int))
+		}
+		return ToFixed(args[0], 0)
+	},
 	"lower":  func(args []any) any { return Lower(args[0].(string)) },
 	"upper":  func(args []any) any { return Upper(args[0].(string)) },
 	"trim":   func(args []any) any { return Trim(args[0].(string)) },

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -4376,6 +4376,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     return `${obj}.${this.capitalizeFieldName(property)}`
   }
 
+  indexAccess(object: ParsedExpr, index: ParsedExpr, emit: (e: ParsedExpr) => string): string {
+    // Go's `index` builtin: `index $arr $i`. Both operands render
+    // through the same emitter so a loop-variable / arithmetic index
+    // lowers correctly. #1897 (`selected()[index]`). (data-table's
+    // broader keyed-loop SSR stays tracked under #1896.)
+    return `index ${emit(object)} ${emit(index)}`
+  }
+
   binary(op: string, left: ParsedExpr, right: ParsedExpr, emit: (e: ParsedExpr) => string): string {
     const l = emit(left)
     const r = emit(right)
@@ -4649,6 +4657,13 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         // `strings.TrimSpace`). Adapter wiring only.
         const recv = emit(object)
         return `bf_trim ${wrapIfMultiToken(recv)}`
+      }
+      case 'toFixed': {
+        // `.toFixed(digits?)` → `bf_to_fixed` (`fmt.Sprintf("%.*f", …)`).
+        // Default 0 digits when the argument is omitted. #1897.
+        const recv = emit(object)
+        const digits = args.length >= 1 ? emit(args[0]) : '0'
+        return `bf_to_fixed ${wrapIfMultiToken(recv)} ${digits}`
       }
       case 'split': {
         // `.split()` / `.split(sep)` / `.split(sep, limit)` — string →
@@ -5858,6 +5873,16 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
           return { preamble: obj.preamble, expr: `len ${obj.expr}` }
         }
         return { preamble: obj.preamble, expr: `${obj.expr}.${this.capitalizeFieldName(expr.property)}` }
+      }
+
+      case 'index-access': {
+        // Go's `index` builtin: `index $arr $i`. #1897.
+        const obj = this.renderConditionExpr(expr.object)
+        const idx = this.renderConditionExpr(expr.index)
+        return {
+          preamble: obj.preamble + idx.preamble,
+          expr: `index ${obj.expr} ${idx.expr}`,
+        }
       }
 
       case 'binary': {

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -4379,9 +4379,11 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   indexAccess(object: ParsedExpr, index: ParsedExpr, emit: (e: ParsedExpr) => string): string {
     // Go's `index` builtin: `index $arr $i`. Both operands render
     // through the same emitter so a loop-variable / arithmetic index
-    // lowers correctly. #1897 (`selected()[index]`). (data-table's
-    // broader keyed-loop SSR stays tracked under #1896.)
-    return `index ${emit(object)} ${emit(index)}`
+    // lowers correctly. A multi-token operand (`bf_add $i 1`) must be
+    // parenthesised or Go parses it as extra `index` arguments. #1897
+    // (`selected()[index]`). (data-table's broader keyed-loop SSR stays
+    // tracked under #1896.)
+    return `index ${wrapIfMultiToken(emit(object))} ${wrapIfMultiToken(emit(index))}`
   }
 
   binary(op: string, left: ParsedExpr, right: ParsedExpr, emit: (e: ParsedExpr) => string): string {
@@ -4663,7 +4665,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         // Default 0 digits when the argument is omitted. #1897.
         const recv = emit(object)
         const digits = args.length >= 1 ? emit(args[0]) : '0'
-        return `bf_to_fixed ${wrapIfMultiToken(recv)} ${digits}`
+        return `bf_to_fixed ${wrapIfMultiToken(recv)} ${wrapIfMultiToken(digits)}`
       }
       case 'split': {
         // `.split()` / `.split(sep)` / `.split(sep, limit)` — string →
@@ -5876,12 +5878,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       }
 
       case 'index-access': {
-        // Go's `index` builtin: `index $arr $i`. #1897.
+        // Go's `index` builtin: `index $arr $i`. A multi-token operand
+        // (`bf_add $i 1`) must be parenthesised or Go parses it as extra
+        // `index` arguments. #1897.
         const obj = this.renderConditionExpr(expr.object)
         const idx = this.renderConditionExpr(expr.index)
         return {
           preamble: obj.preamble + idx.preamble,
-          expr: `index ${obj.expr} ${idx.expr}`,
+          expr: `index ${wrapIfMultiToken(obj.expr)} ${wrapIfMultiToken(idx.expr)}`,
         }
       }
 

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -25,10 +25,21 @@ runAdapterConformanceTests({
   // initials, memo ssrDefaults — closing the strict-vars `Global
   // symbol "$id"` gap), boolean-typed prop routing through
   // `bf->bool_str`, `attr={cond ? v : undefined}` omission, and
-  // literal-const inlining. The remaining demo fixtures are pinned in
-  // `expectedDiagnostics` below — they need the context-provider
-  // object-literal lowering, an adapter feature tracked in #1897.
-  skipJsx: [],
+  // literal-const inlining.
+  //
+  // `data-table` is the one remaining JSX-render skip (#1897). It now
+  // COMPILES clean — `selected()[index]` lowers via the shared
+  // `index-access` parser kind and `payment.amount.toFixed(2)` via
+  // `bf->to_fixed`, and its `/* @client */`-guarded `sortedData` memo
+  // SSR-evaluates to the unsorted `payments` early-return — so the
+  // template renders structurally BYTE-IDENTICAL to Hono on real
+  // Mojolicious. The sole divergence is the scope-ID of imported
+  // components inside the keyed `.map` (`TableCell_<random>` vs Hono's
+  // `DataTablePreviewDemo_test_s9`): the loop-child slot-skip is a
+  // hydration-scope concern tracked with #1896, not an expression gap.
+  // Pinned here rather than in `expectedDiagnostics` because no BF101
+  // fires anymore.
+  skipJsx: ['data-table'],
   // Per-fixture build-time contracts for shapes the Mojo adapter
   // intentionally refuses to lower. Owned by this adapter test file
   // (not by the shared fixtures) so adding a new adapter doesn't
@@ -80,11 +91,11 @@ runAdapterConformanceTests({
     // `ref={(el) => {…}}` function prop on an imported component is
     // skipped at SSR like `on*` handlers.
     //
-    // #1467 Phase 2e: the data-table demo source's `/* @client */`
-    // comparator sort (`selected()[index]` signal-call indexing) has no
-    // EP lowering — refused at the demo-source compile via the
-    // `isSupported` gate.
-    'data-table': [{ code: 'BF101', severity: 'error' }],
+    // #1467 Phase 2e: `data-table` is no longer pinned here either — it
+    // compiles clean (`selected()[index]` → `index-access`,
+    // `.toFixed(2)` → `bf->to_fixed`, `/* @client */` memo SSR-folded)
+    // and is pinned in `skipJsx` above on the keyed-loop scope-ID
+    // divergence alone (#1896), not a BF101.
     // #1443: `[a, b].filter(Boolean).join(' ')` (the registry Slot's
     // shape) now lowers to `join(' ', @{[grep { $_ } @{[$a, $b]}]})`.
     // No BF101 expected — pinned positively via the

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1906,6 +1906,35 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
         return n
       })()
       const indexed = this.recordIndexAccessToPerl(initNode)
+      if (
+        indexed === null &&
+        ts.isElementAccessExpression(initNode) &&
+        initNode.argumentExpression &&
+        !ts.isNumericLiteral(initNode.argumentExpression) &&
+        !ts.isStringLiteral(initNode.argumentExpression)
+      ) {
+        // Variable-index record access (`sizeMap[size]`) that the
+        // static-inline path couldn't resolve — a non-scalar record
+        // value, or a non-const receiver. Since #1897 made variable
+        // indices parseable (`index-access`), the generic value lowering
+        // would now emit `$sizeMap->{$size}` against an UNBOUND module
+        // const instead of refusing. Record BF101 and bail so the whole
+        // spread surfaces the out-of-shape diagnostic, matching the
+        // pre-#1897 behaviour (the refusal then was a side effect of the
+        // value lowering). (A bound receiver — a signal getter like
+        // `selected()[index]` — is an attribute value, not a spread
+        // member, and never reaches here.)
+        this.errors.push({
+          code: 'BF101',
+          severity: 'error',
+          message: `Spread object value '${initNode.getText(sf)}' indexes a record map whose values aren't scalar literals — it can't lower to an inline Perl hashref.`,
+          loc: { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+          suggestion: {
+            message: 'Index a record whose values are number/string literals, or move the spread into a `\'use client\'` component so hydration computes it.',
+          },
+        })
+        return null
+      }
       const valPerl =
         indexed !== null
           ? indexed
@@ -2148,6 +2177,13 @@ function renderArrayMethod(
       const recv = emit(object)
       return `bf->trim(${recv})`
     }
+    case 'toFixed': {
+      // `.toFixed(digits?)` — Number → fixed-decimal string. `bf->to_fixed`
+      // mirrors JS rounding + zero-padding (default 0 digits). #1897.
+      const recv = emit(object)
+      const digits = args.length >= 1 ? emit(args[0]) : '0'
+      return `bf->to_fixed(${recv}, ${digits})`
+    }
     case 'split': {
       // `.split()` / `.split(sep)` / `.split(sep, limit)` — string →
       // ARRAY ref via `bf->split`. With no separator the helper returns
@@ -2376,6 +2412,25 @@ function isStringTypedOperand(expr: ParsedExpr, isStringName: (n: string) => boo
 }
 
 /**
+ * Lower `arr[index]` to a Perl deref. Perl distinguishes array
+ * (`->[$i]`) from hash (`->{$k}`) access, which JS's single `[]` does
+ * not — so we pick by the index expression's type: a string-typed key
+ * derefs the hash, anything else (the common loop-index / arithmetic
+ * case, e.g. `selected()[index]`) derefs the array. #1897.
+ */
+function emitIndexAccessPerl(
+  object: ParsedExpr,
+  index: ParsedExpr,
+  emit: (e: ParsedExpr) => string,
+  isStringName: (n: string) => boolean,
+): string {
+  const i = emit(index)
+  return isStringTypedOperand(index, isStringName)
+    ? `${emit(object)}->{${i}}`
+    : `${emit(object)}->[${i}]`
+}
+
+/**
  * Lowering for the predicate body of a filter / every / some / find,
  * plus the same shape used by `renderBlockBodyCondition` for complex
  * block-body filters. Identifiers resolve against:
@@ -2424,6 +2479,10 @@ class MojoFilterEmitter implements ParsedExprEmitter {
       return `scalar(@{${emit(object)}})`
     }
     return `${emit(object)}->{${property}}`
+  }
+
+  indexAccess(object: ParsedExpr, index: ParsedExpr, emit: (e: ParsedExpr) => string): string {
+    return emitIndexAccessPerl(object, index, emit, this.isStringName)
   }
 
   call(callee: ParsedExpr, args: ParsedExpr[], emit: (e: ParsedExpr) => string): string {
@@ -2610,6 +2669,10 @@ class MojoTopLevelEmitter implements ParsedExprEmitter {
     const obj = emit(object)
     if (property === 'length') return `scalar(@{${obj}})`
     return `${obj}->{${property}}`
+  }
+
+  indexAccess(object: ParsedExpr, index: ParsedExpr, emit: (e: ParsedExpr) => string): string {
+    return emitIndexAccessPerl(object, index, emit, n => this.adapter._isStringValueName(n))
   }
 
   call(callee: ParsedExpr, args: ParsedExpr[], emit: (e: ParsedExpr) => string): string {

--- a/packages/adapter-mojolicious/src/test-render.ts
+++ b/packages/adapter-mojolicious/src/test-render.ts
@@ -592,12 +592,15 @@ function buildPerlProps(
     }
   }
 
-  // Add signal values evaluated from props (must come after user props)
+  // Add signal values evaluated from props (must come after user props).
+  // Seed `undef` for a null / unevaluable initial (e.g. a
+  // `createSignal<SortKey>(null)` whose getter is read in a child-prop
+  // ternary) rather than skipping it — an unseeded getter faults strict
+  // vars with `Global symbol "$x" requires explicit package name`. Same
+  // rule `buildChildDefaultsPerl` applies to child signals (#1897).
   for (const signal of ir.metadata.signals) {
     const value = evaluateSignalInit(signal.initialValue.trim(), props)
-    if (value !== null) {
-      entries.push(`${signal.getter} => ${toPerlLiteral(value)}`)
-    }
+    entries.push(`${signal.getter} => ${value !== null ? toPerlLiteral(value) : 'undef'}`)
   }
 
   // Add memo values. The production Mojo plugin seeds these from the

--- a/packages/adapter-perl/lib/BarefootJS.pm
+++ b/packages/adapter-perl/lib/BarefootJS.pm
@@ -858,7 +858,9 @@ sub trim ($self, $recv) {
 # argument.
 sub to_fixed ($self, $value, $digits = 0) {
     my $n = $self->number($value);
-    return $n if _is_nan($n);
+    # JS `(NaN).toFixed(d)` is the STRING "NaN"; returning the numeric NaN
+    # would stringify per-platform ("nan"/"NaN"/...) and diverge.
+    return 'NaN' if _is_nan($n);
     $digits = 0 if !defined $digits || $digits < 0;
     my $factor  = 10 ** $digits;
     my $rounded = POSIX::floor($n * $factor + 0.5);

--- a/packages/adapter-perl/lib/BarefootJS.pm
+++ b/packages/adapter-perl/lib/BarefootJS.pm
@@ -530,6 +530,10 @@ sub number ($self, $value) {
 # portable sentinel check in floor/ceil/round.
 sub _is_nan { my $n = shift; return $n != $n }
 
+# True for +/-Infinity. `9**9**9` is Perl's portable infinity literal; a
+# finite number is always strictly less than +Inf in magnitude.
+sub _is_inf { my $n = shift; return $n == 9**9**9 || $n == -9**9**9 }
+
 sub floor ($self, $value) {
     my $n = $self->number($value);
     return $n if _is_nan($n);
@@ -858,9 +862,11 @@ sub trim ($self, $recv) {
 # argument.
 sub to_fixed ($self, $value, $digits = 0) {
     my $n = $self->number($value);
-    # JS `(NaN).toFixed(d)` is the STRING "NaN"; returning the numeric NaN
-    # would stringify per-platform ("nan"/"NaN"/...) and diverge.
+    # JS toFixed returns the STRINGS "NaN" / "Infinity" / "-Infinity" for
+    # non-finite inputs; the numeric values would stringify per-platform
+    # ("nan"/"inf"/...) and diverge.
     return 'NaN' if _is_nan($n);
+    return $n < 0 ? '-Infinity' : 'Infinity' if _is_inf($n);
     $digits = 0 if !defined $digits || $digits < 0;
     my $factor  = 10 ** $digits;
     my $rounded = POSIX::floor($n * $factor + 0.5);

--- a/packages/adapter-perl/lib/BarefootJS.pm
+++ b/packages/adapter-perl/lib/BarefootJS.pm
@@ -848,6 +848,23 @@ sub trim ($self, $recv) {
     return $s;
 }
 
+# `Number.prototype.toFixed(digits)` (#1897) — fixed-decimal string with
+# zero-padding. JS rounds the scaled integer half toward +Infinity (the
+# spec's "pick the larger n" tie-break), so `(2.5).toFixed(0)` is "3";
+# bare `sprintf("%.*f")` would round half-to-even ("2"), diverging. Scale
+# by 10**digits, round with `floor(x + 0.5)` (the same tie-break the
+# `round` helper uses), then format the exact multiple. A negative
+# `digits` clamps to 0, mirroring how the adapters default an omitted
+# argument.
+sub to_fixed ($self, $value, $digits = 0) {
+    my $n = $self->number($value);
+    return $n if _is_nan($n);
+    $digits = 0 if !defined $digits || $digits < 0;
+    my $factor  = 10 ** $digits;
+    my $rounded = POSIX::floor($n * $factor + 0.5);
+    return sprintf('%.*f', $digits, $rounded / $factor);
+}
+
 # `String.prototype.split(sep)` (#1448 Tier B) — string → ARRAY ref.
 #
 # Two JS-parity wrinkles drive the helper (a bare `split` emit would

--- a/packages/adapter-perl/t/helper_vectors.t
+++ b/packages/adapter-perl/t/helper_vectors.t
@@ -61,6 +61,7 @@ my %bindings = (
     floor  => sub { $bf->floor($_[0]) },
     ceil   => sub { $bf->ceil($_[0]) },
     round  => sub { $bf->round($_[0]) },
+    to_fixed => sub { $bf->to_fixed(@_) },
 
     # The Mojo renderer emits native lc()/uc(); Xslate emits $bf.lc /
     # $bf.uc. The helper methods wrap CORE::lc/uc, so binding them

--- a/packages/adapter-tests/helper-vectors/cases.ts
+++ b/packages/adapter-tests/helper-vectors/cases.ts
@@ -36,6 +36,7 @@ export const reference: Record<string, (...args: never[]) => unknown> = {
   floor: (v: unknown) => Math.floor(Number(v)),
   ceil: (v: unknown) => Math.ceil(Number(v)),
   round: (v: unknown) => Math.round(Number(v)),
+  to_fixed: (v: unknown, digits?: number) => Number(v).toFixed(digits ?? 0),
   lower: (s: string) => s.toLowerCase(),
   upper: (s: string) => s.toUpperCase(),
   trim: (s: string) => s.trim(),
@@ -209,6 +210,12 @@ export const cases: HelperCase[] = [
   { fn: 'round', args: [-2.4], note: 'negative below half rounds toward zero' },
   { fn: 'round', args: [7], note: 'integral passthrough' },
   { fn: 'round', args: ['6.6'], note: 'numeric-string operand routes through number coercion' },
+
+  { fn: 'to_fixed', args: [316, 2], note: 'integer padded to 2 decimals (data-table amount)' },
+  { fn: 'to_fixed', args: [3.14159, 2], note: 'rounds to 2 decimals' },
+  { fn: 'to_fixed', args: [2.5, 0], note: 'zero digits rounds to integer string' },
+  { fn: 'to_fixed', args: [1.005, 2], note: 'IEEE-754 double: 1.005 formats as 1.00 on all backends' },
+  { fn: 'to_fixed', args: ['7.1', 3], note: 'numeric-string operand routes through number coercion' },
 
   { fn: 'lower', args: ['HeLLo'], note: 'mixed case' },
   { fn: 'lower', args: ['ABC123'], note: 'digits pass through' },

--- a/packages/adapter-tests/helper-vectors/vectors.json
+++ b/packages/adapter-tests/helper-vectors/vectors.json
@@ -599,6 +599,51 @@
       "note": "numeric-string operand routes through number coercion"
     },
     {
+      "fn": "to_fixed",
+      "args": [
+        316,
+        2
+      ],
+      "expect": "316.00",
+      "note": "integer padded to 2 decimals (data-table amount)"
+    },
+    {
+      "fn": "to_fixed",
+      "args": [
+        3.14159,
+        2
+      ],
+      "expect": "3.14",
+      "note": "rounds to 2 decimals"
+    },
+    {
+      "fn": "to_fixed",
+      "args": [
+        2.5,
+        0
+      ],
+      "expect": "3",
+      "note": "zero digits rounds to integer string"
+    },
+    {
+      "fn": "to_fixed",
+      "args": [
+        1.005,
+        2
+      ],
+      "expect": "1.00",
+      "note": "IEEE-754 double: 1.005 formats as 1.00 on all backends"
+    },
+    {
+      "fn": "to_fixed",
+      "args": [
+        "7.1",
+        3
+      ],
+      "expect": "7.100",
+      "note": "numeric-string operand routes through number coercion"
+    },
+    {
       "fn": "lower",
       "args": [
         "HeLLo"

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -36,7 +36,17 @@ runAdapterConformanceTests({
   // literal-const inlining (`totalPages`). Shapes the adapter
   // intentionally refuses at build time stay pinned in
   // `expectedDiagnostics` below.
-  skipJsx: [],
+  //
+  // `data-table` is the one JSX-render skip (#1897): it compiles clean
+  // (`selected()[index]` → shared `index-access` parser kind,
+  // `.toFixed(2)` → `$bf.to_fixed`, `/* @client */`-guarded `sortedData`
+  // memo SSR-folded to the unsorted early-return) and renders
+  // structurally BYTE-IDENTICAL to Hono on real Text::Xslate. The sole
+  // divergence is the scope-ID of imported components inside the keyed
+  // `.map` (a hydration-scope concern tracked with #1896, not an
+  // expression gap), so it's pinned in `skipJsx` rather than
+  // `expectedDiagnostics` (no BF101 fires anymore).
+  skipJsx: ['data-table'],
   // Per-fixture build-time contracts for shapes the Xslate adapter
   // intentionally refuses to lower. Mirrors mojo's set — the lowering
   // gates are shared code paths in the ported adapter.
@@ -90,11 +100,11 @@ runAdapterConformanceTests({
     // to `nil`. The command demo's `ref={(el) => {…}}` function prop on
     // an imported component is skipped at SSR like `on*` handlers.
     //
-    // #1467 Phase 2e: the data-table demo source's `/* @client */`
-    // comparator sort (`selected()[index]` signal-call indexing) has no
-    // Kolon lowering — refused at the demo-source compile, same gate as
-    // mojo.
-    'data-table': [{ code: 'BF101', severity: 'error' }],
+    // #1467 Phase 2e: `data-table` is no longer pinned here — it
+    // compiles clean now (`selected()[index]` → `index-access`,
+    // `.toFixed(2)` → `$bf.to_fixed`, `/* @client */` memo SSR-folded)
+    // and is pinned in `skipJsx` above on the keyed-loop scope-ID
+    // divergence alone (#1896), not a BF101.
     // `style-3-signals` / `style-object-dynamic` no longer pinned — a
     // `style={{ … }}` object literal now lowers to a CSS string with dynamic
     // values interpolated (`background-color:<: $color :>;padding:8px`) via

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -1617,6 +1617,31 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
         return n
       })()
       const indexed = this.recordIndexAccessToKolon(initNode)
+      if (
+        indexed === null &&
+        ts.isElementAccessExpression(initNode) &&
+        initNode.argumentExpression &&
+        !ts.isNumericLiteral(initNode.argumentExpression) &&
+        !ts.isStringLiteral(initNode.argumentExpression)
+      ) {
+        // Variable-index record access (`sizeMap[size]`) the static-inline
+        // path couldn't resolve (non-scalar value / non-const receiver).
+        // Since #1897 made variable indices parseable (`index-access`),
+        // the generic value lowering would emit `$sizeMap[$size]` against
+        // an UNBOUND module const instead of refusing — record BF101 and
+        // bail so the spread surfaces the out-of-shape diagnostic,
+        // matching pre-#1897 behaviour. (Mirrors the Mojo adapter.)
+        this.errors.push({
+          code: 'BF101',
+          severity: 'error',
+          message: `Spread object value '${initNode.getText(sf)}' indexes a record map whose values aren't scalar literals — it can't lower to an inline Kolon hashref.`,
+          loc: { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+          suggestion: {
+            message: 'Index a record whose values are number/string literals, or move the spread into a `\'use client\'` component so hydration computes it.',
+          },
+        })
+        return null
+      }
       const valPerl =
         indexed !== null
           ? indexed
@@ -1880,6 +1905,13 @@ function renderArrayMethod(
       const recv = emit(object)
       return `$bf.trim(${recv})`
     }
+    case 'toFixed': {
+      // `.toFixed(digits?)` — `$bf.to_fixed` mirrors JS rounding +
+      // zero-padding (default 0 digits). #1897.
+      const recv = emit(object)
+      const digits = args.length >= 1 ? emit(args[0]) : '0'
+      return `$bf.to_fixed(${recv}, ${digits})`
+    }
     case 'split': {
       const recv = emit(object)
       if (args.length === 0) {
@@ -2113,6 +2145,13 @@ class XslateFilterEmitter implements ParsedExprEmitter {
     return `${emit(object)}.${property}`
   }
 
+  indexAccess(object: ParsedExpr, index: ParsedExpr, emit: (e: ParsedExpr) => string): string {
+    // Kolon's `[]` postfix is polymorphic (array index or hash key),
+    // mirroring JS — no array/hash split is needed (unlike Perl's
+    // `->[]` vs `->{}`). #1897 (data-table's `selected()[index]`).
+    return `${emit(object)}[${emit(index)}]`
+  }
+
   call(callee: ParsedExpr, args: ParsedExpr[], emit: (e: ParsedExpr) => string): string {
     // Signal getter calls: filter() → $filter
     if (callee.kind === 'identifier' && args.length === 0) {
@@ -2273,6 +2312,12 @@ class XslateTopLevelEmitter implements ParsedExprEmitter {
     if (property === 'length') return `$bf.length(${obj})`
     // Kolon dot access works for hash refs.
     return `${obj}.${property}`
+  }
+
+  indexAccess(object: ParsedExpr, index: ParsedExpr, emit: (e: ParsedExpr) => string): string {
+    // Kolon's `[]` postfix is polymorphic (array index or hash key),
+    // mirroring JS. #1897 (data-table's `selected()[index]`).
+    return `${emit(object)}[${emit(index)}]`
   }
 
   call(callee: ParsedExpr, args: ParsedExpr[], emit: (e: ParsedExpr) => string): string {

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -1136,6 +1136,25 @@ describe('expression-parser', () => {
       expect(result.level).toBe('L2')
     })
 
+    test('L2: variable element access (`arr[index]`) is supported (#1897)', () => {
+      const expr = parseExpression('selected()[index]')
+      expect(expr.kind).toBe('index-access')
+      const result = isSupported(expr)
+      expect(result.supported).toBe(true)
+      expect(result.level).toBe('L2')
+    })
+
+    test('arithmetic index (`arr[i + 1]`) is supported', () => {
+      const expr = parseExpression('arr[i + 1]')
+      expect(expr.kind).toBe('index-access')
+      expect(isSupported(expr).supported).toBe(true)
+    })
+
+    test('element access with an unsupported (arrow) index is refused', () => {
+      const expr = parseExpression('rows[() => x]')
+      expect(isSupported(expr).supported).toBe(false)
+    })
+
     test('L2: .length is supported', () => {
       const expr = parseExpression('items().length')
       const result = isSupported(expr)
@@ -1461,6 +1480,8 @@ describe('expression-parser — array-method full-arity lowering (#1448)', () =>
     ['slice(start)', 'arr.slice(1)'],
     ['slice(start, end)', 'arr.slice(1, 2)'],
     ['trim()', 's.trim()'],
+    ['toFixed(digits)', 'n.toFixed(2)'],
+    ['toFixed() → default 0', 'n.toFixed()'],
     // zero-arg defaults (every one of these escaping both its arm AND
     // the guard is the footgun the relaxation must NOT reintroduce)
     ['join() → default ","', 'arr.join()'],

--- a/packages/jsx/src/__tests__/ssr-defaults.test.ts
+++ b/packages/jsx/src/__tests__/ssr-defaults.test.ts
@@ -99,6 +99,31 @@ describe('extractSsrDefaults', () => {
     expect(defaults?.doubled).toEqual({ value: 10 })
   })
 
+  test('block-body memo with an early-return guard folds to the default-state branch (#1897)', () => {
+    // The data-table `sortedData` shape: a `/* @client */`-guarded sort
+    // whose early return yields the unsorted module-const array when the
+    // sort-key signal is at its initial (null) value. The SSR default is
+    // that early-return array, not `null` — the `if (!key)` guard is
+    // taken because `sortKey()` resolves to its seeded `null` initial.
+    const metadata = metadataFor(`
+      'use client'
+      import { createSignal, createMemo } from '@barefootjs/client'
+      const rows = [{ id: 'a' }, { id: 'b' }]
+      function Table() {
+        const [sortKey, setSortKey] = createSignal<string | null>(null)
+        const sorted = createMemo(() => {
+          const key = sortKey()
+          if (!key) return rows
+          return /* @client */ [...rows].sort((a, b) => a.id < b.id ? -1 : 1)
+        })
+        return <ul>{sorted().map(r => <li>{r.id}</li>)}</ul>
+      }
+    `)
+
+    const defaults = extractSsrDefaults(metadata)
+    expect(defaults?.sorted).toEqual({ value: [{ id: 'a' }, { id: 'b' }] })
+  })
+
   test('non-evaluable initials yield null (caller falls back at render time)', () => {
     const metadata = metadataFor(`
       'use client'

--- a/packages/jsx/src/adapters/parsed-expr-emitter.ts
+++ b/packages/jsx/src/adapters/parsed-expr-emitter.ts
@@ -66,6 +66,7 @@ export type ArrayMethod =
   | 'toLowerCase'
   | 'toUpperCase'
   | 'trim'
+  | 'toFixed'
   | 'split'
   | 'startsWith'
   | 'endsWith'
@@ -113,6 +114,14 @@ export interface ParsedExprEmitter {
     object: ParsedExpr,
     property: string,
     computed: boolean,
+    emit: (e: ParsedExpr) => string,
+  ): string
+  // Element access with a non-literal index (`arr[index]`). The index
+  // is a full `ParsedExpr` (loop variable, arithmetic, etc.); the
+  // adapter picks array vs hash deref per target language. #1897.
+  indexAccess(
+    object: ParsedExpr,
+    index: ParsedExpr,
     emit: (e: ParsedExpr) => string,
   ): string
   binary(op: string, left: ParsedExpr, right: ParsedExpr, emit: (e: ParsedExpr) => string): string
@@ -196,6 +205,8 @@ export function emitParsedExpr(expr: ParsedExpr, emitter: ParsedExprEmitter): st
       return emitter.call(expr.callee, expr.args, emit)
     case 'member':
       return emitter.member(expr.object, expr.property, expr.computed, emit)
+    case 'index-access':
+      return emitter.indexAccess(expr.object, expr.index, emit)
     case 'binary':
       return emitter.binary(expr.op, expr.left, expr.right, emit)
     case 'unary':

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -1145,6 +1145,13 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
   if (ts.isElementAccessExpression(node)) {
     const object = convertNode(node.expression, raw)
     const argNode = node.argumentExpression
+    // `argumentExpression` is non-optional in the TS types but CAN be
+    // undefined on an AST recovered from incomplete source (`arr[`). Guard
+    // so a half-typed expression surfaces a recoverable BF101 instead of
+    // throwing inside `ts.isNumericLiteral(undefined)`.
+    if (!argNode) {
+      return { kind: 'unsupported', raw, reason: 'Element access with no index expression' }
+    }
     // For simple number/string access, store as property
     if (ts.isNumericLiteral(argNode)) {
       return { kind: 'member', object, property: argNode.text, computed: true }

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -17,6 +17,14 @@ export type ParsedExpr =
   | { kind: 'literal'; value: string | number | boolean | null; literalType: 'string' | 'number' | 'boolean' | 'null' }
   | { kind: 'call'; callee: ParsedExpr; args: ParsedExpr[] }
   | { kind: 'member'; object: ParsedExpr; property: string; computed: boolean }
+  // Element access with a NON-literal index (`selected()[index]`,
+  // `rows[i + 1]`). A literal-index access (`arr[0]`, `obj['key']`)
+  // stays a `member` (computed) since the key is statically known and
+  // folds into the same property path. The variable case can't, so the
+  // index travels as its own `ParsedExpr` for the adapter to lower
+  // (array `->[$i]` vs hash `->{$k}` in Perl, `[index]` in JS). #1897
+  // (data-table's per-row `selected()[index]`).
+  | { kind: 'index-access'; object: ParsedExpr; index: ParsedExpr }
   | { kind: 'binary'; op: string; left: ParsedExpr; right: ParsedExpr }
   | { kind: 'unary'; op: string; argument: ParsedExpr }
   | { kind: 'conditional'; test: ParsedExpr; consequent: ParsedExpr; alternate: ParsedExpr }
@@ -46,6 +54,7 @@ export type ParsedExpr =
         | 'toLowerCase'
         | 'toUpperCase'
         | 'trim'
+        | 'toFixed'
         | 'split'
         | 'startsWith'
         | 'endsWith'
@@ -857,6 +866,14 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
       if (callee.property === 'trim') {
         return { kind: 'array-method', method: 'trim', object: callee.object, args }
       }
+      // `.toFixed(digits?)` — Number → fixed-decimal string. The digit
+      // count (default 0) travels as the single arg; all adapters route
+      // through a `to_fixed` runtime helper (Perl) / `fmt.Sprintf` (Go)
+      // so JS's rounding + zero-padding semantics match. #1897
+      // (data-table's `payment.amount.toFixed(2)`).
+      if (callee.property === 'toFixed') {
+        return { kind: 'array-method', method: 'toFixed', object: callee.object, args }
+      }
       // `.split()` / `.split(sep)` / `.split(sep, limit)` — string →
       // array, full JS arity. `.split()` (no separator) returns the
       // whole string as a single element; `.split(sep)` splits on the
@@ -1135,8 +1152,13 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
     if (ts.isStringLiteral(argNode)) {
       return { kind: 'member', object, property: argNode.text, computed: true }
     }
-    // Complex computed access
-    return { kind: 'unsupported', raw, reason: 'Complex computed property access' }
+    // Variable / expression index (`selected()[index]`, `rows[i + 1]`):
+    // carry the index as its own ParsedExpr so the adapter can lower it
+    // (the literal forms above fold into a static property path; this
+    // one can't). #1897 (data-table).
+    const index = convertNode(argNode, raw)
+    if (index.kind === 'unsupported') return index
+    return { kind: 'index-access', object, index }
   }
 
   // Binary expression: a === b, count > 0, a + b
@@ -2088,6 +2110,8 @@ function findImpureDefaultNode(expr: ParsedExpr): string | null {
       return null
     case 'member':
       return findImpureDefaultNode(expr.object)
+    case 'index-access':
+      return findImpureDefaultNode(expr.object) ?? findImpureDefaultNode(expr.index)
     case 'unary':
       return findImpureDefaultNode(expr.argument)
     case 'binary':
@@ -2317,6 +2341,10 @@ function collectIdentifiers(expr: ParsedExpr, out: Set<string>): void {
     case 'member':
       collectIdentifiers(expr.object, out)
       return
+    case 'index-access':
+      collectIdentifiers(expr.object, out)
+      collectIdentifiers(expr.index, out)
+      return
     case 'binary':
     case 'logical':
       collectIdentifiers(expr.left, out)
@@ -2411,6 +2439,8 @@ function substituteDestructuredFields(
           }
         }
         return { kind: 'member', object: walk(e.object), property: e.property, computed: e.computed }
+      case 'index-access':
+        return { kind: 'index-access', object: walk(e.object), index: walk(e.index) }
       case 'binary':
         return { kind: 'binary', op: e.op, left: walk(e.left), right: walk(e.right) }
       case 'logical':
@@ -2659,6 +2689,17 @@ function checkSupport(expr: ParsedExpr): SupportResult {
       return { supported: true, level: 'L2' }
     }
 
+    case 'index-access': {
+      // `arr[index]` — supported when both the receiver and the index
+      // expression are themselves supported (the index is typically a
+      // loop variable or arithmetic over one). #1897 (data-table).
+      const objSupport = checkSupport(expr.object)
+      if (!objSupport.supported) return objSupport
+      const indexSupport = checkSupport(expr.index)
+      if (!indexSupport.supported) return indexSupport
+      return { supported: true, level: 'L2' }
+    }
+
     case 'binary': {
       const leftSupport = checkSupport(expr.left)
       if (!leftSupport.supported) return leftSupport
@@ -2740,6 +2781,8 @@ export function containsHigherOrder(expr: ParsedExpr): boolean {
       return expr.args.some(containsHigherOrder) || containsHigherOrder(expr.callee)
     case 'member':
       return containsHigherOrder(expr.object)
+    case 'index-access':
+      return containsHigherOrder(expr.object) || containsHigherOrder(expr.index)
     case 'binary':
       return containsHigherOrder(expr.left) || containsHigherOrder(expr.right)
     case 'unary':
@@ -2911,6 +2954,8 @@ export function exprToString(expr: ParsedExpr): string {
       return `${exprToString(expr.callee)}(${expr.args.map(exprToString).join(', ')})`
     case 'member':
       return `${exprToString(expr.object)}.${expr.property}`
+    case 'index-access':
+      return `${exprToString(expr.object)}[${exprToString(expr.index)}]`
     case 'binary':
       return `${exprToString(expr.left)} ${expr.op} ${exprToString(expr.right)}`
     case 'unary':
@@ -2992,6 +3037,8 @@ export function stringifyParsedExpr(expr: ParsedExpr): string {
         : JSON.stringify(expr.property)
       return `${obj}[${key}]`
     }
+    case 'index-access':
+      return `${stringifyParsedExpr(expr.object)}[${stringifyParsedExpr(expr.index)}]`
     case 'binary':
       return `${stringifyParsedExpr(expr.left)} ${expr.op} ${stringifyParsedExpr(expr.right)}`
     case 'unary':

--- a/packages/jsx/src/ssr-defaults.ts
+++ b/packages/jsx/src/ssr-defaults.ts
@@ -241,8 +241,8 @@ function tryStaticEval(expr: string, ctx: EvalContext): EvalResult {
  * `const` declarations (bound into `ctx.bindings`, which mutate in
  * place so later statements and nested branches see them), `return`
  * statements, and `if (cond) …` guards whose condition is statically
- * resolvable — the early-return-on-default-state shape of a
- * `/* @client *​/`-guarded memo (`const key = sortKey(); if (!key)
+ * resolvable — the early-return-on-default-state shape of
+ * an `@client`-annotated memo (`const key = sortKey(); if (!key)
  * return payments; … sort …`). A resolvable-but-falsy guard continues
  * to the next statement (`NO_RETURN` from the skipped branch); an
  * unresolvable condition or any other statement kind bails to

--- a/packages/jsx/src/ssr-defaults.ts
+++ b/packages/jsx/src/ssr-defaults.ts
@@ -65,6 +65,12 @@ export interface SsrDefault {
 const UNRESOLVED = Symbol('unresolved')
 type EvalResult = unknown | typeof UNRESOLVED
 
+// Sentinel: a statement list ran to its end without hitting a `return`
+// (so the enclosing branch falls through to the next statement). Kept
+// distinct from `UNRESOLVED` (couldn't evaluate) so a falsy guard
+// (`if (!key) return X`) continues evaluation instead of bailing.
+const NO_RETURN = Symbol('no-return')
+
 interface EvalContext {
   /** Identifier name → previously-resolved value (signal getters, memos). */
   bindings: Record<string, EvalResult>
@@ -230,6 +236,53 @@ function tryStaticEval(expr: string, ctx: EvalContext): EvalResult {
   return evalNode(node, ctx)
 }
 
+/**
+ * Evaluate a block-body's statements for its returned value. Handles
+ * `const` declarations (bound into `ctx.bindings`, which mutate in
+ * place so later statements and nested branches see them), `return`
+ * statements, and `if (cond) …` guards whose condition is statically
+ * resolvable — the early-return-on-default-state shape of a
+ * `/* @client *​/`-guarded memo (`const key = sortKey(); if (!key)
+ * return payments; … sort …`). A resolvable-but-falsy guard continues
+ * to the next statement (`NO_RETURN` from the skipped branch); an
+ * unresolvable condition or any other statement kind bails to
+ * `UNRESOLVED`. #1897 (data-table's `sortedData`).
+ */
+function evalStatementsForReturn(
+  statements: readonly ts.Statement[],
+  ctx: EvalContext,
+): EvalResult | typeof NO_RETURN {
+  for (const stmt of statements) {
+    if (ts.isVariableStatement(stmt)) {
+      for (const d of stmt.declarationList.declarations) {
+        if (!ts.isIdentifier(d.name) || !d.initializer) continue
+        const v = evalNode(d.initializer, ctx)
+        // Leave unresolved locals unbound; only a `return` / guard
+        // referencing one would then surface UNRESOLVED.
+        if (v !== UNRESOLVED) ctx.bindings[d.name.text] = v
+      }
+    } else if (ts.isReturnStatement(stmt)) {
+      return stmt.expression ? evalNode(stmt.expression, ctx) : UNRESOLVED
+    } else if (ts.isIfStatement(stmt)) {
+      const cond = evalNode(stmt.expression, ctx)
+      if (cond === UNRESOLVED) return UNRESOLVED
+      const branch = cond ? stmt.thenStatement : stmt.elseStatement
+      if (branch) {
+        const taken = evalStatementsForReturn(
+          ts.isBlock(branch) ? branch.statements : [branch],
+          ctx,
+        )
+        if (taken !== NO_RETURN) return taken
+      }
+      // Guard not taken (or its branch fell through) — continue.
+    } else {
+      // Any other statement (loop, side-effecting call) — bail.
+      return UNRESOLVED
+    }
+  }
+  return NO_RETURN
+}
+
 function parseExpression(expr: string): ts.Expression | null {
   // Wrap in parens so a leading `{}` parses as an object literal rather
   // than an empty block statement.
@@ -269,23 +322,8 @@ function evalNode(node: ts.Expression, ctx: EvalContext): EvalResult {
     if (!ts.isBlock(node.body)) return evalNode(node.body as ts.Expression, ctx)
     const localBindings: Record<string, EvalResult> = { ...ctx.bindings }
     const localCtx: EvalContext = { ...ctx, bindings: localBindings }
-    for (const stmt of node.body.statements) {
-      if (ts.isVariableStatement(stmt)) {
-        for (const d of stmt.declarationList.declarations) {
-          if (!ts.isIdentifier(d.name) || !d.initializer) continue
-          const v = evalNode(d.initializer, localCtx)
-          // Leave unresolved locals unbound; only the `return` referencing
-          // one would then surface UNRESOLVED.
-          if (v !== UNRESOLVED) localBindings[d.name.text] = v
-        }
-      } else if (ts.isReturnStatement(stmt)) {
-        return stmt.expression ? evalNode(stmt.expression, localCtx) : UNRESOLVED
-      } else {
-        // Any other statement (a branch, a side-effecting call) — bail.
-        return UNRESOLVED
-      }
-    }
-    return UNRESOLVED
+    const result = evalStatementsForReturn(node.body.statements, localCtx)
+    return result === NO_RETURN ? UNRESOLVED : result
   }
 
   if (ts.isNumericLiteral(node)) return Number(node.text)


### PR DESCRIPTION
Fourth increment for #1897 (follows #1908). Brings the composed `data-table` demo from **compile-refused (BF101)** to **compiling clean and rendering structurally byte-identical to Hono** on real Mojolicious and Text::Xslate. This required extending the shared `@barefootjs/jsx` parser (approved scope) plus three supporting fixes.

## Shared-parser features (all four adapters)

- **`index-access` ParsedExpr kind** — element access with a *non-literal* index (`selected()[index]`, `rows[i + 1]`), previously refused as "Complex computed property access". A literal index (`arr[0]`, `obj['key']`) stays a `member` (statically foldable). Dispatched through a new `ParsedExprEmitter.indexAccess` arm:
  - Perl disambiguates array (`->[$i]`) from hash (`->{$k}`) deref by the index's type (loop index / arithmetic → array);
  - Xslate (Kolon) and Hono use the language's polymorphic `[]`;
  - Go emits the `index` builtin.
- **`.toFixed(digits?)`** lowering via a new `array-method` member — `bf->to_fixed` / `$bf.to_fixed` (new Perl runtime helper) and `bf_to_fixed` (new Go helper). Both round **half toward +Infinity** at the target precision to match JS `Number.prototype.toFixed`; bare `sprintf` / `fmt.Sprintf` round half-to-even and would diverge at the `.5` tie (`(2.5).toFixed(0)` is `"3"`, not `"2"`).

## Supporting render fixes (surfaced by un-refusing the module)

- **`extractSsrDefaults` block-body memo folding** — evaluates a statically-resolvable `if (cond) return …` guard, so a `/* @client */`-guarded memo seeds its default-state early-return value (`sortedData` → unsorted `payments`) instead of `null`.
- **Mojo root signal seeding** — a root signal with a `null`/unevaluable initial seeds as `undef` rather than being skipped, so a getter read only in a child-prop expression doesn't fault strict vars.
- **Non-scalar `Record[propKey]` spread** now records BF101 explicitly. The refusal was previously a side effect of the value-lowering path that `index-access` made succeed; the diagnostic is restored at the spread site.

## `data-table` pin

Moves from `expectedDiagnostics` (no BF101 fires anymore) to `skipJsx` on both Perl adapters. It compiles clean and renders **byte-identical to Hono once scope attributes are collapsed** — the sole divergence is the scope-ID of imported components inside the keyed `.map` (`TableCell_<random>` vs `DataTablePreviewDemo_test_s9`). That loop-child slot-skip is a hydration-scope concern tracked with #1896, not an expression-lowering gap. Per #1897's coverage note, the fixture keeps full coverage at the Hono SSR and browser-hydrate layers.

## Verification

- `bun test packages/jsx`: 2178 pass / 0 fail (new `index-access`, `toFixed`, block-memo-fold unit tests)
- `bun test packages/adapter-mojolicious packages/adapter-xslate`: 866 pass / 0 fail (real Mojolicious 9.46 / Text::Xslate 3.5.9)
- `bun test packages/adapter-go-template` (go1.25.6): 502 pass / 0 fail, incl. 5 new `to_fixed` helper-vector cases
- `prove -l` (adapter-perl): 264 PASS, incl. the new `to_fixed` value vectors

https://claude.ai/code/session_01SLhVU7vHcwmDiQNFu8LG1y

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLhVU7vHcwmDiQNFu8LG1y)_