### PR TITLE
feat(jsx): make `<Async>`/`<Region>` import-required built-ins (#1915)

### DIFF
--- a/.changeset/async-region-import-scoped.md
+++ b/.changeset/async-region-import-scoped.md
@@ -1,0 +1,13 @@
+---
+"@barefootjs/jsx": minor
+"@barefootjs/client": minor
+"@barefootjs/hono": patch
+---
+
+`<Async>` and `<Region>` are now **import-scoped, import-required** built-ins instead of bare capitalized tag-name matches (#1915, follow-up to #1914).
+
+The compiler recognises them only when their local binding is imported from `@barefootjs/client` (keyed off `ir.metadata.imports`), so a user's own `<Async>` / `<Region>` component — imported from elsewhere or declared locally — no longer collides with the built-in, and an aliased `import { Async as Boundary }` maps `<Boundary>` through. Real, type-checked `Async` / `Region` stubs now ship from `@barefootjs/client` (they throw if ever executed, since the compiler compiles the tags away), giving authors prop-checking and completion — the model `Portal` already follows, and how Solid imports `<Show>` / `<Suspense>` from `solid-js`. The import is elided on emit (both `templateImports` and the client-JS DOM imports) so it never survives as a phantom runtime import.
+
+A bare `<Async>` / `<Region>` used without the import and with no other in-scope binding now raises `BF054`. This replaces the per-file `declare function Async(...)` workaround and the `@barefootjs/hono` JSX runtime's `export declare function Async` (removed).
+
+**Migration:** add `import { Async, Region } from '@barefootjs/client'` to files that use these tags.

--- a/docs/core/advanced/error-codes.md
+++ b/docs/core/advanced/error-codes.md
@@ -227,6 +227,35 @@ function Child({ initialCount }: Props) {
 <Child count={count()} />
 ```
 
+### BF054 — Built-in `<Async>` / `<Region>` Used Without Import
+
+**Trigger:** A bare `<Async>` or `<Region>` tag is used without importing it
+from `@barefootjs/client`, and no other binding with that name is in scope.
+These compiler built-ins are recognised by their import (not by tag name), so
+an unimported tag is treated as an undeclared component.
+
+```tsx
+// ❌ BF054
+export function Page() {
+  return <Async fallback={<p>Loading…</p>}><Body /></Async>
+}
+```
+
+**Fix:** Import the built-in from `@barefootjs/client`.
+
+```tsx
+// ✅ Fixed
+import { Async } from '@barefootjs/client'
+
+export function Page() {
+  return <Async fallback={<p>Loading…</p>}><Body /></Async>
+}
+```
+
+> A component of your own named `Async` / `Region` does **not** trip BF054 as
+> long as it is imported or declared — the built-in only applies to the
+> `@barefootjs/client` import.
+
 ---
 
 ## Suppressing Warnings
@@ -259,3 +288,4 @@ function Component({ checked }: Props) {
 | BF023 | Error | Missing key in list |
 | BF043 | Warning | Props destructuring breaks reactivity |
 | BF044 | Error | Signal/memo getter passed without calling it |
+| BF054 | Error | Built-in `<Async>` / `<Region>` used without `@barefootjs/client` import |

--- a/packages/adapter-hono/src/__tests__/async-error-boundary.test.ts
+++ b/packages/adapter-hono/src/__tests__/async-error-boundary.test.ts
@@ -29,6 +29,7 @@ function templateOf(source: string): string {
 describe('compiled <Async> boundary — ErrorBoundary wrapping (#1375)', () => {
   test('emits ErrorBoundary enclosing Suspense, sharing the fallback', () => {
     const template = templateOf(`
+      import { Async } from '@barefootjs/client'
       export function Page() {
         return (
           <div>
@@ -52,6 +53,7 @@ describe('compiled <Async> boundary — ErrorBoundary wrapping (#1375)', () => {
 
   test('injects the aliased ErrorBoundary import alongside Suspense', () => {
     const template = templateOf(`
+      import { Async } from '@barefootjs/client'
       export function Page() {
         return (
           <Async fallback={<p>Loading...</p>}>
@@ -71,6 +73,7 @@ describe('compiled <Async> boundary — ErrorBoundary wrapping (#1375)', () => {
     // injected Hono import to duplicate the user's own `ErrorBoundary`
     // binding (which would be a "Duplicate identifier" build error).
     const template = templateOf(`
+      import { Async } from '@barefootjs/client'
       import { ErrorBoundary } from './my-error-boundary'
       export function Page() {
         return (
@@ -91,6 +94,7 @@ describe('compiled <Async> boundary — ErrorBoundary wrapping (#1375)', () => {
 
   test('each of multiple boundaries gets its own ErrorBoundary wrapper', () => {
     const template = templateOf(`
+      import { Async } from '@barefootjs/client'
       export function Dashboard() {
         return (
           <div>

--- a/packages/adapter-hono/src/jsx/jsx-runtime/index.ts
+++ b/packages/adapter-hono/src/jsx/jsx-runtime/index.ts
@@ -26,15 +26,8 @@ export declare namespace JSX {
   type ElementChildrenAttribute = BaseJSX.ElementChildrenAttribute
 }
 
-/**
- * BarefootJS compiler built-in: streaming async boundary.
- *
- * The compiler intercepts `<Async fallback={...}>` in JSX source and emits it
- * as a `<Suspense>` node in the Hono adapter output (IRAsync → renderAsync).
- * This declaration provides TypeScript types for source files; no runtime
- * implementation is needed because the compiler replaces it before execution.
- */
-export declare function Async(props: {
-  fallback: JSX.Element
-  children: JSX.Element | JSX.Element[] | null | undefined
-}): JSX.Element
+// Compiler built-ins `<Async>` / `<Region>` are import-scoped to
+// `@barefootjs/client` (`import { Async, Region } from '@barefootjs/client'`),
+// recognised by that import and compiled away (#1915). They are intentionally
+// not re-declared on this JSX runtime — a bare tag-name declaration here would
+// reintroduce the phantom-import / collision problems #1915 set out to remove.

--- a/packages/adapter-tests/fixtures/async-boundary.ts
+++ b/packages/adapter-tests/fixtures/async-boundary.ts
@@ -4,6 +4,7 @@ export const fixture = createFixture({
   id: 'async-boundary',
   description: 'Async streaming boundary with synchronous-resolved children',
   source: `
+import { Async } from '@barefootjs/client'
 export function ProductPage() {
   return (
     <div>

--- a/packages/adapter-tests/fixtures/region-boundary.ts
+++ b/packages/adapter-tests/fixtures/region-boundary.ts
@@ -14,6 +14,7 @@ export const fixture = createFixture({
   id: 'region-boundary',
   description: '<Region> lowers to a bf-region page-lifecycle boundary',
   source: `
+import { Region } from '@barefootjs/client'
 export function Layout() {
   return (
     <div>

--- a/packages/client/src/builtins.ts
+++ b/packages/client/src/builtins.ts
@@ -1,0 +1,63 @@
+/**
+ * Compiler built-in JSX tags: `<Async>` and `<Region>`.
+ *
+ * These are recognised by the BarefootJS compiler **structurally** — by
+ * their import from `@barefootjs/client` (`ir.metadata.imports`), never by
+ * a bare capitalized tag-name match — and are compiled away: `<Async>`
+ * lowers to a streaming boundary (e.g. Hono `<Suspense>`) and `<Region>`
+ * lowers to a `bf-region` page-lifecycle boundary (spec/router.md). No
+ * runtime value survives in the emitted output; the compiler also elides
+ * the import on emit so it never lingers as a phantom runtime import.
+ *
+ * The real exports here exist so authors can `import { Async, Region }`
+ * with full prop-checking and completion, the same way Solid imports
+ * `<Show>` / `<Suspense>` from `solid-js`. Importing them is what tells the
+ * compiler the tag is the built-in (and keeps a user's own `<Async>` /
+ * `<Region>` component from colliding with it).
+ *
+ * If one of these ever executes, the JSX was rendered outside the
+ * BarefootJS compiler pipeline — that's a bug. See
+ * piconic-ai/barefootjs#1915.
+ */
+
+function compiledAway(name: string): never {
+  throw new Error(
+    `[barefootjs] <${name}> is a compiler built-in and is compiled away. ` +
+      `If you are seeing this at runtime, the JSX was rendered without going ` +
+      `through the BarefootJS compiler — please report a bug.`,
+  )
+}
+
+export interface AsyncProps {
+  /** UI rendered while the streamed children resolve. */
+  fallback: unknown
+  /** Content streamed in once resolved. */
+  children?: unknown
+}
+
+export interface RegionProps {
+  /** The page-lifecycle subtree the router disposes / re-hydrates on navigation. */
+  children?: unknown
+}
+
+/**
+ * Streaming async boundary. Lowered by the compiler to the adapter's
+ * streaming primitive (Hono `<Suspense>`); `fallback` is shown until the
+ * children resolve. Compiled away — never executes at runtime.
+ */
+// Return type is `any` so the built-in satisfies every adapter's
+// `JSX.Element` regardless of the active `jsxImportSource`.
+export function Async(_props: AsyncProps): any {
+  return compiledAway('Async')
+}
+
+/**
+ * Page-lifecycle boundary (spec/router.md). Lowered by the compiler to a
+ * wrapper element carrying a deterministic `bf-region` marker the client
+ * router matches on. Compiled away — never executes at runtime.
+ */
+// Return type is `any` so the built-in satisfies every adapter's
+// `JSX.Element` regardless of the active `jsxImportSource`.
+export function Region(_props: RegionProps): any {
+  return compiledAway('Region')
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -53,3 +53,13 @@ export {
   type PortalOptions,
   type Renderable,
 } from './shims.ts'
+
+// Compiler built-ins (`<Async>` / `<Region>`) — recognised by their import
+// here and compiled away. Importing them is what scopes the recognition; the
+// compiler elides the import on emit. See ./builtins.ts and #1915.
+export {
+  Async,
+  Region,
+  type AsyncProps,
+  type RegionProps,
+} from './builtins.ts'

--- a/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
+++ b/packages/jsx/src/__tests__/compiler-stress-1244.test.ts
@@ -1028,7 +1028,7 @@ describe('<Async> inside .map() — per-item streaming boundary', () => {
   test('async boundary used inside a loop body', () => {
     const src = `
       'use client'
-      import { createSignal } from '@barefootjs/client'
+      import { createSignal, Async } from '@barefootjs/client'
       function Card({ id }: { id: string }) { return <span>{id}</span> }
       export function Demo() {
         const [items, setItems] = createSignal<{ id: string }[]>([])
@@ -1053,7 +1053,7 @@ describe('.map() inside <Async> — loop body wired after async chunk lands', ()
   test('map call inside an async boundary body', () => {
     const src = `
       'use client'
-      import { createSignal } from '@barefootjs/client'
+      import { createSignal, Async } from '@barefootjs/client'
       export function Demo() {
         const [items, setItems] = createSignal<{ id: string; label: string }[]>([])
         return (
@@ -1087,6 +1087,7 @@ describe('<Async> body error path — sync throw + async reject (#1375)', () => 
 
   test('synchronously-throwing body component compiles to a clean boundary', () => {
     const src = `
+      import { Async } from '@barefootjs/client'
       export function Demo() {
         return (
           <Async fallback={<p>Fallback</p>}>
@@ -1100,6 +1101,7 @@ describe('<Async> body error path — sync throw + async reject (#1375)', () => 
 
   test('async (Promise-returning) body component compiles to a clean boundary', () => {
     const src = `
+      import { Async } from '@barefootjs/client'
       export function Demo() {
         return (
           <Async fallback={<Skeleton />}>

--- a/packages/jsx/src/__tests__/ir-async.test.ts
+++ b/packages/jsx/src/__tests__/ir-async.test.ts
@@ -11,6 +11,7 @@ const adapter = new TestAdapter()
 describe('<Async> streaming boundary', () => {
   test('transforms <Async> with fallback and children into IRAsync', () => {
     const source = `
+      import { Async } from '@barefootjs/client'
       export function ProductPage() {
         return (
           <div>
@@ -48,6 +49,7 @@ describe('<Async> streaming boundary', () => {
 
   test('assigns sequential IDs to multiple async boundaries', () => {
     const source = `
+      import { Async } from '@barefootjs/client'
       export function Dashboard() {
         return (
           <div>
@@ -76,6 +78,7 @@ describe('<Async> streaming boundary', () => {
 
   test('fallback can be a self-closing element', () => {
     const source = `
+      import { Async } from '@barefootjs/client'
       export function Page() {
         return (
           <Async fallback={<Skeleton />}>
@@ -98,6 +101,7 @@ describe('<Async> streaming boundary', () => {
 
   test('reports BF046 when fallback prop is missing and emits a fragment stub', () => {
     const source = `
+      import { Async } from '@barefootjs/client'
       export function Page() {
         return (
           <Async>
@@ -123,6 +127,7 @@ describe('<Async> streaming boundary', () => {
 
   test('reports BF046 when self-closing <Async /> is missing fallback', () => {
     const source = `
+      import { Async } from '@barefootjs/client'
       export function Page() {
         return <Async />
       }
@@ -162,6 +167,7 @@ describe('<Async> streaming boundary', () => {
 
   test('body component that throws at render keeps fallback + child wired on the boundary', () => {
     const source = `
+      import { Async } from '@barefootjs/client'
       export function Page() {
         return (
           <Async fallback={<p>Fallback</p>}>
@@ -190,6 +196,7 @@ describe('<Async> streaming boundary', () => {
 
   test('async (Promise-returning) body component keeps the boundary intact', () => {
     const source = `
+      import { Async } from '@barefootjs/client'
       export function Page() {
         return (
           <Async fallback={<Skeleton />}>
@@ -218,6 +225,7 @@ describe('<Async> streaming boundary', () => {
     // and the BF046 diagnostic must reach result.errors so consumers can
     // fail the build.
     const source = `
+      import { Async } from '@barefootjs/client'
       export function Page() {
         return (
           <Async>

--- a/packages/jsx/src/__tests__/ir-builtin-import-scope.test.ts
+++ b/packages/jsx/src/__tests__/ir-builtin-import-scope.test.ts
@@ -104,6 +104,28 @@ describe('import-scoped recognition for <Async> / <Region>', () => {
     expect(ctx.errors.find(e => e.code === ErrorCodes.BUILTIN_REQUIRES_IMPORT)).toBeDefined()
   })
 
+  test('a per-specifier type-only import (`import { type Async }`) does NOT scope the built-in', () => {
+    const { ir: root, ctx } = ir(`
+      import { type Async } from '@barefootjs/client'
+      export function Page() {
+        return <Async fallback={<p>Loading</p>}><Body /></Async>
+      }
+    `)
+    expect((root as IRElement).type).not.toBe('async')
+    expect(ctx.errors.find(e => e.code === ErrorCodes.BUILTIN_REQUIRES_IMPORT)).toBeDefined()
+  })
+
+  test('a value specifier alongside a type-only one is still recognised (`import { type Async, Region }`)', () => {
+    const { ir: root } = ir(`
+      import { type Async, Region } from '@barefootjs/client'
+      export function Shell({ children }) {
+        return <div><Region>{children}</Region></div>
+      }
+    `)
+    const div = root as IRElement
+    expect(div.children.some(c => c.type === 'element' && c.regionId !== undefined)).toBe(true)
+  })
+
   test('bare <Region /> with no import reports BF054', () => {
     const { ctx } = ir(`
       export function Shell() {
@@ -146,5 +168,21 @@ describe('stripClientBuiltinImports (emit-time elision)', () => {
   test('preserves a side-effect import of @barefootjs/client', () => {
     const sideEffect = imp('@barefootjs/client', [])
     expect(stripClientBuiltinImports([sideEffect])).toEqual([sideEffect])
+  })
+
+  test('does NOT strip a per-specifier type-only built-in, but strips the value one', () => {
+    const mixed: ImportInfo = {
+      source: '@barefootjs/client',
+      isTypeOnly: false,
+      loc,
+      specifiers: [
+        { name: 'Async', alias: null, isDefault: false, isNamespace: false, isTypeOnly: true },
+        { name: 'Region', alias: null, isDefault: false, isNamespace: false, isTypeOnly: false },
+      ],
+    }
+    const out = stripClientBuiltinImports([mixed])
+    expect(out).toHaveLength(1)
+    expect(out[0].specifiers.map(s => s.name)).toEqual(['Async'])
+    expect(out[0].specifiers[0].isTypeOnly).toBe(true)
   })
 })

--- a/packages/jsx/src/__tests__/ir-builtin-import-scope.test.ts
+++ b/packages/jsx/src/__tests__/ir-builtin-import-scope.test.ts
@@ -1,0 +1,127 @@
+import { describe, test, expect } from 'bun:test'
+import { analyzeComponent } from '../analyzer'
+import { jsxToIR } from '../jsx-to-ir'
+import { ErrorCodes } from '../errors'
+import { stripClientBuiltinImports } from '../builtins'
+import type { IRAsync, IRElement, IRComponent, ImportInfo } from '../types'
+
+// Import-scoped recognition for the compile-away built-ins `<Async>` /
+// `<Region>` (#1915). The compiler recognises them by their
+// `@barefootjs/client` import — never by a bare capitalized tag name — so a
+// user's own component does not collide with the built-in, and the import is
+// elided on emit.
+
+function ir(source: string, path = 'Comp.tsx') {
+  const ctx = analyzeComponent(source, path)
+  return { ir: jsxToIR(ctx), ctx }
+}
+
+describe('import-scoped recognition for <Async> / <Region>', () => {
+  test('<Async> imported from @barefootjs/client lowers to IRAsync', () => {
+    const { ir: root, ctx } = ir(`
+      import { Async } from '@barefootjs/client'
+      export function Page() {
+        return <div><Async fallback={<p>Loading</p>}><Body /></Async></div>
+      }
+    `)
+    expect(ctx.errors.filter(e => e.severity === 'error')).toEqual([])
+    const div = root as IRElement
+    const async = div.children.find(c => c.type === 'async') as IRAsync
+    expect(async?.type).toBe('async')
+  })
+
+  test('<Region> imported from @barefootjs/client lowers to a region element', () => {
+    const { ir: root } = ir(`
+      import { Region } from '@barefootjs/client'
+      export function Shell({ children }) {
+        return <div><Region>{children}</Region></div>
+      }
+    `)
+    const div = root as IRElement
+    const region = div.children.find(
+      (c): c is IRElement => c.type === 'element' && c.regionId !== undefined,
+    )
+    expect(region).toBeDefined()
+  })
+
+  test('aliased import `Async as Boundary` recognises <Boundary> as the built-in', () => {
+    const { ir: root } = ir(`
+      import { Async as Boundary } from '@barefootjs/client'
+      export function Page() {
+        return <Boundary fallback={<p>Loading</p>}><Body /></Boundary>
+      }
+    `)
+    expect((root as IRAsync).type).toBe('async')
+  })
+
+  test("a user's own <Async> (imported elsewhere) is NOT lowered and emits no diagnostic", () => {
+    const { ir: root, ctx } = ir(`
+      import { Async } from './my-async'
+      export function Page() {
+        return <div><Async fallback={<p>x</p>}><Body /></Async></div>
+      }
+    `)
+    expect(ctx.errors.find(e => e.code === ErrorCodes.BUILTIN_REQUIRES_IMPORT)).toBeUndefined()
+    const div = root as IRElement
+    expect(div.children.some(c => c.type === 'async')).toBe(false)
+    const comp = div.children.find((c): c is IRComponent => c.type === 'component')
+    expect(comp?.name).toBe('Async')
+  })
+
+  test('a locally declared Async component is NOT treated as the built-in', () => {
+    const { ir: root, ctx } = ir(`
+      function Async(props) { return <section>{props.children}</section> }
+      export function Page() {
+        return <Async fallback={<p>x</p>}><Body /></Async>
+      }
+    `)
+    expect(ctx.errors.find(e => e.code === ErrorCodes.BUILTIN_REQUIRES_IMPORT)).toBeUndefined()
+    expect((root as IRElement).type).not.toBe('async')
+  })
+
+  test('bare <Async> with no import and no binding reports BF054', () => {
+    const { ctx } = ir(`
+      export function Page() {
+        return <Async fallback={<p>Loading</p>}><Body /></Async>
+      }
+    `)
+    const err = ctx.errors.find(e => e.code === ErrorCodes.BUILTIN_REQUIRES_IMPORT)
+    expect(err).toBeDefined()
+    expect(err?.severity).toBe('error')
+    expect(err?.message).toContain('@barefootjs/client')
+  })
+
+  test('bare <Region /> with no import reports BF054', () => {
+    const { ctx } = ir(`
+      export function Shell() {
+        return <Region />
+      }
+    `)
+    expect(ctx.errors.find(e => e.code === ErrorCodes.BUILTIN_REQUIRES_IMPORT)).toBeDefined()
+  })
+})
+
+describe('stripClientBuiltinImports (emit-time elision)', () => {
+  const loc = { file: 'x.tsx', line: 1, column: 1 }
+  const imp = (source: string, names: string[]): ImportInfo => ({
+    source,
+    isTypeOnly: false,
+    loc,
+    specifiers: names.map(n => ({ name: n, alias: null, isDefault: false, isNamespace: false })),
+  })
+
+  test('drops the @barefootjs/client import when it only carried built-ins', () => {
+    expect(stripClientBuiltinImports([imp('@barefootjs/client', ['Async', 'Region'])])).toEqual([])
+  })
+
+  test('keeps non-built-in specifiers and drops the built-ins', () => {
+    const out = stripClientBuiltinImports([imp('@barefootjs/client', ['createSignal', 'Async'])])
+    expect(out).toHaveLength(1)
+    expect(out[0].specifiers.map(s => s.name)).toEqual(['createSignal'])
+  })
+
+  test('leaves imports from other sources untouched', () => {
+    const other = imp('./my-async', ['Async'])
+    expect(stripClientBuiltinImports([other])).toEqual([other])
+  })
+})

--- a/packages/jsx/src/__tests__/ir-builtin-import-scope.test.ts
+++ b/packages/jsx/src/__tests__/ir-builtin-import-scope.test.ts
@@ -91,6 +91,19 @@ describe('import-scoped recognition for <Async> / <Region>', () => {
     expect(err?.message).toContain('@barefootjs/client')
   })
 
+  test('a type-only import does NOT scope the built-in and does not suppress BF054', () => {
+    // `import type { Async }` brings no value binding into scope — the design
+    // is import-value-required, so <Async> must still raise BF054.
+    const { ir: root, ctx } = ir(`
+      import type { Async } from '@barefootjs/client'
+      export function Page() {
+        return <Async fallback={<p>Loading</p>}><Body /></Async>
+      }
+    `)
+    expect((root as IRElement).type).not.toBe('async')
+    expect(ctx.errors.find(e => e.code === ErrorCodes.BUILTIN_REQUIRES_IMPORT)).toBeDefined()
+  })
+
   test('bare <Region /> with no import reports BF054', () => {
     const { ctx } = ir(`
       export function Shell() {
@@ -123,5 +136,15 @@ describe('stripClientBuiltinImports (emit-time elision)', () => {
   test('leaves imports from other sources untouched', () => {
     const other = imp('./my-async', ['Async'])
     expect(stripClientBuiltinImports([other])).toEqual([other])
+  })
+
+  test('does NOT strip type-only imports (never a runtime phantom)', () => {
+    const typeOnly: ImportInfo = { ...imp('@barefootjs/client', ['Async', 'Region']), isTypeOnly: true }
+    expect(stripClientBuiltinImports([typeOnly])).toEqual([typeOnly])
+  })
+
+  test('preserves a side-effect import of @barefootjs/client', () => {
+    const sideEffect = imp('@barefootjs/client', [])
+    expect(stripClientBuiltinImports([sideEffect])).toEqual([sideEffect])
   })
 })

--- a/packages/jsx/src/__tests__/ir-region.test.ts
+++ b/packages/jsx/src/__tests__/ir-region.test.ts
@@ -6,6 +6,7 @@ import { HonoAdapter } from '../../../../packages/adapter-hono/src/adapter/hono-
 import type { IRElement } from '../types'
 
 const LAYOUT = `
+  import { Region } from '@barefootjs/client'
   export function Layout({ title, children }) {
     return (
       <div>
@@ -45,6 +46,7 @@ describe('<Region> page-lifecycle boundary', () => {
 
   test('assigns sequential structural indices within a file', () => {
     const source = `
+      import { Region } from '@barefootjs/client'
       export function Split() {
         return (
           <div>

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -1751,6 +1751,8 @@ function collectImport(node: ts.ImportDeclaration, ctx: AnalyzerContext): void {
             alias: element.propertyName ? element.name.text : null,
             isDefault: false,
             isNamespace: false,
+            // Per-specifier `import { type Foo }` — no value binding (#1915).
+            isTypeOnly: element.isTypeOnly,
           })
         }
       }

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -1648,6 +1648,9 @@ const CLIENT_EXPORTS = new Set([
   'forwardProps', 'unwrap', '__slot',
   'createContext', 'useContext', 'provideContext',
   'createPortal', 'isSSRPortal', 'findSiblingSlot', 'cleanupPortalPlaceholder',
+  // Compile-away JSX built-ins (#1915) — importing them is what scopes the
+  // compiler's `<Async>` / `<Region>` recognition; the import is elided on emit.
+  'Async', 'Region',
 ])
 
 /**

--- a/packages/jsx/src/builtins.ts
+++ b/packages/jsx/src/builtins.ts
@@ -50,7 +50,9 @@ export function stripClientBuiltinImports(imports: ImportInfo[]): ImportInfo[] {
       continue
     }
     const kept = imp.specifiers.filter(
-      spec => spec.isDefault || spec.isNamespace || !isClientBuiltinName(spec.name),
+      // Keep per-specifier type-only built-ins (`import { type Async }`) — they
+      // are erased by TS and never a runtime phantom.
+      spec => spec.isDefault || spec.isNamespace || spec.isTypeOnly || !isClientBuiltinName(spec.name),
     )
     // Drop the import entirely when every specifier was a built-in; otherwise
     // re-emit without them.

--- a/packages/jsx/src/builtins.ts
+++ b/packages/jsx/src/builtins.ts
@@ -1,0 +1,56 @@
+/**
+ * Compiler built-in JSX tags that are import-scoped to `@barefootjs/client`
+ * and compiled away (no runtime value survives in emitted output).
+ *
+ * `<Async>` and `<Region>` are recognised **structurally** — by their
+ * `@barefootjs/client` import in `ir.metadata.imports`, never by a bare
+ * capitalized tag-name match — so a user's own `<Async>` / `<Region>`
+ * component (imported from elsewhere or declared locally) does not collide
+ * with the built-in. The import is elided on emit (both `templateImports`
+ * and the client-JS DOM imports) so it never lingers as a phantom runtime
+ * import.
+ *
+ * Runtime stubs + types ship from `@barefootjs/client` (see
+ * `packages/client/src/builtins.ts`). See piconic-ai/barefootjs#1915.
+ */
+
+import type { ImportInfo } from './types.ts'
+
+/** Package that the built-in tags must be imported from to be recognised. */
+export const CLIENT_BUILTIN_SOURCE = '@barefootjs/client'
+
+export type ClientBuiltinTag = 'Async' | 'Region'
+
+/** The recognised built-in tag (export) names. */
+export const CLIENT_BUILTIN_TAGS: readonly ClientBuiltinTag[] = ['Async', 'Region']
+
+/** True when `name` is one of the compile-away built-in export names. */
+export function isClientBuiltinName(name: string): name is ClientBuiltinTag {
+  return name === 'Async' || name === 'Region'
+}
+
+/**
+ * Elide the compile-away built-ins from an import list for emission (#1915).
+ * `<Async>` / `<Region>` are lowered into the template, so their
+ * `@barefootjs/client` import must not survive as a phantom runtime import in
+ * either the SSR template or the client JS bundle. Drops the `Async` / `Region`
+ * specifiers from `@barefootjs/client` imports, and drops the whole import
+ * statement when it has no remaining specifiers.
+ */
+export function stripClientBuiltinImports(imports: ImportInfo[]): ImportInfo[] {
+  const result: ImportInfo[] = []
+  for (const imp of imports) {
+    if (imp.source !== CLIENT_BUILTIN_SOURCE) {
+      result.push(imp)
+      continue
+    }
+    const kept = imp.specifiers.filter(
+      spec => spec.isDefault || spec.isNamespace || !isClientBuiltinName(spec.name),
+    )
+    // A side-effect import (no specifiers) or one whose only specifiers were
+    // the built-ins is dropped entirely; otherwise re-emit without them.
+    if (kept.length === 0 && imp.specifiers.length > 0) continue
+    result.push(kept.length === imp.specifiers.length ? imp : { ...imp, specifiers: kept })
+  }
+  return result
+}

--- a/packages/jsx/src/builtins.ts
+++ b/packages/jsx/src/builtins.ts
@@ -40,16 +40,21 @@ export function isClientBuiltinName(name: string): name is ClientBuiltinTag {
 export function stripClientBuiltinImports(imports: ImportInfo[]): ImportInfo[] {
   const result: ImportInfo[] = []
   for (const imp of imports) {
-    if (imp.source !== CLIENT_BUILTIN_SOURCE) {
+    // Only a *value* named import of the built-ins can become a phantom runtime
+    // import. Leave everything else untouched: imports from other sources;
+    // `import type { Async }` (erased by TS — never a runtime import, and may be
+    // needed to type-check emitted templates); and side-effect imports (no
+    // specifiers, deliberate). See #1915 review.
+    if (imp.source !== CLIENT_BUILTIN_SOURCE || imp.isTypeOnly || imp.specifiers.length === 0) {
       result.push(imp)
       continue
     }
     const kept = imp.specifiers.filter(
       spec => spec.isDefault || spec.isNamespace || !isClientBuiltinName(spec.name),
     )
-    // A side-effect import (no specifiers) or one whose only specifiers were
-    // the built-ins is dropped entirely; otherwise re-emit without them.
-    if (kept.length === 0 && imp.specifiers.length > 0) continue
+    // Drop the import entirely when every specifier was a built-in; otherwise
+    // re-emit without them.
+    if (kept.length === 0) continue
     result.push(kept.length === imp.specifiers.length ? imp : { ...imp, specifiers: kept })
   }
   return result

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -14,6 +14,7 @@ import type {
 import type { TemplateAdapter } from './adapters/interface.ts'
 import { analyzeComponent, listComponentFunctions, createProgramForFile, needsTypeBasedDetection } from './analyzer.ts'
 import { jsxToIR } from './jsx-to-ir.ts'
+import { stripClientBuiltinImports } from './builtins.ts'
 import { generateClientJs, generateClientJsWithSourceMap, analyzeClientNeeds } from './ir-to-client-js/index.ts'
 import { emitModuleLevelDeclarations } from './ir-to-client-js/emit-module-level.ts'
 import { RUNTIME_MODULE, detectUsedImports as detectUsedImportsFromCode } from './ir-to-client-js/imports.ts'
@@ -502,8 +503,11 @@ export function buildMetadata(
     // re-emission. Adapters that re-emit imports (Hono, test) call
     // `rewriteImportsForTemplate` themselves to apply client-shim rewrite or
     // strip behaviour; adapters whose templates never carry imports (Go,
-    // Mojo) only consult this list for diagnostics like BF103.
-    templateImports: ctx.imports,
+    // Mojo) only consult this list for diagnostics like BF103. The
+    // compile-away built-ins (`<Async>` / `<Region>`) are stripped here so
+    // their `@barefootjs/client` import never reaches any adapter's template
+    // as a phantom (#1915).
+    templateImports: stripClientBuiltinImports(ctx.imports),
     namedExports: ctx.namedExports,
     localFunctions: ctx.localFunctions,
     localConstants: ctx.localConstants,

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -47,6 +47,11 @@ export const ErrorCodes = {
   // Import errors (BF050-BF059)
   SHARED_PROGRAM_REQUIRED: 'BF050',
   WRONG_PACKAGE_IMPORT: 'BF051',
+  // A bare `<Async>` / `<Region>` tag was used without importing it from
+  // `@barefootjs/client`. The built-ins are recognised import-scoped (#1915),
+  // so an unimported tag with the built-in name is either a forgotten import
+  // or an undeclared component — fail loud with the import to add.
+  BUILTIN_REQUIRES_IMPORT: 'BF054',
 
   // Init statement errors (BF052)
   UNDECLARED_INIT_STATEMENT_REFERENCE: 'BF052',
@@ -134,6 +139,11 @@ const errorMessages: Record<ErrorCode, string> = {
 
   [ErrorCodes.WRONG_PACKAGE_IMPORT]:
     'Import from wrong package.',
+
+  [ErrorCodes.BUILTIN_REQUIRES_IMPORT]:
+    "Built-in <Async> / <Region> must be imported from '@barefootjs/client'. " +
+    'The compiler recognises these tags by their import (not by tag name), ' +
+    'so an unimported tag with this name is treated as an undeclared component.',
 
   [ErrorCodes.UNDECLARED_INIT_STATEMENT_REFERENCE]:
     'Init statement references an undeclared identifier. Declare it at module scope, inside the component, or import it — otherwise ESM strict mode throws ReferenceError at runtime.',

--- a/packages/jsx/src/ir-to-client-js/imports.ts
+++ b/packages/jsx/src/ir-to-client-js/imports.ts
@@ -3,6 +3,7 @@
  */
 
 import type { ComponentIR, IRNode } from '../types.ts'
+import { isClientBuiltinName } from '../builtins.ts'
 
 // All exports from @barefootjs/client/runtime that may be used in generated code
 export const RUNTIME_IMPORT_CANDIDATES = [
@@ -62,6 +63,10 @@ export function collectUserDomImports(ir: ComponentIR): string[] {
     if (runtimeSources.has(imp.source) && !imp.isTypeOnly) {
       for (const spec of imp.specifiers) {
         if (!spec.isDefault && !spec.isNamespace) {
+          // Compile-away built-ins (`<Async>` / `<Region>`) are lowered into
+          // the template — never emit their import into the client bundle,
+          // where it would be a phantom runtime import (#1915).
+          if (isClientBuiltinName(spec.name)) continue
           userImports.push(spec.alias ? `${spec.name} as ${spec.alias}` : spec.name)
         }
       }

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -35,6 +35,7 @@ import {
 import { type AnalyzerContext, type MultiReturnJsxInfo, getSourceLocation } from './analyzer-context.ts'
 import { parseExpression, isSupported, parseBlockBody, extractSortComparatorFromTS, cssKebabCase, type ParsedExpr, type ParsedStatement, type SortComparator } from './expression-parser.ts'
 import { createError, ErrorCodes, internalInvariant } from './errors.ts'
+import { CLIENT_BUILTIN_SOURCE, isClientBuiltinName, type ClientBuiltinTag } from './builtins.ts'
 import { containsReactiveExpression } from './reactivity-checker.ts'
 import {
   rewriteBarePropRefs as rewriteBarePropRefsCore,
@@ -140,6 +141,14 @@ interface TransformContext {
    * See #1425.
    */
   _branchScopePropDeps?: Map<string, Set<string>>
+  /**
+   * Lazily computed map of local JSX tag name → compile-away built-in
+   * (`Async` / `Region`), derived from `@barefootjs/client` imports (#1915).
+   * Recognition is import-scoped (not a bare tag-name match) so a user's own
+   * `<Async>` / `<Region>` component doesn't collide with the built-in, and an
+   * aliased `import { Async as Boundary }` maps `<Boundary>` to the built-in.
+   */
+  _clientBuiltinTags?: Map<string, ClientBuiltinTag>
 }
 
 /**
@@ -709,6 +718,91 @@ function transformNode(node: ts.Node, ctx: TransformContext): IRNode | null {
 // JSX Element Transformation
 // =============================================================================
 
+/**
+ * Map a local JSX tag name to its compile-away built-in (`Async` / `Region`)
+ * if it was imported from `@barefootjs/client` (#1915). Recognition is
+ * import-scoped — keyed off `imports` metadata, never a bare tag-name match —
+ * so a user's own `<Async>` / `<Region>` component does not collide with the
+ * built-in, and `import { Async as Boundary }` maps `<Boundary>` to it.
+ * Memoized on `ctx`; the import list is fixed for the compile.
+ */
+function clientBuiltinTags(ctx: TransformContext): Map<string, ClientBuiltinTag> {
+  if (ctx._clientBuiltinTags) return ctx._clientBuiltinTags
+  const map = new Map<string, ClientBuiltinTag>()
+  for (const imp of ctx.analyzer.imports) {
+    if (imp.source !== CLIENT_BUILTIN_SOURCE) continue
+    for (const spec of imp.specifiers) {
+      if (spec.isDefault || spec.isNamespace) continue
+      if (isClientBuiltinName(spec.name)) {
+        map.set(spec.alias ?? spec.name, spec.name)
+      }
+    }
+  }
+  ctx._clientBuiltinTags = map
+  return map
+}
+
+/**
+ * Whether `name` resolves to any in-scope value binding — an import (by its
+ * local name), a local function / constant, or an ambient `declare`. Used to
+ * keep the BF054 "import the built-in" diagnostic from firing when the author
+ * legitimately has their own `<Async>` / `<Region>` binding.
+ */
+function isNameBound(ctx: TransformContext, name: string): boolean {
+  const a = ctx.analyzer
+  if (a.ambientGlobals.has(name)) return true
+  if (a.localFunctions.some(f => f.name === name)) return true
+  if (a.localConstants.some(c => c.name === name)) return true
+  for (const imp of a.imports) {
+    for (const spec of imp.specifiers) {
+      if ((spec.alias ?? spec.name) === name) return true
+    }
+  }
+  return false
+}
+
+function reportBuiltinNotImported(
+  ctx: TransformContext,
+  node: ts.Node,
+  tagName: ClientBuiltinTag,
+): void {
+  ctx.analyzer.errors.push(
+    createError(
+      ErrorCodes.BUILTIN_REQUIRES_IMPORT,
+      getSourceLocation(node, ctx.sourceFile, ctx.filePath),
+      {
+        severity: 'error',
+        message: `<${tagName}> must be imported from '${CLIENT_BUILTIN_SOURCE}' to be recognised as a compiler built-in.`,
+        suggestion: {
+          message: `Add: import { ${tagName} } from '${CLIENT_BUILTIN_SOURCE}'`,
+        },
+      },
+    ),
+  )
+}
+
+/**
+ * Dispatch a built-in JSX tag (`Async` / `Region`) when import-scoped
+ * recognition matches, or emit BF054 when the bare built-in name is used
+ * without the import and without any other in-scope binding. Returns the
+ * lowered IR node, or `null` to fall through to normal component handling.
+ */
+function dispatchClientBuiltin(
+  tagName: string,
+  ctx: TransformContext,
+  diagNode: ts.Node,
+  transformAsync: () => IRNode,
+  transformRegion: () => IRNode,
+): IRNode | null {
+  const builtin = clientBuiltinTags(ctx).get(tagName)
+  if (builtin === 'Async') return transformAsync()
+  if (builtin === 'Region') return transformRegion()
+  if (isClientBuiltinName(tagName) && !isNameBound(ctx, tagName)) {
+    reportBuiltinNotImported(ctx, diagNode, tagName)
+  }
+  return null
+}
+
 function transformJsxElement(
   node: ts.JsxElement,
   ctx: TransformContext
@@ -720,15 +814,16 @@ function transformJsxElement(
     return transformProviderElement(node, ctx, tagName)
   }
 
-  // Detect Async streaming boundary: <Async fallback={...}>
-  if (tagName === 'Async') {
-    return transformAsyncElement(node, ctx)
-  }
-
-  // Detect Region page-lifecycle boundary: <Region>{children}</Region>
-  if (tagName === 'Region') {
-    return transformRegionElement(node, ctx)
-  }
+  // Detect compile-away built-ins (`<Async>` / `<Region>`), recognised by
+  // their `@barefootjs/client` import rather than by tag name (#1915).
+  const builtin = dispatchClientBuiltin(
+    tagName,
+    ctx,
+    node.openingElement,
+    () => transformAsyncElement(node, ctx),
+    () => transformRegionElement(node, ctx),
+  )
+  if (builtin) return builtin
 
   const isComponent = /^[A-Z]/.test(tagName)
 
@@ -791,15 +886,16 @@ function transformSelfClosingElement(
     return transformSelfClosingProviderElement(node, ctx, tagName)
   }
 
-  // Detect Async streaming boundary: <Async ... />
-  if (tagName === 'Async') {
-    return transformSelfClosingAsyncElement(node, ctx)
-  }
-
-  // Detect Region page-lifecycle boundary: <Region />
-  if (tagName === 'Region') {
-    return transformSelfClosingRegionElement(node, ctx)
-  }
+  // Detect compile-away built-ins (`<Async />` / `<Region />`), recognised by
+  // their `@barefootjs/client` import rather than by tag name (#1915).
+  const builtin = dispatchClientBuiltin(
+    tagName,
+    ctx,
+    node,
+    () => transformSelfClosingAsyncElement(node, ctx),
+    () => transformSelfClosingRegionElement(node, ctx),
+  )
+  if (builtin) return builtin
 
   const isComponent = /^[A-Z]/.test(tagName)
 
@@ -1026,8 +1122,8 @@ function transformSelfClosingAsyncElement(
  * `bf-region` marker (spec/router.md "Regions"). The id is deterministic —
  * `<file scope>:<index>` — so a layout that compiles to one shared partial
  * emits the *same* id across every page that composes it, which is what the
- * client router matches on. `<Region>` is recognised by its capitalized tag
- * name here; import-scoped disambiguation is a follow-up.
+ * client router matches on. `<Region>` is recognised by its `@barefootjs/client`
+ * import (import-scoped, not a bare tag-name match — #1915).
  */
 function regionId(ctx: TransformContext): string {
   return `${computeFileScope(ctx.filePath)}:${ctx.regionIdCounter++}`

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -736,7 +736,8 @@ function clientBuiltinTags(ctx: TransformContext): Map<string, ClientBuiltinTag>
     // built-in — `<Async>` then falls through to BF054 (#1915 review).
     if (imp.source !== CLIENT_BUILTIN_SOURCE || imp.isTypeOnly) continue
     for (const spec of imp.specifiers) {
-      if (spec.isDefault || spec.isNamespace) continue
+      // Skip per-specifier `import { type Async }` — no value binding.
+      if (spec.isDefault || spec.isNamespace || spec.isTypeOnly) continue
       if (isClientBuiltinName(spec.name)) {
         map.set(spec.alias ?? spec.name, spec.name)
       }
@@ -759,9 +760,11 @@ function isNameBound(ctx: TransformContext, name: string): boolean {
   if (a.localConstants.some(c => c.name === name)) return true
   for (const imp of a.imports) {
     // Type-only imports create a type binding, not a value one — they can't
-    // back a JSX value tag, so they must not suppress BF054 (#1915 review).
+    // back a JSX value tag, so they must not suppress BF054. Applies to both
+    // `import type { ... }` and per-specifier `import { type X }` (#1915 review).
     if (imp.isTypeOnly) continue
     for (const spec of imp.specifiers) {
+      if (spec.isTypeOnly) continue
       if ((spec.alias ?? spec.name) === name) return true
     }
   }

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -730,7 +730,11 @@ function clientBuiltinTags(ctx: TransformContext): Map<string, ClientBuiltinTag>
   if (ctx._clientBuiltinTags) return ctx._clientBuiltinTags
   const map = new Map<string, ClientBuiltinTag>()
   for (const imp of ctx.analyzer.imports) {
-    if (imp.source !== CLIENT_BUILTIN_SOURCE) continue
+    // Require a *value* import: the tag is used as a JSX value, and the design
+    // is import-value-required. `import type { Async }` brings no value binding
+    // into scope (and is never a runtime import), so it does not scope the
+    // built-in — `<Async>` then falls through to BF054 (#1915 review).
+    if (imp.source !== CLIENT_BUILTIN_SOURCE || imp.isTypeOnly) continue
     for (const spec of imp.specifiers) {
       if (spec.isDefault || spec.isNamespace) continue
       if (isClientBuiltinName(spec.name)) {
@@ -754,6 +758,9 @@ function isNameBound(ctx: TransformContext, name: string): boolean {
   if (a.localFunctions.some(f => f.name === name)) return true
   if (a.localConstants.some(c => c.name === name)) return true
   for (const imp of a.imports) {
+    // Type-only imports create a type binding, not a value one — they can't
+    // back a JSX value tag, so they must not suppress BF054 (#1915 review).
+    if (imp.isTypeOnly) continue
     for (const spec of imp.specifiers) {
       if ((spec.alias ?? spec.name) === name) return true
     }

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -1213,6 +1213,15 @@ export interface ImportSpecifier {
   alias: string | null
   isDefault: boolean
   isNamespace: boolean
+  /**
+   * Per-specifier type-only import (`import { type Foo } from '...'`). Distinct
+   * from `ImportInfo.isTypeOnly` (the whole `import type { ... }` statement).
+   * A type-only specifier introduces no runtime/value binding, so consumers
+   * enforcing a value import (e.g. the `<Async>`/`<Region>` built-ins, #1915)
+   * must ignore it. Absent/false for value specifiers and for default /
+   * namespace imports (which cannot be per-specifier type-only).
+   */
+  isTypeOnly?: boolean
 }
 
 export interface FunctionInfo {

--- a/site/ui/components/infinite-scroll-demo.tsx
+++ b/site/ui/components/infinite-scroll-demo.tsx
@@ -14,15 +14,10 @@
  * - Per-item immutable updates inside a reactive loop
  */
 
-import { createSignal, createMemo, onMount, onCleanup } from '@barefootjs/client'
+import { createSignal, createMemo, onMount, onCleanup, Async } from '@barefootjs/client'
 import { Avatar, AvatarFallback } from '@ui/components/ui/avatar'
 import { Button } from '@ui/components/ui/button'
 import { Separator } from '@ui/components/ui/separator'
-
-// Compiler built-in: the BarefootJS compiler intercepts <Async> and emits it
-// as <Suspense> in the Hono adapter output. declare keeps TypeScript happy;
-// no runtime function is needed because it is compiled away.
-declare function Async(props: { fallback: unknown; children: unknown }): unknown
 
 // --- Types ---
 

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -261,6 +261,35 @@ Helpers exported from `@barefootjs/jsx`:
 | `error` | Compilation error is expected |
 | `n/a` | Not applicable (Out of Scope items) |
 
+### Import-scoped built-ins (`<Async>` / `<Region>`)
+
+`<Async>` (streaming boundary → `IRAsync`, e.g. Hono `<Suspense>`) and
+`<Region>` (page-lifecycle boundary → `bf-region`, `spec/router.md`) are
+compiler built-ins that are **compiled away** — no runtime value survives in
+the emitted output. They are recognised **import-scoped**: the compiler treats
+a tag as the built-in only when its local binding is imported from
+`@barefootjs/client` (keyed off `ir.metadata.imports`), never by a bare
+capitalized tag-name match. This is the same model `Portal` already follows and
+mirrors how Solid imports `<Show>` / `<Suspense>` from `solid-js`.
+
+```tsx
+import { Async, Region } from '@barefootjs/client'
+```
+
+- **Provenance & collision safety** — a user's own `<Async>` / `<Region>`
+  component (imported from elsewhere or declared locally) does not collide with
+  the built-in. An aliased `import { Async as Boundary }` maps `<Boundary>` to
+  the built-in.
+- **Diagnostic** — a bare `<Async>` / `<Region>` used without the import and
+  with no other in-scope binding raises `BF054` (import the built-in).
+- **Emit-time elision** — the `@barefootjs/client` import of these tags is
+  stripped on emit (`templateImports` and the client-JS DOM imports) so it never
+  lingers as a phantom runtime import. Real type-checked stubs ship from
+  `@barefootjs/client` (`packages/client/src/builtins.ts`).
+
+The runtime stubs throw if ever executed — reaching them means the JSX was
+rendered outside the compiler pipeline. See piconic-ai/barefootjs#1915.
+
 ### Hydration Markers
 
 1. **Marked Template**: Template with hydration markers (used for both SSR and CSR)


### PR DESCRIPTION
Closes #1915. Follow-up to #1914.

## Problem

`<Async>` and `<Region>` were recognised by a bare capitalized **tag-name match** in `jsx-to-ir.ts`. Because nothing was in scope at the value level, authoring them produced `TS2304: Cannot find name`, with no prop checking or completion — papered over with a per-file `declare function Async(...)` shim (`infinite-scroll-demo.tsx`). The Hono JSX runtime shipped `export declare function Async`, but a `declare`-only symbol is a phantom value import (breaks under `verbatimModuleSyntax`).

## Change

Move both to **import-scoped recognition** — the model `Portal` already follows, and how Solid imports `<Show>`/`<Suspense>` from `solid-js`:

- **Compiler** — recognise the built-in only when its local binding is imported from `@barefootjs/client` (keyed off `ir.metadata.imports`, not a tag-name string). A user's own `<Async>`/`<Region>` component no longer collides; aliased imports (`Async as Boundary`) map through. `spec/router.md` already specified this for `<Region>`; it's now implemented for both.
- **Importable exports** — real, type-checked `Async`/`Region` stubs ship from `@barefootjs/client` (`packages/client/src/builtins.ts`). They throw if ever executed (reaching them means the JSX bypassed the compiler).
- **Emit-time elision** — the built-in import is stripped from both `templateImports` (all adapters) and the client-JS DOM imports, so it never survives as a phantom runtime import. Verified on the real `infinite-scroll-demo` output (no `Async`/`@barefootjs/client` import in the emitted template).
- **Diagnostic** — `BF054` when a bare built-in tag is used without the import and with no other in-scope binding.
- **Workarounds removed** — the `declare function Async` in `infinite-scroll-demo.tsx` and the obsolete `export declare function Async` on the Hono JSX runtime.
- **Docs** — `spec/compiler.md` (new "Import-scoped built-ins" section) and `error-codes.md` (BF054).

## Tests

- New `packages/jsx/src/__tests__/ir-builtin-import-scope.test.ts` — recognition, alias mapping, collision safety (user's own component / local declaration), BF054, and `stripClientBuiltinImports` elision.
- Migrated existing bare-tag sources to add the import (`ir-async`, `ir-region`, `compiler-stress-1244`, `async-error-boundary`, and the `async-boundary`/`region-boundary` adapter fixtures).
- `bun test packages/jsx` (compiler), `packages/adapter-tests`, `packages/adapter-hono`, `packages/client` all green. The 4 `primitive-resolver-*` checker-path failures are pre-existing on a clean tree (they need `@barefootjs/client` built; they pass once `dist/` exists) and are unrelated.

https://claude.ai/code/session_015i9orcorqbbvwFokvp5Vx5

---
_Generated by [Claude Code](https://claude.ai/code/session_015i9orcorqbbvwFokvp5Vx5)_