### PR TITLE
fix(smoke-publish): override transitive @barefootjs/* deps in installer

### DIFF
--- a/scripts/smoke-publish.mjs
+++ b/scripts/smoke-publish.mjs
@@ -141,8 +141,22 @@ const workspace = mkdtempSync(join(tmpdir(), 'bf-smoke-workspace-'))
 // Install create-barefootjs + @barefootjs/cli into a throwaway tree so
 // the bin can `require.resolve('@barefootjs/cli/dist/index.js')`. The
 // app being scaffolded gets its own install via the rewrite below.
+//
+// `overrides` collapses the cli tarball's transitive `@barefootjs/*`
+// deps (`@barefootjs/client`, `@barefootjs/shared` — both `workspace:*`
+// in the repo, resolved to the bumped version by `bun pm pack`) onto the
+// local tarballs. Without this, npm resolves those versions from the
+// registry, which fails on a version-bump PR where the new version isn't
+// published yet (ETARGET "No matching version found"). Mirrors the app
+// rewrite below; `create-barefootjs` is the entry point, never a
+// transitive dep, so it's skipped.
 const installerDir = join(workspace, '_installer')
 mkdirSync(installerDir, { recursive: true })
+const installerOverrides = {}
+for (const [n, p] of Object.entries(tarballs)) {
+  if (n === 'create-barefootjs') continue
+  installerOverrides[n] = `file:${p}`
+}
 writeFileSync(
   resolve(installerDir, 'package.json'),
   JSON.stringify(
@@ -153,6 +167,7 @@ writeFileSync(
         'create-barefootjs': `file:${tarballs['create-barefootjs']}`,
         '@barefootjs/cli': `file:${tarballs['@barefootjs/cli']}`,
       },
+      overrides: installerOverrides,
     },
     null,
     2,


### PR DESCRIPTION
## Background

The **Smoke publish** job on the Changesets release PR (#1894) fails at the "Scaffold from tarballs" step:

```
npm error code ETARGET
npm error notarget No matching version found for @barefootjs/client@0.15.0.
```

## Cause

`scripts/smoke-publish.mjs` first installs a throwaway `_installer` tree containing only the `create-barefootjs` and `@barefootjs/cli` tarballs. The `@barefootjs/cli` tarball declares its `@barefootjs/client` / `@barefootjs/shared` dependencies at the bumped version (`bun pm pack` resolves `workspace:*` → e.g. `0.15.0`).

The installer's `package.json` had **no `overrides`**, so npm tries to resolve those transitive deps from the registry. On a version-bump PR the new version isn't published yet, so the install fails with `ETARGET`. The app-scaffold step below already guards against this with an `overrides` block — the installer step was simply missing the same protection.

## Fix

Add an `overrides` block to the installer `package.json` that collapses every `@barefootjs/*` tarball onto its local `file:` path, mirroring the existing app-scaffold rewrite (`create-barefootjs` is the entry point, never a transitive dep, so it's skipped).

## Verification

Ran `bun run scripts/smoke-publish.mjs` locally end-to-end — packs tarballs, scaffolds, installs, and all smoke commands (`bf build`, `npm run build`, `npm test`, etc.) **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0163vEUPiJoqQKaBgBdcZsFx)_