### PR TITLE
feat(go-template): env-signal searchParams() SSR lowering + runtime

### DIFF
--- a/.changeset/go-searchparams-ssr.md
+++ b/.changeset/go-searchparams-ssr.md
@@ -1,0 +1,11 @@
+---
+"@barefootjs/go-template": minor
+---
+
+`searchParams()` (router v0.5) now renders at SSR on the Go template adapter, so the cross-adapter `search-params` conformance fixture (`{searchParams().get('sort') ?? 'none'}`) runs on Go instead of being skipped (#1922, follow-up to #1917).
+
+- **Lowering**: Go's `and`/`or` are prefix builtins, so a multi-token operand (a method/function call, arithmetic, comparison, nested helper) must be parenthesised or it degrades into extra sibling args. `logical()` now composes both operands through `wrapIfMultiToken` — the file-wide idiom — so `searchParams().get(k) ?? d` lowers to `{{or (.SearchParams.Get "sort") "none"}}` instead of the broken `{{or .SearchParams.Get "sort" "none"}}` (which dropped the call grouping and rendered empty). This fixes the general `obj.method(arg) ?? fallback` shape, not just `searchParams`.
+- **Runtime**: new `bf.SearchParams` type with a `.Get(key)` helper (empty-tolerant zero value over `url.Values`) and a `bf.NewSearchParams(raw)` constructor for route handlers (`bf.NewSearchParams(r.URL.RawQuery)`).
+- **Codegen**: a `SearchParams bf.SearchParams` binding threaded through the generated `Input` / `Props` structs and `NewXxxProps`, emitted only when a component imports `searchParams` (and guarded against a name collision with a user prop/signal/memo of the same name). It is not serialised for hydration (`json:"-"`) — the client re-reads `window.location.search` itself. The zero value is an empty query, so a render with no request query resolves every key to `""` and the author's `?? default` renders.
+
+The Mojolicious / Xslate template adapters stay skipped pending their own env-signal lowering + per-request Perl `search_params` reader (#1922).

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -2502,8 +2502,18 @@ func NewSearchParams(raw string) SearchParams {
 }
 
 // Get returns the first value associated with key, or "" when the key is
-// absent — matching URLSearchParams.get, whose JS `null` the template's
-// `?? default` lowering treats as the default. Safe on the zero value.
+// absent. This mirrors url.Values.Get, which also returns "" for a
+// present-but-empty value (`?sort=`). Safe on the zero value (nil map).
+//
+// This is not byte-for-byte URLSearchParams.get under the template's `??`
+// lowering. JS distinguishes absent (`null`) from present-but-empty (`""`):
+// `null ?? d` yields the default, but `"" ?? d` keeps the empty string. The
+// Go adapter lowers `??` to the `or` builtin — Go templates have no
+// null-coalescing operator — so here BOTH an absent key and a present-but-
+// empty value fall back to the author's default. The conformance fixture only
+// exercises the absent-key default, where the two runtimes agree; the
+// empty-string divergence is the same general `?? → or` limitation that
+// applies to any `x ?? default` the Go adapter lowers.
 func (s SearchParams) Get(key string) string {
 	return s.values.Get(key)
 }

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -9,6 +9,7 @@ import (
 	"html/template"
 	"math"
 	"math/rand"
+	"net/url"
 	"os"
 	"reflect"
 	"sort"
@@ -2465,4 +2466,44 @@ func toString(v any) string {
 	default:
 		return ""
 	}
+}
+
+// =============================================================================
+// searchParams() — request-scoped environment signal (router v0.5, #1922)
+// =============================================================================
+
+// SearchParams is the SSR view of the request query string behind the
+// reactive searchParams() environment signal. The route handler builds it
+// from the request URL and assigns it to the component's SearchParams input
+// field; the generated template reads it via `.SearchParams.Get "key"`.
+//
+// The zero value is an empty query (url.Values.Get tolerates a nil map), so a
+// render with no request query — e.g. the adapter conformance harness, which
+// issues no query string — resolves every key to "", which the template's
+// `or`/`??` fallback turns into the author's default.
+type SearchParams struct {
+	values url.Values
+}
+
+// NewSearchParams parses a raw query string (with or without a leading "?")
+// into a SearchParams. A malformed query yields an empty set rather than an
+// error, mirroring the browser's URLSearchParams, which never throws on junk.
+//
+// Typical handler use (net/http):
+//
+//	in := MyComponentInput{SearchParams: bf.NewSearchParams(r.URL.RawQuery)}
+func NewSearchParams(raw string) SearchParams {
+	raw = strings.TrimPrefix(raw, "?")
+	values, err := url.ParseQuery(raw)
+	if err != nil {
+		values = url.Values{}
+	}
+	return SearchParams{values: values}
+}
+
+// Get returns the first value associated with key, or "" when the key is
+// absent — matching URLSearchParams.get, whose JS `null` the template's
+// `?? default` lowering treats as the default. Safe on the zero value.
+func (s SearchParams) Get(key string) string {
+	return s.values.Get(key)
 }

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -49,12 +49,13 @@ runAdapterConformanceTests({
   // yet (`item.ID` is on the loop datum, not the child's Input). Full
   // coverage remains at the Hono SSR + fixture-hydrate layers.
   //
-  // `search-params` (router v0.5): `searchParams().get(k) ?? d` needs
-  // dedicated env-signal lowering (the generic lowering emits
-  // `{{or .SearchParams.Get "sort" "none"}}`, missing the parens that group the
-  // method call, so it renders empty) plus a Go-runtime `SearchParams` binding.
-  // Tracked in https://github.com/piconic-ai/barefootjs/issues/1922.
-  skipJsx: ['data-table', 'search-params'],
+  // `search-params` (router v0.5) now renders on Go: `logical()` parenthesises
+  // its multi-token operands so `searchParams().get(k) ?? d` lowers to
+  // `{{or (.SearchParams.Get "sort") "none"}}`, and the generated structs carry
+  // a `SearchParams bf.SearchParams` binding (zero value → empty query → the
+  // author's default). See #1922; Mojo / Xslate stay skipped pending their own
+  // env-signal lowering + per-request Perl reader.
+  skipJsx: ['data-table'],
   // Per-fixture build-time contracts for shapes the Go template
   // adapter intentionally refuses to lower. Lives here (not on the
   // shared fixtures) so adding a new adapter doesn't require touching

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -1387,6 +1387,34 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   /**
+   * Whether the component reads the request-scoped `searchParams()`
+   * environment signal (router v0.5, #1922). Detected from a non-type
+   * `searchParams` import off `@barefootjs/client` — the same import the
+   * analyzer validates against `CLIENT_EXPORTS`. When true the generated
+   * structs carry a `SearchParams bf.SearchParams` binding the route handler
+   * fills per request and the template reads via `.SearchParams.Get "key"`.
+   *
+   * Guarded against a name collision with a user prop / signal / memo also
+   * called `searchParams`: that author owns the `SearchParams` field, so the
+   * env-signal field is dropped (the reference would resolve to their value).
+   */
+  private usesSearchParams(ir: ComponentIR): boolean {
+    const imported = ir.metadata.imports.some(
+      imp =>
+        imp.source === '@barefootjs/client' &&
+        !imp.isTypeOnly &&
+        imp.specifiers.some(s => !s.isTypeOnly && (s.alias ?? s.name) === 'searchParams'),
+    )
+    if (!imported) return false
+    const taken = new Set<string>([
+      ...ir.metadata.propsParams.map(p => this.capitalizeFieldName(p.name)),
+      ...ir.metadata.signals.map(s => this.capitalizeFieldName(s.getter)),
+      ...ir.metadata.memos.map(m => this.capitalizeFieldName(m.name)),
+    ])
+    return !taken.has('SearchParams')
+  }
+
+  /**
    * Generate Input struct for a component
    */
   private generateInputStruct(
@@ -1405,6 +1433,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // outer component. Forwarded to Props's BfParent / BfMount.
     lines.push('\tBfParent string // Optional: parent scope id')
     lines.push('\tBfMount string // Optional: slot id in parent')
+
+    // (#1922) Request-scoped `searchParams()` binding. The route handler
+    // builds it from the request URL (`bf.NewSearchParams(r.URL.RawQuery)`);
+    // the zero value is an empty query, so an omitted field resolves every
+    // `.Get` to "" — the author's `?? default` then renders.
+    if (this.usesSearchParams(ir)) {
+      lines.push('\tSearchParams bf.SearchParams // Optional: request query for searchParams()')
+    }
 
     // Static + prop-derived nested components appear in Input;
     // signal-backed dynamic ones are template-only
@@ -1489,6 +1525,13 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
     // Add Scripts field for dynamic script collection
     lines.push('\tScripts *bf.ScriptCollector `json:"-"`')
+
+    // (#1922) Request-scoped `searchParams()` SSR value. Read by the
+    // template as `.SearchParams.Get "key"`. Not serialised for hydration
+    // (`json:"-"`) — the client re-reads `window.location.search` itself.
+    if (this.usesSearchParams(ir)) {
+      lines.push('\tSearchParams bf.SearchParams `json:"-"`')
+    }
 
     // Collect nested component array field names to skip from propsParams
     const nestedArrayFields = new Set(nestedComponents.map(n => `${n.name}s`))
@@ -1720,6 +1763,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // slot-attached child of an outer page/component.
     lines.push('\t\tBfParent: in.BfParent,')
     lines.push('\t\tBfMount: in.BfMount,')
+    // (#1922) Forward the request-scoped searchParams() binding unchanged.
+    if (this.usesSearchParams(ir)) {
+      lines.push('\t\tSearchParams: in.SearchParams,')
+    }
 
     // Collect nested component array field names
     const nestedArrayFields = new Set(nestedComponents.map(n => `${n.name}s`))
@@ -4443,10 +4490,18 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     right: ParsedExpr,
     emit: (e: ParsedExpr) => string,
   ): string {
-    const l = emit(left)
-    const r = emit(right)
-    const wrapLeft = this.needsParens(left) ? `(${l})` : l
-    const wrapRight = this.needsParens(right) ? `(${r})` : r
+    // Go's `and`/`or` are prefix builtins, so every operand that renders to
+    // more than one token (a method/function call like `.SearchParams.Get
+    // "sort"`, an arithmetic `bf_add a b`, a comparison `eq a b`, a nested
+    // `not …` / `or …`) must be parenthesised or it degrades into extra
+    // sibling args of the enclosing `and`/`or`. `wrapIfMultiToken` is the
+    // file-wide idiom for exactly this (every other prefix-helper emitter
+    // composes operands through it); a bare field ref / quoted literal stays
+    // uncluttered. This is what makes `searchParams().get(k) ?? d` lower to
+    // `or (.SearchParams.Get "sort") "none"` instead of the broken
+    // `or .SearchParams.Get "sort" "none"` (#1922).
+    const wrapLeft = wrapIfMultiToken(emit(left))
+    const wrapRight = wrapIfMultiToken(emit(right))
     if (op === '&&') return `and ${wrapLeft} ${wrapRight}`
     return `or ${wrapLeft} ${wrapRight}`
   }

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -1406,11 +1406,21 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         imp.specifiers.some(s => !s.isTypeOnly && (s.alias ?? s.name) === 'searchParams'),
     )
     if (!imported) return false
+    // Every other source that contributes a Props/Input struct field: a
+    // collision on `SearchParams` would redeclare the field and break the Go
+    // compile. Covers props, signals, memos, `useContext` consumers, and the
+    // `{...rest}` bag — the same field-producing sets the struct emitters draw
+    // from. When the author already owns `SearchParams`, drop the env-signal
+    // field (their binding lowers to the same `.SearchParams` reference).
     const taken = new Set<string>([
       ...ir.metadata.propsParams.map(p => this.capitalizeFieldName(p.name)),
       ...ir.metadata.signals.map(s => this.capitalizeFieldName(s.getter)),
       ...ir.metadata.memos.map(m => this.capitalizeFieldName(m.name)),
+      ...this.contextConsumers.map(c => this.contextFieldName(c)),
     ])
+    if (ir.metadata.restPropsName) {
+      taken.add(this.capitalizeFieldName(ir.metadata.restPropsName))
+    }
     return !taken.has('SearchParams')
   }
 


### PR DESCRIPTION
Follow-up to #1917, partial fix for #1922 — the **Go** template adapter slice (the issue's first task group). Mojo / Xslate and the non-Hono JS integrations stay out of scope here.

## What

`searchParams()` (router v0.5) already works end-to-end on Hono. This brings the SSR side to the Go template adapter, so the cross-adapter `search-params` conformance fixture (`{searchParams().get('sort') ?? 'none'}`) now renders on Go and is un-skipped.

## The two gaps closed

### 1. Compiler lowering

Go's `and`/`or` are prefix builtins, so any operand that renders to more than one token must be parenthesised or it degrades into extra sibling args of the enclosing `or`. `logical()` previously parenthesised only `logical`/`unary`/`conditional` nodes, so a method call dropped its grouping:

| | Before (broken) | After |
| --- | --- | --- |
| Go | `{{or .SearchParams.Get "sort" "none"}}` | `{{or (.SearchParams.Get "sort") "none"}}` |

`logical()` now composes both operands through `wrapIfMultiToken` — the file-wide idiom every other prefix-helper emitter already uses (a bare field ref / quoted literal stays uncluttered). This fixes the general `obj.method(arg) ?? fallback` shape, not just `searchParams`.

### 2. Runtime + struct binding

- **`runtime/bf.go`**: a `bf.SearchParams` type with a `.Get(key)` helper (empty-tolerant zero value via `url.Values`), plus `NewSearchParams(raw)` for route handlers (`bf.NewSearchParams(r.URL.RawQuery)`).
- **Adapter codegen**: a `SearchParams bf.SearchParams` field threaded through the generated `Input` / `Props` structs and `NewXxxProps`, emitted only when a component imports `searchParams` (guarded against a name collision with a user prop/signal/memo of the same name). Not serialised for hydration (`json:"-"`) — the client re-reads `window.location.search` itself.

The conformance harness issues no query string, so the zero-value `SearchParams{}` resolves `.Get` to `""` and the author's `?? 'none'` renders `none` — matching the fixture's empty-query default, consistent with Hono.

## Verification

- `bun test packages/adapter-go-template` → **500 pass / 0 fail** (the un-skipped `search-params` now counts among them).
- `tsgo --noEmit` clean.
- Manual Go render against the real runtime: empty query → `none`, `?sort=price` → `price`. (Note: the repo's `isGoAvailable` gate requires Go 1.25+, so the JSX-render conformance step is skipped under the sandbox's Go 1.24 just like every other Go render here; the build/codegen assertions still run.)

## Out of scope (remaining #1922 work)

- Mojo / Xslate env-signal lowering + per-request Perl `search_params` reader.
- Non-Hono JS integrations (elysia / h3 / echo) request-scoped reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVG42m6fAQYAS4mYVR4CN2)_