### PR TITLE
feat(router): v2 compiler-derived nested / sibling regions

### DIFF
--- a/.changeset/router-v2-nested-regions.md
+++ b/.changeset/router-v2-nested-regions.md
@@ -1,0 +1,10 @@
+---
+"@barefootjs/router": minor
+---
+
+Compiler-derived nested / sibling regions (spec/router.md **v2**). When a fetched page exposes the same `bf-region` ids as the live document, the router now swaps only the **deepest regions whose owned content differs** instead of always replacing the single broadest region:
+
+- **Nested** `<Region>…<Region/>…</Region>` — a change confined to an inner region swaps only that inner region; the outer shell (and its island state, scroll, focus) persists. A change to the outer region's own content rebuilds it, and its nested regions ride along.
+- **Sibling** `<><Region/><Region/></>` — independent regions (master–detail): the region that changed swaps while the other keeps its live DOM/state. Both can swap in one navigation when both differ.
+
+A region's *owned* content is compared with its nested `[bf-region]` subtrees masked out, so an outer region is left mounted when only an inner region changed. The match is keyed by the compiler's stable `bf-region="<file scope>:<index>"` id, so the same logical region is recognised across page documents. When the two documents' region-id sets don't line up (or an id collides), the router falls back to the single broadest-region swap — the v0 behaviour, never worse than before. All swaps remain synchronous-before-`await` (last-wins safe) and compose with `data-bf-permanent` morphing (v1).

--- a/packages/router/__tests__/router-regions.test.ts
+++ b/packages/router/__tests__/router-regions.test.ts
@@ -171,6 +171,26 @@ describe('@barefootjs/router v2 — nested / sibling regions', () => {
     expect(document.getElementById('body')?.textContent).toBe('B')
   })
 
+  test('a region whose island mutated the DOM is not swapped when the server render is unchanged', async () => {
+    // The diff compares the incoming SERVER render against the region's server
+    // baseline, not the live DOM — so an island that changed the DOM after
+    // hydration does not make an otherwise-unchanged region look "changed" and
+    // get swapped (which would lose its state). Regression for the v2 review.
+    document.body.innerHTML =
+      `<header>shell</header><div bf-region="r:0" id="outer"><p id="body">server</p></div>`
+    router = startRouter({ rehydrate: () => {}, dispose: () => {} }) // baseline = "<p>server</p>"
+    // Simulate a signal-driven island mutating the live DOM after hydration.
+    ;(document.getElementById('body') as HTMLElement).textContent = 'mutated by island'
+    mark('body', 7)
+    // Incoming server render is byte-identical to the original (the baseline).
+    mockFetch(() => page(`<div bf-region="r:0" id="outer"><p id="body">server</p></div>`))
+    await navigate('/b')
+    await flush()
+    // Not swapped: same live node (marker intact) and the island mutation kept.
+    expect(readMark('body')).toBe(7)
+    expect(document.getElementById('body')?.textContent).toBe('mutated by island')
+  })
+
   test('a navigation that changes no region commits history without swapping', async () => {
     document.body.innerHTML = `<header>shell</header>
       <div bf-region="r:0" id="outer"><p id="body">same</p></div>`

--- a/packages/router/__tests__/router-regions.test.ts
+++ b/packages/router/__tests__/router-regions.test.ts
@@ -191,6 +191,29 @@ describe('@barefootjs/router v2 — nested / sibling regions', () => {
     expect(document.getElementById('body')?.textContent).toBe('mutated by island')
   })
 
+  test('a region differing only by a per-render island scope id is not swapped', async () => {
+    // A top-level island's `bf-s` scope id is randomized per server render, so
+    // two renders of the same region are never byte-identical. The diff must
+    // ignore that scaffolding and treat the region as unchanged (keep its state).
+    document.body.innerHTML =
+      `<header>shell</header>` +
+      `<aside bf-region="nav:0"><div class="w" bf-s="Widget_aaa111" bf-r=""><span id="w-state">keep</span></div></aside>` +
+      `<main bf-region="content:1"><p id="body">A</p></main>`
+    mark('w-state', 8)
+    // Incoming sidebar: SAME content, DIFFERENT random scope id; content differs.
+    mockFetch(() =>
+      page(
+        `<aside bf-region="nav:0"><div class="w" bf-s="Widget_zzz999" bf-r=""><span id="w-state">keep</span></div></aside>` +
+          `<main bf-region="content:1"><p id="body">B</p></main>`,
+      ),
+    )
+    router = startRouter({ rehydrate: () => {}, dispose: () => {} })
+    await navigate('/b')
+    await flush()
+    expect(readMark('w-state')).toBe(8) // sidebar not swapped despite the new scope id
+    expect(document.getElementById('body')?.textContent).toBe('B') // content swapped
+  })
+
   test('a navigation that changes no region commits history without swapping', async () => {
     document.body.innerHTML = `<header>shell</header>
       <div bf-region="r:0" id="outer"><p id="body">same</p></div>`

--- a/packages/router/__tests__/router-regions.test.ts
+++ b/packages/router/__tests__/router-regions.test.ts
@@ -1,0 +1,186 @@
+/**
+ * @barefootjs/router v2 — compiler-derived nested / sibling regions.
+ *
+ * When both documents expose the same `bf-region` ids, the router swaps only
+ * the deepest regions whose *owned* content differs: a nested inner region
+ * swaps while its outer shell persists; one sibling region swaps while the
+ * other keeps its live DOM/state; an outer change rebuilds its nested regions;
+ * and a mismatched id set falls back to the single broadest swap (v0).
+ */
+
+import { describe, test, expect, beforeAll, beforeEach, afterEach } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') {
+    GlobalRegistrator.register({ url: 'https://example.test/a' })
+  }
+  if (typeof window.scrollTo !== 'function') {
+    ;(window as unknown as { scrollTo: () => void }).scrollTo = () => {}
+  }
+})
+
+const { startRouter, navigate } = await import('../src/index.ts')
+
+let router: { stop(): void } | null = null
+const flush = (ms = 10) => new Promise((r) => setTimeout(r, ms))
+
+function setURL(url: string): void {
+  const happy = (globalThis as unknown as { happyDOM?: { setURL?: (u: string) => void } }).happyDOM
+  if (happy?.setURL) happy.setURL(url)
+  else window.history.replaceState(window.history.state, '', url)
+}
+
+/** Full HTML page wrapping `body` in a shell, with a `<title>`. */
+function page(body: string, title = 'p'): string {
+  return `<!doctype html><html><head><title>${title}</title></head><body><header>shell</header>${body}</body></html>`
+}
+
+function mockFetch(htmlFor: (url: string) => string | null): void {
+  ;(globalThis as unknown as { fetch: typeof fetch }).fetch = (async (input: RequestInfo | URL) => {
+    const html = htmlFor(String(input))
+    if (html === null)
+      return { ok: false, status: 404, redirected: false, url: String(input), text: async () => '' } as unknown as Response
+    return { ok: true, status: 200, redirected: false, url: String(input), text: async () => html } as unknown as Response
+  }) as typeof fetch
+}
+
+/** Tag a live element with an identity marker; read it back later to prove the node survived. */
+function mark(id: string, value: number): void {
+  ;(document.getElementById(id) as unknown as { __k?: number }).__k = value
+}
+function readMark(id: string): number | undefined {
+  return (document.getElementById(id) as unknown as { __k?: number } | null)?.__k
+}
+
+beforeEach(() => {
+  setURL('https://example.test/a')
+  ;(window as unknown as { __bf_dispose_within?: (r: Element) => void }).__bf_dispose_within = () => {}
+})
+
+afterEach(() => {
+  router?.stop()
+  router = null
+  delete (window as unknown as Record<string, unknown>).__bf_dispose_within
+})
+
+describe('@barefootjs/router v2 — nested / sibling regions', () => {
+  test('sibling regions: only the one whose content differs swaps', async () => {
+    document.body.innerHTML = `<header>shell</header>
+      <div bf-region="r:0" id="list"><p id="list-item">list A</p></div>
+      <div bf-region="r:1" id="detail"><p id="detail-body">detail A</p></div>`
+    mark('list-item', 1) // tag the list region's live node — it must survive
+
+    // Incoming: identical list region, changed detail region.
+    mockFetch(() =>
+      page(
+        `<div bf-region="r:0" id="list"><p id="list-item">list A</p></div>` +
+          `<div bf-region="r:1" id="detail"><p id="detail-body">detail B</p></div>`,
+      ),
+    )
+    router = startRouter({ rehydrate: () => {}, dispose: () => {} })
+    await navigate('/b')
+    await flush()
+
+    // list region untouched → same live node (marker intact); detail swapped.
+    expect(readMark('list-item')).toBe(1)
+    expect(document.getElementById('detail-body')?.textContent).toBe('detail B')
+  })
+
+  test('sibling regions: both swap when both differ', async () => {
+    document.body.innerHTML = `<header>shell</header>
+      <div bf-region="r:0" id="list"><p id="list-item">list A</p></div>
+      <div bf-region="r:1" id="detail"><p id="detail-body">detail A</p></div>`
+    mark('list-item', 1)
+    mockFetch(() =>
+      page(
+        `<div bf-region="r:0" id="list"><p id="list-item">list B</p></div>` +
+          `<div bf-region="r:1" id="detail"><p id="detail-body">detail B</p></div>`,
+      ),
+    )
+    router = startRouter({ rehydrate: () => {}, dispose: () => {} })
+    await navigate('/b')
+    await flush()
+
+    expect(readMark('list-item')).toBeUndefined() // fresh node — list swapped too
+    expect(document.getElementById('list-item')?.textContent).toBe('list B')
+    expect(document.getElementById('detail-body')?.textContent).toBe('detail B')
+  })
+
+  test('nested regions: only the inner swaps; the outer shell persists', async () => {
+    // Compact markup (no inter-element whitespace): both pages come from the
+    // same compiler, so a region's markup is byte-identical except for real
+    // content changes — owned-content comparison is an exact string compare.
+    document.body.innerHTML =
+      `<header>shell</header>` +
+      `<div bf-region="r:0" id="outer"><p id="outer-own">shell content</p>` +
+      `<div bf-region="r:1" id="inner"><p id="inner-body">inner A</p></div></div>`
+    mark('outer-own', 2) // outer's own live node must survive
+
+    // Incoming: outer's own content identical, inner content changed.
+    mockFetch(() =>
+      page(
+        `<div bf-region="r:0" id="outer">` +
+          `<p id="outer-own">shell content</p>` +
+          `<div bf-region="r:1" id="inner"><p id="inner-body">inner B</p></div>` +
+          `</div>`,
+      ),
+    )
+    router = startRouter({ rehydrate: () => {}, dispose: () => {} })
+    await navigate('/b')
+    await flush()
+
+    expect(readMark('outer-own')).toBe(2) // outer not swapped
+    expect(document.getElementById('inner-body')?.textContent).toBe('inner B') // inner swapped
+  })
+
+  test('nested regions: an outer change rebuilds the outer (inner rides along)', async () => {
+    document.body.innerHTML =
+      `<header>shell</header>` +
+      `<div bf-region="r:0" id="outer"><p id="outer-own">shell A</p>` +
+      `<div bf-region="r:1" id="inner"><p id="inner-body">inner A</p></div></div>`
+    mark('outer-own', 3)
+    mark('inner-body', 4)
+    // Incoming: outer's OWN content changed (inner unchanged).
+    mockFetch(() =>
+      page(
+        `<div bf-region="r:0" id="outer">` +
+          `<p id="outer-own">shell B</p>` +
+          `<div bf-region="r:1" id="inner"><p id="inner-body">inner A</p></div>` +
+          `</div>`,
+      ),
+    )
+    router = startRouter({ rehydrate: () => {}, dispose: () => {} })
+    await navigate('/b')
+    await flush()
+
+    expect(document.getElementById('outer-own')?.textContent).toBe('shell B')
+    expect(readMark('outer-own')).toBeUndefined() // outer rebuilt
+    expect(readMark('inner-body')).toBeUndefined() // inner rebuilt as part of the outer swap
+  })
+
+  test('mismatched region ids fall back to the broadest single swap', async () => {
+    document.body.innerHTML = `<header>shell</header>
+      <div bf-region="r:0" id="outer"><p id="body">A</p></div>`
+    // Incoming exposes a DIFFERENT id set → can't match 1:1 → broadest fallback.
+    mockFetch(() => page(`<div bf-region="r:9" id="outer"><p id="body">B</p></div>`))
+    router = startRouter({ rehydrate: () => {}, dispose: () => {} })
+    await navigate('/b')
+    await flush()
+    // The broadest region (first [bf-region]) still swapped its content.
+    expect(document.getElementById('body')?.textContent).toBe('B')
+  })
+
+  test('a navigation that changes no region commits history without swapping', async () => {
+    document.body.innerHTML = `<header>shell</header>
+      <div bf-region="r:0" id="outer"><p id="body">same</p></div>`
+    mark('body', 5)
+    // Incoming is structurally identical inside every region.
+    mockFetch(() => page(`<div bf-region="r:0" id="outer"><p id="body">same</p></div>`))
+    router = startRouter({ rehydrate: () => {}, dispose: () => {} })
+    await navigate('/b')
+    await flush()
+    expect(readMark('body')).toBe(5) // nothing swapped — live node preserved
+    expect(window.location.pathname).toBe('/b') // but the navigation committed
+  })
+})

--- a/packages/router/__tests__/router-regions.test.ts
+++ b/packages/router/__tests__/router-regions.test.ts
@@ -1,11 +1,15 @@
 /**
- * @barefootjs/router v2 — compiler-derived nested / sibling regions.
+ * @barefootjs/router v2 — compiler-derived nested / sibling regions (table-driven).
  *
- * When both documents expose the same `bf-region` ids, the router swaps only
- * the deepest regions whose *owned* content differs: a nested inner region
- * swaps while its outer shell persists; one sibling region swaps while the
- * other keeps its live DOM/state; an outer change rebuilds its nested regions;
- * and a mismatched id set falls back to the single broadest swap (v0).
+ * Each case sets up the live document and the incoming page, tags live nodes
+ * with an identity marker, navigates, then asserts which regions were
+ * **preserved** (marker survives → not swapped) vs **replaced** (marker gone →
+ * swapped/rebuilt), the resulting text, and whether the router fell back to a
+ * hard navigation. `mutate` runs after the router captured its baseline, to
+ * simulate an island changing the live DOM. Markup inside a region is written
+ * compactly (no inter-element whitespace): both pages come from the same
+ * compiler, so a region's markup is byte-identical except for real changes and
+ * the per-render scope ids the diff already normalizes away.
  */
 
 import { describe, test, expect, beforeAll, beforeEach, afterEach } from 'bun:test'
@@ -23,7 +27,17 @@ beforeAll(() => {
 const { startRouter, navigate } = await import('../src/index.ts')
 
 let router: { stop(): void } | null = null
+let assigned = ''
+let realAssign: typeof window.location.assign
 const flush = (ms = 10) => new Promise((r) => setTimeout(r, ms))
+
+const MARK = 1
+const tag = (id: string) => {
+  const el = document.getElementById(id) as (HTMLElement & { __k?: number }) | null
+  if (el) el.__k = MARK
+}
+const marker = (id: string) =>
+  (document.getElementById(id) as (HTMLElement & { __k?: number }) | null)?.__k
 
 function setURL(url: string): void {
   const happy = (globalThis as unknown as { happyDOM?: { setURL?: (u: string) => void } }).happyDOM
@@ -31,199 +45,219 @@ function setURL(url: string): void {
   else window.history.replaceState(window.history.state, '', url)
 }
 
-/** Full HTML page wrapping `body` in a shell, with a `<title>`. */
-function page(body: string, title = 'p'): string {
-  return `<!doctype html><html><head><title>${title}</title></head><body><header>shell</header>${body}</body></html>`
+/** Wrap region/shell markup in a full HTML document. */
+function fullDoc(body: string, title = 'p'): string {
+  return `<!doctype html><html><head><title>${title}</title></head><body>${body}</body></html>`
 }
 
-function mockFetch(htmlFor: (url: string) => string | null): void {
-  ;(globalThis as unknown as { fetch: typeof fetch }).fetch = (async (input: RequestInfo | URL) => {
-    const html = htmlFor(String(input))
-    if (html === null)
-      return { ok: false, status: 404, redirected: false, url: String(input), text: async () => '' } as unknown as Response
-    return { ok: true, status: 200, redirected: false, url: String(input), text: async () => html } as unknown as Response
-  }) as typeof fetch
-}
-
-/** Tag a live element with an identity marker; read it back later to prove the node survived. */
-function mark(id: string, value: number): void {
-  ;(document.getElementById(id) as unknown as { __k?: number }).__k = value
-}
-function readMark(id: string): number | undefined {
-  return (document.getElementById(id) as unknown as { __k?: number } | null)?.__k
+function mockFetch(html: string): void {
+  ;(globalThis as unknown as { fetch: typeof fetch }).fetch = (async (input: RequestInfo | URL) =>
+    ({
+      ok: true,
+      status: 200,
+      redirected: false,
+      url: String(input),
+      text: async () => html,
+    }) as unknown as Response) as typeof fetch
 }
 
 beforeEach(() => {
   setURL('https://example.test/a')
+  assigned = ''
+  realAssign = window.location.assign
+  ;(window.location as unknown as { assign: (u: string) => void }).assign = (u: string) => {
+    assigned = u
+  }
   ;(window as unknown as { __bf_dispose_within?: (r: Element) => void }).__bf_dispose_within = () => {}
 })
 
 afterEach(() => {
   router?.stop()
   router = null
+  ;(window.location as unknown as { assign: typeof realAssign }).assign = realAssign
   delete (window as unknown as Record<string, unknown>).__bf_dispose_within
 })
 
-describe('@barefootjs/router v2 — nested / sibling regions', () => {
-  test('sibling regions: only the one whose content differs swaps', async () => {
-    document.body.innerHTML = `<header>shell</header>
-      <div bf-region="r:0" id="list"><p id="list-item">list A</p></div>
-      <div bf-region="r:1" id="detail"><p id="detail-body">detail A</p></div>`
-    mark('list-item', 1) // tag the list region's live node — it must survive
+interface RegionCase {
+  name: string
+  /** Live document body (regions + any shell). */
+  current: string
+  /** Incoming fetched page body. */
+  incoming: string
+  /** Live element ids to tag with an identity marker before navigating. */
+  tag?: string[]
+  /** Runs after `startRouter` (baseline captured) — e.g. an island mutating the DOM. */
+  mutate?: () => void
+  /** Ids whose live node must SURVIVE the navigation (region not swapped). */
+  preserved?: string[]
+  /** Ids whose live node must be REPLACED (region swapped/rebuilt). */
+  replaced?: string[]
+  /** Expected `textContent` by element id after the navigation. */
+  text?: Record<string, string>
+  /** Expect a hard navigation (full reload) instead of any swap. */
+  hardNavigate?: boolean
+  /** Expect this committed pathname (a swap commits history). */
+  path?: string
+}
 
-    // Incoming: identical list region, changed detail region.
-    mockFetch(() =>
-      page(
-        `<div bf-region="r:0" id="list"><p id="list-item">list A</p></div>` +
-          `<div bf-region="r:1" id="detail"><p id="detail-body">detail B</p></div>`,
-      ),
-    )
-    router = startRouter({ rehydrate: () => {}, dispose: () => {} })
-    await navigate('/b')
-    await flush()
-
-    // list region untouched → same live node (marker intact); detail swapped.
-    expect(readMark('list-item')).toBe(1)
-    expect(document.getElementById('detail-body')?.textContent).toBe('detail B')
-  })
-
-  test('sibling regions: both swap when both differ', async () => {
-    document.body.innerHTML = `<header>shell</header>
-      <div bf-region="r:0" id="list"><p id="list-item">list A</p></div>
-      <div bf-region="r:1" id="detail"><p id="detail-body">detail A</p></div>`
-    mark('list-item', 1)
-    mockFetch(() =>
-      page(
-        `<div bf-region="r:0" id="list"><p id="list-item">list B</p></div>` +
-          `<div bf-region="r:1" id="detail"><p id="detail-body">detail B</p></div>`,
-      ),
-    )
-    router = startRouter({ rehydrate: () => {}, dispose: () => {} })
-    await navigate('/b')
-    await flush()
-
-    expect(readMark('list-item')).toBeUndefined() // fresh node — list swapped too
-    expect(document.getElementById('list-item')?.textContent).toBe('list B')
-    expect(document.getElementById('detail-body')?.textContent).toBe('detail B')
-  })
-
-  test('nested regions: only the inner swaps; the outer shell persists', async () => {
-    // Compact markup (no inter-element whitespace): both pages come from the
-    // same compiler, so a region's markup is byte-identical except for real
-    // content changes — owned-content comparison is an exact string compare.
-    document.body.innerHTML =
+const cases: RegionCase[] = [
+  {
+    name: 'sibling regions: only the one whose content differs swaps',
+    current:
       `<header>shell</header>` +
-      `<div bf-region="r:0" id="outer"><p id="outer-own">shell content</p>` +
-      `<div bf-region="r:1" id="inner"><p id="inner-body">inner A</p></div></div>`
-    mark('outer-own', 2) // outer's own live node must survive
-
-    // Incoming: outer's own content identical, inner content changed.
-    mockFetch(() =>
-      page(
-        `<div bf-region="r:0" id="outer">` +
-          `<p id="outer-own">shell content</p>` +
-          `<div bf-region="r:1" id="inner"><p id="inner-body">inner B</p></div>` +
-          `</div>`,
-      ),
-    )
-    router = startRouter({ rehydrate: () => {}, dispose: () => {} })
-    await navigate('/b')
-    await flush()
-
-    expect(readMark('outer-own')).toBe(2) // outer not swapped
-    expect(document.getElementById('inner-body')?.textContent).toBe('inner B') // inner swapped
-  })
-
-  test('nested regions: an outer change rebuilds the outer (inner rides along)', async () => {
-    document.body.innerHTML =
+      `<div bf-region="r:0" id="list"><p id="list-item">list A</p></div>` +
+      `<div bf-region="r:1" id="detail"><p id="detail-body">detail A</p></div>`,
+    incoming:
+      `<div bf-region="r:0" id="list"><p id="list-item">list A</p></div>` +
+      `<div bf-region="r:1" id="detail"><p id="detail-body">detail B</p></div>`,
+    tag: ['list-item'],
+    preserved: ['list-item'],
+    text: { 'detail-body': 'detail B' },
+  },
+  {
+    name: 'sibling regions: both swap when both differ',
+    current:
       `<header>shell</header>` +
+      `<div bf-region="r:0" id="list"><p id="list-item">list A</p></div>` +
+      `<div bf-region="r:1" id="detail"><p id="detail-body">detail A</p></div>`,
+    incoming:
+      `<div bf-region="r:0" id="list"><p id="list-item">list B</p></div>` +
+      `<div bf-region="r:1" id="detail"><p id="detail-body">detail B</p></div>`,
+    tag: ['list-item'],
+    replaced: ['list-item'],
+    text: { 'list-item': 'list B', 'detail-body': 'detail B' },
+  },
+  {
+    name: 'nested regions: only the inner swaps; the outer shell persists',
+    current:
+      `<div bf-region="r:0" id="outer"><p id="outer-own">shell</p>` +
+      `<div bf-region="r:1" id="inner"><p id="inner-body">inner A</p></div></div>`,
+    incoming:
+      `<div bf-region="r:0" id="outer"><p id="outer-own">shell</p>` +
+      `<div bf-region="r:1" id="inner"><p id="inner-body">inner B</p></div></div>`,
+    tag: ['outer-own'],
+    preserved: ['outer-own'],
+    text: { 'inner-body': 'inner B' },
+  },
+  {
+    name: 'nested regions: an outer change rebuilds the outer (inner rides along)',
+    current:
       `<div bf-region="r:0" id="outer"><p id="outer-own">shell A</p>` +
-      `<div bf-region="r:1" id="inner"><p id="inner-body">inner A</p></div></div>`
-    mark('outer-own', 3)
-    mark('inner-body', 4)
-    // Incoming: outer's OWN content changed (inner unchanged).
-    mockFetch(() =>
-      page(
-        `<div bf-region="r:0" id="outer">` +
-          `<p id="outer-own">shell B</p>` +
-          `<div bf-region="r:1" id="inner"><p id="inner-body">inner A</p></div>` +
-          `</div>`,
-      ),
-    )
-    router = startRouter({ rehydrate: () => {}, dispose: () => {} })
-    await navigate('/b')
-    await flush()
-
-    expect(document.getElementById('outer-own')?.textContent).toBe('shell B')
-    expect(readMark('outer-own')).toBeUndefined() // outer rebuilt
-    expect(readMark('inner-body')).toBeUndefined() // inner rebuilt as part of the outer swap
-  })
-
-  test('mismatched region ids fall back to the broadest single swap', async () => {
-    document.body.innerHTML = `<header>shell</header>
-      <div bf-region="r:0" id="outer"><p id="body">A</p></div>`
-    // Incoming exposes a DIFFERENT id set → can't match 1:1 → broadest fallback.
-    mockFetch(() => page(`<div bf-region="r:9" id="outer"><p id="body">B</p></div>`))
-    router = startRouter({ rehydrate: () => {}, dispose: () => {} })
-    await navigate('/b')
-    await flush()
-    // The broadest region (first [bf-region]) still swapped its content.
-    expect(document.getElementById('body')?.textContent).toBe('B')
-  })
-
-  test('a region whose island mutated the DOM is not swapped when the server render is unchanged', async () => {
-    // The diff compares the incoming SERVER render against the region's server
-    // baseline, not the live DOM — so an island that changed the DOM after
-    // hydration does not make an otherwise-unchanged region look "changed" and
-    // get swapped (which would lose its state). Regression for the v2 review.
-    document.body.innerHTML =
-      `<header>shell</header><div bf-region="r:0" id="outer"><p id="body">server</p></div>`
-    router = startRouter({ rehydrate: () => {}, dispose: () => {} }) // baseline = "<p>server</p>"
-    // Simulate a signal-driven island mutating the live DOM after hydration.
-    ;(document.getElementById('body') as HTMLElement).textContent = 'mutated by island'
-    mark('body', 7)
-    // Incoming server render is byte-identical to the original (the baseline).
-    mockFetch(() => page(`<div bf-region="r:0" id="outer"><p id="body">server</p></div>`))
-    await navigate('/b')
-    await flush()
-    // Not swapped: same live node (marker intact) and the island mutation kept.
-    expect(readMark('body')).toBe(7)
-    expect(document.getElementById('body')?.textContent).toBe('mutated by island')
-  })
-
-  test('a region differing only by a per-render island scope id is not swapped', async () => {
-    // A top-level island's `bf-s` scope id is randomized per server render, so
-    // two renders of the same region are never byte-identical. The diff must
-    // ignore that scaffolding and treat the region as unchanged (keep its state).
-    document.body.innerHTML =
+      `<div bf-region="r:1" id="inner"><p id="inner-body">inner A</p></div></div>`,
+    incoming:
+      `<div bf-region="r:0" id="outer"><p id="outer-own">shell B</p>` +
+      `<div bf-region="r:1" id="inner"><p id="inner-body">inner A</p></div></div>`,
+    tag: ['outer-own', 'inner-body'],
+    replaced: ['outer-own', 'inner-body'],
+    text: { 'outer-own': 'shell B' },
+  },
+  {
+    name: 'a header change outside every region is ignored (the shell persists)',
+    current:
+      `<header id="hdr">old header</header>` +
+      `<div bf-region="r:0" id="region"><p id="body">same</p></div>`,
+    // Incoming has a DIFFERENT header but an identical region. The router only
+    // swaps regions, so the (out-of-region) header is left as-is and the region
+    // is not swapped — everything outside a region persists across a navigation.
+    incoming:
+      `<header id="hdr">new header</header>` +
+      `<div bf-region="r:0" id="region"><p id="body">same</p></div>`,
+    tag: ['body'],
+    preserved: ['body'],
+    text: { hdr: 'old header', body: 'same' },
+    path: '/b',
+  },
+  {
+    name: 'a region whose island mutated the DOM is not swapped when the server render is unchanged',
+    current: `<header>shell</header><div bf-region="r:0" id="region"><p id="body">server</p></div>`,
+    incoming: `<div bf-region="r:0" id="region"><p id="body">server</p></div>`,
+    // Simulate a signal-driven island mutating the live DOM after hydration; the
+    // diff compares the incoming SERVER render against the baseline server render,
+    // not the live DOM, so the region stays mounted with its mutation intact.
+    mutate: () => {
+      const el = document.getElementById('body')
+      if (el) el.textContent = 'mutated by island'
+    },
+    tag: ['body'],
+    preserved: ['body'],
+    text: { body: 'mutated by island' },
+  },
+  {
+    name: 'a region differing only by a per-render island scope id is not swapped',
+    current:
       `<header>shell</header>` +
-      `<aside bf-region="nav:0"><div class="w" bf-s="Widget_aaa111" bf-r=""><span id="w-state">keep</span></div></aside>` +
-      `<main bf-region="content:1"><p id="body">A</p></main>`
-    mark('w-state', 8)
-    // Incoming sidebar: SAME content, DIFFERENT random scope id; content differs.
-    mockFetch(() =>
-      page(
-        `<aside bf-region="nav:0"><div class="w" bf-s="Widget_zzz999" bf-r=""><span id="w-state">keep</span></div></aside>` +
-          `<main bf-region="content:1"><p id="body">B</p></main>`,
-      ),
-    )
-    router = startRouter({ rehydrate: () => {}, dispose: () => {} })
-    await navigate('/b')
-    await flush()
-    expect(readMark('w-state')).toBe(8) // sidebar not swapped despite the new scope id
-    expect(document.getElementById('body')?.textContent).toBe('B') // content swapped
-  })
+      `<aside bf-region="nav:0" id="nav"><div class="w" bf-s="Widget_aaa111" bf-r=""><span id="w-state">keep</span></div></aside>` +
+      `<main bf-region="content:1" id="main"><p id="body">A</p></main>`,
+    incoming:
+      `<aside bf-region="nav:0" id="nav"><div class="w" bf-s="Widget_zzz999" bf-r=""><span id="w-state">keep</span></div></aside>` +
+      `<main bf-region="content:1" id="main"><p id="body">B</p></main>`,
+    tag: ['w-state'],
+    preserved: ['w-state'],
+    text: { body: 'B' },
+  },
+  {
+    name: 'a navigation that changes no region commits history without swapping',
+    current: `<header>shell</header><div bf-region="r:0" id="region"><p id="body">same</p></div>`,
+    incoming: `<div bf-region="r:0" id="region"><p id="body">same</p></div>`,
+    tag: ['body'],
+    preserved: ['body'],
+    text: { body: 'same' },
+    path: '/b',
+  },
+  {
+    name: 'sibling region set diverges (Region + Region → Region + div): hard-navigates',
+    current:
+      `<header>shell</header>` +
+      `<aside bf-region="nav:0" id="nav"><p id="np">N</p></aside>` +
+      `<main bf-region="content:1" id="main"><p id="mp">A</p></main>`,
+    // The incoming page lost its second region (now a plain <div>), so the id
+    // sets don't match and there is no single root region containing the others.
+    // A single broadest swap would half-update the page, so the router hard-
+    // navigates instead (never worse than an MPA).
+    incoming:
+      `<aside bf-region="nav:0" id="nav"><p id="np">N</p></aside>` +
+      `<div id="plain"><p id="mp">B</p></div>`,
+    tag: ['mp'],
+    hardNavigate: true,
+    text: { mp: 'A' }, // no partial swap happened
+  },
+  {
+    name: 'nested region set diverges but a root contains all: the root rebuilds',
+    current:
+      `<header>shell</header>` +
+      `<div bf-region="r:0" id="outer"><p id="oo">shell</p>` +
+      `<div bf-region="r:1" id="inner"><p id="ii">A</p></div></div>`,
+    // The inner region's id changed (r:1 → r:9), so the sets diverge — but the
+    // outer region is a root containing it, so swapping the outer rebuilds all.
+    incoming:
+      `<div bf-region="r:0" id="outer"><p id="oo">shell</p>` +
+      `<div bf-region="r:9" id="inner"><p id="ii">B</p></div></div>`,
+    tag: ['oo', 'ii'],
+    replaced: ['oo', 'ii'],
+    text: { ii: 'B' },
+  },
+]
 
-  test('a navigation that changes no region commits history without swapping', async () => {
-    document.body.innerHTML = `<header>shell</header>
-      <div bf-region="r:0" id="outer"><p id="body">same</p></div>`
-    mark('body', 5)
-    // Incoming is structurally identical inside every region.
-    mockFetch(() => page(`<div bf-region="r:0" id="outer"><p id="body">same</p></div>`))
-    router = startRouter({ rehydrate: () => {}, dispose: () => {} })
-    await navigate('/b')
-    await flush()
-    expect(readMark('body')).toBe(5) // nothing swapped — live node preserved
-    expect(window.location.pathname).toBe('/b') // but the navigation committed
-  })
+describe('@barefootjs/router v2 — nested / sibling regions', () => {
+  for (const c of cases) {
+    test(c.name, async () => {
+      document.body.innerHTML = c.current
+      mockFetch(fullDoc(c.incoming))
+      router = startRouter({ rehydrate: () => {}, dispose: () => {} })
+      c.mutate?.()
+      for (const id of c.tag ?? []) tag(id)
+
+      await navigate('/b')
+      await flush()
+
+      if (c.hardNavigate) expect(assigned).toContain('/b')
+      else expect(assigned).toBe('')
+      for (const id of c.preserved ?? []) expect(marker(id)).toBe(MARK)
+      for (const id of c.replaced ?? []) expect(marker(id)).toBeUndefined()
+      for (const [id, t] of Object.entries(c.text ?? {})) {
+        expect(document.getElementById(id)?.textContent).toBe(t)
+      }
+      if (c.path) expect(window.location.pathname).toBe(c.path)
+    })
+  }
 })

--- a/packages/router/__tests__/router-regions.test.ts
+++ b/packages/router/__tests__/router-regions.test.ts
@@ -1,15 +1,16 @@
 /**
  * @barefootjs/router v2 — compiler-derived nested / sibling regions (table-driven).
  *
- * Each case sets up the live document and the incoming page, tags live nodes
- * with an identity marker, navigates, then asserts which regions were
- * **preserved** (marker survives → not swapped) vs **replaced** (marker gone →
- * swapped/rebuilt), the resulting text, and whether the router fell back to a
- * hard navigation. `mutate` runs after the router captured its baseline, to
- * simulate an island changing the live DOM. Markup inside a region is written
- * compactly (no inter-element whitespace): both pages come from the same
- * compiler, so a region's markup is byte-identical except for real changes and
- * the per-render scope ids the diff already normalizes away.
+ * Each case declares the live document and the incoming page, then its
+ * expectations: which live nodes `survives` the navigation (their region was
+ * not swapped) vs are `replaced` (swapped/rebuilt), the `textAfter`, whether it
+ * `fallsBackToReload`, and the `committedPath`. The runner auto-tags every node
+ * an expectation names so it can tell a surviving live node from a freshly
+ * rendered one of the same id. `islandMutates` runs after the router captured
+ * its baseline, to simulate an island changing the live DOM. Markup inside a
+ * region is written compactly (no inter-element whitespace): both pages come
+ * from the same compiler, so a region's markup is byte-identical except for real
+ * changes and the per-render scope ids the diff already normalizes away.
  */
 
 import { describe, test, expect, beforeAll, beforeEach, afterEach } from 'bun:test'
@@ -79,25 +80,28 @@ afterEach(() => {
 })
 
 interface RegionCase {
+  /** What this case demonstrates. */
   name: string
-  /** Live document body (regions + any shell). */
+  /** The live document, before navigating. */
   current: string
-  /** Incoming fetched page body. */
+  /** The full page the navigation fetches. */
   incoming: string
-  /** Live element ids to tag with an identity marker before navigating. */
-  tag?: string[]
-  /** Runs after `startRouter` (baseline captured) — e.g. an island mutating the DOM. */
-  mutate?: () => void
-  /** Ids whose live node must SURVIVE the navigation (region not swapped). */
-  preserved?: string[]
-  /** Ids whose live node must be REPLACED (region swapped/rebuilt). */
+
+  // ── optional setup ──
+  /** After the router captured its baseline, an island mutates the live DOM. */
+  islandMutates?: () => void
+
+  // ── expectations (every id listed here is auto-tracked by node identity) ──
+  /** These live nodes must SURVIVE the navigation — their region was not swapped. */
+  survives?: string[]
+  /** These live nodes must be REPLACED — their region was swapped / rebuilt. */
   replaced?: string[]
-  /** Expected `textContent` by element id after the navigation. */
-  text?: Record<string, string>
-  /** Expect a hard navigation (full reload) instead of any swap. */
-  hardNavigate?: boolean
-  /** Expect this committed pathname (a swap commits history). */
-  path?: string
+  /** Expected `textContent` after the navigation, by element id. */
+  textAfter?: Record<string, string>
+  /** The navigation should fall back to a full page reload, not a partial swap. */
+  fallsBackToReload?: boolean
+  /** The pathname the navigation committed to history (a partial swap does). */
+  committedPath?: string
 }
 
 const cases: RegionCase[] = [
@@ -110,9 +114,8 @@ const cases: RegionCase[] = [
     incoming:
       `<div bf-region="r:0" id="list"><p id="list-item">list A</p></div>` +
       `<div bf-region="r:1" id="detail"><p id="detail-body">detail B</p></div>`,
-    tag: ['list-item'],
-    preserved: ['list-item'],
-    text: { 'detail-body': 'detail B' },
+    survives: ['list-item'],
+    textAfter: { 'detail-body': 'detail B' },
   },
   {
     name: 'sibling regions: both swap when both differ',
@@ -123,9 +126,8 @@ const cases: RegionCase[] = [
     incoming:
       `<div bf-region="r:0" id="list"><p id="list-item">list B</p></div>` +
       `<div bf-region="r:1" id="detail"><p id="detail-body">detail B</p></div>`,
-    tag: ['list-item'],
     replaced: ['list-item'],
-    text: { 'list-item': 'list B', 'detail-body': 'detail B' },
+    textAfter: { 'list-item': 'list B', 'detail-body': 'detail B' },
   },
   {
     name: 'nested regions: only the inner swaps; the outer shell persists',
@@ -135,9 +137,8 @@ const cases: RegionCase[] = [
     incoming:
       `<div bf-region="r:0" id="outer"><p id="outer-own">shell</p>` +
       `<div bf-region="r:1" id="inner"><p id="inner-body">inner B</p></div></div>`,
-    tag: ['outer-own'],
-    preserved: ['outer-own'],
-    text: { 'inner-body': 'inner B' },
+    survives: ['outer-own'],
+    textAfter: { 'inner-body': 'inner B' },
   },
   {
     name: 'nested regions: an outer change rebuilds the outer (inner rides along)',
@@ -147,9 +148,8 @@ const cases: RegionCase[] = [
     incoming:
       `<div bf-region="r:0" id="outer"><p id="outer-own">shell B</p>` +
       `<div bf-region="r:1" id="inner"><p id="inner-body">inner A</p></div></div>`,
-    tag: ['outer-own', 'inner-body'],
     replaced: ['outer-own', 'inner-body'],
-    text: { 'outer-own': 'shell B' },
+    textAfter: { 'outer-own': 'shell B' },
   },
   {
     name: 'a header change outside every region is ignored (the shell persists)',
@@ -162,25 +162,22 @@ const cases: RegionCase[] = [
     incoming:
       `<header id="hdr">new header</header>` +
       `<div bf-region="r:0" id="region"><p id="body">same</p></div>`,
-    tag: ['body'],
-    preserved: ['body'],
-    text: { hdr: 'old header', body: 'same' },
-    path: '/b',
+    survives: ['body'],
+    textAfter: { hdr: 'old header', body: 'same' },
+    committedPath: '/b',
   },
   {
     name: 'a region whose island mutated the DOM is not swapped when the server render is unchanged',
     current: `<header>shell</header><div bf-region="r:0" id="region"><p id="body">server</p></div>`,
     incoming: `<div bf-region="r:0" id="region"><p id="body">server</p></div>`,
-    // Simulate a signal-driven island mutating the live DOM after hydration; the
-    // diff compares the incoming SERVER render against the baseline server render,
-    // not the live DOM, so the region stays mounted with its mutation intact.
-    mutate: () => {
+    // The diff compares the incoming SERVER render against the baseline server
+    // render, not the live DOM, so the region stays mounted with its mutation.
+    islandMutates: () => {
       const el = document.getElementById('body')
       if (el) el.textContent = 'mutated by island'
     },
-    tag: ['body'],
-    preserved: ['body'],
-    text: { body: 'mutated by island' },
+    survives: ['body'],
+    textAfter: { body: 'mutated by island' },
   },
   {
     name: 'a region differing only by a per-render island scope id is not swapped',
@@ -191,18 +188,16 @@ const cases: RegionCase[] = [
     incoming:
       `<aside bf-region="nav:0" id="nav"><div class="w" bf-s="Widget_zzz999" bf-r=""><span id="w-state">keep</span></div></aside>` +
       `<main bf-region="content:1" id="main"><p id="body">B</p></main>`,
-    tag: ['w-state'],
-    preserved: ['w-state'],
-    text: { body: 'B' },
+    survives: ['w-state'],
+    textAfter: { body: 'B' },
   },
   {
     name: 'a navigation that changes no region commits history without swapping',
     current: `<header>shell</header><div bf-region="r:0" id="region"><p id="body">same</p></div>`,
     incoming: `<div bf-region="r:0" id="region"><p id="body">same</p></div>`,
-    tag: ['body'],
-    preserved: ['body'],
-    text: { body: 'same' },
-    path: '/b',
+    survives: ['body'],
+    textAfter: { body: 'same' },
+    committedPath: '/b',
   },
   {
     name: 'sibling region set diverges (Region + Region → Region + div): hard-navigates',
@@ -217,9 +212,8 @@ const cases: RegionCase[] = [
     incoming:
       `<aside bf-region="nav:0" id="nav"><p id="np">N</p></aside>` +
       `<div id="plain"><p id="mp">B</p></div>`,
-    tag: ['mp'],
-    hardNavigate: true,
-    text: { mp: 'A' }, // no partial swap happened
+    fallsBackToReload: true,
+    textAfter: { mp: 'A' }, // no partial swap happened
   },
   {
     name: 'nested region set diverges but a root contains all: the root rebuilds',
@@ -232,9 +226,8 @@ const cases: RegionCase[] = [
     incoming:
       `<div bf-region="r:0" id="outer"><p id="oo">shell</p>` +
       `<div bf-region="r:9" id="inner"><p id="ii">B</p></div></div>`,
-    tag: ['oo', 'ii'],
     replaced: ['oo', 'ii'],
-    text: { ii: 'B' },
+    textAfter: { ii: 'B' },
   },
 ]
 
@@ -244,20 +237,22 @@ describe('@barefootjs/router v2 — nested / sibling regions', () => {
       document.body.innerHTML = c.current
       mockFetch(fullDoc(c.incoming))
       router = startRouter({ rehydrate: () => {}, dispose: () => {} })
-      c.mutate?.()
-      for (const id of c.tag ?? []) tag(id)
+      c.islandMutates?.()
+      // Tag every node an expectation refers to, so we can tell a surviving live
+      // node from a freshly rendered one of the same id after the navigation.
+      for (const id of [...(c.survives ?? []), ...(c.replaced ?? [])]) tag(id)
 
       await navigate('/b')
       await flush()
 
-      if (c.hardNavigate) expect(assigned).toContain('/b')
+      if (c.fallsBackToReload) expect(assigned).toContain('/b')
       else expect(assigned).toBe('')
-      for (const id of c.preserved ?? []) expect(marker(id)).toBe(MARK)
+      for (const id of c.survives ?? []) expect(marker(id)).toBe(MARK)
       for (const id of c.replaced ?? []) expect(marker(id)).toBeUndefined()
-      for (const [id, t] of Object.entries(c.text ?? {})) {
+      for (const [id, t] of Object.entries(c.textAfter ?? {})) {
         expect(document.getElementById(id)?.textContent).toBe(t)
       }
-      if (c.path) expect(window.location.pathname).toBe(c.path)
+      if (c.committedPath) expect(window.location.pathname).toBe(c.committedPath)
     })
   }
 })

--- a/packages/router/src/region.ts
+++ b/packages/router/src/region.ts
@@ -1,13 +1,23 @@
 /**
- * Read a fetched page and lift out the swappable region subtree.
+ * Read a fetched page and lift out the swappable region subtree(s).
  *
  * The router fetches an ordinary full-page HTML response (no protocol header),
- * parses it client-side, and extracts the `[bf-region]` children. Island module
- * scripts (`<script type=module src>`) sit at body-end, outside the region, so
- * they are collected from the whole parsed document.
+ * parses it client-side, and matches its `[bf-region]` boundaries against the
+ * live document. v0 swaps a single broad region; v2 matches compiler-derived
+ * nested/sibling regions by their stable `bf-region` id and swaps only the
+ * deepest ones whose *owned* content differs (spec/router.md "Regions"). Island
+ * module scripts (`<script type=module src>`) sit at body-end, outside any
+ * region, so they are collected from the whole parsed document.
  */
 
-import type { RegionContent, RouterState } from './types.ts'
+import { BF_REGION } from '@barefootjs/shared'
+import type { RouterState } from './types.ts'
+
+/** Parse a fetched page's HTML into a detached document. */
+export function parseDocument(html: string): Document {
+  return new DOMParser().parseFromString(html, 'text/html')
+}
+
 
 /**
  * Same-origin absolute URLs of `<script type=module src>` in a tree, resolved
@@ -31,27 +41,105 @@ export function collectModuleScripts(root: ParentNode, baseUrl: string): Set<str
   return out
 }
 
-export function extractRegion(
-  html: string,
+/** A swap target: a live region element and its counterpart in the incoming doc. */
+export interface RegionSwap {
+  current: Element
+  incoming: Element
+}
+
+export type SwapPlan =
+  /** Matched compiler-derived regions: swap exactly `targets` (may be empty when nothing changed). */
+  | { mode: 'regions'; targets: RegionSwap[] }
+  /** Region ids don't line up (or collide): fall back to the single broadest-region swap (v0). */
+  | { mode: 'broadest' }
+
+/**
+ * Index every `[bf-region]` in `root` by its `bf-region` id. Returns `null` if
+ * two regions share an id — they can't be matched 1:1 across documents, so the
+ * caller falls back to the broadest single-region swap.
+ */
+function indexRegions(root: ParentNode, selector: string): Map<string, Element> | null {
+  const map = new Map<string, Element>()
+  for (const el of root.querySelectorAll(selector)) {
+    const id = el.getAttribute(BF_REGION) ?? ''
+    if (map.has(id)) return null
+    map.set(id, el)
+  }
+  return map
+}
+
+/**
+ * A region's **owned** content: its inner HTML with every *nested* `[bf-region]`
+ * subtree masked out (replaced by an id-keyed placeholder). Two regions compare
+ * equal when only their nested regions' interiors differ — so an outer region
+ * stays mounted when just an inner region changed (the deepest differing region
+ * is the one that swaps).
+ */
+export function ownedContentKey(region: Element, selector: string): string {
+  const clone = region.cloneNode(true) as Element
+  // `querySelectorAll` on the clone returns descendants only (not the clone
+  // itself), so this masks nested regions, not this one.
+  for (const nested of Array.from(clone.querySelectorAll(selector))) {
+    // A deeper region already vanished when its ancestor region was masked.
+    if (!clone.contains(nested)) continue
+    const mask = (clone.ownerDocument ?? document).createElement('bf-region-mask')
+    mask.setAttribute('data-id', nested.getAttribute(BF_REGION) ?? '')
+    nested.replaceWith(mask)
+  }
+  return clone.innerHTML
+}
+
+/**
+ * Decide which regions to swap between the live document and a parsed incoming
+ * document. When both expose the **same set** of region ids, swap the *topmost*
+ * regions whose owned content differs (an ancestor swap rebuilds its nested
+ * regions, so a nested candidate inside another candidate is dropped). When the
+ * id sets differ or collide, fall back to the broadest single-region swap.
+ */
+export function planRegionSwaps(
+  currentRoot: ParentNode,
+  incomingRoot: ParentNode,
   selector: string,
-  baseUrl: string,
-): RegionContent | null {
-  const doc = new DOMParser().parseFromString(html, 'text/html')
-  const region = doc.querySelector(selector)
-  if (!region) return null // not part of this shell → caller hard-navigates
-  const title = doc.querySelector('title')?.textContent ?? null
-  const moduleSrcs = [...collectModuleScripts(doc, baseUrl)]
-  // Adopt the parsed nodes into the live document so they're ready to insert.
-  const nodes = Array.from(region.childNodes).map((n) => document.importNode(n, true))
-  return { nodes, title, moduleSrcs }
+): SwapPlan {
+  const cur = indexRegions(currentRoot, selector)
+  const inc = indexRegions(incomingRoot, selector)
+  if (!cur || !inc || !sameKeys(cur, inc)) return { mode: 'broadest' }
+
+  const candidates: RegionSwap[] = []
+  for (const [id, current] of cur) {
+    const incoming = inc.get(id) as Element
+    if (ownedContentKey(current, selector) !== ownedContentKey(incoming, selector)) {
+      candidates.push({ current, incoming })
+    }
+  }
+  // Drop any candidate nested inside another candidate (in the live document):
+  // swapping the ancestor replaces it anyway.
+  const targets = candidates.filter(
+    (c) => !candidates.some((o) => o !== c && o.current.contains(c.current)),
+  )
+  return { mode: 'regions', targets }
+}
+
+function sameKeys(a: Map<string, unknown>, b: Map<string, unknown>): boolean {
+  if (a.size !== b.size) return false
+  for (const k of a.keys()) if (!b.has(k)) return false
+  return true
+}
+
+/**
+ * Adopt an incoming region's child nodes into the live document so they're ready
+ * to insert (the parsed nodes belong to a detached document).
+ */
+export function importRegionChildren(incoming: Element): Node[] {
+  return Array.from(incoming.childNodes).map((n) => document.importNode(n, true))
 }
 
 /**
  * Prefetch-path read: parse once, confirm the page belongs to this shell, and
- * return only its island module srcs (resolved against `baseUrl`). Unlike
- * {@link extractRegion} this does **not** clone/import the region's child nodes
- * — prefetch only needs the module list, and importing a large region's subtree
- * is wasted work. Returns `null` when the page has no region.
+ * return only its island module srcs (resolved against `baseUrl`). It does
+ * **not** clone/import any region subtree — prefetch only needs the module list,
+ * and importing a large region is wasted work. Returns `null` when the page has
+ * no region.
  */
 export function collectRegionModuleSrcs(
   html: string,

--- a/packages/router/src/region.ts
+++ b/packages/router/src/region.ts
@@ -10,7 +10,7 @@
  * region, so they are collected from the whole parsed document.
  */
 
-import { BF_REGION } from '@barefootjs/shared'
+import { BF_HOST, BF_REGION, BF_SCOPE, BF_SCOPE_COMMENT_PREFIX } from '@barefootjs/shared'
 import type { RouterState } from './types.ts'
 
 /** Parse a fetched page's HTML into a detached document. */
@@ -75,10 +75,20 @@ function indexRegions(root: ParentNode, selector: string): Map<string, Element> 
 
 /**
  * A region's **owned** content: its inner HTML with every *nested* `[bf-region]`
- * subtree masked out (replaced by an id-keyed placeholder). Two regions compare
- * equal when only their nested regions' interiors differ — so an outer region
- * stays mounted when just an inner region changed (the deepest differing region
- * is the one that swaps).
+ * subtree masked out (replaced by an id-keyed placeholder), and with per-render
+ * **volatile hydration scaffolding** normalized away. Two regions compare equal
+ * when only their nested regions' interiors differ — so an outer region stays
+ * mounted when just an inner region changed (the deepest differing region is the
+ * one that swaps).
+ *
+ * The normalization matters: a top-level island's scope id is randomized per
+ * server render (`<div bf-s="Counter_a1b2c3">`), so two renders of the *same*
+ * region are never byte-identical. Comparing raw `innerHTML` would flag every
+ * region containing an island as "changed" and swap away its state — the
+ * opposite of v2's goal. The diff therefore compares *content*, ignoring the
+ * scope-id-carrying markers (`bf-s`, `bf-h`, and the id inside `bf-scope:`
+ * comments); the structural markers (`bf` slot refs, `bf-m` slot ids, `bf-r`)
+ * and any props stay, so a real content/prop change is still detected.
  */
 export function ownedContentKey(region: Element, selector: string): string {
   const clone = region.cloneNode(true) as Element
@@ -91,7 +101,41 @@ export function ownedContentKey(region: Element, selector: string): string {
     mask.setAttribute('data-id', nested.getAttribute(BF_REGION) ?? '')
     nested.replaceWith(mask)
   }
+  stripVolatileHydration(clone)
   return clone.innerHTML
+}
+
+/** Hydration attributes carrying a per-render-random scope id — ignored by the diff. */
+const VOLATILE_ATTRS = [BF_SCOPE, BF_HOST]
+
+/** Strip per-render-volatile hydration scaffolding so the diff compares content, not scope ids. */
+function stripVolatileHydration(root: Element): void {
+  for (const a of VOLATILE_ATTRS) root.removeAttribute(a)
+  const walker = (root.ownerDocument ?? document).createTreeWalker(
+    root,
+    NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_COMMENT,
+  )
+  while (walker.nextNode()) {
+    const node = walker.currentNode
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      for (const a of VOLATILE_ATTRS) (node as Element).removeAttribute(a)
+    } else if ((node as Comment).data.startsWith(BF_SCOPE_COMMENT_PREFIX)) {
+      ;(node as Comment).data = normalizeScopeComment((node as Comment).data)
+    }
+  }
+}
+
+/**
+ * Normalize a `bf-scope:<scopeId>[|h=<host>][|m=<slot>][|<props>]` comment: blank
+ * the random `<scopeId>` and drop any `h=<host>` host token (both per-render
+ * volatile), keeping the structural slot (`m=`) and props so a real prop change
+ * is still detected.
+ */
+function normalizeScopeComment(data: string): string {
+  const parts = data.slice(BF_SCOPE_COMMENT_PREFIX.length).split('|')
+  parts[0] = '' // scope id → blanked
+  const kept = parts.filter((p, i) => i === 0 || !p.startsWith('h='))
+  return BF_SCOPE_COMMENT_PREFIX + kept.join('|')
 }
 
 /**

--- a/packages/router/src/region.ts
+++ b/packages/router/src/region.ts
@@ -200,6 +200,21 @@ function sameKeys(a: Map<string, unknown>, b: Map<string, unknown>): boolean {
 }
 
 /**
+ * True when `region` contains every other `[bf-region]` in its document — i.e.
+ * it is a single root whose swap rebuilds them all. Used by the broadest
+ * fallback: a root may be swapped wholesale (the v0 behaviour), but if the
+ * regions are siblings a single swap would only half-update the page, so the
+ * caller hard-navigates instead.
+ */
+export function isRootRegion(region: Element, selector: string): boolean {
+  const root = region.ownerDocument ?? document
+  for (const el of root.querySelectorAll(selector)) {
+    if (el !== region && !region.contains(el)) return false
+  }
+  return true
+}
+
+/**
  * Adopt an incoming region's child nodes into the live document so they're ready
  * to insert (the parsed nodes belong to a detached document).
  */

--- a/packages/router/src/region.ts
+++ b/packages/router/src/region.ts
@@ -48,8 +48,13 @@ export interface RegionSwap {
 }
 
 export type SwapPlan =
-  /** Matched compiler-derived regions: swap exactly `targets` (may be empty when nothing changed). */
-  | { mode: 'regions'; targets: RegionSwap[] }
+  /**
+   * Matched compiler-derived regions: swap exactly `targets` (may be empty when
+   * nothing changed). `incomingKeys` is the owned-content key per matched region
+   * id from the **incoming server render** — the caller commits it as the new
+   * per-region baseline (see {@link planRegionSwaps}).
+   */
+  | { mode: 'regions'; targets: RegionSwap[]; incomingKeys: Map<string, string> }
   /** Region ids don't line up (or collide): fall back to the single broadest-region swap (v0). */
   | { mode: 'broadest' }
 
@@ -95,29 +100,53 @@ export function ownedContentKey(region: Element, selector: string): string {
  * regions whose owned content differs (an ancestor swap rebuilds its nested
  * regions, so a nested candidate inside another candidate is dropped). When the
  * id sets differ or collide, fall back to the broadest single-region swap.
+ *
+ * The "differs" test compares the incoming region's **server-rendered** owned
+ * content against `baselines` — the owned-content key captured from the server
+ * render currently displayed in that region — **not** the live DOM. A live
+ * region's DOM may have been mutated by its islands (signal-driven updates), so
+ * comparing against it would flag an unchanged region as changed and swap away
+ * its state — the opposite of v2's goal. The caller seeds `baselines` from the
+ * initial document and refreshes it from `incomingKeys` after each navigation.
+ * A region missing from `baselines` falls back to its live owned content.
  */
 export function planRegionSwaps(
   currentRoot: ParentNode,
   incomingRoot: ParentNode,
   selector: string,
+  baselines: ReadonlyMap<string, string>,
 ): SwapPlan {
   const cur = indexRegions(currentRoot, selector)
   const inc = indexRegions(incomingRoot, selector)
   if (!cur || !inc || !sameKeys(cur, inc)) return { mode: 'broadest' }
 
+  const incomingKeys = new Map<string, string>()
   const candidates: RegionSwap[] = []
   for (const [id, current] of cur) {
     const incoming = inc.get(id) as Element
-    if (ownedContentKey(current, selector) !== ownedContentKey(incoming, selector)) {
-      candidates.push({ current, incoming })
-    }
+    const incomingKey = ownedContentKey(incoming, selector)
+    incomingKeys.set(id, incomingKey)
+    const baseline = baselines.get(id) ?? ownedContentKey(current, selector)
+    if (incomingKey !== baseline) candidates.push({ current, incoming })
   }
   // Drop any candidate nested inside another candidate (in the live document):
   // swapping the ancestor replaces it anyway.
   const targets = candidates.filter(
     (c) => !candidates.some((o) => o !== c && o.current.contains(c.current)),
   )
-  return { mode: 'regions', targets }
+  return { mode: 'regions', targets, incomingKeys }
+}
+
+/**
+ * Capture the owned-content key of every `[bf-region]` in `root`, keyed by id —
+ * the per-region server-render baseline the swap planner compares against.
+ */
+export function captureRegionBaselines(root: ParentNode, selector: string): Map<string, string> {
+  const out = new Map<string, string>()
+  for (const el of root.querySelectorAll(selector)) {
+    out.set(el.getAttribute(BF_REGION) ?? '', ownedContentKey(el, selector))
+  }
+  return out
 }
 
 function sameKeys(a: Map<string, unknown>, b: Map<string, unknown>): boolean {

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -13,8 +13,11 @@ import { loadPage } from './cache.ts'
 import {
   collectModuleScripts,
   collectRegionModuleSrcs,
-  extractRegion,
+  importRegionChildren,
   loadNewModules,
+  parseDocument,
+  planRegionSwaps,
+  type RegionSwap,
 } from './region.ts'
 import { buildMorphedContent } from './morph.ts'
 import {
@@ -239,46 +242,64 @@ export async function navigate(url: string, options: NavigateOptions = {}): Prom
     }
     const finalUrl = snap.finalUrl
 
-    // Resolve the incoming document's module srcs against the response's final
-    // URL (after redirects), not the current location.
-    const content = extractRegion(snap.html, state.regionSelector, finalUrl)
-    const current = document.querySelector(state.regionSelector)
-    if (!content || !current) {
-      hardNavigate(finalUrl)
-      return
+    // Parse the incoming page once. Module srcs are collected from the whole
+    // document and resolved against the response's final URL (after redirects),
+    // not the current location.
+    const incomingDoc = parseDocument(snap.html)
+    const title = incomingDoc.querySelector('title')?.textContent ?? null
+    const moduleSrcs = [...collectModuleScripts(incomingDoc, finalUrl)]
+
+    // Decide the swap point(s). When the compiler-derived region ids line up
+    // across both documents, swap only the deepest regions whose owned content
+    // differs (nested/sibling, spec v2); otherwise fall back to the single
+    // broadest region (v0).
+    const plan = planRegionSwaps(document, incomingDoc, state.regionSelector)
+    let targets: RegionSwap[]
+    if (plan.mode === 'regions') {
+      targets = plan.targets
+    } else {
+      const current = document.querySelector(state.regionSelector)
+      const incoming = incomingDoc.querySelector(state.regionSelector)
+      if (!current || !incoming) {
+        hardNavigate(finalUrl)
+        return
+      }
+      targets = [{ current, incoming }]
     }
 
-    // Build the incoming tree (morph re-homes live `[data-bf-permanent]` nodes
-    // into it) and swap — both synchronous. A morph-preserved node therefore
-    // travels current → fragment → current without ever being detached across
-    // the dispose `await`: a navigation that supersedes this one still finds it
-    // under the region (last-wins safe), and an abort/throw during dispose can't
-    // leave it orphaned. With no permanent nodes this is a plain `replaceChildren`.
-    const fragment = state.morph
-      ? buildMorphedContent(current, content.nodes)
-      : toFragment(content.nodes)
-    // A shallow clone of the region element (its tag, attributes, id, classes —
-    // e.g. `main[bf-region]`) so a custom `dispose` sees the same shell it ran
-    // against on first mount, not a bare `<div>`.
-    const outgoing = current.cloneNode(false) as Element
-    // Move every current child into the holder. An explicit drain (rather than
-    // `append(...current.childNodes)`) is unambiguous about not skipping nodes
-    // while the live `childNodes` shrinks.
-    while (current.firstChild) outgoing.append(current.firstChild)
-    current.replaceChildren(fragment)
-    if (content.title !== null) document.title = content.title
+    // Swap every target synchronously, before any `await`. A morph-preserved
+    // node therefore travels current → fragment → current without ever being
+    // detached across the dispose `await`: a navigation that supersedes this
+    // one still finds it under its region (last-wins safe), and an abort/throw
+    // during dispose can't leave it orphaned. Each `outgoing` is a shallow clone
+    // of its region element (tag, attributes, id, classes — e.g.
+    // `main[bf-region]`) so a custom `dispose` sees the same shell it ran
+    // against on first mount, not a bare `<div>`. With no permanent nodes and a
+    // single region this is exactly the v0 `replaceChildren` swap.
+    const swapped: { region: Element; outgoing: Element }[] = []
+    for (const { current, incoming } of targets) {
+      const nodes = importRegionChildren(incoming)
+      const fragment = state.morph ? buildMorphedContent(current, nodes) : toFragment(nodes)
+      const outgoing = current.cloneNode(false) as Element
+      // An explicit drain (rather than `append(...current.childNodes)`) is
+      // unambiguous about not skipping nodes while the live `childNodes` shrinks.
+      while (current.firstChild) outgoing.append(current.firstChild)
+      current.replaceChildren(fragment)
+      swapped.push({ region: current, outgoing })
+    }
+    if (title !== null) document.title = title
 
-    // Dispose the outgoing islands. They're now detached in `outgoing`, and the
-    // swap is already committed, so a superseded navigation just skips the
+    // Dispose the outgoing islands. They're now detached in each `outgoing`, and
+    // the swaps are already committed, so a superseded navigation just skips the
     // remaining work below — it never has to undo a DOM mutation. With `morph`,
     // any matched `[data-bf-permanent]` node was moved into the new tree above,
     // so it isn't here; with `morph: false` the permanent nodes stay in
     // `outgoing` and are disposed normally.
-    await state.dispose(outgoing)
+    await Promise.all(swapped.map(({ outgoing }) => state.dispose(outgoing)))
     if (controller.signal.aborted) return
 
     // Register any island modules this response introduced before hydrating.
-    await loadNewModules(state, content.moduleSrcs)
+    await loadNewModules(state, moduleSrcs)
     if (controller.signal.aborted) return
 
     if (mode === 'push') commitHistory('push', finalUrl)
@@ -290,17 +311,19 @@ export async function navigate(url: string, options: NavigateOptions = {}): Prom
 
     if (state.scrollToTop) window.scrollTo(0, 0)
 
-    // Re-hydrate the freshly inserted islands (subtree-scoped).
-    await state.rehydrate(current)
+    // Re-hydrate the freshly inserted islands (subtree-scoped, per region).
+    await Promise.all(swapped.map(({ region }) => state.rehydrate(region)))
     // `rehydrate` may await (a dynamic import); a newer navigation could have
     // superseded us in the meantime — don't run a11y side effects on what is
     // now stale content.
     if (controller.signal.aborted) return
 
-    // Accessibility: move focus into the new region and announce the route.
-    if (state.manageFocus) {
-      focusRegion(current)
-      announceNavigation(content.title)
+    // Accessibility: move focus into the first swapped region (the broadest /
+    // topmost in document order) and announce the route. A navigation with no
+    // changed region (targets empty) still committed history + title above.
+    if (state.manageFocus && swapped.length > 0) {
+      focusRegion(swapped[0].region)
+      announceNavigation(title)
     }
   } finally {
     if (state.inflight === controller) state.inflight = null

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -11,6 +11,7 @@
 import { BF_REGION } from '@barefootjs/shared'
 import { loadPage } from './cache.ts'
 import {
+  captureRegionBaselines,
   collectModuleScripts,
   collectRegionModuleSrcs,
   importRegionChildren,
@@ -67,6 +68,9 @@ export function startRouter(options: RouterOptions = {}): Router {
     scrollToTop: options.scrollToTop ?? true,
     manageFocus: options.manageFocus ?? true,
     morph: options.morph ?? true,
+    // Seed the per-region baselines from the initial document's server render
+    // (captured before islands mutate the DOM). Refreshed after each navigation.
+    regionBaselines: captureRegionBaselines(document, options.region ?? `[${BF_REGION}]`),
     currentPath: window.location.pathname,
     inflight: null,
     hoverTimer: null,
@@ -253,7 +257,7 @@ export async function navigate(url: string, options: NavigateOptions = {}): Prom
     // across both documents, swap only the deepest regions whose owned content
     // differs (nested/sibling, spec v2); otherwise fall back to the single
     // broadest region (v0).
-    const plan = planRegionSwaps(document, incomingDoc, state.regionSelector)
+    const plan = planRegionSwaps(document, incomingDoc, state.regionSelector, state.regionBaselines)
     let targets: RegionSwap[]
     if (plan.mode === 'regions') {
       targets = plan.targets
@@ -289,13 +293,26 @@ export async function navigate(url: string, options: NavigateOptions = {}): Prom
     }
     if (title !== null) document.title = title
 
-    // Dispose the outgoing islands. They're now detached in each `outgoing`, and
-    // the swaps are already committed, so a superseded navigation just skips the
-    // remaining work below — it never has to undo a DOM mutation. With `morph`,
-    // any matched `[data-bf-permanent]` node was moved into the new tree above,
-    // so it isn't here; with `morph: false` the permanent nodes stay in
-    // `outgoing` and are disposed normally.
-    await Promise.all(swapped.map(({ outgoing }) => state.dispose(outgoing)))
+    // Refresh the per-region baselines to the server render now displayed: from
+    // the incoming keys (matched regions), else recaptured from the live DOM
+    // (the broadest fallback just inserted fresh server content). Done right
+    // after the synchronous swaps so a superseded navigation that bails below
+    // still leaves baselines consistent with the committed DOM.
+    if (plan.mode === 'regions') {
+      for (const [id, key] of plan.incomingKeys) state.regionBaselines.set(id, key)
+    } else {
+      state.regionBaselines = captureRegionBaselines(document, state.regionSelector)
+    }
+
+    // Dispose the outgoing islands, sequentially in document order. `dispose` is
+    // user-overridable and may do global teardown or assume single-call
+    // ordering, so we never run several in parallel (the region count is small).
+    // Each `outgoing` is already detached and the swaps are committed, so a
+    // superseded navigation just skips the remaining work below — it never has
+    // to undo a DOM mutation. With `morph`, any matched `[data-bf-permanent]`
+    // node was moved into the new tree above, so it isn't here; with
+    // `morph: false` the permanent nodes stay in `outgoing` and are disposed.
+    for (const { outgoing } of swapped) await state.dispose(outgoing)
     if (controller.signal.aborted) return
 
     // Register any island modules this response introduced before hydrating.
@@ -311,8 +328,11 @@ export async function navigate(url: string, options: NavigateOptions = {}): Prom
 
     if (state.scrollToTop) window.scrollTo(0, 0)
 
-    // Re-hydrate the freshly inserted islands (subtree-scoped, per region).
-    await Promise.all(swapped.map(({ region }) => state.rehydrate(region)))
+    // Re-hydrate the freshly inserted islands (subtree-scoped, per region),
+    // sequentially in document order — like `dispose`, `rehydrate` is
+    // user-overridable and may touch shared global state, so parallel runs are
+    // avoided (the region count is small).
+    for (const { region } of swapped) await state.rehydrate(region)
     // `rehydrate` may await (a dynamic import); a newer navigation could have
     // superseded us in the meantime — don't run a11y side effects on what is
     // now stale content.

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -15,6 +15,7 @@ import {
   collectModuleScripts,
   collectRegionModuleSrcs,
   importRegionChildren,
+  isRootRegion,
   loadNewModules,
   parseDocument,
   planRegionSwaps,
@@ -262,9 +263,14 @@ export async function navigate(url: string, options: NavigateOptions = {}): Prom
     if (plan.mode === 'regions') {
       targets = plan.targets
     } else {
+      // Ids diverge or collide. Swap the broadest region only if it is a true
+      // root containing every other region (one swap rebuilds them all — the v0
+      // single-region behaviour). If the regions are siblings, a single swap
+      // would half-update the page, so hard-navigate instead (never worse than
+      // an MPA).
       const current = document.querySelector(state.regionSelector)
       const incoming = incomingDoc.querySelector(state.regionSelector)
-      if (!current || !incoming) {
+      if (!current || !incoming || !isRootRegion(current, state.regionSelector)) {
         hardNavigate(finalUrl)
         return
       }

--- a/packages/router/src/types.ts
+++ b/packages/router/src/types.ts
@@ -122,6 +122,13 @@ export interface RouterState {
   shouldIntercept: (anchor: HTMLAnchorElement, event: Event) => boolean
   scrollToTop: boolean
   manageFocus: boolean
+  /**
+   * Per-region server-render baseline: `bf-region` id → owned-content key of the
+   * server render currently displayed there. The swap planner compares an
+   * incoming region against this (not the island-mutated live DOM) so an
+   * unchanged region keeps its state; refreshed after each navigation.
+   */
+  regionBaselines: Map<string, string>
   morph: boolean
   /** Pathname of the currently-displayed region (for the query-only short-circuit). */
   currentPath: string

--- a/packages/router/src/types.ts
+++ b/packages/router/src/types.ts
@@ -101,13 +101,6 @@ export interface CacheEntry {
   refreshing: boolean
 }
 
-/** The swappable content lifted out of a fetched page. */
-export interface RegionContent {
-  nodes: Node[]
-  title: string | null
-  moduleSrcs: string[]
-}
-
 /** Mutable state for the one active router instance. */
 export interface RouterState {
   regionSelector: string


### PR DESCRIPTION
## Router v2 — compiler-derived nested / sibling regions

Completes the **v2** milestone (spec/router.md "Regions"). The compiler-side half already shipped — `<Region>` lowering in `jsx-to-ir.ts`, `BF_REGION` + `IRElement.regionId`, the stable `bf-region="<file scope>:<index>"` id, and the cross-adapter `region-boundary` fixture. **This PR adds the runtime half.**

### What changes

When a fetched page exposes the **same `bf-region` ids** as the live document, the router swaps only the **deepest regions whose *owned* content differs**, instead of always replacing the single broadest region (v0):

- **Nested** `<Region>…<Region/>…</Region>` — a change confined to an inner region swaps only the inner; the outer shell (island state, scroll, focus) persists. An outer change rebuilds it, with its nested regions riding along.
- **Sibling** `<><Region/><Region/></>` — independent regions (master–detail): the region that changed swaps while the other keeps its live DOM/state. Both swap in one navigation when both differ.

Placement encodes nested vs sibling — nothing is declared. Composes with **v1** `data-bf-permanent` morphing.

### How

- `region.ts`: `indexRegions` (id → element; `null` on id collision), `ownedContentKey` (a region's `innerHTML` with nested `[bf-region]` subtrees masked by id, so an outer region compares equal when only an inner one changed), `planRegionSwaps` (topmost differing candidates, or a `broadest` fallback when the id sets diverge), `importRegionChildren`, `parseDocument`. Drops the single-region `extractRegion`.
- `router.ts` `navigate()`: parse the incoming doc once → plan targets → **swap every target synchronously before any `await`** (last-wins safe) → dispose all outgoing holders → load modules → rehydrate each swapped region. Focus moves to the first (topmost) swapped region; a no-change navigation still commits history + title.

### Correct-by-default fallback

When the two documents' region-id sets don't line up (or an id collides), the router falls back to the v0 single broadest-region swap — never worse than before. The existing `<main bf-region>` (no id) example keeps working unchanged.

### Tests

`packages/router/__tests__/router-regions.test.ts` — 6 new tests (sibling: one swaps / both swap; nested: inner-only swap with outer persisted / outer change rebuilds inner; id-mismatch → broadest fallback; no-change → history committed without swap). **40 router tests pass**, biome clean, build + types green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPrN8vCxmBqKcVRVYPnUu2

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPrN8vCxmBqKcVRVYPnUu2)_