### PR TITLE
docs(router): router-blog v2 sibling-region demo (stacked on #1925)

### DIFF
--- a/integrations/router-blog/README.md
+++ b/integrations/router-blog/README.md
@@ -1,16 +1,17 @@
 # Router blog — `@barefootjs/router` reference (real-component edition)
 
 A small blog built on [`@barefootjs/router`](../../packages/router) for
-**automatic partial navigation**: clicking a post swaps only the
-`<main bf-region>` content and leaves the page shell mounted; clicking a
+**automatic partial navigation**: clicking a post swaps only the content region
+and leaves the page shell — and a sibling sidebar region — mounted; clicking a
 `?sort=` / `?tag=` link re-orders/filters the list **reactively with no region
-swap at all**; and a marked mini-player keeps **playing across a navigation**.
+swap at all**; a marked mini-player keeps **playing across a navigation**; and a
+sidebar island **keeps its state** while the article beside it swaps.
 
 Every island here is a **real compiled BarefootJS `"use client"` component**
 hydrated by the **real `@barefootjs/client` runtime** — the router drives the
 actual `__bf_hydrate_within` / `__bf_dispose_within` seams, not a hand-written
 stand-in. So this doubles as an end-to-end integration test of the router's
-**v0 / v0.5 / v1** against the shipping compiler + runtime.
+**v0 / v0.5 / v1 / v2** against the shipping compiler + runtime.
 
 ![home](./screenshots/01-home.png)
 
@@ -24,8 +25,10 @@ stand-in. So this doubles as an end-to-end integration test of the router's
 | ![persist](./screenshots/04-permanent-persist.png) | **v1** After paging to the next post (post 9, `partial navs 2`): the player's clock **continued to `1.5s`** — the same live node was moved across the swap — while the unmarked ⏱ reading timer **reset** to `0.7s`. Same region, same swap, only the marker differs. |
 
 The header is the proof of v0's persistent shell: its uptime clock and theme
-toggle start **once**. A full reload would reset them. Only `<main bf-region>`
-is replaced.
+toggle start **once**. A full reload would reset them. The page below it is two
+sibling regions (sidebar + content); only the region whose content differs is
+replaced. (Run `bun run scripts/capture.ts` to regenerate the screenshots,
+including the sibling-region view.)
 
 ## Components (all real `"use client"`)
 
@@ -33,11 +36,12 @@ is replaced.
 |---|---|---|
 | `ShellStats` | shell | uptime clock + a `MutationObserver` partial-nav counter + live-island gauge |
 | `ThemeToggle` | shell | flips `data-theme`; the choice survives navigation |
-| `PostList` | region | the index; reads `searchParams()` to sort/filter with no swap; reactive sort/tag bars |
-| `PostListItem` | region | one keyed row with a local pin toggle (state survives re-sort) |
-| `LikeButton` | region | local like counter — re-created per navigation |
-| `ReadingTimer` | region | a `setInterval` timer wired through `onCleanup` — the **disposal** stress case |
-| `NowPlaying` | region | a mini-player whose root carries `data-bf-permanent` — the **v1 persistence** case (live node + state survive a swap) |
+| `Sidebar` | `nav:0` region | a pin counter in a sibling region — its state survives while the content region swaps (the **v2** case) |
+| `PostList` | `content:1` region | the index; reads `searchParams()` to sort/filter with no swap; reactive sort/tag bars |
+| `PostListItem` | `content:1` region | one keyed row with a local pin toggle (state survives re-sort) |
+| `LikeButton` | `content:1` region | local like counter — re-created per navigation |
+| `ReadingTimer` | `content:1` region | a `setInterval` timer wired through `onCleanup` — the **disposal** stress case |
+| `NowPlaying` | `content:1` region | a mini-player whose root carries `data-bf-permanent` — the **v1 persistence** case (live node + state survive a swap) |
 
 ## How it works
 
@@ -74,9 +78,10 @@ imports at runtime (`@barefootjs/shared`, `@barefootjs/jsx`,
 `searchParams()` imports it). Run `setup` once; after that, iterate with
 `bun run build && bun run serve` (or just `bun run serve`).
 
-Verify behavior in a real browser (drives the router through **22 assertions** —
+Verify behavior in a real browser (drives the router through **27 assertions** —
 region swap, shell persistence, `searchParams()` no-swap sort/filter, pin
-survival, disposal, back/forward, `data-bf-permanent` persistence, console
+survival, disposal, back/forward, `data-bf-permanent` persistence, sibling-region
+persistence, console
 errors):
 
 ```sh
@@ -113,6 +118,30 @@ unmarked `ReadingTimer` right beside it resets on the same swap — same region,
 same navigation, the only difference is the marker. `verify.ts` proves the node
 is the **same live instance** (a marker set on it via `evaluate` survives the
 swap), not just equal text.
+
+## v2 — sibling regions (master–detail)
+
+The page below the header is **two sibling regions**: `<aside bf-region="nav:0">`
+(the `Sidebar` island) and `<main bf-region="content:1">` (the article / list).
+Both pages render both regions, so the router matches them by id and swaps only
+the one whose content differs. Bump the sidebar's 📌 pin counter, then open a
+post: the content region swaps while the **sidebar island is never disposed** —
+its count survives. `verify.ts` proves it is the same live node (a marker set via
+`evaluate` survives the swap).
+
+This is the case a single-region (v0) router cannot express: with two regions it
+would swap the *first* one (the sidebar) and never update the article. Two notes
+on how the match stays robust:
+
+- The ids are written by hand in `renderer.tsx` because that layout is a plain
+  Hono SSR template, not a compiled component tree; in `bf build` output the
+  `<Region>` component lowers to the same deterministic
+  `bf-region="<file scope>:<index>"` ids. The runtime only needs them equal
+  across page documents.
+- A top-level island's `bf-s` scope id is **randomized per server render**, so a
+  region's markup is never byte-identical across pages. The router's owned-content
+  diff normalizes that scaffolding away (it compares content + props, not scope
+  ids), so the unchanged sidebar is correctly left mounted.
 
 ## Integration gaps this surfaced (now shipped in v0 / v0.5)
 

--- a/integrations/router-blog/components/ShellStats.tsx
+++ b/integrations/router-blog/components/ShellStats.tsx
@@ -3,13 +3,16 @@
 import { createSignal, onMount, onCleanup } from '@barefootjs/client'
 
 /**
- * A SHELL island (outside `[bf-region]`) that proves the shell stays mounted
+ * A SHELL island (outside every region) that proves the shell stays mounted
  * across partial navigations:
  *
  *   - uptime — started once on first load; a full reload would reset it.
- *   - partial navs — a `MutationObserver` on the region ticks on every swap.
- *   - live islands — count of hydrated scopes (`[bf-s]`) inside the region,
- *     re-counted after each swap so disposal/re-hydration is observable.
+ *   - partial navs — a `MutationObserver` on the **content** region
+ *     (`main[bf-region]`) ticks on every swap. (The page also has a sibling
+ *     sidebar region that the router leaves mounted, so we watch the content
+ *     region specifically.)
+ *   - live islands — count of hydrated scopes (`[bf-s]`) inside the content
+ *     region, re-counted after each swap so disposal/re-hydration is observable.
  */
 export function ShellStats() {
   const [uptime, setUptime] = createSignal('0.0s')
@@ -21,7 +24,7 @@ export function ShellStats() {
     const handle = setInterval(() => setUptime(`${((Date.now() - start) / 1000).toFixed(1)}s`), 100)
     onCleanup(() => clearInterval(handle))
 
-    const region = document.querySelector('[bf-region]')
+    const region = document.querySelector('main[bf-region]')
     if (!region) return
     const recount = () => setIslands(region.querySelectorAll('[bf-s]').length)
     recount()

--- a/integrations/router-blog/components/Sidebar.tsx
+++ b/integrations/router-blog/components/Sidebar.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { createSignal } from '@barefootjs/client'
+
+/**
+ * The content of the **sidebar region** (`<aside bf-region="nav:0">`), a sibling
+ * of the main content region — a master–detail layout (spec/router.md **v2**).
+ *
+ * Because both pages render this region with the same id and the same content,
+ * its *owned content* never differs — the router's diff normalizes away the
+ * per-render `bf-s` scope ids, so it is not fooled by the non-byte-identical raw
+ * HTML — so it leaves the region mounted while it swaps only the differing
+ * content region. This local pin counter is the proof: bump it, navigate to a
+ * post, and it keeps its value — the sidebar island was never disposed.
+ *
+ * This is exactly the case a single-region (v0) router cannot express: with two
+ * `[bf-region]` boundaries it would swap the first one (here the sidebar) and
+ * never update the article. v2's id-keyed matching is what makes it work.
+ */
+export function Sidebar() {
+  const [pins, setPins] = createSignal(0)
+  return (
+    <div className="sidebar">
+      <div className="sidebar-title">Workspace</div>
+      <button className="sidebar-pin" type="button" onClick={() => setPins((n) => n + 1)}>
+        📌 pinned <span className="v">{pins()}</span>
+      </button>
+      <p className="sidebar-note">
+        This panel is its own region. It keeps its state while the article on the right swaps.
+      </p>
+    </div>
+  )
+}

--- a/integrations/router-blog/renderer.tsx
+++ b/integrations/router-blog/renderer.tsx
@@ -1,11 +1,23 @@
 /**
  * Layout for the router-blog.
  *
- * The shell (`<header>` with its islands) lives OUTSIDE `<main bf-region>`,
- * so a partial navigation never re-renders or re-hydrates it — the uptime
- * clock keeps climbing and the theme toggle keeps its state. Only the
- * `<main bf-region>` children are swapped by `@barefootjs/router` (its
- * default `[bf-region]` selector — the "single authored region", spec v0).
+ * The shell (`<header>` with its islands) lives OUTSIDE any region, so a
+ * partial navigation never re-renders or re-hydrates it — the uptime clock
+ * keeps climbing and the theme toggle keeps its state.
+ *
+ * Below it are **two sibling regions** (spec/router.md **v2**, master–detail):
+ *
+ *   - `<aside bf-region="nav:0">` — a persistent sidebar. Both pages render it
+ *     with the same id and the same content, so its *owned content* never
+ *     differs (the router's diff normalizes away the per-render `bf-s` scope
+ *     ids) and it is left mounted — its `Sidebar` island keeps its state.
+ *   - `<main bf-region="content:1">` — the swappable content. Only this region's
+ *     children change between pages, so it is the one the router swaps.
+ *
+ * The ids are written by hand here because this layout is a plain Hono SSR
+ * template, not a compiled component tree; in `bf build` output the `<Region>`
+ * component lowers to the same deterministic `bf-region="<file scope>:<index>"`
+ * ids. The runtime only needs them equal across page documents to match.
  *
  * `BfScripts` emits the runtime + island module scripts at body end; the
  * router reads those `<script type="module" src>` tags off each navigation
@@ -16,6 +28,7 @@ import { jsxRenderer } from 'hono/jsx-renderer'
 import { BfScripts } from '@barefootjs/hono/scripts'
 import { ShellStats } from '@/components/ShellStats'
 import { ThemeToggle } from '@/components/ThemeToggle'
+import { Sidebar } from '@/components/Sidebar'
 
 const STATIC = '/static/components'
 
@@ -49,7 +62,23 @@ export const renderer = jsxRenderer(({ children, title }) => {
             <ThemeToggle />
           </div>
         </header>
-        <main bf-region>{children}</main>
+        <div className="layout">
+          {/*
+            Two sibling regions. The `bf-region` ids are written BY HAND here
+            only because this layout is a plain Hono `jsxRenderer` template, not
+            a `bf build`-compiled component tree — so the `<Region>` component
+            (from `@barefootjs/client`) would not be lowered. In a compiled tree
+            you write `<Region>{children}</Region>` and the compiler emits a
+            deterministic `bf-region="<file-scope hash>:<index>"` id for you.
+            The router matches regions by plain string equality, so these
+            readable ids work identically — they only need to be the same across
+            every page that renders this layout.
+          */}
+          <aside bf-region="nav:0">
+            <Sidebar />
+          </aside>
+          <main bf-region="content:1">{children}</main>
+        </div>
         <BfScripts />
         <script type="module" src={`${STATIC}/router-entry.js`} />
       </body>
@@ -73,7 +102,16 @@ const STYLES = `
   .chip b { color: #58a6ff; font-variant-numeric: tabular-nums; }
   .toggle { cursor: pointer; background: #0d1117; border: 1px solid #30363d; color: #e6edf3; border-radius: 999px; padding: 5px 12px; font-size: 13px; }
   html[data-theme="light"] .toggle { background: #f6f8fa; border-color: #d0d7de; color: #1f2328; }
-  main { display: block; max-width: 760px; margin: 0 auto; padding: 32px 24px 80px; }
+  .layout { display: flex; gap: 28px; align-items: flex-start; max-width: 1000px; margin: 0 auto; padding: 32px 24px 80px; }
+  .layout main { flex: 1; min-width: 0; }
+  .layout aside { position: sticky; top: 78px; width: 210px; flex: none; }
+  html[data-theme="light"] .sidebar { background: #fff; border-color: #d0d7de; }
+  .sidebar { background: #161b22; border: 1px solid #30363d; border-radius: 12px; padding: 16px; }
+  .sidebar-title { font-weight: 700; font-size: 13px; text-transform: uppercase; letter-spacing: .04em; color: #8b949e; margin-bottom: 12px; }
+  .sidebar-pin { cursor: pointer; width: 100%; background: #0d1117; border: 1px solid #30363d; color: #f2cc60; border-radius: 8px; padding: 8px 12px; font-size: 14px; font-variant-numeric: tabular-nums; }
+  html[data-theme="light"] .sidebar-pin { background: #f6f8fa; border-color: #d0d7de; }
+  .sidebar-note { font-size: 12px; color: #6e7681; margin: 12px 0 0; }
+  @media (max-width: 720px) { .layout { flex-direction: column; } .layout aside { position: static; width: 100%; } }
   .page-title { font-size: 28px; margin: 0 0 6px; }
   .lede, .meta { color: #8b949e; }
   html[data-theme="light"] .lede, html[data-theme="light"] .meta { color: #57606a; }

--- a/integrations/router-blog/scripts/capture.ts
+++ b/integrations/router-blog/scripts/capture.ts
@@ -41,5 +41,16 @@ await page.click('.pager a.pager-link[href^="/posts/"]')
 await page.waitForTimeout(700)
 await shot('04-permanent-persist.png')
 
+// v2: bump the sidebar (its own region), then open a post — the content region
+// swaps while the sidebar island keeps its pin count.
+await page.goto(`${BASE}/`, { waitUntil: 'networkidle' })
+await page.waitForTimeout(500)
+await page.click('.sidebar-pin')
+await page.click('.sidebar-pin')
+await page.click('.sidebar-pin')
+await page.click('.sortable-list li:first-child .item-link')
+await page.waitForTimeout(500)
+await shot('05-sibling-region.png')
+
 await browser.close()
 console.log('Wrote screenshots/')

--- a/integrations/router-blog/scripts/verify.ts
+++ b/integrations/router-blog/scripts/verify.ts
@@ -140,7 +140,47 @@ try {
   const timerAfter = Number(await text('.island.timer .v'))
   check('unmarked timer resets on the same swap (contrast)', timerAfter < 0.5 && playerAfter > 0.5, `timer=${timerAfter} vs player=${playerAfter}`)
 
-  // ── 10. No console / page errors throughout ─────────────────────────────
+  // ── 10. v2: sibling regions — the sidebar persists while content swaps ───
+  // Fresh load so the sidebar island starts clean, then bump its local pin
+  // counter and client-navigate to a post. The sidebar is its own region
+  // (`nav:0`) with identical markup on both pages, so the router swaps only the
+  // content region (`content:1`) — the sidebar island is never disposed and its
+  // counter survives. (A single-region v0 router could not express this: it
+  // would swap the first region — the sidebar — and never update the article.)
+  await page.goto(`${BASE}/`, { waitUntil: 'networkidle' })
+  await page.waitForTimeout(200)
+  await page.click('.sidebar-pin')
+  await page.click('.sidebar-pin')
+  const pinsBefore = await text('.sidebar-pin .v')
+  check('sidebar island hydrated (pin counter)', pinsBefore === '2', `pins=${pinsBefore}`)
+  await page.$eval('aside[bf-region] .sidebar', (el) => {
+    ;(el as unknown as { __mark?: string }).__mark = 'KEEP'
+  })
+  const navsBeforeSidebar = await navCount()
+  await page.click('.sortable-list li:first-child .item-link') // → post: content swaps
+  // Wait for the content region's MutationObserver to tick, then read the count
+  // once — so the condition and the message use the same value (no double read
+  // racing the observer).
+  await page
+    .waitForFunction(
+      (before) =>
+        document.querySelector('.shell-stats .chip:nth-child(2) b')?.textContent !== before,
+      navsBeforeSidebar,
+      { timeout: 2000 },
+    )
+    .catch(() => {})
+  const navsAfterSidebar = await navCount()
+  check('content region swapped (partial nav)', navsAfterSidebar !== navsBeforeSidebar, `navs ${navsBeforeSidebar} → ${navsAfterSidebar}`)
+  check('article content swapped in (like island present)', (await page.locator('.island.like').count()) === 1)
+  const pinsAfter = await text('.sidebar-pin .v')
+  check('sidebar region persisted across the content swap (v2 sibling)', pinsAfter === '2', `pins=${pinsAfter}`)
+  const sidebarSame = await page.$eval(
+    'aside[bf-region] .sidebar',
+    (el) => (el as unknown as { __mark?: string }).__mark,
+  )
+  check('sidebar is the SAME live node (never disposed)', sidebarSame === 'KEEP', `mark=${sidebarSame}`)
+
+  // ── 11. No console / page errors throughout ─────────────────────────────
   check('no console or page errors', errors.length === 0, errors.slice(0, 3).join(' | '))
 } catch (e) {
   check('script ran to completion', false, String(e))


### PR DESCRIPTION
## router-blog: v2 sibling-region demo

Extends the router-blog reference app so it exercises the **v2** runtime end-to-end in a real browser, alongside v0/v0.5/v1 — every island is a real compiled `"use client"` component on the real runtime.

### What's new — sibling regions (master–detail)

The page is now **two sibling regions**: `<aside bf-region="nav:0">` (a `Sidebar` island with a 📌 pin counter) and `<main bf-region="content:1">` (the article / list). Both pages render both, so the router matches by id and swaps **only the content region** — the sidebar island is never disposed and **keeps its state**.

This is the case a single-region (v0) router cannot express: with two regions it would swap the *first* one (the sidebar) and never update the article.

### Verification

`scripts/verify.ts` drives real Chromium through **27 assertions, all green** — including the 5 new v2 ones: sidebar hydrates, content region swaps (`partial navs` ticks), and the sidebar's pin count + live node survive the swap.

```sh
cd integrations/router-blog && bun run start    # http://localhost:8788
PORT=8788 bun run server.tsx & bun run scripts/verify.ts
```

Screenshots are treated as generated artifacts (`bun run scripts/capture.ts`), so this PR commits no screenshot binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPrN8vCxmBqKcVRVYPnUu2