### PR TITLE
fix(go-template): aliased searchParams() import parity

### DIFF
--- a/.changeset/go-searchparams-alias.md
+++ b/.changeset/go-searchparams-alias.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Fix `searchParams()` SSR on the Go template adapter for an aliased import. `import { searchParams as sp }` + `sp().get(k)` now lowers to the canonical `.SearchParams.Get` field (and the `SearchParams bf.SearchParams` struct binding is generated), matching the non-aliased path — previously detection missed the alias (so no field was emitted) and the call lowered to a `.Sp` field that never exists. Detection now uses the shared `searchParamsLocalNames` helper (the same one the Mojo/Xslate adapters use), so the binding is found under any local name. #1922

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -217,6 +217,42 @@ function compileAndGenerate(source: string, adapter?: GoTemplateAdapter) {
 // Go-Template-Specific Tests
 // =============================================================================
 
+describe('GoTemplateAdapter - searchParams() env-signal lowering (#1922)', () => {
+  // `searchParams().get(k)` lowers to a method call on the canonical
+  // `.SearchParams` struct field, parenthesised inside `or` so the nullish
+  // fallback groups correctly.
+  test('lowers searchParams().get(k) to .SearchParams.Get and emits the struct binding', () => {
+    const adapter = new GoTemplateAdapter()
+    const ir = compileToIR(`
+import { searchParams } from '@barefootjs/client'
+export function SortLabel() {
+  return <p>{searchParams().get('sort') ?? 'none'}</p>
+}
+`, adapter)
+    const { template, types } = adapter.generate(ir)
+    expect(template).toContain('{{or (.SearchParams.Get "sort") "none"}}')
+    expect(types).toContain('SearchParams bf.SearchParams')
+    expect(types).toContain('SearchParams: in.SearchParams')
+  })
+
+  // An aliased import binds the env signal to a different local name; the
+  // call `sp()` still resolves to the canonical `.SearchParams` field (the
+  // generated struct field name is fixed, not derived from the JS alias).
+  test('aliased import (`searchParams as sp`) resolves sp() to canonical .SearchParams', () => {
+    const adapter = new GoTemplateAdapter()
+    const ir = compileToIR(`
+import { searchParams as sp } from '@barefootjs/client'
+export function SortLabel() {
+  return <p>{sp().get('sort') ?? 'none'}</p>
+}
+`, adapter)
+    const { template, types } = adapter.generate(ir)
+    expect(template).toContain('{{or (.SearchParams.Get "sort") "none"}}')
+    expect(template).not.toContain('.Sp.Get')
+    expect(types).toContain('SearchParams bf.SearchParams')
+  })
+})
+
 describe('GoTemplateAdapter - Adapter Specific', () => {
   describe('generate - Go struct types', () => {
     test('deduplicates struct field when signal name matches prop name (#461)', () => {

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -1399,19 +1399,19 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
   /**
    * Whether the component reads the request-scoped `searchParams()`
-   * environment signal (router v0.5, #1922). Detected via the shared
-   * `searchParamsLocalNames` helper, which finds the binding under any local
-   * name (including an aliased `import { searchParams as sp }`). When true the
-   * generated structs carry a `SearchParams bf.SearchParams` binding the route
-   * handler fills per request and the template reads via `.SearchParams.Get
-   * "key"`.
+   * environment signal (router v0.5, #1922). Detected from `searchParamsLocals`
+   * — the binding names the shared `searchParamsLocalNames` helper found at
+   * `generate()` / `generateTypes()` entry, covering any local name (including
+   * an aliased `import { searchParams as sp }`). When non-empty the generated
+   * structs carry a `SearchParams bf.SearchParams` binding the route handler
+   * fills per request and the template reads via `.SearchParams.Get "key"`.
    *
    * Guarded against a name collision with a user prop / signal / memo also
    * called `searchParams`: that author owns the `SearchParams` field, so the
    * env-signal field is dropped (the reference would resolve to their value).
    */
   private usesSearchParams(ir: ComponentIR): boolean {
-    if (searchParamsLocalNames(ir.metadata).size === 0) return false
+    if (this.searchParamsLocals.size === 0) return false
     // Every other source that contributes a Props/Input struct field: a
     // collision on `SearchParams` would redeclare the field and break the Go
     // compile. Covers props, signals, memos, `useContext` consumers, and the

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -64,7 +64,8 @@ import {
   collectContextConsumers,
   isLowerableObjectRestDestructure,
   type ContextConsumer,
-  collectModuleStringConsts as collectModuleStringConstsShared
+  collectModuleStringConsts as collectModuleStringConstsShared,
+  searchParamsLocalNames
 } from '@barefootjs/jsx'
 import { findInterpolationEnd } from '@barefootjs/jsx/scanner'
 import { BF_REGION } from '@barefootjs/shared'
@@ -611,6 +612,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    */
   private contextConsumers: ContextConsumer[] = []
 
+  /**
+   * (#1922) Local binding names the request-scoped `searchParams()` env signal
+   * is imported under (handles `import { searchParams as sp }`). A zero-arg call
+   * on one of these names lowers to the canonical `.SearchParams` field
+   * regardless of the JS alias. Set at `generate()` / `generateTypes()` entry.
+   */
+  private searchParamsLocals: Set<string> = new Set()
+
   /** Child component name → the contexts it consumes (cross-component, for provider wiring). */
   private childContextConsumers: Map<string, ContextConsumer[]> = new Map()
 
@@ -654,6 +663,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     this.localConstants = ir.metadata.localConstants ?? []
     this.currentMemos = ir.metadata.memos ?? []
     this.contextConsumers = collectContextConsumers(ir.metadata)
+    this.searchParamsLocals = searchParamsLocalNames(ir.metadata)
     // (#checkbox) Enumerate inherited-attribute accesses (props-object pattern)
     // before computing the nillable set / rendering, so the synthetic params
     // participate in attribute omission and field binding uniformly. Shared
@@ -1032,6 +1042,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     this.localConstants = ir.metadata.localConstants ?? []
     this.currentMemos = ir.metadata.memos ?? []
     this.contextConsumers = collectContextConsumers(ir.metadata)
+    this.searchParamsLocals = searchParamsLocalNames(ir.metadata)
     const lines: string[] = []
 
     const componentName = ir.metadata.componentName
@@ -1388,24 +1399,19 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
   /**
    * Whether the component reads the request-scoped `searchParams()`
-   * environment signal (router v0.5, #1922). Detected from a non-type
-   * `searchParams` import off `@barefootjs/client` — the same import the
-   * analyzer validates against `CLIENT_EXPORTS`. When true the generated
-   * structs carry a `SearchParams bf.SearchParams` binding the route handler
-   * fills per request and the template reads via `.SearchParams.Get "key"`.
+   * environment signal (router v0.5, #1922). Detected via the shared
+   * `searchParamsLocalNames` helper, which finds the binding under any local
+   * name (including an aliased `import { searchParams as sp }`). When true the
+   * generated structs carry a `SearchParams bf.SearchParams` binding the route
+   * handler fills per request and the template reads via `.SearchParams.Get
+   * "key"`.
    *
    * Guarded against a name collision with a user prop / signal / memo also
    * called `searchParams`: that author owns the `SearchParams` field, so the
    * env-signal field is dropped (the reference would resolve to their value).
    */
   private usesSearchParams(ir: ComponentIR): boolean {
-    const imported = ir.metadata.imports.some(
-      imp =>
-        imp.source === '@barefootjs/client' &&
-        !imp.isTypeOnly &&
-        imp.specifiers.some(s => !s.isTypeOnly && (s.alias ?? s.name) === 'searchParams'),
-    )
-    if (!imported) return false
+    if (searchParamsLocalNames(ir.metadata).size === 0) return false
     // Every other source that contributes a Props/Input struct field: a
     // collision on `SearchParams` would redeclare the field and break the Go
     // compile. Covers props, signals, memos, `useContext` consumers, and the
@@ -4263,7 +4269,8 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // the inner dot no longer refers to it, and it's not a root field. (#1677)
     if (this.isOuterLoopParam(name)) return `$${name}`
     if (this.loopVarRefCount.has(name)) return `$${name}`
-    return this.rootFieldRef(name)
+    // Env-signal binding (incl. an alias) → canonical `.SearchParams` (#1922).
+    return this.searchParamsFieldRef(name) ?? this.rootFieldRef(name)
   }
 
   /**
@@ -4290,6 +4297,17 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   private rootFieldRef(name: string): string {
     const prefix = this.loopParamStack.length > 0 ? '$.' : '.'
     return `${prefix}${this.capitalizeFieldName(name)}`
+  }
+
+  /**
+   * (#1922) When `name` is a local binding of the `searchParams()` env signal,
+   * resolve it to the canonical `.SearchParams` field — not `.<Capitalized
+   * name>` — so an aliased `import { searchParams as sp }` (`sp()`) reaches the
+   * same struct field the generator emits. Returns null for any other name so
+   * callers fall back to their normal field-ref lowering.
+   */
+  private searchParamsFieldRef(name: string): string | null {
+    return this.searchParamsLocals.has(name) ? this.rootFieldRef('searchParams') : null
   }
 
   /**
@@ -4344,9 +4362,11 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   call(callee: ParsedExpr, args: ParsedExpr[], emit: (e: ParsedExpr) => string): string {
-    // Signal call: count() -> .Count (or $.Count inside a loop, #1677)
+    // Signal call: count() -> .Count (or $.Count inside a loop, #1677).
+    // An env-signal binding (`searchParams()`, or an aliased `sp()`) resolves to
+    // the canonical `.SearchParams` field regardless of the JS name (#1922).
     if (callee.kind === 'identifier' && args.length === 0) {
-      return this.rootFieldRef(callee.name)
+      return this.searchParamsFieldRef(callee.name) ?? this.rootFieldRef(callee.name)
     }
     // Array methods (`.join` and any others added to ArrayMethod, #1443)
     // are lifted into the `array-method` IR kind at parse time, so


### PR DESCRIPTION
Follow-up to #1923 / #1926 (router v0.5 `searchParams()` SSR), closing the **Go alias-parity** gap surfaced in #1926's review.

## Problem

The Go adapter's `searchParams()` lowering only recognised the literal local name `searchParams`. An aliased import:

```tsx
import { searchParams as sp } from '@barefootjs/client'
export function SortLabel() {
  return <p>{sp().get('sort') ?? 'none'}</p>
}
```

…broke two ways: the adapter's own import check (`(alias ?? name) === 'searchParams'`) missed the alias, so **no `SearchParams` struct field was generated**, and `sp()` lowered to a `.Sp` field that never exists → the template would fail/empty at render. (The Mojo/Xslate adapters were already fixed in #1926 via a shared helper; this brings Go to parity.)

## Fix

- `usesSearchParams` now detects via the shared `searchParamsLocalNames` helper (the same one Mojo/Xslate use), finding the binding under any local name. The collision guard on the `SearchParams` field name is unchanged.
- The adapter stores the local-name set and a `searchParamsFieldRef(name)` helper maps any env-signal binding (incl. an alias) to the **canonical `.SearchParams`** field in both `call()` and `identifier()`.

So `sp().get('sort') ?? 'none'` lowers to `{{or (.SearchParams.Get "sort") "none"}}` — byte-identical to the non-aliased path — and the `SearchParams bf.SearchParams` struct binding + `NewXxxProps` wiring are generated.

The runtime (`bf.SearchParams.Get`) is unchanged — aliasing is purely a compile-time concern — so the cross-language golden vectors need no update.

## Verification

- New regression tests pin both the plain and aliased lowering (template + struct field).
- Go adapter suite: **502 pass / 0 fail** (+2). `tsgo --noEmit` + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVG42m6fAQYAS4mYVR4CN2)_