### PR TITLE
docs(router): compiled nested Region demo + mark v2 shipped in spec

### DIFF
--- a/integrations/router-blog/README.md
+++ b/integrations/router-blog/README.md
@@ -2,10 +2,11 @@
 
 A small blog built on [`@barefootjs/router`](../../packages/router) for
 **automatic partial navigation**: clicking a post swaps only the content region
-and leaves the page shell — and a sibling sidebar region — mounted; clicking a
-`?sort=` / `?tag=` link re-orders/filters the list **reactively with no region
-swap at all**; a marked mini-player keeps **playing across a navigation**; and a
-sidebar island **keeps its state** while the article beside it swaps.
+and leaves the page shell — plus a sibling sidebar region and an outer toolbar
+region — mounted; clicking a `?sort=` / `?tag=` link re-orders/filters the list
+**reactively with no region swap at all**; a marked mini-player keeps **playing
+across a navigation**; and both a sibling sidebar island and a nested toolbar
+island **keep their state** while the article swaps.
 
 Every island here is a **real compiled BarefootJS `"use client"` component**
 hydrated by the **real `@barefootjs/client` runtime** — the router drives the
@@ -36,12 +37,14 @@ including the sibling-region view.)
 |---|---|---|
 | `ShellStats` | shell | uptime clock + a `MutationObserver` partial-nav counter + live-island gauge |
 | `ThemeToggle` | shell | flips `data-theme`; the choice survives navigation |
-| `Sidebar` | `nav:0` region | a pin counter in a sibling region — its state survives while the content region swaps (the **v2** case) |
-| `PostList` | `content:1` region | the index; reads `searchParams()` to sort/filter with no swap; reactive sort/tag bars |
-| `PostListItem` | `content:1` region | one keyed row with a local pin toggle (state survives re-sort) |
-| `LikeButton` | `content:1` region | local like counter — re-created per navigation |
-| `ReadingTimer` | `content:1` region | a `setInterval` timer wired through `onCleanup` — the **disposal** stress case |
-| `NowPlaying` | `content:1` region | a mini-player whose root carries `data-bf-permanent` — the **v1 persistence** case (live node + state survive a swap) |
+| `Sidebar` | sidebar region (`nav:0`, sibling) | a pin counter — its state survives while the content swaps (**v2 sibling**, hand-authored id) |
+| `PageShell` | content area | a compiled layout whose nested `<Region>`s the compiler lowers to `bf-region` ids (**v2 nested**, compiler-derived) |
+| `ReaderToolbar` | outer content region | a font-size control in the outer region — its level survives while the inner region swaps (**v2 nested**) |
+| `PostList` | inner content region | the index; reads `searchParams()` to sort/filter with no swap; reactive sort/tag bars |
+| `PostListItem` | inner content region | one keyed row with a local pin toggle (state survives re-sort) |
+| `LikeButton` | inner content region | local like counter — re-created per navigation |
+| `ReadingTimer` | inner content region | a `setInterval` timer wired through `onCleanup` — the **disposal** stress case |
+| `NowPlaying` | inner content region | a mini-player whose root carries `data-bf-permanent` — the **v1 persistence** case (live node + state survive a swap) |
 
 ## How it works
 
@@ -78,10 +81,10 @@ imports at runtime (`@barefootjs/shared`, `@barefootjs/jsx`,
 `searchParams()` imports it). Run `setup` once; after that, iterate with
 `bun run build && bun run serve` (or just `bun run serve`).
 
-Verify behavior in a real browser (drives the router through **27 assertions** —
+Verify behavior in a real browser (drives the router through **31 assertions** —
 region swap, shell persistence, `searchParams()` no-swap sort/filter, pin
-survival, disposal, back/forward, `data-bf-permanent` persistence, sibling-region
-persistence, console
+survival, disposal, back/forward, `data-bf-permanent` persistence, and both
+sibling- and nested-region persistence, plus console
 errors):
 
 ```sh
@@ -119,29 +122,55 @@ same navigation, the only difference is the marker. `verify.ts` proves the node
 is the **same live instance** (a marker set on it via `evaluate` survives the
 swap), not just equal text.
 
-## v2 — sibling regions (master–detail)
+## v2 — nested & sibling regions
 
-The page below the header is **two sibling regions**: `<aside bf-region="nav:0">`
-(the `Sidebar` island) and `<main bf-region="content:1">` (the article / list).
-Both pages render both regions, so the router matches them by id and swaps only
-the one whose content differs. Bump the sidebar's 📌 pin counter, then open a
-post: the content region swaps while the **sidebar island is never disposed** —
-its count survives. `verify.ts` proves it is the same live node (a marker set via
-`evaluate` survives the swap).
+The page shows both region shapes at once, and both ways to author them.
 
-This is the case a single-region (v0) router cannot express: with two regions it
-would swap the *first* one (the sidebar) and never update the article. Two notes
-on how the match stays robust:
+**Sibling (hand-authored).** `<aside bf-region="nav:0">` (the `Sidebar`) and the
+content `<main>` sit side by side. Bump the sidebar's 📌 pin counter, then open a
+post: only the content swaps while the **sidebar island is never disposed** — its
+count survives. This is the case a single-region (v0) router cannot express: with
+two regions it would swap the *first* one (the sidebar) and never update the
+article.
 
-- The ids are written by hand in `renderer.tsx` because that layout is a plain
-  Hono SSR template, not a compiled component tree; in `bf build` output the
-  `<Region>` component lowers to the same deterministic
-  `bf-region="<file scope>:<index>"` ids. The runtime only needs them equal
-  across page documents.
+**Nested (compiler-derived).** The content area is a compiled `<PageShell>`:
+
+```tsx
+'use client'
+import { Region } from '@barefootjs/client'
+import { ReaderToolbar } from './ReaderToolbar'
+export function PageShell({ children }) {
+  return (
+    <Region>                          {/* outer — bf-region="<hash>:0" */}
+      <ReaderToolbar />               {/* persists across inner swaps */}
+      <div className="content-area">
+        <Region>{children}</Region>   {/* inner — bf-region="<hash>:1" */}
+      </div>
+    </Region>
+  )
+}
+```
+
+`bf build` lowers each `<Region>` to a deterministic `bf-region="<file scope>:<index>"`
+id (`:0` outer, `:1` inner). Bump the `ReaderToolbar` font level, then open a post:
+the **outer region's owned content is unchanged**, so the router swaps only the
+**inner** region — the toolbar (in the outer region) keeps its level while the
+article swaps. `verify.ts` proves both the sidebar and the toolbar are the same
+live nodes after the swap (markers set via `evaluate` survive).
+
+Two notes on how the match stays robust:
+
+- Region ids must be **equal across pages**. The compiler-derived ids are
+  deterministic (same `<Region>` in the same file → same id on every page). The
+  hand-authored sidebar id is a stable literal; the router matches by plain string
+  equality, so both styles interoperate. (`<Region>` only lowers in a
+  `bf build`-compiled file, which is why the Hono `renderer.tsx` layout hand-writes
+  `nav:0` — see the comment there.)
 - A top-level island's `bf-s` scope id is **randomized per server render**, so a
-  region's markup is never byte-identical across pages. The router's owned-content
-  diff normalizes that scaffolding away (it compares content + props, not scope
-  ids), so the unchanged sidebar is correctly left mounted.
+  region's raw markup is never byte-identical across pages. The router's
+  owned-content diff normalizes that scaffolding away (it compares content + props,
+  not scope ids), so an unchanged region containing an island is correctly left
+  mounted.
 
 ## Integration gaps this surfaced (now shipped in v0 / v0.5)
 

--- a/integrations/router-blog/components/PageShell.tsx
+++ b/integrations/router-blog/components/PageShell.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { Region } from '@barefootjs/client'
+import { ReaderToolbar } from './ReaderToolbar'
+
+/**
+ * The content area as **compiler-derived nested regions** (spec/router.md v2).
+ *
+ * Unlike the hand-authored sidebar (`renderer.tsx`), the region boundaries here
+ * come from the `<Region>` component: `bf build` lowers each to a deterministic
+ * `bf-region="<file-scope hash>:<index>"` id — `…:0` for the outer, `…:1` for
+ * the inner — the same on every page that renders this shell.
+ *
+ *   - **outer** region: holds the persistent `ReaderToolbar`. Its owned content
+ *     (the toolbar + the masked inner region) is the same across pages, so the
+ *     router never swaps it — the toolbar keeps its font-size level.
+ *   - **inner** region: wraps the page `children`, which differ per page, so it
+ *     is the region the router actually swaps.
+ *
+ * (`"use client"` is required only because `bf build` compiles island files; the
+ * component ships almost no client JS — it exists to lower the regions.)
+ */
+export function PageShell({ children }: { children?: unknown }) {
+  return (
+    <Region>
+      <ReaderToolbar />
+      <div className="content-area">
+        <Region>{children}</Region>
+      </div>
+    </Region>
+  )
+}

--- a/integrations/router-blog/components/ReaderToolbar.tsx
+++ b/integrations/router-blog/components/ReaderToolbar.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { createSignal } from '@barefootjs/client'
+
+/**
+ * A stateful island that lives in the **outer** region (`PageShell`), above the
+ * inner region the router swaps. Its font-size level is the proof of nested v2:
+ * bump it, navigate between pages, and it keeps its value — the outer region
+ * (and this island) is never swapped, only the inner content region is.
+ */
+export function ReaderToolbar() {
+  const [level, setLevel] = createSignal(1)
+  return (
+    <div className="reader-toolbar">
+      <span className="rt-label">font</span>
+      <button className="rt-btn" type="button" aria-label="smaller" onClick={() => setLevel((n) => Math.max(0, n - 1))}>
+        A-
+      </button>
+      <span className="rt-level v">{level()}</span>
+      <button className="rt-btn" type="button" aria-label="larger" onClick={() => setLevel((n) => n + 1)}>
+        A+
+      </button>
+    </div>
+  )
+}

--- a/integrations/router-blog/components/ShellStats.tsx
+++ b/integrations/router-blog/components/ShellStats.tsx
@@ -24,7 +24,9 @@ export function ShellStats() {
     const handle = setInterval(() => setUptime(`${((Date.now() - start) / 1000).toFixed(1)}s`), 100)
     onCleanup(() => clearInterval(handle))
 
-    const region = document.querySelector('main[bf-region]')
+    // The inner content region (inside PageShell's `.content-area`) is the one
+    // the router swaps on a page navigation — watch it for the partial-nav count.
+    const region = document.querySelector('.content-area [bf-region]')
     if (!region) return
     const recount = () => setIslands(region.querySelectorAll('[bf-s]').length)
     recount()

--- a/integrations/router-blog/renderer.tsx
+++ b/integrations/router-blog/renderer.tsx
@@ -29,6 +29,7 @@ import { BfScripts } from '@barefootjs/hono/scripts'
 import { ShellStats } from '@/components/ShellStats'
 import { ThemeToggle } from '@/components/ThemeToggle'
 import { Sidebar } from '@/components/Sidebar'
+import { PageShell } from '@/components/PageShell'
 
 const STATIC = '/static/components'
 
@@ -64,20 +65,25 @@ export const renderer = jsxRenderer(({ children, title }) => {
         </header>
         <div className="layout">
           {/*
-            Two sibling regions. The `bf-region` ids are written BY HAND here
-            only because this layout is a plain Hono `jsxRenderer` template, not
-            a `bf build`-compiled component tree — so the `<Region>` component
-            (from `@barefootjs/client`) would not be lowered. In a compiled tree
-            you write `<Region>{children}</Region>` and the compiler emits a
-            deterministic `bf-region="<file-scope hash>:<index>"` id for you.
-            The router matches regions by plain string equality, so these
-            readable ids work identically — they only need to be the same across
-            every page that renders this layout.
+            Two ways to author a region, side by side:
+
+            - The sidebar's `bf-region="nav:0"` is written BY HAND, because this
+              layout is a plain Hono `jsxRenderer` template (not a `bf build`-
+              compiled tree), so a `<Region>` here would not be lowered.
+            - The content area is a compiled `<PageShell>` whose `<Region>`s the
+              compiler lowers to deterministic `bf-region="<file scope>:<index>"`
+              ids — and it nests them (an outer region holding a persistent
+              toolbar, an inner region the router swaps).
+
+            The router matches regions by plain string equality, so both styles
+            interoperate; ids only need to be the same across every page.
           */}
           <aside bf-region="nav:0">
             <Sidebar />
           </aside>
-          <main bf-region="content:1">{children}</main>
+          <main>
+            <PageShell>{children}</PageShell>
+          </main>
         </div>
         <BfScripts />
         <script type="module" src={`${STATIC}/router-entry.js`} />
@@ -141,6 +147,12 @@ const STYLES = `
   .island.player { display: inline-flex; align-items: center; gap: 6px; color: #3fb950; font-variant-numeric: tabular-nums; border: 1px solid #30363d; border-radius: 8px; padding: 4px 10px; }
   html[data-theme="light"] .island.player { border-color: #d0d7de; }
   .player-toggle { cursor: pointer; background: none; border: none; color: inherit; font-size: 14px; padding: 0; line-height: 1; }
+  .reader-toolbar { display: flex; align-items: center; gap: 8px; margin-bottom: 18px; padding: 6px 12px; border: 1px solid #30363d; border-radius: 8px; background: #161b22; font-size: 13px; color: #8b949e; }
+  html[data-theme="light"] .reader-toolbar { background: #fff; border-color: #d0d7de; }
+  .rt-label { text-transform: uppercase; letter-spacing: .04em; font-size: 11px; }
+  .rt-btn { cursor: pointer; background: #0d1117; border: 1px solid #30363d; color: #e6edf3; border-radius: 6px; padding: 2px 8px; font-size: 12px; }
+  html[data-theme="light"] .rt-btn { background: #f6f8fa; border-color: #d0d7de; color: #1f2328; }
+  .rt-level { color: #58a6ff; font-variant-numeric: tabular-nums; min-width: 1ch; text-align: center; }
   .prose p { margin: 0 0 18px; color: #d8e0e8; }
   html[data-theme="light"] .prose p { color: #424a53; }
   .back { display: inline-block; margin-bottom: 14px; text-decoration: none; font-size: 14px; }

--- a/integrations/router-blog/scripts/verify.ts
+++ b/integrations/router-blog/scripts/verify.ts
@@ -180,7 +180,40 @@ try {
   )
   check('sidebar is the SAME live node (never disposed)', sidebarSame === 'KEEP', `mark=${sidebarSame}`)
 
-  // ── 11. No console / page errors throughout ─────────────────────────────
+  // ── 11. v2 nested: outer region (ReaderToolbar) persists; inner swaps ─────
+  // The content area is a compiled `<PageShell>` with nested `<Region>`s. The
+  // ReaderToolbar lives in the OUTER region (above the inner one the router
+  // swaps), so its font-size level survives a page navigation while the inner
+  // content swaps — the deepest differing region is the only one replaced.
+  await page.goto(`${BASE}/`, { waitUntil: 'networkidle' })
+  await page.waitForTimeout(300)
+  await page.click('.reader-toolbar .rt-btn[aria-label="larger"]')
+  await page.click('.reader-toolbar .rt-btn[aria-label="larger"]')
+  const levelBefore = await text('.reader-toolbar .v')
+  check('reader toolbar hydrated (font level)', levelBefore === '3', `level=${levelBefore}`)
+  await page.$eval('.reader-toolbar', (el) => {
+    ;(el as unknown as { __mark?: string }).__mark = 'KEEP'
+  })
+  const navsBeforeNested = await navCount()
+  await page.click('.sortable-list li:first-child .item-link') // → post: inner swaps
+  await page
+    .waitForFunction(
+      (before) =>
+        document.querySelector('.shell-stats .chip:nth-child(2) b')?.textContent !== before,
+      navsBeforeNested,
+      { timeout: 2000 },
+    )
+    .catch(() => {})
+  check('inner region swapped (article in)', (await page.locator('.island.like').count()) === 1)
+  const levelAfter = await text('.reader-toolbar .v')
+  check('outer region (toolbar) persisted across the inner swap (v2 nested)', levelAfter === '3', `level=${levelAfter}`)
+  const toolbarSame = await page.$eval(
+    '.reader-toolbar',
+    (el) => (el as unknown as { __mark?: string }).__mark,
+  )
+  check('toolbar is the SAME live node (outer region never swapped)', toolbarSame === 'KEEP', `mark=${toolbarSame}`)
+
+  // ── 12. No console / page errors throughout ─────────────────────────────
   check('no console or page errors', errors.length === 0, errors.slice(0, 3).join(' | '))
 } catch (e) {
   check('script ran to completion', false, String(e))

--- a/spec/router.md
+++ b/spec/router.md
@@ -142,23 +142,34 @@ at `@barefootjs/client/runtime` (`disposeScope`/`rehydrateScope`). Neither may s
 
 ## Phased plan
 
-- **v0 — single authored region, correct by default.** Seams auto-install; shared
-  dispose/rehydrate fallback; `history.state` preserved; response-URL base resolution;
-  focus/a11y on swap. The "never worse than MPA" floor.
-- **v0.5 — `searchParams` done right.** In `@barefootjs/client` (lazy, side-effect-free,
-  router-driven); request-scoped SSR; `"sideEffects": false`. Cookies later.
-- **v1 — persistence within a region.** `data-bf-permanent` + idiomorph-style morphing.
-- **v2 — compiler-derived nested regions.** Smallest proof: `BF_REGION` + `IRElement.regionId`
-  + `<Region>` lowering in `jsx-to-ir.ts`; a Hono fixture asserting a stable id reused
-  across two pages; a runtime test for nearest-enclosing-region dispose + subtree rehydrate.
+- **v0 — single authored region, correct by default.** ✅ Shipped. Seams auto-install;
+  shared dispose/rehydrate fallback; `history.state` preserved; response-URL base
+  resolution; focus/a11y on swap. The "never worse than MPA" floor.
+- **v0.5 — `searchParams` done right.** ✅ Shipped. In `@barefootjs/client` (lazy,
+  side-effect-free, router-driven); request-scoped SSR; `"sideEffects": false`. Cookies later.
+- **v1 — persistence within a region.** ✅ Shipped. `data-bf-permanent` + idiomorph-style morphing.
+- **v2 — compiler-derived nested regions.** ✅ Shipped. `BF_REGION` + `IRElement.regionId`
+  + `<Region>` lowering in `jsx-to-ir.ts` (compiler) and the matching runtime in
+  `@barefootjs/router`: on a navigation the router matches `[bf-region]` ids between the
+  live and incoming documents and swaps only the **deepest regions whose owned content
+  differs** (nested + sibling), falling back to the broadest single swap — or a hard
+  navigation when the region structure diverges and no root contains all. The
+  owned-content diff is taken against a **server-render baseline** (not the island-mutated
+  live DOM) and **normalizes per-render hydration scaffolding** (the random `bf-s` scope
+  ids), so a region containing an island is not mistaken for "changed". Covered by the
+  cross-adapter `region-boundary` fixture (stable id), `router-regions.test.ts` (nested /
+  sibling / divergence), and the `integrations/router-blog` example (hand-authored sibling
+  + compiled nested regions, verified in a real browser).
 
 ## Limitations & non-goals
 
 - True zero-input region inference would need a separate, fragile cross-page diff pass
   (lone-page layouts, conditional shells, per-route layouts confound it). Ship authored
   boundaries first; treat inference as a later optional lint/codemod.
-- Permanent islands and scope-ownership edge cases (portals, context/loops crossing a
-  region) need conformance fixtures before v2 is more than a sketch.
+- v2 ships the nested/sibling swap, but scope-ownership edge cases where a region boundary
+  crosses a portal, context provider, or loop still need dedicated conformance fixtures —
+  the owned-content diff is HTML-structural, so a region split across one of these is not
+  yet guaranteed.
 - No scroll restoration; modulepreload links/dedupe set are session-lived (cap later).
 - **Non-goals:** client route manifest / loader protocol / fragment endpoint; RSC-style
   boundary or non-HTML payload; client-owned Suspense protocol; navigation/content-negotiation header.


### PR DESCRIPTION
## Compiled nested `<Region>` demo + spec status

Two follow-ups to the v2 work, both docs/example only (no `@barefootjs/*` package code changes).

### 1. router-blog now shows both ways to author a region

| | Authoring | Shape | Persists |
|---|---|---|---|
| **Sidebar** | hand-authored `bf-region="nav:0"` | sibling | pin counter survives a content swap |
| **PageShell** | compiled `<Region>` (ids derived by `bf build`) | **nested** | toolbar font-level survives an inner swap |

The previous demo only used hand-authored ids; this adds the **compiler-derived `<Region>`** path, exercised end-to-end against the real runtime:

```tsx
'use client'
import { Region } from '@barefootjs/client'
export function PageShell({ children }) {
  return (
    <Region>                          {/* outer — bf-region="<hash>:0" */}
      <ReaderToolbar />               {/* persists across inner swaps */}
      <div className="content-area">
        <Region>{children}</Region>   {/* inner — bf-region="<hash>:1" */}
      </div>
    </Region>
  )
}
```

`bf build` lowers each `<Region>` to a deterministic `bf-region="<file scope>:<index>"` id. Navigating a post swaps **only the inner region**; the `ReaderToolbar` in the outer region keeps its state.

> Note: `<Region>` only lowers in a `bf build`-compiled file, so `PageShell`/`ReaderToolbar` carry `'use client'` (PageShell ships almost no client JS — it exists to lower the regions). The Hono `renderer.tsx` layout is not compiled, which is why the sidebar id stays hand-authored — documented inline.

### 2. `verify.ts` — 31 assertions, all green

+4 new nested-v2 checks: toolbar hydrates, inner region swaps, toolbar level + live node survive (outer region never swapped). Verified in real Chromium.

### 3. spec/router.md

Marks v0/v0.5/v1/v2 **shipped**; documents the v2 runtime (deepest-differing swap, server-render baseline, scope-id normalization, root/hard-navigate fallback); rewords the scope-ownership limitation (a region split across a portal / context / loop still needs dedicated fixtures) now that v2 is no longer "a sketch".

Screenshots remain generated artifacts (not committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPrN8vCxmBqKcVRVYPnUu2

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPrN8vCxmBqKcVRVYPnUu2)_