### PR TITLE
docs(adapter-tests): refresh search-params fixture comment

### DIFF
--- a/packages/adapter-tests/fixtures/search-params.ts
+++ b/packages/adapter-tests/fixtures/search-params.ts
@@ -7,9 +7,9 @@ import { createFixture } from '../src/types'
 // renders the default `none`.
 //
 // This is the cross-adapter twin of the client-side `env-signal.test.ts` and
-// the Hono `search-params-ssr.test.ts`. It runs on Hono today; the Go / Mojo /
-// Xslate template adapters are skipped via their `skipJsx` lists until
-// env-signal SSR lowering + runtime land for them — tracked in
+// the Hono `search-params-ssr.test.ts`. It now runs on every adapter — Hono,
+// Go, Mojolicious, and Xslate — after env-signal SSR lowering + per-request
+// runtimes landed for the template-string adapters in
 // https://github.com/piconic-ai/barefootjs/issues/1922.
 export const fixture = createFixture({
   id: 'search-params',


### PR DESCRIPTION
## What

Updates the stale header comment on the `search-params` conformance fixture (`packages/adapter-tests/fixtures/search-params.ts`).

## Why

The comment still claimed the Go / Mojolicious / Xslate template adapters were skipped via their `skipJsx` lists pending env-signal SSR support. That work has since landed (#1922): the fixture is now un-skipped and renders across **every** adapter — Hono, Go, Mojolicious, and Xslate.

This is a comment-only change to bring the fixture's documentation in line with the implementation. No code or test behavior changes.

## Context

This is the last loose end for #1922. The implementation tasks (compiler lowering, Go runtime, Perl runtime, fixture un-skip, plus the non-Hono JS integrations via AsyncLocalStorage) are all complete; once this merges, #1922 can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018Rmqf4m7SxAwjvw4LVTBci)_