### PR TITLE
feat(elysia): blog routes in the Elysia app (phase 4)

### DIFF
--- a/integrations/elysia/barefoot.config.ts
+++ b/integrations/elysia/barefoot.config.ts
@@ -6,7 +6,7 @@ import { createConfig } from '@barefootjs/hono/build'
 const staticBase = '/static/components/'
 
 export default createConfig({
-  components: ['../shared/components'],
+  components: ['../shared/components', '../shared/blog'],
   outDir: 'dist',
   minify: true,
   scriptBasePath: staticBase,

--- a/integrations/elysia/blog.tsx
+++ b/integrations/elysia/blog.tsx
@@ -100,6 +100,10 @@ export function renderBlogIndex(base: string, manifest: BarefootBuildManifest, t
   return (
     <BlogLayout base={base} manifest={manifest} title={title}>
       <PostList items={items} tags={allTags} base={blog} />
+      {/* v1: the player also lives in the content region on the index, marked
+          `data-bf-permanent`, so the router moves the same live node between the
+          list and a post — it keeps playing instead of resetting on "← All posts". */}
+      <NowPlaying />
     </BlogLayout>
   )
 }

--- a/integrations/elysia/blog.tsx
+++ b/integrations/elysia/blog.tsx
@@ -1,0 +1,226 @@
+/** @jsxImportSource @barefootjs/hono/jsx */
+//
+// Blog routes for the Elysia integration — the `@barefootjs/router` showcase.
+//
+// Phase 4 of running the blog across every adapter (phase 2 → Hono #1933,
+// phase 3 → h3 #1935), over the same `shared/blog` components. Like h3, Elysia
+// is just the HTTP host with no `jsxRenderer`: this module exports the
+// region-shell `BlogLayout` plus two JSX builders, and `server.tsx` wires them
+// into the Elysia route chain (kept inline so the blog never introduces a
+// second adapter instance — the Cloudflare adapter compiles one app). The
+// islands are the shared blog components in `../shared/blog`, compiled into
+// `dist/components` by this integration's `bf build`; links are base-path aware,
+// so the same shared components work under any adapter's mount point.
+//
+// `searchParams()` SSR rides the adapter's existing reader seam: the whole
+// fetch runs inside `withRequestEnv` (see server.tsx), so the index render of a
+// `?sort=` / `?tag=` URL resolves the query per-request with no manual priming.
+
+import { BfScripts } from '@barefootjs/hono/app'
+import type { BarefootBuildManifest } from '@barefootjs/hono/app'
+import { Sidebar } from '@/components/Sidebar'
+import { PageShell } from '@/components/PageShell'
+import { ThemeToggle } from '@/components/ThemeToggle'
+import { LikeButton } from '@/components/LikeButton'
+import { ReadingTimer } from '@/components/ReadingTimer'
+import { NowPlaying } from '@/components/NowPlaying'
+import { PostList } from '@/components/PostList'
+import { posts, postIndex, allTags } from '../shared/blog/posts'
+
+interface LayoutProps {
+  base: string
+  manifest: BarefootBuildManifest
+  title?: string
+  children?: unknown
+}
+
+function BlogLayout({ base, manifest, title, children }: LayoutProps) {
+  const componentsBase = `${base}/static/components`
+  const blog = `${base}/blog`
+  // `searchParams()` lives in the single physical `@barefootjs/client/reactive`
+  // module re-exported by every `@barefootjs/client*` entry, so the island and
+  // the router bootstrap share ONE signal instance just by resolving the bare
+  // specifiers to the same `barefoot.js`. `BfImportMap` only emits the
+  // `/client` + `/runtime` keys, so the blog writes its own map to add
+  // `/reactive` (same as the Hono / h3 integrations).
+  const importMap = JSON.stringify({
+    imports: {
+      '@barefootjs/client': `${componentsBase}/barefoot.js`,
+      '@barefootjs/client/runtime': `${componentsBase}/barefoot.js`,
+      '@barefootjs/client/reactive': `${componentsBase}/barefoot.js`,
+    },
+  })
+  return (
+    <html lang="en" data-theme="dark">
+      <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>{title ?? 'Barefoot Blog'}</title>
+        <script type="importmap" dangerouslySetInnerHTML={{ __html: importMap }} />
+        <style dangerouslySetInnerHTML={{ __html: STYLES }} />
+      </head>
+      <body>
+        <header className="shell">
+          <a className="shell-brand" href={blog}>📰 Barefoot Blog</a>
+          <div className="shell-island">
+            <ThemeToggle />
+          </div>
+        </header>
+        {/*
+          Two ways to author a region, side by side. The sidebar's
+          `bf-region="nav:0"` is hand-written (this is a plain hono/jsx template,
+          not a `bf build`-compiled tree, so `<Region>` would not lower here).
+          The content area is a compiled `<PageShell>` whose nested `<Region>`s
+          the compiler lowers to deterministic `bf-region="<file scope>:<index>"`
+          ids. The router matches both by string equality.
+        */}
+        <div className="layout">
+          <aside bf-region="nav:0">
+            <Sidebar />
+          </aside>
+          <main>
+            <PageShell>{children}</PageShell>
+          </main>
+        </div>
+        {/* Elysia has no per-page script collector, so BfScripts emits every
+            island in the manifest (the same way every other Elysia page does);
+            the router bootstrap is appended once. */}
+        <BfScripts base={componentsBase} manifest={manifest} />
+        <script type="module" src={`${componentsBase}/router-entry.js`} />
+      </body>
+    </html>
+  )
+}
+
+/** Index page node — the post list reacts to ?sort= / ?tag= via searchParams(). */
+export function renderBlogIndex(base: string, manifest: BarefootBuildManifest, tag?: string) {
+  const blog = `${base}/blog`
+  const items = posts.map((p) => ({ slug: p.slug, title: p.title, date: p.date, tags: p.tags }))
+  const title = tag ? `#${tag} — Barefoot Blog` : 'Barefoot Blog — Latest posts'
+  return (
+    <BlogLayout base={base} manifest={manifest} title={title}>
+      <PostList items={items} tags={allTags} base={blog} />
+    </BlogLayout>
+  )
+}
+
+/** Post page node, or `null` when the slug is unknown (caller returns 404). */
+export function renderBlogPost(base: string, manifest: BarefootBuildManifest, slug: string) {
+  const i = postIndex(slug)
+  if (i < 0) return null
+  const blog = `${base}/blog`
+  const p = posts[i]
+  const prev = posts[i - 1]
+  const next = posts[i + 1]
+  return (
+    <BlogLayout base={base} manifest={manifest} title={`${p.title} — Barefoot Blog`}>
+      <article className="post" data-slug={p.slug}>
+        <a className="back" href={blog}>← All posts</a>
+        <h1 className="page-title">{p.title}</h1>
+        <div className="meta">
+          {p.date} · post {i + 1} of {posts.length} ·{' '}
+          {p.tags.map((t) => (
+            <a className="tag-inline" href={`${blog}?tag=${encodeURIComponent(t)}`}>#{t} </a>
+          ))}
+        </div>
+        <div className="islands">
+          <LikeButton />
+          <ReadingTimer />
+        </div>
+        {/* v1: a docked "Now playing" bar. It reads as a global player but lives
+            in the swappable content region marked `data-bf-permanent`, so the
+            router moves its live node (play state + progress) into the next post
+            instead of disposing it — contrast ReadingTimer above, which resets. */}
+        <NowPlaying />
+        <div className="prose">
+          {p.body.map((para) => (
+            <p>{para}</p>
+          ))}
+        </div>
+        <nav className="pager">
+          {prev ? (
+            <a className="pager-link" href={`${blog}/posts/${prev.slug}`}>← {prev.title}</a>
+          ) : (
+            <span className="pager-link disabled">← Start</span>
+          )}
+          {next ? (
+            <a className="pager-link next" href={`${blog}/posts/${next.slug}`}>{next.title} →</a>
+          ) : (
+            <a className="pager-link next" href={blog}>Back to start →</a>
+          )}
+        </nav>
+      </article>
+    </BlogLayout>
+  )
+}
+
+const STYLES = `
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  html[data-theme="light"] { color-scheme: light; }
+  body { margin: 0; font: 16px/1.6 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background: #0e1116; color: #e6edf3; }
+  html[data-theme="light"] body { background: #f6f8fa; color: #1f2328; }
+  a { color: #58a6ff; }
+  .shell { position: sticky; top: 0; z-index: 10; display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 14px 24px; background: #161b22; border-bottom: 1px solid #30363d; }
+  html[data-theme="light"] .shell { background: #fff; border-bottom-color: #d0d7de; }
+  .shell-brand { font-weight: 700; font-size: 18px; text-decoration: none; color: inherit; }
+  .shell-island { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+  .toggle { cursor: pointer; background: #0d1117; border: 1px solid #30363d; color: #e6edf3; border-radius: 999px; padding: 5px 12px; font-size: 13px; }
+  html[data-theme="light"] .toggle { background: #f6f8fa; border-color: #d0d7de; color: #1f2328; }
+  .layout { display: flex; gap: 28px; align-items: flex-start; max-width: 1000px; margin: 0 auto; padding: 32px 24px 80px; }
+  .layout main { flex: 1; min-width: 0; }
+  .layout aside { position: sticky; top: 78px; width: 210px; flex: none; }
+  html[data-theme="light"] .sidebar { background: #fff; border-color: #d0d7de; }
+  .sidebar { background: #161b22; border: 1px solid #30363d; border-radius: 12px; padding: 16px; }
+  .sidebar-title { font-weight: 700; font-size: 13px; text-transform: uppercase; letter-spacing: .04em; color: #8b949e; margin-bottom: 12px; }
+  .sidebar-pin { cursor: pointer; width: 100%; background: #0d1117; border: 1px solid #30363d; color: #f2cc60; border-radius: 8px; padding: 8px 12px; font-size: 14px; font-variant-numeric: tabular-nums; }
+  html[data-theme="light"] .sidebar-pin { background: #f6f8fa; border-color: #d0d7de; }
+  .sidebar-note { font-size: 12px; color: #6e7681; margin: 12px 0 0; }
+  @media (max-width: 720px) { .layout { flex-direction: column; } .layout aside { position: static; width: 100%; } }
+  .page-title { font-size: 28px; margin: 0 0 6px; }
+  .lede, .meta { color: #8b949e; }
+  html[data-theme="light"] .lede, html[data-theme="light"] .meta { color: #57606a; }
+  .meta { font-size: 13px; margin-bottom: 12px; }
+  .lede { margin: 0 0 18px; }
+  .controls, .tags { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-bottom: 10px; }
+  .ctl-label { font-size: 13px; color: #6e7681; }
+  .tag, .tag-inline, .sort { text-decoration: none; font-size: 13px; color: #9aa7b4; }
+  .tag, .sort { border: 1px solid #30363d; border-radius: 999px; padding: 4px 11px; }
+  .tag.on, .sort.on { background: #1f6feb; border-color: #1f6feb; color: #fff; }
+  .tag-inline { color: #58a6ff; }
+  .status { font-size: 13px; color: #8b949e; margin-bottom: 12px; min-height: 1.2em; font-variant-numeric: tabular-nums; }
+  .sortable-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 8px; }
+  .sortable-list li { display: flex; align-items: center; gap: 10px; border: 1px solid #30363d; border-radius: 10px; background: #161b22; padding: 10px 14px; }
+  html[data-theme="light"] .sortable-list li { background: #fff; border-color: #d0d7de; }
+  .sortable-list li.pinned { border-color: #f2cc60; box-shadow: inset 3px 0 0 #f2cc60; }
+  .pin { cursor: pointer; background: none; border: none; font-size: 16px; color: #f2cc60; padding: 0; line-height: 1; }
+  .item-link { color: #e6edf3; text-decoration: none; font-weight: 600; font-size: 15px; }
+  html[data-theme="light"] .item-link { color: #1f2328; }
+  .item-link:hover { color: #58a6ff; }
+  .item-meta { margin-left: auto; font-size: 12px; color: #6e7681; }
+  .islands { display: flex; gap: 12px; align-items: center; margin: 4px 0 22px; }
+  .island { font-size: 14px; }
+  .island.like { cursor: pointer; background: #161b22; border: 1px solid #30363d; color: #f778ba; border-radius: 8px; padding: 6px 12px; }
+  html[data-theme="light"] .island.like { background: #fff; border-color: #d0d7de; }
+  .island.timer { color: #8b949e; font-variant-numeric: tabular-nums; }
+  .now-playing-bar { position: fixed; left: 50%; transform: translateX(-50%); bottom: 18px; z-index: 50; display: inline-flex; align-items: center; gap: 12px; background: #161b22; border: 1px solid #30363d; border-radius: 999px; padding: 8px 16px; box-shadow: 0 8px 28px rgba(0,0,0,.45); color: #3fb950; font-size: 13px; font-variant-numeric: tabular-nums; }
+  html[data-theme="light"] .now-playing-bar { background: #fff; border-color: #d0d7de; box-shadow: 0 8px 28px rgba(140,149,159,.35); }
+  .np-toggle { cursor: pointer; background: none; border: none; color: inherit; font-size: 15px; padding: 0; line-height: 1; }
+  .np-title { color: #8b949e; }
+  .np-bar { display: inline-block; width: 120px; height: 6px; background: #30363d; border-radius: 999px; overflow: hidden; }
+  html[data-theme="light"] .np-bar { background: #d0d7de; }
+  .np-fill { display: block; height: 100%; background: #3fb950; transition: width .1s linear; }
+  .reader-toolbar { display: flex; align-items: center; gap: 8px; margin-bottom: 18px; padding: 6px 12px; border: 1px solid #30363d; border-radius: 8px; background: #161b22; font-size: 13px; color: #8b949e; }
+  html[data-theme="light"] .reader-toolbar { background: #fff; border-color: #d0d7de; }
+  .rt-label { text-transform: uppercase; letter-spacing: .04em; font-size: 11px; }
+  .rt-btn { cursor: pointer; background: #0d1117; border: 1px solid #30363d; color: #e6edf3; border-radius: 6px; padding: 2px 8px; font-size: 12px; }
+  html[data-theme="light"] .rt-btn { background: #f6f8fa; border-color: #d0d7de; color: #1f2328; }
+  .rt-level { color: #58a6ff; font-variant-numeric: tabular-nums; min-width: 1ch; text-align: center; }
+  .prose p { margin: 0 0 18px; color: #d8e0e8; }
+  html[data-theme="light"] .prose p { color: #424a53; }
+  .back { display: inline-block; margin-bottom: 14px; text-decoration: none; font-size: 14px; }
+  .pager { display: flex; justify-content: space-between; gap: 12px; margin-top: 32px; padding-top: 18px; border-top: 1px solid #30363d; }
+  .pager-link { color: #58a6ff; text-decoration: none; font-weight: 600; font-size: 14px; max-width: 46%; }
+  .pager-link.next { text-align: right; margin-left: auto; }
+  .pager-link.disabled { color: #6e7681; }
+`

--- a/integrations/elysia/client/router-entry.ts
+++ b/integrations/elysia/client/router-entry.ts
@@ -1,0 +1,24 @@
+/**
+ * Client bootstrap for the blog.
+ *
+ * Loaded once per page as a module `<script>`. It:
+ *   1. installs the client-runtime seams the router re-hydrates / disposes
+ *      through (`setupStreaming` → `window.__bf_hydrate_within` +
+ *      `window.__bf_dispose_within`),
+ *   2. starts the router.
+ *
+ * Same-route `?sort=` / `?tag=` navigations become reactive `searchParams()`
+ * updates (no region swap) with no extra wiring here: the router pushes the new
+ * query through the `window.__bf_pushSearch` seam, which `@barefootjs/client`'s
+ * `searchParams()` installs lazily the first time an island reads it.
+ *
+ * `@barefootjs/client*` is left external in the bundle and resolved through the
+ * page's import map to the SAME `barefoot.js` the compiled islands use — so
+ * there is a single reactive runtime instance and `searchParams()` drives the
+ * islands' effects.
+ */
+import { setupStreaming } from '@barefootjs/client/runtime'
+import { startRouter } from '@barefootjs/router'
+
+setupStreaming()
+startRouter()

--- a/integrations/elysia/e2e/blog.spec.ts
+++ b/integrations/elysia/e2e/blog.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect, type Page } from '@playwright/test'
+
+// The blog routes are mounted under the integration's base path.
+const BLOG = '/integrations/elysia/blog'
+
+// Tag a live node with an identity marker; read it back to tell a surviving
+// node (region kept) from a freshly rendered one (region swapped).
+const mark = (page: Page, sel: string) =>
+  page.$eval(sel, (el) => {
+    ;(el as unknown as { __mark?: string }).__mark = 'KEEP'
+  })
+const marker = (page: Page, sel: string) =>
+  page.$eval(sel, (el) => (el as unknown as { __mark?: string }).__mark).catch(() => null)
+
+test('v0.5: sort/tag is a query-only update with no region swap', async ({ page }) => {
+  await page.goto(BLOG, { waitUntil: 'networkidle' })
+  await expect(page.locator('.sortable-list li')).toHaveCount(10)
+  await mark(page, '.content') // the list root — a region swap would replace it
+  await page.click('.controls a.sort:has-text("title")')
+  await page.waitForTimeout(150)
+  const first = await page.locator('.sortable-list li:first-child .item-link').innerText()
+  expect(first[0] === 'A' || first[0] === 'B').toBe(true)
+  expect(await marker(page, '.content')).toBe('KEEP') // not swapped
+  expect(page.url()).toContain('sort=title')
+})
+
+test('v0: clicking a post swaps the content region; shell + theme persist', async ({ page }) => {
+  await page.goto(BLOG, { waitUntil: 'networkidle' })
+  await page.click('.toggle')
+  const theme = await page.getAttribute('html', 'data-theme')
+  await page.click('.sortable-list li:first-child .item-link')
+  await page.waitForSelector('.island.like', { timeout: 3000 })
+  expect(await page.locator('.island.like').count()).toBe(1)
+  expect(await page.getAttribute('html', 'data-theme')).toBe(theme) // shell never reloaded
+  await page.click('.island.like')
+  expect(await page.locator('.island.like .v').innerText()).toBe('1')
+})
+
+test('v1: data-bf-permanent keeps the player live across a post→post swap', async ({ page }) => {
+  test.setTimeout(15000)
+  await page.goto(BLOG, { waitUntil: 'networkidle' })
+  await page.click('.sortable-list li:first-child .item-link')
+  await page.waitForSelector('.now-playing-bar', { timeout: 3000 })
+  await page.click('.now-playing-bar .np-toggle') // ▶ play
+  await page.waitForTimeout(900)
+  const before = Number(await page.locator('.now-playing-bar .np-time').innerText())
+  expect(before).toBeGreaterThan(0.4)
+  await mark(page, '[data-bf-permanent="now-playing"]')
+  await page.click('.pager a.pager-link[href*="/posts/"]')
+  await page.waitForTimeout(400)
+  expect(await marker(page, '[data-bf-permanent="now-playing"]')).toBe('KEEP') // same live node
+  expect(Number(await page.locator('.now-playing-bar .np-time').innerText())).toBeGreaterThanOrEqual(before)
+  expect(Number(await page.locator('.island.timer .v').innerText())).toBeLessThan(0.5) // unmarked timer reset
+})
+
+test('v2 sibling: the sidebar region persists while content swaps', async ({ page }) => {
+  await page.goto(BLOG, { waitUntil: 'networkidle' })
+  await page.click('.sidebar-pin')
+  await page.click('.sidebar-pin')
+  expect(await page.locator('.sidebar-pin .v').innerText()).toBe('2')
+  await mark(page, 'aside[bf-region] .sidebar')
+  await page.click('.sortable-list li:first-child .item-link')
+  await page.waitForSelector('.island.like', { timeout: 3000 })
+  expect(await page.locator('.sidebar-pin .v').innerText()).toBe('2') // state survived
+  expect(await marker(page, 'aside[bf-region] .sidebar')).toBe('KEEP') // same node
+})
+
+test('v2 nested: the outer toolbar region persists while the inner content swaps', async ({ page }) => {
+  await page.goto(BLOG, { waitUntil: 'networkidle' })
+  await page.click('.reader-toolbar .rt-btn[aria-label="larger"]')
+  await page.click('.reader-toolbar .rt-btn[aria-label="larger"]')
+  expect(await page.locator('.reader-toolbar .v').innerText()).toBe('3')
+  await mark(page, '.reader-toolbar')
+  await page.click('.sortable-list li:first-child .item-link')
+  await page.waitForSelector('.island.like', { timeout: 3000 })
+  expect(await page.locator('.reader-toolbar .v').innerText()).toBe('3') // outer region kept
+  expect(await marker(page, '.reader-toolbar')).toBe('KEEP') // same node
+})

--- a/integrations/elysia/e2e/blog.spec.ts
+++ b/integrations/elysia/e2e/blog.spec.ts
@@ -51,6 +51,13 @@ test('v1: data-bf-permanent keeps the player live across a post→post swap', as
   expect(await marker(page, '[data-bf-permanent="now-playing"]')).toBe('KEEP') // same live node
   expect(Number(await page.locator('.now-playing-bar .np-time').innerText())).toBeGreaterThanOrEqual(before)
   expect(Number(await page.locator('.island.timer .v').innerText())).toBeLessThan(0.5) // unmarked timer reset
+  // post → index ("← All posts"): the player is also data-bf-permanent on the
+  // list, so the same live node survives returning to the index — not reset.
+  const elapsed = Number(await page.locator('.now-playing-bar .np-time').innerText())
+  await page.click('.post .back')
+  await page.waitForSelector('.sortable-list li', { timeout: 3000 })
+  expect(await marker(page, '[data-bf-permanent="now-playing"]')).toBe('KEEP') // same live node on the index
+  expect(Number(await page.locator('.now-playing-bar .np-time').innerText())).toBeGreaterThanOrEqual(elapsed)
 })
 
 test('v2 sibling: the sidebar region persists while content swaps', async ({ page }) => {

--- a/integrations/elysia/package.json
+++ b/integrations/elysia/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.1",
   "private": true,
   "scripts": {
-    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/assemble-public.ts",
+    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/build-client.ts && bun run scripts/assemble-public.ts",
     "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
     "dev": "bun run build && wrangler dev",
     "deploy": "bun run build && wrangler deploy",
@@ -14,6 +14,7 @@
     "@barefootjs/client": "workspace:*",
     "@barefootjs/hono": "workspace:*",
     "@barefootjs/jsx": "workspace:*",
+    "@barefootjs/router": "workspace:*",
     "@barefootjs/shared": "workspace:*",
     "elysia": "^1.1.0",
     "hono": "^4"

--- a/integrations/elysia/playwright.config.ts
+++ b/integrations/elysia/playwright.config.ts
@@ -13,6 +13,9 @@ export default defineConfig({
   use: {
     baseURL: 'http://localhost:3005/integrations/elysia',
     trace: 'on-first-retry',
+    // Honour a non-standard Chromium location for local runs; unset in CI, where
+    // Playwright's managed browser is installed.
+    launchOptions: { executablePath: process.env.PW_EXECUTABLE_PATH || undefined },
   },
   projects: [
     {

--- a/integrations/elysia/scripts/build-client.ts
+++ b/integrations/elysia/scripts/build-client.ts
@@ -1,0 +1,37 @@
+/**
+ * Bundle the browser-side bootstrap (`router-entry.js`) next to `barefoot.js`
+ * so one static base (`{BASE}/static/components/`) serves everything.
+ *
+ * `@barefootjs/client*` is kept external so it resolves through the page's
+ * import map to the same `barefoot.js` the compiled islands use — one reactive
+ * runtime instance, so `searchParams()` is a single shared signal and the
+ * router's `__bf_pushSearch` push reaches the islands' effects. The router core
+ * and `@barefootjs/shared` are inlined.
+ */
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(HERE, '..')
+const CLIENT_EXTERNAL = [
+  '@barefootjs/client',
+  '@barefootjs/client/runtime',
+  '@barefootjs/client/reactive',
+]
+
+async function bundle(entry: string, external: string[], label: string): Promise<void> {
+  const result = await Bun.build({
+    entrypoints: [resolve(ROOT, entry)],
+    outdir: resolve(ROOT, 'dist/components'),
+    format: 'esm',
+    target: 'browser',
+    external,
+  })
+  if (!result.success) {
+    for (const log of result.logs) console.error(log)
+    process.exit(1)
+  }
+  console.log(`Generated: ${label}`)
+}
+
+await bundle('client/router-entry.ts', CLIENT_EXTERNAL, 'components/router-entry.js')

--- a/integrations/elysia/server.tsx
+++ b/integrations/elysia/server.tsx
@@ -22,6 +22,7 @@ import { randomUUID } from 'node:crypto'
 import { renderToHtml } from '@barefootjs/hono/render'
 import { withRequestEnv } from '@barefootjs/hono/request-env'
 import { Layout } from './renderer'
+import { renderBlogIndex, renderBlogPost } from './blog'
 import manifest from './dist/components/manifest.json' with { type: 'json' }
 import { Counter } from '@/components/Counter'
 import { Toggle } from '@/components/Toggle'
@@ -140,6 +141,7 @@ const app = new Elysia(onWorkers ? { adapter: CloudflareAdapter } : {})
               <li><a href={link('/todos')}>Todo (@client)</a></li>
               <li><a href={link('/todos-ssr')}>Todo (no @client markers)</a></li>
               <li><a href={link('/ai-chat')}>AI Chat (SSE Streaming)</a></li>
+              <li><a href={link('/blog')}>Blog (@barefootjs/router)</a></li>
             </ul>
           </nav>
         </Layout>,
@@ -235,6 +237,20 @@ const app = new Elysia(onWorkers ? { adapter: CloudflareAdapter } : {})
       ),
     ),
   )
+
+  // ── Blog (@barefootjs/router showcase) — its own region-shell layout ─────
+  .get(link('/blog'), async ({ query }) =>
+    html(await renderToHtml(renderBlogIndex(BASE, manifest, query.tag as string | undefined))),
+  )
+
+  .get(link('/blog/posts/:slug'), async ({ params, set }) => {
+    const node = renderBlogPost(BASE, manifest, params.slug)
+    if (!node) {
+      set.status = 404
+      return 'Not found'
+    }
+    return html(await renderToHtml(node))
+  })
 
   // ── Todo API (relative `api/todos` from the page resolves here) ──────────
   .get(link('/api/todos'), ({ cookie }) => getSession(cookie).todos)

--- a/integrations/h3/blog.tsx
+++ b/integrations/h3/blog.tsx
@@ -130,6 +130,11 @@ export function registerBlog(
     return renderPage(
       <BlogLayout base={base} manifest={manifest} title={title}>
         <PostList items={items} tags={allTags} base={blog} />
+        {/* v1: the player also lives in the content region on the index, marked
+            `data-bf-permanent`, so the router moves the same live node between
+            the list and a post — it keeps playing instead of resetting on
+            "← All posts". */}
+        <NowPlaying />
       </BlogLayout>,
     )
   })

--- a/integrations/h3/e2e/blog.spec.ts
+++ b/integrations/h3/e2e/blog.spec.ts
@@ -51,6 +51,13 @@ test('v1: data-bf-permanent keeps the player live across a post→post swap', as
   expect(await marker(page, '[data-bf-permanent="now-playing"]')).toBe('KEEP') // same live node
   expect(Number(await page.locator('.now-playing-bar .np-time').innerText())).toBeGreaterThanOrEqual(before)
   expect(Number(await page.locator('.island.timer .v').innerText())).toBeLessThan(0.5) // unmarked timer reset
+  // post → index ("← All posts"): the player is also data-bf-permanent on the
+  // list, so the same live node survives returning to the index — not reset.
+  const elapsed = Number(await page.locator('.now-playing-bar .np-time').innerText())
+  await page.click('.post .back')
+  await page.waitForSelector('.sortable-list li', { timeout: 3000 })
+  expect(await marker(page, '[data-bf-permanent="now-playing"]')).toBe('KEEP') // same live node on the index
+  expect(Number(await page.locator('.now-playing-bar .np-time').innerText())).toBeGreaterThanOrEqual(elapsed)
 })
 
 test('v2 sibling: the sidebar region persists while content swaps', async ({ page }) => {

--- a/integrations/hono/blog.tsx
+++ b/integrations/hono/blog.tsx
@@ -89,7 +89,16 @@ blog.get('/', (c) => {
   const tag = c.req.query('tag')
   const items = posts.map((p) => ({ slug: p.slug, title: p.title, date: p.date, tags: p.tags }))
   const title = tag ? `#${tag} — Barefoot Blog` : 'Barefoot Blog — Latest posts'
-  return c.render(<PostList items={items} tags={allTags} base={BASE} />, { title })
+  return c.render(
+    <>
+      <PostList items={items} tags={allTags} base={BASE} />
+      {/* v1: the player also lives in the content region on the index, marked
+          `data-bf-permanent`, so the router moves the same live node between the
+          list and a post — it keeps playing instead of resetting on "← All posts". */}
+      <NowPlaying />
+    </>,
+    { title },
+  )
 })
 
 blog.get('/posts/:slug', (c) => {

--- a/integrations/hono/e2e/blog.spec.ts
+++ b/integrations/hono/e2e/blog.spec.ts
@@ -51,6 +51,13 @@ test('v1: data-bf-permanent keeps the player live across a post→post swap', as
   expect(await marker(page, '[data-bf-permanent="now-playing"]')).toBe('KEEP') // same live node
   expect(Number(await page.locator('.now-playing-bar .np-time').innerText())).toBeGreaterThanOrEqual(before)
   expect(Number(await page.locator('.island.timer .v').innerText())).toBeLessThan(0.5) // unmarked timer reset
+  // post → index ("← All posts"): the player is also data-bf-permanent on the
+  // list, so the same live node survives returning to the index — not reset.
+  const elapsed = Number(await page.locator('.now-playing-bar .np-time').innerText())
+  await page.click('.post .back')
+  await page.waitForSelector('.sortable-list li', { timeout: 3000 })
+  expect(await marker(page, '[data-bf-permanent="now-playing"]')).toBe('KEEP') // same live node on the index
+  expect(Number(await page.locator('.now-playing-bar .np-time').innerText())).toBeGreaterThanOrEqual(elapsed)
 })
 
 test('v2 sibling: the sidebar region persists while content swaps', async ({ page }) => {


### PR DESCRIPTION
## Blog on Elysia — phase 4 (stacked on #1935)

> **Stacked PR.** Base is `claude/blog-h3-phase3` (#1935, merged). This diff is elysia-only plus a cross-adapter player fix on top.

Phase 4 of running the blog (`@barefootjs/router` showcase) **across all adapters**: fold its routes into the **Elysia** integration over the same `shared/blog` components (phase 2 → Hono #1933, phase 3 → h3 #1935).

Like h3, Elysia is just the HTTP host with no `jsxRenderer`. `blog.tsx` exports the region-shell `BlogLayout` plus two JSX builders (`renderBlogIndex`, `renderBlogPost`); `server.tsx` wires them into the Elysia route chain **inline**, so the blog never introduces a second adapter instance.

### What changes (elysia)
- **`blog.tsx`** — `BlogLayout` + builders. Writes its own importmap (adds the `/reactive` key) so islands + router bootstrap share one `barefoot.js` and `searchParams()` stays a single signal.
- **`server.tsx`** — `/blog` + `/blog/posts/:slug` routes + catalog nav link.
- **`barefoot.config.ts`** — also compiles `../shared/blog`.
- **`client/router-entry.ts` + `scripts/build-client.ts`** — bundle the router bootstrap. Adds `@barefootjs/router`.
- **`e2e/blog.spec.ts`** + **`playwright.config.ts`** (`PW_EXECUTABLE_PATH`).

### Player persists across index↔post (hono, h3, elysia)
Follow-up commit: the "Now playing" bar only lived in the post content region, so returning to the index reset it. Now `NowPlaying` is also rendered in the content region on the **index**, still `data-bf-permanent`, so the router moves the same live node between the list and a post — it keeps playing across every navigation. Applied to all three TS adapters; the v1 e2e now also asserts post→index persistence.

### Verification
**57/57 elysia e2e pass** (52 existing + 5 blog). Served HTML has the same 3 regions as Hono/h3 (`nav:0` + compiled `e014722b:0/:1`).

### Next (phased)
Go adapters (chi/echo/gin/nethttp) and Perl (mojolicious/xslate) are being handled in separate threads (the Go family needs go-template adapter compiler fixes first). Then csr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPrN8vCxmBqKcVRVYPnUu2