### PR TITLE
feat(mojolicious): blog showcase (@barefootjs/router demo)

### DIFF
--- a/integrations/elysia/blog.tsx
+++ b/integrations/elysia/blog.tsx
@@ -25,7 +25,7 @@ import { LikeButton } from '@/components/LikeButton'
 import { ReadingTimer } from '@/components/ReadingTimer'
 import { NowPlaying } from '@/components/NowPlaying'
 import { PostList } from '@/components/PostList'
-import { posts, postIndex, allTags } from '../shared/blog/posts'
+import { posts, postIndex, allTags, listItems } from '../shared/blog/posts'
 
 interface LayoutProps {
   base: string
@@ -95,7 +95,7 @@ function BlogLayout({ base, manifest, title, children }: LayoutProps) {
 /** Index page node — the post list reacts to ?sort= / ?tag= via searchParams(). */
 export function renderBlogIndex(base: string, manifest: BarefootBuildManifest, tag?: string) {
   const blog = `${base}/blog`
-  const items = posts.map((p) => ({ slug: p.slug, title: p.title, date: p.date, tags: p.tags }))
+  const items = listItems
   const title = tag ? `#${tag} — Barefoot Blog` : 'Barefoot Blog — Latest posts'
   return (
     <BlogLayout base={base} manifest={manifest} title={title}>

--- a/integrations/h3/blog.tsx
+++ b/integrations/h3/blog.tsx
@@ -35,7 +35,7 @@ import { LikeButton } from '@/components/LikeButton'
 import { ReadingTimer } from '@/components/ReadingTimer'
 import { NowPlaying } from '@/components/NowPlaying'
 import { PostList } from '@/components/PostList'
-import { posts, postIndex, allTags } from '../shared/blog/posts'
+import { posts, postIndex, allTags, listItems } from '../shared/blog/posts'
 
 interface LayoutProps {
   base: string
@@ -125,7 +125,7 @@ export function registerBlog(
   // render of a `?sort=` / `?tag=` URL matches the client with no priming.
   const indexHandler = eventHandler(async (event) => {
     const tag = getQuery(event).tag as string | undefined
-    const items = posts.map((p) => ({ slug: p.slug, title: p.title, date: p.date, tags: p.tags }))
+    const items = listItems
     const title = tag ? `#${tag} — Barefoot Blog` : 'Barefoot Blog — Latest posts'
     return renderPage(
       <BlogLayout base={base} manifest={manifest} title={title}>

--- a/integrations/hono/blog.tsx
+++ b/integrations/hono/blog.tsx
@@ -18,7 +18,7 @@ import { LikeButton } from '@/components/LikeButton'
 import { ReadingTimer } from '@/components/ReadingTimer'
 import { NowPlaying } from '@/components/NowPlaying'
 import { PostList } from '@/components/PostList'
-import { posts, postIndex, allTags } from '../shared/blog/posts'
+import { posts, postIndex, allTags, listItems } from '../shared/blog/posts'
 
 const BASE_PATH = process.env.BASE_PATH ?? '/integrations/hono'
 const STATIC = `${BASE_PATH}/static/components`
@@ -87,7 +87,7 @@ blog.use(blogRenderer)
 // matches the client with no manual priming.
 blog.get('/', (c) => {
   const tag = c.req.query('tag')
-  const items = posts.map((p) => ({ slug: p.slug, title: p.title, date: p.date, tags: p.tags }))
+  const items = listItems
   const title = tag ? `#${tag} — Barefoot Blog` : 'Barefoot Blog — Latest posts'
   return c.render(
     <>

--- a/integrations/mojolicious/app.pl
+++ b/integrations/mojolicious/app.pl
@@ -4,7 +4,9 @@ use Mojolicious::Lite -signatures;
 # container); `../../packages/adapter-mojolicious/lib` is the workspace source (used
 # in local dev). Both are listed so either location resolves.
 use lib 'lib', '../../packages/adapter-mojolicious/lib';
-use Mojo::JSON qw(true false encode_json);
+use Mojo::JSON qw(true false encode_json decode_json);
+use Mojo::ByteStream qw(b);
+use Mojo::Util qw(xml_escape url_escape);
 
 # Load BarefootJS plugin
 plugin 'BarefootJS';
@@ -13,6 +15,10 @@ plugin 'BarefootJS';
 # the app is deploy-ready for barefootjs.dev/integrations/mojolicious.
 my $BASE_PATH = $ENV{BASE_PATH} // '/integrations/mojolicious';
 app->defaults(base_path => $BASE_PATH);
+# Default title so routes that render the `default` layout without setting one
+# (e.g. /counter) don't trip strict-vars on `<%= $title %>` under modern
+# Mojolicious. Routes that set their own title override this.
+app->defaults(title => 'BarefootJS + Mojolicious Example');
 
 # Dev-only browser auto-reload (no-op in production). The companion snippet
 # is emitted in the layout below via `bf_dev_snippet`. The plugin registers
@@ -411,6 +417,313 @@ $r->post('/api/todos/reset' => sub ($c) {
     $session->{todos}   = seed_todos();
     $session->{next_id} = 4;
     $c->rendered(200);
+});
+
+# ---------------------------------------------------------------------------
+# Blog — the @barefootjs/router showcase (mojolicious)
+#
+# Mirrors integrations/hono/blog.tsx: a region-shell layout (header +
+# ThemeToggle in the shell, a hand-authored sidebar region `nav:0` + the
+# compiled <PageShell> nested content regions in the main column) whose islands
+# are the shared blog components in ../shared/blog, compiled by this
+# integration's `bf build`. The client router (client/router-entry.ts, bundled
+# to client/router-entry.js) swaps only the content region on navigation.
+#
+# Unlike Hono — where the whole page is one JSX tree — there is no server JSX
+# here: the page is composed in Perl from individually-rendered island
+# templates (`blog_island`), each sharing the request's script collector so
+# `bf->scripts` emits the full set once.
+#
+# searchParams() SSR (router v0.5): the derived `params` / `visible` memos of
+# PostList are not statically lowerable to a template-string adapter, so their
+# SSR defaults are null (the same class of limitation the Go adapter has). We
+# seed `params` from the request query (correct sort/tag labels on the server)
+# and seed `visible` with the full item list as a graceful fallback; the client
+# re-derives the sorted/filtered list from `searchParams()` on hydration.
+# ---------------------------------------------------------------------------
+
+my $BLOG_MANIFEST = do {
+    my $f = app->home->child('dist/templates/manifest.json');
+    -r $f ? decode_json($f->slurp) : {};
+};
+my $BLOG_DATA = do {
+    my $f = app->home->child('dist/blog-data.json');
+    -r $f ? decode_json($f->slurp) : { posts => [], listItems => [], allTags => [] };
+};
+
+# Blog styles — the same design-system block the Hono showcase inlines, so the
+# region-shell page is self-contained (it does not use the catalog stylesheets).
+my $BLOG_STYLES = <<'CSS';
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  html[data-theme="light"] { color-scheme: light; }
+  body { margin: 0; font: 16px/1.6 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background: #0e1116; color: #e6edf3; }
+  html[data-theme="light"] body { background: #f6f8fa; color: #1f2328; }
+  a { color: #58a6ff; }
+  .shell { position: sticky; top: 0; z-index: 10; display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 14px 24px; background: #161b22; border-bottom: 1px solid #30363d; }
+  html[data-theme="light"] .shell { background: #fff; border-bottom-color: #d0d7de; }
+  .shell-brand { font-weight: 700; font-size: 18px; text-decoration: none; color: inherit; }
+  .shell-island { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+  .toggle { cursor: pointer; background: #0d1117; border: 1px solid #30363d; color: #e6edf3; border-radius: 999px; padding: 5px 12px; font-size: 13px; }
+  html[data-theme="light"] .toggle { background: #f6f8fa; border-color: #d0d7de; color: #1f2328; }
+  .layout { display: flex; gap: 28px; align-items: flex-start; max-width: 1000px; margin: 0 auto; padding: 32px 24px 80px; }
+  .layout main { flex: 1; min-width: 0; }
+  .layout aside { position: sticky; top: 78px; width: 210px; flex: none; }
+  html[data-theme="light"] .sidebar { background: #fff; border-color: #d0d7de; }
+  .sidebar { background: #161b22; border: 1px solid #30363d; border-radius: 12px; padding: 16px; }
+  .sidebar-title { font-weight: 700; font-size: 13px; text-transform: uppercase; letter-spacing: .04em; color: #8b949e; margin-bottom: 12px; }
+  .sidebar-pin { cursor: pointer; width: 100%; background: #0d1117; border: 1px solid #30363d; color: #f2cc60; border-radius: 8px; padding: 8px 12px; font-size: 14px; font-variant-numeric: tabular-nums; }
+  html[data-theme="light"] .sidebar-pin { background: #f6f8fa; border-color: #d0d7de; }
+  .sidebar-note { font-size: 12px; color: #6e7681; margin: 12px 0 0; }
+  @media (max-width: 720px) { .layout { flex-direction: column; } .layout aside { position: static; width: 100%; } }
+  .page-title { font-size: 28px; margin: 0 0 6px; }
+  .lede, .meta { color: #8b949e; }
+  html[data-theme="light"] .lede, html[data-theme="light"] .meta { color: #57606a; }
+  .meta { font-size: 13px; margin-bottom: 12px; }
+  .lede { margin: 0 0 18px; }
+  .controls, .tags { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-bottom: 10px; }
+  .ctl-label { font-size: 13px; color: #6e7681; }
+  .tag, .tag-inline, .sort { text-decoration: none; font-size: 13px; color: #9aa7b4; }
+  .tag, .sort { border: 1px solid #30363d; border-radius: 999px; padding: 4px 11px; }
+  .tag.on, .sort.on { background: #1f6feb; border-color: #1f6feb; color: #fff; }
+  .tag-inline { color: #58a6ff; }
+  .status { font-size: 13px; color: #8b949e; margin-bottom: 12px; min-height: 1.2em; font-variant-numeric: tabular-nums; }
+  .sortable-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 8px; }
+  .sortable-list li { display: flex; align-items: center; gap: 10px; border: 1px solid #30363d; border-radius: 10px; background: #161b22; padding: 10px 14px; }
+  html[data-theme="light"] .sortable-list li { background: #fff; border-color: #d0d7de; }
+  .sortable-list li.pinned { border-color: #f2cc60; box-shadow: inset 3px 0 0 #f2cc60; }
+  .pin { cursor: pointer; background: none; border: none; font-size: 16px; color: #f2cc60; padding: 0; line-height: 1; }
+  .item-link { color: #e6edf3; text-decoration: none; font-weight: 600; font-size: 15px; }
+  html[data-theme="light"] .item-link { color: #1f2328; }
+  .item-link:hover { color: #58a6ff; }
+  .item-meta { margin-left: auto; font-size: 12px; color: #6e7681; }
+  .islands { display: flex; gap: 12px; align-items: center; margin: 4px 0 22px; }
+  .island { font-size: 14px; }
+  .island.like { cursor: pointer; background: #161b22; border: 1px solid #30363d; color: #f778ba; border-radius: 8px; padding: 6px 12px; }
+  html[data-theme="light"] .island.like { background: #fff; border-color: #d0d7de; }
+  .island.timer { color: #8b949e; font-variant-numeric: tabular-nums; }
+  .now-playing-bar { position: fixed; left: 50%; transform: translateX(-50%); bottom: 18px; z-index: 50; display: inline-flex; align-items: center; gap: 12px; background: #161b22; border: 1px solid #30363d; border-radius: 999px; padding: 8px 16px; box-shadow: 0 8px 28px rgba(0,0,0,.45); color: #3fb950; font-size: 13px; font-variant-numeric: tabular-nums; }
+  html[data-theme="light"] .now-playing-bar { background: #fff; border-color: #d0d7de; box-shadow: 0 8px 28px rgba(140,149,159,.35); }
+  .np-toggle { cursor: pointer; background: none; border: none; color: inherit; font-size: 15px; padding: 0; line-height: 1; }
+  .np-title { color: #8b949e; }
+  .np-bar { display: inline-block; width: 120px; height: 6px; background: #30363d; border-radius: 999px; overflow: hidden; }
+  html[data-theme="light"] .np-bar { background: #d0d7de; }
+  .np-fill { display: block; height: 100%; background: #3fb950; transition: width .1s linear; }
+  .reader-toolbar { display: flex; align-items: center; gap: 8px; margin-bottom: 18px; padding: 6px 12px; border: 1px solid #30363d; border-radius: 8px; background: #161b22; font-size: 13px; color: #8b949e; }
+  html[data-theme="light"] .reader-toolbar { background: #fff; border-color: #d0d7de; }
+  .rt-label { text-transform: uppercase; letter-spacing: .04em; font-size: 11px; }
+  .rt-btn { cursor: pointer; background: #0d1117; border: 1px solid #30363d; color: #e6edf3; border-radius: 6px; padding: 2px 8px; font-size: 12px; }
+  html[data-theme="light"] .rt-btn { background: #f6f8fa; border-color: #d0d7de; color: #1f2328; }
+  .rt-level { color: #58a6ff; font-variant-numeric: tabular-nums; min-width: 1ch; text-align: center; }
+  .prose p { margin: 0 0 18px; color: #d8e0e8; }
+  html[data-theme="light"] .prose p { color: #424a53; }
+  .back { display: inline-block; margin-bottom: 14px; text-decoration: none; font-size: 14px; }
+  .pager { display: flex; justify-content: space-between; gap: 12px; margin-top: 32px; padding-top: 18px; border-top: 1px solid #30363d; }
+  .pager-link { color: #58a6ff; text-decoration: none; font-weight: 600; font-size: 14px; max-width: 46%; }
+  .pager-link.next { text-align: right; margin-left: auto; }
+  .pager-link.disabled { color: #6e7681; }
+CSS
+
+sub _rand6 { return substr(rand() =~ s/^0\.//r, 0, 6) }
+
+# Register a renderer for a flat (non-`ui/*`) child component the build manifest
+# knows about (`post_list_item` → PostListItem, `reader_toolbar` → ReaderToolbar).
+# Mirrors the closure `register_components_from_manifest` builds for UI-registry
+# entries: a fresh child scope chained off the caller's slot, the shared script
+# collector + renderer registry, and the manifest's ssrDefaults seeded (the
+# caller's matching prop wins).
+sub _register_blog_child ($c, $parent_bf, $slot, $component) {
+    my $entry = $BLOG_MANIFEST->{$component} or return;
+    my $defaults = $entry->{ssrDefaults};
+    $parent_bf->register_child_renderer($slot, sub {
+        my ($props, $caller) = @_;
+        my $host = $caller // $parent_bf;
+        my $host_scope = $host->_scope_id;
+        my $child = BarefootJS->new($c, { backend => $parent_bf->backend });
+        my $slot_id  = delete $props->{_bf_slot};
+        my $data_key = delete $props->{key};
+        $child->_data_key($data_key) if defined $data_key;
+        $child->_scope_id($slot_id ? $host_scope . '_' . $slot_id : $component . '_' . _rand6());
+        $child->_is_child(1);
+        if ($slot_id) { $child->_bf_parent($host_scope); $child->_bf_mount($slot_id) }
+        $child->_child_renderers($parent_bf->_child_renderers);
+        $child->_scripts($parent_bf->_scripts);
+        $child->_script_seen($parent_bf->_script_seen);
+        my %extra = $defaults
+            ? BarefootJS::_derive_stash_from_defaults($defaults, $props) : ();
+        my $html = $parent_bf->backend->render_named($component, $child, { %$props, %extra });
+        chomp $html;
+        return $html;
+    });
+}
+
+# Render a single top-level island template to an HTML string. The island gets
+# its own scope id but shares the request bf's script collector + renderer
+# registry, so multiple islands compose into one page and `bf->scripts` emits
+# the union once.
+#
+#   $props    — the component's props. Serialised into `bf-p` (so the client
+#               hydration sees them) AND fed to SSR as template vars. PostList's
+#               `visible()` memo reactively reads `props.items`, so these MUST
+#               reach the client, not just the server.
+#   $extra    — SSR-only template vars: the derived memo / getter values that
+#               are not statically lowerable (`params`, `visible`, the
+#               sort/tag class+href scalars). The client re-derives these from
+#               `searchParams()` on hydration, so they stay out of `bf-p`.
+#   $children — slot key → child template to register for this island's nested
+#               `render_child` calls.
+helper blog_island => sub ($c, $component, $props = {}, $extra = {}, $children = {}) {
+    my $root = $c->bf;
+    my $bf = BarefootJS->new($c, { backend => $root->backend });
+    $bf->_scope_id($component . '_' . _rand6());
+    $bf->_props($props) if %$props;
+    $bf->_scripts($root->_scripts);
+    $bf->_script_seen($root->_script_seen);
+    $bf->_child_renderers($root->_child_renderers);
+    _register_blog_child($c, $bf, $_, $children->{$_}) for keys %$children;
+    my $defaults = ($BLOG_MANIFEST->{$component} // {})->{ssrDefaults};
+    my %seed = $defaults
+        ? BarefootJS::_derive_stash_from_defaults($defaults, $props) : ();
+    # `%seed` first, then props (provide `$items`/`$tags`/`$base`), then `%extra`
+    # (the computed `params`/`visible`/… override the seeded nulls).
+    return $root->backend->render_named($component, $bf, { %seed, %$props, %$extra });
+};
+
+# Assemble the full region-shell page around already-rendered content HTML.
+sub _blog_page ($c, $title, $base, $content_html) {
+    my $static = "$BASE_PATH/client";
+    my $theme   = $c->blog_island('ThemeToggle');
+    my $sidebar = $c->blog_island('Sidebar');
+    my $shell   = $c->blog_island(
+        'PageShell',
+        {},                                       # no client props
+        { children => b($content_html) },         # SSR-only: the page content
+        { reader_toolbar => 'ReaderToolbar' },
+    );
+    # `searchParams()` lives in the single physical `@barefootjs/client/reactive`
+    # module re-exported by every `@barefootjs/client*` entry, so the islands and
+    # the router bootstrap share ONE signal instance by resolving the bare
+    # specifiers to the same `barefoot.js`.
+    my $importmap = encode_json({ imports => {
+        '@barefootjs/client'         => "$static/barefoot.js",
+        '@barefootjs/client/runtime' => "$static/barefoot.js",
+        '@barefootjs/client/reactive'=> "$static/barefoot.js",
+    } });
+    my $scripts = $c->bf->scripts;
+    my $esc_title = xml_escape($title);
+    return <<"HTML";
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>$esc_title</title>
+<script type="importmap">$importmap</script>
+<style>$BLOG_STYLES</style>
+</head>
+<body>
+<header class="shell">
+<a class="shell-brand" href="$base">\x{1F4F0} Barefoot Blog</a>
+<div class="shell-island">$theme</div>
+</header>
+<div class="layout">
+<aside bf-region="nav:0">$sidebar</aside>
+<main>$shell</main>
+</div>
+$scripts
+<script type="module" src="$static/router-entry.js"></script>
+</body>
+</html>
+HTML
+}
+
+# The article body for a post page (hand-authored HTML, mirroring the Hono post
+# route). Like / ReadingTimer / NowPlaying are pre-rendered islands spliced in.
+sub _article_html ($c, $p, $i, $prev, $next, $base, $like, $timer, $now) {
+    my $n = scalar @{ $BLOG_DATA->{posts} };
+    my $tags_inline = CORE::join '', map {
+        my $t = $_;
+        my $href = "$base?tag=" . url_escape($t);
+        qq{<a class="tag-inline" href="$href">#@{[ xml_escape($t) ]} </a>}
+    } @{ $p->{tags} };
+    my $prose = CORE::join '', map { '<p>' . xml_escape($_) . '</p>' } @{ $p->{body} };
+    my $pager_prev = $prev
+        ? qq{<a class="pager-link" href="$base/posts/$prev->{slug}">\x{2190} @{[ xml_escape($prev->{title}) ]}</a>}
+        : qq{<span class="pager-link disabled">\x{2190} Start</span>};
+    my $pager_next = $next
+        ? qq{<a class="pager-link next" href="$base/posts/$next->{slug}">@{[ xml_escape($next->{title}) ]} \x{2192}</a>}
+        : qq{<a class="pager-link next" href="$base">Back to start \x{2192}</a>};
+    my $title = xml_escape($p->{title});
+    my $date  = xml_escape($p->{date});
+    my $slug  = xml_escape($p->{slug});
+    my $num   = $i + 1;
+    return <<"HTML";
+<article class="post" data-slug="$slug">
+<a class="back" href="$base">\x{2190} All posts</a>
+<h1 class="page-title">$title</h1>
+<div class="meta">$date \x{B7} post $num of $n \x{B7} $tags_inline</div>
+<div class="islands">$like$timer</div>
+$now
+<div class="prose">$prose</div>
+<nav class="pager">$pager_prev$pager_next</nav>
+</article>
+HTML
+}
+
+my $r_blog = $r;
+
+# Index — PostList + NowPlaying in the content region. NowPlaying lives on the
+# index too (data-bf-permanent) so the router moves the same live node between
+# the list and a post.
+$r_blog->get('/blog' => sub ($c) {
+    my $sort  = $c->param('sort') // 'date';
+    my $tag   = $c->param('tag')  // '';
+    my $base  = "$BASE_PATH/blog";
+    my $items = $BLOG_DATA->{listItems};
+    my $post_list = $c->blog_island(
+        'PostList',
+        # Client props (→ bf-p): `visible()` re-derives from these on every
+        # `searchParams()` change, so they must reach the client.
+        { items => $items, tags => $BLOG_DATA->{allTags}, base => $base },
+        {
+            # SSR-only derived values. `params` is seeded from the request query
+            # for correct server-side labels; `visible` falls back to the full
+            # list (the client re-sorts/filters on hydration). The per-link sort
+            # /tag class+href getters collapse to one SSR scalar each (the
+            # compiler can't tell `sortClass('date')` from `sortClass('title')`
+            # statically), so seed neutral defaults — the client sets the
+            # correct active highlight + hrefs per link from `searchParams()`.
+            params    => { sort => $sort, tag => $tag },
+            visible   => $items,
+            sortClass => 'sort',
+            sortHref  => $base,
+            tagClass  => 'tag',
+            tagHref   => $base,
+        },
+        { post_list_item => 'PostListItem' },
+    );
+    my $now = $c->blog_island('NowPlaying', {}, { Math => { min => 0 } });
+    my $title = length $tag ? "#$tag \x{2014} Barefoot Blog" : "Barefoot Blog \x{2014} Latest posts";
+    $c->render(text => _blog_page($c, $title, $base, $post_list . $now), format => 'html');
+});
+
+$r_blog->get('/blog/posts/:slug' => sub ($c) {
+    my $slug  = $c->param('slug');
+    my $posts = $BLOG_DATA->{posts};
+    my ($i) = grep { $posts->[$_]{slug} eq $slug } 0 .. $#$posts;
+    return $c->reply->not_found unless defined $i;
+    my $p    = $posts->[$i];
+    my $prev = $i > 0        ? $posts->[$i - 1] : undef;
+    my $next = $i < $#$posts ? $posts->[$i + 1] : undef;
+    my $base = "$BASE_PATH/blog";
+    my $like  = $c->blog_island('LikeButton');
+    my $timer = $c->blog_island('ReadingTimer');
+    my $now   = $c->blog_island('NowPlaying', {}, { Math => { min => 0 } });
+    my $content = _article_html($c, $p, $i, $prev, $next, $base, $like, $timer, $now);
+    $c->render(
+        text   => _blog_page($c, "$p->{title} \x{2014} Barefoot Blog", $base, $content),
+        format => 'html',
+    );
 });
 
 app->start;

--- a/integrations/mojolicious/barefoot.config.ts
+++ b/integrations/mojolicious/barefoot.config.ts
@@ -4,7 +4,7 @@ const basePath = process.env.BASE_PATH ?? '/integrations/mojolicious'
 const clientBase = `${basePath}/client/`
 
 export default createConfig({
-  components: ['../shared/components'],
+  components: ['../shared/components', '../shared/blog'],
   outDir: 'dist',
   minify: true,
   adapterOptions: {

--- a/integrations/mojolicious/client/router-entry.ts
+++ b/integrations/mojolicious/client/router-entry.ts
@@ -1,0 +1,24 @@
+/**
+ * Client bootstrap for the blog (Mojolicious integration).
+ *
+ * Loaded once per page as a module `<script>`. It:
+ *   1. installs the client-runtime seams the router re-hydrates / disposes
+ *      through (`setupStreaming` → `window.__bf_hydrate_within` +
+ *      `window.__bf_dispose_within`),
+ *   2. starts the router.
+ *
+ * Same-route `?sort=` / `?tag=` navigations become reactive `searchParams()`
+ * updates (no region swap) with no extra wiring here: the router pushes the new
+ * query through the `window.__bf_pushSearch` seam, which `@barefootjs/client`'s
+ * `searchParams()` installs lazily the first time an island reads it.
+ *
+ * `@barefootjs/client*` is left external in the bundle and resolved through the
+ * page's import map to the SAME `barefoot.js` the compiled islands use — so
+ * there is a single reactive runtime instance and `searchParams()` drives the
+ * islands' effects.
+ */
+import { setupStreaming } from '@barefootjs/client/runtime'
+import { startRouter } from '@barefootjs/router'
+
+setupStreaming()
+startRouter()

--- a/integrations/mojolicious/e2e/blog.spec.ts
+++ b/integrations/mojolicious/e2e/blog.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect, type Page } from '@playwright/test'
+
+// The blog routes are mounted under the integration's base path. Same specs as
+// the Hono reference (integrations/hono/e2e/blog.spec.ts); only the mount point
+// differs — the shared blog islands are base-path aware.
+const BLOG = '/integrations/mojolicious/blog'
+
+// Tag a live node with an identity marker; read it back to tell a surviving
+// node (region kept) from a freshly rendered one (region swapped).
+const mark = (page: Page, sel: string) =>
+  page.$eval(sel, (el) => {
+    ;(el as unknown as { __mark?: string }).__mark = 'KEEP'
+  })
+const marker = (page: Page, sel: string) =>
+  page.$eval(sel, (el) => (el as unknown as { __mark?: string }).__mark).catch(() => null)
+
+test('v0.5: sort/tag is a query-only update with no region swap', async ({ page }) => {
+  await page.goto(BLOG, { waitUntil: 'networkidle' })
+  await expect(page.locator('.sortable-list li')).toHaveCount(10)
+  await mark(page, '.content') // the list root — a region swap would replace it
+  await page.click('.controls a.sort:has-text("title")')
+  await page.waitForTimeout(150)
+  const first = await page.locator('.sortable-list li:first-child .item-link').innerText()
+  expect(first[0] === 'A' || first[0] === 'B').toBe(true)
+  expect(await marker(page, '.content')).toBe('KEEP') // not swapped
+  expect(page.url()).toContain('sort=title')
+})
+
+test('v0: clicking a post swaps the content region; shell + theme persist', async ({ page }) => {
+  await page.goto(BLOG, { waitUntil: 'networkidle' })
+  await page.click('.toggle')
+  const theme = await page.getAttribute('html', 'data-theme')
+  await page.click('.sortable-list li:first-child .item-link')
+  await page.waitForSelector('.island.like', { timeout: 3000 })
+  expect(await page.locator('.island.like').count()).toBe(1)
+  expect(await page.getAttribute('html', 'data-theme')).toBe(theme) // shell never reloaded
+  await page.click('.island.like')
+  expect(await page.locator('.island.like .v').innerText()).toBe('1')
+})
+
+test('v1: data-bf-permanent keeps the player live across a post→post swap', async ({ page }) => {
+  test.setTimeout(15000)
+  await page.goto(BLOG, { waitUntil: 'networkidle' })
+  await page.click('.sortable-list li:first-child .item-link')
+  await page.waitForSelector('.now-playing-bar', { timeout: 3000 })
+  await page.click('.now-playing-bar .np-toggle') // ▶ play
+  await page.waitForTimeout(900)
+  const before = Number(await page.locator('.now-playing-bar .np-time').innerText())
+  expect(before).toBeGreaterThan(0.4)
+  await mark(page, '[data-bf-permanent="now-playing"]')
+  await page.click('.pager a.pager-link[href*="/posts/"]')
+  await page.waitForTimeout(400)
+  expect(await marker(page, '[data-bf-permanent="now-playing"]')).toBe('KEEP') // same live node
+  expect(Number(await page.locator('.now-playing-bar .np-time').innerText())).toBeGreaterThanOrEqual(before)
+  expect(Number(await page.locator('.island.timer .v').innerText())).toBeLessThan(0.5) // unmarked timer reset
+  // post → index ("← All posts"): the player is also data-bf-permanent on the
+  // list, so the same live node survives returning to the index — not reset.
+  const elapsed = Number(await page.locator('.now-playing-bar .np-time').innerText())
+  await page.click('.post .back')
+  await page.waitForSelector('.sortable-list li', { timeout: 3000 })
+  expect(await marker(page, '[data-bf-permanent="now-playing"]')).toBe('KEEP') // same live node on the index
+  expect(Number(await page.locator('.now-playing-bar .np-time').innerText())).toBeGreaterThanOrEqual(elapsed)
+})
+
+test('v2 sibling: the sidebar region persists while content swaps', async ({ page }) => {
+  await page.goto(BLOG, { waitUntil: 'networkidle' })
+  await page.click('.sidebar-pin')
+  await page.click('.sidebar-pin')
+  expect(await page.locator('.sidebar-pin .v').innerText()).toBe('2')
+  await mark(page, 'aside[bf-region] .sidebar')
+  await page.click('.sortable-list li:first-child .item-link')
+  await page.waitForSelector('.island.like', { timeout: 3000 })
+  expect(await page.locator('.sidebar-pin .v').innerText()).toBe('2') // state survived
+  expect(await marker(page, 'aside[bf-region] .sidebar')).toBe('KEEP') // same node
+})
+
+test('v2 nested: the outer toolbar region persists while the inner content swaps', async ({ page }) => {
+  await page.goto(BLOG, { waitUntil: 'networkidle' })
+  await page.click('.reader-toolbar .rt-btn[aria-label="larger"]')
+  await page.click('.reader-toolbar .rt-btn[aria-label="larger"]')
+  expect(await page.locator('.reader-toolbar .v').innerText()).toBe('3')
+  await mark(page, '.reader-toolbar')
+  await page.click('.sortable-list li:first-child .item-link')
+  await page.waitForSelector('.island.like', { timeout: 3000 })
+  expect(await page.locator('.reader-toolbar .v').innerText()).toBe('3') // outer region kept
+  expect(await marker(page, '.reader-toolbar')).toBe('KEEP') // same node
+})

--- a/integrations/mojolicious/package.json
+++ b/integrations/mojolicious/package.json
@@ -3,12 +3,16 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/assemble-deps.ts",
+    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/gen-blog-data.ts && bun run scripts/build-client.ts && bun run scripts/assemble-deps.ts",
     "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
     "dev": "BASE_PATH=/integrations/mojolicious perl app.pl daemon -l 'http://*:3004'",
     "deploy": "bun run build && wrangler deploy",
     "test:e2e": "bunx playwright test",
     "test:e2e:ui": "bunx playwright test --ui"
+  },
+  "dependencies": {
+    "@barefootjs/client": "workspace:*",
+    "@barefootjs/router": "workspace:*"
   },
   "devDependencies": {
     "@barefootjs/jsx": "workspace:*",

--- a/integrations/mojolicious/playwright.config.ts
+++ b/integrations/mojolicious/playwright.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   use: {
     baseURL: 'http://localhost:3004',
     trace: 'on-first-retry',
+    launchOptions: { executablePath: process.env.PW_EXECUTABLE_PATH || undefined },
   },
   projects: [
     {

--- a/integrations/mojolicious/scripts/build-client.ts
+++ b/integrations/mojolicious/scripts/build-client.ts
@@ -1,0 +1,40 @@
+/**
+ * Bundle the browser-side router bootstrap (`router-entry.js`) into
+ * `dist/client/` next to the `bf build`-emitted `barefoot.js`, so the single
+ * static base (`/integrations/mojolicious/client/`) the Mojolicious app serves
+ * carries everything the blog page loads.
+ *
+ * `@barefootjs/client*` is kept external so it resolves through the page's
+ * import map to the same `barefoot.js` the compiled islands use — one reactive
+ * runtime instance, so `searchParams()` is a single shared signal and the
+ * router's `__bf_pushSearch` push reaches the islands' effects. The router core
+ * and `@barefootjs/shared` are inlined.
+ */
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(HERE, '..')
+const CLIENT_EXTERNAL = [
+  '@barefootjs/client',
+  '@barefootjs/client/runtime',
+  '@barefootjs/client/reactive',
+]
+
+async function bundle(entry: string, external: string[], label: string): Promise<void> {
+  const result = await Bun.build({
+    entrypoints: [resolve(ROOT, entry)],
+    outdir: resolve(ROOT, 'dist/client'),
+    format: 'esm',
+    target: 'browser',
+    external,
+    minify: true,
+  })
+  if (!result.success) {
+    for (const log of result.logs) console.error(log)
+    process.exit(1)
+  }
+  console.log(`Generated: ${label}`)
+}
+
+await bundle('client/router-entry.ts', CLIENT_EXTERNAL, 'client/router-entry.js')

--- a/integrations/mojolicious/scripts/gen-blog-data.ts
+++ b/integrations/mojolicious/scripts/gen-blog-data.ts
@@ -1,0 +1,25 @@
+/**
+ * Emit `dist/blog-data.json` for the Perl blog routes.
+ *
+ * The shared blog islands (`../shared/blog/*`) are authored in TS and compiled
+ * to Mojolicious templates by `bf build`, but the *data* the index/post routes
+ * render (the post corpus, the derived list items with their pre-rendered
+ * `meta`, the tag set) lives in `../shared/blog/posts.ts` — TS the Perl server
+ * can't import. Rather than hand-transcribe the corpus into Perl (fragile, and
+ * the kind of duplication the showcase explicitly avoids), this build step
+ * imports the single source of truth and writes it as JSON that `app.pl` reads
+ * at startup. The TS adapters import `posts.ts` directly; the Perl app reads
+ * this JSON — both stay in sync with one authored corpus.
+ */
+import { mkdir, writeFile } from 'node:fs/promises'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { posts, listItems, allTags } from '../../shared/blog/posts'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(HERE, '..')
+const OUT = resolve(ROOT, 'dist/blog-data.json')
+
+await mkdir(dirname(OUT), { recursive: true })
+await writeFile(OUT, JSON.stringify({ posts, listItems, allTags }, null, 0))
+console.log(`Generated: dist/blog-data.json (${posts.length} posts)`)

--- a/integrations/shared/blog/PostList.tsx
+++ b/integrations/shared/blog/PostList.tsx
@@ -8,6 +8,13 @@ interface Item {
   title: string
   date: string
   tags: string[]
+  /**
+   * Pre-rendered meta line (`<date> · #tag #tag`), supplied by the caller. It
+   * is NOT built here from `p.tags` because a value-producing `.map().join()`
+   * in the island template can't be lowered for SSR on the template-string
+   * adapters (Go / Perl) — see `ListItem.meta` in `posts.ts`.
+   */
+  meta: string
 }
 
 type SortKey = 'date' | 'title' | 'tag'
@@ -101,7 +108,7 @@ export function PostList(props: PostListProps) {
             href={`${base}/posts/${p.slug}`}
             title={p.title}
             date={p.date}
-            meta={`${p.date} · ${p.tags.map((t) => `#${t}`).join(' ')}`}
+            meta={p.meta}
           />
         ))}
       </ol>

--- a/integrations/shared/blog/posts.ts
+++ b/integrations/shared/blog/posts.ts
@@ -130,6 +130,36 @@ export const posts: Post[] = [
   },
 ]
 
+/** The item shape the index list renders — the post fields the list needs plus
+ *  a pre-rendered `meta` line. */
+export interface ListItem {
+  slug: string
+  title: string
+  date: string
+  tags: string[]
+  /**
+   * Pre-rendered meta line (`<date> · #tag #tag`). Computed here, NOT inside
+   * the `PostList` island, on purpose: building it in the island needs a
+   * value-producing tag-map-join, a shape the template-string adapters
+   * (Go / Mojolicious / Xslate) can't lower for SSR (it trips the compiler's
+   * `UNSUPPORTED_METHODS` gate → BF101). Pre-computing
+   * it upstream keeps the island's template a plain member access (`p.meta`),
+   * so the same shared component compiles on every adapter. JS-runtime adapters
+   * (Hono / h3 / Elysia) render a byte-identical string.
+   */
+  meta: string
+}
+
+/** Index-list items derived from `posts`, with `meta` pre-rendered. The Perl
+ *  adapters build the equivalent array in their own backend language. */
+export const listItems: ListItem[] = posts.map((p) => ({
+  slug: p.slug,
+  title: p.title,
+  date: p.date,
+  tags: p.tags,
+  meta: `${p.date} · ${p.tags.map((t) => `#${t}`).join(' ')}`,
+}))
+
 export const allTags: string[] = [...new Set(posts.flatMap((p) => p.tags))].sort()
 
 export function postIndex(slug: string): number {


### PR DESCRIPTION
## What

Ports the `@barefootjs/router` **blog showcase** (reference: `integrations/hono/blog.tsx`) to the **Mojolicious** adapter, reusing the same shared islands in `integrations/shared/blog`. Phase 4 of running the blog across every adapter (after Hono #1933 / h3 #1935 / Elysia #1936).

This PR contains two commits:
1. **`fix(blog)`** — a shared workaround needed by *all* template-string adapters (see below). Byte-identical output for the JS-runtime adapters.
2. **`feat(mojolicious)`** — the Mojolicious integration.

## Feasibility findings (why the shared fix)

Building the shared blog islands on the Perl adapters surfaced one hard blocker:

- **`PostList` `meta` (`p.tags.map((t) => \`#${t}\`).join(' ')`)** → **BF101**. A value-producing `.map(cb).join()` (callback returns a string, not JSX) has no SSR lowering on the template-string adapters — it's refused at the **core compiler** level (`expression-parser`'s `UNSUPPORTED_METHODS`), so Go / Mojolicious / Xslate all reject it; only the JS-runtime adapters compile it. Fixed by pre-computing `meta` upstream in a shared `listItems` helper and rendering `p.meta` (a plain member access every adapter can lower).

Everything else compiles and runs:
- `<Region>` / `bf-region` ✅, `searchParams()` SSR (#1922) ✅, the `·` status-row template literal ✅, the keyed `.map` over the imported `PostListItem` ✅ (CLI suppresses BF103 via `siblingTemplatesRegistered`).

### Known SSR-fidelity limitation (same class as the Go adapter)

`PostList`'s `params` / `visible` memos and the per-link sort/tag class+href getters are **not statically lowerable** to a template-string adapter — their `ssrDefaults` are `null`. The route seeds `params` from the request query and `visible` with the full list, so the server renders all 10 posts; the **client** re-derives the sorted/filtered list and the active controls from `searchParams()` on hydration.

## How it's built

- `barefoot.config.ts`: compile the `shared/blog` islands.
- `app.pl`: `/blog` + `/blog/posts/:slug`, composed in Perl from individually-rendered island templates (`blog_island`) sharing one script collector; hand-authored `nav:0` sidebar region beside the compiled `<PageShell>` nested content regions.
- `scripts/gen-blog-data.ts` → `dist/blog-data.json` from the single shared `posts.ts` (no hand-transcribed Perl corpus).
- `client/router-entry.ts` + `scripts/build-client.ts`: bundle `setupStreaming() + startRouter()`, `@barefootjs/client*` external.
- `e2e/blog.spec.ts`: the Hono blog specs re-pointed at the Mojolicious mount.

Also: default `title` stash value (so `/counter` etc. don't trip strict-vars under modern Mojolicious) and `PW_EXECUTABLE_PATH` wired into the Playwright config to match the other integrations.

## Tests

- `bun run build` clean (0 errors).
- **All 103 Mojolicious e2e pass** locally, including the 5 new blog specs (v0 region swap + theme persist, v0.5 query-only sort/filter, v1 `data-bf-permanent` player across post→post and post→index, v2 sibling sidebar region, v2 nested toolbar region).
- Hono builds clean with the shared change (TS adapters unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXtoP11H8gTgJvwUuz7iK2)_