### PR TITLE
feat(xslate): blog showcase (@barefootjs/router demo)

### DIFF
--- a/integrations/xslate/app.psgi
+++ b/integrations/xslate/app.psgi
@@ -322,10 +322,293 @@ sub api_todos_reset ($req) {
     [200, ['Content-Type' => 'text/plain'], ['ok']];
 }
 
+# ---------------------------------------------------------------------------
+# Blog — the @barefootjs/router showcase (Text::Xslate)
+#
+# Mirrors integrations/hono/blog.tsx and the Mojolicious port: a region-shell
+# layout (header + ThemeToggle in the shell, a hand-authored sidebar region
+# `nav:0` + the compiled <PageShell> nested content regions in the main column)
+# whose islands are the shared blog components in ../shared/blog, compiled by
+# this integration's `bf build`. The client router (client/router-entry.ts,
+# bundled to client/router-entry.js) swaps only the content region.
+#
+# There is no server JSX here: the page is composed in Perl from individually-
+# rendered island templates (`blog_island`), each sharing one request-scoped
+# script collector (`$root`) so the page emits the union of <script> tags once.
+#
+# searchParams() SSR (router v0.5): PostList's derived `params` / `visible`
+# memos and the per-link sort/tag getters are not statically lowerable to a
+# template-string adapter (their ssrDefaults are null — the same limitation the
+# Go adapter has). We seed `params` from the request query and `visible` with
+# the full list, so the server renders all posts; the client re-derives the
+# sorted/filtered list + active controls from `searchParams()` on hydration.
+# ---------------------------------------------------------------------------
+sub _slurp_json ($path) {
+    open my $fh, '<:raw', $path or return undef;
+    local $/;
+    my $content = <$fh>;
+    close $fh;
+    return eval { $J->decode($content) };
+}
+my $BLOG_MANIFEST = _slurp_json('dist/templates/manifest.json') // {};
+my $BLOG_DATA = _slurp_json('dist/blog-data.json')
+    // { posts => [], listItems => [], allTags => [] };
+
+# Blog styles — the same design-system block the Hono showcase inlines, so the
+# region-shell page is self-contained (it does not use the catalog stylesheets).
+my $BLOG_STYLES = <<'CSS';
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  html[data-theme="light"] { color-scheme: light; }
+  body { margin: 0; font: 16px/1.6 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background: #0e1116; color: #e6edf3; }
+  html[data-theme="light"] body { background: #f6f8fa; color: #1f2328; }
+  a { color: #58a6ff; }
+  .shell { position: sticky; top: 0; z-index: 10; display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 14px 24px; background: #161b22; border-bottom: 1px solid #30363d; }
+  html[data-theme="light"] .shell { background: #fff; border-bottom-color: #d0d7de; }
+  .shell-brand { font-weight: 700; font-size: 18px; text-decoration: none; color: inherit; }
+  .shell-island { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+  .toggle { cursor: pointer; background: #0d1117; border: 1px solid #30363d; color: #e6edf3; border-radius: 999px; padding: 5px 12px; font-size: 13px; }
+  html[data-theme="light"] .toggle { background: #f6f8fa; border-color: #d0d7de; color: #1f2328; }
+  .layout { display: flex; gap: 28px; align-items: flex-start; max-width: 1000px; margin: 0 auto; padding: 32px 24px 80px; }
+  .layout main { flex: 1; min-width: 0; }
+  .layout aside { position: sticky; top: 78px; width: 210px; flex: none; }
+  html[data-theme="light"] .sidebar { background: #fff; border-color: #d0d7de; }
+  .sidebar { background: #161b22; border: 1px solid #30363d; border-radius: 12px; padding: 16px; }
+  .sidebar-title { font-weight: 700; font-size: 13px; text-transform: uppercase; letter-spacing: .04em; color: #8b949e; margin-bottom: 12px; }
+  .sidebar-pin { cursor: pointer; width: 100%; background: #0d1117; border: 1px solid #30363d; color: #f2cc60; border-radius: 8px; padding: 8px 12px; font-size: 14px; font-variant-numeric: tabular-nums; }
+  html[data-theme="light"] .sidebar-pin { background: #f6f8fa; border-color: #d0d7de; }
+  .sidebar-note { font-size: 12px; color: #6e7681; margin: 12px 0 0; }
+  @media (max-width: 720px) { .layout { flex-direction: column; } .layout aside { position: static; width: 100%; } }
+  .page-title { font-size: 28px; margin: 0 0 6px; }
+  .lede, .meta { color: #8b949e; }
+  html[data-theme="light"] .lede, html[data-theme="light"] .meta { color: #57606a; }
+  .meta { font-size: 13px; margin-bottom: 12px; }
+  .lede { margin: 0 0 18px; }
+  .controls, .tags { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-bottom: 10px; }
+  .ctl-label { font-size: 13px; color: #6e7681; }
+  .tag, .tag-inline, .sort { text-decoration: none; font-size: 13px; color: #9aa7b4; }
+  .tag, .sort { border: 1px solid #30363d; border-radius: 999px; padding: 4px 11px; }
+  .tag.on, .sort.on { background: #1f6feb; border-color: #1f6feb; color: #fff; }
+  .tag-inline { color: #58a6ff; }
+  .status { font-size: 13px; color: #8b949e; margin-bottom: 12px; min-height: 1.2em; font-variant-numeric: tabular-nums; }
+  .sortable-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 8px; }
+  .sortable-list li { display: flex; align-items: center; gap: 10px; border: 1px solid #30363d; border-radius: 10px; background: #161b22; padding: 10px 14px; }
+  html[data-theme="light"] .sortable-list li { background: #fff; border-color: #d0d7de; }
+  .sortable-list li.pinned { border-color: #f2cc60; box-shadow: inset 3px 0 0 #f2cc60; }
+  .pin { cursor: pointer; background: none; border: none; font-size: 16px; color: #f2cc60; padding: 0; line-height: 1; }
+  .item-link { color: #e6edf3; text-decoration: none; font-weight: 600; font-size: 15px; }
+  html[data-theme="light"] .item-link { color: #1f2328; }
+  .item-link:hover { color: #58a6ff; }
+  .item-meta { margin-left: auto; font-size: 12px; color: #6e7681; }
+  .islands { display: flex; gap: 12px; align-items: center; margin: 4px 0 22px; }
+  .island { font-size: 14px; }
+  .island.like { cursor: pointer; background: #161b22; border: 1px solid #30363d; color: #f778ba; border-radius: 8px; padding: 6px 12px; }
+  html[data-theme="light"] .island.like { background: #fff; border-color: #d0d7de; }
+  .island.timer { color: #8b949e; font-variant-numeric: tabular-nums; }
+  .now-playing-bar { position: fixed; left: 50%; transform: translateX(-50%); bottom: 18px; z-index: 50; display: inline-flex; align-items: center; gap: 12px; background: #161b22; border: 1px solid #30363d; border-radius: 999px; padding: 8px 16px; box-shadow: 0 8px 28px rgba(0,0,0,.45); color: #3fb950; font-size: 13px; font-variant-numeric: tabular-nums; }
+  html[data-theme="light"] .now-playing-bar { background: #fff; border-color: #d0d7de; box-shadow: 0 8px 28px rgba(140,149,159,.35); }
+  .np-toggle { cursor: pointer; background: none; border: none; color: inherit; font-size: 15px; padding: 0; line-height: 1; }
+  .np-title { color: #8b949e; }
+  .np-bar { display: inline-block; width: 120px; height: 6px; background: #30363d; border-radius: 999px; overflow: hidden; }
+  html[data-theme="light"] .np-bar { background: #d0d7de; }
+  .np-fill { display: block; height: 100%; background: #3fb950; transition: width .1s linear; }
+  .reader-toolbar { display: flex; align-items: center; gap: 8px; margin-bottom: 18px; padding: 6px 12px; border: 1px solid #30363d; border-radius: 8px; background: #161b22; font-size: 13px; color: #8b949e; }
+  html[data-theme="light"] .reader-toolbar { background: #fff; border-color: #d0d7de; }
+  .rt-label { text-transform: uppercase; letter-spacing: .04em; font-size: 11px; }
+  .rt-btn { cursor: pointer; background: #0d1117; border: 1px solid #30363d; color: #e6edf3; border-radius: 6px; padding: 2px 8px; font-size: 12px; }
+  html[data-theme="light"] .rt-btn { background: #f6f8fa; border-color: #d0d7de; color: #1f2328; }
+  .rt-level { color: #58a6ff; font-variant-numeric: tabular-nums; min-width: 1ch; text-align: center; }
+  .prose p { margin: 0 0 18px; color: #d8e0e8; }
+  html[data-theme="light"] .prose p { color: #424a53; }
+  .back { display: inline-block; margin-bottom: 14px; text-decoration: none; font-size: 14px; }
+  .pager { display: flex; justify-content: space-between; gap: 12px; margin-top: 32px; padding-top: 18px; border-top: 1px solid #30363d; }
+  .pager-link { color: #58a6ff; text-decoration: none; font-weight: 600; font-size: 14px; max-width: 46%; }
+  .pager-link.next { text-align: right; margin-left: auto; }
+  .pager-link.disabled { color: #6e7681; }
+CSS
+
+sub _esc ($s) { return BarefootJS::_html_escape($s) }
+sub _url_esc ($s) {
+    my $e = defined $s ? "$s" : '';
+    $e =~ s/([^A-Za-z0-9_.~-])/sprintf('%%%02X', ord $1)/ge;
+    return $e;
+}
+
+# Register a renderer for a flat (non-`ui/*`) child component from the build
+# manifest (`post_list_item` → PostListItem, `reader_toolbar` → ReaderToolbar):
+# a fresh child scope chained off the caller's slot, the shared script collector
+# + renderer registry, and the manifest's ssrDefaults seeded (caller prop wins).
+sub _register_blog_child ($parent_bf, $slot, $component) {
+    my $entry = $BLOG_MANIFEST->{$component} or return;
+    my $defaults = $entry->{ssrDefaults};
+    $parent_bf->register_child_renderer($slot, sub {
+        my ($props, $caller) = @_;
+        my $host = $caller // $parent_bf;
+        my $host_scope = $host->_scope_id;
+        my $child = BarefootJS->new(undef, { backend => $backend });
+        my $slot_id  = delete $props->{_bf_slot};
+        my $data_key = delete $props->{key};
+        $child->_data_key($data_key) if defined $data_key;
+        $child->_scope_id($slot_id ? "${host_scope}_${slot_id}"
+                                   : "${component}_" . rand_suffix());
+        $child->_is_child(1);
+        if ($slot_id) { $child->_bf_parent($host_scope); $child->_bf_mount($slot_id) }
+        $child->_child_renderers($parent_bf->_child_renderers);
+        $child->_scripts($parent_bf->_scripts);
+        $child->_script_seen($parent_bf->_script_seen);
+        my %extra = $defaults
+            ? BarefootJS::_derive_stash_from_defaults($defaults, $props) : ();
+        return $backend->render_named($component, $child, { %$props, %extra });
+    });
+}
+
+# Render one top-level island to an HTML string, sharing `$root`'s script
+# collector + renderer registry so islands compose into one page.
+#   $props    — props (→ bf-p, so the client hydration sees them, AND template vars)
+#   $extra    — SSR-only template vars (derived memo / getter values not lowered)
+#   $children — slot key → child template to register for nested render_child
+sub blog_island ($root, $component, $props = {}, $extra = {}, $children = {}) {
+    my $bf = BarefootJS->new(undef, { backend => $backend });
+    $bf->_scope_id($component . '_' . rand_suffix());
+    $bf->_props($props) if %$props;
+    $bf->_scripts($root->_scripts);
+    $bf->_script_seen($root->_script_seen);
+    $bf->_child_renderers($root->_child_renderers);
+    _register_blog_child($bf, $_, $children->{$_}) for keys %$children;
+    my $defaults = ($BLOG_MANIFEST->{$component} // {})->{ssrDefaults};
+    my %seed = $defaults
+        ? BarefootJS::_derive_stash_from_defaults($defaults, $props) : ();
+    return $backend->render_named($component, $bf, { %seed, %$props, %$extra });
+}
+
+# Assemble the region-shell page around already-rendered content HTML. `$root`
+# is the request-scoped runtime whose script collector the content islands (and
+# the shell islands rendered here) all share.
+sub blog_page ($root, $title, $base, $content_html) {
+    my $static    = "$BASE/client";
+    my $theme     = blog_island($root, 'ThemeToggle');
+    my $sidebar   = blog_island($root, 'Sidebar');
+    my $shell     = blog_island($root, 'PageShell',
+        {},                                                # no client props
+        { children => $backend->mark_raw($content_html) }, # SSR-only: page content
+        { reader_toolbar => 'ReaderToolbar' });
+    my $importmap = $J->encode({ imports => {
+        '@barefootjs/client'          => "$static/barefoot.js",
+        '@barefootjs/client/runtime'  => "$static/barefoot.js",
+        '@barefootjs/client/reactive' => "$static/barefoot.js",
+    } });
+    my $scripts   = $root->scripts;
+    my $esc_title = _esc($title);
+    return <<"HTML";
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>$esc_title</title>
+<script type="importmap">$importmap</script>
+<style>$BLOG_STYLES</style>
+</head>
+<body>
+<header class="shell">
+<a class="shell-brand" href="$base">\x{1F4F0} Barefoot Blog</a>
+<div class="shell-island">$theme</div>
+</header>
+<div class="layout">
+<aside bf-region="nav:0">$sidebar</aside>
+<main>$shell</main>
+</div>
+$scripts
+<script type="module" src="$static/router-entry.js"></script>
+</body>
+</html>
+HTML
+}
+
+# The article body for a post page (hand-authored HTML, mirroring the Hono post
+# route). Like / ReadingTimer / NowPlaying are pre-rendered islands spliced in.
+sub blog_article_html ($p, $i, $prev, $next, $base, $like, $timer, $now) {
+    my $n = scalar @{ $BLOG_DATA->{posts} };
+    my $tags_inline = join '', map {
+        my $t = $_;
+        '<a class="tag-inline" href="' . "$base?tag=" . _url_esc($t) . '">#' . _esc($t) . ' </a>'
+    } @{ $p->{tags} };
+    my $prose = join '', map { '<p>' . _esc($_) . '</p>' } @{ $p->{body} };
+    my $pager_prev = $prev
+        ? '<a class="pager-link" href="' . "$base/posts/$prev->{slug}" . '">' . "\x{2190} " . _esc($prev->{title}) . '</a>'
+        : '<span class="pager-link disabled">' . "\x{2190} Start" . '</span>';
+    my $pager_next = $next
+        ? '<a class="pager-link next" href="' . "$base/posts/$next->{slug}" . '">' . _esc($next->{title}) . " \x{2192}" . '</a>'
+        : '<a class="pager-link next" href="' . $base . '">' . "Back to start \x{2192}" . '</a>';
+    my $title = _esc($p->{title});
+    my $date  = _esc($p->{date});
+    my $slug  = _esc($p->{slug});
+    my $num   = $i + 1;
+    return <<"HTML";
+<article class="post" data-slug="$slug">
+<a class="back" href="$base">\x{2190} All posts</a>
+<h1 class="page-title">$title</h1>
+<div class="meta">$date \x{B7} post $num of $n \x{B7} $tags_inline</div>
+<div class="islands">$like$timer</div>
+$now
+<div class="prose">$prose</div>
+<nav class="pager">$pager_prev$pager_next</nav>
+</article>
+HTML
+}
+
+sub blog_index_route ($req) {
+    my $root  = BarefootJS->new(undef, { backend => $backend });
+    my $base  = "$BASE/blog";
+    my $sort  = $req->query_parameters->{sort} // 'date';
+    my $tag   = $req->query_parameters->{tag}  // '';
+    my $items = $BLOG_DATA->{listItems};
+    my $post_list = blog_island($root, 'PostList',
+        # Client props (→ bf-p): `visible()` re-derives from these on every
+        # `searchParams()` change, so they must reach the client.
+        { items => $items, tags => $BLOG_DATA->{allTags}, base => $base },
+        {
+            # SSR-only derived values. `params` from the request query (correct
+            # server-side labels); `visible` falls back to the full list. The
+            # per-link sort/tag class+href getters collapse to one SSR scalar
+            # each (the compiler can't tell `sortClass('date')` from
+            # `sortClass('title')` statically), so seed neutral defaults — the
+            # client sets the correct active highlight + hrefs from searchParams.
+            params    => { sort => $sort, tag => $tag },
+            visible   => $items,
+            sortClass => 'sort',
+            sortHref  => $base,
+            tagClass  => 'tag',
+            tagHref   => $base,
+        },
+        { post_list_item => 'PostListItem' });
+    my $now = blog_island($root, 'NowPlaying', {}, { Math => { min => 0 } });
+    my $title = length $tag ? "#$tag \x{2014} Barefoot Blog" : "Barefoot Blog \x{2014} Latest posts";
+    html_response(blog_page($root, $title, $base, $post_list . $now));
+}
+
+sub blog_post_route ($req, $slug) {
+    my $posts = $BLOG_DATA->{posts};
+    my ($i) = grep { $posts->[$_]{slug} eq $slug } 0 .. $#$posts;
+    return [404, ['Content-Type' => 'text/plain'], ['Not Found']] unless defined $i;
+    my $p    = $posts->[$i];
+    my $prev = $i > 0        ? $posts->[$i - 1] : undef;
+    my $next = $i < $#$posts ? $posts->[$i + 1] : undef;
+    my $base = "$BASE/blog";
+    my $root  = BarefootJS->new(undef, { backend => $backend });
+    my $like  = blog_island($root, 'LikeButton');
+    my $timer = blog_island($root, 'ReadingTimer');
+    my $now   = blog_island($root, 'NowPlaying', {}, { Math => { min => 0 } });
+    my $content = blog_article_html($p, $i, $prev, $next, $base, $like, $timer, $now);
+    html_response(blog_page($root, "$p->{title} \x{2014} Barefoot Blog", $base, $content));
+}
+
 # Route table: [ METHOD, path pattern, handler ]. First match wins; any regex
 # captures (e.g. /api/todos/(\d+), /todos(-ssr)?) are passed to the handler
 # after the request.
 my @ROUTES = (
+    [ GET    => qr{^/blog$}                       => \&blog_index_route ],
+    [ GET    => qr{^/blog/posts/([^/]+)$}         => \&blog_post_route ],
     [ GET    => qr{^/$}                           => \&home_route ],
     [ GET    => qr{^/counter$}                    => \&counter_route ],
     [ GET    => qr{^/toggle$}                     => \&toggle_route ],

--- a/integrations/xslate/barefoot.config.ts
+++ b/integrations/xslate/barefoot.config.ts
@@ -4,7 +4,7 @@ const basePath = process.env.BASE_PATH ?? '/integrations/xslate'
 const clientBase = `${basePath}/client/`
 
 export default createConfig({
-  components: ['../shared/components'],
+  components: ['../shared/components', '../shared/blog'],
   outDir: 'dist',
   minify: true,
   adapterOptions: {

--- a/integrations/xslate/client/router-entry.ts
+++ b/integrations/xslate/client/router-entry.ts
@@ -1,0 +1,24 @@
+/**
+ * Client bootstrap for the blog (Text::Xslate integration).
+ *
+ * Loaded once per page as a module `<script>`. It:
+ *   1. installs the client-runtime seams the router re-hydrates / disposes
+ *      through (`setupStreaming` → `window.__bf_hydrate_within` +
+ *      `window.__bf_dispose_within`),
+ *   2. starts the router.
+ *
+ * Same-route `?sort=` / `?tag=` navigations become reactive `searchParams()`
+ * updates (no region swap) with no extra wiring here: the router pushes the new
+ * query through the `window.__bf_pushSearch` seam, which `@barefootjs/client`'s
+ * `searchParams()` installs lazily the first time an island reads it.
+ *
+ * `@barefootjs/client*` is left external in the bundle and resolved through the
+ * page's import map to the SAME `barefoot.js` the compiled islands use — so
+ * there is a single reactive runtime instance and `searchParams()` drives the
+ * islands' effects.
+ */
+import { setupStreaming } from '@barefootjs/client/runtime'
+import { startRouter } from '@barefootjs/router'
+
+setupStreaming()
+startRouter()

--- a/integrations/xslate/e2e/blog.spec.ts
+++ b/integrations/xslate/e2e/blog.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect, type Page } from '@playwright/test'
+
+// The blog routes are mounted under the integration's base path. Same specs as
+// the Hono reference (integrations/hono/e2e/blog.spec.ts); only the mount point
+// differs — the shared blog islands are base-path aware.
+const BLOG = '/integrations/xslate/blog'
+
+// Tag a live node with an identity marker; read it back to tell a surviving
+// node (region kept) from a freshly rendered one (region swapped).
+const mark = (page: Page, sel: string) =>
+  page.$eval(sel, (el) => {
+    ;(el as unknown as { __mark?: string }).__mark = 'KEEP'
+  })
+const marker = (page: Page, sel: string) =>
+  page.$eval(sel, (el) => (el as unknown as { __mark?: string }).__mark).catch(() => null)
+
+test('v0.5: sort/tag is a query-only update with no region swap', async ({ page }) => {
+  await page.goto(BLOG, { waitUntil: 'networkidle' })
+  await expect(page.locator('.sortable-list li')).toHaveCount(10)
+  await mark(page, '.content') // the list root — a region swap would replace it
+  await page.click('.controls a.sort:has-text("title")')
+  await page.waitForTimeout(150)
+  const first = await page.locator('.sortable-list li:first-child .item-link').innerText()
+  expect(first[0] === 'A' || first[0] === 'B').toBe(true)
+  expect(await marker(page, '.content')).toBe('KEEP') // not swapped
+  expect(page.url()).toContain('sort=title')
+})
+
+test('v0: clicking a post swaps the content region; shell + theme persist', async ({ page }) => {
+  await page.goto(BLOG, { waitUntil: 'networkidle' })
+  await page.click('.toggle')
+  const theme = await page.getAttribute('html', 'data-theme')
+  await page.click('.sortable-list li:first-child .item-link')
+  await page.waitForSelector('.island.like', { timeout: 3000 })
+  expect(await page.locator('.island.like').count()).toBe(1)
+  expect(await page.getAttribute('html', 'data-theme')).toBe(theme) // shell never reloaded
+  await page.click('.island.like')
+  expect(await page.locator('.island.like .v').innerText()).toBe('1')
+})
+
+test('v1: data-bf-permanent keeps the player live across a post→post swap', async ({ page }) => {
+  test.setTimeout(15000)
+  await page.goto(BLOG, { waitUntil: 'networkidle' })
+  await page.click('.sortable-list li:first-child .item-link')
+  await page.waitForSelector('.now-playing-bar', { timeout: 3000 })
+  await page.click('.now-playing-bar .np-toggle') // ▶ play
+  await page.waitForTimeout(900)
+  const before = Number(await page.locator('.now-playing-bar .np-time').innerText())
+  expect(before).toBeGreaterThan(0.4)
+  await mark(page, '[data-bf-permanent="now-playing"]')
+  await page.click('.pager a.pager-link[href*="/posts/"]')
+  await page.waitForTimeout(400)
+  expect(await marker(page, '[data-bf-permanent="now-playing"]')).toBe('KEEP') // same live node
+  expect(Number(await page.locator('.now-playing-bar .np-time').innerText())).toBeGreaterThanOrEqual(before)
+  expect(Number(await page.locator('.island.timer .v').innerText())).toBeLessThan(0.5) // unmarked timer reset
+  // post → index ("← All posts"): the player is also data-bf-permanent on the
+  // list, so the same live node survives returning to the index — not reset.
+  const elapsed = Number(await page.locator('.now-playing-bar .np-time').innerText())
+  await page.click('.post .back')
+  await page.waitForSelector('.sortable-list li', { timeout: 3000 })
+  expect(await marker(page, '[data-bf-permanent="now-playing"]')).toBe('KEEP') // same live node on the index
+  expect(Number(await page.locator('.now-playing-bar .np-time').innerText())).toBeGreaterThanOrEqual(elapsed)
+})
+
+test('v2 sibling: the sidebar region persists while content swaps', async ({ page }) => {
+  await page.goto(BLOG, { waitUntil: 'networkidle' })
+  await page.click('.sidebar-pin')
+  await page.click('.sidebar-pin')
+  expect(await page.locator('.sidebar-pin .v').innerText()).toBe('2')
+  await mark(page, 'aside[bf-region] .sidebar')
+  await page.click('.sortable-list li:first-child .item-link')
+  await page.waitForSelector('.island.like', { timeout: 3000 })
+  expect(await page.locator('.sidebar-pin .v').innerText()).toBe('2') // state survived
+  expect(await marker(page, 'aside[bf-region] .sidebar')).toBe('KEEP') // same node
+})
+
+test('v2 nested: the outer toolbar region persists while the inner content swaps', async ({ page }) => {
+  await page.goto(BLOG, { waitUntil: 'networkidle' })
+  await page.click('.reader-toolbar .rt-btn[aria-label="larger"]')
+  await page.click('.reader-toolbar .rt-btn[aria-label="larger"]')
+  expect(await page.locator('.reader-toolbar .v').innerText()).toBe('3')
+  await mark(page, '.reader-toolbar')
+  await page.click('.sortable-list li:first-child .item-link')
+  await page.waitForSelector('.island.like', { timeout: 3000 })
+  expect(await page.locator('.reader-toolbar .v').innerText()).toBe('3') // outer region kept
+  expect(await marker(page, '.reader-toolbar')).toBe('KEEP') // same node
+})

--- a/integrations/xslate/package.json
+++ b/integrations/xslate/package.json
@@ -3,12 +3,16 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/assemble-deps.ts",
+    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/gen-blog-data.ts && bun run scripts/build-client.ts && bun run scripts/assemble-deps.ts",
     "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
     "dev": "BASE_PATH=/integrations/xslate plackup -s Starman --workers 5 -p 3007 app.psgi",
     "deploy": "bun run build && wrangler deploy",
     "test:e2e": "bunx playwright test",
     "test:e2e:ui": "bunx playwright test --ui"
+  },
+  "dependencies": {
+    "@barefootjs/client": "workspace:*",
+    "@barefootjs/router": "workspace:*"
   },
   "devDependencies": {
     "@barefootjs/jsx": "workspace:*",

--- a/integrations/xslate/playwright.config.ts
+++ b/integrations/xslate/playwright.config.ts
@@ -21,7 +21,17 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'BASE_PATH=/integrations/xslate plackup -s Starman --workers 3 -p 3007 app.psgi',
+    // Run the test server in production mode with a larger Starman worker pool.
+    // In dev mode every page that emits the DevReload snippet opens a persistent
+    // SSE connection that pins one Starman prefork worker for the page's
+    // lifetime; a full sequential run starves the pool and the server stops
+    // responding (`net::ERR_ABORTED`). Production mode drops DevReload entirely
+    // (tests don't need hot reload) and exercises the production render path
+    // (template cache on); the wider pool absorbs the SSE/streaming endpoints
+    // (DevReload, the AI-chat stream) without starving. Mojolicious is immune to
+    // this because its daemon is a single-process event loop.
+    command:
+      'BASE_PATH=/integrations/xslate PLACK_ENV=production plackup -s Starman --workers 10 -p 3007 app.psgi',
     url: 'http://localhost:3007/integrations/xslate/',
     reuseExistingServer: !process.env.CI,
     timeout: 30000,

--- a/integrations/xslate/playwright.config.ts
+++ b/integrations/xslate/playwright.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   use: {
     baseURL: 'http://localhost:3007',
     trace: 'on-first-retry',
+    launchOptions: { executablePath: process.env.PW_EXECUTABLE_PATH || undefined },
   },
   projects: [
     {

--- a/integrations/xslate/scripts/build-client.ts
+++ b/integrations/xslate/scripts/build-client.ts
@@ -1,0 +1,40 @@
+/**
+ * Bundle the browser-side router bootstrap (`router-entry.js`) into
+ * `dist/client/` next to the `bf build`-emitted `barefoot.js`, so the single
+ * static base (`/integrations/xslate/client/`) the PSGI app serves carries
+ * everything the blog page loads.
+ *
+ * `@barefootjs/client*` is kept external so it resolves through the page's
+ * import map to the same `barefoot.js` the compiled islands use — one reactive
+ * runtime instance, so `searchParams()` is a single shared signal and the
+ * router's `__bf_pushSearch` push reaches the islands' effects. The router core
+ * and `@barefootjs/shared` are inlined.
+ */
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(HERE, '..')
+const CLIENT_EXTERNAL = [
+  '@barefootjs/client',
+  '@barefootjs/client/runtime',
+  '@barefootjs/client/reactive',
+]
+
+async function bundle(entry: string, external: string[], label: string): Promise<void> {
+  const result = await Bun.build({
+    entrypoints: [resolve(ROOT, entry)],
+    outdir: resolve(ROOT, 'dist/client'),
+    format: 'esm',
+    target: 'browser',
+    external,
+    minify: true,
+  })
+  if (!result.success) {
+    for (const log of result.logs) console.error(log)
+    process.exit(1)
+  }
+  console.log(`Generated: ${label}`)
+}
+
+await bundle('client/router-entry.ts', CLIENT_EXTERNAL, 'client/router-entry.js')

--- a/integrations/xslate/scripts/gen-blog-data.ts
+++ b/integrations/xslate/scripts/gen-blog-data.ts
@@ -1,0 +1,25 @@
+/**
+ * Emit `dist/blog-data.json` for the Perl blog routes.
+ *
+ * The shared blog islands (`../shared/blog/*`) are authored in TS and compiled
+ * to Text::Xslate templates by `bf build`, but the *data* the index/post routes
+ * render (the post corpus, the derived list items with their pre-rendered
+ * `meta`, the tag set) lives in `../shared/blog/posts.ts` — TS the Perl server
+ * can't import. Rather than hand-transcribe the corpus into Perl (fragile, and
+ * the kind of duplication the showcase explicitly avoids), this build step
+ * imports the single source of truth and writes it as JSON that `app.psgi`
+ * reads at startup. The TS adapters import `posts.ts` directly; the Perl app
+ * reads this JSON — both stay in sync with one authored corpus.
+ */
+import { mkdir, writeFile } from 'node:fs/promises'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { posts, listItems, allTags } from '../../shared/blog/posts'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(HERE, '..')
+const OUT = resolve(ROOT, 'dist/blog-data.json')
+
+await mkdir(dirname(OUT), { recursive: true })
+await writeFile(OUT, JSON.stringify({ posts, listItems, allTags }, null, 0))
+console.log(`Generated: dist/blog-data.json (${posts.length} posts)`)


### PR DESCRIPTION
## What

Ports the `@barefootjs/router` **blog showcase** to the **Text::Xslate** adapter, reusing the same shared islands in `integrations/shared/blog`. Completes the Perl side of running the blog across every adapter.

> **Stacked on #1938** (`claude/blog-mojolicious-perl`). Base this on that branch — the shared `PostList` meta fix and the feasibility findings live there. This PR is the Xslate integration only.

## How it's built

Mirrors the Mojolicious port (#1938), adapted to the Plack/PSGI app and Kolon (`.tx`) templates:

- `barefoot.config.ts`: compile the `shared/blog` islands.
- `app.psgi`: `/blog` + `/blog/posts/:slug`, composed in Perl from individually-rendered island templates (`blog_island`) that share one request-scoped script collector (`$root`); hand-authored `nav:0` sidebar region beside the compiled `<PageShell>` nested content regions; the client router swaps only the inner region. Reads the corpus from `dist/blog-data.json`.
- `scripts/gen-blog-data.ts` → `dist/blog-data.json` from the single shared `posts.ts` (no hand-transcribed Perl corpus).
- `client/router-entry.ts` + `scripts/build-client.ts`: bundle `setupStreaming() + startRouter()`, `@barefootjs/client*` external.
- `e2e/blog.spec.ts`: the Hono blog specs re-pointed at the Xslate mount.

### SSR-fidelity note (same as #1938)

PostList's `params` / `visible` memos and the per-link sort/tag getters are not statically lowerable to a template-string adapter (null `ssrDefaults`). `params` is seeded from the request query and `visible` falls back to the full list, so the server renders all 10 posts; the client re-derives the sorted/filtered list + active controls from `searchParams()` on hydration.

## Tests

- `bun run build` clean (0 errors); `perl -c app.psgi` OK.
- **The 5 new blog specs pass** (v0 / v0.5 / v1 / v2 sibling + nested).
- Full Xslate e2e: **91/103 pass** (~1.6 min). Blog + ai-chat + everything else green.

### Test-server fix included here

The Playwright `webServer` started Starman in **dev mode with 3 workers**. In dev mode every page that emits the DevReload snippet opens a persistent SSE connection (`EventSource` → the blocking poll loop in `BarefootJS::DevReload`), pinning one prefork worker for the page's lifetime; a full sequential run starved the pool and the server stopped responding (`net::ERR_ABORTED` — the suite collapsed to 7/65). Mojolicious is immune because its daemon is a single-process event loop.

Fixed by running the test server with `PLACK_ENV=production` (drops DevReload — e2e doesn't need hot reload — and exercises the production render path) and `--workers 10`. No more collapse.

### ⚠️ One pre-existing failure set, NOT from this PR

The remaining **12 failures (`reactive-props` ×11, `toggle` ×1)** are a pre-existing Xslate-adapter issue, independent of the blog:
- They fail in **dev mode too** (worse: 23/27), so production mode isn't the cause.
- They **pass on the Mojolicious adapter** (103/103) and are **green on the TS adapters in CI** — the shared specs/components are fine.
- Their `.tx` templates / client JS are byte-identical to the base branch.

Perl integrations aren't run in CI (only `e2e-hono` / `e2e-h3` / `e2e-elysia`), so this is a local-run observation. Logged in the known-limitations catalog (#1395); left as-is here as out of scope for the blog showcase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)