### PR TITLE
refactor(blog): share the post article + CSS across all adapters

### DIFF
--- a/integrations/elysia/blog.tsx
+++ b/integrations/elysia/blog.tsx
@@ -21,10 +21,9 @@ import type { BarefootBuildManifest } from '@barefootjs/hono/app'
 import { Sidebar } from '@/components/Sidebar'
 import { PageShell } from '@/components/PageShell'
 import { ThemeToggle } from '@/components/ThemeToggle'
-import { LikeButton } from '@/components/LikeButton'
-import { ReadingTimer } from '@/components/ReadingTimer'
 import { NowPlaying } from '@/components/NowPlaying'
 import { PostList } from '@/components/PostList'
+import { PostArticle } from '@/components/PostArticle'
 import { posts, postIndex, allTags, listItems } from '../shared/blog/posts'
 
 interface LayoutProps {
@@ -57,7 +56,7 @@ function BlogLayout({ base, manifest, title, children }: LayoutProps) {
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>{title ?? 'Barefoot Blog'}</title>
         <script type="importmap" dangerouslySetInnerHTML={{ __html: importMap }} />
-        <style dangerouslySetInnerHTML={{ __html: STYLES }} />
+        <link rel="stylesheet" href={`${base}/shared/styles/blog.css`} />
       </head>
       <body>
         <header className="shell">
@@ -116,115 +115,24 @@ export function renderBlogPost(base: string, manifest: BarefootBuildManifest, sl
   const p = posts[i]
   const prev = posts[i - 1]
   const next = posts[i + 1]
+  // The whole article is the shared <PostArticle> island (nested children:
+  // LikeButton / ReadingTimer / NowPlaying), rendered from post data.
   return (
     <BlogLayout base={base} manifest={manifest} title={`${p.title} — Barefoot Blog`}>
-      <article className="post" data-slug={p.slug}>
-        <a className="back" href={blog}>← All posts</a>
-        <h1 className="page-title">{p.title}</h1>
-        <div className="meta">
-          {p.date} · post {i + 1} of {posts.length} ·{' '}
-          {p.tags.map((t) => (
-            <a className="tag-inline" href={`${blog}?tag=${encodeURIComponent(t)}`}>#{t} </a>
-          ))}
-        </div>
-        <div className="islands">
-          <LikeButton />
-          <ReadingTimer />
-        </div>
-        {/* v1: a docked "Now playing" bar. It reads as a global player but lives
-            in the swappable content region marked `data-bf-permanent`, so the
-            router moves its live node (play state + progress) into the next post
-            instead of disposing it — contrast ReadingTimer above, which resets. */}
-        <NowPlaying />
-        <div className="prose">
-          {p.body.map((para) => (
-            <p>{para}</p>
-          ))}
-        </div>
-        <nav className="pager">
-          {prev ? (
-            <a className="pager-link" href={`${blog}/posts/${prev.slug}`}>← {prev.title}</a>
-          ) : (
-            <span className="pager-link disabled">← Start</span>
-          )}
-          {next ? (
-            <a className="pager-link next" href={`${blog}/posts/${next.slug}`}>{next.title} →</a>
-          ) : (
-            <a className="pager-link next" href={blog}>Back to start →</a>
-          )}
-        </nav>
-      </article>
+      <PostArticle
+        slug={p.slug}
+        title={p.title}
+        date={p.date}
+        tags={p.tags}
+        body={p.body}
+        position={i + 1}
+        total={posts.length}
+        base={blog}
+        prevSlug={prev?.slug}
+        prevTitle={prev?.title}
+        nextSlug={next?.slug}
+        nextTitle={next?.title}
+      />
     </BlogLayout>
   )
 }
-
-const STYLES = `
-  :root { color-scheme: dark; }
-  * { box-sizing: border-box; }
-  html[data-theme="light"] { color-scheme: light; }
-  body { margin: 0; font: 16px/1.6 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background: #0e1116; color: #e6edf3; }
-  html[data-theme="light"] body { background: #f6f8fa; color: #1f2328; }
-  a { color: #58a6ff; }
-  .shell { position: sticky; top: 0; z-index: 10; display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 14px 24px; background: #161b22; border-bottom: 1px solid #30363d; }
-  html[data-theme="light"] .shell { background: #fff; border-bottom-color: #d0d7de; }
-  .shell-brand { font-weight: 700; font-size: 18px; text-decoration: none; color: inherit; }
-  .shell-island { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
-  .toggle { cursor: pointer; background: #0d1117; border: 1px solid #30363d; color: #e6edf3; border-radius: 999px; padding: 5px 12px; font-size: 13px; }
-  html[data-theme="light"] .toggle { background: #f6f8fa; border-color: #d0d7de; color: #1f2328; }
-  .layout { display: flex; gap: 28px; align-items: flex-start; max-width: 1000px; margin: 0 auto; padding: 32px 24px 80px; }
-  .layout main { flex: 1; min-width: 0; }
-  .layout aside { position: sticky; top: 78px; width: 210px; flex: none; }
-  html[data-theme="light"] .sidebar { background: #fff; border-color: #d0d7de; }
-  .sidebar { background: #161b22; border: 1px solid #30363d; border-radius: 12px; padding: 16px; }
-  .sidebar-title { font-weight: 700; font-size: 13px; text-transform: uppercase; letter-spacing: .04em; color: #8b949e; margin-bottom: 12px; }
-  .sidebar-pin { cursor: pointer; width: 100%; background: #0d1117; border: 1px solid #30363d; color: #f2cc60; border-radius: 8px; padding: 8px 12px; font-size: 14px; font-variant-numeric: tabular-nums; }
-  html[data-theme="light"] .sidebar-pin { background: #f6f8fa; border-color: #d0d7de; }
-  .sidebar-note { font-size: 12px; color: #6e7681; margin: 12px 0 0; }
-  @media (max-width: 720px) { .layout { flex-direction: column; } .layout aside { position: static; width: 100%; } }
-  .page-title { font-size: 28px; margin: 0 0 6px; }
-  .lede, .meta { color: #8b949e; }
-  html[data-theme="light"] .lede, html[data-theme="light"] .meta { color: #57606a; }
-  .meta { font-size: 13px; margin-bottom: 12px; }
-  .lede { margin: 0 0 18px; }
-  .controls, .tags { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-bottom: 10px; }
-  .ctl-label { font-size: 13px; color: #6e7681; }
-  .tag, .tag-inline, .sort { text-decoration: none; font-size: 13px; color: #9aa7b4; }
-  .tag, .sort { border: 1px solid #30363d; border-radius: 999px; padding: 4px 11px; }
-  .tag.on, .sort.on { background: #1f6feb; border-color: #1f6feb; color: #fff; }
-  .tag-inline { color: #58a6ff; }
-  .status { font-size: 13px; color: #8b949e; margin-bottom: 12px; min-height: 1.2em; font-variant-numeric: tabular-nums; }
-  .sortable-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 8px; }
-  .sortable-list li { display: flex; align-items: center; gap: 10px; border: 1px solid #30363d; border-radius: 10px; background: #161b22; padding: 10px 14px; }
-  html[data-theme="light"] .sortable-list li { background: #fff; border-color: #d0d7de; }
-  .sortable-list li.pinned { border-color: #f2cc60; box-shadow: inset 3px 0 0 #f2cc60; }
-  .pin { cursor: pointer; background: none; border: none; font-size: 16px; color: #f2cc60; padding: 0; line-height: 1; }
-  .item-link { color: #e6edf3; text-decoration: none; font-weight: 600; font-size: 15px; }
-  html[data-theme="light"] .item-link { color: #1f2328; }
-  .item-link:hover { color: #58a6ff; }
-  .item-meta { margin-left: auto; font-size: 12px; color: #6e7681; }
-  .islands { display: flex; gap: 12px; align-items: center; margin: 4px 0 22px; }
-  .island { font-size: 14px; }
-  .island.like { cursor: pointer; background: #161b22; border: 1px solid #30363d; color: #f778ba; border-radius: 8px; padding: 6px 12px; }
-  html[data-theme="light"] .island.like { background: #fff; border-color: #d0d7de; }
-  .island.timer { color: #8b949e; font-variant-numeric: tabular-nums; }
-  .now-playing-bar { position: fixed; left: 50%; transform: translateX(-50%); bottom: 18px; z-index: 50; display: inline-flex; align-items: center; gap: 12px; background: #161b22; border: 1px solid #30363d; border-radius: 999px; padding: 8px 16px; box-shadow: 0 8px 28px rgba(0,0,0,.45); color: #3fb950; font-size: 13px; font-variant-numeric: tabular-nums; }
-  html[data-theme="light"] .now-playing-bar { background: #fff; border-color: #d0d7de; box-shadow: 0 8px 28px rgba(140,149,159,.35); }
-  .np-toggle { cursor: pointer; background: none; border: none; color: inherit; font-size: 15px; padding: 0; line-height: 1; }
-  .np-title { color: #8b949e; }
-  .np-bar { display: inline-block; width: 120px; height: 6px; background: #30363d; border-radius: 999px; overflow: hidden; }
-  html[data-theme="light"] .np-bar { background: #d0d7de; }
-  .np-fill { display: block; height: 100%; background: #3fb950; transition: width .1s linear; }
-  .reader-toolbar { display: flex; align-items: center; gap: 8px; margin-bottom: 18px; padding: 6px 12px; border: 1px solid #30363d; border-radius: 8px; background: #161b22; font-size: 13px; color: #8b949e; }
-  html[data-theme="light"] .reader-toolbar { background: #fff; border-color: #d0d7de; }
-  .rt-label { text-transform: uppercase; letter-spacing: .04em; font-size: 11px; }
-  .rt-btn { cursor: pointer; background: #0d1117; border: 1px solid #30363d; color: #e6edf3; border-radius: 6px; padding: 2px 8px; font-size: 12px; }
-  html[data-theme="light"] .rt-btn { background: #f6f8fa; border-color: #d0d7de; color: #1f2328; }
-  .rt-level { color: #58a6ff; font-variant-numeric: tabular-nums; min-width: 1ch; text-align: center; }
-  .prose p { margin: 0 0 18px; color: #d8e0e8; }
-  html[data-theme="light"] .prose p { color: #424a53; }
-  .back { display: inline-block; margin-bottom: 14px; text-decoration: none; font-size: 14px; }
-  .pager { display: flex; justify-content: space-between; gap: 12px; margin-top: 32px; padding-top: 18px; border-top: 1px solid #30363d; }
-  .pager-link { color: #58a6ff; text-decoration: none; font-weight: 600; font-size: 14px; max-width: 46%; }
-  .pager-link.next { text-align: right; margin-left: auto; }
-  .pager-link.disabled { color: #6e7681; }
-`

--- a/integrations/h3/blog.tsx
+++ b/integrations/h3/blog.tsx
@@ -31,10 +31,9 @@ import type { BarefootBuildManifest } from '@barefootjs/hono/app'
 import { Sidebar } from '@/components/Sidebar'
 import { PageShell } from '@/components/PageShell'
 import { ThemeToggle } from '@/components/ThemeToggle'
-import { LikeButton } from '@/components/LikeButton'
-import { ReadingTimer } from '@/components/ReadingTimer'
 import { NowPlaying } from '@/components/NowPlaying'
 import { PostList } from '@/components/PostList'
+import { PostArticle } from '@/components/PostArticle'
 import { posts, postIndex, allTags, listItems } from '../shared/blog/posts'
 
 interface LayoutProps {
@@ -67,7 +66,7 @@ function BlogLayout({ base, manifest, title, children }: LayoutProps) {
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>{title ?? 'Barefoot Blog'}</title>
         <script type="importmap" dangerouslySetInnerHTML={{ __html: importMap }} />
-        <style dangerouslySetInnerHTML={{ __html: STYLES }} />
+        <link rel="stylesheet" href={`${base}/shared/styles/blog.css`} />
       </head>
       <body>
         <header className="shell">
@@ -153,118 +152,26 @@ export function registerBlog(
       const p = posts[i]
       const prev = posts[i - 1]
       const next = posts[i + 1]
+      // The whole article is the shared <PostArticle> island (nested children:
+      // LikeButton / ReadingTimer / NowPlaying), rendered from post data.
       return renderPage(
         <BlogLayout base={base} manifest={manifest} title={`${p.title} — Barefoot Blog`}>
-          <article className="post" data-slug={p.slug}>
-            <a className="back" href={blog}>← All posts</a>
-            <h1 className="page-title">{p.title}</h1>
-            <div className="meta">
-              {p.date} · post {i + 1} of {posts.length} ·{' '}
-              {p.tags.map((t) => (
-                <a className="tag-inline" href={`${blog}?tag=${encodeURIComponent(t)}`}>#{t} </a>
-              ))}
-            </div>
-            <div className="islands">
-              <LikeButton />
-              <ReadingTimer />
-            </div>
-            {/* v1: a docked "Now playing" bar. It reads as a global player but
-                lives in the swappable content region marked `data-bf-permanent`,
-                so the router moves its live node (play state + progress) into the
-                next post instead of disposing it — contrast ReadingTimer above,
-                which resets. */}
-            <NowPlaying />
-            <div className="prose">
-              {p.body.map((para) => (
-                <p>{para}</p>
-              ))}
-            </div>
-            <nav className="pager">
-              {prev ? (
-                <a className="pager-link" href={`${blog}/posts/${prev.slug}`}>← {prev.title}</a>
-              ) : (
-                <span className="pager-link disabled">← Start</span>
-              )}
-              {next ? (
-                <a className="pager-link next" href={`${blog}/posts/${next.slug}`}>{next.title} →</a>
-              ) : (
-                <a className="pager-link next" href={blog}>Back to start →</a>
-              )}
-            </nav>
-          </article>
+          <PostArticle
+            slug={p.slug}
+            title={p.title}
+            date={p.date}
+            tags={p.tags}
+            body={p.body}
+            position={i + 1}
+            total={posts.length}
+            base={blog}
+            prevSlug={prev?.slug}
+            prevTitle={prev?.title}
+            nextSlug={next?.slug}
+            nextTitle={next?.title}
+          />
         </BlogLayout>,
       )
     }),
   )
 }
-
-const STYLES = `
-  :root { color-scheme: dark; }
-  * { box-sizing: border-box; }
-  html[data-theme="light"] { color-scheme: light; }
-  body { margin: 0; font: 16px/1.6 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background: #0e1116; color: #e6edf3; }
-  html[data-theme="light"] body { background: #f6f8fa; color: #1f2328; }
-  a { color: #58a6ff; }
-  .shell { position: sticky; top: 0; z-index: 10; display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 14px 24px; background: #161b22; border-bottom: 1px solid #30363d; }
-  html[data-theme="light"] .shell { background: #fff; border-bottom-color: #d0d7de; }
-  .shell-brand { font-weight: 700; font-size: 18px; text-decoration: none; color: inherit; }
-  .shell-island { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
-  .toggle { cursor: pointer; background: #0d1117; border: 1px solid #30363d; color: #e6edf3; border-radius: 999px; padding: 5px 12px; font-size: 13px; }
-  html[data-theme="light"] .toggle { background: #f6f8fa; border-color: #d0d7de; color: #1f2328; }
-  .layout { display: flex; gap: 28px; align-items: flex-start; max-width: 1000px; margin: 0 auto; padding: 32px 24px 80px; }
-  .layout main { flex: 1; min-width: 0; }
-  .layout aside { position: sticky; top: 78px; width: 210px; flex: none; }
-  html[data-theme="light"] .sidebar { background: #fff; border-color: #d0d7de; }
-  .sidebar { background: #161b22; border: 1px solid #30363d; border-radius: 12px; padding: 16px; }
-  .sidebar-title { font-weight: 700; font-size: 13px; text-transform: uppercase; letter-spacing: .04em; color: #8b949e; margin-bottom: 12px; }
-  .sidebar-pin { cursor: pointer; width: 100%; background: #0d1117; border: 1px solid #30363d; color: #f2cc60; border-radius: 8px; padding: 8px 12px; font-size: 14px; font-variant-numeric: tabular-nums; }
-  html[data-theme="light"] .sidebar-pin { background: #f6f8fa; border-color: #d0d7de; }
-  .sidebar-note { font-size: 12px; color: #6e7681; margin: 12px 0 0; }
-  @media (max-width: 720px) { .layout { flex-direction: column; } .layout aside { position: static; width: 100%; } }
-  .page-title { font-size: 28px; margin: 0 0 6px; }
-  .lede, .meta { color: #8b949e; }
-  html[data-theme="light"] .lede, html[data-theme="light"] .meta { color: #57606a; }
-  .meta { font-size: 13px; margin-bottom: 12px; }
-  .lede { margin: 0 0 18px; }
-  .controls, .tags { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-bottom: 10px; }
-  .ctl-label { font-size: 13px; color: #6e7681; }
-  .tag, .tag-inline, .sort { text-decoration: none; font-size: 13px; color: #9aa7b4; }
-  .tag, .sort { border: 1px solid #30363d; border-radius: 999px; padding: 4px 11px; }
-  .tag.on, .sort.on { background: #1f6feb; border-color: #1f6feb; color: #fff; }
-  .tag-inline { color: #58a6ff; }
-  .status { font-size: 13px; color: #8b949e; margin-bottom: 12px; min-height: 1.2em; font-variant-numeric: tabular-nums; }
-  .sortable-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 8px; }
-  .sortable-list li { display: flex; align-items: center; gap: 10px; border: 1px solid #30363d; border-radius: 10px; background: #161b22; padding: 10px 14px; }
-  html[data-theme="light"] .sortable-list li { background: #fff; border-color: #d0d7de; }
-  .sortable-list li.pinned { border-color: #f2cc60; box-shadow: inset 3px 0 0 #f2cc60; }
-  .pin { cursor: pointer; background: none; border: none; font-size: 16px; color: #f2cc60; padding: 0; line-height: 1; }
-  .item-link { color: #e6edf3; text-decoration: none; font-weight: 600; font-size: 15px; }
-  html[data-theme="light"] .item-link { color: #1f2328; }
-  .item-link:hover { color: #58a6ff; }
-  .item-meta { margin-left: auto; font-size: 12px; color: #6e7681; }
-  .islands { display: flex; gap: 12px; align-items: center; margin: 4px 0 22px; }
-  .island { font-size: 14px; }
-  .island.like { cursor: pointer; background: #161b22; border: 1px solid #30363d; color: #f778ba; border-radius: 8px; padding: 6px 12px; }
-  html[data-theme="light"] .island.like { background: #fff; border-color: #d0d7de; }
-  .island.timer { color: #8b949e; font-variant-numeric: tabular-nums; }
-  .now-playing-bar { position: fixed; left: 50%; transform: translateX(-50%); bottom: 18px; z-index: 50; display: inline-flex; align-items: center; gap: 12px; background: #161b22; border: 1px solid #30363d; border-radius: 999px; padding: 8px 16px; box-shadow: 0 8px 28px rgba(0,0,0,.45); color: #3fb950; font-size: 13px; font-variant-numeric: tabular-nums; }
-  html[data-theme="light"] .now-playing-bar { background: #fff; border-color: #d0d7de; box-shadow: 0 8px 28px rgba(140,149,159,.35); }
-  .np-toggle { cursor: pointer; background: none; border: none; color: inherit; font-size: 15px; padding: 0; line-height: 1; }
-  .np-title { color: #8b949e; }
-  .np-bar { display: inline-block; width: 120px; height: 6px; background: #30363d; border-radius: 999px; overflow: hidden; }
-  html[data-theme="light"] .np-bar { background: #d0d7de; }
-  .np-fill { display: block; height: 100%; background: #3fb950; transition: width .1s linear; }
-  .reader-toolbar { display: flex; align-items: center; gap: 8px; margin-bottom: 18px; padding: 6px 12px; border: 1px solid #30363d; border-radius: 8px; background: #161b22; font-size: 13px; color: #8b949e; }
-  html[data-theme="light"] .reader-toolbar { background: #fff; border-color: #d0d7de; }
-  .rt-label { text-transform: uppercase; letter-spacing: .04em; font-size: 11px; }
-  .rt-btn { cursor: pointer; background: #0d1117; border: 1px solid #30363d; color: #e6edf3; border-radius: 6px; padding: 2px 8px; font-size: 12px; }
-  html[data-theme="light"] .rt-btn { background: #f6f8fa; border-color: #d0d7de; color: #1f2328; }
-  .rt-level { color: #58a6ff; font-variant-numeric: tabular-nums; min-width: 1ch; text-align: center; }
-  .prose p { margin: 0 0 18px; color: #d8e0e8; }
-  html[data-theme="light"] .prose p { color: #424a53; }
-  .back { display: inline-block; margin-bottom: 14px; text-decoration: none; font-size: 14px; }
-  .pager { display: flex; justify-content: space-between; gap: 12px; margin-top: 32px; padding-top: 18px; border-top: 1px solid #30363d; }
-  .pager-link { color: #58a6ff; text-decoration: none; font-weight: 600; font-size: 14px; max-width: 46%; }
-  .pager-link.next { text-align: right; margin-left: auto; }
-  .pager-link.disabled { color: #6e7681; }
-`

--- a/integrations/hono/blog.tsx
+++ b/integrations/hono/blog.tsx
@@ -14,10 +14,9 @@ import { BfScripts } from '@barefootjs/hono/scripts'
 import { Sidebar } from '@/components/Sidebar'
 import { PageShell } from '@/components/PageShell'
 import { ThemeToggle } from '@/components/ThemeToggle'
-import { LikeButton } from '@/components/LikeButton'
-import { ReadingTimer } from '@/components/ReadingTimer'
 import { NowPlaying } from '@/components/NowPlaying'
 import { PostList } from '@/components/PostList'
+import { PostArticle } from '@/components/PostArticle'
 import { posts, postIndex, allTags, listItems } from '../shared/blog/posts'
 
 const BASE_PATH = process.env.BASE_PATH ?? '/integrations/hono'
@@ -45,7 +44,7 @@ const blogRenderer = jsxRenderer(({ children, title }) => {
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>{title ?? 'Barefoot Blog'}</title>
         <script type="importmap" dangerouslySetInnerHTML={{ __html: importMap }} />
-        <style dangerouslySetInnerHTML={{ __html: STYLES }} />
+        <link rel="stylesheet" href={`${BASE_PATH}/shared/styles/blog.css`} />
       </head>
       <body>
         <header className="shell">
@@ -108,114 +107,24 @@ blog.get('/posts/:slug', (c) => {
   const p = posts[i]
   const prev = posts[i - 1]
   const next = posts[i + 1]
+  // The whole article is the shared <PostArticle> island (its nested children
+  // are LikeButton / ReadingTimer / NowPlaying), so every adapter renders the
+  // same markup from post data instead of hand-authoring it.
   return c.render(
-    <article className="post" data-slug={p.slug}>
-      <a className="back" href={BASE}>← All posts</a>
-      <h1 className="page-title">{p.title}</h1>
-      <div className="meta">
-        {p.date} · post {i + 1} of {posts.length} ·{' '}
-        {p.tags.map((t) => (
-          <a className="tag-inline" href={`${BASE}?tag=${encodeURIComponent(t)}`}>#{t} </a>
-        ))}
-      </div>
-      <div className="islands">
-        <LikeButton />
-        <ReadingTimer />
-      </div>
-      {/* v1: a docked "Now playing" bar. It reads as a global player but lives
-          in the swappable content region marked `data-bf-permanent`, so the
-          router moves its live node (play state + progress) into the next post
-          instead of disposing it — contrast ReadingTimer above, which resets. */}
-      <NowPlaying />
-      <div className="prose">
-        {p.body.map((para) => (
-          <p>{para}</p>
-        ))}
-      </div>
-      <nav className="pager">
-        {prev ? (
-          <a className="pager-link" href={`${BASE}/posts/${prev.slug}`}>← {prev.title}</a>
-        ) : (
-          <span className="pager-link disabled">← Start</span>
-        )}
-        {next ? (
-          <a className="pager-link next" href={`${BASE}/posts/${next.slug}`}>{next.title} →</a>
-        ) : (
-          <a className="pager-link next" href={BASE}>Back to start →</a>
-        )}
-      </nav>
-    </article>,
+    <PostArticle
+      slug={p.slug}
+      title={p.title}
+      date={p.date}
+      tags={p.tags}
+      body={p.body}
+      position={i + 1}
+      total={posts.length}
+      base={BASE}
+      prevSlug={prev?.slug}
+      prevTitle={prev?.title}
+      nextSlug={next?.slug}
+      nextTitle={next?.title}
+    />,
     { title: `${p.title} — Barefoot Blog` },
   )
 })
-
-const STYLES = `
-  :root { color-scheme: dark; }
-  * { box-sizing: border-box; }
-  html[data-theme="light"] { color-scheme: light; }
-  body { margin: 0; font: 16px/1.6 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background: #0e1116; color: #e6edf3; }
-  html[data-theme="light"] body { background: #f6f8fa; color: #1f2328; }
-  a { color: #58a6ff; }
-  .shell { position: sticky; top: 0; z-index: 10; display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 14px 24px; background: #161b22; border-bottom: 1px solid #30363d; }
-  html[data-theme="light"] .shell { background: #fff; border-bottom-color: #d0d7de; }
-  .shell-brand { font-weight: 700; font-size: 18px; text-decoration: none; color: inherit; }
-  .shell-island { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
-  .toggle { cursor: pointer; background: #0d1117; border: 1px solid #30363d; color: #e6edf3; border-radius: 999px; padding: 5px 12px; font-size: 13px; }
-  html[data-theme="light"] .toggle { background: #f6f8fa; border-color: #d0d7de; color: #1f2328; }
-  .layout { display: flex; gap: 28px; align-items: flex-start; max-width: 1000px; margin: 0 auto; padding: 32px 24px 80px; }
-  .layout main { flex: 1; min-width: 0; }
-  .layout aside { position: sticky; top: 78px; width: 210px; flex: none; }
-  html[data-theme="light"] .sidebar { background: #fff; border-color: #d0d7de; }
-  .sidebar { background: #161b22; border: 1px solid #30363d; border-radius: 12px; padding: 16px; }
-  .sidebar-title { font-weight: 700; font-size: 13px; text-transform: uppercase; letter-spacing: .04em; color: #8b949e; margin-bottom: 12px; }
-  .sidebar-pin { cursor: pointer; width: 100%; background: #0d1117; border: 1px solid #30363d; color: #f2cc60; border-radius: 8px; padding: 8px 12px; font-size: 14px; font-variant-numeric: tabular-nums; }
-  html[data-theme="light"] .sidebar-pin { background: #f6f8fa; border-color: #d0d7de; }
-  .sidebar-note { font-size: 12px; color: #6e7681; margin: 12px 0 0; }
-  @media (max-width: 720px) { .layout { flex-direction: column; } .layout aside { position: static; width: 100%; } }
-  .page-title { font-size: 28px; margin: 0 0 6px; }
-  .lede, .meta { color: #8b949e; }
-  html[data-theme="light"] .lede, html[data-theme="light"] .meta { color: #57606a; }
-  .meta { font-size: 13px; margin-bottom: 12px; }
-  .lede { margin: 0 0 18px; }
-  .controls, .tags { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-bottom: 10px; }
-  .ctl-label { font-size: 13px; color: #6e7681; }
-  .tag, .tag-inline, .sort { text-decoration: none; font-size: 13px; color: #9aa7b4; }
-  .tag, .sort { border: 1px solid #30363d; border-radius: 999px; padding: 4px 11px; }
-  .tag.on, .sort.on { background: #1f6feb; border-color: #1f6feb; color: #fff; }
-  .tag-inline { color: #58a6ff; }
-  .status { font-size: 13px; color: #8b949e; margin-bottom: 12px; min-height: 1.2em; font-variant-numeric: tabular-nums; }
-  .sortable-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 8px; }
-  .sortable-list li { display: flex; align-items: center; gap: 10px; border: 1px solid #30363d; border-radius: 10px; background: #161b22; padding: 10px 14px; }
-  html[data-theme="light"] .sortable-list li { background: #fff; border-color: #d0d7de; }
-  .sortable-list li.pinned { border-color: #f2cc60; box-shadow: inset 3px 0 0 #f2cc60; }
-  .pin { cursor: pointer; background: none; border: none; font-size: 16px; color: #f2cc60; padding: 0; line-height: 1; }
-  .item-link { color: #e6edf3; text-decoration: none; font-weight: 600; font-size: 15px; }
-  html[data-theme="light"] .item-link { color: #1f2328; }
-  .item-link:hover { color: #58a6ff; }
-  .item-meta { margin-left: auto; font-size: 12px; color: #6e7681; }
-  .islands { display: flex; gap: 12px; align-items: center; margin: 4px 0 22px; }
-  .island { font-size: 14px; }
-  .island.like { cursor: pointer; background: #161b22; border: 1px solid #30363d; color: #f778ba; border-radius: 8px; padding: 6px 12px; }
-  html[data-theme="light"] .island.like { background: #fff; border-color: #d0d7de; }
-  .island.timer { color: #8b949e; font-variant-numeric: tabular-nums; }
-  .now-playing-bar { position: fixed; left: 50%; transform: translateX(-50%); bottom: 18px; z-index: 50; display: inline-flex; align-items: center; gap: 12px; background: #161b22; border: 1px solid #30363d; border-radius: 999px; padding: 8px 16px; box-shadow: 0 8px 28px rgba(0,0,0,.45); color: #3fb950; font-size: 13px; font-variant-numeric: tabular-nums; }
-  html[data-theme="light"] .now-playing-bar { background: #fff; border-color: #d0d7de; box-shadow: 0 8px 28px rgba(140,149,159,.35); }
-  .np-toggle { cursor: pointer; background: none; border: none; color: inherit; font-size: 15px; padding: 0; line-height: 1; }
-  .np-title { color: #8b949e; }
-  .np-bar { display: inline-block; width: 120px; height: 6px; background: #30363d; border-radius: 999px; overflow: hidden; }
-  html[data-theme="light"] .np-bar { background: #d0d7de; }
-  .np-fill { display: block; height: 100%; background: #3fb950; transition: width .1s linear; }
-  .reader-toolbar { display: flex; align-items: center; gap: 8px; margin-bottom: 18px; padding: 6px 12px; border: 1px solid #30363d; border-radius: 8px; background: #161b22; font-size: 13px; color: #8b949e; }
-  html[data-theme="light"] .reader-toolbar { background: #fff; border-color: #d0d7de; }
-  .rt-label { text-transform: uppercase; letter-spacing: .04em; font-size: 11px; }
-  .rt-btn { cursor: pointer; background: #0d1117; border: 1px solid #30363d; color: #e6edf3; border-radius: 6px; padding: 2px 8px; font-size: 12px; }
-  html[data-theme="light"] .rt-btn { background: #f6f8fa; border-color: #d0d7de; color: #1f2328; }
-  .rt-level { color: #58a6ff; font-variant-numeric: tabular-nums; min-width: 1ch; text-align: center; }
-  .prose p { margin: 0 0 18px; color: #d8e0e8; }
-  html[data-theme="light"] .prose p { color: #424a53; }
-  .back { display: inline-block; margin-bottom: 14px; text-decoration: none; font-size: 14px; }
-  .pager { display: flex; justify-content: space-between; gap: 12px; margin-top: 32px; padding-top: 18px; border-top: 1px solid #30363d; }
-  .pager-link { color: #58a6ff; text-decoration: none; font-weight: 600; font-size: 14px; max-width: 46%; }
-  .pager-link.next { text-align: right; margin-left: auto; }
-  .pager-link.disabled { color: #6e7681; }
-`

--- a/integrations/mojolicious/app.pl
+++ b/integrations/mojolicious/app.pl
@@ -6,7 +6,7 @@ use Mojolicious::Lite -signatures;
 use lib 'lib', '../../packages/adapter-mojolicious/lib';
 use Mojo::JSON qw(true false encode_json decode_json);
 use Mojo::ByteStream qw(b);
-use Mojo::Util qw(xml_escape url_escape);
+use Mojo::Util qw(xml_escape);
 
 # Load BarefootJS plugin
 plugin 'BarefootJS';
@@ -450,80 +450,6 @@ my $BLOG_DATA = do {
     my $f = app->home->child('dist/blog-data.json');
     -r $f ? decode_json($f->slurp) : { posts => [], listItems => [], allTags => [] };
 };
-
-# Blog styles — the same design-system block the Hono showcase inlines, so the
-# region-shell page is self-contained (it does not use the catalog stylesheets).
-my $BLOG_STYLES = <<'CSS';
-  :root { color-scheme: dark; }
-  * { box-sizing: border-box; }
-  html[data-theme="light"] { color-scheme: light; }
-  body { margin: 0; font: 16px/1.6 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background: #0e1116; color: #e6edf3; }
-  html[data-theme="light"] body { background: #f6f8fa; color: #1f2328; }
-  a { color: #58a6ff; }
-  .shell { position: sticky; top: 0; z-index: 10; display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 14px 24px; background: #161b22; border-bottom: 1px solid #30363d; }
-  html[data-theme="light"] .shell { background: #fff; border-bottom-color: #d0d7de; }
-  .shell-brand { font-weight: 700; font-size: 18px; text-decoration: none; color: inherit; }
-  .shell-island { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
-  .toggle { cursor: pointer; background: #0d1117; border: 1px solid #30363d; color: #e6edf3; border-radius: 999px; padding: 5px 12px; font-size: 13px; }
-  html[data-theme="light"] .toggle { background: #f6f8fa; border-color: #d0d7de; color: #1f2328; }
-  .layout { display: flex; gap: 28px; align-items: flex-start; max-width: 1000px; margin: 0 auto; padding: 32px 24px 80px; }
-  .layout main { flex: 1; min-width: 0; }
-  .layout aside { position: sticky; top: 78px; width: 210px; flex: none; }
-  html[data-theme="light"] .sidebar { background: #fff; border-color: #d0d7de; }
-  .sidebar { background: #161b22; border: 1px solid #30363d; border-radius: 12px; padding: 16px; }
-  .sidebar-title { font-weight: 700; font-size: 13px; text-transform: uppercase; letter-spacing: .04em; color: #8b949e; margin-bottom: 12px; }
-  .sidebar-pin { cursor: pointer; width: 100%; background: #0d1117; border: 1px solid #30363d; color: #f2cc60; border-radius: 8px; padding: 8px 12px; font-size: 14px; font-variant-numeric: tabular-nums; }
-  html[data-theme="light"] .sidebar-pin { background: #f6f8fa; border-color: #d0d7de; }
-  .sidebar-note { font-size: 12px; color: #6e7681; margin: 12px 0 0; }
-  @media (max-width: 720px) { .layout { flex-direction: column; } .layout aside { position: static; width: 100%; } }
-  .page-title { font-size: 28px; margin: 0 0 6px; }
-  .lede, .meta { color: #8b949e; }
-  html[data-theme="light"] .lede, html[data-theme="light"] .meta { color: #57606a; }
-  .meta { font-size: 13px; margin-bottom: 12px; }
-  .lede { margin: 0 0 18px; }
-  .controls, .tags { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-bottom: 10px; }
-  .ctl-label { font-size: 13px; color: #6e7681; }
-  .tag, .tag-inline, .sort { text-decoration: none; font-size: 13px; color: #9aa7b4; }
-  .tag, .sort { border: 1px solid #30363d; border-radius: 999px; padding: 4px 11px; }
-  .tag.on, .sort.on { background: #1f6feb; border-color: #1f6feb; color: #fff; }
-  .tag-inline { color: #58a6ff; }
-  .status { font-size: 13px; color: #8b949e; margin-bottom: 12px; min-height: 1.2em; font-variant-numeric: tabular-nums; }
-  .sortable-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 8px; }
-  .sortable-list li { display: flex; align-items: center; gap: 10px; border: 1px solid #30363d; border-radius: 10px; background: #161b22; padding: 10px 14px; }
-  html[data-theme="light"] .sortable-list li { background: #fff; border-color: #d0d7de; }
-  .sortable-list li.pinned { border-color: #f2cc60; box-shadow: inset 3px 0 0 #f2cc60; }
-  .pin { cursor: pointer; background: none; border: none; font-size: 16px; color: #f2cc60; padding: 0; line-height: 1; }
-  .item-link { color: #e6edf3; text-decoration: none; font-weight: 600; font-size: 15px; }
-  html[data-theme="light"] .item-link { color: #1f2328; }
-  .item-link:hover { color: #58a6ff; }
-  .item-meta { margin-left: auto; font-size: 12px; color: #6e7681; }
-  .islands { display: flex; gap: 12px; align-items: center; margin: 4px 0 22px; }
-  .island { font-size: 14px; }
-  .island.like { cursor: pointer; background: #161b22; border: 1px solid #30363d; color: #f778ba; border-radius: 8px; padding: 6px 12px; }
-  html[data-theme="light"] .island.like { background: #fff; border-color: #d0d7de; }
-  .island.timer { color: #8b949e; font-variant-numeric: tabular-nums; }
-  .now-playing-bar { position: fixed; left: 50%; transform: translateX(-50%); bottom: 18px; z-index: 50; display: inline-flex; align-items: center; gap: 12px; background: #161b22; border: 1px solid #30363d; border-radius: 999px; padding: 8px 16px; box-shadow: 0 8px 28px rgba(0,0,0,.45); color: #3fb950; font-size: 13px; font-variant-numeric: tabular-nums; }
-  html[data-theme="light"] .now-playing-bar { background: #fff; border-color: #d0d7de; box-shadow: 0 8px 28px rgba(140,149,159,.35); }
-  .np-toggle { cursor: pointer; background: none; border: none; color: inherit; font-size: 15px; padding: 0; line-height: 1; }
-  .np-title { color: #8b949e; }
-  .np-bar { display: inline-block; width: 120px; height: 6px; background: #30363d; border-radius: 999px; overflow: hidden; }
-  html[data-theme="light"] .np-bar { background: #d0d7de; }
-  .np-fill { display: block; height: 100%; background: #3fb950; transition: width .1s linear; }
-  .reader-toolbar { display: flex; align-items: center; gap: 8px; margin-bottom: 18px; padding: 6px 12px; border: 1px solid #30363d; border-radius: 8px; background: #161b22; font-size: 13px; color: #8b949e; }
-  html[data-theme="light"] .reader-toolbar { background: #fff; border-color: #d0d7de; }
-  .rt-label { text-transform: uppercase; letter-spacing: .04em; font-size: 11px; }
-  .rt-btn { cursor: pointer; background: #0d1117; border: 1px solid #30363d; color: #e6edf3; border-radius: 6px; padding: 2px 8px; font-size: 12px; }
-  html[data-theme="light"] .rt-btn { background: #f6f8fa; border-color: #d0d7de; color: #1f2328; }
-  .rt-level { color: #58a6ff; font-variant-numeric: tabular-nums; min-width: 1ch; text-align: center; }
-  .prose p { margin: 0 0 18px; color: #d8e0e8; }
-  html[data-theme="light"] .prose p { color: #424a53; }
-  .back { display: inline-block; margin-bottom: 14px; text-decoration: none; font-size: 14px; }
-  .pager { display: flex; justify-content: space-between; gap: 12px; margin-top: 32px; padding-top: 18px; border-top: 1px solid #30363d; }
-  .pager-link { color: #58a6ff; text-decoration: none; font-weight: 600; font-size: 14px; max-width: 46%; }
-  .pager-link.next { text-align: right; margin-left: auto; }
-  .pager-link.disabled { color: #6e7681; }
-CSS
-
 sub _rand6 { return substr(rand() =~ s/^0\.//r, 0, 6) }
 
 # Register a renderer for a flat (non-`ui/*`) child component the build manifest
@@ -532,7 +458,7 @@ sub _rand6 { return substr(rand() =~ s/^0\.//r, 0, 6) }
 # entries: a fresh child scope chained off the caller's slot, the shared script
 # collector + renderer registry, and the manifest's ssrDefaults seeded (the
 # caller's matching prop wins).
-sub _register_blog_child ($c, $parent_bf, $slot, $component) {
+sub _register_blog_child ($c, $parent_bf, $slot, $component, $extra_seed = {}) {
     my $entry = $BLOG_MANIFEST->{$component} or return;
     my $defaults = $entry->{ssrDefaults};
     $parent_bf->register_child_renderer($slot, sub {
@@ -551,7 +477,10 @@ sub _register_blog_child ($c, $parent_bf, $slot, $component) {
         $child->_script_seen($parent_bf->_script_seen);
         my %extra = $defaults
             ? BarefootJS::_derive_stash_from_defaults($defaults, $props) : ();
-        my $html = $parent_bf->backend->render_named($component, $child, { %$props, %extra });
+        # Per-child SSR seeds the static extractor can't supply (e.g. NowPlaying's
+        # `Math` → `{ min => 0 }` for the progress-bar width).
+        my $html = $parent_bf->backend->render_named(
+            $component, $child, { %extra, %$extra_seed, %$props });
         chomp $html;
         return $html;
     });
@@ -580,7 +509,12 @@ helper blog_island => sub ($c, $component, $props = {}, $extra = {}, $children =
     $bf->_scripts($root->_scripts);
     $bf->_script_seen($root->_script_seen);
     $bf->_child_renderers($root->_child_renderers);
-    _register_blog_child($c, $bf, $_, $children->{$_}) for keys %$children;
+    # Each child is `slot => 'Template'` or `slot => ['Template', \%extra_seed]`.
+    for my $slot (keys %$children) {
+        my $spec = $children->{$slot};
+        my ($tpl, $seed) = ref($spec) eq 'ARRAY' ? @$spec : ($spec, {});
+        _register_blog_child($c, $bf, $slot, $tpl, $seed);
+    }
     my $defaults = ($BLOG_MANIFEST->{$component} // {})->{ssrDefaults};
     my %seed = $defaults
         ? BarefootJS::_derive_stash_from_defaults($defaults, $props) : ();
@@ -619,7 +553,7 @@ sub _blog_page ($c, $title, $base, $content_html) {
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>$esc_title</title>
 <script type="importmap">$importmap</script>
-<style>$BLOG_STYLES</style>
+<link rel="stylesheet" href="$BASE_PATH/styles/blog.css">
 </head>
 <body>
 <header class="shell">
@@ -634,39 +568,6 @@ $scripts
 <script type="module" src="$static/router-entry.js"></script>
 </body>
 </html>
-HTML
-}
-
-# The article body for a post page (hand-authored HTML, mirroring the Hono post
-# route). Like / ReadingTimer / NowPlaying are pre-rendered islands spliced in.
-sub _article_html ($c, $p, $i, $prev, $next, $base, $like, $timer, $now) {
-    my $n = scalar @{ $BLOG_DATA->{posts} };
-    my $tags_inline = CORE::join '', map {
-        my $t = $_;
-        my $href = "$base?tag=" . url_escape($t);
-        qq{<a class="tag-inline" href="$href">#@{[ xml_escape($t) ]} </a>}
-    } @{ $p->{tags} };
-    my $prose = CORE::join '', map { '<p>' . xml_escape($_) . '</p>' } @{ $p->{body} };
-    my $pager_prev = $prev
-        ? qq{<a class="pager-link" href="$base/posts/$prev->{slug}">\x{2190} @{[ xml_escape($prev->{title}) ]}</a>}
-        : qq{<span class="pager-link disabled">\x{2190} Start</span>};
-    my $pager_next = $next
-        ? qq{<a class="pager-link next" href="$base/posts/$next->{slug}">@{[ xml_escape($next->{title}) ]} \x{2192}</a>}
-        : qq{<a class="pager-link next" href="$base">Back to start \x{2192}</a>};
-    my $title = xml_escape($p->{title});
-    my $date  = xml_escape($p->{date});
-    my $slug  = xml_escape($p->{slug});
-    my $num   = $i + 1;
-    return <<"HTML";
-<article class="post" data-slug="$slug">
-<a class="back" href="$base">\x{2190} All posts</a>
-<h1 class="page-title">$title</h1>
-<div class="meta">$date \x{B7} post $num of $n \x{B7} $tags_inline</div>
-<div class="islands">$like$timer</div>
-$now
-<div class="prose">$prose</div>
-<nav class="pager">$pager_prev$pager_next</nav>
-</article>
 HTML
 }
 
@@ -716,10 +617,27 @@ $r_blog->get('/blog/posts/:slug' => sub ($c) {
     my $prev = $i > 0        ? $posts->[$i - 1] : undef;
     my $next = $i < $#$posts ? $posts->[$i + 1] : undef;
     my $base = "$BASE_PATH/blog";
-    my $like  = $c->blog_island('LikeButton');
-    my $timer = $c->blog_island('ReadingTimer');
-    my $now   = $c->blog_island('NowPlaying', {}, { Math => { min => 0 } });
-    my $content = _article_html($c, $p, $i, $prev, $next, $base, $like, $timer, $now);
+    # The whole article is the shared <PostArticle> island; the interactive
+    # widgets are its nested children (NowPlaying needs Math seeded for the
+    # progress-bar width).
+    my $content = $c->blog_island(
+        'PostArticle',
+        {
+            slug => $p->{slug}, title => $p->{title}, date => $p->{date},
+            tags => $p->{tags}, body => $p->{body},
+            position => $i + 1, total => scalar(@$posts), base => $base,
+            prevSlug  => $prev ? $prev->{slug}  : undef,
+            prevTitle => $prev ? $prev->{title} : undef,
+            nextSlug  => $next ? $next->{slug}  : undef,
+            nextTitle => $next ? $next->{title} : undef,
+        },
+        {},
+        {
+            like_button   => 'LikeButton',
+            reading_timer => 'ReadingTimer',
+            now_playing   => [ 'NowPlaying', { Math => { min => 0 } } ],
+        },
+    );
     $c->render(
         text   => _blog_page($c, "$p->{title} \x{2014} Barefoot Blog", $base, $content),
         format => 'html',

--- a/integrations/shared/blog/PostArticle.tsx
+++ b/integrations/shared/blog/PostArticle.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { LikeButton } from './LikeButton'
+import { ReadingTimer } from './ReadingTimer'
+import { NowPlaying } from './NowPlaying'
+
+interface PostArticleProps {
+  slug: string
+  title: string
+  date: string
+  tags: string[]
+  body: string[]
+  /** 1-based position ("post N of M"). */
+  position: number
+  total: number
+  /** Blog mount path; every link is built relative to it. */
+  base: string
+  prevSlug?: string
+  prevTitle?: string
+  nextSlug?: string
+  nextTitle?: string
+}
+
+/**
+ * The post page body — the article chrome that used to be hand-authored per
+ * adapter (Hono JSX / Perl heredocs). Extracted into one shared island so every
+ * adapter renders the same markup from post data; the interactive widgets
+ * (`LikeButton`, `ReadingTimer`, `NowPlaying`) are nested islands.
+ *
+ * `"use client"` only so `bf build` compiles it into a template (it ships no
+ * client state of its own — same reason as `PageShell`). Tag links use a plain
+ * `?tag=${t}` (the corpus tags are URL-safe slugs) so the href lowers for SSR on
+ * the template-string adapters too, rather than `encodeURIComponent` (a
+ * JS-runtime callee they can't lower).
+ */
+export function PostArticle(props: PostArticleProps) {
+  return (
+    <article className="post" data-slug={props.slug}>
+      <a className="back" href={props.base}>← All posts</a>
+      <h1 className="page-title">{props.title}</h1>
+      <div className="meta">
+        {props.date} · post {props.position} of {props.total} ·{' '}
+        {props.tags.map((t) => (
+          <a key={t} className="tag-inline" href={`${props.base}?tag=${t}`}>#{t} </a>
+        ))}
+      </div>
+      <div className="islands">
+        <LikeButton />
+        <ReadingTimer />
+      </div>
+      {/* v1: docked "Now playing" bar, marked data-bf-permanent inside NowPlaying
+          so the router moves the same live node between posts (and index↔post). */}
+      <NowPlaying />
+      <div className="prose">
+        {props.body.map((para, i) => (
+          <p key={i}>{para}</p>
+        ))}
+      </div>
+      <nav className="pager">
+        {props.prevSlug ? (
+          <a className="pager-link" href={`${props.base}/posts/${props.prevSlug}`}>← {props.prevTitle}</a>
+        ) : (
+          <span className="pager-link disabled">← Start</span>
+        )}
+        {props.nextSlug ? (
+          <a className="pager-link next" href={`${props.base}/posts/${props.nextSlug}`}>{props.nextTitle} →</a>
+        ) : (
+          <a className="pager-link next" href={props.base}>Back to start →</a>
+        )}
+      </nav>
+    </article>
+  )
+}

--- a/integrations/shared/styles/blog.css
+++ b/integrations/shared/styles/blog.css
@@ -1,0 +1,74 @@
+/*
+ * Blog showcase styles (the @barefootjs/router demo). Shared by every adapter's
+ * blog routes — served from this integration's static styles dir and linked,
+ * instead of inlining the same block in each app. Self-contained (the blog uses
+ * its own region-shell layout, not the catalog stylesheets).
+ */
+:root { color-scheme: dark; }
+* { box-sizing: border-box; }
+html[data-theme="light"] { color-scheme: light; }
+body { margin: 0; font: 16px/1.6 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background: #0e1116; color: #e6edf3; }
+html[data-theme="light"] body { background: #f6f8fa; color: #1f2328; }
+a { color: #58a6ff; }
+.shell { position: sticky; top: 0; z-index: 10; display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 14px 24px; background: #161b22; border-bottom: 1px solid #30363d; }
+html[data-theme="light"] .shell { background: #fff; border-bottom-color: #d0d7de; }
+.shell-brand { font-weight: 700; font-size: 18px; text-decoration: none; color: inherit; }
+.shell-island { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.toggle { cursor: pointer; background: #0d1117; border: 1px solid #30363d; color: #e6edf3; border-radius: 999px; padding: 5px 12px; font-size: 13px; }
+html[data-theme="light"] .toggle { background: #f6f8fa; border-color: #d0d7de; color: #1f2328; }
+.layout { display: flex; gap: 28px; align-items: flex-start; max-width: 1000px; margin: 0 auto; padding: 32px 24px 80px; }
+.layout main { flex: 1; min-width: 0; }
+.layout aside { position: sticky; top: 78px; width: 210px; flex: none; }
+html[data-theme="light"] .sidebar { background: #fff; border-color: #d0d7de; }
+.sidebar { background: #161b22; border: 1px solid #30363d; border-radius: 12px; padding: 16px; }
+.sidebar-title { font-weight: 700; font-size: 13px; text-transform: uppercase; letter-spacing: .04em; color: #8b949e; margin-bottom: 12px; }
+.sidebar-pin { cursor: pointer; width: 100%; background: #0d1117; border: 1px solid #30363d; color: #f2cc60; border-radius: 8px; padding: 8px 12px; font-size: 14px; font-variant-numeric: tabular-nums; }
+html[data-theme="light"] .sidebar-pin { background: #f6f8fa; border-color: #d0d7de; }
+.sidebar-note { font-size: 12px; color: #6e7681; margin: 12px 0 0; }
+@media (max-width: 720px) { .layout { flex-direction: column; } .layout aside { position: static; width: 100%; } }
+.page-title { font-size: 28px; margin: 0 0 6px; }
+.lede, .meta { color: #8b949e; }
+html[data-theme="light"] .lede, html[data-theme="light"] .meta { color: #57606a; }
+.meta { font-size: 13px; margin-bottom: 12px; }
+.lede { margin: 0 0 18px; }
+.controls, .tags { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-bottom: 10px; }
+.ctl-label { font-size: 13px; color: #6e7681; }
+.tag, .tag-inline, .sort { text-decoration: none; font-size: 13px; color: #9aa7b4; }
+.tag, .sort { border: 1px solid #30363d; border-radius: 999px; padding: 4px 11px; }
+.tag.on, .sort.on { background: #1f6feb; border-color: #1f6feb; color: #fff; }
+.tag-inline { color: #58a6ff; }
+.status { font-size: 13px; color: #8b949e; margin-bottom: 12px; min-height: 1.2em; font-variant-numeric: tabular-nums; }
+.sortable-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 8px; }
+.sortable-list li { display: flex; align-items: center; gap: 10px; border: 1px solid #30363d; border-radius: 10px; background: #161b22; padding: 10px 14px; }
+html[data-theme="light"] .sortable-list li { background: #fff; border-color: #d0d7de; }
+.sortable-list li.pinned { border-color: #f2cc60; box-shadow: inset 3px 0 0 #f2cc60; }
+.pin { cursor: pointer; background: none; border: none; font-size: 16px; color: #f2cc60; padding: 0; line-height: 1; }
+.item-link { color: #e6edf3; text-decoration: none; font-weight: 600; font-size: 15px; }
+html[data-theme="light"] .item-link { color: #1f2328; }
+.item-link:hover { color: #58a6ff; }
+.item-meta { margin-left: auto; font-size: 12px; color: #6e7681; }
+.islands { display: flex; gap: 12px; align-items: center; margin: 4px 0 22px; }
+.island { font-size: 14px; }
+.island.like { cursor: pointer; background: #161b22; border: 1px solid #30363d; color: #f778ba; border-radius: 8px; padding: 6px 12px; }
+html[data-theme="light"] .island.like { background: #fff; border-color: #d0d7de; }
+.island.timer { color: #8b949e; font-variant-numeric: tabular-nums; }
+.now-playing-bar { position: fixed; left: 50%; transform: translateX(-50%); bottom: 18px; z-index: 50; display: inline-flex; align-items: center; gap: 12px; background: #161b22; border: 1px solid #30363d; border-radius: 999px; padding: 8px 16px; box-shadow: 0 8px 28px rgba(0,0,0,.45); color: #3fb950; font-size: 13px; font-variant-numeric: tabular-nums; }
+html[data-theme="light"] .now-playing-bar { background: #fff; border-color: #d0d7de; box-shadow: 0 8px 28px rgba(140,149,159,.35); }
+.np-toggle { cursor: pointer; background: none; border: none; color: inherit; font-size: 15px; padding: 0; line-height: 1; }
+.np-title { color: #8b949e; }
+.np-bar { display: inline-block; width: 120px; height: 6px; background: #30363d; border-radius: 999px; overflow: hidden; }
+html[data-theme="light"] .np-bar { background: #d0d7de; }
+.np-fill { display: block; height: 100%; background: #3fb950; transition: width .1s linear; }
+.reader-toolbar { display: flex; align-items: center; gap: 8px; margin-bottom: 18px; padding: 6px 12px; border: 1px solid #30363d; border-radius: 8px; background: #161b22; font-size: 13px; color: #8b949e; }
+html[data-theme="light"] .reader-toolbar { background: #fff; border-color: #d0d7de; }
+.rt-label { text-transform: uppercase; letter-spacing: .04em; font-size: 11px; }
+.rt-btn { cursor: pointer; background: #0d1117; border: 1px solid #30363d; color: #e6edf3; border-radius: 6px; padding: 2px 8px; font-size: 12px; }
+html[data-theme="light"] .rt-btn { background: #f6f8fa; border-color: #d0d7de; color: #1f2328; }
+.rt-level { color: #58a6ff; font-variant-numeric: tabular-nums; min-width: 1ch; text-align: center; }
+.prose p { margin: 0 0 18px; color: #d8e0e8; }
+html[data-theme="light"] .prose p { color: #424a53; }
+.back { display: inline-block; margin-bottom: 14px; text-decoration: none; font-size: 14px; }
+.pager { display: flex; justify-content: space-between; gap: 12px; margin-top: 32px; padding-top: 18px; border-top: 1px solid #30363d; }
+.pager-link { color: #58a6ff; text-decoration: none; font-weight: 600; font-size: 14px; max-width: 46%; }
+.pager-link.next { text-align: right; margin-left: auto; }
+.pager-link.disabled { color: #6e7681; }

--- a/integrations/xslate/app.psgi
+++ b/integrations/xslate/app.psgi
@@ -354,91 +354,13 @@ my $BLOG_MANIFEST = _slurp_json('dist/templates/manifest.json') // {};
 my $BLOG_DATA = _slurp_json('dist/blog-data.json')
     // { posts => [], listItems => [], allTags => [] };
 
-# Blog styles — the same design-system block the Hono showcase inlines, so the
-# region-shell page is self-contained (it does not use the catalog stylesheets).
-my $BLOG_STYLES = <<'CSS';
-  :root { color-scheme: dark; }
-  * { box-sizing: border-box; }
-  html[data-theme="light"] { color-scheme: light; }
-  body { margin: 0; font: 16px/1.6 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background: #0e1116; color: #e6edf3; }
-  html[data-theme="light"] body { background: #f6f8fa; color: #1f2328; }
-  a { color: #58a6ff; }
-  .shell { position: sticky; top: 0; z-index: 10; display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 14px 24px; background: #161b22; border-bottom: 1px solid #30363d; }
-  html[data-theme="light"] .shell { background: #fff; border-bottom-color: #d0d7de; }
-  .shell-brand { font-weight: 700; font-size: 18px; text-decoration: none; color: inherit; }
-  .shell-island { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
-  .toggle { cursor: pointer; background: #0d1117; border: 1px solid #30363d; color: #e6edf3; border-radius: 999px; padding: 5px 12px; font-size: 13px; }
-  html[data-theme="light"] .toggle { background: #f6f8fa; border-color: #d0d7de; color: #1f2328; }
-  .layout { display: flex; gap: 28px; align-items: flex-start; max-width: 1000px; margin: 0 auto; padding: 32px 24px 80px; }
-  .layout main { flex: 1; min-width: 0; }
-  .layout aside { position: sticky; top: 78px; width: 210px; flex: none; }
-  html[data-theme="light"] .sidebar { background: #fff; border-color: #d0d7de; }
-  .sidebar { background: #161b22; border: 1px solid #30363d; border-radius: 12px; padding: 16px; }
-  .sidebar-title { font-weight: 700; font-size: 13px; text-transform: uppercase; letter-spacing: .04em; color: #8b949e; margin-bottom: 12px; }
-  .sidebar-pin { cursor: pointer; width: 100%; background: #0d1117; border: 1px solid #30363d; color: #f2cc60; border-radius: 8px; padding: 8px 12px; font-size: 14px; font-variant-numeric: tabular-nums; }
-  html[data-theme="light"] .sidebar-pin { background: #f6f8fa; border-color: #d0d7de; }
-  .sidebar-note { font-size: 12px; color: #6e7681; margin: 12px 0 0; }
-  @media (max-width: 720px) { .layout { flex-direction: column; } .layout aside { position: static; width: 100%; } }
-  .page-title { font-size: 28px; margin: 0 0 6px; }
-  .lede, .meta { color: #8b949e; }
-  html[data-theme="light"] .lede, html[data-theme="light"] .meta { color: #57606a; }
-  .meta { font-size: 13px; margin-bottom: 12px; }
-  .lede { margin: 0 0 18px; }
-  .controls, .tags { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-bottom: 10px; }
-  .ctl-label { font-size: 13px; color: #6e7681; }
-  .tag, .tag-inline, .sort { text-decoration: none; font-size: 13px; color: #9aa7b4; }
-  .tag, .sort { border: 1px solid #30363d; border-radius: 999px; padding: 4px 11px; }
-  .tag.on, .sort.on { background: #1f6feb; border-color: #1f6feb; color: #fff; }
-  .tag-inline { color: #58a6ff; }
-  .status { font-size: 13px; color: #8b949e; margin-bottom: 12px; min-height: 1.2em; font-variant-numeric: tabular-nums; }
-  .sortable-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 8px; }
-  .sortable-list li { display: flex; align-items: center; gap: 10px; border: 1px solid #30363d; border-radius: 10px; background: #161b22; padding: 10px 14px; }
-  html[data-theme="light"] .sortable-list li { background: #fff; border-color: #d0d7de; }
-  .sortable-list li.pinned { border-color: #f2cc60; box-shadow: inset 3px 0 0 #f2cc60; }
-  .pin { cursor: pointer; background: none; border: none; font-size: 16px; color: #f2cc60; padding: 0; line-height: 1; }
-  .item-link { color: #e6edf3; text-decoration: none; font-weight: 600; font-size: 15px; }
-  html[data-theme="light"] .item-link { color: #1f2328; }
-  .item-link:hover { color: #58a6ff; }
-  .item-meta { margin-left: auto; font-size: 12px; color: #6e7681; }
-  .islands { display: flex; gap: 12px; align-items: center; margin: 4px 0 22px; }
-  .island { font-size: 14px; }
-  .island.like { cursor: pointer; background: #161b22; border: 1px solid #30363d; color: #f778ba; border-radius: 8px; padding: 6px 12px; }
-  html[data-theme="light"] .island.like { background: #fff; border-color: #d0d7de; }
-  .island.timer { color: #8b949e; font-variant-numeric: tabular-nums; }
-  .now-playing-bar { position: fixed; left: 50%; transform: translateX(-50%); bottom: 18px; z-index: 50; display: inline-flex; align-items: center; gap: 12px; background: #161b22; border: 1px solid #30363d; border-radius: 999px; padding: 8px 16px; box-shadow: 0 8px 28px rgba(0,0,0,.45); color: #3fb950; font-size: 13px; font-variant-numeric: tabular-nums; }
-  html[data-theme="light"] .now-playing-bar { background: #fff; border-color: #d0d7de; box-shadow: 0 8px 28px rgba(140,149,159,.35); }
-  .np-toggle { cursor: pointer; background: none; border: none; color: inherit; font-size: 15px; padding: 0; line-height: 1; }
-  .np-title { color: #8b949e; }
-  .np-bar { display: inline-block; width: 120px; height: 6px; background: #30363d; border-radius: 999px; overflow: hidden; }
-  html[data-theme="light"] .np-bar { background: #d0d7de; }
-  .np-fill { display: block; height: 100%; background: #3fb950; transition: width .1s linear; }
-  .reader-toolbar { display: flex; align-items: center; gap: 8px; margin-bottom: 18px; padding: 6px 12px; border: 1px solid #30363d; border-radius: 8px; background: #161b22; font-size: 13px; color: #8b949e; }
-  html[data-theme="light"] .reader-toolbar { background: #fff; border-color: #d0d7de; }
-  .rt-label { text-transform: uppercase; letter-spacing: .04em; font-size: 11px; }
-  .rt-btn { cursor: pointer; background: #0d1117; border: 1px solid #30363d; color: #e6edf3; border-radius: 6px; padding: 2px 8px; font-size: 12px; }
-  html[data-theme="light"] .rt-btn { background: #f6f8fa; border-color: #d0d7de; color: #1f2328; }
-  .rt-level { color: #58a6ff; font-variant-numeric: tabular-nums; min-width: 1ch; text-align: center; }
-  .prose p { margin: 0 0 18px; color: #d8e0e8; }
-  html[data-theme="light"] .prose p { color: #424a53; }
-  .back { display: inline-block; margin-bottom: 14px; text-decoration: none; font-size: 14px; }
-  .pager { display: flex; justify-content: space-between; gap: 12px; margin-top: 32px; padding-top: 18px; border-top: 1px solid #30363d; }
-  .pager-link { color: #58a6ff; text-decoration: none; font-weight: 600; font-size: 14px; max-width: 46%; }
-  .pager-link.next { text-align: right; margin-left: auto; }
-  .pager-link.disabled { color: #6e7681; }
-CSS
-
 sub _esc ($s) { return BarefootJS::_html_escape($s) }
-sub _url_esc ($s) {
-    my $e = defined $s ? "$s" : '';
-    $e =~ s/([^A-Za-z0-9_.~-])/sprintf('%%%02X', ord $1)/ge;
-    return $e;
-}
 
 # Register a renderer for a flat (non-`ui/*`) child component from the build
 # manifest (`post_list_item` → PostListItem, `reader_toolbar` → ReaderToolbar):
 # a fresh child scope chained off the caller's slot, the shared script collector
 # + renderer registry, and the manifest's ssrDefaults seeded (caller prop wins).
-sub _register_blog_child ($parent_bf, $slot, $component) {
+sub _register_blog_child ($parent_bf, $slot, $component, $extra_seed = {}) {
     my $entry = $BLOG_MANIFEST->{$component} or return;
     my $defaults = $entry->{ssrDefaults};
     $parent_bf->register_child_renderer($slot, sub {
@@ -458,7 +380,9 @@ sub _register_blog_child ($parent_bf, $slot, $component) {
         $child->_script_seen($parent_bf->_script_seen);
         my %extra = $defaults
             ? BarefootJS::_derive_stash_from_defaults($defaults, $props) : ();
-        return $backend->render_named($component, $child, { %$props, %extra });
+        # Per-child SSR seeds the static extractor can't supply (e.g. NowPlaying's
+        # `Math` → `{ min => 0 }` for the progress-bar width).
+        return $backend->render_named($component, $child, { %extra, %$extra_seed, %$props });
     });
 }
 
@@ -474,7 +398,12 @@ sub blog_island ($root, $component, $props = {}, $extra = {}, $children = {}) {
     $bf->_scripts($root->_scripts);
     $bf->_script_seen($root->_script_seen);
     $bf->_child_renderers($root->_child_renderers);
-    _register_blog_child($bf, $_, $children->{$_}) for keys %$children;
+    # Each child is `slot => 'Template'` or `slot => ['Template', \%extra_seed]`.
+    for my $slot (keys %$children) {
+        my $spec = $children->{$slot};
+        my ($tpl, $seed) = ref($spec) eq 'ARRAY' ? @$spec : ($spec, {});
+        _register_blog_child($bf, $slot, $tpl, $seed);
+    }
     my $defaults = ($BLOG_MANIFEST->{$component} // {})->{ssrDefaults};
     my %seed = $defaults
         ? BarefootJS::_derive_stash_from_defaults($defaults, $props) : ();
@@ -507,7 +436,7 @@ sub blog_page ($root, $title, $base, $content_html) {
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>$esc_title</title>
 <script type="importmap">$importmap</script>
-<style>$BLOG_STYLES</style>
+<link rel="stylesheet" href="$BASE/styles/blog.css">
 </head>
 <body>
 <header class="shell">
@@ -522,38 +451,6 @@ $scripts
 <script type="module" src="$static/router-entry.js"></script>
 </body>
 </html>
-HTML
-}
-
-# The article body for a post page (hand-authored HTML, mirroring the Hono post
-# route). Like / ReadingTimer / NowPlaying are pre-rendered islands spliced in.
-sub blog_article_html ($p, $i, $prev, $next, $base, $like, $timer, $now) {
-    my $n = scalar @{ $BLOG_DATA->{posts} };
-    my $tags_inline = join '', map {
-        my $t = $_;
-        '<a class="tag-inline" href="' . "$base?tag=" . _url_esc($t) . '">#' . _esc($t) . ' </a>'
-    } @{ $p->{tags} };
-    my $prose = join '', map { '<p>' . _esc($_) . '</p>' } @{ $p->{body} };
-    my $pager_prev = $prev
-        ? '<a class="pager-link" href="' . "$base/posts/$prev->{slug}" . '">' . "\x{2190} " . _esc($prev->{title}) . '</a>'
-        : '<span class="pager-link disabled">' . "\x{2190} Start" . '</span>';
-    my $pager_next = $next
-        ? '<a class="pager-link next" href="' . "$base/posts/$next->{slug}" . '">' . _esc($next->{title}) . " \x{2192}" . '</a>'
-        : '<a class="pager-link next" href="' . $base . '">' . "Back to start \x{2192}" . '</a>';
-    my $title = _esc($p->{title});
-    my $date  = _esc($p->{date});
-    my $slug  = _esc($p->{slug});
-    my $num   = $i + 1;
-    return <<"HTML";
-<article class="post" data-slug="$slug">
-<a class="back" href="$base">\x{2190} All posts</a>
-<h1 class="page-title">$title</h1>
-<div class="meta">$date \x{B7} post $num of $n \x{B7} $tags_inline</div>
-<div class="islands">$like$timer</div>
-$now
-<div class="prose">$prose</div>
-<nav class="pager">$pager_prev$pager_next</nav>
-</article>
 HTML
 }
 
@@ -595,11 +492,25 @@ sub blog_post_route ($req, $slug) {
     my $prev = $i > 0        ? $posts->[$i - 1] : undef;
     my $next = $i < $#$posts ? $posts->[$i + 1] : undef;
     my $base = "$BASE/blog";
-    my $root  = BarefootJS->new(undef, { backend => $backend });
-    my $like  = blog_island($root, 'LikeButton');
-    my $timer = blog_island($root, 'ReadingTimer');
-    my $now   = blog_island($root, 'NowPlaying', {}, { Math => { min => 0 } });
-    my $content = blog_article_html($p, $i, $prev, $next, $base, $like, $timer, $now);
+    my $root = BarefootJS->new(undef, { backend => $backend });
+    # The whole article is the shared <PostArticle> island; the interactive
+    # widgets are its nested children (NowPlaying needs Math seeded).
+    my $content = blog_island($root, 'PostArticle',
+        {
+            slug => $p->{slug}, title => $p->{title}, date => $p->{date},
+            tags => $p->{tags}, body => $p->{body},
+            position => $i + 1, total => scalar(@$posts), base => $base,
+            prevSlug  => $prev ? $prev->{slug}  : undef,
+            prevTitle => $prev ? $prev->{title} : undef,
+            nextSlug  => $next ? $next->{slug}  : undef,
+            nextTitle => $next ? $next->{title} : undef,
+        },
+        {},
+        {
+            like_button   => 'LikeButton',
+            reading_timer => 'ReadingTimer',
+            now_playing   => [ 'NowPlaying', { Math => { min => 0 } } ],
+        });
     html_response(blog_page($root, "$p->{title} \x{2014} Barefoot Blog", $base, $content));
 }
 


### PR DESCRIPTION
## Why

Follow-up to the blog showcase ports (#1933 / #1935 / #1936 / #1938 / #1939). Review feedback on the Mojolicious port: the post-page article was hand-authored HTML (fragile, and "hard-to-hand-write" in Perl heredocs), and the ~70-line stylesheet was inlined in every adapter. Those were the same in the Hono reference too — only the interactive islands were shared. This PR shares them.

## What

- **`shared/blog/PostArticle.tsx`** — one island that renders the whole article (back link, title, meta + tag links, prose, prev/next pager) from post data, with `LikeButton` / `ReadingTimer` / `NowPlaying` as nested children. Every adapter now renders `<PostArticle …/>` instead of building the article by hand.
- **`shared/styles/blog.css`** — the blog stylesheet, served from each adapter's static styles dir and linked, replacing the five inlined `<style>` copies.
- All five blog routes updated (Hono, h3, Elysia, Mojolicious, Xslate).

**Net ~450 fewer lines** across the five integrations (566 deletions / 119 insertions + the 2 shared files); the article and its styling now have a single source of truth.

## Design notes / tradeoffs

- `PostArticle` is a `"use client"` island. A non-`"use client"` component is **skipped** by `bf build` (no template emitted), so the template-string adapters (Mojo/Xslate) couldn't render it — making it an island is the only way to share it. Consequence: its data rides in `bf-p` (the body text is therefore present in both the SSR DOM and `bf-p`). Acceptable for the showcase; it's the cost of one shared, hydration-capable article.
- Tag links use a plain `?tag=${t}` instead of `encodeURIComponent(t)` — the corpus tags are URL-safe slugs, and `encodeURIComponent` is a JS-runtime callee the template-string adapters can't lower for SSR (same `UNSUPPORTED_METHODS` gate noted in #1395).
- The Perl `blog_island` child map now accepts `slot => ['Template', \%seed]` so the nested `NowPlaying` still gets its `Math => { min => 0 }` seed (progress-bar width) when rendered as a child.

## Tests

- `bun run build` clean on all five integrations (0 errors).
- **Blog e2e pass 5/5 on every adapter** (v0 region swap + theme persist, v0.5 query-only sort/filter, v1 `data-bf-permanent` player across post→post and post→index, v2 sibling sidebar + nested toolbar regions).
- `perl -c` OK for both Perl apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXtoP11H8gTgJvwUuz7iK2)_