### PR TITLE
feat(go-template): compute object-returning searchParams memos for SSR (PostList derived state, Capability A)

### DIFF
--- a/.changeset/go-derived-object-memo.md
+++ b/.changeset/go-derived-object-memo.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/go-template": minor
+---
+
+Compute object-returning `searchParams()` memos for SSR instead of emitting a nil map (PostList derived-state blocker, #1897 follow-up — Capability A).
+
+A block-body memo of the shape `() => { const sp = searchParams(); return { sort: asSortKey(sp.get('sort')), tag: sp.get('tag') ?? '' } }` previously fell through every memo pattern and was initialized to `nil` in `NewXxxProps`, so the template's `.Params.Sort` / `.Params.Tag` accesses read a nil map. The adapter now lowers the object's values to Go in the constructor context and emits a computed `map[string]interface{}` with capitalized keys (matching the template's field access). The lowerer supports the narrow surface these memos use: `<sp>.get('k')` → `in.SearchParams.Get("k")`, `<arr>.includes(<x>)` → `bf.Includes([]string{…}, <x>)`, module arrow-helper inlining (e.g. `asSortKey`), `<expr> ?? ''`, and string ternaries. Unsupported shapes still fall back to `nil`, so nothing regresses.

--- a/packages/adapter-go-template/src/__tests__/derived-state-memo.test.ts
+++ b/packages/adapter-go-template/src/__tests__/derived-state-memo.test.ts
@@ -88,4 +88,25 @@ export function P() {
     // Must NOT emit a string as a Go bool condition.
     expect(types).not.toContain('if in.SearchParams.Get')
   })
+
+  // A block with control flow (an early `return` inside an `if`, plus the final
+  // return) must fall back to nil — not silently lower the final return as if it
+  // were unconditional, which would change SSR semantics (#1941 review).
+  test('block-body memo with control flow falls back to nil', () => {
+    const src = `
+'use client'
+import { createMemo, searchParams } from '@barefootjs/client'
+export function P() {
+  const params = createMemo(() => {
+    const sp = searchParams()
+    if (sp.get('x')) return { sort: 'early' }
+    return { sort: sp.get('sort') ?? '' }
+  })
+  return <div>{params().sort}</div>
+}
+`
+    const { types } = generate(src)
+    expect(types).toContain('Params: nil')
+    expect(types).not.toContain('Params: map[string]interface{}{')
+  })
 })

--- a/packages/adapter-go-template/src/__tests__/derived-state-memo.test.ts
+++ b/packages/adapter-go-template/src/__tests__/derived-state-memo.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Derived-state SSR for the Go adapter (PostList blocker, #1897 follow-up).
+ *
+ * Capability A: an object-returning block-body memo that derives from
+ * `searchParams()` must compute a NON-nil `map[string]interface{}` in
+ * `NewXxxProps`, so the template's `.Params.Sort` / `.Params.Tag` field
+ * accesses resolve at execute time instead of reading a nil map.
+ */
+import { describe, test, expect } from 'bun:test'
+import { compileJSX, type ComponentIR } from '@barefootjs/jsx'
+import { GoTemplateAdapter } from '../adapter/go-template-adapter'
+
+function generate(src: string) {
+  const adapter = new GoTemplateAdapter()
+  const result = compileJSX(src.trimStart(), 'T.tsx', { adapter, outputIR: true })
+  const irFile = result.files.find(f => f.type === 'ir')
+  if (!irFile) throw new Error('no IR')
+  const ir = JSON.parse(irFile.content) as ComponentIR
+  return adapter.generate(ir)
+}
+
+describe('Capability A: object-returning searchParams memo → computed map field', () => {
+  const SRC = `
+'use client'
+import { createMemo, searchParams } from '@barefootjs/client'
+const SORT_KEYS = ['date', 'title', 'tag']
+const asSortKey = (raw) => (SORT_KEYS.includes(raw) ? raw : 'date')
+export function P() {
+  const params = createMemo(() => {
+    const sp = searchParams()
+    return { sort: asSortKey(sp.get('sort')), tag: sp.get('tag') ?? '' }
+  })
+  return (
+    <div>
+      <span>{params().sort}</span>
+      <span>{params().tag}</span>
+    </div>
+  )
+}
+`
+
+  test('NewProps computes the map instead of nil', () => {
+    const { types } = generate(SRC)
+    expect(types).not.toContain('Params: nil')
+    expect(types).toContain('Params: map[string]interface{}{')
+  })
+
+  test('object keys are capitalized to match template field access', () => {
+    const { types } = generate(SRC)
+    expect(types).toContain('"Sort":')
+    expect(types).toContain('"Tag":')
+  })
+
+  test('searchParams().get is lowered to the SSR SearchParams field', () => {
+    const { types } = generate(SRC)
+    expect(types).toContain('in.SearchParams.Get("sort")')
+    expect(types).toContain('in.SearchParams.Get("tag")')
+  })
+
+  test('module helper asSortKey is inlined with bf.Includes over the const array', () => {
+    const { types } = generate(SRC)
+    expect(types).toContain('bf.Includes([]string{"date", "title", "tag"}')
+  })
+
+  test('template still reads .Params.Sort / .Params.Tag (unchanged field access)', () => {
+    const { template } = generate(SRC)
+    expect(template).toContain('.Params.Sort')
+    expect(template).toContain('.Params.Tag')
+  })
+})

--- a/packages/adapter-go-template/src/__tests__/derived-state-memo.test.ts
+++ b/packages/adapter-go-template/src/__tests__/derived-state-memo.test.ts
@@ -67,4 +67,25 @@ export function P() {
     expect(template).toContain('.Params.Sort')
     expect(template).toContain('.Params.Tag')
   })
+
+  // A ternary whose condition is string-valued (`sp.get('tag') ? … : …`) is
+  // truthy in JS but `if "<string>"` does not compile in Go. The lowerer must
+  // fall back to nil rather than emit invalid code (#1941 review).
+  test('string-valued ternary condition falls back to nil, never invalid Go', () => {
+    const src = `
+'use client'
+import { createMemo, searchParams } from '@barefootjs/client'
+export function P() {
+  const params = createMemo(() => {
+    const sp = searchParams()
+    return { label: sp.get('tag') ? 'has' : 'none' }
+  })
+  return <div>{params().label}</div>
+}
+`
+    const { types } = generate(src)
+    expect(types).toContain('Params: nil')
+    // Must NOT emit a string as a Go bool condition.
+    expect(types).not.toContain('if in.SearchParams.Get')
+  })
 })

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -4168,10 +4168,18 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     const arrow = this.parseLiteralExpression(computation)
     if (!arrow || !ts.isArrowFunction(arrow) || !ts.isBlock(arrow.body)) return null
 
-    // Collect `const <v> = searchParams()` bindings and the returned object.
+    // Accept only a strict shape: zero or more `const`/`let` declarations
+    // followed by exactly one `return { … }` as the LAST statement. Any other
+    // statement kind — `if`, an early/extra `return`, a loop, a bare call —
+    // means the block has control flow this resolver can't reason about, so we
+    // bail to the nil fallback rather than silently lowering one of several
+    // returns (#1941 review). Along the way, collect `const <v> = searchParams()`
+    // bindings (the env for `<v>.get('k')`).
     const searchParamsVars = new Set<string>()
     let retObj: ts.ObjectLiteralExpression | null = null
-    for (const s of arrow.body.statements) {
+    const statements = arrow.body.statements
+    for (let i = 0; i < statements.length; i++) {
+      const s = statements[i]
       if (ts.isVariableStatement(s)) {
         for (const d of s.declarationList.declarations) {
           if (
@@ -4179,16 +4187,26 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
             d.initializer &&
             ts.isCallExpression(d.initializer) &&
             ts.isIdentifier(d.initializer.expression) &&
+            d.initializer.arguments.length === 0 &&
             this.searchParamsLocals.has(d.initializer.expression.text)
           ) {
             searchParamsVars.add(d.name.text)
           }
         }
-      } else if (ts.isReturnStatement(s) && s.expression) {
+        continue
+      }
+      if (ts.isReturnStatement(s)) {
+        // The return must be the last statement (so it's the only one) and
+        // return an object literal.
+        if (i !== statements.length - 1 || !s.expression) return null
         let e: ts.Expression = s.expression
         while (ts.isParenthesizedExpression(e)) e = e.expression
-        if (ts.isObjectLiteralExpression(e)) retObj = e
+        if (!ts.isObjectLiteralExpression(e)) return null
+        retObj = e
+        continue
       }
+      // Any other statement kind → control flow we don't model → bail.
+      return null
     }
     if (!retObj || retObj.properties.length === 0) return null
 

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -197,6 +197,17 @@ interface PropFallbackVar {
   zeroLiteral: string
 }
 
+/**
+ * Scope for `lowerCtorExpr` — lowering a JS expression to Go in the
+ * `NewXxxProps` constructor context (#1897 PostList derived state).
+ */
+interface CtorLowerEnv {
+  /** Local names bound to `searchParams()` (`const sp = searchParams()`). */
+  searchParamsVars: Set<string>
+  /** Helper-param name → its already-lowered Go argument, for inlining. */
+  params: Map<string, string>
+}
+
 export interface GoTemplateAdapterOptions {
   /** Go package name for generated types (default: 'components') */
   packageName?: string
@@ -4030,6 +4041,16 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       )
     }
 
+    // (#1897 PostList) Pattern: an object-returning block-body memo derived from
+    // `searchParams()` — `() => { const sp = searchParams(); return { sort:
+    // asSortKey(sp.get('sort')), tag: sp.get('tag') ?? '' } }`. Compute a Go
+    // `map[string]interface{}` whose values are lowered from the request query,
+    // so `.Params.Sort` / `.Params.Tag` resolve at execute time instead of
+    // reading a nil map. Returns null for any unsupported shape (→ nil fallback,
+    // no regression).
+    const objMemo = this.computeObjectMemoInitialValue(computation)
+    if (objMemo !== null) return objMemo
+
     return null
   }
 
@@ -4131,6 +4152,193 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     } catch {
       return null
     }
+  }
+
+  /**
+   * (#1897 PostList) Compute the SSR value of an object-returning block-body
+   * memo derived from `searchParams()`:
+   *   () => { const sp = searchParams(); return { sort: asSortKey(sp.get('sort')),
+   *                                               tag: sp.get('tag') ?? '' } }
+   * Emits a Go `map[string]interface{}{ "Sort": …, "Tag": … }` whose values are
+   * lowered from the request query (see `lowerCtorExpr`). Keys are capitalized to
+   * match the template's `.Params.<Field>` map access. Returns null for any shape
+   * the lowerer can't represent, so the caller falls back to a nil map.
+   */
+  private computeObjectMemoInitialValue(computation: string): string | null {
+    const arrow = this.parseLiteralExpression(computation)
+    if (!arrow || !ts.isArrowFunction(arrow) || !ts.isBlock(arrow.body)) return null
+
+    // Collect `const <v> = searchParams()` bindings and the returned object.
+    const searchParamsVars = new Set<string>()
+    let retObj: ts.ObjectLiteralExpression | null = null
+    for (const s of arrow.body.statements) {
+      if (ts.isVariableStatement(s)) {
+        for (const d of s.declarationList.declarations) {
+          if (
+            ts.isIdentifier(d.name) &&
+            d.initializer &&
+            ts.isCallExpression(d.initializer) &&
+            ts.isIdentifier(d.initializer.expression) &&
+            this.searchParamsLocals.has(d.initializer.expression.text)
+          ) {
+            searchParamsVars.add(d.name.text)
+          }
+        }
+      } else if (ts.isReturnStatement(s) && s.expression) {
+        let e: ts.Expression = s.expression
+        while (ts.isParenthesizedExpression(e)) e = e.expression
+        if (ts.isObjectLiteralExpression(e)) retObj = e
+      }
+    }
+    if (!retObj || retObj.properties.length === 0) return null
+
+    const env: CtorLowerEnv = { searchParamsVars, params: new Map() }
+    const entries: string[] = []
+    for (const prop of retObj.properties) {
+      if (!ts.isPropertyAssignment(prop)) return null
+      const key =
+        ts.isIdentifier(prop.name) || ts.isStringLiteral(prop.name) ? prop.name.text : null
+      if (!key) return null
+      const go = this.lowerCtorExpr(prop.initializer, env)
+      if (go === null) return null
+      entries.push(`"${this.capitalizeFieldName(key)}": ${go}`)
+    }
+    return `map[string]interface{}{\n\t\t${entries.join(',\n\t\t')},\n\t}`
+  }
+
+  /**
+   * Lower a JS expression to a Go expression in the `NewXxxProps` constructor
+   * context. This is Go *code*, not template syntax — so a search-param read
+   * becomes `in.SearchParams.Get("k")` (method call), not the template's
+   * `.SearchParams.Get "k"`. Supports the narrow surface derived-state memos
+   * need: string/number literals, `<sp>.get('k')`, `<arr>.includes(<x>)`,
+   * module arrow-helper inlining, `<expr> ?? <fallback>`, and string ternaries.
+   * Returns null for anything else so the caller can fall back safely.
+   */
+  private lowerCtorExpr(node: ts.Expression, env: CtorLowerEnv): string | null {
+    while (ts.isParenthesizedExpression(node)) node = node.expression
+
+    if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+      return JSON.stringify(node.text)
+    }
+    if (ts.isNumericLiteral(node)) return node.text
+
+    // Identifier: a substituted helper param, else a module string const.
+    if (ts.isIdentifier(node)) {
+      const sub = env.params.get(node.text)
+      if (sub !== undefined) return sub
+      const c = this.localConstants.find(lc => lc.name === node.text && lc.isModule)
+      if (c?.value !== undefined) {
+        const lit = this.parseLiteralExpression(c.value)
+        if (lit && (ts.isStringLiteral(lit) || ts.isNoSubstitutionTemplateLiteral(lit))) {
+          return JSON.stringify(lit.text)
+        }
+      }
+      return null
+    }
+
+    if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+      const method = node.expression.name.text
+      const recv = node.expression.expression
+      // `<sp>.get('k')` where <sp> is bound to searchParams().
+      if (
+        method === 'get' &&
+        ts.isIdentifier(recv) &&
+        env.searchParamsVars.has(recv.text) &&
+        node.arguments.length === 1 &&
+        ts.isStringLiteral(node.arguments[0])
+      ) {
+        return `in.SearchParams.Get(${JSON.stringify(node.arguments[0].text)})`
+      }
+      // `<arr>.includes(<x>)` → bf.Includes(<[]string{…}>, <x>) (bool).
+      if (method === 'includes' && node.arguments.length === 1) {
+        const arr = this.lowerCtorStringArray(recv)
+        const elem = this.lowerCtorExpr(node.arguments[0], env)
+        if (arr !== null && elem !== null) return `bf.Includes(${arr}, ${elem})`
+        return null
+      }
+      return null
+    }
+
+    // `helper(<args>)` where helper is a module arrow const → inline its body.
+    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
+      const fnConst = this.localConstants.find(
+        lc => lc.name === (node.expression as ts.Identifier).text && lc.isModule,
+      )
+      if (fnConst?.value) {
+        const fn = this.parseLiteralExpression(fnConst.value)
+        if (
+          fn &&
+          ts.isArrowFunction(fn) &&
+          !ts.isBlock(fn.body) &&
+          fn.parameters.length === node.arguments.length
+        ) {
+          const params = new Map(env.params)
+          for (let i = 0; i < fn.parameters.length; i++) {
+            const p = fn.parameters[i]
+            if (!ts.isIdentifier(p.name)) return null
+            const argGo = this.lowerCtorExpr(node.arguments[i], env)
+            if (argGo === null) return null
+            params.set(p.name.text, argGo)
+          }
+          return this.lowerCtorExpr(fn.body, { searchParamsVars: env.searchParamsVars, params })
+        }
+      }
+      return null
+    }
+
+    // `<expr> ?? <fallback>`
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken
+    ) {
+      const left = this.lowerCtorExpr(node.left, env)
+      if (left === null) return null
+      let r: ts.Expression = node.right
+      while (ts.isParenthesizedExpression(r)) r = r.expression
+      // `?? ''` is a no-op: SearchParams.Get already returns "" for a missing key.
+      if ((ts.isStringLiteral(r) || ts.isNoSubstitutionTemplateLiteral(r)) && r.text === '') {
+        return left
+      }
+      const right = this.lowerCtorExpr(node.right, env)
+      if (right === null) return null
+      return `func() string { v := ${left}; if v != "" { return v }; return ${right} }()`
+    }
+
+    // `<cond> ? <t> : <f>` (string result)
+    if (ts.isConditionalExpression(node)) {
+      const cond = this.lowerCtorExpr(node.condition, env)
+      const t = this.lowerCtorExpr(node.whenTrue, env)
+      const f = this.lowerCtorExpr(node.whenFalse, env)
+      if (cond !== null && t !== null && f !== null) {
+        return `func() string { if ${cond} { return ${t} }; return ${f} }()`
+      }
+      return null
+    }
+
+    return null
+  }
+
+  /**
+   * Resolve a string-array expression (a `['a','b']` literal, or a module const
+   * bound to one) to a Go `[]string{…}` literal, or null when it isn't a pure
+   * string-array. Used by `lowerCtorExpr` for `<arr>.includes(<x>)`.
+   */
+  private lowerCtorStringArray(node: ts.Expression): string | null {
+    let arr: ts.Expression | null = node
+    if (ts.isIdentifier(node)) {
+      const c = this.localConstants.find(lc => lc.name === node.text && lc.isModule)
+      if (!c?.value) return null
+      arr = this.parseLiteralExpression(c.value)
+    }
+    if (!arr || !ts.isArrayLiteralExpression(arr)) return null
+    const elems: string[] = []
+    for (const el of arr.elements) {
+      if (ts.isStringLiteral(el) || ts.isNoSubstitutionTemplateLiteral(el)) {
+        elems.push(JSON.stringify(el.text))
+      } else return null
+    }
+    return `[]string{${elems.join(', ')}}`
   }
 
   /**

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -4307,13 +4307,68 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
     // `<cond> ? <t> : <f>` (string result)
     if (ts.isConditionalExpression(node)) {
-      const cond = this.lowerCtorExpr(node.condition, env)
+      // The condition must be lowered as a *boolean* (`lowerCtorCond`), not a
+      // value: a string-valued JS condition like `sp.get('tag') ? a : b` is
+      // truthy in JS, but `if "<string>"` does not compile in Go — such shapes
+      // return null so the memo falls back to nil rather than emitting invalid
+      // code (#1941 review).
+      const cond = this.lowerCtorCond(node.condition, env)
       const t = this.lowerCtorExpr(node.whenTrue, env)
       const f = this.lowerCtorExpr(node.whenFalse, env)
       if (cond !== null && t !== null && f !== null) {
         return `func() string { if ${cond} { return ${t} }; return ${f} }()`
       }
       return null
+    }
+
+    return null
+  }
+
+  /**
+   * Lower a JS expression used as a *boolean* condition to a Go bool expression,
+   * or null when it is not provably boolean. Distinct from `lowerCtorExpr`,
+   * which lowers value expressions: a string-valued condition (`sp.get('tag')`)
+   * is truthy in JS but `if "<string>"` does not compile in Go, so anything not
+   * known to yield a Go bool must fall back to null (#1941 review).
+   */
+  private lowerCtorCond(node: ts.Expression, env: CtorLowerEnv): string | null {
+    while (ts.isParenthesizedExpression(node)) node = node.expression
+
+    if (node.kind === ts.SyntaxKind.TrueKeyword) return 'true'
+    if (node.kind === ts.SyntaxKind.FalseKeyword) return 'false'
+
+    // `!<cond>`
+    if (
+      ts.isPrefixUnaryExpression(node) &&
+      node.operator === ts.SyntaxKind.ExclamationToken
+    ) {
+      const inner = this.lowerCtorCond(node.operand, env)
+      return inner === null ? null : `!(${inner})`
+    }
+
+    // `<a> && <b>` / `<a> || <b>` — both operands must themselves be boolean.
+    if (ts.isBinaryExpression(node)) {
+      const op =
+        node.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken
+          ? '&&'
+          : node.operatorToken.kind === ts.SyntaxKind.BarBarToken
+            ? '||'
+            : null
+      if (op) {
+        const l = this.lowerCtorCond(node.left, env)
+        const r = this.lowerCtorCond(node.right, env)
+        return l !== null && r !== null ? `(${l} ${op} ${r})` : null
+      }
+    }
+
+    // `<arr>.includes(<x>)` is the one value-shape `lowerCtorExpr` lowers to a
+    // Go bool (`bf.Includes(...)`); reuse it for that case only.
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === 'includes'
+    ) {
+      return this.lowerCtorExpr(node, env)
     }
 
     return null


### PR DESCRIPTION
## What

First of a phased root-cause fix for the **PostList derived-state SSR blocker** (#1897 follow-up). PostList's derived state is unpopulated on the Go adapter, causing execute-time failures. This PR lands **Capability A**: object-returning `searchParams()` memos are now computed instead of left `nil`.

### The problem
A block-body memo like:
```ts
const params = createMemo(() => {
  const sp = searchParams()
  return { sort: asSortKey(sp.get('sort')), tag: sp.get('tag') ?? '' }
})
```
matched no existing memo pattern, so `NewXxxProps` set `Params: nil`. The template's `{{.Params.Sort}}` / `{{.Params.Tag}}` / `{{if .Params.Tag}}` then read a nil map (empty / wrong output).

### The fix
`computeObjectMemoInitialValue` (TS AST) detects the object-returning block-body memo and lowers each property value to Go in the **constructor context** via a new `lowerCtorExpr`. It emits a computed `map[string]interface{}` with capitalized keys matching the template's field access:

```go
Params: map[string]interface{}{
    "Sort": func() string { if bf.Includes([]string{"date", "title", "tag"}, in.SearchParams.Get("sort")) { return in.SearchParams.Get("sort") }; return "date" }(),
    "Tag":  in.SearchParams.Get("tag"),
},
```

`lowerCtorExpr` covers the narrow surface these memos use:
- `<sp>.get('k')` → `in.SearchParams.Get("k")`
- `<arr>.includes(<x>)` → `bf.Includes([]string{…}, <x>)` (existing runtime helper)
- module arrow-helper inlining (e.g. `asSortKey`)
- `<expr> ?? ''` (no-op; `Get` already returns `""`)
- string ternaries → `func() string { … }()`

Any unsupported shape returns `null` → existing nil fallback, **no regression**.

## Verification
- Emitted Go **compiles and matches JS semantics** via the real Go toolchain — incl. `asSortKey` validation: `?sort=bogus` → `"date"`, `?sort=title&tag=go` → `Sort="title" Tag="go"`.
- Real `PostList` now computes `.Params` (previously `nil`).
- go-template adapter **525 pass**, conformance **761 pass**, `tsc` clean.

## Scope / not in this PR (follow-up capabilities)
This is **A** of a capability-by-capability plan agreed for the root fix:
- **B** — inline local pure helpers (`sortClass`/`tagClass`) at call sites → kills the `{{.SortClass …}}` execute-time crash.
- **C** — URL building (`hrefFor`/`URLSearchParams`) via a generic `bf_query` runtime helper → fixes `{{.SortHref …}}`.
- **D** — filtered-array memo → `Visible` count (`{{len .Visible}}`).

PostList renders without crashing once A+B+C land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JT4Rcc5b1qcMStCJfmD3V1)_