### PR TITLE
fix(mojo,xslate): pass _bf_slot for body children inside loops (#1896)

### DIFF
--- a/.changeset/perl-data-table-scope-id.md
+++ b/.changeset/perl-data-table-scope-id.md
@@ -1,0 +1,6 @@
+---
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+---
+
+Fix scope-ID divergence for body children of loop-item components (#1896). Both Perl adapters now reset `inLoop` before rendering body children in `renderComponent`, so nested components (e.g. `<TableCell>` inside a looped `<TableRow>`) receive `_bf_slot` for deterministic parent-scope-derived IDs matching Hono. Removes `data-table` from `skipJsx` in both adapter conformance tests.

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -18,34 +18,12 @@ runAdapterConformanceTests({
   factory: () => new MojoAdapter(),
   render: renderMojoComponent,
   // No JSX-render skips: every shared conformance fixture — including
-  // the renderable members of the composed `site/ui` demo corpus
-  // (#1467 / #1897) — renders to Hono parity on real Mojolicious.
-  // `tabs` / `tooltip` / `pagination` came off via the harness's
-  // child-defaults seeding (declared props, inherited accesses, signal
-  // initials, memo ssrDefaults — closing the strict-vars `Global
-  // symbol "$id"` gap), boolean-typed prop routing through
-  // `bf->bool_str`, `attr={cond ? v : undefined}` omission, and
-  // literal-const inlining.
-  //
-  // `data-table` is the one remaining JSX-render skip (#1897). It now
-  // COMPILES clean — `selected()[index]` lowers via the shared
-  // `index-access` parser kind and `payment.amount.toFixed(2)` via
-  // `bf->to_fixed`, and its `/* @client */`-guarded `sortedData` memo
-  // SSR-evaluates to the unsorted `payments` early-return — so the
-  // template renders structurally BYTE-IDENTICAL to Hono on real
-  // Mojolicious. The sole divergence is the scope-ID of imported
-  // components inside the keyed `.map` (`TableCell_<random>` vs Hono's
-  // `DataTablePreviewDemo_test_s9`): the loop-child slot-skip is a
-  // hydration-scope concern tracked with #1896, not an expression gap.
-  // Pinned here rather than in `expectedDiagnostics` because no BF101
-  // fires anymore.
-  //
-  // `search-params` (router v0.5) now renders: the emitter lowers
-  // `searchParams().get('sort')` to a real method call on the per-request
-  // `$searchParams` reader (`$searchParams->get('sort')`), and the harness
-  // binds it to an empty-query `BarefootJS::SearchParams` (`.get` → undef →
-  // `// 'none'` renders the default). See #1922.
-  skipJsx: ['data-table'],
+  // the composed `site/ui` demo corpus (#1467 / #1897) — renders to
+  // Hono parity on real Mojolicious. `data-table` came off via the
+  // body-children `inLoop` reset (#1896): the loop-item component
+  // (TableRow) still gets `ComponentName_<random>` scope IDs, but its
+  // body children (TableCell) now receive `_bf_slot` for deterministic
+  // parent-scope-derived IDs matching Hono.
   // Per-fixture build-time contracts for shapes the Mojo adapter
   // intentionally refuses to lower. Owned by this adapter test file
   // (not by the shared fixtures) so adding a new adapter doesn't

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1254,7 +1254,10 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       // `render_child` would let the inner `%>` close the outer tag.
       // `render_child` materializes the resulting CODE ref into the
       // captured Mojo::ByteStream.
+      const prevInLoop = this.inLoop
+      this.inLoop = false
       const childrenBody = this.renderChildren(effectiveChildren)
+      this.inLoop = prevInLoop
       const varName = `$bf_children_${comp.slotId ?? 'c' + this.childrenCaptureCounter++}`
       return `<% my ${varName} = begin %>${childrenBody}<% end %><%== bf->render_child('${tplName}'${propsStr}, children => ${varName}) %>`
     }

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -27,32 +27,11 @@ runAdapterConformanceTests({
   render: renderXslateComponent,
   // No JSX-render skips: every shared conformance fixture — including
   // the composed `site/ui` demo corpus (#1467 / #1897) — renders to
-  // Hono parity on real Text::Xslate. The last three (`tabs`,
-  // `accordion`, `pagination`) came off via: shared module-const
-  // resolution (composed template-literal consts), compile-time
-  // record-property lookup (`variantClasses.ghost`), ARIA
-  // `aria-selected`/`aria-expanded` + boolean-TYPED prop routing
-  // through `bool_str`, `attr={cond ? v : undefined}` omission, and
-  // literal-const inlining (`totalPages`). Shapes the adapter
-  // intentionally refuses at build time stay pinned in
-  // `expectedDiagnostics` below.
-  //
-  // `data-table` is the one JSX-render skip (#1897): it compiles clean
-  // (`selected()[index]` → shared `index-access` parser kind,
-  // `.toFixed(2)` → `$bf.to_fixed`, `/* @client */`-guarded `sortedData`
-  // memo SSR-folded to the unsorted early-return) and renders
-  // structurally BYTE-IDENTICAL to Hono on real Text::Xslate. The sole
-  // divergence is the scope-ID of imported components inside the keyed
-  // `.map` (a hydration-scope concern tracked with #1896, not an
-  // expression gap), so it's pinned in `skipJsx` rather than
-  // `expectedDiagnostics` (no BF101 fires anymore).
-  //
-  // `search-params` (router v0.5) now renders: the emitter lowers
-  // `searchParams().get('sort')` to a real method call on the per-request
-  // `$searchParams` reader (`$searchParams.get('sort')`), and the harness
-  // binds it to an empty-query `BarefootJS::SearchParams` (`.get` → nil →
-  // `// 'none'` renders the default). See #1922.
-  skipJsx: ['data-table'],
+  // Hono parity on real Text::Xslate. `data-table` came off via the
+  // body-children `inLoop` reset (#1896): the loop-item component
+  // (TableRow) still gets `ComponentName_<random>` scope IDs, but its
+  // body children (TableCell) now receive `_bf_slot` for deterministic
+  // parent-scope-derived IDs matching Hono.
   // Per-fixture build-time contracts for shapes the Xslate adapter
   // intentionally refuses to lower. Mirrors mojo's set — the lowering
   // gates are shared code paths in the ported adapter.

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -1080,7 +1080,10 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
       // children HTML; the macro call result is passed as the `children` entry
       // of the render_child hashref. `render_child` materializes a CODE-ref
       // children value through the backend before handing it to the child.
+      const prevInLoop = this.inLoop
+      this.inLoop = false
       const childrenBody = this.renderChildren(effectiveChildren)
+      this.inLoop = prevInLoop
       const macroName = `bf_children_${comp.slotId ?? 'c' + this.childrenCaptureCounter++}`
       const childrenEntry = `children => ${macroName}()`
       const allParts = [...propParts, childrenEntry]


### PR DESCRIPTION
## Summary

- **Fix scope-ID divergence** for imported components' body children inside keyed `.map()` loops in both Perl adapters (Mojolicious + Xslate)
- Both adapters' `renderComponent` now saves/resets `inLoop = false` before rendering body children, then restores it — so the direct loop-item component (e.g. `TableRow`) still gets a per-iteration `ComponentName_<random>` scope ID, but its slotted children (e.g. `TableCell`) receive `_bf_slot` for deterministic parent-scope-derived IDs matching Hono
- **Removes `data-table` from `skipJsx`** in both adapter conformance tests

## Context

The `data-table` fixture was the last remaining `skipJsx` entry for both Perl adapters (#1897). It compiled clean and rendered structurally byte-identical HTML to Hono — the sole divergence was the `bf-s` scope-ID on body children inside the keyed loop: Perl emitted `TableCell_<random>` while Hono emitted `DataTablePreviewDemo_test_s9`. Root cause: `this.inLoop` persisted into the body-children render path, suppressing `_bf_slot` for all nested components, not just the direct loop item.

## Test plan

- [x] Mojo adapter conformance: 463 pass, 0 fail (locally; rendering skipped — Mojolicious not installed)
- [x] Xslate adapter conformance: 338 pass, 0 fail (locally; rendering skipped — Text::Xslate not installed)
- [x] Go adapter conformance: 514 pass, 0 fail (regression check)
- [x] Shared adapter tests: 761 pass, 0 fail
- [ ] CI: verify Perl rendering passes on real Mojolicious + Text::Xslate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8F7kPrdbcRmTxgy9PzsTp

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8F7kPrdbcRmTxgy9PzsTp)_