### PR TITLE
feat(go-template): inline local pure helper calls at template call sites (PostList derived state, Capability B)

### DIFF
--- a/.changeset/go-inline-local-helpers.md
+++ b/.changeset/go-inline-local-helpers.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/go-template": minor
+---
+
+Inline local pure helper calls at template call sites (PostList derived-state blocker, #1897 follow-up — Capability B).
+
+A call to a local, expression-bodied helper arrow const — `className={sortClass('date')}` where `const sortClass = (k) => params().sort === k ? 'sort on' : 'sort'` — previously lowered to `{{.SortClass "date"}}`, a method call on the Props struct with no Go method backing it (execute-time `can't evaluate field SortClass`). The adapter now inlines the helper's body at the call site, substituting the call arguments for the params (AST span-splice, so it is shadowing- and member-name-safe), and lowers the result: `class="{{if eq (bf_string .Params.Sort) "date"}}sort on{{else}}sort{{end}}"`. Works inside loops too (`tagClass(t)` resolves the loop var and root memo). Only self-contained helpers are inlined; one that delegates to another local helper (e.g. `sortHref` → `hrefFor`) is left untouched for a later capability. The attribute-value emitter no longer double-wraps an inlined helper that lowers to a self-contained `{{…}}` action block.

--- a/packages/adapter-go-template/src/__tests__/derived-state-memo.test.ts
+++ b/packages/adapter-go-template/src/__tests__/derived-state-memo.test.ts
@@ -179,4 +179,45 @@ export function P(props: { base: string }) {
     // sortHref delegates to hrefFor (a local helper) → not inlined here.
     expect(template).toContain('.SortHref')
   })
+
+  // A compound argument must keep its precedence when spliced into the body —
+  // `sig() === <param>` with arg `a ?? b` must not become `sig() === a ?? b`
+  // (#1943 review). The substituted arg is parenthesized.
+  test('compound call argument is parenthesized (precedence preserved)', () => {
+    const src = `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function P(props: { a?: string; b?: string }) {
+  const [sig] = createSignal('x')
+  const cls = (k) => (sig() === k ? 'on' : 'off')
+  return <a className={cls(props.a ?? props.b)}>x</a>
+}
+`
+    const { template } = generate(src)
+    expect(template).not.toContain('.Cls')
+    // `===` must stay the outer operation (`eq .Sig …`). Without parenthesizing
+    // the arg, `sig() === props.a ?? props.b` would bind as
+    // `(sig() === props.a) ?? props.b` → an outer `{{if or …}}`. This matches
+    // what a direct `sig() === (props.a ?? props.b)` lowers to.
+    expect(template).toContain('{{if eq .Sig')
+    expect(template).not.toContain('{{if or')
+  })
+
+  // The splicer is scope-blind, so a helper whose body contains a nested
+  // function is NOT inlined (avoids shadowing / param-position corruption) —
+  // it falls back to the method-call form (#1943 review).
+  test('helper with a nested function scope is not inlined', () => {
+    const src = `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function P(props: { xs: string[] }) {
+  const [sig] = createSignal('x')
+  const has = (k) => (props.xs.some((x) => x === k) ? 'on' : 'off')
+  return <a className={has('y')}>x</a>
+}
+`
+    const { template } = generate(src)
+    // Not inlined → stays as the (un-backed) method-call form.
+    expect(template).toContain('.Has')
+  })
 })

--- a/packages/adapter-go-template/src/__tests__/derived-state-memo.test.ts
+++ b/packages/adapter-go-template/src/__tests__/derived-state-memo.test.ts
@@ -110,3 +110,73 @@ export function P() {
     expect(types).not.toContain('Params: map[string]interface{}{')
   })
 })
+
+describe('Capability B: inline local pure helper calls at attribute call sites', () => {
+  test('sortClass(k) inlines to a conditional, not a .SortClass method call', () => {
+    const src = `
+'use client'
+import { createMemo, searchParams } from '@barefootjs/client'
+const SORT_KEYS = ['date', 'title', 'tag']
+const asSortKey = (raw) => (SORT_KEYS.includes(raw) ? raw : 'date')
+export function P() {
+  const params = createMemo(() => {
+    const sp = searchParams()
+    return { sort: asSortKey(sp.get('sort')), tag: sp.get('tag') ?? '' }
+  })
+  const sortClass = (k) => (params().sort === k ? 'sort on' : 'sort')
+  return <a className={sortClass('date')}>date</a>
+}
+`
+    const { template } = generate(src)
+    expect(template).not.toContain('.SortClass')
+    // `.Params.Sort` is interface{} (a map value), so `eq` coerces it via
+    // `bf_string` before comparing to the string literal.
+    expect(template).toContain(
+      'class="{{if eq (bf_string .Params.Sort) "date"}}sort on{{else}}sort{{end}}"',
+    )
+  })
+
+  test('tagClass(t) inlines inside a loop, resolving the loop var and root memo', () => {
+    const src = `
+'use client'
+import { createMemo, searchParams } from '@barefootjs/client'
+export function P(props: { tags: string[] }) {
+  const params = createMemo(() => {
+    const sp = searchParams()
+    return { tag: sp.get('tag') ?? '' }
+  })
+  const tagClass = (t) => (params().tag === t ? 'tag on' : 'tag')
+  return <div>{props.tags.map((t) => <a key={t} className={tagClass(t)}>#{t}</a>)}</div>
+}
+`
+    const { template } = generate(src)
+    expect(template).not.toContain('.TagClass')
+    // params() is a root memo (→ $.Params) and t is the loop var (→ .)
+    expect(template).toContain('{{if eq $.Params.Tag .}}tag on{{else}}tag{{end}}')
+  })
+
+  test('a helper that delegates to another local helper is NOT inlined (left for Capability C)', () => {
+    const src = `
+'use client'
+import { createMemo, searchParams } from '@barefootjs/client'
+export function P(props: { base: string }) {
+  const params = createMemo(() => {
+    const sp = searchParams()
+    return { sort: sp.get('sort') ?? '' }
+  })
+  const hrefFor = (sort: string, tag: string) => {
+    const u = new URLSearchParams()
+    if (sort !== 'date') u.set('sort', sort)
+    if (tag) u.set('tag', tag)
+    const s = u.toString()
+    return s ? '/' + '?' + s : '/'
+  }
+  const sortHref = (k) => hrefFor(k, params().sort)
+  return <a href={sortHref('date')}>date</a>
+}
+`
+    const { template } = generate(src)
+    // sortHref delegates to hrefFor (a local helper) → not inlined here.
+    expect(template).toContain('.SortHref')
+  })
+})

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -645,6 +645,13 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    */
   private searchParamsLocals: Set<string> = new Set()
 
+  /**
+   * Names of component-scope arrow-const helpers (`const sortClass = …`),
+   * eligible for call-site inlining (#1897). Precomputed per component so the
+   * inliner can skip the AST parse for the common non-helper expression.
+   */
+  private localHelperNames: Set<string> = new Set()
+
   /** Child component name → the contexts it consumes (cross-component, for provider wiring). */
   private childContextConsumers: Map<string, ContextConsumer[]> = new Map()
 
@@ -686,6 +693,9 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     this.restPropsName = ir.metadata.restPropsName ?? null
     this.moduleStringConsts = this.collectModuleStringConsts(ir.metadata.localConstants)
     this.localConstants = ir.metadata.localConstants ?? []
+    this.localHelperNames = new Set(
+      this.localConstants.filter(c => !c.isModule && c.containsArrow).map(c => c.name),
+    )
     this.currentMemos = ir.metadata.memos ?? []
     this.currentTypeDefinitions = ir.metadata.typeDefinitions ?? []
     this.contextConsumers = collectContextConsumers(ir.metadata)
@@ -1066,6 +1076,9 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // lookups — both need the const tables populated on this standalone entry.
     this.moduleStringConsts = this.collectModuleStringConsts(ir.metadata.localConstants)
     this.localConstants = ir.metadata.localConstants ?? []
+    this.localHelperNames = new Set(
+      this.localConstants.filter(c => !c.isModule && c.containsArrow).map(c => c.name),
+    )
     this.currentMemos = ir.metadata.memos ?? []
     this.currentTypeDefinitions = ir.metadata.typeDefinitions ?? []
     this.contextConsumers = collectContextConsumers(ir.metadata)
@@ -6420,6 +6433,18 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       }
     }
 
+    // (#1897 PostList) Inline a call to a local, expression-bodied helper arrow
+    // (`sortClass(k)` / `tagClass(t)`) by substituting its params with the call
+    // args and lowering the resulting expression. There is no Go method backing
+    // a `.SortClass "date"` call, so the call site must carry the computation
+    // (`{{if eq .Params.Sort "date"}}sort on{{else}}sort{{end}}`). Only self-
+    // contained helpers are inlined; one that delegates to another local helper
+    // (e.g. `sortHref` → `hrefFor`) is left for a later capability.
+    const inlined = this.inlineLocalHelperCall(trimmed)
+    if (inlined !== null) {
+      return this.convertExpressionToGo(inlined, out)
+    }
+
     // Parse only here — *after* the early returns above, which resolve
     // `null`/`undefined`, static record indexes, and inlined literal consts
     // without a parse. The result is reported to the caller via `out` below
@@ -6456,6 +6481,108 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     if (out) out.parsed = parsed
 
     return this.renderParsedExpr(parsed)
+  }
+
+  /**
+   * (#1897 PostList) If `jsExpr` is a call to a local, expression-bodied helper
+   * arrow const (`sortClass(k)` / `tagClass(t)`), return its body with the call
+   * args substituted for the params (re-emitted to source), so the caller can
+   * lower the inlined expression. Returns null when `jsExpr` is not such a call,
+   * or when the helper delegates to another local helper (e.g. `sortHref` →
+   * `hrefFor`) — those need their own lowering capability and must not be
+   * half-inlined here. Substitution is AST-based (no string matching) so it is
+   * shadowing- and member-name-safe.
+   */
+  private inlineLocalHelperCall(jsExpr: string): string | null {
+    if (this.localHelperNames.size === 0) return null
+    // Fast path: skip the AST parse unless the expression begins with a known
+    // helper name applied as a call (`<helper>(`). The leading-identifier match
+    // is an unambiguous prefix — the real shape check is the AST parse below.
+    const head = /^\s*([A-Za-z_$][\w$]*)\s*\(/.exec(jsExpr)
+    if (!head || !this.localHelperNames.has(head[1])) return null
+
+    const call = this.parseLiteralExpression(jsExpr)
+    if (!call || !ts.isCallExpression(call) || !ts.isIdentifier(call.expression)) return null
+    const fnConst = this.localConstants.find(
+      c => c.name === (call.expression as ts.Identifier).text && !c.isModule && c.value,
+    )
+    if (!fnConst?.value) return null
+    const fn = this.parseLiteralExpression(fnConst.value)
+    if (!fn || !ts.isArrowFunction(fn) || ts.isBlock(fn.body)) return null
+    if (fn.parameters.length !== call.arguments.length) return null
+    // Don't half-inline a helper that calls another local helper.
+    if (this.bodyCallsLocalHelper(fn.body)) return null
+
+    const subs = new Map<string, string>()
+    for (let i = 0; i < fn.parameters.length; i++) {
+      const p = fn.parameters[i]
+      if (!ts.isIdentifier(p.name)) return null
+      subs.set(p.name.text, call.arguments[i].getText())
+    }
+    return this.substituteHelperParams(fn.body, subs)
+  }
+
+  /**
+   * True when `body` contains a call to a *local* (component-scope) arrow helper
+   * const — the signal that inlining `body` here would only push the problem to
+   * another un-lowered helper (e.g. `sortHref`'s body calls `hrefFor`).
+   */
+  private bodyCallsLocalHelper(body: ts.Node): boolean {
+    let found = false
+    const visit = (n: ts.Node): void => {
+      if (found) return
+      if (ts.isCallExpression(n) && ts.isIdentifier(n.expression)) {
+        const name = n.expression.text
+        if (
+          this.localConstants.some(c => c.name === name && !c.isModule && c.containsArrow)
+        ) {
+          found = true
+          return
+        }
+      }
+      ts.forEachChild(n, visit)
+    }
+    visit(body)
+    return found
+  }
+
+  /**
+   * Re-emit `body` to source with each identifier named in `subs` replaced by
+   * the substitution's source text. Implemented as span splicing over `body`'s
+   * own source (single source file — args are passed as text, not cross-file
+   * AST nodes, which would corrupt a printer keyed to `body`'s source). The walk
+   * skips the property NAME in `a.b`, so a param sharing a name with a member is
+   * left untouched.
+   */
+  private substituteHelperParams(
+    body: ts.Expression,
+    subs: ReadonlyMap<string, string>,
+  ): string {
+    const sf = body.getSourceFile()
+    const base = body.getStart(sf)
+    // Collect replacement spans (relative to the body's start), right-to-left.
+    const repls: { start: number; end: number; text: string }[] = []
+    const visit = (node: ts.Node): void => {
+      if (ts.isPropertyAccessExpression(node)) {
+        visit(node.expression) // skip `.name`
+        return
+      }
+      if (ts.isIdentifier(node)) {
+        const sub = subs.get(node.text)
+        if (sub !== undefined) {
+          repls.push({ start: node.getStart(sf) - base, end: node.getEnd() - base, text: sub })
+          return
+        }
+      }
+      ts.forEachChild(node, visit)
+    }
+    visit(body)
+
+    let text = body.getText(sf)
+    for (const r of repls.sort((a, b) => b.start - a.start)) {
+      text = text.slice(0, r.start) + r.text + text.slice(r.end)
+    }
+    return text
   }
 
   /**
@@ -7318,7 +7445,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         const field = `.${this.capitalizeFieldName(propName)}`
         return `{{if ne ${field} nil}}${name}="{{${this.convertExpressionToGo(value.expr)}}}"{{end}}`
       }
-      return `${name}="{{${this.convertExpressionToGo(value.expr)}}}"`
+      // Lower once; if the result is already a self-contained action block (e.g.
+      // an inlined `sortClass(k)` → `{{if …}}…{{end}}`, #1897), embed it as-is
+      // rather than double-wrapping it in another `{{…}}`.
+      const exprOut: { parsed?: ParsedExpr } = {}
+      const go = this.convertExpressionToGo(value.expr, exprOut)
+      return this.isTemplateFragment(go, exprOut.parsed?.kind)
+        ? `${name}="${go}"`
+        : `${name}="{{${go}}}"`
     },
     emitBooleanAttr: (_value, name) => name,
     // Spread attributes (`<div {...attrs()} />`) lower through the

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -6503,6 +6503,8 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
     const call = this.parseLiteralExpression(jsExpr)
     if (!call || !ts.isCallExpression(call) || !ts.isIdentifier(call.expression)) return null
+    // A spread arg (`f(...xs)`) can't map to positional params by text splice.
+    if (call.arguments.some(a => ts.isSpreadElement(a))) return null
     const fnConst = this.localConstants.find(
       c => c.name === (call.expression as ts.Identifier).text && !c.isModule && c.value,
     )
@@ -6517,9 +6519,45 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     for (let i = 0; i < fn.parameters.length; i++) {
       const p = fn.parameters[i]
       if (!ts.isIdentifier(p.name)) return null
-      subs.set(p.name.text, call.arguments[i].getText())
+      // Parenthesize the arg so its own precedence survives the splice into the
+      // body (e.g. `x === <param>` with arg `a || b` must not become
+      // `x === a || b`).
+      subs.set(p.name.text, `(${call.arguments[i].getText()})`)
     }
+    // The splicer is scope-blind, so reject bodies where a textual identifier
+    // replacement could be wrong: nested function scopes (shadowing / param
+    // positions) and object shorthand keys that are params.
+    if (!this.isSpliceSafeHelperBody(fn.body, new Set(subs.keys()))) return null
     return this.substituteHelperParams(fn.body, subs)
+  }
+
+  /**
+   * Guard for `substituteHelperParams`: the span splicer replaces identifiers by
+   * name without scope tracking, so it is only safe on bodies free of
+   * constructs where a param name could appear in a position the splice can't
+   * handle — a nested function scope (shadowing or its own parameters), or an
+   * object shorthand key (`{ k }`, which can't be rewritten to `{ (arg) }`).
+   */
+  private isSpliceSafeHelperBody(body: ts.Node, paramNames: ReadonlySet<string>): boolean {
+    let safe = true
+    const visit = (n: ts.Node): void => {
+      if (!safe) return
+      if (
+        ts.isArrowFunction(n) ||
+        ts.isFunctionExpression(n) ||
+        ts.isFunctionDeclaration(n)
+      ) {
+        safe = false
+        return
+      }
+      if (ts.isShorthandPropertyAssignment(n) && paramNames.has(n.name.text)) {
+        safe = false
+        return
+      }
+      ts.forEachChild(n, visit)
+    }
+    visit(body)
+    return safe
   }
 
   /**
@@ -6551,8 +6589,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * the substitution's source text. Implemented as span splicing over `body`'s
    * own source (single source file — args are passed as text, not cross-file
    * AST nodes, which would corrupt a printer keyed to `body`'s source). The walk
-   * skips the property NAME in `a.b`, so a param sharing a name with a member is
-   * left untouched.
+   * skips non-value identifier positions — the property NAME in `a.b` and a
+   * plain object-literal key in `{ k: … }` — so a param sharing a name with a
+   * member or key is left untouched. (`isSpliceSafeHelperBody` has already
+   * rejected nested functions and `{ k }` shorthand keys.)
    */
   private substituteHelperParams(
     body: ts.Expression,
@@ -6565,6 +6605,13 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     const visit = (node: ts.Node): void => {
       if (ts.isPropertyAccessExpression(node)) {
         visit(node.expression) // skip `.name`
+        return
+      }
+      if (ts.isPropertyAssignment(node)) {
+        // A plain identifier/string key isn't a value position; only a computed
+        // key (`[expr]`) is. Visit the initializer (and computed key) only.
+        if (ts.isComputedPropertyName(node.name)) visit(node.name)
+        visit(node.initializer)
         return
       }
       if (ts.isIdentifier(node)) {


### PR DESCRIPTION
## What

**Capability B** of the phased PostList derived-state SSR fix (#1897 follow-up). Capability A (#1941) is **merged**; this PR now targets `main` directly and contains only B's two commits.

### The problem
A call to a local, expression-bodied helper arrow const:
```ts
const sortClass = (k) => params().sort === k ? 'sort on' : 'sort'
// …
<a className={sortClass('date')}>
```
lowered to `{{.SortClass "date"}}` — a method call on the Props struct with **no Go method behind it** → execute-time `can't evaluate field SortClass`.

### The fix
`convertExpressionToGo` now **inlines** such a call: it substitutes the call args for the helper's params (AST span-splice over the body's own source) and lowers the result:
```
class="{{if eq (bf_string .Params.Sort) "date"}}sort on{{else}}sort{{end}}"
```
- Works inside loops — `tagClass(t)` resolves the loop var (`.`) and the root memo (`$.Params`): `{{if eq $.Params.Tag .}}tag on{{else}}tag{{end}}`.
- Only **self-contained** helpers inline. One that delegates to another local helper (`sortHref` → `hrefFor`) is left untouched for **Capability C**.
- The attribute-value emitter no longer double-wraps an inlined helper that lowers to a self-contained `{{…}}` block (`isTemplateFragment` guard).
- A precomputed `localHelperNames` set + a leading-identifier fast path keep the inliner **off the parse hot path**.

### Substitution safety (review follow-ups)
- Each substituted arg is **parenthesized** (precedence-preserving); **spread args bail**.
- Bodies with a **nested function scope** or an object **shorthand key that is a param** are rejected (`isSpliceSafeHelperBody`) — the scope-blind splicer can't handle them.
- Plain object-literal **keys** (`{ k: … }`) are skipped like the property name in `a.b`.

## Verification
- The `eq` interface{}-vs-string comparison **executes in real Go**.
- Real `PostList` drops `.SortClass` / `.TagClass` (still has `.SortHref` → C, `.Visible` → D).
- Adapter + conformance **1293 pass / 0 fail**, `tsc` clean.

## Stack
- #1941 — A — object memo → computed map field ✅ **merged**
- **this** — B — inline local pure helpers
- #1944 — C1 — `bf_query` runtime helper (stacked on this)
- next — C2 — `hrefFor` / `URLSearchParams` → `bf_query` (+ `base`/`root`)
- next — D — filtered-array memo → `Visible` count

🤖 Generated with [Claude Code](https://claude.com/claude-code)