### PR TITLE
feat(go-template): add bf_query runtime helper for URL query building (PostList href, Capability C1)

### DIFF
--- a/.changeset/go-query-helper.md
+++ b/.changeset/go-query-helper.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Add the `bf_query` runtime helper (PostList href blocker, #1897 follow-up — Capability C1).
+
+`bf_query(base, ...triples)` builds a URL from a base path plus a query string assembled from `(include bool, key, value)` triples, in order — appending each pair only when its `include` flag is true, with keys/values query-escaped. It mirrors a JS `URLSearchParams` builder whose `.set(key, value)` calls are each guarded by an `if` (the compiler lowers each guard to the `include` bool). This is the runtime primitive the upcoming adapter lowering of `hrefFor`-style helpers emits; no generated output uses it yet.

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -47,6 +47,11 @@ func FuncMap() template.FuncMap {
 		"bf_pad_end":     PadEnd,
 		"bf_string":      String,
 
+		// URL query builder (#1897 PostList href helpers): conditional
+		// (include, key, value) triples → "base?k=v&…", mirroring a
+		// URLSearchParams builder with guarded `.set()` calls.
+		"bf_query": Query,
+
 		// JSON / numeric primitives — JS-compat callees registered on
 		// the Go adapter's `templatePrimitives` map (#1188).
 		"bf_json":   JSON,
@@ -119,6 +124,35 @@ func FuncMap() template.FuncMap {
 		// JSX intrinsic-element spread lowering (#1407)
 		"bf_spread_attrs": SpreadAttrs,
 	}
+}
+
+// Query builds a URL from a base path plus a query string assembled from
+// (include, key, value) triples, in order. A pair is appended only when its
+// `include` flag is true — mirroring a JS URLSearchParams builder whose
+// `.set(key, value)` calls are each guarded by an `if`. The compiler lowers
+// each guard to the `include` bool (so empty-but-included values, and
+// non-empty-but-excluded values, both match the source semantics). Keys and
+// values are query-escaped (spaces → "+", like URLSearchParams). An empty
+// query yields the bare base.
+//
+// Trailing args that don't complete a triple are ignored.
+func Query(base string, triples ...any) string {
+	var b strings.Builder
+	for i := 0; i+2 < len(triples); i += 3 {
+		include, _ := triples[i].(bool)
+		if !include {
+			continue
+		}
+		if b.Len() == 0 {
+			b.WriteByte('?')
+		} else {
+			b.WriteByte('&')
+		}
+		b.WriteString(url.QueryEscape(String(triples[i+1])))
+		b.WriteByte('=')
+		b.WriteString(url.QueryEscape(String(triples[i+2])))
+	}
+	return base + b.String()
 }
 
 // ScopeAttr returns the bare bf-s scope id (#1249).

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -135,22 +135,37 @@ func FuncMap() template.FuncMap {
 // values are query-escaped (spaces → "+", like URLSearchParams). An empty
 // query yields the bare base.
 //
-// Trailing args that don't complete a triple are ignored.
+// Included pairs follow URLSearchParams.set() semantics: repeating a key
+// overwrites the value at the key's first position rather than emitting a
+// duplicate `k=v&k=w`. Trailing args that don't complete a triple are ignored.
 func Query(base string, triples ...any) string {
-	var b strings.Builder
+	type kv struct{ key, val string }
+	pairs := make([]kv, 0, len(triples)/3)
+	pos := make(map[string]int)
 	for i := 0; i+2 < len(triples); i += 3 {
 		include, _ := triples[i].(bool)
 		if !include {
 			continue
 		}
+		k := String(triples[i+1])
+		v := String(triples[i+2])
+		if at, ok := pos[k]; ok {
+			pairs[at].val = v // set(): overwrite the first occurrence's value
+		} else {
+			pos[k] = len(pairs)
+			pairs = append(pairs, kv{k, v})
+		}
+	}
+	var b strings.Builder
+	for _, p := range pairs {
 		if b.Len() == 0 {
 			b.WriteByte('?')
 		} else {
 			b.WriteByte('&')
 		}
-		b.WriteString(url.QueryEscape(String(triples[i+1])))
+		b.WriteString(url.QueryEscape(p.key))
 		b.WriteByte('=')
-		b.WriteString(url.QueryEscape(String(triples[i+2])))
+		b.WriteString(url.QueryEscape(p.val))
 	}
 	return base + b.String()
 }

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -1870,6 +1870,11 @@ func TestQuery(t *testing.T) {
 		{"escapes value", "/", []any{true, "tag", "a b&c"}, "/?tag=a+b%26c"},
 		{"empty-but-included value", "/", []any{true, "tag", ""}, "/?tag="},
 		{"trailing partial triple ignored", "/", []any{true, "sort", "title", true, "tag"}, "/?sort=title"},
+		// URLSearchParams.set(): repeating a key overwrites the value at the
+		// key's first position, never duplicating `k=v&k=w`.
+		{"repeated key overwrites first position", "/", []any{true, "sort", "title", true, "sort", "date"}, "/?sort=date"},
+		{"overwrite keeps first position among others", "/blog", []any{true, "sort", "title", true, "tag", "go", true, "sort", "date"}, "/blog?sort=date&tag=go"},
+		{"excluded repeat does not overwrite", "/", []any{true, "sort", "title", false, "sort", "date"}, "/?sort=title"},
 	}
 	for _, tt := range tests {
 		if got := Query(tt.base, tt.triples...); got != tt.want {

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -1854,3 +1854,26 @@ func TestRender_AutoAssignsChildScopeIDs(t *testing.T) {
 		t.Fatal("expected Render to backfill the empty child ScopeID in place")
 	}
 }
+
+func TestQuery(t *testing.T) {
+	tests := []struct {
+		name    string
+		base    string
+		triples []any
+		want    string
+	}{
+		{"no triples", "/", nil, "/"},
+		{"all excluded", "/", []any{false, "sort", "title", false, "tag", "go"}, "/"},
+		{"one included", "/", []any{true, "sort", "title"}, "/?sort=title"},
+		{"order preserved", "/blog", []any{true, "sort", "title", true, "tag", "go"}, "/blog?sort=title&tag=go"},
+		{"mixed include", "/blog", []any{false, "sort", "date", true, "tag", "go"}, "/blog?tag=go"},
+		{"escapes value", "/", []any{true, "tag", "a b&c"}, "/?tag=a+b%26c"},
+		{"empty-but-included value", "/", []any{true, "tag", ""}, "/?tag="},
+		{"trailing partial triple ignored", "/", []any{true, "sort", "title", true, "tag"}, "/?sort=title"},
+	}
+	for _, tt := range tests {
+		if got := Query(tt.base, tt.triples...); got != tt.want {
+			t.Errorf("%s: Query(%q, %v) = %q, want %q", tt.name, tt.base, tt.triples, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## What

**Capability C1** of the phased PostList derived-state SSR fix (#1897 follow-up). Capabilities A (#1941) and B (#1943) are **merged**; this PR now targets `main` directly with a single commit.

Adds the `bf_query` Go **runtime helper** that the upcoming adapter lowering of `hrefFor`-style URL helpers (C2) will emit. Capability C was split: this PR is the self-contained runtime primitive; C2 is the adapter integration that recognizes the `URLSearchParams` builder idiom and emits `bf_query` calls (and lowers the `base`/`root` derived consts those helpers consume).

### The helper
```go
bf_query(base string, triples ...any) string
```
Assembles a URL from `base` plus a query string built from `(include bool, key, value)` triples, in order:
- a pair is appended **only when its `include` flag is true** — mirroring a JS `URLSearchParams` builder whose `.set(key, value)` calls are each guarded by an `if`. The compiler lowers each guard (`if (sort !== 'date')`, `if (tag)`) to the `include` bool, so empty-but-included and non-empty-but-excluded values both match the source.
- keys/values are query-escaped (spaces → `+`, like URLSearchParams).
- empty query → bare `base`.

## Why a (include, key, value) triple
Per the agreed design: the guard is computed by the existing condition lowering and passed as a Go `bool`, so arbitrary `if` guards map cleanly and the JS `.set()` semantics are preserved exactly (no value-side helpers needed).

## Verification
- Go unit test (`TestQuery`): ordering preserved, include/exclude, escaping, empty-but-included value, partial-triple ignored.
- `go vet ./...` clean, full runtime `go test ./...` green.
- No generated template references `bf_query` yet — it's wired in C2.

## Stack
- #1941 — A — object memo → computed map field ✅ **merged**
- #1943 — B — inline local pure helpers ✅ **merged**
- **this** — C1 — `bf_query` runtime helper
- next — C2 — adapter lowering: `hrefFor` / `URLSearchParams` → `bf_query` (+ `base`/`root`)
- next — D — filtered-array memo → `Visible` count

🤖 Generated with [Claude Code](https://claude.com/claude-code)