### PR TITLE
feat(go-template): lower URL-builder helpers to bf_query + derived Root field (PostList href, Capability C2)

### DIFF
--- a/.changeset/go-url-builder-lowering.md
+++ b/.changeset/go-url-builder-lowering.md
@@ -1,0 +1,12 @@
+---
+"@barefootjs/go-template": minor
+---
+
+Lower `hrefFor`-style URL-builder helpers to `bf_query`, and compute derived string consts as struct fields (PostList href blocker, #1897 follow-up — Capability C2).
+
+A call to a local URL-builder helper — `href={sortHref('date')}` where `sortHref` delegates to `hrefFor = (sort, tag) => { const u = new URLSearchParams(); if (sort !== 'date') u.set('sort', sort); if (tag) u.set('tag', tag); return u.toString() ? \`${root}?${u}\` : root }` — previously lowered to `{{.SortHref "date"}}`, a method call with no Go method behind it. The adapter now:
+
+- Recognizes the `URLSearchParams` builder idiom (AST) and emits a `bf_query` action, lowering each guarded `.set()` to an `(include bool, key, value)` triple — the guard via the existing condition lowering (`if (sort !== 'date')` → `ne … "date"`; `if (tag)` → `ne … ""`). Pass-through delegates (`sortHref` → `hrefFor`) are inlined and recursed.
+- Computes component-scope derived string consts that the template references (e.g. `root = base || '/'`, with `base = (props.base ?? '').replace(/\/+$/, '')`) as `NewXxxProps`-initialized struct fields. `(…).replace(/\/+$/, '')` lowers to `strings.TrimRight(_, "/")` (this trailing-slash pattern only), `||` to an empty-fallback, and `props.X` to `in.X`; `strings` is added to the generated imports when used.
+
+Verified end-to-end against the shared blog `PostList`: `.SortHref` / `.TagHref` are gone, `Root` is computed, and the emitted Go renders correct URLs (`/blog?sort=title&tag=go`, trailing-slash bases normalized).

--- a/packages/adapter-go-template/src/__tests__/derived-state-memo.test.ts
+++ b/packages/adapter-go-template/src/__tests__/derived-state-memo.test.ts
@@ -318,4 +318,18 @@ export function P(props: { count: number }) {
     const { types } = generate(src)
     expect(types).not.toContain('N string')
   })
+
+  // `||`/`??` evaluate to one operand, so a non-string left makes the result
+  // non-string even when the right is a string literal (#1945 review).
+  test('a `?? ""` over a non-string is not emitted as a string field', () => {
+    const src = `
+'use client'
+export function P(props: { count: number }) {
+  const c = props.count ?? ''
+  return <span>{c}</span>
+}
+`
+    const { types } = generate(src)
+    expect(types).not.toContain('C string')
+  })
 })

--- a/packages/adapter-go-template/src/__tests__/derived-state-memo.test.ts
+++ b/packages/adapter-go-template/src/__tests__/derived-state-memo.test.ts
@@ -155,29 +155,21 @@ export function P(props: { tags: string[] }) {
     expect(template).toContain('{{if eq $.Params.Tag .}}tag on{{else}}tag{{end}}')
   })
 
-  test('a helper that delegates to another local helper is NOT inlined (left for Capability C)', () => {
+  test('a helper that delegates to a non-URL-builder local helper is not inlined', () => {
     const src = `
 'use client'
-import { createMemo, searchParams } from '@barefootjs/client'
-export function P(props: { base: string }) {
-  const params = createMemo(() => {
-    const sp = searchParams()
-    return { sort: sp.get('sort') ?? '' }
-  })
-  const hrefFor = (sort: string, tag: string) => {
-    const u = new URLSearchParams()
-    if (sort !== 'date') u.set('sort', sort)
-    if (tag) u.set('tag', tag)
-    const s = u.toString()
-    return s ? '/' + '?' + s : '/'
-  }
-  const sortHref = (k) => hrefFor(k, params().sort)
-  return <a href={sortHref('date')}>date</a>
+import { createSignal } from '@barefootjs/client'
+export function P() {
+  const [sig] = createSignal('x')
+  const label = (k) => (sig() === k ? 'on' : 'off')
+  const wrap = (k) => '[' + label(k) + ']'
+  return <a className={wrap('y')}>x</a>
 }
 `
     const { template } = generate(src)
-    // sortHref delegates to hrefFor (a local helper) → not inlined here.
-    expect(template).toContain('.SortHref')
+    // wrap delegates to label (a local helper) and isn't a URL builder → not
+    // inlined; falls back to the method-call form.
+    expect(template).toContain('.Wrap')
   })
 
   // A compound argument must keep its precedence when spliced into the body —
@@ -219,5 +211,58 @@ export function P(props: { xs: string[] }) {
     const { template } = generate(src)
     // Not inlined → stays as the (un-backed) method-call form.
     expect(template).toContain('.Has')
+  })
+})
+
+describe('Capability C2: URL-builder helpers → bf_query + derived Root field', () => {
+  const SRC = `
+'use client'
+import { createMemo, searchParams } from '@barefootjs/client'
+export function P(props: { base: string }) {
+  const params = createMemo(() => {
+    const sp = searchParams()
+    return { sort: sp.get('sort') ?? '', tag: sp.get('tag') ?? '' }
+  })
+  const base = (props.base ?? '').replace(/\\/+$/, '')
+  const root = base || '/'
+  const hrefFor = (sort: string, tag: string) => {
+    const u = new URLSearchParams()
+    if (sort !== 'date') u.set('sort', sort)
+    if (tag) u.set('tag', tag)
+    const s = u.toString()
+    return s ? \`\${root}?\${s}\` : root
+  }
+  const sortHref = (k) => hrefFor(k, params().tag)
+  const tagHref = (t) => hrefFor(params().sort, t)
+  return (
+    <div>
+      <a href={sortHref('title')}>s</a>
+      {props.base ? <a href={tagHref('go')}>t</a> : null}
+    </div>
+  )
+}
+`
+
+  test('sortHref/tagHref lower to bf_query, not a .SortHref method call', () => {
+    const { template } = generate(SRC)
+    expect(template).not.toContain('.SortHref')
+    expect(template).not.toContain('.TagHref')
+    expect(template).toContain('bf_query .Root')
+  })
+
+  test('guarded set() calls become bool include triples', () => {
+    const { template } = generate(SRC)
+    // sort !== 'date' guard (runtime sort case via tagHref) + tag truthiness.
+    expect(template).toContain('(ne (bf_string .Params.Sort) "date") "sort"')
+    expect(template).toContain('(ne .Params.Tag "") "tag"')
+  })
+
+  test('derived `root` const becomes a computed Root field', () => {
+    const { types } = generate(SRC)
+    expect(types).toContain('Root string `json:"-"`')
+    expect(types).toContain(
+      'Root: func() string { v := strings.TrimRight(in.Base, "/"); if v != "" { return v }; return "/" }(),',
+    )
+    expect(types).toContain('"strings"')
   })
 })

--- a/packages/adapter-go-template/src/__tests__/derived-state-memo.test.ts
+++ b/packages/adapter-go-template/src/__tests__/derived-state-memo.test.ts
@@ -265,4 +265,57 @@ export function P(props: { base: string }) {
     )
     expect(types).toContain('"strings"')
   })
+
+  // A `&&` guard is NOT a Go bool (Go's `and` returns an operand); it must be
+  // truthiness-wrapped so `bf_query`'s `include` receives a real bool (#1945 review).
+  test('a && guard is wrapped to a bool, not passed as bare `and`', () => {
+    const src = `
+'use client'
+import { createMemo, searchParams } from '@barefootjs/client'
+export function P(props: { base: string }) {
+  const params = createMemo(() => { const sp = searchParams(); return { tag: sp.get('tag') ?? '' } })
+  const root = (props.base ?? '') || '/'
+  const hrefFor = (sort: string, tag: string) => {
+    const u = new URLSearchParams()
+    if (sort && tag) u.set('both', sort)
+    return u.toString() ? \`\${root}?\${u}\` : root
+  }
+  const h = (k) => hrefFor(k, params().tag)
+  return <a href={h('x')}>x</a>
+}
+`
+    const { template } = generate(src)
+    expect(template).toContain('(ne (and "x" .Params.Tag) "")')
+  })
+
+  // A URL-builder helper whose return isn't the conditional with-query/base
+  // shape must not be lowered to bf_query (#1945 review) — it falls back to the
+  // method-call form.
+  test('a builder returning a non-conditional shape is not lowered to bf_query', () => {
+    const src = `
+'use client'
+import { searchParams } from '@barefootjs/client'
+export function P() {
+  const bad = (sort: string) => { const u = new URLSearchParams(); u.set('s', sort); return u.toString() }
+  return <a href={bad('x')}>x</a>
+}
+`
+    const { template } = generate(src)
+    expect(template).not.toContain('bf_query')
+    expect(template).toContain('.Bad')
+  })
+
+  // A non-string derived const referenced by the template must not be emitted
+  // as a `string` field with a non-string initializer (#1945 review).
+  test('a numeric derived const is not emitted as a string field', () => {
+    const src = `
+'use client'
+export function P(props: { count: number }) {
+  const n = props.count + 1
+  return <span>{n}</span>
+}
+`
+    const { types } = generate(src)
+    expect(types).not.toContain('N string')
+  })
 })

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -206,6 +206,8 @@ interface CtorLowerEnv {
   searchParamsVars: Set<string>
   /** Helper-param name → its already-lowered Go argument, for inlining. */
   params: Map<string, string>
+  /** Component-scope const names currently being inlined (cycle guard). */
+  consts?: Set<string>
 }
 
 export interface GoTemplateAdapterOptions {
@@ -652,6 +654,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    */
   private localHelperNames: Set<string> = new Set()
 
+  /** Set when a constructor-context lowering emits a `strings.` call (#1897), so
+   *  `strings` is added to the generated types file's import block. */
+  private needsStringsImport = false
+
+  /** Component-scope derived consts referenced by the template during rendering
+   *  (e.g. `root` → `.Root`). `generateTypes` emits a computed field for each
+   *  that's resolvable and non-colliding (#1897). */
+  private referencedDerivedConsts: Set<string> = new Set()
+
   /** Child component name → the contexts it consumes (cross-component, for provider wiring). */
   private childContextConsumers: Map<string, ContextConsumer[]> = new Map()
 
@@ -687,6 +698,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   generate(ir: ComponentIR, options?: AdapterGenerateOptions): AdapterOutput {
     this.componentName = ir.metadata.componentName
     this.errors = []
+    this.referencedDerivedConsts = new Set()
     this.templateVarCounter = 0
     this.pendingChildrenDefines = []
     this.propsObjectName = ir.metadata.propsObjectName
@@ -1209,6 +1221,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     this.generateInputStruct(lines, ir, componentName, nestedComponents, propTypeOverrides, spreadSlots)
 
     // Generate Props struct for main component
+    this.needsStringsImport = false
     this.generatePropsStruct(lines, ir, componentName, nestedComponents, propTypeOverrides, spreadSlots)
 
     // Generate NewXxxProps function
@@ -1226,6 +1239,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     if (this.usesFmt) header.push('\t"fmt"')
     if (this.usesHtmlTemplate) header.push('\t"html/template"')
     header.push('\t"math/rand"')
+    if (this.needsStringsImport) header.push('\t"strings"')
     header.push('')
     header.push('\tbf "github.com/barefootjs/runtime/bf"')
     header.push(')')
@@ -1721,6 +1735,18 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       lines.push(`\t${fieldName} ${goType} \`json:"${jsonTag}"\``)
     }
 
+    // (#1897 PostList) Computed fields for component-scope derived string consts
+    // the template references (e.g. `root = base || '/'`). Not serialised — the
+    // route handler doesn't supply them; `NewXxxProps` computes them.
+    const takenForDerivedConsts = new Set<string>([
+      ...ir.metadata.propsParams.map(p => this.capitalizeFieldName(p.name)),
+      ...ir.metadata.signals.map(s => this.capitalizeFieldName(s.getter)),
+      ...ir.metadata.memos.map(m => this.capitalizeFieldName(m.name)),
+    ])
+    for (const f of this.computeDerivedConstFields(takenForDerivedConsts)) {
+      lines.push(`\t${f.name} string \`json:"-"\``)
+    }
+
     // `useContext` consumer fields (skip names already taken by a prop /
     // signal / memo field).
     const takenProps = new Set<string>([
@@ -2211,6 +2237,17 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       const goType = this.inferMemoType(memo, ir.metadata.signals, memoPropsParamMap)
       const memoValue = this.computeMemoInitialValue(memo, ir.metadata.signals, ir.metadata.propsParams, propFallbackVars, goType)
       lines.push(`\t\t${fieldName}: ${memoValue},`)
+    }
+
+    // (#1897 PostList) Initialise computed derived-const fields
+    // (e.g. `Root: func() string { … }()`), matching `generatePropsStruct`.
+    const takenDerivedInit = new Set<string>([
+      ...ir.metadata.propsParams.map(p => this.capitalizeFieldName(p.name)),
+      ...ir.metadata.signals.map(s => this.capitalizeFieldName(s.getter)),
+      ...ir.metadata.memos.map(m => this.capitalizeFieldName(m.name)),
+    ])
+    for (const f of this.computeDerivedConstFields(takenDerivedInit)) {
+      lines.push(`\t\t${f.name}: ${f.init},`)
     }
 
     // `useContext` consumer fields: default to the `createContext` default
@@ -4254,18 +4291,40 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     }
     if (ts.isNumericLiteral(node)) return node.text
 
-    // Identifier: a substituted helper param, else a module string const.
+    // Identifier: a substituted helper param, a module string const, or a
+    // component-scope derived const inlined recursively (e.g. `root` → its
+    // `base || '/'` value).
     if (ts.isIdentifier(node)) {
       const sub = env.params.get(node.text)
       if (sub !== undefined) return sub
-      const c = this.localConstants.find(lc => lc.name === node.text && lc.isModule)
+      const c = this.localConstants.find(lc => lc.name === node.text)
       if (c?.value !== undefined) {
-        const lit = this.parseLiteralExpression(c.value)
-        if (lit && (ts.isStringLiteral(lit) || ts.isNoSubstitutionTemplateLiteral(lit))) {
-          return JSON.stringify(lit.text)
+        if (c.isModule) {
+          const lit = this.parseLiteralExpression(c.value)
+          if (lit && (ts.isStringLiteral(lit) || ts.isNoSubstitutionTemplateLiteral(lit))) {
+            return JSON.stringify(lit.text)
+          }
+          return null
         }
+        // Component-scope const: inline its computed value, guarding cycles.
+        if (env.consts?.has(node.text)) return null
+        const inner = this.parseLiteralExpression(c.value)
+        if (!inner) return null
+        return this.lowerCtorExpr(inner, {
+          ...env,
+          consts: new Set([...(env.consts ?? []), node.text]),
+        })
       }
       return null
+    }
+
+    // `props.<X>` → the constructor input field `in.<X>`.
+    if (
+      ts.isPropertyAccessExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === this.propsObjectName
+    ) {
+      return `in.${this.capitalizeFieldName(node.name.text)}`
     }
 
     if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
@@ -4287,6 +4346,23 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         const elem = this.lowerCtorExpr(node.arguments[0], env)
         if (arr !== null && elem !== null) return `bf.Includes(${arr}, ${elem})`
         return null
+      }
+      // `<s>.replace(/\/+$/, '')` — strip trailing slashes → strings.TrimRight.
+      // Only this exact trailing-slash regex is recognized (a general regex
+      // replace would need Go's regexp; out of scope).
+      if (
+        method === 'replace' &&
+        node.arguments.length === 2 &&
+        node.arguments[0].kind === ts.SyntaxKind.RegularExpressionLiteral &&
+        (node.arguments[0] as ts.Node).getText() === '/\\/+$/' &&
+        (ts.isStringLiteral(node.arguments[1]) ||
+          ts.isNoSubstitutionTemplateLiteral(node.arguments[1])) &&
+        node.arguments[1].text === ''
+      ) {
+        const recvGo = this.lowerCtorExpr(recv, env)
+        if (recvGo === null) return null
+        this.needsStringsImport = true
+        return `strings.TrimRight(${recvGo}, "/")`
       }
       return null
     }
@@ -4333,6 +4409,18 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       }
       const right = this.lowerCtorExpr(node.right, env)
       if (right === null) return null
+      return `func() string { v := ${left}; if v != "" { return v }; return ${right} }()`
+    }
+
+    // `<expr> || <fallback>` (string `||` — falsy = empty, like `?? ''` but the
+    // left can itself be empty): `base || '/'`.
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.BarBarToken
+    ) {
+      const left = this.lowerCtorExpr(node.left, env)
+      const right = this.lowerCtorExpr(node.right, env)
+      if (left === null || right === null) return null
       return `func() string { v := ${left}; if v != "" { return v }; return ${right} }()`
     }
 
@@ -5048,8 +5136,42 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // the inner dot no longer refers to it, and it's not a root field. (#1677)
     if (this.isOuterLoopParam(name)) return `$${name}`
     if (this.loopVarRefCount.has(name)) return `$${name}`
+    // (#1897) A bare reference to a component-scope derived const (e.g. `root`)
+    // lowers to `.Root`; note it so `generateTypes` emits a computed field.
+    if (this.localConstants.some(c => c.name === name && !c.isModule && !c.containsArrow)) {
+      this.referencedDerivedConsts.add(name)
+    }
     // Env-signal binding (incl. an alias) → canonical `.SearchParams` (#1922).
     return this.searchParamsFieldRef(name) ?? this.rootFieldRef(name)
+  }
+
+  /**
+   * (#1897 PostList) Compute the Go struct fields for component-scope derived
+   * string consts referenced by the template (e.g. `root = base || '/'`). Each
+   * is lowered to a constructor-context Go expression via `lowerCtorExpr`, with
+   * its dependency consts inlined. Skips names that collide with an existing
+   * field (`takenFieldNames`) or that the lowerer can't represent.
+   */
+  private computeDerivedConstFields(
+    takenFieldNames: ReadonlySet<string>,
+  ): { name: string; init: string }[] {
+    const fields: { name: string; init: string }[] = []
+    for (const name of this.referencedDerivedConsts) {
+      const fieldName = this.capitalizeFieldName(name)
+      if (takenFieldNames.has(fieldName)) continue
+      const c = this.localConstants.find(lc => lc.name === name && !lc.isModule && lc.value)
+      if (!c?.value) continue
+      const expr = this.parseLiteralExpression(c.value)
+      if (!expr) continue
+      const init = this.lowerCtorExpr(expr, {
+        searchParamsVars: new Set(),
+        params: new Map(),
+        consts: new Set([name]),
+      })
+      if (init === null) continue
+      fields.push({ name: fieldName, init })
+    }
+    return fields
   }
 
   /**
@@ -6433,7 +6555,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       }
     }
 
-    // (#1897 PostList) Inline a call to a local, expression-bodied helper arrow
+    // (#1897 PostList) A local URL-builder helper (`hrefFor`, or `sortHref` /
+    // `tagHref` delegating to it) lowers to a `bf_query` action — there is no Go
+    // method backing a `.SortHref "date"` call. Tried before the generic inliner
+    // because these helpers are block-bodied / delegate, which the inliner skips.
+    const urlBuilt = this.lowerUrlBuilderHelperCall(trimmed)
+    if (urlBuilt !== null) return urlBuilt
+
+    // Inline a call to a local, expression-bodied helper arrow
     // (`sortClass(k)` / `tagClass(t)`) by substituting its params with the call
     // args and lowering the resulting expression. There is no Go method backing
     // a `.SortClass "date"` call, so the call site must carry the computation
@@ -6630,6 +6759,200 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       text = text.slice(0, r.start) + r.text + text.slice(r.end)
     }
     return text
+  }
+
+  /**
+   * (#1897 PostList) Lower a call to a local URL-builder helper to a `bf_query`
+   * template expression. Handles two shapes:
+   *   - the builder itself — `(sort, tag) => { const u = new URLSearchParams();
+   *     if (sort !== 'date') u.set('sort', sort); if (tag) u.set('tag', tag);
+   *     return u.toString() ? \`${root}?${u}\` : root }` — substitute the call
+   *     args for params and emit `bf_query <base> (<guard>) "key" <value> …`;
+   *   - a pass-through delegate — `(k) => hrefFor(k, params().tag)` — substitute
+   *     and recurse on the delegated call.
+   * Returns null for anything else (→ existing lowering / method-call fallback).
+   */
+  private lowerUrlBuilderHelperCall(jsExpr: string): string | null {
+    if (this.localHelperNames.size === 0) return null
+    const head = /^\s*([A-Za-z_$][\w$]*)\s*\(/.exec(jsExpr)
+    if (!head || !this.localHelperNames.has(head[1])) return null
+
+    const call = this.parseLiteralExpression(jsExpr)
+    if (!call || !ts.isCallExpression(call) || !ts.isIdentifier(call.expression)) return null
+    if (call.arguments.some(a => ts.isSpreadElement(a))) return null
+    const fnConst = this.localConstants.find(
+      c => c.name === (call.expression as ts.Identifier).text && !c.isModule && c.value,
+    )
+    if (!fnConst?.value) return null
+    const fn = this.parseLiteralExpression(fnConst.value)
+    if (!fn || !ts.isArrowFunction(fn) || fn.parameters.length !== call.arguments.length) return null
+
+    const subs = new Map<string, string>()
+    for (let i = 0; i < fn.parameters.length; i++) {
+      const p = fn.parameters[i]
+      if (!ts.isIdentifier(p.name)) return null
+      subs.set(p.name.text, `(${call.arguments[i].getText()})`)
+    }
+
+    // Shape 1: the helper is itself a URLSearchParams builder.
+    const shape = this.extractUrlBuilder(fn)
+    if (shape) return this.emitUrlBuilder(shape, subs)
+
+    // Shape 2: a pass-through delegate to another local URL-builder helper.
+    if (!ts.isBlock(fn.body)) {
+      let body: ts.Expression = fn.body
+      while (ts.isParenthesizedExpression(body)) body = body.expression
+      if (
+        ts.isCallExpression(body) &&
+        ts.isIdentifier(body.expression) &&
+        this.localHelperNames.has(body.expression.text)
+      ) {
+        return this.lowerUrlBuilderHelperCall(this.substituteHelperParams(body, subs))
+      }
+    }
+    return null
+  }
+
+  /**
+   * Extract the `bf_query` shape from a `(…) => { const u = new URLSearchParams();
+   * [if (G)] u.set(K, V); …; return <s> ? … : <base> }` helper, or null when the
+   * block doesn't match that exact builder idiom.
+   */
+  private extractUrlBuilder(
+    arrow: ts.ArrowFunction,
+  ): { base: ts.Expression; sets: { guard: ts.Expression | null; key: string; value: ts.Expression }[] } | null {
+    if (!ts.isBlock(arrow.body)) return null
+    let builderVar: string | null = null
+    let base: ts.Expression | null = null
+    const sets: { guard: ts.Expression | null; key: string; value: ts.Expression }[] = []
+
+    for (const s of arrow.body.statements) {
+      if (ts.isVariableStatement(s)) {
+        for (const d of s.declarationList.declarations) {
+          if (
+            ts.isIdentifier(d.name) &&
+            d.initializer &&
+            ts.isNewExpression(d.initializer) &&
+            ts.isIdentifier(d.initializer.expression) &&
+            d.initializer.expression.text === 'URLSearchParams' &&
+            (d.initializer.arguments?.length ?? 0) === 0
+          ) {
+            builderVar = d.name.text
+          }
+          // Other locals (`const s = u.toString()`) are inert — ignored.
+        }
+        continue
+      }
+      // `if (G) u.set(K, V)` (no else).
+      if (ts.isIfStatement(s) && !s.elseStatement && builderVar) {
+        const set = this.matchUrlSet(s.thenStatement, builderVar)
+        if (!set) return null
+        sets.push({ guard: s.expression, key: set.key, value: set.value })
+        continue
+      }
+      // Unguarded `u.set(K, V)`.
+      if (ts.isExpressionStatement(s) && builderVar) {
+        const set = this.matchUrlSet(s, builderVar)
+        if (set) {
+          sets.push({ guard: null, key: set.key, value: set.value })
+          continue
+        }
+        return null
+      }
+      // `return <s> ? `${base}?…` : <base>` — the alternate is the no-query base.
+      if (ts.isReturnStatement(s) && s.expression) {
+        let e: ts.Expression = s.expression
+        while (ts.isParenthesizedExpression(e)) e = e.expression
+        base = ts.isConditionalExpression(e) ? e.whenFalse : e
+        continue
+      }
+      return null
+    }
+    if (!builderVar || !base || sets.length === 0) return null
+    return { base, sets }
+  }
+
+  /**
+   * Match `<builderVar>.set('literalKey', <value>)` — as a statement or an
+   * if-then — returning the key text and value node, else null.
+   */
+  private matchUrlSet(
+    node: ts.Node,
+    builderVar: string,
+  ): { key: string; value: ts.Expression } | null {
+    const stmt = ts.isBlock(node) ? (node.statements.length === 1 ? node.statements[0] : null) : node
+    if (!stmt || !ts.isExpressionStatement(stmt)) return null
+    const call = stmt.expression
+    if (
+      ts.isCallExpression(call) &&
+      ts.isPropertyAccessExpression(call.expression) &&
+      ts.isIdentifier(call.expression.expression) &&
+      call.expression.expression.text === builderVar &&
+      call.expression.name.text === 'set' &&
+      call.arguments.length === 2 &&
+      ts.isStringLiteral(call.arguments[0])
+    ) {
+      return { key: call.arguments[0].text, value: call.arguments[1] }
+    }
+    return null
+  }
+
+  /**
+   * Emit `bf_query <base> (<guard>) "key" <value> …` from an extracted builder
+   * shape, lowering each part (with the call args substituted for params) via
+   * the normal expression / condition lowering. Unguarded sets use `true`.
+   */
+  private emitUrlBuilder(
+    shape: { base: ts.Expression; sets: { guard: ts.Expression | null; key: string; value: ts.Expression }[] },
+    subs: ReadonlyMap<string, string>,
+  ): string | null {
+    const lowerExpr = (n: ts.Expression): string =>
+      this.convertExpressionToGo(this.substituteHelperParams(n, subs))
+    const baseGo = wrapIfMultiToken(lowerExpr(shape.base))
+    const parts: string[] = [baseGo]
+    for (const set of shape.sets) {
+      const guardGo = set.guard ? this.lowerUrlGuard(set.guard, subs) : 'true'
+      parts.push(`(${guardGo})`)
+      parts.push(JSON.stringify(set.key))
+      parts.push(wrapIfMultiToken(lowerExpr(set.value)))
+    }
+    return `bf_query ${parts.join(' ')}`
+  }
+
+  /**
+   * Lower a `u.set()` guard to a Go *bool* for `bf_query`'s `include` argument.
+   * A comparison / logical / negation / bool-literal already yields a bool
+   * (`convertConditionToGo`); a bare value (`if (tag)`) is JS string-truthiness,
+   * lowered to `ne <value> ""`. The arg must be a real bool — `bf_query` type-
+   * asserts it, so Go-template truthiness (`{{if x}}`) is not enough.
+   */
+  private lowerUrlGuard(guard: ts.Expression, subs: ReadonlyMap<string, string>): string {
+    let g = guard
+    while (ts.isParenthesizedExpression(g)) g = g.expression
+    const isBoolShape =
+      (ts.isBinaryExpression(g) &&
+        [
+          ts.SyntaxKind.EqualsEqualsToken,
+          ts.SyntaxKind.EqualsEqualsEqualsToken,
+          ts.SyntaxKind.ExclamationEqualsToken,
+          ts.SyntaxKind.ExclamationEqualsEqualsToken,
+          ts.SyntaxKind.LessThanToken,
+          ts.SyntaxKind.GreaterThanToken,
+          ts.SyntaxKind.LessThanEqualsToken,
+          ts.SyntaxKind.GreaterThanEqualsToken,
+          ts.SyntaxKind.AmpersandAmpersandToken,
+          ts.SyntaxKind.BarBarToken,
+        ].includes(g.operatorToken.kind)) ||
+      (ts.isPrefixUnaryExpression(g) && g.operator === ts.SyntaxKind.ExclamationToken) ||
+      g.kind === ts.SyntaxKind.TrueKeyword ||
+      g.kind === ts.SyntaxKind.FalseKeyword
+    if (isBoolShape) {
+      return this.convertConditionToGo(this.substituteHelperParams(guard, subs)).condition
+    }
+    const valueGo = wrapIfMultiToken(
+      this.convertExpressionToGo(this.substituteHelperParams(guard, subs)),
+    )
+    return `ne ${valueGo} ""`
   }
 
   /**

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -5197,12 +5197,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     }
     if (ts.isBinaryExpression(node)) {
       const op = node.operatorToken.kind
-      if (
-        op === ts.SyntaxKind.PlusToken ||
-        op === ts.SyntaxKind.BarBarToken ||
-        op === ts.SyntaxKind.QuestionQuestionToken
-      ) {
+      // `+`: a string on *either* side forces string concatenation.
+      if (op === ts.SyntaxKind.PlusToken) {
         return this.isStringExpr(node.left, seen) || this.isStringExpr(node.right, seen)
+      }
+      // `||` / `??` evaluate to *one* operand, so the result is only provably a
+      // string when *both* sides are (`props.count ?? ''` is not — it can be the
+      // number) (#1945 review).
+      if (op === ts.SyntaxKind.BarBarToken || op === ts.SyntaxKind.QuestionQuestionToken) {
+        return this.isStringExpr(node.left, seen) && this.isStringExpr(node.right, seen)
       }
       return false
     }

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -5163,6 +5163,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       if (!c?.value) continue
       const expr = this.parseLiteralExpression(c.value)
       if (!expr) continue
+      // The field is typed `string`; only emit when the value is provably a Go
+      // string, so a numeric/other const referenced in the template can't be
+      // assigned into a string field (#1945 review).
+      if (!this.isStringExpr(expr, new Set())) continue
       const init = this.lowerCtorExpr(expr, {
         searchParamsVars: new Set(),
         params: new Map(),
@@ -5172,6 +5176,58 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       fields.push({ name: fieldName, init })
     }
     return fields
+  }
+
+  /**
+   * Conservative check that a JS expression is *definitely* string-valued —
+   * used to gate derived-const field emission (the field is typed `string`).
+   * Recognizes string/template literals, string-returning methods (`.replace`,
+   * `.trim`, … and `searchParams().get`), `+` / `||` / `??` where a branch is
+   * string-valued, and a component-const reference to such a value. Anything
+   * unproven (numbers, `props.X`, calls it doesn't know) returns false.
+   */
+  private isStringExpr(node: ts.Expression, seen: Set<string>): boolean {
+    while (ts.isParenthesizedExpression(node)) node = node.expression
+    if (
+      ts.isStringLiteral(node) ||
+      ts.isNoSubstitutionTemplateLiteral(node) ||
+      ts.isTemplateExpression(node)
+    ) {
+      return true
+    }
+    if (ts.isBinaryExpression(node)) {
+      const op = node.operatorToken.kind
+      if (
+        op === ts.SyntaxKind.PlusToken ||
+        op === ts.SyntaxKind.BarBarToken ||
+        op === ts.SyntaxKind.QuestionQuestionToken
+      ) {
+        return this.isStringExpr(node.left, seen) || this.isStringExpr(node.right, seen)
+      }
+      return false
+    }
+    if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+      const m = node.expression.name.text
+      const STRING_METHODS = new Set([
+        'replace', 'trim', 'trimStart', 'trimEnd', 'toLowerCase', 'toUpperCase',
+        'slice', 'substring', 'substr', 'padStart', 'padEnd', 'concat', 'repeat', 'get',
+      ])
+      return STRING_METHODS.has(m)
+    }
+    if (ts.isConditionalExpression(node)) {
+      return (
+        this.isStringExpr(node.whenTrue, seen) && this.isStringExpr(node.whenFalse, seen)
+      )
+    }
+    if (ts.isIdentifier(node)) {
+      if (seen.has(node.text)) return false
+      const c = this.localConstants.find(lc => lc.name === node.text && !lc.isModule && lc.value)
+      if (c?.value) {
+        const inner = this.parseLiteralExpression(c.value)
+        if (inner) return this.isStringExpr(inner, new Set([...seen, node.text]))
+      }
+    }
+    return false
   }
 
   /**
@@ -6859,11 +6915,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         }
         return null
       }
-      // `return <s> ? `${base}?…` : <base>` — the alternate is the no-query base.
+      // `return <s> ? `${base}?…` : <base>` — the builder's return must be the
+      // conditional that picks between the with-query and bare-base URL; its
+      // `whenFalse` (no-query) branch is the base. Any other return shape isn't
+      // this idiom (#1945 review) — bail to the method-call fallback.
       if (ts.isReturnStatement(s) && s.expression) {
         let e: ts.Expression = s.expression
         while (ts.isParenthesizedExpression(e)) e = e.expression
-        base = ts.isConditionalExpression(e) ? e.whenFalse : e
+        if (!ts.isConditionalExpression(e)) return null
+        base = e.whenFalse
         continue
       }
       return null
@@ -6929,6 +6989,11 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   private lowerUrlGuard(guard: ts.Expression, subs: ReadonlyMap<string, string>): string {
     let g = guard
     while (ts.isParenthesizedExpression(g)) g = g.expression
+    // Comparisons, `!x`, and bool literals lower to a Go bool via the condition
+    // lowering. `&&` / `||` do NOT qualify: Go's `and`/`or` return one of their
+    // operands (a string for a truthiness guard like `tag && other`), not a
+    // bool — so they take the truthiness-wrap path below, yielding
+    // `ne (and …) ""`, an actual bool (#1945 review).
     const isBoolShape =
       (ts.isBinaryExpression(g) &&
         [
@@ -6940,8 +7005,6 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
           ts.SyntaxKind.GreaterThanToken,
           ts.SyntaxKind.LessThanEqualsToken,
           ts.SyntaxKind.GreaterThanEqualsToken,
-          ts.SyntaxKind.AmpersandAmpersandToken,
-          ts.SyntaxKind.BarBarToken,
         ].includes(g.operatorToken.kind)) ||
       (ts.isPrefixUnaryExpression(g) && g.operator === ts.SyntaxKind.ExclamationToken) ||
       g.kind === ts.SyntaxKind.TrueKeyword ||


### PR DESCRIPTION
## What

**Capability C2** of the phased PostList derived-state SSR fix (#1897 follow-up). Capabilities A (#1941), B (#1943), and C1 (#1944, the `bf_query` runtime helper) are **merged**; this PR targets `main` and wires the adapter to emit `bf_query`, eliminating the last execute-time href crash.

### The problem
`href={sortHref('date')}`, where `sortHref` delegates to a `hrefFor` that drives `new URLSearchParams()` + guarded `.set()`, lowered to `{{.SortHref "date"}}` — a method call with **no Go method behind it** (execute-time `can't evaluate field SortHref`).

### The fix
1. **URLSearchParams builder → `bf_query`.** The adapter recognizes the builder idiom via AST and emits a `bf_query` action. Each guarded `.set()` becomes an `(include, key, value)` triple, the guard lowered to a Go **bool** by the existing condition lowering:
   ```
   href="{{bf_query .Root (ne (bf_string .Params.Sort) "date") "sort" .Params.Sort (ne .Params.Tag "") "tag" .Params.Tag}}"
   ```
   Pass-through delegates (`sortHref` → `hrefFor`) are substituted and recursed.
2. **Derived string consts → computed fields.** Component-scope consts the template references (e.g. `root = base || '/'`, `base = (props.base ?? '').replace(/\/+$/, '')`) become `NewXxxProps`-initialized fields:
   ```go
   Root: func() string { v := strings.TrimRight(in.Base, "/"); if v != "" { return v }; return "/" }(),
   ```
   `lowerCtorExpr` gains `props.X` → `in.X`, `||`, and the trailing-slash `.replace(/\/+$/, '')` → `strings.TrimRight` (that pattern only). `strings` joins the imports when used. **Only consts actually referenced during template rendering get a field** (no unused fields → no conformance churn).

## Verification
- Emitted Go **renders correct URLs in real Go**: `/blog?sort=title&tag=go`, `sort=date` omitted (default), trailing-slash bases normalized (`/blog/` → `/blog`, `''` → `/`).
- Real `PostList`: `.SortHref` / `.TagHref` **gone**, `Root` computed, `bf_query` ×5.
- Adapter + conformance **1296 pass / 0 fail**, `tsc` clean, `go vet` clean.

## PostList status after this PR
With A+B+C1+C2 merged, PostList renders on Go **without execute-time crashes**: `.Params` computed (A), `.SortClass`/`.TagClass` inlined (B), `.SortHref`/`.TagHref` → `bf_query` (C1+C2). The remaining item is the **`{{len .Visible}}` count** (Capability **D**) — still a nil map, rendering `0`.

## Stack
- #1941 — A — object memo → computed map field ✅ merged
- #1943 — B — inline local pure helpers ✅ merged
- #1944 — C1 — `bf_query` runtime helper ✅ merged
- **this** — C2 — URL-builder lowering + derived `Root` field
- next — D — filtered-array memo → `Visible` count

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JT4Rcc5b1qcMStCJfmD3V1)_