### PR TITLE
feat(go-template): lower array-memo .length to its loop slice count (PostList status count, Capability D)

### DIFF
--- a/.changeset/go-array-memo-length.md
+++ b/.changeset/go-array-memo-length.md
@@ -1,0 +1,9 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Lower an array memo's `.length` to its handler-filled loop slice count (PostList status count, #1897 follow-up — Capability D, completing the derived-state fix).
+
+A memo used both as a loop source (`visible().map(...)`) and as a count (`visible().length`) previously lowered the count to `len .Visible` — a memo field the adapter leaves unset (nil) — so the status line rendered `0`. The loop's `.map()` already becomes a handler-filled slice (`.PostListItems`) holding exactly the rendered (filtered) items, so the adapter now maps each array memo to that slice and lowers `<memo>().length` to `len .<Slice>` (loop-scoped through `$.` when nested). `props.items.length` and other lengths are unaffected.
+
+With this, the shared blog `PostList` renders fully on Go template SSR: `params` / derived classes / hrefs / counts all resolve, no execute-time crashes.

--- a/packages/adapter-go-template/src/__tests__/derived-state-memo.test.ts
+++ b/packages/adapter-go-template/src/__tests__/derived-state-memo.test.ts
@@ -333,3 +333,39 @@ export function P(props: { count: number }) {
     expect(types).not.toContain('C string')
   })
 })
+
+describe('Capability D: array-memo .length → handler-filled loop slice count', () => {
+  test('visible().length lowers to len .<Slice>, not the nil memo field', () => {
+    const src = `
+'use client'
+import { createMemo, searchParams } from '@barefootjs/client'
+import { Row } from './Row'
+export function P(props: { items: { id: string }[] }) {
+  const params = createMemo(() => {
+    const sp = searchParams()
+    return { tag: sp.get('tag') ?? '' }
+  })
+  const visible = createMemo(() => {
+    const { tag } = params()
+    return props.items.filter((p) => !tag || p.id === tag)
+  })
+  return (
+    <div>
+      <span>{visible().length} / {props.items.length} shown</span>
+      <ul>
+        {visible().map((p) => (
+          <Row key={p.id} id={p.id} />
+        ))}
+      </ul>
+    </div>
+  )
+}
+`
+    const { template } = generate(src)
+    expect(template).not.toContain('len .Visible')
+    // The loop over visible() is handler-filled as `.Rows`; the count reuses it.
+    expect(template).toContain('len .Rows')
+    // props.items.length is unaffected.
+    expect(template).toContain('len .Items')
+  })
+})

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -663,6 +663,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    *  that's resolvable and non-colliding (#1897). */
   private referencedDerivedConsts: Set<string> = new Set()
 
+  /** Array-memo name → the handler-filled loop slice field its `.map()` feeds
+   *  (e.g. `visible` → `PostListItems`). Lets `<memo>().length` lower to
+   *  `len .<Slice>` instead of `len .<Memo>` (a nil/unset memo field) — the
+   *  slice IS the rendered (filtered) items, so its length is the count (#1897). */
+  private memoBackedLoopSlice: Map<string, string> = new Map()
+
   /** Child component name → the contexts it consumes (cross-component, for provider wiring). */
   private childContextConsumers: Map<string, ContextConsumer[]> = new Map()
 
@@ -748,6 +754,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     const isIfStatement = ir.root.type === 'if-statement'
 
     this.rootScopeNodes = collectRootScopeNodes(ir.root)
+    // Map each array memo that backs a loop (`<memo>().map(...)`) to that loop's
+    // handler-filled slice field, so `<memo>().length` can lower to the slice's
+    // length (#1897 PostList status count). Built before rendering — the
+    // `.length` reference can appear before the loop in source order.
+    this.memoBackedLoopSlice = new Map()
+    for (const nested of this.findNestedComponents(ir.root)) {
+      const memoName = this.extractMemoNameFromLoopArray(nested.loopArray)
+      if (memoName) this.memoBackedLoopSlice.set(memoName, `${nested.name}s`)
+    }
     const templateBody = isIfStatement
       ? this.renderIfStatement(ir.root as IRIfStatement, { isRootOfClientComponent: hasInteractivity })
       : this.renderNode(ir.root, { isRootOfClientComponent: hasInteractivity && isRootComponent })
@@ -5376,6 +5391,24 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     if (property === 'length' && object.kind === 'higher-order') {
       const result = this.renderFilterLengthExpr(object, emit)
       if (result) return result
+    }
+
+    // `<memo>().length` where the memo's `.map()` feeds a handler-filled loop
+    // slice → `len .<Slice>` (#1897 PostList: `visible().length` →
+    // `len .PostListItems`). The slice holds the rendered (filtered) items, so
+    // its length is the count — unlike the memo's own field, which is unset.
+    if (
+      property === 'length' &&
+      object.kind === 'call' &&
+      object.callee.kind === 'identifier' &&
+      object.args.length === 0
+    ) {
+      const slice = this.memoBackedLoopSlice.get(object.callee.name)
+      if (slice) {
+        // Root field, so reach it through `$.` inside a loop (#1677).
+        const prefix = this.loopParamStack.length > 0 ? '$.' : '.'
+        return `len ${prefix}${slice}`
+      }
     }
 
     // find().property / findLast().property → {{with bf_find ...}}{{.Property}}{{end}}


### PR DESCRIPTION
## What

**Capability D** — the **final** piece of the phased PostList derived-state SSR fix (#1897 follow-up). A (#1941), B (#1943), C1 (#1944), C2 (#1945) are merged; this completes it.

### The problem
A memo used both as a loop source and as a count:
```ts
const visible = createMemo(() => props.items.filter(...))   // … the list
<span>{visible().length} / {props.items.length} shown</span> // … the count
{visible().map((p) => <PostListItem … />)}                   // … the loop
```
lowered the count to `len .Visible` — a memo field the adapter leaves **unset (nil)** — so the status line rendered `0`.

### The fix
The loop's `.map()` already becomes a **handler-filled slice** (`.PostListItems`) holding exactly the rendered (filtered) items. Before rendering, the adapter builds a memo→slice map (from `findNestedComponents` + the existing `extractMemoNameFromLoopArray`) and lowers `<memo>().length` to `len .<Slice>` — reached through `$.` when nested in a loop:
```
{{len .PostListItems}} / {{len .Items}} shown
```
`props.items.length` and other `.length` uses are unaffected.

## Verification
- Real `PostList`: `len .Visible` → `len .PostListItems` (the visible/filtered count); `len .Items` (total) unchanged.
- Adapter + conformance **1301 pass / 0 fail**, `tsc` clean.

## 🎉 PostList derived-state fix complete
With A+B+C1+C2+D, the shared blog `PostList` renders **fully on Go template SSR** — no execute-time crashes, correct values:

| Concern | Capability |
|---|---|
| `.Params` (searchParams memo) | A |
| `.SortClass` / `.TagClass` | B |
| `bf_query` runtime helper | C1 |
| `.SortHref` / `.TagHref` + `Root` | C2 |
| **`{{len .Visible}}` count** | **D (this)** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JT4Rcc5b1qcMStCJfmD3V1)_