### PR TITLE
fix(changeset): unblock release by dropping ignored package from go-data-table changeset

### DIFF
--- a/.changeset/go-data-table-support.md
+++ b/.changeset/go-data-table-support.md
@@ -1,6 +1,5 @@
 ---
 "@barefootjs/go-template": minor
-"@barefootjs/adapter-tests": patch
 ---
 
 data-table component now renders on Go template (#1897). Three adapter-level capabilities were added:


### PR DESCRIPTION
## What

The release workflow on `main` is failing at `bunx changeset version` ([run](https://github.com/piconic-ai/barefootjs/actions/runs/27807443402/job/82290147927)):

```
🦋  error Error: Found mixed changeset go-data-table-support
🦋  error Found ignored packages: @barefootjs/adapter-tests
🦋  error Found not ignored packages: @barefootjs/go-template
🦋  error Mixed changesets that contain both ignored and not ignored packages are not allowed
```

## Cause

`.changeset/go-data-table-support.md` bumped both:

- `@barefootjs/go-template` (`minor`) — published
- `@barefootjs/adapter-tests` (`patch`) — listed in `ignore` in `.changeset/config.json`

changesets disallows a single changeset that mixes ignored and non-ignored packages, so `changeset version` aborts and the release job fails.

## Fix

`@barefootjs/adapter-tests` is never published (it's in the ignore list), so its entry in the changeset is meaningless. Dropping that line resolves the conflict while keeping the `@barefootjs/go-template` minor bump intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012wJAZ47mgEhQ4BtT2r1w2e)_