### PR TITLE
feat(chi): add the @barefootjs/router blog showcase to the Go integration

### DIFF
--- a/.changeset/go-blog-math-and-imports.md
+++ b/.changeset/go-blog-math-and-imports.md
@@ -1,0 +1,10 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Go template adapter codegen fixes surfaced by bringing the shared blog islands to the Go/Chi integration.
+
+- **`Math.min` / `Math.max`** now lower to the `bf_min` / `bf_max` runtime helpers (two-arg form; the N-arg form still falls back to the standard BF101 unsupported-call diagnostic via the arity gate). Previously `Math.min(...)` emitted a non-existent `.Math.Min` field access that crashed at execute time.
+- **Nested arithmetic** parenthesises compound operands, so `(a / b) * c` emits `bf_mul (bf_div .A .B) .C` instead of `bf_mul bf_div .A .B 100`, which handed `bf_mul` four arguments. Comparisons (`gt`/`lt`/`eq`/…) wrap compound operands the same way.
+- **Module numeric consts** (`const TRACK = 8`) inline their literal value rather than emitting a `.TRACK` Props field that never exists (mirrors the existing module string-const inlining).
+- **Combined types file** adds the `"strings"` import when the merged constructors reference `strings.*` (a `searchParams()`-backed component emits `strings.TrimRight` for its router base), fixing an `undefined: strings` compile error in the generated types.

--- a/integrations/chi/barefoot.config.ts
+++ b/integrations/chi/barefoot.config.ts
@@ -4,7 +4,7 @@ const basePath = process.env.BASE_PATH ?? '/integrations/chi'
 const staticBase = `${basePath}/static/client/`
 
 export default createConfig({
-  components: ['../shared/components'],
+  components: ['../shared/components', '../shared/blog'],
   outDir: 'dist',
   minify: true,
   adapterOptions: {

--- a/integrations/chi/blog.go
+++ b/integrations/chi/blog.go
@@ -5,6 +5,7 @@ import (
 	"html/template"
 	"net/http"
 	"sort"
+	"strings"
 
 	bf "github.com/barefootjs/runtime/bf"
 	"github.com/barefootjs/runtime/bf/bfdev"
@@ -36,10 +37,15 @@ var blogSortKeys = []string{"date", "title", "tag"}
 // router's query push reaches the islands' effects.
 func blogImportMap() string {
 	bjs := basePath + "/static/client/barefoot.js"
-	return fmt.Sprintf(
+	j := fmt.Sprintf(
 		`{"imports":{"@barefootjs/client":%q,"@barefootjs/client/runtime":%q,"@barefootjs/client/reactive":%q}}`,
 		bjs, bjs, bjs,
 	)
+	// Escape "<" so a stray "</script>" in the value (e.g. a misconfigured
+	// BASE_PATH) can't break out of the inline <script type="importmap">. The
+	// replacement is the JS unicode escape backslash-u003c, built by
+	// concatenation so it survives verbatim.
+	return strings.ReplaceAll(j, "<", `\`+"u003c")
 }
 
 // blogFrag renders one island subtree against shared script/portal collectors.
@@ -173,20 +179,25 @@ func firstTag(p BlogPost) string {
 }
 
 // blogPostListItems builds the per-row child props for the filtered+sorted
-// list. ScopeID is left empty so RenderFragment backfills a unique one;
-// BfDataKey carries the post slug so the keyed list reconciles by identity
-// (a pinned row keeps its state across a re-sort), matching `key={p.slug}`.
-func blogPostListItems(sortKey, tag string) []PostListItemProps {
+// list, following the contract documented on NewPostListProps in components.go:
+// each row mounts at slot "s13" under the list's scope (BfParent/BfMount), so it
+// gets the bf-h/bf-m hydration markers the runtime reconciles the loop through.
+// BfDataKey carries the post slug so the keyed list reconciles by identity (a
+// pinned row keeps its state across a re-sort), matching `key={p.slug}`.
+func blogPostListItems(parentScope, sortKey, tag string) []PostListItemProps {
 	visible := blogVisible(sortKey, tag)
 	items := make([]PostListItemProps, len(visible))
 	for i, p := range visible {
-		items[i] = PostListItemProps{
-			BfDataKey: p.Slug,
-			Href:      blogBasePath() + "/posts/" + p.Slug,
-			Title:     p.Title,
-			Date:      p.Date,
-			Meta:      blogMeta(p),
-		}
+		row := NewPostListItemProps(PostListItemInput{
+			Href:  blogBasePath() + "/posts/" + p.Slug,
+			Title: p.Title,
+			Date:  p.Date,
+			Meta:  blogMeta(p),
+		})
+		row.BfParent = parentScope
+		row.BfMount = "s13"
+		row.BfDataKey = p.Slug
+		items[i] = row
 	}
 	return items
 }
@@ -221,7 +232,7 @@ func blogIndexHandler(w http.ResponseWriter, req *http.Request) {
 			Base:         blogBasePath(),
 			SearchParams: sp,
 		})
-		listProps.PostListItems = blogPostListItems(sortKey, tag)
+		listProps.PostListItems = blogPostListItems(listProps.ScopeID, sortKey, tag)
 		listHTML := frag("PostList", &listProps)
 
 		// The player lives in the content region on the index too, marked

--- a/integrations/chi/blog.go
+++ b/integrations/chi/blog.go
@@ -1,0 +1,276 @@
+package main
+
+import (
+	"fmt"
+	"html/template"
+	"net/http"
+	"sort"
+
+	bf "github.com/barefootjs/runtime/bf"
+	"github.com/barefootjs/runtime/bf/bfdev"
+	"github.com/go-chi/chi/v5"
+)
+
+// Blog — the `@barefootjs/router` showcase for the Go/Chi adapter.
+//
+// A region-shell sub-site mounted at `${basePath}/blog`, mirroring the Hono /
+// h3 / Elysia integrations. The islands are the SAME shared components under
+// `../shared/blog`, compiled by this integration's `bf build`. Partial
+// navigation is driven entirely on the client by `@barefootjs/router`
+// (bundled into `static/client/router-entry.js`); the server's only job is to
+// return a plain HTML page per route with the right `bf-region` boundaries —
+// exactly the "any backend, zero cooperation" point the blog itself makes.
+
+// blogBasePath is where the blog is mounted; every blog link is built relative
+// to it so the shared components work under any adapter's base path.
+func blogBasePath() string { return basePath + "/blog" }
+
+// blogSortKeys are the sort values the PostList understands; anything else
+// falls back to "date" (matching the island's `asSortKey`).
+var blogSortKeys = []string{"date", "title", "tag"}
+
+// blogImportMap maps the bare `@barefootjs/client*` specifiers that the router
+// bundle imports to the SAME physical `barefoot.js` the compiled islands import
+// via the relative `./barefoot.js`. Resolving both to one URL gives a single
+// reactive runtime instance, so `searchParams()` is one shared signal and the
+// router's query push reaches the islands' effects.
+func blogImportMap() string {
+	bjs := basePath + "/static/client/barefoot.js"
+	return fmt.Sprintf(
+		`{"imports":{"@barefootjs/client":%q,"@barefootjs/client/runtime":%q,"@barefootjs/client/reactive":%q}}`,
+		bjs, bjs, bjs,
+	)
+}
+
+// blogFrag renders one island subtree against shared script/portal collectors.
+type blogFrag func(name string, props interface{}) template.HTML
+
+// blogPageHTML assembles the region-shell document shared by every blog route.
+// It mirrors the Hono blog renderer: a persistent shell (header ThemeToggle +
+// a hand-authored `bf-region="nav:0"` Sidebar) wrapping a compiled <PageShell>
+// whose inner region holds the per-route content.
+//
+// Every island — the shell ones AND the route content built by `renderContent`
+// — is rendered through bf.Renderer.RenderFragment against ONE script + portal
+// collector, so `barefoot.js` and each island's client JS are emitted exactly
+// once and share a single runtime instance.
+func blogPageHTML(title string, renderContent func(frag blogFrag) template.HTML) string {
+	r := bf.NewRenderer(currentTemplates(), nil)
+	sc := bf.NewScriptCollector()
+	pc := bf.NewPortalCollector()
+
+	frag := func(name string, props interface{}) template.HTML {
+		return r.RenderFragment(bf.RenderOptions{ComponentName: name, Props: props}, sc, pc)
+	}
+
+	// Content first so its islands register before the shell's; PageShell wraps
+	// it as `children`, Sidebar + ThemeToggle are the persistent shell.
+	content := renderContent(frag)
+
+	shellProps := NewPageShellProps(PageShellInput{Children: content})
+	shellHTML := frag("PageShell", &shellProps)
+
+	sidebarProps := NewSidebarProps(SidebarInput{})
+	sidebarHTML := frag("Sidebar", &sidebarProps)
+
+	themeProps := NewThemeToggleProps(ThemeToggleInput{})
+	themeHTML := frag("ThemeToggle", &themeProps)
+
+	scripts := bf.BfScripts(sc)
+	portals := pc.Render()
+
+	// Dev auto-reload snippet (empty in production) so `bun run build:watch`
+	// rebuilds show up on refresh, matching the catalog pages' layout.
+	devSnippet := bfdev.Snippet(bfdev.Config{Disabled: !isDevEnv()})
+
+	return fmt.Sprintf(`<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>%s</title>
+    <script type="importmap">%s</script>
+    <link rel="stylesheet" href="%s/shared/styles/blog.css">
+</head>
+<body>
+    <header class="shell">
+        <a class="shell-brand" href="%s">📰 Barefoot Blog</a>
+        <div class="shell-island">%s</div>
+    </header>
+    <div class="layout">
+        <aside bf-region="nav:0">%s</aside>
+        <main>%s</main>
+    </div>
+    %s%s
+    <script type="module" src="%s/static/client/router-entry.js"></script>%s
+</body>
+</html>`,
+		template.HTMLEscapeString(title),
+		blogImportMap(),
+		basePath,
+		blogBasePath(),
+		themeHTML,
+		sidebarHTML,
+		shellHTML,
+		scripts,
+		portals,
+		basePath,
+		devSnippet,
+	)
+}
+
+// writeBlogHTML flushes an assembled blog page.
+func writeBlogHTML(w http.ResponseWriter, status int, html string) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(html))
+}
+
+// blogTagContains reports whether tag is one of the post's tags.
+func blogTagContains(tags []string, tag string) bool {
+	for _, t := range tags {
+		if t == tag {
+			return true
+		}
+	}
+	return false
+}
+
+// blogVisible filters by tag then sorts, replicating the PostList island's
+// `visible()` memo so the server render matches the client for any `?sort=` /
+// `?tag=` URL. Go's byte-wise string comparison matches `localeCompare` for the
+// ASCII titles/tags and ISO date strings used here.
+func blogVisible(sortKey, tag string) []BlogPost {
+	list := make([]BlogPost, 0, len(blogPosts))
+	for _, p := range blogPosts {
+		if tag == "" || blogTagContains(p.Tags, tag) {
+			list = append(list, p)
+		}
+	}
+	switch sortKey {
+	case "title":
+		sort.SliceStable(list, func(i, j int) bool { return list[i].Title < list[j].Title })
+	case "tag":
+		sort.SliceStable(list, func(i, j int) bool {
+			ti, tj := firstTag(list[i]), firstTag(list[j])
+			if ti != tj {
+				return ti < tj
+			}
+			return list[i].Date > list[j].Date // tie-break: newest first
+		})
+	default: // "date"
+		sort.SliceStable(list, func(i, j int) bool { return list[i].Date > list[j].Date })
+	}
+	return list
+}
+
+// firstTag returns the post's first tag, or "" (mirrors `a.tags[0] ?? ”`).
+func firstTag(p BlogPost) string {
+	if len(p.Tags) > 0 {
+		return p.Tags[0]
+	}
+	return ""
+}
+
+// blogPostListItems builds the per-row child props for the filtered+sorted
+// list. ScopeID is left empty so RenderFragment backfills a unique one;
+// BfDataKey carries the post slug so the keyed list reconciles by identity
+// (a pinned row keeps its state across a re-sort), matching `key={p.slug}`.
+func blogPostListItems(sortKey, tag string) []PostListItemProps {
+	visible := blogVisible(sortKey, tag)
+	items := make([]PostListItemProps, len(visible))
+	for i, p := range visible {
+		items[i] = PostListItemProps{
+			BfDataKey: p.Slug,
+			Href:      blogBasePath() + "/posts/" + p.Slug,
+			Title:     p.Title,
+			Date:      p.Date,
+			Meta:      blogMeta(p),
+		}
+	}
+	return items
+}
+
+// validSortKey clamps a raw `?sort=` value to a known key, like the island's
+// `asSortKey`. NewPostListProps applies the same clamp for `.Params.Sort`; we
+// recompute it here to build the matching SSR row list.
+func validSortKey(raw string) string {
+	if bf.Includes(blogSortKeys, raw) {
+		return raw
+	}
+	return "date"
+}
+
+// blogIndexHandler renders the post list. The list reacts to `?sort=` / `?tag=`
+// via searchParams() on the client; on the server the same query drives both
+// `NewPostListProps` (active highlight + hrefs) and the SSR row order/visibility.
+func blogIndexHandler(w http.ResponseWriter, req *http.Request) {
+	sp := bf.NewSearchParams(req.URL.RawQuery)
+	sortKey := validSortKey(sp.Get("sort"))
+	tag := sp.Get("tag")
+
+	title := "Barefoot Blog — Latest posts"
+	if tag != "" {
+		title = fmt.Sprintf("#%s — Barefoot Blog", tag)
+	}
+
+	html := blogPageHTML(title, func(frag blogFrag) template.HTML {
+		listProps := NewPostListProps(PostListInput{
+			Items:        blogListItems(),
+			Tags:         blogAllTags(),
+			Base:         blogBasePath(),
+			SearchParams: sp,
+		})
+		listProps.PostListItems = blogPostListItems(sortKey, tag)
+		listHTML := frag("PostList", &listProps)
+
+		// The player lives in the content region on the index too, marked
+		// data-bf-permanent, so the router moves the same live node between the
+		// list and a post — it keeps playing instead of resetting.
+		npProps := NewNowPlayingProps(NowPlayingInput{})
+		npHTML := frag("NowPlaying", &npProps)
+
+		return listHTML + npHTML
+	})
+
+	writeBlogHTML(w, http.StatusOK, html)
+}
+
+// blogPostHandler renders a single article. The whole article is the shared
+// <PostArticle> island (its nested children are LikeButton / ReadingTimer /
+// NowPlaying), so the markup comes from post data, not hand-authored HTML.
+func blogPostHandler(w http.ResponseWriter, req *http.Request) {
+	slug := chi.URLParam(req, "slug")
+	i := blogPostIndex(slug)
+	if i < 0 {
+		http.NotFound(w, req)
+		return
+	}
+	p := blogPosts[i]
+
+	in := PostArticleInput{
+		Slug:     p.Slug,
+		Title:    p.Title,
+		Date:     p.Date,
+		Tags:     p.Tags,
+		Body:     p.Body,
+		Position: i + 1,
+		Total:    len(blogPosts),
+		Base:     blogBasePath(),
+	}
+	if i > 0 {
+		in.PrevSlug = blogPosts[i-1].Slug
+		in.PrevTitle = blogPosts[i-1].Title
+	}
+	if i < len(blogPosts)-1 {
+		in.NextSlug = blogPosts[i+1].Slug
+		in.NextTitle = blogPosts[i+1].Title
+	}
+
+	html := blogPageHTML(p.Title+" — Barefoot Blog", func(frag blogFrag) template.HTML {
+		props := NewPostArticleProps(in)
+		return frag("PostArticle", &props)
+	})
+
+	writeBlogHTML(w, http.StatusOK, html)
+}

--- a/integrations/chi/blog_data.go
+++ b/integrations/chi/blog_data.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// BlogPost is the source post data for the blog showcase, ported from the
+// shared TS source `integrations/shared/blog/posts.ts`. The JS integrations
+// (Hono / h3 / Elysia) import that module directly; the Go integration keeps a
+// byte-identical copy here so the same shared islands render the same markup.
+type BlogPost struct {
+	Slug    string
+	Title   string
+	Date    string
+	Tags    []string
+	Excerpt string
+	Body    []string
+}
+
+// blogPosts mirrors `posts` in posts.ts, in the same order.
+var blogPosts = []BlogPost{
+	{
+		Slug:    "partial-navigation",
+		Title:   "Partial navigation, without a SPA framework",
+		Date:    "2026-06-01",
+		Tags:    []string{"design", "runtime"},
+		Excerpt: `Swap only the content region and leave the shell mounted — no virtual DOM, no full rebuild.`,
+		Body: []string{
+			`Most "SPA feel" comes down to one trick: when you follow a link, replace only the part of the page that changed and keep everything else where it is.`,
+			`BarefootJS already renders on the server and hydrates islands in place. The router adds the missing piece — intercept the link, fetch the next page, swap just the content outlet, re-hydrate.`,
+			`The header you are reading this in never reloads. Watch the live counters as you move between posts.`,
+		},
+	},
+	{
+		Slug:    "any-backend",
+		Title:   "Any backend, zero cooperation required",
+		Date:    "2026-06-03",
+		Tags:    []string{"backend", "design"},
+		Excerpt: `The server just returns HTML. The router pulls the outlet out of the response on the client.`,
+		Body: []string{
+			`There is no special protocol to implement. This blog is a plain Hono server returning HTML strings.`,
+			`The router sends no content-negotiation header: it just fetches the page and pulls the outlet out of the response on the client.`,
+			`That is why the same approach works against Go, Perl, or any other backend the adapters target — the server stays a plain HTML server.`,
+		},
+	},
+	{
+		Slug:    "islands-stay-alive",
+		Title:   "Islands in the shell stay alive",
+		Date:    "2026-06-05",
+		Tags:    []string{"islands", "runtime"},
+		Excerpt: `Anything outside the outlet keeps its state: open menus, playing media, live counters, theme.`,
+		Body: []string{
+			`Because only the outlet is replaced, every interactive island in the surrounding shell survives a navigation untouched.`,
+			`The uptime timer in the header was started once, on first load. Full reloads would reset it. It does not.`,
+			`Toggle the theme switch up there, then navigate — the choice sticks because the shell was never torn down.`,
+		},
+	},
+	{
+		Slug:    "reuses-the-runtime",
+		Title:   "It reuses the runtime you already ship",
+		Date:    "2026-06-08",
+		Tags:    []string{"runtime", "design"},
+		Excerpt: `Re-hydration after a swap goes through the same walk the streaming primitive uses.`,
+		Body: []string{
+			`After the outlet is swapped, the freshly inserted islands need to hydrate. The router calls the same re-hydration walk the streaming primitive already uses.`,
+			`New islands light up; the shell is left alone. The router package is tiny because the heavy lifting already lives in the runtime.`,
+			`The like button and "time on page" timer below are outlet islands — they are re-created on every navigation, and torn down when you leave.`,
+		},
+	},
+	{
+		Slug:    "disposal-is-the-hard-part",
+		Title:   "Disposal is the hard part",
+		Date:    "2026-06-10",
+		Tags:    []string{"runtime", "perf"},
+		Excerpt: `Outgoing islands must release timers and listeners or they leak. The stress test measures it.`,
+		Body: []string{
+			`Swapping HTML in is easy. The subtle work is tearing the OLD islands down — their intervals, listeners, and subscriptions.`,
+			`This demo wires a dispose hook that clears each outlet island on the way out. With it off, the per-page timers keep firing forever.`,
+			`That is exactly why precise per-scope disposal is the router prototype's next step.`,
+		},
+	},
+	{
+		Slug:    "history-back-forward",
+		Title:   "Back and forward, done right",
+		Date:    "2026-06-12",
+		Tags:    []string{"history", "design"},
+		Excerpt: `popstate swaps the outlet to match the URL without pushing duplicate entries.`,
+		Body: []string{
+			`A client router lives or dies on the back button. On popstate the router swaps the outlet to match the new URL — without recording a fresh history entry.`,
+			`The stress harness walks forward through several posts then mashes Back, asserting the content matches the URL at every step.`,
+			`Scroll restoration on back/forward is a known gap — the router resets to the top for now.`,
+		},
+	},
+	{
+		Slug:    "rapid-fire",
+		Title:   "Rapid-fire clicks and the last-wins rule",
+		Date:    "2026-06-14",
+		Tags:    []string{"perf", "runtime"},
+		Excerpt: `Spam the links: the latest navigation must win even if an earlier response resolves last.`,
+		Body: []string{
+			`Users double-click. They click B before A has loaded. The router aborts the in-flight request and bails after each await, so the latest target always wins.`,
+			`The stress harness forces a slow response, then navigates away, and asserts the stale content never lands.`,
+			`This was a real race in the first cut — the prototype now has a regression test for it.`,
+		},
+	},
+	{
+		Slug:    "query-string-nav",
+		Title:   "Filtering by tag is just navigation",
+		Date:    "2026-06-16",
+		Tags:    []string{"design", "backend"},
+		Excerpt: `Same path, different query string — the outlet swaps just like any other link.`,
+		Body: []string{
+			`Tag filters on the index are plain links to ?tag=x. To the router they are ordinary same-origin navigations.`,
+			`The outlet swaps to the filtered list; the shell and its theme stay put.`,
+			`Hash-only links, in contrast, are left to the browser so in-page anchors keep working.`,
+		},
+	},
+	{
+		Slug:    "no-fragment-negotiation",
+		Title:   "Why there is no fragment negotiation",
+		Date:    "2026-06-18",
+		Tags:    []string{"backend", "perf"},
+		Excerpt: `Returning just the outlet fragment was considered and dropped — it shaves compressible markup but hurts caching.`,
+		Body: []string{
+			`A "smaller" fragment response only removes the shell markup, which gzip already compresses to almost nothing — while making the same URL return two different bodies, so it needs a Vary header that fragments the cache.`,
+			`It would also force every fragment to re-include its island <script type="module"> tags and <title>, or navigated-to islands go inert.`,
+			`The cost that actually matters is the round-trip, not the byte count — so the effort goes into prefetch, and the server stays a plain, cacheable HTML server.`,
+		},
+	},
+	{
+		Slug:    "where-this-goes",
+		Title:   "Where this goes next",
+		Date:    "2026-06-20",
+		Tags:    []string{"design", "islands"},
+		Excerpt: `Compiler-derived outlets, morph for persistent islands, prefetch on hover, snapshot cache.`,
+		Body: []string{
+			`The outlet is authored by hand today. The end state is the compiler deriving it from the component tree.`,
+			`Add idiomorph-style morphing and data-bf-permanent for islands that should survive a swap, plus hover prefetch and a snapshot cache for instant back/forward.`,
+			`This is the last post — loop back to the start from the navigation below.`,
+		},
+	},
+}
+
+// blogMeta renders the index list's pre-computed `meta` line (`<date> · #tag
+// #tag`), matching `listItems[].meta` in posts.ts. It is computed here, NOT in
+// the PostList island, on purpose: building it in the island needs a
+// value-producing tag-map-join that the template-string adapters (Go included)
+// can't lower for SSR. Pre-computing it upstream keeps the island's template a
+// plain member access so the same shared component compiles on every adapter.
+func blogMeta(p BlogPost) string {
+	tags := make([]string, len(p.Tags))
+	for i, t := range p.Tags {
+		tags[i] = "#" + t
+	}
+	return fmt.Sprintf("%s · %s", p.Date, strings.Join(tags, " "))
+}
+
+// blogListItems derives the index-list items from blogPosts with `meta`
+// pre-rendered, mirroring `listItems` in posts.ts.
+func blogListItems() []Item {
+	items := make([]Item, len(blogPosts))
+	for i, p := range blogPosts {
+		items[i] = Item{
+			Slug:  p.Slug,
+			Title: p.Title,
+			Date:  p.Date,
+			Tags:  p.Tags,
+			Meta:  blogMeta(p),
+		}
+	}
+	return items
+}
+
+// blogAllTags returns the sorted, de-duplicated tag set across all posts,
+// mirroring `allTags` in posts.ts.
+func blogAllTags() []string {
+	seen := map[string]bool{}
+	var tags []string
+	for _, p := range blogPosts {
+		for _, t := range p.Tags {
+			if !seen[t] {
+				seen[t] = true
+				tags = append(tags, t)
+			}
+		}
+	}
+	sort.Strings(tags)
+	return tags
+}
+
+// blogPostIndex returns the index of the post with the given slug, or -1,
+// mirroring `postIndex` in posts.ts.
+func blogPostIndex(slug string) int {
+	for i, p := range blogPosts {
+		if p.Slug == slug {
+			return i
+		}
+	}
+	return -1
+}

--- a/integrations/chi/client/router-entry.ts
+++ b/integrations/chi/client/router-entry.ts
@@ -1,0 +1,24 @@
+/**
+ * Client bootstrap for the blog.
+ *
+ * Loaded once per page as a module `<script>`. It:
+ *   1. installs the client-runtime seams the router re-hydrates / disposes
+ *      through (`setupStreaming` → `window.__bf_hydrate_within` +
+ *      `window.__bf_dispose_within`),
+ *   2. starts the router.
+ *
+ * Same-route `?sort=` / `?tag=` navigations become reactive `searchParams()`
+ * updates (no region swap) with no extra wiring here: the router pushes the new
+ * query through the `window.__bf_pushSearch` seam, which `@barefootjs/client`'s
+ * `searchParams()` installs lazily the first time an island reads it.
+ *
+ * `@barefootjs/client*` is left external in the bundle and resolved through the
+ * page's import map to the SAME `barefoot.js` the compiled islands import via
+ * the relative `./barefoot.js` — so there is a single reactive runtime instance
+ * and `searchParams()` drives the islands' effects.
+ */
+import { setupStreaming } from '@barefootjs/client/runtime'
+import { startRouter } from '@barefootjs/router'
+
+setupStreaming()
+startRouter()

--- a/integrations/chi/components.go
+++ b/integrations/chi/components.go
@@ -4,6 +4,7 @@ package main
 import (
 	"fmt"
 	"math/rand"
+	"strings"
 
 	bf "github.com/barefootjs/runtime/bf"
 )
@@ -392,6 +393,256 @@ type ToggleProps struct {
 	ToggleItems []ToggleItemProps `json:"toggleItems"`
 }
 
+// LikeButtonInput is the user-facing input type.
+type LikeButtonInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// LikeButtonProps is the props type for the LikeButton component.
+type LikeButtonProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Likes int `json:"likes"`
+}
+
+// NowPlayingInput is the user-facing input type.
+type NowPlayingInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// NowPlayingProps is the props type for the NowPlaying component.
+type NowPlayingProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Playing bool `json:"playing"`
+	Elapsed int `json:"elapsed"`
+}
+
+// PageShellInput is the user-facing input type.
+type PageShellInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+	Children interface{}
+}
+
+// PageShellProps is the props type for the PageShell component.
+type PageShellProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Children interface{} `json:"children"`
+	ReaderToolbarSlot0 ReaderToolbarProps `json:"-"`
+}
+
+// PostArticleInput is the user-facing input type.
+type PostArticleInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+	Slug string
+	Title string
+	Date string
+	Tags []string
+	Body []string
+	Position int
+	Total int
+	Base string
+	PrevSlug string
+	PrevTitle string
+	NextSlug string
+	NextTitle string
+}
+
+// PostArticleProps is the props type for the PostArticle component.
+type PostArticleProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Slug string `json:"slug"`
+	Title string `json:"title"`
+	Date string `json:"date"`
+	Tags []string `json:"tags"`
+	Body []string `json:"body"`
+	Position int `json:"position"`
+	Total int `json:"total"`
+	Base string `json:"base"`
+	PrevSlug string `json:"prevSlug"`
+	PrevTitle string `json:"prevTitle"`
+	NextSlug string `json:"nextSlug"`
+	NextTitle string `json:"nextTitle"`
+	LikeButtonSlot9 LikeButtonProps `json:"-"`
+	ReadingTimerSlot10 ReadingTimerProps `json:"-"`
+	NowPlayingSlot11 NowPlayingProps `json:"-"`
+}
+
+// Item represents a item.
+type Item struct {
+	Slug string `json:"slug"`
+	Title string `json:"title"`
+	Date string `json:"date"`
+	Tags []string `json:"tags"`
+	Meta string `json:"meta"`
+}
+
+// SortKey is a string type.
+type SortKey = string
+
+// PostListInput is the user-facing input type.
+type PostListInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+	SearchParams bf.SearchParams // Optional: request query for searchParams()
+	Items []Item
+	Tags []string
+	Base string
+}
+
+// PostListProps is the props type for the PostList component.
+type PostListProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	SearchParams bf.SearchParams `json:"-"`
+	Items []Item `json:"items"`
+	Tags []string `json:"tags"`
+	Base string `json:"base"`
+	Params map[string]interface{} `json:"params"`
+	Visible map[string]interface{} `json:"visible"`
+	Root string `json:"-"`
+	PostListItems []PostListItemProps `json:"-"`
+}
+
+// PostListItemInput is the user-facing input type.
+type PostListItemInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+	Href string
+	Title string
+	Date string
+	Meta string
+}
+
+// PostListItemProps is the props type for the PostListItem component.
+type PostListItemProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Href string `json:"href"`
+	Title string `json:"title"`
+	Date string `json:"date"`
+	Meta string `json:"meta"`
+	Pinned bool `json:"pinned"`
+}
+
+// ReaderToolbarInput is the user-facing input type.
+type ReaderToolbarInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// ReaderToolbarProps is the props type for the ReaderToolbar component.
+type ReaderToolbarProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Level int `json:"level"`
+}
+
+// ReadingTimerInput is the user-facing input type.
+type ReadingTimerInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// ReadingTimerProps is the props type for the ReadingTimer component.
+type ReadingTimerProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Secs int `json:"secs"`
+}
+
+// SidebarInput is the user-facing input type.
+type SidebarInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// SidebarProps is the props type for the Sidebar component.
+type SidebarProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Pins int `json:"pins"`
+}
+
+// ThemeToggleInput is the user-facing input type.
+type ThemeToggleInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// ThemeToggleProps is the props type for the ThemeToggle component.
+type ThemeToggleProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Light bool `json:"light"`
+}
+
 // NewAIChatInteractiveProps creates AIChatInteractiveProps from AIChatInteractiveInput.
 func NewAIChatInteractiveProps(in AIChatInteractiveInput) AIChatInteractiveProps {
 	scopeID := in.ScopeID
@@ -717,5 +968,213 @@ func NewToggleProps(in ToggleInput) ToggleProps {
 		BfParent: in.BfParent,
 		BfMount: in.BfMount,
 		ToggleItems: toggleItems,
+	}
+}
+
+// NewLikeButtonProps creates LikeButtonProps from LikeButtonInput.
+func NewLikeButtonProps(in LikeButtonInput) LikeButtonProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "LikeButton_" + randomID(6)
+	}
+
+	return LikeButtonProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Likes: 0,
+	}
+}
+
+// NewNowPlayingProps creates NowPlayingProps from NowPlayingInput.
+func NewNowPlayingProps(in NowPlayingInput) NowPlayingProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "NowPlaying_" + randomID(6)
+	}
+
+	return NowPlayingProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Playing: false,
+		Elapsed: 0,
+	}
+}
+
+// NewPageShellProps creates PageShellProps from PageShellInput.
+func NewPageShellProps(in PageShellInput) PageShellProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "PageShell_" + randomID(6)
+	}
+
+	return PageShellProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Children: in.Children,
+		ReaderToolbarSlot0: NewReaderToolbarProps(ReaderToolbarInput{
+			ScopeID: scopeID + "_s0",
+			BfParent: scopeID,
+			BfMount: "s0",
+		}),
+	}
+}
+
+// NewPostArticleProps creates PostArticleProps from PostArticleInput.
+func NewPostArticleProps(in PostArticleInput) PostArticleProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "PostArticle_" + randomID(6)
+	}
+
+	return PostArticleProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Slug: in.Slug,
+		Title: in.Title,
+		Date: in.Date,
+		Tags: in.Tags,
+		Body: in.Body,
+		Position: in.Position,
+		Total: in.Total,
+		Base: in.Base,
+		PrevSlug: in.PrevSlug,
+		PrevTitle: in.PrevTitle,
+		NextSlug: in.NextSlug,
+		NextTitle: in.NextTitle,
+		LikeButtonSlot9: NewLikeButtonProps(LikeButtonInput{
+			ScopeID: scopeID + "_s9",
+			BfParent: scopeID,
+			BfMount: "s9",
+		}),
+		ReadingTimerSlot10: NewReadingTimerProps(ReadingTimerInput{
+			ScopeID: scopeID + "_s10",
+			BfParent: scopeID,
+			BfMount: "s10",
+		}),
+		NowPlayingSlot11: NewNowPlayingProps(NowPlayingInput{
+			ScopeID: scopeID + "_s11",
+			BfParent: scopeID,
+			BfMount: "s11",
+		}),
+	}
+}
+
+// NewPostListProps creates PostListProps from PostListInput.
+//
+// NOTE: `PostListItems` is populated by the route handler, not by
+// NewPostListProps — the SSR template iterates over it
+// dynamically (`.PostListItems`). Build the slice from your source data and
+// assign it before passing the props to your renderer. Example:
+//
+//   props := NewPostListProps(PostListInput{ /* ... */ })
+//   props.PostListItems = make([]PostListItemProps, len(items))
+//   for i, item := range items {
+//     props.PostListItems[i] = NewPostListItemProps(PostListItemInput{ /* fields */ })
+//     props.PostListItems[i].BfParent = props.ScopeID
+//     props.PostListItems[i].BfMount = "s13"
+//   }
+func NewPostListProps(in PostListInput) PostListProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "PostList_" + randomID(6)
+	}
+
+	return PostListProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		SearchParams: in.SearchParams,
+		Items: in.Items,
+		Tags: in.Tags,
+		Base: in.Base,
+		Params: map[string]interface{}{
+		"Sort": func() string { if bf.Includes([]string{"date", "title", "tag"}, in.SearchParams.Get("sort")) { return in.SearchParams.Get("sort") }; return "date" }(),
+		"Tag": in.SearchParams.Get("tag"),
+	},
+		Visible: nil,
+		Root: func() string { v := strings.TrimRight(in.Base, "/"); if v != "" { return v }; return "/" }(),
+	}
+}
+
+// NewPostListItemProps creates PostListItemProps from PostListItemInput.
+func NewPostListItemProps(in PostListItemInput) PostListItemProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "PostListItem_" + randomID(6)
+	}
+
+	return PostListItemProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Href: in.Href,
+		Title: in.Title,
+		Date: in.Date,
+		Meta: in.Meta,
+		Pinned: false,
+	}
+}
+
+// NewReaderToolbarProps creates ReaderToolbarProps from ReaderToolbarInput.
+func NewReaderToolbarProps(in ReaderToolbarInput) ReaderToolbarProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "ReaderToolbar_" + randomID(6)
+	}
+
+	return ReaderToolbarProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Level: 1,
+	}
+}
+
+// NewReadingTimerProps creates ReadingTimerProps from ReadingTimerInput.
+func NewReadingTimerProps(in ReadingTimerInput) ReadingTimerProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "ReadingTimer_" + randomID(6)
+	}
+
+	return ReadingTimerProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Secs: 0,
+	}
+}
+
+// NewSidebarProps creates SidebarProps from SidebarInput.
+func NewSidebarProps(in SidebarInput) SidebarProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "Sidebar_" + randomID(6)
+	}
+
+	return SidebarProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Pins: 0,
+	}
+}
+
+// NewThemeToggleProps creates ThemeToggleProps from ThemeToggleInput.
+func NewThemeToggleProps(in ThemeToggleInput) ThemeToggleProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "ThemeToggle_" + randomID(6)
+	}
+
+	return ThemeToggleProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Light: false,
 	}
 }

--- a/integrations/chi/e2e/blog.spec.ts
+++ b/integrations/chi/e2e/blog.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect, type Page } from '@playwright/test'
+
+// The blog sub-app is mounted under the integration's base path. The shared
+// blog islands + the client router are backend-agnostic, so this spec mirrors
+// the Hono integration's blog.spec.ts — only the mount path differs.
+const BLOG = '/integrations/chi/blog'
+
+// The partial-navigation flows below fetch + swap pages, drive intervals, and
+// wait on timers, so they need more headroom than the catalog specs' 5s global.
+test.describe('blog — @barefootjs/router showcase', () => {
+  test.describe.configure({ timeout: 15000 })
+
+  // Tag a live node with an identity marker; read it back to tell a surviving
+  // node (region kept) from a freshly rendered one (region swapped).
+  const mark = (page: Page, sel: string) =>
+    page.$eval(sel, (el) => {
+      ;(el as unknown as { __mark?: string }).__mark = 'KEEP'
+    })
+  const marker = (page: Page, sel: string) =>
+    page.$eval(sel, (el) => (el as unknown as { __mark?: string }).__mark).catch(() => null)
+
+  test('v0.5: sort/tag is a query-only update with no region swap', async ({ page }) => {
+    await page.goto(BLOG, { waitUntil: 'networkidle' })
+    await expect(page.locator('.sortable-list li')).toHaveCount(10)
+    await mark(page, '.content') // the list root — a region swap would replace it
+    await page.click('.controls a.sort:has-text("title")')
+    await page.waitForTimeout(150)
+    const first = await page.locator('.sortable-list li:first-child .item-link').innerText()
+    expect(first[0] === 'A' || first[0] === 'B').toBe(true)
+    expect(await marker(page, '.content')).toBe('KEEP') // not swapped
+    expect(page.url()).toContain('sort=title')
+  })
+
+  test('v0: clicking a post swaps the content region; shell + theme persist', async ({ page }) => {
+    await page.goto(BLOG, { waitUntil: 'networkidle' })
+    await page.click('.toggle')
+    const theme = await page.getAttribute('html', 'data-theme')
+    await page.click('.sortable-list li:first-child .item-link')
+    await page.waitForSelector('.island.like', { timeout: 3000 })
+    expect(await page.locator('.island.like').count()).toBe(1)
+    expect(await page.getAttribute('html', 'data-theme')).toBe(theme) // shell never reloaded
+    await page.click('.island.like')
+    expect(await page.locator('.island.like .v').innerText()).toBe('1')
+  })
+
+  test('v1: data-bf-permanent keeps the player live across a post→post swap', async ({ page }) => {
+    await page.goto(BLOG, { waitUntil: 'networkidle' })
+    await page.click('.sortable-list li:first-child .item-link')
+    await page.waitForSelector('.now-playing-bar', { timeout: 3000 })
+    await page.click('.now-playing-bar .np-toggle') // ▶ play
+    await page.waitForTimeout(900)
+    const before = Number(await page.locator('.now-playing-bar .np-time').innerText())
+    expect(before).toBeGreaterThan(0.4)
+    await mark(page, '[data-bf-permanent="now-playing"]')
+    await page.click('.pager a.pager-link[href*="/posts/"]')
+    await page.waitForTimeout(400)
+    expect(await marker(page, '[data-bf-permanent="now-playing"]')).toBe('KEEP') // same live node
+    expect(Number(await page.locator('.now-playing-bar .np-time').innerText())).toBeGreaterThanOrEqual(before)
+    expect(Number(await page.locator('.island.timer .v').innerText())).toBeLessThan(0.5) // unmarked timer reset
+    // post → index ("← All posts"): the player is also data-bf-permanent on the
+    // list, so the same live node survives returning to the index — not reset.
+    const elapsed = Number(await page.locator('.now-playing-bar .np-time').innerText())
+    await page.click('.post .back')
+    await page.waitForSelector('.sortable-list li', { timeout: 3000 })
+    expect(await marker(page, '[data-bf-permanent="now-playing"]')).toBe('KEEP') // same live node on the index
+    expect(Number(await page.locator('.now-playing-bar .np-time').innerText())).toBeGreaterThanOrEqual(elapsed)
+  })
+
+  test('v2 sibling: the sidebar region persists while content swaps', async ({ page }) => {
+    await page.goto(BLOG, { waitUntil: 'networkidle' })
+    await page.click('.sidebar-pin')
+    await page.click('.sidebar-pin')
+    expect(await page.locator('.sidebar-pin .v').innerText()).toBe('2')
+    await mark(page, 'aside[bf-region] .sidebar')
+    await page.click('.sortable-list li:first-child .item-link')
+    await page.waitForSelector('.island.like', { timeout: 3000 })
+    expect(await page.locator('.sidebar-pin .v').innerText()).toBe('2') // state survived
+    expect(await marker(page, 'aside[bf-region] .sidebar')).toBe('KEEP') // same node
+  })
+
+  test('v2 nested: the outer toolbar region persists while the inner content swaps', async ({ page }) => {
+    await page.goto(BLOG, { waitUntil: 'networkidle' })
+    await page.click('.reader-toolbar .rt-btn[aria-label="larger"]')
+    await page.click('.reader-toolbar .rt-btn[aria-label="larger"]')
+    expect(await page.locator('.reader-toolbar .v').innerText()).toBe('3')
+    await mark(page, '.reader-toolbar')
+    await page.click('.sortable-list li:first-child .item-link')
+    await page.waitForSelector('.island.like', { timeout: 3000 })
+    expect(await page.locator('.reader-toolbar .v').innerText()).toBe('3') // outer region kept
+    expect(await marker(page, '.reader-toolbar')).toBe('KEEP') // same node
+  })
+})

--- a/integrations/chi/main.go
+++ b/integrations/chi/main.go
@@ -35,7 +35,21 @@ var basePath string
 var (
 	renderer *bf.Renderer
 	layoutFn bf.LayoutFunc
+	// baseTemplates is the parsed template set, kept so the blog renderer (which
+	// composes several islands via RenderFragment) can build its own bf.Renderer
+	// without re-parsing in production. In dev, currentTemplates re-parses per
+	// request so build:watch rebuilds show on refresh.
+	baseTemplates *template.Template
 )
+
+// currentTemplates returns the parsed templates: re-parsed per call in dev so
+// `bun run build:watch` rebuilds appear on reload, the cached set otherwise.
+func currentTemplates() *template.Template {
+	if isDevEnv() {
+		return loadTemplates()
+	}
+	return baseTemplates
+}
 
 // loadTemplates walks dist/templates/ recursively and parses every .tmpl
 // file, registering a no-op "Tag" stub first so html/template's escape pass
@@ -251,7 +265,8 @@ func main() {
 		}
 	}
 	layoutFn = layout
-	renderer = bf.NewRenderer(loadTemplates(), layout)
+	baseTemplates = loadTemplates()
+	renderer = bf.NewRenderer(baseTemplates, layout)
 
 	r := chi.NewRouter()
 	r.Use(middleware.Logger)
@@ -272,6 +287,12 @@ func main() {
 	r.Get(basePath+"/conditional-return-link", conditionalReturnLinkHandler)
 	r.Get(basePath+"/ai-chat", aiChatHandler)
 	r.Get(basePath+"/api/ai-chat", aiChatSSEHandler)
+
+	// Blog — the @barefootjs/router showcase (partial navigation across a
+	// region shell). Its own region-shell layout, separate from the catalog
+	// renderer, mounted under ${basePath}/blog.
+	r.Get(basePath+"/blog", blogIndexHandler)
+	r.Get(basePath+"/blog/posts/{slug}", blogPostHandler)
 
 	// Todo API endpoints
 	r.Get(basePath+"/api/todos", getTodosAPI)
@@ -309,7 +330,8 @@ func indexHandler(w http.ResponseWriter, _ *http.Request) {
         <li><a href="%s/todos">Todo (@client)</a></li>
         <li><a href="%s/todos-ssr">Todo (no @client markers)</a></li>
         <li><a href="%s/ai-chat">AI Chat (SSE Streaming)</a></li>
-    </ul>`, basePath, basePath, basePath, basePath, basePath)
+        <li><a href="%s/blog">Blog (@barefootjs/router — partial navigation)</a></li>
+    </ul>`, basePath, basePath, basePath, basePath, basePath, basePath)
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	fmt.Fprintf(w, `<!DOCTYPE html>

--- a/integrations/chi/package.json
+++ b/integrations/chi/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/copy-shared.ts",
+    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/build-client.ts && bun run scripts/copy-shared.ts",
     "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
     "dev": "APP_ENV=development BASE_PATH=/integrations/chi go run .",
     "setup": "go mod tidy",
@@ -14,6 +14,8 @@
   "devDependencies": {
     "@barefootjs/jsx": "workspace:*",
     "@barefootjs/go-template": "workspace:*",
+    "@barefootjs/client": "workspace:*",
+    "@barefootjs/router": "workspace:*",
     "@cloudflare/containers": "^0.3.2",
     "@cloudflare/workers-types": "^4",
     "@playwright/test": "^1.41.0",

--- a/integrations/chi/scripts/build-client.ts
+++ b/integrations/chi/scripts/build-client.ts
@@ -1,0 +1,38 @@
+/**
+ * Bundle the browser-side bootstrap (`router-entry.js`) into `dist/client/`,
+ * next to the `barefoot.js` runtime and the compiled islands, so the single
+ * static base (`/static/client/`) serves everything.
+ *
+ * `@barefootjs/client*` is kept external so it resolves through the page's
+ * import map to the same `barefoot.js` the compiled islands import via the
+ * relative `./barefoot.js` — one reactive runtime instance, so `searchParams()`
+ * is a single shared signal and the router's `__bf_pushSearch` push reaches the
+ * islands' effects. The router core and `@barefootjs/shared` are inlined.
+ */
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(HERE, '..')
+const CLIENT_EXTERNAL = [
+  '@barefootjs/client',
+  '@barefootjs/client/runtime',
+  '@barefootjs/client/reactive',
+]
+
+async function bundle(entry: string, external: string[], label: string): Promise<void> {
+  const result = await Bun.build({
+    entrypoints: [resolve(ROOT, entry)],
+    outdir: resolve(ROOT, 'dist/client'),
+    format: 'esm',
+    target: 'browser',
+    external,
+  })
+  if (!result.success) {
+    for (const log of result.logs) console.error(log)
+    process.exit(1)
+  }
+  console.log(`Generated: ${label}`)
+}
+
+await bundle('client/router-entry.ts', CLIENT_EXTERNAL, 'client/router-entry.js')

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -31,10 +31,12 @@ func FuncMap() template.FuncMap {
 		"bf_div": Div,
 		"bf_mod": Mod,
 		"bf_neg": Neg,
+		"bf_min": Min,
+		"bf_max": Max,
 
 		// String
-		"bf_lower":    Lower,
-		"bf_upper":    Upper,
+		"bf_lower":       Lower,
+		"bf_upper":       Upper,
 		"bf_trim":        Trim,
 		"bf_contains":    Contains,
 		"bf_join":        Join,
@@ -54,8 +56,8 @@ func FuncMap() template.FuncMap {
 
 		// JSON / numeric primitives — JS-compat callees registered on
 		// the Go adapter's `templatePrimitives` map (#1188).
-		"bf_json":   JSON,
-		"bf_number": Number,
+		"bf_json":     JSON,
+		"bf_number":   Number,
 		"bf_floor":    Floor,
 		"bf_ceil":     Ceil,
 		"bf_round":    Round,
@@ -79,20 +81,20 @@ func FuncMap() template.FuncMap {
 		"bf_filter_truthy":  FilterTruthy,
 
 		// Higher-order Array Methods
-		"bf_every":      Every,
-		"bf_some":       Some,
-		"bf_filter":     Filter,
+		"bf_every":           Every,
+		"bf_some":            Some,
+		"bf_filter":          Filter,
 		"bf_find":            Find,
 		"bf_find_index":      FindIndex,
 		"bf_find_last":       FindLast,
 		"bf_find_last_index": FindLastIndex,
-		"bf_sort":       Sort,
-		"bf_reduce":     Reduce,
+		"bf_sort":            Sort,
+		"bf_reduce":          Reduce,
 
 		// Comment marker (for hydration)
-		"bfComment":    Comment,
-		"bfTextStart":  TextStart,
-		"bfTextEnd":    TextEnd,
+		"bfComment":   Comment,
+		"bfTextStart": TextStart,
+		"bfTextEnd":   TextEnd,
 
 		// Script collection
 		"bfScripts": BfScripts,
@@ -505,6 +507,35 @@ func Div(a, b any) any {
 		return 0
 	}
 	return av / bv
+}
+
+// Min returns the smaller of a and b (two-arg `Math.min`). Like Mul, it keeps
+// an integer result when both operands are int-like so a CSS value such as
+// `bf_min 100 x` stays `100` rather than `100.000000`.
+func Min(a, b any) any {
+	av, bv := toFloat64(a), toFloat64(b)
+	r := av
+	if bv < av {
+		r = bv
+	}
+	if isIntLike(a) && isIntLike(b) && r == float64(int(r)) {
+		return int(r)
+	}
+	return r
+}
+
+// Max returns the larger of a and b (two-arg `Math.max`), with the same
+// int-preserving rule as Min.
+func Max(a, b any) any {
+	av, bv := toFloat64(a), toFloat64(b)
+	r := av
+	if bv > av {
+		r = bv
+	}
+	if isIntLike(a) && isIntLike(b) && r == float64(int(r)) {
+		return int(r)
+	}
+	return r
 }
 
 // Mod returns a % b (modulo). Supports int only.
@@ -1634,6 +1665,7 @@ func decapitalize(s string) string {
 //   - numeric-*string* keys fold numerically here, but JS `+`
 //     string-concatenates once an operand is a string, so
 //     numeric-string data can render differently under CSR.
+//
 // Genuine numbers — the common SSR case — agree across all three.
 func Reduce(items any, op, keyKind, keyName, typ, init, direction string) any {
 	v := reflect.ValueOf(items)
@@ -2018,13 +2050,14 @@ func renderTemplateErrorPanel(componentName string, err error) string {
 		`</pre><div style="margin-top:.75em;font-size:12px;opacity:.7">Common cause: a JSX expression referenced a name the adapter could not resolve to a struct field. Open the matching <code>dist/templates/*.tmpl</code> for the unresolved reference, then fix the source component.</div></div>`
 }
 
-func (r *Renderer) Render(opts RenderOptions) string {
-	// Create script collector and inject into props
-	scriptCollector := NewScriptCollector()
+// renderComponentInto wires a component's props (script/portal collectors,
+// child-slot scope ids + hydration, root marking) against the PROVIDED
+// collectors and returns just the component's HTML — no layout. Both Render
+// (one fresh collector pair per page) and RenderFragment (a shared pair across
+// several islands) funnel through here so their wiring stays identical.
+func (r *Renderer) renderComponentInto(opts RenderOptions, scriptCollector *ScriptCollector, portalCollector *PortalCollector) template.HTML {
+	// Inject the shared collectors into the props.
 	setScriptsField(opts.Props, scriptCollector)
-
-	// Create portal collector and inject into props
-	portalCollector := NewPortalCollector()
 	setPortalsField(opts.Props, portalCollector)
 
 	// Auto-detect and process child component props (slices)
@@ -2075,6 +2108,16 @@ func (r *Renderer) Render(opts RenderOptions) string {
 		componentBuf.WriteString(renderTemplateErrorPanel(opts.ComponentName, err))
 	}
 
+	return template.HTML(componentBuf.String())
+}
+
+func (r *Renderer) Render(opts RenderOptions) string {
+	// One script + portal collector pair for the whole page.
+	scriptCollector := NewScriptCollector()
+	portalCollector := NewPortalCollector()
+
+	componentHTML := r.renderComponentInto(opts, scriptCollector, portalCollector)
+
 	// Determine title (default: "{ComponentName} - BarefootJS")
 	title := opts.Title
 	if title == "" {
@@ -2088,7 +2131,7 @@ func (r *Renderer) Render(opts RenderOptions) string {
 	ctx := &RenderContext{
 		ComponentName: opts.ComponentName,
 		Props:         opts.Props,
-		ComponentHTML: template.HTML(componentBuf.String()),
+		ComponentHTML: componentHTML,
 		Portals:       portalCollector.Render(),
 		Scripts:       BfScripts(scriptCollector),
 		Title:         title,
@@ -2097,6 +2140,25 @@ func (r *Renderer) Render(opts RenderOptions) string {
 	}
 
 	return r.layout(ctx)
+}
+
+// RenderFragment renders a single island subtree into the caller-provided
+// script and portal collectors and returns just its HTML — no page layout.
+//
+// It exists for hand-authored "region shell" pages (the `@barefootjs/router`
+// showcase): a layout that places several independent islands — e.g. a header
+// ThemeToggle, an `<aside bf-region>` Sidebar, and a `<PageShell>` wrapping the
+// route content — must collect ALL their scripts and portals into ONE place so
+// the runtime (`barefoot.js`) and each island's client JS are emitted exactly
+// once and share a single reactive instance. Render each island with the same
+// collectors, splice the returned HTML into the shell, then emit
+// `BfScripts(sc)` and `pc.Render()` once at the end of the document.
+//
+// Each fragment is treated as its own root (it emits `bf-p` like any top-level
+// island); nested children declared in its props are wired as children, exactly
+// as in Render.
+func (r *Renderer) RenderFragment(opts RenderOptions, scriptCollector *ScriptCollector, portalCollector *PortalCollector) template.HTML {
+	return r.renderComponentInto(opts, scriptCollector, portalCollector)
 }
 
 // setScriptsField sets the Scripts field on a struct using reflection.
@@ -2355,7 +2417,6 @@ func setPortalsOnSlice(slice interface{}, collector *PortalCollector) {
 	}
 }
 
-
 // findSingleChildComponents finds single struct fields containing child component props.
 // Child props are identified by having ScopeID and Scripts fields.
 func findSingleChildComponents(props interface{}) []interface{} {
@@ -2423,7 +2484,6 @@ func setPortalsOnSingle(child interface{}, collector *PortalCollector) {
 		}
 	}
 }
-
 
 // =============================================================================
 // Internal Helpers

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -80,6 +80,40 @@ func TestDiv(t *testing.T) {
 	}
 }
 
+func TestMin(t *testing.T) {
+	tests := []struct {
+		a, b any
+		want any
+	}{
+		{3, 4, 3},         // both int-like → int result
+		{4, 3, 3},         // order independent
+		{100, 12.5, 12.5}, // mixed operands → float64 result
+		{-2, 5, -2},       // negatives
+	}
+	for _, tt := range tests {
+		if got := Min(tt.a, tt.b); got != tt.want {
+			t.Errorf("Min(%v, %v) = %v, want %v", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestMax(t *testing.T) {
+	tests := []struct {
+		a, b any
+		want any
+	}{
+		{3, 4, 4},
+		{4, 3, 4},
+		{2.5, 1, 2.5}, // mixed operands → float64 result
+		{-5, -2, -2},
+	}
+	for _, tt := range tests {
+		if got := Max(tt.a, tt.b); got != tt.want {
+			t.Errorf("Max(%v, %v) = %v, want %v", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
 func TestMod(t *testing.T) {
 	tests := []struct {
 		a, b any

--- a/packages/adapter-go-template/src/__tests__/build.test.ts
+++ b/packages/adapter-go-template/src/__tests__/build.test.ts
@@ -1,5 +1,44 @@
 import { describe, expect, test } from 'bun:test'
-import { deduplicateGoTypes } from '../build'
+import { combineGoTypes, deduplicateGoTypes } from '../build'
+
+describe('combineGoTypes stdlib imports', () => {
+  // The combined types file strips each component's own import block and
+  // rebuilds one header, pulling in stdlib packages only when the merged code
+  // references them. A `searchParams()`-backed constructor emits
+  // `strings.TrimRight(in.Base, "/")`, so the header must include "strings" or
+  // the generated file fails to compile (`undefined: strings`).
+  test('adds "strings" import when a constructor uses strings.*', () => {
+    const types = new Map<string, string>([
+      [
+        'Foo',
+        [
+          'package main',
+          '',
+          'import (',
+          '\t"strings"',
+          ')',
+          '',
+          'func NewFooProps(in FooInput) FooProps {',
+          '\treturn FooProps{Root: strings.TrimRight(in.Base, "/")}',
+          '}',
+        ].join('\n'),
+      ],
+    ])
+    const result = combineGoTypes({ types, packageName: 'main' })
+    expect(result).toContain('\t"strings"')
+  })
+
+  test('omits "strings" import when unused', () => {
+    const types = new Map<string, string>([
+      [
+        'Foo',
+        ['package main', '', 'func NewFooProps(in FooInput) FooProps {', '\treturn FooProps{}', '}'].join('\n'),
+      ],
+    ])
+    const result = combineGoTypes({ types, packageName: 'main' })
+    expect(result).not.toContain('"strings"')
+  })
+})
 
 describe('deduplicateGoTypes', () => {
   test('deduplicates NewXxxProps with single-line doc comment', () => {

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -2191,6 +2191,18 @@ export function Tagged(props: { className?: string }) {
       expect(result.template).toContain('bf_add .N 12')
     })
 
+    test('module numeric const with separators inlines the stripped value', () => {
+      const result = compileAndGenerate(`
+        'use client'
+        const GAP = 100_000
+        export function Foo(props: { n: number }) {
+          return <div data-x={props.n + GAP}>hi</div>
+        }
+      `)
+      // 100_000 (TS numeric separator) → 100000; Go template literals reject "_".
+      expect(result.template).toContain('bf_add .N 100000')
+    })
+
     test('registry exposes the expected V1 callees', () => {
       // Pin the V1 surface so a future refactor doesn't accidentally
       // drop a primitive. New entries are additive — extend this

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -2142,13 +2142,62 @@ export function Tagged(props: { className?: string }) {
       expect(numberResult.template).toContain('bf_number .V')
     })
 
+    test('Math.min(a, b) emits bf_min and parenthesises compound operands', () => {
+      // The blog's NowPlaying progress bar: `Math.min(100, (elapsed / TRACK) *
+      // 100)`. Math.min must lower to bf_min, the nested arithmetic must keep
+      // its inner parens (so bf_mul / bf_div get exactly two args each), and the
+      // module const TRACK must inline to its literal value.
+      const result = compileAndGenerate(`
+        'use client'
+        const TRACK = 8
+        export function Foo(props: { elapsed: number }) {
+          return <div data-x={Math.min(100, (props.elapsed / TRACK) * 100)}>hi</div>
+        }
+      `)
+      expect(result.template).toContain('bf_min 100 (bf_mul (bf_div .Elapsed 8) 100)')
+    })
+
+    test('Math.max(a, b) emits bf_max', () => {
+      const result = compileAndGenerate(`
+        'use client'
+        export function Foo(props: { a: number; b: number }) {
+          return <div data-x={Math.max(props.a, props.b)}>hi</div>
+        }
+      `)
+      expect(result.template).toContain('bf_max .A .B')
+    })
+
+    test('nested arithmetic parenthesises a compound operand', () => {
+      // Without wrapping, `(a / b) * c` would emit `bf_mul bf_div .A .B .C`,
+      // handing bf_mul four args. Each compound operand must be parenthesised.
+      const result = compileAndGenerate(`
+        'use client'
+        export function Foo(props: { a: number; b: number; c: number }) {
+          return <div data-x={(props.a / props.b) * props.c}>hi</div>
+        }
+      `)
+      expect(result.template).toContain('bf_mul (bf_div .A .B) .C')
+    })
+
+    test('module numeric const inlines its literal value', () => {
+      const result = compileAndGenerate(`
+        'use client'
+        const SIZE = 12
+        export function Foo(props: { n: number }) {
+          return <div data-x={props.n + SIZE}>hi</div>
+        }
+      `)
+      // SIZE inlines to 12 rather than emitting a bogus `.SIZE` Props field.
+      expect(result.template).toContain('bf_add .N 12')
+    })
+
     test('registry exposes the expected V1 callees', () => {
       // Pin the V1 surface so a future refactor doesn't accidentally
       // drop a primitive. New entries are additive — extend this
       // list rather than replace.
       const a = new GoTemplateAdapter()
       const keys = Object.keys(a.templatePrimitives ?? {}).sort()
-      expect(keys).toEqual(['JSON.stringify', 'Math.ceil', 'Math.floor', 'Math.round', 'Number', 'String'])
+      expect(keys).toEqual(['JSON.stringify', 'Math.ceil', 'Math.floor', 'Math.max', 'Math.min', 'Math.round', 'Number', 'String'])
     })
 
     test('unregistered identifier-path callee is NOT accepted by the registry', () => {

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -455,6 +455,10 @@ const GO_TEMPLATE_PRIMITIVES: Record<string, PrimitiveSpec> = {
   'Math.floor':     { arity: 1, emit: (args) => `bf_floor ${wrapGoArg(args[0])}` },
   'Math.ceil':      { arity: 1, emit: (args) => `bf_ceil ${wrapGoArg(args[0])}` },
   'Math.round':     { arity: 1, emit: (args) => `bf_round ${wrapGoArg(args[0])}` },
+  // Two-arg forms only; an N-arg `Math.min(a, b, c)` falls through to the
+  // standard BF101 unsupported-call diagnostic via the arity gate.
+  'Math.min':       { arity: 2, emit: (args) => `bf_min ${wrapGoArg(args[0])} ${wrapGoArg(args[1])}` },
+  'Math.max':       { arity: 2, emit: (args) => `bf_max ${wrapGoArg(args[0])} ${wrapGoArg(args[1])}` },
 }
 
 export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter, IRNodeEmitter<GoRenderCtx> {
@@ -5144,6 +5148,11 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     }
     const inlined = this.resolveModuleStringConst(name)
     if (inlined !== null) return inlined
+    // Module numeric const (e.g. `const TRACK = 8` used in a width expression):
+    // inline the literal value rather than emit `{{.TRACK}}` against a Props
+    // field that never exists. Mirrors the string-const inlining above.
+    const inlinedNum = this.resolveModuleNumericConst(name)
+    if (inlinedNum !== null) return inlinedNum
     const currentLoopParam = this.loopParamStack[this.loopParamStack.length - 1]
     if (currentLoopParam && name === currentLoopParam) return '.'
     // An *outer* loop's value variable (we're in a nested loop) is in scope as
@@ -5330,6 +5339,27 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     return `"${this.escapeGoString(value)}"`
   }
 
+  /**
+   * Inline a module-level numeric const (`const TRACK = 8`) as its literal
+   * value. Only a plain numeric initializer qualifies — anything computed or
+   * non-numeric falls through to the normal field/ident resolution. Scoped to
+   * module consts (like the string variant) and guarded against loop vars so a
+   * range variable that shadows a const name still wins.
+   */
+  private resolveModuleNumericConst(name: string): string | null {
+    if (this.loopParamStack.length > 0 && this.loopParamStack[this.loopParamStack.length - 1] === name) {
+      return null
+    }
+    if (this.loopVarRefCount.has(name)) return null
+    if (this.isOuterLoopParam(name)) return null
+    const c = this.localConstants.find(
+      (k) => k.name === name && k.isModule && !k.containsArrow,
+    )
+    if (!c || c.value === undefined) return null
+    const v = c.value.trim()
+    return /^-?\d+(\.\d+)?$/.test(v) ? v : null
+  }
+
   literal(value: string | number | boolean | null, literalType: LiteralType): string {
     if (literalType === 'string') return `"${value}"`
     if (literalType === 'null') return 'nil'
@@ -5466,35 +5496,43 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   binary(op: string, left: ParsedExpr, right: ParsedExpr, emit: (e: ParsedExpr) => string): string {
     const l = emit(left)
     const r = emit(right)
+    // Every Go form below is a prefix function call (`bf_mul a b`, `gt a b`,
+    // `eq a b`), so a COMPOUND operand must be parenthesised or the template
+    // parser folds its tokens into the call's argument list — e.g. nested
+    // arithmetic `(elapsed / TRACK) * 100` would emit `bf_mul bf_div .Elapsed
+    // .TRACK 100`, handing `bf_mul` four args. `wrapIfMultiToken` is a no-op
+    // for single tokens and quoted literals, so simple operands are untouched.
+    const wl = wrapIfMultiToken(l)
+    const wr = wrapIfMultiToken(r)
     switch (op) {
       case '===':
       case '==': {
         const [el, er] = stringTolerantEqOperands(l, r)
-        return `eq ${el} ${er}`
+        return `eq ${wrapIfMultiToken(el)} ${wrapIfMultiToken(er)}`
       }
       case '!==':
       case '!=': {
         const [el, er] = stringTolerantEqOperands(l, r)
-        return `ne ${el} ${er}`
+        return `ne ${wrapIfMultiToken(el)} ${wrapIfMultiToken(er)}`
       }
       case '>':
-        return `gt ${l} ${r}`
+        return `gt ${wl} ${wr}`
       case '<':
-        return `lt ${l} ${r}`
+        return `lt ${wl} ${wr}`
       case '>=':
-        return `ge ${l} ${r}`
+        return `ge ${wl} ${wr}`
       case '<=':
-        return `le ${l} ${r}`
+        return `le ${wl} ${wr}`
       case '+':
-        return `bf_add ${l} ${r}`
+        return `bf_add ${wl} ${wr}`
       case '-':
-        return `bf_sub ${l} ${r}`
+        return `bf_sub ${wl} ${wr}`
       case '*':
-        return `bf_mul ${l} ${r}`
+        return `bf_mul ${wl} ${wr}`
       case '/':
-        return `bf_div ${l} ${r}`
+        return `bf_div ${wl} ${wr}`
       case '%':
-        return `bf_mod ${l} ${r}`
+        return `bf_mod ${wl} ${wr}`
       default:
         return `${l} ${op} ${r}`
     }

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -5356,7 +5356,11 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       (k) => k.name === name && k.isModule && !k.containsArrow,
     )
     if (!c || c.value === undefined) return null
-    const v = c.value.trim()
+    // `value` is reconstructed from source text, so a valid TS literal may carry
+    // numeric separators (`100_000`). Strip them between digits, then accept a
+    // plain decimal / float; Go template numeric literals don't allow `_`, so
+    // the stripped form is what gets emitted.
+    const v = c.value.trim().replace(/(?<=\d)_(?=\d)/g, '')
     return /^-?\d+(\.\d+)?$/.test(v) ? v : null
   }
 

--- a/packages/adapter-go-template/src/build.ts
+++ b/packages/adapter-go-template/src/build.ts
@@ -165,6 +165,10 @@ export function combineGoTypes(options: {
   const usageScan = combinedContent + '\n' + (manualTypes ?? '')
   const stdlibImports: string[] = [`\t"math/rand"`]
   if (/\bfmt\./.test(usageScan)) stdlibImports.push(`\t"fmt"`)
+  // `strings.` shows up in generated constructors that normalize a prop, e.g.
+  // `searchParams()`-backed components emit `strings.TrimRight(in.Base, "/")`
+  // to derive the router base. Only imported when referenced, like the others.
+  if (/\bstrings\./.test(usageScan)) stdlibImports.push(`\t"strings"`)
   if (/\btemplate\.HTML\b/.test(usageScan)) stdlibImports.push(`\t"html/template"`)
   // gofmt sorts the stdlib group alphabetically by import path.
   stdlibImports.sort()


### PR DESCRIPTION
## Summary

Brings the blog sub-app (already shipped on Hono / h3 / Elysia) to the **Go/Chi** integration, so `@barefootjs/router` partial navigation works the same against a plain `html/template` server. The islands are the **same** shared components under `integrations/shared/blog`, compiled by chi's `bf build` — the server's only job is to return a plain HTML page per route with the right `bf-region` boundaries.

This validates end-to-end (in a real Go app) the `searchParams()` SSR work from the earlier `go-derived-memo-cap*` PRs: `?sort=` / `?tag=` resolve server-side to match the client.

## Integration (`integrations/chi`)

- **`blog.go`** — region-shell layout + handlers for `/blog` (PostList + NowPlaying) and `/blog/posts/{slug}` (PostArticle with prev/next). Every island renders through the new `bf.Renderer.RenderFragment` against **one** shared script/portal collector, so `barefoot.js` and each island's client JS emit **exactly once** (verified).
- **`blog_data.go`** — posts data ported from `shared/blog/posts.ts` (list items with pre-computed `meta`, tag set, and a `visible()` sort/filter that mirrors the island so the SSR row order matches the URL).
- **`client/router-entry.ts`** + **`scripts/build-client.ts`** — bundle the client router next to `barefoot.js`; an import map resolves `@barefootjs/client*` to the same runtime instance the islands import via `./barefoot.js` (single reactive instance → one shared `searchParams()` signal).
- **`barefoot.config.ts` / `package.json` / `main.go`** — compile the blog components, register routes, link the bundle, add an index link.
- **`e2e/blog.spec.ts`** — mirrors the Hono blog spec (v0.5 query-only update, v0 region swap + shell persistence, v1 `data-bf-permanent` player, v2 sibling/nested regions).

## Go adapter fixes (first Go user of these islands surfaced them)

- **`RenderFragment`** — compose several top-level islands into a hand-authored shell sharing one script/portal collection. `Render` was refactored onto the same core so its behavior is unchanged.
- **`Math.min` / `Math.max`** → `bf_min` / `bf_max` (new runtime helpers). The N-arg form still falls back to BF101 via the arity gate.
- **`binary()`** — parenthesise compound operands so nested arithmetic `(a / b) * c` emits `bf_mul (bf_div a b) c` instead of a 4-arg `bf_mul` (was broken for any nested arithmetic).
- **module numeric consts** — `const TRACK = 8` inlines its literal value instead of emitting a non-existent `.TRACK` Props field.
- **`combineGoTypes`** — add the `"strings"` import when the merged constructors reference `strings.*` (the `searchParams()`-backed `Root` normalization emits `strings.TrimRight`), fixing `undefined: strings` in the generated `components.go`.

## Testing

- Adapter unit tests for each lowering fix (`Math.min`/`max`, nested-arithmetic parens, numeric-const inlining) + build test for the `strings` import + runtime `TestMin`/`TestMax`.
- Full `adapter-go-template` (549) and `adapter-tests` conformance (761) suites green; `go vet` + `go build` clean.
- Manual SSR verification: all blog routes return 200, zero template-error panels, prev/next pager correct, scripts deduped to one each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JT4Rcc5b1qcMStCJfmD3V1)_