### PR TITLE
feat(gin): add the @barefootjs/router blog showcase to the Gin integration

### DIFF
--- a/integrations/gin/barefoot.config.ts
+++ b/integrations/gin/barefoot.config.ts
@@ -4,7 +4,7 @@ const basePath = process.env.BASE_PATH ?? '/integrations/gin'
 const staticBase = `${basePath}/static/client/`
 
 export default createConfig({
-  components: ['../shared/components'],
+  components: ['../shared/components', '../shared/blog'],
   outDir: 'dist',
   minify: true,
   adapterOptions: {

--- a/integrations/gin/blog.go
+++ b/integrations/gin/blog.go
@@ -1,0 +1,280 @@
+package main
+
+import (
+	"fmt"
+	"html/template"
+	"net/http"
+	"sort"
+	"strings"
+
+	bf "github.com/barefootjs/runtime/bf"
+	"github.com/barefootjs/runtime/bf/bfdev"
+	"github.com/gin-gonic/gin"
+)
+
+// Blog — the `@barefootjs/router` showcase for the Go/Gin adapter.
+//
+// A region-shell sub-site mounted at `${basePath}/blog`, mirroring the Hono /
+// h3 / Elysia integrations. The islands are the SAME shared components under
+// `../shared/blog`, compiled by this integration's `bf build`. Partial
+// navigation is driven entirely on the client by `@barefootjs/router`
+// (bundled into `static/client/router-entry.js`); the server's only job is to
+// return a plain HTML page per route with the right `bf-region` boundaries —
+// exactly the "any backend, zero cooperation" point the blog itself makes.
+
+// blogBasePath is where the blog is mounted; every blog link is built relative
+// to it so the shared components work under any adapter's base path.
+func blogBasePath() string { return basePath + "/blog" }
+
+// blogSortKeys are the sort values the PostList understands; anything else
+// falls back to "date" (matching the island's `asSortKey`).
+var blogSortKeys = []string{"date", "title", "tag"}
+
+// blogImportMap maps the bare `@barefootjs/client*` specifiers that the router
+// bundle imports to the SAME physical `barefoot.js` the compiled islands import
+// via the relative `./barefoot.js`. Resolving both to one URL gives a single
+// reactive runtime instance, so `searchParams()` is one shared signal and the
+// router's query push reaches the islands' effects.
+func blogImportMap() string {
+	bjs := basePath + "/static/client/barefoot.js"
+	j := fmt.Sprintf(
+		`{"imports":{"@barefootjs/client":%q,"@barefootjs/client/runtime":%q,"@barefootjs/client/reactive":%q}}`,
+		bjs, bjs, bjs,
+	)
+	// Escape "<" so a stray "</script>" in the value (e.g. a misconfigured
+	// BASE_PATH) can't break out of the inline <script type="importmap">. The
+	// replacement is the JS unicode escape backslash-u003c, built by
+	// concatenation so it survives verbatim.
+	return strings.ReplaceAll(j, "<", `\`+"u003c")
+}
+
+// blogFrag renders one island subtree against shared script/portal collectors.
+type blogFrag func(name string, props interface{}) template.HTML
+
+// blogPageHTML assembles the region-shell document shared by every blog route.
+// It mirrors the Hono blog renderer: a persistent shell (header ThemeToggle +
+// a hand-authored `bf-region="nav:0"` Sidebar) wrapping a compiled <PageShell>
+// whose inner region holds the per-route content.
+//
+// Every island — the shell ones AND the route content built by `renderContent`
+// — is rendered through bf.Renderer.RenderFragment against ONE script + portal
+// collector, so `barefoot.js` and each island's client JS are emitted exactly
+// once and share a single runtime instance.
+func blogPageHTML(title string, renderContent func(frag blogFrag) template.HTML) string {
+	r := bf.NewRenderer(currentTemplates(), nil)
+	sc := bf.NewScriptCollector()
+	pc := bf.NewPortalCollector()
+
+	frag := func(name string, props interface{}) template.HTML {
+		return r.RenderFragment(bf.RenderOptions{ComponentName: name, Props: props}, sc, pc)
+	}
+
+	// Content first so its islands register before the shell's; PageShell wraps
+	// it as `children`, Sidebar + ThemeToggle are the persistent shell.
+	content := renderContent(frag)
+
+	shellProps := NewPageShellProps(PageShellInput{Children: content})
+	shellHTML := frag("PageShell", &shellProps)
+
+	sidebarProps := NewSidebarProps(SidebarInput{})
+	sidebarHTML := frag("Sidebar", &sidebarProps)
+
+	themeProps := NewThemeToggleProps(ThemeToggleInput{})
+	themeHTML := frag("ThemeToggle", &themeProps)
+
+	scripts := bf.BfScripts(sc)
+	portals := pc.Render()
+
+	// Dev auto-reload snippet (empty in production) so `bun run build:watch`
+	// rebuilds show up on refresh, matching the catalog pages' layout.
+	devSnippet := bfdev.Snippet(bfdev.Config{Disabled: !isDevEnv()})
+
+	return fmt.Sprintf(`<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>%s</title>
+    <script type="importmap">%s</script>
+    <link rel="stylesheet" href="%s/shared/styles/blog.css">
+</head>
+<body>
+    <header class="shell">
+        <a class="shell-brand" href="%s">📰 Barefoot Blog</a>
+        <div class="shell-island">%s</div>
+    </header>
+    <div class="layout">
+        <aside bf-region="nav:0">%s</aside>
+        <main>%s</main>
+    </div>
+    %s%s
+    <script type="module" src="%s/static/client/router-entry.js"></script>%s
+</body>
+</html>`,
+		template.HTMLEscapeString(title),
+		blogImportMap(),
+		basePath,
+		blogBasePath(),
+		themeHTML,
+		sidebarHTML,
+		shellHTML,
+		scripts,
+		portals,
+		basePath,
+		devSnippet,
+	)
+}
+
+// blogTagContains reports whether tag is one of the post's tags.
+func blogTagContains(tags []string, tag string) bool {
+	for _, t := range tags {
+		if t == tag {
+			return true
+		}
+	}
+	return false
+}
+
+// blogVisible filters by tag then sorts, replicating the PostList island's
+// `visible()` memo so the server render matches the client for any `?sort=` /
+// `?tag=` URL. Go's byte-wise string comparison matches `localeCompare` for the
+// ASCII titles/tags and ISO date strings used here.
+func blogVisible(sortKey, tag string) []BlogPost {
+	list := make([]BlogPost, 0, len(blogPosts))
+	for _, p := range blogPosts {
+		if tag == "" || blogTagContains(p.Tags, tag) {
+			list = append(list, p)
+		}
+	}
+	switch sortKey {
+	case "title":
+		sort.SliceStable(list, func(i, j int) bool { return list[i].Title < list[j].Title })
+	case "tag":
+		sort.SliceStable(list, func(i, j int) bool {
+			ti, tj := firstTag(list[i]), firstTag(list[j])
+			if ti != tj {
+				return ti < tj
+			}
+			return list[i].Date > list[j].Date // tie-break: newest first
+		})
+	default: // "date"
+		sort.SliceStable(list, func(i, j int) bool { return list[i].Date > list[j].Date })
+	}
+	return list
+}
+
+// firstTag returns the post's first tag, or "" (mirrors `a.tags[0] ?? ”`).
+func firstTag(p BlogPost) string {
+	if len(p.Tags) > 0 {
+		return p.Tags[0]
+	}
+	return ""
+}
+
+// blogPostListItems builds the per-row child props for the filtered+sorted
+// list, following the contract documented on NewPostListProps in components.go:
+// each row mounts at slot "s13" under the list's scope (BfParent/BfMount), so it
+// gets the bf-h/bf-m hydration markers the runtime reconciles the loop through.
+// BfDataKey carries the post slug so the keyed list reconciles by identity (a
+// pinned row keeps its state across a re-sort), matching `key={p.slug}`.
+func blogPostListItems(parentScope, sortKey, tag string) []PostListItemProps {
+	visible := blogVisible(sortKey, tag)
+	items := make([]PostListItemProps, len(visible))
+	for i, p := range visible {
+		row := NewPostListItemProps(PostListItemInput{
+			Href:  blogBasePath() + "/posts/" + p.Slug,
+			Title: p.Title,
+			Date:  p.Date,
+			Meta:  blogMeta(p),
+		})
+		row.BfParent = parentScope
+		row.BfMount = "s13"
+		row.BfDataKey = p.Slug
+		items[i] = row
+	}
+	return items
+}
+
+// validSortKey clamps a raw `?sort=` value to a known key, like the island's
+// `asSortKey`. NewPostListProps applies the same clamp for `.Params.Sort`; we
+// recompute it here to build the matching SSR row list.
+func validSortKey(raw string) string {
+	if bf.Includes(blogSortKeys, raw) {
+		return raw
+	}
+	return "date"
+}
+
+// blogIndexHandler renders the post list. The list reacts to `?sort=` / `?tag=`
+// via searchParams() on the client; on the server the same query drives both
+// `NewPostListProps` (active highlight + hrefs) and the SSR row order/visibility.
+func blogIndexHandler(c *gin.Context) {
+	sp := bf.NewSearchParams(c.Request.URL.RawQuery)
+	sortKey := validSortKey(sp.Get("sort"))
+	tag := sp.Get("tag")
+
+	title := "Barefoot Blog — Latest posts"
+	if tag != "" {
+		title = fmt.Sprintf("#%s — Barefoot Blog", tag)
+	}
+
+	html := blogPageHTML(title, func(frag blogFrag) template.HTML {
+		listProps := NewPostListProps(PostListInput{
+			Items:        blogListItems(),
+			Tags:         blogAllTags(),
+			Base:         blogBasePath(),
+			SearchParams: sp,
+		})
+		listProps.PostListItems = blogPostListItems(listProps.ScopeID, sortKey, tag)
+		listHTML := frag("PostList", &listProps)
+
+		// The player lives in the content region on the index too, marked
+		// data-bf-permanent, so the router moves the same live node between the
+		// list and a post — it keeps playing instead of resetting.
+		npProps := NewNowPlayingProps(NowPlayingInput{})
+		npHTML := frag("NowPlaying", &npProps)
+
+		return listHTML + npHTML
+	})
+
+	c.Data(http.StatusOK, "text/html; charset=utf-8", []byte(html))
+}
+
+// blogPostHandler renders a single article. The whole article is the shared
+// <PostArticle> island (its nested children are LikeButton / ReadingTimer /
+// NowPlaying), so the markup comes from post data, not hand-authored HTML.
+func blogPostHandler(c *gin.Context) {
+	slug := c.Param("slug")
+	i := blogPostIndex(slug)
+	if i < 0 {
+		c.Status(http.StatusNotFound)
+		return
+	}
+	p := blogPosts[i]
+
+	in := PostArticleInput{
+		Slug:     p.Slug,
+		Title:    p.Title,
+		Date:     p.Date,
+		Tags:     p.Tags,
+		Body:     p.Body,
+		Position: i + 1,
+		Total:    len(blogPosts),
+		Base:     blogBasePath(),
+	}
+	if i > 0 {
+		in.PrevSlug = blogPosts[i-1].Slug
+		in.PrevTitle = blogPosts[i-1].Title
+	}
+	if i < len(blogPosts)-1 {
+		in.NextSlug = blogPosts[i+1].Slug
+		in.NextTitle = blogPosts[i+1].Title
+	}
+
+	html := blogPageHTML(p.Title+" — Barefoot Blog", func(frag blogFrag) template.HTML {
+		props := NewPostArticleProps(in)
+		return frag("PostArticle", &props)
+	})
+
+	c.Data(http.StatusOK, "text/html; charset=utf-8", []byte(html))
+}

--- a/integrations/gin/blog_data.go
+++ b/integrations/gin/blog_data.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// BlogPost is the source post data for the blog showcase, ported from the
+// shared TS source `integrations/shared/blog/posts.ts`. The JS integrations
+// (Hono / h3 / Elysia) import that module directly; the Go integration keeps a
+// byte-identical copy here so the same shared islands render the same markup.
+type BlogPost struct {
+	Slug    string
+	Title   string
+	Date    string
+	Tags    []string
+	Excerpt string
+	Body    []string
+}
+
+// blogPosts mirrors `posts` in posts.ts, in the same order.
+var blogPosts = []BlogPost{
+	{
+		Slug:    "partial-navigation",
+		Title:   "Partial navigation, without a SPA framework",
+		Date:    "2026-06-01",
+		Tags:    []string{"design", "runtime"},
+		Excerpt: `Swap only the content region and leave the shell mounted — no virtual DOM, no full rebuild.`,
+		Body: []string{
+			`Most "SPA feel" comes down to one trick: when you follow a link, replace only the part of the page that changed and keep everything else where it is.`,
+			`BarefootJS already renders on the server and hydrates islands in place. The router adds the missing piece — intercept the link, fetch the next page, swap just the content outlet, re-hydrate.`,
+			`The header you are reading this in never reloads. Watch the live counters as you move between posts.`,
+		},
+	},
+	{
+		Slug:    "any-backend",
+		Title:   "Any backend, zero cooperation required",
+		Date:    "2026-06-03",
+		Tags:    []string{"backend", "design"},
+		Excerpt: `The server just returns HTML. The router pulls the outlet out of the response on the client.`,
+		Body: []string{
+			`There is no special protocol to implement. This blog is a plain Hono server returning HTML strings.`,
+			`The router sends no content-negotiation header: it just fetches the page and pulls the outlet out of the response on the client.`,
+			`That is why the same approach works against Go, Perl, or any other backend the adapters target — the server stays a plain HTML server.`,
+		},
+	},
+	{
+		Slug:    "islands-stay-alive",
+		Title:   "Islands in the shell stay alive",
+		Date:    "2026-06-05",
+		Tags:    []string{"islands", "runtime"},
+		Excerpt: `Anything outside the outlet keeps its state: open menus, playing media, live counters, theme.`,
+		Body: []string{
+			`Because only the outlet is replaced, every interactive island in the surrounding shell survives a navigation untouched.`,
+			`The uptime timer in the header was started once, on first load. Full reloads would reset it. It does not.`,
+			`Toggle the theme switch up there, then navigate — the choice sticks because the shell was never torn down.`,
+		},
+	},
+	{
+		Slug:    "reuses-the-runtime",
+		Title:   "It reuses the runtime you already ship",
+		Date:    "2026-06-08",
+		Tags:    []string{"runtime", "design"},
+		Excerpt: `Re-hydration after a swap goes through the same walk the streaming primitive uses.`,
+		Body: []string{
+			`After the outlet is swapped, the freshly inserted islands need to hydrate. The router calls the same re-hydration walk the streaming primitive already uses.`,
+			`New islands light up; the shell is left alone. The router package is tiny because the heavy lifting already lives in the runtime.`,
+			`The like button and "time on page" timer below are outlet islands — they are re-created on every navigation, and torn down when you leave.`,
+		},
+	},
+	{
+		Slug:    "disposal-is-the-hard-part",
+		Title:   "Disposal is the hard part",
+		Date:    "2026-06-10",
+		Tags:    []string{"runtime", "perf"},
+		Excerpt: `Outgoing islands must release timers and listeners or they leak. The stress test measures it.`,
+		Body: []string{
+			`Swapping HTML in is easy. The subtle work is tearing the OLD islands down — their intervals, listeners, and subscriptions.`,
+			`This demo wires a dispose hook that clears each outlet island on the way out. With it off, the per-page timers keep firing forever.`,
+			`That is exactly why precise per-scope disposal is the router prototype's next step.`,
+		},
+	},
+	{
+		Slug:    "history-back-forward",
+		Title:   "Back and forward, done right",
+		Date:    "2026-06-12",
+		Tags:    []string{"history", "design"},
+		Excerpt: `popstate swaps the outlet to match the URL without pushing duplicate entries.`,
+		Body: []string{
+			`A client router lives or dies on the back button. On popstate the router swaps the outlet to match the new URL — without recording a fresh history entry.`,
+			`The stress harness walks forward through several posts then mashes Back, asserting the content matches the URL at every step.`,
+			`Scroll restoration on back/forward is a known gap — the router resets to the top for now.`,
+		},
+	},
+	{
+		Slug:    "rapid-fire",
+		Title:   "Rapid-fire clicks and the last-wins rule",
+		Date:    "2026-06-14",
+		Tags:    []string{"perf", "runtime"},
+		Excerpt: `Spam the links: the latest navigation must win even if an earlier response resolves last.`,
+		Body: []string{
+			`Users double-click. They click B before A has loaded. The router aborts the in-flight request and bails after each await, so the latest target always wins.`,
+			`The stress harness forces a slow response, then navigates away, and asserts the stale content never lands.`,
+			`This was a real race in the first cut — the prototype now has a regression test for it.`,
+		},
+	},
+	{
+		Slug:    "query-string-nav",
+		Title:   "Filtering by tag is just navigation",
+		Date:    "2026-06-16",
+		Tags:    []string{"design", "backend"},
+		Excerpt: `Same path, different query string — the outlet swaps just like any other link.`,
+		Body: []string{
+			`Tag filters on the index are plain links to ?tag=x. To the router they are ordinary same-origin navigations.`,
+			`The outlet swaps to the filtered list; the shell and its theme stay put.`,
+			`Hash-only links, in contrast, are left to the browser so in-page anchors keep working.`,
+		},
+	},
+	{
+		Slug:    "no-fragment-negotiation",
+		Title:   "Why there is no fragment negotiation",
+		Date:    "2026-06-18",
+		Tags:    []string{"backend", "perf"},
+		Excerpt: `Returning just the outlet fragment was considered and dropped — it shaves compressible markup but hurts caching.`,
+		Body: []string{
+			`A "smaller" fragment response only removes the shell markup, which gzip already compresses to almost nothing — while making the same URL return two different bodies, so it needs a Vary header that fragments the cache.`,
+			`It would also force every fragment to re-include its island <script type="module"> tags and <title>, or navigated-to islands go inert.`,
+			`The cost that actually matters is the round-trip, not the byte count — so the effort goes into prefetch, and the server stays a plain, cacheable HTML server.`,
+		},
+	},
+	{
+		Slug:    "where-this-goes",
+		Title:   "Where this goes next",
+		Date:    "2026-06-20",
+		Tags:    []string{"design", "islands"},
+		Excerpt: `Compiler-derived outlets, morph for persistent islands, prefetch on hover, snapshot cache.`,
+		Body: []string{
+			`The outlet is authored by hand today. The end state is the compiler deriving it from the component tree.`,
+			`Add idiomorph-style morphing and data-bf-permanent for islands that should survive a swap, plus hover prefetch and a snapshot cache for instant back/forward.`,
+			`This is the last post — loop back to the start from the navigation below.`,
+		},
+	},
+}
+
+// blogMeta renders the index list's pre-computed `meta` line (`<date> · #tag
+// #tag`), matching `listItems[].meta` in posts.ts. It is computed here, NOT in
+// the PostList island, on purpose: building it in the island needs a
+// value-producing tag-map-join that the template-string adapters (Go included)
+// can't lower for SSR. Pre-computing it upstream keeps the island's template a
+// plain member access so the same shared component compiles on every adapter.
+func blogMeta(p BlogPost) string {
+	tags := make([]string, len(p.Tags))
+	for i, t := range p.Tags {
+		tags[i] = "#" + t
+	}
+	return fmt.Sprintf("%s · %s", p.Date, strings.Join(tags, " "))
+}
+
+// blogListItems derives the index-list items from blogPosts with `meta`
+// pre-rendered, mirroring `listItems` in posts.ts.
+func blogListItems() []Item {
+	items := make([]Item, len(blogPosts))
+	for i, p := range blogPosts {
+		items[i] = Item{
+			Slug:  p.Slug,
+			Title: p.Title,
+			Date:  p.Date,
+			Tags:  p.Tags,
+			Meta:  blogMeta(p),
+		}
+	}
+	return items
+}
+
+// blogAllTags returns the sorted, de-duplicated tag set across all posts,
+// mirroring `allTags` in posts.ts.
+func blogAllTags() []string {
+	seen := map[string]bool{}
+	var tags []string
+	for _, p := range blogPosts {
+		for _, t := range p.Tags {
+			if !seen[t] {
+				seen[t] = true
+				tags = append(tags, t)
+			}
+		}
+	}
+	sort.Strings(tags)
+	return tags
+}
+
+// blogPostIndex returns the index of the post with the given slug, or -1,
+// mirroring `postIndex` in posts.ts.
+func blogPostIndex(slug string) int {
+	for i, p := range blogPosts {
+		if p.Slug == slug {
+			return i
+		}
+	}
+	return -1
+}

--- a/integrations/gin/client/router-entry.ts
+++ b/integrations/gin/client/router-entry.ts
@@ -1,0 +1,24 @@
+/**
+ * Client bootstrap for the blog.
+ *
+ * Loaded once per page as a module `<script>`. It:
+ *   1. installs the client-runtime seams the router re-hydrates / disposes
+ *      through (`setupStreaming` → `window.__bf_hydrate_within` +
+ *      `window.__bf_dispose_within`),
+ *   2. starts the router.
+ *
+ * Same-route `?sort=` / `?tag=` navigations become reactive `searchParams()`
+ * updates (no region swap) with no extra wiring here: the router pushes the new
+ * query through the `window.__bf_pushSearch` seam, which `@barefootjs/client`'s
+ * `searchParams()` installs lazily the first time an island reads it.
+ *
+ * `@barefootjs/client*` is left external in the bundle and resolved through the
+ * page's import map to the SAME `barefoot.js` the compiled islands import via
+ * the relative `./barefoot.js` — so there is a single reactive runtime instance
+ * and `searchParams()` drives the islands' effects.
+ */
+import { setupStreaming } from '@barefootjs/client/runtime'
+import { startRouter } from '@barefootjs/router'
+
+setupStreaming()
+startRouter()

--- a/integrations/gin/components.go
+++ b/integrations/gin/components.go
@@ -4,6 +4,7 @@ package main
 import (
 	"fmt"
 	"math/rand"
+	"strings"
 
 	bf "github.com/barefootjs/runtime/bf"
 )
@@ -392,6 +393,256 @@ type ToggleProps struct {
 	ToggleItems []ToggleItemProps `json:"toggleItems"`
 }
 
+// LikeButtonInput is the user-facing input type.
+type LikeButtonInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// LikeButtonProps is the props type for the LikeButton component.
+type LikeButtonProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Likes int `json:"likes"`
+}
+
+// NowPlayingInput is the user-facing input type.
+type NowPlayingInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// NowPlayingProps is the props type for the NowPlaying component.
+type NowPlayingProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Playing bool `json:"playing"`
+	Elapsed int `json:"elapsed"`
+}
+
+// PageShellInput is the user-facing input type.
+type PageShellInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+	Children interface{}
+}
+
+// PageShellProps is the props type for the PageShell component.
+type PageShellProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Children interface{} `json:"children"`
+	ReaderToolbarSlot0 ReaderToolbarProps `json:"-"`
+}
+
+// PostArticleInput is the user-facing input type.
+type PostArticleInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+	Slug string
+	Title string
+	Date string
+	Tags []string
+	Body []string
+	Position int
+	Total int
+	Base string
+	PrevSlug string
+	PrevTitle string
+	NextSlug string
+	NextTitle string
+}
+
+// PostArticleProps is the props type for the PostArticle component.
+type PostArticleProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Slug string `json:"slug"`
+	Title string `json:"title"`
+	Date string `json:"date"`
+	Tags []string `json:"tags"`
+	Body []string `json:"body"`
+	Position int `json:"position"`
+	Total int `json:"total"`
+	Base string `json:"base"`
+	PrevSlug string `json:"prevSlug"`
+	PrevTitle string `json:"prevTitle"`
+	NextSlug string `json:"nextSlug"`
+	NextTitle string `json:"nextTitle"`
+	LikeButtonSlot9 LikeButtonProps `json:"-"`
+	ReadingTimerSlot10 ReadingTimerProps `json:"-"`
+	NowPlayingSlot11 NowPlayingProps `json:"-"`
+}
+
+// Item represents a item.
+type Item struct {
+	Slug string `json:"slug"`
+	Title string `json:"title"`
+	Date string `json:"date"`
+	Tags []string `json:"tags"`
+	Meta string `json:"meta"`
+}
+
+// SortKey is a string type.
+type SortKey = string
+
+// PostListInput is the user-facing input type.
+type PostListInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+	SearchParams bf.SearchParams // Optional: request query for searchParams()
+	Items []Item
+	Tags []string
+	Base string
+}
+
+// PostListProps is the props type for the PostList component.
+type PostListProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	SearchParams bf.SearchParams `json:"-"`
+	Items []Item `json:"items"`
+	Tags []string `json:"tags"`
+	Base string `json:"base"`
+	Params map[string]interface{} `json:"params"`
+	Visible map[string]interface{} `json:"visible"`
+	Root string `json:"-"`
+	PostListItems []PostListItemProps `json:"-"`
+}
+
+// PostListItemInput is the user-facing input type.
+type PostListItemInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+	Href string
+	Title string
+	Date string
+	Meta string
+}
+
+// PostListItemProps is the props type for the PostListItem component.
+type PostListItemProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Href string `json:"href"`
+	Title string `json:"title"`
+	Date string `json:"date"`
+	Meta string `json:"meta"`
+	Pinned bool `json:"pinned"`
+}
+
+// ReaderToolbarInput is the user-facing input type.
+type ReaderToolbarInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// ReaderToolbarProps is the props type for the ReaderToolbar component.
+type ReaderToolbarProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Level int `json:"level"`
+}
+
+// ReadingTimerInput is the user-facing input type.
+type ReadingTimerInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// ReadingTimerProps is the props type for the ReadingTimer component.
+type ReadingTimerProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Secs int `json:"secs"`
+}
+
+// SidebarInput is the user-facing input type.
+type SidebarInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// SidebarProps is the props type for the Sidebar component.
+type SidebarProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Pins int `json:"pins"`
+}
+
+// ThemeToggleInput is the user-facing input type.
+type ThemeToggleInput struct {
+	ScopeID string // Optional: if empty, random ID is generated
+	BfParent string // Optional: parent scope id
+	BfMount string // Optional: slot id in parent
+}
+
+// ThemeToggleProps is the props type for the ThemeToggle component.
+type ThemeToggleProps struct {
+	ScopeID string `json:"scopeID"`
+	BfIsRoot bool `json:"-"`
+	BfIsChild bool `json:"-"`
+	BfParent string `json:"-"`
+	BfMount string `json:"-"`
+	BfDataKey string `json:"-"`
+	Scripts *bf.ScriptCollector `json:"-"`
+	Light bool `json:"light"`
+}
+
 // NewAIChatInteractiveProps creates AIChatInteractiveProps from AIChatInteractiveInput.
 func NewAIChatInteractiveProps(in AIChatInteractiveInput) AIChatInteractiveProps {
 	scopeID := in.ScopeID
@@ -717,5 +968,213 @@ func NewToggleProps(in ToggleInput) ToggleProps {
 		BfParent: in.BfParent,
 		BfMount: in.BfMount,
 		ToggleItems: toggleItems,
+	}
+}
+
+// NewLikeButtonProps creates LikeButtonProps from LikeButtonInput.
+func NewLikeButtonProps(in LikeButtonInput) LikeButtonProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "LikeButton_" + randomID(6)
+	}
+
+	return LikeButtonProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Likes: 0,
+	}
+}
+
+// NewNowPlayingProps creates NowPlayingProps from NowPlayingInput.
+func NewNowPlayingProps(in NowPlayingInput) NowPlayingProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "NowPlaying_" + randomID(6)
+	}
+
+	return NowPlayingProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Playing: false,
+		Elapsed: 0,
+	}
+}
+
+// NewPageShellProps creates PageShellProps from PageShellInput.
+func NewPageShellProps(in PageShellInput) PageShellProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "PageShell_" + randomID(6)
+	}
+
+	return PageShellProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Children: in.Children,
+		ReaderToolbarSlot0: NewReaderToolbarProps(ReaderToolbarInput{
+			ScopeID: scopeID + "_s0",
+			BfParent: scopeID,
+			BfMount: "s0",
+		}),
+	}
+}
+
+// NewPostArticleProps creates PostArticleProps from PostArticleInput.
+func NewPostArticleProps(in PostArticleInput) PostArticleProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "PostArticle_" + randomID(6)
+	}
+
+	return PostArticleProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Slug: in.Slug,
+		Title: in.Title,
+		Date: in.Date,
+		Tags: in.Tags,
+		Body: in.Body,
+		Position: in.Position,
+		Total: in.Total,
+		Base: in.Base,
+		PrevSlug: in.PrevSlug,
+		PrevTitle: in.PrevTitle,
+		NextSlug: in.NextSlug,
+		NextTitle: in.NextTitle,
+		LikeButtonSlot9: NewLikeButtonProps(LikeButtonInput{
+			ScopeID: scopeID + "_s9",
+			BfParent: scopeID,
+			BfMount: "s9",
+		}),
+		ReadingTimerSlot10: NewReadingTimerProps(ReadingTimerInput{
+			ScopeID: scopeID + "_s10",
+			BfParent: scopeID,
+			BfMount: "s10",
+		}),
+		NowPlayingSlot11: NewNowPlayingProps(NowPlayingInput{
+			ScopeID: scopeID + "_s11",
+			BfParent: scopeID,
+			BfMount: "s11",
+		}),
+	}
+}
+
+// NewPostListProps creates PostListProps from PostListInput.
+//
+// NOTE: `PostListItems` is populated by the route handler, not by
+// NewPostListProps — the SSR template iterates over it
+// dynamically (`.PostListItems`). Build the slice from your source data and
+// assign it before passing the props to your renderer. Example:
+//
+//   props := NewPostListProps(PostListInput{ /* ... */ })
+//   props.PostListItems = make([]PostListItemProps, len(items))
+//   for i, item := range items {
+//     props.PostListItems[i] = NewPostListItemProps(PostListItemInput{ /* fields */ })
+//     props.PostListItems[i].BfParent = props.ScopeID
+//     props.PostListItems[i].BfMount = "s13"
+//   }
+func NewPostListProps(in PostListInput) PostListProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "PostList_" + randomID(6)
+	}
+
+	return PostListProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		SearchParams: in.SearchParams,
+		Items: in.Items,
+		Tags: in.Tags,
+		Base: in.Base,
+		Params: map[string]interface{}{
+		"Sort": func() string { if bf.Includes([]string{"date", "title", "tag"}, in.SearchParams.Get("sort")) { return in.SearchParams.Get("sort") }; return "date" }(),
+		"Tag": in.SearchParams.Get("tag"),
+	},
+		Visible: nil,
+		Root: func() string { v := strings.TrimRight(in.Base, "/"); if v != "" { return v }; return "/" }(),
+	}
+}
+
+// NewPostListItemProps creates PostListItemProps from PostListItemInput.
+func NewPostListItemProps(in PostListItemInput) PostListItemProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "PostListItem_" + randomID(6)
+	}
+
+	return PostListItemProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Href: in.Href,
+		Title: in.Title,
+		Date: in.Date,
+		Meta: in.Meta,
+		Pinned: false,
+	}
+}
+
+// NewReaderToolbarProps creates ReaderToolbarProps from ReaderToolbarInput.
+func NewReaderToolbarProps(in ReaderToolbarInput) ReaderToolbarProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "ReaderToolbar_" + randomID(6)
+	}
+
+	return ReaderToolbarProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Level: 1,
+	}
+}
+
+// NewReadingTimerProps creates ReadingTimerProps from ReadingTimerInput.
+func NewReadingTimerProps(in ReadingTimerInput) ReadingTimerProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "ReadingTimer_" + randomID(6)
+	}
+
+	return ReadingTimerProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Secs: 0,
+	}
+}
+
+// NewSidebarProps creates SidebarProps from SidebarInput.
+func NewSidebarProps(in SidebarInput) SidebarProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "Sidebar_" + randomID(6)
+	}
+
+	return SidebarProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Pins: 0,
+	}
+}
+
+// NewThemeToggleProps creates ThemeToggleProps from ThemeToggleInput.
+func NewThemeToggleProps(in ThemeToggleInput) ThemeToggleProps {
+	scopeID := in.ScopeID
+	if scopeID == "" {
+		scopeID = "ThemeToggle_" + randomID(6)
+	}
+
+	return ThemeToggleProps{
+		ScopeID: scopeID,
+		BfParent: in.BfParent,
+		BfMount: in.BfMount,
+		Light: false,
 	}
 }

--- a/integrations/gin/e2e/blog.spec.ts
+++ b/integrations/gin/e2e/blog.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect, type Page } from '@playwright/test'
+
+// The blog sub-app is mounted under the integration's base path. The shared
+// blog islands + the client router are backend-agnostic, so this spec mirrors
+// the Hono integration's blog.spec.ts — only the mount path differs.
+const BLOG = '/integrations/gin/blog'
+
+// The partial-navigation flows below fetch + swap pages, drive intervals, and
+// wait on timers, so they need more headroom than the catalog specs' 5s global.
+test.describe('blog — @barefootjs/router showcase', () => {
+  test.describe.configure({ timeout: 15000 })
+
+  // Tag a live node with an identity marker; read it back to tell a surviving
+  // node (region kept) from a freshly rendered one (region swapped).
+  const mark = (page: Page, sel: string) =>
+    page.$eval(sel, (el) => {
+      ;(el as unknown as { __mark?: string }).__mark = 'KEEP'
+    })
+  const marker = (page: Page, sel: string) =>
+    page.$eval(sel, (el) => (el as unknown as { __mark?: string }).__mark).catch(() => null)
+
+  test('v0.5: sort/tag is a query-only update with no region swap', async ({ page }) => {
+    await page.goto(BLOG, { waitUntil: 'networkidle' })
+    await expect(page.locator('.sortable-list li')).toHaveCount(10)
+    await mark(page, '.content') // the list root — a region swap would replace it
+    await page.click('.controls a.sort:has-text("title")')
+    await page.waitForTimeout(150)
+    const first = await page.locator('.sortable-list li:first-child .item-link').innerText()
+    expect(first[0] === 'A' || first[0] === 'B').toBe(true)
+    expect(await marker(page, '.content')).toBe('KEEP') // not swapped
+    expect(page.url()).toContain('sort=title')
+  })
+
+  test('v0: clicking a post swaps the content region; shell + theme persist', async ({ page }) => {
+    await page.goto(BLOG, { waitUntil: 'networkidle' })
+    await page.click('.toggle')
+    const theme = await page.getAttribute('html', 'data-theme')
+    await page.click('.sortable-list li:first-child .item-link')
+    await page.waitForSelector('.island.like', { timeout: 3000 })
+    expect(await page.locator('.island.like').count()).toBe(1)
+    expect(await page.getAttribute('html', 'data-theme')).toBe(theme) // shell never reloaded
+    await page.click('.island.like')
+    expect(await page.locator('.island.like .v').innerText()).toBe('1')
+  })
+
+  test('v1: data-bf-permanent keeps the player live across a post→post swap', async ({ page }) => {
+    await page.goto(BLOG, { waitUntil: 'networkidle' })
+    await page.click('.sortable-list li:first-child .item-link')
+    await page.waitForSelector('.now-playing-bar', { timeout: 3000 })
+    await page.click('.now-playing-bar .np-toggle') // ▶ play
+    await page.waitForTimeout(900)
+    const before = Number(await page.locator('.now-playing-bar .np-time').innerText())
+    expect(before).toBeGreaterThan(0.4)
+    await mark(page, '[data-bf-permanent="now-playing"]')
+    await page.click('.pager a.pager-link[href*="/posts/"]')
+    await page.waitForTimeout(400)
+    expect(await marker(page, '[data-bf-permanent="now-playing"]')).toBe('KEEP') // same live node
+    expect(Number(await page.locator('.now-playing-bar .np-time').innerText())).toBeGreaterThanOrEqual(before)
+    expect(Number(await page.locator('.island.timer .v').innerText())).toBeLessThan(0.5) // unmarked timer reset
+    // post → index ("← All posts"): the player is also data-bf-permanent on the
+    // list, so the same live node survives returning to the index — not reset.
+    const elapsed = Number(await page.locator('.now-playing-bar .np-time').innerText())
+    await page.click('.post .back')
+    await page.waitForSelector('.sortable-list li', { timeout: 3000 })
+    expect(await marker(page, '[data-bf-permanent="now-playing"]')).toBe('KEEP') // same live node on the index
+    expect(Number(await page.locator('.now-playing-bar .np-time').innerText())).toBeGreaterThanOrEqual(elapsed)
+  })
+
+  test('v2 sibling: the sidebar region persists while content swaps', async ({ page }) => {
+    await page.goto(BLOG, { waitUntil: 'networkidle' })
+    await page.click('.sidebar-pin')
+    await page.click('.sidebar-pin')
+    expect(await page.locator('.sidebar-pin .v').innerText()).toBe('2')
+    await mark(page, 'aside[bf-region] .sidebar')
+    await page.click('.sortable-list li:first-child .item-link')
+    await page.waitForSelector('.island.like', { timeout: 3000 })
+    expect(await page.locator('.sidebar-pin .v').innerText()).toBe('2') // state survived
+    expect(await marker(page, 'aside[bf-region] .sidebar')).toBe('KEEP') // same node
+  })
+
+  test('v2 nested: the outer toolbar region persists while the inner content swaps', async ({ page }) => {
+    await page.goto(BLOG, { waitUntil: 'networkidle' })
+    await page.click('.reader-toolbar .rt-btn[aria-label="larger"]')
+    await page.click('.reader-toolbar .rt-btn[aria-label="larger"]')
+    expect(await page.locator('.reader-toolbar .v').innerText()).toBe('3')
+    await mark(page, '.reader-toolbar')
+    await page.click('.sortable-list li:first-child .item-link')
+    await page.waitForSelector('.island.like', { timeout: 3000 })
+    expect(await page.locator('.reader-toolbar .v').innerText()).toBe('3') // outer region kept
+    expect(await marker(page, '.reader-toolbar')).toBe('KEEP') // same node
+  })
+})

--- a/integrations/gin/main.go
+++ b/integrations/gin/main.go
@@ -56,6 +56,21 @@ func loadTemplates() *template.Template {
 	return root
 }
 
+// baseTemplates is the parsed template set, kept so the blog renderer (which
+// composes several islands via RenderFragment) can build its own bf.Renderer
+// without re-parsing in production. In dev, currentTemplates re-parses per
+// request so build:watch rebuilds show on refresh.
+var baseTemplates *template.Template
+
+// currentTemplates returns the parsed templates: re-parsed per call in dev so
+// `bun run build:watch` rebuilds appear on reload, the cached set otherwise.
+func currentTemplates() *template.Template {
+	if isDevEnv() {
+		return loadTemplates()
+	}
+	return baseTemplates
+}
+
 // isDevEnv reports whether the process is running in development.
 func isDevEnv() bool {
 	return bfdev.IsDevDefault()
@@ -228,7 +243,8 @@ func main() {
 		}
 	}
 	layoutFn = layout
-	renderer = bf.NewRenderer(loadTemplates(), layout)
+	baseTemplates = loadTemplates()
+	renderer = bf.NewRenderer(baseTemplates, layout)
 
 	r := gin.Default()
 
@@ -247,6 +263,11 @@ func main() {
 	g.GET("/conditional-return-link", conditionalReturnLinkHandler)
 	g.GET("/ai-chat", aiChatHandler)
 	g.GET("/api/ai-chat", aiChatSSEHandler)
+
+	// Blog — the @barefootjs/router showcase (partial navigation across a
+	// region shell), mounted under ${basePath}/blog.
+	g.GET("/blog", blogIndexHandler)
+	g.GET("/blog/posts/:slug", blogPostHandler)
 
 	// Todo API endpoints
 	g.GET("/api/todos", getTodosAPI)
@@ -285,7 +306,8 @@ func indexHandler(c *gin.Context) {
         <li><a href="%s/todos">Todo (@client)</a></li>
         <li><a href="%s/todos-ssr">Todo (no @client markers)</a></li>
         <li><a href="%s/ai-chat">AI Chat (SSE Streaming)</a></li>
-    </ul>`, basePath, basePath, basePath, basePath, basePath)
+        <li><a href="%s/blog">Blog (@barefootjs/router — partial navigation)</a></li>
+    </ul>`, basePath, basePath, basePath, basePath, basePath, basePath)
 
 	c.Data(http.StatusOK, "text/html; charset=utf-8", []byte(fmt.Sprintf(`<!DOCTYPE html>
 <html lang="en" class="dark">

--- a/integrations/gin/package.json
+++ b/integrations/gin/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/copy-shared.ts",
+    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/build-client.ts && bun run scripts/copy-shared.ts",
     "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
     "dev": "APP_ENV=development BASE_PATH=/integrations/gin go run .",
     "setup": "go mod tidy",
@@ -18,6 +18,8 @@
     "@cloudflare/workers-types": "^4",
     "@playwright/test": "^1.41.0",
     "bun-types": "^1.1.0",
-    "wrangler": "^4"
+    "wrangler": "^4",
+    "@barefootjs/client": "workspace:*",
+    "@barefootjs/router": "workspace:*"
   }
 }

--- a/integrations/gin/scripts/build-client.ts
+++ b/integrations/gin/scripts/build-client.ts
@@ -1,0 +1,38 @@
+/**
+ * Bundle the browser-side bootstrap (`router-entry.js`) into `dist/client/`,
+ * next to the `barefoot.js` runtime and the compiled islands, so the single
+ * static base (`/static/client/`) serves everything.
+ *
+ * `@barefootjs/client*` is kept external so it resolves through the page's
+ * import map to the same `barefoot.js` the compiled islands import via the
+ * relative `./barefoot.js` — one reactive runtime instance, so `searchParams()`
+ * is a single shared signal and the router's `__bf_pushSearch` push reaches the
+ * islands' effects. The router core and `@barefootjs/shared` are inlined.
+ */
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(HERE, '..')
+const CLIENT_EXTERNAL = [
+  '@barefootjs/client',
+  '@barefootjs/client/runtime',
+  '@barefootjs/client/reactive',
+]
+
+async function bundle(entry: string, external: string[], label: string): Promise<void> {
+  const result = await Bun.build({
+    entrypoints: [resolve(ROOT, entry)],
+    outdir: resolve(ROOT, 'dist/client'),
+    format: 'esm',
+    target: 'browser',
+    external,
+  })
+  if (!result.success) {
+    for (const log of result.logs) console.error(log)
+    process.exit(1)
+  }
+  console.log(`Generated: ${label}`)
+}
+
+await bundle('client/router-entry.ts', CLIENT_EXTERNAL, 'client/router-entry.js')


### PR DESCRIPTION
## Summary

Ports the `@barefootjs/router` blog showcase to the **Gin** integration. Second of the 3-PR stack (echo → **gin** → nethttp); **stacked on #1949** (base `claude/go-blog-echo`).

The shared blog islands under `integrations/shared/blog` are compiled by Gin's `bf build`. The framework-agnostic pieces are identical to Chi/Echo; only the handler signatures and route wiring are Gin-specific.

## Changes (`integrations/gin`)

- **`blog.go`** — region-shell layout + `/blog` (PostList + NowPlaying, `?sort=`/`?tag=` resolved server-side) and `/blog/posts/:slug` (PostArticle) handlers. Every island composed through `bf.Renderer.RenderFragment` against one shared script/portal collector. Handlers use `*gin.Context` (`c.Param`, `c.Data`, `c.Request.URL.RawQuery`).
- **`blog_data.go`** — posts data + SSR sort/filter (identical to Chi).
- **`client/router-entry.ts`** + **`scripts/build-client.ts`** — client router bundle.
- **`barefoot.config.ts` / `package.json` / `main.go`** — compile the blog components, add `baseTemplates` + `currentTemplates`, register routes, link the bundle, add the index link.
- **`e2e/blog.spec.ts`** — the Chi blog spec under the Gin base path.

**No adapter changes** — the Go template adapter fixes landed with the Chi PR (#1948).

## Testing

Manual SSR verification (Gin): `/blog` 200 with 10 rows, `?tag=perf` → 3, `?sort=title` reorders, post page 200, bad slug 404, rows carry `bf-h`/`bf-m="s13"`, NowPlaying renders (no error panels). `go vet` + `gofmt` clean, build green (21 compiled, 0 errors).

> Note: review/merge #1949 (Echo) first; this PR's diff resolves to just the Gin files once its base lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JT4Rcc5b1qcMStCJfmD3V1)_