### PR TITLE
Go blog: load data from the shared corpus + walk the article pager in list order

### DIFF
--- a/integrations/chi/blog.go
+++ b/integrations/chi/blog.go
@@ -252,33 +252,27 @@ func blogIndexHandler(w http.ResponseWriter, req *http.Request) {
 // NowPlaying), so the markup comes from post data, not hand-authored HTML.
 func blogPostHandler(w http.ResponseWriter, req *http.Request) {
 	slug := chi.URLParam(req, "slug")
-	i := blogPostIndex(slug)
-	if i < 0 {
+	a := blogArticleFor(slug)
+	if !a.Found {
 		http.NotFound(w, req)
 		return
 	}
-	p := blogPosts[i]
-
 	in := PostArticleInput{
-		Slug:     p.Slug,
-		Title:    p.Title,
-		Date:     p.Date,
-		Tags:     p.Tags,
-		Body:     p.Body,
-		Position: i + 1,
-		Total:    len(blogPosts),
-		Base:     blogBasePath(),
-	}
-	if i > 0 {
-		in.PrevSlug = blogPosts[i-1].Slug
-		in.PrevTitle = blogPosts[i-1].Title
-	}
-	if i < len(blogPosts)-1 {
-		in.NextSlug = blogPosts[i+1].Slug
-		in.NextTitle = blogPosts[i+1].Title
+		Slug:      a.Post.Slug,
+		Title:     a.Post.Title,
+		Date:      a.Post.Date,
+		Tags:      a.Post.Tags,
+		Body:      a.Post.Body,
+		Position:  a.Position,
+		Total:     a.Total,
+		Base:      blogBasePath(),
+		PrevSlug:  a.PrevSlug,
+		PrevTitle: a.PrevTitle,
+		NextSlug:  a.NextSlug,
+		NextTitle: a.NextTitle,
 	}
 
-	html := blogPageHTML(p.Title+" — Barefoot Blog", func(frag blogFrag) template.HTML {
+	html := blogPageHTML(a.Post.Title+" — Barefoot Blog", func(frag blogFrag) template.HTML {
 		props := NewPostArticleProps(in)
 		return frag("PostArticle", &props)
 	})

--- a/integrations/chi/blog_data.go
+++ b/integrations/chi/blog_data.go
@@ -67,12 +67,36 @@ func blogMeta(p BlogPost) string {
 	return fmt.Sprintf("%s · %s", p.Date, strings.Join(tags, " "))
 }
 
-// blogPostIndex returns the index of the post with the given slug, or -1.
-func blogPostIndex(slug string) int {
-	for i, p := range blogPosts {
-		if p.Slug == slug {
-			return i
+// blogArticle is everything a post page needs, with its pager neighbours
+// computed in the index's default display order (date descending — newest
+// first) rather than the authored corpus order (oldest-first). That way the
+// article pager walks DOWN the list the reader is browsing: "next" is the post
+// below in the list, "prev" the post above. The newest post (top of the list)
+// thus gets a real "next" instead of falling off the end into "back to list".
+type blogArticle struct {
+	Post                BlogPost
+	Position, Total     int
+	PrevSlug, PrevTitle string
+	NextSlug, NextTitle string
+	Found               bool
+}
+
+// blogArticleFor looks up a post by slug and computes its pager neighbours in
+// the default list order (date descending). Found is false for an unknown slug.
+func blogArticleFor(slug string) blogArticle {
+	ordered := blogVisible("date", "")
+	for pos, q := range ordered {
+		if q.Slug != slug {
+			continue
 		}
+		a := blogArticle{Post: q, Position: pos + 1, Total: len(ordered), Found: true}
+		if pos > 0 {
+			a.PrevSlug, a.PrevTitle = ordered[pos-1].Slug, ordered[pos-1].Title
+		}
+		if pos < len(ordered)-1 {
+			a.NextSlug, a.NextTitle = ordered[pos+1].Slug, ordered[pos+1].Title
+		}
+		return a
 	}
-	return -1
+	return blogArticle{}
 }

--- a/integrations/chi/blog_data.go
+++ b/integrations/chi/blog_data.go
@@ -1,154 +1,64 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
-	"sort"
+	"os"
 	"strings"
 )
 
-// BlogPost is the source post data for the blog showcase, ported from the
-// shared TS source `integrations/shared/blog/posts.ts`. The JS integrations
-// (Hono / h3 / Elysia) import that module directly; the Go integration keeps a
-// byte-identical copy here so the same shared islands render the same markup.
+// BlogPost is one post from the shared corpus.
 type BlogPost struct {
-	Slug    string
-	Title   string
-	Date    string
-	Tags    []string
-	Excerpt string
-	Body    []string
+	Slug    string   `json:"slug"`
+	Title   string   `json:"title"`
+	Date    string   `json:"date"`
+	Tags    []string `json:"tags"`
+	Excerpt string   `json:"excerpt"`
+	Body    []string `json:"body"`
 }
 
-// blogPosts mirrors `posts` in posts.ts, in the same order.
-var blogPosts = []BlogPost{
-	{
-		Slug:    "partial-navigation",
-		Title:   "Partial navigation, without a SPA framework",
-		Date:    "2026-06-01",
-		Tags:    []string{"design", "runtime"},
-		Excerpt: `Swap only the content region and leave the shell mounted — no virtual DOM, no full rebuild.`,
-		Body: []string{
-			`Most "SPA feel" comes down to one trick: when you follow a link, replace only the part of the page that changed and keep everything else where it is.`,
-			`BarefootJS already renders on the server and hydrates islands in place. The router adds the missing piece — intercept the link, fetch the next page, swap just the content outlet, re-hydrate.`,
-			`The header you are reading this in never reloads. Watch the live counters as you move between posts.`,
-		},
-	},
-	{
-		Slug:    "any-backend",
-		Title:   "Any backend, zero cooperation required",
-		Date:    "2026-06-03",
-		Tags:    []string{"backend", "design"},
-		Excerpt: `The server just returns HTML. The router pulls the outlet out of the response on the client.`,
-		Body: []string{
-			`There is no special protocol to implement. This blog is a plain Hono server returning HTML strings.`,
-			`The router sends no content-negotiation header: it just fetches the page and pulls the outlet out of the response on the client.`,
-			`That is why the same approach works against Go, Perl, or any other backend the adapters target — the server stays a plain HTML server.`,
-		},
-	},
-	{
-		Slug:    "islands-stay-alive",
-		Title:   "Islands in the shell stay alive",
-		Date:    "2026-06-05",
-		Tags:    []string{"islands", "runtime"},
-		Excerpt: `Anything outside the outlet keeps its state: open menus, playing media, live counters, theme.`,
-		Body: []string{
-			`Because only the outlet is replaced, every interactive island in the surrounding shell survives a navigation untouched.`,
-			`The uptime timer in the header was started once, on first load. Full reloads would reset it. It does not.`,
-			`Toggle the theme switch up there, then navigate — the choice sticks because the shell was never torn down.`,
-		},
-	},
-	{
-		Slug:    "reuses-the-runtime",
-		Title:   "It reuses the runtime you already ship",
-		Date:    "2026-06-08",
-		Tags:    []string{"runtime", "design"},
-		Excerpt: `Re-hydration after a swap goes through the same walk the streaming primitive uses.`,
-		Body: []string{
-			`After the outlet is swapped, the freshly inserted islands need to hydrate. The router calls the same re-hydration walk the streaming primitive already uses.`,
-			`New islands light up; the shell is left alone. The router package is tiny because the heavy lifting already lives in the runtime.`,
-			`The like button and "time on page" timer below are outlet islands — they are re-created on every navigation, and torn down when you leave.`,
-		},
-	},
-	{
-		Slug:    "disposal-is-the-hard-part",
-		Title:   "Disposal is the hard part",
-		Date:    "2026-06-10",
-		Tags:    []string{"runtime", "perf"},
-		Excerpt: `Outgoing islands must release timers and listeners or they leak. The stress test measures it.`,
-		Body: []string{
-			`Swapping HTML in is easy. The subtle work is tearing the OLD islands down — their intervals, listeners, and subscriptions.`,
-			`This demo wires a dispose hook that clears each outlet island on the way out. With it off, the per-page timers keep firing forever.`,
-			`That is exactly why precise per-scope disposal is the router prototype's next step.`,
-		},
-	},
-	{
-		Slug:    "history-back-forward",
-		Title:   "Back and forward, done right",
-		Date:    "2026-06-12",
-		Tags:    []string{"history", "design"},
-		Excerpt: `popstate swaps the outlet to match the URL without pushing duplicate entries.`,
-		Body: []string{
-			`A client router lives or dies on the back button. On popstate the router swaps the outlet to match the new URL — without recording a fresh history entry.`,
-			`The stress harness walks forward through several posts then mashes Back, asserting the content matches the URL at every step.`,
-			`Scroll restoration on back/forward is a known gap — the router resets to the top for now.`,
-		},
-	},
-	{
-		Slug:    "rapid-fire",
-		Title:   "Rapid-fire clicks and the last-wins rule",
-		Date:    "2026-06-14",
-		Tags:    []string{"perf", "runtime"},
-		Excerpt: `Spam the links: the latest navigation must win even if an earlier response resolves last.`,
-		Body: []string{
-			`Users double-click. They click B before A has loaded. The router aborts the in-flight request and bails after each await, so the latest target always wins.`,
-			`The stress harness forces a slow response, then navigates away, and asserts the stale content never lands.`,
-			`This was a real race in the first cut — the prototype now has a regression test for it.`,
-		},
-	},
-	{
-		Slug:    "query-string-nav",
-		Title:   "Filtering by tag is just navigation",
-		Date:    "2026-06-16",
-		Tags:    []string{"design", "backend"},
-		Excerpt: `Same path, different query string — the outlet swaps just like any other link.`,
-		Body: []string{
-			`Tag filters on the index are plain links to ?tag=x. To the router they are ordinary same-origin navigations.`,
-			`The outlet swaps to the filtered list; the shell and its theme stay put.`,
-			`Hash-only links, in contrast, are left to the browser so in-page anchors keep working.`,
-		},
-	},
-	{
-		Slug:    "no-fragment-negotiation",
-		Title:   "Why there is no fragment negotiation",
-		Date:    "2026-06-18",
-		Tags:    []string{"backend", "perf"},
-		Excerpt: `Returning just the outlet fragment was considered and dropped — it shaves compressible markup but hurts caching.`,
-		Body: []string{
-			`A "smaller" fragment response only removes the shell markup, which gzip already compresses to almost nothing — while making the same URL return two different bodies, so it needs a Vary header that fragments the cache.`,
-			`It would also force every fragment to re-include its island <script type="module"> tags and <title>, or navigated-to islands go inert.`,
-			`The cost that actually matters is the round-trip, not the byte count — so the effort goes into prefetch, and the server stays a plain, cacheable HTML server.`,
-		},
-	},
-	{
-		Slug:    "where-this-goes",
-		Title:   "Where this goes next",
-		Date:    "2026-06-20",
-		Tags:    []string{"design", "islands"},
-		Excerpt: `Compiler-derived outlets, morph for persistent islands, prefetch on hover, snapshot cache.`,
-		Body: []string{
-			`The outlet is authored by hand today. The end state is the compiler deriving it from the component tree.`,
-			`Add idiomorph-style morphing and data-bf-permanent for islands that should survive a swap, plus hover prefetch and a snapshot cache for instant back/forward.`,
-			`This is the last post — loop back to the start from the navigation below.`,
-		},
-	},
+// blogDataFile is the shape of dist/blog-data.json, generated at build time by
+// scripts/gen-blog-data.ts from the single shared corpus
+// (../shared/blog/posts.ts) — the same source the JS adapters import and the
+// Perl integrations read. The Go corpus is no longer hand-transcribed.
+type blogDataFile struct {
+	Posts     []BlogPost `json:"posts"`
+	ListItems []Item     `json:"listItems"`
+	AllTags   []string   `json:"allTags"`
 }
 
-// blogMeta renders the index list's pre-computed `meta` line (`<date> · #tag
-// #tag`), matching `listItems[].meta` in posts.ts. It is computed here, NOT in
-// the PostList island, on purpose: building it in the island needs a
-// value-producing tag-map-join that the template-string adapters (Go included)
-// can't lower for SSR. Pre-computing it upstream keeps the island's template a
-// plain member access so the same shared component compiles on every adapter.
+// blogData is loaded once at process start. A missing / unreadable file yields
+// an empty corpus (the blog renders empty) rather than crashing the whole
+// server, matching the Perl integration's graceful fallback.
+var blogData = loadBlogData()
+
+func loadBlogData() blogDataFile {
+	b, err := os.ReadFile("dist/blog-data.json")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "barefoot: blog data not found (run `bun run build`): %v\n", err)
+		return blogDataFile{}
+	}
+	var d blogDataFile
+	if err := json.Unmarshal(b, &d); err != nil {
+		fmt.Fprintf(os.Stderr, "barefoot: blog data parse error: %v\n", err)
+		return blogDataFile{}
+	}
+	return d
+}
+
+// blogPosts is the post corpus.
+var blogPosts = blogData.Posts
+
+// blogListItems returns the index-list items with pre-rendered `meta`, derived
+// upstream in posts.ts so every adapter renders identical markup.
+func blogListItems() []Item { return blogData.ListItems }
+
+// blogAllTags returns the sorted, de-duplicated tag set.
+func blogAllTags() []string { return blogData.AllTags }
+
+// blogMeta renders the `<date> · #tag #tag` meta line for a post — the same
+// format posts.ts pre-computes into listItems[].meta, recomputed here for the
+// rows blogPostListItems builds from the sorted/filtered corpus.
 func blogMeta(p BlogPost) string {
 	tags := make([]string, len(p.Tags))
 	for i, t := range p.Tags {
@@ -157,41 +67,7 @@ func blogMeta(p BlogPost) string {
 	return fmt.Sprintf("%s · %s", p.Date, strings.Join(tags, " "))
 }
 
-// blogListItems derives the index-list items from blogPosts with `meta`
-// pre-rendered, mirroring `listItems` in posts.ts.
-func blogListItems() []Item {
-	items := make([]Item, len(blogPosts))
-	for i, p := range blogPosts {
-		items[i] = Item{
-			Slug:  p.Slug,
-			Title: p.Title,
-			Date:  p.Date,
-			Tags:  p.Tags,
-			Meta:  blogMeta(p),
-		}
-	}
-	return items
-}
-
-// blogAllTags returns the sorted, de-duplicated tag set across all posts,
-// mirroring `allTags` in posts.ts.
-func blogAllTags() []string {
-	seen := map[string]bool{}
-	var tags []string
-	for _, p := range blogPosts {
-		for _, t := range p.Tags {
-			if !seen[t] {
-				seen[t] = true
-				tags = append(tags, t)
-			}
-		}
-	}
-	sort.Strings(tags)
-	return tags
-}
-
-// blogPostIndex returns the index of the post with the given slug, or -1,
-// mirroring `postIndex` in posts.ts.
+// blogPostIndex returns the index of the post with the given slug, or -1.
 func blogPostIndex(slug string) int {
 	for i, p := range blogPosts {
 		if p.Slug == slug {

--- a/integrations/chi/package.json
+++ b/integrations/chi/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/build-client.ts && bun run scripts/copy-shared.ts",
+    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/gen-blog-data.ts && bun run scripts/build-client.ts && bun run scripts/copy-shared.ts",
     "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
     "dev": "APP_ENV=development BASE_PATH=/integrations/chi go run .",
     "setup": "go mod tidy",

--- a/integrations/chi/scripts/gen-blog-data.ts
+++ b/integrations/chi/scripts/gen-blog-data.ts
@@ -1,0 +1,25 @@
+/**
+ * Emit `dist/blog-data.json` for the Go blog routes.
+ *
+ * The shared blog islands (`../shared/blog/*`) are authored in TS and compiled
+ * to Go templates by `bf build`, but the *data* the index/post routes render
+ * (the post corpus, the derived list items with their pre-rendered `meta`, the
+ * tag set) lives in `../shared/blog/posts.ts` — TS the Go server can't import.
+ * Rather than hand-transcribe the corpus into Go (fragile, and the kind of
+ * duplication the showcase explicitly avoids), this build step imports the
+ * single source of truth and writes it as JSON that `blog_data.go` reads at
+ * startup. The TS adapters import `posts.ts` directly; the Go and Perl apps read
+ * this JSON — every backend stays in sync with one authored corpus.
+ */
+import { mkdir, writeFile } from 'node:fs/promises'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { posts, listItems, allTags } from '../../shared/blog/posts'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(HERE, '..')
+const OUT = resolve(ROOT, 'dist/blog-data.json')
+
+await mkdir(dirname(OUT), { recursive: true })
+await writeFile(OUT, JSON.stringify({ posts, listItems, allTags }, null, 0))
+console.log(`Generated: dist/blog-data.json (${posts.length} posts)`)

--- a/integrations/echo/blog.go
+++ b/integrations/echo/blog.go
@@ -245,32 +245,26 @@ func blogIndexHandler(c echo.Context) error {
 // NowPlaying), so the markup comes from post data, not hand-authored HTML.
 func blogPostHandler(c echo.Context) error {
 	slug := c.Param("slug")
-	i := blogPostIndex(slug)
-	if i < 0 {
+	a := blogArticleFor(slug)
+	if !a.Found {
 		return echo.NewHTTPError(http.StatusNotFound)
 	}
-	p := blogPosts[i]
-
 	in := PostArticleInput{
-		Slug:     p.Slug,
-		Title:    p.Title,
-		Date:     p.Date,
-		Tags:     p.Tags,
-		Body:     p.Body,
-		Position: i + 1,
-		Total:    len(blogPosts),
-		Base:     blogBasePath(),
-	}
-	if i > 0 {
-		in.PrevSlug = blogPosts[i-1].Slug
-		in.PrevTitle = blogPosts[i-1].Title
-	}
-	if i < len(blogPosts)-1 {
-		in.NextSlug = blogPosts[i+1].Slug
-		in.NextTitle = blogPosts[i+1].Title
+		Slug:      a.Post.Slug,
+		Title:     a.Post.Title,
+		Date:      a.Post.Date,
+		Tags:      a.Post.Tags,
+		Body:      a.Post.Body,
+		Position:  a.Position,
+		Total:     a.Total,
+		Base:      blogBasePath(),
+		PrevSlug:  a.PrevSlug,
+		PrevTitle: a.PrevTitle,
+		NextSlug:  a.NextSlug,
+		NextTitle: a.NextTitle,
 	}
 
-	html := blogPageHTML(p.Title+" — Barefoot Blog", func(frag blogFrag) template.HTML {
+	html := blogPageHTML(a.Post.Title+" — Barefoot Blog", func(frag blogFrag) template.HTML {
 		props := NewPostArticleProps(in)
 		return frag("PostArticle", &props)
 	})

--- a/integrations/echo/blog_data.go
+++ b/integrations/echo/blog_data.go
@@ -67,12 +67,36 @@ func blogMeta(p BlogPost) string {
 	return fmt.Sprintf("%s · %s", p.Date, strings.Join(tags, " "))
 }
 
-// blogPostIndex returns the index of the post with the given slug, or -1.
-func blogPostIndex(slug string) int {
-	for i, p := range blogPosts {
-		if p.Slug == slug {
-			return i
+// blogArticle is everything a post page needs, with its pager neighbours
+// computed in the index's default display order (date descending — newest
+// first) rather than the authored corpus order (oldest-first). That way the
+// article pager walks DOWN the list the reader is browsing: "next" is the post
+// below in the list, "prev" the post above. The newest post (top of the list)
+// thus gets a real "next" instead of falling off the end into "back to list".
+type blogArticle struct {
+	Post                BlogPost
+	Position, Total     int
+	PrevSlug, PrevTitle string
+	NextSlug, NextTitle string
+	Found               bool
+}
+
+// blogArticleFor looks up a post by slug and computes its pager neighbours in
+// the default list order (date descending). Found is false for an unknown slug.
+func blogArticleFor(slug string) blogArticle {
+	ordered := blogVisible("date", "")
+	for pos, q := range ordered {
+		if q.Slug != slug {
+			continue
 		}
+		a := blogArticle{Post: q, Position: pos + 1, Total: len(ordered), Found: true}
+		if pos > 0 {
+			a.PrevSlug, a.PrevTitle = ordered[pos-1].Slug, ordered[pos-1].Title
+		}
+		if pos < len(ordered)-1 {
+			a.NextSlug, a.NextTitle = ordered[pos+1].Slug, ordered[pos+1].Title
+		}
+		return a
 	}
-	return -1
+	return blogArticle{}
 }

--- a/integrations/echo/blog_data.go
+++ b/integrations/echo/blog_data.go
@@ -1,154 +1,64 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
-	"sort"
+	"os"
 	"strings"
 )
 
-// BlogPost is the source post data for the blog showcase, ported from the
-// shared TS source `integrations/shared/blog/posts.ts`. The JS integrations
-// (Hono / h3 / Elysia) import that module directly; the Go integration keeps a
-// byte-identical copy here so the same shared islands render the same markup.
+// BlogPost is one post from the shared corpus.
 type BlogPost struct {
-	Slug    string
-	Title   string
-	Date    string
-	Tags    []string
-	Excerpt string
-	Body    []string
+	Slug    string   `json:"slug"`
+	Title   string   `json:"title"`
+	Date    string   `json:"date"`
+	Tags    []string `json:"tags"`
+	Excerpt string   `json:"excerpt"`
+	Body    []string `json:"body"`
 }
 
-// blogPosts mirrors `posts` in posts.ts, in the same order.
-var blogPosts = []BlogPost{
-	{
-		Slug:    "partial-navigation",
-		Title:   "Partial navigation, without a SPA framework",
-		Date:    "2026-06-01",
-		Tags:    []string{"design", "runtime"},
-		Excerpt: `Swap only the content region and leave the shell mounted — no virtual DOM, no full rebuild.`,
-		Body: []string{
-			`Most "SPA feel" comes down to one trick: when you follow a link, replace only the part of the page that changed and keep everything else where it is.`,
-			`BarefootJS already renders on the server and hydrates islands in place. The router adds the missing piece — intercept the link, fetch the next page, swap just the content outlet, re-hydrate.`,
-			`The header you are reading this in never reloads. Watch the live counters as you move between posts.`,
-		},
-	},
-	{
-		Slug:    "any-backend",
-		Title:   "Any backend, zero cooperation required",
-		Date:    "2026-06-03",
-		Tags:    []string{"backend", "design"},
-		Excerpt: `The server just returns HTML. The router pulls the outlet out of the response on the client.`,
-		Body: []string{
-			`There is no special protocol to implement. This blog is a plain Hono server returning HTML strings.`,
-			`The router sends no content-negotiation header: it just fetches the page and pulls the outlet out of the response on the client.`,
-			`That is why the same approach works against Go, Perl, or any other backend the adapters target — the server stays a plain HTML server.`,
-		},
-	},
-	{
-		Slug:    "islands-stay-alive",
-		Title:   "Islands in the shell stay alive",
-		Date:    "2026-06-05",
-		Tags:    []string{"islands", "runtime"},
-		Excerpt: `Anything outside the outlet keeps its state: open menus, playing media, live counters, theme.`,
-		Body: []string{
-			`Because only the outlet is replaced, every interactive island in the surrounding shell survives a navigation untouched.`,
-			`The uptime timer in the header was started once, on first load. Full reloads would reset it. It does not.`,
-			`Toggle the theme switch up there, then navigate — the choice sticks because the shell was never torn down.`,
-		},
-	},
-	{
-		Slug:    "reuses-the-runtime",
-		Title:   "It reuses the runtime you already ship",
-		Date:    "2026-06-08",
-		Tags:    []string{"runtime", "design"},
-		Excerpt: `Re-hydration after a swap goes through the same walk the streaming primitive uses.`,
-		Body: []string{
-			`After the outlet is swapped, the freshly inserted islands need to hydrate. The router calls the same re-hydration walk the streaming primitive already uses.`,
-			`New islands light up; the shell is left alone. The router package is tiny because the heavy lifting already lives in the runtime.`,
-			`The like button and "time on page" timer below are outlet islands — they are re-created on every navigation, and torn down when you leave.`,
-		},
-	},
-	{
-		Slug:    "disposal-is-the-hard-part",
-		Title:   "Disposal is the hard part",
-		Date:    "2026-06-10",
-		Tags:    []string{"runtime", "perf"},
-		Excerpt: `Outgoing islands must release timers and listeners or they leak. The stress test measures it.`,
-		Body: []string{
-			`Swapping HTML in is easy. The subtle work is tearing the OLD islands down — their intervals, listeners, and subscriptions.`,
-			`This demo wires a dispose hook that clears each outlet island on the way out. With it off, the per-page timers keep firing forever.`,
-			`That is exactly why precise per-scope disposal is the router prototype's next step.`,
-		},
-	},
-	{
-		Slug:    "history-back-forward",
-		Title:   "Back and forward, done right",
-		Date:    "2026-06-12",
-		Tags:    []string{"history", "design"},
-		Excerpt: `popstate swaps the outlet to match the URL without pushing duplicate entries.`,
-		Body: []string{
-			`A client router lives or dies on the back button. On popstate the router swaps the outlet to match the new URL — without recording a fresh history entry.`,
-			`The stress harness walks forward through several posts then mashes Back, asserting the content matches the URL at every step.`,
-			`Scroll restoration on back/forward is a known gap — the router resets to the top for now.`,
-		},
-	},
-	{
-		Slug:    "rapid-fire",
-		Title:   "Rapid-fire clicks and the last-wins rule",
-		Date:    "2026-06-14",
-		Tags:    []string{"perf", "runtime"},
-		Excerpt: `Spam the links: the latest navigation must win even if an earlier response resolves last.`,
-		Body: []string{
-			`Users double-click. They click B before A has loaded. The router aborts the in-flight request and bails after each await, so the latest target always wins.`,
-			`The stress harness forces a slow response, then navigates away, and asserts the stale content never lands.`,
-			`This was a real race in the first cut — the prototype now has a regression test for it.`,
-		},
-	},
-	{
-		Slug:    "query-string-nav",
-		Title:   "Filtering by tag is just navigation",
-		Date:    "2026-06-16",
-		Tags:    []string{"design", "backend"},
-		Excerpt: `Same path, different query string — the outlet swaps just like any other link.`,
-		Body: []string{
-			`Tag filters on the index are plain links to ?tag=x. To the router they are ordinary same-origin navigations.`,
-			`The outlet swaps to the filtered list; the shell and its theme stay put.`,
-			`Hash-only links, in contrast, are left to the browser so in-page anchors keep working.`,
-		},
-	},
-	{
-		Slug:    "no-fragment-negotiation",
-		Title:   "Why there is no fragment negotiation",
-		Date:    "2026-06-18",
-		Tags:    []string{"backend", "perf"},
-		Excerpt: `Returning just the outlet fragment was considered and dropped — it shaves compressible markup but hurts caching.`,
-		Body: []string{
-			`A "smaller" fragment response only removes the shell markup, which gzip already compresses to almost nothing — while making the same URL return two different bodies, so it needs a Vary header that fragments the cache.`,
-			`It would also force every fragment to re-include its island <script type="module"> tags and <title>, or navigated-to islands go inert.`,
-			`The cost that actually matters is the round-trip, not the byte count — so the effort goes into prefetch, and the server stays a plain, cacheable HTML server.`,
-		},
-	},
-	{
-		Slug:    "where-this-goes",
-		Title:   "Where this goes next",
-		Date:    "2026-06-20",
-		Tags:    []string{"design", "islands"},
-		Excerpt: `Compiler-derived outlets, morph for persistent islands, prefetch on hover, snapshot cache.`,
-		Body: []string{
-			`The outlet is authored by hand today. The end state is the compiler deriving it from the component tree.`,
-			`Add idiomorph-style morphing and data-bf-permanent for islands that should survive a swap, plus hover prefetch and a snapshot cache for instant back/forward.`,
-			`This is the last post — loop back to the start from the navigation below.`,
-		},
-	},
+// blogDataFile is the shape of dist/blog-data.json, generated at build time by
+// scripts/gen-blog-data.ts from the single shared corpus
+// (../shared/blog/posts.ts) — the same source the JS adapters import and the
+// Perl integrations read. The Go corpus is no longer hand-transcribed.
+type blogDataFile struct {
+	Posts     []BlogPost `json:"posts"`
+	ListItems []Item     `json:"listItems"`
+	AllTags   []string   `json:"allTags"`
 }
 
-// blogMeta renders the index list's pre-computed `meta` line (`<date> · #tag
-// #tag`), matching `listItems[].meta` in posts.ts. It is computed here, NOT in
-// the PostList island, on purpose: building it in the island needs a
-// value-producing tag-map-join that the template-string adapters (Go included)
-// can't lower for SSR. Pre-computing it upstream keeps the island's template a
-// plain member access so the same shared component compiles on every adapter.
+// blogData is loaded once at process start. A missing / unreadable file yields
+// an empty corpus (the blog renders empty) rather than crashing the whole
+// server, matching the Perl integration's graceful fallback.
+var blogData = loadBlogData()
+
+func loadBlogData() blogDataFile {
+	b, err := os.ReadFile("dist/blog-data.json")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "barefoot: blog data not found (run `bun run build`): %v\n", err)
+		return blogDataFile{}
+	}
+	var d blogDataFile
+	if err := json.Unmarshal(b, &d); err != nil {
+		fmt.Fprintf(os.Stderr, "barefoot: blog data parse error: %v\n", err)
+		return blogDataFile{}
+	}
+	return d
+}
+
+// blogPosts is the post corpus.
+var blogPosts = blogData.Posts
+
+// blogListItems returns the index-list items with pre-rendered `meta`, derived
+// upstream in posts.ts so every adapter renders identical markup.
+func blogListItems() []Item { return blogData.ListItems }
+
+// blogAllTags returns the sorted, de-duplicated tag set.
+func blogAllTags() []string { return blogData.AllTags }
+
+// blogMeta renders the `<date> · #tag #tag` meta line for a post — the same
+// format posts.ts pre-computes into listItems[].meta, recomputed here for the
+// rows blogPostListItems builds from the sorted/filtered corpus.
 func blogMeta(p BlogPost) string {
 	tags := make([]string, len(p.Tags))
 	for i, t := range p.Tags {
@@ -157,41 +67,7 @@ func blogMeta(p BlogPost) string {
 	return fmt.Sprintf("%s · %s", p.Date, strings.Join(tags, " "))
 }
 
-// blogListItems derives the index-list items from blogPosts with `meta`
-// pre-rendered, mirroring `listItems` in posts.ts.
-func blogListItems() []Item {
-	items := make([]Item, len(blogPosts))
-	for i, p := range blogPosts {
-		items[i] = Item{
-			Slug:  p.Slug,
-			Title: p.Title,
-			Date:  p.Date,
-			Tags:  p.Tags,
-			Meta:  blogMeta(p),
-		}
-	}
-	return items
-}
-
-// blogAllTags returns the sorted, de-duplicated tag set across all posts,
-// mirroring `allTags` in posts.ts.
-func blogAllTags() []string {
-	seen := map[string]bool{}
-	var tags []string
-	for _, p := range blogPosts {
-		for _, t := range p.Tags {
-			if !seen[t] {
-				seen[t] = true
-				tags = append(tags, t)
-			}
-		}
-	}
-	sort.Strings(tags)
-	return tags
-}
-
-// blogPostIndex returns the index of the post with the given slug, or -1,
-// mirroring `postIndex` in posts.ts.
+// blogPostIndex returns the index of the post with the given slug, or -1.
 func blogPostIndex(slug string) int {
 	for i, p := range blogPosts {
 		if p.Slug == slug {

--- a/integrations/echo/package.json
+++ b/integrations/echo/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/build-client.ts && bun run scripts/copy-shared.ts",
+    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/gen-blog-data.ts && bun run scripts/build-client.ts && bun run scripts/copy-shared.ts",
     "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
     "dev": "APP_ENV=development BASE_PATH=/integrations/echo go run .",
     "setup": "go mod tidy",

--- a/integrations/echo/scripts/gen-blog-data.ts
+++ b/integrations/echo/scripts/gen-blog-data.ts
@@ -1,0 +1,25 @@
+/**
+ * Emit `dist/blog-data.json` for the Go blog routes.
+ *
+ * The shared blog islands (`../shared/blog/*`) are authored in TS and compiled
+ * to Go templates by `bf build`, but the *data* the index/post routes render
+ * (the post corpus, the derived list items with their pre-rendered `meta`, the
+ * tag set) lives in `../shared/blog/posts.ts` — TS the Go server can't import.
+ * Rather than hand-transcribe the corpus into Go (fragile, and the kind of
+ * duplication the showcase explicitly avoids), this build step imports the
+ * single source of truth and writes it as JSON that `blog_data.go` reads at
+ * startup. The TS adapters import `posts.ts` directly; the Go and Perl apps read
+ * this JSON — every backend stays in sync with one authored corpus.
+ */
+import { mkdir, writeFile } from 'node:fs/promises'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { posts, listItems, allTags } from '../../shared/blog/posts'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(HERE, '..')
+const OUT = resolve(ROOT, 'dist/blog-data.json')
+
+await mkdir(dirname(OUT), { recursive: true })
+await writeFile(OUT, JSON.stringify({ posts, listItems, allTags }, null, 0))
+console.log(`Generated: dist/blog-data.json (${posts.length} posts)`)

--- a/integrations/gin/blog.go
+++ b/integrations/gin/blog.go
@@ -245,33 +245,27 @@ func blogIndexHandler(c *gin.Context) {
 // NowPlaying), so the markup comes from post data, not hand-authored HTML.
 func blogPostHandler(c *gin.Context) {
 	slug := c.Param("slug")
-	i := blogPostIndex(slug)
-	if i < 0 {
+	a := blogArticleFor(slug)
+	if !a.Found {
 		c.Status(http.StatusNotFound)
 		return
 	}
-	p := blogPosts[i]
-
 	in := PostArticleInput{
-		Slug:     p.Slug,
-		Title:    p.Title,
-		Date:     p.Date,
-		Tags:     p.Tags,
-		Body:     p.Body,
-		Position: i + 1,
-		Total:    len(blogPosts),
-		Base:     blogBasePath(),
-	}
-	if i > 0 {
-		in.PrevSlug = blogPosts[i-1].Slug
-		in.PrevTitle = blogPosts[i-1].Title
-	}
-	if i < len(blogPosts)-1 {
-		in.NextSlug = blogPosts[i+1].Slug
-		in.NextTitle = blogPosts[i+1].Title
+		Slug:      a.Post.Slug,
+		Title:     a.Post.Title,
+		Date:      a.Post.Date,
+		Tags:      a.Post.Tags,
+		Body:      a.Post.Body,
+		Position:  a.Position,
+		Total:     a.Total,
+		Base:      blogBasePath(),
+		PrevSlug:  a.PrevSlug,
+		PrevTitle: a.PrevTitle,
+		NextSlug:  a.NextSlug,
+		NextTitle: a.NextTitle,
 	}
 
-	html := blogPageHTML(p.Title+" — Barefoot Blog", func(frag blogFrag) template.HTML {
+	html := blogPageHTML(a.Post.Title+" — Barefoot Blog", func(frag blogFrag) template.HTML {
 		props := NewPostArticleProps(in)
 		return frag("PostArticle", &props)
 	})

--- a/integrations/gin/blog_data.go
+++ b/integrations/gin/blog_data.go
@@ -67,12 +67,36 @@ func blogMeta(p BlogPost) string {
 	return fmt.Sprintf("%s · %s", p.Date, strings.Join(tags, " "))
 }
 
-// blogPostIndex returns the index of the post with the given slug, or -1.
-func blogPostIndex(slug string) int {
-	for i, p := range blogPosts {
-		if p.Slug == slug {
-			return i
+// blogArticle is everything a post page needs, with its pager neighbours
+// computed in the index's default display order (date descending — newest
+// first) rather than the authored corpus order (oldest-first). That way the
+// article pager walks DOWN the list the reader is browsing: "next" is the post
+// below in the list, "prev" the post above. The newest post (top of the list)
+// thus gets a real "next" instead of falling off the end into "back to list".
+type blogArticle struct {
+	Post                BlogPost
+	Position, Total     int
+	PrevSlug, PrevTitle string
+	NextSlug, NextTitle string
+	Found               bool
+}
+
+// blogArticleFor looks up a post by slug and computes its pager neighbours in
+// the default list order (date descending). Found is false for an unknown slug.
+func blogArticleFor(slug string) blogArticle {
+	ordered := blogVisible("date", "")
+	for pos, q := range ordered {
+		if q.Slug != slug {
+			continue
 		}
+		a := blogArticle{Post: q, Position: pos + 1, Total: len(ordered), Found: true}
+		if pos > 0 {
+			a.PrevSlug, a.PrevTitle = ordered[pos-1].Slug, ordered[pos-1].Title
+		}
+		if pos < len(ordered)-1 {
+			a.NextSlug, a.NextTitle = ordered[pos+1].Slug, ordered[pos+1].Title
+		}
+		return a
 	}
-	return -1
+	return blogArticle{}
 }

--- a/integrations/gin/blog_data.go
+++ b/integrations/gin/blog_data.go
@@ -1,154 +1,64 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
-	"sort"
+	"os"
 	"strings"
 )
 
-// BlogPost is the source post data for the blog showcase, ported from the
-// shared TS source `integrations/shared/blog/posts.ts`. The JS integrations
-// (Hono / h3 / Elysia) import that module directly; the Go integration keeps a
-// byte-identical copy here so the same shared islands render the same markup.
+// BlogPost is one post from the shared corpus.
 type BlogPost struct {
-	Slug    string
-	Title   string
-	Date    string
-	Tags    []string
-	Excerpt string
-	Body    []string
+	Slug    string   `json:"slug"`
+	Title   string   `json:"title"`
+	Date    string   `json:"date"`
+	Tags    []string `json:"tags"`
+	Excerpt string   `json:"excerpt"`
+	Body    []string `json:"body"`
 }
 
-// blogPosts mirrors `posts` in posts.ts, in the same order.
-var blogPosts = []BlogPost{
-	{
-		Slug:    "partial-navigation",
-		Title:   "Partial navigation, without a SPA framework",
-		Date:    "2026-06-01",
-		Tags:    []string{"design", "runtime"},
-		Excerpt: `Swap only the content region and leave the shell mounted — no virtual DOM, no full rebuild.`,
-		Body: []string{
-			`Most "SPA feel" comes down to one trick: when you follow a link, replace only the part of the page that changed and keep everything else where it is.`,
-			`BarefootJS already renders on the server and hydrates islands in place. The router adds the missing piece — intercept the link, fetch the next page, swap just the content outlet, re-hydrate.`,
-			`The header you are reading this in never reloads. Watch the live counters as you move between posts.`,
-		},
-	},
-	{
-		Slug:    "any-backend",
-		Title:   "Any backend, zero cooperation required",
-		Date:    "2026-06-03",
-		Tags:    []string{"backend", "design"},
-		Excerpt: `The server just returns HTML. The router pulls the outlet out of the response on the client.`,
-		Body: []string{
-			`There is no special protocol to implement. This blog is a plain Hono server returning HTML strings.`,
-			`The router sends no content-negotiation header: it just fetches the page and pulls the outlet out of the response on the client.`,
-			`That is why the same approach works against Go, Perl, or any other backend the adapters target — the server stays a plain HTML server.`,
-		},
-	},
-	{
-		Slug:    "islands-stay-alive",
-		Title:   "Islands in the shell stay alive",
-		Date:    "2026-06-05",
-		Tags:    []string{"islands", "runtime"},
-		Excerpt: `Anything outside the outlet keeps its state: open menus, playing media, live counters, theme.`,
-		Body: []string{
-			`Because only the outlet is replaced, every interactive island in the surrounding shell survives a navigation untouched.`,
-			`The uptime timer in the header was started once, on first load. Full reloads would reset it. It does not.`,
-			`Toggle the theme switch up there, then navigate — the choice sticks because the shell was never torn down.`,
-		},
-	},
-	{
-		Slug:    "reuses-the-runtime",
-		Title:   "It reuses the runtime you already ship",
-		Date:    "2026-06-08",
-		Tags:    []string{"runtime", "design"},
-		Excerpt: `Re-hydration after a swap goes through the same walk the streaming primitive uses.`,
-		Body: []string{
-			`After the outlet is swapped, the freshly inserted islands need to hydrate. The router calls the same re-hydration walk the streaming primitive already uses.`,
-			`New islands light up; the shell is left alone. The router package is tiny because the heavy lifting already lives in the runtime.`,
-			`The like button and "time on page" timer below are outlet islands — they are re-created on every navigation, and torn down when you leave.`,
-		},
-	},
-	{
-		Slug:    "disposal-is-the-hard-part",
-		Title:   "Disposal is the hard part",
-		Date:    "2026-06-10",
-		Tags:    []string{"runtime", "perf"},
-		Excerpt: `Outgoing islands must release timers and listeners or they leak. The stress test measures it.`,
-		Body: []string{
-			`Swapping HTML in is easy. The subtle work is tearing the OLD islands down — their intervals, listeners, and subscriptions.`,
-			`This demo wires a dispose hook that clears each outlet island on the way out. With it off, the per-page timers keep firing forever.`,
-			`That is exactly why precise per-scope disposal is the router prototype's next step.`,
-		},
-	},
-	{
-		Slug:    "history-back-forward",
-		Title:   "Back and forward, done right",
-		Date:    "2026-06-12",
-		Tags:    []string{"history", "design"},
-		Excerpt: `popstate swaps the outlet to match the URL without pushing duplicate entries.`,
-		Body: []string{
-			`A client router lives or dies on the back button. On popstate the router swaps the outlet to match the new URL — without recording a fresh history entry.`,
-			`The stress harness walks forward through several posts then mashes Back, asserting the content matches the URL at every step.`,
-			`Scroll restoration on back/forward is a known gap — the router resets to the top for now.`,
-		},
-	},
-	{
-		Slug:    "rapid-fire",
-		Title:   "Rapid-fire clicks and the last-wins rule",
-		Date:    "2026-06-14",
-		Tags:    []string{"perf", "runtime"},
-		Excerpt: `Spam the links: the latest navigation must win even if an earlier response resolves last.`,
-		Body: []string{
-			`Users double-click. They click B before A has loaded. The router aborts the in-flight request and bails after each await, so the latest target always wins.`,
-			`The stress harness forces a slow response, then navigates away, and asserts the stale content never lands.`,
-			`This was a real race in the first cut — the prototype now has a regression test for it.`,
-		},
-	},
-	{
-		Slug:    "query-string-nav",
-		Title:   "Filtering by tag is just navigation",
-		Date:    "2026-06-16",
-		Tags:    []string{"design", "backend"},
-		Excerpt: `Same path, different query string — the outlet swaps just like any other link.`,
-		Body: []string{
-			`Tag filters on the index are plain links to ?tag=x. To the router they are ordinary same-origin navigations.`,
-			`The outlet swaps to the filtered list; the shell and its theme stay put.`,
-			`Hash-only links, in contrast, are left to the browser so in-page anchors keep working.`,
-		},
-	},
-	{
-		Slug:    "no-fragment-negotiation",
-		Title:   "Why there is no fragment negotiation",
-		Date:    "2026-06-18",
-		Tags:    []string{"backend", "perf"},
-		Excerpt: `Returning just the outlet fragment was considered and dropped — it shaves compressible markup but hurts caching.`,
-		Body: []string{
-			`A "smaller" fragment response only removes the shell markup, which gzip already compresses to almost nothing — while making the same URL return two different bodies, so it needs a Vary header that fragments the cache.`,
-			`It would also force every fragment to re-include its island <script type="module"> tags and <title>, or navigated-to islands go inert.`,
-			`The cost that actually matters is the round-trip, not the byte count — so the effort goes into prefetch, and the server stays a plain, cacheable HTML server.`,
-		},
-	},
-	{
-		Slug:    "where-this-goes",
-		Title:   "Where this goes next",
-		Date:    "2026-06-20",
-		Tags:    []string{"design", "islands"},
-		Excerpt: `Compiler-derived outlets, morph for persistent islands, prefetch on hover, snapshot cache.`,
-		Body: []string{
-			`The outlet is authored by hand today. The end state is the compiler deriving it from the component tree.`,
-			`Add idiomorph-style morphing and data-bf-permanent for islands that should survive a swap, plus hover prefetch and a snapshot cache for instant back/forward.`,
-			`This is the last post — loop back to the start from the navigation below.`,
-		},
-	},
+// blogDataFile is the shape of dist/blog-data.json, generated at build time by
+// scripts/gen-blog-data.ts from the single shared corpus
+// (../shared/blog/posts.ts) — the same source the JS adapters import and the
+// Perl integrations read. The Go corpus is no longer hand-transcribed.
+type blogDataFile struct {
+	Posts     []BlogPost `json:"posts"`
+	ListItems []Item     `json:"listItems"`
+	AllTags   []string   `json:"allTags"`
 }
 
-// blogMeta renders the index list's pre-computed `meta` line (`<date> · #tag
-// #tag`), matching `listItems[].meta` in posts.ts. It is computed here, NOT in
-// the PostList island, on purpose: building it in the island needs a
-// value-producing tag-map-join that the template-string adapters (Go included)
-// can't lower for SSR. Pre-computing it upstream keeps the island's template a
-// plain member access so the same shared component compiles on every adapter.
+// blogData is loaded once at process start. A missing / unreadable file yields
+// an empty corpus (the blog renders empty) rather than crashing the whole
+// server, matching the Perl integration's graceful fallback.
+var blogData = loadBlogData()
+
+func loadBlogData() blogDataFile {
+	b, err := os.ReadFile("dist/blog-data.json")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "barefoot: blog data not found (run `bun run build`): %v\n", err)
+		return blogDataFile{}
+	}
+	var d blogDataFile
+	if err := json.Unmarshal(b, &d); err != nil {
+		fmt.Fprintf(os.Stderr, "barefoot: blog data parse error: %v\n", err)
+		return blogDataFile{}
+	}
+	return d
+}
+
+// blogPosts is the post corpus.
+var blogPosts = blogData.Posts
+
+// blogListItems returns the index-list items with pre-rendered `meta`, derived
+// upstream in posts.ts so every adapter renders identical markup.
+func blogListItems() []Item { return blogData.ListItems }
+
+// blogAllTags returns the sorted, de-duplicated tag set.
+func blogAllTags() []string { return blogData.AllTags }
+
+// blogMeta renders the `<date> · #tag #tag` meta line for a post — the same
+// format posts.ts pre-computes into listItems[].meta, recomputed here for the
+// rows blogPostListItems builds from the sorted/filtered corpus.
 func blogMeta(p BlogPost) string {
 	tags := make([]string, len(p.Tags))
 	for i, t := range p.Tags {
@@ -157,41 +67,7 @@ func blogMeta(p BlogPost) string {
 	return fmt.Sprintf("%s · %s", p.Date, strings.Join(tags, " "))
 }
 
-// blogListItems derives the index-list items from blogPosts with `meta`
-// pre-rendered, mirroring `listItems` in posts.ts.
-func blogListItems() []Item {
-	items := make([]Item, len(blogPosts))
-	for i, p := range blogPosts {
-		items[i] = Item{
-			Slug:  p.Slug,
-			Title: p.Title,
-			Date:  p.Date,
-			Tags:  p.Tags,
-			Meta:  blogMeta(p),
-		}
-	}
-	return items
-}
-
-// blogAllTags returns the sorted, de-duplicated tag set across all posts,
-// mirroring `allTags` in posts.ts.
-func blogAllTags() []string {
-	seen := map[string]bool{}
-	var tags []string
-	for _, p := range blogPosts {
-		for _, t := range p.Tags {
-			if !seen[t] {
-				seen[t] = true
-				tags = append(tags, t)
-			}
-		}
-	}
-	sort.Strings(tags)
-	return tags
-}
-
-// blogPostIndex returns the index of the post with the given slug, or -1,
-// mirroring `postIndex` in posts.ts.
+// blogPostIndex returns the index of the post with the given slug, or -1.
 func blogPostIndex(slug string) int {
 	for i, p := range blogPosts {
 		if p.Slug == slug {

--- a/integrations/gin/package.json
+++ b/integrations/gin/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/build-client.ts && bun run scripts/copy-shared.ts",
+    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/gen-blog-data.ts && bun run scripts/build-client.ts && bun run scripts/copy-shared.ts",
     "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
     "dev": "APP_ENV=development BASE_PATH=/integrations/gin go run .",
     "setup": "go mod tidy",

--- a/integrations/gin/scripts/gen-blog-data.ts
+++ b/integrations/gin/scripts/gen-blog-data.ts
@@ -1,0 +1,25 @@
+/**
+ * Emit `dist/blog-data.json` for the Go blog routes.
+ *
+ * The shared blog islands (`../shared/blog/*`) are authored in TS and compiled
+ * to Go templates by `bf build`, but the *data* the index/post routes render
+ * (the post corpus, the derived list items with their pre-rendered `meta`, the
+ * tag set) lives in `../shared/blog/posts.ts` — TS the Go server can't import.
+ * Rather than hand-transcribe the corpus into Go (fragile, and the kind of
+ * duplication the showcase explicitly avoids), this build step imports the
+ * single source of truth and writes it as JSON that `blog_data.go` reads at
+ * startup. The TS adapters import `posts.ts` directly; the Go and Perl apps read
+ * this JSON — every backend stays in sync with one authored corpus.
+ */
+import { mkdir, writeFile } from 'node:fs/promises'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { posts, listItems, allTags } from '../../shared/blog/posts'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(HERE, '..')
+const OUT = resolve(ROOT, 'dist/blog-data.json')
+
+await mkdir(dirname(OUT), { recursive: true })
+await writeFile(OUT, JSON.stringify({ posts, listItems, allTags }, null, 0))
+console.log(`Generated: dist/blog-data.json (${posts.length} posts)`)

--- a/integrations/nethttp/blog.go
+++ b/integrations/nethttp/blog.go
@@ -251,33 +251,27 @@ func blogIndexHandler(w http.ResponseWriter, req *http.Request) {
 // NowPlaying), so the markup comes from post data, not hand-authored HTML.
 func blogPostHandler(w http.ResponseWriter, req *http.Request) {
 	slug := req.PathValue("slug")
-	i := blogPostIndex(slug)
-	if i < 0 {
+	a := blogArticleFor(slug)
+	if !a.Found {
 		http.NotFound(w, req)
 		return
 	}
-	p := blogPosts[i]
-
 	in := PostArticleInput{
-		Slug:     p.Slug,
-		Title:    p.Title,
-		Date:     p.Date,
-		Tags:     p.Tags,
-		Body:     p.Body,
-		Position: i + 1,
-		Total:    len(blogPosts),
-		Base:     blogBasePath(),
-	}
-	if i > 0 {
-		in.PrevSlug = blogPosts[i-1].Slug
-		in.PrevTitle = blogPosts[i-1].Title
-	}
-	if i < len(blogPosts)-1 {
-		in.NextSlug = blogPosts[i+1].Slug
-		in.NextTitle = blogPosts[i+1].Title
+		Slug:      a.Post.Slug,
+		Title:     a.Post.Title,
+		Date:      a.Post.Date,
+		Tags:      a.Post.Tags,
+		Body:      a.Post.Body,
+		Position:  a.Position,
+		Total:     a.Total,
+		Base:      blogBasePath(),
+		PrevSlug:  a.PrevSlug,
+		PrevTitle: a.PrevTitle,
+		NextSlug:  a.NextSlug,
+		NextTitle: a.NextTitle,
 	}
 
-	html := blogPageHTML(p.Title+" — Barefoot Blog", func(frag blogFrag) template.HTML {
+	html := blogPageHTML(a.Post.Title+" — Barefoot Blog", func(frag blogFrag) template.HTML {
 		props := NewPostArticleProps(in)
 		return frag("PostArticle", &props)
 	})

--- a/integrations/nethttp/blog_data.go
+++ b/integrations/nethttp/blog_data.go
@@ -67,12 +67,36 @@ func blogMeta(p BlogPost) string {
 	return fmt.Sprintf("%s · %s", p.Date, strings.Join(tags, " "))
 }
 
-// blogPostIndex returns the index of the post with the given slug, or -1.
-func blogPostIndex(slug string) int {
-	for i, p := range blogPosts {
-		if p.Slug == slug {
-			return i
+// blogArticle is everything a post page needs, with its pager neighbours
+// computed in the index's default display order (date descending — newest
+// first) rather than the authored corpus order (oldest-first). That way the
+// article pager walks DOWN the list the reader is browsing: "next" is the post
+// below in the list, "prev" the post above. The newest post (top of the list)
+// thus gets a real "next" instead of falling off the end into "back to list".
+type blogArticle struct {
+	Post                BlogPost
+	Position, Total     int
+	PrevSlug, PrevTitle string
+	NextSlug, NextTitle string
+	Found               bool
+}
+
+// blogArticleFor looks up a post by slug and computes its pager neighbours in
+// the default list order (date descending). Found is false for an unknown slug.
+func blogArticleFor(slug string) blogArticle {
+	ordered := blogVisible("date", "")
+	for pos, q := range ordered {
+		if q.Slug != slug {
+			continue
 		}
+		a := blogArticle{Post: q, Position: pos + 1, Total: len(ordered), Found: true}
+		if pos > 0 {
+			a.PrevSlug, a.PrevTitle = ordered[pos-1].Slug, ordered[pos-1].Title
+		}
+		if pos < len(ordered)-1 {
+			a.NextSlug, a.NextTitle = ordered[pos+1].Slug, ordered[pos+1].Title
+		}
+		return a
 	}
-	return -1
+	return blogArticle{}
 }

--- a/integrations/nethttp/blog_data.go
+++ b/integrations/nethttp/blog_data.go
@@ -1,154 +1,64 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
-	"sort"
+	"os"
 	"strings"
 )
 
-// BlogPost is the source post data for the blog showcase, ported from the
-// shared TS source `integrations/shared/blog/posts.ts`. The JS integrations
-// (Hono / h3 / Elysia) import that module directly; the Go integration keeps a
-// byte-identical copy here so the same shared islands render the same markup.
+// BlogPost is one post from the shared corpus.
 type BlogPost struct {
-	Slug    string
-	Title   string
-	Date    string
-	Tags    []string
-	Excerpt string
-	Body    []string
+	Slug    string   `json:"slug"`
+	Title   string   `json:"title"`
+	Date    string   `json:"date"`
+	Tags    []string `json:"tags"`
+	Excerpt string   `json:"excerpt"`
+	Body    []string `json:"body"`
 }
 
-// blogPosts mirrors `posts` in posts.ts, in the same order.
-var blogPosts = []BlogPost{
-	{
-		Slug:    "partial-navigation",
-		Title:   "Partial navigation, without a SPA framework",
-		Date:    "2026-06-01",
-		Tags:    []string{"design", "runtime"},
-		Excerpt: `Swap only the content region and leave the shell mounted — no virtual DOM, no full rebuild.`,
-		Body: []string{
-			`Most "SPA feel" comes down to one trick: when you follow a link, replace only the part of the page that changed and keep everything else where it is.`,
-			`BarefootJS already renders on the server and hydrates islands in place. The router adds the missing piece — intercept the link, fetch the next page, swap just the content outlet, re-hydrate.`,
-			`The header you are reading this in never reloads. Watch the live counters as you move between posts.`,
-		},
-	},
-	{
-		Slug:    "any-backend",
-		Title:   "Any backend, zero cooperation required",
-		Date:    "2026-06-03",
-		Tags:    []string{"backend", "design"},
-		Excerpt: `The server just returns HTML. The router pulls the outlet out of the response on the client.`,
-		Body: []string{
-			`There is no special protocol to implement. This blog is a plain Hono server returning HTML strings.`,
-			`The router sends no content-negotiation header: it just fetches the page and pulls the outlet out of the response on the client.`,
-			`That is why the same approach works against Go, Perl, or any other backend the adapters target — the server stays a plain HTML server.`,
-		},
-	},
-	{
-		Slug:    "islands-stay-alive",
-		Title:   "Islands in the shell stay alive",
-		Date:    "2026-06-05",
-		Tags:    []string{"islands", "runtime"},
-		Excerpt: `Anything outside the outlet keeps its state: open menus, playing media, live counters, theme.`,
-		Body: []string{
-			`Because only the outlet is replaced, every interactive island in the surrounding shell survives a navigation untouched.`,
-			`The uptime timer in the header was started once, on first load. Full reloads would reset it. It does not.`,
-			`Toggle the theme switch up there, then navigate — the choice sticks because the shell was never torn down.`,
-		},
-	},
-	{
-		Slug:    "reuses-the-runtime",
-		Title:   "It reuses the runtime you already ship",
-		Date:    "2026-06-08",
-		Tags:    []string{"runtime", "design"},
-		Excerpt: `Re-hydration after a swap goes through the same walk the streaming primitive uses.`,
-		Body: []string{
-			`After the outlet is swapped, the freshly inserted islands need to hydrate. The router calls the same re-hydration walk the streaming primitive already uses.`,
-			`New islands light up; the shell is left alone. The router package is tiny because the heavy lifting already lives in the runtime.`,
-			`The like button and "time on page" timer below are outlet islands — they are re-created on every navigation, and torn down when you leave.`,
-		},
-	},
-	{
-		Slug:    "disposal-is-the-hard-part",
-		Title:   "Disposal is the hard part",
-		Date:    "2026-06-10",
-		Tags:    []string{"runtime", "perf"},
-		Excerpt: `Outgoing islands must release timers and listeners or they leak. The stress test measures it.`,
-		Body: []string{
-			`Swapping HTML in is easy. The subtle work is tearing the OLD islands down — their intervals, listeners, and subscriptions.`,
-			`This demo wires a dispose hook that clears each outlet island on the way out. With it off, the per-page timers keep firing forever.`,
-			`That is exactly why precise per-scope disposal is the router prototype's next step.`,
-		},
-	},
-	{
-		Slug:    "history-back-forward",
-		Title:   "Back and forward, done right",
-		Date:    "2026-06-12",
-		Tags:    []string{"history", "design"},
-		Excerpt: `popstate swaps the outlet to match the URL without pushing duplicate entries.`,
-		Body: []string{
-			`A client router lives or dies on the back button. On popstate the router swaps the outlet to match the new URL — without recording a fresh history entry.`,
-			`The stress harness walks forward through several posts then mashes Back, asserting the content matches the URL at every step.`,
-			`Scroll restoration on back/forward is a known gap — the router resets to the top for now.`,
-		},
-	},
-	{
-		Slug:    "rapid-fire",
-		Title:   "Rapid-fire clicks and the last-wins rule",
-		Date:    "2026-06-14",
-		Tags:    []string{"perf", "runtime"},
-		Excerpt: `Spam the links: the latest navigation must win even if an earlier response resolves last.`,
-		Body: []string{
-			`Users double-click. They click B before A has loaded. The router aborts the in-flight request and bails after each await, so the latest target always wins.`,
-			`The stress harness forces a slow response, then navigates away, and asserts the stale content never lands.`,
-			`This was a real race in the first cut — the prototype now has a regression test for it.`,
-		},
-	},
-	{
-		Slug:    "query-string-nav",
-		Title:   "Filtering by tag is just navigation",
-		Date:    "2026-06-16",
-		Tags:    []string{"design", "backend"},
-		Excerpt: `Same path, different query string — the outlet swaps just like any other link.`,
-		Body: []string{
-			`Tag filters on the index are plain links to ?tag=x. To the router they are ordinary same-origin navigations.`,
-			`The outlet swaps to the filtered list; the shell and its theme stay put.`,
-			`Hash-only links, in contrast, are left to the browser so in-page anchors keep working.`,
-		},
-	},
-	{
-		Slug:    "no-fragment-negotiation",
-		Title:   "Why there is no fragment negotiation",
-		Date:    "2026-06-18",
-		Tags:    []string{"backend", "perf"},
-		Excerpt: `Returning just the outlet fragment was considered and dropped — it shaves compressible markup but hurts caching.`,
-		Body: []string{
-			`A "smaller" fragment response only removes the shell markup, which gzip already compresses to almost nothing — while making the same URL return two different bodies, so it needs a Vary header that fragments the cache.`,
-			`It would also force every fragment to re-include its island <script type="module"> tags and <title>, or navigated-to islands go inert.`,
-			`The cost that actually matters is the round-trip, not the byte count — so the effort goes into prefetch, and the server stays a plain, cacheable HTML server.`,
-		},
-	},
-	{
-		Slug:    "where-this-goes",
-		Title:   "Where this goes next",
-		Date:    "2026-06-20",
-		Tags:    []string{"design", "islands"},
-		Excerpt: `Compiler-derived outlets, morph for persistent islands, prefetch on hover, snapshot cache.`,
-		Body: []string{
-			`The outlet is authored by hand today. The end state is the compiler deriving it from the component tree.`,
-			`Add idiomorph-style morphing and data-bf-permanent for islands that should survive a swap, plus hover prefetch and a snapshot cache for instant back/forward.`,
-			`This is the last post — loop back to the start from the navigation below.`,
-		},
-	},
+// blogDataFile is the shape of dist/blog-data.json, generated at build time by
+// scripts/gen-blog-data.ts from the single shared corpus
+// (../shared/blog/posts.ts) — the same source the JS adapters import and the
+// Perl integrations read. The Go corpus is no longer hand-transcribed.
+type blogDataFile struct {
+	Posts     []BlogPost `json:"posts"`
+	ListItems []Item     `json:"listItems"`
+	AllTags   []string   `json:"allTags"`
 }
 
-// blogMeta renders the index list's pre-computed `meta` line (`<date> · #tag
-// #tag`), matching `listItems[].meta` in posts.ts. It is computed here, NOT in
-// the PostList island, on purpose: building it in the island needs a
-// value-producing tag-map-join that the template-string adapters (Go included)
-// can't lower for SSR. Pre-computing it upstream keeps the island's template a
-// plain member access so the same shared component compiles on every adapter.
+// blogData is loaded once at process start. A missing / unreadable file yields
+// an empty corpus (the blog renders empty) rather than crashing the whole
+// server, matching the Perl integration's graceful fallback.
+var blogData = loadBlogData()
+
+func loadBlogData() blogDataFile {
+	b, err := os.ReadFile("dist/blog-data.json")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "barefoot: blog data not found (run `bun run build`): %v\n", err)
+		return blogDataFile{}
+	}
+	var d blogDataFile
+	if err := json.Unmarshal(b, &d); err != nil {
+		fmt.Fprintf(os.Stderr, "barefoot: blog data parse error: %v\n", err)
+		return blogDataFile{}
+	}
+	return d
+}
+
+// blogPosts is the post corpus.
+var blogPosts = blogData.Posts
+
+// blogListItems returns the index-list items with pre-rendered `meta`, derived
+// upstream in posts.ts so every adapter renders identical markup.
+func blogListItems() []Item { return blogData.ListItems }
+
+// blogAllTags returns the sorted, de-duplicated tag set.
+func blogAllTags() []string { return blogData.AllTags }
+
+// blogMeta renders the `<date> · #tag #tag` meta line for a post — the same
+// format posts.ts pre-computes into listItems[].meta, recomputed here for the
+// rows blogPostListItems builds from the sorted/filtered corpus.
 func blogMeta(p BlogPost) string {
 	tags := make([]string, len(p.Tags))
 	for i, t := range p.Tags {
@@ -157,41 +67,7 @@ func blogMeta(p BlogPost) string {
 	return fmt.Sprintf("%s · %s", p.Date, strings.Join(tags, " "))
 }
 
-// blogListItems derives the index-list items from blogPosts with `meta`
-// pre-rendered, mirroring `listItems` in posts.ts.
-func blogListItems() []Item {
-	items := make([]Item, len(blogPosts))
-	for i, p := range blogPosts {
-		items[i] = Item{
-			Slug:  p.Slug,
-			Title: p.Title,
-			Date:  p.Date,
-			Tags:  p.Tags,
-			Meta:  blogMeta(p),
-		}
-	}
-	return items
-}
-
-// blogAllTags returns the sorted, de-duplicated tag set across all posts,
-// mirroring `allTags` in posts.ts.
-func blogAllTags() []string {
-	seen := map[string]bool{}
-	var tags []string
-	for _, p := range blogPosts {
-		for _, t := range p.Tags {
-			if !seen[t] {
-				seen[t] = true
-				tags = append(tags, t)
-			}
-		}
-	}
-	sort.Strings(tags)
-	return tags
-}
-
-// blogPostIndex returns the index of the post with the given slug, or -1,
-// mirroring `postIndex` in posts.ts.
+// blogPostIndex returns the index of the post with the given slug, or -1.
 func blogPostIndex(slug string) int {
 	for i, p := range blogPosts {
 		if p.Slug == slug {

--- a/integrations/nethttp/package.json
+++ b/integrations/nethttp/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/build-client.ts && bun run scripts/copy-shared.ts",
+    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/gen-blog-data.ts && bun run scripts/build-client.ts && bun run scripts/copy-shared.ts",
     "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
     "dev": "APP_ENV=development BASE_PATH=/integrations/nethttp go run .",
     "setup": "go mod tidy",

--- a/integrations/nethttp/scripts/gen-blog-data.ts
+++ b/integrations/nethttp/scripts/gen-blog-data.ts
@@ -1,0 +1,25 @@
+/**
+ * Emit `dist/blog-data.json` for the Go blog routes.
+ *
+ * The shared blog islands (`../shared/blog/*`) are authored in TS and compiled
+ * to Go templates by `bf build`, but the *data* the index/post routes render
+ * (the post corpus, the derived list items with their pre-rendered `meta`, the
+ * tag set) lives in `../shared/blog/posts.ts` — TS the Go server can't import.
+ * Rather than hand-transcribe the corpus into Go (fragile, and the kind of
+ * duplication the showcase explicitly avoids), this build step imports the
+ * single source of truth and writes it as JSON that `blog_data.go` reads at
+ * startup. The TS adapters import `posts.ts` directly; the Go and Perl apps read
+ * this JSON — every backend stays in sync with one authored corpus.
+ */
+import { mkdir, writeFile } from 'node:fs/promises'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { posts, listItems, allTags } from '../../shared/blog/posts'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(HERE, '..')
+const OUT = resolve(ROOT, 'dist/blog-data.json')
+
+await mkdir(dirname(OUT), { recursive: true })
+await writeFile(OUT, JSON.stringify({ posts, listItems, allTags }, null, 0))
+console.log(`Generated: dist/blog-data.json (${posts.length} posts)`)


### PR DESCRIPTION
Two follow-up refinements to the Go blog integrations (chi / echo / gin / net/http), both committed here.

## 1. `refactor(go)`: load blog data from the shared corpus

All four Go integrations hard-coded a **byte-identical copy** of the blog post corpus in `blog_data.go` — the same data the JS adapters import from `../shared/blog/posts.ts` and the **Perl** integrations (mojolicious / xslate) already read from a generated JSON. This aligns Go with that existing single-source pattern.

- **`scripts/gen-blog-data.ts`** (new, mirrors `mojolicious/scripts/gen-blog-data.ts`) — imports the shared `posts.ts` and writes `dist/blog-data.json` (`{ posts, listItems, allTags }`) at build time.
- **`blog_data.go`** — drops the ~140-line hard-coded corpus; loads `dist/blog-data.json` once at startup into the same types, with a graceful empty fallback if the file is missing (matching the Perl app). `blog.go`'s handlers are untouched by this part.
- **`package.json`** — runs `gen-blog-data.ts` after `bf build`, before `build-client`.

One authored corpus (`posts.ts`) now feeds every adapter — JS imports it directly, Go and Perl read the generated JSON. `posts.ts` and the JS/Perl adapters are unchanged.

## 2. `fix(go-blog)`: walk the article pager in the index's display order

The list defaults to **date-descending** (newest first), but the article prev/next walked the authored corpus order (oldest-first) — so the newest post (top of the list) was the pager's *last* entry, and its **"next →" linked back to the list** instead of to a post.

The pager neighbours and the "post N of M" counter are now computed in the default list order via a shared `blogArticleFor(slug)` helper. "next" walks **down** the list the reader is browsing: the top post advances to the second post, and the oldest (bottom) post is the one that ends with "Back to start". `blogPostIndex` is gone.

## Testing

Per integration: `bun run build` generates `dist/blog-data.json` (10 posts); `go vet` + `gofmt` + `go build` clean. SSR-verified on chi/echo: `/blog` 200 with 10 rows, `?tag=perf` → 3, post pages render correct title/body/meta, zero error panels. Pager after the fix — `where-this-goes` (list top) is now `post 1 of 10` with **next → `no-fragment-negotiation`** (a post); `partial-navigation` (list bottom) is `post 10 of 10` and ends with "Back to start".

🤖 Generated with [Claude Code](https://claude.com/claude-code)