### PR TITLE
fix(blog): article pager in list order (TS + Perl) + add the blog link to the Perl index

### DIFF
--- a/integrations/elysia/blog.tsx
+++ b/integrations/elysia/blog.tsx
@@ -24,7 +24,7 @@ import { ThemeToggle } from '@/components/ThemeToggle'
 import { NowPlaying } from '@/components/NowPlaying'
 import { PostList } from '@/components/PostList'
 import { PostArticle } from '@/components/PostArticle'
-import { posts, postIndex, allTags, listItems } from '../shared/blog/posts'
+import { allTags, listItems, articleNav } from '../shared/blog/posts'
 
 interface LayoutProps {
   base: string
@@ -109,12 +109,10 @@ export function renderBlogIndex(base: string, manifest: BarefootBuildManifest, t
 
 /** Post page node, or `null` when the slug is unknown (caller returns 404). */
 export function renderBlogPost(base: string, manifest: BarefootBuildManifest, slug: string) {
-  const i = postIndex(slug)
-  if (i < 0) return null
+  const nav = articleNav(slug)
+  if (!nav) return null
   const blog = `${base}/blog`
-  const p = posts[i]
-  const prev = posts[i - 1]
-  const next = posts[i + 1]
+  const { post: p, position, total, prev, next } = nav
   // The whole article is the shared <PostArticle> island (nested children:
   // LikeButton / ReadingTimer / NowPlaying), rendered from post data.
   return (
@@ -125,8 +123,8 @@ export function renderBlogPost(base: string, manifest: BarefootBuildManifest, sl
         date={p.date}
         tags={p.tags}
         body={p.body}
-        position={i + 1}
-        total={posts.length}
+        position={position}
+        total={total}
         base={blog}
         prevSlug={prev?.slug}
         prevTitle={prev?.title}

--- a/integrations/h3/blog.tsx
+++ b/integrations/h3/blog.tsx
@@ -34,7 +34,7 @@ import { ThemeToggle } from '@/components/ThemeToggle'
 import { NowPlaying } from '@/components/NowPlaying'
 import { PostList } from '@/components/PostList'
 import { PostArticle } from '@/components/PostArticle'
-import { posts, postIndex, allTags, listItems } from '../shared/blog/posts'
+import { allTags, listItems, articleNav } from '../shared/blog/posts'
 
 interface LayoutProps {
   base: string
@@ -144,14 +144,12 @@ export function registerBlog(
     `${blog}/posts/:slug`,
     eventHandler(async (event) => {
       const slug = getRouterParam(event, 'slug')
-      const i = slug ? postIndex(slug) : -1
-      if (i < 0) {
+      const nav = slug ? articleNav(slug) : undefined
+      if (!nav) {
         setResponseStatus(event, 404)
         return 'Not found'
       }
-      const p = posts[i]
-      const prev = posts[i - 1]
-      const next = posts[i + 1]
+      const { post: p, position, total, prev, next } = nav
       // The whole article is the shared <PostArticle> island (nested children:
       // LikeButton / ReadingTimer / NowPlaying), rendered from post data.
       return renderPage(
@@ -162,8 +160,8 @@ export function registerBlog(
             date={p.date}
             tags={p.tags}
             body={p.body}
-            position={i + 1}
-            total={posts.length}
+            position={position}
+            total={total}
             base={blog}
             prevSlug={prev?.slug}
             prevTitle={prev?.title}

--- a/integrations/hono/blog.tsx
+++ b/integrations/hono/blog.tsx
@@ -17,7 +17,7 @@ import { ThemeToggle } from '@/components/ThemeToggle'
 import { NowPlaying } from '@/components/NowPlaying'
 import { PostList } from '@/components/PostList'
 import { PostArticle } from '@/components/PostArticle'
-import { posts, postIndex, allTags, listItems } from '../shared/blog/posts'
+import { allTags, listItems, articleNav } from '../shared/blog/posts'
 
 const BASE_PATH = process.env.BASE_PATH ?? '/integrations/hono'
 const STATIC = `${BASE_PATH}/static/components`
@@ -102,11 +102,9 @@ blog.get('/', (c) => {
 
 blog.get('/posts/:slug', (c) => {
   const slug = c.req.param('slug')
-  const i = postIndex(slug)
-  if (i < 0) return c.notFound()
-  const p = posts[i]
-  const prev = posts[i - 1]
-  const next = posts[i + 1]
+  const nav = articleNav(slug)
+  if (!nav) return c.notFound()
+  const { post: p, position, total, prev, next } = nav
   // The whole article is the shared <PostArticle> island (its nested children
   // are LikeButton / ReadingTimer / NowPlaying), so every adapter renders the
   // same markup from post data instead of hand-authoring it.
@@ -117,8 +115,8 @@ blog.get('/posts/:slug', (c) => {
       date={p.date}
       tags={p.tags}
       body={p.body}
-      position={i + 1}
-      total={posts.length}
+      position={position}
+      total={total}
       base={BASE}
       prevSlug={prev?.slug}
       prevTitle={prev?.title}

--- a/integrations/mojolicious/app.pl
+++ b/integrations/mojolicious/app.pl
@@ -610,7 +610,9 @@ $r_blog->get('/blog' => sub ($c) {
 
 $r_blog->get('/blog/posts/:slug' => sub ($c) {
     my $slug  = $c->param('slug');
-    my $posts = $BLOG_DATA->{posts};
+    # Sort newest-first (the index's default display order) so the article pager
+    # walks down the list the reader is browsing; the corpus is authored oldest-first.
+    my $posts = [ sort { $b->{date} cmp $a->{date} } @{ $BLOG_DATA->{posts} } ];
     my ($i) = grep { $posts->[$_]{slug} eq $slug } 0 .. $#$posts;
     return $c->reply->not_found unless defined $i;
     my $p    = $posts->[$i];
@@ -707,4 +709,5 @@ __DATA__
     <li><a href="<%= $bp %>/todos">Todo (@client)</a></li>
     <li><a href="<%= $bp %>/todos-ssr">Todo (no @client markers)</a></li>
     <li><a href="<%= $bp %>/ai-chat">AI Chat (SSE Streaming)</a></li>
+    <li><a href="<%= $bp %>/blog">Blog (@barefootjs/router - partial navigation)</a></li>
 </ul>

--- a/integrations/shared/blog/posts.ts
+++ b/integrations/shared/blog/posts.ts
@@ -165,3 +165,34 @@ export const allTags: string[] = [...new Set(posts.flatMap((p) => p.tags))].sort
 export function postIndex(slug: string): number {
   return posts.findIndex((p) => p.slug === slug)
 }
+
+/** Posts in the index's default display order — date descending (newest first),
+ *  the order `PostList` shows by default. The article pager walks this order so
+ *  "next" moves DOWN the list the reader is browsing; the corpus above is
+ *  authored oldest-first, so without this the newest post (top of the list)
+ *  would be the pager's last entry and its "next" would fall back to the list. */
+export const orderedPosts: Post[] = [...posts].sort((a, b) => b.date.localeCompare(a.date))
+
+/** A post plus its pager neighbours, in the index's display order. */
+export interface ArticleNav {
+  post: Post
+  /** 1-based position in display order. */
+  position: number
+  total: number
+  prev?: Post
+  next?: Post
+}
+
+/** Look up a post and its pager neighbours in the index's display order.
+ *  Returns undefined for an unknown slug. */
+export function articleNav(slug: string): ArticleNav | undefined {
+  const pos = orderedPosts.findIndex((p) => p.slug === slug)
+  if (pos < 0) return undefined
+  return {
+    post: orderedPosts[pos],
+    position: pos + 1,
+    total: orderedPosts.length,
+    prev: orderedPosts[pos - 1],
+    next: orderedPosts[pos + 1],
+  }
+}

--- a/integrations/xslate/app.psgi
+++ b/integrations/xslate/app.psgi
@@ -485,7 +485,9 @@ sub blog_index_route ($req) {
 }
 
 sub blog_post_route ($req, $slug) {
-    my $posts = $BLOG_DATA->{posts};
+    # Sort newest-first (the index's default display order) so the article pager
+    # walks down the list the reader is browsing; the corpus is authored oldest-first.
+    my $posts = [ sort { $b->{date} cmp $a->{date} } @{ $BLOG_DATA->{posts} } ];
     my ($i) = grep { $posts->[$_]{slug} eq $slug } 0 .. $#$posts;
     return [404, ['Content-Type' => 'text/plain'], ['Not Found']] unless defined $i;
     my $p    = $posts->[$i];
@@ -569,6 +571,7 @@ under a plain Plack/PSGI app — no web framework required.</p>
     <li><a href="$BASE/todos">Todo (\@client)</a></li>
     <li><a href="$BASE/todos-ssr">Todo (no \@client markers)</a></li>
     <li><a href="$BASE/ai-chat">AI Chat (SSE Streaming)</a></li>
+    <li><a href="$BASE/blog">Blog (\@barefootjs/router - partial navigation)</a></li>
 </ul>
 HTML
     );


### PR DESCRIPTION
Two follow-ups that bring the **TS** (Hono / h3 / Elysia) and **Perl** (Mojolicious / Xslate) blog integrations in line with the Go-only changes already on `main`.

## 1. Article pager order (TS + Perl)

The post list defaults to **date-descending** (newest first), but every adapter walked the article prev/next over the *authored corpus* order (oldest-first) — so the newest post (top of the list) was the pager's last entry, and its **"next →" fell back to the list** instead of a post. Same bug fixed for Go in #1953.

- **`shared/blog/posts.ts`** — add `orderedPosts` (date-desc) and an `articleNav(slug)` helper returning a post plus its pager neighbours and 1-based position **in display order**.
- **`hono` / `h3` / `elysia` `blog.tsx`** — look the article up via `articleNav` instead of `postIndex` + `posts[i±1]`.
- **`mojolicious` / `xslate`** — sort the corpus newest-first before computing prev/next (a one-line change; the existing index math then walks the display order).

Now "next" moves *down* the list the reader is browsing; the oldest (bottom) post is the one that ends with "Back to start". Verified the ordering for both: `articleNav("where-this-goes")` → `post 1 of 10`, next → `no-fragment-negotiation`; the Perl sort gives the identical order.

## 2. Perl index link

The Mojolicious and Xslate example index pages listed Counter / Toggle / Todo / AI Chat but **not the blog** — the Go and TS indexes already link it (e.g. https://barefootjs.dev/integrations/xslate). Added.

## Notes

`posts.ts` only gains exports (existing consumers and the `gen-blog-data.ts` scripts are unaffected). No changeset — integration-only. Perl servers couldn't be run here (Mojolicious/Plack modules aren't installed in this env), but the sort/prev/next logic was verified in isolation with `perl`, and the markup mirrors the existing entries' escaping (`@client` literal in the Mojo EP template, `\@client` in the Xslate heredoc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JT4Rcc5b1qcMStCJfmD3V1)_