### PR TITLE
build: publish @barefootjs/router to npm in the release pipeline

### DIFF
--- a/scripts/changeset-publish.ts
+++ b/scripts/changeset-publish.ts
@@ -33,6 +33,7 @@ const PUBLISHABLE = [
   'packages/streaming',
   'packages/jsx',
   'packages/client',
+  'packages/router',
   'packages/test',
   'packages/form',
   'packages/chart',


### PR DESCRIPTION
## What

Add `packages/router` to the hand-maintained `PUBLISHABLE` list in `scripts/changeset-publish.ts`, right after `packages/client` (preserving the dependencies-before-dependents order — router depends on `@barefootjs/shared` + `@barefootjs/client`).

## Why

`scripts/changeset-publish.ts` drives npm publishing from a hand-maintained list, and `@barefootjs/router` was missing from it. Even though Changesets version-bumps router in lock-step with the rest of the fixed `@barefootjs/*` group, the release pipeline never ran `npm publish` for it (nor cut a git tag), so it has never shipped to npm.

This is **Step 1** of bringing up the first `@barefootjs/router` release. Note this PR alone is not sufficient to publish router, because npm Trusted Publishing (OIDC) is per-package and the package does not yet exist on npm:

1. ✅ **(this PR)** Add router to `PUBLISHABLE`.
2. ⬜ Bootstrap the package on npm with a one-time manual `npm publish` (no provenance), so a Trusted Publisher can be attached.
3. ⬜ Register a Trusted Publisher for `@barefootjs/router` on npmjs.com → `release.yml`.
4. ⬜ Merge the Version Packages PR — router then ships via OIDC in lock-step with the rest.

The JSR side (`scripts/jsr-publish.ts`) auto-discovers `@barefootjs/*` packages, so no change is needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015QEcFktw9J3MDsWUN8Ykbq)_