### PR TITLE
fix(adapter-mojolicious): require BarefootJS >= 0.15.0

### DIFF
--- a/packages/adapter-mojolicious/cpanfile
+++ b/packages/adapter-mojolicious/cpanfile
@@ -1,5 +1,5 @@
 requires 'perl', '5.020';
-requires 'BarefootJS';
+requires 'BarefootJS', '0.15.0';
 requires 'Mojolicious', '9.0';
 
 on 'test' => sub {


### PR DESCRIPTION
## Summary

- Add minimum version `0.15.0` to the `BarefootJS` dependency in `packages/adapter-mojolicious/cpanfile`
- The plugin calls `$bf->search_params()` (added in 0.15.0); without a version floor, CPAN smokers with older BarefootJS fail `manifest_defaults.t`

Fixes #1958

## Test plan

- [ ] Verify `Makefile.PL` picks up the version constraint from `cpanfile` (it uses `Module::CPANfile->load`)
- [ ] Confirm CPAN install pulls BarefootJS >= 0.15.0 as a prerequisite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lkwi1oCdBpYPnY1rJ9BDjv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lkwi1oCdBpYPnY1rJ9BDjv)_