### PR TITLE
docs(adapters): mark #1896 data-table as resolved in tracking comments

### DIFF
--- a/.changeset/itchy-spiders-cheer.md
+++ b/.changeset/itchy-spiders-cheer.md
@@ -1,0 +1,6 @@
+---
+---
+
+docs: mark #1896 `data-table` tracking comments as resolved. Comment-only
+change (Go adapter `indexAccess` note + go/mojo/xslate test docstrings) —
+no behavior change and no published output, so no version bump.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -42,12 +42,15 @@ runAdapterConformanceTests({
   // `TemplateFuncMap`). Shapes the adapter intentionally refuses at
   // build time are pinned in `expectedDiagnostics` below.
   //
-  // `data-table` is the one remaining #1896 gap: its table body is a
-  // keyed `.map` over a `/* @client */`-sorted MEMO whose data is a
-  // module-const object array — a memo-derived dynamic loop of imported
-  // components, which the nested-component slice constructor can't bake
-  // yet (`item.ID` is on the loop datum, not the child's Input). Full
-  // coverage remains at the Hono SSR + fixture-hydrate layers.
+  // `data-table` — the last #1896 holdout — now renders to Hono byte
+  // parity on real Go and is fully un-skipped (run in CI). Its table
+  // body is a keyed `.map` over a `/* @client */`-sorted MEMO whose
+  // data is a module-const object array (a memo-derived dynamic loop of
+  // imported components); the nested-component slice constructor bakes
+  // it via loop-body children companion defines, a wrapper struct +
+  // constructor, and block-body memo folding (#1897). On Go it is
+  // un-skipped everywhere — including `skipMarkerConformance` below,
+  // since the SSR template emits the slot ids the IR declares.
   //
   // `search-params` (router v0.5) now renders on Go: `logical()` parenthesises
   // its multi-token operands so `searchParams().get(k) ?? d` lowers to

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -5495,8 +5495,8 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // through the same emitter so a loop-variable / arithmetic index
     // lowers correctly. A multi-token operand (`bf_add $i 1`) must be
     // parenthesised or Go parses it as extra `index` arguments. #1897
-    // (`selected()[index]`). (data-table's broader keyed-loop SSR stays
-    // tracked under #1896.)
+    // (`selected()[index]`). (data-table's broader keyed-loop SSR now
+    // renders at parity — #1896 resolved.)
     return `index ${wrapIfMultiToken(emit(object))} ${wrapIfMultiToken(emit(index))}`
   }
 

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -78,8 +78,12 @@ runAdapterConformanceTests({
     // #1467 Phase 2e: `data-table` is no longer pinned here either — it
     // compiles clean (`selected()[index]` → `index-access`,
     // `.toFixed(2)` → `bf->to_fixed`, `/* @client */` memo SSR-folded)
-    // and is pinned in `skipJsx` above on the keyed-loop scope-ID
-    // divergence alone (#1896), not a BF101.
+    // and renders to Hono parity on real Mojolicious. The keyed-loop
+    // scope-ID divergence (#1896) was fixed by the body-children
+    // `inLoop` reset (loop-item children get `_bf_slot`); data-table is
+    // off `skipJsx` entirely and only kept in `skipMarkerConformance`
+    // below for the shared `/* @client */` keyed-map slot-id elision
+    // contract (same as `todo-app`), not a render or BF101 gap.
     // #1443: `[a, b].filter(Boolean).join(' ')` (the registry Slot's
     // shape) now lowers to `join(' ', @{[grep { $_ } @{[$a, $b]}]})`.
     // No BF101 expected — pinned positively via the

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -88,8 +88,12 @@ runAdapterConformanceTests({
     // #1467 Phase 2e: `data-table` is no longer pinned here — it
     // compiles clean now (`selected()[index]` → `index-access`,
     // `.toFixed(2)` → `$bf.to_fixed`, `/* @client */` memo SSR-folded)
-    // and is pinned in `skipJsx` above on the keyed-loop scope-ID
-    // divergence alone (#1896), not a BF101.
+    // and renders to Hono parity on real Text::Xslate. The keyed-loop
+    // scope-ID divergence (#1896) was fixed by the body-children
+    // `inLoop` reset (loop-item children get `_bf_slot`); data-table is
+    // off `skipJsx` entirely and only kept in `skipMarkerConformance`
+    // below for the shared `/* @client */` keyed-map slot-id elision
+    // contract (same as `todo-app`), not a render or BF101 gap.
     // `style-3-signals` / `style-object-dynamic` no longer pinned — a
     // `style={{ … }}` object literal now lowers to a CSS string with dynamic
     // values interpolated (`background-color:<: $color :>;padding:8px`) via


### PR DESCRIPTION
## Summary

#1896 is functionally **already resolved** — this PR only corrects the now-inaccurate tracking docstrings that still describe `data-table` as an open gap.

- The headline gap (JSX children of an imported child component rendering as an empty container on the Go template adapter) was fixed by **PR #1903**.
- The single remaining case — `data-table`, a keyed `.map` over a `/* @client */`-sorted **memo** of module-const object data (a memo-derived dynamic loop of imported components) — was fixed by **PR #1909 (#1897)** via loop-body children companion defines, a wrapper struct + constructor, and block-body memo folding.

## Verification

Ran the Go adapter conformance suite on **real Go 1.25.6** (`GOTOOLCHAIN=go1.25.6 bun test`):

```
520 pass · 3 skip · 0 fail   (523 tests)
```

`data-table` is un-skipped and renders to **Hono byte parity** on real Go. (The 3 skips are the unrelated Math.floor / JSON.stringify / @client *e2e* probes.) On Mojolicious / Text::Xslate `data-table` likewise renders at parity — it is off `skipJsx` entirely and kept only in `skipMarkerConformance` for the shared `/* @client */` keyed-map slot-id elision contract (the same contract as `todo-app`), which is not a #1896 concern.

## Changes (comments only — no behavior change)

- `adapter-go-template` test: the `skipJsx` docstring no longer calls `data-table` "the one remaining #1896 gap" — it now records that data-table renders at parity and is un-skipped everywhere on Go.
- `adapter-go-template` `indexAccess` note: drops the stale "stays tracked under #1896" parenthetical.
- `adapter-mojolicious` / `adapter-xslate` tests: the `data-table` notes claimed it was "pinned in `skipJsx` above" — there is no `skipJsx` set; corrected to describe the resolved state (the #1896 keyed-loop scope-ID divergence was fixed by the body-children `inLoop` reset).

## Recommendation

With the headline gap and the data-table case both merged and verified at parity, **#1896 can be closed.** Posting the verification summary on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKxKGfmBQe5n4oN6XUd7gu)_