### PR TITLE
feat(cli): agent gates and machine-readable contract for bf debug profile

### DIFF
--- a/.changeset/profile-agent-gates.md
+++ b/.changeset/profile-agent-gates.md
@@ -1,0 +1,10 @@
+---
+"@barefootjs/jsx": minor
+"@barefootjs/cli": minor
+---
+
+Add agent-oriented gates and a machine-readable contract to `bf debug profile` (#1841).
+
+A dynamic run (`--scenario`) now carries an agent contract in its JSON: a normalized top-level `status` (`ok`/`warning`/`error`), a flattened `findings` array (each with `severity`, an explicit `actionable` flag, and ready-to-run `nextCommands` like `bf debug trace <comp> <signal> --json`), a `coverage.ratio`, and — when handlers were under-exercised — `guidance` pointing at a story/scenario file. The structured per-analysis tables are unchanged; this is an additive agent view alongside them.
+
+New opt-in CI gates make the command fail with intent: `--fail-on unresolved|hot|coverage` (with `--scenario`) and `--fail-on regression` (with `--diff`), plus the numeric thresholds `--min-coverage`, `--max-runs-per-turn`, and `--max-unresolved`. A tripped gate exits non-zero, escalates `status` to `error`, and emits a `gates` block (`{passed, failed, checks}`). By default no gate is active, so an ungated run is unchanged.

--- a/packages/cli/src/__tests__/debug-profile-flags.test.ts
+++ b/packages/cli/src/__tests__/debug-profile-flags.test.ts
@@ -27,6 +27,32 @@ describe('bf debug profile — --scenario + --diff are mutually exclusive (#1849
   })
 })
 
+describe('bf debug profile — agent gate flag validation (#1841)', () => {
+  test('a dynamic gate without --scenario is a usage error', () => {
+    const r = runCli(['debug', 'profile', 'button', '--min-coverage', '0.8'])
+    expect(r.exitCode).toBe(1)
+    expect(r.stderr).toContain('--scenario')
+  })
+
+  test('--fail-on regression without --diff is a usage error', () => {
+    const r = runCli(['debug', 'profile', 'button', '--fail-on', 'regression'])
+    expect(r.exitCode).toBe(1)
+    expect(r.stderr).toContain('--diff')
+  })
+
+  test('an unknown gate name in --fail-on is rejected', () => {
+    const r = runCli(['debug', 'profile', 'button', '--scenario', 'auto', '--fail-on', 'bogus'])
+    expect(r.exitCode).toBe(1)
+    expect(r.stderr).toContain('unknown gate')
+  })
+
+  test('--min-coverage out of [0,1] is rejected', () => {
+    const r = runCli(['debug', 'profile', 'button', '--scenario', 'auto', '--min-coverage', '2'])
+    expect(r.exitCode).toBe(1)
+    expect(r.stderr).toContain('--min-coverage')
+  })
+})
+
 describe('bf debug profile — git stderr does not leak on a bad --diff ref (#1849 B8)', () => {
   test('git diagnostics fold into the CLI error, no raw "fatal:" line leaks', () => {
     const r = runCli(['debug', 'profile', 'button', '--diff', 'nonexistent-ref'])

--- a/packages/cli/src/commands/debug-profile.ts
+++ b/packages/cli/src/commands/debug-profile.ts
@@ -15,10 +15,11 @@ import { execFileSync } from 'child_process'
 import { readFileSync } from 'fs'
 import path from 'path'
 import type { CliContext } from '../context'
+import type { GateConfig, GateName, GateResult } from '@barefootjs/jsx'
 import { resolveComponentSource } from '../lib/resolve-source'
 
 const USAGE =
-  'Usage: bf debug profile <component> [--diff <ref>] [--scenario auto|<file>] [--fanout <n>] [--top <n>] [--hot-ms <n>] [--wasted-pct <n>] [--json]'
+  'Usage: bf debug profile <component> [--diff <ref>] [--scenario auto|<file>] [--fanout <n>] [--top <n>] [--hot-ms <n>] [--wasted-pct <n>] [--fail-on <gates>] [--min-coverage <r>] [--max-runs-per-turn <n>] [--max-unresolved <n>] [--json]'
 
 // Full, self-contained guide (shown by `bf debug profile --help`). This is the
 // single source of truth for the profiler's UX — there is no separate spec doc
@@ -87,6 +88,25 @@ FLAGS
                       is additive-only. Stable schema with deterministic
                       tie-breaking; structural findings reproduce run-to-run
                       (wall-clock-timed ranks can shift near rounding boundaries).
+                      A dynamic run also carries \`status\`, normalized \`findings\`
+                      (severity + actionable + nextCommands), and — when handlers
+                      were under-exercised — \`guidance\` pointing at a story file.
+
+AGENT GATES (CI pass/fail with intent)
+  By default a run never fails CI. Opt into a gate and the command exits non-zero
+  when it trips, emitting a \`gates\` block ({passed, failed, checks}) in --json and
+  escalating \`status\` to "error". Gates compose with --json so an agent decides
+  fail-vs-continue without parsing prose.
+
+  --fail-on <gates>        Comma-separated: unresolved,hot,coverage (need
+                           --scenario) and regression (needs --diff). Each uses its
+                           default threshold unless a numeric flag below overrides.
+  --min-coverage <r>       Fail when coverage ratio < r (0–1). Implies the
+                           coverage gate. Needs --scenario.
+  --max-runs-per-turn <n>  Fail when the hottest subscriber exceeds n runs/turn.
+                           Implies the hot gate. Needs --scenario.
+  --max-unresolved <n>     Fail when more than n unresolved (actionable) coverage
+                           gaps remain. Implies the unresolved gate. Needs --scenario.
 
 EXAMPLES
   bf debug profile calendar                       # static budget, no run
@@ -94,6 +114,8 @@ EXAMPLES
   bf debug profile calendar --scenario auto --top 5 --hot-ms 1
   bf debug profile checkout --scenario ./stories/checkout.tsx --json
   bf debug profile checkout --diff origin/main    # regression gate (CI)
+  bf debug profile calendar --scenario auto --min-coverage 0.8 --fail-on hot --json
+  bf debug profile checkout --diff origin/main --fail-on regression --json
 
 NOTES
   • Instrumentation is dev-only and is stripped from production builds.
@@ -112,7 +134,34 @@ interface ProfileFlags {
   minMs?: number
   /** `--wasted-pct <n>`: flag a subscriber whose runs are ≥ n% identical output. */
   wastedPct?: number
+  /** `--fail-on <gates>`: comma-separated gate names that make the run exit non-zero. */
+  failOn?: GateName[]
+  /** `--min-coverage <r>`: minimum coverage ratio in [0,1] (gate). */
+  minCoverage?: number
+  /** `--max-runs-per-turn <n>`: budget for the hottest subscriber's runs/turn (gate). */
+  maxRunsPerTurn?: number
+  /** `--max-unresolved <n>`: maximum allowed unresolved coverage gaps (gate). */
+  maxUnresolved?: number
   positional: string[]
+}
+
+const GATE_NAMES: readonly GateName[] = ['unresolved', 'hot', 'coverage', 'regression']
+
+/** Parse and validate `--fail-on a,b,c` into a deduped list of known gate names. */
+function parseFailOn(raw: string): GateName[] {
+  const parts = raw
+    .split(',')
+    .map(s => s.trim())
+    .filter(s => s.length > 0)
+  if (parts.length === 0) fail('--fail-on requires at least one gate name.')
+  const out: GateName[] = []
+  for (const p of parts) {
+    if (!GATE_NAMES.includes(p as GateName)) {
+      fail(`--fail-on: unknown gate "${p}" (expected ${GATE_NAMES.join(', ')}).`)
+    }
+    if (!out.includes(p as GateName)) out.push(p as GateName)
+  }
+  return out
 }
 
 /**
@@ -162,6 +211,10 @@ function parseFlags(args: string[]): ProfileFlags {
     else if (a === '--top') flags.topN = num(args, ++i, '--top', { integer: true, min: 1 })
     else if (a === '--hot-ms') flags.minMs = num(args, ++i, '--hot-ms', { min: 0 })
     else if (a === '--wasted-pct') flags.wastedPct = num(args, ++i, '--wasted-pct', { min: 0, max: 100 })
+    else if (a === '--fail-on') flags.failOn = parseFailOn(value(args, ++i, '--fail-on'))
+    else if (a === '--min-coverage') flags.minCoverage = num(args, ++i, '--min-coverage', { min: 0, max: 1 })
+    else if (a === '--max-runs-per-turn') flags.maxRunsPerTurn = num(args, ++i, '--max-runs-per-turn', { min: 0 })
+    else if (a === '--max-unresolved') flags.maxUnresolved = num(args, ++i, '--max-unresolved', { integer: true, min: 0 })
     else if (a.startsWith('-')) fail(`Unknown flag "${a}".`)
     else flags.positional.push(a)
   }
@@ -172,6 +225,13 @@ function fail(message: string): never {
   console.error(`Error: ${message}`)
   console.error(USAGE)
   process.exit(1)
+}
+
+/** Render a gate result as a compact pass/fail block for the text output. */
+function formatGates(g: GateResult): string {
+  const lines = [`gates: ${g.passed ? 'PASS' : 'FAIL'}`]
+  for (const c of g.checks) lines.push(`  ${c.passed ? '✓' : '✗'} ${c.gate}: ${c.message}`)
+  return lines.join('\n')
 }
 
 export async function run(args: string[], ctx: CliContext): Promise<void> {
@@ -192,6 +252,25 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
     fail('--scenario and --diff cannot be combined: --scenario measures a run, --diff compares two compiles. Pick one.')
   }
 
+  // Gates need the data their mode produces, so validate the pairing up front
+  // (#1841): the dynamic gates (coverage / unresolved / hot + their thresholds)
+  // need a measured run (`--scenario`); the `regression` gate needs a compile
+  // comparison (`--diff`). Mixing them — or using either without its mode — is a
+  // usage error, caught here rather than silently producing an empty gate set.
+  const wantsRegression = (flags.failOn ?? []).includes('regression')
+  const dynamicFailOn = (flags.failOn ?? []).filter((g): g is GateName => g !== 'regression')
+  const wantsDynamicGate =
+    dynamicFailOn.length > 0 ||
+    flags.minCoverage !== undefined ||
+    flags.maxRunsPerTurn !== undefined ||
+    flags.maxUnresolved !== undefined
+  if (wantsDynamicGate && !flags.scenario) {
+    fail('Coverage / unresolved / hot gates need a measured run — add --scenario auto|<file>.')
+  }
+  if (wantsRegression && !flags.diff) {
+    fail('--fail-on regression needs a compile comparison — add --diff <ref>.')
+  }
+
   const {
     buildStaticBudget,
     formatStaticBudget,
@@ -199,6 +278,7 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
     formatBudgetDiff,
     buildProfileReport,
     formatProfileReport,
+    evaluateProfileGates,
   } = await import('@barefootjs/jsx')
 
   const componentName = flags.positional[0]
@@ -257,12 +337,30 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
         // `--wasted-pct` is a percentage on the CLI; the analysis takes a [0,1] fraction.
         wastedRatio: flags.wastedPct !== undefined ? flags.wastedPct / 100 : undefined,
       })
+      // Gates (#1841): turn the measured report into a CI pass/fail. A gate is
+      // active only when the agent asked for it (named in --fail-on or its
+      // threshold set), so a plain run is unchanged — no gates, no exit code.
+      const gateConfig: GateConfig = {
+        failOn: dynamicFailOn,
+        minCoverage: flags.minCoverage,
+        maxRunsPerTurn: flags.maxRunsPerTurn,
+        maxUnresolved: flags.maxUnresolved,
+      }
+      const gates = wantsDynamicGate ? evaluateProfileGates(report, gateConfig) : undefined
+
       if (ctx.jsonFlag) {
-        console.log(JSON.stringify(report, null, 2))
+        // A failed gate escalates the measured status to `error`; merge the gate
+        // result in as a top-level field so an agent reads one object.
+        const out = gates
+          ? { ...report, status: gates.passed ? report.status : 'error', gates }
+          : report
+        console.log(JSON.stringify(out, null, 2))
       } else {
         console.log(formatProfileReport(report))
         if (fired === 0) console.log('  note: no interactive elements were found to fire.')
+        if (gates) console.log('\n' + formatGates(gates))
       }
+      if (gates && !gates.passed) process.exit(1)
     } catch (err) {
       console.error(`Error: ${(err as Error).message}`)
       process.exit(1)
@@ -290,10 +388,31 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
     })
     const diff = diffStaticBudget(base, head)
 
+    // `--diff` is already CI-able: it exits non-zero on any structural
+    // regression. `--fail-on regression` (#1841) makes that contract explicit
+    // and emits a machine-readable `gates` block, but the exit behavior is
+    // unchanged so existing pipelines keep working without the flag.
+    const gates: GateResult | undefined = wantsRegression
+      ? {
+          passed: !diff.regressed,
+          failed: diff.regressed ? ['regression'] : [],
+          checks: [
+            {
+              gate: 'regression',
+              passed: !diff.regressed,
+              observed: diff.regressed ? 1 : 0,
+              threshold: 0,
+              message: diff.regressed ? 'a reactivity metric regressed' : 'no regression',
+            },
+          ],
+        }
+      : undefined
+
     if (ctx.jsonFlag) {
-      console.log(JSON.stringify(diff, null, 2))
+      console.log(JSON.stringify(gates ? { ...diff, gates } : diff, null, 2))
     } else {
       console.log(formatBudgetDiff(diff))
+      if (gates) console.log('\n' + formatGates(gates))
     }
     if (diff.regressed) process.exit(1)
     return

--- a/packages/cli/src/commands/debug-profile.ts
+++ b/packages/cli/src/commands/debug-profile.ts
@@ -347,14 +347,14 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
         maxUnresolved: flags.maxUnresolved,
       }
       const gates = wantsDynamicGate ? evaluateProfileGates(report, gateConfig) : undefined
+      // A tripped gate escalates the measured status to `error`. Apply it on the
+      // report itself so both the JSON object and the text report (which reads
+      // `report.status`) agree — the contract is one status, not per-format.
+      if (gates && !gates.passed) report.status = 'error'
 
       if (ctx.jsonFlag) {
-        // A failed gate escalates the measured status to `error`; merge the gate
-        // result in as a top-level field so an agent reads one object.
-        const out = gates
-          ? { ...report, status: gates.passed ? report.status : 'error', gates }
-          : report
-        console.log(JSON.stringify(out, null, 2))
+        // Merge the gate result in as a top-level field so an agent reads one object.
+        console.log(JSON.stringify(gates ? { ...report, gates } : report, null, 2))
       } else {
         console.log(formatProfileReport(report))
         if (fired === 0) console.log('  note: no interactive elements were found to fire.')

--- a/packages/jsx/src/__tests__/profiler.test.ts
+++ b/packages/jsx/src/__tests__/profiler.test.ts
@@ -601,6 +601,19 @@ describe('agent contract: status, findings, guidance (#1841)', () => {
     expect(gap.subscriber).toBe('Calc#memo:ghost')
   })
 
+  test('nextCommands target the component parsed from the id, not the root', () => {
+    n = 0
+    // A scenario-file run resolves subscribers from composed children: the id's
+    // component (`Child`) differs from the profiled root (`Calc`). Follow-up
+    // commands must target `Child`, or they point an agent at the wrong file.
+    const events: ProfilerEvent[] = [ev('effectEnter', { subscriber: 'Child#memo:ghost' })]
+    const r = buildProfileReport({ source: src, filePath: 'Calc.tsx', scenario: 'auto', events })
+    const gap = r.findings.find(f => f.kind === 'coverage-gap')!
+    expect(gap.nextCommands).toContain('bf debug trace Child ghost --json')
+    expect(gap.nextCommands).toContain('bf debug graph Child --json')
+    expect(gap.nextCommands.every(c => !c.includes('graph Calc'))).toBe(true)
+  })
+
   test('a zero-turn run emits guidance pointing at a story file', () => {
     n = 0
     // Handlers exist (the onClick) but none fired → no-interactions guidance.

--- a/packages/jsx/src/__tests__/profiler.test.ts
+++ b/packages/jsx/src/__tests__/profiler.test.ts
@@ -614,6 +614,20 @@ describe('agent contract: status, findings, guidance (#1841)', () => {
     expect(gap.nextCommands.every(c => !c.includes('graph Calc'))).toBe(true)
   })
 
+  test('coverage.ratio is clamped to 1 when the stream over-counts handlers', () => {
+    n = 0
+    // Calc exposes a single handler (handlersTotal 1), but a malformed stream
+    // reports two distinct turn ids — without clamping the ratio would be 2.0
+    // and silently pass a `--min-coverage` gate it shouldn't.
+    const events: ProfilerEvent[] = [
+      ev('effectEnter', { subscriber: 'Calc#memo:a', turn: 'Calc#handler:s0:click' }),
+      ev('effectEnter', { subscriber: 'Calc#memo:a', turn: 'Calc#handler:s9:click' }),
+    ]
+    const r = buildProfileReport({ source: src, filePath: 'Calc.tsx', scenario: 'auto', events })
+    expect(r.coverage.ratio).toBe(1)
+    expect(r.coverage.ratio).toBeLessThanOrEqual(1)
+  })
+
   test('a zero-turn run emits guidance pointing at a story file', () => {
     n = 0
     // Handlers exist (the onClick) but none fired → no-interactions guidance.

--- a/packages/jsx/src/__tests__/profiler.test.ts
+++ b/packages/jsx/src/__tests__/profiler.test.ts
@@ -20,6 +20,7 @@ import {
   buildIdIndex,
   joinProfilerEvents,
   findUninstrumentedEffects,
+  evaluateProfileGates,
 } from '../profiler'
 import { buildComponentAnalysis } from '../debug'
 import type { ProfilerEvent } from '@barefootjs/shared'
@@ -531,5 +532,126 @@ describe('findUninstrumentedEffects (#1849 B6)', () => {
     // Only the uninstrumented (line 8) call is a candidate; the instrumented
     // top-level effect (line 6) is excluded.
     expect(e1.candidates).toEqual([{ file: 'C.tsx', line: 8 }])
+  })
+})
+
+describe('agent contract: status, findings, guidance (#1841)', () => {
+  const src = `
+    'use client'
+    import { createSignal, createMemo } from '@barefootjs/client'
+    export function Calc() {
+      const [count, setCount] = createSignal(0)
+      const a = createMemo(() => count() * 2)
+      return <button onClick={() => setCount(count() + 1)}>{a()}</button>
+    }
+  `
+  let n = 0
+  const ev = (type: ProfilerEvent['type'], f: Partial<ProfilerEvent> = {}): ProfilerEvent =>
+    ({ type, seq: n++, turn: null, ...f })
+
+  // A memo that re-runs 3× in a single turn → runsPerTurn 3 → flagged `hot`.
+  function hotRunEvents(): ProfilerEvent[] {
+    n = 0
+    const turn = 'Calc#handler:s0:click'
+    const events: ProfilerEvent[] = [ev('turnBegin', { handlerId: turn })]
+    for (let i = 0; i < 3; i++) {
+      events.push(ev('effectEnter', { subscriber: 'Calc#memo:a', turn }))
+      events.push(ev('effectExit', { subscriber: 'Calc#memo:a', dur: 1, turn }))
+    }
+    events.push(ev('turnEnd', {}))
+    return events
+  }
+
+  test('a clean run is status ok with no findings', () => {
+    n = 0
+    // One memo run in a turn → runsPerTurn 1 → not hot, nothing flagged.
+    const turn = 'Calc#handler:s0:click'
+    const events: ProfilerEvent[] = [
+      ev('turnBegin', { handlerId: turn }),
+      ev('effectEnter', { subscriber: 'Calc#memo:a', turn }),
+      ev('effectExit', { subscriber: 'Calc#memo:a', dur: 1, turn }),
+      ev('turnEnd', {}),
+    ]
+    const r = buildProfileReport({ source: src, filePath: 'Calc.tsx', scenario: 'auto', events })
+    expect(r.status).toBe('ok')
+    expect(r.findings).toHaveLength(0)
+    expect(r.coverage.ratio).toBe(1)
+    expect(r.guidance).toBeUndefined()
+  })
+
+  test('a hot subscriber becomes a warning finding with valid nextCommands', () => {
+    const r = buildProfileReport({ source: src, filePath: 'Calc.tsx', scenario: 'auto', events: hotRunEvents() })
+    expect(r.status).toBe('warning')
+    const hot = r.findings.find(f => f.kind === 'hot-subscriber')!
+    expect(hot.severity).toBe('warning')
+    expect(hot.actionable).toBe(true)
+    expect(hot.subscriber).toBe('Calc#memo:a')
+    // A memo id maps to a name `bf debug trace` accepts; graph is the fallback.
+    expect(hot.nextCommands).toContain('bf debug trace Calc a --json')
+    expect(hot.nextCommands).toContain('bf debug graph Calc --json')
+  })
+
+  test('an unresolved id is an actionable coverage-gap finding', () => {
+    n = 0
+    // A profiler-shaped id with no matching IR node → SR4 coverage gap.
+    const events: ProfilerEvent[] = [ev('effectEnter', { subscriber: 'Calc#memo:ghost' })]
+    const r = buildProfileReport({ source: src, filePath: 'Calc.tsx', scenario: 'auto', events })
+    const gap = r.findings.find(f => f.kind === 'coverage-gap')!
+    expect(gap.actionable).toBe(true)
+    expect(gap.subscriber).toBe('Calc#memo:ghost')
+  })
+
+  test('a zero-turn run emits guidance pointing at a story file', () => {
+    n = 0
+    // Handlers exist (the onClick) but none fired → no-interactions guidance.
+    const events: ProfilerEvent[] = [ev('effectEnter', { subscriber: 'Calc#memo:a' })]
+    const r = buildProfileReport({ source: src, filePath: 'Calc.tsx', scenario: 'auto', events })
+    expect(r.turns).toBe(0)
+    expect(r.guidance?.reason).toBe('no-interactions')
+    expect(r.guidance?.nextCommands[0]).toContain('--scenario <story.tsx>')
+  })
+
+  describe('evaluateProfileGates', () => {
+    test('hot gate fails when a subscriber exceeds the runs/turn budget', () => {
+      const r = buildProfileReport({ source: src, filePath: 'Calc.tsx', scenario: 'auto', events: hotRunEvents() })
+      const fail = evaluateProfileGates(r, { maxRunsPerTurn: 2 })
+      expect(fail.passed).toBe(false)
+      expect(fail.failed).toContain('hot')
+      const pass = evaluateProfileGates(r, { maxRunsPerTurn: 5 })
+      expect(pass.passed).toBe(true)
+    })
+
+    test('bare --fail-on hot trips on any flagged hot subscriber', () => {
+      const r = buildProfileReport({ source: src, filePath: 'Calc.tsx', scenario: 'auto', events: hotRunEvents() })
+      const g = evaluateProfileGates(r, { failOn: ['hot'] })
+      expect(g.passed).toBe(false)
+      expect(g.checks[0].threshold).toBeNull()
+    })
+
+    test('coverage gate compares ratio against --min-coverage', () => {
+      n = 0
+      // Handlers exist but only mount runs, no turn → ratio 0.
+      const events: ProfilerEvent[] = [ev('effectEnter', { subscriber: 'Calc#memo:a' })]
+      const r = buildProfileReport({ source: src, filePath: 'Calc.tsx', scenario: 'auto', events })
+      expect(r.coverage.ratio).toBe(0)
+      const g = evaluateProfileGates(r, { minCoverage: 0.8 })
+      expect(g.passed).toBe(false)
+      expect(g.failed).toContain('coverage')
+    })
+
+    test('unresolved gate counts actionable gaps against --max-unresolved', () => {
+      n = 0
+      const events: ProfilerEvent[] = [ev('effectEnter', { subscriber: 'Calc#memo:ghost' })]
+      const r = buildProfileReport({ source: src, filePath: 'Calc.tsx', scenario: 'auto', events })
+      expect(evaluateProfileGates(r, { maxUnresolved: 0 }).passed).toBe(false)
+      expect(evaluateProfileGates(r, { maxUnresolved: 5 }).passed).toBe(true)
+    })
+
+    test('no configured gate yields an empty, passing result', () => {
+      const r = buildProfileReport({ source: src, filePath: 'Calc.tsx', scenario: 'auto', events: hotRunEvents() })
+      const g = evaluateProfileGates(r, {})
+      expect(g.passed).toBe(true)
+      expect(g.checks).toHaveLength(0)
+    })
   })
 })

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -308,6 +308,7 @@ export {
   formatWastedReReruns,
   analyzeBatchAdvisor,
   formatBatchAdvisor,
+  evaluateProfileGates,
 } from './profiler.ts'
 export type {
   StaticBudget,
@@ -335,6 +336,14 @@ export type {
   BatchAdvisorResult,
   BatchCandidate,
   BatchSafety,
+  ProfileSeverity,
+  ProfileStatus,
+  AgentFinding,
+  ScenarioGuidance,
+  GateName,
+  GateConfig,
+  GateCheck,
+  GateResult,
 } from './profiler.ts'
 
 // Reactive profile — findings layer (#1690 dogfood: Bug A/C/D fixes, batch-candidate dedup,

--- a/packages/jsx/src/profiler.ts
+++ b/packages/jsx/src/profiler.ts
@@ -1706,8 +1706,11 @@ export function buildProfileReport(input: ProfileReportInput): ProfileReport {
   const status: ProfileStatus = findings.some(f => f.severity === 'warning' || f.severity === 'error') ? 'warning' : 'ok'
 
   // Coverage ratio: 1 when there is nothing to cover (no handlers), else the
-  // exercised fraction. Drives `--min-coverage` and the guidance below.
-  const ratio = handlersTotal > 0 ? handlerIds.size / handlersTotal : 1
+  // exercised fraction. Clamped to `[0,1]` — a malformed stream (more distinct
+  // turn ids than `buildEventSummary` knows about, e.g. missing `extraSources`)
+  // must not push the ratio past 1 and break a gate's assumptions. Drives
+  // `--min-coverage` and the guidance below.
+  const ratio = handlersTotal > 0 ? Math.min(1, handlerIds.size / handlersTotal) : 1
   let guidance: ScenarioGuidance | undefined
   if (turnSeqs.size === 0) {
     guidance =
@@ -1825,7 +1828,7 @@ export interface GateConfig {
 }
 
 export interface GateCheck {
-  gate: string
+  gate: GateName
   passed: boolean
   /** The measured value the gate compared (ratio, count, or runs/turn). */
   observed: number
@@ -1837,7 +1840,7 @@ export interface GateCheck {
 export interface GateResult {
   passed: boolean
   /** Names of the gates that failed — the `gates.failed` an agent branches on. */
-  failed: string[]
+  failed: GateName[]
   checks: GateCheck[]
 }
 

--- a/packages/jsx/src/profiler.ts
+++ b/packages/jsx/src/profiler.ts
@@ -1395,9 +1395,12 @@ export interface ProfileReport {
   coverage: ProfileCoverage
   /**
    * Normalized run status an agent can branch on without parsing prose (#1841):
-   * `ok` when nothing is flagged, `warning` when there are actionable findings.
-   * A failed *gate* escalates this to `error` — but gates are policy applied by
-   * the CLI from flags, so the builder only ever sets `ok`/`warning` here.
+   * `ok` when nothing is flagged, `warning` when any finding is severity
+   * `warning` or higher — regardless of its `actionable` flag, since an
+   * unresolved-but-real cost (e.g. a hot subscriber with no source loc) is still
+   * worth surfacing. A failed *gate* escalates this to `error` — but gates are
+   * policy applied by the CLI from flags, so the builder only ever sets
+   * `ok`/`warning` here.
    */
   status: ProfileStatus
   /**

--- a/packages/jsx/src/profiler.ts
+++ b/packages/jsx/src/profiler.ts
@@ -1427,13 +1427,20 @@ export type ProfileStatus = 'ok' | 'warning' | 'error'
  * One normalized, machine-actionable finding flattened from the per-analysis
  * tables (hot subscribers / wasted re-runs / batch advisor / coverage gaps).
  * Carries the agent contract fields the issue asks for: a normalized `severity`,
- * an explicit `actionable` flag (`false` ⇒ internal bookkeeping noise, not worth
- * a fix), and `nextCommands` — valid, ready-to-run `bf debug …` follow-ups.
+ * an explicit `actionable` flag (`false` ⇒ no safe direct fix — e.g. an
+ * unverified advisory), and `nextCommands` — valid, ready-to-run `bf debug …`
+ * follow-ups.
  */
 export interface AgentFinding {
   kind: 'hot-subscriber' | 'wasted-re-run' | 'batch-candidate' | 'coverage-gap'
   severity: ProfileSeverity
-  /** False for non-actionable findings (e.g. an unresolved id with no source). */
+  /**
+   * Whether this finding has a concrete fix worth acting on directly. `false`
+   * marks a finding an agent should *not* apply blindly — an unverified `batch()`
+   * advisory (the wrap could change behavior) or a finding whose source location
+   * the id index couldn't resolve. A coverage gap is `actionable: true`: the next
+   * step (widen the scenario, inspect the graph) is clear even without a `loc`.
+   */
   actionable: boolean
   /** The compiler subscriber/turn id this finding is about, when it has one. */
   subscriber?: string
@@ -1488,10 +1495,17 @@ export interface ProfileReportInput {
  * memo/signal id resolves to a name `bf debug trace` accepts; a DOM-binding id
  * resolves to a slotId `bf debug why-update` accepts; `bf debug graph` is always
  * applicable, so it is the universal fallback.
+ *
+ * Commands target the component parsed *from the id* (`<Component>#…`), not the
+ * primary component — a scenario-file run resolves subscribers from composed
+ * children (`extraSources`), so a child's finding must point at the child. The
+ * passed `fallbackComponent` is used only for ids that don't parse (e.g. an
+ * anonymous `e1`).
  */
-function nextCommandsForSubscriber(component: string, subscriber: string): string[] {
+function nextCommandsForSubscriber(fallbackComponent: string, subscriber: string): string[] {
   const cmds: string[] = []
   const parsed = parseProfilerId(subscriber)
+  const component = parsed?.component ?? fallbackComponent
   if (parsed) {
     if (parsed.kind === 'memo' || parsed.kind === 'signal') {
       cmds.push(`bf debug trace ${component} ${parsed.rest} --json`)
@@ -1553,7 +1567,9 @@ function buildAgentFindings(
       subscriber: c.turn,
       loc: c.loc,
       message: `${c.handler ?? c.turn} re-ran shared effects ${c.savings}× extra across ${c.writes} writes — batch() candidate (${c.safety}).`,
-      nextCommands: [`bf debug graph ${component} --json`],
+      // The turn id is `<Component>#handler:…` — for a scenario-file run it can be
+      // a composed child, so route through the helper to target the right one.
+      nextCommands: nextCommandsForSubscriber(component, c.turn),
     })
   }
   for (const u of unattributed) {
@@ -1563,7 +1579,9 @@ function buildAgentFindings(
       actionable: true,
       subscriber: u.id,
       message: `Unresolved subscriber id "${u.id}" — could not map to source (scope caveat).`,
-      nextCommands: [`bf debug graph ${component} --json`],
+      // `u.id` is shaped `<Component>#…` and may name a composed child — route
+      // through the helper so the command targets that component, not the root.
+      nextCommands: nextCommandsForSubscriber(component, u.id),
     })
   }
   return findings

--- a/packages/jsx/src/profiler.ts
+++ b/packages/jsx/src/profiler.ts
@@ -1360,6 +1360,13 @@ export interface ProfileCoverage {
   handlersFired: number
   /** Handlers the IR knows about (`buildEventSummary`). */
   handlersTotal: number
+  /**
+   * `handlersFired / handlersTotal` in `[0,1]` — the fraction of known handlers
+   * this run exercised, so an agent can gate on it (`--min-coverage`) without
+   * dividing the two counts itself (#1841). `1` when the component has no
+   * handlers (nothing to cover ⇒ trivially complete, not a gap).
+   */
+  ratio: number
   /** SR4 ids the IR could not resolve — the honest, actionable gap. */
   unattributed: UnattributedId[]
   /**
@@ -1386,6 +1393,69 @@ export interface ProfileReport {
   wastedReReruns: WastedReRunsResult
   batchAdvisor: BatchAdvisorResult
   coverage: ProfileCoverage
+  /**
+   * Normalized run status an agent can branch on without parsing prose (#1841):
+   * `ok` when nothing is flagged, `warning` when there are actionable findings.
+   * A failed *gate* escalates this to `error` — but gates are policy applied by
+   * the CLI from flags, so the builder only ever sets `ok`/`warning` here.
+   */
+  status: ProfileStatus
+  /**
+   * Flattened, normalized findings (#1841): the hot/wasted/batch/coverage tables
+   * re-expressed with a single `severity` scale, an explicit `actionable` flag,
+   * and `nextCommands` — the exact follow-up `bf debug …` invocations to run.
+   * The structured tables above stay the source of truth; this is the agent view.
+   */
+  findings: AgentFinding[]
+  /**
+   * Coverage guidance for an under-exercised run (#1841): present only when the
+   * scenario fired no or only some handlers, which usually means a story file is
+   * needed (handlers live in composed children).
+   */
+  guidance?: ScenarioGuidance
+}
+
+// -- Agent contract (#1841): normalized severity, actionable findings, guidance
+
+/** Normalized finding severity an agent can branch on without parsing prose. */
+export type ProfileSeverity = 'info' | 'warning' | 'error'
+
+/** Top-level run status: `ok` (clean), `warning` (findings), `error` (gate failed). */
+export type ProfileStatus = 'ok' | 'warning' | 'error'
+
+/**
+ * One normalized, machine-actionable finding flattened from the per-analysis
+ * tables (hot subscribers / wasted re-runs / batch advisor / coverage gaps).
+ * Carries the agent contract fields the issue asks for: a normalized `severity`,
+ * an explicit `actionable` flag (`false` ⇒ internal bookkeeping noise, not worth
+ * a fix), and `nextCommands` — valid, ready-to-run `bf debug …` follow-ups.
+ */
+export interface AgentFinding {
+  kind: 'hot-subscriber' | 'wasted-re-run' | 'batch-candidate' | 'coverage-gap'
+  severity: ProfileSeverity
+  /** False for non-actionable findings (e.g. an unresolved id with no source). */
+  actionable: boolean
+  /** The compiler subscriber/turn id this finding is about, when it has one. */
+  subscriber?: string
+  /** Source location, when the id resolved to an IR node. */
+  loc?: { file: string; line: number }
+  /** One-line human summary — the same sentence the text report would print. */
+  message: string
+  /** Follow-up commands to run next — valid, ready-to-run `bf debug …` lines. */
+  nextCommands: string[]
+}
+
+/**
+ * Coverage guidance for an under-exercised run (#1841). `--scenario auto` can
+ * only fire handlers the IR exposes on *this* component; for a compound/context
+ * component whose handlers live in composed children it fires `0/N`, and the
+ * honest next step is a story/scenario file rather than trusting a thin run.
+ */
+export interface ScenarioGuidance {
+  /** Why coverage was incomplete — drives the suggested next step. */
+  reason: 'no-handlers' | 'no-interactions' | 'partial-coverage'
+  message: string
+  nextCommands: string[]
 }
 
 export interface ProfileReportInput {
@@ -1410,6 +1480,93 @@ export interface ProfileReportInput {
    * fraction in `[0,1]`. Default 0.5.
    */
   wastedRatio?: number
+}
+
+/**
+ * The follow-up `bf debug …` commands an agent should run to investigate a
+ * subscriber finding (#1841). Every command is valid and ready to run: a
+ * memo/signal id resolves to a name `bf debug trace` accepts; a DOM-binding id
+ * resolves to a slotId `bf debug why-update` accepts; `bf debug graph` is always
+ * applicable, so it is the universal fallback.
+ */
+function nextCommandsForSubscriber(component: string, subscriber: string): string[] {
+  const cmds: string[] = []
+  const parsed = parseProfilerId(subscriber)
+  if (parsed) {
+    if (parsed.kind === 'memo' || parsed.kind === 'signal') {
+      cmds.push(`bf debug trace ${component} ${parsed.rest} --json`)
+    } else if (parsed.kind === 'binding') {
+      cmds.push(`bf debug why-update ${component} ${parsed.rest} --json`)
+    }
+  }
+  cmds.push(`bf debug graph ${component} --json`)
+  return cmds
+}
+
+/**
+ * Flatten the per-analysis tables into the normalized agent findings (#1841).
+ * Only *flagged* rows become findings — a hot subscriber that isn't `hot`, or a
+ * subscriber below the wasted threshold, is data in the tables but not something
+ * the agent must act on. Coverage gaps (unresolved ids) are actionable findings;
+ * the non-actionable bookkeeping ids stay in `coverage.diagnostics`.
+ */
+function buildAgentFindings(
+  component: string,
+  hotSubscribers: HotSubscribersResult,
+  wastedReReruns: WastedReRunsResult,
+  batchAdvisor: BatchAdvisorResult,
+  unattributed: readonly UnattributedId[],
+): AgentFinding[] {
+  const findings: AgentFinding[] = []
+  for (const s of hotSubscribers.subscribers) {
+    if (!s.hot) continue
+    findings.push({
+      kind: 'hot-subscriber',
+      severity: 'warning',
+      actionable: s.loc !== undefined,
+      subscriber: s.subscriber,
+      loc: s.loc,
+      message: `${s.name ?? s.subscriber} ran ${s.runsPerTurn.toFixed(1)}×/turn — re-run pressure (split or batch).`,
+      nextCommands: nextCommandsForSubscriber(component, s.subscriber),
+    })
+  }
+  for (const s of wastedReReruns.subscribers) {
+    if (!s.wasted) continue
+    findings.push({
+      kind: 'wasted-re-run',
+      severity: 'warning',
+      actionable: s.loc !== undefined,
+      subscriber: s.subscriber,
+      loc: s.loc,
+      message: `${s.name ?? s.subscriber} produced identical output in ${Math.round(s.wastedRatio * 100)}% of runs — finer split.`,
+      nextCommands: nextCommandsForSubscriber(component, s.subscriber),
+    })
+  }
+  for (const c of batchAdvisor.candidates) {
+    findings.push({
+      kind: 'batch-candidate',
+      // Only a *proven-safe* batch is advised as actionable warning; an
+      // unverified one is surfaced as info so an agent doesn't apply a wrap that
+      // could change behavior (mirrors the batch advisor's own safety gate).
+      severity: c.safety === 'safe' ? 'warning' : 'info',
+      actionable: c.safety === 'safe' && c.loc !== undefined,
+      subscriber: c.turn,
+      loc: c.loc,
+      message: `${c.handler ?? c.turn} re-ran shared effects ${c.savings}× extra across ${c.writes} writes — batch() candidate (${c.safety}).`,
+      nextCommands: [`bf debug graph ${component} --json`],
+    })
+  }
+  for (const u of unattributed) {
+    findings.push({
+      kind: 'coverage-gap',
+      severity: 'warning',
+      actionable: true,
+      subscriber: u.id,
+      message: `Unresolved subscriber id "${u.id}" — could not map to source (scope caveat).`,
+      nextCommands: [`bf debug graph ${component} --json`],
+    })
+  }
+  return findings
 }
 
 /**
@@ -1524,6 +1681,38 @@ export function buildProfileReport(input: ProfileReportInput): ProfileReport {
     }
   }
 
+  const findings = buildAgentFindings(primary.componentName, hotSubscribers, wastedReReruns, batchAdvisor, unattributed)
+  // Status is measurement-only here: any warning/error finding ⇒ `warning`. A
+  // failed gate escalates to `error`, but gates are CLI policy (flags), so the
+  // builder never sets `error` itself.
+  const status: ProfileStatus = findings.some(f => f.severity === 'warning' || f.severity === 'error') ? 'warning' : 'ok'
+
+  // Coverage ratio: 1 when there is nothing to cover (no handlers), else the
+  // exercised fraction. Drives `--min-coverage` and the guidance below.
+  const ratio = handlersTotal > 0 ? handlerIds.size / handlersTotal : 1
+  let guidance: ScenarioGuidance | undefined
+  if (turnSeqs.size === 0) {
+    guidance =
+      handlersTotal === 0
+        ? {
+            reason: 'no-handlers',
+            message: 'No event handlers — use the static budget instead of a dynamic run.',
+            nextCommands: [`bf debug profile ${primary.componentName} --json`],
+          }
+        : {
+            reason: 'no-interactions',
+            message:
+              'Handlers exist but none fired — they likely live in composed children. Drive the component with a story/scenario file.',
+            nextCommands: [`bf debug profile ${primary.componentName} --scenario <story.tsx> --json`],
+          }
+  } else if (ratio < 1) {
+    guidance = {
+      reason: 'partial-coverage',
+      message: `Only ${handlerIds.size}/${handlersTotal} handlers exercised — a story/scenario file can cover the rest.`,
+      nextCommands: [`bf debug profile ${primary.componentName} --scenario <story.tsx> --json`],
+    }
+  }
+
   return {
     kind: 'profile',
     schemaVersion: PROFILE_SCHEMA_VERSION,
@@ -1538,12 +1727,16 @@ export function buildProfileReport(input: ProfileReportInput): ProfileReport {
     coverage: {
       handlersFired: handlerIds.size,
       handlersTotal,
+      ratio,
       unattributed,
       // Roll the (potentially hundreds of) bookkeeping ids up to a count + a
       // small sample so JSON consumers aren't flooded (#1849 B7). `diagnostics`
       // is already sorted hottest-first by `joinProfilerEvents`.
       diagnostics: { count: diagnostics.length, sample: diagnostics.slice(0, 3).map(d => d.id) },
     },
+    status,
+    findings,
+    ...(guidance ? { guidance } : {}),
   }
 }
 
@@ -1579,5 +1772,116 @@ export function formatProfileReport(r: ProfileReport): string {
   if (c.diagnostics.count > 0) {
     lines.push(`  · ${c.diagnostics.count} anonymous runtime id(s) (non-actionable bookkeeping)`)
   }
+  // Agent contract footer (#1841): a normalized status and the single most
+  // useful next command, so a human reading the text output sees the same
+  // signal `--json` consumers branch on.
+  lines.push('')
+  lines.push(`status: ${r.status} (${r.findings.length} finding(s))`)
+  if (r.guidance) {
+    lines.push(`  guidance: ${r.guidance.message}`)
+    lines.push(`  next: ${r.guidance.nextCommands[0]}`)
+  } else if (r.findings.length > 0) {
+    lines.push(`  next: ${r.findings[0].nextCommands[0]}`)
+  }
   return lines.join('\n')
+}
+
+// -- Gates (#1841): turn a measured report into a pass/fail CI decision --------
+
+/** The gate names `--fail-on` accepts. `regression` applies to `--diff` mode. */
+export type GateName = 'unresolved' | 'hot' | 'coverage' | 'regression'
+
+/**
+ * Gate thresholds an agent/CI supplies via flags. A gate is *active* when it is
+ * named in `failOn` or its numeric threshold is set — so `--max-unresolved 0`
+ * enforces the unresolved gate without also passing `--fail-on unresolved`.
+ */
+export interface GateConfig {
+  failOn?: readonly GateName[]
+  /** `--min-coverage`: minimum `coverage.ratio` in `[0,1]`. */
+  minCoverage?: number
+  /** `--max-runs-per-turn`: budget for the hottest subscriber's runs/turn. */
+  maxRunsPerTurn?: number
+  /** `--max-unresolved`: maximum allowed unresolved (actionable) coverage gaps. */
+  maxUnresolved?: number
+}
+
+export interface GateCheck {
+  gate: string
+  passed: boolean
+  /** The measured value the gate compared (ratio, count, or runs/turn). */
+  observed: number
+  /** The threshold it was compared against; `null` for a boolean gate. */
+  threshold: number | null
+  message: string
+}
+
+export interface GateResult {
+  passed: boolean
+  /** Names of the gates that failed — the `gates.failed` an agent branches on. */
+  failed: string[]
+  checks: GateCheck[]
+}
+
+/**
+ * Evaluate the dynamic-run gates (#1841) against a measured report. Pure: maps a
+ * `ProfileReport` + thresholds to a pass/fail decision the CLI turns into an
+ * exit code. The `regression` gate is *not* evaluated here — it belongs to
+ * `--diff` mode, which the CLI gates directly off the `BudgetDiff`.
+ */
+export function evaluateProfileGates(report: ProfileReport, config: GateConfig): GateResult {
+  const failOn = new Set(config.failOn ?? [])
+  const checks: GateCheck[] = []
+
+  if (failOn.has('coverage') || config.minCoverage !== undefined) {
+    const threshold = config.minCoverage ?? 1
+    const observed = report.coverage.ratio
+    checks.push({
+      gate: 'coverage',
+      passed: observed >= threshold,
+      observed,
+      threshold,
+      message: `coverage ${(observed * 100).toFixed(0)}% ${observed >= threshold ? '≥' : '<'} required ${(threshold * 100).toFixed(0)}%`,
+    })
+  }
+
+  if (failOn.has('unresolved') || config.maxUnresolved !== undefined) {
+    const threshold = config.maxUnresolved ?? 0
+    const observed = report.coverage.unattributed.length
+    checks.push({
+      gate: 'unresolved',
+      passed: observed <= threshold,
+      observed,
+      threshold,
+      message: `${observed} unresolved id(s) ${observed <= threshold ? '≤' : '>'} allowed ${threshold}`,
+    })
+  }
+
+  if (failOn.has('hot') || config.maxRunsPerTurn !== undefined) {
+    const observed = report.hotSubscribers.subscribers.reduce((m, s) => Math.max(m, s.runsPerTurn), 0)
+    if (config.maxRunsPerTurn !== undefined) {
+      // Numeric budget: the hottest subscriber must not exceed it.
+      const threshold = config.maxRunsPerTurn
+      checks.push({
+        gate: 'hot',
+        passed: observed <= threshold,
+        observed,
+        threshold,
+        message: `max ${observed.toFixed(1)} runs/turn ${observed <= threshold ? '≤' : '>'} budget ${threshold}`,
+      })
+    } else {
+      // Bare `--fail-on hot`: any subscriber the analysis flagged `hot` fails it.
+      const anyHot = report.hotSubscribers.subscribers.some(s => s.hot)
+      checks.push({
+        gate: 'hot',
+        passed: !anyHot,
+        observed,
+        threshold: null,
+        message: anyHot ? `hot subscriber(s) present (max ${observed.toFixed(1)} runs/turn)` : 'no hot subscribers',
+      })
+    }
+  }
+
+  const failed = checks.filter(c => !c.passed).map(c => c.gate)
+  return { passed: failed.length === 0, failed, checks }
 }


### PR DESCRIPTION
## Summary

Closes #1841. Turns `bf debug profile` into a CI-able, agent-driveable command. The profiler already **measures** richly; this PR adds the **contract** layer an autonomous agent needs:

- Should this run fail CI or continue?
- Is this unresolved id actionable, or bookkeeping noise?
- Which follow-up command should run next?
- Did this run profile enough of the component to trust the result?

The existing structured tables (`hotSubscribers`, `wastedReReruns`, `batchAdvisor`, `coverage`) are unchanged — everything here is **additive** (schema stays `schemaVersion: 1`).

## Agent-friendly JSON (dynamic `--scenario` runs)

- **`status`** — normalized top-level `ok` / `warning` / `error`.
- **`findings[]`** — the per-analysis tables flattened to one normalized scale: `severity`, an explicit `actionable` flag (false ⇒ internal marker noise), and `nextCommands` — *valid, ready-to-run* follow-ups derived from the resolved id (`bf debug trace <comp> <signal> --json` for a memo/signal, `bf debug why-update <comp> <slot> --json` for a DOM binding, `bf debug graph <comp> --json` as the universal fallback).
- **`coverage.ratio`** — `handlersFired / handlersTotal`, so an agent gates on it without dividing.
- **`guidance`** — when a scenario fired `0/0` or `0/N` handlers, points at a story/scenario file (the usual cause: handlers live in composed children).

## Opt-in gates (CI pass/fail with intent)

By default no gate is active and a run is unchanged. Opt in and a tripped gate exits non-zero, escalates `status` to `error`, and emits a `gates` block (`{passed, failed, checks}`):

| Flag | Mode | Meaning |
|------|------|---------|
| `--fail-on unresolved\|hot\|coverage` | `--scenario` | enable a gate at its default threshold |
| `--fail-on regression` | `--diff` | explicit, machine-readable form of `--diff`'s existing exit-on-regression |
| `--min-coverage <r>` | `--scenario` | fail when `coverage.ratio < r` |
| `--max-runs-per-turn <n>` | `--scenario` | fail when the hottest subscriber exceeds `n` runs/turn |
| `--max-unresolved <n>` | `--scenario` | fail when more than `n` actionable coverage gaps remain |

Gate/mode mismatches are caught up front with actionable usage errors (a dynamic gate without `--scenario`; `--fail-on regression` without `--diff`).

## Example

```jsonc
{
  "schemaVersion": 1,
  "status": "error",
  "coverage": { "handlersFired": 1, "handlersTotal": 5, "ratio": 0.2, /* … */ },
  "findings": [
    { "kind": "hot-subscriber", "severity": "warning", "actionable": true,
      "subscriber": "Calendar#memo:currentMonth",
      "nextCommands": ["bf debug trace Calendar currentMonth --json", "bf debug graph Calendar --json"] }
  ],
  "guidance": { "reason": "partial-coverage", "message": "Only 1/5 handlers exercised — a story/scenario file can cover the rest.", "nextCommands": ["…"] },
  "gates": { "passed": false, "failed": ["coverage"], "checks": [/* … */] }
}
```

## Design notes

- Gate evaluation (`evaluateProfileGates`) and the findings/status/guidance derivation live in `@barefootjs/jsx` — pure over the report, deterministic, unit-tested. The CLI only wires flags → config → exit code.
- `nextCommands` are built from the parsed compiler id (`parseProfilerId`), so they reference real, runnable commands rather than guesses.
- The static-budget `handlers[]` array requested in the issue's follow-up comment (A1) already shipped (#1850), so it isn't re-done here.

## Scope

The file-based **baseline workflow** (`--save-baseline` / `--diff-baseline`) from the issue is intentionally **out of scope** — it overlaps `--diff <git-ref>`, which already covers regression detection. Happy to add it in a follow-up if a non-git baseline turns out to be needed.

## Tests

- `packages/jsx/src/__tests__/profiler.test.ts` — status/findings/guidance derivation, `coverage.ratio`, and `evaluateProfileGates` (hot budget, bare `--fail-on hot`, coverage, unresolved, empty config).
- `packages/cli/src/__tests__/debug-profile-flags.test.ts` — gate/mode validation and flag-range errors.
- Verified end-to-end against `toggle` in all three modes (gated dynamic JSON pass/fail with correct exit codes, `--diff --fail-on regression`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015yUAa7UrtqQPPhKfoZmSPW)_