### PR TITLE
Make Calendar render across all adapters (Go / Mojo / Xslate), #1467

### DIFF
--- a/.changeset/memo-checker-type-inference.md
+++ b/.changeset/memo-checker-type-inference.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Infer `createMemo` field types via the type checker (#1968).
+
+When the syntactic `inferTypeFromValue` heuristic can't resolve a memo's type (`object`/`unknown` — e.g. a local-function call like `generateCalendarDays()` or a ternary of typed arrays) and a type checker is available, the analyzer now asks it for the memo body's return type and converts it to `TypeInfo`. Adapters then generate precise types (`[][]CalendarDay`, `[]string`, `bool`, `string`) instead of `map[string]interface{}` / `bool` placeholders, so a typed backend (e.g. Go) can populate the SSR data. Only imprecise syntactic results are upgraded; already-precise types are untouched.

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -63,11 +63,17 @@ import { fixture as command } from './command'
 // #1467 Phase 2e (complex): `pagination` (one signal fanned across
 // seven href="#" links whose handlers must preventDefault) and
 // `data-table` (keyed-loop reorder on sort — the corpus's first keyed
-// reconciliation probe). `calendar` (current-month grid is a function
-// of the wall clock — non-deterministic frozen HTML) and `carousel`
-// (embla-carousel arrives via a browser dynamic import the host page
-// can't resolve without a vendor-serving story) are deferred; see the
-// #1467 Phase 2e comment.
+// reconciliation probe). `calendar` and `carousel` stay out of this
+// frozen-HTML corpus: the calendar grid renders the current month (SSR
+// output is a function of the wall clock — non-deterministic snapshot)
+// and carousel's embla arrives via a browser dynamic import the host
+// page can't resolve without a vendor-serving story. Their cross-adapter
+// SSR is still pinned, just not as frozen fixtures: calendar by the
+// deterministic compile conformance in
+// `src/__tests__/calendar-cross-adapter.test.ts` (Go/Mojo/Hono, zero
+// diagnostics — the #1467 predicate -> precomputed-field fix), and
+// runtime behavior by the `site/ui/e2e/{calendar,carousel}.spec.ts`
+// specs.
 import { fixture as pagination } from './pagination'
 import { fixture as dataTable } from './data-table'
 // #1694: text-content HTML-escaping (parallel to the #1692 attribute fix).

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -70,8 +70,8 @@ import { fixture as command } from './command'
 // page can't resolve without a vendor-serving story. Their cross-adapter
 // SSR is still pinned, just not as frozen fixtures: calendar by the
 // deterministic compile conformance in
-// `src/__tests__/calendar-cross-adapter.test.ts` (Go/Mojo/Hono, zero
-// diagnostics — the #1467 predicate -> precomputed-field fix), and
+// `src/__tests__/calendar-cross-adapter.test.ts` (Go/Mojo/Xslate/Hono,
+// zero diagnostics — the #1467 predicate -> precomputed-field fix), and
 // runtime behavior by the `site/ui/e2e/{calendar,carousel}.spec.ts`
 // specs.
 import { fixture as pagination } from './pagination'

--- a/packages/adapter-tests/package.json
+++ b/packages/adapter-tests/package.json
@@ -20,6 +20,7 @@
     "@barefootjs/go-template": "workspace:*",
     "@barefootjs/hono": "workspace:*",
     "@barefootjs/mojolicious": "workspace:*",
+    "@barefootjs/xslate": "workspace:*",
     "@playwright/test": "^1.57.0",
     "typescript": "^5.0.0"
   }

--- a/packages/adapter-tests/src/__tests__/calendar-cross-adapter.test.ts
+++ b/packages/adapter-tests/src/__tests__/calendar-cross-adapter.test.ts
@@ -10,7 +10,8 @@
  * the Go adapter (and was a latent hazard on the Perl adapters). This
  * test pins the fix: the Calendar component, the `date-picker` that
  * composes it, and the shipped Calendar demos must all compile to every
- * non-Hono adapter with zero error diagnostics.
+ * shipping adapter — Hono, Go, Mojolicious, and Text::Xslate — with zero
+ * error diagnostics.
  *
  * This is a *compile* conformance (diagnostics only), deliberately NOT a
  * frozen-HTML fixture in the `fixtures/` corpus: the grid renders the
@@ -26,6 +27,7 @@ import { fileURLToPath } from 'node:url'
 import { compileJSX } from '@barefootjs/jsx'
 import { goTemplateAdapter } from '@barefootjs/go-template/adapter'
 import { mojoAdapter } from '@barefootjs/mojolicious/adapter'
+import { xslateAdapter } from '@barefootjs/xslate/adapter'
 import { honoAdapter } from '@barefootjs/hono/adapter'
 
 // `packages/adapter-tests` is ESM ("type": "module"), so `__dirname` is not
@@ -44,6 +46,7 @@ const sources: ReadonlyArray<readonly [label: string, relPath: string]> = [
 const adapters = [
   ['Go', goTemplateAdapter],
   ['Mojo', mojoAdapter],
+  ['Xslate', xslateAdapter],
   ['Hono', honoAdapter],
 ] as const
 

--- a/packages/adapter-tests/src/__tests__/calendar-cross-adapter.test.ts
+++ b/packages/adapter-tests/src/__tests__/calendar-cross-adapter.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Calendar cross-adapter compile conformance (#1467).
+ *
+ * The Calendar grid bakes per-day selection state (single + range) onto
+ * the `CalendarDay` data so the template reads member fields
+ * (`day.isSingleSelected`, `day.buttonClasses`, …) instead of calling
+ * user-defined predicates per cell. A server-side template language has
+ * no JS runtime and cannot evaluate a `dayIsSingleSelected(day)`
+ * predicate at render time, so the predicate-call form raised BF102 on
+ * the Go adapter (and was a latent hazard on the Perl adapters). This
+ * test pins the fix: the Calendar component, the `date-picker` that
+ * composes it, and the shipped Calendar demos must all compile to every
+ * non-Hono adapter with zero error diagnostics.
+ *
+ * This is a *compile* conformance (diagnostics only), deliberately NOT a
+ * frozen-HTML fixture in the `fixtures/` corpus: the grid renders the
+ * current month, so byte-exact SSR output is a function of the wall
+ * clock and unsuitable for a deterministic snapshot. Runtime selection
+ * behavior (the reactive grid rebuild on click) is covered by
+ * `site/ui/e2e/calendar.spec.ts`.
+ */
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { compileJSX } from '@barefootjs/jsx'
+import { goTemplateAdapter } from '@barefootjs/go-template/adapter'
+import { mojoAdapter } from '@barefootjs/mojolicious/adapter'
+import { honoAdapter } from '@barefootjs/hono/adapter'
+
+// __tests__ -> src -> adapter-tests -> packages -> repo root
+const ROOT = resolve(__dirname, '../../../..')
+
+const sources: ReadonlyArray<readonly [label: string, relPath: string]> = [
+  ['calendar UI', 'ui/components/ui/calendar/index.tsx'],
+  ['date-picker UI (composes calendar)', 'ui/components/ui/date-picker/index.tsx'],
+  ['calendar-demo', 'site/ui/components/calendar-demo.tsx'],
+  ['calendar-usage-demo', 'site/ui/components/calendar-usage-demo.tsx'],
+]
+
+const adapters = [
+  ['Go', goTemplateAdapter],
+  ['Mojo', mojoAdapter],
+  ['Hono', honoAdapter],
+] as const
+
+describe('Calendar cross-adapter compile conformance (#1467)', () => {
+  for (const [label, relPath] of sources) {
+    const source = readFileSync(resolve(ROOT, relPath), 'utf8').trimStart()
+    const filename = relPath.split('/').pop()!
+    for (const [adapterName, adapter] of adapters) {
+      test(`${label} compiles on ${adapterName} with no error diagnostics`, () => {
+        const result = compileJSX(source, filename, { adapter, outputIR: true })
+        const errors = (result.errors ?? []).filter((e) => e.severity === 'error')
+        expect(errors).toEqual([])
+      })
+    }
+  }
+})

--- a/packages/adapter-tests/src/__tests__/calendar-cross-adapter.test.ts
+++ b/packages/adapter-tests/src/__tests__/calendar-cross-adapter.test.ts
@@ -21,14 +21,18 @@
  */
 import { describe, test, expect } from 'bun:test'
 import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { compileJSX } from '@barefootjs/jsx'
 import { goTemplateAdapter } from '@barefootjs/go-template/adapter'
 import { mojoAdapter } from '@barefootjs/mojolicious/adapter'
 import { honoAdapter } from '@barefootjs/hono/adapter'
 
+// `packages/adapter-tests` is ESM ("type": "module"), so `__dirname` is not
+// defined — compute the dir from `import.meta.url` (same idiom as
+// `no-bun-coupling.test.ts`).
 // __tests__ -> src -> adapter-tests -> packages -> repo root
-const ROOT = resolve(__dirname, '../../../..')
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..')
 
 const sources: ReadonlyArray<readonly [label: string, relPath: string]> = [
   ['calendar UI', 'ui/components/ui/calendar/index.tsx'],

--- a/packages/adapter-tests/src/__tests__/calendar-cross-adapter.test.ts
+++ b/packages/adapter-tests/src/__tests__/calendar-cross-adapter.test.ts
@@ -55,11 +55,14 @@ describe('Calendar cross-adapter compile conformance (#1467)', () => {
     const source = readFileSync(resolve(ROOT, relPath), 'utf8').trimStart()
     const filename = relPath.split('/').pop()!
     for (const [adapterName, adapter] of adapters) {
+      // Each case builds a TS program for the type-based analysis (~2s cold);
+      // a generous timeout keeps the first cold-cache case from flaking past
+      // bun's 5s default (the matrix is source × 4 adapters).
       test(`${label} compiles on ${adapterName} with no error diagnostics`, () => {
         const result = compileJSX(source, filename, { adapter, outputIR: true })
         const errors = (result.errors ?? []).filter((e) => e.severity === 'error')
         expect(errors).toEqual([])
-      })
+      }, 30_000)
     }
   }
 })

--- a/packages/jsx/src/analyzer-context.ts
+++ b/packages/jsx/src/analyzer-context.ts
@@ -344,11 +344,21 @@ function propertyNameText(
 
 export function typeNodeToTypeInfo(
   typeNode: ts.TypeNode | undefined,
-  sourceFile: ts.SourceFile
+  sourceFile: ts.SourceFile,
+  // When set, `raw` is derived from this extractor instead of
+  // `node.getText(sourceFile)`. Synthetic nodes (from `checker.typeToTypeNode`,
+  // used by `tsTypeToTypeInfo`) have no source positions, so `getText()` would
+  // throw — callers pass a printer-based extractor. In that mode the
+  // object-literal / function branches that need member/param source text emit
+  // a `raw`-only shape (those consumers only run on real source).
+  rawOf?: (node: ts.TypeNode) => string
 ): TypeInfo | null {
   if (!typeNode) return null
 
-  const raw = typeNode.getText(sourceFile)
+  const synthetic = rawOf !== undefined
+  const raw = rawOf ? rawOf(typeNode) : typeNode.getText(sourceFile)
+  const recurse = (n: ts.TypeNode): TypeInfo =>
+    typeNodeToTypeInfo(n, sourceFile, rawOf) ?? { kind: 'unknown', raw: 'unknown' }
 
   // Primitive types (check by SyntaxKind)
   switch (typeNode.kind) {
@@ -366,26 +376,12 @@ export function typeNodeToTypeInfo(
 
   // Array types
   if (ts.isArrayTypeNode(typeNode)) {
-    return {
-      kind: 'array',
-      raw,
-      elementType: typeNodeToTypeInfo(typeNode.elementType, sourceFile) ?? {
-        kind: 'unknown',
-        raw: 'unknown',
-      },
-    }
+    return { kind: 'array', raw, elementType: recurse(typeNode.elementType) }
   }
 
   // Union types
   if (ts.isUnionTypeNode(typeNode)) {
-    return {
-      kind: 'union',
-      raw,
-      unionTypes: typeNode.types.map(
-        (t) =>
-          typeNodeToTypeInfo(t, sourceFile) ?? { kind: 'unknown', raw: 'unknown' }
-      ),
-    }
+    return { kind: 'union', raw, unionTypes: typeNode.types.map(recurse) }
   }
 
   // Type literal (object type)
@@ -393,7 +389,9 @@ export function typeNodeToTypeInfo(
     return {
       kind: 'object',
       raw,
-      properties: membersToProperties(typeNode.members, sourceFile),
+      // Synthetic members have no source positions for membersToProperties'
+      // getText(); emit a property-less object in that mode.
+      ...(synthetic ? {} : { properties: membersToProperties(typeNode.members, sourceFile) }),
     }
   }
 
@@ -407,14 +405,7 @@ export function typeNodeToTypeInfo(
       (refName === 'Array' || refName === 'ReadonlyArray') &&
       typeNode.typeArguments?.length === 1
     ) {
-      return {
-        kind: 'array',
-        raw,
-        elementType: typeNodeToTypeInfo(typeNode.typeArguments[0], sourceFile) ?? {
-          kind: 'unknown',
-          raw: 'unknown',
-        },
-      }
+      return { kind: 'array', raw, elementType: recurse(typeNode.typeArguments[0]) }
     }
     return {
       kind: 'interface',
@@ -424,6 +415,8 @@ export function typeNodeToTypeInfo(
 
   // Function type
   if (ts.isFunctionTypeNode(typeNode)) {
+    // Param names/defaults come from getText — skip them for synthetic nodes.
+    if (synthetic) return { kind: 'function', raw }
     return {
       kind: 'function',
       raw,
@@ -450,46 +443,6 @@ export function typeNodeToTypeInfo(
 const _typePrinter = ts.createPrinter({ removeComments: true, omitTrailingSemicolon: true })
 const _blankTypeSourceFile = ts.createSourceFile('__bf_types__.ts', '', ts.ScriptTarget.Latest)
 
-function synthTypeNodeToTypeInfo(node: ts.TypeNode): TypeInfo {
-  let raw: string
-  try {
-    raw = _typePrinter.printNode(ts.EmitHint.Unspecified, node, _blankTypeSourceFile)
-  } catch {
-    raw = 'unknown'
-  }
-
-  switch (node.kind) {
-    case ts.SyntaxKind.StringKeyword:
-      return { kind: 'primitive', raw, primitive: 'string' }
-    case ts.SyntaxKind.NumberKeyword:
-      return { kind: 'primitive', raw, primitive: 'number' }
-    case ts.SyntaxKind.BooleanKeyword:
-      return { kind: 'primitive', raw, primitive: 'boolean' }
-    case ts.SyntaxKind.UndefinedKeyword:
-      return { kind: 'primitive', raw, primitive: 'undefined' }
-    case ts.SyntaxKind.NullKeyword:
-      return { kind: 'primitive', raw, primitive: 'null' }
-  }
-
-  if (ts.isArrayTypeNode(node)) {
-    return { kind: 'array', raw, elementType: synthTypeNodeToTypeInfo(node.elementType) }
-  }
-  if (ts.isUnionTypeNode(node)) {
-    return { kind: 'union', raw, unionTypes: node.types.map(synthTypeNodeToTypeInfo) }
-  }
-  if (ts.isTypeReferenceNode(node)) {
-    const name = ts.isIdentifier(node.typeName) ? node.typeName.text : ''
-    if ((name === 'Array' || name === 'ReadonlyArray') && node.typeArguments?.length === 1) {
-      return { kind: 'array', raw, elementType: synthTypeNodeToTypeInfo(node.typeArguments[0]) }
-    }
-    return { kind: 'interface', raw }
-  }
-  if (ts.isTypeLiteralNode(node)) {
-    return { kind: 'object', raw }
-  }
-  return { kind: 'unknown', raw }
-}
-
 /**
  * Convert a resolved `ts.Type` to `TypeInfo` via the type checker. Used to
  * sharpen `createMemo` field types the syntactic `inferTypeFromValue`
@@ -499,11 +452,22 @@ function synthTypeNodeToTypeInfo(node: ts.TypeNode): TypeInfo {
  * `map[string]interface{}` / `bool` placeholders, so a typed backend can't
  * populate the SSR data (#1968). Returns `null` when the type can't be
  * lowered to a `ts.TypeNode`.
+ *
+ * Shares the structural lowering in `typeNodeToTypeInfo` (via the `rawOf`
+ * extractor) so node→TypeInfo logic lives in one place; the synthetic nodes
+ * from `typeToTypeNode` have no source text, so `raw` comes from the printer.
  */
 export function tsTypeToTypeInfo(type: ts.Type, checker: ts.TypeChecker): TypeInfo | null {
   const node = checker.typeToTypeNode(type, undefined, ts.NodeBuilderFlags.NoTruncation)
   if (!node) return null
-  return synthTypeNodeToTypeInfo(node)
+  const rawOf = (n: ts.TypeNode): string => {
+    try {
+      return _typePrinter.printNode(ts.EmitHint.Unspecified, n, _blankTypeSourceFile)
+    } catch {
+      return 'unknown'
+    }
+  }
+  return typeNodeToTypeInfo(node, _blankTypeSourceFile, rawOf)
 }
 
 // =============================================================================

--- a/packages/jsx/src/analyzer-context.ts
+++ b/packages/jsx/src/analyzer-context.ts
@@ -443,6 +443,69 @@ export function typeNodeToTypeInfo(
   return { kind: 'unknown', raw }
 }
 
+// Printer + blank source file reused across calls so checker-driven type
+// conversion never allocates a fresh `ts.createSourceFile` per memo on the
+// build hot path (the blank file is only printer context for synthetic
+// nodes, created once at module load).
+const _typePrinter = ts.createPrinter({ removeComments: true, omitTrailingSemicolon: true })
+const _blankTypeSourceFile = ts.createSourceFile('__bf_types__.ts', '', ts.ScriptTarget.Latest)
+
+function synthTypeNodeToTypeInfo(node: ts.TypeNode): TypeInfo {
+  let raw: string
+  try {
+    raw = _typePrinter.printNode(ts.EmitHint.Unspecified, node, _blankTypeSourceFile)
+  } catch {
+    raw = 'unknown'
+  }
+
+  switch (node.kind) {
+    case ts.SyntaxKind.StringKeyword:
+      return { kind: 'primitive', raw, primitive: 'string' }
+    case ts.SyntaxKind.NumberKeyword:
+      return { kind: 'primitive', raw, primitive: 'number' }
+    case ts.SyntaxKind.BooleanKeyword:
+      return { kind: 'primitive', raw, primitive: 'boolean' }
+    case ts.SyntaxKind.UndefinedKeyword:
+      return { kind: 'primitive', raw, primitive: 'undefined' }
+    case ts.SyntaxKind.NullKeyword:
+      return { kind: 'primitive', raw, primitive: 'null' }
+  }
+
+  if (ts.isArrayTypeNode(node)) {
+    return { kind: 'array', raw, elementType: synthTypeNodeToTypeInfo(node.elementType) }
+  }
+  if (ts.isUnionTypeNode(node)) {
+    return { kind: 'union', raw, unionTypes: node.types.map(synthTypeNodeToTypeInfo) }
+  }
+  if (ts.isTypeReferenceNode(node)) {
+    const name = ts.isIdentifier(node.typeName) ? node.typeName.text : ''
+    if ((name === 'Array' || name === 'ReadonlyArray') && node.typeArguments?.length === 1) {
+      return { kind: 'array', raw, elementType: synthTypeNodeToTypeInfo(node.typeArguments[0]) }
+    }
+    return { kind: 'interface', raw }
+  }
+  if (ts.isTypeLiteralNode(node)) {
+    return { kind: 'object', raw }
+  }
+  return { kind: 'unknown', raw }
+}
+
+/**
+ * Convert a resolved `ts.Type` to `TypeInfo` via the type checker. Used to
+ * sharpen `createMemo` field types the syntactic `inferTypeFromValue`
+ * heuristic can't reach — e.g. `createMemo(() => generateDays())` whose body
+ * is a local-function call (→ `CalendarDay[][]`) or a ternary of typed
+ * arrays (→ `string[]`). Without this the Go adapter renders such memos as
+ * `map[string]interface{}` / `bool` placeholders, so a typed backend can't
+ * populate the SSR data (#1968). Returns `null` when the type can't be
+ * lowered to a `ts.TypeNode`.
+ */
+export function tsTypeToTypeInfo(type: ts.Type, checker: ts.TypeChecker): TypeInfo | null {
+  const node = checker.typeToTypeNode(type, undefined, ts.NodeBuilderFlags.NoTruncation)
+  if (!node) return null
+  return synthTypeNodeToTypeInfo(node)
+}
+
 // =============================================================================
 // AST Helpers
 // =============================================================================

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -16,6 +16,7 @@ import {
   createAnalyzerContext,
   getSourceLocation,
   typeNodeToTypeInfo,
+  tsTypeToTypeInfo,
   membersToProperties,
   isComponentFunction,
   isArrowComponentFunction,
@@ -1360,6 +1361,27 @@ function collectMemo(node: ts.VariableDeclaration, ctx: AnalyzerContext): void {
     const arrowBody = computation.replace(/^\s*\([^)]*\)\s*=>\s*/, '').trim()
     if (arrowBody && arrowBody !== computation) {
       type = inferTypeFromValue(arrowBody)
+    }
+  }
+
+  // When the syntactic heuristic above can't resolve a precise type
+  // (`object`/`unknown` — e.g. a local-function call or a ternary of typed
+  // arrays), ask the type checker for the memo body's actual type. This is
+  // what lets the Go adapter emit `[][]CalendarDay` / `[]string` / `bool`
+  // instead of `map[string]interface{}` / `bool` placeholders (#1968), so a
+  // typed backend can populate the SSR data. Only upgrades imprecise results —
+  // already-precise syntactic types are left untouched.
+  if (
+    ctx.checker &&
+    (type.kind === 'unknown' || type.kind === 'object') &&
+    callExpr.arguments[0] &&
+    (ts.isArrowFunction(callExpr.arguments[0]) || ts.isFunctionExpression(callExpr.arguments[0]))
+  ) {
+    const fnType = ctx.checker.getTypeAtLocation(callExpr.arguments[0])
+    const sig = fnType.getCallSignatures()[0]
+    if (sig) {
+      const inferred = tsTypeToTypeInfo(ctx.checker.getReturnTypeOfSignature(sig), ctx.checker)
+      if (inferred && inferred.kind !== 'unknown') type = inferred
     }
   }
 

--- a/ui/components/ui/calendar/index.tsx
+++ b/ui/components/ui/calendar/index.tsx
@@ -70,6 +70,14 @@ function toISODateString(date: Date): string {
 
 interface CalendarDay {
   date: Date
+  // Date-derived strings/numbers used by the template, pre-computed here so
+  // the template reads member fields instead of calling JS date helpers
+  // (`toISODateString(day.date)`, `day.date.getDate()`). A server-side
+  // template language (Go html/template, Mojo, Xslate) has no JS runtime and
+  // cannot call those helpers, so baking the results keeps the template a
+  // pure member-access read that lowers cleanly to every adapter.
+  isoDate: string
+  dayNumber: number
   isOutside: boolean
   isToday: boolean
   isDisabled: boolean
@@ -126,6 +134,8 @@ function buildDay(
     !!(isRangeMode && !isOutside && selectedRange?.from && !selectedRange?.to && isSameDay(date, selectedRange.from))
   const day: CalendarDay = {
     date,
+    isoDate: toISODateString(date),
+    dayNumber: date.getDate(),
     isOutside,
     isToday: isToday(date),
     isDisabled,
@@ -305,7 +315,10 @@ type CalendarProps = CalendarSingleProps | CalendarRangeProps
 function Calendar(props: CalendarProps) {
   const today = new Date()
   const isRangeMode = () => props.mode === 'range'
-  const numMonths = () => props.numberOfMonths ?? 1
+  // A memo (not a plain arrow) so the value materializes as template data on
+  // server-side adapters — the layout conditionals below read it in the
+  // template, where a no-JS backend can only reference data fields.
+  const numMonths = createMemo(() => props.numberOfMonths ?? 1)
 
   const initialMonth = props.defaultMonth
     ?? (props.mode === 'range' ? (props as CalendarRangeProps).selected?.from : undefined)
@@ -505,11 +518,11 @@ function Calendar(props: CalendarProps) {
             {weeks.map((week: CalendarDay[], wi: number) => (
               <tr key={wi} data-slot="calendar-week">
                 {week.map((day: CalendarDay) => (
-                  <td key={toISODateString(day.date)} data-slot="calendar-day" className={dayCellClasses}>
+                  <td key={day.isoDate} data-slot="calendar-day" className={dayCellClasses}>
                     <button
                       data-slot="calendar-day-button"
                       className={day.buttonClasses}
-                      data-date={toISODateString(day.date)}
+                      data-date={day.isoDate}
                       data-today={day.isToday || undefined}
                       data-outside={day.isOutside || undefined}
                       data-disabled={day.isDisabled || undefined}
@@ -521,7 +534,7 @@ function Calendar(props: CalendarProps) {
                       aria-selected={day.ariaSelected || undefined}
                       disabled={day.isDisabled}
                     >
-                      {day.date.getDate()}
+                      {day.dayNumber}
                     </button>
                   </td>
                 ))}

--- a/ui/components/ui/calendar/index.tsx
+++ b/ui/components/ui/calendar/index.tsx
@@ -73,6 +73,71 @@ interface CalendarDay {
   isOutside: boolean
   isToday: boolean
   isDisabled: boolean
+  // --- Selection state, pre-computed into the day data ---
+  //
+  // Selection (single + range) is baked onto each day at grid-build time
+  // rather than computed by per-cell predicate calls in the template. A
+  // server-side template language (Go html/template, Mojo, Xslate) has no
+  // JS runtime and cannot call a user-defined predicate per cell, so a
+  // `dayIsSingleSelected(day)`-style call in an attribute raised BF102 on
+  // the Go adapter. Member access on pre-computed fields lowers cleanly to
+  // every adapter; the values recompute reactively because `weeks0`/`weeks1`
+  // depend on `selectedDate()`/`selectedRange()`, so a selection click
+  // re-renders the keyed grid (no imperative DOM patching needed).
+  isSingleSelected: boolean
+  isRangeStart: boolean
+  isRangeEnd: boolean
+  isRangeMiddle: boolean
+  ariaSelected: boolean
+  buttonClasses: string
+}
+
+// Determine the range position for a given date within the selected range.
+function computeRangePosition(
+  date: Date,
+  isOutside: boolean,
+  range: DateRange | undefined,
+): 'start' | 'end' | 'middle' | undefined {
+  if (isOutside) return undefined
+  if (!range?.from) return undefined
+  if (isSameDay(date, range.from)) {
+    return range.to ? 'start' : undefined
+  }
+  if (range.to && isSameDay(date, range.to)) return 'end'
+  if (isInRange(date, range)) return 'middle'
+  return undefined
+}
+
+// Build a fully-resolved CalendarDay with selection state baked in.
+function buildDay(
+  date: Date,
+  isOutside: boolean,
+  disabled: boolean | ((date: Date) => boolean) | undefined,
+  fromDate: Date | undefined,
+  toDate: Date | undefined,
+  selectedDate: Date | undefined,
+  selectedRange: DateRange | undefined,
+  isRangeMode: boolean,
+): CalendarDay {
+  const isDisabled = isDateDisabled(date, disabled, fromDate, toDate)
+  const rangePos = isRangeMode ? computeRangePosition(date, isOutside, selectedRange) : undefined
+  const isSingleSelected = !isRangeMode && !!selectedDate && isSameDay(selectedDate, date)
+  const isSelected = isSingleSelected ||
+    !!(isRangeMode && !isOutside && selectedRange?.from && !selectedRange?.to && isSameDay(date, selectedRange.from))
+  const day: CalendarDay = {
+    date,
+    isOutside,
+    isToday: isToday(date),
+    isDisabled,
+    isSingleSelected,
+    isRangeStart: rangePos === 'start',
+    isRangeEnd: rangePos === 'end',
+    isRangeMiddle: rangePos === 'middle',
+    ariaSelected: isSelected || rangePos !== undefined,
+    buttonClasses: '',
+  }
+  day.buttonClasses = getDayClasses(day, isSelected, rangePos)
+  return day
 }
 
 function generateCalendarDays(
@@ -83,6 +148,9 @@ function generateCalendarDays(
   fromDate: Date | undefined,
   toDate: Date | undefined,
   showOutsideDays: boolean,
+  selectedDate: Date | undefined,
+  selectedRange: DateRange | undefined,
+  isRangeMode: boolean,
 ): CalendarDay[][] {
   const daysInMonth = getDaysInMonth(year, month)
   const firstDay = new Date(year, month, 1).getDay()
@@ -99,24 +167,14 @@ function generateCalendarDays(
     const prevDaysInMonth = getDaysInMonth(prevYear, prevMonth)
     for (let i = offset - 1; i >= 0; i--) {
       const date = new Date(prevYear, prevMonth, prevDaysInMonth - i)
-      week.push({
-        date,
-        isOutside: true,
-        isToday: isToday(date),
-        isDisabled: isDateDisabled(date, disabled, fromDate, toDate),
-      })
+      week.push(buildDay(date, true, disabled, fromDate, toDate, selectedDate, selectedRange, isRangeMode))
     }
   }
 
   // Current month days
   for (let day = 1; day <= daysInMonth; day++) {
     const date = new Date(year, month, day)
-    week.push({
-      date,
-      isOutside: false,
-      isToday: isToday(date),
-      isDisabled: isDateDisabled(date, disabled, fromDate, toDate),
-    })
+    week.push(buildDay(date, false, disabled, fromDate, toDate, selectedDate, selectedRange, isRangeMode))
     if (week.length === 7) {
       weeks.push(week)
       week = []
@@ -130,12 +188,7 @@ function generateCalendarDays(
     let nextDay = 1
     while (week.length < 7) {
       const date = new Date(nextYear, nextMonth, nextDay)
-      week.push({
-        date,
-        isOutside: true,
-        isToday: isToday(date),
-        isDisabled: isDateDisabled(date, disabled, fromDate, toDate),
-      })
+      week.push(buildDay(date, true, disabled, fromDate, toDate, selectedDate, selectedRange, isRangeMode))
       nextDay++
     }
     weeks.push(week)
@@ -290,10 +343,13 @@ function Calendar(props: CalendarProps) {
     (props.weekStartsOn ?? 0) === 1 ? WEEKDAYS_MON : WEEKDAYS_SUN
   )
 
+  // Grids depend on month AND selection: a selection click recomputes the
+  // baked-in selection fields and the keyed grid reconciles in place.
   const weeks0 = createMemo(() => {
     return generateCalendarDays(
       currentYear(), currentMonth(),
       props.weekStartsOn ?? 0, props.disabled, props.fromDate, props.toDate, props.showOutsideDays !== false,
+      selectedDate(), selectedRange(), isRangeMode(),
     )
   })
   const monthLabel0 = createMemo(() => formatMonthYear(new Date(currentYear(), currentMonth())))
@@ -304,6 +360,7 @@ function Calendar(props: CalendarProps) {
     return generateCalendarDays(
       y, m > 11 ? 0 : m,
       props.weekStartsOn ?? 0, props.disabled, props.fromDate, props.toDate, props.showOutsideDays !== false,
+      selectedDate(), selectedRange(), isRangeMode(),
     )
   })
   const monthLabel1 = createMemo(() => {
@@ -353,83 +410,9 @@ function Calendar(props: CalendarProps) {
     }
   }
 
-  // Restore day button classes based on its data attributes
-  const restoreDayClasses = (el: Element): void => {
-    const isOutside = el.hasAttribute('data-outside')
-    const isTodayEl = el.hasAttribute('data-today')
-    const isDisabledEl = el.hasAttribute('data-disabled')
-    let classes = dayButtonBaseClasses
-    if (isDisabledEl) {
-      classes += ` ${dayButtonDisabledClasses}`
-    } else if (isOutside) {
-      classes += ` ${dayButtonOutsideClasses}`
-    } else if (isTodayEl) {
-      classes += ` ${dayButtonTodayClasses}`
-    } else {
-      classes += ` ${dayButtonDefaultClasses}`
-    }
-    el.className = classes
-  }
-
-  // Update calendar UI after single day selection
-  const updateSingleUI = (container: HTMLElement, newDate: Date | undefined) => {
-    const prevSelected = container.querySelector('[data-selected-single]')
-    if (prevSelected) {
-      prevSelected.removeAttribute('data-selected-single')
-      prevSelected.removeAttribute('aria-selected')
-      restoreDayClasses(prevSelected)
-    }
-    if (newDate) {
-      const dayButton = container.querySelector(`[data-date="${toISODateString(newDate)}"]`) as HTMLElement | null
-      if (dayButton) {
-        dayButton.setAttribute('data-selected-single', '')
-        dayButton.setAttribute('aria-selected', 'true')
-        dayButton.className = `${dayButtonBaseClasses} ${dayButtonSelectedClasses}`
-      }
-    }
-  }
-
-  // Update calendar UI after range selection
-  const updateRangeUI = (container: HTMLElement, range: DateRange | undefined) => {
-    container.querySelectorAll('[data-selected-range-start], [data-selected-range-end], [data-selected-range-middle]').forEach(el => {
-      el.removeAttribute('data-selected-range-start')
-      el.removeAttribute('data-selected-range-end')
-      el.removeAttribute('data-selected-range-middle')
-      el.removeAttribute('aria-selected')
-      restoreDayClasses(el)
-    })
-    if (!range?.from) return
-
-    const startBtn = container.querySelector(`[data-date="${toISODateString(range.from)}"]`) as HTMLElement | null
-    if (startBtn) {
-      startBtn.setAttribute('data-selected-range-start', '')
-      startBtn.setAttribute('aria-selected', 'true')
-      startBtn.className = `${dayButtonBaseClasses} ${range.to ? dayButtonRangeStartClasses : dayButtonSelectedClasses}`
-    }
-
-    if (!range.to) return
-
-    const endBtn = container.querySelector(`[data-date="${toISODateString(range.to)}"]`) as HTMLElement | null
-    if (endBtn) {
-      endBtn.setAttribute('data-selected-range-end', '')
-      endBtn.setAttribute('aria-selected', 'true')
-      endBtn.className = `${dayButtonBaseClasses} ${dayButtonRangeEndClasses}`
-    }
-
-    const allDayButtons = container.querySelectorAll('[data-slot="calendar-day-button"][data-date]')
-    allDayButtons.forEach(btn => {
-      const dateStr = btn.getAttribute('data-date')!
-      const [y, m, d] = dateStr.split('-').map(Number)
-      const date = new Date(y, m - 1, d)
-      if (isInRange(date, range) && !btn.hasAttribute('data-outside')) {
-        btn.setAttribute('data-selected-range-middle', '')
-        btn.setAttribute('aria-selected', 'true')
-        btn.className = `${dayButtonBaseClasses} ${dayButtonRangeMiddleClasses}`
-      }
-    })
-  }
-
-  // Event delegation for day button clicks (day buttons are inside .map())
+  // Event delegation for day button clicks (day buttons are inside .map()).
+  // Selection state lives in signals; the grid re-renders reactively, so the
+  // handlers only update state and notify the parent — no imperative DOM.
   const handleCalendarClick = (e: MouseEvent) => {
     const el = e.target as HTMLElement
     const target = el.closest('[data-slot="calendar-day-button"]') as HTMLElement | null
@@ -456,8 +439,6 @@ function Calendar(props: CalendarProps) {
 
     setInternalSelected(newDate)
 
-    if (container) updateSingleUI(container, newDate)
-
     // Notify parent
     const scope = container?.closest('[bf-s]')
     // @ts-ignore - onselect is set by parent during hydration
@@ -483,7 +464,6 @@ function Calendar(props: CalendarProps) {
     }
 
     setInternalRange(newRange)
-    if (container) updateRangeUI(container, newRange)
 
     // Notify parent
     const scope = container?.closest('[bf-s]')
@@ -492,31 +472,6 @@ function Calendar(props: CalendarProps) {
     const handler = (props as CalendarRangeProps).onSelect || scopeCallback
     handler?.(newRange)
   }
-
-  // Determine range position for a day
-  const getRangePosition = (day: CalendarDay): 'start' | 'end' | 'middle' | undefined => {
-    if (day.isOutside) return undefined
-    const range = selectedRange()
-    if (!range?.from) return undefined
-    if (isSameDay(day.date, range.from)) {
-      return range.to ? 'start' : undefined
-    }
-    if (range.to && isSameDay(day.date, range.to)) return 'end'
-    if (isInRange(day.date, range)) return 'middle'
-    return undefined
-  }
-
-  // Per-day helpers: defined here so the inner map() callback has no local
-  // variable declarations. Without this, the compiler generates a nested
-  // mapArray callback that references `isSelected`/`rangePos` from an outer
-  // scope that doesn't exist inside the inner renderItem function, causing
-  // ReferenceError when the month changes and new day elements are created.
-  const dayRangePos = (day: CalendarDay) => isRangeMode() ? getRangePosition(day) : undefined
-  const dayIsSingleSelected = (day: CalendarDay) =>
-    !isRangeMode() && !!selectedDate() && isSameDay(selectedDate()!, day.date)
-  const dayIsSelected = (day: CalendarDay) =>
-    dayIsSingleSelected(day) ||
-    !!(isRangeMode() && !day.isOutside && selectedRange()?.from && !selectedRange()?.to && isSameDay(day.date, selectedRange()!.from))
 
   function renderMonthGrid(weeks: CalendarDay[][], label: string, showPrev: boolean, showNext: boolean) {
     return (
@@ -553,17 +508,17 @@ function Calendar(props: CalendarProps) {
                   <td key={toISODateString(day.date)} data-slot="calendar-day" className={dayCellClasses}>
                     <button
                       data-slot="calendar-day-button"
-                      className={getDayClasses(day, dayIsSelected(day), dayRangePos(day))}
+                      className={day.buttonClasses}
                       data-date={toISODateString(day.date)}
                       data-today={day.isToday || undefined}
                       data-outside={day.isOutside || undefined}
                       data-disabled={day.isDisabled || undefined}
                       data-current-month={!day.isOutside || undefined}
-                      data-selected-single={dayIsSingleSelected(day) || undefined}
-                      data-selected-range-start={dayRangePos(day) === 'start' || undefined}
-                      data-selected-range-end={dayRangePos(day) === 'end' || undefined}
-                      data-selected-range-middle={dayRangePos(day) === 'middle' || undefined}
-                      aria-selected={dayIsSelected(day) || dayRangePos(day) !== undefined || undefined}
+                      data-selected-single={day.isSingleSelected || undefined}
+                      data-selected-range-start={day.isRangeStart || undefined}
+                      data-selected-range-end={day.isRangeEnd || undefined}
+                      data-selected-range-middle={day.isRangeMiddle || undefined}
+                      aria-selected={day.ariaSelected || undefined}
                       disabled={day.isDisabled}
                     >
                       {day.date.getDate()}

--- a/ui/components/ui/calendar/index.tsx
+++ b/ui/components/ui/calendar/index.tsx
@@ -79,6 +79,10 @@ interface CalendarDay {
   isoDate: string
   dayNumber: number
   isOutside: boolean
+  // True for an outside (prev/next-month) day when `showOutsideDays` is off —
+  // the template renders an empty placeholder cell instead of a day button,
+  // keeping the 7-column grid shape.
+  isHidden: boolean
   isToday: boolean
   isDisabled: boolean
   // --- Selection state, pre-computed into the day data ---
@@ -123,6 +127,7 @@ function buildDay(
   disabled: boolean | ((date: Date) => boolean) | undefined,
   fromDate: Date | undefined,
   toDate: Date | undefined,
+  showOutsideDays: boolean,
   selectedDate: Date | undefined,
   selectedRange: DateRange | undefined,
   isRangeMode: boolean,
@@ -137,6 +142,7 @@ function buildDay(
     isoDate: toISODateString(date),
     dayNumber: date.getDate(),
     isOutside,
+    isHidden: isOutside && !showOutsideDays,
     isToday: isToday(date),
     isDisabled,
     isSingleSelected,
@@ -177,14 +183,14 @@ function generateCalendarDays(
     const prevDaysInMonth = getDaysInMonth(prevYear, prevMonth)
     for (let i = offset - 1; i >= 0; i--) {
       const date = new Date(prevYear, prevMonth, prevDaysInMonth - i)
-      week.push(buildDay(date, true, disabled, fromDate, toDate, selectedDate, selectedRange, isRangeMode))
+      week.push(buildDay(date, true, disabled, fromDate, toDate, showOutsideDays, selectedDate, selectedRange, isRangeMode))
     }
   }
 
   // Current month days
   for (let day = 1; day <= daysInMonth; day++) {
     const date = new Date(year, month, day)
-    week.push(buildDay(date, false, disabled, fromDate, toDate, selectedDate, selectedRange, isRangeMode))
+    week.push(buildDay(date, false, disabled, fromDate, toDate, showOutsideDays, selectedDate, selectedRange, isRangeMode))
     if (week.length === 7) {
       weeks.push(week)
       week = []
@@ -198,17 +204,15 @@ function generateCalendarDays(
     let nextDay = 1
     while (week.length < 7) {
       const date = new Date(nextYear, nextMonth, nextDay)
-      week.push(buildDay(date, true, disabled, fromDate, toDate, selectedDate, selectedRange, isRangeMode))
+      week.push(buildDay(date, true, disabled, fromDate, toDate, showOutsideDays, selectedDate, selectedRange, isRangeMode))
       nextDay++
     }
     weeks.push(week)
   }
 
-  // Hide outside days if not showing them
-  if (!showOutsideDays) {
-    return weeks
-  }
-
+  // Outside (prev/next-month) days are kept in the grid for shape but flagged
+  // `isHidden` when `showOutsideDays` is off; the template renders an empty
+  // placeholder cell for them (see `buildDay`).
   return weeks
 }
 
@@ -519,23 +523,27 @@ function Calendar(props: CalendarProps) {
               <tr key={wi} data-slot="calendar-week">
                 {week.map((day: CalendarDay) => (
                   <td key={day.isoDate} data-slot="calendar-day" className={dayCellClasses}>
-                    <button
-                      data-slot="calendar-day-button"
-                      className={day.buttonClasses}
-                      data-date={day.isoDate}
-                      data-today={day.isToday || undefined}
-                      data-outside={day.isOutside || undefined}
-                      data-disabled={day.isDisabled || undefined}
-                      data-current-month={!day.isOutside || undefined}
-                      data-selected-single={day.isSingleSelected || undefined}
-                      data-selected-range-start={day.isRangeStart || undefined}
-                      data-selected-range-end={day.isRangeEnd || undefined}
-                      data-selected-range-middle={day.isRangeMiddle || undefined}
-                      aria-selected={day.ariaSelected || undefined}
-                      disabled={day.isDisabled}
-                    >
-                      {day.dayNumber}
-                    </button>
+                    {day.isHidden ? (
+                      <div className="size-8" />
+                    ) : (
+                      <button
+                        data-slot="calendar-day-button"
+                        className={day.buttonClasses}
+                        data-date={day.isoDate}
+                        data-today={day.isToday || undefined}
+                        data-outside={day.isOutside || undefined}
+                        data-disabled={day.isDisabled || undefined}
+                        data-current-month={!day.isOutside || undefined}
+                        data-selected-single={day.isSingleSelected || undefined}
+                        data-selected-range-start={day.isRangeStart || undefined}
+                        data-selected-range-end={day.isRangeEnd || undefined}
+                        data-selected-range-middle={day.isRangeMiddle || undefined}
+                        aria-selected={day.ariaSelected || undefined}
+                        disabled={day.isDisabled}
+                      >
+                        {day.dayNumber}
+                      </button>
+                    )}
                   </td>
                 ))}
               </tr>

--- a/ui/meta/calendar.json
+++ b/ui/meta/calendar.json
@@ -117,6 +117,10 @@
   ],
   "memos": [
     {
+      "name": "numMonths",
+      "deps": []
+    },
+    {
       "name": "selectedDate",
       "deps": [
         "internalSelected"
@@ -175,7 +179,8 @@
       "name": "isNextDisabled",
       "deps": [
         "currentYear",
-        "currentMonth"
+        "currentMonth",
+        "numMonths"
       ]
     }
   ]

--- a/ui/meta/calendar.json
+++ b/ui/meta/calendar.json
@@ -75,12 +75,12 @@
   "accessibility": {
     "role": "grid",
     "ariaAttributes": [
-      "aria-selected",
-      "aria-label"
+      "aria-label",
+      "aria-selected"
     ],
     "dataAttributes": [
-      "data-disabled",
-      "data-slot"
+      "data-slot",
+      "data-disabled"
     ]
   },
   "dependencies": {
@@ -136,7 +136,9 @@
       "name": "weeks0",
       "deps": [
         "currentYear",
-        "currentMonth"
+        "currentMonth",
+        "selectedDate",
+        "selectedRange"
       ]
     },
     {
@@ -150,7 +152,9 @@
       "name": "weeks1",
       "deps": [
         "currentYear",
-        "currentMonth"
+        "currentMonth",
+        "selectedDate",
+        "selectedRange"
       ]
     },
     {


### PR DESCRIPTION
## Summary

Makes `Calendar` render on **every** adapter — Hono, Go `html/template`, Perl Mojolicious, Perl Text::Xslate — not just the JS backend.

The blockers were JS computation reaching the template, where a no-JS backend can't run it:
1. per-cell selection predicates (`dayIsSingleSelected(day)` …) → **BF102** on Go;
2. per-cell date helpers (`toISODateString(day.date)`, `day.date.getDate()`) → method calls the adapter never generated;
3. `numMonths()` plain arrow local → a `.NumMonths` field the struct never declared.

Fix (consistent across all adapters): **pre-compute everything the template needs into the day data / memos**, so the template is pure member-access + ranges + conditionals:
- selection state baked onto each `CalendarDay` (`isSingleSelected`, range flags, `ariaSelected`, `buttonClasses`);
- date-derived values baked too (`isoDate`, `dayNumber`);
- `numMonths` promoted to a `createMemo` so it materializes as template data.

The keyed grid stays reactive (`weeks0`/`weeks1` depend on `selectedDate()`/`selectedRange()`), so a selection click re-renders in place — the imperative DOM patching (`updateSingleUI`/`updateRangeUI`/`restoreDayClasses`) is removed.

This PR also fixes the **memo type inference** so a *typed* backend can populate the SSR data (Closes #1968): when the syntactic heuristic is imprecise (`object`/`unknown`) and a type checker is available, the analyzer asks it for the memo's return type. Calendar now generates correct Go types (`Weeks0 [][]CalendarDay`, `Weekdays []string`, `IsPrevDisabled bool`, `MonthLabel0 string`) with type-appropriate zero-value constructor inits; the Go adapter is unchanged.

## Verification

- **Compile**: `calendar`, the `date-picker` that composes it, and the demos compile with zero error diagnostics on Hono/Go/Mojo/Xslate — pinned by `packages/adapter-tests/src/__tests__/calendar-cross-adapter.test.ts`.
- **Runtime, Hono**: real-browser E2E (`site/ui/e2e/calendar.spec.ts`); also verified in a live Chromium against the built site (click selects a day; controlled-mode prop round-trip updates the grid).
- **Runtime, Go / Mojo / Xslate**: the adapter-generated templates were executed by `go1.25.6` (`html/template`, via a typed program: `props.Weeks0 [][]CalendarDay` + `NewCalendarProps` for the real ChevronIcon children), Mojolicious 9.46 (`Mojo::Template`) and Text::Xslate v3.5.9 (Kolon), with the grid supplied by a backend data layer ("any backend" model). All three produce the identical calendar (June 2026, the 15th selected, today highlighted, outside days muted). Screenshots in the PR thread.
- **Full suite, zero regressions from the type-inference change**: jsx 2181, adapter-go-template 551, adapter-hono 438, adapter-mojolicious 527, adapter-xslate 353, adapter-tests 773 — all 0 fail.

## Note

`calendar` stays out of the frozen-HTML fixture corpus: the grid renders the current month, so byte-exact SSR is wall-clock-dependent. Cross-adapter coverage is the deterministic compile test above plus the E2E spec (comment in `fixtures/index.ts` updated). #1966 (attribute-level `@client`) was a sibling finding, fixed separately in #1967.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRDJtBy9zR3KH8UG9tkbZ7