### PR TITLE
fix(adapters): honor /* @client */ on attribute bindings

### DIFF
--- a/.changeset/client-attr-defer.md
+++ b/.changeset/client-attr-defer.md
@@ -1,0 +1,12 @@
+---
+"@barefootjs/go-template": patch
+"@barefootjs/hono": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+---
+
+Honor `/* @client */` on attribute bindings (#1966).
+
+The inline directive deferred a JSX child/text expression to hydration but was silently ignored on attribute initializers: a Go-unsupported predicate in `data-x={/* @client */ pred(x)}` still got lowered and raised BF101/BF102, making the BF102 remediation misleading for attribute-only reactive state.
+
+The `clientOnly` flag was already set in the IR and honored by the client-JS reactive-attribute path (the CSR template omits the attribute and a mount effect sets/patches it on hydrate). The gap was in the adapters: `renderAttributes` lowered every attribute. All four adapters (Go, Mojo, Xslate, Hono) now skip SSR emission for `clientOnly` attributes, so the server omits the attribute, the unsupported-expression lowering is never reached, and the client sets it on hydrate.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -3186,3 +3186,87 @@ export function C() {
     }
   })
 })
+
+// =============================================================================
+// #1966 — `/* @client */` defers ATTRIBUTE bindings (not just child/text)
+// =============================================================================
+//
+// Before #1966 the directive was honoured for JSX child/text expressions
+// but silently ignored on attribute initializers: a Go-unsupported
+// predicate in `data-x={/* @client */ pred(x)}` still got lowered, raising
+// BF101/BF102 even though the author had explicitly opted out of SSR. That
+// made the BF102 remediation ("defer it with /* @client */") misleading for
+// attribute-only reactive state (the Calendar case in #1467 / PR #1965).
+//
+// The fix carries the existing `attr.clientOnly` flag (already set in
+// jsx-to-ir, already honoured by the client-JS reactive-attribute path —
+// CSR template omits the attr and a mount effect sets it) through to the
+// adapter: `renderAttributes` skips SSR emission for `clientOnly` attrs, so
+// the unsupported-expression lowering is never reached.
+describe('GoTemplateAdapter - #1966 @client defers attribute bindings', () => {
+  function compileAttr(attrExpr: string) {
+    const adapter = new GoTemplateAdapter()
+    const result = compileJSX(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+export function C() {
+  const [sel] = createSignal(0)
+  const [s] = createSignal("a")
+  const pred = (n: number) => sel() === n
+  return <div data-x={${attrExpr}}>hi</div>
+}
+`.trimStart(), 'test.tsx', { adapter })
+    const template = result.files?.find(f => f.path.endsWith('.tmpl'))?.content ?? ''
+    return { errors: result.errors ?? [], template }
+  }
+
+  test('Go-lowerable predicate: bare emits data-x; @client omits it from SSR', () => {
+    // `sel() === 1` lowers to `{{eq .Sel 1}}`, so the bare form is valid
+    // Go and emits the attribute — the directive is what removes it.
+    const bare = compileAttr('pred(1)')
+    expect(bare.errors).toEqual([])
+    expect(bare.template).toContain('data-x=')
+
+    const deferred = compileAttr('/* @client */ pred(1)')
+    expect(deferred.errors).toEqual([])
+    // Server omits the attribute; the client patches it on hydrate.
+    expect(deferred.template).not.toContain('data-x')
+  })
+
+  test('Go-unsupported predicate: bare raises BF101; @client clears it and omits the attr', () => {
+    const bare = compileAttr('/[0-9]/.test(s())')
+    expect(bare.errors.some(e => e.code === 'BF101' || e.code === 'BF102')).toBe(true)
+
+    const deferred = compileAttr('/* @client */ /[0-9]/.test(s())')
+    // No BF101/BF102 — the lowering is never reached for a deferred attr.
+    expect(deferred.errors).toEqual([])
+    expect(deferred.template).not.toContain('data-x')
+  })
+
+  test('@client attribute inside a keyed .map() loop body is also deferred', () => {
+    const adapter = new GoTemplateAdapter()
+    const result = compileJSX(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+type Day = { n: number }
+export function C() {
+  const [sel] = createSignal(0)
+  const pred = (d: Day) => sel() === d.n
+  const days: Day[] = [{ n: 1 }, { n: 2 }]
+  return (
+    <div>
+      {days.map((day: Day) => (
+        <div key={day.n} data-x={/* @client */ pred(day)}>cell</div>
+      ))}
+    </div>
+  )
+}
+`.trimStart(), 'test.tsx', { adapter })
+    const template = result.files?.find(f => f.path.endsWith('.tmpl'))?.content ?? ''
+    expect(result.errors ?? []).toEqual([])
+    // The loop still renders (the array is a static const) but the deferred
+    // attribute is absent from the emitted `<div>` cell.
+    expect(template).toContain('range')
+    expect(template).not.toContain('data-x')
+  })
+})

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -8062,6 +8062,16 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     const parts: string[] = []
 
     for (const attr of element.attrs) {
+      // `/* @client */` attribute bindings are deferred to hydrate: the
+      // client runtime sets/patches the attribute in a mount effect (see
+      // the reactive-attribute path in ir-to-client-js, which already
+      // omits `clientOnly` attrs from the CSR template and emits a
+      // `setAttribute`/`removeAttribute` effect). Skip SSR emission so the
+      // server omits the attribute — and, crucially, so the unsupported-
+      // expression lowering below is never reached for a deferred predicate
+      // (no BF101 / BF102). This makes the BF102 remediation ("defer it
+      // with /* @client */") accurate for attribute-only state. #1966
+      if (attr.clientOnly) continue
       // Rewrite JSX special-prop names to their HTML-attribute
       // counterparts. The Hono reference adapter relies on its JSX
       // runtime to strip `key` and emit `data-key` from a separate

--- a/packages/adapter-hono/src/adapter/hono-adapter.ts
+++ b/packages/adapter-hono/src/adapter/hono-adapter.ts
@@ -1120,6 +1120,14 @@ export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderC
     const parts: string[] = []
 
     for (const attr of element.attrs) {
+      // `/* @client */` attribute bindings are deferred to hydrate: the
+      // client runtime sets/patches the attribute in a mount effect (the
+      // CSR template omits it; ir-to-client-js emits the setAttribute
+      // effect). Skip SSR emission so the server omits the attribute,
+      // matching the client-deferred shape and avoiding a hydration
+      // mismatch where the server renders an attribute the client would
+      // re-derive on mount. #1966
+      if (attr.clientOnly) continue
       const lowered = emitAttrValue(attr.value, this.elementAttrEmitter, attr.name)
       if (lowered) parts.push(lowered)
     }

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -1752,3 +1752,36 @@ export function C() {
     expect(template).not.toContain('$JSON->{stringify}')
   })
 })
+
+// =============================================================================
+// #1966 — `/* @client */` defers ATTRIBUTE bindings (not just child/text)
+// =============================================================================
+//
+// `renderAttributes` skips SSR emission for `attr.clientOnly`, so a
+// deferred attribute predicate is omitted from the Mojo template (and the
+// unsupported-expression lowering is never reached → no BF101/BF102). The
+// client runtime sets the attribute on hydrate. Mirrors the Go pins.
+describe('MojoAdapter - #1966 @client defers attribute bindings', () => {
+  function compileAttr(attrExpr: string) {
+    const adapter = new MojoAdapter()
+    const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+export function C() {
+  const [sel] = createSignal(0)
+  const pred = (n: number) => sel() === n
+  return <div data-x={${attrExpr}}>hi</div>
+}
+`, adapter)
+    const template = adapter.generate(ir).template ?? ''
+    const errors = (adapter as unknown as { errors: { code: string }[] }).errors ?? []
+    return { errors, template }
+  }
+
+  test('bare emits data-x; @client omits it from SSR', () => {
+    expect(compileAttr('pred(1)').template).toContain('data-x')
+    const deferred = compileAttr('/* @client */ pred(1)')
+    expect(deferred.errors).toEqual([])
+    expect(deferred.template).not.toContain('data-x')
+  })
+})

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1583,6 +1583,13 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     const parts: string[] = []
 
     for (const attr of element.attrs) {
+      // `/* @client */` attribute bindings are deferred to hydrate: the
+      // client runtime sets/patches the attribute in a mount effect (the
+      // CSR template omits it; ir-to-client-js emits the setAttribute
+      // effect). Skip SSR emission so the server omits the attribute and
+      // the unsupported-expression lowering is never reached for a deferred
+      // predicate (no BF101 / BF102). #1966
+      if (attr.clientOnly) continue
       // Rewrite JSX special-prop names to their HTML-attribute
       // counterparts (#1475). `className` → `class` was already
       // wired in; the `key` → `data-key` rewrite matches the

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -258,3 +258,36 @@ export function Item({ on }: { on?: boolean }) {
     expect(count).toBe(2)
   })
 })
+
+// =============================================================================
+// #1966 — `/* @client */` defers ATTRIBUTE bindings (not just child/text)
+// =============================================================================
+//
+// `renderAttributes` skips SSR emission for `attr.clientOnly`, so a
+// deferred attribute predicate is omitted from the Xslate template (and the
+// unsupported-expression lowering is never reached → no BF101/BF102). The
+// client runtime sets the attribute on hydrate. Mirrors the Go pins.
+describe('XslateAdapter - #1966 @client defers attribute bindings', () => {
+  function compileAttr(attrExpr: string) {
+    const adapter = new XslateAdapter()
+    const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+export function C() {
+  const [sel] = createSignal(0)
+  const pred = (n: number) => sel() === n
+  return <div data-x={${attrExpr}}>hi</div>
+}
+`)
+    const template = adapter.generate(ir).template ?? ''
+    const errors = (adapter as unknown as { errors: { code: string }[] }).errors ?? []
+    return { errors, template }
+  }
+
+  test('bare emits data-x; @client omits it from SSR', () => {
+    expect(compileAttr('pred(1)').template).toContain('data-x')
+    const deferred = compileAttr('/* @client */ pred(1)')
+    expect(deferred.errors).toEqual([])
+    expect(deferred.template).not.toContain('data-x')
+  })
+})

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -1355,6 +1355,13 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     const parts: string[] = []
 
     for (const attr of element.attrs) {
+      // `/* @client */` attribute bindings are deferred to hydrate: the
+      // client runtime sets/patches the attribute in a mount effect (the
+      // CSR template omits it; ir-to-client-js emits the setAttribute
+      // effect). Skip SSR emission so the server omits the attribute and
+      // the unsupported-expression lowering is never reached for a deferred
+      // predicate (no BF101 / BF102). #1966
+      if (attr.clientOnly) continue
       // Rewrite JSX special-prop names to their HTML-attribute counterparts.
       let attrName: string
       if (attr.name === 'className') attrName = 'class'

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -793,6 +793,8 @@ The accumulator must be the binary expression's left operand (`acc + x`, not `x 
 
 When `@client` is present, the compiler skips template generation for that expression without emitting an error.
 
+This applies equally to **attribute bindings**, not just child/text expressions: `data-x={/* @client */ pred(item)}` defers the attribute to hydration. The adapters omit a `clientOnly` attribute from SSR (so the unsupported-expression lowering is never reached → no BF101/BF102), and the client runtime sets/patches it in a mount effect. This makes the BF102 remediation accurate for components whose reactive state is expressed purely as attributes (the Calendar case in #1966 / #1467).
+
 ### Known limitations — methods that don't lower to the template adapters
 
 The Go / Mojo template adapters lower a finite, growing catalogue of `Array.prototype` / `String.prototype` methods (see "Currently lowered" in the now-closed origin catalogue issue [#1448](https://github.com/piconic-ai/barefootjs/issues/1448), whose residual gaps are folded into the master known-limitations catalog [#1395](https://github.com/piconic-ai/barefootjs/issues/1395)). The shapes below are the residual gaps. They are intentional — each is either covered by an escape hatch or carries a cross-adapter design barrier — and `/* @client */` (or lifting the expression into an event handler / `createEffect`, where full JS is available) is the workaround for all of them.


### PR DESCRIPTION
## Summary

Closes #1966.

The inline `/* @client */` directive deferred a JSX **child/text** expression to hydration but was silently ignored for **attribute bindings**: a Go-unsupported predicate in `data-x={/* @client */ pred(x)}` still got lowered and raised **BF101/BF102**, making the BF102 remediation (*"defer it with `/* @client */`"*) misleading for attribute-only reactive state (the Calendar case in #1467 / PR #1965).

## Root cause

The `attr.clientOnly` flag was **already** set in `jsx-to-ir.ts` and **already** honored by the client-JS reactive-attribute path — the CSR template omits the attribute and a mount `createEffect` sets/patches it on hydrate:

```js
createEffect(() => {
  if (_s0) { const __v = pred(1); if (__v != null) _s0.setAttribute('data-x', String(__v)); else _s0.removeAttribute('data-x') }
})
hydrate('Mini', { ..., template: (_p) => `<div bf="s0">hi</div>` })  // data-x omitted
```

The gap was purely in the **adapters**: each `renderAttributes` iterated every `element.attrs` entry and lowered each one, so a deferred predicate still reached the unsupported-expression lowering → BF101/BF102, and the attribute was emitted at SSR anyway.

## Fix

Skip SSR emission for `clientOnly` attributes in all four adapters (Go, Mojo, Xslate, Hono):

```ts
for (const attr of element.attrs) {
  if (attr.clientOnly) continue   // #1966
  ...
}
```

The server now omits the attribute, the lowering is never reached (no BF101/BF102), and the client sets it on hydrate — matching the existing child/text `@client` semantics and avoiding a hydration mismatch.

## Acceptance (from the issue)

- ✅ `data-x={/* @client */ pred(x)}` compiles with no BF101/BF102 on Go/Mojo/Xslate (and Hono); server omits the attribute; client sets it on hydrate.
- ✅ Works the same inside a keyed `.map()` loop body.
- ✅ BF102 remediation text ("Use @client directive for client-side evaluation") is now accurate for the attribute case — no change needed.

## Tests

- `#1966` pin blocks added to the Go / Mojo / Xslate adapter test files (Go covers the lowerable predicate, the genuinely-unsupported predicate, and the loop-body case).
- Spec note added to `spec/compiler.md`.
- All four adapter suites green: Go 551, Hono 438, Mojo 527, Xslate 353.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPqiK1w6sgyZxEwnVqGdFH)_