### PR TITLE
fix(mojo,xslate): carousel SSR parity with Hono (#1971)

### DIFF
--- a/.changeset/carousel-perl-ssr.md
+++ b/.changeset/carousel-perl-ssr.md
@@ -1,0 +1,11 @@
+---
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+---
+
+Render carousel demos byte-identical to the Hono SSR reference on the Perl adapters (#1971).
+
+- **Both adapters:** an inline object-literal child prop (carousel's `opts={{ align: 'start' }}`) is now lowered to a Perl/Kolon hashref instead of being refused with BF101, so the child can serialize it for `data-opts`.
+- **Mojolicious:** a `<Ctx.Provider value>` member that references a client-only function — a local handler const (`scrollPrev`) or a signal setter (`setCanScrollPrev`) — is now lowered to `undef` instead of an undeclared `$scrollPrev`, which previously tripped Perl strict mode at render time. Members that resolve to a prop / signal getter / memo are unaffected.
+
+All three carousel demos now render byte-identical HTML on Mojolicious, Text::Xslate, Go, and Hono (covered by `carousel-cross-adapter.test.ts`).

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -712,13 +712,16 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
 
   /**
    * (#1971) True when `src` is a bare identifier that doesn't resolve to a
-   * prop/signal/memo — i.e. a client-only function reference in a context
-   * value (a local handler const or a signal setter). See `providerDataNames`.
+   * prop/signal/memo or an SSR-inlinable module string const — i.e. a
+   * client-only function reference in a context value (a local handler const
+   * like `scrollPrev`, or a signal setter like `setCanScrollPrev`). See
+   * `providerDataNames`. Module-scope string consts (`carouselClasses`) ARE
+   * SSR-resolvable via `moduleStringConsts`, so they're excluded here.
    */
   private isClientOnlyContextIdentifier(src: string): boolean {
     const t = src.trim()
     if (!/^[A-Za-z_$][\w$]*$/.test(t)) return false
-    return !this.providerDataNames.has(t)
+    return !this.providerDataNames.has(t) && !this.moduleStringConsts.has(t)
   }
 
   /** Perl literal for a context-consumer's `createContext` default. */
@@ -1228,9 +1231,12 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       }
       // Inline object-literal child prop (carousel's `opts={{ align: 'start' }}`):
       // lower to a Perl hashref so the child can serialize it (`data-opts`),
-      // instead of refusing the bare object with BF101. (#1971 Perl)
-      const hashref = this.objectLiteralExprToPerlHashref(value.expr)
-      if (hashref !== null) return `${perlHashKey(name)} => ${hashref}`
+      // instead of refusing the bare object with BF101. (#1971 Perl) Cheap `{`
+      // guard so the common non-object case skips the AST parse.
+      if (value.expr.trim().startsWith('{')) {
+        const hashref = this.objectLiteralExprToPerlHashref(value.expr)
+        if (hashref !== null) return `${perlHashKey(name)} => ${hashref}`
+      }
       return `${perlHashKey(name)} => ${this.convertExpressionToPerl(value.expr)}`
     },
     emitSpread: (value) => {

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -255,6 +255,14 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
   private propsParams: { name: string }[] = []
   private booleanTypedProps: Set<string> = new Set()
   /**
+   * (#1971) Names that resolve to a real SSR template var — prop param, signal
+   * getter, or memo. A `<Ctx.Provider value>` member referencing a name NOT in
+   * this set is a client-only function (a local handler const like `scrollPrev`
+   * or a signal setter like `setCanScrollPrev`) with no SSR value: it would
+   * emit an undeclared `$var`, so it's lowered to `undef` instead.
+   */
+  private providerDataNames: Set<string> = new Set()
+  /**
    * Names (signal getters + props) whose value is a string, so `===`/`!==`
    * against them lowers to Perl `eq`/`ne` rather than numeric `==`/`!=`.
    * Perl's numeric `==` coerces non-numeric strings to 0, making `"b" == "a"`
@@ -336,6 +344,12 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     // serialization happens before `generate`, so this mutation doesn't reach it).
     augmentInheritedPropAccesses(ir)
     this.propsParams = ir.metadata.propsParams.map(p => ({ name: p.name }))
+    // (#1971) SSR-resolvable context-value names: props, signal getters, memos.
+    this.providerDataNames = new Set<string>([
+      ...ir.metadata.propsParams.map(p => p.name),
+      ...(ir.metadata.signals ?? []).map(s => s.getter),
+      ...(ir.metadata.memos ?? []).map(m => m.name),
+    ])
     // Props whose declared TS type is boolean — a bare binding of one
     // (`data-active={props.isActive}`) must stringify as JS
     // `String(boolean)` ("true"/"false"), not Perl's native `1`/`''`
@@ -685,9 +699,26 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       const key = `'${m.name.replace(/[\\']/g, c => `\\${c}`)}'`
       if (m.kind === 'function' || /^on[A-Z]/.test(m.name)) return `${key} => undef`
       const src = m.kind === 'getter' ? m.body : m.expr
+      // (#1971) A member whose value is a bare identifier that doesn't resolve
+      // to a prop/signal/memo is a client-only function reference (a local
+      // handler const like `scrollPrev`, or a signal setter like
+      // `setCanScrollPrev`) — no SSR value, and emitting `$scrollPrev` would
+      // trip Perl strict mode on an undeclared var. Lower to undef.
+      if (this.isClientOnlyContextIdentifier(src)) return `${key} => undef`
       return `${key} => ${this.convertExpressionToPerl(src)}`
     })
     return `{ ${entries.join(', ')} }`
+  }
+
+  /**
+   * (#1971) True when `src` is a bare identifier that doesn't resolve to a
+   * prop/signal/memo — i.e. a client-only function reference in a context
+   * value (a local handler const or a signal setter). See `providerDataNames`.
+   */
+  private isClientOnlyContextIdentifier(src: string): boolean {
+    const t = src.trim()
+    if (!/^[A-Za-z_$][\w$]*$/.test(t)) return false
+    return !this.providerDataNames.has(t)
   }
 
   /** Perl literal for a context-consumer's `createContext` default. */
@@ -1195,6 +1226,11 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       if (value.parts) {
         return `${perlHashKey(name)} => ${this.convertTemplateLiteralPartsToPerl(value.parts)}`
       }
+      // Inline object-literal child prop (carousel's `opts={{ align: 'start' }}`):
+      // lower to a Perl hashref so the child can serialize it (`data-opts`),
+      // instead of refusing the bare object with BF101. (#1971 Perl)
+      const hashref = this.objectLiteralExprToPerlHashref(value.expr)
+      if (hashref !== null) return `${perlHashKey(name)} => ${hashref}`
       return `${perlHashKey(name)} => ${this.convertExpressionToPerl(value.expr)}`
     },
     emitSpread: (value) => {
@@ -1913,6 +1949,23 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
    * values resolve via `convertExpressionToPerl`. Returns null for any
    * computed/spread/dynamic key. Empty object → `{}`.
    */
+  /**
+   * (#1971 Perl) Parse a bare object-literal expression string
+   * (`{ align: 'start' }`) and lower it to a Perl hashref via
+   * `objectLiteralToPerlHashref`, or null when it isn't a plain object
+   * literal. Used for inline object-literal child props (carousel `opts`).
+   */
+  private objectLiteralExprToPerlHashref(expr: string): string | null {
+    const sf = ts.createSourceFile('__obj.ts', `(${expr})`, ts.ScriptTarget.Latest, true)
+    if (sf.statements.length !== 1) return null
+    const stmt = sf.statements[0]
+    if (!ts.isExpressionStatement(stmt)) return null
+    let node: ts.Expression = stmt.expression
+    while (ts.isParenthesizedExpression(node)) node = node.expression
+    if (!ts.isObjectLiteralExpression(node)) return null
+    return this.objectLiteralToPerlHashref(node, sf)
+  }
+
   private objectLiteralToPerlHashref(
     obj: ts.ObjectLiteralExpression,
     sf: ts.SourceFile,

--- a/packages/adapter-tests/src/__tests__/carousel-cross-adapter.test.ts
+++ b/packages/adapter-tests/src/__tests__/carousel-cross-adapter.test.ts
@@ -75,8 +75,10 @@ interface AdapterCase {
     components?: Record<string, string>
     componentName: string
   }) => Promise<string>
-  /** Error thrown when this adapter's runtime is absent (→ skip, not fail). */
-  notAvailable: new (...args: never[]) => Error
+  /** Error thrown when this adapter's runtime is absent (→ skip, not fail).
+   *  `any[]` (not `never[]`) so the concrete `(message: string)` ctors of the
+   *  *NotAvailableError classes assign cleanly; only used for `instanceof`. */
+  notAvailable: new (...args: any[]) => Error
 }
 
 const adapterCases: AdapterCase[] = [

--- a/packages/adapter-tests/src/__tests__/carousel-cross-adapter.test.ts
+++ b/packages/adapter-tests/src/__tests__/carousel-cross-adapter.test.ts
@@ -3,32 +3,31 @@
  *
  * Unlike `calendar-cross-adapter` (compile-diagnostics only — the calendar
  * grid is wall-clock dependent), the carousel demos render a fully static
- * SSR template, so this asserts the stronger property: the Go adapter
- * produces byte-identical normalized HTML to the Hono reference for every
- * carousel demo.
+ * SSR template, so this asserts the stronger property: every server adapter
+ * (Go, Mojo, Xslate) produces byte-identical normalized HTML to the Hono
+ * reference for all three carousel demos.
  *
- * This pins the #1971 Go fixes, each of which previously diverged silently
- * (compiled clean, rendered wrong):
- *   - the `directionClasses` / `positionClasses` / `paddingClass` string
- *     ternary memos (were mistyped `bool` → `class="false"`);
- *   - the optional `opts` object prop (a value struct was always truthy, so
- *     `data-opts` was never omitted; and an inline `opts={{…}}` was dropped);
- *   - the inline `[1,2,3,4,5].map(...)` scalar-item loop (rendered zero
- *     items because the loop's scalar datum was never plumbed into the Go
- *     wrapper / body / constructor).
+ * This pins the #1971 SSR-parity fixes, each of which previously diverged
+ * silently (compiled clean / rendered wrong, or refused with BF101):
+ *   - string-ternary memos (`directionClasses` / `positionClasses` /
+ *     `paddingClass`) — Go mistyped them `bool`;
+ *   - the optional `opts` object prop — Go always-truthy struct, and an
+ *     inline `opts={{ … }}` was dropped (Go) or refused with BF101
+ *     (Mojo/Xslate);
+ *   - the inline `[1,2,3,4,5].map(...)` scalar-item loop — Go rendered zero
+ *     items;
+ *   - the carousel context value's client-only function members — Mojo
+ *     emitted undeclared `$scrollPrev` vars.
  *
- * Mojo/Xslate are intentionally NOT covered yet: the demo's
- * `opts={{ align: 'start' }}` inline object prop raises BF101 there, and the
- * scalar-literal loop has the same unmaterialised-SSR gap as Go did. Those
- * are tracked separately ("Go first", per the issue).
- *
- * Skips gracefully when no Go 1.25+ toolchain is available (the renderer
- * shells out to `go run`), matching the adapter-conformance suite's policy.
+ * Each adapter skips gracefully when its runtime isn't installed (Go 1.25+,
+ * or perl with Mojolicious / Text::Xslate), matching the adapter-conformance
+ * suite's policy.
  */
 import { describe, test, expect } from 'bun:test'
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import type { TemplateAdapter } from '@barefootjs/jsx'
 import { renderHonoComponent } from '@barefootjs/hono/test-render'
 import { honoAdapter } from '@barefootjs/hono/adapter'
 import {
@@ -36,6 +35,16 @@ import {
   GoNotAvailableError,
 } from '@barefootjs/go-template/test-render'
 import { goTemplateAdapter } from '@barefootjs/go-template/adapter'
+import {
+  renderMojoComponent,
+  PerlNotAvailableError,
+} from '@barefootjs/mojolicious/test-render'
+import { mojoAdapter } from '@barefootjs/mojolicious/adapter'
+import {
+  renderXslateComponent,
+  XslateNotAvailableError,
+} from '@barefootjs/xslate/test-render'
+import { xslateAdapter } from '@barefootjs/xslate/adapter'
 import { normalizeHTML } from '../jsx-runner'
 import { resolveSiblingComponents } from '../../fixtures/_helpers'
 import { spec as carouselSpec } from '../../fixtures/carousel'
@@ -56,30 +65,50 @@ const demos = [
   'CarouselOrientationDemo',
 ] as const
 
+interface AdapterCase {
+  name: string
+  adapter: TemplateAdapter
+  render: (opts: {
+    source: string
+    adapter: TemplateAdapter
+    props: Record<string, unknown>
+    components?: Record<string, string>
+    componentName: string
+  }) => Promise<string>
+  /** Error thrown when this adapter's runtime is absent (→ skip, not fail). */
+  notAvailable: new (...args: never[]) => Error
+}
+
+const adapterCases: AdapterCase[] = [
+  { name: 'Go', adapter: goTemplateAdapter, render: renderGoTemplateComponent, notAvailable: GoNotAvailableError },
+  { name: 'Mojo', adapter: mojoAdapter, render: renderMojoComponent, notAvailable: PerlNotAvailableError },
+  { name: 'Xslate', adapter: xslateAdapter, render: renderXslateComponent, notAvailable: XslateNotAvailableError },
+]
+
 describe('Carousel cross-adapter SSR render conformance (#1971)', () => {
   for (const componentName of demos) {
-    test(`${componentName} renders byte-identical on Go and Hono`, async () => {
-      const common = {
-        source,
-        props: { __instanceId: `${componentName}_test` },
-        components,
-        componentName,
-      }
-      const hono = normalizeHTML(
-        await renderHonoComponent({ adapter: honoAdapter, ...common }),
-      )
-      let go: string
-      try {
-        go = normalizeHTML(
-          await renderGoTemplateComponent({ adapter: goTemplateAdapter, ...common }),
+    for (const { name, adapter, render, notAvailable } of adapterCases) {
+      test(`${componentName} renders byte-identical on ${name} and Hono`, async () => {
+        const common = {
+          source,
+          props: { __instanceId: `${componentName}_test` },
+          components,
+          componentName,
+        }
+        const hono = normalizeHTML(
+          await renderHonoComponent({ adapter: honoAdapter, ...common }),
         )
-      } catch (err) {
-        // No Go toolchain (CI image without Go 1.25+): skip, same as the
-        // adapter-conformance renderer's `onRenderError` policy.
-        if (err instanceof GoNotAvailableError) return
-        throw err
-      }
-      expect(go).toBe(hono)
-    }, 30_000)
+        let out: string
+        try {
+          out = normalizeHTML(await render({ adapter, ...common }))
+        } catch (err) {
+          // Runtime not installed (CI image without Go 1.25+ / perl modules):
+          // skip, same as the adapter-conformance renderer's policy.
+          if (err instanceof notAvailable) return
+          throw err
+        }
+        expect(out).toBe(hono)
+      }, 30_000)
+    }
   }
 })

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -1009,6 +1009,11 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
       if (value.parts) {
         return `${kolonHashKey(name)} => ${this.convertTemplateLiteralPartsToKolon(value.parts)}`
       }
+      // Inline object-literal child prop (carousel's `opts={{ align: 'start' }}`):
+      // lower to a Kolon hashref so the child can serialize it (`data-opts`),
+      // instead of refusing the bare object with BF101. (#1971 Perl)
+      const hashref = this.objectLiteralExprToKolonHashref(value.expr)
+      if (hashref !== null) return `${kolonHashKey(name)} => ${hashref}`
       return `${kolonHashKey(name)} => ${this.convertExpressionToKolon(value.expr)}`
     },
     emitSpread: (value) => {
@@ -1625,6 +1630,23 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
    * lowering). Returns `null` for any computed/spread/dynamic key. Empty object
    * → `{}`. Mirror of `objectLiteralToPerlHashref`.
    */
+  /**
+   * (#1971 Perl) Parse a bare object-literal expression string
+   * (`{ align: 'start' }`) and lower it to a Kolon hashref via
+   * `objectLiteralToKolonHashref`, or null when it isn't a plain object
+   * literal. Used for inline object-literal child props (carousel `opts`).
+   */
+  private objectLiteralExprToKolonHashref(expr: string): string | null {
+    const sf = ts.createSourceFile('__obj.ts', `(${expr})`, ts.ScriptTarget.Latest, true)
+    if (sf.statements.length !== 1) return null
+    const stmt = sf.statements[0]
+    if (!ts.isExpressionStatement(stmt)) return null
+    let node: ts.Expression = stmt.expression
+    while (ts.isParenthesizedExpression(node)) node = node.expression
+    if (!ts.isObjectLiteralExpression(node)) return null
+    return this.objectLiteralToKolonHashref(node, sf)
+  }
+
   private objectLiteralToKolonHashref(
     obj: ts.ObjectLiteralExpression,
     sf: ts.SourceFile,

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -1011,9 +1011,12 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
       }
       // Inline object-literal child prop (carousel's `opts={{ align: 'start' }}`):
       // lower to a Kolon hashref so the child can serialize it (`data-opts`),
-      // instead of refusing the bare object with BF101. (#1971 Perl)
-      const hashref = this.objectLiteralExprToKolonHashref(value.expr)
-      if (hashref !== null) return `${kolonHashKey(name)} => ${hashref}`
+      // instead of refusing the bare object with BF101. (#1971 Perl) Cheap `{`
+      // guard so the common non-object case skips the AST parse.
+      if (value.expr.trim().startsWith('{')) {
+        const hashref = this.objectLiteralExprToKolonHashref(value.expr)
+        if (hashref !== null) return `${kolonHashKey(name)} => ${hashref}`
+      }
       return `${kolonHashKey(name)} => ${this.convertExpressionToKolon(value.expr)}`
     },
     emitSpread: (value) => {


### PR DESCRIPTION
## Summary

Follow-up to #1972 (which brought the **Go** adapter to carousel SSR parity): does the same for the two **Perl** adapters. All three carousel demos (`CarouselPreviewDemo` / `CarouselSizesDemo` / `CarouselOrientationDemo`) now render **byte-identical** normalized HTML on **Mojolicious, Text::Xslate, Go, and Hono**.

## Findings (the two adapters differed)

- **Xslate** already rendered the loop, string-ternary memos, and `data-opts` correctly — its *only* blocker was BF101 on the inline `opts` object.
- **Mojolicious** had a deeper issue on top of BF101: the carousel context provider value emitted client-only function members as undeclared `$scrollPrev` vars, failing Perl strict mode at render time.

## Changes

### Both adapters — inline object-literal child prop (BF101)
`<Carousel opts={{ align: 'start' }}>` was refused with BF101. Now the inline object literal is lowered to a Perl/Kolon hashref (reusing the existing `objectLiteralTo{Perl,Kolon}Hashref` helpers via a small expression-parsing wrapper), so the child serializes it for `data-opts` — matching Hono's `JSON.stringify`.

### Mojolicious — client-only context-value members
A `<Ctx.Provider value>` member referencing a client-only function — a local handler const (`scrollPrev`/`scrollNext`) or a signal setter (`setCanScrollPrev`/`setCanScrollNext`) — now lowers to `undef` instead of an undeclared `$scrollPrev`. Gated on a `providerDataNames` set (prop params + signal getters + memos); members that resolve to real SSR data (a signal getter like `canScrollPrev`, the `orientation` memo) are unaffected. Mirrors the existing `setApi: (api) => …` → `undef` handling.

## Testing
- `carousel-cross-adapter.test.ts` extended to a **Go × Mojo × Xslate × 3-demo** matrix (9 cases), each asserting byte-equality vs Hono and skipping gracefully without its runtime.
- `bun test packages/adapter-mojolicious`: **527 pass, 0 fail**.
- `bun test packages/adapter-xslate`: **353 pass, 0 fail**.
- `bun test packages/adapter-tests`: **786 pass, 0 fail**.

Changeset: patch bump for `@barefootjs/mojolicious` + `@barefootjs/xslate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DAR8b8gdH6esBqr56daEp3)_