### PR TITLE
refactor(go-template): Phase 4 decomposition — GoEmitContext seam + first clusters

### DIFF
--- a/.changeset/go-adapter-phase4-decompose.md
+++ b/.changeset/go-adapter-phase4-decompose.md
@@ -1,0 +1,10 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Continue decomposing the Go html/template adapter (Phase 4). Internal-only, output byte-identical (verified by the adapter unit + conformance suites); no behavioural or public-API change.
+
+- `analysis/component-tree.ts` — pure IR structural walks (`hasClientInteractivity`, nested/child-component discovery) moved out as free functions that read no adapter state.
+- `emit-context.ts` — introduce `GoEmitContext`, the narrow interface (per-compile `state` + the recursive entry points) that extracted emit modules depend on instead of the concrete adapter. The adapter implements it and passes `this`.
+- `expr/helper-inline.ts` — local arrow-const helper inlining at a call site.
+- `expr/url-builder.ts` — `URLSearchParams` builder helpers → `bf_query` lowering.

--- a/packages/adapter-go-template/src/adapter/analysis/component-tree.ts
+++ b/packages/adapter-go-template/src/adapter/analysis/component-tree.ts
@@ -1,0 +1,176 @@
+/**
+ * IR component-tree analysis for the Go html/template adapter.
+ *
+ * Pure structural walks over the IR — no adapter instance state, no rendering.
+ * Extracted from `go-template-adapter.ts` (Phase 4 decomposition). Only the two
+ * entry points (`hasClientInteractivity`, `findNestedComponents`) are exported;
+ * the recursive collectors stay module-internal.
+ */
+
+import type {
+  ComponentIR,
+  IRNode,
+  IRElement,
+  IRFragment,
+  IRConditional,
+  IRLoop,
+  IRIfStatement,
+  IRComponent,
+} from '@barefootjs/jsx'
+
+import type { NestedComponentInfo } from '../lib/types.ts'
+
+/**
+ * Does the component need client JS? True when it has reactive state
+ * (signals), effects, onMounts, any event handler in the tree, or any
+ * child component (which needs the parent's hydration).
+ */
+export function hasClientInteractivity(ir: ComponentIR): boolean {
+  if (ir.metadata.signals.length > 0) return true
+  if (ir.metadata.effects.length > 0) return true
+  if (ir.metadata.onMounts.length > 0) return true
+  if (hasEventsInTree(ir.root)) return true
+  // Child components need the parent's hydration.
+  if (findChildComponentNames(ir.root).size > 0) return true
+  return false
+}
+
+/** Recursively check if any element in the tree has events. */
+function hasEventsInTree(node: IRNode): boolean {
+  if (node.type === 'element') {
+    const element = node as IRElement
+    if (element.events.length > 0) return true
+    for (const child of element.children) {
+      if (hasEventsInTree(child)) return true
+    }
+  } else if (node.type === 'fragment') {
+    const fragment = node as IRFragment
+    for (const child of fragment.children) {
+      if (hasEventsInTree(child)) return true
+    }
+  } else if (node.type === 'conditional') {
+    const cond = node as IRConditional
+    if (hasEventsInTree(cond.whenTrue)) return true
+    if (cond.whenFalse && hasEventsInTree(cond.whenFalse)) return true
+  } else if (node.type === 'loop') {
+    const loop = node as IRLoop
+    for (const child of loop.children) {
+      if (hasEventsInTree(child)) return true
+    }
+  } else if (node.type === 'if-statement') {
+    const ifStmt = node as IRIfStatement
+    if (hasEventsInTree(ifStmt.consequent)) return true
+    if (ifStmt.alternate && hasEventsInTree(ifStmt.alternate)) return true
+  }
+  return false
+}
+
+/** Find all child component names used in the IR tree. */
+function findChildComponentNames(node: IRNode): Set<string> {
+  const names = new Set<string>()
+  collectChildComponentNames(node, names)
+  return names
+}
+
+function collectChildComponentNames(node: IRNode, names: Set<string>): void {
+  if (node.type === 'component') {
+    const comp = node as IRComponent
+    names.add(comp.name)
+  } else if (node.type === 'element') {
+    const element = node as IRElement
+    for (const child of element.children) {
+      collectChildComponentNames(child, names)
+    }
+  } else if (node.type === 'fragment') {
+    const fragment = node as IRFragment
+    for (const child of fragment.children) {
+      collectChildComponentNames(child, names)
+    }
+  } else if (node.type === 'conditional') {
+    const cond = node as IRConditional
+    collectChildComponentNames(cond.whenTrue, names)
+    if (cond.whenFalse) {
+      collectChildComponentNames(cond.whenFalse, names)
+    }
+  } else if (node.type === 'loop') {
+    const loop = node as IRLoop
+    for (const child of loop.children) {
+      collectChildComponentNames(child, names)
+    }
+  } else if (node.type === 'if-statement') {
+    const ifStmt = node as IRIfStatement
+    collectChildComponentNames(ifStmt.consequent, names)
+    if (ifStmt.alternate) {
+      collectChildComponentNames(ifStmt.alternate, names)
+    }
+  }
+}
+
+/**
+ * Find all nested components (loops with `childComponent`). Returns extended
+ * info that includes whether the component comes from a dynamic (signal) array
+ * loop vs a static one.
+ */
+export function findNestedComponents(node: IRNode): NestedComponentInfo[] {
+  const result: NestedComponentInfo[] = []
+  collectNestedComponents(node, result)
+  return result
+}
+
+function collectNestedComponents(node: IRNode, result: NestedComponentInfo[]): void {
+  if (node.type === 'loop') {
+    const loop = node as IRLoop
+    if (loop.childComponent) {
+      // Check for duplicates
+      if (!result.some(c => c.name === loop.childComponent!.name)) {
+        const hasBodyChildren = loop.childComponent.children.length > 0
+        result.push({
+          ...loop.childComponent,
+          isDynamic: !loop.isStaticArray,
+          isPropDerived: !!loop.isPropDerivedArray,
+          loopKey: loop.key ?? undefined,
+          loopParam: loop.param ?? undefined,
+          bodyChildren: hasBodyChildren ? loop.childComponent.children : undefined,
+          loopArray: loop.array,
+          loopMarkerId: loop.markerId,
+          loopItemType: loop.itemType,
+        })
+      }
+    }
+    for (const child of loop.children) {
+      collectNestedComponents(child, result)
+    }
+  } else if (node.type === 'element') {
+    const element = node as IRElement
+    for (const child of element.children) {
+      collectNestedComponents(child, result)
+    }
+  } else if (node.type === 'fragment') {
+    const fragment = node as IRFragment
+    for (const child of fragment.children) {
+      collectNestedComponents(child, result)
+    }
+  } else if (node.type === 'conditional') {
+    const cond = node as IRConditional
+    collectNestedComponents(cond.whenTrue, result)
+    if (cond.whenFalse) {
+      collectNestedComponents(cond.whenFalse, result)
+    }
+  } else if (node.type === 'if-statement') {
+    const stmt = node as IRIfStatement
+    collectNestedComponents(stmt.consequent, result)
+    if (stmt.alternate) {
+      collectNestedComponents(stmt.alternate, result)
+    }
+  } else if (node.type === 'component') {
+    // (#1896) JSX children passed to an imported component render via
+    // a companion define with the PARENT's data, so a keyed loop
+    // nested inside them (DataTablePreviewDemo's `sortedData().map(…)`
+    // inside `<TableBody>`) needs its `<Name>s` slice on THIS
+    // component's props like any other nested loop.
+    const comp = node as IRComponent
+    for (const child of comp.children) {
+      collectNestedComponents(child, result)
+    }
+  }
+}

--- a/packages/adapter-go-template/src/adapter/emit-context.ts
+++ b/packages/adapter-go-template/src/adapter/emit-context.ts
@@ -1,0 +1,37 @@
+/**
+ * The contract extracted emit modules depend on instead of the concrete
+ * `GoTemplateAdapter`.
+ *
+ * The Go adapter's lowering is deeply mutually recursive (expression lowering ↔
+ * condition lowering ↔ rendering), so a cluster pulled into its own module
+ * still needs to call back into the shared per-compile state and the recursive
+ * entry points. `GoEmitContext` is that seam: extracted free functions take a
+ * `GoEmitContext` as their first argument, and the adapter — which owns the
+ * state and implements the entry points — passes `this`. Modules depend on this
+ * narrow interface, not the 8k-line class, so the dependency is explicit and
+ * the modules are unit-testable against a stub.
+ *
+ * Keep this surface minimal: add a member only when an extracted module
+ * genuinely needs it, so the seam documents the real cross-module coupling
+ * rather than re-exposing the whole adapter.
+ */
+
+import type ts from 'typescript'
+
+import type { ParsedExpr } from '@barefootjs/jsx'
+
+import type { CompileState } from './lib/compile-state.ts'
+
+export interface GoEmitContext {
+  /** Per-compile mutable state (signals, consts, type tables, errors, …). */
+  readonly state: CompileState
+
+  /** Parse a JS expression source string into a TS expression node, or null. */
+  parseLiteralExpression(value: string): ts.Expression | null
+
+  /** Lower a JS expression to its Go-template form (the core recursive entry). */
+  convertExpressionToGo(jsExpr: string, out?: { parsed?: ParsedExpr }): string
+
+  /** Lower a JS condition to a Go-template bool + any hoisted preamble. */
+  convertConditionToGo(jsCondition: string): { condition: string; preamble: string }
+}

--- a/packages/adapter-go-template/src/adapter/expr/helper-inline.ts
+++ b/packages/adapter-go-template/src/adapter/expr/helper-inline.ts
@@ -1,0 +1,161 @@
+/**
+ * Inlining of component-scope arrow-const helpers at a call site.
+ *
+ * Extracted from `go-template-adapter.ts` (Phase 4 decomposition). When a JSX
+ * expression calls a local `const f = (a) => …` helper, the Go adapter has no
+ * function to emit — it inlines the helper body with the call args spliced in
+ * for the params, so the result lowers like any inline expression. The splicer
+ * is scope-blind, so the guards here reject bodies where a textual identifier
+ * replacement could be wrong.
+ *
+ * `substituteHelperParams` is exported because the URL-builder lowering reuses
+ * it; the other helpers are module-internal.
+ */
+
+import ts from 'typescript'
+
+import type { GoEmitContext } from '../emit-context.ts'
+
+/**
+ * Inline a call to a local arrow-const helper, returning the spliced body
+ * source, or null when the expression isn't such a call or the body isn't
+ * splice-safe (nested functions, helper-calling helpers, spread args, …).
+ */
+export function inlineLocalHelperCall(ctx: GoEmitContext, jsExpr: string): string | null {
+  if (ctx.state.localHelperNames.size === 0) return null
+  // Fast path: skip the AST parse unless the expression begins with a known
+  // helper name applied as a call (`<helper>(`). The leading-identifier match
+  // is an unambiguous prefix — the real shape check is the AST parse below.
+  const head = /^\s*([A-Za-z_$][\w$]*)\s*\(/.exec(jsExpr)
+  if (!head || !ctx.state.localHelperNames.has(head[1])) return null
+
+  const call = ctx.parseLiteralExpression(jsExpr)
+  if (!call || !ts.isCallExpression(call) || !ts.isIdentifier(call.expression)) return null
+  // A spread arg (`f(...xs)`) can't map to positional params by text splice.
+  if (call.arguments.some(a => ts.isSpreadElement(a))) return null
+  const fnConst = ctx.state.localConstants.find(
+    c => c.name === (call.expression as ts.Identifier).text && !c.isModule && c.value,
+  )
+  if (!fnConst?.value) return null
+  const fn = ctx.parseLiteralExpression(fnConst.value)
+  if (!fn || !ts.isArrowFunction(fn) || ts.isBlock(fn.body)) return null
+  if (fn.parameters.length !== call.arguments.length) return null
+  // Don't half-inline a helper that calls another local helper.
+  if (bodyCallsLocalHelper(ctx, fn.body)) return null
+
+  const subs = new Map<string, string>()
+  for (let i = 0; i < fn.parameters.length; i++) {
+    const p = fn.parameters[i]
+    if (!ts.isIdentifier(p.name)) return null
+    // Parenthesize the arg so its own precedence survives the splice into the
+    // body (e.g. `x === <param>` with arg `a || b` must not become
+    // `x === a || b`).
+    subs.set(p.name.text, `(${call.arguments[i].getText()})`)
+  }
+  // The splicer is scope-blind, so reject bodies where a textual identifier
+  // replacement could be wrong: nested function scopes (shadowing / param
+  // positions) and object shorthand keys that are params.
+  if (!isSpliceSafeHelperBody(fn.body, new Set(subs.keys()))) return null
+  return substituteHelperParams(fn.body, subs)
+}
+
+/**
+ * Guard for `substituteHelperParams`: the span splicer replaces identifiers by
+ * name without scope tracking, so it is only safe on bodies free of
+ * constructs where a param name could appear in a position the splice can't
+ * handle — a nested function scope (shadowing or its own parameters), or an
+ * object shorthand key (`{ k }`, which can't be rewritten to `{ (arg) }`).
+ */
+function isSpliceSafeHelperBody(body: ts.Node, paramNames: ReadonlySet<string>): boolean {
+  let safe = true
+  const visit = (n: ts.Node): void => {
+    if (!safe) return
+    if (
+      ts.isArrowFunction(n) ||
+      ts.isFunctionExpression(n) ||
+      ts.isFunctionDeclaration(n)
+    ) {
+      safe = false
+      return
+    }
+    if (ts.isShorthandPropertyAssignment(n) && paramNames.has(n.name.text)) {
+      safe = false
+      return
+    }
+    ts.forEachChild(n, visit)
+  }
+  visit(body)
+  return safe
+}
+
+/**
+ * True when `body` contains a call to a *local* (component-scope) arrow helper
+ * const — the signal that inlining `body` here would only push the problem to
+ * another un-lowered helper (e.g. `sortHref`'s body calls `hrefFor`).
+ */
+function bodyCallsLocalHelper(ctx: GoEmitContext, body: ts.Node): boolean {
+  let found = false
+  const visit = (n: ts.Node): void => {
+    if (found) return
+    if (ts.isCallExpression(n) && ts.isIdentifier(n.expression)) {
+      const name = n.expression.text
+      if (
+        ctx.state.localConstants.some(c => c.name === name && !c.isModule && c.containsArrow)
+      ) {
+        found = true
+        return
+      }
+    }
+    ts.forEachChild(n, visit)
+  }
+  visit(body)
+  return found
+}
+
+/**
+ * Re-emit `body` to source with each identifier named in `subs` replaced by
+ * the substitution's source text. Implemented as span splicing over `body`'s
+ * own source (single source file — args are passed as text, not cross-file
+ * AST nodes, which would corrupt a printer keyed to `body`'s source). The walk
+ * skips non-value identifier positions — the property NAME in `a.b` and a
+ * plain object-literal key in `{ k: … }` — so a param sharing a name with a
+ * member or key is left untouched. (`isSpliceSafeHelperBody` has already
+ * rejected nested functions and `{ k }` shorthand keys.)
+ */
+export function substituteHelperParams(
+  body: ts.Expression,
+  subs: ReadonlyMap<string, string>,
+): string {
+  const sf = body.getSourceFile()
+  const base = body.getStart(sf)
+  // Collect replacement spans (relative to the body's start), right-to-left.
+  const repls: { start: number; end: number; text: string }[] = []
+  const visit = (node: ts.Node): void => {
+    if (ts.isPropertyAccessExpression(node)) {
+      visit(node.expression) // skip `.name`
+      return
+    }
+    if (ts.isPropertyAssignment(node)) {
+      // A plain identifier/string key isn't a value position; only a computed
+      // key (`[expr]`) is. Visit the initializer (and computed key) only.
+      if (ts.isComputedPropertyName(node.name)) visit(node.name)
+      visit(node.initializer)
+      return
+    }
+    if (ts.isIdentifier(node)) {
+      const sub = subs.get(node.text)
+      if (sub !== undefined) {
+        repls.push({ start: node.getStart(sf) - base, end: node.getEnd() - base, text: sub })
+        return
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(body)
+
+  let text = body.getText(sf)
+  for (const r of repls.sort((a, b) => b.start - a.start)) {
+    text = text.slice(0, r.start) + r.text + text.slice(r.end)
+  }
+  return text
+}

--- a/packages/adapter-go-template/src/adapter/expr/url-builder.ts
+++ b/packages/adapter-go-template/src/adapter/expr/url-builder.ts
@@ -1,0 +1,222 @@
+/**
+ * Lowering of local `URLSearchParams` builder helpers to `bf_query` (#1897).
+ *
+ * Extracted from `go-template-adapter.ts` (Phase 4 decomposition). Recognises
+ * the `(…) => { const u = new URLSearchParams(); if (G) u.set(K, V); …; return
+ * <s> ? \`${base}?${u}\` : base }` idiom (and a pass-through delegate to another
+ * such helper) and emits a `bf_query` template expression. Anything else
+ * returns null so the caller falls back to the generic lowering.
+ */
+
+import ts from 'typescript'
+
+import type { GoEmitContext } from '../emit-context.ts'
+import { wrapIfMultiToken } from '../lib/go-emit.ts'
+import { substituteHelperParams } from './helper-inline.ts'
+
+type UrlBuilderShape = {
+  base: ts.Expression
+  sets: { guard: ts.Expression | null; key: string; value: ts.Expression }[]
+}
+
+/**
+ * Lower a call to a local URL-builder helper to a `bf_query` template
+ * expression. Handles two shapes:
+ *   - the builder itself — substitute the call args for params and emit
+ *     `bf_query <base> (<guard>) "key" <value> …`;
+ *   - a pass-through delegate (`(k) => hrefFor(k, params().tag)`) — substitute
+ *     and recurse on the delegated call.
+ * Returns null for anything else (→ existing lowering / method-call fallback).
+ */
+export function lowerUrlBuilderHelperCall(ctx: GoEmitContext, jsExpr: string): string | null {
+  if (ctx.state.localHelperNames.size === 0) return null
+  const head = /^\s*([A-Za-z_$][\w$]*)\s*\(/.exec(jsExpr)
+  if (!head || !ctx.state.localHelperNames.has(head[1])) return null
+
+  const call = ctx.parseLiteralExpression(jsExpr)
+  if (!call || !ts.isCallExpression(call) || !ts.isIdentifier(call.expression)) return null
+  if (call.arguments.some(a => ts.isSpreadElement(a))) return null
+  const fnConst = ctx.state.localConstants.find(
+    c => c.name === (call.expression as ts.Identifier).text && !c.isModule && c.value,
+  )
+  if (!fnConst?.value) return null
+  const fn = ctx.parseLiteralExpression(fnConst.value)
+  if (!fn || !ts.isArrowFunction(fn) || fn.parameters.length !== call.arguments.length) return null
+
+  const subs = new Map<string, string>()
+  for (let i = 0; i < fn.parameters.length; i++) {
+    const p = fn.parameters[i]
+    if (!ts.isIdentifier(p.name)) return null
+    subs.set(p.name.text, `(${call.arguments[i].getText()})`)
+  }
+
+  // Shape 1: the helper is itself a URLSearchParams builder.
+  const shape = extractUrlBuilder(fn)
+  if (shape) return emitUrlBuilder(ctx, shape, subs)
+
+  // Shape 2: a pass-through delegate to another local URL-builder helper.
+  if (!ts.isBlock(fn.body)) {
+    let body: ts.Expression = fn.body
+    while (ts.isParenthesizedExpression(body)) body = body.expression
+    if (
+      ts.isCallExpression(body) &&
+      ts.isIdentifier(body.expression) &&
+      ctx.state.localHelperNames.has(body.expression.text)
+    ) {
+      return lowerUrlBuilderHelperCall(ctx, substituteHelperParams(body, subs))
+    }
+  }
+  return null
+}
+
+/**
+ * Extract the `bf_query` shape from a `(…) => { const u = new URLSearchParams();
+ * [if (G)] u.set(K, V); …; return <s> ? … : <base> }` helper, or null when the
+ * block doesn't match that exact builder idiom.
+ */
+function extractUrlBuilder(arrow: ts.ArrowFunction): UrlBuilderShape | null {
+  if (!ts.isBlock(arrow.body)) return null
+  let builderVar: string | null = null
+  let base: ts.Expression | null = null
+  const sets: { guard: ts.Expression | null; key: string; value: ts.Expression }[] = []
+
+  for (const s of arrow.body.statements) {
+    if (ts.isVariableStatement(s)) {
+      for (const d of s.declarationList.declarations) {
+        if (
+          ts.isIdentifier(d.name) &&
+          d.initializer &&
+          ts.isNewExpression(d.initializer) &&
+          ts.isIdentifier(d.initializer.expression) &&
+          d.initializer.expression.text === 'URLSearchParams' &&
+          (d.initializer.arguments?.length ?? 0) === 0
+        ) {
+          builderVar = d.name.text
+        }
+        // Other locals (`const s = u.toString()`) are inert — ignored.
+      }
+      continue
+    }
+    // `if (G) u.set(K, V)` (no else).
+    if (ts.isIfStatement(s) && !s.elseStatement && builderVar) {
+      const set = matchUrlSet(s.thenStatement, builderVar)
+      if (!set) return null
+      sets.push({ guard: s.expression, key: set.key, value: set.value })
+      continue
+    }
+    // Unguarded `u.set(K, V)`.
+    if (ts.isExpressionStatement(s) && builderVar) {
+      const set = matchUrlSet(s, builderVar)
+      if (set) {
+        sets.push({ guard: null, key: set.key, value: set.value })
+        continue
+      }
+      return null
+    }
+    // `return <s> ? `${base}?…` : <base>` — the builder's return must be the
+    // conditional that picks between the with-query and bare-base URL; its
+    // `whenFalse` (no-query) branch is the base. Any other return shape isn't
+    // this idiom (#1945 review) — bail to the method-call fallback.
+    if (ts.isReturnStatement(s) && s.expression) {
+      let e: ts.Expression = s.expression
+      while (ts.isParenthesizedExpression(e)) e = e.expression
+      if (!ts.isConditionalExpression(e)) return null
+      base = e.whenFalse
+      continue
+    }
+    return null
+  }
+  if (!builderVar || !base || sets.length === 0) return null
+  return { base, sets }
+}
+
+/**
+ * Match `<builderVar>.set('literalKey', <value>)` — as a statement or an
+ * if-then — returning the key text and value node, else null.
+ */
+function matchUrlSet(
+  node: ts.Node,
+  builderVar: string,
+): { key: string; value: ts.Expression } | null {
+  const stmt = ts.isBlock(node) ? (node.statements.length === 1 ? node.statements[0] : null) : node
+  if (!stmt || !ts.isExpressionStatement(stmt)) return null
+  const call = stmt.expression
+  if (
+    ts.isCallExpression(call) &&
+    ts.isPropertyAccessExpression(call.expression) &&
+    ts.isIdentifier(call.expression.expression) &&
+    call.expression.expression.text === builderVar &&
+    call.expression.name.text === 'set' &&
+    call.arguments.length === 2 &&
+    ts.isStringLiteral(call.arguments[0])
+  ) {
+    return { key: call.arguments[0].text, value: call.arguments[1] }
+  }
+  return null
+}
+
+/**
+ * Emit `bf_query <base> (<guard>) "key" <value> …` from an extracted builder
+ * shape, lowering each part (with the call args substituted for params) via
+ * the normal expression / condition lowering. Unguarded sets use `true`.
+ */
+function emitUrlBuilder(
+  ctx: GoEmitContext,
+  shape: UrlBuilderShape,
+  subs: ReadonlyMap<string, string>,
+): string | null {
+  const lowerExpr = (n: ts.Expression): string =>
+    ctx.convertExpressionToGo(substituteHelperParams(n, subs))
+  const baseGo = wrapIfMultiToken(lowerExpr(shape.base))
+  const parts: string[] = [baseGo]
+  for (const set of shape.sets) {
+    const guardGo = set.guard ? lowerUrlGuard(ctx, set.guard, subs) : 'true'
+    parts.push(`(${guardGo})`)
+    parts.push(JSON.stringify(set.key))
+    parts.push(wrapIfMultiToken(lowerExpr(set.value)))
+  }
+  return `bf_query ${parts.join(' ')}`
+}
+
+/**
+ * Lower a `u.set()` guard to a Go *bool* for `bf_query`'s `include` argument.
+ * A comparison / logical / negation / bool-literal already yields a bool
+ * (`convertConditionToGo`); a bare value (`if (tag)`) is JS string-truthiness,
+ * lowered to `ne <value> ""`. The arg must be a real bool — `bf_query` type-
+ * asserts it, so Go-template truthiness (`{{if x}}`) is not enough.
+ */
+function lowerUrlGuard(
+  ctx: GoEmitContext,
+  guard: ts.Expression,
+  subs: ReadonlyMap<string, string>,
+): string {
+  let g = guard
+  while (ts.isParenthesizedExpression(g)) g = g.expression
+  // Comparisons, `!x`, and bool literals lower to a Go bool via the condition
+  // lowering. `&&` / `||` do NOT qualify: Go's `and`/`or` return one of their
+  // operands (a string for a truthiness guard like `tag && other`), not a
+  // bool — so they take the truthiness-wrap path below, yielding
+  // `ne (and …) ""`, an actual bool (#1945 review).
+  const isBoolShape =
+    (ts.isBinaryExpression(g) &&
+      [
+        ts.SyntaxKind.EqualsEqualsToken,
+        ts.SyntaxKind.EqualsEqualsEqualsToken,
+        ts.SyntaxKind.ExclamationEqualsToken,
+        ts.SyntaxKind.ExclamationEqualsEqualsToken,
+        ts.SyntaxKind.LessThanToken,
+        ts.SyntaxKind.GreaterThanToken,
+        ts.SyntaxKind.LessThanEqualsToken,
+        ts.SyntaxKind.GreaterThanEqualsToken,
+      ].includes(g.operatorToken.kind)) ||
+    (ts.isPrefixUnaryExpression(g) && g.operator === ts.SyntaxKind.ExclamationToken) ||
+    g.kind === ts.SyntaxKind.TrueKeyword ||
+    g.kind === ts.SyntaxKind.FalseKeyword
+  if (isBoolShape) {
+    return ctx.convertConditionToGo(substituteHelperParams(guard, subs)).condition
+  }
+  const valueGo = wrapIfMultiToken(
+    ctx.convertExpressionToGo(substituteHelperParams(guard, subs)),
+  )
+  return `ne ${valueGo} ""`
+}

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -104,6 +104,7 @@ import type {
 import { collectRootScopeNodes } from "./lib/ir-scope.ts"
 import { GO_TEMPLATE_PRIMITIVES } from "./lib/constants.ts"
 import { CompileState } from "./lib/compile-state.ts"
+import { hasClientInteractivity, findNestedComponents } from "./analysis/component-tree.ts"
 
 export type { GoTemplateAdapterOptions } from "./lib/types.ts"
 
@@ -290,7 +291,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       this.checkImportedLoopChildComponents(ir)
     }
 
-    const hasInteractivity = this.hasClientInteractivity(ir)
+    const hasInteractivity = hasClientInteractivity(ir)
     const isRootComponent = ir.root.type === 'component'
     const isIfStatement = ir.root.type === 'if-statement'
 
@@ -300,7 +301,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // length (#1897 PostList status count). Built before rendering — the
     // `.length` reference can appear before the loop in source order.
     this.state.memoBackedLoopSlice = new Map()
-    for (const nested of this.findNestedComponents(ir.root)) {
+    for (const nested of findNestedComponents(ir.root)) {
       const memoName = this.extractMemoNameFromLoopArray(nested.loopArray)
       if (memoName) this.state.memoBackedLoopSlice.set(memoName, `${nested.name}s`)
     }
@@ -342,107 +343,6 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       sections,
       types: types || undefined,
       extension: this.extension,
-    }
-  }
-
-  /**
-   * Check if a component has client interactivity (needs client JS).
-   * A component has client interactivity if it has:
-   * - Signals (reactive state)
-   * - Effects (side effects)
-   * - Events on elements
-   */
-  private hasClientInteractivity(ir: ComponentIR): boolean {
-    // Check for signals
-    if (ir.metadata.signals.length > 0) return true
-
-    // Check for effects
-    if (ir.metadata.effects.length > 0) return true
-
-    // Check for onMounts
-    if (ir.metadata.onMounts.length > 0) return true
-
-    // Check for events in the IR tree
-    if (this.hasEventsInTree(ir.root)) return true
-
-    // Check for child components (they need parent's hydration)
-    if (this.findChildComponentNames(ir.root).size > 0) return true
-
-    return false
-  }
-
-  /**
-   * Recursively check if any element in the tree has events.
-   */
-  private hasEventsInTree(node: IRNode): boolean {
-    if (node.type === 'element') {
-      const element = node as IRElement
-      if (element.events.length > 0) return true
-      for (const child of element.children) {
-        if (this.hasEventsInTree(child)) return true
-      }
-    } else if (node.type === 'fragment') {
-      const fragment = node as IRFragment
-      for (const child of fragment.children) {
-        if (this.hasEventsInTree(child)) return true
-      }
-    } else if (node.type === 'conditional') {
-      const cond = node as IRConditional
-      if (this.hasEventsInTree(cond.whenTrue)) return true
-      if (cond.whenFalse && this.hasEventsInTree(cond.whenFalse)) return true
-    } else if (node.type === 'loop') {
-      const loop = node as IRLoop
-      for (const child of loop.children) {
-        if (this.hasEventsInTree(child)) return true
-      }
-    } else if (node.type === 'if-statement') {
-      const ifStmt = node as IRIfStatement
-      if (this.hasEventsInTree(ifStmt.consequent)) return true
-      if (ifStmt.alternate && this.hasEventsInTree(ifStmt.alternate)) return true
-    }
-    return false
-  }
-
-  /**
-   * Find all child component names used in the IR tree.
-   */
-  private findChildComponentNames(node: IRNode): Set<string> {
-    const names = new Set<string>()
-    this.collectChildComponentNames(node, names)
-    return names
-  }
-
-  private collectChildComponentNames(node: IRNode, names: Set<string>): void {
-    if (node.type === 'component') {
-      const comp = node as IRComponent
-      names.add(comp.name)
-    } else if (node.type === 'element') {
-      const element = node as IRElement
-      for (const child of element.children) {
-        this.collectChildComponentNames(child, names)
-      }
-    } else if (node.type === 'fragment') {
-      const fragment = node as IRFragment
-      for (const child of fragment.children) {
-        this.collectChildComponentNames(child, names)
-      }
-    } else if (node.type === 'conditional') {
-      const cond = node as IRConditional
-      this.collectChildComponentNames(cond.whenTrue, names)
-      if (cond.whenFalse) {
-        this.collectChildComponentNames(cond.whenFalse, names)
-      }
-    } else if (node.type === 'loop') {
-      const loop = node as IRLoop
-      for (const child of loop.children) {
-        this.collectChildComponentNames(child, names)
-      }
-    } else if (node.type === 'if-statement') {
-      const ifStmt = node as IRIfStatement
-      this.collectChildComponentNames(ifStmt.consequent, names)
-      if (ifStmt.alternate) {
-        this.collectChildComponentNames(ifStmt.alternate, names)
-      }
     }
   }
 
@@ -552,7 +452,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    */
   private generateScriptRegistrations(ir: ComponentIR, scriptBaseName?: string): string {
     // Check if this component has client interactivity
-    const hasInteractivity = this.hasClientInteractivity(ir)
+    const hasInteractivity = hasClientInteractivity(ir)
 
     if (!hasInteractivity) {
       return ''
@@ -726,7 +626,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     }
 
     // Find nested components (loops with childComponent)
-    const nestedComponents = this.findNestedComponents(ir.root)
+    const nestedComponents = findNestedComponents(ir.root)
 
     // (#1897) When a loop's `itemType` is null, resolve the element type
     // from the source array so wrapper structs get correct datum fields.
@@ -2102,74 +2002,6 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    */
   private toJsonTag(name: string): string {
     return name.charAt(0).toLowerCase() + name.slice(1)
-  }
-
-  /**
-   * Find all nested components (loops with childComponent).
-   * Returns extended info that includes whether the component comes from a dynamic (signal) array loop.
-   */
-  private findNestedComponents(node: IRNode): NestedComponentInfo[] {
-    const result: NestedComponentInfo[] = []
-    this.collectNestedComponents(node, result)
-    return result
-  }
-
-  private collectNestedComponents(node: IRNode, result: NestedComponentInfo[]): void {
-    if (node.type === 'loop') {
-      const loop = node as IRLoop
-      if (loop.childComponent) {
-        // Check for duplicates
-        if (!result.some(c => c.name === loop.childComponent!.name)) {
-          const hasBodyChildren = loop.childComponent.children.length > 0
-          result.push({
-            ...loop.childComponent,
-            isDynamic: !loop.isStaticArray,
-            isPropDerived: !!loop.isPropDerivedArray,
-            loopKey: loop.key ?? undefined,
-            loopParam: loop.param ?? undefined,
-            bodyChildren: hasBodyChildren ? loop.childComponent.children : undefined,
-            loopArray: loop.array,
-            loopMarkerId: loop.markerId,
-            loopItemType: loop.itemType,
-          })
-        }
-      }
-      for (const child of loop.children) {
-        this.collectNestedComponents(child, result)
-      }
-    } else if (node.type === 'element') {
-      const element = node as IRElement
-      for (const child of element.children) {
-        this.collectNestedComponents(child, result)
-      }
-    } else if (node.type === 'fragment') {
-      const fragment = node as IRFragment
-      for (const child of fragment.children) {
-        this.collectNestedComponents(child, result)
-      }
-    } else if (node.type === 'conditional') {
-      const cond = node as IRConditional
-      this.collectNestedComponents(cond.whenTrue, result)
-      if (cond.whenFalse) {
-        this.collectNestedComponents(cond.whenFalse, result)
-      }
-    } else if (node.type === 'if-statement') {
-      const stmt = node as IRIfStatement
-      this.collectNestedComponents(stmt.consequent, result)
-      if (stmt.alternate) {
-        this.collectNestedComponents(stmt.alternate, result)
-      }
-    } else if (node.type === 'component') {
-      // (#1896) JSX children passed to an imported component render via
-      // a companion define with the PARENT's data, so a keyed loop
-      // nested inside them (DataTablePreviewDemo's `sortedData().map(…)`
-      // inside `<TableBody>`) needs its `<Name>s` slice on THIS
-      // component's props like any other nested loop.
-      const comp = node as IRComponent
-      for (const child of comp.children) {
-        this.collectNestedComponents(child, result)
-      }
-    }
   }
 
   /**
@@ -4589,7 +4421,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   private collectPropFallbackVars(ir: ComponentIR): Map<string, PropFallbackVar> {
     const result = new Map<string, PropFallbackVar>()
     const localTaken = new Set(['scopeID'])
-    for (const nested of this.findNestedComponents(ir.root)) {
+    for (const nested of findNestedComponents(ir.root)) {
       localTaken.add(`${nested.name.charAt(0).toLowerCase()}${nested.name.slice(1)}s`)
     }
 

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -111,7 +111,7 @@ import { lowerUrlBuilderHelperCall } from "./expr/url-builder.ts"
 
 export type { GoTemplateAdapterOptions } from "./lib/types.ts"
 
-export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter, IRNodeEmitter<GoRenderCtx>, GoEmitContext {
+export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter, IRNodeEmitter<GoRenderCtx> {
   name = 'go-template'
   extension = '.tmpl'
 
@@ -186,7 +186,22 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * bookkeeping lives in one place rather than scattered across the
    * adapter's fields. See `CompileState` for the field-by-field docs.
    */
-  readonly state = new CompileState()
+  private readonly state = new CompileState()
+
+  /**
+   * The `GoEmitContext` handed to extracted emit modules. Built once over the
+   * adapter's own (private) state and recursive entry points, so the modules
+   * get the seam without `state` / `convert*` / `parseLiteralExpression`
+   * leaking onto the exported adapter's public type. `state` is captured by
+   * reference — `CompileState` is reset in place per compile, never reassigned
+   * — so a single `emitCtx` stays valid across `generate()` calls.
+   */
+  private readonly emitCtx: GoEmitContext = {
+    state: this.state,
+    parseLiteralExpression: (value) => this.parseLiteralExpression(value),
+    convertExpressionToGo: (jsExpr, out) => this.convertExpressionToGo(jsExpr, out),
+    convertConditionToGo: (jsCondition) => this.convertConditionToGo(jsCondition),
+  }
 
   /**
    * Diagnostics collected during the current compile. `generate()` merges
@@ -2839,7 +2854,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * or `null` when it isn't a single expression. Shared by the literal baker
    * and the struct-shape synthesiser.
    */
-  parseLiteralExpression(value: string): ts.Expression | null {
+  private parseLiteralExpression(value: string): ts.Expression | null {
     const sf = ts.createSourceFile(
       '__lit.ts', `(${value})`, ts.ScriptTarget.Latest, /* setParentNodes */ true,
     )
@@ -6267,7 +6282,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   /**
    * Convert a JS expression to Go template syntax.
    */
-  convertExpressionToGo(jsExpr: string, out?: { parsed?: ParsedExpr }): string {
+  private convertExpressionToGo(jsExpr: string, out?: { parsed?: ParsedExpr }): string {
     const trimmed = jsExpr.trim()
 
     // Handle null/undefined specially
@@ -6306,7 +6321,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // `tagHref` delegating to it) lowers to a `bf_query` action — there is no Go
     // method backing a `.SortHref "date"` call. Tried before the generic inliner
     // because these helpers are block-bodied / delegate, which the inliner skips.
-    const urlBuilt = lowerUrlBuilderHelperCall(this, trimmed)
+    const urlBuilt = lowerUrlBuilderHelperCall(this.emitCtx, trimmed)
     if (urlBuilt !== null) return urlBuilt
 
     // Inline a call to a local, expression-bodied helper arrow
@@ -6316,7 +6331,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // (`{{if eq .Params.Sort "date"}}sort on{{else}}sort{{end}}`). Only self-
     // contained helpers are inlined; one that delegates to another local helper
     // (e.g. `sortHref` → `hrefFor`) is left for a later capability.
-    const inlined = inlineLocalHelperCall(this, trimmed)
+    const inlined = inlineLocalHelperCall(this.emitCtx, trimmed)
     if (inlined !== null) {
       return this.convertExpressionToGo(inlined, out)
     }
@@ -6528,7 +6543,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * Returns { condition, preamble } where preamble contains template blocks
    * that must be emitted before the {{if}} (e.g., every/some range blocks).
    */
-  convertConditionToGo(jsCondition: string): { condition: string; preamble: string } {
+  private convertConditionToGo(jsCondition: string): { condition: string; preamble: string } {
     const trimmed = jsCondition.trim()
     const parsed = parseExpression(trimmed)
     const support = isSupported(parsed)

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -105,10 +105,13 @@ import { collectRootScopeNodes } from "./lib/ir-scope.ts"
 import { GO_TEMPLATE_PRIMITIVES } from "./lib/constants.ts"
 import { CompileState } from "./lib/compile-state.ts"
 import { hasClientInteractivity, findNestedComponents } from "./analysis/component-tree.ts"
+import type { GoEmitContext } from "./emit-context.ts"
+import { inlineLocalHelperCall } from "./expr/helper-inline.ts"
+import { lowerUrlBuilderHelperCall } from "./expr/url-builder.ts"
 
 export type { GoTemplateAdapterOptions } from "./lib/types.ts"
 
-export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter, IRNodeEmitter<GoRenderCtx> {
+export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter, IRNodeEmitter<GoRenderCtx>, GoEmitContext {
   name = 'go-template'
   extension = '.tmpl'
 
@@ -183,7 +186,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * bookkeeping lives in one place rather than scattered across the
    * adapter's fields. See `CompileState` for the field-by-field docs.
    */
-  private readonly state = new CompileState()
+  readonly state = new CompileState()
 
   /**
    * Diagnostics collected during the current compile. `generate()` merges
@@ -2836,7 +2839,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * or `null` when it isn't a single expression. Shared by the literal baker
    * and the struct-shape synthesiser.
    */
-  private parseLiteralExpression(value: string): ts.Expression | null {
+  parseLiteralExpression(value: string): ts.Expression | null {
     const sf = ts.createSourceFile(
       '__lit.ts', `(${value})`, ts.ScriptTarget.Latest, /* setParentNodes */ true,
     )
@@ -6264,7 +6267,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   /**
    * Convert a JS expression to Go template syntax.
    */
-  private convertExpressionToGo(jsExpr: string, out?: { parsed?: ParsedExpr }): string {
+  convertExpressionToGo(jsExpr: string, out?: { parsed?: ParsedExpr }): string {
     const trimmed = jsExpr.trim()
 
     // Handle null/undefined specially
@@ -6303,7 +6306,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // `tagHref` delegating to it) lowers to a `bf_query` action — there is no Go
     // method backing a `.SortHref "date"` call. Tried before the generic inliner
     // because these helpers are block-bodied / delegate, which the inliner skips.
-    const urlBuilt = this.lowerUrlBuilderHelperCall(trimmed)
+    const urlBuilt = lowerUrlBuilderHelperCall(this, trimmed)
     if (urlBuilt !== null) return urlBuilt
 
     // Inline a call to a local, expression-bodied helper arrow
@@ -6313,7 +6316,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // (`{{if eq .Params.Sort "date"}}sort on{{else}}sort{{end}}`). Only self-
     // contained helpers are inlined; one that delegates to another local helper
     // (e.g. `sortHref` → `hrefFor`) is left for a later capability.
-    const inlined = this.inlineLocalHelperCall(trimmed)
+    const inlined = inlineLocalHelperCall(this, trimmed)
     if (inlined !== null) {
       return this.convertExpressionToGo(inlined, out)
     }
@@ -6354,356 +6357,6 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     if (out) out.parsed = parsed
 
     return this.renderParsedExpr(parsed)
-  }
-
-  /**
-   * (#1897 PostList) If `jsExpr` is a call to a local, expression-bodied helper
-   * arrow const (`sortClass(k)` / `tagClass(t)`), return its body with the call
-   * args substituted for the params (re-emitted to source), so the caller can
-   * lower the inlined expression. Returns null when `jsExpr` is not such a call,
-   * or when the helper delegates to another local helper (e.g. `sortHref` →
-   * `hrefFor`) — those need their own lowering capability and must not be
-   * half-inlined here. Substitution is AST-based (no string matching) so it is
-   * shadowing- and member-name-safe.
-   */
-  private inlineLocalHelperCall(jsExpr: string): string | null {
-    if (this.state.localHelperNames.size === 0) return null
-    // Fast path: skip the AST parse unless the expression begins with a known
-    // helper name applied as a call (`<helper>(`). The leading-identifier match
-    // is an unambiguous prefix — the real shape check is the AST parse below.
-    const head = /^\s*([A-Za-z_$][\w$]*)\s*\(/.exec(jsExpr)
-    if (!head || !this.state.localHelperNames.has(head[1])) return null
-
-    const call = this.parseLiteralExpression(jsExpr)
-    if (!call || !ts.isCallExpression(call) || !ts.isIdentifier(call.expression)) return null
-    // A spread arg (`f(...xs)`) can't map to positional params by text splice.
-    if (call.arguments.some(a => ts.isSpreadElement(a))) return null
-    const fnConst = this.state.localConstants.find(
-      c => c.name === (call.expression as ts.Identifier).text && !c.isModule && c.value,
-    )
-    if (!fnConst?.value) return null
-    const fn = this.parseLiteralExpression(fnConst.value)
-    if (!fn || !ts.isArrowFunction(fn) || ts.isBlock(fn.body)) return null
-    if (fn.parameters.length !== call.arguments.length) return null
-    // Don't half-inline a helper that calls another local helper.
-    if (this.bodyCallsLocalHelper(fn.body)) return null
-
-    const subs = new Map<string, string>()
-    for (let i = 0; i < fn.parameters.length; i++) {
-      const p = fn.parameters[i]
-      if (!ts.isIdentifier(p.name)) return null
-      // Parenthesize the arg so its own precedence survives the splice into the
-      // body (e.g. `x === <param>` with arg `a || b` must not become
-      // `x === a || b`).
-      subs.set(p.name.text, `(${call.arguments[i].getText()})`)
-    }
-    // The splicer is scope-blind, so reject bodies where a textual identifier
-    // replacement could be wrong: nested function scopes (shadowing / param
-    // positions) and object shorthand keys that are params.
-    if (!this.isSpliceSafeHelperBody(fn.body, new Set(subs.keys()))) return null
-    return this.substituteHelperParams(fn.body, subs)
-  }
-
-  /**
-   * Guard for `substituteHelperParams`: the span splicer replaces identifiers by
-   * name without scope tracking, so it is only safe on bodies free of
-   * constructs where a param name could appear in a position the splice can't
-   * handle — a nested function scope (shadowing or its own parameters), or an
-   * object shorthand key (`{ k }`, which can't be rewritten to `{ (arg) }`).
-   */
-  private isSpliceSafeHelperBody(body: ts.Node, paramNames: ReadonlySet<string>): boolean {
-    let safe = true
-    const visit = (n: ts.Node): void => {
-      if (!safe) return
-      if (
-        ts.isArrowFunction(n) ||
-        ts.isFunctionExpression(n) ||
-        ts.isFunctionDeclaration(n)
-      ) {
-        safe = false
-        return
-      }
-      if (ts.isShorthandPropertyAssignment(n) && paramNames.has(n.name.text)) {
-        safe = false
-        return
-      }
-      ts.forEachChild(n, visit)
-    }
-    visit(body)
-    return safe
-  }
-
-  /**
-   * True when `body` contains a call to a *local* (component-scope) arrow helper
-   * const — the signal that inlining `body` here would only push the problem to
-   * another un-lowered helper (e.g. `sortHref`'s body calls `hrefFor`).
-   */
-  private bodyCallsLocalHelper(body: ts.Node): boolean {
-    let found = false
-    const visit = (n: ts.Node): void => {
-      if (found) return
-      if (ts.isCallExpression(n) && ts.isIdentifier(n.expression)) {
-        const name = n.expression.text
-        if (
-          this.state.localConstants.some(c => c.name === name && !c.isModule && c.containsArrow)
-        ) {
-          found = true
-          return
-        }
-      }
-      ts.forEachChild(n, visit)
-    }
-    visit(body)
-    return found
-  }
-
-  /**
-   * Re-emit `body` to source with each identifier named in `subs` replaced by
-   * the substitution's source text. Implemented as span splicing over `body`'s
-   * own source (single source file — args are passed as text, not cross-file
-   * AST nodes, which would corrupt a printer keyed to `body`'s source). The walk
-   * skips non-value identifier positions — the property NAME in `a.b` and a
-   * plain object-literal key in `{ k: … }` — so a param sharing a name with a
-   * member or key is left untouched. (`isSpliceSafeHelperBody` has already
-   * rejected nested functions and `{ k }` shorthand keys.)
-   */
-  private substituteHelperParams(
-    body: ts.Expression,
-    subs: ReadonlyMap<string, string>,
-  ): string {
-    const sf = body.getSourceFile()
-    const base = body.getStart(sf)
-    // Collect replacement spans (relative to the body's start), right-to-left.
-    const repls: { start: number; end: number; text: string }[] = []
-    const visit = (node: ts.Node): void => {
-      if (ts.isPropertyAccessExpression(node)) {
-        visit(node.expression) // skip `.name`
-        return
-      }
-      if (ts.isPropertyAssignment(node)) {
-        // A plain identifier/string key isn't a value position; only a computed
-        // key (`[expr]`) is. Visit the initializer (and computed key) only.
-        if (ts.isComputedPropertyName(node.name)) visit(node.name)
-        visit(node.initializer)
-        return
-      }
-      if (ts.isIdentifier(node)) {
-        const sub = subs.get(node.text)
-        if (sub !== undefined) {
-          repls.push({ start: node.getStart(sf) - base, end: node.getEnd() - base, text: sub })
-          return
-        }
-      }
-      ts.forEachChild(node, visit)
-    }
-    visit(body)
-
-    let text = body.getText(sf)
-    for (const r of repls.sort((a, b) => b.start - a.start)) {
-      text = text.slice(0, r.start) + r.text + text.slice(r.end)
-    }
-    return text
-  }
-
-  /**
-   * (#1897 PostList) Lower a call to a local URL-builder helper to a `bf_query`
-   * template expression. Handles two shapes:
-   *   - the builder itself — `(sort, tag) => { const u = new URLSearchParams();
-   *     if (sort !== 'date') u.set('sort', sort); if (tag) u.set('tag', tag);
-   *     return u.toString() ? \`${root}?${u}\` : root }` — substitute the call
-   *     args for params and emit `bf_query <base> (<guard>) "key" <value> …`;
-   *   - a pass-through delegate — `(k) => hrefFor(k, params().tag)` — substitute
-   *     and recurse on the delegated call.
-   * Returns null for anything else (→ existing lowering / method-call fallback).
-   */
-  private lowerUrlBuilderHelperCall(jsExpr: string): string | null {
-    if (this.state.localHelperNames.size === 0) return null
-    const head = /^\s*([A-Za-z_$][\w$]*)\s*\(/.exec(jsExpr)
-    if (!head || !this.state.localHelperNames.has(head[1])) return null
-
-    const call = this.parseLiteralExpression(jsExpr)
-    if (!call || !ts.isCallExpression(call) || !ts.isIdentifier(call.expression)) return null
-    if (call.arguments.some(a => ts.isSpreadElement(a))) return null
-    const fnConst = this.state.localConstants.find(
-      c => c.name === (call.expression as ts.Identifier).text && !c.isModule && c.value,
-    )
-    if (!fnConst?.value) return null
-    const fn = this.parseLiteralExpression(fnConst.value)
-    if (!fn || !ts.isArrowFunction(fn) || fn.parameters.length !== call.arguments.length) return null
-
-    const subs = new Map<string, string>()
-    for (let i = 0; i < fn.parameters.length; i++) {
-      const p = fn.parameters[i]
-      if (!ts.isIdentifier(p.name)) return null
-      subs.set(p.name.text, `(${call.arguments[i].getText()})`)
-    }
-
-    // Shape 1: the helper is itself a URLSearchParams builder.
-    const shape = this.extractUrlBuilder(fn)
-    if (shape) return this.emitUrlBuilder(shape, subs)
-
-    // Shape 2: a pass-through delegate to another local URL-builder helper.
-    if (!ts.isBlock(fn.body)) {
-      let body: ts.Expression = fn.body
-      while (ts.isParenthesizedExpression(body)) body = body.expression
-      if (
-        ts.isCallExpression(body) &&
-        ts.isIdentifier(body.expression) &&
-        this.state.localHelperNames.has(body.expression.text)
-      ) {
-        return this.lowerUrlBuilderHelperCall(this.substituteHelperParams(body, subs))
-      }
-    }
-    return null
-  }
-
-  /**
-   * Extract the `bf_query` shape from a `(…) => { const u = new URLSearchParams();
-   * [if (G)] u.set(K, V); …; return <s> ? … : <base> }` helper, or null when the
-   * block doesn't match that exact builder idiom.
-   */
-  private extractUrlBuilder(
-    arrow: ts.ArrowFunction,
-  ): { base: ts.Expression; sets: { guard: ts.Expression | null; key: string; value: ts.Expression }[] } | null {
-    if (!ts.isBlock(arrow.body)) return null
-    let builderVar: string | null = null
-    let base: ts.Expression | null = null
-    const sets: { guard: ts.Expression | null; key: string; value: ts.Expression }[] = []
-
-    for (const s of arrow.body.statements) {
-      if (ts.isVariableStatement(s)) {
-        for (const d of s.declarationList.declarations) {
-          if (
-            ts.isIdentifier(d.name) &&
-            d.initializer &&
-            ts.isNewExpression(d.initializer) &&
-            ts.isIdentifier(d.initializer.expression) &&
-            d.initializer.expression.text === 'URLSearchParams' &&
-            (d.initializer.arguments?.length ?? 0) === 0
-          ) {
-            builderVar = d.name.text
-          }
-          // Other locals (`const s = u.toString()`) are inert — ignored.
-        }
-        continue
-      }
-      // `if (G) u.set(K, V)` (no else).
-      if (ts.isIfStatement(s) && !s.elseStatement && builderVar) {
-        const set = this.matchUrlSet(s.thenStatement, builderVar)
-        if (!set) return null
-        sets.push({ guard: s.expression, key: set.key, value: set.value })
-        continue
-      }
-      // Unguarded `u.set(K, V)`.
-      if (ts.isExpressionStatement(s) && builderVar) {
-        const set = this.matchUrlSet(s, builderVar)
-        if (set) {
-          sets.push({ guard: null, key: set.key, value: set.value })
-          continue
-        }
-        return null
-      }
-      // `return <s> ? `${base}?…` : <base>` — the builder's return must be the
-      // conditional that picks between the with-query and bare-base URL; its
-      // `whenFalse` (no-query) branch is the base. Any other return shape isn't
-      // this idiom (#1945 review) — bail to the method-call fallback.
-      if (ts.isReturnStatement(s) && s.expression) {
-        let e: ts.Expression = s.expression
-        while (ts.isParenthesizedExpression(e)) e = e.expression
-        if (!ts.isConditionalExpression(e)) return null
-        base = e.whenFalse
-        continue
-      }
-      return null
-    }
-    if (!builderVar || !base || sets.length === 0) return null
-    return { base, sets }
-  }
-
-  /**
-   * Match `<builderVar>.set('literalKey', <value>)` — as a statement or an
-   * if-then — returning the key text and value node, else null.
-   */
-  private matchUrlSet(
-    node: ts.Node,
-    builderVar: string,
-  ): { key: string; value: ts.Expression } | null {
-    const stmt = ts.isBlock(node) ? (node.statements.length === 1 ? node.statements[0] : null) : node
-    if (!stmt || !ts.isExpressionStatement(stmt)) return null
-    const call = stmt.expression
-    if (
-      ts.isCallExpression(call) &&
-      ts.isPropertyAccessExpression(call.expression) &&
-      ts.isIdentifier(call.expression.expression) &&
-      call.expression.expression.text === builderVar &&
-      call.expression.name.text === 'set' &&
-      call.arguments.length === 2 &&
-      ts.isStringLiteral(call.arguments[0])
-    ) {
-      return { key: call.arguments[0].text, value: call.arguments[1] }
-    }
-    return null
-  }
-
-  /**
-   * Emit `bf_query <base> (<guard>) "key" <value> …` from an extracted builder
-   * shape, lowering each part (with the call args substituted for params) via
-   * the normal expression / condition lowering. Unguarded sets use `true`.
-   */
-  private emitUrlBuilder(
-    shape: { base: ts.Expression; sets: { guard: ts.Expression | null; key: string; value: ts.Expression }[] },
-    subs: ReadonlyMap<string, string>,
-  ): string | null {
-    const lowerExpr = (n: ts.Expression): string =>
-      this.convertExpressionToGo(this.substituteHelperParams(n, subs))
-    const baseGo = wrapIfMultiToken(lowerExpr(shape.base))
-    const parts: string[] = [baseGo]
-    for (const set of shape.sets) {
-      const guardGo = set.guard ? this.lowerUrlGuard(set.guard, subs) : 'true'
-      parts.push(`(${guardGo})`)
-      parts.push(JSON.stringify(set.key))
-      parts.push(wrapIfMultiToken(lowerExpr(set.value)))
-    }
-    return `bf_query ${parts.join(' ')}`
-  }
-
-  /**
-   * Lower a `u.set()` guard to a Go *bool* for `bf_query`'s `include` argument.
-   * A comparison / logical / negation / bool-literal already yields a bool
-   * (`convertConditionToGo`); a bare value (`if (tag)`) is JS string-truthiness,
-   * lowered to `ne <value> ""`. The arg must be a real bool — `bf_query` type-
-   * asserts it, so Go-template truthiness (`{{if x}}`) is not enough.
-   */
-  private lowerUrlGuard(guard: ts.Expression, subs: ReadonlyMap<string, string>): string {
-    let g = guard
-    while (ts.isParenthesizedExpression(g)) g = g.expression
-    // Comparisons, `!x`, and bool literals lower to a Go bool via the condition
-    // lowering. `&&` / `||` do NOT qualify: Go's `and`/`or` return one of their
-    // operands (a string for a truthiness guard like `tag && other`), not a
-    // bool — so they take the truthiness-wrap path below, yielding
-    // `ne (and …) ""`, an actual bool (#1945 review).
-    const isBoolShape =
-      (ts.isBinaryExpression(g) &&
-        [
-          ts.SyntaxKind.EqualsEqualsToken,
-          ts.SyntaxKind.EqualsEqualsEqualsToken,
-          ts.SyntaxKind.ExclamationEqualsToken,
-          ts.SyntaxKind.ExclamationEqualsEqualsToken,
-          ts.SyntaxKind.LessThanToken,
-          ts.SyntaxKind.GreaterThanToken,
-          ts.SyntaxKind.LessThanEqualsToken,
-          ts.SyntaxKind.GreaterThanEqualsToken,
-        ].includes(g.operatorToken.kind)) ||
-      (ts.isPrefixUnaryExpression(g) && g.operator === ts.SyntaxKind.ExclamationToken) ||
-      g.kind === ts.SyntaxKind.TrueKeyword ||
-      g.kind === ts.SyntaxKind.FalseKeyword
-    if (isBoolShape) {
-      return this.convertConditionToGo(this.substituteHelperParams(guard, subs)).condition
-    }
-    const valueGo = wrapIfMultiToken(
-      this.convertExpressionToGo(this.substituteHelperParams(guard, subs)),
-    )
-    return `ne ${valueGo} ""`
   }
 
   /**
@@ -6875,7 +6528,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * Returns { condition, preamble } where preamble contains template blocks
    * that must be emitted before the {{if}} (e.g., every/some range blocks).
    */
-  private convertConditionToGo(jsCondition: string): { condition: string; preamble: string } {
+  convertConditionToGo(jsCondition: string): { condition: string; preamble: string } {
     const trimmed = jsCondition.trim()
     const parsed = parseExpression(trimmed)
     const support = isSupported(parsed)


### PR DESCRIPTION
## Summary

Phase 4 of the Go html/template adapter cleanup, aiming at the ideal decomposition where `GoTemplateAdapter` becomes a thin orchestrator and each logical domain lives in its own module. Phases 1–3 (#1974) extracted pure helpers, types, and per-compile state; this PR establishes the **architecture** the rest of the decomposition builds on and lands the first self-contained clusters.

**Behaviour is unchanged (byte-identical):** generated Go template output is not altered.

## Why a seam is needed

The adapter's lowering is deeply mutually recursive (expression lowering ↔ condition lowering ↔ rendering), and the `ParsedExprEmitter` / `IRNodeEmitter` / `AttrValueEmitter` interface methods *must* stay on the class (the shared dispatchers call `adapter.literal()`, `adapter.emitElement()`, …). So a cluster pulled into its own module still needs to call back into the shared per-compile state and the recursive entry points.

`GoEmitContext` is that seam: a **narrow interface** exposing the per-compile `state` plus the recursive entry points (`parseLiteralExpression`, `convertExpressionToGo`, `convertConditionToGo`). Extracted modules are free functions taking a `GoEmitContext`; the adapter implements it and passes `this`. Modules depend on this interface, not the 8k-line class — so cross-module coupling is explicit and the modules are unit-testable against a stub. The surface is kept minimal: a member is added only when an extracted module genuinely needs it.

## Changes

| Module | Contents | Coupling |
|---|---|---|
| `analysis/component-tree.ts` | Pure IR structural walks: `hasClientInteractivity`, `hasEventsInTree`, child/nested-component discovery | none (no state, no rendering) — plain free functions |
| `emit-context.ts` | The `GoEmitContext` interface | — |
| `expr/helper-inline.ts` | Local arrow-const helper inlining at a call site (`inlineLocalHelperCall` + splice-safety guards + `substituteHelperParams`) | via `GoEmitContext` |
| `expr/url-builder.ts` | `URLSearchParams` builder helpers → `bf_query` lowering (#1897) | via `GoEmitContext` |

Main file: **8,048 → 7,533 lines**.

## Verification (each commit)

- `adapter-go-template` unit: ✅ 551 pass / 0 fail
- `adapter-tests` conformance (byte-identical SSR): ✅ 786 pass / 0 fail
- `tsgo --noEmit`: ✅ &nbsp;·&nbsp; `biome check`: ✅

## Roadmap (subsequent PRs, on this seam)

`type-codegen` → `value-lowering` → `memo-lowering` → `spread-codegen` → `props-codegen` → `array-lowering`, with node rendering (`renderElement` / `renderLoop` / `renderComponent` / `renderAttributes`) remaining as the orchestrator core. Each is its own byte-identical, test-verified PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_