### PR TITLE
refactor(jsx,go-template): carry IRExpression.parsed; reuse it in the Go adapter

### DIFF
--- a/.changeset/ir-expression-parsed.md
+++ b/.changeset/ir-expression-parsed.md
@@ -1,0 +1,9 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+---
+
+Carry the parsed expression tree in the IR for text-interpolation nodes, so SSR adapters emit from it instead of each re-parsing the string at emit time (and a multi-adapter build parses it once, not per adapter). Output byte-identical; the only public-API change is additive (`IRExpression` gains an optional `parsed` field).
+
+- `@barefootjs/jsx`: `jsxToIR` now walks the produced tree and attaches `IRExpression.parsed` (`parseExpression(expr.trim())`) to every text-interpolation node. Best-effort — a node left without `parsed` (or an empty expr) just falls back to adapter-side parsing, so it is never a behavioural change.
+- `@barefootjs/go-template`: `convertExpressionToGo` takes an optional pre-parsed tree and `renderExpression` passes `expr.parsed`, so a rendered interpolation reuses the IR's parse instead of calling `parseExpression` again. The string-based early returns (null/undefined, static record index, inlined consts, helper/url lowering) are unchanged and still run first.

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -4711,7 +4711,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // resolves via early returns (`null`/`undefined`, inlined consts) on the
     // `bf build` hot path.
     const classify: { parsed?: ParsedExpr } = {}
-    const goExpr = this.convertExpressionToGo(expr.expr, classify)
+    const goExpr = this.convertExpressionToGo(expr.expr, classify, expr.parsed)
 
     // If the lowered expression is already template text, don't wrap it again
     // in {{...}} (double-wrapping). Two distinct shapes reach here:
@@ -6333,7 +6333,16 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   /**
    * Convert a JS expression to Go template syntax.
    */
-  private convertExpressionToGo(jsExpr: string, out?: { parsed?: ParsedExpr }): string {
+  private convertExpressionToGo(
+    jsExpr: string,
+    out?: { parsed?: ParsedExpr },
+    // Pre-parsed tree from the IR (`IRExpression.parsed`), reused instead of
+    // re-parsing `jsExpr` here — but only after the string-based early returns
+    // below, which resolve null/undefined, static record indexes, inlined
+    // consts, and helper/url lowerings without a parse. Recursive calls (with
+    // derived strings) pass none and parse normally.
+    preParsed?: ParsedExpr,
+  ): string {
     const trimmed = jsExpr.trim()
 
     // Handle null/undefined specially
@@ -6394,7 +6403,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // expression (template literal vs. not) off this single `parseExpression`,
     // with no extra `ts.createSourceFile` on the `bf build` hot path and no
     // parse at all for the early-return shapes.
-    const parsed = parseExpression(trimmed)
+    const parsed = preParsed ?? parseExpression(trimmed)
     const support = isSupported(parsed)
 
     if (!support.supported) {

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -554,7 +554,45 @@ function makeBindingEnv(ctx: TransformContext): BindingEnvironment {
 // Main Entry Point
 // =============================================================================
 
+/**
+ * Attach `parsed` (`parseExpression(expr.trim())`) to every `expression` node
+ * in the tree, so SSR adapters emit from the structured tree instead of each
+ * re-parsing the string at emit time. Best-effort: a node this walk misses (or
+ * an empty `expr`) simply has no `parsed`, and the adapter falls back to
+ * parsing — so under-coverage is safe, never a behavioural change.
+ */
+function attachParsedExpressions(node: IRNode): void {
+  if (node.type === 'expression') {
+    const trimmed = node.expr.trim()
+    if (trimmed) node.parsed = parseExpression(trimmed)
+  }
+  switch (node.type) {
+    case 'element':
+    case 'loop':
+    case 'component':
+    case 'fragment':
+    case 'provider':
+    case 'async':
+      for (const child of node.children) attachParsedExpressions(child)
+      break
+    case 'conditional':
+      attachParsedExpressions(node.whenTrue)
+      attachParsedExpressions(node.whenFalse)
+      break
+    case 'if-statement':
+      attachParsedExpressions(node.consequent)
+      if (node.alternate) attachParsedExpressions(node.alternate)
+      break
+  }
+}
+
 export function jsxToIR(analyzer: AnalyzerContext): IRNode | null {
+  const root = buildIRRoot(analyzer)
+  if (root) attachParsedExpressions(root)
+  return root
+}
+
+function buildIRRoot(analyzer: AnalyzerContext): IRNode | null {
   // If there are conditional returns (if statements with JSX returns),
   // build an if-statement chain instead of a single node
   if (analyzer.conditionalReturns.length > 0) {

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -568,12 +568,27 @@ function attachParsedExpressions(node: IRNode): void {
   }
   switch (node.type) {
     case 'element':
-    case 'loop':
     case 'component':
     case 'fragment':
     case 'provider':
-    case 'async':
       for (const child of node.children) attachParsedExpressions(child)
+      break
+    case 'async':
+      attachParsedExpressions(node.fallback)
+      for (const child of node.children) attachParsedExpressions(child)
+      break
+    case 'loop':
+      for (const child of node.children) attachParsedExpressions(child)
+      // Loops also hold expression nodes off the main `children` array.
+      if (node.childComponent) {
+        for (const child of node.childComponent.children) attachParsedExpressions(child)
+      }
+      for (const nested of node.nestedComponents ?? []) {
+        for (const child of nested.children) attachParsedExpressions(child)
+      }
+      for (const frag of node.flatMapCallback?.fragments ?? []) {
+        attachParsedExpressions(frag.ir)
+      }
       break
     case 'conditional':
       attachParsedExpressions(node.whenTrue)

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -327,9 +327,14 @@ export interface IRExpression {
    * Structured parse of `expr` (`parseExpression(expr.trim())`), attached once
    * during IR construction so SSR adapters emit from the tree instead of each
    * re-parsing the string at emit time (and so a multi-adapter build parses it
-   * once, not per adapter). Plain serializable data. Absent only when `expr`
-   * is empty/whitespace; an unparsable expression is still present as an
-   * `{ kind: 'unsupported' }` node (the adapter's own support gate handles it).
+   * once, not per adapter). Plain serializable data.
+   *
+   * OPTIONAL by design — consumers MUST fall back to parsing `expr` when it is
+   * missing. It is absent for an empty/whitespace `expr`, and may also be
+   * absent for a node the IR-build walk doesn't reach (the walk is best-effort;
+   * under-coverage is a missed optimization, never a behavioural change). When
+   * present, an unparsable expression is a `{ kind: 'unsupported' }` node (the
+   * adapter's own support gate handles it).
    */
   parsed?: ParsedExpr
   typeInfo: TypeInfo | null

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -323,6 +323,15 @@ export interface IRExpression {
   expr: string
   /** Pre-transformed expr with destructured prop refs rewritten to _p.xxx (for client JS templates). */
   templateExpr?: string
+  /**
+   * Structured parse of `expr` (`parseExpression(expr.trim())`), attached once
+   * during IR construction so SSR adapters emit from the tree instead of each
+   * re-parsing the string at emit time (and so a multi-adapter build parses it
+   * once, not per adapter). Plain serializable data. Absent only when `expr`
+   * is empty/whitespace; an unparsable expression is still present as an
+   * `{ kind: 'unsupported' }` node (the adapter's own support gate handles it).
+   */
+  parsed?: ParsedExpr
   typeInfo: TypeInfo | null
   reactive: boolean
   slotId: string | null


### PR DESCRIPTION
## Summary

Continues the **"IR carries the semantics, adapters emit from it"** direction (after the merged memo PR #1976), this time for text-interpolation expressions. The IR now stores the parsed expression tree for each `{expr}` node, so SSR adapters emit from it instead of each re-parsing the string at emit time — and a multi-adapter build (Go + Mojo) parses each expression once, not per adapter.

**Behaviour is unchanged (byte-identical).** The only public-API change is additive: `IRExpression` gains an optional `parsed` field.

## Changes

**`@barefootjs/jsx`**
- `IRExpression.parsed?: ParsedExpr`. `jsxToIR` walks the produced tree once and attaches `parseExpression(expr.trim())` to every text-interpolation node (`attachParsedExpressions`). **Best-effort and fallback-safe**: a node this walk doesn't reach (or one with an empty `expr`) simply has no `parsed`, and the adapter falls back to parsing — so under-coverage is never a behavioural change.

**`@barefootjs/go-template`**
- `convertExpressionToGo` takes an optional `preParsed` tree; `renderExpression` passes `expr.parsed`. A rendered interpolation reuses the IR's parse (`preParsed ?? parseExpression(trimmed)`) instead of calling `parseExpression` again. The string-based early returns (null/undefined, static record index, inlined consts, helper/url lowering) are unchanged and still run first — `preParsed` is consulted only at the single parse site after them.

## Tradeoff

Expressions the adapter resolves via an early return (e.g. `x ?? undefined`, inlined consts) are now parsed at IR-build even though the adapter skips parsing them. Those are a minority, so the extra build-time parsing is negligible next to moving the parse to Phase 1 and sharing it across adapters.

## Verification

- `adapter-go-template` unit: ✅ 552 / 0
- `adapter-tests` conformance (byte-identical SSR, real analyzer→IR→adapter pipeline): ✅ 786 / 0
- `@barefootjs/jsx` suite: ✅ 2181 / 0
- `tsgo --noEmit` ✅ · `biome check` ✅

## Follow-ups (same direction)

Extend `parsed` to attribute expressions (`ExpressionAttr`) and conditions, then signal `initialValue` and local-const values; and have the Mojo adapter consume `IRExpression.parsed` / `MemoInfo.parsed` too. Each is its own byte-identical PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_