### PR TITLE
refactor(jsx,go-template): carry parsedCondition in IR; reuse it in the Go adapter

### DIFF
--- a/.changeset/ir-condition-parsed.md
+++ b/.changeset/ir-condition-parsed.md
@@ -1,0 +1,9 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+---
+
+Carry the parsed condition tree in the IR (continuing the "IR carries semantics, adapters emit from it" direction). Output byte-identical; the only public-API change is additive.
+
+- `@barefootjs/jsx`: `IRConditional` and `IRIfStatement` gain an optional `parsedCondition` (`parseExpression(condition.trim())`), attached by the `jsxToIR` walk. Optional/best-effort like `IRExpression.parsed`.
+- `@barefootjs/go-template`: `convertConditionToGo` takes an optional pre-parsed tree; `renderConditional` and `renderIfStatement` (incl. else-if chains) pass `parsedCondition`, so a rendered condition reuses the IR's parse instead of calling `parseExpression` again.

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -6502,14 +6502,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   private renderIfStatement(ifStmt: IRIfStatement, ctx?: { isRootOfClientComponent?: boolean }): string {
-    const { condition: goCondition, preamble } = this.convertConditionToGo(ifStmt.condition)
+    const { condition: goCondition, preamble } = this.convertConditionToGo(ifStmt.condition, ifStmt.parsedCondition)
     const consequent = this.renderNode(ifStmt.consequent, ctx)
     let result = `${preamble}{{if ${goCondition}}}${consequent}`
 
     if (ifStmt.alternate) {
       if (ifStmt.alternate.type === 'if-statement') {
         const altIfStmt = ifStmt.alternate as IRIfStatement
-        const { condition: altCondition, preamble: altPreamble } = this.convertConditionToGo(altIfStmt.condition)
+        const { condition: altCondition, preamble: altPreamble } = this.convertConditionToGo(altIfStmt.condition, altIfStmt.parsedCondition)
         if (altPreamble) {
           // Preamble in else-if context is not supported
           this.state.errors.push({
@@ -6544,7 +6544,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       return this.renderClientOnlyConditional(cond)
     }
 
-    const { condition: goCondition, preamble } = this.convertConditionToGo(cond.condition)
+    const { condition: goCondition, preamble } = this.convertConditionToGo(cond.condition, cond.parsedCondition)
     const whenTrue = this.renderNode(cond.whenTrue)
 
     // If reactive (has slotId), wrap each branch with cond marker
@@ -6603,9 +6603,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * Returns { condition, preamble } where preamble contains template blocks
    * that must be emitted before the {{if}} (e.g., every/some range blocks).
    */
-  private convertConditionToGo(jsCondition: string): { condition: string; preamble: string } {
+  private convertConditionToGo(
+    jsCondition: string,
+    // Pre-parsed tree from the IR (`IRConditional.parsedCondition` /
+    // `IRIfStatement.parsedCondition`), reused instead of re-parsing here.
+    preParsed?: ParsedExpr,
+  ): { condition: string; preamble: string } {
     const trimmed = jsCondition.trim()
-    const parsed = parseExpression(trimmed)
+    const parsed = preParsed ?? parseExpression(trimmed)
     const support = isSupported(parsed)
 
     if (!support.supported) {

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -565,6 +565,9 @@ function attachParsedExpressions(node: IRNode): void {
   if (node.type === 'expression') {
     const trimmed = node.expr.trim()
     if (trimmed) node.parsed = parseExpression(trimmed)
+  } else if (node.type === 'conditional' || node.type === 'if-statement') {
+    const trimmed = node.condition.trim()
+    if (trimmed) node.parsedCondition = parseExpression(trimmed)
   }
   switch (node.type) {
     case 'element':

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -361,6 +361,13 @@ export interface IRConditional {
   condition: string
   /** Pre-transformed condition with destructured prop refs rewritten to _p.xxx. */
   templateCondition?: string
+  /**
+   * Structured parse of `condition` (`parseExpression(condition.trim())`),
+   * attached during IR construction so adapters lower the condition from the
+   * tree instead of re-parsing the string. Optional/best-effort — see
+   * `IRExpression.parsed`; consumers fall back to parsing `condition`.
+   */
+  parsedCondition?: ParsedExpr
   conditionType: TypeInfo | null
   reactive: boolean
   whenTrue: IRNode
@@ -760,6 +767,13 @@ export interface IRIfStatement {
   condition: string
   /** Pre-transformed condition with destructured prop refs rewritten to _p.xxx. */
   templateCondition?: string
+  /**
+   * Structured parse of `condition` (`parseExpression(condition.trim())`),
+   * attached during IR construction so adapters lower the condition from the
+   * tree instead of re-parsing the string. Optional/best-effort — see
+   * `IRExpression.parsed`; consumers fall back to parsing `condition`.
+   */
+  parsedCondition?: ParsedExpr
   /** The JSX return in the then branch */
   consequent: IRNode
   /** The else branch: either another IRIfStatement (else if) or IRNode (final else) */


### PR DESCRIPTION
## Summary

Stacked on #1977. Continues the **"IR carries the semantics, adapters emit from it"** direction, this time for **condition expressions** (`{cond ? … : …}`, `if (…) return …`, etc.).

**Behaviour unchanged (byte-identical).** Public-API change is additive only.

> Stacked PR — review/merge #1977 first; the base will retarget to `main` once #1977 lands.

## Changes

**`@barefootjs/jsx`**
- `IRConditional` and `IRIfStatement` gain optional `parsedCondition` (`parseExpression(condition.trim())`), attached by the `jsxToIR` walk. Optional/best-effort like `IRExpression.parsed` — consumers fall back to parsing `condition`.

**`@barefootjs/go-template`**
- `convertConditionToGo` takes an optional pre-parsed tree; `renderConditional` and `renderIfStatement` (including else-if chains) pass `parsedCondition`. A rendered condition reuses the IR's parse instead of calling `parseExpression` again. Parsing the exact `condition` field the adapter consumes means no type-strip mismatch (the lesson from #1976).

## Verification

- `adapter-go-template` unit: ✅ 552 / 0
- `adapter-tests` conformance (byte-identical, real pipeline): ✅ 786 / 0
- `tsgo --noEmit` ✅ · `biome` ✅ · jsx suite running

## Goal context

Part of the agreed target architecture (IR-carries-semantics + thin adapter / pure functions). Roadmap: condition exprs (this) → attribute exprs → signal `initialValue` → const values (drives the Go adapter's `parseExpression` / `ts.createSourceFile` / regex counts toward 0), then extracting the adapter's domain logic into `EmitContext` modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_