### PR TITLE
refactor(jsx,go-template): carry ExpressionAttr.parsed; reuse it in the Go attr emitter

### DIFF
--- a/.changeset/ir-attr-parsed.md
+++ b/.changeset/ir-attr-parsed.md
@@ -1,0 +1,9 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+---
+
+Carry the parsed expression tree for intrinsic-element attribute expressions in the IR (continuing the "IR carries semantics, adapters emit from it" direction). Output byte-identical; the only public-API change is additive.
+
+- `@barefootjs/jsx`: `ExpressionAttr` gains an optional `parsed` (`parseExpression(expr.trim())`), attached by the `jsxToIR` walk for each element attribute. Optional/best-effort like `IRExpression.parsed`.
+- `@barefootjs/go-template`: the element attribute emitter reuses `value.parsed` for its condition/classification/value lowerings (`convertConditionToGo`, the conditional/template-literal classification parse, and `convertExpressionToGo`), instead of re-parsing the same attribute string up to several times per attribute.

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -7250,7 +7250,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         if (css !== null) return `style="${css}"`
       }
       if (isBooleanAttr(name) || value.presenceOrUndefined) {
-        const { condition: goCond, preamble } = this.convertConditionToGo(value.expr)
+        const { condition: goCond, preamble } = this.convertConditionToGo(value.expr, value.parsed)
         // ARIA attributes are string-valued ("true"/"false"), not HTML5
         // presence booleans — Hono renders the truthy presence form as
         // `aria-x="true"` (#1896, SelectItem's
@@ -7258,7 +7258,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         const body = name.startsWith('aria-') ? `${name}="true"` : name
         return `${preamble}{{if ${goCond}}}${body}{{end}}`
       }
-      const parsed = parseExpression(value.expr.trim())
+      const parsed = value.parsed ?? parseExpression(value.expr.trim())
       if (parsed.kind === 'conditional') {
         // A ternary whose falsy branch is `undefined` / `null` OMITS the
         // attribute entirely on Hono (`aria-current={props.isActive ?
@@ -7308,13 +7308,13 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
           : bareId
       if (/^[A-Za-z_$][\w$]*$/.test(propName) && this.state.nillablePropNames.has(propName)) {
         const field = `.${capitalizeFieldName(propName)}`
-        return `{{if ne ${field} nil}}${name}="{{${this.convertExpressionToGo(value.expr)}}}"{{end}}`
+        return `{{if ne ${field} nil}}${name}="{{${this.convertExpressionToGo(value.expr, undefined, value.parsed)}}}"{{end}}`
       }
       // Lower once; if the result is already a self-contained action block (e.g.
       // an inlined `sortClass(k)` → `{{if …}}…{{end}}`, #1897), embed it as-is
       // rather than double-wrapping it in another `{{…}}`.
       const exprOut: { parsed?: ParsedExpr } = {}
-      const go = this.convertExpressionToGo(value.expr, exprOut)
+      const go = this.convertExpressionToGo(value.expr, exprOut, value.parsed)
       return this.isTemplateFragment(go, exprOut.parsed?.kind)
         ? `${name}="${go}"`
         : `${name}="{{${go}}}"`

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -569,6 +569,14 @@ function attachParsedExpressions(node: IRNode): void {
     const trimmed = node.condition.trim()
     if (trimmed) node.parsedCondition = parseExpression(trimmed)
   }
+  if (node.type === 'element') {
+    for (const attr of node.attrs) {
+      if (attr.value.kind === 'expression') {
+        const trimmed = attr.value.expr.trim()
+        if (trimmed) attr.value.parsed = parseExpression(trimmed)
+      }
+    }
+  }
   switch (node.type) {
     case 'element':
     case 'component':

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -867,6 +867,14 @@ export interface ExpressionAttr {
   /** `expr` with destructured prop refs rewritten to `_p.xxx`, for SSR
    *  template inlining. Absent when no rewrite was needed. */
   templateExpr?: string
+  /**
+   * Structured parse of `expr` (`parseExpression(expr.trim())`), attached
+   * during IR construction so adapters lower the attribute value from the tree
+   * instead of re-parsing the string (often several times per attribute).
+   * Optional/best-effort — see `IRExpression.parsed`; consumers fall back to
+   * parsing `expr`.
+   */
+  parsed?: ParsedExpr
   /** Set when the producer peeled an `expr || undefined` boolean-presence
    *  pattern; adapters fold this back into `(expr) || undefined` at emit. */
   presenceOrUndefined?: boolean


### PR DESCRIPTION
## Summary

Stacked on #1978 (which is stacked on #1977). Continues the **"IR carries the semantics, adapters emit from it"** direction, for **intrinsic-element attribute expressions** (`<div class={…} aria-current={…}>`).

**Behaviour unchanged (byte-identical).** Public-API change is additive only.

> Stacked PR — merge #1977 → #1978 first; bases retarget toward `main` as they land.

## Changes

**`@barefootjs/jsx`**
- `ExpressionAttr` gains optional `parsed` (`parseExpression(expr.trim())`), attached by the `jsxToIR` walk for each element attribute. Optional/best-effort like `IRExpression.parsed`.

**`@barefootjs/go-template`**
- The element attribute emitter reuses `value.parsed` for its condition lowering (`convertConditionToGo`), its conditional/template-literal classification parse, and its value lowering (`convertExpressionToGo`) — instead of re-parsing the same attribute string up to several times per attribute. The one genuinely-derived case (a ternary test sliced from the source) keeps parsing.

## Verification

- `adapter-go-template` unit: ✅ 552 / 0
- `adapter-tests` conformance (byte-identical, real pipeline): ✅ 786 / 0
- `tsgo --noEmit` ✅ · `biome` ✅ · jsx suite running

## Goal context

Roadmap toward the agreed target architecture: text interpolation (#1977) → conditions (#1978) → **attribute exprs (this)** → signal `initialValue` → const values, driving the Go adapter's `parseExpression` / `ts.createSourceFile` / regex counts toward 0; then extracting the adapter's domain logic into `EmitContext` modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_