### PR TITLE
refactor(go-template): extract value-lowering into value/value-lowering.ts

### DIFF
--- a/.changeset/go-adapter-value-lowering.md
+++ b/.changeset/go-adapter-value-lowering.md
@@ -1,0 +1,8 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Extract the Go html/template adapter's value-lowering cluster into `value/value-lowering.ts` (Roadmap B). Internal-only, output byte-identical (verified by the adapter unit + conformance suites); no behavioural or public-API change.
+
+- `value/value-lowering.ts` — `convertInitialValue`, `jsLiteralToGo`, `objectLiteralToGoMap`, `tsLiteralToGo`, `getSignalInitialValueAsGo` moved out as pure free functions over `GoEmitContext`. They bake inline signal/const initial values into Go literals (scalars, prop references, fully-literal arrays/objects) and fall back to `nil`/`0` otherwise.
+- `emit-context.ts` — `GoEmitContext` gains `typeInfoToGo` and `extractPropNameFromInitialValue`, the two adapter entry points the moved functions call back into (`parseLiteralExpression` was already on the seam). `typeInfoToGo` / `parseLiteralExpression` stay on the adapter as widely-shared members.

--- a/packages/adapter-go-template/src/adapter/emit-context.ts
+++ b/packages/adapter-go-template/src/adapter/emit-context.ts
@@ -18,7 +18,7 @@
 
 import type ts from 'typescript'
 
-import type { ParsedExpr } from '@barefootjs/jsx'
+import type { ParsedExpr, TypeInfo } from '@barefootjs/jsx'
 
 import type { CompileState } from './lib/compile-state.ts'
 
@@ -34,4 +34,10 @@ export interface GoEmitContext {
 
   /** Lower a JS condition to a Go-template bool + any hoisted preamble. */
   convertConditionToGo(jsCondition: string): { condition: string; preamble: string }
+
+  /** Render a `TypeInfo` as its Go type string (inferring from `defaultValue`). */
+  typeInfoToGo(typeInfo: TypeInfo, defaultValue?: string): string
+
+  /** Extract the prop name from a `props.X ?? …` initial value, or null. */
+  extractPropNameFromInitialValue(initialValue: string): string | null
 }

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -108,6 +108,12 @@ import { hasClientInteractivity, findNestedComponents } from "./analysis/compone
 import type { GoEmitContext } from "./emit-context.ts"
 import { inlineLocalHelperCall } from "./expr/helper-inline.ts"
 import { lowerUrlBuilderHelperCall } from "./expr/url-builder.ts"
+import {
+  convertInitialValue,
+  jsLiteralToGo,
+  objectLiteralToGoMap,
+  getSignalInitialValueAsGo,
+} from "./value/value-lowering.ts"
 
 export type { GoTemplateAdapterOptions } from "./lib/types.ts"
 
@@ -201,6 +207,8 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     parseLiteralExpression: (value) => this.parseLiteralExpression(value),
     convertExpressionToGo: (jsExpr, out) => this.convertExpressionToGo(jsExpr, out),
     convertConditionToGo: (jsCondition) => this.convertConditionToGo(jsCondition),
+    typeInfoToGo: (typeInfo, defaultValue) => this.typeInfoToGo(typeInfo, defaultValue),
+    extractPropNameFromInitialValue: (initialValue) => this.extractPropNameFromInitialValue(initialValue),
   }
 
   /**
@@ -1529,13 +1537,13 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         : null
       const scalarLoopType = this.scalarLiteralLoopGoType(nested.loopArray, nested.loopItemType)
       let bakedValue = moduleConst?.type
-        ? this.convertInitialValue(moduleConst.value!, moduleConst.type, ir.metadata.propsParams)
+        ? convertInitialValue(this.emitCtx, moduleConst.value!, moduleConst.type, ir.metadata.propsParams)
         : null
       // (#1971) Inline primitive-literal array (`[1,2,3,4,5].map(...)`): no
       // named module const to look up, so bake the literal slice directly so
       // SSR renders the items (matching Hono) instead of an empty loop.
       if (!bakedValue && scalarLoopType) {
-        bakedValue = this.jsLiteralToGo(nested.loopArray!, { kind: 'unknown', raw: 'unknown' })
+        bakedValue = jsLiteralToGo(this.emitCtx, nested.loopArray!, { kind: 'unknown', raw: 'unknown' })
       }
       if (!bakedValue || bakedValue === 'nil' || bakedValue === '0') continue
 
@@ -1782,7 +1790,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         // Bake against the synthesised struct type when one was inferred for
         // this untyped object-array signal (#1680), else the signal's own type.
         const bakeType = this.state.synthStructTypes.get(signal.getter) ?? signal.type
-        const initialValue = this.convertInitialValue(signal.initialValue, bakeType, ir.metadata.propsParams)
+        const initialValue = convertInitialValue(this.emitCtx, signal.initialValue, bakeType, ir.metadata.propsParams)
         lines.push(`\t\t${fieldName}: ${initialValue},`)
       }
     }
@@ -1933,7 +1941,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
             // literal — the child field is `map[string]interface{}` and
             // `resolveDynamicPropValue` can't represent an object literal.
             if (childShape?.mapTypedParamNames.has(prop.name)) {
-              const goMap = this.objectLiteralToGoMap(exprText)
+              const goMap = objectLiteralToGoMap(this.emitCtx, exprText)
               if (goMap !== null) {
                 emitChildField(prop.name, goMap)
                 break
@@ -2725,131 +2733,6 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   /**
-   * Convert JavaScript initial value to Go value for NewXxxProps function.
-   * References to props params are converted to in.FieldName format.
-   */
-  private convertInitialValue(value: string, typeInfo: TypeInfo, propsParams?: { name: string }[]): string {
-    // Check if it's a simple identifier (props param reference)
-    if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(value)) {
-      // Check if this matches a props param
-      if (propsParams?.some(p => p.name === value)) {
-        return `in.${capitalizeFieldName(value)}`
-      }
-    }
-
-    // Check for props.xxx pattern (e.g., "props.initial ?? 0")
-    const propName = this.extractPropNameFromInitialValue(value)
-    if (propName && propsParams?.some(p => p.name === propName)) {
-      return `in.${capitalizeFieldName(propName)}`
-    }
-
-    if (typeInfo.kind === 'primitive') {
-      if (typeInfo.primitive === 'boolean') {
-        return value === 'true' ? 'true' : 'false'
-      }
-      if (typeInfo.primitive === 'number') {
-        // Check if it's a simple number
-        if (/^\d+$/.test(value)) return value
-        if (/^\d+\.\d+$/.test(value)) return value
-        return '0'
-      }
-      if (typeInfo.primitive === 'string') {
-        // Remove quotes if present and add Go string syntax
-        if (value.startsWith("'") || value.endsWith("'")) {
-          return value.replace(/'/g, '"')
-        }
-        if (value.startsWith('"') && value.endsWith('"')) {
-          return value
-        }
-        return '""'
-      }
-    }
-
-    // For arrays, bake a fully-literal initial value into a Go slice literal
-    // so the SSR data context carries the items (#1672). Empty / nullish
-    // literals collapse to nil, and any non-literal element (a call, a
-    // variable reference, …) falls back to nil so the handler populates it.
-    //
-    // The baked literal is element-type-aware so it both compiles and renders:
-    //   - scalar elements →  `[]string{…}` / `[]interface{}{…}`  (template `{{.}}`)
-    //   - struct elements →  `[]Item{Item{ID: …}}`               (template `.ID`)
-    // An untyped object array would land in a `[]interface{}` field whose
-    // `map[string]interface{}` items the template can't reach via field access
-    // (`.ID` → <nil>), so `jsLiteralToGo` returns null there and we keep nil.
-    if (typeInfo.kind === 'array') {
-      // Bake a fully-literal initial value into a Go slice literal; anything
-      // the parser can't reduce to a literal — a call, an identifier, `null` /
-      // `undefined`, or an empty array — yields null and we keep `nil`.
-      return this.jsLiteralToGo(value, typeInfo) ?? 'nil'
-    }
-
-    // String alias (e.g., Filter = string) — return string value instead of nil
-    if (typeInfo.kind === 'interface' && typeInfo.raw) {
-      const aliasBase = this.state.localTypeAliases.get(typeInfo.raw)
-      if (aliasBase === 'string') {
-        if (value.startsWith("'") || value.startsWith('"')) {
-          return value.replace(/'/g, '"')
-        }
-        return '""'
-      }
-    }
-
-    // Default for complex expressions
-    return 'nil'
-  }
-
-  /**
-   * Convert a fully-literal JS expression string into an equivalent Go literal
-   * whose Go type matches `typeInfo` (#1672), used to bake a signal's inline
-   * initial value into the SSR data context:
-   *
-   *   `["x", "y"]`             (string[])  → `[]string{"x", "y"}`
-   *   `["x", "y"]`             (unknown[]) → `[]interface{}{"x", "y"}`
-   *   `[{ id: "a" }]`          (Item[])    → `[]Item{Item{ID: "a"}}`
-   *
-   * Returns `null` — so the caller keeps `nil` — when the expression (or any
-   * nested element) is not a pure literal (a call, identifier, template with
-   * interpolation, …) or cannot be expressed in the target Go type without a
-   * render/compile mismatch (e.g. an object element in a `[]interface{}` field,
-   * which the SSR template reaches via struct field access the map lacks).
-   */
-  private jsLiteralToGo(value: string, typeInfo: TypeInfo): string | null {
-    const expr = this.parseLiteralExpression(value)
-    if (!expr) return null
-    return this.tsLiteralToGo(expr, typeInfo)
-  }
-
-  /**
-   * (#1971) Bake a pure object-literal expression (`{ align: 'start' }`) into a
-   * Go `map[string]interface{}` literal keyed by the SOURCE property names, so
-   * it round-trips through `bf_json` exactly like JS `JSON.stringify` of the
-   * same object — only the supplied keys, no zero-filled struct fields. Used
-   * when an inline object literal is passed to a child's optional object prop
-   * (`<Carousel opts={{ align: 'start' }}>`). Returns null for any non-literal
-   * or nested object/array value (carousel's opts are flat scalars).
-   */
-  private objectLiteralToGoMap(exprText: string): string | null {
-    const expr = this.parseLiteralExpression(exprText)
-    if (!expr || !ts.isObjectLiteralExpression(expr)) return null
-    const entries: string[] = []
-    for (const prop of expr.properties) {
-      if (!ts.isPropertyAssignment(prop)) return null
-      if (
-        !ts.isIdentifier(prop.name) &&
-        !ts.isStringLiteral(prop.name) &&
-        !ts.isNumericLiteral(prop.name)
-      ) {
-        return null
-      }
-      const val = this.tsLiteralToGo(prop.initializer)
-      if (val === null) return null
-      entries.push(`${JSON.stringify(prop.name.text)}: ${val}`)
-    }
-    if (entries.length === 0) return null
-    return `map[string]interface{}{${entries.join(', ')}}`
-  }
-
-  /**
    * Parse a JS expression string into its TS AST node (parentheses unwrapped),
    * or `null` when it isn't a single expression. Shared by the literal baker
    * and the struct-shape synthesiser.
@@ -2867,96 +2750,6 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     let expr: ts.Expression = stmt.expression
     while (ts.isParenthesizedExpression(expr)) expr = expr.expression
     return expr
-  }
-
-  /**
-   * Recursively convert a TS literal AST node to a Go literal typed as
-   * `typeInfo`, or null when the node is not a pure literal / cannot be
-   * represented in that Go type.
-   */
-  private tsLiteralToGo(node: ts.Expression, typeInfo?: TypeInfo): string | null {
-    // Unwrap a leading unary minus on a numeric literal (`-1`).
-    if (
-      ts.isPrefixUnaryExpression(node) &&
-      node.operator === ts.SyntaxKind.MinusToken &&
-      ts.isNumericLiteral(node.operand)
-    ) {
-      return `-${node.operand.text}`
-    }
-    if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
-      return JSON.stringify(node.text)
-    }
-    // Pass the numeric literal's source spelling through verbatim. Every form
-    // the TS parser accepts here (`1`, `1.5`, `1e3`, `0x10`, `1_000`) is also a
-    // valid Go numeric literal, so no re-formatting is needed.
-    if (ts.isNumericLiteral(node)) return node.text
-    if (node.kind === ts.SyntaxKind.TrueKeyword) return 'true'
-    if (node.kind === ts.SyntaxKind.FalseKeyword) return 'false'
-    if (node.kind === ts.SyntaxKind.NullKeyword) return 'nil'
-
-    if (ts.isArrayLiteralExpression(node)) {
-      // An empty array literal (`[]`, and — since the TS parser tolerates
-      // whitespace/comments — `[ ]`, `[/* */]`) carries no items, so there's
-      // nothing to bake. Returning null keeps the field `nil`, which JSON-
-      // marshals as `null` rather than the `[]` an empty slice would produce.
-      if (node.elements.length === 0) return null
-
-      // Slice header mirrors the field's Go type (`[]string`, `[]Item`,
-      // `[]interface{}`); elements are converted against the element type.
-      const elemType = typeInfo?.kind === 'array' ? typeInfo.elementType : undefined
-      const sliceHeader = typeInfo?.kind === 'array'
-        ? this.typeInfoToGo(typeInfo)
-        : '[]interface{}'
-      const elems: string[] = []
-      for (const el of node.elements) {
-        const go = this.tsLiteralToGo(el, elemType)
-        if (go === null) return null
-        elems.push(go)
-      }
-      return `${sliceHeader}{${elems.join(', ')}}`
-    }
-
-    if (ts.isObjectLiteralExpression(node)) {
-      // An object can only be baked when the target Go type is a concrete
-      // struct — otherwise it would land in `interface{}` / a map the SSR
-      // template can't reach via field access. The struct's field map is the
-      // source of truth: it tells us the exact Go field name for each source
-      // key and, by omission, which keys the struct doesn't declare. Bail
-      // (→ nil) when the type isn't a known struct.
-      const goType = typeInfo ? this.typeInfoToGo(typeInfo) : 'interface{}'
-      const structFields = this.state.localStructFields.get(goType)
-      if (!structFields) return null
-      const entries: string[] = []
-      for (const prop of node.properties) {
-        // Only plain `key: scalar` pairs are baked; spreads, methods,
-        // shorthand, computed/accessor members, and nested object/array
-        // values (whose struct field types we don't track here) bail to nil.
-        if (!ts.isPropertyAssignment(prop)) return null
-        if (
-          !ts.isIdentifier(prop.name) &&
-          !ts.isStringLiteral(prop.name) &&
-          !ts.isNumericLiteral(prop.name)
-        ) {
-          return null
-        }
-        // Resolve the Go field name from the struct's own field map rather
-        // than re-deriving it. A key the struct doesn't declare (a typo, or a
-        // non-identifier key like `"data-id"` that never became a field) is
-        // absent here, so we bail to nil instead of emitting a literal that
-        // names a nonexistent field and won't compile.
-        const goField = structFields.get(prop.name.text)
-        if (!goField) return null
-        const init = prop.initializer
-        if (ts.isObjectLiteralExpression(init) || ts.isArrayLiteralExpression(init)) {
-          return null
-        }
-        const go = this.tsLiteralToGo(init)
-        if (go === null) return null
-        entries.push(`${goField}: ${go}`)
-      }
-      return `${goType}{${entries.join(', ')}}`
-    }
-    return null
   }
 
   /**
@@ -3003,56 +2796,6 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       default:
         return 'interface{}'
     }
-  }
-
-  /**
-   * Get signal's initial value as Go code.
-   * Handles both literal values (0, true, "str") and props references (initial).
-   *
-   * (#1423) When the signal references a prop via `props.X ?? N` and
-   * the caller hoisted a fallback variable for `X`, return the hoisted
-   * variable's name so the memo inherits the signal-time fallback.
-   */
-  private getSignalInitialValueAsGo(
-    initialValue: string,
-    propsParams: { name: string }[],
-    propFallbackVars: ReadonlyMap<string, PropFallbackVar> = GoTemplateAdapter.EMPTY_PROP_FALLBACK_VARS,
-  ): string {
-    // Check if it's a props param reference
-    if (propsParams.some(p => p.name === initialValue)) {
-      const hoisted = propFallbackVars.get(initialValue)
-      if (hoisted) return hoisted.varName
-      return `in.${capitalizeFieldName(initialValue)}`
-    }
-
-    // Check for props.xxx pattern (e.g., "props.initial ?? 0")
-    const propName = this.extractPropNameFromInitialValue(initialValue)
-    if (propName && propsParams.some(p => p.name === propName)) {
-      const hoisted = propFallbackVars.get(propName)
-      if (hoisted) return hoisted.varName
-      return `in.${capitalizeFieldName(propName)}`
-    }
-
-    // Check if it's a literal value
-    // Number literals
-    if (/^-?\d+$/.test(initialValue)) {
-      return initialValue
-    }
-    if (/^-?\d+\.\d+$/.test(initialValue)) {
-      return initialValue
-    }
-    // Boolean literals
-    if (initialValue === 'true' || initialValue === 'false') {
-      return initialValue
-    }
-    // String literals
-    if ((initialValue.startsWith("'") && initialValue.endsWith("'")) ||
-        (initialValue.startsWith('"') && initialValue.endsWith('"'))) {
-      return initialValue.replace(/'/g, '"')
-    }
-
-    // Default: return 0 for unknown
-    return '0'
   }
 
   /**
@@ -3170,7 +2913,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       // Check if it's a signal
       const signal = signals.find(s => s.getter === getterName)
       if (signal) {
-        return this.convertInitialValue(signal.initialValue, signal.type, propsParams)
+        return convertInitialValue(this.emitCtx, signal.initialValue, signal.type, propsParams)
       }
 
       // Check if it's a memo. Use the pattern-matching core: when no
@@ -3534,7 +3277,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
           let condGo: string | null = null
           const condSignal = signals.find(sg => sg.getter === condName)
           if (condSignal) {
-            condGo = this.getSignalInitialValueAsGo(condSignal.initialValue, propsParams, propFallbackVars)
+            condGo = getSignalInitialValueAsGo(this.emitCtx, condSignal.initialValue, propsParams, propFallbackVars)
           } else {
             const condMemo = (this.state.currentMemos ?? []).find(m => m.name === condName)
             if (condMemo) {
@@ -3570,7 +3313,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       if (depName) {
         const signal = signals.find(s => s.getter === depName)
         if (signal) {
-          const signalInitial = this.getSignalInitialValueAsGo(signal.initialValue, propsParams, propFallbackVars)
+          const signalInitial = getSignalInitialValueAsGo(this.emitCtx, signal.initialValue, propsParams, propFallbackVars)
           return `${signalInitial} ${operator} ${operand}`
         }
       }
@@ -3613,7 +3356,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     if (simpleDep) {
       const signal = signals.find(s => s.getter === simpleDep)
       if (signal) {
-        return this.getSignalInitialValueAsGo(signal.initialValue, propsParams, propFallbackVars)
+        return getSignalInitialValueAsGo(this.emitCtx, signal.initialValue, propsParams, propFallbackVars)
       }
     }
 
@@ -3697,7 +3440,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // can reduce it to a Go slice.
     const blockReturn = this.resolveBlockBodyMemoModuleConst(computation, signals)
     if (blockReturn !== null && blockReturn.constValue && blockReturn.constType) {
-      return this.convertInitialValue(
+      return convertInitialValue(this.emitCtx, 
         blockReturn.constValue,
         blockReturn.constType,
         propsParams,
@@ -3733,7 +3476,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   ): string | null {
     const signal = signals.find(s => s.getter === name)
     if (signal) {
-      return this.getSignalInitialValueAsGo(signal.initialValue, propsParams, propFallbackVars)
+      return getSignalInitialValueAsGo(this.emitCtx, signal.initialValue, propsParams, propFallbackVars)
     }
     const memo = (this.state.currentMemos ?? []).find(m => m.name === name)
     if (memo) {

--- a/packages/adapter-go-template/src/adapter/value/value-lowering.ts
+++ b/packages/adapter-go-template/src/adapter/value/value-lowering.ts
@@ -1,0 +1,296 @@
+/**
+ * Value lowering: convert JS signal/const initial values into Go literals.
+ *
+ * Pure free functions over a {@link GoEmitContext}. The cluster bakes inline
+ * initial values into the SSR data context — scalars, prop references, and
+ * fully-literal arrays/objects — and falls back to `nil`/`0` for anything the
+ * parser can't reduce to a literal. They depend on the context's `state`
+ * (struct-field / type-alias tables), `parseLiteralExpression`,
+ * `typeInfoToGo`, and `extractPropNameFromInitialValue`.
+ */
+
+import ts from 'typescript'
+
+import type { TypeInfo } from '@barefootjs/jsx'
+
+import type { GoEmitContext } from '../emit-context.ts'
+import type { PropFallbackVar } from '../lib/types.ts'
+import { capitalizeFieldName } from '../lib/go-naming.ts'
+
+/** Default for `getSignalInitialValueAsGo`'s optional fallback-var map. */
+const EMPTY_PROP_FALLBACK_VARS: ReadonlyMap<string, PropFallbackVar> = new Map()
+
+export function convertInitialValue(
+  ctx: GoEmitContext,
+  value: string,
+  typeInfo: TypeInfo,
+  propsParams?: { name: string }[],
+): string {
+  // Check if it's a simple identifier (props param reference)
+  if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(value)) {
+    // Check if this matches a props param
+    if (propsParams?.some(p => p.name === value)) {
+      return `in.${capitalizeFieldName(value)}`
+    }
+  }
+
+  // Check for props.xxx pattern (e.g., "props.initial ?? 0")
+  const propName = ctx.extractPropNameFromInitialValue(value)
+  if (propName && propsParams?.some(p => p.name === propName)) {
+    return `in.${capitalizeFieldName(propName)}`
+  }
+
+  if (typeInfo.kind === 'primitive') {
+    if (typeInfo.primitive === 'boolean') {
+      return value === 'true' ? 'true' : 'false'
+    }
+    if (typeInfo.primitive === 'number') {
+      // Check if it's a simple number
+      if (/^\d+$/.test(value)) return value
+      if (/^\d+\.\d+$/.test(value)) return value
+      return '0'
+    }
+    if (typeInfo.primitive === 'string') {
+      // Remove quotes if present and add Go string syntax
+      if (value.startsWith("'") || value.endsWith("'")) {
+        return value.replace(/'/g, '"')
+      }
+      if (value.startsWith('"') && value.endsWith('"')) {
+        return value
+      }
+      return '""'
+    }
+  }
+
+  // For arrays, bake a fully-literal initial value into a Go slice literal
+  // so the SSR data context carries the items (#1672). Empty / nullish
+  // literals collapse to nil, and any non-literal element (a call, a
+  // variable reference, …) falls back to nil so the handler populates it.
+  //
+  // The baked literal is element-type-aware so it both compiles and renders:
+  //   - scalar elements →  `[]string{…}` / `[]interface{}{…}`  (template `{{.}}`)
+  //   - struct elements →  `[]Item{Item{ID: …}}`               (template `.ID`)
+  // An untyped object array would land in a `[]interface{}` field whose
+  // `map[string]interface{}` items the template can't reach via field access
+  // (`.ID` → <nil>), so `jsLiteralToGo` returns null there and we keep nil.
+  if (typeInfo.kind === 'array') {
+    // Bake a fully-literal initial value into a Go slice literal; anything
+    // the parser can't reduce to a literal — a call, an identifier, `null` /
+    // `undefined`, or an empty array — yields null and we keep `nil`.
+    return jsLiteralToGo(ctx, value, typeInfo) ?? 'nil'
+  }
+
+  // String alias (e.g., Filter = string) — return string value instead of nil
+  if (typeInfo.kind === 'interface' && typeInfo.raw) {
+    const aliasBase = ctx.state.localTypeAliases.get(typeInfo.raw)
+    if (aliasBase === 'string') {
+      if (value.startsWith("'") || value.startsWith('"')) {
+        return value.replace(/'/g, '"')
+      }
+      return '""'
+    }
+  }
+
+  // Default for complex expressions
+  return 'nil'
+}
+
+/**
+ * Convert a fully-literal JS expression string into an equivalent Go literal
+ * whose Go type matches `typeInfo` (#1672), used to bake a signal's inline
+ * initial value into the SSR data context:
+ *
+ *   `["x", "y"]`             (string[])  → `[]string{"x", "y"}`
+ *   `["x", "y"]`             (unknown[]) → `[]interface{}{"x", "y"}`
+ *   `[{ id: "a" }]`          (Item[])    → `[]Item{Item{ID: "a"}}`
+ *
+ * Returns `null` — so the caller keeps `nil` — when the expression (or any
+ * nested element) is not a pure literal (a call, identifier, template with
+ * interpolation, …) or cannot be expressed in the target Go type without a
+ * render/compile mismatch (e.g. an object element in a `[]interface{}` field,
+ * which the SSR template reaches via struct field access the map lacks).
+ */
+export function jsLiteralToGo(
+  ctx: GoEmitContext,
+  value: string,
+  typeInfo: TypeInfo,
+): string | null {
+  const expr = ctx.parseLiteralExpression(value)
+  if (!expr) return null
+  return tsLiteralToGo(ctx, expr, typeInfo)
+}
+
+/**
+ * (#1971) Bake a pure object-literal expression (`{ align: 'start' }`) into a
+ * Go `map[string]interface{}` literal keyed by the SOURCE property names, so
+ * it round-trips through `bf_json` exactly like JS `JSON.stringify` of the
+ * same object — only the supplied keys, no zero-filled struct fields. Used
+ * when an inline object literal is passed to a child's optional object prop
+ * (`<Carousel opts={{ align: 'start' }}>`). Returns null for any non-literal
+ * or nested object/array value (carousel's opts are flat scalars).
+ */
+export function objectLiteralToGoMap(ctx: GoEmitContext, exprText: string): string | null {
+  const expr = ctx.parseLiteralExpression(exprText)
+  if (!expr || !ts.isObjectLiteralExpression(expr)) return null
+  const entries: string[] = []
+  for (const prop of expr.properties) {
+    if (!ts.isPropertyAssignment(prop)) return null
+    if (
+      !ts.isIdentifier(prop.name) &&
+      !ts.isStringLiteral(prop.name) &&
+      !ts.isNumericLiteral(prop.name)
+    ) {
+      return null
+    }
+    const val = tsLiteralToGo(ctx, prop.initializer)
+    if (val === null) return null
+    entries.push(`${JSON.stringify(prop.name.text)}: ${val}`)
+  }
+  if (entries.length === 0) return null
+  return `map[string]interface{}{${entries.join(', ')}}`
+}
+
+/**
+ * Recursively convert a TS literal AST node to a Go literal typed as
+ * `typeInfo`, or null when the node is not a pure literal / cannot be
+ * represented in that Go type.
+ */
+export function tsLiteralToGo(
+  ctx: GoEmitContext,
+  node: ts.Expression,
+  typeInfo?: TypeInfo,
+): string | null {
+  // Unwrap a leading unary minus on a numeric literal (`-1`).
+  if (
+    ts.isPrefixUnaryExpression(node) &&
+    node.operator === ts.SyntaxKind.MinusToken &&
+    ts.isNumericLiteral(node.operand)
+  ) {
+    return `-${node.operand.text}`
+  }
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+    return JSON.stringify(node.text)
+  }
+  // Pass the numeric literal's source spelling through verbatim. Every form
+  // the TS parser accepts here (`1`, `1.5`, `1e3`, `0x10`, `1_000`) is also a
+  // valid Go numeric literal, so no re-formatting is needed.
+  if (ts.isNumericLiteral(node)) return node.text
+  if (node.kind === ts.SyntaxKind.TrueKeyword) return 'true'
+  if (node.kind === ts.SyntaxKind.FalseKeyword) return 'false'
+  if (node.kind === ts.SyntaxKind.NullKeyword) return 'nil'
+
+  if (ts.isArrayLiteralExpression(node)) {
+    // An empty array literal (`[]`, and — since the TS parser tolerates
+    // whitespace/comments — `[ ]`, `[/* */]`) carries no items, so there's
+    // nothing to bake. Returning null keeps the field `nil`, which JSON-
+    // marshals as `null` rather than the `[]` an empty slice would produce.
+    if (node.elements.length === 0) return null
+
+    // Slice header mirrors the field's Go type (`[]string`, `[]Item`,
+    // `[]interface{}`); elements are converted against the element type.
+    const elemType = typeInfo?.kind === 'array' ? typeInfo.elementType : undefined
+    const sliceHeader = typeInfo?.kind === 'array'
+      ? ctx.typeInfoToGo(typeInfo)
+      : '[]interface{}'
+    const elems: string[] = []
+    for (const el of node.elements) {
+      const go = tsLiteralToGo(ctx, el, elemType)
+      if (go === null) return null
+      elems.push(go)
+    }
+    return `${sliceHeader}{${elems.join(', ')}}`
+  }
+
+  if (ts.isObjectLiteralExpression(node)) {
+    // An object can only be baked when the target Go type is a concrete
+    // struct — otherwise it would land in `interface{}` / a map the SSR
+    // template can't reach via field access. The struct's field map is the
+    // source of truth: it tells us the exact Go field name for each source
+    // key and, by omission, which keys the struct doesn't declare. Bail
+    // (→ nil) when the type isn't a known struct.
+    const goType = typeInfo ? ctx.typeInfoToGo(typeInfo) : 'interface{}'
+    const structFields = ctx.state.localStructFields.get(goType)
+    if (!structFields) return null
+    const entries: string[] = []
+    for (const prop of node.properties) {
+      // Only plain `key: scalar` pairs are baked; spreads, methods,
+      // shorthand, computed/accessor members, and nested object/array
+      // values (whose struct field types we don't track here) bail to nil.
+      if (!ts.isPropertyAssignment(prop)) return null
+      if (
+        !ts.isIdentifier(prop.name) &&
+        !ts.isStringLiteral(prop.name) &&
+        !ts.isNumericLiteral(prop.name)
+      ) {
+        return null
+      }
+      // Resolve the Go field name from the struct's own field map rather
+      // than re-deriving it. A key the struct doesn't declare (a typo, or a
+      // non-identifier key like `"data-id"` that never became a field) is
+      // absent here, so we bail to nil instead of emitting a literal that
+      // names a nonexistent field and won't compile.
+      const goField = structFields.get(prop.name.text)
+      if (!goField) return null
+      const init = prop.initializer
+      if (ts.isObjectLiteralExpression(init) || ts.isArrayLiteralExpression(init)) {
+        return null
+      }
+      const go = tsLiteralToGo(ctx, init)
+      if (go === null) return null
+      entries.push(`${goField}: ${go}`)
+    }
+    return `${goType}{${entries.join(', ')}}`
+  }
+  return null
+}
+
+/**
+ * Get signal's initial value as Go code.
+ * Handles both literal values (0, true, "str") and props references (initial).
+ *
+ * (#1423) When the signal references a prop via `props.X ?? N` and
+ * the caller hoisted a fallback variable for `X`, return the hoisted
+ * variable's name so the memo inherits the signal-time fallback.
+ */
+export function getSignalInitialValueAsGo(
+  ctx: GoEmitContext,
+  initialValue: string,
+  propsParams: { name: string }[],
+  propFallbackVars: ReadonlyMap<string, PropFallbackVar> = EMPTY_PROP_FALLBACK_VARS,
+): string {
+  // Check if it's a props param reference
+  if (propsParams.some(p => p.name === initialValue)) {
+    const hoisted = propFallbackVars.get(initialValue)
+    if (hoisted) return hoisted.varName
+    return `in.${capitalizeFieldName(initialValue)}`
+  }
+
+  // Check for props.xxx pattern (e.g., "props.initial ?? 0")
+  const propName = ctx.extractPropNameFromInitialValue(initialValue)
+  if (propName && propsParams.some(p => p.name === propName)) {
+    const hoisted = propFallbackVars.get(propName)
+    if (hoisted) return hoisted.varName
+    return `in.${capitalizeFieldName(propName)}`
+  }
+
+  // Check if it's a literal value
+  // Number literals
+  if (/^-?\d+$/.test(initialValue)) {
+    return initialValue
+  }
+  if (/^-?\d+\.\d+$/.test(initialValue)) {
+    return initialValue
+  }
+  // Boolean literals
+  if (initialValue === 'true' || initialValue === 'false') {
+    return initialValue
+  }
+  // String literals
+  if ((initialValue.startsWith("'") && initialValue.endsWith("'")) ||
+      (initialValue.startsWith('"') && initialValue.endsWith('"'))) {
+    return initialValue.replace(/'/g, '"')
+  }
+
+  // Default: return 0 for unknown
+  return '0'
+}


### PR DESCRIPTION
## What

First unit of **Roadmap B** (adapter decomposition, see `spec/adapter-architecture.md`): move the Go adapter's value-lowering cluster out of the `GoTemplateAdapter` class into pure free functions over `GoEmitContext`.

`value/value-lowering.ts` (new) holds:

- `convertInitialValue` — JS signal/const initial value → Go value for `NewXxxProps` (prop refs → `in.FieldName`, scalars, literal arrays via `jsLiteralToGo`).
- `jsLiteralToGo` / `tsLiteralToGo` — bake a fully-literal JS expression into a type-matched Go literal (`["x"]`→`[]string{"x"}`, `[{id:"a"}]`→`[]Item{Item{ID:"a"}}`), `null` when not a pure literal.
- `objectLiteralToGoMap` — `{align:'start'}` → `map[string]interface{}{…}` keyed by source props (#1971).
- `getSignalInitialValueAsGo` — signal initial value as Go code, honoring hoisted prop-fallback vars (#1423).

## The seam

`GoEmitContext` gains the two adapter entry points the moved functions call back into:

- `typeInfoToGo(typeInfo, defaultValue?)`
- `extractPropNameFromInitialValue(initialValue)`

(`parseLiteralExpression` was already on the seam.) `typeInfoToGo` and `parseLiteralExpression` stay as methods on the adapter — they are widely shared across other still-resident code — and are exposed to the module through the context closure. Call sites become `convertInitialValue(this.emitCtx, …)` etc.

## Guarantees

- **Byte-identical output** — no behavioural or public-API change.
- Adapter unit suite: **552 pass**.
- Adapter-tests conformance suite (the byte-identical authority): **786 pass**.
- `tsgo --noEmit` and `biome` clean.

Stacked-PR series toward the target adapter architecture; next units: `type-codegen`, `memo-lowering`, `spread-codegen`, `props-codegen`, `array-lowering`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_