### PR TITLE
refactor(go-template): extract prop-type resolution into props/prop-types.ts

### DIFF
--- a/.changeset/go-adapter-prop-types.md
+++ b/.changeset/go-adapter-prop-types.md
@@ -1,0 +1,9 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Extract the Go html/template adapter's prop-type resolution into `props/prop-types.ts` (Roadmap B). Internal-only, output byte-identical (verified by the adapter unit + conformance suites); no behavioural or public-API change.
+
+- `props/prop-types.ts` — `buildPropTypeOverrides` (signal-inferred Go-type overrides), `resolvePropGoType` (the shared per-field type resolver — optional named-struct props → `map[string]interface{}`), and `collectNillablePropNames` moved out as free functions. They read only `state.localStructFields` and `extractPropNameFromInitialValue` and resolve via `typeInfoToGo`; no new `GoEmitContext` member.
+
+Note: the struct *assembly* generators (`generateInputStruct` / `generatePropsStruct` / `generateNewPropsFunction`) remain on the adapter — they are the orchestrator core that composes the extracted lowering modules (~18 cross-method dependencies), which the architecture deliberately keeps on the object rather than re-exposing through the seam.

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -118,6 +118,7 @@ import { lowerCtorExpr } from "./memo/ctor-lowering.ts"
 import { resolveBlockBodyMemoModuleConst } from "./memo/memo-value.ts"
 import { computeMemoInitialValue, computeMemoInitialValueOrNull } from "./memo/memo-compute.ts"
 import { collectSpreadSlots, buildSpreadInitializer } from "./spread/spread-codegen.ts"
+import { buildPropTypeOverrides, resolvePropGoType, collectNillablePropNames } from "./props/prop-types.ts"
 
 export type { GoTemplateAdapterOptions } from "./lib/types.ts"
 
@@ -296,7 +297,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // participate in attribute omission and field binding uniformly. Shared
     // with the Mojo adapter (single source of truth in `@barefootjs/jsx`).
     augmentInheritedPropAccesses(ir)
-    this.state.nillablePropNames = this.collectNillablePropNames(ir)
+    this.state.nillablePropNames = collectNillablePropNames(this.emitCtx, ir)
 
     // Surface loop-body usages of components imported from sibling
     // .tsx files. The adapter emits `{{template "X" .}}` for these,
@@ -706,7 +707,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     }
 
     // Build prop type overrides from signal types
-    const propTypeOverrides = this.buildPropTypeOverrides(ir)
+    const propTypeOverrides = buildPropTypeOverrides(this.emitCtx, ir)
 
     // Compute spread slot info once and thread it through all three
     // generators — `collectSpreadSlots` walks the IR tree, so caching
@@ -915,86 +916,6 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   /**
-   * Build a map from prop name to a better Go type inferred from signals.
-   * When a signal is initialized from a prop (e.g., createSignal(props.initial ?? 0)),
-   * the signal's type annotation may be more specific than the prop's TypeInfo.
-   */
-  private buildPropTypeOverrides(ir: ComponentIR): Map<string, string> {
-    const overrides = new Map<string, string>()
-    for (const signal of ir.metadata.signals) {
-      // Check simple identifier reference
-      const propNames = [signal.initialValue]
-      const extracted = this.extractPropNameFromInitialValue(signal.initialValue)
-      if (extracted) propNames.push(extracted)
-
-      for (const propName of propNames) {
-        const param = ir.metadata.propsParams.find(p => p.name === propName)
-        if (!param) continue
-        const propGoType = typeInfoToGo(this.emitCtx, param.type, param.defaultValue)
-        // Override when prop type is generic (interface{} or contains interface{})
-        if (propGoType.includes('interface{}')) {
-          const signalGoType = typeInfoToGo(this.emitCtx, signal.type, signal.initialValue)
-          if (!signalGoType.includes('interface{}')) {
-            overrides.set(propName, signalGoType)
-          }
-        }
-      }
-    }
-    return overrides
-  }
-
-  /**
-   * Resolve a prop param's Go struct-field type using the SAME logic
-   * `generatePropsStruct` / `generateInputStruct` use for the field
-   * declaration: a `propTypeOverrides` entry (signal-inferred override)
-   * wins, otherwise `typeInfoToGo(param.type, param.defaultValue)`.
-   * Factored out so the nillable-field set (`collectNillablePropNames`)
-   * can't drift from the actual emitted field types.
-   */
-  private resolvePropGoType(
-    param: IRMetadata['propsParams'][number],
-    propTypeOverrides: Map<string, string>,
-  ): string {
-    const base = propTypeOverrides.get(param.name) ?? typeInfoToGo(this.emitCtx, param.type, param.defaultValue)
-    // (#1971) An OPTIONAL prop typed as a named struct (e.g. carousel's
-    // `opts?: EmblaOptionsType`) lowers to `map[string]interface{}` rather
-    // than the value struct. Two reasons: a value struct is always truthy in
-    // Go templates, so a `{{if .Opts}}`-guarded attribute (`data-opts={opts ?
-    // JSON.stringify(opts) : undefined}`) can never be omitted when the
-    // caller leaves it out; and a map round-trips through `bf_json` with only
-    // the keys actually supplied, matching JS `JSON.stringify` of a partial
-    // object literal instead of a zero-filled struct. A nil/empty map is
-    // falsy, so the omit-when-absent guard works for free.
-    // Gate on `localStructFields` (an actual generated struct), NOT
-    // `localTypeNames` — the latter also covers string-union aliases like
-    // `placement?: 'top' | 'right' | …` (tooltip), which must stay their
-    // scalar Go type, not become a map.
-    if (param.optional && this.state.localStructFields.has(base)) {
-      return 'map[string]interface{}'
-    }
-    return base
-  }
-
-  /**
-   * Build the set of prop NAMES whose resolved Go field type is exactly
-   * `interface{}` (nillable). Uses the same `propTypeOverrides` +
-   * `resolvePropGoType` pipeline as the struct generators, so a prop
-   * that ends up `interface{}` on the Props struct — and only such a
-   * prop — is treated as nillable for Hono-style attribute omission.
-   * Concrete (`string`/`int`/`bool`/`[]T`/struct) types are excluded.
-   */
-  private collectNillablePropNames(ir: ComponentIR): Set<string> {
-    const propTypeOverrides = this.buildPropTypeOverrides(ir)
-    const nillable = new Set<string>()
-    for (const param of ir.metadata.propsParams) {
-      if (this.resolvePropGoType(param, propTypeOverrides) === 'interface{}') {
-        nillable.add(param.name)
-      }
-    }
-    return nillable
-  }
-
-  /**
    * Whether the component reads the request-scoped `searchParams()`
    * environment signal (router v0.5, #1922). Detected from `searchParamsLocals`
    * — the binding names the shared `searchParamsLocalNames` helper found at
@@ -1066,7 +987,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     for (const param of ir.metadata.propsParams) {
       const fieldName = capitalizeFieldName(param.name)
       if (nestedArrayFields.has(fieldName)) continue
-      const goType = this.resolvePropGoType(param, propTypeOverrides)
+      const goType = resolvePropGoType(this.emitCtx, param, propTypeOverrides)
       lines.push(`\t${fieldName} ${goType}`)
     }
 
@@ -1156,7 +1077,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       const fieldName = capitalizeFieldName(param.name)
       // Skip if this field will be replaced by a typed array for nested components
       if (nestedArrayFields.has(fieldName)) continue
-      const goType = this.resolvePropGoType(param, propTypeOverrides)
+      const goType = resolvePropGoType(this.emitCtx, param, propTypeOverrides)
       // Children are already rendered in the DOM; serialising them into bf-p
       // leaks nested scope ids and bloats the attribute. Exclude from JSON
       // so BfPropsAttr never marshals them (#1952).
@@ -1727,7 +1648,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         p => capitalizeFieldName(p.name) === capitalizeFieldName(memo.name),
       )
       if (!param) continue
-      const goType = this.resolvePropGoType(param, propTypeOverrides)
+      const goType = resolvePropGoType(this.emitCtx, param, propTypeOverrides)
       if (goType !== 'string' && goType !== 'interface{}') continue
       memoFallbacks.set(capitalizeFieldName(memo.name), { goFallback: m.goFallback, goType })
     }

--- a/packages/adapter-go-template/src/adapter/props/prop-types.ts
+++ b/packages/adapter-go-template/src/adapter/props/prop-types.ts
@@ -1,0 +1,94 @@
+/**
+ * Prop-type resolution: decide each prop's Go struct-field type.
+ *
+ * Free functions over a {@link GoEmitContext}, shared by the Input / Props
+ * struct generators and the nillable-field set so they can't drift. They read
+ * `state.localStructFields` and `extractPropNameFromInitialValue`, and resolve
+ * Go types via the type-codegen module's `typeInfoToGo`.
+ */
+
+import type { ComponentIR, IRMetadata } from '@barefootjs/jsx'
+
+import type { GoEmitContext } from '../emit-context.ts'
+import { typeInfoToGo } from '../type/type-codegen.ts'
+
+/**
+ * Build a map from prop name to a better Go type inferred from signals.
+ * When a signal is initialized from a prop (e.g., createSignal(props.initial ?? 0)),
+ * the signal's type annotation may be more specific than the prop's TypeInfo.
+ */
+export function buildPropTypeOverrides(ctx: GoEmitContext, ir: ComponentIR): Map<string, string> {
+  const overrides = new Map<string, string>()
+  for (const signal of ir.metadata.signals) {
+    // Check simple identifier reference
+    const propNames = [signal.initialValue]
+    const extracted = ctx.extractPropNameFromInitialValue(signal.initialValue)
+    if (extracted) propNames.push(extracted)
+
+    for (const propName of propNames) {
+      const param = ir.metadata.propsParams.find(p => p.name === propName)
+      if (!param) continue
+      const propGoType = typeInfoToGo(ctx, param.type, param.defaultValue)
+      // Override when prop type is generic (interface{} or contains interface{})
+      if (propGoType.includes('interface{}')) {
+        const signalGoType = typeInfoToGo(ctx, signal.type, signal.initialValue)
+        if (!signalGoType.includes('interface{}')) {
+          overrides.set(propName, signalGoType)
+        }
+      }
+    }
+  }
+  return overrides
+}
+
+/**
+ * Resolve a prop param's Go struct-field type using the SAME logic
+ * `generatePropsStruct` / `generateInputStruct` use for the field
+ * declaration: a `propTypeOverrides` entry (signal-inferred override)
+ * wins, otherwise `typeInfoToGo(param.type, param.defaultValue)`.
+ * Factored out so the nillable-field set (`collectNillablePropNames`)
+ * can't drift from the actual emitted field types.
+ */
+export function resolvePropGoType(
+  ctx: GoEmitContext,
+  param: IRMetadata['propsParams'][number],
+  propTypeOverrides: Map<string, string>,
+): string {
+  const base = propTypeOverrides.get(param.name) ?? typeInfoToGo(ctx, param.type, param.defaultValue)
+  // (#1971) An OPTIONAL prop typed as a named struct (e.g. carousel's
+  // `opts?: EmblaOptionsType`) lowers to `map[string]interface{}` rather
+  // than the value struct. Two reasons: a value struct is always truthy in
+  // Go templates, so a `{{if .Opts}}`-guarded attribute (`data-opts={opts ?
+  // JSON.stringify(opts) : undefined}`) can never be omitted when the
+  // caller leaves it out; and a map round-trips through `bf_json` with only
+  // the keys actually supplied, matching JS `JSON.stringify` of a partial
+  // object literal instead of a zero-filled struct. A nil/empty map is
+  // falsy, so the omit-when-absent guard works for free.
+  // Gate on `localStructFields` (an actual generated struct), NOT
+  // `localTypeNames` — the latter also covers string-union aliases like
+  // `placement?: 'top' | 'right' | …` (tooltip), which must stay their
+  // scalar Go type, not become a map.
+  if (param.optional && ctx.state.localStructFields.has(base)) {
+    return 'map[string]interface{}'
+  }
+  return base
+}
+
+/**
+ * Build the set of prop NAMES whose resolved Go field type is exactly
+ * `interface{}` (nillable). Uses the same `propTypeOverrides` +
+ * `resolvePropGoType` pipeline as the struct generators, so a prop
+ * that ends up `interface{}` on the Props struct — and only such a
+ * prop — is treated as nillable for Hono-style attribute omission.
+ * Concrete (`string`/`int`/`bool`/`[]T`/struct) types are excluded.
+ */
+export function collectNillablePropNames(ctx: GoEmitContext, ir: ComponentIR): Set<string> {
+  const propTypeOverrides = buildPropTypeOverrides(ctx, ir)
+  const nillable = new Set<string>()
+  for (const param of ir.metadata.propsParams) {
+    if (resolvePropGoType(ctx, param, propTypeOverrides) === 'interface{}') {
+      nillable.add(param.name)
+    }
+  }
+  return nillable
+}


### PR DESCRIPTION
## What

Ninth unit of **Roadmap B** (adapter decomposition), **stacked on #1988**: extract the prop-type resolution helpers out of the `GoTemplateAdapter` class into pure free functions.

`props/prop-types.ts` (new):

- `buildPropTypeOverrides(ctx, ir)` — map a prop name to a better Go type inferred from a signal initialized from it (`createSignal(props.initial ?? 0)`).
- `resolvePropGoType(ctx, param, overrides)` — the single source of truth the Input/Props struct generators and the nillable set both use for a field's Go type (incl. optional named-struct props → `map[string]interface{}`, #1971).
- `collectNillablePropNames(ctx, ir)` — the set of props whose resolved type is exactly `interface{}`.

They read only `state.localStructFields` + `extractPropNameFromInitialValue` and resolve via `typeInfoToGo` — **no new `GoEmitContext` member**.

## Scope note — where decomposition stops

The struct *assembly* generators (`generateInputStruct` / `generatePropsStruct` / `generateNewPropsFunction`) **remain on the adapter**. They are the orchestrator core that composes the now-extracted lowering modules — they call ~18 distinct adapter methods (`toJsonTag`, `resolveLoopDatumFields`, `loopBodyWrapperName`, `inferMemoType`, child-instance collectors, context-consumer helpers, …). Extracting them wholesale would mean re-exposing most of the adapter through the `GoEmitContext` seam, which the architecture deliberately avoids ("the adapter object is a thin orchestrator … real logic lives in pure free functions"; composition stays on the object). This unit extracts the *pure type-resolution* slice of props-codegen; the assembly stays.

## Guarantees

- **Byte-identical output** — no behavioural or public-API change.
- Adapter unit suite: **552 pass**.
- Adapter-tests conformance suite (the byte-identical authority): **786 pass**.
- `tsgo --noEmit` and `biome` clean.

> Stacked on #1988 → base is `claude/go-adapter-spread-codegen`; retargets to `main` once #1988 merges. Series so far: #1981–#1987 ✓, spread-codegen #1988, prop-types (this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_