### PR TITLE
refactor(go-template): split self-contained sections out of generateNewPropsFunction

### DIFF
--- a/.changeset/go-adapter-new-props-split.md
+++ b/.changeset/go-adapter-new-props-split.md
@@ -1,0 +1,11 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Split the self-contained sections out of the Go adapter's ~590-line `generateNewPropsFunction` into focused private emitters (readability). Internal-only, output byte-identical (verified by the adapter unit + conformance suites); no behavioural or public-API change.
+
+- `emitNewPropsDocComment` — the `NewXxxProps` doc header + per-component "handler-populated slice" NOTE.
+- `emitStaticChildInstances` — the ~145-line static child-component instance emitter (props, rest-bag routing, context bindings, children passthrough).
+- `emitSpreadBagInits` — spread-bag field initializers + the BF101 fallback.
+
+These stay as adapter methods (orchestrator), just no longer inline. The loop-body wrapper builders (which share `emittedWrapperVars` / `propFallbackVars`) are left for a follow-up.

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -1358,23 +1358,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     const signalDynamicNested = nestedComponents.filter(
       n => n.isDynamic && !n.isPropDerived && !(n.bodyChildren && n.bodyChildren.length > 0),
     )
-    lines.push(`// New${componentName}Props creates ${propsTypeName} from ${inputTypeName}.`)
-    for (const nested of signalDynamicNested) {
-      const arrayField = `${nested.name}s`
-      lines.push(`//`)
-      lines.push(`// NOTE: \`${arrayField}\` is populated by the route handler, not by`)
-      lines.push(`// New${componentName}Props — the SSR template iterates over it`)
-      lines.push(`// dynamically (\`.${arrayField}\`). Build the slice from your source data and`)
-      lines.push(`// assign it before passing the props to your renderer. Example:`)
-      lines.push(`//`)
-      lines.push(`//   props := New${componentName}Props(${inputTypeName}{ /* ... */ })`)
-      lines.push(`//   props.${arrayField} = make([]${nested.name}Props, len(items))`)
-      lines.push(`//   for i, item := range items {`)
-      lines.push(`//     props.${arrayField}[i] = New${nested.name}Props(${nested.name}Input{ /* fields */ })`)
-      lines.push(`//     props.${arrayField}[i].BfParent = props.ScopeID`)
-      lines.push(`//     props.${arrayField}[i].BfMount = "${nested.slotId}"`)
-      lines.push(`//   }`)
-    }
+    this.emitNewPropsDocComment(lines, componentName, inputTypeName, propsTypeName, signalDynamicNested)
     lines.push(`func New${componentName}Props(in ${inputTypeName}) ${propsTypeName} {`)
     lines.push('\tscopeID := in.ScopeID')
     lines.push('\tif scopeID == "" {')
@@ -1745,6 +1729,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     }
 
     // Add static child component instances
+    this.emitStaticChildInstances(lines, ir)
+
+    this.emitSpreadBagInits(lines, ir, spreadSlots)
+
+    lines.push('\t}')
+    lines.push('}')
+  }
+
+  private emitStaticChildInstances(lines: string[], ir: ComponentIR): void {
     const staticChildren = this.collectStaticChildInstances(ir.root)
     for (const child of staticChildren) {
       lines.push(`\t\t${child.fieldName}: New${child.name}Props(${child.name}Input{`)
@@ -1889,7 +1882,35 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       }
       lines.push(`\t\t}),`)
     }
+  }
 
+  private emitNewPropsDocComment(
+    lines: string[],
+    componentName: string,
+    inputTypeName: string,
+    propsTypeName: string,
+    signalDynamicNested: NestedComponentInfo[],
+  ): void {
+    lines.push(`// New${componentName}Props creates ${propsTypeName} from ${inputTypeName}.`)
+    for (const nested of signalDynamicNested) {
+      const arrayField = `${nested.name}s`
+      lines.push(`//`)
+      lines.push(`// NOTE: \`${arrayField}\` is populated by the route handler, not by`)
+      lines.push(`// New${componentName}Props — the SSR template iterates over it`)
+      lines.push(`// dynamically (\`.${arrayField}\`). Build the slice from your source data and`)
+      lines.push(`// assign it before passing the props to your renderer. Example:`)
+      lines.push(`//`)
+      lines.push(`//   props := New${componentName}Props(${inputTypeName}{ /* ... */ })`)
+      lines.push(`//   props.${arrayField} = make([]${nested.name}Props, len(items))`)
+      lines.push(`//   for i, item := range items {`)
+      lines.push(`//     props.${arrayField}[i] = New${nested.name}Props(${nested.name}Input{ /* fields */ })`)
+      lines.push(`//     props.${arrayField}[i].BfParent = props.ScopeID`)
+      lines.push(`//     props.${arrayField}[i].BfMount = "${nested.slotId}"`)
+      lines.push(`//   }`)
+    }
+  }
+
+  private emitSpreadBagInits(lines: string[], ir: ComponentIR, spreadSlots: SpreadSlotInfo[]): void {
     // (#1407) Initialise spread bag fields. Unsupported shapes (e.g.
     // signal getters whose initialValue isn't a plain object literal,
     // identifiers that don't resolve to a propsParam) fall through to
@@ -1913,9 +1934,6 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         })
       }
     }
-
-    lines.push('\t}')
-    lines.push('}')
   }
 
   /**


### PR DESCRIPTION
## What

Second unit of the generate-area readability pass, **stacked on #1991**: split the self-contained sections out of `generateNewPropsFunction` (~590 lines) into focused private emitters.

Extracted (each stays an adapter method — orchestrator, no seam impact):
- **`emitNewPropsDocComment`** — the `NewXxxProps` doc header + the per-signal-backed-component "this slice is handler-populated" NOTE block.
- **`emitStaticChildInstances`** — the ~145-line static child-component instance emitter (literal/boolean/expression/template props, hyphenated-attr → rest-bag routing, `useContext` provider bindings, JSX-children passthrough).
- **`emitSpreadBagInits`** — the spread-bag field initializers + the BF101 unsupported-shape diagnostic.

The method drops from ~590 to ~370 lines. The two loop-body wrapper builders (static-with-body / dynamic-with-body) share `emittedWrapperVars` / `propFallbackVars` across sections, so they're left for a follow-up to keep this PR's threading trivial.

## Guarantees

- **Byte-identical output** — no behavioural or public-API change.
- Adapter unit suite: **552 pass**.
- Adapter-tests conformance suite (the byte-identical authority): **786 pass**.
- `tsgo --noEmit` and `biome` clean.

> Stacked on #1991 → base is `claude/go-adapter-prime-state`; retargets to `main` once #1991 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_