### PR TITLE
feat(jsx): add object-literal kind to ParsedExpr (Roadmap A-1)

### DIFF
--- a/.changeset/parsedexpr-object-literal.md
+++ b/.changeset/parsedexpr-object-literal.md
@@ -1,0 +1,22 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+---
+
+Add an `object-literal` kind to `ParsedExpr` (Roadmap A-1). The expression
+parser now structures plain object literals (`{ a: 1, b: x }` / shorthand
+`{ a }`) into `{ kind: 'object-literal', properties, raw }` instead of falling
+through to `unsupported`; spread, computed-key, method, and getter/setter
+literals still fall through unchanged. A matching `objectLiteral` method was
+added to the shared `ParsedExprEmitter` dispatcher, so every adapter
+(`go-template`, `mojolicious`, `xslate`) handles the new kind explicitly — the
+same drift defence used for `array-literal` / `array-method`.
+
+This is the foundational, byte-identical step that unblocks carrying signal
+and local-`const` object/array values structurally on the IR (so the Go
+adapter can drop its remaining `ts.createSourceFile` / value-regex lowering).
+Adapters currently emit the new kind exactly as they emitted an object literal
+before — through their `unsupported` path — and the IR-carry gates still treat
+it like `unsupported`, so no emitted output changes.

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -25,6 +25,7 @@ import type {
   CompilerError,
   SourceLocation,
   ParsedExpr,
+  ObjectLiteralProperty,
   ParsedStatement,
   SortComparator,
   ReduceOp,
@@ -3275,6 +3276,16 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     return `bf_arr ${parts.join(' ')}`
   }
 
+  objectLiteral(_properties: ObjectLiteralProperty[], raw: string, _emit: (e: ParsedExpr) => string): string {
+    // Not yet lowered structurally from `properties`: emit exactly as an
+    // object literal did before the `object-literal` kind existed — through
+    // the `unsupported` path (`[UNSUPPORTED: …]`). Byte-identical (Roadmap
+    // A-1). A later unit lowers it to a `bf_map …` runtime call. Object
+    // values that DO reach a Go map today (signal/const inits, spread bags)
+    // go through the dedicated `objectLiteralToGoMap` lowering, not here.
+    return this.unsupported(raw, 'object literal')
+  }
+
   higherOrder(
     method: HigherOrderMethod,
     object: ParsedExpr,
@@ -4800,6 +4811,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         return plain(this.renderParsedExpr(expr))
 
       case 'unsupported':
+      // `raw` holds the original expression string, so a bare object literal
+      // in a condition lowers identically to the pre-`object-literal`
+      // behaviour (byte-identical; Roadmap A-1).
+      case 'object-literal':
         return plain(expr.raw)
     }
   }

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -71,7 +71,7 @@ import { isAriaBooleanAttr, isBooleanResultExpr } from './boolean-result.ts'
  * the `IRNodeEmitter` interface.
  */
 type MojoRenderCtx = Record<string, never>
-import type { ParsedExpr, ParsedStatement, SortComparator, ReduceOp, FlatDepth, FlatMapOp, TemplatePart } from '@barefootjs/jsx'
+import type { ParsedExpr, ObjectLiteralProperty, ParsedStatement, SortComparator, ReduceOp, FlatDepth, FlatMapOp, TemplatePart } from '@barefootjs/jsx'
 import { BF_SLOT, BF_COND, BF_REGION } from '@barefootjs/shared'
 
 interface PrimitiveSpec {
@@ -2698,6 +2698,14 @@ class MojoFilterEmitter implements ParsedExprEmitter {
   unsupported(_raw: string, _reason: string): string {
     return '1'
   }
+
+  objectLiteral(_properties: ObjectLiteralProperty[], _raw: string, _emit: (e: ParsedExpr) => string): string {
+    // Filter-predicate context: an object literal is not a boolean leaf, so
+    // emit the truthy sentinel exactly as `unsupported` does (byte-identical
+    // with the pre-`object-literal` fallback; Roadmap A-1). Object *values*
+    // are lowered to Perl hashrefs in the conditional/attr paths, not here.
+    return '1'
+  }
 }
 
 /**
@@ -2970,6 +2978,15 @@ class MojoTopLevelEmitter implements ParsedExprEmitter {
     // recurses, so a top-level supported expression never contains an
     // `unsupported` node. Return a safe Perl empty-string literal in
     // case a future caller renders a node tree directly.
+    return "''"
+  }
+
+  objectLiteral(_properties: ObjectLiteralProperty[], _raw: string, _emit: (e: ParsedExpr) => string): string {
+    // Mirror `unsupported`: a bare object literal reaching the dispatcher
+    // lowers to the safe Perl empty-string literal, exactly as before the
+    // `object-literal` kind existed (byte-identical; Roadmap A-1). Object
+    // values that round-trip to a Perl hashref go through the dedicated
+    // `objectLiteralToPerlHashref` lowering in the conditional/attr paths.
     return "''"
   }
 }

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -85,7 +85,7 @@ import ts from 'typescript'
  * `IRNodeEmitter` interface.
  */
 type XslateRenderCtx = Record<string, never>
-import type { ParsedExpr, ParsedStatement, SortComparator, ReduceOp, FlatDepth, FlatMapOp, TemplatePart } from '@barefootjs/jsx'
+import type { ParsedExpr, ObjectLiteralProperty, ParsedStatement, SortComparator, ReduceOp, FlatDepth, FlatMapOp, TemplatePart } from '@barefootjs/jsx'
 import { BF_SLOT, BF_COND, BF_REGION } from '@barefootjs/shared'
 
 interface PrimitiveSpec {
@@ -2311,6 +2311,14 @@ class XslateFilterEmitter implements ParsedExprEmitter {
   unsupported(_raw: string, _reason: string): string {
     return '1'
   }
+
+  objectLiteral(_properties: ObjectLiteralProperty[], _raw: string, _emit: (e: ParsedExpr) => string): string {
+    // Filter-predicate context: emit the truthy sentinel exactly as
+    // `unsupported` does, byte-identical with the pre-`object-literal`
+    // fallback (Roadmap A-1). Object values lower to Kolon hashrefs in the
+    // conditional/attr paths, not through this dispatcher.
+    return '1'
+  }
 }
 
 /**
@@ -2537,6 +2545,15 @@ class XslateTopLevelEmitter implements ParsedExprEmitter {
   }
 
   unsupported(_raw: string, _reason: string): string {
+    return "''"
+  }
+
+  objectLiteral(_properties: ObjectLiteralProperty[], _raw: string, _emit: (e: ParsedExpr) => string): string {
+    // Mirror `unsupported`: a bare object literal reaching the dispatcher
+    // lowers to the safe empty-string literal, exactly as before the
+    // `object-literal` kind existed (byte-identical; Roadmap A-1). Object
+    // values that round-trip to a Kolon hashref go through the dedicated
+    // `objectLiteralToKolonHashref` lowering in the conditional/attr paths.
     return "''"
   }
 }

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -300,6 +300,52 @@ describe('expression-parser', () => {
       }
     })
 
+    // Object literal → `object-literal` kind (Roadmap A-1). Carried so
+    // adapters can lower an object value structurally instead of
+    // re-parsing the source with `ts.createSourceFile`. Object literals
+    // reach the parser parenthesised — `() => ({ … })`, a prop value —
+    // because a leading `{` at statement position is a block, not an
+    // expression (covered below).
+    test('parses object literal into object-literal kind', () => {
+      const result = parseExpression('({ a: 1, b: x, "c-d": foo() })')
+      expect(result.kind).toBe('object-literal')
+      if (result.kind === 'object-literal') {
+        expect(result.properties.map(p => p.key)).toEqual(['a', 'b', 'c-d'])
+        expect(result.properties.map(p => p.value.kind)).toEqual([
+          'literal', 'identifier', 'call',
+        ])
+        expect(result.properties.every(p => !p.shorthand)).toBe(true)
+        // `raw` preserves the original string for byte-identical fallback.
+        expect(result.raw).toBe('({ a: 1, b: x, "c-d": foo() })')
+      }
+    })
+
+    test('parses shorthand object literal, expanding `{ a }` to `a: a`', () => {
+      const result = parseExpression('({ a, b: 2 })')
+      expect(result.kind).toBe('object-literal')
+      if (result.kind === 'object-literal') {
+        expect(result.properties[0]).toMatchObject({
+          key: 'a', shorthand: true, value: { kind: 'identifier', name: 'a' },
+        })
+        expect(result.properties[1]).toMatchObject({ key: 'b', shorthand: false })
+      }
+    })
+
+    test('falls through to unsupported for spread / computed-key object literals', () => {
+      // A spread member is not a plain map property — preserves the
+      // pre-A-1 `unsupported` behaviour (byte-identical).
+      expect(parseExpression('({ ...rest, a: 1 })').kind).toBe('unsupported')
+      // Computed key `[k]: v` can't resolve to a static name.
+      expect(parseExpression('({ [k]: 1 })').kind).toBe('unsupported')
+    })
+
+    test('a bare `{ … }` at statement position is a block, not an object literal', () => {
+      // TS parses a leading `{` as a block statement, so a non-parenthesised
+      // object literal string is `unsupported` (`Not an expression
+      // statement`). Real call sites always supply the parenthesised form.
+      expect(parseExpression('{ a: 1 }').kind).toBe('unsupported')
+    })
+
     // Destructured filter param (#1443). The parser rewrites the
     // shorthand binding `({done})` into the equivalent dotted-access
     // form on a synthetic param (`_t.done`), so adapters can reuse

--- a/packages/jsx/src/adapters/parsed-expr-emitter.ts
+++ b/packages/jsx/src/adapters/parsed-expr-emitter.ts
@@ -33,7 +33,7 @@
  *     be added in one place.
  */
 
-import type { ParsedExpr, SortComparator, ReduceOp, FlatDepth, FlatMapOp, TemplatePart } from '../expression-parser.ts'
+import type { ParsedExpr, SortComparator, ReduceOp, FlatDepth, FlatMapOp, TemplatePart, ObjectLiteralProperty } from '../expression-parser.ts'
 
 export type HigherOrderMethod = 'filter' | 'every' | 'some' | 'find' | 'findIndex' | 'findLast' | 'findLastIndex'
 
@@ -148,6 +148,14 @@ export interface ParsedExprEmitter {
     emit: (e: ParsedExpr) => string,
   ): string
   arrayLiteral(elements: ParsedExpr[], emit: (e: ParsedExpr) => string): string
+  // Emit an object literal `{ a: 1, b: x }`. `raw` is the original
+  // expression string so an adapter that doesn't lower object values yet
+  // can delegate to `unsupported(raw, …)` and stay byte-identical.
+  objectLiteral(
+    properties: ObjectLiteralProperty[],
+    raw: string,
+    emit: (e: ParsedExpr) => string,
+  ): string
   arrayMethod(
     method: ArrayMethod,
     object: ParsedExpr,
@@ -223,6 +231,8 @@ export function emitParsedExpr(expr: ParsedExpr, emitter: ParsedExprEmitter): st
       return emitter.higherOrder(expr.method, expr.object, expr.param, expr.predicate, emit)
     case 'array-literal':
       return emitter.arrayLiteral(expr.elements, emit)
+    case 'object-literal':
+      return emitter.objectLiteral(expr.properties, expr.raw, emit)
     case 'array-method':
       if (expr.method === 'sort' || expr.method === 'toSorted') {
         return emitter.sortMethod(expr.method, expr.object, expr.comparator, emit)

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -1399,7 +1399,14 @@ function collectMemo(node: ts.VariableDeclaration, ctx: AnalyzerContext): void {
     memoArrow && ts.isArrowFunction(memoArrow) && !ts.isBlock(memoArrow.body)
       ? parseExpression(ctx.getJS(memoArrow.body))
       : undefined
-  const parsed = parsedBody && parsedBody.kind !== 'unsupported' ? parsedBody : undefined
+  // `object-literal` is excluded alongside `unsupported`: an object-returning
+  // memo (`() => ({ … })`) isn't lowered from the parsed tree yet, so leaving
+  // `parsed` undefined keeps the adapter on its existing object-memo lowering
+  // (byte-identical; flipped in a later Roadmap A unit).
+  const parsed =
+    parsedBody && parsedBody.kind !== 'unsupported' && parsedBody.kind !== 'object-literal'
+      ? parsedBody
+      : undefined
 
   ctx.memos.push({
     name,

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -33,6 +33,19 @@ export type ParsedExpr =
   | { kind: 'arrow-fn'; param: string; body: ParsedExpr }
   | { kind: 'higher-order'; method: 'filter' | 'every' | 'some' | 'find' | 'findIndex' | 'findLast' | 'findLastIndex'; object: ParsedExpr; param: string; predicate: ParsedExpr }
   | { kind: 'array-literal'; elements: ParsedExpr[] }
+  // Object literal `{ a: 1, b: x }` / shorthand `{ a }`. Carried so an
+  // adapter that lowers an object *value* (Go `map[string]interface{}`,
+  // Perl hashref) can emit from structure instead of re-parsing the
+  // source with `ts.createSourceFile`. Only produced for plain literals:
+  // every property is a non-computed `key: value` or shorthand `{ key }`.
+  // Spreads, computed keys, methods, and getters/setters fall through to
+  // `unsupported` (unchanged). `raw` is the original expression string —
+  // the same value the old `unsupported` fallback carried — so an adapter
+  // that does not yet consume `properties` stays byte-identical by
+  // emitting it exactly as it emits `unsupported`. Extending the type
+  // adds a TS compile error in every exhaustive `ParsedExpr` switch, the
+  // same drift defence used for `array-literal` / `array-method`.
+  | { kind: 'object-literal'; properties: ObjectLiteralProperty[]; raw: string }
   // Non-higher-order array methods. Discriminated by `method` so each
   // adapter handles the full set via one exhaustive switch instead of
   // sprinkling per-method branches across the call / member emitters.
@@ -126,6 +139,22 @@ export type ParsedExpr =
       flatMapOp: FlatMapOp
     }
   | { kind: 'unsupported'; raw: string; reason: string }
+
+/**
+ * One property of an `object-literal` `ParsedExpr`. The key is the
+ * resolved (non-computed) property name — for `{ a: 1 }` and shorthand
+ * `{ a }` it is `a`; for `{ 'a-b': 1 }` it is `a-b`. Computed keys
+ * (`{ [k]: 1 }`) are not represented; such literals fall through to
+ * `unsupported` at parse time.
+ */
+export type ObjectLiteralProperty = {
+  key: string
+  // Shorthand `{ a }` (the value is the identifier `a`) vs explicit
+  // `{ a: <value> }`. The `value` already carries the resolved tree
+  // either way; this flag is kept for re-stringification fidelity.
+  shorthand: boolean
+  value: ParsedExpr
+}
 
 /**
  * One comparison key inside a sort comparator. A simple
@@ -670,6 +699,19 @@ export function parseExpression(expr: string): ParsedExpr {
 }
 
 /**
+ * Resolve a non-computed object-literal property key to its string name.
+ * Identifier / string / numeric names resolve to their text; a computed
+ * (`[expr]`) or otherwise non-plain key returns null so the caller treats
+ * the whole literal as `unsupported`.
+ */
+function objectLiteralKeyName(name: ts.PropertyName): string | null {
+  if (ts.isIdentifier(name)) return name.text
+  if (ts.isStringLiteral(name)) return name.text
+  if (ts.isNumericLiteral(name)) return name.text
+  return null
+}
+
+/**
  * Convert a TypeScript AST node to ParsedExpr.
  */
 function convertNode(node: ts.Node, raw: string): ParsedExpr {
@@ -965,14 +1007,18 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
               'String.prototype.replace supports only a string pattern + string replacement (the regex form is deferred); use a string pattern or wrap the expression in /* @client */',
           }
         }
+        // Treat an object-literal argument like `unsupported` — a `.replace`
+        // with an object pattern/replacement isn't lowerable, same as before
+        // the `object-literal` kind existed (byte-identical; Roadmap A-1).
         const badArg =
-          args[0].kind === 'unsupported'
+          args[0].kind === 'unsupported' || args[0].kind === 'object-literal'
             ? args[0]
-            : args[1].kind === 'unsupported'
+            : args[1].kind === 'unsupported' || args[1].kind === 'object-literal'
               ? args[1]
               : undefined
-        if (badArg && badArg.kind === 'unsupported') {
-          return { kind: 'unsupported', raw, reason: badArg.reason }
+        if (badArg) {
+          const reason = badArg.kind === 'unsupported' ? badArg.reason : 'Unsupported syntax: ObjectLiteralExpression'
+          return { kind: 'unsupported', raw, reason }
         }
         return { kind: 'array-method', method: 'replace', object: callee.object, args }
       }
@@ -1132,6 +1178,29 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
     return { kind: 'array-literal', elements }
   }
 
+  // Object literal: { a: 1, b: x, shorthand }. Only plain literals are
+  // structured — every property must be a non-computed `key: value` or a
+  // shorthand `{ key }`. Anything else (spread, computed key, method,
+  // getter/setter) falls through to the generic `unsupported` fallback
+  // below, exactly as before this kind existed.
+  if (ts.isObjectLiteralExpression(node)) {
+    const properties: ObjectLiteralProperty[] = []
+    for (const prop of node.properties) {
+      if (ts.isPropertyAssignment(prop)) {
+        const key = objectLiteralKeyName(prop.name)
+        if (key === null) return { kind: 'unsupported', raw, reason: `Unsupported syntax: ${ts.SyntaxKind[node.kind]}` }
+        properties.push({ key, shorthand: false, value: convertNode(prop.initializer, raw) })
+      } else if (ts.isShorthandPropertyAssignment(prop)) {
+        const key = prop.name.text
+        properties.push({ key, shorthand: true, value: { kind: 'identifier', name: key } })
+      } else {
+        // Spread assignment, method, getter/setter — not a plain map.
+        return { kind: 'unsupported', raw, reason: `Unsupported syntax: ${ts.SyntaxKind[node.kind]}` }
+      }
+    }
+    return { kind: 'object-literal', properties, raw }
+  }
+
   // Property access: user.name, items().length
   if (ts.isPropertyAccessExpression(node)) {
     const object = convertNode(node.expression, raw)
@@ -1164,7 +1233,10 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
     // (the literal forms above fold into a static property path; this
     // one can't). #1897 (data-table).
     const index = convertNode(argNode, raw)
-    if (index.kind === 'unsupported') return index
+    // An object-literal index (`arr[{…}]`) isn't lowerable — surface it
+    // as the whole expression, exactly as an `unsupported` index did
+    // before the kind existed (byte-identical; Roadmap A-1).
+    if (index.kind === 'unsupported' || index.kind === 'object-literal') return index
     return { kind: 'index-access', object, index }
   }
 
@@ -2070,8 +2142,12 @@ function collectDestructureBindings(
     let defaultExpr: ParsedExpr | undefined
     if (el.initializer) {
       const parsed = convertNode(el.initializer, raw)
-      if (parsed.kind === 'unsupported') {
-        return { ok: false, reason: `Default value in destructured filter param failed to parse: ${parsed.reason}` }
+      // An object-literal default isn't lowered into a destructured filter
+      // predicate yet — refuse it exactly as before the kind existed, with
+      // the same reason text the `unsupported` fallback produced (A-1).
+      if (parsed.kind === 'unsupported' || parsed.kind === 'object-literal') {
+        const reason = parsed.kind === 'unsupported' ? parsed.reason : 'Unsupported syntax: ObjectLiteralExpression'
+        return { ok: false, reason: `Default value in destructured filter param failed to parse: ${reason}` }
       }
       defaultExpr = parsed
     }
@@ -2114,6 +2190,7 @@ function findImpureDefaultNode(expr: ParsedExpr): string | null {
     case 'literal':
     case 'identifier':
     case 'unsupported':
+    case 'object-literal':
       return null
     case 'member':
       return findImpureDefaultNode(expr.object)
@@ -2271,6 +2348,7 @@ function validateRestUsage(
         return
       case 'literal':
       case 'unsupported':
+      case 'object-literal':
         return
     }
   }
@@ -2386,6 +2464,9 @@ function collectIdentifiers(expr: ParsedExpr, out: Set<string>): void {
       return
     case 'literal':
     case 'unsupported':
+    // Mirror `unsupported`: an object literal was not carried before this
+    // kind existed, so it collects no identifiers (byte-identical A-1).
+    case 'object-literal':
       return
   }
 }
@@ -2506,6 +2587,9 @@ function substituteDestructuredFields(
         return { kind: 'array-method', method: e.method, object: walk(e.object), args: e.args.map(walk) }
       case 'literal':
       case 'unsupported':
+      // Mirror `unsupported`: object literals were not substituted into
+      // before this kind existed — return verbatim (byte-identical A-1).
+      case 'object-literal':
         return e
     }
   }
@@ -2566,6 +2650,15 @@ function checkSupport(expr: ParsedExpr): SupportResult {
   switch (expr.kind) {
     case 'unsupported':
       return { supported: false, reason: expr.reason }
+
+    // A bare object literal is still refused as a standalone template
+    // expression — adapters that lower one as a *value* (Go map / Perl
+    // hashref) do so in their own emitter, like `array-literal`, not
+    // through this support gate. The reason string is the exact text the
+    // `unsupported` fallback produced before the `object-literal` kind
+    // existed, so diagnostics stay byte-identical (Roadmap A-1).
+    case 'object-literal':
+      return { supported: false, reason: 'Unsupported syntax: ObjectLiteralExpression' }
 
     case 'identifier':
       return { supported: true, level: 'L1' }
@@ -2864,7 +2957,10 @@ function parseStatement(
     const name = decl.name.text
     const initText = getJS(decl.initializer)
     const init = parseExpression(initText)
-    if (init.kind === 'unsupported') {
+    // `object-literal` is not yet lowered by the block-body consumers, so
+    // treat it like `unsupported` here — the memo/block path falls back to
+    // its `ts.createSourceFile` lowering (byte-identical; Roadmap A-1).
+    if (init.kind === 'unsupported' || init.kind === 'object-literal') {
       return null
     }
     return { kind: 'var-decl', name, init }
@@ -2878,7 +2974,9 @@ function parseStatement(
     }
     const valueText = getJS(stmt.expression)
     const value = parseExpression(valueText)
-    if (value.kind === 'unsupported') {
+    // See the var-decl note above: object literals fall back to the
+    // block-body's createSourceFile lowering for now (Roadmap A-1).
+    if (value.kind === 'unsupported' || value.kind === 'object-literal') {
       return null
     }
     return { kind: 'return', value }
@@ -2888,7 +2986,7 @@ function parseStatement(
   if (ts.isIfStatement(stmt)) {
     const conditionText = getJS(stmt.expression)
     const condition = parseExpression(conditionText)
-    if (condition.kind === 'unsupported') {
+    if (condition.kind === 'unsupported' || condition.kind === 'object-literal') {
       return null
     }
 
@@ -3010,6 +3108,9 @@ export function exprToString(expr: ParsedExpr): string {
       }
       return `${exprToString(expr.object)}.${expr.method}(${expr.args.map(exprToString).join(', ')})`
     case 'unsupported':
+    // `raw` holds the original expression string (same value the old
+    // `unsupported` carried), so the round-trip stays byte-identical.
+    case 'object-literal':
       return `[UNSUPPORTED: ${expr.raw}]`
   }
 }
@@ -3097,6 +3198,9 @@ export function stringifyParsedExpr(expr: ParsedExpr): string {
       }
       return `${stringifyParsedExpr(expr.object)}.${expr.method}(${expr.args.map(stringifyParsedExpr).join(', ')})`
     case 'unsupported':
+    // `raw` is the original expression string, so re-stringification is
+    // byte-identical to the pre-`object-literal` behaviour (Roadmap A-1).
+    case 'object-literal':
       return expr.raw
   }
 }

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -256,7 +256,7 @@ export { ErrorCodes, createError, formatError, generateCodeFrame } from './error
 // Expression Parser
 export { parseExpression, isSupported, exprToString, stringifyParsedExpr, identifierPath, parseBlockBody, containsHigherOrder, extractArrowBodyExpression, parseStyleObjectEntries, parseProviderObjectLiteral, type ProviderObjectMember } from './expression-parser.ts'
 export type { StyleObjectEntry } from './expression-parser.ts'
-export type { ParsedExpr, ParsedStatement, SortComparator, SortKey, ReduceOp, FlatDepth, FlatMapOp, FlatMapLeaf, SupportLevel, SupportResult, TemplatePart } from './expression-parser.ts'
+export type { ParsedExpr, ObjectLiteralProperty, ParsedStatement, SortComparator, SortKey, ReduceOp, FlatDepth, FlatMapOp, FlatMapLeaf, SupportLevel, SupportResult, TemplatePart } from './expression-parser.ts'
 export { buildLoopChainExpr } from './loop-chain.ts'
 export type { LoopChainInputs } from './loop-chain.ts'
 export { isLowerableObjectRestDestructure } from './loop-destructure.ts'


### PR DESCRIPTION
## Roadmap A-1 — the foundational ParsedExpr extension

Adapter-architecture Roadmap A drives the Go adapter's residual
`parseExpression` / `ts.createSourceFile` / value-regex to **0** by carrying
the last value-shaped IR fields structurally. Those fields (signal
`initialValue`, local `const` values) are frequently **object literals** —
which `ParsedExpr` could not model. This PR adds that missing piece.

### What changes
- **New `object-literal` kind** on `ParsedExpr`: `{ properties, raw }`, where
  each property is `{ key, shorthand, value: ParsedExpr }`. `convertNode`
  structures plain object literals (`({ a: 1, b: x })`, shorthand `({ a })`).
  Spread / computed-key / method / getter-setter literals still fall through to
  `unsupported`, unchanged.
- **`objectLiteral` dispatcher method** on the shared `ParsedExprEmitter`, so
  the **go-template / mojolicious / xslate** adapters each handle the kind
  explicitly. Extending the union is a TS compile error in every exhaustive
  switch — the same drift defence used for `array-literal` / `array-method`.

### Byte-identical
This is a pure capability addition — **no emitted output changes**:
- Every exhaustive `ParsedExpr` switch mirrors its `unsupported` arm for
  `object-literal` (`checkSupport` preserves the exact old reason string).
- Each adapter's `objectLiteral` emits exactly as an object literal did before
  — through its `unsupported` path.
- The IR-carry gates (analyzer memo body, block-body parse, destructured-filter
  default) still treat `object-literal` like `unsupported`, so nothing new is
  carried into the IR yet. Later Roadmap A units flip the specific gates they
  need alongside the matching Go consumption.

`raw` carries the original expression string so any not-yet-structural consumer
stays byte-identical.

### Verification
- Unit: jsx **2181**, go **552**, mojo **527**, xslate **353** — all green.
- Conformance (byte-identical authority): go **786** pass, 0 fail.
- `tsgo --noEmit` + `biome` clean across jsx + all three adapters.
- New parser unit tests cover the structured / shorthand / spread-fallthrough /
  bare-brace-is-a-block cases.

### Next in the stack
A-2 (carry signal `initialValue`), A-3 (carry local `const` values — depends on
this kind), A-4 (sweep residual `createSourceFile` / regex → 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_