### PR TITLE
docs: add CONTRIBUTING, CODE_OF_CONDUCT, and SECURITY

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,136 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement privately through
+GitHub. Open a confidential report using GitHub's
+[private reporting](https://github.com/piconic-ai/barefootjs/security/advisories/new)
+(under the repository's **Security** tab), and the maintainers will follow up.
+**Please do not report Code of Conduct concerns in public issues.**
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla coc]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,6 +36,16 @@ Examples of unacceptable behavior include:
 - Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
+## Unconscious bias and microaggressions
+
+Harassment is not always intentional. Everyone carries unconscious bias, and
+because it cannot be eliminated entirely, what matters is recognizing that we
+each may hold assumptions and reflecting honestly on our own words and actions.
+Even without ill intent, small biased remarks or attitudes can accumulate —
+microaggressions — and unintentionally exclude or hurt others. We ask everyone
+to imagine the impact their words and actions have on others, and to
+communicate with care and mutual respect.
+
 ## Enforcement Responsibilities
 
 Community leaders are responsible for clarifying and enforcing our standards of
@@ -72,58 +82,28 @@ reporter of any incident.
 
 ## Enforcement Guidelines
 
-Community leaders will follow these Community Impact Guidelines in determining
-the consequences for any action they deem in violation of this Code of Conduct:
+There is no fixed escalation ladder. Community leaders assess each reported
+incident on a case-by-case basis and apply whatever response they judge
+appropriate and proportionate to the situation — ranging from a private word,
+to editing or removing contributions, to a temporary or permanent ban.
 
-### 1. Correction
-
-**Community Impact**: Use of inappropriate language or other behavior deemed
-unprofessional or unwelcome in the community.
-
-**Consequence**: A private, written warning from community leaders, providing
-clarity around the nature of the violation and an explanation of why the
-behavior was inappropriate. A public apology may be requested.
-
-### 2. Warning
-
-**Community Impact**: A violation through a single incident or series of
-actions.
-
-**Consequence**: A warning with consequences for continued behavior. No
-interaction with the people involved, including unsolicited interaction with
-those enforcing the Code of Conduct, for a specified period of time. This
-includes avoiding interactions in community spaces as well as external channels
-like social media. Violating these terms may lead to a temporary or permanent
-ban.
-
-### 3. Temporary Ban
-
-**Community Impact**: A serious violation of community standards, including
-sustained inappropriate behavior.
-
-**Consequence**: A temporary ban from any sort of interaction or public
-communication with the community for a specified period of time. No public or
-private interaction with the people involved, including unsolicited interaction
-with those enforcing the Code of Conduct, is allowed during this period.
-Violating these terms may lead to a permanent ban.
-
-### 4. Permanent Ban
-
-**Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior, harassment of an
-individual, or aggression toward or disparagement of classes of individuals.
-
-**Consequence**: A permanent ban from any sort of public interaction within the
-community.
+A minor, good-faith first offense may warrant only a quiet, private correction.
+A serious or malicious violation — harassment, threats, or deliberate abuse —
+may result in an immediate and permanent ban, without prior warning, at the
+maintainers' sole discretion.
 
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.1, available at
 [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+The standard escalation ladder has been replaced with case-by-case
+enforcement at the maintainers' discretion.
 
-Community Impact Guidelines were inspired by
-[Mozilla's code of conduct enforcement ladder][mozilla coc].
+The "Unconscious bias and microaggressions" section is adapted from the
+[YAPC::Japan / Japan.pm Code of Conduct][yapc], licensed under
+[CC BY 3.0][ccby] and itself based on the jsconf.us 2012 and Ada Initiative
+codes of conduct.
 
 For answers to common questions about this code of conduct, see the FAQ at
 [https://www.contributor-covenant.org/faq][faq]. Translations are available at
@@ -131,6 +111,7 @@ For answers to common questions about this code of conduct, see the FAQ at
 
 [homepage]: https://www.contributor-covenant.org
 [v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
-[mozilla coc]: https://github.com/mozilla/diversity
+[yapc]: https://japan.perlassociation.org/entry/yapc/code_of_conduct
+[ccby]: https://creativecommons.org/licenses/by/3.0/
 [faq]: https://www.contributor-covenant.org/faq
 [translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,156 @@
+# Contributing to BarefootJS
+
+Thanks for your interest in BarefootJS! This project has a deliberately
+unusual contribution model — please read this first.
+
+> [!WARNING]
+> **Alpha software.** APIs may change without notice. The contribution
+> process below may also evolve as the project matures.
+
+## Contribution policy: issues, not external PRs
+
+**We do not accept unsolicited pull requests from outside the core team.**
+
+This is a conscious decision, not unfriendliness. As a compiler that other
+people's apps build on, BarefootJS treats its supply chain seriously, and we
+want to keep the codebase free of unreviewed, machine-generated "AI slop."
+Accepting arbitrary external PRs works against both goals.
+
+Instead, **design discussions in issues are very welcome**, and they are how
+real change happens here:
+
+- Found a bug? **Open an issue.**
+- Want a feature, an API change, or a new adapter? **Open an issue** and let's
+  discuss the design first.
+- Have a fix in mind? Describe it in the issue — code snippets, a diff, a
+  reproduction, or a full patch in the issue body are all great.
+
+**Contributions made through issues are credited as co-authors on the
+resulting commits.** When a maintainer lands the change, your name goes in the
+`Co-authored-by:` trailers. You get credit; the project keeps a reviewed,
+trusted history.
+
+If you are a core maintainer (or have been explicitly invited to send a PR for
+a specific issue), the rest of this guide is for you.
+
+## Where to start
+
+- **Bug reports** → use the [bug report template](.github/ISSUE_TEMPLATE/bug_report.yml).
+- **Feature / design proposals** → use the [feature request template](.github/ISSUE_TEMPLATE/feature_request.yml).
+- **Known limitations** are tracked under the
+  [`known-limitation`](https://github.com/piconic-ai/barefootjs/labels/known-limitation)
+  label. Each issue documents the shape, affected fixtures, available
+  workaround, and fix direction — a good place to understand current edges.
+
+## Project overview
+
+BarefootJS compiles signal-based TSX into a marked template plus client JS for
+any backend, using a 2-phase pipeline: **JSX → IR → Marked Template + Client JS**.
+
+- `packages/jsx/` — Core compiler (`jsx-to-ir.ts`, `ir-to-client-js.ts`, `analyzer.ts`).
+- `packages/client/` — Client runtime (`createSignal`, `createEffect`, DOM runtime).
+- `packages/cli/` — The `bf` CLI.
+- Adapters — `packages/adapter-hono/`, `packages/adapter-go-template/`,
+  `packages/adapter-mojolicious/`, and others.
+
+See [`spec/compiler.md`](spec/compiler.md) for the full pipeline, IR schema,
+transformation rules, adapter interface, and error codes.
+
+## Development setup
+
+Requires **Node 22+** and [Bun](https://bun.sh) (this repo uses `bun`, not `npm`,
+for package management).
+
+```sh
+git clone https://github.com/piconic-ai/barefootjs.git
+cd barefootjs
+bun install
+bun run build
+```
+
+Useful scripts:
+
+| Command | What it does |
+|---------|--------------|
+| `bun run build` | Build all packages (ordered) |
+| `bun test` | Run the root test suite |
+| `bun run lint` | Lint / format check with Biome |
+| `bun run bf --help` | The `bf` CLI — component APIs, docs, signal graphs |
+| `bun run dev:all` | Run the site + example apps locally |
+
+The `bf` CLI is the fastest way to understand a component before touching it —
+`bf docs <component>` for the API surface, `bf debug graph <component>` for the
+reactive structure of a `"use client"` component.
+
+## Testing
+
+BarefootJS has layered tests; pick the layer that matches your change. Full
+details live in [`spec/testing.md`](spec/testing.md).
+
+| Layer | Verifies | Location |
+|-------|----------|----------|
+| Compiler unit | Transformation rules, error codes, analysis | `packages/jsx/src/__tests__/` |
+| Component IR | Structure, a11y, signals, classes, event wiring | `ui/components/ui/*/index.test.tsx` |
+| Adapter conformance | IR → HTML output per adapter | `packages/adapter-tests/fixtures/` |
+| CSR conformance | Client JS → correct DOM output | `packages/adapter-tests/src/__tests__/csr-conformance.test.ts` |
+| Runtime unit | Signals, DOM ops, hydration primitives | `packages/client/__tests__/` |
+| E2E | User interactions, hydration, visual | `site/ui/e2e/` |
+
+Quick guide:
+
+- **New UI component** → Component IR test using `renderToTest()`.
+- **Compiler internals** (analysis, error codes, codegen) → Compiler unit test.
+- **Template HTML output** → Adapter conformance fixture.
+- **Client JS behavior** → CSR conformance fixture.
+- **Click / keyboard behavior** → E2E test.
+
+Run the relevant suite before submitting, and `bun run lint` to keep formatting
+consistent.
+
+## Coding conventions
+
+A few rules the codebase enforces (see [`CLAUDE.md`](CLAUDE.md) for the full set):
+
+- **Never parse imports or any JS/TS syntax with regex or string matching.**
+  Use the established AST-based patterns — the IR's parsed metadata for source
+  files, a TS AST walk for compiled client JS. `typescript` is already a
+  direct dependency; do not add a second parser.
+- **Do not add compiler options/hooks for tool-specific output rewriting.**
+  Tools that need to adjust emitted client JS post-process it themselves.
+- TypeScript with Go template adapters; CSS via UnoCSS.
+
+## Changesets
+
+This repo uses [Changesets](https://github.com/changesets/changesets) for
+versioning. If your change affects a published package, add a changeset:
+
+```sh
+bun changeset
+```
+
+Describe the change and pick the appropriate semver bump. Internal-only
+packages are ignored (see `.changeset/config.json`).
+
+## Commit conventions
+
+Every commit ends with `Co-authored-by:` trailers for **all** participants
+other than the git author — including issue contributors whose design or patch
+landed in the commit. Place them as the final lines of the message, with no
+blank line or trailing content after them, or GitHub will not recognize them:
+
+```
+Fix signal dependency tracking in nested effects
+
+Co-authored-by: Some Contributor <contributor@example.com>
+```
+
+## Code of Conduct & Security
+
+By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md). To
+report a security vulnerability, follow the [Security Policy](SECURITY.md) —
+**please do not open a public issue for security reports.**
+
+## License
+
+By contributing, you agree that your contributions are licensed under the
+[MIT License](LICENSE) that covers the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,9 @@ A few rules the codebase enforces (see [`CLAUDE.md`](CLAUDE.md) for the full set
   direct dependency; do not add a second parser.
 - **Do not add compiler options/hooks for tool-specific output rewriting.**
   Tools that need to adjust emitted client JS post-process it themselves.
-- TypeScript with Go template adapters; CSS via UnoCSS.
+- The codebase is TypeScript. Adapters target a range of backends (Hono,
+  Go `html/template`, Mojolicious, and more), so keep core compiler and
+  runtime code adapter-agnostic. CSS uses UnoCSS.
 
 ## Changesets
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## Supported versions
+
+BarefootJS is in **early alpha** (`0.x`). APIs may change without notice, and
+only the latest published release receives security fixes. There are no
+long-term support branches at this stage.
+
+| Version | Supported |
+|---------|-----------|
+| Latest `0.x` release | ✅ |
+| Older `0.x` releases | ❌ |
+
+If you are running BarefootJS in production despite the alpha status, please
+stay on the most recent release so that fixes reach you.
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Report privately using GitHub's
+[private vulnerability reporting](https://github.com/piconic-ai/barefootjs/security/advisories/new)
+(the **Report a vulnerability** button under the repository's **Security** tab).
+This opens a confidential channel visible only to you and the maintainers.
+
+Please include as much of the following as you can:
+
+- A description of the vulnerability and its impact.
+- The affected package(s) and version(s) (e.g. `@barefootjs/jsx`,
+  `@barefootjs/client`, the `bf` CLI, or an adapter).
+- Steps to reproduce, ideally a minimal reproduction or proof of concept.
+- Any known mitigations or workarounds.
+
+Because BarefootJS is a compiler that other projects build on, we take
+supply-chain and generated-output safety seriously. Reports about the compiler
+emitting unsafe client JS or templates, or about the build/release pipeline,
+are in scope and welcome.
+
+## What to expect
+
+- **Acknowledgement** — we aim to acknowledge a valid report within a few
+  business days.
+- **Assessment** — we will investigate, confirm the issue, and determine the
+  affected versions.
+- **Fix & disclosure** — we will prepare a fix and coordinate a release. With
+  your permission, we will credit you in the advisory and release notes.
+
+Please give us a reasonable opportunity to address the issue before any public
+disclosure. We appreciate responsible disclosure and the effort it takes to
+report security issues carefully.


### PR DESCRIPTION
Adds the three community health files the repo was missing.

## What's here

- **CONTRIBUTING.md** — documents the project's deliberate contribution model: no unsolicited external PRs (supply-chain / AI-slop concerns), but design discussions in issues are welcome and **credited as commit co-authors**. Also covers dev setup (Node 22+, Bun), the layered testing strategy, key coding conventions (no regex parsing of JS/TS, no tool-specific compiler hooks), Changesets, and commit `Co-authored-by:` rules.
- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1.
- **SECURITY.md** — supported versions (alpha `0.x`, latest only) and reporting process.

## Decisions reflected

- The existing `.github/ISSUE_TEMPLATE/config.yml` already states the "issues, not external PRs" policy — CONTRIBUTING.md is consistent with it.
- Both Code of Conduct reports and security disclosures route through **GitHub's private vulnerability reporting** (no public email address exposed), per the maintainer's choice.

## Notes for review

- The CoC/security report link points to `…/security/advisories/new`. Private vulnerability reporting must be **enabled** in repo Settings → Security for that flow to work.
- Content is drawn from `README.md`, `CLAUDE.md`, `spec/`, and existing repo metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbU5GEhNqHEcCvqMFusj9c)_