### PR TITLE
feat(jsx,go-template): carry signal initial values on the IR (Roadmap A-3)

### DIFF
--- a/.changeset/signal-init-parsed.md
+++ b/.changeset/signal-init-parsed.md
@@ -1,0 +1,18 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+---
+
+Carry a signal's parsed initial value on the IR (`SignalInfo.parsed`, Roadmap
+A-3) and lower literal signal inits from it. The analyzer structures each
+signal's `initialValue` once (best-effort, from the same type-stripped string
+the adapter consumes). A new `ParsedExpr.literal.raw` field carries the numeric
+literal's `ts.NumericLiteral.text` (TS's normalised token) so a structured
+lowering matches the existing `ts.createSourceFile` path byte-for-byte instead
+of the lossy `parseFloat` value. The Go adapter's scalar-array signal bake
+(`convertInitialValue` → `jsLiteralToGo`) now reads the carried tree via a new
+`parsedLiteralToGo` helper, which reproduces the scalar / scalar-array shapes
+exactly and defers (returns null) everything else — object/struct-array baking,
+empty arrays, `as const` — to the unchanged `ts.createSourceFile` fallback. So
+only the reproduced shapes skip the re-parse; behaviour is byte-identical,
+verified by the Go adapter unit + conformance suites.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -735,6 +735,28 @@ export function Tags() {
       )
     })
 
+    test('bakes a numeric scalar array from the carried tree (Roadmap A-3)', () => {
+      // The analyzer carries `SignalInfo.parsed`, so the scalar-array bake
+      // reads the structured tree (`parsedLiteralToGo`) instead of re-parsing
+      // the value string with `ts.createSourceFile`. Each numeric element uses
+      // the carried raw token (= `NumericLiteral.text`), so the bake matches
+      // the fallback byte-for-byte — including TS's `.text` normalisation of
+      // `1e3` → `1000` and `0x10` → `16`.
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+export function Nums() {
+  const [ns] = createSignal<number[]>([1, 2, 1e3, 0x10])
+  return <ul>{ns().map((n) => <li key={n}>{n}</li>)}</ul>
+}
+`)
+      expect(adapter.generate(ir).types!).toContain(
+        'Ns: []int{1, 2, 1000, 16},',
+      )
+    })
+
     test('synthesises a struct for an untyped object array and bakes it (#1680)', () => {
       // An untyped object array has no element type to bake against. Rather
       // than leave it nil (empty SSR loop), infer a struct from the literal's

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -1242,7 +1242,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         // Bake against the synthesised struct type when one was inferred for
         // this untyped object-array signal (#1680), else the signal's own type.
         const bakeType = this.state.synthStructTypes.get(signal.getter) ?? signal.type
-        const initialValue = convertInitialValue(this.emitCtx, signal.initialValue, bakeType, ir.metadata.propsParams)
+        const initialValue = convertInitialValue(this.emitCtx, signal.initialValue, bakeType, ir.metadata.propsParams, signal.parsed)
         lines.push(`\t\t${fieldName}: ${initialValue},`)
       }
     }
@@ -2329,7 +2329,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
   private resolveDynamicPropValue(
     expr: string,
-    signals: { getter: string; setter: string | null; initialValue: string; type: TypeInfo }[],
+    signals: { getter: string; setter: string | null; initialValue: string; type: TypeInfo; parsed?: ParsedExpr }[],
     memos: { name: string; computation: string; deps: string[] }[],
     propsParams: { name: string }[]
   ): string | null {
@@ -2366,7 +2366,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       // Check if it's a signal
       const signal = signals.find(s => s.getter === getterName)
       if (signal) {
-        return convertInitialValue(this.emitCtx, signal.initialValue, signal.type, propsParams)
+        return convertInitialValue(this.emitCtx, signal.initialValue, signal.type, propsParams, signal.parsed)
       }
 
       // Check if it's a memo. Use the pattern-matching core: when no

--- a/packages/adapter-go-template/src/adapter/value/parsed-literal-to-go.ts
+++ b/packages/adapter-go-template/src/adapter/value/parsed-literal-to-go.ts
@@ -1,0 +1,74 @@
+/**
+ * Lower a structured literal `ParsedExpr` (carried on the IR by the analyzer)
+ * to a Go literal, mirroring `tsLiteralToGo`'s output for the shapes it covers
+ * so the signal-init bake can read the tree instead of re-parsing the value
+ * string with `ts.createSourceFile`.
+ *
+ * The contract is **null-means-defer**: this returns null for anything it does
+ * not reproduce exactly (object literals — whose struct-field baking lives in
+ * `tsLiteralToGo`; empty arrays; identifiers / calls; or a numeric literal
+ * whose raw spelling wasn't carried). The caller then falls back to the
+ * `ts.createSourceFile` path, so only the shapes reproduced here short-circuit
+ * and behaviour stays byte-identical.
+ */
+
+import type { ParsedExpr, TypeInfo } from '@barefootjs/jsx'
+
+import type { GoEmitContext } from '../emit-context.ts'
+import { typeInfoToGo } from '../type/type-codegen.ts'
+
+export function parsedLiteralToGo(
+  ctx: GoEmitContext,
+  expr: ParsedExpr,
+  typeInfo?: TypeInfo,
+): string | null {
+  // Leading unary minus on a numeric literal (`-1`) — mirror
+  // `tsLiteralToGo`'s `-${operand.text}` using the carried `raw` token.
+  if (
+    expr.kind === 'unary' &&
+    expr.op === '-' &&
+    expr.argument.kind === 'literal' &&
+    expr.argument.literalType === 'number'
+  ) {
+    return expr.argument.raw !== undefined ? `-${expr.argument.raw}` : null
+  }
+
+  if (expr.kind === 'literal') {
+    switch (expr.literalType) {
+      case 'string':
+        // `value` is the interpreted (unquoted) text, exactly like
+        // `ts.StringLiteral.text`; `JSON.stringify` re-quotes it for Go.
+        return JSON.stringify(expr.value)
+      case 'number':
+        // Need the exact source token (`tsLiteralToGo` returns
+        // `NumericLiteral.text`); without it the `parseFloat` value could
+        // change spelling / lose precision, so defer.
+        return expr.raw ?? null
+      case 'boolean':
+        return expr.value ? 'true' : 'false'
+      case 'null':
+        return 'nil'
+    }
+  }
+
+  if (expr.kind === 'array-literal') {
+    // An empty array bakes to nothing in `tsLiteralToGo` (returns null so the
+    // field stays nil, JSON-marshalling as `null`). Defer so the fallback
+    // reaches that same nil rather than emitting an empty slice.
+    if (expr.elements.length === 0) return null
+    const elemType = typeInfo?.kind === 'array' ? typeInfo.elementType : undefined
+    const sliceHeader = typeInfo?.kind === 'array' ? typeInfoToGo(ctx, typeInfo) : '[]interface{}'
+    const elems: string[] = []
+    for (const el of expr.elements) {
+      const go = parsedLiteralToGo(ctx, el, elemType)
+      // Any non-scalar element (an object, a call, an identifier) defers the
+      // WHOLE array to the TS path, which owns the struct-element baking.
+      if (go === null) return null
+      elems.push(go)
+    }
+    return `${sliceHeader}{${elems.join(', ')}}`
+  }
+
+  // object-literal / identifier / call / member / … → defer.
+  return null
+}

--- a/packages/adapter-go-template/src/adapter/value/value-lowering.ts
+++ b/packages/adapter-go-template/src/adapter/value/value-lowering.ts
@@ -12,12 +12,13 @@
 
 import ts from 'typescript'
 
-import type { TypeInfo } from '@barefootjs/jsx'
+import type { ParsedExpr, TypeInfo } from '@barefootjs/jsx'
 
 import type { GoEmitContext } from '../emit-context.ts'
 import type { PropFallbackVar } from '../lib/types.ts'
 import { capitalizeFieldName } from '../lib/go-naming.ts'
 import { typeInfoToGo } from '../type/type-codegen.ts'
+import { parsedLiteralToGo } from './parsed-literal-to-go.ts'
 
 /** Default for `getSignalInitialValueAsGo`'s optional fallback-var map. */
 const EMPTY_PROP_FALLBACK_VARS: ReadonlyMap<string, PropFallbackVar> = new Map()
@@ -27,6 +28,7 @@ export function convertInitialValue(
   value: string,
   typeInfo: TypeInfo,
   propsParams?: { name: string }[],
+  preParsed?: ParsedExpr,
 ): string {
   // Check if it's a simple identifier (props param reference)
   if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(value)) {
@@ -79,7 +81,7 @@ export function convertInitialValue(
     // Bake a fully-literal initial value into a Go slice literal; anything
     // the parser can't reduce to a literal — a call, an identifier, `null` /
     // `undefined`, or an empty array — yields null and we keep `nil`.
-    return jsLiteralToGo(ctx, value, typeInfo) ?? 'nil'
+    return jsLiteralToGo(ctx, value, typeInfo, preParsed) ?? 'nil'
   }
 
   // String alias (e.g., Filter = string) — return string value instead of nil
@@ -116,7 +118,18 @@ export function jsLiteralToGo(
   ctx: GoEmitContext,
   value: string,
   typeInfo: TypeInfo,
+  preParsed?: ParsedExpr,
 ): string | null {
+  // Roadmap A: when the analyzer carried a structured parse, lower the literal
+  // from the tree first. `parsedLiteralToGo` reproduces the scalar / scalar-
+  // array shapes exactly and returns null to DEFER everything else (object
+  // baking, empty arrays, `as const`, …) to the `ts.createSourceFile` path
+  // below, so behaviour stays byte-identical — only the reproduced shapes skip
+  // the re-parse.
+  if (preParsed) {
+    const structured = parsedLiteralToGo(ctx, preParsed, typeInfo)
+    if (structured !== null) return structured
+  }
   const expr = ctx.parseLiteralExpression(value)
   if (!expr) return null
   return tsLiteralToGo(ctx, expr, typeInfo)

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -331,6 +331,28 @@ describe('expression-parser', () => {
       }
     })
 
+    test('carries the raw numeric token (= ts NumericLiteral.text) (Roadmap A-3)', () => {
+      // `raw` is the TS `NumericLiteral.text` — the exact token the adapter's
+      // `tsLiteralToGo` already emits — so a structured lowering matches it
+      // byte-for-byte. TS normalises separators / radix / exponent in `.text`
+      // (`1_000`/`0x10`/`1e3` → decimal), which is precisely why carrying the
+      // token beats the lossy `parseFloat` `value` (e.g. `parseFloat('1_000')`
+      // is 1, not 1000).
+      for (const [src, value, raw] of [
+        ['1', 1, '1'],
+        ['3.14', 3.14, '3.14'],
+        ['0x10', 16, '16'],
+        ['1e3', 1000, '1000'],
+        ['1_000', 1000, '1000'],
+      ] as const) {
+        const r = parseExpression(src)
+        expect(r).toMatchObject({ kind: 'literal', literalType: 'number', value, raw })
+      }
+      // Non-numeric literals don't carry `raw` (their `value` is canonical).
+      expect((parseExpression("'x'") as { raw?: string }).raw).toBeUndefined()
+      expect((parseExpression('true') as { raw?: string }).raw).toBeUndefined()
+    })
+
     test('falls through to unsupported for spread / computed-key object literals', () => {
       // A spread member is not a plain map property — preserves the
       // pre-A-1 `unsupported` behaviour (byte-identical).

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -262,6 +262,18 @@ export function analyzeComponent(
   // Post-processing validations
   validateContext(ctx)
 
+  // Roadmap A: carry a best-effort structured parse of each signal's initial
+  // value so adapters lower a literal init (`useState(['a', 'b'])`) from the
+  // tree instead of re-parsing the string with `ts.createSourceFile`. Parse
+  // the SAME (type-stripped) `initialValue` the adapter consumes; an
+  // unsupported shape leaves `parsed` undefined and the adapter falls back.
+  // Runs after `scanImportedClientSignals` so imported signals are covered too.
+  for (const signal of ctx.signals) {
+    if (!signal.initialValue) continue
+    const parsed = parseExpression(signal.initialValue)
+    if (parsed.kind !== 'unsupported') signal.parsed = parsed
+  }
+
   return ctx
 }
 

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -14,7 +14,16 @@ import ts from 'typescript'
 
 export type ParsedExpr =
   | { kind: 'identifier'; name: string }
-  | { kind: 'literal'; value: string | number | boolean | null; literalType: 'string' | 'number' | 'boolean' | 'null' }
+  // `raw` is the numeric literal's `ts.NumericLiteral.text` — the token TS
+  // itself normalises (separators stripped, radix / exponent folded to
+  // decimal: `1_000`/`0x10`/`1e3` → `1000`/`16`/`1000`). It is NOT the
+  // verbatim source spelling. Its value is that it equals the exact string an
+  // adapter's literal lowering already emits, so a structured lowering matches
+  // byte-for-byte — which the lossy `parseFloat` `value` can't guarantee (e.g.
+  // `parseFloat('1_000')` is 1, and large integers lose precision). Only
+  // populated for numeric literals; string / boolean / null carry their
+  // canonical form in `value`.
+  | { kind: 'literal'; value: string | number | boolean | null; literalType: 'string' | 'number' | 'boolean' | 'null'; raw?: string }
   | { kind: 'call'; callee: ParsedExpr; args: ParsedExpr[] }
   | { kind: 'member'; object: ParsedExpr; property: string; computed: boolean }
   // Element access with a NON-literal index (`selected()[index]`,
@@ -725,10 +734,13 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
     return { kind: 'literal', value: node.text, literalType: 'string' }
   }
 
-  // Numeric literal: 0, 5, 3.14
+  // Numeric literal: 0, 5, 3.14. Keep `ts.NumericLiteral.text` in `raw` (TS's
+  // normalised token — `1_000`/`0x10`/`1e3` → `1000`/`16`/`1000`) so an adapter
+  // emits the exact string its own literal lowering already produces; `value`
+  // is the parsed number for structural reasoning.
   if (ts.isNumericLiteral(node)) {
     const value = parseFloat(node.text)
-    return { kind: 'literal', value, literalType: 'number' }
+    return { kind: 'literal', value, literalType: 'number', raw: node.text }
   }
 
   // Boolean literals and null

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -1075,6 +1075,14 @@ export interface SignalInfo {
   getter: string
   setter: string | null
   initialValue: string
+  /**
+   * `initialValue` parsed into a structured tree (Roadmap A). Attached
+   * best-effort by the analyzer so adapters can lower a literal initial value
+   * (e.g. `useState(['a', 'b'])`) from structure instead of re-parsing the
+   * string with `ts.createSourceFile`. Absent when the shape isn't supported;
+   * consumers fall back to parsing `initialValue`.
+   */
+  parsed?: ParsedExpr
   /** Initial value with TypeScript type annotations preserved, for .tsx output */
   typedInitialValue?: string
   type: TypeInfo


### PR DESCRIPTION
## Roadmap A-3 — carry signal initial values on the IR

Stacked on #1997 (A-2). Third unit of [Roadmap A](https://github.com/piconic-ai/barefootjs/blob/main/spec/adapter-architecture.md#remaining-roadmap): drive the Go adapter's `parseExpression` / `ts.createSourceFile` / expression-regex toward 0 by carrying value-shaped IR fields structurally.

### What it does
- **`ParsedExpr.literal.raw`** (shared layer) — preserves the exact numeric source token (`ts.NumericLiteral.text`). This is the enabler: the existing `tsLiteralToGo` emits `node.text`, so a structured lowering needs the same token to stay byte-identical, rather than the lossy `parseFloat` `value` (e.g. `parseFloat('1_000')` is `1`, not `1000`). Only numeric literals carry it; string/boolean/null are canonical in `value`.
- **`SignalInfo.parsed`** — the analyzer attaches a best-effort structured parse of each signal's `initialValue`, parsed from the **same type-stripped string** the adapter consumes (covers imported `@client` signals too).
- **`value/parsed-literal-to-go.ts`** — a new pure helper that lowers the carried tree to Go, reproducing `tsLiteralToGo`'s scalar / scalar-array output **exactly** and returning `null` to **defer** everything else (object/struct-array baking, empty arrays, `as const`, identifiers/calls) to the unchanged `ts.createSourceFile` fallback.
- The Go scalar-array signal bake (`convertInitialValue` → `jsLiteralToGo`) now reads the carried tree first; only the reproduced shapes skip the re-parse.

### Why it's byte-identical
The structured path reproduces `tsLiteralToGo` token-for-token (numbers via `raw` = `node.text`; strings via `JSON.stringify(text)`; same slice header / element recursion), and **defers via `null`** on anything it doesn't reproduce — so the `createSourceFile` path stays authoritative for objects / structs / empty arrays. The existing struct-array bake test (object elements) verifies the defer path; a new scalar-array test verifies the structured path.

### Verification
jsx 2216 · go 556 · mojo 546 · xslate 359 unit · **conformance 786** · all `tsgo` + `biome` green.

> Note: this PR's base is the A-2 branch (`claude/const-value-parsed`); it will re-target `main` once #1997 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_