### PR TITLE
feat(go-template): bake object/struct-array signal inits from the IR tree (Roadmap A-4)

### DIFF
--- a/.changeset/parsed-literal-objects.md
+++ b/.changeset/parsed-literal-objects.md
@@ -1,0 +1,15 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Lower object / struct-array signal initial values from the carried IR tree too
+(Roadmap A-4). `parsedLiteralToGo` now bakes an object literal against a
+concrete local struct — mirroring `tsLiteralToGo`'s object branch (Go field
+names resolved from the struct's field map, deferring on an unknown struct, an
+undeclared key, or a nested object/array value). Combined with A-3's scalar
+support, every fully-literal signal-array init (`createSignal<Item[]>([{ id:
+"a" }])`, untyped synthesised-struct arrays, scalar arrays) now bakes from the
+structured tree instead of re-parsing the value string with
+`ts.createSourceFile`, which stays the fallback only for shapes the tree can't
+represent (`as const`, calls, identifiers). Byte-identical — verified by the Go
+adapter struct/scalar bake unit tests + conformance suite.

--- a/packages/adapter-go-template/src/adapter/value/parsed-literal-to-go.ts
+++ b/packages/adapter-go-template/src/adapter/value/parsed-literal-to-go.ts
@@ -4,9 +4,12 @@
  * so the signal-init bake can read the tree instead of re-parsing the value
  * string with `ts.createSourceFile`.
  *
- * The contract is **null-means-defer**: this returns null for anything it does
- * not reproduce exactly (object literals — whose struct-field baking lives in
- * `tsLiteralToGo`; empty arrays; identifiers / calls; or a numeric literal
+ * Covers scalar literals, a unary-minus number, arrays of those, and object
+ * literals baked against a concrete local struct (capitalised field names from
+ * the struct's field map). The contract is **null-means-defer**: this returns
+ * null for anything it does not reproduce exactly (an object whose target type
+ * isn't a known struct, a key the struct doesn't declare, a nested object /
+ * array property value, empty arrays, identifiers / calls, or a numeric literal
  * whose raw spelling wasn't carried). The caller then falls back to the
  * `ts.createSourceFile` path, so only the shapes reproduced here short-circuit
  * and behaviour stays byte-identical.
@@ -69,6 +72,31 @@ export function parsedLiteralToGo(
     return `${sliceHeader}{${elems.join(', ')}}`
   }
 
-  // object-literal / identifier / call / member / … → defer.
+  if (expr.kind === 'object-literal') {
+    // Bake against a concrete local struct only — mirror `tsLiteralToGo`'s
+    // object branch exactly. The struct's field map is the source of truth for
+    // the Go field name of each source key (and, by omission, which keys it
+    // declares); bail (→ defer) when the target type isn't a known struct.
+    const goType = typeInfo ? typeInfoToGo(ctx, typeInfo) : 'interface{}'
+    const structFields = ctx.state.localStructFields.get(goType)
+    if (!structFields) return null
+    const entries: string[] = []
+    for (const prop of expr.properties) {
+      // A shorthand `{ a }` carries an identifier value (not a literal); it
+      // lowers to null below and defers the whole object — matching
+      // `tsLiteralToGo`, which refuses a `ShorthandPropertyAssignment`.
+      const goField = structFields.get(prop.key)
+      if (!goField) return null
+      // Nested object / array property values aren't baked here (their field
+      // types aren't tracked) — defer, exactly as `tsLiteralToGo` does.
+      if (prop.value.kind === 'object-literal' || prop.value.kind === 'array-literal') return null
+      const go = parsedLiteralToGo(ctx, prop.value)
+      if (go === null) return null
+      entries.push(`${goField}: ${go}`)
+    }
+    return `${goType}{${entries.join(', ')}}`
+  }
+
+  // identifier / call / member / … → defer.
   return null
 }


### PR DESCRIPTION
## Roadmap A-4 — bake object/struct-array signal inits from the IR tree

Stacked on #1999 (A-3). Extends A-3's `parsedLiteralToGo` so the **object/struct** shapes lower from the carried tree too, completing structural coverage for literal signal-array inits.

### What it does
`parsedLiteralToGo` now bakes an object literal against a concrete local struct, **mirroring `tsLiteralToGo`'s object branch exactly**:
- Go field names resolved from the struct's field map (`state.localStructFields`).
- Defers (returns `null`) on an unknown struct type, a key the struct doesn't declare, or a nested object/array property value — the same bail conditions as `tsLiteralToGo`.

Combined with A-3 (scalars), every fully-literal signal-array init now bakes from the structured tree instead of re-parsing with `ts.createSourceFile`:
- `createSignal<Item[]>([{ id: "a" }, { id: "b" }])` → `[]Item{Item{ID: "a"}, Item{ID: "b"}}`
- untyped synthesised-struct arrays (#1680) and scalar arrays — all structural.

`ts.createSourceFile` remains the fallback only for shapes the tree can't represent (`as const`, calls, identifiers, nested object/array fields).

### Why it's byte-identical
The object branch is a line-for-line port of `tsLiteralToGo`'s (same field-map lookup, same nested-value bail, same `${goType}{…}` shape), and array elements thread `elemType` identically. The existing struct/scalar bake tests (typed `Item[]`, untyped synthesised struct, nested-array-field bail, negative numbers) and the conformance suite exercise these paths.

### Verification
go 556 unit · **conformance 786** · `tsgo` + `biome` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_