### PR TITLE
docs(go-template): clarify literal `raw` wording, fix A-4 changeset code span

### DIFF
--- a/.changeset/parsed-literal-objects.md
+++ b/.changeset/parsed-literal-objects.md
@@ -7,9 +7,10 @@ Lower object / struct-array signal initial values from the carried IR tree too
 concrete local struct — mirroring `tsLiteralToGo`'s object branch (Go field
 names resolved from the struct's field map, deferring on an unknown struct, an
 undeclared key, or a nested object/array value). Combined with A-3's scalar
-support, every fully-literal signal-array init (`createSignal<Item[]>([{ id:
-"a" }])`, untyped synthesised-struct arrays, scalar arrays) now bakes from the
-structured tree instead of re-parsing the value string with
+support, every fully-literal signal-array init — a typed struct array
+`createSignal<Item[]>([{ id: "a" }])`, an untyped synthesised-struct array, or a
+scalar array — now bakes from the structured tree instead of re-parsing the
+value string with
 `ts.createSourceFile`, which stays the fallback only for shapes the tree can't
 represent (`as const`, calls, identifiers). Byte-identical — verified by the Go
 adapter struct/scalar bake unit tests + conformance suite.

--- a/packages/adapter-go-template/src/adapter/value/parsed-literal-to-go.ts
+++ b/packages/adapter-go-template/src/adapter/value/parsed-literal-to-go.ts
@@ -10,7 +10,8 @@
  * null for anything it does not reproduce exactly (an object whose target type
  * isn't a known struct, a key the struct doesn't declare, a nested object /
  * array property value, empty arrays, identifiers / calls, or a numeric literal
- * whose raw spelling wasn't carried). The caller then falls back to the
+ * that didn't carry its `raw` token — the normalised `ts.NumericLiteral.text`,
+ * not the verbatim source spelling). The caller then falls back to the
  * `ts.createSourceFile` path, so only the shapes reproduced here short-circuit
  * and behaviour stays byte-identical.
  */


### PR DESCRIPTION
## Follow-up to #2000 review (docs only)

Addresses the two Copilot comments on the merged #2000:

1. **`parsed-literal-to-go.ts` header** — the "defer" list called the numeric literal's `raw` its *"raw spelling"*, but `raw` is the TS-**normalized** `ts.NumericLiteral.text` (`0x10` → `16`, `1e3` → `1000`), not the verbatim source. Reworded to match the `ParsedExpr.literal.raw` type definition and avoid confusion when reasoning about byte-identical output. ([thread](https://github.com/piconic-ai/barefootjs/pull/2000#discussion_r3478812031))
2. **`.changeset/parsed-literal-objects.md`** — the inline-code span for the `createSignal<Item[]>([{ id: "a" }])` example wrapped across a source line with an unbalanced backtick, rendering incorrectly. Rebalanced onto one span. ([thread](https://github.com/piconic-ai/barefootjs/pull/2000#discussion_r3478812041))

No behavior change — comments + changeset prose only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_