### PR TITLE
refactor(jsx,go-template): make memo-type.ts parse-free via the IR (terminal sweep 1)

### DIFF
--- a/.changeset/memo-template-classify.md
+++ b/.changeset/memo-template-classify.md
@@ -3,13 +3,21 @@
 "@barefootjs/go-template": patch
 ---
 
-Classify a memo's template-literal body on the IR (`MemoInfo.bodyIsTemplateLiteral`)
-instead of in the Go adapter. The analyzer sets the flag from the real arrow AST
-node at analysis time; the Go adapter's `inferMemoType` reads it rather than
-re-parsing `computation` with `ts.createSourceFile` (the `isTemplateLiteralMemo`
-helper is removed). A no-substitution `` `plain` `` template folds to a plain
-string `ParsedExpr` literal, so a dedicated boolean — not a `parsed.kind` check —
-preserves the backtick distinction. Byte-identical (analyzer logic mirrors the
-former adapter predicate on the same source); verified by the Go adapter unit +
-conformance suites. Advances the constitution's "no expression parsing in
-adapters" rule by moving the classification to Phase 1.
+Make `memo/memo-type.ts` parse-free by classifying memo bodies from the IR
+instead of re-parsing `computation` with `ts.createSourceFile`:
+
+- `MemoInfo.bodyIsTemplateLiteral` — the analyzer sets this from the real arrow
+  AST node; `inferMemoType` reads it instead of the removed `isTemplateLiteralMemo`
+  helper. A no-substitution `` `plain` `` template folds to a plain string
+  `ParsedExpr` literal, so a dedicated boolean (not a `parsed.kind` check)
+  preserves the backtick distinction.
+- `isStringTernaryMemo` now reads the analyzer-carried `MemoInfo.parsed`
+  conditional tree (the `moduleStringConsts` membership check stays a plain Set
+  lookup in the adapter). A block-bodied memo has no `parsed`, so it returns
+  false — matching the former predicate, which never descended a block.
+
+Byte-identical (the analyzer logic mirrors the former adapter predicates over
+the same source); verified by go unit (556) + conformance (786). Drops the
+adapter's package-wide `ts.createSourceFile` count from 8 to 6 and advances the
+constitution's "no expression parsing in adapters" rule by moving the
+classification to Phase 1.

--- a/.changeset/memo-template-classify.md
+++ b/.changeset/memo-template-classify.md
@@ -1,0 +1,15 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+---
+
+Classify a memo's template-literal body on the IR (`MemoInfo.bodyIsTemplateLiteral`)
+instead of in the Go adapter. The analyzer sets the flag from the real arrow AST
+node at analysis time; the Go adapter's `inferMemoType` reads it rather than
+re-parsing `computation` with `ts.createSourceFile` (the `isTemplateLiteralMemo`
+helper is removed). A no-substitution `` `plain` `` template folds to a plain
+string `ParsedExpr` literal, so a dedicated boolean — not a `parsed.kind` check —
+preserves the backtick distinction. Byte-identical (analyzer logic mirrors the
+former adapter predicate on the same source); verified by the Go adapter unit +
+conformance suites. Advances the constitution's "no expression parsing in
+adapters" rule by moving the classification to Phase 1.

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -2385,7 +2385,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * Infer the Go type for a memo based on its computation and dependencies.
    */
   private inferMemoType(
-    memo: { name: string; computation: string; type: TypeInfo; deps: string[]; bodyIsTemplateLiteral?: boolean },
+    memo: { name: string; computation: string; type: TypeInfo; deps: string[]; bodyIsTemplateLiteral?: boolean; parsed?: ParsedExpr },
     signals: { getter: string; initialValue: string; type: TypeInfo }[],
     propsParamMap: Map<string, { name: string; type: TypeInfo; defaultValue?: string }>
   ): string {
@@ -2432,7 +2432,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // string even though its condition has `===`. Decide before the boolean
     // heuristic so it's typed `string` (zero value `""`), not `interface{}`
     // (whose nil zero renders `<nil>`).
-    if (typeInfoToGo(this.emitCtx, memo.type) === 'interface{}' && isStringTernaryMemo(this.emitCtx, memo.computation)) {
+    if (typeInfoToGo(this.emitCtx, memo.type) === 'interface{}' && isStringTernaryMemo(this.emitCtx, memo.parsed)) {
       return 'string'
     }
     if (typeInfoToGo(this.emitCtx, memo.type) === 'interface{}' && isBooleanMemo(this.emitCtx, memo, signals, propsParamMap)) {

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -114,7 +114,7 @@ import {
   objectLiteralToGoMap,
 } from "./value/value-lowering.ts"
 import { typeInfoToGo } from "./type/type-codegen.ts"
-import { isTemplateLiteralMemo, isBooleanMemo, isStringTernaryMemo } from "./memo/memo-type.ts"
+import { isBooleanMemo, isStringTernaryMemo } from "./memo/memo-type.ts"
 import { lowerCtorExpr } from "./memo/ctor-lowering.ts"
 import { resolveBlockBodyMemoModuleConst } from "./memo/memo-value.ts"
 import { computeMemoInitialValue, computeMemoInitialValueOrNull } from "./memo/memo-compute.ts"
@@ -2385,14 +2385,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * Infer the Go type for a memo based on its computation and dependencies.
    */
   private inferMemoType(
-    memo: { name: string; computation: string; type: TypeInfo; deps: string[] },
+    memo: { name: string; computation: string; type: TypeInfo; deps: string[]; bodyIsTemplateLiteral?: boolean },
     signals: { getter: string; initialValue: string; type: TypeInfo }[],
     propsParamMap: Map<string, { name: string; type: TypeInfo; defaultValue?: string }>
   ): string {
     // A template-literal memo always produces a string. Decide this first so a
     // class-string `/` (e.g. `ring-ring/50`) doesn't trip the arithmetic
-    // heuristic below into `int`.
-    if (isTemplateLiteralMemo(memo.computation)) return 'string'
+    // heuristic below into `int`. The analyzer classified the body shape from
+    // the real arrow AST (`MemoInfo.bodyIsTemplateLiteral`), so no re-parse here.
+    if (memo.bodyIsTemplateLiteral) return 'string'
 
     // Check if computation involves multiplication (*) - likely number
     if (memo.computation.includes('*') || memo.computation.includes('/') ||

--- a/packages/adapter-go-template/src/adapter/memo/memo-type.ts
+++ b/packages/adapter-go-template/src/adapter/memo/memo-type.ts
@@ -5,7 +5,8 @@
  * computation so `inferMemoType` can pick the right Go field type (and thus the
  * right SSR zero value). They read the context's `state.moduleStringConsts`,
  * `extractPropNameFromInitialValue`, and `typeInfoToGo` from the type-codegen
- * module. `isTemplateLiteralMemo` is fully pure (no context).
+ * module. (Template-literal classification now rides on the IR as
+ * `MemoInfo.bodyIsTemplateLiteral`, set by the analyzer, so it isn't here.)
  */
 
 import ts from 'typescript'
@@ -14,30 +15,6 @@ import type { TypeInfo } from '@barefootjs/jsx'
 
 import type { GoEmitContext } from '../emit-context.ts'
 import { typeInfoToGo } from '../type/type-codegen.ts'
-
-export function isTemplateLiteralMemo(computation: string): boolean {
-  const sf = ts.createSourceFile(
-    '__memo.ts', `const __x = (${computation});`, ts.ScriptTarget.Latest, /*setParentNodes*/ false,
-  )
-  const stmt = sf.statements[0]
-  if (!stmt || !ts.isVariableStatement(stmt)) return false
-  let init = stmt.declarationList.declarations[0]?.initializer
-  while (init && ts.isParenthesizedExpression(init)) init = init.expression
-  if (!init || !ts.isArrowFunction(init)) return false
-  let body = init.body as ts.Node
-  while (ts.isParenthesizedExpression(body as ts.Expression)) {
-    body = (body as ts.ParenthesizedExpression).expression
-  }
-  if (ts.isBlock(body)) {
-    const ret = body.statements.find(ts.isReturnStatement)
-    if (!ret || !ret.expression) return false
-    body = ret.expression
-    while (ts.isParenthesizedExpression(body as ts.Expression)) {
-      body = (body as ts.ParenthesizedExpression).expression
-    }
-  }
-  return ts.isTemplateExpression(body) || ts.isNoSubstitutionTemplateLiteral(body)
-}
 
 /**
  * (#checkbox) Heuristic: does this memo evaluate to a boolean? True when its

--- a/packages/adapter-go-template/src/adapter/memo/memo-type.ts
+++ b/packages/adapter-go-template/src/adapter/memo/memo-type.ts
@@ -9,9 +9,7 @@
  * `MemoInfo.bodyIsTemplateLiteral`, set by the analyzer, so it isn't here.)
  */
 
-import ts from 'typescript'
-
-import type { TypeInfo } from '@barefootjs/jsx'
+import type { ParsedExpr, TypeInfo } from '@barefootjs/jsx'
 
 import type { GoEmitContext } from '../emit-context.ts'
 import { typeInfoToGo } from '../type/type-codegen.ts'
@@ -24,7 +22,7 @@ import { typeInfoToGo } from '../type/type-codegen.ts'
  */
 export function isBooleanMemo(
   ctx: GoEmitContext,
-  memo: { computation: string; deps: string[] },
+  memo: { computation: string; deps: string[]; parsed?: ParsedExpr },
   signals: { getter: string; initialValue: string; type: TypeInfo }[],
   propsParamMap: Map<string, { name: string; type: TypeInfo; defaultValue?: string }>,
 ): boolean {
@@ -34,7 +32,7 @@ export function isBooleanMemo(
   // not boolean — the `===` lives in the *condition*, so the blanket
   // comparison check below would misclassify it as bool and bake `false`
   // (#1971 carousel `directionClasses`). Bail before that check.
-  if (isStringTernaryMemo(ctx, c)) return false
+  if (isStringTernaryMemo(ctx, memo.parsed)) return false
   if (/(!==|===|!=(?!=)|==(?!=))/.test(c)) return true
   if (/=>\s*!/.test(c)) return true
   // Ternary `() => cond() ? a() : b()` — boolean when both branches are
@@ -63,36 +61,24 @@ export function isBooleanMemo(
 
 /**
  * (#1971) Does this memo's arrow body resolve to a string-valued ternary
- * whose BOTH branches are string literals — e.g. `() => orientation() ===
+ * whose BOTH branches are string-valued — e.g. `() => orientation() ===
  * 'vertical' ? 'flex-col -mt-4' : 'flex -ml-4'`? Such a memo is a string,
- * not a bool, even though its condition contains `===`. AST-based (the
- * repo idiom) so quotes inside class strings don't trip a regex.
+ * not a bool, even though its condition contains `===`.
+ *
+ * Reads the analyzer-carried body tree (`MemoInfo.parsed`) instead of
+ * re-parsing `computation`. A block-bodied memo has no `parsed`, so it returns
+ * false — matching the former predicate, which only inspected an expression
+ * body and never descended a block. A no-substitution `` `lit` `` branch folds
+ * to a plain string literal in `ParsedExpr`, which `isStr` accepts just as the
+ * old `isNoSubstitutionTemplateLiteral` check did, so output is unchanged.
  */
-export function isStringTernaryMemo(ctx: GoEmitContext, computation: string): boolean {
-  try {
-    const sf = ts.createSourceFile(
-      '__memo.ts',
-      `const __x = (${computation});`,
-      ts.ScriptTarget.Latest,
-      false,
-    )
-    const stmt = sf.statements[0]
-    if (!stmt || !ts.isVariableStatement(stmt)) return false
-    let init = stmt.declarationList.declarations[0]?.initializer
-    while (init && ts.isParenthesizedExpression(init)) init = init.expression
-    if (!init || !ts.isArrowFunction(init)) return false
-    let body: ts.Node = init.body
-    while (ts.isParenthesizedExpression(body)) body = body.expression
-    if (!ts.isConditionalExpression(body)) return false
-    // A branch is string-valued when it's a string/template literal or an
-    // identifier bound to a module-scope string const (carousel's
-    // `positionClasses` → `prevVerticalClasses`/`prevHorizontalClasses`).
-    const isStr = (n: ts.Expression): boolean =>
-      ts.isStringLiteral(n) ||
-      ts.isNoSubstitutionTemplateLiteral(n) ||
-      (ts.isIdentifier(n) && ctx.state.moduleStringConsts.has(n.text))
-    return isStr(body.whenTrue) && isStr(body.whenFalse)
-  } catch {
-    return false
-  }
+export function isStringTernaryMemo(ctx: GoEmitContext, parsed: ParsedExpr | undefined): boolean {
+  if (!parsed || parsed.kind !== 'conditional') return false
+  // A branch is string-valued when it's a string literal or an identifier
+  // bound to a module-scope string const (carousel's `positionClasses` →
+  // `prevVerticalClasses` / `prevHorizontalClasses`).
+  const isStr = (n: ParsedExpr): boolean =>
+    (n.kind === 'literal' && n.literalType === 'string') ||
+    (n.kind === 'identifier' && ctx.state.moduleStringConsts.has(n.name))
+  return isStr(parsed.consequent) && isStr(parsed.alternate)
 }

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -1348,6 +1348,28 @@ function isMemoDeclaration(node: ts.VariableDeclaration, ctx: AnalyzerContext): 
   return resolvePrimitiveKind(node.initializer, ctx) === 'memo'
 }
 
+/**
+ * Does the memo arrow's effective body resolve to a template literal? Mirrors
+ * the Go adapter's former `isTemplateLiteralMemo` (which re-parsed `computation`
+ * with `ts.createSourceFile`) but runs on the real arrow node at analysis time:
+ * unwrap parens, descend a block body to its first `return`, and check for a
+ * template expression / no-substitution template literal.
+ */
+function memoBodyIsTemplateLiteral(memoArrow: ts.Expression | undefined): boolean {
+  let node: ts.Node | undefined = memoArrow
+  while (node && ts.isParenthesizedExpression(node)) node = node.expression
+  if (!node || !ts.isArrowFunction(node)) return false
+  let body: ts.Node = node.body
+  while (ts.isParenthesizedExpression(body)) body = body.expression
+  if (ts.isBlock(body)) {
+    const ret = body.statements.find(ts.isReturnStatement)
+    if (!ret || !ret.expression) return false
+    body = ret.expression
+    while (ts.isParenthesizedExpression(body)) body = body.expression
+  }
+  return ts.isTemplateExpression(body) || ts.isNoSubstitutionTemplateLiteral(body)
+}
+
 function collectMemo(node: ts.VariableDeclaration, ctx: AnalyzerContext): void {
   const name = (node.name as ts.Identifier).text
   const callExpr = node.initializer as ts.CallExpression
@@ -1425,6 +1447,7 @@ function collectMemo(node: ts.VariableDeclaration, ctx: AnalyzerContext): void {
     computation,
     typedComputation: typedComputation !== computation ? typedComputation : undefined,
     parsed,
+    bodyIsTemplateLiteral: memoBodyIsTemplateLiteral(memoArrow),
     type,
     deps,
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -1136,6 +1136,16 @@ export interface MemoInfo {
    * consumers must fall back to `computation` when it's missing.
    */
   parsed?: ParsedExpr
+  /**
+   * Whether the memo's effective body is a template literal (`() => `…`` or a
+   * block body whose first `return` is one), classified once at analysis time
+   * from the real arrow AST. Lets the Go adapter pick the `string` field type
+   * without re-parsing `computation` with `ts.createSourceFile`. A template
+   * literal — including a no-substitution `` `plain` `` — folds to a plain
+   * string `ParsedExpr` literal, losing the backtick distinction, so this is a
+   * dedicated flag rather than a `parsed.kind` check.
+   */
+  bodyIsTemplateLiteral?: boolean
   type: TypeInfo
   deps: string[]
   loc: SourceLocation


### PR DESCRIPTION
## Terminal sweep (1/N) — `memo/memo-type.ts` is now parse-free

First unit of the remaining "drive adapter `ts.createSourceFile`/regex → 0" work following the merged Roadmap A. The constitution forbids parsing in **adapters**, not in the analyzer (Phase 1) — so the fix is to **classify in the analyzer and carry the result on the IR**, then have the adapter read it.

Both `ts.createSourceFile` calls in `memo-type.ts` are eliminated:

### 1. `isTemplateLiteralMemo` → `MemoInfo.bodyIsTemplateLiteral`
The analyzer classifies the memo's effective body (expression body, or a block body's first `return`) as a template literal, directly from the **real arrow AST node**; `inferMemoType` reads the flag. The helper is removed.

A no-substitution `` `plain` `` template folds to a plain string `ParsedExpr` literal (`literalType: 'string'`), losing the backtick distinction the predicate relied on — so this is a dedicated boolean computed from the AST, not a `parsed.kind` check.

### 2. `isStringTernaryMemo` → reads `MemoInfo.parsed`
Now inspects the analyzer-carried `conditional` tree instead of re-parsing. The `moduleStringConsts` membership check stays a plain `Set` lookup in the adapter (not parsing). A block-bodied memo has no `parsed` → returns `false`, exactly matching the former predicate, which never descended a block body. The backtick fold is harmless here since `isStr` accepted both string-literal and no-sub-template.

### Byte-identical
Analyzer logic mirrors the former adapter predicates over the same (type-stripped) source. Conformance **786** and go units **556** green; the carousel class/direction memos still infer `string`.

**Effect:** adapter-wide `ts.createSourceFile` count **8 → 6**. (Remaining: block-body memo value analysis, the shared literal parser, spread/computed object maps, the static-record fallback — tracked for follow-up units.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)