### PR TITLE
refactor(jsx,go-template): lower spread signal object-map from the IR tree (terminal sweep 3)

### DIFF
--- a/.changeset/spread-objmap-parsed.md
+++ b/.changeset/spread-objmap-parsed.md
@@ -1,0 +1,17 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+---
+
+Lower a spread bag's signal object-literal initial value (`{...attrs()}` where
+`attrs` is `createSignal({ ... })`) from the carried IR tree instead of
+re-parsing with `ts.createSourceFile`. The analyzer now parenthesises a signal's
+`initialValue` before parsing (`(${initialValue})`), so a bare object-literal
+init resolves to an `object-literal` `ParsedExpr` rather than being read as a
+block — `parseExpression` unwraps the parens, so array / scalar / prop-ref inits
+(the existing consumers) are unchanged. The Go spread codegen reads
+`signal.parsed` via a new `parsedObjectLiteralToGoMap`; a non-object / spread /
+computed init leaves `parsed` absent or non-object, returning null exactly as
+the former string parser did. Byte-identical — verified by go unit (556),
+conformance (786), and jsx unit (2216). Drops the adapter's package-wide
+`ts.createSourceFile` count by one.

--- a/.changeset/spread-objmap-parsed.md
+++ b/.changeset/spread-objmap-parsed.md
@@ -15,3 +15,9 @@ computed init leaves `parsed` absent or non-object, returning null exactly as
 the former string parser did. Byte-identical — verified by go unit (556),
 conformance (786), and jsx unit (2216). Drops the adapter's package-wide
 `ts.createSourceFile` count by one.
+
+Also adds an optional `ObjectLiteralProperty.keyKind` (`identifier` / `string` /
+`numeric`) to the shared `ParsedExpr` so the spread lowering can keep rejecting
+numeric object keys (`{ 1: 'a' }`) exactly as the former parser did — `key`
+normalises numeric and string keys to the same text. Additive and optional;
+other consumers ignore it.

--- a/packages/adapter-go-template/src/adapter/spread/spread-codegen.ts
+++ b/packages/adapter-go-template/src/adapter/spread/spread-codegen.ts
@@ -158,6 +158,10 @@ function parsedObjectLiteralToGoMap(parsed: ParsedExpr | undefined): string | nu
   if (!parsed || parsed.kind !== 'object-literal') return null
   const entries: string[] = []
   for (const prop of parsed.properties) {
+    // A numeric key (`{ 1: 'a' }`) was rejected by the former parser (only
+    // identifier / string keys were accepted), so keep refusing it — `key`
+    // alone can't distinguish it from a string `'1'` key, hence `keyKind`.
+    if (prop.keyKind === 'numeric') return null
     const v = prop.value
     let goVal: string
     if (v.kind === 'literal' && v.literalType === 'string') {

--- a/packages/adapter-go-template/src/adapter/spread/spread-codegen.ts
+++ b/packages/adapter-go-template/src/adapter/spread/spread-codegen.ts
@@ -25,6 +25,7 @@ import type {
   IRComponent,
   IRProvider,
   IRAsync,
+  ParsedExpr,
 } from '@barefootjs/jsx'
 
 import type { GoEmitContext } from '../emit-context.ts'
@@ -142,62 +143,46 @@ function collectSpreadSlotsRecursive(ctx: GoEmitContext, node: IRNode, result: S
 }
 
 /**
- * Parse a JS object-literal source text (the raw string captured
- * for a signal's `initialValue` or a spread expression's argument)
- * into a Go `map[string]any{...}` literal source (#1407).
+ * Lower a signal's carried object-literal initial value (`MemoInfo`-style
+ * `SignalInfo.parsed`) into a Go `map[string]any{...}` literal source (#1407),
+ * instead of re-parsing the `initialValue` string with `ts.createSourceFile`.
  *
- * Supports a deliberately conservative subset so the Go output is
- * a 1:1 translation of the JS source: string/number/boolean/null
- * values keyed by identifier or string-literal keys. Returns null
- * for unsupported shapes (nested objects, computed values,
- * function calls, spread elements) — callers fall back to BF101.
+ * Supports a deliberately conservative subset so the Go output is a 1:1
+ * translation of the source: string/number/boolean/null values (and a
+ * signed-number `{count: -1}`) keyed by identifier or string-literal keys.
+ * Returns null for any other shape — a non-object init (`parsed` absent or not
+ * an `object-literal`), a shorthand / nested-object / computed / call value —
+ * so callers fall back to BF101.
  */
-function parseJsObjectLiteralToGoMap(jsText: string): string | null {
-  const sf = ts.createSourceFile('inline.ts', `(${jsText})`, ts.ScriptTarget.Latest, true)
-  if (sf.statements.length !== 1) return null
-  const stmt = sf.statements[0]
-  if (!ts.isExpressionStatement(stmt)) return null
-  let expr: ts.Expression = stmt.expression
-  while (ts.isParenthesizedExpression(expr)) expr = expr.expression
-  if (!ts.isObjectLiteralExpression(expr)) return null
+function parsedObjectLiteralToGoMap(parsed: ParsedExpr | undefined): string | null {
+  if (!parsed || parsed.kind !== 'object-literal') return null
   const entries: string[] = []
-  for (const prop of expr.properties) {
-    if (!ts.isPropertyAssignment(prop)) return null
-    let key: string
-    if (ts.isIdentifier(prop.name)) {
-      key = prop.name.text
-    } else if (ts.isStringLiteral(prop.name) || ts.isNoSubstitutionTemplateLiteral(prop.name)) {
-      key = prop.name.text
-    } else {
-      return null
-    }
-    const val = prop.initializer
+  for (const prop of parsed.properties) {
+    const v = prop.value
     let goVal: string
-    if (ts.isStringLiteral(val) || ts.isNoSubstitutionTemplateLiteral(val)) {
-      goVal = JSON.stringify(val.text)
-    } else if (ts.isNumericLiteral(val)) {
-      goVal = val.text
+    if (v.kind === 'literal' && v.literalType === 'string') {
+      goVal = JSON.stringify(v.value)
+    } else if (v.kind === 'literal' && v.literalType === 'number') {
+      // `raw` is the exact numeric token; `value` is the fallback.
+      goVal = v.raw ?? String(v.value)
     } else if (
-      // TypeScript parses `-1` and `+1` as `PrefixUnaryExpression`
-      // rather than `NumericLiteral` — accept both signs explicitly
-      // so a bag like `{count: -1}` doesn't collapse to BF101
-      // (#1411 review).
-      ts.isPrefixUnaryExpression(val)
-      && (val.operator === ts.SyntaxKind.MinusToken || val.operator === ts.SyntaxKind.PlusToken)
-      && ts.isNumericLiteral(val.operand)
+      // `-1` / `+1` parse as a unary expression over a numeric literal — accept
+      // both signs so a bag like `{count: -1}` doesn't collapse to BF101.
+      v.kind === 'unary'
+      && (v.op === '-' || v.op === '+')
+      && v.argument.kind === 'literal'
+      && v.argument.literalType === 'number'
     ) {
-      const sign = val.operator === ts.SyntaxKind.MinusToken ? '-' : ''
-      goVal = `${sign}${val.operand.text}`
-    } else if (val.kind === ts.SyntaxKind.TrueKeyword) {
-      goVal = 'true'
-    } else if (val.kind === ts.SyntaxKind.FalseKeyword) {
-      goVal = 'false'
-    } else if (val.kind === ts.SyntaxKind.NullKeyword) {
+      const sign = v.op === '-' ? '-' : ''
+      goVal = `${sign}${v.argument.raw ?? String(v.argument.value)}`
+    } else if (v.kind === 'literal' && v.literalType === 'boolean') {
+      goVal = v.value ? 'true' : 'false'
+    } else if (v.kind === 'literal' && v.literalType === 'null') {
       goVal = 'nil'
     } else {
       return null
     }
-    entries.push(`${JSON.stringify(key)}: ${goVal}`)
+    entries.push(`${JSON.stringify(prop.key)}: ${goVal}`)
   }
   return `map[string]any{${entries.join(', ')}}`
 }
@@ -251,7 +236,7 @@ export function buildSpreadInitializer(
     const getterName = callMatch[1]
     const signal = ir.metadata.signals.find(s => s.getter === getterName)
     if (signal && signal.initialValue) {
-      const goMap = parseJsObjectLiteralToGoMap(signal.initialValue)
+      const goMap = parsedObjectLiteralToGoMap(signal.parsed)
       if (goMap) return goMap
     }
     return null

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -320,6 +320,18 @@ describe('expression-parser', () => {
       }
     })
 
+    test('records the key kind so numeric and string keys are distinguishable', () => {
+      const result = parseExpression('({ a: 1, "1": 2, 3: 4 })')
+      expect(result.kind).toBe('object-literal')
+      if (result.kind === 'object-literal') {
+        // `key` normalises all three to a string ('a' / '1' / '3'), but
+        // `keyKind` keeps `{ '1': … }` (string) distinct from `{ 3: … }`
+        // (numeric) — a consumer that rejects numeric keys needs this.
+        expect(result.properties.map(p => p.key)).toEqual(['a', '1', '3'])
+        expect(result.properties.map(p => p.keyKind)).toEqual(['identifier', 'string', 'numeric'])
+      }
+    })
+
     test('parses shorthand object literal, expanding `{ a }` to `a: a`', () => {
       const result = parseExpression('({ a, b: 2 })')
       expect(result.kind).toBe('object-literal')

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -264,13 +264,16 @@ export function analyzeComponent(
 
   // Roadmap A: carry a best-effort structured parse of each signal's initial
   // value so adapters lower a literal init (`useState(['a', 'b'])`) from the
-  // tree instead of re-parsing the string with `ts.createSourceFile`. Parse
-  // the SAME (type-stripped) `initialValue` the adapter consumes; an
-  // unsupported shape leaves `parsed` undefined and the adapter falls back.
-  // Runs after `scanImportedClientSignals` so imported signals are covered too.
+  // tree instead of re-parsing the string with `ts.createSourceFile`. The value
+  // is parenthesised before parsing so a bare object-literal init
+  // (`createSignal({ a: 1 })`) resolves to an `object-literal` rather than being
+  // read as a block statement; `parseExpression` unwraps the parens, so arrays /
+  // scalars / prop refs are unchanged. An unsupported shape leaves `parsed`
+  // undefined and the adapter falls back. Runs after `scanImportedClientSignals`
+  // so imported signals are covered too.
   for (const signal of ctx.signals) {
     if (!signal.initialValue) continue
-    const parsed = parseExpression(signal.initialValue)
+    const parsed = parseExpression(`(${signal.initialValue})`)
     if (parsed.kind !== 'unsupported') signal.parsed = parsed
   }
 

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -158,6 +158,11 @@ export type ParsedExpr =
  */
 export type ObjectLiteralProperty = {
   key: string
+  // The syntactic kind of the key, since `key` normalises all three to a
+  // string and so loses the distinction. A consumer that must treat a numeric
+  // key (`{ 1: 'a' }`) differently from a same-text string key (`{ '1': 'a' }`)
+  // reads this; most consumers ignore it. `identifier` for shorthand.
+  keyKind?: 'identifier' | 'string' | 'numeric'
   // Shorthand `{ a }` (the value is the identifier `a`) vs explicit
   // `{ a: <value> }`. The `value` already carries the resolved tree
   // either way; this flag is kept for re-stringification fidelity.
@@ -713,10 +718,12 @@ export function parseExpression(expr: string): ParsedExpr {
  * (`[expr]`) or otherwise non-plain key returns null so the caller treats
  * the whole literal as `unsupported`.
  */
-function objectLiteralKeyName(name: ts.PropertyName): string | null {
-  if (ts.isIdentifier(name)) return name.text
-  if (ts.isStringLiteral(name)) return name.text
-  if (ts.isNumericLiteral(name)) return name.text
+function objectLiteralKeyName(
+  name: ts.PropertyName,
+): { key: string; keyKind: 'identifier' | 'string' | 'numeric' } | null {
+  if (ts.isIdentifier(name)) return { key: name.text, keyKind: 'identifier' }
+  if (ts.isStringLiteral(name)) return { key: name.text, keyKind: 'string' }
+  if (ts.isNumericLiteral(name)) return { key: name.text, keyKind: 'numeric' }
   return null
 }
 
@@ -1199,12 +1206,12 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
     const properties: ObjectLiteralProperty[] = []
     for (const prop of node.properties) {
       if (ts.isPropertyAssignment(prop)) {
-        const key = objectLiteralKeyName(prop.name)
-        if (key === null) return { kind: 'unsupported', raw, reason: `Unsupported syntax: ${ts.SyntaxKind[node.kind]}` }
-        properties.push({ key, shorthand: false, value: convertNode(prop.initializer, raw) })
+        const k = objectLiteralKeyName(prop.name)
+        if (k === null) return { kind: 'unsupported', raw, reason: `Unsupported syntax: ${ts.SyntaxKind[node.kind]}` }
+        properties.push({ key: k.key, keyKind: k.keyKind, shorthand: false, value: convertNode(prop.initializer, raw) })
       } else if (ts.isShorthandPropertyAssignment(prop)) {
         const key = prop.name.text
-        properties.push({ key, shorthand: true, value: { kind: 'identifier', name: key } })
+        properties.push({ key, keyKind: 'identifier', shorthand: true, value: { kind: 'identifier', name: key } })
       } else {
         // Spread assignment, method, getter/setter — not a plain map.
         return { kind: 'unsupported', raw, reason: `Unsupported syntax: ${ts.SyntaxKind[node.kind]}` }


### PR DESCRIPTION
## Terminal sweep (3/N) — spread signal object-map from the IR

`{...attrs()}` where `attrs` is `createSignal({ ... })` previously re-parsed the signal's `initialValue` string with `ts.createSourceFile`. Now it reads the carried tree:

- **Analyzer** parenthesises a signal's `initialValue` before parsing (`(${initialValue})`), so a bare object-literal init resolves to an `object-literal` `ParsedExpr` rather than being read as a block statement. `parseExpression` unwraps the parens, so array / scalar / prop-ref inits — the existing `signal.parsed` consumers (only go's `convertInitialValue` array branch) — are unchanged.
- **Go spread codegen** reads `signal.parsed` via a new `parsedObjectLiteralToGoMap` (handles string / number / signed-number / bool / null values, identifier / string keys). A non-object / spread / computed init leaves `parsed` absent or non-object → returns null, exactly as the former string parser did.

### Byte-identical
Verified by go units (**556**), conformance (**786**), and jsx units (**2216**) — no other adapter reads `signal.parsed`, and the paren-wrap only newly affects object literals.

**Effect:** removes the `spread-codegen.ts` `ts.createSourceFile`. Independent of #2003 (different files); when both land the adapter-wide count reaches 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_