### PR TITLE
refactor(jsx,go-template): carry block-body memo statements on the IR (terminal sweep 4)

### DIFF
--- a/.changeset/memo-blockbody-guard.md
+++ b/.changeset/memo-blockbody-guard.md
@@ -1,0 +1,16 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+---
+
+Carry a block-bodied memo's statements on the IR (`MemoInfo.parsedBlock`) so the
+Go adapter can pattern-match block shapes without re-parsing `computation` with
+`ts.createSourceFile`. The analyzer attaches them via a new
+`parseBlockBodyTolerant` (best-effort: a statement the parser can't represent —
+e.g. a trailing `return /* @client */ …` — is omitted rather than failing the
+whole block, matching the adapter's former tolerant walk). The Go
+`resolveBlockBodyMemoModuleConst` (the `const k = getter(); if (!k) return CONST`
+guard memo, #1897) now reads `parsedBlock`. Additive and optional — other
+adapters ignore the field, and `parseBlockBody` (strict) is unchanged.
+Byte-identical, verified by go unit (556) + conformance (786). Removes the
+`memo-value.ts` `ts.createSourceFile`.

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -1765,8 +1765,8 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       if (memoName) {
         const memo = ir.metadata.memos.find(m => m.name === memoName)
         if (memo) {
-          const blockReturn = resolveBlockBodyMemoModuleConst(this.emitCtx, 
-            memo.computation, ir.metadata.signals,
+          const blockReturn = resolveBlockBodyMemoModuleConst(this.emitCtx,
+            memo.parsedBlock, ir.metadata.signals,
           )
           if (blockReturn) {
             const constant = (ir.metadata.localConstants ?? []).find(
@@ -2385,7 +2385,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * Infer the Go type for a memo based on its computation and dependencies.
    */
   private inferMemoType(
-    memo: { name: string; computation: string; type: TypeInfo; deps: string[]; bodyIsTemplateLiteral?: boolean; parsed?: ParsedExpr },
+    memo: { name: string; computation: string; type: TypeInfo; deps: string[]; bodyIsTemplateLiteral?: boolean; parsed?: ParsedExpr; parsedBlock?: ParsedStatement[] },
     signals: { getter: string; initialValue: string; type: TypeInfo }[],
     propsParamMap: Map<string, { name: string; type: TypeInfo; defaultValue?: string }>
   ): string {
@@ -2441,7 +2441,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
     // (#1897) Block-body memo returning a module-const array: use the
     // constant's array type instead of the memo's generic `object`.
-    const blockReturn = resolveBlockBodyMemoModuleConst(this.emitCtx, memo.computation, signals)
+    const blockReturn = resolveBlockBodyMemoModuleConst(this.emitCtx, memo.parsedBlock, signals)
     if (blockReturn?.constType?.kind === 'array') {
       return typeInfoToGo(this.emitCtx, blockReturn.constType)
     }

--- a/packages/adapter-go-template/src/adapter/memo/memo-compute.ts
+++ b/packages/adapter-go-template/src/adapter/memo/memo-compute.ts
@@ -12,7 +12,7 @@
 
 import ts from 'typescript'
 
-import type { ParsedExpr, TypeInfo } from '@barefootjs/jsx'
+import type { ParsedExpr, ParsedStatement, TypeInfo } from '@barefootjs/jsx'
 
 import type { GoEmitContext } from '../emit-context.ts'
 import type { PropFallbackVar } from '../lib/types.ts'
@@ -269,7 +269,7 @@ export function memoInitialFromParsedBody(
  */
 export function computeMemoInitialValueOrNull(
   ctx: GoEmitContext,
-  memo: { name: string; computation: string; deps: string[]; parsed?: ParsedExpr },
+  memo: { name: string; computation: string; deps: string[]; parsed?: ParsedExpr; parsedBlock?: ParsedStatement[] },
   signals: { getter: string; initialValue: string }[],
   propsParams: { name: string; type?: TypeInfo; defaultValue?: string }[],
   propFallbackVars: ReadonlyMap<string, PropFallbackVar> = EMPTY_PROP_FALLBACK_VARS,
@@ -323,7 +323,7 @@ export function computeMemoInitialValueOrNull(
   // null, the SSR value is the module-const array. The constant's literal
   // value (not the identifier) is passed to the baker so `jsLiteralToGo`
   // can reduce it to a Go slice.
-  const blockReturn = resolveBlockBodyMemoModuleConst(ctx, computation, signals)
+  const blockReturn = resolveBlockBodyMemoModuleConst(ctx, memo.parsedBlock, signals)
   if (blockReturn !== null && blockReturn.constValue && blockReturn.constType) {
     return convertInitialValue(ctx,
       blockReturn.constValue,

--- a/packages/adapter-go-template/src/adapter/memo/memo-value.ts
+++ b/packages/adapter-go-template/src/adapter/memo/memo-value.ts
@@ -12,7 +12,7 @@
 
 import ts from 'typescript'
 
-import type { TypeInfo } from '@barefootjs/jsx'
+import type { ParsedStatement, TypeInfo } from '@barefootjs/jsx'
 
 import type { GoEmitContext } from '../emit-context.ts'
 import type { CtorLowerEnv } from '../lib/types.ts'
@@ -27,96 +27,64 @@ import { lowerCtorExpr } from './ctor-lowering.ts'
  */
 export function resolveBlockBodyMemoModuleConst(
   ctx: GoEmitContext,
-  computation: string,
+  parsedBlock: ParsedStatement[] | undefined,
   signals: { getter: string; initialValue: string }[],
 ): { constName: string; constValue: string | undefined; constType: TypeInfo | undefined } | null {
-  try {
-    const sf = ts.createSourceFile(
-      '__memo.ts',
-      `const __x = (${computation});`,
-      ts.ScriptTarget.Latest,
-      false,
-    )
-    const stmt = sf.statements[0]
-    if (!stmt || !ts.isVariableStatement(stmt)) return null
-    let init = stmt.declarationList.declarations[0]?.initializer
-    while (init && ts.isParenthesizedExpression(init)) init = init.expression
-    if (!init || !ts.isArrowFunction(init)) return null
-    const body = init.body
-    if (!ts.isBlock(body)) return null
+  if (!parsedBlock) return null
 
-    // Walk the block's statements collecting:
-    //   const <varName> = <signalGetter>()   →  varToSignal map
-    //   if (!<varName>) return <moduleConst>  →  match varName back to signal
-    const varToSignal = new Map<string, string>()
-    let guardSignalGetter: string | null = null
-    let returnedConst: string | null = null
+  // Walk the analyzer-carried statements collecting:
+  //   const <varName> = <signalGetter>()   →  varToSignal map
+  //   if (!<varName>) return <moduleConst>  →  match varName back to signal
+  const varToSignal = new Map<string, string>()
+  let guardSignalGetter: string | null = null
+  let returnedConst: string | null = null
 
-    for (const s of body.statements) {
-      if (ts.isVariableStatement(s)) {
-        for (const decl of s.declarationList.declarations) {
-          if (
-            ts.isIdentifier(decl.name) &&
-            decl.initializer &&
-            ts.isCallExpression(decl.initializer) &&
-            ts.isIdentifier(decl.initializer.expression)
-          ) {
-            const callee = decl.initializer.expression.text
-            if (signals.some(sg => sg.getter === callee)) {
-              varToSignal.set(decl.name.text, callee)
-            }
-          }
+  for (const s of parsedBlock) {
+    if (s.kind === 'var-decl' && s.init.kind === 'call' && s.init.callee.kind === 'identifier') {
+      const callee = s.init.callee.name
+      if (signals.some(sg => sg.getter === callee)) {
+        varToSignal.set(s.name, callee)
+      }
+    }
+    if (
+      s.kind === 'if' &&
+      s.condition.kind === 'unary' &&
+      s.condition.op === '!' &&
+      s.condition.argument.kind === 'identifier'
+    ) {
+      const guardVar = s.condition.argument.name
+      const signalGetter = varToSignal.get(guardVar)
+      if (!signalGetter) continue
+      for (const rs of s.consequent) {
+        if (rs.kind === 'return' && rs.value.kind === 'identifier') {
+          guardSignalGetter = signalGetter
+          returnedConst = rs.value.name
         }
       }
-      if (
-        ts.isIfStatement(s) &&
-        ts.isPrefixUnaryExpression(s.expression) &&
-        s.expression.operator === ts.SyntaxKind.ExclamationToken &&
-        ts.isIdentifier(s.expression.operand)
-      ) {
-        const guardVar = s.expression.operand.text
-        const signalGetter = varToSignal.get(guardVar)
-        if (!signalGetter) continue
-        const thenBlock = ts.isBlock(s.thenStatement)
-          ? s.thenStatement.statements
-          : [s.thenStatement]
-        for (const rs of thenBlock) {
-          if (
-            ts.isReturnStatement(rs) &&
-            rs.expression &&
-            ts.isIdentifier(rs.expression)
-          ) {
-            guardSignalGetter = signalGetter
-            returnedConst = rs.expression.text
-          }
-        }
-      }
-      if (guardSignalGetter && returnedConst) break
     }
+    if (guardSignalGetter && returnedConst) break
+  }
 
-    if (!guardSignalGetter || !returnedConst) return null
+  if (!guardSignalGetter || !returnedConst) return null
 
-    // The guard signal must start falsy (null, '', 0, false)
-    const guardSignal = signals.find(sg => sg.getter === guardSignalGetter)
-    if (!guardSignal) return null
-    const iv = guardSignal.initialValue.trim()
-    if (iv !== 'null' && iv !== "''" && iv !== '""' && iv !== '0' && iv !== 'false') {
-      return null
-    }
-
-    // The returned identifier must be a module-scope constant
-    const constant = ctx.state.localConstants.find(
-      c => c.name === returnedConst && c.origin?.scope === 'module',
-    )
-    if (!constant) return null
-
-    return {
-      constName: constant.name,
-      constValue: constant.value,
-      constType: constant.type ?? undefined,
-    }
-  } catch {
+  // The guard signal must start falsy (null, '', 0, false)
+  const guardSignal = signals.find(sg => sg.getter === guardSignalGetter)
+  if (!guardSignal) return null
+  const iv = guardSignal.initialValue.trim()
+  if (iv !== 'null' && iv !== "''" && iv !== '""' && iv !== '0' && iv !== 'false') {
     return null
+  }
+
+  // The returned identifier must be a module-scope constant
+  const constant = ctx.state.localConstants.find(
+    c => c.name === returnedConst && c.origin?.scope === 'module',
+  )
+  if (!constant) return null
+
+  return {
+    constName: constant.name,
+    constValue: constant.value,
+    constType: constant.type ?? undefined,
   }
 }
 

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -8,7 +8,7 @@
 
 import ts from 'typescript'
 import type { ImportSpecifier, TypeInfo, ParamInfo, ReactiveFactoryInfo } from './types.ts'
-import { parseExpression } from './expression-parser.ts'
+import { parseExpression, parseBlockBodyTolerant } from './expression-parser.ts'
 import { rewriteBarePropRefs } from './prop-rewrite.ts'
 import { incrementCounter } from './instrumentation.ts'
 import {
@@ -1442,9 +1442,21 @@ function collectMemo(node: ts.VariableDeclaration, ctx: AnalyzerContext): void {
       ? parsedBody
       : undefined
 
+  // Block-bodied memos: carry the statements (tolerant — unparseable ones are
+  // omitted) so adapters can pattern-match block shapes (e.g. a guard-and-
+  // return-const memo) without re-parsing `computation`. Unwrap parens around
+  // the arrow to match the former adapter walks.
+  let arrowNode: ts.Node | undefined = memoArrow
+  while (arrowNode && ts.isParenthesizedExpression(arrowNode)) arrowNode = arrowNode.expression
+  const parsedBlock =
+    arrowNode && ts.isArrowFunction(arrowNode) && ts.isBlock(arrowNode.body)
+      ? parseBlockBodyTolerant(arrowNode.body, ctx.sourceFile, node => ctx.getJS(node))
+      : undefined
+
   ctx.memos.push({
     name,
     computation,
+    parsedBlock,
     typedComputation: typedComputation !== computation ? typedComputation : undefined,
     parsed,
     bodyIsTemplateLiteral: memoBodyIsTemplateLiteral(memoArrow),

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -2957,10 +2957,10 @@ export function parseBlockBody(
  * represent is **skipped** rather than failing the whole block. Used to carry a
  * block-body memo's structure on the IR for adapters that only pattern-match a
  * recognised prefix of statements (e.g. a `const k = getter(); if (!k) return
- * CONST` guard) and ignore the rest — including a trailing
- * `return /* @client *​/ …` that the strict parser would reject. Mirrors the
- * tolerant `continue`-on-unrecognised walks those adapters previously ran over
- * a re-parsed source string, so it never carries a *more* permissive result.
+ * CONST` guard) and ignore the rest — including a trailing client-directive
+ * (`@client`) return that the strict parser would reject. Mirrors the tolerant
+ * `continue`-on-unrecognised walks those adapters previously ran over a
+ * re-parsed source string, so it never carries a *more* permissive result.
  */
 export function parseBlockBodyTolerant(
   block: ts.Block,

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -2953,6 +2953,29 @@ export function parseBlockBody(
 }
 
 /**
+ * Like {@link parseBlockBody} but tolerant: a statement `parseStatement` can't
+ * represent is **skipped** rather than failing the whole block. Used to carry a
+ * block-body memo's structure on the IR for adapters that only pattern-match a
+ * recognised prefix of statements (e.g. a `const k = getter(); if (!k) return
+ * CONST` guard) and ignore the rest — including a trailing
+ * `return /* @client *​/ …` that the strict parser would reject. Mirrors the
+ * tolerant `continue`-on-unrecognised walks those adapters previously ran over
+ * a re-parsed source string, so it never carries a *more* permissive result.
+ */
+export function parseBlockBodyTolerant(
+  block: ts.Block,
+  sourceFile: ts.SourceFile,
+  getJS: (node: ts.Node) => string
+): ParsedStatement[] {
+  const statements: ParsedStatement[] = []
+  for (const stmt of block.statements) {
+    const parsed = parseStatement(stmt, sourceFile, getJS)
+    if (parsed !== null) statements.push(parsed)
+  }
+  return statements
+}
+
+/**
  * Parse a single statement into ParsedStatement.
  */
 function parseStatement(

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -254,7 +254,7 @@ export {
 export { ErrorCodes, createError, formatError, generateCodeFrame } from './errors.ts'
 
 // Expression Parser
-export { parseExpression, isSupported, exprToString, stringifyParsedExpr, identifierPath, parseBlockBody, containsHigherOrder, extractArrowBodyExpression, parseStyleObjectEntries, parseProviderObjectLiteral, type ProviderObjectMember } from './expression-parser.ts'
+export { parseExpression, isSupported, exprToString, stringifyParsedExpr, identifierPath, parseBlockBody, parseBlockBodyTolerant, containsHigherOrder, extractArrowBodyExpression, parseStyleObjectEntries, parseProviderObjectLiteral, type ProviderObjectMember } from './expression-parser.ts'
 export type { StyleObjectEntry } from './expression-parser.ts'
 export type { ParsedExpr, ObjectLiteralProperty, ParsedStatement, SortComparator, SortKey, ReduceOp, FlatDepth, FlatMapOp, FlatMapLeaf, SupportLevel, SupportResult, TemplatePart } from './expression-parser.ts'
 export { buildLoopChainExpr } from './loop-chain.ts'

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -1146,6 +1146,15 @@ export interface MemoInfo {
    * dedicated flag rather than a `parsed.kind` check.
    */
   bodyIsTemplateLiteral?: boolean
+  /**
+   * A block-bodied memo's statements, parsed best-effort (tolerant: a statement
+   * the parser can't represent is omitted). Lets the Go adapter pattern-match
+   * block-body memo shapes — e.g. the `const k = getter(); if (!k) return CONST`
+   * guard — on the structured statements instead of re-parsing `computation`
+   * with `ts.createSourceFile`. Absent for expression-bodied memos (those carry
+   * `parsed` instead) and when the arrow has no block body.
+   */
+  parsedBlock?: ParsedStatement[]
   type: TypeInfo
   deps: string[]
   loc: SourceLocation


### PR DESCRIPTION
## Terminal sweep (4/N) — block-body memo guard from the IR

The `const k = getter(); if (!k) return MODULE_CONST` guard memo (#1897) previously re-parsed `computation` with `ts.createSourceFile` in `resolveBlockBodyMemoModuleConst`. Now it reads the analyzer-carried block.

### Optional / additive (no other-adapter impact)
Per the plan to keep mojo/xslate untouched until their own refactor:
- **`MemoInfo.parsedBlock`** — a new **optional** field; only the Go adapter reads it, mojo/xslate ignore it.
- **`parseBlockBodyTolerant`** — a **new** exported parser (strict `parseBlockBody` is unchanged, so its existing callers are unaffected). It's tolerant: a statement it can't represent — e.g. a trailing `return /* @client */ …` — is **omitted** rather than failing the whole block, matching the adapter's former `continue`-on-unrecognised walk.

The Go `resolveBlockBodyMemoModuleConst` walks `parsedBlock` (`var-decl` → `call`; `if` → `unary('!')` → `return` identifier), keeping its signal-falsy and module-const validations as plain state lookups.

### Byte-identical
conformance **786**, go units **556**, jsx units **2216** — all green. (One bug found and fixed in development: `ctx.getJS` is a `this`-bound method, so it's passed wrapped as `node => ctx.getJS(node)`.)

**Effect:** removes the `memo-value.ts` `ts.createSourceFile`. Independent of #2003/#2004 (different files); with all of them the adapter-wide count reaches 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_