### PR TITLE
refactor(go-template): resolve static Record-index from the IR object-literal, drop createSourceFile (terminal sweep)

### DIFF
--- a/.changeset/go-static-record-no-createsf.md
+++ b/.changeset/go-static-record-no-createsf.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Resolve static `Record`-index lookups (`variantClasses[variant]`, icon registries) from the IR-carried `object-literal` tree instead of re-parsing the const value with `ts.createSourceFile` at emit time. Numeric record values now emit `literal.raw` (the exact `NumericLiteral.text` token captured by the analyzer), preserving spelling byte-for-byte without a second parse. Verified byte-identical by the conformance (786) and Go unit (556) suites.

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -4438,59 +4438,26 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     )
     if (constInfo?.value === undefined) return null
 
-    // Prefer the IR-carried structured value (Roadmap A): the analyzer parses
-    // a module record's `{ key: 'lit' }` once into an `object-literal`, so the
-    // key lookup reads the structured tree instead of re-parsing the value
-    // string here. Falls through to the `ts.createSourceFile` path below when
-    // the value wasn't carried as a plain object literal (a spread / computed-
-    // key / template-key record stays `unsupported`, handled there unchanged).
-    // Prefer the IR-carried structured value, but ONLY for string-literal
-    // record values. A parsed numeric literal has already been through
-    // `parseFloat` (in the expression parser), which can change the spelling
-    // (e.g. `1e3` → `1000`) or lose precision for integers beyond
-    // `Number.MAX_SAFE_INTEGER`, whereas the `ts.createSourceFile` fallback
-    // below preserves the exact `NumericLiteral.text` token. So for numbers —
-    // and anything that isn't a plain string literal — fall through to that
-    // path, which stays byte-identical. (A later Roadmap A unit carries a raw
-    // numeric spelling on the IR, at which point numbers can use the fast path
-    // too.) Strings are already escape-equivalent to the fallback's
-    // `JSON.stringify(text)`, so the common icon-registry record short-circuits.
+    // Read the IR-carried structured value (Roadmap A): the analyzer parses a
+    // module record's `{ key: 'lit' }` once into an `object-literal` (parsing
+    // the SAME parenthesised value this used to re-parse with
+    // `ts.createSourceFile`), so the key lookup reads the structured tree here.
+    //   - string values map to `JSON.stringify(text)` (escape-equivalent to the
+    //     former fallback's string branch);
+    //   - number values emit `literal.raw`, the exact `NumericLiteral.text`
+    //     token captured by the parser, so the spelling (`1e3`, large ints) is
+    //     preserved byte-for-byte without going through `parseFloat`.
+    // Any non-record / non-string-or-number value resolves to null, matching
+    // the former fallback's bail. The corpus's record consts are all plain
+    // string-keyed string/number object literals (icon registries, variant/size
+    // class maps), so this fully covers them.
     const carried = constInfo.parsed
     if (carried?.kind === 'object-literal') {
       const hit = carried.properties.find(prop => prop.key === key)
-      if (hit && hit.value.kind === 'literal' && hit.value.literalType === 'string') {
-        return JSON.stringify(hit.value.value)
+      if (hit && hit.value.kind === 'literal') {
+        if (hit.value.literalType === 'string') return JSON.stringify(hit.value.value)
+        if (hit.value.literalType === 'number') return hit.value.raw ?? String(hit.value.value)
       }
-      // else: fall through to the exact-text createSourceFile path below.
-    }
-
-    const sf = ts.createSourceFile(
-      '__rec.ts',
-      `(${constInfo.value})`,
-      ts.ScriptTarget.Latest,
-      /* setParentNodes */ true,
-    )
-    if (sf.statements.length !== 1) return null
-    const stmt = sf.statements[0]
-    if (!ts.isExpressionStatement(stmt)) return null
-    let parsed: ts.Expression = stmt.expression
-    while (ts.isParenthesizedExpression(parsed)) parsed = parsed.expression
-    if (!ts.isObjectLiteralExpression(parsed)) return null
-    for (const prop of parsed.properties) {
-      if (!ts.isPropertyAssignment(prop)) continue
-      const name = prop.name
-      const propKey =
-        ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNoSubstitutionTemplateLiteral(name)
-          ? name.text
-          : null
-      if (propKey !== key) continue
-      let v: ts.Expression = prop.initializer
-      while (ts.isParenthesizedExpression(v)) v = v.expression
-      if (ts.isNumericLiteral(v)) return v.text
-      if (ts.isStringLiteral(v) || ts.isNoSubstitutionTemplateLiteral(v)) {
-        return JSON.stringify(v.text)
-      }
-      return null
     }
     return null
   }


### PR DESCRIPTION
## Terminal sweep — static `Record`-index from the IR

`resolveStaticRecordLiteralIndex` (e.g. an icon registry's `strokePaths['chevron-down']`, a `variantClasses[variant]` class map) previously re-parsed the const's value string with `ts.createSourceFile` for any value the carried fast-path didn't already cover. It now reads the analyzer-carried `object-literal` tree (`ConstantInfo.parsed`, Roadmap A-2) for **both** string and numeric record values:

- **string** → `JSON.stringify(value)` (escape-equivalent to the former string branch);
- **number** → `literal.raw`, the exact `NumericLiteral.text` token the analyzer captured (A-3), so the spelling (`1e3`, large ints) is preserved byte-for-byte without going through `parseFloat`.

The `ts.createSourceFile` fallback is removed. The corpus's record consts are all plain string-keyed string/number object literals, so the structured path fully covers them and the former spread/computed-key fallback was corpus-unreachable.

### Byte-identical
Verified by the conformance suite (**786**) and Go unit suite (**556**) — all green; `tsgo` + Biome clean.

**Effect:** removes one of the two `ts.createSourceFile` sites in `go-template-adapter.ts`. The other (`parseLiteralExpression`, the shared 13-caller terminal) is the documented architectural floor — see #2006.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_