### PR TITLE
docs(go-template): document parseLiteralExpression as the terminal-sweep floor (#2006)

### DIFF
--- a/.changeset/go-parselit-floor-doc.md
+++ b/.changeset/go-parselit-floor-doc.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Document `parseLiteralExpression` as the terminal sweep's architectural floor — the last `ts.createSourceFile` in the adapter, a shared 13-caller parser whose removal requires expanding the shared `ParsedExpr` into a near-complete expression AST (tracked in #2006). Docstring-only; no behavioural or API change.

--- a/.changeset/go-parselit-floor-doc.md
+++ b/.changeset/go-parselit-floor-doc.md
@@ -2,4 +2,4 @@
 "@barefootjs/go-template": patch
 ---
 
-Document `parseLiteralExpression` as the terminal sweep's architectural floor — the last `ts.createSourceFile` in the adapter, a shared 13-caller parser whose removal requires expanding the shared `ParsedExpr` into a near-complete expression AST (tracked in #2006). Docstring-only; no behavioural or API change.
+Document `parseLiteralExpression` as the terminal sweep's final target — the last `ts.createSourceFile` in the adapter, a shared parser (many call sites across the constructor/value lowering) being removed incrementally via the Go-only `ParsedExpr2` bridge (tracked in #2006). Docstring-only; no behavioural or API change.

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -2235,6 +2235,17 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * Parse a JS expression string into its TS AST node (parentheses unwrapped),
    * or `null` when it isn't a single expression. Shared by the literal baker
    * and the struct-shape synthesiser.
+   *
+   * This is the **last** `ts.createSourceFile` in the adapter — the terminal
+   * sweep's architectural floor (see issue #2006). Unlike the dedicated sites
+   * that were removed by carrying a parsed tree on the IR, this is a shared
+   * parser with 13 live callers, several of which are full TS-expression
+   * *interpreters* (`lowerCtorExpr` evaluates `.get`/`.includes`/`.replace`,
+   * regex literals, arrow-helper inlining, and `??`/`||`/`?:`). Removing it
+   * requires expanding the shared `ParsedExpr` (in `@barefootjs/jsx`, consumed
+   * by all adapters) into a near-complete expression AST and rewriting every
+   * caller — a multi-PR re-architecture, intentionally deferred and tracked in
+   * #2006. Do NOT add new callers: read a carried `ParsedExpr` field instead.
    */
   private parseLiteralExpression(value: string): ts.Expression | null {
     const sf = ts.createSourceFile(

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -2237,15 +2237,17 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * and the struct-shape synthesiser.
    *
    * This is the **last** `ts.createSourceFile` in the adapter — the terminal
-   * sweep's architectural floor (see issue #2006). Unlike the dedicated sites
-   * that were removed by carrying a parsed tree on the IR, this is a shared
-   * parser with 13 live callers, several of which are full TS-expression
-   * *interpreters* (`lowerCtorExpr` evaluates `.get`/`.includes`/`.replace`,
-   * regex literals, arrow-helper inlining, and `??`/`||`/`?:`). Removing it
-   * requires expanding the shared `ParsedExpr` (in `@barefootjs/jsx`, consumed
-   * by all adapters) into a near-complete expression AST and rewriting every
-   * caller — a multi-PR re-architecture, intentionally deferred and tracked in
-   * #2006. Do NOT add new callers: read a carried `ParsedExpr` field instead.
+   * sweep's final target (issue #2006). Unlike the dedicated sites that were
+   * removed by carrying a parsed tree on the IR, this is a shared parser with
+   * many call sites across the adapter's constructor/value lowering, several of
+   * which are full TS-expression *interpreters* (`lowerCtorExpr` evaluates
+   * `.get`/`.includes`/`.replace`, regex literals, arrow-helper inlining, and
+   * `??`/`||`/`?:`). It is being removed incrementally via the Go-only
+   * `ParsedExpr2` bridge (a separate tree carrying the multi-param-arrow and
+   * regex shapes `ParsedExpr` can't model, so the shared `ParsedExpr` /
+   * `ParsedExprEmitter` — and thus mojo/xslate — are untouched; see #2006).
+   * Do NOT add new callers: read a carried `ParsedExpr2` / `ParsedExpr` field
+   * instead.
    */
   private parseLiteralExpression(value: string): ts.Expression | null {
     const sf = ts.createSourceFile(


### PR DESCRIPTION
## Document the terminal sweep's architectural floor

The terminal sweep drove the Go adapter's `ts.createSourceFile` count **8 → 1**. The remaining one — the shared helper `parseLiteralExpression` — is not a leaf site but a parser with **13 live callers**, several of which (`lowerCtorExpr` et al.) are full TS-expression *interpreters* (`.get`/`.includes`/`.replace`, regex literals, arrow-helper inlining, `??`/`||`/`?:`). Removing it requires expanding the shared `ParsedExpr` (in `@barefootjs/jsx`, consumed by all adapters) into a near-complete expression AST and rewriting every caller — a multi-PR re-architecture, intentionally deferred.

This PR adds a docstring on `parseLiteralExpression` marking it the architectural floor, with a pointer to the tracking issue (#2006) and the full removal roadmap, plus a caution not to add new callers (read a carried `ParsedExpr` field instead). Matches the repo convention of pointing adapter-internal declarations back to their tracked limitation.

Docstring-only — no behavioural or API change; `tsgo` + Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_