### PR TITLE
feat(jsx): add parseExpression2 / ParsedExpr2 — Go ctor-lowering bridge (#2006)

### DIFF
--- a/.changeset/parsedexpr2-foundation.md
+++ b/.changeset/parsedexpr2-foundation.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Add `parseExpression2` / `ParsedExpr2` — a focused, self-contained expression tree for the Go adapter's constructor-context lowering (terminal sweep, #2006). It adds the two shapes the Go ctor/helper/spread lowerers need that `ParsedExpr` cannot model — multi-parameter arrow functions and a regex literal — without touching the shared `ParsedExpr` / `ParsedExprEmitter`, so the other adapters (mojolicious, xslate) are not forced to handle new kinds before their own refactor. Method calls are modelled uniformly as `call` + `member`. Additive and unused for now (no consumer), so output is unchanged; it's the structured replacement that will let the Go adapter drop its last `ts.createSourceFile` (`parseLiteralExpression`).

--- a/packages/jsx/src/__tests__/parse-expression2.test.ts
+++ b/packages/jsx/src/__tests__/parse-expression2.test.ts
@@ -86,6 +86,15 @@ describe('parseExpression2', () => {
     expect((parseExpression2("a === b") as ParsedExpr2 & { kind: 'binary' }).op).toBe('===')
   })
 
+  test('out-of-surface binary / unary operators resolve to unsupported (not op: "unknown")', () => {
+    // Operators getOperatorString/getUnaryOperatorString don't recognise must
+    // opt out, not emit a node with a meaningless `op` a consumer could mishandle.
+    expect(parseExpression2('a instanceof B').kind).toBe('unsupported')
+    expect(parseExpression2('a ** b').kind).toBe('unsupported')
+    expect(parseExpression2('++x').kind).toBe('unsupported')
+    expect(parseExpression2('--x').kind).toBe('unsupported')
+  })
+
   test('nested: base.replace(/\\/+$/, "") || "/"', () => {
     const r = parseExpression2("base.replace(/\\/+$/, '') || '/'")
     expect(r.kind).toBe('logical')

--- a/packages/jsx/src/__tests__/parse-expression2.test.ts
+++ b/packages/jsx/src/__tests__/parse-expression2.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from 'bun:test'
+import { type ParsedExpr2, parseExpression2 } from '../expression-parser'
+
+/**
+ * `parseExpression2` is the Go-adapter constructor-lowering bridge tree
+ * (#2006). These tests pin the two gap shapes it adds over `ParsedExpr`
+ * (multi-parameter arrow, regex literal) plus the narrow surface the ctor /
+ * helper / spread lowerers consume.
+ */
+describe('parseExpression2', () => {
+  test('identifier / string / number / boolean / null literals', () => {
+    expect(parseExpression2('count')).toEqual({ kind: 'identifier', name: 'count' })
+    expect(parseExpression2("'all'")).toEqual({ kind: 'literal', value: 'all', literalType: 'string' })
+    // `raw` is TS's normalised NumericLiteral.text (`1e3` → `1000`), same as ParsedExpr.
+    expect(parseExpression2('1e3')).toEqual({ kind: 'literal', value: 1000, literalType: 'number', raw: '1000' })
+    expect(parseExpression2('42')).toEqual({ kind: 'literal', value: 42, literalType: 'number', raw: '42' })
+    expect(parseExpression2('true')).toEqual({ kind: 'literal', value: true, literalType: 'boolean' })
+    expect(parseExpression2('null')).toEqual({ kind: 'literal', value: null, literalType: 'null' })
+  })
+
+  test('no-substitution template folds to a string literal', () => {
+    expect(parseExpression2('`plain`')).toEqual({ kind: 'literal', value: 'plain', literalType: 'string' })
+  })
+
+  test('member access (props.X)', () => {
+    expect(parseExpression2('props.base')).toEqual({
+      kind: 'member',
+      object: { kind: 'identifier', name: 'props' },
+      property: 'base',
+      computed: false,
+    })
+  })
+
+  test('method call modelled uniformly as call + member', () => {
+    expect(parseExpression2("sp.get('tag')")).toEqual({
+      kind: 'call',
+      callee: { kind: 'member', object: { kind: 'identifier', name: 'sp' }, property: 'get', computed: false },
+      args: [{ kind: 'literal', value: 'tag', literalType: 'string' }],
+    })
+  })
+
+  test('regex literal carried as exact source text', () => {
+    const r = parseExpression2('/\\/+$/')
+    expect(r).toEqual({ kind: 'regex', raw: '/\\/+$/' })
+  })
+
+  test('.replace(/\\/+$/, "") — the trailing-slash strip the ctor lowering recognises', () => {
+    const r = parseExpression2("base.replace(/\\/+$/, '')")
+    expect(r.kind).toBe('call')
+    if (r.kind !== 'call') return
+    expect(r.callee).toEqual({
+      kind: 'member',
+      object: { kind: 'identifier', name: 'base' },
+      property: 'replace',
+      computed: false,
+    })
+    expect(r.args[0]).toEqual({ kind: 'regex', raw: '/\\/+$/' })
+    expect(r.args[1]).toEqual({ kind: 'literal', value: '', literalType: 'string' })
+  })
+
+  test('multi-parameter arrow (helper inlining)', () => {
+    const r = parseExpression2('(base, path) => base + path')
+    expect(r.kind).toBe('arrow')
+    if (r.kind !== 'arrow') return
+    expect(r.params).toEqual(['base', 'path'])
+    expect(r.body.kind).toBe('binary')
+  })
+
+  test('single-parameter arrow normalises to params: [x]', () => {
+    const r = parseExpression2('x => x')
+    expect(r).toEqual({
+      kind: 'arrow',
+      params: ['x'],
+      body: { kind: 'identifier', name: 'x' },
+    })
+  })
+
+  test('block-body arrow is unsupported', () => {
+    expect(parseExpression2('(x) => { return x }').kind).toBe('unsupported')
+  })
+
+  test('logical ?? / || / && discriminated from binary', () => {
+    expect((parseExpression2("a ?? b") as ParsedExpr2 & { kind: 'logical' }).op).toBe('??')
+    expect((parseExpression2("a || b") as ParsedExpr2 & { kind: 'logical' }).op).toBe('||')
+    expect((parseExpression2("a && b") as ParsedExpr2 & { kind: 'logical' }).op).toBe('&&')
+    expect((parseExpression2("a === b") as ParsedExpr2 & { kind: 'binary' }).op).toBe('===')
+  })
+
+  test('nested: base.replace(/\\/+$/, "") || "/"', () => {
+    const r = parseExpression2("base.replace(/\\/+$/, '') || '/'")
+    expect(r.kind).toBe('logical')
+    if (r.kind !== 'logical') return
+    expect(r.op).toBe('||')
+    expect(r.left.kind).toBe('call')
+    expect(r.right).toEqual({ kind: 'literal', value: '/', literalType: 'string' })
+  })
+
+  test('unary ! and conditional', () => {
+    expect(parseExpression2('!open')).toEqual({
+      kind: 'unary',
+      op: '!',
+      argument: { kind: 'identifier', name: 'open' },
+    })
+    const c = parseExpression2("cond ? 'a' : 'b'")
+    expect(c.kind).toBe('conditional')
+  })
+
+  test('string array literal', () => {
+    expect(parseExpression2("['a', 'b']")).toEqual({
+      kind: 'array-literal',
+      elements: [
+        { kind: 'literal', value: 'a', literalType: 'string' },
+        { kind: 'literal', value: 'b', literalType: 'string' },
+      ],
+    })
+  })
+
+  test('object literal with identifier / string / numeric keys', () => {
+    // Object literals are paren-wrapped by the analyzer (a bare `{…}` at
+    // statement position parses as a block), mirroring `parseExpression`.
+    const r = parseExpression2("({ align: 'start', 'data-x': 1, 2: 'two' })")
+    expect(r.kind).toBe('object-literal')
+    if (r.kind !== 'object-literal') return
+    expect(r.properties.map(p => [p.key, p.keyKind])).toEqual([
+      ['align', 'identifier'],
+      ['data-x', 'string'],
+      ['2', 'numeric'],
+    ])
+    expect(r.properties[0].value).toEqual({ kind: 'literal', value: 'start', literalType: 'string' })
+  })
+
+  test('shorthand object property', () => {
+    const r = parseExpression2('({ a })')
+    expect(r.kind).toBe('object-literal')
+    if (r.kind !== 'object-literal') return
+    expect(r.properties[0]).toEqual({
+      key: 'a',
+      keyKind: 'identifier',
+      shorthand: true,
+      value: { kind: 'identifier', name: 'a' },
+    })
+  })
+
+  test('spread / computed-key objects resolve to unsupported', () => {
+    expect(parseExpression2('({ ...rest })').kind).toBe('unsupported')
+    expect(parseExpression2('({ [k]: 1 })').kind).toBe('unsupported')
+  })
+
+  test('empty / non-expression input is unsupported', () => {
+    expect(parseExpression2('').kind).toBe('unsupported')
+    expect(parseExpression2('   ').kind).toBe('unsupported')
+  })
+})

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -846,10 +846,19 @@ function convertNode2(node: ts.Node, raw: string): ParsedExpr2 {
     if (k === ts.SyntaxKind.AmpersandAmpersandToken) return { kind: 'logical', op: '&&', left, right }
     if (k === ts.SyntaxKind.BarBarToken) return { kind: 'logical', op: '||', left, right }
     if (k === ts.SyntaxKind.QuestionQuestionToken) return { kind: 'logical', op: '??', left, right }
-    return { kind: 'binary', op: getOperatorString(k), left, right }
+    // An operator outside the recognised set yields `'unknown'`; keep the
+    // narrow-surface contract by resolving to `unsupported` rather than a
+    // `binary` node a consumer might mis-handle.
+    const op = getOperatorString(k)
+    if (op === 'unknown') return { kind: 'unsupported', raw, reason: `Unsupported binary operator ${ts.SyntaxKind[k]}` }
+    return { kind: 'binary', op, left, right }
   }
   if (ts.isPrefixUnaryExpression(node)) {
-    return { kind: 'unary', op: getUnaryOperatorString(node.operator), argument: convertNode2(node.operand, raw) }
+    // `++x` / `--x` etc. resolve to `'unknown'` — opt out to `unsupported`
+    // rather than emitting a `unary` node with a meaningless operator.
+    const op = getUnaryOperatorString(node.operator)
+    if (op === 'unknown') return { kind: 'unsupported', raw, reason: `Unsupported unary operator ${ts.SyntaxKind[node.operator]}` }
+    return { kind: 'unary', op, argument: convertNode2(node.operand, raw) }
   }
   if (ts.isConditionalExpression(node)) {
     return {

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -712,6 +712,185 @@ export function parseExpression(expr: string): ParsedExpr {
   return convertNode(firstStmt.expression, expr)
 }
 
+// =============================================================================
+// ParsedExpr2 — Go-adapter constructor/helper lowering bridge (issue #2006)
+// =============================================================================
+
+/**
+ * A focused, self-contained expression tree for the Go adapter's
+ * *constructor-context* lowering (`lowerCtorExpr`, module/helper inlining,
+ * conditional spread, string-array baking).
+ *
+ * Deliberately separate from {@link ParsedExpr}: it adds the two shapes the Go
+ * ctor lowerers need that `ParsedExpr` cannot model — multi-parameter arrow
+ * functions (helper inlining) and a regex literal (the `/\/+$/` trailing-slash
+ * strip, `String.replace`) — WITHOUT touching the shared `ParsedExpr` /
+ * `ParsedExprEmitter`, so the other adapters (mojolicious, xslate) are not
+ * forced to handle new kinds before their own refactor. Method calls are
+ * modelled uniformly as `call` + `member` (the ctor lowering dispatches on
+ * `member.property` — `get` / `includes` / `replace`), so the `array-method` /
+ * `higher-order` abstractions that exist for template lowering are
+ * intentionally omitted from this narrow surface.
+ *
+ * This is a temporary bridge for the terminal sweep: it is the structured
+ * replacement for the adapter's last `ts.createSourceFile`
+ * (`parseLiteralExpression`). When the mojo/xslate refactor lands, the gap
+ * kinds fold back into a unified `ParsedExpr`. Tracked in #2006.
+ */
+export type ParsedExpr2 =
+  | { kind: 'literal'; value: string | number | boolean | null; literalType: 'string' | 'number' | 'boolean' | 'null'; raw?: string }
+  | { kind: 'identifier'; name: string }
+  | { kind: 'member'; object: ParsedExpr2; property: string; computed: boolean }
+  | { kind: 'index-access'; object: ParsedExpr2; index: ParsedExpr2 }
+  | { kind: 'call'; callee: ParsedExpr2; args: ParsedExpr2[] }
+  // A regex literal carried as its exact source text (`/\/+$/`), so the ctor
+  // lowering matches the one trailing-slash-strip pattern it recognises.
+  | { kind: 'regex'; raw: string }
+  // Multi-parameter, expression-bodied arrow (`(a, b) => …`) for module/helper
+  // inlining. Block-bodied arrows resolve to `unsupported`.
+  | { kind: 'arrow'; params: string[]; body: ParsedExpr2 }
+  | { kind: 'logical'; op: '&&' | '||' | '??'; left: ParsedExpr2; right: ParsedExpr2 }
+  | { kind: 'binary'; op: string; left: ParsedExpr2; right: ParsedExpr2 }
+  | { kind: 'unary'; op: string; argument: ParsedExpr2 }
+  | { kind: 'conditional'; test: ParsedExpr2; consequent: ParsedExpr2; alternate: ParsedExpr2 }
+  | { kind: 'array-literal'; elements: ParsedExpr2[] }
+  | { kind: 'object-literal'; properties: ParsedExpr2Property[]; raw: string }
+  | { kind: 'unsupported'; raw: string; reason: string }
+
+/** A plain `key: value` / shorthand `{ key }` property of a {@link ParsedExpr2} object literal. */
+export interface ParsedExpr2Property {
+  key: string
+  keyKind: 'identifier' | 'string' | 'numeric'
+  shorthand: boolean
+  value: ParsedExpr2
+}
+
+/**
+ * Parse a JS expression string into a {@link ParsedExpr2}, the Go adapter's
+ * constructor-lowering tree. Mirrors {@link parseExpression} but targets the
+ * narrow self-contained surface above; a shape outside it resolves to
+ * `unsupported` (so the caller falls back exactly as the former
+ * `parseLiteralExpression` + null path did).
+ */
+export function parseExpression2(expr: string): ParsedExpr2 {
+  const trimmed = expr.trim()
+  if (!trimmed) return { kind: 'unsupported', raw: expr, reason: 'Empty expression' }
+  const sourceFile = ts.createSourceFile(
+    'expression2.ts',
+    trimmed,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  )
+  if (sourceFile.statements.length === 0) {
+    return { kind: 'unsupported', raw: expr, reason: 'No statements found' }
+  }
+  const firstStmt = sourceFile.statements[0]
+  if (!ts.isExpressionStatement(firstStmt)) {
+    return { kind: 'unsupported', raw: expr, reason: 'Not an expression statement' }
+  }
+  return convertNode2(firstStmt.expression, expr)
+}
+
+/** Convert a TypeScript AST node to {@link ParsedExpr2} (parentheses unwrapped). */
+function convertNode2(node: ts.Node, raw: string): ParsedExpr2 {
+  while (ts.isParenthesizedExpression(node)) node = node.expression
+
+  if (ts.isIdentifier(node)) return { kind: 'identifier', name: node.text }
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+    return { kind: 'literal', value: node.text, literalType: 'string' }
+  }
+  if (ts.isNumericLiteral(node)) {
+    return { kind: 'literal', value: parseFloat(node.text), literalType: 'number', raw: node.text }
+  }
+  if (node.kind === ts.SyntaxKind.TrueKeyword) return { kind: 'literal', value: true, literalType: 'boolean' }
+  if (node.kind === ts.SyntaxKind.FalseKeyword) return { kind: 'literal', value: false, literalType: 'boolean' }
+  if (node.kind === ts.SyntaxKind.NullKeyword) return { kind: 'literal', value: null, literalType: 'null' }
+
+  if (ts.isRegularExpressionLiteral(node)) return { kind: 'regex', raw: node.getText() }
+
+  if (ts.isPropertyAccessExpression(node)) {
+    return { kind: 'member', object: convertNode2(node.expression, raw), property: node.name.text, computed: false }
+  }
+  if (ts.isElementAccessExpression(node)) {
+    return {
+      kind: 'index-access',
+      object: convertNode2(node.expression, raw),
+      index: convertNode2(node.argumentExpression, raw),
+    }
+  }
+  if (ts.isCallExpression(node)) {
+    return {
+      kind: 'call',
+      callee: convertNode2(node.expression, raw),
+      args: node.arguments.map(a => convertNode2(a, raw)),
+    }
+  }
+  if (ts.isArrowFunction(node)) {
+    if (ts.isBlock(node.body)) {
+      return { kind: 'unsupported', raw, reason: 'Block body arrow functions are not supported' }
+    }
+    const params: string[] = []
+    for (const p of node.parameters) {
+      if (!ts.isIdentifier(p.name)) {
+        return { kind: 'unsupported', raw, reason: 'Only identifier arrow parameters are supported' }
+      }
+      params.push(p.name.text)
+    }
+    return { kind: 'arrow', params, body: convertNode2(node.body, raw) }
+  }
+  if (ts.isBinaryExpression(node)) {
+    const left = convertNode2(node.left, raw)
+    const right = convertNode2(node.right, raw)
+    const k = node.operatorToken.kind
+    if (k === ts.SyntaxKind.AmpersandAmpersandToken) return { kind: 'logical', op: '&&', left, right }
+    if (k === ts.SyntaxKind.BarBarToken) return { kind: 'logical', op: '||', left, right }
+    if (k === ts.SyntaxKind.QuestionQuestionToken) return { kind: 'logical', op: '??', left, right }
+    return { kind: 'binary', op: getOperatorString(k), left, right }
+  }
+  if (ts.isPrefixUnaryExpression(node)) {
+    return { kind: 'unary', op: getUnaryOperatorString(node.operator), argument: convertNode2(node.operand, raw) }
+  }
+  if (ts.isConditionalExpression(node)) {
+    return {
+      kind: 'conditional',
+      test: convertNode2(node.condition, raw),
+      consequent: convertNode2(node.whenTrue, raw),
+      alternate: convertNode2(node.whenFalse, raw),
+    }
+  }
+  if (ts.isArrayLiteralExpression(node)) {
+    return { kind: 'array-literal', elements: node.elements.map(e => convertNode2(e, raw)) }
+  }
+  if (ts.isObjectLiteralExpression(node)) {
+    const properties: ParsedExpr2Property[] = []
+    for (const prop of node.properties) {
+      if (ts.isPropertyAssignment(prop)) {
+        const named = objectLiteralKeyName(prop.name)
+        if (named === null) return { kind: 'unsupported', raw, reason: 'Computed or non-plain object key' }
+        properties.push({
+          key: named.key,
+          keyKind: named.keyKind,
+          shorthand: false,
+          value: convertNode2(prop.initializer, raw),
+        })
+      } else if (ts.isShorthandPropertyAssignment(prop)) {
+        properties.push({
+          key: prop.name.text,
+          keyKind: 'identifier',
+          shorthand: true,
+          value: { kind: 'identifier', name: prop.name.text },
+        })
+      } else {
+        return { kind: 'unsupported', raw, reason: 'Spread, method, or accessor object property' }
+      }
+    }
+    return { kind: 'object-literal', properties, raw: node.getText() }
+  }
+
+  return { kind: 'unsupported', raw, reason: `Unsupported node kind ${ts.SyntaxKind[node.kind]}` }
+}
+
 /**
  * Resolve a non-computed object-literal property key to its string name.
  * Identifier / string / numeric names resolve to their text; a computed

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -254,9 +254,9 @@ export {
 export { ErrorCodes, createError, formatError, generateCodeFrame } from './errors.ts'
 
 // Expression Parser
-export { parseExpression, isSupported, exprToString, stringifyParsedExpr, identifierPath, parseBlockBody, parseBlockBodyTolerant, containsHigherOrder, extractArrowBodyExpression, parseStyleObjectEntries, parseProviderObjectLiteral, type ProviderObjectMember } from './expression-parser.ts'
+export { parseExpression, parseExpression2, isSupported, exprToString, stringifyParsedExpr, identifierPath, parseBlockBody, parseBlockBodyTolerant, containsHigherOrder, extractArrowBodyExpression, parseStyleObjectEntries, parseProviderObjectLiteral, type ProviderObjectMember } from './expression-parser.ts'
 export type { StyleObjectEntry } from './expression-parser.ts'
-export type { ParsedExpr, ObjectLiteralProperty, ParsedStatement, SortComparator, SortKey, ReduceOp, FlatDepth, FlatMapOp, FlatMapLeaf, SupportLevel, SupportResult, TemplatePart } from './expression-parser.ts'
+export type { ParsedExpr, ParsedExpr2, ParsedExpr2Property, ObjectLiteralProperty, ParsedStatement, SortComparator, SortKey, ReduceOp, FlatDepth, FlatMapOp, FlatMapLeaf, SupportLevel, SupportResult, TemplatePart } from './expression-parser.ts'
 export { buildLoopChainExpr } from './loop-chain.ts'
 export type { LoopChainInputs } from './loop-chain.ts'
 export { isLowerableObjectRestDestructure } from './loop-destructure.ts'


### PR DESCRIPTION
## Terminal sweep — foundation for removing the last `ts.createSourceFile`

The adapter's final `ts.createSourceFile` is the shared helper `parseLiteralExpression` (#2006). Its 13 callers include full TS-expression *interpreters* (`lowerCtorExpr` et al.), so removing it needs a structured tree carrying shapes `ParsedExpr` doesn't model:
- **multi-parameter arrow functions** (module/helper inlining), and
- a **regex literal** (the `/\/+$/` trailing-slash strip in `String.replace`).

### Why a separate `ParsedExpr2` (not extending `ParsedExpr`)

Growing the shared `ParsedExpr` would force **mojo/xslate** to handle the new kinds via the `ParsedExprEmitter` drift-defence — before their own refactor is ready. So this adds a **Go-only, self-contained `ParsedExpr2`**: a focused union covering exactly the ctor/helper/spread surface, with method calls modelled uniformly as `call` + `member` (the lowering dispatches on `member.property` — `get`/`includes`/`replace`). The shared `ParsedExpr` / `ParsedExprEmitter` are untouched, so the other adapters see nothing.

It's a deliberate **temporary bridge** — folded back into a unified `ParsedExpr` during the mojo/xslate refactor (tracked in #2006).

### This PR
- `parseExpression2(expr): ParsedExpr2` + the `ParsedExpr2` / `ParsedExpr2Property` types in `expression-parser.ts`, exported from the package index.
- 17 unit tests pinning the gap shapes (multi-param arrow, regex, `.replace(/\/+$/, '')`, nested `… || '/'`) and the narrow surface.

**Additive and unused** (no consumer yet) → output unchanged. Existing parser suite (205) green; jsx build + `tsgo` + Biome clean.

### Next (this stack)
U3 ports `ctor-lowering.ts` to consume `ParsedExpr2`; U4 helper-inline/url-builder; U5 spread; U6 data-literal callers; U7 deletes `parseLiteralExpression` → adapter `ts.createSourceFile` = 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_