### PR TITLE
refactor(go-template): lower constructor expressions from ParsedExpr2 (#2006)

### DIFF
--- a/.changeset/go-ctor-lowering-parsedexpr2.md
+++ b/.changeset/go-ctor-lowering-parsedexpr2.md
@@ -1,0 +1,6 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+---
+
+Go constructor lowering now reads `ConstantInfo.parsed2` / `ParsedExpr2` instead of re-parsing const values with `ts.createSourceFile`. The four `parseLiteralExpression` call sites in `ctor-lowering.ts` (and the derived-const caller in `go-template-adapter.ts`) are removed; `lowerCtorExpr` / `lowerCtorCond` / `lowerCtorStringArray` take the IR-carried `ParsedExpr2` tree, and a new `tsNodeToParsedExpr2` bridge converts the return-object initializers in `memo-value.ts`. Go-only (mojo/xslate untouched); output is byte-identical (786/556 conformance + Go suites).

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -25,6 +25,7 @@ import type {
   CompilerError,
   SourceLocation,
   ParsedExpr,
+  ParsedExpr2,
   ObjectLiteralProperty,
   ParsedStatement,
   SortComparator,
@@ -2845,7 +2846,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       if (takenFieldNames.has(fieldName)) continue
       const c = this.state.localConstants.find(lc => lc.name === name && !lc.isModule && lc.value)
       if (!c?.value) continue
-      const expr = this.parseLiteralExpression(c.value)
+      const expr = c.parsed2
       if (!expr) continue
       // The field is typed `string`; only emit when the value is provably a Go
       // string, so a numeric/other const referenced in the template can't be
@@ -2870,48 +2871,43 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * string-valued, and a component-const reference to such a value. Anything
    * unproven (numbers, `props.X`, calls it doesn't know) returns false.
    */
-  private isStringExpr(node: ts.Expression, seen: Set<string>): boolean {
-    while (ts.isParenthesizedExpression(node)) node = node.expression
-    if (
-      ts.isStringLiteral(node) ||
-      ts.isNoSubstitutionTemplateLiteral(node) ||
-      ts.isTemplateExpression(node)
-    ) {
+  private isStringExpr(node: ParsedExpr2, seen: Set<string>): boolean {
+    // `+` and `||` / `??` are carried as `binary` / `logical`; the parser
+    // resolves template literals with substitutions to `unsupported` (so
+    // `parsed2` is undefined upstream), and a substitution-free template to a
+    // string `literal`.
+    if (node.kind === 'literal' && node.literalType === 'string') {
       return true
     }
-    if (ts.isBinaryExpression(node)) {
-      const op = node.operatorToken.kind
+    if (node.kind === 'binary' && node.op === '+') {
       // `+`: a string on *either* side forces string concatenation.
-      if (op === ts.SyntaxKind.PlusToken) {
-        return this.isStringExpr(node.left, seen) || this.isStringExpr(node.right, seen)
-      }
+      return this.isStringExpr(node.left, seen) || this.isStringExpr(node.right, seen)
+    }
+    if (node.kind === 'logical' && (node.op === '||' || node.op === '??')) {
       // `||` / `??` evaluate to *one* operand, so the result is only provably a
       // string when *both* sides are (`props.count ?? ''` is not — it can be the
       // number) (#1945 review).
-      if (op === ts.SyntaxKind.BarBarToken || op === ts.SyntaxKind.QuestionQuestionToken) {
-        return this.isStringExpr(node.left, seen) && this.isStringExpr(node.right, seen)
-      }
-      return false
+      return this.isStringExpr(node.left, seen) && this.isStringExpr(node.right, seen)
     }
-    if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
-      const m = node.expression.name.text
+    if (node.kind === 'call' && node.callee.kind === 'member') {
+      const m = node.callee.property
       const STRING_METHODS = new Set([
         'replace', 'trim', 'trimStart', 'trimEnd', 'toLowerCase', 'toUpperCase',
         'slice', 'substring', 'substr', 'padStart', 'padEnd', 'concat', 'repeat', 'get',
       ])
       return STRING_METHODS.has(m)
     }
-    if (ts.isConditionalExpression(node)) {
+    if (node.kind === 'conditional') {
       return (
-        this.isStringExpr(node.whenTrue, seen) && this.isStringExpr(node.whenFalse, seen)
+        this.isStringExpr(node.consequent, seen) && this.isStringExpr(node.alternate, seen)
       )
     }
-    if (ts.isIdentifier(node)) {
-      if (seen.has(node.text)) return false
-      const c = this.state.localConstants.find(lc => lc.name === node.text && !lc.isModule && lc.value)
+    if (node.kind === 'identifier') {
+      if (seen.has(node.name)) return false
+      const c = this.state.localConstants.find(lc => lc.name === node.name && !lc.isModule && lc.value)
       if (c?.value) {
-        const inner = this.parseLiteralExpression(c.value)
-        if (inner) return this.isStringExpr(inner, new Set([...seen, node.text]))
+        const inner = c.parsed2
+        if (inner) return this.isStringExpr(inner, new Set([...seen, node.name]))
       }
     }
     return false

--- a/packages/adapter-go-template/src/adapter/memo/ctor-lowering.ts
+++ b/packages/adapter-go-template/src/adapter/memo/ctor-lowering.ts
@@ -6,13 +6,13 @@
  * syntax) evaluated in the `NewXxxProps` constructor — e.g. a search-param read
  * becomes `in.SearchParams.Get("k")`. Mutually recursive (`lowerCtorExpr` ↔
  * `lowerCtorCond`), they read the context's `state.localConstants` /
- * `state.propsObjectName` and `parseLiteralExpression`, and set
- * `state.needsStringsImport` when they emit a `strings.*` call. Anything
- * outside the supported surface returns null so the caller can fall back to nil
- * safely.
+ * `state.propsObjectName` and each const's carried {@link ParsedExpr2}
+ * (`ConstantInfo.parsed2`), and set `state.needsStringsImport` when they emit a
+ * `strings.*` call. Anything outside the supported surface returns null so the
+ * caller can fall back to nil safely.
  */
 
-import ts from 'typescript'
+import type { ParsedExpr2 } from '@barefootjs/jsx'
 
 import type { GoEmitContext } from '../emit-context.ts'
 import type { CtorLowerEnv } from '../lib/types.ts'
@@ -29,38 +29,38 @@ import { capitalizeFieldName } from '../lib/go-naming.ts'
  */
 export function lowerCtorExpr(
   ctx: GoEmitContext,
-  node: ts.Expression,
+  node: ParsedExpr2,
   env: CtorLowerEnv,
 ): string | null {
-  while (ts.isParenthesizedExpression(node)) node = node.expression
-
-  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
-    return JSON.stringify(node.text)
+  if (node.kind === 'literal' && node.literalType === 'string') {
+    return JSON.stringify(node.value)
   }
-  if (ts.isNumericLiteral(node)) return node.text
+  if (node.kind === 'literal' && node.literalType === 'number') {
+    return node.raw ?? String(node.value)
+  }
 
   // Identifier: a substituted helper param, a module string const, or a
   // component-scope derived const inlined recursively (e.g. `root` → its
   // `base || '/'` value).
-  if (ts.isIdentifier(node)) {
-    const sub = env.params.get(node.text)
+  if (node.kind === 'identifier') {
+    const sub = env.params.get(node.name)
     if (sub !== undefined) return sub
-    const c = ctx.state.localConstants.find(lc => lc.name === node.text)
+    const c = ctx.state.localConstants.find(lc => lc.name === node.name)
     if (c?.value !== undefined) {
       if (c.isModule) {
-        const lit = ctx.parseLiteralExpression(c.value)
-        if (lit && (ts.isStringLiteral(lit) || ts.isNoSubstitutionTemplateLiteral(lit))) {
-          return JSON.stringify(lit.text)
+        const lit = c.parsed2
+        if (lit && lit.kind === 'literal' && lit.literalType === 'string') {
+          return JSON.stringify(lit.value)
         }
         return null
       }
       // Component-scope const: inline its computed value, guarding cycles.
-      if (env.consts?.has(node.text)) return null
-      const inner = ctx.parseLiteralExpression(c.value)
+      if (env.consts?.has(node.name)) return null
+      const inner = c.parsed2
       if (!inner) return null
       return lowerCtorExpr(ctx, inner, {
         ...env,
-        consts: new Set([...(env.consts ?? []), node.text]),
+        consts: new Set([...(env.consts ?? []), node.name]),
       })
     }
     return null
@@ -68,30 +68,32 @@ export function lowerCtorExpr(
 
   // `props.<X>` → the constructor input field `in.<X>`.
   if (
-    ts.isPropertyAccessExpression(node) &&
-    ts.isIdentifier(node.expression) &&
-    node.expression.text === ctx.state.propsObjectName
+    node.kind === 'member' &&
+    node.object.kind === 'identifier' &&
+    node.object.name === ctx.state.propsObjectName &&
+    !node.computed
   ) {
-    return `in.${capitalizeFieldName(node.name.text)}`
+    return `in.${capitalizeFieldName(node.property)}`
   }
 
-  if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
-    const method = node.expression.name.text
-    const recv = node.expression.expression
+  if (node.kind === 'call' && node.callee.kind === 'member') {
+    const method = node.callee.property
+    const recv = node.callee.object
     // `<sp>.get('k')` where <sp> is bound to searchParams().
     if (
       method === 'get' &&
-      ts.isIdentifier(recv) &&
-      env.searchParamsVars.has(recv.text) &&
-      node.arguments.length === 1 &&
-      ts.isStringLiteral(node.arguments[0])
+      recv.kind === 'identifier' &&
+      env.searchParamsVars.has(recv.name) &&
+      node.args.length === 1 &&
+      node.args[0].kind === 'literal' &&
+      node.args[0].literalType === 'string'
     ) {
-      return `in.SearchParams.Get(${JSON.stringify(node.arguments[0].text)})`
+      return `in.SearchParams.Get(${JSON.stringify(node.args[0].value)})`
     }
     // `<arr>.includes(<x>)` → bf.Includes(<[]string{…}>, <x>) (bool).
-    if (method === 'includes' && node.arguments.length === 1) {
+    if (method === 'includes' && node.args.length === 1) {
       const arr = lowerCtorStringArray(ctx, recv)
-      const elem = lowerCtorExpr(ctx, node.arguments[0], env)
+      const elem = lowerCtorExpr(ctx, node.args[0], env)
       if (arr !== null && elem !== null) return `bf.Includes(${arr}, ${elem})`
       return null
     }
@@ -100,12 +102,12 @@ export function lowerCtorExpr(
     // replace would need Go's regexp; out of scope).
     if (
       method === 'replace' &&
-      node.arguments.length === 2 &&
-      node.arguments[0].kind === ts.SyntaxKind.RegularExpressionLiteral &&
-      (node.arguments[0] as ts.Node).getText() === '/\\/+$/' &&
-      (ts.isStringLiteral(node.arguments[1]) ||
-        ts.isNoSubstitutionTemplateLiteral(node.arguments[1])) &&
-      node.arguments[1].text === ''
+      node.args.length === 2 &&
+      node.args[0].kind === 'regex' &&
+      node.args[0].raw === '/\\/+$/' &&
+      node.args[1].kind === 'literal' &&
+      node.args[1].literalType === 'string' &&
+      node.args[1].value === ''
     ) {
       const recvGo = lowerCtorExpr(ctx, recv, env)
       if (recvGo === null) return null
@@ -116,25 +118,19 @@ export function lowerCtorExpr(
   }
 
   // `helper(<args>)` where helper is a module arrow const → inline its body.
-  if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
+  if (node.kind === 'call' && node.callee.kind === 'identifier') {
+    const calleeName = node.callee.name
     const fnConst = ctx.state.localConstants.find(
-      lc => lc.name === (node.expression as ts.Identifier).text && lc.isModule,
+      lc => lc.name === calleeName && lc.isModule,
     )
     if (fnConst?.value) {
-      const fn = ctx.parseLiteralExpression(fnConst.value)
-      if (
-        fn &&
-        ts.isArrowFunction(fn) &&
-        !ts.isBlock(fn.body) &&
-        fn.parameters.length === node.arguments.length
-      ) {
+      const fn = fnConst.parsed2
+      if (fn && fn.kind === 'arrow' && fn.params.length === node.args.length) {
         const params = new Map(env.params)
-        for (let i = 0; i < fn.parameters.length; i++) {
-          const p = fn.parameters[i]
-          if (!ts.isIdentifier(p.name)) return null
-          const argGo = lowerCtorExpr(ctx, node.arguments[i], env)
+        for (let i = 0; i < fn.params.length; i++) {
+          const argGo = lowerCtorExpr(ctx, node.args[i], env)
           if (argGo === null) return null
-          params.set(p.name.text, argGo)
+          params.set(fn.params[i], argGo)
         }
         return lowerCtorExpr(ctx, fn.body, { searchParamsVars: env.searchParamsVars, params })
       }
@@ -143,16 +139,12 @@ export function lowerCtorExpr(
   }
 
   // `<expr> ?? <fallback>`
-  if (
-    ts.isBinaryExpression(node) &&
-    node.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken
-  ) {
+  if (node.kind === 'logical' && node.op === '??') {
     const left = lowerCtorExpr(ctx, node.left, env)
     if (left === null) return null
-    let r: ts.Expression = node.right
-    while (ts.isParenthesizedExpression(r)) r = r.expression
+    const r = node.right
     // `?? ''` is a no-op: SearchParams.Get already returns "" for a missing key.
-    if ((ts.isStringLiteral(r) || ts.isNoSubstitutionTemplateLiteral(r)) && r.text === '') {
+    if (r.kind === 'literal' && r.literalType === 'string' && r.value === '') {
       return left
     }
     const right = lowerCtorExpr(ctx, node.right, env)
@@ -162,10 +154,7 @@ export function lowerCtorExpr(
 
   // `<expr> || <fallback>` (string `||` — falsy = empty, like `?? ''` but the
   // left can itself be empty): `base || '/'`.
-  if (
-    ts.isBinaryExpression(node) &&
-    node.operatorToken.kind === ts.SyntaxKind.BarBarToken
-  ) {
+  if (node.kind === 'logical' && node.op === '||') {
     const left = lowerCtorExpr(ctx, node.left, env)
     const right = lowerCtorExpr(ctx, node.right, env)
     if (left === null || right === null) return null
@@ -173,15 +162,15 @@ export function lowerCtorExpr(
   }
 
   // `<cond> ? <t> : <f>` (string result)
-  if (ts.isConditionalExpression(node)) {
+  if (node.kind === 'conditional') {
     // The condition must be lowered as a *boolean* (`lowerCtorCond`), not a
     // value: a string-valued JS condition like `sp.get('tag') ? a : b` is
     // truthy in JS, but `if "<string>"` does not compile in Go — such shapes
     // return null so the memo falls back to nil rather than emitting invalid
     // code (#1941 review).
-    const cond = lowerCtorCond(ctx, node.condition, env)
-    const t = lowerCtorExpr(ctx, node.whenTrue, env)
-    const f = lowerCtorExpr(ctx, node.whenFalse, env)
+    const cond = lowerCtorCond(ctx, node.test, env)
+    const t = lowerCtorExpr(ctx, node.consequent, env)
+    const f = lowerCtorExpr(ctx, node.alternate, env)
     if (cond !== null && t !== null && f !== null) {
       return `func() string { if ${cond} { return ${t} }; return ${f} }()`
     }
@@ -200,44 +189,33 @@ export function lowerCtorExpr(
  */
 export function lowerCtorCond(
   ctx: GoEmitContext,
-  node: ts.Expression,
+  node: ParsedExpr2,
   env: CtorLowerEnv,
 ): string | null {
-  while (ts.isParenthesizedExpression(node)) node = node.expression
-
-  if (node.kind === ts.SyntaxKind.TrueKeyword) return 'true'
-  if (node.kind === ts.SyntaxKind.FalseKeyword) return 'false'
+  if (node.kind === 'literal' && node.literalType === 'boolean') {
+    return String(node.value)
+  }
 
   // `!<cond>`
-  if (
-    ts.isPrefixUnaryExpression(node) &&
-    node.operator === ts.SyntaxKind.ExclamationToken
-  ) {
-    const inner = lowerCtorCond(ctx, node.operand, env)
+  if (node.kind === 'unary' && node.op === '!') {
+    const inner = lowerCtorCond(ctx, node.argument, env)
     return inner === null ? null : `!(${inner})`
   }
 
   // `<a> && <b>` / `<a> || <b>` — both operands must themselves be boolean.
-  if (ts.isBinaryExpression(node)) {
-    const op =
-      node.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken
-        ? '&&'
-        : node.operatorToken.kind === ts.SyntaxKind.BarBarToken
-          ? '||'
-          : null
-    if (op) {
-      const l = lowerCtorCond(ctx, node.left, env)
-      const r = lowerCtorCond(ctx, node.right, env)
-      return l !== null && r !== null ? `(${l} ${op} ${r})` : null
-    }
+  if (node.kind === 'logical' && (node.op === '&&' || node.op === '||')) {
+    const op = node.op
+    const l = lowerCtorCond(ctx, node.left, env)
+    const r = lowerCtorCond(ctx, node.right, env)
+    return l !== null && r !== null ? `(${l} ${op} ${r})` : null
   }
 
   // `<arr>.includes(<x>)` is the one value-shape `lowerCtorExpr` lowers to a
   // Go bool (`bf.Includes(...)`); reuse it for that case only.
   if (
-    ts.isCallExpression(node) &&
-    ts.isPropertyAccessExpression(node.expression) &&
-    node.expression.name.text === 'includes'
+    node.kind === 'call' &&
+    node.callee.kind === 'member' &&
+    node.callee.property === 'includes'
   ) {
     return lowerCtorExpr(ctx, node, env)
   }
@@ -250,18 +228,18 @@ export function lowerCtorCond(
  * bound to one) to a Go `[]string{…}` literal, or null when it isn't a pure
  * string-array. Used by `lowerCtorExpr` for `<arr>.includes(<x>)`.
  */
-export function lowerCtorStringArray(ctx: GoEmitContext, node: ts.Expression): string | null {
-  let arr: ts.Expression | null = node
-  if (ts.isIdentifier(node)) {
-    const c = ctx.state.localConstants.find(lc => lc.name === node.text && lc.isModule)
+export function lowerCtorStringArray(ctx: GoEmitContext, node: ParsedExpr2): string | null {
+  let arr: ParsedExpr2 | null = node
+  if (node.kind === 'identifier') {
+    const c = ctx.state.localConstants.find(lc => lc.name === node.name && lc.isModule)
     if (!c?.value) return null
-    arr = ctx.parseLiteralExpression(c.value)
+    arr = c.parsed2 ?? null
   }
-  if (!arr || !ts.isArrayLiteralExpression(arr)) return null
+  if (!arr || arr.kind !== 'array-literal') return null
   const elems: string[] = []
   for (const el of arr.elements) {
-    if (ts.isStringLiteral(el) || ts.isNoSubstitutionTemplateLiteral(el)) {
-      elems.push(JSON.stringify(el.text))
+    if (el.kind === 'literal' && el.literalType === 'string') {
+      elems.push(JSON.stringify(el.value))
     } else return null
   }
   return `[]string{${elems.join(', ')}}`

--- a/packages/adapter-go-template/src/adapter/memo/memo-value.ts
+++ b/packages/adapter-go-template/src/adapter/memo/memo-value.ts
@@ -13,6 +13,7 @@
 import ts from 'typescript'
 
 import type { ParsedStatement, TypeInfo } from '@barefootjs/jsx'
+import { tsNodeToParsedExpr2 } from '@barefootjs/jsx'
 
 import type { GoEmitContext } from '../emit-context.ts'
 import type { CtorLowerEnv } from '../lib/types.ts'
@@ -151,7 +152,7 @@ export function computeObjectMemoInitialValue(ctx: GoEmitContext, computation: s
     const key =
       ts.isIdentifier(prop.name) || ts.isStringLiteral(prop.name) ? prop.name.text : null
     if (!key) return null
-    const go = lowerCtorExpr(ctx, prop.initializer, env)
+    const go = lowerCtorExpr(ctx, tsNodeToParsedExpr2(prop.initializer), env)
     if (go === null) return null
     entries.push(`"${capitalizeFieldName(key)}": ${go}`)
   }

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -8,7 +8,7 @@
 
 import ts from 'typescript'
 import type { ImportSpecifier, TypeInfo, ParamInfo, ReactiveFactoryInfo } from './types.ts'
-import { parseExpression, parseBlockBodyTolerant } from './expression-parser.ts'
+import { parseExpression, parseExpression2, parseBlockBodyTolerant } from './expression-parser.ts'
 import { rewriteBarePropRefs } from './prop-rewrite.ts'
 import { incrementCounter } from './instrumentation.ts'
 import {
@@ -2829,10 +2829,20 @@ function collectConstant(
       ? parseExpression(`(${value.trim()})`)
       : undefined
 
+  // Go-only constructor-lowering tree (#2006). Unlike `parsed` (module-only),
+  // this is carried for component-scope consts too — `lowerCtorExpr` inlines a
+  // derived component const's value (`base || '/'`) recursively. Best-effort;
+  // an unrepresentable shape leaves `parsed2` undefined and the adapter falls
+  // back. Other adapters ignore it.
+  const parsed2Raw =
+    value && !isJsx && !isJsxFunction ? parseExpression2(`(${value.trim()})`) : undefined
+  const parsed2 = parsed2Raw && parsed2Raw.kind !== 'unsupported' ? parsed2Raw : undefined
+
   ctx.localConstants.push({
     name,
     value,
     parsed,
+    parsed2,
     typedValue: typedValue !== value ? typedValue : undefined,
     valueBranches,
     declarationKind,

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -792,6 +792,16 @@ export function parseExpression2(expr: string): ParsedExpr2 {
   return convertNode2(firstStmt.expression, expr)
 }
 
+/**
+ * Convert an already-parsed TypeScript node directly into a {@link ParsedExpr2}.
+ * The caller-2 bridge for the Go ctor lowering: lets a consumer that already
+ * holds a `ts.Node` (e.g. a return-object initializer) reuse the same structured
+ * conversion without re-parsing source via `ts.createSourceFile`.
+ */
+export function tsNodeToParsedExpr2(node: ts.Node): ParsedExpr2 {
+  return convertNode2(node, '')
+}
+
 /** Convert a TypeScript AST node to {@link ParsedExpr2} (parentheses unwrapped). */
 function convertNode2(node: ts.Node, raw: string): ParsedExpr2 {
   while (ts.isParenthesizedExpression(node)) node = node.expression

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -799,7 +799,16 @@ export function parseExpression2(expr: string): ParsedExpr2 {
  * conversion without re-parsing source via `ts.createSourceFile`.
  */
 export function tsNodeToParsedExpr2(node: ts.Node): ParsedExpr2 {
-  return convertNode2(node, '')
+  // Preserve the node's source in `raw` (like `parseExpression2`), so an
+  // `unsupported` result still carries the original text for debugging. A
+  // synthetic node with no source file can't yield text — fall back to ''.
+  let raw = ''
+  try {
+    raw = node.getText()
+  } catch {
+    /* synthetic node without a source file */
+  }
+  return convertNode2(node, raw)
 }
 
 /** Convert a TypeScript AST node to {@link ParsedExpr2} (parentheses unwrapped). */

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -254,7 +254,7 @@ export {
 export { ErrorCodes, createError, formatError, generateCodeFrame } from './errors.ts'
 
 // Expression Parser
-export { parseExpression, parseExpression2, isSupported, exprToString, stringifyParsedExpr, identifierPath, parseBlockBody, parseBlockBodyTolerant, containsHigherOrder, extractArrowBodyExpression, parseStyleObjectEntries, parseProviderObjectLiteral, type ProviderObjectMember } from './expression-parser.ts'
+export { parseExpression, parseExpression2, tsNodeToParsedExpr2, isSupported, exprToString, stringifyParsedExpr, identifierPath, parseBlockBody, parseBlockBodyTolerant, containsHigherOrder, extractArrowBodyExpression, parseStyleObjectEntries, parseProviderObjectLiteral, type ProviderObjectMember } from './expression-parser.ts'
 export type { StyleObjectEntry } from './expression-parser.ts'
 export type { ParsedExpr, ParsedExpr2, ParsedExpr2Property, ObjectLiteralProperty, ParsedStatement, SortComparator, SortKey, ReduceOp, FlatDepth, FlatMapOp, FlatMapLeaf, SupportLevel, SupportResult, TemplatePart } from './expression-parser.ts'
 export { buildLoopChainExpr } from './loop-chain.ts'

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -4,7 +4,7 @@
  * JSX-independent intermediate representation for multi-backend support.
  */
 
-import type { ParsedExpr, ParsedStatement, SortComparator } from './expression-parser.ts'
+import type { ParsedExpr, ParsedExpr2, ParsedStatement, SortComparator } from './expression-parser.ts'
 
 // =============================================================================
 // Source Location (for Error Reporting)
@@ -1377,6 +1377,16 @@ export interface ConstantInfo {
    * couldn't structure it (best-effort — consumers fall back to the string).
    */
   parsed?: ParsedExpr
+  /**
+   * `value` parsed into the Go-adapter constructor-lowering tree
+   * ({@link ParsedExpr2}, issue #2006). Attached best-effort for module AND
+   * component-scope consts (parsed from the parenthesised value, like
+   * `parsed`). Carries the multi-param-arrow and regex shapes `ParsedExpr`
+   * can't model, so the Go ctor lowerers (`lowerCtorExpr`) read it instead of
+   * re-parsing the value with `ts.createSourceFile`. Go-only — other adapters
+   * ignore it. Absent when there's no `value` or the shape isn't representable.
+   */
+  parsed2?: ParsedExpr2
   /** Value with TypeScript type annotations preserved, for .tsx output */
   typedValue?: string
   valueBranches?: string[]


### PR DESCRIPTION
## Terminal sweep — constructor lowering from the IR (U2 + U3)

Stacked on #2010 (the `ParsedExpr2` foundation). Removes 6 of the adapter's `parseLiteralExpression` call sites by reading the carried `ParsedExpr2` tree instead of re-parsing const values with `ts.createSourceFile`.

### U2 — `ConstantInfo.parsed2`
The analyzer attaches a `ParsedExpr2` tree to each const (module **and** component scope — `lowerCtorExpr` inlines derived component consts recursively), best-effort. Additive, Go-only (other adapters ignore `parsed2`).

### U3 — port `ctor-lowering.ts`
`lowerCtorExpr` / `lowerCtorCond` / `lowerCtorStringArray` now consume `ParsedExpr2` instead of `ts.Expression`; every `ts.is*` branch maps to the equivalent `kind` check, preserving the exact Go output strings and the recursion/cycle-guard structure (`import ts` dropped). Const + helper resolution reads `c.parsed2`.
- `computeDerivedConstFields` + `isStringExpr` (in `go-template-adapter.ts`) read `c.parsed2`.
- `computeObjectMemoInitialValue` bridges its already-parsed return-object initializers via a new `tsNodeToParsedExpr2` (no new `createSourceFile`); its own line-134 parse is removed in a later unit.

**Removed:** the 4 `ctor-lowering.ts` `parseLiteralExpression` calls + the 2 derived-const caller sites.

### Byte-identical
conformance **786**, go units **556**, jsx + go `tsgo` clean. Method calls modelled uniformly as `call`+`member`; numeric literals emit the exact `raw` token. mojo/xslate untouched (separate `ParsedExpr2`, not in the shared emitter).

### Next in stack
U4 helper-inline/url-builder; U5 spread; U6 data-literal callers + object-memo; U7 deletes `parseLiteralExpression`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_