### PR TITLE
refactor(jsx,go-template): carry SpreadAttr.parsed; lower conditional spread from the IR (#2006)

### DIFF
--- a/.changeset/spread-conditional-parsed.md
+++ b/.changeset/spread-conditional-parsed.md
@@ -1,0 +1,6 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+---
+
+Carry a `SpreadAttr.parsed` tree on the IR so the Go adapter's conditional inline-object spread codegen lowers from the parsed tree instead of re-parsing the spread source with `ts.createSourceFile` (`parseLiteralExpression`). Additive and best-effort (mirrors `ExpressionAttr.parsed`); the generated Go is byte-identical (786/556 conformance + go-template tests unchanged).

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -1492,7 +1492,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // `spreadSlots` is computed once in `generateTypes` and threaded
     // through to avoid a second IR walk (#1411 review).
     for (const slot of spreadSlots) {
-      const goExpr = buildSpreadInitializer(this.emitCtx, slot.expr, ir)
+      const goExpr = buildSpreadInitializer(this.emitCtx, slot.expr, ir, slot.parsed)
       if (goExpr) {
         lines.push(`\t\t${slot.slotId}: ${goExpr},`)
       } else {

--- a/packages/adapter-go-template/src/adapter/lib/types.ts
+++ b/packages/adapter-go-template/src/adapter/lib/types.ts
@@ -133,7 +133,9 @@ export interface SpreadSlotInfo {
    * Best-effort structured parse of `expr` carried from `SpreadAttr.parsed`
    * (#2006). Lets `buildConditionalSpreadInitializer` lower the conditional
    * inline-object spread from the tree instead of re-parsing `expr` with
-   * `ts.createSourceFile`. Absent / `unsupported` → former string path.
+   * `ts.createSourceFile`. When absent, `buildSpreadInitializer` parses `expr`
+   * once with `parseExpression`; a non-conditional or `unsupported` tree just
+   * falls through to the other spread shapes (there is no separate legacy path).
    */
   parsed: ParsedExpr | undefined
   templateExpr: string | undefined

--- a/packages/adapter-go-template/src/adapter/lib/types.ts
+++ b/packages/adapter-go-template/src/adapter/lib/types.ts
@@ -11,6 +11,7 @@ import type {
   IRLoopChildComponent,
   IRNode,
   IRProp,
+  ParsedExpr,
   TypeInfo,
 } from '@barefootjs/jsx'
 
@@ -128,6 +129,13 @@ export interface ChildComponentShape {
 export interface SpreadSlotInfo {
   slotId: string
   expr: string
+  /**
+   * Best-effort structured parse of `expr` carried from `SpreadAttr.parsed`
+   * (#2006). Lets `buildConditionalSpreadInitializer` lower the conditional
+   * inline-object spread from the tree instead of re-parsing `expr` with
+   * `ts.createSourceFile`. Absent / `unsupported` → former string path.
+   */
+  parsed: ParsedExpr | undefined
   templateExpr: string | undefined
   bagSource: 'inline' | 'input-bag'
 }

--- a/packages/adapter-go-template/src/adapter/spread/spread-codegen.ts
+++ b/packages/adapter-go-template/src/adapter/spread/spread-codegen.ts
@@ -8,13 +8,15 @@
  *     initial value placed inside `NewXxxProps` (#1407): signal-getter object
  *     literals, destructured / SolidJS-style / rest props, and conditional
  *     inline-object spreads.
- * They read `state.restPropsName` / `state.usesFmt` and `parseLiteralExpression`;
- * everything else comes from the per-call `ComponentIR`.
+ * They read `state.restPropsName` / `state.usesFmt`; the conditional inline-
+ * object spread is lowered from the carried `SpreadAttr.parsed` tree (#2006)
+ * rather than re-parsing the source with `ts.createSourceFile`. Everything else
+ * comes from the per-call `ComponentIR`.
  */
 
 import ts from 'typescript'
 
-import { parseRecordIndexAccess } from '@barefootjs/jsx'
+import { parseExpression, parseRecordIndexAccess } from '@barefootjs/jsx'
 import type {
   ComponentIR,
   IRNode,
@@ -76,6 +78,7 @@ function collectSpreadSlotsRecursive(ctx: GoEmitContext, node: IRNode, result: S
       result.push({
         slotId: attr.value.slotId,
         expr: attr.value.expr,
+        parsed: attr.value.parsed,
         templateExpr: attr.value.templateExpr,
         bagSource: classifySpreadBagSource(ctx, attr.value.expr),
       })
@@ -222,6 +225,7 @@ export function buildSpreadInitializer(
   ctx: GoEmitContext,
   spreadExpr: string,
   ir: ComponentIR,
+  parsed?: ParsedExpr,
 ): string | null {
   const trimmed = spreadExpr.trim()
   // Conditional inline-object spread:
@@ -231,7 +235,12 @@ export function buildSpreadInitializer(
   // is OMITTED rather than rendered as `k=""` — `SpreadAttrs` does
   // NOT filter empty strings). Returns null for any shape it can't
   // faithfully convert so the caller falls back to BF101 (#textarea).
-  const conditional = buildConditionalSpreadInitializer(ctx, trimmed, ir)
+  // Consume the carried `SpreadAttr.parsed` tree (#2006); when absent
+  // (older/hand-built IR), parse `trimmed` once as a fallback so the
+  // shape is still recognised without re-introducing the per-attribute
+  // `ts.createSourceFile` parse on the build hot path.
+  const conditionalTree = parsed ?? parseExpression(trimmed)
+  const conditional = buildConditionalSpreadInitializer(ctx, conditionalTree, ir)
   if (conditional !== undefined) return conditional
   // Signal-getter call: `attrs()` — pluck the signal's initialValue
   // and translate the JS object literal to a Go map literal.
@@ -298,7 +307,7 @@ export function buildSpreadInitializer(
       // Reject a const resolving to a bare identifier to avoid an
       // unbounded resolution loop / non-literal forwarding.
       if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(initTrimmed)) {
-        const resolved = buildConditionalSpreadInitializer(ctx, initTrimmed, ir)
+        const resolved = buildConditionalSpreadInitializer(ctx, parseExpression(initTrimmed), ir)
         // `undefined` → not a conditional-spread shape; fall through to
         // BF101. `null` → that shape but unconvertible; also BF101.
         if (resolved) return resolved
@@ -334,18 +343,19 @@ export function buildSpreadInitializer(
  */
 function buildConditionalSpreadInitializer(
   ctx: GoEmitContext,
-  spreadExpr: string,
+  expr: ParsedExpr | undefined,
   ir: ComponentIR,
 ): string | null | undefined {
-  const expr = ctx.parseLiteralExpression(spreadExpr)
-  if (!expr || !ts.isConditionalExpression(expr)) return undefined
-  const whenTrue = unwrapParens(expr.whenTrue)
-  const whenFalse = unwrapParens(expr.whenFalse)
-  if (!ts.isObjectLiteralExpression(whenTrue) || !ts.isObjectLiteralExpression(whenFalse)) {
+  // `parseExpression` already unwraps redundant parentheses, so the
+  // conditional / object-literal shapes surface directly.
+  if (!expr || expr.kind !== 'conditional') return undefined
+  const whenTrue = expr.consequent
+  const whenFalse = expr.alternate
+  if (whenTrue.kind !== 'object-literal' || whenFalse.kind !== 'object-literal') {
     return undefined
   }
   // Condition → Go bool against `in.`, type-aware on the prop.
-  const goCond = conditionToGoBool(expr.condition, ir)
+  const goCond = conditionToGoBool(expr.test, ir)
   if (goCond === null) return null
   const trueMap = objectLiteralToGoSpreadMap(ctx, whenTrue, ir)
   const falseMap = objectLiteralToGoSpreadMap(ctx, whenFalse, ir)
@@ -358,13 +368,6 @@ function buildConditionalSpreadInitializer(
     `\t\treturn ${falseMap}\n` +
     `\t}()`
   )
-}
-
-/** Strip redundant parenthesised wrappers off a TS expression. */
-function unwrapParens(node: ts.Expression): ts.Expression {
-  let e = node
-  while (ts.isParenthesizedExpression(e)) e = e.expression
-  return e
 }
 
 /**
@@ -382,17 +385,18 @@ function unwrapParens(node: ts.Expression): ts.Expression {
  * Returns null for any other shape (caller → BF101).
  */
 function conditionToGoBool(
-  condition: ts.Expression,
+  condition: ParsedExpr,
   ir: ComponentIR,
 ): string | null {
-  let node = unwrapParens(condition)
+  // Parens are already stripped by `parseExpression`.
+  let node = condition
   let negate = false
-  if (ts.isPrefixUnaryExpression(node) && node.operator === ts.SyntaxKind.ExclamationToken) {
+  if (node.kind === 'unary' && node.op === '!') {
     negate = true
-    node = unwrapParens(node.operand)
+    node = node.argument
   }
-  if (!ts.isIdentifier(node)) return null
-  const param = ir.metadata.propsParams.find(p => p.name === node.text)
+  if (node.kind !== 'identifier') return null
+  const param = ir.metadata.propsParams.find(p => p.name === node.name)
   if (!param) return null
   const field = `in.${capitalizeFieldName(param.name)}`
   const prim = param.type.kind === 'primitive' ? param.type.primitive : undefined
@@ -429,26 +433,25 @@ function conditionToGoBool(
  */
 function objectLiteralToGoSpreadMap(
   ctx: GoEmitContext,
-  obj: ts.ObjectLiteralExpression,
+  obj: Extract<ParsedExpr, { kind: 'object-literal' }>,
   ir: ComponentIR,
 ): string | null {
   const entries: string[] = []
   for (const prop of obj.properties) {
-    if (!ts.isPropertyAssignment(prop)) return null
-    let key: string
-    if (ts.isIdentifier(prop.name)) {
-      key = prop.name.text
-    } else if (ts.isStringLiteral(prop.name) || ts.isNoSubstitutionTemplateLiteral(prop.name)) {
-      key = prop.name.text
-    } else {
-      return null
-    }
-    const val = unwrapParens(prop.initializer)
+    // Shorthand (`{ describedBy }`) was a `ShorthandPropertyAssignment` — not a
+    // `PropertyAssignment` — so the former parser rejected it; keep refusing.
+    if (prop.shorthand) return null
+    // Numeric keys (`{ 1: x }`) were rejected by the former parser (only
+    // identifier / string-literal names were accepted); `keyKind` distinguishes
+    // them from a string `'1'` key.
+    if (prop.keyKind === 'numeric') return null
+    const key = prop.key
+    const val = prop.value
     let goVal: string
-    if (ts.isStringLiteral(val) || ts.isNoSubstitutionTemplateLiteral(val)) {
-      goVal = JSON.stringify(val.text)
-    } else if (ts.isIdentifier(val)) {
-      const param = ir.metadata.propsParams.find(p => p.name === val.text)
+    if (val.kind === 'literal' && val.literalType === 'string') {
+      goVal = JSON.stringify(val.value)
+    } else if (val.kind === 'identifier') {
+      const param = ir.metadata.propsParams.find(p => p.name === val.name)
       if (!param) return null
       goVal = `in.${capitalizeFieldName(param.name)}`
     } else {
@@ -479,13 +482,29 @@ function objectLiteralToGoSpreadMap(
  */
 function recordIndexAccessToGoMap(
   ctx: GoEmitContext,
-  val: ts.Expression,
+  val: ParsedExpr,
   ir: ComponentIR,
 ): string | null {
+  // `parseRecordIndexAccess` (the shared single-source-of-truth parser) takes a
+  // `ts.Expression`. The only shape it accepts is `IDENT[KEY]` with identifier
+  // object and index, so rebuild exactly that node from the carried tree via
+  // `ts.factory` — no source-text re-parse needed. Any other shape can't match
+  // and short-circuits to `null` here.
+  if (
+    val.kind !== 'index-access'
+    || val.object.kind !== 'identifier'
+    || val.index.kind !== 'identifier'
+  ) {
+    return null
+  }
+  const tsVal = ts.factory.createElementAccessExpression(
+    ts.factory.createIdentifier(val.object.name),
+    ts.factory.createIdentifier(val.index.name),
+  )
   // Shared structural parse (single source of truth in `@barefootjs/jsx`);
   // this wrapper only does the Go-specific emit from the structured result.
   const parsed = parseRecordIndexAccess(
-    val,
+    tsVal,
     ir.metadata.localConstants ?? [],
     ir.metadata.propsParams,
   )

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -574,6 +574,9 @@ function attachParsedExpressions(node: IRNode): void {
       if (attr.value.kind === 'expression') {
         const trimmed = attr.value.expr.trim()
         if (trimmed) attr.value.parsed = parseExpression(trimmed)
+      } else if (attr.value.kind === 'spread') {
+        const trimmed = attr.value.expr.trim()
+        if (trimmed) attr.value.parsed = parseExpression(trimmed)
       }
     }
   }

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -913,9 +913,10 @@ export interface SpreadAttr {
    * Structured parse of `expr` (`parseExpression(expr.trim())`), attached
    * during IR construction so adapters lower the spread bag from the tree
    * instead of re-parsing the string with `ts.createSourceFile`. Optional /
-   * best-effort — mirrors `ExpressionAttr.parsed`: a node the attach walk
-   * misses, an empty `expr`, or an `unsupported` parse simply leaves the
-   * adapter to fall back to its former string path.
+   * best-effort — mirrors `ExpressionAttr.parsed`: it may be absent (a node the
+   * attach walk misses, or an empty `expr`), and parsing may yield
+   * `{ kind: 'unsupported' }`, which adapters treat as unlowerable and handle
+   * via their existing non-conditional spread paths (or BF101).
    */
   parsed?: ParsedExpr
   /**

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -910,6 +910,15 @@ export interface SpreadAttr {
   expr: string
   templateExpr?: string
   /**
+   * Structured parse of `expr` (`parseExpression(expr.trim())`), attached
+   * during IR construction so adapters lower the spread bag from the tree
+   * instead of re-parsing the string with `ts.createSourceFile`. Optional /
+   * best-effort — mirrors `ExpressionAttr.parsed`: a node the attach walk
+   * misses, an empty `expr`, or an `unsupported` parse simply leaves the
+   * adapter to fall back to its former string path.
+   */
+  parsed?: ParsedExpr
+  /**
    * Component-scoped, stable slot ID assigned at IR-build time for
    * adapters that need to plumb the spread bag through a structured
    * data path (Go template's `.Spread_N`, future Mojo `$bf_spread_n`).


### PR DESCRIPTION
## Terminal sweep — conditional spread from the IR (U5)

Independent of the ParsedExpr2 stack (#2010/#2011) — this shape is all plain `ParsedExpr`, so no new type is needed. Removes the `spread-codegen.ts` `ts.createSourceFile`.

- **jsx (additive):** `SpreadAttr` gains `parsed?: ParsedExpr`, attached by `jsx-to-ir.ts`'s `attachParsedExpressions` (exact mirror of the `ExpressionAttr.parsed` branch). Other adapters ignore it.
- **Go adapter:** `SpreadSlotInfo` carries `parsed`; `buildConditionalSpreadInitializer` / `conditionToGoBool` / `objectLiteralToGoSpreadMap` / `recordIndexAccessToGoMap` rewritten to walk `ParsedExpr` (`conditional` / `object-literal` / `identifier` / `unary` / `index-access`) instead of re-parsing the spread string. `unwrapParens` deleted (parens pre-stripped). The `parseLiteralExpression` call is removed (`spread-codegen.ts` count → 0).

### Byte-identical
conformance **786**, go units **556**, jsx + go `tsgo` clean. Go output strings preserved byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_