### PR TITLE
refactor(go-template): data-literal callers from carried ParsedExpr — struct-synth, object-map, scalar-array (#2006)

### DIFF
--- a/.changeset/object-map-scalar-array-parsed.md
+++ b/.changeset/object-map-scalar-array-parsed.md
@@ -1,0 +1,20 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+---
+
+Read carried `ParsedExpr` trees in two more Go-adapter lowerings instead of
+re-parsing source strings with `ts.createSourceFile` (Roadmap A terminal
+sweep). Object-literal child-prop maps — an inline object passed to a child's
+optional object prop (`<Carousel opts={{ align: 'start' }}>` →
+`map[string]interface{}`) — now lower from the `ExpressionAttr.parsed`
+`object-literal` tree via `objectLiteralToGoMap`. Scalar-literal loop typing —
+`[1,2,3,4,5].map(...)` style loops whose `BfLoopItem` field types as
+`interface{}` — now read a new `IRLoop.arrayParsed` (attached in `jsx-to-ir.ts`
+as the parse of the same `array` string the adapter consumes, threaded through
+`NestedComponentInfo.loopArrayParsed`) instead of re-parsing the loop's array
+string in `scalarLiteralLoopGoType`. Both reproduce the previous output
+byte-for-byte (string via `JSON.stringify`, numbers via the carried `raw`
+token, unary-minus numbers preserved) and fall back / defer identically when
+the tree is absent or unsupported — verified by the adapter conformance and Go
+adapter suites (786 / 556).

--- a/.changeset/struct-synth-parsed.md
+++ b/.changeset/struct-synth-parsed.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Untyped object-array signal struct synthesis now reads the analyzer-carried `signal.parsed` tree instead of re-parsing `initialValue` with `ts.createSourceFile` (`parseLiteralExpression`). Byte-identical output (786 adapter-tests / 556 go-template).

--- a/packages/adapter-go-template/src/adapter/analysis/component-tree.ts
+++ b/packages/adapter-go-template/src/adapter/analysis/component-tree.ts
@@ -132,6 +132,7 @@ function collectNestedComponents(node: IRNode, result: NestedComponentInfo[]): v
           loopParam: loop.param ?? undefined,
           bodyChildren: hasBodyChildren ? loop.childComponent.children : undefined,
           loopArray: loop.array,
+          loopArrayParsed: loop.arrayParsed,
           loopMarkerId: loop.markerId,
           loopItemType: loop.itemType,
         })

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -700,7 +700,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * existing type) returns `null`.
    */
   private synthesizeStructFromSignal(
-    signal: { getter: string; type: TypeInfo; initialValue: string },
+    signal: { getter: string; type: TypeInfo; initialValue: string; parsed?: ParsedExpr },
     componentName: string,
   ): { name: string; fields: Array<{ tsName: string; goName: string; goType: string }> } | null {
     // Only untyped arrays: a typed (`Item[]`) or scalar (`string[]`) element
@@ -709,8 +709,11 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     const elem = signal.type.elementType
     if (elem && elem.kind !== 'unknown') return null
 
-    const node = this.parseLiteralExpression(signal.initialValue)
-    if (!node || !ts.isArrayLiteralExpression(node) || node.elements.length === 0) return null
+    // Walk the analyzer-carried structured tree (#2006) instead of re-parsing
+    // `initialValue` with `ts.createSourceFile`. Absent / non-array-literal
+    // initial values simply don't synthesise a struct.
+    const node = signal.parsed
+    if (!node || node.kind !== 'array-literal' || node.elements.length === 0) return null
 
     // Collect the field order + per-key Go types from the first element, then
     // require every other element to match exactly.
@@ -718,20 +721,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     const goTypes = new Map<string, string>()
     for (let i = 0; i < node.elements.length; i++) {
       const el = node.elements[i]
-      if (!ts.isObjectLiteralExpression(el)) return null
+      if (el.kind !== 'object-literal') return null
       const seen = new Set<string>()
       for (const prop of el.properties) {
-        if (!ts.isPropertyAssignment(prop)) return null
-        if (
-          !ts.isIdentifier(prop.name) &&
-          !ts.isStringLiteral(prop.name) &&
-          !ts.isNumericLiteral(prop.name)
-        ) {
-          return null
-        }
-        const key = prop.name.text
+        // Shorthand `{ a }` is not a `ts.PropertyAssignment`, so the old
+        // ts-AST walk bailed synthesis on it; keep that.
+        if (prop.shorthand) return null
+        const key = prop.key
         if (!GO_IDENTIFIER.test(key)) return null
-        const goType = this.scalarLiteralGoType(prop.initializer)
+        const goType = this.scalarParsedGoType(prop.value)
         if (!goType) return null
         seen.add(key)
         const prev = goTypes.get(key)
@@ -764,23 +762,26 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   /**
-   * The Go type for a scalar JS literal used as a synthesised struct field
-   * value, or `null` for anything non-scalar (objects, arrays, identifiers,
-   * calls, interpolated templates) so the caller bails out of synthesis.
+   * The Go type for a scalar literal `ParsedExpr` used as a synthesised struct
+   * field value, or `null` for anything non-scalar (objects, arrays,
+   * identifiers, calls, interpolated templates) so the caller bails out of
+   * synthesis. Mirrors the former ts-AST `scalarLiteralGoType` byte-for-byte:
+   * a string / no-substitution template literal → `string`, a numeric literal
+   * (optionally prefix-negated) → its int/float64 type via `numericLiteralGoType`
+   * over the carried `raw` token, a boolean → `bool` (#2006).
    */
-  private scalarLiteralGoType(node: ts.Expression): string | null {
-    if (
-      ts.isPrefixUnaryExpression(node) &&
-      node.operator === ts.SyntaxKind.MinusToken &&
-      ts.isNumericLiteral(node.operand)
-    ) {
-      return this.numericLiteralGoType(node.operand.text)
+  private scalarParsedGoType(value: ParsedExpr): string | null {
+    // `-5` parses to a unary minus over a numeric literal; classify by the
+    // inner literal exactly like the old `ts.isPrefixUnaryExpression` branch.
+    if (value.kind === 'unary' && value.op === '-' && value.argument.kind === 'literal') {
+      const inner = value.argument
+      if (inner.literalType === 'number') return this.numericLiteralGoType(inner.raw ?? String(inner.value))
+      return null
     }
-    if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) return 'string'
-    if (ts.isNumericLiteral(node)) return this.numericLiteralGoType(node.text)
-    if (node.kind === ts.SyntaxKind.TrueKeyword || node.kind === ts.SyntaxKind.FalseKeyword) {
-      return 'bool'
-    }
+    if (value.kind !== 'literal') return null
+    if (value.literalType === 'string') return 'string'
+    if (value.literalType === 'number') return this.numericLiteralGoType(value.raw ?? String(value.value))
+    if (value.literalType === 'boolean') return 'bool'
     return null
   }
 

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -970,7 +970,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // (#1971) Scalar-item loop (`[1,2,3,4,5].map(n => …{n}…)`) — no datum
     // fields, so carry the whole range value here; the loop's body define is
     // fed `.BfLoopItem` and renders the bare param.
-    const scalarLoopType = this.scalarLiteralLoopGoType(nested.loopArray, nested.loopItemType)
+    const scalarLoopType = this.scalarLiteralLoopGoType(nested.loopArrayParsed, nested.loopItemType)
     if (scalarLoopType && datumFields.length === 0) {
       lines.push(`\tBfLoopItem ${scalarLoopType} \`json:"-"\``)
     }
@@ -1032,20 +1032,28 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * the existing datum-field path). AST-based to avoid misreading literals.
    */
   private scalarLiteralLoopGoType(
-    arrayText: string | undefined,
+    arrayParsed: ParsedExpr | undefined,
     itemType: TypeInfo | null | undefined,
   ): string | null {
     if (this.resolveLoopDatumFields(itemType).length > 0) return null
-    if (!arrayText) return null
-    const expr = this.parseLiteralExpression(arrayText)
-    if (!expr || !ts.isArrayLiteralExpression(expr) || expr.elements.length === 0) {
+    // Roadmap A: read the carried `ParsedExpr` tree (the parse of the SAME
+    // `array` string this used to re-parse) instead of `ts.createSourceFile`.
+    // Absent / non-array tree → null, same as a non-array string did.
+    if (!arrayParsed) return null
+    if (arrayParsed.kind !== 'array-literal' || arrayParsed.elements.length === 0) {
       return null
     }
-    for (const el of expr.elements) {
-      const isStr = ts.isStringLiteral(el) || ts.isNoSubstitutionTemplateLiteral(el)
+    for (const el of arrayParsed.elements) {
+      const isStr = el.kind === 'literal' && el.literalType === 'string'
+      // A bare numeric literal, or a unary-minus wrapping a numeric literal
+      // (`-1`) — mirrors the old `isNumericLiteral || (isPrefixUnary &&
+      // isNumericLiteral(operand))` check.
       const isNum =
-        ts.isNumericLiteral(el) ||
-        (ts.isPrefixUnaryExpression(el) && ts.isNumericLiteral(el.operand))
+        (el.kind === 'literal' && el.literalType === 'number') ||
+        (el.kind === 'unary' &&
+          el.op === '-' &&
+          el.argument.kind === 'literal' &&
+          el.argument.literalType === 'number')
       if (!isStr && !isNum) return null
     }
     return 'interface{}'
@@ -1402,8 +1410,18 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
             // object prop (`opts={{ align: 'start' }}`) bakes to a Go map
             // literal — the child field is `map[string]interface{}` and
             // `resolveDynamicPropValue` can't represent an object literal.
-            if (childShape?.mapTypedParamNames.has(prop.name)) {
-              const goMap = objectLiteralToGoMap(this.emitCtx, exprText)
+            // The carried `ParsedExpr` (attached to `ExpressionAttr` by the
+            // analyzer since Roadmap A-2) lets the map lowering read the tree
+            // instead of re-parsing `exprText` with `ts.createSourceFile`.
+            // Only an `expression` attr carries `.parsed`; a `spread` /
+            // `template` value can't be an inline object literal here.
+            const parsedValue =
+              prop.value.kind === 'expression' ? prop.value.parsed : undefined
+            if (
+              parsedValue &&
+              childShape?.mapTypedParamNames.has(prop.name)
+            ) {
+              const goMap = objectLiteralToGoMap(this.emitCtx, parsedValue)
               if (goMap !== null) {
                 emitChildField(prop.name, goMap)
                 break
@@ -1528,7 +1546,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
             c => c.name === loopArray && c.origin?.scope === 'module' && c.value && c.type,
           )
         : null
-      const scalarLoopType = this.scalarLiteralLoopGoType(nested.loopArray, nested.loopItemType)
+      const scalarLoopType = this.scalarLiteralLoopGoType(nested.loopArrayParsed, nested.loopItemType)
       let bakedValue = moduleConst?.type
         ? convertInitialValue(this.emitCtx, moduleConst.value!, moduleConst.type, ir.metadata.propsParams)
         : null
@@ -4961,7 +4979,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // instead of `.`. Pushed around the body render only; mirrors the
     // wrapper/constructor `scalarLiteralLoopGoType` gate exactly.
     this.loopScalarItemStack.push(
-      this.scalarLiteralLoopGoType(loop.array, loop.itemType) !== null,
+      this.scalarLiteralLoopGoType(loop.arrayParsed, loop.itemType) !== null,
     )
     const children = this.renderChildren(loop.children)
     this.loopScalarItemStack.pop()

--- a/packages/adapter-go-template/src/adapter/lib/types.ts
+++ b/packages/adapter-go-template/src/adapter/lib/types.ts
@@ -11,6 +11,7 @@ import type {
   IRLoopChildComponent,
   IRNode,
   IRProp,
+  ParsedExpr,
   TypeInfo,
 } from '@barefootjs/jsx'
 
@@ -42,6 +43,9 @@ export interface NestedComponentInfo extends IRLoopChildComponent {
   bodyChildren?: IRNode[]
   /** The loop's array expression for baking (e.g. `sortedData()`) */
   loopArray?: string
+  /** Structured parse of `loopArray` (the loop's `array` string), carried so
+   *  scalar-literal loop typing reads the tree instead of re-parsing. */
+  loopArrayParsed?: ParsedExpr
   /** The enclosing loop's `markerId` (e.g. `l0`) for unique naming */
   loopMarkerId?: string
   /** The loop item's TS type (`Payment` from `sortedData().map(payment => …)`),

--- a/packages/adapter-go-template/src/adapter/value/value-lowering.ts
+++ b/packages/adapter-go-template/src/adapter/value/value-lowering.ts
@@ -144,22 +144,29 @@ export function jsLiteralToGo(
  * (`<Carousel opts={{ align: 'start' }}>`). Returns null for any non-literal
  * or nested object/array value (carousel's opts are flat scalars).
  */
-export function objectLiteralToGoMap(ctx: GoEmitContext, exprText: string): string | null {
-  const expr = ctx.parseLiteralExpression(exprText)
-  if (!expr || !ts.isObjectLiteralExpression(expr)) return null
+export function objectLiteralToGoMap(ctx: GoEmitContext, expr: ParsedExpr): string | null {
+  // Roadmap A: read the carried `ParsedExpr` tree instead of re-parsing the
+  // source with `ts.createSourceFile`. The tree is only an `object-literal`
+  // when every property is a non-computed `key: value` / shorthand `{ key }`
+  // (spreads, computed keys, methods fall through to `unsupported` upstream),
+  // which is exactly the shape the old `ts.isObjectLiteralExpression` +
+  // `ts.isPropertyAssignment` checks accepted.
+  if (expr.kind !== 'object-literal') return null
   const entries: string[] = []
   for (const prop of expr.properties) {
-    if (!ts.isPropertyAssignment(prop)) return null
-    if (
-      !ts.isIdentifier(prop.name) &&
-      !ts.isStringLiteral(prop.name) &&
-      !ts.isNumericLiteral(prop.name)
-    ) {
-      return null
-    }
-    const val = tsLiteralToGo(ctx, prop.initializer)
+    // Shorthand `{ a }` carried an identifier value upstream; the old code
+    // refused a `ShorthandPropertyAssignment`, so bail here too.
+    if (prop.shorthand) return null
+    // `parsedLiteralToGo` with no typeInfo reproduces `tsLiteralToGo`'s scalar
+    // output byte-for-byte (string via `JSON.stringify`, number via the
+    // carried `raw` token, boolean/null literally). Nested object / array
+    // property values lower to null and defer — matching the old behaviour,
+    // where carousel's flat-scalar opts were the only supported shape.
+    const val = parsedLiteralToGo(ctx, prop.value)
     if (val === null) return null
-    entries.push(`${JSON.stringify(prop.name.text)}: ${val}`)
+    // `prop.key` is the resolved key text (identifier / string / numeric all
+    // normalised to a string), exactly like the old `prop.name.text`.
+    entries.push(`${JSON.stringify(prop.key)}: ${val}`)
   }
   if (entries.length === 0) return null
   return `map[string]interface{}{${entries.join(', ')}}`

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -588,7 +588,13 @@ function attachParsedExpressions(node: IRNode): void {
       attachParsedExpressions(node.fallback)
       for (const child of node.children) attachParsedExpressions(child)
       break
-    case 'loop':
+    case 'loop': {
+      // Attach the parse of the SAME `array` string the adapters consume
+      // (the Go adapter's scalar-literal loop typing reads `loop.array` /
+      // `nested.loopArray`, which is exactly `loop.array`), so it can read
+      // the tree instead of re-parsing with `ts.createSourceFile`.
+      const trimmedArray = node.array.trim()
+      if (trimmedArray) node.arrayParsed = parseExpression(trimmedArray)
       for (const child of node.children) attachParsedExpressions(child)
       // Loops also hold expression nodes off the main `children` array.
       if (node.childComponent) {
@@ -601,6 +607,7 @@ function attachParsedExpressions(node: IRNode): void {
         attachParsedExpressions(frag.ir)
       }
       break
+    }
     case 'conditional':
       attachParsedExpressions(node.whenTrue)
       attachParsedExpressions(node.whenFalse)

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -569,12 +569,29 @@ function attachParsedExpressions(node: IRNode): void {
     const trimmed = node.condition.trim()
     if (trimmed) node.parsedCondition = parseExpression(trimmed)
   }
+  // Attach `parsed` to every expression-valued attribute / prop so adapters can
+  // lower from the tree instead of re-parsing the string. Element attrs,
+  // component props (e.g. `opts={{ … }}` → Go map), and a provider's `value`
+  // prop all carry it; only `expression` values do (a `spread` / `template`
+  // value can't be the inline object literal the consumers read).
   if (node.type === 'element') {
     for (const attr of node.attrs) {
       if (attr.value.kind === 'expression') {
         const trimmed = attr.value.expr.trim()
         if (trimmed) attr.value.parsed = parseExpression(trimmed)
       }
+    }
+  } else if (node.type === 'component') {
+    for (const prop of node.props) {
+      if (prop.value.kind === 'expression') {
+        const trimmed = prop.value.expr.trim()
+        if (trimmed) prop.value.parsed = parseExpression(trimmed)
+      }
+    }
+  } else if (node.type === 'provider') {
+    if (node.valueProp.value.kind === 'expression') {
+      const trimmed = node.valueProp.value.expr.trim()
+      if (trimmed) node.valueProp.value.parsed = parseExpression(trimmed)
     }
   }
   switch (node.type) {

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -425,6 +425,14 @@ export interface IRLoop {
    */
   method?: 'flatMap'
   array: string
+  /**
+   * Structured parse of `array` (`parseExpression(array.trim())`), attached
+   * during IR construction so adapters lower the loop's array from the tree
+   * instead of re-parsing the string (e.g. the Go adapter's scalar-literal
+   * loop typing). Optional/best-effort — mirrors `IRExpression.parsed`;
+   * consumers fall back to parsing `array`.
+   */
+  arrayParsed?: ParsedExpr
   /** Pre-transformed array expr with destructured prop refs rewritten to _p.xxx. */
   templateArray?: string
   arrayType: TypeInfo | null


### PR DESCRIPTION
## Terminal sweep — data-literal callers from the IR (U6a + U6b)

Independent of the ParsedExpr2 stack (plain `ParsedExpr`). Removes **3** `parseLiteralExpression` (`ts.createSourceFile`) call sites by reading carried trees.

### U6a — struct synthesis (`go-template-adapter.ts:712`)
`synthesizeStructFromSignal` (#1680 untyped object-array signals) walks `signal.parsed` (carried since A-3) instead of re-parsing `initialValue`. New `scalarParsedGoType(value: ParsedExpr)` reproduces the old Go-type mapping byte-for-byte.

### U6b — object-map child prop (`value-lowering.ts:148`)
`objectLiteralToGoMap` (e.g. `<Carousel opts={{ align: 'start' }}>`) takes the caller's `ExpressionAttr.parsed` (A-2) instead of re-parsing; scalar values via the existing `parsedLiteralToGo`.

### U6b — scalar-array loop type (`go-template-adapter.ts:1039`)
New `IRLoop.arrayParsed` (analyzer-attached) carries the loop array tree; `scalarLiteralLoopGoType` reads it instead of re-parsing `loop.array`. Plumbed through `NestedComponentInfo.loopArrayParsed`.

### Byte-identical
conformance **786**, go units **556**, jsx + go `tsgo` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)