### PR TITLE
refactor(jsx,go-template): lower object-memo from parsedBlock; add parsedExprToParsedExpr2 (#2006)

### DIFF
--- a/.changeset/object-memo-parsedblock.md
+++ b/.changeset/object-memo-parsedblock.md
@@ -1,0 +1,11 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+---
+
+Lower the object-returning `searchParams()` memo from the analyzer-carried `parsedBlock` instead of re-parsing `computation` with `ts.createSourceFile` (terminal sweep, #2006).
+
+- `@barefootjs/jsx` — add `parsedExprToParsedExpr2`, a pure structural `ParsedExpr` → `ParsedExpr2` converter for the object-memo value surface; the block-body tolerant parser (`parseStatement`) now also carries `object-literal` var-decl inits and returns (an object-literal return is parenthesised to force expression context), completing the Roadmap A-1 deferral.
+- `@barefootjs/go-template` — `computeObjectMemoInitialValue` walks `MemoInfo.parsedBlock` / `parsedBlockComplete` and lowers each return-object property via `parsedExprToParsedExpr2` + `lowerCtorExpr`, dropping the adapter's last `parseLiteralExpression` (`ts.createSourceFile`) call.
+
+Byte-identical Go output (786 adapter-conformance / 553+3-skip go-template tests stay green); no public-API or behavioural change.

--- a/packages/adapter-go-template/src/adapter/memo/memo-compute.ts
+++ b/packages/adapter-go-template/src/adapter/memo/memo-compute.ts
@@ -267,7 +267,7 @@ export function memoInitialFromParsedBody(
  */
 export function computeMemoInitialValueOrNull(
   ctx: GoEmitContext,
-  memo: { name: string; computation: string; deps: string[]; parsed?: ParsedExpr; parsedBlock?: ParsedStatement[] },
+  memo: { name: string; computation: string; deps: string[]; parsed?: ParsedExpr; parsedBlock?: ParsedStatement[]; parsedBlockComplete?: boolean },
   signals: { getter: string; initialValue: string }[],
   propsParams: { name: string; type?: TypeInfo; defaultValue?: string }[],
   propFallbackVars: ReadonlyMap<string, PropFallbackVar> = EMPTY_PROP_FALLBACK_VARS,
@@ -337,7 +337,7 @@ export function computeMemoInitialValueOrNull(
   // so `.Params.Sort` / `.Params.Tag` resolve at execute time instead of
   // reading a nil map. Returns null for any unsupported shape (→ nil fallback,
   // no regression).
-  const objMemo = computeObjectMemoInitialValue(ctx, computation)
+  const objMemo = computeObjectMemoInitialValue(ctx, memo)
   if (objMemo !== null) return objMemo
 
   return null

--- a/packages/adapter-go-template/src/adapter/memo/memo-value.ts
+++ b/packages/adapter-go-template/src/adapter/memo/memo-value.ts
@@ -6,14 +6,12 @@
  *     const memo and reports the constant, reading `state.localConstants`.
  *   - `computeObjectMemoInitialValue` lowers a `searchParams()`-derived
  *     object-returning memo to a Go `map[string]interface{}` literal, reading
- *     `state.searchParamsLocals` and `parseLiteralExpression` and delegating
- *     value lowering to `lowerCtorExpr`.
+ *     the analyzer-carried `parsedBlock` and `state.searchParamsLocals` and
+ *     delegating value lowering to `lowerCtorExpr`.
  */
 
-import ts from 'typescript'
-
-import type { ParsedStatement, TypeInfo } from '@barefootjs/jsx'
-import { tsNodeToParsedExpr2 } from '@barefootjs/jsx'
+import type { ParsedExpr, ParsedStatement, TypeInfo } from '@barefootjs/jsx'
+import { parsedExprToParsedExpr2 } from '@barefootjs/jsx'
 
 import type { GoEmitContext } from '../emit-context.ts'
 import type { CtorLowerEnv } from '../lib/types.ts'
@@ -99,48 +97,52 @@ export function resolveBlockBodyMemoModuleConst(
  * match the template's `.Params.<Field>` map access. Returns null for any shape
  * the lowerer can't represent, so the caller falls back to a nil map.
  */
-export function computeObjectMemoInitialValue(ctx: GoEmitContext, computation: string): string | null {
-  const arrow = ctx.parseLiteralExpression(computation)
-  if (!arrow || !ts.isArrowFunction(arrow) || !ts.isBlock(arrow.body)) return null
+export function computeObjectMemoInitialValue(
+  ctx: GoEmitContext,
+  memo: { parsedBlock?: ParsedStatement[]; parsedBlockComplete?: boolean },
+): string | null {
+  // Read the analyzer-carried block statements instead of re-parsing the
+  // `computation` source with `ts.createSourceFile` (#2006). An incomplete
+  // block (`parsedBlockComplete === false`) means a statement was omitted from
+  // the tolerant parse — it could hide control flow this resolver can't model,
+  // so bail to the nil fallback exactly as the former bail-on-unknown-statement
+  // walk did.
+  if (!memo.parsedBlock || !memo.parsedBlockComplete) return null
 
   // Accept only a strict shape: zero or more `const`/`let` declarations
   // followed by exactly one `return { … }` as the LAST statement. Any other
-  // statement kind — `if`, an early/extra `return`, a loop, a bare call —
-  // means the block has control flow this resolver can't reason about, so we
-  // bail to the nil fallback rather than silently lowering one of several
-  // returns (#1941 review). Along the way, collect `const <v> = searchParams()`
-  // bindings (the env for `<v>.get('k')`).
+  // statement kind — `if`, an early/extra `return` — means the block has
+  // control flow this resolver can't reason about, so we bail to the nil
+  // fallback rather than silently lowering one of several returns (#1941
+  // review). Along the way, collect `const <v> = searchParams()` bindings
+  // (the env for `<v>.get('k')`).
   const searchParamsVars = new Set<string>()
-  let retObj: ts.ObjectLiteralExpression | null = null
-  const statements = arrow.body.statements
+  let retObj: Extract<ParsedExpr, { kind: 'object-literal' }> | null = null
+  const statements = memo.parsedBlock
   for (let i = 0; i < statements.length; i++) {
     const s = statements[i]
-    if (ts.isVariableStatement(s)) {
-      for (const d of s.declarationList.declarations) {
-        if (
-          ts.isIdentifier(d.name) &&
-          d.initializer &&
-          ts.isCallExpression(d.initializer) &&
-          ts.isIdentifier(d.initializer.expression) &&
-          d.initializer.arguments.length === 0 &&
-          ctx.state.searchParamsLocals.has(d.initializer.expression.text)
-        ) {
-          searchParamsVars.add(d.name.text)
-        }
+    if (s.kind === 'var-decl') {
+      // `const <v> = searchParams()` — a zero-arg call to a searchParams
+      // local. Any other var-decl (a non-searchParams binding) is accepted
+      // and ignored, matching the old code that accepted any const.
+      if (
+        s.init.kind === 'call' &&
+        s.init.callee.kind === 'identifier' &&
+        s.init.args.length === 0 &&
+        ctx.state.searchParamsLocals.has(s.init.callee.name)
+      ) {
+        searchParamsVars.add(s.name)
       }
       continue
     }
-    if (ts.isReturnStatement(s)) {
+    if (s.kind === 'return') {
       // The return must be the last statement (so it's the only one) and
       // return an object literal.
-      if (i !== statements.length - 1 || !s.expression) return null
-      let e: ts.Expression = s.expression
-      while (ts.isParenthesizedExpression(e)) e = e.expression
-      if (!ts.isObjectLiteralExpression(e)) return null
-      retObj = e
+      if (i !== statements.length - 1 || s.value.kind !== 'object-literal') return null
+      retObj = s.value
       continue
     }
-    // Any other statement kind → control flow we don't model → bail.
+    // Any other statement kind (`if`) → control flow we don't model → bail.
     return null
   }
   if (!retObj || retObj.properties.length === 0) return null
@@ -148,13 +150,15 @@ export function computeObjectMemoInitialValue(ctx: GoEmitContext, computation: s
   const env: CtorLowerEnv = { searchParamsVars, params: new Map() }
   const entries: string[] = []
   for (const prop of retObj.properties) {
-    if (!ts.isPropertyAssignment(prop)) return null
-    const key =
-      ts.isIdentifier(prop.name) || ts.isStringLiteral(prop.name) ? prop.name.text : null
-    if (!key) return null
-    const go = lowerCtorExpr(ctx, tsNodeToParsedExpr2(prop.initializer), env)
+    // The key must be identifier- or string-named (a numeric key has no
+    // matching `.Params.<Field>` accessor), matching the old
+    // `ts.isIdentifier || ts.isStringLiteral` check.
+    if (prop.keyKind !== undefined && prop.keyKind !== 'identifier' && prop.keyKind !== 'string') {
+      return null
+    }
+    const go = lowerCtorExpr(ctx, parsedExprToParsedExpr2(prop.value), env)
     if (go === null) return null
-    entries.push(`"${capitalizeFieldName(key)}": ${go}`)
+    entries.push(`"${capitalizeFieldName(prop.key)}": ${go}`)
   }
   return `map[string]interface{}{\n\t\t${entries.join(',\n\t\t')},\n\t}`
 }

--- a/packages/adapter-go-template/src/adapter/memo/memo-value.ts
+++ b/packages/adapter-go-template/src/adapter/memo/memo-value.ts
@@ -150,6 +150,12 @@ export function computeObjectMemoInitialValue(
   const env: CtorLowerEnv = { searchParamsVars, params: new Map() }
   const entries: string[] = []
   for (const prop of retObj.properties) {
+    // Bail on a shorthand property (`return { tag }`). The former walk only
+    // accepted `ts.PropertyAssignment` and bailed on `ShorthandPropertyAssignment`;
+    // preserve that strictness so this stays byte-identical (a shorthand value
+    // is a bare identifier whose name need not match a `.Params.<Field>`
+    // accessor, and lowering it would silently widen the accepted shape).
+    if (prop.shorthand) return null
     // The key must be identifier- or string-named (a numeric key has no
     // matching `.Params.<Field>` accessor), matching the old
     // `ts.isIdentifier || ts.isStringLiteral` check.

--- a/packages/jsx/src/__tests__/parsed-expr-to-2.test.ts
+++ b/packages/jsx/src/__tests__/parsed-expr-to-2.test.ts
@@ -60,4 +60,19 @@ describe('parsedExprToParsedExpr2', () => {
     const out = parsedExprToParsedExpr2(e)
     expect(out).toEqual({ kind: 'unsupported', raw: '', reason: 'unsupported in ParsedExpr2' })
   })
+
+  test('an already-unsupported node preserves its original reason and raw', () => {
+    // A computed object key falls through to `unsupported` at parse time with a
+    // tailored reason; the converter must preserve it, not overwrite it with
+    // the generic ParsedExpr2 message.
+    const e: ParsedExpr = parseExpression('{ [k]: 1 }')
+    expect(e.kind).toBe('unsupported')
+    const out = parsedExprToParsedExpr2(e)
+    expect(out.kind).toBe('unsupported')
+    if (e.kind === 'unsupported' && out.kind === 'unsupported') {
+      expect(out.reason).toBe(e.reason)
+      expect(out.reason).not.toBe('unsupported in ParsedExpr2')
+      expect(out.raw).toBe(e.raw)
+    }
+  })
 })

--- a/packages/jsx/src/__tests__/parsed-expr-to-2.test.ts
+++ b/packages/jsx/src/__tests__/parsed-expr-to-2.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'bun:test'
+import { type ParsedExpr, parseExpression, parsedExprToParsedExpr2 } from '../expression-parser'
+
+/**
+ * `parsedExprToParsedExpr2` is the pure structural bridge from the shared
+ * template-lowering tree (`ParsedExpr`) to the Go ctor-lowering tree
+ * (`ParsedExpr2`), used by the object-returning searchParams memo path to lower
+ * from the analyzer-carried `parsedBlock` instead of re-parsing `computation`
+ * with `ts.createSourceFile` (#2006). These pin the object-memo value surface
+ * plus the unsupported fall-through.
+ */
+describe('parsedExprToParsedExpr2', () => {
+  test('call + member: sp.get(\'x\')', () => {
+    const e = parseExpression("sp.get('x')")
+    expect(parsedExprToParsedExpr2(e)).toEqual({
+      kind: 'call',
+      callee: {
+        kind: 'member',
+        object: { kind: 'identifier', name: 'sp' },
+        property: 'get',
+        computed: false,
+      },
+      args: [{ kind: 'literal', value: 'x', literalType: 'string' }],
+    })
+  })
+
+  test("nullish-coalescing logical: sp.get('tag') ?? ''", () => {
+    const e = parseExpression("sp.get('tag') ?? ''")
+    expect(parsedExprToParsedExpr2(e)).toEqual({
+      kind: 'logical',
+      op: '??',
+      left: {
+        kind: 'call',
+        callee: {
+          kind: 'member',
+          object: { kind: 'identifier', name: 'sp' },
+          property: 'get',
+          computed: false,
+        },
+        args: [{ kind: 'literal', value: 'tag', literalType: 'string' }],
+      },
+      right: { kind: 'literal', value: '', literalType: 'string' },
+    })
+  })
+
+  test('object literal converts properties recursively', () => {
+    const e = parseExpression("({ sort: sp.get('sort'), tag: sp.get('tag') ?? '' })")
+    const out = parsedExprToParsedExpr2(e)
+    expect(out.kind).toBe('object-literal')
+    if (out.kind !== 'object-literal') throw new Error('expected object-literal')
+    expect(out.properties.map(p => ({ key: p.key, keyKind: p.keyKind, shorthand: p.shorthand, valueKind: p.value.kind }))).toEqual([
+      { key: 'sort', keyKind: 'identifier', shorthand: false, valueKind: 'call' },
+      { key: 'tag', keyKind: 'identifier', shorthand: false, valueKind: 'logical' },
+    ])
+  })
+
+  test('unsupported kind (template-literal) maps to unsupported carrying raw', () => {
+    const e: ParsedExpr = parseExpression('`hi ${name}`')
+    expect(e.kind).toBe('template-literal')
+    const out = parsedExprToParsedExpr2(e)
+    expect(out).toEqual({ kind: 'unsupported', raw: '', reason: 'unsupported in ParsedExpr2' })
+  })
+})

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -862,10 +862,18 @@ export function parsedExprToParsedExpr2(e: ParsedExpr): ParsedExpr2 {
         })),
         raw: e.raw,
       }
+    // An already-`unsupported` node carries its own diagnostic `reason` from
+    // the original parse — preserve it (and its `raw`) so downstream debugging
+    // stays consistent rather than collapsing to the generic message below.
+    case 'unsupported':
+      return { kind: 'unsupported', raw: e.raw, reason: e.reason }
     default:
+      // The remaining out-of-surface kinds (`template-literal`, `arrow-fn`,
+      // `higher-order`, `array-method`) carry no `raw` field, so there is none
+      // to preserve here.
       return {
         kind: 'unsupported',
-        raw: ('raw' in e ? e.raw : '') ?? '',
+        raw: '',
         reason: 'unsupported in ParsedExpr2',
       }
   }

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -811,6 +811,66 @@ export function tsNodeToParsedExpr2(node: ts.Node): ParsedExpr2 {
   return convertNode2(node, raw)
 }
 
+/**
+ * Structurally convert a {@link ParsedExpr} (the shared template-lowering tree)
+ * into a {@link ParsedExpr2} (the Go ctor-lowering tree). A pure 1:1 recursive
+ * mapping — no `ts`, no re-parsing — covering the object-memo value surface
+ * (literals, identifiers, member / index access, calls, logical / binary /
+ * unary / conditional operators, array and object literals). Any `ParsedExpr`
+ * kind outside that surface (`higher-order`, `array-method`, `template-literal`,
+ * `arrow-fn`, `unsupported`, …) maps to `unsupported`, carrying its `raw` when
+ * present, so a caller falls back exactly as the former re-parse + null path
+ * did. The structured replacement for the object-memo path's last
+ * `ts.createSourceFile` (`parseLiteralExpression`). #2006.
+ */
+export function parsedExprToParsedExpr2(e: ParsedExpr): ParsedExpr2 {
+  const rec = parsedExprToParsedExpr2
+  switch (e.kind) {
+    case 'literal':
+      return { kind: 'literal', value: e.value, literalType: e.literalType, raw: e.raw }
+    case 'identifier':
+      return { kind: 'identifier', name: e.name }
+    case 'member':
+      return { kind: 'member', object: rec(e.object), property: e.property, computed: e.computed }
+    case 'index-access':
+      return { kind: 'index-access', object: rec(e.object), index: rec(e.index) }
+    case 'call':
+      return { kind: 'call', callee: rec(e.callee), args: e.args.map(rec) }
+    case 'logical':
+      return { kind: 'logical', op: e.op, left: rec(e.left), right: rec(e.right) }
+    case 'binary':
+      return { kind: 'binary', op: e.op, left: rec(e.left), right: rec(e.right) }
+    case 'unary':
+      return { kind: 'unary', op: e.op, argument: rec(e.argument) }
+    case 'conditional':
+      return {
+        kind: 'conditional',
+        test: rec(e.test),
+        consequent: rec(e.consequent),
+        alternate: rec(e.alternate),
+      }
+    case 'array-literal':
+      return { kind: 'array-literal', elements: e.elements.map(rec) }
+    case 'object-literal':
+      return {
+        kind: 'object-literal',
+        properties: e.properties.map(p => ({
+          key: p.key,
+          keyKind: p.keyKind ?? 'identifier',
+          shorthand: p.shorthand,
+          value: rec(p.value),
+        })),
+        raw: e.raw,
+      }
+    default:
+      return {
+        kind: 'unsupported',
+        raw: ('raw' in e ? e.raw : '') ?? '',
+        reason: 'unsupported in ParsedExpr2',
+      }
+  }
+}
+
 /** Convert a TypeScript AST node to {@link ParsedExpr2} (parentheses unwrapped). */
 function convertNode2(node: ts.Node, raw: string): ParsedExpr2 {
   while (ts.isParenthesizedExpression(node)) node = node.expression
@@ -3206,10 +3266,7 @@ function parseStatement(
     const name = decl.name.text
     const initText = getJS(decl.initializer)
     const init = parseExpression(initText)
-    // `object-literal` is not yet lowered by the block-body consumers, so
-    // treat it like `unsupported` here — the memo/block path falls back to
-    // its `ts.createSourceFile` lowering (byte-identical; Roadmap A-1).
-    if (init.kind === 'unsupported' || init.kind === 'object-literal') {
+    if (init.kind === 'unsupported') {
       return null
     }
     return { kind: 'var-decl', name, init }
@@ -3221,11 +3278,18 @@ function parseStatement(
       // return; (no value) -> return undefined, treat as return true
       return { kind: 'return', value: { kind: 'literal', value: true, literalType: 'boolean' } }
     }
-    const valueText = getJS(stmt.expression)
-    const value = parseExpression(valueText)
-    // See the var-decl note above: object literals fall back to the
-    // block-body's createSourceFile lowering for now (Roadmap A-1).
-    if (value.kind === 'unsupported' || value.kind === 'object-literal') {
+    // A bare object-literal return (`return { a: 1 }`) re-parses as a *block*
+    // statement if its braces lead the source, yielding `unsupported`. Unwrap
+    // any parens, and when the returned expression is an object literal, wrap
+    // the text in parens to force expression context so it parses as an
+    // `object-literal` ParsedExpr (consumed by the Go object-memo lowering).
+    let retExpr: ts.Expression = stmt.expression
+    while (ts.isParenthesizedExpression(retExpr)) retExpr = retExpr.expression
+    const valueText = getJS(retExpr)
+    const value = parseExpression(
+      ts.isObjectLiteralExpression(retExpr) ? `(${valueText})` : valueText,
+    )
+    if (value.kind === 'unsupported') {
       return null
     }
     return { kind: 'return', value }

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -254,7 +254,7 @@ export {
 export { ErrorCodes, createError, formatError, generateCodeFrame } from './errors.ts'
 
 // Expression Parser
-export { parseExpression, parseExpression2, tsNodeToParsedExpr2, isSupported, exprToString, stringifyParsedExpr, identifierPath, parseBlockBody, parseBlockBodyTolerant, containsHigherOrder, extractArrowBodyExpression, parseStyleObjectEntries, parseProviderObjectLiteral, type ProviderObjectMember } from './expression-parser.ts'
+export { parseExpression, parseExpression2, tsNodeToParsedExpr2, parsedExprToParsedExpr2, isSupported, exprToString, stringifyParsedExpr, identifierPath, parseBlockBody, parseBlockBodyTolerant, containsHigherOrder, extractArrowBodyExpression, parseStyleObjectEntries, parseProviderObjectLiteral, type ProviderObjectMember } from './expression-parser.ts'
 export type { StyleObjectEntry } from './expression-parser.ts'
 export type { ParsedExpr, ParsedExpr2, ParsedExpr2Property, ObjectLiteralProperty, ParsedStatement, SortComparator, SortKey, ReduceOp, FlatDepth, FlatMapOp, FlatMapLeaf, SupportLevel, SupportResult, TemplatePart } from './expression-parser.ts'
 export { buildLoopChainExpr } from './loop-chain.ts'


### PR DESCRIPTION
## Terminal sweep — object-memo from the IR (U6c)

`computeObjectMemoInitialValue` (the `searchParams()`-derived object memo, #1897 PostList) re-parsed `computation` with `ts.createSourceFile`. It now reads the analyzer-carried `MemoInfo.parsedBlock` (+ `parsedBlockComplete`) instead.

- **jsx:** new `parsedExprToParsedExpr2(e: ParsedExpr): ParsedExpr2` — a pure structural 1:1 converter over the object-memo value surface (call/member/logical/literal/identifier/…; everything else → `unsupported`), exported alongside `tsNodeToParsedExpr2`. Also completes the Roadmap A-1 deferral: `parseStatement` no longer carves object-literals out of `var-decl`/`return` arms (and parenthesises a `return { … }` so it parses as an `object-literal`), so `parsedBlock` actually carries the return object. Verified non-regressive against the full jsx suite (2209).
- **Go adapter:** `computeObjectMemoInitialValue` walks `parsedBlock` (searchParams var-decls + strict last-statement object-literal return), converts each return-object value via `parsedExprToParsedExpr2`, and lowers via `lowerCtorExpr`. Removes the `memo-value.ts` `parseLiteralExpression` (count → 0).

### Byte-identical
conformance **786**, go units **556** (incl. the #1897 PostList object-memo fixture), full jsx **2209**, jsx + go `tsgo` clean.

**Effect:** `parseLiteralExpression` callers 6 → 5 (remaining: `value-lowering.ts:133` fallback + helper-inline/url-builder ×4 → U4 → then U7 deletes the helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_