### PR TITLE
refactor(go-template): drop jsLiteralToGo ts.createSourceFile fallback (#2006)

### DIFF
--- a/.changeset/jsliteral-fallback.md
+++ b/.changeset/jsliteral-fallback.md
@@ -1,0 +1,18 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Remove the `ts.createSourceFile` (`parseLiteralExpression` + `tsLiteralToGo`)
+fallback from `jsLiteralToGo` in the Go adapter's value lowering (terminal
+sweep, #2006). Signal/const inline initial values now bake exclusively from the
+analyzer's carried structured `ParsedExpr` tree via `parsedLiteralToGo`, which
+already reproduces every bakeable shape (scalars, a unary-minus number, scalar
+arrays, and objects against a local struct) and keeps `nil` for everything else
+(empty arrays, objects with no known struct, identifiers/calls, nested
+object/array values, `as const`). The deleted fallback covered the same
+bakeable shapes — every shape the analyzer leaves `unsupported` (so no tree is
+carried) is also one the fallback's own `ts.is*` checks declined — so the
+removal is byte-identical (verified by the 786/556 adapter gauntlet). The
+inline primitive-literal loop-array bake now threads the loop's carried
+`ParsedExpr` through the same structured path. The now-dead `tsLiteralToGo`
+helper and its `typescript`/`typeInfoToGo` imports are deleted.

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -1549,7 +1549,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         : null
       const scalarLoopType = this.scalarLiteralLoopGoType(nested.loopArrayParsed, nested.loopItemType)
       let bakedValue = moduleConst?.type
-        ? convertInitialValue(this.emitCtx, moduleConst.value!, moduleConst.type, ir.metadata.propsParams)
+        ? convertInitialValue(this.emitCtx, moduleConst.value!, moduleConst.type, ir.metadata.propsParams, moduleConst.parsed)
         : null
       // (#1971) Inline primitive-literal array (`[1,2,3,4,5].map(...)`): no
       // named module const to look up, so bake the literal slice directly so

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -663,7 +663,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * properties — no string parsing of the definition. This is the single
    * source of truth for which fields a generated struct has and each field's Go
    * name/type; both the struct emitter ({@link typeDefinitionToGo}) and the
-   * object-literal baker ({@link tsLiteralToGo}) consume it, so a baked literal
+   * object-literal baker ({@link parsedLiteralToGo}) consume it, so a baked literal
    * can never name a field the struct doesn't declare.
    *
    * A property whose source key isn't a valid Go identifier (`"data-id"`, a
@@ -1555,7 +1555,11 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       // named module const to look up, so bake the literal slice directly so
       // SSR renders the items (matching Hono) instead of an empty loop.
       if (!bakedValue && scalarLoopType) {
-        bakedValue = jsLiteralToGo(this.emitCtx, nested.loopArray!, { kind: 'unknown', raw: 'unknown' })
+        bakedValue = jsLiteralToGo(
+          this.emitCtx,
+          { kind: 'unknown', raw: 'unknown' },
+          nested.loopArrayParsed,
+        )
       }
       if (!bakedValue || bakedValue === 'nil' || bakedValue === '0') continue
 

--- a/packages/adapter-go-template/src/adapter/memo/memo-compute.ts
+++ b/packages/adapter-go-template/src/adapter/memo/memo-compute.ts
@@ -327,6 +327,7 @@ export function computeMemoInitialValueOrNull(
       blockReturn.constValue,
       blockReturn.constType,
       propsParams,
+      blockReturn.constParsed,
     )
   }
 

--- a/packages/adapter-go-template/src/adapter/memo/memo-value.ts
+++ b/packages/adapter-go-template/src/adapter/memo/memo-value.ts
@@ -28,7 +28,12 @@ export function resolveBlockBodyMemoModuleConst(
   ctx: GoEmitContext,
   parsedBlock: ParsedStatement[] | undefined,
   signals: { getter: string; initialValue: string }[],
-): { constName: string; constValue: string | undefined; constType: TypeInfo | undefined } | null {
+): {
+  constName: string
+  constValue: string | undefined
+  constType: TypeInfo | undefined
+  constParsed: ParsedExpr | undefined
+} | null {
   if (!parsedBlock) return null
 
   // Walk the analyzer-carried statements collecting:
@@ -84,6 +89,7 @@ export function resolveBlockBodyMemoModuleConst(
     constName: constant.name,
     constValue: constant.value,
     constType: constant.type ?? undefined,
+    constParsed: constant.parsed,
   }
 }
 

--- a/packages/adapter-go-template/src/adapter/value/value-lowering.ts
+++ b/packages/adapter-go-template/src/adapter/value/value-lowering.ts
@@ -5,19 +5,15 @@
  * initial values into the SSR data context — scalars, prop references, and
  * fully-literal arrays/objects — and falls back to `nil`/`0` for anything the
  * parser can't reduce to a literal. They depend on the context's `state`
- * (struct-field / type-alias tables), `parseLiteralExpression`, and
- * `extractPropNameFromInitialValue`, plus `typeInfoToGo` from the type-codegen
- * module.
+ * (struct-field / type-alias tables) and `extractPropNameFromInitialValue`,
+ * plus `typeInfoToGo` from the type-codegen module.
  */
-
-import ts from 'typescript'
 
 import type { ParsedExpr, TypeInfo } from '@barefootjs/jsx'
 
 import type { GoEmitContext } from '../emit-context.ts'
 import type { PropFallbackVar } from '../lib/types.ts'
 import { capitalizeFieldName } from '../lib/go-naming.ts'
-import { typeInfoToGo } from '../type/type-codegen.ts'
 import { parsedLiteralToGo } from './parsed-literal-to-go.ts'
 
 /** Default for `getSignalInitialValueAsGo`'s optional fallback-var map. */
@@ -81,7 +77,7 @@ export function convertInitialValue(
     // Bake a fully-literal initial value into a Go slice literal; anything
     // the parser can't reduce to a literal — a call, an identifier, `null` /
     // `undefined`, or an empty array — yields null and we keep `nil`.
-    return jsLiteralToGo(ctx, value, typeInfo, preParsed) ?? 'nil'
+    return jsLiteralToGo(ctx, typeInfo, preParsed) ?? 'nil'
   }
 
   // String alias (e.g., Filter = string) — return string value instead of nil
@@ -100,39 +96,43 @@ export function convertInitialValue(
 }
 
 /**
- * Convert a fully-literal JS expression string into an equivalent Go literal
- * whose Go type matches `typeInfo` (#1672), used to bake a signal's inline
- * initial value into the SSR data context:
+ * Convert a fully-literal JS expression — carried as the analyzer's structured
+ * `ParsedExpr` tree (#2006) — into an equivalent Go literal whose Go type
+ * matches `typeInfo` (#1672), used to bake a signal's inline initial value into
+ * the SSR data context:
  *
  *   `["x", "y"]`             (string[])  → `[]string{"x", "y"}`
  *   `["x", "y"]`             (unknown[]) → `[]interface{}{"x", "y"}`
  *   `[{ id: "a" }]`          (Item[])    → `[]Item{Item{ID: "a"}}`
  *
- * Returns `null` — so the caller keeps `nil` — when the expression (or any
- * nested element) is not a pure literal (a call, identifier, template with
- * interpolation, …) or cannot be expressed in the target Go type without a
- * render/compile mismatch (e.g. an object element in a `[]interface{}` field,
- * which the SSR template reaches via struct field access the map lacks).
+ * Returns `null` — so the caller keeps `nil` — when no structured tree was
+ * carried (the analyzer's `parseExpression` returned `unsupported`), or when
+ * the tree (or any nested element) is not a pure literal (a call, identifier,
+ * template with interpolation, …) or cannot be expressed in the target Go type
+ * without a render/compile mismatch (e.g. an object element in a `[]interface{}`
+ * field, which the SSR template reaches via struct field access the map lacks).
  */
 export function jsLiteralToGo(
   ctx: GoEmitContext,
-  value: string,
   typeInfo: TypeInfo,
   preParsed?: ParsedExpr,
 ): string | null {
-  // Roadmap A: when the analyzer carried a structured parse, lower the literal
-  // from the tree first. `parsedLiteralToGo` reproduces the scalar / scalar-
-  // array shapes exactly and returns null to DEFER everything else (object
-  // baking, empty arrays, `as const`, …) to the `ts.createSourceFile` path
-  // below, so behaviour stays byte-identical — only the reproduced shapes skip
-  // the re-parse.
+  // Roadmap A (terminal sweep, #2006): lower the literal from the carried
+  // structured parse only. `parsedLiteralToGo` reproduces every bakeable shape
+  // (scalars, a unary-minus number, scalar arrays, and objects against a local
+  // struct) and returns null to keep `nil` for everything else (empty arrays,
+  // objects with no known struct, identifiers / calls, nested object/array
+  // values, `as const`). The former `ctx.parseLiteralExpression` +
+  // `tsLiteralToGo` re-parse fallback covered the same bakeable shapes — every
+  // shape the analyzer's `parseExpression` leaves `unsupported` (so `preParsed`
+  // is absent) is also one the fallback's own `ts.is*` checks declined — so
+  // dropping it is byte-identical (verified by the 786/556 adapter gauntlet,
+  // the project's byte-identity authority).
   if (preParsed) {
     const structured = parsedLiteralToGo(ctx, preParsed, typeInfo)
     if (structured !== null) return structured
   }
-  const expr = ctx.parseLiteralExpression(value)
-  if (!expr) return null
-  return tsLiteralToGo(ctx, expr, typeInfo)
+  return null
 }
 
 /**
@@ -170,100 +170,6 @@ export function objectLiteralToGoMap(ctx: GoEmitContext, expr: ParsedExpr): stri
   }
   if (entries.length === 0) return null
   return `map[string]interface{}{${entries.join(', ')}}`
-}
-
-/**
- * Recursively convert a TS literal AST node to a Go literal typed as
- * `typeInfo`, or null when the node is not a pure literal / cannot be
- * represented in that Go type.
- */
-export function tsLiteralToGo(
-  ctx: GoEmitContext,
-  node: ts.Expression,
-  typeInfo?: TypeInfo,
-): string | null {
-  // Unwrap a leading unary minus on a numeric literal (`-1`).
-  if (
-    ts.isPrefixUnaryExpression(node) &&
-    node.operator === ts.SyntaxKind.MinusToken &&
-    ts.isNumericLiteral(node.operand)
-  ) {
-    return `-${node.operand.text}`
-  }
-  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
-    return JSON.stringify(node.text)
-  }
-  // Pass the numeric literal's source spelling through verbatim. Every form
-  // the TS parser accepts here (`1`, `1.5`, `1e3`, `0x10`, `1_000`) is also a
-  // valid Go numeric literal, so no re-formatting is needed.
-  if (ts.isNumericLiteral(node)) return node.text
-  if (node.kind === ts.SyntaxKind.TrueKeyword) return 'true'
-  if (node.kind === ts.SyntaxKind.FalseKeyword) return 'false'
-  if (node.kind === ts.SyntaxKind.NullKeyword) return 'nil'
-
-  if (ts.isArrayLiteralExpression(node)) {
-    // An empty array literal (`[]`, and — since the TS parser tolerates
-    // whitespace/comments — `[ ]`, `[/* */]`) carries no items, so there's
-    // nothing to bake. Returning null keeps the field `nil`, which JSON-
-    // marshals as `null` rather than the `[]` an empty slice would produce.
-    if (node.elements.length === 0) return null
-
-    // Slice header mirrors the field's Go type (`[]string`, `[]Item`,
-    // `[]interface{}`); elements are converted against the element type.
-    const elemType = typeInfo?.kind === 'array' ? typeInfo.elementType : undefined
-    const sliceHeader = typeInfo?.kind === 'array'
-      ? typeInfoToGo(ctx, typeInfo)
-      : '[]interface{}'
-    const elems: string[] = []
-    for (const el of node.elements) {
-      const go = tsLiteralToGo(ctx, el, elemType)
-      if (go === null) return null
-      elems.push(go)
-    }
-    return `${sliceHeader}{${elems.join(', ')}}`
-  }
-
-  if (ts.isObjectLiteralExpression(node)) {
-    // An object can only be baked when the target Go type is a concrete
-    // struct — otherwise it would land in `interface{}` / a map the SSR
-    // template can't reach via field access. The struct's field map is the
-    // source of truth: it tells us the exact Go field name for each source
-    // key and, by omission, which keys the struct doesn't declare. Bail
-    // (→ nil) when the type isn't a known struct.
-    const goType = typeInfo ? typeInfoToGo(ctx, typeInfo) : 'interface{}'
-    const structFields = ctx.state.localStructFields.get(goType)
-    if (!structFields) return null
-    const entries: string[] = []
-    for (const prop of node.properties) {
-      // Only plain `key: scalar` pairs are baked; spreads, methods,
-      // shorthand, computed/accessor members, and nested object/array
-      // values (whose struct field types we don't track here) bail to nil.
-      if (!ts.isPropertyAssignment(prop)) return null
-      if (
-        !ts.isIdentifier(prop.name) &&
-        !ts.isStringLiteral(prop.name) &&
-        !ts.isNumericLiteral(prop.name)
-      ) {
-        return null
-      }
-      // Resolve the Go field name from the struct's own field map rather
-      // than re-deriving it. A key the struct doesn't declare (a typo, or a
-      // non-identifier key like `"data-id"` that never became a field) is
-      // absent here, so we bail to nil instead of emitting a literal that
-      // names a nonexistent field and won't compile.
-      const goField = structFields.get(prop.name.text)
-      if (!goField) return null
-      const init = prop.initializer
-      if (ts.isObjectLiteralExpression(init) || ts.isArrayLiteralExpression(init)) {
-        return null
-      }
-      const go = tsLiteralToGo(ctx, init)
-      if (go === null) return null
-      entries.push(`${goField}: ${go}`)
-    }
-    return `${goType}{${entries.join(', ')}}`
-  }
-  return null
 }
 
 /**


### PR DESCRIPTION
## Terminal sweep — drop the `jsLiteralToGo` fallback

`jsLiteralToGo` lowered a signal/const initial value from the carried `signal.parsed` tree (`parsedLiteralToGo`), then fell back to `ts.createSourceFile` + `tsLiteralToGo` for shapes the structured path deferred.

A branch-by-branch comparison found **no shape `tsLiteralToGo` bakes that `parsedLiteralToGo` defers** — they're shape-for-shape equivalent (scalars, unary-minus numbers, scalar arrays, object-against-struct). So the fallback is redundant **provided every caller threads its carried `preParsed` tree**.

- Removed the `parseLiteralExpression` + `tsLiteralToGo` fallback; `jsLiteralToGo` lowers from `preParsed` only.
- Deleted the now-dead `tsLiteralToGo` (and its `ts` / `typeInfoToGo` imports) and the unused `value` param.
- Threaded `preParsed` through the remaining `convertInitialValue` callers that previously relied on the string-parse fallback:
  - `emitStaticBodyWrappers`, inline `[1,2,3].map(...)` loop-array bake → `nested.loopArrayParsed`.
  - **the block-body memo SSR path** (`resolveBlockBodyMemoModuleConst` → `convertInitialValue`) → the constant's `parsed`. This is data-table's `sortedData` memo, which returns the `payments` module const while the sort key starts null; without the tree its SSR rows baked to `nil` and regressed `[data-table] keyed-loop reorder on sort`.
  - the static-wrapper module-const bake → `moduleConst.parsed`.

### Byte-identical
`parsedLiteralToGo` reproduces the prior `tsLiteralToGo` output exactly — e.g. data-table bakes `[]Payment{Payment{ID: "PAY001", Amount: 316, ...}, …}`, verified against the pre-sweep baseline. conformance **786**, go units **553/3 skip**, jsx + go `tsgo` clean.

**Effect:** removes `value-lowering.ts:133`. With #2015 (object-memo), `parseLiteralExpression` callers → helper-inline/url-builder ×4 only (U4), then U7 deletes the helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_