### PR TITLE
refactor(go-template): inline component-scope arrow helpers structurally (#2006)

### DIFF
--- a/.changeset/helper-inline-parsed.md
+++ b/.changeset/helper-inline-parsed.md
@@ -1,0 +1,10 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+---
+
+Inline component-scope arrow helpers structurally, removing the Go helper-inliner's `ts.createSourceFile` re-parses (#2006).
+
+The Go adapter's `inlineLocalHelperCall` no longer parses the call expression or the helper arrow body with `parseLiteralExpression`. It substitutes the call args (carried as the call's `ParsedExpr` `preParsed` tree) into the helper body recovered structurally from `ConstantInfo.parsed2`, then lowers the substituted tree directly — so a compound arg (`props.a ?? props.b`) keeps its precedence by structure instead of the former text-splice parenthesisation. A new `parsedExpr2ToParsedExpr` bridge (the reverse of the `ParsedExpr2` ctor tree) is added to `@barefootjs/jsx` for this.
+
+Output is byte-identical across the affected fixtures (`sortClass` / `tagClass` inliner). The block-bodied `URLSearchParams` URL-builder helpers (`hrefFor` / `sortHref` / `tagHref`) keep their text path — `ParsedExpr2` can't model a statement block, so there's no structured body tree to substitute in.

--- a/packages/adapter-go-template/src/adapter/emit-context.ts
+++ b/packages/adapter-go-template/src/adapter/emit-context.ts
@@ -29,8 +29,17 @@ export interface GoEmitContext {
   /** Parse a JS expression source string into a TS expression node, or null. */
   parseLiteralExpression(value: string): ts.Expression | null
 
-  /** Lower a JS expression to its Go-template form (the core recursive entry). */
-  convertExpressionToGo(jsExpr: string, out?: { parsed?: ParsedExpr }): string
+  /**
+   * Lower a JS expression to its Go-template form (the core recursive entry).
+   * `preParsed` reuses an already-built tree instead of re-parsing `jsExpr`
+   * (the helper-inliner lowers a structurally substituted body this way, with
+   * no `ts.createSourceFile`, #2006).
+   */
+  convertExpressionToGo(
+    jsExpr: string,
+    out?: { parsed?: ParsedExpr },
+    preParsed?: ParsedExpr,
+  ): string
 
   /** Lower a JS condition to a Go-template bool + any hoisted preamble. */
   convertConditionToGo(jsCondition: string): { condition: string; preamble: string }

--- a/packages/adapter-go-template/src/adapter/expr/helper-inline.ts
+++ b/packages/adapter-go-template/src/adapter/expr/helper-inline.ts
@@ -3,86 +3,109 @@
  *
  * Extracted from `go-template-adapter.ts` (Phase 4 decomposition). When a JSX
  * expression calls a local `const f = (a) => …` helper, the Go adapter has no
- * function to emit — it inlines the helper body with the call args spliced in
- * for the params, so the result lowers like any inline expression. The splicer
- * is scope-blind, so the guards here reject bodies where a textual identifier
+ * function to emit — it inlines the helper body with the call args substituted
+ * for the params, so the result lowers like any inline expression. The
+ * substitution is scope-blind, so the guards here reject bodies where a param
  * replacement could be wrong.
  *
- * `substituteHelperParams` is exported because the URL-builder lowering reuses
- * it; the other helpers are module-internal.
+ * The whole path is structural (#2006): the call arrives already parsed (its
+ * `ParsedExpr` tree, threaded from `convertExpressionToGo`'s `preParsed`), and
+ * the helper body is the analyzer-attached `ConstantInfo.parsed2` tree — so no
+ * `ts.createSourceFile` re-parse is needed.
  */
 
-import ts from 'typescript'
+import { type ParsedExpr, parsedExpr2ToParsedExpr } from '@barefootjs/jsx'
 
 import type { GoEmitContext } from '../emit-context.ts'
 
 /**
- * Inline a call to a local arrow-const helper, returning the spliced body
- * source, or null when the expression isn't such a call or the body isn't
- * splice-safe (nested functions, helper-calling helpers, spread args, …).
+ * Inline a call to a local arrow-const helper, returning the substituted body
+ * tree, or null when the expression isn't such a call or the body isn't
+ * substitution-safe (nested functions, helper-calling helpers, spread args, …).
+ *
+ * `callParsed` is the call's already-built `ParsedExpr` (the `preParsed` tree
+ * threaded from `convertExpressionToGo`). It must be a `call` node; without it
+ * (a call site that didn't carry a tree) inlining is declined — every site that
+ * legitimately inlines a helper threads its IR `parsed`.
  */
-export function inlineLocalHelperCall(ctx: GoEmitContext, jsExpr: string): string | null {
+export function inlineLocalHelperCall(
+  ctx: GoEmitContext,
+  jsExpr: string,
+  callParsed?: ParsedExpr,
+): ParsedExpr | null {
   if (ctx.state.localHelperNames.size === 0) return null
-  // Fast path: skip the AST parse unless the expression begins with a known
-  // helper name applied as a call (`<helper>(`). The leading-identifier match
-  // is an unambiguous prefix — the real shape check is the AST parse below.
+  // Fast path: skip the work unless the expression begins with a known helper
+  // name applied as a call (`<helper>(`). The leading-identifier match is an
+  // unambiguous prefix — the real shape check is the tree inspection below.
   const head = /^\s*([A-Za-z_$][\w$]*)\s*\(/.exec(jsExpr)
   if (!head || !ctx.state.localHelperNames.has(head[1])) return null
 
-  const call = ctx.parseLiteralExpression(jsExpr)
-  if (!call || !ts.isCallExpression(call) || !ts.isIdentifier(call.expression)) return null
-  // A spread arg (`f(...xs)`) can't map to positional params by text splice.
-  if (call.arguments.some(a => ts.isSpreadElement(a))) return null
-  const fnConst = ctx.state.localConstants.find(
-    c => c.name === (call.expression as ts.Identifier).text && !c.isModule && c.value,
-  )
-  if (!fnConst?.value) return null
-  const fn = ctx.parseLiteralExpression(fnConst.value)
-  if (!fn || !ts.isArrowFunction(fn) || ts.isBlock(fn.body)) return null
-  if (fn.parameters.length !== call.arguments.length) return null
-  // Don't half-inline a helper that calls another local helper.
-  if (bodyCallsLocalHelper(ctx, fn.body)) return null
-
-  const subs = new Map<string, string>()
-  for (let i = 0; i < fn.parameters.length; i++) {
-    const p = fn.parameters[i]
-    if (!ts.isIdentifier(p.name)) return null
-    // Parenthesize the arg so its own precedence survives the splice into the
-    // body (e.g. `x === <param>` with arg `a || b` must not become
-    // `x === a || b`).
-    subs.set(p.name.text, `(${call.arguments[i].getText()})`)
+  if (!callParsed || callParsed.kind !== 'call' || callParsed.callee.kind !== 'identifier') {
+    return null
   }
-  // The splicer is scope-blind, so reject bodies where a textual identifier
-  // replacement could be wrong: nested function scopes (shadowing / param
-  // positions) and object shorthand keys that are params.
-  if (!isSpliceSafeHelperBody(fn.body, new Set(subs.keys()))) return null
-  return substituteHelperParams(fn.body, subs)
+  const calleeName = callParsed.callee.name
+  if (!ctx.state.localHelperNames.has(calleeName)) return null
+
+  const fnConst = ctx.state.localConstants.find(
+    c => c.name === calleeName && !c.isModule && c.parsed2,
+  )
+  const arrow = fnConst?.parsed2
+  if (!arrow || arrow.kind !== 'arrow') return null
+  if (arrow.params.length !== callParsed.args.length) return null
+
+  // The body must lower to a `ParsedExpr` — a nested arrow / regex (the shapes
+  // `ParsedExpr` can't model) refuses here, which subsumes the
+  // nested-function-scope guard (a nested `(x) => …` in the body converts to
+  // null) the former text splicer enforced separately.
+  const body = parsedExpr2ToParsedExpr(arrow.body)
+  if (!body || body.kind === 'unsupported') return null
+
+  // Don't half-inline a helper that calls another local helper.
+  if (bodyCallsLocalHelper(ctx, body)) return null
+
+  // Refuse a body containing a method call (`x.foo(…)`). The structural body
+  // tree models it as a generic `call`, but `parseExpression` (which the rest
+  // of the lowering is keyed to) folds the string / array method family
+  // (`.replace`, `.toLowerCase`, `.includes`, `.filter`, …) into specialised
+  // `array-method` / `higher-order` nodes — so lowering this tree directly
+  // would diverge. The current inliner fixtures (`sortClass` / `tagClass`) have
+  // no method-call bodies; one that did falls back to the generic path
+  // (#2006). (`x()` with an identifier callee — `params()` — is fine.)
+  if (bodyHasMethodCall(body)) return null
+
+  const subs = new Map<string, ParsedExpr>()
+  for (let i = 0; i < arrow.params.length; i++) {
+    subs.set(arrow.params[i], callParsed.args[i])
+  }
+  // Reject bodies where a param name appears as an object shorthand key
+  // (`{ k }`, which can't be rewritten to `{ (arg) }`).
+  if (!isSubstituteSafeBody(body, new Set(subs.keys()))) return null
+  return substituteHelperParams(body, subs)
 }
 
 /**
- * Guard for `substituteHelperParams`: the span splicer replaces identifiers by
- * name without scope tracking, so it is only safe on bodies free of
- * constructs where a param name could appear in a position the splice can't
- * handle — a nested function scope (shadowing or its own parameters), or an
- * object shorthand key (`{ k }`, which can't be rewritten to `{ (arg) }`).
+ * Guard for `substituteHelperParams`: the substitution replaces value-position
+ * identifiers by name, so it is only safe on bodies free of an object shorthand
+ * key (`{ k }`) whose name is a param — that key isn't a value position and
+ * can't be rewritten to `{ (arg) }`. Nested function scopes are already
+ * rejected upstream (their `ParsedExpr2` `arrow` doesn't convert to
+ * `ParsedExpr`), so this only checks shorthand keys.
  */
-function isSpliceSafeHelperBody(body: ts.Node, paramNames: ReadonlySet<string>): boolean {
+function isSubstituteSafeBody(body: ParsedExpr, paramNames: ReadonlySet<string>): boolean {
   let safe = true
-  const visit = (n: ts.Node): void => {
+  const visit = (n: ParsedExpr): void => {
     if (!safe) return
-    if (
-      ts.isArrowFunction(n) ||
-      ts.isFunctionExpression(n) ||
-      ts.isFunctionDeclaration(n)
-    ) {
-      safe = false
+    if (n.kind === 'object-literal') {
+      for (const p of n.properties) {
+        if (p.shorthand && paramNames.has(p.key)) {
+          safe = false
+          return
+        }
+        visit(p.value)
+      }
       return
     }
-    if (ts.isShorthandPropertyAssignment(n) && paramNames.has(n.name.text)) {
-      safe = false
-      return
-    }
-    ts.forEachChild(n, visit)
+    forEachValueChild(n, visit)
   }
   visit(body)
   return safe
@@ -93,69 +116,162 @@ function isSpliceSafeHelperBody(body: ts.Node, paramNames: ReadonlySet<string>):
  * const — the signal that inlining `body` here would only push the problem to
  * another un-lowered helper (e.g. `sortHref`'s body calls `hrefFor`).
  */
-function bodyCallsLocalHelper(ctx: GoEmitContext, body: ts.Node): boolean {
+function bodyCallsLocalHelper(ctx: GoEmitContext, body: ParsedExpr): boolean {
   let found = false
-  const visit = (n: ts.Node): void => {
+  const visit = (n: ParsedExpr): void => {
     if (found) return
-    if (ts.isCallExpression(n) && ts.isIdentifier(n.expression)) {
-      const name = n.expression.text
-      if (
-        ctx.state.localConstants.some(c => c.name === name && !c.isModule && c.containsArrow)
-      ) {
+    if (n.kind === 'call' && n.callee.kind === 'identifier') {
+      const name = n.callee.name
+      if (ctx.state.localConstants.some(c => c.name === name && !c.isModule && c.containsArrow)) {
         found = true
         return
       }
     }
-    ts.forEachChild(n, visit)
+    forEachValueChild(n, visit)
   }
   visit(body)
   return found
 }
 
 /**
- * Re-emit `body` to source with each identifier named in `subs` replaced by
- * the substitution's source text. Implemented as span splicing over `body`'s
- * own source (single source file — args are passed as text, not cross-file
- * AST nodes, which would corrupt a printer keyed to `body`'s source). The walk
- * skips non-value identifier positions — the property NAME in `a.b` and a
- * plain object-literal key in `{ k: … }` — so a param sharing a name with a
- * member or key is left untouched. (`isSpliceSafeHelperBody` has already
- * rejected nested functions and `{ k }` shorthand keys.)
+ * True when `body` contains a method call (`x.foo(…)` — a `call` whose callee
+ * is a `member`). Such calls are folded by `parseExpression` into specialised
+ * `array-method` / `higher-order` nodes that the structural body tree models as
+ * a generic `call` instead, so a method-call body must not be lowered from this
+ * tree (see the guard in `inlineLocalHelperCall`).
  */
-export function substituteHelperParams(
-  body: ts.Expression,
-  subs: ReadonlyMap<string, string>,
-): string {
-  const sf = body.getSourceFile()
-  const base = body.getStart(sf)
-  // Collect replacement spans (relative to the body's start), right-to-left.
-  const repls: { start: number; end: number; text: string }[] = []
-  const visit = (node: ts.Node): void => {
-    if (ts.isPropertyAccessExpression(node)) {
-      visit(node.expression) // skip `.name`
+function bodyHasMethodCall(body: ParsedExpr): boolean {
+  let found = false
+  const visit = (n: ParsedExpr): void => {
+    if (found) return
+    if (n.kind === 'call' && n.callee.kind === 'member') {
+      found = true
       return
     }
-    if (ts.isPropertyAssignment(node)) {
-      // A plain identifier/string key isn't a value position; only a computed
-      // key (`[expr]`) is. Visit the initializer (and computed key) only.
-      if (ts.isComputedPropertyName(node.name)) visit(node.name)
-      visit(node.initializer)
-      return
-    }
-    if (ts.isIdentifier(node)) {
-      const sub = subs.get(node.text)
-      if (sub !== undefined) {
-        repls.push({ start: node.getStart(sf) - base, end: node.getEnd() - base, text: sub })
-        return
-      }
-    }
-    ts.forEachChild(node, visit)
+    forEachValueChild(n, visit)
   }
   visit(body)
+  return found
+}
 
-  let text = body.getText(sf)
-  for (const r of repls.sort((a, b) => b.start - a.start)) {
-    text = text.slice(0, r.start) + r.text + text.slice(r.end)
+/**
+ * Re-build `body` with each identifier named in `subs` replaced by the
+ * substitution's `ParsedExpr` subtree. A structural rewrite (#2006): the
+ * substitution is the arg subtree itself, so operator precedence survives
+ * without parenthesisation (the tree *is* the precedence). Non-value identifier
+ * positions — the property NAME in `a.b`, a plain `{ k: … }` key — are not
+ * visited, so a param sharing a name with a member or key is left untouched.
+ * (`isSubstituteSafeBody` has already rejected `{ k }` shorthand keys; nested
+ * functions were rejected at conversion, so `arrow-fn` / `higher-order` /
+ * `array-method` callbacks never reach here in practice — they pass through
+ * unchanged.)
+ */
+export function substituteHelperParams(
+  body: ParsedExpr,
+  subs: ReadonlyMap<string, ParsedExpr>,
+): ParsedExpr {
+  const go = (n: ParsedExpr): ParsedExpr => {
+    switch (n.kind) {
+      case 'identifier': {
+        const sub = subs.get(n.name)
+        return sub !== undefined ? sub : n
+      }
+      // `object-literal` / `unsupported` lower from their `raw` string, so
+      // re-lowering structured children would have no effect — leave as-is
+      // (a param inside such a node is rejected by the shorthand guard or
+      // simply never observed).
+      case 'literal':
+      case 'object-literal':
+      case 'unsupported':
+        return n
+      case 'member':
+        return { ...n, object: go(n.object) }
+      case 'index-access':
+        return { ...n, object: go(n.object), index: go(n.index) }
+      case 'call':
+        return { ...n, callee: go(n.callee), args: n.args.map(go) }
+      case 'binary':
+        return { ...n, left: go(n.left), right: go(n.right) }
+      case 'logical':
+        return { ...n, left: go(n.left), right: go(n.right) }
+      case 'unary':
+        return { ...n, argument: go(n.argument) }
+      case 'conditional':
+        return { ...n, test: go(n.test), consequent: go(n.consequent), alternate: go(n.alternate) }
+      case 'template-literal':
+        return {
+          ...n,
+          parts: n.parts.map(p =>
+            p.type === 'expression' ? { type: 'expression', expr: go(p.expr) } : p,
+          ),
+        }
+      case 'array-literal':
+        return { ...n, elements: n.elements.map(go) }
+      case 'arrow-fn':
+        return { ...n, body: go(n.body) }
+      case 'higher-order':
+        return { ...n, object: go(n.object), predicate: go(n.predicate) }
+      case 'array-method':
+        // `object` is the only re-lowered child; the structured op
+        // (comparator / reduceOp / …) is opaque to substitution.
+        return { ...n, object: go(n.object) } as ParsedExpr
+    }
   }
-  return text
+  return go(body)
+}
+
+/**
+ * Visit the value-position `ParsedExpr` children of `n` (the property name in
+ * `a.b` and a plain `{ k: v }` key are skipped — they aren't value positions;
+ * `object-literal` is handled by the caller because its shorthand keys carry a
+ * guard).
+ */
+function forEachValueChild(n: ParsedExpr, visit: (c: ParsedExpr) => void): void {
+  switch (n.kind) {
+    case 'identifier':
+    case 'literal':
+    case 'unsupported':
+    case 'object-literal':
+      return
+    case 'member':
+      visit(n.object)
+      return
+    case 'index-access':
+      visit(n.object)
+      visit(n.index)
+      return
+    case 'call':
+      visit(n.callee)
+      n.args.forEach(visit)
+      return
+    case 'binary':
+    case 'logical':
+      visit(n.left)
+      visit(n.right)
+      return
+    case 'unary':
+      visit(n.argument)
+      return
+    case 'conditional':
+      visit(n.test)
+      visit(n.consequent)
+      visit(n.alternate)
+      return
+    case 'template-literal':
+      for (const p of n.parts) if (p.type === 'expression') visit(p.expr)
+      return
+    case 'array-literal':
+      n.elements.forEach(visit)
+      return
+    case 'arrow-fn':
+      visit(n.body)
+      return
+    case 'higher-order':
+      visit(n.object)
+      visit(n.predicate)
+      return
+    case 'array-method':
+      visit(n.object)
+      return
+  }
 }

--- a/packages/adapter-go-template/src/adapter/expr/helper-inline.ts
+++ b/packages/adapter-go-template/src/adapter/expr/helper-inline.ts
@@ -85,24 +85,40 @@ export function inlineLocalHelperCall(
 
 /**
  * Guard for `substituteHelperParams`: the substitution replaces value-position
- * identifiers by name, so it is only safe on bodies free of an object shorthand
- * key (`{ k }`) whose name is a param — that key isn't a value position and
- * can't be rewritten to `{ (arg) }`. Nested function scopes are already
- * rejected upstream (their `ParsedExpr2` `arrow` doesn't convert to
- * `ParsedExpr`), so this only checks shorthand keys.
+ * identifiers by name, but an `object-literal` lowers opaquely from its `raw`
+ * source string downstream — `substituteHelperParams` leaves it untouched — so a
+ * param referenced ANYWHERE inside an object literal survives un-substituted:
+ * not just a shorthand key (`{ p }`, which also isn't a value position) but a
+ * value position too (`{ x: p }`, `{ x: f(p) }`). Either would emit the param's
+ * original name instead of the call arg, producing a wrong template. So a body
+ * is substitute-safe only when no object literal it contains references any
+ * param. (Nested function scopes are already rejected upstream — their
+ * `ParsedExpr2` `arrow` doesn't convert to `ParsedExpr`.)
  */
 function isSubstituteSafeBody(body: ParsedExpr, paramNames: ReadonlySet<string>): boolean {
+  // True when `n`'s subtree references any param (handling object-literal
+  // shorthand keys, which carry the param name on the key rather than a value).
+  const referencesParam = (n: ParsedExpr): boolean => {
+    if (n.kind === 'identifier') return paramNames.has(n.name)
+    if (n.kind === 'object-literal') {
+      return n.properties.some(
+        p => (p.shorthand && paramNames.has(p.key)) || referencesParam(p.value),
+      )
+    }
+    let hit = false
+    forEachValueChild(n, c => {
+      if (referencesParam(c)) hit = true
+    })
+    return hit
+  }
+
   let safe = true
   const visit = (n: ParsedExpr): void => {
     if (!safe) return
     if (n.kind === 'object-literal') {
-      for (const p of n.properties) {
-        if (p.shorthand && paramNames.has(p.key)) {
-          safe = false
-          return
-        }
-        visit(p.value)
-      }
+      // The whole object literal lowers from `raw`; if it mentions a param
+      // anywhere, that reference can't be substituted — decline the body.
+      if (referencesParam(n)) safe = false
       return
     }
     forEachValueChild(n, visit)

--- a/packages/adapter-go-template/src/adapter/expr/url-builder.ts
+++ b/packages/adapter-go-template/src/adapter/expr/url-builder.ts
@@ -12,7 +12,6 @@ import ts from 'typescript'
 
 import type { GoEmitContext } from '../emit-context.ts'
 import { wrapIfMultiToken } from '../lib/go-emit.ts'
-import { substituteHelperParams } from './helper-inline.ts'
 
 type UrlBuilderShape = {
   base: ts.Expression
@@ -219,4 +218,57 @@ function lowerUrlGuard(
     ctx.convertExpressionToGo(substituteHelperParams(guard, subs)),
   )
   return `ne ${valueGo} ""`
+}
+
+/**
+ * Re-emit `body` to source with each identifier named in `subs` replaced by the
+ * substitution's source text. Span splicing over `body`'s own source (single
+ * source file — args are passed as text, not cross-file AST nodes, which would
+ * corrupt a printer keyed to `body`'s source). The walk skips non-value
+ * identifier positions — the property NAME in `a.b` and a plain object-literal
+ * key in `{ k: … }` — so a param sharing a name with a member or key is left
+ * untouched.
+ *
+ * The URL-builder lowering keeps this text path (#2006): its block-bodied
+ * `URLSearchParams` helpers aren't representable as a `ParsedExpr2` (only
+ * expression-bodied arrows are), so there is no structured body tree to
+ * substitute in — the spliced string is re-parsed by `convertExpressionToGo` /
+ * `convertConditionToGo` / the delegate recursion.
+ */
+function substituteHelperParams(
+  body: ts.Expression,
+  subs: ReadonlyMap<string, string>,
+): string {
+  const sf = body.getSourceFile()
+  const base = body.getStart(sf)
+  // Collect replacement spans (relative to the body's start), right-to-left.
+  const repls: { start: number; end: number; text: string }[] = []
+  const visit = (node: ts.Node): void => {
+    if (ts.isPropertyAccessExpression(node)) {
+      visit(node.expression) // skip `.name`
+      return
+    }
+    if (ts.isPropertyAssignment(node)) {
+      // A plain identifier/string key isn't a value position; only a computed
+      // key (`[expr]`) is. Visit the initializer (and computed key) only.
+      if (ts.isComputedPropertyName(node.name)) visit(node.name)
+      visit(node.initializer)
+      return
+    }
+    if (ts.isIdentifier(node)) {
+      const sub = subs.get(node.text)
+      if (sub !== undefined) {
+        repls.push({ start: node.getStart(sf) - base, end: node.getEnd() - base, text: sub })
+        return
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(body)
+
+  let text = body.getText(sf)
+  for (const r of repls.sort((a, b) => b.start - a.start)) {
+    text = text.slice(0, r.start) + r.text + text.slice(r.end)
+  }
+  return text
 }

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -54,6 +54,7 @@ import {
   type SupportResult,
   isBooleanAttr,
   parseExpression,
+  stringifyParsedExpr,
   parseStyleObjectEntries,
   isSupported,
   exprToString,
@@ -212,7 +213,8 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   private readonly emitCtx: GoEmitContext = {
     state: this.state,
     parseLiteralExpression: (value) => this.parseLiteralExpression(value),
-    convertExpressionToGo: (jsExpr, out) => this.convertExpressionToGo(jsExpr, out),
+    convertExpressionToGo: (jsExpr, out, preParsed) =>
+      this.convertExpressionToGo(jsExpr, out, preParsed),
     convertConditionToGo: (jsCondition) => this.convertConditionToGo(jsCondition),
     extractPropNameFromInitialValue: (initialValue) => this.extractPropNameFromInitialValue(initialValue),
     extractPropFallback: (initialValue) => this.extractPropFallback(initialValue),
@@ -4401,9 +4403,18 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // (`{{if eq .Params.Sort "date"}}sort on{{else}}sort{{end}}`). Only self-
     // contained helpers are inlined; one that delegates to another local helper
     // (e.g. `sortHref` → `hrefFor`) is left for a later capability.
-    const inlined = inlineLocalHelperCall(this.emitCtx, trimmed)
+    const inlined = inlineLocalHelperCall(this.emitCtx, trimmed, preParsed)
     if (inlined !== null) {
-      return this.convertExpressionToGo(inlined, out)
+      // Lower the substituted body *tree* directly (as `preParsed`), so operator
+      // precedence is carried by the structure — a compound arg subtree
+      // (`props.a ?? props.b`) substituted into `sig() === k` keeps `===` the
+      // outer op without the parenthesisation the former text splice needed. The
+      // stringified form only drives the string-keyed early returns above (a body
+      // that resolves to a bare literal const / static index re-resolves
+      // identically). The inliner rejects method-call bodies, so the tree never
+      // carries a generic `call` that `parseExpression` would have specialised
+      // into `array-method` (#2006).
+      return this.convertExpressionToGo(stringifyParsedExpr(inlined), out, inlined)
     }
 
     // Parse only here — *after* the early returns above, which resolve

--- a/packages/jsx/src/__tests__/parse-expression2.test.ts
+++ b/packages/jsx/src/__tests__/parse-expression2.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'bun:test'
-import { type ParsedExpr2, parseExpression2 } from '../expression-parser'
+import {
+  type ParsedExpr2,
+  parseExpression2,
+  parsedExpr2ToParsedExpr,
+  stringifyParsedExpr,
+} from '../expression-parser'
 
 /**
  * `parseExpression2` is the Go-adapter constructor-lowering bridge tree
@@ -158,5 +163,88 @@ describe('parseExpression2', () => {
   test('empty / non-expression input is unsupported', () => {
     expect(parseExpression2('').kind).toBe('unsupported')
     expect(parseExpression2('   ').kind).toBe('unsupported')
+  })
+})
+
+/**
+ * `parsedExpr2ToParsedExpr` is the reverse bridge (#2006): it recovers a
+ * component-scope helper body (carried as `parsed2`) as a `ParsedExpr` the Go
+ * inliner can substitute the call args into, then re-stringifies the result for
+ * the normal lowering. It is a faithful structural *mirror*, not a re-parse, so
+ * the round-trip invariant is over `stringifyParsedExpr`: the mirror must
+ * stringify back to a source string that means the same expression.
+ */
+describe('parsedExpr2ToParsedExpr', () => {
+  test.each([
+    "params().sort === k ? 'sort on' : 'sort'",
+    'a || b',
+    'a ?? b',
+    '!open',
+    'a + b * c',
+    'arr[i]',
+    'a.b.c',
+    "f(x, 'y', 1)",
+    "base.replace('x', '')",
+  ])('round-trips through stringifyParsedExpr for %p', src => {
+    const back = parsedExpr2ToParsedExpr(parseExpression2(`(${src})`))
+    expect(back).not.toBeNull()
+    // Re-parsing the stringified mirror yields the same ParsedExpr2 — i.e. the
+    // mirror preserves the expression's meaning across the round-trip.
+    if (back) expect(parseExpression2(stringifyParsedExpr(back))).toEqual(parseExpression2(src))
+  })
+
+  test('conditional helper body mirrors structurally', () => {
+    const back = parsedExpr2ToParsedExpr(
+      parseExpression2("(params().sort === k ? 'sort on' : 'sort')"),
+    )
+    expect(back).toEqual({
+      kind: 'conditional',
+      test: {
+        kind: 'binary',
+        op: '===',
+        left: {
+          kind: 'member',
+          object: { kind: 'call', callee: { kind: 'identifier', name: 'params' }, args: [] },
+          property: 'sort',
+          computed: false,
+        },
+        right: { kind: 'identifier', name: 'k' },
+      },
+      consequent: { kind: 'literal', value: 'sort on', literalType: 'string' },
+      alternate: { kind: 'literal', value: 'sort', literalType: 'string' },
+    })
+  })
+
+  test('arrow and regex have no ParsedExpr form → null', () => {
+    expect(parsedExpr2ToParsedExpr(parseExpression2('(a, b) => a + b'))).toBeNull()
+    expect(parsedExpr2ToParsedExpr(parseExpression2('/\\/+$/'))).toBeNull()
+    // A nested arrow/regex anywhere in the tree poisons the whole conversion.
+    expect(parsedExpr2ToParsedExpr(parseExpression2('xs.map(x => x)'))).toBeNull()
+    expect(parsedExpr2ToParsedExpr(parseExpression2("base.replace(/\\/+$/, '')"))).toBeNull()
+  })
+
+  test('literal element access folds to a computed member (matches parseExpression)', () => {
+    // `parseExpression` folds `obj['key']` / `arr[0]` into a computed `member`;
+    // the mirror replicates that so the lowering (keyed to `parseExpression`'s
+    // shapes) treats them identically. A variable index stays `index-access`.
+    expect(parsedExpr2ToParsedExpr(parseExpression2("(obj['key'])"))).toEqual({
+      kind: 'member',
+      object: { kind: 'identifier', name: 'obj' },
+      property: 'key',
+      computed: true,
+    })
+    expect(parsedExpr2ToParsedExpr(parseExpression2('(arr[0])'))).toEqual({
+      kind: 'member',
+      object: { kind: 'identifier', name: 'arr' },
+      property: '0',
+      computed: true,
+    })
+    const idx = parsedExpr2ToParsedExpr(parseExpression2('(rows[i])'))
+    expect(idx?.kind).toBe('index-access')
+  })
+
+  test('unsupported round-trips as unsupported (the fallback sentinel)', () => {
+    const u = parsedExpr2ToParsedExpr({ kind: 'unsupported', raw: 'a ** b', reason: 'x' })
+    expect(u).toEqual({ kind: 'unsupported', raw: 'a ** b', reason: 'x' })
   })
 })

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -3538,12 +3538,15 @@ export function stringifyParsedExpr(expr: ParsedExpr): string {
  * (carried structurally as `ConstantInfo.parsed2`) as a tree it can substitute
  * the call args into, then re-stringifies the substituted result for the normal
  * string lowering (#2006) — eliminating the helper-inline `ts.createSourceFile`
- * re-parse. The mirror is NOT a re-parse: it does not fold method calls into
- * the `array-method` / `higher-order` shapes `parseExpression` recognises, nor
- * literal element access into a computed `member` — those folds happen when the
- * stringified body is re-parsed downstream, so the mirror only needs to
- * round-trip through `stringifyParsedExpr` faithfully (any node it can't model
- * already lives in `ParsedExpr2` as `arrow` / `regex` and returns `null`).
+ * re-parse. The mirror is NOT a full re-parse: it does not fold method calls
+ * into the `array-method` / `higher-order` shapes `parseExpression` recognises —
+ * that fold happens when the stringified body is re-parsed downstream. It DOES,
+ * however, fold a literal element access (`obj['key']`, `arr[0]`) into a
+ * computed `member`, mirroring `parseExpression` so the result matches the shape
+ * the rest of the lowering is keyed to (a non-literal index like `rows[i]` stays
+ * an `index-access`). Otherwise the mirror only needs to round-trip through
+ * `stringifyParsedExpr` faithfully (any node it can't model already lives in
+ * `ParsedExpr2` as `arrow` / `regex` and returns `null`).
  */
 export function parsedExpr2ToParsedExpr(expr: ParsedExpr2): ParsedExpr | null {
   switch (expr.kind) {

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -3527,6 +3527,116 @@ export function stringifyParsedExpr(expr: ParsedExpr): string {
 }
 
 /**
+ * Convert a {@link ParsedExpr2} into a structurally faithful {@link ParsedExpr}
+ * mirror, or `null` when the tree contains a shape `ParsedExpr` can't model.
+ * `ParsedExpr2` carries two extras with no `ParsedExpr` arm — `regex` (a `/…/`
+ * literal) and `arrow` (a multi-param `(a, b) => …`); a tree containing either
+ * (anywhere) returns `null`. `unsupported` maps to `unsupported` (the caller
+ * already treats it as the fallback sentinel).
+ *
+ * The Go helper-inliner uses this to recover a component-scope helper's body
+ * (carried structurally as `ConstantInfo.parsed2`) as a tree it can substitute
+ * the call args into, then re-stringifies the substituted result for the normal
+ * string lowering (#2006) — eliminating the helper-inline `ts.createSourceFile`
+ * re-parse. The mirror is NOT a re-parse: it does not fold method calls into
+ * the `array-method` / `higher-order` shapes `parseExpression` recognises, nor
+ * literal element access into a computed `member` — those folds happen when the
+ * stringified body is re-parsed downstream, so the mirror only needs to
+ * round-trip through `stringifyParsedExpr` faithfully (any node it can't model
+ * already lives in `ParsedExpr2` as `arrow` / `regex` and returns `null`).
+ */
+export function parsedExpr2ToParsedExpr(expr: ParsedExpr2): ParsedExpr | null {
+  switch (expr.kind) {
+    case 'identifier':
+      return { kind: 'identifier', name: expr.name }
+    case 'literal':
+      return expr.raw !== undefined
+        ? { kind: 'literal', value: expr.value, literalType: expr.literalType, raw: expr.raw }
+        : { kind: 'literal', value: expr.value, literalType: expr.literalType }
+    case 'member': {
+      const object = parsedExpr2ToParsedExpr(expr.object)
+      return object && { kind: 'member', object, property: expr.property, computed: expr.computed }
+    }
+    case 'index-access': {
+      const object = parsedExpr2ToParsedExpr(expr.object)
+      if (!object) return null
+      // `parseExpression` folds a literal string / numeric element access
+      // (`obj['key']`, `arr[0]`) into a computed `member`; `parseExpression2`
+      // keeps it an `index-access`. Replicate the fold so the mirror matches
+      // the shape the rest of the lowering is keyed to (a non-literal index —
+      // `rows[i]` — stays an `index-access`, as in both parsers).
+      if (
+        expr.index.kind === 'literal' &&
+        (expr.index.literalType === 'string' || expr.index.literalType === 'number')
+      ) {
+        const property = expr.index.raw ?? String(expr.index.value)
+        return { kind: 'member', object, property, computed: true }
+      }
+      const index = parsedExpr2ToParsedExpr(expr.index)
+      return index ? { kind: 'index-access', object, index } : null
+    }
+    case 'call': {
+      const callee = parsedExpr2ToParsedExpr(expr.callee)
+      if (!callee) return null
+      const args: ParsedExpr[] = []
+      for (const a of expr.args) {
+        const c = parsedExpr2ToParsedExpr(a)
+        if (!c) return null
+        args.push(c)
+      }
+      return { kind: 'call', callee, args }
+    }
+    case 'logical': {
+      const left = parsedExpr2ToParsedExpr(expr.left)
+      const right = parsedExpr2ToParsedExpr(expr.right)
+      return left && right ? { kind: 'logical', op: expr.op, left, right } : null
+    }
+    case 'binary': {
+      const left = parsedExpr2ToParsedExpr(expr.left)
+      const right = parsedExpr2ToParsedExpr(expr.right)
+      return left && right ? { kind: 'binary', op: expr.op, left, right } : null
+    }
+    case 'unary': {
+      const argument = parsedExpr2ToParsedExpr(expr.argument)
+      return argument && { kind: 'unary', op: expr.op, argument }
+    }
+    case 'conditional': {
+      const test = parsedExpr2ToParsedExpr(expr.test)
+      const consequent = parsedExpr2ToParsedExpr(expr.consequent)
+      const alternate = parsedExpr2ToParsedExpr(expr.alternate)
+      return test && consequent && alternate
+        ? { kind: 'conditional', test, consequent, alternate }
+        : null
+    }
+    case 'array-literal': {
+      const elements: ParsedExpr[] = []
+      for (const e of expr.elements) {
+        const c = parsedExpr2ToParsedExpr(e)
+        if (!c) return null
+        elements.push(c)
+      }
+      return { kind: 'array-literal', elements }
+    }
+    case 'object-literal': {
+      const properties: ObjectLiteralProperty[] = []
+      for (const p of expr.properties) {
+        const value = parsedExpr2ToParsedExpr(p.value)
+        if (!value) return null
+        properties.push({ key: p.key, keyKind: p.keyKind, shorthand: p.shorthand, value })
+      }
+      return { kind: 'object-literal', properties, raw: expr.raw }
+    }
+    case 'unsupported':
+      return { kind: 'unsupported', raw: expr.raw, reason: expr.reason }
+    // `regex` and `arrow` have no `ParsedExpr` representation — refuse so the
+    // caller falls back to its string path.
+    case 'regex':
+    case 'arrow':
+      return null
+  }
+}
+
+/**
  * Extract the textual identifier path from a parsed expression's
  * callee — `{kind:'identifier', name:'String'}` → `"String"`,
  * `{kind:'member', object:{kind:'identifier', name:'JSON'},

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -254,7 +254,7 @@ export {
 export { ErrorCodes, createError, formatError, generateCodeFrame } from './errors.ts'
 
 // Expression Parser
-export { parseExpression, parseExpression2, tsNodeToParsedExpr2, parsedExprToParsedExpr2, isSupported, exprToString, stringifyParsedExpr, identifierPath, parseBlockBody, parseBlockBodyTolerant, containsHigherOrder, extractArrowBodyExpression, parseStyleObjectEntries, parseProviderObjectLiteral, type ProviderObjectMember } from './expression-parser.ts'
+export { parseExpression, parseExpression2, tsNodeToParsedExpr2, parsedExprToParsedExpr2, parsedExpr2ToParsedExpr, isSupported, exprToString, stringifyParsedExpr, identifierPath, parseBlockBody, parseBlockBodyTolerant, containsHigherOrder, extractArrowBodyExpression, parseStyleObjectEntries, parseProviderObjectLiteral, type ProviderObjectMember } from './expression-parser.ts'
 export type { StyleObjectEntry } from './expression-parser.ts'
 export type { ParsedExpr, ParsedExpr2, ParsedExpr2Property, ObjectLiteralProperty, ParsedStatement, SortComparator, SortKey, ReduceOp, FlatDepth, FlatMapOp, FlatMapLeaf, SupportLevel, SupportResult, TemplatePart } from './expression-parser.ts'
 export { buildLoopChainExpr } from './loop-chain.ts'


### PR DESCRIPTION
## Terminal sweep (U4) — helper-inline goes parse-free

`inlineLocalHelperCall` re-parsed both the call expression **and** the helper arrow body with `parseLiteralExpression` / `ts.createSourceFile` at emit time. This lowers it to a structural transform over the carried trees instead.

### Changes
- **`expression-parser.ts`** — added `parsedExpr2ToParsedExpr(e: ParsedExpr2): ParsedExpr | null` (exported via `index.ts`), the reverse of the `ParsedExpr2` ctor tree. Returns `null` for the `arrow`/`regex` gap kinds, maps `unsupported`→`unsupported`, and folds literal element access (`obj['key']` / `arr[0]`) into a computed `member` to match `parseExpression`'s shape.
- **`expr/helper-inline.ts`** — fully structural now. `inlineLocalHelperCall` takes the call's `ParsedExpr` (threaded as `convertExpressionToGo`'s `preParsed`), recovers the helper body from `ConstantInfo.parsed2`, converts it via `parsedExpr2ToParsedExpr`, substitutes arg subtrees structurally (precedence carried by structure — no parenthesisation), and returns a `ParsedExpr`. Guards rewritten over the tree; nested functions fall out for free. Added a method-call guard (`x.foo(…)`) because the structural tree models those as generic `call` while `parseExpression` specialises them into `array-method` / `higher-order` — those bodies fall back to the generic path.
- **`go-template-adapter.ts` / `emit-context.ts`** — caller lowers the substituted tree via `convertExpressionToGo(stringifyParsedExpr(tree), out, tree)`; the seam gains the `preParsed` param.
- **`expr/url-builder.ts`** — kept its text path (see below); moved the text-based `substituteHelperParams` splicer in as a local function (it was the sole remaining consumer).
- Added converter unit tests + a changeset (`@barefootjs/jsx` + `@barefootjs/go-template` patch).

### Scope: 2 of 4 `parseLiteralExpression` calls eliminated
`helper-inline.ts` → **0**. `url-builder.ts` stays at **2** and is the remaining hard blocker for the terminal sweep:

> `hrefFor` is a **block-bodied** arrow (`{ const u = new URLSearchParams(); if (G) u.set(...); return ... }`). `parseExpression2` returns `unsupported` for block bodies, so `ConstantInfo.parsed2` is `undefined` for these helpers, and `ParsedExpr2` has no statement/block kinds to model the `URLSearchParams` idiom. `extractUrlBuilder` / `matchUrlSet` need the block AST. Eliminating these 2 would require extending `ParsedExpr2` with a statement/block surface (analyzer + `parsed2`-contract change) or a new structured representation for the builder idiom — large and out of scope here.

### Byte-identical
adapter-tests **786 pass**, adapter-go-template **553 pass / 3 skip**, jsx **2218 pass**; `tsgo --noEmit` clean for both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_