### PR TITLE
Define lightweight ParsedExpr evaluator contract (#2018, Track A)

### DIFF
--- a/.changeset/eval-contract.md
+++ b/.changeset/eval-contract.md
@@ -1,0 +1,18 @@
+---
+---
+
+Define the lightweight `ParsedExpr` evaluator contract (#2018, Track A).
+
+Documents the pure-expression subset semantics (evaluation order,
+numeric/string/boolean coercion, strict equality, allowed operators and
+built-in calls) in `spec/compiler.md` under "ParsedExpr Evaluator
+Semantics", and adds the cross-language golden vectors that pin it:
+`packages/adapter-tests/helper-vectors/eval-cases.ts` (authored as JS
+source + environment), the JS reference evaluator `eval-reference.ts`,
+the generator `eval-generate.ts`, and the committed `eval-vectors.json`.
+A freshness/shape guard (`eval-vectors.test.ts`) keeps the vectors in
+sync with the cases.
+
+Backend-independent: no published-package behaviour changes. The Go
+(`bf.go`) and shared Perl (`BarefootJS::Evaluator`) implementations that
+consume these vectors land in Tracks B and C.

--- a/packages/adapter-tests/helper-vectors/eval-cases.ts
+++ b/packages/adapter-tests/helper-vectors/eval-cases.ts
@@ -1,0 +1,123 @@
+/**
+ * Golden-vector case definitions for the lightweight `ParsedExpr`
+ * evaluator (issue #2018, Track A — the evaluator contract).
+ *
+ * These pin the pure-expression subset's semantics (eval order,
+ * numeric/string coercion, equality, allowed operators/builtins) that
+ * each backend runtime (Go `bf.go`, shared Perl `Evaluator.pm`)
+ * re-implements. They are the cross-language *contract*: an expression
+ * tree plus an environment (`{acc, item, …captured free vars}`) maps to
+ * one expected value.
+ *
+ * A case is authored as a JS source string plus an environment. The
+ * generator (eval-generate.ts) parses the source with the real compiler
+ * `parseExpression` — so every vector carries a genuine `ParsedExpr`
+ * tree, never a hand-transcribed one — and computes `expect` by running
+ * the JS reference evaluator (eval-reference.ts). JS parity is therefore
+ * mechanical, exactly like helper-vectors/cases.ts.
+ *
+ * Each case should pin a rule stated in the spec's "ParsedExpr
+ * Evaluator Semantics" section, named by its `note`.
+ */
+import type { EvalEnv } from './eval-reference'
+
+export interface EvalCase {
+  /** A JS callback-body expression; parsed to a `ParsedExpr` tree. */
+  src: string
+  /** The environment the tree is evaluated against (`acc`/`item`/free vars). */
+  env: EvalEnv
+  /** Which spec rule this case pins. Copied into eval-vectors.json. */
+  note: string
+}
+
+export const evalCases: EvalCase[] = [
+  // ----- literals & identifiers -------------------------------------------
+  { src: '42', env: {}, note: 'numeric literal' },
+  { src: "'hi'", env: {}, note: 'string literal' },
+  { src: 'true', env: {}, note: 'boolean literal' },
+  { src: 'null', env: {}, note: 'null literal' },
+  { src: 'acc', env: { acc: 7 }, note: 'identifier reads from the environment' },
+  { src: 'item', env: { item: { price: 5 } }, note: 'identifier binds a structured value' },
+
+  // ----- arithmetic: numeric addition vs string concatenation -------------
+  { src: 'acc + item', env: { acc: 1, item: 2 }, note: 'numeric + adds' },
+  { src: 'acc + item.price', env: { acc: 10, item: { price: 5 } }, note: 'reduce body: acc + field projection' },
+  { src: "acc + item", env: { acc: 'x', item: 'y' }, note: '+ concatenates once an operand is a string' },
+  { src: "acc + item", env: { acc: 'n=', item: 5 }, note: '+ string/number coerces the number to string' },
+  { src: 'acc - item', env: { acc: 5, item: 3 }, note: 'numeric subtraction' },
+  { src: 'acc - item', env: { acc: '5', item: 2 }, note: '- coerces a numeric string to number' },
+  { src: 'a * b', env: { a: 3, b: 4 }, note: 'multiplication' },
+  { src: 'a / b', env: { a: 7, b: 2 }, note: 'division yields a double' },
+  { src: 'a % b', env: { a: 7, b: 3 }, note: 'modulo' },
+  { src: 'true + 1', env: {}, note: 'boolean true coerces to 1 under numeric +' },
+  { src: 'null + 1', env: {}, note: 'null coerces to 0 under numeric +' },
+
+  // ----- unary ------------------------------------------------------------
+  { src: '-acc', env: { acc: 5 }, note: 'unary minus negates' },
+  { src: '+item', env: { item: '8' }, note: 'unary plus coerces a numeric string' },
+  { src: '!item.done', env: { item: { done: false } }, note: 'logical not of a falsy field is true' },
+  { src: '!item.done', env: { item: { done: true } }, note: 'logical not of a truthy field is false' },
+
+  // ----- relational comparison --------------------------------------------
+  { src: 'a < b', env: { a: 1, b: 2 }, note: 'numeric less-than' },
+  { src: 'a >= b', env: { a: 2, b: 2 }, note: 'numeric greater-or-equal at the boundary' },
+  { src: 'a < b', env: { a: 'apple', b: 'banana' }, note: 'string relational compares by code unit' },
+  { src: 'a < b', env: { a: 'B', b: 'a' }, note: 'code-unit order is case-sensitive (uppercase before lowercase)' },
+  { src: "a < b", env: { a: '10', b: '9' }, note: 'two numeric strings compare lexically, not numerically' },
+
+  // ----- strict equality --------------------------------------------------
+  { src: 'item.id === 2', env: { item: { id: 2 } }, note: 'strict equality on equal numbers' },
+  { src: 'item.id === 2', env: { item: { id: 3 } }, note: 'strict equality on unequal numbers' },
+  { src: "item.id === 2", env: { item: { id: '2' } }, note: 'strict equality is false across number/string' },
+  { src: "item.status !== 'done'", env: { item: { status: 'open' } }, note: 'strict inequality on strings' },
+
+  // ----- logical (operand-returning + short-circuit) ----------------------
+  { src: 'item.done && item.priority > 3', env: { item: { done: true, priority: 5 } }, note: 'filter body: && both truthy' },
+  { src: 'item.done && item.priority > 3', env: { item: { done: false, priority: 5 } }, note: '&& short-circuits on a falsy left, returning it' },
+  { src: "item.label || 'untitled'", env: { item: { label: '' } }, note: '|| falls through an empty string to the default' },
+  { src: "item.label || 'untitled'", env: { item: { label: 'set' } }, note: '|| returns the truthy left operand' },
+  { src: 'item.qty ?? 0', env: { item: { qty: 0 } }, note: '?? keeps a present zero (only null coalesces)' },
+  { src: 'item.qty ?? 0', env: { item: { qty: null } }, note: '?? coalesces a null to the default' },
+  { src: 'item.missing ?? 9', env: { item: {} }, note: '?? coalesces a missing field (reads as null)' },
+
+  // ----- conditional (ternary), incl. the sort 3-way comparator -----------
+  { src: "item.n ? 'y' : 'n'", env: { item: { n: 0 } }, note: 'ternary test: 0 is falsy' },
+  { src: "item.s ? 'y' : 'n'", env: { item: { s: '0' } }, note: 'ternary test: the string "0" is truthy' },
+  { src: 'a > b ? 1 : a < b ? -1 : 0', env: { a: 5, b: 3 }, note: 'sort comparator: 3-way ternary, greater branch' },
+  { src: 'a > b ? 1 : a < b ? -1 : 0', env: { a: 3, b: 3 }, note: 'sort comparator: 3-way ternary, equal branch' },
+
+  // ----- member / index access --------------------------------------------
+  { src: 'item.a.b', env: { item: { a: { b: 42 } } }, note: 'nested member access' },
+  { src: 'item.missing', env: { item: {} }, note: 'a missing field reads as null' },
+  { src: 'item.tags.length', env: { item: { tags: ['x', 'y', 'z'] } }, note: '.length on an array field' },
+  { src: 'item.name.length', env: { item: { name: 'abcd' } }, note: '.length on a string field' },
+  { src: 'item[i]', env: { item: [10, 20, 30], i: 1 }, note: 'index access by a numeric variable' },
+  { src: 'item[i]', env: { item: [10, 20], i: 5 }, note: 'out-of-range index reads as null' },
+  { src: 'row[k]', env: { row: { price: 9 }, k: 'price' }, note: 'index access into an object by a string key' },
+
+  // ----- template literal -------------------------------------------------
+  { src: '`${item.id}: ${item.name}`', env: { item: { id: 7, name: 'widget' } }, note: 'template literal interpolates and stringifies parts' },
+  { src: '`n=${acc + 1}`', env: { acc: 4 }, note: 'template literal evaluates an embedded expression' },
+
+  // ----- array / object literals ------------------------------------------
+  { src: '[item.a, item.b]', env: { item: { a: 1, b: 2 } }, note: 'array literal of field projections' },
+  { src: '({ id: item.id, doubled: item.n * 2 })', env: { item: { id: 3, n: 4 } }, note: 'object literal: map body building a new record' },
+
+  // ----- built-in calls (the deterministic allowlist) ---------------------
+  { src: 'Math.max(a, b)', env: { a: 3, b: 7 }, note: 'Math.max of two numbers' },
+  { src: 'Math.min(a, b, c)', env: { a: 3, b: 7, c: 1 }, note: 'Math.min is variadic' },
+  { src: 'Math.abs(acc)', env: { acc: -5 }, note: 'Math.abs' },
+  { src: 'Math.floor(item.x)', env: { item: { x: 3.7 } }, note: 'Math.floor truncates toward -Infinity' },
+  { src: 'Math.ceil(item.x)', env: { item: { x: 3.2 } }, note: 'Math.ceil rounds up' },
+  { src: 'Math.round(item.x)', env: { item: { x: 2.5 } }, note: 'Math.round: positive half rounds toward +Infinity' },
+  { src: 'Math.round(item.x)', env: { item: { x: -2.5 } }, note: 'Math.round: negative half rounds toward +Infinity (to -2)' },
+  { src: 'String(item.n)', env: { item: { n: 42 } }, note: 'String() coerces a number' },
+  { src: 'Number(item.s)', env: { item: { s: '3.14' } }, note: 'Number() parses a numeric string' },
+  { src: 'Boolean(item.s)', env: { item: { s: '' } }, note: 'Boolean() of an empty string is false' },
+
+  // ----- realistic callback bodies (the issue's motivating shapes) --------
+  { src: 'acc + item.price * item.qty', env: { acc: 100, item: { price: 5, qty: 3 } }, note: 'reduce body: running total with precedence' },
+  { src: 'a.price - b.price', env: { a: { price: 30 }, b: { price: 10 } }, note: 'sort comparator: numeric field difference' },
+  { src: 'item.qty * 2', env: { item: { qty: 21 } }, note: 'map body: arithmetic projection' },
+  { src: "item.tags.length > 0 && item.active", env: { item: { tags: ['a'], active: true } }, note: 'filter body: length guard plus boolean field' },
+]

--- a/packages/adapter-tests/helper-vectors/eval-generate.ts
+++ b/packages/adapter-tests/helper-vectors/eval-generate.ts
@@ -1,0 +1,64 @@
+/**
+ * Golden-vector generator for the lightweight `ParsedExpr` evaluator
+ * (issue #2018, Track A — the evaluator contract).
+ *
+ * Parses every case in eval-cases.ts with the real compiler
+ * `parseExpression` (so each vector carries a genuine `ParsedExpr` tree)
+ * and runs it through the JS reference evaluator (eval-reference.ts) to
+ * compute `expect`. Writes eval-vectors.json — the language-independent
+ * conformance data the Go (runtime/eval_vectors_test.go) and Perl
+ * (t/eval_vectors.t) harnesses consume to prove their evaluators are
+ * isomorphic with JS.
+ *
+ *   cd packages/adapter-tests && bun run generate:eval-vectors
+ *
+ * The freshness test in src/__tests__/eval-vectors.test.ts fails CI when
+ * eval-vectors.json is out of date with eval-cases.ts.
+ */
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { parseExpression } from '@barefootjs/jsx'
+import { assertEncodable, encodeExpect } from './generate'
+import { evalCases } from './eval-cases'
+import { evaluate } from './eval-reference'
+import type { EvalEnv } from './eval-reference'
+import type { ParsedExpr } from '@barefootjs/jsx'
+
+export const EVAL_VECTORS_PATH = join(dirname(fileURLToPath(import.meta.url)), 'eval-vectors.json')
+
+export interface EvalVectorFile {
+  version: number
+  generator: string
+  spec: string
+  cases: Array<{ src: string; expr: ParsedExpr; env: EvalEnv; expect: unknown; note: string }>
+}
+
+export function buildEvalVectors(): EvalVectorFile {
+  return {
+    version: 1,
+    generator: 'packages/adapter-tests/helper-vectors/eval-generate.ts',
+    spec: 'spec/compiler.md#parsedexpr-evaluator-semantics',
+    cases: evalCases.map((c) => {
+      const context = `${c.note}: ${c.src}`
+      const expr = parseExpression(c.src)
+      if (expr.kind === 'unsupported') {
+        throw new Error(`${context}: parseExpression refused the source (${expr.reason})`)
+      }
+      // The environment is plain JSON input — hold it to the same
+      // encodable-value rule as helper-vector args.
+      assertEncodable(c.env, `${context} → env`)
+      const expect = encodeExpect(evaluate(expr, c.env), `${context} → expect`)
+      return { src: c.src, expr, env: c.env, expect, note: c.note }
+    }),
+  }
+}
+
+export function serializeEvalVectors(): string {
+  return JSON.stringify(buildEvalVectors(), null, 2) + '\n'
+}
+
+if (import.meta.main) {
+  const { writeFileSync } = await import('node:fs')
+  writeFileSync(EVAL_VECTORS_PATH, serializeEvalVectors())
+  console.log(`wrote ${EVAL_VECTORS_PATH} (${evalCases.length} cases)`)
+}

--- a/packages/adapter-tests/helper-vectors/eval-reference.ts
+++ b/packages/adapter-tests/helper-vectors/eval-reference.ts
@@ -1,0 +1,316 @@
+/**
+ * Reference implementation of the lightweight `ParsedExpr` evaluator
+ * (issue #2018, Track A — the evaluator contract).
+ *
+ * This is the *semantic source of truth* for the pure-expression subset
+ * each backend runtime (Go `bf.go`, shared Perl `Evaluator.pm`)
+ * re-implements. Like the helper-vectors `reference` table, it is the
+ * literal JS each construct lowers to (`a + b`, `Number(x)`, …), so the
+ * golden `eval-vectors.json` encodes real JS engine behaviour and the
+ * backends are held to JS parity.
+ *
+ * Scope: the evaluator is **only** for higher-order callback bodies
+ * (`reduce` / `sort` / `map` / `filter` / `find` `(…) => expr`). Ordinary
+ * expressions stay lowered to template-native syntax — this is not a
+ * general expression engine. The accepted subset and its semantics are
+ * documented in spec/compiler.md ("ParsedExpr Evaluator Semantics").
+ *
+ * The subset is intentionally narrow and deterministic so the three
+ * backends stay byte-isomorphic:
+ *   - numbers are IEEE-754 doubles with JS coercion;
+ *   - string relational comparison is by code unit (locale-sensitive
+ *     ops like `localeCompare` are deliberately OUT of the subset);
+ *   - equality is strict (`===` / `!==`) only.
+ *
+ * Anything outside the subset throws `EvalUnsupported` — the same gate
+ * the backends use to refuse a callback body (BF101 upstream).
+ */
+import type { ParsedExpr, TemplatePart } from '@barefootjs/jsx'
+
+/** A runtime value in the evaluator's domain (JSON-shaped). */
+export type EvalValue = string | number | boolean | null | EvalValue[] | { [k: string]: EvalValue }
+
+/** The environment: `acc` / `item` / `index` plus captured free vars. */
+export type EvalEnv = Record<string, EvalValue>
+
+/** Thrown when a case uses a node/operator/builtin outside the subset. */
+export class EvalUnsupported extends Error {}
+
+// ---------------------------------------------------------------------------
+// JS coercion primitives (ToNumber / ToString / ToBoolean), pinned so the
+// backends match. These are the literal JS `Number()` / `String()` /
+// truthiness rules, NOT the divergent `bf->string`/`bf_reduce` helper
+// conventions — the evaluator is JS-faithful.
+// ---------------------------------------------------------------------------
+
+function toNumber(v: EvalValue): number {
+  if (typeof v === 'number') return v
+  if (typeof v === 'boolean') return v ? 1 : 0
+  if (v === null) return 0
+  if (typeof v === 'string') {
+    const t = v.trim()
+    if (t === '') return 0
+    const n = Number(t)
+    return n
+  }
+  // arrays/objects are out of the numeric subset
+  throw new EvalUnsupported(`cannot coerce ${typeof v} to number`)
+}
+
+function toStr(v: EvalValue): string {
+  if (typeof v === 'string') return v
+  if (typeof v === 'number') return numToStr(v)
+  if (typeof v === 'boolean') return v ? 'true' : 'false'
+  if (v === null) return 'null'
+  throw new EvalUnsupported(`cannot coerce ${typeof v} to string`)
+}
+
+/** JS Number→String. Split out so the spec can name the one rule. */
+function numToStr(n: number): string {
+  return String(n)
+}
+
+function toBool(v: EvalValue): boolean {
+  if (typeof v === 'boolean') return v
+  if (typeof v === 'number') return v !== 0 && !Number.isNaN(v)
+  if (typeof v === 'string') return v !== ''
+  if (v === null) return false
+  // arrays/objects are always truthy in JS
+  return true
+}
+
+function isNullish(v: EvalValue): boolean {
+  return v === null
+}
+
+// ---------------------------------------------------------------------------
+// Operators
+// ---------------------------------------------------------------------------
+
+function binary(op: string, l: EvalValue, r: EvalValue): EvalValue {
+  switch (op) {
+    case '+':
+      // JS `+`: string concatenation once either operand is a string,
+      // numeric addition otherwise.
+      if (typeof l === 'string' || typeof r === 'string') return toStr(l) + toStr(r)
+      return toNumber(l) + toNumber(r)
+    case '-':
+      return toNumber(l) - toNumber(r)
+    case '*':
+      return toNumber(l) * toNumber(r)
+    case '/':
+      return toNumber(l) / toNumber(r)
+    case '%':
+      return toNumber(l) % toNumber(r)
+    case '<':
+    case '<=':
+    case '>':
+    case '>=':
+      return relational(op, l, r)
+    case '===':
+      return strictEquals(l, r)
+    case '!==':
+      return !strictEquals(l, r)
+    default:
+      // Loose equality (`==`/`!=`) and bitwise/shift operators are
+      // intentionally NOT in the subset — their coercion is hard to keep
+      // byte-isomorphic across backends.
+      throw new EvalUnsupported(`binary operator '${op}' is not in the evaluator subset`)
+  }
+}
+
+function relational(op: string, l: EvalValue, r: EvalValue): boolean {
+  // JS Abstract Relational Comparison: both strings → compare by code
+  // unit; otherwise coerce both to numbers (NaN makes every comparison
+  // false).
+  let c: number
+  if (typeof l === 'string' && typeof r === 'string') {
+    c = l < r ? -1 : l > r ? 1 : 0
+  } else {
+    const ln = toNumber(l)
+    const rn = toNumber(r)
+    if (Number.isNaN(ln) || Number.isNaN(rn)) return false
+    c = ln < rn ? -1 : ln > rn ? 1 : 0
+  }
+  switch (op) {
+    case '<':
+      return c < 0
+    case '<=':
+      return c <= 0
+    case '>':
+      return c > 0
+    case '>=':
+      return c >= 0
+  }
+  return false
+}
+
+function strictEquals(l: EvalValue, r: EvalValue): boolean {
+  // Strict `===`: same type, same value. Different types never equal.
+  // Arrays/objects are reference types in JS; the subset only pins
+  // primitive equality, so a structural operand is refused.
+  if (typeof l === 'object' && l !== null) {
+    throw new EvalUnsupported('=== on a non-primitive is not in the evaluator subset')
+  }
+  if (typeof r === 'object' && r !== null) {
+    throw new EvalUnsupported('=== on a non-primitive is not in the evaluator subset')
+  }
+  return l === r
+}
+
+function unary(op: string, v: EvalValue): EvalValue {
+  switch (op) {
+    case '!':
+      return !toBool(v)
+    case '-':
+      return -toNumber(v)
+    case '+':
+      return toNumber(v)
+    default:
+      throw new EvalUnsupported(`unary operator '${op}' is not in the evaluator subset`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Built-in calls (the deterministic allowlist). Locale-sensitive and
+// I/O-ish builtins are deliberately excluded to keep backends isomorphic.
+// ---------------------------------------------------------------------------
+
+/** JS `Math.round`: half rounds toward +Infinity (2.5→3, -2.5→-2). */
+function mathRound(n: number): number {
+  return Math.floor(n + 0.5)
+}
+
+function callBuiltin(name: string, args: EvalValue[]): EvalValue {
+  switch (name) {
+    case 'Math.max':
+      return Math.max(...args.map(toNumber))
+    case 'Math.min':
+      return Math.min(...args.map(toNumber))
+    case 'Math.abs':
+      return Math.abs(toNumber(args[0]))
+    case 'Math.floor':
+      return Math.floor(toNumber(args[0]))
+    case 'Math.ceil':
+      return Math.ceil(toNumber(args[0]))
+    case 'Math.round':
+      return mathRound(toNumber(args[0]))
+    case 'String':
+      return toStr(args[0])
+    case 'Number':
+      return toNumber(args[0])
+    case 'Boolean':
+      return toBool(args[0])
+    default:
+      throw new EvalUnsupported(`builtin '${name}' is not in the evaluator subset`)
+  }
+}
+
+/** Resolve a `call` callee to its builtin name (e.g. `Math.max`). */
+function builtinName(callee: ParsedExpr): string | null {
+  if (callee.kind === 'identifier') return callee.name
+  if (callee.kind === 'member' && !callee.computed && callee.object.kind === 'identifier') {
+    return `${callee.object.name}.${callee.property}`
+  }
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Member / index access
+// ---------------------------------------------------------------------------
+
+function readProperty(obj: EvalValue, key: string): EvalValue {
+  if (typeof obj === 'string') {
+    if (key === 'length') return obj.length
+    throw new EvalUnsupported(`property '${key}' on a string is not in the evaluator subset`)
+  }
+  if (Array.isArray(obj)) {
+    if (key === 'length') return obj.length
+    throw new EvalUnsupported(`property '${key}' on an array is not in the evaluator subset`)
+  }
+  if (obj !== null && typeof obj === 'object') {
+    // Missing keys read as `null` (the backends' single absent value).
+    return key in obj ? obj[key] : null
+  }
+  throw new EvalUnsupported(`cannot read property '${key}' of ${obj === null ? 'null' : typeof obj}`)
+}
+
+function readIndex(obj: EvalValue, index: EvalValue): EvalValue {
+  if (Array.isArray(obj)) {
+    const i = toNumber(index)
+    if (!Number.isInteger(i) || i < 0 || i >= obj.length) return null
+    return obj[i]
+  }
+  if (obj !== null && typeof obj === 'object') {
+    return readProperty(obj, toStr(index))
+  }
+  throw new EvalUnsupported(`cannot index ${obj === null ? 'null' : typeof obj}`)
+}
+
+// ---------------------------------------------------------------------------
+// Evaluator
+// ---------------------------------------------------------------------------
+
+export function evaluate(expr: ParsedExpr, env: EvalEnv): EvalValue {
+  switch (expr.kind) {
+    case 'literal':
+      return expr.value
+
+    case 'identifier': {
+      if (!(expr.name in env)) {
+        throw new EvalUnsupported(`unbound identifier '${expr.name}'`)
+      }
+      return env[expr.name]
+    }
+
+    case 'binary':
+      return binary(expr.op, evaluate(expr.left, env), evaluate(expr.right, env))
+
+    case 'unary':
+      return unary(expr.op, evaluate(expr.argument, env))
+
+    case 'logical': {
+      const left = evaluate(expr.left, env)
+      if (expr.op === '&&') return toBool(left) ? evaluate(expr.right, env) : left
+      if (expr.op === '||') return toBool(left) ? left : evaluate(expr.right, env)
+      // `??`
+      return isNullish(left) ? evaluate(expr.right, env) : left
+    }
+
+    case 'conditional':
+      return toBool(evaluate(expr.test, env))
+        ? evaluate(expr.consequent, env)
+        : evaluate(expr.alternate, env)
+
+    case 'member':
+      return readProperty(evaluate(expr.object, env), expr.property)
+
+    case 'index-access':
+      return readIndex(evaluate(expr.object, env), evaluate(expr.index, env))
+
+    case 'call': {
+      const name = builtinName(expr.callee)
+      if (name === null) {
+        throw new EvalUnsupported('only built-in calls (Math.*, String/Number/Boolean) are in the subset')
+      }
+      return callBuiltin(name, expr.args.map((a) => evaluate(a, env)))
+    }
+
+    case 'template-literal':
+      return expr.parts.map((p: TemplatePart) => (p.type === 'string' ? p.value : toStr(evaluate(p.expr, env)))).join('')
+
+    case 'array-literal':
+      return expr.elements.map((e) => evaluate(e, env))
+
+    case 'object-literal': {
+      const out: { [k: string]: EvalValue } = {}
+      for (const prop of expr.properties) out[prop.key] = evaluate(prop.value, env)
+      return out
+    }
+
+    default:
+      // arrow-fn, higher-order, array-method, unsupported: a callback
+      // body that itself contains these is refused (BF101 upstream).
+      throw new EvalUnsupported(`node kind '${expr.kind}' is not in the evaluator subset`)
+  }
+}

--- a/packages/adapter-tests/helper-vectors/eval-reference.ts
+++ b/packages/adapter-tests/helper-vectors/eval-reference.ts
@@ -176,9 +176,16 @@ function unary(op: string, v: EvalValue): EvalValue {
 // I/O-ish builtins are deliberately excluded to keep backends isomorphic.
 // ---------------------------------------------------------------------------
 
-/** JS `Math.round`: half rounds toward +Infinity (2.5→3, -2.5→-2). */
+/**
+ * JS `Math.round` — the reference is literal JS, so it inherits JS's exact
+ * semantics: a half rounds toward +Infinity (2.5→3, -2.5→-2) and the sign of
+ * zero is preserved (-0.4 → -0, so `1 / Math.round(-0.4)` is -Infinity). The
+ * backends approximate this with `floor(n + 0.5)`, which agrees on every
+ * JSON-representable result — a -0 result serializes to 0 in the vectors, so
+ * the sign-of-zero edge is not observable across the contract.
+ */
 function mathRound(n: number): number {
-  return Math.floor(n + 0.5)
+  return Math.round(n)
 }
 
 function callBuiltin(name: string, args: EvalValue[]): EvalValue {
@@ -229,8 +236,11 @@ function readProperty(obj: EvalValue, key: string): EvalValue {
     throw new EvalUnsupported(`property '${key}' on an array is not in the evaluator subset`)
   }
   if (obj !== null && typeof obj === 'object') {
-    // Missing keys read as `null` (the backends' single absent value).
-    return key in obj ? obj[key] : null
+    // Own-property only: a missing field reads as `null` (the backends'
+    // single absent value). `key in obj` would walk the prototype chain and
+    // surface `toString` / `constructor` as "present", returning non-JSON
+    // values that Go maps / Perl hashes have no analogue for.
+    return Object.prototype.hasOwnProperty.call(obj, key) ? (obj as { [k: string]: EvalValue })[key] : null
   }
   throw new EvalUnsupported(`cannot read property '${key}' of ${obj === null ? 'null' : typeof obj}`)
 }

--- a/packages/adapter-tests/helper-vectors/eval-reference.ts
+++ b/packages/adapter-tests/helper-vectors/eval-reference.ts
@@ -313,7 +313,11 @@ export function evaluate(expr: ParsedExpr, env: EvalEnv): EvalValue {
       return expr.elements.map((e) => evaluate(e, env))
 
     case 'object-literal': {
-      const out: { [k: string]: EvalValue } = {}
+      // Null-prototype so every key is data-only — a `__proto__` key can't
+      // mutate the prototype chain (which a plain `{}` would allow via
+      // assignment), keeping parity with Go maps / Perl hashes that treat
+      // every key as data.
+      const out: { [k: string]: EvalValue } = Object.create(null)
       for (const prop of expr.properties) out[prop.key] = evaluate(prop.value, env)
       return out
     }

--- a/packages/adapter-tests/helper-vectors/eval-vectors.json
+++ b/packages/adapter-tests/helper-vectors/eval-vectors.json
@@ -1,0 +1,1831 @@
+{
+  "version": 1,
+  "generator": "packages/adapter-tests/helper-vectors/eval-generate.ts",
+  "spec": "spec/compiler.md#parsedexpr-evaluator-semantics",
+  "cases": [
+    {
+      "src": "42",
+      "expr": {
+        "kind": "literal",
+        "value": 42,
+        "literalType": "number",
+        "raw": "42"
+      },
+      "env": {},
+      "expect": 42,
+      "note": "numeric literal"
+    },
+    {
+      "src": "'hi'",
+      "expr": {
+        "kind": "literal",
+        "value": "hi",
+        "literalType": "string"
+      },
+      "env": {},
+      "expect": "hi",
+      "note": "string literal"
+    },
+    {
+      "src": "true",
+      "expr": {
+        "kind": "literal",
+        "value": true,
+        "literalType": "boolean"
+      },
+      "env": {},
+      "expect": true,
+      "note": "boolean literal"
+    },
+    {
+      "src": "null",
+      "expr": {
+        "kind": "literal",
+        "value": null,
+        "literalType": "null"
+      },
+      "env": {},
+      "expect": null,
+      "note": "null literal"
+    },
+    {
+      "src": "acc",
+      "expr": {
+        "kind": "identifier",
+        "name": "acc"
+      },
+      "env": {
+        "acc": 7
+      },
+      "expect": 7,
+      "note": "identifier reads from the environment"
+    },
+    {
+      "src": "item",
+      "expr": {
+        "kind": "identifier",
+        "name": "item"
+      },
+      "env": {
+        "item": {
+          "price": 5
+        }
+      },
+      "expect": {
+        "price": 5
+      },
+      "note": "identifier binds a structured value"
+    },
+    {
+      "src": "acc + item",
+      "expr": {
+        "kind": "binary",
+        "op": "+",
+        "left": {
+          "kind": "identifier",
+          "name": "acc"
+        },
+        "right": {
+          "kind": "identifier",
+          "name": "item"
+        }
+      },
+      "env": {
+        "acc": 1,
+        "item": 2
+      },
+      "expect": 3,
+      "note": "numeric + adds"
+    },
+    {
+      "src": "acc + item.price",
+      "expr": {
+        "kind": "binary",
+        "op": "+",
+        "left": {
+          "kind": "identifier",
+          "name": "acc"
+        },
+        "right": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "item"
+          },
+          "property": "price",
+          "computed": false
+        }
+      },
+      "env": {
+        "acc": 10,
+        "item": {
+          "price": 5
+        }
+      },
+      "expect": 15,
+      "note": "reduce body: acc + field projection"
+    },
+    {
+      "src": "acc + item",
+      "expr": {
+        "kind": "binary",
+        "op": "+",
+        "left": {
+          "kind": "identifier",
+          "name": "acc"
+        },
+        "right": {
+          "kind": "identifier",
+          "name": "item"
+        }
+      },
+      "env": {
+        "acc": "x",
+        "item": "y"
+      },
+      "expect": "xy",
+      "note": "+ concatenates once an operand is a string"
+    },
+    {
+      "src": "acc + item",
+      "expr": {
+        "kind": "binary",
+        "op": "+",
+        "left": {
+          "kind": "identifier",
+          "name": "acc"
+        },
+        "right": {
+          "kind": "identifier",
+          "name": "item"
+        }
+      },
+      "env": {
+        "acc": "n=",
+        "item": 5
+      },
+      "expect": "n=5",
+      "note": "+ string/number coerces the number to string"
+    },
+    {
+      "src": "acc - item",
+      "expr": {
+        "kind": "binary",
+        "op": "-",
+        "left": {
+          "kind": "identifier",
+          "name": "acc"
+        },
+        "right": {
+          "kind": "identifier",
+          "name": "item"
+        }
+      },
+      "env": {
+        "acc": 5,
+        "item": 3
+      },
+      "expect": 2,
+      "note": "numeric subtraction"
+    },
+    {
+      "src": "acc - item",
+      "expr": {
+        "kind": "binary",
+        "op": "-",
+        "left": {
+          "kind": "identifier",
+          "name": "acc"
+        },
+        "right": {
+          "kind": "identifier",
+          "name": "item"
+        }
+      },
+      "env": {
+        "acc": "5",
+        "item": 2
+      },
+      "expect": 3,
+      "note": "- coerces a numeric string to number"
+    },
+    {
+      "src": "a * b",
+      "expr": {
+        "kind": "binary",
+        "op": "*",
+        "left": {
+          "kind": "identifier",
+          "name": "a"
+        },
+        "right": {
+          "kind": "identifier",
+          "name": "b"
+        }
+      },
+      "env": {
+        "a": 3,
+        "b": 4
+      },
+      "expect": 12,
+      "note": "multiplication"
+    },
+    {
+      "src": "a / b",
+      "expr": {
+        "kind": "binary",
+        "op": "/",
+        "left": {
+          "kind": "identifier",
+          "name": "a"
+        },
+        "right": {
+          "kind": "identifier",
+          "name": "b"
+        }
+      },
+      "env": {
+        "a": 7,
+        "b": 2
+      },
+      "expect": 3.5,
+      "note": "division yields a double"
+    },
+    {
+      "src": "a % b",
+      "expr": {
+        "kind": "binary",
+        "op": "%",
+        "left": {
+          "kind": "identifier",
+          "name": "a"
+        },
+        "right": {
+          "kind": "identifier",
+          "name": "b"
+        }
+      },
+      "env": {
+        "a": 7,
+        "b": 3
+      },
+      "expect": 1,
+      "note": "modulo"
+    },
+    {
+      "src": "true + 1",
+      "expr": {
+        "kind": "binary",
+        "op": "+",
+        "left": {
+          "kind": "literal",
+          "value": true,
+          "literalType": "boolean"
+        },
+        "right": {
+          "kind": "literal",
+          "value": 1,
+          "literalType": "number",
+          "raw": "1"
+        }
+      },
+      "env": {},
+      "expect": 2,
+      "note": "boolean true coerces to 1 under numeric +"
+    },
+    {
+      "src": "null + 1",
+      "expr": {
+        "kind": "binary",
+        "op": "+",
+        "left": {
+          "kind": "literal",
+          "value": null,
+          "literalType": "null"
+        },
+        "right": {
+          "kind": "literal",
+          "value": 1,
+          "literalType": "number",
+          "raw": "1"
+        }
+      },
+      "env": {},
+      "expect": 1,
+      "note": "null coerces to 0 under numeric +"
+    },
+    {
+      "src": "-acc",
+      "expr": {
+        "kind": "unary",
+        "op": "-",
+        "argument": {
+          "kind": "identifier",
+          "name": "acc"
+        }
+      },
+      "env": {
+        "acc": 5
+      },
+      "expect": -5,
+      "note": "unary minus negates"
+    },
+    {
+      "src": "+item",
+      "expr": {
+        "kind": "unary",
+        "op": "+",
+        "argument": {
+          "kind": "identifier",
+          "name": "item"
+        }
+      },
+      "env": {
+        "item": "8"
+      },
+      "expect": 8,
+      "note": "unary plus coerces a numeric string"
+    },
+    {
+      "src": "!item.done",
+      "expr": {
+        "kind": "unary",
+        "op": "!",
+        "argument": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "item"
+          },
+          "property": "done",
+          "computed": false
+        }
+      },
+      "env": {
+        "item": {
+          "done": false
+        }
+      },
+      "expect": true,
+      "note": "logical not of a falsy field is true"
+    },
+    {
+      "src": "!item.done",
+      "expr": {
+        "kind": "unary",
+        "op": "!",
+        "argument": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "item"
+          },
+          "property": "done",
+          "computed": false
+        }
+      },
+      "env": {
+        "item": {
+          "done": true
+        }
+      },
+      "expect": false,
+      "note": "logical not of a truthy field is false"
+    },
+    {
+      "src": "a < b",
+      "expr": {
+        "kind": "binary",
+        "op": "<",
+        "left": {
+          "kind": "identifier",
+          "name": "a"
+        },
+        "right": {
+          "kind": "identifier",
+          "name": "b"
+        }
+      },
+      "env": {
+        "a": 1,
+        "b": 2
+      },
+      "expect": true,
+      "note": "numeric less-than"
+    },
+    {
+      "src": "a >= b",
+      "expr": {
+        "kind": "binary",
+        "op": ">=",
+        "left": {
+          "kind": "identifier",
+          "name": "a"
+        },
+        "right": {
+          "kind": "identifier",
+          "name": "b"
+        }
+      },
+      "env": {
+        "a": 2,
+        "b": 2
+      },
+      "expect": true,
+      "note": "numeric greater-or-equal at the boundary"
+    },
+    {
+      "src": "a < b",
+      "expr": {
+        "kind": "binary",
+        "op": "<",
+        "left": {
+          "kind": "identifier",
+          "name": "a"
+        },
+        "right": {
+          "kind": "identifier",
+          "name": "b"
+        }
+      },
+      "env": {
+        "a": "apple",
+        "b": "banana"
+      },
+      "expect": true,
+      "note": "string relational compares by code unit"
+    },
+    {
+      "src": "a < b",
+      "expr": {
+        "kind": "binary",
+        "op": "<",
+        "left": {
+          "kind": "identifier",
+          "name": "a"
+        },
+        "right": {
+          "kind": "identifier",
+          "name": "b"
+        }
+      },
+      "env": {
+        "a": "B",
+        "b": "a"
+      },
+      "expect": true,
+      "note": "code-unit order is case-sensitive (uppercase before lowercase)"
+    },
+    {
+      "src": "a < b",
+      "expr": {
+        "kind": "binary",
+        "op": "<",
+        "left": {
+          "kind": "identifier",
+          "name": "a"
+        },
+        "right": {
+          "kind": "identifier",
+          "name": "b"
+        }
+      },
+      "env": {
+        "a": "10",
+        "b": "9"
+      },
+      "expect": true,
+      "note": "two numeric strings compare lexically, not numerically"
+    },
+    {
+      "src": "item.id === 2",
+      "expr": {
+        "kind": "binary",
+        "op": "===",
+        "left": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "item"
+          },
+          "property": "id",
+          "computed": false
+        },
+        "right": {
+          "kind": "literal",
+          "value": 2,
+          "literalType": "number",
+          "raw": "2"
+        }
+      },
+      "env": {
+        "item": {
+          "id": 2
+        }
+      },
+      "expect": true,
+      "note": "strict equality on equal numbers"
+    },
+    {
+      "src": "item.id === 2",
+      "expr": {
+        "kind": "binary",
+        "op": "===",
+        "left": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "item"
+          },
+          "property": "id",
+          "computed": false
+        },
+        "right": {
+          "kind": "literal",
+          "value": 2,
+          "literalType": "number",
+          "raw": "2"
+        }
+      },
+      "env": {
+        "item": {
+          "id": 3
+        }
+      },
+      "expect": false,
+      "note": "strict equality on unequal numbers"
+    },
+    {
+      "src": "item.id === 2",
+      "expr": {
+        "kind": "binary",
+        "op": "===",
+        "left": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "item"
+          },
+          "property": "id",
+          "computed": false
+        },
+        "right": {
+          "kind": "literal",
+          "value": 2,
+          "literalType": "number",
+          "raw": "2"
+        }
+      },
+      "env": {
+        "item": {
+          "id": "2"
+        }
+      },
+      "expect": false,
+      "note": "strict equality is false across number/string"
+    },
+    {
+      "src": "item.status !== 'done'",
+      "expr": {
+        "kind": "binary",
+        "op": "!==",
+        "left": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "item"
+          },
+          "property": "status",
+          "computed": false
+        },
+        "right": {
+          "kind": "literal",
+          "value": "done",
+          "literalType": "string"
+        }
+      },
+      "env": {
+        "item": {
+          "status": "open"
+        }
+      },
+      "expect": true,
+      "note": "strict inequality on strings"
+    },
+    {
+      "src": "item.done && item.priority > 3",
+      "expr": {
+        "kind": "logical",
+        "op": "&&",
+        "left": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "item"
+          },
+          "property": "done",
+          "computed": false
+        },
+        "right": {
+          "kind": "binary",
+          "op": ">",
+          "left": {
+            "kind": "member",
+            "object": {
+              "kind": "identifier",
+              "name": "item"
+            },
+            "property": "priority",
+            "computed": false
+          },
+          "right": {
+            "kind": "literal",
+            "value": 3,
+            "literalType": "number",
+            "raw": "3"
+          }
+        }
+      },
+      "env": {
+        "item": {
+          "done": true,
+          "priority": 5
+        }
+      },
+      "expect": true,
+      "note": "filter body: && both truthy"
+    },
+    {
+      "src": "item.done && item.priority > 3",
+      "expr": {
+        "kind": "logical",
+        "op": "&&",
+        "left": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "item"
+          },
+          "property": "done",
+          "computed": false
+        },
+        "right": {
+          "kind": "binary",
+          "op": ">",
+          "left": {
+            "kind": "member",
+            "object": {
+              "kind": "identifier",
+              "name": "item"
+            },
+            "property": "priority",
+            "computed": false
+          },
+          "right": {
+            "kind": "literal",
+            "value": 3,
+            "literalType": "number",
+            "raw": "3"
+          }
+        }
+      },
+      "env": {
+        "item": {
+          "done": false,
+          "priority": 5
+        }
+      },
+      "expect": false,
+      "note": "&& short-circuits on a falsy left, returning it"
+    },
+    {
+      "src": "item.label || 'untitled'",
+      "expr": {
+        "kind": "logical",
+        "op": "||",
+        "left": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "item"
+          },
+          "property": "label",
+          "computed": false
+        },
+        "right": {
+          "kind": "literal",
+          "value": "untitled",
+          "literalType": "string"
+        }
+      },
+      "env": {
+        "item": {
+          "label": ""
+        }
+      },
+      "expect": "untitled",
+      "note": "|| falls through an empty string to the default"
+    },
+    {
+      "src": "item.label || 'untitled'",
+      "expr": {
+        "kind": "logical",
+        "op": "||",
+        "left": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "item"
+          },
+          "property": "label",
+          "computed": false
+        },
+        "right": {
+          "kind": "literal",
+          "value": "untitled",
+          "literalType": "string"
+        }
+      },
+      "env": {
+        "item": {
+          "label": "set"
+        }
+      },
+      "expect": "set",
+      "note": "|| returns the truthy left operand"
+    },
+    {
+      "src": "item.qty ?? 0",
+      "expr": {
+        "kind": "logical",
+        "op": "??",
+        "left": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "item"
+          },
+          "property": "qty",
+          "computed": false
+        },
+        "right": {
+          "kind": "literal",
+          "value": 0,
+          "literalType": "number",
+          "raw": "0"
+        }
+      },
+      "env": {
+        "item": {
+          "qty": 0
+        }
+      },
+      "expect": 0,
+      "note": "?? keeps a present zero (only null coalesces)"
+    },
+    {
+      "src": "item.qty ?? 0",
+      "expr": {
+        "kind": "logical",
+        "op": "??",
+        "left": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "item"
+          },
+          "property": "qty",
+          "computed": false
+        },
+        "right": {
+          "kind": "literal",
+          "value": 0,
+          "literalType": "number",
+          "raw": "0"
+        }
+      },
+      "env": {
+        "item": {
+          "qty": null
+        }
+      },
+      "expect": 0,
+      "note": "?? coalesces a null to the default"
+    },
+    {
+      "src": "item.missing ?? 9",
+      "expr": {
+        "kind": "logical",
+        "op": "??",
+        "left": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "item"
+          },
+          "property": "missing",
+          "computed": false
+        },
+        "right": {
+          "kind": "literal",
+          "value": 9,
+          "literalType": "number",
+          "raw": "9"
+        }
+      },
+      "env": {
+        "item": {}
+      },
+      "expect": 9,
+      "note": "?? coalesces a missing field (reads as null)"
+    },
+    {
+      "src": "item.n ? 'y' : 'n'",
+      "expr": {
+        "kind": "conditional",
+        "test": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "item"
+          },
+          "property": "n",
+          "computed": false
+        },
+        "consequent": {
+          "kind": "literal",
+          "value": "y",
+          "literalType": "string"
+        },
+        "alternate": {
+          "kind": "literal",
+          "value": "n",
+          "literalType": "string"
+        }
+      },
+      "env": {
+        "item": {
+          "n": 0
+        }
+      },
+      "expect": "n",
+      "note": "ternary test: 0 is falsy"
+    },
+    {
+      "src": "item.s ? 'y' : 'n'",
+      "expr": {
+        "kind": "conditional",
+        "test": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "item"
+          },
+          "property": "s",
+          "computed": false
+        },
+        "consequent": {
+          "kind": "literal",
+          "value": "y",
+          "literalType": "string"
+        },
+        "alternate": {
+          "kind": "literal",
+          "value": "n",
+          "literalType": "string"
+        }
+      },
+      "env": {
+        "item": {
+          "s": "0"
+        }
+      },
+      "expect": "y",
+      "note": "ternary test: the string \"0\" is truthy"
+    },
+    {
+      "src": "a > b ? 1 : a < b ? -1 : 0",
+      "expr": {
+        "kind": "conditional",
+        "test": {
+          "kind": "binary",
+          "op": ">",
+          "left": {
+            "kind": "identifier",
+            "name": "a"
+          },
+          "right": {
+            "kind": "identifier",
+            "name": "b"
+          }
+        },
+        "consequent": {
+          "kind": "literal",
+          "value": 1,
+          "literalType": "number",
+          "raw": "1"
+        },
+        "alternate": {
+          "kind": "conditional",
+          "test": {
+            "kind": "binary",
+            "op": "<",
+            "left": {
+              "kind": "identifier",
+              "name": "a"
+            },
+            "right": {
+              "kind": "identifier",
+              "name": "b"
+            }
+          },
+          "consequent": {
+            "kind": "unary",
+            "op": "-",
+            "argument": {
+              "kind": "literal",
+              "value": 1,
+              "literalType": "number",
+              "raw": "1"
+            }
+          },
+          "alternate": {
+            "kind": "literal",
+            "value": 0,
+            "literalType": "number",
+            "raw": "0"
+          }
+        }
+      },
+      "env": {
+        "a": 5,
+        "b": 3
+      },
+      "expect": 1,
+      "note": "sort comparator: 3-way ternary, greater branch"
+    },
+    {
+      "src": "a > b ? 1 : a < b ? -1 : 0",
+      "expr": {
+        "kind": "conditional",
+        "test": {
+          "kind": "binary",
+          "op": ">",
+          "left": {
+            "kind": "identifier",
+            "name": "a"
+          },
+          "right": {
+            "kind": "identifier",
+            "name": "b"
+          }
+        },
+        "consequent": {
+          "kind": "literal",
+          "value": 1,
+          "literalType": "number",
+          "raw": "1"
+        },
+        "alternate": {
+          "kind": "conditional",
+          "test": {
+            "kind": "binary",
+            "op": "<",
+            "left": {
+              "kind": "identifier",
+              "name": "a"
+            },
+            "right": {
+              "kind": "identifier",
+              "name": "b"
+            }
+          },
+          "consequent": {
+            "kind": "unary",
+            "op": "-",
+            "argument": {
+              "kind": "literal",
+              "value": 1,
+              "literalType": "number",
+              "raw": "1"
+            }
+          },
+          "alternate": {
+            "kind": "literal",
+            "value": 0,
+            "literalType": "number",
+            "raw": "0"
+          }
+        }
+      },
+      "env": {
+        "a": 3,
+        "b": 3
+      },
+      "expect": 0,
+      "note": "sort comparator: 3-way ternary, equal branch"
+    },
+    {
+      "src": "item.a.b",
+      "expr": {
+        "kind": "member",
+        "object": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "item"
+          },
+          "property": "a",
+          "computed": false
+        },
+        "property": "b",
+        "computed": false
+      },
+      "env": {
+        "item": {
+          "a": {
+            "b": 42
+          }
+        }
+      },
+      "expect": 42,
+      "note": "nested member access"
+    },
+    {
+      "src": "item.missing",
+      "expr": {
+        "kind": "member",
+        "object": {
+          "kind": "identifier",
+          "name": "item"
+        },
+        "property": "missing",
+        "computed": false
+      },
+      "env": {
+        "item": {}
+      },
+      "expect": null,
+      "note": "a missing field reads as null"
+    },
+    {
+      "src": "item.tags.length",
+      "expr": {
+        "kind": "member",
+        "object": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "item"
+          },
+          "property": "tags",
+          "computed": false
+        },
+        "property": "length",
+        "computed": false
+      },
+      "env": {
+        "item": {
+          "tags": [
+            "x",
+            "y",
+            "z"
+          ]
+        }
+      },
+      "expect": 3,
+      "note": ".length on an array field"
+    },
+    {
+      "src": "item.name.length",
+      "expr": {
+        "kind": "member",
+        "object": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "item"
+          },
+          "property": "name",
+          "computed": false
+        },
+        "property": "length",
+        "computed": false
+      },
+      "env": {
+        "item": {
+          "name": "abcd"
+        }
+      },
+      "expect": 4,
+      "note": ".length on a string field"
+    },
+    {
+      "src": "item[i]",
+      "expr": {
+        "kind": "index-access",
+        "object": {
+          "kind": "identifier",
+          "name": "item"
+        },
+        "index": {
+          "kind": "identifier",
+          "name": "i"
+        }
+      },
+      "env": {
+        "item": [
+          10,
+          20,
+          30
+        ],
+        "i": 1
+      },
+      "expect": 20,
+      "note": "index access by a numeric variable"
+    },
+    {
+      "src": "item[i]",
+      "expr": {
+        "kind": "index-access",
+        "object": {
+          "kind": "identifier",
+          "name": "item"
+        },
+        "index": {
+          "kind": "identifier",
+          "name": "i"
+        }
+      },
+      "env": {
+        "item": [
+          10,
+          20
+        ],
+        "i": 5
+      },
+      "expect": null,
+      "note": "out-of-range index reads as null"
+    },
+    {
+      "src": "row[k]",
+      "expr": {
+        "kind": "index-access",
+        "object": {
+          "kind": "identifier",
+          "name": "row"
+        },
+        "index": {
+          "kind": "identifier",
+          "name": "k"
+        }
+      },
+      "env": {
+        "row": {
+          "price": 9
+        },
+        "k": "price"
+      },
+      "expect": 9,
+      "note": "index access into an object by a string key"
+    },
+    {
+      "src": "`${item.id}: ${item.name}`",
+      "expr": {
+        "kind": "template-literal",
+        "parts": [
+          {
+            "type": "expression",
+            "expr": {
+              "kind": "member",
+              "object": {
+                "kind": "identifier",
+                "name": "item"
+              },
+              "property": "id",
+              "computed": false
+            }
+          },
+          {
+            "type": "string",
+            "value": ": "
+          },
+          {
+            "type": "expression",
+            "expr": {
+              "kind": "member",
+              "object": {
+                "kind": "identifier",
+                "name": "item"
+              },
+              "property": "name",
+              "computed": false
+            }
+          }
+        ]
+      },
+      "env": {
+        "item": {
+          "id": 7,
+          "name": "widget"
+        }
+      },
+      "expect": "7: widget",
+      "note": "template literal interpolates and stringifies parts"
+    },
+    {
+      "src": "`n=${acc + 1}`",
+      "expr": {
+        "kind": "template-literal",
+        "parts": [
+          {
+            "type": "string",
+            "value": "n="
+          },
+          {
+            "type": "expression",
+            "expr": {
+              "kind": "binary",
+              "op": "+",
+              "left": {
+                "kind": "identifier",
+                "name": "acc"
+              },
+              "right": {
+                "kind": "literal",
+                "value": 1,
+                "literalType": "number",
+                "raw": "1"
+              }
+            }
+          }
+        ]
+      },
+      "env": {
+        "acc": 4
+      },
+      "expect": "n=5",
+      "note": "template literal evaluates an embedded expression"
+    },
+    {
+      "src": "[item.a, item.b]",
+      "expr": {
+        "kind": "array-literal",
+        "elements": [
+          {
+            "kind": "member",
+            "object": {
+              "kind": "identifier",
+              "name": "item"
+            },
+            "property": "a",
+            "computed": false
+          },
+          {
+            "kind": "member",
+            "object": {
+              "kind": "identifier",
+              "name": "item"
+            },
+            "property": "b",
+            "computed": false
+          }
+        ]
+      },
+      "env": {
+        "item": {
+          "a": 1,
+          "b": 2
+        }
+      },
+      "expect": [
+        1,
+        2
+      ],
+      "note": "array literal of field projections"
+    },
+    {
+      "src": "({ id: item.id, doubled: item.n * 2 })",
+      "expr": {
+        "kind": "object-literal",
+        "properties": [
+          {
+            "key": "id",
+            "keyKind": "identifier",
+            "shorthand": false,
+            "value": {
+              "kind": "member",
+              "object": {
+                "kind": "identifier",
+                "name": "item"
+              },
+              "property": "id",
+              "computed": false
+            }
+          },
+          {
+            "key": "doubled",
+            "keyKind": "identifier",
+            "shorthand": false,
+            "value": {
+              "kind": "binary",
+              "op": "*",
+              "left": {
+                "kind": "member",
+                "object": {
+                  "kind": "identifier",
+                  "name": "item"
+                },
+                "property": "n",
+                "computed": false
+              },
+              "right": {
+                "kind": "literal",
+                "value": 2,
+                "literalType": "number",
+                "raw": "2"
+              }
+            }
+          }
+        ],
+        "raw": "({ id: item.id, doubled: item.n * 2 })"
+      },
+      "env": {
+        "item": {
+          "id": 3,
+          "n": 4
+        }
+      },
+      "expect": {
+        "id": 3,
+        "doubled": 8
+      },
+      "note": "object literal: map body building a new record"
+    },
+    {
+      "src": "Math.max(a, b)",
+      "expr": {
+        "kind": "call",
+        "callee": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "Math"
+          },
+          "property": "max",
+          "computed": false
+        },
+        "args": [
+          {
+            "kind": "identifier",
+            "name": "a"
+          },
+          {
+            "kind": "identifier",
+            "name": "b"
+          }
+        ]
+      },
+      "env": {
+        "a": 3,
+        "b": 7
+      },
+      "expect": 7,
+      "note": "Math.max of two numbers"
+    },
+    {
+      "src": "Math.min(a, b, c)",
+      "expr": {
+        "kind": "call",
+        "callee": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "Math"
+          },
+          "property": "min",
+          "computed": false
+        },
+        "args": [
+          {
+            "kind": "identifier",
+            "name": "a"
+          },
+          {
+            "kind": "identifier",
+            "name": "b"
+          },
+          {
+            "kind": "identifier",
+            "name": "c"
+          }
+        ]
+      },
+      "env": {
+        "a": 3,
+        "b": 7,
+        "c": 1
+      },
+      "expect": 1,
+      "note": "Math.min is variadic"
+    },
+    {
+      "src": "Math.abs(acc)",
+      "expr": {
+        "kind": "call",
+        "callee": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "Math"
+          },
+          "property": "abs",
+          "computed": false
+        },
+        "args": [
+          {
+            "kind": "identifier",
+            "name": "acc"
+          }
+        ]
+      },
+      "env": {
+        "acc": -5
+      },
+      "expect": 5,
+      "note": "Math.abs"
+    },
+    {
+      "src": "Math.floor(item.x)",
+      "expr": {
+        "kind": "call",
+        "callee": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "Math"
+          },
+          "property": "floor",
+          "computed": false
+        },
+        "args": [
+          {
+            "kind": "member",
+            "object": {
+              "kind": "identifier",
+              "name": "item"
+            },
+            "property": "x",
+            "computed": false
+          }
+        ]
+      },
+      "env": {
+        "item": {
+          "x": 3.7
+        }
+      },
+      "expect": 3,
+      "note": "Math.floor truncates toward -Infinity"
+    },
+    {
+      "src": "Math.ceil(item.x)",
+      "expr": {
+        "kind": "call",
+        "callee": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "Math"
+          },
+          "property": "ceil",
+          "computed": false
+        },
+        "args": [
+          {
+            "kind": "member",
+            "object": {
+              "kind": "identifier",
+              "name": "item"
+            },
+            "property": "x",
+            "computed": false
+          }
+        ]
+      },
+      "env": {
+        "item": {
+          "x": 3.2
+        }
+      },
+      "expect": 4,
+      "note": "Math.ceil rounds up"
+    },
+    {
+      "src": "Math.round(item.x)",
+      "expr": {
+        "kind": "call",
+        "callee": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "Math"
+          },
+          "property": "round",
+          "computed": false
+        },
+        "args": [
+          {
+            "kind": "member",
+            "object": {
+              "kind": "identifier",
+              "name": "item"
+            },
+            "property": "x",
+            "computed": false
+          }
+        ]
+      },
+      "env": {
+        "item": {
+          "x": 2.5
+        }
+      },
+      "expect": 3,
+      "note": "Math.round: positive half rounds toward +Infinity"
+    },
+    {
+      "src": "Math.round(item.x)",
+      "expr": {
+        "kind": "call",
+        "callee": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "Math"
+          },
+          "property": "round",
+          "computed": false
+        },
+        "args": [
+          {
+            "kind": "member",
+            "object": {
+              "kind": "identifier",
+              "name": "item"
+            },
+            "property": "x",
+            "computed": false
+          }
+        ]
+      },
+      "env": {
+        "item": {
+          "x": -2.5
+        }
+      },
+      "expect": -2,
+      "note": "Math.round: negative half rounds toward +Infinity (to -2)"
+    },
+    {
+      "src": "String(item.n)",
+      "expr": {
+        "kind": "call",
+        "callee": {
+          "kind": "identifier",
+          "name": "String"
+        },
+        "args": [
+          {
+            "kind": "member",
+            "object": {
+              "kind": "identifier",
+              "name": "item"
+            },
+            "property": "n",
+            "computed": false
+          }
+        ]
+      },
+      "env": {
+        "item": {
+          "n": 42
+        }
+      },
+      "expect": "42",
+      "note": "String() coerces a number"
+    },
+    {
+      "src": "Number(item.s)",
+      "expr": {
+        "kind": "call",
+        "callee": {
+          "kind": "identifier",
+          "name": "Number"
+        },
+        "args": [
+          {
+            "kind": "member",
+            "object": {
+              "kind": "identifier",
+              "name": "item"
+            },
+            "property": "s",
+            "computed": false
+          }
+        ]
+      },
+      "env": {
+        "item": {
+          "s": "3.14"
+        }
+      },
+      "expect": 3.14,
+      "note": "Number() parses a numeric string"
+    },
+    {
+      "src": "Boolean(item.s)",
+      "expr": {
+        "kind": "call",
+        "callee": {
+          "kind": "identifier",
+          "name": "Boolean"
+        },
+        "args": [
+          {
+            "kind": "member",
+            "object": {
+              "kind": "identifier",
+              "name": "item"
+            },
+            "property": "s",
+            "computed": false
+          }
+        ]
+      },
+      "env": {
+        "item": {
+          "s": ""
+        }
+      },
+      "expect": false,
+      "note": "Boolean() of an empty string is false"
+    },
+    {
+      "src": "acc + item.price * item.qty",
+      "expr": {
+        "kind": "binary",
+        "op": "+",
+        "left": {
+          "kind": "identifier",
+          "name": "acc"
+        },
+        "right": {
+          "kind": "binary",
+          "op": "*",
+          "left": {
+            "kind": "member",
+            "object": {
+              "kind": "identifier",
+              "name": "item"
+            },
+            "property": "price",
+            "computed": false
+          },
+          "right": {
+            "kind": "member",
+            "object": {
+              "kind": "identifier",
+              "name": "item"
+            },
+            "property": "qty",
+            "computed": false
+          }
+        }
+      },
+      "env": {
+        "acc": 100,
+        "item": {
+          "price": 5,
+          "qty": 3
+        }
+      },
+      "expect": 115,
+      "note": "reduce body: running total with precedence"
+    },
+    {
+      "src": "a.price - b.price",
+      "expr": {
+        "kind": "binary",
+        "op": "-",
+        "left": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "a"
+          },
+          "property": "price",
+          "computed": false
+        },
+        "right": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "b"
+          },
+          "property": "price",
+          "computed": false
+        }
+      },
+      "env": {
+        "a": {
+          "price": 30
+        },
+        "b": {
+          "price": 10
+        }
+      },
+      "expect": 20,
+      "note": "sort comparator: numeric field difference"
+    },
+    {
+      "src": "item.qty * 2",
+      "expr": {
+        "kind": "binary",
+        "op": "*",
+        "left": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "item"
+          },
+          "property": "qty",
+          "computed": false
+        },
+        "right": {
+          "kind": "literal",
+          "value": 2,
+          "literalType": "number",
+          "raw": "2"
+        }
+      },
+      "env": {
+        "item": {
+          "qty": 21
+        }
+      },
+      "expect": 42,
+      "note": "map body: arithmetic projection"
+    },
+    {
+      "src": "item.tags.length > 0 && item.active",
+      "expr": {
+        "kind": "logical",
+        "op": "&&",
+        "left": {
+          "kind": "binary",
+          "op": ">",
+          "left": {
+            "kind": "member",
+            "object": {
+              "kind": "member",
+              "object": {
+                "kind": "identifier",
+                "name": "item"
+              },
+              "property": "tags",
+              "computed": false
+            },
+            "property": "length",
+            "computed": false
+          },
+          "right": {
+            "kind": "literal",
+            "value": 0,
+            "literalType": "number",
+            "raw": "0"
+          }
+        },
+        "right": {
+          "kind": "member",
+          "object": {
+            "kind": "identifier",
+            "name": "item"
+          },
+          "property": "active",
+          "computed": false
+        }
+      },
+      "env": {
+        "item": {
+          "tags": [
+            "a"
+          ],
+          "active": true
+        }
+      },
+      "expect": true,
+      "note": "filter body: length guard plus boolean field"
+    }
+  ]
+}

--- a/packages/adapter-tests/helper-vectors/generate.ts
+++ b/packages/adapter-tests/helper-vectors/generate.ts
@@ -32,7 +32,7 @@ export interface VectorFile {
  * encodable. Args must stay finite (refused loudly) until a
  * composition case needs otherwise.
  */
-function assertEncodable(value: unknown, context: string): void {
+export function assertEncodable(value: unknown, context: string): void {
   if (value === undefined) throw new Error(`${context}: undefined is not encodable in vectors.json`)
   if (typeof value === 'number' && !Number.isFinite(value)) {
     throw new Error(`${context}: non-finite number ${value} is not encodable in vectors.json`)
@@ -44,7 +44,7 @@ function assertEncodable(value: unknown, context: string): void {
   }
 }
 
-function encodeExpect(value: unknown, context: string): unknown {
+export function encodeExpect(value: unknown, context: string): unknown {
   // JS distinguishes undefined from null; the template backends have a
   // single absent value (Go nil / Perl undef). Per the spec, an
   // undefined EXPECT encodes as null (value-compat).

--- a/packages/adapter-tests/package.json
+++ b/packages/adapter-tests/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "generate:helper-vectors": "bun helper-vectors/generate.ts",
+    "generate:eval-vectors": "bun helper-vectors/eval-generate.ts",
     "test:fixture-hydrate": "bunx playwright test --config=playwright.config.ts"
   },
   "dependencies": {

--- a/packages/adapter-tests/src/__tests__/eval-vectors.test.ts
+++ b/packages/adapter-tests/src/__tests__/eval-vectors.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Freshness + shape guard for the golden ParsedExpr-evaluator vectors
+ * (issue #2018, Track A — spec/compiler.md "ParsedExpr Evaluator
+ * Semantics").
+ *
+ * eval-vectors.json is generated from helper-vectors/eval-cases.ts and
+ * committed; the Go (runtime/eval_vectors_test.go) and Perl
+ * (t/eval_vectors.t) harnesses consume the committed file to prove their
+ * evaluators are isomorphic with JS. This test fails when the file
+ * drifts from the case definitions, so "edited eval-cases.ts but forgot
+ * to regenerate" (or a hand-edited eval-vectors.json) can't land.
+ */
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import {
+  buildEvalVectors,
+  serializeEvalVectors,
+  EVAL_VECTORS_PATH,
+} from '../../helper-vectors/eval-generate'
+
+describe('ParsedExpr evaluator golden vectors', () => {
+  test('eval-vectors.json is up to date with eval-cases.ts (run `bun run generate:eval-vectors`)', () => {
+    expect(readFileSync(EVAL_VECTORS_PATH, 'utf8')).toBe(serializeEvalVectors())
+  })
+
+  test('every case parses to a supported ParsedExpr (none fall to `unsupported`)', () => {
+    for (const c of buildEvalVectors().cases) {
+      expect(c.expr.kind).not.toBe('unsupported')
+    }
+  })
+
+  test('case notes are unique — harness diagnostics reference them', () => {
+    const seen = new Set<string>()
+    for (const c of buildEvalVectors().cases) {
+      expect(seen.has(c.note)).toBe(false)
+      seen.add(c.note)
+    }
+  })
+})

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -552,6 +552,52 @@ interface level; `JsxAdapter` is purely code reuse.
 
 When implementing a new adapter, handle these concerns in addition to the basic `TemplateAdapter` interface:
 
+#### ParsedExpr Evaluator Semantics
+
+> Status: contract defined (issue [#2018](https://github.com/piconic-ai/barefootjs/issues/2018), Track A). Go (`bf.go`) and shared Perl (`BarefootJS::Evaluator`) implementations land in Tracks B / C.
+
+Templates carry ordinary expressions structurally and lower them to **template-native** syntax — that is unchanged, and the evaluator described here is **not** a general expression engine. The one place a template genuinely cannot express the source is a **higher-order callback body**: `reduce` / `sort` / `map` / `filter` / `find` `(…) => expr`. A template cannot hold a lambda in expression position, which is *why* the adapter historically special-cased these callbacks into fixed shapes (`bf_sort`'s comparator catalogue, `bf_reduce`'s `+`/`*` fold with an `acc`-canonical form). This evaluator replaces that ad-hoc list: each backend runtime carries the callback **body** as a `ParsedExpr` subtree and **evaluates** it against an environment.
+
+This subsection pins the evaluator's contract so the backends stay byte-isomorphic. The semantic source of truth is the JS reference evaluator at `packages/adapter-tests/helper-vectors/eval-reference.ts`; the cross-language golden vectors are `eval-vectors.json` (generated from `eval-cases.ts`, consumed by the Go and Perl harnesses).
+
+**The environment.** Evaluation is against a flat map of names to values: the higher-order parameters (`acc`, `item`, and the second `sort` operand) plus any captured free variables (outer `const` / signal references). A reference to a name not in the environment is **refused** (the callback is not a closed pure expression).
+
+**Value domain.** JSON-shaped values: IEEE-754 number, string, boolean, null, array, object. There is no `undefined` — a missing object field and an out-of-range array index both read as **null** (the backends' single absent value).
+
+**Accepted node kinds** (any other kind in a callback body — `arrow-fn`, `higher-order`, `array-method`, etc. — is refused):
+
+| Kind | Semantics |
+|---|---|
+| `literal` | the literal value |
+| `identifier` | environment lookup; an unbound name is refused |
+| `binary` | `+` `-` `*` `/` `%`, relational `<` `<=` `>` `>=`, strict `===` `!==` (see below) |
+| `unary` | `!` (logical not), `-` (numeric negate), `+` (numeric coerce) |
+| `logical` | `&&` `\|\|` `??` — short-circuit, **operand-returning** (not coerced to boolean) |
+| `conditional` | ternary; the test uses JS truthiness; only the taken branch is evaluated |
+| `member` | `obj.field` → field or null; `.length` on a string/array; reading a field of null is refused |
+| `index-access` | `obj[i]` → array element (integer, in-range, else null) or object field by string key |
+| `template-literal` | string parts verbatim; expression parts coerced via ToString |
+| `array-literal` / `object-literal` | element/property values evaluated left-to-right |
+| `call` | **allowlisted builtins only**: `Math.max` / `Math.min` / `Math.abs` / `Math.floor` / `Math.ceil` / `Math.round`, and `String` / `Number` / `Boolean`. Any other callee is refused. |
+
+**Evaluation order.** Strict left-to-right. Operands are evaluated before the operator is applied, except for the short-circuiting forms (`&&`, `||`, `??`, and the ternary), which evaluate the right/branch operand only when reached.
+
+**Coercion (the literal JS rules — not the divergent `bf->string` / `bf_reduce` helper conventions):**
+- *ToNumber*: number → itself; boolean → 1 / 0; null → 0; string → trimmed parse (empty → 0, non-numeric → NaN).
+- *ToString*: string → itself; number → JS number-to-string; boolean → `"true"` / `"false"`; null → `"null"`.
+- *ToBoolean* (truthiness, used by `!`, `&&`, `||`, ternary): the JS falsy set is `false`, `0`, `NaN`, `""`, `null`. Everything else is truthy — notably the string `"0"`, an empty array, and an empty object.
+
+**Operator details:**
+- `+` is overloaded exactly like JS: if either operand is a string, both are ToString'd and concatenated; otherwise both are ToNumber'd and added. `-` `*` `/` `%` are always numeric.
+- Relational `<` `<=` `>` `>=` follow JS Abstract Relational Comparison: if **both** operands are strings, compare by code unit (case-sensitive — uppercase sorts before lowercase); otherwise ToNumber both (a NaN operand makes the comparison false).
+- Equality is **strict only** (`===` / `!==`): equal type and value, no coercion; a non-primitive operand is refused. Loose `==` / `!=` and bitwise/shift operators are deliberately **out of the subset** (their coercion is hard to keep byte-isomorphic).
+- `&&` returns its left operand when that is falsy, else the right; `||` returns its left when truthy, else the right; `??` returns its left unless the left is null. All three return the operand value, not a coerced boolean.
+- `Math.round` rounds a half **toward +Infinity** (`2.5 → 3`, `-2.5 → -2`), matching the existing `round` helper rather than Go's `math.Round` (which rounds half away from zero).
+
+**Deliberate exclusions for isomorphism.** Locale-sensitive operations are not in the subset — most importantly `String.prototype.localeCompare`, whose ICU collation cannot be guaranteed byte-equal across JS / Go (`golang.org/x/text/collate`) / Perl (`Unicode::Collate`). This is the same barrier already documented for the `bf_sort` `string` key (see "Sort comparator follow-ups" under Known limitations); string ordering inside a comparator must use relational `<` / `>` (code-unit order), and non-ASCII relational comparison is a known divergence region.
+
+**Refusal.** A callback body using anything outside this subset (an unaccepted node kind, operator, builtin, or an unbound identifier) is **unsupported** and surfaces **BF101** upstream, with `/* @client */` as the escape hatch — exactly as the off-catalogue `.reduce` does today. The evaluator is **growing-only**: widening the subset adds vectors and never removes a previously-accepted shape.
+
 #### Child Component Rendering
 
 Child components produce `IRComponent` nodes. The adapter emits a call to the runtime's child-render mechanism (e.g., `render_child('name', prop => val)`). Key rules:

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -562,7 +562,7 @@ This subsection pins the evaluator's contract so the backends stay byte-isomorph
 
 **The environment.** Evaluation is against a flat map of names to values: the higher-order parameters (`acc`, `item`, and the second `sort` operand) plus any captured free variables (outer `const` / signal references). A reference to a name not in the environment is **refused** (the callback is not a closed pure expression).
 
-**Value domain.** JSON-shaped values: IEEE-754 number, string, boolean, null, array, object. There is no `undefined` — a missing object field and an out-of-range array index both read as **null** (the backends' single absent value).
+**Value domain.** JSON-shaped values: IEEE-754 number, string, boolean, null, array, object. There is no `undefined` — a missing object field and an out-of-range array index both read as **null** (the backends' single absent value). Numbers are full IEEE-754 doubles, so a coercion or division can yield a **non-finite** value: `Number("x")` and `0/0` produce `NaN` (always falsy, and `NaN !== NaN`); `1/0` produces `Infinity`. In `eval-vectors.json` a non-finite EXPECT is carried with the reserved `{"$num": "NaN" | "Infinity" | "-Infinity"}` sentinel — the same encoding the helper vectors use (spec/template-helpers.md) — so backend harnesses match against it rather than a literal number.
 
 **Accepted node kinds** (any other kind in a callback body — `arrow-fn`, `higher-order`, `array-method`, etc. — is refused):
 


### PR DESCRIPTION
## Track A of #2018 — the evaluator contract (backend-independent)

Higher-order callback bodies (`reduce` / `sort` / `map` / `filter` / `find` `(…) => expr`) are the one place a template genuinely cannot express the source. Today the adapter special-cases them into fixed shapes (`bf_sort`'s comparator catalogue, `bf_reduce`'s `+`/`*` fold with an `acc`-canonical form) — an ad-hoc list that grows with each new shape. This track defines the abstraction that replaces it: a lightweight, pure-`ParsedExpr` evaluator that each backend runtime implements, with its semantics pinned **isomorphically** by golden vectors.

This is the contract only (per the issue's sequencing A → B → C). The Go (`bf.go`) and shared Perl (`BarefootJS::Evaluator`) implementations that consume these vectors land in Tracks B and C.

### What's here

- **`spec/compiler.md` → "ParsedExpr Evaluator Semantics"** — documents the accepted pure subset (node kinds, allowed operators, the `Math.*` / `String`/`Number`/`Boolean` built-in allowlist), strict left-to-right evaluation order with short-circuiting, JS-faithful coercion (ToNumber / ToString / ToBoolean), strict-only equality, operand-returning logicals, `Math.round` half-toward-+Infinity, and the deliberate locale-sensitive exclusions (`localeCompare`) that keep the three backends byte-equal.
- **`helper-vectors/eval-reference.ts`** — the JS reference evaluator: the semantic source of truth, written as the literal JS each construct lowers to.
- **`helper-vectors/eval-cases.ts`** — cases authored as a JS source string plus an environment (`{acc, item, …free vars}`). Covers coercion, numeric/string comparison, logicals, member/index access, template/array/object literals, the builtin allowlist, and the issue's motivating `reduce`/`sort`/`map`/`filter` callback bodies.
- **`helper-vectors/eval-generate.ts` + `eval-vectors.json`** — each vector's `expr` tree is produced by the **real compiler `parseExpression`** (never hand-transcribed); `expect` is computed mechanically by the reference evaluator, exactly like the existing helper-vectors pipeline.
- **`src/__tests__/eval-vectors.test.ts`** — freshness (regenerate-or-fail), shape (no case falls to `unsupported`), and note-uniqueness guards.

### Design notes

- The evaluator is **callbacks-only** — ordinary expressions stay lowered to template-native syntax. This is the minimum surface for the maximum generalization, not a general expression engine.
- Coercion follows the **literal JS rules**, not the divergent `bf->string` / `bf_reduce` helper conventions, so the contract is unambiguous and JS-faithful.
- Locale-sensitive ordering is **out of the subset** (same barrier already documented for the `bf_sort` `string` key): ICU collation can't be guaranteed byte-equal across JS / Go / Perl.
- The evaluator is **growing-only** — widening the subset adds vectors and never removes a previously-accepted shape.

### Verification

```
bun test packages/adapter-tests/src/__tests__/eval-vectors.test.ts      # 3 pass
bun test packages/adapter-tests/src/__tests__/helper-vectors.test.ts    # 3 pass (unchanged)
bun run --cwd packages/adapter-tests generate:eval-vectors              # 66 cases, no drift
```

`@barefootjs/adapter-tests` is release-ignored, so no published-package behaviour changes (empty changeset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W89ev91UM87mj2gXesFDUh)_