### PR TITLE
docs(go-template): trim historical comments, structure contracts as JSDoc

### DIFF
--- a/packages/adapter-go-template/src/adapter/analysis/component-tree.ts
+++ b/packages/adapter-go-template/src/adapter/analysis/component-tree.ts
@@ -2,9 +2,9 @@
  * IR component-tree analysis for the Go html/template adapter.
  *
  * Pure structural walks over the IR — no adapter instance state, no rendering.
- * Extracted from `go-template-adapter.ts` (Phase 4 decomposition). Only the two
- * entry points (`hasClientInteractivity`, `findNestedComponents`) are exported;
- * the recursive collectors stay module-internal.
+ * Only the two entry points (`hasClientInteractivity`,
+ * `findNestedComponents`) are exported; the recursive collectors stay
+ * module-internal.
  */
 
 import type {
@@ -121,7 +121,6 @@ function collectNestedComponents(node: IRNode, result: NestedComponentInfo[]): v
   if (node.type === 'loop') {
     const loop = node as IRLoop
     if (loop.childComponent) {
-      // Check for duplicates
       if (!result.some(c => c.name === loop.childComponent!.name)) {
         const hasBodyChildren = loop.childComponent.children.length > 0
         result.push({
@@ -164,11 +163,9 @@ function collectNestedComponents(node: IRNode, result: NestedComponentInfo[]): v
       collectNestedComponents(stmt.alternate, result)
     }
   } else if (node.type === 'component') {
-    // (#1896) JSX children passed to an imported component render via
-    // a companion define with the PARENT's data, so a keyed loop
-    // nested inside them (DataTablePreviewDemo's `sortedData().map(…)`
-    // inside `<TableBody>`) needs its `<Name>s` slice on THIS
-    // component's props like any other nested loop.
+    // JSX children passed to an imported component render via a companion
+    // define with the PARENT's data, so a keyed loop nested inside them needs
+    // its `<Name>s` slice on THIS component's props like any other nested loop.
     const comp = node as IRComponent
     for (const child of comp.children) {
       collectNestedComponents(child, result)

--- a/packages/adapter-go-template/src/adapter/emit-context.ts
+++ b/packages/adapter-go-template/src/adapter/emit-context.ts
@@ -2,18 +2,16 @@
  * The contract extracted emit modules depend on instead of the concrete
  * `GoTemplateAdapter`.
  *
- * The Go adapter's lowering is deeply mutually recursive (expression lowering ↔
- * condition lowering ↔ rendering), so a cluster pulled into its own module
- * still needs to call back into the shared per-compile state and the recursive
- * entry points. `GoEmitContext` is that seam: extracted free functions take a
- * `GoEmitContext` as their first argument, and the adapter — which owns the
- * state and implements the entry points — passes `this`. Modules depend on this
- * narrow interface, not the 8k-line class, so the dependency is explicit and
- * the modules are unit-testable against a stub.
+ * The Go adapter's lowering is deeply mutually recursive (expression ↔
+ * condition ↔ rendering), so a module pulled out still needs to call back into
+ * the shared per-compile state and the recursive entry points. `GoEmitContext`
+ * is that seam: extracted free functions take it as their first argument, and
+ * the adapter — which owns the state and implements the entry points — passes
+ * `this`. Modules depend on this narrow interface, so they stay unit-testable
+ * against a stub.
  *
  * Keep this surface minimal: add a member only when an extracted module
- * genuinely needs it, so the seam documents the real cross-module coupling
- * rather than re-exposing the whole adapter.
+ * genuinely needs it, so the seam documents the real cross-module coupling.
  */
 
 import type ts from 'typescript'
@@ -31,9 +29,7 @@ export interface GoEmitContext {
 
   /**
    * Lower a JS expression to its Go-template form (the core recursive entry).
-   * `preParsed` reuses an already-built tree instead of re-parsing `jsExpr`
-   * (the helper-inliner lowers a structurally substituted body this way, with
-   * no `ts.createSourceFile`, #2006).
+   * `preParsed` reuses an already-built tree instead of re-parsing `jsExpr`.
    */
   convertExpressionToGo(
     jsExpr: string,

--- a/packages/adapter-go-template/src/adapter/expr/helper-inline.ts
+++ b/packages/adapter-go-template/src/adapter/expr/helper-inline.ts
@@ -1,17 +1,11 @@
 /**
  * Inlining of component-scope arrow-const helpers at a call site.
  *
- * Extracted from `go-template-adapter.ts` (Phase 4 decomposition). When a JSX
- * expression calls a local `const f = (a) => …` helper, the Go adapter has no
- * function to emit — it inlines the helper body with the call args substituted
- * for the params, so the result lowers like any inline expression. The
- * substitution is scope-blind, so the guards here reject bodies where a param
- * replacement could be wrong.
- *
- * The whole path is structural (#2006): the call arrives already parsed (its
- * `ParsedExpr` tree, threaded from `convertExpressionToGo`'s `preParsed`), and
- * the helper body is the analyzer-attached `ConstantInfo.parsed2` tree — so no
- * `ts.createSourceFile` re-parse is needed.
+ * When a JSX expression calls a local `const f = (a) => …` helper, the Go
+ * adapter has no function to emit — it inlines the helper body with the call
+ * args substituted for the params, so the result lowers like any inline
+ * expression. The substitution is scope-blind, so the guards here reject bodies
+ * where a param replacement could be wrong.
  */
 
 import { type ParsedExpr, parsedExpr2ToParsedExpr } from '@barefootjs/jsx'
@@ -19,14 +13,13 @@ import { type ParsedExpr, parsedExpr2ToParsedExpr } from '@barefootjs/jsx'
 import type { GoEmitContext } from '../emit-context.ts'
 
 /**
- * Inline a call to a local arrow-const helper, returning the substituted body
- * tree, or null when the expression isn't such a call or the body isn't
- * substitution-safe (nested functions, helper-calling helpers, spread args, …).
+ * Inline a call to a local arrow-const helper.
  *
- * `callParsed` is the call's already-built `ParsedExpr` (the `preParsed` tree
- * threaded from `convertExpressionToGo`). It must be a `call` node; without it
- * (a call site that didn't carry a tree) inlining is declined — every site that
- * legitimately inlines a helper threads its IR `parsed`.
+ * @param callParsed the call's already-built `ParsedExpr`. Must be a `call`
+ *   node; inlining is declined without it.
+ * @returns the substituted body tree, or null when the expression isn't such a
+ *   call or the body isn't substitution-safe (nested functions, helper-calling
+ *   helpers, spread args, …)
  */
 export function inlineLocalHelperCall(
   ctx: GoEmitContext,
@@ -34,9 +27,9 @@ export function inlineLocalHelperCall(
   callParsed?: ParsedExpr,
 ): ParsedExpr | null {
   if (ctx.state.localHelperNames.size === 0) return null
-  // Fast path: skip the work unless the expression begins with a known helper
-  // name applied as a call (`<helper>(`). The leading-identifier match is an
-  // unambiguous prefix — the real shape check is the tree inspection below.
+  // Fast path: skip unless the expression begins with a known helper name
+  // applied as a call (`<helper>(`); the real shape check is the tree
+  // inspection below.
   const head = /^\s*([A-Za-z_$][\w$]*)\s*\(/.exec(jsExpr)
   if (!head || !ctx.state.localHelperNames.has(head[1])) return null
 
@@ -53,10 +46,9 @@ export function inlineLocalHelperCall(
   if (!arrow || arrow.kind !== 'arrow') return null
   if (arrow.params.length !== callParsed.args.length) return null
 
-  // The body must lower to a `ParsedExpr` — a nested arrow / regex (the shapes
-  // `ParsedExpr` can't model) refuses here, which subsumes the
-  // nested-function-scope guard (a nested `(x) => …` in the body converts to
-  // null) the former text splicer enforced separately.
+  // The body must lower to a `ParsedExpr` — a nested arrow / regex (shapes
+  // `ParsedExpr` can't model) refuses here, which also covers the
+  // nested-function-scope guard (a nested `(x) => …` converts to null).
   const body = parsedExpr2ToParsedExpr(arrow.body)
   if (!body || body.kind === 'unsupported') return null
 
@@ -66,11 +58,9 @@ export function inlineLocalHelperCall(
   // Refuse a body containing a method call (`x.foo(…)`). The structural body
   // tree models it as a generic `call`, but `parseExpression` (which the rest
   // of the lowering is keyed to) folds the string / array method family
-  // (`.replace`, `.toLowerCase`, `.includes`, `.filter`, …) into specialised
-  // `array-method` / `higher-order` nodes — so lowering this tree directly
-  // would diverge. The current inliner fixtures (`sortClass` / `tagClass`) have
-  // no method-call bodies; one that did falls back to the generic path
-  // (#2006). (`x()` with an identifier callee — `params()` — is fine.)
+  // (`.replace`, `.includes`, `.filter`, …) into specialised `array-method` /
+  // `higher-order` nodes — so lowering this tree directly would diverge.
+  // (`x()` with an identifier callee — `params()` — is fine.)
   if (bodyHasMethodCall(body)) return null
 
   const subs = new Map<string, ParsedExpr>()
@@ -84,16 +74,12 @@ export function inlineLocalHelperCall(
 }
 
 /**
- * Guard for `substituteHelperParams`: the substitution replaces value-position
- * identifiers by name, but an `object-literal` lowers opaquely from its `raw`
- * source string downstream — `substituteHelperParams` leaves it untouched — so a
- * param referenced ANYWHERE inside an object literal survives un-substituted:
- * not just a shorthand key (`{ p }`, which also isn't a value position) but a
- * value position too (`{ x: p }`, `{ x: f(p) }`). Either would emit the param's
- * original name instead of the call arg, producing a wrong template. So a body
- * is substitute-safe only when no object literal it contains references any
- * param. (Nested function scopes are already rejected upstream — their
- * `ParsedExpr2` `arrow` doesn't convert to `ParsedExpr`.)
+ * Guard for `substituteHelperParams`: an `object-literal` lowers opaquely from
+ * its `raw` source string, so a param referenced ANYWHERE inside it survives
+ * un-substituted — a shorthand key (`{ p }`) or a value position (`{ x: p }`,
+ * `{ x: f(p) }`) — and would emit the param's original name instead of the call
+ * arg. A body is substitute-safe only when no object literal it contains
+ * references any param.
  */
 function isSubstituteSafeBody(body: ParsedExpr, paramNames: ReadonlySet<string>): boolean {
   // True when `n`'s subtree references any param (handling object-literal
@@ -116,8 +102,8 @@ function isSubstituteSafeBody(body: ParsedExpr, paramNames: ReadonlySet<string>)
   const visit = (n: ParsedExpr): void => {
     if (!safe) return
     if (n.kind === 'object-literal') {
-      // The whole object literal lowers from `raw`; if it mentions a param
-      // anywhere, that reference can't be substituted — decline the body.
+      // The whole object literal lowers from `raw`; a param mentioned anywhere
+      // inside can't be substituted — decline the body.
       if (referencesParam(n)) safe = false
       return
     }
@@ -151,10 +137,8 @@ function bodyCallsLocalHelper(ctx: GoEmitContext, body: ParsedExpr): boolean {
 
 /**
  * True when `body` contains a method call (`x.foo(…)` — a `call` whose callee
- * is a `member`). Such calls are folded by `parseExpression` into specialised
- * `array-method` / `higher-order` nodes that the structural body tree models as
- * a generic `call` instead, so a method-call body must not be lowered from this
- * tree (see the guard in `inlineLocalHelperCall`).
+ * is a `member`); such a body must not be lowered from this tree. See the guard
+ * in `inlineLocalHelperCall` for why.
  */
 function bodyHasMethodCall(body: ParsedExpr): boolean {
   let found = false
@@ -172,15 +156,11 @@ function bodyHasMethodCall(body: ParsedExpr): boolean {
 
 /**
  * Re-build `body` with each identifier named in `subs` replaced by the
- * substitution's `ParsedExpr` subtree. A structural rewrite (#2006): the
- * substitution is the arg subtree itself, so operator precedence survives
- * without parenthesisation (the tree *is* the precedence). Non-value identifier
- * positions — the property NAME in `a.b`, a plain `{ k: … }` key — are not
- * visited, so a param sharing a name with a member or key is left untouched.
- * (`isSubstituteSafeBody` has already rejected `{ k }` shorthand keys; nested
- * functions were rejected at conversion, so `arrow-fn` / `higher-order` /
- * `array-method` callbacks never reach here in practice — they pass through
- * unchanged.)
+ * substitution's `ParsedExpr` subtree. The substitution is the arg subtree
+ * itself, so operator precedence survives without parenthesisation (the tree
+ * *is* the precedence). Non-value identifier positions — the property NAME in
+ * `a.b`, a plain `{ k: … }` key — are not visited, so a param sharing a name
+ * with a member or key is left untouched.
  */
 export function substituteHelperParams(
   body: ParsedExpr,
@@ -193,9 +173,8 @@ export function substituteHelperParams(
         return sub !== undefined ? sub : n
       }
       // `object-literal` / `unsupported` lower from their `raw` string, so
-      // re-lowering structured children would have no effect — leave as-is
-      // (a param inside such a node is rejected by the shorthand guard or
-      // simply never observed).
+      // re-lowering structured children has no effect — leave as-is (a param
+      // inside such a node is rejected by the shorthand guard upstream).
       case 'literal':
       case 'object-literal':
       case 'unsupported':

--- a/packages/adapter-go-template/src/adapter/expr/url-builder.ts
+++ b/packages/adapter-go-template/src/adapter/expr/url-builder.ts
@@ -1,11 +1,10 @@
 /**
- * Lowering of local `URLSearchParams` builder helpers to `bf_query` (#1897).
+ * Lowering of local `URLSearchParams` builder helpers to `bf_query`.
  *
- * Extracted from `go-template-adapter.ts` (Phase 4 decomposition). Recognises
- * the `(…) => { const u = new URLSearchParams(); if (G) u.set(K, V); …; return
- * <s> ? \`${base}?${u}\` : base }` idiom (and a pass-through delegate to another
- * such helper) and emits a `bf_query` template expression. Anything else
- * returns null so the caller falls back to the generic lowering.
+ * Recognises the `(…) => { const u = new URLSearchParams(); if (G) u.set(K, V);
+ * …; return <s> ? \`${base}?${u}\` : base }` idiom (and a pass-through delegate
+ * to another such helper) and emits a `bf_query` template expression. Anything
+ * else returns null so the caller falls back to the generic lowering.
  */
 
 import ts from 'typescript'
@@ -25,7 +24,9 @@ type UrlBuilderShape = {
  *     `bf_query <base> (<guard>) "key" <value> …`;
  *   - a pass-through delegate (`(k) => hrefFor(k, params().tag)`) — substitute
  *     and recurse on the delegated call.
- * Returns null for anything else (→ existing lowering / method-call fallback).
+ *
+ * @returns the `bf_query` expression, or null for anything else (→ generic
+ *   lowering / method-call fallback)
  */
 export function lowerUrlBuilderHelperCall(ctx: GoEmitContext, jsExpr: string): string | null {
   if (ctx.state.localHelperNames.size === 0) return null
@@ -114,8 +115,8 @@ function extractUrlBuilder(arrow: ts.ArrowFunction): UrlBuilderShape | null {
     }
     // `return <s> ? `${base}?…` : <base>` — the builder's return must be the
     // conditional that picks between the with-query and bare-base URL; its
-    // `whenFalse` (no-query) branch is the base. Any other return shape isn't
-    // this idiom (#1945 review) — bail to the method-call fallback.
+    // `whenFalse` (no-query) branch is the base. Any other return shape bails
+    // to the method-call fallback.
     if (ts.isReturnStatement(s) && s.expression) {
       let e: ts.Expression = s.expression
       while (ts.isParenthesizedExpression(e)) e = e.expression
@@ -195,7 +196,7 @@ function lowerUrlGuard(
   // lowering. `&&` / `||` do NOT qualify: Go's `and`/`or` return one of their
   // operands (a string for a truthiness guard like `tag && other`), not a
   // bool — so they take the truthiness-wrap path below, yielding
-  // `ne (and …) ""`, an actual bool (#1945 review).
+  // `ne (and …) ""`, an actual bool.
   const isBoolShape =
     (ts.isBinaryExpression(g) &&
       [
@@ -227,13 +228,7 @@ function lowerUrlGuard(
  * corrupt a printer keyed to `body`'s source). The walk skips non-value
  * identifier positions — the property NAME in `a.b` and a plain object-literal
  * key in `{ k: … }` — so a param sharing a name with a member or key is left
- * untouched.
- *
- * The URL-builder lowering keeps this text path (#2006): its block-bodied
- * `URLSearchParams` helpers aren't representable as a `ParsedExpr2` (only
- * expression-bodied arrows are), so there is no structured body tree to
- * substitute in — the spliced string is re-parsed by `convertExpressionToGo` /
- * `convertConditionToGo` / the delegate recursion.
+ * untouched. The spliced string is re-parsed by the caller.
  */
 function substituteHelperParams(
   body: ts.Expression,

--- a/packages/adapter-go-template/src/adapter/lib/compile-state.ts
+++ b/packages/adapter-go-template/src/adapter/lib/compile-state.ts
@@ -1,20 +1,13 @@
 /**
- * Per-compile mutable state for the Go html/template adapter.
+ * Per-compile mutable state for the Go html/template adapter. The adapter is a
+ * reused singleton; everything established (and reset) per `generate()` /
+ * `generateTypes()` run lives here. The adapter holds a single `CompileState`
+ * and resets its members at the start of each compile.
  *
- * Extracted from `go-template-adapter.ts` (Phase 3 refactor). The adapter is a
- * reused singleton; everything that is established (and reset) per `generate()`
- * / `generateTypes()` run lives here in one place rather than scattered across
- * ~two dozen instance fields. The adapter holds a single `CompileState` and
- * resets its members at the start of each compile, exactly as before — this
- * relocation preserves field lifetimes 1:1. It also creates the seam a future
- * phase can use to make each compile fully isolated (`new CompileState()` per
- * `generate()`), or to thread the state into extracted, stateless emit modules.
- *
- * NOT included (deliberately): the adapter's cross-compile child-shape
- * registries (`childComponentShapes`, `childContextConsumers`, populated
- * out-of-band before a parent compiles), the render-recursion cursor stacks
- * (`loopParamStack`, `filterExprDepth`, …), and constant config (`options`,
- * `templatePrimitives`).
+ * NOT included (deliberately): cross-compile child-shape registries
+ * (`childComponentShapes`, `childContextConsumers`, populated before a parent
+ * compiles), the render-recursion cursor stacks (`loopParamStack`,
+ * `filterExprDepth`, …), and constant config (`options`, `templatePrimitives`).
  */
 
 import type {
@@ -35,15 +28,14 @@ export class CompileState {
 
   /** Component-scope derived consts referenced by the template during rendering
    *  (e.g. `root` → `.Root`). `generateTypes` emits a computed field for each
-   *  that's resolvable and non-colliding (#1897). */
+   *  that's resolvable and non-colliding. */
   referencedDerivedConsts: Set<string> = new Set()
 
   templateVarCounter: number = 0
 
   /**
-   * Companion `{{define "<Component>__children_<slot>"}}` blocks queued
-   * while rendering the template body (#1896). Flushed after the main
-   * define in `generate()`.
+   * Companion `{{define "<Component>__children_<slot>"}}` blocks queued while
+   * rendering the template body. Flushed after the main define in `generate()`.
    */
   pendingChildrenDefines: Array<{ name: string; content: string }> = []
 
@@ -52,7 +44,7 @@ export class CompileState {
   /**
    * Component-scoped rest binding identifier (`function({ a, ...rest }: P)`
    * → `'rest'`). Stashed at `generate()` entry so per-attribute emitter
-   * callbacks can classify a spread expression against it (#1407 follow-up).
+   * callbacks can classify a spread expression against it.
    */
   restPropsName: string | null = null
 
@@ -73,7 +65,7 @@ export class CompileState {
 
   /**
    * Names of component-scope arrow-const helpers (`const sortClass = …`),
-   * eligible for call-site inlining (#1897).
+   * eligible for call-site inlining.
    */
   localHelperNames: Set<string> = new Set()
 
@@ -82,36 +74,35 @@ export class CompileState {
    *  Full `MemoInfo` so consumers can read the analyzer-attached `parsed` tree. */
   currentMemos: MemoInfo[] = []
 
-  /** Full type definitions from the current IR, stashed for loop-datum field resolution (#1897). */
+  /** Full type definitions from the current IR, stashed for loop-datum field resolution. */
   currentTypeDefinitions: TypeDefinition[] = []
 
   /**
    * `useContext(...)` consumers in the component being generated. Each becomes
-   * a struct field defaulted to the `createContext` default. (#1297)
+   * a struct field defaulted to the `createContext` default.
    */
   contextConsumers: ContextConsumer[] = []
 
   /**
-   * (#1922) Local binding names the request-scoped `searchParams()` env signal
-   * is imported under (handles `import { searchParams as sp }`).
+   * Local binding names the request-scoped `searchParams()` env signal is
+   * imported under (handles `import { searchParams as sp }`).
    */
   searchParamsLocals: Set<string> = new Set()
 
   /**
-   * Set of prop NAMES whose resolved Go struct-field type is exactly
-   * `interface{}` — i.e. nillable. Populated at `generate()` entry. Used by
-   * the attribute emitter to omit a dynamic attribute whose value is a bare
-   * reference to a nillable prop when that prop is nil.
+   * Prop NAMES whose resolved Go struct-field type is exactly `interface{}`
+   * — i.e. nillable. Used by the attribute emitter to omit a dynamic attribute
+   * whose value is a bare reference to such a prop when it's nil.
    */
   nillablePropNames: Set<string> = new Set()
 
   /** Component root scope element(s) — each carries `data-key` for a keyed loop
-   *  item. (#1297) */
+   *  item. */
   rootScopeNodes: Set<IRNode> = new Set()
 
   /** Array-memo name → the handler-filled loop slice field its `.map()` feeds
    *  (e.g. `visible` → `PostListItems`). Lets `<memo>().length` lower to the
-   *  slice's length instead of a nil/unset memo field (#1897). */
+   *  slice's length instead of a nil/unset memo field. */
   memoBackedLoopSlice: Map<string, string> = new Map()
 
   // --- Reset at the start of `generateTypes()` ------------------------------
@@ -139,11 +130,11 @@ export class CompileState {
 
   /**
    * Synthesised array types for untyped object-array signals (signal getter →
-   * `[]SynthStruct` TypeInfo), populated during generateTypes (#1680).
+   * `[]SynthStruct` TypeInfo), populated during generateTypes.
    */
   synthStructTypes: Map<string, TypeInfo> = new Map()
 
-  /** Set when a constructor-context lowering emits a `strings.` call (#1897), so
+  /** Set when a constructor-context lowering emits a `strings.` call, so
    *  `strings` is added to the generated types file's import block. */
   needsStringsImport = false
 }

--- a/packages/adapter-go-template/src/adapter/lib/constants.ts
+++ b/packages/adapter-go-template/src/adapter/lib/constants.ts
@@ -1,18 +1,14 @@
 /**
  * Compile-time constant tables for the Go html/template adapter.
- *
- * Extracted from `go-template-adapter.ts` (Phase 2 refactor).
  */
 
 import type { PrimitiveSpec } from "./types.ts"
 import { wrapGoArg } from "./go-emit.ts"
 
 /**
- * Single source of truth for the Go adapter's template-primitive
- * surface (#1188). Each entry pairs the expected arity with the
- * emit function so adding / removing a primitive is a one-line
- * change and the two derived maps (`templatePrimitives` and
- * `templatePrimitiveArities`) can't drift out of sync.
+ * Single source of truth for the Go adapter's template-primitive surface. Each
+ * entry pairs the expected arity with the emit function so the two derived maps
+ * (`templatePrimitives` and `templatePrimitiveArities`) can't drift out of sync.
  */
 export const GO_TEMPLATE_PRIMITIVES: Record<string, PrimitiveSpec> = {
   'JSON.stringify': { arity: 1, emit: (args) => `bf_json ${wrapGoArg(args[0])}` },

--- a/packages/adapter-go-template/src/adapter/lib/go-emit.ts
+++ b/packages/adapter-go-template/src/adapter/lib/go-emit.ts
@@ -1,10 +1,7 @@
 /**
- * Go html/template emit helpers for the Go adapter.
- *
- * Pure helpers extracted from `go-template-adapter.ts` (Phase 1 refactor):
- * Go-template string escaping, argument wrapping, `bf_*` runtime-helper
- * call construction, and JSX-literal → Go-literal lowering. None read
- * adapter instance state.
+ * Go html/template emit helpers: string escaping, argument wrapping, `bf_*`
+ * runtime-helper call construction, and JSX-literal → Go-literal lowering.
+ * Pure free functions — none read adapter instance state.
  */
 
 import type { SortComparator, ReduceOp, SupportResult } from '@barefootjs/jsx'
@@ -17,19 +14,15 @@ export function escapeGoString(s: string): string {
 }
 
 /**
- * Wrap a rendered Go template fragment in parens when it would
- * otherwise parse as multiple sibling args of an enclosing prefix
- * call. A bare identifier / dotted path / quoted literal stays
- * uncluttered; anything containing whitespace (a function call,
- * `len ...`, etc.) gets `(...)` so `bf_join (...) bf_trim .Raw`
- * doesn't degrade to four args of `bf_join`. Used by emitters that
- * compose runtime helpers (#1443 / #1445 Copilot review).
+ * Wrap a rendered Go template fragment in parens when it would otherwise parse
+ * as multiple sibling args of an enclosing prefix call. A bare identifier /
+ * dotted path / quoted literal stays uncluttered; anything containing
+ * whitespace (a call, `len ...`) gets `(...)` so `bf_join (...) bf_trim .Raw`
+ * doesn't degrade to four args of `bf_join`.
  */
 export function wrapIfMultiToken(rendered: string): string {
-  // Already wrapped — don't double-wrap.
   if (rendered.startsWith('(') && rendered.endsWith(')')) return rendered
-  // Quoted literals can contain spaces inside the string but parse
-  // as a single token; leave them alone.
+  // Quoted literals may contain spaces but parse as one token — leave alone.
   if (rendered.startsWith('"') && rendered.endsWith('"')) return rendered
   if (/\s/.test(rendered)) return `(${rendered})`
   return rendered
@@ -37,9 +30,8 @@ export function wrapIfMultiToken(rendered: string): string {
 
 /**
  * Parenthesize a compound Go template argument (`or .Checked false`) so a
- * primitive call reads it as ONE argument — unwrapped, the parser splits
- * it into three and `bf_string` fails with "want 1 got 3" (#1896,
- * DropdownMenuCheckboxItem's `String(props.checked ?? false)`).
+ * primitive call reads it as ONE argument — unwrapped, the parser splits it
+ * into three and `bf_string` fails with "want 1 got 3".
  */
 export function wrapGoArg(arg: string): string {
   if (!/\s/.test(arg)) return arg
@@ -48,10 +40,7 @@ export function wrapGoArg(arg: string): string {
 }
 
 /**
- * Emit the `bf_sort` call shared by the standalone `sortMethod()`
- * arm and the chained `.sort().map()` loop hoist. The runtime helper
- * takes 4 string operands so a future `nulls` knob can grow on the
- * end without rewriting either call site (#1448 Tier B):
+ * Emit the `bf_sort` call:
  *
  *   bf_sort <recv> (<keyKind> <keyName> <compareType> <direction>)+
  *
@@ -60,20 +49,13 @@ export function wrapGoArg(arg: string): string {
  *   compareType:  "numeric" | "string" | "auto"
  *   direction:    "asc" | "desc"
  *
- * The 4-string group repeats once per comparison key: a simple
- * comparator emits one group; a `||`-chained multi-key comparator
- * emits one per operand, applied in order as tie-breakers by the
- * variadic `bf_sort` runtime.
- *
- * The capitalisation mirrors the Go-side struct-field convention
- * (`bf_sort .Items "field" "Price" "numeric" "asc"`) so the runtime
- * helper's reflect lookup matches without a recapitalise step.
+ * The 4-string group repeats once per comparison key: a simple comparator emits
+ * one group; a `||`-chained multi-key comparator emits one per operand, applied
+ * in order as tie-breakers by the variadic `bf_sort` runtime. Capitalisation
+ * mirrors the Go struct-field convention so the runtime's reflect lookup
+ * matches without a recapitalise step.
  */
 export function emitBfSort(recv: string, c: SortComparator): string {
-  // One 4-string group per comparison key (keyKind, keyName,
-  // compareType, direction). A single-key comparator emits exactly the
-  // pre-multi-key shape; `||`-chained keys append further groups, which
-  // `bf_sort`'s variadic runtime applies in order as tie-breakers.
   const groups = c.keys.map((k) => {
     const keyName = k.key.kind === 'field' ? capitalize(k.key.field) : ''
     return `"${k.key.kind}" "${keyName}" "${k.type}" "${k.direction}"`
@@ -82,54 +64,41 @@ export function emitBfSort(recv: string, c: SortComparator): string {
 }
 
 /**
- * Emit the `bf_reduce` call for a `.reduce(fn, init)` arithmetic fold
- * (#1448 Tier C):
+ * Emit the `bf_reduce` call for a `.reduce(fn, init)` arithmetic fold:
  *
  *   bf_reduce <recv> "<op>" "<keyKind>" "<keyName>" "<type>" "<init>" "<direction>"
  *
  *   op:        "+" | "*"
  *   keyKind:   "self" | "field"
  *   keyName:   "" when keyKind=self; capitalised field name otherwise
- *              (matches the Go struct-field convention, mirroring
- *              `emitBfSort`)
  *   type:      "numeric" | "string"
- *   init:      the fold's start value — the numeric literal's text for a
- *              numeric fold, or the string literal's contents for a
- *              concat fold
+ *   init:      the fold's start value (numeric literal text, or concat string)
  *   direction: "left" (reduce) | "right" (reduceRight)
  *
- * The runtime folds `init <op> key(item)` in `direction` order and
- * returns the accumulated value (float64 for numeric, string for
- * concat). The order is only observable for string concat — numeric
- * sum / product commute.
+ * The runtime folds `init <op> key(item)` in `direction` order, returning the
+ * accumulated value (float64 for numeric, string for concat). Order is only
+ * observable for string concat — numeric sum / product commute.
  */
 export function emitBfReduce(recv: string, op: ReduceOp, direction: 'left' | 'right'): string {
   const keyName = op.key.kind === 'field' ? capitalize(op.key.field) : ''
-  // `op.init` is already the decoded seed value (canonical decimal for
-  // numeric folds — `strconv.ParseFloat`-safe; escape-free contents for
-  // concat folds). Pass it as a quoted operand the runtime interprets
-  // by `type`. `direction` is "left" (reduce) or "right" (reduceRight)
-  // — only observable for string concatenation; numeric folds are
-  // commutative.
+  // `op.init` is the decoded seed value (canonical decimal / escape-free
+  // contents); passed as a quoted operand the runtime interprets by `type`.
   return `bf_reduce ${wrapIfMultiToken(recv)} "${op.op}" "${op.key.kind}" "${keyName}" "${op.type}" "${escapeGoString(op.init)}" "${direction}"`
 }
 
 /**
- * Make an equality comparison string-tolerant when exactly one side is a
- * Go string literal (#1896): JS `sorted === 'asc'` is loosely false for
- * `sorted = false`, but Go's template `eq` ERRORS on bool-vs-string
- * (`incompatible types for comparison` — DataTableColumnHeader's
- * `'asc' | 'desc' | false` union prop). Routing the non-literal side
- * through `bf_string` preserves JS comparison semantics for every
- * concrete type while keeping same-kind comparisons untouched.
+ * Make an equality comparison string-tolerant when exactly one side is a Go
+ * string literal: JS `sorted === 'asc'` is loosely false for `sorted = false`,
+ * but Go's template `eq` ERRORS on bool-vs-string (`incompatible types for
+ * comparison`). Routing the non-literal side through `bf_string` preserves JS
+ * comparison semantics for every concrete type while leaving same-kind
+ * comparisons untouched.
  */
 export function stringTolerantEqOperands(l: string, r: string): [string, string] {
   const isStrLit = (x: string) => /^"(?:[^"\\]|\\.)*"$/.test(x)
   if (isStrLit(l) === isStrLit(r)) return [l, r]
-  // Keep `wrapGoArg`'s parentheses: a compound operand must reach
-  // `bf_string` as ONE argument — `(bf_string (or .Placement "top"))`,
-  // not `(bf_string or .Placement "top")` (which the template parser
-  // reads as three arguments and fails at runtime).
+  // Keep `wrapGoArg`'s parens: a compound operand must reach `bf_string` as ONE
+  // argument — `(bf_string (or .Placement "top"))`, not `(bf_string or …)`.
   const wrap = (x: string) => (isStrLit(x) ? x : `(bf_string ${wrapGoArg(x)})`)
   return [wrap(l), wrap(r)]
 }
@@ -151,10 +120,11 @@ export function buildUnsupportedSuggestion(support: SupportResult): string {
 }
 
 /**
- * Translate a JSX param default (e.g. `'default'`, `0`, `false`) into
- * the corresponding Go literal. Returns null when the default is
- * absent or non-trivial (objects, arrow functions, etc.) — those
- * fall back to letting Go's zero value win.
+ * Translate a JSX param default (e.g. `'default'`, `0`, `false`) into the
+ * corresponding Go literal.
+ *
+ * @returns the Go literal, or `null` when the default is absent or non-trivial
+ *   (objects, arrow functions, …) — caller then lets Go's zero value win.
  */
 export function goPropDefault(defaultValue: string | undefined): string | null {
   if (!defaultValue) return null
@@ -162,7 +132,6 @@ export function goPropDefault(defaultValue: string | undefined): string | null {
   if (trimmed === '') return null
   if (trimmed === 'true' || trimmed === 'false') return trimmed
   if (/^-?\d+(\.\d+)?$/.test(trimmed)) return trimmed
-  // Single- and double-quoted strings.
   if (
     (trimmed.startsWith("'") && trimmed.endsWith("'")) ||
     (trimmed.startsWith('"') && trimmed.endsWith('"'))
@@ -170,27 +139,22 @@ export function goPropDefault(defaultValue: string | undefined): string | null {
     const body = trimmed.slice(1, -1)
     return JSON.stringify(body)
   }
-  // Bail on anything richer (objects, arrays, expressions). The
-  // generated Go would mis-execute a JS expression.
+  // Anything richer (objects, arrays, expressions) would mis-execute as Go.
   return null
 }
 
 /**
- * Wrap an `in.X` reference in a Go expression that substitutes
- * `fallback` when the input is the zero value for its type. We pick
- * the comparison based on the fallback literal's shape.
+ * Wrap an `in.X` reference in a Go expression that substitutes `fallback` when
+ * the input is the zero value for its type; the comparison is picked from the
+ * fallback literal's shape.
  *
- * Asymmetry on bool defaults is intentional and worth flagging:
- *   - For a `true` default, the generated expression is
- *     `(in.X || true)` — which is **always `true`**. Go has no
- *     unset-vs-explicit-false distinction at the struct-field level,
- *     so any caller wanting to thread `false` through has to set it
- *     after `NewXxxProps` rather than via the input struct.
- *   - For a `false` default, the Go zero value already matches, so
- *     the helper is a no-op (returns `ref` unchanged).
- * Numeric `0` defaults are similarly indistinguishable from "unset"
- * and pass through as the zero value; non-zero numeric defaults
- * substitute, matching the JSX behavior of `(initial = 5) => ...`.
+ * Asymmetry on bool/zero defaults is intentional (Go has no
+ * unset-vs-explicit-false distinction at the struct-field level):
+ *   - `true` default → `(in.X || true)`, which is ALWAYS `true`; a caller
+ *     wanting `false` must set it after `NewXxxProps`, not via the input struct.
+ *   - `false` / `0` default → matches the Go zero value, so this is a no-op
+ *     (returns `ref` unchanged).
+ * Non-zero numeric defaults substitute, matching JSX `(initial = 5) => …`.
  */
 export function applyGoFallback(ref: string, fallback: string): string {
   if (fallback === 'true' || fallback === 'false') {
@@ -200,24 +164,20 @@ export function applyGoFallback(ref: string, fallback: string): string {
     if (fallback === '0') return ref
     return `func() int { if ${ref} == 0 { return ${fallback} }; return ${ref} }()`
   }
-  // String fallback (quoted)
+  // String fallback (quoted).
   return `func() string { if ${ref} == "" { return ${fallback} }; return ${ref} }()`
 }
 
 /** Convert a JavaScript literal value to Go literal syntax. */
 export function goLiteral(value: string): string {
-  // Boolean
   if (value === 'true' || value === 'false') return value
-  // Number
   if (/^-?\d+(\.\d+)?$/.test(value)) return value
-  // String with single quotes -> Go double quotes
+  // Single-quoted → Go double quotes; double-quoted kept as-is.
   if (value.startsWith("'") && value.endsWith("'")) {
     return `"${value.slice(1, -1)}"`
   }
-  // String with double quotes -> keep as is
   if (value.startsWith('"') && value.endsWith('"')) {
     return value
   }
-  // Default: wrap in quotes
   return `"${value}"`
 }

--- a/packages/adapter-go-template/src/adapter/lib/go-naming.ts
+++ b/packages/adapter-go-template/src/adapter/lib/go-naming.ts
@@ -1,10 +1,7 @@
 /**
- * Go identifier / field-name conventions for the Go html/template adapter.
- *
- * Pure helpers extracted from `go-template-adapter.ts` (Phase 1 refactor):
- * none of these read adapter instance state, so they live at module scope
- * as the single source of truth for capitalisation, initialism handling,
- * and slot/loop-key → Go field-path lowering.
+ * Go identifier / field-name conventions: the single source of truth for
+ * capitalisation, initialism handling, and slot/loop-key → Go field-path
+ * lowering. Pure helpers — none read adapter instance state.
  */
 
 /** Matches a bare Go identifier (no dots, no brackets). */
@@ -18,9 +15,8 @@ export const GO_INITIALISMS = new Set([
 ])
 
 /**
- * (#1423) Go reserved keywords. When we hoist a local var named after
- * a JSX prop, the prop name could collide with one of these — append
- * `_` until the name is free.
+ * Go reserved keywords. When hoisting a local var named after a JSX prop, a
+ * collision with one of these is resolved by appending `_` until free.
  */
 export const GO_KEYWORDS = new Set([
   'break', 'case', 'chan', 'const', 'continue', 'default', 'defer',
@@ -46,7 +42,7 @@ export function capitalize(s: string): string {
 /** Capitalise a JSX prop / field name to its exported Go struct field name. */
 export function capitalizeFieldName(name: string): string {
   if (!name) return name
-  // Check if the entire name is a Go initialism (e.g., 'id' → 'ID')
+  // Whole-name initialism (e.g. 'id' → 'ID').
   if (GO_INITIALISMS.has(name.toLowerCase())) {
     return name.toUpperCase()
   }
@@ -58,22 +54,24 @@ export function capitalizeFieldName(name: string): string {
  * Keeps field names human-readable regardless of the internal slot ID format.
  */
 export function slotIdToFieldSuffix(slotId: string): string {
-  // Strip parent-owned prefix (^) for Go struct field names
+  // Strip the parent-owned prefix (^).
   const cleanId = slotId.startsWith('^') ? slotId.slice(1) : slotId
   const match = cleanId.match(/^s(\d+)$/)
   if (match) {
     return `Slot${match[1]}`
   }
-  // Fallback for legacy format or non-standard IDs
+  // Fallback for non-standard IDs.
   return cleanId.replace('slot_', 'Slot')
 }
 
 /**
  * Lower a keyed-loop `key` expression to the Go field path on the loop's range
  * variable (always `item` in the generated `for i, item := range …`), e.g.
- * `item.label` → `item.Label`. Returns null for a non-simple key (computed
- * expression, whole-element key, mismatched param) so the loop-child init just
- * skips `data-key` rather than emitting something that won't compile. (#1297)
+ * `item.label` → `item.Label`.
+ *
+ * @returns `null` for a non-simple key (computed expression, whole-element key,
+ *   mismatched param) — caller then skips `data-key` rather than emit
+ *   something that won't compile.
  */
 export function loopKeyToGoFieldPath(key: string | undefined, param: string | undefined): string | null {
   if (!key || !param) return null

--- a/packages/adapter-go-template/src/adapter/lib/ir-scope.ts
+++ b/packages/adapter-go-template/src/adapter/lib/ir-scope.ts
@@ -1,8 +1,6 @@
 /**
- * IR traversal helpers for the Go html/template adapter.
- *
- * Extracted from `go-template-adapter.ts` (Phase 2 refactor). Pure functions
- * over the IR tree — no adapter instance state.
+ * IR traversal helpers for the Go html/template adapter. Pure functions over
+ * the IR tree — no adapter instance state.
  */
 
 import type { IRNode, IRIfStatement, IRFragment } from '@barefootjs/jsx'
@@ -11,7 +9,7 @@ import type { IRNode, IRIfStatement, IRFragment } from '@barefootjs/jsx'
  * Collect the component's root scope element node(s) — the elements that become
  * the rendered root and so carry `data-key` for a keyed loop item. A plain
  * element root is itself; an `if-statement` (early-return) root contributes the
- * top element of each branch, since exactly one renders at runtime. (#1297)
+ * top element of each branch, since exactly one renders at runtime.
  */
 export function collectRootScopeNodes(node: IRNode): Set<IRNode> {
   const out = new Set<IRNode>()

--- a/packages/adapter-go-template/src/adapter/lib/types.ts
+++ b/packages/adapter-go-template/src/adapter/lib/types.ts
@@ -1,10 +1,8 @@
 /**
- * Internal type definitions for the Go html/template adapter.
- *
- * Extracted from `go-template-adapter.ts` (Phase 2 refactor). These describe
- * the adapter's intermediate bookkeeping shapes (nested-component info, static
- * child instances, spread slots, ctor-lowering scope, etc.) plus the public
- * `GoTemplateAdapterOptions`. They carry no behaviour — pure type surface.
+ * Internal type definitions for the Go html/template adapter: the adapter's
+ * intermediate bookkeeping shapes (nested-component info, static child
+ * instances, spread slots, ctor-lowering scope, …) plus the public
+ * `GoTemplateAdapterOptions`. Pure type surface — no behaviour.
  */
 
 import type {
@@ -36,10 +34,8 @@ export interface NestedComponentInfo extends IRLoopChildComponent {
    *  name (`item`), so the loop-child init can stamp `data-key` per item. */
   loopKey?: string
   loopParam?: string
-  /** The loop body component's JSX children (e.g. the 4 `<TableCell>` nodes
-   *  inside `<TableRow>` in data-table's `.map(payment => <TableRow>…</TableRow>)`).
-   *  Non-empty when the loop body component has children that need a companion
-   *  define rendered via `bf_with_children` + `bf_tmpl`. (#1897) */
+  /** The loop body component's JSX children. Non-empty when those children need
+   *  a companion define rendered via `bf_with_children` + `bf_tmpl`. */
   bodyChildren?: IRNode[]
   /** The loop's array expression for baking (e.g. `sortedData()`) */
   loopArray?: string
@@ -59,86 +55,72 @@ export interface StaticChildInstance {
   props: IRProp[]
   fieldName: string
   /** Concatenated text content from JSX children (e.g. `+1` for
-   *  `<Button>+1</Button>`). Null when children include any non-text
-   *  node; those go through the `childrenHtml` path when they're
-   *  purely static HTML, otherwise they're dropped. */
+   *  `<Button>+1</Button>`). Null when children include any non-text node;
+   *  those take the `childrenHtml` path if purely static HTML, else dropped. */
   childrenText: string | null
-  /** Rendered Go-template fragment for purely-static, non-text JSX
-   *  children (e.g. `<Card><span>x</span></Card>`). Forwarded to the
-   *  child via `Children: template.HTML(...)` so the child's
-   *  `{{or .Children ""}}` skips re-escaping. Null when children are
-   *  text-only or absent — and also null when the rendered fragment
-   *  contains any `{{...}}` action (signal expressions, nested
-   *  components, conditionals, etc.) since those wouldn't re-evaluate
-   *  through the parent's `{{.Children}}` read; those cases stay on
-   *  the existing drop path. */
+  /** Rendered Go-template fragment for purely-static, non-text JSX children,
+   *  forwarded via `Children: template.HTML(...)` so the child's
+   *  `{{or .Children ""}}` skips re-escaping. Null when children are text-only
+   *  or absent, OR when the fragment contains any `{{...}}` action (those
+   *  wouldn't re-evaluate through the parent's `{{.Children}}` read — kept on
+   *  the drop path). */
   childrenHtml: string | null
   /** Go string-concat expression for hoisted-JSX children that carry a
-   *  `needsScope` root (`children={<span/>}` — #1326 / #1335). The root's
-   *  `bf-s` resolves to the PARENT scope (mirroring the client
-   *  `__BF_PARENT_SCOPE__` placeholder + Mojo's begin/end capture), so the
-   *  fragment can't bake to a static string — the runtime `scopeID` is
-   *  spliced in (`"<span bf-s=\"" + scopeID + "\">x</span>"`). Null when the
-   *  static `childrenHtml` path already covers the children, or when any
-   *  other template action survives (genuinely dynamic — kept on the drop
-   *  path). */
+   *  `needsScope` root (`children={<span/>}`). The root's `bf-s` resolves to
+   *  the PARENT scope, so the fragment can't bake to a static string — the
+   *  runtime `scopeID` is spliced in (`"<span bf-s=\"" + scopeID + "\">x</span>"`).
+   *  Null when static `childrenHtml` already covers the children, or when any
+   *  other template action survives (genuinely dynamic — drop path). */
   childrenScopedHtmlExpr: string | null
   /**
    * Context values from enclosing `<Ctx.Provider value>` ancestors
    * (`createContext` identifier → Go value literal), wired into this child
    * slot's input against its own context-consumer fields. Empty/undefined when
-   * the child isn't under any provider. (#1297)
+   * the child isn't under any provider.
    */
   contextBindings?: ReadonlyMap<string, string>
 }
 
 /**
- * Cross-component shape of a child component the parent renders (#checkbox).
+ * Cross-component shape of a child component the parent renders.
  * `paramNames` are the child's declared `propsParams`; `restBagField` is the
- * Go field name of the child's open-ended rest bag (`Capitalize(restPropsName)`),
- * or null when the child has no `...props` rest spread.
+ * Go field name of the child's open-ended rest bag
+ * (`Capitalize(restPropsName)`), or null when the child has no `...props` rest.
  */
 export interface ChildComponentShape {
   paramNames: Set<string>
   restBagField: string | null
   /**
-   * (#1971) Child param names whose Go field is `map[string]interface{}` —
-   * an optional object/named-interface prop (carousel's `opts?:
-   * EmblaOptionsType`). A parent passing an inline object literal to such a
-   * param bakes it to a Go map literal so the keys round-trip faithfully.
+   * Child param names whose Go field is `map[string]interface{}` — an optional
+   * object/named-interface prop (`opts?: EmblaOptionsType`). A parent passing
+   * an inline object literal to such a param bakes it to a Go map literal so
+   * the keys round-trip faithfully.
    */
   mapTypedParamNames: Set<string>
 }
 
 /**
- * Top-level (non-loop) JSX intrinsic-element spread slot (#1407).
- * Collected by `collectSpreadSlots` so the adapter can emit one
- * `Spread_<slotId> map[string]any` field on the component's Props
- * struct and initialise it in `NewXxxProps` from the source JS
- * expression. Loop-internal spreads don't appear here — they emit
- * the bag inline via the loop's iteration variable instead.
+ * Top-level (non-loop) JSX intrinsic-element spread slot. The adapter emits one
+ * `Spread_<slotId> map[string]any` field on the component's Props struct and
+ * initialises it in `NewXxxProps` from the source JS expression. Loop-internal
+ * spreads don't appear here — they emit the bag inline via the loop's iteration
+ * variable instead.
  *
- * `bagSource` records how the bag is supplied so the Input struct
- * and `NewXxxProps` can be wired correctly (#1407 follow-up):
- *
- * - `'inline'`: bag is constructed inside `NewXxxProps` from
- *   compile-time-known data (signal initial values, prop refs,
- *   propsObject enumeration). No Input field needed.
- * - `'input-bag'`: bag is provided by the caller as a
- *   `Spread_<slotId> map[string]any` field on the Input struct
- *   (used for `restPropsName` spreads where the rest's keys are
- *   open-ended and Go's static typing can't enumerate them).
+ * `bagSource` records how the bag is supplied:
+ * - `'inline'`: constructed inside `NewXxxProps` from compile-time-known data
+ *   (signal initial values, prop refs, propsObject enumeration). No Input field.
+ * - `'input-bag'`: provided by the caller as a `Spread_<slotId> map[string]any`
+ *   field on the Input struct (for `restPropsName` spreads whose keys are
+ *   open-ended and can't be enumerated under Go's static typing).
  */
 export interface SpreadSlotInfo {
   slotId: string
   expr: string
   /**
-   * Best-effort structured parse of `expr` carried from `SpreadAttr.parsed`
-   * (#2006). Lets `buildConditionalSpreadInitializer` lower the conditional
-   * inline-object spread from the tree instead of re-parsing `expr` with
-   * `ts.createSourceFile`. When absent, `buildSpreadInitializer` parses `expr`
-   * once with `parseExpression`; a non-conditional or `unsupported` tree just
-   * falls through to the other spread shapes (there is no separate legacy path).
+   * Best-effort structured parse of `expr`. Lets the conditional inline-object
+   * spread lower from the tree instead of re-parsing `expr`. When absent, a
+   * non-conditional / `unsupported` tree falls through to the other spread
+   * shapes.
    */
   parsed: ParsedExpr | undefined
   templateExpr: string | undefined
@@ -146,9 +128,8 @@ export interface SpreadSlotInfo {
 }
 
 /**
- * (#1423) Hoisted local var representing a prop with a signal-time
- * `??` fallback. Used by `generateNewPropsFunction` to share the
- * fallback-applied value across the prop, signal, and memo fields.
+ * Hoisted local var representing a prop with a signal-time `??` fallback. Used
+ * to share the fallback-applied value across the prop, signal, and memo fields.
  */
 export interface PropFallbackVar {
   /** Local variable name (typically the lowercase prop identifier). */
@@ -163,7 +144,7 @@ export interface PropFallbackVar {
 
 /**
  * Scope for `lowerCtorExpr` — lowering a JS expression to Go in the
- * `NewXxxProps` constructor context (#1897 PostList derived state).
+ * `NewXxxProps` constructor context.
  */
 export interface CtorLowerEnv {
   /** Local names bound to `searchParams()` (`const sp = searchParams()`). */
@@ -191,11 +172,9 @@ export interface GoTemplateAdapterOptions {
 }
 
 /**
- * Single source of truth for the Go adapter's template-primitive
- * surface (#1188). Each entry pairs the expected arity with the
- * emit function so adding / removing a primitive is a one-line
- * change and the two derived maps (`templatePrimitives` and
- * `templatePrimitiveArities`) can't drift out of sync.
+ * Single source of truth for the Go adapter's template-primitive surface. Each
+ * entry pairs the expected arity with the emit function so the two derived maps
+ * (`templatePrimitives` and `templatePrimitiveArities`) can't drift out of sync.
  */
 export interface PrimitiveSpec {
   arity: number

--- a/packages/adapter-go-template/src/adapter/memo/ctor-lowering.ts
+++ b/packages/adapter-go-template/src/adapter/memo/ctor-lowering.ts
@@ -1,13 +1,11 @@
 /**
- * Constructor-context expression lowering (#1897 PostList derived state).
+ * Constructor-context expression lowering for derived-state memos.
  *
  * Free functions over a {@link GoEmitContext} that lower the narrow surface of
  * JS expressions a derived-state memo needs into Go *code* (not template
  * syntax) evaluated in the `NewXxxProps` constructor — e.g. a search-param read
- * becomes `in.SearchParams.Get("k")`. Mutually recursive (`lowerCtorExpr` ↔
- * `lowerCtorCond`), they read the context's `state.localConstants` /
- * `state.propsObjectName` and each const's carried {@link ParsedExpr2}
- * (`ConstantInfo.parsed2`), and set `state.needsStringsImport` when they emit a
+ * becomes `in.SearchParams.Get("k")`. `lowerCtorExpr` and `lowerCtorCond` are
+ * mutually recursive and set `state.needsStringsImport` when they emit a
  * `strings.*` call. Anything outside the supported surface returns null so the
  * caller can fall back to nil safely.
  */
@@ -166,8 +164,7 @@ export function lowerCtorExpr(
     // The condition must be lowered as a *boolean* (`lowerCtorCond`), not a
     // value: a string-valued JS condition like `sp.get('tag') ? a : b` is
     // truthy in JS, but `if "<string>"` does not compile in Go — such shapes
-    // return null so the memo falls back to nil rather than emitting invalid
-    // code (#1941 review).
+    // return null so the memo falls back to nil rather than emitting invalid Go.
     const cond = lowerCtorCond(ctx, node.test, env)
     const t = lowerCtorExpr(ctx, node.consequent, env)
     const f = lowerCtorExpr(ctx, node.alternate, env)
@@ -182,10 +179,10 @@ export function lowerCtorExpr(
 
 /**
  * Lower a JS expression used as a *boolean* condition to a Go bool expression,
- * or null when it is not provably boolean. Distinct from `lowerCtorExpr`,
- * which lowers value expressions: a string-valued condition (`sp.get('tag')`)
- * is truthy in JS but `if "<string>"` does not compile in Go, so anything not
- * known to yield a Go bool must fall back to null (#1941 review).
+ * or null when it is not provably boolean. Distinct from `lowerCtorExpr`, which
+ * lowers value expressions: a string-valued condition (`sp.get('tag')`) is
+ * truthy in JS but `if "<string>"` does not compile in Go, so anything not
+ * known to yield a Go bool must fall back to null.
  */
 export function lowerCtorCond(
   ctx: GoEmitContext,

--- a/packages/adapter-go-template/src/adapter/memo/memo-compute.ts
+++ b/packages/adapter-go-template/src/adapter/memo/memo-compute.ts
@@ -1,13 +1,11 @@
 /**
- * Memo initial-value computation — the core that lowers a memo's computation to
- * its SSR initial value as a Go expression.
+ * Memo initial-value computation — lower a memo's computation to its SSR initial
+ * value as a Go expression.
  *
  * Free functions over a {@link GoEmitContext}. `computeMemoInitialValue` is the
  * typed-field entry (zero-value defaulting); `computeMemoInitialValueOrNull` is
- * the pattern-matching core that dispatches over template-literal, parsed-body,
- * comparison-ternary, block-body and object memo shapes. They read
- * `state.currentMemos` / `state.moduleStringConsts`, `extractPropFallback`, and
- * delegate to the value / type / template / memo-value modules.
+ * the pattern-matching core dispatching over template-literal, parsed-body,
+ * comparison-ternary, block-body and object memo shapes.
  */
 
 import type { ParsedExpr, ParsedStatement, TypeInfo } from '@barefootjs/jsx'
@@ -24,13 +22,14 @@ import { resolveBlockBodyMemoModuleConst, computeObjectMemoInitialValue } from '
 const EMPTY_PROP_FALLBACK_VARS: ReadonlyMap<string, PropFallbackVar> = new Map()
 
 /**
- * Compute the initial value for a memo based on its computation and signal initial values.
- * Handles simple cases like `() => count() * 2` → `in.Initial * 2`
- * Also handles props.xxx patterns like `() => props.value * 10` → `in.Value * 10`
+ * Compute a memo's SSR initial value as a Go expression — e.g.
+ * `() => count() * 2` → `in.Initial * 2`, `() => props.value * 10` →
+ * `in.Value * 10`. Unresolved computations default to the memo's Go zero value.
  *
- * (#1423) When `propFallbackVars` carries a hoisted variable for the
- * referenced prop, substitute it for `in.FieldName` so the memo
- * inherits the signal-time `??` fallback.
+ * @param propFallbackVars when a hoisted fallback var exists for a referenced
+ *   prop, it is substituted for `in.FieldName` so the memo inherits the
+ *   signal-time `??` fallback
+ * @param goType Go type of the memo field, used to pick the zero-value fallback
  */
 export function computeMemoInitialValue(
   ctx: GoEmitContext,
@@ -38,22 +37,15 @@ export function computeMemoInitialValue(
   signals: { getter: string; initialValue: string }[],
   propsParams: { name: string; type?: TypeInfo; defaultValue?: string }[],
   propFallbackVars: ReadonlyMap<string, PropFallbackVar> = EMPTY_PROP_FALLBACK_VARS,
-  // (#checkbox) Go type of the memo field; used to pick the zero-value
-  // fallback for an unresolved computation (`false` for `bool`, `""` for
-  // `string`, else the historical `0`).
   goType?: string,
 ): string {
   const resolved = computeMemoInitialValueOrNull(
     ctx, memo, signals, propsParams, propFallbackVars,
   )
   if (resolved !== null) return resolved
-  // Default: zero value for the memo's Go type (#checkbox). A boolean memo
-  // (`isChecked`) renders `false`, a string memo `""`; reference types
-  // (map / slice / interface / pointer) take `nil` — `0` is not
-  // assignable to them and broke the struct literal for a
-  // block-bodied string-building memo whose type inferred to
-  // `map[string]any` (#1896, select-demo's `summary`). Other types
-  // keep the historical int `0`.
+  // Zero value for the memo's Go type: `false` for bool, `""` for string,
+  // `nil` for reference types (map / slice / interface / pointer — `0` is not
+  // assignable to them), else the int `0`.
   if (goType === 'bool') return 'false'
   if (goType === 'string') return '""'
   if (
@@ -71,14 +63,12 @@ export function computeMemoInitialValue(
 
 /**
  * Structural matcher for the common expression-bodied memo shapes, driven by
- * the analyzer-attached `MemoInfo.parsed` (the memo arrow's body `ParsedExpr`)
- * instead of regexes over `computation`. Mirrors the former `computation.match`
- * chain 1:1 — `getter() === 'lit'`, `props.X ?? false`, `cond() ? A : B`,
- * `<getter()|props.X|var> <*+-/> <int>`, and bare `getter()` / `props.X` /
- * `var` — returning the Go SSR value, or null when the body isn't one of these
- * (the caller then falls through to the comparison-ternary / block-body /
- * object-memo handling). Structural matching is tolerant of quote style,
- * parenthesisation, and whitespace that the regexes were sensitive to.
+ * the analyzer-attached `MemoInfo.parsed` (the memo arrow's body): `getter() ===
+ * 'lit'`, `props.X ?? false`, `cond() ? A : B`, `<getter()|props.X|var> <*+-/>
+ * <int>`, and bare `getter()` / `props.X` / `var`.
+ *
+ * @returns the Go SSR value, or null when the body is none of these (the caller
+ *   then falls through to comparison-ternary / block-body / object-memo handling)
  */
 export function memoInitialFromParsedBody(
   ctx: GoEmitContext,
@@ -173,9 +163,8 @@ export function memoInitialFromParsedBody(
     }
   }
 
-  // () => <ref> <*|+|-|/> <non-negative int>. The operand stays an integer
-  // literal (the regexes only matched `\d+`), so float/negative bodies fall
-  // through unchanged.
+  // () => <ref> <*|+|-|/> <non-negative int>. The operand must be a
+  // non-negative integer literal; float/negative bodies fall through unchanged.
   if (
     body.kind === 'binary' &&
     ['*', '+', '-', '/'].includes(body.op) &&
@@ -215,8 +204,7 @@ export function memoInitialFromParsedBody(
       }
     }
 
-    // var * N — destructured prop (no hoisted-var lookup, mirroring the
-    // former `varArithmeticMatch`).
+    // var * N — destructured prop (no hoisted-var lookup).
     if (body.left.kind === 'identifier') {
       const varName = body.left.name
       const param = propsParams.find(p => p.name === varName)
@@ -257,13 +245,13 @@ export function memoInitialFromParsedBody(
 }
 
 /**
- * Pattern-matching core of `computeMemoInitialValue`: returns the
- * memo's SSR initial value as a Go expression, or `null` when no
- * pattern applies. Callers that have a typed field to fill use the
- * zero-value-defaulting wrapper above; callers that can simply OMIT
- * the field (a child-instance prop init — Go's zero values then apply
- * with the right type for free) use this directly (#1896,
- * data-table's `Checked: 0` into a bool field).
+ * Pattern-matching core of `computeMemoInitialValue`.
+ *
+ * @returns the memo's SSR initial value as a Go expression, or `null` when no
+ *   pattern applies. Callers with a typed field to fill use the
+ *   zero-value-defaulting wrapper above; callers that can OMIT the field (a
+ *   child-instance prop init, where Go's zero values then apply with the right
+ *   type) use this directly.
  */
 export function computeMemoInitialValueOrNull(
   ctx: GoEmitContext,
@@ -274,20 +262,12 @@ export function computeMemoInitialValueOrNull(
 ): string | null {
   const computation = memo.computation
 
-  // (#checkbox) Pattern: () => `...${expr}...` — a template-literal memo
-  // (the classes memo: `${baseClasses} ${focusClasses} ... ${props.className
-  // ?? ''} grid place-content-center`). Build a Go string concatenation that
-  // inlines module string consts (incl. `[...].join(' ')` consts resolved by
-  // `resolveModuleStringConst`) and resolves `props.X ?? ''` / bare `props.X`
-  // to the corresponding `in.Field`. Returns null when any interpolation
-  // isn't representable, so the existing patterns below still apply.
+  // () => `...${expr}...` — template-literal memo (the classes memo). Builds a
+  // Go string concatenation; null when any interpolation isn't representable.
   const tmplMemo = computeTemplateLiteralMemoInitialValue(ctx, memo, propsParams)
   if (tmplMemo !== null) return tmplMemo
 
-  // Expression-bodied memo shapes (`getter() === 'lit'`, `props.X ?? false`,
-  // `cond() ? A : B`, `<ref> * N`, bare `getter()` / `props.X` / `var`) are
-  // matched structurally on the analyzer-attached `parsed` tree instead of
-  // re-parsing `computation` with regexes (IR-carries-semantics migration).
+  // Expression-bodied memo shapes, matched structurally on `parsed`.
   if (memo.parsed) {
     const fromParsed = memoInitialFromParsedBody(
       ctx,
@@ -299,13 +279,9 @@ export function computeMemoInitialValueOrNull(
     if (fromParsed !== null) return fromParsed
   }
 
-  // (#1971) Pattern: () => <operand> ===/!== 'lit' ? A : B, where each
-  // branch is a string literal/module-const and <operand> is a getter call
-  // (`orientation()`), an inline nullish-defaulted prop
-  // (`props.orientation ?? 'horizontal'`), or a bare `props.X` — carousel's
-  // `directionClasses` / `positionClasses` / `paddingClass`. Resolved via an
-  // AST walk (not regex) so quote style, parenthesization, and whitespace
-  // don't matter.
+  // () => <operand> ===/!== 'lit' ? A : B, where each branch is a string
+  // literal/module-const and <operand> is a getter call, an inline
+  // nullish-defaulted prop (`props.X ?? 'horizontal'`), or a bare `props.X`.
   const cmpTernary = computeComparisonTernaryGo(
     ctx,
     memo.parsed,
@@ -315,12 +291,10 @@ export function computeMemoInitialValueOrNull(
   )
   if (cmpTernary !== null) return cmpTernary
 
-  // (#1897) Pattern: block-body memo that early-returns a module-const array
-  // when a guard signal is falsy — `() => { const k = getter(); if (!k)
-  // return MODULE_ARRAY; return /* @client */ ... }`. When the signal starts
-  // null, the SSR value is the module-const array. The constant's literal
-  // value (not the identifier) is passed to the baker so `jsLiteralToGo`
-  // can reduce it to a Go slice.
+  // Block-body memo that early-returns a module-const array when a guard signal
+  // is falsy: `() => { const k = getter(); if (!k) return MODULE_ARRAY; … }`.
+  // When the signal starts null the SSR value is that array; its literal value
+  // (not the identifier) is passed to the baker so it reduces to a Go slice.
   const blockReturn = resolveBlockBodyMemoModuleConst(ctx, memo.parsedBlock, signals)
   if (blockReturn !== null && blockReturn.constValue && blockReturn.constType) {
     return convertInitialValue(ctx,
@@ -331,13 +305,10 @@ export function computeMemoInitialValueOrNull(
     )
   }
 
-  // (#1897 PostList) Pattern: an object-returning block-body memo derived from
-  // `searchParams()` — `() => { const sp = searchParams(); return { sort:
-  // asSortKey(sp.get('sort')), tag: sp.get('tag') ?? '' } }`. Compute a Go
-  // `map[string]interface{}` whose values are lowered from the request query,
-  // so `.Params.Sort` / `.Params.Tag` resolve at execute time instead of
-  // reading a nil map. Returns null for any unsupported shape (→ nil fallback,
-  // no regression).
+  // Object-returning block-body memo derived from `searchParams()`. Computes a
+  // Go `map[string]interface{}` whose values are lowered from the request
+  // query, so `.Params.Sort` etc. resolve at execute time instead of reading a
+  // nil map; null for any unsupported shape (→ nil fallback).
   const objMemo = computeObjectMemoInitialValue(ctx, memo)
   if (objMemo !== null) return objMemo
 
@@ -345,12 +316,12 @@ export function computeMemoInitialValueOrNull(
 }
 
 /**
- * (#1971) Resolve a signal/memo getter NAME to a Go value expression, for
- * use as the condition operand of another memo's ternary (carousel's
- * `directionClasses` reads the `orientation` memo). Handles a plain
- * signal, a prop-shadow memo `() => props.X ?? 'lit'` (→ a nil/empty-
- * tolerant field read mirroring the prop fold in `generateNewPropsFunction`),
- * else recurses. Returns null when the shape isn't representable.
+ * Resolve a signal/memo getter NAME to a Go value expression, for use as the
+ * condition operand of another memo's ternary. Handles a plain signal, a
+ * prop-shadow memo `() => props.X ?? 'lit'` (→ a nil/empty-tolerant field
+ * read), else recurses.
+ *
+ * @returns the Go expression, or null when the shape isn't representable
  */
 export function resolveGetterValueAsGo(
   ctx: GoEmitContext,
@@ -382,13 +353,12 @@ export function resolveGetterValueAsGo(
 }
 
 /**
- * (#1971) Resolve a string-ternary memo whose condition is a literal
- * comparison — `() => <operand> === 'lit' ? A : B` (or `!==`) — to a Go
- * runtime conditional, or null when the shape isn't supported. AST-based
- * (the repo idiom): tolerant of quote style, parenthesization, and
- * whitespace that a regex would miss. Branches must be string
- * literals/module-string-consts; the operand resolves via
- * `resolveComparisonOperandGo`.
+ * Resolve a string-ternary memo whose condition is a literal comparison —
+ * `() => <operand> === 'lit' ? A : B` (or `!==`) — to a Go runtime conditional.
+ * Branches must be string literals/module-string-consts; the operand resolves
+ * via `resolveComparisonOperandGo`.
+ *
+ * @returns the Go conditional, or null when the shape isn't supported
  */
 export function computeComparisonTernaryGo(
   ctx: GoEmitContext,
@@ -397,11 +367,8 @@ export function computeComparisonTernaryGo(
   propsParams: { name: string; type?: TypeInfo; defaultValue?: string }[],
   propFallbackVars: ReadonlyMap<string, PropFallbackVar>,
 ): string | null {
-  // Reads the analyzer-carried body tree (`MemoInfo.parsed`) instead of
-  // re-parsing `computation`. The former predicate only ever matched an
-  // expression-bodied conditional (a block arrow `body` is not a conditional,
-  // so it returned null) — a block-bodied memo has no `parsed`, so this returns
-  // null too, preserving that behaviour.
+  // Only an expression-bodied conditional matches; a block-bodied memo has no
+  // `parsed`, so it returns null.
   if (!parsed || parsed.kind !== 'conditional') return null
   const cond = parsed.test
   if (cond.kind !== 'binary' || !(cond.right.kind === 'literal' && cond.right.literalType === 'string')) {
@@ -441,11 +408,11 @@ export function computeComparisonTernaryGo(
 }
 
 /**
- * (#1971) Resolve the left operand of a string-ternary memo's comparison
- * condition to a Go expression: a zero-arg getter call (`orientation()` —
- * a signal/prop-shadow memo), an inline `props.X ?? 'def'` (folds the
- * default like `generateNewPropsFunction`), or a bare `props.X`. Returns
- * null for anything else.
+ * Resolve the left operand of a string-ternary memo's comparison condition to a
+ * Go expression: a zero-arg getter call (a signal/prop-shadow memo), an inline
+ * `props.X ?? 'def'` (folds the default), or a bare `props.X`.
+ *
+ * @returns the Go expression, or null for anything else
  */
 export function resolveComparisonOperandGo(
   ctx: GoEmitContext,

--- a/packages/adapter-go-template/src/adapter/memo/memo-type.ts
+++ b/packages/adapter-go-template/src/adapter/memo/memo-type.ts
@@ -3,10 +3,7 @@
  *
  * Pure free functions over a {@link GoEmitContext} that classify a memo's
  * computation so `inferMemoType` can pick the right Go field type (and thus the
- * right SSR zero value). They read the context's `state.moduleStringConsts`,
- * `extractPropNameFromInitialValue`, and `typeInfoToGo` from the type-codegen
- * module. (Template-literal classification now rides on the IR as
- * `MemoInfo.bodyIsTemplateLiteral`, set by the analyzer, so it isn't here.)
+ * right SSR zero value).
  */
 
 import type { ParsedExpr, TypeInfo } from '@barefootjs/jsx'
@@ -15,10 +12,10 @@ import type { GoEmitContext } from '../emit-context.ts'
 import { typeInfoToGo } from '../type/type-codegen.ts'
 
 /**
- * (#checkbox) Heuristic: does this memo evaluate to a boolean? True when its
- * computation is a comparison (`!==`/`===`/`!=`/`==`), a negation (`!x`), or
- * a ternary whose branches are all boolean signals/props. Used to pick `bool`
- * (zero value `false`) over the int `0` default for the SSR initial value.
+ * Heuristic: does this memo evaluate to a boolean? True when its computation is
+ * a comparison (`!==`/`===`/`!=`/`==`), a negation (`!x`), or a ternary whose
+ * branches are all boolean signals/props. Used to pick `bool` (zero value
+ * `false`) over the int `0` default for the SSR initial value.
  */
 export function isBooleanMemo(
   ctx: GoEmitContext,
@@ -27,11 +24,9 @@ export function isBooleanMemo(
   propsParamMap: Map<string, { name: string; type: TypeInfo; defaultValue?: string }>,
 ): boolean {
   const c = memo.computation
-  // A ternary whose two branches are string literals is a STRING memo
-  // (`orientation() === 'vertical' ? 'flex-col -mt-4' : 'flex -ml-4'`),
-  // not boolean — the `===` lives in the *condition*, so the blanket
-  // comparison check below would misclassify it as bool and bake `false`
-  // (#1971 carousel `directionClasses`). Bail before that check.
+  // A ternary whose two branches are string literals is a STRING memo, not
+  // boolean — the `===` lives in the *condition*, so the blanket comparison
+  // check below would misclassify it as bool and bake `false`. Bail first.
   if (isStringTernaryMemo(ctx, memo.parsed)) return false
   if (/(!==|===|!=(?!=)|==(?!=))/.test(c)) return true
   if (/=>\s*!/.test(c)) return true
@@ -60,17 +55,10 @@ export function isBooleanMemo(
 }
 
 /**
- * (#1971) Does this memo's arrow body resolve to a string-valued ternary
- * whose BOTH branches are string-valued — e.g. `() => orientation() ===
- * 'vertical' ? 'flex-col -mt-4' : 'flex -ml-4'`? Such a memo is a string,
- * not a bool, even though its condition contains `===`.
- *
- * Reads the analyzer-carried body tree (`MemoInfo.parsed`) instead of
- * re-parsing `computation`. A block-bodied memo has no `parsed`, so it returns
- * false — matching the former predicate, which only inspected an expression
- * body and never descended a block. A no-substitution `` `lit` `` branch folds
- * to a plain string literal in `ParsedExpr`, which `isStr` accepts just as the
- * old `isNoSubstitutionTemplateLiteral` check did, so output is unchanged.
+ * Does this memo's arrow body resolve to a ternary whose BOTH branches are
+ * string-valued — e.g. `() => orientation() === 'vertical' ? 'flex-col' :
+ * 'flex'`? Such a memo is a string, not a bool, even though its condition
+ * contains `===`. A block-bodied memo has no `parsed`, so it returns false.
  */
 export function isStringTernaryMemo(ctx: GoEmitContext, parsed: ParsedExpr | undefined): boolean {
   if (!parsed || parsed.kind !== 'conditional') return false

--- a/packages/adapter-go-template/src/adapter/memo/memo-value.ts
+++ b/packages/adapter-go-template/src/adapter/memo/memo-value.ts
@@ -19,10 +19,11 @@ import { capitalizeFieldName } from '../lib/go-naming.ts'
 import { lowerCtorExpr } from './ctor-lowering.ts'
 
 /**
- * (#1897) Recognises a block-body memo whose SSR path returns a module-const
- * array when the guard signal starts falsy:
+ * Recognise a block-body memo whose SSR path returns a module-const array when
+ * the guard signal starts falsy:
  *   `() => { const k = getter(); if (!k) return MODULE_CONST; … }`
- * Returns the constant's name and inferred type, or null.
+ *
+ * @returns the constant's name, value, inferred type and parsed tree, or null
  */
 export function resolveBlockBodyMemoModuleConst(
   ctx: GoEmitContext,
@@ -94,34 +95,32 @@ export function resolveBlockBodyMemoModuleConst(
 }
 
 /**
- * (#1897 PostList) Compute the SSR value of an object-returning block-body
- * memo derived from `searchParams()`:
+ * Compute the SSR value of an object-returning block-body memo derived from
+ * `searchParams()`:
  *   () => { const sp = searchParams(); return { sort: asSortKey(sp.get('sort')),
  *                                               tag: sp.get('tag') ?? '' } }
  * Emits a Go `map[string]interface{}{ "Sort": …, "Tag": … }` whose values are
  * lowered from the request query (see `lowerCtorExpr`). Keys are capitalized to
- * match the template's `.Params.<Field>` map access. Returns null for any shape
- * the lowerer can't represent, so the caller falls back to a nil map.
+ * match the template's `.Params.<Field>` map access.
+ *
+ * @returns the Go map literal, or null for any shape the lowerer can't
+ *   represent (→ nil-map fallback)
  */
 export function computeObjectMemoInitialValue(
   ctx: GoEmitContext,
   memo: { parsedBlock?: ParsedStatement[]; parsedBlockComplete?: boolean },
 ): string | null {
-  // Read the analyzer-carried block statements instead of re-parsing the
-  // `computation` source with `ts.createSourceFile` (#2006). An incomplete
-  // block (`parsedBlockComplete === false`) means a statement was omitted from
-  // the tolerant parse — it could hide control flow this resolver can't model,
-  // so bail to the nil fallback exactly as the former bail-on-unknown-statement
-  // walk did.
+  // An incomplete block (`parsedBlockComplete === false`) means a statement was
+  // omitted from the tolerant parse — it could hide control flow this resolver
+  // can't model, so bail to the nil fallback.
   if (!memo.parsedBlock || !memo.parsedBlockComplete) return null
 
   // Accept only a strict shape: zero or more `const`/`let` declarations
   // followed by exactly one `return { … }` as the LAST statement. Any other
   // statement kind — `if`, an early/extra `return` — means the block has
-  // control flow this resolver can't reason about, so we bail to the nil
-  // fallback rather than silently lowering one of several returns (#1941
-  // review). Along the way, collect `const <v> = searchParams()` bindings
-  // (the env for `<v>.get('k')`).
+  // control flow this resolver can't reason about, so bail to the nil fallback
+  // rather than silently lowering one of several returns. Along the way,
+  // collect `const <v> = searchParams()` bindings (the env for `<v>.get('k')`).
   const searchParamsVars = new Set<string>()
   let retObj: Extract<ParsedExpr, { kind: 'object-literal' }> | null = null
   const statements = memo.parsedBlock
@@ -129,8 +128,7 @@ export function computeObjectMemoInitialValue(
     const s = statements[i]
     if (s.kind === 'var-decl') {
       // `const <v> = searchParams()` — a zero-arg call to a searchParams
-      // local. Any other var-decl (a non-searchParams binding) is accepted
-      // and ignored, matching the old code that accepted any const.
+      // local. Any other var-decl is accepted and ignored.
       if (
         s.init.kind === 'call' &&
         s.init.callee.kind === 'identifier' &&
@@ -156,15 +154,11 @@ export function computeObjectMemoInitialValue(
   const env: CtorLowerEnv = { searchParamsVars, params: new Map() }
   const entries: string[] = []
   for (const prop of retObj.properties) {
-    // Bail on a shorthand property (`return { tag }`). The former walk only
-    // accepted `ts.PropertyAssignment` and bailed on `ShorthandPropertyAssignment`;
-    // preserve that strictness so this stays byte-identical (a shorthand value
-    // is a bare identifier whose name need not match a `.Params.<Field>`
-    // accessor, and lowering it would silently widen the accepted shape).
+    // Bail on a shorthand property (`return { tag }`): its value is a bare
+    // identifier whose name need not match a `.Params.<Field>` accessor.
     if (prop.shorthand) return null
     // The key must be identifier- or string-named (a numeric key has no
-    // matching `.Params.<Field>` accessor), matching the old
-    // `ts.isIdentifier || ts.isStringLiteral` check.
+    // matching `.Params.<Field>` accessor).
     if (prop.keyKind !== undefined && prop.keyKind !== 'identifier' && prop.keyKind !== 'string') {
       return null
     }

--- a/packages/adapter-go-template/src/adapter/memo/template-interp.ts
+++ b/packages/adapter-go-template/src/adapter/memo/template-interp.ts
@@ -5,9 +5,8 @@
  * value of a template-literal memo (`() => `${a} ${props.x ?? ''} grid``) as a
  * Go `string` expression. Each quasi becomes a Go string literal; each
  * interpolation resolves to a module string const, a `Record`-index access, or
- * a `props.<name>` field read. They read the context's `state.localConstants` /
- * `state.propsObjectName` and `resolveModuleStringConst`, and set
- * `state.usesFmt` when a `Record`-index interpolation emits `fmt.Sprint`.
+ * a `props.<name>` field read. Sets `state.usesFmt` when a `Record`-index
+ * interpolation emits `fmt.Sprint`.
  */
 
 import ts from 'typescript'
@@ -19,45 +18,39 @@ import { escapeGoString } from '../lib/go-emit.ts'
 import { capitalizeFieldName } from '../lib/go-naming.ts'
 
 /**
- * (#checkbox) Compute the SSR initial value of a template-literal memo as a
- * Go `string` expression. The memo computation looks like
- * `() => `${a} ${b} ${props.className ?? ''} grid place-content-center``.
+ * Compute the SSR initial value of a template-literal memo as a Go `string`
+ * expression, e.g. `() => `${a} ${props.className ?? ''} grid``.
  *
- * Each quasi (literal text span) becomes a Go string literal; each
- * interpolation is resolved:
- *   - an identifier naming a module string const → its inlined literal
- *     (covers both pure-string and `[...].join(' ')` consts);
- *   - `props.<name> ?? '<fallback>'` or bare `props.<name>` → `in.<Field>`
- *     when `<name>` is a known prop param (typed `string`); the `?? ''`
- *     fallback maps to Go's zero value for an unset string field, matching
- *     the Hono reference's empty-string result.
+ * Each quasi becomes a Go string literal; each interpolation is resolved:
+ *   - an identifier naming a module string const → its inlined literal (covers
+ *     pure-string and `[...].join(' ')` consts);
+ *   - `props.<name> ?? '<fallback>'` or bare `props.<name>` → `in.<Field>` when
+ *     `<name>` is a known string-typed prop param (the `?? ''` fallback maps to
+ *     Go's zero value for an unset string field).
  *
- * Returns the `"a" + in.Field + " grid..."` concatenation, or null when the
- * computation isn't a single template literal or any interpolation isn't
- * representable (so the caller keeps its existing pattern matching).
+ * @returns the `"a" + in.Field + " grid..."` concatenation, or null when the
+ *   computation isn't a single template literal or any interpolation isn't
+ *   representable
  */
 export function computeTemplateLiteralMemoInitialValue(
   ctx: GoEmitContext,
   memo: { parsed?: ParsedExpr; parsedBlock?: ParsedStatement[]; parsedBlockComplete?: boolean },
   propsParams: { name: string; type?: TypeInfo; defaultValue?: string }[],
 ): string | null {
-  // Resolve the template value (a `template-literal` ParsedExpr, or a plain
-  // string `literal` for a no-substitution `` `plain` `` which folds to one)
-  // plus any memo-local `const X = props.Y ?? 'lit'` key bindings, from the
-  // analyzer-carried tree instead of re-parsing `computation`.
+  // Resolve the template value (a `template-literal`, or a plain string
+  // `literal` for a no-substitution `` `plain` `` which folds to one) plus any
+  // memo-local `const X = props.Y ?? 'lit'` key bindings.
   const localKeyBindings = new Map<string, { propName: string; defaultLiteral?: string }>()
   let templateValue: ParsedExpr | undefined
   if (memo.parsedBlock) {
     // Block-bodied arrow (the Toggle `classes` memo): collect leading key
     // bindings, then resolve against the single returned template literal. Any
-    // statement that isn't a var-decl or the return (an `if`, a loop) is shape
-    // we don't model — bail to the existing patterns, matching the former walk.
+    // statement that isn't a var-decl or the return (an `if`, a loop) is a
+    // shape we don't model — bail.
     //
-    // `parsedBlock` is tolerant — it OMITS statements it can't represent (a
-    // `for`/`while`/`switch`), so an incomplete block could otherwise look like
-    // just `var-decl`s + `return` and be lowered when the former TS-AST walk
-    // would have bailed on the unrepresented statement. Bail when it isn't
-    // complete so behaviour matches that walk.
+    // `parsedBlock` is tolerant: it OMITS statements it can't represent
+    // (`for`/`while`/`switch`), so an incomplete block could look like just
+    // `var-decl`s + `return`. Bail when it isn't complete.
     if (!memo.parsedBlockComplete) return null
     for (const s of memo.parsedBlock) {
       if (s.kind === 'var-decl') {
@@ -100,10 +93,9 @@ export function computeTemplateLiteralMemoInitialValue(
 }
 
 /**
- * (#checkbox) Resolve one `${expr}` interpolation of a template-literal memo
- * to a Go string expression, or null when unsupported. Operates on the
- * carried `ParsedExpr`. See `computeTemplateLiteralMemoInitialValue` for the
- * supported shapes.
+ * Resolve one `${expr}` interpolation of a template-literal memo to a Go string
+ * expression, or null when unsupported. See
+ * `computeTemplateLiteralMemoInitialValue` for the supported shapes.
  */
 function resolveTemplateInterpolation(
   ctx: GoEmitContext,
@@ -167,14 +159,15 @@ function parseLocalKeyBinding(
 }
 
 /**
- * Lower a `recordConst[key]` interpolation to an inline indexed Go map,
- * emitting `map[string]string{…}[fmt.Sprint(in.Field)]` (or `map[string]any`
- * for mixed values). `recordConst` resolves via the carried
- * `ConstantInfo.parsed` object-literal (module-scope `Record<keys, scalar>`);
- * `key` is a bare prop or a memo-local const bound to `props.X ?? 'default'`
- * (via `localKeyBindings`), whose `'default'` fallback also maps `""` so an
- * unset prop renders the default. Returns null for any non-record /
- * non-resolvable key so the caller falls through.
+ * Lower a `recordConst[key]` interpolation to an inline indexed Go map:
+ * `map[string]string{…}[fmt.Sprint(in.Field)]` (or `map[string]any` for mixed
+ * values). `recordConst` is a module-scope `Record<keys, scalar>` object
+ * literal; `key` is a bare prop or a memo-local const bound to `props.X ??
+ * 'default'`, whose `'default'` fallback also maps `""` so an unset prop
+ * renders the default.
+ *
+ * @returns the indexed-map expression, or null for any non-record /
+ *   non-resolvable key
  */
 function recordIndexInterpolationToGo(
   ctx: GoEmitContext,

--- a/packages/adapter-go-template/src/adapter/props/prop-types.ts
+++ b/packages/adapter-go-template/src/adapter/props/prop-types.ts
@@ -1,10 +1,8 @@
 /**
  * Prop-type resolution: decide each prop's Go struct-field type.
  *
- * Free functions over a {@link GoEmitContext}, shared by the Input / Props
- * struct generators and the nillable-field set so they can't drift. They read
- * `state.localStructFields` and `extractPropNameFromInitialValue`, and resolve
- * Go types via the type-codegen module's `typeInfoToGo`.
+ * Free functions over a {@link GoEmitContext}, shared by the Input/Props struct
+ * generators and the nillable-field set so they can't drift.
  */
 
 import type { ComponentIR, IRMetadata } from '@barefootjs/jsx'
@@ -13,14 +11,14 @@ import type { GoEmitContext } from '../emit-context.ts'
 import { typeInfoToGo } from '../type/type-codegen.ts'
 
 /**
- * Build a map from prop name to a better Go type inferred from signals.
- * When a signal is initialized from a prop (e.g., createSignal(props.initial ?? 0)),
- * the signal's type annotation may be more specific than the prop's TypeInfo.
+ * Build a map from prop name to a better Go type inferred from signals. When a
+ * signal is initialized from a prop (`createSignal(props.initial ?? 0)`), the
+ * signal's type annotation may be more specific than the prop's `TypeInfo`. Only
+ * generic prop types (containing `interface{}`) are overridden.
  */
 export function buildPropTypeOverrides(ctx: GoEmitContext, ir: ComponentIR): Map<string, string> {
   const overrides = new Map<string, string>()
   for (const signal of ir.metadata.signals) {
-    // Check simple identifier reference
     const propNames = [signal.initialValue]
     const extracted = ctx.extractPropNameFromInitialValue(signal.initialValue)
     if (extracted) propNames.push(extracted)
@@ -29,7 +27,6 @@ export function buildPropTypeOverrides(ctx: GoEmitContext, ir: ComponentIR): Map
       const param = ir.metadata.propsParams.find(p => p.name === propName)
       if (!param) continue
       const propGoType = typeInfoToGo(ctx, param.type, param.defaultValue)
-      // Override when prop type is generic (interface{} or contains interface{})
       if (propGoType.includes('interface{}')) {
         const signalGoType = typeInfoToGo(ctx, signal.type, signal.initialValue)
         if (!signalGoType.includes('interface{}')) {
@@ -43,11 +40,10 @@ export function buildPropTypeOverrides(ctx: GoEmitContext, ir: ComponentIR): Map
 
 /**
  * Resolve a prop param's Go struct-field type using the SAME logic
- * `generatePropsStruct` / `generateInputStruct` use for the field
- * declaration: a `propTypeOverrides` entry (signal-inferred override)
- * wins, otherwise `typeInfoToGo(param.type, param.defaultValue)`.
- * Factored out so the nillable-field set (`collectNillablePropNames`)
- * can't drift from the actual emitted field types.
+ * `generatePropsStruct` / `generateInputStruct` use: a `propTypeOverrides` entry
+ * wins, otherwise `typeInfoToGo(param.type, param.defaultValue)`. Factored out so
+ * the nillable-field set (`collectNillablePropNames`) can't drift from the
+ * emitted field types.
  */
 export function resolvePropGoType(
   ctx: GoEmitContext,
@@ -55,19 +51,15 @@ export function resolvePropGoType(
   propTypeOverrides: Map<string, string>,
 ): string {
   const base = propTypeOverrides.get(param.name) ?? typeInfoToGo(ctx, param.type, param.defaultValue)
-  // (#1971) An OPTIONAL prop typed as a named struct (e.g. carousel's
-  // `opts?: EmblaOptionsType`) lowers to `map[string]interface{}` rather
-  // than the value struct. Two reasons: a value struct is always truthy in
-  // Go templates, so a `{{if .Opts}}`-guarded attribute (`data-opts={opts ?
-  // JSON.stringify(opts) : undefined}`) can never be omitted when the
-  // caller leaves it out; and a map round-trips through `bf_json` with only
-  // the keys actually supplied, matching JS `JSON.stringify` of a partial
-  // object literal instead of a zero-filled struct. A nil/empty map is
-  // falsy, so the omit-when-absent guard works for free.
+  // An OPTIONAL prop typed as a named struct (`opts?: EmblaOptionsType`) lowers
+  // to `map[string]interface{}`, not the value struct: a value struct is always
+  // truthy in Go templates (so a `{{if .Opts}}`-guarded attribute could never be
+  // omitted), whereas a nil/empty map is falsy and round-trips through `bf_json`
+  // with only the supplied keys — matching JS `JSON.stringify` of a partial
+  // object instead of a zero-filled struct.
   // Gate on `localStructFields` (an actual generated struct), NOT
-  // `localTypeNames` — the latter also covers string-union aliases like
-  // `placement?: 'top' | 'right' | …` (tooltip), which must stay their
-  // scalar Go type, not become a map.
+  // `localTypeNames` — the latter also covers string-union aliases
+  // (`placement?: 'top' | 'right' | …`), which must stay their scalar Go type.
   if (param.optional && ctx.state.localStructFields.has(base)) {
     return 'map[string]interface{}'
   }
@@ -76,10 +68,8 @@ export function resolvePropGoType(
 
 /**
  * Build the set of prop NAMES whose resolved Go field type is exactly
- * `interface{}` (nillable). Uses the same `propTypeOverrides` +
- * `resolvePropGoType` pipeline as the struct generators, so a prop
- * that ends up `interface{}` on the Props struct — and only such a
- * prop — is treated as nillable for Hono-style attribute omission.
+ * `interface{}` (nillable, for Hono-style attribute omission). Uses the same
+ * `propTypeOverrides` + `resolvePropGoType` pipeline as the struct generators.
  * Concrete (`string`/`int`/`bool`/`[]T`/struct) types are excluded.
  */
 export function collectNillablePropNames(ctx: GoEmitContext, ir: ComponentIR): Set<string> {

--- a/packages/adapter-go-template/src/adapter/spread/spread-codegen.ts
+++ b/packages/adapter-go-template/src/adapter/spread/spread-codegen.ts
@@ -5,13 +5,9 @@
  *   - `collectSpreadSlots` walks the IR (stopping at loop bodies) to gather the
  *     `SpreadSlotInfo` entries plumbed onto the Input/Props structs.
  *   - `buildSpreadInitializer` builds the Go expression for a spread bag's
- *     initial value placed inside `NewXxxProps` (#1407): signal-getter object
- *     literals, destructured / SolidJS-style / rest props, and conditional
- *     inline-object spreads.
- * They read `state.restPropsName` / `state.usesFmt`; the conditional inline-
- * object spread is lowered from the carried `SpreadAttr.parsed` tree (#2006)
- * rather than re-parsing the source with `ts.createSourceFile`. Everything else
- * comes from the per-call `ComponentIR`.
+ *     initial value placed inside `NewXxxProps`: signal-getter object literals,
+ *     destructured / SolidJS-style / rest props, and conditional inline-object
+ *     spreads.
  */
 
 import ts from 'typescript'
@@ -35,10 +31,9 @@ import type { SpreadSlotInfo } from '../lib/types.ts'
 import { capitalizeFieldName } from '../lib/go-naming.ts'
 
 /**
- * Walks the IR tree, descending into elements, fragments,
- * conditionals, providers, async, and components, but stopping at
- * loop bodies. Each `IRElement.attrs[i].value` of kind `'spread'`
- * that has a `slotId` becomes one `SpreadSlotInfo` entry.
+ * Walk the IR (elements, fragments, conditionals, providers, async, components)
+ * but stop at loop bodies. Each `'spread'` attr value with a `slotId` becomes
+ * one `SpreadSlotInfo` entry.
  */
 export function collectSpreadSlots(ctx: GoEmitContext, node: IRNode): SpreadSlotInfo[] {
   const result: SpreadSlotInfo[] = []
@@ -47,18 +42,12 @@ export function collectSpreadSlots(ctx: GoEmitContext, node: IRNode): SpreadSlot
 }
 
 /**
- * Decide how a spread bag should be plumbed onto the Input/Props
- * structs (#1407 follow-up). A bare-identifier spread that
- * matches the component's `restPropsName` is open-ended (Go's
- * static typing can't enumerate the keys), so the caller must
- * supply the bag via an Input-side `map[string]any` field. Every
- * other shape — signal getter, `propsObjectName`, plain
- * propsParam, object literal — can be constructed inline in
- * `NewXxxProps` from compile-time-known data.
- *
- * Reads `state.restPropsName` (stashed at `generate()` entry)
- * rather than receiving the IR per-call — matches the existing
- * `state.propsObjectName` / `state.componentName` storage pattern.
+ * Decide how a spread bag is plumbed onto the Input/Props structs. A
+ * bare-identifier spread matching `restPropsName` is open-ended (Go can't
+ * enumerate the keys), so the caller supplies the bag via an Input-side
+ * `map[string]any` field (`input-bag`). Every other shape — signal getter,
+ * `propsObjectName`, plain propsParam, object literal — is built inline in
+ * `NewXxxProps` from compile-time-known data (`inline`).
  */
 function classifySpreadBagSource(ctx: GoEmitContext, spreadExpr: string): 'input-bag' | 'inline' {
   const trimmed = spreadExpr.trim()
@@ -109,16 +98,13 @@ function collectSpreadSlotsRecursive(ctx: GoEmitContext, node: IRNode, result: S
   }
   if (node.type === 'component') {
     const comp = node as IRComponent
-    // `IRComponent.children` are the JSX children passed to *this*
-    // component instance at the call site (`<Child>...</Child>`).
-    // They are part of the PARENT's IR and evaluate in the parent's
-    // render scope, so any spreads inside them belong on the parent's
-    // Props struct. The child component's own template body is a
-    // separate `ComponentIR` with its own `ir.root`, compiled in a
-    // separate `generate()` pass — it never appears in the parent's
-    // IR tree, so the recursion never crosses a component boundary
-    // and the per-component `spreadIdCounter` can't collide across
-    // unrelated components (#1411 review).
+    // `IRComponent.children` are the JSX children passed to *this* instance at
+    // the call site (`<Child>...</Child>`) — part of the PARENT's IR, evaluated
+    // in the parent's render scope, so spreads inside them belong on the
+    // parent's Props struct. The child's own template body is a separate
+    // `ComponentIR` compiled in a separate `generate()` pass, so the recursion
+    // never crosses a component boundary and per-component `spreadIdCounter`
+    // can't collide across unrelated components.
     for (const child of comp.children) {
       collectSpreadSlotsRecursive(ctx, child, result)
     }
@@ -139,31 +125,26 @@ function collectSpreadSlotsRecursive(ctx: GoEmitContext, node: IRNode, result: S
     }
     return
   }
-  // Loops are intentionally not descended — loop-internal spreads
-  // emit `{{bf_spread_attrs <go-expr>}}` inline from
-  // `elementAttrEmitter.emitSpread` instead of plumbing through a
-  // Props struct field.
+  // Loops are intentionally not descended — loop-internal spreads emit
+  // `{{bf_spread_attrs <go-expr>}}` inline from `elementAttrEmitter.emitSpread`
+  // instead of plumbing through a Props struct field.
 }
 
 /**
- * Lower a signal's carried object-literal initial value (`MemoInfo`-style
- * `SignalInfo.parsed`) into a Go `map[string]any{...}` literal source (#1407),
- * instead of re-parsing the `initialValue` string with `ts.createSourceFile`.
+ * Lower a signal's carried object-literal initial value into a Go
+ * `map[string]any{...}` literal. Conservative subset: string/number/boolean/null
+ * values (and a signed-number `{count: -1}`) keyed by identifier or
+ * string-literal keys.
  *
- * Supports a deliberately conservative subset so the Go output is a 1:1
- * translation of the source: string/number/boolean/null values (and a
- * signed-number `{count: -1}`) keyed by identifier or string-literal keys.
- * Returns null for any other shape — a non-object init (`parsed` absent or not
- * an `object-literal`), a shorthand / nested-object / computed / call value —
- * so callers fall back to BF101.
+ * @returns `null` (→ caller falls back to BF101) for any other shape — a
+ *   non-object init, or a shorthand / nested-object / computed / call value.
  */
 function parsedObjectLiteralToGoMap(parsed: ParsedExpr | undefined): string | null {
   if (!parsed || parsed.kind !== 'object-literal') return null
   const entries: string[] = []
   for (const prop of parsed.properties) {
-    // A numeric key (`{ 1: 'a' }`) was rejected by the former parser (only
-    // identifier / string keys were accepted), so keep refusing it — `key`
-    // alone can't distinguish it from a string `'1'` key, hence `keyKind`.
+    // Reject a numeric key (`{ 1: 'a' }`); `keyKind` distinguishes it from a
+    // string `'1'` key.
     if (prop.keyKind === 'numeric') return null
     const v = prop.value
     let goVal: string
@@ -173,8 +154,7 @@ function parsedObjectLiteralToGoMap(parsed: ParsedExpr | undefined): string | nu
       // `raw` is the exact numeric token; `value` is the fallback.
       goVal = v.raw ?? String(v.value)
     } else if (
-      // `-1` / `+1` parse as a unary expression over a numeric literal — accept
-      // both signs so a bag like `{count: -1}` doesn't collapse to BF101.
+      // `-1` / `+1` parse as a unary over a numeric literal — accept both signs.
       v.kind === 'unary'
       && (v.op === '-' || v.op === '+')
       && v.argument.kind === 'literal'
@@ -195,31 +175,22 @@ function parsedObjectLiteralToGoMap(parsed: ParsedExpr | undefined): string | nu
 }
 
 /**
- * Build a Go expression for a JSX spread bag's initial value, to
- * be placed inside `NewXxxProps`'s return literal (#1407).
+ * Build a Go expression for a JSX spread bag's initial value, placed inside
+ * `NewXxxProps`'s return literal.
  *
  * Supported shapes:
- *   - Signal-getter call (e.g. `attrs()`): look up the signal,
- *     parse its `initialValue` as a JS object literal, and emit a
- *     Go `map[string]any{...}` literal.
- *   - Bare identifier matching a destructured `propsParam` (e.g.
- *     `function({ extras }: P) { <el {...extras}/> }`): emit
- *     `in.<FieldName>` — works when the prop's Go type is a map
- *     type the bag is assignable to.
- *   - Bare identifier matching `propsObjectName` (SolidJS-style
- *     `function(props: P) { <el {...props}/> }`): enumerate the
- *     analyzer-extracted `propsParams` into an inline
- *     `map[string]any{...}` literal so each typed Input field
- *     surfaces as a bag key (#1407 follow-up).
- *   - Bare identifier matching `restPropsName` (the destructured-
- *     rest pattern `function({a, ...rest}: P) { <el {...rest}/> }`):
- *     emit `in.<slotId>` against the `map[string]any` Input field
- *     that `generateInputStruct` adds for `input-bag` slots. The
- *     caller (parent component or test harness) populates the
- *     bag with the open-ended rest values (#1407 follow-up).
+ *   - Signal-getter call (`attrs()`): emit the signal's object literal as a Go
+ *     `map[string]any{...}`.
+ *   - Bare identifier matching a destructured `propsParam`: emit `in.<Field>`.
+ *   - Bare identifier matching `propsObjectName` (SolidJS-style `props`):
+ *     enumerate `propsParams` into an inline `map[string]any{...}` (each Input
+ *     field becomes a bag key).
+ *   - Bare identifier matching `restPropsName` (destructured rest): emit
+ *     `in.<Field>` against the `map[string]any` Input field added for
+ *     `input-bag` slots; the caller populates the open-ended rest values.
  *
- * Returns null for unsupported shapes so the caller can raise a
- * narrowed BF101 with the offending expression.
+ * @returns `null` for unsupported shapes so the caller can raise a narrowed
+ *   BF101 with the offending expression.
  */
 export function buildSpreadInitializer(
   ctx: GoEmitContext,
@@ -228,22 +199,16 @@ export function buildSpreadInitializer(
   parsed?: ParsedExpr,
 ): string | null {
   const trimmed = spreadExpr.trim()
-  // Conditional inline-object spread:
-  //   `{...(COND ? { 'k': v } : {})}` (either branch possibly `{}`).
-  // Lower to an immediately-invoked func literal that conditionally
-  // builds the bag, so the falsy branch yields an empty map (the key
-  // is OMITTED rather than rendered as `k=""` — `SpreadAttrs` does
-  // NOT filter empty strings). Returns null for any shape it can't
-  // faithfully convert so the caller falls back to BF101 (#textarea).
-  // Consume the carried `SpreadAttr.parsed` tree (#2006); when absent
-  // (older/hand-built IR), parse `trimmed` once as a fallback so the
-  // shape is still recognised without re-introducing the per-attribute
-  // `ts.createSourceFile` parse on the build hot path.
+  // Conditional inline-object spread `{...(COND ? { 'k': v } : {})}` (either
+  // branch possibly `{}`). The falsy branch yields an empty map so the key is
+  // OMITTED rather than rendered as `k=""` (`SpreadAttrs` does NOT filter empty
+  // strings). Consume the carried `parsed` tree; when absent (older/hand-built
+  // IR), parse `trimmed` once as a fallback.
   const conditionalTree = parsed ?? parseExpression(trimmed)
   const conditional = buildConditionalSpreadInitializer(ctx, conditionalTree, ir)
   if (conditional !== undefined) return conditional
-  // Signal-getter call: `attrs()` — pluck the signal's initialValue
-  // and translate the JS object literal to a Go map literal.
+  // Signal-getter call `attrs()` — translate the signal's object literal to a
+  // Go map literal.
   const callMatch = /^([a-zA-Z_][a-zA-Z0-9_]*)\s*\(\s*\)$/.exec(trimmed)
   if (callMatch) {
     const getterName = callMatch[1]
@@ -256,56 +221,46 @@ export function buildSpreadInitializer(
   }
   // Bare-identifier paths.
   if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(trimmed)) {
-    // 1. Destructured-from-props parameter: `function({ extras }: P)`
-    //    → spread `{...extras}` resolves to `in.Extras`.
+    // 1. Destructured-from-props parameter `function({ extras }: P)` →
+    //    `{...extras}` resolves to `in.Extras`.
     const param = ir.metadata.propsParams.find(p => p.name === trimmed)
     if (param) {
       return `in.${capitalizeFieldName(param.name)}`
     }
     // 2. SolidJS-style props object: `function(props: P)` → spread
-    //    `{...props}` enumerates all analyzer-extracted propsParams
-    //    into a `map[string]any` literal. Every Input field becomes
-    //    a bag key. When `propsParams` is empty (analyzer couldn't
-    //    enumerate the type — e.g. an unresolved interface
-    //    `extends` chain), the literal is `map[string]any{}`. SSR
-    //    then renders no spread attrs; the CSR `applyRestAttrs`
-    //    hydrate path still applies them. Strictly worse than a
-    //    full enumeration, but strictly better than BF101 blocking
-    //    the build.
+    //    `{...props}` enumerates all propsParams into a `map[string]any`
+    //    literal; every Input field becomes a bag key. When `propsParams` is
+    //    empty (analyzer couldn't enumerate the type), the literal is
+    //    `map[string]any{}`: SSR renders no spread attrs, but the CSR
+    //    `applyRestAttrs` hydrate path still applies them — worse than full
+    //    enumeration, better than BF101 blocking the build.
     if (ir.metadata.propsObjectName === trimmed) {
       const entries = ir.metadata.propsParams.map(p =>
         `${JSON.stringify(p.name)}: in.${capitalizeFieldName(p.name)}`,
       )
       return `map[string]any{${entries.join(', ')}}`
     }
-    // 3. Destructured-rest identifier:
-    //    `function({a, ...rest}: P) { <el {...rest}/> }`. The
-    //    rest's key set is open-ended (Go can't enumerate it
-    //    statically when the analyzer's `restPropsExpandedKeys`
-    //    isn't populated), so `generateInputStruct` added an
-    //    Input field named after the rest binding itself
-    //    (`rest` → `Rest`) so callers can write
-    //    `XxxInput{Rest: ...}` using the same identifier they
-    //    saw in source. Forward it through.
+    // 3. Destructured-rest identifier `function({a, ...rest}: P)`. The rest's
+    //    key set is open-ended, so `generateInputStruct` added an Input field
+    //    named after the rest binding (`rest` → `Rest`); callers write
+    //    `XxxInput{Rest: ...}` with the same identifier they saw in source.
+    //    Forward it through.
     if (ir.metadata.restPropsName === trimmed) {
       return `in.${capitalizeFieldName(trimmed)}`
     }
-    // 4. Function-scope local const holding a conditional inline-object
-    //    spread: `const sizeAttrs = size ? {…} : {}` then `{...sizeAttrs}`
-    //    (#checkbox / icon). Resolve the identifier to its initializer
-    //    text and route through the conditional-spread lowering. Only
-    //    function-scope (`!isModule`) consts qualify — a module const is
-    //    a different shape, and the resolved initializer must itself be a
-    //    conditional-of-object-literals (else `buildConditionalSpreadInitializer`
-    //    returns undefined and we fall through to BF101). Guard against a
-    //    const that resolves to another bare identifier (loop / non-literal).
+    // 4. Function-scope local const holding a conditional inline-object spread:
+    //    `const sizeAttrs = size ? {…} : {}` then `{...sizeAttrs}`. Resolve to
+    //    its initializer text and route through the conditional-spread lowering.
+    //    Only function-scope (`!isModule`) consts qualify, and the initializer
+    //    must itself be a conditional-of-object-literals (else fall through to
+    //    BF101).
     const localConst = (ir.metadata.localConstants ?? []).find(
       c => c.name === trimmed && !c.isModule,
     )
     if (localConst?.value !== undefined) {
       const initTrimmed = localConst.value.trim()
-      // Reject a const resolving to a bare identifier to avoid an
-      // unbounded resolution loop / non-literal forwarding.
+      // Reject a const resolving to a bare identifier to avoid an unbounded
+      // resolution loop / non-literal forwarding.
       if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(initTrimmed)) {
         const resolved = buildConditionalSpreadInitializer(ctx, parseExpression(initTrimmed), ir)
         // `undefined` → not a conditional-spread shape; fall through to
@@ -319,12 +274,10 @@ export function buildSpreadInitializer(
 }
 
 /**
- * Lower a conditional inline-object spread bag value:
- *   `(COND ? { 'aria-describedby': describedBy } : {})`
- * into an immediately-invoked Go func literal that conditionally
- * builds the map (so the falsy branch OMITS the key rather than
- * rendering it as an empty string, which `SpreadAttrs` does not
- * filter):
+ * Lower a conditional inline-object spread `(COND ? { 'aria-describedby':
+ * describedBy } : {})` into a Go IIFE that conditionally builds the map (the
+ * falsy branch OMITS the key rather than rendering it as an empty string, which
+ * `SpreadAttrs` does not filter):
  *
  *   func() map[string]any {
  *     if bf.Truthy(in.DescribedBy) {
@@ -333,21 +286,17 @@ export function buildSpreadInitializer(
  *     return map[string]any{}
  *   }()
  *
- * Returns:
- *   - `undefined` when the expression is NOT a parenthesized ternary
- *     of object literals — the caller falls through to other shapes.
- *   - `null` when it IS that shape but a part can't be faithfully
- *     converted (non-static key, unsupported condition, …) — the
- *     caller raises BF101.
- *   - the Go IIFE string when fully convertible.
+ * @returns `undefined` when the expression is NOT a ternary of object literals
+ *   (caller tries other shapes); `null` when it IS that shape but a part can't
+ *   be converted (non-static key, unsupported condition) → caller raises BF101;
+ *   the Go IIFE string when fully convertible.
  */
 function buildConditionalSpreadInitializer(
   ctx: GoEmitContext,
   expr: ParsedExpr | undefined,
   ir: ComponentIR,
 ): string | null | undefined {
-  // `parseExpression` already unwraps redundant parentheses, so the
-  // conditional / object-literal shapes surface directly.
+  // `parseExpression` already unwraps redundant parentheses.
   if (!expr || expr.kind !== 'conditional') return undefined
   const whenTrue = expr.consequent
   const whenFalse = expr.alternate
@@ -371,24 +320,21 @@ function buildConditionalSpreadInitializer(
 }
 
 /**
- * Convert a conditional-spread condition expression to a Go bool in
- * the `in.` context. Supports a bare prop identifier (`describedBy`)
- * and its negation (`!describedBy`), type-aware on the prop:
+ * Convert a conditional-spread condition to a Go bool in the `in.` context.
+ * Supports a bare prop identifier (`describedBy`) and its negation, type-aware:
  *   string  → `in.X != ""`
  *   boolean → `in.X`
  *   number  → `in.X != 0`
  *   unknown / interface{} → `bf.Truthy(in.X)`
- *     (faithful JS truthiness for an interface holding a string /
- *     number / bool — textarea's `describedBy` resolves to interface{};
- *     a string-biased `!= ""` test would misread `0` / `false` as truthy,
- *     Copilot review #1752).
- * Returns null for any other shape (caller → BF101).
+ * For interface{}, `bf.Truthy` gives faithful JS truthiness; a string-biased
+ * `!= ""` test would misread an interface holding `0` / `false` as truthy.
+ *
+ * @returns `null` for any other shape (caller → BF101).
  */
 function conditionToGoBool(
   condition: ParsedExpr,
   ir: ComponentIR,
 ): string | null {
-  // Parens are already stripped by `parseExpression`.
   let node = condition
   let negate = false
   if (node.kind === 'unary' && node.op === '!') {
@@ -408,15 +354,13 @@ function conditionToGoBool(
   } else if (prim === 'string') {
     truthy = `${field} != ""`
   } else {
-    // unknown / interface{}: the runtime value may be a string, number,
-    // bool, etc., so a string-biased `!= ""` test would diverge from JS
-    // truthiness (e.g. an `interface{}` holding `0` or `false` is falsy in
-    // JS but `!= ""` reads true). Route through `bf.Truthy`, the exported
-    // `Boolean(x)` equivalent, for a faithful check (Copilot review #1752).
+    // unknown / interface{}: route through `bf.Truthy` (the `Boolean(x)`
+    // equivalent) for faithful JS truthiness; `!= ""` would misread an
+    // interface holding `0` / `false`.
     truthy = `bf.Truthy(${field})`
   }
   if (!negate) return truthy
-  // Negation: wrap so `!` applies to the whole truthiness test.
+  // Negation: `!` applies to the whole truthiness test.
   if (prim === 'boolean') return `!${field}`
   if (prim === 'number') return `${field} == 0`
   if (prim === 'string') return `${field} == ""`
@@ -424,12 +368,13 @@ function conditionToGoBool(
 }
 
 /**
- * Convert a static object literal (`{ 'aria-describedby': describedBy }`)
- * into a Go `map[string]any{...}` literal for a conditional spread.
- * Only static string/identifier keys are allowed; values resolve
- * prop-identifier references to `in.FieldName` and string literals to
- * Go string literals. Returns null for any computed/spread/dynamic
- * key or unsupported value (caller → BF101). Empty object → `map[string]any{}`.
+ * Convert a static object literal (`{ 'aria-describedby': describedBy }`) into a
+ * Go `map[string]any{...}` for a conditional spread. Only static
+ * string/identifier keys; values resolve prop identifiers to `in.Field` and
+ * string literals to Go string literals. Empty object → `map[string]any{}`.
+ *
+ * @returns `null` for any computed/spread/dynamic key or unsupported value
+ *   (caller → BF101).
  */
 function objectLiteralToGoSpreadMap(
   ctx: GoEmitContext,
@@ -438,12 +383,10 @@ function objectLiteralToGoSpreadMap(
 ): string | null {
   const entries: string[] = []
   for (const prop of obj.properties) {
-    // Shorthand (`{ describedBy }`) was a `ShorthandPropertyAssignment` — not a
-    // `PropertyAssignment` — so the former parser rejected it; keep refusing.
+    // Shorthand (`{ describedBy }`) is unsupported.
     if (prop.shorthand) return null
-    // Numeric keys (`{ 1: x }`) were rejected by the former parser (only
-    // identifier / string-literal names were accepted); `keyKind` distinguishes
-    // them from a string `'1'` key.
+    // Reject a numeric key (`{ 1: x }`); `keyKind` distinguishes it from a
+    // string `'1'` key.
     if (prop.keyKind === 'numeric') return null
     const key = prop.key
     const val = prop.value
@@ -466,30 +409,27 @@ function objectLiteralToGoSpreadMap(
 
 /**
  * Lower a spread-object VALUE of the form `IDENT[KEY]` where:
- *   - `IDENT` resolves via `localConstants` to a MODULE-scope object
- *     literal whose property values are all scalar (number/string)
- *     literals under static (string-literal or identifier) keys
- *     (a `Record<staticKeys, scalar>` map like `sizeMap`), AND
+ *   - `IDENT` resolves via `localConstants` to a MODULE-scope object literal
+ *     whose property values are all scalar literals under static keys (a
+ *     `Record<staticKeys, scalar>` map like `sizeMap`), AND
  *   - `KEY` is a bare identifier that is a prop.
  * Emits an inline indexed Go map:
  *   `map[string]any{"sm": 16, ...}[fmt.Sprint(in.Size)]`
- * (`fmt.Sprint` coerces the `interface{}`/typed prop to the map's
- * string key space — sets `usesFmt` so the `"fmt"` import is added).
+ * (`fmt.Sprint` coerces the prop to the map's string key space — sets `usesFmt`
+ * so the `"fmt"` import is added).
  *
- * Returns the Go string when convertible, else `null` (caller → BF101)
- * for any non-scalar value, non-static key, or non-prop index so
- * unrelated shapes don't regress. (#checkbox / icon `sizeMap[size]`.)
+ * @returns the Go string, else `null` (caller → BF101) for any non-scalar
+ *   value, non-static key, or non-prop index.
  */
 function recordIndexAccessToGoMap(
   ctx: GoEmitContext,
   val: ParsedExpr,
   ir: ComponentIR,
 ): string | null {
-  // `parseRecordIndexAccess` (the shared single-source-of-truth parser) takes a
-  // `ts.Expression`. The only shape it accepts is `IDENT[KEY]` with identifier
-  // object and index, so rebuild exactly that node from the carried tree via
-  // `ts.factory` — no source-text re-parse needed. Any other shape can't match
-  // and short-circuits to `null` here.
+  // `parseRecordIndexAccess` (shared parser) takes a `ts.Expression` and only
+  // accepts `IDENT[KEY]` with identifier object and index, so rebuild exactly
+  // that node from the carried tree via `ts.factory`. Any other shape
+  // short-circuits to `null` here.
   if (
     val.kind !== 'index-access'
     || val.object.kind !== 'identifier'
@@ -501,8 +441,7 @@ function recordIndexAccessToGoMap(
     ts.factory.createIdentifier(val.object.name),
     ts.factory.createIdentifier(val.index.name),
   )
-  // Shared structural parse (single source of truth in `@barefootjs/jsx`);
-  // this wrapper only does the Go-specific emit from the structured result.
+  // Shared structural parse; this wrapper only does the Go-specific emit.
   const parsed = parseRecordIndexAccess(
     tsVal,
     ir.metadata.localConstants ?? [],

--- a/packages/adapter-go-template/src/adapter/type/type-codegen.ts
+++ b/packages/adapter-go-template/src/adapter/type/type-codegen.ts
@@ -1,11 +1,10 @@
 /**
  * Type codegen: render TypeScript types as Go type strings.
  *
- * Pure free functions over a {@link GoEmitContext}. They resolve a prop /
- * signal / const's TypeScript type (`TypeInfo`, a raw type string, or — as a
- * last resort — an inferred shape from a literal value) into the Go type used
- * for its struct field. They read only the context's `state.localTypeNames`
- * table; `inferTypeFromValue` is fully pure (no context needed).
+ * Free functions over a {@link GoEmitContext}. They resolve a prop/signal/const's
+ * type (`TypeInfo`, a raw type string, or — as a last resort — an inferred shape
+ * from a literal value) into the Go type used for its struct field. They read
+ * only `state.localTypeNames`; `inferTypeFromValue` is fully pure.
  */
 
 import type { TypeInfo } from '@barefootjs/jsx'
@@ -13,8 +12,10 @@ import type { TypeInfo } from '@barefootjs/jsx'
 import type { GoEmitContext } from '../emit-context.ts'
 
 /**
- * Convert TypeInfo to Go type string.
- * If type is unknown, tries to infer from defaultValue.
+ * Convert a `TypeInfo` to a Go type string.
+ *
+ * @param defaultValue used to infer the type when `typeInfo.kind` is `unknown`
+ * @returns the Go type, falling back to `interface{}` when unresolvable
  */
 export function typeInfoToGo(
   ctx: GoEmitContext,
@@ -41,18 +42,16 @@ export function typeInfoToGo(
     case 'object':
       return 'map[string]interface{}'
     case 'interface':
-      // Check if raw type name matches a locally-defined type
       if (typeInfo.raw && ctx.state.localTypeNames.has(typeInfo.raw)) {
         return typeInfo.raw
       }
-      // Try to parse raw type string as a known pattern (e.g., Array<Todo>)
+      // Resolve a raw type string pattern (e.g. `Array<Todo>`).
       if (typeInfo.raw) {
         const resolved = tsTypeStringToGo(ctx, typeInfo.raw)
         if (resolved !== 'interface{}') return resolved
       }
       return 'interface{}'
     case 'unknown':
-      // Try to infer type from default value
       if (defaultValue !== undefined) {
         return inferTypeFromValue(defaultValue)
       }
@@ -63,8 +62,8 @@ export function typeInfoToGo(
 }
 
 /**
- * Convert a raw TypeScript type string to a Go type string.
- * Handles primitives (number, string, boolean) and basic arrays.
+ * Convert a raw TypeScript type string to a Go type string. Handles primitives,
+ * `T[]` / `Array<T>` arrays, and known local types; else `interface{}`.
  */
 export function tsTypeStringToGo(ctx: GoEmitContext, tsType: string): string {
   const t = tsType.trim()
@@ -77,30 +76,20 @@ export function tsTypeStringToGo(ctx: GoEmitContext, tsType: string): string {
   }
   const arrayMatch = t.match(/^Array<(.+)>$/)
   if (arrayMatch) return `[]${tsTypeStringToGo(ctx, arrayMatch[1])}`
-  // Check if it's a known local type
   if (ctx.state.localTypeNames.has(t)) return t
   return 'interface{}'
 }
 
-/**
- * Infer Go type from a JavaScript value literal.
- */
+/** Infer a Go type from a JS value literal; `interface{}` when unrecognized. */
 export function inferTypeFromValue(value: string): string {
-  // Boolean literals
   if (value === 'true' || value === 'false') return 'bool'
-  // Number literals (int)
   if (/^-?\d+$/.test(value)) return 'int'
-  // Number literals (float)
   if (/^-?\d+\.\d+$/.test(value)) return 'float64'
-  // String literals
   if ((value.startsWith("'") && value.endsWith("'")) ||
       (value.startsWith('"') && value.endsWith('"'))) {
     return 'string'
   }
-  // Empty string
   if (value === '""' || value === "''") return 'string'
-  // Array literals
   if (value.startsWith('[')) return '[]interface{}'
-  // Default
   return 'interface{}'
 }

--- a/packages/adapter-go-template/src/adapter/value/parsed-literal-to-go.ts
+++ b/packages/adapter-go-template/src/adapter/value/parsed-literal-to-go.ts
@@ -1,19 +1,15 @@
 /**
- * Lower a structured literal `ParsedExpr` (carried on the IR by the analyzer)
- * to a Go literal, mirroring `tsLiteralToGo`'s output for the shapes it covers
- * so the signal-init bake can read the tree instead of re-parsing the value
- * string with `ts.createSourceFile`.
+ * Lower a structured literal `ParsedExpr` (carried on the IR) to a Go literal,
+ * for baking a signal's inline initial value into the SSR data context.
  *
  * Covers scalar literals, a unary-minus number, arrays of those, and object
- * literals baked against a concrete local struct (capitalised field names from
- * the struct's field map). The contract is **null-means-defer**: this returns
- * null for anything it does not reproduce exactly (an object whose target type
- * isn't a known struct, a key the struct doesn't declare, a nested object /
- * array property value, empty arrays, identifiers / calls, or a numeric literal
- * that didn't carry its `raw` token — the normalised `ts.NumericLiteral.text`,
- * not the verbatim source spelling). The caller then falls back to the
- * `ts.createSourceFile` path, so only the shapes reproduced here short-circuit
- * and behaviour stays byte-identical.
+ * literals baked against a concrete local struct.
+ *
+ * Contract is **null-means-defer**: returns null for anything not reproduced
+ * exactly — an object whose target type isn't a known struct, a key the struct
+ * doesn't declare, a nested object/array property value, an empty array, an
+ * identifier/call, or a numeric literal missing its `raw` token. The caller
+ * then keeps `nil`.
  */
 
 import type { ParsedExpr, TypeInfo } from '@barefootjs/jsx'
@@ -26,8 +22,8 @@ export function parsedLiteralToGo(
   expr: ParsedExpr,
   typeInfo?: TypeInfo,
 ): string | null {
-  // Leading unary minus on a numeric literal (`-1`) — mirror
-  // `tsLiteralToGo`'s `-${operand.text}` using the carried `raw` token.
+  // Leading unary minus on a numeric literal (`-1`), from the carried `raw`
+  // token.
   if (
     expr.kind === 'unary' &&
     expr.op === '-' &&
@@ -40,13 +36,11 @@ export function parsedLiteralToGo(
   if (expr.kind === 'literal') {
     switch (expr.literalType) {
       case 'string':
-        // `value` is the interpreted (unquoted) text, exactly like
-        // `ts.StringLiteral.text`; `JSON.stringify` re-quotes it for Go.
+        // `value` is the unquoted text; `JSON.stringify` re-quotes it for Go.
         return JSON.stringify(expr.value)
       case 'number':
-        // Need the exact source token (`tsLiteralToGo` returns
-        // `NumericLiteral.text`); without it the `parseFloat` value could
-        // change spelling / lose precision, so defer.
+        // Need the exact source token; without it the value could change
+        // spelling / lose precision, so defer.
         return expr.raw ?? null
       case 'boolean':
         return expr.value ? 'true' : 'false'
@@ -56,17 +50,16 @@ export function parsedLiteralToGo(
   }
 
   if (expr.kind === 'array-literal') {
-    // An empty array bakes to nothing in `tsLiteralToGo` (returns null so the
-    // field stays nil, JSON-marshalling as `null`). Defer so the fallback
-    // reaches that same nil rather than emitting an empty slice.
+    // Empty array → null so the field stays nil (JSON-marshals as `null`)
+    // rather than an empty slice.
     if (expr.elements.length === 0) return null
     const elemType = typeInfo?.kind === 'array' ? typeInfo.elementType : undefined
     const sliceHeader = typeInfo?.kind === 'array' ? typeInfoToGo(ctx, typeInfo) : '[]interface{}'
     const elems: string[] = []
     for (const el of expr.elements) {
       const go = parsedLiteralToGo(ctx, el, elemType)
-      // Any non-scalar element (an object, a call, an identifier) defers the
-      // WHOLE array to the TS path, which owns the struct-element baking.
+      // Any non-scalar element (object / call / identifier) defers the WHOLE
+      // array — struct-element baking is owned elsewhere.
       if (go === null) return null
       elems.push(go)
     }
@@ -74,22 +67,20 @@ export function parsedLiteralToGo(
   }
 
   if (expr.kind === 'object-literal') {
-    // Bake against a concrete local struct only — mirror `tsLiteralToGo`'s
-    // object branch exactly. The struct's field map is the source of truth for
-    // the Go field name of each source key (and, by omission, which keys it
-    // declares); bail (→ defer) when the target type isn't a known struct.
+    // Bake against a concrete local struct only. The struct's field map is the
+    // source of truth for each source key's Go field name (and, by omission,
+    // which keys it declares); defer when the target type isn't a known struct.
     const goType = typeInfo ? typeInfoToGo(ctx, typeInfo) : 'interface{}'
     const structFields = ctx.state.localStructFields.get(goType)
     if (!structFields) return null
     const entries: string[] = []
     for (const prop of expr.properties) {
-      // A shorthand `{ a }` carries an identifier value (not a literal); it
-      // lowers to null below and defers the whole object — matching
-      // `tsLiteralToGo`, which refuses a `ShorthandPropertyAssignment`.
+      // A shorthand `{ a }` carries an identifier value → lowers to null below
+      // and defers the whole object.
       const goField = structFields.get(prop.key)
       if (!goField) return null
-      // Nested object / array property values aren't baked here (their field
-      // types aren't tracked) — defer, exactly as `tsLiteralToGo` does.
+      // Nested object/array property values aren't baked here (field types
+      // untracked) — defer.
       if (prop.value.kind === 'object-literal' || prop.value.kind === 'array-literal') return null
       const go = parsedLiteralToGo(ctx, prop.value)
       if (go === null) return null

--- a/packages/adapter-go-template/src/adapter/value/value-lowering.ts
+++ b/packages/adapter-go-template/src/adapter/value/value-lowering.ts
@@ -1,12 +1,8 @@
 /**
- * Value lowering: convert JS signal/const initial values into Go literals.
- *
- * Pure free functions over a {@link GoEmitContext}. The cluster bakes inline
- * initial values into the SSR data context — scalars, prop references, and
- * fully-literal arrays/objects — and falls back to `nil`/`0` for anything the
- * parser can't reduce to a literal. They depend on the context's `state`
- * (struct-field / type-alias tables) and `extractPropNameFromInitialValue`,
- * plus `typeInfoToGo` from the type-codegen module.
+ * Value lowering: convert a JS signal/const initial value into a Go literal for
+ * the SSR data context — scalars, prop references, and fully-literal
+ * arrays/objects — falling back to `nil`/`0` for anything not reducible to a
+ * literal. Pure free functions over a {@link GoEmitContext}.
  */
 
 import type { ParsedExpr, TypeInfo } from '@barefootjs/jsx'
@@ -19,6 +15,14 @@ import { parsedLiteralToGo } from './parsed-literal-to-go.ts'
 /** Default for `getSignalInitialValueAsGo`'s optional fallback-var map. */
 const EMPTY_PROP_FALLBACK_VARS: ReadonlyMap<string, PropFallbackVar> = new Map()
 
+/**
+ * Lower a signal/const initial value to its Go SSR literal.
+ *
+ * @param value     the initial-value source text
+ * @param preParsed the analyzer's structured parse of `value`, when available
+ * @returns the Go literal; `in.<Field>` for a prop reference; or the type's
+ *   zero (`nil` / `0` / `""`) when `value` is not a bakeable literal
+ */
 export function convertInitialValue(
   ctx: GoEmitContext,
   value: string,
@@ -26,15 +30,14 @@ export function convertInitialValue(
   propsParams?: { name: string }[],
   preParsed?: ParsedExpr,
 ): string {
-  // Check if it's a simple identifier (props param reference)
+  // A bare identifier matching a props param → its input field.
   if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(value)) {
-    // Check if this matches a props param
     if (propsParams?.some(p => p.name === value)) {
       return `in.${capitalizeFieldName(value)}`
     }
   }
 
-  // Check for props.xxx pattern (e.g., "props.initial ?? 0")
+  // `props.X ?? …` referencing a props param → its input field.
   const propName = ctx.extractPropNameFromInitialValue(value)
   if (propName && propsParams?.some(p => p.name === propName)) {
     return `in.${capitalizeFieldName(propName)}`
@@ -45,13 +48,12 @@ export function convertInitialValue(
       return value === 'true' ? 'true' : 'false'
     }
     if (typeInfo.primitive === 'number') {
-      // Check if it's a simple number
       if (/^\d+$/.test(value)) return value
       if (/^\d+\.\d+$/.test(value)) return value
       return '0'
     }
     if (typeInfo.primitive === 'string') {
-      // Remove quotes if present and add Go string syntax
+      // Normalize single-quoted / unquoted source to a Go string literal.
       if (value.startsWith("'") || value.endsWith("'")) {
         return value.replace(/'/g, '"')
       }
@@ -62,25 +64,15 @@ export function convertInitialValue(
     }
   }
 
-  // For arrays, bake a fully-literal initial value into a Go slice literal
-  // so the SSR data context carries the items (#1672). Empty / nullish
-  // literals collapse to nil, and any non-literal element (a call, a
-  // variable reference, …) falls back to nil so the handler populates it.
-  //
-  // The baked literal is element-type-aware so it both compiles and renders:
-  //   - scalar elements →  `[]string{…}` / `[]interface{}{…}`  (template `{{.}}`)
-  //   - struct elements →  `[]Item{Item{ID: …}}`               (template `.ID`)
-  // An untyped object array would land in a `[]interface{}` field whose
-  // `map[string]interface{}` items the template can't reach via field access
-  // (`.ID` → <nil>), so `jsLiteralToGo` returns null there and we keep nil.
+  // Bake a fully-literal array into a Go slice literal so the SSR context
+  // carries the items, element-type-aware so it both compiles and renders
+  // (`[]string{…}` / `[]Item{Item{ID: …}}`). A call / identifier / empty array /
+  // object-in-`[]interface{}` yields null → keep `nil`.
   if (typeInfo.kind === 'array') {
-    // Bake a fully-literal initial value into a Go slice literal; anything
-    // the parser can't reduce to a literal — a call, an identifier, `null` /
-    // `undefined`, or an empty array — yields null and we keep `nil`.
     return jsLiteralToGo(ctx, typeInfo, preParsed) ?? 'nil'
   }
 
-  // String alias (e.g., Filter = string) — return string value instead of nil
+  // String alias (e.g. `type Filter = string`) → the string value, not nil.
   if (typeInfo.kind === 'interface' && typeInfo.raw) {
     const aliasBase = ctx.state.localTypeAliases.get(typeInfo.raw)
     if (aliasBase === 'string') {
@@ -96,38 +88,26 @@ export function convertInitialValue(
 }
 
 /**
- * Convert a fully-literal JS expression — carried as the analyzer's structured
- * `ParsedExpr` tree (#2006) — into an equivalent Go literal whose Go type
- * matches `typeInfo` (#1672), used to bake a signal's inline initial value into
- * the SSR data context:
+ * Lower a fully-literal value — from the analyzer's carried `ParsedExpr` tree —
+ * to a Go literal typed as `typeInfo`:
  *
- *   `["x", "y"]`             (string[])  → `[]string{"x", "y"}`
- *   `["x", "y"]`             (unknown[]) → `[]interface{}{"x", "y"}`
- *   `[{ id: "a" }]`          (Item[])    → `[]Item{Item{ID: "a"}}`
+ *   `["x", "y"]`    (string[])  → `[]string{"x", "y"}`
+ *   `["x", "y"]`    (unknown[]) → `[]interface{}{"x", "y"}`
+ *   `[{ id: "a" }]` (Item[])    → `[]Item{Item{ID: "a"}}`
  *
- * Returns `null` — so the caller keeps `nil` — when no structured tree was
- * carried (the analyzer's `parseExpression` returned `unsupported`), or when
- * the tree (or any nested element) is not a pure literal (a call, identifier,
- * template with interpolation, …) or cannot be expressed in the target Go type
- * without a render/compile mismatch (e.g. an object element in a `[]interface{}`
- * field, which the SSR template reaches via struct field access the map lacks).
+ * @returns `null` (→ caller keeps `nil`) when no tree was carried, the tree
+ *   isn't a pure literal, or it can't be expressed in the target Go type
+ *   without a render/compile mismatch (e.g. an object element in a
+ *   `[]interface{}`, unreachable via the template's struct-field access).
  */
 export function jsLiteralToGo(
   ctx: GoEmitContext,
   typeInfo: TypeInfo,
   preParsed?: ParsedExpr,
 ): string | null {
-  // Roadmap A (terminal sweep, #2006): lower the literal from the carried
-  // structured parse only. `parsedLiteralToGo` reproduces every bakeable shape
-  // (scalars, a unary-minus number, scalar arrays, and objects against a local
-  // struct) and returns null to keep `nil` for everything else (empty arrays,
-  // objects with no known struct, identifiers / calls, nested object/array
-  // values, `as const`). The former `ctx.parseLiteralExpression` +
-  // `tsLiteralToGo` re-parse fallback covered the same bakeable shapes — every
-  // shape the analyzer's `parseExpression` leaves `unsupported` (so `preParsed`
-  // is absent) is also one the fallback's own `ts.is*` checks declined — so
-  // dropping it is byte-identical (verified by the 786/556 adapter gauntlet,
-  // the project's byte-identity authority).
+  // `parsedLiteralToGo` reproduces every bakeable shape (scalars, unary-minus
+  // number, scalar arrays, objects against a local struct) and returns null to
+  // keep `nil` for anything else.
   if (preParsed) {
     const structured = parsedLiteralToGo(ctx, preParsed, typeInfo)
     if (structured !== null) return structured
@@ -136,36 +116,24 @@ export function jsLiteralToGo(
 }
 
 /**
- * (#1971) Bake a pure object-literal expression (`{ align: 'start' }`) into a
- * Go `map[string]interface{}` literal keyed by the SOURCE property names, so
- * it round-trips through `bf_json` exactly like JS `JSON.stringify` of the
- * same object — only the supplied keys, no zero-filled struct fields. Used
- * when an inline object literal is passed to a child's optional object prop
- * (`<Carousel opts={{ align: 'start' }}>`). Returns null for any non-literal
- * or nested object/array value (carousel's opts are flat scalars).
+ * Bake a flat object literal (`{ align: 'start' }`) into a Go
+ * `map[string]interface{}` keyed by the SOURCE property names, so it
+ * round-trips through `bf_json` like `JSON.stringify` — only the supplied keys,
+ * no zero-filled struct fields. Used for an inline object passed to a child's
+ * optional object prop (`<Carousel opts={{ align: 'start' }}>`).
+ *
+ * @returns `null` for a non-object-literal, a shorthand property, a nested
+ *   object/array value, or an empty object.
  */
 export function objectLiteralToGoMap(ctx: GoEmitContext, expr: ParsedExpr): string | null {
-  // Roadmap A: read the carried `ParsedExpr` tree instead of re-parsing the
-  // source with `ts.createSourceFile`. The tree is only an `object-literal`
-  // when every property is a non-computed `key: value` / shorthand `{ key }`
-  // (spreads, computed keys, methods fall through to `unsupported` upstream),
-  // which is exactly the shape the old `ts.isObjectLiteralExpression` +
-  // `ts.isPropertyAssignment` checks accepted.
   if (expr.kind !== 'object-literal') return null
   const entries: string[] = []
   for (const prop of expr.properties) {
-    // Shorthand `{ a }` carried an identifier value upstream; the old code
-    // refused a `ShorthandPropertyAssignment`, so bail here too.
+    // Shorthand `{ a }` (identifier value) is unsupported.
     if (prop.shorthand) return null
-    // `parsedLiteralToGo` with no typeInfo reproduces `tsLiteralToGo`'s scalar
-    // output byte-for-byte (string via `JSON.stringify`, number via the
-    // carried `raw` token, boolean/null literally). Nested object / array
-    // property values lower to null and defer — matching the old behaviour,
-    // where carousel's flat-scalar opts were the only supported shape.
+    // Scalar lowering (no typeInfo); a nested object/array value defers to null.
     const val = parsedLiteralToGo(ctx, prop.value)
     if (val === null) return null
-    // `prop.key` is the resolved key text (identifier / string / numeric all
-    // normalised to a string), exactly like the old `prop.name.text`.
     entries.push(`${JSON.stringify(prop.key)}: ${val}`)
   }
   if (entries.length === 0) return null
@@ -173,12 +141,13 @@ export function objectLiteralToGoMap(ctx: GoEmitContext, expr: ParsedExpr): stri
 }
 
 /**
- * Get signal's initial value as Go code.
- * Handles both literal values (0, true, "str") and props references (initial).
+ * Get a signal's initial value as Go code — a literal (`0`, `true`, `"str"`) or
+ * a props reference.
  *
- * (#1423) When the signal references a prop via `props.X ?? N` and
- * the caller hoisted a fallback variable for `X`, return the hoisted
- * variable's name so the memo inherits the signal-time fallback.
+ * @param propFallbackVars when the signal is `props.X ?? N` and the caller
+ *   hoisted a fallback var for `X`, its name is returned so the memo inherits
+ *   the signal-time fallback.
+ * @returns the Go expression, or `0` for an unrecognized value
  */
 export function getSignalInitialValueAsGo(
   ctx: GoEmitContext,
@@ -186,14 +155,14 @@ export function getSignalInitialValueAsGo(
   propsParams: { name: string }[],
   propFallbackVars: ReadonlyMap<string, PropFallbackVar> = EMPTY_PROP_FALLBACK_VARS,
 ): string {
-  // Check if it's a props param reference
+  // A bare props-param reference → its input field (or the hoisted fallback var).
   if (propsParams.some(p => p.name === initialValue)) {
     const hoisted = propFallbackVars.get(initialValue)
     if (hoisted) return hoisted.varName
     return `in.${capitalizeFieldName(initialValue)}`
   }
 
-  // Check for props.xxx pattern (e.g., "props.initial ?? 0")
+  // `props.X ?? …` referencing a props param → its input field / fallback var.
   const propName = ctx.extractPropNameFromInitialValue(initialValue)
   if (propName && propsParams.some(p => p.name === propName)) {
     const hoisted = propFallbackVars.get(propName)
@@ -201,24 +170,20 @@ export function getSignalInitialValueAsGo(
     return `in.${capitalizeFieldName(propName)}`
   }
 
-  // Check if it's a literal value
-  // Number literals
+  // Literals pass through (single quotes normalized to Go double quotes).
   if (/^-?\d+$/.test(initialValue)) {
     return initialValue
   }
   if (/^-?\d+\.\d+$/.test(initialValue)) {
     return initialValue
   }
-  // Boolean literals
   if (initialValue === 'true' || initialValue === 'false') {
     return initialValue
   }
-  // String literals
   if ((initialValue.startsWith("'") && initialValue.endsWith("'")) ||
       (initialValue.startsWith('"') && initialValue.endsWith('"'))) {
     return initialValue.replace(/'/g, '"')
   }
 
-  // Default: return 0 for unknown
   return '0'
 }

--- a/packages/adapter-go-template/src/adapter/value/value-lowering.ts
+++ b/packages/adapter-go-template/src/adapter/value/value-lowering.ts
@@ -16,12 +16,8 @@ import { parsedLiteralToGo } from './parsed-literal-to-go.ts'
 const EMPTY_PROP_FALLBACK_VARS: ReadonlyMap<string, PropFallbackVar> = new Map()
 
 /**
- * Lower a signal/const initial value to its Go SSR literal.
- *
- * @param value     the initial-value source text
- * @param preParsed the analyzer's structured parse of `value`, when available
- * @returns the Go literal; `in.<Field>` for a prop reference; or the type's
- *   zero (`nil` / `0` / `""`) when `value` is not a bakeable literal
+ * Lower a signal/const initial value to its Go SSR literal: a prop reference
+ * becomes `in.<Field>`, a non-literal falls back to the type's zero value.
  */
 export function convertInitialValue(
   ctx: GoEmitContext,
@@ -30,14 +26,12 @@ export function convertInitialValue(
   propsParams?: { name: string }[],
   preParsed?: ParsedExpr,
 ): string {
-  // A bare identifier matching a props param → its input field.
   if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(value)) {
     if (propsParams?.some(p => p.name === value)) {
       return `in.${capitalizeFieldName(value)}`
     }
   }
 
-  // `props.X ?? …` referencing a props param → its input field.
   const propName = ctx.extractPropNameFromInitialValue(value)
   if (propName && propsParams?.some(p => p.name === propName)) {
     return `in.${capitalizeFieldName(propName)}`
@@ -53,7 +47,6 @@ export function convertInitialValue(
       return '0'
     }
     if (typeInfo.primitive === 'string') {
-      // Normalize single-quoted / unquoted source to a Go string literal.
       if (value.startsWith("'") || value.endsWith("'")) {
         return value.replace(/'/g, '"')
       }
@@ -64,15 +57,11 @@ export function convertInitialValue(
     }
   }
 
-  // Bake a fully-literal array into a Go slice literal so the SSR context
-  // carries the items, element-type-aware so it both compiles and renders
-  // (`[]string{…}` / `[]Item{Item{ID: …}}`). A call / identifier / empty array /
-  // object-in-`[]interface{}` yields null → keep `nil`.
   if (typeInfo.kind === 'array') {
     return jsLiteralToGo(ctx, typeInfo, preParsed) ?? 'nil'
   }
 
-  // String alias (e.g. `type Filter = string`) → the string value, not nil.
+  // A string type-alias keeps its string value instead of falling to nil.
   if (typeInfo.kind === 'interface' && typeInfo.raw) {
     const aliasBase = ctx.state.localTypeAliases.get(typeInfo.raw)
     if (aliasBase === 'string') {
@@ -83,7 +72,6 @@ export function convertInitialValue(
     }
   }
 
-  // Default for complex expressions
   return 'nil'
 }
 
@@ -95,19 +83,15 @@ export function convertInitialValue(
  *   `["x", "y"]`    (unknown[]) → `[]interface{}{"x", "y"}`
  *   `[{ id: "a" }]` (Item[])    → `[]Item{Item{ID: "a"}}`
  *
- * @returns `null` (→ caller keeps `nil`) when no tree was carried, the tree
- *   isn't a pure literal, or it can't be expressed in the target Go type
- *   without a render/compile mismatch (e.g. an object element in a
- *   `[]interface{}`, unreachable via the template's struct-field access).
+ * Returns null (caller keeps `nil`) for a non-literal, or a shape that can't be
+ * expressed in the target type (e.g. an object in a `[]interface{}`, unreachable
+ * via the template's struct-field access).
  */
 export function jsLiteralToGo(
   ctx: GoEmitContext,
   typeInfo: TypeInfo,
   preParsed?: ParsedExpr,
 ): string | null {
-  // `parsedLiteralToGo` reproduces every bakeable shape (scalars, unary-minus
-  // number, scalar arrays, objects against a local struct) and returns null to
-  // keep `nil` for anything else.
   if (preParsed) {
     const structured = parsedLiteralToGo(ctx, preParsed, typeInfo)
     if (structured !== null) return structured
@@ -117,21 +101,16 @@ export function jsLiteralToGo(
 
 /**
  * Bake a flat object literal (`{ align: 'start' }`) into a Go
- * `map[string]interface{}` keyed by the SOURCE property names, so it
- * round-trips through `bf_json` like `JSON.stringify` — only the supplied keys,
- * no zero-filled struct fields. Used for an inline object passed to a child's
- * optional object prop (`<Carousel opts={{ align: 'start' }}>`).
- *
- * @returns `null` for a non-object-literal, a shorthand property, a nested
- *   object/array value, or an empty object.
+ * `map[string]interface{}` keyed by SOURCE property names, so it round-trips
+ * through `bf_json` like `JSON.stringify` (only the supplied keys, no zero-filled
+ * struct fields). Used for an inline object passed to a child's optional object
+ * prop. Returns null for a non-object / shorthand / nested / empty object.
  */
 export function objectLiteralToGoMap(ctx: GoEmitContext, expr: ParsedExpr): string | null {
   if (expr.kind !== 'object-literal') return null
   const entries: string[] = []
   for (const prop of expr.properties) {
-    // Shorthand `{ a }` (identifier value) is unsupported.
     if (prop.shorthand) return null
-    // Scalar lowering (no typeInfo); a nested object/array value defers to null.
     const val = parsedLiteralToGo(ctx, prop.value)
     if (val === null) return null
     entries.push(`${JSON.stringify(prop.key)}: ${val}`)
@@ -141,13 +120,9 @@ export function objectLiteralToGoMap(ctx: GoEmitContext, expr: ParsedExpr): stri
 }
 
 /**
- * Get a signal's initial value as Go code — a literal (`0`, `true`, `"str"`) or
- * a props reference.
- *
- * @param propFallbackVars when the signal is `props.X ?? N` and the caller
- *   hoisted a fallback var for `X`, its name is returned so the memo inherits
- *   the signal-time fallback.
- * @returns the Go expression, or `0` for an unrecognized value
+ * Get a signal's initial value as Go code — a literal, or a props reference
+ * (`in.<Field>`, or the hoisted fallback var when `props.X ?? N` has one).
+ * Unrecognized values default to `0`.
  */
 export function getSignalInitialValueAsGo(
   ctx: GoEmitContext,
@@ -155,14 +130,12 @@ export function getSignalInitialValueAsGo(
   propsParams: { name: string }[],
   propFallbackVars: ReadonlyMap<string, PropFallbackVar> = EMPTY_PROP_FALLBACK_VARS,
 ): string {
-  // A bare props-param reference → its input field (or the hoisted fallback var).
   if (propsParams.some(p => p.name === initialValue)) {
     const hoisted = propFallbackVars.get(initialValue)
     if (hoisted) return hoisted.varName
     return `in.${capitalizeFieldName(initialValue)}`
   }
 
-  // `props.X ?? …` referencing a props param → its input field / fallback var.
   const propName = ctx.extractPropNameFromInitialValue(initialValue)
   if (propName && propsParams.some(p => p.name === propName)) {
     const hoisted = propFallbackVars.get(propName)
@@ -170,7 +143,7 @@ export function getSignalInitialValueAsGo(
     return `in.${capitalizeFieldName(propName)}`
   }
 
-  // Literals pass through (single quotes normalized to Go double quotes).
+  // single quotes are normalized to Go double quotes
   if (/^-?\d+$/.test(initialValue)) {
     return initialValue
   }


### PR DESCRIPTION
## Why

The go-template adapter's comments had drifted to ~38% of lines, weighted toward **implementation history** — PR/issue references (`#1407`, `#1672`, `#1897`, `#1945 review`, …), `former X` / `the old …` / `matching the old behaviour` notes, and line comments that merely paraphrase the code. That history belongs in git/PR, not the source. Meanwhile the **how-to-call** documentation was thin: **0 `@returns` across the entire package** before this.

## What

Comments-only cleanup across **20 files** in `src/adapter/`:

- **Removed**: historical / review / issue-number commentary, and code-paraphrasing line comments (`// Check if it's a number`, …).
- **Kept & restructured**: contracts, invariants, and traps (null/zero meaning, defer conditions, truthiness edge cases, byte-identity-sensitive guards) — rewritten as **one-line summary + non-obvious `@param` + `@returns`** (the return contract: what `null` / zero / special values mean).

Example (`value-lowering.ts`, the reference others were matched to):

```diff
-/**
- * Convert a fully-literal JS expression — carried as the analyzer's structured
- * `ParsedExpr` tree (#2006) — into an equivalent Go literal whose Go type
- * matches `typeInfo` (#1672), used to bake a signal's inline initial value …
- * Returns `null` — so the caller keeps `nil` — when no structured tree was
- * carried (the analyzer's `parseExpression` returned `unsupported`), or … [16 lines]
- */
+/**
+ * Lower a fully-literal value — from the analyzer's carried `ParsedExpr` tree —
+ * to a Go literal typed as `typeInfo`:
+ *   `["x","y"]` (string[]) → `[]string{"x", "y"}` …
+ * @returns `null` (→ caller keeps `nil`) when no tree was carried, the tree
+ *   isn't a pure literal, or it can't be expressed in the target Go type …
+ */
```

## Byte-identical

**Not a single identifier, expression, statement, type, or import changed** — verified per file (`git diff … | grep` for any non-comment changed line: empty for all 20). Comment lines **1460 → 1162 (-298)**.

- biome: clean
- build: green
- conformance: **786 pass**
- go units: **553 pass / 3 skip**

## Notes

- Comments-only, output unchanged → no changeset (no-changeset).
- `go-template-adapter.ts` (the ~1.8k-comment-line core file) is intentionally **out of scope here** and will be cleaned in a follow-up PR to keep this reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_