### PR TITLE
Implement shared Perl ParsedExpr evaluator (#2018, Track C)

### DIFF
--- a/.changeset/perl-eval.md
+++ b/.changeset/perl-eval.md
@@ -1,0 +1,28 @@
+---
+"@barefootjs/mojolicious": minor
+"@barefootjs/xslate": minor
+---
+
+Add the shared Perl ParsedExpr evaluator for both backends (#2018, Track C).
+
+`BarefootJS::Evaluator` lands in `packages/adapter-perl/lib/BarefootJS/`
+(the engine-agnostic core, alongside `SearchParams.pm`) as **one**
+implementation both the Mojo and Xslate backends share. It evaluates a
+pure `ParsedExpr` callback body (`reduce` / `sort` / `map` / `filter` /
+`find`) against an environment (`{acc, item, …captured free vars}`),
+plus `fold` / `sort_by` — the evaluator-driven generalization of the
+`bf->reduce` / `bf->sort` callback catalogue (any reducer / comparator
+body, lifting the op and pattern restrictions).
+
+The coercion is JS-faithful (ToNumber / ToString / ToBoolean, strict
+equality, `Math.round` half-toward-+Infinity) and deliberately distinct
+from the divergent `bf->string` / `number` helpers. It distinguishes a JS
+*string* `"10"` from a JS *number* `10` via SV flags, so relational
+comparison and the `+` overload match JS even for numeric strings —
+proven isomorphic with the Go evaluator by the shared Track A golden
+vectors (a new `t/eval_vectors.t` runs every `eval-vectors.json` case and
+matches the JS reference exactly; same input → same output as Go).
+
+Purely additive (core Perl only: `B` / `POSIX` / `Scalar::Util`); not yet
+wired into emit, so existing template output is unchanged. The emit
+migration is the follow-up integration (Track E).

--- a/packages/adapter-perl/lib/BarefootJS/Evaluator.pm
+++ b/packages/adapter-perl/lib/BarefootJS/Evaluator.pm
@@ -313,15 +313,21 @@ sub _math_round ($n) {
 
 sub _call_builtin ($name, $args) {
     if ($name eq 'Math.max') {
-        return 9**9**9 * -1 unless @$args;
-        my $m = _to_number($args->[0]);
-        for my $a (@$args[1 .. $#$args]) { my $n = _to_number($a); $m = $n if $n > $m }
+        my $m = -(9**9**9);    # JS Math.max() with no args is -Infinity
+        for my $a (@$args) {
+            my $n = _to_number($a);
+            return $n if $n != $n;    # any NaN argument ⇒ NaN (JS / Go)
+            $m = $n if $n > $m;
+        }
         return $m;
     }
     if ($name eq 'Math.min') {
-        return 9**9**9 unless @$args;
-        my $m = _to_number($args->[0]);
-        for my $a (@$args[1 .. $#$args]) { my $n = _to_number($a); $m = $n if $n < $m }
+        my $m = 9**9**9;       # JS Math.min() with no args is +Infinity
+        for my $a (@$args) {
+            my $n = _to_number($a);
+            return $n if $n != $n;    # any NaN argument ⇒ NaN (JS / Go)
+            $m = $n if $n < $m;
+        }
         return $m;
     }
     return abs(_to_number($args->[0]))          if $name eq 'Math.abs';

--- a/packages/adapter-perl/lib/BarefootJS/Evaluator.pm
+++ b/packages/adapter-perl/lib/BarefootJS/Evaluator.pm
@@ -1,0 +1,374 @@
+package BarefootJS::Evaluator;
+our $VERSION = "0.14.0";
+use strict;
+use warnings;
+use utf8;
+use feature 'signatures';
+no warnings 'experimental::signatures';
+use sort 'stable';
+
+use B ();
+use POSIX ();
+use Scalar::Util qw(looks_like_number);
+
+# Lightweight evaluator for the pure `ParsedExpr` subset, scoped to
+# higher-order callback bodies (reduce / sort / map / filter / find
+# `(…) => expr`) — issue #2018. Templates cannot carry a lambda in
+# expression position, which is why the adapters historically special-cased
+# these callbacks into fixed shapes (bf_sort's comparator catalogue,
+# bf_reduce's +/* fold). Instead, the callback BODY rides as a pure
+# `ParsedExpr` subtree (the structured IR the compiler already produces) and
+# is evaluated here against an environment (`{acc, item, …captured free
+# vars}`).
+#
+# ONE shared implementation for both Perl backends (Mojo + Xslate), living
+# alongside SearchParams.pm in the engine-agnostic core (no CPAN deps beyond
+# core B / POSIX / Scalar::Util). The accepted subset and its semantics are
+# documented in spec/compiler.md ("ParsedExpr Evaluator Semantics") and pinned
+# isomorphically by the cross-language golden vectors
+# (packages/adapter-tests/helper-vectors/eval-vectors.json), shared with the Go
+# evaluator (bf.go) — same input → same output.
+#
+# The coercion below is JS-faithful (ToNumber / ToString / ToBoolean, strict
+# equality) and deliberately distinct from the divergent bf->string / number
+# helpers in BarefootJS.pm, so the contract is unambiguous and the two
+# template adapters stay byte-equal with each other and with Go.
+
+# evaluate($node, $env)
+#
+# Evaluate a decoded ParsedExpr node (a hashref keyed by `kind`) against the
+# environment hashref ($env), returning a Perl value (number, string,
+# JSON::PP::Boolean, undef for null, arrayref, hashref). The matching JSON
+# entry point is eval_json() below.
+sub evaluate ($node, $env) {
+    return undef unless ref $node eq 'HASH';
+    my $kind = $node->{kind} // '';
+
+    if ($kind eq 'literal') {
+        return $node->{value};
+    }
+    if ($kind eq 'identifier') {
+        return $env->{ $node->{name} };
+    }
+    if ($kind eq 'binary') {
+        return _binary($node->{op},
+            evaluate($node->{left}, $env), evaluate($node->{right}, $env));
+    }
+    if ($kind eq 'unary') {
+        return _unary($node->{op}, evaluate($node->{argument}, $env));
+    }
+    if ($kind eq 'logical') {
+        my $op   = $node->{op};
+        my $left = evaluate($node->{left}, $env);
+        if ($op eq '&&') {
+            return _truthy($left) ? evaluate($node->{right}, $env) : $left;
+        }
+        if ($op eq '||') {
+            return _truthy($left) ? $left : evaluate($node->{right}, $env);
+        }
+        # `??`
+        return defined $left ? $left : evaluate($node->{right}, $env);
+    }
+    if ($kind eq 'conditional') {
+        return _truthy(evaluate($node->{test}, $env))
+            ? evaluate($node->{consequent}, $env)
+            : evaluate($node->{alternate}, $env);
+    }
+    if ($kind eq 'member') {
+        return _read_property(evaluate($node->{object}, $env), $node->{property});
+    }
+    if ($kind eq 'index-access') {
+        return _read_index(evaluate($node->{object}, $env), evaluate($node->{index}, $env));
+    }
+    if ($kind eq 'call') {
+        my $name = _builtin_name($node->{callee});
+        return undef unless defined $name && $name ne '';
+        my @args = map { evaluate($_, $env) } @{ $node->{args} // [] };
+        return _call_builtin($name, \@args);
+    }
+    if ($kind eq 'template-literal') {
+        my $out = '';
+        for my $p (@{ $node->{parts} // [] }) {
+            if (($p->{type} // '') eq 'string') {
+                $out .= $p->{value} // '';
+            }
+            else {
+                $out .= _to_string(evaluate($p->{expr}, $env));
+            }
+        }
+        return $out;
+    }
+    if ($kind eq 'array-literal') {
+        return [ map { evaluate($_, $env) } @{ $node->{elements} // [] } ];
+    }
+    if ($kind eq 'object-literal') {
+        my %out;
+        for my $prop (@{ $node->{properties} // [] }) {
+            $out{ $prop->{key} } = evaluate($prop->{value}, $env);
+        }
+        return \%out;
+    }
+
+    # arrow-fn / higher-order / array-method / unsupported: a callback body
+    # containing these is refused upstream (BF101); never reached here.
+    return undef;
+}
+
+# eval_json($json, $env): decode a ParsedExpr JSON string and evaluate it.
+# Mirrors the Go EvalExpr entry point. Requires JSON::PP only when used.
+sub eval_json ($json, $env) {
+    require JSON::PP;
+    my $node = JSON::PP->new->decode($json);
+    return evaluate($node, $env);
+}
+
+# ---------------------------------------------------------------------------
+# JS value classification. JSON-decoded strings carry the string flag (POK)
+# but no numeric flag; JSON-decoded numbers carry IOK/NOK. This lets the
+# evaluator tell the JS *string* "10" from the JS *number* 10 — essential for
+# the `+` overload and relational comparison — which looks_like_number alone
+# cannot (it is true for both).
+# ---------------------------------------------------------------------------
+
+sub _is_string ($v) {
+    return 0 if !defined $v || ref $v;
+    my $f = B::svref_2object(\$v)->FLAGS;
+    return (($f & B::SVf_POK) && !($f & (B::SVf_IOK | B::SVf_NOK))) ? 1 : 0;
+}
+
+sub _is_number ($v) {
+    return (defined $v && !ref $v && !_is_string($v)) ? 1 : 0;
+}
+
+sub _nan {
+    my $inf = 9**9**9;
+    return $inf - $inf;
+}
+
+# ---------------------------------------------------------------------------
+# JS coercion primitives (ToNumber / ToString / ToBoolean).
+# ---------------------------------------------------------------------------
+
+sub _to_number ($v) {
+    return 0 if !defined $v;
+    if (ref $v eq 'JSON::PP::Boolean') { return $v ? 1 : 0 }
+    return _nan() if ref $v;
+    if (_is_string($v)) {
+        my $t = $v;
+        $t =~ s/\A\s+//;
+        $t =~ s/\s+\z//;
+        return 0 if $t eq '';
+        return looks_like_number($t) ? ($t + 0) : _nan();
+    }
+    return $v + 0;
+}
+
+sub _to_string ($v) {
+    return 'null' if !defined $v;
+    if (ref $v eq 'JSON::PP::Boolean') { return $v ? 'true' : 'false' }
+    return "$v";
+}
+
+sub _truthy ($v) {
+    return 0 if !defined $v;
+    if (ref $v eq 'JSON::PP::Boolean') { return $v ? 1 : 0 }
+    return 1 if ref $v;    # arrays / objects are always truthy in JS
+    if (_is_string($v)) { return $v ne '' ? 1 : 0 }    # incl. the truthy "0"
+    my $n = $v + 0;
+    return ($n != 0 && $n == $n) ? 1 : 0;              # nonzero and not NaN
+}
+
+# ---------------------------------------------------------------------------
+# Operators
+# ---------------------------------------------------------------------------
+
+sub _binary ($op, $l, $r) {
+    if ($op eq '+') {
+        # JS `+`: string concatenation once either operand is a string,
+        # numeric addition otherwise.
+        return _to_string($l) . _to_string($r) if _is_string($l) || _is_string($r);
+        return _to_number($l) + _to_number($r);
+    }
+    return _to_number($l) - _to_number($r) if $op eq '-';
+    return _to_number($l) * _to_number($r) if $op eq '*';
+    return _to_number($l) / _to_number($r) if $op eq '/';
+    if ($op eq '%') {
+        my $rn = _to_number($r);
+        return _nan() if $rn == 0;
+        return POSIX::fmod(_to_number($l), $rn);
+    }
+    return _relational($op, $l, $r) if $op eq '<' || $op eq '<=' || $op eq '>' || $op eq '>=';
+    return _strict_eq($l, $r)       if $op eq '===';
+    return (_strict_eq($l, $r) ? 0 : 1) if $op eq '!==';
+    # Loose equality / bitwise / shift are out of the subset.
+    return undef;
+}
+
+sub _relational ($op, $l, $r) {
+    # JS Abstract Relational Comparison: both strings → compare by code unit;
+    # otherwise coerce both to numbers (a NaN operand makes it false).
+    my $c;
+    if (_is_string($l) && _is_string($r)) {
+        $c = $l lt $r ? -1 : $l gt $r ? 1 : 0;
+    }
+    else {
+        my $ln = _to_number($l);
+        my $rn = _to_number($r);
+        return 0 if $ln != $ln || $rn != $rn;    # NaN
+        $c = $ln < $rn ? -1 : $ln > $rn ? 1 : 0;
+    }
+    return ($c < 0  ? 1 : 0) if $op eq '<';
+    return ($c <= 0 ? 1 : 0) if $op eq '<=';
+    return ($c > 0  ? 1 : 0) if $op eq '>';
+    return ($c >= 0 ? 1 : 0) if $op eq '>=';
+    return 0;
+}
+
+sub _strict_eq ($l, $r) {
+    # Strict `===`: equal JS type and value, no coercion.
+    my $ln = _is_number($l);
+    my $rn = _is_number($r);
+    if ($ln && $rn) {
+        my ($lf, $rf) = ($l + 0, $r + 0);
+        return 0 if $lf != $lf || $rf != $rf;    # NaN
+        return $lf == $rf ? 1 : 0;
+    }
+    return 0 if $ln != $rn;    # one numeric, one not
+    if (!defined $l) { return !defined $r ? 1 : 0 }
+    return 0 if !defined $r;
+    my $lb = ref $l eq 'JSON::PP::Boolean';
+    my $rb = ref $r eq 'JSON::PP::Boolean';
+    if ($lb || $rb) {
+        return 0 unless $lb && $rb;
+        return ((!!$l) == (!!$r)) ? 1 : 0;
+    }
+    return ($l eq $r ? 1 : 0) if _is_string($l) && _is_string($r);
+    return 0;
+}
+
+sub _unary ($op, $v) {
+    return (_truthy($v) ? 0 : 1) if $op eq '!';
+    return -_to_number($v) if $op eq '-';
+    return _to_number($v)  if $op eq '+';
+    return undef;
+}
+
+# ---------------------------------------------------------------------------
+# Built-in calls (the deterministic allowlist). Locale-sensitive builtins
+# (localeCompare) are deliberately excluded to keep the backends isomorphic.
+# ---------------------------------------------------------------------------
+
+# _builtin_name: resolve a `call` callee to its builtin name (e.g.
+# "Math.max"), or '' when the callee is not an allowlisted builtin reference.
+sub _builtin_name ($callee) {
+    return '' unless ref $callee eq 'HASH';
+    my $kind = $callee->{kind} // '';
+    if ($kind eq 'identifier') {
+        return $callee->{name} // '';
+    }
+    if ($kind eq 'member' && !$callee->{computed}) {
+        my $obj = $callee->{object};
+        return '' unless ref $obj eq 'HASH' && ($obj->{kind} // '') eq 'identifier';
+        return ($obj->{name} // '') . '.' . ($callee->{property} // '');
+    }
+    return '';
+}
+
+# _math_round: half rounds toward +Infinity (JS Math.round: 2.5→3, -2.5→-2),
+# matching the existing round helper rather than half-away-from-zero.
+sub _math_round ($n) {
+    return POSIX::floor($n + 0.5);
+}
+
+sub _call_builtin ($name, $args) {
+    if ($name eq 'Math.max') {
+        return 9**9**9 * -1 unless @$args;
+        my $m = _to_number($args->[0]);
+        for my $a (@$args[1 .. $#$args]) { my $n = _to_number($a); $m = $n if $n > $m }
+        return $m;
+    }
+    if ($name eq 'Math.min') {
+        return 9**9**9 unless @$args;
+        my $m = _to_number($args->[0]);
+        for my $a (@$args[1 .. $#$args]) { my $n = _to_number($a); $m = $n if $n < $m }
+        return $m;
+    }
+    return abs(_to_number($args->[0]))          if $name eq 'Math.abs';
+    return POSIX::floor(_to_number($args->[0])) if $name eq 'Math.floor';
+    return POSIX::ceil(_to_number($args->[0]))  if $name eq 'Math.ceil';
+    return _math_round(_to_number($args->[0]))  if $name eq 'Math.round';
+    return _to_string($args->[0])              if $name eq 'String';
+    return _to_number($args->[0])              if $name eq 'Number';
+    return _truthy($args->[0])                 if $name eq 'Boolean';
+    # Any other callee is outside the subset (refused upstream).
+    return undef;
+}
+
+# ---------------------------------------------------------------------------
+# Member / index access
+# ---------------------------------------------------------------------------
+
+sub _read_property ($obj, $key) {
+    return undef unless defined $obj;
+    if (ref $obj eq 'HASH') {
+        return exists $obj->{$key} ? $obj->{$key} : undef;
+    }
+    if (ref $obj eq 'ARRAY') {
+        return $key eq 'length' ? scalar(@$obj) : undef;
+    }
+    return undef if ref $obj;
+    # plain scalar (string)
+    return length($obj) if $key eq 'length';
+    return undef;
+}
+
+sub _read_index ($obj, $index) {
+    if (ref $obj eq 'ARRAY') {
+        my $f = _to_number($index);
+        my $i = int($f);
+        return undef if $i != $f || $i < 0 || $i >= @$obj;
+        return $obj->[$i];
+    }
+    if (ref $obj eq 'HASH') {
+        return $obj->{ _to_string($index) };
+    }
+    return undef;
+}
+
+# ---------------------------------------------------------------------------
+# Evaluator-driven higher-order folds (the generalization of bf_reduce /
+# bf_sort onto the evaluator) — the runtime half both Perl backends share.
+# ---------------------------------------------------------------------------
+
+# fold($items, $body, $acc_name, $item_name, $init, $direction)
+#
+# Fold an arrayref into a value via the evaluator. The reducer $body is a
+# pure ParsedExpr node evaluated against `{$acc_name => acc, $item_name =>
+# item}` per element; $init seeds the accumulator and $direction is "left"
+# (reduce) or "right" (reduceRight). Generalizes bf_reduce — any reducer body,
+# not just the +/* arithmetic catalogue, and acc may appear anywhere.
+sub fold ($items, $body, $acc_name, $item_name, $init, $direction = 'left') {
+    my @arr = ref $items eq 'ARRAY' ? @$items : ();
+    @arr = reverse @arr if ($direction // '') eq 'right';
+    my $acc = $init;
+    for my $item (@arr) {
+        $acc = evaluate($body, { $acc_name => $acc, $item_name => $item });
+    }
+    return $acc;
+}
+
+# sort_by($items, $cmp, $param_a, $param_b)
+#
+# Return a new arrayref ordered by a ParsedExpr comparator $cmp evaluated
+# against `{$param_a => a, $param_b => b}` to a number (negative / zero /
+# positive, like a JS comparator). Generalizes bf_sort — any comparator body.
+# Stable (`use sort 'stable'`), non-mutating.
+sub sort_by ($items, $cmp, $param_a, $param_b) {
+    return undef unless ref $items eq 'ARRAY';
+    my @sorted = sort {
+        _to_number(evaluate($cmp, { $param_a => $a, $param_b => $b })) <=> 0
+    } @$items;
+    return \@sorted;
+}
+
+1;

--- a/packages/adapter-perl/lib/BarefootJS/Evaluator.pm
+++ b/packages/adapter-perl/lib/BarefootJS/Evaluator.pm
@@ -5,7 +5,6 @@ use warnings;
 use utf8;
 use feature 'signatures';
 no warnings 'experimental::signatures';
-use sort 'stable';
 
 use B ();
 use POSIX ();
@@ -410,7 +409,7 @@ sub fold ($items, $body, $acc_name, $item_name, $init, $direction = 'left', $bas
 # against `{$param_a => a, $param_b => b}` plus the captured free vars in
 # $base_env to a number (negative / zero / positive, like a JS comparator).
 # Generalizes bf_sort — any comparator body. $base_env is optional. Stable
-# (`use sort 'stable'`), non-mutating. Mirrors Go's SortEval.
+# and non-mutating. Mirrors Go's SortEval.
 sub sort_by ($items, $cmp, $param_a, $param_b, $base_env = undef) {
     # Non-array receiver → empty arrayref, matching the nil-tolerant
     # BarefootJS->sort helper convention (and avoiding an undef-deref footgun
@@ -418,17 +417,23 @@ sub sort_by ($items, $cmp, $param_a, $param_b, $base_env = undef) {
     # the Go SortEval, whose nil slice iterates as empty too.
     return [] unless ref $items eq 'ARRAY';
     my %env = $base_env ? %$base_env : ();
+    # Decorate each element with its original index and tie-break on it when
+    # the comparator returns 0, so stability is explicit and independent of
+    # the `sort` pragma / build (portable to the declared minimum Perl, and
+    # matching Go's sort.SliceStable).
+    my @decorated = map { [ $_, $items->[$_] ] } 0 .. $#$items;
     my @sorted = sort {
-        $env{$param_a} = $a;
-        $env{$param_b} = $b;
+        $env{$param_a} = $a->[1];
+        $env{$param_b} = $b->[1];
         my $c = _to_number(evaluate($cmp, \%env));
         # Explicit sign test rather than `<=> 0`: a NaN comparator result
         # warns / is undefined under `<=>`, whereas `< 0` / `> 0` are both
         # false for NaN, yielding 0 (no reordering) — matching JS (NaN
-        # comparator ⇒ keep order) and the Go SortEval sign test.
-        $c < 0 ? -1 : $c > 0 ? 1 : 0
-    } @$items;
-    return \@sorted;
+        # comparator ⇒ keep order) and the Go SortEval sign test. The
+        # original-index tie-break then preserves input order for equal keys.
+        ($c < 0 ? -1 : $c > 0 ? 1 : 0) || ($a->[0] <=> $b->[0])
+    } @decorated;
+    return [ map { $_->[1] } @sorted ];
 }
 
 1;

--- a/packages/adapter-perl/lib/BarefootJS/Evaluator.pm
+++ b/packages/adapter-perl/lib/BarefootJS/Evaluator.pm
@@ -9,6 +9,7 @@ use sort 'stable';
 
 use B ();
 use POSIX ();
+use JSON::PP ();
 use Scalar::Util qw(looks_like_number);
 
 # Lightweight evaluator for the pure `ParsedExpr` subset, scoped to
@@ -189,6 +190,13 @@ sub _truthy ($v) {
     return ($n != 0 && $n == $n) ? 1 : 0;              # nonzero and not NaN
 }
 
+# _bool: wrap a Perl truthy/falsy into a JS boolean (JSON::PP::Boolean), so
+# boolean-valued operators (relational, ===, !, Boolean()) return a real
+# boolean rather than 1/0 — matching the Go evaluator's bool (e.g.
+# String(a < b) is "true", and `'x' + (a < b)` is "xtrue"). The coercions
+# above already treat JSON::PP::Boolean correctly.
+sub _bool ($t) { $t ? JSON::PP::true() : JSON::PP::false() }
+
 # ---------------------------------------------------------------------------
 # Operators
 # ---------------------------------------------------------------------------
@@ -221,8 +229,8 @@ sub _binary ($op, $l, $r) {
         return POSIX::fmod(_to_number($l), $rn);
     }
     return _relational($op, $l, $r) if $op eq '<' || $op eq '<=' || $op eq '>' || $op eq '>=';
-    return _strict_eq($l, $r)       if $op eq '===';
-    return (_strict_eq($l, $r) ? 0 : 1) if $op eq '!==';
+    return _bool(_strict_eq($l, $r))  if $op eq '===';
+    return _bool(!_strict_eq($l, $r)) if $op eq '!==';
     # Loose equality / bitwise / shift are out of the subset.
     return undef;
 }
@@ -237,14 +245,14 @@ sub _relational ($op, $l, $r) {
     else {
         my $ln = _to_number($l);
         my $rn = _to_number($r);
-        return 0 if $ln != $ln || $rn != $rn;    # NaN
+        return _bool(0) if $ln != $ln || $rn != $rn;    # NaN → false
         $c = $ln < $rn ? -1 : $ln > $rn ? 1 : 0;
     }
-    return ($c < 0  ? 1 : 0) if $op eq '<';
-    return ($c <= 0 ? 1 : 0) if $op eq '<=';
-    return ($c > 0  ? 1 : 0) if $op eq '>';
-    return ($c >= 0 ? 1 : 0) if $op eq '>=';
-    return 0;
+    return _bool($c < 0)  if $op eq '<';
+    return _bool($c <= 0) if $op eq '<=';
+    return _bool($c > 0)  if $op eq '>';
+    return _bool($c >= 0) if $op eq '>=';
+    return _bool(0);
 }
 
 sub _strict_eq ($l, $r) {
@@ -270,7 +278,7 @@ sub _strict_eq ($l, $r) {
 }
 
 sub _unary ($op, $v) {
-    return (_truthy($v) ? 0 : 1) if $op eq '!';
+    return _bool(!_truthy($v)) if $op eq '!';
     return -_to_number($v) if $op eq '-';
     return _to_number($v)  if $op eq '+';
     return undef;
@@ -322,7 +330,7 @@ sub _call_builtin ($name, $args) {
     return _math_round(_to_number($args->[0]))  if $name eq 'Math.round';
     return _to_string($args->[0])              if $name eq 'String';
     return _to_number($args->[0])              if $name eq 'Number';
-    return _truthy($args->[0])                 if $name eq 'Boolean';
+    return _bool(_truthy($args->[0]))          if $name eq 'Boolean';
     # Any other callee is outside the subset (refused upstream).
     return undef;
 }
@@ -340,8 +348,11 @@ sub _read_property ($obj, $key) {
         return $key eq 'length' ? scalar(@$obj) : undef;
     }
     return undef if ref $obj;
-    # plain scalar (string)
-    return length($obj) if $key eq 'length';
+    # `.length` is a string property only — a numeric scalar (123) has no
+    # `.length` in the subset (JS `(123).length` is undefined → null), so
+    # guard on _is_string rather than coercing the number to a string.
+    # Matches the Go evaluator (numbers fall through to nil there).
+    return length($obj) if $key eq 'length' && _is_string($obj);
     return undef;
 }
 
@@ -400,7 +411,12 @@ sub sort_by ($items, $cmp, $param_a, $param_b, $base_env = undef) {
     my @sorted = sort {
         $env{$param_a} = $a;
         $env{$param_b} = $b;
-        _to_number(evaluate($cmp, \%env)) <=> 0
+        my $c = _to_number(evaluate($cmp, \%env));
+        # Explicit sign test rather than `<=> 0`: a NaN comparator result
+        # warns / is undefined under `<=>`, whereas `< 0` / `> 0` are both
+        # false for NaN, yielding 0 (no reordering) — matching JS (NaN
+        # comparator ⇒ keep order) and the Go SortEval sign test.
+        $c < 0 ? -1 : $c > 0 ? 1 : 0
     } @$items;
     return \@sorted;
 }

--- a/packages/adapter-perl/lib/BarefootJS/Evaluator.pm
+++ b/packages/adapter-perl/lib/BarefootJS/Evaluator.pm
@@ -412,7 +412,11 @@ sub fold ($items, $body, $acc_name, $item_name, $init, $direction = 'left', $bas
 # Generalizes bf_sort — any comparator body. $base_env is optional. Stable
 # (`use sort 'stable'`), non-mutating. Mirrors Go's SortEval.
 sub sort_by ($items, $cmp, $param_a, $param_b, $base_env = undef) {
-    return undef unless ref $items eq 'ARRAY';
+    # Non-array receiver → empty arrayref, matching the nil-tolerant
+    # BarefootJS->sort helper convention (and avoiding an undef-deref footgun
+    # for callers that use the result as an arrayref). Value-compatible with
+    # the Go SortEval, whose nil slice iterates as empty too.
+    return [] unless ref $items eq 'ARRAY';
     my %env = $base_env ? %$base_env : ();
     my @sorted = sort {
         $env{$param_a} = $a;

--- a/packages/adapter-perl/lib/BarefootJS/Evaluator.pm
+++ b/packages/adapter-perl/lib/BarefootJS/Evaluator.pm
@@ -166,6 +166,17 @@ sub _to_number ($v) {
 sub _to_string ($v) {
     return 'null' if !defined $v;
     if (ref $v eq 'JSON::PP::Boolean') { return $v ? 'true' : 'false' }
+    # JS spells the non-finite doubles "Infinity" / "-Infinity" / "NaN";
+    # Perl stringifies them "Inf" / "-Inf" / "NaN", so the non-finite cases
+    # are pinned here to stay JS-faithful (and match the Go evaluator's
+    # evalToString). Finite numbers and strings fall through to plain
+    # interpolation.
+    if (_is_number($v)) {
+        my $n = $v + 0;
+        return 'NaN'       if $n != $n;
+        return 'Infinity'  if $n == 9**9**9;
+        return '-Infinity' if $n == -(9**9**9);
+    }
     return "$v";
 }
 
@@ -191,7 +202,19 @@ sub _binary ($op, $l, $r) {
     }
     return _to_number($l) - _to_number($r) if $op eq '-';
     return _to_number($l) * _to_number($r) if $op eq '*';
-    return _to_number($l) / _to_number($r) if $op eq '/';
+    if ($op eq '/') {
+        my $ln = _to_number($l);
+        my $rn = _to_number($r);
+        # JS division by zero is finite-valued, not an error: x/0 is ±Infinity
+        # (NaN for 0/0). Perl's native `/` dies on a zero divisor, so guard it
+        # to stay JS-faithful and match the Go evaluator (Go float division
+        # already yields ±Inf / NaN).
+        if ($rn == 0) {
+            return _nan() if $ln == 0 || $ln != $ln;
+            return $ln > 0 ? 9**9**9 : -(9**9**9);
+        }
+        return $ln / $rn;
+    }
     if ($op eq '%') {
         my $rn = _to_number($r);
         return _nan() if $rn == 0;

--- a/packages/adapter-perl/lib/BarefootJS/Evaluator.pm
+++ b/packages/adapter-perl/lib/BarefootJS/Evaluator.pm
@@ -363,33 +363,44 @@ sub _read_index ($obj, $index) {
 # bf_sort onto the evaluator) — the runtime half both Perl backends share.
 # ---------------------------------------------------------------------------
 
-# fold($items, $body, $acc_name, $item_name, $init, $direction)
+# fold($items, $body, $acc_name, $item_name, $init, $direction, $base_env)
 #
 # Fold an arrayref into a value via the evaluator. The reducer $body is a
 # pure ParsedExpr node evaluated against `{$acc_name => acc, $item_name =>
-# item}` per element; $init seeds the accumulator and $direction is "left"
-# (reduce) or "right" (reduceRight). Generalizes bf_reduce — any reducer body,
-# not just the +/* arithmetic catalogue, and acc may appear anywhere.
-sub fold ($items, $body, $acc_name, $item_name, $init, $direction = 'left') {
+# item}` plus the captured free vars in $base_env per element; $init seeds the
+# accumulator and $direction is "left" (reduce) or "right" (reduceRight).
+# Generalizes bf_reduce — any reducer body, not just the +/* arithmetic
+# catalogue, and acc may appear anywhere. $base_env is optional; the
+# acc/item keys shadow any same-named base key. Mirrors Go's FoldEval.
+sub fold ($items, $body, $acc_name, $item_name, $init, $direction = 'left', $base_env = undef) {
     my @arr = ref $items eq 'ARRAY' ? @$items : ();
     @arr = reverse @arr if ($direction // '') eq 'right';
+    # Seed the env from the captured free vars once; acc / item are
+    # overwritten each iteration (constant base keys carry through).
+    my %env = $base_env ? %$base_env : ();
     my $acc = $init;
     for my $item (@arr) {
-        $acc = evaluate($body, { $acc_name => $acc, $item_name => $item });
+        $env{$acc_name}  = $acc;
+        $env{$item_name} = $item;
+        $acc = evaluate($body, \%env);
     }
     return $acc;
 }
 
-# sort_by($items, $cmp, $param_a, $param_b)
+# sort_by($items, $cmp, $param_a, $param_b, $base_env)
 #
 # Return a new arrayref ordered by a ParsedExpr comparator $cmp evaluated
-# against `{$param_a => a, $param_b => b}` to a number (negative / zero /
-# positive, like a JS comparator). Generalizes bf_sort — any comparator body.
-# Stable (`use sort 'stable'`), non-mutating.
-sub sort_by ($items, $cmp, $param_a, $param_b) {
+# against `{$param_a => a, $param_b => b}` plus the captured free vars in
+# $base_env to a number (negative / zero / positive, like a JS comparator).
+# Generalizes bf_sort — any comparator body. $base_env is optional. Stable
+# (`use sort 'stable'`), non-mutating. Mirrors Go's SortEval.
+sub sort_by ($items, $cmp, $param_a, $param_b, $base_env = undef) {
     return undef unless ref $items eq 'ARRAY';
+    my %env = $base_env ? %$base_env : ();
     my @sorted = sort {
-        _to_number(evaluate($cmp, { $param_a => $a, $param_b => $b })) <=> 0
+        $env{$param_a} = $a;
+        $env{$param_b} = $b;
+        _to_number(evaluate($cmp, \%env)) <=> 0
     } @$items;
     return \@sorted;
 }

--- a/packages/adapter-perl/t/eval_vectors.t
+++ b/packages/adapter-perl/t/eval_vectors.t
@@ -75,6 +75,10 @@ sub _match {
         return $got == ($kind eq 'Infinity' ? $inf : -$inf) ? 1 : 0;
     }
     if (JSON::PP::is_bool($expect)) {
+        # The result must itself be a JS boolean (JSON::PP::Boolean), not a
+        # truthy/falsy 1/0 — otherwise a boolean-valued expression returning
+        # the number 1 instead of `true` would pass and mask the divergence.
+        return 0 unless JSON::PP::is_bool($got);
         return (!!$got eq !!$expect) ? 1 : 0;
     }
     if (ref $expect eq 'ARRAY') {

--- a/packages/adapter-perl/t/eval_vectors.t
+++ b/packages/adapter-perl/t/eval_vectors.t
@@ -4,6 +4,7 @@ use Test::More;
 use FindBin;
 use File::Spec;
 use JSON::PP ();
+use B ();
 use Scalar::Util qw(looks_like_number);
 
 use lib "$FindBin::Bin/../lib";
@@ -49,6 +50,17 @@ for my $case (@{ $doc->{cases} }) {
 
 done_testing;
 
+# _is_real_number: true only when the scalar is an actual number (SV carries
+# IOK/NOK), NOT a numeric-looking string. JSON::PP decodes a JSON number to
+# IOK/NOK and a JSON string to a POK-only scalar, so this tells the JS *number*
+# 42 from the JS *string* "42" — the distinction the evaluator must preserve.
+# (looks_like_number can't: it is true for the string "42" too.)
+sub _is_real_number {
+    my ($v) = @_;
+    return 0 unless defined $v && !ref $v;
+    return (B::svref_2object(\$v)->FLAGS & (B::SVf_IOK | B::SVf_NOK)) ? 1 : 0;
+}
+
 # _match: boolean form of the spec's value-compat comparison against a
 # JSON-decoded expect — non-finite sentinel hashes, booleans by truthiness,
 # numbers numerically, arrays/hashes recursively, strings by eq.
@@ -79,7 +91,12 @@ sub _match {
         return 1;
     }
     return 0 if !defined $got || ref $got;
-    return ($got == $expect ? 1 : 0) if looks_like_number($expect) && looks_like_number($got);
+    # Numeric == only when BOTH are real numbers (not numeric-looking strings),
+    # so a string-vs-number mismatch fails: e.g. String(42) must return the
+    # string "42", and the evaluator returning the number 42 must NOT pass.
+    my $want_num = _is_real_number($expect);
+    return 0 if $want_num != _is_real_number($got);
+    return ($got == $expect ? 1 : 0) if $want_num;
     return ($got eq $expect) ? 1 : 0;
 }
 

--- a/packages/adapter-perl/t/eval_vectors.t
+++ b/packages/adapter-perl/t/eval_vectors.t
@@ -1,0 +1,92 @@
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+use File::Spec;
+use JSON::PP ();
+use Scalar::Util qw(looks_like_number);
+
+use lib "$FindBin::Bin/../lib";
+use BarefootJS::Evaluator;
+
+# Golden ParsedExpr-evaluator vectors (issue #2018, spec/compiler.md
+# "ParsedExpr Evaluator Semantics"), generated from the JS reference
+# evaluator and shared with the Go evaluator. The file is not shipped in
+# the CPAN dist — packages/adapter-tests only exists in a monorepo
+# checkout — so skip everywhere else.
+my $vectors_path = File::Spec->catfile(
+    $FindBin::Bin, '..', '..', 'adapter-tests', 'helper-vectors', 'eval-vectors.json'
+);
+plan skip_all => 'eval vectors not available outside the monorepo checkout'
+    unless -e $vectors_path;
+
+my $doc = do {
+    open my $fh, '<:raw', $vectors_path or die "open $vectors_path: $!";
+    local $/;
+    JSON::PP->new->decode(<$fh>);
+};
+
+die "eval-vectors.json contains no cases" unless @{ $doc->{cases} || [] };
+
+# The evaluator is JS-faithful by contract, so there are NO Perl-side
+# divergences here (unlike the bf->string / number helper vectors). Each
+# case's real ParsedExpr tree, evaluated against its environment, must
+# reproduce the JS-computed expect exactly — same input → same output as Go.
+for my $case (@{ $doc->{cases} }) {
+    my $note   = $case->{note};
+    my $expr   = $case->{expr};
+    my $env    = $case->{env};
+    my $expect = $case->{expect};
+
+    my $got = eval { BarefootJS::Evaluator::evaluate($expr, $env) };
+    if (my $err = $@) {
+        fail("$note died: $err");
+        next;
+    }
+    ok(_match($got, $expect), $note)
+        or diag('got ' . explain_value($got) . ', want ' . explain_value($expect));
+}
+
+done_testing;
+
+# _match: boolean form of the spec's value-compat comparison against a
+# JSON-decoded expect — non-finite sentinel hashes, booleans by truthiness,
+# numbers numerically, arrays/hashes recursively, strings by eq.
+sub _match {
+    my ($got, $expect) = @_;
+    return !defined $got if !defined $expect;
+    if (ref $expect eq 'HASH' && exists $expect->{'$num'}) {
+        my $kind = $expect->{'$num'};
+        return 0 unless defined $got && looks_like_number($got);
+        return $got != $got ? 1 : 0 if $kind eq 'NaN';
+        my $inf = 9**9**9;
+        return $got == ($kind eq 'Infinity' ? $inf : -$inf) ? 1 : 0;
+    }
+    if (JSON::PP::is_bool($expect)) {
+        return (!!$got eq !!$expect) ? 1 : 0;
+    }
+    if (ref $expect eq 'ARRAY') {
+        return 0 unless ref $got eq 'ARRAY' && @$got == @$expect;
+        _match($got->[$_], $expect->[$_]) or return 0 for 0 .. $#$expect;
+        return 1;
+    }
+    if (ref $expect eq 'HASH') {
+        return 0 unless ref $got eq 'HASH' && keys %$got == keys %$expect;
+        for my $k (keys %$expect) {
+            return 0 unless exists $got->{$k};
+            _match($got->{$k}, $expect->{$k}) or return 0;
+        }
+        return 1;
+    }
+    return 0 if !defined $got || ref $got;
+    return ($got == $expect ? 1 : 0) if looks_like_number($expect) && looks_like_number($got);
+    return ($got eq $expect) ? 1 : 0;
+}
+
+sub explain_value {
+    my ($v) = @_;
+    return 'undef' unless defined $v;
+    return JSON::PP->new->canonical->allow_nonref->allow_blessed->convert_blessed->encode($v)
+        if ref $v;
+    return "'$v'";
+}

--- a/packages/adapter-perl/t/evaluator.t
+++ b/packages/adapter-perl/t/evaluator.t
@@ -65,4 +65,26 @@ subtest 'sort_by: descending via a reversed comparator' => sub {
     is_deeply([ map { $_->{x} } @$sorted ], [ 30, 20, 10 ], 'descending by x');
 };
 
+# Non-finite coercion stays JS-faithful (and matches the Go evaluator):
+# division by zero is ±Infinity / NaN rather than a Perl die, and those
+# values stringify as "Infinity" / "-Infinity" / "NaN" (not Perl's "Inf").
+subtest 'non-finite: division by zero and JS stringification' => sub {
+    my $div = sub {
+        my ($a, $b) = @_;
+        BarefootJS::Evaluator::evaluate(
+            nbin('/', { kind => 'identifier', name => 'a' }, { kind => 'identifier', name => 'b' }),
+            { a => $a, b => $b },
+        );
+    };
+    my $inf = 9**9**9;
+    is($div->(1, 0),  $inf,  '1/0 is +Infinity, not a die');
+    is($div->(-1, 0), -$inf, '-1/0 is -Infinity');
+    my $nan = $div->(0, 0);
+    ok($nan != $nan, '0/0 is NaN');
+
+    is(BarefootJS::Evaluator::_to_string($inf),    'Infinity',  'String(Infinity)');
+    is(BarefootJS::Evaluator::_to_string(-$inf),   '-Infinity', 'String(-Infinity)');
+    is(BarefootJS::Evaluator::_to_string($inf - $inf), 'NaN',   'String(NaN)');
+};
+
 done_testing;

--- a/packages/adapter-perl/t/evaluator.t
+++ b/packages/adapter-perl/t/evaluator.t
@@ -134,4 +134,12 @@ subtest 'boolean-valued ops return JS booleans, not 1/0' => sub {
     ok(!defined $len, '(123).length is null, not 3');
 };
 
+# sort_by tolerates a non-array receiver by returning an empty arrayref (the
+# BarefootJS->sort convention), never undef — so callers can always deref it.
+subtest 'sort_by non-array receiver returns []' => sub {
+    my $cmp = nbin('-', nid('a'), nid('b'));
+    is_deeply(BarefootJS::Evaluator::sort_by(undef, $cmp, 'a', 'b'), [], 'undef receiver → []');
+    is_deeply(BarefootJS::Evaluator::sort_by(42, $cmp, 'a', 'b'), [], 'scalar receiver → []');
+};
+
 done_testing;

--- a/packages/adapter-perl/t/evaluator.t
+++ b/packages/adapter-perl/t/evaluator.t
@@ -142,4 +142,21 @@ subtest 'sort_by non-array receiver returns []' => sub {
     is_deeply(BarefootJS::Evaluator::sort_by(42, $cmp, 'a', 'b'), [], 'scalar receiver → []');
 };
 
+# sort_by is stable: equal-comparing elements keep their input order. The
+# explicit index tie-break makes this independent of the `sort` pragma /
+# build, matching Go's sort.SliceStable.
+subtest 'sort_by is stable for equal keys' => sub {
+    my $cmp = nbin('-', nmem(nid('a'), 'k'), nmem(nid('b'), 'k'));
+    # All-equal keys → input order preserved.
+    my $eq = BarefootJS::Evaluator::sort_by(
+        [ { k => 1, id => 'a' }, { k => 1, id => 'b' }, { k => 1, id => 'c' } ],
+        $cmp, 'a', 'b');
+    is_deeply([ map { $_->{id} } @$eq ], [ 'a', 'b', 'c' ], 'equal keys keep input order');
+    # Mixed keys → sorted by key, ties stable (x before z).
+    my $mixed = BarefootJS::Evaluator::sort_by(
+        [ { k => 2, id => 'x' }, { k => 1, id => 'y' }, { k => 2, id => 'z' } ],
+        $cmp, 'a', 'b');
+    is_deeply([ map { $_->{id} } @$mixed ], [ 'y', 'x', 'z' ], 'tie (x,z) stays in input order');
+};
+
 done_testing;

--- a/packages/adapter-perl/t/evaluator.t
+++ b/packages/adapter-perl/t/evaluator.t
@@ -87,4 +87,21 @@ subtest 'non-finite: division by zero and JS stringification' => sub {
     is(BarefootJS::Evaluator::_to_string($inf - $inf), 'NaN',   'String(NaN)');
 };
 
+# Captured free vars flow through $base_env (mirrors the Go FoldEval/SortEval
+# baseEnv test) — a reducer / comparator body can reference an outer const.
+subtest 'captured free vars via base_env' => sub {
+    # reduce: acc + item * factor, with `factor` captured.
+    my $body = nbin('+', nid('acc'), nbin('*', nid('item'), nid('factor')));
+    my $sum = BarefootJS::Evaluator::fold([1, 2, 3], $body, 'acc', 'item', 0, 'left', { factor => 10 });
+    is($sum, 60, '0 + 1*10 + 2*10 + 3*10 with captured factor');
+
+    # sort by distance from a captured `pivot`: |a-pivot| - |b-pivot|.
+    my $cmp = nbin('-',
+        ncall_math('abs', nbin('-', nid('a'), nid('pivot'))),
+        ncall_math('abs', nbin('-', nid('b'), nid('pivot'))),
+    );
+    my $sorted = BarefootJS::Evaluator::sort_by([1, 8, 4], $cmp, 'a', 'b', { pivot => 5 });
+    is_deeply($sorted, [4, 8, 1], 'ascending by distance from captured pivot');
+};
+
 done_testing;

--- a/packages/adapter-perl/t/evaluator.t
+++ b/packages/adapter-perl/t/evaluator.t
@@ -1,0 +1,68 @@
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+
+use lib "$FindBin::Bin/../lib";
+use BarefootJS::Evaluator;
+
+# Hand-built ParsedExpr constructors for the fold / sort_by trees, mirroring
+# the Go eval_test.go demonstrations so the two backends prove the SAME
+# restriction-lifting on the SAME shapes.
+sub nid  { return { kind => 'identifier', name => $_[0] } }
+sub nmem { return { kind => 'member', object => $_[0], property => $_[1], computed => JSON_false() } }
+sub nbin { return { kind => 'binary', op => $_[0], left => $_[1], right => $_[2] } }
+
+sub ncall_math {
+    my ($fn, $arg) = @_;
+    return { kind => 'call', callee => nmem(nid('Math'), $fn), args => [$arg] };
+}
+
+# A plain false for the `computed` flag; the evaluator only checks truthiness.
+sub JSON_false { return 0 }
+
+# fold lifts bf_reduce's op restriction and acc-canonical form: a reducer body
+# that mixes acc with a product of two fields is impossible in the +/*
+# self/field catalogue but trivial for the evaluator.
+subtest 'fold: arbitrary reducer body (acc + item.price * item.qty)' => sub {
+    my $body = nbin('+',
+        nid('acc'),
+        nbin('*', nmem(nid('item'), 'price'), nmem(nid('item'), 'qty')),
+    );
+    my $items = [ { price => 5, qty => 3 }, { price => 2, qty => 4 } ];
+    is(BarefootJS::Evaluator::fold($items, $body, 'acc', 'item', 0, 'left'),
+        23, '0 + 5*3 + 2*4');
+};
+
+# reduceRight is observable for string concatenation; the same body folds both
+# directions.
+subtest 'fold: direction is observable for string concat' => sub {
+    my $body  = nbin('+', nid('acc'), nid('item'));
+    my $items = [ 'a', 'b', 'c' ];
+    is(BarefootJS::Evaluator::fold($items, $body, 'acc', 'item', '', 'left'),  'abc', 'left');
+    is(BarefootJS::Evaluator::fold($items, $body, 'acc', 'item', '', 'right'), 'cba', 'right');
+};
+
+# sort_by lifts bf_sort's comparator pattern restriction: a comparator that
+# calls Math.abs on each operand's field is outside the subtraction /
+# localeCompare / relational-ternary catalogue, but is just another pure
+# expression to the evaluator.
+subtest 'sort_by: arbitrary comparator body (abs-of-field difference)' => sub {
+    my $cmp = nbin('-',
+        ncall_math('abs', nmem(nid('a'), 'v')),
+        ncall_math('abs', nmem(nid('b'), 'v')),
+    );
+    my $items  = [ { v => -5 }, { v => 3 }, { v => -1 } ];
+    my $sorted = BarefootJS::Evaluator::sort_by($items, $cmp, 'a', 'b');
+    is_deeply([ map { $_->{v} } @$sorted ], [ -1, 3, -5 ], 'ascending by |v|');
+};
+
+# Descending is just a reversed comparator body — no separate direction knob.
+subtest 'sort_by: descending via a reversed comparator' => sub {
+    my $cmp = nbin('-', nmem(nid('b'), 'x'), nmem(nid('a'), 'x'));
+    my $items  = [ { x => 10 }, { x => 30 }, { x => 20 } ];
+    my $sorted = BarefootJS::Evaluator::sort_by($items, $cmp, 'a', 'b');
+    is_deeply([ map { $_->{x} } @$sorted ], [ 30, 20, 10 ], 'descending by x');
+};
+
+done_testing;

--- a/packages/adapter-perl/t/evaluator.t
+++ b/packages/adapter-perl/t/evaluator.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use Test::More;
 use FindBin;
+use JSON::PP ();
 
 use lib "$FindBin::Bin/../lib";
 use BarefootJS::Evaluator;
@@ -12,6 +13,7 @@ use BarefootJS::Evaluator;
 sub nid  { return { kind => 'identifier', name => $_[0] } }
 sub nmem { return { kind => 'member', object => $_[0], property => $_[1], computed => JSON_false() } }
 sub nbin { return { kind => 'binary', op => $_[0], left => $_[1], right => $_[2] } }
+sub nstr { return { kind => 'literal', value => $_[0], literalType => 'string' } }
 
 sub ncall_math {
     my ($fn, $arg) = @_;
@@ -102,6 +104,34 @@ subtest 'captured free vars via base_env' => sub {
     );
     my $sorted = BarefootJS::Evaluator::sort_by([1, 8, 4], $cmp, 'a', 'b', { pivot => 5 });
     is_deeply($sorted, [4, 8, 1], 'ascending by distance from captured pivot');
+};
+
+# Boolean-valued operators return JS booleans (JSON::PP::Boolean), not 1/0 —
+# matching the Go evaluator, so they stringify "true"/"false" and concatenate
+# as JS does.
+subtest 'boolean-valued ops return JS booleans, not 1/0' => sub {
+    my $lt = BarefootJS::Evaluator::evaluate(nbin('<', nid('a'), nid('b')), { a => 1, b => 2 });
+    ok(JSON::PP::is_bool($lt), 'a < b is a JS boolean');
+    is(BarefootJS::Evaluator::_to_string($lt), 'true', 'String(a < b) is "true", not "1"');
+
+    my $cat = BarefootJS::Evaluator::evaluate(
+        nbin('+', nstr('x'), nbin('<', nid('a'), nid('b'))), { a => 1, b => 2 });
+    is($cat, 'xtrue', "'x' + (a < b) is 'xtrue', not 'x1'");
+
+    my $eq = BarefootJS::Evaluator::evaluate(nbin('===', nid('a'), nid('b')), { a => 1, b => 1 });
+    ok(JSON::PP::is_bool($eq), '1 === 1 is a JS boolean');
+
+    my $not = BarefootJS::Evaluator::evaluate({ kind => 'unary', op => '!', argument => nstr('') }, {});
+    is(BarefootJS::Evaluator::_to_string($not), 'true', 'String(!"") is "true"');
+
+    my $b = BarefootJS::Evaluator::evaluate(
+        { kind => 'call', callee => nid('Boolean'), args => [nstr('')] }, {});
+    ok(JSON::PP::is_bool($b), 'Boolean("") is a JS boolean');
+    is(BarefootJS::Evaluator::_to_string($b), 'false', 'String(Boolean("")) is "false", not "0"');
+
+    # `.length` is a string/array property only; a numeric scalar has none.
+    my $len = BarefootJS::Evaluator::evaluate(nmem(nid('n'), 'length'), { n => 123 });
+    ok(!defined $len, '(123).length is null, not 3');
 };
 
 done_testing;


### PR DESCRIPTION
## Track C of #2018 — the shared Perl evaluator

> **Track A (#2019) is now merged.** This PR is rebased onto `main`, so its diff is just the Perl module + tests.

Implements the lightweight `ParsedExpr` evaluator in Perl as **one shared implementation for both the Mojo and Xslate backends**, proven isomorphic with the Go evaluator (Track B, #2021) via Track A's golden vectors.

### What's here

- **`packages/adapter-perl/lib/BarefootJS/Evaluator.pm`** — lands in the engine-agnostic core alongside `SearchParams.pm` (so both `BarefootJS::Backend::Mojo` and `BarefootJS::Backend::Xslate` build on it), core Perl only (`B` / `POSIX` / `Scalar::Util`).
  - `evaluate($node, $env)` / `eval_json($json, $env)` — evaluate a pure `ParsedExpr` callback body against `{acc, item, …captured free vars}`.
  - `fold` / `sort_by` — the evaluator-driven generalization of `bf->reduce` / `bf->sort` (any reducer/comparator body; lifts the op and comparator-pattern restrictions), mirroring Go's `FoldEval` / `SortEval`.
- **`t/eval_vectors.t`** — runs every `eval-vectors.json` case and matches the JS-computed `expect` with **no Perl-side divergence**.
- **`t/evaluator.t`** — `fold`/`sort_by` exercise reducer/comparator bodies the old catalogue couldn't express, using the **same trees and inputs as the Go `eval_test.go`**.

### The key isomorphism problem (and its fix)

Perl scalars don't natively distinguish the JS *string* `"10"` from the JS *number* `10` — and `looks_like_number` is true for both, so it can't either. That matters: `'10' < '9'` is **`true`** in JS (lexical string compare) but a numeric compare would give `false`. The evaluator inspects **SV flags** (`B::svref_2object`) — a JSON-decoded string carries `SVf_POK` without `SVf_IOK`/`SVf_NOK`; a number carries the numeric flag — so relational comparison and the `+` overload match JS exactly, even for numeric strings. The coercion (ToNumber / ToString / ToBoolean, strict-only equality, `Math.round` half-toward-+Infinity) is JS-faithful and deliberately distinct from the divergent `bf->string` / `number` helpers.

### Completion criteria (per the goal)

- ✅ **Perl vectors all green** — `t/eval_vectors.t` passes all 66 cases (0 `not ok`).
- ✅ **Same input → same output, Go and Perl** — both backends pass the identical `eval-vectors.json`; `t/evaluator.t` and Go's `eval_test.go` drive the identical `fold`/`sort_by` trees to identical results.
- ✅ **Usable by both backends** — placed in the shared `adapter-perl/lib` core, core-Perl-only, stateless functions.
- ✅ Purely additive — not wired into emit, so existing template output is unchanged.

### Verification

```
cd packages/adapter-perl
perl -c lib/BarefootJS/Evaluator.pm        # syntax OK
prove -l t/eval_vectors.t t/evaluator.t    # All tests successful (70 assertions)
```

(The repo's other `t/*.t` need `Test2::V0` / Mojo, which aren't installed in this sandbox; both new tests use core `Test::More` like `t/helper_vectors.t`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)