### PR TITLE
refactor(mojo,xslate): lower spreads from IR ParsedExpr, drop emit-time re-parse (#2018)

### DIFF
--- a/.changeset/mojo-xslate-parsedexpr.md
+++ b/.changeset/mojo-xslate-parsedexpr.md
@@ -1,0 +1,6 @@
+---
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+---
+
+Lower conditional-spread and inline object-literal expressions from the IR-carried structured `ParsedExpr` tree instead of re-parsing source with `ts.createSourceFile` at emit time (#2018, mirroring go-template's U5/U6/Roadmap-A). Behaviour and output are unchanged — the condition and scalar values still route through `convertExpressionToPerl` / `convertExpressionToKolon`, which re-parse, so the emitted Perl/Kolon stays byte-identical. The now-orphaned `parsePureStringLiteral` (superseded by the shared `collectModuleStringConsts`) was removed from the Mojo adapter.

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -867,10 +867,13 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       }
       // Inline object-literal child prop (carousel's `opts={{ align: 'start' }}`):
       // lower to a Perl hashref so the child can serialize it (`data-opts`),
-      // instead of refusing the bare object with BF101. (#1971 Perl) Cheap `{`
-      // guard so the common non-object case skips the AST parse.
-      if (value.expr.trim().startsWith('{')) {
-        const hashref = objectLiteralExprToPerlHashref(this.spreadCtx, value.expr)
+      // instead of refusing the bare object with BF101. (#1971 Perl) Read the
+      // IR-carried structured `ParsedExpr` tree (#2018) instead of re-parsing
+      // `value.expr` with `ts.createSourceFile`; the lowering returns null for
+      // any non-object-literal shape, so the common non-object case falls
+      // straight through to the bare-expression path below.
+      if (value.parsed) {
+        const hashref = objectLiteralExprToPerlHashref(this.spreadCtx, value.parsed)
         if (hashref !== null) return `${perlHashKey(name)} => ${hashref}`
       }
       return `${perlHashKey(name)} => ${this.convertExpressionToPerl(value.expr)}`
@@ -1189,7 +1192,9 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       // OMITS the key (`bf->spread_attrs` does NOT filter empty
       // strings, so we cannot always-include it). Mirrors the Go
       // adapter's IIFE-of-maps lowering (#textarea).
-      const ternaryHashref = conditionalSpreadToPerl(this.spreadCtx, trimmed)
+      // Read the spread's IR-carried `ParsedExpr` tree (#2018) instead of
+      // re-parsing `trimmed` with `ts.createSourceFile`.
+      const ternaryHashref = conditionalSpreadToPerl(this.spreadCtx, value.parsed)
       if (ternaryHashref !== null) {
         return `<%== bf->spread_attrs(${ternaryHashref}) %>`
       }
@@ -1206,7 +1211,15 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
         if (localConst?.value !== undefined) {
           const initTrimmed = localConst.value.trim()
           if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(initTrimmed)) {
-            const resolved = conditionalSpreadToPerl(this.spreadCtx, initTrimmed)
+            // The local const's initializer text isn't carried as a structured
+            // tree on the spread attr, so parse it once via the shared
+            // `parseExpression` (the analyzer's own entry) — not
+            // `ts.createSourceFile` — mirroring go-template's same local-const
+            // resolution path.
+            const resolved = conditionalSpreadToPerl(
+              this.spreadCtx,
+              parseExpression(initTrimmed),
+            )
             if (resolved !== null) {
               return `<%== bf->spread_attrs(${resolved}) %>`
             }

--- a/packages/adapter-mojolicious/src/adapter/spread/spread-codegen.ts
+++ b/packages/adapter-mojolicious/src/adapter/spread/spread-codegen.ts
@@ -40,6 +40,11 @@ export function conditionalSpreadToPerl(
   if (whenTrue.kind !== 'object-literal' || whenFalse.kind !== 'object-literal') {
     return null
   }
+  // TODO(#2018): round-trip — the condition's `ParsedExpr` is re-stringified
+  // here and re-parsed inside `convertExpressionToPerl`. Retire once
+  // `convertExpressionToPerl` takes a `preParsed?: ParsedExpr` (cf.
+  // go-template's `convertExpressionToGo(jsExpr, out?, preParsed?)`), so the
+  // carried tree threads straight through instead of stringify→re-parse.
   const condPerl = ctx.convertExpressionToPerl(stringifyParsedExpr(expr.test))
   const truePerl = objectLiteralToPerlHashref(ctx, whenTrue)
   const falsePerl = objectLiteralToPerlHashref(ctx, whenFalse)
@@ -113,6 +118,9 @@ export function objectLiteralToPerlHashref(
     const valPerl =
       indexed !== null
         ? indexed
+        // TODO(#2018): round-trip — re-stringify + re-parse via
+        // `convertExpressionToPerl`. Thread the carried `val` tree directly once
+        // `convertExpressionToPerl` gains a `preParsed?: ParsedExpr` param.
         : ctx.convertExpressionToPerl(stringifyParsedExpr(val))
     entries.push(`'${key.replace(/'/g, "\\'")}' => ${valPerl}`)
   }

--- a/packages/adapter-mojolicious/src/adapter/spread/spread-codegen.ts
+++ b/packages/adapter-mojolicious/src/adapter/spread/spread-codegen.ts
@@ -7,57 +7,58 @@
  * `spreadCtx` getter) so the cluster depends on the narrow seam — the recursive
  * expression entry plus per-compile bookkeeping — rather than the whole
  * adapter class. Mirror of the Go adapter's `spread/spread-codegen.ts`.
+ *
+ * The conditional-spread / object-literal entries read the IR-carried
+ * structured `ParsedExpr` tree (#2018, mirroring go-template's U5/U6) instead
+ * of re-parsing the source with `ts.createSourceFile`. The condition and scalar
+ * values are re-stringified with `stringifyParsedExpr` and routed back through
+ * `ctx.convertExpressionToPerl`, which re-parses — so the emitted Perl stays
+ * byte-identical to the former AST-text path. The `ts.factory` rebuild in
+ * `recordIndexAccessToPerl` only reconstructs the `IDENT[KEY]` node the shared
+ * `parseRecordIndexAccess` parser accepts; no source-text re-parse.
  */
 
 import ts from 'typescript'
-import { parseRecordIndexAccess } from '@barefootjs/jsx'
+import { parseRecordIndexAccess, stringifyParsedExpr } from '@barefootjs/jsx'
+import type { ParsedExpr } from '@barefootjs/jsx'
 
 import type { MojoSpreadContext } from '../emit-context.ts'
 
 /**
- * Parse a `cond ? {…} : {…}` conditional-spread expression and lower it to a
- * Perl ternary over two hashrefs, or null when it isn't that shape.
+ * Lower a `cond ? {…} : {…}` conditional-spread expression — carried as the
+ * IR's structured `ParsedExpr` tree — to a Perl ternary over two hashrefs, or
+ * null when it isn't that shape. `parseExpression` already strips redundant
+ * parentheses, so the conditional / object-literal shapes surface directly.
  */
-export function conditionalSpreadToPerl(ctx: MojoSpreadContext, expr: string): string | null {
-  const sf = ts.createSourceFile('__spread.ts', `(${expr})`, ts.ScriptTarget.Latest, true)
-  if (sf.statements.length !== 1) return null
-  const stmt = sf.statements[0]
-  if (!ts.isExpressionStatement(stmt)) return null
-  let node: ts.Expression = stmt.expression
-  while (ts.isParenthesizedExpression(node)) node = node.expression
-  if (!ts.isConditionalExpression(node)) return null
-  const unwrap = (e: ts.Expression): ts.Expression => {
-    let n = e
-    while (ts.isParenthesizedExpression(n)) n = n.expression
-    return n
-  }
-  const whenTrue = unwrap(node.whenTrue)
-  const whenFalse = unwrap(node.whenFalse)
-  if (!ts.isObjectLiteralExpression(whenTrue) || !ts.isObjectLiteralExpression(whenFalse)) {
+export function conditionalSpreadToPerl(
+  ctx: MojoSpreadContext,
+  expr: ParsedExpr | undefined,
+): string | null {
+  if (!expr || expr.kind !== 'conditional') return null
+  const whenTrue = expr.consequent
+  const whenFalse = expr.alternate
+  if (whenTrue.kind !== 'object-literal' || whenFalse.kind !== 'object-literal') {
     return null
   }
-  const condPerl = ctx.convertExpressionToPerl(node.condition.getText(sf))
-  const truePerl = objectLiteralToPerlHashref(ctx, whenTrue, sf)
-  const falsePerl = objectLiteralToPerlHashref(ctx, whenFalse, sf)
+  const condPerl = ctx.convertExpressionToPerl(stringifyParsedExpr(expr.test))
+  const truePerl = objectLiteralToPerlHashref(ctx, whenTrue)
+  const falsePerl = objectLiteralToPerlHashref(ctx, whenFalse)
   if (truePerl === null || falsePerl === null) return null
   return `${condPerl} ? ${truePerl} : ${falsePerl}`
 }
 
 /**
- * (#1971 Perl) Parse a bare object-literal expression string
- * (`{ align: 'start' }`) and lower it to a Perl hashref via
- * `objectLiteralToPerlHashref`, or null when it isn't a plain object
- * literal. Used for inline object-literal child props (carousel `opts`).
+ * (#1971 Perl) Lower a bare object-literal expression (`{ align: 'start' }`),
+ * carried as the IR's structured `ParsedExpr` tree, to a Perl hashref via
+ * `objectLiteralToPerlHashref`, or null when it isn't a plain object literal.
+ * Used for inline object-literal child props (carousel `opts`).
  */
-export function objectLiteralExprToPerlHashref(ctx: MojoSpreadContext, expr: string): string | null {
-  const sf = ts.createSourceFile('__obj.ts', `(${expr})`, ts.ScriptTarget.Latest, true)
-  if (sf.statements.length !== 1) return null
-  const stmt = sf.statements[0]
-  if (!ts.isExpressionStatement(stmt)) return null
-  let node: ts.Expression = stmt.expression
-  while (ts.isParenthesizedExpression(node)) node = node.expression
-  if (!ts.isObjectLiteralExpression(node)) return null
-  return objectLiteralToPerlHashref(ctx, node, sf)
+export function objectLiteralExprToPerlHashref(
+  ctx: MojoSpreadContext,
+  expr: ParsedExpr | undefined,
+): string | null {
+  if (!expr || expr.kind !== 'object-literal') return null
+  return objectLiteralToPerlHashref(ctx, expr)
 }
 
 /**
@@ -68,32 +69,24 @@ export function objectLiteralExprToPerlHashref(ctx: MojoSpreadContext, expr: str
  */
 export function objectLiteralToPerlHashref(
   ctx: MojoSpreadContext,
-  obj: ts.ObjectLiteralExpression,
-  sf: ts.SourceFile,
+  obj: Extract<ParsedExpr, { kind: 'object-literal' }>,
 ): string | null {
   const entries: string[] = []
   for (const prop of obj.properties) {
-    if (!ts.isPropertyAssignment(prop)) return null
-    let key: string
-    if (ts.isIdentifier(prop.name)) {
-      key = prop.name.text
-    } else if (ts.isStringLiteral(prop.name) || ts.isNoSubstitutionTemplateLiteral(prop.name)) {
-      key = prop.name.text
-    } else {
-      return null
-    }
-    const initNode = (() => {
-      let n: ts.Expression = prop.initializer
-      while (ts.isParenthesizedExpression(n)) n = n.expression
-      return n
-    })()
-    const indexed = recordIndexAccessToPerl(ctx, initNode)
+    // Shorthand `{ a }` was a `ShorthandPropertyAssignment` (not a
+    // `PropertyAssignment`), so the former parser rejected it — keep refusing.
+    if (prop.shorthand) return null
+    // A numeric key (`{ 1: x }`) was rejected by the former parser (only
+    // identifier / string-literal names were accepted); `keyKind`
+    // distinguishes it from a same-text string `'1'` key.
+    if (prop.keyKind === 'numeric') return null
+    const key = prop.key
+    const val = prop.value
+    const indexed = recordIndexAccessToPerl(ctx, val)
     if (
       indexed === null &&
-      ts.isElementAccessExpression(initNode) &&
-      initNode.argumentExpression &&
-      !ts.isNumericLiteral(initNode.argumentExpression) &&
-      !ts.isStringLiteral(initNode.argumentExpression)
+      val.kind === 'index-access' &&
+      !isLiteralIndex(val.index)
     ) {
       // Variable-index record access (`sizeMap[size]`) that the
       // static-inline path couldn't resolve — a non-scalar record
@@ -109,7 +102,7 @@ export function objectLiteralToPerlHashref(
       ctx.errors.push({
         code: 'BF101',
         severity: 'error',
-        message: `Spread object value '${initNode.getText(sf)}' indexes a record map whose values aren't scalar literals — it can't lower to an inline Perl hashref.`,
+        message: `Spread object value '${stringifyParsedExpr(val)}' indexes a record map whose values aren't scalar literals — it can't lower to an inline Perl hashref.`,
         loc: { file: ctx.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
         suggestion: {
           message: 'Index a record whose values are number/string literals, or move the spread into a `\'use client\'` component so hydration computes it.',
@@ -120,10 +113,18 @@ export function objectLiteralToPerlHashref(
     const valPerl =
       indexed !== null
         ? indexed
-        : ctx.convertExpressionToPerl(prop.initializer.getText(sf))
+        : ctx.convertExpressionToPerl(stringifyParsedExpr(val))
     entries.push(`'${key.replace(/'/g, "\\'")}' => ${valPerl}`)
   }
   return entries.length === 0 ? '{}' : `{ ${entries.join(', ')} }`
+}
+
+/** True when a parsed index is a numeric or string literal (`arr[0]`, `m['k']`). */
+function isLiteralIndex(index: ParsedExpr): boolean {
+  return (
+    index.kind === 'literal' &&
+    (index.literalType === 'number' || index.literalType === 'string')
+  )
 }
 
 /**
@@ -140,11 +141,27 @@ export function objectLiteralToPerlHashref(
  * falls back to its normal value lowering (which records BF101 for an
  * unsupported shape). Mirror of the Go adapter's `recordIndexAccessToGoMap`.
  */
-export function recordIndexAccessToPerl(ctx: MojoSpreadContext, val: ts.Expression): string | null {
+export function recordIndexAccessToPerl(ctx: MojoSpreadContext, val: ParsedExpr): string | null {
+  // `parseRecordIndexAccess` (the shared single-source-of-truth parser) takes a
+  // `ts.Expression`. The only shape it accepts is `IDENT[KEY]` with identifier
+  // object and index, so rebuild exactly that node from the carried tree via
+  // `ts.factory` — no source-text re-parse needed. Any other shape can't match
+  // and short-circuits to `null` here.
+  if (
+    val.kind !== 'index-access' ||
+    val.object.kind !== 'identifier' ||
+    val.index.kind !== 'identifier'
+  ) {
+    return null
+  }
+  const tsVal = ts.factory.createElementAccessExpression(
+    ts.factory.createIdentifier(val.object.name),
+    ts.factory.createIdentifier(val.index.name),
+  )
   // Shared structural parse (single source of truth in `@barefootjs/jsx`);
   // this wrapper only does the Perl-specific emit (single-quote escaping)
   // from the structured result.
-  const parsed = parseRecordIndexAccess(val, ctx.localConstants, ctx.propsParams)
+  const parsed = parseRecordIndexAccess(tsVal, ctx.localConstants, ctx.propsParams)
   if (!parsed) return null
   const entries = parsed.entries.map(e => {
     const mapVal =

--- a/packages/adapter-mojolicious/src/adapter/value/parsed-literal.ts
+++ b/packages/adapter-mojolicious/src/adapter/value/parsed-literal.ts
@@ -1,48 +1,24 @@
 /**
- * String-literal value lowering for the Mojolicious EP template adapter.
+ * String-type value helpers for the Mojolicious EP template adapter.
  *
  * Extracted from `mojo-adapter.ts` (domain-module refactor, issue #2018
- * track D). Pure functions over const-initializer source text and
- * analyzer type info — no adapter instance state.
+ * track D). Pure functions over analyzer type info / const-initializer text —
+ * no adapter instance state.
  *
  * SHARED CANDIDATE: `isStringTypeInfo` and `isBareStringLiteral` are
  * byte-identical to the Xslate adapter's copies and adapter-agnostic —
  * extraction candidates for a shared Perl-family codegen module (groundwork
  * for the future Perl evaluator integration, issue #2018 track D).
- * `parsePureStringLiteral` deliberately differs (Mojo uses the TS parser;
- * Xslate hand-parses), so it stays per-adapter.
+ *
+ * (#2018) The former `parsePureStringLiteral` (the file's only
+ * `ts.createSourceFile` re-parse) was removed: module-scope pure-string-const
+ * inlining is owned by the shared `collectModuleStringConsts` in
+ * `@barefootjs/jsx` (consumed via `moduleStringConsts`), so the adapter-local
+ * copy had no callers. Dropping it keeps the adapter free of emit-time source
+ * re-parsing without changing any output.
  */
 
-import ts from 'typescript'
-import { evalStringArrayJoin, type TypeInfo } from '@barefootjs/jsx'
-
-/**
- * Parse a const initializer's source text. Returns the unescaped string
- * value when the whole initializer is a single string literal (or a
- * no-substitution template literal), else `null`. Uses the TS parser so
- * escapes/quotes resolve exactly as JS would, matching the value the Hono
- * reference inlines at runtime.
- */
-export function parsePureStringLiteral(source: string): string | null {
-  const sf = ts.createSourceFile(
-    '__const.ts',
-    `const __x = (${source});`,
-    ts.ScriptTarget.Latest,
-    /*setParentNodes*/ false,
-  )
-  const stmt = sf.statements[0]
-  if (!stmt || !ts.isVariableStatement(stmt)) return null
-  const decl = stmt.declarationList.declarations[0]
-  let init = decl?.initializer
-  while (init && ts.isParenthesizedExpression(init)) init = init.expression
-  if (!init) return null
-  if (ts.isStringLiteral(init) || ts.isNoSubstitutionTemplateLiteral(init)) {
-    return init.text
-  }
-  // `[<literals>].join(' ')` module consts (e.g. Switch's `trackStateClasses`)
-  // → inline the flattened string byte-for-byte. See `evalStringArrayJoin`.
-  return evalStringArrayJoin(source)
-}
+import type { TypeInfo } from '@barefootjs/jsx'
 
 /** True when `type` is the `string` primitive. */
 export function isStringTypeInfo(type: TypeInfo | undefined): boolean {

--- a/packages/adapter-xslate/src/adapter/spread/spread-codegen.ts
+++ b/packages/adapter-xslate/src/adapter/spread/spread-codegen.ts
@@ -47,6 +47,11 @@ export function conditionalSpreadToKolon(
   if (whenTrue.kind !== 'object-literal' || whenFalse.kind !== 'object-literal') {
     return null
   }
+  // TODO(#2018): round-trip — the condition's `ParsedExpr` is re-stringified
+  // here and re-parsed inside `convertExpressionToKolon`. Retire once
+  // `convertExpressionToKolon` takes a `preParsed?: ParsedExpr` (cf.
+  // go-template's `convertExpressionToGo(jsExpr, out?, preParsed?)`), so the
+  // carried tree threads straight through instead of stringify→re-parse.
   const condKolon = ctx.convertExpressionToKolon(stringifyParsedExpr(expr.test))
   const trueKolon = objectLiteralToKolonHashref(ctx, whenTrue)
   const falseKolon = objectLiteralToKolonHashref(ctx, whenFalse)
@@ -117,6 +122,9 @@ export function objectLiteralToKolonHashref(
     const valKolon =
       indexed !== null
         ? indexed
+        // TODO(#2018): round-trip — re-stringify + re-parse via
+        // `convertExpressionToKolon`. Thread the carried `val` tree directly once
+        // `convertExpressionToKolon` gains a `preParsed?: ParsedExpr` param.
         : ctx.convertExpressionToKolon(stringifyParsedExpr(val))
     entries.push(`'${escapeKolonSingleQuoted(key)}' => ${valKolon}`)
   }

--- a/packages/adapter-xslate/src/adapter/spread/spread-codegen.ts
+++ b/packages/adapter-xslate/src/adapter/spread/spread-codegen.ts
@@ -7,10 +7,20 @@
  * `spreadCtx` getter) so the cluster depends on the narrow seam — the recursive
  * expression entry plus per-compile bookkeeping — rather than the whole
  * adapter class. Mirror of the Go / Mojo adapter's `spread/spread-codegen.ts`.
+ *
+ * The conditional-spread / object-literal entries read the IR-carried
+ * structured `ParsedExpr` tree (#2018, mirroring go-template's U5/U6) instead
+ * of re-parsing the source with `ts.createSourceFile`. The condition and scalar
+ * values are re-stringified with `stringifyParsedExpr` and routed back through
+ * `ctx.convertExpressionToKolon`, which re-parses — so the emitted Kolon stays
+ * byte-identical to the former AST-text path. The `ts.factory` rebuild in
+ * `recordIndexAccessToKolon` only reconstructs the `IDENT[KEY]` node the shared
+ * `parseRecordIndexAccess` parser accepts; no source-text re-parse.
  */
 
 import ts from 'typescript'
-import { parseRecordIndexAccess } from '@barefootjs/jsx'
+import { parseRecordIndexAccess, stringifyParsedExpr } from '@barefootjs/jsx'
+import type { ParsedExpr } from '@barefootjs/jsx'
 
 import type { XslateSpreadContext } from '../emit-context.ts'
 import { escapeKolonSingleQuoted } from '../lib/kolon-naming.ts'
@@ -20,50 +30,42 @@ import { escapeKolonSingleQuoted } from '../lib/kolon-naming.ts'
  *   `COND ? { 'aria-describedby': describedBy } : {}`
  * to a Kolon inline ternary of hashrefs
  *   `$describedBy ? { 'aria-describedby' => $describedBy } : {}`.
- * Both branches must be object literals; the condition + values route through
+ * Reads the IR-carried structured `ParsedExpr` tree; both branches must be
+ * object literals; the condition + values route through
  * `convertExpressionToKolon`. Returns `null` for any other shape so the caller
  * falls back to its normal lowering. Mirror of `conditionalSpreadToPerl`.
+ * `parseExpression` already strips redundant parentheses, so the conditional /
+ * object-literal shapes surface directly.
  */
-export function conditionalSpreadToKolon(ctx: XslateSpreadContext, expr: string): string | null {
-  const sf = ts.createSourceFile('__spread.ts', `(${expr})`, ts.ScriptTarget.Latest, true)
-  if (sf.statements.length !== 1) return null
-  const stmt = sf.statements[0]
-  if (!ts.isExpressionStatement(stmt)) return null
-  let node: ts.Expression = stmt.expression
-  while (ts.isParenthesizedExpression(node)) node = node.expression
-  if (!ts.isConditionalExpression(node)) return null
-  const unwrap = (e: ts.Expression): ts.Expression => {
-    let n = e
-    while (ts.isParenthesizedExpression(n)) n = n.expression
-    return n
-  }
-  const whenTrue = unwrap(node.whenTrue)
-  const whenFalse = unwrap(node.whenFalse)
-  if (!ts.isObjectLiteralExpression(whenTrue) || !ts.isObjectLiteralExpression(whenFalse)) {
+export function conditionalSpreadToKolon(
+  ctx: XslateSpreadContext,
+  expr: ParsedExpr | undefined,
+): string | null {
+  if (!expr || expr.kind !== 'conditional') return null
+  const whenTrue = expr.consequent
+  const whenFalse = expr.alternate
+  if (whenTrue.kind !== 'object-literal' || whenFalse.kind !== 'object-literal') {
     return null
   }
-  const condKolon = ctx.convertExpressionToKolon(node.condition.getText(sf))
-  const trueKolon = objectLiteralToKolonHashref(ctx, whenTrue, sf)
-  const falseKolon = objectLiteralToKolonHashref(ctx, whenFalse, sf)
+  const condKolon = ctx.convertExpressionToKolon(stringifyParsedExpr(expr.test))
+  const trueKolon = objectLiteralToKolonHashref(ctx, whenTrue)
+  const falseKolon = objectLiteralToKolonHashref(ctx, whenFalse)
   if (trueKolon === null || falseKolon === null) return null
   return `${condKolon} ? ${trueKolon} : ${falseKolon}`
 }
 
 /**
- * (#1971 Perl) Parse a bare object-literal expression string
- * (`{ align: 'start' }`) and lower it to a Kolon hashref via
- * `objectLiteralToKolonHashref`, or null when it isn't a plain object
- * literal. Used for inline object-literal child props (carousel `opts`).
+ * (#1971 Perl) Lower a bare object-literal expression (`{ align: 'start' }`),
+ * carried as the IR's structured `ParsedExpr` tree, to a Kolon hashref via
+ * `objectLiteralToKolonHashref`, or null when it isn't a plain object literal.
+ * Used for inline object-literal child props (carousel `opts`).
  */
-export function objectLiteralExprToKolonHashref(ctx: XslateSpreadContext, expr: string): string | null {
-  const sf = ts.createSourceFile('__obj.ts', `(${expr})`, ts.ScriptTarget.Latest, true)
-  if (sf.statements.length !== 1) return null
-  const stmt = sf.statements[0]
-  if (!ts.isExpressionStatement(stmt)) return null
-  let node: ts.Expression = stmt.expression
-  while (ts.isParenthesizedExpression(node)) node = node.expression
-  if (!ts.isObjectLiteralExpression(node)) return null
-  return objectLiteralToKolonHashref(ctx, node, sf)
+export function objectLiteralExprToKolonHashref(
+  ctx: XslateSpreadContext,
+  expr: ParsedExpr | undefined,
+): string | null {
+  if (!expr || expr.kind !== 'object-literal') return null
+  return objectLiteralToKolonHashref(ctx, expr)
 }
 
 /**
@@ -75,32 +77,24 @@ export function objectLiteralExprToKolonHashref(ctx: XslateSpreadContext, expr: 
  */
 export function objectLiteralToKolonHashref(
   ctx: XslateSpreadContext,
-  obj: ts.ObjectLiteralExpression,
-  sf: ts.SourceFile,
+  obj: Extract<ParsedExpr, { kind: 'object-literal' }>,
 ): string | null {
   const entries: string[] = []
   for (const prop of obj.properties) {
-    if (!ts.isPropertyAssignment(prop)) return null
-    let key: string
-    if (ts.isIdentifier(prop.name)) {
-      key = prop.name.text
-    } else if (ts.isStringLiteral(prop.name) || ts.isNoSubstitutionTemplateLiteral(prop.name)) {
-      key = prop.name.text
-    } else {
-      return null
-    }
-    const initNode = (() => {
-      let n: ts.Expression = prop.initializer
-      while (ts.isParenthesizedExpression(n)) n = n.expression
-      return n
-    })()
-    const indexed = recordIndexAccessToKolon(ctx, initNode)
+    // Shorthand `{ a }` was a `ShorthandPropertyAssignment` (not a
+    // `PropertyAssignment`), so the former parser rejected it — keep refusing.
+    if (prop.shorthand) return null
+    // A numeric key (`{ 1: x }`) was rejected by the former parser (only
+    // identifier / string-literal names were accepted); `keyKind`
+    // distinguishes it from a same-text string `'1'` key.
+    if (prop.keyKind === 'numeric') return null
+    const key = prop.key
+    const val = prop.value
+    const indexed = recordIndexAccessToKolon(ctx, val)
     if (
       indexed === null &&
-      ts.isElementAccessExpression(initNode) &&
-      initNode.argumentExpression &&
-      !ts.isNumericLiteral(initNode.argumentExpression) &&
-      !ts.isStringLiteral(initNode.argumentExpression)
+      val.kind === 'index-access' &&
+      !isLiteralIndex(val.index)
     ) {
       // Variable-index record access (`sizeMap[size]`) the static-inline
       // path couldn't resolve (non-scalar value / non-const receiver).
@@ -112,7 +106,7 @@ export function objectLiteralToKolonHashref(
       ctx.errors.push({
         code: 'BF101',
         severity: 'error',
-        message: `Spread object value '${initNode.getText(sf)}' indexes a record map whose values aren't scalar literals — it can't lower to an inline Kolon hashref.`,
+        message: `Spread object value '${stringifyParsedExpr(val)}' indexes a record map whose values aren't scalar literals — it can't lower to an inline Kolon hashref.`,
         loc: { file: ctx.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
         suggestion: {
           message: 'Index a record whose values are number/string literals, or move the spread into a `\'use client\'` component so hydration computes it.',
@@ -123,24 +117,49 @@ export function objectLiteralToKolonHashref(
     const valKolon =
       indexed !== null
         ? indexed
-        : ctx.convertExpressionToKolon(prop.initializer.getText(sf))
+        : ctx.convertExpressionToKolon(stringifyParsedExpr(val))
     entries.push(`'${escapeKolonSingleQuoted(key)}' => ${valKolon}`)
   }
   return entries.length === 0 ? '{}' : `{ ${entries.join(', ')} }`
+}
+
+/** True when a parsed index is a numeric or string literal (`arr[0]`, `m['k']`). */
+function isLiteralIndex(index: ParsedExpr): boolean {
+  return (
+    index.kind === 'literal' &&
+    (index.literalType === 'number' || index.literalType === 'string')
+  )
 }
 
 /**
  * Lower a spread-object VALUE of the form `IDENT[KEY]` (CheckIcon's
  * `sizeMap[size]`) to an inline indexed Kolon hashref
  *   `{ 'sm' => 16, 'md' => 20, ... }[$size]`.
- * Reuses the shared structural parse (`parseRecordIndexAccess`); this wrapper
- * only does the single-quote escaping + Kolon index emit. NB: Kolon indexes a
- * hashref literal with bracket syntax `{…}[$key]`, NOT Perl's arrow-deref
- * `{…}->{$key}` (which Kolon's parser rejects) — this is the one divergence
- * from the Mojo `recordIndexAccessToPerl` emit.
+ * Reuses the shared structural parse (`parseRecordIndexAccess`) — rebuilding
+ * the `IDENT[KEY]` node from the carried tree via `ts.factory` rather than
+ * re-parsing source text; this wrapper only does the single-quote escaping +
+ * Kolon index emit. NB: Kolon indexes a hashref literal with bracket syntax
+ * `{…}[$key]`, NOT Perl's arrow-deref `{…}->{$key}` (which Kolon's parser
+ * rejects) — this is the one divergence from the Mojo `recordIndexAccessToPerl`
+ * emit.
  */
-export function recordIndexAccessToKolon(ctx: XslateSpreadContext, val: ts.Expression): string | null {
-  const parsed = parseRecordIndexAccess(val, ctx.localConstants ?? [], ctx.propsParams)
+export function recordIndexAccessToKolon(ctx: XslateSpreadContext, val: ParsedExpr): string | null {
+  // The only shape `parseRecordIndexAccess` accepts is `IDENT[KEY]` with
+  // identifier object and index, so rebuild exactly that node from the carried
+  // tree via `ts.factory` — no source-text re-parse. Any other shape can't
+  // match and short-circuits to `null` here.
+  if (
+    val.kind !== 'index-access' ||
+    val.object.kind !== 'identifier' ||
+    val.index.kind !== 'identifier'
+  ) {
+    return null
+  }
+  const tsVal = ts.factory.createElementAccessExpression(
+    ts.factory.createIdentifier(val.object.name),
+    ts.factory.createIdentifier(val.index.name),
+  )
+  const parsed = parseRecordIndexAccess(tsVal, ctx.localConstants ?? [], ctx.propsParams)
   if (!parsed) return null
   const entries = parsed.entries.map(e => {
     const mapVal =

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -709,10 +709,13 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
       }
       // Inline object-literal child prop (carousel's `opts={{ align: 'start' }}`):
       // lower to a Kolon hashref so the child can serialize it (`data-opts`),
-      // instead of refusing the bare object with BF101. (#1971 Perl) Cheap `{`
-      // guard so the common non-object case skips the AST parse.
-      if (value.expr.trim().startsWith('{')) {
-        const hashref = objectLiteralExprToKolonHashref(this.spreadCtx, value.expr)
+      // instead of refusing the bare object with BF101. (#1971 Perl) Read the
+      // IR-carried structured `ParsedExpr` tree (#2018) instead of re-parsing
+      // `value.expr` with `ts.createSourceFile`; the lowering returns null for
+      // any non-object-literal shape, so the common non-object case falls
+      // straight through to the bare-expression path below.
+      if (value.parsed) {
+        const hashref = objectLiteralExprToKolonHashref(this.spreadCtx, value.parsed)
         if (hashref !== null) return `${kolonHashKey(name)} => ${hashref}`
       }
       return `${kolonHashKey(name)} => ${this.convertExpressionToKolon(value.expr)}`
@@ -990,7 +993,9 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
       // Emit a Kolon inline ternary of hashrefs — Perl truthiness handles the
       // condition for free, and the falsy `{}` branch OMITS the key
       // (`spread_attrs` does NOT emit empty hashref entries).
-      const ternaryHashref = conditionalSpreadToKolon(this.spreadCtx, trimmed)
+      // Read the spread's IR-carried `ParsedExpr` tree (#2018) instead of
+      // re-parsing `trimmed` with `ts.createSourceFile`.
+      const ternaryHashref = conditionalSpreadToKolon(this.spreadCtx, value.parsed)
       if (ternaryHashref !== null) {
         return `<: $bf.spread_attrs(${ternaryHashref}) | mark_raw :>`
       }
@@ -1007,7 +1012,15 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
         if (localConst?.value !== undefined) {
           const initTrimmed = localConst.value.trim()
           if (!/^[A-Za-z_$][\w$]*$/.test(initTrimmed)) {
-            const resolved = conditionalSpreadToKolon(this.spreadCtx, initTrimmed)
+            // The local const's initializer text isn't carried as a structured
+            // tree on the spread attr, so parse it once via the shared
+            // `parseExpression` (the analyzer's own entry) — not
+            // `ts.createSourceFile` — mirroring go-template's same local-const
+            // resolution path.
+            const resolved = conditionalSpreadToKolon(
+              this.spreadCtx,
+              parseExpression(initTrimmed),
+            )
             if (resolved !== null) {
               return `<: $bf.spread_attrs(${resolved}) | mark_raw :>`
             }


### PR DESCRIPTION
## Summary

Tracks **issue #2018**: drive the Mojolicious and Xslate adapters' expression lowering from the IR-carried structured `ParsedExpr` tree instead of re-parsing source text with `ts.createSourceFile` at emit time — achieving **zero live `createSourceFile` calls** in both adapters' `src` (test files excluded; only explanatory comment references remain, matching the go-template precedent).

This applies to mojo/xslate exactly what go-template already achieved:
- **U5** — conditional spread lowered from `SpreadAttr.parsed` (`go-template/.../spread/spread-codegen.ts`).
- **U6** — inline object-literal → map/hashref from `ExpressionAttr.parsed` (`go-template/.../value/value-lowering.ts`, `objectLiteralToGoMap`).
- **Roadmap A** — structured literal lowering (`go-template/.../value/parsed-literal-to-go.ts`).

## Changes (5 emit-time re-parse sites across 3 files)

- `packages/adapter-mojolicious/src/adapter/spread/spread-codegen.ts` — `conditionalSpreadToPerl` and `objectLiteralExprToPerlHashref` now take `ParsedExpr | undefined` (was `expr: string`); `objectLiteralToPerlHashref` / `recordIndexAccessToPerl` consume the structured tree.
- `packages/adapter-xslate/src/adapter/spread/spread-codegen.ts` — same for the Kolon (`conditionalSpreadToKolon`, `objectLiteralExprToKolonHashref`, …).
- `packages/adapter-mojolicious/src/adapter/value/parsed-literal.ts` — the orphaned `parsePureStringLiteral` (the file's only `ts.createSourceFile`) is **removed**: module-scope pure-string-const inlining is owned by the shared `collectModuleStringConsts` in `@barefootjs/jsx` (consumed via `moduleStringConsts`), so the adapter-local copy had **zero callers**. Removing it is behaviour-preserving and reaches `createSourceFile = 0`. The two live helpers (`isStringTypeInfo`, `isBareStringLiteral`) are retained.

Call sites in `mojo-adapter.ts` / `xslate-adapter.ts` pass `value.parsed` for the spread / component-prop expressions, and `parseExpression(initTrimmed)` (the analyzer's own entry, not `ts.createSourceFile`) for the local-const resolution branch — mirroring go-template's same path.

## Byte-identity

The condition and scalar values are re-stringified with `stringifyParsedExpr` and routed back through `convertExpressionToPerl` / `convertExpressionToKolon`, which re-parse — so the emitted Perl/Kolon is byte-identical to the former AST-text path. The `ts.factory` rebuild in `recordIndexAccess*` only reconstructs the `IDENT[KEY]` node the shared `parseRecordIndexAccess` accepts; no source-text re-parse. **`@barefootjs/jsx` is unchanged** — only existing IR fields/exports are consumed.

## Verification

- `bun test packages/adapter-mojolicious/` → **527 pass / 0 fail**
- `bun test packages/adapter-xslate/` → **353 pass / 0 fail**
- `bunx tsgo --noEmit` (both packages) → clean
- `bunx biome check` (both adapter dirs) → clean
- `git grep -nE "\.createSourceFile\(|parseLiteralExpression\("` over both adapters' `src` (tests excluded) → **0 live calls**

Local Perl/Xslate interpreters are absent, so real-render conformance cases skip locally (CI runs them); IR/structure conformance passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_