### PR TITLE
refactor(mojo,xslate): thread preParsed through spread converters (#2018)

### DIFF
--- a/.changeset/mojo-xslate-preparsed-seam.md
+++ b/.changeset/mojo-xslate-preparsed-seam.md
@@ -1,0 +1,8 @@
+---
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+---
+
+Remove the spread-lowering `ParsedExpr` round-trip in the Mojolicious and Xslate adapters (#2018).
+
+The conditional-spread / object-literal spread codegen previously re-stringified the IR-carried `ParsedExpr` tree (`stringifyParsedExpr`) and routed it back through `convertExpressionToPerl` / `convertExpressionToKolon`, which re-parsed the text. The seam now matches go-template's `convertExpressionToGo(jsExpr, out?, preParsed?)`: the converters accept an optional `preParsed?: ParsedExpr` and thread the carried tree straight through, eliminating the stringify→re-parse round-trip. Output is byte-identical (the carried tree is exactly what re-parsing the stringified text produced). `stringifyParsedExpr` is retained only for BF101 diagnostic message text.

--- a/packages/adapter-mojolicious/src/adapter/emit-context.ts
+++ b/packages/adapter-mojolicious/src/adapter/emit-context.ts
@@ -76,12 +76,14 @@ export interface MojoSpreadContext {
   /**
    * Lower a JS expression to its Perl form (the core recursive entry).
    *
-   * String-in today. Once the IR-carries-semantics work (#2018) lands, this
-   * seam should also accept an already-parsed `ParsedExpr` — cf. go-template's
-   * `convertExpressionToGo(jsExpr, out?, preParsed?)` — so the future Perl
-   * evaluator can thread a structured tree instead of re-parsing source text.
+   * When the IR already carries a structured `ParsedExpr` tree, pass it as
+   * `preParsed` so the converter threads it straight through instead of
+   * re-parsing `expr` — mirrors go-template's
+   * `convertExpressionToGo(jsExpr, out?, preParsed?)`. With `preParsed` set,
+   * `expr` is unused for parsing (the converter derives any diagnostic text
+   * from the tree), so callers may pass `''`.
    */
-  convertExpressionToPerl(expr: string): string
+  convertExpressionToPerl(expr: string, preParsed?: ParsedExpr): string
 }
 
 /**
@@ -94,10 +96,12 @@ export interface MojoMemoContext {
   /**
    * Lower a JS expression to its Perl form (the core recursive entry).
    *
-   * String-in today. Once the IR-carries-semantics work (#2018) lands, this
-   * seam should also accept an already-parsed `ParsedExpr` — cf. go-template's
-   * `convertExpressionToGo(jsExpr, out?, preParsed?)` — so the future Perl
-   * evaluator can thread a structured tree instead of re-parsing source text.
+   * When the IR already carries a structured `ParsedExpr` tree, pass it as
+   * `preParsed` so the converter threads it straight through instead of
+   * re-parsing `expr` — mirrors go-template's
+   * `convertExpressionToGo(jsExpr, out?, preParsed?)`. With `preParsed` set,
+   * `expr` is unused for parsing (the converter derives any diagnostic text
+   * from the tree), so callers may pass `''`.
    */
-  convertExpressionToPerl(expr: string): string
+  convertExpressionToPerl(expr: string, preParsed?: ParsedExpr): string
 }

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -37,6 +37,7 @@ import {
   type AttrValueEmitter,
   isBooleanAttr,
   parseExpression,
+  stringifyParsedExpr,
   parseStyleObjectEntries,
   isSupported,
   exprToString,
@@ -1586,16 +1587,16 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       errors: this.errors,
       localConstants: this.localConstants,
       propsParams: this.propsParams,
-      convertExpressionToPerl: (e) => this.convertExpressionToPerl(e),
+      convertExpressionToPerl: (e, preParsed) => this.convertExpressionToPerl(e, preParsed),
     }
   }
 
   /** Build the narrow context the extracted memo seeding depends on. */
   private get memoCtx(): MojoMemoContext {
-    return { convertExpressionToPerl: (e) => this.convertExpressionToPerl(e) }
+    return { convertExpressionToPerl: (e, preParsed) => this.convertExpressionToPerl(e, preParsed) }
   }
 
-  private convertExpressionToPerl(expr: string): string {
+  private convertExpressionToPerl(expr: string, preParsed?: ParsedExpr): string {
     // Parse-first lowering — parity with the Go adapter's
     // `convertExpressionToGo`. Parse the JS expression once, gate it on
     // the shared `isSupported`, and render every supported shape through
@@ -1605,16 +1606,28 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     // string-rewriting pipeline. Unsupported shapes (un-lowered methods,
     // unparseable hand-written JS, etc.) surface as BF101 with the
     // `/* @client */` escape hatch instead of being silently mangled.
-    const trimmed = expr.trim()
-    if (trimmed === '') return "''"
+    //
+    // `preParsed` is the IR-carried `ParsedExpr` tree (cf. go-template's
+    // `convertExpressionToGo(jsExpr, out?, preParsed?)`); when present it is
+    // used directly instead of re-parsing `expr`, so spread condition/value
+    // lowering threads the carried tree through without a stringify→re-parse
+    // round-trip. The diagnostic text is then derived from the tree
+    // (`stringifyParsedExpr`) so callers can pass `''` for `expr`.
+    let parsed: ParsedExpr
+    if (preParsed) {
+      parsed = preParsed
+    } else {
+      const trimmed = expr.trim()
+      if (trimmed === '') return "''"
+      parsed = parseExpression(trimmed)
+    }
 
-    const parsed = parseExpression(trimmed)
     const support = isSupported(parsed)
     if (!support.supported) {
       this.errors.push({
         code: 'BF101',
         severity: 'error',
-        message: `Expression not supported: ${trimmed}`,
+        message: `Expression not supported: ${preParsed ? stringifyParsedExpr(parsed) : expr.trim()}`,
         loc: { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
         suggestion: {
           message: support.reason

--- a/packages/adapter-mojolicious/src/adapter/spread/spread-codegen.ts
+++ b/packages/adapter-mojolicious/src/adapter/spread/spread-codegen.ts
@@ -11,11 +11,15 @@
  * The conditional-spread / object-literal entries read the IR-carried
  * structured `ParsedExpr` tree (#2018, mirroring go-template's U5/U6) instead
  * of re-parsing the source with `ts.createSourceFile`. The condition and scalar
- * values are re-stringified with `stringifyParsedExpr` and routed back through
- * `ctx.convertExpressionToPerl`, which re-parses — so the emitted Perl stays
- * byte-identical to the former AST-text path. The `ts.factory` rebuild in
- * `recordIndexAccessToPerl` only reconstructs the `IDENT[KEY]` node the shared
- * `parseRecordIndexAccess` parser accepts; no source-text re-parse.
+ * values are threaded straight into `ctx.convertExpressionToPerl` as its
+ * `preParsed` argument (cf. go-template's
+ * `convertExpressionToGo(jsExpr, out?, preParsed?)`), so no stringify→re-parse
+ * round-trip occurs — the emitted Perl is byte-identical to the former path
+ * because the carried tree is exactly what re-parsing the stringified text
+ * produced. The `ts.factory` rebuild in `recordIndexAccessToPerl` only
+ * reconstructs the `IDENT[KEY]` node the shared `parseRecordIndexAccess` parser
+ * accepts; no source-text re-parse. `stringifyParsedExpr` is retained solely for
+ * the BF101 diagnostic message (display purposes).
  */
 
 import ts from 'typescript'
@@ -40,12 +44,10 @@ export function conditionalSpreadToPerl(
   if (whenTrue.kind !== 'object-literal' || whenFalse.kind !== 'object-literal') {
     return null
   }
-  // TODO(#2018): round-trip — the condition's `ParsedExpr` is re-stringified
-  // here and re-parsed inside `convertExpressionToPerl`. Retire once
-  // `convertExpressionToPerl` takes a `preParsed?: ParsedExpr` (cf.
-  // go-template's `convertExpressionToGo(jsExpr, out?, preParsed?)`), so the
-  // carried tree threads straight through instead of stringify→re-parse.
-  const condPerl = ctx.convertExpressionToPerl(stringifyParsedExpr(expr.test))
+  // Thread the condition's carried `ParsedExpr` tree straight through as
+  // `preParsed` (#2018) — no stringify→re-parse round-trip; `convertExpressionToPerl`
+  // uses the tree directly and derives any diagnostic text from it.
+  const condPerl = ctx.convertExpressionToPerl('', expr.test)
   const truePerl = objectLiteralToPerlHashref(ctx, whenTrue)
   const falsePerl = objectLiteralToPerlHashref(ctx, whenFalse)
   if (truePerl === null || falsePerl === null) return null
@@ -118,10 +120,9 @@ export function objectLiteralToPerlHashref(
     const valPerl =
       indexed !== null
         ? indexed
-        // TODO(#2018): round-trip — re-stringify + re-parse via
-        // `convertExpressionToPerl`. Thread the carried `val` tree directly once
-        // `convertExpressionToPerl` gains a `preParsed?: ParsedExpr` param.
-        : ctx.convertExpressionToPerl(stringifyParsedExpr(val))
+        // Thread the carried `val` tree straight through as `preParsed` (#2018)
+        // — no stringify→re-parse round-trip.
+        : ctx.convertExpressionToPerl('', val)
     entries.push(`'${key.replace(/'/g, "\\'")}' => ${valPerl}`)
   }
   return entries.length === 0 ? '{}' : `{ ${entries.join(', ')} }`

--- a/packages/adapter-xslate/src/adapter/emit-context.ts
+++ b/packages/adapter-xslate/src/adapter/emit-context.ts
@@ -73,12 +73,14 @@ export interface XslateSpreadContext {
   /**
    * Lower a JS expression to its Kolon form (the core recursive entry).
    *
-   * String-in today. Once the IR-carries-semantics work (#2018) lands, this
-   * seam should also accept an already-parsed `ParsedExpr` — cf. go-template's
-   * `convertExpressionToGo(jsExpr, out?, preParsed?)` — so the future Perl
-   * evaluator can thread a structured tree instead of re-parsing source text.
+   * When the IR already carries a structured `ParsedExpr` tree, pass it as
+   * `preParsed` so the converter threads it straight through instead of
+   * re-parsing `expr` — mirrors go-template's
+   * `convertExpressionToGo(jsExpr, out?, preParsed?)`. With `preParsed` set,
+   * `expr` is unused for parsing (the converter derives any diagnostic text
+   * from the tree), so callers may pass `''`.
    */
-  convertExpressionToKolon(expr: string): string
+  convertExpressionToKolon(expr: string, preParsed?: ParsedExpr): string
 }
 
 /**
@@ -91,10 +93,12 @@ export interface XslateMemoContext {
   /**
    * Lower a JS expression to its Kolon form (the core recursive entry).
    *
-   * String-in today. Once the IR-carries-semantics work (#2018) lands, this
-   * seam should also accept an already-parsed `ParsedExpr` — cf. go-template's
-   * `convertExpressionToGo(jsExpr, out?, preParsed?)` — so the future Perl
-   * evaluator can thread a structured tree instead of re-parsing source text.
+   * When the IR already carries a structured `ParsedExpr` tree, pass it as
+   * `preParsed` so the converter threads it straight through instead of
+   * re-parsing `expr` — mirrors go-template's
+   * `convertExpressionToGo(jsExpr, out?, preParsed?)`. With `preParsed` set,
+   * `expr` is unused for parsing (the converter derives any diagnostic text
+   * from the tree), so callers may pass `''`.
    */
-  convertExpressionToKolon(expr: string): string
+  convertExpressionToKolon(expr: string, preParsed?: ParsedExpr): string
 }

--- a/packages/adapter-xslate/src/adapter/spread/spread-codegen.ts
+++ b/packages/adapter-xslate/src/adapter/spread/spread-codegen.ts
@@ -11,11 +11,15 @@
  * The conditional-spread / object-literal entries read the IR-carried
  * structured `ParsedExpr` tree (#2018, mirroring go-template's U5/U6) instead
  * of re-parsing the source with `ts.createSourceFile`. The condition and scalar
- * values are re-stringified with `stringifyParsedExpr` and routed back through
- * `ctx.convertExpressionToKolon`, which re-parses — so the emitted Kolon stays
- * byte-identical to the former AST-text path. The `ts.factory` rebuild in
- * `recordIndexAccessToKolon` only reconstructs the `IDENT[KEY]` node the shared
- * `parseRecordIndexAccess` parser accepts; no source-text re-parse.
+ * values are threaded straight into `ctx.convertExpressionToKolon` as its
+ * `preParsed` argument (cf. go-template's
+ * `convertExpressionToGo(jsExpr, out?, preParsed?)`), so no stringify→re-parse
+ * round-trip occurs — the emitted Kolon is byte-identical to the former path
+ * because the carried tree is exactly what re-parsing the stringified text
+ * produced. The `ts.factory` rebuild in `recordIndexAccessToKolon` only
+ * reconstructs the `IDENT[KEY]` node the shared `parseRecordIndexAccess` parser
+ * accepts; no source-text re-parse. `stringifyParsedExpr` is retained solely for
+ * the BF101 diagnostic message (display purposes).
  */
 
 import ts from 'typescript'
@@ -47,12 +51,10 @@ export function conditionalSpreadToKolon(
   if (whenTrue.kind !== 'object-literal' || whenFalse.kind !== 'object-literal') {
     return null
   }
-  // TODO(#2018): round-trip — the condition's `ParsedExpr` is re-stringified
-  // here and re-parsed inside `convertExpressionToKolon`. Retire once
-  // `convertExpressionToKolon` takes a `preParsed?: ParsedExpr` (cf.
-  // go-template's `convertExpressionToGo(jsExpr, out?, preParsed?)`), so the
-  // carried tree threads straight through instead of stringify→re-parse.
-  const condKolon = ctx.convertExpressionToKolon(stringifyParsedExpr(expr.test))
+  // Thread the condition's carried `ParsedExpr` tree straight through as
+  // `preParsed` (#2018) — no stringify→re-parse round-trip; `convertExpressionToKolon`
+  // uses the tree directly and derives any diagnostic text from it.
+  const condKolon = ctx.convertExpressionToKolon('', expr.test)
   const trueKolon = objectLiteralToKolonHashref(ctx, whenTrue)
   const falseKolon = objectLiteralToKolonHashref(ctx, whenFalse)
   if (trueKolon === null || falseKolon === null) return null
@@ -122,10 +124,9 @@ export function objectLiteralToKolonHashref(
     const valKolon =
       indexed !== null
         ? indexed
-        // TODO(#2018): round-trip — re-stringify + re-parse via
-        // `convertExpressionToKolon`. Thread the carried `val` tree directly once
-        // `convertExpressionToKolon` gains a `preParsed?: ParsedExpr` param.
-        : ctx.convertExpressionToKolon(stringifyParsedExpr(val))
+        // Thread the carried `val` tree straight through as `preParsed` (#2018)
+        // — no stringify→re-parse round-trip.
+        : ctx.convertExpressionToKolon('', val)
     entries.push(`'${escapeKolonSingleQuoted(key)}' => ${valKolon}`)
   }
   return entries.length === 0 ? '{}' : `{ ${entries.join(', ')} }`

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -51,6 +51,7 @@ import {
   type AttrValueEmitter,
   isBooleanAttr,
   parseExpression,
+  stringifyParsedExpr,
   exprToString,
   parseProviderObjectLiteral,
   parseStyleObjectEntries,
@@ -1334,30 +1335,42 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
       errors: this.errors,
       localConstants: this.localConstants,
       propsParams: this.propsParams,
-      convertExpressionToKolon: (e) => this.convertExpressionToKolon(e),
+      convertExpressionToKolon: (e, preParsed) => this.convertExpressionToKolon(e, preParsed),
     }
   }
 
   /** Build the narrow context the extracted memo seeding depends on. */
   private get memoCtx(): XslateMemoContext {
-    return { convertExpressionToKolon: (e) => this.convertExpressionToKolon(e) }
+    return { convertExpressionToKolon: (e, preParsed) => this.convertExpressionToKolon(e, preParsed) }
   }
 
-  private convertExpressionToKolon(expr: string): string {
+  private convertExpressionToKolon(expr: string, preParsed?: ParsedExpr): string {
     // Parse-first lowering — parity with the Mojo adapter's
     // `convertExpressionToPerl`. Parse the JS expression once, gate it on the
     // shared `isSupported`, and render every supported shape through the AST
     // emitter. Unsupported shapes surface as BF101.
-    const trimmed = expr.trim()
-    if (trimmed === '') return "''"
+    //
+    // `preParsed` is the IR-carried `ParsedExpr` tree (cf. go-template's
+    // `convertExpressionToGo(jsExpr, out?, preParsed?)`); when present it is
+    // used directly instead of re-parsing `expr`, so spread condition/value
+    // lowering threads the carried tree through without a stringify→re-parse
+    // round-trip. The diagnostic text is then derived from the tree
+    // (`stringifyParsedExpr`) so callers can pass `''` for `expr`.
+    let parsed: ParsedExpr
+    if (preParsed) {
+      parsed = preParsed
+    } else {
+      const trimmed = expr.trim()
+      if (trimmed === '') return "''"
+      parsed = parseExpression(trimmed)
+    }
 
-    const parsed = parseExpression(trimmed)
     const support = isSupported(parsed)
     if (!support.supported) {
       this.errors.push({
         code: 'BF101',
         severity: 'error',
-        message: `Expression not supported: ${trimmed}`,
+        message: `Expression not supported: ${preParsed ? stringifyParsedExpr(parsed) : expr.trim()}`,
         loc: { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
         suggestion: {
           message: support.reason


### PR DESCRIPTION
## Summary

Removes the residual `ParsedExpr` round-trip (stringify → re-parse) in the spread lowering of the Mojolicious and Xslate adapters, tracked by #2018.

The conditional-spread / object-literal spread codegen (`spread/spread-codegen.ts`) previously took the IR-carried `ParsedExpr` tree, re-stringified it with `stringifyParsedExpr(...)`, and routed it back through `convertExpressionToPerl` / `convertExpressionToKolon`, which then **re-parsed** the text. `ts.createSourceFile` was already at 0 after #2025, but this re-parse remained.

This change aligns the Perl/Kolon converters with go-template's `convertExpressionToGo(jsExpr, out?, preParsed?)`: both converters now accept an optional `preParsed?: ParsedExpr` and use the carried tree directly (`const parsed = preParsed ?? parseExpression(...)`), so the spread call sites thread the tree straight through with no round-trip.

## Changes

- **`emit-context.ts`** (mojo + xslate): extended the `convertExpressionToPerl` / `convertExpressionToKolon` seam declarations (on the `*SpreadContext` and `*MemoContext` interfaces) to `(expr: string, preParsed?: ParsedExpr)`. The `#2018` "should also accept preParsed" TODO docstrings are updated to describe the now-realized behavior.
- **`mojo-adapter.ts` / `xslate-adapter.ts`**: the converter implementations use `preParsed` directly when supplied instead of re-parsing; the `spreadCtx` / `memoCtx` getters forward the new arg.
- **`spread/spread-codegen.ts`** (mojo + xslate): the 4 round-trip sites (each adapter's conditional-spread condition + non-structural object value) now pass the carried tree as `preParsed` and drop the `stringifyParsedExpr(...)` first argument (passing `''`, since the converter derives diagnostic text from the tree). The `stringifyParsedExpr` call backing the BF101 "indexes a record map…" message is **retained** (display-only).

## Byte-identity

Guaranteed: `preParsed` is the same tree that `parseExpression(stringifyParsedExpr(tree))` produced, so the AST emitter receives identical input and emits identical Perl/Kolon. The only string still derived from text — the BF101 "Expression not supported" message — is reconstructed via `stringifyParsedExpr(parsed)` when `preParsed` is set, which equals the former `${trimmed}` source. `ts.createSourceFile` stays at 0 (verified: all remaining references are comments).

## Verification

- `bun test packages/adapter-mojolicious/` → **527 pass / 0 fail**
- `bun test packages/adapter-xslate/` → **353 pass / 0 fail**
- `bunx tsgo --noEmit` (both packages) → clean
- `bunx biome check` (both adapter dirs) → clean

Real Perl/Xslate render conformance runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_