### PR TITLE
fix(jsx): parse inline object-literal attr/prop values as object-literal (carousel SSR regression)

### DIFF
--- a/.changeset/fix-inline-object-prop-parse.md
+++ b/.changeset/fix-inline-object-prop-parse.md
@@ -2,10 +2,10 @@
 "@barefootjs/jsx": patch
 ---
 
-Fix inline object-literal attribute / prop / provider values parsing to
-`unsupported` instead of `object-literal`. `attachParsedExpressions` parsed a
-bare `{ … }` value directly, but an unparenthesized object literal is a block
-statement, so `opts={{ align: 'start' }}` / `style={{ … }}` landed as
+Fix inline object-literal attribute / prop / provider values being parsed as
+`unsupported` when they should be `object-literal`. `attachParsedExpressions`
+parsed a bare `{ … }` value directly, but an unparenthesized object literal is a
+block statement, so `opts={{ align: 'start' }}` / `style={{ … }}` landed as
 `unsupported`. After the adapters switched to reading the IR-carried tree
 (#2018), the Mojolicious / Xslate inline-object lowerings then refused these
 with BF101 (regressing the carousel SSR conformance). Parenthesize a

--- a/.changeset/fix-inline-object-prop-parse.md
+++ b/.changeset/fix-inline-object-prop-parse.md
@@ -1,0 +1,15 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix inline object-literal attribute / prop / provider values parsing to
+`unsupported` instead of `object-literal`. `attachParsedExpressions` parsed a
+bare `{ … }` value directly, but an unparenthesized object literal is a block
+statement, so `opts={{ align: 'start' }}` / `style={{ … }}` landed as
+`unsupported`. After the adapters switched to reading the IR-carried tree
+(#2018), the Mojolicious / Xslate inline-object lowerings then refused these
+with BF101 (regressing the carousel SSR conformance). Parenthesize a
+`{`-leading value before parsing so it becomes the `object-literal` the
+adapters' `objectLiteralExprToPerlHashref` / `objectLiteralToGoMap` lowerings
+expect; every other expression is unaffected (redundant parens are stripped on
+parse). Restores byte-identical carousel render across Go / Mojo / Xslate.

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -555,13 +555,6 @@ function makeBindingEnv(ctx: TransformContext): BindingEnvironment {
 // =============================================================================
 
 /**
- * Attach `parsed` (`parseExpression(expr.trim())`) to every `expression` node
- * in the tree, so SSR adapters emit from the structured tree instead of each
- * re-parsing the string at emit time. Best-effort: a node this walk misses (or
- * an empty `expr`) simply has no `parsed`, and the adapter falls back to
- * parsing — so under-coverage is safe, never a behavioural change.
- */
-/**
  * Parse an attribute / prop / provider value expression. An inline object
  * literal (`opts={{ align: 'start' }}`, `style={{ … }}`) parses as a block
  * statement unless parenthesized, so a bare `{ … }` would land as `unsupported`
@@ -575,6 +568,13 @@ function parseValueExpr(trimmed: string): ParsedExpr {
   return parseExpression(trimmed.startsWith('{') ? `(${trimmed})` : trimmed)
 }
 
+/**
+ * Attach `parsed` (`parseExpression(expr.trim())`) to every `expression` node
+ * in the tree, so SSR adapters emit from the structured tree instead of each
+ * re-parsing the string at emit time. Best-effort: a node this walk misses (or
+ * an empty `expr`) simply has no `parsed`, and the adapter falls back to
+ * parsing — so under-coverage is safe, never a behavioural change.
+ */
 function attachParsedExpressions(node: IRNode): void {
   if (node.type === 'expression') {
     const trimmed = node.expr.trim()

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -561,6 +561,20 @@ function makeBindingEnv(ctx: TransformContext): BindingEnvironment {
  * an empty `expr`) simply has no `parsed`, and the adapter falls back to
  * parsing — so under-coverage is safe, never a behavioural change.
  */
+/**
+ * Parse an attribute / prop / provider value expression. An inline object
+ * literal (`opts={{ align: 'start' }}`, `style={{ … }}`) parses as a block
+ * statement unless parenthesized, so a bare `{ … }` would land as `unsupported`
+ * instead of `object-literal` — the adapters that lower an inline object value
+ * (Go `objectLiteralToGoMap`, Perl `objectLiteralExprToPerlHashref`) then refuse
+ * it (BF101). Wrap a `{`-leading value in parens so it parses as the
+ * `object-literal` they expect; every other expression is unaffected (redundant
+ * parens are stripped on parse).
+ */
+function parseValueExpr(trimmed: string): ParsedExpr {
+  return parseExpression(trimmed.startsWith('{') ? `(${trimmed})` : trimmed)
+}
+
 function attachParsedExpressions(node: IRNode): void {
   if (node.type === 'expression') {
     const trimmed = node.expr.trim()
@@ -578,7 +592,7 @@ function attachParsedExpressions(node: IRNode): void {
     for (const attr of node.attrs) {
       if (attr.value.kind === 'expression') {
         const trimmed = attr.value.expr.trim()
-        if (trimmed) attr.value.parsed = parseExpression(trimmed)
+        if (trimmed) attr.value.parsed = parseValueExpr(trimmed)
       } else if (attr.value.kind === 'spread') {
         const trimmed = attr.value.expr.trim()
         if (trimmed) attr.value.parsed = parseExpression(trimmed)
@@ -588,13 +602,13 @@ function attachParsedExpressions(node: IRNode): void {
     for (const prop of node.props) {
       if (prop.value.kind === 'expression') {
         const trimmed = prop.value.expr.trim()
-        if (trimmed) prop.value.parsed = parseExpression(trimmed)
+        if (trimmed) prop.value.parsed = parseValueExpr(trimmed)
       }
     }
   } else if (node.type === 'provider') {
     if (node.valueProp.value.kind === 'expression') {
       const trimmed = node.valueProp.value.expr.trim()
-      if (trimmed) node.valueProp.value.parsed = parseExpression(trimmed)
+      if (trimmed) node.valueProp.value.parsed = parseValueExpr(trimmed)
     }
   }
   switch (node.type) {


### PR DESCRIPTION
## Why

`main` is red on 6 `test` cases — the carousel cross-adapter SSR conformance
(`CarouselPreview/Sizes/Orientation` on Mojo & Xslate), a regression introduced
by #2025 (the mojo/xslate spreads-from-IR-`ParsedExpr` refactor). It blocks the
`test` job on every PR.

## Root cause

`attachParsedExpressions` (jsx-to-ir) parses an attribute / prop / provider
expression value with `parseExpression(trimmed)`. A bare, unparenthesized object
literal is a **block statement**, so `opts={{ align: 'start' }}` /
`style={{ … }}` parsed to `unsupported` instead of `object-literal`:

```
parseExpression("{ align: 'start' }")    → kind: 'unsupported'
parseExpression("({ align: 'start' })")  → kind: 'object-literal'
```

This was latent until #2025 switched the Mojo/Xslate inline-object lowering from
re-parsing the value string to reading the IR-carried `value.parsed`. With
`value.parsed` now `unsupported`, `objectLiteralExprToPerlHashref` returns null
and the dispatch falls through to `convertExpressionToPerl("{ … }")` → **BF101**.
(Go happened to keep passing via its own fallback.)

## Fix

Parenthesize a `{`-leading value before parsing (`parseValueExpr`) so it lands as
the `object-literal` the adapters' `objectLiteralExprToPerlHashref` /
`objectLiteralToGoMap` lowerings expect. Every other expression is unaffected —
redundant parens are stripped on parse. Root-cause fix in the IR (one place,
benefits all adapters) rather than per-adapter fallbacks.

## Verification

- Carousel cross-adapter: **9/9** (was 3/9), Go unchanged.
- `adapter-tests` conformance + CSR: **789/0** (was 783/6).
- `@barefootjs/jsx` **2223/0**, go-template **553/0**, mojolicious **527/0**, xslate **353/0**.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_