### PR TITLE
feat(go-template): sort/reduce via the runtime evaluator — P1 (#2018)

### DIFF
--- a/.changeset/go-eval-sort-reduce.md
+++ b/.changeset/go-eval-sort-reduce.md
@@ -1,0 +1,17 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Lower standalone `.sort(cmp)` / `.reduce(fn, init)` on the Go adapter through the
+runtime evaluator (#2018, P1). The comparator / reducer body is serialized to a
+ParsedExpr JSON blob and evaluated per element by the new `bf_sort_eval` /
+`bf_reduce_eval` template helpers, with captured free variables threaded as
+`base_env` via `bf_env` — generalizing the fixed `bf_sort` / `bf_reduce`
+catalogues to any pure comparator / reducer body. A comparator the evaluator
+can't model (e.g. `localeCompare`) falls back to the legacy `bf_sort` path, so
+behavior there is unchanged. The runtime struct-field reader now resolves a JS
+field name (`id`) case-insensitively against the Go struct field (`ID`), which
+the evaluator's raw field names require. Rendered HTML is unchanged; only the
+emitted template text moves to the evaluator helpers. (The chained
+`.sort().map()` / `.filter().map()` loop-hoist and the mojo/xslate adapters keep
+the legacy path until their own phases.)

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -91,6 +91,16 @@ func FuncMap() template.FuncMap {
 		"bf_sort":            Sort,
 		"bf_reduce":          Reduce,
 
+		// Evaluator-driven higher-order folds (#2018): the comparator / reducer
+		// body travels as a serialized ParsedExpr (JSON) evaluated per element,
+		// generalizing bf_sort / bf_reduce beyond their fixed catalogues. The
+		// adapter falls back to bf_sort for a comparator the evaluator can't
+		// model (e.g. localeCompare). `bf_env` builds the captured-free-var
+		// environment passed as the trailing base_env argument.
+		"bf_sort_eval":   SortEval,
+		"bf_reduce_eval": FoldEval,
+		"bf_env":         Env,
+
 		// Comment marker (for hydration)
 		"bfComment":   Comment,
 		"bfTextStart": TextStart,

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -1612,7 +1612,18 @@ func getFieldValue(item any, field string) any {
 
 	fieldVal := v.FieldByName(field)
 	if !fieldVal.IsValid() {
-		return nil
+		// Case-variant fallback: the evaluator carries the JS field name
+		// (`id` / `url`) against a Go-capitalised struct field (`ID` / `URL`),
+		// which exact `FieldByName` misses and the initialism rules can't be
+		// reproduced char-for-char here. Match case-insensitively instead —
+		// `FieldByNameFunc` returns the zero Value (→ nil) for an ambiguous
+		// match, so it stays safe. The legacy bf_sort/bf_reduce pass an
+		// already-capitalised name, so they hit the exact match above and never
+		// reach this fallback.
+		fieldVal = v.FieldByNameFunc(func(n string) bool { return strings.EqualFold(n, field) })
+		if !fieldVal.IsValid() {
+			return nil
+		}
 	}
 	return fieldVal.Interface()
 }

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -875,6 +875,7 @@ func TestFuncMap(t *testing.T) {
 		"bf_len", "bf_at", "bf_includes", "bf_first", "bf_last",
 		"bf_arr", "bf_filter_truthy",
 		"bf_every", "bf_some", "bf_filter", "bf_find", "bf_find_index", "bf_sort",
+		"bf_sort_eval", "bf_reduce_eval", "bf_env",
 		"bfComment", "bfTextStart", "bfTextEnd", "bfPortalHTML",
 	}
 
@@ -882,6 +883,70 @@ func TestFuncMap(t *testing.T) {
 		if _, ok := fm[name]; !ok {
 			t.Errorf("FuncMap missing function: %s", name)
 		}
+	}
+}
+
+func TestEnv(t *testing.T) {
+	env := Env("factor", 2, "label", "x")
+	if env["factor"] != 2 || env["label"] != "x" {
+		t.Fatalf("Env built wrong map: %v", env)
+	}
+	if got := Env(); len(got) != 0 {
+		t.Fatalf("Env() with no pairs should be empty, got %v", got)
+	}
+	if got := Env("k"); len(got) != 0 {
+		t.Fatalf("Env with a dangling key should drop it, got %v", got)
+	}
+}
+
+// End-to-end wiring of the #2018 evaluator-driven folds through the template
+// FuncMap, driven by the exact JSON `serializeParsedExpr` emits for the callback
+// body — proves the P1 path from template call (`bf_sort_eval` / `bf_reduce_eval`
+// / `bf_env`) to result, including a captured free var in base_env.
+func TestEvalTemplateFuncs(t *testing.T) {
+	fm := FuncMap()
+	items := []any{
+		map[string]any{"price": 3.0},
+		map[string]any{"price": 1.0},
+		map[string]any{"price": 2.0},
+	}
+
+	// sort: a.price - b.price → ascending by price, no captures.
+	cmp := mustJSON(t, nbin("-", nmem(nid("a"), "price"), nmem(nid("b"), "price")))
+	sortTmpl := template.Must(template.New("s").Funcs(fm).Parse(
+		`{{range bf_sort_eval .Items .Cmp "a" "b" bf_env}}{{.price}} {{end}}`))
+	var sb strings.Builder
+	if err := sortTmpl.Execute(&sb, map[string]any{"Items": items, "Cmp": cmp}); err != nil {
+		t.Fatalf("sort tmpl: %v", err)
+	}
+	if got := sb.String(); got != "1 2 3 " {
+		t.Fatalf("bf_sort_eval = %q, want %q", got, "1 2 3 ")
+	}
+
+	// reduce: acc + item.price, init 0 → sum 6.
+	body := mustJSON(t, nbin("+", nid("acc"), nmem(nid("item"), "price")))
+	redTmpl := template.Must(template.New("r").Funcs(fm).Parse(
+		`{{bf_reduce_eval .Items .Body "acc" "item" 0.0 "left" bf_env}}`))
+	sb.Reset()
+	if err := redTmpl.Execute(&sb, map[string]any{"Items": items, "Body": body}); err != nil {
+		t.Fatalf("reduce tmpl: %v", err)
+	}
+	if got := sb.String(); got != "6" {
+		t.Fatalf("bf_reduce_eval = %q, want %q", got, "6")
+	}
+
+	// captured free var: comparator reads `factor` from base_env (bf_env).
+	cmp2 := mustJSON(t, nbin("-",
+		nbin("*", nmem(nid("a"), "price"), nid("factor")),
+		nbin("*", nmem(nid("b"), "price"), nid("factor"))))
+	capTmpl := template.Must(template.New("c").Funcs(fm).Parse(
+		`{{range bf_sort_eval .Items .Cmp "a" "b" (bf_env "factor" .Factor)}}{{.price}} {{end}}`))
+	sb.Reset()
+	if err := capTmpl.Execute(&sb, map[string]any{"Items": items, "Cmp": cmp2, "Factor": 2.0}); err != nil {
+		t.Fatalf("capture tmpl: %v", err)
+	}
+	if got := sb.String(); got != "1 2 3 " {
+		t.Fatalf("bf_sort_eval w/ base_env = %q, want %q", got, "1 2 3 ")
 	}
 }
 

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -976,6 +976,38 @@ func TestEvalFoldSortOverStruct(t *testing.T) {
 	}
 }
 
+// TestEvalFoldSortOverPascalKeyedMap reproduces the conformance render shape:
+// an inline anonymous prop (`items: { duration: number }[]`) has no named Go
+// struct, so the test harness emits `[]any{map[string]any{"Duration": 95}, …}`
+// with PascalCase keys (test-render.ts goArrayLiteralFromArray, capitalizeKeys).
+// The callback body carries the raw JS property (`t.duration`), so the map read
+// must resolve `duration` → `Duration` case-insensitively — otherwise the field
+// reads as null and the fold collapses to its seed (#2030 reduce-sum-field).
+func TestEvalFoldSortOverPascalKeyedMap(t *testing.T) {
+	items := []any{
+		map[string]any{"Duration": 95.0},
+		map[string]any{"Duration": 213.0},
+		map[string]any{"Duration": 185.0},
+	}
+
+	// reduce: sum + t.duration, seed 0 → 493
+	body := mustJSON(t, nbin("+", nid("sum"), nmem(nid("t"), "duration")))
+	if got := evalToNumber(FoldEval(items, body, "sum", "t", 0.0, "left", nil)); got != 493 {
+		t.Fatalf("FoldEval over PascalCase-keyed map = %v, want 493", got)
+	}
+
+	// sort: a.duration - b.duration → ascending
+	cmp := mustJSON(t, nbin("-", nmem(nid("a"), "duration"), nmem(nid("b"), "duration")))
+	sorted := SortEval(items, cmp, "a", "b", nil)
+	got := make([]float64, len(sorted))
+	for i, s := range sorted {
+		got[i] = s.(map[string]any)["Duration"].(float64)
+	}
+	if got[0] != 95 || got[1] != 185 || got[2] != 213 {
+		t.Fatalf("SortEval over PascalCase-keyed map = %v, want [95 185 213]", got)
+	}
+}
+
 // =============================================================================
 // Portal HTML Rendering Tests
 // =============================================================================

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -950,6 +950,32 @@ func TestEvalTemplateFuncs(t *testing.T) {
 	}
 }
 
+// SSR data is Go structs with capitalised fields, but a serialized callback
+// body carries the JS field name (`x.id`). Verify the evaluator's field reader
+// resolves it case-variantly against the struct field (ID) for both fold and
+// sort — the path the real template render uses.
+func TestEvalFoldSortOverStruct(t *testing.T) {
+	type item struct{ ID int }
+	items := []item{{ID: 10}, {ID: 5}, {ID: 7}}
+
+	// reduce: acc + x.id, seed 0 → 22
+	body := mustJSON(t, nbin("+", nid("acc"), nmem(nid("x"), "id")))
+	if got := evalToNumber(FoldEval(items, body, "acc", "x", 0.0, "left", nil)); got != 22 {
+		t.Fatalf("FoldEval over struct = %v, want 22", got)
+	}
+
+	// sort: a.id - b.id → ascending by ID
+	cmp := mustJSON(t, nbin("-", nmem(nid("a"), "id"), nmem(nid("b"), "id")))
+	sorted := SortEval(items, cmp, "a", "b", nil)
+	got := make([]int, len(sorted))
+	for i, s := range sorted {
+		got[i] = s.(item).ID
+	}
+	if got[0] != 5 || got[1] != 7 || got[2] != 10 {
+		t.Fatalf("SortEval over struct = %v, want [5 7 10]", got)
+	}
+}
+
 // =============================================================================
 // Portal HTML Rendering Tests
 // =============================================================================

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -897,6 +897,11 @@ func TestEnv(t *testing.T) {
 	if got := Env("k"); len(got) != 0 {
 		t.Fatalf("Env with a dangling key should drop it, got %v", got)
 	}
+	// A non-string key (only reachable by a malformed template call) is
+	// skipped, not collapsed into an `env[""]` slot.
+	if got := Env(42, "v", "real", 7); len(got) != 1 || got["real"] != 7 {
+		t.Fatalf("Env should skip a non-string key, got %v", got)
+	}
 }
 
 // End-to-end wiring of the #2018 evaluator-driven folds through the template

--- a/packages/adapter-go-template/runtime/eval.go
+++ b/packages/adapter-go-template/runtime/eval.go
@@ -501,8 +501,12 @@ func evalReadProperty(obj any, key string) any {
 		}
 		return nil
 	case map[string]any:
-		// A missing key reads as null (the backends' single absent value).
-		return o[key]
+		// Case-variant lookup: a callback body reads the raw JS property
+		// (`t.duration`), but test data / Go-keyed maps may carry PascalCase
+		// keys (`{"Duration": …}`). Reuse the field reader the sort / reduce
+		// helpers use — it resolves `duration` → `Duration` and reads a
+		// genuinely missing key as null (the backends' single absent value).
+		return getFieldValue(o, key)
 	case nil:
 		return nil
 	default:

--- a/packages/adapter-go-template/runtime/eval.go
+++ b/packages/adapter-go-template/runtime/eval.go
@@ -615,11 +615,16 @@ func SortEval(items any, cmpJSON, paramA, paramB string, baseEnv map[string]any)
 // flat key, value, key, value, … argument list — the adapter emits
 // `bf_env "k1" v1 "k2" v2 …` for the free variables a callback body references
 // beyond its own params. An odd trailing key with no value is ignored; with no
-// pairs it returns an empty (non-nil) map, the no-capture case.
+// pairs it returns an empty (non-nil) map, the no-capture case. A non-string
+// key (only reachable by a malformed template call, never by the adapter's
+// quoted-literal emit) is skipped rather than collapsed into an `env[""]` slot.
 func Env(pairs ...any) map[string]any {
 	env := make(map[string]any, len(pairs)/2)
 	for i := 0; i+1 < len(pairs); i += 2 {
-		key, _ := pairs[i].(string)
+		key, ok := pairs[i].(string)
+		if !ok {
+			continue
+		}
 		env[key] = pairs[i+1]
 	}
 	return env

--- a/packages/adapter-go-template/runtime/eval.go
+++ b/packages/adapter-go-template/runtime/eval.go
@@ -607,6 +607,20 @@ func SortEval(items any, cmpJSON, paramA, paramB string, baseEnv map[string]any)
 	return arr
 }
 
+// Env builds the captured-free-var environment for FoldEval / SortEval from a
+// flat key, value, key, value, … argument list — the adapter emits
+// `bf_env "k1" v1 "k2" v2 …` for the free variables a callback body references
+// beyond its own params. An odd trailing key with no value is ignored; with no
+// pairs it returns an empty (non-nil) map, the no-capture case.
+func Env(pairs ...any) map[string]any {
+	env := make(map[string]any, len(pairs)/2)
+	for i := 0; i+1 < len(pairs); i += 2 {
+		key, _ := pairs[i].(string)
+		env[key] = pairs[i+1]
+	}
+	return env
+}
+
 func evalReadIndex(obj any, index any) any {
 	switch o := obj.(type) {
 	case []any:

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -2864,14 +2864,17 @@ describe('GoTemplateAdapter - #1448 Tier A/B fixture-driven lowering pins', () =
     // standalone shapes inline the helper at the call site.
     { fixture: arraySortFieldAscFixture,  expect: 'bf_sort .Items "field" "Price" "numeric" "asc"' },
     { fixture: arraySortFieldDescFixture, expect: 'bf_sort .Items "field" "Price" "numeric" "desc"' },
-    { fixture: arraySortPrimitiveFixture, expect: 'bf_sort .Nums "self" "" "numeric" "asc"' },
+    // Standalone numeric sorts now lower through the evaluator (#2018): the
+    // comparator body travels as serialized ParsedExpr to `bf_sort_eval`.
+    { fixture: arraySortPrimitiveFixture, expect: 'bf_sort_eval .Nums' },
+    // localeCompare can't be evaluated, so it keeps the legacy `bf_sort` path.
     { fixture: arraySortLocaleFixture,    expect: 'bf_sort .Names "self" "" "string" "asc"' },
     // Multi-key (`||`-chain): one 4-string group per comparison key,
     // applied in priority order as tie-breakers.
     { fixture: arraySortMultiKeyFixture,  expect: 'bf_sort .Items "field" "Price" "numeric" "asc" "field" "Name" "string" "asc"' },
     // Relational-ternary comparator lowers to a single `auto` key.
     { fixture: arraySortTernaryFixture,   expect: 'bf_sort .Items "field" "Rank" "auto" "asc"' },
-    { fixture: arrayToSortedFixture,      expect: 'bf_sort .Nums "self" "" "numeric" "asc"' },
+    { fixture: arrayToSortedFixture,      expect: 'bf_sort_eval .Nums' },
     // #1448 Tier B — iteration shapes. These are loop-level
     // patterns (range binding order), not helper function calls.
     { fixture: arrayEntriesFixture,       expect: '{{range $i, $v := .Items}}' },
@@ -2916,14 +2919,14 @@ describe('GoTemplateAdapter - #1448 Tier A/B fixture-driven lowering pins', () =
 // now listed in `UNSUPPORTED_METHODS`, so `isSupported` refuses them
 // and `convertExpressionToGo` records BF101 — the same treatment the
 // unsupported array methods already got. These tests pin that parity.
-describe('GoTemplateAdapter - #1448 Tier C reduce field capitalisation', () => {
-  // #1728 review: `bf_reduce`'s projected field name must use the same
-  // initialism-aware capitalisation the adapter applies when generating
-  // struct fields (`capitalizeFieldName`), or the runtime reflect lookup
-  // misses the exported field (`id` → struct `ID`, not `Id`) and folds a
-  // zero value. Pin the emitted key so a regression to plain
-  // first-letter capitalisation fails here.
-  test('reduce over an initialism field emits the Go-initialism key (ID, not Id)', () => {
+describe('GoTemplateAdapter - #2018 reduce via the evaluator', () => {
+  // A standalone `.reduce(fn, init)` now lowers through the evaluator: the
+  // reducer body is serialized to ParsedExpr JSON and folded by `bf_reduce_eval`.
+  // The body carries the JS field name (`x.id`); the runtime field reader
+  // (`getFieldValue`) resolves it case-variantly against the Go struct field
+  // (`ID`) at render time, so no compile-time capitalisation is needed (the
+  // former #1728 initialism gotcha is moot on this path).
+  test('reduce over a field lowers to bf_reduce_eval with the serialized body', () => {
     const adapter = new GoTemplateAdapter()
     const ir = compileToIR(`
 function C({ items }: { items: { id: number }[] }) {
@@ -2932,8 +2935,9 @@ function C({ items }: { items: { id: number }[] }) {
 export { C }
 `, adapter)
     const template = adapter.generate(ir).template ?? ''
-    expect(template).toContain('bf_reduce .Items "+" "field" "ID" "numeric" "0"')
-    expect(template).not.toContain('"Id"')
+    expect(template).toContain('bf_reduce_eval .Items')
+    // The seed is threaded through bf_number; the body is the serialized tree.
+    expect(template).toContain('(bf_number "0")')
   })
 })
 

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -50,6 +50,8 @@ import {
   type SupportResult,
   isBooleanAttr,
   parseExpression,
+  serializeParsedExpr,
+  freeVarsInBody,
   stringifyParsedExpr,
   parseStyleObjectEntries,
   isSupported,
@@ -82,6 +84,8 @@ import {
   wrapGoArg,
   emitBfSort,
   emitBfReduce,
+  emitSortEval,
+  emitReduceEval,
   stringTolerantEqOperands,
   buildUnsupportedSuggestion,
   GO_REMEDIATION_OPTIONS,
@@ -3152,7 +3156,11 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // `.sort().map()` loop hoist in `renderLoop` (both feed `bf_sort` the same 4
     // string operands). `method` is preserved for future divergence but unused.
     void method
-    return emitBfSort(emit(object), comparator)
+    const recv = emit(object)
+    // Prefer the evaluator (#2018): the comparator body is serialized and
+    // evaluated per comparison. Falls back to the structured `bf_sort` for a
+    // comparator the evaluator can't model (e.g. localeCompare).
+    return emitSortEval(recv, comparator, emit) ?? emitBfSort(recv, comparator)
   }
 
   reduceMethod(
@@ -3166,7 +3174,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // feed the `bf_reduce` runtime helper, which folds the receiver into a
     // scalar.
     const direction = method === 'reduceRight' ? 'right' : 'left'
-    return emitBfReduce(emit(object), reduceOp, direction)
+    const recv = emit(object)
+    // Prefer the evaluator (#2018): the reducer body is serialized and folded
+    // per element. Falls back to the structured `bf_reduce` if it can't model
+    // the body (the arithmetic-fold catalogue always serializes, so this is
+    // defensive).
+    return emitReduceEval(recv, reduceOp, direction, emit) ?? emitBfReduce(recv, reduceOp, direction)
   }
 
   flatMethod(object: ParsedExpr, depth: FlatDepth, emit: (e: ParsedExpr) => string): string {

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -50,8 +50,6 @@ import {
   type SupportResult,
   isBooleanAttr,
   parseExpression,
-  serializeParsedExpr,
-  freeVarsInBody,
   stringifyParsedExpr,
   parseStyleObjectEntries,
   isSupported,

--- a/packages/adapter-go-template/src/adapter/lib/go-emit.ts
+++ b/packages/adapter-go-template/src/adapter/lib/go-emit.ts
@@ -4,7 +4,8 @@
  * Pure free functions — none read adapter instance state.
  */
 
-import type { SortComparator, ReduceOp, SupportResult } from '@barefootjs/jsx'
+import type { SortComparator, ReduceOp, SupportResult, ParsedExpr } from '@barefootjs/jsx'
+import { parseExpression, serializeParsedExpr, freeVarsInBody } from '@barefootjs/jsx'
 
 import { capitalize } from "./go-naming.ts"
 
@@ -84,6 +85,64 @@ export function emitBfReduce(recv: string, op: ReduceOp, direction: 'left' | 'ri
   // `op.init` is the decoded seed value (canonical decimal / escape-free
   // contents); passed as a quoted operand the runtime interprets by `type`.
   return `bf_reduce ${wrapIfMultiToken(recv)} "${op.op}" "${op.key.kind}" "${keyName}" "${op.type}" "${escapeGoString(op.init)}" "${direction}"`
+}
+
+/**
+ * Build the `bf_env` base_env argument for a callback body: one `"name" <value>`
+ * pair per captured free variable (a body identifier that isn't a callback
+ * param), each lowered to its Go template value via `emit`. No captures →
+ * the bare `bf_env` (an empty env).
+ */
+function emitEvalEnvArg(body: ParsedExpr, params: string[], emit: (e: ParsedExpr) => string): string {
+  const free = freeVarsInBody(body, new Set(params))
+  if (free.length === 0) return 'bf_env'
+  const pairs = free.map(
+    n => `"${escapeGoString(n)}" ${wrapIfMultiToken(emit({ kind: 'identifier', name: n }))}`,
+  )
+  return `(bf_env ${pairs.join(' ')})`
+}
+
+/**
+ * Emit a `.sort(cmp)` via the evaluator (#2018): the comparator body travels as
+ * serialized-ParsedExpr JSON, evaluated per comparison against `{paramA, paramB,
+ * …captured}`. Returns null when the comparator can't be evaluated (e.g. a
+ * `localeCompare` body — `serializeParsedExpr` refuses it), so the caller falls
+ * back to the structured `bf_sort`. A `||`-chained multi-key comparator needs no
+ * special handling — JS `0 || next` is exactly the tie-break semantics.
+ */
+export function emitSortEval(
+  recv: string,
+  c: SortComparator,
+  emit: (e: ParsedExpr) => string,
+): string | null {
+  const body = parseExpression(c.raw)
+  const json = serializeParsedExpr(body)
+  if (json === null) return null
+  const env = emitEvalEnvArg(body, [c.paramA, c.paramB], emit)
+  return `bf_sort_eval ${wrapIfMultiToken(recv)} "${escapeGoString(json)}" "${c.paramA}" "${c.paramB}" ${env}`
+}
+
+/**
+ * Emit a `.reduce(fn, init)` via the evaluator (#2018): the reducer body travels
+ * as serialized-ParsedExpr JSON, folded over the receiver from `init`. Returns
+ * null when the body can't be evaluated (→ caller falls back to `bf_reduce`). A
+ * numeric seed is passed through `bf_number` (handles any decimal incl. negative
+ * / float); a concat seed as a quoted string.
+ */
+export function emitReduceEval(
+  recv: string,
+  op: ReduceOp,
+  direction: 'left' | 'right',
+  emit: (e: ParsedExpr) => string,
+): string | null {
+  const body = parseExpression(op.raw)
+  const json = serializeParsedExpr(body)
+  if (json === null) return null
+  const env = emitEvalEnvArg(body, [op.paramAcc, op.paramItem], emit)
+  const init = op.type === 'string'
+    ? `"${escapeGoString(op.init)}"`
+    : `(bf_number "${escapeGoString(op.init)}")`
+  return `bf_reduce_eval ${wrapIfMultiToken(recv)} "${escapeGoString(json)}" "${op.paramAcc}" "${op.paramItem}" ${init} "${direction}" ${env}`
 }
 
 /**


### PR DESCRIPTION
## Why

P1 of the EXPR2 migration (#2018): now that the evaluator seam (`serializeParsedExpr`
/ `freeVarsInBody`, P0) and the Go evaluator runtime (`SortEval`/`FoldEval`) are
in place, route the Go adapter's standalone `.sort(cmp)` / `.reduce(fn, init)`
through the evaluator instead of the fixed `bf_sort` / `bf_reduce` catalogues.

## What

**Runtime** (`runtime/bf.go`, `eval.go`):
- Register `bf_sort_eval` (SortEval) and `bf_reduce_eval` (FoldEval) as template
  funcs, plus `bf_env` (new `Env`) to build the captured-free-var `base_env`.
- `getFieldValue` gains a case-insensitive fallback so the evaluator's raw JS
  field name (`id`) resolves against the Go-capitalised struct field (`ID`).
  Legacy `bf_sort`/`bf_reduce` pass already-capitalised names and hit the exact
  match first, so they're unchanged.

**Emit** (`adapter/lib/go-emit.ts`, `go-template-adapter.ts`):
- `sortMethod` / `reduceMethod` serialize the comparator / reducer body and emit
  `bf_sort_eval` / `bf_reduce_eval` with `base_env` built from the body's free
  vars (lowered via the adapter's identifier emit). A `||`-chained multi-key
  comparator needs no special handling — JS `0 || next` is the tie-break.
- **localeCompare** (and any body the evaluator can't model) → `serializeParsedExpr`
  returns null → automatic fallback to legacy `bf_sort`. Behavior there is
  unchanged, per the agreed scope.

The chained `.sort().map()` / `.filter().map()` loop-hoist stays on `bf_sort`
(its own phase, P3); mojo/xslate keep the legacy path until P1-perl.

## Invariant

Rendered HTML is unchanged — only the emitted template text moves to the eval
helpers (template-text fixtures updated in this PR). Go render parity is the gate
(CI; locally the conformance render harness skips Go).

## Verification

- `go test ./...` — new tests cover the eval template funcs end-to-end (incl.
  captured free var) and fold/sort over **Go structs** (case-variant field read);
  `go vet` clean.
- `@barefootjs/jsx` 0-fail; go-template adapter **553/0**; adapter-tests
  conformance **789/0**; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_