### PR TITLE
feat(perl): lower standalone .sort/.reduce through the runtime evaluator (#2018 P1)

### DIFF
--- a/.changeset/free-vars-skip-builtins.md
+++ b/.changeset/free-vars-skip-builtins.md
@@ -1,0 +1,13 @@
+---
+"@barefootjs/jsx": patch
+---
+
+`freeVarsInBody` no longer captures builtin call callees (`Math.<fn>`,
+`String` / `Number` / `Boolean`) as free variables. The evaluator resolves
+those syntactically, so emitting them into a callback's `base_env` produced an
+undefined template reference (`$Math` / `.Math`) for any comparator / reducer /
+predicate body that called a builtin — e.g. `(a, b) => Math.abs(a) - Math.abs(b)`
+(Copilot review #2031). The arguments of such a call are still real references
+and remain captured. Latent until now because no shipped fixture used a builtin
+inside a serialized callback body; the fix covers both the Go and Perl
+evaluator-emit paths.

--- a/.changeset/perl-eval-sort-reduce.md
+++ b/.changeset/perl-eval-sort-reduce.md
@@ -1,0 +1,20 @@
+---
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+"@barefootjs/perl": patch
+---
+
+Lower standalone `.sort(cmp)` / `.reduce(fn, init)` on the Mojolicious and
+Xslate adapters through the runtime evaluator (#2018, P1 — the Perl half of the
+Go change). The comparator / reducer body is serialized to a ParsedExpr JSON
+blob and evaluated per element by the new `bf->sort_eval` / `bf->reduce_eval`
+(`$bf.sort_eval` / `$bf.reduce_eval` in Xslate) helpers, with captured free
+variables threaded as a `base_env` hashref — generalizing the fixed `bf->sort` /
+`bf->reduce` catalogues to any pure comparator / reducer body. A comparator the
+evaluator can't model (e.g. `localeCompare`) falls back to the legacy `bf->sort`
+path, so behavior there is unchanged. The shared Perl runtime gains
+`BarefootJS::Evaluator::fold_json` / `sort_by_json` (the JSON-string seam the
+templates emit into) and the `sort_eval` / `reduce_eval` controller helpers.
+Rendered HTML is unchanged; only the emitted template text moves to the
+evaluator helpers. The chained `.sort().map()` / `.filter().map()` loop-hoist
+keeps the legacy path until its own phase (P3).

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -1355,19 +1355,26 @@ describe('MojoAdapter - #1448 Tier A/B fixture-driven lowering pins', () => {
     // #1448 Tier B — string → string, padded to a target width.
     { fixture: stringPadStartFixture,   expect: `bf->pad_start($value, 5, '0')` },
     { fixture: stringPadEndFixture,     expect: `bf->pad_end($value, 5, '.')` },
-    // #1448 Tier B — sort / toSorted. The loop-chained field cases
-    // hoist into a `my $bf_iter_lN = bf->sort(...)` local; the
-    // standalone primitive cases inline the call. Each comparison key
-    // is one hash under `keys` (a single-key comparator → one element).
+    // #1448 Tier B — sort / toSorted. EXPR2 migration (#2018): a
+    // STANDALONE `.sort(cmp)` value call serializes the comparator body
+    // and emits `bf->sort_eval(...)` (JSON body + param names + captured
+    // env). The loop-chained `.sort().map()` field cases still hoist into
+    // a `my $bf_iter_lN = bf->sort(...)` legacy local (loop-hoist de-fold
+    // is P3, not this phase). `localeCompare` comparators fall back to the
+    // structured `bf->sort` — `serializeParsedExpr` refuses them.
     { fixture: arraySortFieldAscFixture,  expect: `bf->sort($items, { keys => [{ key_kind => 'field', key => 'price', compare_type => 'numeric', direction => 'asc' }] })` },
     { fixture: arraySortFieldDescFixture, expect: `bf->sort($items, { keys => [{ key_kind => 'field', key => 'price', compare_type => 'numeric', direction => 'desc' }] })` },
-    { fixture: arraySortPrimitiveFixture, expect: `bf->sort($nums, { keys => [{ key_kind => 'self', compare_type => 'numeric', direction => 'asc' }] })` },
+    { fixture: arraySortPrimitiveFixture, expect: `bf->sort_eval($nums, '{"kind":"binary","op":"-","left":{"kind":"identifier","name":"a"},"right":{"kind":"identifier","name":"b"}}', 'a', 'b', {})` },
+    // localeCompare → outside the evaluator surface → legacy `bf->sort`.
     { fixture: arraySortLocaleFixture,    expect: `bf->sort($names, { keys => [{ key_kind => 'self', compare_type => 'string', direction => 'asc' }] })` },
-    // Multi-key (`||`-chain): one hash per comparison key, in order.
+    // Multi-key (`||`-chain): the second key is a `localeCompare`, so the
+    // whole comparator falls back to the structured `bf->sort` (one hash
+    // per comparison key, in order).
     { fixture: arraySortMultiKeyFixture,  expect: `bf->sort($items, { keys => [{ key_kind => 'field', key => 'price', compare_type => 'numeric', direction => 'asc' }, { key_kind => 'field', key => 'name', compare_type => 'string', direction => 'asc' }] })` },
-    // Relational-ternary comparator lowers to a single `auto` key.
+    // Relational-ternary comparator — loop-hoisted (`.sort().map()`), so
+    // it stays on the legacy `auto`-key `bf->sort` until P3.
     { fixture: arraySortTernaryFixture,   expect: `bf->sort($items, { keys => [{ key_kind => 'field', key => 'rank', compare_type => 'auto', direction => 'asc' }] })` },
-    { fixture: arrayToSortedFixture,      expect: `bf->sort($nums, { keys => [{ key_kind => 'self', compare_type => 'numeric', direction => 'asc' }] })` },
+    { fixture: arrayToSortedFixture,      expect: `bf->sort_eval($nums, '{"kind":"binary","op":"-","left":{"kind":"identifier","name":"a"},"right":{"kind":"identifier","name":"b"}}', 'a', 'b', {})` },
     // #1448 Tier B — iteration shapes. These are loop-level patterns.
     // .entries() → for loop with both $i index var and $v value var
     { fixture: arrayEntriesFixture,       expect: '% my $v = $items->[$i];' },
@@ -1375,17 +1382,19 @@ describe('MojoAdapter - #1448 Tier A/B fixture-driven lowering pins', () => {
     { fixture: arrayKeysFixture,          expect: '% for my $k (0..$#{$items})' },
     // .values() → standard for loop (same as plain .map())
     { fixture: arrayValuesFixture,        expect: '% my $v = $items->[$_i];' },
-    // #1448 Tier C — .reduce(fn, init) arithmetic fold. The structured
-    // ReduceOp lowers to a single `bf->reduce(...)` call with op /
-    // key / type / init / direction in the options hash. Each shape
-    // exercises one arm: field-numeric sum, self-numeric sum,
-    // string-concat fold, the product (`*`) operator, and the
-    // right-to-left `direction` of reduceRight.
-    { fixture: reduceSumFieldFixture,     expect: `bf->reduce($items, { op => '+', key_kind => 'field', key => 'duration', type => 'numeric', init => 0, direction => 'left' })` },
-    { fixture: reduceSumSelfFixture,      expect: `bf->reduce($nums, { op => '+', key_kind => 'self', type => 'numeric', init => 0, direction => 'left' })` },
-    { fixture: reduceConcatFixture,       expect: `bf->reduce($items, { op => '+', key_kind => 'field', key => 'label', type => 'string', init => '', direction => 'left' })` },
-    { fixture: reduceProductFixture,      expect: `bf->reduce($items, { op => '*', key_kind => 'field', key => 'qty', type => 'numeric', init => 1, direction => 'left' })` },
-    { fixture: reduceRightConcatFixture,  expect: `bf->reduce($items, { op => '+', key_kind => 'field', key => 'label', type => 'string', init => '', direction => 'right' })` },
+    // #1448 Tier C — .reduce(fn, init) arithmetic fold. EXPR2 migration
+    // (#2018): the reducer body is serialized to ParsedExpr JSON and
+    // folded by `bf->reduce_eval(json, accName, itemName, init, direction,
+    // env)` — the runtime evaluator subsumes the old `+`/`*` catalogue.
+    // A numeric seed passes through bare (`0` / `1`); a concat seed as a
+    // single-quoted string (`''`). Each shape exercises one arm: field-
+    // numeric sum, self-numeric sum, string-concat fold, the product
+    // (`*`) operator, and the right-to-left `direction` of reduceRight.
+    { fixture: reduceSumFieldFixture,     expect: `bf->reduce_eval($items, '{"kind":"binary","op":"+","left":{"kind":"identifier","name":"sum"},"right":{"kind":"member","object":{"kind":"identifier","name":"t"},"property":"duration"}}', 'sum', 't', 0, 'left', {})` },
+    { fixture: reduceSumSelfFixture,      expect: `bf->reduce_eval($nums, '{"kind":"binary","op":"+","left":{"kind":"identifier","name":"a"},"right":{"kind":"identifier","name":"b"}}', 'a', 'b', 0, 'left', {})` },
+    { fixture: reduceConcatFixture,       expect: `bf->reduce_eval($items, '{"kind":"binary","op":"+","left":{"kind":"identifier","name":"acc"},"right":{"kind":"member","object":{"kind":"identifier","name":"x"},"property":"label"}}', 'acc', 'x', '', 'left', {})` },
+    { fixture: reduceProductFixture,      expect: `bf->reduce_eval($items, '{"kind":"binary","op":"*","left":{"kind":"identifier","name":"acc"},"right":{"kind":"member","object":{"kind":"identifier","name":"x"},"property":"qty"}}', 'acc', 'x', 1, 'left', {})` },
+    { fixture: reduceRightConcatFixture,  expect: `bf->reduce_eval($items, '{"kind":"binary","op":"+","left":{"kind":"identifier","name":"acc"},"right":{"kind":"member","object":{"kind":"identifier","name":"x"},"property":"label"}}', 'acc', 'x', '', 'right', {})` },
   ]
 
   for (const { fixture, expect: expectedHelper } of cases) {

--- a/packages/adapter-mojolicious/src/adapter/expr/array-method.ts
+++ b/packages/adapter-mojolicious/src/adapter/expr/array-method.ts
@@ -7,6 +7,11 @@
  * argument recursion and read no adapter instance state.
  */
 
+import {
+  parseExpression,
+  serializeParsedExpr,
+  freeVarsInBody,
+} from '@barefootjs/jsx'
 import type {
   ParsedExpr,
   ArrayMethod,
@@ -235,6 +240,79 @@ export function renderArrayMethod(
       )
     }
   }
+}
+
+/** Escape a string for embedding in a Perl single-quoted literal. */
+function escapePerlSingleQuote(s: string): string {
+  // Double every backslash and escape apostrophes: Perl single-quote
+  // un-escaping then restores the original bytes (a JSON `\\` must reach
+  // `JSON::PP->decode` as `\\`, so it travels as `\\\\` in the literal).
+  return s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
+}
+
+/**
+ * Build the `base_env` hashref argument for an evaluator call: the
+ * comparator / reducer body's free variables (body idents minus the
+ * callback params), each materialised to its SSR value via `emit`. An
+ * empty capture set yields `{}` — the runtime's seed-once env.
+ */
+function emitEvalEnvArg(
+  body: ParsedExpr,
+  params: string[],
+  emit: (e: ParsedExpr) => string,
+): string {
+  const free = freeVarsInBody(body, new Set(params))
+  if (free.length === 0) return '{}'
+  const pairs = free.map(
+    n => `'${escapePerlSingleQuote(n)}' => ${emit({ kind: 'identifier', name: n })}`,
+  )
+  return `{ ${pairs.join(', ')} }`
+}
+
+/**
+ * Emit a `.sort(cmp)` / `.toSorted(cmp)` via the runtime evaluator (#2018):
+ * the comparator body travels as serialized-ParsedExpr JSON, evaluated per
+ * comparison against `{paramA, paramB, …captured}`. Returns null when the
+ * body can't be evaluated (e.g. a `localeCompare` comparator —
+ * `serializeParsedExpr` refuses it), so the caller falls back to the
+ * structured `bf->sort`. A `||`-chained multi-key comparator needs no
+ * special handling — JS `0 || next` is exactly the tie-break semantics.
+ */
+export function renderSortEval(
+  recv: string,
+  c: SortComparator,
+  emit: (e: ParsedExpr) => string,
+): string | null {
+  const body = parseExpression(c.raw)
+  const json = serializeParsedExpr(body)
+  if (json === null) return null
+  const env = emitEvalEnvArg(body, [c.paramA, c.paramB], emit)
+  return `bf->sort_eval(${recv}, '${escapePerlSingleQuote(json)}', '${c.paramA}', '${c.paramB}', ${env})`
+}
+
+/**
+ * Emit a `.reduce(fn, init)` / `.reduceRight(fn, init)` via the runtime
+ * evaluator (#2018): the reducer body travels as serialized-ParsedExpr JSON,
+ * folded over the receiver from `init` in `direction` order. Returns null when
+ * the body can't be evaluated (→ caller falls back to `bf->reduce`). A numeric
+ * seed passes through as a bare Perl number; a concat seed as a single-quoted
+ * string.
+ */
+export function renderReduceEval(
+  recv: string,
+  op: ReduceOp,
+  direction: 'left' | 'right',
+  emit: (e: ParsedExpr) => string,
+): string | null {
+  const body = parseExpression(op.raw)
+  const json = serializeParsedExpr(body)
+  if (json === null) return null
+  const env = emitEvalEnvArg(body, [op.paramAcc, op.paramItem], emit)
+  const init =
+    op.type === 'string'
+      ? `'${escapePerlSingleQuote(op.init)}'`
+      : op.init
+  return `bf->reduce_eval(${recv}, '${escapePerlSingleQuote(json)}', '${op.paramAcc}', '${op.paramItem}', ${init}, '${direction}', ${env})`
 }
 
 /**

--- a/packages/adapter-mojolicious/src/adapter/expr/emitters.ts
+++ b/packages/adapter-mojolicious/src/adapter/expr/emitters.ts
@@ -35,6 +35,8 @@ import {
   renderArrayMethod,
   renderSortMethod,
   renderReduceMethod,
+  renderSortEval,
+  renderReduceEval,
   renderFlatMethod,
   renderFlatMapMethod,
 } from './array-method.ts'
@@ -190,11 +192,17 @@ export class MojoFilterEmitter implements ParsedExprEmitter {
     comparator: SortComparator,
     emit: (e: ParsedExpr) => string,
   ): string {
-    return renderSortMethod(emit(object), comparator)
+    const recv = emit(object)
+    // Evaluator path (#2018): serialize the comparator body + emit
+    // `bf->sort_eval`; fall back to the structured `bf->sort` when the
+    // body is outside the evaluator surface (e.g. `localeCompare`).
+    return renderSortEval(recv, comparator, emit) ?? renderSortMethod(recv, comparator)
   }
 
   reduceMethod(method: 'reduce' | 'reduceRight', object: ParsedExpr, reduceOp: ReduceOp, emit: (e: ParsedExpr) => string): string {
-    return renderReduceMethod(emit(object), reduceOp, method === 'reduceRight' ? 'right' : 'left')
+    const recv = emit(object)
+    const direction = method === 'reduceRight' ? 'right' : 'left'
+    return renderReduceEval(recv, reduceOp, direction, emit) ?? renderReduceMethod(recv, reduceOp, direction)
   }
 
   flatMethod(object: ParsedExpr, depth: FlatDepth, emit: (e: ParsedExpr) => string): string {
@@ -430,11 +438,17 @@ export class MojoTopLevelEmitter implements ParsedExprEmitter {
     comparator: SortComparator,
     emit: (e: ParsedExpr) => string,
   ): string {
-    return renderSortMethod(emit(object), comparator)
+    const recv = emit(object)
+    // Evaluator path (#2018): serialize the comparator body + emit
+    // `bf->sort_eval`; fall back to the structured `bf->sort` when the
+    // body is outside the evaluator surface (e.g. `localeCompare`).
+    return renderSortEval(recv, comparator, emit) ?? renderSortMethod(recv, comparator)
   }
 
   reduceMethod(method: 'reduce' | 'reduceRight', object: ParsedExpr, reduceOp: ReduceOp, emit: (e: ParsedExpr) => string): string {
-    return renderReduceMethod(emit(object), reduceOp, method === 'reduceRight' ? 'right' : 'left')
+    const recv = emit(object)
+    const direction = method === 'reduceRight' ? 'right' : 'left'
+    return renderReduceEval(recv, reduceOp, direction, emit) ?? renderReduceMethod(recv, reduceOp, direction)
   }
 
   flatMethod(object: ParsedExpr, depth: FlatDepth, emit: (e: ParsedExpr) => string): string {

--- a/packages/adapter-perl/MANIFEST
+++ b/packages/adapter-perl/MANIFEST
@@ -2,6 +2,7 @@ Changes
 cpanfile
 lib/BarefootJS.pm
 lib/BarefootJS/DevReload.pm
+lib/BarefootJS/Evaluator.pm
 lib/BarefootJS/SearchParams.pm
 LICENSE
 MANIFEST

--- a/packages/adapter-perl/lib/BarefootJS.pm
+++ b/packages/adapter-perl/lib/BarefootJS.pm
@@ -8,6 +8,7 @@ no warnings 'experimental::signatures';
 
 use POSIX ();
 use Scalar::Util qw(looks_like_number weaken);
+use BarefootJS::Evaluator ();
 
 # NOTE: This runtime is template-engine-agnostic AND framework-agnostic by
 # design, so it can ship as a standalone CPAN distribution. It depends only on
@@ -1088,6 +1089,19 @@ sub pad_end ($self, $recv, $target, $pad = undef) {
 #
 # A future `nulls => 'first' | 'last'` knob can land per key without
 # churn — the opts hash is the right place to grow.
+
+# Evaluator-driven sort / reduce (#2018): the comparator / reducer body rides
+# as a serialized-ParsedExpr JSON string and is evaluated per element, delegating
+# to the shared BarefootJS::Evaluator. The adapter emits `bf->sort_eval(...)` /
+# `bf->reduce_eval(...)` for any pure comparator / reducer body; a body it can't
+# model (e.g. localeCompare) keeps the legacy `bf->sort` / `bf->reduce` path.
+sub sort_eval ($self, $recv, $cmp_json, $param_a, $param_b, $base_env = {}) {
+    return BarefootJS::Evaluator::sort_by_json($recv, $cmp_json, $param_a, $param_b, $base_env);
+}
+
+sub reduce_eval ($self, $recv, $body_json, $acc_name, $item_name, $init, $direction = 'left', $base_env = {}) {
+    return BarefootJS::Evaluator::fold_json($recv, $body_json, $acc_name, $item_name, $init, $direction, $base_env);
+}
 
 sub sort ($self, $recv, $opts = {}) {
     return [] unless ref($recv) eq 'ARRAY';

--- a/packages/adapter-perl/lib/BarefootJS/Evaluator.pm
+++ b/packages/adapter-perl/lib/BarefootJS/Evaluator.pm
@@ -436,4 +436,17 @@ sub sort_by ($items, $cmp, $param_a, $param_b, $base_env = undef) {
     return [ map { $_->[1] } @sorted ];
 }
 
+# JSON entry points for the adapters: decode the callback body once, then fold /
+# sort. Mirror the Go `bf_reduce_eval` / `bf_sort_eval` template funcs, which the
+# adapters emit with a serialized-ParsedExpr body argument.
+sub fold_json ($items, $body_json, $acc_name, $item_name, $init, $direction = 'left', $base_env = undef) {
+    require JSON::PP;
+    return fold($items, JSON::PP->new->decode($body_json), $acc_name, $item_name, $init, $direction, $base_env);
+}
+
+sub sort_by_json ($items, $cmp_json, $param_a, $param_b, $base_env = undef) {
+    require JSON::PP;
+    return sort_by($items, JSON::PP->new->decode($cmp_json), $param_a, $param_b, $base_env);
+}
+
 1;

--- a/packages/adapter-perl/t/evaluator.t
+++ b/packages/adapter-perl/t/evaluator.t
@@ -159,4 +159,35 @@ subtest 'sort_by is stable for equal keys' => sub {
     is_deeply([ map { $_->{id} } @$mixed ], [ 'y', 'x', 'z' ], 'tie (x,z) stays in input order');
 };
 
+# fold_json / sort_by_json are the JSON-string seam the adapters emit into:
+# the serialized ParsedExpr body travels as a `bf->reduce_eval` / `bf->sort_eval`
+# argument and is decoded here, then handed to fold / sort_by. These exercise
+# the exact shapes the #2018 EXPR2 reduce/sort migration emits (field access
+# over hashref rows keyed by the raw JS prop name), with the captured-env arg.
+subtest 'fold_json / sort_by_json decode a JSON body and evaluate it' => sub {
+    my @rows = ({ duration => 95 }, { duration => 213 }, { duration => 185 });
+
+    # reduce: sum + t.duration, seed 0 → 493
+    my $reduce = JSON::PP->new->encode(
+        nbin('+', nid('sum'), nmem(nid('t'), 'duration')));
+    is(BarefootJS::Evaluator::fold_json(\@rows, $reduce, 'sum', 't', 0, 'left', {}),
+        493, 'fold_json sums a field');
+
+    # reduceRight concat is order-observable: cba, not abc.
+    my @labels = ({ label => 'a' }, { label => 'b' }, { label => 'c' });
+    my $concat = JSON::PP->new->encode(
+        nbin('+', nid('acc'), nmem(nid('x'), 'label')));
+    is(BarefootJS::Evaluator::fold_json(\@labels, $concat, 'acc', 'x', '', 'left', {}),
+        'abc', 'fold_json concat left → abc');
+    is(BarefootJS::Evaluator::fold_json(\@labels, $concat, 'acc', 'x', '', 'right', {}),
+        'cba', 'fold_json concat right → cba');
+
+    # sort: a.duration - b.duration → ascending
+    my $cmp = JSON::PP->new->encode(
+        nbin('-', nmem(nid('a'), 'duration'), nmem(nid('b'), 'duration')));
+    my $sorted = BarefootJS::Evaluator::sort_by_json(\@rows, $cmp, 'a', 'b', {});
+    is_deeply([ map { $_->{duration} } @$sorted ], [ 95, 185, 213 ],
+        'sort_by_json orders by a field');
+};
+
 done_testing;

--- a/packages/adapter-xslate/src/adapter/expr/array-method.ts
+++ b/packages/adapter-xslate/src/adapter/expr/array-method.ts
@@ -11,6 +11,11 @@
  * `bf->NAME`.
  */
 
+import {
+  parseExpression,
+  serializeParsedExpr,
+  freeVarsInBody,
+} from '@barefootjs/jsx'
 import type {
   ParsedExpr,
   ArrayMethod,
@@ -149,6 +154,78 @@ export function renderArrayMethod(
       )
     }
   }
+}
+
+/** Escape a string for embedding in a Perl single-quoted literal. */
+function escapePerlSingleQuote(s: string): string {
+  // Double every backslash and escape apostrophes: Perl single-quote
+  // un-escaping then restores the original bytes (a JSON `\\` must reach
+  // `JSON::PP->decode` as `\\`, so it travels as `\\\\` in the literal).
+  return s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
+}
+
+/**
+ * Build the `base_env` hashref argument for an evaluator call: the
+ * comparator / reducer body's free variables (body idents minus the
+ * callback params), each materialised to its SSR value via `emit`. An
+ * empty capture set yields `{}` — the runtime's seed-once env.
+ */
+function emitEvalEnvArg(
+  body: ParsedExpr,
+  params: string[],
+  emit: (e: ParsedExpr) => string,
+): string {
+  const free = freeVarsInBody(body, new Set(params))
+  if (free.length === 0) return '{}'
+  const pairs = free.map(
+    n => `'${escapePerlSingleQuote(n)}' => ${emit({ kind: 'identifier', name: n })}`,
+  )
+  return `{ ${pairs.join(', ')} }`
+}
+
+/**
+ * Emit a `.sort(cmp)` / `.toSorted(cmp)` via the runtime evaluator (#2018):
+ * the comparator body travels as serialized-ParsedExpr JSON, evaluated per
+ * comparison against `{paramA, paramB, …captured}`. Returns null when the
+ * body is outside the evaluator surface (e.g. a `localeCompare` comparator —
+ * `serializeParsedExpr` refuses it), so the caller falls back to the
+ * structured `$bf.sort`.
+ */
+export function renderSortEval(
+  recv: string,
+  c: SortComparator,
+  emit: (e: ParsedExpr) => string,
+): string | null {
+  const body = parseExpression(c.raw)
+  const json = serializeParsedExpr(body)
+  if (json === null) return null
+  const env = emitEvalEnvArg(body, [c.paramA, c.paramB], emit)
+  return `$bf.sort_eval(${recv}, '${escapePerlSingleQuote(json)}', '${c.paramA}', '${c.paramB}', ${env})`
+}
+
+/**
+ * Emit a `.reduce(fn, init)` / `.reduceRight(fn, init)` via the runtime
+ * evaluator (#2018): the reducer body travels as serialized-ParsedExpr JSON,
+ * folded over the receiver from `init` in `direction` order. Returns null when
+ * the body is outside the evaluator surface (→ caller falls back to
+ * `$bf.reduce`). A numeric seed passes through as a bare Perl number; a concat
+ * seed as a single-quoted string.
+ */
+export function renderReduceEval(
+  recv: string,
+  op: ReduceOp,
+  direction: 'left' | 'right',
+  emit: (e: ParsedExpr) => string,
+): string | null {
+  const body = parseExpression(op.raw)
+  const json = serializeParsedExpr(body)
+  if (json === null) return null
+  const env = emitEvalEnvArg(body, [op.paramAcc, op.paramItem], emit)
+  const init =
+    op.type === 'string'
+      ? `'${escapePerlSingleQuote(op.init)}'`
+      : op.init
+  return `$bf.reduce_eval(${recv}, '${escapePerlSingleQuote(json)}', '${op.paramAcc}', '${op.paramItem}', ${init}, '${direction}', ${env})`
 }
 
 /**

--- a/packages/adapter-xslate/src/adapter/expr/emitters.ts
+++ b/packages/adapter-xslate/src/adapter/expr/emitters.ts
@@ -33,6 +33,8 @@ import {
   renderArrayMethod,
   renderSortMethod,
   renderReduceMethod,
+  renderSortEval,
+  renderReduceEval,
   renderFlatMethod,
   renderFlatMapMethod,
 } from './array-method.ts'
@@ -164,11 +166,17 @@ export class XslateFilterEmitter implements ParsedExprEmitter {
     comparator: SortComparator,
     emit: (e: ParsedExpr) => string,
   ): string {
-    return renderSortMethod(emit(object), comparator)
+    const recv = emit(object)
+    // Evaluator path (#2018): serialize the comparator body + emit
+    // `$bf.sort_eval`; fall back to the structured `$bf.sort` when the
+    // body is outside the evaluator surface (e.g. `localeCompare`).
+    return renderSortEval(recv, comparator, emit) ?? renderSortMethod(recv, comparator)
   }
 
   reduceMethod(method: 'reduce' | 'reduceRight', object: ParsedExpr, reduceOp: ReduceOp, emit: (e: ParsedExpr) => string): string {
-    return renderReduceMethod(emit(object), reduceOp, method === 'reduceRight' ? 'right' : 'left')
+    const recv = emit(object)
+    const direction = method === 'reduceRight' ? 'right' : 'left'
+    return renderReduceEval(recv, reduceOp, direction, emit) ?? renderReduceMethod(recv, reduceOp, direction)
   }
 
   flatMethod(object: ParsedExpr, depth: FlatDepth, emit: (e: ParsedExpr) => string): string {
@@ -377,11 +385,17 @@ export class XslateTopLevelEmitter implements ParsedExprEmitter {
     comparator: SortComparator,
     emit: (e: ParsedExpr) => string,
   ): string {
-    return renderSortMethod(emit(object), comparator)
+    const recv = emit(object)
+    // Evaluator path (#2018): serialize the comparator body + emit
+    // `$bf.sort_eval`; fall back to the structured `$bf.sort` when the
+    // body is outside the evaluator surface (e.g. `localeCompare`).
+    return renderSortEval(recv, comparator, emit) ?? renderSortMethod(recv, comparator)
   }
 
   reduceMethod(method: 'reduce' | 'reduceRight', object: ParsedExpr, reduceOp: ReduceOp, emit: (e: ParsedExpr) => string): string {
-    return renderReduceMethod(emit(object), reduceOp, method === 'reduceRight' ? 'right' : 'left')
+    const recv = emit(object)
+    const direction = method === 'reduceRight' ? 'right' : 'left'
+    return renderReduceEval(recv, reduceOp, direction, emit) ?? renderReduceMethod(recv, reduceOp, direction)
   }
 
   flatMethod(object: ParsedExpr, depth: FlatDepth, emit: (e: ParsedExpr) => string): string {

--- a/packages/jsx/src/__tests__/serialize-parsed-expr.test.ts
+++ b/packages/jsx/src/__tests__/serialize-parsed-expr.test.ts
@@ -187,7 +187,18 @@ describe('freeVarsInBody', () => {
   })
 
   test('template + index + call cover their value positions', () => {
+    // `Math` is a builtin callee resolved syntactically by the evaluator — it
+    // is NOT captured (it would emit an undefined `$Math` / `.Math` base_env
+    // entry). The real refs `k`, `n`, `row` are.
     const body = parseExpression('`${row[k]}-${Math.abs(n)}`')
-    expect(freeVarsInBody(body, new Set())).toEqual(['Math', 'k', 'n', 'row'])
+    expect(freeVarsInBody(body, new Set())).toEqual(['k', 'n', 'row'])
+  })
+
+  test('builtin call callees (Math.<fn> / String / Number / Boolean) are not captured', () => {
+    // Each builtin is resolved syntactically by the evaluator, so its
+    // identifier must not enter base_env (Copilot review #2031). The
+    // arguments, however, ARE real references.
+    const body = parseExpression('Math.max(a, factor) + Number(label) + String(x) + Boolean(flag)')
+    expect(freeVarsInBody(body, new Set(['a']))).toEqual(['factor', 'flag', 'label', 'x'])
   })
 })

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -3586,7 +3586,13 @@ export function freeVarsInBody(body: ParsedExpr, params: ReadonlySet<string>): s
         visit(e.index)
         return
       case 'call':
-        visit(e.callee)
+        // A builtin callee (`String`/`Number`/`Boolean`, or `Math.<fn>`) is
+        // resolved syntactically by the evaluator — its identifier is NOT a
+        // captured free var. Visiting it would add `Math` / `String` to the
+        // env, making the adapter emit an undefined `$Math` / `.Math` base_env
+        // entry (Copilot review #2031). Skip the callee identifier in that
+        // case; the arguments are still real references and are visited.
+        if (evalBuiltinCalleeName(e.callee) === null) visit(e.callee)
         e.args.forEach(visit)
         return
       case 'template-literal':


### PR DESCRIPTION
## What

The Perl half of #2018 **P1** (the Go half is #2030). Lowers a **standalone**
`.sort(cmp)` / `.reduce(fn, init)` value call on the **Mojolicious** and
**Xslate** adapters through the runtime evaluator instead of the fixed
comparator/reducer catalogues.

The comparator / reducer body is serialized to a `ParsedExpr` JSON blob
(`serializeParsedExpr`) and evaluated per element by new helpers:

- Mojo: `bf->sort_eval(...)` / `bf->reduce_eval(...)`
- Xslate (Kolon): `$bf.sort_eval(...)` / `$bf.reduce_eval(...)`

Captured free variables (body idents minus the callback params, via
`freeVarsInBody`) are threaded as a `base_env` hashref. This generalizes the
`+`/`*` reduce catalogue and the subtraction/relational-ternary sort catalogue
to **any pure body**.

## Scope (matches the Go P1 PR #2030 exactly)

- Only the **standalone** emitter arms convert (top-level + filter-context).
- The chained `.sort().map()` / `.filter().map()` **loop-hoist** keeps the
  legacy `bf->sort` path — that de-fold is **P3**.
- A comparator outside the evaluator surface (e.g. `localeCompare`) returns
  `null` from `serializeParsedExpr` and **falls back to the legacy `bf->sort`**,
  so behavior there is unchanged. `localeCompare` multi-key chains fall back too.

## Runtime

- `BarefootJS::Evaluator::fold_json` / `sort_by_json` — the JSON-string seam the
  templates emit into (decode + delegate to the existing `fold` / `sort_by`).
- `sort_eval` / `reduce_eval` controller helpers on `BarefootJS`.

## Invariant

**Rendered HTML is unchanged.** Only the emitted template text moves to the
evaluator form. The standalone sort/reduce template-text pins in
`mojo-adapter.test.ts` are regenerated in this PR; loop-hoisted and
`localeCompare` cases stay legacy.

## Verification

- `tsc --noEmit` clean for `@barefootjs/mojolicious` + `@barefootjs/xslate`.
- `bun test mojo-adapter.test.ts` 464 pass / 0 fail; `xslate-adapter.test.ts`
  339 pass / 0 fail.
- `prove -Ilib t/evaluator.t` passes, with a new `fold_json` / `sort_by_json`
  subtest pinning the field-access fold + sort over hashref rows (sum=493,
  concat left=`abc` / right=`cba`, ascending sort).
- Real Mojo/Xslate render parity runs in CI (skips locally — no Perl template
  modules in the local harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_