### PR TITLE
feat: higher-order predicate evaluator helpers (#2018 P2 foundation)

### DIFF
--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -101,6 +101,17 @@ func FuncMap() template.FuncMap {
 		"bf_reduce_eval": FoldEval,
 		"bf_env":         Env,
 
+		// Evaluator-driven higher-order predicates (#2018, P2): the predicate
+		// body travels as a serialized ParsedExpr (JSON) evaluated per element,
+		// generalizing bf_filter / bf_find / bf_find_index / bf_every / bf_some
+		// beyond their field-equality / truthiness catalogues. `bf_find_eval` /
+		// `bf_find_index_eval` take a `forward` bool (false → findLast variants).
+		"bf_filter_eval":     FilterEval,
+		"bf_every_eval":      EveryEval,
+		"bf_some_eval":       SomeEval,
+		"bf_find_eval":       FindEval,
+		"bf_find_index_eval": FindIndexEval,
+
 		// Comment marker (for hydration)
 		"bfComment":   Comment,
 		"bfTextStart": TextStart,

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -876,6 +876,8 @@ func TestFuncMap(t *testing.T) {
 		"bf_arr", "bf_filter_truthy",
 		"bf_every", "bf_some", "bf_filter", "bf_find", "bf_find_index", "bf_sort",
 		"bf_sort_eval", "bf_reduce_eval", "bf_env",
+		"bf_filter_eval", "bf_every_eval", "bf_some_eval",
+		"bf_find_eval", "bf_find_index_eval",
 		"bfComment", "bfTextStart", "bfTextEnd", "bfPortalHTML",
 	}
 

--- a/packages/adapter-go-template/runtime/eval.go
+++ b/packages/adapter-go-template/runtime/eval.go
@@ -611,6 +611,135 @@ func SortEval(items any, cmpJSON, paramA, paramB string, baseEnv map[string]any)
 	return arr
 }
 
+// ---------------------------------------------------------------------------
+// Evaluator-driven higher-order predicates (#2018, P2) — the generalization
+// of bf_filter / bf_find / bf_find_index / bf_every / bf_some onto the
+// evaluator. The predicate BODY travels as a pure ParsedExpr (JSON) and is
+// evaluated per element against `{param: item}` plus the captured free vars in
+// `baseEnv`, lifting the field-equality / truthiness restriction of the
+// special-cased helpers to any pure predicate. `baseEnv` may be nil.
+// ---------------------------------------------------------------------------
+
+// decodeEvalBody unmarshals a serialized ParsedExpr body; ok is false on bad
+// JSON (only reachable by a corrupt emit — the adapter always emits valid JSON).
+func decodeEvalBody(bodyJSON string) (any, bool) {
+	var body any
+	if err := json.Unmarshal([]byte(bodyJSON), &body); err != nil {
+		return nil, false
+	}
+	return body, true
+}
+
+// seedPredEnv copies the captured free vars into a fresh env with room for the
+// single predicate param, which the callers overwrite per element.
+func seedPredEnv(baseEnv map[string]any) map[string]any {
+	env := make(map[string]any, len(baseEnv)+1)
+	for k, v := range baseEnv {
+		env[k] = v
+	}
+	return env
+}
+
+// FilterEval returns a new slice of the elements for which the predicate body
+// evaluates truthy — the evaluator generalization of bf_filter. Returns a
+// non-nil empty slice when nothing matches (so a downstream `range` / `bf_join`
+// sees a real slice); returns nil only on a bad body.
+func FilterEval(items any, predJSON, param string, baseEnv map[string]any) []any {
+	pred, ok := decodeEvalBody(predJSON)
+	if !ok {
+		return nil
+	}
+	env := seedPredEnv(baseEnv)
+	out := []any{}
+	for _, item := range toAnySlice(items) {
+		env[param] = item
+		if evalTruthy(EvalNode(pred, env)) {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+// EveryEval reports whether every element satisfies the predicate (vacuously
+// true for an empty receiver, like JS) — the generalization of bf_every.
+func EveryEval(items any, predJSON, param string, baseEnv map[string]any) bool {
+	pred, ok := decodeEvalBody(predJSON)
+	if !ok {
+		return false
+	}
+	env := seedPredEnv(baseEnv)
+	for _, item := range toAnySlice(items) {
+		env[param] = item
+		if !evalTruthy(EvalNode(pred, env)) {
+			return false
+		}
+	}
+	return true
+}
+
+// SomeEval reports whether any element satisfies the predicate (false for an
+// empty receiver, like JS) — the generalization of bf_some.
+func SomeEval(items any, predJSON, param string, baseEnv map[string]any) bool {
+	pred, ok := decodeEvalBody(predJSON)
+	if !ok {
+		return false
+	}
+	env := seedPredEnv(baseEnv)
+	for _, item := range toAnySlice(items) {
+		env[param] = item
+		if evalTruthy(EvalNode(pred, env)) {
+			return true
+		}
+	}
+	return false
+}
+
+// FindEval returns the first element satisfying the predicate, or nil when none
+// does — the generalization of bf_find. `forward` false searches from the end
+// (findLast).
+func FindEval(items any, predJSON, param string, forward bool, baseEnv map[string]any) any {
+	pred, ok := decodeEvalBody(predJSON)
+	if !ok {
+		return nil
+	}
+	env := seedPredEnv(baseEnv)
+	arr := toAnySlice(items)
+	for n := range arr {
+		i := n
+		if !forward {
+			i = len(arr) - 1 - n
+		}
+		env[param] = arr[i]
+		if evalTruthy(EvalNode(pred, env)) {
+			return arr[i]
+		}
+	}
+	return nil
+}
+
+// FindIndexEval returns the index of the first element satisfying the predicate,
+// or -1 when none does — the generalization of bf_find_index. `forward` false
+// searches from the end (findLastIndex).
+func FindIndexEval(items any, predJSON, param string, forward bool, baseEnv map[string]any) int {
+	pred, ok := decodeEvalBody(predJSON)
+	if !ok {
+		return -1
+	}
+	env := seedPredEnv(baseEnv)
+	arr := toAnySlice(items)
+	for n := range arr {
+		i := n
+		if !forward {
+			i = len(arr) - 1 - n
+		}
+		env[param] = arr[i]
+		if evalTruthy(EvalNode(pred, env)) {
+			return i
+		}
+	}
+	return -1
+}
+
 // Env builds the captured-free-var environment for FoldEval / SortEval from a
 // flat key, value, key, value, … argument list — the adapter emits
 // `bf_env "k1" v1 "k2" v2 …` for the free variables a callback body references

--- a/packages/adapter-go-template/runtime/eval_test.go
+++ b/packages/adapter-go-template/runtime/eval_test.go
@@ -59,6 +59,66 @@ func ncallMath(fn string, arg map[string]any) map[string]any {
 	}
 }
 
+func nlit(v any, lt string) map[string]any {
+	return map[string]any{"kind": "literal", "value": v, "literalType": lt}
+}
+
+// The #2018 P2 higher-order predicate helpers evaluate an arbitrary pure
+// predicate body per element, generalizing bf_filter / bf_find / bf_every /
+// bf_some. The rows are PascalCase-keyed maps (the Go conformance harness
+// shape) with a raw-lowercase-prop predicate, exercising the case-variant
+// field read the same way the reduce fixtures do.
+func TestPredicateEvalHelpers(t *testing.T) {
+	rows := []any{
+		map[string]any{"Age": 15.0},
+		map[string]any{"Age": 30.0},
+		map[string]any{"Age": 18.0},
+	}
+	// u => u.age >= 18
+	pred := mustJSON(t, nbin(">=", nmem(nid("u"), "age"), nlit(18, "number")))
+
+	filtered := FilterEval(rows, pred, "u", nil)
+	if len(filtered) != 2 {
+		t.Fatalf("FilterEval kept %d, want 2", len(filtered))
+	}
+
+	if !SomeEval(rows, pred, "u", nil) {
+		t.Errorf("SomeEval = false, want true")
+	}
+	if EveryEval(rows, pred, "u", nil) {
+		t.Errorf("EveryEval = true, want false (15 < 18)")
+	}
+
+	// find forward → 30 (first >= 18); findLast → 18 (last >= 18)
+	if got := FindEval(rows, pred, "u", true, nil); got.(map[string]any)["Age"] != 30.0 {
+		t.Errorf("FindEval forward = %v, want Age 30", got)
+	}
+	if got := FindEval(rows, pred, "u", false, nil); got.(map[string]any)["Age"] != 18.0 {
+		t.Errorf("FindEval backward = %v, want Age 18", got)
+	}
+	if got := FindIndexEval(rows, pred, "u", true, nil); got != 1 {
+		t.Errorf("FindIndexEval forward = %d, want 1", got)
+	}
+	if got := FindIndexEval(rows, pred, "u", false, nil); got != 2 {
+		t.Errorf("FindIndexEval backward = %d, want 2", got)
+	}
+
+	// Empty receiver: every → true (vacuous), some → false, find → nil/-1.
+	empty := []any{}
+	if !EveryEval(empty, pred, "u", nil) {
+		t.Errorf("EveryEval(empty) = false, want true")
+	}
+	if SomeEval(empty, pred, "u", nil) {
+		t.Errorf("SomeEval(empty) = true, want false")
+	}
+	if got := FindEval(empty, pred, "u", true, nil); got != nil {
+		t.Errorf("FindEval(empty) = %v, want nil", got)
+	}
+	if got := FindIndexEval(empty, pred, "u", true, nil); got != -1 {
+		t.Errorf("FindIndexEval(empty) = %d, want -1", got)
+	}
+}
+
 // FoldEval lifts bf_reduce's op restriction and acc-canonical form: the
 // reducer body `acc + item.price * item.qty` mixes `acc` with a product of two
 // fields — impossible in the +/* self/field catalogue, trivial for the

--- a/packages/adapter-go-template/runtime/eval_test.go
+++ b/packages/adapter-go-template/runtime/eval_test.go
@@ -117,6 +117,19 @@ func TestPredicateEvalHelpers(t *testing.T) {
 	if got := FindIndexEval(empty, pred, "u", true, nil); got != -1 {
 		t.Errorf("FindIndexEval(empty) = %d, want -1", got)
 	}
+
+	// Captured base_env: a predicate `u => u.age >= threshold` reads the
+	// outer `threshold` from base_env, and changing it changes the result —
+	// pins the capture plumbing (Copilot review #2032).
+	capPred := mustJSON(t, nbin(">=", nmem(nid("u"), "age"), nid("threshold")))
+	hi := FilterEval(rows, capPred, "u", map[string]any{"threshold": 18.0})
+	lo := FilterEval(rows, capPred, "u", map[string]any{"threshold": 100.0})
+	if len(hi) != 2 || len(lo) != 0 {
+		t.Fatalf("FilterEval with captured threshold: hi=%d lo=%d, want 2/0", len(hi), len(lo))
+	}
+	if FindIndexEval(rows, capPred, "u", true, map[string]any{"threshold": 100.0}) != -1 {
+		t.Errorf("FindIndexEval with unmet captured threshold should be -1")
+	}
 }
 
 // FoldEval lifts bf_reduce's op restriction and acc-canonical form: the

--- a/packages/adapter-perl/lib/BarefootJS/Evaluator.pm
+++ b/packages/adapter-perl/lib/BarefootJS/Evaluator.pm
@@ -449,4 +449,107 @@ sub sort_by_json ($items, $cmp_json, $param_a, $param_b, $base_env = undef) {
     return sort_by($items, JSON::PP->new->decode($cmp_json), $param_a, $param_b, $base_env);
 }
 
+# ---------------------------------------------------------------------------
+# Higher-order predicates (#2018, P2) — the generalization of bf_filter /
+# bf_find / bf_find_index / bf_every / bf_some onto the evaluator. The
+# predicate $pred is a pure ParsedExpr evaluated against `{$param => item}`
+# plus the captured free vars in $base_env per element, lifting the
+# field-equality / truthiness restriction to any pure predicate body. Each
+# mirrors the corresponding Go helper (FilterEval / EveryEval / SomeEval /
+# FindEval / FindIndexEval). $base_env is optional.
+# ---------------------------------------------------------------------------
+
+# filter — new arrayref of the elements the predicate keeps. Non-array receiver
+# → empty arrayref (the BarefootJS->filter nil-tolerant convention).
+sub filter ($items, $pred, $param, $base_env = undef) {
+    return [] unless ref $items eq 'ARRAY';
+    my %env = $base_env ? %$base_env : ();
+    my @out;
+    for my $item (@$items) {
+        $env{$param} = $item;
+        push @out, $item if _truthy(evaluate($pred, \%env));
+    }
+    return \@out;
+}
+
+# every — 1 iff the predicate holds for every element (vacuously 1 for an empty
+# receiver, like JS).
+sub every ($items, $pred, $param, $base_env = undef) {
+    my @arr = ref $items eq 'ARRAY' ? @$items : ();
+    my %env = $base_env ? %$base_env : ();
+    for my $item (@arr) {
+        $env{$param} = $item;
+        return 0 unless _truthy(evaluate($pred, \%env));
+    }
+    return 1;
+}
+
+# some — 1 iff the predicate holds for any element (0 for an empty receiver).
+sub some ($items, $pred, $param, $base_env = undef) {
+    my @arr = ref $items eq 'ARRAY' ? @$items : ();
+    my %env = $base_env ? %$base_env : ();
+    for my $item (@arr) {
+        $env{$param} = $item;
+        return 1 if _truthy(evaluate($pred, \%env));
+    }
+    return 0;
+}
+
+# find — first matching element, or undef. $forward false searches from the end
+# (findLast).
+sub find ($items, $pred, $param, $forward = 1, $base_env = undef) {
+    my @arr = ref $items eq 'ARRAY' ? @$items : ();
+    @arr = reverse @arr unless $forward;
+    my %env = $base_env ? %$base_env : ();
+    for my $item (@arr) {
+        $env{$param} = $item;
+        return $item if _truthy(evaluate($pred, \%env));
+    }
+    return undef;
+}
+
+# find_index — index of the first matching element, or -1. $forward false →
+# findLastIndex (the index is into the original array either way).
+sub find_index ($items, $pred, $param, $forward = 1, $base_env = undef) {
+    my @arr = ref $items eq 'ARRAY' ? @$items : ();
+    my %env = $base_env ? %$base_env : ();
+    my @idx = $forward ? ( 0 .. $#arr ) : reverse( 0 .. $#arr );
+    for my $i (@idx) {
+        $env{$param} = $arr[$i];
+        return $i if _truthy(evaluate($pred, \%env));
+    }
+    return -1;
+}
+
+# ---------------------------------------------------------------------------
+# JSON-string seams — the adapters emit `bf->filter_eval($recv, '<json>', …)`;
+# the predicate body arrives as a JSON string here, decoded then handed to the
+# helper above (mirroring fold_json / sort_by_json).
+# ---------------------------------------------------------------------------
+
+sub filter_json ($items, $pred_json, $param, $base_env = undef) {
+    require JSON::PP;
+    return filter($items, JSON::PP->new->decode($pred_json), $param, $base_env);
+}
+
+sub every_json ($items, $pred_json, $param, $base_env = undef) {
+    require JSON::PP;
+    return every($items, JSON::PP->new->decode($pred_json), $param, $base_env);
+}
+
+sub some_json ($items, $pred_json, $param, $base_env = undef) {
+    require JSON::PP;
+    return some($items, JSON::PP->new->decode($pred_json), $param, $base_env);
+}
+
+sub find_json ($items, $pred_json, $param, $forward = 1, $base_env = undef) {
+    require JSON::PP;
+    return find($items, JSON::PP->new->decode($pred_json), $param, $forward, $base_env);
+}
+
+sub find_index_json ($items, $pred_json, $param, $forward = 1, $base_env = undef) {
+    require JSON::PP;
+    return find_index($items, JSON::PP->new->decode($pred_json), $param, $forward, $base_env);
+}
+
 1;

--- a/packages/adapter-perl/t/evaluator.t
+++ b/packages/adapter-perl/t/evaluator.t
@@ -215,10 +215,27 @@ subtest 'filter / every / some / find / find_index over a predicate body' => sub
     ok(!defined BarefootJS::Evaluator::find([], $pred, 'u'), 'find(empty) → undef');
     is(BarefootJS::Evaluator::find_index([], $pred, 'u'), -1, 'find_index(empty) → -1');
 
-    # JSON seam: the body arrives as the string the adapter emits.
+    # JSON seam: the body arrives as the string the adapter emits. Cover more
+    # than filter_json so each *_json entry point is pinned (Copilot review
+    # #2032).
     my $json = JSON::PP->new->encode($pred);
     my $fj = BarefootJS::Evaluator::filter_json(\@rows, $json, 'u');
     is_deeply([ map { $_->{age} } @$fj ], [ 30, 18 ], 'filter_json decodes + filters');
+    is(BarefootJS::Evaluator::every_json(\@rows, $json, 'u'), 0, 'every_json → false');
+    is(BarefootJS::Evaluator::some_json(\@rows, $json, 'u'),  1, 'some_json → true');
+    is(BarefootJS::Evaluator::find_json(\@rows, $json, 'u', 1)->{age}, 30, 'find_json forward → 30');
+    is(BarefootJS::Evaluator::find_index_json(\@rows, $json, 'u', 0), 2, 'find_index_json backward → 2');
+
+    # Captured base_env: a predicate `u => u.age >= threshold` reads the outer
+    # `threshold`, and changing it changes the result — pins the capture
+    # plumbing (Copilot review #2032).
+    my $cap = nbin('>=', nmem(nid('u'), 'age'), nid('threshold'));
+    my $hi  = BarefootJS::Evaluator::filter(\@rows, $cap, 'u', { threshold => 18 });
+    my $lo  = BarefootJS::Evaluator::filter(\@rows, $cap, 'u', { threshold => 100 });
+    is(scalar(@$hi), 2, 'captured threshold 18 keeps 2');
+    is(scalar(@$lo), 0, 'captured threshold 100 keeps 0');
+    is(BarefootJS::Evaluator::find_index(\@rows, $cap, 'u', 1, { threshold => 100 }), -1,
+        'find_index with unmet captured threshold → -1');
 };
 
 done_testing;

--- a/packages/adapter-perl/t/evaluator.t
+++ b/packages/adapter-perl/t/evaluator.t
@@ -190,4 +190,35 @@ subtest 'fold_json / sort_by_json decode a JSON body and evaluate it' => sub {
         'sort_by_json orders by a field');
 };
 
+# The #2018 P2 higher-order predicate helpers evaluate an arbitrary pure
+# predicate body per element, generalizing bf_filter / bf_find / bf_every /
+# bf_some. Mirrors the Go TestPredicateEvalHelpers shapes (u => u.age >= 18).
+subtest 'filter / every / some / find / find_index over a predicate body' => sub {
+    my @rows = ({ age => 15 }, { age => 30 }, { age => 18 });
+    my $pred = nbin('>=', nmem(nid('u'), 'age'),
+        { kind => 'literal', value => 18, literalType => 'number' });
+
+    my $f = BarefootJS::Evaluator::filter(\@rows, $pred, 'u');
+    is_deeply([ map { $_->{age} } @$f ], [ 30, 18 ], 'filter keeps age >= 18');
+
+    is(BarefootJS::Evaluator::some(\@rows, $pred, 'u'), 1, 'some → true');
+    is(BarefootJS::Evaluator::every(\@rows, $pred, 'u'), 0, 'every → false (15 < 18)');
+
+    is(BarefootJS::Evaluator::find(\@rows, $pred, 'u', 1)->{age}, 30, 'find forward → 30');
+    is(BarefootJS::Evaluator::find(\@rows, $pred, 'u', 0)->{age}, 18, 'findLast → 18');
+    is(BarefootJS::Evaluator::find_index(\@rows, $pred, 'u', 1), 1, 'findIndex → 1');
+    is(BarefootJS::Evaluator::find_index(\@rows, $pred, 'u', 0), 2, 'findLastIndex → 2');
+
+    # Empty receiver: every vacuously true, some false, find undef / index -1.
+    is(BarefootJS::Evaluator::every([], $pred, 'u'), 1, 'every(empty) → true');
+    is(BarefootJS::Evaluator::some([], $pred, 'u'), 0, 'some(empty) → false');
+    ok(!defined BarefootJS::Evaluator::find([], $pred, 'u'), 'find(empty) → undef');
+    is(BarefootJS::Evaluator::find_index([], $pred, 'u'), -1, 'find_index(empty) → -1');
+
+    # JSON seam: the body arrives as the string the adapter emits.
+    my $json = JSON::PP->new->encode($pred);
+    my $fj = BarefootJS::Evaluator::filter_json(\@rows, $json, 'u');
+    is_deeply([ map { $_->{age} } @$fj ], [ 30, 18 ], 'filter_json decodes + filters');
+};
+
 done_testing;


### PR DESCRIPTION
## What

The **additive runtime foundation** for #2018 **P2** (filter / find / findIndex /
findLast / findLastIndex / every / some → evaluator). Rebased onto `main` after
#2030 + #2031 landed; the diff is now a single commit. **No emit change** — like
P0 (#2028), this lands the runtime seam first; the emit conversion is the next
stacked PR.

The predicate body travels as a serialized `ParsedExpr` (JSON) evaluated per
element against `{param: item}` + captured `base_env`, generalizing the
field-equality / truthiness catalogues of `bf_filter` / `bf_find` /
`bf_find_index` / `bf_every` / `bf_some` to **any pure predicate body**.

- **Go (`eval.go`)**: `FilterEval` / `EveryEval` / `SomeEval` / `FindEval` /
  `FindIndexEval` (the find pair take a `forward` bool — `false` = findLast /
  findLastIndex). Registered as `bf_filter_eval` / `bf_every_eval` /
  `bf_some_eval` / `bf_find_eval` / `bf_find_index_eval`. Pinned by
  `TestPredicateEvalHelpers` over PascalCase-keyed maps (the conformance shape),
  incl. empty-receiver edge cases (every→true, some→false, find→nil/-1).
- **Perl (`Evaluator.pm`)**: `filter` / `every` / `some` / `find` / `find_index`
  + the `*_json` string seams. Pinned by a new `evaluator.t` subtest mirroring
  the Go shapes (`u => u.age >= 18`).

## Verification

- `go test ./...` green (runtime); `prove -Ilib t/evaluator.t` green (11 subtests).

## Next P2 step (stacked PR)

Convert the `higherOrder` emitter arms (go-template-adapter; mojo/xslate
`emitters.ts`) — the `higher-order` IR kind already carries the predicate as a
`ParsedExpr`, so it serializes directly — preserve the `.filter(…).length`
short-circuit, add the Perl controller helpers (`filter_eval` / …), add
eval-vectors, and regenerate the conformance fixtures. Retire `bf_filter` /
`bf_every` / `bf_some` / `bf_find` / `bf_find_index` once unreferenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)