### PR TITLE
feat(go): lower higher-order methods through the evaluator (#2018 P2)

### DIFF
--- a/.changeset/go-higher-order-eval.md
+++ b/.changeset/go-higher-order-eval.md
@@ -1,0 +1,16 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Lower higher-order methods (`.filter` / `.find` / `.findIndex` / `.findLast` /
+`.findLastIndex` / `.every` / `.some`) on the Go template adapter through the
+runtime evaluator (#2018, P2). The predicate body — already a `ParsedExpr` on
+the `higher-order` IR node — serializes to JSON and emits `bf_filter_eval` /
+`bf_find_eval` / `bf_find_index_eval` / `bf_every_eval` / `bf_some_eval`, with
+captured free vars threaded via `bf_env`, generalizing the field-equality /
+truthiness predicate catalogue to any pure predicate body. A predicate the
+evaluator can't model (a method-call / signal-getter predicate) falls back to
+the structured `bf_filter` / `bf_find` / … helpers and the `{{range}}`
+template-block path; `.filter(Boolean)` keeps its dedicated `bf_filter_truthy`
+lowering. Rendered HTML is unchanged; only the emitted template text moves to
+the evaluator helpers.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -1737,7 +1737,9 @@ export function TodoStatus() {
   return <div>{todos().every(t => t.done)}</div>
 }
 `)
-      expect(result.template).toContain('bf_every .Todos "Done"')
+      // #2018 P2: `.every(t => t.done)` now lowers through the evaluator —
+      // the predicate body travels as serialized ParsedExpr JSON.
+      expect(result.template).toContain('bf_every_eval .Todos')
     })
 
     test('nested .filter(...).length in filter predicate lowers via len (bf_filter ...) (#1443 PR4)', () => {
@@ -1767,7 +1769,7 @@ export function TodoList() {
 }
 `, adapter)
       expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
-      expect(result.template).toContain('gt (len (bf_filter .Tags "Active" true)) 0')
+      expect(result.template).toContain('gt (len (bf_filter_eval .Tags')
       // No degenerate fallbacks
       expect(result.template).not.toContain('{{if false}}')
       expect(result.template).not.toContain('[UNSUPPORTED-FILTER-EXPR]')
@@ -1798,7 +1800,7 @@ export function TodoList() {
   )
 }
 `, adapter)
-      expect(result.template).toContain('gt (len (bf_filter .Tags "Active" true)) 0')
+      expect(result.template).toContain('gt (len (bf_filter_eval .Tags')
       expect(result.template).toContain('{{if not .Done}}')
     })
 
@@ -1859,7 +1861,10 @@ export function ItemChecker() {
   return <div>{items().find(t => t.done) ? 'Found' : 'Not found'}</div>
 }
 `)
-      expect(result.template).toContain('bf_find .Items "Done" true')
+      // #2018 P2: `.find(t => t.done)` lowers through the evaluator; the
+      // trailing `true` is the forward-search flag (find / findIndex).
+      expect(result.template).toContain('bf_find_eval .Items')
+      expect(result.template).toContain('true bf_env')
       expect(result.template).toContain('Found')
     })
   })
@@ -1877,7 +1882,10 @@ export function ItemChecker() {
   return <div>{items().findLast(t => t.done) ? 'Found' : 'Not found'}</div>
 }
 `)
-      expect(result.template).toContain('bf_find_last .Items "Done" true')
+      // #2018 P2: `.findLast(t => t.done)` shares `bf_find_eval` with `.find`,
+      // distinguished by the `false` (backward) forward-flag.
+      expect(result.template).toContain('bf_find_eval .Items')
+      expect(result.template).toContain('false bf_env')
       expect(result.template).toContain('Found')
     })
 
@@ -1911,10 +1919,20 @@ export function ItemChecker() {
   return <div>idx: {items().findLastIndex(t => t.done)}</div>
 }
 `)
-      expect(result.template).toContain('bf_find_last_index .Items "Done" true')
+      // #2018 P2: `.findLastIndex` lowers via `bf_find_index_eval` with the
+      // `false` (backward) forward-flag.
+      expect(result.template).toContain('bf_find_index_eval .Items')
+      expect(result.template).toContain('false bf_env')
     })
 
-    test('renders findLastIndex() with complex predicate via range', () => {
+    test('renders findLastIndex() with a pure complex predicate via the evaluator', () => {
+      // #2018 P2: a pure (call-free) complex predicate like
+      // `t.price > 50 && t.active` is no longer confined to the
+      // field-equality catalogue — it serializes to a ParsedExpr and lowers
+      // through `bf_find_index_eval` (backward `false` flag), replacing the
+      // old `{{range}}` $bf_r accumulator. The range fallback is now reserved
+      // for predicates the evaluator can't model (e.g. a signal-getter call,
+      // covered by the findLast test above).
       const result = compileAndGenerate(`
 "use client"
 import { createSignal } from "@barefootjs/client"
@@ -1926,10 +1944,9 @@ export function ItemFinder() {
   return <div>{items().findLastIndex(t => t.price > 50 && t.active)}</div>
 }
 `)
-      const varMatch = result.template.match(/(\$bf_r\d+) := -1/)
-      expect(varMatch).not.toBeNull()
-      expect(result.template).toContain(`${varMatch![1]} = $i`)
-      expect(result.template).not.toContain('{{break}}')
+      expect(result.template).toContain('bf_find_index_eval .Items')
+      expect(result.template).toContain('false bf_env')
+      expect(result.template).not.toContain('$bf_r')
     })
 
     test('findLast() complex predicate in IR-level ternary works via preamble splitting', () => {
@@ -2450,7 +2467,9 @@ export function C() {
   return <ul>{items().filter(({done}) => done).map(t => <li key={t.id}>{t.name}</li>)}</ul>
 }`)
       expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
-      expect(result.template).toContain('bf_filter .Items "Done" true')
+      // #2018 P2: the normalised `_t => _t.done` predicate lowers through the
+      // evaluator (`bf_filter_eval`).
+      expect(result.template).toContain('bf_filter_eval .Items')
     })
 
     test('.filter(function (x) { return x.done }).map(...) lowers cleanly', () => {
@@ -2463,7 +2482,9 @@ export function C() {
   return <ul>{items().filter(function (x) { return x.done }).map(t => <li key={t.id}>{t.name}</li>)}</ul>
 }`)
       expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
-      expect(result.template).toContain('bf_filter .Items "Done" true')
+      // #2018 P2: the normalised `_t => _t.done` predicate lowers through the
+      // evaluator (`bf_filter_eval`).
+      expect(result.template).toContain('bf_filter_eval .Items')
     })
   })
 

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -84,6 +84,7 @@ import {
   emitBfReduce,
   emitSortEval,
   emitReduceEval,
+  emitPredicateEval,
   stringTolerantEqOperands,
   buildUnsupportedSuggestion,
   GO_REMEDIATION_OPTIONS,
@@ -3277,11 +3278,60 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * Go template, or null when the shape isn't supported. `renderArray` is passed
    * in so the array can recurse through different lowering methods.
    */
+  /**
+   * Emit a higher-order method through the runtime evaluator (#2018 P2):
+   * `bf_filter_eval` / `bf_every_eval` / `bf_some_eval` / `bf_find_eval` /
+   * `bf_find_index_eval`, carrying the serialized predicate body + captured
+   * env. Returns null when the predicate is outside the evaluator surface
+   * (caller falls back to the structured helper / template block). The find /
+   * findLast (and findIndex / findLastIndex) pair share a helper, differing
+   * only by the `forward` bool argument.
+   */
+  private renderHigherOrderEval(
+    expr: Extract<ParsedExpr, { kind: 'higher-order' }>,
+    arrayExpr: string,
+    emit: (e: ParsedExpr) => string,
+  ): string | null {
+    const { method, predicate, param } = expr
+    const pe = (fn: string, extra: string[] = []) =>
+      emitPredicateEval(fn, arrayExpr, predicate, param, emit, extra)
+    switch (method) {
+      case 'filter':
+        // `.filter(Boolean)` (identity predicate `_t => _t`) keeps its
+        // dedicated `bf_filter_truthy` lowering — identical render, and it
+        // composes through the array-method chain (`.filter(Boolean).join`).
+        if (predicate.kind === 'identifier' && predicate.name === param) return null
+        return pe('bf_filter_eval')
+      case 'every':
+        return pe('bf_every_eval')
+      case 'some':
+        return pe('bf_some_eval')
+      case 'find':
+        return pe('bf_find_eval', ['true'])
+      case 'findLast':
+        return pe('bf_find_eval', ['false'])
+      case 'findIndex':
+        return pe('bf_find_index_eval', ['true'])
+      case 'findLastIndex':
+        return pe('bf_find_index_eval', ['false'])
+    }
+    return null
+  }
+
   private renderHigherOrderExpr(
     expr: Extract<ParsedExpr, { kind: 'higher-order' }>,
     renderArray: (e: ParsedExpr) => string
   ): string | null {
     const arrayExpr = renderArray(expr.object)
+
+    // Evaluator path (#2018 P2): the predicate body is already a ParsedExpr on
+    // the IR node, so serialize it and emit the matching `bf_*_eval` helper.
+    // This generalizes the field-equality / truthiness predicate catalogue
+    // below to ANY pure predicate body; a method-call predicate (which
+    // `serializeParsedExpr` refuses) returns null here and falls through to the
+    // structured helpers / template-block fallback.
+    const evalForm = this.renderHigherOrderEval(expr, arrayExpr, renderArray)
+    if (evalForm !== null) return evalForm
 
     if (expr.method === 'every' || expr.method === 'some') {
       const { field } = this.extractFieldPredicate(expr.predicate, expr.param)
@@ -3418,12 +3468,21 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       return null
     }
 
+    const arrayExpr = renderArray(filterExpr.object)
+
+    // Evaluator path (#2018 P2): `len (bf_filter_eval …)` for any pure
+    // predicate. Falls back to the structured `bf_filter` below for a
+    // method-call predicate the evaluator can't model.
+    const evalForm = emitPredicateEval(
+      'bf_filter_eval', arrayExpr, filterExpr.predicate, filterExpr.param, renderArray,
+    )
+    if (evalForm !== null) return `len (${evalForm})`
+
     const { field, negated } = this.extractFieldPredicate(filterExpr.predicate, filterExpr.param)
     if (!field) {
       return null
     }
 
-    const arrayExpr = renderArray(filterExpr.object)
     const value = negated ? 'false' : 'true'
     return `len (bf_filter ${arrayExpr} "${field}" ${value})`
   }

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -3274,11 +3274,6 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   /**
-   * Render a higher-order expression (filter, every, some, find, findIndex) to
-   * Go template, or null when the shape isn't supported. `renderArray` is passed
-   * in so the array can recurse through different lowering methods.
-   */
-  /**
    * Emit a higher-order method through the runtime evaluator (#2018 P2):
    * `bf_filter_eval` / `bf_every_eval` / `bf_some_eval` / `bf_find_eval` /
    * `bf_find_index_eval`, carrying the serialized predicate body + captured
@@ -3318,6 +3313,11 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     return null
   }
 
+  /**
+   * Render a higher-order expression (filter, every, some, find, findIndex) to
+   * Go template, or null when the shape isn't supported. `renderArray` is passed
+   * in so the array can recurse through different lowering methods.
+   */
   private renderHigherOrderExpr(
     expr: Extract<ParsedExpr, { kind: 'higher-order' }>,
     renderArray: (e: ParsedExpr) => string

--- a/packages/adapter-go-template/src/adapter/lib/go-emit.ts
+++ b/packages/adapter-go-template/src/adapter/lib/go-emit.ts
@@ -146,6 +146,37 @@ export function emitReduceEval(
 }
 
 /**
+ * Emit a higher-order predicate call via the evaluator (#2018, P2): the
+ * predicate body (already a `ParsedExpr` on the `higher-order` IR node) travels
+ * as serialized-ParsedExpr JSON, evaluated per element against `{param,
+ * …captured}`. Generalizes the field-equality / truthiness catalogues of
+ * `bf_filter` / `bf_find` / `bf_every` / `bf_some` to any pure predicate body.
+ * Returns null when the predicate is outside the evaluator surface (e.g. a
+ * method-call predicate — `serializeParsedExpr` refuses it), so the caller
+ * falls back to the structured helper / template-block path.
+ *
+ *   <func> <recv> "<json>" "<param>" [<extraArgs>…] <env>
+ *
+ * `extraArgs` are inserted between the param name and the env — used for the
+ * find / findIndex `forward` bool (`true` = find / findIndex, `false` =
+ * findLast / findLastIndex).
+ */
+export function emitPredicateEval(
+  funcName: string,
+  recv: string,
+  predicate: ParsedExpr,
+  param: string,
+  emit: (e: ParsedExpr) => string,
+  extraArgs: string[] = [],
+): string | null {
+  const json = serializeParsedExpr(predicate)
+  if (json === null) return null
+  const env = emitEvalEnvArg(predicate, [param], emit)
+  const extra = extraArgs.length > 0 ? ` ${extraArgs.join(' ')}` : ''
+  return `${funcName} ${wrapIfMultiToken(recv)} "${escapeGoString(json)}" "${param}"${extra} ${env}`
+}
+
+/**
  * Make an equality comparison string-tolerant when exactly one side is a Go
  * string literal: JS `sorted === 'asc'` is loosely false for `sorted = false`,
  * but Go's template `eq` ERRORS on bool-vs-string (`incompatible types for


### PR DESCRIPTION
## What

**Stacked on #2032** (the P2 runtime foundation). Routes `.filter` / `.find` /
`.findIndex` / `.findLast` / `.findLastIndex` / `.every` / `.some` on the **Go**
adapter through the runtime evaluator.

The predicate body — already a `ParsedExpr` on the `higher-order` IR node —
serializes to JSON and emits `bf_filter_eval` / `bf_find_eval` /
`bf_find_index_eval` / `bf_every_eval` / `bf_some_eval`, with captured free vars
threaded via `bf_env`. This **generalizes the field-equality / truthiness
predicate catalogue to any pure predicate body** (e.g. `t => t.price > 50 &&
t.active` no longer needs the `{{range}}` accumulator fallback).

## How

- New `go-emit` helper `emitPredicateEval` (funcName + recv + serialized
  predicate + param + optional `forward` flag + env). find/findLast and
  findIndex/findLastIndex share a helper, differing only by the `forward` bool.
- Eval-first in `renderHigherOrderExpr` and `renderFilterLengthExpr`
  (`len (bf_filter_eval …)`); the `find().property` member path wraps the eval
  form in `{{with bf_find_eval …}}{{.Prop}}{{end}}` unchanged.
- A predicate the evaluator can't model (a method-call / signal-getter
  predicate — `serializeParsedExpr` returns null) **falls back** to the
  structured `bf_filter` / `bf_find` / … helpers and the `{{range}}`
  template-block path. `.filter(Boolean)` keeps its dedicated
  `bf_filter_truthy` lowering (identical render, composes through the
  array-method chain).

## Invariant

**Rendered HTML is unchanged** (Go conformance render green: 524 pass / 0 fail).
The SSR template-text pins move to the `*_eval` form; a pure complex
find/filter predicate that previously fell to `{{range}}` now lowers via the
evaluator.

## Next (further stacked PR)

The Perl half — mojo/xslate `higherOrder` arms → `bf->filter_eval` /
`$bf.filter_eval` (evaluator-first, `grep` / `bf->find` fallback) + the
`filter_eval` / … controller helpers on `BarefootJS` + eval-vectors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_