### PR TITLE
feat(perl): lower higher-order methods through the evaluator (#2018 P2)

### DIFF
--- a/.changeset/perl-higher-order-eval.md
+++ b/.changeset/perl-higher-order-eval.md
@@ -1,0 +1,21 @@
+---
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+"@barefootjs/perl": patch
+---
+
+Lower higher-order methods (`.filter` / `.find` / `.findIndex` / `.findLast` /
+`.findLastIndex` / `.every` / `.some`) on the Mojolicious and Xslate adapters
+through the runtime evaluator (#2018, P2 — the Perl half of the Go change). The
+predicate body serializes to a ParsedExpr JSON blob and emits
+`bf->filter_eval` / `bf->find_eval` / `bf->find_index_eval` / `bf->every_eval` /
+`bf->some_eval` (`$bf.…` in Xslate), with captured free vars threaded as a
+`base_env` hashref — the same JS-faithful evaluator the Go adapter uses, so the
+two SSR backends stay byte-isomorphic. A predicate the evaluator can't model
+(e.g. a method-call predicate) falls back to the inline `grep` / Kolon-lambda /
+`bf->find` lowering, and `.filter(Boolean)` keeps its inline truthiness form.
+
+The shared `BarefootJS` runtime gains `filter_eval` / `every_eval` / `some_eval`
+/ `find_eval` / `find_index_eval` controller helpers, delegating to the
+`BarefootJS::Evaluator` predicate helpers. Rendered HTML is unchanged; only the
+emitted template text moves to the evaluator helpers.

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -1010,6 +1010,39 @@ export { A }`, 'A.tsx', { adapter })
     }
   })
 
+  test('lowers .every / .some via the evaluator, with grep fallback for a method-call predicate', () => {
+    // #2018 P2: a pure predicate routes `.every` / `.some` through
+    // `bf->every_eval` / `bf->some_eval`; a method-call predicate the
+    // evaluator can't model (`serializeParsedExpr` → null) falls back to the
+    // inline `grep` form.
+    const evalCases: Array<[string, string]> = [
+      ['every', 'every_eval'],
+      ['some', 'some_eval'],
+    ]
+    for (const [js, helper] of evalCases) {
+      const adapter = new MojoAdapter()
+      const result = compileJSX(`function A({ items }: { items: { done: boolean }[] }) {
+  return <div>{items.${js}(x => x.done) ? 'y' : 'n'}</div>
+}
+export { A }`, 'A.tsx', { adapter })
+      expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
+      const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
+      expect(template).toContain(`bf->${helper}($items,`)
+      expect(template).toContain('"property":"done"')
+    }
+
+    // Fallback: a method-call predicate (`x => x.name.includes('a')`) is
+    // outside the evaluator surface, so `.every` keeps the inline grep form.
+    const adapter = new MojoAdapter()
+    const fb = compileJSX(`function A({ items }: { items: { name: string }[] }) {
+  return <div>{items.every(x => x.name.includes('a')) ? 'y' : 'n'}</div>
+}
+export { A }`, 'A.tsx', { adapter })
+    const fbTemplate = fb.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
+    expect(fbTemplate).toContain('grep {')
+    expect(fbTemplate).not.toContain('every_eval')
+  })
+
   test('lowers .reverse().join(\' \') via bf->reverse + join (#1448 Tier A)', () => {
     // SSR templates render a snapshot, so `.reverse` and
     // `.toReversed` share a Mojo lowering — both return a new

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -760,7 +760,11 @@ export function C() {
 }`, 'C.tsx', { adapter })
     expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
     const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
-    expect(template).toContain('grep { $_->{done} } @{$items}')
+    // #2018 P2: the `.filter().map()` loop hoists over the filtered array,
+    // now produced by the evaluator (`bf->filter_eval`). (Hoisting the call
+    // into a single `my` var is a P3 optimization.)
+    expect(template).toContain('bf->filter_eval($items,')
+    expect(template).toContain('"property":"done"')
   })
 
   test('lowers nested .filter(...).length > 0 in outer filter predicate (#1443 PR4)', () => {
@@ -798,7 +802,11 @@ export function C() {
 }`, 'C.tsx', { adapter })
     expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
     const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
-    expect(template).toContain('grep { $_->{done} } @{$items}')
+    // #2018 P2: the `.filter().map()` loop hoists over the filtered array,
+    // now produced by the evaluator (`bf->filter_eval`). (Hoisting the call
+    // into a single `my` var is a P3 optimization.)
+    expect(template).toContain('bf->filter_eval($items,')
+    expect(template).toContain('"property":"done"')
   })
 
   test('lowers the registry Slot\'s [a, b].filter(Boolean).join(\' \') chain (#1443)', () => {
@@ -977,17 +985,18 @@ export { A }`, 'A.tsx', { adapter })
     expect(template).not.toContain('$bf->trim')
   })
 
-  test('lowers .find / .findIndex / .findLast / .findLastIndex via runtime helpers', () => {
-    // The runtime `bf->find` / `find_index` / `find_last` / `find_last_index`
-    // call the predicate as a per-element coderef; the camelCase JS names map
-    // to the snake_case helpers (matching Xslate's Kolon-lambda lowering).
-    const cases: Array<[string, string]> = [
-      ['find', 'find'],
-      ['findIndex', 'find_index'],
-      ['findLast', 'find_last'],
-      ['findLastIndex', 'find_last_index'],
+  test('lowers .find / .findIndex / .findLast / .findLastIndex via the evaluator', () => {
+    // #2018 P2: the pure predicate `x => x === 'b'` serializes and lowers
+    // through the evaluator. find / findIndex share `bf->find_eval` /
+    // `bf->find_index_eval` with findLast / findLastIndex, distinguished by
+    // the `forward` flag (1 = forward, 0 = backward).
+    const cases: Array<[string, string, number]> = [
+      ['find', 'find_eval', 1],
+      ['findIndex', 'find_index_eval', 1],
+      ['findLast', 'find_eval', 0],
+      ['findLastIndex', 'find_index_eval', 0],
     ]
-    for (const [js, helper] of cases) {
+    for (const [js, helper, fwd] of cases) {
       const adapter = new MojoAdapter()
       const result = compileJSX(`function A({ items }: { items: string[] }) {
   return <div>{items.${js}(x => x === 'b')}</div>
@@ -995,7 +1004,8 @@ export { A }`, 'A.tsx', { adapter })
 export { A }`, 'A.tsx', { adapter })
       expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
       const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
-      expect(template).toContain(`bf->${helper}($items, sub { my $x = $_[0]; $x eq 'b' })`)
+      expect(template).toContain(`bf->${helper}($items,`)
+      expect(template).toContain(`'x', ${fwd}, {})`)
       expect(template).not.toContain(`$bf->${helper}`)
     }
   })

--- a/packages/adapter-mojolicious/src/adapter/expr/array-method.ts
+++ b/packages/adapter-mojolicious/src/adapter/expr/array-method.ts
@@ -316,6 +316,33 @@ export function renderReduceEval(
 }
 
 /**
+ * Emit a higher-order predicate call via the runtime evaluator (#2018, P2):
+ * `bf->filter_eval` / `bf->every_eval` / `bf->some_eval` / `bf->find_eval` /
+ * `bf->find_index_eval`, carrying the serialized predicate body + captured env
+ * hashref. Generalizes the inline `grep` / `bf->find` lowering to the same
+ * JS-faithful evaluator the Go adapter uses (cross-adapter isomorphism).
+ * Returns null when the predicate is outside the evaluator surface (e.g. a
+ * method-call predicate — `serializeParsedExpr` refuses it), so the caller
+ * falls back to the `grep` / `bf->find` form. `forward` (find / findIndex
+ * family only) selects the search direction — `false` = findLast /
+ * findLastIndex.
+ */
+export function renderPredicateEval(
+  funcName: string,
+  recv: string,
+  predicate: ParsedExpr,
+  param: string,
+  emit: (e: ParsedExpr) => string,
+  forward?: boolean,
+): string | null {
+  const json = serializeParsedExpr(predicate)
+  if (json === null) return null
+  const env = emitEvalEnvArg(predicate, [param], emit)
+  const fwd = forward === undefined ? '' : `, ${forward ? 1 : 0}`
+  return `bf->${funcName}(${recv}, '${escapePerlSingleQuote(json)}', '${param}'${fwd}, ${env})`
+}
+
+/**
  * Shared Mojo emit for `.sort(cmp)` / `.toSorted(cmp)` (#1448 Tier B).
  * Used by both the filter-context emitter and the top-level emitter,
  * plus the loop-hoist path in `renderLoop` — same emit shape across

--- a/packages/adapter-mojolicious/src/adapter/expr/emitters.ts
+++ b/packages/adapter-mojolicious/src/adapter/expr/emitters.ts
@@ -37,6 +37,7 @@ import {
   renderReduceMethod,
   renderSortEval,
   renderReduceEval,
+  renderPredicateEval,
   renderFlatMethod,
   renderFlatMapMethod,
 } from './array-method.ts'
@@ -392,6 +393,28 @@ export class MojoTopLevelEmitter implements ParsedExprEmitter {
     emit: (e: ParsedExpr) => string,
   ): string {
     const arrayExpr = emit(object)
+
+    // Evaluator path (#2018 P2): serialize the predicate body + emit the
+    // matching `bf->*_eval` helper (isomorphic with the Go adapter). Falls
+    // back to the inline `grep` / `bf->find` lowering below for a predicate
+    // the evaluator can't model (e.g. a method-call predicate).
+    const evalFn: Record<string, [string, boolean?]> = {
+      filter: ['filter_eval'], every: ['every_eval'], some: ['some_eval'],
+      find: ['find_eval', true], findLast: ['find_eval', false],
+      findIndex: ['find_index_eval', true], findLastIndex: ['find_index_eval', false],
+    }
+    // `.filter(Boolean)` (identity predicate `_t => _t`) keeps the inline
+    // `grep { $_ }` form — it composes through the array-method chain
+    // (`.filter(Boolean).join(' ')` in the registry Slot) and renders
+    // identically to a truthiness filter.
+    const isIdentity =
+      method === 'filter' && predicate.kind === 'identifier' && predicate.name === param
+    const spec = evalFn[method]
+    if (spec && !isIdentity) {
+      const evalForm = renderPredicateEval(spec[0], arrayExpr, predicate, param, emit, spec[1])
+      if (evalForm !== null) return evalForm
+    }
+
     const predBody = this.ctx._renderPerlFilterExprPublic(predicate, param)
     const grepBody = predBody.replace(new RegExp(`\\$${param}\\b`, 'g'), '$_')
     if (method === 'filter') return `[grep { ${grepBody} } @{${arrayExpr}}]`

--- a/packages/adapter-perl/lib/BarefootJS.pm
+++ b/packages/adapter-perl/lib/BarefootJS.pm
@@ -1103,6 +1103,32 @@ sub reduce_eval ($self, $recv, $body_json, $acc_name, $item_name, $init, $direct
     return BarefootJS::Evaluator::fold_json($recv, $body_json, $acc_name, $item_name, $init, $direction, $base_env);
 }
 
+# Evaluator-driven higher-order predicates (#2018, P2): the predicate body
+# rides as a serialized-ParsedExpr JSON string evaluated per element, delegating
+# to the shared BarefootJS::Evaluator. The adapter emits `bf->filter_eval(...)`
+# etc. for any pure predicate; a body it can't model (e.g. a method-call
+# predicate) keeps the legacy `grep` / `bf->find` path. `find_eval` /
+# `find_index_eval` take a `$forward` flag (false → findLast / findLastIndex).
+sub filter_eval ($self, $recv, $pred_json, $param, $base_env = {}) {
+    return BarefootJS::Evaluator::filter_json($recv, $pred_json, $param, $base_env);
+}
+
+sub every_eval ($self, $recv, $pred_json, $param, $base_env = {}) {
+    return BarefootJS::Evaluator::every_json($recv, $pred_json, $param, $base_env);
+}
+
+sub some_eval ($self, $recv, $pred_json, $param, $base_env = {}) {
+    return BarefootJS::Evaluator::some_json($recv, $pred_json, $param, $base_env);
+}
+
+sub find_eval ($self, $recv, $pred_json, $param, $forward = 1, $base_env = {}) {
+    return BarefootJS::Evaluator::find_json($recv, $pred_json, $param, $forward, $base_env);
+}
+
+sub find_index_eval ($self, $recv, $pred_json, $param, $forward = 1, $base_env = {}) {
+    return BarefootJS::Evaluator::find_index_json($recv, $pred_json, $param, $forward, $base_env);
+}
+
 sub sort ($self, $recv, $opts = {}) {
     return [] unless ref($recv) eq 'ARRAY';
 

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -291,3 +291,58 @@ export function C() {
     expect(deferred.template).not.toContain('data-x')
   })
 })
+
+// #2018 P2: higher-order predicates lower through the runtime evaluator
+// (`$bf.*_eval`), isomorphic with the Go / Mojo `*_eval` helpers. A predicate
+// the evaluator can't model (a method-call predicate) falls back to the Kolon
+// lambda runtime call. Template-text pins guard against silent divergence.
+describe('XslateAdapter - higher-order predicate lowering (#2018 P2)', () => {
+  test('a serializable predicate lowers to $bf.filter_eval with the JSON body + env', () => {
+    // A standalone `.filter().length` exercises the higher-order emitter (the
+    // `.filter().map()` form is a loop-hoist with an inline `: if`, handled by
+    // renderLoop, not this emitter).
+    const { template } = compileAndGenerate(`
+function A({ items }: { items: { done: boolean }[] }) {
+  return <div>{items.filter(x => x.done).length}</div>
+}
+export { A }
+`)
+    expect(template).toContain('$bf.filter_eval(')
+    expect(template).toContain('"property":"done"')
+    expect(template).toContain("'x'")
+  })
+
+  test('.find / .findLast share $bf.find_eval, distinguished by the forward flag', () => {
+    const find = compileAndGenerate(`
+function A({ items }: { items: { done: boolean }[] }) {
+  return <div>{items.find(x => x.done) ? 'y' : 'n'}</div>
+}
+export { A }
+`).template
+    expect(find).toContain('$bf.find_eval(')
+    expect(find).toContain(', 1, {})')
+
+    const findLast = compileAndGenerate(`
+function A({ items }: { items: { done: boolean }[] }) {
+  return <div>{items.findLast(x => x.done) ? 'y' : 'n'}</div>
+}
+export { A }
+`).template
+    expect(findLast).toContain('$bf.find_eval(')
+    expect(findLast).toContain(', 0, {})')
+  })
+
+  test('a method-call predicate falls back to the Kolon-lambda runtime call', () => {
+    const { template } = compileAndGenerate(`
+function A({ items }: { items: { name: string }[] }) {
+  return <div>{items.every(x => x.name.includes('a')) ? 'y' : 'n'}</div>
+}
+export { A }
+`)
+    // No evaluator helper — the unsupported predicate keeps the `-> $x { … }`
+    // lambda form passed to the runtime `$bf.every`.
+    expect(template).not.toContain('every_eval')
+    expect(template).toContain('$bf.every(')
+    expect(template).toContain('-> $x {')
+  })
+})

--- a/packages/adapter-xslate/src/adapter/expr/array-method.ts
+++ b/packages/adapter-xslate/src/adapter/expr/array-method.ts
@@ -229,6 +229,32 @@ export function renderReduceEval(
 }
 
 /**
+ * Emit a higher-order predicate call via the runtime evaluator (#2018, P2):
+ * `$bf.filter_eval` / `$bf.every_eval` / `$bf.some_eval` / `$bf.find_eval` /
+ * `$bf.find_index_eval`, carrying the serialized predicate body + captured env
+ * hashref. Generalizes the Kolon-lambda `$bf.filter` lowering to the same
+ * JS-faithful evaluator the Go adapter uses (cross-adapter isomorphism).
+ * Returns null when the predicate is outside the evaluator surface (e.g. a
+ * method-call predicate — `serializeParsedExpr` refuses it), so the caller
+ * falls back to the lambda form. `forward` (find / findIndex family only)
+ * selects the search direction — `false` = findLast / findLastIndex.
+ */
+export function renderPredicateEval(
+  funcName: string,
+  recv: string,
+  predicate: ParsedExpr,
+  param: string,
+  emit: (e: ParsedExpr) => string,
+  forward?: boolean,
+): string | null {
+  const json = serializeParsedExpr(predicate)
+  if (json === null) return null
+  const env = emitEvalEnvArg(predicate, [param], emit)
+  const fwd = forward === undefined ? '' : `, ${forward ? 1 : 0}`
+  return `$bf.${funcName}(${recv}, '${escapePerlSingleQuote(json)}', '${param}'${fwd}, ${env})`
+}
+
+/**
  * Shared Kolon emit for `.sort(cmp)` / `.toSorted(cmp)`. Used by both the
  * filter-context emitter and the top-level emitter, plus the loop-array
  * wrap in `renderLoop`. The runtime `$bf.sort` accepts a hashref opts bag and

--- a/packages/adapter-xslate/src/adapter/expr/emitters.ts
+++ b/packages/adapter-xslate/src/adapter/expr/emitters.ts
@@ -35,6 +35,7 @@ import {
   renderReduceMethod,
   renderSortEval,
   renderReduceEval,
+  renderPredicateEval,
   renderFlatMethod,
   renderFlatMapMethod,
 } from './array-method.ts'
@@ -349,6 +350,27 @@ export class XslateTopLevelEmitter implements ParsedExprEmitter {
     // methods (like index_of / last_index_of). The `.filter(...).map(...)`
     // *loop* form is handled separately by renderLoop's inline predicate.
     const arrayExpr = emit(object)
+
+    // Evaluator path (#2018 P2): serialize the predicate body + emit the
+    // matching `$bf.*_eval` helper (isomorphic with the Go adapter). Falls
+    // back to the Kolon-lambda runtime call below for a predicate the
+    // evaluator can't model (e.g. a method-call predicate).
+    const evalFn: Record<string, [string, boolean?]> = {
+      filter: ['filter_eval'], every: ['every_eval'], some: ['some_eval'],
+      find: ['find_eval', true], findLast: ['find_eval', false],
+      findIndex: ['find_index_eval', true], findLastIndex: ['find_index_eval', false],
+    }
+    // `.filter(Boolean)` (identity predicate `_t => _t`) keeps the lambda
+    // form — it composes through the array-method chain and renders
+    // identically to a truthiness filter.
+    const isIdentity =
+      method === 'filter' && predicate.kind === 'identifier' && predicate.name === param
+    const spec = evalFn[method]
+    if (spec && !isIdentity) {
+      const evalForm = renderPredicateEval(spec[0], arrayExpr, predicate, param, emit, spec[1])
+      if (evalForm !== null) return evalForm
+    }
+
     const predBody = this.ctx._renderKolonFilterExprPublic(predicate, param)
     const lambda = `-> $${param} { ${predBody} }`
     const fn: Record<string, string> = {


### PR DESCRIPTION
## What

**Stacked on #2033** (the Go P2 emit). The Perl half: routes `.filter` /
`.find` / `.findIndex` / `.findLast` / `.findLastIndex` / `.every` / `.some` on
the **Mojolicious** and **Xslate** adapters through the runtime evaluator.

The predicate body serializes to a `ParsedExpr` JSON blob and emits
`bf->filter_eval` / `bf->find_eval` / `bf->find_index_eval` / `bf->every_eval` /
`bf->some_eval` (`$bf.…` in Xslate), with captured free vars threaded as a
`base_env` hashref — **the same JS-faithful evaluator the Go adapter uses**, so
the two SSR backends stay byte-isomorphic (the inline Perl `grep` / Kolon-lambda
forms had their own coercion semantics).

## How

- New `renderPredicateEval` in each adapter's `array-method.ts` (funcName +
  recv + serialized predicate + param + optional `forward` flag + env hashref).
- Eval-first in the top-level `higherOrder` emitter arm; a predicate the
  evaluator can't model (a method-call predicate — `serializeParsedExpr`
  returns null) **falls back** to the inline `grep` / Kolon-lambda / `bf->find`
  lowering. `.filter(Boolean)` keeps its inline truthiness form.
- Controller helpers `filter_eval` / `every_eval` / `some_eval` / `find_eval` /
  `find_index_eval` on `BarefootJS`, delegating to `BarefootJS::Evaluator`.
- `find_eval` / `find_index_eval` take a `forward` flag (`0` → findLast /
  findLastIndex).

## Invariant

**Rendered HTML is unchanged.** The standalone higher-order template-text pins
move to the `*_eval` form; the mojo `.filter().map()` loop now hoists over the
evaluator-filtered array (hoisting the call into a single `my` var is a P3
optimization). Mojo 464 pass / Xslate 353 pass / 0 fail locally;
`prove t/evaluator.t` green. Real Mojo/Xslate render parity runs in CI (skips
locally — no Perl template modules in the local harness).

## Deferred

The nested-higher-order-in-predicate (`grep`-fallback) emitter and the
`bf_filter` / `bf->find` legacy-helper retirement stay until they're
unreferenced; eval-vectors for the predicate helpers are covered by the
existing evaluator vectors + the Go/Perl unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_