### PR TITLE
feat: lower the .sort().map() loop-hoist comparator through the evaluator (#2018 P3)

### DIFF
--- a/.changeset/loop-hoist-sort-eval.md
+++ b/.changeset/loop-hoist-sort-eval.md
@@ -1,0 +1,18 @@
+---
+"@barefootjs/go-template": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+---
+
+Lower the `.sort().map()` loop-hoist comparator through the runtime evaluator
+(#2018, P3). The chained-sort site that wraps a loop's iterable now serializes
+the comparator body and emits `bf_sort_eval` / `bf->sort_eval` / `$bf.sort_eval`
+(the same path the standalone `.sort(cmp)` value call uses since P1), with
+captured free vars threaded as the env argument. A comparator the evaluator
+can't model (e.g. `localeCompare`, including a `||`-chain that ends in one)
+falls back to the legacy structured `bf_sort` / `bf->sort` path, so behavior
+there is unchanged. Rendered HTML is unchanged; only the emitted template text
+moves to the evaluator helper. The `.filter().map()` loop gate stays an inline
+`{{if}}` / `: if` on the raw predicate (already de-folded). This removes the
+last standalone consumer of the structured `SortComparator` outside the parser,
+ahead of collapsing the folded `ParsedExpr` model.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -2880,21 +2880,22 @@ describe('GoTemplateAdapter - #1448 Tier A/B fixture-driven lowering pins', () =
     // #1448 Tier B — string → string, padded to a target width.
     { fixture: stringPadStartFixture,   expect: 'bf_pad_start .Value 5 "0"' },
     { fixture: stringPadEndFixture,     expect: 'bf_pad_end .Value 5 "."' },
-    // #1448 Tier B — sort / toSorted. Loop-chained shapes wrap the
-    // iterable in `bf_sort .Items <kind> <key> <type> <dir>`;
-    // standalone shapes inline the helper at the call site.
-    { fixture: arraySortFieldAscFixture,  expect: 'bf_sort .Items "field" "Price" "numeric" "asc"' },
-    { fixture: arraySortFieldDescFixture, expect: 'bf_sort .Items "field" "Price" "numeric" "desc"' },
-    // Standalone numeric sorts now lower through the evaluator (#2018): the
-    // comparator body travels as serialized ParsedExpr to `bf_sort_eval`.
+    // #1448 Tier B — sort / toSorted. Both the standalone shapes and the
+    // `.sort().map()` loop-hoist now lower through the evaluator (#2018 P1/P3):
+    // the comparator body travels as serialized ParsedExpr to `bf_sort_eval`.
+    { fixture: arraySortFieldAscFixture,  expect: 'bf_sort_eval .Items' },
+    { fixture: arraySortFieldDescFixture, expect: 'bf_sort_eval .Items' },
     { fixture: arraySortPrimitiveFixture, expect: 'bf_sort_eval .Nums' },
-    // localeCompare can't be evaluated, so it keeps the legacy `bf_sort` path.
+    // localeCompare can't be evaluated, so it keeps the legacy `bf_sort` path
+    // (both standalone and loop-hoist fall back).
     { fixture: arraySortLocaleFixture,    expect: 'bf_sort .Names "self" "" "string" "asc"' },
-    // Multi-key (`||`-chain): one 4-string group per comparison key,
-    // applied in priority order as tie-breakers.
+    // Multi-key (`||`-chain) here ends in a `localeCompare`, so the whole
+    // comparator falls back to the structured `bf_sort` (one 4-string group
+    // per comparison key, applied in priority order as tie-breakers).
     { fixture: arraySortMultiKeyFixture,  expect: 'bf_sort .Items "field" "Price" "numeric" "asc" "field" "Name" "string" "asc"' },
-    // Relational-ternary comparator lowers to a single `auto` key.
-    { fixture: arraySortTernaryFixture,   expect: 'bf_sort .Items "field" "Rank" "auto" "asc"' },
+    // Relational-ternary comparator — a pure body, so it lowers via the
+    // evaluator like the other field sorts.
+    { fixture: arraySortTernaryFixture,   expect: 'bf_sort_eval .Items' },
     { fixture: arrayToSortedFixture,      expect: 'bf_sort_eval .Nums' },
     // #1448 Tier B — iteration shapes. These are loop-level
     // patterns (range binding order), not helper function calls.

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -4573,11 +4573,18 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     if (pushedBindingMap) this.loopBindingStack.pop()
     this.inLoop = false
 
-    // Apply sort if present: wrap the array in a bf_sort pipeline. The same
-    // `emitBfSort` helper feeds both this loop-chained call site and the
-    // standalone `sortMethod()` arm above.
+    // Apply sort if present: wrap the array in a sort pipeline before `range`.
+    // Evaluator-first (#2018 P3): serialize the comparator body + emit
+    // `bf_sort_eval`, the same path the standalone `sortMethod()` arm uses;
+    // fall back to the structured `bf_sort` for a comparator the evaluator
+    // can't model (e.g. `localeCompare`). The sort runs after the loop-scope
+    // cleanup above, so the captured-free-var env renders in the outer scope.
     if (loop.sortComparator) {
-      goArray = `(${emitBfSort(goArray, loop.sortComparator)})`
+      const sortEmit = (e: ParsedExpr) => this.renderParsedExpr(e)
+      const sorted =
+        emitSortEval(goArray, loop.sortComparator, sortEmit) ??
+        emitBfSort(goArray, loop.sortComparator)
+      goArray = `(${sorted})`
     }
 
     // filter().map(): gate the body on an `{{if}}` condition.

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -1398,15 +1398,15 @@ describe('MojoAdapter - #1448 Tier A/B fixture-driven lowering pins', () => {
     // #1448 Tier B — string → string, padded to a target width.
     { fixture: stringPadStartFixture,   expect: `bf->pad_start($value, 5, '0')` },
     { fixture: stringPadEndFixture,     expect: `bf->pad_end($value, 5, '.')` },
-    // #1448 Tier B — sort / toSorted. EXPR2 migration (#2018): a
-    // STANDALONE `.sort(cmp)` value call serializes the comparator body
-    // and emits `bf->sort_eval(...)` (JSON body + param names + captured
-    // env). The loop-chained `.sort().map()` field cases still hoist into
-    // a `my $bf_iter_lN = bf->sort(...)` legacy local (loop-hoist de-fold
-    // is P3, not this phase). `localeCompare` comparators fall back to the
-    // structured `bf->sort` — `serializeParsedExpr` refuses them.
-    { fixture: arraySortFieldAscFixture,  expect: `bf->sort($items, { keys => [{ key_kind => 'field', key => 'price', compare_type => 'numeric', direction => 'asc' }] })` },
-    { fixture: arraySortFieldDescFixture, expect: `bf->sort($items, { keys => [{ key_kind => 'field', key => 'price', compare_type => 'numeric', direction => 'desc' }] })` },
+    // #1448 Tier B — sort / toSorted. EXPR2 migration (#2018): both a
+    // STANDALONE `.sort(cmp)` value call AND the `.sort().map()` loop-hoist
+    // (#2018 P3) serialize the comparator body and emit `bf->sort_eval(...)`
+    // (JSON body + param names + captured env). `localeCompare` comparators
+    // fall back to the structured `bf->sort` — `serializeParsedExpr` refuses
+    // them. (Loop-hoist field cases pin only the helper + receiver; their
+    // comparator JSON is verified by the render conformance.)
+    { fixture: arraySortFieldAscFixture,  expect: `bf->sort_eval($items,` },
+    { fixture: arraySortFieldDescFixture, expect: `bf->sort_eval($items,` },
     { fixture: arraySortPrimitiveFixture, expect: `bf->sort_eval($nums, '{"kind":"binary","op":"-","left":{"kind":"identifier","name":"a"},"right":{"kind":"identifier","name":"b"}}', 'a', 'b', {})` },
     // localeCompare → outside the evaluator surface → legacy `bf->sort`.
     { fixture: arraySortLocaleFixture,    expect: `bf->sort($names, { keys => [{ key_kind => 'self', compare_type => 'string', direction => 'asc' }] })` },
@@ -1414,9 +1414,9 @@ describe('MojoAdapter - #1448 Tier A/B fixture-driven lowering pins', () => {
     // whole comparator falls back to the structured `bf->sort` (one hash
     // per comparison key, in order).
     { fixture: arraySortMultiKeyFixture,  expect: `bf->sort($items, { keys => [{ key_kind => 'field', key => 'price', compare_type => 'numeric', direction => 'asc' }, { key_kind => 'field', key => 'name', compare_type => 'string', direction => 'asc' }] })` },
-    // Relational-ternary comparator — loop-hoisted (`.sort().map()`), so
-    // it stays on the legacy `auto`-key `bf->sort` until P3.
-    { fixture: arraySortTernaryFixture,   expect: `bf->sort($items, { keys => [{ key_kind => 'field', key => 'rank', compare_type => 'auto', direction => 'asc' }] })` },
+    // Relational-ternary comparator — a pure body, so the loop-hoist now
+    // serializes it through `bf->sort_eval` like the other field sorts.
+    { fixture: arraySortTernaryFixture,   expect: `bf->sort_eval($items,` },
     { fixture: arrayToSortedFixture,      expect: `bf->sort_eval($nums, '{"kind":"binary","op":"-","left":{"kind":"identifier","name":"a"},"right":{"kind":"identifier","name":"b"}}', 'a', 'b', {})` },
     // #1448 Tier B — iteration shapes. These are loop-level patterns.
     // .entries() → for loop with both $i index var and $v value var

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -781,10 +781,26 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       // Evaluator-first (#2018 P3): serialize the comparator + emit
       // `bf->sort_eval`; fall back to the structured `bf->sort` for a
       // comparator the evaluator can't model (e.g. `localeCompare`).
+      //
+      // The hoisted sort runs OUTSIDE this loop, so this loop's bound names
+      // must not shadow the comparator's captured free vars while emitting the
+      // env — otherwise a captured var that happens to share a loop-param name
+      // is blocked from inlining its module const and renders as an undefined
+      // `$name` (strict-mode fault, Copilot review #2035). Drop this loop's
+      // bound names for the sort emit, then restore (a nested loop's outer
+      // bindings, ref-counted, stay in effect).
+      for (const n of loopBound) {
+        const c = (this.loopBoundNames.get(n) ?? 1) - 1
+        if (c <= 0) this.loopBoundNames.delete(n)
+        else this.loopBoundNames.set(n, c)
+      }
       const sortEmit = (e: ParsedExpr) => this.convertExpressionToPerl('', e)
       const sorted =
         renderSortEval(rawArray, loop.sortComparator, sortEmit) ??
         renderSortMethod(rawArray, loop.sortComparator)
+      for (const n of loopBound) {
+        this.loopBoundNames.set(n, (this.loopBoundNames.get(n) ?? 0) + 1)
+      }
       lines.push(`% my $${sortedHoist} = ${sorted};`)
     }
     lines.push(`% for my ${indexVar} (0..$#{${array}}) {`)

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -66,7 +66,7 @@ import {
   resolveJsxChildrenProp,
   collectRootScopeNodes,
 } from './lib/ir-scope.ts'
-import { renderSortMethod } from './expr/array-method.ts'
+import { renderSortMethod, renderSortEval } from './expr/array-method.ts'
 import { MojoFilterEmitter, MojoTopLevelEmitter } from './expr/emitters.ts'
 import type { MojoEmitContext, MojoSpreadContext, MojoMemoContext } from './emit-context.ts'
 import {
@@ -778,7 +778,14 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     // each get their own reconciliation range (#1087).
     lines.push(`<%== bf->comment("loop:${loop.markerId}") %>`)
     if (sortedHoist && loop.sortComparator) {
-      lines.push(`% my $${sortedHoist} = ${renderSortMethod(rawArray, loop.sortComparator)};`)
+      // Evaluator-first (#2018 P3): serialize the comparator + emit
+      // `bf->sort_eval`; fall back to the structured `bf->sort` for a
+      // comparator the evaluator can't model (e.g. `localeCompare`).
+      const sortEmit = (e: ParsedExpr) => this.convertExpressionToPerl('', e)
+      const sorted =
+        renderSortEval(rawArray, loop.sortComparator, sortEmit) ??
+        renderSortMethod(rawArray, loop.sortComparator)
+      lines.push(`% my $${sortedHoist} = ${sorted};`)
     }
     lines.push(`% for my ${indexVar} (0..$#{${array}}) {`)
     if (loop.iterationShape !== 'keys') {

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -81,7 +81,7 @@ import {
   resolveJsxChildrenProp,
   collectRootScopeNodes,
 } from './lib/ir-scope.ts'
-import { renderSortMethod } from './expr/array-method.ts'
+import { renderSortMethod, renderSortEval } from './expr/array-method.ts'
 import { XslateFilterEmitter, XslateTopLevelEmitter } from './expr/emitters.ts'
 import type { XslateEmitContext, XslateSpreadContext, XslateMemoContext } from './emit-context.ts'
 import {
@@ -592,7 +592,13 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     // helper runs once.
     let array = rawArray
     if (loop.sortComparator) {
-      array = renderSortMethod(rawArray, loop.sortComparator)
+      // Evaluator-first (#2018 P3): serialize the comparator + emit
+      // `$bf.sort_eval`; fall back to the structured `$bf.sort` for a
+      // comparator the evaluator can't model (e.g. `localeCompare`).
+      const sortEmit = (e: ParsedExpr) => this.convertExpressionToKolon('', e)
+      array =
+        renderSortEval(rawArray, loop.sortComparator, sortEmit) ??
+        renderSortMethod(rawArray, loop.sortComparator)
     }
     const param = loop.param
     // Kolon binds the item directly via `for LIST -> $item`. The index, when


### PR DESCRIPTION
## What

**Stacked on #2034** (P2 Perl emit). The first **P3** step: the `.sort().map()`
loop-hoist comparator now lowers through the runtime evaluator across all three
adapters, instead of the structured `bf_sort` / `bf->sort` catalogue.

The chained-sort site that wraps a loop's iterable (renderLoop in
go-template-adapter / mojo-adapter / xslate-adapter) serializes the comparator
body and emits `bf_sort_eval` / `bf->sort_eval` / `$bf.sort_eval` — the same
path the standalone `.sort(cmp)` value call has used since P1 — with captured
free vars threaded as the env argument. The sort runs after the loop-scope
cleanup, so the env renders in the outer scope.

## Scope & fallback

- A comparator the evaluator can't model (`localeCompare`, or a `||`-chain
  ending in one) **falls back** to the legacy structured `bf_sort` / `bf->sort`.
- The `.filter().map()` loop gate stays an inline `{{if}}` / `: if` on the raw
  predicate — it was never folded (it renders the predicate `ParsedExpr`
  directly), so it's already P5-safe and needs no change.

## Invariant

**Rendered HTML is unchanged.** The loop-hoist sort template-text pins move to
the `*_eval` form (field-asc / field-desc / ternary); localeCompare and the
multi-key-with-localeCompare cases stay legacy. Go 524 pass / Mojo 465 / Xslate
356 / 0 fail locally; Go render conformance green. Perl render parity runs in CI.

This removes the last standalone consumer of the structured `SortComparator`
outside the parser, ahead of P5's folded-model collapse.

## Next (further stacked PR)

`.flatMap` → an evaluator `FlatMapEval` (serialized projection body + new
runtime helpers), the remaining map/flatMap de-fold piece of P3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_