### PR TITLE
feat: lower .flatMap(proj) through the evaluator (#2018 P3)

### DIFF
--- a/.changeset/flatmap-eval.md
+++ b/.changeset/flatmap-eval.md
@@ -1,0 +1,18 @@
+---
+"@barefootjs/go-template": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+"@barefootjs/perl": patch
+---
+
+Lower `.flatMap(proj)` through the runtime evaluator (#2018, P3). The projection
+body serializes to a ParsedExpr JSON blob and `bf_flat_map_eval` /
+`bf->flat_map_eval` / `$bf.flat_map_eval` projects each element then flattens
+one level, generalizing the structured self / field / tuple
+(`bf_flat_map` / `bf_flat_map_tuple`) catalogue to any pure projection. A
+projection the evaluator can't model falls back to the structured helper. The
+shared runtime gains `BarefootJS::Evaluator::flat_map` / `flat_map_json` and a
+`flat_map_eval` controller helper (Go `FlatMapEval`, registered as
+`bf_flat_map_eval`). Rendered HTML is unchanged; only the emitted template text
+moves to the evaluator helper. (`.flat(depth?)` is a non-callback array method
+and stays folded.)

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -111,6 +111,9 @@ func FuncMap() template.FuncMap {
 		"bf_some_eval":       SomeEval,
 		"bf_find_eval":       FindEval,
 		"bf_find_index_eval": FindIndexEval,
+		// `.flatMap(proj)`: project each element through the serialized
+		// projection body, then flatten one level.
+		"bf_flat_map_eval": FlatMapEval,
 
 		// Comment marker (for hydration)
 		"bfComment":   Comment,

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -877,7 +877,7 @@ func TestFuncMap(t *testing.T) {
 		"bf_every", "bf_some", "bf_filter", "bf_find", "bf_find_index", "bf_sort",
 		"bf_sort_eval", "bf_reduce_eval", "bf_env",
 		"bf_filter_eval", "bf_every_eval", "bf_some_eval",
-		"bf_find_eval", "bf_find_index_eval",
+		"bf_find_eval", "bf_find_index_eval", "bf_flat_map_eval",
 		"bfComment", "bfTextStart", "bfTextEnd", "bfPortalHTML",
 	}
 

--- a/packages/adapter-go-template/runtime/eval.go
+++ b/packages/adapter-go-template/runtime/eval.go
@@ -757,7 +757,12 @@ func FlatMapEval(items any, projJSON, param string, baseEnv map[string]any) []an
 	for _, item := range toAnySlice(items) {
 		env[param] = item
 		v := EvalNode(proj, env)
-		if sub, isSlice := v.([]any); isSlice {
+		// Flatten any slice/array kind one level, not just []any: real Go
+		// template data projects a field like `i.tags` to a typed slice
+		// (`[]string` / `[]int`), which `toAnySlice` normalizes to []any. A
+		// non-slice value (string / number / struct / nil) contributes itself,
+		// matching JS `.flatMap` (a non-array return is kept as one element).
+		if sub := toAnySlice(v); sub != nil {
 			out = append(out, sub...)
 		} else {
 			out = append(out, v)

--- a/packages/adapter-go-template/runtime/eval.go
+++ b/packages/adapter-go-template/runtime/eval.go
@@ -740,6 +740,32 @@ func FindIndexEval(items any, predJSON, param string, forward bool, baseEnv map[
 	return -1
 }
 
+// FlatMapEval projects each element through the projection body (a pure
+// ParsedExpr JSON evaluated against `{param: item}` + baseEnv) and flattens the
+// results one level — the evaluator generalization of bf_flat_map /
+// bf_flat_map_tuple. A projection that yields a slice contributes its elements;
+// any other value contributes itself (matching JS `.flatMap`, where a non-array
+// return is kept as a single element). Returns a non-nil empty slice on a bad
+// body so a downstream `range` / `bf_join` sees a real slice.
+func FlatMapEval(items any, projJSON, param string, baseEnv map[string]any) []any {
+	proj, ok := decodeEvalBody(projJSON)
+	if !ok {
+		return []any{}
+	}
+	env := seedPredEnv(baseEnv)
+	out := []any{}
+	for _, item := range toAnySlice(items) {
+		env[param] = item
+		v := EvalNode(proj, env)
+		if sub, isSlice := v.([]any); isSlice {
+			out = append(out, sub...)
+		} else {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
 // Env builds the captured-free-var environment for FoldEval / SortEval from a
 // flat key, value, key, value, … argument list — the adapter emits
 // `bf_env "k1" v1 "k2" v2 …` for the free variables a callback body references

--- a/packages/adapter-go-template/runtime/eval_test.go
+++ b/packages/adapter-go-template/runtime/eval_test.go
@@ -132,6 +132,40 @@ func TestPredicateEvalHelpers(t *testing.T) {
 	}
 }
 
+// FlatMapEval projects + flattens one level: a field projection yielding a
+// slice contributes its elements; a tuple (array-literal) projection
+// contributes its leaves; a scalar projection is kept as a single element.
+func TestFlatMapEval(t *testing.T) {
+	rows := []any{
+		map[string]any{"tags": []any{"a", "b"}},
+		map[string]any{"tags": []any{"c"}},
+	}
+	// field: i => i.tags  → ["a","b","c"]
+	field := mustJSON(t, nmem(nid("i"), "tags"))
+	if got := FlatMapEval(rows, field, "i", nil); len(got) != 3 || got[0] != "a" || got[2] != "c" {
+		t.Fatalf("FlatMapEval field = %v, want [a b c]", got)
+	}
+
+	// tuple: p => [p.x, p.y]  → [1,2,3,4]
+	pts := []any{
+		map[string]any{"x": 1.0, "y": 2.0},
+		map[string]any{"x": 3.0, "y": 4.0},
+	}
+	tuple := mustJSON(t, map[string]any{
+		"kind":     "array-literal",
+		"elements": []any{nmem(nid("p"), "x"), nmem(nid("p"), "y")},
+	})
+	got := FlatMapEval(pts, tuple, "p", nil)
+	if len(got) != 4 || evalToNumber(got[0]) != 1 || evalToNumber(got[3]) != 4 {
+		t.Fatalf("FlatMapEval tuple = %v, want [1 2 3 4]", got)
+	}
+
+	// A scalar (self) projection of non-array items keeps each as one element.
+	if got := FlatMapEval([]any{1.0, 2.0}, mustJSON(t, nid("i")), "i", nil); len(got) != 2 {
+		t.Fatalf("FlatMapEval self-scalar = %v, want length 2", got)
+	}
+}
+
 // FoldEval lifts bf_reduce's op restriction and acc-canonical form: the
 // reducer body `acc + item.price * item.qty` mixes `acc` with a product of two
 // fields — impossible in the +/* self/field catalogue, trivial for the

--- a/packages/adapter-go-template/runtime/eval_test.go
+++ b/packages/adapter-go-template/runtime/eval_test.go
@@ -136,14 +136,17 @@ func TestPredicateEvalHelpers(t *testing.T) {
 // slice contributes its elements; a tuple (array-literal) projection
 // contributes its leaves; a scalar projection is kept as a single element.
 func TestFlatMapEval(t *testing.T) {
+	// Typed `[]string` fields (the real Go-template data shape, not []any) must
+	// flatten too — `toAnySlice` normalizes any slice/array kind (Copilot
+	// review #2036).
 	rows := []any{
-		map[string]any{"tags": []any{"a", "b"}},
-		map[string]any{"tags": []any{"c"}},
+		map[string]any{"tags": []string{"a", "b"}},
+		map[string]any{"tags": []string{"c"}},
 	}
 	// field: i => i.tags  → ["a","b","c"]
 	field := mustJSON(t, nmem(nid("i"), "tags"))
 	if got := FlatMapEval(rows, field, "i", nil); len(got) != 3 || got[0] != "a" || got[2] != "c" {
-		t.Fatalf("FlatMapEval field = %v, want [a b c]", got)
+		t.Fatalf("FlatMapEval typed-slice field = %v, want [a b c]", got)
 	}
 
 	// tuple: p => [p.x, p.y]  → [1,2,3,4]

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -3000,20 +3000,24 @@ export { C }
     return adapter.generate(ir).template ?? ''
   }
 
-  test('.flatMap(i => i.field) emits bf_flat_map with the Go-capitalised field', () => {
-    expect(emitFlatMap('rows.flatMap(i => i.tags).join(" ")')).toContain('bf_flat_map .Rows "field" "Tags"')
+  // #2018 P3: `.flatMap(proj)` lowers through the evaluator — the projection
+  // body serializes to ParsedExpr JSON and `bf_flat_map_eval` flattens the
+  // results one level. The raw (lowercase) field name travels in the JSON; the
+  // runtime field reader resolves it case-insensitively against Go data.
+  // (The serialized projection JSON is embedded in a Go-template double-quoted
+  // string — its quotes are backslash-escaped — so these pins assert the helper
+  // + receiver; the projection JSON itself is verified by the render
+  // conformance fixtures + the runtime TestFlatMapEval.)
+  test('.flatMap(i => i.field) emits bf_flat_map_eval', () => {
+    expect(emitFlatMap('rows.flatMap(i => i.tags).join(" ")')).toContain('bf_flat_map_eval .Rows')
   })
 
-  test('.flatMap(i => i) emits the self projection', () => {
-    expect(emitFlatMap('rows.flatMap(i => i).join(" ")')).toContain('bf_flat_map .Rows "self" ""')
+  test('.flatMap(i => i) emits bf_flat_map_eval (self projection)', () => {
+    expect(emitFlatMap('rows.flatMap(i => i).join(" ")')).toContain('bf_flat_map_eval .Rows')
   })
 
-  test('.flatMap(i => [i.a, i.b]) emits bf_flat_map_tuple with capitalised leaves', () => {
-    expect(emitFlatMap('rows.flatMap(i => [i.a, i.b]).join(" ")')).toContain('bf_flat_map_tuple .Rows "field" "A" "field" "B"')
-  })
-
-  test('tuple self + field leaves', () => {
-    expect(emitFlatMap('rows.flatMap(i => [i, i.a]).join(" ")')).toContain('bf_flat_map_tuple .Rows "self" "" "field" "A"')
+  test('.flatMap(i => [i.a, i.b]) emits bf_flat_map_eval (array-literal projection)', () => {
+    expect(emitFlatMap('rows.flatMap(i => [i.a, i.b]).join(" ")')).toContain('bf_flat_map_eval .Rows')
   })
 })
 

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -85,6 +85,7 @@ import {
   emitSortEval,
   emitReduceEval,
   emitPredicateEval,
+  emitFlatMapEval,
   stringTolerantEqOperands,
   buildUnsupportedSuggestion,
   GO_REMEDIATION_OPTIONS,
@@ -3191,6 +3192,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
   flatMapMethod(object: ParsedExpr, op: FlatMapOp, emit: (e: ParsedExpr) => string): string {
     const recv = wrapIfMultiToken(emit(object))
+
+    // Evaluator-first (#2018 P3): serialize the projection body + emit
+    // `bf_flat_map_eval`. Generalizes the structured self/field/tuple
+    // projections to any pure projection; falls back to the structured
+    // `bf_flat_map` / `bf_flat_map_tuple` for a projection the evaluator can't
+    // model.
+    const evalForm = emitFlatMapEval(recv, op, emit)
+    if (evalForm !== null) return evalForm
+
     const proj = op.projection
     // Tuple projection `i => [i.a, i.b]` → `bf_flat_map_tuple <recv> "<kind>"
     // "<name>" ...` (one quoted pair per leaf). flat(1) removes only the

--- a/packages/adapter-go-template/src/adapter/lib/go-emit.ts
+++ b/packages/adapter-go-template/src/adapter/lib/go-emit.ts
@@ -4,7 +4,7 @@
  * Pure free functions — none read adapter instance state.
  */
 
-import type { SortComparator, ReduceOp, SupportResult, ParsedExpr } from '@barefootjs/jsx'
+import type { SortComparator, ReduceOp, FlatMapOp, SupportResult, ParsedExpr } from '@barefootjs/jsx'
 import { parseExpression, serializeParsedExpr, freeVarsInBody } from '@barefootjs/jsx'
 
 import { capitalize } from "./go-naming.ts"
@@ -174,6 +174,26 @@ export function emitPredicateEval(
   const env = emitEvalEnvArg(predicate, [param], emit)
   const extra = extraArgs.length > 0 ? ` ${extraArgs.join(' ')}` : ''
   return `${funcName} ${wrapIfMultiToken(recv)} "${escapeGoString(json)}" "${param}"${extra} ${env}`
+}
+
+/**
+ * Emit a `.flatMap(proj)` via the evaluator (#2018, P3): the projection body
+ * (`FlatMapOp.raw`, e.g. `i.tags` / `[i.a, i.b]`) is serialized and evaluated
+ * per element by `bf_flat_map_eval`, which flattens the results one level.
+ * Generalizes the structured `bf_flat_map` / `bf_flat_map_tuple` (self / field /
+ * tuple) to any pure projection. Returns null when the projection is outside
+ * the evaluator surface (→ caller falls back to the structured helper).
+ */
+export function emitFlatMapEval(
+  recv: string,
+  op: FlatMapOp,
+  emit: (e: ParsedExpr) => string,
+): string | null {
+  const body = parseExpression(op.raw)
+  const json = serializeParsedExpr(body)
+  if (json === null) return null
+  const env = emitEvalEnvArg(body, [op.param], emit)
+  return `bf_flat_map_eval ${wrapIfMultiToken(recv)} "${escapeGoString(json)}" "${op.param}" ${env}`
 }
 
 /**

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -1496,20 +1496,26 @@ export { C }
     return a.generate(ir).template ?? ''
   }
 
-  test('.flatMap(i => i.field) emits bf->flat_map with the raw field key', () => {
-    expect(emitFlatMap('rows.flatMap(i => i.tags).join(" ")')).toContain(`bf->flat_map($rows, 'field', 'tags')`)
+  // #2018 P3: `.flatMap(proj)` lowers through the evaluator — the projection
+  // body serializes to ParsedExpr JSON and `bf->flat_map_eval` flattens the
+  // results one level. (In Mojo the JSON rides in a single-quoted Perl string,
+  // so its double quotes are literal and assertable.)
+  test('.flatMap(i => i.field) emits bf->flat_map_eval with the field projection', () => {
+    const t = emitFlatMap('rows.flatMap(i => i.tags).join(" ")')
+    expect(t).toContain(`bf->flat_map_eval($rows,`)
+    expect(t).toContain(`"property":"tags"`)
   })
 
-  test('.flatMap(i => i) emits the self projection', () => {
-    expect(emitFlatMap('rows.flatMap(i => i).join(" ")')).toContain(`bf->flat_map($rows, 'self', '')`)
+  test('.flatMap(i => i) emits bf->flat_map_eval (self/identifier projection)', () => {
+    const t = emitFlatMap('rows.flatMap(i => i).join(" ")')
+    expect(t).toContain(`bf->flat_map_eval($rows,`)
+    expect(t).toContain(`"kind":"identifier","name":"i"`)
   })
 
-  test('.flatMap(i => [i.a, i.b]) emits bf->flat_map_tuple with leaf specs', () => {
-    expect(emitFlatMap('rows.flatMap(i => [i.a, i.b]).join(" ")')).toContain(`bf->flat_map_tuple($rows, ['field', 'a'], ['field', 'b'])`)
-  })
-
-  test('tuple self + field leaves', () => {
-    expect(emitFlatMap('rows.flatMap(i => [i, i.a]).join(" ")')).toContain(`bf->flat_map_tuple($rows, ['self', ''], ['field', 'a'])`)
+  test('.flatMap(i => [i.a, i.b]) emits bf->flat_map_eval over an array-literal projection', () => {
+    const t = emitFlatMap('rows.flatMap(i => [i.a, i.b]).join(" ")')
+    expect(t).toContain(`bf->flat_map_eval($rows,`)
+    expect(t).toContain(`"kind":"array-literal"`)
   })
 
   test('field-projection flatMap as a loop base lowers (no BF101)', () => {
@@ -1522,7 +1528,7 @@ export function C() {
 }`, a)
     const template = a.generate(ir).template ?? ''
     expect((a.errors ?? []).filter(e => e.code === 'BF101')).toEqual([])
-    expect(template).toContain(`bf->flat_map($items, 'field', 'tags')`)
+    expect(template).toContain(`bf->flat_map_eval($items,`)
   })
 })
 

--- a/packages/adapter-mojolicious/src/adapter/expr/array-method.ts
+++ b/packages/adapter-mojolicious/src/adapter/expr/array-method.ts
@@ -343,6 +343,26 @@ export function renderPredicateEval(
 }
 
 /**
+ * Emit a `.flatMap(proj)` via the runtime evaluator (#2018, P3): the projection
+ * body (`FlatMapOp.raw`) serializes to JSON and `bf->flat_map_eval` projects +
+ * flattens one level. Generalizes the structured `bf->flat_map` /
+ * `bf->flat_map_tuple` to any pure projection; returns null when the projection
+ * is outside the evaluator surface (→ caller falls back to the structured
+ * helper).
+ */
+export function renderFlatMapEval(
+  recv: string,
+  op: FlatMapOp,
+  emit: (e: ParsedExpr) => string,
+): string | null {
+  const body = parseExpression(op.raw)
+  const json = serializeParsedExpr(body)
+  if (json === null) return null
+  const env = emitEvalEnvArg(body, [op.param], emit)
+  return `bf->flat_map_eval(${recv}, '${escapePerlSingleQuote(json)}', '${op.param}', ${env})`
+}
+
+/**
  * Shared Mojo emit for `.sort(cmp)` / `.toSorted(cmp)` (#1448 Tier B).
  * Used by both the filter-context emitter and the top-level emitter,
  * plus the loop-hoist path in `renderLoop` — same emit shape across

--- a/packages/adapter-mojolicious/src/adapter/expr/emitters.ts
+++ b/packages/adapter-mojolicious/src/adapter/expr/emitters.ts
@@ -40,6 +40,7 @@ import {
   renderPredicateEval,
   renderFlatMethod,
   renderFlatMapMethod,
+  renderFlatMapEval,
 } from './array-method.ts'
 
 /**
@@ -211,7 +212,10 @@ export class MojoFilterEmitter implements ParsedExprEmitter {
   }
 
   flatMapMethod(object: ParsedExpr, op: FlatMapOp, emit: (e: ParsedExpr) => string): string {
-    return renderFlatMapMethod(emit(object), op)
+    const recv = emit(object)
+    // Evaluator-first (#2018 P3); fall back to the structured helper for a
+    // projection the evaluator can't model.
+    return renderFlatMapEval(recv, op, emit) ?? renderFlatMapMethod(recv, op)
   }
 
   conditional(_test: ParsedExpr, _consequent: ParsedExpr, _alternate: ParsedExpr): string {
@@ -479,7 +483,10 @@ export class MojoTopLevelEmitter implements ParsedExprEmitter {
   }
 
   flatMapMethod(object: ParsedExpr, op: FlatMapOp, emit: (e: ParsedExpr) => string): string {
-    return renderFlatMapMethod(emit(object), op)
+    const recv = emit(object)
+    // Evaluator-first (#2018 P3); fall back to the structured helper for a
+    // projection the evaluator can't model.
+    return renderFlatMapEval(recv, op, emit) ?? renderFlatMapMethod(recv, op)
   }
 
   conditional(

--- a/packages/adapter-perl/lib/BarefootJS.pm
+++ b/packages/adapter-perl/lib/BarefootJS.pm
@@ -1129,6 +1129,10 @@ sub find_index_eval ($self, $recv, $pred_json, $param, $forward = 1, $base_env =
     return BarefootJS::Evaluator::find_index_json($recv, $pred_json, $param, $forward, $base_env);
 }
 
+sub flat_map_eval ($self, $recv, $proj_json, $param, $base_env = {}) {
+    return BarefootJS::Evaluator::flat_map_json($recv, $proj_json, $param, $base_env);
+}
+
 sub sort ($self, $recv, $opts = {}) {
     return [] unless ref($recv) eq 'ARRAY';
 

--- a/packages/adapter-perl/lib/BarefootJS/Evaluator.pm
+++ b/packages/adapter-perl/lib/BarefootJS/Evaluator.pm
@@ -521,6 +521,24 @@ sub find_index ($items, $pred, $param, $forward = 1, $base_env = undef) {
     return -1;
 }
 
+# flat_map — project each element through $proj (a pure ParsedExpr) and flatten
+# the results one level. A projection yielding an arrayref contributes its
+# elements; any other value contributes itself (JS `.flatMap` keeps a non-array
+# return as a single element). Generalizes bf->flat_map / flat_map_tuple to any
+# pure projection. Mirrors Go's FlatMapEval. $base_env is optional.
+sub flat_map ($items, $proj, $param, $base_env = undef) {
+    my @arr = ref $items eq 'ARRAY' ? @$items : ();
+    my %env = $base_env ? %$base_env : ();
+    my @out;
+    for my $item (@arr) {
+        $env{$param} = $item;
+        my $v = evaluate($proj, \%env);
+        if (ref $v eq 'ARRAY') { push @out, @$v }
+        else                   { push @out, $v }
+    }
+    return \@out;
+}
+
 # ---------------------------------------------------------------------------
 # JSON-string seams — the adapters emit `bf->filter_eval($recv, '<json>', …)`;
 # the predicate body arrives as a JSON string here, decoded then handed to the
@@ -550,6 +568,11 @@ sub find_json ($items, $pred_json, $param, $forward = 1, $base_env = undef) {
 sub find_index_json ($items, $pred_json, $param, $forward = 1, $base_env = undef) {
     require JSON::PP;
     return find_index($items, JSON::PP->new->decode($pred_json), $param, $forward, $base_env);
+}
+
+sub flat_map_json ($items, $proj_json, $param, $base_env = undef) {
+    require JSON::PP;
+    return flat_map($items, JSON::PP->new->decode($proj_json), $param, $base_env);
 }
 
 1;

--- a/packages/adapter-perl/t/evaluator.t
+++ b/packages/adapter-perl/t/evaluator.t
@@ -238,4 +238,28 @@ subtest 'filter / every / some / find / find_index over a predicate body' => sub
         'find_index with unmet captured threshold → -1');
 };
 
+# #2018 P3: flat_map projects each element through a projection body and
+# flattens one level — a field projection yielding an arrayref contributes its
+# elements; an array-literal (tuple) projection contributes its leaves. Mirrors
+# the Go TestFlatMapEval shapes.
+subtest 'flat_map projects + flattens one level' => sub {
+    my @rows = ({ tags => [ 'a', 'b' ] }, { tags => [ 'c' ] });
+    my $field = nmem(nid('i'), 'tags');
+    is_deeply(BarefootJS::Evaluator::flat_map(\@rows, $field, 'i'), [ 'a', 'b', 'c' ],
+        'field projection flattens the per-item arrays');
+
+    my @pts = ({ x => 1, y => 2 }, { x => 3, y => 4 });
+    my $tuple = {
+        kind     => 'array-literal',
+        elements => [ nmem(nid('p'), 'x'), nmem(nid('p'), 'y') ],
+    };
+    is_deeply(BarefootJS::Evaluator::flat_map(\@pts, $tuple, 'p'), [ 1, 2, 3, 4 ],
+        'array-literal projection flattens the leaf tuples');
+
+    # JSON seam.
+    my $fj = BarefootJS::Evaluator::flat_map_json(\@rows,
+        JSON::PP->new->encode($field), 'i');
+    is_deeply($fj, [ 'a', 'b', 'c' ], 'flat_map_json decodes + projects');
+};
+
 done_testing;

--- a/packages/adapter-xslate/src/adapter/expr/array-method.ts
+++ b/packages/adapter-xslate/src/adapter/expr/array-method.ts
@@ -255,6 +255,24 @@ export function renderPredicateEval(
 }
 
 /**
+ * Emit a `.flatMap(proj)` via the runtime evaluator (#2018, P3): the projection
+ * body (`FlatMapOp.raw`) serializes to JSON and `$bf.flat_map_eval` projects +
+ * flattens one level. Returns null when the projection is outside the evaluator
+ * surface (→ caller falls back to the structured `$bf.flat_map`).
+ */
+export function renderFlatMapEval(
+  recv: string,
+  op: FlatMapOp,
+  emit: (e: ParsedExpr) => string,
+): string | null {
+  const body = parseExpression(op.raw)
+  const json = serializeParsedExpr(body)
+  if (json === null) return null
+  const env = emitEvalEnvArg(body, [op.param], emit)
+  return `$bf.flat_map_eval(${recv}, '${escapePerlSingleQuote(json)}', '${op.param}', ${env})`
+}
+
+/**
  * Shared Kolon emit for `.sort(cmp)` / `.toSorted(cmp)`. Used by both the
  * filter-context emitter and the top-level emitter, plus the loop-array
  * wrap in `renderLoop`. The runtime `$bf.sort` accepts a hashref opts bag and

--- a/packages/adapter-xslate/src/adapter/expr/emitters.ts
+++ b/packages/adapter-xslate/src/adapter/expr/emitters.ts
@@ -38,6 +38,7 @@ import {
   renderPredicateEval,
   renderFlatMethod,
   renderFlatMapMethod,
+  renderFlatMapEval,
 } from './array-method.ts'
 
 /**
@@ -185,7 +186,10 @@ export class XslateFilterEmitter implements ParsedExprEmitter {
   }
 
   flatMapMethod(object: ParsedExpr, op: FlatMapOp, emit: (e: ParsedExpr) => string): string {
-    return renderFlatMapMethod(emit(object), op)
+    const recv = emit(object)
+    // Evaluator-first (#2018 P3); fall back to the structured helper for a
+    // projection the evaluator can't model.
+    return renderFlatMapEval(recv, op, emit) ?? renderFlatMapMethod(recv, op)
   }
 
   conditional(_test: ParsedExpr, _consequent: ParsedExpr, _alternate: ParsedExpr): string {
@@ -425,7 +429,10 @@ export class XslateTopLevelEmitter implements ParsedExprEmitter {
   }
 
   flatMapMethod(object: ParsedExpr, op: FlatMapOp, emit: (e: ParsedExpr) => string): string {
-    return renderFlatMapMethod(emit(object), op)
+    const recv = emit(object)
+    // Evaluator-first (#2018 P3); fall back to the structured helper for a
+    // projection the evaluator can't model.
+    return renderFlatMapEval(recv, op, emit) ?? renderFlatMapMethod(recv, op)
   }
 
   conditional(


### PR DESCRIPTION
## What

**Stacked on #2035** (P3 loop-hoist sort). Completes **P3**'s map/flatMap
de-fold: `.flatMap(proj)` on all three SSR adapters now lowers through the
runtime evaluator.

The projection body (`FlatMapOp.raw` — e.g. `i.tags`, `[i.a, i.b]`, `i`)
serializes to a `ParsedExpr` JSON blob and `bf_flat_map_eval` /
`bf->flat_map_eval` / `$bf.flat_map_eval` projects each element then flattens
one level — generalizing the structured self / field / tuple catalogue
(`bf_flat_map` / `bf_flat_map_tuple`) to **any pure projection**. A projection
the evaluator can't model falls back to the structured helper.

## Runtime

- **Go**: `FlatMapEval` (registered `bf_flat_map_eval`; pinned in `TestFuncMap`
  + `TestFlatMapEval` — field / array-literal / scalar-self shapes).
- **Perl**: `BarefootJS::Evaluator::flat_map` / `flat_map_json` + the
  `flat_map_eval` controller helper; pinned by an `evaluator.t` subtest.

## Invariant

**Rendered HTML is unchanged.** The flatMap template-text pins move to the
`*_eval` form. Go 523 pass / Mojo 464 / Xslate 356 / 0 fail locally; Go render
conformance (array-flatmap field/self/tuple) green. Perl render parity runs in
CI. `.flat(depth?)` is a non-callback array method and stays folded.

This completes the callback-de-fold half of P3; combined with #2035 it removes
every standalone consumer of the structured `SortComparator` / `FlatMapOp`
outside the parser, clearing the way for P5's folded-model collapse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj8TZvBgtHWcMK84GHjs1b)_