### PR TITLE
refactor(go-template): carry url-builder & regex-replace as IR; drop adapter re-parse (#2039)

### DIFF
--- a/.changeset/url-builder-ir.md
+++ b/.changeset/url-builder-ir.md
@@ -1,0 +1,11 @@
+---
+"@barefootjs/go-template": patch
+"@barefootjs/jsx": patch
+---
+
+Carry the URL-query-builder and regex-`replace` shapes as pure IR, retiring the last emit-time `ts.createSourceFile` / `parseLiteralExpression` re-parses in the go-template adapter (#2039).
+
+- The `URLSearchParams` helper idiom (`hrefFor` → `bf_query`) is recognised at analysis time and carried on `ConstantInfo.urlBuilder` as a pure `UrlBuilderInfo` (a builder shape, or a pass-through delegate). The go-template adapter consumes that IR instead of re-parsing the (block-bodied, otherwise-`unsupported`) arrow at emit time; the former adapter-side `extractUrlBuilder` / `matchUrlSet` are removed.
+- The regex form of `String.replace` is now carried structurally (an `array-method` `replace` whose first arg is a `regex` node) rather than collapsing to `unsupported`, so the derived-memo constructor lowering recovers the `/\/+$/` trailing-slash strip → `strings.TrimRight` off the IR, with no `ts.createSourceFile` on the `bf build` hot path. Template use of a regex `.replace` stays refused with the same deferred-form diagnostic via `isSupported`.
+
+No change to rendered HTML across the go-template, Mojolicious, and Xslate SSR adapters.

--- a/packages/adapter-go-template/src/adapter/emit-context.ts
+++ b/packages/adapter-go-template/src/adapter/emit-context.ts
@@ -14,8 +14,6 @@
  * genuinely needs it, so the seam documents the real cross-module coupling.
  */
 
-import type ts from 'typescript'
-
 import type { ParsedExpr } from '@barefootjs/jsx'
 
 import type { CompileState } from './lib/compile-state.ts'
@@ -23,9 +21,6 @@ import type { CompileState } from './lib/compile-state.ts'
 export interface GoEmitContext {
   /** Per-compile mutable state (signals, consts, type tables, errors, …). */
   readonly state: CompileState
-
-  /** Parse a JS expression source string into a TS expression node, or null. */
-  parseLiteralExpression(value: string): ts.Expression | null
 
   /**
    * Lower a JS expression to its Go-template form (the core recursive entry).
@@ -37,8 +32,14 @@ export interface GoEmitContext {
     preParsed?: ParsedExpr,
   ): string
 
-  /** Lower a JS condition to a Go-template bool + any hoisted preamble. */
-  convertConditionToGo(jsCondition: string): { condition: string; preamble: string }
+  /**
+   * Lower a JS condition to a Go-template bool + any hoisted preamble.
+   * `preParsed` reuses an already-built tree instead of re-parsing `jsCondition`.
+   */
+  convertConditionToGo(
+    jsCondition: string,
+    preParsed?: ParsedExpr,
+  ): { condition: string; preamble: string }
 
   /** Extract the prop name from a `props.X ?? …` initial value, or null. */
   extractPropNameFromInitialValue(initialValue: string): string | null

--- a/packages/adapter-go-template/src/adapter/expr/url-builder.ts
+++ b/packages/adapter-go-template/src/adapter/expr/url-builder.ts
@@ -104,6 +104,14 @@ const BOOL_COMPARISON_OPS: ReadonlySet<string> = new Set([
  * (`convertConditionToGo`); a bare value (`if (tag)`) is JS string-truthiness,
  * lowered to `ne <value> ""`. The arg must be a real bool — `bf_query` type-
  * asserts it, so Go-template truthiness (`{{if x}}`) is not enough.
+ *
+ * The `ne <value> ""` path models *string* truthiness, which is the query-
+ * builder domain: `URLSearchParams.set(k, v)` stringifies `v`, and these guards
+ * gate string values (`if (tag)`). A guard on a non-string value (a raw number,
+ * `null`, a bool-typed identifier) is outside the recognised idiom; the type-
+ * assert on `bf_query`'s include arg surfaces it as a build error rather than
+ * silently mis-including. (Pre-existing behaviour, carried verbatim from the
+ * former re-parse path; #2041 review.)
  */
 function lowerUrlGuard(
   ctx: GoEmitContext,

--- a/packages/adapter-go-template/src/adapter/expr/url-builder.ts
+++ b/packages/adapter-go-template/src/adapter/expr/url-builder.ts
@@ -1,175 +1,91 @@
 /**
  * Lowering of local `URLSearchParams` builder helpers to `bf_query`.
  *
- * Recognises the `(…) => { const u = new URLSearchParams(); if (G) u.set(K, V);
- * …; return <s> ? \`${base}?${u}\` : base }` idiom (and a pass-through delegate
- * to another such helper) and emits a `bf_query` template expression. Anything
- * else returns null so the caller falls back to the generic lowering.
+ * The builder shape is recognised at analysis time and carried as pure IR on the
+ * constant (`ConstantInfo.urlBuilder`, #2039) — the `URLSearchParams` idiom is a
+ * block-bodied arrow that the structured parser collapses to `unsupported`, so
+ * the recognition can't happen here. This module only *consumes* that IR: it
+ * substitutes the call args for the helper's params and emits a `bf_query`
+ * template expression, with no emit-time re-parse.
  */
 
-import ts from 'typescript'
+import {
+  type ParsedExpr,
+  type UrlBuilderInfo,
+  parseExpression,
+  stringifyParsedExpr,
+} from '@barefootjs/jsx'
 
 import type { GoEmitContext } from '../emit-context.ts'
 import { wrapIfMultiToken } from '../lib/go-emit.ts'
-
-type UrlBuilderShape = {
-  base: ts.Expression
-  sets: { guard: ts.Expression | null; key: string; value: ts.Expression }[]
-}
+import { substituteHelperParams } from './helper-inline.ts'
 
 /**
  * Lower a call to a local URL-builder helper to a `bf_query` template
- * expression. Handles two shapes:
- *   - the builder itself — substitute the call args for params and emit
- *     `bf_query <base> (<guard>) "key" <value> …`;
- *   - a pass-through delegate (`(k) => hrefFor(k, params().tag)`) — substitute
- *     and recurse on the delegated call.
- *
- * @returns the `bf_query` expression, or null for anything else (→ generic
- *   lowering / method-call fallback)
+ * expression, or null for anything else (→ generic lowering / method-call
+ * fallback). `jsExpr` is the call source; `preParsed` is its already-built tree
+ * (reused instead of re-parsing). Handles the builder itself and a pass-through
+ * delegate (`(k) => hrefFor(k, params().tag)`) by recursing on the delegated
+ * call with the args substituted.
  */
-export function lowerUrlBuilderHelperCall(ctx: GoEmitContext, jsExpr: string): string | null {
-  if (ctx.state.localHelperNames.size === 0) return null
+export function lowerUrlBuilderHelperCall(
+  ctx: GoEmitContext,
+  jsExpr: string,
+  preParsed?: ParsedExpr,
+): string | null {
+  // Cheap gate: a `name(` call whose head names a recognised URL-builder helper.
+  // Avoids parsing for the overwhelmingly common non-helper expression.
   const head = /^\s*([A-Za-z_$][\w$]*)\s*\(/.exec(jsExpr)
-  if (!head || !ctx.state.localHelperNames.has(head[1])) return null
-
-  const call = ctx.parseLiteralExpression(jsExpr)
-  if (!call || !ts.isCallExpression(call) || !ts.isIdentifier(call.expression)) return null
-  if (call.arguments.some(a => ts.isSpreadElement(a))) return null
-  const fnConst = ctx.state.localConstants.find(
-    c => c.name === (call.expression as ts.Identifier).text && !c.isModule && c.value,
-  )
-  if (!fnConst?.value) return null
-  const fn = ctx.parseLiteralExpression(fnConst.value)
-  if (!fn || !ts.isArrowFunction(fn) || fn.parameters.length !== call.arguments.length) return null
-
-  const subs = new Map<string, string>()
-  for (let i = 0; i < fn.parameters.length; i++) {
-    const p = fn.parameters[i]
-    if (!ts.isIdentifier(p.name)) return null
-    subs.set(p.name.text, `(${call.arguments[i].getText()})`)
-  }
-
-  // Shape 1: the helper is itself a URLSearchParams builder.
-  const shape = extractUrlBuilder(fn)
-  if (shape) return emitUrlBuilder(ctx, shape, subs)
-
-  // Shape 2: a pass-through delegate to another local URL-builder helper.
-  if (!ts.isBlock(fn.body)) {
-    let body: ts.Expression = fn.body
-    while (ts.isParenthesizedExpression(body)) body = body.expression
-    if (
-      ts.isCallExpression(body) &&
-      ts.isIdentifier(body.expression) &&
-      ctx.state.localHelperNames.has(body.expression.text)
-    ) {
-      return lowerUrlBuilderHelperCall(ctx, substituteHelperParams(body, subs))
-    }
-  }
-  return null
-}
-
-/**
- * Extract the `bf_query` shape from a `(…) => { const u = new URLSearchParams();
- * [if (G)] u.set(K, V); …; return <s> ? … : <base> }` helper, or null when the
- * block doesn't match that exact builder idiom.
- */
-function extractUrlBuilder(arrow: ts.ArrowFunction): UrlBuilderShape | null {
-  if (!ts.isBlock(arrow.body)) return null
-  let builderVar: string | null = null
-  let base: ts.Expression | null = null
-  const sets: { guard: ts.Expression | null; key: string; value: ts.Expression }[] = []
-
-  for (const s of arrow.body.statements) {
-    if (ts.isVariableStatement(s)) {
-      for (const d of s.declarationList.declarations) {
-        if (
-          ts.isIdentifier(d.name) &&
-          d.initializer &&
-          ts.isNewExpression(d.initializer) &&
-          ts.isIdentifier(d.initializer.expression) &&
-          d.initializer.expression.text === 'URLSearchParams' &&
-          (d.initializer.arguments?.length ?? 0) === 0
-        ) {
-          builderVar = d.name.text
-        }
-        // Other locals (`const s = u.toString()`) are inert — ignored.
-      }
-      continue
-    }
-    // `if (G) u.set(K, V)` (no else).
-    if (ts.isIfStatement(s) && !s.elseStatement && builderVar) {
-      const set = matchUrlSet(s.thenStatement, builderVar)
-      if (!set) return null
-      sets.push({ guard: s.expression, key: set.key, value: set.value })
-      continue
-    }
-    // Unguarded `u.set(K, V)`.
-    if (ts.isExpressionStatement(s) && builderVar) {
-      const set = matchUrlSet(s, builderVar)
-      if (set) {
-        sets.push({ guard: null, key: set.key, value: set.value })
-        continue
-      }
-      return null
-    }
-    // `return <s> ? `${base}?…` : <base>` — the builder's return must be the
-    // conditional that picks between the with-query and bare-base URL; its
-    // `whenFalse` (no-query) branch is the base. Any other return shape bails
-    // to the method-call fallback.
-    if (ts.isReturnStatement(s) && s.expression) {
-      let e: ts.Expression = s.expression
-      while (ts.isParenthesizedExpression(e)) e = e.expression
-      if (!ts.isConditionalExpression(e)) return null
-      base = e.whenFalse
-      continue
-    }
+  if (!head) return null
+  if (
+    !ctx.state.localConstants.some(
+      c => c.name === head[1] && !c.isModule && c.urlBuilder !== undefined,
+    )
+  ) {
     return null
   }
-  if (!builderVar || !base || sets.length === 0) return null
-  return { base, sets }
+  const call = preParsed?.kind === 'call' ? preParsed : parseExpression(jsExpr)
+  return lowerCall(ctx, call)
 }
 
-/**
- * Match `<builderVar>.set('literalKey', <value>)` — as a statement or an
- * if-then — returning the key text and value node, else null.
- */
-function matchUrlSet(
-  node: ts.Node,
-  builderVar: string,
-): { key: string; value: ts.Expression } | null {
-  const stmt = ts.isBlock(node) ? (node.statements.length === 1 ? node.statements[0] : null) : node
-  if (!stmt || !ts.isExpressionStatement(stmt)) return null
-  const call = stmt.expression
-  if (
-    ts.isCallExpression(call) &&
-    ts.isPropertyAccessExpression(call.expression) &&
-    ts.isIdentifier(call.expression.expression) &&
-    call.expression.expression.text === builderVar &&
-    call.expression.name.text === 'set' &&
-    call.arguments.length === 2 &&
-    ts.isStringLiteral(call.arguments[0])
-  ) {
-    return { key: call.arguments[0].text, value: call.arguments[1] }
+/** Lower an already-parsed `helper(args)` call tree, recursing through delegates. */
+function lowerCall(ctx: GoEmitContext, call: ParsedExpr): string | null {
+  if (call.kind !== 'call' || call.callee.kind !== 'identifier') return null
+  if (call.args.some(a => a.kind === 'unsupported')) return null
+  const calleeName = call.callee.name
+  const fnConst = ctx.state.localConstants.find(
+    c => c.name === calleeName && !c.isModule && c.urlBuilder !== undefined,
+  )
+  const info: UrlBuilderInfo | undefined = fnConst?.urlBuilder
+  if (!info || info.params.length !== call.args.length) return null
+
+  const subs = new Map<string, ParsedExpr>()
+  for (let i = 0; i < info.params.length; i++) subs.set(info.params[i], call.args[i])
+
+  if (info.kind === 'delegate') {
+    const args = info.args.map(a => substituteHelperParams(a, subs))
+    return lowerCall(ctx, { kind: 'call', callee: { kind: 'identifier', name: info.target }, args })
   }
-  return null
+  return emitUrlBuilder(ctx, info, subs)
 }
 
 /**
- * Emit `bf_query <base> (<guard>) "key" <value> …` from an extracted builder
- * shape, lowering each part (with the call args substituted for params) via
- * the normal expression / condition lowering. Unguarded sets use `true`.
+ * Emit `bf_query <base> (<guard>) "key" <value> …` from a builder shape, lowering
+ * each part (with the call args substituted for params) via the normal expression
+ * / condition lowering. Unguarded sets use `true`.
  */
 function emitUrlBuilder(
   ctx: GoEmitContext,
-  shape: UrlBuilderShape,
-  subs: ReadonlyMap<string, string>,
+  info: Extract<UrlBuilderInfo, { kind: 'builder' }>,
+  subs: ReadonlyMap<string, ParsedExpr>,
 ): string | null {
-  const lowerExpr = (n: ts.Expression): string =>
-    ctx.convertExpressionToGo(substituteHelperParams(n, subs))
-  const baseGo = wrapIfMultiToken(lowerExpr(shape.base))
+  const lowerExpr = (n: ParsedExpr): string => {
+    const sub = substituteHelperParams(n, subs)
+    return ctx.convertExpressionToGo(stringifyParsedExpr(sub), undefined, sub)
+  }
+  const baseGo = wrapIfMultiToken(lowerExpr(info.base))
   const parts: string[] = [baseGo]
-  for (const set of shape.sets) {
+  for (const set of info.sets) {
     const guardGo = set.guard ? lowerUrlGuard(ctx, set.guard, subs) : 'true'
     parts.push(`(${guardGo})`)
     parts.push(JSON.stringify(set.key))
@@ -178,92 +94,35 @@ function emitUrlBuilder(
   return `bf_query ${parts.join(' ')}`
 }
 
+const BOOL_COMPARISON_OPS: ReadonlySet<string> = new Set([
+  '==', '===', '!=', '!==', '<', '>', '<=', '>=',
+])
+
 /**
  * Lower a `u.set()` guard to a Go *bool* for `bf_query`'s `include` argument.
- * A comparison / logical / negation / bool-literal already yields a bool
+ * A comparison / negation / bool-literal already yields a bool
  * (`convertConditionToGo`); a bare value (`if (tag)`) is JS string-truthiness,
  * lowered to `ne <value> ""`. The arg must be a real bool — `bf_query` type-
  * asserts it, so Go-template truthiness (`{{if x}}`) is not enough.
  */
 function lowerUrlGuard(
   ctx: GoEmitContext,
-  guard: ts.Expression,
-  subs: ReadonlyMap<string, string>,
+  guard: ParsedExpr,
+  subs: ReadonlyMap<string, ParsedExpr>,
 ): string {
-  let g = guard
-  while (ts.isParenthesizedExpression(g)) g = g.expression
+  const g = substituteHelperParams(guard, subs)
   // Comparisons, `!x`, and bool literals lower to a Go bool via the condition
   // lowering. `&&` / `||` do NOT qualify: Go's `and`/`or` return one of their
   // operands (a string for a truthiness guard like `tag && other`), not a
   // bool — so they take the truthiness-wrap path below, yielding
   // `ne (and …) ""`, an actual bool.
   const isBoolShape =
-    (ts.isBinaryExpression(g) &&
-      [
-        ts.SyntaxKind.EqualsEqualsToken,
-        ts.SyntaxKind.EqualsEqualsEqualsToken,
-        ts.SyntaxKind.ExclamationEqualsToken,
-        ts.SyntaxKind.ExclamationEqualsEqualsToken,
-        ts.SyntaxKind.LessThanToken,
-        ts.SyntaxKind.GreaterThanToken,
-        ts.SyntaxKind.LessThanEqualsToken,
-        ts.SyntaxKind.GreaterThanEqualsToken,
-      ].includes(g.operatorToken.kind)) ||
-    (ts.isPrefixUnaryExpression(g) && g.operator === ts.SyntaxKind.ExclamationToken) ||
-    g.kind === ts.SyntaxKind.TrueKeyword ||
-    g.kind === ts.SyntaxKind.FalseKeyword
+    (g.kind === 'binary' && BOOL_COMPARISON_OPS.has(g.op)) ||
+    (g.kind === 'unary' && g.op === '!') ||
+    (g.kind === 'literal' && g.literalType === 'boolean')
   if (isBoolShape) {
-    return ctx.convertConditionToGo(substituteHelperParams(guard, subs)).condition
+    return ctx.convertConditionToGo(stringifyParsedExpr(g), g).condition
   }
-  const valueGo = wrapIfMultiToken(
-    ctx.convertExpressionToGo(substituteHelperParams(guard, subs)),
-  )
+  const valueGo = wrapIfMultiToken(ctx.convertExpressionToGo(stringifyParsedExpr(g), undefined, g))
   return `ne ${valueGo} ""`
-}
-
-/**
- * Re-emit `body` to source with each identifier named in `subs` replaced by the
- * substitution's source text. Span splicing over `body`'s own source (single
- * source file — args are passed as text, not cross-file AST nodes, which would
- * corrupt a printer keyed to `body`'s source). The walk skips non-value
- * identifier positions — the property NAME in `a.b` and a plain object-literal
- * key in `{ k: … }` — so a param sharing a name with a member or key is left
- * untouched. The spliced string is re-parsed by the caller.
- */
-function substituteHelperParams(
-  body: ts.Expression,
-  subs: ReadonlyMap<string, string>,
-): string {
-  const sf = body.getSourceFile()
-  const base = body.getStart(sf)
-  // Collect replacement spans (relative to the body's start), right-to-left.
-  const repls: { start: number; end: number; text: string }[] = []
-  const visit = (node: ts.Node): void => {
-    if (ts.isPropertyAccessExpression(node)) {
-      visit(node.expression) // skip `.name`
-      return
-    }
-    if (ts.isPropertyAssignment(node)) {
-      // A plain identifier/string key isn't a value position; only a computed
-      // key (`[expr]`) is. Visit the initializer (and computed key) only.
-      if (ts.isComputedPropertyName(node.name)) visit(node.name)
-      visit(node.initializer)
-      return
-    }
-    if (ts.isIdentifier(node)) {
-      const sub = subs.get(node.text)
-      if (sub !== undefined) {
-        repls.push({ start: node.getStart(sf) - base, end: node.getEnd() - base, text: sub })
-        return
-      }
-    }
-    ts.forEachChild(node, visit)
-  }
-  visit(body)
-
-  let text = body.getText(sf)
-  for (const r of repls.sort((a, b) => b.start - a.start)) {
-    text = text.slice(0, r.start) + r.text + text.slice(r.end)
-  }
-  return text
 }

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -115,7 +115,7 @@ import {
 } from "./value/value-lowering.ts"
 import { typeInfoToGo } from "./type/type-codegen.ts"
 import { isBooleanMemo, isStringTernaryMemo } from "./memo/memo-type.ts"
-import { lowerCtorExpr, matchTrailingSlashReplace } from "./memo/ctor-lowering.ts"
+import { lowerCtorExpr } from "./memo/ctor-lowering.ts"
 import { resolveBlockBodyMemoModuleConst } from "./memo/memo-value.ts"
 import { computeMemoInitialValue, computeMemoInitialValueOrNull } from "./memo/memo-compute.ts"
 import { collectSpreadSlots, buildSpreadInitializer } from "./spread/spread-codegen.ts"
@@ -197,16 +197,16 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
   /**
    * The `GoEmitContext` handed to extracted emit modules — the seam that keeps
-   * `state` / `convert*` / `parseLiteralExpression` off the public adapter
-   * type. `state` is captured by reference (reset in place, never reassigned),
-   * so this single `emitCtx` stays valid across `generate()` calls.
+   * `state` / `convert*` off the public adapter type. `state` is captured by
+   * reference (reset in place, never reassigned), so this single `emitCtx` stays
+   * valid across `generate()` calls.
    */
   private readonly emitCtx: GoEmitContext = {
     state: this.state,
-    parseLiteralExpression: (value) => this.parseLiteralExpression(value),
     convertExpressionToGo: (jsExpr, out, preParsed) =>
       this.convertExpressionToGo(jsExpr, out, preParsed),
-    convertConditionToGo: (jsCondition) => this.convertConditionToGo(jsCondition),
+    convertConditionToGo: (jsCondition, preParsed) =>
+      this.convertConditionToGo(jsCondition, preParsed),
     extractPropNameFromInitialValue: (initialValue) => this.extractPropNameFromInitialValue(initialValue),
     extractPropFallback: (initialValue) => this.extractPropFallback(initialValue),
     resolveModuleStringConst: (name) => this.resolveModuleStringConst(name),
@@ -1982,31 +1982,6 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   /**
-   * Parse a JS expression string into its TS AST node (parentheses unwrapped),
-   * or `null` when it isn't a single expression. Shared by the literal baker,
-   * the struct-shape synthesiser, and the constructor-expression interpreters
-   * (`lowerCtorExpr` and friends).
-   *
-   * Do NOT add new callers: read a carried `ParsedExpr` field instead. This is
-   * the last `ts.createSourceFile` in the adapter and is being removed
-   * incrementally.
-   */
-  private parseLiteralExpression(value: string): ts.Expression | null {
-    const sf = ts.createSourceFile(
-      '__lit.ts', `(${value})`, ts.ScriptTarget.Latest, /* setParentNodes */ true,
-    )
-    // Require exactly one expression statement. A value that error-recovers
-    // into multiple statements (e.g. `1; 2`) isn't a single literal — bail
-    // rather than silently baking only the first.
-    if (sf.statements.length !== 1) return null
-    const stmt = sf.statements[0]
-    if (!ts.isExpressionStatement(stmt)) return null
-    let expr: ts.Expression = stmt.expression
-    while (ts.isParenthesizedExpression(expr)) expr = expr.expression
-    return expr
-  }
-
-  /**
    * Convert a template literal's parsed parts into a `string`-typed Go
    * expression in `NewXxxProps` scope (destructured prop refs → `in.FieldName`),
    * or null so the caller falls back to `resolveDynamicPropValue`. A `string`
@@ -2584,13 +2559,9 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       return STRING_METHODS.has(node.callee.property)
     }
     if (node.kind === 'array-method') {
+      // `.replace` (including the structurally-carried regex trailing-slash form,
+      // #2039) is in STRING_METHODS, so it's covered here — no special case.
       return STRING_METHODS.has(node.method)
-    }
-    // The deferred regex form of `String.replace` (`<s>.replace(/\/+$/, '')`)
-    // resolves to `unsupported`, but `lowerCtorExpr` recovers it as a
-    // `strings.TrimRight` (string), so treat the recognized pattern as a string.
-    if (node.kind === 'unsupported' && matchTrailingSlashReplace(node.raw) !== null) {
-      return true
     }
     if (node.kind === 'conditional') {
       return (
@@ -4044,7 +4015,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // delegating to it) lowers to a `bf_query` action — there is no Go method
     // backing a `.SortHref "date"` call. Tried before the generic inliner
     // because these helpers are block-bodied / delegate, which the inliner skips.
-    const urlBuilt = lowerUrlBuilderHelperCall(this.emitCtx, trimmed)
+    const urlBuilt = lowerUrlBuilderHelperCall(this.emitCtx, trimmed, preParsed)
     if (urlBuilt !== null) return urlBuilt
 
     // Inline a call to a local, expression-bodied helper arrow

--- a/packages/adapter-go-template/src/adapter/memo/ctor-lowering.ts
+++ b/packages/adapter-go-template/src/adapter/memo/ctor-lowering.ts
@@ -10,37 +10,29 @@
  * caller can fall back to nil safely.
  */
 
-import ts from 'typescript'
-
-import { type ParsedExpr, tsNodeToParsedExpr } from '@barefootjs/jsx'
+import { type ParsedExpr } from '@barefootjs/jsx'
 
 import type { GoEmitContext } from '../emit-context.ts'
 import type { CtorLowerEnv } from '../lib/types.ts'
 import { capitalizeFieldName } from '../lib/go-naming.ts'
 
 /**
- * Recover the receiver of an `<recv>.replace(/\/+$/, '')` trailing-slash strip
- * from an `unsupported` node's raw source. The collapsed `parseExpression`
- * defers the regex form of `String.replace` to `unsupported`, so the only way to
- * reach the structured receiver is to re-parse — done with a TS AST walk (the
- * repo idiom; never string-matching), validating the exact regex pattern and the
- * empty-string replacement before returning the receiver's `ParsedExpr`. Any
- * other shape returns null.
+ * Whether `node` is the trailing-slash strip `<recv>.replace(/\/+$/, '')`. The
+ * structured parser carries the deferred regex form of `String.replace` as an
+ * `array-method` whose first arg is a `regex` node (#2039), so the one pattern
+ * the ctor lowering recognises is matched off the IR — no emit-time re-parse.
+ * Validates the exact regex pattern and the empty-string replacement.
  */
-export function matchTrailingSlashReplace(raw: string): ParsedExpr | null {
-  const sf = ts.createSourceFile('expr.ts', `(${raw})`, ts.ScriptTarget.Latest, true)
-  const stmt = sf.statements[0]
-  if (!stmt || !ts.isExpressionStatement(stmt)) return null
-  let expr: ts.Expression = stmt.expression
-  while (ts.isParenthesizedExpression(expr)) expr = expr.expression
-  if (!ts.isCallExpression(expr)) return null
-  const callee = expr.expression
-  if (!ts.isPropertyAccessExpression(callee) || callee.name.text !== 'replace') return null
-  if (expr.arguments.length !== 2) return null
-  const [pattern, replacement] = expr.arguments
-  if (!ts.isRegularExpressionLiteral(pattern) || pattern.text !== '/\\/+$/') return null
-  if (!ts.isStringLiteralLike(replacement) || replacement.text !== '') return null
-  return tsNodeToParsedExpr(callee.expression)
+function isTrailingSlashReplace(node: ParsedExpr): boolean {
+  if (node.kind !== 'array-method' || node.method !== 'replace') return false
+  const [pattern, replacement] = node.args
+  return (
+    pattern?.kind === 'regex' &&
+    pattern.raw === '/\\/+$/' &&
+    replacement?.kind === 'literal' &&
+    replacement.literalType === 'string' &&
+    replacement.value === ''
+  )
 }
 
 /**
@@ -129,19 +121,17 @@ export function lowerCtorExpr(
   }
 
   // `<s>.replace(/\/+$/, '')` — strip trailing slashes → strings.TrimRight. The
-  // collapsed `parseExpression` defers the regex form of `String.replace` to an
-  // `unsupported` node (it doesn't model regex replacement), so recover this one
-  // recognized pattern from the `unsupported` raw. Only this exact trailing-slash
-  // regex is supported (a general regex replace would need Go's regexp).
-  if (node.kind === 'unsupported') {
-    const trim = matchTrailingSlashReplace(node.raw)
-    if (trim !== null) {
-      const recvGo = lowerCtorExpr(ctx, trim, env)
-      if (recvGo === null) return null
-      ctx.state.needsStringsImport = true
-      return `strings.TrimRight(${recvGo}, "/")`
-    }
-    return null
+  // parser defers the regex form of `String.replace` but carries its shape
+  // structurally (an `array-method` replace with a `regex` first arg, #2039), so
+  // the one recognized pattern is matched off the IR — no re-parse. Only this
+  // exact trailing-slash regex is supported (a general regex replace would need
+  // Go's regexp).
+  if (node.kind === 'array-method' && node.method === 'replace') {
+    if (!isTrailingSlashReplace(node)) return null
+    const recvGo = lowerCtorExpr(ctx, node.object, env)
+    if (recvGo === null) return null
+    ctx.state.needsStringsImport = true
+    return `strings.TrimRight(${recvGo}, "/")`
   }
 
   // `helper(<args>)` where helper is a module arrow const → inline its body.

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -542,11 +542,21 @@ describe('expression-parser', () => {
       }
     })
 
-    test('.replace(/re/, repl) refuses the regex form with the deferred reason (#1448 Tier B)', () => {
+    test('.replace(/re/, repl) carries the regex form structurally; isSupported refuses it with the deferred reason (#1448 Tier B, #2039)', () => {
+      // The regex form is deferred, but its shape is carried as an
+      // `array-method` whose first arg is a `regex` node — so the Go ctor
+      // lowering can recover the trailing-slash pattern without re-parsing
+      // (#2039). Template use is still refused, via `isSupported`.
       const result = parseExpression(`name().replace(/a/g, "b")`)
-      expect(result.kind).toBe('unsupported')
-      if (result.kind === 'unsupported') {
-        expect(result.reason).toContain('regex form is deferred')
+      expect(result.kind).toBe('array-method')
+      if (result.kind === 'array-method') {
+        expect(result.method).toBe('replace')
+        expect(result.args[0].kind).toBe('regex')
+      }
+      const support = isSupported(result)
+      expect(support.supported).toBe(false)
+      if (!support.supported) {
+        expect(support.reason).toContain('regex form is deferred')
       }
     })
 

--- a/packages/jsx/src/__tests__/url-builder-shape.test.ts
+++ b/packages/jsx/src/__tests__/url-builder-shape.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Pins the analysis-time recognition of the `URLSearchParams` URL-query helper
+ * idiom into `ConstantInfo.urlBuilder` (#2039). Carrying the shape as pure IR is
+ * what lets the go-template adapter emit `bf_query` without re-parsing the
+ * (block-bodied, `unsupported`-to-the-parser) arrow at emit time.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+import type { ConstantInfo } from '../types'
+
+const adapter = new TestAdapter()
+
+function localConstants(source: string): ConstantInfo[] {
+  const result = compileJSX(source, 'demo.tsx', { adapter, outputIR: true })
+  expect(result.errors.filter(e => e.severity === 'error')).toEqual([])
+  const ir = result.files.find(f => f.type === 'ir')!
+  return JSON.parse(ir.content).metadata.localConstants as ConstantInfo[]
+}
+
+const SRC = `
+'use client'
+import { createMemo, searchParams } from '@barefootjs/client'
+export function P(props: { base: string }) {
+  const params = createMemo(() => {
+    const sp = searchParams()
+    return { sort: sp.get('sort') ?? '', tag: sp.get('tag') ?? '' }
+  })
+  const root = (props.base ?? '') || '/'
+  const hrefFor = (sort: string, tag: string) => {
+    const u = new URLSearchParams()
+    if (sort !== 'date') u.set('sort', sort)
+    if (tag) u.set('tag', tag)
+    const s = u.toString()
+    return s ? \`\${root}?\${s}\` : root
+  }
+  const sortHref = (k) => hrefFor(k, params().tag)
+  return <a href={sortHref('title')}>s</a>
+}
+`
+
+describe('URL-builder shape recognition → ConstantInfo.urlBuilder (#2039)', () => {
+  test('the URLSearchParams builder helper carries a `builder` shape', () => {
+    const consts = localConstants(SRC)
+    const hrefFor = consts.find(c => c.name === 'hrefFor')
+    expect(hrefFor?.urlBuilder?.kind).toBe('builder')
+    if (hrefFor?.urlBuilder?.kind === 'builder') {
+      expect(hrefFor.urlBuilder.params).toEqual(['sort', 'tag'])
+      // One guarded set per `if (g) u.set(...)`, in order.
+      expect(hrefFor.urlBuilder.sets.map(s => s.key)).toEqual(['sort', 'tag'])
+      // `if (sort !== 'date')` → a binary guard; `if (tag)` → a bare identifier.
+      expect(hrefFor.urlBuilder.sets[0].guard?.kind).toBe('binary')
+      expect(hrefFor.urlBuilder.sets[1].guard?.kind).toBe('identifier')
+      // `return s ? ... : root` — the no-query branch (`root`) is the base.
+      expect(hrefFor.urlBuilder.base.kind).toBe('identifier')
+    }
+  })
+
+  test('a pass-through helper carries a `delegate` shape pointing at the builder', () => {
+    const consts = localConstants(SRC)
+    const sortHref = consts.find(c => c.name === 'sortHref')
+    expect(sortHref?.urlBuilder?.kind).toBe('delegate')
+    if (sortHref?.urlBuilder?.kind === 'delegate') {
+      expect(sortHref.urlBuilder.params).toEqual(['k'])
+      expect(sortHref.urlBuilder.target).toBe('hrefFor')
+      // `hrefFor(k, params().tag)` — first arg is the param, second the memo read.
+      expect(sortHref.urlBuilder.args.length).toBe(2)
+      expect(sortHref.urlBuilder.args[0]).toEqual({ kind: 'identifier', name: 'k' })
+    }
+  })
+
+  test('an ordinary const is not mistaken for a URL builder', () => {
+    const consts = localConstants(SRC)
+    expect(consts.find(c => c.name === 'root')?.urlBuilder).toBeUndefined()
+    expect(consts.find(c => c.name === 'params')?.urlBuilder).toBeUndefined()
+  })
+})

--- a/packages/jsx/src/__tests__/url-builder-shape.test.ts
+++ b/packages/jsx/src/__tests__/url-builder-shape.test.ts
@@ -75,4 +75,44 @@ describe('URL-builder shape recognition → ConstantInfo.urlBuilder (#2039)', ()
     expect(consts.find(c => c.name === 'root')?.urlBuilder).toBeUndefined()
     expect(consts.find(c => c.name === 'params')?.urlBuilder).toBeUndefined()
   })
+
+  // #2041 review: a helper that builds a `URLSearchParams` and returns a
+  // conditional whose condition is NOT the query-string truthiness is not a
+  // query builder — it must be refused (fall back to the method-call lowering),
+  // not mis-recognised and silently mis-lowered to `bf_query`.
+  test('a conditional return over an unrelated predicate is refused', () => {
+    const src = `
+'use client'
+export function P(props: { flag: boolean; base: string }) {
+  const weird = (k: string) => {
+    const u = new URLSearchParams()
+    u.set('k', k)
+    return props.flag ? 'yes' : props.base
+  }
+  return <a href={weird('x')}>x</a>
+}
+`
+    const consts = localConstants(src)
+    expect(consts.find(c => c.name === 'weird')?.urlBuilder).toBeUndefined()
+  })
+
+  // The direct `return u.toString() ? ... : base` form (no `const s`) is the
+  // other accepted query-truthiness shape — keep it recognised.
+  test('the inline `u.toString()` return condition is accepted', () => {
+    const src = `
+'use client'
+import { searchParams } from '@barefootjs/client'
+export function P() {
+  const root = '/'
+  const hrefFor = (tag: string) => {
+    const u = new URLSearchParams()
+    if (tag) u.set('tag', tag)
+    return u.toString() ? \`\${root}?\${u}\` : root
+  }
+  return <a href={hrefFor('go')}>x</a>
+}
+`
+    const consts = localConstants(src)
+    expect(consts.find(c => c.name === 'hrefFor')?.urlBuilder?.kind).toBe('builder')
+  })
 })

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -7,8 +7,9 @@
  */
 
 import ts from 'typescript'
-import type { ImportSpecifier, TypeInfo, ParamInfo, ReactiveFactoryInfo } from './types.ts'
+import type { ImportSpecifier, TypeInfo, ParamInfo, ReactiveFactoryInfo, UrlBuilderInfo } from './types.ts'
 import { parseExpression, parseBlockBodyTolerant } from './expression-parser.ts'
+import { recognizeUrlBuilder } from './url-builder-shape.ts'
 import { rewriteBarePropRefs } from './prop-rewrite.ts'
 import { incrementCounter } from './instrumentation.ts'
 import {
@@ -2656,6 +2657,7 @@ function collectConstant(
   // Detect JSX initializers and store AST nodes for IR-level inlining (#547)
   let isJsx = false
   let isJsxFunction = false
+  let urlBuilder: UrlBuilderInfo | undefined
   if (node.initializer) {
     let init: ts.Expression = node.initializer
     while (ts.isParenthesizedExpression(init)) init = init.expression
@@ -2723,6 +2725,19 @@ function collectConstant(
           })
         }
       }
+    }
+
+    // Recognise a local URL-query helper (the `URLSearchParams` builder idiom,
+    // or a pass-through delegate to one) and carry its shape as pure IR (#2039)
+    // — the block-bodied builder arrow is `unsupported` to the structured parser,
+    // so this lets the go-template adapter emit `bf_query` from IR instead of
+    // re-parsing the arrow source at emit time. A delegate resolves its target
+    // against builders recognised earlier in declaration order.
+    if (ts.isArrowFunction(init) && !isJsxFunction) {
+      urlBuilder =
+        recognizeUrlBuilder(init, n =>
+          ctx.localConstants.some(c => c.name === n && c.urlBuilder !== undefined),
+        ) ?? undefined
     }
   }
 
@@ -2840,6 +2855,7 @@ function collectConstant(
     name,
     value,
     parsed,
+    urlBuilder,
     typedValue: typedValue !== value ? typedValue : undefined,
     valueBranches,
     declarationKind,

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -901,9 +901,12 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
       // replacing the FIRST occurrence (JS semantics for a string
       // pattern). Go uses `bf_replace` (`strings.Replace` with n=1);
       // Mojo uses `bf->replace` (index/substr splice, no regex). A
-      // regex-literal pattern parses as `unsupported` (convertNode has
-      // no regex arm), so it's refused explicitly here rather than
-      // emitting a broken `.Replace` — the Perl `s///` vs Go
+      // regex-literal pattern is the deferred form — its `regex` first
+      // arg is carried STRUCTURALLY (not collapsed to `unsupported`) so
+      // the Go ctor lowering can recover the one trailing-slash pattern
+      // it supports without re-parsing (#2039). Template use stays
+      // refused: `isSupported` maps a regex-pattern `.replace` to the
+      // deferred-form BF101 reason — the Perl `s///` vs Go
       // `regexp.ReplaceAllString` flavour gap is the open design
       // question in #1448. `replaceAll` stays refused entirely.
       //
@@ -921,19 +924,17 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
           }
         }
         // A regex-literal pattern is the deferred form (the Perl `s///`
-        // vs Go `regexp.ReplaceAllString` flavour gap, #1448) — detect it
-        // on the TS node so the message is accurate. Any OTHER unsupported
-        // pattern/replacement (an object literal, an unsupported call, …)
-        // surfaces ITS OWN reason rather than being mislabelled as the
-        // regex form.
+        // vs Go `regexp.ReplaceAllString` flavour gap, #1448). Its shape
+        // is carried structurally — `args[0]` is a `regex` node (convertNode
+        // line ~1127) — so a consumer that recognises one fixed pattern (the
+        // Go ctor's `/\/+$/` trailing-slash strip → `strings.TrimRight`) reads
+        // it from the tree instead of re-parsing the raw (#2039). Returned
+        // before the object-literal `badArg` check below so the regex form
+        // keeps its dedicated diagnostic precedence; `isSupported` then refuses
+        // any template use with the deferred-form reason.
         const patternNode = node.arguments[0]
         if (patternNode && ts.isRegularExpressionLiteral(patternNode)) {
-          return {
-            kind: 'unsupported',
-            raw,
-            reason:
-              'String.prototype.replace supports only a string pattern + string replacement (the regex form is deferred); use a string pattern or wrap the expression in /* @client */',
-          }
+          return { kind: 'array-method', method: 'replace', object: callee.object, args }
         }
         // Treat an object-literal argument like `unsupported` — a `.replace`
         // with an object pattern/replacement isn't lowerable, same as before
@@ -2155,6 +2156,17 @@ function checkSupport(expr: ParsedExpr): SupportResult {
     }
 
     case 'array-method': {
+      // A regex-pattern `.replace` is carried structurally (a `regex` first
+      // arg) but is the deferred form (#1448) — no template language lowers it.
+      // Refuse with the dedicated reason rather than the generic standalone-regex
+      // message, preserving the diagnostic the parser used to emit directly.
+      if (expr.method === 'replace' && expr.args[0]?.kind === 'regex') {
+        return {
+          supported: false,
+          reason:
+            'String.prototype.replace supports only a string pattern + string replacement (the regex form is deferred); use a string pattern or wrap the expression in /* @client */',
+        }
+      }
       const objSupport = checkSupport(expr.object)
       if (!objSupport.supported) return objSupport
       for (const arg of expr.args) {

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -46,6 +46,8 @@ export type {
   TypeDefinition,
   SourceLocation,
   CompilerError,
+  UrlBuilderInfo,
+  UrlBuilderSet,
 } from './types.ts'
 
 // Analyzer

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -1413,6 +1413,15 @@ export interface ConstantInfo {
    * couldn't structure it (best-effort — consumers fall back to the string).
    */
   parsed?: ParsedExpr
+  /**
+   * A recognised local URL-query helper, lowered to a pure tree at analysis
+   * time (#2039). The `URLSearchParams` builder idiom is a multi-statement
+   * block-bodied arrow, which `parsed` collapses to `unsupported`; this carries
+   * its shape structurally so the go-template adapter emits `bf_query` from IR
+   * instead of re-parsing the arrow source at emit time. Absent for any const
+   * that isn't such a helper. See {@link UrlBuilderInfo}.
+   */
+  urlBuilder?: UrlBuilderInfo
   /** Value with TypeScript type annotations preserved, for .tsx output */
   typedValue?: string
   valueBranches?: string[]
@@ -1442,6 +1451,36 @@ export interface ConstantInfo {
    */
   origin?: OriginInfo
 }
+
+/**
+ * One `u.set(key, value)` call in a recognised URL-query builder (#2039),
+ * carried as pure IR. `guard` is the `if (…)` condition wrapping the set (the
+ * `bf_query` `include` arg), or null for an unguarded set. `key` is the literal
+ * search-param name; `value` is the value expression (both may reference the
+ * builder arrow's params, substituted at the call site).
+ */
+export interface UrlBuilderSet {
+  guard: ParsedExpr | null
+  key: string
+  value: ParsedExpr
+}
+
+/**
+ * A recognised local URL-query helper (#2039), lowered to a pure tree at
+ * analysis time so adapters consume it as IR instead of re-parsing the arrow
+ * source at emit time. Two shapes:
+ *   - `builder` — the `URLSearchParams` idiom itself: `(params) => { const u =
+ *     new URLSearchParams(); [if (g)] u.set(k, v); …; return s ? `${base}?${s}`
+ *     : base }`. `base` is the no-query URL; `sets` are the guarded/unguarded
+ *     `u.set(…)` calls.
+ *   - `delegate` — a pass-through `(params) => target(args…)` to another such
+ *     helper. `target` is the delegated helper name; `args` are its call args
+ *     (in terms of this arrow's params, substituted when lowered).
+ * `params` is the arrow's parameter names, in order.
+ */
+export type UrlBuilderInfo =
+  | { kind: 'builder'; params: string[]; base: ParsedExpr; sets: UrlBuilderSet[] }
+  | { kind: 'delegate'; params: string[]; target: string; args: ParsedExpr[] }
 
 export interface TypeDefinition {
   kind: 'interface' | 'type'

--- a/packages/jsx/src/url-builder-shape.ts
+++ b/packages/jsx/src/url-builder-shape.ts
@@ -77,6 +77,10 @@ function extractUrlBuilder(
 ): { base: ParsedExpr; sets: UrlBuilderSet[] } | null {
   if (!ts.isBlock(arrow.body)) return null
   let builderVar: string | null = null
+  // Locals bound to `<builderVar>.toString()` — the query-string truthiness the
+  // builder's `return <s> ? … : <base>` switches on. Tracked (not ignored) so
+  // the return shape can be validated, not assumed.
+  const toStringVars = new Set<string>()
   let base: ParsedExpr | null = null
   const sets: UrlBuilderSet[] = []
 
@@ -92,8 +96,16 @@ function extractUrlBuilder(
           (d.initializer.arguments?.length ?? 0) === 0
         ) {
           builderVar = d.name.text
+        } else if (
+          ts.isIdentifier(d.name) &&
+          d.initializer &&
+          builderVar &&
+          isBuilderToString(d.initializer, builderVar)
+        ) {
+          // `const s = u.toString()` — the query-string value.
+          toStringVars.add(d.name.text)
         }
-        // Other locals (`const s = u.toString()`) are inert — ignored.
+        // Any other local is inert — ignored.
       }
       continue
     }
@@ -113,14 +125,18 @@ function extractUrlBuilder(
       }
       return null
     }
-    // `return <s> ? `${base}?…` : <base>` — the builder's return must be the
-    // conditional that picks between the with-query and bare-base URL; its
-    // `whenFalse` (no-query) branch is the base. Any other return shape bails
-    // to the adapter's method-call fallback.
-    if (ts.isReturnStatement(s) && s.expression) {
+    // `return <q> ? `${base}?…` : <base>` — the builder's return must be the
+    // conditional that switches on the *query-string truthiness* (`u.toString()`,
+    // or a local bound to it) and falls back to the bare base. Validating the
+    // condition is what makes "`whenFalse` is the base" sound — a conditional
+    // return over some unrelated predicate is NOT a query builder and must bail
+    // to the adapter's method-call fallback rather than be mis-lowered (#2041
+    // review). Other return shapes bail too.
+    if (ts.isReturnStatement(s) && s.expression && builderVar) {
       let e: ts.Expression = s.expression
       while (ts.isParenthesizedExpression(e)) e = e.expression
       if (!ts.isConditionalExpression(e)) return null
+      if (!isQueryTruthiness(e.condition, builderVar, toStringVars)) return null
       base = tsNodeToParsedExpr(e.whenFalse)
       continue
     }
@@ -128,6 +144,36 @@ function extractUrlBuilder(
   }
   if (!builderVar || !base || sets.length === 0) return null
   return { base, sets }
+}
+
+/** `<builderVar>.toString()` — the query-string materialisation. */
+function isBuilderToString(node: ts.Expression, builderVar: string): boolean {
+  let e: ts.Expression = node
+  while (ts.isParenthesizedExpression(e)) e = e.expression
+  return (
+    ts.isCallExpression(e) &&
+    e.arguments.length === 0 &&
+    ts.isPropertyAccessExpression(e.expression) &&
+    ts.isIdentifier(e.expression.expression) &&
+    e.expression.expression.text === builderVar &&
+    e.expression.name.text === 'toString'
+  )
+}
+
+/**
+ * The builder return's condition is the query-string truthiness: a direct
+ * `<builderVar>.toString()` call, or an identifier bound to one earlier
+ * (`const s = u.toString()`). Anything else is not a query builder.
+ */
+function isQueryTruthiness(
+  cond: ts.Expression,
+  builderVar: string,
+  toStringVars: ReadonlySet<string>,
+): boolean {
+  let e: ts.Expression = cond
+  while (ts.isParenthesizedExpression(e)) e = e.expression
+  if (ts.isIdentifier(e)) return toStringVars.has(e.text)
+  return isBuilderToString(e, builderVar)
 }
 
 /**

--- a/packages/jsx/src/url-builder-shape.ts
+++ b/packages/jsx/src/url-builder-shape.ts
@@ -1,0 +1,156 @@
+/**
+ * Recognition of the local `URLSearchParams` URL-query helper idiom, lowered to
+ * a pure {@link UrlBuilderInfo} tree at analysis time (#2039).
+ *
+ * The go-template adapter lowers these helpers to a `bf_query` template action.
+ * Their bodies are multi-statement block-bodied arrows, which the structured
+ * expression parser collapses to `unsupported` — so the adapter used to recover
+ * the shape by re-parsing the arrow source with `ts.createSourceFile` at emit
+ * time. Doing the recognition here, where the TS AST is already in hand, carries
+ * the shape as IR (`ConstantInfo.urlBuilder`) and retires the adapter-side
+ * re-parse. The recognition is backend-neutral; only the `bf_query` emission is
+ * go-template-specific (and stays in the adapter).
+ */
+
+import ts from 'typescript'
+
+import { tsNodeToParsedExpr } from './expression-parser.ts'
+import type { ParsedExpr } from './expression-parser.ts'
+import type { UrlBuilderInfo, UrlBuilderSet } from './types.ts'
+
+/**
+ * Recognise a local URL-query helper arrow and lower it to a pure
+ * {@link UrlBuilderInfo}, or null when it isn't one of the two supported shapes.
+ *
+ * `isUrlBuilderName` reports whether a name resolves to an already-recognised
+ * URL-builder helper — used to gate the `delegate` shape. (Helpers are recognised
+ * in declaration order, so a delegate must follow the builder it targets; a
+ * forward reference is left unrecognised and the adapter falls back to its
+ * generic lowering, which is a no-op-equivalent rather than a miscompile.)
+ */
+export function recognizeUrlBuilder(
+  arrow: ts.ArrowFunction,
+  isUrlBuilderName: (name: string) => boolean,
+): UrlBuilderInfo | null {
+  // Every param must be a plain identifier — the call-site substitution binds
+  // params by name. A destructured / rest param can't be substituted, so bail.
+  const params: string[] = []
+  for (const p of arrow.parameters) {
+    if (!ts.isIdentifier(p.name) || p.dotDotDotToken) return null
+    params.push(p.name.text)
+  }
+
+  // Shape 1: the helper is itself a `URLSearchParams` builder (block body).
+  const builder = extractUrlBuilder(arrow)
+  if (builder) return { kind: 'builder', params, base: builder.base, sets: builder.sets }
+
+  // Shape 2: a pass-through delegate to another local URL-builder helper
+  // (`(k) => hrefFor(k, params().tag)`).
+  if (!ts.isBlock(arrow.body)) {
+    let body: ts.Expression = arrow.body
+    while (ts.isParenthesizedExpression(body)) body = body.expression
+    if (
+      ts.isCallExpression(body) &&
+      ts.isIdentifier(body.expression) &&
+      isUrlBuilderName(body.expression.text) &&
+      !body.arguments.some(a => ts.isSpreadElement(a))
+    ) {
+      return {
+        kind: 'delegate',
+        params,
+        target: body.expression.text,
+        args: body.arguments.map(a => tsNodeToParsedExpr(a)),
+      }
+    }
+  }
+  return null
+}
+
+/**
+ * Extract the builder shape from a `(…) => { const u = new URLSearchParams();
+ * [if (G)] u.set(K, V); …; return <s> ? … : <base> }` helper, or null when the
+ * block doesn't match that exact builder idiom. Sub-expressions are converted to
+ * `ParsedExpr` so the result is a pure tree.
+ */
+function extractUrlBuilder(
+  arrow: ts.ArrowFunction,
+): { base: ParsedExpr; sets: UrlBuilderSet[] } | null {
+  if (!ts.isBlock(arrow.body)) return null
+  let builderVar: string | null = null
+  let base: ParsedExpr | null = null
+  const sets: UrlBuilderSet[] = []
+
+  for (const s of arrow.body.statements) {
+    if (ts.isVariableStatement(s)) {
+      for (const d of s.declarationList.declarations) {
+        if (
+          ts.isIdentifier(d.name) &&
+          d.initializer &&
+          ts.isNewExpression(d.initializer) &&
+          ts.isIdentifier(d.initializer.expression) &&
+          d.initializer.expression.text === 'URLSearchParams' &&
+          (d.initializer.arguments?.length ?? 0) === 0
+        ) {
+          builderVar = d.name.text
+        }
+        // Other locals (`const s = u.toString()`) are inert — ignored.
+      }
+      continue
+    }
+    // `if (G) u.set(K, V)` (no else).
+    if (ts.isIfStatement(s) && !s.elseStatement && builderVar) {
+      const set = matchUrlSet(s.thenStatement, builderVar)
+      if (!set) return null
+      sets.push({ guard: tsNodeToParsedExpr(s.expression), key: set.key, value: set.value })
+      continue
+    }
+    // Unguarded `u.set(K, V)`.
+    if (ts.isExpressionStatement(s) && builderVar) {
+      const set = matchUrlSet(s, builderVar)
+      if (set) {
+        sets.push({ guard: null, key: set.key, value: set.value })
+        continue
+      }
+      return null
+    }
+    // `return <s> ? `${base}?…` : <base>` — the builder's return must be the
+    // conditional that picks between the with-query and bare-base URL; its
+    // `whenFalse` (no-query) branch is the base. Any other return shape bails
+    // to the adapter's method-call fallback.
+    if (ts.isReturnStatement(s) && s.expression) {
+      let e: ts.Expression = s.expression
+      while (ts.isParenthesizedExpression(e)) e = e.expression
+      if (!ts.isConditionalExpression(e)) return null
+      base = tsNodeToParsedExpr(e.whenFalse)
+      continue
+    }
+    return null
+  }
+  if (!builderVar || !base || sets.length === 0) return null
+  return { base, sets }
+}
+
+/**
+ * Match `<builderVar>.set('literalKey', <value>)` — as a statement or an
+ * if-then — returning the key text and value as a `ParsedExpr`, else null.
+ */
+function matchUrlSet(
+  node: ts.Node,
+  builderVar: string,
+): { key: string; value: ParsedExpr } | null {
+  const stmt = ts.isBlock(node) ? (node.statements.length === 1 ? node.statements[0] : null) : node
+  if (!stmt || !ts.isExpressionStatement(stmt)) return null
+  const call = stmt.expression
+  if (
+    ts.isCallExpression(call) &&
+    ts.isPropertyAccessExpression(call.expression) &&
+    ts.isIdentifier(call.expression.expression) &&
+    call.expression.expression.text === builderVar &&
+    call.expression.name.text === 'set' &&
+    call.arguments.length === 2 &&
+    ts.isStringLiteral(call.arguments[0])
+  ) {
+    return { key: call.arguments[0].text, value: tsNodeToParsedExpr(call.arguments[1]) }
+  }
+  return null
+}


### PR DESCRIPTION
Closes #2039.

Retires the last emit-time `ts.createSourceFile` / `parseLiteralExpression` calls from the **go-template adapter** (#2018 stage 4 / "U7") by carrying the two shapes that forced re-parsing as pure IR built in Phase 1.

## What re-parsed, and why

Both call sites existed because the structured expression parser collapses a shape to `unsupported` (losing structure), so the adapter recovered it by re-parsing the source with the TS AST at emit time:

1. **`expr/url-builder.ts`** — the `URLSearchParams` helper (`hrefFor`) is a multi-statement block-bodied arrow → `unsupported`. The adapter re-parsed both the call and the arrow body to recognise the builder shape.
2. **`memo/ctor-lowering.ts`** — `<s>.replace(/\/+$/, '')` was deferred to `unsupported`, and the memo ctor lowering re-parsed the raw with `ts.createSourceFile` **on the `bf build` hot path** (introduced by #2037/P5) to recover the trailing-slash strip.

## Changes

**url-builder → pure IR (`ConstantInfo.urlBuilder`)**
- New `UrlBuilderInfo` type (`builder` shape, or a pass-through `delegate`) carried on `ConstantInfo`.
- Recognition moved to the analyzer (`url-builder-shape.ts`), where the TS AST is already in hand — backend-neutral; only the `bf_query` emission stays go-template-specific.
- The adapter now consumes that IR: substitutes the call args (reusing the shared `substituteHelperParams`) and emits `bf_query` with no re-parse. The former adapter-side `extractUrlBuilder` / `matchUrlSet` are removed.
- A `delegate` resolves its target against builders recognised earlier in declaration order (the idiomatic ordering; a forward reference falls back to the generic lowering rather than miscompiling).

**regex-replace → structural carry**
- The parser now carries the regex form of `String.replace` as an `array-method` `replace` whose first arg is a `regex` node, instead of collapsing to `unsupported`.
- The memo ctor lowering matches the `/\/+$/` + empty-replacement trailing-slash strip off the IR → `strings.TrimRight`, no `ts.createSourceFile`.
- Template use stays refused: `isSupported` maps a regex-pattern `.replace` to the same deferred-form BF101 reason it emitted before, so diagnostics are unchanged.

**Seam cleanup**
- `EmitContext.parseLiteralExpression` and the adapter's private `parseLiteralExpression` (the last `ts.createSourceFile` in the adapter) are removed.
- `convertConditionToGo` gains a `preParsed` arg so the url-builder lowering passes its substituted tree instead of a string.

## Definition of done

- ✅ `grep -rn 'createSourceFile\|parseLiteralExpression' packages/adapter-go-template/src | grep -v __tests__` → comment-only (0 active calls). (Mojo/Xslate were already comment-only; an active `createSourceFile` remains only in `packages/adapter-tests` snapshot-test tooling, off the build hot path and outside the three SSR adapters.)
- ✅ `extractUrlBuilder` / `matchUrlSet` removed (replaced by the pure analyzer lowering).
- ✅ Rendered-HTML conformance unchanged across go-template / mojo / xslate.

## Testing

- `packages/adapter-go-template` full suite — green (552 pass); C2 url-builder + trailing-slash fixtures pass via the new IR path.
- `packages/adapter-mojolicious` (524 pass) and `packages/adapter-xslate` (356 pass) — green (shared parser change validated).
- `packages/jsx` — green except 3 pre-existing TypeChecker resolver-migration tests that also fail on the base branch (unrelated).
- New `packages/jsx/src/__tests__/url-builder-shape.test.ts` pins the analysis-time `ConstantInfo.urlBuilder` carrier (builder + delegate).
- Pre-existing, unrelated to this change: 9 Carousel cross-adapter conformance failures and the 3 resolver tests above (all fail identically on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkK14npEtF2TnALVYt1nec)_