### PR TITLE
chore: ignore barefootjs-xslate-example in changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -22,6 +22,7 @@
     "barefootjs-hono-jsx-example",
     "barefootjs-integrations-shared",
     "barefootjs-mojolicious-example",
-    "barefootjs-site"
+    "barefootjs-site",
+    "barefootjs-xslate-example"
   ]
 }


### PR DESCRIPTION
## Background

The [Version Packages PR #1970](https://github.com/piconic-ai/barefootjs/pull/1970) included `barefootjs-xslate-example@0.1.5`. This is a private example package that is not published to npm, so it should not appear in the release PR.

## Changes

Added `barefootjs-xslate-example` to the `ignore` list in `.changeset/config.json`. The other example packages (e.g. `barefootjs-mojolicious-example`) are already ignored, so this brings it in line with them.

Once this is merged into `main`, the changesets action will regenerate the Version Packages PR (#1970) without the `barefootjs-xslate-example` version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)