### PR TITLE
fix(go-template): form-encode bf_query to match URLSearchParams (#2048)

### DIFF
--- a/.changeset/go-bfquery-form-encode.md
+++ b/.changeset/go-bfquery-form-encode.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Encode `bf_query` keys/values with `application/x-www-form-urlencoded` (matching the browser's `URLSearchParams` and the Perl `query` helper) instead of Go's `url.QueryEscape`, so a `queryHref(base, { … })` renders byte-for-byte identically across the go-template, Mojolicious, and Xslate SSR adapters and the Hono client (#2048, follow-up to #2042).
+
+The two encoders agreed on everything except `~` and `*`: `url.QueryEscape` keeps `~` and percent-encodes `*`, whereas `URLSearchParams` percent-encodes `~` → `%7E` and keeps `*`. The new `formEscape` keeps the unreserved set `A-Z a-z 0-9 * - . _`, turns a space into `+`, and percent-encodes every other byte as `%XX` (uppercase, byte-wise UTF-8) — so query values containing `~` or `*` now match the other backends exactly.

--- a/.changeset/go-bfquery-form-encode.md
+++ b/.changeset/go-bfquery-form-encode.md
@@ -5,3 +5,5 @@
 Encode `bf_query` keys/values with `application/x-www-form-urlencoded` (matching the browser's `URLSearchParams` and the Perl `query` helper) instead of Go's `url.QueryEscape`, so a `queryHref(base, { … })` renders byte-for-byte identically across the go-template, Mojolicious, and Xslate SSR adapters and the Hono client (#2048, follow-up to #2042).
 
 The two encoders agreed on everything except `~` and `*`: `url.QueryEscape` keeps `~` and percent-encodes `*`, whereas `URLSearchParams` percent-encodes `~` → `%7E` and keeps `*`. The new `formEscape` keeps the unreserved set `A-Z a-z 0-9 * - . _`, turns a space into `+`, and percent-encodes every other byte as `%XX` (uppercase, byte-wise UTF-8) — so query values containing `~` or `*` now match the other backends exactly.
+
+The `query` helper is now covered by the shared golden helper vectors (`packages/adapter-tests/helper-vectors`), so the Go and Perl backends are conformance-tested against one set of `URLSearchParams`-derived expectations instead of hand-duplicated per-backend cases.

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -164,6 +164,12 @@ func FuncMap() template.FuncMap {
 // Included pairs follow URLSearchParams.set() semantics: repeating a key
 // overwrites the value at the key's first position rather than emitting a
 // duplicate `k=v&k=w`. Trailing args that don't complete a triple are ignored.
+//
+// Keys and values use formEscape (application/x-www-form-urlencoded), not
+// url.QueryEscape, so the rendered query is byte-for-byte identical to the
+// browser's URLSearchParams (and the Perl `query` helper) — the two diverge on
+// `~` (kept by QueryEscape, `%7E` here) and `*` (`%2A` by QueryEscape, kept
+// here).
 func Query(base string, triples ...any) string {
 	type kv struct{ key, val string }
 	pairs := make([]kv, 0, len(triples)/3)
@@ -189,11 +195,41 @@ func Query(base string, triples ...any) string {
 		} else {
 			b.WriteByte('&')
 		}
-		b.WriteString(url.QueryEscape(p.key))
+		b.WriteString(formEscape(p.key))
 		b.WriteByte('=')
-		b.WriteString(url.QueryEscape(p.val))
+		b.WriteString(formEscape(p.val))
 	}
 	return base + b.String()
+}
+
+const hexUpper = "0123456789ABCDEF"
+
+// formEscape percent-encodes s with the application/x-www-form-urlencoded byte
+// set, matching the browser's URLSearchParams serialization (and the Perl
+// `query` helper) so SSR query strings render byte-for-byte identically across
+// adapters. The unreserved set kept verbatim is A-Z a-z 0-9 and `* - . _`; a
+// space becomes `+`; every other byte is `%XX` with uppercase hex. Encoding is
+// byte-wise, so multi-byte UTF-8 is percent-encoded per byte (`é` → `%C3%A9`).
+//
+// This differs from url.QueryEscape only for `~` (kept by QueryEscape, encoded
+// to `%7E` here) and `*` (encoded to `%2A` by QueryEscape, kept here).
+func formEscape(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z', c >= '0' && c <= '9',
+			c == '*', c == '-', c == '.', c == '_':
+			b.WriteByte(c)
+		case c == ' ':
+			b.WriteByte('+')
+		default:
+			b.WriteByte('%')
+			b.WriteByte(hexUpper[c>>4])
+			b.WriteByte(hexUpper[c&0x0F])
+		}
+	}
+	return b.String()
 }
 
 // ScopeAttr returns the bare bf-s scope id (#1249).

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -2019,6 +2019,14 @@ func TestRender_AutoAssignsChildScopeIDs(t *testing.T) {
 	}
 }
 
+// Query (`bf_query`)'s cross-backend behaviour — control flow plus form-encoding
+// parity with the browser's URLSearchParams — lives in the shared golden helper
+// vectors (TestHelperVectors, fn "query"), the same vectors the Perl backend
+// runs. This direct test keeps a few representative cases for always-on coverage
+// (the golden file is monorepo-only) and pins the one Go-SPECIFIC behaviour: an
+// included-but-empty value is kept as `k=`, because lowerQueryHrefCall folds the
+// `ne value ""` check INTO the include flag, so the Go helper itself never
+// re-checks (the client / Perl omit empties in the helper instead).
 func TestQuery(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -2026,28 +2034,13 @@ func TestQuery(t *testing.T) {
 		triples []any
 		want    string
 	}{
-		{"no triples", "/", nil, "/"},
-		{"all excluded", "/", []any{false, "sort", "title", false, "tag", "go"}, "/"},
-		{"one included", "/", []any{true, "sort", "title"}, "/?sort=title"},
-		{"order preserved", "/blog", []any{true, "sort", "title", true, "tag", "go"}, "/blog?sort=title&tag=go"},
-		{"mixed include", "/blog", []any{false, "sort", "date", true, "tag", "go"}, "/blog?tag=go"},
-		{"escapes value", "/", []any{true, "tag", "a b&c"}, "/?tag=a+b%26c"},
-		{"empty-but-included value", "/", []any{true, "tag", ""}, "/?tag="},
-		{"trailing partial triple ignored", "/", []any{true, "sort", "title", true, "tag"}, "/?sort=title"},
-		// URLSearchParams.set(): repeating a key overwrites the value at the
-		// key's first position, never duplicating `k=v&k=w`.
-		{"repeated key overwrites first position", "/", []any{true, "sort", "title", true, "sort", "date"}, "/?sort=date"},
-		{"overwrite keeps first position among others", "/blog", []any{true, "sort", "title", true, "tag", "go", true, "sort", "date"}, "/blog?sort=date&tag=go"},
-		{"excluded repeat does not overwrite", "/", []any{true, "sort", "title", false, "sort", "date"}, "/?sort=title"},
-		// Form-encoding (application/x-www-form-urlencoded) parity with the
-		// browser's URLSearchParams — NOT url.QueryEscape. These vectors mirror
-		// the Perl `query` helper's t/query.t so all four backends render the
-		// same bytes. The `~`/`*` cases are exactly where url.QueryEscape would
-		// diverge (it keeps `~` and encodes `*`).
-		{"tilde encoded, star kept (URLSearchParams set)", "/s", []any{true, "t", "a~b*c"}, "/s?t=a%7Eb*c"},
-		{"space to plus in key and value, & encoded", "/s", []any{true, "q", "a b", true, "x y", "c&d"}, "/s?q=a+b&x+y=c%26d"},
-		{"utf-8 byte-encoded", "/s", []any{true, "q", "café"}, "/s?q=caf%C3%A9"},
-		{"percent and tilde and star together", "/s", []any{true, "t", "100%~free*"}, "/s?t=100%25%7Efree*"},
+		{"one included pair", "/", []any{true, "sort", "title"}, "/?sort=title"},
+		{"order + overwrite at first position", "/blog", []any{true, "sort", "title", true, "tag", "go", true, "sort", "date"}, "/blog?sort=date&tag=go"},
+		// formEscape (not url.QueryEscape): `~` → %7E, `*` kept, space → `+`.
+		{"form-encode ~ * space", "/s", []any{true, "t", "a~b *c"}, "/s?t=a%7Eb+*c"},
+		// Go-specific: an explicitly-included empty value is kept (no helper-side
+		// emptiness check); pinned as a divergence in the golden harness.
+		{"included-but-empty value is kept as k=", "/", []any{true, "tag", ""}, "/?tag="},
 	}
 	for _, tt := range tests {
 		if got := Query(tt.base, tt.triples...); got != tt.want {

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -2039,6 +2039,15 @@ func TestQuery(t *testing.T) {
 		{"repeated key overwrites first position", "/", []any{true, "sort", "title", true, "sort", "date"}, "/?sort=date"},
 		{"overwrite keeps first position among others", "/blog", []any{true, "sort", "title", true, "tag", "go", true, "sort", "date"}, "/blog?sort=date&tag=go"},
 		{"excluded repeat does not overwrite", "/", []any{true, "sort", "title", false, "sort", "date"}, "/?sort=title"},
+		// Form-encoding (application/x-www-form-urlencoded) parity with the
+		// browser's URLSearchParams — NOT url.QueryEscape. These vectors mirror
+		// the Perl `query` helper's t/query.t so all four backends render the
+		// same bytes. The `~`/`*` cases are exactly where url.QueryEscape would
+		// diverge (it keeps `~` and encodes `*`).
+		{"tilde encoded, star kept (URLSearchParams set)", "/s", []any{true, "t", "a~b*c"}, "/s?t=a%7Eb*c"},
+		{"space to plus in key and value, & encoded", "/s", []any{true, "q", "a b", true, "x y", "c&d"}, "/s?q=a+b&x+y=c%26d"},
+		{"utf-8 byte-encoded", "/s", []any{true, "q", "café"}, "/s?q=caf%C3%A9"},
+		{"percent and tilde and star together", "/s", []any{true, "t", "100%~free*"}, "/s?t=100%25%7Efree*"},
 	}
 	for _, tt := range tests {
 		if got := Query(tt.base, tt.triples...); got != tt.want {

--- a/packages/adapter-go-template/runtime/vectors_test.go
+++ b/packages/adapter-go-template/runtime/vectors_test.go
@@ -33,12 +33,12 @@ type vectorFile struct {
 // vector whose fn has no binding here FAILS the test — the Go backend
 // is not allowed to silently fall behind the catalogue.
 var vectorBindings = map[string]func(args []any) any{
-	"add": func(args []any) any { return Add(args[0], args[1]) },
-	"sub": func(args []any) any { return Sub(args[0], args[1]) },
-	"mul": func(args []any) any { return Mul(args[0], args[1]) },
-	"div": func(args []any) any { return Div(args[0], args[1]) },
-	"mod": func(args []any) any { return Mod(args[0], args[1]) },
-	"neg": func(args []any) any { return Neg(args[0]) },
+	"add":    func(args []any) any { return Add(args[0], args[1]) },
+	"sub":    func(args []any) any { return Sub(args[0], args[1]) },
+	"mul":    func(args []any) any { return Mul(args[0], args[1]) },
+	"div":    func(args []any) any { return Div(args[0], args[1]) },
+	"mod":    func(args []any) any { return Mod(args[0], args[1]) },
+	"neg":    func(args []any) any { return Neg(args[0]) },
 	"string": func(args []any) any { return String(args[0]) },
 	"json": func(args []any) any {
 		s, err := JSON(args[0])
@@ -59,9 +59,9 @@ var vectorBindings = map[string]func(args []any) any{
 		}
 		return ToFixed(args[0], 0)
 	},
-	"lower":  func(args []any) any { return Lower(args[0].(string)) },
-	"upper":  func(args []any) any { return Upper(args[0].(string)) },
-	"trim":   func(args []any) any { return Trim(args[0].(string)) },
+	"lower": func(args []any) any { return Lower(args[0].(string)) },
+	"upper": func(args []any) any { return Upper(args[0].(string)) },
+	"trim":  func(args []any) any { return Trim(args[0].(string)) },
 	"starts_with": func(args []any) any {
 		if len(args) > 2 {
 			return StartsWith(args[0].(string), args[1].(string), args[2].(int))
@@ -114,12 +114,13 @@ var vectorBindings = map[string]func(args []any) any{
 	"search_params_get": func(args []any) any {
 		return NewSearchParams(args[0].(string)).Get(args[1].(string))
 	},
-	"every":         func(args []any) any { return Every(args[0], args[1].(string)) },
-	"some":          func(args []any) any { return Some(args[0], args[1].(string)) },
-	"filter":        func(args []any) any { return Filter(args[0], args[1].(string), args[2]) },
-	"find":          func(args []any) any { return Find(args[0], args[1].(string), args[2]) },
-	"find_index":    func(args []any) any { return FindIndex(args[0], args[1].(string), args[2]) },
-	"find_last":     func(args []any) any { return FindLast(args[0], args[1].(string), args[2]) },
+	"query":      func(args []any) any { return Query(args[0].(string), args[1:]...) },
+	"every":      func(args []any) any { return Every(args[0], args[1].(string)) },
+	"some":       func(args []any) any { return Some(args[0], args[1].(string)) },
+	"filter":     func(args []any) any { return Filter(args[0], args[1].(string), args[2]) },
+	"find":       func(args []any) any { return Find(args[0], args[1].(string), args[2]) },
+	"find_index": func(args []any) any { return FindIndex(args[0], args[1].(string), args[2]) },
+	"find_last":  func(args []any) any { return FindLast(args[0], args[1].(string), args[2]) },
 	"find_last_index": func(args []any) any {
 		return FindLastIndex(args[0], args[1].(string), args[2])
 	},
@@ -203,6 +204,10 @@ var vectorDivergences = map[string]vectorDivergence{
 	"search_params_get/absent key is null": {
 		expect: "",
 		reason: "url.Values.Get returns \"\" for an absent key where JS URLSearchParams.get returns null; the ?? → or lowering folds both to the author default, so SSR output still matches",
+	},
+	"query/included-but-empty value is omitted": {
+		expect: "/?tag=",
+		reason: "Go's Query has no value-emptiness check: lowerQueryHrefCall folds `ne value \"\"` INTO the include flag (`and (cond) (ne value \"\")`), so the compiler never emits an included-empty triple. The Perl helper instead omits empties itself, so the two helpers split that responsibility; real SSR output matches the client on both.",
 	},
 }
 

--- a/packages/adapter-perl/t/helper_vectors.t
+++ b/packages/adapter-perl/t/helper_vectors.t
@@ -9,6 +9,12 @@ use Scalar::Util qw(looks_like_number);
 use lib "$FindBin::Bin/../lib";
 use BarefootJS;
 
+# vectors.json is UTF-8 (string args like "café"; `≡` in some notes). Decode it
+# as UTF-8 (below) and route TAP through a UTF-8 layer so wide test names don't
+# trigger "Wide character in print".
+binmode Test::More->builder->$_, ':encoding(UTF-8)'
+    for qw(output failure_output todo_output);
+
 # Pure-Perl backend (core JSON::PP only) so this test runs with zero
 # Mojo present — same pattern as t/template_primitives.t.
 {
@@ -37,7 +43,10 @@ plan skip_all => 'golden vectors not available outside the monorepo checkout'
 my $doc = do {
     open my $fh, '<:raw', $vectors_path or die "open $vectors_path: $!";
     local $/;
-    JSON::PP->new->decode(<$fh>);
+    # ->utf8 decodes the file's UTF-8 bytes into Perl characters, so a value
+    # like "café" round-trips to a single é (U+00E9) instead of its two raw
+    # bytes — otherwise _form_escape would re-encode them and double-escape.
+    JSON::PP->new->utf8->decode(scalar <$fh>);
 };
 
 # One binding per canonical helper id in the spec catalogue, bound to
@@ -98,6 +107,11 @@ my %bindings = (
     # No divergence entry: get() returns undef for an absent key (~ JS null)
     # and '' for present-but-empty, so the Perl backend matches JS exactly.
     search_params_get => sub { BarefootJS->search_params($_[0])->get($_[1]) },
+
+    # queryHref SSR builder (#2042): (base, include, key, value, …) → URL. The
+    # include flags arrive as JSON booleans (JSON::PP::Boolean, truthy/falsy
+    # under `next unless`); the helper form-encodes to match URLSearchParams.
+    query => sub { $bf->query(@_) },
 
     # Higher-order entries arrive in the canonical projection form
     # (spec: items + field [+ value]); the closures below rebuild the

--- a/packages/adapter-perl/t/query.t
+++ b/packages/adapter-perl/t/query.t
@@ -2,10 +2,20 @@ use Test2::V0;
 use utf8;
 
 # BarefootJS->query — the `queryHref(base, { … })` URL-query builder helper
-# (#2042). The cross-language VALUE semantics (truthy-omit over strings,
-# `URLSearchParams.set` overwrite, form-encoding) must equal the browser /
-# Hono render the SSR is compared against, so the expected strings below are the
-# `URLSearchParams`-serialised forms.
+# (#2042).
+#
+# The full CROSS-BACKEND behaviour (control flow + form-encoding parity with the
+# browser's URLSearchParams) is defined ONCE in the shared golden helper vectors
+# — packages/adapter-tests/helper-vectors/vectors.json, fn "query" — and run
+# here by t/helper_vectors.t and by the Go runtime's TestHelperVectors, so the
+# Perl and Go expectations can't drift apart.
+#
+# This file keeps a few representative cases for always-on coverage (the golden
+# file is monorepo-only, absent from the CPAN dist) plus the Perl-runtime-
+# SPECIFIC defensive behaviour the golden vectors can't express: an `undef`
+# value. JSON has no `undefined`, and a JSON `null` stringifies to "null" under
+# JS `String()`, so it can't be a shared vector; Perl coerces `undef` to '' and
+# omits the empty pair.
 
 use FindBin qw($Bin);
 use lib "$Bin/../lib";
@@ -13,38 +23,22 @@ use lib "$Bin/../lib";
 use BarefootJS;
 
 # `query` is a pure helper (no backend / controller), so a bare blessed stub is
-# enough — mirroring t/helper_vectors.t.
+# enough — mirroring t/helper_vectors.t. Triples are (include, key, value).
 my $bf = bless {}, 'BarefootJS';
 
-# Triples are (guard, key, value); the adapter passes guard `1` for a plain
-# `key: v` and the lowered condition for `key: cond ? v : undefined`.
+# Representative control flow: a repeated key overwrites at its first position
+# (URLSearchParams.set), surrounding order preserved.
+is $bf->query('/blog', 1, 'sort', 'title', 1, 'tag', 'go', 1, 'sort', 'date'),
+    '/blog?sort=date&tag=go', 'order preserved, repeated key overwrites at first position';
 
-is $bf->query('/list'), '/list', 'no params → bare base';
-is $bf->query('/list', 1, 'tag', 'go'), '/list?tag=go', 'single pair';
-is $bf->query('/list', 1, 'tag', ''), '/list', 'empty value omitted (truthy-omit)';
-is $bf->query('/list', 1, 'sort', 'name', 1, 'tag', 'go'),
-    '/list?sort=name&tag=go', 'two pairs, in order';
+# Representative form-encoding: space → '+', '~' → %7E, '*' kept (URLSearchParams,
+# not Go's url.QueryEscape).
+is $bf->query('/s', 1, 't', 'a~b *c'), '/s?t=a%7Eb+*c', 'form-encode: ~ → %7E, * kept, space → +';
 
-# guard false (a `cond ? v : undefined` whose cond is false) drops the pair.
-is $bf->query('/list', 0, 'sort', 'x', 1, 'tag', 'go'),
-    '/list?tag=go', 'falsy guard drops the pair';
-# guard true but value empty → still omitted (matches `if (cond ? '' : undefined)`).
-is $bf->query('/list', 1, 'sort', ''), '/list', 'truthy guard, empty value → omitted';
-
-# `URLSearchParams.set` overwrite: a repeated key keeps its first position,
-# last value.
-is $bf->query('/p', 1, 'k', 'v', 1, 'k', 'w'), '/p?k=w', 'repeated key overwrites at first position';
-
-# Form-encoding parity with URLSearchParams: space → '+', '&' → %26, '~' → %7E,
-# '*' kept.
-is $bf->query('/s', 1, 'q', 'a b', 1, 'x y', 'c&d'),
-    '/s?q=a+b&x+y=c%26d', 'space → + and & → %26';
-is $bf->query('/s', 1, 't', 'a~b*c'), '/s?t=a%7Eb*c', '~ → %7E, * kept (URLSearchParams set)';
-
-# UTF-8 is encoded byte-wise.
-is $bf->query('/s', 1, 'q', 'café'), '/s?q=caf%C3%A9', 'UTF-8 byte-encoded';
-
-# undef value / undef key are coerced to '' (and an empty value is omitted).
-is $bf->query('/list', 1, 'tag', undef), '/list', 'undef value omitted';
+# Perl-specific: an `undef` value is coerced to '' and then omitted, without
+# disturbing the surrounding pairs.
+is $bf->query('/list', 1, 'tag', undef), '/list', 'undef value coerced to empty → omitted';
+is $bf->query('/list', 1, 'tag', undef, 1, 'keep', 'me'), '/list?keep=me',
+    'undef value dropped, surrounding pairs intact';
 
 done_testing;

--- a/packages/adapter-tests/helper-vectors/cases.ts
+++ b/packages/adapter-tests/helper-vectors/cases.ts
@@ -69,6 +69,27 @@ export const reference: Record<string, (...args: never[]) => unknown> = {
   // returns "" for an absent key where JS returns null).
   search_params_get: (query: string, key: string) => new URLSearchParams(query).get(key),
 
+  // queryHref()'s URL builder (#2042) as the SSR `query` / `bf_query` helper
+  // receives it: a base plus a flat list of (include, key, value) triples. A
+  // pair is included iff its `include` flag is truthy AND its value is a
+  // non-empty string; a repeated key overwrites at its first position
+  // (URLSearchParams.set). The reference encodes through URLSearchParams, so the
+  // Go (bf.Query) and Perl (BarefootJS::query) backends are held to byte-
+  // identical form-encoding — space → '+', '~' → %7E, '*' kept, UTF-8 byte-wise
+  // — the parity #2048 aligns the Go backend's encoder to.
+  query: (base: string, ...triples: unknown[]) => {
+    const params = new URLSearchParams()
+    for (let i = 0; i + 2 < triples.length; i += 3) {
+      if (!triples[i]) continue
+      const key = String(triples[i + 1])
+      const val = String(triples[i + 2])
+      if (val === '') continue
+      params.set(key, val)
+    }
+    const s = params.toString()
+    return s ? `${base}?${s}` : base
+  },
+
   // Higher-order entries use the compiled projection catalogue as the
   // canonical argument form (spec: "canonical projection form") — the
   // references run the REAL JS array methods over predicates built
@@ -502,4 +523,23 @@ export const cases: HelperCase[] = [
   { fn: 'search_params_get', args: ['q=a%20b', 'q'], note: 'percent-encoded space decodes' },
   { fn: 'search_params_get', args: ['q=a%26b', 'q'], note: 'encoded & in a value is data, not a separator' },
   { fn: 'search_params_get', args: ['token=a=b=c', 'token'], note: 'only the first = splits; the rest is value' },
+
+  // query() — the queryHref SSR builder. Control-flow rules (include flag,
+  // empty-value omit, order, URLSearchParams.set overwrite) plus form-encoding
+  // parity. The `~` / `*` vectors are exactly where Go's old url.QueryEscape
+  // diverged from URLSearchParams (#2048).
+  { fn: 'query', args: ['/'], note: 'no triples yields the bare base' },
+  { fn: 'query', args: ['/', false, 'sort', 'title', false, 'tag', 'go'], note: 'all-excluded yields the bare base' },
+  { fn: 'query', args: ['/', true, 'sort', 'title'], note: 'one included pair' },
+  { fn: 'query', args: ['/blog', true, 'sort', 'title', true, 'tag', 'go'], note: 'order preserved' },
+  { fn: 'query', args: ['/blog', false, 'sort', 'date', true, 'tag', 'go'], note: 'excluded pair dropped, included kept' },
+  { fn: 'query', args: ['/', true, 'tag', ''], note: 'included-but-empty value is omitted' },
+  { fn: 'query', args: ['/', true, 'sort', 'title', true, 'tag'], note: 'trailing partial triple ignored' },
+  { fn: 'query', args: ['/', true, 'sort', 'title', true, 'sort', 'date'], note: 'repeated key overwrites at first position (set)' },
+  { fn: 'query', args: ['/blog', true, 'sort', 'title', true, 'tag', 'go', true, 'sort', 'date'], note: 'overwrite keeps first position among others' },
+  { fn: 'query', args: ['/', true, 'sort', 'title', false, 'sort', 'date'], note: 'excluded repeat does not overwrite' },
+  { fn: 'query', args: ['/s', true, 't', 'a~b*c'], note: 'form-encode: ~ to %7E, * kept (URLSearchParams, not QueryEscape)' },
+  { fn: 'query', args: ['/s', true, 'q', 'a b', true, 'x y', 'c&d'], note: 'form-encode: space to + in key and value, & to %26' },
+  { fn: 'query', args: ['/s', true, 'q', 'café'], note: 'form-encode: UTF-8 byte-wise' },
+  { fn: 'query', args: ['/s', true, 't', '100%~free*'], note: 'form-encode: % ~ * together' },
 ]

--- a/packages/adapter-tests/helper-vectors/vectors.json
+++ b/packages/adapter-tests/helper-vectors/vectors.json
@@ -2683,6 +2683,183 @@
       ],
       "expect": "a=b=c",
       "note": "only the first = splits; the rest is value"
+    },
+    {
+      "fn": "query",
+      "args": [
+        "/"
+      ],
+      "expect": "/",
+      "note": "no triples yields the bare base"
+    },
+    {
+      "fn": "query",
+      "args": [
+        "/",
+        false,
+        "sort",
+        "title",
+        false,
+        "tag",
+        "go"
+      ],
+      "expect": "/",
+      "note": "all-excluded yields the bare base"
+    },
+    {
+      "fn": "query",
+      "args": [
+        "/",
+        true,
+        "sort",
+        "title"
+      ],
+      "expect": "/?sort=title",
+      "note": "one included pair"
+    },
+    {
+      "fn": "query",
+      "args": [
+        "/blog",
+        true,
+        "sort",
+        "title",
+        true,
+        "tag",
+        "go"
+      ],
+      "expect": "/blog?sort=title&tag=go",
+      "note": "order preserved"
+    },
+    {
+      "fn": "query",
+      "args": [
+        "/blog",
+        false,
+        "sort",
+        "date",
+        true,
+        "tag",
+        "go"
+      ],
+      "expect": "/blog?tag=go",
+      "note": "excluded pair dropped, included kept"
+    },
+    {
+      "fn": "query",
+      "args": [
+        "/",
+        true,
+        "tag",
+        ""
+      ],
+      "expect": "/",
+      "note": "included-but-empty value is omitted"
+    },
+    {
+      "fn": "query",
+      "args": [
+        "/",
+        true,
+        "sort",
+        "title",
+        true,
+        "tag"
+      ],
+      "expect": "/?sort=title",
+      "note": "trailing partial triple ignored"
+    },
+    {
+      "fn": "query",
+      "args": [
+        "/",
+        true,
+        "sort",
+        "title",
+        true,
+        "sort",
+        "date"
+      ],
+      "expect": "/?sort=date",
+      "note": "repeated key overwrites at first position (set)"
+    },
+    {
+      "fn": "query",
+      "args": [
+        "/blog",
+        true,
+        "sort",
+        "title",
+        true,
+        "tag",
+        "go",
+        true,
+        "sort",
+        "date"
+      ],
+      "expect": "/blog?sort=date&tag=go",
+      "note": "overwrite keeps first position among others"
+    },
+    {
+      "fn": "query",
+      "args": [
+        "/",
+        true,
+        "sort",
+        "title",
+        false,
+        "sort",
+        "date"
+      ],
+      "expect": "/?sort=title",
+      "note": "excluded repeat does not overwrite"
+    },
+    {
+      "fn": "query",
+      "args": [
+        "/s",
+        true,
+        "t",
+        "a~b*c"
+      ],
+      "expect": "/s?t=a%7Eb*c",
+      "note": "form-encode: ~ to %7E, * kept (URLSearchParams, not QueryEscape)"
+    },
+    {
+      "fn": "query",
+      "args": [
+        "/s",
+        true,
+        "q",
+        "a b",
+        true,
+        "x y",
+        "c&d"
+      ],
+      "expect": "/s?q=a+b&x+y=c%26d",
+      "note": "form-encode: space to + in key and value, & to %26"
+    },
+    {
+      "fn": "query",
+      "args": [
+        "/s",
+        true,
+        "q",
+        "café"
+      ],
+      "expect": "/s?q=caf%C3%A9",
+      "note": "form-encode: UTF-8 byte-wise"
+    },
+    {
+      "fn": "query",
+      "args": [
+        "/s",
+        true,
+        "t",
+        "100%~free*"
+      ],
+      "expect": "/s?t=100%25%7Efree*",
+      "note": "form-encode: % ~ * together"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Closes the **Q5** follow-up split out of #2042 (→ #2048): aligns the go-template `bf_query` query encoder with the browser's `URLSearchParams` so a `queryHref(base, { … })` renders byte-for-byte identically across the go-template, Mojolicious, and Xslate SSR adapters and the Hono client.

`Query` (the `bf_query` runtime helper in `runtime/bf.go`) encoded keys/values with Go's `url.QueryEscape`. That agrees with `URLSearchParams` on everything **except** two characters:

| char | `URLSearchParams` (client, Perl `query`) | go `url.QueryEscape` |
|------|------------------------------------------|----------------------|
| `~`  | `%7E`                                    | `~` (kept)           |
| `*`  | `*` (kept)                               | `%2A`                |

Since each SSR adapter is conformance-compared byte-for-byte against the Hono render, a query value containing `~` or `*` rendered differently on the go adapter than on the other three backends.

## Changes

- **`runtime/bf.go`** — add `formEscape` (`application/x-www-form-urlencoded`: keep the unreserved set `A-Z a-z 0-9 * - . _`, space → `+`, every other byte → `%XX` uppercase, byte-wise UTF-8) and use it for both key and value in `Query`. This is the same byte set the Perl `_form_escape` helper already uses. `url.QueryEscape` is no longer used by `Query` (the `url` import stays — `url.Values` / `url.ParseQuery` are used elsewhere in the file).
- **`runtime/bf_test.go`** — extend `TestQuery` with the `~` / `*` / UTF-8 / `%` vectors, mirroring the Perl helper's `t/query.t` so all four backends share the same expectations.

## Behavior

Only the encoding of `~` and `*` in query keys/values changes (now `%7E` / `*`). All other characters — including space → `+`, `&` → `%26`, and UTF-8 — were already identical. No component in the repo emits a `~`/`*` query value today (`PostList` uses plain `sort`/`tag` strings), so there's no fixture or snapshot fallout.

## Test plan

- `go test ./...` in `packages/adapter-go-template/runtime` green (incl. the new `TestQuery` vectors).
- `gofmt` / `go vet` clean.
- Verified the expected strings against Node's `URLSearchParams` (`a~b*c` → `a%7Eb*c`, `100%~free*` → `100%25%7Efree*`, `café` → `caf%C3%A9`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkK14npEtF2TnALVYt1nec)_