### PR TITLE
feat(queryHref): array values for multi-value query keys (#2048)

### DIFF
--- a/.changeset/queryhref-multi-value.md
+++ b/.changeset/queryhref-multi-value.md
@@ -1,0 +1,15 @@
+---
+"@barefootjs/client": minor
+"@barefootjs/go-template": minor
+"@barefootjs/perl": minor
+---
+
+`queryHref` now accepts an **array value** for multi-value query keys (#2048, the Q4 follow-up to #2042): `queryHref(base, { tag: ['a', 'b'] })` → `?tag=a&tag=b`, i.e. `URLSearchParams.append` rather than `set`. Empty / falsy members are skipped (same truthy-omit as a scalar), so an empty — or all-empty — array contributes nothing. `QueryParamValue` becomes `string | string[] | null | undefined`.
+
+This works across the client and all SSR adapters byte-for-byte:
+
+- **`@barefootjs/client`**: `queryHref` appends each non-empty array member.
+- **`@barefootjs/perl`** (Mojolicious + Xslate via the shared `query` helper): an array ref appends one pair per non-empty member.
+- **`@barefootjs/go-template`**: `bf_query` appends each non-empty member of a `[]string` (or `[]any`) value. To support this, the value-emptiness check moved from the lowering into the `bf_query` helper itself — a plain `key: v` now lowers to a `(true)` include and a conditional to `(cond)`, and the helper drops an included-but-empty value. This matches the client and Perl exactly (it also removes the previous Go-only divergence where an explicitly-included empty value was kept as `k=`); rendered output for existing scalar usage is unchanged.
+
+The `query` helper's array behaviour is conformance-tested across the Go and Perl backends via the shared golden helper vectors.

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -153,23 +153,25 @@ func FuncMap() template.FuncMap {
 }
 
 // Query builds a URL from a base path plus a query string assembled from
-// (include, key, value) triples, in order. A pair is appended only when its
+// (include, key, value) triples, in order. A pair is considered only when its
 // `include` flag is true — mirroring a JS URLSearchParams builder whose
-// `.set(key, value)` calls are each guarded by an `if`. The compiler lowers
-// each guard to the `include` bool (so empty-but-included values, and
-// non-empty-but-excluded values, both match the source semantics). Keys and
-// values are query-escaped (spaces → "+", like URLSearchParams). An empty
-// query yields the bare base.
+// `.set(key, value)` calls are each guarded by an `if`. The compiler lowers a
+// conditional `cond ? v : undefined` to the `include` bool and a plain `key: v`
+// to a `true` include; the emptiness check is applied HERE (an included but
+// empty value is dropped), matching the client `queryHref` and the Perl `query`
+// helper. Keys and values use formEscape (application/x-www-form-urlencoded),
+// so the rendered query is byte-for-byte identical to the browser's
+// URLSearchParams. An empty query yields the bare base.
 //
-// Included pairs follow URLSearchParams.set() semantics: repeating a key
-// overwrites the value at the key's first position rather than emitting a
-// duplicate `k=v&k=w`. Trailing args that don't complete a triple are ignored.
+// A value may be a string slice ([]string or []any), which APPENDS one pair per
+// non-empty member (URLSearchParams.append) — `{tag: [a, b]}` → `tag=a&tag=b`.
+// A scalar value follows URLSearchParams.set() semantics: repeating a key
+// overwrites the value at the key's first position rather than duplicating it
+// (object literals have unique keys, so this is defensive). Trailing args that
+// don't complete a triple are ignored.
 //
-// Keys and values use formEscape (application/x-www-form-urlencoded), not
-// url.QueryEscape, so the rendered query is byte-for-byte identical to the
-// browser's URLSearchParams (and the Perl `query` helper) — the two diverge on
-// `~` (kept by QueryEscape, `%7E` here) and `*` (`%2A` by QueryEscape, kept
-// here).
+// formEscape differs from url.QueryEscape only on `~` (kept by QueryEscape,
+// `%7E` here) and `*` (`%2A` by QueryEscape, kept here).
 func Query(base string, triples ...any) string {
 	type kv struct{ key, val string }
 	pairs := make([]kv, 0, len(triples)/3)
@@ -180,7 +182,21 @@ func Query(base string, triples ...any) string {
 			continue
 		}
 		k := String(triples[i+1])
+		if members, ok := asStringSlice(triples[i+2]); ok {
+			// Array value → append each non-empty member; appended pairs never
+			// overwrite, so they don't participate in the set()-position map.
+			for _, m := range members {
+				if m == "" {
+					continue
+				}
+				pairs = append(pairs, kv{k, m})
+			}
+			continue
+		}
 		v := String(triples[i+2])
+		if v == "" {
+			continue // omit an included-but-empty value (client / Perl parity)
+		}
 		if at, ok := pos[k]; ok {
 			pairs[at].val = v // set(): overwrite the first occurrence's value
 		} else {
@@ -200,6 +216,25 @@ func Query(base string, triples ...any) string {
 		b.WriteString(formEscape(p.val))
 	}
 	return base + b.String()
+}
+
+// asStringSlice reports whether v is a query *array* value and, if so, returns
+// its members stringified. A compiled template passes a `[]string` field; the
+// golden conformance vectors decode JSON arrays to `[]any`. Anything else is a
+// scalar (false), handled by the set() path.
+func asStringSlice(v any) ([]string, bool) {
+	switch s := v.(type) {
+	case []string:
+		return s, true
+	case []any:
+		out := make([]string, len(s))
+		for i, m := range s {
+			out[i] = String(m)
+		}
+		return out, true
+	default:
+		return nil, false
+	}
 }
 
 const hexUpper = "0123456789ABCDEF"

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -2023,10 +2023,9 @@ func TestRender_AutoAssignsChildScopeIDs(t *testing.T) {
 // parity with the browser's URLSearchParams — lives in the shared golden helper
 // vectors (TestHelperVectors, fn "query"), the same vectors the Perl backend
 // runs. This direct test keeps a few representative cases for always-on coverage
-// (the golden file is monorepo-only) and pins the one Go-SPECIFIC behaviour: an
-// included-but-empty value is kept as `k=`, because lowerQueryHrefCall folds the
-// `ne value ""` check INTO the include flag, so the Go helper itself never
-// re-checks (the client / Perl omit empties in the helper instead).
+// (the golden file is monorepo-only), including the slice-typed value path the
+// JSON golden args can only exercise as []any (a compiled template passes a
+// []string field).
 func TestQuery(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -2038,9 +2037,14 @@ func TestQuery(t *testing.T) {
 		{"order + overwrite at first position", "/blog", []any{true, "sort", "title", true, "tag", "go", true, "sort", "date"}, "/blog?sort=date&tag=go"},
 		// formEscape (not url.QueryEscape): `~` → %7E, `*` kept, space → `+`.
 		{"form-encode ~ * space", "/s", []any{true, "t", "a~b *c"}, "/s?t=a%7Eb+*c"},
-		// Go-specific: an explicitly-included empty value is kept (no helper-side
-		// emptiness check); pinned as a divergence in the golden harness.
-		{"included-but-empty value is kept as k=", "/", []any{true, "tag", ""}, "/?tag="},
+		// An included-but-empty value is dropped (helper-side non-empty check,
+		// matching the client / Perl).
+		{"included-but-empty value is omitted", "/", []any{true, "tag", ""}, "/"},
+		// Array value ([]string, the compiled-template type) appends each
+		// non-empty member; an all-empty/empty array contributes nothing.
+		{"[]string value appends members", "/l", []any{true, "tag", []string{"a", "b"}}, "/l?tag=a&tag=b"},
+		{"empty members in a slice are skipped", "/l", []any{true, "tag", []string{"a", "", "b"}}, "/l?tag=a&tag=b"},
+		{"empty slice contributes nothing", "/l", []any{true, "sort", "name", true, "tag", []string{}}, "/l?sort=name"},
 	}
 	for _, tt := range tests {
 		if got := Query(tt.base, tt.triples...); got != tt.want {

--- a/packages/adapter-go-template/runtime/vectors_test.go
+++ b/packages/adapter-go-template/runtime/vectors_test.go
@@ -205,10 +205,6 @@ var vectorDivergences = map[string]vectorDivergence{
 		expect: "",
 		reason: "url.Values.Get returns \"\" for an absent key where JS URLSearchParams.get returns null; the ?? → or lowering folds both to the author default, so SSR output still matches",
 	},
-	"query/included-but-empty value is omitted": {
-		expect: "/?tag=",
-		reason: "Go's Query has no value-emptiness check: lowerQueryHrefCall folds `ne value \"\"` INTO the include flag (`and (cond) (ne value \"\")`), so the compiler never emits an included-empty triple. The Perl helper instead omits empties itself, so the two helpers split that responsibility; real SSR output matches the client on both.",
-	},
 }
 
 // vectorUnsupported marks helper ids this backend has not implemented

--- a/packages/adapter-go-template/src/__tests__/query-href.test.ts
+++ b/packages/adapter-go-template/src/__tests__/query-href.test.ts
@@ -3,10 +3,12 @@
  *
  * The pure functional URL builder is a structured `call` + `object-literal` in
  * the IR, so the adapter lowers it directly — no block-body recognizer, no
- * re-parse. Values are strings; inclusion mirrors the client `if (value)` over
- * strings: plain `key: v` → `(ne v "") "key" v`; conditional `key: cond ? a :
- * undefined` ≡ client `if (cond ? a : undefined)` → `(and (cond) (ne a "")) "key"
- * a` (include iff `cond` AND `a` is non-empty — not just `cond`).
+ * re-parse. The lowering emits `(include) "key" value` triples and lets the
+ * `bf_query` runtime helper own the non-empty check (so it can also append array
+ * values member-by-member, #2048): a plain `key: v` → `(true) "key" v`; a
+ * conditional `key: cond ? a : undefined` → `(cond) "key" a` (the helper drops an
+ * empty `a`). The full value semantics are conformance-tested against
+ * URLSearchParams in the shared golden vectors (TestHelperVectors, fn "query").
  */
 import { describe, test, expect } from 'bun:test'
 import { compileJSX, type ComponentIR } from '@barefootjs/jsx'
@@ -22,7 +24,7 @@ function generate(src: string) {
 }
 
 describe('queryHref → bf_query (#2042)', () => {
-  test('a plain value becomes a value-truthiness include triple', () => {
+  test('a plain value passes a `true` include — bf_query drops it if empty', () => {
     const src = `
 'use client'
 import { queryHref } from '@barefootjs/client'
@@ -31,11 +33,11 @@ export function P(props: { base: string; tag: string }) {
 }
 `
     const { template } = generate(src)
-    expect(template).toContain('bf_query .Base (ne .Tag "") "tag" .Tag')
+    expect(template).toContain('bf_query .Base (true) "tag" .Tag')
     expect(template).not.toContain('.QueryHref')
   })
 
-  test('a conditional include is `and (cond) (ne consequent "")` — matching client value-truthiness', () => {
+  test('a conditional include lowers to `(cond)` — the helper applies the non-empty check', () => {
     const src = `
 'use client'
 import { queryHref } from '@barefootjs/client'
@@ -50,16 +52,17 @@ export function P(props: { base: string; sort: string; tag: string }) {
 `
     const { template } = generate(src)
     expect(template).toContain(
-      'bf_query .Base (and (ne (bf_string .Sort) "date") (ne .Sort "")) "sort" .Sort (ne .Tag "") "tag" .Tag',
+      'bf_query .Base (ne (bf_string .Sort) "date") "sort" .Sort (true) "tag" .Tag',
     )
+    // The `ne consequent ""` non-empty check is no longer folded into the
+    // include — bf_query owns it (so it can also append array values).
+    expect(template).not.toContain('(ne .Sort "")')
   })
 
   // A `&&` / `||` guard is NOT a comparison, so `lowerUrlGuard` can't emit it as
   // a bare Go bool — `and`/`or` return one of their operands (a string), which
   // `bf_query` type-asserts against. It must take the truthiness-wrap path,
-  // `ne (and …) ""`, yielding a real bool. (This branch lost its dedicated test
-  // when the URLSearchParams recognizer fixture was retired; queryHref reaches it
-  // via a `cond && other ? a : undefined` guard. #2042 review.)
+  // `ne (and …) ""`, yielding a real bool.
   test('a `&&` guard is wrapped to a bool — `ne (and …) ""`, not a bare `and`', () => {
     const src = `
 'use client'
@@ -69,7 +72,7 @@ export function P(props: { base: string; a: string; b: string }) {
 }
 `
     const { template } = generate(src)
-    expect(template).toContain('bf_query .Base (and (ne (and .A .B) "") (ne .A "")) "both" .A')
+    expect(template).toContain('bf_query .Base (ne (and .A .B) "") "both" .A')
   })
 
   test('null / empty-string alternates are both treated as the omit branch', () => {
@@ -85,8 +88,35 @@ export function P(props: { base: string; mode: string; a: string; b: string }) {
 `
     const { template } = generate(src)
     // Both '' and null alternates fold to the same conditional-include form.
-    expect(template).toContain('(and (ne (bf_string .Mode) "off") (ne .A "")) "a" .A')
-    expect(template).toContain('(and (ne (bf_string .Mode) "off") (ne .B "")) "b" .B')
+    expect(template).toContain('(ne (bf_string .Mode) "off") "a" .A')
+    expect(template).toContain('(ne (bf_string .Mode) "off") "b" .B')
+  })
+
+  test('an array value lowers the slice expression; bf_query appends its members', () => {
+    const src = `
+'use client'
+import { queryHref } from '@barefootjs/client'
+export function P(props: { base: string; tags: string[] }) {
+  return <a href={queryHref(props.base, { tag: props.tags })}>x</a>
+}
+`
+    const { template } = generate(src)
+    // The value is the raw slice field; member-append + non-empty omit happen in
+    // the helper at render time (verified against URLSearchParams in the golden
+    // vectors). The old `ne value ""` fold would have been invalid Go here.
+    expect(template).toContain('bf_query .Base (true) "tag" .Tags')
+  })
+
+  test('a conditional array value keeps the guard and passes the slice', () => {
+    const src = `
+'use client'
+import { queryHref } from '@barefootjs/client'
+export function P(props: { base: string; on: string; tags: string[] }) {
+  return <a href={queryHref(props.base, { tag: props.on !== '' ? props.tags : undefined })}>x</a>
+}
+`
+    const { template } = generate(src)
+    expect(template).toContain('bf_query .Base (ne (bf_string .On) "") "tag" .Tags')
   })
 
   test('an aliased import is still recognised', () => {
@@ -112,7 +142,7 @@ export function P(props: { base: string }) {
 }
 `
     const { template } = generate(src)
-    expect(template).toContain('bf_query .Base (ne "home" "") "view" "home"')
+    expect(template).toContain('bf_query .Base (true) "view" "home"')
     expect(template).not.toContain('.HomeHref')
   })
 

--- a/packages/adapter-go-template/src/adapter/expr/url-builder.ts
+++ b/packages/adapter-go-template/src/adapter/expr/url-builder.ts
@@ -95,15 +95,15 @@ export function lowerQueryHrefCall(
     let includeGo: string
     let valueNode: ParsedExpr
     if (v.kind === 'conditional' && isOmitSentinel(v.alternate)) {
-      // `key: cond ? a : <omit>` ≡ client `if (cond ? a : undefined)` ≡
-      // `cond` truthy AND `a` non-empty.
-      const testBool = lowerUrlGuard(ctx, v.test)
-      const consGo = wrapIfMultiToken(lowerExpr(v.consequent))
-      includeGo = `and (${testBool}) (ne ${consGo} "")`
+      // `key: cond ? a : <omit>` → include on `cond`. The non-empty check is no
+      // longer folded in here: bf_query drops an included-but-empty value (and
+      // appends an array value member-by-member), matching the client / Perl.
+      includeGo = lowerUrlGuard(ctx, v.test)
       valueNode = v.consequent
     } else {
-      // `key: v` — include iff the (string) value is non-empty.
-      includeGo = lowerUrlGuard(ctx, v)
+      // `key: v` → always hand the value to bf_query, which omits it when empty
+      // (or array-empty) and appends array members.
+      includeGo = 'true'
       valueNode = v
     }
     parts.push(`(${includeGo})`)

--- a/packages/adapter-mojolicious/src/__tests__/query-href.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/query-href.test.ts
@@ -55,6 +55,21 @@ export function P(props: { base: string; flag: string; val: string }) {
     expect(t).toContain("bf->query($base, ($flag ne ''), 'q', $val)")
   })
 
+  // An array value (`{ tag: props.tags }`) lowers to the bare slice expression;
+  // the shared Perl `query` helper detects the arrayref at runtime and appends
+  // one pair per non-empty member (#2048). No adapter-side change beyond passing
+  // the value through.
+  test('an array value passes the slice expression for the helper to append', () => {
+    const t = template(`
+'use client'
+import { queryHref } from '@barefootjs/client'
+export function P(props: { base: string; tags: string[] }) {
+  return <a href={queryHref(props.base, { tag: props.tags })}>x</a>
+}
+`)
+    expect(t).toContain("bf->query($base, 1, 'tag', $tags)")
+  })
+
   test('an aliased import is recognised', () => {
     const t = template(`
 'use client'

--- a/packages/adapter-perl/lib/BarefootJS.pm
+++ b/packages/adapter-perl/lib/BarefootJS.pm
@@ -1017,8 +1017,14 @@ sub replace ($self, $recv, $pattern, $replacement) {
 # (value)` over string values: the adapter passes the guard `1` for a plain
 # `key: v`, or the lowered condition for `key: cond ? v : undefined`. Repeating a
 # key overwrites the value at its first position (`URLSearchParams.set`
-# semantics). Keys/values are form-encoded to equal the browser render
-# byte-for-byte; no surviving pair yields the bare base.
+# semantics).
+#
+# A value may instead be an array ref, which APPENDS one pair per non-empty
+# member (`{ tag => ['a','b'] }` → `tag=a&tag=b`, i.e. `URLSearchParams.append`);
+# empty members are skipped, so an empty/all-empty array contributes nothing.
+#
+# Keys/values are form-encoded to equal the browser render byte-for-byte; no
+# surviving pair yields the bare base.
 sub query ($self, $base, @triples) {
     my $b = defined $base && !ref($base) ? "$base" : '';
     my (@pairs, %pos);
@@ -1028,6 +1034,16 @@ sub query ($self, $base, @triples) {
         $i += 3;
         next unless $guard;
         $key = defined $key && !ref($key) ? "$key" : '';
+        if (ref($val) eq 'ARRAY') {
+            # Append each non-empty member; appended pairs never overwrite, so
+            # they don't participate in the set()-position map.
+            for my $m (@$val) {
+                my $s = defined $m && !ref($m) ? "$m" : '';
+                next if $s eq '';
+                push @pairs, [$key, $s];
+            }
+            next;
+        }
         $val = defined $val && !ref($val) ? "$val" : '';
         next if $val eq '';
         if (exists $pos{$key}) {

--- a/packages/adapter-perl/t/query.t
+++ b/packages/adapter-perl/t/query.t
@@ -35,6 +35,11 @@ is $bf->query('/blog', 1, 'sort', 'title', 1, 'tag', 'go', 1, 'sort', 'date'),
 # not Go's url.QueryEscape).
 is $bf->query('/s', 1, 't', 'a~b *c'), '/s?t=a%7Eb+*c', 'form-encode: ~ → %7E, * kept, space → +';
 
+# Representative array value: an array ref appends one pair per non-empty member
+# (#2048), skipping empties.
+is $bf->query('/list', 1, 'tag', ['a', '', 'b']), '/list?tag=a&tag=b',
+    'array value appends a pair per non-empty member';
+
 # Perl-specific: an `undef` value is coerced to '' and then omitted, without
 # disturbing the surrounding pairs.
 is $bf->query('/list', 1, 'tag', undef), '/list', 'undef value coerced to empty → omitted';

--- a/packages/adapter-tests/helper-vectors/cases.ts
+++ b/packages/adapter-tests/helper-vectors/cases.ts
@@ -71,18 +71,27 @@ export const reference: Record<string, (...args: never[]) => unknown> = {
 
   // queryHref()'s URL builder (#2042) as the SSR `query` / `bf_query` helper
   // receives it: a base plus a flat list of (include, key, value) triples. A
-  // pair is included iff its `include` flag is truthy AND its value is a
-  // non-empty string; a repeated key overwrites at its first position
-  // (URLSearchParams.set). The reference encodes through URLSearchParams, so the
-  // Go (bf.Query) and Perl (BarefootJS::query) backends are held to byte-
-  // identical form-encoding — space → '+', '~' → %7E, '*' kept, UTF-8 byte-wise
-  // — the parity #2048 aligns the Go backend's encoder to.
+  // pair is kept iff its `include` flag is truthy AND its value is non-empty; a
+  // repeated key overwrites at its first position (URLSearchParams.set). A value
+  // may instead be an array, appending one pair per non-empty member
+  // (URLSearchParams.append, #2048). The reference encodes through
+  // URLSearchParams, so the Go (bf.Query) and Perl (BarefootJS::query) backends
+  // are held to byte-identical form-encoding — space → '+', '~' → %7E, '*' kept,
+  // UTF-8 byte-wise.
   query: (base: string, ...triples: unknown[]) => {
     const params = new URLSearchParams()
     for (let i = 0; i + 2 < triples.length; i += 3) {
       if (!triples[i]) continue
       const key = String(triples[i + 1])
-      const val = String(triples[i + 2])
+      const value = triples[i + 2]
+      if (Array.isArray(value)) {
+        for (const member of value) {
+          const m = String(member)
+          if (m !== '') params.append(key, m)
+        }
+        continue
+      }
+      const val = String(value)
       if (val === '') continue
       params.set(key, val)
     }
@@ -542,4 +551,12 @@ export const cases: HelperCase[] = [
   { fn: 'query', args: ['/s', true, 'q', 'a b', true, 'x y', 'c&d'], note: 'form-encode: space to + in key and value, & to %26' },
   { fn: 'query', args: ['/s', true, 'q', 'café'], note: 'form-encode: UTF-8 byte-wise' },
   { fn: 'query', args: ['/s', true, 't', '100%~free*'], note: 'form-encode: % ~ * together' },
+  // Array values append one pair per non-empty member (URLSearchParams.append, #2048).
+  { fn: 'query', args: ['/list', true, 'tag', ['a', 'b']], note: 'array value appends one pair per member' },
+  { fn: 'query', args: ['/list', true, 'sort', 'name', true, 'tag', ['a', 'b']], note: 'array interleaves with a scalar pair in order' },
+  { fn: 'query', args: ['/list', true, 'tag', ['a', '', 'b']], note: 'empty array members are skipped' },
+  { fn: 'query', args: ['/list', true, 'tag', []], note: 'empty array contributes nothing' },
+  { fn: 'query', args: ['/list', true, 'sort', 'name', true, 'tag', []], note: 'array reduced to nothing leaves the scalar' },
+  { fn: 'query', args: ['/s', true, 'tag', ['a b', 'c~d*']], note: 'array members are form-encoded like scalars' },
+  { fn: 'query', args: ['/list', false, 'tag', ['a', 'b']], note: 'excluded array contributes nothing' },
 ]

--- a/packages/adapter-tests/helper-vectors/vectors.json
+++ b/packages/adapter-tests/helper-vectors/vectors.json
@@ -2860,6 +2860,105 @@
       ],
       "expect": "/s?t=100%25%7Efree*",
       "note": "form-encode: % ~ * together"
+    },
+    {
+      "fn": "query",
+      "args": [
+        "/list",
+        true,
+        "tag",
+        [
+          "a",
+          "b"
+        ]
+      ],
+      "expect": "/list?tag=a&tag=b",
+      "note": "array value appends one pair per member"
+    },
+    {
+      "fn": "query",
+      "args": [
+        "/list",
+        true,
+        "sort",
+        "name",
+        true,
+        "tag",
+        [
+          "a",
+          "b"
+        ]
+      ],
+      "expect": "/list?sort=name&tag=a&tag=b",
+      "note": "array interleaves with a scalar pair in order"
+    },
+    {
+      "fn": "query",
+      "args": [
+        "/list",
+        true,
+        "tag",
+        [
+          "a",
+          "",
+          "b"
+        ]
+      ],
+      "expect": "/list?tag=a&tag=b",
+      "note": "empty array members are skipped"
+    },
+    {
+      "fn": "query",
+      "args": [
+        "/list",
+        true,
+        "tag",
+        []
+      ],
+      "expect": "/list",
+      "note": "empty array contributes nothing"
+    },
+    {
+      "fn": "query",
+      "args": [
+        "/list",
+        true,
+        "sort",
+        "name",
+        true,
+        "tag",
+        []
+      ],
+      "expect": "/list?sort=name",
+      "note": "array reduced to nothing leaves the scalar"
+    },
+    {
+      "fn": "query",
+      "args": [
+        "/s",
+        true,
+        "tag",
+        [
+          "a b",
+          "c~d*"
+        ]
+      ],
+      "expect": "/s?tag=a+b&tag=c%7Ed*",
+      "note": "array members are form-encoded like scalars"
+    },
+    {
+      "fn": "query",
+      "args": [
+        "/list",
+        false,
+        "tag",
+        [
+          "a",
+          "b"
+        ]
+      ],
+      "expect": "/list",
+      "note": "excluded array contributes nothing"
     }
   ]
 }

--- a/packages/adapter-xslate/src/__tests__/query-href.test.ts
+++ b/packages/adapter-xslate/src/__tests__/query-href.test.ts
@@ -57,6 +57,21 @@ export function P(props: { base: string; flag: string; val: string }) {
     expect(t).toContain("$bf.query($base, ($flag != ''), 'q', $val)")
   })
 
+  // An array value (`{ tag: props.tags }`) lowers to the bare slice expression;
+  // the shared Perl `query` helper detects the arrayref at runtime and appends
+  // one pair per non-empty member (#2048). No adapter-side change beyond passing
+  // the value through.
+  test('an array value passes the slice expression for the helper to append', () => {
+    const t = template(`
+'use client'
+import { queryHref } from '@barefootjs/client'
+export function P(props: { base: string; tags: string[] }) {
+  return <a href={queryHref(props.base, { tag: props.tags })}>x</a>
+}
+`)
+    expect(t).toContain("$bf.query($base, 1, 'tag', $tags)")
+  })
+
   test('an aliased import is recognised', () => {
     const t = template(`
 'use client'

--- a/packages/client/__tests__/query-href.test.ts
+++ b/packages/client/__tests__/query-href.test.ts
@@ -32,9 +32,29 @@ describe('queryHref', () => {
 
   test('a conditional whose consequent is empty is still omitted (matches the SSR guard)', () => {
     // `cond ? '' : undefined` → `if ('')` → omitted, even though `cond` holds.
-    // The SSR lowering must mirror this with `and (cond) (ne v "")`, not `(cond)`.
+    // The SSR lowering mirrors this by passing `(cond)` as the include flag and
+    // letting the query helper omit the empty value (the same non-empty check it
+    // applies to a plain `key: v`).
     const build = (sort: string) => queryHref('/list', { sort: sort !== 'date' ? sort : undefined })
     expect(build('')).toBe('/list') // sort='' is !== 'date' (cond true) but value empty → omit
+  })
+
+  test('an array value appends one entry per non-empty member (URLSearchParams.append)', () => {
+    expect(queryHref('/list', { tag: ['a', 'b'] })).toBe('/list?tag=a&tag=b')
+    // Interleaves with scalar params in insertion order.
+    expect(queryHref('/list', { sort: 'name', tag: ['a', 'b'] })).toBe('/list?sort=name&tag=a&tag=b')
+  })
+
+  test('empty array members are skipped (truthy-omit); an all-empty array contributes nothing', () => {
+    expect(queryHref('/list', { tag: ['a', '', 'b'] })).toBe('/list?tag=a&tag=b')
+    expect(queryHref('/list', { tag: [] })).toBe('/list')
+    expect(queryHref('/list', { tag: ['', ''] })).toBe('/list')
+    // An array reduced to nothing leaves only the surviving scalar.
+    expect(queryHref('/list', { sort: 'name', tag: [] })).toBe('/list?sort=name')
+  })
+
+  test('array members are form-encoded like scalars', () => {
+    expect(queryHref('/s', { tag: ['a b', 'c~d*'] })).toBe('/s?tag=a+b&tag=c%7Ed*')
   })
 
   test('form-encodes keys and values like URLSearchParams (space → +)', () => {

--- a/packages/client/src/query-href.ts
+++ b/packages/client/src/query-href.ts
@@ -16,6 +16,12 @@
  * survive. Values are encoded with `URLSearchParams` (form-encoding, spaces →
  * `+`).
  *
+ * A value may also be a **`string[]`**, which appends one entry per non-empty
+ * member (`{ tag: ['a', 'b'] }` → `?tag=a&tag=b`), i.e. `URLSearchParams.append`
+ * rather than `set`. Empty / falsy members are skipped (same truthy-omit as a
+ * scalar), so an empty array — or one whose members are all empty — contributes
+ * nothing.
+ *
  * Values are **strings** (`QueryParamValue`). Number / boolean aren't accepted:
  * JS truthiness would omit `0` / `false`, which the SSR adapters' string guard
  * can't model without per-value type info — so keeping values string-only
@@ -27,13 +33,17 @@
  * `queryHref(base, { … })` call to their query helper (go-template: `bf_query`),
  * which is why the params object must be a plain object literal at the call site.
  */
-export type QueryParamValue = string | null | undefined
+export type QueryParamValue = string | string[] | null | undefined
 export type QueryParams = Record<string, QueryParamValue>
 
 export function queryHref(base: string, params: QueryParams): string {
   const u = new URLSearchParams()
   for (const [key, value] of Object.entries(params)) {
-    if (value) u.set(key, value)
+    if (Array.isArray(value)) {
+      for (const member of value) if (member) u.append(key, member)
+    } else if (value) {
+      u.set(key, value)
+    }
   }
   const qs = u.toString()
   return qs ? `${base}?${qs}` : base


### PR DESCRIPTION
## Summary

Implements **Q4** from #2048 (the last `queryHref` follow-up to #2042): `queryHref` now accepts an **array value** for multi-value query keys.

```tsx
queryHref('/list', { tag: ['a', 'b'] })            // → /list?tag=a&tag=b
queryHref('/list', { sort: 'name', tag: ['a','b'] }) // → /list?sort=name&tag=a&tag=b
```

An array value appends one entry per **non-empty** member (`URLSearchParams.append`, not `set`). Empty / falsy members are skipped — same truthy-omit as a scalar — so an empty (or all-empty) array contributes nothing. `QueryParamValue` becomes `string | string[] | null | undefined`.

Works byte-for-byte across the client and every SSR backend (Hono ≡ Go ≡ Mojo ≡ Xslate).

## Changes

- **`@barefootjs/client`** — `queryHref` appends each non-empty array member.
- **`@barefootjs/perl`** (Mojolicious + Xslate via the shared `query` helper) — an array ref appends one pair per non-empty member. No Mojo/Xslate adapter code change: the value passes through and the runtime helper detects the array.
- **`@barefootjs/go-template`** — `bf_query` appends each non-empty member of a `[]string` / `[]any` value (`asStringSlice`). To enable this, the value-emptiness check **moved from the lowering into the `bf_query` helper**: a plain `key: v` now lowers to a `(true)` include and a conditional to `(cond)`, and the helper drops an included-but-empty value.

## Behaviour note (Go unification)

Folding `ne value ""` into the include flag at lowering time can't work when the value is an array (`ne <slice> ""` is invalid), so the non-empty check now lives in the helper for all values — matching what the Perl/Mojo/Xslate helper already did. This:

- keeps **scalar** render output identical, and
- **removes the previous Go-only divergence** (an explicitly-included empty value was kept as `k=`; it's now omitted, matching the client / Perl). The corresponding golden-vector divergence pin is removed.

## Test plan

- Client `queryHref` unit tests (array append, empty-member skip, empty array, form-encoding).
- Go `TestQuery` + adapter lowering tests (plain `(true)`, conditional `(cond)`, `[]string` append, slice expression lowering).
- Perl `t/query.t` array case + shared golden helper vectors (`fn: query`, 7 new array cases) run by **both** the Go (`TestHelperVectors`) and Perl (`t/helper_vectors.t`) harnesses.
- Mojo / Xslate lowering tests (array value passes the slice expression).
- `go test ./...`, `gofmt`, `go vet`, Biome, freshness test all green.

Closes #2048.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkK14npEtF2TnALVYt1nec)_