### PR TITLE
feat(jsx): normalize value-producing block-bodied callbacks to expressions (#2040)

### DIFF
--- a/.changeset/block-expr-normalization.md
+++ b/.changeset/block-expr-normalization.md
@@ -1,0 +1,14 @@
+---
+"@barefootjs/jsx": minor
+---
+
+Normalize value-producing block-bodied callbacks into a single expression (#2040, carved from #2018 stage 5). A higher-order callback (`.sort` / `.reduce` / `.find` / `.some` / `.every` / `.flatMap` …) written with a `{ … }` block body now folds to an expression when its body is purely-functionally expressible, instead of being refused with "only single-`return` block-body functions are supported":
+
+- **let-inline** — pure `const` bindings inline into the expression that uses them.
+- **early-return / value `if`** — `if (c) return A; return B` (and `if/else`, `else if` chains) become a ternary in value position.
+
+The folded expression flows through the existing `ParsedExpr` surface (the #2018 callback evaluator / template-native lowering), so no new IR statement shapes are carried.
+
+Genuinely **imperative** block bodies — raw `for` / `while` loops, `break`, local re-assignment / mutable state, side-effecting or I/O calls — have no value-position lowering and stay `unsupported`, surfacing the adapter's BF101 with an actionable message (rewrite an accumulation loop as `.reduce(...)`, or move the body to a `/* @client */` value that runs natively on the client).
+
+New public helper `foldBlockToExpr(ParsedStatement[])` performs the normalization; `convertNode`'s arrow path uses it. The single-`return` fast path is unchanged, so existing output is byte-identical.

--- a/docs/core/rendering/jsx-compatibility.md
+++ b/docs/core/rendering/jsx-compatibility.md
@@ -156,16 +156,30 @@ Some JavaScript expressions cannot be translated into marked template syntax. Wh
 
 ### Patterns that error on all adapters
 
-**Unsupported sort comparators** (multi-statement block bodies, function references):
+**Unsupported sort comparators** (imperative block bodies, function references):
+
+A value-producing block body normalizes to an expression — pure `const`
+bindings inline (let-inline) and a value-producing `if` / early `return`
+becomes a ternary — so it lowers on all adapters just like the expression form:
+
+```tsx
+// ✅ Value-producing block bodies normalize (let-inline) and lower everywhere
+{items().sort((a, b) => { const an = a.name; return an > b.name ? 1 : -1 }).map(item => (
+  <Item key={item.id} item={item} />
+))}
+```
+
+Only a genuinely imperative comparator — one that re-assigns a local, loops, or
+`break`s — has no value-position lowering and errors:
 
 ```tsx
 // ❌ BF021 (all adapters)
-{items().sort((a, b) => { const an = a.name; return an > b.name ? 1 : -1 }).map(item => (
+{items().sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }).map(item => (
   <Item key={item.id} item={item} />
 ))}
 
 // ✅ Use /* @client */
-{/* @client */ items().sort((a, b) => { const an = a.name; return an > b.name ? 1 : -1 }).map(item => (
+{/* @client */ items().sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }).map(item => (
   <Item key={item.id} item={item} />
 ))}
 ```

--- a/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
+++ b/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
@@ -943,7 +943,7 @@ hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:
 export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
 `;
 
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L168 — ✅ Use /* @client */ 1`] = `
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L167 — ✅ Value-producing block bodies normalize (let-inline) and lower everywhere 1`] = `
 "import { $, $t, __bfText, createComponent, createEffect, createSignal, escapeText, hydrate, initChild, mapArray, renderChild } from '@barefootjs/client/runtime'
 
 export function initTodoItem(__scope, _p = {}) {
@@ -997,14 +997,79 @@ export function initExample(__scope, _p = {}) {
 
   const [_s1] = $(__scope, 's1')
 
-  mapArray(() => items().sort((a, b) => { const an = a.name; return an > b.name ? 1 : -1 }), _s1, (item) => String(item.id), (item, __idx, __existing) => {
+  mapArray(() => items().toSorted((a, b) => a.name > b.name ? 1 : -1), _s1, (item) => String(item.id), (item, __idx, __existing) => {
     if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
     return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
   }, 'l0')
 
 }
 
-hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).sort((a, b) => { const an = a.name; return an > b.name ? 1 : -1 }).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).toSorted((a, b) => a.name > b.name ? 1 : -1).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L182 — ✅ Use /* @client */ 1`] = `
+"import { $, $t, __bfText, createComponent, createEffect, createSignal, escapeText, hydrate, initChild, mapArray, renderChild } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const [_s0] = $t(__scope, 's0')
+
+  let __anchor_s0 = _s0
+  createEffect(() => {
+    const __val = String(_p.todo)
+    __anchor_s0 = __bfText(__anchor_s0, __val)
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\` })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const [_s0] = $t(__scope, 's0')
+
+  let __anchor_s0 = _s0
+  createEffect(() => {
+    const __val = String(_p.item)
+    __anchor_s0 = __bfText(__anchor_s0, __val)
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\` })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\` })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const children = _p.children
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  const [_s1] = $(__scope, 's1')
+
+  mapArray(() => items().sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }), _s1, (item) => String(item.id), (item, __idx, __existing) => {
+    if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
+    return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
+  }, 'l0')
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
 export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
 `;
 
@@ -5204,134 +5269,4 @@ export function initCounter(__scope, _p = {}) {
 
 hydrate('Counter', { init: initCounter, template: (_p) => \`<button bf="s1"> Count: <!--bf:s0-->\${escapeText((0))}<!--/--></button>\` })
 export function Counter(_p, __bfKey) { return createComponent('Counter', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L167 — ✅ Value-producing block bodies normalize (let-inline) and lower everywhere 1`] = `
-"import { $, $t, __bfText, createComponent, createEffect, createSignal, escapeText, hydrate, initChild, mapArray, renderChild } from '@barefootjs/client/runtime'
-
-export function initTodoItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const [_s0] = $t(__scope, 's0')
-
-  let __anchor_s0 = _s0
-  createEffect(() => {
-    const __val = String(_p.todo)
-    __anchor_s0 = __bfText(__anchor_s0, __val)
-  })
-
-}
-
-hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\` })
-export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
-export function initItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const [_s0] = $t(__scope, 's0')
-
-  let __anchor_s0 = _s0
-  createEffect(() => {
-    const __val = String(_p.item)
-    __anchor_s0 = __bfText(__anchor_s0, __val)
-  })
-
-}
-
-hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\` })
-export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
-function initDashboard() {}
-
-hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\` })
-export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
-export function initExample(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const children = _p.children
-  const [count, setCount] = createSignal(0)
-  const [isLoggedIn] = createSignal(false)
-  const [todos] = createSignal([])
-  const [items] = createSignal([])
-  const [filter] = createSignal('all')
-  const [accepted] = createSignal(false)
-  const [text, setText] = createSignal('')
-
-  const [_s1] = $(__scope, 's1')
-
-  mapArray(() => items().toSorted((a, b) => a.name > b.name ? 1 : -1), _s1, (item) => String(item.id), (item, __idx, __existing) => {
-    if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
-    return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
-  }, 'l0')
-
-}
-
-hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).toSorted((a, b) => a.name > b.name ? 1 : -1).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
-export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
-`;
-
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L182 — ✅ Use /* @client */ 1`] = `
-"import { $, $t, __bfText, createComponent, createEffect, createSignal, escapeText, hydrate, initChild, mapArray, renderChild } from '@barefootjs/client/runtime'
-
-export function initTodoItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const [_s0] = $t(__scope, 's0')
-
-  let __anchor_s0 = _s0
-  createEffect(() => {
-    const __val = String(_p.todo)
-    __anchor_s0 = __bfText(__anchor_s0, __val)
-  })
-
-}
-
-hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\` })
-export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
-export function initItem(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const [_s0] = $t(__scope, 's0')
-
-  let __anchor_s0 = _s0
-  createEffect(() => {
-    const __val = String(_p.item)
-    __anchor_s0 = __bfText(__anchor_s0, __val)
-  })
-
-}
-
-hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\` })
-export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
-function initDashboard() {}
-
-hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\` })
-export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
-export function initExample(__scope, _p = {}) {
-  if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
-
-  const children = _p.children
-  const [count, setCount] = createSignal(0)
-  const [isLoggedIn] = createSignal(false)
-  const [todos] = createSignal([])
-  const [items] = createSignal([])
-  const [filter] = createSignal('all')
-  const [accepted] = createSignal(false)
-  const [text, setText] = createSignal('')
-
-  const [_s1] = $(__scope, 's1')
-
-  mapArray(() => items().sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }), _s1, (item) => String(item.id), (item, __idx, __existing) => {
-    if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
-    return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
-  }, 'l0')
-
-}
-
-hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
-export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
 `;

--- a/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
+++ b/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
@@ -5205,3 +5205,133 @@ export function initCounter(__scope, _p = {}) {
 hydrate('Counter', { init: initCounter, template: (_p) => \`<button bf="s1"> Count: <!--bf:s0-->\${escapeText((0))}<!--/--></button>\` })
 export function Counter(_p, __bfKey) { return createComponent('Counter', _p, __bfKey) }"
 `;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L167 — ✅ Value-producing block bodies normalize (let-inline) and lower everywhere 1`] = `
+"import { $, $t, __bfText, createComponent, createEffect, createSignal, escapeText, hydrate, initChild, mapArray, renderChild } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const [_s0] = $t(__scope, 's0')
+
+  let __anchor_s0 = _s0
+  createEffect(() => {
+    const __val = String(_p.todo)
+    __anchor_s0 = __bfText(__anchor_s0, __val)
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\` })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const [_s0] = $t(__scope, 's0')
+
+  let __anchor_s0 = _s0
+  createEffect(() => {
+    const __val = String(_p.item)
+    __anchor_s0 = __bfText(__anchor_s0, __val)
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\` })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\` })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const children = _p.children
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  const [_s1] = $(__scope, 's1')
+
+  mapArray(() => items().toSorted((a, b) => a.name > b.name ? 1 : -1), _s1, (item) => String(item.id), (item, __idx, __existing) => {
+    if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
+    return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
+  }, 'l0')
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).toSorted((a, b) => a.name > b.name ? 1 : -1).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L182 — ✅ Use /* @client */ 1`] = `
+"import { $, $t, __bfText, createComponent, createEffect, createSignal, escapeText, hydrate, initChild, mapArray, renderChild } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const [_s0] = $t(__scope, 's0')
+
+  let __anchor_s0 = _s0
+  createEffect(() => {
+    const __val = String(_p.todo)
+    __anchor_s0 = __bfText(__anchor_s0, __val)
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\` })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const [_s0] = $t(__scope, 's0')
+
+  let __anchor_s0 = _s0
+  createEffect(() => {
+    const __val = String(_p.item)
+    __anchor_s0 = __bfText(__anchor_s0, __val)
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\` })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\` })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const children = _p.children
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  const [_s1] = $(__scope, 's1')
+
+  mapArray(() => items().sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }), _s1, (item) => String(item.id), (item, __idx, __existing) => {
+    if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
+    return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
+  }, 'l0')
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -2068,4 +2068,30 @@ describe('foldBlockToExpr', () => {
     const folded = foldBlockToExpr(stmts)
     expect(folded.ok).toBe(true)
   })
+
+  // Soundness: an impure init must be evaluated once on EVERY path, not just
+  // "at most once on some path" (PR #2051 re-review). A binding used in only one
+  // ternary arm is dropped on the other arm even though `max` uses is 1.
+  test('refuses a possibly-impure init used on only one branch (then)', () => {
+    const stmts = parseBlock('{ const d = next(); if (c) return d; return 0 }')!
+    expect(foldBlockToExpr(stmts).ok).toBe(false)
+  })
+
+  test('refuses a possibly-impure init used on only one branch (else)', () => {
+    const stmts = parseBlock('{ const d = next(); if (c) return 0; return d }')!
+    expect(foldBlockToExpr(stmts).ok).toBe(false)
+  })
+
+  test('refuses a possibly-impure init behind a short-circuiting operand', () => {
+    // `c && next()` skips the call when `c` is falsy; the original always calls
+    // it once.
+    const stmts = parseBlock('{ const d = next(); return c && d }')!
+    expect(foldBlockToExpr(stmts).ok).toBe(false)
+  })
+
+  test('allows a possibly-impure init evaluated unconditionally before a short-circuit', () => {
+    // `next() && c` always evaluates the call exactly once (left operand).
+    const stmts = parseBlock('{ const d = next(); return d && c }')!
+    expect(foldBlockToExpr(stmts).ok).toBe(true)
+  })
 })

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -2028,4 +2028,44 @@ describe('foldBlockToExpr', () => {
     const stmts = parseBlock('{ let y = 1; y = y + 1; return y }')
     expect(stmts).toBeNull()
   })
+
+  // Soundness: let-inline must not be hygienic-blind or duplicate/drop effects
+  // (PR #2051 review).
+  test('refuses substitution that would capture a var under a nested callback param', () => {
+    // `x` is bound to the outer `a`; inlining into `list.map(a => a + x)` would
+    // capture the outer `a` under the inner `map` param `a`. Refuse rather than
+    // silently miscompile to `a + a`.
+    const stmts = parseBlock('{ const x = a; return list.map(a => a + x) }')!
+    expect(foldBlockToExpr(stmts).ok).toBe(false)
+  })
+
+  test('refuses a possibly-impure init used more than once (double-eval)', () => {
+    const stmts = parseBlock('{ const d = next(); return d + d }')!
+    expect(foldBlockToExpr(stmts).ok).toBe(false)
+  })
+
+  test('refuses a possibly-impure init that is never used (dropped effect)', () => {
+    const stmts = parseBlock('{ const _ = log(); return a - b }')!
+    expect(foldBlockToExpr(stmts).ok).toBe(false)
+  })
+
+  test('refuses a possibly-impure init referenced inside a callback (per-element eval)', () => {
+    const stmts = parseBlock('{ const d = next(); return arr.map(x => x + d) }')!
+    expect(foldBlockToExpr(stmts).ok).toBe(false)
+  })
+
+  test('allows a possibly-impure init used exactly once (eval-count preserved)', () => {
+    const stmts = parseBlock('{ const d = next(); return d }')!
+    const folded = foldBlockToExpr(stmts)
+    expect(folded.ok).toBe(true)
+    expect(folded.ok && folded.expr).toEqual({ kind: 'call', callee: { kind: 'identifier', name: 'next' }, args: [] })
+  })
+
+  test('allows a pure init used many times (signal-getter / member access)', () => {
+    // A pure init is safe to inline at any number of sites — `filter()` read
+    // once in the condition is the canonical case; a member access twice is fine.
+    const stmts = parseBlock('{ const n = item.n; return n > 0 ? n : 0 }')!
+    const folded = foldBlockToExpr(stmts)
+    expect(folded.ok).toBe(true)
+  })
 })

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test'
 import ts from 'typescript'
-import { parseExpression, isSupported, exprToString, stringifyParsedExpr, parseBlockBody, extractArrowBodyExpression, parseStyleObjectEntries, parseProviderObjectLiteral, asCallbackMethodCall, containsHigherOrder } from '../expression-parser'
+import { parseExpression, isSupported, exprToString, stringifyParsedExpr, parseBlockBody, foldBlockToExpr, extractArrowBodyExpression, parseStyleObjectEntries, parseProviderObjectLiteral, asCallbackMethodCall, containsHigherOrder } from '../expression-parser'
 import { collectAllTypeRanges, reconstructWithoutTypes } from '../strip-types'
 
 describe('expression-parser', () => {
@@ -1215,8 +1215,28 @@ describe('expression-parser', () => {
       expect(cb!.arrow.body.kind).toBe('member')
     })
 
-    test('rejects function-keyword filter with multiple statements (#1443)', () => {
+    // #2040: a value-producing multi-statement block body (pure `const`
+    // bindings + a terminal `return`) is normalised to a single expression via
+    // let-inline, so the higher-order detector recognises it. Previously the
+    // "only single-`return`" restriction refused it.
+    test('folds function-keyword filter with let-inline block body (#2040)', () => {
       const result = parseExpression('todos().filter(function (x) { const y = x; return y.done })')
+      const cb = asCallbackMethodCall(result)
+      expect(cb).not.toBeNull()
+      expect(cb!.arrow.params[0]).toBe('x')
+      // `const y = x; return y.done` inlines to `x.done`.
+      expect(cb!.arrow.body).toEqual({
+        kind: 'member',
+        object: { kind: 'identifier', name: 'x' },
+        property: 'done',
+        computed: false,
+      })
+    })
+
+    // #2040: an imperative block body (local re-assignment / mutation) has no
+    // value-position lowering and stays `unsupported`.
+    test('rejects function-keyword filter with imperative block body (#2040)', () => {
+      const result = parseExpression('todos().filter(function (x) { let y = 0; y = x.n; return y })')
       expect(result.kind).toBe('call')
       expect(asCallbackMethodCall(result)).toBeNull()
     })
@@ -1910,5 +1930,102 @@ describe('parseStyleObjectEntries', () => {
 
   test('returns null for a non-object source', () => {
     expect(parseStyleObjectEntries('color')).toBeNull()
+  })
+})
+
+// =============================================================================
+// Block → Expression Normalization (#2040)
+// =============================================================================
+
+describe('foldBlockToExpr', () => {
+  // Parse `{ … }` block source into ParsedStatement[] for the fold under test.
+  function parseBlock(blockSrc: string) {
+    const sf = ts.createSourceFile('b.ts', `(() => ${blockSrc})`, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
+    const stmt = sf.statements[0]
+    if (!ts.isExpressionStatement(stmt)) throw new Error('expected expression statement')
+    let expr = stmt.expression
+    while (ts.isParenthesizedExpression(expr)) expr = expr.expression
+    if (!ts.isArrowFunction(expr) || !ts.isBlock(expr.body)) throw new Error('expected block-body arrow')
+    return parseBlockBody(expr.body, sf, n => n.getText(sf))
+  }
+
+  test('let-inline: a const binding inlines into the returned expression', () => {
+    const stmts = parseBlock('{ const x = a + 1; return x * 2 }')!
+    const folded = foldBlockToExpr(stmts)
+    expect(folded.ok).toBe(true)
+    // `x` is replaced by `a + 1` in `x * 2`, giving the `*`-over-`+` tree.
+    expect(folded.ok && folded.expr).toEqual({
+      kind: 'binary',
+      op: '*',
+      left: { kind: 'binary', op: '+', left: { kind: 'identifier', name: 'a' }, right: { kind: 'literal', value: 1, literalType: 'number', raw: '1' } },
+      right: { kind: 'literal', value: 2, literalType: 'number', raw: '2' },
+    })
+  })
+
+  test('chained let-inline: later bindings see earlier ones', () => {
+    const stmts = parseBlock('{ const a = x + 1; const b = a * 2; return b }')!
+    const folded = foldBlockToExpr(stmts)
+    expect(folded.ok).toBe(true)
+    expect(folded.ok && folded.expr).toEqual({
+      kind: 'binary',
+      op: '*',
+      left: { kind: 'binary', op: '+', left: { kind: 'identifier', name: 'x' }, right: { kind: 'literal', value: 1, literalType: 'number', raw: '1' } },
+      right: { kind: 'literal', value: 2, literalType: 'number', raw: '2' },
+    })
+  })
+
+  test('early return: `if (c) return A; return B` → ternary', () => {
+    const stmts = parseBlock("{ if (f() === 'active') return !t.done; return true }")!
+    const folded = foldBlockToExpr(stmts)
+    expect(folded.ok).toBe(true)
+    expect(folded.ok && folded.expr.kind).toBe('conditional')
+    // `stringifyParsedExpr` normalises string literals to double quotes.
+    expect(folded.ok && stringifyParsedExpr(folded.expr)).toBe('f() === "active" ? !t.done : true')
+  })
+
+  test('if/else: both branches return → ternary', () => {
+    const stmts = parseBlock('{ if (c) { return 1 } else { return 2 } }')!
+    const folded = foldBlockToExpr(stmts)
+    expect(folded.ok).toBe(true)
+    expect(folded.ok && stringifyParsedExpr(folded.expr)).toBe('c ? 1 : 2')
+  })
+
+  test('else-if chain → right-nested ternary', () => {
+    const stmts = parseBlock('{ if (a()) return 1; else if (b()) return 2; return 3 }')!
+    const folded = foldBlockToExpr(stmts)
+    expect(folded.ok).toBe(true)
+    expect(folded.ok && stringifyParsedExpr(folded.expr)).toBe('a() ? 1 : b() ? 2 : 3')
+  })
+
+  test('let-inline before an early return is visible in both ternary arms', () => {
+    const stmts = parseBlock("{ const f = filter(); if (f === 'active') return !t.done; return true }")!
+    const folded = foldBlockToExpr(stmts)
+    expect(folded.ok).toBe(true)
+    expect(folded.ok && stringifyParsedExpr(folded.expr)).toBe('filter() === "active" ? !t.done : true')
+  })
+
+  test('refuses a block that falls through without returning a value', () => {
+    const stmts = parseBlock('{ const x = 1 }')!
+    const folded = foldBlockToExpr(stmts)
+    expect(folded.ok).toBe(false)
+  })
+
+  test('refuses an `if` whose branch does not produce a value (side-effect only)', () => {
+    const stmts = parseBlock('{ if (c) { const z = 1 } return 0 }')
+    // `{ const z = 1 }` is a value-less then-branch that falls through to the
+    // trailing `return 0`; the fold still produces `c ? 0 : 0` since the
+    // then-branch continues into the rest. A genuinely imperative shape is the
+    // reassignment case below, which `parseBlockBody` cannot even represent.
+    expect(stmts).not.toBeNull()
+  })
+
+  test('parseBlockBody returns null for an imperative statement (for loop)', () => {
+    const stmts = parseBlock('{ let s = 0; for (const x of arr) s += x; return s }')
+    expect(stmts).toBeNull()
+  })
+
+  test('parseBlockBody returns null for a local re-assignment', () => {
+    const stmts = parseBlock('{ let y = 1; y = y + 1; return y }')
+    expect(stmts).toBeNull()
   })
 })

--- a/packages/jsx/src/__tests__/unsupported-expression.test.ts
+++ b/packages/jsx/src/__tests__/unsupported-expression.test.ts
@@ -216,10 +216,11 @@ describe('Unsupported Sort Comparator (BF021)', () => {
     expect(bf021[0].message).toContain('not a supported shape')
   })
 
-  test('emits BF021 error for multi-statement block-body sort comparator', () => {
-    // Single-`return` block bodies now lower (#1448 Tier B follow-up),
-    // but multi-statement / local-var bodies stay refused — generalising
-    // over arbitrary statement sequences isn't tractable in a template.
+  test('no BF021 for let-inline block-body sort comparator (#2040)', () => {
+    // #2040: a value-producing block body (pure `const` bindings + a terminal
+    // `return`) normalises to a single expression via let-inline, so a
+    // `{ const x = a.price; return x - b.price }` comparator now lowers exactly
+    // like the expression-bodied `(a, b) => a.price - b.price`.
     const source = `
       'use client'
       import { createSignal } from '@barefootjs/client'
@@ -229,6 +230,32 @@ describe('Unsupported Sort Comparator (BF021)', () => {
         return (
           <ul>
             {items().sort((a, b) => { const x = a.price; return x - b.price }).map(t => (
+              <li>{t.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const { errors } = compileToIR(source)
+    const bf021 = errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+
+    expect(bf021).toHaveLength(0)
+  })
+
+  test('emits BF021 error for imperative block-body sort comparator (#2040)', () => {
+    // An imperative comparator (local re-assignment / mutation) has no
+    // value-position lowering — `foldBlockToExpr` refuses it, so the arrow stays
+    // `unsupported` and the sort extraction surfaces BF021.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function TodoList() {
+        const [items, setItems] = createSignal<any[]>([])
+        return (
+          <ul>
+            {items().sort((a, b) => { let r = 0; r = a.price - b.price; return r }).map(t => (
               <li>{t.name}</li>
             ))}
           </ul>

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -2585,63 +2585,194 @@ function statementsTerminate(stmts: ParsedStatement[]): boolean {
 }
 
 /**
- * Substitute free identifiers in `expr` with their bound expression from `env`
- * (the let-inline half of {@link foldBlockToExpr}). A nested `arrow`'s own
- * params shadow the environment for its body, so a bound name that collides with
- * a param is left untouched inside that body. Mirrors the structural walk used
- * by `substituteDestructuredFields`; every `ParsedExpr` kind is handled so a new
- * kind surfaces as a compile error here rather than silently skipping
- * substitution.
+ * Refusal reason when inlining a `const` binding would capture a free variable
+ * of its initializer under a nested callback parameter of the same name. The
+ * let-inline substitution is not a hygienic (alpha-renaming) substitution, so
+ * rather than silently miscompile the callback we refuse and adapters surface
+ * BF101.
  */
-function substituteIdents(
+export const CAPTURE_BLOCK_REASON =
+  'Block body cannot be normalized: inlining a `const` binding would capture ' +
+  'one of its free variables under a nested callback parameter of the same ' +
+  'name (e.g. `const x = a; … list.map(a => a + x)`). Rename the inner ' +
+  'parameter, or move the body to a `/* @client */` value so it runs natively ' +
+  'on the client.'
+
+/**
+ * Refusal reason when a `const` initializer may have side effects (it contains
+ * a function/method call) and the binding is NOT used exactly once on a single
+ * runtime path. Let-inline substitutes the initializer at each use site, which
+ * would drop the effect (zero uses) or duplicate it (multiple uses / a use
+ * inside a callback that runs per element) — exactly the side-effecting shape
+ * the fold must refuse rather than miscompile.
+ */
+export const IMPURE_INLINE_BLOCK_REASON =
+  'Block body cannot be normalized: a `const` whose initializer may have side ' +
+  'effects (a function or method call) is used zero or more than once, so ' +
+  'inlining it would drop or duplicate the effect. Bind a pure value, use the ' +
+  'binding exactly once, or move the body to a `/* @client */` value so it ' +
+  'runs natively on the client.'
+
+/**
+ * Whether an expression is provably free of side effects by syntax alone, so it
+ * is safe to inline at any number of use sites. Conservative: any function or
+ * method call (or a value the parser couldn't represent) is treated as possibly
+ * impure. Member access is treated as pure, matching `substituteDestructuredFields`
+ * and the rest of the compiler's expression handling.
+ */
+function isPureInit(e: ParsedExpr): boolean {
+  switch (e.kind) {
+    case 'identifier':
+    case 'literal':
+    case 'regex':
+      return true
+    case 'member':
+      return isPureInit(e.object)
+    case 'index-access':
+      return isPureInit(e.object) && isPureInit(e.index)
+    case 'binary':
+    case 'logical':
+      return isPureInit(e.left) && isPureInit(e.right)
+    case 'unary':
+      return isPureInit(e.argument)
+    case 'conditional':
+      return isPureInit(e.test) && isPureInit(e.consequent) && isPureInit(e.alternate)
+    case 'template-literal':
+      return e.parts.every(p => p.type !== 'expression' || isPureInit(p.expr))
+    case 'array-literal':
+      return e.elements.every(isPureInit)
+    case 'object-literal':
+      return e.properties.every(p => isPureInit(p.value))
+    // A call / method call may be effectful or non-deterministic; an arrow value
+    // can capture impurity; `unsupported` is opaque. Treat all as possibly impure.
+    case 'call':
+    case 'array-method':
+    case 'arrow':
+    case 'unsupported':
+      return false
+  }
+}
+
+/**
+ * Maximum number of times `name` is evaluated on a single runtime path through
+ * `expr`. A `conditional` only ever evaluates one branch, so its branch cost is
+ * the max (not the sum) of the two arms plus the always-evaluated test. A use
+ * inside a nested `arrow` body may run any number of times (the callback is
+ * invoked per element / comparison), so it counts as "more than once" — modelled
+ * as `Infinity` — which forces an impure binding referenced from a callback to
+ * be refused. Used to decide whether inlining a possibly-impure init is
+ * evaluation-count-preserving.
+ */
+function maxUsesPerPath(name: string, expr: ParsedExpr): number {
+  const walk = (e: ParsedExpr): number => {
+    switch (e.kind) {
+      case 'identifier':
+        return e.name === name ? 1 : 0
+      case 'literal':
+      case 'regex':
+      case 'unsupported':
+        return 0
+      case 'member':
+        return walk(e.object)
+      case 'index-access':
+        return walk(e.object) + walk(e.index)
+      case 'binary':
+      case 'logical':
+        return walk(e.left) + walk(e.right)
+      case 'unary':
+        return walk(e.argument)
+      case 'conditional':
+        return walk(e.test) + Math.max(walk(e.consequent), walk(e.alternate))
+      case 'template-literal':
+        return e.parts.reduce((n, p) => n + (p.type === 'expression' ? walk(p.expr) : 0), 0)
+      case 'call':
+        return walk(e.callee) + e.args.reduce((n, a) => n + walk(a), 0)
+      case 'array-literal':
+        return e.elements.reduce((n, el) => n + walk(el), 0)
+      case 'array-method':
+        return walk(e.object) + (e.method === 'flat' ? 0 : e.args.reduce((n, a) => n + walk(a), 0))
+      case 'object-literal':
+        return e.properties.reduce((n, p) => n + walk(p.value), 0)
+      case 'arrow':
+        // A callback body may run per element; any use inside counts as unbounded.
+        return walk(e.body) > 0 ? Number.POSITIVE_INFINITY : 0
+    }
+  }
+  return walk(expr)
+}
+
+/**
+ * Inline `name → value` everywhere it appears free in `expr` (the let-inline
+ * step). Returns `null` if the substitution would capture a free variable of
+ * `value` under a nested callback parameter of the same name — that shape is
+ * unsound to inline non-hygienically, so the caller refuses with
+ * {@link CAPTURE_BLOCK_REASON}. A nested arrow parameter that shadows `name`
+ * leaves that inner reference untouched (it is the parameter, not the binding).
+ * Mirrors the structural walk of `substituteDestructuredFields`; every
+ * `ParsedExpr` kind is handled so a new kind surfaces as a compile error here.
+ */
+function inlineBinding(
   expr: ParsedExpr,
-  env: ReadonlyMap<string, ParsedExpr>,
-): ParsedExpr {
-  if (env.size === 0) return expr
-  const walk = (e: ParsedExpr): ParsedExpr => {
+  name: string,
+  value: ParsedExpr,
+): ParsedExpr | null {
+  // Free variables of `value` that an enclosing callback parameter could capture.
+  const valueFree = new Set<string>()
+  collectIdentifiers(value, valueFree)
+  let captured = false
+
+  const walk = (e: ParsedExpr, enclosing: ReadonlySet<string>): ParsedExpr => {
     switch (e.kind) {
       case 'identifier': {
-        const bound = env.get(e.name)
-        return bound !== undefined ? bound : e
+        if (e.name !== name) return e
+        // Shadowed by an enclosing callback param → this is the parameter, not
+        // the binding; leave it.
+        if (enclosing.has(e.name)) return e
+        // Inlining here: does any enclosing param capture a free var of `value`?
+        for (const p of enclosing) {
+          if (valueFree.has(p)) {
+            captured = true
+            return e
+          }
+        }
+        return value
       }
       case 'call':
-        return { kind: 'call', callee: walk(e.callee), args: e.args.map(walk) }
+        return { kind: 'call', callee: walk(e.callee, enclosing), args: e.args.map(a => walk(a, enclosing)) }
       case 'member':
-        return { kind: 'member', object: walk(e.object), property: e.property, computed: e.computed }
+        return { kind: 'member', object: walk(e.object, enclosing), property: e.property, computed: e.computed }
       case 'index-access':
-        return { kind: 'index-access', object: walk(e.object), index: walk(e.index) }
+        return { kind: 'index-access', object: walk(e.object, enclosing), index: walk(e.index, enclosing) }
       case 'binary':
-        return { kind: 'binary', op: e.op, left: walk(e.left), right: walk(e.right) }
+        return { kind: 'binary', op: e.op, left: walk(e.left, enclosing), right: walk(e.right, enclosing) }
       case 'logical':
-        return { kind: 'logical', op: e.op, left: walk(e.left), right: walk(e.right) }
+        return { kind: 'logical', op: e.op, left: walk(e.left, enclosing), right: walk(e.right, enclosing) }
       case 'unary':
-        return { kind: 'unary', op: e.op, argument: walk(e.argument) }
+        return { kind: 'unary', op: e.op, argument: walk(e.argument, enclosing) }
       case 'conditional':
-        return { kind: 'conditional', test: walk(e.test), consequent: walk(e.consequent), alternate: walk(e.alternate) }
+        return { kind: 'conditional', test: walk(e.test, enclosing), consequent: walk(e.consequent, enclosing), alternate: walk(e.alternate, enclosing) }
       case 'template-literal':
         return {
           kind: 'template-literal',
           parts: e.parts.map(p =>
-            p.type === 'expression' ? { type: 'expression', expr: walk(p.expr) } : p,
+            p.type === 'expression' ? { type: 'expression', expr: walk(p.expr, enclosing) } : p,
           ),
         }
       case 'arrow': {
-        // Params shadow the outer let-bindings inside the body.
-        const inner = new Map(env)
-        for (const p of e.params) inner.delete(p)
-        return { kind: 'arrow', params: e.params, body: substituteIdents(e.body, inner) }
+        const innerEnclosing = e.params.length === 0 ? enclosing : new Set([...enclosing, ...e.params])
+        return { kind: 'arrow', params: e.params, body: walk(e.body, innerEnclosing) }
       }
       case 'array-literal':
-        return { kind: 'array-literal', elements: e.elements.map(walk) }
+        return { kind: 'array-literal', elements: e.elements.map(el => walk(el, enclosing)) }
       case 'array-method':
         if (e.method === 'flat') {
-          return { kind: 'array-method', method: 'flat', object: walk(e.object), args: [], flatDepth: e.flatDepth }
+          return { kind: 'array-method', method: 'flat', object: walk(e.object, enclosing), args: [], flatDepth: e.flatDepth }
         }
-        return { kind: 'array-method', method: e.method, object: walk(e.object), args: e.args.map(walk) }
+        return { kind: 'array-method', method: e.method, object: walk(e.object, enclosing), args: e.args.map(a => walk(a, enclosing)) }
       case 'object-literal':
         return {
           kind: 'object-literal',
-          properties: e.properties.map(p => ({ ...p, value: walk(p.value) })),
+          properties: e.properties.map(p => ({ ...p, value: walk(p.value, enclosing) })),
           raw: e.raw,
         }
       case 'literal':
@@ -2650,11 +2781,13 @@ function substituteIdents(
         return e
     }
   }
-  return walk(expr)
+
+  const result = walk(expr, new Set())
+  return captured ? null : result
 }
 
 /**
- * Fold a value-producing block body — a {@link ParsedStatement} sequence of pure
+ * Fold a value-producing block body — a {@link ParsedStatement} sequence of
  * `const` bindings, value-producing `if` / early `return`, and a terminal
  * `return` — into a single {@link ParsedExpr}, so block-bodied memos / derived /
  * callbacks flow through the same expression surface as expression-bodied ones
@@ -2663,13 +2796,20 @@ function substituteIdents(
  * `bf_sort` / `bf_reduce` catalogue: one normalization, no growing pattern list.
  *
  * Transformations:
- *   - `const x = <init>; …` → inline `x`'s (already-folded) init into the rest
- *     (let-inline). The binding is pure by construction — a `ParsedStatement`
- *     `var-decl` only ever carries an expression init.
+ *   - `const x = <init>; …` → inline `x`'s init into the rest (let-inline).
  *   - `if (c) <then> [else <else>] …` → `c ? fold(then-path) : fold(else-path)`,
  *     where a branch that does not itself terminate continues into the
  *     statements following the `if` (the early-return idiom).
- *   - `return <v>` → `<v>` (with the accumulated bindings substituted in).
+ *   - `return <v>` → `<v>`.
+ *
+ * The rest is folded first, leaving each binding as a free identifier, so its
+ * use count can be measured before inlining. Inlining is refused (→ `ok: false`)
+ * when it would be unsound:
+ *   - a possibly-impure init (one containing a call) used zero or more than once
+ *     on a path would drop or duplicate the side effect (a pure init is always
+ *     safe to inline any number of times);
+ *   - a substitution would capture a free variable of the init under a nested
+ *     callback parameter of the same name (substitution is not hygienic).
  *
  * Returns `{ ok: false }` for a sequence that cannot produce a value on some
  * path (falls through with no `return`) — the genuinely-imperative residue that
@@ -2681,31 +2821,41 @@ function substituteIdents(
 export function foldBlockToExpr(
   stmts: ParsedStatement[],
 ): { ok: true; expr: ParsedExpr } | { ok: false; reason: string } {
-  return foldStatements(stmts, new Map())
-}
-
-function foldStatements(
-  stmts: ParsedStatement[],
-  env: ReadonlyMap<string, ParsedExpr>,
-): { ok: true; expr: ParsedExpr } | { ok: false; reason: string } {
   if (stmts.length === 0) {
     return { ok: false, reason: IMPERATIVE_BLOCK_REASON }
   }
   const [head, ...rest] = stmts
   switch (head.kind) {
     case 'var-decl': {
-      const next = new Map(env)
-      next.set(head.name, substituteIdents(head.init, env))
-      return foldStatements(rest, next)
+      // Fold the remaining statements first, leaving `head.name` free so its use
+      // count can drive the soundness check. Any earlier-binding references in
+      // the rest are inlined by the enclosing `var-decl` frames; references to
+      // `head.name` inside `head.init` cannot occur (a `const` can't read itself).
+      const restFold = foldBlockToExpr(rest)
+      if (!restFold.ok) return restFold
+      const uses = maxUsesPerPath(head.name, restFold.expr)
+      // A possibly-impure init is only safe to inline when it is evaluated
+      // exactly once on a single path — same as the original block. A pure init
+      // is safe at any count (including zero: dropping a pure unused binding is
+      // observationally identical).
+      if (!isPureInit(head.init) && uses !== 1) {
+        return { ok: false, reason: IMPURE_INLINE_BLOCK_REASON }
+      }
+      const inlined = inlineBinding(restFold.expr, head.name, head.init)
+      if (inlined === null) {
+        return { ok: false, reason: CAPTURE_BLOCK_REASON }
+      }
+      return { ok: true, expr: inlined }
     }
     case 'return':
-      return { ok: true, expr: substituteIdents(head.value, env) }
+      return { ok: true, expr: head.value }
     case 'if': {
       // A branch that doesn't return falls through to the statements after the
       // `if` (early-return idiom). A branch that returns makes `rest` dead for
       // that path, so it is not appended. `rest` is intentionally duplicated
-      // into both fall-through paths: value computation is side-effect-free, so
-      // the duplication is semantics-preserving.
+      // into both fall-through paths; because each path is a separate ternary
+      // arm, a binding used once per arm is still evaluated at most once per
+      // runtime path.
       const thenPath = statementsTerminate(head.consequent)
         ? head.consequent
         : [...head.consequent, ...rest]
@@ -2713,15 +2863,15 @@ function foldStatements(
       const elsePath = statementsTerminate(elseBase)
         ? elseBase
         : [...elseBase, ...rest]
-      const consequent = foldStatements(thenPath, env)
+      const consequent = foldBlockToExpr(thenPath)
       if (!consequent.ok) return consequent
-      const alternate = foldStatements(elsePath, env)
+      const alternate = foldBlockToExpr(elsePath)
       if (!alternate.ok) return alternate
       return {
         ok: true,
         expr: {
           kind: 'conditional',
-          test: substituteIdents(head.condition, env),
+          test: head.condition,
           consequent: consequent.expr,
           alternate: alternate.expr,
         },

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -2608,10 +2608,10 @@ export const CAPTURE_BLOCK_REASON =
  */
 export const IMPURE_INLINE_BLOCK_REASON =
   'Block body cannot be normalized: a `const` whose initializer may have side ' +
-  'effects (a function or method call) is used zero or more than once, so ' +
-  'inlining it would drop or duplicate the effect. Bind a pure value, use the ' +
-  'binding exactly once, or move the body to a `/* @client */` value so it ' +
-  'runs natively on the client.'
+  'effects (a function or method call) is not used exactly once on every path, ' +
+  'so inlining it would drop the effect on some path or duplicate it on ' +
+  'another. Bind a pure value, use the binding exactly once unconditionally, ' +
+  'or move the body to a `/* @client */` value so it runs natively on the client.'
 
 /**
  * Whether an expression is provably free of side effects by syntax alone, so it
@@ -2654,48 +2654,71 @@ function isPureInit(e: ParsedExpr): boolean {
 }
 
 /**
- * Maximum number of times `name` is evaluated on a single runtime path through
- * `expr`. A `conditional` only ever evaluates one branch, so its branch cost is
- * the max (not the sum) of the two arms plus the always-evaluated test. A use
- * inside a nested `arrow` body may run any number of times (the callback is
- * invoked per element / comparison), so it counts as "more than once" — modelled
- * as `Infinity` — which forces an impure binding referenced from a callback to
- * be refused. Used to decide whether inlining a possibly-impure init is
- * evaluation-count-preserving.
+ * The `{ min, max }` number of times `name` is evaluated on a single runtime
+ * path through `expr` — the minimum-cost path and the maximum-cost path. Used to
+ * decide whether inlining a possibly-impure init is evaluation-count-preserving:
+ * sound only when it is evaluated **exactly once on every path** (`min === 1 &&
+ * max === 1`), so the substituted call neither drops nor duplicates its effect.
+ *
+ * Path semantics:
+ *   - `conditional` evaluates the test then exactly one arm → test + the min/max
+ *     of the two arms (a binding used in only one arm has `min` 0: it is skipped
+ *     on the other path).
+ *   - `logical` (`&&` / `||` / `??`) evaluates the left, then the right only on
+ *     some paths (short-circuit) → the right contributes to `max` but not `min`.
+ *   - a nested `arrow` body may run any number of times (a callback invoked per
+ *     element / comparison, or never) → a use inside has `min` 0 and `max`
+ *     `Infinity`, forcing an impure binding referenced from a callback to be
+ *     refused.
  */
-function maxUsesPerPath(name: string, expr: ParsedExpr): number {
-  const walk = (e: ParsedExpr): number => {
+function usesPerPath(name: string, expr: ParsedExpr): { min: number; max: number } {
+  const add = (a: { min: number; max: number }, b: { min: number; max: number }) => ({
+    min: a.min + b.min,
+    max: a.max + b.max,
+  })
+  const sum = (xs: ParsedExpr[]) => xs.reduce((acc, x) => add(acc, walk(x)), { min: 0, max: 0 })
+  const walk = (e: ParsedExpr): { min: number; max: number } => {
     switch (e.kind) {
       case 'identifier':
-        return e.name === name ? 1 : 0
+        return e.name === name ? { min: 1, max: 1 } : { min: 0, max: 0 }
       case 'literal':
       case 'regex':
       case 'unsupported':
-        return 0
+        return { min: 0, max: 0 }
       case 'member':
         return walk(e.object)
       case 'index-access':
-        return walk(e.object) + walk(e.index)
+        return add(walk(e.object), walk(e.index))
       case 'binary':
-      case 'logical':
-        return walk(e.left) + walk(e.right)
+        return add(walk(e.left), walk(e.right))
+      case 'logical': {
+        // The right operand is only evaluated on some paths (short-circuit), so
+        // it contributes to the max but never to the guaranteed min.
+        const l = walk(e.left)
+        const r = walk(e.right)
+        return { min: l.min, max: l.max + r.max }
+      }
       case 'unary':
         return walk(e.argument)
-      case 'conditional':
-        return walk(e.test) + Math.max(walk(e.consequent), walk(e.alternate))
+      case 'conditional': {
+        const t = walk(e.test)
+        const c = walk(e.consequent)
+        const a = walk(e.alternate)
+        return { min: t.min + Math.min(c.min, a.min), max: t.max + Math.max(c.max, a.max) }
+      }
       case 'template-literal':
-        return e.parts.reduce((n, p) => n + (p.type === 'expression' ? walk(p.expr) : 0), 0)
+        return sum(e.parts.flatMap(p => (p.type === 'expression' ? [p.expr] : [])))
       case 'call':
-        return walk(e.callee) + e.args.reduce((n, a) => n + walk(a), 0)
+        return add(walk(e.callee), sum(e.args))
       case 'array-literal':
-        return e.elements.reduce((n, el) => n + walk(el), 0)
+        return sum(e.elements)
       case 'array-method':
-        return walk(e.object) + (e.method === 'flat' ? 0 : e.args.reduce((n, a) => n + walk(a), 0))
+        return add(walk(e.object), e.method === 'flat' ? { min: 0, max: 0 } : sum(e.args))
       case 'object-literal':
-        return e.properties.reduce((n, p) => n + walk(p.value), 0)
+        return sum(e.properties.map(p => p.value))
       case 'arrow':
-        // A callback body may run per element; any use inside counts as unbounded.
-        return walk(e.body) > 0 ? Number.POSITIVE_INFINITY : 0
+        // A callback body may run any number of times (per element, or never).
+        return walk(e.body).max > 0 ? { min: 0, max: Number.POSITIVE_INFINITY } : { min: 0, max: 0 }
     }
   }
   return walk(expr)
@@ -2833,12 +2856,14 @@ export function foldBlockToExpr(
       // `head.name` inside `head.init` cannot occur (a `const` can't read itself).
       const restFold = foldBlockToExpr(rest)
       if (!restFold.ok) return restFold
-      const uses = maxUsesPerPath(head.name, restFold.expr)
+      const uses = usesPerPath(head.name, restFold.expr)
       // A possibly-impure init is only safe to inline when it is evaluated
-      // exactly once on a single path — same as the original block. A pure init
-      // is safe at any count (including zero: dropping a pure unused binding is
-      // observationally identical).
-      if (!isPureInit(head.init) && uses !== 1) {
+      // exactly once on EVERY path — same as the original block, which runs the
+      // `const` initializer unconditionally once. `min !== 1` catches an effect
+      // dropped on some path (unused, or used in only one ternary arm / a
+      // short-circuited operand / a callback); `max !== 1` catches duplication.
+      // A pure init is safe at any count (drop / duplicate is unobservable).
+      if (!isPureInit(head.init) && !(uses.min === 1 && uses.max === 1)) {
         return { ok: false, reason: IMPURE_INLINE_BLOCK_REASON }
       }
       const inlined = inlineBinding(restFold.expr, head.name, head.init)

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -1142,18 +1142,42 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
     // directly; a block body (arrow `=> { … }` or a function expression)
     // must reduce to exactly one `return <expr>;`. Multi-statement /
     // local-var bodies stay refused.
-    let bodyNode: ts.Expression
+    let body: ParsedExpr
     if (ts.isArrowFunction(node) && !ts.isBlock(node.body)) {
-      bodyNode = node.body
+      body = convertNode(node.body, raw)
     } else {
       const block = node.body as ts.Block
       const stmts = block.statements
-      if (stmts.length !== 1 || !ts.isReturnStatement(stmts[0]) || !stmts[0].expression) {
-        return { kind: 'unsupported', raw, reason: 'Only single-`return` block-body functions are supported' }
+      // Fast path: a single `return <expr>` keeps the pre-#2040 conversion
+      // (convertNode on the returned node), byte-identical for the existing
+      // corpus.
+      if (stmts.length === 1 && ts.isReturnStatement(stmts[0]) && stmts[0].expression) {
+        body = convertNode(stmts[0].expression, raw)
+      } else {
+        // General value-producing block: normalize `let`-inline + value `if` /
+        // early `return` into a single expression (#2040). Imperative shapes
+        // (raw `for` / `while`, `break`, mutation, side effects) don't parse
+        // into ParsedStatement, or fall through without a value — either way we
+        // refuse with an actionable reason and adapters surface BF101.
+        let sf: ts.SourceFile | undefined
+        try {
+          sf = block.getSourceFile()
+        } catch {
+          sf = undefined
+        }
+        const parsed = sf
+          ? parseBlockBody(block, sf, n => n.getText(sf))
+          : null
+        if (!parsed) {
+          return { kind: 'unsupported', raw, reason: IMPERATIVE_BLOCK_REASON }
+        }
+        const folded = foldBlockToExpr(parsed)
+        if (!folded.ok) {
+          return { kind: 'unsupported', raw, reason: folded.reason }
+        }
+        body = folded.expr
       }
-      bodyNode = stmts[0].expression
     }
-    const body = convertNode(bodyNode, raw)
 
     // Single object-binding-pattern param: `({done}) => done` (#1443),
     // `({user: {name}}) => name` (#1530), `({done = false}) => done`
@@ -2516,6 +2540,194 @@ function parseStatement(
 
   // Unsupported statement (for, while, switch, etc.)
   return null
+}
+
+// =============================================================================
+// Block → Expression Normalization (#2040)
+// =============================================================================
+
+/**
+ * The actionable refusal reason for a block body that is not purely-functionally
+ * expressible. Carried on the `unsupported` ParsedExpr so adapters surface it as
+ * the BF101 message. A loop that mutates a local to accumulate a value is a fold
+ * (already expressible via `.reduce`); a loop that does anything else, a `break`,
+ * a re-assignment, or a side-effecting/I-O call is genuinely imperative and has
+ * no value-position lowering.
+ */
+export const IMPERATIVE_BLOCK_REASON =
+  'Block body cannot be normalized to a value expression. Only pure ' +
+  '`const` bindings, value-producing `if` / early `return`, and a final ' +
+  '`return` are supported. Imperative shapes (raw `for` / `while` loops, ' +
+  '`break`, local re-assignment, side-effecting or I/O calls) are not. ' +
+  'Rewrite an accumulation loop as `.reduce(...)`, or move the imperative ' +
+  'body to a `/* @client */` value so it runs natively on the client.'
+
+/**
+ * Whether a statement sequence always reaches a `return` on every control-flow
+ * path (so anything textually after it is dead). A bare `return` terminates; an
+ * `if` terminates only when it has an `else` and both branches terminate. Used
+ * by {@link foldBlockToExpr} to decide whether the statements following an `if`
+ * belong to the fall-through (else) path.
+ */
+function statementsTerminate(stmts: ParsedStatement[]): boolean {
+  for (const s of stmts) {
+    if (s.kind === 'return') return true
+    if (
+      s.kind === 'if' &&
+      s.alternate !== undefined &&
+      statementsTerminate(s.consequent) &&
+      statementsTerminate(s.alternate)
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * Substitute free identifiers in `expr` with their bound expression from `env`
+ * (the let-inline half of {@link foldBlockToExpr}). A nested `arrow`'s own
+ * params shadow the environment for its body, so a bound name that collides with
+ * a param is left untouched inside that body. Mirrors the structural walk used
+ * by `substituteDestructuredFields`; every `ParsedExpr` kind is handled so a new
+ * kind surfaces as a compile error here rather than silently skipping
+ * substitution.
+ */
+function substituteIdents(
+  expr: ParsedExpr,
+  env: ReadonlyMap<string, ParsedExpr>,
+): ParsedExpr {
+  if (env.size === 0) return expr
+  const walk = (e: ParsedExpr): ParsedExpr => {
+    switch (e.kind) {
+      case 'identifier': {
+        const bound = env.get(e.name)
+        return bound !== undefined ? bound : e
+      }
+      case 'call':
+        return { kind: 'call', callee: walk(e.callee), args: e.args.map(walk) }
+      case 'member':
+        return { kind: 'member', object: walk(e.object), property: e.property, computed: e.computed }
+      case 'index-access':
+        return { kind: 'index-access', object: walk(e.object), index: walk(e.index) }
+      case 'binary':
+        return { kind: 'binary', op: e.op, left: walk(e.left), right: walk(e.right) }
+      case 'logical':
+        return { kind: 'logical', op: e.op, left: walk(e.left), right: walk(e.right) }
+      case 'unary':
+        return { kind: 'unary', op: e.op, argument: walk(e.argument) }
+      case 'conditional':
+        return { kind: 'conditional', test: walk(e.test), consequent: walk(e.consequent), alternate: walk(e.alternate) }
+      case 'template-literal':
+        return {
+          kind: 'template-literal',
+          parts: e.parts.map(p =>
+            p.type === 'expression' ? { type: 'expression', expr: walk(p.expr) } : p,
+          ),
+        }
+      case 'arrow': {
+        // Params shadow the outer let-bindings inside the body.
+        const inner = new Map(env)
+        for (const p of e.params) inner.delete(p)
+        return { kind: 'arrow', params: e.params, body: substituteIdents(e.body, inner) }
+      }
+      case 'array-literal':
+        return { kind: 'array-literal', elements: e.elements.map(walk) }
+      case 'array-method':
+        if (e.method === 'flat') {
+          return { kind: 'array-method', method: 'flat', object: walk(e.object), args: [], flatDepth: e.flatDepth }
+        }
+        return { kind: 'array-method', method: e.method, object: walk(e.object), args: e.args.map(walk) }
+      case 'object-literal':
+        return {
+          kind: 'object-literal',
+          properties: e.properties.map(p => ({ ...p, value: walk(p.value) })),
+          raw: e.raw,
+        }
+      case 'literal':
+      case 'regex':
+      case 'unsupported':
+        return e
+    }
+  }
+  return walk(expr)
+}
+
+/**
+ * Fold a value-producing block body — a {@link ParsedStatement} sequence of pure
+ * `const` bindings, value-producing `if` / early `return`, and a terminal
+ * `return` — into a single {@link ParsedExpr}, so block-bodied memos / derived /
+ * callbacks flow through the same expression surface as expression-bodied ones
+ * (#2040, carved from #2018 stage 5). This generalizes the per-idiom block-memo
+ * recognizers (#1897 / #1945 / #2015) the same way the evaluator replaced the
+ * `bf_sort` / `bf_reduce` catalogue: one normalization, no growing pattern list.
+ *
+ * Transformations:
+ *   - `const x = <init>; …` → inline `x`'s (already-folded) init into the rest
+ *     (let-inline). The binding is pure by construction — a `ParsedStatement`
+ *     `var-decl` only ever carries an expression init.
+ *   - `if (c) <then> [else <else>] …` → `c ? fold(then-path) : fold(else-path)`,
+ *     where a branch that does not itself terminate continues into the
+ *     statements following the `if` (the early-return idiom).
+ *   - `return <v>` → `<v>` (with the accumulated bindings substituted in).
+ *
+ * Returns `{ ok: false }` for a sequence that cannot produce a value on some
+ * path (falls through with no `return`) — the genuinely-imperative residue that
+ * {@link IMPERATIVE_BLOCK_REASON} describes. The input is assumed to be the
+ * STRICT parse ({@link parseBlockBody}, not the tolerant variant): every source
+ * statement is represented, so a `false` here reflects the real shape rather
+ * than a silently-dropped statement.
+ */
+export function foldBlockToExpr(
+  stmts: ParsedStatement[],
+): { ok: true; expr: ParsedExpr } | { ok: false; reason: string } {
+  return foldStatements(stmts, new Map())
+}
+
+function foldStatements(
+  stmts: ParsedStatement[],
+  env: ReadonlyMap<string, ParsedExpr>,
+): { ok: true; expr: ParsedExpr } | { ok: false; reason: string } {
+  if (stmts.length === 0) {
+    return { ok: false, reason: IMPERATIVE_BLOCK_REASON }
+  }
+  const [head, ...rest] = stmts
+  switch (head.kind) {
+    case 'var-decl': {
+      const next = new Map(env)
+      next.set(head.name, substituteIdents(head.init, env))
+      return foldStatements(rest, next)
+    }
+    case 'return':
+      return { ok: true, expr: substituteIdents(head.value, env) }
+    case 'if': {
+      // A branch that doesn't return falls through to the statements after the
+      // `if` (early-return idiom). A branch that returns makes `rest` dead for
+      // that path, so it is not appended. `rest` is intentionally duplicated
+      // into both fall-through paths: value computation is side-effect-free, so
+      // the duplication is semantics-preserving.
+      const thenPath = statementsTerminate(head.consequent)
+        ? head.consequent
+        : [...head.consequent, ...rest]
+      const elseBase = head.alternate ?? []
+      const elsePath = statementsTerminate(elseBase)
+        ? elseBase
+        : [...elseBase, ...rest]
+      const consequent = foldStatements(thenPath, env)
+      if (!consequent.ok) return consequent
+      const alternate = foldStatements(elsePath, env)
+      if (!alternate.ok) return alternate
+      return {
+        ok: true,
+        expr: {
+          kind: 'conditional',
+          test: substituteIdents(head.condition, env),
+          consequent: consequent.expr,
+          alternate: alternate.expr,
+        },
+      }
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
Carved from #2018 stage 5 — the **block bodies** half of the purely-functional-expressibility boundary. Closes the callback portion of #2040.

## What

A higher-order callback (`.sort` / `.reduce` / `.find` / `.some` / `.every` / `.flatMap` …) written with a `{ … }` block body now **normalizes to a single expression** when its body is purely-functionally expressible, instead of being refused with *"only single-`return` block-body functions are supported"*:

- **let-inline** — pure `const` bindings inline into the expression that uses them.
- **early-return / value `if`** — `if (c) return A; return B` (incl. `if/else` and `else if` chains) folds to a ternary in value position.

The folded result flows through the existing `ParsedExpr` surface (the #2018 callback evaluator / template-native lowering), so **no new IR statement shapes are carried** — matching the issue's non-goal of growing a procedure interpreter.

Genuinely **imperative** block bodies — raw `for` / `while`, `break`, local re-assignment / mutable state, side-effecting or I/O calls — have no value-position lowering and stay `unsupported`, so adapters surface **BF101** with an actionable message (rewrite an accumulation loop as `.reduce(...)`, or move the body to a `/* @client */` value that runs natively on the client).

## How

- New public helper `foldBlockToExpr(ParsedStatement[])` in `expression-parser.ts` performs the fold (let-inline substitution + `if`/early-return → ternary, with branch-termination analysis for the fall-through/early-return idiom).
- `convertNode`'s arrow path uses it for multi-statement block bodies. The single-`return` fast path is unchanged, so existing output is **byte-identical**.

## Scope / follow-up

This lands the **callback** half of #2040. The **memo / derived** block-recognizer replacement (#1897 / #1945 / #2015) is deliberately **not** in this PR: the Go adapter's memo lowering checks `MemoInfo.parsed` before its `parsedBlock` recognizers (`memo-compute.ts`), while `template-interp.ts` checks `parsedBlock` first — so populating `parsed` from a fold would reroute memo emission and needs per-adapter (Go + shared Perl) parity work, ideally alongside the mojo/xslate decomposition from #2018 track D. `foldBlockToExpr` is the reusable core that work will build on.

## Testing

- `foldBlockToExpr` unit tests (let-inline, chained let, early-return ternary, `if/else`, `else if` chain, fall-through refusal, imperative refusal).
- Updated `expression-parser` / `unsupported-expression` tests that previously asserted the old "single-`return` only" restriction.
- Updated `docs/core/rendering/jsx-compatibility.md` (the let-inline sort comparator now lowers; the ❌ example is now a genuinely imperative comparator).
- Verified green: `@barefootjs/jsx`, `go-template`, `mojolicious`, `xslate` unit suites. Conformance suite unchanged — the only failures (carousel cross-adapter render) are **pre-existing on `main`** (confirmed by re-running with the change stashed).

Refs: #2040, #2018.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdVpB6GWgFddUzDo1MYixm)_