### PR TITLE
feat(go-template): fold searchParams object memos to expressions (#2040)

### DIFF
--- a/.changeset/searchparams-object-fold.md
+++ b/.changeset/searchparams-object-fold.md
@@ -1,0 +1,10 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+---
+
+Lower the searchParams-derived object memo (#2015) through the general fold instead of a bespoke statement walk (#2040, PR-C of the memo follow-up stack).
+
+`computeObjectMemoInitialValue` previously walked `parsedBlock` for `const sp = searchParams()` bindings + a terminal `return { … }`. It now folds the block with `foldBlockToExpr`, adding `searchParams` to the purity oracle (an idempotent request-query read, safe to inline at each `sp.get('k')` site), and lowers the resulting object-literal. `sp` is inlined to `searchParams()`, so `lowerCtorExpr` now recognises a `searchParams().get('k')` receiver in addition to the `const sp` env form. `foldBlockToExpr` is exported from `@barefootjs/jsx`.
+
+This drops the statement-shape matching (var-decl scan + last-return check) for the object memo, and as a side benefit lowers an object memo that calls `searchParams().get('k')` directly without a `const` binding. A block that doesn't fold to an object literal returns null → the same nil fallback as before. Render parity verified by the Go adapter conformance + unit suites.

--- a/packages/adapter-go-template/src/__tests__/derived-state-memo.test.ts
+++ b/packages/adapter-go-template/src/__tests__/derived-state-memo.test.ts
@@ -393,3 +393,42 @@ export function Box() {
     expect(types).toContain('"flex"')
   })
 })
+
+// #2040 PR-C: the object-returning searchParams memo lowers via the general
+// fold (`foldBlockToExpr` with `searchParams` treated as a pure idempotent
+// read), not a bespoke statement walk.
+describe('Capability D: searchParams object memo via fold (#2040 PR-C)', () => {
+  test('object memo using searchParams() directly (no const binding) lowers', () => {
+    // The old statement walk required a `const sp = searchParams()` binding to
+    // populate its env; the fold inlines any binding, so a direct
+    // `searchParams().get('k')` in the returned object now lowers too.
+    const { types } = generate(`
+"use client"
+import { createMemo, searchParams } from "@barefootjs/client"
+export function PostList() {
+  const params = createMemo(() => {
+    return { tag: searchParams().get('tag') ?? '' }
+  })
+  return <div>{params().tag}</div>
+}
+`)
+    expect(types).toContain('map[string]interface{}{')
+    expect(types).toContain('"Tag":')
+    expect(types).toContain('in.SearchParams.Get("tag")')
+  })
+
+  test('aliased searchParams import still lowers (local-name oracle)', () => {
+    const { types } = generate(`
+"use client"
+import { createMemo, searchParams as sp } from "@barefootjs/client"
+export function PostList() {
+  const params = createMemo(() => {
+    const q = sp()
+    return { tag: q.get('tag') ?? '' }
+  })
+  return <div>{params().tag}</div>
+}
+`)
+    expect(types).toContain('in.SearchParams.Get("tag")')
+  })
+})

--- a/packages/adapter-go-template/src/adapter/memo/ctor-lowering.ts
+++ b/packages/adapter-go-template/src/adapter/memo/ctor-lowering.ts
@@ -96,11 +96,19 @@ export function lowerCtorExpr(
   if (node.kind === 'call' && node.callee.kind === 'member') {
     const method = node.callee.property
     const recv = node.callee.object
-    // `<sp>.get('k')` where <sp> is bound to searchParams().
+    // `<sp>.get('k')` where the receiver is `searchParams()`: either a local
+    // bound to it (`const sp = searchParams()` → `sp.get(...)`, the env path) or
+    // — once the block memo is folded (#2040) — the inlined `searchParams()`
+    // call directly.
+    const isSearchParamsRecv =
+      (recv.kind === 'identifier' && env.searchParamsVars.has(recv.name)) ||
+      (recv.kind === 'call' &&
+        recv.callee.kind === 'identifier' &&
+        recv.args.length === 0 &&
+        ctx.state.searchParamsLocals.has(recv.callee.name))
     if (
       method === 'get' &&
-      recv.kind === 'identifier' &&
-      env.searchParamsVars.has(recv.name) &&
+      isSearchParamsRecv &&
       node.args.length === 1 &&
       node.args[0].kind === 'literal' &&
       node.args[0].literalType === 'string'

--- a/packages/adapter-go-template/src/adapter/memo/memo-value.ts
+++ b/packages/adapter-go-template/src/adapter/memo/memo-value.ts
@@ -10,6 +10,7 @@
  *     delegating value lowering to `lowerCtorExpr`.
  */
 
+import { foldBlockToExpr } from '@barefootjs/jsx'
 import type { ParsedExpr, ParsedStatement, TypeInfo } from '@barefootjs/jsx'
 
 import type { GoEmitContext } from '../emit-context.ts'
@@ -152,50 +153,32 @@ function fromStatementPrefix(
  */
 export function computeObjectMemoInitialValue(
   ctx: GoEmitContext,
-  memo: { parsedBlock?: ParsedStatement[]; parsedBlockComplete?: boolean },
+  memo: { parsed?: ParsedExpr; parsedBlock?: ParsedStatement[]; parsedBlockComplete?: boolean },
 ): string | null {
-  // An incomplete block (`parsedBlockComplete === false`) means a statement was
-  // omitted from the tolerant parse — it could hide control flow this resolver
-  // can't model, so bail to the nil fallback.
-  if (!memo.parsedBlock || !memo.parsedBlockComplete) return null
-
-  // Accept only a strict shape: zero or more `const`/`let` declarations
-  // followed by exactly one `return { … }` as the LAST statement. Any other
-  // statement kind — `if`, an early/extra `return` — means the block has
-  // control flow this resolver can't reason about, so bail to the nil fallback
-  // rather than silently lowering one of several returns. Along the way,
-  // collect `const <v> = searchParams()` bindings (the env for `<v>.get('k')`).
-  const searchParamsVars = new Set<string>()
-  let retObj: Extract<ParsedExpr, { kind: 'object-literal' }> | null = null
-  const statements = memo.parsedBlock
-  for (let i = 0; i < statements.length; i++) {
-    const s = statements[i]
-    if (s.kind === 'var-decl') {
-      // `const <v> = searchParams()` — a zero-arg call to a searchParams
-      // local. Any other var-decl is accepted and ignored.
-      if (
-        s.init.kind === 'call' &&
-        s.init.callee.kind === 'identifier' &&
-        s.init.args.length === 0 &&
-        ctx.state.searchParamsLocals.has(s.init.callee.name)
-      ) {
-        searchParamsVars.add(s.name)
-      }
-      continue
-    }
-    if (s.kind === 'return') {
-      // The return must be the last statement (so it's the only one) and
-      // return an object literal.
-      if (i !== statements.length - 1 || s.value.kind !== 'object-literal') return null
-      retObj = s.value
-      continue
-    }
-    // Any other statement kind (`if`) → control flow we don't model → bail.
-    return null
+  // Normalize the block to a single object-literal expression (#2040). The
+  // analyzer's fold treats only signal/memo reads as pure, so a
+  // `const sp = searchParams()` (read twice) isn't folded there; redo the fold
+  // here with `searchParams` added to the purity oracle — it is an idempotent
+  // request-query read, so inlining `sp` at each `sp.get('k')` site is sound.
+  // The folded object's values become `searchParams().get('k')` (sp inlined),
+  // lowered by `lowerCtorExpr`. A block that doesn't fold to an object literal
+  // (extra control flow, an impure non-searchParams binding) yields null → the
+  // caller's nil fallback, exactly as the previous statement walk did.
+  let retObj = memo.parsed?.kind === 'object-literal' ? memo.parsed : null
+  if (!retObj) {
+    if (!memo.parsedBlock || !memo.parsedBlockComplete) return null
+    const folded = foldBlockToExpr(memo.parsedBlock, {
+      pureCallNames: ctx.state.searchParamsLocals,
+    })
+    if (!folded.ok || folded.expr.kind !== 'object-literal') return null
+    retObj = folded.expr
   }
-  if (!retObj || retObj.properties.length === 0) return null
+  if (retObj.properties.length === 0) return null
 
-  const env: CtorLowerEnv = { searchParamsVars, params: new Map() }
+  // `sp` is inlined to `searchParams()` in the folded values, so no
+  // local→searchParams var env is needed; `lowerCtorExpr` recognises the
+  // `searchParams().get('k')` receiver shape directly.
+  const env: CtorLowerEnv = { searchParamsVars: new Set(), params: new Map() }
   const entries: string[] = []
   for (const prop of retObj.properties) {
     // Bail on a shorthand property (`return { tag }`): its value is a bare

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -255,7 +255,7 @@ export {
 export { ErrorCodes, createError, formatError, generateCodeFrame } from './errors.ts'
 
 // Expression Parser
-export { parseExpression, tsNodeToParsedExpr, asCallbackMethodCall, CALLBACK_METHODS, sortComparatorFromArrow, serializeParsedExpr, freeVarsInBody, isSupported, exprToString, stringifyParsedExpr, identifierPath, parseBlockBody, parseBlockBodyTolerant, containsHigherOrder, extractArrowBodyExpression, parseStyleObjectEntries, parseProviderObjectLiteral, type ProviderObjectMember } from './expression-parser.ts'
+export { parseExpression, tsNodeToParsedExpr, asCallbackMethodCall, CALLBACK_METHODS, sortComparatorFromArrow, serializeParsedExpr, freeVarsInBody, isSupported, exprToString, stringifyParsedExpr, identifierPath, parseBlockBody, parseBlockBodyTolerant, foldBlockToExpr, predicateTernaryToLogical, containsHigherOrder, extractArrowBodyExpression, parseStyleObjectEntries, parseProviderObjectLiteral, type ProviderObjectMember, type FoldBlockOptions } from './expression-parser.ts'
 export type { StyleObjectEntry } from './expression-parser.ts'
 export type { ParsedExpr, ObjectLiteralProperty, ParsedStatement, SortComparator, SortKey, FlatDepth, SupportLevel, SupportResult, TemplatePart } from './expression-parser.ts'
 export { buildLoopChainExpr } from './loop-chain.ts'


### PR DESCRIPTION
**Stack PR-C of the #2040 memo follow-up.** Base: **`claude/2040-B-memo-guard-const-fold` (PR #2053)** — review/merge PR-B first; this diff is only PR-C's commit on top.

## What

Retires the last per-idiom block-memo recognizer's statement walk — the searchParams-derived object memo (#2015) — by lowering it through the general fold.

```tsx
createMemo(() => {
  const sp = searchParams()
  return { sort: asSortKey(sp.get('sort')), tag: sp.get('tag') ?? '' }
})
```

## How

- `computeObjectMemoInitialValue` previously walked `parsedBlock` for `const sp = searchParams()` bindings + a terminal `return { … }`. It now folds the block with `foldBlockToExpr`, adding `searchParams` to the purity oracle — an idempotent request-query read, safe to inline at each `sp.get('k')` site — and lowers the resulting object-literal. `sp` inlines to `searchParams()`.
- `lowerCtorExpr` now recognises a `searchParams().get('k')` receiver (the inlined form) in addition to the `const sp` env form.
- `foldBlockToExpr` / `predicateTernaryToLogical` / `FoldBlockOptions` are exported from `@barefootjs/jsx` so the adapter can fold.

searchParams-purity knowledge stays in the Go adapter (where `searchParamsLocals` already lives — covering aliased imports), so there's no analyzer coupling.

## Side benefit

An object memo calling `searchParams().get('k')` **directly** (no `const` binding) now lowers too — the old walk required the binding to populate its env. A block that doesn't fold to an object literal returns null → the same nil fallback as before.

## Testing

- New tests: direct-`searchParams()` object memo, aliased `searchParams as sp` import.
- **Go adapter unit: 563 pass / 0 fail.**
- **Conformance (Go + Perl): 780 pass, 9 fail** — the 9 are the pre-existing carousel failures on `main`.
- **jsx: 2165 pass**, only the 4 pre-existing checker-alias failures.

Note: `parsedBlock` is still consumed by the template-literal block memo (template-interp) and the guard-const fallback; its full removal from the IR is the remaining stack PR (PR-D).

Refs: #2040, #2018, #2015.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdVpB6GWgFddUzDo1MYixm)_