### PR TITLE
feat(jsx): fold searchParams object memos in the analyzer; value-only fold mode (#2040)

### DIFF
--- a/.changeset/memo-fold-value-only.md
+++ b/.changeset/memo-fold-value-only.md
@@ -1,0 +1,12 @@
+---
+"@barefootjs/jsx": minor
+"@barefootjs/go-template": patch
+---
+
+Fold the searchParams object memo in the analyzer (value-only mode); the Go adapter reads the folded `parsed` directly (#2040, PR-D of the memo follow-up stack).
+
+`foldBlockToExpr` gains a `valueOnly` option: for a memo's SSR initial value the `parsed` tree is consumed for its VALUE only — effects run on the client via the verbatim runtime code — so a possibly-impure `const` used on some paths but not others is safe to inline (the value on every path is unchanged; only an effect on a path that doesn't use the value is dropped). Duplication of a non-deterministic call (used more than once on a path) is still refused.
+
+The analyzer's memo fold now (a) uses `valueOnly` and (b) adds the `searchParams()` env-signal local(s) to the purity oracle — an idempotent request-query read — so a `const sp = searchParams()` object memo folds to an `object-literal` `parsed` at analysis time. The Go adapter's `computeObjectMemoInitialValue` then reads that folded `parsed` directly and the per-adapter re-fold is removed; `searchParamsLocalNames` is reusable from `{ imports }` (one definition, shared by the analyzer and the adapters).
+
+This drops `parsedBlock` from the object-memo path. Two justified consumers remain (the template-literal block memo and the guard-const fallback for blocks whose unfoldable *alternate* branch — irrelevant to the SSR value — prevents a whole-block fold), so `parsedBlock` stays in the IR for now. Render parity verified: Go adapter unit + conformance (Go + Perl) green, jsx suite carries only the pre-existing checker-alias failures.

--- a/packages/adapter-go-template/src/adapter/memo/memo-value.ts
+++ b/packages/adapter-go-template/src/adapter/memo/memo-value.ts
@@ -10,7 +10,6 @@
  *     delegating value lowering to `lowerCtorExpr`.
  */
 
-import { foldBlockToExpr } from '@barefootjs/jsx'
 import type { ParsedExpr, ParsedStatement, TypeInfo } from '@barefootjs/jsx'
 
 import type { GoEmitContext } from '../emit-context.ts'
@@ -153,26 +152,17 @@ function fromStatementPrefix(
  */
 export function computeObjectMemoInitialValue(
   ctx: GoEmitContext,
-  memo: { parsed?: ParsedExpr; parsedBlock?: ParsedStatement[]; parsedBlockComplete?: boolean },
+  memo: { parsed?: ParsedExpr },
 ): string | null {
-  // Normalize the block to a single object-literal expression (#2040). The
-  // analyzer's fold treats only signal/memo reads as pure, so a
-  // `const sp = searchParams()` (read twice) isn't folded there; redo the fold
-  // here with `searchParams` added to the purity oracle — it is an idempotent
-  // request-query read, so inlining `sp` at each `sp.get('k')` site is sound.
-  // The folded object's values become `searchParams().get('k')` (sp inlined),
-  // lowered by `lowerCtorExpr`. A block that doesn't fold to an object literal
-  // (extra control flow, an impure non-searchParams binding) yields null → the
-  // caller's nil fallback, exactly as the previous statement walk did.
-  let retObj = memo.parsed?.kind === 'object-literal' ? memo.parsed : null
-  if (!retObj) {
-    if (!memo.parsedBlock || !memo.parsedBlockComplete) return null
-    const folded = foldBlockToExpr(memo.parsedBlock, {
-      pureCallNames: ctx.state.searchParamsLocals,
-    })
-    if (!folded.ok || folded.expr.kind !== 'object-literal') return null
-    retObj = folded.expr
-  }
+  // The block is normalized to a single object-literal `parsed` upstream (#2040,
+  // `foldBlockToExpr` in the analyzer, which treats `searchParams()` — an
+  // idempotent request-query read — as pure so `const sp = searchParams()` is
+  // inlined at each `sp.get('k')` site). The folded object's values are
+  // `searchParams().get('k')` (sp inlined), lowered by `lowerCtorExpr`. A block
+  // that doesn't fold to an object literal leaves `parsed` non-object → null →
+  // the caller's nil fallback, exactly as the previous statement walk did.
+  if (memo.parsed?.kind !== 'object-literal') return null
+  const retObj = memo.parsed
   if (retObj.properties.length === 0) return null
 
   // `sp` is inlined to `searchParams()` in the folded values, so no

--- a/packages/jsx/src/adapters/env-signal.ts
+++ b/packages/jsx/src/adapters/env-signal.ts
@@ -7,7 +7,7 @@
 // adapters special-case it to a real per-request reader method call. See #1922.
 
 import type { ParsedExpr } from '../expression-parser.ts'
-import type { IRMetadata } from '../types.ts'
+import type { ImportInfo, IRMetadata } from '../types.ts'
 
 /**
  * The local binding name(s) that `searchParams` from `@barefootjs/client` is
@@ -23,7 +23,7 @@ import type { IRMetadata } from '../types.ts'
  * 'searchParams'` and the local binding is `alias ?? name`. Namespace / default
  * specifiers bind a different identifier and are excluded.
  */
-export function searchParamsLocalNames(metadata: IRMetadata): Set<string> {
+export function searchParamsLocalNames(metadata: { imports: readonly ImportInfo[] }): Set<string> {
   const names = new Set<string>()
   for (const imp of metadata.imports) {
     if (imp.source !== '@barefootjs/client' || imp.isTypeOnly) continue

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -9,6 +9,7 @@
 import ts from 'typescript'
 import type { ImportSpecifier, TypeInfo, ParamInfo, ReactiveFactoryInfo } from './types.ts'
 import { parseExpression, parseBlockBodyTolerant, foldBlockToExpr } from './expression-parser.ts'
+import { searchParamsLocalNames } from './adapters/env-signal.ts'
 import { rewriteBarePropRefs } from './prop-rewrite.ts'
 import { incrementCounter } from './instrumentation.ts'
 import {
@@ -281,16 +282,22 @@ export function analyzeComponent(
   // #2040: fold a complete, value-producing block-bodied memo into a single
   // expression so it flows through the same `parsed` path as an expression-bodied
   // memo, instead of relying on per-idiom block recognizers (#1897 / #1945 /
-  // #2015). Runs after all signals/memos are collected so the reactive-getter
-  // set (used as the purity oracle — an idempotent signal/memo read may be
-  // inlined on several branches) is complete. An incomplete block (the tolerant
-  // parser dropped a statement it couldn't represent) or one that doesn't fold
-  // (imperative residue) leaves `parsed` undefined and consumers keep their
-  // existing `parsedBlock` fallback.
+  // #2015). Runs after all signals/memos are collected so the purity oracle is
+  // complete. The oracle is the reactive getters (signal/memo reads) plus the
+  // `searchParams()` env signal — all idempotent within a render, so safe to
+  // inline at several sites (e.g. `sp.get('sort')` + `sp.get('tag')`). `valueOnly`
+  // because a memo's `parsed` is consumed for SSR value baking only (its effects
+  // run on the client via the verbatim runtime code), so an impure binding
+  // dropped on a path that doesn't use its value is fine — only duplication of a
+  // non-deterministic call is refused. An incomplete block (the tolerant parser
+  // dropped a statement) leaves `parsed` undefined.
+  const spLocals = searchParamsLocalNames({ imports: ctx.imports })
   const reactiveGetterNames = collectReactiveGetterNames(ctx.signals, ctx.memos)
+  const pureCallNames =
+    spLocals.size === 0 ? reactiveGetterNames : new Set([...reactiveGetterNames, ...spLocals])
   for (const memo of ctx.memos) {
     if (memo.parsed || !memo.parsedBlock || !memo.parsedBlockComplete) continue
-    const folded = foldBlockToExpr(memo.parsedBlock, { pureCallNames: reactiveGetterNames })
+    const folded = foldBlockToExpr(memo.parsedBlock, { pureCallNames, valueOnly: true })
     if (folded.ok) memo.parsed = folded.expr
   }
 

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -2629,6 +2629,18 @@ export interface FoldBlockOptions {
    * pure by this set.
    */
   pureCallNames?: ReadonlySet<string>
+  /**
+   * Fold for VALUE only, ignoring dropped side effects. When the folded result
+   * is consumed purely for its value — the SSR initial value of a memo, whose
+   * effects run separately on the client via the verbatim runtime code — a
+   * possibly-impure `const` that ends up used on SOME paths but not others is
+   * still safe to inline: the value on every path is unchanged; only an effect
+   * on a path that doesn't use the value is dropped, and that effect isn't part
+   * of the value. DUPLICATION of a possibly-impure call (used more than once on
+   * a path) stays refused — a non-deterministic call evaluated twice would
+   * change the value. Off by default (the callback path needs effect fidelity).
+   */
+  valueOnly?: boolean
 }
 
 /**
@@ -2893,7 +2905,13 @@ export function foldBlockToExpr(
       // short-circuited operand / a callback); `max !== 1` catches duplication.
       // A pure init is safe at any count (drop / duplicate is unobservable);
       // idempotent reactive getter reads in `pureCallNames` count as pure.
-      if (!isPureInit(head.init, opts?.pureCallNames) && !(uses.min === 1 && uses.max === 1)) {
+      //
+      // In `valueOnly` mode (memo SSR baking) a dropped effect doesn't matter —
+      // the value on every path is unchanged and effects run on the client — so
+      // only DUPLICATION (`max > 1`, a non-deterministic call evaluated twice)
+      // is refused; `min` may be 0.
+      const safeUse = opts?.valueOnly ? uses.max <= 1 : uses.min === 1 && uses.max === 1
+      if (!isPureInit(head.init, opts?.pureCallNames) && !safeUse) {
         return { ok: false, reason: IMPURE_INLINE_BLOCK_REASON }
       }
       const inlined = inlineBinding(restFold.expr, head.name, head.init)


### PR DESCRIPTION
**Stack PR-D of the #2040 memo follow-up.** Base: **`claude/2040-C-searchparams-object-fold` (PR #2054)** — review/merge PR-C first; this diff is only PR-D's commit on top.

## What

Moves the searchParams object-memo fold into the **analyzer** (the compiler normalizes once), and adds the **value-only fold mode** that memo SSR baking needs. Reduces `parsedBlock` consumers 3 → 2.

## Honest scope note

I set out to fully remove `parsedBlock` (the statement AST) from the IR — the "Expr but the IR still carries statements" concern. **It can't be fully removed**, and the probe shows why: the guard-const memo
```
{ const k=sel(); const n=ext(); if(!k) return ALL; return ALL.filter(t=>t.length===n).concat(ALL.slice(n)) }
```
folds *all-or-nothing*. The SSR value only needs the `consequent` (`ALL`, guard falsy), but the **alternate** uses `n` inside a per-element callback — value-unsafe to duplicate — so `foldBlockToExpr` (even `valueOnly`) refuses the whole block. The guard-const fallback therefore genuinely needs the tolerant `parsedBlock` for blocks whose *alternate* (irrelevant to the SSR value) can't fold. So `parsedBlock` stays in the IR with two justified consumers (guard-const fallback + template-literal memo).

## How

- **`foldBlockToExpr({ valueOnly })`** — a memo's `parsed` is consumed for its VALUE only (effects run on the client via the verbatim runtime code), so a possibly-impure `const` used on some paths but not others is safe to inline: the value on every path is unchanged; only an effect on an unused-value path is dropped. Duplication of a non-deterministic call stays refused.
- The analyzer's memo fold uses `valueOnly` and adds the `searchParams()` env-signal local(s) to the purity oracle (idempotent request-query read), so the object memo folds to an `object-literal` `parsed` at analysis time.
- `computeObjectMemoInitialValue` reads that folded `parsed` directly; the per-adapter re-fold (PR-C) and its `parsedBlock` dependency are removed.
- `searchParamsLocalNames` accepts `{ imports }`, shared by the analyzer and the adapters (one definition of the env-signal import recognition).

## Testing

- **Go adapter unit: 563 pass / 0 fail.**
- **Conformance (Go + Perl): 780 pass, 9 fail** — the 9 are the pre-existing carousel failures on `main`.
- **jsx: 2165 pass**, only the 4 pre-existing checker-alias failures.

Refs: #2040, #2018, #2015.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdVpB6GWgFddUzDo1MYixm)_