### PR TITLE
feat(#2057): searchParams env signal → structural createSearchParams() (part 1)

### DIFF
--- a/.changeset/searchparams-structural-signal.md
+++ b/.changeset/searchparams-structural-signal.md
@@ -1,0 +1,34 @@
+---
+"@barefootjs/client": minor
+"@barefootjs/jsx": minor
+"@barefootjs/shared": patch
+"@barefootjs/go-template": patch
+"@barefootjs/hono": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+---
+
+Recognize the `searchParams` env signal structurally via `createSearchParams()` (#2057, part 1).
+
+The request-scoped query env signal is now a `createSignal`-shaped factory the compiler recognizes by structure, removing the `searchParams` name allow-list from the compiler core:
+
+```tsx
+// before
+import { searchParams } from '@barefootjs/client'
+searchParams().get('sort')
+
+// after
+import { createSearchParams } from '@barefootjs/client'
+const [searchParams, setSearchParams] = createSearchParams()
+searchParams().get('sort')        // reactive read
+setSearchParams({ sort: 'price' }) // single imperative navigation path
+```
+
+Because `searchParams` is now a real signal getter, it lands in the fold purity oracle and reactive-getter set structurally — the clean fix for the fold-oracle special-casing (superseding the reverted #2055) with no name allow-list.
+
+- `@barefootjs/client`: **breaking** — the bare `searchParams` export is replaced by `createSearchParams()`, which returns a `[getter, setter]` tuple. The getter is the request-scoped query reader (unchanged SSR + client resolution); `setSearchParams(next)` is the single imperative navigation path (soft same-route nav via the router seam, hard-nav fallback otherwise), replacing the confusing mutable-`URLSearchParams` write path. `SearchParamsInit` accepts a query string, `URLSearchParams`, or a record.
+- `@barefootjs/jsx`: `createSearchParams` is a recognized signal primitive tagged with an `envReader` key on `SignalInfo`; `CLIENT_EXPORTS` swaps `searchParams` for `createSearchParams`; env-signal recognition flows from IR structure, not import names. Codegen keeps env signals out of normal value/field emission while leaving them in the reactivity graph.
+- `@barefootjs/shared`: new `BF_SEAM_NAV_SEARCH` seam for imperative query navigation.
+- Adapters (`go-template`, `hono`, `mojolicious`, `xslate`): env-signal reader lowering keys off signal structure instead of the import name; the per-request reader binding (`bf.SearchParams` / `$searchParams`) is unchanged.
+
+Migration: replace `import { searchParams } from '@barefootjs/client'` + `searchParams()` with `import { createSearchParams } from '@barefootjs/client'` + `const [searchParams] = createSearchParams()`, and use `setSearchParams(...)` for imperative query navigation.

--- a/integrations/shared/blog/PostList.tsx
+++ b/integrations/shared/blog/PostList.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { createMemo, searchParams, queryHref } from '@barefootjs/client'
+import { createMemo, createSearchParams, queryHref } from '@barefootjs/client'
 import { PostListItem } from './PostListItem'
 
 interface Item {
@@ -40,6 +40,7 @@ interface PostListProps {
  * reactive off the same source, so they stay in sync as the query changes.
  */
 export function PostList(props: PostListProps) {
+  const [searchParams] = createSearchParams()
   const params = createMemo(() => {
     const sp = searchParams()
     // Validate the query value against the known keys so an invalid `?sort=foo`

--- a/packages/adapter-go-template/src/__tests__/derived-state-memo.test.ts
+++ b/packages/adapter-go-template/src/__tests__/derived-state-memo.test.ts
@@ -22,10 +22,11 @@ function generate(src: string) {
 describe('Capability A: object-returning searchParams memo → computed map field', () => {
   const SRC = `
 'use client'
-import { createMemo, searchParams } from '@barefootjs/client'
+import { createMemo, createSearchParams } from '@barefootjs/client'
 const SORT_KEYS = ['date', 'title', 'tag']
 const asSortKey = (raw) => (SORT_KEYS.includes(raw) ? raw : 'date')
 export function P() {
+  const [searchParams] = createSearchParams()
   const params = createMemo(() => {
     const sp = searchParams()
     return { sort: asSortKey(sp.get('sort')), tag: sp.get('tag') ?? '' }
@@ -74,8 +75,9 @@ export function P() {
   test('string-valued ternary condition falls back to nil, never invalid Go', () => {
     const src = `
 'use client'
-import { createMemo, searchParams } from '@barefootjs/client'
+import { createMemo, createSearchParams } from '@barefootjs/client'
 export function P() {
+  const [searchParams] = createSearchParams()
   const params = createMemo(() => {
     const sp = searchParams()
     return { label: sp.get('tag') ? 'has' : 'none' }
@@ -95,8 +97,9 @@ export function P() {
   test('block-body memo with control flow falls back to nil', () => {
     const src = `
 'use client'
-import { createMemo, searchParams } from '@barefootjs/client'
+import { createMemo, createSearchParams } from '@barefootjs/client'
 export function P() {
+  const [searchParams] = createSearchParams()
   const params = createMemo(() => {
     const sp = searchParams()
     if (sp.get('x')) return { sort: 'early' }
@@ -115,10 +118,11 @@ describe('Capability B: inline local pure helper calls at attribute call sites',
   test('sortClass(k) inlines to a conditional, not a .SortClass method call', () => {
     const src = `
 'use client'
-import { createMemo, searchParams } from '@barefootjs/client'
+import { createMemo, createSearchParams } from '@barefootjs/client'
 const SORT_KEYS = ['date', 'title', 'tag']
 const asSortKey = (raw) => (SORT_KEYS.includes(raw) ? raw : 'date')
 export function P() {
+  const [searchParams] = createSearchParams()
   const params = createMemo(() => {
     const sp = searchParams()
     return { sort: asSortKey(sp.get('sort')), tag: sp.get('tag') ?? '' }
@@ -139,8 +143,9 @@ export function P() {
   test('tagClass(t) inlines inside a loop, resolving the loop var and root memo', () => {
     const src = `
 'use client'
-import { createMemo, searchParams } from '@barefootjs/client'
+import { createMemo, createSearchParams } from '@barefootjs/client'
 export function P(props: { tags: string[] }) {
+  const [searchParams] = createSearchParams()
   const params = createMemo(() => {
     const sp = searchParams()
     return { tag: sp.get('tag') ?? '' }
@@ -270,9 +275,10 @@ describe('Capability D: array-memo .length → handler-filled loop slice count',
   test('visible().length lowers to len .<Slice>, not the nil memo field', () => {
     const src = `
 'use client'
-import { createMemo, searchParams } from '@barefootjs/client'
+import { createMemo, createSearchParams } from '@barefootjs/client'
 import { Row } from './Row'
 export function P(props: { items: { id: string }[] }) {
+  const [searchParams] = createSearchParams()
   const params = createMemo(() => {
     const sp = searchParams()
     return { tag: sp.get('tag') ?? '' }
@@ -404,8 +410,9 @@ describe('Capability D: searchParams object memo via fold (#2040 PR-C)', () => {
     // `searchParams().get('k')` in the returned object now lowers too.
     const { types } = generate(`
 "use client"
-import { createMemo, searchParams } from "@barefootjs/client"
+import { createMemo, createSearchParams } from "@barefootjs/client"
 export function PostList() {
+  const [searchParams] = createSearchParams()
   const params = createMemo(() => {
     return { tag: searchParams().get('tag') ?? '' }
   })
@@ -417,11 +424,12 @@ export function PostList() {
     expect(types).toContain('in.SearchParams.Get("tag")')
   })
 
-  test('aliased searchParams import still lowers (local-name oracle)', () => {
+  test('aliased env-signal getter still lowers (local-name oracle)', () => {
     const { types } = generate(`
 "use client"
-import { createMemo, searchParams as sp } from "@barefootjs/client"
+import { createMemo, createSearchParams } from "@barefootjs/client"
 export function PostList() {
+  const [sp] = createSearchParams()
   const params = createMemo(() => {
     const q = sp()
     return { tag: q.get('tag') ?? '' }

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -226,8 +226,9 @@ describe('GoTemplateAdapter - searchParams() env-signal lowering (#1922)', () =>
   test('lowers searchParams().get(k) to .SearchParams.Get and emits the struct binding', () => {
     const adapter = new GoTemplateAdapter()
     const ir = compileToIR(`
-import { searchParams } from '@barefootjs/client'
+import { createSearchParams } from '@barefootjs/client'
 export function SortLabel() {
+  const [searchParams] = createSearchParams()
   return <p>{searchParams().get('sort') ?? 'none'}</p>
 }
 `, adapter)
@@ -237,14 +238,15 @@ export function SortLabel() {
     expect(types).toContain('SearchParams: in.SearchParams')
   })
 
-  // An aliased import binds the env signal to a different local name; the
-  // call `sp()` still resolves to the canonical `.SearchParams` field (the
-  // generated struct field name is fixed, not derived from the JS alias).
-  test('aliased import (`searchParams as sp`) resolves sp() to canonical .SearchParams', () => {
+  // An aliased destructured getter binds the env signal to a different local
+  // name; the call `sp()` still resolves to the canonical `.SearchParams` field
+  // (the generated struct field name is fixed, not derived from the JS name).
+  test('aliased env-signal getter (`const [sp] = createSearchParams()`) resolves sp() to canonical .SearchParams', () => {
     const adapter = new GoTemplateAdapter()
     const ir = compileToIR(`
-import { searchParams as sp } from '@barefootjs/client'
+import { createSearchParams } from '@barefootjs/client'
 export function SortLabel() {
+  const [sp] = createSearchParams()
   return <p>{sp().get('sort') ?? 'none'}</p>
 }
 `, adapter)
@@ -267,8 +269,9 @@ describe('GoTemplateAdapter - template-literal text lowering (#1933)', () => {
     const adapter = new GoTemplateAdapter()
     const ir = compileToIR(`
 'use client'
-import { createMemo, searchParams } from '@barefootjs/client'
+import { createMemo, createSearchParams } from '@barefootjs/client'
 export function StatusLine() {
+  const [searchParams] = createSearchParams()
   const tag = createMemo(() => searchParams().get('tag') ?? '')
   return (
     <div className="status">

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -701,7 +701,11 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // redeclare the field and break the Go compile.
     const taken = new Set<string>([
       ...ir.metadata.propsParams.map(p => capitalizeFieldName(p.name)),
-      ...ir.metadata.signals.map(s => capitalizeFieldName(s.getter)),
+      // Env signals (`createSearchParams()`) don't produce a normal value field —
+      // they ARE the `SearchParams` binding — so they must not poison this
+      // collision set (a getter named `searchParams` would otherwise capitalise
+      // to `SearchParams` and suppress the real reader field).
+      ...ir.metadata.signals.filter(s => !s.envReader).map(s => capitalizeFieldName(s.getter)),
       ...ir.metadata.memos.map(m => capitalizeFieldName(m.name)),
       ...this.state.contextConsumers.map(c => this.contextFieldName(c)),
     ])
@@ -1060,6 +1064,9 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
     // Signal initial values (skip a name already emitted as a prop field).
     for (const signal of ir.metadata.signals) {
+      // Env signals are the request-scoped `SearchParams` reader field, not a
+      // stored value — no baked initial value to emit here (#2057).
+      if (signal.envReader) continue
       const fieldName = capitalizeFieldName(signal.getter)
       if (propFieldNames.has(fieldName)) continue
       // `props.X ?? N` reuses the hoisted fallback var so signal and memo share
@@ -1528,6 +1535,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // localTypeNames/localStructFields so the baker resolves the element type.
     this.state.synthStructTypes = new Map<string, TypeInfo>()
     for (const signal of ir.metadata.signals) {
+      if (signal.envReader) continue // env signal has no bakeable initial shape (#2057)
       const synth = this.synthesizeStructFromSignal(signal, componentName)
       if (!synth) continue
       this.state.localTypeNames.add(synth.name)
@@ -1657,6 +1665,9 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     const propsParamMap = new Map(ir.metadata.propsParams.map(p => [p.name, p]))
 
     for (const signal of ir.metadata.signals) {
+      // Env signals are bound as the `SearchParams bf.SearchParams` reader field
+      // (see generateInputStruct), not as a generic value field (#2057).
+      if (signal.envReader) continue
       const fieldName = capitalizeFieldName(signal.getter)
       if (propFieldNames.has(fieldName)) continue
       const jsonTag = this.toJsonTag(signal.getter)

--- a/packages/adapter-hono/src/__tests__/request-env.test.tsx
+++ b/packages/adapter-hono/src/__tests__/request-env.test.tsx
@@ -12,13 +12,14 @@
  */
 
 import { describe, test, expect, beforeAll } from 'bun:test'
-import { searchParams } from '@barefootjs/client'
+import { createSearchParams } from '@barefootjs/client'
 import { renderToHtml } from '../render'
 import { runWithRequestEnv, withRequestEnv } from '../request-env'
 
 // A plain hono/jsx component that reads the env signal at SSR — exactly what a
 // compiled BarefootJS component lowers `{searchParams().get('sort') ?? 'none'}`
 // to on the Hono adapter.
+const [searchParams] = createSearchParams()
 const SortLabel = () => <p>{searchParams().get('sort') ?? 'none'}</p>
 
 // Install a prior keyed reader on the seam BEFORE the first `runWithRequestEnv`

--- a/packages/adapter-hono/src/adapter/hono-adapter.ts
+++ b/packages/adapter-hono/src/adapter/hono-adapter.ts
@@ -376,8 +376,12 @@ export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderC
     const propsTypeName = this.getPropsTypeName(ir)
 
     // Validate: only reactive primitives (signals, memos, effects, onMounts) require "use client"
+    // Env signals (`createSearchParams()`, #2057) are exempt — reading the
+    // request query is SSR-safe and needs no hydration, so a component that only
+    // reads an env signal stays a plain SSR component (as `searchParams()` did
+    // before it became a structural signal).
     const hasReactivePrimitives =
-      ir.metadata.signals.length > 0 ||
+      ir.metadata.signals.some(s => !s.envReader) ||
       ir.metadata.memos.length > 0 ||
       ir.metadata.effects.length > 0 ||
       ir.metadata.onMounts.length > 0

--- a/packages/adapter-hono/src/client-shim.ts
+++ b/packages/adapter-hono/src/client-shim.ts
@@ -27,12 +27,12 @@ export {
   forwardProps,
   unwrap,
   __slot,
-  // Request-scoped env signal (router v0.5). Unlike the reactive primitives
-  // below, `searchParams()` is meant to resolve during SSR — on the server it
-  // reads the per-request query via the injected reader (the Hono adapter wires
-  // it in `search-params-ssr.ts`), defaulting to an empty query — so the real
-  // export is re-exported, not a throwing stub.
-  searchParams,
+  // Request-scoped env signal factory (router v0.5). Unlike the reactive
+  // primitives below, `createSearchParams()`'s getter is meant to resolve during
+  // SSR — on the server it reads the per-request query via the injected reader
+  // (the Hono adapter wires it in `search-params-ssr.ts`), defaulting to an empty
+  // query — so the real export is re-exported, not a throwing stub.
+  createSearchParams,
   // Pure URL-query builder (#2042) — like the other pure helpers above, it has
   // no reactivity and runs unchanged during SSR, so the real export is
   // re-exported (not a stub).

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -239,8 +239,9 @@ describe('MojoAdapter - searchParams() env-signal lowering (#1922)', () => {
   // generic hash deref `$searchParams->{get}` (which drops the arg).
   test('lowers searchParams().get(k) to a method call on $searchParams', () => {
     const { template } = compileAndGenerate(`
-import { searchParams } from '@barefootjs/client'
+import { createSearchParams } from '@barefootjs/client'
 function SortLabel() {
+  const [searchParams] = createSearchParams()
   return <p>{searchParams().get('sort') ?? 'none'}</p>
 }
 `)
@@ -248,13 +249,14 @@ function SortLabel() {
     expect(template).not.toContain('$searchParams->{get}')
   })
 
-  // An aliased import binds the env signal to a different local name; the
-  // expression reads `sp()`, but it still lowers to the canonical
+  // An aliased destructured getter binds the env signal to a different local
+  // name; the expression reads `sp()`, but it still lowers to the canonical
   // `$searchParams` reader (the harness/plugin seed that fixed var).
-  test('matches an aliased import (`searchParams as sp`) and emits canonical $searchParams', () => {
+  test('matches an aliased env-signal getter (`const [sp] = createSearchParams()`) and emits canonical $searchParams', () => {
     const { template } = compileAndGenerate(`
-import { searchParams as sp } from '@barefootjs/client'
+import { createSearchParams } from '@barefootjs/client'
 function SortLabel() {
+  const [sp] = createSearchParams()
   return <p>{sp().get('sort') ?? 'none'}</p>
 }
 `)

--- a/packages/adapter-mojolicious/src/test-render.ts
+++ b/packages/adapter-mojolicious/src/test-render.ts
@@ -453,6 +453,7 @@ function buildChildDefaultsPerl(ir: ComponentIR): string {
     }
   }
   for (const signal of ir.metadata.signals) {
+    if (signal.envReader) continue // env signal is the request reader, not a stashed value (#2057)
     const value = evaluateSignalInit(signal.initialValue.trim(), undefined)
     entries.push(`${signal.getter} => ${value !== null ? toPerlLiteral(value) : 'undef'}`)
   }
@@ -599,6 +600,7 @@ function buildPerlProps(
   // vars with `Global symbol "$x" requires explicit package name`. Same
   // rule `buildChildDefaultsPerl` applies to child signals (#1897).
   for (const signal of ir.metadata.signals) {
+    if (signal.envReader) continue // env signal bound below via search_params('') (#2057)
     const value = evaluateSignalInit(signal.initialValue.trim(), props)
     entries.push(`${signal.getter} => ${value !== null ? toPerlLiteral(value) : 'undef'}`)
   }

--- a/packages/adapter-tests/fixtures/search-params.ts
+++ b/packages/adapter-tests/fixtures/search-params.ts
@@ -1,8 +1,9 @@
 import { createFixture } from '../src/types'
 
-// `searchParams()` (router v0.5) is a request-scoped reactive environment
-// signal. Reading it in a component compiles to a normal dynamic-text binding;
-// on the server it resolves the current request's query (empty here, since the
+// `createSearchParams()` (router v0.5) is a request-scoped reactive environment
+// signal — a `createSignal`-shaped `[getter, setter]` recognised structurally
+// (#2057). Reading the getter compiles to a normal dynamic-text binding; on the
+// server it resolves the current request's query (empty here, since the
 // conformance harness issues no query string), so `.get('sort') ?? 'none'`
 // renders the default `none`.
 //
@@ -13,14 +14,15 @@ import { createFixture } from '../src/types'
 // https://github.com/piconic-ai/barefootjs/issues/1922.
 export const fixture = createFixture({
   id: 'search-params',
-  description: 'searchParams() env signal renders its empty-query default at SSR',
+  description: 'createSearchParams() env signal renders its empty-query default at SSR',
   source: `
-import { searchParams } from '@barefootjs/client'
+import { createSearchParams } from '@barefootjs/client'
 export function SortLabel() {
+  const [searchParams] = createSearchParams()
   return <p>{searchParams().get('sort') ?? 'none'}</p>
 }
 `,
   expectedHtml: `
-    <p bf-s="test"><!--bf:s0-->none<!--/--></p>
+    <p bf-s="test" bf="s1"><!--bf:s0-->none<!--/--></p>
   `,
 })

--- a/packages/adapter-xslate/src/test-render.ts
+++ b/packages/adapter-xslate/src/test-render.ts
@@ -516,6 +516,9 @@ function buildPerlProps(
 
   // Signal values evaluated from props (after user props).
   for (const signal of ir.metadata.signals) {
+    // Env signals (#2057) are bound below via `search_params('')`, not from a
+    // static initial value.
+    if (signal.envReader) continue
     const value = evaluateSignalInit(signal.initialValue.trim(), props)
     if (value !== null) {
       entries.push(`${signal.getter} => ${toPerlLiteral(value)}`)

--- a/packages/client/__tests__/env-signal.test.ts
+++ b/packages/client/__tests__/env-signal.test.ts
@@ -17,9 +17,10 @@ beforeAll(() => {
   }
 })
 
-const { searchParams, __bfSetServerEnvReader, createEffect, createRoot } = await import(
+const { createSearchParams, __bfSetServerEnvReader, createEffect, createRoot } = await import(
   '../src/reactive.ts'
 )
+const [searchParams, setSearchParams] = createSearchParams()
 
 describe('searchParams (client)', () => {
   test('reads the live URL query on first access and installs the push seam', () => {

--- a/packages/client/__tests__/env-signal.test.ts
+++ b/packages/client/__tests__/env-signal.test.ts
@@ -22,6 +22,16 @@ const { createSearchParams, __bfSetServerEnvReader, createEffect, createRoot } =
 )
 const [searchParams, setSearchParams] = createSearchParams()
 
+describe('createSearchParams', () => {
+  test('returns a referentially-stable tuple (same getter + setter every call)', () => {
+    const a = createSearchParams()
+    const b = createSearchParams()
+    expect(a).toBe(b)
+    expect(a[0]).toBe(b[0])
+    expect(a[1]).toBe(b[1])
+  })
+})
+
 describe('searchParams (client)', () => {
   test('reads the live URL query on first access and installs the push seam', () => {
     expect(searchParams().get('sort')).toBe('price')

--- a/packages/client/__tests__/env-signal.test.ts
+++ b/packages/client/__tests__/env-signal.test.ts
@@ -32,6 +32,59 @@ describe('createSearchParams', () => {
   })
 })
 
+describe('setSearchParams', () => {
+  // Capture the imperative-nav seam the router would install, so we can assert
+  // both the seam wiring and the `SearchParamsInit` normalization without a
+  // real navigation.
+  const NAV_SEAM = '__bf_navSearch'
+  function withNavSeam(fn: (calls: string[]) => void): void {
+    const w = window as unknown as Record<string, ((s: string) => void) | undefined>
+    const prev = w[NAV_SEAM]
+    const calls: string[] = []
+    w[NAV_SEAM] = (s: string) => calls.push(s)
+    try {
+      fn(calls)
+    } finally {
+      w[NAV_SEAM] = prev
+    }
+  }
+
+  test('writes through the nav seam when a router has installed it', () => {
+    withNavSeam((calls) => {
+      setSearchParams('?sort=price')
+      expect(calls).toEqual(['?sort=price'])
+    })
+  })
+
+  test('normalizes a bare string (adds leading ?)', () => {
+    withNavSeam((calls) => {
+      setSearchParams('sort=price')
+      expect(calls).toEqual(['?sort=price'])
+    })
+  })
+
+  test('normalizes a record, appending array values as multi-value', () => {
+    withNavSeam((calls) => {
+      setSearchParams({ sort: 'price', tag: ['a', 'b'] })
+      expect(calls).toEqual(['?sort=price&tag=a&tag=b'])
+    })
+  })
+
+  test('normalizes a URLSearchParams', () => {
+    withNavSeam((calls) => {
+      setSearchParams(new URLSearchParams({ q: 'hi there' }))
+      expect(calls).toEqual(['?q=hi+there'])
+    })
+  })
+
+  test('an empty query normalizes to the empty string', () => {
+    withNavSeam((calls) => {
+      setSearchParams({})
+      expect(calls).toEqual([''])
+    })
+  })
+})
+
 describe('searchParams (client)', () => {
   test('reads the live URL query on first access and installs the push seam', () => {
     expect(searchParams().get('sort')).toBe('price')

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -16,10 +16,12 @@ export {
   endTurn,
   __bfReportOutput,
   // Request-scoped reactive environment signals (spec/router.md "The wedge").
-  // `searchParams` lives in the shared reactive module too, so this entry and
-  // the `/runtime` entry resolve to ONE signal instance. `createEnvSignal` stays
-  // internal; `__bfSetServerEnvReader` is the keyed adapter/host hook for SSR.
-  searchParams,
+  // `createSearchParams` lives in the shared reactive module too, so this entry
+  // and the `/runtime` entry resolve to ONE signal instance. `createEnvSignal`
+  // stays internal; `__bfSetServerEnvReader` is the keyed adapter/host hook for
+  // SSR.
+  createSearchParams,
+  type SearchParamsInit,
   __bfSetServerEnvReader,
   type Reactive,
   type Signal,

--- a/packages/client/src/reactive.ts
+++ b/packages/client/src/reactive.ts
@@ -793,9 +793,15 @@ const [searchParamsGetter, setSearchParamsRaw] = createEnvSignal(
  * Every call returns the same request-scoped getter/setter — there is one query
  * per document, so the tuple is a stable view, not per-call state.
  */
+const setSearchParams = (next: SearchParamsInit): void => setSearchParamsRaw(toSearchString(next))
+const searchParamsTuple: readonly [
+  Reactive<() => URLSearchParams>,
+  (next: SearchParamsInit) => void,
+] = [searchParamsGetter, setSearchParams]
+
 export function createSearchParams(): readonly [
   Reactive<() => URLSearchParams>,
   (next: SearchParamsInit) => void,
 ] {
-  return [searchParamsGetter, (next: SearchParamsInit) => setSearchParamsRaw(toSearchString(next))]
+  return searchParamsTuple
 }

--- a/packages/client/src/reactive.ts
+++ b/packages/client/src/reactive.ts
@@ -5,7 +5,7 @@
  * Inspired by SolidJS signals.
  */
 
-import { BF_SEAM_PUSH_SEARCH } from '@barefootjs/shared'
+import { BF_SEAM_NAV_SEARCH, BF_SEAM_PUSH_SEARCH } from '@barefootjs/shared'
 
 /**
  * Phantom brand for compile-time reactivity detection.
@@ -665,15 +665,22 @@ function resolveServerEnv(key: string): string | undefined {
 
 /**
  * Build a request-scoped reactive environment signal, keyed by `key` — the env
- * id the SSR reader resolves (`'search'`, …). Internal: only concrete instances
- * (`searchParams`, …) are exported.
+ * id the SSR reader resolves (`'search'`, …) — as a `createSignal`-shaped
+ * `[getter, setter]` tuple. Internal: only concrete factories
+ * (`createSearchParams`, …) are exported.
+ *
+ * The tuple shape is deliberate (#2057): the compiler recognises the getter
+ * *structurally* — the same path as `createSignal` — so it needs no env-signal
+ * name allow-list, and the getter is pure-within-render for the block fold. The
+ * setter is the single imperative navigation path.
  */
 function createEnvSignal<T>(
   key: string,
   readClient: () => string,
   parse: (raw: string) => T,
   pushSeam: string,
-): Reactive<() => T> {
+  navSeam: string,
+): readonly [Reactive<() => T>, (nextRaw: string) => void] {
   let getRaw: (() => string) | null = null
 
   function ensureClientSignal(): string {
@@ -693,7 +700,7 @@ function createEnvSignal<T>(
     return getRaw()
   }
 
-  return (() => {
+  const getter = (() => {
     if (typeof window === 'undefined') {
       // SSR: resolve per-call inside the host's request context. Never cache a
       // module-level signal — it would be a process-wide global that races.
@@ -701,29 +708,94 @@ function createEnvSignal<T>(
     }
     return parse(ensureClientSignal())
   }) as Reactive<() => T>
+
+  // Imperative navigation. The setter writes the new raw value through the
+  // router's nav seam (soft, same-route query navigation) when a router has
+  // installed it; otherwise it hard-navigates — "never worse than an MPA" — so
+  // the write is correct standalone. The getter is then updated by the router
+  // through `pushSeam`, keeping read reactivity in one place. On the server a
+  // setter call is a no-op (there is nothing to navigate).
+  const setter = (nextRaw: string) => {
+    if (typeof window === 'undefined') return
+    const w = window as unknown as Record<string, ((next: string) => void) | undefined>
+    const nav = w[navSeam]
+    if (typeof nav === 'function') {
+      nav(nextRaw)
+      return
+    }
+    window.location.search = nextRaw
+  }
+
+  return [getter, setter] as const
 }
 
-/**
- * Reactive read of the current query string as `URLSearchParams`.
- *
- * ```tsx
- * const sort = createMemo(() => searchParams().get('sort') ?? 'recent')
- * ```
- *
- * A same-route, query-only navigation (`/list?sort=price`) driven by
- * `@barefootjs/router` updates this signal and the URL **without a swap or
- * re-hydration**. On the server it reflects the current request's query.
- *
- * Reactivity is **router-driven**: the signal is seeded once on first read and
- * thereafter updated only through the `window.__bf_pushSearch` seam, which
- * `startRouter()` drives (including on `popstate`). Without the router running
- * — or after a non-router `history` change — the value is read-once; the seam
- * name is shared with `@barefootjs/router` via `BF_SEAM_PUSH_SEARCH`, so the
- * installer (here) and the pusher agree by construction.
- */
-export const searchParams = createEnvSignal(
+/** Accepted inputs for `setSearchParams` — a raw query string (with or without
+ *  a leading `?`), a `URLSearchParams`, or a plain record (array = multi-value,
+ *  form-encoded like the client `queryHref`, cf. #2048). */
+export type SearchParamsInit =
+  | string
+  | URLSearchParams
+  | Record<string, string | readonly string[]>
+
+function toSearchString(next: SearchParamsInit): string {
+  let usp: URLSearchParams
+  if (next instanceof URLSearchParams) {
+    usp = next
+  } else if (typeof next === 'string') {
+    usp = new URLSearchParams(next.startsWith('?') ? next.slice(1) : next)
+  } else {
+    usp = new URLSearchParams()
+    for (const [k, v] of Object.entries(next)) {
+      if (Array.isArray(v)) {
+        for (const item of v) usp.append(k, item)
+      } else {
+        usp.append(k, v as string)
+      }
+    }
+  }
+  const s = usp.toString()
+  return s ? `?${s}` : ''
+}
+
+const [searchParamsGetter, setSearchParamsRaw] = createEnvSignal(
   'search',
   () => window.location.search,
   (raw) => new URLSearchParams(raw),
   BF_SEAM_PUSH_SEARCH,
+  BF_SEAM_NAV_SEARCH,
 )
+
+/**
+ * `createSearchParams()` — the request-scoped query-string env signal, returned
+ * as a `createSignal`-shaped `[getter, setter]` tuple (#2057):
+ *
+ * ```tsx
+ * const [searchParams, setSearchParams] = createSearchParams()
+ * const sort = createMemo(() => searchParams().get('sort') ?? 'recent')
+ * // …
+ * setSearchParams({ sort: 'price' })   // imperative, same-route navigation
+ * ```
+ *
+ * **Read** (`searchParams()`): the current query as `URLSearchParams`. A
+ * same-route, query-only navigation (`/list?sort=price`) driven by
+ * `@barefootjs/router` updates this signal and the URL **without a swap or
+ * re-hydration**. On the server it reflects the current request's query.
+ * Reactivity is **router-driven**: the signal is seeded once on first read and
+ * thereafter updated only through the `window.__bf_pushSearch` seam, which
+ * `startRouter()` drives (including on `popstate`).
+ *
+ * **Write** (`setSearchParams(next)`): the single imperative navigation path —
+ * a soft same-route navigation when a router is running, a hard navigation
+ * otherwise. This replaces mutating a live `URLSearchParams` reader (which only
+ * ever changed a throwaway copy), so there is exactly one way to change the
+ * query.
+ *
+ * Every call returns the same request-scoped getter/setter — there is one query
+ * per document, so the tuple is a stable view, not per-call state.
+ */
+export function createSearchParams(): readonly [
+  Reactive<() => URLSearchParams>,
+  (next: SearchParamsInit) => void,
+] {
+  return [searchParamsGetter, (next: SearchParamsInit) => setSearchParamsRaw(toSearchString(next))]
+}

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -23,11 +23,13 @@ export {
   endTurn,
   __bfReportOutput,
   // Request-scoped env signal (router v0.5). The compiler emits island client JS
-  // that imports `searchParams` from `@barefootjs/client/runtime`; re-exporting
-  // it from the shared reactive module (same as the signal primitives above)
-  // means this entry and the main `@barefootjs/client` entry resolve to ONE
-  // signal instance — no second copy to disconnect from router pushes.
-  searchParams,
+  // that imports `createSearchParams` from `@barefootjs/client/runtime`;
+  // re-exporting it from the shared reactive module (same as the signal
+  // primitives above) means this entry and the main `@barefootjs/client` entry
+  // resolve to ONE signal instance — no second copy to disconnect from router
+  // pushes.
+  createSearchParams,
+  type SearchParamsInit,
   __bfSetServerEnvReader,
   type Reactive,
   type Signal,

--- a/packages/jsx/src/__tests__/primitive-resolver-alias.test.ts
+++ b/packages/jsx/src/__tests__/primitive-resolver-alias.test.ts
@@ -100,6 +100,29 @@ describe('reactive primitive resolver — alias fidelity (checker path)', () => 
     expect(ctx.signals[0].initialValue).toBe('0')
   })
 
+  test('import { createSearchParams as csp }: csp() is recognized as an env signal', () => {
+    // #2057: the env-signal factory resolves through the same alias path as
+    // createSignal. The signal must be tagged `envReader` and carry the
+    // as-written callee (`csp`) so client/SSR emit `csp()`, not the canonical
+    // name — and validateReactiveFactoryCalls must NOT raise BF110 for it.
+    const filePath = path.resolve(CLIENT_DIR, '../.bench-env-alias-test.tsx')
+    const source = `
+      import { createSearchParams as csp } from '@barefootjs/client'
+      export function SortLabel() {
+        const [sp] = csp()
+        return <p>{sp().get('sort') ?? 'none'}</p>
+      }
+    `
+    const program = programFor(filePath, source)
+    const ctx = analyzeComponent(source, filePath, undefined, program)
+    expect(ctx.signals).toHaveLength(1)
+    expect(ctx.signals[0].getter).toBe('sp')
+    expect(ctx.signals[0].envReader).toBe('search')
+    expect(ctx.signals[0].envFactory).toBe('csp')
+    // No spurious BF110 (unrecognized reactive factory) for the aliased call.
+    expect(ctx.errors.some(e => e.code === 'BF110')).toBe(false)
+  })
+
   test('user-defined function named createSignal is NOT misclassified without checker', () => {
     // Without a checker, the fast path still matches by name. This
     // documents the limitation — the fast path is optimistic. A shared

--- a/packages/jsx/src/adapters/env-signal.ts
+++ b/packages/jsx/src/adapters/env-signal.ts
@@ -10,36 +10,45 @@ import type { ParsedExpr } from '../expression-parser.ts'
 import type { IRMetadata } from '../types.ts'
 
 /**
- * The local binding name(s) that `searchParams` from `@barefootjs/client` is
- * imported under in this component — the same import the analyzer allow-lists
- * (`CLIENT_EXPORTS`). Usually the single name `searchParams`, but an aliased
- * import (`import { searchParams as sp }`) binds it to `sp`, and the template
- * expression then reads `sp()` — so adapters must gate + match against the
- * LOCAL name(s), not the literal `searchParams`. Empty when the env signal is
- * not imported (the component keeps the generic signal lowering).
+ * Env-signal key → the runtime factory that produces it (`'search'` →
+ * `createSearchParams`). Single source of truth for the reverse of the
+ * analyzer's `ENV_SIGNAL_FACTORIES` (#2057): an env signal is `createSignal`-
+ * shaped for analysis, but every backend that re-emits its declaration (client
+ * JS, JSX/Hono SSR) must call this factory, not `createSignal`, so the value is
+ * the request-scoped reader rather than stored state.
+ */
+export const ENV_SIGNAL_CLIENT_FACTORY: Record<string, string> = {
+  search: 'createSearchParams',
+}
+
+/**
+ * The getter name(s) of the `searchParams` env signal in this component.
  *
- * `ImportSpecifier.name` is the exported name and `alias` the local rebinding
- * (see `collectImport` in analyzer.ts), so the import is detected by `name ===
- * 'searchParams'` and the local binding is `alias ?? name`. Namespace / default
- * specifiers bind a different identifier and are excluded.
+ * Recognised **structurally** (#2057): the env signal is now declared as a
+ * `createSignal`-shaped `const [searchParams, setSearchParams] =
+ * createSearchParams()`, so the analyzer collects it into `metadata.signals`
+ * with `envReader: 'search'` — exactly like any other signal, but tagged. This
+ * function returns those getters (whatever the destructured name is —
+ * `searchParams`, or an alias), so adapters match the reader `.get()` call
+ * against the binding actually used, with **no `searchParams`-name allow-list**
+ * (this supersedes the import-name matching, and the closed #2055).
+ *
+ * Empty when the component declares no env signal (the component keeps the
+ * generic signal lowering).
  */
 export function searchParamsLocalNames(metadata: IRMetadata): Set<string> {
   const names = new Set<string>()
-  for (const imp of metadata.imports) {
-    if (imp.source !== '@barefootjs/client' || imp.isTypeOnly) continue
-    for (const s of imp.specifiers) {
-      if (s.isTypeOnly || s.isNamespace || s.isDefault) continue
-      if (s.name === 'searchParams') names.add(s.alias ?? s.name)
-    }
+  for (const s of metadata.signals) {
+    if (s.envReader === 'search') names.add(s.getter)
   }
   return names
 }
 
 /**
- * True when the component imports the `searchParams` env signal under any local
- * name. Convenience for adapters/harnesses that only need to gate on presence
- * (the lowering itself needs the {@link searchParamsLocalNames} set to match the
- * actual binding in the expression).
+ * True when the component declares the `searchParams` env signal. Convenience
+ * for adapters/harnesses that only need to gate on presence (the lowering
+ * itself needs the {@link searchParamsLocalNames} set to match the actual
+ * binding in the expression).
  */
 export function importsSearchParams(metadata: IRMetadata): boolean {
   return searchParamsLocalNames(metadata).size > 0

--- a/packages/jsx/src/adapters/jsx-adapter.ts
+++ b/packages/jsx/src/adapters/jsx-adapter.ts
@@ -114,8 +114,10 @@ export abstract class JsxAdapter extends BaseAdapter {
       if (signal.envReader) {
         // Env signal (#2057): call the real runtime factory so SSR resolves the
         // request query through the installed server env reader, not a static
-        // initial value. The `createSearchParams` import is preserved for SSR.
-        const factory = ENV_SIGNAL_CLIENT_FACTORY[signal.envReader]
+        // initial value. Emit the factory as written (alias / namespace aware),
+        // matching the import re-emitted into the SSR module; fall back to the
+        // canonical name if the callee text wasn't captured.
+        const factory = signal.envFactory ?? ENV_SIGNAL_CLIENT_FACTORY[signal.envReader]
         if (factory) {
           lines.push(
             signal.setter

--- a/packages/jsx/src/adapters/jsx-adapter.ts
+++ b/packages/jsx/src/adapters/jsx-adapter.ts
@@ -12,6 +12,7 @@ import type {
 } from '../types.ts'
 import { BF_SCOPE, BF_SLOT, BF_COND } from '@barefootjs/shared'
 import { BaseAdapter } from './interface.ts'
+import { ENV_SIGNAL_CLIENT_FACTORY } from './env-signal.ts'
 import { formatParamWithType, findReachableNames } from '../module-exports.ts'
 
 export interface JsxAdapterConfig {
@@ -110,6 +111,20 @@ export abstract class JsxAdapter extends BaseAdapter {
 
     for (const signal of ir.metadata.signals) {
       if (signal.isModule) continue
+      if (signal.envReader) {
+        // Env signal (#2057): call the real runtime factory so SSR resolves the
+        // request query through the installed server env reader, not a static
+        // initial value. The `createSearchParams` import is preserved for SSR.
+        const factory = ENV_SIGNAL_CLIENT_FACTORY[signal.envReader]
+        if (factory) {
+          lines.push(
+            signal.setter
+              ? `  const [${signal.getter}, ${signal.setter}] = ${factory}()`
+              : `  const [${signal.getter}] = ${factory}()`,
+          )
+        }
+        continue
+      }
       // Create a getter that returns the initial value for SSR
       const rawInitialValue = preserveTypes
         ? (signal.typedInitialValue ?? signal.initialValue)

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -994,6 +994,24 @@ const PRIMITIVE_CANONICAL_NAMES: Record<string, 'signal' | 'memo' | 'effect' | '
   createEffect: 'effect',
   onMount: 'onMount',
   onCleanup: 'onCleanup',
+  // Request-scoped env-signal factories (#2057) are `createSignal`-shaped, so
+  // they resolve to the `signal` kind and flow through the normal signal
+  // collection + fold purity oracle. Their env key (see ENV_SIGNAL_FACTORIES)
+  // is recorded separately on the collected signal so adapters can lower the
+  // reader value; the reactivity kind itself is just `signal`.
+  createSearchParams: 'signal',
+}
+
+/**
+ * Env-signal factories → the request-env key their getter reads
+ * (`createSearchParams` → `'search'`, matching the runtime's
+ * `createEnvSignal('search', …)`). Recognising the *factory* is a general
+ * mechanism (like the reactive-primitive names above); the resulting signal is
+ * tagged with the key so adapters lower its reader value from structure, with
+ * no `searchParams`-name allow-list (#2057, superseding #2055).
+ */
+const ENV_SIGNAL_FACTORIES: Record<string, string> = {
+  createSearchParams: 'search',
 }
 
 type PrimitiveKind = (typeof PRIMITIVE_CANONICAL_NAMES)[keyof typeof PRIMITIVE_CANONICAL_NAMES]
@@ -1054,6 +1072,22 @@ function resolveCalleeViaChecker(
   ident: ts.Identifier,
   ctx: AnalyzerContext
 ): PrimitiveKind | null {
+  const name = resolveCanonicalClientExportName(ident, ctx)
+  return name ? (PRIMITIVE_CANONICAL_NAMES[name] ?? null) : null
+}
+
+/**
+ * Resolve an identifier back to the canonical export name it was imported under
+ * from `@barefootjs/client`, following alias chains
+ * (`import { createSignal as sig }`). Returns null when the checker is
+ * unavailable, the symbol doesn't resolve, or its declaration doesn't live in
+ * `@barefootjs/client` — so a user-defined function that happens to share a
+ * name never matches. Shared by the primitive-kind and env-signal resolvers.
+ */
+function resolveCanonicalClientExportName(
+  ident: ts.Identifier,
+  ctx: AnalyzerContext
+): string | null {
   if (!ctx.checker) return null
   let symbol: ts.Symbol | undefined
   try {
@@ -1073,16 +1107,37 @@ function resolveCalleeViaChecker(
       return null
     }
   }
-  const originalName = target.getName()
-  const hit = PRIMITIVE_CANONICAL_NAMES[originalName]
-  if (!hit) return null
   // Confirm the declaration actually lives in @barefootjs/client so we
   // don't match a user-defined function that happens to share the name.
   for (const decl of target.declarations ?? []) {
     const sourceName = decl.getSourceFile().fileName
     if (sourceName.includes('@barefootjs/client') || sourceName.includes('packages/client/')) {
-      return hit
+      return target.getName()
     }
+  }
+  return null
+}
+
+/**
+ * Resolve a call expression to the request-env key of the env-signal factory it
+ * calls (`createSearchParams()` → `'search'`), or null if it isn't one. Mirrors
+ * {@link resolvePrimitiveKind}'s fast/slow paths (direct name, alias via
+ * checker, `bf.createSearchParams` namespace access) against
+ * {@link ENV_SIGNAL_FACTORIES}.
+ */
+function resolveEnvSignalKey(
+  callExpr: ts.CallExpression,
+  ctx: AnalyzerContext
+): string | null {
+  if (ts.isIdentifier(callExpr.expression)) {
+    const key = ENV_SIGNAL_FACTORIES[callExpr.expression.text]
+    if (key) return key
+    const canonical = resolveCanonicalClientExportName(callExpr.expression, ctx)
+    return canonical ? (ENV_SIGNAL_FACTORIES[canonical] ?? null) : null
+  }
+  if (ts.isPropertyAccessExpression(callExpr.expression)) {
+    const key = ENV_SIGNAL_FACTORIES[callExpr.expression.name.text]
+    if (key && isBarefootClientNamespace(callExpr.expression.expression, ctx)) return key
   }
   return null
 }
@@ -1161,6 +1216,8 @@ function collectSignal(node: ts.VariableDeclaration, ctx: AnalyzerContext): void
     type = inferTypeFromValue(initialValue)
   }
 
+  const envReader = resolveEnvSignalKey(callExpr, ctx) ?? undefined
+
   ctx.signals.push({
     getter,
     setter,
@@ -1171,6 +1228,7 @@ function collectSignal(node: ts.VariableDeclaration, ctx: AnalyzerContext): void
     initialFreeIdentifiers: callExpr.arguments[0]
       ? extractFreeIdentifiersFromNode(callExpr.arguments[0])
       : new Set(),
+    envReader,
   })
 }
 
@@ -1770,10 +1828,11 @@ const CLIENT_EXPORTS = new Set([
   'forwardProps', 'unwrap', '__slot',
   'createContext', 'useContext', 'provideContext',
   'createPortal', 'isSSRPortal', 'findSiblingSlot', 'cleanupPortalPlaceholder',
-  // Request-scoped environment signal (router v0.5) — a real user-facing
-  // reactive export the compiler lowers like any other `@barefootjs/client`
-  // signal read (SSR: a template binding; client: a `createEffect`).
-  'searchParams',
+  // Request-scoped environment signal factory (router v0.5) — `createSignal`-
+  // shaped, recognised structurally (#2057) so its getter is just a signal
+  // getter; the compiler lowers the reader value per adapter via the signal's
+  // `envReader` key, with no `searchParams`-name allow-list.
+  'createSearchParams',
   // Pure URL-query builder (#2042) — the functional counterpart to
   // `searchParams`. Runs natively on the client; SSR adapters lower a
   // `queryHref(base, { … })` call to their query helper (go-template: `bf_query`).
@@ -3242,8 +3301,11 @@ function validateContext(ctx: AnalyzerContext): void {
   // their implementations live in `@barefootjs/client/runtime` and require
   // compiler emission to run correctly.
   if (!ctx.hasUseClientDirective) {
+    // Env signals (`createSearchParams()`, #2057) are exempt: reading the
+    // request query is SSR-safe and hydrates without `use client`, exactly as
+    // the pre-#2057 bare `searchParams()` import did (it was not a signal).
     const usesBrowserOnlyApi =
-      ctx.signals.length > 0 || importsBrowserOnlyClientApi(ctx)
+      ctx.signals.some(s => !s.envReader) || importsBrowserOnlyClientApi(ctx)
     if (usesBrowserOnlyApi) {
       ctx.errors.push(
         createError(ErrorCodes.MISSING_USE_CLIENT, {
@@ -3972,6 +4034,9 @@ export function validateReactiveFactoryCalls(ctx: AnalyzerContext): void {
       if (!ts.isIdentifier(decl.initializer.expression)) continue
       const callee = decl.initializer.expression.text
       if (callee === 'createSignal' || callee === 'createMemo') continue
+      // Env-signal factories (`createSearchParams`, #2057) are `createSignal`-
+      // shaped and recognised structurally — a valid tuple destructure.
+      if (callee in ENV_SIGNAL_FACTORIES) continue
       // Inlined factories were rewritten away before this analysis, so
       // anything still matching the shape is a destructure of an
       // unrecognised callee (imported helper, ad-hoc tuple fn, factory

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -1217,6 +1217,9 @@ function collectSignal(node: ts.VariableDeclaration, ctx: AnalyzerContext): void
   }
 
   const envReader = resolveEnvSignalKey(callExpr, ctx) ?? undefined
+  // The factory as written (identifier, alias, or `ns.factory`), so emit re-emits
+  // the binding actually in scope rather than a hardcoded canonical name (#2057).
+  const envFactory = envReader ? callExpr.expression.getText(ctx.sourceFile) : undefined
 
   ctx.signals.push({
     getter,
@@ -1229,6 +1232,7 @@ function collectSignal(node: ts.VariableDeclaration, ctx: AnalyzerContext): void
       ? extractFreeIdentifiersFromNode(callExpr.arguments[0])
       : new Set(),
     envReader,
+    envFactory,
   })
 }
 
@@ -4035,8 +4039,11 @@ export function validateReactiveFactoryCalls(ctx: AnalyzerContext): void {
       const callee = decl.initializer.expression.text
       if (callee === 'createSignal' || callee === 'createMemo') continue
       // Env-signal factories (`createSearchParams`, #2057) are `createSignal`-
-      // shaped and recognised structurally — a valid tuple destructure.
-      if (callee in ENV_SIGNAL_FACTORIES) continue
+      // shaped and recognised structurally — a valid tuple destructure. Resolve
+      // via the same path as recognition (`resolveEnvSignalKey`) so an aliased
+      // import (`import { createSearchParams as csp }`) is accepted here too,
+      // rather than falling through to a spurious BF110.
+      if (resolveEnvSignalKey(decl.initializer, ctx)) continue
       // Inlined factories were rewritten away before this analysis, so
       // anything still matching the shape is a destructure of an
       // unrecognised callee (imported helper, ad-hoc tuple fn, factory

--- a/packages/jsx/src/ir-to-client-js/csr-substitute.ts
+++ b/packages/jsx/src/ir-to-client-js/csr-substitute.ts
@@ -380,6 +380,11 @@ export function buildSignalMemoEnv(
 ): CsrEnv {
   const substitutions = new Map<string, CsrSubstitution>()
   for (const s of signals) {
+    // Env signals (#2057) have no static initial value to bake — their getter
+    // is a live request-scoped read (`searchParams().get(k)`). Leave it in the
+    // CSR template as a real call, exactly as the pre-#2057 bare `searchParams()`
+    // import was (it was never a substitutable signal).
+    if (s.envReader) continue
     substitutions.set(s.getter, {
       kind: 'call',
       replacement: normalizeSignalInitial(s, propsObjectName),

--- a/packages/jsx/src/ir-to-client-js/plan/build-declaration-emit.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/build-declaration-emit.ts
@@ -86,15 +86,19 @@ function buildSignalPlan(
   ctx: ClientJsContext,
   lookups: DeclarationEmitLookups,
 ): SignalEmitPlan {
-  const envFactory = signal.envReader ? ENV_SIGNAL_CLIENT_FACTORY[signal.envReader] : undefined
-  if (envFactory) {
-    return {
-      kind: 'signal',
-      getter: signal.getter,
-      setter: signal.setter,
-      initialValueExpr: '',
-      controlledEffect: null,
-      initializerOverride: `${envFactory}()`,
+  if (signal.envReader) {
+    // Emit the factory as written (alias / namespace aware, #2057), falling back
+    // to the canonical name if the callee text wasn't captured.
+    const factory = signal.envFactory ?? ENV_SIGNAL_CLIENT_FACTORY[signal.envReader]
+    if (factory) {
+      return {
+        kind: 'signal',
+        getter: signal.getter,
+        setter: signal.setter,
+        initialValueExpr: '',
+        controlledEffect: null,
+        initializerOverride: `${factory}()`,
+      }
     }
   }
   const controlledEffect = buildControlledSignalEffect(signal, lookups)

--- a/packages/jsx/src/ir-to-client-js/plan/build-declaration-emit.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/build-declaration-emit.ts
@@ -13,6 +13,7 @@ import type { Declaration } from '../declaration-sort.ts'
 import type { ClientJsContext } from '../types.ts'
 import type { ParamInfo, SignalInfo } from '../../types.ts'
 import { inferDefaultValue, PROPS_PARAM } from '../utils.ts'
+import { ENV_SIGNAL_CLIENT_FACTORY } from '../../adapters/env-signal.ts'
 import type {
   ControlledSignalEffectPlan,
   DeclarationEmitPlan,
@@ -85,6 +86,17 @@ function buildSignalPlan(
   ctx: ClientJsContext,
   lookups: DeclarationEmitLookups,
 ): SignalEmitPlan {
+  const envFactory = signal.envReader ? ENV_SIGNAL_CLIENT_FACTORY[signal.envReader] : undefined
+  if (envFactory) {
+    return {
+      kind: 'signal',
+      getter: signal.getter,
+      setter: signal.setter,
+      initialValueExpr: '',
+      controlledEffect: null,
+      initializerOverride: `${envFactory}()`,
+    }
+  }
   const controlledEffect = buildControlledSignalEffect(signal, lookups)
   if (controlledEffect && ctx.profile) {
     controlledEffect.bfId = `${ctx.componentName}#effect:controlled:${signal.setter}`

--- a/packages/jsx/src/ir-to-client-js/plan/declaration-emit.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/declaration-emit.ts
@@ -54,6 +54,15 @@ export interface SignalEmitPlan {
   branchCondition?: string
   /** Profile-mode IR-aligned id, appended as the `createSignal` 2nd arg (#1690). */
   bfId?: string
+  /**
+   * When set, the full initializer expression to emit verbatim instead of
+   * `createSignal(<initialValueExpr>)`. Env signals (#2057) emit their own
+   * factory call — e.g. `createSearchParams()` — with no baked initial value,
+   * profile id, controlled effect, or branch condition (the tuple is a stable
+   * request-scoped view, not stored state). When present the stringifier emits
+   * `const [<getter>, <setter>] = <initializerOverride>` and nothing else.
+   */
+  initializerOverride?: string
 }
 
 export interface ControlledSignalEffectPlan {

--- a/packages/jsx/src/ir-to-client-js/stringify/declaration-emit.ts
+++ b/packages/jsx/src/ir-to-client-js/stringify/declaration-emit.ts
@@ -65,6 +65,17 @@ function bfIdArg(bfId: string | undefined): string {
 }
 
 function emitSignal(lines: string[], plan: SignalEmitPlan): void {
+  // Env signal (#2057): emit its own factory call verbatim (`createSearchParams()`)
+  // — a stable request-scoped view, so no baked initial value, profile id,
+  // controlled effect, or branch condition applies.
+  if (plan.initializerOverride) {
+    if (plan.setter) {
+      lines.push(`  const [${plan.getter}, ${plan.setter}] = ${plan.initializerOverride}`)
+    } else {
+      lines.push(`  const [${plan.getter}] = ${plan.initializerOverride}`)
+    }
+    return
+  }
   const id = bfIdArg(plan.bfId)
   if (plan.branchCondition) {
     // #1414 cell #8: signal declared inside an early-return `if`-block.

--- a/packages/jsx/src/ssr-defaults.ts
+++ b/packages/jsx/src/ssr-defaults.ts
@@ -143,6 +143,10 @@ export function extractSsrDefaults(metadata: IRMetadata): Record<string, SsrDefa
   }
   for (const sig of metadata.signals) {
     if (!sig.getter || sig.isModule) continue
+    // Env signals (#2057) have no static SSR default — their value is the
+    // request-scoped reader, seeded by the adapter's env-signal binding, not a
+    // baked initial value.
+    if (sig.envReader) continue
     const value = tryStaticEval(sig.initialValue, { bindings, propsLike })
     out[sig.getter] = { value: resultToJsonable(value) }
     bindings[sig.getter] = value
@@ -169,7 +173,7 @@ export function extractSsrDefaults(metadata: IRMetadata): Record<string, SsrDefa
   if (metadata.propsObjectName !== null) {
     const referenced = new Set<string>()
     for (const sig of metadata.signals) {
-      if (!sig.getter || sig.isModule) continue
+      if (!sig.getter || sig.isModule || sig.envReader) continue
       collectPropRefs(sig.initialValue, metadata.propsObjectName, referenced)
     }
     for (const memo of metadata.memos) {

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -1168,6 +1168,15 @@ export interface SignalInfo {
    * env signal from structure instead of matching the import name.
    */
   envReader?: string
+  /**
+   * For an env signal (`envReader` set), the exact callee text of its factory
+   * call as written — `'createSearchParams'`, an alias (`'csp'` for
+   * `import { createSearchParams as csp }`), or a namespace access
+   * (`'bf.createSearchParams'`). Backends that re-emit the declaration (client
+   * JS, JSX/Hono SSR) emit `<envFactory>()` so the call resolves to the binding
+   * actually in scope, not a hardcoded canonical name (#2057).
+   */
+  envFactory?: string
 }
 
 export interface MemoInfo {

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -1157,6 +1157,17 @@ export interface SignalInfo {
   isModule?: boolean
   /** When true, the declaration carries an `export` keyword. */
   isExported?: boolean
+  /**
+   * Request-scoped environment-signal key when this signal was produced by an
+   * env-signal factory (`createSearchParams()` → `'search'`), rather than by
+   * `createSignal`. Set structurally by the analyzer (#2057) — the getter is a
+   * normal reactive getter (so it lands in the fold purity oracle for free, no
+   * name allow-list), but its *value* is a request-scoped reader with methods
+   * (`.get(key)`), which adapters lower to their per-request reader object
+   * instead of a plain template field. This flag is how adapters recognise an
+   * env signal from structure instead of matching the import name.
+   */
+  envReader?: string
 }
 
 export interface MemoInfo {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -29,6 +29,7 @@ export {
   BF_SEAM_HYDRATE_WITHIN,
   BF_SEAM_DISPOSE_WITHIN,
   BF_SEAM_PUSH_SEARCH,
+  BF_SEAM_NAV_SEARCH,
 } from './markers.ts'
 
 export {

--- a/packages/shared/src/markers.ts
+++ b/packages/shared/src/markers.ts
@@ -227,3 +227,14 @@ export const BF_SEAM_HYDRATE_WITHIN = '__bf_hydrate_within'
 export const BF_SEAM_DISPOSE_WITHIN = '__bf_dispose_within'
 /** Push a new query string into the `searchParams()` env signal. `window[BF_SEAM_PUSH_SEARCH](search)`. */
 export const BF_SEAM_PUSH_SEARCH = '__bf_pushSearch'
+/**
+ * Imperative query-only navigation for `setSearchParams(...)`
+ * (`createSearchParams()`, router v0.5). `window[BF_SEAM_NAV_SEARCH](search)`.
+ *
+ * The client's `setSearchParams` writes the new query through this seam so the
+ * router can perform a soft, same-route navigation (history push + region
+ * re-render) without `@barefootjs/client` importing the router. When no router
+ * has installed the seam, `setSearchParams` falls back to a hard navigation —
+ * "never worse than an MPA" — so the imperative write is correct standalone.
+ */
+export const BF_SEAM_NAV_SEARCH = '__bf_navSearch'

--- a/packages/shared/src/markers.ts
+++ b/packages/shared/src/markers.ts
@@ -213,7 +213,7 @@ export const BF_PARENT_SCOPE_PLACEHOLDER = '__BF_PARENT_SCOPE__'
 // The optional client router (`@barefootjs/router`) reaches the client runtime
 // through a few `window.__bf_*` function properties. The runtime *installs*
 // them (`@barefootjs/client/runtime/streaming.ts`, `@barefootjs/client`'s
-// `searchParams`) and the router *reads* them (`@barefootjs/router/seams.ts`),
+// `createSearchParams`) and the router *reads* them (`@barefootjs/router/seams.ts`),
 // in different packages — so the names live here as the single source of truth.
 // A rename is then a compile error on both sides instead of a silently-broken
 // seam (the router would otherwise fall back to a dynamic import and mask the
@@ -225,7 +225,8 @@ export const BF_SEAM_HYDRATE = '__bf_hydrate'
 export const BF_SEAM_HYDRATE_WITHIN = '__bf_hydrate_within'
 /** Dispose the islands in a subtree. `window[BF_SEAM_DISPOSE_WITHIN](root)`. */
 export const BF_SEAM_DISPOSE_WITHIN = '__bf_dispose_within'
-/** Push a new query string into the `searchParams()` env signal. `window[BF_SEAM_PUSH_SEARCH](search)`. */
+/** Push a new query string into the env-signal getter returned by
+ *  `createSearchParams()`. `window[BF_SEAM_PUSH_SEARCH](search)`. */
 export const BF_SEAM_PUSH_SEARCH = '__bf_pushSearch'
 /**
  * Imperative query-only navigation for `setSearchParams(...)`


### PR DESCRIPTION
## What

Part 1 of the [#2057](https://github.com/piconic-ai/barefootjs/issues/2057) RFC: keep API-name specialization out of the compiler core. This PR removes the **`searchParams` name allow-list** by turning the env signal into a `createSignal`-shaped factory the compiler recognizes **structurally**.

```tsx
// before: bare global getter, recognized by import name
import { searchParams } from '@barefootjs/client'
searchParams().get('sort')

// after: createSignal-shaped, recognized by structure (no name allow-list)
import { createSearchParams } from '@barefootjs/client'
const [searchParams, setSearchParams] = createSearchParams()
searchParams().get('sort')       // reactive read
setSearchParams({ sort: 'price' }) // single imperative navigation path
```

This is the clean fix for the closed #2055 fold-oracle smell: `searchParams` is now a real signal getter, so it lands in the fold purity oracle and reactive-getter set for free.

## Runtime (`@barefootjs/client`)

- `createSearchParams()` returns a `[getter, setter]` tuple. The getter is the request-scoped query reader (unchanged SSR + client resolution via `__bf_pushSearch`). The setter is the single imperative navigation path — it writes the new query through a new `BF_SEAM_NAV_SEARCH` seam (soft same-route nav when a router installs it, hard-nav fallback otherwise, so it's correct standalone). This also removes the confusing "mutate a throwaway `URLSearchParams`" write path.
- The bare `searchParams` export is removed (breaking; migration note to follow in the final PR of the stack).

## Compiler core (`@barefootjs/jsx`)

- `createSearchParams` is a recognized signal primitive (`PRIMITIVE_CANONICAL_NAMES`), tagged as an env factory (`ENV_SIGNAL_FACTORIES`); the collected `SignalInfo` carries an `envReader` key.
- `CLIENT_EXPORTS` drops `searchParams`, adds `createSearchParams`.
- `env-signal.ts` derives the reader getter names from **signal structure** (`envReader`), not import names.
- Codegen guards keep env signals out of normal value emission while leaving them in the reactivity graph:
  - client JS emits `createSearchParams()` (not `createSignal(...)`)
  - CSR substitution leaves the getter as a live call
  - Go struct-field / Hono+JSX SSR-initializer / `ssr-defaults` / Mojo+Xslate test-render value paths skip env signals
  - env-only components stay SSR (no forced `use client`); env factories are valid tuple destructures (BF110 exempt)

## Adapters

Env-signal recognition now flows from IR structure. Go keeps the `bf.SearchParams` reader field; Mojo/Xslate keep the canonical `$searchParams` reader.

## Tests

Fixtures and unit tests migrated to `createSearchParams()`. Green: full adapter conformance (all adapters) + CSR conformance + client / go-template / hono / mojolicious / xslate suites. The `search-params` conformance fixture now carries a `bf="s1"` element finder — a legitimate consequence of the env signal being a real reactive signal.

## Follow-ups (rest of the #2057 stack)

- PR-2: core `LoweringPlugin` registry + neutral `LoweringNode` renderers
- PR-3: move `queryHref` to the router layer, register it via the registry
- PR-4: grep-verify no barefoot-specific API names remain in core, refine the CLAUDE.md hook rule, migration note

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdVpB6GWgFddUzDo1MYixm)_