### PR TITLE
feat(#2057): backend-neutral call-lowering plugin registry (part 2)

### DIFF
--- a/.changeset/lowering-plugin-registry.md
+++ b/.changeset/lowering-plugin-registry.md
@@ -1,0 +1,14 @@
+---
+"@barefootjs/jsx": minor
+"@barefootjs/go-template": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+---
+
+Introduce a backend-neutral call-lowering plugin registry (#2057, part 2).
+
+The compiler core no longer hardcodes how a pure builder call like `queryHref(base, { … })` is recognized and lowered. A lowering plugin *matches* a call to a backend-neutral `LoweringNode`; each adapter *renders* that node in its own template syntax (`bf_query` / `bf->query` / `$bf.query`). This is a two-layer split — recognition is adapter-agnostic, rendering is plugin-agnostic — so SSR/CSR parity is enforced once, not per plugin.
+
+New `@barefootjs/jsx` exports: `registerLoweringPlugin`, `prepareLoweringMatchers`, `matchLoweringCall`, `getLoweringPlugins`, and the `LoweringPlugin` / `LoweringNode` / `LoweringMatcher` types. `queryHref` is still registered by core for now; a later change relocates that registration to the router layer so core carries no runtime-API names.
+
+Output is byte-identical: the Go / Mojolicious / Xslate adapters now obtain their query lowering through the registry instead of a hardcoded `queryHref` recognizer, producing the same templates as before.

--- a/packages/adapter-go-template/src/adapter/expr/url-builder.ts
+++ b/packages/adapter-go-template/src/adapter/expr/url-builder.ts
@@ -1,11 +1,13 @@
 /**
- * Lowering of the pure, functional `queryHref(base, { … })` URL-query API to a
- * `bf_query` template expression (#2042). The call + object literal are already
- * structured IR, so there is no recognizer and no emit-time re-parse — each
- * property maps to a `bf_query` include triple directly.
+ * Go rendering of a backend-neutral `guard-list` lowering node (#2057) — today
+ * the `queryHref(base, { … })` URL-query API lowered to a `bf_query` template
+ * expression (#2042). Recognition (which import, what call shape) lives in the
+ * lowering-plugin registry; this module is the Go *renderer* for the neutral
+ * node it produces: each triple maps to a `bf_query` include triple directly.
  */
 
 import {
+  type LoweringNode,
   type ParsedExpr,
   parseExpression,
   stringifyParsedExpr,
@@ -13,6 +15,9 @@ import {
 
 import type { GoEmitContext } from '../emit-context.ts'
 import { wrapIfMultiToken } from '../lib/go-emit.ts'
+
+/** Logical helper id → Go template helper name. */
+const GO_HELPER_NAMES: Record<string, string> = { query: 'bf_query' }
 
 const BOOL_COMPARISON_OPS: ReadonlySet<string> = new Set([
   '==', '===', '!=', '!==', '<', '>', '<=', '>=',
@@ -49,79 +54,60 @@ function lowerUrlGuard(ctx: GoEmitContext, g: ParsedExpr): string {
 }
 
 /**
- * Lower a `queryHref(<base>, { <key>: <value>, … })` call to a `bf_query`
- * expression (#2042). Because the call + object literal are already structured
- * IR, there's no recognition or re-parse — this maps each property to a
- * `bf_query` include triple directly. Returns null for
- * anything that isn't a `queryHref(base, {object})` call (→ generic lowering).
+ * Try every active lowering matcher against an expression, returning the Go
+ * rendering of the first neutral node produced, or null when none match (→ the
+ * generic lowering). Matchers are bound to the component metadata at init
+ * (`ctx.state.loweringMatchers`), so recognition of *which* API this is lives in
+ * the plugin registry, not here.
  *
- * Inclusion mirrors the client `queryHref` exactly, where every param value is a
- * STRING (`QueryParamValue`): an entry is included iff its value is a non-empty
- * string (the client's `if (value)` over strings).
- *   - plain `key: v`            → `(ne v "") "key" v`
- *   - conditional `key: cond ? a : <undefined|null|''>` → the client evaluates
- *     `if (cond ? a : undefined)`, i.e. include iff `cond` AND `a` is non-empty,
- *     so this emits `(and (<cond>) (ne a "")) "key" a` — NOT just `(cond)`, which
- *     would wrongly include `?key=` when `cond` holds but `a` is empty.
- *
- * Number / boolean values are intentionally outside `QueryParamValue`: JS
- * truthiness omits `0` / `false`, which a string `ne … ""` guard can't model
- * without per-value type info (a possible follow-up). Keeping values string-only
- * guarantees SSR ≡ client.
+ * Cheap-out order mirrors the old inline recognizer: no matchers → null; else
+ * reuse `preParsed` when it's already a call, otherwise a regex pre-filter gates
+ * the parse so non-call expressions never pay for `parseExpression`.
  */
-export function lowerQueryHrefCall(
+export function lowerRegisteredCall(
   ctx: GoEmitContext,
   jsExpr: string,
   preParsed?: ParsedExpr,
 ): string | null {
-  const localNames = ctx.state.queryHrefLocals
-  if (localNames.size === 0) return null
-  const head = /^\s*([A-Za-z_$][\w$]*)\s*\(/.exec(jsExpr)
-  if (!head || !localNames.has(head[1])) return null
+  const matchers = ctx.state.loweringMatchers
+  if (matchers.length === 0) return null
 
-  const call = preParsed?.kind === 'call' ? preParsed : parseExpression(jsExpr)
-  if (call.kind !== 'call' || call.callee.kind !== 'identifier') return null
-  if (!localNames.has(call.callee.name) || call.args.length !== 2) return null
-  const [base, obj] = call.args
-  // The params must be a plain object literal — a dynamic object can't be lowered
-  // to static include triples, so fall back to the generic lowering.
-  if (obj.kind !== 'object-literal') return null
-
-  const lowerExpr = (n: ParsedExpr): string =>
-    ctx.convertExpressionToGo(stringifyParsedExpr(n), undefined, n)
-  const parts: string[] = [wrapIfMultiToken(lowerExpr(base))]
-  for (const p of obj.properties) {
-    const v = p.value
-    let includeGo: string
-    let valueNode: ParsedExpr
-    if (v.kind === 'conditional' && isOmitSentinel(v.alternate)) {
-      // `key: cond ? a : <omit>` → include on `cond`. The non-empty check is no
-      // longer folded in here: bf_query drops an included-but-empty value (and
-      // appends an array value member-by-member), matching the client / Perl.
-      includeGo = lowerUrlGuard(ctx, v.test)
-      valueNode = v.consequent
-    } else {
-      // `key: v` → always hand the value to bf_query, which omits it when empty
-      // (or array-empty) and appends array members.
-      includeGo = 'true'
-      valueNode = v
-    }
-    parts.push(`(${includeGo})`)
-    parts.push(JSON.stringify(p.key))
-    parts.push(wrapIfMultiToken(lowerExpr(valueNode)))
+  let call: ParsedExpr | undefined = preParsed?.kind === 'call' ? preParsed : undefined
+  if (!call) {
+    if (!/^\s*[A-Za-z_$][\w$]*\s*\(/.test(jsExpr)) return null
+    const parsed = parseExpression(jsExpr)
+    if (parsed.kind !== 'call') return null
+    call = parsed
   }
-  return `bf_query ${parts.join(' ')}`
+
+  for (const matcher of matchers) {
+    const node = matcher(call.callee, call.args)
+    if (node) return renderLoweringNode(ctx, node)
+  }
+  return null
 }
 
-/**
- * The falsy "omit" branch of a conditional include — `undefined` (an identifier),
- * `null`, or `''`. These are the alternates that make `cond ? v : <omit>` a
- * conditional include.
- */
-function isOmitSentinel(node: ParsedExpr): boolean {
-  if (node.kind === 'identifier') return node.name === 'undefined'
-  if (node.kind === 'literal') {
-    return node.literalType === 'null' || (node.literalType === 'string' && node.value === '')
+/** Render a backend-neutral lowering node to a Go template expression. */
+function renderLoweringNode(ctx: GoEmitContext, node: LoweringNode): string {
+  const lowerExpr = (n: ParsedExpr): string =>
+    ctx.convertExpressionToGo(stringifyParsedExpr(n), undefined, n)
+  const helper = GO_HELPER_NAMES[node.helper] ?? node.helper
+  if (node.kind === 'helper-call') {
+    const args = node.args.map(a => wrapIfMultiToken(lowerExpr(a)))
+    return [helper, ...args].join(' ')
   }
-  return false
+  // guard-list — `queryHref`-shaped. Inclusion mirrors the client exactly, where
+  // every param value is a STRING (`QueryParamValue`): bf_query drops an
+  // included-but-empty value and appends array members.
+  //   - plain `key: v` (guard null)        → `(true) "key" v`
+  //   - conditional `key: cond ? a : <omit>` → `(<cond>) "key" a`, where the
+  //     non-empty check is done by bf_query, not folded into the guard.
+  const parts: string[] = [wrapIfMultiToken(lowerExpr(node.base))]
+  for (const t of node.triples) {
+    const includeGo = t.guard === null ? 'true' : lowerUrlGuard(ctx, t.guard)
+    parts.push(`(${includeGo})`)
+    parts.push(JSON.stringify(t.key))
+    parts.push(wrapIfMultiToken(lowerExpr(t.value)))
+  }
+  return `${helper} ${parts.join(' ')}`
 }

--- a/packages/adapter-go-template/src/adapter/expr/url-builder.ts
+++ b/packages/adapter-go-template/src/adapter/expr/url-builder.ts
@@ -82,16 +82,25 @@ export function lowerRegisteredCall(
 
   for (const matcher of matchers) {
     const node = matcher(call.callee, call.args)
-    if (node) return renderLoweringNode(ctx, node)
+    if (!node) continue
+    const rendered = renderLoweringNode(ctx, node)
+    if (rendered !== null) return rendered
   }
   return null
 }
 
-/** Render a backend-neutral lowering node to a Go template expression. */
-function renderLoweringNode(ctx: GoEmitContext, node: LoweringNode): string {
+/**
+ * Render a backend-neutral lowering node to a Go template expression, or null
+ * when the node's `helper` has no Go mapping — the caller then declines
+ * (generic lowering → BF101), rather than emitting the raw helper id, which
+ * would be invalid Go. Adapters must switch on `helper`; an unknown one is not
+ * rendered.
+ */
+function renderLoweringNode(ctx: GoEmitContext, node: LoweringNode): string | null {
+  const helper = GO_HELPER_NAMES[node.helper]
+  if (!helper) return null
   const lowerExpr = (n: ParsedExpr): string =>
     ctx.convertExpressionToGo(stringifyParsedExpr(n), undefined, n)
-  const helper = GO_HELPER_NAMES[node.helper] ?? node.helper
   if (node.kind === 'helper-call') {
     const args = node.args.map(a => wrapIfMultiToken(lowerExpr(a)))
     return [helper, ...args].join(' ')

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -63,7 +63,7 @@ import {
   type ContextConsumer,
   collectModuleStringConsts as collectModuleStringConstsShared,
   searchParamsLocalNames,
-  queryHrefLocalNames
+  prepareLoweringMatchers
 } from '@barefootjs/jsx'
 import { findInterpolationEnd } from '@barefootjs/jsx/scanner'
 import { BF_REGION } from '@barefootjs/shared'
@@ -108,7 +108,7 @@ import { CompileState } from "./lib/compile-state.ts"
 import { hasClientInteractivity, findNestedComponents } from "./analysis/component-tree.ts"
 import type { GoEmitContext } from "./emit-context.ts"
 import { inlineLocalHelperCall } from "./expr/helper-inline.ts"
-import { lowerQueryHrefCall } from "./expr/url-builder.ts"
+import { lowerRegisteredCall } from "./expr/url-builder.ts"
 import {
   convertInitialValue,
   jsLiteralToGo,
@@ -273,7 +273,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     this.state.currentTypeDefinitions = ir.metadata.typeDefinitions ?? []
     this.state.contextConsumers = collectContextConsumers(ir.metadata)
     this.state.searchParamsLocals = searchParamsLocalNames(ir.metadata)
-    this.state.queryHrefLocals = queryHrefLocalNames(ir.metadata)
+    this.state.loweringMatchers = prepareLoweringMatchers(ir.metadata)
     augmentInheritedPropAccesses(ir)
   }
 
@@ -3853,11 +3853,11 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       }
     }
 
-    // `queryHref(base, { … })` (the pure URL builder, #2042) lowers to a
-    // `bf_query` action. Tried before the generic path because its object-literal
-    // arg is otherwise `unsupported` at the support gate.
-    const queryBuilt = lowerQueryHrefCall(this.emitCtx, trimmed, preParsed)
-    if (queryBuilt !== null) return queryBuilt
+    // Registered call lowerings (#2057) — e.g. `queryHref(base, { … })` (#2042)
+    // → a `bf_query` action. Tried before the generic path because such calls'
+    // object-literal args are otherwise `unsupported` at the support gate.
+    const loweredCall = lowerRegisteredCall(this.emitCtx, trimmed, preParsed)
+    if (loweredCall !== null) return loweredCall
 
     // Inline a call to a local, expression-bodied helper arrow
     // (`sortClass(k)` / `tagClass(t)`) by substituting its params with the call

--- a/packages/adapter-go-template/src/adapter/lib/compile-state.ts
+++ b/packages/adapter-go-template/src/adapter/lib/compile-state.ts
@@ -15,6 +15,7 @@ import type {
   ContextConsumer,
   IRMetadata,
   IRNode,
+  LoweringMatcher,
   MemoInfo,
   TypeDefinition,
   TypeInfo,
@@ -90,11 +91,13 @@ export class CompileState {
   searchParamsLocals: Set<string> = new Set()
 
   /**
-   * Local binding names the pure `queryHref` URL builder is imported under
-   * (handles `import { queryHref as qh }`). A `queryHref(base, { … })` call is
-   * lowered to `bf_query` (#2042).
+   * Call-lowering matchers active for this component, bound to its metadata at
+   * init via `prepareLoweringMatchers` (#2057). Each maps a recognised call
+   * (e.g. `queryHref(base, { … })`) to a backend-neutral `LoweringNode` the
+   * adapter renders (go: `bf_query`). Replaces the hardcoded `queryHref`
+   * name-recognition.
    */
-  queryHrefLocals: Set<string> = new Set()
+  loweringMatchers: LoweringMatcher[] = []
 
   /**
    * Prop NAMES whose resolved Go struct-field type is exactly `interface{}`

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -54,13 +54,12 @@ import {
   collectModuleStringConsts,
   lookupStaticRecordLiteral,
   searchParamsLocalNames,
-  queryHrefLocalNames,
-  matchQueryHrefCall,
+  prepareLoweringMatchers,
   queryHrefArgs,
   sortComparatorFromArrow,
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr } from './boolean-result.ts'
-import type { ParsedExpr } from '@barefootjs/jsx'
+import type { ParsedExpr, LoweringMatcher } from '@barefootjs/jsx'
 import { BF_SLOT, BF_COND, BF_REGION } from '@barefootjs/shared'
 
 import type { MojoRenderCtx } from './lib/types.ts'
@@ -163,11 +162,12 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
   private _searchParamsLocals: Set<string> = new Set()
 
   /**
-   * Local binding names `queryHref` is imported under (#2042). Set at
-   * `generate()` entry; read by the top-level emitter to lower a
-   * `queryHref(base, { … })` call to a `bf->query(...)` helper call.
+   * Call-lowering matchers active for this component (#2057), bound to its
+   * metadata at `generate()` entry via `prepareLoweringMatchers`. Read by the
+   * top-level emitter to lower a recognised call (e.g. `queryHref(base, { … })`)
+   * to a `bf->query(...)` helper call.
    */
-  private _queryHrefLocals: Set<string> = new Set()
+  private _loweringMatchers: LoweringMatcher[] = []
   /**
    * Module-scope pure string-literal constants (`const X = 'literal'` at
    * file top-level), keyed by name → resolved literal value. Populated at
@@ -241,7 +241,7 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     this.stringValueNames = collectStringValueNames(ir)
     this.moduleStringConsts = collectModuleStringConsts(ir.metadata.localConstants)
     this._searchParamsLocals = searchParamsLocalNames(ir.metadata)
-    this._queryHrefLocals = queryHrefLocalNames(ir.metadata)
+    this._loweringMatchers = prepareLoweringMatchers(ir.metadata)
     this.localConstants = ir.metadata.localConstants ?? []
     this.loopBoundNames.clear()
     this.errors = []
@@ -1578,17 +1578,19 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       parsed = parseExpression(trimmed)
     }
 
-    // `queryHref(base, { … })` (#2042) → `bf->query(base, <triples>)`. Recognised
-    // before the support gate because the object-literal arg is otherwise
-    // `unsupported` (BF101) — mirroring the go adapter's `lowerQueryHrefCall`. The
-    // `bf->query` helper includes a pair iff its guard is truthy AND its value is
-    // a non-empty string (the client's `if (value)`): a plain `key: v` passes
-    // guard `1`, a conditional `key: cond ? v : undefined` passes the lowered cond.
-    if (this._queryHrefLocals.size > 0 && parsed.kind === 'call') {
-      const q = matchQueryHrefCall(parsed.callee, parsed.args, this._queryHrefLocals)
-      if (q) {
-        const argsGo = queryHrefArgs(q, n => this.renderParsedExprToPerl(n))
-        return `bf->query(${argsGo.join(', ')})`
+    // Registered call lowerings (#2057) — e.g. `queryHref(base, { … })` (#2042)
+    // → `bf->query(base, <triples>)`. Recognised before the support gate because
+    // the object-literal arg is otherwise `unsupported` (BF101). The `bf->query`
+    // helper includes a pair iff its guard is truthy AND its value is a non-empty
+    // string (the client's `if (value)`): a plain `key: v` passes guard `1`, a
+    // conditional `key: cond ? v : undefined` passes the lowered cond.
+    if (this._loweringMatchers.length > 0 && parsed.kind === 'call') {
+      for (const matcher of this._loweringMatchers) {
+        const node = matcher(parsed.callee, parsed.args)
+        if (node?.kind === 'guard-list') {
+          const argsGo = queryHrefArgs(node, n => this.renderParsedExprToPerl(n))
+          return `bf->query(${argsGo.join(', ')})`
+        }
       }
     }
 

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1587,7 +1587,9 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     if (this._loweringMatchers.length > 0 && parsed.kind === 'call') {
       for (const matcher of this._loweringMatchers) {
         const node = matcher(parsed.callee, parsed.args)
-        if (node?.kind === 'guard-list') {
+        // Only the `query` helper renders to `bf->query`; a future guard-list
+        // helper must not be silently mis-rendered as a query.
+        if (node?.kind === 'guard-list' && node.helper === 'query') {
           const argsGo = queryHrefArgs(node, n => this.renderParsedExprToPerl(n))
           return `bf->query(${argsGo.join(', ')})`
         }

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -1301,7 +1301,9 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     if (this._loweringMatchers.length > 0 && parsed.kind === 'call') {
       for (const matcher of this._loweringMatchers) {
         const node = matcher(parsed.callee, parsed.args)
-        if (node?.kind === 'guard-list') {
+        // Only the `query` helper renders to `$bf.query`; a future guard-list
+        // helper must not be silently mis-rendered as a query.
+        if (node?.kind === 'guard-list' && node.helper === 'query') {
           const qArgs = queryHrefArgs(node, n => this.renderParsedExprToKolon(n))
           return `$bf.query(${qArgs.join(', ')})`
         }

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -68,14 +68,13 @@ import {
   type ContextConsumer,
   lookupStaticRecordLiteral,
   searchParamsLocalNames,
-  queryHrefLocalNames,
-  matchQueryHrefCall,
+  prepareLoweringMatchers,
   queryHrefArgs,
   sortComparatorFromArrow,
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr } from './boolean-result.ts'
 import ts from 'typescript'
-import type { ParsedExpr } from '@barefootjs/jsx'
+import type { ParsedExpr, LoweringMatcher } from '@barefootjs/jsx'
 import { BF_SLOT, BF_COND, BF_REGION } from '@barefootjs/shared'
 
 import type { XslateRenderCtx } from './lib/types.ts'
@@ -175,11 +174,12 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
   private _searchParamsLocals: Set<string> = new Set()
 
   /**
-   * Local binding names `queryHref` is imported under (#2042). Set at
-   * `generate()` entry; read by the top-level emitter to lower a
-   * `queryHref(base, { … })` call to a `$bf.query(...)` helper call.
+   * Call-lowering matchers active for this component (#2057), bound to its
+   * metadata at `generate()` entry via `prepareLoweringMatchers`. Read by the
+   * top-level emitter to lower a recognised call (e.g. `queryHref(base, { … })`)
+   * to a `$bf.query(...)` helper call.
    */
-  private _queryHrefLocals: Set<string> = new Set()
+  private _loweringMatchers: LoweringMatcher[] = []
 
   /**
    * Local + module constants from the IR, used by the conditional-spread and
@@ -225,7 +225,7 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     this.stringValueNames = collectStringValueNames(ir)
     this.moduleStringConsts = collectModuleStringConsts(ir.metadata.localConstants)
     this._searchParamsLocals = searchParamsLocalNames(ir.metadata)
-    this._queryHrefLocals = queryHrefLocalNames(ir.metadata)
+    this._loweringMatchers = prepareLoweringMatchers(ir.metadata)
     this.errors = []
     this.childrenCaptureCounter = 0
 
@@ -1292,17 +1292,19 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
       parsed = parseExpression(trimmed)
     }
 
-    // `queryHref(base, { … })` (#2042) → `$bf.query(base, <triples>)`. Recognised
-    // before the support gate because the object-literal arg is otherwise
-    // `unsupported` (BF101) — mirroring the go adapter. The `query` helper
-    // includes a pair iff its guard is truthy AND its value is a non-empty string
-    // (the client's `if (value)`): a plain `key: v` passes guard `1`, a
+    // Registered call lowerings (#2057) — e.g. `queryHref(base, { … })` (#2042)
+    // → `$bf.query(base, <triples>)`. Recognised before the support gate because
+    // the object-literal arg is otherwise `unsupported` (BF101). The `query`
+    // helper includes a pair iff its guard is truthy AND its value is a non-empty
+    // string (the client's `if (value)`): a plain `key: v` passes guard `1`, a
     // conditional `key: cond ? v : undefined` passes the lowered cond.
-    if (this._queryHrefLocals.size > 0 && parsed.kind === 'call') {
-      const q = matchQueryHrefCall(parsed.callee, parsed.args, this._queryHrefLocals)
-      if (q) {
-        const qArgs = queryHrefArgs(q, n => this.renderParsedExprToKolon(n))
-        return `$bf.query(${qArgs.join(', ')})`
+    if (this._loweringMatchers.length > 0 && parsed.kind === 'call') {
+      for (const matcher of this._loweringMatchers) {
+        const node = matcher(parsed.callee, parsed.args)
+        if (node?.kind === 'guard-list') {
+          const qArgs = queryHrefArgs(node, n => this.renderParsedExprToKolon(n))
+          return `$bf.query(${qArgs.join(', ')})`
+        }
       }
     }
 

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -79,6 +79,15 @@ export { emitParsedExpr } from './adapters/parsed-expr-emitter.ts'
 export type { ParsedExprEmitter, HigherOrderMethod, ArrayMethod, SortMethod, LiteralType } from './adapters/parsed-expr-emitter.ts'
 export { importsSearchParams, searchParamsLocalNames, queryHrefLocalNames, matchSearchParamsMethodCall } from './adapters/env-signal.ts'
 export { matchQueryHrefCall, queryHrefArgs, type QueryHrefCall, type QueryHrefTriple } from './query-href-lowering.ts'
+export {
+  registerLoweringPlugin,
+  getLoweringPlugins,
+  prepareLoweringMatchers,
+  matchLoweringCall,
+  type LoweringPlugin,
+  type LoweringNode,
+  type LoweringMatcher,
+} from './lowering-registry.ts'
 export { emitIRNode } from './adapters/ir-node-emitter.ts'
 export type { IRNodeEmitter, EmitIRNode } from './adapters/ir-node-emitter.ts'
 export { emitAttrValue } from './adapters/attr-value-emitter.ts'

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -86,6 +86,7 @@ export {
   matchLoweringCall,
   type LoweringPlugin,
   type LoweringNode,
+  type LoweringTriple,
   type LoweringMatcher,
 } from './lowering-registry.ts'
 export { emitIRNode } from './adapters/ir-node-emitter.ts'

--- a/packages/jsx/src/lowering-registry.ts
+++ b/packages/jsx/src/lowering-registry.ts
@@ -1,0 +1,145 @@
+/**
+ * Call-lowering plugin registry (#2057).
+ *
+ * The compiler core carries no specific runtime-API names. Instead, a lowering
+ * plugin *recognises* a call — by the import it comes from and its argument
+ * shape — and returns a **backend-neutral `LoweringNode`**. Each adapter renders
+ * that node in its own template syntax. This is a deliberate two-layer split:
+ *
+ *   - **Layer 1 (this module + plugins):** adapter-agnostic. A plugin matches a
+ *     call to a neutral node and never mentions Go/Perl/… syntax.
+ *   - **Layer 2 (adapters):** plugin-agnostic. Each adapter has ONE renderer per
+ *     node kind, so SSR/CSR parity is enforced once, not per plugin.
+ *
+ * A first-party package registers its plugin via {@link registerLoweringPlugin}
+ * (a side-effect import at build time). Today the only plugin is `queryHref`,
+ * still registered by core below; #2057 PR-3 moves that registration into the
+ * `@barefootjs/router` layer and removes it from core, at which point core holds
+ * zero runtime-API names. The registry itself is the durable *mechanism*.
+ *
+ * This is NOT the "output-rewriting hook" CLAUDE.md forbids: a plugin returns a
+ * structured IR node, never a rewritten output string, so the compiler's output
+ * stays determined by the compiler, not by whatever munges the emitted text.
+ */
+
+import type { ParsedExpr } from './expression-parser.ts'
+import type { IRMetadata } from './types.ts'
+import type { QueryHrefTriple } from './query-href-lowering.ts'
+import { matchQueryHrefCall } from './query-href-lowering.ts'
+import { queryHrefLocalNames } from './adapters/env-signal.ts'
+
+/**
+ * A backend-neutral lowering result. Adapters render each variant in their own
+ * template language; the shapes carry everything a renderer needs and nothing
+ * adapter-specific.
+ */
+export type LoweringNode =
+  /**
+   * A guard/key/value include list lowered to a query helper — the shape of
+   * `queryHref(base, { … })`. `helper` is the logical helper id (`'query'`),
+   * which each adapter maps to its own runtime helper (`bf_query` in go,
+   * `bf->query` in mojo, `$bf.query` in xslate) and renders per its own
+   * inclusion rule (go folds the non-empty check into the guard; the
+   * template-string adapters pass raw triples to a helper that checks).
+   */
+  | { kind: 'guard-list'; helper: string; base: ParsedExpr; triples: QueryHrefTriple[] }
+  /**
+   * A plain helper call `helper(...args)` — the general escape hatch for a pure
+   * builder that lowers to a single runtime-helper invocation. Unused today;
+   * present so the neutral vocabulary isn't single-purpose.
+   */
+  | { kind: 'helper-call'; helper: string; args: readonly ParsedExpr[] }
+
+/**
+ * A matcher bound to one component's metadata: given a parsed call's callee +
+ * args, returns a neutral node or null to decline. Produced by a plugin's
+ * {@link LoweringPlugin.prepare} so the per-component import-name resolution runs
+ * once (at adapter init), not on every emit.
+ */
+export type LoweringMatcher = (
+  callee: ParsedExpr,
+  args: readonly ParsedExpr[],
+) => LoweringNode | null
+
+/**
+ * A lowering plugin. `prepare` resolves the local names its import is bound
+ * under in this component and returns a bound {@link LoweringMatcher}, or null
+ * when the component doesn't use it (so the adapter skips it entirely). A
+ * plugin never emits adapter syntax — only neutral nodes.
+ */
+export interface LoweringPlugin {
+  /** Stable id, for dedup/diagnostics (`'queryHref'`). */
+  name: string
+  prepare(metadata: IRMetadata): LoweringMatcher | null
+}
+
+const plugins: LoweringPlugin[] = []
+
+/**
+ * Register a lowering plugin. Idempotent by `name` — re-registering the same
+ * name replaces the prior plugin, so a double side-effect import can't stack
+ * duplicates. First-party packages call this at module load.
+ */
+export function registerLoweringPlugin(plugin: LoweringPlugin): void {
+  const existing = plugins.findIndex(p => p.name === plugin.name)
+  if (existing >= 0) plugins[existing] = plugin
+  else plugins.push(plugin)
+}
+
+/** The registered plugins, in registration order. */
+export function getLoweringPlugins(): readonly LoweringPlugin[] {
+  return plugins
+}
+
+/**
+ * Bind every registered plugin to a component's metadata, returning the matchers
+ * that are active for it (import present). Adapters call this once at init and
+ * store the result, then try each matcher on the calls they lower — replacing a
+ * hardcoded per-API recognizer.
+ */
+export function prepareLoweringMatchers(metadata: IRMetadata): LoweringMatcher[] {
+  const matchers: LoweringMatcher[] = []
+  for (const plugin of plugins) {
+    const matcher = plugin.prepare(metadata)
+    if (matcher) matchers.push(matcher)
+  }
+  return matchers
+}
+
+/**
+ * Convenience one-shot match against all registered plugins for a given
+ * metadata. Prefer {@link prepareLoweringMatchers} on a hot path (it resolves
+ * import names once); this re-resolves per call and is meant for tests / cold
+ * call sites.
+ */
+export function matchLoweringCall(
+  callee: ParsedExpr,
+  args: readonly ParsedExpr[],
+  metadata: IRMetadata,
+): LoweringNode | null {
+  for (const matcher of prepareLoweringMatchers(metadata)) {
+    const node = matcher(callee, args)
+    if (node) return node
+  }
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// First-party default plugins
+// ---------------------------------------------------------------------------
+//
+// `queryHref` (#2042) is registered here by core for now. #2057 PR-3 relocates
+// this registration into `@barefootjs/router` (a side-effect import wired by the
+// build) and deletes it from core — leaving core with no runtime-API names.
+
+registerLoweringPlugin({
+  name: 'queryHref',
+  prepare(metadata) {
+    const localNames = queryHrefLocalNames(metadata)
+    if (localNames.size === 0) return null
+    return (callee, args) => {
+      const q = matchQueryHrefCall(callee, args, localNames)
+      return q ? { kind: 'guard-list', helper: 'query', base: q.base, triples: q.triples } : null
+    }
+  },
+})

--- a/packages/jsx/src/lowering-registry.ts
+++ b/packages/jsx/src/lowering-registry.ts
@@ -24,9 +24,22 @@
 
 import type { ParsedExpr } from './expression-parser.ts'
 import type { IRMetadata } from './types.ts'
-import type { QueryHrefTriple } from './query-href-lowering.ts'
 import { matchQueryHrefCall } from './query-href-lowering.ts'
 import { queryHrefLocalNames } from './adapters/env-signal.ts'
+
+/**
+ * A backend-neutral include triple for a {@link LoweringNode} `guard-list`.
+ * `guard` is the conditional test of a `key: cond ? v : <omit>` include, or null
+ * for a plain `key: v` (included purely on value-truthiness). An adapter renders
+ * the guard to decide inclusion; the *runtime helper* then applies the emptiness
+ * / array-append rules to the value. (Structurally identical to the query-href
+ * lowering's own triple, which the `queryHref` plugin passes through unchanged.)
+ */
+export interface LoweringTriple {
+  guard: ParsedExpr | null
+  key: string
+  value: ParsedExpr
+}
 
 /**
  * A backend-neutral lowering result. Adapters render each variant in their own
@@ -38,11 +51,13 @@ export type LoweringNode =
    * A guard/key/value include list lowered to a query helper — the shape of
    * `queryHref(base, { … })`. `helper` is the logical helper id (`'query'`),
    * which each adapter maps to its own runtime helper (`bf_query` in go,
-   * `bf->query` in mojo, `$bf.query` in xslate) and renders per its own
-   * inclusion rule (go folds the non-empty check into the guard; the
-   * template-string adapters pass raw triples to a helper that checks).
+   * `bf->query` in mojo, `$bf.query` in xslate). Each triple's `guard` controls
+   * inclusion; the runtime helper then applies the non-empty / array-append
+   * rules to the value (so an included-but-empty value is dropped and array
+   * members are appended), matching the client `queryHref` exactly. Adapters
+   * MUST switch on `helper` — a `guard-list` is not implicitly `query`.
    */
-  | { kind: 'guard-list'; helper: string; base: ParsedExpr; triples: QueryHrefTriple[] }
+  | { kind: 'guard-list'; helper: string; base: ParsedExpr; triples: LoweringTriple[] }
   /**
    * A plain helper call `helper(...args)` — the general escape hatch for a pure
    * builder that lowers to a single runtime-helper invocation. Unused today;
@@ -86,9 +101,10 @@ export function registerLoweringPlugin(plugin: LoweringPlugin): void {
   else plugins.push(plugin)
 }
 
-/** The registered plugins, in registration order. */
+/** The registered plugins, in registration order (a copy — mutating the result
+ *  can't reorder or corrupt the registry). */
 export function getLoweringPlugins(): readonly LoweringPlugin[] {
-  return plugins
+  return [...plugins]
 }
 
 /**


### PR DESCRIPTION
Part 2 of the #2057 stack (stacked on #2059). Introduces a backend-neutral **call-lowering plugin registry** so the compiler core no longer hardcodes how a pure builder call like `queryHref(base, { … })` is recognized and lowered.

## Why

RFC #2057 wants the compiler core to carry no specific runtime-API names. Today `queryHref` is recognized by name (`queryHrefLocalNames`) and lowered by a hardcoded per-adapter recognizer. This PR replaces that with a registry mechanism; a later part relocates the `queryHref` registration out of core into the router layer.

## Design — two layers

- **Layer 1 (registry + plugins):** a `LoweringPlugin` *matches* a call to a backend-neutral `LoweringNode`. Adapter-agnostic — never mentions Go/Perl/… syntax.
- **Layer 2 (adapters):** each adapter has one renderer per node kind, mapping the logical helper (`query`) to its own runtime helper (`bf_query` / `bf->query` / `$bf.query`). Plugin-agnostic — so SSR/CSR parity is enforced once, not per plugin.

This is **not** the "output-rewriting hook" CLAUDE.md forbids: a plugin returns a structured IR node, never a rewritten output string, so the compiler's output stays determined by the compiler.

## Changes

- New `@barefootjs/jsx` module `lowering-registry.ts`: `registerLoweringPlugin`, `prepareLoweringMatchers`, `matchLoweringCall`, `getLoweringPlugins`, and the `LoweringPlugin` / `LoweringNode` / `LoweringMatcher` types.
- `queryHref` is registered by core here **for now** — part 3 moves that registration into `@barefootjs/router` and removes it from core, leaving core with zero runtime-API names.
- Go / Mojolicious / Xslate adapters obtain their query lowering through the registry (matchers bound to component metadata at init) instead of the hardcoded `queryHref` recognizer.

## Parity

Output is **byte-identical** — the adapters produce the same templates as before, now sourced through the registry.

## Verification

- Query-href tests: jsx recognition (4), go (10), mojo (6), xslate (6) — all pass.
- Adapter conformance + CSR (byte-exact oracle): 789 pass.
- Full adapter suites: go 563, mojo 530, xslate 362; jsx 2211; client 377 — 0 failures.
- `tsgo --noEmit` clean across jsx + all three template adapters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdVpB6GWgFddUzDo1MYixm)_