### PR TITLE
fix(#2038): surface BF101 for nested-callback filter predicates instead of silent lossy lowering

### DIFF
--- a/.changeset/nested-callback-predicate-loud.md
+++ b/.changeset/nested-callback-predicate-loud.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/go-template": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+---
+
+Surface BF101 for a filter predicate whose body contains a nested higher-order callback the adapter can only degrade (#2038). The runtime evaluator refuses nested arrows, and the legacy predicate fallbacks silently rewrote such predicates — Xslate's Kolon-lambda emit collapsed the inner call to its receiver (`!other.some(r => …)` → `!other`), Mojo degraded nested `find*` / sort / reduce / flatMap the same way, and the Go filter-expr `call` arm dropped the arrow argument entirely. Each adapter is now loud at its exact degrade points, with `/* @client */` as the escape hatch. Faithful nested lowerings are untouched: Mojo's inline `grep` for nested `filter` / `every` / `some` and Go's `len (bf_filter_eval …)` for `.filter(cb).length` still render (pinned by the new `filter-nested-callback-predicate` conformance fixture).

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -98,6 +98,13 @@ runAdapterConformanceTests({
     // (`cn\`base \${tone()}\``) likewise can't lower into Go template
     // syntax — same BF101 refusal.
     'tagged-template-classname': [{ code: 'BF101', severity: 'error' }],
+    // #2038: a filter predicate whose body contains a NESTED callback call
+    // (`t => !picked().some(p => …)`). The evaluator refuses nested arrows
+    // and `renderFilterExpr` has no faithful Go form for the inner call (its
+    // `call` arm used to silently drop the arrow argument and render only
+    // the callee) — the compiler is loud instead of lossy.
+    // https://github.com/piconic-ai/barefootjs/issues/2038
+    'filter-nested-callback-predicate': [{ code: 'BF101', severity: 'error' }],
     // #1310: rest destructure in .map() callback. The object-rest shape read
     // via member access (`rest-destructure-object-in-map`) now lowers — each
     // binding resolves to a field on a synthetic `$__bf_item0` range var (the
@@ -1824,6 +1831,53 @@ export function TodoList() {
       ))}
     </ul>
   )
+}
+`, adapter)
+      adapter.generate(ir)
+      const bf101 = adapter.errors.filter(e => e.code === 'BF101')
+      expect(bf101).toEqual([])
+    })
+
+    test('nested .some(...) in filter predicate surfaces BF101 instead of dropping the callback (#2038)', () => {
+      // Pre-#2038 the `call` arm of `renderFilterExprNode` rendered only the
+      // callee for a nested callback call, silently DROPPING the arrow
+      // argument (`!picked().some(p => p.id === t.id)` degraded to a bogus
+      // field-path read) — a lossy predicate rewrite. The compiler is loud
+      // now: BF101 with the /* @client */ escape hatch.
+      const adapter = new GoTemplateAdapter()
+      const result = compileAndGenerate(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+type Item = { id: number }
+
+export function Picker() {
+  const [items, setItems] = createSignal<Item[]>([])
+  const [picked, setPicked] = createSignal<Item[]>([])
+  return <ul>{items().filter(t => !picked().some(p => p.id === t.id)).map(t => <li key={t.id}>{t.id}</li>)}</ul>
+}
+`, adapter)
+      const bf101 = adapter.errors.filter(e => e.code === 'BF101')
+      expect(bf101.length).toBeGreaterThan(0)
+      expect(bf101.some(e => e.message.includes('.some('))).toBe(true)
+      // The emitted template must stay syntactically valid (refusal sentinel,
+      // not a half-rendered predicate).
+      expect(result.template).not.toContain('.Some')
+      expect(result.template).toContain('{{if false}}')
+    })
+
+    test('nested .some(...) in filter predicate + /* @client */ suppresses BF101 (#2038)', () => {
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+type Item = { id: number }
+
+export function Picker() {
+  const [items, setItems] = createSignal<Item[]>([])
+  const [picked, setPicked] = createSignal<Item[]>([])
+  return <ul>{/* @client */ items().filter(t => !picked().some(p => p.id === t.id)).map(t => <li key={t.id}>{t.id}</li>)}</ul>
 }
 `, adapter)
       adapter.generate(ir)

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -99,12 +99,16 @@ runAdapterConformanceTests({
     // syntax — same BF101 refusal.
     'tagged-template-classname': [{ code: 'BF101', severity: 'error' }],
     // #2038: a filter predicate whose body contains a NESTED callback call
-    // (`t => !picked().some(p => …)`). The evaluator refuses nested arrows
-    // and `renderFilterExpr` has no faithful Go form for the inner call (its
-    // `call` arm used to silently drop the arrow argument and render only
-    // the callee) — the compiler is loud instead of lossy.
+    // (`t => !picked().some(p => …)` / `t => picked().find(p => …)`). The
+    // evaluator refuses nested arrows and `renderFilterExpr` has no faithful
+    // Go form for the inner call (its `call` arm used to silently drop the
+    // arrow argument and render only the callee) — the compiler is loud
+    // instead of lossy. The `/* @client */` twin
+    // (`filter-nested-callback-predicate-client`) has no pin here: it must
+    // render clean on every adapter, which asserts the suppression contract.
     // https://github.com/piconic-ai/barefootjs/issues/2038
     'filter-nested-callback-predicate': [{ code: 'BF101', severity: 'error' }],
+    'filter-nested-find-predicate': [{ code: 'BF101', severity: 'error' }],
     // #1310: rest destructure in .map() callback. The object-rest shape read
     // via member access (`rest-destructure-object-in-map`) now lowers — each
     // binding resolves to a field on a synthetic `$__bf_item0` range var (the
@@ -1838,12 +1842,13 @@ export function TodoList() {
       expect(bf101).toEqual([])
     })
 
-    test('nested .some(...) in filter predicate surfaces BF101 instead of dropping the callback (#2038)', () => {
-      // Pre-#2038 the `call` arm of `renderFilterExprNode` rendered only the
-      // callee for a nested callback call, silently DROPPING the arrow
-      // argument (`!picked().some(p => p.id === t.id)` degraded to a bogus
-      // field-path read) — a lossy predicate rewrite. The compiler is loud
-      // now: BF101 with the /* @client */ escape hatch.
+    test('nested-callback refusal keeps the emitted template syntactically valid (#2038)', () => {
+      // The BF101 contract itself is pinned at the shared conformance layer
+      // (`filter-nested-callback-predicate` / `filter-nested-find-predicate`
+      // expectedDiagnostics; the `/* @client */` suppression twin renders
+      // clean). This test pins the GO-SPECIFIC half: the refusal must emit
+      // the `false` sentinel — not a half-rendered predicate like `.Some` —
+      // so `text/template` parsing doesn't cascade into secondary errors.
       const adapter = new GoTemplateAdapter()
       const result = compileAndGenerate(`
 "use client"
@@ -1857,32 +1862,9 @@ export function Picker() {
   return <ul>{items().filter(t => !picked().some(p => p.id === t.id)).map(t => <li key={t.id}>{t.id}</li>)}</ul>
 }
 `, adapter)
-      const bf101 = adapter.errors.filter(e => e.code === 'BF101')
-      expect(bf101.length).toBeGreaterThan(0)
-      expect(bf101.some(e => e.message.includes('.some('))).toBe(true)
-      // The emitted template must stay syntactically valid (refusal sentinel,
-      // not a half-rendered predicate).
+      expect(adapter.errors.some(e => e.code === 'BF101')).toBe(true)
       expect(result.template).not.toContain('.Some')
       expect(result.template).toContain('{{if false}}')
-    })
-
-    test('nested .some(...) in filter predicate + /* @client */ suppresses BF101 (#2038)', () => {
-      const adapter = new GoTemplateAdapter()
-      const ir = compileToIR(`
-"use client"
-import { createSignal } from "@barefootjs/client"
-
-type Item = { id: number }
-
-export function Picker() {
-  const [items, setItems] = createSignal<Item[]>([])
-  const [picked, setPicked] = createSignal<Item[]>([])
-  return <ul>{/* @client */ items().filter(t => !picked().some(p => p.id === t.id)).map(t => <li key={t.id}>{t.id}</li>)}</ul>
-}
-`, adapter)
-      adapter.generate(ir)
-      const bf101 = adapter.errors.filter(e => e.code === 'BF101')
-      expect(bf101).toEqual([])
     })
   })
 

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -3657,6 +3657,16 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         if (expr.callee.kind === 'identifier' && expr.args.length === 0) {
           return `$.${capitalizeFieldName(expr.callee.name)}`
         }
+        // A nested callback method call (`other.some(r => …)`) reaching this
+        // arm has no Go template form in filter context — the fallthrough
+        // below renders only the callee and silently DROPS the arrow argument,
+        // changing predicate semantics (#2038). The one faithful nested shape
+        // (`.filter(cb).length` → `len (bf_filter_eval …)`) is intercepted at
+        // the `member` arm before this node is visited; everything else must
+        // be loud.
+        if (asCallbackMethodCall(expr) !== null) {
+          return this.refuseFilterExprNode(expr)
+        }
         const result = this.renderFilterExpr(expr.callee, param, localVarMap)
         if (this.filterExprUnsupported) return 'false'
         return result
@@ -3721,29 +3731,35 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         return `or (${left}) (${right})`
       }
 
-      default: {
-        // The filter predicate body contains a node kind we can't lower to a Go
-        // template action — most commonly a nested higher-order
-        // (`x => x.tags.filter(...).length > 0`). Surface BF101 with the
-        // offending expression. Set the recursion-wide `filterExprUnsupported`
-        // flag so parent branches return `false` instead of wrapping the
-        // sentinel into `false.Length` / `gt false.Length 0` etc.: the build
-        // fails on BF101 anyway, but the emitted template must stay
-        // syntactically valid so `text/template` parsing doesn't cascade into
-        // confusing secondary errors.
-        this.filterExprUnsupported = true
-        this.state.errors.push({
-          code: 'BF101',
-          severity: 'error',
-          message: `Filter predicate contains an expression that cannot be lowered to a Go template action: ${exprToString(expr)}`,
-          loc: this.makeLoc(),
-          suggestion: {
-            message: 'Options:\n1. Use /* @client */ for client-side evaluation\n2. Rewrite the predicate to avoid nested higher-order methods (`.filter()` / `.map()` / etc. inside the predicate body)',
-          },
-        })
-        return 'false'
-      }
+      default:
+        // The filter predicate body contains a node kind we can't lower to a
+        // Go template action. Shared refusal with the nested-callback guard in
+        // the `call` arm (#2038).
+        return this.refuseFilterExprNode(expr)
     }
+  }
+
+  /**
+   * Refuse a filter-predicate node that has no Go template lowering. Surfaces
+   * BF101 with the offending expression and sets the recursion-wide
+   * `filterExprUnsupported` flag so parent branches return `false` instead of
+   * wrapping the sentinel into `false.Length` / `gt false.Length 0` etc.: the
+   * build fails on BF101 anyway, but the emitted template must stay
+   * syntactically valid so `text/template` parsing doesn't cascade into
+   * confusing secondary errors.
+   */
+  private refuseFilterExprNode(expr: ParsedExpr): string {
+    this.filterExprUnsupported = true
+    this.state.errors.push({
+      code: 'BF101',
+      severity: 'error',
+      message: `Filter predicate contains an expression that cannot be lowered to a Go template action: ${exprToString(expr)}`,
+      loc: this.makeLoc(),
+      suggestion: {
+        message: 'Options:\n1. Use /* @client */ for client-side evaluation\n2. Rewrite the predicate to avoid nested higher-order methods (`.filter()` / `.map()` / etc. inside the predicate body)',
+      },
+    })
+    return 'false'
   }
 
   /**

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -792,6 +792,47 @@ export function C() {
     expect(template).toContain('scalar(@{[grep { $_->{active} } @{$t->{tags}}]})')
   })
 
+  test('lowers nested .some(...) in filter predicate to an inline grep — no BF101 (#2038)', () => {
+    // The evaluator refuses the nested arrow (`serializeParsedExpr` → null),
+    // but the Perl filter emitter has a FAITHFUL form for nested
+    // filter / every / some: a real inline `grep` closing over the outer
+    // loop var. Pin it positively so the #2038 loudness fix (which targets
+    // the degrade-only arms: nested `find*`, sort / reduce / flatMap) never
+    // over-reaches into this supported shape.
+    const adapter = new MojoAdapter()
+    const result = compileJSX(`'use client'
+import { createSignal } from '@barefootjs/client'
+type Item = { id: number }
+export function Picker() {
+  const [items] = createSignal<Item[]>([])
+  const [picked] = createSignal<Item[]>([])
+  return <ul>{items().filter(t => !picked().some(p => p.id === t.id)).map(t => <li key={t.id}>{t.id}</li>)}</ul>
+}`, 'C.tsx', { adapter })
+    expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
+    const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
+    expect(template).toContain('grep')
+    expect(template).toContain('@{$picked}')
+  })
+
+  test('nested .find(...) in filter predicate surfaces BF101 instead of degrading to its receiver (#2038)', () => {
+    // `find*` returns an element, not a boolean — there is no inline grep
+    // form, and the pre-#2038 emitter silently degraded the call to its
+    // receiver (`picked().find(p => …)` → `$picked`), changing predicate
+    // semantics. The compiler is loud now.
+    const adapter = new MojoAdapter()
+    const result = compileJSX(`'use client'
+import { createSignal } from '@barefootjs/client'
+type Item = { id: number; parent: number }
+export function Picker() {
+  const [items] = createSignal<Item[]>([])
+  const [picked] = createSignal<Item[]>([])
+  return <ul>{items().filter(t => picked().find(p => p.id === t.parent) !== null).map(t => <li key={t.id}>{t.id}</li>)}</ul>
+}`, 'C.tsx', { adapter })
+    const bf101 = result.errors?.filter(e => e.code === 'BF101') ?? []
+    expect(bf101.length).toBeGreaterThan(0)
+    expect(bf101.some(e => e.message.includes(".find(...)"))).toBe(true)
+  })
+
   test('lowers .filter(function (x) { return x.done }).map(...) — function-keyword filter (#1443)', () => {
     // Function expressions with a single `return <expr>` body normalise
     // to the arrow-fn IR shape at parse time, so the higher-order

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -65,6 +65,14 @@ runAdapterConformanceTests({
     // (`cn\`base \${tone()}\``) — same family as #1322 above and refused
     // via the same gate.
     'tagged-template-classname': [{ code: 'BF101', severity: 'error' }],
+    // #2038: a filter predicate containing a nested `.find(...)` callback.
+    // `find*` returns an element, not a boolean — there is no inline grep
+    // form, and the emitter used to degrade the call to its receiver.
+    // The nested `.some` sibling (`filter-nested-callback-predicate`) is
+    // NOT pinned: Mojo lowers it to a real inline Perl `grep` and must
+    // render to Hono parity instead.
+    // https://github.com/piconic-ai/barefootjs/issues/2038
+    'filter-nested-find-predicate': [{ code: 'BF101', severity: 'error' }],
     // #1467 demo-corpus context providers (`radio-group`, `accordion`,
     // `dialog`, `popover`, `select`, `dropdown-menu`, `combobox`,
     // `command`) are no longer pinned — an object-literal provider value
@@ -153,6 +161,9 @@ runAdapterConformanceTests({
   skipMarkerConformance: new Set([
     'client-only',
     'client-only-loop-with-sibling-cond',
+    // Same clientOnly-loop marker gap as `client-only` above — the #2038
+    // `/* @client */` suppression twin's loop is client-only by construction.
+    'filter-nested-callback-predicate-client',
     // Same as Hono: `/* @client */` markers on TodoApp's keyed `.map`
     // intentionally elide a slot id from the SSR template that the IR
     // still declares (s6). See hono-adapter.test for the contract.
@@ -796,9 +807,12 @@ export function C() {
     // The evaluator refuses the nested arrow (`serializeParsedExpr` → null),
     // but the Perl filter emitter has a FAITHFUL form for nested
     // filter / every / some: a real inline `grep` closing over the outer
-    // loop var. Pin it positively so the #2038 loudness fix (which targets
-    // the degrade-only arms: nested `find*`, sort / reduce / flatMap) never
-    // over-reaches into this supported shape.
+    // loop var. Pin the emitted EP shape positively so the #2038 loudness
+    // fix (which targets the degrade-only arms: nested `find*`,
+    // sort / reduce / flatMap — see the `filter-nested-find-predicate`
+    // expectedDiagnostics entry) never over-reaches into this supported
+    // shape. The rendered-HTML side of this contract lives in the shared
+    // `filter-nested-callback-predicate` fixture (Hono-parity render).
     const adapter = new MojoAdapter()
     const result = compileJSX(`'use client'
 import { createSignal } from '@barefootjs/client'
@@ -812,25 +826,6 @@ export function Picker() {
     const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
     expect(template).toContain('grep')
     expect(template).toContain('@{$picked}')
-  })
-
-  test('nested .find(...) in filter predicate surfaces BF101 instead of degrading to its receiver (#2038)', () => {
-    // `find*` returns an element, not a boolean — there is no inline grep
-    // form, and the pre-#2038 emitter silently degraded the call to its
-    // receiver (`picked().find(p => …)` → `$picked`), changing predicate
-    // semantics. The compiler is loud now.
-    const adapter = new MojoAdapter()
-    const result = compileJSX(`'use client'
-import { createSignal } from '@barefootjs/client'
-type Item = { id: number; parent: number }
-export function Picker() {
-  const [items] = createSignal<Item[]>([])
-  const [picked] = createSignal<Item[]>([])
-  return <ul>{items().filter(t => picked().find(p => p.id === t.parent) !== null).map(t => <li key={t.id}>{t.id}</li>)}</ul>
-}`, 'C.tsx', { adapter })
-    const bf101 = result.errors?.filter(e => e.code === 'BF101') ?? []
-    expect(bf101.length).toBeGreaterThan(0)
-    expect(bf101.some(e => e.message.includes(".find(...)"))).toBe(true)
   })
 
   test('lowers .filter(function (x) { return x.done }).map(...) — function-keyword filter (#1443)', () => {

--- a/packages/adapter-mojolicious/src/adapter/expr/emitters.ts
+++ b/packages/adapter-mojolicious/src/adapter/expr/emitters.ts
@@ -81,6 +81,11 @@ export class MojoFilterEmitter implements ParsedExprEmitter {
     // against it lowers to `eq`/`ne` (#1672). Defaults to "never" for callers
     // that don't thread it through.
     private readonly isStringName: (n: string) => boolean = () => false,
+    // Records a BF101 for nested callback shapes this emitter can only
+    // degrade — `find*` and the non-predicate methods (#2038). Optional so
+    // emitter construction stays possible without an adapter; a missing hook
+    // keeps the old silent-degrade emit.
+    private readonly onUnsupported?: (message: string, reason?: string) => void,
   ) {}
 
   identifier(name: string): string {
@@ -172,20 +177,34 @@ export class MojoFilterEmitter implements ParsedExprEmitter {
   ): string {
     // Filter context only meaningfully handles the predicate methods
     // (filter / every / some land here through nested `.filter(...)` chains).
-    // Sort / reduce / flatMap never arise inside a predicate, so route them to
-    // the truthy sentinel like the old `default` arm did.
-    if (!PREDICATE_METHODS.has(method)) return '1'
+    // Sort / reduce / flatMap have no scalar Perl form here — the old
+    // `default` arm degraded them to the truthy sentinel, silently rewriting
+    // the predicate, so surface BF101 instead (#2038).
+    if (!PREDICATE_METHODS.has(method)) {
+      this.onUnsupported?.(
+        `Filter predicate contains a nested '.${method}(...)' callback, which has no Perl scalar form`,
+        `Rewrite the predicate without a nested callback method, or add /* @client */ for client-only evaluation (no SSR).`,
+      )
+      return '1'
+    }
     // The predicate body is also a filter context, but with this
     // callback's own `param` (potentially shadowing the outer one),
     // so we spin up a nested emitter with the inner param.
     const param = arrow.params[0]
     const predicate = arrow.body
     const arrayExpr = emit(object)
-    const predBody = emitParsedExpr(predicate, new MojoFilterEmitter(param, this.localVarMap, this.isStringName))
+    const predBody = emitParsedExpr(predicate, new MojoFilterEmitter(param, this.localVarMap, this.isStringName, this.onUnsupported))
     const grepBody = predBody.replace(new RegExp(`\\$${param}\\b`, 'g'), '$_')
     if (method === 'filter') return `[grep { ${grepBody} } @{${arrayExpr}}]`
     if (method === 'every') return `!(grep { !(${grepBody}) } @{${arrayExpr}})`
     if (method === 'some') return `!!(grep { ${grepBody} } @{${arrayExpr}})`
+    // `find` / `findIndex` / `findLast` / `findLastIndex` return an element
+    // (or index), not a boolean — there is no inline grep form. Degrading to
+    // the receiver silently changes predicate semantics, so be loud (#2038).
+    this.onUnsupported?.(
+      `Filter predicate contains a nested '.${method}(...)' callback, which has no Perl scalar form`,
+      `Rewrite the predicate without a nested callback method, or add /* @client */ for client-only evaluation (no SSR).`,
+    )
     return arrayExpr
   }
 

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1389,13 +1389,22 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     // now lowering `.length` on a higher-order object to
     // `scalar(@{...})`, the canonical
     // `x.tags.filter(t => t.active).length > 0` shape lowers
-    // cleanly. Predicates that combine a nested higher-order with
-    // something OTHER than `.length` (e.g. `.includes`, `.join`)
-    // still fall back to whatever the emitter produces — most of
-    // those would yield runtime errors in Perl, which is the user's
-    // signal to refactor. Wholesale refusal would also block the
-    // canonical case the issue exists to enable.
-    return emitParsedExpr(expr, new MojoFilterEmitter(param, localVarMap, n => this._isStringValueName(n)))
+    // cleanly, and nested `filter` / `every` / `some` lower to real
+    // inline `grep` forms. The shapes the emitter can only DEGRADE
+    // (nested `find*`, sort / reduce / flatMap inside a predicate)
+    // surface BF101 through the hook below instead of silently
+    // rewriting the predicate (#2038). Wholesale refusal would block
+    // the canonical case #1443 exists to enable, so the gate lives at
+    // the exact degrade points inside `MojoFilterEmitter.callbackMethod`.
+    return emitParsedExpr(
+      expr,
+      new MojoFilterEmitter(
+        param,
+        localVarMap,
+        n => this._isStringValueName(n),
+        (message, reason) => this._recordExprBF101(message, reason),
+      ),
+    )
   }
 
   // ===========================================================================

--- a/packages/adapter-tests/fixtures/filter-nested-callback-predicate-client.ts
+++ b/packages/adapter-tests/fixtures/filter-nested-callback-predicate-client.ts
@@ -1,0 +1,28 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `/* @client *​/` twin of `filter-nested-callback-predicate` (#2038).
+ *
+ * The marker defers the whole chain to client evaluation, so the loop is
+ * client-only: SSR renders the empty `<ul>` on EVERY adapter and no BF101
+ * may fire — the SSR render helpers throw on any compile error, so this
+ * fixture pins the suppression contract across the corpus without any
+ * per-adapter `expectedDiagnostics` entry (same pattern as `client-only`).
+ */
+export const fixture = createFixture({
+  id: 'filter-nested-callback-predicate-client',
+  description: 'Nested-callback filter predicate + /* @client */ suppresses BF101 (#2038)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Item = { id: number }
+export function NestedCallbackPredicateClient() {
+  const [items, setItems] = createSignal<Item[]>([])
+  const [picked, setPicked] = createSignal<Item[]>([])
+  return <ul>{/* @client */ items().filter(t => !picked().some(p => p.id === t.id)).map((t, i) => <li key={i}>{t.id}</li>)}</ul>
+}
+`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s1"></ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/filter-nested-callback-predicate.ts
+++ b/packages/adapter-tests/fixtures/filter-nested-callback-predicate.ts
@@ -1,0 +1,36 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Filter predicate whose body contains a NESTED higher-order callback call
+ * (`items().filter(t => !picked().some(p => …))`) — the #2038 repro shape
+ * (thread-demo's "unreacted emojis" chain).
+ *
+ * The runtime evaluator refuses nested arrows (`serializeParsedExpr` → null),
+ * so SSR adapters that lack a faithful nested lowering used to fall back to a
+ * lambda form that silently DEGRADED the inner `.some(...)` to its receiver,
+ * changing predicate semantics. This fixture pins the corrected behavior:
+ *
+ *   - Hono / CSR evaluate JS natively and render the chain faithfully.
+ *   - Mojo lowers the nested `.some` to a real inline Perl `grep` and must
+ *     match the Hono reference HTML.
+ *   - Go template / Xslate have no faithful nested form and now surface a
+ *     loud BF101 (declared via those adapters' `expectedDiagnostics`)
+ *     instead of the silent lossy lambda.
+ */
+export const fixture = createFixture({
+  id: 'filter-nested-callback-predicate',
+  description: 'Filter predicate containing a nested .some() callback (#2038)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Item = { id: number }
+export function NestedCallbackPredicate() {
+  const [items, setItems] = createSignal<Item[]>([])
+  const [picked, setPicked] = createSignal<Item[]>([])
+  return <ul>{items().filter(t => !picked().some(p => p.id === t.id)).map((t, i) => <li key={i}>{t.id}</li>)}</ul>
+}
+`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s1"></ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/filter-nested-find-predicate.ts
+++ b/packages/adapter-tests/fixtures/filter-nested-find-predicate.ts
@@ -1,0 +1,31 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Filter predicate whose body is a nested `.find(...)` truthiness check
+ * (#2038). Unlike the nested `.some` of `filter-nested-callback-predicate`,
+ * `find*` returns an ELEMENT, not a boolean — so even Mojo (which lowers
+ * nested filter / every / some to real inline `grep` forms) has no faithful
+ * scalar lowering and used to degrade the call to its receiver.
+ *
+ * Pinned behavior:
+ *   - Hono / CSR evaluate JS natively and render the chain faithfully.
+ *   - Go template / Mojo / Xslate surface a loud BF101 (declared via each
+ *     adapter's `expectedDiagnostics`) instead of a silent lossy rewrite.
+ */
+export const fixture = createFixture({
+  id: 'filter-nested-find-predicate',
+  description: 'Filter predicate containing a nested .find() callback (#2038)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Item = { id: number }
+export function NestedFindPredicate() {
+  const [items, setItems] = createSignal<Item[]>([])
+  const [picked, setPicked] = createSignal<Item[]>([])
+  return <ul>{items().filter(t => picked().find(p => p.id === t.id)).map((t, i) => <li key={i}>{t.id}</li>)}</ul>
+}
+`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s1"></ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -105,6 +105,7 @@ import { fixture as ifStatement } from './if-statement'
 import { fixture as mapBasic } from './map-basic'
 import { fixture as mapWithIndex } from './map-with-index'
 import { fixture as filterSimple } from './filter-simple'
+import { fixture as filterNestedCallbackPredicate } from './filter-nested-callback-predicate'
 import { fixture as sortSimple } from './sort-simple'
 import { fixture as filterSortChain } from './filter-sort-chain'
 import { fixture as mapNested } from './map-nested'
@@ -322,6 +323,7 @@ export const jsxFixtures: JSXFixture[] = [
   mapBasic,
   mapWithIndex,
   filterSimple,
+  filterNestedCallbackPredicate,
   sortSimple,
   filterSortChain,
   mapNested,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -106,6 +106,8 @@ import { fixture as mapBasic } from './map-basic'
 import { fixture as mapWithIndex } from './map-with-index'
 import { fixture as filterSimple } from './filter-simple'
 import { fixture as filterNestedCallbackPredicate } from './filter-nested-callback-predicate'
+import { fixture as filterNestedCallbackPredicateClient } from './filter-nested-callback-predicate-client'
+import { fixture as filterNestedFindPredicate } from './filter-nested-find-predicate'
 import { fixture as sortSimple } from './sort-simple'
 import { fixture as filterSortChain } from './filter-sort-chain'
 import { fixture as mapNested } from './map-nested'
@@ -324,6 +326,8 @@ export const jsxFixtures: JSXFixture[] = [
   mapWithIndex,
   filterSimple,
   filterNestedCallbackPredicate,
+  filterNestedCallbackPredicateClient,
+  filterNestedFindPredicate,
   sortSimple,
   filterSortChain,
   mapNested,

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -101,6 +101,14 @@ runAdapterConformanceTests({
     // Tagged-template-literal call in a className — same family, same
     // refusal (BF101).
     'tagged-template-classname': [{ code: 'BF101', severity: 'error' }],
+    // #2038: a filter predicate whose body contains a NESTED callback call
+    // (`t => !picked().some(p => …)`). Kolon has no inline `grep` form, so
+    // `XslateFilterEmitter.callbackMethod` used to degrade the inner call to
+    // its receiver, silently changing predicate semantics — the compiler is
+    // loud instead of lossy. (Mojo is NOT pinned: it lowers the nested
+    // `.some` to a real inline Perl `grep`.)
+    // https://github.com/piconic-ai/barefootjs/issues/2038
+    'filter-nested-callback-predicate': [{ code: 'BF101', severity: 'error' }],
     // NB: `.find` / `.findIndex` / `.findLast` / `.findLastIndex` are NOT
     // pinned here — unlike mojo (which refuses them), Xslate lowers them to
     // `$bf.find` / `find_index` / `find_last` / `find_last_index` via the same
@@ -344,5 +352,41 @@ export { A }
     expect(template).not.toContain('every_eval')
     expect(template).toContain('$bf.every(')
     expect(template).toContain('-> $x {')
+  })
+})
+
+describe('XslateAdapter - nested callback inside a predicate is loud (#2038)', () => {
+  // Kolon has no inline `grep` form, so a nested callback call inside a
+  // predicate body has no faithful scalar lowering. Pre-#2038 the
+  // Kolon-lambda fallback degraded the inner call to its receiver
+  // (`!picked().some(p => …)` → `!$picked`), silently changing predicate
+  // semantics — the thread-demo repro. The emit must surface BF101 instead.
+  const nestedSomeSource = `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Item = { id: number }
+export function Picker() {
+  const [items, setItems] = createSignal<Item[]>([])
+  const [picked, setPicked] = createSignal<Item[]>([])
+  return <ul>{items().filter(t => !picked().some(p => p.id === t.id)).map(t => <li key={t.id}>{t.id}</li>)}</ul>
+}
+`
+
+  test('nested .some(...) in a loop filter predicate surfaces BF101', () => {
+    const adapter = new XslateAdapter()
+    const result = compileJSX(nestedSomeSource.trimStart(), 'test.tsx', { adapter })
+    const bf101 = result.errors?.filter(e => e.code === 'BF101') ?? []
+    expect(bf101.length).toBeGreaterThan(0)
+    expect(bf101.some(e => e.message.includes(".some(...)"))).toBe(true)
+  })
+
+  test('nested .some(...) + /* @client */ suppresses BF101', () => {
+    const adapter = new XslateAdapter()
+    const result = compileJSX(
+      nestedSomeSource.replace('<ul>{items()', '<ul>{/* @client */ items()').trimStart(),
+      'test.tsx',
+      { adapter },
+    )
+    expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
   })
 })

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -102,17 +102,23 @@ runAdapterConformanceTests({
     // refusal (BF101).
     'tagged-template-classname': [{ code: 'BF101', severity: 'error' }],
     // #2038: a filter predicate whose body contains a NESTED callback call
-    // (`t => !picked().some(p => …)`). Kolon has no inline `grep` form, so
-    // `XslateFilterEmitter.callbackMethod` used to degrade the inner call to
-    // its receiver, silently changing predicate semantics — the compiler is
-    // loud instead of lossy. (Mojo is NOT pinned: it lowers the nested
-    // `.some` to a real inline Perl `grep`.)
+    // (`t => !picked().some(p => …)` / `t => picked().find(p => …)`). Kolon
+    // has no inline `grep` form, so `XslateFilterEmitter.callbackMethod` used
+    // to degrade the inner call to its receiver, silently changing predicate
+    // semantics — the compiler is loud instead of lossy. (Mojo is pinned only
+    // for the `.find` variant: it lowers a nested `.some` to a real inline
+    // Perl `grep`.) The `/* @client */` twin
+    // (`filter-nested-callback-predicate-client`) has no pin here: it must
+    // render clean on every adapter, which asserts the suppression contract.
     // https://github.com/piconic-ai/barefootjs/issues/2038
     'filter-nested-callback-predicate': [{ code: 'BF101', severity: 'error' }],
-    // NB: `.find` / `.findIndex` / `.findLast` / `.findLastIndex` are NOT
-    // pinned here — unlike mojo (which refuses them), Xslate lowers them to
-    // `$bf.find` / `find_index` / `find_last` / `find_last_index` via the same
-    // Kolon-lambda mechanism as `.filter` / `.every` / `.some`, so they render.
+    'filter-nested-find-predicate': [{ code: 'BF101', severity: 'error' }],
+    // NB: TOP-LEVEL `.find` / `.findIndex` / `.findLast` / `.findLastIndex`
+    // (text position) are NOT pinned here — unlike mojo (which refuses them),
+    // Xslate lowers them to `$bf.find` / `find_index` / `find_last` /
+    // `find_last_index` via the same Kolon-lambda mechanism as `.filter` /
+    // `.every` / `.some`, so they render. Only the NESTED-in-a-predicate form
+    // above is refused (#2038).
   },
   // Template-primitive registry parity: same V1 surface as mojo, so the
   // same two cases stay skipped (bespoke user import + customSerialize
@@ -126,6 +132,9 @@ runAdapterConformanceTests({
   skipMarkerConformance: new Set([
     'client-only',
     'client-only-loop-with-sibling-cond',
+    // Same clientOnly-loop marker gap as `client-only` above — the #2038
+    // `/* @client */` suppression twin's loop is client-only by construction.
+    'filter-nested-callback-predicate-client',
     'todo-app',
     // #1467 Phase 2e: same `/* @client */` keyed-map elision (data-table).
     'data-table',
@@ -355,38 +364,8 @@ export { A }
   })
 })
 
-describe('XslateAdapter - nested callback inside a predicate is loud (#2038)', () => {
-  // Kolon has no inline `grep` form, so a nested callback call inside a
-  // predicate body has no faithful scalar lowering. Pre-#2038 the
-  // Kolon-lambda fallback degraded the inner call to its receiver
-  // (`!picked().some(p => …)` → `!$picked`), silently changing predicate
-  // semantics — the thread-demo repro. The emit must surface BF101 instead.
-  const nestedSomeSource = `
-'use client'
-import { createSignal } from '@barefootjs/client'
-type Item = { id: number }
-export function Picker() {
-  const [items, setItems] = createSignal<Item[]>([])
-  const [picked, setPicked] = createSignal<Item[]>([])
-  return <ul>{items().filter(t => !picked().some(p => p.id === t.id)).map(t => <li key={t.id}>{t.id}</li>)}</ul>
-}
-`
-
-  test('nested .some(...) in a loop filter predicate surfaces BF101', () => {
-    const adapter = new XslateAdapter()
-    const result = compileJSX(nestedSomeSource.trimStart(), 'test.tsx', { adapter })
-    const bf101 = result.errors?.filter(e => e.code === 'BF101') ?? []
-    expect(bf101.length).toBeGreaterThan(0)
-    expect(bf101.some(e => e.message.includes(".some(...)"))).toBe(true)
-  })
-
-  test('nested .some(...) + /* @client */ suppresses BF101', () => {
-    const adapter = new XslateAdapter()
-    const result = compileJSX(
-      nestedSomeSource.replace('<ul>{items()', '<ul>{/* @client */ items()').trimStart(),
-      'test.tsx',
-      { adapter },
-    )
-    expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
-  })
-})
+// #2038 nested-callback-predicate loudness is pinned at the shared
+// conformance layer: `filter-nested-callback-predicate` /
+// `filter-nested-find-predicate` (BF101 via `expectedDiagnostics` above) and
+// `filter-nested-callback-predicate-client` (the `/* @client */` suppression
+// twin, which must render clean).

--- a/packages/adapter-xslate/src/adapter/expr/emitters.ts
+++ b/packages/adapter-xslate/src/adapter/expr/emitters.ts
@@ -62,18 +62,20 @@ const PREDICATE_METHODS = new Set<HigherOrderMethod>([
  * filters. Higher-order predicates are emitted using Kolon's own scalar
  * comparison operators (which delegate to Perl semantics).
  *
- * NOTE: Kolon has no `grep { } @{...}` form, so nested higher-order chains
- * (`x.tags.filter(...).length`) inside a predicate route through the
- * top-level emitter's `$bf`-helper higher-order lowering. This emitter keeps
- * the scalar-comparison surface the predicates the adapter accepts actually
- * use; richer nested shapes fall back to the helper or surface as BF101 via
- * the top-level emitter.
+ * NOTE: Kolon has no `grep { } @{...}` form, so a nested higher-order call
+ * (`x.tags.filter(...)`, `other.some(...)`) inside a predicate has no faithful
+ * scalar lowering here. Such predicates surface BF101 via `onUnsupported`
+ * (#2038) instead of silently degrading to the callback's receiver.
  */
 export class XslateFilterEmitter implements ParsedExprEmitter {
   constructor(
     private readonly param: string,
     private readonly localVarMap: Map<string, string>,
     private readonly isStringName: (n: string) => boolean = () => false,
+    // Records a BF101 for predicate shapes this emitter can only degrade
+    // (#2038). Optional so emitter construction stays possible without an
+    // adapter; a missing hook keeps the old silent-degrade emit.
+    private readonly onUnsupported?: (message: string, reason?: string) => void,
   ) {}
 
   identifier(name: string): string {
@@ -155,12 +157,15 @@ export class XslateFilterEmitter implements ParsedExprEmitter {
     _restArgs: ParsedExpr[],
     emit: (e: ParsedExpr) => string,
   ): string {
-    // Nested callback method inside a filter predicate has no Kolon scalar
-    // form; defer to the receiver so the predicate at least references a real
-    // value (a richer chain would surface its own diagnostic at the top level).
-    // Matches the pre-#2018-P5 `higherOrder` arm, which returned `emit(object)`
-    // for every method.
-    void method
+    // A nested callback method inside a filter predicate has no Kolon scalar
+    // form. The pre-#2038 behavior degraded it to its receiver, which silently
+    // changes predicate semantics (`!other.some(r => …)` collapses to
+    // `!other`), so surface BF101 instead. The receiver emit is kept only so
+    // the template stays syntactically valid while the build fails.
+    this.onUnsupported?.(
+      `Filter predicate contains a nested '.${method}(...)' callback, which has no Kolon scalar form`,
+      `Rewrite the predicate without a nested callback method, or add /* @client */ for client-only evaluation (no SSR).`,
+    )
     return emit(object)
   }
 

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -1147,7 +1147,18 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     param: string,
     localVarMap: Map<string, string> = new Map(),
   ): string {
-    return emitParsedExpr(expr, new XslateFilterEmitter(param, localVarMap, n => this._isStringValueName(n)))
+    return emitParsedExpr(
+      expr,
+      new XslateFilterEmitter(
+        param,
+        localVarMap,
+        n => this._isStringValueName(n),
+        // A nested callback method inside the predicate has no Kolon scalar
+        // form — surface BF101 (#2038) instead of silently degrading it to
+        // its receiver.
+        (message, reason) => this._recordExprBF101(message, reason),
+      ),
+    )
   }
 
   // ===========================================================================

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -2207,8 +2207,12 @@ function checkSupport(expr: ParsedExpr): SupportResult {
       // the receiver and the callback BODY are supported. Recognised before the
       // `UNSUPPORTED_METHODS` gate so the eval-lowered shapes aren't refused
       // (a BARE method reference — `arr.filter` uncalled, no arrow arg — still
-      // falls through to the gate). A nested callback inside the body refuses
-      // at the adapter's `serializeParsedExpr` purity gate, not here.
+      // falls through to the gate). A nested callback inside the body is NOT
+      // refused here: the evaluator refuses it (`serializeParsedExpr` → null)
+      // and each adapter then either lowers it faithfully (Mojo's inline
+      // `grep`, Go's `len (bf_filter_eval …)`) or surfaces BF101 at its
+      // predicate fallback's exact degrade points (#2038) — a blanket refusal
+      // here would break the faithful shapes (#1443 PR4).
       const cb = asCallbackMethodCall(expr)
       if (cb) {
         const objSupport = checkSupport(cb.object)


### PR DESCRIPTION
Closes #2038.

## Problem

A higher-order **predicate** whose body contains a *nested* higher-order callback call (e.g. `reactionEmojis.filter(e => !comment.reactions.some(r => r.emoji === e))`, the thread-demo repro) cannot be serialized to the runtime evaluator (`serializeParsedExpr` refuses nested arrows), so the SSR adapters fell back to lambda/structural forms that **silently rewrote the predicate**:

- **Xslate** — `XslateFilterEmitter.callbackMethod` degraded every nested callback to its receiver (`!other.some(r => …)` collapsed to `!other`).
- **Mojo** — `MojoFilterEmitter.callbackMethod` degraded nested `find*` to the receiver and nested sort / reduce / flatMap to the truthy sentinel `'1'`.
- **Go** — `renderFilterExprNode`'s `call` arm rendered only the callee, silently dropping the arrow argument.

## Fix

Per the compiler's no-safe-fallback rule (`spec/compiler.md`: a template-position predicate the adapter cannot lower must be **loud**), each adapter now records **BF101** at its exact degrade points, with `/* @client */` as the escape hatch:

- Xslate/Mojo: the filter emitters take an optional `onUnsupported` hook, threaded from the adapters' `_recordExprBF101`.
- Go: the nested-callback guard in the `call` arm routes to the same refusal as the existing `default` arm (extracted into `refuseFilterExprNode`), keeping the emitted template syntactically valid (`{{if false}}`).

**A blanket `containsHigherOrder` gate in the jsx purity gate was deliberately ruled out**: Mojo lowers nested `filter` / `every` / `some` to real inline Perl `grep` forms, and Go lowers `.filter(cb).length` via `len (bf_filter_eval …)` — refusing centrally would break those faithful shapes (#1443 PR4 removed exactly such a gate). The `checkSupport` comment in `expression-parser.ts` is updated to document this.

## Behavior change

A currently-(lossily-)compiling component now fails loudly with BF101 on Go/Xslate (and on Mojo for nested `find*` / non-predicate callbacks). This is the deliberate change #2038 calls for; `/* @client */` defers the position to the client, matching the pre-existing suppression contract.

## Tests

The contracts live at the **shared conformance layer** (fixtures + per-adapter `expectedDiagnostics`), not as duplicated per-adapter unit tests:

- `filter-nested-callback-predicate` — nested `.some` predicate. BF101 pinned on Go/Xslate via `expectedDiagnostics`; renders to Hono parity on Mojo (faithful inline `grep`) and CSR.
- `filter-nested-callback-predicate-client` — the `/* @client */` suppression twin. No diagnostics pinned anywhere: the SSR render helpers throw on any compile error, so a clean render on every adapter *is* the suppression pin (same pattern as the existing `client-only` fixture). Added to mojo/xslate `skipMarkerConformance` for the pre-existing clientOnly-loop boundary-marker gap.
- `filter-nested-find-predicate` — nested `.find` predicate. BF101 pinned on all three SSR adapters (`find*` returns an element, so even Mojo has no inline grep form).
- Adapter test files keep only adapter-specific output assertions: Go's refusal-sentinel template validity (`{{if false}}`, no half-rendered `.Some`) and Mojo's faithful inline-grep EP shape for nested `.some`.
- Full suites for `adapter-go-template`, `adapter-mojolicious`, `adapter-xslate`, `adapter-tests`, `adapter-hono`, and `jsx` run clean; the only failures are pre-existing on the base commit (env-dependent: carousel byte-parity, context-bridge, resolver-alias checker tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BECDX5Bt2mLqwfMtmS951B