### PR TITLE
fix(#2066): emit loop boundary markers for clientOnly loops in Mojo/Xslate adapters

### DIFF
--- a/.changeset/client-only-loop-markers.md
+++ b/.changeset/client-only-loop-markers.md
@@ -1,0 +1,6 @@
+---
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+---
+
+Emit the `<!--bf-loop:<id>-->` / `<!--bf-/loop:<id>-->` boundary marker pair for clientOnly (`/* @client */`) loops (#2066). Both adapters previously rendered nothing at the loop position, so the client runtime's `mapArray()` resolved `anchor = null` and appended hydrated items after sibling markers (#872 defect class). The pair now matches Hono / Go emission, with per-call-site marker ids (#1087) keeping sibling `.map()` ranges distinct.

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -151,19 +151,12 @@ runAdapterConformanceTests({
     TemplatePrimitiveCaseId.USER_IMPORT_VIA_CONST,
     TemplatePrimitiveCaseId.NO_DOUBLE_REWRITE_OF_PROPS_OBJECT,
   ]),
-  // Mojo `renderLoop` does not yet emit the `bf->comment("loop:<id>")`
-  // boundary markers when the loop is `@client` (Hono and Go both do).
-  // The client runtime relies on these markers to locate the insertion
-  // anchor when hydrating the array; without them, mapArray() resolves
-  // anchor = null and appends after sibling markers (#872 parity).
-  // Tracked as a follow-up; remove from this set when Mojo emits the
-  // boundary pair for clientOnly loops too.
+  // `client-only` / `client-only-loop-with-sibling-cond` /
+  // `filter-nested-callback-predicate-client` are no longer skipped —
+  // `renderLoop` now emits the `bf->comment("loop:<id>")` boundary pair
+  // for clientOnly loops (Hono / Go parity), so mapArray() can locate
+  // its insertion anchor at hydration time (#872 / #1087).
   skipMarkerConformance: new Set([
-    'client-only',
-    'client-only-loop-with-sibling-cond',
-    // Same clientOnly-loop marker gap as `client-only` above — the #2038
-    // `/* @client */` suppression twin's loop is client-only by construction.
-    'filter-nested-callback-predicate-client',
     // Same as Hono: `/* @client */` markers on TodoApp's keyed `.map`
     // intentionally elide a slot id from the SSR template that the IR
     // still declares (s6). See hono-adapter.test for the contract.
@@ -616,6 +609,28 @@ export function List() {
     // Markers are scoped per-call-site (#1087): `bf->comment("loop:<id>")`.
     expect(result.template).toMatch(/bf->comment\("loop:[^"]+"\)/)
     expect(result.template).toMatch(/bf->comment\("\/loop:[^"]+"\)/)
+  })
+
+  test('emits the loop boundary marker pair for a clientOnly loop (#872 / #1087 parity)', () => {
+    // A `/* @client */` loop renders no items at SSR time, but the
+    // `loop:`/`/loop:` boundary pair must still be emitted (as Hono and
+    // Go do) so the client runtime's mapArray() can locate its insertion
+    // anchor at hydration time.
+    const result = compileAndGenerate(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+export function List() {
+  const [items, setItems] = createSignal<string[]>([])
+  return <ul>{/* @client */ items().map(item => <li>{item}</li>)}</ul>
+}
+`)
+    expect(result.template).toMatch(
+      /bf->comment\("loop:([\w-]+)"\) %><%== bf->comment\("\/loop:\1"\)/,
+    )
+    // No SSR item rows and no Perl loop for a clientOnly map.
+    expect(result.template).not.toContain('<li')
+    expect(result.template).not.toContain('% for my')
   })
 
   test('compares string signals with Perl `eq`, not numeric `==` (#1672)', () => {

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -695,8 +695,15 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
   // ===========================================================================
 
   renderLoop(loop: IRLoop): string {
-    // Client-only loops: skip SSR rendering entirely
-    if (loop.clientOnly) return ''
+    // clientOnly loops must not render items at SSR time, but must still emit
+    // the `loop:`/`/loop:` boundary marker pair (Hono and Go parity) so the
+    // client runtime's mapArray() can locate the insertion anchor when
+    // hydrating the array. Without the markers, mapArray() resolves
+    // anchor = null and appends after sibling markers (#872). The marker id
+    // disambiguates sibling `.map()` calls under the same parent (#1087).
+    if (loop.clientOnly) {
+      return `<%== bf->comment("loop:${loop.markerId}") %><%== bf->comment("/loop:${loop.markerId}") %>`
+    }
 
     // An array/object-destructure loop param (`([emoji, users]) => ...`
     // or `({ name, age }) => ...`) lowers to invalid Perl — the adapter

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -127,14 +127,15 @@ runAdapterConformanceTests({
     TemplatePrimitiveCaseId.USER_IMPORT_VIA_CONST,
     TemplatePrimitiveCaseId.NO_DOUBLE_REWRITE_OF_PROPS_OBJECT,
   ]),
-  // Loop boundary markers for `@client` loops aren't emitted by the
-  // Xslate adapter yet (ported from mojo, which skips the same set).
+  // `client-only` / `client-only-loop-with-sibling-cond` /
+  // `filter-nested-callback-predicate-client` are no longer skipped —
+  // `renderLoop` now emits the `$bf.comment("loop:<id>")` boundary pair
+  // for clientOnly loops (Hono / Go parity), so mapArray() can locate
+  // its insertion anchor at hydration time (#872 / #1087).
   skipMarkerConformance: new Set([
-    'client-only',
-    'client-only-loop-with-sibling-cond',
-    // Same clientOnly-loop marker gap as `client-only` above — the #2038
-    // `/* @client */` suppression twin's loop is client-only by construction.
-    'filter-nested-callback-predicate-client',
+    // Same as Hono / Mojo: `/* @client */` markers on TodoApp's keyed
+    // `.map` intentionally elide a slot id from the SSR template that
+    // the IR still declares (s6). See hono-adapter.test for the contract.
     'todo-app',
     // #1467 Phase 2e: same `/* @client */` keyed-map elision (data-table).
     'data-table',
@@ -169,6 +170,30 @@ function compileAndGenerate(source: string) {
 // =============================================================================
 // Xslate-Specific Tests
 // =============================================================================
+
+describe('XslateAdapter - clientOnly loop boundary markers (#872 / #1087 parity)', () => {
+  test('emits the loop boundary marker pair for a clientOnly loop', () => {
+    // A `/* @client */` loop renders no items at SSR time, but the
+    // `loop:`/`/loop:` boundary pair must still be emitted (as Hono and
+    // Go do) so the client runtime's mapArray() can locate its insertion
+    // anchor at hydration time.
+    const { template } = compileAndGenerate(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+export function List() {
+  const [items, setItems] = createSignal<string[]>([])
+  return <ul>{/* @client */ items().map(item => <li>{item}</li>)}</ul>
+}
+`)
+    expect(template).toMatch(
+      /\$bf\.comment\("loop:([\w-]+)"\) \| mark_raw :><: \$bf\.comment\("\/loop:\1"\) \| mark_raw :>/,
+    )
+    // No SSR item rows and no Kolon loop for a clientOnly map.
+    expect(template).not.toContain('<li')
+    expect(template).not.toContain(': for ')
+  })
+})
 
 describe('XslateAdapter - SSR context propagation (#1297)', () => {
   // `<Ctx.Provider value>` brackets its children with inline provide/revoke

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -568,8 +568,15 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
   // ===========================================================================
 
   renderLoop(loop: IRLoop): string {
-    // Client-only loops: skip SSR rendering entirely
-    if (loop.clientOnly) return ''
+    // clientOnly loops must not render items at SSR time, but must still emit
+    // the `loop:`/`/loop:` boundary marker pair (Hono and Go parity) so the
+    // client runtime's mapArray() can locate the insertion anchor when
+    // hydrating the array. Without the markers, mapArray() resolves
+    // anchor = null and appends after sibling markers (#872). The marker id
+    // disambiguates sibling `.map()` calls under the same parent (#1087).
+    if (loop.clientOnly) {
+      return `<: $bf.comment("loop:${loop.markerId}") | mark_raw :><: $bf.comment("/loop:${loop.markerId}") | mark_raw :>`
+    }
 
     // An array/object-destructure loop param (`([emoji, users]) => ...` or
     // `({ name, age }) => ...`) lowers to invalid Kolon — Kolon's `for LIST


### PR DESCRIPTION
## Summary

Knocks out the first actionable entry of the known-limitations catalog #1395: the Mojo adapter's *"`bf->comment(\"loop:\")` boundary markers not emitted for clientOnly loops"* entry (split out as #2066). The Xslate adapter turned out to share the exact same gap, so both are fixed together.

- `MojoAdapter.renderLoop` and `XslateAdapter.renderLoop` returned an empty string for a `/* @client */` (clientOnly) loop. Hono and Go both emit the `<!--bf-loop:<id>--><!--bf-/loop:<id>-->` boundary pair even for clientOnly loops; without it the client runtime's `mapArray()` resolves `anchor = null` and appends items after sibling markers (#872 defect class; per-call-site marker ids per #1087).
- Both `renderLoop` clientOnly early-returns now emit the boundary pair (Hono / Go parity).
- `client-only`, `client-only-loop-with-sibling-cond`, and `filter-nested-callback-predicate-client` are removed from both `skipMarkerConformance` sets, so marker conformance now enforces the contract for these fixtures.
- Positive template-output pins added to both adapter test suites for the clientOnly marker-pair shape.

Rendered-HTML conformance is unaffected: `normalizeHTML` strips loop boundary comments before comparison.

## Testing

- `bun test packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts` — 822 pass / 0 fail, including real-Perl render conformance (Mojolicious + Text::Xslate installed locally), the re-enabled marker-conformance fixtures, and the two new positive pins.

Fixes #2066. Refs #1395.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RK1RNMCWzncKFkJr4d8rt3

---
_Generated by [Claude Code](https://claude.ai/code/session_01RK1RNMCWzncKFkJr4d8rt3)_