### PR TITLE
test(#2066): enforce the loop boundary-pair contract cross-adapter via shared conformance

### DIFF
--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -611,28 +611,6 @@ export function List() {
     expect(result.template).toMatch(/bf->comment\("\/loop:[^"]+"\)/)
   })
 
-  test('emits the loop boundary marker pair for a clientOnly loop (#872 / #1087 parity)', () => {
-    // A `/* @client */` loop renders no items at SSR time, but the
-    // `loop:`/`/loop:` boundary pair must still be emitted (as Hono and
-    // Go do) so the client runtime's mapArray() can locate its insertion
-    // anchor at hydration time.
-    const result = compileAndGenerate(`
-"use client"
-import { createSignal } from "@barefootjs/client"
-
-export function List() {
-  const [items, setItems] = createSignal<string[]>([])
-  return <ul>{/* @client */ items().map(item => <li>{item}</li>)}</ul>
-}
-`)
-    expect(result.template).toMatch(
-      /bf->comment\("loop:([\w-]+)"\) %><%== bf->comment\("\/loop:\1"\)/,
-    )
-    // No SSR item rows and no Perl loop for a clientOnly map.
-    expect(result.template).not.toContain('<li')
-    expect(result.template).not.toContain('% for my')
-  })
-
   test('compares string signals with Perl `eq`, not numeric `==` (#1672)', () => {
     // `sel() === t.id` where `sel` is a string signal must lower to `eq`.
     // Perl numeric `==` coerces non-numeric strings to 0, so `"b" == "a"` is

--- a/packages/adapter-tests/fixtures/client-only-loop.ts
+++ b/packages/adapter-tests/fixtures/client-only-loop.ts
@@ -1,0 +1,32 @@
+import { createFixture } from '../src/types'
+
+// Minimal clientOnly-loop shape (#2066): a bare `/* @client */ items().map()`
+// with no filter chain or sibling nodes. SSR renders no items, but every
+// adapter must still emit the `loop:`/`/loop:` boundary marker pair so the
+// client runtime's mapArray() can locate its insertion anchor at hydration
+// time (#872; per-call-site marker ids per #1087). The pair contract itself
+// is enforced cross-adapter by the marker-conformance suite (start AND end
+// marker sets both match the IR's loop ids); this fixture exists so that
+// contract has a dedicated minimal shape not entangled with `client-only`'s
+// filter chain or `client-only-loop-with-sibling-cond`'s sibling markers.
+export const fixture = createFixture({
+  id: 'client-only-loop',
+  description: 'Client-only directive suppresses SSR for a bare loop, keeping boundary markers',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function ClientOnlyLoop() {
+  const [items, setItems] = createSignal<string[]>([])
+  return (
+    <ul>
+      {/* @client */ items().map(item => (
+        <li key={item}>{item}</li>
+      ))}
+    </ul>
+  )
+}
+`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s1"></ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -126,6 +126,7 @@ import { fixture as fragment } from './fragment'
 import { fixture as fragmentConditional } from './fragment-conditional'
 import { fixture as loopItemConditional } from './loop-item-conditional'
 import { fixture as clientOnly } from './client-only'
+import { fixture as clientOnlyLoop } from './client-only-loop'
 import { fixture as clientOnlyLoopWithSiblingCond } from './client-only-loop-with-sibling-cond'
 import { fixture as eventHandlers } from './event-handlers'
 import { fixture as defaultProps } from './default-props'
@@ -346,6 +347,7 @@ export const jsxFixtures: JSXFixture[] = [
   fragmentConditional,
   loopItemConditional,
   clientOnly,
+  clientOnlyLoop,
   clientOnlyLoopWithSiblingCond,
   eventHandlers,
   defaultProps,

--- a/packages/adapter-tests/src/marker-conformance.ts
+++ b/packages/adapter-tests/src/marker-conformance.ts
@@ -60,10 +60,20 @@ export interface MarkerIdSets {
   slots: Set<string>
   conds: Set<string>
   loops: Set<string>
+  /**
+   * Loop END markers (`/loop:<id>`), collected separately from the start
+   * markers so the suite can assert the boundary PAIR: the client runtime's
+   * mapArray() needs both markers to bracket its insertion range, so a
+   * start marker without its end (or vice versa) is a hydration break even
+   * though the id "appears" in the template. clientOnly loops emit the
+   * pair with no items between (#2066); the IR side has a single loop-id
+   * set, which both template-side sets must match.
+   */
+  loopEnds: Set<string>
 }
 
 function emptySets(): MarkerIdSets {
-  return { slots: new Set(), conds: new Set(), loops: new Set() }
+  return { slots: new Set(), conds: new Set(), loops: new Set(), loopEnds: new Set() }
 }
 
 /**
@@ -181,7 +191,9 @@ export function extractIRMarkerIds(ir: ComponentIR): MarkerIdSets {
  *   - cond: `bf-c="<id>"` attribute OR `cond-start:<id>` substring
  *     inside a comment marker.
  *   - loop: `loop:<id>` substring (NOT preceded by `/`, which would
- *     match the end-marker form).
+ *     match the end-marker form). The end-marker form (`/loop:<id>`) is
+ *     collected into `loopEnds` so the pair contract is asserted, not
+ *     just id presence.
  */
 export function extractTemplateMarkerIds(template: string): MarkerIdSets {
   const out = emptySets()
@@ -192,6 +204,7 @@ export function extractTemplateMarkerIds(template: string): MarkerIdSets {
   for (const m of template.matchAll(/\bbf-c="([\w-]+)"/g)) out.conds.add(m[1])
   for (const m of template.matchAll(/cond-start:([\w-]+)/g)) out.conds.add(m[1])
   for (const m of template.matchAll(/(?:^|[^/])loop:([\w-]+)/g)) out.loops.add(m[1])
+  for (const m of template.matchAll(/\/loop:([\w-]+)/g)) out.loopEnds.add(m[1])
   return out
 }
 
@@ -259,6 +272,10 @@ export function runMarkerConformance(opts: RunMarkerConformanceOptions): void {
         expect([...actual.slots].sort()).toEqual([...expected.slots].sort())
         expect([...actual.conds].sort()).toEqual([...expected.conds].sort())
         expect([...actual.loops].sort()).toEqual([...expected.loops].sort())
+        // Boundary-pair contract: every loop id must ALSO close with its
+        // `/loop:<id>` end marker. The IR carries one loop-id set; the
+        // template's start and end sets must both match it (#2066).
+        expect([...actual.loopEnds].sort()).toEqual([...expected.loops].sort())
       })
     }
   })

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -171,30 +171,6 @@ function compileAndGenerate(source: string) {
 // Xslate-Specific Tests
 // =============================================================================
 
-describe('XslateAdapter - clientOnly loop boundary markers (#872 / #1087 parity)', () => {
-  test('emits the loop boundary marker pair for a clientOnly loop', () => {
-    // A `/* @client */` loop renders no items at SSR time, but the
-    // `loop:`/`/loop:` boundary pair must still be emitted (as Hono and
-    // Go do) so the client runtime's mapArray() can locate its insertion
-    // anchor at hydration time.
-    const { template } = compileAndGenerate(`
-"use client"
-import { createSignal } from "@barefootjs/client"
-
-export function List() {
-  const [items, setItems] = createSignal<string[]>([])
-  return <ul>{/* @client */ items().map(item => <li>{item}</li>)}</ul>
-}
-`)
-    expect(template).toMatch(
-      /\$bf\.comment\("loop:([\w-]+)"\) \| mark_raw :><: \$bf\.comment\("\/loop:\1"\) \| mark_raw :>/,
-    )
-    // No SSR item rows and no Kolon loop for a clientOnly map.
-    expect(template).not.toContain('<li')
-    expect(template).not.toContain(': for ')
-  })
-})
-
 describe('XslateAdapter - SSR context propagation (#1297)', () => {
   // `<Ctx.Provider value>` brackets its children with inline provide/revoke
   // calls (both return '' so the `<: … :>` discards them); descendant


### PR DESCRIPTION
## Summary

Follow-up to #2067 (merged): restructures the clientOnly-loop marker verification from per-adapter unit pins into fixture-driven cross-adapter conformance, so every adapter — Hono, Go, Mojo, Xslate, and any future one — is checked for the same contract by the same suite.

- **New shared fixture `client-only-loop`** — the minimal bare `/* @client */ items().map()` shape, deliberately not entangled with `client-only`'s filter chain or `client-only-loop-with-sibling-cond`'s sibling markers. It runs through render conformance, marker conformance, and CSR conformance on all adapters automatically.
- **Marker conformance now asserts the boundary PAIR** — `extractTemplateMarkerIds` collects loop end markers (`/loop:<id>`) into a separate `loopEnds` set, and the suite asserts both the start and end sets match the IR's loop-id set. Previously only start-marker presence was checked; a start without its closing end marker (or vice versa) is a hydration break for `mapArray()` that id-presence alone missed.
- **Removed the bespoke Mojo / Xslate template-regex pins** added in #2067 — superseded by the shared layer, which covers the identical contract uniformly (and also now covers Hono and Go, which previously had no pair-shape check at all).

## Testing

- `bun test packages/adapter-mojolicious packages/adapter-xslate packages/adapter-go-template packages/adapter-tests packages/adapter-hono` — 2288 + 421 pass; the only failures (14 Hono context-bridge / search-params, 9 carousel cross-adapter) reproduce identically on a clean `main` checkout in this environment (module-resolution / env issues, unrelated to this diff).
- The new `client-only-loop` fixture passes render + marker + CSR conformance on all adapters; the strengthened `loopEnds` assertion passes for every fixture on every adapter.

No changeset: touches only `@barefootjs/adapter-tests` (private, changeset-ignored) and adapter `__tests__` files.

Refs #1395.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RK1RNMCWzncKFkJr4d8rt3

---
_Generated by [Claude Code](https://claude.ai/code/session_01RK1RNMCWzncKFkJr4d8rt3)_