### PR TITLE
fix(integrations): flask/fastapi containers must listen on the probed port 8080

### DIFF
--- a/integrations/fastapi/Dockerfile
+++ b/integrations/fastapi/Dockerfile
@@ -18,6 +18,9 @@ COPY dist ./dist
 
 ENV BASE_PATH=/integrations/fastapi
 ENV FASTAPI_ENV=production
+# The Cloudflare Container worker probes defaultPort 8080 (container.ts);
+# without this the app falls back to its dev port 3009 and never comes up.
+ENV PORT=8080
 EXPOSE 8080
 USER app
 CMD ["python3", "app.py"]

--- a/integrations/flask/Dockerfile
+++ b/integrations/flask/Dockerfile
@@ -18,6 +18,9 @@ COPY dist ./dist
 
 ENV BASE_PATH=/integrations/flask
 ENV FLASK_ENV=production
+# The Cloudflare Container worker probes defaultPort 8080 (container.ts);
+# without this the app falls back to its dev port 3008 and never comes up.
+ENV PORT=8080
 EXPOSE 8080
 USER app
 CMD ["python3", "app.py"]


### PR DESCRIPTION
## Summary

Fixes the production deploy failure on https://barefootjs.dev/integrations/flask:

> Failed to start container: The container is not listening in the TCP address 10.0.0.1:8080

The flask/fastapi production Dockerfiles `EXPOSE 8080` and the Cloudflare Container shim (`container.ts`) probes `defaultPort = 8080`, but `CMD ["python3", "app.py"]` started the app without a `PORT`, so it fell back to its dev port (3008 / 3009) and the container never came up on the probed address. This adds `ENV PORT=8080` to both Dockerfiles — the Python analogue of the xslate image's explicit `starman --listen :8080`.

## Test plan

- [x] Local reproduction of the container environment for both apps (`FLASK_ENV=production PORT=8080` / `FASTAPI_ENV=production PORT=8080` with `PYTHONPATH=./lib`): `curl http://localhost:8080/integrations/{flask,fastapi}/counter` → 200 for both.
- [ ] Re-deploy via the `deploy-integrations-{flask,fastapi}` jobs and confirm https://barefootjs.dev/integrations/flask and /integrations/fastapi come up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgRnbzmQeeCi1itXMyv1Gn

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgRnbzmQeeCi1itXMyv1Gn)_