### PR TITLE
Align Flask/FastAPI home pages, add missing adapters to /integrations index

### DIFF
--- a/integrations/fastapi/app.py
+++ b/integrations/fastapi/app.py
@@ -747,10 +747,6 @@ under a plain FastAPI app.</p>
 <ul>
     <li><a href="{BASE}/counter">Counter</a></li>
     <li><a href="{BASE}/toggle">Toggle</a></li>
-    <li><a href="{BASE}/form">Form</a></li>
-    <li><a href="{BASE}/reactive-props">Reactive Props</a></li>
-    <li><a href="{BASE}/conditional-return">Conditional Return</a></li>
-    <li><a href="{BASE}/portal">Portal</a></li>
     <li><a href="{BASE}/todos">Todo (@client)</a></li>
     <li><a href="{BASE}/todos-ssr">Todo (no @client markers)</a></li>
     <li><a href="{BASE}/ai-chat">AI Chat (SSE Streaming)</a></li>

--- a/integrations/flask/app.py
+++ b/integrations/flask/app.py
@@ -742,10 +742,6 @@ under a plain Flask app.</p>
 <ul>
     <li><a href="{BASE}/counter">Counter</a></li>
     <li><a href="{BASE}/toggle">Toggle</a></li>
-    <li><a href="{BASE}/form">Form</a></li>
-    <li><a href="{BASE}/reactive-props">Reactive Props</a></li>
-    <li><a href="{BASE}/conditional-return">Conditional Return</a></li>
-    <li><a href="{BASE}/portal">Portal</a></li>
     <li><a href="{BASE}/todos">Todo (@client)</a></li>
     <li><a href="{BASE}/todos-ssr">Todo (no @client markers)</a></li>
     <li><a href="{BASE}/ai-chat">AI Chat (SSE Streaming)</a></li>

--- a/site/core/integrations/routes.tsx
+++ b/site/core/integrations/routes.tsx
@@ -26,6 +26,10 @@ const ADAPTERS: Adapter[] = [
   { slug: 'gin',         name: 'Gin',         language: 'Go' },
   { slug: 'chi',         name: 'Chi',         language: 'Go' },
   { slug: 'nethttp',     name: 'net/http',    language: 'Go' },
+  { slug: 'flask',       name: 'Flask',       language: 'Python' },
+  { slug: 'fastapi',     name: 'FastAPI',     language: 'Python' },
+  { slug: 'sinatra',     name: 'Sinatra',     language: 'Ruby' },
+  { slug: 'rails',       name: 'Rails',       language: 'Ruby' },
   { slug: 'mojolicious', name: 'Mojolicious', language: 'Perl' },
   { slug: 'xslate',      name: 'Text::Xslate', language: 'Perl' },
 ]
@@ -56,7 +60,7 @@ export function createIntegrationsApp() {
     c.render(<IntegrationsIndex />, {
       title: 'Integrations — Barefoot.js',
       description:
-        'Same JSX components running on Hono, h3 and Elysia (TypeScript), Echo, Gin, Chi and net/http (Go), and Mojolicious and Text::Xslate (Perl).',
+        'Same JSX components running on Hono, h3 and Elysia (TypeScript), Echo, Gin, Chi and net/http (Go), Flask and FastAPI (Python), Sinatra and Rails (Ruby), and Mojolicious and Text::Xslate (Perl).',
     }),
   )
 


### PR DESCRIPTION
## Summary
- Flask's and FastAPI's home page nav listed demo links (Form, Reactive Props, Conditional Return, Portal) that aren't user-facing — the Hono integration's home page doesn't show them. Removed them so all three lists match. The underlying routes are untouched (still used by e2e specs).
- The top-level `/integrations` catalog (`site/core/integrations/routes.tsx`) was missing Flask, FastAPI, Sinatra, and Rails — added all four cards and updated the page description to mention Python and Ruby.

## Test plan
- [ ] Visually check `/integrations/flask` and `/integrations/fastapi` home pages match `/integrations/hono`'s nav list
- [ ] Visually check `/integrations` lists Flask, FastAPI, Sinatra, and Rails

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014gj4oSQQbYs96wKyfthTJB)_