### PR TITLE
fix(integrations/axum): accept trailing-slash URLs via path normalization

### DIFF
--- a/integrations/axum/Cargo.lock
+++ b/integrations/axum/Cargo.lock
@@ -103,6 +103,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tower",
  "tower-http",
 ]
 

--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -19,7 +19,14 @@ minijinja = { version = "2", features = ["loader"] }
 
 axum = "0.8"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs", "time", "signal"] }
-tower-http = { version = "0.6", features = ["fs"] }
+# `normalize-path` trims trailing slashes BEFORE routing so
+# `/integrations/axum/` and `/integrations/axum/counter/` resolve to the
+# same handlers as their bare forms — axum's `nest` does not normalize
+# these itself (flask/gin accept both spellings, and the deployed proxy
+# surfaces both). `tower` is needed directly for the `Layer` trait to
+# apply it around the whole `Router`.
+tower = "0.5"
+tower-http = { version = "0.6", features = ["fs", "normalize-path"] }
 # Small, single-purpose: turns an `async fn` body with `yield` into a
 # `futures_core::Stream` -- used for the char-by-char AI chat SSE endpoint
 # (`tokio::time::sleep` between yields keeps the runtime unblocked, per the

--- a/integrations/axum/src/main.rs
+++ b/integrations/axum/src/main.rs
@@ -13,11 +13,11 @@ mod render;
 mod session;
 mod todo;
 
-use axum::extract::State;
+use axum::extract::{Request, State};
 use axum::http::{header, StatusCode};
 use axum::response::{IntoResponse, Redirect, Response};
 use axum::routing::get;
-use axum::Router;
+use axum::{Router, ServiceExt};
 use barefootjs::backend_minijinja;
 use barefootjs::JsValue;
 use minijinja::Environment;
@@ -75,12 +75,23 @@ async fn main() {
         sessions: Arc::new(session::SessionStore::new()),
     };
 
-    let app = build_router(state.clone(), &base);
+    // Trim trailing slashes BEFORE routing (`/integrations/axum/` →
+    // `/integrations/axum`): axum's `nest` matches only the bare prefix, so
+    // without this the slash spelling 404s in production while flask/gin
+    // accept both. The layer must wrap the finished `Router` (path rewriting
+    // has to happen before route matching), hence `ServiceExt::into_make_service`
+    // instead of serving the `Router` directly.
+    let app = tower::Layer::layer(
+        &tower_http::normalize_path::NormalizePathLayer::trim_trailing_slash(),
+        build_router(state.clone(), &base),
+    );
 
     let port: u16 = std::env::var("PORT").ok().and_then(|p| p.parse().ok()).unwrap_or(8080);
     let listener = tokio::net::TcpListener::bind(("0.0.0.0", port)).await.expect("bind failed");
     println!("barefoot: axum example listening on 0.0.0.0:{port} (base {base})");
-    axum::serve(listener, app).await.expect("server error");
+    axum::serve(listener, ServiceExt::<Request>::into_make_service(app))
+        .await
+        .expect("server error");
 }
 
 fn build_router(state: AppState, base: &str) -> Router {


### PR DESCRIPTION
## Summary

`https://barefootjs.dev/integrations/axum/` (trailing slash) returned 404 in production — as did every other trailing-slash spelling like `/integrations/axum/counter/` — while the bare forms were fine. The `deploy-integrations-axum` job itself succeeded; the gap is that axum's `Router::nest` matches only the bare prefix and does not normalize trailing slashes, unlike flask/gin which accept both spellings.

Fix (uniform, not per-route): wrap the finished router in tower-http's `NormalizePathLayer::trim_trailing_slash()` so the path rewrite happens **before** route matching, served via `ServiceExt::into_make_service` (the documented axum 0.8 pattern). Adds the `normalize-path` feature to the existing tower-http dependency and a direct `tower` dependency for the `Layer` trait.

## Verification

- Locally, bare and slash variants of `/integrations/axum`, `/counter`, `/blog`, `/todos` all return 200; static assets (`/styles/tokens.css`) unaffected.
- `cargo build` + `cargo clippy --all-targets -- -D warnings` clean.
- Shared e2e suite: **103/103 passing** (no regression).
- Production probes after this deploys should show 200 for `https://barefootjs.dev/integrations/axum/` (previously 404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKpQnQur4MFptq3w2wwbrq

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKpQnQur4MFptq3w2wwbrq)_