### PR TITLE
fix: axum blog SSR props, shared blog-ssr e2e guard, bf-p truncation in 4 runtimes

### DIFF
--- a/.changeset/props-attr-escape.md
+++ b/.changeset/props-attr-escape.md
@@ -1,0 +1,8 @@
+---
+'@barefootjs/perl': patch
+'@barefootjs/jinja': patch
+'@barefootjs/erb': patch
+'@barefootjs/rust': patch
+---
+
+Fix `props_attr` truncating the `bf-p` hydration payload: the encoded props JSON is embedded in a single-quoted attribute, so a raw `'` inside any string value (e.g. a blog paragraph) terminated the attribute early and the client hydrated from broken JSON (island text bound to props rendered empty). The JSON is now attribute-escaped with each runtime's existing HTML escape (`&#34;`/`&#39;`, matching the Go and JS adapters' behavior); the browser entity-decodes the attribute, so the client's `JSON.parse` sees the original text. Same fix applied to the Perl, Python, Ruby, and Rust runtimes, each with a new `props_attr` round-trip test.

--- a/integrations/axum/e2e/blog-ssr.spec.ts
+++ b/integrations/axum/e2e/blog-ssr.spec.ts
@@ -1,0 +1,3 @@
+import { blogSsrTests } from '../../shared/e2e/blog-ssr.spec'
+
+blogSsrTests('http://localhost:3012/integrations/axum/blog')

--- a/integrations/axum/e2e/blog.spec.ts
+++ b/integrations/axum/e2e/blog.spec.ts
@@ -16,6 +16,22 @@ const mark = (page: Page, sel: string) =>
 const marker = (page: Page, sel: string) =>
   page.$eval(sel, (el) => (el as unknown as { __mark?: string }).__mark).catch(() => null)
 
+// Direct-load SSR guard (adapter-local addition): a post page fetched by URL
+// must carry the article content in the SERVER-rendered HTML — title, date,
+// pager position, and body are static props, so hydration never fills them
+// in after the fact. This pins the flask-`blog_island` var-merge semantics
+// (`{**seed, **props, **extra}`) in `render.rs::render_island`; without the
+// props merge the article SSRs empty and every other test here still passes.
+test('ssr: direct-loading a post page renders the full article server-side', async ({ page }) => {
+  const res = await page.goto(`${BLOG}/posts/disposal-is-the-hard-part`, { waitUntil: 'commit' })
+  const html = (await res?.text()) ?? ''
+  expect(html).toContain('Disposal is the hard part')
+  expect(html).toContain('2026-06-10')
+  expect(html).toContain('data-slug="disposal-is-the-hard-part"')
+  expect(html).toContain('Swapping HTML in is easy.')
+  await expect(page.locator('.post h1')).toHaveText('Disposal is the hard part')
+})
+
 test('v0.5: sort/tag is a query-only update with no region swap', async ({ page }) => {
   await page.goto(BLOG, { waitUntil: 'networkidle' })
   await expect(page.locator('.sortable-list li')).toHaveCount(10)

--- a/integrations/axum/e2e/blog.spec.ts
+++ b/integrations/axum/e2e/blog.spec.ts
@@ -16,21 +16,11 @@ const mark = (page: Page, sel: string) =>
 const marker = (page: Page, sel: string) =>
   page.$eval(sel, (el) => (el as unknown as { __mark?: string }).__mark).catch(() => null)
 
-// Direct-load SSR guard (adapter-local addition): a post page fetched by URL
-// must carry the article content in the SERVER-rendered HTML — title, date,
-// pager position, and body are static props, so hydration never fills them
-// in after the fact. This pins the flask-`blog_island` var-merge semantics
-// (`{**seed, **props, **extra}`) in `render.rs::render_island`; without the
-// props merge the article SSRs empty and every other test here still passes.
-test('ssr: direct-loading a post page renders the full article server-side', async ({ page }) => {
-  const res = await page.goto(`${BLOG}/posts/disposal-is-the-hard-part`, { waitUntil: 'commit' })
-  const html = (await res?.text()) ?? ''
-  expect(html).toContain('Disposal is the hard part')
-  expect(html).toContain('2026-06-10')
-  expect(html).toContain('data-slug="disposal-is-the-hard-part"')
-  expect(html).toContain('Swapping HTML in is easy.')
-  await expect(page.locator('.post h1')).toHaveText('Disposal is the hard part')
-})
+// Direct-load SSR is guarded by the SHARED suite (e2e/blog-ssr.spec.ts →
+// integrations/shared/e2e/blog-ssr.spec.ts): it pins the flask-`blog_island`
+// var-merge semantics (`{**seed, **props, **extra}`) in
+// `render.rs::render_island` — without the props merge the article SSRs
+// empty while every region test below still passes.
 
 test('v0.5: sort/tag is a query-only update with no region swap', async ({ page }) => {
   await page.goto(BLOG, { waitUntil: 'networkidle' })

--- a/integrations/axum/src/render.rs
+++ b/integrations/axum/src/render.rs
@@ -159,6 +159,22 @@ pub fn render_component(
     props: JsValue,
     stash: JsValue,
 ) -> Result<(String, String), String> {
+    let defaults = ssr_defaults_for(&state.manifest, component);
+    let mut vars = barefootjs::derive_stash_from_defaults(&defaults, &props);
+    merge_into(&mut vars, &stash);
+    render_root(state, session, component, &props, &vars)
+}
+
+/// Shared tail of [`render_component`] / [`render_island`]: mint a root
+/// scope id, attach `props` as the `bf-p` hydration payload (when
+/// non-empty), and render `component` with the caller-assembled `vars`.
+fn render_root(
+    state: &AppState,
+    session: &Arc<RenderSession>,
+    component: &str,
+    props: &JsValue,
+    vars: &JsValue,
+) -> Result<(String, String), String> {
     let scope_id = format!("{component}_{}", session.next_rand_hex6());
     let mut root = BfInstance::root(Arc::clone(session), scope_id);
     if let Some(m) = props.as_object() {
@@ -167,11 +183,7 @@ pub fn render_component(
         }
     }
 
-    let defaults = ssr_defaults_for(&state.manifest, component);
-    let mut vars = barefootjs::derive_stash_from_defaults(&defaults, &props);
-    merge_into(&mut vars, &stash);
-
-    let body = with_env(state, |env| backend_minijinja::render_named(env, component, root.as_mj_value(), &vars))
+    let body = with_env(state, |env| backend_minijinja::render_named(env, component, root.as_mj_value(), vars))
         .map_err(|e| format!("{e:#}"))?;
     let scripts = root.scripts();
     Ok((body, scripts))
@@ -233,7 +245,17 @@ pub fn render_island(
     props: JsValue,
     extra: JsValue,
 ) -> Result<String, String> {
-    let (body, _scripts) = render_component(state, session, component, props, extra)?;
+    // flask's `blog_island` renders with `{**seed, **props, **extra}`: the
+    // caller's client props are ALSO template vars, wholesale — not just
+    // where an ssrDefaults entry's `propName` picks them up. PostArticle
+    // depends on this (its `title`/`date`/`body`/… props have no static
+    // defaults, so `derive_stash_from_defaults` alone drops them and the
+    // article SSRs empty; hydration never fills static text back in).
+    let defaults = ssr_defaults_for(&state.manifest, component);
+    let mut vars = barefootjs::derive_stash_from_defaults(&defaults, &props);
+    merge_into(&mut vars, &props);
+    merge_into(&mut vars, &extra);
+    let (body, _scripts) = render_root(state, session, component, &props, &vars)?;
     Ok(body)
 }
 

--- a/integrations/chi/e2e/blog-ssr.spec.ts
+++ b/integrations/chi/e2e/blog-ssr.spec.ts
@@ -1,0 +1,3 @@
+import { blogSsrTests } from '../../shared/e2e/blog-ssr.spec'
+
+blogSsrTests('http://localhost:8082/integrations/chi/blog')

--- a/integrations/echo/e2e/blog-ssr.spec.ts
+++ b/integrations/echo/e2e/blog-ssr.spec.ts
@@ -1,0 +1,3 @@
+import { blogSsrTests } from '../../shared/e2e/blog-ssr.spec'
+
+blogSsrTests('http://localhost:8080/integrations/echo/blog')

--- a/integrations/elysia/e2e/blog-ssr.spec.ts
+++ b/integrations/elysia/e2e/blog-ssr.spec.ts
@@ -1,0 +1,3 @@
+import { blogSsrTests } from '../../shared/e2e/blog-ssr.spec'
+
+blogSsrTests('http://localhost:3005/integrations/elysia/blog')

--- a/integrations/fastapi/e2e/blog-ssr.spec.ts
+++ b/integrations/fastapi/e2e/blog-ssr.spec.ts
@@ -1,0 +1,3 @@
+import { blogSsrTests } from '../../shared/e2e/blog-ssr.spec'
+
+blogSsrTests('http://localhost:3009/integrations/fastapi/blog')

--- a/integrations/flask/e2e/blog-ssr.spec.ts
+++ b/integrations/flask/e2e/blog-ssr.spec.ts
@@ -1,0 +1,3 @@
+import { blogSsrTests } from '../../shared/e2e/blog-ssr.spec'
+
+blogSsrTests('http://localhost:3008/integrations/flask/blog')

--- a/integrations/gin/e2e/blog-ssr.spec.ts
+++ b/integrations/gin/e2e/blog-ssr.spec.ts
@@ -1,0 +1,3 @@
+import { blogSsrTests } from '../../shared/e2e/blog-ssr.spec'
+
+blogSsrTests('http://localhost:8081/integrations/gin/blog')

--- a/integrations/h3/e2e/blog-ssr.spec.ts
+++ b/integrations/h3/e2e/blog-ssr.spec.ts
@@ -1,0 +1,3 @@
+import { blogSsrTests } from '../../shared/e2e/blog-ssr.spec'
+
+blogSsrTests('http://localhost:3003/integrations/h3/blog')

--- a/integrations/hono/e2e/blog-ssr.spec.ts
+++ b/integrations/hono/e2e/blog-ssr.spec.ts
@@ -1,0 +1,3 @@
+import { blogSsrTests } from '../../shared/e2e/blog-ssr.spec'
+
+blogSsrTests('http://localhost:3001/integrations/hono/blog')

--- a/integrations/mojolicious/e2e/blog-ssr.spec.ts
+++ b/integrations/mojolicious/e2e/blog-ssr.spec.ts
@@ -1,0 +1,3 @@
+import { blogSsrTests } from '../../shared/e2e/blog-ssr.spec'
+
+blogSsrTests('http://localhost:3004/integrations/mojolicious/blog')

--- a/integrations/nethttp/e2e/blog-ssr.spec.ts
+++ b/integrations/nethttp/e2e/blog-ssr.spec.ts
@@ -1,0 +1,3 @@
+import { blogSsrTests } from '../../shared/e2e/blog-ssr.spec'
+
+blogSsrTests('http://localhost:8083/integrations/nethttp/blog')

--- a/integrations/rails/e2e/blog-ssr.spec.ts
+++ b/integrations/rails/e2e/blog-ssr.spec.ts
@@ -1,0 +1,3 @@
+import { blogSsrTests } from '../../shared/e2e/blog-ssr.spec'
+
+blogSsrTests('http://localhost:3011/integrations/rails/blog')

--- a/integrations/shared/e2e/blog-ssr.spec.ts
+++ b/integrations/shared/e2e/blog-ssr.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared blog SSR (direct-load) E2E test.
+ *
+ * Guards the class of bug where a post page's article props (title, date,
+ * body, slug, pager titles) reach the client hydration payload (`bf-p`) but
+ * never make it into the SERVER-rendered HTML — these are static props, so
+ * hydration never fills them in and the page stays visibly empty. The other
+ * shared suites (and the adapter-local `blog.spec.ts` region tests) all
+ * assert post-hydration/navigation behavior, so they pass against an
+ * empty-SSR page; only a direct fetch of the raw HTML catches it. First
+ * seen on axum, whose `render_island` originally dropped props with no
+ * `ssrDefaults` entry.
+ *
+ * Expected values derive from the shared corpus (`../blog/posts`), so the
+ * test tracks content edits. Assertions avoid markup- and escaping-
+ * sensitive fragments: each string is cut before the first character an
+ * adapter may entity-escape differently (`' " & < >`).
+ */
+
+import { test, expect } from '@playwright/test'
+import { posts } from '../blog/posts'
+
+/** Longest prefix free of cross-adapter escaping differences. */
+function safeFragment(s: string): string {
+  return s.split(/['"&<>]/)[0].trim().slice(0, 60).trim()
+}
+
+/**
+ * Run the blog direct-load SSR test.
+ *
+ * @param blogUrl - The blog mount point (e.g. 'http://localhost:3008/integrations/flask/blog')
+ */
+export function blogSsrTests(blogUrl: string) {
+  // Any post would do; pin one mid-list so BOTH pager links (prev + next)
+  // exist and their titles assert the props actually flowed.
+  const slug = 'disposal-is-the-hard-part'
+
+  // Mirror the route handlers: the pager walks the list newest-first.
+  const sorted = [...posts].sort((a, b) => b.date.localeCompare(a.date))
+  const idx = sorted.findIndex((p) => p.slug === slug)
+  const post = sorted[idx]
+  const prev = sorted[idx - 1]
+  const next = sorted[idx + 1]
+
+  test.describe('Blog SSR (direct load)', () => {
+    test('a post page carries the full article in the server-rendered HTML', async ({ page }) => {
+      const res = await page.goto(`${blogUrl}/posts/${slug}`, { waitUntil: 'commit' })
+      expect(res?.status()).toBe(200)
+      // Assert on the raw response body — the pre-hydration server output —
+      // not the live DOM, which client JS may have already touched.
+      const html = (await res?.text()) ?? ''
+      expect(html).toContain(safeFragment(post.title))
+      expect(html).toContain(post.date)
+      expect(html).toContain(`data-slug="${slug}"`)
+      for (const para of post.body) {
+        const fragment = safeFragment(para)
+        if (fragment.length > 10) expect(html).toContain(fragment)
+      }
+      expect(html).toContain(safeFragment(prev.title))
+      expect(html).toContain(safeFragment(next.title))
+      // And the visible article heading (shared PostArticle markup).
+      await expect(page.locator('.post h1')).toHaveText(post.title)
+    })
+  })
+}

--- a/integrations/sinatra/e2e/blog-ssr.spec.ts
+++ b/integrations/sinatra/e2e/blog-ssr.spec.ts
@@ -1,0 +1,3 @@
+import { blogSsrTests } from '../../shared/e2e/blog-ssr.spec'
+
+blogSsrTests('http://localhost:3010/integrations/sinatra/blog')

--- a/integrations/xslate/e2e/blog-ssr.spec.ts
+++ b/integrations/xslate/e2e/blog-ssr.spec.ts
@@ -1,0 +1,3 @@
+import { blogSsrTests } from '../../shared/e2e/blog-ssr.spec'
+
+blogSsrTests('http://localhost:3007/integrations/xslate/blog')

--- a/packages/adapter-erb/lib/barefoot_js.rb
+++ b/packages/adapter-erb/lib/barefoot_js.rb
@@ -110,7 +110,11 @@ module BarefootJS
       props = _props
       return '' unless props && !props.empty?
 
-      json = backend.encode_json(props)
+      # The JSON must be attribute-escaped: a raw `'` inside a string value
+      # (e.g. a blog paragraph) terminates the single-quoted attribute and
+      # truncates the hydration payload. The browser entity-decodes the
+      # attribute value, so the client's JSON.parse sees the original text.
+      json = html_escape(backend.encode_json(props))
       %( bf-p='#{json}')
     end
 

--- a/packages/adapter-erb/test/props_attr_test.rb
+++ b/packages/adapter-erb/test/props_attr_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'json'
+require 'barefoot_js'
+
+# props_attr -- the `bf-p` hydration-payload attribute. The encoded JSON is
+# embedded in a SINGLE-quoted attribute, so it must be attribute-escaped: a
+# raw `'` inside a string value (e.g. a blog paragraph) terminates the
+# attribute early and the client hydrates from truncated JSON (empty island
+# text; found via the shared blog-ssr e2e). Same fix across the Perl,
+# Python, Ruby, and Rust runtimes -- keep the four tests in sync.
+class PropsAttrStubBackend
+  def encode_json(value)
+    JSON.generate(value)
+  end
+end
+
+class PropsAttrTest < Minitest::Test
+  def bf_with(props)
+    bf = BarefootJS::Context.new(PropsAttrStubBackend.new)
+    bf._props(props)
+    bf
+  end
+
+  def test_empty_props_emit_nothing
+    assert_equal '', BarefootJS::Context.new(PropsAttrStubBackend.new).props_attr
+    assert_equal '', bf_with({}).props_attr
+  end
+
+  def test_json_is_attribute_escaped
+    attr = bf_with({ 'note' => "it's <b> & co" }).props_attr
+    assert_equal " bf-p='{&#34;note&#34;:&#34;it&#39;s &lt;b&gt; &amp; co&#34;}'", attr
+  end
+
+  def test_attribute_round_trips_through_entity_decoding
+    attr = bf_with({ 'note' => "it's <b> & co" }).props_attr
+    value = attr[%r{bf-p='([^']*)'}, 1]
+    decoded = value.gsub('&#34;', '"').gsub('&#39;', "'").gsub('&lt;', '<').gsub('&gt;', '>').gsub('&amp;', '&')
+    assert_equal({ 'note' => "it's <b> & co" }, JSON.parse(decoded))
+  end
+end

--- a/packages/adapter-jinja/python/barefootjs/runtime.py
+++ b/packages/adapter-jinja/python/barefootjs/runtime.py
@@ -506,7 +506,11 @@ class BarefootJS:
         props = self._props()
         if not props:
             return ""
-        j = self.backend.encode_json(props)
+        # The JSON must be attribute-escaped: a raw `'` inside a string value
+        # (e.g. a blog paragraph) terminates the single-quoted attribute and
+        # truncates the hydration payload. The browser entity-decodes the
+        # attribute value, so the client's JSON.parse sees the original text.
+        j = _html_escape(self.backend.encode_json(props))
         return f" bf-p='{j}'"
 
     # -----------------------------------------------------------------

--- a/packages/adapter-jinja/python/tests/test_props_attr.py
+++ b/packages/adapter-jinja/python/tests/test_props_attr.py
@@ -1,0 +1,54 @@
+"""`BarefootJS.props_attr` -- the `bf-p` hydration-payload attribute.
+
+The encoded JSON is embedded in a SINGLE-quoted attribute, so it must be
+attribute-escaped: a raw `'` inside a string value (e.g. a blog paragraph)
+terminates the attribute early and the client hydrates from truncated JSON
+(empty island text; found via the shared blog-ssr e2e). Same fix across the
+Perl, Python, Ruby, and Rust runtimes -- keep the four tests in sync.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import unittest
+
+from barefootjs import BarefootJS
+
+
+class _PureBackend:
+    def encode_json(self, value):
+        return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def bf_with(props):
+    bf = BarefootJS(None, {"backend": _PureBackend()})
+    if props is not None:
+        bf._props(props)
+    return bf
+
+
+class PropsAttrTest(unittest.TestCase):
+    def test_empty_props_emit_nothing(self):
+        self.assertEqual(bf_with(None).props_attr(), "")
+        self.assertEqual(bf_with({}).props_attr(), "")
+
+    def test_json_is_attribute_escaped(self):
+        attr = bf_with({"note": "it's <b> & co"}).props_attr()
+        self.assertEqual(attr, " bf-p='{&#34;note&#34;:&#34;it&#39;s &lt;b&gt; &amp; co&#34;}'")
+
+    def test_attribute_round_trips_through_entity_decoding(self):
+        attr = bf_with({"note": "it's <b> & co"}).props_attr()
+        value = re.search(r"bf-p='([^']*)'", attr).group(1)
+        decoded = (
+            value.replace("&#34;", '"')
+            .replace("&#39;", "'")
+            .replace("&lt;", "<")
+            .replace("&gt;", ">")
+            .replace("&amp;", "&")
+        )
+        self.assertEqual(json.loads(decoded), {"note": "it's <b> & co"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/adapter-perl/lib/BarefootJS.pm
+++ b/packages/adapter-perl/lib/BarefootJS.pm
@@ -168,7 +168,11 @@ sub props_attr ($self) {
     return '' unless $props && %$props;
     # encode_json returns a character string (not bytes) for safe embedding
     # in templates (the Mojo backend uses Mojo::JSON::to_json).
-    my $json = $self->backend->encode_json($props);
+    # The JSON must then be attribute-escaped: a raw `'` inside a string
+    # value (e.g. a blog paragraph) terminates the single-quoted attribute
+    # and truncates the hydration payload. The browser entity-decodes the
+    # attribute value, so the client's JSON.parse sees the original text.
+    my $json = _html_escape($self->backend->encode_json($props));
     return qq{ bf-p='$json'};
 }
 

--- a/packages/adapter-perl/t/props_attr.t
+++ b/packages/adapter-perl/t/props_attr.t
@@ -19,7 +19,8 @@ use JSON::PP ();
     sub encode_json { JSON::PP->new->canonical->encode($_[1]) }
 }
 
-sub bf_with ($props) {
+sub bf_with {
+    my ($props) = @_;
     my $bf = BarefootJS->new(undef, { backend => PropsAttrStubBackend->new });
     $bf->_props($props) if $props;
     return $bf;

--- a/packages/adapter-perl/t/props_attr.t
+++ b/packages/adapter-perl/t/props_attr.t
@@ -1,0 +1,41 @@
+use Test2::V0;
+
+# props_attr — the `bf-p` hydration-payload attribute. The encoded JSON is
+# embedded in a SINGLE-quoted attribute, so it must be attribute-escaped: a
+# raw `'` inside a string value (e.g. a blog paragraph) terminates the
+# attribute early and the client hydrates from truncated JSON (empty island
+# text; found via the shared blog-ssr e2e). Same fix across the Perl,
+# Python, Ruby, and Rust runtimes — keep the four tests in sync.
+
+use FindBin qw($Bin);
+use lib "$Bin/../lib";
+
+use BarefootJS;
+use JSON::PP ();
+
+{
+    package PropsAttrStubBackend;
+    sub new         { bless {}, shift }
+    sub encode_json { JSON::PP->new->canonical->encode($_[1]) }
+}
+
+sub bf_with ($props) {
+    my $bf = BarefootJS->new(undef, { backend => PropsAttrStubBackend->new });
+    $bf->_props($props) if $props;
+    return $bf;
+}
+
+is bf_with(undef)->props_attr, '', 'no props emits nothing';
+is bf_with({})->props_attr,    '', 'empty props emits nothing';
+
+my $attr = bf_with({ note => q{it's <b> & co} })->props_attr;
+is $attr, q{ bf-p='{&#34;note&#34;:&#34;it&#39;s &lt;b&gt; &amp; co&#34;}'},
+    'JSON is attribute-escaped';
+
+my ($value) = $attr =~ /bf-p='([^']*)'/;
+my %ent = ('&#34;' => '"', '&#39;' => "'", '&lt;' => '<', '&gt;' => '>', '&amp;' => '&');
+(my $decoded = $value) =~ s/(&#34;|&#39;|&lt;|&gt;|&amp;)/$ent{$1}/g;
+is JSON::PP->new->decode($decoded), { note => q{it's <b> & co} },
+    'attribute round-trips through entity decoding';
+
+done_testing;

--- a/packages/adapter-perl/t/props_attr.t
+++ b/packages/adapter-perl/t/props_attr.t
@@ -36,7 +36,9 @@ is $attr, q{ bf-p='{&#34;note&#34;:&#34;it&#39;s &lt;b&gt; &amp; co&#34;}'},
 my ($value) = $attr =~ /bf-p='([^']*)'/;
 my %ent = ('&#34;' => '"', '&#39;' => "'", '&lt;' => '<', '&gt;' => '>', '&amp;' => '&');
 (my $decoded = $value) =~ s/(&#34;|&#39;|&lt;|&gt;|&amp;)/$ent{$1}/g;
-is JSON::PP->new->decode($decoded), { note => q{it's <b> & co} },
+# Assign first: `is JSON::PP->...` parses as indirect-object notation.
+my $parsed = JSON::PP->new->decode($decoded);
+is $parsed, { note => q{it's <b> & co} },
     'attribute round-trips through entity decoding';
 
 done_testing;

--- a/packages/adapter-rust/runtime/src/runtime.rs
+++ b/packages/adapter-rust/runtime/src/runtime.rs
@@ -240,7 +240,11 @@ fn form_escape(v: &JsValue) -> String {
 /// formatter's plain-interpolation escaper (`&quot;` for `"`) -- see
 /// `backend_minijinja.rs`'s formatter docstring for why the two differ.
 fn html_escape(v: &JsValue) -> String {
-    js_string(v).replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;").replace('"', "&#34;").replace('\'', "&#39;")
+    escape_html_chars(&js_string(v))
+}
+
+fn escape_html_chars(s: &str) -> String {
+    s.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;").replace('"', "&#34;").replace('\'', "&#39;")
 }
 
 fn style_to_css(v: &JsValue) -> Option<String> {
@@ -756,7 +760,11 @@ impl BfInstance {
         if self.props_is_empty() {
             return String::new();
         }
-        let j = backend_minijinja::encode_json(self.props.as_ref().unwrap());
+        // The JSON must be attribute-escaped: a raw `'` inside a string value
+        // (e.g. a blog paragraph) terminates the single-quoted attribute and
+        // truncates the hydration payload. The browser entity-decodes the
+        // attribute value, so the client's JSON.parse sees the original text.
+        let j = escape_html_chars(&backend_minijinja::encode_json(self.props.as_ref().unwrap()));
         format!(" bf-p='{j}'")
     }
 

--- a/packages/adapter-rust/runtime/tests/props_attr.rs
+++ b/packages/adapter-rust/runtime/tests/props_attr.rs
@@ -1,0 +1,75 @@
+//! `props_attr` -- the `bf-p` hydration-payload attribute. The encoded JSON
+//! is embedded in a SINGLE-quoted attribute, so it must be
+//! attribute-escaped: a raw `'` inside a string value (e.g. a blog
+//! paragraph) terminates the attribute early and the client hydrates from
+//! truncated JSON (empty island text; found via the shared blog-ssr e2e).
+//! Same fix across the Perl, Python, Ruby, and Rust runtimes -- keep the
+//! four tests in sync. Like `render_child.rs`, the method is driven through
+//! a real template render (the `bf` object needs a live `&State`).
+
+use barefootjs::num::JsValue;
+use barefootjs::{backend_minijinja, BfInstance, RenderSession};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+struct TempDir(PathBuf);
+
+impl TempDir {
+    fn new() -> TempDir {
+        let dir = std::env::temp_dir().join(format!(
+            "bf-props-attr-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        TempDir(dir)
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(&self.0).ok();
+    }
+}
+
+fn render_props_attr(props: Option<JsValue>) -> String {
+    let dir = TempDir::new();
+    std::fs::write(dir.0.join("host.j2"), "<div{{ bf.props_attr() | safe }}></div>").unwrap();
+    let env = backend_minijinja::build_environment(&dir.0);
+    let session = RenderSession::new();
+    let mut root = BfInstance::root(Arc::clone(&session), "test");
+    root.props = props;
+    backend_minijinja::render_named(&env, "host", root.as_mj_value(), &JsValue::Object(BTreeMap::new())).unwrap()
+}
+
+fn obj(entries: &[(&str, &str)]) -> JsValue {
+    JsValue::Object(entries.iter().map(|(k, v)| (k.to_string(), JsValue::String(v.to_string()))).collect())
+}
+
+#[test]
+fn empty_props_emit_nothing() {
+    assert_eq!(render_props_attr(None), "<div></div>");
+    assert_eq!(render_props_attr(Some(JsValue::Object(BTreeMap::new()))), "<div></div>");
+}
+
+#[test]
+fn json_is_attribute_escaped() {
+    let html = render_props_attr(Some(obj(&[("note", "it's <b> & co")])));
+    assert_eq!(html, "<div bf-p='{&#34;note&#34;:&#34;it&#39;s &lt;b&gt; &amp; co&#34;}'></div>");
+}
+
+#[test]
+fn attribute_round_trips_through_entity_decoding() {
+    let html = render_props_attr(Some(obj(&[("note", "it's <b> & co")])));
+    let start = html.find("bf-p='").unwrap() + 6;
+    let end = html[start..].find('\'').unwrap() + start;
+    let decoded = html[start..end]
+        .replace("&#34;", "\"")
+        .replace("&#39;", "'")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&amp;", "&");
+    let parsed: serde_json::Value = serde_json::from_str(&decoded).unwrap();
+    assert_eq!(parsed, serde_json::json!({"note": "it's <b> & co"}));
+}


### PR DESCRIPTION
## Summary

Started as one axum bug and grew into three related fixes as each layer of verification exposed the next:

### 1. axum: blog islands must receive caller props as template vars
`/integrations/axum/blog/posts/<slug>` SSR'd an empty article (title/date/body/slug/pager all missing) while `bf-p` carried the data. axum's `render_island` built template vars solely via `derive_stash_from_defaults`; flask's `blog_island` renders with `{**seed, **props, **extra}`. `render_island` now mirrors that merge exactly (the generic `render_component` keeps seed ⊕ stash, matching flask's `render_component`). Also fixes the blog index's SSR'd link hrefs.

### 2. Shared blog direct-load SSR e2e guard (all 14 blog integrations)
The existing 103 e2e tests all passed against the empty-SSR page — they assert post-hydration/navigation behavior. New shared factory `integrations/shared/e2e/blog-ssr.spec.ts` fetches a post page directly and asserts the article content (title, date, slug, body, both pager titles) is present in the raw server-rendered HTML, plus the post-hydration `h1`. Expected values derive from the shared corpus; wired into all 14 blog-capable integrations.

### 3. `props_attr` bf-p truncation — Perl, Python, Ruby, Rust runtimes
The new test's `h1` assertion immediately exposed a pre-existing cross-runtime bug: `props_attr` embeds the props JSON in a single-quoted `bf-p` attribute **without attribute-escaping it**, so the raw apostrophe in the blog corpus (`prototype's`) terminated the attribute and every island on the page hydrated from truncated JSON. Confirmed live on the deployed **mojolicious, xslate, flask, fastapi, sinatra, and rails** pages (`bf-p` cut at char ~385). The Go and JS adapters already escape (`&#34;`/`&quot;`) and were unaffected. Fixed uniformly via each runtime's existing HTML-escape helper; the browser entity-decodes attribute values, so the client's `JSON.parse` sees the original text. Added a `props_attr` round-trip test in each of the four languages (none existed anywhere — which is how this survived). Changeset patches `@barefootjs/perl`, `@barefootjs/jinja`, `@barefootjs/erb`, `@barefootjs/rust`.

## Verification

- axum article SSR matches flask on the visible text; axum e2e **104/104** (103 + shared guard).
- Rust: cargo test 13 suites + `clippy -D warnings` clean. Python: full `unittest discover` OK. Ruby: all `test/*_test.rb` pass. Perl: `BarefootJS.pm` compiles + escape smoke test verified byte-identical output (`Test2::V0` unavailable in this environment; `t/props_attr.t` runs in the perl CI).
- Conformance suites: `@barefootjs/rust` and `@barefootjs/jinja` both 394 tests, 0 fail.
- Production probes confirmed the truncation on all six deployed Perl/Python/Ruby integrations pre-fix; those pages heal on their next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKpQnQur4MFptq3w2wwbrq