### PR TITLE
ci.yml: cut wall time ~9m → ~3.5m via e2e unblock + unit-test sharding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,18 +68,14 @@ jobs:
 
       - name: Run unit tests
         parallel:
-          client:
-            steps:
-              - run: bun test packages/client
-          jsx:
-            steps:
-              - run: bun test packages/jsx
-          test-pkg:
-            steps:
-              - run: bun test packages/test
-          adapter-tests:
-            steps:
-              - run: bun test packages/adapter-tests
+          - name: client
+            run: bun test packages/client
+          - name: jsx
+            run: bun test packages/jsx
+          - name: test-pkg
+            run: bun test packages/test
+          - name: adapter-tests
+            run: bun test packages/adapter-tests
 
   test-ui:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,15 +67,16 @@ jobs:
           bun run --filter '@barefootjs/client' build
 
       - name: Run unit tests
-        parallel:
-          - name: client
-            run: bun test packages/client
-          - name: jsx
-            run: bun test packages/jsx
-          - name: test-pkg
-            run: bun test packages/test
-          - name: adapter-tests
-            run: bun test packages/adapter-tests
+        run: |
+          bun test packages/client & pids+=($!)
+          bun test packages/jsx & pids+=($!)
+          bun test packages/test & pids+=($!)
+          bun test packages/adapter-tests & pids+=($!)
+          status=0
+          for pid in "${pids[@]}"; do
+            wait "$pid" || status=1
+          done
+          exit $status
 
   test-ui:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,19 @@ jobs:
           bun run --filter '@barefootjs/client' build
 
       - name: Run unit tests
-        run: bun test packages/client packages/jsx packages/test packages/adapter-tests
+        parallel:
+          client:
+            steps:
+              - run: bun test packages/client
+          jsx:
+            steps:
+              - run: bun test packages/jsx
+          test-pkg:
+            steps:
+              - run: bun test packages/test
+          adapter-tests:
+            steps:
+              - run: bun test packages/adapter-tests
 
   test-ui:
     runs-on: ubuntu-latest
@@ -91,7 +103,6 @@ jobs:
 
   e2e-site-ui:
     runs-on: ubuntu-latest
-    needs: test
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ on:
       # Central divergence validation in adapter-tests re-checks every
       # adapter's declarations, so it must re-run when any adapter edits its.
       - 'packages/**/vector-divergences.json'
+      - 'scripts/ci/shard-test-files.ts'
   pull_request:
     paths:
       - 'packages/client/**'
@@ -44,6 +45,7 @@ on:
       # Central divergence validation in adapter-tests re-checks every
       # adapter's declarations, so it must re-run when any adapter edits its.
       - 'packages/**/vector-divergences.json'
+      - 'scripts/ci/shard-test-files.ts'
 
 permissions:
   contents: read
@@ -51,6 +53,21 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    name: test (${{ matrix.group }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # jsx-1/jsx-2 split packages/jsx's 178 test files into two
+          # size-balanced shards (see scripts/ci/shard-test-files.ts) since
+          # jsx dominates unit test wall time (~300-440s vs ~25-180s for the
+          # other packages). `rest` covers everything else in one runner.
+          - group: jsx-1
+            run: bun test $(bun scripts/ci/shard-test-files.ts packages/jsx 1 2)
+          - group: jsx-2
+            run: bun test $(bun scripts/ci/shard-test-files.ts packages/jsx 2 2)
+          - group: rest
+            run: bun test packages/client packages/test packages/adapter-tests
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -67,7 +84,7 @@ jobs:
           bun run --filter '@barefootjs/client' build
 
       - name: Run unit tests
-        run: bun test packages/client packages/jsx packages/test packages/adapter-tests
+        run: ${{ matrix.run }}
 
   test-ui:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,16 +67,7 @@ jobs:
           bun run --filter '@barefootjs/client' build
 
       - name: Run unit tests
-        run: |
-          bun test packages/client & pids+=($!)
-          bun test packages/jsx & pids+=($!)
-          bun test packages/test & pids+=($!)
-          bun test packages/adapter-tests & pids+=($!)
-          status=0
-          for pid in "${pids[@]}"; do
-            wait "$pid" || status=1
-          done
-          exit $status
+        run: bun test packages/client packages/jsx packages/test packages/adapter-tests
 
   test-ui:
     runs-on: ubuntu-latest

--- a/scripts/ci/shard-test-files.ts
+++ b/scripts/ci/shard-test-files.ts
@@ -1,0 +1,99 @@
+#!/usr/bin/env bun
+/**
+ * Deterministically partition a directory's test files into N shards for
+ * CI matrix runners.
+ *
+ * `bun test` (as pinned in this repo) has no --shard flag, so we compute
+ * the file list ourselves and pass it as explicit args:
+ *   bun test $(bun scripts/ci/shard-test-files.ts packages/jsx 1 2)
+ *
+ * Balancing strategy: sort files by (size desc, path asc), then greedily
+ * assign each file to the shard with the smallest running total size,
+ * breaking ties by lowest shard index. This approximates a balanced
+ * partition of wall-clock time (file size is a stable, deterministic proxy
+ * for test run time — no timestamps or randomness involved) far better
+ * than alphabetical round-robin, which was measured to produce a 1.7x
+ * imbalance on packages/jsx.
+ *
+ * Usage: bun scripts/ci/shard-test-files.ts <dir> <shardIndex> <shardCount>
+ *   <shardIndex> is 1-based.
+ */
+
+import { readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+const TEST_FILE_PATTERN = /\.test\.tsx?$/
+
+function findTestFiles(dir: string): string[] {
+  const results: string[] = []
+
+  function walk(current: string): void {
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue
+      const full = join(current, entry.name)
+      if (entry.isDirectory()) {
+        walk(full)
+      } else if (entry.isFile() && TEST_FILE_PATTERN.test(entry.name)) {
+        results.push(full)
+      }
+    }
+  }
+
+  walk(dir)
+  return results
+}
+
+function main(): void {
+  const [dir, shardIndexArg, shardCountArg] = process.argv.slice(2)
+
+  if (!dir || !shardIndexArg || !shardCountArg) {
+    console.error(
+      'Usage: bun scripts/ci/shard-test-files.ts <dir> <shardIndex> <shardCount>',
+    )
+    process.exit(1)
+  }
+
+  const shardIndex = Number.parseInt(shardIndexArg, 10)
+  const shardCount = Number.parseInt(shardCountArg, 10)
+
+  if (
+    !Number.isInteger(shardIndex) ||
+    !Number.isInteger(shardCount) ||
+    shardCount < 1 ||
+    shardIndex < 1 ||
+    shardIndex > shardCount
+  ) {
+    console.error(
+      `Invalid shardIndex/shardCount: ${shardIndexArg}/${shardCountArg} (shardIndex is 1-based)`,
+    )
+    process.exit(1)
+  }
+
+  const files = findTestFiles(dir)
+
+  const sized = files
+    .map((path) => ({ path, size: statSync(path).size }))
+    .sort((a, b) => b.size - a.size || a.path.localeCompare(b.path))
+
+  const bins: { total: number; files: string[] }[] = Array.from(
+    { length: shardCount },
+    () => ({ total: 0, files: [] }),
+  )
+
+  for (const { path, size } of sized) {
+    let smallest = 0
+    for (let i = 1; i < bins.length; i++) {
+      if (bins[i].total < bins[smallest].total) smallest = i
+    }
+    bins[smallest].files.push(path)
+    bins[smallest].total += size
+  }
+
+  const shard = bins[shardIndex - 1].files
+    .map((path) => relative(process.cwd(), path))
+    .sort((a, b) => a.localeCompare(b))
+
+  console.log(shard.join('\n'))
+}
+
+main()


### PR DESCRIPTION
## Summary
- **`e2e-site-ui` no longer waits on `needs: test`.** It's matrix-sharded and independent of the unit-test job; the old smoke-test rationale no longer applies. Confirmed on CI: all 4 shards + `test-ui` run and pass concurrently with `test`.
- **The `test` job is now a 3-way matrix across separate runners** (`jsx-1`, `jsx-2`, `rest`), each running one sequential `bun test`:
  - Profiling showed `packages/jsx` (~440s, 178 files) dominates and its time is *spread* (top-5 files = 34%), so there's no single hotspot to fix — sharding is the right lever.
  - `scripts/ci/shard-test-files.ts` deterministically splits a directory's test files by sorting on file size (measured r=0.52 proxy for runtime) and greedy-packing into equal bins. Simulated against measured per-file times: 222s/220s split, vs 1.7x imbalance for naive alphabetical round-robin.
  - `rest` = client + test + adapter-tests (~180s combined).
- **Why not same-runner parallelism:** tried and reverted earlier in this branch — GitHub's new `parallel:`/`background` step keywords aren't rolled out to this org (2 runs failed to parse), and shell backgrounding caused a real failure (client's #1725 hydration test, fixed 5s timeout, took 6.2s under CPU contention from the concurrent jsx suite). Separate runners avoid contention entirely.

Expected ci.yml wall clock: **~9m (original) → ~6m44s (e2e unblock) → ~3.5m (this)**, bounded by the slowest unit shard.

⚠️ Note for merge: the `test` check is now reported as `test (jsx-1)` / `test (jsx-2)` / `test (rest)` — if branch protection pins a required check named `test`, it needs updating.

## Test plan
- [x] Shard partition verified locally: shard1 ∪ shard2 = all 178 jsx test files, intersection empty
- [x] Both shards pass locally: 953 pass / 0 fail (224s) and 1293 pass / 0 fail (213s)
- [x] ci.yml validates against the published github-workflow.json schema
- [x] Prior run confirmed e2e-site-ui + test-ui run concurrently with test
- [ ] Verify the new matrix run is green on CI and record actual wall time
