### PR TITLE
feat: lower array-index / nested / rest-spread .map() destructure on template adapters (BF104)

### DIFF
--- a/.changeset/map-destructure-lowering.md
+++ b/.changeset/map-destructure-lowering.md
@@ -1,0 +1,19 @@
+---
+"@barefootjs/jsx": minor
+"@barefootjs/go-template": minor
+"@barefootjs/mojolicious": minor
+"@barefootjs/xslate": minor
+"@barefootjs/perl": minor
+"@barefootjs/erb": minor
+"@barefootjs/jinja": minor
+"@barefootjs/twig": minor
+"@barefootjs/rust": minor
+---
+
+Lower array-index / nested / rest destructure `.map()` callback params on all template adapters (#2087, refs #2069).
+
+`LoopParamBinding` gains a structured `segments` path (field/index steps with `isIdent` classification) and the shared gate — renamed `isLowerableLoopDestructure`, old name kept as a deprecated alias — now admits fixed bindings at any path depth (`([k, v])`, `{ cells: [head] }`, `{ user: { name } }`), array-rest (`[first, ...tail]`, lowered as the exact slice), and object-rest used as member access or as a `{...rest}` spread onto an intrinsic element (lowered as a true residual bag via a new per-adapter `omit` runtime helper feeding the existing `spread_attrs` pipeline; ERB uses native `Hash#except`).
+
+The `rest-destructure-{object-spread,array,nested}-in-map` conformance fixtures graduate from BF104 pins to real-engine HTML comparison on all seven template adapters, alongside the new `destructure-array-index-in-map` / `destructure-nested-object-in-map` fixtures. Still refused (BF104): bare value uses of an object-rest name, spreads onto components/providers, `.filter().map(destructure)` chains, and `__bf_`-prefixed binding names.
+
+Collateral hardening: `static-array-from-props(-with-component)`'s destructure no longer trips BF104, which exposed an orthogonal gap — a loop array bound to a computed function-scope const would silently render empty. Template adapters now raise a narrow BF101 for that shape instead.

--- a/packages/adapter-erb/src/__tests__/erb-adapter.test.ts
+++ b/packages/adapter-erb/src/__tests__/erb-adapter.test.ts
@@ -42,7 +42,7 @@ runAdapterConformanceTests({
   // parent-scope-derived IDs matching Hono.
   // Per-fixture build-time contracts for shapes the ERB adapter
   // intentionally refuses to lower. Mirrors mojo's set — the lowering
-  // gates (`isLowerableObjectRestDestructure`, `collectImportedLoopChild
+  // gates (`isLowerableLoopDestructure`, `collectImportedLoopChild
   // ComponentErrors`, `refuseUnsupportedAttrExpression`, the #2038
   // nested-higher-order-callback gate) are shared code in `@barefootjs/jsx`
   // that every EP/ERB-family adapter reuses verbatim.
@@ -57,25 +57,42 @@ runAdapterConformanceTests({
     // level so the shared-component corpus stays adapter-neutral.
     'todo-app': [{ code: 'BF103', severity: 'error' }],
     'todo-app-ssr': [{ code: 'BF103', severity: 'error' }],
-    // Array-destructure loop param (`([k, v]) => ...`) lowers to
-    // invalid Ruby block-param syntax (`|[k, v]|` can't unpack a tuple
-    // into scalar locals the way this adapter's loop emission needs).
-    // Same BF104 gate (`isLowerableObjectRestDestructure`) as mojo.
-    'static-array-from-props': [{ code: 'BF104', severity: 'error' }],
-    // Both BF103 (imported child) and BF104 (destructure) fire.
+    // `static-array-from-props` / `static-array-from-props-with-component`:
+    // the `.map(([emoji, users]) => …)` / `.map(([id, t]) => …)` callback is
+    // a plain array-index destructure (the `.filter(...)` runs on a
+    // separate `const entries = …` statement, so `loop.filterPredicate` is
+    // unset — this is not the `.filter().map(destructure)` chain
+    // `isLowerableLoopDestructure` still refuses), and #2087 Phase B's
+    // segments-walking accessor DOES lower it natively. But both fixtures'
+    // loop array is that same `entries` — a component-scope `const`
+    // computed from `Object.entries(props.x).filter(...)`, a runtime
+    // expression the ERB adapter has no mechanism to evaluate at SSR
+    // render time (only a pure-literal or module-string const is ever
+    // inlined; a computed const falls through to an unseeded `v[:entries]`
+    // and crashes). This is a pre-existing, orthogonal gap the widened
+    // destructure gate merely exposes — it reproduces identically with a
+    // non-destructured param (verified) — not a destructure-lowering
+    // limitation, so it is NOT part of #2087's scope. Tracked as its own
+    // gap under https://github.com/piconic-ai/barefootjs/issues/2087;
+    // pinned honestly as BF101 (the adapter's own check, see `renderLoop`'s
+    // "Loop array is a bare identifier..." comment) rather than faked as
+    // BF104 or silently producing broken Ruby.
+    'static-array-from-props': [{ code: 'BF101', severity: 'error' }],
     'static-array-from-props-with-component': [
       { code: 'BF103', severity: 'error' },
-      { code: 'BF104', severity: 'error' },
+      { code: 'BF101', severity: 'error' },
     ],
-    // Rest-destructure `.map()` callbacks — the object-rest shape read via
-    // member access (`rest-destructure-object-in-map`) lowers via a per-item
-    // Ruby local plus one local per binding (`rest` aliases the item so
-    // `rest[:flag]` resolves). The other three stay refused: rest SPREAD
-    // (`{...rest}`) needs a residual Hash, and array-index / nested paths
-    // can't unpack into scalar locals (same surface as mojo).
-    'rest-destructure-object-spread-in-map': [{ code: 'BF104', severity: 'error' }],
-    'rest-destructure-array-in-map': [{ code: 'BF104', severity: 'error' }],
-    'rest-destructure-nested-in-map': [{ code: 'BF104', severity: 'error' }],
+    // #2087 Phase B: `isLowerableLoopDestructure` now admits every fixed-
+    // binding shape (any field/index depth — `destructure-array-index-in-map`,
+    // `destructure-nested-object-in-map`), array-rest (`rest-destructure-
+    // array-in-map`, native `bf.slice`), and object-rest whose every use is a
+    // member read or a `{...rest}` spread onto an intrinsic element
+    // (`rest-destructure-object-in-map`, `rest-destructure-object-spread-in-
+    // map`, `rest-destructure-nested-in-map` — native `Hash#except` builds a
+    // true residual Hash). None of the six destructure-in-map fixtures are
+    // pinned here any more; all render to Hono parity. See
+    // `rubyAccessorFromSegments` / the object-rest-in-loop branch in
+    // `erb-adapter.ts`'s `renderLoop`.
     // #1244 stress catalog #12 (#1323): tagged-template-literal call
     // (`cn\`base \${tone()}\``) has no idiomatic ERB template form — refused
     // via `refuseUnsupportedAttrExpression`, same gate mojo/xslate share.

--- a/packages/adapter-erb/src/adapter/erb-adapter.ts
+++ b/packages/adapter-erb/src/adapter/erb-adapter.ts
@@ -79,7 +79,7 @@ import {
   parseRecordIndexAccess,
   extractArrowBodyExpression,
   collectContextConsumers,
-  isLowerableObjectRestDestructure,
+  isLowerableLoopDestructure,
   type ContextConsumer,
   collectModuleStringConsts,
   lookupStaticRecordLiteral,
@@ -89,7 +89,7 @@ import {
   sortComparatorFromArrow,
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr, isExplicitStringCall } from './boolean-result.ts'
-import type { ParsedExpr, LoweringMatcher } from '@barefootjs/jsx'
+import type { ParsedExpr, LoweringMatcher, LoopBindingPathSegment } from '@barefootjs/jsx'
 import { BF_SLOT, BF_COND, BF_REGION } from '@barefootjs/shared'
 
 import type { ErbRenderCtx } from './lib/types.ts'
@@ -129,6 +129,24 @@ import {
 
 export type { ErbAdapterOptions } from './lib/types.ts'
 import type { ErbAdapterOptions } from './lib/types.ts'
+
+/**
+ * Build a chained Ruby Hash/Array accessor from a `.map()` destructure
+ * binding's structured `segments` path (#2087 Phase B) — walking `segments`
+ * instead of string-parsing `LoopParamBinding.path` (repo rule: never parse
+ * JS/TS syntax with regex or string matching). A `field` step reads a
+ * symbol key (`[:name]` / `[:"data-priority"]`, matching every item Hash's
+ * `JSON.parse(..., symbolize_names: true)` construction); an `index` step
+ * reads a numeric Array index (`[0]`). Empty `segments` (a rest binding at
+ * the loop root) returns `base` unchanged.
+ */
+function rubyAccessorFromSegments(base: string, segments: readonly LoopBindingPathSegment[]): string {
+  let accessor = base
+  for (const seg of segments) {
+    accessor += seg.kind === 'index' ? `[${seg.index}]` : `[${rubySymbolLiteral(seg.key)}]`
+  }
+  return accessor
+}
 
 export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCtx> {
   name = 'erb'
@@ -795,29 +813,64 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
 
     // An array/object-destructure loop param (`([emoji, users]) => ...` or
     // `({ name, age }) => ...`) lowers to invalid Ruby block-param syntax in
-    // general — the adapter would otherwise need `|[emoji, users]|`-shaped
-    // destructuring the IR doesn't carry structurally for every case. A
-    // destructure loop param IS lowerable for the object-rest / simple-field
-    // shape (`.map(({ id, title, ...rest }) => …)`, `rest` read via member
-    // access): each binding becomes a Ruby local off the per-item Hash, so
-    // the body's `id` / `rest[:flag]` resolve natively. Array-index / nested
-    // / rest-spread shapes still can't unpack into scalar locals → BF104.
+    // general — Ruby has no destructuring-assignment analog for an arbitrary
+    // nested pattern in a single statement. `isLowerableLoopDestructure`
+    // (#2087) instead admits any FIXED-binding shape — single field, nested
+    // field, array-index, any depth/mix (`{ user: { name } }`, `([k, v])`,
+    // `{ cells: [head] }`) — by walking the binding's structured `segments`
+    // path into a chained Ruby accessor (`__bf_item[:user][:name]`), plus
+    // array-rest (`[first, ...tail]`, native `bf.slice`) and object-rest
+    // (`{ id, ...rest }`, native `Hash#except`) whose every use is a member
+    // read (`rest.flag`) or a `{...rest}` spread onto an intrinsic element.
+    // Bare-value rest uses, a spread onto a component/provider, and
+    // `.filter().map(destructure)` still have no Ruby scalar form → BF104.
     const destructure = !!(loop.paramBindings && loop.paramBindings.length > 0)
-    const supportableDestructure = destructure && isLowerableObjectRestDestructure(loop)
+    const supportableDestructure = destructure && isLowerableLoopDestructure(loop)
     if (destructure && !supportableDestructure) {
       this.errors.push({
         code: 'BF104',
         severity: 'error',
-        message: `Loop callback uses an array/object destructure pattern (\`${loop.param}\`) that the ERB adapter cannot lower — Ruby local bindings can't unpack a tuple in a single assignment.`,
+        message: `Loop callback uses an array/object destructure pattern (\`${loop.param}\`) that the ERB adapter cannot lower — the rest binding is used in a way (bare value, or spread onto a component) that has no native Ruby accessor form.`,
         loc: loop.loc ?? { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
         suggestion: {
           message:
             `Options:\n` +
-            `  1. Rename the parameter to a single name and access tuple elements with index syntax in the body (e.g. \`entry => entry[0]\` instead of \`([k, v]) => ...\`).\n` +
+            `  1. Read the rest binding as a member access (\`rest.field\`) or spread it onto an intrinsic element (\`<li {...rest}>\`) instead of using it as a bare value.\n` +
             `  2. Mark the loop position as @client-only so the destructure runs in JS on the client.\n` +
             `  3. Move the loop into a primitive that the adapter registers explicitly.`,
         },
       })
+    }
+
+    // Loop array is a bare identifier naming a component-scope (non-module)
+    // `const` the adapter has no way to compute at SSR render time. Only a
+    // pure-literal const (`resolveLiteralConst`) or a module-scope
+    // pure-string const (`resolveModuleStringConst`) is ever inlined —
+    // anything else (`const entries = Object.entries(props.x).filter(...)`)
+    // falls through to the generic `v[:entries]` vars-Hash read, which is
+    // never seeded (the ERB test/production vars-seed only covers props,
+    // signals, and memos — see `test-render.ts::buildRubyProps`) and raises
+    // a Ruby `NoMethodError` on `.length` at render time. This is a
+    // pre-existing, orthogonal gap surfaced by #2087 widening the loop
+    // destructure gate (`isLowerableLoopDestructure` now admits the
+    // array-index destructure `static-array-from-props(-with-component)`
+    // use, which used to be hidden behind the old destructure BF104) — it
+    // reproduces identically with a non-destructured param, so it is NOT a
+    // destructure-lowering limitation. Surface BF101 honestly instead of
+    // emitting a loop bound that silently crashes / renders empty.
+    if (loop.arrayParsed?.kind === 'identifier') {
+      const arrayName = loop.arrayParsed.name
+      const isUnresolvableLocalConst =
+        !this.loopBoundNames.has(arrayName) &&
+        this.resolveModuleStringConst(arrayName) === null &&
+        this.resolveLiteralConst(arrayName) === null &&
+        this.localConstants.some(c => c.name === arrayName && !c.isModule)
+      if (isUnresolvableLocalConst) {
+        this._recordExprBF101(
+          `Loop array \`${arrayName}\` is a component-scope const computed from a runtime expression the ERB adapter cannot evaluate at SSR render time.`,
+          `Options:\n1. Inline the array expression directly in the .map() call instead of a preceding const.\n2. Mark the loop position as @client-only so the array materialises on the client.\n3. Precompute the value server-side and pass it in as a prop.`,
+        )
+      }
     }
 
     const rawArray = this.convertExpressionToRuby(loop.array)
@@ -915,15 +968,36 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
     lines.push(`<%- (0...${array}.length).each do |${indexVar}| -%>`)
     if (loop.iterationShape !== 'keys') {
       if (supportableDestructure) {
-        // Per-item local + one local per binding; `rest` aliases the item
-        // so `rest[:flag]` resolves (object-rest read via member access).
+        // Per-item local + one local per binding, built off the binding's
+        // structured `segments` path (never `b.path` — repo rule: no
+        // string-parsing of a JS-shaped accessor). See `rubyAccessorFromSegments`.
         lines.push(`<%- __bf_item = ${array}[${indexVar}] -%>`)
         for (const b of loop.paramBindings ?? []) {
-          lines.push(
-            b.rest
-              ? `<%- ${rubyLocal(b.name)} = __bf_item -%>`
-              : `<%- ${rubyLocal(b.name)} = __bf_item[${rubySymbolLiteral(b.path.slice(1))}] -%>`,
-          )
+          // Fixed bindings: `segments` is the FULL accessor path from the
+          // item to this binding. Rest bindings: `segments` is the PARENT
+          // prefix (possibly empty, at the loop root) — the accessor below
+          // is the rest's parent object/array, not the rest binding itself.
+          const accessor = rubyAccessorFromSegments('__bf_item', b.segments ?? [])
+          if (b.rest?.kind === 'array') {
+            // Native Ruby range-slice has different past-end nil semantics
+            // than JS `Array.prototype.slice` (`arr[4..]` is `nil` where
+            // `arr.slice(4)` is `[]`) — route through the runtime's `slice`
+            // helper (barefoot_js.rb) so both edge cases (`from` at or past
+            // length) return `[]` like JS, matching the Go/Perl ports.
+            lines.push(`<%- ${rubyLocal(b.name)} = bf.slice(${accessor}, ${b.rest.from}) -%>`)
+          } else if (b.rest?.kind === 'object') {
+            // A TRUE residual Hash (not an alias of the parent) via native
+            // `Hash#except` (Ruby >= 3.0; CI pins 3.3) — so a member read
+            // (`rest.flag` → `rest[:flag]`, `ErbTopLevelEmitter#member`) and
+            // the existing `{...rest}` spread emit (`bf.spread_attrs`) both
+            // see only the non-destructured keys, same as the Hono/CSR IIFE.
+            // Symbol keys match the vars-Hash convention: every item Hash is
+            // built by `JSON.parse(..., symbolize_names: true)`.
+            const excludeSyms = b.rest.exclude.map(k => rubySymbolLiteral(k.key)).join(', ')
+            lines.push(`<%- ${rubyLocal(b.name)} = ${accessor}.except(${excludeSyms}) -%>`)
+          } else {
+            lines.push(`<%- ${rubyLocal(b.name)} = ${accessor} -%>`)
+          }
         }
       } else {
         lines.push(`<%- ${rubyLocal(param)} = ${array}[${indexVar}] -%>`)

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -152,6 +152,10 @@ func FuncMap() template.FuncMap {
 
 		// JSX intrinsic-element spread lowering (#1407)
 		"bf_spread_attrs": SpreadAttrs,
+
+		// Destructure object-rest spread-onto-element residual (#2087):
+		// "every field except these" for a struct/map, keyed by json tag.
+		"bf_omit": Omit,
 	}
 }
 
@@ -535,6 +539,85 @@ func SpreadAttrs(bag any) template.HTMLAttr {
 		return ""
 	}
 	return template.HTMLAttr(strings.Join(parts, " "))
+}
+
+// Omit builds a `map[string]any` residual bag from a struct or map value,
+// excluding the given keys — powers the `{...rest}` spread-onto-element
+// lowering for a destructured `.map()` loop-item's object-rest binding
+// (#2087): `.map(({ id, title, ...rest }) => <li {...rest}>)` needs "every
+// field EXCEPT the ones the pattern already destructured out", and a static
+// Go struct type has no way to express "minus a field" — the exclude set is
+// known at COMPILE TIME (the sibling keys the destructure pattern names), so
+// the compiler passes them here and this does the per-item field-vs-key
+// matching a static type can't. The result feeds `bf_spread_attrs`
+// (`SpreadAttrs`), same as a top-level `{...attrs()}` bag.
+//
+// Struct receiver: iterates exported fields via reflection, keyed by each
+// field's `json` struct tag (falling back to the Go field name when absent)
+// — the generated struct's json tag is always the ORIGINAL source property
+// name (see `structFieldsFor` / `typeDefinitionToGo` in the Go adapter), so
+// this reproduces the exact JS key `SpreadAttrs`'s `toAttrName` expects
+// (`"data-priority"`, not a re-derived `"DataPriority"`). A tag of `"-"`
+// (opt-out) is skipped like `encoding/json` does.
+//
+// Map receiver: copies string keys through directly, same exclude/skip
+// rules.
+//
+// Anything else (nil, a non-struct/non-map interface) returns an empty map.
+func Omit(item any, excludeKeys ...string) map[string]any {
+	exclude := make(map[string]struct{}, len(excludeKeys))
+	for _, k := range excludeKeys {
+		exclude[k] = struct{}{}
+	}
+	out := map[string]any{}
+	rv := reflect.ValueOf(item)
+	for rv.Kind() == reflect.Interface || rv.Kind() == reflect.Pointer {
+		if rv.IsNil() {
+			return out
+		}
+		rv = rv.Elem()
+	}
+	switch rv.Kind() {
+	case reflect.Struct:
+		rt := rv.Type()
+		for i := 0; i < rt.NumField(); i++ {
+			field := rt.Field(i)
+			if !field.IsExported() {
+				continue
+			}
+			key := field.Name
+			if tag, ok := field.Tag.Lookup("json"); ok {
+				if comma := strings.Index(tag, ","); comma >= 0 {
+					tag = tag[:comma]
+				}
+				if tag == "-" {
+					continue
+				}
+				if tag != "" {
+					key = tag
+				}
+			}
+			if _, skip := exclude[key]; skip {
+				continue
+			}
+			out[key] = rv.Field(i).Interface()
+		}
+	case reflect.Map:
+		for _, k := range rv.MapKeys() {
+			if k.Kind() != reflect.String {
+				continue
+			}
+			key := k.String()
+			if _, skip := exclude[key]; skip {
+				continue
+			}
+			val := rv.MapIndex(k)
+			if val.IsValid() {
+				out[key] = val.Interface()
+			}
+		}
+	}
+	return out
 }
 
 // BfPropsAttr returns the bf-p attribute with the JSON-serialized

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -963,6 +963,54 @@ export function Rows() {
       expect(types).toContain('Rows: []Row{Row{DataID: "a"}},')
     })
 
+    test('bakes a non-Go-identifier key inside a nested INLINE object with the same sanitizer as the accessor side (#2089 review)', () => {
+      // A nested inline-object property (`meta: { 'data-x': string }` — no
+      // named Go struct, lowered to map[string]interface{}) bakes as a Go map
+      // literal. The map KEY must be produced by `goFieldNameForKey` — the
+      // same function `buildSegmentAccessor`/`structFieldsFor` use — so the
+      // emitted accessor (`.Meta.DataX`, an exact-string MapIndex on maps)
+      // actually finds the value. `capitalizeFieldName` alone would bake
+      // `"Data-x"`, a key no emitted accessor can reach, silently rendering
+      // empty (flagged by Copilot on PR #2089).
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+type Row = { id: string; meta: { "data-x": string } }
+export function Rows() {
+  const [rows] = createSignal<Row[]>([{ id: "r1", meta: { "data-x": "v" } }])
+  return <ul>{rows().map(({ id, meta }) => <li key={id}>{meta["data-x"]}</li>)}</ul>
+}
+`)
+      const types = adapter.generate(ir).types!
+      expect(types).toContain('map[string]interface{}{"DataX": "v"}')
+      expect(types).not.toContain('"Data-x"')
+    })
+
+    test('snake_case keys keep their underscore in the generated field name (#2089 review)', () => {
+      // Underscores are VALID Go identifier characters, and `Foo_bar` is the
+      // field name this adapter has always generated for a snake_case key —
+      // `goFieldNameForKey` must NOT split on `_` (that would rename the
+      // generated field to `FooBar`, silently diverging from the `.Foo_bar`
+      // dot access the member emitter produces AND breaking consumers'
+      // hand-written constructors against previously generated types).
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+type Row = { foo_bar: string }
+export function Rows() {
+  const [rows] = createSignal<Row[]>([{ foo_bar: "a" }])
+  return <ul>{rows().map((r) => <li key={r.foo_bar}>{r.foo_bar}</li>)}</ul>
+}
+`)
+      const out = adapter.generate(ir)
+      expect(out.types!).toContain('Foo_bar string `json:"foo_bar"`')
+      expect(out.template).toContain('.Foo_bar')
+    })
+
     test('collapses whitespace-padded empty array literal to nil (#1675 review)', () => {
       // The empty-literal fast-path must match `[ ]` too, not only the exact
       // `[]`, so a padded empty initial value still defaults to nil rather than

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -89,15 +89,24 @@ runAdapterConformanceTests({
     // shared-component corpus stays adapter-neutral.
     'todo-app': [{ code: 'BF103', severity: 'error' }],
     'todo-app-ssr': [{ code: 'BF103', severity: 'error' }],
-    // Array-destructure loop param (`([k, v]) => ...`): Go's `{{range
-    // $a, $b := ...}}` only supports single-name bindings, so the
-    // adapter would otherwise emit invalid template syntax.
-    'static-array-from-props': [{ code: 'BF104', severity: 'error' }],
-    // Same destructure shape with a child component body — fires both
-    // BF103 (imported child in loop) and BF104 (destructure param).
+    // `([emoji, users]) => ...` is an array-index tuple destructure — #2087
+    // Phase B's widened gate now admits this shape (`destructure-array-index-in-map`
+    // exercises the same `segments`-based lowering). The remaining refusal here
+    // is orthogonal: `entries` is a function-scope local const with a computed
+    // initializer (`Object.entries(props.reactions ?? {}).filter(...)`) that
+    // the Go adapter has no binding for (only a STRING-derived local resolves
+    // to a generated struct field, via `computeDerivedConstFields`/`isStringExpr`)
+    // — left unchecked this would silently execute-time-fail instead of
+    // building loud, so `renderLoop` raises BF101 for a bare-identifier loop
+    // array bound to such a const. See the `renderLoop` comment at the check
+    // site; Jinja / ERB apply the same narrow check for the same reason.
+    'static-array-from-props': [{ code: 'BF101', severity: 'error' }],
+    // Same computed-const array as above, plus the pre-existing BF103 (a
+    // sibling-imported child component used inside the loop body) — the
+    // destructure param itself no longer contributes a diagnostic.
     'static-array-from-props-with-component': [
       { code: 'BF103', severity: 'error' },
-      { code: 'BF104', severity: 'error' },
+      { code: 'BF101', severity: 'error' },
     ],
     // (`style-3-signals` graduated alongside `style-object-dynamic` — see note
     // above; the `style={{ … }}` object now lowers to a CSS string.)
@@ -116,17 +125,21 @@ runAdapterConformanceTests({
     // https://github.com/piconic-ai/barefootjs/issues/2038
     'filter-nested-callback-predicate': [{ code: 'BF101', severity: 'error' }],
     'filter-nested-find-predicate': [{ code: 'BF101', severity: 'error' }],
-    // #1310: rest destructure in .map() callback. The object-rest shape read
-    // via member access (`rest-destructure-object-in-map`) now lowers — each
-    // binding resolves to a field on a synthetic `$__bf_item0` range var (the
-    // reserved `__bf_item` name, depth-suffixed) and `rest.flag` →
-    // `$__bf_item0.Flag` (`destructureBindingsSupportable`). The
-    // other three stay refused: rest SPREAD (`{...rest}`) needs a residual
-    // object, and array-index / nested paths (`[a, ...t]`, `{ cells: [h] }`)
-    // need index/slice machinery Go's `{{range}}` can't express inline.
-    'rest-destructure-object-spread-in-map': [{ code: 'BF104', severity: 'error' }],
-    'rest-destructure-array-in-map': [{ code: 'BF104', severity: 'error' }],
-    'rest-destructure-nested-in-map': [{ code: 'BF104', severity: 'error' }],
+    // #1310 / #2087: rest destructure in .map() callback. `isLowerableLoopDestructure`
+    // now admits every shape this fixture family exercises — each fixed/rest
+    // binding resolves via `buildSegmentAccessor`/`buildDestructureBindingMap`
+    // against a synthetic `$__bf_item0` range var (the reserved `__bf_item`
+    // name, depth-suffixed): a plain field → `$__bf_item0.Id`, an array-index
+    // step → `(index $__bf_item0 0)`, an array-rest → `(bf_slice $__bf_item0
+    // 1)` (composes under `.length` via `member()`'s generic `len <obj>` arm),
+    // and an object-rest member read (`rest.flag`) → `$__bf_item0.Flag`. A
+    // `{...rest}` SPREAD (`rest-destructure-object-spread-in-map`) routes
+    // through the new `bf_omit` runtime helper instead, so the residual omits
+    // exactly the sibling keys the pattern destructured out. No fixture in
+    // this family is pinned anymore — all six render to real Go / byte-exact
+    // HTML (`rest-destructure-object-in-map`, `rest-destructure-object-spread-in-map`,
+    // `rest-destructure-array-in-map`, `rest-destructure-nested-in-map`,
+    // `destructure-array-index-in-map`, `destructure-nested-object-in-map`).
     // #1443: `[a, b].filter(Boolean).join(' ')` (registry Slot) now
     // lowers to `bf_join (bf_filter_truthy (bf_arr ...)) " "`. No
     // BF101 expected — pinned positively by the
@@ -922,10 +935,18 @@ export function Dyn() {
       expect(types).toContain('Items: nil,')
     })
 
-    test('keeps nil for object keys that are not Go-identifier-safe (#1675 review)', () => {
-      // A quoted key like "data-id" capitalises to `Data-id`, which is not a
-      // valid Go struct field identifier — baking it would emit a keyed struct
-      // literal that doesn't compile, so the whole array must stay nil.
+    test('bakes a non-Go-identifier object key via a sanitized struct field (#1675 review, revised #2087)', () => {
+      // A quoted key like "data-id" used to capitalise to `Data-id` (not a
+      // valid Go struct field identifier), so the struct field was dropped
+      // entirely and the whole array baked to nil rather than emit invalid
+      // Go — silently losing the data. #2087 Phase B's `goFieldNameForKey`
+      // (packages/adapter-go-template/src/adapter/lib/go-naming.ts) instead
+      // PascalCases each segment split on the hyphen (`data-id` → `DataID`,
+      // matching the `id` whole-word initialism), giving the field a real
+      // Go name — needed so the destructure-rest residual lowering
+      // (`rest-destructure-object-spread-in-map`, #2087) has something to
+      // read a non-identifier sibling key back from. The array now bakes for
+      // real instead of deferring to nil.
       const adapter = new GoTemplateAdapter()
       const ir = compileToIR(`
 "use client"
@@ -938,7 +959,8 @@ export function Rows() {
 }
 `)
       const types = adapter.generate(ir).types!
-      expect(types).toContain('Rows: nil,')
+      expect(types).toContain('DataID string `json:"data-id"`')
+      expect(types).toContain('Rows: []Row{Row{DataID: "a"}},')
     })
 
     test('collapses whitespace-padded empty array literal to nil (#1675 review)', () => {
@@ -3589,6 +3611,14 @@ export function C() {
 
   test('@client attribute inside a keyed .map() loop body is also deferred', () => {
     const adapter = new GoTemplateAdapter()
+    // `days` is signal-backed (not a bare function-scope local) so the loop
+    // array itself resolves to a real `.Days []Day` field — a plain
+    // `const days: Day[] = [...]` array-of-objects local has no such backing
+    // (the Go adapter only binds a STRING-derived function-scope const as a
+    // field; #2087's `renderLoop` BF101 check now catches that case loudly
+    // instead of emitting a template that references a nonexistent field).
+    // This test's actual subject is the `/* @client */` attribute deferral
+    // inside a loop body, which is orthogonal to how the array is sourced.
     const result = compileJSX(`
 "use client"
 import { createSignal } from "@barefootjs/client"
@@ -3596,10 +3626,10 @@ type Day = { n: number }
 export function C() {
   const [sel] = createSignal(0)
   const pred = (d: Day) => sel() === d.n
-  const days: Day[] = [{ n: 1 }, { n: 2 }]
+  const [days] = createSignal<Day[]>([{ n: 1 }, { n: 2 }])
   return (
     <div>
-      {days.map((day: Day) => (
+      {days().map((day: Day) => (
         <div key={day.n} data-x={/* @client */ pred(day)}>cell</div>
       ))}
     </div>
@@ -3608,7 +3638,7 @@ export function C() {
 `.trimStart(), 'test.tsx', { adapter })
     const template = result.files?.find(f => f.path.endsWith('.tmpl'))?.content ?? ''
     expect(result.errors ?? []).toEqual([])
-    // The loop still renders (the array is a static const) but the deferred
+    // The loop still renders (the array is signal-backed) but the deferred
     // attribute is absent from the emitted `<div>` cell.
     expect(template).toContain('range')
     expect(template).not.toContain('data-x')

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -31,6 +31,7 @@ import type {
   IRAsync,
   IRMetadata,
   TemplatePrimitiveRegistry,
+  LoopBindingPathSegment,
 } from '@barefootjs/jsx'
 import {
   BaseAdapter,
@@ -59,7 +60,7 @@ import {
   emitAttrValue,
   augmentInheritedPropAccesses,
   collectContextConsumers,
-  isLowerableObjectRestDestructure,
+  isLowerableLoopDestructure,
   type ContextConsumer,
   collectModuleStringConsts as collectModuleStringConstsShared,
   prepareLoweringMatchers,
@@ -74,6 +75,7 @@ import {
   GO_KEYWORDS,
   capitalize,
   capitalizeFieldName,
+  goFieldNameForKey,
   slotIdToFieldSuffix,
   loopKeyToGoFieldPath,
 } from "./lib/go-naming.ts"
@@ -230,9 +232,24 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   private loopScalarItemStack: boolean[] = []
   private loopVarRefCount: Map<string, number> = new Map()
   /** Stack of destructure-param binding maps (binding name → Go accessor on the
-   *  range var, e.g. `id` → `$__bf_item0.Id`, `rest` → `$__bf_item0`). Innermost
-   *  last. Lets `.map(({ id, ...rest }) => …)` resolve instead of BF104. */
+   *  range var, e.g. `id` → `$__bf_item0.Id`, `rest` → `$__bf_item0`, an
+   *  array-rest → `(bf_slice $__bf_item0 1)`, a nested/index path →
+   *  `(index $__bf_item0.Cells 0)`). Innermost last. Lets `.map(({ id, ...rest
+   *  })` / `.map(([k, v]) =>` / nested-path destructure resolve instead of
+   *  BF104 (#2087 Phase B — see `buildDestructureBindingMap`). */
   private loopBindingStack: Array<Map<string, string>> = []
+  /**
+   * Stack of object-rest exclude-key maps, parallel to `loopBindingStack`
+   * (same push/pop points, innermost last). Only object-rest bindings appear
+   * here — keyed by binding name, each entry carries the PARENT accessor
+   * (same value as `loopBindingStack`'s entry for that name) plus the sibling
+   * keys the destructure pattern already pulled out. `emitSpread` consults
+   * this for a `{...rest}` spread onto an intrinsic element, so the residual
+   * omits exactly the keys the pattern destructured — member reads
+   * (`rest.flag`) don't need it and keep resolving through `loopBindingStack`
+   * alone (#2087 Phase B).
+   */
+  private loopRestExcludeStack: Array<Map<string, { parent: string; excludeKeys: string[] }>> = []
 
   /**
    * Cross-component child shapes, keyed by child component name. Populated via
@@ -591,16 +608,23 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * analyzer's structured properties (no definition-string parsing). Both the
    * struct emitter and the object-literal baker consume it, so a baked literal
    * can't name a field the struct lacks. A non-Go-identifier source key
-   * (`"data-id"`, a numeric key) is dropped here, so the baker bails to nil for
-   * any literal using such a key.
+   * (`"data-priority"`, a numeric key) still gets a field via
+   * `goFieldNameForKey`'s segment-splitting PascalCase (#2087 Phase B —
+   * `rest-destructure-object-spread-in-map`'s `'data-priority'` residual key
+   * needs a real field to bake into, or the whole literal defers to nil); a
+   * dedup guard drops a later key that sanitizes to a Go name already taken
+   * (rare, but two fields can't share one Go identifier).
    */
   private structFieldsFor(td: TypeDefinition): Array<{ tsName: string; goName: string; goType: string }> {
     const fields: Array<{ tsName: string; goName: string; goType: string }> = []
+    const seenGoNames = new Set<string>()
     for (const prop of td.properties ?? []) {
-      if (!GO_IDENTIFIER.test(prop.name)) continue
+      const goName = goFieldNameForKey(prop.name)
+      if (seenGoNames.has(goName)) continue
+      seenGoNames.add(goName)
       fields.push({
         tsName: prop.name,
-        goName: capitalizeFieldName(prop.name),
+        goName,
         goType: typeInfoToGo(this.emitCtx, prop.type),
       })
     }
@@ -4414,20 +4438,78 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   /**
-   * Map each destructure binding to its Go accessor on the range var: a named
-   * binding → `$<rangeVar>.<Field>`, an object-rest binding → the bare
-   * `$<rangeVar>` so the member emitter renders `rest.flag` → `$<rangeVar>.Flag`.
+   * Walk a destructure binding's structured `segments` path (#2087 Phase A) into
+   * a Go accessor over `base`. A `field` step appends `.<GoFieldName>` — dot
+   * access resolves against a struct field OR a map key (Go template's
+   * `evalField` supports both), and `goFieldNameForKey` produces a valid Go
+   * identifier regardless of whether the SOURCE key was one (`cells` → `Cells`,
+   * `data-priority` → `DataPriority`) — Go dot-syntax only requires the EMITTED
+   * name to be a legal identifier, not the original JS key. An `index` step
+   * has no dot-notation form, so it wraps in Go's `index` builtin
+   * (`(index <acc> N)`); the wrap also parenthesises the whole accessor so a
+   * following step or an outer composition (`len (...)`) can't swallow it as
+   * extra call arguments.
    */
-  private buildDestructureBindingMap(loop: IRLoop, rangeVar: string): Map<string, string> {
-    const m = new Map<string, string>()
+  private buildSegmentAccessor(base: string, segments: readonly LoopBindingPathSegment[]): string {
+    let acc = base
+    for (const seg of segments) {
+      acc = seg.kind === 'field' ? `${acc}.${goFieldNameForKey(seg.key)}` : `(index ${acc} ${seg.index})`
+    }
+    return acc
+  }
+
+  /**
+   * Map each destructure binding to its Go accessor on the range var (#2087
+   * Phase B — `isLowerableLoopDestructure` admits every shape below):
+   *
+   *   - fixed binding (any depth): the FULL `segments` path over the range var
+   *     (`id` → `$item.Id`, `head` in `cells: [head]` → `(index $item.Cells 0)`,
+   *     `k` in `[k, v]` → `(index $item 0)`).
+   *   - array-rest (`[first, ...tail]`): the PARENT `segments` prefix wrapped in
+   *     `bf_slice` (`tail` → `(bf_slice $item 1)`) — this IS the binding's whole
+   *     value, so it composes correctly both bare and under `.length` (`len
+   *     (bf_slice $item 1)`, via the `member()` emitter's generic `len <obj>`
+   *     arm).
+   *   - object-rest (`{ id, ...rest }`): the bare PARENT accessor, so a member
+   *     read (`rest.flag`) renders `$item.Flag` — the simplest lowering that
+   *     keeps the already-green `rest-destructure-object-in-map` fixture byte-
+   *     exact. A `{...rest}` SPREAD needs the residual (item minus the
+   *     destructured siblings), which this map alone can't express; that case
+   *     is tracked separately in the returned `restExcludes` map and consumed
+   *     by `emitSpread`'s `bf_omit` lowering, not through this binding value.
+   */
+  private buildDestructureBindingMap(
+    loop: IRLoop,
+    rangeVar: string,
+  ): {
+    bindings: Map<string, string>
+    restExcludes: Map<string, { parent: string; excludeKeys: string[] }>
+  } {
+    const bindings = new Map<string, string>()
+    const restExcludes = new Map<string, { parent: string; excludeKeys: string[] }>()
+    const base = `$${rangeVar}`
     for (const b of loop.paramBindings ?? []) {
-      if (b.rest) {
-        m.set(b.name, `$${rangeVar}`)
+      const parent = this.buildSegmentAccessor(base, b.segments ?? [])
+      if (!b.rest) {
+        bindings.set(b.name, parent)
+      } else if (b.rest.kind === 'array') {
+        bindings.set(b.name, `(bf_slice ${parent} ${b.rest.from})`)
       } else {
-        m.set(b.name, `$${rangeVar}.${capitalizeFieldName(b.path.slice(1))}`)
+        bindings.set(b.name, parent)
+        restExcludes.set(b.name, { parent, excludeKeys: b.rest.exclude.map(k => k.key) })
       }
     }
-    return m
+    return { bindings, restExcludes }
+  }
+
+  /** Innermost-first lookup mirroring `loopBindingStack`'s search in
+   * `identifier()`, but over the object-rest exclude-key side table. */
+  private lookupRestExclude(name: string): { parent: string; excludeKeys: string[] } | undefined {
+    for (let i = this.loopRestExcludeStack.length - 1; i >= 0; i--) {
+      const info = this.loopRestExcludeStack[i].get(name)
+      if (info) return info
+    }
+    return undefined
   }
 
   renderLoop(loop: IRLoop): string {
@@ -4446,15 +4528,17 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     //
     // Check the IR's structured `paramBindings` field rather than string-matching
     // `loop.param`: Phase 1 populates it iff the param is a destructure pattern,
-    // and the structured check is robust to formatting variants. A destructure
-    // param is lowerable only for the object-rest / simple-field shape
-    // (`.map(({ id, title, ...rest }) => …)`, `rest` read via member access):
-    // each binding resolves to a field on a named range var (`$__bf_item0.Id`,
-    // `rest.flag` → `$__bf_item0.Flag`). Array-index / nested / rest-spread
-    // shapes (`[a, ...t]`, `{ cells: [h] }`, `{...rest}`) still need machinery
-    // Go's `{{range}}` can't express inline → BF104.
+    // and the structured check is robust to formatting variants. `isLowerableLoopDestructure`
+    // (#2087 Phase A/B) admits fixed bindings at ANY depth (`.field`, array-index,
+    // nested combinations of either — `buildSegmentAccessor` walks the structured
+    // `segments` path), array-rest (`[a, ...t]` → `bf_slice`), and object-rest
+    // whose every use is a member read (`rest.flag`) or a `{...rest}` spread onto
+    // an intrinsic element (→ `bf_omit`, see `emitSpread`). Still refused (BF104):
+    // a bare-value object-rest use (`String(rest)`, `{rest}`, spread onto a
+    // component), and a `.filter().map(destructure)` chain — those need either the
+    // actual residual object or a filter-param retarget this lowering doesn't do.
     const destructure = !!(loop.paramBindings && loop.paramBindings.length > 0)
-    const supportableDestructure = destructure && isLowerableObjectRestDestructure(loop)
+    const supportableDestructure = destructure && isLowerableLoopDestructure(loop)
     if (destructure && !supportableDestructure) {
       this.state.errors.push({
         code: 'BF104',
@@ -4469,6 +4553,42 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
             `  3. Move the loop into a primitive that the adapter registers explicitly.`,
         },
       })
+    }
+
+    // A loop array that's a bare reference to a FUNCTION-SCOPE local const with
+    // a computed initializer (`const entries = Object.entries(props.x ??
+    // {}).filter(...)`) can't be bound as a Go template value: module-scope
+    // consts (`isModule`) are a different, already-working case (statically
+    // evaluated and seeded into the render context elsewhere), but a
+    // function-scope local only reaches the template at all via
+    // `computeDerivedConstFields`'s STRING-typed derived-const lowering
+    // (`isStringExpr`) — an array-typed initializer like this one never
+    // qualifies, so `identifier()` would still emit `.Entries` (the naive
+    // `rootFieldRef` fallback) while `generateTypes` emits no such field.
+    // `html/template` resolves struct fields dynamically at EXECUTE time, not
+    // at Go compile time, so left unchecked this fails loudly only when the
+    // template actually runs (`can't evaluate field Entries in type
+    // ...Props`) instead of at build time. Pre-existing, general limitation,
+    // orthogonal to #2087's destructure-binding work — newly reachable in this
+    // adapter's test corpus only because the widened destructure gate (#2087
+    // Phase A/B) no longer refuses `static-array-from-props`'s `([emoji,
+    // users]) => ...` param first. Cross-adapter policy: Jinja / ERB apply the
+    // same narrow check in their own `renderLoop` (see `jinja-adapter.ts`).
+    const arrayName = loop.array.trim()
+    if (/^[A-Za-z_$][\w$]*$/.test(arrayName)) {
+      const arrayConst = this.state.localConstants.find(c => c.name === arrayName)
+      if (arrayConst && !arrayConst.isModule && arrayConst.parsed && !this.isStringExpr(arrayConst.parsed, new Set())) {
+        this.state.errors.push({
+          code: 'BF101',
+          severity: 'error',
+          message: `Loop array \`${arrayName}\` is a local computed value (\`${arrayConst.value}\`) that the Go template adapter cannot bind as a template variable — only a string-derived local resolves to a generated struct field.`,
+          loc: loop.loc ?? this.makeLoc(),
+          suggestion: {
+            message:
+              'Pre-compute the array server-side and pass it as a prop, or mark the loop position as @client-only so it runs in JS on the client.',
+          },
+        })
+      }
     }
 
     let goArray = this.convertExpressionToGo(loop.array)
@@ -4513,7 +4633,9 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     if (supportableDestructure) {
       // Bindings resolve against the synthetic `$__bf_item` range var; don't push
       // a loop param (the param is a pattern, not a name).
-      this.loopBindingStack.push(this.buildDestructureBindingMap(loop, rangeValue))
+      const built = this.buildDestructureBindingMap(loop, rangeValue)
+      this.loopBindingStack.push(built.bindings)
+      this.loopRestExcludeStack.push(built.restExcludes)
       pushedBindingMap = true
       this.loopParamStack.push('')
       if (rangeIndex !== '_') {
@@ -4551,7 +4673,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       else this.loopVarRefCount.set(v, rc)
     }
     this.loopParamStack.pop()
-    if (pushedBindingMap) this.loopBindingStack.pop()
+    if (pushedBindingMap) {
+      this.loopBindingStack.pop()
+      this.loopRestExcludeStack.pop()
+    }
     this.inLoop = false
 
     // Apply sort if present: wrap the array in a sort pipeline before `range`.
@@ -4896,15 +5021,29 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         // Property access through the loop param (`t.attrs`) is already handled
         // by the member-expression path that returns `.Attrs`.
         //
-        // The emit path is wired up but end-to-end fixture coverage is gated on
-        // two harness gaps: (a) `buildGoPropsInit` in `test-render.ts` can't pass
-        // nested-object arrays from JS into the Go input struct, and (b)
-        // `convertInitialValue` returns `nil` for complex literal arrays so
-        // signal-init arrays of objects don't reach the SSR template.
+        // A per-item spread whose operand is a plain object/array field read
+        // (not a destructure-rest binding) is otherwise gated on whether the
+        // enclosing signal's literal initial value bakes at all — see
+        // `parsed-literal-to-go.ts`'s nested object/array property support
+        // (#2087), which lifted the flat-object-only restriction for the
+        // destructure-residual fixtures below.
         const trimmed = value.expr.trim()
         const currentLoopParam = this.loopParamStack[this.loopParamStack.length - 1]
         if (currentLoopParam && trimmed === currentLoopParam) {
           return `{{bf_spread_attrs .}}`
+        }
+        // Destructure object-rest spread onto an element (`{...rest}`, #2087
+        // Phase B): `rest` alone would spread the WHOLE item (every field,
+        // including the ones the pattern already destructured out as `id` /
+        // `title`) — route through `bf_omit` instead so the residual excludes
+        // exactly those sibling keys. Only a spread whose expr is the BARE
+        // rest name matches (`isLowerableLoopDestructure`'s admitted shape);
+        // anything else (`{...fn(rest)}`) already refused at the IR gate.
+        const restInfo = this.lookupRestExclude(trimmed)
+        if (restInfo) {
+          const excludeArgs = restInfo.excludeKeys.map(k => JSON.stringify(k)).join(' ')
+          const omitArgs = excludeArgs ? `${restInfo.parent} ${excludeArgs}` : restInfo.parent
+          return `{{bf_spread_attrs (bf_omit ${omitArgs})}}`
         }
         const goExpr = this.convertExpressionToGo(value.expr)
         // `convertExpressionToGo` already pushes BF101 for unsupported

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -2870,10 +2870,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     if (objHO && (objHO.method === 'find' || objHO.method === 'findLast')) {
       const findResult = this.renderHigherOrderExpr(objHO, emit)
       if (findResult) {
-        return `{{with ${findResult}}}{{.${capitalizeFieldName(property)}}}{{end}}`
+        return `{{with ${findResult}}}{{.${goFieldNameForKey(property)}}}{{end}}`
       }
       const templateBlock = this.renderFindTemplateBlock(
-        objHO, emit, capitalizeFieldName(property),
+        objHO, emit, goFieldNameForKey(property),
       )
       if (templateBlock) return templateBlock
     }
@@ -2898,14 +2898,22 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
     // Inside a loop, the loop param variable refers to the current item
     // (dot). e.g. `msg.role` inside `{{range $_, $msg := .Messages}}` → `.Role`
+    //
+    // Field names route through `goFieldNameForKey` — the same sanitizer the
+    // struct/map bake side uses — NOT bare `capitalizeFieldName`: a
+    // non-identifier property (`meta["data-x"]`, parsed as computed member
+    // access) would otherwise emit `.Data-x`, which is not even valid Go
+    // template syntax, let alone a reachable field (PR #2089 review). For
+    // identifier keys (snake_case included) the two functions agree, so
+    // nothing previously reachable changes shape.
     const currentLoopParam = this.loopParamStack[this.loopParamStack.length - 1]
     if (object.kind === 'identifier' && currentLoopParam && object.name === currentLoopParam) {
-      return `.${capitalizeFieldName(property)}`
+      return `.${goFieldNameForKey(property)}`
     }
 
     const obj = emit(object)
     if (property === 'length') return `len ${obj}`
-    return `${obj}.${capitalizeFieldName(property)}`
+    return `${obj}.${goFieldNameForKey(property)}`
   }
 
   indexAccess(object: ParsedExpr, index: ParsedExpr, emit: (e: ParsedExpr) => string): string {

--- a/packages/adapter-go-template/src/adapter/lib/go-naming.ts
+++ b/packages/adapter-go-template/src/adapter/lib/go-naming.ts
@@ -52,24 +52,30 @@ export function capitalizeFieldName(name: string): string {
 /**
  * Resolve ANY source property key — identifier or not (`data-priority`,
  * `aria-label`, a numeric key) — to a valid Go struct field name. Splits on
- * runs of non-alphanumeric characters and PascalCases each segment through
- * `capitalizeFieldName`, so a plain identifier key round-trips to the exact
- * same name `capitalizeFieldName` alone would produce (single segment, no
- * separator) while a hyphenated key gets a real field instead of being
- * silently dropped (`data-priority` → `DataPriority`). Falls back to
- * `Field` for a key with no alphanumeric characters at all (not expected
- * from real TS property names, but keeps the function total).
+ * runs of characters that are invalid in a Go identifier (underscores are
+ * VALID and preserved, so a snake_case key round-trips to the exact same
+ * name `capitalizeFieldName` alone has always produced — `foo_bar` →
+ * `Foo_bar`, never `FooBar`; renaming it would break both existing member
+ * emission and consumers' hand-written constructors against generated
+ * types) and PascalCases each segment through `capitalizeFieldName`, so a
+ * hyphenated key gets a real field instead of being silently dropped
+ * (`data-priority` → `DataPriority`). A result that would start with a
+ * digit (numeric key `0`) is prefixed with `Field` (`Field0`), and a key
+ * with no usable characters at all falls back to `Field` — both keep the
+ * emitted struct compiling (not expected from real TS property names, but
+ * keeps the function total).
  *
- * Used for struct-field generation (#2087 Phase B — `structFieldsFor`) so a
- * TS object type with a quoted non-identifier key (`'data-priority':
- * string`) still gets a real field the destructure-rest lowering can bake
- * into and read back, instead of the value being silently deferred out of
- * the baked literal.
+ * Single source of truth for the source-key → Go-name mapping: used for
+ * struct-field generation (#2087 Phase B — `structFieldsFor`), inline-map
+ * baking (`bakeInlineObjectAsGoMap`), and the `member()` dot-access
+ * emitter, so the baked side and the accessor side can never disagree
+ * (PR #2089 review).
  */
 export function goFieldNameForKey(key: string): string {
-  const parts = key.split(/[^A-Za-z0-9]+/).filter(Boolean)
+  const parts = key.split(/[^A-Za-z0-9_]+/).filter(Boolean)
   if (parts.length === 0) return 'Field'
-  return parts.map(capitalizeFieldName).join('')
+  const name = parts.map(capitalizeFieldName).join('')
+  return /^[0-9]/.test(name) ? `Field${name}` : name
 }
 
 /**

--- a/packages/adapter-go-template/src/adapter/lib/go-naming.ts
+++ b/packages/adapter-go-template/src/adapter/lib/go-naming.ts
@@ -50,6 +50,29 @@ export function capitalizeFieldName(name: string): string {
 }
 
 /**
+ * Resolve ANY source property key — identifier or not (`data-priority`,
+ * `aria-label`, a numeric key) — to a valid Go struct field name. Splits on
+ * runs of non-alphanumeric characters and PascalCases each segment through
+ * `capitalizeFieldName`, so a plain identifier key round-trips to the exact
+ * same name `capitalizeFieldName` alone would produce (single segment, no
+ * separator) while a hyphenated key gets a real field instead of being
+ * silently dropped (`data-priority` → `DataPriority`). Falls back to
+ * `Field` for a key with no alphanumeric characters at all (not expected
+ * from real TS property names, but keeps the function total).
+ *
+ * Used for struct-field generation (#2087 Phase B — `structFieldsFor`) so a
+ * TS object type with a quoted non-identifier key (`'data-priority':
+ * string`) still gets a real field the destructure-rest lowering can bake
+ * into and read back, instead of the value being silently deferred out of
+ * the baked literal.
+ */
+export function goFieldNameForKey(key: string): string {
+  const parts = key.split(/[^A-Za-z0-9]+/).filter(Boolean)
+  if (parts.length === 0) return 'Field'
+  return parts.map(capitalizeFieldName).join('')
+}
+
+/**
  * Convert a slot ID (e.g., 's6') to a Go struct field suffix (e.g., 'Slot6').
  * Keeps field names human-readable regardless of the internal slot ID format.
  */

--- a/packages/adapter-go-template/src/adapter/type/type-codegen.ts
+++ b/packages/adapter-go-template/src/adapter/type/type-codegen.ts
@@ -4,7 +4,11 @@
  * Free functions over a {@link GoEmitContext}. They resolve a prop/signal/const's
  * type (`TypeInfo`, a raw type string, or — as a last resort — an inferred shape
  * from a literal value) into the Go type used for its struct field. They read
- * only `state.localTypeNames`; `inferTypeFromValue` is fully pure.
+ * `state.localStructFields` / `state.localTypeAliases` (an ACTUAL Go-backed
+ * local type — a generated struct or a string-union alias) rather than the
+ * broader `state.localTypeNames` (every type definition, including a tuple
+ * alias no struct was ever emitted for — #2087); `inferTypeFromValue` is fully
+ * pure.
  */
 
 import type { TypeInfo } from '@barefootjs/jsx'
@@ -42,7 +46,19 @@ export function typeInfoToGo(
     case 'object':
       return 'map[string]interface{}'
     case 'interface':
-      if (typeInfo.raw && ctx.state.localTypeNames.has(typeInfo.raw)) {
+      // Gate on an ACTUAL backing (a generated struct — `localStructFields` —
+      // or a string-union alias — `localTypeAliases`, which emits `type X =
+      // string`), not mere presence in `localTypeNames`: the latter registers
+      // EVERY type definition unconditionally (#2087), including a tuple alias
+      // (`type Row = readonly [string, string]`) that `typeDefinitionToGo`
+      // can't turn into a struct (no object properties) and so never actually
+      // emits. Returning the bare name for one of those would reference an
+      // undeclared Go type (`[]Row`) and fail to compile — fall through to the
+      // generic-array/interface{} handling below instead, so a tuple-typed
+      // signal bakes as `[]interface{}` (each item itself an `interface{}`
+      // holding a `[]interface{}`) and the destructure `index`/`bf_slice`
+      // lowering still works via reflection regardless of the static type.
+      if (typeInfo.raw && (ctx.state.localStructFields.has(typeInfo.raw) || ctx.state.localTypeAliases.has(typeInfo.raw))) {
         return typeInfo.raw
       }
       // Resolve a raw type string pattern (e.g. `Array<Todo>`).
@@ -76,7 +92,10 @@ export function tsTypeStringToGo(ctx: GoEmitContext, tsType: string): string {
   }
   const arrayMatch = t.match(/^Array<(.+)>$/)
   if (arrayMatch) return `[]${tsTypeStringToGo(ctx, arrayMatch[1])}`
-  if (ctx.state.localTypeNames.has(t)) return t
+  // Same backing gate as `typeInfoToGo`'s 'interface' case above — an
+  // unbacked local type name (a tuple alias with no struct fields) must not
+  // be returned bare, or the generated code references an undeclared type.
+  if (ctx.state.localStructFields.has(t) || ctx.state.localTypeAliases.has(t)) return t
   return 'interface{}'
 }
 

--- a/packages/adapter-go-template/src/adapter/value/parsed-literal-to-go.ts
+++ b/packages/adapter-go-template/src/adapter/value/parsed-literal-to-go.ts
@@ -3,19 +3,69 @@
  * for baking a signal's inline initial value into the SSR data context.
  *
  * Covers scalar literals, a unary-minus number, arrays of those, and object
- * literals baked against a concrete local struct.
+ * literals baked against a concrete local struct — including, per #2087, a
+ * struct property whose OWN value is a nested array or object literal
+ * (`{ id, cells: ['a', 'b'] }`, `{ id, user: { name: 'Ada' } }`): the struct's
+ * declared property TYPE (looked up from `ctx.state.currentTypeDefinitions`)
+ * threads through so a typed nested array bakes via the normal array branch
+ * below, and a nested INLINE object (one with no named Go struct —
+ * `typeInfoToGo`'s `'object'` case always falls back to
+ * `map[string]interface{}`) bakes as a capitalized-key Go map literal instead
+ * — the same convention `test-render.ts`'s harness-prop baking already uses
+ * for object elements, since `html/template`'s map field access is an exact
+ * case-sensitive `MapIndex`.
  *
  * Contract is **null-means-defer**: returns null for anything not reproduced
  * exactly — an object whose target type isn't a known struct, a key the struct
- * doesn't declare, a nested object/array property value, an empty array, an
- * identifier/call, or a numeric literal missing its `raw` token. The caller
- * then keeps `nil`.
+ * doesn't declare, an empty array, an identifier/call, or a numeric literal
+ * missing its `raw` token. The caller then keeps `nil`.
  */
 
-import type { ParsedExpr, TypeInfo } from '@barefootjs/jsx'
+import type { ParsedExpr, TypeDefinition, TypeInfo } from '@barefootjs/jsx'
 
 import type { GoEmitContext } from '../emit-context.ts'
+import { capitalizeFieldName } from '../lib/go-naming.ts'
 import { typeInfoToGo } from '../type/type-codegen.ts'
+
+/**
+ * Look up a struct property's declared `TypeInfo` by source key, from the
+ * user's own `TypeDefinition` (not a synthesized struct — those only arise
+ * from an UNTYPED literal, which never carries nested object/array elements
+ * because `synthesizeStructFromSignal` requires every property value to be a
+ * scalar literal). Returns undefined when the struct name isn't a user type
+ * or the key isn't declared — callers treat that as "nested type unknown"
+ * and fall back to the generic/inline lowering.
+ */
+function structPropertyType(ctx: GoEmitContext, structGoType: string, key: string): TypeInfo | undefined {
+  const td = ctx.state.currentTypeDefinitions.find((t: TypeDefinition) => t.name === structGoType)
+  return td?.properties?.find(p => p.name === key)?.type
+}
+
+/**
+ * Bake a nested INLINE object-literal property value — one whose declared
+ * type has no named Go struct (`user: { name: string }` lowers its field to
+ * `map[string]interface{}`, not a struct) — as a Go map literal with
+ * CAPITALIZED keys, recursing for further nesting. `html/template`'s dot
+ * access on a map value does an exact-string `MapIndex`, so a template
+ * action like `.User.Name` only resolves when the baked key is literally
+ * `"Name"`, not the source-cased `"name"` — mirrors the same convention
+ * `test-render.ts`'s `goArrayLiteralFromArray` uses for object elements
+ * passed as harness props.
+ */
+function bakeInlineObjectAsGoMap(ctx: GoEmitContext, expr: ParsedExpr): string | null {
+  if (expr.kind !== 'object-literal') return null
+  const entries: string[] = []
+  for (const prop of expr.properties) {
+    if (prop.shorthand) return null
+    const go =
+      prop.value.kind === 'object-literal'
+        ? bakeInlineObjectAsGoMap(ctx, prop.value)
+        : parsedLiteralToGo(ctx, prop.value)
+    if (go === null) return null
+    entries.push(`${JSON.stringify(capitalizeFieldName(prop.key))}: ${go}`)
+  }
+  return `map[string]interface{}{${entries.join(', ')}}`
+}
 
 export function parsedLiteralToGo(
   ctx: GoEmitContext,
@@ -79,10 +129,26 @@ export function parsedLiteralToGo(
       // and defers the whole object.
       const goField = structFields.get(prop.key)
       if (!goField) return null
-      // Nested object/array property values aren't baked here (field types
-      // untracked) — defer.
-      if (prop.value.kind === 'object-literal' || prop.value.kind === 'array-literal') return null
-      const go = parsedLiteralToGo(ctx, prop.value)
+      const propType = structPropertyType(ctx, goType, prop.key)
+      let go: string | null
+      if (prop.value.kind === 'array-literal') {
+        // A nested array property (`cells: readonly string[]`, #2087):
+        // thread the struct's own declared property type through so the
+        // array branch below bakes a properly-typed slice (`[]string{…}`)
+        // instead of deferring.
+        go = parsedLiteralToGo(ctx, prop.value, propType)
+      } else if (prop.value.kind === 'object-literal') {
+        // A nested object property (`user: { name: string }`, #2087): bake
+        // against a named struct if the declared type resolves to one,
+        // else fall back to the capitalized-key inline-map convention.
+        const nestedGoType = propType ? typeInfoToGo(ctx, propType) : undefined
+        go =
+          nestedGoType && ctx.state.localStructFields.has(nestedGoType)
+            ? parsedLiteralToGo(ctx, prop.value, propType)
+            : bakeInlineObjectAsGoMap(ctx, prop.value)
+      } else {
+        go = parsedLiteralToGo(ctx, prop.value)
+      }
       if (go === null) return null
       entries.push(`${goField}: ${go}`)
     }

--- a/packages/adapter-go-template/src/adapter/value/parsed-literal-to-go.ts
+++ b/packages/adapter-go-template/src/adapter/value/parsed-literal-to-go.ts
@@ -24,7 +24,7 @@
 import type { ParsedExpr, TypeDefinition, TypeInfo } from '@barefootjs/jsx'
 
 import type { GoEmitContext } from '../emit-context.ts'
-import { capitalizeFieldName } from '../lib/go-naming.ts'
+import { goFieldNameForKey } from '../lib/go-naming.ts'
 import { typeInfoToGo } from '../type/type-codegen.ts'
 
 /**
@@ -51,6 +51,13 @@ function structPropertyType(ctx: GoEmitContext, structGoType: string, key: strin
  * `"Name"`, not the source-cased `"name"` — mirrors the same convention
  * `test-render.ts`'s `goArrayLiteralFromArray` uses for object elements
  * passed as harness props.
+ *
+ * Keys are sanitized with `goFieldNameForKey` — the SAME function the
+ * accessor side (`buildSegmentAccessor` / `structFieldsFor`) uses — so a
+ * non-identifier key (`'data-x'`) bakes as `"DataX"` and dot access
+ * `.Meta.DataX` finds it. `capitalizeFieldName` alone would bake
+ * `"Data-x"`, a key no emitted accessor can ever reach (Copilot review,
+ * PR #2089).
  */
 function bakeInlineObjectAsGoMap(ctx: GoEmitContext, expr: ParsedExpr): string | null {
   if (expr.kind !== 'object-literal') return null
@@ -62,7 +69,7 @@ function bakeInlineObjectAsGoMap(ctx: GoEmitContext, expr: ParsedExpr): string |
         ? bakeInlineObjectAsGoMap(ctx, prop.value)
         : parsedLiteralToGo(ctx, prop.value)
     if (go === null) return null
-    entries.push(`${JSON.stringify(capitalizeFieldName(prop.key))}: ${go}`)
+    entries.push(`${JSON.stringify(goFieldNameForKey(prop.key))}: ${go}`)
   }
   return `map[string]interface{}{${entries.join(', ')}}`
 }

--- a/packages/adapter-jinja/python/barefootjs/runtime.py
+++ b/packages/adapter-jinja/python/barefootjs/runtime.py
@@ -1191,6 +1191,25 @@ class BarefootJS:
         return self.backend.mark_raw(" ".join(parts))
 
     # -----------------------------------------------------------------
+    # Loop-destructure object-rest residual object (#2087 Phase B)
+    # -----------------------------------------------------------------
+
+    def omit(self, recv: Any, keys: Any) -> dict:
+        """Shallow copy of `recv` with `keys` removed -- the TRUE residual
+        dict for an object-rest `.map()` callback binding
+        (`{ id, title, ...rest }` -> `{% set rest = bf.omit(item, ['id',
+        'title']) %}`), so `rest.flag` member reads and
+        `bf.spread_attrs(rest)` (forwarding `{...rest}` onto an element)
+        both see exactly the sibling keys NOT already destructured -- never
+        the whole item. Mirrors `spread_attrs`'s defensive non-dict
+        handling: a non-dict `recv` yields `{}` rather than raising.
+        """
+        if not isinstance(recv, dict):
+            return {}
+        exclude = set(keys) if keys else set()
+        return {k: v for k, v in recv.items() if k not in exclude}
+
+    # -----------------------------------------------------------------
     # Evaluator-driven sort / reduce / higher-order predicates (#2018):
     # the comparator / reducer / predicate body rides as a
     # serialized-ParsedExpr JSON string and is evaluated per element,

--- a/packages/adapter-jinja/python/tests/test_omit.py
+++ b/packages/adapter-jinja/python/tests/test_omit.py
@@ -1,0 +1,62 @@
+"""`BarefootJS.omit` -- the object-rest `.map()` destructure residual-object
+helper (#2087 Phase B). Companion to `test_spread_attrs.py`: `omit` builds
+the TRUE residual dict (`{ id, title, ...rest }` -> `bf.omit(item, ['id',
+'title'])`) that `rest.flag` member reads and `bf.spread_attrs(rest)`
+forwarding both read from.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from barefootjs import BarefootJS
+
+
+class _PureBackend:
+    def mark_raw(self, s):
+        return s
+
+
+def run(recv, keys):
+    bf = BarefootJS(None, {"backend": _PureBackend()})
+    return bf.omit(recv, keys)
+
+
+class OmitTest(unittest.TestCase):
+    def test_basic_shape(self):
+        self.assertEqual(
+            run({"id": "t1", "title": "one", "flag": "a"}, ["id", "title"]),
+            {"flag": "a"},
+        )
+
+    def test_no_keys_excluded(self):
+        self.assertEqual(run({"a": 1, "b": 2}, []), {"a": 1, "b": 2})
+
+    def test_all_keys_excluded(self):
+        self.assertEqual(run({"a": 1, "b": 2}, ["a", "b"]), {})
+
+    def test_non_identifier_key(self):
+        # The rest-spread fixture's residual carries a non-identifier
+        # sibling key (`data-priority`) through untouched.
+        self.assertEqual(
+            run(
+                {"id": "t1", "title": "one", "data-priority": "high", "tag": "urgent"},
+                ["id", "title"],
+            ),
+            {"data-priority": "high", "tag": "urgent"},
+        )
+
+    def test_non_dict_input(self):
+        self.assertEqual(run(None, ["id"]), {})
+        self.assertEqual(run("not a dict", ["id"]), {})
+        self.assertEqual(run([1, 2, 3], ["id"]), {})
+
+    def test_key_not_present_is_noop(self):
+        self.assertEqual(run({"a": 1}, ["missing"]), {"a": 1})
+
+    def test_empty_keys_arg(self):
+        self.assertEqual(run({"a": 1}, None), {"a": 1})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/adapter-jinja/src/__tests__/jinja-adapter.test.ts
+++ b/packages/adapter-jinja/src/__tests__/jinja-adapter.test.ts
@@ -35,25 +35,45 @@ runAdapterConformanceTests({
     // `.map`) as xslate.
     'todo-app': [{ code: 'BF103', severity: 'error' }],
     'todo-app-ssr': [{ code: 'BF103', severity: 'error' }],
-    // Array-destructure loop param (`([k, v]) => …`) can't lower to a
-    // single Jinja `for` loop variable (same BF104 as xslate — Jinja's
-    // `for item in list` binds one loop variable, just like Kolon's
-    // `for $arr -> $item`).
-    'static-array-from-props': [{ code: 'BF104', severity: 'error' }],
-    // Both BF103 (imported child) and BF104 (destructure) fire.
+    // #2087 Phase A/B widened the destructure gate (`isLowerableLoopDestructure`)
+    // to admit array-index / nested-path fixed bindings, so the
+    // `([emoji, users]) => ...` / `([id, t]) => ...` params in these two
+    // fixtures no longer trip BF104 — the destructure itself now lowers
+    // cleanly to a native `{% set %}` accessor. But both fixtures' loop
+    // array is `entries`, a bare identifier bound to a function-scope local
+    // const with a NON-inlineable initializer
+    // (`Object.entries(props.x ?? {}).filter(...)`) — a pre-existing,
+    // orthogonal limitation this adapter has always had (it only ever
+    // INLINES a local const's value at its use site — numeric/string
+    // literal, or a static-record-literal lookup — never binds one as a
+    // `{% set %}` template local), just never reachable before because the
+    // narrower pre-#2087 gate refused the destructure param first. Left
+    // unhandled it would silently render an EMPTY list (Jinja's
+    // `ChainableUndefined` tolerates iterating an unbound name as zero
+    // iterations) instead of failing loudly, so `renderLoop` in
+    // `jinja-adapter.ts` now detects this shape and raises BF101 instead —
+    // see the "Loop array `<name>` is a local computed value" diagnostic.
+    // Fixing the underlying gap (computed-array-from-props as a loop
+    // source) is out of scope for #2087; tracked as a follow-up at
+    // https://github.com/piconic-ai/barefootjs/issues/2087.
+    'static-array-from-props': [{ code: 'BF101', severity: 'error' }],
+    // Both BF103 (imported child) and BF101 (unresolvable computed loop
+    // array, see above) fire.
     'static-array-from-props-with-component': [
       { code: 'BF103', severity: 'error' },
-      { code: 'BF104', severity: 'error' },
+      { code: 'BF101', severity: 'error' },
     ],
-    // Rest-destructure `.map()` callbacks — the object-rest shape read via
-    // member access (`rest-destructure-object-in-map`) lowers via a Jinja
-    // `{% set %}` local binding (same mechanism as Kolon's `: my`). The
-    // other three stay refused: rest SPREAD needs a residual object,
-    // array-index / nested paths can't unpack a tuple (same surface as
-    // xslate).
-    'rest-destructure-object-spread-in-map': [{ code: 'BF104', severity: 'error' }],
-    'rest-destructure-array-in-map': [{ code: 'BF104', severity: 'error' }],
-    'rest-destructure-nested-in-map': [{ code: 'BF104', severity: 'error' }],
+    // Rest-destructure / structured-path `.map()` callbacks (#2087 Phase B):
+    // `isLowerableLoopDestructure` now admits fixed bindings at any
+    // field/index depth, array-rest (`bf.slice`), and object-rest whose uses
+    // are member reads or a `{...rest}` spread onto an intrinsic element
+    // (`bf.omit` builds the TRUE residual dict). Each binding becomes a
+    // native `{% set %}` local off the per-item var — see
+    // `renderLoop`/`jinjaAccessorFromSegments` in `jinja-adapter.ts`. So
+    // `rest-destructure-object-in-map`, `rest-destructure-object-spread-in-map`,
+    // `rest-destructure-array-in-map`, `rest-destructure-nested-in-map`,
+    // `destructure-array-index-in-map`, and `destructure-nested-object-in-map`
+    // all render clean now — none of them are pinned here.
     // The site/ui Button auto-infers a `<Slot>` sibling that spreads
     // `{...props}` / `{...children.props}` onto its root element. Jinja
     // dict literals can't splat a runtime dict into named call-site

--- a/packages/adapter-jinja/src/adapter/jinja-adapter.ts
+++ b/packages/adapter-jinja/src/adapter/jinja-adapter.ts
@@ -132,7 +132,7 @@ import {
   collectModuleStringConsts,
   extractArrowBodyExpression,
   collectContextConsumers,
-  isLowerableObjectRestDestructure,
+  isLowerableLoopDestructure,
   type ContextConsumer,
   lookupStaticRecordLiteral,
   searchParamsLocalNames,
@@ -146,7 +146,12 @@ import { BF_SLOT, BF_COND, BF_REGION } from '@barefootjs/shared'
 
 import type { JinjaRenderCtx } from './lib/types.ts'
 import { JINJA_PRIMITIVE_EMIT_MAP } from './lib/constants.ts'
-import { jinjaHashKey, jinjaIdent, escapeJinjaSingleQuoted } from './lib/jinja-naming.ts'
+import {
+  jinjaHashKey,
+  jinjaIdent,
+  escapeJinjaSingleQuoted,
+  jinjaAccessorFromSegments,
+} from './lib/jinja-naming.ts'
 import {
   resolveJsxChildrenProp,
   collectRootScopeNodes,
@@ -643,32 +648,78 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
       return `{{ bf.comment("loop:${loop.markerId}") | safe }}{{ bf.comment("/loop:${loop.markerId}") | safe }}`
     }
 
-    // An array/object-destructure loop param (`([emoji, users]) => ...` or
-    // `({ name, age }) => ...`) lowers to invalid Jinja — Jinja's `for item in
-    // list` binds a single loop variable and can't unpack a tuple the way a
-    // Python `for` statement can. Surface this at build time instead of
-    // shipping a broken template line.
-    // A destructure loop param is lowerable for the object-rest / simple-field
-    // shape (`.map(({ id, title, ...rest }) => …)`, `rest` read via member
-    // access): each binding becomes a `{% set %}` local off the per-item var,
-    // so the body's `id` / `rest.flag` resolve. Array-index / nested /
-    // rest-spread shapes still can't unpack a tuple → BF104. (#1310)
+    // Jinja's `{% for item in list %}` binds a single loop variable — it
+    // can't natively unpack a tuple the way a Python `for` statement can, so
+    // a `.map()` destructure param never lowers to a bare Jinja for-target.
+    // Instead, `isLowerableLoopDestructure` (#2087) admits any shape whose
+    // bindings resolve to a per-adapter accessor without needing the JS/CSR
+    // runtime: fixed bindings at any field/index depth (`{ id }`, `[k, v]`,
+    // `{ user: { name } }`), array-rest (`[first, ...tail]`), and
+    // object-rest whose every use is a member read (`rest.flag`) or a
+    // `{...rest}` spread onto an intrinsic element. Each admitted binding
+    // becomes a `{% set %}` local off the per-item var (a native accessor
+    // for fixed bindings, `bf.slice`/`bf.omit` for rest), so the body's
+    // `id` / `v` / `name` / `rest.flag` all resolve. Still refused (BF104):
+    // a bare-value rest use (`String(rest)`, `{rest}` as text, `{...fn(rest)}`),
+    // a rest spread onto a component/provider, `.filter().map(destructure)`,
+    // and `__bf_`-prefixed binding names (would collide with the synthetic
+    // per-item var).
     const destructure = !!(loop.paramBindings && loop.paramBindings.length > 0)
-    const supportableDestructure = destructure && isLowerableObjectRestDestructure(loop)
+    const supportableDestructure = destructure && isLowerableLoopDestructure(loop)
     if (destructure && !supportableDestructure) {
       this.errors.push({
         code: 'BF104',
         severity: 'error',
-        message: `Loop callback uses an array/object destructure pattern (\`${loop.param}\`) that the Jinja adapter cannot lower — Jinja \`for item in list\` binds a single loop variable and can't unpack a tuple.`,
+        message: `Loop callback uses a destructure pattern (\`${loop.param}\`) that the Jinja adapter cannot lower to a native accessor — Jinja \`for item in list\` binds a single loop variable and this shape needs the actual residual value materialized (e.g. a bare object-rest use, or a rest spread onto a component).`,
         loc: loop.loc ?? { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
         suggestion: {
           message:
             `Options:\n` +
-            `  1. Rename the parameter to a single name and access tuple elements with index syntax in the body (e.g. \`entry => entry[0]\` instead of \`([k, v]) => ...\`).\n` +
-            `  2. Mark the loop position as @client-only so the destructure runs in JS on the client.\n` +
-            `  3. Move the loop into a primitive that the adapter registers explicitly.`,
+            `  1. Rename the parameter to a single name and access tuple/object elements directly in the body (e.g. \`entry => entry[0]\` instead of \`([k, v]) => ...\`).\n` +
+            `  2. If using object rest, only read individual fields off it (\`rest.flag\`) or spread it onto an intrinsic element (\`{...rest}\`) — not as a bare value.\n` +
+            `  3. Mark the loop position as @client-only so the destructure runs in JS on the client.\n` +
+            `  4. Move the loop into a primitive that the adapter registers explicitly.`,
         },
       })
+    }
+
+    // A `.map()` loop whose array is a bare identifier bound to a
+    // FUNCTION-scope local const with a non-statically-evaluable initializer
+    // that reads props/signals (e.g. `const entries =
+    // Object.entries(props.x ?? {}).filter(...)`) can't render correctly.
+    // Module-scope consts (`isModule`, e.g. `const payments = [...]` at the
+    // top of the file) are a DIFFERENT, already-working case — the shared
+    // `ssr-defaults.ts` statically evaluates those and seeds them straight
+    // into the render context, so a bare `payments` reference resolves for
+    // free (data-table demo). Function-scope locals get no such seeding
+    // (`ssr-defaults.ts`: "component-scope locals can depend on
+    // signals/props and are evaluated lazily elsewhere") — and this
+    // adapter's only "elsewhere" is inlining a const's value at its use
+    // site (`_resolveLiteralConst`'s numeric/single-quoted-string fast
+    // path, or a static-record-literal lookup), never binding one as a
+    // `{% set %}` template local. Left unchecked, `{% for item in entries
+    // %}` over an unbound name would silently iterate zero times (Jinja's
+    // `ChainableUndefined` tolerates it rather than raising) instead of
+    // failing loudly. Pre-existing, general limitation, orthogonal to
+    // #2087's destructure-binding work — newly reachable in this adapter's
+    // test corpus only because the widened destructure gate (#2087 Phase
+    // A/B) no longer refuses this fixture's `([emoji, users]) => ...`
+    // param first.
+    const arrayName = loop.array.trim()
+    if (/^[A-Za-z_$][\w$]*$/.test(arrayName)) {
+      const arrayConst = (this.localConstants ?? []).find(c => c.name === arrayName)
+      if (arrayConst && !arrayConst.isModule && this._resolveLiteralConst(arrayName) === null) {
+        this.errors.push({
+          code: 'BF101',
+          severity: 'error',
+          message: `Loop array \`${arrayName}\` is a local computed value (\`${arrayConst.value}\`) that the Jinja adapter cannot bind as a template variable — only numeric/string-literal locals inline at their use site.`,
+          loc: loop.loc ?? { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+          suggestion: {
+            message:
+              'Pre-compute the array server-side and pass it as a prop, or mark the loop position as @client-only so it runs in JS on the client.',
+          },
+        })
+      }
     }
 
     const rawArray = this.convertExpressionToJinja(loop.array)
@@ -709,8 +760,21 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
     // Index alias: when an explicit `index` param is present (`.map((x, i) =>
     // ...)`) or the iteration is `keys`-shaped, expose it via a `{% set %}`
     // local bound to Jinja's `loop.index0`. A supported destructure param
-    // adds one `{% set %}` local per binding (`rest` aliases the item so
-    // `rest.flag` resolves).
+    // adds one `{% set %}` local per binding, built from the binding's
+    // structured `segments` path (#2087 Phase B — never string-parse
+    // `b.path`):
+    //
+    //   - fixed binding: a native accessor walking `segments` off the
+    //     per-item var (`.field` / `[index]`, any depth).
+    //   - array-rest binding: `bf.slice(<parent accessor>, from, none)` —
+    //     the exact JS slice, so every read of the binding (including
+    //     `.length` via the shared member emitter's `bf.length` routing)
+    //     matches JS semantics with no adapter-side special-casing.
+    //   - object-rest binding: `bf.omit(<parent accessor>, [<excluded
+    //     sibling keys>])` — a TRUE residual dict (not an alias to the
+    //     whole item), so `rest.flag` member reads and the existing
+    //     `{...rest}` → `bf.spread_attrs(rest)` emit path both see only the
+    //     keys NOT already destructured.
     const indexLocalLines: string[] = []
     if (loop.iterationShape === 'keys') {
       indexLocalLines.push(`{% set ${jinjaIdent(param)} = loop.index0 %}`)
@@ -719,11 +783,19 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
     }
     if (supportableDestructure) {
       for (const b of loop.paramBindings ?? []) {
-        indexLocalLines.push(
-          b.rest
-            ? `{% set ${jinjaIdent(b.name)} = ${jinjaIdent(loopVar)} %}`
-            : `{% set ${jinjaIdent(b.name)} = ${jinjaIdent(loopVar)}${b.path} %}`,
-        )
+        const parentAccessor = jinjaAccessorFromSegments(jinjaIdent(loopVar), b.segments ?? [])
+        if (!b.rest) {
+          indexLocalLines.push(`{% set ${jinjaIdent(b.name)} = ${parentAccessor} %}`)
+        } else if (b.rest.kind === 'array') {
+          indexLocalLines.push(
+            `{% set ${jinjaIdent(b.name)} = bf.slice(${parentAccessor}, ${b.rest.from}, none) %}`,
+          )
+        } else {
+          const excludeKeys = b.rest.exclude.map(k => jinjaHashKey(k.key)).join(', ')
+          indexLocalLines.push(
+            `{% set ${jinjaIdent(b.name)} = bf.omit(${parentAccessor}, [${excludeKeys}]) %}`,
+          )
+        }
       }
     }
 

--- a/packages/adapter-jinja/src/adapter/lib/jinja-naming.ts
+++ b/packages/adapter-jinja/src/adapter/lib/jinja-naming.ts
@@ -32,6 +32,8 @@
  *    both sides.
  */
 
+import type { LoopBindingPathSegment } from '@barefootjs/jsx'
+
 /**
  * Escape a string for a Jinja/Python single-quoted literal: backslash first
  * (so it doesn't double-escape the quote we add next), then the quote.
@@ -73,4 +75,40 @@ const RESERVED_WORDS = new Set([
  */
 export function jinjaIdent(name: string): string {
   return RESERVED_WORDS.has(name) ? `${name}_` : name
+}
+
+/**
+ * Build a native Jinja accessor expression from a `.map()` destructure
+ * binding's structured {@link LoopBindingPathSegment} path (#2087 Phase B) —
+ * the per-adapter counterpart to the JS accessor suffix carried in
+ * `LoopParamBinding.path`. Walks `segments` (never string-parses `path` —
+ * repo rule) appending, per step:
+ *
+ *   - `{ kind: 'index', index }` → `[N]` (a Python list index — same postfix
+ *     Jinja uses for dict-key lookup, so this is unambiguous either way).
+ *   - `{ kind: 'field', key, isIdent: true }` → `.key` (bare attribute
+ *     access — Jinja resolves it against a dict transparently).
+ *   - `{ kind: 'field', key, isIdent: false }` → `[<quoted key>]` (e.g. a
+ *     `'data-priority'` sibling key can't be a bare Jinja attribute, same
+ *     reasoning as `jinjaHashKey` on dict-literal keys).
+ *
+ * `base` is the already-`jinjaIdent`-mangled loop variable (or a parent
+ * accessor expression when called recursively); an empty `segments` array
+ * (a rest binding sitting at the loop root) returns `base` unchanged.
+ */
+export function jinjaAccessorFromSegments(
+  base: string,
+  segments: readonly LoopBindingPathSegment[],
+): string {
+  let acc = base
+  for (const seg of segments) {
+    if (seg.kind === 'index') {
+      acc += `[${seg.index}]`
+    } else if (seg.isIdent) {
+      acc += `.${seg.key}`
+    } else {
+      acc += `[${jinjaHashKey(seg.key)}]`
+    }
+  }
+  return acc
 }

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -40,23 +40,38 @@ runAdapterConformanceTests({
     // level so the shared-component corpus stays adapter-neutral.
     'todo-app': [{ code: 'BF103', severity: 'error' }],
     'todo-app-ssr': [{ code: 'BF103', severity: 'error' }],
-    // Array-destructure loop param (`([k, v]) => ...`) lowers to
-    // invalid Perl (`% my $[k, v] = $entries->[$_i];`).
-    'static-array-from-props': [{ code: 'BF104', severity: 'error' }],
-    // Both BF103 (imported child) and BF104 (destructure) fire.
+    // `([emoji, users]) => ...` / `([id, t]) => ...` are plain array-index
+    // (tuple) destructures, no rest — #2087 Phase B's `segments`-walking
+    // accessor lowers both to `$__bf_item->[0]` / `$__bf_item->[1]` `my`
+    // locals like any other fixed binding, so BF104 no longer fires for
+    // either fixture. Each now hits a DIFFERENT, pre-existing, orthogonal
+    // gap instead: the loop array (`entries`) is a function-scope local
+    // const with a computed initializer
+    // (`Object.entries(props.x ?? {}).filter(...)`) that the adapter can't
+    // bind as a template variable — see the dedicated `arrayConst` BF101
+    // check in `renderLoop`. This was always true; it was simply
+    // unreachable before because BF104 refused the destructure shape first.
+    'static-array-from-props': [{ code: 'BF101', severity: 'error' }],
+    // Both BF103 (sibling-imported `<Tag>` child component) and the BF101
+    // above fire; BF104 no longer does (see above).
     'static-array-from-props-with-component': [
       { code: 'BF103', severity: 'error' },
-      { code: 'BF104', severity: 'error' },
+      { code: 'BF101', severity: 'error' },
     ],
-    // #1310: rest destructure in .map() callback. The object-rest shape read
-    // via member access (`rest-destructure-object-in-map`) now lowers — each
-    // binding becomes a Perl `my` local off the per-item var (`$rest` aliases
-    // the item so `$rest->{flag}` resolves). The other three stay refused:
-    // rest SPREAD (`{...rest}`) needs a residual hash, and array-index /
-    // nested paths can't unpack into scalar `my`s.
-    'rest-destructure-object-spread-in-map': [{ code: 'BF104', severity: 'error' }],
-    'rest-destructure-array-in-map': [{ code: 'BF104', severity: 'error' }],
-    'rest-destructure-nested-in-map': [{ code: 'BF104', severity: 'error' }],
+    // #1310 / #2087: rest destructure in .map() callback. All four shapes
+    // now lower via #2087 Phase B's `segments`-walking accessor:
+    //   - object-rest read via member access (`rest-destructure-object-in-map`):
+    //     `bf->omit($__bf_item, [...exclude keys...])`, `$rest->{flag}` reads
+    //     the residual hashref.
+    //   - object-rest spread onto the root element
+    //     (`rest-destructure-object-spread-in-map`): same `bf->omit(...)`
+    //     residual, forwarded via the existing `bf->spread_attrs($rest)` path.
+    //   - array-rest (`rest-destructure-array-in-map`): `bf->slice($__bf_item,
+    //     N, undef)` — the same runtime helper `.slice()` JS-method calls use.
+    //   - nested rest inside an object pattern (`rest-destructure-nested-in-map`):
+    //     the parent-prefix accessor (`$__bf_item->{cells}`) feeds the same
+    //     `bf->slice(...)` call.
+    // None of these are pinned here anymore.
     // `style-3-signals` / `style-object-dynamic` no longer pinned — a
     // `style={{ … }}` object literal now lowers to a CSS string with dynamic
     // values interpolated (`background-color:<%= $color %>;padding:8px`) via

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -26,6 +26,7 @@ import type {
   CompilerError,
   TypeInfo,
   TemplatePrimitiveRegistry,
+  LoopBindingPathSegment,
 } from '@barefootjs/jsx'
 import {
   BaseAdapter,
@@ -49,7 +50,6 @@ import {
   parseRecordIndexAccess,
   extractArrowBodyExpression,
   collectContextConsumers,
-  isLowerableObjectRestDestructure,
   type ContextConsumer,
   collectModuleStringConsts,
   lookupStaticRecordLiteral,
@@ -57,6 +57,7 @@ import {
   prepareLoweringMatchers,
   queryHrefArgs,
   sortComparatorFromArrow,
+  isLowerableLoopDestructure,
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr } from './boolean-result.ts'
 import type { ParsedExpr, LoweringMatcher } from '@barefootjs/jsx'
@@ -93,6 +94,43 @@ import {
 
 export type { MojoAdapterOptions } from './lib/types.ts'
 import type { MojoAdapterOptions } from './lib/types.ts'
+
+/**
+ * Build a Perl accessor expression for a `.map()` destructure binding's
+ * structured `segments` path (#2087 Phase B), walking `field` (`->{key}`,
+ * quoted with `perlHashKey`'s convention when `!isIdent`) / `index`
+ * (`->[N]`) steps onto `base`. Never string-parses `LoopParamBinding.path` —
+ * see the repo-wide rule against regex-parsing JS/TS-derived syntax.
+ *
+ * Used both for a fixed binding's FULL accessor (`base` = `$__bf_item`,
+ * `segments` = the whole path) and a rest binding's PARENT-prefix accessor
+ * (`segments` may be empty, at the loop root, in which case this returns
+ * `base` unchanged) — see `LoopParamBinding.segments` jsdoc for which case
+ * a binding is in.
+ */
+function perlSegmentAccessor(base: string, segments: readonly LoopBindingPathSegment[]): string {
+  let expr = base
+  for (const seg of segments) {
+    expr +=
+      seg.kind === 'field'
+        ? `->{${seg.isIdent ? seg.key : perlHashKey(seg.key)}}`
+        : `->[${seg.index}]`
+  }
+  return expr
+}
+
+/**
+ * Quote a string as a Perl single-quoted literal (backslash first, then the
+ * quote, so the escape doesn't double up). Unlike `perlHashKey` — which
+ * intentionally leaves an identifier-safe name as a bareword for `->{key}` /
+ * `key => val` hash-key position — a plain list element (`bf->omit($x, [id,
+ * title])`) is NOT hash-key position: an unquoted bareword there is a sub
+ * call under `use strict subs`, so every object-rest exclude key needs an
+ * unconditional string literal.
+ */
+function perlStringLiteral(s: string): string {
+  return `'${s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`
+}
 
 export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRenderCtx> {
   name = 'mojolicious'
@@ -705,39 +743,77 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       return `<%== bf->comment("loop:${loop.markerId}") %><%== bf->comment("/loop:${loop.markerId}") %>`
     }
 
-    // An array/object-destructure loop param (`([emoji, users]) => ...`
-    // or `({ name, age }) => ...`) lowers to invalid Perl — the adapter
-    // would otherwise emit `% my $[emoji, users] = $entries->[$_i];`,
-    // which is a parse error. Surface this at build time (#1266)
-    // instead of shipping the broken template line for the user to
-    // discover at request time.
+    // A `.map()` destructure loop param (`([k, v]) => ...` / `({ id, user: {
+    // name } }) => ...` / `({ id, ...rest }) => ...`) lowers to a Perl `my`
+    // local per binding, walking each binding's structured `segments` path
+    // (#2087 Phase B) into a native `->{key}` / `->[N]` accessor off the
+    // per-item var — so the body's `$id` / `$name` / `$rest->{flag}` /
+    // `{...rest}` all resolve natively, at any nesting depth.
     //
     // Check the IR's structured `paramBindings` field rather than
     // string-matching `loop.param`: Phase 1 populates `paramBindings`
     // iff the param is a destructure pattern (array or object); a
     // simple identifier leaves it `undefined`. The structured check is
     // robust to whitespace / formatting variants in the source.
-    // A destructure loop param is lowerable for the object-rest / simple-field
-    // shape (`.map(({ id, title, ...rest }) => …)`, `rest` read via member
-    // access): each binding becomes a Perl `my` local off the per-item var, so
-    // the body's `$id` / `$rest->{flag}` resolve natively. Array-index / nested
-    // / rest-spread shapes still can't unpack into scalar `my`s → BF104. (#1310)
+    //
+    // `isLowerableLoopDestructure` (#2087) still refuses: an object-rest
+    // binding used any way other than member access (`rest.flag`) or a
+    // `{...rest}` spread onto an intrinsic element (that needs the actual
+    // residual *object*, which isn't always safe to materialize — see the
+    // gate's own jsdoc for the full list); a `.filter().map(destructure)`
+    // chain (the filter-param rewrite is out of scope here); and a
+    // computed property key (`{ [k]: v }`, refused earlier as BF025).
     const destructure = !!(loop.paramBindings && loop.paramBindings.length > 0)
-    const supportableDestructure = destructure && isLowerableObjectRestDestructure(loop)
+    const supportableDestructure = destructure && isLowerableLoopDestructure(loop)
     if (destructure && !supportableDestructure) {
       this.errors.push({
         code: 'BF104',
         severity: 'error',
-        message: `Loop callback uses an array/object destructure pattern (\`${loop.param}\`) that the Mojo adapter cannot lower — Perl scalar bindings can't unpack a tuple in a single \`my\` declaration.`,
+        message: `Loop callback uses a destructure pattern (\`${loop.param}\`) that the Mojo adapter cannot lower — see the diagnostic detail for the specific shape.`,
         loc: loop.loc ?? { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
         suggestion: {
           message:
             `Options:\n` +
-            `  1. Rename the parameter to a single name and access tuple elements with index syntax in the body (e.g. \`entry => entry->[0]\` instead of \`([k, v]) => ...\`).\n` +
-            `  2. Mark the loop position as @client-only so the destructure runs in JS on the client.\n` +
-            `  3. Move the loop into a primitive that the adapter registers explicitly.`,
+            `  1. If this is an object-rest binding (\`{ ...rest }\`), only reading \`rest.field\` or spreading \`{...rest}\` onto an intrinsic element lowers — other uses (passing \`rest\` to a function, rendering it as text) need the client runtime.\n` +
+            `  2. If this is chained \`.filter().map(({ ... }) => ...)\`, hoist the destructure into a variable inside the callback body instead.\n` +
+            `  3. Mark the loop position as @client-only so the destructure runs in JS on the client.\n` +
+            `  4. Move the loop into a primitive that the adapter registers explicitly.`,
         },
       })
+    }
+
+    // A `.map()` loop whose array is a bare identifier bound to a
+    // FUNCTION-scope local const with a non-statically-evaluable initializer
+    // that reads props/signals (e.g. `const entries =
+    // Object.entries(props.x ?? {}).filter(...)`) can't render correctly.
+    // Module-scope consts (`isModule`, e.g. `const payments = [...]` at the
+    // top of the file) are a DIFFERENT, already-working case handled
+    // elsewhere. Function-scope locals get no per-render stash slot — this
+    // adapter's only "elsewhere" for a local const is inlining its value at
+    // the use site (`resolveLiteralConst`'s numeric/single-quoted-string fast
+    // path, or a static-record-literal lookup), never binding one as a `my`
+    // template local. Left unchecked, `% for my $_i (0..$#{$entries}) {`
+    // over an undeclared `$entries` faults under `use strict` at request
+    // time instead of failing loudly at build time. Pre-existing, general
+    // limitation, orthogonal to #2087's destructure-binding work — newly
+    // reachable in this adapter's test corpus only because the widened
+    // destructure gate (#2087 Phase A/B) no longer refuses this fixture's
+    // `([emoji, users]) => ...` param first.
+    const arrayName = loop.array.trim()
+    if (/^[A-Za-z_$][\w$]*$/.test(arrayName)) {
+      const arrayConst = (this.localConstants ?? []).find(c => c.name === arrayName)
+      if (arrayConst && !arrayConst.isModule && this.resolveLiteralConst(arrayName) === null) {
+        this.errors.push({
+          code: 'BF101',
+          severity: 'error',
+          message: `Loop array \`${arrayName}\` is a local computed value (\`${arrayConst.value}\`) that the Mojo adapter cannot bind as a template variable — only numeric/string-literal locals inline at their use site.`,
+          loc: loop.loc ?? { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+          suggestion: {
+            message:
+              'Pre-compute the array server-side and pass it as a prop, or mark the loop position as @client-only so it runs in JS on the client.',
+          },
+        })
+      }
     }
 
     const rawArray = this.convertExpressionToPerl(loop.array)
@@ -844,15 +920,31 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     lines.push(`% for my ${indexVar} (0..$#{${array}}) {`)
     if (loop.iterationShape !== 'keys') {
       if (supportableDestructure) {
-        // Per-item var + one `my` local per binding; `rest` aliases the item
-        // so `$rest->{flag}` resolves (object-rest read via member access).
+        // Per-item var + one `my` local per binding, walking each binding's
+        // `segments` path (#2087 Phase B):
+        //   - fixed (`b.rest` unset): the FULL accessor from `$__bf_item`.
+        //   - array-rest: `bf->slice(parent, from, undef)` — the same
+        //     runtime helper `.slice()` JS-method calls lower to (see
+        //     `array-method.ts`), so the "no end → to length" arithmetic
+        //     stays in one place.
+        //   - object-rest: `bf->omit(parent, [...excluded keys...])` — a
+        //     TRUE residual hashref (not the whole item aliased), so both
+        //     `$rest->{flag}` (member-access use) and `bf->spread_attrs($rest)`
+        //     (spread-onto-element use) see only the non-destructured keys.
+        // `parent` is `$__bf_item` walked through the binding's PARENT-prefix
+        // `segments` (empty at the loop root, per the `LoopParamBinding`
+        // jsdoc) — NOT the same as a fixed binding's full-accessor segments.
         lines.push(`% my $__bf_item = ${array}->[${indexVar}];`)
         for (const b of loop.paramBindings ?? []) {
-          lines.push(
-            b.rest
-              ? `% my $${b.name} = $__bf_item;`
-              : `% my $${b.name} = $__bf_item->{${b.path.slice(1)}};`,
-          )
+          const parent = perlSegmentAccessor('$__bf_item', b.segments ?? [])
+          if (b.rest?.kind === 'object') {
+            const exclude = b.rest.exclude.map(k => perlStringLiteral(k.key)).join(', ')
+            lines.push(`% my $${b.name} = bf->omit(${parent}, [${exclude}]);`)
+          } else if (b.rest?.kind === 'array') {
+            lines.push(`% my $${b.name} = bf->slice(${parent}, ${b.rest.from}, undef);`)
+          } else {
+            lines.push(`% my $${b.name} = ${perlSegmentAccessor('$__bf_item', b.segments ?? [])};`)
+          }
         }
       } else {
         lines.push(`% my $${param} = ${array}->[${indexVar}];`)

--- a/packages/adapter-perl/lib/BarefootJS.pm
+++ b/packages/adapter-perl/lib/BarefootJS.pm
@@ -1425,6 +1425,25 @@ sub _style_to_css ($value) {
     return @parts ? CORE::join(';', @parts) : undef;
 }
 
+
+# Object-rest residual for a `.map()` destructure binding
+# (`{ id, ...rest } => …`, #2087 Phase B): returns a NEW hashref holding
+# every key of `$bag` except those named in `$keys` (an ARRAY ref of key
+# strings). This is plain JS destructure semantics (`const { id, ...rest }
+# = item`) — unlike `spread_attrs` below, there's no event-handler /
+# `children` filtering or key remapping here, because the residual is a
+# *value* the template may read fields off of (`$rest->{flag}`) or later
+# forward wholesale to `spread_attrs` (`{...rest}` on an element) — either
+# consumer applies its own rules downstream. A non-hashref `$bag` returns
+# an empty hashref rather than dying, so this stays safe as a `my` local
+# initializer even off unexpected/absent data (same defensive contract as
+# `spread_attrs`'s "no bag → nothing").
+sub omit ($self, $bag, $keys) {
+    return {} unless defined $bag && ref($bag) eq 'HASH';
+    my %exclude = map { $_ => 1 } @$keys;
+    return { map { $_ => $bag->{$_} } grep { !$exclude{$_} } keys %$bag };
+}
+
 sub spread_attrs ($self, $bag) {
     return '' unless defined $bag && ref($bag) eq 'HASH';
     my @parts;

--- a/packages/adapter-perl/t/omit.t
+++ b/packages/adapter-perl/t/omit.t
@@ -1,0 +1,61 @@
+use Test2::V0;
+
+# omit — object-rest residual runtime helper for a `.map()` destructure
+# binding (`{ id, ...rest } => …`, #2087 Phase B). Both the Mojo and Xslate
+# template adapters lower an object-rest binding to `bf->omit($parent,
+# [...excluded keys...])` / `$bf.omit($parent, [...])` so the residual is a
+# TRUE hashref (not the whole item aliased) — `rest.flag` and `{...rest}`
+# both read from the same real value. See packages/adapter-perl/lib/BarefootJS.pm.
+
+use FindBin qw($Bin);
+use lib "$Bin/../lib";
+
+use BarefootJS;
+
+# Minimal pure-Perl backend: `omit` never reaches the backend (no
+# mark_raw / escaping — it returns a plain hashref, not markup).
+{
+    package PureBackend;
+    sub new { bless {}, shift }
+}
+
+my $bf = bless { c => undef, config => {}, backend => PureBackend->new }, 'BarefootJS';
+
+subtest 'basic shapes' => sub {
+    is $bf->omit(undef, []), {}, 'undef bag -> empty hashref';
+    is $bf->omit('not a hash', []), {}, 'non-hash scalar -> empty hashref';
+    is $bf->omit({}, []), {}, 'empty bag -> empty hashref';
+    is $bf->omit({ id => 'a', title => 'b' }, []),
+       { id => 'a', title => 'b' },
+       'no excluded keys -> full copy';
+};
+
+subtest 'excludes named keys' => sub {
+    is $bf->omit({ id => 't1', title => 'one', flag => 'a' }, ['id', 'title']),
+       { flag => 'a' },
+       'excludes the destructured sibling keys, keeps the rest';
+    is $bf->omit({ id => 't1' }, ['id', 'title']),
+       {},
+       'excluding a key absent from the bag is a no-op for that key';
+};
+
+subtest 'non-identifier keys (rest-spread-onto-element shape)' => sub {
+    # Mirrors the `rest-destructure-object-spread-in-map` fixture:
+    # `{ id, title, ...rest }` with a hyphenated sibling key
+    # (`'data-priority'`) surviving into the residual untouched.
+    is $bf->omit(
+        { id => 't1', title => 'one', 'data-priority' => 'high', tag => 'urgent' },
+        ['id', 'title'],
+    ),
+       { 'data-priority' => 'high', tag => 'urgent' },
+       'non-identifier keys pass through the residual unchanged';
+};
+
+subtest 'returns a new hashref (no aliasing)' => sub {
+    my $bag = { id => 'a', flag => 'x' };
+    my $rest = $bf->omit($bag, ['id']);
+    $rest->{flag} = 'mutated';
+    is $bag->{flag}, 'x', 'mutating the residual does not affect the source bag';
+};
+
+done_testing;

--- a/packages/adapter-rust/runtime/src/runtime.rs
+++ b/packages/adapter-rust/runtime/src/runtime.rs
@@ -1125,6 +1125,9 @@ impl Object for BfInstance {
             "at" => Ok(js_to_mj(&at(a(0), a(1)))),
             "concat" => Ok(js_to_mj(&concat(a(0), a(1)))),
             "slice" => Ok(js_to_mj(&slice(a(0), a(1), a(2)))),
+            // Object-rest residual for a `.map()` destructure binding (#2087
+            // Phase B) -- see `omit`'s docstring.
+            "omit" => Ok(js_to_mj(&omit(a(0), a(1)))),
             "reverse" => Ok(js_to_mj(&reverse(a(0)))),
             "flat" => {
                 let depth = if matches!(a(1), JsValue::Null) { 1 } else { num::to_f64(a(1)) as i64 };
@@ -1323,6 +1326,32 @@ pub fn slice(recv: &JsValue, start: &JsValue, end: &JsValue) -> JsValue {
         return JsValue::Array(Vec::new());
     }
     JsValue::Array(items[s as usize..e as usize].to_vec())
+}
+
+/// Build a TRUE residual object -- every key of `recv` NOT listed in
+/// `exclude` -- for a `.map()` callback's object-rest destructure binding
+/// (`{ id, title, ...rest }`, #2087 Phase B). Mirrors `slice`'s array-rest
+/// counterpart: the adapter binds the destructured local straight to this
+/// helper's result (`{% set rest = bf.omit(item, ["id", "title"]) %}`), so a
+/// member read (`rest.flag`) or the existing `{...rest}` spread emit
+/// (`bf.spread_attrs`) both see only the non-destructured keys, same as the
+/// Hono/CSR IIFE (`(({ id: __bfR0, title: __bfR1, ...__bfRest }) =>
+/// __bfRest)(__bfItem())`). A non-object `recv`, or a non-array `exclude`,
+/// degrades to an empty object (consistent with `slice`'s non-array-recv →
+/// empty-array fallback) rather than panicking.
+pub fn omit(recv: &JsValue, exclude: &JsValue) -> JsValue {
+    let map = match recv.as_object() {
+        Some(m) => m,
+        None => return JsValue::Object(BTreeMap::new()),
+    };
+    let exclude_keys: HashSet<&str> =
+        exclude.as_array().unwrap_or(&[]).iter().filter_map(|v| v.as_str()).collect();
+    JsValue::Object(
+        map.iter()
+            .filter(|(k, _)| !exclude_keys.contains(k.as_str()))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect(),
+    )
 }
 
 pub fn reverse(recv: &JsValue) -> JsValue {

--- a/packages/adapter-rust/runtime/tests/omit.rs
+++ b/packages/adapter-rust/runtime/tests/omit.rs
@@ -1,0 +1,79 @@
+//! `runtime::omit` -- the residual-object helper backing `bf.omit`, which
+//! the minijinja adapter emits for an object-rest `.map()` destructure
+//! binding whose rest is used (#2087 Phase B):
+//!
+//!   `{% set rest = bf.omit(item, ["id", "title"]) %}`
+//!
+//! Builds a TRUE residual object (every key of `item` NOT in the exclude
+//! list) so a member read (`rest.flag`, native Jinja attribute access) and
+//! the existing `{...rest}` spread emit (`bf.spread_attrs`) both see only
+//! the non-destructured keys, matching the Hono/CSR IIFE
+//! (`(({ id: __bfR0, title: __bfR1, ...__bfRest }) => __bfRest)(__bfItem())`).
+//! No shared cross-adapter golden-vector entry exists for this helper (it is
+//! new with #2087 and specific to the structural-destructure lowering, not
+//! the `spec/template-helpers.md` catalogue `helper_vectors.rs` runs) -- this
+//! file is this crate's own conformance pin, alongside `spread_attrs.rs`.
+
+use barefootjs::num::JsValue;
+use barefootjs::runtime;
+use std::collections::BTreeMap;
+
+fn obj(pairs: &[(&str, JsValue)]) -> JsValue {
+    JsValue::Object(pairs.iter().map(|(k, v)| (k.to_string(), v.clone())).collect::<BTreeMap<_, _>>())
+}
+
+fn arr(items: &[&str]) -> JsValue {
+    JsValue::Array(items.iter().map(|s| JsValue::from(*s)).collect())
+}
+
+fn s(v: &str) -> JsValue {
+    JsValue::from(v)
+}
+
+fn run(recv: &JsValue, exclude: &JsValue) -> JsValue {
+    runtime::omit(recv, exclude)
+}
+
+#[test]
+fn excludes_listed_keys() {
+    let item = obj(&[("id", s("t1")), ("title", s("one")), ("flag", s("a"))]);
+    let out = run(&item, &arr(&["id", "title"]));
+    assert_eq!(out, obj(&[("flag", s("a"))]));
+}
+
+#[test]
+fn keeps_non_excluded_keys_including_non_identifier_names() {
+    let item = obj(&[
+        ("id", s("t1")),
+        ("title", s("one")),
+        ("data-priority", s("high")),
+        ("tag", s("urgent")),
+    ]);
+    let out = run(&item, &arr(&["id", "title"]));
+    assert_eq!(out, obj(&[("data-priority", s("high")), ("tag", s("urgent"))]));
+}
+
+#[test]
+fn empty_exclude_returns_full_object() {
+    let item = obj(&[("a", s("1")), ("b", s("2"))]);
+    assert_eq!(run(&item, &arr(&[])), item);
+}
+
+#[test]
+fn excluding_every_key_returns_empty_object() {
+    let item = obj(&[("a", s("1")), ("b", s("2"))]);
+    assert_eq!(run(&item, &arr(&["a", "b"])), obj(&[]));
+}
+
+#[test]
+fn non_object_receiver_degrades_to_empty_object() {
+    assert_eq!(run(&JsValue::Null, &arr(&["id"])), obj(&[]));
+    assert_eq!(run(&s("not a hash"), &arr(&["id"])), obj(&[]));
+    assert_eq!(run(&JsValue::Array(vec![s("a")]), &arr(&["id"])), obj(&[]));
+}
+
+#[test]
+fn non_array_exclude_degrades_to_no_op_filter() {
+    let item = obj(&[("a", s("1"))]);
+    assert_eq!(run(&item, &JsValue::Null), item);
+}

--- a/packages/adapter-rust/src/__tests__/minijinja-adapter.test.ts
+++ b/packages/adapter-rust/src/__tests__/minijinja-adapter.test.ts
@@ -40,25 +40,44 @@ runAdapterConformanceTests({
     // `.map`) as xslate.
     'todo-app': [{ code: 'BF103', severity: 'error' }],
     'todo-app-ssr': [{ code: 'BF103', severity: 'error' }],
-    // Array-destructure loop param (`([k, v]) => …`) can't lower to a
-    // single Jinja `for` loop variable (same BF104 as xslate — Jinja's
-    // `for item in list` binds one loop variable, just like Kolon's
-    // `for $arr -> $item`).
-    'static-array-from-props': [{ code: 'BF104', severity: 'error' }],
-    // Both BF103 (imported child) and BF104 (destructure) fire.
+    // The `([emoji, users]) => ...` / `([id, t]) => ...` params in these two
+    // fixtures no longer trip BF104 — the destructure itself now lowers
+    // cleanly to a native `{% set %}` accessor (#2087 Phase B). But both
+    // fixtures' loop array is `entries`, a bare identifier bound to a
+    // function-scope local const with a NON-inlineable initializer
+    // (`Object.entries(props.x ?? {}).filter(...)`) — a pre-existing,
+    // orthogonal limitation this adapter has always had (it only ever
+    // INLINES a local const's value at its use site — numeric/string
+    // literal, or a static-record-literal lookup — never binds one as a
+    // `{% set %}` template local), just never reachable before because the
+    // narrower pre-#2087 gate refused the destructure param first. Left
+    // unhandled it would silently render an EMPTY list (minijinja's
+    // `UndefinedBehavior::Chainable` tolerates iterating an unbound name as
+    // zero iterations) instead of failing loudly, so `renderLoop` in
+    // `minijinja-adapter.ts` now detects this shape and raises BF101
+    // instead — see the "Loop array `<name>` is a local computed value"
+    // diagnostic (mirrors adapter-jinja's identical check). Fixing the
+    // underlying gap (computed-array-from-props as a loop source) is out of
+    // scope for #2087; tracked as a follow-up at
+    // https://github.com/piconic-ai/barefootjs/issues/2087.
+    'static-array-from-props': [{ code: 'BF101', severity: 'error' }],
+    // Both BF103 (imported child) and BF101 (unresolvable computed loop
+    // array, see above) fire.
     'static-array-from-props-with-component': [
       { code: 'BF103', severity: 'error' },
-      { code: 'BF104', severity: 'error' },
+      { code: 'BF101', severity: 'error' },
     ],
-    // Rest-destructure `.map()` callbacks — the object-rest shape read via
-    // member access (`rest-destructure-object-in-map`) lowers via a Jinja
-    // `{% set %}` local binding (same mechanism as Kolon's `: my`). The
-    // other three stay refused: rest SPREAD needs a residual object,
-    // array-index / nested paths can't unpack a tuple (same surface as
-    // xslate).
-    'rest-destructure-object-spread-in-map': [{ code: 'BF104', severity: 'error' }],
-    'rest-destructure-array-in-map': [{ code: 'BF104', severity: 'error' }],
-    'rest-destructure-nested-in-map': [{ code: 'BF104', severity: 'error' }],
+    // Rest-destructure `.map()` callbacks (#2087 Phase B): every shape now
+    // lowers natively — fixed bindings at any depth/shape via a chained
+    // Jinja accessor built off `LoopParamBinding.segments`
+    // (`minijinjaAccessorFromSegments`), array-rest via the runtime's
+    // `bf.slice`, and object-rest (read via member access OR spread onto an
+    // intrinsic element) via a TRUE residual dict from the new `bf.omit`
+    // runtime helper. No `expectedDiagnostics` pins remain for any of the
+    // `rest-destructure-*-in-map` / `destructure-*-in-map` fixtures — see
+    // `rest-destructure-object-spread-in-map` for the residual-spread case
+    // and `destructure-array-index-in-map` / `destructure-nested-object-in-map`
+    // for the no-rest fixed-binding shapes.
     // The site/ui Button auto-infers a `<Slot>` sibling that spreads
     // `{...props}` / `{...children.props}` onto its root element. Jinja
     // dict literals can't splat a runtime dict into named call-site

--- a/packages/adapter-rust/src/adapter/minijinja-adapter.ts
+++ b/packages/adapter-rust/src/adapter/minijinja-adapter.ts
@@ -157,7 +157,7 @@ import {
   collectModuleStringConsts,
   extractArrowBodyExpression,
   collectContextConsumers,
-  isLowerableObjectRestDestructure,
+  isLowerableLoopDestructure,
   type ContextConsumer,
   lookupStaticRecordLiteral,
   searchParamsLocalNames,
@@ -166,7 +166,7 @@ import {
   sortComparatorFromArrow,
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr, isExplicitStringCall } from './boolean-result.ts'
-import type { ParsedExpr, LoweringMatcher } from '@barefootjs/jsx'
+import type { ParsedExpr, LoweringMatcher, LoopBindingPathSegment } from '@barefootjs/jsx'
 import { BF_SLOT, BF_COND, BF_REGION } from '@barefootjs/shared'
 
 import type { JinjaRenderCtx } from './lib/types.ts'
@@ -199,6 +199,34 @@ import {
 
 export type { MinijinjaAdapterOptions } from './lib/types.ts'
 import type { MinijinjaAdapterOptions } from './lib/types.ts'
+
+/**
+ * Build a chained Jinja attribute/subscript accessor from a `.map()`
+ * destructure binding's structured `segments` path (#2087 Phase B) — walking
+ * `segments` instead of string-parsing `LoopParamBinding.path` (repo rule:
+ * never parse JS/TS syntax with regex or string matching). Verified against
+ * the real minijinja 2.21 engine (scratch spike): a `field` step with an
+ * identifier key reads via native dotted access (`.name`, cheapest / most
+ * idiomatic Jinja form); a non-identifier key (`data-priority`) reads via a
+ * single-quoted bracket subscript (`['data-priority']`, same quoting
+ * convention as `minijinjaHashKey`/`escapeMinijinjaSingleQuoted` — quotes are
+ * mandatory here since a bareword subscript would be a variable lookup, not
+ * this adapter's concern for a bracket step but kept consistent regardless);
+ * an `index` step reads a numeric Array index (`[0]`). Empty `segments` (a
+ * rest binding at the loop root) returns `base` unchanged.
+ */
+function minijinjaAccessorFromSegments(base: string, segments: readonly LoopBindingPathSegment[]): string {
+  let accessor = base
+  for (const seg of segments) {
+    accessor +=
+      seg.kind === 'index'
+        ? `[${seg.index}]`
+        : seg.isIdent
+          ? `.${seg.key}`
+          : `['${escapeMinijinjaSingleQuoted(seg.key)}']`
+  }
+  return accessor
+}
 
 export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRenderCtx> {
   name = 'minijinja'
@@ -669,31 +697,75 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
     }
 
     // An array/object-destructure loop param (`([emoji, users]) => ...` or
-    // `({ name, age }) => ...`) lowers to invalid Jinja — Jinja's `for item in
-    // list` binds a single loop variable and can't unpack a tuple the way a
-    // Python `for` statement can. Surface this at build time instead of
-    // shipping a broken template line.
-    // A destructure loop param is lowerable for the object-rest / simple-field
-    // shape (`.map(({ id, title, ...rest }) => …)`, `rest` read via member
-    // access): each binding becomes a `{% set %}` local off the per-item var,
-    // so the body's `id` / `rest.flag` resolve. Array-index / nested /
-    // rest-spread shapes still can't unpack a tuple → BF104. (#1310)
+    // `({ name, age }) => ...`) lowers to invalid Jinja in general — Jinja's
+    // `for item in list` binds a single loop variable and can't unpack a
+    // tuple the way a Python `for` statement can. `isLowerableLoopDestructure`
+    // (#2087) instead admits any FIXED-binding shape — single field, nested
+    // field, array-index, any depth/mix (`{ user: { name } }`, `([k, v])`,
+    // `{ cells: [head] }`) — by walking the binding's structured `segments`
+    // path into a chained Jinja accessor (`__bf_item.user.name`,
+    // `minijinjaAccessorFromSegments`), plus array-rest (`[first, ...tail]`,
+    // native `bf.slice`) and object-rest (`{ id, ...rest }`, native
+    // `bf.omit`) whose every use is a member read (`rest.flag`) or a
+    // `{...rest}` spread onto an intrinsic element. Bare-value rest uses, a
+    // spread onto a component/provider, and `.filter().map(destructure)`
+    // still have no Jinja scalar form → BF104.
     const destructure = !!(loop.paramBindings && loop.paramBindings.length > 0)
-    const supportableDestructure = destructure && isLowerableObjectRestDestructure(loop)
+    const supportableDestructure = destructure && isLowerableLoopDestructure(loop)
     if (destructure && !supportableDestructure) {
       this.errors.push({
         code: 'BF104',
         severity: 'error',
-        message: `Loop callback uses an array/object destructure pattern (\`${loop.param}\`) that the Jinja adapter cannot lower — Jinja \`for item in list\` binds a single loop variable and can't unpack a tuple.`,
+        message: `Loop callback uses an array/object destructure pattern (\`${loop.param}\`) that the Jinja adapter cannot lower — the rest binding is used in a way (bare value, or spread onto a component) that has no native Jinja accessor form.`,
         loc: loop.loc ?? { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
         suggestion: {
           message:
             `Options:\n` +
-            `  1. Rename the parameter to a single name and access tuple elements with index syntax in the body (e.g. \`entry => entry[0]\` instead of \`([k, v]) => ...\`).\n` +
+            `  1. Read the rest binding as a member access (\`rest.field\`) or spread it onto an intrinsic element (\`<li {...rest}>\`) instead of using it as a bare value.\n` +
             `  2. Mark the loop position as @client-only so the destructure runs in JS on the client.\n` +
             `  3. Move the loop into a primitive that the adapter registers explicitly.`,
         },
       })
+    }
+
+    // A `.map()` loop whose array is a bare identifier bound to a
+    // FUNCTION-scope local const with a non-statically-evaluable initializer
+    // that reads props/signals (e.g. `const entries =
+    // Object.entries(props.x ?? {}).filter(...)`) can't render correctly.
+    // Module-scope consts (`isModule`, e.g. `const payments = [...]` at the
+    // top of the file) are a DIFFERENT, already-working case — the shared
+    // `ssr-defaults.ts` statically evaluates those and seeds them straight
+    // into the render context, so a bare `payments` reference resolves for
+    // free (data-table demo). Function-scope locals get no such seeding
+    // (`ssr-defaults.ts`: "component-scope locals can depend on
+    // signals/props and are evaluated lazily elsewhere") — and this
+    // adapter's only "elsewhere" is inlining a const's value at its use
+    // site (`_resolveLiteralConst`'s numeric/single-quoted-string fast
+    // path, or a static-record-literal lookup), never binding one as a
+    // `{% set %}` template local. Left unchecked, `{% for item in entries
+    // %}` over an unbound name would silently iterate zero times
+    // (minijinja's `UndefinedBehavior::Chainable` tolerates it rather than
+    // raising, same as Jinja's `ChainableUndefined`) instead of failing
+    // loudly. Pre-existing, general limitation, orthogonal to #2087's
+    // destructure-binding work — newly reachable in this adapter's test
+    // corpus only because the widened destructure gate (#2087 Phase A/B)
+    // no longer refuses this fixture's `([emoji, users]) => ...` param
+    // first. Mirrors adapter-jinja's identical check.
+    const arrayName = loop.array.trim()
+    if (/^[A-Za-z_$][\w$]*$/.test(arrayName)) {
+      const arrayConst = (this.localConstants ?? []).find(c => c.name === arrayName)
+      if (arrayConst && !arrayConst.isModule && this._resolveLiteralConst(arrayName) === null) {
+        this.errors.push({
+          code: 'BF101',
+          severity: 'error',
+          message: `Loop array \`${arrayName}\` is a local computed value (\`${arrayConst.value}\`) that the MiniJinja adapter cannot bind as a template variable — only numeric/string-literal locals inline at their use site.`,
+          loc: loop.loc ?? { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+          suggestion: {
+            message:
+              'Pre-compute the array server-side and pass it as a prop, or mark the loop position as @client-only so it runs in JS on the client.',
+          },
+        })
+      }
     }
 
     const rawArray = this.convertExpressionToJinja(loop.array)
@@ -744,11 +816,27 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
     }
     if (supportableDestructure) {
       for (const b of loop.paramBindings ?? []) {
-        indexLocalLines.push(
-          b.rest
-            ? `{% set ${minijinjaIdent(b.name)} = ${minijinjaIdent(loopVar)} %}`
-            : `{% set ${minijinjaIdent(b.name)} = ${minijinjaIdent(loopVar)}${b.path} %}`,
-        )
+        // Built off the binding's structured `segments` path (never `b.path`
+        // — repo rule: no string-parsing of a JS-shaped accessor). See
+        // `minijinjaAccessorFromSegments`.
+        const parent = minijinjaAccessorFromSegments(minijinjaIdent(loopVar), b.segments ?? [])
+        if (b.rest?.kind === 'array') {
+          // MiniJinja has no native slice syntax — route through the
+          // runtime's `bf.slice` (matches the JS `.slice(from)` semantics,
+          // including the past-end-length edge case) so the residual local
+          // is the exact same tail array `tail === item.slice(from)`.
+          indexLocalLines.push(`{% set ${minijinjaIdent(b.name)} = bf.slice(${parent}, ${b.rest.from}) %}`)
+        } else if (b.rest?.kind === 'object') {
+          // A TRUE residual dict (not an alias of the parent) via the
+          // runtime's `bf.omit` helper (runtime.rs) — so a member read
+          // (`rest.flag`) and the existing `{...rest}` spread emit
+          // (`bf.spread_attrs`) both see only the non-destructured keys,
+          // same as the Hono/CSR IIFE.
+          const excludeKeys = b.rest.exclude.map(k => `'${escapeMinijinjaSingleQuoted(k.key)}'`).join(', ')
+          indexLocalLines.push(`{% set ${minijinjaIdent(b.name)} = bf.omit(${parent}, [${excludeKeys}]) %}`)
+        } else {
+          indexLocalLines.push(`{% set ${minijinjaIdent(b.name)} = ${parent} %}`)
+        }
       }
     }
 

--- a/packages/adapter-tests/fixtures/destructure-array-index-in-map.ts
+++ b/packages/adapter-tests/fixtures/destructure-array-index-in-map.ts
@@ -14,13 +14,11 @@ import { createFixture } from '../src/types'
  * `destructure-nested-object-in-map`.
  *
  * Hono / CSR already lowered this pre-#2087 (the client-JS emit path is
- * unchanged by this PR — see `wrapLoopParamAsAccessor` /
- * `renderLoopBindingAccess`). Text-template adapters (Go, Mojo, Xslate,
- * Twig, Jinja, ERB, Rust/MiniJinja) gain the ability to admit this shape
- * only once each grows a `segments`-based accessor emitter in Phase B —
- * until then they still refuse it with BF104. Do not add
- * `expectedDiagnostics` pins for this fixture in any adapter's suite
- * (Phase B owns that).
+ * unchanged — see `wrapLoopParamAsAccessor` / `renderLoopBindingAccess`).
+ * All seven template adapters (Go, Mojo, Xslate, Twig, Jinja, ERB,
+ * Rust/MiniJinja) lower it via their `segments`-based accessor emitters;
+ * the loop item is an ARRAY here, so the fixed bindings start with an
+ * index segment (`[0]` / `[1]`) rather than a field step.
  */
 export const fixture = createFixture({
   id: 'destructure-array-index-in-map',

--- a/packages/adapter-tests/fixtures/destructure-array-index-in-map.ts
+++ b/packages/adapter-tests/fixtures/destructure-array-index-in-map.ts
@@ -1,0 +1,53 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Array-index (tuple) destructure in a `.map()` callback, no rest
+ * (`([k, v]) => …`).
+ *
+ * #2087 Phase A extended `LoopParamBinding` with a structured `segments`
+ * path (`{ kind: 'index', index }` / `{ kind: 'field', key, isIdent }`) so
+ * template adapters can build a native accessor for ANY fixed-binding
+ * shape — not just the single-level `.field` case the pre-#2087 gate
+ * admitted. This fixture pins the plain tuple-destructure case (positional
+ * bindings, no nesting, no rest) as the simplest new shape the gate
+ * (`isLowerableLoopDestructure`) now accepts. Its nested-object sibling is
+ * `destructure-nested-object-in-map`.
+ *
+ * Hono / CSR already lowered this pre-#2087 (the client-JS emit path is
+ * unchanged by this PR — see `wrapLoopParamAsAccessor` /
+ * `renderLoopBindingAccess`). Text-template adapters (Go, Mojo, Xslate,
+ * Twig, Jinja, ERB, Rust/MiniJinja) gain the ability to admit this shape
+ * only once each grows a `segments`-based accessor emitter in Phase B —
+ * until then they still refuse it with BF104. Do not add
+ * `expectedDiagnostics` pins for this fixture in any adapter's suite
+ * (Phase B owns that).
+ */
+export const fixture = createFixture({
+  id: 'destructure-array-index-in-map',
+  description: 'Array-index (tuple) destructure in .map() callback, no rest (#2087)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+type Row = readonly [string, string]
+export function IndexPairs() {
+  const [rows, setRows] = createSignal<Row[]>([
+    ['r1', 'a'],
+    ['r2', 'b'],
+  ])
+  return (
+    <ul onClick={() => setRows(r => r)}>
+      {rows().map(([k, v]) => (
+        <li key={k}>{k}:{v}</li>
+      ))}
+    </ul>
+  )
+}
+`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s2">
+      <li data-key="r1"><!--bf:s0-->r1<!--/-->:<!--bf:s1-->a<!--/--></li>
+      <li data-key="r2"><!--bf:s0-->r2<!--/-->:<!--bf:s1-->b<!--/--></li>
+    </ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/destructure-nested-object-in-map.ts
+++ b/packages/adapter-tests/fixtures/destructure-nested-object-in-map.ts
@@ -1,0 +1,49 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Nested object-path destructure in a `.map()` callback, no rest
+ * (`{ id, user: { name } } => …`).
+ *
+ * Companion to `destructure-array-index-in-map`: that fixture pins the
+ * array-index `segments` shape (`{ kind: 'index', index }`); this one pins
+ * the nested `.field` shape (`{ kind: 'field', key: 'user', isIdent: true }`
+ * followed by `{ kind: 'field', key: 'name', isIdent: true }`) — two levels
+ * deep, still no rest. #2087 Phase A threads this structured path through
+ * `LoopParamBinding.segments` so adapters can build a native nested
+ * accessor without string-parsing `path`.
+ *
+ * Hono / CSR already lowered nested fixed-path destructure pre-#2087 (the
+ * client-JS emit path is unchanged by this PR). Text-template adapters
+ * refuse the shape with BF104 until each grows a `segments`-based emitter
+ * in Phase B — no `expectedDiagnostics` pins are added here for that; this
+ * fixture is expected to fail on those adapters' suites until then.
+ */
+export const fixture = createFixture({
+  id: 'destructure-nested-object-in-map',
+  description: 'Nested object-path destructure in .map() callback, no rest (#2087)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+type Row = { id: string; user: { name: string } }
+export function NestedNames() {
+  const [rows, setRows] = createSignal<Row[]>([
+    { id: 'r1', user: { name: 'Ada' } },
+    { id: 'r2', user: { name: 'Grace' } },
+  ])
+  return (
+    <ul onClick={() => setRows(r => r)}>
+      {rows().map(({ id, user: { name } }) => (
+        <li key={id}>{name}</li>
+      ))}
+    </ul>
+  )
+}
+`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s1">
+      <li data-key="r1"><!--bf:s0-->Ada<!--/--></li>
+      <li data-key="r2"><!--bf:s0-->Grace<!--/--></li>
+    </ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/destructure-nested-object-in-map.ts
+++ b/packages/adapter-tests/fixtures/destructure-nested-object-in-map.ts
@@ -13,10 +13,8 @@ import { createFixture } from '../src/types'
  * accessor without string-parsing `path`.
  *
  * Hono / CSR already lowered nested fixed-path destructure pre-#2087 (the
- * client-JS emit path is unchanged by this PR). Text-template adapters
- * refuse the shape with BF104 until each grows a `segments`-based emitter
- * in Phase B — no `expectedDiagnostics` pins are added here for that; this
- * fixture is expected to fail on those adapters' suites until then.
+ * client-JS emit path is unchanged). All seven template adapters lower it
+ * via their `segments`-based accessor emitters; none pin a diagnostic.
  */
 export const fixture = createFixture({
   id: 'destructure-nested-object-in-map',

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -178,11 +178,11 @@ import { fixture as restDestructureObjectInMap } from './rest-destructure-object
 import { fixture as restDestructureObjectSpreadInMap } from './rest-destructure-object-spread-in-map'
 import { fixture as restDestructureArrayInMap } from './rest-destructure-array-in-map'
 import { fixture as restDestructureNestedInMap } from './rest-destructure-nested-in-map'
-// #2087 Phase A: fixed-binding (no-rest) destructure shapes newly admitted
-// by `isLowerableLoopDestructure`'s `segments`-based gate — array-index
-// (tuple) and nested-object-path destructure. Hono/CSR already lowered
-// these; Go/Mojo/Xslate/Twig/Jinja/ERB/Rust refuse with BF104 until each
-// grows a `segments`-based accessor emitter in Phase B.
+// #2087: fixed-binding (no-rest) destructure shapes admitted by
+// `isLowerableLoopDestructure`'s `segments`-based gate — array-index
+// (tuple) and nested-object-path destructure. All seven template adapters
+// (Go/Mojo/Xslate/Twig/Jinja/ERB/Rust) lower these via their
+// `segments`-based accessor emitters; Hono/CSR lowered them all along.
 import { fixture as destructureArrayIndexInMap } from './destructure-array-index-in-map'
 import { fixture as destructureNestedObjectInMap } from './destructure-nested-object-in-map'
 // Priority 11: JS Array / String method lowering (#1448 Tier A).

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -178,6 +178,13 @@ import { fixture as restDestructureObjectInMap } from './rest-destructure-object
 import { fixture as restDestructureObjectSpreadInMap } from './rest-destructure-object-spread-in-map'
 import { fixture as restDestructureArrayInMap } from './rest-destructure-array-in-map'
 import { fixture as restDestructureNestedInMap } from './rest-destructure-nested-in-map'
+// #2087 Phase A: fixed-binding (no-rest) destructure shapes newly admitted
+// by `isLowerableLoopDestructure`'s `segments`-based gate — array-index
+// (tuple) and nested-object-path destructure. Hono/CSR already lowered
+// these; Go/Mojo/Xslate/Twig/Jinja/ERB/Rust refuse with BF104 until each
+// grows a `segments`-based accessor emitter in Phase B.
+import { fixture as destructureArrayIndexInMap } from './destructure-array-index-in-map'
+import { fixture as destructureNestedObjectInMap } from './destructure-nested-object-in-map'
 // Priority 11: JS Array / String method lowering (#1448 Tier A).
 // One fixture per method — every adapter starts pinned with BF101 in
 // its own `expectedDiagnostics`, and each method PR removes its row
@@ -410,6 +417,9 @@ export const jsxFixtures: JSXFixture[] = [
   restDestructureObjectSpreadInMap,
   restDestructureArrayInMap,
   restDestructureNestedInMap,
+  // #2087 Phase A: fixed-binding (no-rest) destructure — array-index / nested.
+  destructureArrayIndexInMap,
+  destructureNestedObjectInMap,
   // #1448 Tier A — Array methods.
   arrayIncludes,
   arrayIndexOf,

--- a/packages/adapter-tests/fixtures/rest-destructure-array-in-map.ts
+++ b/packages/adapter-tests/fixtures/rest-destructure-array-in-map.ts
@@ -4,8 +4,10 @@ import { createFixture } from '../src/types'
  * Array rest destructure in a `.map()` callback (`[first, ...tail]`).
  *
  * Counterpart to `rest-destructure-object-in-map`. The Hono / CSR emit
- * path lowers the rest binding to `__bfItem().slice(n)`. Text-template
- * adapters refuse the whole destructure shape with BF104. See #1310.
+ * path lowers the rest binding to `__bfItem().slice(n)`; since #2087 the
+ * template adapters lower it too (a per-item local bound to the runtime
+ * `slice` helper — the exact JS slice, so `tail.length` composes through
+ * each adapter's member emitter). Previously refused with BF104 (#1310).
  */
 export const fixture = createFixture({
   id: 'rest-destructure-array-in-map',

--- a/packages/adapter-tests/fixtures/rest-destructure-nested-in-map.ts
+++ b/packages/adapter-tests/fixtures/rest-destructure-nested-in-map.ts
@@ -6,8 +6,11 @@ import { createFixture } from '../src/types'
  *
  * Exercises the IR walker recursing into a nested array binding inside an
  * object pattern, where the inner pattern carries the rest token. Same
- * adapter parity contract as the flat-rest fixtures: Hono / CSR lowers it;
- * Go / Mojo refuse the loop destructure with BF104. See #1310.
+ * adapter parity contract as the flat-rest fixtures: Hono / CSR lowers it,
+ * and since #2087 the template adapters do too — the nested fixed binding
+ * walks the structured `segments` path (`.cells[0]`), and the nested
+ * array-rest slices the parent accessor. Previously refused with BF104
+ * (#1310).
  */
 export const fixture = createFixture({
   id: 'rest-destructure-nested-in-map',

--- a/packages/adapter-tests/fixtures/rest-destructure-object-in-map.ts
+++ b/packages/adapter-tests/fixtures/rest-destructure-object-in-map.ts
@@ -6,14 +6,12 @@ import { createFixture } from '../src/types'
  * #1309 / #1244 added IR-level support for rest patterns and the Hono / CSR
  * emit path lowers them to an inline residual-object accessor
  * (`(({ id: __bfR0, title: __bfR1, ...__bfRest }) => __bfRest)(__bfItem())`).
- * Text-template adapters (Go, Mojo) have no analogous lowering — they
- * already refuse any loop destructure (`paramBindings.length > 0`) with
- * BF104, but no fixture pinned that contract for the rest variant.
- *
- * This fixture lets each adapter declare its position against the rest
- * shape (currently both Go and Mojo expect BF104 via `expectedDiagnostics`).
- * When either adapter grows a native lowering, dropping the diagnostic
- * here is the single edit that flips the contract on. See #1310.
+ * The template adapters first lowered the member-read-only shape pinned
+ * here (the rest binding aliased to the whole item, `rest.flag` read back
+ * off it — #1310); #2087 generalized the destructure lowering (structured
+ * `segments` accessors, slice-based array-rest, residual-bag object-rest
+ * feeding the spread pipeline). All seven template adapters render this
+ * fixture through their real engines; none pin a diagnostic for it.
  */
 export const fixture = createFixture({
   id: 'rest-destructure-object-in-map',

--- a/packages/adapter-tests/fixtures/rest-destructure-object-spread-in-map.ts
+++ b/packages/adapter-tests/fixtures/rest-destructure-object-spread-in-map.ts
@@ -20,11 +20,12 @@ import { createFixture } from '../src/types'
  * destructured `title` sibling key is identifier-named; the rest
  * residual carries `data-priority` through to the spread).
  *
- * Text-template adapters (Go, Mojo) refuse the whole destructure shape
- * with BF104 regardless of whether the rest is spread or read; the
- * per-adapter `expectedDiagnostics` declarations pin that contract.
- * When either adapter grows a native lowering, dropping the diagnostic
- * here is the single edit that flips the contract on.
+ * Since #2087 the template adapters lower this shape natively: the rest
+ * local binds a TRUE residual bag (an `omit`-style runtime helper / Ruby
+ * `Hash#except`, subtracting the `RestExcludeKey` siblings) and the
+ * existing spread-attrs pipeline emits it, so the non-identifier
+ * `data-priority` key flows through each engine's quoted/attribute
+ * access form. Previously refused with BF104 and pinned per adapter.
  *
  * SSR / CSR attribute-order divergence (surfaced limitation):
  * Hono SSR serializes the residual-object attributes BEFORE the

--- a/packages/adapter-twig/php/src/BarefootJS.php
+++ b/packages/adapter-twig/php/src/BarefootJS.php
@@ -1431,6 +1431,44 @@ final class BarefootJS
         return $this->backend->mark_raw(implode(' ', $parts));
     }
 
+    /**
+     * Object-rest residual (`{ id, title, ...rest }` -> `rest`), #2087 Phase
+     * B. Returns a TRUE residual -- a fresh assoc array holding every key of
+     * `$bag` EXCEPT those in `$exclude` (the sibling keys the destructure
+     * pattern already bound explicitly) -- not an alias of the whole item,
+     * so a template read of `rest.someExplicitlyDestructuredKey` can't
+     * observe a value the JS destructure semantics say it shouldn't see.
+     *
+     * Mirrors `spread_attrs`'s bag-shape handling: `$bag` is either a
+     * `stdClass` (a JSON-decoded loop item) or a plain PHP assoc array (the
+     * "canonical value convention" accepts both as an "object" -- see
+     * `spread_attrs`'s docstring above). Returns a plain PHP array (not
+     * `stdClass`) so both Twig's dot accessor (`rest.flag`) and
+     * `spread_attrs`'s own bag handling work on the result unchanged --
+     * verified empirically against Twig 3.x: dot notation resolves an
+     * ARRAY-ITEM key before falling back to an object property, so `.flag`
+     * on an assoc array works exactly like `.flag` on a `stdClass`.
+     */
+    public function omit($bag, array $exclude): array
+    {
+        if ($bag instanceof \stdClass) {
+            $assoc = get_object_vars($bag);
+        } elseif (is_array($bag)) {
+            $assoc = $bag;
+        } else {
+            return [];
+        }
+        $excludeSet = array_flip(array_map('strval', $exclude));
+        $out = [];
+        foreach ($assoc as $key => $val) {
+            if (array_key_exists((string) $key, $excludeSet)) {
+                continue;
+            }
+            $out[$key] = $val;
+        }
+        return $out;
+    }
+
     // -----------------------------------------------------------------
     // NEW helpers vs. the Perl/Python ports (design doc section 2): JS
     // `===`/`!==` for the JSON value domain -- Twig `==` compiles to PHP

--- a/packages/adapter-twig/php/tests/run.php
+++ b/packages/adapter-twig/php/tests/run.php
@@ -25,6 +25,7 @@ $testFiles = [
     'test_query.php',
     'test_search_params.php',
     'test_spread_attrs.php',
+    'test_omit.php',
     'test_props_attr.php',
     'test_render_child.php',
     'test_render.php',

--- a/packages/adapter-twig/php/tests/test_omit.php
+++ b/packages/adapter-twig/php/tests/test_omit.php
@@ -9,9 +9,11 @@ declare(strict_types=1);
  * (`twig-adapter.ts`'s `renderLoop`): each loop iteration binds `rest` to
  * `bf.omit(item, [excludeKeys])`, a TRUE residual hash (every key of the
  * item except the ones the pattern destructured explicitly), not an alias
- * of the whole item. No JS/Perl/Python counterpart -- this helper is
- * Twig-only, since Twig (unlike those hosts) has no bareword-key hash
- * literal it could use to materialize the residual inline.
+ * of the whole item. Every template-adapter runtime ships the same helper
+ * under the same contract (#2087 Phase B: Go `bf_omit`, shared Perl
+ * `BarefootJS::omit`, Python/Rust `bf.omit`) -- except ERB, which uses
+ * Ruby's native `Hash#except`. Only the JS/CSR side has no `omit`: it
+ * materializes the residual with a real destructure IIFE instead.
  */
 
 require_once __DIR__ . '/_harness.php';

--- a/packages/adapter-twig/php/tests/test_omit.php
+++ b/packages/adapter-twig/php/tests/test_omit.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * `BarefootJS::omit` -- object-rest destructure residual (#2087 Phase B).
+ *
+ * Backs the Twig adapter's `.map(({ id, title, ...rest }) => ...)` lowering
+ * (`twig-adapter.ts`'s `renderLoop`): each loop iteration binds `rest` to
+ * `bf.omit(item, [excludeKeys])`, a TRUE residual hash (every key of the
+ * item except the ones the pattern destructured explicitly), not an alias
+ * of the whole item. No JS/Perl/Python counterpart -- this helper is
+ * Twig-only, since Twig (unlike those hosts) has no bareword-key hash
+ * literal it could use to materialize the residual inline.
+ */
+
+require_once __DIR__ . '/_harness.php';
+bf_require_runtime();
+bf_reset();
+
+use Barefoot\BarefootJS;
+
+$bf = new BarefootJS(null, ['backend' => new class {
+    public function mark_raw($s)
+    {
+        return $s;
+    }
+}]);
+
+bf_test('basic shapes', function () use ($bf) {
+    bf_assert_eq($bf->omit(null, ['id']), []);
+    bf_assert_eq($bf->omit('not a bag', ['id']), []);
+    bf_assert_eq($bf->omit([], ['id']), []);
+    bf_assert_eq($bf->omit(['id' => 'a', 'flag' => 'x'], []), ['id' => 'a', 'flag' => 'x']);
+});
+
+bf_test('excludes the destructured sibling keys, keeps the rest', function () use ($bf) {
+    $item = ['id' => 't1', 'title' => 'one', 'data-priority' => 'high', 'tag' => 'urgent'];
+    bf_assert_eq($bf->omit($item, ['id', 'title']), ['data-priority' => 'high', 'tag' => 'urgent']);
+});
+
+bf_test('accepts a stdClass bag (JSON-decoded loop item shape)', function () use ($bf) {
+    $item = json_decode('{"id": "t1", "title": "one", "flag": "a"}');
+    bf_assert_eq($bf->omit($item, ['id', 'title']), ['flag' => 'a']);
+});
+
+bf_test('excluding every key yields an empty residual', function () use ($bf) {
+    bf_assert_eq($bf->omit(['id' => 'a'], ['id']), []);
+});
+
+bf_test('an exclude key absent from the bag is a no-op', function () use ($bf) {
+    bf_assert_eq($bf->omit(['id' => 'a'], ['nope']), ['id' => 'a']);
+});
+
+return bf_finish();

--- a/packages/adapter-twig/src/__tests__/twig-adapter.test.ts
+++ b/packages/adapter-twig/src/__tests__/twig-adapter.test.ts
@@ -34,25 +34,33 @@ runAdapterConformanceTests({
     // `.map`) as Jinja.
     'todo-app': [{ code: 'BF103', severity: 'error' }],
     'todo-app-ssr': [{ code: 'BF103', severity: 'error' }],
-    // Array-destructure loop param (`([k, v]) => …`) can't lower to a
-    // single Twig `for` loop variable (same BF104 as Jinja — Twig's
-    // `for item in list` binds one loop variable, just like Jinja's
-    // `for item in arr`).
-    'static-array-from-props': [{ code: 'BF104', severity: 'error' }],
-    // Both BF103 (imported child) and BF104 (destructure) fire.
+    // The `([emoji, users]) => …` array-destructure param itself now lowers
+    // (#2087 Phase B — see the destructure comment below), but the loop
+    // ARRAY is a function-scope computed const (`const entries =
+    // Object.entries(props.reactions ?? {}).filter(...)`) that the adapter
+    // can't bind as a template variable — refused loudly with BF101 (same
+    // check and policy as Jinja / ERB) instead of silently iterating zero
+    // times over an unbound name.
+    'static-array-from-props': [{ code: 'BF101', severity: 'error' }],
+    // Both BF103 (imported child) and BF101 (computed local-const loop
+    // array, as above) fire.
     'static-array-from-props-with-component': [
       { code: 'BF103', severity: 'error' },
-      { code: 'BF104', severity: 'error' },
+      { code: 'BF101', severity: 'error' },
     ],
-    // Rest-destructure `.map()` callbacks — the object-rest shape read via
-    // member access (`rest-destructure-object-in-map`) lowers via a Twig
-    // `{% set %}` local binding (same mechanism as Jinja's `{% set %}`).
-    // The other three stay refused: rest SPREAD needs a residual object,
-    // array-index / nested paths can't unpack a tuple (same surface as
-    // Jinja).
-    'rest-destructure-object-spread-in-map': [{ code: 'BF104', severity: 'error' }],
-    'rest-destructure-array-in-map': [{ code: 'BF104', severity: 'error' }],
-    'rest-destructure-nested-in-map': [{ code: 'BF104', severity: 'error' }],
+    // #2087 Phase B: every `.map()` destructure shape in the shared corpus
+    // now lowers on Twig via a `{% set %}` local built from the binding's
+    // structured `segments` path (`twigLoopBindingAccessor` in
+    // `lib/twig-naming.ts`) — fixed bindings at any field/index depth
+    // (`destructure-array-index-in-map`, `destructure-nested-object-in-map`),
+    // array-rest via `bf.slice` (`rest-destructure-array-in-map`,
+    // `rest-destructure-nested-in-map`), and object-rest via the new
+    // `bf.omit` residual helper, read by member access
+    // (`rest-destructure-object-in-map`) or spread onto the element
+    // (`rest-destructure-object-spread-in-map`). No `expectedDiagnostics`
+    // pins remain for any of them — see `twig-adapter.ts`'s `renderLoop` for
+    // the still-refused shapes (bare-value rest use, `.filter().map()`
+    // chains, `__bf_`-prefixed names).
     // The site/ui Button auto-infers a `<Slot>` sibling that spreads
     // `{...props}` / `{...children.props}` onto its root element. Twig
     // hash literals can't splat a runtime dict into named call-site

--- a/packages/adapter-twig/src/adapter/lib/twig-naming.ts
+++ b/packages/adapter-twig/src/adapter/lib/twig-naming.ts
@@ -24,6 +24,8 @@
  *    `if` is threaded through as template var `'if_'` on both sides.
  */
 
+import type { LoopBindingPathSegment } from '@barefootjs/jsx'
+
 /**
  * Escape a string for a Twig single-quoted literal: backslash first (so it
  * doesn't double-escape the quote we add next), then the quote. Verified
@@ -70,4 +72,59 @@ const RESERVED_WORDS = new Set([
  */
 export function twigIdent(name: string): string {
   return RESERVED_WORDS.has(name) ? `${name}_` : name
+}
+
+/**
+ * Build a Twig accessor expression that walks a `.map()` destructure
+ * binding's structured `segments` path (#2087 Phase A, `LoopBindingPathSegment`)
+ * off `base` — the per-iteration loop var (`__bf_item`) for a fixed binding
+ * or a top-level rest binding, or an already-built PARENT accessor for a
+ * nested rest binding (`segments` there is the prefix up to, not including,
+ * the rest token).
+ *
+ * Verified empirically against Twig 3.x (`vendor/twig/twig` bundled under
+ * `packages/adapter-twig/php`) — the two SSR item shapes this walk ever
+ * touches are a JSON-decoded `stdClass` (an object field) or a PHP list
+ * array (an array index), per the "canonical value convention" documented in
+ * `test-render.ts` (JSON objects → stdClass, JSON arrays → PHP lists):
+ *
+ *   - `index` segments ALWAYS use bracket subscript (`base[N]`), never Twig's
+ *     `base.N` dot form. Chaining two dot-number steps (`base.0.1`) mis-lexes
+ *     as the single FLOAT LITERAL `0.1` — Twig's lexer greedily consumes
+ *     `NUMBER '.' NUMBER` as one token right after the leading dot — which
+ *     silently produces the wrong accessor instead of a parse error.
+ *     Bracket subscript has no such collision, at any chain position, and
+ *     works identically on a PHP list.
+ *   - `field` segments with an identifier-safe key (`isIdent`) use dot
+ *     notation (`base.key`): Twig's dot accessor resolves an object PROPERTY
+ *     first, which is correct on `stdClass` — confirmed empirically that
+ *     even reserved-word-shaped keys (`if`, `and`, `class`) read fine as
+ *     `.if` / `.and` / `.class`, since Twig's NAME token is not
+ *     keyword-reserved at the lexer level (only bareword HASH-LITERAL keys
+ *     are, which is why `twigHashKey` above always quotes).
+ *   - `field` segments with a non-identifier key (e.g. `'data-priority'`)
+ *     do NOT use bracket subscript the way a JS accessor string would —
+ *     confirmed empirically that Twig's `[...]` subscript on a `stdClass` is
+ *     an ARRAY-item lookup only and silently resolves to nothing (no error,
+ *     under `strict_variables: false`). Twig's built-in `attribute(receiver,
+ *     key)` function is the one accessor that checks object-property AND
+ *     array-item access uniformly (confirmed against both `stdClass` and PHP
+ *     arrays, string or integer key), so non-ident field steps route through
+ *     it instead.
+ */
+export function twigLoopBindingAccessor(
+  base: string,
+  segments: readonly LoopBindingPathSegment[],
+): string {
+  let acc = base
+  for (const seg of segments) {
+    if (seg.kind === 'index') {
+      acc = `${acc}[${seg.index}]`
+    } else if (seg.isIdent) {
+      acc = `${acc}.${seg.key}`
+    } else {
+      acc = `attribute(${acc}, '${escapeTwigSingleQuoted(seg.key)}')`
+    }
+  }
+  return acc
 }

--- a/packages/adapter-twig/src/adapter/twig-adapter.ts
+++ b/packages/adapter-twig/src/adapter/twig-adapter.ts
@@ -187,7 +187,7 @@ import {
   collectModuleStringConsts,
   extractArrowBodyExpression,
   collectContextConsumers,
-  isLowerableObjectRestDestructure,
+  isLowerableLoopDestructure,
   type ContextConsumer,
   lookupStaticRecordLiteral,
   searchParamsLocalNames,
@@ -201,7 +201,7 @@ import { BF_SLOT, BF_COND, BF_REGION } from '@barefootjs/shared'
 
 import type { TwigRenderCtx } from './lib/types.ts'
 import { TWIG_PRIMITIVE_EMIT_MAP } from './lib/constants.ts'
-import { twigHashKey, twigIdent, escapeTwigSingleQuoted } from './lib/twig-naming.ts'
+import { twigHashKey, twigIdent, escapeTwigSingleQuoted, twigLoopBindingAccessor } from './lib/twig-naming.ts'
 import {
   resolveJsxChildrenProp,
   collectRootScopeNodes,
@@ -699,32 +699,76 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
       return `{{ bf.comment("loop:${loop.markerId}") | raw }}{{ bf.comment("/loop:${loop.markerId}") | raw }}`
     }
 
-    // An array/object-destructure loop param (`([emoji, users]) => ...` or
-    // `({ name, age }) => ...`) lowers to invalid Twig — Twig's `for item in
-    // list` binds a single loop variable and can't unpack a tuple the way a
-    // Python `for` statement can. Surface this at build time instead of
-    // shipping a broken template line.
-    // A destructure loop param is lowerable for the object-rest / simple-field
-    // shape (`.map(({ id, title, ...rest }) => …)`, `rest` read via member
-    // access): each binding becomes a `{% set %}` local off the per-item var,
-    // so the body's `id` / `rest.flag` resolve. Array-index / nested /
-    // rest-spread shapes still can't unpack a tuple → BF104. (#1310)
+    // A `.map()` destructure loop param (`([k, v]) => ...` / `({ id, title,
+    // ...rest }) => ...`) lowers to a Twig `{% set %}` local per binding, off
+    // a structured accessor built from `LoopParamBinding.segments` (#2087) —
+    // see `twigLoopBindingAccessor`. `isLowerableLoopDestructure` (#2087
+    // Phase A) admits: fixed bindings at any field/index depth (`.field`,
+    // `[k, v]`, and nested combinations), array-rest (`[first, ...tail]` →
+    // `bf.slice`), and object-rest (`{ id, ...rest }` → `bf.omit`) whose
+    // every use is a member read (`rest.flag`) or a `{...rest}` spread onto
+    // an intrinsic element. Still refused (→ BF104): any OTHER object-rest
+    // use (needs the actual residual value some other way, e.g.
+    // `String(rest)` or `{...fn(rest)}`), a `.filter().map(destructure)`
+    // chain (needs the filter-param rewrite to retarget the synthetic
+    // per-item var), and a binding name in the reserved `__bf_` namespace
+    // (would collide with the synthetic per-item loop var). (#1310, #2087)
     const destructure = !!(loop.paramBindings && loop.paramBindings.length > 0)
-    const supportableDestructure = destructure && isLowerableObjectRestDestructure(loop)
+    const supportableDestructure = destructure && isLowerableLoopDestructure(loop)
     if (destructure && !supportableDestructure) {
       this.errors.push({
         code: 'BF104',
         severity: 'error',
-        message: `Loop callback uses an array/object destructure pattern (\`${loop.param}\`) that the Twig adapter cannot lower — Twig \`for item in list\` binds a single loop variable and can't unpack a tuple.`,
+        message: `Loop callback uses a destructure pattern (\`${loop.param}\`) that the Twig adapter cannot lower — e.g. an object-rest binding used as a bare value, a \`.filter().map(destructure)\` chain, or a reserved \`__bf_\`-prefixed binding name.`,
         loc: loop.loc ?? { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
         suggestion: {
           message:
             `Options:\n` +
-            `  1. Rename the parameter to a single name and access tuple elements with index syntax in the body (e.g. \`entry => entry[0]\` instead of \`([k, v]) => ...\`).\n` +
+            `  1. Read the rest binding via member access (\`rest.flag\`) or spread it onto the element (\`{...rest}\`) instead of using it as a bare value.\n` +
             `  2. Mark the loop position as @client-only so the destructure runs in JS on the client.\n` +
             `  3. Move the loop into a primitive that the adapter registers explicitly.`,
         },
       })
+    }
+
+    // A `.map()` loop whose array is a bare identifier bound to a
+    // FUNCTION-scope local const with a non-statically-evaluable initializer
+    // that reads props/signals (e.g. `const entries =
+    // Object.entries(props.x ?? {}).filter(...)`) can't render correctly.
+    // Module-scope consts (`isModule`, e.g. `const payments = [...]` at the
+    // top of the file) are a DIFFERENT, already-working case — the shared
+    // `ssr-defaults.ts` statically evaluates those and seeds them straight
+    // into the render context, so a bare `payments` reference resolves for
+    // free (data-table demo). Function-scope locals get no such seeding
+    // (`ssr-defaults.ts`: "component-scope locals can depend on
+    // signals/props and are evaluated lazily elsewhere") — and this
+    // adapter's only "elsewhere" is inlining a const's value at its use
+    // site (`_resolveLiteralConst`'s numeric/single-quoted-string fast
+    // path, or a static-record-literal lookup), never binding one as a
+    // `{% set %}` template local. Left unchecked, `{% for item in entries
+    // %}` over an unbound name would silently iterate zero times (Twig's
+    // `strict_variables: false` resolves it to `null` rather than raising)
+    // instead of failing loudly. Pre-existing, general limitation,
+    // orthogonal to #2087's destructure-binding work — newly reachable in
+    // this adapter's test corpus only because the widened destructure gate
+    // (#2087 Phase A/B) no longer refuses this fixture's `([emoji, users])
+    // => ...` param first. Same policy and shape as the Jinja / ERB
+    // adapters' check.
+    const arrayName = loop.array.trim()
+    if (/^[A-Za-z_$][\w$]*$/.test(arrayName)) {
+      const arrayConst = (this.localConstants ?? []).find(c => c.name === arrayName)
+      if (arrayConst && !arrayConst.isModule && this._resolveLiteralConst(arrayName) === null) {
+        this.errors.push({
+          code: 'BF101',
+          severity: 'error',
+          message: `Loop array \`${arrayName}\` is a local computed value (\`${arrayConst.value}\`) that the Twig adapter cannot bind as a template variable — only numeric/string-literal locals inline at their use site.`,
+          loc: loop.loc ?? { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+          suggestion: {
+            message:
+              'Pre-compute the array server-side and pass it as a prop, or mark the loop position as @client-only so it runs in JS on the client.',
+          },
+        })
+      }
     }
 
     const rawArray = this.convertExpressionToTwig(loop.array)
@@ -764,9 +808,18 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
 
     // Index alias: when an explicit `index` param is present (`.map((x, i) =>
     // ...)`) or the iteration is `keys`-shaped, expose it via a `{% set %}`
-    // local bound to Twig's `loop.index0`. A supported destructure param
-    // adds one `{% set %}` local per binding (`rest` aliases the item so
-    // `rest.flag` resolves).
+    // local bound to Twig's `loop.index0`. A supported destructure param adds
+    // one `{% set %}` local per binding, built from the binding's structured
+    // `segments` path (never `b.path` verbatim — see `twigLoopBindingAccessor`
+    // for why a naive JS-accessor splice mis-lowers on Twig/stdClass):
+    //   - fixed binding: the full accessor off the per-item var.
+    //   - array-rest (`[first, ...tail]`): `bf.slice(parent, from, null)` —
+    //     `parent` is the accessor for `segments` (the rest token's PARENT
+    //     prefix, empty at the loop root), `from` is the rest's start index.
+    //   - object-rest (`{ id, ...rest }`): `bf.omit(parent, [excludeKeys])` —
+    //     a TRUE residual hash (not an alias of the whole item), so a use
+    //     other than member-access / spread (already refused by the gate)
+    //     can't observe a sibling field the pattern destructured explicitly.
     const indexLocalLines: string[] = []
     if (loop.iterationShape === 'keys') {
       indexLocalLines.push(`{% set ${twigIdent(param)} = loop.index0 %}`)
@@ -774,12 +827,23 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
       indexLocalLines.push(`{% set ${twigIdent(loop.index)} = loop.index0 %}`)
     }
     if (supportableDestructure) {
+      const loopVarIdent = twigIdent(loopVar)
       for (const b of loop.paramBindings ?? []) {
-        indexLocalLines.push(
-          b.rest
-            ? `{% set ${twigIdent(b.name)} = ${twigIdent(loopVar)} %}`
-            : `{% set ${twigIdent(b.name)} = ${twigIdent(loopVar)}${b.path} %}`,
-        )
+        const parentAccessor = twigLoopBindingAccessor(loopVarIdent, b.segments ?? [])
+        if (b.rest?.kind === 'array') {
+          indexLocalLines.push(
+            `{% set ${twigIdent(b.name)} = bf.slice(${parentAccessor}, ${b.rest.from}, null) %}`,
+          )
+        } else if (b.rest?.kind === 'object') {
+          const excludeList = b.rest.exclude
+            .map(k => `'${escapeTwigSingleQuoted(k.key)}'`)
+            .join(', ')
+          indexLocalLines.push(
+            `{% set ${twigIdent(b.name)} = bf.omit(${parentAccessor}, [${excludeList}]) %}`,
+          )
+        } else {
+          indexLocalLines.push(`{% set ${twigIdent(b.name)} = ${parentAccessor} %}`)
+        }
       }
     }
 

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -47,22 +47,38 @@ runAdapterConformanceTests({
     // lowers and the only remaining gate is the imported-child one.
     'todo-app': [{ code: 'BF103', severity: 'error' }],
     'todo-app-ssr': [{ code: 'BF103', severity: 'error' }],
-    // Array-destructure loop param (`([k, v]) => …`) can't lower to a
-    // single Kolon loop variable (same BF104 as mojo).
-    'static-array-from-props': [{ code: 'BF104', severity: 'error' }],
-    // Both BF103 (imported child) and BF104 (destructure) fire.
+    // `([emoji, users]) => ...` / `([id, t]) => ...` are plain array-index
+    // (tuple) destructures, no rest — #2087 Phase B's `segments`-walking
+    // accessor lowers both to `$__bf_item[0]` / `$__bf_item[1]` `: my` locals
+    // like any other fixed binding, so BF104 no longer fires for either
+    // fixture. Each now hits a DIFFERENT, pre-existing, orthogonal gap
+    // instead: the loop array (`entries`) is a function-scope local const
+    // with a computed initializer (`Object.entries(props.x ?? {}).filter(...)`)
+    // that the adapter can't bind as a template variable — see the dedicated
+    // `arrayConst` BF101 check in `renderLoop`. This was always true; it was
+    // simply unreachable before because BF104 refused the destructure shape
+    // first.
+    'static-array-from-props': [{ code: 'BF101', severity: 'error' }],
+    // Both BF103 (sibling-imported `<Tag>` child component) and the BF101
+    // above fire; BF104 no longer does (see above).
     'static-array-from-props-with-component': [
       { code: 'BF103', severity: 'error' },
-      { code: 'BF104', severity: 'error' },
+      { code: 'BF101', severity: 'error' },
     ],
-    // Rest-destructure `.map()` callbacks — the object-rest shape read via
-    // member access (`rest-destructure-object-in-map`) now lowers via Kolon
-    // `: my` binding locals (`$rest` aliases the item). The other three stay
-    // refused: rest SPREAD needs a residual object, array-index / nested paths
-    // can't unpack a tuple (same surface as mojo).
-    'rest-destructure-object-spread-in-map': [{ code: 'BF104', severity: 'error' }],
-    'rest-destructure-array-in-map': [{ code: 'BF104', severity: 'error' }],
-    'rest-destructure-nested-in-map': [{ code: 'BF104', severity: 'error' }],
+    // #1310 / #2087: rest destructure in .map() callback. All four shapes now
+    // lower via #2087 Phase B's `segments`-walking accessor:
+    //   - object-rest read via member access (`rest-destructure-object-in-map`):
+    //     `$bf.omit($__bf_item, [...exclude keys...])`, `$rest.flag` reads the
+    //     residual hashref.
+    //   - object-rest spread onto the root element
+    //     (`rest-destructure-object-spread-in-map`): same `$bf.omit(...)`
+    //     residual, forwarded via the existing `$bf.spread_attrs($rest)` path.
+    //   - array-rest (`rest-destructure-array-in-map`): `$bf.slice($__bf_item,
+    //     N, nil)` — the same runtime helper `.slice()` JS-method calls use.
+    //   - nested rest inside an object pattern (`rest-destructure-nested-in-map`):
+    //     the parent-prefix accessor (`$__bf_item.cells`) feeds the same
+    //     `$bf.slice(...)` call.
+    // None of these are pinned here anymore.
     // XSLATE-SPECIFIC (mojo passes this): the site/ui Button auto-infers a
     // `<Slot>` sibling that spreads `{...props}` / `{...children.props}`
     // onto its root element. Kolon hashref method args can't splat a

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -40,6 +40,7 @@ import type {
   TypeInfo,
   TemplatePrimitiveRegistry,
   IRMetadata,
+  LoopBindingPathSegment,
 } from '@barefootjs/jsx'
 import {
   BaseAdapter,
@@ -64,13 +65,13 @@ import {
   collectModuleStringConsts,
   extractArrowBodyExpression,
   collectContextConsumers,
-  isLowerableObjectRestDestructure,
   type ContextConsumer,
   lookupStaticRecordLiteral,
   searchParamsLocalNames,
   prepareLoweringMatchers,
   queryHrefArgs,
   sortComparatorFromArrow,
+  isLowerableLoopDestructure,
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr } from './boolean-result.ts'
 import ts from 'typescript'
@@ -79,7 +80,7 @@ import { BF_SLOT, BF_COND, BF_REGION } from '@barefootjs/shared'
 
 import type { XslateRenderCtx } from './lib/types.ts'
 import { XSLATE_PRIMITIVE_EMIT_MAP } from './lib/constants.ts'
-import { kolonHashKey } from './lib/kolon-naming.ts'
+import { kolonHashKey, escapeKolonSingleQuoted } from './lib/kolon-naming.ts'
 import {
   resolveJsxChildrenProp,
   collectRootScopeNodes,
@@ -107,6 +108,47 @@ import {
 
 export type { XslateAdapterOptions } from './lib/types.ts'
 import type { XslateAdapterOptions } from './lib/types.ts'
+
+/**
+ * Build a Kolon accessor expression for a `.map()` destructure binding's
+ * structured `segments` path (#2087 Phase B), walking `field` (`.key` for an
+ * identifier-safe name, `["key"]` — quoted with `kolonHashKey`'s convention —
+ * otherwise, since Kolon parses `$x.data-priority` as a subtraction) /
+ * `index` (`[N]`) steps onto `base`. Verified against real Text::Xslate that
+ * dot- and bracket-access chain freely (`$x.cells[0]`, `$x["cells"][0]`).
+ * Never string-parses `LoopParamBinding.path` — see the repo-wide rule
+ * against regex-parsing JS/TS-derived syntax.
+ *
+ * Used both for a fixed binding's FULL accessor (`base` = `$__bf_item`,
+ * `segments` = the whole path) and a rest binding's PARENT-prefix accessor
+ * (`segments` may be empty, at the loop root, in which case this returns
+ * `base` unchanged) — see `LoopParamBinding.segments` jsdoc for which case
+ * a binding is in.
+ */
+function kolonSegmentAccessor(base: string, segments: readonly LoopBindingPathSegment[]): string {
+  let expr = base
+  for (const seg of segments) {
+    expr +=
+      seg.kind === 'field'
+        ? seg.isIdent
+          ? `.${seg.key}`
+          : `[${kolonHashKey(seg.key)}]`
+        : `[${seg.index}]`
+  }
+  return expr
+}
+
+/**
+ * Quote a string as a Kolon single-quoted literal, unconditionally — unlike
+ * `kolonHashKey` (which leaves an identifier-safe name unquoted for `key =>
+ * val` hashref-literal position), a plain array-literal element
+ * (`$bf.omit($x, [id, title])`) is NOT hash-key position: Kolon has no
+ * bareword-as-string convention there, so every object-rest exclude key
+ * needs an explicit string literal.
+ */
+function kolonStringLiteral(s: string): string {
+  return `'${escapeKolonSingleQuoted(s)}'`
+}
 
 export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRenderCtx> {
   name = 'xslate'
@@ -578,31 +620,77 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
       return `<: $bf.comment("loop:${loop.markerId}") | mark_raw :><: $bf.comment("/loop:${loop.markerId}") | mark_raw :>`
     }
 
-    // An array/object-destructure loop param (`([emoji, users]) => ...` or
-    // `({ name, age }) => ...`) lowers to invalid Kolon — Kolon's `for LIST
-    // -> $item` binds a single scalar and can't unpack a tuple. Surface this
-    // at build time instead of shipping a broken template line.
-    // A destructure loop param is lowerable for the object-rest / simple-field
-    // shape (`.map(({ id, title, ...rest }) => …)`, `rest` read via member
-    // access): each binding becomes a Kolon `: my` local off the per-item var,
-    // so the body's `$id` / `$rest.flag` resolve. Array-index / nested /
-    // rest-spread shapes still can't unpack a tuple → BF104. (#1310)
+    // A `.map()` destructure loop param (`([k, v]) => ...` / `({ id, user: {
+    // name } }) => ...` / `({ id, ...rest }) => ...`) lowers to a Kolon `: my`
+    // local per binding, walking each binding's structured `segments` path
+    // (#2087 Phase B) into a native `.key` / `["key"]` / `[N]` accessor off
+    // the per-item var — so the body's `$id` / `$name` / `$rest.flag` /
+    // `{...rest}` all resolve natively, at any nesting depth.
+    //
+    // Check the IR's structured `paramBindings` field rather than
+    // string-matching `loop.param`: Phase 1 populates `paramBindings`
+    // iff the param is a destructure pattern (array or object); a
+    // simple identifier leaves it `undefined`. The structured check is
+    // robust to whitespace / formatting variants in the source.
+    //
+    // `isLowerableLoopDestructure` (#2087) still refuses: an object-rest
+    // binding used any way other than member access (`rest.flag`) or a
+    // `{...rest}` spread onto an intrinsic element (that needs the actual
+    // residual *object*, which isn't always safe to materialize — see the
+    // gate's own jsdoc for the full list); a `.filter().map(destructure)`
+    // chain (the filter-param rewrite is out of scope here); and a
+    // computed property key (`{ [k]: v }`, refused earlier as BF025).
     const destructure = !!(loop.paramBindings && loop.paramBindings.length > 0)
-    const supportableDestructure = destructure && isLowerableObjectRestDestructure(loop)
+    const supportableDestructure = destructure && isLowerableLoopDestructure(loop)
     if (destructure && !supportableDestructure) {
       this.errors.push({
         code: 'BF104',
         severity: 'error',
-        message: `Loop callback uses an array/object destructure pattern (\`${loop.param}\`) that the Xslate adapter cannot lower — Kolon \`for LIST -> $item\` binds a single scalar and can't unpack a tuple.`,
+        message: `Loop callback uses a destructure pattern (\`${loop.param}\`) that the Xslate adapter cannot lower — see the diagnostic detail for the specific shape.`,
         loc: loop.loc ?? { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
         suggestion: {
           message:
             `Options:\n` +
-            `  1. Rename the parameter to a single name and access tuple elements with index syntax in the body (e.g. \`entry => entry[0]\` instead of \`([k, v]) => ...\`).\n` +
-            `  2. Mark the loop position as @client-only so the destructure runs in JS on the client.\n` +
-            `  3. Move the loop into a primitive that the adapter registers explicitly.`,
+            `  1. If this is an object-rest binding (\`{ ...rest }\`), only reading \`rest.field\` or spreading \`{...rest}\` onto an intrinsic element lowers — other uses (passing \`rest\` to a function, rendering it as text) need the client runtime.\n` +
+            `  2. If this is chained \`.filter().map(({ ... }) => ...)\`, hoist the destructure into a variable inside the callback body instead.\n` +
+            `  3. Mark the loop position as @client-only so the destructure runs in JS on the client.\n` +
+            `  4. Move the loop into a primitive that the adapter registers explicitly.`,
         },
       })
+    }
+
+    // A `.map()` loop whose array is a bare identifier bound to a
+    // FUNCTION-scope local const with a non-statically-evaluable initializer
+    // that reads props/signals (e.g. `const entries =
+    // Object.entries(props.x ?? {}).filter(...)`) can't render correctly.
+    // Module-scope consts (`isModule`, e.g. `const payments = [...]` at the
+    // top of the file) are a DIFFERENT, already-working case handled
+    // elsewhere. Function-scope locals get no per-render stash slot — this
+    // adapter's only "elsewhere" for a local const is inlining its value at
+    // the use site (`_resolveLiteralConst`'s numeric/single-quoted-string
+    // fast path, or a static-record-literal lookup), never binding one as a
+    // `: my` template local. Left unchecked, `: for $entries -> $__bf_item {`
+    // over an undeclared `$entries` faults at request time instead of
+    // failing loudly at build time. Pre-existing, general limitation,
+    // orthogonal to #2087's destructure-binding work — newly reachable in
+    // this adapter's test corpus only because the widened destructure gate
+    // (#2087 Phase A/B) no longer refuses this fixture's `([emoji, users])
+    // => ...` param first.
+    const arrayName = loop.array.trim()
+    if (/^[A-Za-z_$][\w$]*$/.test(arrayName)) {
+      const arrayConst = (this.localConstants ?? []).find(c => c.name === arrayName)
+      if (arrayConst && !arrayConst.isModule && this._resolveLiteralConst(arrayName) === null) {
+        this.errors.push({
+          code: 'BF101',
+          severity: 'error',
+          message: `Loop array \`${arrayName}\` is a local computed value (\`${arrayConst.value}\`) that the Xslate adapter cannot bind as a template variable — only numeric/string-literal locals inline at their use site.`,
+          loc: loop.loc ?? { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+          suggestion: {
+            message:
+              'Pre-compute the array server-side and pass it as a prop, or mark the loop position as @client-only so it runs in JS on the client.',
+          },
+        })
+      }
     }
 
     const rawArray = this.convertExpressionToKolon(loop.array)
@@ -642,8 +730,20 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     // Index alias: when an explicit `index` param is present (`.map((x, i) =>
     // ...)`) or the iteration is `keys`-shaped, expose it via a `: my` Kolon
     // local bound to the loop variable's `.index` accessor. A supported
-    // destructure param adds one `: my` local per binding (`rest` aliases the
-    // item so `$rest.flag` resolves).
+    // destructure param adds one `: my` local per binding, walking each
+    // binding's `segments` path (#2087 Phase B):
+    //   - fixed (`b.rest` unset): the FULL accessor from `$__bf_item`.
+    //   - array-rest: `$bf.slice(parent, from, nil)` — the same runtime
+    //     helper `.slice()` JS-method calls lower to (see `array-method.ts`),
+    //     so the "no end → to length" arithmetic stays in one place. Kolon's
+    //     undefined literal is `nil`, not Perl's `undef`.
+    //   - object-rest: `$bf.omit(parent, [...excluded keys...])` — a TRUE
+    //     residual hashref (not the whole item aliased), so both
+    //     `$rest.flag` (member-access use) and `$bf.spread_attrs($rest)`
+    //     (spread-onto-element use) see only the non-destructured keys.
+    // `parent` is `$__bf_item` walked through the binding's PARENT-prefix
+    // `segments` (empty at the loop root, per the `LoopParamBinding` jsdoc) —
+    // NOT the same as a fixed binding's full-accessor segments.
     const indexLocalLines: string[] = []
     if (loop.iterationShape === 'keys') {
       indexLocalLines.push(`: my $${param} = $~${loopVar}.index;`)
@@ -652,11 +752,17 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     }
     if (supportableDestructure) {
       for (const b of loop.paramBindings ?? []) {
-        indexLocalLines.push(
-          b.rest
-            ? `: my $${b.name} = $${loopVar};`
-            : `: my $${b.name} = $${loopVar}${b.path};`,
-        )
+        const parent = kolonSegmentAccessor(`$${loopVar}`, b.segments ?? [])
+        if (b.rest?.kind === 'object') {
+          const exclude = b.rest.exclude.map(k => kolonStringLiteral(k.key)).join(', ')
+          indexLocalLines.push(`: my $${b.name} = $bf.omit(${parent}, [${exclude}]);`)
+        } else if (b.rest?.kind === 'array') {
+          indexLocalLines.push(`: my $${b.name} = $bf.slice(${parent}, ${b.rest.from}, nil);`)
+        } else {
+          indexLocalLines.push(
+            `: my $${b.name} = ${kolonSegmentAccessor(`$${loopVar}`, b.segments ?? [])};`,
+          )
+        }
       }
     }
 

--- a/packages/jsx/src/__tests__/loop-destructure.test.ts
+++ b/packages/jsx/src/__tests__/loop-destructure.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Tests for #2087 Phase A: `isLowerableLoopDestructure` (née
+ * `isLowerableObjectRestDestructure`) — the gate template adapters use to
+ * decide whether a `.map()` callback's destructure param can be lowered
+ * natively, versus falling back to the BF104 diagnostic.
+ *
+ * Compiles a small component to IR (`analyzeComponent` + `jsxToIR`, the same
+ * helper pattern as `ir-sort-comparator.test.ts`), locates the `IRLoop`
+ * node, and asserts the gate's verdict plus (where relevant) the structured
+ * `segments` path each binding carries.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { analyzeComponent } from '../analyzer'
+import { jsxToIR } from '../jsx-to-ir'
+import { isLowerableLoopDestructure, isLowerableObjectRestDestructure } from '../loop-destructure'
+import { ErrorCodes } from '../errors'
+import type { IRLoop, IRNode } from '../types'
+
+function findFirstLoop(node: IRNode): IRLoop {
+  if (node.type === 'loop') return node
+  if (node.type === 'element' || node.type === 'fragment') {
+    for (const child of node.children) {
+      if (child.type === 'loop') return child
+      if (child.type === 'element' || child.type === 'fragment') {
+        try {
+          return findFirstLoop(child)
+        } catch {
+          // keep scanning siblings
+        }
+      }
+    }
+  }
+  throw new Error('no loop node found in IR')
+}
+
+function compileLoop(
+  source: string,
+  targetComponentName?: string,
+  filename = 'Test.tsx',
+): { loop: IRLoop; errors: ReturnType<typeof analyzeComponent>['errors'] } {
+  const ctx = analyzeComponent(source, filename, targetComponentName)
+  const ir = jsxToIR(ctx)
+  expect(ir).not.toBeNull()
+  return { loop: findFirstLoop(ir!), errors: ctx.errors }
+}
+
+describe('isLowerableLoopDestructure (#2087)', () => {
+  test('simple .field bindings + object-rest read via member access → true (existing behavior)', () => {
+    const { loop } = compileLoop(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Task = { id: string; title: string; flag: string }
+      export function RestObject() {
+        const [tasks, setTasks] = createSignal<Task[]>([])
+        return (
+          <ul onClick={() => setTasks(t => t)}>
+            {tasks().map(({ id, title, ...rest }) => (
+              <li key={id}>{title}:{rest.flag}</li>
+            ))}
+          </ul>
+        )
+      }
+    `)
+    expect(isLowerableLoopDestructure(loop)).toBe(true)
+  })
+
+  test('array-index tuple destructure ([k, v]) → true (NEW)', () => {
+    const { loop } = compileLoop(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Row = readonly [string, string]
+      export function IndexPairs() {
+        const [rows, setRows] = createSignal<Row[]>([])
+        return (
+          <ul onClick={() => setRows(r => r)}>
+            {rows().map(([k, v]) => (
+              <li key={k}>{k}:{v}</li>
+            ))}
+          </ul>
+        )
+      }
+    `)
+    expect(isLowerableLoopDestructure(loop)).toBe(true)
+  })
+
+  test('nested { id, cells: [head] } → true (NEW)', () => {
+    const { loop } = compileLoop(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Row = { id: string; cells: readonly string[] }
+      export function NestedHead() {
+        const [rows, setRows] = createSignal<Row[]>([])
+        return (
+          <ul onClick={() => setRows(r => r)}>
+            {rows().map(({ id, cells: [head] }) => (
+              <li key={id}>{head}</li>
+            ))}
+          </ul>
+        )
+      }
+    `)
+    expect(isLowerableLoopDestructure(loop)).toBe(true)
+  })
+
+  test('array-rest [first, ...tail] with tail.length read → true (NEW)', () => {
+    const { loop } = compileLoop(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function RestTuple() {
+        const [rows, setRows] = createSignal<string[][]>([])
+        return (
+          <ul onClick={() => setRows(r => r)}>
+            {rows().map(([first, ...tail]) => (
+              <li key={first}>{first} (+{tail.length})</li>
+            ))}
+          </ul>
+        )
+      }
+    `)
+    expect(isLowerableLoopDestructure(loop)).toBe(true)
+  })
+
+  test('object-rest {...rest} spread onto the loop-item root <li> → true (NEW)', () => {
+    const { loop } = compileLoop(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Task = { id: string; title: string; flag: string }
+      export function RestSpread() {
+        const [tasks, setTasks] = createSignal<Task[]>([])
+        return (
+          <ul onClick={() => setTasks(t => t)}>
+            {tasks().map(({ id, title, ...rest }) => (
+              <li key={id} {...rest}>{title}</li>
+            ))}
+          </ul>
+        )
+      }
+    `)
+    expect(isLowerableLoopDestructure(loop)).toBe(true)
+  })
+
+  test('object-rest spread on a COMPONENT (<Child {...rest} />) → false', () => {
+    const { loop } = compileLoop(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Task = { id: string; title: string; flag: string }
+      function Child(props: { title: string; flag: string }) {
+        return <span>{props.title}</span>
+      }
+      export function RestOntoComponent() {
+        const [tasks, setTasks] = createSignal<Task[]>([])
+        return (
+          <ul onClick={() => setTasks(t => t)}>
+            {tasks().map(({ id, ...rest }) => (
+              <li key={id}><Child {...rest} /></li>
+            ))}
+          </ul>
+        )
+      }
+    `, 'RestOntoComponent')
+    expect(isLowerableLoopDestructure(loop)).toBe(false)
+  })
+
+  test('object-rest bare value use in a text expression ({String(rest)}) → false', () => {
+    const { loop } = compileLoop(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Task = { id: string; title: string; flag: string }
+      export function RestBareText() {
+        const [tasks, setTasks] = createSignal<Task[]>([])
+        return (
+          <ul onClick={() => setTasks(t => t)}>
+            {tasks().map(({ id, ...rest }) => (
+              <li key={id}>{String(rest)}</li>
+            ))}
+          </ul>
+        )
+      }
+    `)
+    expect(isLowerableLoopDestructure(loop)).toBe(false)
+  })
+
+  test('object-rest bare value use in an event handler (onClick={() => fn(rest)}) → false', () => {
+    const { loop } = compileLoop(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Task = { id: string; title: string; flag: string }
+      export function RestBareHandler() {
+        const [tasks, setTasks] = createSignal<Task[]>([])
+        const fn = (t: unknown) => {}
+        return (
+          <ul>
+            {tasks().map(({ id, ...rest }) => (
+              <li key={id} onClick={() => fn(rest)}>{id}</li>
+            ))}
+          </ul>
+        )
+      }
+    `)
+    expect(isLowerableLoopDestructure(loop)).toBe(false)
+  })
+
+  test('.filter(...).map(({a}) => ...) chain → false', () => {
+    const { loop } = compileLoop(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Task = { id: string; done: boolean }
+      export function FilterChain() {
+        const [tasks, setTasks] = createSignal<Task[]>([])
+        return (
+          <ul onClick={() => setTasks(t => t)}>
+            {tasks().filter(t => !t.done).map(({ id }) => (
+              <li key={id}>{id}</li>
+            ))}
+          </ul>
+        )
+      }
+    `)
+    expect(isLowerableLoopDestructure(loop)).toBe(false)
+  })
+
+  test('binding named __bf_item → false', () => {
+    const { loop } = compileLoop(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function ReservedName() {
+        const [rows, setRows] = createSignal<{ __bf_item: string }[]>([])
+        return (
+          <ul onClick={() => setRows(r => r)}>
+            {rows().map(({ __bf_item }) => (
+              <li key={__bf_item}>{__bf_item}</li>
+            ))}
+          </ul>
+        )
+      }
+    `)
+    expect(isLowerableLoopDestructure(loop)).toBe(false)
+  })
+
+  test('computed property key still raises BF025 and produces no paramBindings (unchanged)', () => {
+    const { loop, errors } = compileLoop(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      const KEY = 'a' as const
+      export function Computed() {
+        const [items, setItems] = createSignal<Record<string, number>[]>([])
+        return (
+          <ul onClick={() => setItems(i => i)}>
+            {items().map(({ [KEY]: v }) => <li key={v}>{v}</li>)}
+          </ul>
+        )
+      }
+    `)
+    const bf025 = errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_DESTRUCTURE_REST)
+    expect(bf025.length).toBe(1)
+    expect(bf025[0].severity).toBe('error')
+    expect(loop.paramBindings).toBeUndefined()
+    expect(isLowerableLoopDestructure(loop)).toBe(false)
+  })
+
+  test('deprecated alias isLowerableObjectRestDestructure is the same function', () => {
+    expect(isLowerableObjectRestDestructure).toBe(isLowerableLoopDestructure)
+  })
+
+  test('segments: nested { id, cells: [head, ...rest] } pins field/index/non-ident classification', () => {
+    const { loop } = compileLoop(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Row = { id: string; cells: readonly string[]; 'data-priority': string }
+      export function NestedSegments() {
+        const [rows, setRows] = createSignal<Row[]>([])
+        return (
+          <ul onClick={() => setRows(r => r)}>
+            {rows().map(({ id, cells: [head, ...rest], 'data-priority': prio }) => (
+              <li key={id}>{head}:{String(rest.length)}:{prio}</li>
+            ))}
+          </ul>
+        )
+      }
+    `)
+    const bindings = loop.paramBindings
+    expect(bindings).toBeDefined()
+
+    const idBinding = bindings!.find(b => b.name === 'id')
+    expect(idBinding?.segments).toEqual([{ kind: 'field', key: 'id', isIdent: true }])
+
+    const headBinding = bindings!.find(b => b.name === 'head')
+    expect(headBinding?.segments).toEqual([
+      { kind: 'field', key: 'cells', isIdent: true },
+      { kind: 'index', index: 0 },
+    ])
+
+    const restBinding = bindings!.find(b => b.name === 'rest')
+    expect(restBinding?.rest?.kind).toBe('array')
+    expect(restBinding?.segments).toEqual([{ kind: 'field', key: 'cells', isIdent: true }])
+
+    const prioBinding = bindings!.find(b => b.name === 'prio')
+    expect(prioBinding?.segments).toEqual([{ kind: 'field', key: 'data-priority', isIdent: false }])
+  })
+})

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -26,6 +26,9 @@ export type {
   IRConditional,
   IRLoop,
   IRLoopChildComponent,
+  LoopParamBinding,
+  LoopBindingPathSegment,
+  RestExcludeKey,
   IRComponent,
   IRFragment,
   IRSlot,
@@ -286,7 +289,7 @@ export type { StyleObjectEntry } from './expression-parser.ts'
 export type { ParsedExpr, ObjectLiteralProperty, ParsedStatement, SortComparator, SortKey, FlatDepth, SupportLevel, SupportResult, TemplatePart } from './expression-parser.ts'
 export { buildLoopChainExpr } from './loop-chain.ts'
 export type { LoopChainInputs } from './loop-chain.ts'
-export { isLowerableObjectRestDestructure } from './loop-destructure.ts'
+export { isLowerableLoopDestructure, isLowerableObjectRestDestructure } from './loop-destructure.ts'
 
 // Debug analysis
 export {

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -23,6 +23,7 @@ import {
   type AttrValue,
   type IRTemplatePart,
   type LoopParamBinding,
+  type LoopBindingPathSegment,
   type RestExcludeKey,
   type FlatMapCallback,
   type FlatMapJsxFragment,
@@ -2650,7 +2651,11 @@ function extractLoopParamBindings(
       : `${prefix}[${JSON.stringify(key)}]`
   }
 
-  const walk = (p: ts.ArrayBindingPattern | ts.ObjectBindingPattern, prefix: string): void => {
+  const walk = (
+    p: ts.ArrayBindingPattern | ts.ObjectBindingPattern,
+    prefix: string,
+    segments: readonly LoopBindingPathSegment[],
+  ): void => {
     if (unsupported) return
     if (ts.isArrayBindingPattern(p)) {
       const elements = p.elements
@@ -2676,14 +2681,16 @@ function extractLoopParamBindings(
             name: el.name.text,
             path: prefix,
             rest: { kind: 'array', from: index },
+            segments,
           })
           return
         }
         const path = `${prefix}[${index}]`
+        const nextSegments = [...segments, { kind: 'index', index } as const]
         if (ts.isIdentifier(el.name)) {
-          bindings.push({ name: el.name.text, path })
+          bindings.push({ name: el.name.text, path, segments: nextSegments })
         } else {
-          walk(el.name, path)
+          walk(el.name, path, nextSegments)
         }
       }
       return
@@ -2712,6 +2719,7 @@ function extractLoopParamBindings(
           name: el.name.text,
           path: prefix,
           rest: { kind: 'object', exclude: collectedKeys },
+          segments,
         })
         return
       }
@@ -2728,18 +2736,20 @@ function extractLoopParamBindings(
         unsupported = true
         return
       }
-      collectedKeys.push({ key: keyText, isIdent: isIdent(keyText) })
+      const keyIsIdent = isIdent(keyText)
+      collectedKeys.push({ key: keyText, isIdent: keyIsIdent })
       const path = appendDotAccess(prefix, keyText)
+      const nextSegments = [...segments, { kind: 'field', key: keyText, isIdent: keyIsIdent } as const]
       if (ts.isIdentifier(el.name)) {
-        bindings.push({ name: el.name.text, path })
+        bindings.push({ name: el.name.text, path, segments: nextSegments })
       } else {
-        walk(el.name, path)
+        walk(el.name, path, nextSegments)
       }
     }
   }
 
   if (ts.isArrayBindingPattern(pattern) || ts.isObjectBindingPattern(pattern)) {
-    walk(pattern, '')
+    walk(pattern, '', [])
     if (unsupported) return { unsupported: true }
     return bindings
   }

--- a/packages/jsx/src/loop-destructure.ts
+++ b/packages/jsx/src/loop-destructure.ts
@@ -1,31 +1,60 @@
 import type { IRLoop, IRNode, AttrValue, IRTemplatePart } from './types.ts'
 
-const SIMPLE_FIELD = /^\.[A-Za-z_$][\w$]*$/
-
 /**
- * True when a loop's destructure param is the single shape the non-JS SSR
- * adapters (Go template / Mojolicious / Xslate) can lower today:
+ * True when a loop's `.map()` destructure param is one of the shapes this
+ * repo's per-adapter emitters can lower to a native accessor, WITHOUT
+ * relying on the JS/CSR runtime to evaluate an arbitrary residual object.
  *
- *   `arr.map(({ id, title, ...rest }) => …)`
+ * Admitted (all via `LoopParamBinding.segments` — the structured, non-string
+ * accessor path built by `extractLoopParamBindings`; see #2087):
  *
- * where every binding is a simple `.field` access or an **object-rest read only
- * via member access** (`rest.flag`). The adapters lower the rest binding as an
- * alias to the whole iteration item, which matches JS rest semantics only for
- * member reads of non-consumed keys — so any other use must be refused:
+ *   - fixed bindings at any depth / shape: `.field` (`{ id }`), array-index
+ *     (`[k, v]`), and nested paths through either (`{ cells: [head] }`,
+ *     `{ user: { name } }`) — anything the IR walker turned into a
+ *     `segments` path. `segments` is required; a fixed binding with no
+ *     `segments` is stale/foreign IR and refused conservatively.
+ *   - array-rest bindings (`[first, ...tail]`): the lowered value IS the
+ *     exact JS slice (`tail === item.slice(1)`), so there is no way for an
+ *     adapter to observe a "wrong" value from any use of the name — no
+ *     use-restriction scan needed, unlike object-rest below.
+ *   - object-rest bindings (`{ id, ...rest }`) whose every use in the loop
+ *     subtree is one of:
+ *       (a) a member-access base (`rest.flag` / `rest?.flag` — the
+ *           "read one field back off the rest" idiom), or
+ *       (b) NEW: a spread attr (`{...rest}`) on an intrinsic ELEMENT node
+ *           (`<li {...rest}>`) whose `expr` is *exactly* the rest name —
+ *           "forward everything else onto this element" is a residual the
+ *           adapters can express as "all attrs not already destructured",
+ *           without ever materializing the residual object itself.
+ *     A spread on a `component` or `provider` node still refuses — a
+ *     component's own props lowering is a different code path with its own
+ *     contract, not something this gate should reach into. A spread whose
+ *     expr merely *contains* the name (`{...fn(rest)}`) still refuses too —
+ *     that's an opaque call, not a literal forward.
  *
- *   - array-rest / array-index / nested paths (`[a, ...t]`, `{ cells: [h] }`)
- *     need index/slice the `range`/`for` can't express inline;
- *   - spread (`{...rest}`) and bare value uses (`String(rest)`, `{rest}`,
- *     `fn(rest)`) would observe the consumed keys too — they need a residual
- *     object the templates can't build inline;
- *   - a chained `.filter().map(destructure)` would need the filter-param
- *     rewrite to target the synthetic per-item var, so it's refused as well.
+ * Still refused, and why:
  *
- * Unsupported shapes fall through to the adapters' BF104 diagnostic. The scan
- * is conservative: an ambiguous use refuses (false-negative is safe — it keeps
- * the existing build-time error rather than shipping wrong output).
+ *   - any OTHER use of an object-rest name (`String(rest)`, `{rest}` as a
+ *     text/expression node, `onClick={() => fn(rest)}`, `{...fn(rest)}`)
+ *     needs the actual residual *object*, which the non-JS template
+ *     adapters can't build inline — only "read one field" (member access)
+ *     and "spread all remaining attrs onto this element" (the new spread
+ *     case) have an adapter-side answer that doesn't require constructing
+ *     the value.
+ *   - a chained `.filter().map(destructure)` needs the filter-param
+ *     rewrite to retarget the synthetic per-item var; out of scope here.
+ *   - a binding name (or `loop.index`) in the reserved `__bf_` namespace
+ *     would collide with the synthetic per-item loop variable the SSR
+ *     adapters emit (duplicate locals, ambiguous accessors).
+ *   - computed property keys (`{ [k]: v }`) can't be expressed as any
+ *     accessor path at all — they raise `BF025` at Phase 1 and never reach
+ *     this gate (`loop.paramBindings` is simply absent).
+ *
+ * Unsupported shapes fall through to the adapters' BF104 diagnostic. The
+ * scan is conservative: an ambiguous use refuses (false-negative is safe —
+ * it keeps the existing build-time error rather than shipping wrong output).
  */
-export function isLowerableObjectRestDestructure(loop: IRLoop): boolean {
+export function isLowerableLoopDestructure(loop: IRLoop): boolean {
   const bindings = loop.paramBindings
   if (!bindings || bindings.length === 0) return false
   if (loop.filterPredicate) return false
@@ -39,31 +68,49 @@ export function isLowerableObjectRestDestructure(loop: IRLoop): boolean {
   }
   for (const b of bindings) {
     if (b.rest) {
-      if (b.rest.kind !== 'object') return false
-    } else if (!SIMPLE_FIELD.test(b.path)) {
+      // Both rest kinds require `segments` (the array-rest kind may
+      // legitimately have an empty one, at the loop root — `([...rest]) =>`).
+      if (!b.segments) return false
+    } else if (!b.segments || b.segments.length === 0) {
+      // Fixed binding with no structured path: stale/foreign IR built
+      // before `segments` existed. Refuse rather than guess from `path`.
       return false
     }
   }
-  const restNames = bindings.filter(b => b.rest).map(b => b.name)
-  if (restNames.length === 0) return true
-  return !restNamesMisused(loop, restNames)
+  const objectRestNames = bindings.filter(b => b.rest?.kind === 'object').map(b => b.name)
+  if (objectRestNames.length === 0) return true
+  return !restNamesMisused(loop, objectRestNames)
 }
+
+/** @deprecated Use {@link isLowerableLoopDestructure}. Kept as an alias so
+ * existing template-adapter imports keep compiling; the underlying gate now
+ * admits more shapes (array-index / nested paths / array-rest / the
+ * spread-onto-element case) than the name suggests — see #2087 Phase A.
+ */
+export const isLowerableObjectRestDestructure = isLowerableLoopDestructure
 
 /**
  * Walks the whole loop subtree (every node type, every expression-bearing
- * field) and reports whether any rest name is referenced as something other
- * than a member-access base (`rest.flag` / `rest?.flag`). A spread expr
- * (`{...rest}` → expr `"rest"`) and bare value uses are caught by the same
- * regex; a property of an unrelated object (`foo.rest`) is excluded by the
- * lookbehind.
+ * field) and reports whether any object-rest name is referenced as
+ * something other than:
+ *
+ *   - a member-access base (`rest.flag` / `rest?.flag`), or
+ *   - a spread attr on an intrinsic ELEMENT node whose expr is *exactly*
+ *     the rest name (`<li {...rest}>`) — the one new admitted shape.
+ *
+ * A spread expr on a `component` / `provider` node, or a spread whose expr
+ * merely contains the name, still counts as misuse (falls through to the
+ * generic bare-value-use regex below). A property of an unrelated object
+ * (`foo.rest`) is excluded by the lookbehind, same as before.
  *
  * The scan covers the gated loop's own non-children expression fields too
- * (`array` / `key` / `mapPreamble` / `flatMapCallback` body) — a bare rest use
- * can surface there (e.g. `.map(({ ...rest }) => { const x = rest; … })`
+ * (`array` / `key` / `mapPreamble` / `flatMapCallback` body) — a bare rest
+ * use can surface there (e.g. `.map(({ ...rest }) => { const x = rest; … })`
  * lifts `const x = rest` into `mapPreamble`), plus intrinsic element event
  * handlers (`onClick={() => fn(rest)}`).
  */
 function restNamesMisused(loop: IRLoop, names: string[]): boolean {
+  const nameSet = new Set(names)
   const valueUse = names.map(
     n => new RegExp(`(?<![\\w.$])${escapeRe(n)}(?!\\s*\\??\\.)(?![\\w$])`),
   )
@@ -77,7 +124,13 @@ function restNamesMisused(loop: IRLoop, names: string[]): boolean {
       }
     }
   }
-  const attr = (v: AttrValue): void => {
+  // `isIntrinsicElementAttrs` distinguishes `<li {...rest}>` (element,
+  // admitted) from `<Child {...rest} />` / a provider's value prop
+  // (still refused) — same spread AttrValue shape, different node kind.
+  const attr = (v: AttrValue, isIntrinsicElementAttrs: boolean): void => {
+    if (v.kind === 'spread' && isIntrinsicElementAttrs && nameSet.has(v.expr.trim())) {
+      return
+    }
     if (v.kind === 'expression' || v.kind === 'spread') {
       check(v.expr)
       check(v.templateExpr)
@@ -134,16 +187,16 @@ function restNamesMisused(loop: IRLoop, names: string[]): boolean {
         if (node.alternate) visit(node.alternate)
         break
       case 'element':
-        node.attrs.forEach(a => attr(a.value))
+        node.attrs.forEach(a => attr(a.value, true))
         node.events.forEach(e => check(e.handler))
         node.children.forEach(visit)
         break
       case 'component':
-        node.props.forEach(p => attr(p.value))
+        node.props.forEach(p => attr(p.value, false))
         node.children.forEach(visit)
         break
       case 'provider':
-        attr(node.valueProp.value)
+        attr(node.valueProp.value, false)
         node.children.forEach(visit)
         break
       case 'fragment':

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -696,6 +696,26 @@ export interface RestExcludeKey {
 }
 
 /**
+ * Structured, non-string form of a `.map()` callback destructure accessor
+ * step — one entry per `.foo` / `["a-b"]` / `[0]` step folded into
+ * {@link LoopParamBinding.path}. Adapters that need to build their own
+ * accessor expression (rather than splice `path` in as a JS suffix) walk
+ * `segments` instead of parsing `path` with a regex (repo rule: never parse
+ * JS/TS syntax with regex or string matching).
+ *
+ * - `{ kind: 'field', key, isIdent }`: an object-property step. `isIdent`
+ *   uses the same `ts.isIdentifierStart`/`isIdentifierPart` classification
+ *   as {@link RestExcludeKey.isIdent} — an adapter choosing between a native
+ *   `.foo` accessor and a quoted/bracketed one (`["data-priority"]`, a
+ *   quoted map key, ...) reads this instead of re-deriving the identifier
+ *   rule itself.
+ * - `{ kind: 'index', index }`: an array-position step (`[0]`, `[1]`, ...).
+ */
+export type LoopBindingPathSegment =
+  | { kind: 'field'; key: string; isIdent: boolean }
+  | { kind: 'index'; index: number }
+
+/**
  * Destructured binding extracted from a `.map()` callback's item parameter.
  *
  * For *fixed* bindings (plain identifier, alias, nested access), `path` is a
@@ -721,6 +741,24 @@ export interface LoopParamBinding {
   rest?:
     | { kind: 'object'; exclude: readonly RestExcludeKey[] }
     | { kind: 'array'; from: number }
+  /**
+   * Structured form of `path` (see {@link LoopBindingPathSegment}).
+   *
+   * - Fixed bindings (`rest` unset): the full accessor from the loop item to
+   *   this binding, one segment per `path` step. Always non-empty — a fixed
+   *   binding always has at least one accessor step.
+   * - Rest bindings (`rest` set): the structured form of the PARENT prefix
+   *   (i.e. of `path`, which for rest bindings holds the parent prefix, not
+   *   an accessor to the rest binding itself) — possibly empty when the
+   *   rest sits at the loop root (`({ ...rest }) => …` / `([...rest]) => …`).
+   *
+   * Optional only so older/foreign IR (built before this field existed)
+   * still type-checks; `extractLoopParamBindings` always populates it now.
+   * Downstream gates (`isLowerableLoopDestructure`) treat a missing
+   * `segments` as "unknown shape" and refuse conservatively rather than
+   * reading it as "binding at the loop root".
+   */
+  segments?: readonly LoopBindingPathSegment[]
 }
 
 export interface IRComponent {

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -801,7 +801,7 @@ symbol of each JSX tag through to the resolver; tracked as a follow-up.
 | BF021 | Unsupported JSX pattern (e.g., filter predicate or sort comparator too complex for template compilation) |
 | BF023 | Missing `key` attribute in `.map()` loop — root JSX element has no `key` prop |
 | BF024 | Missing `key` attribute in nested `.map()` loop — inner loop root JSX element has no `key` prop |
-| BF025 | Unsupported destructure shape in `.map()` callback (rest element or computed property key) |
+| BF025 | Unsupported destructure shape in `.map()` callback (computed property key — rest elements have been supported since #1244/#1309) |
 | BF043 | Props destructuring breaks reactivity |
 | BF044 | Signal/memo getter passed without calling it |
 | BF060 | Reactive binding (signal/memo getter) referenced from template scope (staged-IR; opt-in diagnostic) |


### PR DESCRIPTION
Closes #2087. Refs #2069 (known-limitations catalog v2 — the "Array-index / nested / rest-spread destructure in `.map()` callback (BF104)" entry, checkbox ticked).

## What

Extends `.map()`-callback destructure lowering on all seven template adapters (Go template, Mojolicious, Xslate, ERB, Jinja, Twig, MiniJinja) to the shapes that previously refused with BF104:

- **Array-index destructure** — `rows().map(([k, v]) => …)`
- **Nested paths** — `{ cells: [head] }`, `{ user: { name } }`
- **Array-rest** — `[first, ...tail]` (lowered as the exact JS slice via each runtime's `slice` helper, so `tail.length` composes through the member emitters)
- **Object-rest spread onto an intrinsic element** — `{ id, title, ...rest }` + `<li {...rest}>` (lowered as a residual bag minus the consumed keys, through each adapter's existing spread-attrs pipeline)

Still refused (by design, now with an accurate BF104 message): bare value uses of an object-rest name (`fn(rest)`, `{rest}`), spreads onto components/providers, `.filter().map(destructure)` chains, and `__bf_`-prefixed binding names.

## How

**jsx core:**
- `LoopParamBinding` gains structured `segments` (`{kind:'field',key,isIdent} | {kind:'index',index}`) built by `extractLoopParamBindings`, so adapters build native accessors without string-parsing the JS `path` suffix (repo rule).
- The shared gate is renamed `isLowerableLoopDestructure` (deprecated alias kept) and widened per the list above; `{...rest}` is admitted only as a spread attr on an intrinsic element whose expr is exactly the rest name.
- CSR/client-JS emission is unchanged (it already supported every shape); gate behavior is pinned by `packages/jsx/src/__tests__/loop-destructure.test.ts`.
- New conformance fixtures `destructure-array-index-in-map` (tuple rows — bindings start with an index segment) and `destructure-nested-object-in-map`.
- `spec/compiler.md` BF025 row corrected (computed property keys only).

**Per adapter:**
- Per-binding template locals / accessor maps walk `segments` (native field/index access, non-identifier keys via each engine's quoted/attribute form — e.g. Twig routes them through `attribute()` because bracket subscript on a `stdClass` silently resolves to nothing).
- New `omit` runtime helper (Go `bf_omit`, shared Perl `BarefootJS::omit`, Python/PHP/Rust `bf.omit`) feeding the existing `spread_attrs`; ERB uses native `Hash#except`. Each helper has runtime-side unit tests.
- Residual strategy: the six locals-based adapters bind the object-rest local to a **true residual** (member reads of consumed keys now match JS); Go keeps the whole-item alias for member reads (struct-field access can't retarget a runtime map) and routes only the `{...rest}` spread through `bf_omit` — documented at `buildDestructureBindingMap`.
- Go bonus fixes surfaced by the tuple/non-ident-key fixtures: non-Go-identifier property keys now bake as sanitized struct fields with `json` tags (`data-priority` → `DataPriority`) instead of deferring the literal to `nil`, and tuple type aliases fall through to `[]interface{}` instead of referencing an undeclared Go type.

**Collateral hardening (BF101):** widening the gate stopped BF104 from (incidentally) masking `static-array-from-props(-with-component)` — their loop array is a computed **function-scope** const (`Object.entries(props.x ?? {}).filter(...)`) no template adapter can bind, which would have silently rendered an empty list. All seven adapters now raise a narrow BF101 for a bare-identifier loop array bound to such a const (verified corpus-wide for false positives; module-scope consts stay exempt via ssr-defaults seeding), and the two fixtures are re-pinned BF101 / BF103+BF101. This "computed function-scope const as loop source" gap is pre-existing and orthogonal — it may deserve its own catalog entry in #2069.

The three previously pinned fixtures (`rest-destructure-{object-spread,array,nested}-in-map`) are graduated on all seven adapters — no BF104 `expectedDiagnostics` pins remain for the destructure family. `rest-destructure-object-spread-in-map` stays in the CSR-conformance skip list for the documented SSR/CSR attribute-order divergence only (by-design catalog entry in #2069).

## Testing (all through real engines, run locally)

| Suite | Result |
|---|---|
| `packages/jsx` | 2289 tests, 0 fail |
| `packages/adapter-tests` (incl. CSR conformance) | 896 pass, 0 fail |
| go-template (+ `go test ./...`, `go vet`) | 602 pass, 0 fail |
| mojolicious + xslate (+ `prove -l t/` in adapter-perl: 398) | 958 pass, 0 fail |
| erb (real Ruby) | 369 pass, 0 fail |
| jinja (+ python unittest: 78) | 394 pass, 0 fail |
| twig (+ PHP runtime tests: 395) | 394 pass, 0 fail |
| rust/minijinja (+ `cargo test`: 95) | 394 pass, 0 fail |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxvCRykcJLzVZPN37sU5T1