### PR TITLE
feat(#2090): resolve function-reference sort comparators through local scope

### DIFF
--- a/.changeset/sort-function-reference-comparators.md
+++ b/.changeset/sort-function-reference-comparators.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/jsx": minor
+---
+
+`.sort(byPrice)` / `.toSorted(byPrice)` now resolve a bare-identifier comparator one hop through same-file scope (module- or component-scope `const byPrice = (a, b) => …` or `function byPrice(a, b) {…}`) and feed the resolved arrow through the unchanged comparator catalogue, so a function reference compiles exactly like the inlined comparator on every adapter (#2090). Unresolvable references (imports, props, alias chains) and resolved-but-off-catalogue bodies keep BF021, with distinct messages naming the comparator.

--- a/docs/core/advanced/error-codes.md
+++ b/docs/core/advanced/error-codes.md
@@ -141,10 +141,18 @@ Simple subtraction: `(a, b) => a.field - b.field`:
 // ✅ SSR-compilable
 {items().sort((a, b) => a.price - b.price).map(...)}     // ascending
 {items().toSorted((a, b) => b.date - a.date).map(...)}   // descending
+{items().sort((a, b) => { return a.price - b.price }).map(...)}     // single-return block body
+{items().sort((a, b) => a.name.localeCompare(b.name)).map(...)}     // zero-arg localeCompare
 
-// ❌ BF021 — block bodies, localeCompare, ternary operators, etc. are not supported
-{items().sort((a, b) => { return a.price - b.price }).map(...)}
-{items().sort((a, b) => a.name.localeCompare(b.name)).map(...)}
+// A bare identifier reference to a same-file const/function comparator
+// resolves one hop and compiles like the inline arrow above (#2090):
+const byPrice = (a, b) => a.price - b.price
+{items().sort(byPrice).map(...)}
+
+// ❌ BF021 — locale/options localeCompare, and an unresolved comparator
+// (imported, a prop, or an alias chain) are not supported
+{items().sort((a, b) => a.name.localeCompare(b.name, 'ja', { numeric: true })).map(...)}
+{items().sort(importedCmp).map(...)}
 ```
 
 #### Workaround

--- a/docs/core/rendering/jsx-compatibility.md
+++ b/docs/core/rendering/jsx-compatibility.md
@@ -193,9 +193,9 @@ only one binding, so it can't see through a re-export or `const c2 = c1`:
 ```tsx
 // ❌ BF021 — `byPrice` is imported, not declared in this file
 import { byPrice } from './comparators'
-{items().sort(byPrice).map(item => (
-  <Item key={item.id} item={item} />
-))}
+function SortedList({ items }: { items: Item[] }) {
+  return <ul>{items.sort(byPrice).map((item) => <li key={item.id}>{item.name}</li>)}</ul>
+}
 
 // ✅ Use /* @client */, or inline / re-declare the comparator locally
 {/* @client */ items().sort(byPrice).map(item => (

--- a/docs/core/rendering/jsx-compatibility.md
+++ b/docs/core/rendering/jsx-compatibility.md
@@ -76,7 +76,7 @@ return <div>...</div>
 ))}
 ```
 
-Supported comparator shapes: `(a, b) => a - b`, `(a, b) => a.field - b.field`, `(a, b) => a.localeCompare(b)`, `(a, b) => a.field.localeCompare(b.field)`, relational-ternary returns (`(a, b) => a.field > b.field ? 1 : -1`, including the 3-way `a < b ? -1 : a > b ? 1 : 0` form), and any of these `||`-chained for multi-key tie-breaks. A single-`return` block body (`(a, b) => { return a.field - b.field }`) works too. Reverse the operands (or the ternary sign) for descending order. Other shapes — function references (`sort(myCmp)`), multi-statement block bodies, and `localeCompare(b, locale, opts)` — produce a compile error; use `/* @client */` in that case.
+Supported comparator shapes: `(a, b) => a - b`, `(a, b) => a.field - b.field`, `(a, b) => a.localeCompare(b)`, `(a, b) => a.field.localeCompare(b.field)`, relational-ternary returns (`(a, b) => a.field > b.field ? 1 : -1`, including the 3-way `a < b ? -1 : a > b ? 1 : 0` form), and any of these `||`-chained for multi-key tie-breaks. A single-`return` block body (`(a, b) => { return a.field - b.field }`) works too. Reverse the operands (or the ternary sign) for descending order. A bare identifier reference to a same-file `const`/`function` comparator (`sort(byPrice)`) resolves one hop and compiles the same as the inline arrow. Other shapes — multi-statement block bodies, `localeCompare(b, locale, opts)`, and an unresolved reference (imported, a prop, or an alias chain like `const c2 = c1`) — produce a compile error; use `/* @client */` in that case.
 
 
 ## Event Handling
@@ -107,7 +107,8 @@ Some JavaScript expressions cannot be translated into marked template syntax. Wh
 | `.filter()` with `function` keyword callback | works | **BF101** |
 | `.reduce()`, `.forEach()`, `.flatMap()` | works | **BF101** |
 | Nested higher-order in filter predicate (`x => x.tags.filter(...).length > 0`) | works | **BF101** |
-| Sort comparator that's a function reference, multi-statement block body, or `localeCompare(b, locale, opts)` | **BF021** (all adapters) | **BF021** |
+| Sort comparator that's a multi-statement block body or `localeCompare(b, locale, opts)` | **BF021** (all adapters) | **BF021** |
+| Sort comparator that's a function reference to an imported/prop identifier, or an alias chain (`const c2 = c1`) | **BF021** (all adapters) | **BF021** |
 | `typeof` in a filter predicate | **BF021** (all adapters) | **BF021** |
 
 `BF021` is raised at the IR layer and applies to every adapter. `BF101` is raised by adapters that can't lower the expression to their template language. Either way, add [`/* @client */`](./client-directive.md) to opt into client-only evaluation and suppress the error.
@@ -156,7 +157,7 @@ Some JavaScript expressions cannot be translated into marked template syntax. Wh
 
 ### Patterns that error on all adapters
 
-**Unsupported sort comparators** (imperative block bodies, function references):
+**Unsupported sort comparators** (imperative block bodies, unresolved function references):
 
 A value-producing block body normalizes to an expression — pure `const`
 bindings inline (let-inline) and a value-producing `if` / early `return`
@@ -180,6 +181,24 @@ Only a genuinely imperative comparator — one that re-assigns a local, loops, o
 
 // ✅ Use /* @client */
 {/* @client */ items().sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }).map(item => (
+  <Item key={item.id} item={item} />
+))}
+```
+
+A same-file `const`/`function` comparator reference resolves one hop and
+compiles (see the "Sort comparators" section above); an **imported** or
+**aliased** reference does not — the compiler follows the identifier back
+only one binding, so it can't see through a re-export or `const c2 = c1`:
+
+```tsx
+// ❌ BF021 — `byPrice` is imported, not declared in this file
+import { byPrice } from './comparators'
+{items().sort(byPrice).map(item => (
+  <Item key={item.id} item={item} />
+))}
+
+// ✅ Use /* @client */, or inline / re-declare the comparator locally
+{/* @client */ items().sort(byPrice).map(item => (
   <Item key={item.id} item={item} />
 ))}
 ```

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -3544,7 +3544,6 @@ export { C }
 
   // Tier B `.sort` / `.toSorted` follow-ups still refused with BF021.
   const unsupportedSort: Array<[string, string]> = [
-    ['function-reference comparator', `items().toSorted(myCmp).map(x => <li key={x.name}>{x.name}</li>)`],
     ['localeCompare locale/options arg', `items().toSorted((a, b) => a.name.localeCompare(b.name, "ja", { numeric: true })).map(x => <li key={x.name}>{x.name}</li>)`],
   ]
   for (const [label, chain] of unsupportedSort) {
@@ -3566,6 +3565,17 @@ export function C() {
       expect(guarded.template).toMatch(/bfComment "loop:l\d+"/)
     })
   }
+
+  // #2090: a function-reference comparator (`.toSorted(myCmp)`, `myCmp` a
+  // same-file const arrow) now resolves through the analyzer's scope
+  // machinery and compiles — no BF021, and the sort lowers exactly like an
+  // inline comparator (`bf_sort` / `bf_sort_eval` group in the template).
+  test('sort follow-up (function-reference comparator): resolves and compiles without BF021', () => {
+    const chain = `items().toSorted(myCmp).map(x => <li key={x.name}>{x.name}</li>)`
+    const result = emitLoop(chain, false)
+    expect(result.errors).toEqual([])
+    expect(result.template).toMatch(/bf_sort/)
+  })
 
   // End-to-end proof via `go run`: the `@client` form renders a
   // `<!--bf-client:sN-->` placeholder. The bare form is now caught at

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -1874,7 +1874,6 @@ export { C }
   // contract here is: no errors + the comparator never lowers + no
   // rendered `<li>` survives.
   const unsupportedSort: Array<[string, string]> = [
-    ['function-reference comparator', `items().toSorted(myCmp).map(x => <li key={x.name}>{x.name}</li>)`],
     ['localeCompare locale/options arg', `items().toSorted((a, b) => a.name.localeCompare(b.name, "ja", { numeric: true })).map(x => <li key={x.name}>{x.name}</li>)`],
   ]
   for (const [label, chain] of unsupportedSort) {
@@ -1897,6 +1896,17 @@ export function C() {
       expect(guarded.template).not.toContain('localeCompare')
     })
   }
+
+  // #2090: a function-reference comparator (`.toSorted(myCmp)`, `myCmp` a
+  // same-file const arrow) now resolves through the analyzer's scope
+  // machinery and compiles — no BF021, and the sort lowers exactly like an
+  // inline comparator (a `bf->sort` / `bf->sort_eval` call in the template).
+  test('sort follow-up (function-reference comparator): resolves and compiles without BF021', () => {
+    const chain = `items().toSorted(myCmp).map(x => <li key={x.name}>{x.name}</li>)`
+    const result = emitLoop(chain, false)
+    expect(result.errors).toEqual([])
+    expect(result.template).toMatch(/bf->sort/)
+  })
 
   // End-to-end proof via perl + Mojolicious: the `@client` form renders
   // a `<!--bf-client:sN-->` placeholder. The bare form is now caught at

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -263,6 +263,7 @@ import { fixture as arraySortLocale } from './methods/array-sort-locale'
 import { fixture as arraySortMultiKey } from './methods/array-sort-multikey'
 import { fixture as arraySortTernary } from './methods/array-sort-ternary'
 import { fixture as arrayToSorted } from './methods/array-toSorted'
+import { fixture as arraySortFnRef } from './methods/array-sort-fnref'
 // #1448 Tier C — `.reduce(fn, init)` arithmetic-fold catalogue. Numeric
 // sum / product over a field or primitive `self`, plus string concat.
 // Lowers via the `array-method` + `ReduceOp` IR and the `bf_reduce`
@@ -479,6 +480,7 @@ export const jsxFixtures: JSXFixture[] = [
   arraySortMultiKey,
   arraySortTernary,
   arrayToSorted,
+  arraySortFnRef,
   arrayEntries,
   arrayKeys,
   arrayValues,

--- a/packages/adapter-tests/fixtures/methods/array-sort-fnref.ts
+++ b/packages/adapter-tests/fixtures/methods/array-sort-fnref.ts
@@ -1,0 +1,38 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `Array.prototype.toSorted(cmp)` where `cmp` is a bare identifier
+ * reference to a module-scope `const cmp = (a, b) => ...` comparator,
+ * rather than an inline arrow (#2090). The identifier is resolved
+ * through the analyzer's scope machinery (one hop, same-file only) to
+ * its underlying arrow, then fed through the SAME `sortComparatorFromArrow`
+ * catalogue an inline comparator uses — so this fixture must produce
+ * byte-identical output to `array-sort-field-asc` (the `.sort()` /
+ * inline-arrow sibling), just via `.toSorted(byPrice)`.
+ */
+export const fixture = createFixture({
+  id: 'array-sort-fnref',
+  description: '.toSorted(byPrice) resolves a module-scope const arrow comparator by reference',
+  source: `
+const byPrice = (a, b) => a.price - b.price
+
+function ArraySortFnRef({ items }: { items: { name: string; price: number }[] }) {
+  return <ul>{items.toSorted(byPrice).map(it => <li key={it.name}>{it.name}</li>)}</ul>
+}
+export { ArraySortFnRef }
+`,
+  props: {
+    items: [
+      { name: 'c', price: 30 },
+      { name: 'a', price: 10 },
+      { name: 'b', price: 20 },
+    ],
+  },
+  expectedHtml: `
+    <ul bf-s="test" bf="s1">
+      <li data-key="a"><!--bf:s0-->a<!--/--></li>
+      <li data-key="b"><!--bf:s0-->b<!--/--></li>
+      <li data-key="c"><!--bf:s0-->c<!--/--></li>
+    </ul>
+  `,
+})

--- a/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
+++ b/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
@@ -682,7 +682,7 @@ hydrate('Example', { init: initExample, template: (_p) => \`<div><button bf="s0"
 export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
 `;
 
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L131 — ❌ BF101 on Go/Mojo; works on Hono 1`] = `
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L132 — ❌ BF101 on Go/Mojo; works on Hono 1`] = `
 "import { $t, __bfText, createComponent, createEffect, createSignal, escapeText, hydrate } from '@barefootjs/client/runtime'
 
 export function initTodoItem(__scope, _p = {}) {
@@ -748,7 +748,7 @@ hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:
 export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
 `;
 
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L134 — ✅ Use /* @client */ 1`] = `
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L135 — ✅ Use /* @client */ 1`] = `
 "import { $t, __bfText, createComponent, createEffect, createSignal, escapeText, hydrate, updateClientMarker } from '@barefootjs/client/runtime'
 
 export function initTodoItem(__scope, _p = {}) {
@@ -811,7 +811,7 @@ hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-
 export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
 `;
 
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L151 — ❌ BF101 on Go/Mojo; works on Hono 1`] = `
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L152 — ❌ BF101 on Go/Mojo; works on Hono 1`] = `
 "import { $t, __bfText, createComponent, createEffect, createSignal, escapeText, hydrate } from '@barefootjs/client/runtime'
 
 export function initTodoItem(__scope, _p = {}) {
@@ -877,7 +877,7 @@ hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:
 export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
 `;
 
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L154 — ✅ Use arrow functions for adapter portability 1`] = `
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L155 — ✅ Use arrow functions for adapter portability 1`] = `
 "import { $t, __bfText, createComponent, createEffect, createSignal, escapeText, hydrate } from '@barefootjs/client/runtime'
 
 export function initTodoItem(__scope, _p = {}) {
@@ -943,7 +943,7 @@ hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf:
 export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
 `;
 
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L167 — ✅ Value-producing block bodies normalize (let-inline) and lower everywhere 1`] = `
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L168 — ✅ Value-producing block bodies normalize (let-inline) and lower everywhere 1`] = `
 "import { $, $t, __bfText, createComponent, createEffect, createSignal, escapeText, hydrate, initChild, mapArray, renderChild } from '@barefootjs/client/runtime'
 
 export function initTodoItem(__scope, _p = {}) {
@@ -1008,7 +1008,7 @@ hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-
 export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
 `;
 
-exports[`docs/core/rendering/jsx-compatibility.md doc-examples L182 — ✅ Use /* @client */ 1`] = `
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L183 — ✅ Use /* @client */ 1`] = `
 "import { $, $t, __bfText, createComponent, createEffect, createSignal, escapeText, hydrate, initChild, mapArray, renderChild } from '@barefootjs/client/runtime'
 
 export function initTodoItem(__scope, _p = {}) {
@@ -1070,6 +1070,71 @@ export function initExample(__scope, _p = {}) {
 }
 
 hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).sort((a, b) => { let r = 0; r = a.name > b.name ? 1 : -1; return r }).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
+export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
+`;
+
+exports[`docs/core/rendering/jsx-compatibility.md doc-examples L201 — ✅ Use /* @client */, or inline / re-declare the comparator locally 1`] = `
+"import { $, $t, __bfText, createComponent, createEffect, createSignal, escapeText, hydrate, initChild, mapArray, renderChild } from '@barefootjs/client/runtime'
+
+export function initTodoItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const [_s0] = $t(__scope, 's0')
+
+  let __anchor_s0 = _s0
+  createEffect(() => {
+    const __val = String(_p.todo)
+    __anchor_s0 = __bfText(__anchor_s0, __val)
+  })
+
+}
+
+hydrate('TodoItem__b3c36eee', { init: initTodoItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.todo))}<!--/--></li>\` })
+export function TodoItem(_p, __bfKey) { return createComponent('TodoItem__b3c36eee', _p, __bfKey) }
+export function initItem(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const [_s0] = $t(__scope, 's0')
+
+  let __anchor_s0 = _s0
+  createEffect(() => {
+    const __val = String(_p.item)
+    __anchor_s0 = __bfText(__anchor_s0, __val)
+  })
+
+}
+
+hydrate('Item__b3c36eee', { init: initItem, template: (_p) => \`<li bf="s1"><!--bf:s0-->\${escapeText(String(_p.item))}<!--/--></li>\` })
+export function Item(_p, __bfKey) { return createComponent('Item__b3c36eee', _p, __bfKey) }
+function initDashboard() {}
+
+hydrate('Dashboard__b3c36eee', { init: initDashboard, template: (_p) => \`<div>D</div>\` })
+export function Dashboard(_p, __bfKey) { return createComponent('Dashboard__b3c36eee', _p, __bfKey) }
+export function initExample(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const children = _p.children
+  const [count, setCount] = createSignal(0)
+  const [isLoggedIn] = createSignal(false)
+  const [todos] = createSignal([])
+  const [items] = createSignal([])
+  const [filter] = createSignal('all')
+  const [accepted] = createSignal(false)
+  const [text, setText] = createSignal('')
+
+  const [_s1] = $(__scope, 's1')
+
+  mapArray(() => items().sort(byPrice), _s1, (item) => String(item.id), (item, __idx, __existing) => {
+    if (__existing) { initChild('Item__b3c36eee', __existing, { get item() { return item() } }); return __existing }
+    return createComponent('Item__b3c36eee', { get item() { return item() } }, item().id)
+  }, 'l0')
+
+}
+
+hydrate('Example', { init: initExample, template: (_p) => \`<div bf="s1"><!--bf-loop:l0-->\${([]).sort(byPrice).map((item) => \`\${renderChild('Item__b3c36eee', {item: item}, item.id)}\`).join('')}<!--bf-/loop:l0--></div>\` })
 export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
 `;
 

--- a/packages/jsx/src/__tests__/ir-sort-comparator.test.ts
+++ b/packages/jsx/src/__tests__/ir-sort-comparator.test.ts
@@ -382,3 +382,264 @@ describe('sort().map() / toSorted().map()', () => {
     }
   })
 })
+
+// #2090: `.sort(cb)` / `.toSorted(cb)` where `cb` is a bare identifier
+// reference to a same-file arrow/function-declaration comparator, resolved
+// through the analyzer's scope machinery (`findLocalConst` /
+// `findLocalFunction` in jsx-to-ir.ts) one hop, then fed through the SAME
+// `sortComparatorFromArrow` catalogue as an inline comparator — no new
+// comparator shapes, no IR schema change.
+describe('function-reference sort comparator (#2090)', () => {
+  test('const arrow reference, ascending', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function ProductList() {
+        const [products, setProducts] = createSignal<any[]>([])
+        const byPrice = (a, b) => a.price - b.price
+        return (
+          <ul>
+            {products().sort(byPrice).map(p => (
+              <li key={p.name}>{p.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'ProductList.tsx')
+    const ir = jsxToIR(ctx)
+
+    expect(ir).not.toBeNull()
+    if (ir!.type === 'element') {
+      const loop = ir!.children.find(c => c.type === 'loop')
+      expect(loop).toBeDefined()
+      if (loop?.type === 'loop') {
+        expect(loop.sortComparator).toBeDefined()
+        expect(sortComparatorFromArrow(loop.sortComparator!.arrow)!.keys).toEqual([
+          { key: { kind: 'field', field: 'price' }, type: 'numeric', direction: 'asc' },
+        ])
+        expect(loop.sortComparator!.paramA).toBe('a')
+        expect(loop.sortComparator!.paramB).toBe('b')
+        expect(loop.sortComparator!.raw).toBe('a.price - b.price')
+        expect(loop.array).toBe('products()')
+      }
+    }
+  })
+
+  test('const arrow reference, descending multi-key (||-chain)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function ProductList() {
+        const [products, setProducts] = createSignal<any[]>([])
+        const byPriceThenName = (a, b) => b.price - a.price || a.name.localeCompare(b.name)
+        return (
+          <ul>
+            {products().sort(byPriceThenName).map(p => (
+              <li key={p.name}>{p.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'ProductList.tsx')
+    const ir = jsxToIR(ctx)
+
+    expect(ir).not.toBeNull()
+    if (ir!.type === 'element') {
+      const loop = ir!.children.find(c => c.type === 'loop')
+      if (loop?.type === 'loop') {
+        expect(loop.sortComparator).toBeDefined()
+        expect(sortComparatorFromArrow(loop.sortComparator!.arrow)!.keys).toEqual([
+          { key: { kind: 'field', field: 'price' }, type: 'numeric', direction: 'desc' },
+          { key: { kind: 'field', field: 'name' }, type: 'string', direction: 'asc' },
+        ])
+        expect(loop.sortComparator!.raw).toBe('b.price - a.price || a.name.localeCompare(b.name)')
+      }
+    }
+  })
+
+  test('function-declaration reference with return-block body', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function byPrice(a, b) {
+        return a.price - b.price
+      }
+
+      export function ProductList() {
+        const [products, setProducts] = createSignal<any[]>([])
+        return (
+          <ul>
+            {products().sort(byPrice).map(p => (
+              <li key={p.name}>{p.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'ProductList.tsx')
+    const ir = jsxToIR(ctx)
+
+    expect(ir).not.toBeNull()
+    if (ir!.type === 'element') {
+      const loop = ir!.children.find(c => c.type === 'loop')
+      if (loop?.type === 'loop') {
+        expect(loop.sortComparator).toBeDefined()
+        expect(sortComparatorFromArrow(loop.sortComparator!.arrow)!.keys).toEqual([
+          { key: { kind: 'field', field: 'price' }, type: 'numeric', direction: 'asc' },
+        ])
+        expect(loop.sortComparator!.paramA).toBe('a')
+        expect(loop.sortComparator!.paramB).toBe('b')
+        expect(loop.sortComparator!.raw).toBe('a.price - b.price')
+      }
+    }
+  })
+
+  test('.toSorted(ref) resolves the same way as .sort(ref)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function ProductList() {
+        const [products, setProducts] = createSignal<any[]>([])
+        const byPrice = (a, b) => a.price - b.price
+        return (
+          <ul>
+            {products().toSorted(byPrice).map(p => (
+              <li key={p.name}>{p.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'ProductList.tsx')
+    const ir = jsxToIR(ctx)
+
+    expect(ir).not.toBeNull()
+    if (ir!.type === 'element') {
+      const loop = ir!.children.find(c => c.type === 'loop')
+      if (loop?.type === 'loop') {
+        expect(loop.sortComparator).toBeDefined()
+        expect(sortComparatorFromArrow(loop.sortComparator!.arrow)!.keys).toEqual([
+          { key: { kind: 'field', field: 'price' }, type: 'numeric', direction: 'asc' },
+        ])
+      }
+    }
+  })
+
+  test('component-scope const shadows a module-scope const of the same name', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      const byPrice = (a, b) => a.price - b.price
+
+      export function ProductList() {
+        const [products, setProducts] = createSignal<any[]>([])
+        const byPrice = (a, b) => b.price - a.price
+        return (
+          <ul>
+            {products().sort(byPrice).map(p => (
+              <li key={p.name}>{p.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'ProductList.tsx')
+    const ir = jsxToIR(ctx)
+
+    expect(ir).not.toBeNull()
+    if (ir!.type === 'element') {
+      const loop = ir!.children.find(c => c.type === 'loop')
+      if (loop?.type === 'loop') {
+        expect(loop.sortComparator).toBeDefined()
+        // The component-scope binding (descending) wins over the
+        // module-scope one (ascending) — distinguishable via `direction`.
+        expect(sortComparatorFromArrow(loop.sortComparator!.arrow)!.keys).toEqual([
+          { key: { kind: 'field', field: 'price' }, type: 'numeric', direction: 'desc' },
+        ])
+        expect(loop.sortComparator!.raw).toBe('b.price - a.price')
+      }
+    }
+  })
+
+  test('filter().sort(ref).map() resolves the reference in a chain', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function TodoList() {
+        const [todos, setTodos] = createSignal<any[]>([])
+        const byPriority = (a, b) => a.priority - b.priority
+        return (
+          <ul>
+            {todos().filter(t => !t.done).sort(byPriority).map(t => (
+              <li key={t.text}>{t.text}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'TodoList.tsx')
+    const ir = jsxToIR(ctx)
+
+    expect(ir).not.toBeNull()
+    if (ir!.type === 'element') {
+      const loop = ir!.children.find(c => c.type === 'loop')
+      if (loop?.type === 'loop') {
+        expect(loop.filterPredicate).toBeDefined()
+        expect(loop.sortComparator).toBeDefined()
+        expect(loop.chainOrder).toBe('filter-sort')
+        expect(sortComparatorFromArrow(loop.sortComparator!.arrow)!.keys).toEqual([
+          { key: { kind: 'field', field: 'priority' }, type: 'numeric', direction: 'asc' },
+        ])
+      }
+    }
+  })
+
+  test('sort(ref).filter().map() resolves the reference in a chain', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function TodoList() {
+        const [todos, setTodos] = createSignal<any[]>([])
+        const byPriority = (a, b) => a.priority - b.priority
+        return (
+          <ul>
+            {todos().sort(byPriority).filter(t => !t.done).map(t => (
+              <li key={t.text}>{t.text}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'TodoList.tsx')
+    const ir = jsxToIR(ctx)
+
+    expect(ir).not.toBeNull()
+    if (ir!.type === 'element') {
+      const loop = ir!.children.find(c => c.type === 'loop')
+      if (loop?.type === 'loop') {
+        expect(loop.filterPredicate).toBeDefined()
+        expect(loop.sortComparator).toBeDefined()
+        expect(loop.chainOrder).toBe('sort-filter')
+        expect(sortComparatorFromArrow(loop.sortComparator!.arrow)!.keys).toEqual([
+          { key: { kind: 'field', field: 'priority' }, type: 'numeric', direction: 'asc' },
+        ])
+      }
+    }
+  })
+})

--- a/packages/jsx/src/__tests__/unsupported-expression.test.ts
+++ b/packages/jsx/src/__tests__/unsupported-expression.test.ts
@@ -234,6 +234,70 @@ describe('Unsupported Sort Comparator (BF021)', () => {
     expect(bf021[0].message).toContain('could not be resolved')
   })
 
+  test('cross-kind shadowing (component const over module function) emits BF021, not the shadowed function (#2090)', () => {
+    // A name bound both as a const and as a `function` declaration can
+    // only happen across scopes, and FunctionInfo does not carry lexical
+    // scope (component-body functions are hoisted for client emission).
+    // Resolution refuses the ambiguity rather than guessing — pre-fix
+    // this wrongly compiled against the shadowed module function
+    // (Copilot review on #2091).
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function cmp(a, b) { return a.priority - b.priority }
+
+      export function TodoList() {
+        const [items, setItems] = createSignal<any[]>([])
+        const cmp = 5
+        return (
+          <ul>
+            {items().sort(cmp).map(t => (
+              <li key={t.name}>{t.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const { errors } = compileToIR(source)
+    const bf021 = errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+
+    expect(bf021).toHaveLength(1)
+    expect(bf021[0].message).toContain('could not be resolved')
+  })
+
+  test('cross-kind shadowing (component function over module const) also refuses with BF021 (#2090)', () => {
+    // The safe half of the same ambiguity: JS would use the component
+    // function here, but resolution cannot prove which binding the call
+    // site sees, so it refuses loudly instead of risking the WRONG
+    // (opposite-direction) comparator.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      const byPrice = (a, b) => a.price - b.price
+
+      export function ProductList() {
+        const [products, setProducts] = createSignal<any[]>([])
+        function byPrice(a, b) { return b.price - a.price }
+        return (
+          <ul>
+            {products().sort(byPrice).map(p => (
+              <li key={p.name}>{p.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const { errors } = compileToIR(source)
+    const bf021 = errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+
+    expect(bf021).toHaveLength(1)
+    expect(bf021[0].message).toContain('could not be resolved')
+  })
+
   test('unresolved (imported) identifier comparator emits BF021 (#2090)', () => {
     const source = `
       'use client'

--- a/packages/jsx/src/__tests__/unsupported-expression.test.ts
+++ b/packages/jsx/src/__tests__/unsupported-expression.test.ts
@@ -136,12 +136,14 @@ describe('Unsupported Expression Error (BF021)', () => {
 })
 
 describe('Unsupported Sort Comparator (BF021)', () => {
-  test('emits BF021 for function-reference comparator — outside accepted catalogue', () => {
+  test('function-reference comparator resolves through scope — no BF021 (#2090)', () => {
     // #1448 Tier B follow-up widened the catalogue to include
     // multi-key (`a.x - b.x || a.y - b.y`), relational ternary, and
-    // single-`return` block bodies. Function-reference comparators
-    // (`arr.sort(cmp)` where `cmp` is a named function) are still out
-    // of scope — they need scope resolution and refuse here.
+    // single-`return` block bodies. #2090 closes the remaining gap:
+    // a bare identifier callback (`arr.sort(cmp)`) is now resolved
+    // through the analyzer's scope machinery (one hop, same-file
+    // only) to the const-bound arrow, then fed through the same
+    // catalogue as an inline comparator.
     const source = `
       'use client'
       import { createSignal } from '@barefootjs/client'
@@ -152,7 +154,73 @@ describe('Unsupported Sort Comparator (BF021)', () => {
         return (
           <ul>
             {items().sort(cmp).map(t => (
-              <li>{t.name}</li>
+              <li key={t.name}>{t.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const { ir, errors } = compileToIR(source)
+    const bf021 = errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+
+    expect(bf021).toHaveLength(0)
+    expect(ir).not.toBeNull()
+    if (ir!.type === 'element') {
+      const loop = ir!.children.find(c => c.type === 'loop')
+      expect(loop).toBeDefined()
+      if (loop?.type === 'loop') {
+        expect(loop.sortComparator).toBeDefined()
+        expect(loop.sortComparator!.raw).toBe('a.priority - b.priority')
+      }
+    }
+  })
+
+  test('function-declaration comparator reference resolves — no BF021 (#2090)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function cmp(a, b) { return a.priority - b.priority }
+
+      export function TodoList() {
+        const [items, setItems] = createSignal<any[]>([])
+        return (
+          <ul>
+            {items().toSorted(cmp).map(t => (
+              <li key={t.name}>{t.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const { ir, errors } = compileToIR(source)
+    const bf021 = errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+
+    expect(bf021).toHaveLength(0)
+    expect(ir).not.toBeNull()
+    if (ir!.type === 'element') {
+      const loop = ir!.children.find(c => c.type === 'loop')
+      if (loop?.type === 'loop') {
+        expect(loop.sortComparator).toBeDefined()
+        expect(loop.sortComparator!.raw).toBe('a.priority - b.priority')
+      }
+    }
+  })
+
+  test('identifier resolving to a non-function const emits BF021 (#2090)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function TodoList() {
+        const [items, setItems] = createSignal<any[]>([])
+        const cmp = 5
+        return (
+          <ul>
+            {items().sort(cmp).map(t => (
+              <li key={t.name}>{t.name}</li>
             ))}
           </ul>
         )
@@ -163,16 +231,71 @@ describe('Unsupported Sort Comparator (BF021)', () => {
     const bf021 = errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
 
     expect(bf021).toHaveLength(1)
+    expect(bf021[0].message).toContain('could not be resolved')
   })
 
-  test('@client suppresses BF021 for unsupported sort comparator', () => {
+  test('unresolved (imported) identifier comparator emits BF021 (#2090)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { cmp } from './cmp'
+
+      export function TodoList() {
+        const [items, setItems] = createSignal<any[]>([])
+        return (
+          <ul>
+            {items().sort(cmp).map(t => (
+              <li key={t.name}>{t.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const { errors } = compileToIR(source)
+    const bf021 = errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+
+    expect(bf021).toHaveLength(1)
+    expect(bf021[0].message).toContain('could not be resolved')
+  })
+
+  test('resolved-but-off-catalogue comparator body emits BF021 naming the comparator (#2090)', () => {
+    // `a.deep.x - b.deep.x` has operand depth > 1 — `classifySortOperand`
+    // only accepts the param itself or a single-level field access, so this
+    // stays refused even once the identifier resolves to the arrow.
     const source = `
       'use client'
       import { createSignal } from '@barefootjs/client'
 
       export function TodoList() {
         const [items, setItems] = createSignal<any[]>([])
-        const cmp = (a, b) => a.priority - b.priority
+        const cmp = (a, b) => a.deep.x - b.deep.x
+        return (
+          <ul>
+            {items().sort(cmp).map(t => (
+              <li key={t.name}>{t.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+
+    const { errors } = compileToIR(source)
+    const bf021 = errors.filter(e => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+
+    expect(bf021).toHaveLength(1)
+    expect(bf021[0].message).toContain("'cmp'")
+    expect(bf021[0].message).toContain('not a supported shape')
+  })
+
+  test('@client suppresses BF021 for an unresolved sort comparator identifier', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      import { cmp } from './cmp'
+
+      export function TodoList() {
+        const [items, setItems] = createSignal<any[]>([])
         return (
           <ul>
             {/* @client */ items().sort(cmp).map(t => (

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -35,7 +35,8 @@ import {
 } from './types.ts'
 import { type AnalyzerContext, type MultiReturnJsxInfo, getSourceLocation, collectReactiveGetterNames } from './analyzer-context.ts'
 import { parseExpression, isSupported, parseBlockBody, foldBlockToExpr, predicateTernaryToLogical, tsNodeToParsedExpr, sortComparatorFromArrow, stringifyParsedExpr, cssKebabCase, type ParsedExpr } from './expression-parser.ts'
-import type { IRLoopSort } from './types.ts'
+import type { IRLoopSort, FunctionInfo } from './types.ts'
+import { formatParamWithType } from './module-exports.ts'
 import { createError, ErrorCodes, internalInvariant } from './errors.ts'
 import { CLIENT_BUILTIN_SOURCE, isClientBuiltinName, type ClientBuiltinTag } from './builtins.ts'
 import { containsReactiveExpression } from './reactivity-checker.ts'
@@ -2441,35 +2442,57 @@ type SortExtractionResult = {
  * (eval-first) and the client's JS round-trip. Accepted catalogue: subtraction
  * (`a.f - b.f`, `a - b`, reverse for desc), `.localeCompare`, and the
  * relational-ternary sign forms; any of them `||`-chained for multi-key.
+ *
+ * A bare identifier callback (`.sort(byPrice)`, #2090) is resolved one hop
+ * through {@link resolveSortComparatorIdentifier} — a module- or
+ * component-scope `const byPrice = (a, b) => …` or `function byPrice(a, b)
+ * {…}` — before falling into the same arrow + catalogue gate below, so a
+ * resolved reference is byte-for-byte equivalent to inlining it. Alias
+ * chains (`const c2 = c1`) and imported/prop identifiers are NOT followed —
+ * they surface a distinct "could not be resolved" BF021.
  */
 function extractSortComparator(
   callback: ts.Expression,
   _method: 'sort' | 'toSorted',
   ctx: TransformContext
 ): SortExtractionResult {
-  const unsupported = (): SortExtractionResult => {
-    // Surface the OUTER callback source — users see the string they wrote.
-    const raw = ctx.getJS(callback)
-    return {
-      result: null,
-      unsupportedReason:
-        `Sort comparator '${raw}' is not a supported shape. Accepted:\n` +
-        `  (a, b) => a - b\n` +
-        `  (a, b) => a.field - b.field\n` +
-        `  (a, b) => a.localeCompare(b)\n` +
-        `  (a, b) => a.field.localeCompare(b.field)\n` +
-        `  (a, b) => a.field > b.field ? 1 : a.field < b.field ? -1 : 0\n` +
-        `  any of the above '||'-chained for multi-key tie-breaks\n` +
-        `(reverse the operands for descending order).`,
+  // Surface the OUTER callback source — users see the string they wrote
+  // (for an identifier callback, `ctx.getJS` returns just the bare name).
+  const outerRaw = ctx.getJS(callback)
+  const unsupported = (): SortExtractionResult => ({
+    result: null,
+    unsupportedReason:
+      `Sort comparator '${outerRaw}' is not a supported shape. Accepted:\n` +
+      `  (a, b) => a - b\n` +
+      `  (a, b) => a.field - b.field\n` +
+      `  (a, b) => a.localeCompare(b)\n` +
+      `  (a, b) => a.field.localeCompare(b.field)\n` +
+      `  (a, b) => a.field > b.field ? 1 : a.field < b.field ? -1 : 0\n` +
+      `  any of the above '||'-chained for multi-key tie-breaks\n` +
+      `(reverse the operands for descending order).`,
+  })
+
+  let resolvedNode: ts.Expression = callback
+  if (ts.isIdentifier(callback)) {
+    const resolved = resolveSortComparatorIdentifier(callback.text, ctx)
+    if (!resolved) {
+      return {
+        result: null,
+        unsupportedReason:
+          `Sort comparator '${outerRaw}' could not be resolved to a local function — ` +
+          `declare it in the same file or inline it.`,
+      }
     }
+    resolvedNode = resolved
   }
-  if (!ts.isArrowFunction(callback) && !ts.isFunctionExpression(callback)) {
+
+  if (!ts.isArrowFunction(resolvedNode) && !ts.isFunctionExpression(resolvedNode)) {
     return {
       result: null,
       unsupportedReason: 'Sort comparator must be an arrow function or function expression',
     }
   }
-  const arrow = tsNodeToParsedExpr(callback)
+  const arrow = tsNodeToParsedExpr(resolvedNode)
   if (arrow.kind !== 'arrow' || arrow.params.length !== 2) return unsupported()
   // Gate on the same catalogue the localeCompare fallback recovers, so the
   // hoist decision (and thus the SSR/client split) is byte-for-byte unchanged.
@@ -2482,6 +2505,35 @@ function extractSortComparator(
       raw: stringifyParsedExpr(arrow.body),
     },
   }
+}
+
+/**
+ * Resolve a bare-identifier sort comparator callback (`.sort(byPrice)`,
+ * #2090) to its underlying arrow / function-expression node, ONE HOP only
+ * — no alias chains (`const c2 = c1` is not followed; `c2` resolves to the
+ * identifier `c1`, not a function, and is left unresolved).
+ *
+ * Tries a `const` binding first (`findLocalConst`, shadowing-aware: inner
+ * component-scope wins over module scope), then a `function` declaration
+ * (`ctx.analyzer.localFunctions`, same shadowing preference via
+ * `findLocalFunction`). Returns null when the name doesn't resolve to a
+ * local arrow / function-expression — covers a non-function const, an
+ * import, a prop, or a name with no local binding at all. The caller
+ * surfaces BF021 either way; the specific message (off-catalogue vs.
+ * unresolved) is decided by the caller, not here.
+ */
+function resolveSortComparatorIdentifier(name: string, ctx: TransformContext): ts.Expression | null {
+  const constInfo = findLocalConst(name, ctx)
+  if (constInfo) {
+    const ast = parseConstInitializer(constInfo)
+    if (ast && (ts.isArrowFunction(ast) || ts.isFunctionExpression(ast))) return ast
+  }
+  const fnInfo = findLocalFunction(name, ctx)
+  if (fnInfo) {
+    const ast = parseFunctionInfoAsExpr(fnInfo)
+    if (ast && (ts.isArrowFunction(ast) || ts.isFunctionExpression(ast))) return ast
+  }
+  return null
 }
 
 /**
@@ -4292,6 +4344,22 @@ function findLocalConst(name: string, ctx: TransformContext) {
 }
 
 /**
+ * Resolve a `function` declaration name with the same shadowing-aware
+ * lookup as {@link findLocalConst} — a component-scope declaration wins
+ * over a module-scope one of the same name, and among several
+ * component-scope declarations the last in source order wins.
+ *
+ * Returns undefined when no local function matches.
+ */
+function findLocalFunction(name: string, ctx: TransformContext) {
+  const matches = ctx.analyzer.localFunctions.filter(f => f.name === name)
+  if (matches.length === 0) return undefined
+  const fnScoped = matches.filter(f => !f.isModule)
+  const pool = fnScoped.length > 0 ? fnScoped : matches
+  return pool[pool.length - 1]
+}
+
+/**
  * Detect a PascalCase JSX tag that is really a *dynamic tag* local
  * (`const Tag = children.tag`) rather than a component reference.
  *
@@ -4471,6 +4539,59 @@ function parseConstInitializerImpl(c: { value?: string }): ts.Expression | null 
 /** Get text for a node living in any source file (synthetic or otherwise). */
 function astText(node: ts.Node): string {
   return node.getText(node.getSourceFile())
+}
+
+/**
+ * Re-parse a `FunctionInfo` (a `function foo(...) {...}` declaration
+ * collected by the analyzer) into an anonymous `ts.FunctionExpression`, for
+ * the same reason `parseConstInitializer` re-parses a const's initializer
+ * text — the analyzer stores source text, not a live AST node tied to
+ * `ctx.sourceFile`.
+ *
+ * Wraps as `const __bf_resolve_fn__ = function(params) body` (an
+ * EXPRESSION position) rather than reparsing a standalone `function foo() {}`
+ * statement, because `convertNode` in expression-parser.ts only recognizes
+ * `ts.isArrowFunction` / `ts.isFunctionExpression` — not
+ * `ts.isFunctionDeclaration`. The returned node's parameters/body are then
+ * structurally identical to a function-expression sort comparator, so it
+ * flows through the existing `tsNodeToParsedExpr` → `sortComparatorFromArrow`
+ * path unchanged. Uses `typedParams`/`typedBody` when present (verbatim
+ * source, may carry type annotations that don't affect `ts.isIdentifier(p.name)`
+ * checks downstream) and falls back to reconstructing from `params`/`body`.
+ *
+ * Returns null when the source doesn't parse cleanly (e.g. no body).
+ * Memoized per `FunctionInfo` object identity — mirrors
+ * `constInitializerCache`.
+ */
+const functionInfoExprCache = new WeakMap<object, ts.Expression | null>()
+
+function parseFunctionInfoAsExpr(fn: FunctionInfo): ts.Expression | null {
+  const cached = functionInfoExprCache.get(fn as object)
+  if (cached !== undefined) return cached
+  const result = parseFunctionInfoAsExprImpl(fn)
+  functionInfoExprCache.set(fn as object, result)
+  return result
+}
+
+function parseFunctionInfoAsExprImpl(fn: FunctionInfo): ts.Expression | null {
+  if (!fn.body) return null
+  const params = fn.typedParams !== undefined
+    ? fn.typedParams
+    : fn.params.map(formatParamWithType).join(', ')
+  const body = fn.typedBody ?? fn.body
+  const wrapped = `const __bf_resolve_fn__ = function(${params}) ${body}`
+  const sf = ts.createSourceFile(
+    '__bf_resolve_fn.ts',
+    wrapped,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TS,
+  )
+  const stmt = sf.statements[0]
+  if (!stmt || !ts.isVariableStatement(stmt)) return null
+  const decl = stmt.declarationList.declarations[0]
+  if (!decl?.initializer) return null
+  return decl.initializer
 }
 
 /**

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -2513,25 +2513,37 @@ function extractSortComparator(
  * — no alias chains (`const c2 = c1` is not followed; `c2` resolves to the
  * identifier `c1`, not a function, and is left unresolved).
  *
- * Tries a `const` binding first (`findLocalConst`, shadowing-aware: inner
- * component-scope wins over module scope), then a `function` declaration
- * (`ctx.analyzer.localFunctions`, same shadowing preference via
- * `findLocalFunction`). Returns null when the name doesn't resolve to a
- * local arrow / function-expression — covers a non-function const, an
- * import, a prop, or a name with no local binding at all. The caller
- * surfaces BF021 either way; the specific message (off-catalogue vs.
- * unresolved) is decided by the caller, not here.
+ * A name bound BOTH as a const and as a `function` declaration is refused
+ * outright. In valid JS that collision only occurs across scopes (a
+ * same-scope redeclaration is a syntax error), and `FunctionInfo` does not
+ * carry the source scope — component-body `function` declarations are
+ * hoisted to module scope for client emission, so its `isModule` reflects
+ * EMISSION placement, not lexical position. Picking either binding would
+ * risk compiling the comparator the call site can't actually see (Copilot
+ * review on #2091), so the ambiguity resolves to the loud unresolved
+ * BF021 instead of a guess. Within a single kind, the existing
+ * shadowing-aware lookups apply (`findLocalConst` / `findLocalFunction`:
+ * component scope beats module scope, last in source order); a binding
+ * that isn't an arrow / function expression fails resolution without any
+ * cross-kind fallback.
+ *
+ * Returns null when the name doesn't resolve to a local arrow /
+ * function-expression — covers the cross-kind ambiguity, a non-function
+ * const, an import, a prop, or a name with no local binding at all. The
+ * caller surfaces BF021 either way; the specific message (off-catalogue
+ * vs. unresolved) is decided by the caller, not here.
  */
 function resolveSortComparatorIdentifier(name: string, ctx: TransformContext): ts.Expression | null {
   const constInfo = findLocalConst(name, ctx)
+  const fnInfo = findLocalFunction(name, ctx)
+  if (constInfo && fnInfo) return null
   if (constInfo) {
     const ast = parseConstInitializer(constInfo)
-    if (ast && (ts.isArrowFunction(ast) || ts.isFunctionExpression(ast))) return ast
+    return ast && (ts.isArrowFunction(ast) || ts.isFunctionExpression(ast)) ? ast : null
   }
-  const fnInfo = findLocalFunction(name, ctx)
   if (fnInfo) {
     const ast = parseFunctionInfoAsExpr(fnInfo)
-    if (ast && (ts.isArrowFunction(ast) || ts.isFunctionExpression(ast))) return ast
+    return ast && (ts.isArrowFunction(ast) || ts.isFunctionExpression(ast)) ? ast : null
   }
   return null
 }

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -855,7 +855,22 @@ error[BF021]: Expression cannot be compiled to marked template: Higher-order met
    = help: Add /* @client */ to evaluate this expression on the client only
 ```
 
-**Sort comparators**: The comparator body is parsed into a structured `SortComparator` (a `keys: SortKey[]` list). A body is split on top-level `||` into one comparison key per operand (multi-key tie-breaks), and each operand (leaf) must match one of the accepted shapes below. Comparators outside the catalogue — function references (`sort(myCmp)`), multi-statement / local-var block bodies, and `localeCompare(b, locale, opts)` — trigger BF021.
+**Sort comparators**: The comparator body is parsed into a structured `SortComparator` (a `keys: SortKey[]` list). A body is split on top-level `||` into one comparison key per operand (multi-key tie-breaks), and each operand (leaf) must match one of the accepted shapes below. Comparators outside the catalogue — multi-statement / local-var block bodies and `localeCompare(b, locale, opts)` — trigger BF021.
+
+**Function-reference comparators** (`sort(myCmp)`, #2090): a bare identifier callback is resolved ONE HOP through the same scope machinery the compiler uses for cva-style `className` consts — a `const myCmp = (a, b) => …` or `function myCmp(a, b) {…}` declared anywhere in the same file (module scope or component scope; a component-scope declaration shadows a module-scope one of the same name) — and the resolved arrow is fed through the identical catalogue below, so a resolved reference compiles byte-for-byte like an inline comparator. Two residual refusals still trigger BF021:
+
+```
+error[BF021]: Expression cannot be compiled to marked template: Sort comparator 'myCmp' could not be resolved to a local function — declare it in the same file or inline it.
+
+  --> src/components/List.tsx:9:30
+   |
+ 9 |             {items().sort(myCmp).map(t => (
+   |                           ^^^^^
+   |
+   = help: Add /* @client */ to evaluate this expression on the client only
+```
+
+— `myCmp` is imported, a prop, or otherwise has no local `const`/`function` binding in the file (alias chains like `const c2 = c1` are also NOT followed — only one hop is resolved); or the identifier resolves to a local binding whose body is off-catalogue, in which case the message names the comparator and matches the inline-comparator refusal:
 
 ```
 error[BF021]: Expression cannot be compiled to marked template: Sort comparator 'myCmp' is not a supported shape.
@@ -878,6 +893,7 @@ error[BF021]: Expression cannot be compiled to marked template: Sort comparator 
 - `toSorted((a, b) => b.priority - a.priority)` → descending by `priority`
 - `sort((a, b) => a.price - b.price || a.name.localeCompare(b.name))` → multi-key: `price` asc, ties broken by `name`
 - `sort((a, b) => { return a.price - b.price })` → single-`return` block body (unwrapped to the returned comparator)
+- `sort(byPrice)` / `toSorted(byPrice)` where `byPrice` is a same-file `const`/`function` comparator (#2090) → resolved one hop, then compiled exactly like the equivalent inline arrow
 - `filter(...).sort(...).map(...)` → filter + sort chaining
 - `sort(...).filter(...).map(...)` → sort + filter chaining
 
@@ -909,7 +925,7 @@ This applies equally to **attribute bindings**, not just child/text expressions:
 The Go / Mojo / Xslate / Erb template adapters lower a finite, growing catalogue of `Array.prototype` / `String.prototype` methods (see "Currently lowered" in the now-closed origin catalogue issue [#1448](https://github.com/piconic-ai/barefootjs/issues/1448), whose residual gaps are folded into the master known-limitations catalog [#2069](https://github.com/piconic-ai/barefootjs/issues/2069), the v2 successor of #1395). The shapes below are the residual gaps. They are intentional — each is either covered by an escape hatch or carries a cross-adapter design barrier — and `/* @client */` (or lifting the expression into an event handler / `createEffect`, where full JS is available) is the workaround for all of them.
 
 - **`.flat` / `.flatMap` richer transforms (BF101).** Value-returning `.flat(depth?)` and `.flatMap` lower for the structured catalogue: `flat` with a literal depth (`FlatDepth`), and `flatMap` self / field / array-literal-tuple-of-leaves projections (`FlatMapOp`) — `i => i`, `i => i.field`, `i => [i.a, i.b]`. Refused: a non-literal `.flat()` depth, and `.flatMap` callbacks with a transform body (arithmetic, calls, computed / deep access, **literal** array elements, the spread form) or the 2-arg `flatMap(fn, thisArg)`. The **JSX-returning** `.flatMap` lowers separately as an `IRLoop` and is unaffected.
-- **Sort comparator follow-ups (BF021).** Function-reference comparators (`sort(myCmp)` — needs scope resolution; inline the comparator instead) and `localeCompare(b, locale, opts)`. The latter is effectively won't-fix for byte-equal SSR: Go (`golang.org/x/text/collate`) and Perl (`Unicode::Collate`) collation cannot be guaranteed byte-equal to each other or to the JS / CSR path, which breaks the three-adapter parity contract.
+- **Sort comparator follow-ups (BF021).** `localeCompare(b, locale, opts)` is effectively won't-fix for byte-equal SSR: Go (`golang.org/x/text/collate`) and Perl (`Unicode::Collate`) collation cannot be guaranteed byte-equal to each other or to the JS / CSR path, which breaks the three-adapter parity contract. Function-reference comparators (`sort(myCmp)`) now resolve (#2090) when `myCmp` is a same-file `const`/`function` — the residual gap is an imported or aliased comparator (`import { myCmp } from './cmp'`, or `const c2 = c1`), which still needs `/* @client */` or inlining.
 - **String methods out of scope.** `.charAt`, `.charCodeAt`, `.codePointAt`, `.normalize` (rarely needed in template position — compose with `String(...)` if required) and the iterator forms (`@@iterator`, `matchAll`, which would need synthetic IR).
 - **Mutating array methods (Tier D).** `.push` / `.pop` / `.splice` / `.fill` / … have no template-level meaning (SSR renders a snapshot); they only appear in client-runtime callbacks, which never reach the lowering path.
 

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -870,7 +870,7 @@ error[BF021]: Expression cannot be compiled to marked template: Sort comparator 
    = help: Add /* @client */ to evaluate this expression on the client only
 ```
 
-— `myCmp` is imported, a prop, or otherwise has no local `const`/`function` binding in the file (alias chains like `const c2 = c1` are also NOT followed — only one hop is resolved); or the identifier resolves to a local binding whose body is off-catalogue, in which case the message names the comparator and matches the inline-comparator refusal:
+— `myCmp` is imported, a prop, or otherwise has no local `const`/`function` binding in the file (alias chains like `const c2 = c1` are also NOT followed — only one hop is resolved); or the name is bound BOTH as a const and as a `function` declaration (only possible across scopes; `FunctionInfo` carries emission placement, not lexical scope, so the ambiguity refuses loudly rather than guessing which binding the call site sees); or the identifier resolves to a local binding whose body is off-catalogue, in which case the message names the comparator and matches the inline-comparator refusal:
 
 ```
 error[BF021]: Expression cannot be compiled to marked template: Sort comparator 'myCmp' is not a supported shape.


### PR DESCRIPTION
Closes #2090. Refs #2069 (known-limitations catalog v2, entry "Function-reference sort comparators (BF021)").

Stacked PR 1/4 for the four remaining #2069 catalog entries.

## What

`.sort(byPrice)` / `.toSorted(byPrice)` with a comparator declared in the same file — `const byPrice = (a, b) => a.price - b.price` (module or component scope) or `function byPrice(a, b) { return a.price - b.price }` — now compiles instead of refusing with BF021.

## How

`extractSortComparator` (`packages/jsx/src/jsx-to-ir.ts`) resolves a bare-identifier callback **one hop** through the analyzer's existing scope machinery before applying the unchanged comparator catalogue:

- `findLocalConst` (existing, shadowing-aware) for const-declared arrows / function expressions, then a new `findLocalFunction` with the same shadowing preference (component scope beats module scope, last in source order) over `ctx.analyzer.localFunctions`.
- A `function` declaration is re-parsed as an anonymous function expression (`parseFunctionInfoAsExpr`, memoized, mirroring `parseConstInitializer`) because the expression parser only recognizes arrow/function-expression nodes.
- The resolved node then flows through the **existing** `tsNodeToParsedExpr` → `sortComparatorFromArrow` gate. No new comparator shapes, no `IRLoopSort` schema change, no adapter emit changes — a resolved reference is byte-for-byte equivalent to inlining it, so all adapters (and the client `.toSorted((a,b) => …)` rebuild) graduate at once.

Residual BF021 refusals keep distinct messages:

- unresolvable identifier (import, prop, alias chain — one-hop only): `Sort comparator 'myCmp' could not be resolved to a local function — declare it in the same file or inline it`
- resolved but off-catalogue body: the existing `not a supported shape … Accepted:` text, now naming the comparator.

## Tests

- New conformance fixture `methods/array-sort-fnref.ts` (`.toSorted(byPrice)` referencing a module-scope const arrow). Verified passing on CSR conformance, Go, Mojolicious, Jinja, Twig, Xslate, ERB, Hono. The Rust render step fails in this sandbox identically to its pre-existing sort siblings (`array-sort-field-asc` also times out on clean main), i.e. environmental, not fixture-specific.
- `unsupported-expression.test.ts`: function-reference case flipped to positive; new negatives (non-function const, unresolved import, off-catalogue resolved body — message contains the name) and `@client` suppression.
- `ir-sort-comparator.test.ts`: new `#2090` describe — const arrow asc, multi-key `||` desc, function declaration with return-block body, `.toSorted(ref)`, component-scope shadowing module scope, both `filter().sort()` / `sort().filter()` chain orders.
- Go / Mojo `unsupportedSort` BF021 tables: function-reference row replaced by a positive `bf_sort` emit assertion.

## Docs

`spec/compiler.md` (BF021 section + known-limitation line), `docs/core/advanced/error-codes.md`, `docs/core/rendering/jsx-compatibility.md` updated to describe resolution + the residual import/alias-chain refusal.

## Out of scope (residual, documented)

- Imported comparators and alias chains (`const c2 = c1`) still refuse with a clear message.
- The value-position sort (`{items.toSorted(cmp).join(',')}` outside a `.map()` loop) is a different code path (`asCallbackMethodCall`) and unchanged — the catalog entry and #2090 scope the JSX loop-hoist path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqeDWcnhQjpWtoCcAosyuG

---
_Generated by [Claude Code](https://claude.ai/code/session_01SqeDWcnhQjpWtoCcAosyuG)_