### PR TITLE
Fix Django integration 404 on bare /integrations/django (no trailing slash)

### DIFF
--- a/integrations/django/app.py
+++ b/integrations/django/app.py
@@ -819,11 +819,20 @@ def root_redirect(request):
 # `BASE.lstrip('/')` (mirrors Flask's Blueprint `url_prefix=BASE`).
 # ROOT_URLCONF (set above, in the Django-setup section) points straight at
 # this module, so this list is the whole "app".
+#
+# The bare prefix (no trailing slash, e.g. `/integrations/django`) needs its
+# own explicit redirect to `home_route`'s `{_prefix}/` route: Flask's
+# Blueprint and FastAPI's APIRouter both redirect a missing trailing slash to
+# the matching slashed route automatically (Werkzeug's `strict_slashes` /
+# Starlette's `redirect_slashes`), but Django's equivalent (`CommonMiddleware`
+# + `APPEND_SLASH`) is unused here since MIDDLEWARE is empty, so without this
+# entry the bare prefix 404s instead of reaching home_route.
 # ---------------------------------------------------------------------------
 _prefix = BASE.lstrip("/")
 
 urlpatterns = [
     path("", root_redirect),
+    path(_prefix, root_redirect),
     path(f"{_prefix}/", home_route),
     path(f"{_prefix}/counter", counter_route),
     path(f"{_prefix}/toggle", toggle_route),


### PR DESCRIPTION
## Summary

- `https://barefootjs.dev/integrations/django` (no trailing slash) 404ed after #2104's deploy, while `https://barefootjs.dev/integrations/django/` worked. Flask's Blueprint and FastAPI's APIRouter both auto-redirect a missing trailing slash to the matching route (Werkzeug's `strict_slashes` / Starlette's `redirect_slashes`), but this integration's `MIDDLEWARE=[]` means Django's equivalent (`CommonMiddleware` + `APPEND_SLASH`) never runs — so the bare prefix had no matching `urlpattern` and 404ed instead of reaching `home_route`.
- Adds an explicit `path(_prefix, root_redirect)` entry so the bare prefix 302-redirects to the trailing-slash route, matching the other two Python examples' behavior.

## Test plan

- [x] `cd integrations/django && bun run build`, ran the app in production mode, confirmed `GET /integrations/django` → `302` → `Location: /integrations/django/`, and `GET /integrations/django/` → `200`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BBhTibU8rFT2Qfc1QhvpPK)_