### PR TITLE
fix(site/core): add Compatibility Matrix link to the mobile menu

### DIFF
--- a/site/core/components/mobile-menu.tsx
+++ b/site/core/components/mobile-menu.tsx
@@ -289,6 +289,7 @@ export function MobileMenu() {
                   <a href="/docs/advanced/ir-schema" className={menuLinkClass}>IR Schema</a>
                   <a href="/docs/advanced/error-codes" className={menuLinkClass}>Error Codes</a>
                   <a href="/docs/advanced/performance" className={menuLinkClass}>Performance</a>
+                  <a href="/docs/advanced/compatibility-matrix" className={menuLinkClass}>Compatibility Matrix</a>
                 </div>
               </details>
             </div>


### PR DESCRIPTION
## Summary

Follow-up to #2099: the mobile bottom-sheet menu (`site/core/components/mobile-menu.tsx`) duplicates the docs navigation as hardcoded links instead of deriving it from `lib/navigation.ts`, so the new Compatibility Matrix page appeared in the desktop sidebar but was missing from the mobile menu (reported from a device screenshot). Adds the missing link to the Advanced section.

Verified with a mobile-viewport (390×844) Playwright run against the dev server: the Advanced section now lists Advanced / Compiler Internals / IR Schema / Error Codes / Performance / **Compatibility Matrix**, and `site/core` builds cleanly.

## Note

The hardcoded duplication is drift-prone — this exact miss will recur for the next nav entry. Deriving the mobile menu's sections from the `navigation` export would fix the class of bug; left as a possible follow-up since it touches the menu's interactive structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPzPqKejepWiA6RDLqBZVc

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPzPqKejepWiA6RDLqBZVc)_