### PR TITLE
fix(jsx): don't leak init-scope locals into the CSR template when inline gates disagree

### DIFF
--- a/.changeset/fix-template-scope-local-leak.md
+++ b/.changeset/fix-template-scope-local-leak.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix a CSR template `ReferenceError` regression from the templatePrimitives V2 widening (#2069): a const whose initializer calls a method on a module-scope literal receiver (e.g. `(moduleArray).includes(prop)`) could pass the compiler's raw-form inline-safety check (an adapter with a broad `acceptsTemplateCall`, like Hono's SSR runtime, accepts any identifier-path callee) while the *actual* CSR-substituted form — where the module-scope array has been literal-inlined (`['a','b'].includes(prop)`) — was correctly refused by the same check re-run downstream. The two verdicts disagreeing left the const's name absent from both the CSR substitution map and the unsafe-name set, so the compiler emitted the bare, module-scope-invisible identifier straight into the generated `hydrate()` template instead of degrading to the spec'd `undefined` fallback — throwing at template evaluation.
+
+`generateCsrTemplate` now folds the CSR-substitution layer's own null verdicts into its unsafe-name set, so a name refused there is always treated as unsafe at the CSR template layer, regardless of what the (looser, pre-substitution) classification concluded elsewhere.

--- a/packages/adapter-tests/fixtures/__snapshots__/accordion.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/accordion.client.js
@@ -2714,7 +2714,7 @@ hydrate('Icon', { init: initIcon, template: (_p) => `${_p.name === 'github' ? `$
   md: 20,
   lg: 24,
   xl: 32,
-})[_p.size])) + '"' : ''} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" ${(linecap) != null ? 'stroke-linecap="' + escapeAttr(linecap) + '"' : ''} stroke-linejoin="round" ${(`shrink-0 ${_p.className}`) != null ? 'class="' + escapeAttr(`shrink-0 ${_p.className}`) + '"' : ''} aria-hidden="true" bf="s1"><path ${((({
+})[_p.size])) + '"' : ''} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" ${(undefined) != null ? 'stroke-linecap="' + escapeAttr(undefined) + '"' : ''} stroke-linejoin="round" ${(`shrink-0 ${_p.className}`) != null ? 'class="' + escapeAttr(`shrink-0 ${_p.className}`) + '"' : ''} aria-hidden="true" bf="s1"><path ${((({
   'check': 'M20 6 9 17l-5-5',
   'chevron-down': 'm6 9 6 6 6-6',
   'chevron-up': 'm18 15-6-6-6 6',

--- a/packages/adapter-tests/fixtures/__snapshots__/carousel.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/carousel.client.js
@@ -2714,7 +2714,7 @@ hydrate('Icon', { init: initIcon, template: (_p) => `${_p.name === 'github' ? `$
   md: 20,
   lg: 24,
   xl: 32,
-})[_p.size])) + '"' : ''} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" ${(linecap) != null ? 'stroke-linecap="' + escapeAttr(linecap) + '"' : ''} stroke-linejoin="round" ${(`shrink-0 ${_p.className}`) != null ? 'class="' + escapeAttr(`shrink-0 ${_p.className}`) + '"' : ''} aria-hidden="true" bf="s1"><path ${((({
+})[_p.size])) + '"' : ''} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" ${(undefined) != null ? 'stroke-linecap="' + escapeAttr(undefined) + '"' : ''} stroke-linejoin="round" ${(`shrink-0 ${_p.className}`) != null ? 'class="' + escapeAttr(`shrink-0 ${_p.className}`) + '"' : ''} aria-hidden="true" bf="s1"><path ${((({
   'check': 'M20 6 9 17l-5-5',
   'chevron-down': 'm6 9 6 6 6-6',
   'chevron-up': 'm18 15-6-6-6 6',

--- a/packages/adapter-tests/fixtures/__snapshots__/checkbox.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/checkbox.client.js
@@ -2714,7 +2714,7 @@ hydrate('Icon', { init: initIcon, template: (_p) => `${_p.name === 'github' ? `$
   md: 20,
   lg: 24,
   xl: 32,
-})[_p.size])) + '"' : ''} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" ${(linecap) != null ? 'stroke-linecap="' + escapeAttr(linecap) + '"' : ''} stroke-linejoin="round" ${(`shrink-0 ${_p.className}`) != null ? 'class="' + escapeAttr(`shrink-0 ${_p.className}`) + '"' : ''} aria-hidden="true" bf="s1"><path ${((({
+})[_p.size])) + '"' : ''} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" ${(undefined) != null ? 'stroke-linecap="' + escapeAttr(undefined) + '"' : ''} stroke-linejoin="round" ${(`shrink-0 ${_p.className}`) != null ? 'class="' + escapeAttr(`shrink-0 ${_p.className}`) + '"' : ''} aria-hidden="true" bf="s1"><path ${((({
   'check': 'M20 6 9 17l-5-5',
   'chevron-down': 'm6 9 6 6 6-6',
   'chevron-up': 'm18 15-6-6-6 6',

--- a/packages/adapter-tests/fixtures/__snapshots__/combobox.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/combobox.client.js
@@ -2714,7 +2714,7 @@ hydrate('Icon', { init: initIcon, template: (_p) => `${_p.name === 'github' ? `$
   md: 20,
   lg: 24,
   xl: 32,
-})[_p.size])) + '"' : ''} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" ${(linecap) != null ? 'stroke-linecap="' + escapeAttr(linecap) + '"' : ''} stroke-linejoin="round" ${(`shrink-0 ${_p.className}`) != null ? 'class="' + escapeAttr(`shrink-0 ${_p.className}`) + '"' : ''} aria-hidden="true" bf="s1"><path ${((({
+})[_p.size])) + '"' : ''} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" ${(undefined) != null ? 'stroke-linecap="' + escapeAttr(undefined) + '"' : ''} stroke-linejoin="round" ${(`shrink-0 ${_p.className}`) != null ? 'class="' + escapeAttr(`shrink-0 ${_p.className}`) + '"' : ''} aria-hidden="true" bf="s1"><path ${((({
   'check': 'M20 6 9 17l-5-5',
   'chevron-down': 'm6 9 6 6 6-6',
   'chevron-up': 'm18 15-6-6-6 6',

--- a/packages/adapter-tests/fixtures/__snapshots__/command.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/command.client.js
@@ -2714,7 +2714,7 @@ hydrate('Icon', { init: initIcon, template: (_p) => `${_p.name === 'github' ? `$
   md: 20,
   lg: 24,
   xl: 32,
-})[_p.size])) + '"' : ''} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" ${(linecap) != null ? 'stroke-linecap="' + escapeAttr(linecap) + '"' : ''} stroke-linejoin="round" ${(`shrink-0 ${_p.className}`) != null ? 'class="' + escapeAttr(`shrink-0 ${_p.className}`) + '"' : ''} aria-hidden="true" bf="s1"><path ${((({
+})[_p.size])) + '"' : ''} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" ${(undefined) != null ? 'stroke-linecap="' + escapeAttr(undefined) + '"' : ''} stroke-linejoin="round" ${(`shrink-0 ${_p.className}`) != null ? 'class="' + escapeAttr(`shrink-0 ${_p.className}`) + '"' : ''} aria-hidden="true" bf="s1"><path ${((({
   'check': 'M20 6 9 17l-5-5',
   'chevron-down': 'm6 9 6 6 6-6',
   'chevron-up': 'm18 15-6-6-6 6',

--- a/packages/adapter-tests/fixtures/__snapshots__/data-table.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/data-table.client.js
@@ -2898,7 +2898,7 @@ hydrate('Icon', { init: initIcon, template: (_p) => `${_p.name === 'github' ? `$
   md: 20,
   lg: 24,
   xl: 32,
-})[_p.size])) + '"' : ''} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" ${(linecap) != null ? 'stroke-linecap="' + escapeAttr(linecap) + '"' : ''} stroke-linejoin="round" ${(`shrink-0 ${_p.className}`) != null ? 'class="' + escapeAttr(`shrink-0 ${_p.className}`) + '"' : ''} aria-hidden="true" bf="s1"><path ${((({
+})[_p.size])) + '"' : ''} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" ${(undefined) != null ? 'stroke-linecap="' + escapeAttr(undefined) + '"' : ''} stroke-linejoin="round" ${(`shrink-0 ${_p.className}`) != null ? 'class="' + escapeAttr(`shrink-0 ${_p.className}`) + '"' : ''} aria-hidden="true" bf="s1"><path ${((({
   'check': 'M20 6 9 17l-5-5',
   'chevron-down': 'm6 9 6 6 6-6',
   'chevron-up': 'm18 15-6-6-6 6',

--- a/packages/adapter-tests/fixtures/__snapshots__/dropdown-menu.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/dropdown-menu.client.js
@@ -2714,7 +2714,7 @@ hydrate('Icon', { init: initIcon, template: (_p) => `${_p.name === 'github' ? `$
   md: 20,
   lg: 24,
   xl: 32,
-})[_p.size])) + '"' : ''} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" ${(linecap) != null ? 'stroke-linecap="' + escapeAttr(linecap) + '"' : ''} stroke-linejoin="round" ${(`shrink-0 ${_p.className}`) != null ? 'class="' + escapeAttr(`shrink-0 ${_p.className}`) + '"' : ''} aria-hidden="true" bf="s1"><path ${((({
+})[_p.size])) + '"' : ''} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" ${(undefined) != null ? 'stroke-linecap="' + escapeAttr(undefined) + '"' : ''} stroke-linejoin="round" ${(`shrink-0 ${_p.className}`) != null ? 'class="' + escapeAttr(`shrink-0 ${_p.className}`) + '"' : ''} aria-hidden="true" bf="s1"><path ${((({
   'check': 'M20 6 9 17l-5-5',
   'chevron-down': 'm6 9 6 6 6-6',
   'chevron-up': 'm18 15-6-6-6 6',

--- a/packages/adapter-tests/fixtures/__snapshots__/pagination.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/pagination.client.js
@@ -2714,7 +2714,7 @@ hydrate('Icon', { init: initIcon, template: (_p) => `${_p.name === 'github' ? `$
   md: 20,
   lg: 24,
   xl: 32,
-})[_p.size])) + '"' : ''} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" ${(linecap) != null ? 'stroke-linecap="' + escapeAttr(linecap) + '"' : ''} stroke-linejoin="round" ${(`shrink-0 ${_p.className}`) != null ? 'class="' + escapeAttr(`shrink-0 ${_p.className}`) + '"' : ''} aria-hidden="true" bf="s1"><path ${((({
+})[_p.size])) + '"' : ''} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" ${(undefined) != null ? 'stroke-linecap="' + escapeAttr(undefined) + '"' : ''} stroke-linejoin="round" ${(`shrink-0 ${_p.className}`) != null ? 'class="' + escapeAttr(`shrink-0 ${_p.className}`) + '"' : ''} aria-hidden="true" bf="s1"><path ${((({
   'check': 'M20 6 9 17l-5-5',
   'chevron-down': 'm6 9 6 6 6-6',
   'chevron-up': 'm18 15-6-6-6 6',

--- a/packages/adapter-tests/fixtures/__snapshots__/select.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/select.client.js
@@ -2714,7 +2714,7 @@ hydrate('Icon', { init: initIcon, template: (_p) => `${_p.name === 'github' ? `$
   md: 20,
   lg: 24,
   xl: 32,
-})[_p.size])) + '"' : ''} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" ${(linecap) != null ? 'stroke-linecap="' + escapeAttr(linecap) + '"' : ''} stroke-linejoin="round" ${(`shrink-0 ${_p.className}`) != null ? 'class="' + escapeAttr(`shrink-0 ${_p.className}`) + '"' : ''} aria-hidden="true" bf="s1"><path ${((({
+})[_p.size])) + '"' : ''} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" ${(undefined) != null ? 'stroke-linecap="' + escapeAttr(undefined) + '"' : ''} stroke-linejoin="round" ${(`shrink-0 ${_p.className}`) != null ? 'class="' + escapeAttr(`shrink-0 ${_p.className}`) + '"' : ''} aria-hidden="true" bf="s1"><path ${((({
   'check': 'M20 6 9 17l-5-5',
   'chevron-down': 'm6 9 6 6 6-6',
   'chevron-up': 'm18 15-6-6-6 6',

--- a/packages/jsx/src/__tests__/csr-substitution-safety-divergence.test.ts
+++ b/packages/jsx/src/__tests__/csr-substitution-safety-divergence.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Regression tests for #2106: the templatePrimitives V2 widening (#2069)
+ * let a call whose RAW callee is an identifier path
+ * (`someModuleArray.includes(prop)`) pass `computeInlinability`'s Stage-2
+ * classification (`classifyConstantInitial`, compute-inlinability.ts) —
+ * e.g. via an adapter with a broad `acceptsTemplateCall` (Hono's SSR
+ * runtime is a full JS engine, so it accepts any identifier-path callee).
+ * That check runs on the RAW initializer text so it can still see
+ * bridged prop args for the #1138 rejection.
+ *
+ * `populateCsrInlinable` (compute-inlinability.ts) re-runs the same
+ * `isInlinableInTemplate` check on the CSR-*substituted* form, where the
+ * module-scope array has already been literal-inlined
+ * (`['plus','minus'].includes(name)`). The callee is no longer an
+ * identifier path at all, so the adapter can't vouch for it, and the
+ * bridged-arg rejection correctly fires — recorded as
+ * `ctx.csrInlinable.get(name) === null`.
+ *
+ * Pre-fix, `unsafeLocalNames` (Stage-2-derived) didn't know about this
+ * second, stricter refusal, so the CSR template emitter
+ * (`generateCsrTemplate` / `transformExpr` in html-template.ts) found
+ * neither a substitution (excluded by `csrInlinableConstantsFromCtx`,
+ * which skips null entries) NOR an unsafe flag — the bare,
+ * module-scope-invisible identifier leaked straight into the emitted
+ * template text, throwing `ReferenceError` when the template function
+ * actually ran. This is the same bug class (and same shape) as the real
+ * repro in `ui/components/ui/icon`'s `linecap` constant.
+ *
+ * Fix: `generateCsrTemplate` (html-template.ts) folds `ctx.csrInlinable`'s
+ * null verdicts into the unsafe-name set it uses internally
+ * (`mergeCsrNullUnsafe`), so a name `populateCsrInlinable` refused is
+ * always treated as unsafe at the CSR template layer, regardless of what
+ * the looser Stage-2 check concluded elsewhere.
+ */
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { HonoAdapter } from '../../../adapter-hono/src/adapter/hono-adapter'
+import { extractTemplateBody } from './staged-ir/helpers'
+import { RUNTIME_IMPORT_CANDIDATES } from '../ir-to-client-js/imports'
+
+const onlyErrors = (errors: { severity?: string }[]) =>
+  errors.filter((e) => e.severity === 'error')
+
+/**
+ * Compile `source` with `HonoAdapter` (broad `acceptsTemplateCall`, the
+ * ingredient the real bug needs) and extract the CSR template's
+ * back-tick body.
+ */
+function compileTemplateBody(source: string, fileName: string): { templateBody: string; clientJs: string; errors: string[] } {
+  const result = compileJSX(source, fileName, { adapter: new HonoAdapter() })
+  expect(onlyErrors(result.errors)).toHaveLength(0)
+  const clientJs = result.files.find((f) => f.type === 'clientJs')!.content
+  return { templateBody: extractTemplateBody(clientJs), clientJs, errors: result.errors.map((e) => e.code) }
+}
+
+/**
+ * Evaluate an extracted CSR template body as a real template-literal
+ * function, with every runtime helper the compiler might reference
+ * stubbed out. Mirrors what `hydrate()` does at runtime, minus the DOM.
+ */
+function evalTemplate(templateBody: string, props: Record<string, unknown>): string {
+  const helperNames = [...RUNTIME_IMPORT_CANDIDATES]
+  const stubs = helperNames.map((name) => {
+    if (name === 'escapeAttr' || name === 'escapeText' || name === 'styleToCss') {
+      return (v: unknown) => String(v)
+    }
+    return (..._args: unknown[]) => ''
+  })
+  // eslint-disable-next-line no-new-func
+  const fn = new Function('_p', ...helperNames, `return \`${templateBody}\``)
+  return fn(props, ...stubs)
+}
+
+describe('CSR template: Stage-2 / post-substitution inline-safety divergence (#2106)', () => {
+  test('a const whose RAW form is adapter-accepted but whose CSR-substituted form is refused falls back to undefined, not a bare identifier', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      const buttLinecapIcons = ['plus', 'minus']
+
+      export function CsrNullDivergence({ name }: { name: string }) {
+        const [count] = createSignal(0)
+        const linecap = (buttLinecapIcons).includes(name) ? 'butt' : 'round'
+        return <div data-linecap={linecap}>{count()}</div>
+      }
+    `
+    const { templateBody } = compileTemplateBody(source, 'CsrNullDivergence.tsx')
+
+    // (a) No bare `linecap` identifier anywhere in the template body.
+    // Excludes the HTML attribute name text `data-linecap="` (preceded by
+    // `-`, not a real identifier reference) from the check.
+    expect(templateBody).not.toMatch(/(?<![-.\w$])linecap(?![\w$])/)
+
+    // (c) The fallback is the spec'd null-guarded `undefined` shape
+    // (`(undefined) != null ? '...' : ''`), the same fallback every other
+    // unsafe-template-scope reference degrades to (html-template.ts's
+    // `templateAttrExpr` generic path).
+    expect(templateBody).toMatch(/\(undefined\)\s*!=\s*null/)
+
+    // (b) Evaluating the template with stub runtime helpers must not
+    // throw `ReferenceError: linecap is not defined` — the pre-fix
+    // manifestation of this bug.
+    let rendered = ''
+    expect(() => { rendered = evalTemplate(templateBody, { name: 'plus', size: 'md', className: '' }) }).not.toThrow()
+
+    // The dropped-attribute fallback: SSR/CSR-initial HTML omits the
+    // attribute entirely rather than emitting a bogus value.
+    expect(rendered).not.toContain('linecap=')
+  })
+
+  test('control: a plain object-literal lookup (no call involved) still inlines through the same CSR path', () => {
+    // Guards against over-suppression: the fix must only affect names
+    // `ctx.csrInlinable` actually refused (`=== null`), not every const
+    // whose value happens to reference a module-scope constant.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      const sizeMap: Record<string, string> = { sm: 'h-4', md: 'h-6' }
+
+      export function CsrStillInlines({ size }: { size: string }) {
+        const [count] = createSignal(0)
+        const cls = sizeMap[size]
+        return <div data-cls={cls}>{count()}</div>
+      }
+    `
+    const { templateBody } = compileTemplateBody(source, 'CsrStillInlines.tsx')
+
+    // No bare `cls` identifier left in the template — it was inlined.
+    expect(templateBody).not.toMatch(/(?<![-.\w$])cls(?![\w$])/)
+    // The module-scope object literal was substituted in place of `sizeMap`,
+    // and the prop was correctly bridged to `_p.size` — not marked unsafe.
+    expect(templateBody).toContain(`{ sm: 'h-4', md: 'h-6' })[_p.size]`)
+    expect(templateBody).not.toContain('undefined')
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/emit-registration.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-registration.ts
@@ -102,8 +102,10 @@ export function buildInlinableConstants(
  * — the AST substitution + chain resolution now lives upstream.
  *
  * Excludes constants whose entry is `null` (unsafe to inline) — those
- * stay in `unsafeLocalNames` and the CSR template's expression
- * substitution surfaces the UNSAFE sentinel for any reference to them.
+ * are also folded into the unsafe set `generateCsrTemplate` uses
+ * internally (see `mergeCsrNullUnsafe` in html-template.ts, #2106), so
+ * every caller of `generateCsrTemplate` gets a consistent
+ * substitute-or-fallback decision with no extra wiring required here.
  */
 export function csrInlinableConstantsFromCtx(ctx: ClientJsContext): Map<string, string> {
   const out = new Map<string, string>()

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -1382,7 +1382,67 @@ export function generateCsrTemplate(
       }
     }
   }
-  return generateCsrTemplateWithOpts(node, { inlinableConstants, restSpreadNames, propsObjectName, csrEnv, insideLoop, unsafeLocalNames, deferredChildSlots, loopDepth: -1 })
+  const effectiveUnsafeLocalNames = mergeCsrNullUnsafe(ctx, unsafeLocalNames)
+  return generateCsrTemplateWithOpts(node, { inlinableConstants, restSpreadNames, propsObjectName, csrEnv, insideLoop, unsafeLocalNames: effectiveUnsafeLocalNames, deferredChildSlots, loopDepth: -1 })
+}
+
+/**
+ * Fold `ctx.csrInlinable`'s null verdicts into `unsafeLocalNames`, so
+ * `generateCsrTemplate`'s callers can't independently drift out of sync
+ * with `ctx.csrInlinable` (#2106).
+ *
+ * The two "is this constant's value safe to inline into a module-scope
+ * template" checks in `compute-inlinability.ts` can legitimately disagree:
+ *
+ *   - Stage-2 classification (`classifyConstantInitial`) runs
+ *     `isInlinableInTemplate` on the RAW initializer text — deliberately,
+ *     so it can still see bridged prop args (`useYjs(props.X)`) for the
+ *     #1138 rejection. A call whose raw receiver is an identifier path
+ *     (`someModuleArray.includes(name)`) can pass this check (e.g. an
+ *     adapter with a broad `acceptsTemplateCall` accepts any
+ *     identifier-path callee) even though `name` is a bridged prop arg.
+ *   - `populateCsrInlinable` re-runs the same check on the
+ *     CSR-*substituted* form, where `someModuleArray` has already been
+ *     literal-inlined (`['a','b'].includes(name)`). The callee is no
+ *     longer an identifier path at all, so the adapter can't vouch for
+ *     it, and the bridged-arg rejection correctly fires — recorded as
+ *     `ctx.csrInlinable.get(name) === null`.
+ *
+ * `unsafeLocalNames` (passed in from the Stage-2-derived
+ * `toLegacyInlinability` result) only reflects the first, looser verdict,
+ * so a name `populateCsrInlinable` refused could still be missing from
+ * it. Left alone, `transformExpr` below finds no CSR substitution for the
+ * name (`inlinableConstants` — built from `ctx.csrInlinable` by the
+ * caller — excludes null entries) AND no unsafe flag, so the bare,
+ * module-scope-invisible identifier leaks straight into the emitted
+ * template text (`ReferenceError` at template evaluation, #2106).
+ *
+ * `ctx.csrInlinable` is the ground truth for the CSR path — this makes it
+ * the single source added to (never subtracted from) the effective
+ * unsafe set used below: any post-substitution refusal is unsafe here,
+ * full stop, regardless of what the looser Stage-2 check concluded.
+ * Doing this once, inside `generateCsrTemplate` itself, means every
+ * caller (the full-init path in `emit-registration.ts` AND the
+ * template-only path in `index.ts`) gets the correction for free instead
+ * of each needing to remember to fold `ctx.csrInlinable` in themselves.
+ *
+ * System-construct (`createContext()`, `new WeakMap()`) and JSX-inline
+ * constants are exempted even though `populateCsrInlinable` also marks
+ * them `null` — that's "not applicable" routing (module-scope singleton
+ * referenced by name at runtime / already inlined at IR level), not an
+ * unsafe reference, and `toLegacyInlinability` never treated them as
+ * unsafe either.
+ */
+function mergeCsrNullUnsafe(ctx: ClientJsContext, unsafeLocalNames: Set<string> | undefined): Set<string> | undefined {
+  let merged: Set<string> | null = null
+  for (const [name, entry] of ctx.csrInlinable) {
+    if (entry !== null || unsafeLocalNames?.has(name)) continue
+    const info = ctx.localConstants.find((c) => c.name === name)
+    if (info && (info.isJsx || info.systemConstructKind)) continue
+    if (!merged) merged = new Set(unsafeLocalNames ?? [])
+    merged.add(name)
+  }
+  return merged ?? unsafeLocalNames
 }
 
 /**

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -1435,10 +1435,14 @@ export function generateCsrTemplate(
  */
 function mergeCsrNullUnsafe(ctx: ClientJsContext, unsafeLocalNames: Set<string> | undefined): Set<string> | undefined {
   let merged: Set<string> | null = null
+  // Built lazily on the first null verdict, so the common all-inlinable
+  // component pays nothing; a Set keeps the merge linear in the number
+  // of local constants instead of a per-name `.find()` scan.
+  let exemptNames: Set<string> | null = null
   for (const [name, entry] of ctx.csrInlinable) {
     if (entry !== null || unsafeLocalNames?.has(name)) continue
-    const info = ctx.localConstants.find((c) => c.name === name)
-    if (info && (info.isJsx || info.systemConstructKind)) continue
+    exemptNames ??= new Set(ctx.localConstants.filter((c) => c.isJsx || c.systemConstructKind).map((c) => c.name))
+    if (exemptNames.has(name)) continue
     if (!merged) merged = new Set(unsafeLocalNames ?? [])
     merged.add(name)
   }


### PR DESCRIPTION
## Summary

Fixes #2106 — the latent `ReferenceError` where Icon's generated `hydrate()` template referenced the init-scope local `linecap` at module scope (thrown whenever the generic-`<svg>` branch of the CSR template evaluated, e.g. `name: 'chevron-down'`).

## Root cause

templatePrimitives V2 (#2069, `fa393c0`) widened `isInlinableInTemplate`'s acceptance, which let the compiler's two inline-safety verdicts for the same const **disagree**:

- **Stage-2 classification** (`classifyConstantInitial`) checks the **raw** initializer — `buttLinecapIcons.includes(name)` has an identifier-path callee, which a broad `acceptsTemplateCall` (Hono) accepts → `linecap` removed from `unsafeLocalNames`.
- **`populateCsrInlinable`** re-checks the **CSR-substituted** form — `['plus','minus'].includes(name)` has a literal receiver (no identifier path to vouch for) and a bridged prop arg → refused, `csrInlinable['linecap'] = null`.

A name caught in that gap was **neither substituted nor flagged unsafe**, so `transformExpr` emitted the bare identifier into the template text. Per `spec/compiler.md`'s relocate() decision table, an init-local at template scope must degrade to the null-guarded `undefined` fallback — never a bare identifier.

## Fix

`generateCsrTemplate` now folds `ctx.csrInlinable`'s null verdicts into its unsafe-name set (`mergeCsrNullUnsafe`, one choke point covering both callers): a post-substitution refusal is always unsafe at the CSR template layer, regardless of the looser raw-form verdict. `system-construct` / JSX-inline null entries stay exempt (they're routing decisions, not unsafe references).

Deliberately **not** widened: true inlining of literal-receiver `.includes(prop)` (which would keep `stroke-linecap` present in CSR-template renders) — that's an acceptance-surface extension touching adapter semantics, left as a possible follow-up.

## Verification

- New regression test `packages/jsx/src/__tests__/csr-substitution-safety-divergence.test.ts` — **confirmed failing pre-fix** (reproduces the exact `escapeAttr(linecap)` leak), passing post-fix, plus a control case pinning that safe consts still inline (no over-suppression).
- Real-world repro: compiled `ui/components/ui/icon`, evaluated the template with `{name:'chevron-down'}` — no throw; `stroke-linecap` correctly dropped by the null guard (the documented safe-fallback degradation, recovered at hydrate).
- 9 `packages/adapter-tests/fixtures/__snapshots__/*.client.js` regenerated with the same command `update-fixtures.yml` uses — each diff is the one-line `escapeAttr(linecap)` → `escapeAttr(undefined)` flip; no `.html` changes.
- `bun test packages/jsx` 2308 pass / `ui/components` 1240 pass / `packages/adapter-tests` 921 pass; `bun run compat:lock` diff empty (client-JS emission only); biome + typecheck clean.
- BF061 loudness does not extend to this call-shape rejection without a new diagnostic category — noted as out of scope in the code comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPzPqKejepWiA6RDLqBZVc

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPzPqKejepWiA6RDLqBZVc)_