### PR TITLE
feat(twig): lower component-spread props via |merge instead of refusing BF101

### DIFF
--- a/.changeset/twig-component-spread-merge.md
+++ b/.changeset/twig-component-spread-merge.md
@@ -1,0 +1,9 @@
+---
+"@barefootjs/twig": minor
+---
+
+Lower `{...props}` component-spread props on the Twig adapter instead of refusing them with BF101.
+
+Twig hash literals have no splat syntax, so `renderComponent` now builds each child's props dict as an ordered sequence of segments — literal `{k: v, ...}` hash entries and spread expressions — and folds them into one expression via chained `|merge(...)` calls, with later segments winning on key conflict (matching JSX's `{...a, ...b}` / `Object.assign` semantics). A spread operand is routed through the existing `bf.omit(expr, [])` residual helper (introduced for `.map()` object-rest lowering) rather than a bare `?? {}` guard: a request-scoped props bag round-trips through `json_decode` as a PHP `stdClass`, which Twig's `merge` filter rejects outright, while `bf.omit` already normalizes `stdClass` / array / `null` into a plain array `merge` accepts. This mirrors what the ERB adapter already does with Ruby's `**hash` and the Mojolicious adapter with Perl's `%{$props}` — a blind splat that doesn't filter `onXxx`/`ref` keys out of the runtime bag at compile time.
+
+This unblocks the site/ui `Slot` polymorphism pattern (`<Slot className={classes} {...props}>`) used by `badge`, `breadcrumb`, `button`, `button-group`, `icon`, `item`, `kbd`, and `slot` itself, all of which previously failed to compile on Twig. The `button` and `kbd` pins in `conformance-pins.ts` graduate from an expected-BF101 diagnostic contract to real rendered-HTML conformance.

--- a/packages/adapter-twig/src/adapter/twig-adapter.ts
+++ b/packages/adapter-twig/src/adapter/twig-adapter.ts
@@ -946,11 +946,11 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
     },
     emitSpread: (value) => {
       // Twig hashes can't be splatted into the entry list the way `**`
-      // flattens Python kwargs into a call. The propsObject case is handled
-      // in `renderComponent` (it enumerates the analyzer's props params);
-      // any other spread shape is refused there via the unsupported gate.
-      // Emit the lowered expression so a downstream consumer sees something
-      // coherent, but renderComponent only routes the enumerated case here.
+      // flattens Ruby/Python kwargs into a call literal. `renderComponent`
+      // handles EVERY spread shape itself (both the enumerated propsObject
+      // case and the general `|merge(...)` chain — see its own docstring),
+      // so this callback is never reached for `kind: 'spread'` props; it
+      // only exists to satisfy the `AttrValueEmitter` interface.
       return this.convertExpressionToTwig(value.expr)
     },
     emitTemplate: (value, name) =>
@@ -962,41 +962,105 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
     emitJsxChildren: () => '',
   }
 
+  /**
+   * A `renderComponent` props dict, built as an ORDERED sequence of
+   * segments so `{...before, ...spread, after: 1}` JSX spread semantics
+   * (later entries win) survive the trip through Twig, which has no
+   * hash-splat syntax. Each `'entries'` segment is a literal Twig hash
+   * `{k: v, ...}`; each `'spread'` segment is an arbitrary expression
+   * lowered from a `{...expr}` prop. `combineComponentPropSegments` folds
+   * the sequence into ONE expression via Twig's `merge` filter (later
+   * segment wins on key conflict, matching `Object.assign`/JSX order).
+   */
+  private componentPropSegmentEntries(
+    segments: Array<{ kind: 'entries'; parts: string[] } | { kind: 'spread'; expr: string }>,
+  ): string[] {
+    const last = segments[segments.length - 1]
+    if (last && last.kind === 'entries') return last.parts
+    const seg = { kind: 'entries' as const, parts: [] as string[] }
+    segments.push(seg)
+    return seg.parts
+  }
+
+  /**
+   * Fold ordered prop segments into a single Twig expression via chained
+   * `|merge(...)` calls — Twig's array/hash union filter, later argument
+   * wins on key conflict, exactly like `{...a, ...b}`. Empty `'entries'`
+   * segments are dropped so a leading/trailing spread doesn't drag in a
+   * needless `{}|merge(...)`. Returns `'{}'` when every segment is empty
+   * (no props at all).
+   */
+  private combineComponentPropSegments(
+    segments: ReadonlyArray<{ kind: 'entries'; parts: string[] } | { kind: 'spread'; expr: string }>,
+  ): string {
+    let acc: string | null = null
+    for (const seg of segments) {
+      const text = seg.kind === 'entries'
+        ? (seg.parts.length > 0 ? `{${seg.parts.join(', ')}}` : null)
+        : seg.expr
+      if (text === null) continue
+      acc = acc === null ? text : `${acc}|merge(${text})`
+    }
+    return acc ?? '{}'
+  }
+
   renderComponent(comp: IRComponent): string {
-    const propParts: string[] = []
+    type Segment = { kind: 'entries'; parts: string[] } | { kind: 'spread'; expr: string }
+    const segments: Segment[] = [{ kind: 'entries', parts: [] }]
+    const currentEntries = () => this.componentPropSegmentEntries(segments)
+
     for (const p of comp.props) {
       // Skip callback props (onXxx) and `ref` — both are client-only for
       // SSR (Hono renders neither; the client JS wires them at hydration).
       if ((p.name.match(/^on[A-Z]/) || p.name === 'ref') && p.value.kind === 'expression') continue
-      // Spread props: enumerate the analyzer's props params into hash
-      // entries (the propsObject case) — Twig can't flatten a hash into
-      // the entry list. Other spread shapes are refused with BF101.
       if (p.value.kind === 'spread') {
         const trimmed = p.value.expr.trim()
+        // SolidJS-style props identifier (`function(props: P)`) has no
+        // matching runtime hash in Twig scope — props arrive as a flat
+        // set of top-level template vars, so enumerate the
+        // analyzer-extracted props params into hash entries instead of
+        // treating it as a runtime spread expression.
         if (this.propsObjectName && this.propsObjectName === trimmed) {
           for (const pp of this.propsParams) {
-            propParts.push(`${twigHashKey(pp.name)}: ${twigIdent(pp.name)}`)
+            currentEntries().push(`${twigHashKey(pp.name)}: ${twigIdent(pp.name)}`)
           }
           continue
         }
-        this.errors.push({
-          code: 'BF101',
-          severity: 'error',
-          message: `Spread props (\`{...${trimmed}}\`) on a child component cannot be lowered to Twig — Twig hash literals can't splat a runtime hash into named entries at a call site.`,
-          loc: comp.loc ?? { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
-          suggestion: {
-            message: 'Pass the child component its props explicitly rather than spreading a runtime object.',
-          },
-        })
+        // Every other spread shape (a destructure rest-bag `props`, a
+        // member-access bag like `children.props`, an intrinsic-element
+        // spread helper's own operand, …) — Twig hash literals can't
+        // splat a runtime hash into named entries at a call site, but
+        // `|merge` can fold it into the accumulated dict at the right
+        // ordinal position, mirroring ERB's `**hash` / Mojolicious's
+        // `%{$props}` blind splat: no compile-time filtering of onXxx/ref
+        // keys out of the runtime bag (the render contract tolerates
+        // them, same as the other two adapters). The operand is routed
+        // through `bf.omit(expr, [])` (the #2087 object-rest residual
+        // helper, called with an empty exclude list) rather than a bare
+        // `?? {}` guard: a request-scoped bag round-trips through
+        // `json_decode` as a `stdClass`, and Twig's `merge` filter throws
+        // `RuntimeError` on anything that isn't an array/Traversable
+        // (verified empirically — `stdClass` is rejected even though
+        // dot-access accepts it). `bf.omit` already normalises BOTH
+        // shapes (`stdClass` → assoc array, `null`/non-object → `[]`)
+        // into a plain PHP array `merge` accepts, exactly like the
+        // `bf.spread_attrs(...)` runtime helper the intrinsic-element
+        // spread path uses (that one tolerates any bag shape itself,
+        // since it's a plain function call rather than a Twig filter).
+        const spreadExpr = this.convertExpressionToTwig(p.value.expr)
+        segments.push({ kind: 'spread', expr: `bf.omit(${spreadExpr}, [])` })
         continue
       }
       const lowered = emitAttrValue(p.value, this.componentPropEmitter, p.name)
-      if (lowered) propParts.push(lowered)
+      if (lowered) currentEntries().push(lowered)
     }
     // Pass slot ID so the child renderer can set correct scope ID for
     // hydration. Skip for loop children — they use ComponentName_random.
+    // Appended to whatever the trailing entries segment is so a spread's
+    // own `_bf_slot`/`children` keys (if any) never win over these
+    // compiler-controlled entries.
     if (comp.slotId && !this.inLoop) {
-      propParts.push(`${twigHashKey('_bf_slot')}: '${comp.slotId}'`)
+      currentEntries().push(`${twigHashKey('_bf_slot')}: '${comp.slotId}'`)
     }
     const tplName = this.toTemplateName(comp.name)
 
@@ -1021,12 +1085,13 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
       const childrenBody = this.renderChildren(effectiveChildren)
       this.inLoop = prevInLoop
       const captureName = `bf_children_${comp.slotId ?? 'c' + this.childrenCaptureCounter++}`
-      const childrenEntry = `${twigHashKey('children')}: ${captureName}`
-      const allParts = [...propParts, childrenEntry]
-      return `{% set ${captureName} %}${childrenBody}{% endset %}{{ bf.render_child('${tplName}', {${allParts.join(', ')}}) | raw }}`
+      currentEntries().push(`${twigHashKey('children')}: ${captureName}`)
+      const dict = this.combineComponentPropSegments(segments)
+      return `{% set ${captureName} %}${childrenBody}{% endset %}{{ bf.render_child('${tplName}', ${dict}) | raw }}`
     }
 
-    const dictEntries = propParts.length > 0 ? `, {${propParts.join(', ')}}` : ''
+    const isEmpty = segments.every(s => s.kind === 'entries' && s.parts.length === 0)
+    const dictEntries = isEmpty ? '' : `, ${this.combineComponentPropSegments(segments)}`
     return `{{ bf.render_child('${tplName}'${dictEntries}) | raw }}`
   }
 

--- a/packages/adapter-twig/src/conformance-pins.ts
+++ b/packages/adapter-twig/src/conformance-pins.ts
@@ -47,19 +47,10 @@ export const conformancePins: ConformancePins = {
   // pins remain for any of them — see `twig-adapter.ts`'s `renderLoop` for
   // the still-refused shapes (bare-value rest use, `.filter().map()`
   // chains, `__bf_`-prefixed names).
-  // The site/ui Button auto-infers a `<Slot>` sibling that spreads
-  // `{...props}` / `{...children.props}` onto its root element. Twig
-  // hash literals can't splat a runtime dict into named call-site
-  // entries either (same engine limitation as Jinja's dict-splat), so
-  // the adapter refuses the spread with BF101 rather than emit a broken
-  // render_child call. Same genuine engine divergence as Jinja, pinned
-  // declaratively here.
-  'button': [{ code: 'BF101', severity: 'error' }],
-  // `kbd` auto-infers the same `<Slot>` `{...props}` spread as `button`
-  // above — refused with BF101 for the identical Twig hash-splat
-  // reason, not a render-mismatch (so it's pinned here, not in
-  // `skipJsx`).
-  'kbd': [{ code: 'BF101', severity: 'error' }],
+  // (button/kbd graduated: the site/ui Button/Kbd `<Slot>` `{...props}` /
+  // `{...children.props}` component-spread now lowers via Twig's `merge`
+  // filter — see `twig-adapter.ts`'s `renderComponent` — instead of
+  // refusing with BF101, so these two no longer need a pin here.)
   // (`tagged-template-classname` graduated by #2092 — the tag resolves
   // through the interleave-tag catalogue and desugars to an untagged
   // template literal, so it lowers like any other className template.)

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -182,16 +182,7 @@
         "ok": true
       },
       "twig": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038"
-            ]
-          }
-        ]
+        "ok": true
       },
       "xslate": {
         "ok": false,
@@ -246,16 +237,7 @@
         "ok": true
       },
       "twig": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038"
-            ]
-          }
-        ]
+        "ok": true
       },
       "xslate": {
         "ok": false,
@@ -310,16 +292,7 @@
         "ok": true
       },
       "twig": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038"
-            ]
-          }
-        ]
+        "ok": true
       },
       "xslate": {
         "ok": false,
@@ -374,16 +347,7 @@
         "ok": true
       },
       "twig": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038"
-            ]
-          }
-        ]
+        "ok": true
       },
       "xslate": {
         "ok": false,
@@ -963,16 +927,7 @@
         "ok": true
       },
       "twig": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038"
-            ]
-          }
-        ]
+        "ok": true
       },
       "xslate": {
         "ok": false,
@@ -1105,16 +1060,7 @@
         "ok": true
       },
       "twig": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038"
-            ]
-          }
-        ]
+        "ok": true
       },
       "xslate": {
         "ok": false,
@@ -1169,16 +1115,7 @@
         "ok": true
       },
       "twig": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038"
-            ]
-          }
-        ]
+        "ok": true
       },
       "xslate": {
         "ok": false,
@@ -1675,16 +1612,7 @@
         "ok": true
       },
       "twig": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038"
-            ]
-          }
-        ]
+        "ok": true
       },
       "xslate": {
         "ok": false,


### PR DESCRIPTION
# Summary

PR 1/3 of a stack driving the [compatibility matrix](https://barefootjs.dev/docs/advanced/compatibility-matrix) to all-✓ (496/496 cells). This PR fixes the **Twig** column's component-spread failures; PR 2 ports the mechanism to Xslate/Jinja/MiniJinja, PR 3 fixes the remaining `?? {}` (chart) limitation.

The Twig adapter refused spread props onto a child component (`<Slot className={classes} {...props}>`) with BF101 whenever the operand wasn't the enumerable SolidJS-style `props` object — blocking `badge`, `breadcrumb`, `button`, `button-group`, `icon`, `item`, `kbd`, and `slot` (8 cells) on the twig column.

## Mechanism

`renderComponent` now builds the child props dict as an **ordered sequence of segments** — literal `{k: v}` hash entries and spread expressions — folded into a single expression via chained `|merge(...)`. Twig's `merge` gives later arguments precedence, so JSX `{...a, ...b}` (later wins) semantics survive. This mirrors what ERB already does with Ruby `**hash` and Mojolicious with Perl `%{$props}`: a blind splat, no compile-time filtering of `onXxx`/`ref` keys out of the runtime bag.

Emitted Twig for `<Slot className={c} {...props}>children</Slot>`:

```twig
{% set bf_children_s1 %}...{% endset %}
{{ bf.render_child('slot', {'className': ...}|merge(bf.omit(props, []))|merge({'_bf_slot': 's1', 'children': bf_children_s1})) | raw }}
```

Spread operands route through the existing `bf.omit(expr, [])` residual helper (from the #2087 object-rest work) rather than a bare `?? {}` guard: a request-scoped props bag round-trips through `json_decode` as a PHP `stdClass`, which Twig's `merge` filter rejects with `RuntimeError`; `bf.omit` normalises `stdClass` / array / `null` into a plain array (verified against the real PHP evaluator).

## Changes

- `packages/adapter-twig/src/adapter/twig-adapter.ts` — segment-based props-dict construction; BF101 refusal removed; `propsObjectName` enumeration case unchanged.
- `packages/adapter-twig/src/conformance-pins.ts` — `button` / `kbd` BF101 pins graduated to real rendered-HTML conformance.
- `ui/compat.lock.json` — regenerated: exactly 8 twig cells flip to ✓ (466/496 ok, was 458). `chart`×twig still fails on the separate `?? {}` limitation (PR 3).
- `.changeset/twig-component-spread-merge.md` — `@barefootjs/twig`: minor.

## Verification

- `packages/adapter-twig` `bun test`: **406 pass / 2 skip / 0 fail** (real PHP/Twig evaluator; graduated button/kbd fixtures assert rendered output).
- `packages/adapter-tests` `bun test`: 921 pass / 0 fail.
- `bun run compat:lock` regenerated; cell-level diff checked — no non-twig cell changed.
- `biome check` clean.

## Note (pre-existing, out of scope)

While render-verifying on the real PHP evaluator we found `Slot`'s internal `isValidElement(children)` check miscompiles on Twig to a ternary that always evaluates false — pre-existing (previously masked by the BF101 abort), does not affect compile-compatibility or the conformance suite. Worth a separate known-limitation issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q2jexFB9zaveNhiTDfymf2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2jexFB9zaveNhiTDfymf2)_