### PR TITLE
feat(jinja,minijinja,xslate): lower component-spread props via engine merge folds

### DIFF
--- a/.changeset/jinja-rust-xslate-component-spread.md
+++ b/.changeset/jinja-rust-xslate-component-spread.md
@@ -1,0 +1,13 @@
+---
+"@barefootjs/jinja": minor
+"@barefootjs/rust": minor
+"@barefootjs/xslate": minor
+---
+
+Lower `{...props}` component-spread props on the Jinja, MiniJinja, and Xslate adapters instead of refusing them with BF101 — porting the segment-based fold the Twig adapter shipped with previously.
+
+Jinja and MiniJinja have no dict-splat syntax that flattens past a single `**` per call (CPython's `dict()` builtin raises `TemplateSyntaxError` on more than one `**` argument), so `renderComponent` now builds each child's props dict as an ordered sequence of segments — literal `{'k': v, ...}` dict entries and spread expressions — and folds them into one expression via NESTED `dict(base, **top)` calls, later segment winning on key conflict (matching JSX's `{...a, ...b}` / `Object.assign` semantics). A spread operand is wrapped `(EXPR or {})` before unpacking: `**`-unpacking an undefined/none bag raises even though Jinja's `ChainableUndefined` (Python) / `UndefinedBehavior::Chainable` (minijinja) tolerate chained member access on it, so the `or {}` guard normalises a missing bag (e.g. `children.props` when `children` was never passed) to an empty dict first. Verified against real jinja2 3.1.6 (Python) and the minijinja crate v2 (Rust).
+
+Xslate's Kolon dialect has no hash-splat syntax at all (`%$hash`-into-hashref-literal is a parse error), so its `renderComponent` instead folds the same ordered segments via chained `.merge(...)` calls — Kolon's builtin hash method, later argument wins. A spread operand is wrapped `(EXPR // {})`: `.merge(undef)` warns "Merging value is not a HASH reference" on real Text::Xslate 3.5.9, so the defined-or guard is required.
+
+This unblocks the site/ui `Slot` polymorphism pattern (`<Slot className={classes} {...props}>`) used by `badge`, `breadcrumb`, `button`, `button-group`, `icon`, `item`, `kbd`, and `slot` itself, all of which previously failed to compile on these three adapters. The `button` and `kbd` pins in each package's `conformance-pins.ts` graduate from an expected-BF101 diagnostic contract to real rendered-HTML conformance.

--- a/packages/adapter-jinja/src/adapter/jinja-adapter.ts
+++ b/packages/adapter-jinja/src/adapter/jinja-adapter.ts
@@ -898,11 +898,12 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
     },
     emitSpread: (value) => {
       // Jinja dicts can't be splatted into the entry list the way `**`
-      // flattens Python kwargs into a call. The propsObject case is handled
-      // in `renderComponent` (it enumerates the analyzer's props params);
-      // any other spread shape is refused there via the unsupported gate.
-      // Emit the lowered expression so a downstream consumer sees something
-      // coherent, but renderComponent only routes the enumerated case here.
+      // flattens Python kwargs into a call literal. `renderComponent`
+      // handles EVERY spread shape itself (both the enumerated propsObject
+      // case and the general nested `dict(base, **spread)` fold — see its
+      // own docstring), so this callback is never reached for `kind:
+      // 'spread'` props; it only exists to satisfy the `AttrValueEmitter`
+      // interface.
       return this.convertExpressionToJinja(value.expr)
     },
     emitTemplate: (value, name) =>
@@ -914,41 +915,107 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
     emitJsxChildren: () => '',
   }
 
+  /**
+   * A `renderComponent` props dict, built as an ORDERED sequence of
+   * segments so `{...before, ...spread, after: 1}` JSX spread semantics
+   * (later entries win) survive the trip through Jinja, which has no
+   * dict-splat syntax for anything past a SINGLE `**` per `dict(...)`
+   * call. Each `'entries'` segment is a literal Jinja dict `{'k': v, ...}`;
+   * each `'spread'` segment is an arbitrary expression lowered from a
+   * `{...expr}` prop. `combineComponentPropSegments` folds the sequence
+   * into ONE expression via nested `dict(base, **top)` calls (later
+   * segment wins on key conflict, matching `Object.assign`/JSX order).
+   */
+  private componentPropSegmentEntries(
+    segments: Array<{ kind: 'entries'; parts: string[] } | { kind: 'spread'; expr: string }>,
+  ): string[] {
+    const last = segments[segments.length - 1]
+    if (last && last.kind === 'entries') return last.parts
+    const seg = { kind: 'entries' as const, parts: [] as string[] }
+    segments.push(seg)
+    return seg.parts
+  }
+
+  /**
+   * Fold ordered prop segments into a single Jinja expression via nested
+   * `dict(base, **top)` calls — CPython's `dict()` builtin raises
+   * `TemplateSyntaxError` on MORE THAN ONE `**` per call, so a flat
+   * `dict(**a, **b, **c)` is not an option; each successive segment wraps
+   * the accumulator as the positional `base` with the new segment
+   * `**`-unpacked on top, later argument wins on key conflict — exactly
+   * like `{...a, ...b}`. A spread segment's expression is wrapped
+   * `(EXPR or {})` before unpacking: Jinja's `ChainableUndefined` lets a
+   * missing bag (e.g. `children.props` when `children` was never passed)
+   * chain through member access without raising, but `**`-unpacking an
+   * `Undefined`/`None` value still fails, so the `or {}` guard normalises
+   * it to an empty dict first (verified against real jinja2 3.1.6).
+   * Empty `'entries'` segments are dropped so a leading/trailing spread
+   * doesn't drag in a needless `dict({}, **...)`. Returns `'{}'` when
+   * every segment is empty (no props at all).
+   */
+  private combineComponentPropSegments(
+    segments: ReadonlyArray<{ kind: 'entries'; parts: string[] } | { kind: 'spread'; expr: string }>,
+  ): string {
+    let acc: string | null = null
+    for (const seg of segments) {
+      if (seg.kind === 'entries') {
+        if (seg.parts.length === 0) continue
+        const text = `{${seg.parts.join(', ')}}`
+        acc = acc === null ? text : `dict(${acc}, **${text})`
+      } else {
+        const text = `(${seg.expr} or {})`
+        acc = acc === null ? text : `dict(${acc}, **${text})`
+      }
+    }
+    return acc ?? '{}'
+  }
+
   renderComponent(comp: IRComponent): string {
-    const propParts: string[] = []
+    type Segment = { kind: 'entries'; parts: string[] } | { kind: 'spread'; expr: string }
+    const segments: Segment[] = [{ kind: 'entries', parts: [] }]
+    const currentEntries = () => this.componentPropSegmentEntries(segments)
+
     for (const p of comp.props) {
       // Skip callback props (onXxx) and `ref` — both are client-only for
       // SSR (Hono renders neither; the client JS wires them at hydration).
       if ((p.name.match(/^on[A-Z]/) || p.name === 'ref') && p.value.kind === 'expression') continue
-      // Spread props: enumerate the analyzer's props params into dict
-      // entries (the propsObject case) — Jinja can't flatten a dict into
-      // the entry list. Other spread shapes are refused with BF101.
       if (p.value.kind === 'spread') {
         const trimmed = p.value.expr.trim()
+        // SolidJS-style props identifier (`function(props: P)`) has no
+        // matching runtime dict in Jinja scope — props arrive as a flat
+        // set of top-level template vars, so enumerate the
+        // analyzer-extracted props params into dict entries instead of
+        // treating it as a runtime spread expression.
         if (this.propsObjectName && this.propsObjectName === trimmed) {
           for (const pp of this.propsParams) {
-            propParts.push(`${jinjaHashKey(pp.name)}: ${jinjaIdent(pp.name)}`)
+            currentEntries().push(`${jinjaHashKey(pp.name)}: ${jinjaIdent(pp.name)}`)
           }
           continue
         }
-        this.errors.push({
-          code: 'BF101',
-          severity: 'error',
-          message: `Spread props (\`{...${trimmed}}\`) on a child component cannot be lowered to Jinja — Jinja dict literals can't splat a runtime dict into named entries at a call site.`,
-          loc: comp.loc ?? { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
-          suggestion: {
-            message: 'Pass the child component its props explicitly rather than spreading a runtime object.',
-          },
-        })
+        // Every other spread shape (a destructure rest-bag `props`, a
+        // member-access bag like `children.props`, an intrinsic-element
+        // spread helper's own operand, …) — Jinja dict literals can't
+        // splat a runtime dict into named entries at a call site, but a
+        // nested `dict(base, **top)` call can fold it into the
+        // accumulated dict at the right ordinal position (CPython's
+        // `dict()` rejects more than one `**` per call, so the fold
+        // nests rather than flattens — see `combineComponentPropSegments`).
+        // No compile-time filtering of onXxx/ref keys out of the runtime
+        // bag (the render contract tolerates them, same as the other
+        // spread-lowering adapters).
+        segments.push({ kind: 'spread', expr: this.convertExpressionToJinja(p.value.expr) })
         continue
       }
       const lowered = emitAttrValue(p.value, this.componentPropEmitter, p.name)
-      if (lowered) propParts.push(lowered)
+      if (lowered) currentEntries().push(lowered)
     }
     // Pass slot ID so the child renderer can set correct scope ID for
     // hydration. Skip for loop children — they use ComponentName_random.
+    // Appended to whatever the trailing entries segment is so a spread's
+    // own `_bf_slot`/`children` keys (if any) never win over these
+    // compiler-controlled entries.
     if (comp.slotId && !this.inLoop) {
-      propParts.push(`${jinjaHashKey('_bf_slot')}: '${comp.slotId}'`)
+      currentEntries().push(`${jinjaHashKey('_bf_slot')}: '${comp.slotId}'`)
     }
     const tplName = this.toTemplateName(comp.name)
 
@@ -973,12 +1040,13 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
       const childrenBody = this.renderChildren(effectiveChildren)
       this.inLoop = prevInLoop
       const captureName = `bf_children_${comp.slotId ?? 'c' + this.childrenCaptureCounter++}`
-      const childrenEntry = `${jinjaHashKey('children')}: ${captureName}`
-      const allParts = [...propParts, childrenEntry]
-      return `{% set ${captureName} %}${childrenBody}{% endset %}{{ bf.render_child('${tplName}', {${allParts.join(', ')}}) | safe }}`
+      currentEntries().push(`${jinjaHashKey('children')}: ${captureName}`)
+      const dict = this.combineComponentPropSegments(segments)
+      return `{% set ${captureName} %}${childrenBody}{% endset %}{{ bf.render_child('${tplName}', ${dict}) | safe }}`
     }
 
-    const dictEntries = propParts.length > 0 ? `, {${propParts.join(', ')}}` : ''
+    const isEmpty = segments.every(s => s.kind === 'entries' && s.parts.length === 0)
+    const dictEntries = isEmpty ? '' : `, ${this.combineComponentPropSegments(segments)}`
     return `{{ bf.render_child('${tplName}'${dictEntries}) | safe }}`
   }
 

--- a/packages/adapter-jinja/src/conformance-pins.ts
+++ b/packages/adapter-jinja/src/conformance-pins.ts
@@ -61,19 +61,11 @@ export const conformancePins: ConformancePins = {
   // `rest-destructure-array-in-map`, `rest-destructure-nested-in-map`,
   // `destructure-array-index-in-map`, and `destructure-nested-object-in-map`
   // all render clean now — none of them are pinned here.
-  // The site/ui Button auto-infers a `<Slot>` sibling that spreads
-  // `{...props}` / `{...children.props}` onto its root element. Jinja
-  // dict literals can't splat a runtime dict into named call-site
-  // entries either (same engine limitation as Kolon's hashref method
-  // args), so the adapter refuses the spread with BF101 rather than
-  // emit a broken render_child call. Same genuine engine divergence as
-  // xslate, pinned declaratively here.
-  'button': [{ code: 'BF101', severity: 'error' }],
-  // `kbd` auto-infers the same `<Slot>` `{...props}` spread as `button`
-  // above — refused with BF101 for the identical Jinja dict-splat
-  // reason, not a render-mismatch (so it's pinned here, not in
-  // `skipJsx`).
-  'kbd': [{ code: 'BF101', severity: 'error' }],
+  // (button/kbd graduated: the site/ui Button/Kbd `<Slot>` `{...props}` /
+  // `{...children.props}` component-spread now lowers via nested
+  // `dict(base, **top)` calls — see `jinja-adapter.ts`'s `renderComponent`
+  // — instead of refusing with BF101, so these two no longer need a pin
+  // here.)
   // (`tagged-template-classname` graduated by #2092 — the tag resolves
   // through the interleave-tag catalogue and desugars to an untagged
   // template literal, so it lowers like any other className template.)

--- a/packages/adapter-rust/src/adapter/minijinja-adapter.ts
+++ b/packages/adapter-rust/src/adapter/minijinja-adapter.ts
@@ -939,11 +939,12 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
     },
     emitSpread: (value) => {
       // Jinja dicts can't be splatted into the entry list the way `**`
-      // flattens Python kwargs into a call. The propsObject case is handled
-      // in `renderComponent` (it enumerates the analyzer's props params);
-      // any other spread shape is refused there via the unsupported gate.
-      // Emit the lowered expression so a downstream consumer sees something
-      // coherent, but renderComponent only routes the enumerated case here.
+      // flattens Python kwargs into a call literal. `renderComponent`
+      // handles EVERY spread shape itself (both the enumerated propsObject
+      // case and the general nested `dict(base, **spread)` fold — see its
+      // own docstring), so this callback is never reached for `kind:
+      // 'spread'` props; it only exists to satisfy the `AttrValueEmitter`
+      // interface.
       return this.convertExpressionToJinja(value.expr)
     },
     emitTemplate: (value, name) =>
@@ -955,41 +956,109 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
     emitJsxChildren: () => '',
   }
 
+  /**
+   * A `renderComponent` props dict, built as an ORDERED sequence of
+   * segments so `{...before, ...spread, after: 1}` JSX spread semantics
+   * (later entries win) survive the trip through Jinja, which has no
+   * dict-splat syntax for anything past a SINGLE `**` per `dict(...)`
+   * call. Each `'entries'` segment is a literal Jinja dict `{'k': v, ...}`;
+   * each `'spread'` segment is an arbitrary expression lowered from a
+   * `{...expr}` prop. `combineComponentPropSegments` folds the sequence
+   * into ONE expression via nested `dict(base, **top)` calls (later
+   * segment wins on key conflict, matching `Object.assign`/JSX order).
+   */
+  private componentPropSegmentEntries(
+    segments: Array<{ kind: 'entries'; parts: string[] } | { kind: 'spread'; expr: string }>,
+  ): string[] {
+    const last = segments[segments.length - 1]
+    if (last && last.kind === 'entries') return last.parts
+    const seg = { kind: 'entries' as const, parts: [] as string[] }
+    segments.push(seg)
+    return seg.parts
+  }
+
+  /**
+   * Fold ordered prop segments into a single Jinja expression via nested
+   * `dict(base, **top)` calls — matching the CPython Jinja2 adapter's
+   * emitted syntax exactly (though minijinja itself tolerates more than
+   * one `**` per call, this adapter emits the SAME single-`**`-per-call
+   * nested form so the two engines stay syntax-identical): each
+   * successive segment wraps the accumulator as the positional `base`
+   * with the new segment `**`-unpacked on top, later argument wins on key
+   * conflict — exactly like `{...a, ...b}`. A spread segment's expression
+   * is wrapped `(EXPR or {})` before unpacking: minijinja's
+   * `UndefinedBehavior::Chainable` lets a missing bag (e.g.
+   * `children.props` when `children` was never passed) chain through
+   * member access without raising, but `**`-unpacking an undefined/none
+   * value still needs a concrete dict, so the `or {}` guard normalises it
+   * first (verified against the real minijinja crate v2 `bf-render`
+   * binary). Empty `'entries'` segments are dropped so a leading/trailing
+   * spread doesn't drag in a needless `dict({}, **...)`. Returns `'{}'`
+   * when every segment is empty (no props at all).
+   */
+  private combineComponentPropSegments(
+    segments: ReadonlyArray<{ kind: 'entries'; parts: string[] } | { kind: 'spread'; expr: string }>,
+  ): string {
+    let acc: string | null = null
+    for (const seg of segments) {
+      if (seg.kind === 'entries') {
+        if (seg.parts.length === 0) continue
+        const text = `{${seg.parts.join(', ')}}`
+        acc = acc === null ? text : `dict(${acc}, **${text})`
+      } else {
+        const text = `(${seg.expr} or {})`
+        acc = acc === null ? text : `dict(${acc}, **${text})`
+      }
+    }
+    return acc ?? '{}'
+  }
+
   renderComponent(comp: IRComponent): string {
-    const propParts: string[] = []
+    type Segment = { kind: 'entries'; parts: string[] } | { kind: 'spread'; expr: string }
+    const segments: Segment[] = [{ kind: 'entries', parts: [] }]
+    const currentEntries = () => this.componentPropSegmentEntries(segments)
+
     for (const p of comp.props) {
       // Skip callback props (onXxx) and `ref` — both are client-only for
       // SSR (Hono renders neither; the client JS wires them at hydration).
       if ((p.name.match(/^on[A-Z]/) || p.name === 'ref') && p.value.kind === 'expression') continue
-      // Spread props: enumerate the analyzer's props params into dict
-      // entries (the propsObject case) — Jinja can't flatten a dict into
-      // the entry list. Other spread shapes are refused with BF101.
       if (p.value.kind === 'spread') {
         const trimmed = p.value.expr.trim()
+        // SolidJS-style props identifier (`function(props: P)`) has no
+        // matching runtime dict in Jinja scope — props arrive as a flat
+        // set of top-level template vars, so enumerate the
+        // analyzer-extracted props params into dict entries instead of
+        // treating it as a runtime spread expression.
         if (this.propsObjectName && this.propsObjectName === trimmed) {
           for (const pp of this.propsParams) {
-            propParts.push(`${minijinjaHashKey(pp.name)}: ${minijinjaIdent(pp.name)}`)
+            currentEntries().push(`${minijinjaHashKey(pp.name)}: ${minijinjaIdent(pp.name)}`)
           }
           continue
         }
-        this.errors.push({
-          code: 'BF101',
-          severity: 'error',
-          message: `Spread props (\`{...${trimmed}}\`) on a child component cannot be lowered to Jinja — Jinja dict literals can't splat a runtime dict into named entries at a call site.`,
-          loc: comp.loc ?? { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
-          suggestion: {
-            message: 'Pass the child component its props explicitly rather than spreading a runtime object.',
-          },
-        })
+        // Every other spread shape (a destructure rest-bag `props`, a
+        // member-access bag like `children.props`, an intrinsic-element
+        // spread helper's own operand, …) — Jinja dict literals can't
+        // splat a runtime dict into named entries at a call site, but a
+        // nested `dict(base, **top)` call can fold it into the
+        // accumulated dict at the right ordinal position (kept
+        // single-`**`-per-call, matching Jinja/CPython's stricter grammar
+        // — see `combineComponentPropSegments`). No compile-time
+        // filtering of onXxx/ref keys out of the runtime bag (the render
+        // contract tolerates them, same as the other spread-lowering
+        // adapters).
+        segments.push({ kind: 'spread', expr: this.convertExpressionToJinja(p.value.expr) })
         continue
       }
       const lowered = emitAttrValue(p.value, this.componentPropEmitter, p.name)
-      if (lowered) propParts.push(lowered)
+      if (lowered) currentEntries().push(lowered)
     }
     // Pass slot ID so the child renderer can set correct scope ID for
     // hydration. Skip for loop children — they use ComponentName_random.
+    // Appended to whatever the trailing entries segment is so a spread's
+    // own `_bf_slot`/`children` keys (if any) never win over these
+    // compiler-controlled entries.
     if (comp.slotId && !this.inLoop) {
-      propParts.push(`${minijinjaHashKey('_bf_slot')}: '${comp.slotId}'`)
+      currentEntries().push(`${minijinjaHashKey('_bf_slot')}: '${comp.slotId}'`)
     }
     const tplName = this.toTemplateName(comp.name)
 
@@ -1014,12 +1083,13 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
       const childrenBody = this.renderChildren(effectiveChildren)
       this.inLoop = prevInLoop
       const captureName = `bf_children_${comp.slotId ?? 'c' + this.childrenCaptureCounter++}`
-      const childrenEntry = `${minijinjaHashKey('children')}: ${captureName}`
-      const allParts = [...propParts, childrenEntry]
-      return `{% set ${captureName} %}${childrenBody}{% endset %}{{ bf.render_child('${tplName}', {${allParts.join(', ')}}) | safe }}`
+      currentEntries().push(`${minijinjaHashKey('children')}: ${captureName}`)
+      const dict = this.combineComponentPropSegments(segments)
+      return `{% set ${captureName} %}${childrenBody}{% endset %}{{ bf.render_child('${tplName}', ${dict}) | safe }}`
     }
 
-    const dictEntries = propParts.length > 0 ? `, {${propParts.join(', ')}}` : ''
+    const isEmpty = segments.every(s => s.kind === 'entries' && s.parts.length === 0)
+    const dictEntries = isEmpty ? '' : `, ${this.combineComponentPropSegments(segments)}`
     return `{{ bf.render_child('${tplName}'${dictEntries}) | safe }}`
   }
 

--- a/packages/adapter-rust/src/conformance-pins.ts
+++ b/packages/adapter-rust/src/conformance-pins.ts
@@ -61,19 +61,11 @@ export const conformancePins: ConformancePins = {
   // `rest-destructure-object-spread-in-map` for the residual-spread case
   // and `destructure-array-index-in-map` / `destructure-nested-object-in-map`
   // for the no-rest fixed-binding shapes.
-  // The site/ui Button auto-infers a `<Slot>` sibling that spreads
-  // `{...props}` / `{...children.props}` onto its root element. Jinja
-  // dict literals can't splat a runtime dict into named call-site
-  // entries either (same engine limitation as Kolon's hashref method
-  // args), so the adapter refuses the spread with BF101 rather than
-  // emit a broken render_child call. Same genuine engine divergence as
-  // xslate, pinned declaratively here.
-  'button': [{ code: 'BF101', severity: 'error' }],
-  // `kbd` auto-infers the same `<Slot>` `{...props}` spread as `button`
-  // above — refused with BF101 for the identical Jinja dict-splat
-  // reason, not a render-mismatch (so it's pinned here, not in
-  // `skipJsx`).
-  'kbd': [{ code: 'BF101', severity: 'error' }],
+  // (button/kbd graduated: the site/ui Button/Kbd `<Slot>` `{...props}` /
+  // `{...children.props}` component-spread now lowers via nested
+  // `dict(base, **top)` calls — see `minijinja-adapter.ts`'s
+  // `renderComponent` — instead of refusing with BF101, so these two no
+  // longer need a pin here.)
   // (`tagged-template-classname` graduated by #2092 — the tag resolves
   // through the interleave-tag catalogue and desugars to an untagged
   // template literal, so it lowers like any other className template.)

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -857,11 +857,11 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     },
     emitSpread: (value) => {
       // Kolon hashrefs can't be splatted into the entry list the way Perl
-      // `%{...}` flattens into a list. The propsObject case is handled in
-      // `renderComponent` (it enumerates the analyzer's props params); any
-      // other spread shape is refused there via the unsupported gate. Emit
-      // the lowered expression so a downstream consumer sees something
-      // coherent, but renderComponent only routes the enumerated case here.
+      // `%{...}` flattens into a list. `renderComponent` handles EVERY
+      // spread shape itself (both the enumerated propsObject case and the
+      // general chained `.merge(...)` fold — see its own docstring), so
+      // this callback is never reached for `kind: 'spread'` props; it
+      // only exists to satisfy the `AttrValueEmitter` interface.
       return this.convertExpressionToKolon(value.expr)
     },
     emitTemplate: (value, name) =>
@@ -873,41 +873,106 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     emitJsxChildren: () => '',
   }
 
+  /**
+   * A `renderComponent` props hashref, built as an ORDERED sequence of
+   * segments so `{...before, ...spread, after: 1}` JSX spread semantics
+   * (later entries win) survive the trip through Kolon, which has no
+   * hash-splat syntax (no `%$h`-into-hashref-literal form — verified: parse
+   * error). Each `'entries'` segment is a literal Kolon hashref
+   * `{ k => v, ... }`; each `'spread'` segment is an arbitrary expression
+   * lowered from a `{...expr}` prop. `combineComponentPropSegments` folds
+   * the sequence into ONE expression via chained `.merge(...)` calls
+   * (Kolon's builtin hash method, later argument wins on key conflict,
+   * matching `Object.assign`/JSX order).
+   */
+  private componentPropSegmentEntries(
+    segments: Array<{ kind: 'entries'; parts: string[] } | { kind: 'spread'; expr: string }>,
+  ): string[] {
+    const last = segments[segments.length - 1]
+    if (last && last.kind === 'entries') return last.parts
+    const seg = { kind: 'entries' as const, parts: [] as string[] }
+    segments.push(seg)
+    return seg.parts
+  }
+
+  /**
+   * Fold ordered prop segments into a single Kolon expression via chained
+   * `.merge(...)` calls — Kolon's builtin hash method, later argument wins
+   * on key conflict, exactly like `{...a, ...b}`. A spread segment's
+   * expression is wrapped `(EXPR // {})` before merging: `.merge(undef)`
+   * warns "Merging value is not a HASH reference" (verified against real
+   * Text::Xslate 3.5.9), so the defined-or guard normalises a missing bag
+   * (e.g. `$children.props` when `children` was never passed — Kolon
+   * tolerates the chained dot-access on an undefined value itself,
+   * verified empirically) to an empty hashref first. If the fold starts
+   * with a spread segment, the base is just `($SPREAD // {})`; a
+   * following segment chains `.merge({...})` onto it. Empty `'entries'`
+   * segments are dropped so a leading/trailing spread doesn't drag in a
+   * needless `{}.merge(...)`. Returns `'{}'` when every segment is empty
+   * (no props at all).
+   */
+  private combineComponentPropSegments(
+    segments: ReadonlyArray<{ kind: 'entries'; parts: string[] } | { kind: 'spread'; expr: string }>,
+  ): string {
+    let acc: string | null = null
+    for (const seg of segments) {
+      if (seg.kind === 'entries') {
+        if (seg.parts.length === 0) continue
+        const text = `{ ${seg.parts.join(', ')} }`
+        acc = acc === null ? text : `${acc}.merge(${text})`
+      } else {
+        const text = `(${seg.expr} // {})`
+        acc = acc === null ? text : `${acc}.merge(${text})`
+      }
+    }
+    return acc ?? '{}'
+  }
+
   renderComponent(comp: IRComponent): string {
-    const propParts: string[] = []
+    type Segment = { kind: 'entries'; parts: string[] } | { kind: 'spread'; expr: string }
+    const segments: Segment[] = [{ kind: 'entries', parts: [] }]
+    const currentEntries = () => this.componentPropSegmentEntries(segments)
+
     for (const p of comp.props) {
       // Skip callback props (onXxx) and `ref` — both are client-only for
       // SSR (Hono renders neither; the client JS wires them at hydration).
       if ((p.name.match(/^on[A-Z]/) || p.name === 'ref') && p.value.kind === 'expression') continue
-      // Spread props: enumerate the analyzer's props params into hashref
-      // entries (the propsObject case) — Kolon can't flatten a hashref into
-      // the entry list. Other spread shapes are refused with BF101.
       if (p.value.kind === 'spread') {
         const trimmed = p.value.expr.trim()
+        // SolidJS-style props identifier (`function(props: P)`) has no
+        // matching runtime hash in Kolon scope — props arrive as a flat
+        // set of top-level template vars, so enumerate the
+        // analyzer-extracted props params into hashref entries instead of
+        // treating it as a runtime spread expression.
         if (this.propsObjectName && this.propsObjectName === trimmed) {
           for (const pp of this.propsParams) {
-            propParts.push(`${pp.name} => $${pp.name}`)
+            currentEntries().push(`${pp.name} => $${pp.name}`)
           }
           continue
         }
-        this.errors.push({
-          code: 'BF101',
-          severity: 'error',
-          message: `Spread props (\`{...${trimmed}}\`) on a child component cannot be lowered to Kolon — Kolon hashref method args can't splat a runtime hash into named entries.`,
-          loc: comp.loc ?? { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
-          suggestion: {
-            message: 'Pass the child component its props explicitly rather than spreading a runtime object.',
-          },
-        })
+        // Every other spread shape (a destructure rest-bag `props`, a
+        // member-access bag like `children.props`, an intrinsic-element
+        // spread helper's own operand, …) — Kolon hashref literals can't
+        // splat a runtime hash into named entries at a call site, but the
+        // builtin `.merge` method can fold it into the accumulated
+        // hashref at the right ordinal position, mirroring Twig's
+        // `|merge` / Jinja's `dict(base, **top)`: no compile-time
+        // filtering of onXxx/ref keys out of the runtime bag (the render
+        // contract tolerates them, same as the other spread-lowering
+        // adapters).
+        segments.push({ kind: 'spread', expr: this.convertExpressionToKolon(p.value.expr) })
         continue
       }
       const lowered = emitAttrValue(p.value, this.componentPropEmitter, p.name)
-      if (lowered) propParts.push(lowered)
+      if (lowered) currentEntries().push(lowered)
     }
     // Pass slot ID so the child renderer can set correct scope ID for
     // hydration. Skip for loop children — they use ComponentName_random.
+    // Appended to whatever the trailing entries segment is so a spread's
+    // own `_bf_slot`/`children` keys (if any) never win over these
+    // compiler-controlled entries.
     if (comp.slotId && !this.inLoop) {
-      propParts.push(`_bf_slot => '${comp.slotId}'`)
+      currentEntries().push(`_bf_slot => '${comp.slotId}'`)
     }
     const tplName = this.toTemplateName(comp.name)
 
@@ -929,12 +994,13 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
       const childrenBody = this.renderChildren(effectiveChildren)
       this.inLoop = prevInLoop
       const macroName = `bf_children_${comp.slotId ?? 'c' + this.childrenCaptureCounter++}`
-      const childrenEntry = `children => ${macroName}()`
-      const allParts = [...propParts, childrenEntry]
-      return `<: macro ${macroName} -> () { :>${childrenBody}<: } :><: $bf.render_child('${tplName}', { ${allParts.join(', ')} }) | mark_raw :>`
+      currentEntries().push(`children => ${macroName}()`)
+      const dict = this.combineComponentPropSegments(segments)
+      return `<: macro ${macroName} -> () { :>${childrenBody}<: } :><: $bf.render_child('${tplName}', ${dict}) | mark_raw :>`
     }
 
-    const hashEntries = propParts.length > 0 ? `, { ${propParts.join(', ')} }` : ''
+    const isEmpty = segments.every(s => s.kind === 'entries' && s.parts.length === 0)
+    const hashEntries = isEmpty ? '' : `, ${this.combineComponentPropSegments(segments)}`
     return `<: $bf.render_child('${tplName}'${hashEntries}) | mark_raw :>`
   }
 

--- a/packages/adapter-xslate/src/conformance-pins.ts
+++ b/packages/adapter-xslate/src/conformance-pins.ts
@@ -52,19 +52,11 @@ export const conformancePins: ConformancePins = {
   //     the parent-prefix accessor (`$__bf_item.cells`) feeds the same
   //     `$bf.slice(...)` call.
   // None of these are pinned here anymore.
-  // XSLATE-SPECIFIC (mojo passes this): the site/ui Button auto-infers a
-  // `<Slot>` sibling that spreads `{...props}` / `{...children.props}`
-  // onto its root element. Kolon hashref method args can't splat a
-  // runtime hash into named entries (no `%$h`-into-call-args form), so
-  // the adapter refuses the spread with BF101 rather than emit a broken
-  // render_child call. Mojo's EP `%= include` accepts a flat stash, so it
-  // lowers the same shape; this is a genuine engine divergence, pinned
-  // declaratively here.
-  'button': [{ code: 'BF101', severity: 'error' }],
-  // `kbd` auto-infers the same `<Slot>` `{...props}` spread as `button`
-  // above — refused with BF101 for the identical Kolon engine reason, not a
-  // render-mismatch (so it's pinned here, not in `skipJsx`).
-  'kbd': [{ code: 'BF101', severity: 'error' }],
+  // (button/kbd graduated: the site/ui Button/Kbd `<Slot>` `{...props}` /
+  // `{...children.props}` component-spread now lowers via Kolon's builtin
+  // `.merge(...)` method chain — see `xslate-adapter.ts`'s
+  // `renderComponent` — instead of refusing with BF101, so these two no
+  // longer need a pin here.)
   // #1467 demo-corpus context providers (`radio-group`, `select`,
   // `dropdown-menu`, `combobox`, `command`) are no longer pinned — an
   // object-literal provider value (`{ value: currentValue,

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -153,30 +153,10 @@
         "ok": true
       },
       "jinja": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038",
-              "https://github.com/piconic-ai/barefootjs/issues/2087"
-            ]
-          }
-        ]
+        "ok": true
       },
       "minijinja": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038",
-              "https://github.com/piconic-ai/barefootjs/issues/2087"
-            ]
-          }
-        ]
+        "ok": true
       },
       "mojolicious": {
         "ok": true
@@ -185,16 +165,7 @@
         "ok": true
       },
       "xslate": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038"
-            ]
-          }
-        ]
+        "ok": true
       }
     },
     "breadcrumb": {
@@ -208,30 +179,10 @@
         "ok": true
       },
       "jinja": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038",
-              "https://github.com/piconic-ai/barefootjs/issues/2087"
-            ]
-          }
-        ]
+        "ok": true
       },
       "minijinja": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038",
-              "https://github.com/piconic-ai/barefootjs/issues/2087"
-            ]
-          }
-        ]
+        "ok": true
       },
       "mojolicious": {
         "ok": true
@@ -240,16 +191,7 @@
         "ok": true
       },
       "xslate": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038"
-            ]
-          }
-        ]
+        "ok": true
       }
     },
     "button": {
@@ -263,30 +205,10 @@
         "ok": true
       },
       "jinja": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038",
-              "https://github.com/piconic-ai/barefootjs/issues/2087"
-            ]
-          }
-        ]
+        "ok": true
       },
       "minijinja": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038",
-              "https://github.com/piconic-ai/barefootjs/issues/2087"
-            ]
-          }
-        ]
+        "ok": true
       },
       "mojolicious": {
         "ok": true
@@ -295,16 +217,7 @@
         "ok": true
       },
       "xslate": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038"
-            ]
-          }
-        ]
+        "ok": true
       }
     },
     "button-group": {
@@ -318,30 +231,10 @@
         "ok": true
       },
       "jinja": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038",
-              "https://github.com/piconic-ai/barefootjs/issues/2087"
-            ]
-          }
-        ]
+        "ok": true
       },
       "minijinja": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038",
-              "https://github.com/piconic-ai/barefootjs/issues/2087"
-            ]
-          }
-        ]
+        "ok": true
       },
       "mojolicious": {
         "ok": true
@@ -350,16 +243,7 @@
         "ok": true
       },
       "xslate": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038"
-            ]
-          }
-        ]
+        "ok": true
       }
     },
     "calendar": {
@@ -898,30 +782,10 @@
         "ok": true
       },
       "jinja": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038",
-              "https://github.com/piconic-ai/barefootjs/issues/2087"
-            ]
-          }
-        ]
+        "ok": true
       },
       "minijinja": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038",
-              "https://github.com/piconic-ai/barefootjs/issues/2087"
-            ]
-          }
-        ]
+        "ok": true
       },
       "mojolicious": {
         "ok": true
@@ -930,16 +794,7 @@
         "ok": true
       },
       "xslate": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038"
-            ]
-          }
-        ]
+        "ok": true
       }
     },
     "input": {
@@ -1031,30 +886,10 @@
         "ok": true
       },
       "jinja": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038",
-              "https://github.com/piconic-ai/barefootjs/issues/2087"
-            ]
-          }
-        ]
+        "ok": true
       },
       "minijinja": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038",
-              "https://github.com/piconic-ai/barefootjs/issues/2087"
-            ]
-          }
-        ]
+        "ok": true
       },
       "mojolicious": {
         "ok": true
@@ -1063,16 +898,7 @@
         "ok": true
       },
       "xslate": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038"
-            ]
-          }
-        ]
+        "ok": true
       }
     },
     "kbd": {
@@ -1086,30 +912,10 @@
         "ok": true
       },
       "jinja": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038",
-              "https://github.com/piconic-ai/barefootjs/issues/2087"
-            ]
-          }
-        ]
+        "ok": true
       },
       "minijinja": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038",
-              "https://github.com/piconic-ai/barefootjs/issues/2087"
-            ]
-          }
-        ]
+        "ok": true
       },
       "mojolicious": {
         "ok": true
@@ -1118,16 +924,7 @@
         "ok": true
       },
       "xslate": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038"
-            ]
-          }
-        ]
+        "ok": true
       }
     },
     "label": {
@@ -1583,30 +1380,10 @@
         "ok": true
       },
       "jinja": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038",
-              "https://github.com/piconic-ai/barefootjs/issues/2087"
-            ]
-          }
-        ]
+        "ok": true
       },
       "minijinja": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038",
-              "https://github.com/piconic-ai/barefootjs/issues/2087"
-            ]
-          }
-        ]
+        "ok": true
       },
       "mojolicious": {
         "ok": true
@@ -1615,16 +1392,7 @@
         "ok": true
       },
       "xslate": {
-        "ok": false,
-        "diagnostics": [
-          {
-            "code": "BF101",
-            "severity": "error",
-            "issues": [
-              "https://github.com/piconic-ai/barefootjs/issues/2038"
-            ]
-          }
-        ]
+        "ok": true
       }
     },
     "spinner": {


### PR DESCRIPTION
# Summary

PR 2/3 of the compatibility-matrix stack (stacked on #2109; PR 3 will fix the remaining `?? {}` chart limitation). Ports #2109's ordered-segment component-spread lowering from Twig to the three remaining refusing adapters, so `<Slot className={classes} {...props}>` compiles everywhere.

## Mechanism per engine (all verified against the real engines before implementation)

- **Jinja / MiniJinja** — nested `dict(base, **spread)` folds. CPython Jinja2 raises `TemplateSyntaxError` on more than one `**` per call (the minijinja crate tolerates several), so both adapters emit the same nested single-`**` form and stay syntax-identical. Spread operands are guarded `(expr or {})` — safe for absent bags under the Python runtime's `ChainableUndefined` and minijinja's chainable undefined.
- **Xslate (Kolon)** — chained `.merge(...)` builtin hash-method folds. Kolon has no hash-splat syntax at all (`{ %$props }` is a parse error, verified), but `.merge()`'s argument wins on key conflict, preserving JSX later-wins order. Spread operands are guarded `(expr // {})` since `.merge(undef)` is rejected by Text::Xslate.

Emitted syntax for `<Slot className={c} {...props}>children</Slot>`:

```jinja
bf.render_child('slot', dict(dict({'className': className}, **(props or {})), **{'_bf_slot': 's0', 'children': bf_children_s0}))
```
```kolon
$bf.render_child('slot', { className => $className }.merge(($props // {})).merge({ _bf_slot => 's0', children => bf_children_s0() }))
```

The `renderComponent` structure (segment list + fold helper) is kept structurally parallel across all four adapters touched by this stack. MiniJinja's adapter is a deliberate code-duplicated port of Jinja's, so the change is applied to both files independently, matching that file's conventions.

## Changes

- `packages/adapter-jinja/src/adapter/jinja-adapter.ts`, `packages/adapter-rust/src/adapter/minijinja-adapter.ts`, `packages/adapter-xslate/src/adapter/xslate-adapter.ts` — BF101 refusal replaced with segment folds; `propsObjectName` enumeration case unchanged.
- `conformance-pins.ts` ×3 — `button` / `kbd` BF101 pins graduated to rendered-HTML conformance.
- `ui/compat.lock.json` — regenerated: exactly the 24 spread-blocked cells flip to ✓ (`{badge, breadcrumb, button, button-group, icon, item, kbd, slot} × {jinja, minijinja, xslate}`), **490/496 ok** (was 466). Remaining 6 failures are all `chart` (`?? {}`, PR 3).
- `.changeset/jinja-rust-xslate-component-spread.md` — `@barefootjs/jinja` / `@barefootjs/rust` / `@barefootjs/xslate`: minor.

## Verification

- `packages/adapter-jinja` `bun test`: 408 tests, 0 fail (real python3 + jinja2 3.1.6 evaluator).
- `packages/adapter-rust` `bun test`: 408 tests, 0 fail (real `bf-render` minijinja binary).
- `packages/adapter-xslate` `bun test`: 409 tests, 0 fail (Text::Xslate 3.5.9 installed — the previously-skipped render tests ran for real).
- `packages/adapter-tests` `bun test`: 921 pass, 0 fail.
- Compat-lock cell diff verified programmatically: 24 expected flips, zero regressions, chart cells byte-identical.
- `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q2jexFB9zaveNhiTDfymf2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2jexFB9zaveNhiTDfymf2)_