### PR TITLE
Drop the LP footer copyright/license line

### DIFF
--- a/site/core/landing/components/lp-chrome.tsx
+++ b/site/core/landing/components/lp-chrome.tsx
@@ -41,7 +41,6 @@ export function LpFooter({ uiHref = 'https://ui.barefootjs.dev' }: { uiHref?: st
           <a href="/docs/advanced/compatibility-matrix">Compatibility</a>
           <a href="https://github.com/piconic-ai/barefootjs">GitHub</a>
         </div>
-        <div>© 2026 Piconic — open source (MIT).</div>
       </div>
     </footer>
   )


### PR DESCRIPTION
Follow-up to #2112. The footer's "© 2026 Piconic — open source (MIT)." line was placed without real consideration: there is no Piconic legal entity to credit yet, and the license is already stated in the repository (LICENSE / README). The LP footer now carries navigation links only.

Verified: `site/core` build passes and the rendered footer contains just the five nav links — no copyright/license text remains on the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfJFhMBQZ2nzYYmdSBuMhv

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfJFhMBQZ2nzYYmdSBuMhv)_