### PR TITLE
Minify served client JS in site/core and site/ui builds

### DIFF
--- a/site/core/build.ts
+++ b/site/core/build.ts
@@ -26,6 +26,7 @@ import {
   generateHash,
   resolveRelativeImports,
 } from '../../packages/cli/src/lib/build'
+import { transpile } from '../../packages/cli/src/lib/runtime'
 import { addScriptCollection } from '../../packages/adapter-hono/src/build'
 
 const ROOT_DIR = dirname(import.meta.path)
@@ -64,11 +65,23 @@ if (!await Bun.file(domDistFile).exists()) {
   await proc.exited
 }
 
-await Bun.write(
-  resolve(DIST_COMPONENTS_DIR, barefootFileName),
-  Bun.file(domDistFile)
-)
-console.log(`Generated: dist/components/${barefootFileName}`)
+// Fully minify the runtime at copy time (identifier mangling included —
+// unlike component client JS, only the runtime's ESM export names must
+// survive, and Bun.build preserves those). The runtime is the largest
+// single script the site serves, and the LP's "~14 kB gzipped" claim is
+// measured on this minified build.
+const runtimeBuild = await Bun.build({
+  entrypoints: [domDistFile],
+  target: 'browser',
+  format: 'esm',
+  minify: true,
+})
+if (!runtimeBuild.success || runtimeBuild.outputs.length === 0) {
+  for (const log of runtimeBuild.logs) console.error(log)
+  throw new Error('Failed to minify barefoot.js runtime')
+}
+await Bun.write(resolve(DIST_COMPONENTS_DIR, barefootFileName), runtimeBuild.outputs[0])
+console.log(`Generated: dist/components/${barefootFileName} (minified)`)
 
 // ── 3. Compile "use client" components ────────────────────────
 
@@ -205,6 +218,24 @@ await resolveRelativeImports({
   manifest,
   sourceDirs: [COMPONENTS_DIR, resolve(SHARED_DIR, 'components'), LANDING_COMPONENTS_DIR],
 })
+
+// Minify client JS. Runs after combine + import resolution so the pass
+// sees the final file contents; the static/ copies below inherit it.
+// The runtime (barefoot.js) is already minified at copy time above.
+for (const [name, entry] of Object.entries(manifest)) {
+  if (name === '__barefoot__' || !entry.clientJs) continue
+  const filePath = resolve(DIST_DIR, entry.clientJs)
+  const content = await Bun.file(filePath).text().catch(() => '')
+  if (!content) continue
+  try {
+    // loader 'ts': some inlined utility modules carry TS-only syntax
+    // (non-null assertions) that the plain 'js' parser rejects.
+    await Bun.write(filePath, transpile(content, { loader: 'ts', minify: true }))
+  } catch (err) {
+    throw new Error(`Failed to minify ${entry.clientJs}: ${err instanceof Error ? err.message : err}`)
+  }
+}
+console.log('Minified: component client JS')
 
 // Generate index.ts for re-exporting all compiled components
 async function collectExports(dir: string, prefix: string = ''): Promise<string[]> {

--- a/site/ui/build.ts
+++ b/site/ui/build.ts
@@ -24,6 +24,7 @@ import {
   generateHash,
   resolveRelativeImports,
 } from '../../packages/cli/src/lib/build'
+import { transpile } from '../../packages/cli/src/lib/runtime'
 import { loadIndex } from '../../packages/cli/src/lib/meta-loader'
 import { generateUiLlmsTxt } from '../../packages/cli/src/lib/llms-txt-generator'
 import { addScriptCollection } from '../../packages/adapter-hono/src/build'
@@ -129,12 +130,22 @@ if (!await Bun.file(domDistFile).exists()) {
   await proc.exited
 }
 
-// Copy to dist/components/ for components inside rootDir (ui/components/)
-await Bun.write(
-  resolve(DIST_COMPONENTS_DIR, barefootFileName),
-  Bun.file(domDistFile)
-)
-console.log(`Generated: dist/components/${barefootFileName}`)
+// Copy to dist/components/ for components inside rootDir (ui/components/).
+// Fully minified at copy time (identifier mangling included — unlike
+// component client JS, only the runtime's ESM export names must survive,
+// and Bun.build preserves those).
+const runtimeBuild = await Bun.build({
+  entrypoints: [domDistFile],
+  target: 'browser',
+  format: 'esm',
+  minify: true,
+})
+if (!runtimeBuild.success || runtimeBuild.outputs.length === 0) {
+  for (const log of runtimeBuild.logs) console.error(log)
+  throw new Error('Failed to minify barefoot.js runtime')
+}
+await Bun.write(resolve(DIST_COMPONENTS_DIR, barefootFileName), runtimeBuild.outputs[0])
+console.log(`Generated: dist/components/${barefootFileName} (minified)`)
 
 // Build and copy barefoot-form.js from @barefootjs/form
 // External @barefootjs/client so it resolves via import map
@@ -145,6 +156,7 @@ console.log('Building @barefootjs/form for site...')
 const formBuildResult = await Bun.build({
   entrypoints: [formEntryFile],
   format: 'esm',
+  minify: true,
   external: ['@barefootjs/client', '@barefootjs/client/runtime'],
 })
 
@@ -165,6 +177,7 @@ console.log('Building @barefootjs/chart for site...')
 const chartBuildResult = await Bun.build({
   entrypoints: [chartEntryFile],
   format: 'esm',
+  minify: true,
   external: ['@barefootjs/client', '@barefootjs/client/runtime'],
 })
 
@@ -189,6 +202,7 @@ console.log('Building @barefootjs/xyflow for site...')
 const xyflowBuildResult = await Bun.build({
   entrypoints: [xyflowEntryFile],
   format: 'esm',
+  minify: true,
   external: [
     '@barefootjs/client',
     '@barefootjs/client/runtime',
@@ -213,6 +227,7 @@ await Bun.write(zodWrapper, `export { z } from 'zod';\n`)
 const zodBuildResult = await Bun.build({
   entrypoints: [zodWrapper],
   format: 'esm',
+  minify: true,
 })
 // Clean up temporary wrapper
 await Bun.file(zodWrapper).exists() && await import('node:fs/promises').then(fs => fs.unlink(zodWrapper))
@@ -429,6 +444,24 @@ await resolveRelativeImports({
   sourceDirs: [UI_COMPONENTS_DIR, SHARED_COMPONENTS_DIR, DOCS_COMPONENTS_DIR],
 })
 
+// Minify client JS. Runs after combine + import resolution so the pass
+// sees the final file contents; the static/ copies below inherit it.
+// The runtime (barefoot.js) is already minified at copy time above.
+for (const [name, entry] of Object.entries(manifest)) {
+  if (name === '__barefoot__' || !entry.clientJs) continue
+  const filePath = resolve(DIST_DIR, entry.clientJs)
+  const content = await Bun.file(filePath).text().catch(() => '')
+  if (!content) continue
+  try {
+    // loader 'ts': some inlined utility modules carry TS-only syntax
+    // (non-null assertions) that the plain 'js' parser rejects.
+    await Bun.write(filePath, transpile(content, { loader: 'ts', minify: true }))
+  } catch (err) {
+    throw new Error(`Failed to minify ${entry.clientJs}: ${err instanceof Error ? err.message : err}`)
+  }
+}
+console.log('Minified: component client JS')
+
 // Generate index.ts for re-exporting all components (handles subdirectories)
 async function collectExports(dir: string, prefix: string = ''): Promise<string[]> {
   const exports: string[] = []
@@ -471,8 +504,11 @@ const EMBLA_ESM = resolve(ROOT_DIR, '../../node_modules/embla-carousel/esm/embla
 if (await Bun.file(EMBLA_ESM).exists()) {
   const emblaDir = resolve(DIST_DIR, 'lib')
   await mkdir(emblaDir, { recursive: true })
-  await Bun.write(resolve(emblaDir, 'embla-carousel.esm.js'), Bun.file(EMBLA_ESM))
-  console.log('Copied: dist/lib/embla-carousel.esm.js')
+  await Bun.write(
+    resolve(emblaDir, 'embla-carousel.esm.js'),
+    transpile(await Bun.file(EMBLA_ESM).text(), { loader: 'js', minify: true })
+  )
+  console.log('Copied: dist/lib/embla-carousel.esm.js (minified)')
 }
 
 // Copy lib/ directory to dist/


### PR DESCRIPTION
Reduces the payload both sites ship. The integrations were already covered — all 17 `barefoot.config.ts` files set `minify: true` and their committed `dist/client/*.js` is minified — so this PR closes the gap in the two custom site builds, which shipped everything unminified.

## What's minified now

| Asset | Before | After |
| --- | --- | --- |
| `barefoot.js` runtime (both sites) | 88.9 kB (19.7 kB gzip) | **42.4 kB (13.8 kB gzip)** |
| site/core component client JS (total) | 190 kB | 127 kB |
| site/ui `dist/components` (total) | 33.9 MB | 23.3 MB |
| `barefoot-xyflow.js` | 239 kB | 117 kB |
| `embla-carousel.esm.js` | 48 kB | 36 kB |

The runtime's 13.8 kB gzip now matches the landing page's "~14 kB gzipped" claim exactly.

## How

- **Runtime**: minified with `Bun.build` at copy time, identifier mangling included — unlike component client JS, only the runtime's ESM export names must survive (client JS imports them by name via the import map), and `Bun.build` preserves those.
- **Component client JS**: the same `transpile(..., { minify: true })` pass `bf build --minify` uses (whitespace/syntax only; identifiers preserved so hydration hooks survive), applied after the combine + import-resolution steps so the `static/` copies inherit it. Runs with loader `'ts'` because some inlined utility modules carry TS-only syntax (non-null assertions) the plain `'js'` parser rejects.
- **site/ui side bundles**: `minify: true` added to the `Bun.build` calls for `barefoot-form`, `barefoot-chart`, `barefoot-xyflow`, and `zod`; the `embla-carousel` ESM copy is minified in transit.

## Verification

- site/core LP e2e suite (8 tests) passes against the minified output, including the hydrated copy-button test.
- site/ui e2e for accordion / dialog / carousel / tabs / form-builder / bar-chart / graph-editor: 136 tests pass; the two `form-builder` "required toggle" failures reproduce identically on the **unminified** main build (pre-existing, unrelated to this change).
- The `docs-tabs.tsx` compile warning during the site/ui build is likewise pre-existing on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfJFhMBQZ2nzYYmdSBuMhv

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfJFhMBQZ2nzYYmdSBuMhv)_