### PR TITLE
fix: resolve all P1 blockers for Go scaffolds and bf add

### DIFF
--- a/.changeset/bf-add-kick-css-watcher.md
+++ b/.changeset/bf-add-kick-css-watcher.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/cli": patch
+---
+
+Touch `uno.config.ts` after `bf add` writes new component files so a running `unocss --watch` re-scans its globs and generates styles for newly-created component directories.

--- a/.changeset/go-scaffold-eval-go.md
+++ b/.changeset/go-scaffold-eval-go.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/cli": patch
+---
+
+Include `eval.go` in Go scaffold templates so all four Go adapters (chi/gin/echo/net/http) compile out of the box. Since #2018 `bf.go` references `SortEval`, `FoldEval`, `FilterEval`, `Env` etc. from `eval.go`, but the file was never added to the CLI's embedded scaffold templates.

--- a/.changeset/go-scaffold-template-funcmap.md
+++ b/.changeset/go-scaffold-template-funcmap.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/cli": patch
+---
+
+Register `TemplateFuncMap` in scaffolded `bf_render.go` so `bf_tmpl` calls work out of the box. The scaffold only called `bf.FuncMap()` but not `bf.TemplateFuncMap(root)`, causing `function "bf_tmpl" not defined` on first render.

--- a/packages/cli/scripts/embed-runtimes.mjs
+++ b/packages/cli/scripts/embed-runtimes.mjs
@@ -29,6 +29,7 @@ const repoRoot = resolve(cliPkg, '../..')
 // dependencies in a `cpanfile` instead of vendoring `.pm` copies.
 const sources = {
   bfGoSource: 'packages/adapter-go-template/runtime/bf.go',
+  evalGoSource: 'packages/adapter-go-template/runtime/eval.go',
   streamingGoSource: 'packages/adapter-go-template/runtime/streaming.go',
   bfdevGoSource: 'packages/adapter-go-template/runtime/bfdev/bfdev.go',
 }

--- a/packages/cli/src/__tests__/add-remote.test.ts
+++ b/packages/cli/src/__tests__/add-remote.test.ts
@@ -3,7 +3,7 @@ import { fetchRegistryItem } from '../lib/meta-loader'
 import { addFromRegistry, toRegistryName } from '../commands/add'
 import type { RegistryItem } from '../lib/types'
 import type { BarefootConfig } from '../context'
-import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'fs'
+import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, statSync } from 'fs'
 import path from 'path'
 import os from 'os'
 
@@ -370,6 +370,43 @@ describe('addFromRegistry', () => {
       'https://example.com/r/mixed.json',
       'https://example.com/r/Mixed.json',
     ])
+  })
+
+  test('touches uno.config.ts after adding files so unocss --watch picks up new directories', async () => {
+    globalThis.fetch = async () => new Response(JSON.stringify(buttonItem), { status: 200 })
+
+    const unoConfig = path.join(tmpDir, 'uno.config.ts')
+    writeFileSync(unoConfig, 'export default {}')
+    const before = statSync(unoConfig).mtimeMs
+
+    await new Promise(r => setTimeout(r, 50))
+    await addFromRegistry(['button'], 'https://example.com/r/', tmpDir, config, false)
+
+    const after = statSync(unoConfig).mtimeMs
+    expect(after).toBeGreaterThan(before)
+  })
+
+  test('does not touch uno.config.ts when no files were added', async () => {
+    globalThis.fetch = async () => new Response(JSON.stringify(buttonItem), { status: 200 })
+
+    // Pre-create all files so nothing is added
+    for (const file of buttonItem.files) {
+      const destPath = file.path.startsWith('components/ui/')
+        ? path.join(tmpDir, file.path)
+        : path.join(tmpDir, file.path)
+      mkdirSync(path.dirname(destPath), { recursive: true })
+      writeFileSync(destPath, file.content)
+    }
+
+    const unoConfig = path.join(tmpDir, 'uno.config.ts')
+    writeFileSync(unoConfig, 'export default {}')
+    const before = statSync(unoConfig).mtimeMs
+
+    await new Promise(r => setTimeout(r, 50))
+    await addFromRegistry(['button'], 'https://example.com/r/', tmpDir, config, false)
+
+    const after = statSync(unoConfig).mtimeMs
+    expect(after).toBe(before)
   })
 })
 

--- a/packages/cli/src/__tests__/templates.test.ts
+++ b/packages/cli/src/__tests__/templates.test.ts
@@ -29,15 +29,18 @@ describe('adapter registry', () => {
       expect(adapter.files['renderer.go']).toContain('func defaultLayout')
       expect(adapter.files['env.go']).toContain('func IsDev')
       // Vendored runtime, including the bfdev subpackage the dev
-      // auto-reload handler lives in.
+      // auto-reload handler lives in and eval.go (ParsedExpr evaluator).
       expect(adapter.files['bf-runtime/bf.go']).toContain('package bf')
+      expect(adapter.files['bf-runtime/eval.go']).toContain('package bf')
       expect(adapter.files['bf-runtime/bfdev/bfdev.go']).toContain('package bfdev')
       expect(adapter.files['go.mod']).toContain(
         'replace github.com/barefootjs/runtime/bf => ./bf-runtime',
       )
-      // The render bridge wires the dev auto-reload endpoint + snippet.
+      // The render bridge wires the dev auto-reload endpoint + snippet,
+      // and registers TemplateFuncMap so bf_tmpl calls resolve (#2120).
       expect(adapter.files['bf_render.go']).toContain('/_bf/reload')
       expect(adapter.files['bf_render.go']).toContain('bfdev.Snippet')
+      expect(adapter.files['bf_render.go']).toContain('bf.TemplateFuncMap(root)')
       // Client JS and public assets are served from disjoint prefixes
       // (so Gin's router tree doesn't panic on nested catch-alls).
       expect(adapter.files['barefoot.config.ts']).toContain("clientJsBasePath: '/client/'")
@@ -284,9 +287,11 @@ describe('adapter registry', () => {
   test('echo bundles the vendored Go runtime', () => {
     const echo = ADAPTERS.echo
     expect(echo.files['bf-runtime/bf.go']).toMatch(/package bf/)
+    expect(echo.files['bf-runtime/eval.go']).toMatch(/package bf/)
     expect(echo.files['bf-runtime/streaming.go']).toBeTruthy()
     expect(echo.files['bf-runtime/go.mod']).toMatch(/^module github\.com\/barefootjs\/runtime\/bf/m)
     expect(echo.files['go.mod']).toMatch(/replace github\.com\/barefootjs\/runtime\/bf => \.\/bf-runtime/)
+    expect(echo.files['bf_render.go']).toContain('bf.TemplateFuncMap(root)')
   })
 
   test('mojo declares its BarefootJS Perl deps via cpanfile (not vendored lib/)', () => {

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,6 +1,6 @@
 // `bf add <component...>` — Add components to a BarefootJS project.
 
-import { existsSync, mkdirSync, copyFileSync, writeFileSync, readFileSync, readdirSync } from 'fs'
+import { existsSync, mkdirSync, copyFileSync, writeFileSync, readFileSync, readdirSync, utimesSync } from 'fs'
 import path from 'path'
 import type { CliContext } from '../context'
 import type { BarefootConfig } from '../context'
@@ -8,6 +8,21 @@ import { resolveDependenciesFromSource } from '../lib/dependency-resolver'
 import { extractMetaForFile } from './meta-extract'
 import { commandsFor, detectPackageManager } from '../lib/pm'
 import type { MetaIndex, MetaIndexEntry, ComponentMeta, RegistryItem } from '../lib/types'
+
+/**
+ * Touch `uno.config.ts` so a running `unocss --watch` re-scans its
+ * globs and picks up files in newly-created component directories.
+ * chokidar (used by the UnoCSS CLI) resolves `**` globs to the set of
+ * directories that exist at startup; directories created later by
+ * `bf add` are invisible until the watcher restarts or the config
+ * file's mtime changes.
+ */
+function kickCssWatcher(projectDir: string): void {
+  const unoConfig = path.resolve(projectDir, 'uno.config.ts')
+  if (!existsSync(unoConfig)) return
+  const now = new Date()
+  try { utimesSync(unoConfig, now, now) } catch { /* best-effort */ }
+}
 
 export async function run(args: string[], ctx: CliContext): Promise<void> {
   const force = args.includes('--force')
@@ -267,6 +282,10 @@ export async function addFromRegistry(
     rebuildMetaIndex(destMetaDir)
   }
 
+  if (added.length > 0) {
+    kickCssWatcher(projectDir)
+  }
+
   // Summary
   if (silent) return
   if (added.length > 0) {
@@ -370,6 +389,10 @@ function addFromLocal(
 
   // Rebuild meta/index.json from meta/*.json files
   rebuildMetaIndex(destMetaDir)
+
+  if (added.length > 0) {
+    kickCssWatcher(projectDir)
+  }
 
   // Summary
   if (added.length > 0) {

--- a/packages/cli/src/lib/adapters/echo.ts
+++ b/packages/cli/src/lib/adapters/echo.ts
@@ -30,6 +30,7 @@ import {
 } from './shared'
 import {
   bfGoSource,
+  evalGoSource,
   streamingGoSource,
 } from './runtimes.generated'
 
@@ -525,6 +526,7 @@ export const ECHO_ADAPTER: AdapterTemplate = {
     'env.go': ECHO_ENV_GO,
     'go.mod': ECHO_GO_MOD,
     'bf-runtime/bf.go': bfGoSource,
+    'bf-runtime/eval.go': evalGoSource,
     'bf-runtime/streaming.go': streamingGoSource,
     'bf-runtime/go.mod': ECHO_BF_RUNTIME_GO_MOD,
     'barefoot.config.ts': ECHO_BAREFOOT_CONFIG_TS,

--- a/packages/cli/src/lib/adapters/echo.ts
+++ b/packages/cli/src/lib/adapters/echo.ts
@@ -221,6 +221,7 @@ import (
 // updated boilerplate).
 func loadTemplates() (*template.Template, error) {
 \troot := template.New("").Funcs(bf.FuncMap())
+\troot = root.Funcs(bf.TemplateFuncMap(root))
 \tif _, err := root.New("Tag").Parse(""); err != nil {
 \t\treturn nil, err
 \t}

--- a/packages/cli/src/lib/adapters/go-shared.ts
+++ b/packages/cli/src/lib/adapters/go-shared.ts
@@ -41,6 +41,7 @@ import {
 import {
   bfdevGoSource,
   bfGoSource,
+  evalGoSource,
   streamingGoSource,
 } from './runtimes.generated'
 import type { AdapterTemplate, AdapterScriptValue } from '../templates'
@@ -266,6 +267,7 @@ export function goCommonFiles(): Record<string, string> {
     'renderer.go': GO_RENDERER_GO,
     'env.go': GO_ENV_GO,
     'bf-runtime/bf.go': bfGoSource,
+    'bf-runtime/eval.go': evalGoSource,
     'bf-runtime/streaming.go': streamingGoSource,
     'bf-runtime/bfdev/bfdev.go': bfdevGoSource,
     'bf-runtime/go.mod': GO_BF_RUNTIME_GO_MOD,

--- a/packages/cli/src/lib/adapters/go-shared.ts
+++ b/packages/cli/src/lib/adapters/go-shared.ts
@@ -201,6 +201,7 @@ export const GO_RENDER_SHARED_FNS = `// loadTemplates walks dist/templates/ recu
 // inside Slot that's only reachable when AsChild=true.
 func loadTemplates() (*template.Template, error) {
 	root := template.New("").Funcs(bf.FuncMap())
+	root = root.Funcs(bf.TemplateFuncMap(root))
 	if _, err := root.New("Tag").Parse(""); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Three fixes that resolve all P1 blockers from #2125 — making the Go scaffold compile, render, and the `bf add` workflow reliable with a running dev server:

### Commit 1: Include `eval.go` in Go scaffold templates (fixes #2119)
- Since #2018, `bf.go` references `SortEval`, `FoldEval`, `FilterEval`, `Env` etc. from `eval.go`, but the file was never added to `embed-runtimes.mjs`
- All four Go adapters (chi/gin/echo/net/http) failed to compile immediately after scaffolding

### Commit 2: Register `TemplateFuncMap` in scaffolded `bf_render.go` (fixes #2120)
- The scaffolded `loadTemplates()` only called `bf.FuncMap()` but not `bf.TemplateFuncMap(root)`
- `bf_tmpl` template calls failed with `function "bf_tmpl" not defined` on first render

### Commit 3: Kick UnoCSS watcher after `bf add` (fixes #2121)
- `chokidar` (used by `unocss --watch`) resolves `**` globs at startup and misses directories created later by `bf add`
- Touch `uno.config.ts` after writing new component files so the watcher re-scans
- Without this, `bf add` while the dev server is running produces invisible components (0×0 px)

## Changes

| File | Change |
|------|--------|
| `packages/cli/scripts/embed-runtimes.mjs` | Add `eval.go` to the `sources` map |
| `packages/cli/src/lib/adapters/go-shared.ts` | Import `evalGoSource`, add to `goCommonFiles()`, register `TemplateFuncMap` |
| `packages/cli/src/lib/adapters/echo.ts` | Import `evalGoSource`, add to Echo's file map, register `TemplateFuncMap` |
| `packages/cli/src/commands/add.ts` | Touch `uno.config.ts` after `bf add` writes new components |

## Test plan

- [ ] `bun run --filter '@barefootjs/cli' build` succeeds with 4 embedded runtimes
- [ ] Scaffold a chi project and verify `go build ./...` succeeds
- [ ] Verify scaffolded app renders the Counter page without `bf_tmpl` errors
- [ ] Run `bf add checkbox` while dev server is running; verify styles generate without restart

Fixes #2119, fixes #2120, fixes #2121

Resolves all P1 items from #2125