### PR TITLE
fix(mojo): stop stock scaffold route 500ing — lazy manifest load + seed all bare-props props

### DIFF
--- a/.changeset/mojo-scaffold-stock-route-500.md
+++ b/.changeset/mojo-scaffold-stock-route-500.md
@@ -1,0 +1,11 @@
+---
+"@barefootjs/mojolicious": patch
+"@barefootjs/jsx": patch
+"@barefootjs/cli": patch
+---
+
+Fix the Mojo scaffold's stock `/` route 500ing with `Global symbol "$initial" requires explicit package name` (#2126):
+
+- `Mojolicious::Plugin::BarefootJS` now resolves the build manifest lazily per render (cached on the file's mtime/size) instead of once at plugin-register time. The scaffold's dev script starts `bf build --watch` and morbo concurrently, so the app routinely boots before the first build writes `dist/templates/manifest.json` — previously that startup race disabled ssrDefaults stash seeding for the server's lifetime and every top-level render died under strict. Rebuilt manifests (`bf build --watch`, `bf add`) are now also picked up without a server restart.
+- `extractSsrDefaults` seeds every prop declared on a bare-props parameter's type (`function Foo(props: Props)`), not just the ones a signal/memo initializer references. Template-stash adapters flatten `props.X` to a bare scalar (`$X`), so a direct template read of an unseeded, unpassed prop was a strict-mode compile error rather than a soft `undef`.
+- The mojo scaffold's `/` route now passes `initial => 0` explicitly, keeping the starter page self-sufficient and doubling as the worked example of how props reach a component (they're stash values).

--- a/packages/adapter-mojolicious/Changes
+++ b/packages/adapter-mojolicious/Changes
@@ -2,6 +2,12 @@ Revision history for Perl extension Mojolicious-Plugin-BarefootJS
 
 {{$NEXT}}
 
+    - Load the build manifest lazily per render (cached on mtime/size)
+      instead of once at plugin-register time, so booting before the
+      first `bf build` completes no longer disables ssrDefaults stash
+      seeding for the server's lifetime (GH#2126). Manifest rewrites
+      are picked up without a server restart.
+
 0.17.1 - 2026-07-03
 
 0.17.0 - 2026-07-02

--- a/packages/adapter-mojolicious/lib/Mojolicious/Plugin/BarefootJS.pm
+++ b/packages/adapter-mojolicious/lib/Mojolicious/Plugin/BarefootJS.pm
@@ -31,28 +31,64 @@ sub register ($self, $app, $config = {}) {
         $c->stash->{'bf.instance'} //= BarefootJS->new($c, $config);
     });
 
-    my $manifest = _load_manifest($app, $config);
-    return unless $manifest;
+    return if exists $config->{manifest_path} && !defined $config->{manifest_path};
+    my $manifest_path = path(
+        $config->{manifest_path} // $app->home->child('dist/templates/manifest.json'));
 
-    # Cache the set of UI-registry slot keys so we can answer
-    # "is this template name a child or a top-level page?" with a
-    # single hash lookup at render time. Top-level entries are
-    # everything that isn't `__barefoot__` and doesn't match
-    # `ui/<name>/index` — the same partition `register_components_from_manifest`
-    # applies internally.
-    my %is_child_entry;
-    for my $entry_name (keys %$manifest) {
-        next if $entry_name eq '__barefoot__';
-        next unless $entry_name =~ m{^ui/[^/]+/index$};
-        $is_child_entry{$entry_name} = 1;
-    }
+    # Manifest resolution is lazy, re-checked per render (#2126). The
+    # scaffold's dev script starts `bf build --watch` and the web server
+    # concurrently, so the app routinely boots before the first build has
+    # written `manifest.json`. Loading once at register time turned that
+    # startup race into a permanent failure: auto-init stayed disabled for
+    # the server's lifetime and every top-level render died under strict
+    # (`Global symbol "$initial" requires explicit package name`). The
+    # cache is keyed on the file's (mtime, size), so the steady-state cost
+    # is one stat() per render — and `bf build --watch` rebuilds (new
+    # ssrDefaults, `bf add`ed components) are picked up without a restart.
+    my ($cached_sig, $manifest, $is_child_entry);
+    my $load_manifest = sub {
+        my ($size, $mtime) = (stat "$manifest_path")[7, 9];
+        unless (defined $mtime) {
+            # Missing (or unreadable) — drop the cache so the manifest is
+            # re-read as soon as the first build writes it.
+            ($cached_sig, $manifest, $is_child_entry) = (undef, undef, undef);
+            return undef;
+        }
+        my $sig = "$mtime/$size";
+        return $manifest if defined $cached_sig && $cached_sig eq $sig;
+        # Cache parse failures under the same signature so a broken file
+        # warns once, not on every render, and retries when it changes.
+        $cached_sig = $sig;
+        ($manifest, $is_child_entry) = (undef, undef);
+        my $m = eval { decode_json($manifest_path->slurp) };
+        if ($@ || ref($m) ne 'HASH') {
+            $app->log->warn("BarefootJS: cannot parse manifest at $manifest_path: $@") if $@;
+            return undef;
+        }
+        $manifest = $m;
+
+        # Cache the set of UI-registry slot keys so we can answer
+        # "is this template name a child or a top-level page?" with a
+        # single hash lookup at render time. Top-level entries are
+        # everything that isn't `__barefoot__` and doesn't match
+        # `ui/<name>/index` — the same partition `register_components_from_manifest`
+        # applies internally.
+        $is_child_entry = {};
+        for my $entry_name (keys %$manifest) {
+            next if $entry_name eq '__barefoot__';
+            next unless $entry_name =~ m{^ui/[^/]+/index$};
+            $is_child_entry->{$entry_name} = 1;
+        }
+        return $manifest;
+    };
 
     $app->hook(before_render => sub ($c, $args) {
         my $template = $args->{template};
         return unless defined $template && length $template;
-        my $entry = $manifest->{$template};
+        my $m = $load_manifest->() or return;
+        my $entry = $m->{$template};
         return unless $entry;
-        return if $is_child_entry{$template};
+        return if $is_child_entry->{$template};
         # Idempotency guard for nested renders. A controller might
         # call `render_to_string` inside an action and then `render`
         # — without this we'd re-init `bf` on the second pass and
@@ -72,7 +108,7 @@ sub register ($self, $app, $config = {}) {
         $c->stash->{'bf.auto_init_done'} = 1;
 
         $bf->_scope_id($template . '_' . substr(rand() =~ s/^0\.//r, 0, 6));
-        $bf->register_components_from_manifest($manifest);
+        $bf->register_components_from_manifest($m);
 
         # Seed each ssrDefault into the stash unless the caller has
         # already supplied a value for that key — callers always win.
@@ -96,20 +132,6 @@ sub register ($self, $app, $config = {}) {
         $c->stash->{searchParams} //=
             $bf->search_params($c->req->query_params->to_string);
     });
-}
-
-sub _load_manifest ($app, $config) {
-    return undef if exists $config->{manifest_path} && !defined $config->{manifest_path};
-    my $manifest_path = $config->{manifest_path}
-        // $app->home->child('dist/templates/manifest.json');
-    my $file = path($manifest_path);
-    return undef unless -r $file;
-    my $manifest = eval { decode_json($file->slurp) };
-    if ($@ || ref($manifest) ne 'HASH') {
-        $app->log->warn("BarefootJS: cannot parse manifest at $file: $@") if $@;
-        return undef;
-    }
-    return $manifest;
 }
 
 1;

--- a/packages/adapter-mojolicious/src/__tests__/stock-route.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/stock-route.test.ts
@@ -1,0 +1,203 @@
+// Stock-route smoke test for the Mojo scaffold contract (#2126).
+//
+// The scaffold's happy path is: `npm run dev` (which starts `bf build
+// --watch` and morbo *concurrently*), then open `/`. That page renders a
+// component whose EP template reads props/signals as bare scalars
+// (`% my $count = ($initial // 0);`), and Mojo templates compile under
+// `use strict` — so every one of those scalars must be declared by the
+// time the template runs. Two production bugs hid in that path:
+//
+//   1. The route passes no props, so the stash seeding has to come from
+//      the manifest's `ssrDefaults` via the plugin's `before_render`
+//      hook — including props only referenced through `props.X` reads.
+//   2. The plugin used to load the manifest once at register time, so
+//      booting before the first build wrote `manifest.json` disabled
+//      auto-init for the server's lifetime: every render of `/` died
+//      with `Global symbol "$initial" requires explicit package name`
+//      (HTTP 500) until a manual restart.
+//
+// This test boots a real Mojolicious app whose `app.pl` mirrors the
+// scaffold's (plugin + dist/templates renderer path + a `/` route that
+// passes NO props) against a template + manifest produced by the real
+// compiler, and asserts the page renders — in both boot orders. It is
+// the in-repo equivalent of "scaffold → build → curl / expects 200".
+//
+// Runs only when `perl` with Mojolicious is installed (same skip policy
+// as the conformance render tests). The DevReload plugin is omitted:
+// it's dev-only plumbing with its own coverage in t/dev_reload.t.
+
+import { describe, test, expect, beforeAll } from 'bun:test'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { compileJSX } from '@barefootjs/jsx'
+import { MojoAdapter } from '../adapter/mojo-adapter'
+
+const MOJO_LIB_DIR = path.resolve(import.meta.dir, '../../lib')
+const PERL_CORE_LIB_DIR = path.resolve(import.meta.dir, '../../../adapter-perl/lib')
+
+function perlWithMojoAvailable(): boolean {
+  try {
+    const proc = Bun.spawnSync(['perl', '-MMojolicious', '-MTest::Mojo', '-e1'], {
+      env: process.env,
+    })
+    return proc.exitCode === 0
+  } catch {
+    return false
+  }
+}
+
+const PERL_AVAILABLE = perlWithMojoAvailable()
+
+// The starter-Counter shape: a prop read only through `props.X ?? …`
+// (never passed by the stock route) feeding a signal, plus a memo.
+// Exactly the pattern that dies under strict when seeding breaks.
+// `props.label` is read directly in the body (no signal/memo in
+// between) — that flattens to a bare `<%= $label %>` too, so it pins
+// that ssrDefaults seeds every declared prop, not just the ones a
+// signal initializer references.
+const COUNTER_TSX = `'use client'
+
+import { createSignal, createMemo } from '@barefootjs/client'
+
+interface CounterProps {
+  initial?: number
+  label?: string
+}
+
+export function Counter(props: CounterProps) {
+  const [count, setCount] = createSignal(props.initial ?? 0)
+  const doubled = createMemo(() => count() * 2)
+
+  return (
+    <div className="counter">
+      <p className="counter-label">{props.label}</p>
+      <p className="counter-value">count: {count()}</p>
+      <p className="counter-doubled">doubled: {doubled()}</p>
+      <button onClick={() => setCount(n => n + 1)}>+1</button>
+    </div>
+  )
+}
+`
+
+// Mirrors the scaffold's app.pl essentials. The `/` route deliberately
+// passes NO props — the manifest seeding alone must carry it. The
+// second route pins that a caller-supplied prop still wins.
+const APP_PL = `#!/usr/bin/env perl
+use Mojolicious::Lite -signatures;
+
+plugin 'BarefootJS';
+
+app->renderer->paths->[0] = app->home->child('dist/templates');
+
+get '/' => sub ($c) {
+    $c->render(template => 'Counter', layout => 'default');
+};
+
+get '/with-prop' => sub ($c) {
+    $c->render(template => 'Counter', layout => 'default', initial => 5);
+};
+
+app->start;
+
+__DATA__
+
+@@ layouts/default.html.ep
+<!DOCTYPE html>
+<html><body>
+<main><%== content %></main>
+%== $c->bf->scripts
+</body></html>
+`
+
+// Test::Mojo harness. SMOKE_SCENARIO picks the boot order:
+//   manifest-at-boot   — the manifest exists before the app loads
+//                        (server restarted after a completed build).
+//   manifest-after-boot — the app loads first, the manifest appears
+//                        afterwards (the concurrent `bf build --watch`
+//                        + morbo dev race on a fresh scaffold).
+const SMOKE_PL = `use Mojo::Base -strict;
+use Test::More;
+use Test::Mojo;
+use Mojo::File qw(curfile path);
+
+my $home     = curfile->dirname;
+my $scenario = $ENV{SMOKE_SCENARIO} // 'manifest-at-boot';
+my $staged   = $home->child('manifest.staged.json');
+my $manifest = $home->child('dist/templates/manifest.json');
+
+unlink "$manifest";
+$staged->copy_to("$manifest") if $scenario eq 'manifest-at-boot';
+
+my $t = Test::Mojo->new($home->child('app.pl'));
+
+$staged->copy_to("$manifest") if $scenario eq 'manifest-after-boot';
+
+# Stock route: no props passed — manifest ssrDefaults must seed every
+# bare template scalar ($initial included) or strict mode 500s.
+$t->get_ok('/')->status_is(200)
+  ->text_like('p.counter-value',   qr/count:\\s*0/)
+  ->text_like('p.counter-doubled', qr/doubled:\\s*0/)
+  ->content_like(qr/Counter\\.client\\.js/, 'auto-init registered the client bundle');
+
+# Caller-supplied prop wins over the manifest default.
+$t->get_ok('/with-prop')->status_is(200)
+  ->text_like('p.counter-value',   qr/count:\\s*5/)
+  ->text_like('p.counter-doubled', qr/doubled:\\s*10/);
+
+done_testing;
+`
+
+describe.skipIf(!PERL_AVAILABLE)('Mojo scaffold stock route (#2126)', () => {
+  let appDir: string
+
+  beforeAll(() => {
+    appDir = mkdtempSync(path.join(tmpdir(), 'bf-mojo-stock-route-'))
+    mkdirSync(path.join(appDir, 'dist/templates'), { recursive: true })
+
+    const result = compileJSX(COUNTER_TSX, 'Counter.tsx', { adapter: new MojoAdapter() })
+    const template = result.files.find(f => f.type === 'markedTemplate')
+    const ssrDefaults = result.files.find(f => f.type === 'ssrDefaults')
+    if (!template || !ssrDefaults) throw new Error('compileJSX produced no template/ssrDefaults')
+
+    writeFileSync(path.join(appDir, 'dist/templates/Counter.html.ep'), template.content)
+    // Same entry shape `bf build` writes to dist/templates/manifest.json.
+    writeFileSync(
+      path.join(appDir, 'manifest.staged.json'),
+      JSON.stringify({
+        Counter: {
+          markedTemplate: 'templates/Counter.html.ep',
+          ssrDefaults: JSON.parse(ssrDefaults.content),
+        },
+      }),
+    )
+    writeFileSync(path.join(appDir, 'app.pl'), APP_PL)
+    writeFileSync(path.join(appDir, 'smoke.pl'), SMOKE_PL)
+  })
+
+  async function runScenario(scenario: string): Promise<void> {
+    const perl5lib = [MOJO_LIB_DIR, PERL_CORE_LIB_DIR, process.env.PERL5LIB]
+      .filter(Boolean)
+      .join(':')
+    const proc = Bun.spawn(['perl', 'smoke.pl'], {
+      cwd: appDir,
+      env: { ...process.env, PERL5LIB: perl5lib, SMOKE_SCENARIO: scenario },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+    expect(exitCode, `TAP output:\n${stdout}\n${stderr}`).toBe(0)
+  }
+
+  test('renders / with the manifest present at boot', async () => {
+    await runScenario('manifest-at-boot')
+  })
+
+  test('renders / when the manifest appears after boot (concurrent dev-startup race)', async () => {
+    await runScenario('manifest-after-boot')
+  })
+})

--- a/packages/adapter-mojolicious/t/manifest_defaults.t
+++ b/packages/adapter-mojolicious/t/manifest_defaults.t
@@ -165,6 +165,77 @@ subtest 'plugin before_render — caller searchParams wins over the request' => 
     is $c->stash('searchParams'), $custom, 'caller-supplied searchParams preserved (//=)';
 };
 
+subtest 'plugin loads a manifest that appears after startup (#2126)' => sub {
+    # The scaffold's dev script starts `bf build --watch` and the web
+    # server concurrently, so the app can boot before the first build
+    # writes `manifest.json`. The plugin must pick the manifest up on a
+    # later render instead of permanently disabling auto-init (which
+    # left every top-level template variable unseeded → 500 under
+    # strict).
+    my $dir = tempdir;
+    my $manifest_file = $dir->child('manifest.json');    # not written yet
+
+    my $app = Mojolicious->new;
+    $app->plugin('BarefootJS' => { manifest_path => "$manifest_file" });
+
+    my $c1 = $app->build_controller;
+    $app->plugins->emit_hook(before_render => $c1, { template => 'Counter' });
+    ok !exists $c1->stash->{count}, 'no seeding while the manifest is missing';
+
+    # First `bf build` completes → the very next render must be seeded.
+    $manifest_file->spew(encode_json({
+        Counter => {
+            markedTemplate => 'templates/Counter.html.ep',
+            ssrDefaults    => {
+                count   => { value => 0 },
+                initial => { propName => 'initial', value => undef },
+            },
+        },
+    }));
+
+    my $c2 = $app->build_controller;
+    $app->plugins->emit_hook(before_render => $c2, { template => 'Counter' });
+    is $c2->stash('count'), 0, 'signal default seeded once the manifest exists';
+    ok exists $c2->stash->{initial},
+        'null-valued prop entry still declares the template variable';
+};
+
+subtest 'plugin re-reads the manifest when the file changes' => sub {
+    # `bf build --watch` rewrites the manifest on every rebuild; a new
+    # component (`bf add`) or changed defaults must reach renders
+    # without a server restart. The cache is keyed on (mtime, size).
+    my $dir = tempdir;
+    my $manifest_file = $dir->child('manifest.json');
+    $manifest_file->spew(encode_json({
+        Counter => {
+            markedTemplate => 'templates/Counter.html.ep',
+            ssrDefaults    => { count => { value => 1 } },
+        },
+    }));
+
+    my $app = Mojolicious->new;
+    $app->plugin('BarefootJS' => { manifest_path => "$manifest_file" });
+
+    my $c1 = $app->build_controller;
+    $app->plugins->emit_hook(before_render => $c1, { template => 'Counter' });
+    is $c1->stash('count'), 1, 'initial manifest read';
+
+    # Rewrite with a different value; bump mtime past the 1s stat
+    # granularity so the (mtime, size) signature is guaranteed to change.
+    $manifest_file->spew(encode_json({
+        Counter => {
+            markedTemplate => 'templates/Counter.html.ep',
+            ssrDefaults    => { count => { value => 2 }, extra => { value => 3 } },
+        },
+    }));
+    my $future = time + 2;
+    utime $future, $future, "$manifest_file";
+
+    my $c2 = $app->build_controller;
+    $app->plugins->emit_hook(before_render => $c2, { template => 'Counter' });
+    is $c2->stash('count'), 2, 'rebuilt manifest is picked up without a restart';
+};
+
 subtest 'plugin before_render — skips child templates' => sub {
     my $dir = tempdir;
     my $manifest_file = $dir->child('manifest.json');

--- a/packages/cli/src/__tests__/templates.test.ts
+++ b/packages/cli/src/__tests__/templates.test.ts
@@ -184,9 +184,20 @@ describe('adapter registry', () => {
       // so adding a new UI component via `bf add badge` doesn't
       // require parallel edits to `app.pl`.
       const appPl = ADAPTERS.mojo.files['app.pl']
-      expect(appPl).toMatch(/\$c->render\(template => 'Counter', layout => 'default'\)/)
+      expect(appPl).toMatch(/\$c->render\(template => 'Counter', layout => 'default', initial => 0\)/)
       expect(appPl).not.toMatch(/signal_init\s*=>/)
       expect(appPl).not.toMatch(/_scope_id\(/)
+    })
+
+    test('mojo route passes the Counter prop explicitly (#2126)', () => {
+      // The stock `/` page must never depend on the manifest being
+      // present at server boot: `npm run dev` starts `bf build --watch`
+      // and morbo concurrently, so the first request can arrive before
+      // the first build seeds the stash defaults. Passing `initial => 0`
+      // keeps the happy path self-sufficient — and doubles as the worked
+      // example of how props reach a component (they're stash values).
+      const appPl = ADAPTERS.mojo.files['app.pl']
+      expect(appPl).toContain('initial => 0')
     })
 
     test('mojo disables template cache in development mode', () => {

--- a/packages/cli/src/lib/adapters/mojo.ts
+++ b/packages/cli/src/lib/adapters/mojo.ts
@@ -82,8 +82,12 @@ get '/static/*asset' => sub ($c) {
     $c->reply->static($c->stash('asset') // '') or $c->reply->not_found;
 };
 
+# Component props are ordinary stash values. The plugin seeds every
+# template variable's static default from the build manifest, so
+# passing \`initial\` here is optional — but it's how you hand real
+# data to a component, so the starter route shows the shape.
 get '/' => sub ($c) {
-    $c->render(template => 'Counter', layout => 'default');
+    $c->render(template => 'Counter', layout => 'default', initial => 0);
 };
 
 app->start;

--- a/packages/jsx/src/__tests__/ssr-defaults.test.ts
+++ b/packages/jsx/src/__tests__/ssr-defaults.test.ts
@@ -82,6 +82,26 @@ describe('extractSsrDefaults', () => {
     expect(defaults?.initial).toEqual({ propName: 'initial', value: null })
   })
 
+  test('seeds every declared bare-props prop, including direct template reads (#2126)', () => {
+    // Template-stash adapters flatten `props.label` to the bare scalar
+    // `$label` even when no signal/memo references it (`<%= $label %>` in
+    // the body), so a prop the caller forgets to pass must still exist in
+    // the stash. Every prop declared on the props type gets an entry —
+    // not just the ones a signal / memo initializer reads.
+    const metadata = metadataFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      function Greeting(props: { label?: string }) {
+        const [n, setN] = createSignal(0)
+        return <div><p>{props.label}</p><button onClick={() => setN(n() + 1)}>{n()}</button></div>
+      }
+    `)
+
+    const defaults = extractSsrDefaults(metadata)
+    expect(defaults?.label).toEqual({ propName: 'label', value: null })
+    expect(defaults?.n).toEqual({ value: 0 })
+  })
+
   test('memo derived from a signal evaluates through the chain', () => {
     const metadata = metadataFor(`
       'use client'

--- a/packages/jsx/src/ssr-defaults.ts
+++ b/packages/jsx/src/ssr-defaults.ts
@@ -93,27 +93,29 @@ export function extractSsrDefaults(metadata: IRMetadata): Record<string, SsrDefa
   if (metadata.propsObjectName) propsLike.add(metadata.propsObjectName)
   for (const p of metadata.propsParams) propsLike.add(p.name)
 
-  // Prop destructure defaults. Only emit entries for the
-  // destructured-prop form (`function Foo({ variant = 'default' })`)
-  // where each `propsParam` name corresponds to a template-stash
-  // variable. The bare-props-arg form (`function Foo(props: Props)`)
-  // also populates `propsParams` from the type, but those names are
-  // never referenced as bare scalars in the generated template —
-  // accesses go through `$props->{X}` — so seeding them would just
-  // crowd the manifest with no-op entries.
-  if (metadata.propsObjectName === null) {
-    for (const p of metadata.propsParams) {
-      if (p.isRest) continue
-      if (p.defaultValue !== undefined) {
-        const value = tryStaticEval(p.defaultValue, { bindings: {}, propsLike })
-        out[p.name] = { propName: p.name, value: resultToJsonable(value) }
-      } else {
-        // No destructure default — the template will read it as-is, source
-        // from props and let Perl's `//` operator decide what `undef`
-        // becomes. We still register the entry so consumers can supply
-        // the propName even with no static fallback.
-        out[p.name] = { propName: p.name, value: null }
-      }
+  // Prop entries. Both parameter forms need one entry per prop:
+  //   - Destructured form (`function Foo({ variant = 'default' })`):
+  //     each `propsParam` is a template-stash variable; a literal
+  //     destructure default becomes the static fallback value.
+  //   - Bare-props form (`function Foo(props: Props)`): template-stash
+  //     adapters flatten `props.X` to the same bare scalar (`$X` — see
+  //     the Mojo emitter's `member()`), NOT a `$props->{X}` hash read,
+  //     so an unseeded prop the caller forgets to pass is a strict-mode
+  //     compile error, not a soft `undef` (#2126). Seed every declared
+  //     prop with a `null` fallback (→ undef; the template-side `// …`
+  //     recompute supplies the real default, and a caller-passed prop
+  //     wins via `propName`).
+  for (const p of metadata.propsParams) {
+    if (p.isRest) continue
+    if (metadata.propsObjectName === null && p.defaultValue !== undefined) {
+      const value = tryStaticEval(p.defaultValue, { bindings: {}, propsLike })
+      out[p.name] = { propName: p.name, value: resultToJsonable(value) }
+    } else {
+      // No destructure default — the template reads the prop as-is;
+      // Perl's `//` operator decides what `undef` becomes. The entry
+      // still matters so the template variable exists and consumers
+      // can supply the propName even with no static fallback.
+      out[p.name] = { propName: p.name, value: null }
     }
   }
   // Rest-props bag (`...props`) — tracked separately from `propsParams`
@@ -159,17 +161,17 @@ export function extractSsrDefaults(metadata: IRMetadata): Record<string, SsrDefa
     bindings[memo.name] = value
   }
 
-  // Bare-props-arg form (`function Foo(props: Props)`): a signal / memo
-  // whose initializer reads `props.X` is lowered by template-stash
-  // adapters to a *bare scalar* recompute (`my $count = ($initial // 0)`,
-  // the #1297 prop-derived seeding) — not a `$props->{X}` hash read. That
-  // bare `$initial` has to exist in the stash or Perl's strict mode aborts
-  // the render with `Global symbol "$initial" requires explicit package
-  // name`. The top block skips bare-props props on the assumption they're
-  // only ever read via `$props->{X}`, which the prop-derived seeding
-  // violates — so seed every prop a signal / memo initializer references.
-  // Value is `null` (→ undef): the recompute's own `?? <literal>` supplies
-  // the real fallback, and a caller-passed prop still wins via `propName`.
+  // Bare-props-arg safety net: the prop block above covers every prop
+  // *declared* on the props type, but `propsParams` can miss props read
+  // through an untyped / inline-typed `props` object. A signal / memo
+  // initializer's `props.X` read is lowered by template-stash adapters
+  // to a *bare scalar* recompute (`my $count = ($initial // 0)`, the
+  // #1297 prop-derived seeding), and that bare `$initial` has to exist
+  // in the stash or Perl's strict mode aborts the render with `Global
+  // symbol "$initial" requires explicit package name` — so also seed
+  // every prop a signal / memo initializer references. Value is `null`
+  // (→ undef): the recompute's own `?? <literal>` supplies the real
+  // fallback, and a caller-passed prop still wins via `propName`.
   if (metadata.propsObjectName !== null) {
     const referenced = new Set<string>()
     for (const sig of metadata.signals) {


### PR DESCRIPTION
Closes #2126

## What was actually wrong

The reported 500 (`Global symbol "$initial" requires explicit package name` at `Counter.html.ep` line 3) is real, but the scaffold route not passing `initial` is only the surface. The framework already has the machinery to make the stock route work with no props (`ssrDefaults` in the build manifest + the plugin's `before_render` stash seeding, #1416/#1297). Two independent holes disabled it — both reproduced end-to-end against real Mojolicious before fixing:

1. **Startup race, made permanent.** `Mojolicious::Plugin::BarefootJS` loaded `dist/templates/manifest.json` once at plugin-register time. The scaffold's `npm run dev` starts `bf build --watch` and morbo **concurrently**, so on a fresh scaffold the app boots before the first build writes the manifest → auto-init stayed disabled for the server's lifetime → every render of `/` 500s under strict, forever (morbo doesn't watch `dist/`). Reproduced: manifest present at boot → 200; manifest written 2s after boot → 500 on every request.
2. **Direct prop reads were never seeded.** `extractSsrDefaults` skipped bare-props-form props (`function Foo(props: Props)`) on the assumption template reads go through `$props-&gt;{X}` — but the Mojo emitter flattens `props.X` to the bare scalar `$X`. A prop read directly in the body (e.g. `{props.label}`) had no manifest entry, so even with the manifest loaded, a top-level render that doesn't pass it dies under strict. (The issue predicted this class: "will bite every prop a user forgets to pass".)

## Changes

- **`Mojolicious::Plugin::BarefootJS`**: manifest resolution is now lazy, re-checked per render with a cache keyed on the file's (mtime, size) — one `stat()` per render steady-state. The manifest is picked up as soon as the first build lands, and rebuilds (`bf build --watch`, `bf add`) apply without a server restart. Parse failures are cached per file signature so a broken manifest warns once, not per request.
- **`extractSsrDefaults` (jsx)**: every prop declared on the props type gets a manifest entry for both parameter forms (destructured defaults keep their evaluated value; bare-props props get `value: null` → undef, with the template-side `// …` recompute supplying the real fallback and a caller-passed prop winning via `propName`). The signal/memo-referenced-prop collection stays as a safety net for props read through an untyped `props` object.
- **Scaffold `app.pl`** (issue suggestion 1): the `/` route passes `initial =&gt; 0` explicitly — self-sufficient regardless of manifest state, and doubles as the worked example that props are stash values.

### Why not `stash('initial')` in the codegen (issue suggestion 2)

Considered, but prop reads lower in many emitter paths (member flatten, destructured identifiers, prop-classes, spreads), and dozens of unit/conformance pins assert the bare-scalar template text. The two fixes above close the same failure class at the layer the repo already built for it (manifest seeding), with the caller-wins semantics preserved. Happy to follow up with the codegen hardening if you still want templates to degrade with zero manifest.

### Smoke test (issue suggestion 3)

`packages/adapter-mojolicious/src/__tests__/stock-route.test.ts` is the in-repo equivalent of "scaffold → build → `curl /` expects 200": it compiles a starter-shaped Counter with the real compiler (including a direct `props.label` read), writes the same manifest entry shape `bf build` emits, boots a scaffold-shaped `app.pl` whose `/` route passes **no** props, and asserts 200 + rendered values + registered client bundle in **both boot orders** (manifest before/after app load). Skips when `perl`/Mojolicious is unavailable, same policy as the conformance renders. Verified it fails against each bug in isolation: old plugin → race scenario fails; old `extractSsrDefaults` → both scenarios fail.

## Tests

- New: 2 stock-route smoke tests (bun, real Perl), 2 Perl subtests in `t/manifest_defaults.t` (manifest appearing after startup; mtime-based re-read), 1 jsx unit test (direct-prop-read seeding), 1 cli templates test (`initial =&gt; 0` pin, existing one-liner pin updated).
- Green with real Perl rendering: adapter-mojolicious (594 bun + `prove t/`), adapter-perl, adapter-xslate, adapter-go-template, adapter-erb/twig/jinja/blade, adapter-tests, jsx, cli, create-barefootjs. Pre-existing failures unrelated to this diff (verified identical on the base commit): 5 jsx alias-resolver tests, 9 carousel cross-adapter renders, adapter-rust harness, 11 cli `runAutoScenario` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DsbC2Pkzb6NZvifEK6GrL

---
_Generated by [Claude Code](https://claude.ai/code/session_019DsbC2Pkzb6NZvifEK6GrL)_