### PR TITLE
fix(go-template,cli): loop child-component range target + rest-spread call-site attrs

### DIFF
--- a/.changeset/go-loop-child-and-rest-bag-fixes.md
+++ b/.changeset/go-loop-child-and-rest-bag-fixes.md
@@ -1,0 +1,9 @@
+---
+"@barefootjs/go-template": patch
+"@barefootjs/cli": patch
+---
+
+Fix two Go template adapter codegen bugs against generated props structs (#2130, #2131):
+
+- **#2130** — a `.map()` loop whose body is an element *wrapping* a child component (`<li><Badge>…</Badge></li>`) retargeted its `{{range}}` at a `.{ChildName}s` slice that only exists for direct single-component bodies, 500ing at render with `can't evaluate field Badges in type *XxxProps`. The range now iterates the real collection (gated on the IR's `loop.childComponent`, the same condition the slice generator uses), and the wrapped child renders through the parent's once-per-slot instance (`$.{Name}SlotN`) with per-item children injected via the loop-body companion define.
+- **#2131** — `bf build` never registered child component shapes on the adapter (only the test harness did), so HTML attributes passed to a rest-spread child (`<Input placeholder="…" />`) were emitted as named Go struct fields the generated `Input` struct doesn't declare, breaking `go build` with `unknown field Placeholder`. The CLI now runs a metadata-only pre-pass (`analyzeComponent` + `buildMetadata` per discovered component) that registers every component's shape before the first entry compiles, so non-param attrs route into the child's `Props map[string]any` rest bag.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -3729,3 +3729,131 @@ export function Root(props: Props) {
     expect(consumerTemplate).not.toContain('.Ctx.Config')
   })
 })
+
+describe('GoTemplateAdapter - #2130 loop with element-wrapped child component', () => {
+  // The `.{Name}s` wrapper-slice retarget is ONLY valid when the loop body IS
+  // a single component (`loop.childComponent`) — that's the sole condition
+  // under which `findNestedComponents` generates the slice field. A component
+  // merely nested inside an element item used to retarget the range at a
+  // slice that never exists (`{{range … := .Tags}}` with no `Tags` field →
+  // `can't evaluate field Tags in type *LoopChildProbeProps`, a 500 at
+  // render time).
+  test('element-wrapped child: range iterates the real collection, child renders via the parent slot instance', () => {
+    const adapter = new GoTemplateAdapter()
+    const ir = compileToIR(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+import { Tag } from '@ui/components/ui/tag'
+
+interface Row { id: number; label: string }
+
+export function LoopChildProbe(props: { rows?: Row[] }) {
+  const [rows] = createSignal(props.rows ?? [])
+  return (
+    <ul>
+      {rows().map(row => (
+        <li key={row.id}><Tag>{row.label}</Tag></li>
+      ))}
+    </ul>
+  )
+}
+`, adapter)
+    const { template, types } = adapter.generate(ir)
+
+    // The range targets the generated collection field, never a
+    // `.{ChildName}s` slice that no struct declares.
+    expect(template).toContain(':= .Rows}}')
+    expect(template).not.toContain('.Tags}}')
+    expect(types).not.toContain('Tags []')
+
+    // The wrapped child calls through the parent's once-per-slot instance
+    // (root context `$`), with per-item children via the loop-body define.
+    expect(template).toContain('{{template "Tag" (bf_with_children $.TagSlot1')
+    expect(types).toContain('TagSlot1 TagProps')
+    expect(types).toContain('TagSlot1: NewTagProps(TagInput{')
+  })
+
+  // End-to-end on real Go: the emitted template + structs must compile AND
+  // execute (`go run`) — the original failure mode was a request-time 500
+  // (`html/template` resolves struct fields at execute time, not at Go
+  // compile time). Cross-adapter note: this stays a Go-package test rather
+  // than a shared conformance fixture because the EP-family adapters
+  // (Mojo / ERB / Jinja / ...) render loop-nested children with per-item
+  // `ComponentName_<random>` scope ids by design (`comp.slotId &&
+  // !this.inLoop` in their renderComponent), while Hono / Go emit the
+  // parent-slot-derived id — same DOM, different id shape, so a single
+  // `expectedHtml` cannot pin both families.
+  test('element-wrapped child renders per-item content on real Go', async () => {
+    const adapter = new GoTemplateAdapter()
+    let html: string
+    try {
+      html = await renderGoTemplateComponent({
+        source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+import { Tag } from '@ui/components/ui/tag'
+
+interface Row { id: number; label: string }
+
+export function LoopChildProbe(props: { rows?: Row[] }) {
+  const [rows] = createSignal(props.rows ?? [])
+  return (
+    <ul>
+      {rows().map(row => (
+        <li key={row.id}><Tag>{row.label}</Tag></li>
+      ))}
+    </ul>
+  )
+}
+`.trimStart(),
+        adapter,
+        components: {
+          '@ui/components/ui/tag': `
+export function Tag(props: { children?: any }) {
+  return <span class="tag">{props.children}</span>
+}
+`.trimStart(),
+        },
+        props: { rows: [{ id: 1, label: 'one' }, { id: 2, label: 'two' }] },
+      })
+    } catch (err) {
+      if (err instanceof GoNotAvailableError) return
+      throw err
+    }
+    // One <li> per row, each wrapping a rendered Tag with the row's label —
+    // not a template error and not an empty loop.
+    expect(html).toContain('data-key="1"')
+    expect(html).toContain('data-key="2"')
+    expect(html).toContain('>one<')
+    expect(html).toContain('>two<')
+    expect(html).toContain('class="tag"')
+  })
+
+  // Companion guard: the wrapper-slice path is untouched — a loop body that
+  // IS a single component still iterates `.{Name}s` (the todo-app / data-table
+  // machinery this fix must not regress).
+  test('single-component body keeps iterating the wrapper slice', () => {
+    const adapter = new GoTemplateAdapter()
+    const ir = compileToIR(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+import { TodoItem } from '@ui/components/ui/todo-item'
+
+interface Todo { id: number; text: string }
+
+export function TodoList(props: { todos?: Todo[] }) {
+  const [todos] = createSignal(props.todos ?? [])
+  return (
+    <ul>
+      {todos().map(todo => (
+        <TodoItem key={todo.id} text={todo.text} />
+      ))}
+    </ul>
+  )
+}
+`, adapter)
+    const { template, types } = adapter.generate(ir)
+    expect(template).toContain(':= .TodoItems}}')
+    expect(types).toContain('TodoItems []')
+  })
+})

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -231,6 +231,16 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * wrapper's synthetic scalar field) instead of `.`. Innermost last.
    */
   private loopScalarItemStack: boolean[] = []
+  /**
+   * Per-loop: true when the loop body IS a single component
+   * (`loop.childComponent`), i.e. the range iterates the `.{Name}s` wrapper
+   * slice and `.` inside the body is a wrapper struct that embeds the child's
+   * Props. False for a component merely nested inside an element item
+   * (`<li><Badge/></li>`, #2130), where `.` is the raw datum and the child's
+   * props live on the PARENT's once-per-slot instance (`$.{Name}SlotN`).
+   * Innermost last.
+   */
+  private loopWrapperStack: boolean[] = []
   private loopVarRefCount: Map<string, number> = new Map()
   /** Stack of destructure-param binding maps (binding name → Go accessor on the
    *  range var, e.g. `id` → `$__bf_item0.Id`, `rest` → `$__bf_item0`, an
@@ -493,9 +503,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
   /**
    * Register a child component's shape (see `childComponentShapes`). Call once
-   * per known child IR before the parent's `generateTypes`. Idempotent.
+   * per known child IR before the parent's `generateTypes`. Idempotent. Takes
+   * only the IR's `metadata` so orchestrators that never build the full IR
+   * (the CLI's cross-file shape pre-pass, #2131) can register from a bare
+   * analyzer pass — a full `ComponentIR` still satisfies it structurally.
    */
-  registerChildComponentShape(ir: ComponentIR): void {
+  registerChildComponentShape(ir: Pick<ComponentIR, 'metadata'>): void {
     const name = ir.metadata.componentName
     if (!name) return
     const paramNames = new Set((ir.metadata.propsParams ?? []).map(p => p.name))
@@ -2053,9 +2066,22 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       }
     } else if (node.type === 'loop') {
       const loop = node as IRLoop
-      // Mark children as inside loop
+      // A loop whose body IS a single component is the nestedComponents /
+      // wrapper-slice machinery's case — mark its subtree as in-loop so the
+      // component (and its body children, which live on the wrapper struct)
+      // are skipped here. A component merely nested inside an element item
+      // (`<li><Badge/></li>`, #2130) gets NO wrapper slice: keep collecting,
+      // so it registers a normal once-per-slot instance (shared across rows,
+      // like the wrapper's `bodyChildInstances`); per-item content reaches it
+      // through the loop-body children define (see `renderComponent`).
       for (const child of loop.children) {
-        this.collectStaticChildInstancesRecursive(child, result, true, providerCtx, propsParams)
+        this.collectStaticChildInstancesRecursive(
+          child,
+          result,
+          inLoop || !!loop.childComponent,
+          providerCtx,
+          propsParams,
+        )
       }
     } else if (node.type === 'element') {
       const element = node as IRElement
@@ -4837,11 +4863,18 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       rangeValue = '_'
     }
 
-    // If the loop contains a component child, range over `.{ComponentName}s`,
-    // which carries a ScopeID per item (TodoItem → `.TodoItems`).
-    const childComponent = this.findChildComponent(loop.children)
-    if (childComponent) {
-      goArray = `.${childComponent.name}s`
+    // If the loop body IS a single component, range over `.{ComponentName}s`,
+    // which carries a ScopeID per item (TodoItem → `.TodoItems`). Gate on the
+    // IR's `loop.childComponent` — the SAME condition `findNestedComponents`
+    // uses to generate that slice field — not on a deep search of the body:
+    // a component merely nested inside an element item (`<li><Badge/></li>`)
+    // generates NO `.Badges` slice, so retargeting the range at it 500s at
+    // render with `can't evaluate field Badges in type *XxxProps` (#2130).
+    // Such loops keep iterating the real collection; the nested child renders
+    // through the parent's once-per-slot instance (see `renderComponent`'s
+    // non-wrapper in-loop branch).
+    if (loop.childComponent) {
+      goArray = `.${loop.childComponent.name}s`
     }
 
     this.inLoop = true
@@ -4886,7 +4919,9 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     this.loopScalarItemStack.push(
       this.scalarLiteralLoopGoType(loop.arrayParsed, loop.itemType) !== null,
     )
+    this.loopWrapperStack.push(!!loop.childComponent)
     const children = this.renderChildren(loop.children)
+    this.loopWrapperStack.pop()
     this.loopScalarItemStack.pop()
     // Build the per-item anchor marker while the loop param is still on the
     // stack, so a `bodyIsItemConditional` key expression resolves against the
@@ -4956,24 +4991,6 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       return `{{bfComment (printf "loop-i:%v" ${this.convertExpressionToGo(loop.key)})}}`
     }
     return ''
-  }
-
-  /** Find the first component child in a list of nodes. */
-  private findChildComponent(nodes: IRNode[]): IRComponent | null {
-    for (const node of nodes) {
-      if (node.type === 'component') {
-        return node as IRComponent
-      }
-      if (node.type === 'element' && (node as IRElement).children) {
-        const found = this.findChildComponent((node as IRElement).children)
-        if (found) return found
-      }
-      if (node.type === 'fragment' && (node as IRFragment).children) {
-        const found = this.findChildComponent((node as IRFragment).children)
-        if (found) return found
-      }
-    }
-    return null
   }
 
   /**
@@ -5049,13 +5066,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
     // In Go templates, components are rendered via {{template "name" data}}.
     let templateCall: string
-    if (this.inLoop) {
-      // Loop body component with JSX children: render children through a
-      // companion define so `bf_with_children` injects them at template
-      // execution time. Temporarily exit loop context so nested component calls
-      // (e.g. TableCell inside TableRow) use the normal non-loop rendering path
-      // (`.TableCellSlotN` fields on the wrapper struct), while the loop param
-      // stack stays intact so datum references resolve.
+    if (this.inLoop && (this.loopWrapperStack[this.loopWrapperStack.length - 1] ?? false)) {
+      // Wrapper-slice loop (body IS this component): `.` is the wrapper struct
+      // embedding the child's Props. Loop body component with JSX children:
+      // render children through a companion define so `bf_with_children`
+      // injects them at template execution time. Temporarily exit loop context
+      // so nested component calls (e.g. TableCell inside TableRow) use the
+      // normal non-loop rendering path (`.TableCellSlotN` fields on the
+      // wrapper struct), while the loop param stack stays intact so datum
+      // references resolve.
       const loopBodyDefine = this.queueLoopBodyChildrenDefine(comp)
       if (loopBodyDefine) {
         // Scalar-item loop: feed the body define the wrapper's `.BfLoopItem` (the
@@ -5068,6 +5087,24 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       } else {
         templateCall = `{{template "${comp.name}" .}}`
       }
+    } else if (this.inLoop && comp.slotId) {
+      // Non-wrapper loop (component nested inside an element item, #2130):
+      // the range iterates the REAL collection, so `.` is the raw datum and
+      // carries none of the child's props. Call through the parent's
+      // once-per-slot instance via the root context (`$` — the define's own
+      // data, i.e. the parent's Props), injecting per-item content through a
+      // loop-body children define executed with the datum (`.`). The shared
+      // instance means identical child scope IDs across rows — the same
+      // contract the wrapper machinery's `bodyChildInstances` already uses.
+      const suffix = slotIdToFieldSuffix(comp.slotId)
+      const loopBodyDefine = this.queueLoopBodyChildrenDefine(comp)
+      templateCall = loopBodyDefine
+        ? `{{template "${comp.name}" (bf_with_children $.${comp.name}${suffix} (bf_tmpl "${loopBodyDefine}" .))}}`
+        : `{{template "${comp.name}" $.${comp.name}${suffix}}}`
+    } else if (this.inLoop) {
+      // Loop-nested component without a slotId: no parent field to route
+      // through — legacy passthrough of the current dot.
+      templateCall = `{{template "${comp.name}" .}}`
     } else if (comp.slotId) {
       // Static children with slotId: unique field name based on slotId.
       const suffix = slotIdToFieldSuffix(comp.slotId)

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -142,6 +142,7 @@ import { fixture as returnNullishCoalescing } from './return-nullish-coalescing'
 import { fixture as returnMap } from './return-map'
 // Priority 7: Multi-file composition
 import { fixture as childComponent } from './child-component'
+import { fixture as restSpreadChildAttrs } from './rest-spread-child-attrs'
 import { fixture as componentWithJsxChildren } from './component-with-jsx-children'
 import { fixture as nativeSelectSpreadChildren } from './native-select-spread-children'
 import { fixture as multipleInstances } from './multiple-instances'
@@ -390,6 +391,7 @@ export const jsxFixtures: JSXFixture[] = [
   returnMap,
   // Priority 7: Multi-file composition
   childComponent,
+  restSpreadChildAttrs,
   componentWithJsxChildren,
   nativeSelectSpreadChildren,
   multipleInstances,

--- a/packages/adapter-tests/fixtures/rest-spread-child-attrs.ts
+++ b/packages/adapter-tests/fixtures/rest-spread-child-attrs.ts
@@ -47,8 +47,6 @@ export function TextInput({ className = '', type, ...props }: TextInputProps) {
 `,
   },
   expectedHtml: `
-    <div bf-s="test">
-      <input bf-s="test_s0" bf="s0" class="" placeholder="type here" value="seed">
-    </div>
+    <div bf-s="test"><input bf-s="test_s0" bf="s0" class="" placeholder="type here" value="seed"></div>
   `,
 })

--- a/packages/adapter-tests/fixtures/rest-spread-child-attrs.ts
+++ b/packages/adapter-tests/fixtures/rest-spread-child-attrs.ts
@@ -1,0 +1,54 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Parent passes standard HTML attributes (`placeholder`, `value`) to a
+ * child whose props type is an open-ended rest-spread
+ * (`{ className, type, ...props }` — the `bf add input` registry
+ * component's shape). The attributes are NOT declared child params, so
+ * call-site codegen must route them into the child's rest bag
+ * (Go: `Props map[string]any`) and the spread must surface them in the
+ * SSR output.
+ *
+ * Regression pin for #2131: the Go template adapter emitted these as
+ * named struct fields (`Placeholder:`, `Value:`) that the generated
+ * `TextInputInput` struct never declares, so the emitted Go did not even
+ * compile (`unknown field Placeholder in struct literal`). Here the
+ * real-Go conformance render fails on either the compile error or the
+ * missing attributes. The `bf build` orchestration half of the bug (the
+ * CLI never registered child shapes on the adapter) is pinned by
+ * `packages/cli/src/__tests__/build-child-shapes.test.ts`.
+ */
+export const fixture = createFixture({
+  id: 'rest-spread-child-attrs',
+  description: 'HTML attrs on a rest-spread child route into the rest bag and render in SSR (#2131)',
+  source: `
+'use client'
+import { TextInput } from './text-input'
+
+export function InputAttrProbe() {
+  return (
+    <div>
+      <TextInput placeholder="type here" value="seed" />
+    </div>
+  )
+}
+`,
+  components: {
+    './text-input.tsx': `
+interface TextInputProps {
+  className?: string
+  type?: string
+  [key: string]: unknown
+}
+
+export function TextInput({ className = '', type, ...props }: TextInputProps) {
+  return <input type={type} className={className} {...props} />
+}
+`,
+  },
+  expectedHtml: `
+    <div bf-s="test">
+      <input bf-s="test_s0" bf="s0" class="" placeholder="type here" value="seed">
+    </div>
+  `,
+})

--- a/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
+++ b/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
@@ -145,6 +145,14 @@ describe('CSR Conformance Tests', () => {
     // object`; the real-browser fixture-hydrate layer exercises the spread
     // for real (and the typed value survives hydration there).
     'input',
+    // #2131: same `applyRestAttrs`-not-modeled limitation as `input` /
+    // `jsx-spread-rest-prop` above — the child renders `placeholder` /
+    // `value` through its `{...props}` spread at init time, which the CSR
+    // template-eval harness stubs as a noop. The fixture's contract (the
+    // parent's call site routes non-param attrs into the child's rest bag
+    // and SSR renders them) is pinned by the per-adapter render
+    // conformance, where real Go compiles + executes the emitted structs.
+    'rest-spread-child-attrs',
     // #1467 demo corpus: `radio-group-demo.tsx` exports three sibling
     // demos and the CSR harness evaluates `__lastComponent` — the last
     // `hydrate()` registration (`RadioGroupCardDemo`) — rather than the

--- a/packages/cli/src/__tests__/build-child-shapes.test.ts
+++ b/packages/cli/src/__tests__/build-child-shapes.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Cross-file child-shape pre-pass (#2131).
+ *
+ * `bf build` compiles each source independently, but the Go template
+ * adapter's call-site codegen needs the CHILD component's shape (declared
+ * params + rest-bag field) registered before the PARENT's `generateTypes`
+ * runs — otherwise an HTML attribute passed to a rest-spread child
+ * (`<Input placeholder="..." />` where Input is
+ * `({ className, type, ...props }: InputHTMLAttributes)`) is emitted as a
+ * named Go struct field (`Placeholder:`) that the generated `InputInput`
+ * struct never declares, and the project's `go build` fails with
+ * `unknown field Placeholder in struct literal`.
+ *
+ * The adapter-tests harness always registered shapes (`registerChildShape`
+ * in test-render.ts); this pins that the CLI build pipeline does too
+ * (`registerAdapterChildShapes` in lib/build.ts).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { build } from '../lib/build'
+import { GoTemplateAdapter } from '../../../adapter-go-template/src/adapter/go-template-adapter'
+import { mkdirSync, writeFileSync, rmSync, realpathSync } from 'fs'
+import { resolve } from 'path'
+import { tmpdir } from 'os'
+
+function makeTmpDir(label: string) {
+  const dir = resolve(tmpdir(), `bf-test-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+  mkdirSync(dir, { recursive: true })
+  return realpathSync(dir)
+}
+
+// A rest-spread child in the shape of the `bf add input` registry component:
+// `placeholder` / `value` are NOT declared params, so they belong in the
+// open-ended `Props map[string]any` rest bag.
+const INPUT_SOURCE = `'use client'
+interface InputHTMLAttributes {
+  className?: string
+  type?: string
+  [key: string]: unknown
+}
+
+export function Input({ className = '', type, ...props }: InputHTMLAttributes) {
+  return <input type={type} className={className} {...props} />
+}
+`
+
+const PROBE_SOURCE = `'use client'
+import { Input } from './input'
+
+export function InputAttrProbe() {
+  return (
+    <div>
+      <Input placeholder="type here" value="seed" />
+    </div>
+  )
+}
+`
+
+describe('build() registers child component shapes before compiling (#2131)', () => {
+  test('rest-spread child attrs land in the Props rest bag, not named struct fields', async () => {
+    const projectDir = makeTmpDir('child-shapes-src')
+    const outDir = makeTmpDir('child-shapes-out')
+    try {
+      const componentsDir = resolve(projectDir, 'components')
+      mkdirSync(componentsDir, { recursive: true })
+      writeFileSync(resolve(componentsDir, 'input.tsx'), INPUT_SOURCE)
+      writeFileSync(resolve(componentsDir, 'probe.tsx'), PROBE_SOURCE)
+
+      const collectedTypes = new Map<string, string>()
+      const result = await build({
+        projectDir,
+        adapter: new GoTemplateAdapter(),
+        componentDirs: [componentsDir],
+        outDir,
+        minify: false,
+        contentHash: false,
+        clientOnly: false,
+        postBuild: (ctx) => {
+          for (const [k, v] of ctx.types) collectedTypes.set(k, v)
+        },
+      })
+
+      expect(result.errorCount).toBe(0)
+      const probeTypes = collectedTypes.get('probe')
+      expect(probeTypes).toBeDefined()
+
+      // The call site routes the non-param attrs into the child's rest bag…
+      expect(probeTypes!).toContain('Props: map[string]any{"placeholder": "type here", "value": "seed"}')
+      // …and emits no named struct fields the generated InputInput never declares.
+      expect(probeTypes!).not.toContain('Placeholder:')
+      expect(probeTypes!).not.toContain('Value:')
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+      rmSync(outDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -1,7 +1,7 @@
 // Core build module: shared pipeline for `bf build`.
 
-import { compileJSX, combineParentChildClientJs, createProgramForCorpus, formatError, renderImportMapHtml, REACTIVE_PRIMITIVES, BROWSER_ONLY_CLIENT_APIS } from '@barefootjs/jsx'
-import type { TemplateAdapter, OutputLayout, PostBuildContext, ExternalSpec, BundleEntry, ExternalsManifest } from '@barefootjs/jsx'
+import { compileJSX, combineParentChildClientJs, createProgramForCorpus, formatError, renderImportMapHtml, REACTIVE_PRIMITIVES, BROWSER_ONLY_CLIENT_APIS, listComponentFunctions, analyzeComponent, buildMetadata } from '@barefootjs/jsx'
+import type { TemplateAdapter, OutputLayout, PostBuildContext, ExternalSpec, BundleEntry, ExternalsManifest, IRMetadata } from '@barefootjs/jsx'
 import ts from 'typescript'
 import { mkdir, readdir, stat, unlink } from 'node:fs/promises'
 import { resolve, basename, relative, dirname, isAbsolute } from 'node:path'
@@ -569,6 +569,17 @@ export async function build(
     return sharedProgram
   }
 
+  // Lazy child-shape pre-pass (#2131): must run before the FIRST entry that
+  // actually compiles (cache-fresh builds skip it entirely, keeping no-op
+  // builds free). One flag, not per-entry — `registerAdapterChildShapes`
+  // walks the whole corpus once and registration is idempotent.
+  let childShapesRegistered = false
+  const ensureChildShapesRegistered = (): void => {
+    if (childShapesRegistered) return
+    childShapesRegistered = true
+    registerAdapterChildShapes(config.adapter, allFiles, sourceContents, getSharedProgram())
+  }
+
   // 4. Compile each component (or reuse from cache)
   for (const entryPath of allFiles) {
     const sourceContent = sourceContents.get(entryPath)!
@@ -613,6 +624,7 @@ export async function build(
       continue
     }
 
+    ensureChildShapesRegistered()
     const result = await compileEntry({
       entryPath,
       sourceContent,
@@ -1630,6 +1642,49 @@ export async function processBundleEntries(
     }
   }
   return anyChanged
+}
+
+// ── Cross-file child-shape pre-pass ──────────────────────────────────────
+
+/**
+ * Register every discovered component's cross-component shape on the adapter
+ * before any entry compiles (#2131). Adapters that pre-compute child props at
+ * the call site (the Go template adapter) route an attribute that is NOT a
+ * declared child param into the child's rest bag (`Props map[string]any`) —
+ * but only when the child's shape was registered first. The adapter-tests
+ * harness always did this (`registerChildShape` in test-render.ts); the CLI
+ * never did, so `bf build` emitted rest-spread attrs as named struct fields
+ * (`Placeholder:` on `InputInput`) and the generated components.go failed
+ * `go build` with `unknown field ...`.
+ *
+ * Metadata-only: `analyzeComponent` + `buildMetadata` per exported component,
+ * no IR/codegen. Adapters without the hook (Hono, Mojo, ...) cost one method
+ * probe. Failures are non-fatal — a file that can't be analyzed contributes
+ * no shape and the affected parent keeps the pre-registration behaviour; the
+ * real compile of that file still reports its errors through `compileEntry`.
+ */
+function registerAdapterChildShapes(
+  adapter: TemplateAdapter,
+  allFiles: string[],
+  sourceContents: Map<string, string>,
+  program: ts.Program | undefined,
+): void {
+  const hook = (adapter as { registerChildComponentShape?: (ir: { metadata: IRMetadata }) => void })
+    .registerChildComponentShape
+  if (typeof hook !== 'function') return
+  for (const filePath of allFiles) {
+    const source = sourceContents.get(filePath)
+    if (!source) continue
+    try {
+      for (const componentName of listComponentFunctions(source, filePath)) {
+        const ctx = analyzeComponent(source, filePath, componentName, program)
+        if (!ctx.jsxReturn) continue
+        hook.call(adapter, { metadata: buildMetadata(ctx) })
+      }
+    } catch {
+      // Fail open (see docstring).
+    }
+  }
 }
 
 // ── Dependency scanner ───────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #2130, fixes #2131 — the two Go-adapter codegen mismatches against the generated props structs reported from the Go TodoApp port, plus regression tests at every layer where the bugs lived.

## #2130 — loop rendering a child component iterates a non-existent field (500 at render)

`renderLoop` used a **deep search** for any descendant component to retarget the `{{range}}` collection at `.{ChildName}s` (naively pluralized: `Badge`→`.Badges`, `Checkbox`→`.Checkboxs`). But the type generator (`findNestedComponents`) only creates that wrapper slice when the loop body **IS** a single component (`loop.childComponent`). For the shape of virtually every list UI — `rows().map(row => <li><Badge>{row.label}</Badge></li>)` — the emitted template ranged over a field no struct declares, and `html/template` resolves fields at **execute** time, so a clean build 500'd at request time with `can't evaluate field Badges in type *XxxProps`.

Fix (`packages/adapter-go-template/src/adapter/go-template-adapter.ts`):
- The `.{Name}s` retarget is now gated on `loop.childComponent` — the exact condition the slice generator uses — so element-wrapped-child loops iterate the **real** collection (`.Rows`), as the issue's cross-adapter check (Perl mojo) already did.
- The wrapped child renders through the parent's once-per-slot instance via the root context (`{{template "Badge" (bf_with_children $.BadgeSlotN (bf_tmpl "<loop-body define>" .))}}`), with per-item content flowing through the loop-body companion define executed with the row datum. The shared instance (identical child scope IDs across rows) is the same contract the wrapper machinery's `bodyChildInstances` already uses.
- `collectStaticChildInstances` now collects components inside non-`childComponent` loops so the parent's Props struct + constructor emit the `{Name}SlotN` field/init pair.
- The wrapper-slice path (todo-app / data-table) is untouched, pinned by a companion guard test.

## #2131 — HTML attrs on a rest-spread child emit unknown struct fields (components.go won't compile)

The adapter already routes non-param attrs into a child's rest bag (`Props map[string]any`) — but only when the child's shape was registered via `registerChildComponentShape` first. The **adapter-tests harness always did this** (`registerChildShape` in test-render.ts); the **CLI never did**, so `bf build` emitted `Placeholder:` / `Value:` named fields the generated `InputInput` struct never declares → `go build`: `unknown field Placeholder in struct literal`.

Fix (`packages/cli/src/lib/build.ts`):
- A lazy, metadata-only pre-pass (`registerAdapterChildShapes`: `listComponentFunctions` + `analyzeComponent` + `buildMetadata` per discovered component — TS AST all the way, no regex import parsing) registers every component's shape on the adapter before the first entry that actually compiles. Cache-fresh no-op builds skip it entirely.
- `registerChildComponentShape` is widened to `Pick<ComponentIR, 'metadata'>` so the pre-pass doesn't need to build full IR; existing full-IR callers still satisfy it structurally.

## Regression tests (conformance に習った再発防止)

| Layer | Test |
|---|---|
| Adapter conformance fixture (shared corpus) | `rest-spread-child-attrs` — parent passes `placeholder`/`value` to a `{...props}` child; on Go the render fails on either the compile error or the missing attrs. Verified green on Hono / Go (real `go run`) / ERB / Jinja / Mojo. CSR-skipped with the same `applyRestAttrs`-not-modeled rationale as the existing `input` fixture. |
| Go adapter unit + real-Go E2E | `#2130` describe: range targets `.Rows` (never `.Tags`), child routes through `$.TagSlot1`, wrapper-slice guard, and an end-to-end `renderGoTemplateComponent` render of the element-wrapped-child loop (compiles **and** executes). Kept Go-package-local rather than a shared fixture because the EP-family adapters (Mojo/ERB/Jinja/…) render loop-nested children with per-item `ComponentName_<random>` scope ids by design, so one `expectedHtml` can't pin both families — the test documents this. |
| CLI build | `build-child-shapes.test.ts` — real `build()` over a parent+child temp project; asserts the collected types route the attrs into `Props: map[string]any{…}` and emit no `Placeholder:`/`Value:` named fields. Red without the pre-pass (reproduces the issue's exact broken output), green with it. |

## Test runs

- `adapter-go-template` (GOTOOLCHAIN=go1.25.6, real Go renders): **628 pass / 0 fail**
- `adapter-hono`: 476 pass / 0 fail · `adapter-tests`: 934 pass / 0 fail · `adapter-erb`: 385 / 0 · `adapter-jinja`: 410 / 0 · `adapter-mojolicious`: 581 / 0 · `adapter-blade`/`twig`/`xslate`: 0 fail
- `cli`: 803 pass / 0 fail
- (`adapter-rust` fails 176 tests on `main` in this environment before any change — pre-existing local-toolchain breakage, unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBnQd5Qmowsz3NVQrx98gr

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBnQd5Qmowsz3NVQrx98gr)_