### PR TITLE
Fix multi-component registry modules (Toast/Dialog/Tabs) 500ing on the Perl (mojo) adapter

### DIFF
--- a/.changeset/mojo-multi-component-registry.md
+++ b/.changeset/mojo-multi-component-registry.md
@@ -1,0 +1,13 @@
+---
+"@barefootjs/cli": minor
+"@barefootjs/jsx": minor
+"@barefootjs/perl": minor
+"@barefootjs/mojolicious": minor
+---
+
+Fix multi-component registry modules (Toast/Dialog/Tabs/DropdownMenu) 500ing on the Perl (mojo) adapter (#2132). A registry module exporting several components from one file compiles to one EP template per component, but the build manifest carried a single `markedTemplate` per entry, so `register_components_from_manifest` never registered the sub-components and every `render_child('toast_provider')` died with "No renderer registered".
+
+- **`@barefootjs/cli`**: for `templatesPerComponent` adapters, each manifest entry now carries a `components` map — one row per exported component with its own `markedTemplate` and `ssrDefaults`, keyed by the component name. The key comes from the compiler's new structural `componentName` stamp, not the template basename (a single-component file's template is named after the source file, e.g. `index.html.ep`). Additive: every runtime parses manifest entries key-by-key, so older runtimes ignore the new field.
+- **`@barefootjs/jsx`**: `FileOutput` gains an optional `componentName`, set on `markedTemplate` / `ssrDefaults` outputs so the build pipeline can pair them per component without basename guessing.
+- **`@barefootjs/perl`**: `register_components_from_manifest` registers one child renderer per `components` row under the snake_cased component name the compiled templates call (`toast_provider`, `toast_title`, …), seeding each child from its own per-component `ssrDefaults`. Per-component registrations win over the directory-name key — for `ui/toast/index` the key `toast` now resolves to Toast's own template instead of the module's first template (ToastProvider). Manifests from older builds (no `components` map) keep the directory-name behaviour.
+- **`@barefootjs/mojolicious`** (`BarefootJS::Backend::Mojo`): `render_named` now dies when `render_to_string` returns undef (missing template) instead of letting the calling template's `<%==` silently render the child subtree as an empty string, and the active `bf.instance` swap is `local`ized so it's restored when a nested render dies.

--- a/packages/adapter-mojolicious/MANIFEST
+++ b/packages/adapter-mojolicious/MANIFEST
@@ -8,3 +8,4 @@ MANIFEST
 Makefile.PL
 t/dev_reload.t
 t/manifest_defaults.t
+t/render_named.t

--- a/packages/adapter-mojolicious/lib/BarefootJS/Backend/Mojo.pm
+++ b/packages/adapter-mojolicious/lib/BarefootJS/Backend/Mojo.pm
@@ -78,13 +78,22 @@ sub materialize ($self, $value) {
 # instance for that render. The Mojo `bf` helper resolves the current
 # instance off `$c->stash->{'bf.instance'}`; swap it for the duration of
 # the nested render and restore it afterwards so sibling renders are
-# unaffected.
+# unaffected. `local` (rather than a manual swap) keeps the restore
+# exception-safe: a die inside the nested render — e.g. a grandchild with
+# no registered renderer — propagates without leaving the child instance
+# bound as the request's active one.
 sub render_named ($self, $template_name, $child_bf, $vars) {
     my $c = $self->c;
-    my $prev = $c->stash->{'bf.instance'};
-    $c->stash->{'bf.instance'} = $child_bf;
+    local $c->stash->{'bf.instance'} = $child_bf;
     my $html = $c->render_to_string(template => $template_name, %$vars);
-    $c->stash->{'bf.instance'} = $prev;
+    # `render_to_string` returns undef — it does NOT die — when the named
+    # template can't be rendered (typically: the template file is missing
+    # from the renderer paths). The calling template's `<%==` would emit
+    # that as an empty string, silently dropping the whole child subtree
+    # from the page (#2132). Fail the render loudly instead.
+    die qq{BarefootJS: child template "$template_name" rendered no output }
+      . qq{(is the template missing from the renderer paths?)\n}
+        unless defined $html;
     return $html;
 }
 

--- a/packages/adapter-mojolicious/src/__tests__/multi-component-registry.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/multi-component-registry.test.ts
@@ -1,0 +1,215 @@
+// Multi-component registry modules on the Mojo plugin path (#2132).
+//
+// A registry module that exports several components from one file —
+// `ui/toast/index.tsx` exporting ToastProvider / Toast / ToastTitle — compiles
+// to one EP template PER component, and every compiled parent invokes each one
+// under its snake_cased name (`bf->render_child('toast_provider')`). The
+// manifest entry used to carry only the module's FIRST template, so
+// `register_components_from_manifest` registered nothing for the
+// sub-components and every page using Toast / Dialog / Tabs 500'd with
+// "No renderer registered for child component 'toast_provider'".
+//
+// This is the in-repo equivalent of the issue's repro: `bf add toast` →
+// render a <Toast>-using component on mojo → expect 200 with toast markup.
+// It boots a real Mojolicious app with the production plugin against
+// compiler-produced templates plus a manifest in the shape `bf build` now
+// emits (per-component rows under `components` — pinned on the emitter side
+// by packages/cli/src/__tests__/build-manifest-components.test.ts).
+//
+// Runs only when `perl` with Mojolicious is installed (same skip policy as
+// stock-route.test.ts, which this file mirrors).
+
+import { describe, test, expect, beforeAll } from 'bun:test'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { compileJSX } from '@barefootjs/jsx'
+import { MojoAdapter } from '../adapter/mojo-adapter'
+
+const MOJO_LIB_DIR = path.resolve(import.meta.dir, '../../lib')
+const PERL_CORE_LIB_DIR = path.resolve(import.meta.dir, '../../../adapter-perl/lib')
+
+function perlWithMojoAvailable(): boolean {
+  try {
+    const proc = Bun.spawnSync(['perl', '-MMojolicious', '-MTest::Mojo', '-e1'], {
+      env: process.env,
+    })
+    return proc.exitCode === 0
+  } catch {
+    return false
+  }
+}
+
+const PERL_AVAILABLE = perlWithMojoAvailable()
+
+// The registry-toast shape: one module, several exported components, one of
+// them ("Toast") snake_casing to the module's directory name — the collision
+// that used to render the WRONG template even when the name resolved.
+const TOAST_TSX = `'use client'
+
+interface ToastProviderProps {
+  children?: any
+}
+
+export function ToastProvider({ children }: ToastProviderProps) {
+  return <div data-slot="toast-provider">{children}</div>
+}
+
+interface ToastProps {
+  open?: boolean
+  children?: any
+}
+
+export function Toast({ open = false, children }: ToastProps) {
+  return (
+    <div data-slot="toast" data-state={open ? 'open' : 'closed'}>
+      {children}
+    </div>
+  )
+}
+
+export function ToastTitle({ children }: { children?: any }) {
+  return <div data-slot="toast-title">{children}</div>
+}
+`
+
+// The issue's ToastProbe: a page component driving the module's
+// sub-components, with a signal feeding Toast's `open` prop.
+const PROBE_TSX = `'use client'
+import { createSignal } from '@barefootjs/client'
+import { ToastProvider, Toast, ToastTitle } from '@/components/ui/toast'
+
+export function ToastProbe() {
+  const [open, setOpen] = createSignal(true)
+  return (
+    <ToastProvider>
+      <Toast open={open()}>
+        <ToastTitle>hi</ToastTitle>
+      </Toast>
+    </ToastProvider>
+  )
+}
+`
+
+const APP_PL = `#!/usr/bin/env perl
+use Mojolicious::Lite -signatures;
+
+plugin 'BarefootJS';
+
+app->renderer->paths->[0] = app->home->child('dist/templates');
+
+get '/toast-probe' => sub ($c) {
+    $c->render(template => 'ToastProbe', layout => 'default');
+};
+
+app->start;
+
+__DATA__
+
+@@ layouts/default.html.ep
+<!DOCTYPE html>
+<html><body>
+<main><%== content %></main>
+%== $c->bf->scripts
+</body></html>
+`
+
+const SMOKE_PL = `use Mojo::Base -strict;
+use Test::More;
+use Test::Mojo;
+use Mojo::File qw(curfile);
+
+my $t = Test::Mojo->new(curfile->dirname->child('app.pl'));
+
+# The issue's regression bar: 200 with toast markup (was a 500 with
+# "No renderer registered for child component 'toast_provider'").
+$t->get_ok('/toast-probe')->status_is(200)
+  ->element_exists('[data-slot="toast-provider"]', 'provider rendered')
+  ->element_exists('[data-slot="toast"]',          'toast rendered')
+  ->element_exists('[data-slot="toast-title"]',    'title rendered')
+  ->text_like('[data-slot="toast-title"]', qr/hi/, 'children reached the title')
+  ->element_exists('[data-slot="toast"][data-state="open"]',
+      'parent signal reached the sub-component prop (not Toast\\'s own open=false default)');
+
+done_testing;
+`
+
+describe.skipIf(!PERL_AVAILABLE)('Mojo multi-component registry modules (#2132)', () => {
+  let appDir: string
+
+  beforeAll(() => {
+    appDir = mkdtempSync(path.join(tmpdir(), 'bf-mojo-multi-component-'))
+    mkdirSync(path.join(appDir, 'dist/templates/ui/toast'), { recursive: true })
+
+    const adapter = new MojoAdapter()
+
+    // Compile the multi-component module: one template + ssr-defaults pair
+    // per exported component, each stamped with its componentName.
+    const toastResult = compileJSX(TOAST_TSX, 'components/ui/toast/index.tsx', { adapter })
+    const toastErrors = toastResult.errors.filter(e => e.severity === 'error')
+    if (toastErrors.length > 0) {
+      throw new Error(`toast module compile failed:\n${toastErrors.map(e => e.message).join('\n')}`)
+    }
+    const componentRows: Record<string, { markedTemplate: string; ssrDefaults?: unknown }> = {}
+    const toastTemplates = toastResult.files.filter(f => f.type === 'markedTemplate')
+    for (const tpl of toastTemplates) {
+      const fileName = path.basename(tpl.path)
+      writeFileSync(path.join(appDir, 'dist/templates/ui/toast', fileName), tpl.content)
+      const defaults = toastResult.files.find(
+        f => f.type === 'ssrDefaults' && f.componentName === tpl.componentName,
+      )
+      componentRows[tpl.componentName!] = {
+        markedTemplate: `templates/ui/toast/${fileName}`,
+        ...(defaults ? { ssrDefaults: JSON.parse(defaults.content) } : {}),
+      }
+    }
+    expect(Object.keys(componentRows).sort()).toEqual(['Toast', 'ToastProvider', 'ToastTitle'])
+
+    // Compile the probe page.
+    const probeResult = compileJSX(PROBE_TSX, 'components/ToastProbe.tsx', { adapter })
+    const probeErrors = probeResult.errors.filter(e => e.severity === 'error')
+    if (probeErrors.length > 0) {
+      throw new Error(`probe compile failed:\n${probeErrors.map(e => e.message).join('\n')}`)
+    }
+    const probeTemplate = probeResult.files.find(f => f.type === 'markedTemplate')
+    const probeDefaults = probeResult.files.find(f => f.type === 'ssrDefaults')
+    if (!probeTemplate) throw new Error('probe compile produced no template')
+    writeFileSync(path.join(appDir, 'dist/templates/ToastProbe.html.ep'), probeTemplate.content)
+
+    // Same entry shape `bf build` writes to dist/templates/manifest.json
+    // (see build-manifest-components.test.ts for the emitter pin).
+    writeFileSync(
+      path.join(appDir, 'dist/templates/manifest.json'),
+      JSON.stringify({
+        ToastProbe: {
+          markedTemplate: 'templates/ToastProbe.html.ep',
+          ...(probeDefaults ? { ssrDefaults: JSON.parse(probeDefaults.content) } : {}),
+        },
+        'ui/toast/index': {
+          markedTemplate: componentRows[toastTemplates[0].componentName!].markedTemplate,
+          components: componentRows,
+        },
+      }),
+    )
+    writeFileSync(path.join(appDir, 'app.pl'), APP_PL)
+    writeFileSync(path.join(appDir, 'smoke.pl'), SMOKE_PL)
+  })
+
+  test('a <Toast>-using page renders 200 with toast markup', async () => {
+    const perl5lib = [MOJO_LIB_DIR, PERL_CORE_LIB_DIR, process.env.PERL5LIB]
+      .filter(Boolean)
+      .join(':')
+    const proc = Bun.spawn(['perl', 'smoke.pl'], {
+      cwd: appDir,
+      env: { ...process.env, PERL5LIB: perl5lib },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+    expect(exitCode, `TAP output:\n${stdout}\n${stderr}`).toBe(0)
+  })
+})

--- a/packages/adapter-mojolicious/t/render_named.t
+++ b/packages/adapter-mojolicious/t/render_named.t
@@ -1,0 +1,55 @@
+use Test2::V0;
+
+# BarefootJS::Backend::Mojo::render_named error propagation (#2132).
+#
+# `$c->render_to_string` returns undef — it does NOT die — when the named
+# template can't be rendered (missing template file). The calling template's
+# `<%==` emitted that as an empty string, silently dropping the whole child
+# subtree from the page. render_named must fail loudly instead, and a die
+# mid-child-render must leave the request's active bf instance restored.
+
+use FindBin qw($Bin);
+use lib "$Bin/../lib";
+
+use Mojo::File qw(tempdir);
+use Mojolicious;
+
+use BarefootJS;
+use BarefootJS::Backend::Mojo;
+
+my $dir = tempdir;
+$dir->child('boom.html.ep')->spew(qq{% die "kaboom";\n});
+$dir->child('ok.html.ep')->spew(qq{fine\n});
+
+my $app = Mojolicious->new;
+push @{ $app->renderer->paths }, "$dir";
+my $c = $app->build_controller;
+
+my $root_bf  = BarefootJS->new($c, {});
+my $child_bf = BarefootJS->new($c, {});
+$c->stash->{'bf.instance'} = $root_bf;
+my $backend = BarefootJS::Backend::Mojo->new(c => $c);
+
+subtest 'a resolvable template renders' => sub {
+    my $html = $backend->render_named('ok', $child_bf, {});
+    like $html, qr/fine/, 'named template output returned';
+    ref_is $c->stash->{'bf.instance'}, $root_bf,
+        'active instance restored after the nested render';
+};
+
+subtest 'a missing template dies instead of rendering empty' => sub {
+    like dies { $backend->render_named('no/such/template', $child_bf, {}) },
+        qr/rendered no output/,
+        'undef from render_to_string surfaces as an exception';
+    ref_is $c->stash->{'bf.instance'}, $root_bf,
+        'active instance restored after the failed render';
+};
+
+subtest 'a template exception propagates and restores the active instance' => sub {
+    like dies { $backend->render_named('boom', $child_bf, {}) },
+        qr/kaboom/, 'template die reaches the caller';
+    ref_is $c->stash->{'bf.instance'}, $root_bf,
+        'active instance restored even when the nested render dies';
+};
+
+done_testing;

--- a/packages/adapter-perl/MANIFEST
+++ b/packages/adapter-perl/MANIFEST
@@ -11,6 +11,7 @@ README.md
 t/controller_cycle.t
 t/dev_reload.t
 t/helper_vectors.t
+t/manifest_components.t
 t/search_params.t
 t/spread_attrs.t
 t/template_primitives.t

--- a/packages/adapter-perl/lib/BarefootJS.pm
+++ b/packages/adapter-perl/lib/BarefootJS.pm
@@ -349,8 +349,72 @@ sub render_child ($self, $name, @args) {
 # it takes precedence over the manifest's `ssrDefaults` for that
 # child, allowing callers to mix manual overrides with auto-derived
 # defaults for siblings.
+#
+# Multi-component modules (#2132): a registry module exporting several
+# components from one file (`ui/toast/index.tsx` → ToastProvider, Toast,
+# ToastTitle, ...) compiles to one template PER component, listed in the
+# entry's `components` map (`{ ToastProvider => { markedTemplate,
+# ssrDefaults }, ... }`). Compiled parent templates invoke each one under
+# its snake_cased component name (`render_child('toast_provider')`), so a
+# renderer is registered per component. These run AFTER the directory-name
+# registration and win on collision — for `ui/toast/index` the key `toast`
+# must resolve to Toast's own template, not the module's first template
+# (ToastProvider), which is all the bare `markedTemplate` carries.
 sub register_components_from_manifest ($self, $manifest, %opts) {
     my $signal_inits = $opts{signal_init} // {};
+
+    for my $entry_name (keys %$manifest) {
+        # `__barefoot__` is the runtime entry, not a component.
+        next if $entry_name eq '__barefoot__';
+        # Only UI registry components (path shape `ui/<name>/index`)
+        # become child renderers; top-level page components are the
+        # render target rather than a child.
+        next unless $entry_name =~ m{^ui/([^/]+)/index$};
+        my $slot_key = $1;
+        my $entry = $manifest->{$entry_name};
+
+        # Directory-name registration — the pre-`components` convention,
+        # kept so manifests from older builds (no `components` map) still
+        # resolve single-component modules like `button`.
+        $self->_register_manifest_child(
+            $slot_key, $entry->{markedTemplate},
+            $signal_inits->{$slot_key}, $entry->{ssrDefaults},
+        );
+
+        # Per-component registrations (#2132), keyed by the snake_cased
+        # component name the compiled templates actually call.
+        my $components = $entry->{components};
+        next unless ref($components) eq 'HASH';
+        for my $component_name (sort keys %$components) {
+            my $component = $components->{$component_name};
+            next unless ref($component) eq 'HASH';
+            my $component_key = _snake_case($component_name);
+            $self->_register_manifest_child(
+                $component_key, $component->{markedTemplate},
+                $signal_inits->{$component_key}, $component->{ssrDefaults},
+            );
+        }
+    }
+}
+
+# PascalCase → snake_case, mirroring the Mojo adapter's `toTemplateName`
+# (prefix every uppercase letter with `_`, lowercase the whole string,
+# strip the leading `_`): `ToastProvider` → `toast_provider`.
+sub _snake_case ($name) {
+    my $s = $name;
+    $s =~ s/([A-Z])/_$1/g;
+    $s = CORE::lc $s;
+    $s =~ s/^_//;
+    return $s;
+}
+
+# Register one manifest-driven child renderer: `$slot_key` becomes the
+# `render_child` name, `$marked` locates the template, and `$signal_init`
+# / `$manifest_defaults` seed the child's template vars (see
+# `register_components_from_manifest` for the contract).
+sub _register_manifest_child ($self, $slot_key, $marked, $signal_init, $manifest_defaults) {
+    $marked //= '';
+    return unless $marked;
     my $parent_scope = $self->_scope_id;
     # Weaken the parent capture so the child-renderer closures stored on
     # `$self->_child_renderers` don't keep `$self` alive (the direct
@@ -361,76 +425,63 @@ sub register_components_from_manifest ($self, $manifest, %opts) {
     # stored on `$parent`, so `$parent` outlives every invocation).
     weaken(my $parent = $self);
 
-    for my $entry_name (keys %$manifest) {
-        # `__barefoot__` is the runtime entry, not a component.
-        next if $entry_name eq '__barefoot__';
-        # Only UI registry components (path shape `ui/<name>/index`)
-        # become child renderers; top-level page components are the
-        # render target rather than a child.
-        next unless $entry_name =~ m{^ui/([^/]+)/index$};
-        my $slot_key = $1;
-        my $marked = $manifest->{$entry_name}{markedTemplate} // '';
-        next unless $marked;
-        # `templates/ui/button/index.html.ep` → `ui/button/index`
-        my $template_name = $marked;
-        $template_name =~ s{^templates/}{};
-        $template_name =~ s{\.html\.ep$}{};
+    # `templates/ui/button/index.html.ep` → `ui/button/index`
+    my $template_name = $marked;
+    $template_name =~ s{^templates/}{};
+    $template_name =~ s{\.html\.ep$}{};
 
-        my $signal_init = $signal_inits->{$slot_key};
-        my $manifest_defaults = $manifest->{$entry_name}{ssrDefaults};
-        $self->register_child_renderer($slot_key, sub {
-            # `$caller` is the instance whose template invoked
-            # `render_child` (#1897) — for a nested render that is a child
-            # instance, and the grandchild's scope/slot identity must chain
-            # off ITS scope id (`root_s0_s0`), not the registrant's.
-            my ($props, $caller) = @_;
-            my $host = $caller // $parent;
-            my $host_scope = $host->_scope_id // $parent_scope;
-            # Child shares the parent's backend so nested renders go
-            # through the same engine + controller (and inherit any
-            # injected json_encoder). The controller is fetched via the weak
-            # `$parent` at call time — never captured strongly — so the
-            # closure adds no edge to the per-request reference cycle.
-            my $child_bf = BarefootJS->new($parent->c, { backend => $parent->backend });
-            my $slot_id = delete $props->{_bf_slot};
-            # JSX `key` (a reserved prop) → data-key on the child's scope root
-            # for keyed-loop reconciliation (see `data_key_attr`).
-            my $data_key = delete $props->{key};
-            $child_bf->_data_key($data_key) if defined $data_key;
-            $child_bf->_scope_id(
-                $slot_id ? $host_scope . '_' . $slot_id
-                         : $template_name . '_' . substr(rand() =~ s/^0\.//r, 0, 6)
-            );
-            $child_bf->_is_child(1);
-            # (#1249) Slot identity: host scope + slot id. Emitted as
-            # bf-h / bf-m attributes by hydration_attrs.
-            if ($slot_id) {
-                $child_bf->_bf_parent($host_scope);
-                $child_bf->_bf_mount($slot_id);
-            }
-            # Share the root registry so the child's own template can
-            # render further imported components (#1897).
-            $child_bf->_child_renderers($parent->_child_renderers);
-            $child_bf->_scripts($parent->_scripts);
-            $child_bf->_script_seen($parent->_script_seen);
+    $self->register_child_renderer($slot_key, sub {
+        # `$caller` is the instance whose template invoked
+        # `render_child` (#1897) — for a nested render that is a child
+        # instance, and the grandchild's scope/slot identity must chain
+        # off ITS scope id (`root_s0_s0`), not the registrant's.
+        my ($props, $caller) = @_;
+        my $host = $caller // $parent;
+        my $host_scope = $host->_scope_id // $parent_scope;
+        # Child shares the parent's backend so nested renders go
+        # through the same engine + controller (and inherit any
+        # injected json_encoder). The controller is fetched via the weak
+        # `$parent` at call time — never captured strongly — so the
+        # closure adds no edge to the per-request reference cycle.
+        my $child_bf = BarefootJS->new($parent->c, { backend => $parent->backend });
+        my $slot_id = delete $props->{_bf_slot};
+        # JSX `key` (a reserved prop) → data-key on the child's scope root
+        # for keyed-loop reconciliation (see `data_key_attr`).
+        my $data_key = delete $props->{key};
+        $child_bf->_data_key($data_key) if defined $data_key;
+        $child_bf->_scope_id(
+            $slot_id ? $host_scope . '_' . $slot_id
+                     : $template_name . '_' . substr(rand() =~ s/^0\.//r, 0, 6)
+        );
+        $child_bf->_is_child(1);
+        # (#1249) Slot identity: host scope + slot id. Emitted as
+        # bf-h / bf-m attributes by hydration_attrs.
+        if ($slot_id) {
+            $child_bf->_bf_parent($host_scope);
+            $child_bf->_bf_mount($slot_id);
+        }
+        # Share the root registry so the child's own template can
+        # render further imported components (#1897).
+        $child_bf->_child_renderers($parent->_child_renderers);
+        $child_bf->_scripts($parent->_scripts);
+        $child_bf->_script_seen($parent->_script_seen);
 
-            my %extra;
-            if ($signal_init) {
-                %extra = $signal_init->($props);
-            } elsif ($manifest_defaults) {
-                %extra = _derive_stash_from_defaults($manifest_defaults, $props);
-            }
+        my %extra;
+        if ($signal_init) {
+            %extra = $signal_init->($props);
+        } elsif ($manifest_defaults) {
+            %extra = _derive_stash_from_defaults($manifest_defaults, $props);
+        }
 
-            # Render the child template with $child_bf bound as the active
-            # instance for the nested render. The backend owns the
-            # engine-specific binding + restore (stash juggle for Mojo).
-            my $html = $parent->backend->render_named(
-                $template_name, $child_bf, { %$props, %extra },
-            );
-            chomp $html;
-            return $html;
-        });
-    }
+        # Render the child template with $child_bf bound as the active
+        # instance for the nested render. The backend owns the
+        # engine-specific binding + restore (stash juggle for Mojo).
+        my $html = $parent->backend->render_named(
+            $template_name, $child_bf, { %$props, %extra },
+        );
+        chomp $html;
+        return $html;
+    });
 }
 
 # Derive template-stash kvs from a manifest entry's `ssrDefaults`

--- a/packages/adapter-perl/t/manifest_components.t
+++ b/packages/adapter-perl/t/manifest_components.t
@@ -1,0 +1,170 @@
+use strict;
+use warnings;
+use utf8;
+
+use Test2::V0;
+
+use FindBin qw($Bin);
+use lib "$Bin/../lib";
+
+use BarefootJS;
+
+# Multi-component registry modules (#2132).
+#
+# A registry module exporting several components from one file
+# (`ui/toast/index.tsx` → ToastProvider / Toast / ToastTitle) compiles to
+# one template per component, and `bf build` lists them in the manifest
+# entry's `components` map. Compiled parent templates call each one under
+# its snake_cased component name (`render_child('toast_provider')`), so
+# `register_components_from_manifest` must register one child renderer per
+# component — the old dir-name-only registration left every sub-component
+# unresolvable and the render died with "No renderer registered".
+
+# Backend stub that records which template each nested render resolved to,
+# along with the vars it received.
+{
+    package RecordingBackend;
+    sub new { bless { calls => [] }, shift }
+    sub calls       { $_[0]{calls} }
+    sub encode_json { '{}' }
+    sub mark_raw    { $_[1] }
+    sub materialize { $_[1] }
+    sub render_named {
+        my ($self, $template_name, $child_bf, $vars) = @_;
+        push @{ $self->{calls} }, { template => $template_name, vars => $vars };
+        return "<rendered:$template_name>";
+    }
+}
+
+sub new_bf {
+    my $backend = RecordingBackend->new;
+    my $bf = BarefootJS->new(undef, { backend => $backend });
+    $bf->_scope_id('Root_test');
+    return ($bf, $backend);
+}
+
+# The manifest shape `bf build` emits for the toast module (see the emitter
+# pin in packages/cli/src/__tests__/build-manifest-components.test.ts).
+my $TOAST_ENTRY = {
+    markedTemplate => 'templates/ui/toast/ToastProvider.html.ep',
+    clientJs       => 'client/ui/toast/index.client.js',
+    ssrDefaults    => { children => { propName => 'children', value => undef } },
+    components     => {
+        ToastProvider => {
+            markedTemplate => 'templates/ui/toast/ToastProvider.html.ep',
+            ssrDefaults    => { children => { propName => 'children', value => undef } },
+        },
+        Toast => {
+            markedTemplate => 'templates/ui/toast/Toast.html.ep',
+            ssrDefaults    => {
+                open     => { propName => 'open', value => 0 },
+                children => { propName => 'children', value => undef },
+            },
+        },
+        ToastTitle => {
+            markedTemplate => 'templates/ui/toast/ToastTitle.html.ep',
+            ssrDefaults    => { children => { propName => 'children', value => undef } },
+        },
+    },
+};
+
+subtest 'each exported component gets a renderer under its snake_case name' => sub {
+    my ($bf, $backend) = new_bf();
+    $bf->register_components_from_manifest({ 'ui/toast/index' => $TOAST_ENTRY });
+
+    for my $case (
+        [ toast_provider => 'ui/toast/ToastProvider' ],
+        [ toast          => 'ui/toast/Toast' ],
+        [ toast_title    => 'ui/toast/ToastTitle' ],
+    ) {
+        my ($slot_key, $template) = @$case;
+        my $html = $bf->render_child($slot_key);
+        is $html, "<rendered:$template>",
+            "render_child('$slot_key') renders $template";
+    }
+};
+
+subtest 'the dir-name key resolves to the COMPONENT template, not the module primary' => sub {
+    # `ui/toast/index`'s dir key is `toast`, which collides with
+    # snake_case('Toast'). The per-component registration must win: without
+    # it, `render_child('toast')` renders the module's FIRST template
+    # (ToastProvider) — the wrong markup entirely.
+    my ($bf, $backend) = new_bf();
+    $bf->register_components_from_manifest({ 'ui/toast/index' => $TOAST_ENTRY });
+
+    $bf->render_child('toast');
+    is $backend->calls->[-1]{template}, 'ui/toast/Toast',
+        'toast maps to Toast.html.ep (not ToastProvider.html.ep)';
+};
+
+subtest 'per-component ssrDefaults seed the child vars' => sub {
+    my ($bf, $backend) = new_bf();
+    $bf->register_components_from_manifest({ 'ui/toast/index' => $TOAST_ENTRY });
+
+    # No caller prop → Toast's own static default.
+    $bf->render_child('toast');
+    is $backend->calls->[-1]{vars}{open}, 0,
+        'omitted prop falls back to the component default';
+
+    # Caller-supplied prop wins.
+    $bf->render_child('toast', open => 1);
+    is $backend->calls->[-1]{vars}{open}, 1, 'caller prop overrides the default';
+};
+
+subtest 'signal_init override applies per component key' => sub {
+    my ($bf, $backend) = new_bf();
+    $bf->register_components_from_manifest(
+        { 'ui/toast/index' => $TOAST_ENTRY },
+        signal_init => { toast => sub { (open => 'forced') } },
+    );
+
+    $bf->render_child('toast');
+    is $backend->calls->[-1]{vars}{open}, 'forced',
+        'signal_init keyed by the snake_case component name wins over ssrDefaults';
+
+    $bf->render_child('toast_title');
+    is $backend->calls->[-1]{template}, 'ui/toast/ToastTitle',
+        'sibling components without an override still render';
+};
+
+subtest 'manifests without a components map keep the dir-name registration' => sub {
+    # Older builds emit no `components` map; the single-component
+    # convention (dir name == snake_cased component name) must keep working.
+    my ($bf, $backend) = new_bf();
+    $bf->register_components_from_manifest({
+        'ui/button/index' => {
+            markedTemplate => 'templates/ui/button/index.html.ep',
+            ssrDefaults    => { variant => { propName => 'variant', value => 'default' } },
+        },
+    });
+
+    my $html = $bf->render_child('button');
+    is $html, '<rendered:ui/button/index>', 'dir-name key still renders';
+    is $backend->calls->[-1]{vars}{variant}, 'default', 'entry ssrDefaults still seed';
+};
+
+subtest 'a components row without a markedTemplate is skipped, siblings survive' => sub {
+    my ($bf, $backend) = new_bf();
+    my $entry = {
+        %$TOAST_ENTRY,
+        components => {
+            %{ $TOAST_ENTRY->{components} },
+            Broken => {},    # no markedTemplate
+        },
+    };
+    $bf->register_components_from_manifest({ 'ui/toast/index' => $entry });
+
+    like dies { $bf->render_child('broken') }, qr/No renderer registered/,
+        'template-less row registers nothing';
+    is $bf->render_child('toast_title'), '<rendered:ui/toast/ToastTitle>',
+        'sibling components still registered';
+};
+
+subtest '_snake_case mirrors the Mojo adapter toTemplateName' => sub {
+    is BarefootJS::_snake_case('Toast'),         'toast',          'single word';
+    is BarefootJS::_snake_case('ToastProvider'), 'toast_provider', 'two words';
+    is BarefootJS::_snake_case('DropdownMenu'),  'dropdown_menu',  'kebab-dir module component';
+    is BarefootJS::_snake_case('InputOTP'),      'input_o_t_p',    'acronym splits per capital';
+};
+
+done_testing;

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -142,6 +142,7 @@ import { fixture as returnNullishCoalescing } from './return-nullish-coalescing'
 import { fixture as returnMap } from './return-map'
 // Priority 7: Multi-file composition
 import { fixture as childComponent } from './child-component'
+import { fixture as multiComponentModule } from './multi-component-module'
 import { fixture as restSpreadChildAttrs } from './rest-spread-child-attrs'
 import { fixture as componentWithJsxChildren } from './component-with-jsx-children'
 import { fixture as nativeSelectSpreadChildren } from './native-select-spread-children'
@@ -391,6 +392,7 @@ export const jsxFixtures: JSXFixture[] = [
   returnMap,
   // Priority 7: Multi-file composition
   childComponent,
+  multiComponentModule,
   restSpreadChildAttrs,
   componentWithJsxChildren,
   nativeSelectSpreadChildren,

--- a/packages/adapter-tests/fixtures/multi-component-module.ts
+++ b/packages/adapter-tests/fixtures/multi-component-module.ts
@@ -1,0 +1,77 @@
+/**
+ * Multi-component child MODULE (#2132) — a parent renders several
+ * components exported from ONE child file, the registry-toast shape
+ * (`ui/toast/index.tsx` exporting ToastProvider / Toast / ToastTitle).
+ *
+ * Every other multi-file fixture's child file exports exactly one
+ * component, so this shape had no cross-adapter conformance coverage:
+ * `templatesPerComponent` adapters emit one template per exported
+ * component and must resolve each `render_child('<snake_case_name>')`
+ * to that component's OWN template. The production mojo bug was
+ * manifest-side (no per-component registration — every page using
+ * Toast/Dialog/Tabs 500'd), but the same mis-pairing can hide in any
+ * adapter harness: pairing every sibling template to the module's first
+ * component would render ToastProvider's markup for `<Toast>` and still
+ * produce *some* HTML.
+ *
+ * The fixture pins the three tells of a correct pairing:
+ *   - each sub-component's own `data-slot` appears exactly once;
+ *   - Toast renders its `open` PROP (parent signal, `data-state="open"`),
+ *     not its `false` destructure default;
+ *   - children pass through two nesting levels of the same module.
+ */
+
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'multi-component-module',
+  description:
+    'Parent renders several components exported from one child file (registry-toast shape, #2132)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+import { ToastProvider, Toast, ToastTitle } from './toast'
+
+export function ToastProbe() {
+  const [open, setOpen] = createSignal(true)
+  return (
+    <ToastProvider>
+      <Toast open={open()}>
+        <ToastTitle>hi</ToastTitle>
+      </Toast>
+    </ToastProvider>
+  )
+}
+`,
+  components: {
+    './toast.tsx': `
+interface ToastProviderProps {
+  children?: any
+}
+
+export function ToastProvider({ children }: ToastProviderProps) {
+  return <div data-slot="toast-provider">{children}</div>
+}
+
+interface ToastProps {
+  open?: boolean
+  children?: any
+}
+
+export function Toast({ open = false, children }: ToastProps) {
+  return (
+    <div data-slot="toast" data-state={open ? 'open' : 'closed'}>
+      {children}
+    </div>
+  )
+}
+
+export function ToastTitle({ children }: { children?: any }) {
+  return <div data-slot="toast-title">{children}</div>
+}
+`,
+  },
+  expectedHtml: `
+    <div bf-s="test_s2" data-slot="toast-provider"><div bf-s="test_s1" bf="s0" data-slot="toast" data-state="open"><div bf-s="test_s0" data-slot="toast-title">hi</div></div></div>
+  `,
+})

--- a/packages/cli/src/__tests__/build-manifest-components.test.ts
+++ b/packages/cli/src/__tests__/build-manifest-components.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Manifest `components` map for multi-component registry modules (#2132).
+ *
+ * `templatesPerComponent` adapters (Mojolicious) compile a registry module
+ * that exports several components from one file — `ui/toast/index.tsx`
+ * exporting ToastProvider / Toast / ToastTitle — into one template file PER
+ * component, but the manifest entry used to carry a single `markedTemplate`
+ * (the first component's). Server runtimes register child renderers from the
+ * manifest, so `render_child('toast_provider')` found nothing and the whole
+ * module 500'd on SSR.
+ *
+ * This pins the emitter side of the fix: each manifest entry for a
+ * `templatesPerComponent` adapter carries a `components` map — one row per
+ * exported component with its own `markedTemplate` + `ssrDefaults` — keyed by
+ * the component name (NOT the template basename: a single-component file's
+ * template is named after the source file, e.g. `index.html.ep`). The
+ * consumer side lives in the Perl runtime
+ * (`packages/adapter-perl/t/manifest_components.t`).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { build } from '../lib/build'
+import { MojoAdapter } from '../../../adapter-mojolicious/src/adapter/mojo-adapter'
+import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync, realpathSync, symlinkSync } from 'fs'
+import { resolve } from 'path'
+import { tmpdir } from 'os'
+
+function makeTmpDir(label: string) {
+  const dir = resolve(tmpdir(), `bf-test-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+  mkdirSync(dir, { recursive: true })
+  return realpathSync(dir)
+}
+
+/**
+ * Link the workspace `@barefootjs/client` into the throwaway project so the
+ * build can copy `barefoot.js` — without it the compiled client bundles'
+ * `../../barefoot.js` imports don't resolve on disk and the rebuild pass
+ * raises BF053, which is noise unrelated to what this file pins.
+ */
+function linkClientRuntime(projectDir: string) {
+  const scope = resolve(projectDir, 'node_modules/@barefootjs')
+  mkdirSync(scope, { recursive: true })
+  symlinkSync(resolve(import.meta.dir, '../../../client'), resolve(scope, 'client'))
+}
+
+// The registry-toast shape: one module, several exported components.
+const TOAST_SOURCE = `'use client'
+
+interface ToastProviderProps {
+  children?: any
+}
+
+export function ToastProvider({ children }: ToastProviderProps) {
+  return <div data-slot="toast-provider">{children}</div>
+}
+
+interface ToastProps {
+  open?: boolean
+  children?: any
+}
+
+export function Toast({ open = false, children }: ToastProps) {
+  return (
+    <div data-slot="toast" data-state={open ? 'open' : 'closed'}>
+      {children}
+    </div>
+  )
+}
+
+export function ToastTitle({ children }: { children?: any }) {
+  return <div data-slot="toast-title">{children}</div>
+}
+`
+
+// Single-component module whose template is named after the SOURCE file
+// (`index.html.ep`) — the component name must still key the map.
+const TOASTER_SOURCE = `'use client'
+import { createSignal } from '@barefootjs/client'
+
+export function Toaster() {
+  const [count, setCount] = createSignal(0)
+  return <div data-slot="toaster" onClick={() => setCount(count() + 1)}>{count()}</div>
+}
+`
+
+async function runBuild(projectDir: string, outDir: string) {
+  return build({
+    projectDir,
+    adapter: new MojoAdapter(),
+    componentDirs: [resolve(projectDir, 'components')],
+    outDir,
+    minify: false,
+    contentHash: false,
+    clientOnly: false,
+    outputLayout: { templates: 'templates', clientJs: 'client', runtime: 'client' },
+  })
+}
+
+describe('manifest `components` map for templatesPerComponent adapters (#2132)', () => {
+  test('multi-component ui module lists one row per exported component', async () => {
+    const projectDir = makeTmpDir('manifest-components-src')
+    const outDir = makeTmpDir('manifest-components-out')
+    try {
+      const toastDir = resolve(projectDir, 'components/ui/toast')
+      const toasterDir = resolve(projectDir, 'components/ui/toaster')
+      mkdirSync(toastDir, { recursive: true })
+      mkdirSync(toasterDir, { recursive: true })
+      writeFileSync(resolve(toastDir, 'index.tsx'), TOAST_SOURCE)
+      writeFileSync(resolve(toasterDir, 'index.tsx'), TOASTER_SOURCE)
+      linkClientRuntime(projectDir)
+
+      const result = await runBuild(projectDir, outDir)
+      expect(result.errorCount).toBe(0)
+
+      const entry = result.manifest['ui/toast/index']
+      expect(entry).toBeDefined()
+      expect(Object.keys(entry.components ?? {}).sort()).toEqual([
+        'Toast',
+        'ToastProvider',
+        'ToastTitle',
+      ])
+      expect(entry.components!.ToastProvider.markedTemplate).toBe(
+        'templates/ui/toast/ToastProvider.html.ep',
+      )
+      expect(entry.components!.Toast.markedTemplate).toBe('templates/ui/toast/Toast.html.ep')
+      expect(entry.components!.ToastTitle.markedTemplate).toBe(
+        'templates/ui/toast/ToastTitle.html.ep',
+      )
+      // Per-component ssrDefaults, not the module-primary's: Toast's `open`
+      // destructure default must ride on Toast's own row so the runtime can
+      // seed `$open` when the caller passes no prop.
+      expect(entry.components!.Toast.ssrDefaults).toEqual({
+        open: { propName: 'open', value: false },
+        children: { propName: 'children', value: null },
+      })
+      // Every listed template exists on disk.
+      for (const row of Object.values(entry.components!)) {
+        expect(existsSync(resolve(outDir, row.markedTemplate))).toBe(true)
+      }
+
+      // The map key is the component name even when the single template is
+      // named after the source file.
+      const toaster = result.manifest['ui/toaster/index']
+      expect(Object.keys(toaster.components ?? {})).toEqual(['Toaster'])
+      expect(toaster.components!.Toaster.markedTemplate).toBe(
+        'templates/ui/toaster/index.html.ep',
+      )
+
+      // The on-disk manifest carries the same rows.
+      const onDisk = JSON.parse(
+        readFileSync(resolve(outDir, 'templates/manifest.json'), 'utf-8'),
+      )
+      expect(onDisk['ui/toast/index'].components).toEqual(entry.components)
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+      rmSync(outDir, { recursive: true, force: true })
+    }
+  })
+
+  test('cache-hit rebuild restores the components map', async () => {
+    const projectDir = makeTmpDir('manifest-components-cache-src')
+    const outDir = makeTmpDir('manifest-components-cache-out')
+    try {
+      const toastDir = resolve(projectDir, 'components/ui/toast')
+      mkdirSync(toastDir, { recursive: true })
+      writeFileSync(resolve(toastDir, 'index.tsx'), TOAST_SOURCE)
+      linkClientRuntime(projectDir)
+
+      const first = await runBuild(projectDir, outDir)
+      expect(first.errorCount).toBe(0)
+
+      const second = await runBuild(projectDir, outDir)
+      expect(second.errorCount).toBe(0)
+      expect(second.cachedCount).toBeGreaterThan(0)
+      expect(second.manifest['ui/toast/index'].components).toEqual(
+        first.manifest['ui/toast/index'].components,
+      )
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+      rmSync(outDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/cli/src/lib/build-cache.ts
+++ b/packages/cli/src/lib/build-cache.ts
@@ -6,6 +6,31 @@ import { fileExists, hashString, readText, writeText } from './runtime'
 
 export const CACHE_FILENAME = '.buildcache.json'
 
+/**
+ * Per-exported-component row inside a manifest entry's `components` map.
+ * Emitted only for `templatesPerComponent` adapters, where a multi-component
+ * source file (e.g. the registry's `ui/toast/index.tsx` exporting
+ * ToastProvider / Toast / ToastTitle / ToastClose) compiles to one template
+ * file per component. Server runtimes register one child renderer per row so
+ * `render_child('toast_provider')` etc. resolve (piconic-ai/barefootjs#2132).
+ */
+export interface ManifestComponentEntry {
+  /** Template path relative to outDir (e.g. `templates/ui/toast/Toast.html.ep`) */
+  markedTemplate: string
+  /** This component's statically-derived SSR defaults (see packages/jsx/src/ssr-defaults.ts) */
+  ssrDefaults?: Record<string, unknown>
+}
+
+/** One source file's row in `dist/templates/manifest.json`. */
+export interface ManifestEntry {
+  markedTemplate: string
+  clientJs?: string
+  stubDeps?: string[]
+  ssrDefaults?: Record<string, unknown>
+  /** Per-exported-component templates for `templatesPerComponent` adapters (#2132) */
+  components?: Record<string, ManifestComponentEntry>
+}
+
 export interface CacheEntry {
   /** Content hash of the source file itself */
   hash: string
@@ -16,7 +41,7 @@ export interface CacheEntry {
   /** Manifest key this entry contributes to (null when the entry produced no manifest row) */
   manifestKey: string | null
   /** Stored manifest row, so cache-hit entries can restore it without recompiling */
-  manifestEntry?: { markedTemplate: string; clientJs?: string; stubDeps?: string[]; ssrDefaults?: Record<string, unknown> }
+  manifestEntry?: ManifestEntry
   /** Key used to register this entry's types with the postBuild hook */
   typesKey?: string
   /** Adapter-generated types (e.g. Go structs). Restored on cache hit so the

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -15,6 +15,8 @@ import {
   saveCache,
   type BuildCache,
   type CacheEntry,
+  type ManifestComponentEntry,
+  type ManifestEntry,
 } from './build-cache'
 import {
   BUNDLE_KEY_PREFIX,
@@ -83,7 +85,7 @@ export interface BuildResult {
   /** Number of compilation errors */
   errorCount: number
   /** Manifest entries */
-  manifest: Record<string, { clientJs?: string; markedTemplate: string; stubDeps?: string[] }>
+  manifest: Record<string, ManifestEntry>
   /** True when any output file on disk was changed (write or delete) */
   changed: boolean
   /**
@@ -482,7 +484,7 @@ export async function build(
   }
 
   // 3. Manifest baseline (runtime sentinel always present)
-  const manifest: Record<string, { clientJs?: string; markedTemplate: string; stubDeps?: string[] }> = {
+  const manifest: Record<string, ManifestEntry> = {
     '__barefoot__': { markedTemplate: '', clientJs: `${runtimeSubdir}/barefoot.js` },
   }
 
@@ -1757,7 +1759,7 @@ type CompileEntryOutcome =
       deps: Record<string, string>
       outputs: string[]
       manifestKey: string | null
-      manifestEntry?: { markedTemplate: string; clientJs?: string; stubDeps?: string[]; ssrDefaults?: Record<string, unknown> }
+      manifestEntry?: ManifestEntry
       wroteAny: boolean
       types?: string
       typesKey?: string
@@ -1915,33 +1917,57 @@ async function compileEntry(args: CompileEntryArgs): Promise<CompileEntryOutcome
   }
 
   let manifestKey: string | null = null
-  let manifestEntry: { markedTemplate: string; clientJs?: string; ssrDefaults?: Record<string, unknown> } | undefined
+  let manifestEntry: ManifestEntry | undefined
   if (!config.clientOnly && markedTemplates.length > 0) {
     const primaryTpl =
       markedTemplates.find(t => effectiveOutName(t.path, baseNameNoExt).startsWith(baseNameNoExt + '.'))
       ?? markedTemplates[0]
     manifestKey = baseNameNoExt
-    // Pair the SSR-defaults JSON to the primary template by basename.
-    // The jsx package emits one ssr-defaults file per generated template
-    // (multi-component-per-file adapters emit per-component pairs); pick
-    // whichever sits next to the primary template.
-    const primaryBase = primaryTpl.path.replace(/\.[^.]+$/, '').replace(/\.html$/, '')
-    const ssrDefaultsFile =
-      result.files.find(
-        f => f.type === 'ssrDefaults' && f.path === primaryBase + '.ssr-defaults.json',
-      ) ?? result.files.find(f => f.type === 'ssrDefaults')
-    let ssrDefaults: Record<string, unknown> | undefined
-    if (ssrDefaultsFile) {
+    // Pair each SSR-defaults JSON to its template by basename. The jsx
+    // package emits one ssr-defaults file per generated template
+    // (multi-component-per-file adapters emit per-component pairs).
+    const ssrDefaultsForTemplate = (tplPath: string): Record<string, unknown> | undefined => {
+      const base = tplPath.replace(/\.[^.]+$/, '').replace(/\.html$/, '')
+      const file =
+        result.files.find(f => f.type === 'ssrDefaults' && f.path === base + '.ssr-defaults.json')
+        ?? (tplPath === primaryTpl.path ? result.files.find(f => f.type === 'ssrDefaults') : undefined)
+      if (!file) return undefined
       try {
-        ssrDefaults = JSON.parse(ssrDefaultsFile.content) as Record<string, unknown>
+        return JSON.parse(file.content) as Record<string, unknown>
       } catch {
-        ssrDefaults = undefined
+        return undefined
       }
+    }
+    const ssrDefaults = ssrDefaultsForTemplate(primaryTpl.path)
+    // Per-exported-component rows (#2132). `templatesPerComponent` adapters
+    // emit one template per component, named `<ComponentName><extension>`
+    // (see compileMultipleComponents in packages/jsx/src/compiler.ts), so a
+    // multi-component module like the registry's `ui/toast/index.tsx` has
+    // several templates behind one manifest key. Server runtimes need each
+    // component's template + ssrDefaults to register one child renderer per
+    // exported component — the single `markedTemplate` above only carries
+    // the first one.
+    let components: Record<string, ManifestComponentEntry> | undefined
+    if (config.adapter.templatesPerComponent) {
+      components = {}
+      for (const tpl of markedTemplates) {
+        // The compiler stamps every markedTemplate with its component name
+        // (a single-component file's template is named after the SOURCE
+        // file, so the basename alone can't recover it).
+        if (!tpl.componentName) continue
+        const componentDefaults = ssrDefaultsForTemplate(tpl.path)
+        components[tpl.componentName] = {
+          markedTemplate: `${templatesSubdir}/${effectiveOutName(tpl.path, baseNameNoExt)}`,
+          ...(componentDefaults ? { ssrDefaults: componentDefaults } : {}),
+        }
+      }
+      if (Object.keys(components).length === 0) components = undefined
     }
     manifestEntry = {
       markedTemplate: `${templatesSubdir}/${effectiveOutName(primaryTpl.path, baseNameNoExt)}`,
       clientJs: hasClientJs ? `${clientJsSubdir}/${clientJsFilename}` : undefined,
       ...(ssrDefaults ? { ssrDefaults } : {}),
+      ...(components ? { components } : {}),
     }
   }
 

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -276,6 +276,7 @@ function compileMultipleComponents(
         path: dir + output.componentName + adapter.extension,
         content: output.rawTemplate,
         type: 'markedTemplate',
+        componentName: output.componentName,
       })
       // SSR defaults, paired with the per-component template file via
       // the matching basename (the build pipeline pairs them in
@@ -287,6 +288,7 @@ function compileMultipleComponents(
           path: dir + output.componentName + '.ssr-defaults.json',
           content: JSON.stringify(ssrDefaults),
           type: 'ssrDefaults',
+          componentName: output.componentName,
         })
       }
     }
@@ -672,6 +674,7 @@ export function compileJSX(
     path: filePath.replace(/\.tsx?$/, adapter.extension),
     content,
     type: 'markedTemplate',
+    componentName: componentIR.metadata.componentName,
   })
 
   // SSR defaults — JSON-encoded seed values for the template's
@@ -686,6 +689,7 @@ export function compileJSX(
         path: filePath.replace(/\.tsx?$/, '.ssr-defaults.json'),
         content: JSON.stringify(ssrDefaults),
         type: 'ssrDefaults',
+        componentName: componentIR.metadata.componentName,
       })
     }
   }

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -1826,6 +1826,15 @@ export interface FileOutput {
   path: string
   content: string
   type: 'markedTemplate' | 'clientJs' | 'ir' | 'sourceMap' | 'types' | 'ssrDefaults'
+  /**
+   * The exported component this file was generated for. Set on
+   * `markedTemplate` / `ssrDefaults` outputs so the build pipeline can pair
+   * them per component without guessing from file basenames — a
+   * single-component file's template is named after the SOURCE file
+   * (`index.html.ep`), not the component, so the basename alone can't
+   * recover the component name (#2132).
+   */
+  componentName?: string
 }
 
 export interface CompileResult {


### PR DESCRIPTION
Fixes #2132.

## Problem

A registry module that exports several components from one file (`ui/toast/index.tsx` → ToastProvider / Toast / ToastTitle / ToastClose) compiles to one EP template per component, but the build manifest carried a **single** `markedTemplate` per entry. `register_components_from_manifest` therefore registered only the directory-name key (`toast`), so:

- `render_child('toast_provider')` / `render_child('toast_title')` found no renderer → HTTP 500 ("No renderer registered for child component 'toast_provider'").
- Worse, the one key that *did* resolve — `toast` — rendered the **wrong template**: the module's first one (`ToastProvider.html.ep`), not `Toast.html.ep`.

Reproduced end-to-end with a real Mojolicious app: `/toast-probe` 500'd exactly as reported; after the fix it renders 200 with the full toast markup and correct `data-state="open"` seeding.

## Fix

**Emitter (`@barefootjs/cli` + `@barefootjs/jsx`)** — for `templatesPerComponent` adapters, each manifest entry now carries a `components` map, one row per exported component with its own `markedTemplate` + `ssrDefaults`:

```json
"ui/toast/index": {
  "markedTemplate": "templates/ui/toast/ToastProvider.html.ep",
  "clientJs": "client/ui/toast/index.client.js",
  "components": {
    "ToastProvider": { "markedTemplate": "templates/ui/toast/ToastProvider.html.ep", "ssrDefaults": { … } },
    "Toast":         { "markedTemplate": "templates/ui/toast/Toast.html.ep",         "ssrDefaults": { … } },
    "ToastTitle":    { "markedTemplate": "templates/ui/toast/ToastTitle.html.ep",    "ssrDefaults": { … } }
  }
}
```

The map is keyed by the component name via a new structural `FileOutput.componentName` stamp (a single-component file's template is named after the *source* file — `index.html.ep` — so the basename can't recover the name). The field is additive: every runtime (Perl/PHP/Python/Ruby/Rust) parses manifest entries key-by-key, so older runtimes ignore it, and the new Perl runtime falls back to the directory-name convention for manifests from older builds.

**Runtime (`@barefootjs/perl`)** — `register_components_from_manifest` registers one child renderer per `components` row under the snake_cased name the compiled templates actually call (`toast_provider`, `toast_title`, …), seeding each child from its own per-component `ssrDefaults` (so `<Toast>` without an `open` prop gets Toast's `false` default, not the provider's defaults). Per-component registrations win over the directory-name key, fixing the `toast` → ToastProvider mis-mapping. This also fixes single-component modules in kebab-case dirs (`ui/dropdown-menu` exporting `DropdownMenu` → `dropdown_menu`).

**Silent-empty guard (`@barefootjs/mojolicious`)** — `BarefootJS::Backend::Mojo::render_named` now dies when `render_to_string` returns undef (missing template) instead of letting the calling template's `<%==` silently render the child subtree as an empty string — the issue's "blank page with a 200" failure mode. The `bf.instance` swap is `local`ized so a die mid-child-render restores the active instance. (Real template exceptions already propagated to a loud 500; the zero-byte-200 mode was not reproducible on Mojolicious 9.47 with current code, but this closes the one undef-swallowing path in the child-render wrapper.)

## Tests

- `packages/cli/src/__tests__/build-manifest-components.test.ts` — pins the emitted `components` map (multi-component keys, per-component ssrDefaults, single-component `index.html.ep` keyed by real component name, cache-hit rebuild restore).
- `packages/adapter-perl/t/manifest_components.t` — runtime registration: snake_case keys per component, dir-key collision resolved to the component's own template, per-component defaults + `signal_init` override, legacy-manifest fallback.
- `packages/adapter-mojolicious/src/__tests__/multi-component-registry.test.ts` — the issue's regression bar: boots a real Mojolicious app with the production plugin against compiler-produced templates → `GET /toast-probe` is 200 with `data-slot="toast"` markup (mirrors `stock-route.test.ts`, runs when perl+Mojolicious are installed — CI's mojolicious job does).
- `packages/adapter-mojolicious/t/render_named.t` — missing template dies instead of rendering empty; `bf.instance` restored across nested-render exceptions.
- Suites run locally: adapter-perl `prove t/` (425), adapter-mojolicious `prove t/` (18) + `bun test` (582, with Mojolicious 9.47 installed), cli `bun test` (806), jsx `bun test` (2346) — all green.

## Notes

- The other `templatesPerComponent` runtimes (ERB / Jinja / PHP / Twig / Blade / Rust) have the same missing-sub-component registration gap; the manifest now carries the data they need, so they can be fixed the same way in follow-ups. Xslate's manifest-driven child rendering is not wired up yet (documented in `packages/cli/src/lib/adapters/xslate.ts`) and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GqwQ1NBBVAqRhbG1hVQe9

---
_Generated by [Claude Code](https://claude.ai/code/session_011GqwQ1NBBVAqRhbG1hVQe9)_