### PR TITLE
perf(cli): tree-shake the runtime bundle to each project's used exports

### DIFF
--- a/.changeset/cli-runtime-tree-shaking.md
+++ b/.changeset/cli-runtime-tree-shaking.md
@@ -1,0 +1,13 @@
+---
+"@barefootjs/cli": patch
+"@barefootjs/client": patch
+"@barefootjs/jsx": patch
+---
+
+`bf build` now tree-shakes the client runtime bundle (`barefoot.js`) down to only the `@barefootjs/client*` exports a project's compiled client JS (components, `bundleEntries`, rebundled `externals` chunks) actually imports, plus a small always-kept public mount API (`render`, `hydrate`, `flushHydration`, `rehydrateAll`, `rehydrateScope`, `disposeScope`, `setupStreaming`, `createSearchParams`) for hand-written page scripts the compiler never sees. Previously `barefoot.js` was always a byte-for-byte copy of the entire prebuilt runtime regardless of what the project used — on the CSR benchmark app this shipped ~72KB raw / ~19.4KB gzip; the same app now ships ~24KB raw / ~8.8KB gzip.
+
+New config surface (`createConfig()` in `@barefootjs/client/build`, or any `barefoot.config.ts`):
+- `runtimeBundle?: 'treeshake' | 'full'` — defaults to `'treeshake'`. Set to `'full'` to restore the previous verbatim-copy behavior.
+- `runtimeKeep?: string[]` — extra runtime export names to force-keep, for names only ever referenced from hand-written page scripts beyond the always-kept set.
+
+Safety: if the collector sees an import shape it can't safely narrow (a namespace import, a default import, or a dynamic `import()` of the runtime — reachable only through `bundleEntries`/rebundled `externals`, since the compiler's own component codegen never emits these shapes), the build falls back to a full runtime copy for that build and logs why, rather than risk shipping a `barefoot.js` missing something that's actually used.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -135,28 +135,30 @@ signal, wall-clock will differ).
 
 | Operation | vanilla | barefoot | react | solid |
 |---|---|---|---|---|
-| create1k | 71.55 ms | 79.30 ms (1.11x) | 85.30 ms (1.19x) | 72.60 ms (1.01x) |
-| replace1k | 87.30 ms | 95.75 ms (1.10x) | 104.90 ms (1.20x) | 87.95 ms (1.01x) |
-| update10th | 12.25 ms | 13.40 ms (1.09x) | 15.25 ms (1.24x) | 11.05 ms (0.90x) |
-| select | 3.65 ms | 4.05 ms (1.11x) | 4.75 ms (1.30x) | 3.95 ms (1.08x) |
-| swap | 15.35 ms | 17.50 ms (1.14x) | 83.40 ms (5.43x) | 17.65 ms (1.15x) |
-| remove | 17.55 ms | 20.75 ms (1.18x) | 20.20 ms (1.15x) | 18.80 ms (1.07x) |
-| create10k | 776.00 ms | 854.50 ms (1.10x) | 1045.00 ms (1.35x) | 699.60 ms (0.90x) |
-| append1k | 302.40 ms | 321.30 ms (1.06x) | 318.80 ms (1.05x) | 250.50 ms (0.83x) |
-| clear10k | 65.20 ms | 76.40 ms (1.17x) | 110.10 ms (1.69x) | 69.70 ms (1.07x) |
-| startup | 37.80 ms | 44.10 ms (1.17x) | 58.30 ms (1.54x) | 37.20 ms (0.98x) |
-| memory (1k rows) | 253.4KB | 1495.6KB (5.90x) | 2091.9KB (8.26x) | 1486.7KB (5.87x) |
-| shipped JS (gzip) | 1.1KB | 19.4KB | 58.8KB | 6.8KB |
+| create1k | 104.20 ms | 116.40 ms (1.12x) | 105.85 ms (1.02x) | 111.35 ms (1.07x) |
+| replace1k | 128.10 ms | 142.50 ms (1.11x) | 136.20 ms (1.06x) | 131.95 ms (1.03x) |
+| update10th | 20.70 ms | 19.00 ms (0.92x) | 22.15 ms (1.07x) | 21.95 ms (1.06x) |
+| select | 4.70 ms | 6.15 ms (1.31x) | 8.00 ms (1.70x) | 5.85 ms (1.24x) |
+| swap | 20.85 ms | 21.35 ms (1.02x) | 104.15 ms (5.00x) | 29.95 ms (1.44x) |
+| remove | 24.90 ms | 27.35 ms (1.10x) | 28.65 ms (1.15x) | 29.70 ms (1.19x) |
+| create10k | 914.60 ms | 1027.60 ms (1.12x) | 1372.40 ms (1.50x) | 955.60 ms (1.04x) |
+| append1k | 353.10 ms | 390.20 ms (1.11x) | 476.80 ms (1.35x) | 357.70 ms (1.01x) |
+| clear10k | 73.70 ms | 92.50 ms (1.26x) | 155.80 ms (2.11x) | 84.00 ms (1.14x) |
+| startup | 39.30 ms | 47.20 ms (1.20x) | 83.40 ms (2.12x) | 39.90 ms (1.02x) |
+| memory (1k rows) | 253.2KB | 1495.4KB (5.91x) | 2092.3KB (8.26x) | 1483.4KB (5.86x) |
+| shipped JS (gzip) | 1.1KB | 8.7KB | 58.8KB | 6.8KB |
 
-Reading it honestly: BarefootJS now sits within 6-18% of the vanilla
-baseline on every operation — matching or beating React across the board
-and close to Solid everywhere. Solid keeps a real edge on bulk creation
-(create10k 0.90x, append 0.83x) and ships the smaller runtime; heap per
-1k rows is now essentially equal to Solid's. These numbers include the
-compiler's hoisted shared loop template (one HTML parse per loop, clone
-per row) and the runtime's generation-stamped dependency tracking — both
-landed after the first published run of this suite, whose creation-path
-numbers were 1.4-1.5x.
+Reading it honestly: BarefootJS sits close to the vanilla baseline on
+every operation — competitive with React and Solid across the board
+(individual cells swing a few tenths between runs on shared hardware;
+compare whole columns, not single cells). Heap per 1k rows is at Solid's
+level and shipped JS (8.7KB gzip) is near Solid's 6.8KB after the CLI
+started tree-shaking the runtime bundle to each project's used exports.
+These numbers include the compiler's hoisted shared loop template (one
+HTML parse per loop, clone per row) and the runtime's generation-stamped
+dependency tracking — the first published run of this suite predated all
+three optimizations and had creation-path numbers at 1.4-1.5x and
+19.4KB gzip shipped.
 
 ### SSR + hydration (1,000-row table)
 

--- a/packages/cli/src/__tests__/build-runtime-treeshake.test.ts
+++ b/packages/cli/src/__tests__/build-runtime-treeshake.test.ts
@@ -1,0 +1,253 @@
+// Integration coverage for per-project runtime tree-shaking wired into the
+// full `build()` pipeline: `runtimeBundle: 'treeshake'` (default) vs
+// `'full'`, the unsafe-import fallback, `runtimeKeep`, and cache
+// correctness across incremental rebuilds. Unit tests for the collector and
+// the esbuild wrapper themselves live in `runtime-treeshake.test.ts`.
+
+import { describe, test, expect } from 'bun:test'
+import { mkdirSync, rmSync, realpathSync, writeFileSync, readFileSync, existsSync } from 'fs'
+import { resolve } from 'path'
+import { tmpdir } from 'os'
+import { build } from '../lib/build'
+import { loadCache } from '../lib/build-cache'
+import { TestAdapter } from '../../../jsx/src/adapters/test-adapter'
+
+function makeTmpDir(label: string) {
+  const dir = resolve(tmpdir(), `bf-test-rts-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+  mkdirSync(dir, { recursive: true })
+  return realpathSync(dir)
+}
+
+// The real, already-built dist (this monorepo's `packages/client` build
+// output). Using the genuine runtime — instead of a hand-rolled fixture with
+// a curated stub for each name — means these tests exercise the collector
+// against the same client JS shape a real component compile produces
+// (which imports plenty of compiler-injected helpers like `createComponent`,
+// `hydrate`, `$`/`$t`, `escapeText` that no fixture would think to stub) and
+// asserts tree-shaking against real, un-minified `function <name>` bodies.
+const REAL_DIST = resolve(__dirname, '../../../client/dist/runtime/standalone.js')
+
+function writeFixtureDist(projectDir: string): void {
+  if (!existsSync(REAL_DIST)) {
+    throw new Error(`${REAL_DIST} not found — run \`bun run build\` in packages/client first`)
+  }
+  const runtimeDir = resolve(projectDir, 'node_modules/@barefootjs/client/dist/runtime')
+  mkdirSync(runtimeDir, { recursive: true })
+  writeFileSync(resolve(runtimeDir, 'standalone.js'), readFileSync(REAL_DIST, 'utf8'))
+}
+
+/** Asserts `content` contains a top-level `function <name>` declaration. */
+function expectHasFn(content: string, name: string): void {
+  expect(content).toContain(`function ${name}(`)
+}
+
+/** Asserts `content` does NOT contain a top-level `function <name>` declaration. */
+function expectLacksFn(content: string, name: string): void {
+  expect(content).not.toContain(`function ${name}(`)
+}
+
+function makeConfig(projectDir: string, outDir: string, extra: Record<string, unknown> = {}) {
+  return {
+    projectDir,
+    adapter: new TestAdapter(),
+    componentDirs: [resolve(projectDir, 'components')],
+    outDir,
+    minify: false,
+    contentHash: false,
+    clientOnly: true,
+    ...extra,
+  }
+}
+
+function writeComponent(projectDir: string, name: string, imports: string[]): void {
+  const componentsDir = resolve(projectDir, 'components')
+  mkdirSync(componentsDir, { recursive: true })
+  writeFileSync(
+    resolve(componentsDir, `${name}.tsx`),
+    `'use client'\n` +
+      `import { ${imports.join(', ')} } from '@barefootjs/client'\n` +
+      `export function ${name}() {\n` +
+      `  const [v, setV] = createSignal(0)\n` +
+      `  ${imports.includes('createEffect') ? 'createEffect(() => { v() })' : ''}\n` +
+      `  ${imports.includes('onMount') ? 'onMount(() => {})' : ''}\n` +
+      `  return <button onClick={() => setV(v() + 1)}>{v()}</button>\n` +
+      `}\n`,
+  )
+}
+
+describe('build() runtime tree-shaking', () => {
+  test('treeshake mode (default) keeps only used + always-kept exports', async () => {
+    const projectDir = makeTmpDir('default-src')
+    const outDir = makeTmpDir('default-out')
+    try {
+      writeFixtureDist(projectDir)
+      writeComponent(projectDir, 'Counter', ['createSignal', 'createEffect'])
+
+      const result = await build(makeConfig(projectDir, outDir))
+      expect(result.errorCount).toBe(0)
+
+      const runtimePath = resolve(outDir, 'components/barefoot.js')
+      expect(existsSync(runtimePath)).toBe(true)
+      const content = readFileSync(runtimePath, 'utf8')
+
+      // Used by the component itself.
+      expectHasFn(content, 'createSignal')
+      expectHasFn(content, 'createEffect')
+      // Compiler-injected component scaffolding every 'use client' component
+      // needs, regardless of what the source imports.
+      expectHasFn(content, 'createComponent')
+      expectHasFn(content, 'hydrate')
+      // Always-kept public mount API, even though no compiled component
+      // calls it directly.
+      expectHasFn(content, 'render')
+      expectHasFn(content, 'setupStreaming')
+      // Not used anywhere and not always-kept — tree-shaken out.
+      expectLacksFn(content, 'onMount')
+      expectLacksFn(content, 'onCleanup')
+      expectLacksFn(content, 'createMemo')
+      expectLacksFn(content, 'createPortal')
+      expectLacksFn(content, 'reconcileList')
+
+      // And it's meaningfully smaller than the full runtime.
+      expect(content.length).toBeLessThan(readFileSync(REAL_DIST, 'utf8').length / 2)
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+      rmSync(outDir, { recursive: true, force: true })
+    }
+  })
+
+  test("runtimeBundle: 'full' copies the entire dist verbatim", async () => {
+    const projectDir = makeTmpDir('full-src')
+    const outDir = makeTmpDir('full-out')
+    try {
+      writeFixtureDist(projectDir)
+      writeComponent(projectDir, 'Counter', ['createSignal'])
+
+      const result = await build(makeConfig(projectDir, outDir, { runtimeBundle: 'full' }))
+      expect(result.errorCount).toBe(0)
+
+      const content = readFileSync(resolve(outDir, 'components/barefoot.js'), 'utf8')
+      // Every runtime export present, including ones nothing imports.
+      for (const name of ['onMount', 'onCleanup', 'createMemo', 'createPortal', 'reconcileList']) {
+        expectHasFn(content, name)
+      }
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+      rmSync(outDir, { recursive: true, force: true })
+    }
+  })
+
+  test('runtimeKeep force-keeps extra names beyond what compiled components import', async () => {
+    const projectDir = makeTmpDir('keep-src')
+    const outDir = makeTmpDir('keep-out')
+    try {
+      writeFixtureDist(projectDir)
+      writeComponent(projectDir, 'Counter', ['createSignal'])
+
+      const result = await build(makeConfig(projectDir, outDir, { runtimeKeep: ['createPortal'] }))
+      expect(result.errorCount).toBe(0)
+
+      const content = readFileSync(resolve(outDir, 'components/barefoot.js'), 'utf8')
+      expectHasFn(content, 'createPortal')
+      // Still tree-shaken: an unrelated, non-kept name stays out.
+      expectLacksFn(content, 'createMemo')
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+      rmSync(outDir, { recursive: true, force: true })
+    }
+  })
+
+  // A `'use client'` component's own compiled output never contains a
+  // namespace/default/dynamic import of the runtime — the compiler
+  // statically recognizes reactive-primitive usage (even written as
+  // `bf.createSignal(...)` through a namespace import) and regenerates its
+  // own normalized named-import codegen regardless of how the source wrote
+  // it. The unsafe shapes this collector guards against are only reachable
+  // through code the compiler doesn't rewrite: a `bundleEntries` script
+  // (bundled by esbuild with `@barefootjs/client*` kept external, so
+  // whatever import shape the author wrote survives verbatim).
+  test('falls back to a full copy when a bundleEntries script uses an unsafe import shape (namespace import)', async () => {
+    const projectDir = makeTmpDir('unsafe-src')
+    const outDir = makeTmpDir('unsafe-out')
+    try {
+      writeFixtureDist(projectDir)
+      writeComponent(projectDir, 'Counter', ['createSignal'])
+      const clientDir = resolve(projectDir, 'client')
+      mkdirSync(clientDir, { recursive: true })
+      writeFileSync(
+        resolve(clientDir, 'router-entry.ts'),
+        `import * as bf from '@barefootjs/client/runtime'\n` +
+          `bf.setupStreaming()\n`,
+      )
+
+      const result = await build(makeConfig(projectDir, outDir, {
+        bundleEntries: [{ entry: resolve(clientDir, 'router-entry.ts'), outfile: 'router-entry.js' }],
+      }))
+      expect(result.errorCount).toBe(0)
+
+      const content = readFileSync(resolve(outDir, 'components/barefoot.js'), 'utf8')
+      // Fell back to full copy — every runtime export present, including
+      // ones neither the component nor the router entry ever names directly.
+      expectHasFn(content, 'onMount')
+      expectHasFn(content, 'createMemo')
+      expectHasFn(content, 'createPortal')
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+      rmSync(outDir, { recursive: true, force: true })
+    }
+  })
+
+  test('no prebuilt dist found: warns and leaves barefoot.js unwritten rather than crashing', async () => {
+    const projectDir = makeTmpDir('nodist-src')
+    const outDir = makeTmpDir('nodist-out')
+    try {
+      // Deliberately do NOT call writeFixtureDist — no node_modules/@barefootjs/client.
+      writeComponent(projectDir, 'Counter', ['createSignal'])
+
+      const result = await build(makeConfig(projectDir, outDir))
+      expect(result.errorCount).toBe(0)
+      expect(existsSync(resolve(outDir, 'components/barefoot.js'))).toBe(false)
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+      rmSync(outDir, { recursive: true, force: true })
+    }
+  })
+
+  test('incremental rebuild: unchanged imports keep a stable runtimeKeepHash; a newly-imported export regenerates barefoot.js', async () => {
+    const projectDir = makeTmpDir('incr-src')
+    const outDir = makeTmpDir('incr-out')
+    try {
+      writeFixtureDist(projectDir)
+      writeComponent(projectDir, 'Counter', ['createSignal'])
+
+      const first = await build(makeConfig(projectDir, outDir))
+      expect(first.errorCount).toBe(0)
+      const firstContent = readFileSync(resolve(outDir, 'components/barefoot.js'), 'utf8')
+      expectLacksFn(firstContent, 'onMount')
+      const cacheAfterFirst = await loadCache(outDir)
+      expect(cacheAfterFirst?.runtimeKeepHash).toBeTruthy()
+
+      // No-op rebuild: same source, same dist. The keep-hash should be
+      // stable (nothing that would change barefoot.js's contents changed).
+      const second = await build(makeConfig(projectDir, outDir))
+      expect(second.errorCount).toBe(0)
+      const cacheAfterSecond = await loadCache(outDir)
+      expect(cacheAfterSecond?.runtimeKeepHash).toBe(cacheAfterFirst?.runtimeKeepHash)
+
+      // Now a component starts importing something new. This doesn't touch
+      // barefoot.config.ts, so `globalHash` is unchanged — the runtime
+      // regen has to be driven by the collected keep-set changing, not by
+      // cache invalidation.
+      writeComponent(projectDir, 'Counter', ['createSignal', 'onMount'])
+      const third = await build(makeConfig(projectDir, outDir))
+      expect(third.errorCount).toBe(0)
+      const thirdContent = readFileSync(resolve(outDir, 'components/barefoot.js'), 'utf8')
+      expectHasFn(thirdContent, 'onMount')
+      const cacheAfterThird = await loadCache(outDir)
+      expect(cacheAfterThird?.runtimeKeepHash).not.toBe(cacheAfterSecond?.runtimeKeepHash)
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+      rmSync(outDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/cli/src/__tests__/build-runtime-treeshake.test.ts
+++ b/packages/cli/src/__tests__/build-runtime-treeshake.test.ts
@@ -27,9 +27,26 @@ function makeTmpDir(label: string) {
 // asserts tree-shaking against real, un-minified `function <name>` bodies.
 const REAL_DIST = resolve(__dirname, '../../../client/dist/runtime/standalone.js')
 
+// Self-sufficient on a clean checkout: build @barefootjs/client's dist once
+// if it isn't there yet (CI jobs and fresh clones may run this suite before
+// any package build). One-time cost, skipped entirely when dist exists.
+if (!existsSync(REAL_DIST)) {
+  const proc = Bun.spawnSync({
+    cmd: ['bun', 'run', 'build'],
+    cwd: resolve(__dirname, '../../../client'),
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  if (proc.exitCode !== 0 || !existsSync(REAL_DIST)) {
+    throw new Error(
+      `failed to build packages/client for the runtime-treeshake integration tests:\n${proc.stderr.toString()}`,
+    )
+  }
+}
+
 function writeFixtureDist(projectDir: string): void {
   if (!existsSync(REAL_DIST)) {
-    throw new Error(`${REAL_DIST} not found — run \`bun run build\` in packages/client first`)
+    throw new Error(`${REAL_DIST} not found even after building packages/client`)
   }
   const runtimeDir = resolve(projectDir, 'node_modules/@barefootjs/client/dist/runtime')
   mkdirSync(runtimeDir, { recursive: true })

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -1062,7 +1062,7 @@ describe('processBundleEntries', () => {
       const config = makeConfig(outDir, outDir)
       const cache: BuildCache = emptyCache('global-hash')
       const nextEntries: Record<string, CacheEntry> = {}
-      const changed = await processBundleEntries(config, outDir, 'components', [], cache, nextEntries, false)
+      const { changed } = await processBundleEntries(config, outDir, 'components', [], cache, nextEntries, false)
       expect(changed).toBe(false)
       expect(Object.keys(nextEntries).length).toBe(0)
     } finally {
@@ -1085,7 +1085,7 @@ describe('processBundleEntries', () => {
       const cache: BuildCache = emptyCache('global-hash')
       const nextEntries: Record<string, CacheEntry> = {}
 
-      const changed = await processBundleEntries(config, outDir, 'components', [], cache, nextEntries, false)
+      const { changed } = await processBundleEntries(config, outDir, 'components', [], cache, nextEntries, false)
       expect(changed).toBe(true)
 
       const outPath = resolve(outDir, 'entry.js')
@@ -1134,7 +1134,7 @@ describe('processBundleEntries', () => {
       // allExternals is empty (no `externals` config), yet the bundler must
       // still leave every `@barefootjs/client*` import external rather than
       // trying to inline/resolve them — otherwise the reactive runtime forks.
-      const changed = await processBundleEntries(config, outDir, 'components', [], cache, nextEntries, false)
+      const { changed } = await processBundleEntries(config, outDir, 'components', [], cache, nextEntries, false)
       expect(changed).toBe(true)
 
       const outContent = readFileSync(resolve(outDir, 'entry.js'), 'utf8')
@@ -1173,7 +1173,7 @@ describe('processBundleEntries', () => {
       const cache2: BuildCache = { globalHash: 'global-hash', entries: entries1 }
       const entries2: Record<string, CacheEntry> = {}
       await new Promise((r) => setTimeout(r, 20)) // ensure a distinguishable mtime if rebuilt
-      const changed = await processBundleEntries(config, outDir, 'components', [], cache2, entries2, false)
+      const { changed } = await processBundleEntries(config, outDir, 'components', [], cache2, entries2, false)
 
       expect(changed).toBe(false)
       const mtime2 = statSync(outPath).mtimeMs
@@ -1212,7 +1212,7 @@ describe('processBundleEntries', () => {
 
       const cache2: BuildCache = { globalHash: 'global-hash', entries: entries1 }
       const entries2: Record<string, CacheEntry> = {}
-      const changed = await processBundleEntries(config, outDir, 'components', [], cache2, entries2, false)
+      const { changed } = await processBundleEntries(config, outDir, 'components', [], cache2, entries2, false)
       expect(changed).toBe(true)
 
       const outAfter = readFileSync(resolve(outDir, 'entry.js'), 'utf8')
@@ -1245,7 +1245,7 @@ describe('processBundleEntries', () => {
 
       const cache2: BuildCache = { globalHash: 'global-hash', entries: entries1 }
       const entries2: Record<string, CacheEntry> = {}
-      const changed = await processBundleEntries(config, outDir, 'components', [], cache2, entries2, false)
+      const { changed } = await processBundleEntries(config, outDir, 'components', [], cache2, entries2, false)
       expect(changed).toBe(true)
       expect(existsSync(resolve(outDir, 'entry.js'))).toBe(true)
     } finally {
@@ -1271,7 +1271,7 @@ describe('processBundleEntries', () => {
 
       const cache2: BuildCache = { globalHash: 'global-hash', entries: entries1 }
       const entries2: Record<string, CacheEntry> = {}
-      const changed = await processBundleEntries(config, outDir, 'components', [], cache2, entries2, true)
+      const { changed } = await processBundleEntries(config, outDir, 'components', [], cache2, entries2, true)
       expect(changed).toBe(true)
     } finally {
       rmSync(projectDir, { recursive: true, force: true })

--- a/packages/cli/src/__tests__/runtime-treeshake.test.ts
+++ b/packages/cli/src/__tests__/runtime-treeshake.test.ts
@@ -210,7 +210,6 @@ describe('buildRuntimeBundle', () => {
       const entrySource = writeFixtureRuntime(dir)
       const bundled = await buildRuntimeBundle({
         entrySource,
-        workingDir: dir,
         keepNames: ['keepMe', 'alsoKeepMe'],
         minify: false,
       })
@@ -229,13 +228,11 @@ describe('buildRuntimeBundle', () => {
       const entrySource = writeFixtureRuntime(dir)
       const unminified = await buildRuntimeBundle({
         entrySource,
-        workingDir: dir,
         keepNames: ['keepMe'],
         minify: false,
       })
       const bundled = await buildRuntimeBundle({
         entrySource,
-        workingDir: dir,
         keepNames: ['keepMe'],
         minify: true,
       })
@@ -253,14 +250,17 @@ describe('buildRuntimeBundle', () => {
     }
   })
 
-  test('cleans up its temp entry file after bundling', async () => {
+  test('writes no temp entry file at all (stdin-fed entry)', async () => {
+    // The entry is fed to esbuild via stdin + resolveDir (also the
+    // cross-platform fix: no absolute path inside a module specifier), so
+    // the dist directory must stay untouched apart from the fixture itself.
     const dir = makeTmpDir('cleanup')
     try {
       const entrySource = writeFixtureRuntime(dir)
-      await buildRuntimeBundle({ entrySource, workingDir: dir, keepNames: ['keepMe'], minify: false })
+      await buildRuntimeBundle({ entrySource, keepNames: ['keepMe'], minify: false })
       const { readdirSync } = await import('fs')
-      const leftover = readdirSync(dir).filter(f => f.startsWith('.bf-runtime-entry-'))
-      expect(leftover).toEqual([])
+      const entries = readdirSync(dir)
+      expect(entries).toEqual([entrySource.split('/').pop()])
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }
@@ -271,7 +271,7 @@ describe('buildRuntimeBundle', () => {
     try {
       const entrySource = writeFixtureRuntime(dir)
       await expect(
-        buildRuntimeBundle({ entrySource, workingDir: dir, keepNames: [], minify: false })
+        buildRuntimeBundle({ entrySource, keepNames: [], minify: false })
       ).rejects.toThrow()
     } finally {
       rmSync(dir, { recursive: true, force: true })

--- a/packages/cli/src/__tests__/runtime-treeshake.test.ts
+++ b/packages/cli/src/__tests__/runtime-treeshake.test.ts
@@ -1,0 +1,280 @@
+import { describe, test, expect } from 'bun:test'
+import { mkdirSync, rmSync, realpathSync, writeFileSync } from 'fs'
+import { resolve } from 'path'
+import { tmpdir } from 'os'
+import {
+  ALWAYS_KEEP_RUNTIME_EXPORTS,
+  buildRuntimeBundle,
+  collectUsedRuntimeExports,
+  isBarefootClientSpecifier,
+  mergeRuntimeImportCollections,
+} from '../lib/runtime-treeshake'
+
+// ── isBarefootClientSpecifier ────────────────────────────────────────────
+
+describe('isBarefootClientSpecifier', () => {
+  test('matches the bare package and every subpath', () => {
+    expect(isBarefootClientSpecifier('@barefootjs/client')).toBe(true)
+    expect(isBarefootClientSpecifier('@barefootjs/client/runtime')).toBe(true)
+    expect(isBarefootClientSpecifier('@barefootjs/client/reactive')).toBe(true)
+    expect(isBarefootClientSpecifier('@barefootjs/client/build')).toBe(true)
+  })
+
+  test('does not match unrelated or partially-overlapping specifiers', () => {
+    expect(isBarefootClientSpecifier('@barefootjs/chart')).toBe(false)
+    expect(isBarefootClientSpecifier('@barefootjs/client-extra')).toBe(false)
+    expect(isBarefootClientSpecifier('some-other-package')).toBe(false)
+  })
+})
+
+// ── collectUsedRuntimeExports ────────────────────────────────────────────
+
+describe('collectUsedRuntimeExports', () => {
+  test('collects named imports from the bare package specifier', () => {
+    const result = collectUsedRuntimeExports(
+      `import { createSignal, createEffect } from '@barefootjs/client'\ncreateSignal(0)\n`
+    )
+    expect([...result.names].sort()).toEqual(['createEffect', 'createSignal'])
+    expect(result.unsafe).toBe(false)
+  })
+
+  test('collects named imports from /runtime and /reactive subpaths', () => {
+    const a = collectUsedRuntimeExports(`import { hydrate } from '@barefootjs/client/runtime'\n`)
+    const b = collectUsedRuntimeExports(`import { createMemo } from '@barefootjs/client/reactive'\n`)
+    expect([...a.names]).toEqual(['hydrate'])
+    expect([...b.names]).toEqual(['createMemo'])
+  })
+
+  test('resolves aliased named imports to the original (imported) name', () => {
+    const result = collectUsedRuntimeExports(
+      `import { createSignal as sig } from '@barefootjs/client'\n`
+    )
+    expect([...result.names]).toEqual(['createSignal'])
+  })
+
+  test('handles a multi-line import clause with a trailing comma', () => {
+    const code = [
+      `import {`,
+      `  createSignal,`,
+      `  createEffect,`,
+      `  onMount,`,
+      `} from '@barefootjs/client'`,
+      ``,
+    ].join('\n')
+    expect([...collectUsedRuntimeExports(code).names].sort()).toEqual(['createEffect', 'createSignal', 'onMount'])
+  })
+
+  test('ignores `import type` (type-only imports contribute nothing at runtime)', () => {
+    const result = collectUsedRuntimeExports(
+      `import type { Signal } from '@barefootjs/client'\n`
+    )
+    expect(result.names.size).toBe(0)
+    expect(result.unsafe).toBe(false)
+  })
+
+  test('ignores individually-marked type-only named bindings', () => {
+    const result = collectUsedRuntimeExports(
+      `import { createSignal, type Signal } from '@barefootjs/client'\n`
+    )
+    expect([...result.names]).toEqual(['createSignal'])
+  })
+
+  test('does not false-match a specifier that only appears inside a comment', () => {
+    const result = collectUsedRuntimeExports(
+      `// import { createEffect } from '@barefootjs/client'\nconst x = 1\n`
+    )
+    expect(result.names.size).toBe(0)
+    expect(result.unsafe).toBe(false)
+  })
+
+  test('does not false-match a specifier that only appears inside a string literal', () => {
+    const result = collectUsedRuntimeExports(
+      `const snippet = "import { createEffect } from '@barefootjs/client'"\n`
+    )
+    expect(result.names.size).toBe(0)
+    expect(result.unsafe).toBe(false)
+  })
+
+  test('side-effect import contributes no names and is not unsafe', () => {
+    const result = collectUsedRuntimeExports(`import '@barefootjs/client/runtime'\n`)
+    expect(result.names.size).toBe(0)
+    expect(result.unsafe).toBe(false)
+  })
+
+  test('flags a namespace import as unsafe', () => {
+    const result = collectUsedRuntimeExports(`import * as bf from '@barefootjs/client'\nbf.createSignal(0)\n`)
+    expect(result.unsafe).toBe(true)
+    expect(result.reasons[0]).toContain('namespace import')
+  })
+
+  test('flags a default import as unsafe', () => {
+    const result = collectUsedRuntimeExports(`import bf from '@barefootjs/client'\n`)
+    expect(result.unsafe).toBe(true)
+    expect(result.reasons[0]).toContain('default import')
+  })
+
+  test('flags a default import combined with named bindings as unsafe (and still collects the named ones)', () => {
+    const result = collectUsedRuntimeExports(`import bf, { createSignal } from '@barefootjs/client'\n`)
+    expect(result.unsafe).toBe(true)
+    expect([...result.names]).toEqual(['createSignal'])
+  })
+
+  test('flags a dynamic import() of the runtime as unsafe', () => {
+    const result = collectUsedRuntimeExports(`async function f() { const m = await import('@barefootjs/client/runtime'); m.hydrate() }\n`)
+    expect(result.unsafe).toBe(true)
+    expect(result.reasons[0]).toContain('dynamic import')
+  })
+
+  test('ignores imports from unrelated packages entirely', () => {
+    const result = collectUsedRuntimeExports(
+      `import { z } from 'zod'\nimport { Button } from '@ui/components/ui/button'\n`
+    )
+    expect(result.names.size).toBe(0)
+    expect(result.unsafe).toBe(false)
+  })
+
+  test('a source with no @barefootjs/client text short-circuits cleanly', () => {
+    const result = collectUsedRuntimeExports(`export function f() { return 1 }\n`)
+    expect(result.names.size).toBe(0)
+    expect(result.unsafe).toBe(false)
+  })
+})
+
+// ── mergeRuntimeImportCollections ────────────────────────────────────────
+
+describe('mergeRuntimeImportCollections', () => {
+  test('unions names across collections', () => {
+    const a = collectUsedRuntimeExports(`import { createSignal } from '@barefootjs/client'\n`)
+    const b = collectUsedRuntimeExports(`import { createEffect } from '@barefootjs/client'\n`)
+    const merged = mergeRuntimeImportCollections([a, b])
+    expect([...merged.names].sort()).toEqual(['createEffect', 'createSignal'])
+    expect(merged.unsafe).toBe(false)
+  })
+
+  test('propagates unsafe + reasons from any collection', () => {
+    const safe = collectUsedRuntimeExports(`import { createSignal } from '@barefootjs/client'\n`)
+    const unsafe = collectUsedRuntimeExports(`import * as bf from '@barefootjs/client'\n`)
+    const merged = mergeRuntimeImportCollections([safe, unsafe])
+    expect(merged.unsafe).toBe(true)
+    expect(merged.reasons.length).toBe(1)
+    expect([...merged.names]).toEqual(['createSignal'])
+  })
+
+  test('merging zero collections is safe and empty', () => {
+    const merged = mergeRuntimeImportCollections([])
+    expect(merged.names.size).toBe(0)
+    expect(merged.unsafe).toBe(false)
+  })
+})
+
+// ── ALWAYS_KEEP_RUNTIME_EXPORTS ──────────────────────────────────────────
+
+describe('ALWAYS_KEEP_RUNTIME_EXPORTS', () => {
+  test('covers the documented public mount API', () => {
+    for (const name of ['render', 'hydrate', 'flushHydration', 'rehydrateAll', 'rehydrateScope', 'disposeScope', 'setupStreaming']) {
+      expect(ALWAYS_KEEP_RUNTIME_EXPORTS).toContain(name)
+    }
+  })
+})
+
+// ── buildRuntimeBundle ───────────────────────────────────────────────────
+
+describe('buildRuntimeBundle', () => {
+  function makeTmpDir(label: string) {
+    const dir = resolve(tmpdir(), `bf-test-runtime-bundle-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+    mkdirSync(dir, { recursive: true })
+    return realpathSync(dir)
+  }
+
+  // A tiny synthetic "runtime dist" with several independent, side-effect-free
+  // top-level exports — enough to prove esbuild's DCE drops unreferenced ones
+  // without needing the real (much larger) @barefootjs/client dist file.
+  function writeFixtureRuntime(dir: string): string {
+    const path = resolve(dir, 'fixture-runtime.js')
+    writeFileSync(
+      path,
+      [
+        `export function keepMe() { return 'kept-fn-body-marker' }`,
+        `export function alsoKeepMe() { return 'also-kept-fn-body-marker' }`,
+        `export function dropMe() { return 'dropped-fn-body-marker' }`,
+        `export function alsoDropMe() { return 'also-dropped-fn-body-marker' }`,
+        ``,
+      ].join('\n'),
+    )
+    return path
+  }
+
+  test('keeps only the requested exports (and drops the rest via DCE)', async () => {
+    const dir = makeTmpDir('basic')
+    try {
+      const entrySource = writeFixtureRuntime(dir)
+      const bundled = await buildRuntimeBundle({
+        entrySource,
+        workingDir: dir,
+        keepNames: ['keepMe', 'alsoKeepMe'],
+        minify: false,
+      })
+      expect(bundled).toContain('kept-fn-body-marker')
+      expect(bundled).toContain('also-kept-fn-body-marker')
+      expect(bundled).not.toContain('dropped-fn-body-marker')
+      expect(bundled).not.toContain('also-dropped-fn-body-marker')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('minify: true minifies whitespace/syntax/identifiers but keeps the exported binding name stable', async () => {
+    const dir = makeTmpDir('minify')
+    try {
+      const entrySource = writeFixtureRuntime(dir)
+      const unminified = await buildRuntimeBundle({
+        entrySource,
+        workingDir: dir,
+        keepNames: ['keepMe'],
+        minify: false,
+      })
+      const bundled = await buildRuntimeBundle({
+        entrySource,
+        workingDir: dir,
+        keepNames: ['keepMe'],
+        minify: true,
+      })
+      expect(bundled).toContain('kept-fn-body-marker')
+      // The minified bundle is meaningfully smaller (whitespace + internal
+      // identifiers minified) than the unminified one...
+      expect(bundled.length).toBeLessThan(unminified.length)
+      // ...yet the *exported* binding name is untouched — esbuild never
+      // renames a re-export's public name, only its internal implementation
+      // — so a consumer's `import { keepMe } from './barefoot.js'` still
+      // resolves correctly regardless of internal minification.
+      expect(bundled).toMatch(/\bkeepMe\b/)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('cleans up its temp entry file after bundling', async () => {
+    const dir = makeTmpDir('cleanup')
+    try {
+      const entrySource = writeFixtureRuntime(dir)
+      await buildRuntimeBundle({ entrySource, workingDir: dir, keepNames: ['keepMe'], minify: false })
+      const { readdirSync } = await import('fs')
+      const leftover = readdirSync(dir).filter(f => f.startsWith('.bf-runtime-entry-'))
+      expect(leftover).toEqual([])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('rejects an empty keep set rather than emitting a syntactically-invalid entry', async () => {
+    const dir = makeTmpDir('empty')
+    try {
+      const entrySource = writeFixtureRuntime(dir)
+      await expect(
+        buildRuntimeBundle({ entrySource, workingDir: dir, keepNames: [], minify: false })
+      ).rejects.toThrow()
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/cli/src/lib/build-cache.ts
+++ b/packages/cli/src/lib/build-cache.ts
@@ -35,6 +35,17 @@ export interface BuildCache {
    *  ships with it) implicitly discards the old cache. */
   globalHash: string
   entries: Record<string, CacheEntry>
+  /**
+   * Hash of the tree-shaken runtime's inputs (the collected used-export set,
+   * `runtimeBundle` mode, `minify`, and the source runtime dist file's own
+   * content hash) from the last build that actually regenerated
+   * `barefoot.js`. Lets an incremental build skip re-bundling the runtime
+   * when nothing that would change its contents has changed, while still
+   * regenerating it the moment a component starts (or stops) importing
+   * something — even though that component's own recompile doesn't bump
+   * `globalHash`. See `packages/cli/src/lib/runtime-treeshake.ts`.
+   */
+  runtimeKeepHash?: string
 }
 
 /** Hash a string for cache-equality checks. Short hex is plenty. */

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -1026,7 +1026,6 @@ export async function build(
           try {
             const bundled = await buildRuntimeBundle({
               entrySource: domDistFile,
-              workingDir: runtimeOutDir,
               keepNames,
               minify: config.minify,
             })

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -33,6 +33,13 @@ import {
 } from './assets-ignore'
 import { fileExists, hashBytes, readBytes, readText, transpile } from './runtime'
 import { build as esbuildBuild } from 'esbuild'
+import {
+  ALWAYS_KEEP_RUNTIME_EXPORTS,
+  buildRuntimeBundle,
+  collectUsedRuntimeExports,
+  mergeRuntimeImportCollections,
+  type RuntimeImportCollection,
+} from './runtime-treeshake'
 
 export { resolveRelativeImports } from './resolve-imports'
 
@@ -71,6 +78,31 @@ export interface BuildConfig {
    * tsconfig `paths` aliases). Forwarded to `compileJSX`.
    */
   localImportPrefixes?: string[]
+  /**
+   * How to produce `barefoot.js`:
+   *   - `'treeshake'` (default) — bundle only the `@barefootjs/client*`
+   *     exports this project's compiled client JS (plus `bundleEntries` and
+   *     rebundled `externals` chunks) actually imports, plus the
+   *     always-kept public mount API (`ALWAYS_KEEP_RUNTIME_EXPORTS` in
+   *     `./runtime-treeshake.ts`). Falls back to `'full'` for this build,
+   *     with a console warning, if collection hits an import shape it can't
+   *     safely narrow (namespace import, default import, or dynamic
+   *     `import()` of the runtime) or if no prebuilt runtime dist file can
+   *     be found to bundle from.
+   *   - `'full'` — copy the entire prebuilt runtime bundle verbatim, as
+   *     `bf build` always did before per-project tree-shaking.
+   */
+  runtimeBundle?: 'treeshake' | 'full'
+  /**
+   * Extra `@barefootjs/client*` export names to force-keep in `barefoot.js`
+   * under `runtimeBundle: 'treeshake'`, on top of whatever the collector
+   * finds and the always-kept public mount API. Use this for names only
+   * ever referenced from hand-written page scripts the CLI never compiles
+   * (an inline `<script type="module">` calling `hydrate()` directly, a
+   * hand-rolled router bootstrap, etc.) that aren't already covered by
+   * `ALWAYS_KEEP_RUNTIME_EXPORTS`.
+   */
+  runtimeKeep?: string[]
 }
 
 export interface BuildResult {
@@ -240,7 +272,7 @@ export function generateHash(content: string): string {
  */
 export function resolveBuildConfigFromTs(
   projectDir: string,
-  tsConfig: { adapter: TemplateAdapter; components?: string[]; outDir?: string; minify?: boolean; contentHash?: boolean; clientOnly?: boolean; transformMarkedTemplate?: (content: string, componentId: string, clientJsPath: string) => string; outputLayout?: OutputLayout; postBuild?: (ctx: PostBuildContext) => Promise<void> | void; externals?: Record<string, ExternalSpec>; externalsBasePath?: string; bundleEntries?: BundleEntry[]; localImportPrefixes?: string[] },
+  tsConfig: { adapter: TemplateAdapter; components?: string[]; outDir?: string; minify?: boolean; contentHash?: boolean; clientOnly?: boolean; transformMarkedTemplate?: (content: string, componentId: string, clientJsPath: string) => string; outputLayout?: OutputLayout; postBuild?: (ctx: PostBuildContext) => Promise<void> | void; externals?: Record<string, ExternalSpec>; externalsBasePath?: string; bundleEntries?: BundleEntry[]; localImportPrefixes?: string[]; runtimeBundle?: 'treeshake' | 'full'; runtimeKeep?: string[] },
   overrides?: { minify?: boolean }
 ): BuildConfig {
   const componentDirs = (tsConfig.components ?? ['components']).map(
@@ -267,6 +299,8 @@ export function resolveBuildConfigFromTs(
       externals: e.externals,
     })),
     localImportPrefixes: tsConfig.localImportPrefixes,
+    runtimeBundle: tsConfig.runtimeBundle,
+    runtimeKeep: tsConfig.runtimeKeep,
   }
 }
 
@@ -422,11 +456,14 @@ export async function build(
   const previousEmitEntries: Record<string, string[]> =
     loadedLedger?.entries ?? extractLedgerFromCache(onDiskCache)
 
-  // 1. Runtime file — copy the standalone runtime bundle (reactive inlined)
-  //    to barefoot.js. The sibling `./runtime` entry keeps
-  //    `@barefootjs/client/reactive` as an external import so downstream
-  //    bundlers can dedupe it against the main entry; when we ship a file
-  //    for the browser to load directly, we need the self-contained build.
+  // 1. Locate the prebuilt runtime dist file (reactive inlined) that
+  //    `barefoot.js` gets produced from — either copied verbatim
+  //    (`runtimeBundle: 'full'`) or bundled down to only the exports this
+  //    project uses (`runtimeBundle: 'treeshake'`, the default; see step 6d).
+  //    The sibling `./runtime` entry keeps `@barefootjs/client/reactive` as
+  //    an external import so downstream bundlers can dedupe it against the
+  //    main entry; when we ship a file for the browser to load directly, we
+  //    need the self-contained build.
   const domPkgDir = resolve(config.projectDir, 'node_modules/@barefootjs/client')
   const domDistCandidates = [
     resolve(config.projectDir, '../../packages/client/dist/runtime/standalone.js'),
@@ -447,33 +484,44 @@ export async function build(
     }
   }
 
-  if (domDistFile) {
-    const runtimeOutPath = resolve(runtimeOutDir, 'barefoot.js')
-    let runtimeContent: string | Uint8Array
-    if (config.minify) {
-      // Minify at copy time so the minify pass below doesn't need to touch
-      // barefoot.js (keeping it out of the per-build write loop).
-      runtimeContent = transpile(await readText(domDistFile), { loader: 'js', minify: true })
+  const runtimeMode: 'treeshake' | 'full' = config.runtimeBundle ?? 'treeshake'
+
+  if (runtimeMode === 'full') {
+    if (domDistFile) {
+      const runtimeOutPath = resolve(runtimeOutDir, 'barefoot.js')
+      let runtimeContent: string | Uint8Array
+      if (config.minify) {
+        // Minify at copy time so the minify pass below doesn't need to touch
+        // barefoot.js (keeping it out of the per-build write loop).
+        runtimeContent = transpile(await readText(domDistFile), { loader: 'js', minify: true })
+      } else {
+        runtimeContent = await readBytes(domDistFile)
+      }
+      const wrote = await writeIfChanged(runtimeOutPath, runtimeContent)
+      if (wrote) {
+        anyOutputChanged = true
+        console.log(`Generated: ${runtimeSubdir}/barefoot.js`)
+      }
     } else {
-      runtimeContent = await readBytes(domDistFile)
+      console.warn('Warning: @barefootjs/client dist not found. Skipping barefoot.js copy.')
     }
-    const wrote = await writeIfChanged(runtimeOutPath, runtimeContent)
-    if (wrote) {
-      anyOutputChanged = true
-      console.log(`Generated: ${runtimeSubdir}/barefoot.js`)
-    }
-  } else {
-    console.warn('Warning: @barefootjs/client dist not found. Skipping barefoot.js copy.')
   }
+  // `runtimeMode === 'treeshake'`: barefoot.js is produced at step 6d, once
+  // every component's (and bundleEntries'/externals') final client JS is
+  // known, so the used-export collection sees everything.
 
   // 1b. Externals — copy vendor chunks, emit importmap + barefoot-externals.json
-  const { changed: externalsChanged, allExternals } = await processExternals(config, runtimeSubdir, runtimeOutDir)
+  const { changed: externalsChanged, allExternals, outfiles: externalOutfiles } =
+    await processExternals(config, runtimeSubdir, runtimeOutDir)
   if (externalsChanged) anyOutputChanged = true
 
-  // 1c. bundleEntries entries — bundle with esbuild using auto-applied externals
-  if (await processBundleEntries(config, clientJsOutDir, clientJsSubdir, allExternals, cache, nextEntries, force)) {
-    anyOutputChanged = true
-  }
+  // 1c. bundleEntries entries — bundle with esbuild using auto-applied externals.
+  // (Its outputs land in `nextEntries` via the cache row below, same as
+  // component entries — step 6d's scan picks them up from there, so the
+  // return value here only needs `changed`.)
+  const { changed: bundleEntriesChanged } =
+    await processBundleEntries(config, clientJsOutDir, clientJsSubdir, allExternals, cache, nextEntries, force)
+  if (bundleEntriesChanged) anyOutputChanged = true
 
   // 2. Discover component files
   const allFiles: string[] = []
@@ -890,6 +938,121 @@ export async function build(
     }
   }
 
+  // 6d. Runtime bundle — collect the `@barefootjs/client*` exports actually
+  //     used across every emitted client JS file (components, bundleEntries,
+  //     rebundled externals chunks) and bundle `barefoot.js` down to just
+  //     those names plus the always-kept public mount API
+  //     (`ALWAYS_KEEP_RUNTIME_EXPORTS`). Must run BEFORE step 6c below: 6c
+  //     rewrites `@barefootjs/client*` specifiers to a relative
+  //     `./barefoot.js` path, and the collector's AST walk matches on the
+  //     original bare specifier.
+  //
+  //     Scans `nextEntries` (every current-build source's recorded
+  //     `outputs`) rather than `manifest`: in `clientOnly` (CSR) projects —
+  //     the primary target of tree-shaking, since there's no SSR template to
+  //     pair a component's client JS with — `compileEntry` never populates
+  //     `manifestKey`/`manifestEntry` (see its `!config.clientOnly &&
+  //     markedTemplates.length > 0` gate), so `manifest` only ever has the
+  //     `__barefoot__` sentinel row. `outputs` is recorded unconditionally
+  //     whenever a source produced client JS, cache-hit or freshly compiled,
+  //     so filtering it to `.js` paths (marked templates use the adapter's
+  //     own extension, never `.js`) finds every component's compiled output
+  //     in both modes. `bundleEntries` outputs are included via this same
+  //     path (`processBundleEntries` records them in `nextEntries` too); only
+  //     `externals` chunks need adding separately, since those aren't
+  //     source-driven cache entries.
+  let runtimeKeepHash: string | undefined = cache.runtimeKeepHash
+  if (runtimeMode === 'treeshake') {
+    if (!domDistFile) {
+      console.warn('Warning: @barefootjs/client dist not found. Skipping barefoot.js generation.')
+      runtimeKeepHash = undefined
+    } else {
+      const scanTargets: string[] = [...externalOutfiles]
+      for (const entry of Object.values(nextEntries)) {
+        for (const rel of entry.outputs) {
+          if (rel.endsWith('.js')) scanTargets.push(resolve(config.outDir, rel))
+        }
+      }
+      const collections: RuntimeImportCollection[] = []
+      for (const filePath of scanTargets) {
+        try {
+          collections.push(collectUsedRuntimeExports(await readText(filePath), relative(config.outDir, filePath)))
+        } catch {
+          // File may not exist (e.g. a manifest entry whose write failed
+          // this run) — nothing to scan, not a tree-shake safety concern.
+        }
+      }
+      const merged = mergeRuntimeImportCollections(collections)
+      const runtimeOutPath = resolve(runtimeOutDir, 'barefoot.js')
+
+      if (merged.unsafe) {
+        // Fallback safety: an import shape the collector can't safely
+        // narrow (namespace import, default import, or a dynamic
+        // `import()`) was seen somewhere. Ship the full runtime rather than
+        // risk stripping an export that's actually reachable through it.
+        for (const reason of merged.reasons) {
+          console.warn(`Warning: runtime tree-shake — falling back to full runtime copy (${reason})`)
+        }
+        let runtimeContent: string | Uint8Array
+        if (config.minify) {
+          runtimeContent = transpile(await readText(domDistFile), { loader: 'js', minify: true })
+        } else {
+          runtimeContent = await readBytes(domDistFile)
+        }
+        if (await writeIfChanged(runtimeOutPath, runtimeContent)) {
+          anyOutputChanged = true
+          console.log(`Generated: ${runtimeSubdir}/barefoot.js (full copy — see warning above)`)
+        }
+        runtimeKeepHash = undefined
+      } else {
+        const keepNames = new Set<string>([
+          ...ALWAYS_KEEP_RUNTIME_EXPORTS,
+          ...(config.runtimeKeep ?? []),
+          ...merged.names,
+        ])
+        const distBytes = await readBytes(domDistFile)
+        const nextKeepHash = hashContent(JSON.stringify({
+          mode: runtimeMode,
+          minify: config.minify,
+          distHash: hashBytes(distBytes),
+          keep: [...keepNames].sort(),
+        }))
+
+        if (nextKeepHash === cache.runtimeKeepHash && await fileExists(runtimeOutPath)) {
+          // Nothing that would change barefoot.js's contents has changed —
+          // skip re-invoking esbuild.
+          runtimeKeepHash = nextKeepHash
+        } else {
+          try {
+            const bundled = await buildRuntimeBundle({
+              entrySource: domDistFile,
+              workingDir: runtimeOutDir,
+              keepNames,
+              minify: config.minify,
+            })
+            if (await writeIfChanged(runtimeOutPath, bundled)) {
+              anyOutputChanged = true
+              console.log(`Generated: ${runtimeSubdir}/barefoot.js (tree-shaken: ${keepNames.size} exports kept)`)
+            }
+            runtimeKeepHash = nextKeepHash
+          } catch (err) {
+            console.warn(
+              `Warning: runtime tree-shake bundling failed (${(err as Error).message}); falling back to full runtime copy.`
+            )
+            const runtimeContent: string | Uint8Array = config.minify
+              ? transpile(new TextDecoder().decode(distBytes), { loader: 'js', minify: true })
+              : distBytes
+            if (await writeIfChanged(runtimeOutPath, runtimeContent)) {
+              anyOutputChanged = true
+              console.log(`Generated: ${runtimeSubdir}/barefoot.js (full copy — see warning above)`)
+            }
+            runtimeKeepHash = undefined
+          }
+        }
+      }
+    }
+  }
+
   // 6c. Normalize @barefootjs/client* specifiers to the relative barefoot.js
   //     path so the per-source dedup below can collapse multiple specifiers
   //     pointing at the same runtime (watch-rebuild remnants, #1148-hoisted
@@ -971,6 +1134,7 @@ export async function build(
   const nextCache: BuildCache = {
     globalHash,
     entries: nextEntries,
+    runtimeKeepHash,
   }
   const nextLedger: EmitLedger = emptyLedger()
   for (const [key, entry] of Object.entries(nextEntries)) {
@@ -1413,20 +1577,28 @@ export type { ExternalsManifest } from '@barefootjs/jsx'
 /**
  * Process the `externals` config: copy vendor chunks to outDir, build the
  * importmap JSON, and write `barefoot-externals.json`.
- * Returns whether any output file changed and the full list of external package names.
+ * Returns whether any output file changed, the full list of external package
+ * names, and the local chunk file paths written (for the runtime tree-shake
+ * collector at step 6d — a vendor package that itself imports
+ * `@barefootjs/client*` keeps that import as a literal specifier in its
+ * emitted chunk, since `rebundleExternalsFor`/the plain-copy path both leave
+ * `@barefootjs/client*` unbundled).
  */
 export async function processExternals(
   config: BuildConfig,
   runtimeSubdir: string,
   runtimeOutDir: string,
-): Promise<{ changed: boolean; allExternals: string[] }> {
-  if (!config.externals || Object.keys(config.externals).length === 0) return { changed: false, allExternals: [] }
+): Promise<{ changed: boolean; allExternals: string[]; outfiles: string[] }> {
+  if (!config.externals || Object.keys(config.externals).length === 0) {
+    return { changed: false, allExternals: [], outfiles: [] }
+  }
 
   const basePath = config.externalsBasePath ?? `/${runtimeSubdir}/`
   const base = basePath.endsWith('/') ? basePath : basePath + '/'
 
   const imports: Record<string, string> = {}
   const preloads: string[] = []
+  const outfiles: string[] = []
   let anyChanged = false
 
   for (const [pkgName, spec] of Object.entries(config.externals)) {
@@ -1454,6 +1626,7 @@ export async function processExternals(
       const srcFile = entry.path
       const filename = vendorChunkFilename(pkgName)
       const destPath = resolve(runtimeOutDir, filename)
+      outfiles.push(destPath)
 
       if (wantRebundle) {
         await esbuildBuild({
@@ -1538,7 +1711,7 @@ export async function processExternals(
     }
   }
 
-  return { changed: anyChanged, allExternals }
+  return { changed: anyChanged, allExternals, outfiles }
 }
 
 /**
@@ -1551,6 +1724,12 @@ export async function processExternals(
  * esbuild's metafile on first build (project-local files only — node_modules
  * and externals are excluded). On subsequent runs, the entry is rebuilt only
  * if the source or any dep hash has changed, or the output file is missing.
+ *
+ * `outfiles` in the return value lists every entry's output path (cache-hit
+ * or freshly built) so the runtime tree-shake collector at step 6d can scan
+ * them too — `@barefootjs/client*` is always kept external here (see below),
+ * so a bundle entry like `client/router-entry.ts` importing `setupStreaming`
+ * from `@barefootjs/client/runtime` keeps that import verbatim in its output.
  */
 export async function processBundleEntries(
   config: BuildConfig,
@@ -1560,10 +1739,11 @@ export async function processBundleEntries(
   cache: BuildCache,
   nextEntries: Record<string, CacheEntry>,
   force: boolean,
-): Promise<boolean> {
-  if (!config.bundleEntries || config.bundleEntries.length === 0) return false
+): Promise<{ changed: boolean; outfiles: string[] }> {
+  if (!config.bundleEntries || config.bundleEntries.length === 0) return { changed: false, outfiles: [] }
 
   let anyChanged = false
+  const outfiles: string[] = []
   for (const entry of config.bundleEntries) {
     // `@barefootjs/client*` is always external for bundled entries: in a
     // BarefootJS app it resolves through the page's import map to the same
@@ -1575,6 +1755,7 @@ export async function processBundleEntries(
       ...new Set([...BF_CLIENT_DEDUP_KEYS, ...allExternals, ...(entry.externals ?? [])]),
     ]
     const outfilePath = resolve(clientJsOutDir, entry.outfile)
+    outfiles.push(outfilePath)
     const absEntry = resolve(entry.entry)
     const cacheKey = `${BUNDLE_KEY_PREFIX}${absEntry}`
 
@@ -1641,7 +1822,7 @@ export async function processBundleEntries(
       manifestKey: null,
     }
   }
-  return anyChanged
+  return { changed: anyChanged, outfiles }
 }
 
 // ── Cross-file child-shape pre-pass ──────────────────────────────────────

--- a/packages/cli/src/lib/runtime-treeshake.ts
+++ b/packages/cli/src/lib/runtime-treeshake.ts
@@ -1,0 +1,221 @@
+// Per-project tree-shaking of the client runtime bundle (`barefoot.js`).
+//
+// `bf build` compiles every component's client JS against the full
+// `@barefootjs/client/runtime` surface, but a given project only ever calls
+// a fraction of it. This module collects the *named* runtime imports that
+// actually appear across a project's emitted client JS (components,
+// `bundleEntries`, rebundled `externals` chunks) so `build.ts` can bundle a
+// `barefoot.js` containing only those exports (plus an always-kept public
+// mount API — see `ALWAYS_KEEP_RUNTIME_EXPORTS`) instead of shipping the
+// entire runtime verbatim.
+//
+// Per CLAUDE.md: never parse imports with regex. This walks the TypeScript
+// AST over top-level statements, the same pattern `shapeFromDecl` in
+// `resolve-imports.ts` uses — so multi-line import clauses, `import type`,
+// and specifiers that merely appear inside a comment or string literal are
+// all handled correctly instead of false-matching.
+//
+// Bundling itself uses `esbuild` (already a runtime dependency of this
+// package, and already used elsewhere in `build.ts` for `bundleEntries` /
+// rebundled `externals`), not `Bun.build` — `packages/cli/src/lib/runtime.ts`
+// exists specifically so the published CLI runs unchanged under a plain
+// Node runtime (see its docstring), and `Bun.build` is Bun-only.
+
+import ts from 'typescript'
+import { unlink } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { build as esbuildBuild } from 'esbuild'
+import { writeText } from './runtime'
+
+/** True for `@barefootjs/client`, `@barefootjs/client/runtime`, `@barefootjs/client/reactive`, and any other `@barefootjs/client/*` subpath. */
+export function isBarefootClientSpecifier(spec: string): boolean {
+  return spec === '@barefootjs/client' || spec.startsWith('@barefootjs/client/')
+}
+
+export interface RuntimeImportCollection {
+  /** Original (imported, not local-alias) export names referenced via a named import. */
+  names: Set<string>
+  /**
+   * True when an import shape was seen that this collector cannot safely
+   * narrow — a namespace import (`import * as ns from '@barefootjs/client'`),
+   * a default import, or a dynamic `import('@barefootjs/client...')` call.
+   * Any of these can reach an arbitrary subset of the runtime through a
+   * binding this walk can't enumerate, so the caller should fall back to
+   * shipping the full runtime rather than risk stripping something used.
+   */
+  unsafe: boolean
+  /** Human-readable reasons `unsafe` was set (one per occurrence), for logging. */
+  reasons: string[]
+}
+
+function emptyCollection(): RuntimeImportCollection {
+  return { names: new Set(), unsafe: false, reasons: [] }
+}
+
+/**
+ * Walk one emitted client JS (or bundled entry) file's AST and collect the
+ * named `@barefootjs/client*` imports it references.
+ *
+ * `sourceLabel` is used only for diagnostics (parse-failure / unsafe-import
+ * messages), not for resolution.
+ */
+export function collectUsedRuntimeExports(code: string, sourceLabel = '<input>'): RuntimeImportCollection {
+  const result = emptyCollection()
+
+  // Nothing to walk if the specifier text doesn't even appear — cheap
+  // short-circuit for the common case (most files) before paying for a
+  // full AST parse. Mirrors the pre-scan in `mergeDuplicateNamedImports`.
+  if (!code.includes('@barefootjs/client')) return result
+
+  let sourceFile: ts.SourceFile
+  try {
+    sourceFile = ts.createSourceFile(sourceLabel, code, ts.ScriptTarget.Latest, /*setParentNodes*/ false, ts.ScriptKind.JS)
+  } catch (err) {
+    result.unsafe = true
+    result.reasons.push(`failed to parse ${sourceLabel}: ${(err as Error).message}`)
+    return result
+  }
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isImportDeclaration(node)) {
+      const spec = node.moduleSpecifier
+      if (ts.isStringLiteral(spec) && isBarefootClientSpecifier(spec.text)) {
+        const clause = node.importClause
+        if (!clause) {
+          // Side-effect import (`import '@barefootjs/client/runtime'`) — no
+          // bindings to collect, and not a safety concern.
+        } else if (clause.isTypeOnly) {
+          // `import type { ... } from '@barefootjs/client'` — erased at
+          // runtime, contributes nothing to the used set.
+        } else if (clause.namedBindings && ts.isNamedImports(clause.namedBindings)) {
+          for (const el of clause.namedBindings.elements) {
+            if (el.isTypeOnly) continue
+            const imported = (el.propertyName ?? el.name).text
+            result.names.add(imported)
+          }
+          // A named-import clause can *also* carry a default binding
+          // (`import D, { a } from '...'`) — check that too.
+          if (clause.name) {
+            result.unsafe = true
+            result.reasons.push(`default import of "${spec.text}" in ${sourceLabel}`)
+          }
+        } else if (clause.namedBindings && ts.isNamespaceImport(clause.namedBindings)) {
+          result.unsafe = true
+          result.reasons.push(`namespace import (* as ${clause.namedBindings.name.text}) of "${spec.text}" in ${sourceLabel}`)
+        } else if (clause.name) {
+          result.unsafe = true
+          result.reasons.push(`default import of "${spec.text}" in ${sourceLabel}`)
+        }
+      }
+    } else if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword
+    ) {
+      const arg = node.arguments[0]
+      if (arg && ts.isStringLiteral(arg) && isBarefootClientSpecifier(arg.text)) {
+        result.unsafe = true
+        result.reasons.push(`dynamic import("${arg.text}") in ${sourceLabel}`)
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
+
+  return result
+}
+
+/** Union multiple per-file collections into one. */
+export function mergeRuntimeImportCollections(collections: Iterable<RuntimeImportCollection>): RuntimeImportCollection {
+  const merged = emptyCollection()
+  for (const c of collections) {
+    for (const n of c.names) merged.names.add(n)
+    if (c.unsafe) {
+      merged.unsafe = true
+      merged.reasons.push(...c.reasons)
+    }
+  }
+  return merged
+}
+
+/**
+ * Public mount API that hand-written page scripts use directly (resolved at
+ * the browser through the importmap, so invisible to this collector — it
+ * only sees *compiled* client JS). Always kept regardless of what the scan
+ * finds. Derived from the runtime entries real pages in this repo import
+ * directly: `render`/`hydrate`/`flushHydration`/`rehydrateAll`/
+ * `rehydrateScope`/`disposeScope` (CSR + SSR page bootstraps),
+ * `setupStreaming` (every `client/router-entry.ts` across `integrations/*`),
+ * and `createSearchParams` (router v0.5 request-scoped env signal, created
+ * from page-level router wiring rather than a compiled component).
+ */
+export const ALWAYS_KEEP_RUNTIME_EXPORTS: readonly string[] = [
+  'render',
+  'hydrate',
+  'flushHydration',
+  'rehydrateAll',
+  'rehydrateScope',
+  'disposeScope',
+  'setupStreaming',
+  'createSearchParams',
+]
+
+export interface BuildRuntimeBundleOptions {
+  /** Absolute path to the prebuilt runtime dist file to re-export from. */
+  entrySource: string
+  /** Directory the temp entry file is written into (also esbuild's working dir). */
+  workingDir: string
+  /** Names to re-export from `entrySource`. */
+  keepNames: Iterable<string>
+  minify: boolean
+}
+
+/**
+ * Bundle a `barefoot.js` containing only `keepNames` (plus whatever they
+ * transitively pull in) from `entrySource`, using esbuild's own
+ * dead-code elimination. Returns the bundled source text; does not write it
+ * anywhere — the caller decides the output path and whether to
+ * `writeIfChanged`.
+ */
+export async function buildRuntimeBundle(opts: BuildRuntimeBundleOptions): Promise<string> {
+  const { entrySource, workingDir, keepNames, minify } = opts
+  const sorted = [...new Set(keepNames)].sort()
+  if (sorted.length === 0) {
+    throw new Error('buildRuntimeBundle: keepNames is empty')
+  }
+  const entryContents = `export { ${sorted.join(', ')} } from ${JSON.stringify(entrySource)}\n`
+  const entryPath = resolve(workingDir, `.bf-runtime-entry-${process.pid}-${Date.now()}.mjs`)
+  await writeText(entryPath, entryContents)
+  try {
+    const result = await esbuildBuild({
+      entryPoints: [entryPath],
+      format: 'esm',
+      bundle: true,
+      // Unlike `transpile()`'s policy for per-component client JS
+      // (packages/cli/src/lib/runtime.ts — identifiers preserved there so
+      // e.g. `hydrate('ComponentName', ...)` call-site names and combine.ts's
+      // cross-file lookups stay intact), `barefoot.js` is a self-contained
+      // leaf artifact loaded only via the importmap: nothing parses its
+      // source for internal identifier names, and esbuild always keeps
+      // *exported* binding names stable regardless of `minifyIdentifiers`
+      // (verified: a re-export entry's `export { keepMe } from '...'` still
+      // exports as `keepMe` even when the internal implementation is renamed).
+      // So full minification is safe here and meaningfully smaller.
+      minify,
+      treeShaking: true,
+      platform: 'browser',
+      write: false,
+    })
+    const out = result.outputFiles?.[0]
+    if (!out) {
+      throw new Error('esbuild produced no output for the runtime bundle')
+    }
+    return out.text
+  } finally {
+    try {
+      await unlink(entryPath)
+    } catch {
+      // best-effort cleanup; a leftover temp file next to barefoot.js is
+      // harmless and gets overwritten/ignored on the next build
+    }
+  }
+}

--- a/packages/cli/src/lib/runtime-treeshake.ts
+++ b/packages/cli/src/lib/runtime-treeshake.ts
@@ -22,10 +22,8 @@
 // Node runtime (see its docstring), and `Bun.build` is Bun-only.
 
 import ts from 'typescript'
-import { unlink } from 'node:fs/promises'
-import { resolve } from 'node:path'
+import { basename, dirname } from 'node:path'
 import { build as esbuildBuild } from 'esbuild'
-import { writeText } from './runtime'
 
 /** True for `@barefootjs/client`, `@barefootjs/client/runtime`, `@barefootjs/client/reactive`, and any other `@barefootjs/client/*` subpath. */
 export function isBarefootClientSpecifier(spec: string): boolean {
@@ -162,8 +160,6 @@ export const ALWAYS_KEEP_RUNTIME_EXPORTS: readonly string[] = [
 export interface BuildRuntimeBundleOptions {
   /** Absolute path to the prebuilt runtime dist file to re-export from. */
   entrySource: string
-  /** Directory the temp entry file is written into (also esbuild's working dir). */
-  workingDir: string
   /** Names to re-export from `entrySource`. */
   keepNames: Iterable<string>
   minify: boolean
@@ -175,47 +171,46 @@ export interface BuildRuntimeBundleOptions {
  * dead-code elimination. Returns the bundled source text; does not write it
  * anywhere — the caller decides the output path and whether to
  * `writeIfChanged`.
+ *
+ * The re-export entry is fed to esbuild via `stdin` with `resolveDir` set to
+ * the dist file's directory and a plain `./<basename>` specifier — no temp
+ * file, and no absolute path embedded in a module specifier (a Windows
+ * absolute path inside `from "..."` is not portable across resolvers).
  */
 export async function buildRuntimeBundle(opts: BuildRuntimeBundleOptions): Promise<string> {
-  const { entrySource, workingDir, keepNames, minify } = opts
+  const { entrySource, keepNames, minify } = opts
   const sorted = [...new Set(keepNames)].sort()
   if (sorted.length === 0) {
     throw new Error('buildRuntimeBundle: keepNames is empty')
   }
-  const entryContents = `export { ${sorted.join(', ')} } from ${JSON.stringify(entrySource)}\n`
-  const entryPath = resolve(workingDir, `.bf-runtime-entry-${process.pid}-${Date.now()}.mjs`)
-  await writeText(entryPath, entryContents)
-  try {
-    const result = await esbuildBuild({
-      entryPoints: [entryPath],
-      format: 'esm',
-      bundle: true,
-      // Unlike `transpile()`'s policy for per-component client JS
-      // (packages/cli/src/lib/runtime.ts — identifiers preserved there so
-      // e.g. `hydrate('ComponentName', ...)` call-site names and combine.ts's
-      // cross-file lookups stay intact), `barefoot.js` is a self-contained
-      // leaf artifact loaded only via the importmap: nothing parses its
-      // source for internal identifier names, and esbuild always keeps
-      // *exported* binding names stable regardless of `minifyIdentifiers`
-      // (verified: a re-export entry's `export { keepMe } from '...'` still
-      // exports as `keepMe` even when the internal implementation is renamed).
-      // So full minification is safe here and meaningfully smaller.
-      minify,
-      treeShaking: true,
-      platform: 'browser',
-      write: false,
-    })
-    const out = result.outputFiles?.[0]
-    if (!out) {
-      throw new Error('esbuild produced no output for the runtime bundle')
-    }
-    return out.text
-  } finally {
-    try {
-      await unlink(entryPath)
-    } catch {
-      // best-effort cleanup; a leftover temp file next to barefoot.js is
-      // harmless and gets overwritten/ignored on the next build
-    }
+  const entryContents = `export { ${sorted.join(', ')} } from ${JSON.stringify(`./${basename(entrySource)}`)}\n`
+  const result = await esbuildBuild({
+    stdin: {
+      contents: entryContents,
+      resolveDir: dirname(entrySource),
+      sourcefile: 'bf-runtime-entry.mjs',
+      loader: 'js',
+    },
+    format: 'esm',
+    bundle: true,
+    // Unlike `transpile()`'s policy for per-component client JS
+    // (packages/cli/src/lib/runtime.ts — identifiers preserved there so
+    // e.g. `hydrate('ComponentName', ...)` call-site names and combine.ts's
+    // cross-file lookups stay intact), `barefoot.js` is a self-contained
+    // leaf artifact loaded only via the importmap: nothing parses its
+    // source for internal identifier names, and esbuild always keeps
+    // *exported* binding names stable regardless of `minifyIdentifiers`
+    // (verified: a re-export entry's `export { keepMe } from '...'` still
+    // exports as `keepMe` even when the internal implementation is renamed).
+    // So full minification is safe here and meaningfully smaller.
+    minify,
+    treeShaking: true,
+    platform: 'browser',
+    write: false,
+  })
+  const out = result.outputFiles?.[0]
+  if (!out) {
+    throw new Error('esbuild produced no output for the runtime bundle')
   }
+  return out.text
 }

--- a/packages/client/src/build.ts
+++ b/packages/client/src/build.ts
@@ -58,6 +58,20 @@ export interface CSRBuildOptions {
   adapter?: TemplateAdapter
   /** Options forwarded to the default `CSRAdapter`. Ignored when `adapter` is set. */
   adapterOptions?: CSRAdapterOptions
+  /**
+   * How the CLI produces `barefoot.js`. Defaults to `'treeshake'`, which
+   * bundles only the runtime exports this project's compiled client JS
+   * actually imports (plus the always-kept public mount API). Set to
+   * `'full'` to copy the entire prebuilt runtime bundle verbatim, matching
+   * pre-tree-shaking behavior.
+   */
+  runtimeBundle?: 'treeshake' | 'full'
+  /**
+   * Extra `@barefootjs/client*` export names to force-keep in `barefoot.js`
+   * under `runtimeBundle: 'treeshake'` — for names only ever referenced
+   * from hand-written page scripts the CLI never compiles.
+   */
+  runtimeKeep?: string[]
 }
 
 /**
@@ -85,6 +99,8 @@ export function createConfig(options: CSRBuildOptions = {}) {
     bundleEntries: options.bundleEntries,
     outputLayout: options.outputLayout,
     postBuild: options.postBuild,
+    runtimeBundle: options.runtimeBundle,
+    runtimeKeep: options.runtimeKeep,
   }
 }
 

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -266,6 +266,22 @@ export interface BuildOptions {
    * Forwarded to `compileJSX` as `CompileOptions.localImportPrefixes`.
    */
   localImportPrefixes?: string[]
+  /**
+   * How the CLI produces `barefoot.js` (the client runtime bundle):
+   *   - `'treeshake'` (default) — bundle only the runtime exports this
+   *     project's compiled client JS actually imports, plus a small
+   *     always-kept public mount API (`render`, `hydrate`, etc.).
+   *   - `'full'` — copy the entire prebuilt runtime bundle verbatim.
+   * See `@barefootjs/cli`'s `runtime-treeshake.ts` for the collector and
+   * `ALWAYS_KEEP_RUNTIME_EXPORTS` for the always-kept names.
+   */
+  runtimeBundle?: 'treeshake' | 'full'
+  /**
+   * Extra `@barefootjs/client*` export names to force-keep in `barefoot.js`
+   * under `runtimeBundle: 'treeshake'` — for names only ever referenced
+   * from hand-written page scripts the CLI never compiles.
+   */
+  runtimeKeep?: string[]
 }
 
 // AttrValue constructors


### PR DESCRIPTION
# Summary

`bf build` previously copied the **entire** prebuilt client runtime (~66KB raw / ~17KB gzip) to `dist` as `barefoot.js`, regardless of what the project actually used. The build now ships only what the app imports: **benchmark-app shipped JS drops from 19.4KB to 8.7KB gzip** (total, `barefoot.js` alone 19.1KB raw / 7.0KB gzip) — closing most of the gap to SolidJS's 6.8KB in the fair-comparison suite.

## How it works

1. **Collect used exports**: after all components compile, walk every emitted client JS module's top-level import declarations with the TypeScript AST (per the repo convention — no regex; same pattern as `resolve-imports.ts`) and take the union of named imports of `@barefootjs/client*`. Covers component client JS, `bundleEntries` outputs, and externals chunks.
2. **Always keep the public mount API** that hand-written page scripts use via the importmap and the CLI can't see: `render`, `hydrate`, `flushHydration`, `rehydrateAll`, `rehydrateScope`, `disposeScope`, `setupStreaming`, `createSearchParams` — derived by auditing every real page script in the repo (CSR pages, all integrations' router entries, SSR bootstraps).
3. **Bundle** a generated re-export entry with esbuild (already a CLI dependency; keeps the CLI runnable under plain Node). DCE effectiveness on the flat dist bundle was measured to match bundling from per-module sources, so the existing dist resolution is reused in every installation layout.
4. **Safety valves**: `runtimeBundle: 'treeshake' | 'full'` (default `treeshake`) and `runtimeKeep: string[]` on the build config; namespace/default/dynamic imports of the runtime in scanned output trigger a loud per-build fallback to the full copy.
5. **Cache-correct**: `runtimeKeepHash` in `.buildcache.json` regenerates `barefoot.js` exactly when the used-export set, minify mode, or runtime dist content changes. Importmap/manifest paths unchanged.

## Verification

| Gate | Result |
|---|---|
| `bun test packages/cli` | 1,235 pass / 0 fail (25 new collector unit tests + 6 integration tests against the real dist) |
| `bun test packages/jsx` / `packages/client` / `packages/adapter-tests` | 2,319 / 400 / 934 pass, 0 fail |
| Benchmark compiled-app smoke | 15/15 (incl. keyed-swap element identity) |
| SSR bench interactivity gate | PASS |
| Full DOM suite | all correctness gates pass; results snapshot refreshed in `benchmarks/README.md` |
| `integrations/csr` e2e | failure set **byte-identical** to unmodified `main` (pre-existing issues; verified by stash A/B) — zero regressions |

## Sizes (benchmark app, dist total JS)

| | raw | gzip |
|---|---|---|
| before | 72.5KB | 19.4KB |
| after | **23.9KB** | **8.7KB** |
| (reference: solid) | 17.3KB | 6.8KB |

## Risks / notes

- An app whose *hand-written* page script imports a runtime name outside both the keep list and its components' imports would need `runtimeKeep` (or `runtimeBundle: 'full'`). The keep list covers every page-script import found in-repo.
- Startup timing in the containerized bench environment was too noisy to attribute a win; bundle size is the reliable signal.
- Changeset included (patch: cli / client / jsx — versioned together).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014a8dS2WiLAPzYyZBVthgg3

---
_Generated by [Claude Code](https://claude.ai/code/session_014a8dS2WiLAPzYyZBVthgg3)_