### PR TITLE
fix(client): render nullish text interpolations as empty, not "undefined" (#2137)

### DIFF
--- a/.changeset/escape-text-nullish-empty.md
+++ b/.changeset/escape-text-nullish-empty.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/client": patch
+---
+
+`escapeText` — the runtime helper that escapes interpolated text content for the initial client render (`<!--bf:sN-->${escapeText(expr)}<!--/-->` slots) — now renders a nullish value as empty text instead of stringifying it into literal `"undefined"` / `"null"`. This matches the JSX/Solid semantics the Hono SSR reference follows (`{undefined}` / `{null}` produce no text) and the reactive text-update path, which already coerces via `String(value ?? '')` (`dynamic-text.ts`, `client-marker.ts`). Previously a bare `{props.x}` reading an absent prop diverged from the server-rendered output at first paint — empty on SSR, literal `"undefined"` on CSR (#2137). Non-nullish values (including `0` and `false`) keep their `String()` form, matching the reactive path.

--- a/packages/adapter-tests/fixtures/untyped-props-reads.ts
+++ b/packages/adapter-tests/fixtures/untyped-props-reads.ts
@@ -11,13 +11,10 @@ import { createFixture } from '../src/types'
 // condition, empty list, seeded signal default) purely from the compiler's
 // own seeding — nothing is supplied at the call site.
 //
-// The label read carries a `?? ''` fallback: the strict-var coverage is
-// identical (the template still references the bare `$label` scalar —
-// existence, not value, is what strict mode checks), but a BARE
-// `{props.label}` diverges on the CSR runtime, which stringifies the raw
-// `undefined` into literal "undefined" text where Hono renders ''. That
-// divergence is a separate client-runtime semantic, not this fixture's
-// subject.
+// The bare `{props.label}` text read (no `?? ''` fallback) doubles as the
+// CSR regression pin for #2137: a nullish text interpolation must render
+// as empty text on every path, including the CSR runtime that used to
+// stringify `undefined` into literal "undefined".
 export const fixture = createFixture({
   id: 'untyped-props-reads',
   description:
@@ -29,7 +26,7 @@ export function UntypedReads(props) {
   const [count, setCount] = createSignal(props.initial ?? 0)
   return (
     <div>
-      <p>{props.label ?? ''}</p>
+      <p>{props.label}</p>
       {props.show && <span>visible</span>}
       <ul>{(props.items ?? []).map((it) => <li key={it}>{it}</li>)}</ul>
       <button onClick={() => setCount(count() + 1)}>count: {count()}</button>

--- a/packages/adapter-tests/src/csr-render.ts
+++ b/packages/adapter-tests/src/csr-render.ts
@@ -257,8 +257,10 @@ const escapeAttr = (value) =>
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
 // Mirror @barefootjs/client/runtime escapeText: text-content escaping uses
-// the same set as attributes (Hono escapes text identically), so delegate.
-const escapeText = (value) => escapeAttr(value)
+// the same set as attributes (Hono escapes text identically). A nullish
+// value renders as empty text (JSX/Solid semantics; #2137) — otherwise a
+// bare \`{props.x}\` on an absent prop would surface literal "undefined".
+const escapeText = (value) => value == null ? '' : escapeAttr(value)
 // Mirror @barefootjs/client/runtime/spread-attrs.ts: format a record of
 // attributes as an HTML attribute string for use inside template literals.
 // The real runtime helper is imported by generated client JS, but the

--- a/packages/client/__tests__/runtime/escape-text.test.ts
+++ b/packages/client/__tests__/runtime/escape-text.test.ts
@@ -34,13 +34,21 @@ describe('escapeText', () => {
     expect(escapeText('count: 0')).toBe('count: 0')
   })
 
-  test('coerces non-string values via String()', () => {
+  test('coerces non-nullish non-string values via String()', () => {
     expect(escapeText(0)).toBe('0')
-    expect(escapeText(undefined)).toBe('undefined')
-    expect(escapeText(null)).toBe('null')
+    // `false` keeps its String() form, matching the reactive text path
+    // (`dynamic-text.ts` is nullish-only via `?? ''`).
+    expect(escapeText(false)).toBe('false')
   })
 
-  test('is byte-identical to escapeAttr (Hono escapes both contexts alike)', () => {
+  test('renders nullish as empty text (#2137)', () => {
+    // JSX/Solid semantics + the Hono SSR reference: `{undefined}` / `{null}`
+    // produce no text. Matches the reactive update path (`String(value ?? '')`).
+    expect(escapeText(undefined)).toBe('')
+    expect(escapeText(null)).toBe('')
+  })
+
+  test('is byte-identical to escapeAttr for non-nullish values (Hono escapes both contexts alike)', () => {
     const samples = ['a&b<c>d"e\'f', 'plain', '<script>', "O'Brien & co"]
     for (const s of samples) expect(escapeText(s)).toBe(escapeAttr(s))
   })

--- a/packages/client/src/runtime/component.ts
+++ b/packages/client/src/runtime/component.ts
@@ -463,12 +463,23 @@ export function escapeAttr(value: unknown): string {
  * slots). The HTML spec only requires `& < >` in text, but the SSR
  * adapters (Hono) escape text with the same set as attribute values
  * (`& " ' < >`), and the fixture-hydrate / CSR-conformance layer requires
- * byte-parity with the server-rendered output — so this delegates to
- * `escapeAttr`. Kept as a distinct export so generated code reads
+ * byte-parity with the server-rendered output — so the escaping delegates
+ * to `escapeAttr`. Kept as a distinct export so generated code reads
  * `escapeText(...)` at text sites (self-documenting) and so the two
- * contexts can diverge later without touching call sites.
+ * contexts can diverge (as they now do for nullish) without touching call
+ * sites.
+ *
+ * A nullish value renders as empty text — the JSX/Solid semantics the Hono
+ * SSR reference follows (`{undefined}` / `{null}` produce no text), and
+ * what the reactive text-update path already does (`dynamic-text.ts` and
+ * `client-marker.ts` both `String(value ?? '')`). Only this initial-render
+ * escape site used to stringify `undefined` / `null` into literal
+ * "undefined" / "null" text, so a bare `{props.x}` on an absent prop
+ * diverged from SSR at first paint (#2137). Non-nullish values (including
+ * `0` and `false`) keep their `String()` form, matching the reactive path.
  */
 export function escapeText(value: unknown): string {
+  if (value == null) return ''
   return escapeAttr(value)
 }
 


### PR DESCRIPTION
Closes #2137. Found while building the `untyped-props-reads` fixture for #2136.

## The bug

`escapeText` — the client runtime helper that escapes interpolated text content for the **initial** render's text slots (`<!--bf:sN-->${escapeText(expr)}<!--/-->`) — delegated straight to `escapeAttr`, i.e. `String(value)…`. So a nullish value became literal text:

| value | Hono SSR | CSR (before) | CSR (after) |
| --- | --- | --- | --- |
| `undefined` | `` (empty) | `undefined` | `` ✓ |
| `null` | `` (empty) | `null` | `` ✓ |
| `0` | `0` | `0` | `0` |
| `false` | `` (empty) | `false` | `false` |

A bare `{props.x}` reading an absent prop therefore diverged from the server-rendered output at first paint.

## Why this is the right coercion

The fix coerces **nullish** to `''` at the escape site — not booleans — because that's what the codebase's other text paths already do, so initial render and reactive update now agree:

- **Reactive text updates** (`dynamic-text.ts`, `client-marker.ts`) already do `String(value ?? '')` — nullish only. Making the initial escape site match means a signal that starts `undefined` renders empty at first paint *and* stays empty after the first reactive tick, instead of flipping between `"undefined"` and `""`.
- **Child/branch slots** (`__bfSlot`) already drop `null`/`undefined`/`false`/`true` and only call `escapeText` for non-nullish values — unaffected by this change.

`false` still stringifies to `"false"` in the text-slot position (matching the reactive path); that's a separate JSX-boolean-in-text question and dropping it would require changing the reactive path too, so it's deliberately out of scope for this nullish-focused fix.

## Changes

- `escapeText` (packages/client): `value == null ? '' : escapeAttr(value)`.
- Mirror the coercion in the CSR-conformance harness stub (`adapter-tests/src/csr-render.ts`) so the layer reflects real runtime behavior.
- Drop the `?? ''` workaround from the `untyped-props-reads` fixture — the bare `{props.label}` rendered with no props is now the cross-adapter CSR regression pin for this behavior (the workaround was added in #2136 specifically to sidestep this bug).
- Update the `escapeText` unit contract to assert nullish → `''`.

## Tests

- `escape-text.test.ts` unit contract updated + green.
- Full `csr-conformance` suite green (142), including `untyped-props-reads` (now bare `{props.label}`) and `text-escape`.
- `untyped-props-reads` still green on the SSR side against the live Hono reference: mojo, go-template, hono/jsx conformance.
- Full `@barefootjs/client` suite green (401).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DsbC2Pkzb6NZvifEK6GrL

---
_Generated by [Claude Code](https://claude.ai/code/session_019DsbC2Pkzb6NZvifEK6GrL)_