### PR TITLE
Fix PHP Packagist split package names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,8 @@
 #     @barefootjs/erb          RubyGems barefoot_js
 #     @barefootjs/rust         crates.io barefootjs
 #     @barefootjs/twig         Packagist barefootjs/twig (via split mirror)
-#     @barefootjs/php          Packagist barefootjs/runtime (via split mirror,
+#     @barefootjs/blade        Packagist barefootjs/blade (via split mirror)
+#     @barefootjs/php          Packagist barefootjs/php (via split mirror,
 #                              packages/adapter-php -- the engine-agnostic
 #                              runtime shared by the Twig/Blade/... backends)
 
@@ -258,9 +259,9 @@ jobs:
           php-version: '8.2'
           tools: composer
 
-      - name: Validate PHP runtime
+      - name: Validate Twig backend package
         working-directory: packages/adapter-twig/php
-        # NOT --strict: this package intentionally requires barefootjs/runtime
+        # NOT --strict: this package intentionally requires barefootjs/php
         # as an unbound `@dev` constraint (resolved via the `path` repository
         # pointing at ../../adapter-php, see composer.json) so the in-monorepo
         # dependency doesn't need a manually-maintained semver range kept in
@@ -273,7 +274,7 @@ jobs:
             composer test
           fi
 
-      - name: Push PHP runtime split to Packagist mirror
+      - name: Push Twig backend split to Packagist mirror
         env:
           PHP_SPLIT_REPOSITORY: ${{ vars.PHP_SPLIT_REPOSITORY || 'piconic-ai/barefootjs-twig' }}
           PHP_SPLIT_REPO_TOKEN: ${{ secrets.PHP_SPLIT_REPO_TOKEN }}
@@ -284,22 +285,92 @@ jobs:
 
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-          git branch -D php-runtime-release 2>/dev/null || true
-          git subtree split --prefix=packages/adapter-twig/php -b php-runtime-release
+          git branch -D php-twig-release 2>/dev/null || true
+          git subtree split --prefix=packages/adapter-twig/php -b php-twig-release
+
+          split_dir=$(mktemp -d)
+          git worktree add "$split_dir" php-twig-release
+          jq --arg version "$version" 'del(.repositories) | .require["barefootjs/php"] = $version' \
+            "$split_dir/composer.json" > "$split_dir/composer.json.tmp"
+          mv "$split_dir/composer.json.tmp" "$split_dir/composer.json"
+          composer validate --working-dir="$split_dir" --strict
+          git -C "$split_dir" add composer.json
+          git -C "$split_dir" commit -m "chore: prepare barefootjs/twig ${version} for Packagist"
+          split_ref=$(git -C "$split_dir" rev-parse HEAD)
 
           remote="https://x-access-token:${PHP_SPLIT_REPO_TOKEN}@github.com/${PHP_SPLIT_REPOSITORY}.git"
-          git push --force "$remote" php-runtime-release:main
-          git tag -f "v${version}" php-runtime-release
+          git push --force "$remote" "${split_ref}:main"
+          git tag -f "v${version}" "$split_ref"
           git push --force "$remote" "v${version}"
+          git worktree remove "$split_dir" --force
+
+  packagist-blade-release:
+    needs: release
+    if: needs.release.outputs.published == 'true' && contains(fromJSON(needs.release.outputs.publishedPackages).*.name, '@barefootjs/blade')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 # v2
+        with:
+          php-version: '8.2'
+          tools: composer
+
+      - name: Validate Blade backend package
+        working-directory: packages/adapter-blade/php
+        # NOT --strict: this package intentionally requires barefootjs/php
+        # as an unbound `@dev` constraint resolved through the monorepo path
+        # repository, matching the Twig backend package.
+        run: |
+          composer validate
+          composer install --no-interaction --prefer-dist
+          if jq -e '.scripts.test' composer.json > /dev/null 2>&1; then
+            composer test
+          fi
+
+      - name: Push Blade backend split to Packagist mirror
+        env:
+          PHP_BLADE_SPLIT_REPOSITORY: ${{ vars.PHP_BLADE_SPLIT_REPOSITORY || 'piconic-ai/barefootjs-blade' }}
+          PHP_SPLIT_REPO_TOKEN: ${{ secrets.PHP_SPLIT_REPO_TOKEN }}
+        run: |
+          version=$(jq -r '.version' packages/adapter-blade/package.json)
+          test -n "$version"
+          test "$version" != "null"
+
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git branch -D php-blade-release 2>/dev/null || true
+          git subtree split --prefix=packages/adapter-blade/php -b php-blade-release
+
+          split_dir=$(mktemp -d)
+          git worktree add "$split_dir" php-blade-release
+          jq --arg version "$version" 'del(.repositories) | .require["barefootjs/php"] = $version' \
+            "$split_dir/composer.json" > "$split_dir/composer.json.tmp"
+          mv "$split_dir/composer.json.tmp" "$split_dir/composer.json"
+          composer validate --working-dir="$split_dir" --strict
+          git -C "$split_dir" add composer.json
+          git -C "$split_dir" commit -m "chore: prepare barefootjs/blade ${version} for Packagist"
+          split_ref=$(git -C "$split_dir" rev-parse HEAD)
+
+          remote="https://x-access-token:${PHP_SPLIT_REPO_TOKEN}@github.com/${PHP_BLADE_SPLIT_REPOSITORY}.git"
+          git push --force "$remote" "${split_ref}:main"
+          git tag -f "v${version}" "$split_ref"
+          git push --force "$remote" "v${version}"
+          git worktree remove "$split_dir" --force
+
 
   # Mirrors packagist-release's shape for the engine-agnostic PHP runtime
-  # package (packages/adapter-php, Composer name barefootjs/runtime) --
+  # package (packages/adapter-php, Composer name barefootjs/php) --
   # gated on @barefootjs/php (not @barefootjs/twig) being the package
   # Changesets just published, since the runtime and the Twig backend are
   # versioned/published independently.
   packagist-runtime-release:
     needs: release
-    if: needs.release.outputs.published == 'true' && contains(needs.release.outputs.publishedPackages, '"name":"@barefootjs/php"')
+    if: needs.release.outputs.published == 'true' && contains(fromJSON(needs.release.outputs.publishedPackages).*.name, '@barefootjs/php')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -324,7 +395,7 @@ jobs:
 
       - name: Push PHP runtime split to Packagist mirror
         env:
-          PHP_RUNTIME_SPLIT_REPOSITORY: ${{ vars.PHP_RUNTIME_SPLIT_REPOSITORY || 'piconic-ai/barefootjs-runtime' }}
+          PHP_RUNTIME_SPLIT_REPOSITORY: ${{ vars.PHP_RUNTIME_SPLIT_REPOSITORY || 'piconic-ai/barefootjs-php' }}
           PHP_SPLIT_REPO_TOKEN: ${{ secrets.PHP_SPLIT_REPO_TOKEN }}
         run: |
           version=$(jq -r '.version' packages/adapter-php/package.json)

--- a/docs/core/adapters/php-adapter.md
+++ b/docs/core/adapters/php-adapter.md
@@ -15,7 +15,7 @@ JSX → IR → marked template (.twig / .blade.php) + Component.client.js
                  │
                  ▼
    BarefootJS runtime  ──delegates──▶  pluggable backend
-   (@barefootjs/php, `barefootjs/runtime`)   (Twig | Laravel Blade)
+   (@barefootjs/php, `barefootjs/php`)       (Twig | Laravel Blade)
 ```
 
 ## Two backends, one runtime
@@ -28,7 +28,7 @@ JSX → IR → marked template (.twig / .blade.php) + Component.client.js
 Both compile-time packages emit per-component template files and the shared
 client JS, and both render through the same engine-agnostic PHP runtime
 (`Barefoot\BarefootJS`, shipped by `@barefootjs/php` / Composer package
-`barefootjs/runtime`). The only thing that differs is the **backend**: a tiny
+`barefootjs/php`). The only thing that differs is the **backend**: a tiny
 object that implements the five operations the runtime delegates to.
 
 Both adapters are near-mechanical ports of `@barefootjs/jinja` (the Jinja2
@@ -163,7 +163,7 @@ Both backends share the same hydration-marker contract:
 
 ## PHP runtime
 
-`packages/adapter-php` (Composer package `barefootjs/runtime`, npm package
+`packages/adapter-php` (Composer package `barefootjs/php`, npm package
 `@barefootjs/php`) is a self-contained, engine-agnostic PHP package with no
 template-engine dependency. It implements the `bf` object every emitted
 template calls into: hydration markers, context propagation

--- a/packages/adapter-blade/php/README.md
+++ b/packages/adapter-blade/php/README.md
@@ -11,7 +11,7 @@ runtime as a `$bf` object (`{{ $bf->scope_attr() }}`, `{{ $bf->json($x) }}`,
 
 The engine-agnostic runtime itself (`Barefoot\BarefootJS`, `Evaluator`,
 `SearchParams`, `Json`) lives in a separate package,
-[`packages/adapter-php`](../../adapter-php) (`barefootjs/runtime` on
+[`packages/adapter-php`](../../adapter-php) (`barefootjs/php` on
 Composer) -- see that package's README for the backend contract every PHP
 engine adapter (Twig, Blade, ...) implements.
 
@@ -21,7 +21,7 @@ Packagist-facing repository only for Composer distribution.
 - Source of truth: <https://github.com/piconic-ai/barefootjs/tree/main/packages/adapter-blade/php>
 - Monorepo: <https://github.com/piconic-ai/barefootjs>
 - npm adapter: `@barefootjs/blade`
-- Runtime dependency: `barefootjs/runtime` (`packages/adapter-php`)
+- Runtime dependency: `barefootjs/php` (`packages/adapter-php`)
 
 Do not send implementation pull requests to the Packagist mirror. Send changes to
 the monorepo path above; the release workflow splits this directory and pushes the

--- a/packages/adapter-blade/php/composer.json
+++ b/packages/adapter-blade/php/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "barefootjs/blade",
-    "description": "Laravel Blade rendering backend for the BarefootJS PHP runtime (barefootjs/runtime) -- BladeBackend implements the engine backend contract on illuminate/view standalone (Filesystem + Dispatcher + EngineResolver/BladeCompiler + FileViewFinder + Factory), ported from packages/adapter-twig/php/src/TwigBackend.php (see also the packages/adapter-jinja/python port's JinjaBackend).",
+    "description": "Laravel Blade rendering backend for the BarefootJS PHP runtime (barefootjs/php) -- BladeBackend implements the engine backend contract on illuminate/view standalone (Filesystem + Dispatcher + EngineResolver/BladeCompiler + FileViewFinder + Factory), ported from packages/adapter-twig/php/src/TwigBackend.php (see also the packages/adapter-jinja/python port's JinjaBackend).",
     "type": "library",
     "license": "MIT",
     "authors": [
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=8.2",
         "illuminate/view": "^12.0",
-        "barefootjs/runtime": "@dev"
+        "barefootjs/php": "@dev"
     },
     "repositories": [
         {

--- a/packages/adapter-php/README.md
+++ b/packages/adapter-php/README.md
@@ -39,9 +39,22 @@ templates (`.twig`).
 
 ## Composer
 
-The Packagist distribution name is `barefootjs/runtime`. The npm package
+The Packagist distribution name is `barefootjs/php`. The npm package
 ships the same `src/` so the monorepo integrations can consume it without a
 separate install.
+
+
+This package is maintained in the BarefootJS monorepo and is mirrored to a
+Packagist-facing repository only for Composer distribution.
+
+- Source of truth: <https://github.com/piconic-ai/barefootjs/tree/main/packages/adapter-php>
+- Monorepo: <https://github.com/piconic-ai/barefootjs>
+- npm package: `@barefootjs/php`
+- Composer package: `barefootjs/php`
+
+Do not send implementation pull requests to the Packagist mirror. Send changes to
+the monorepo path above; the release workflow splits this directory and pushes the
+mirror automatically.
 
 ## Tests
 

--- a/packages/adapter-php/composer.json
+++ b/packages/adapter-php/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "barefootjs/runtime",
+    "name": "barefootjs/php",
     "description": "Engine-agnostic PHP runtime for BarefootJS -- the shared BarefootJS.php runtime the Twig, Blade, and other PHP engine adapters bind as a pluggable backend.",
     "type": "library",
     "license": "MIT",

--- a/packages/adapter-twig/php/README.md
+++ b/packages/adapter-twig/php/README.md
@@ -10,7 +10,7 @@ a `bf` object (`{{ bf.scope_attr() }}`, `{{ bf.json(x) }}`,
 
 The engine-agnostic runtime itself (`Barefoot\BarefootJS`, `Evaluator`,
 `SearchParams`, `Json`) lives in a separate package,
-[`packages/adapter-php`](../../adapter-php) (`barefootjs/runtime` on
+[`packages/adapter-php`](../../adapter-php) (`barefootjs/php` on
 Composer) -- see that package's README for the backend contract every PHP
 engine adapter (Twig, Blade, ...) implements.
 
@@ -20,7 +20,7 @@ Packagist-facing repository only for Composer distribution.
 - Source of truth: <https://github.com/piconic-ai/barefootjs/tree/main/packages/adapter-twig/php>
 - Monorepo: <https://github.com/piconic-ai/barefootjs>
 - npm adapter: `@barefootjs/twig`
-- Runtime dependency: `barefootjs/runtime` (`packages/adapter-php`)
+- Runtime dependency: `barefootjs/php` (`packages/adapter-php`)
 
 Do not send implementation pull requests to the Packagist mirror. Send changes to
 the monorepo path above; the release workflow splits this directory and pushes the

--- a/packages/adapter-twig/php/composer.json
+++ b/packages/adapter-twig/php/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "barefootjs/twig",
-    "description": "Twig rendering backend for the BarefootJS PHP runtime (barefootjs/runtime) -- TwigBackend implements the engine backend contract on an autoescaping Twig\\Environment, ported from packages/adapter-perl/lib/BarefootJS/Backend/*.pm (see also the packages/adapter-jinja/python port's JinjaBackend).",
+    "description": "Twig rendering backend for the BarefootJS PHP runtime (barefootjs/php) -- TwigBackend implements the engine backend contract on an autoescaping Twig\\Environment, ported from packages/adapter-perl/lib/BarefootJS/Backend/*.pm (see also the packages/adapter-jinja/python port's JinjaBackend).",
     "type": "library",
     "license": "MIT",
     "authors": [
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=8.2",
         "twig/twig": "^3.10",
-        "barefootjs/runtime": "@dev"
+        "barefootjs/php": "@dev"
     },
     "repositories": [
         {


### PR DESCRIPTION
### Motivation

The Blade adapter and shared PHP runtime work has already landed on `main`, but the follow-up Packagist split configuration still needed to converge on the intended package names and mirror repositories.

### Description

- Rename the shared PHP runtime Composer package from `barefootjs/runtime` to `barefootjs/php` in the monorepo metadata and docs.
- Keep Twig and Blade local development wired to `barefootjs/php: @dev` through the path repository.
- Extend `release.yml` with Twig, Blade, and shared PHP Packagist split jobs using the intended mirrors:
  - `piconic-ai/barefootjs-twig` -> `barefootjs/twig`
  - `piconic-ai/barefootjs-blade` -> `barefootjs/blade`
  - `piconic-ai/barefootjs-php` -> `barefootjs/php`
- Before pushing Twig/Blade split mirrors, remove the local `repositories` entry and replace `barefootjs/php` with the release version.

### Testing

- `git rev-list --left-right --count origin/main...HEAD` -> `0 1`
- `git diff --check origin/main...HEAD`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'yaml ok'"`
- JSON syntax check for all three Composer manifests

Composer CLI is not installed in this local environment, so `composer validate` could not be run here.