### PR TITLE
[stack 2/3] Fix adapter-discovery papercuts in npm create / bf init (#2122)

### DIFF
--- a/.changeset/adapter-discovery-papercuts.md
+++ b/.changeset/adapter-discovery-papercuts.md
@@ -1,0 +1,6 @@
+---
+"@barefootjs/cli": patch
+"create-barefootjs": patch
+---
+
+Adapter discovery: `--list-adapters` prints every adapter id + CSS library option; `--adapter go`/`golang`/`perl` now get a targeted hint naming the concrete adapter ids instead of the generic unknown-adapter error; a failed init no longer leaves an empty target directory behind; adapter/css choices resolved via flags or `--yes` print the same "✔" confirmation lines as the interactive picker.

--- a/packages/cli/src/__tests__/init-flags.test.ts
+++ b/packages/cli/src/__tests__/init-flags.test.ts
@@ -1,0 +1,118 @@
+// Coverage for the adapter-discovery papercuts fixed in #2122:
+//   - `--list-adapters` (offline, works even inside an already-
+//     initialized project directory)
+//   - targeted language-alias hints for `--adapter go`/`perl`/...
+//   - non-interactive "✔ ..." confirmation lines when the adapter/css
+//     choice is resolved via flag rather than the interactive picker
+//
+// All scenarios here are failing-fast or `--css none` paths, so none
+// of them reach the registry probe in `run()` — safe to run offline,
+// same rationale `init-gate.test.ts` documents for the gate checks.
+
+import { describe, test, expect } from 'bun:test'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { tmpdir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+
+const CLI_ENTRY = path.join(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '..',
+  'index.ts',
+)
+
+function mktmp(): string {
+  return mkdtempSync(path.join(tmpdir(), 'bf-init-flags-test-'))
+}
+
+interface RunResult {
+  exitCode: number | null
+  stdout: string
+  stderr: string
+}
+
+function runInit(args: string[], cwd: string): RunResult {
+  const result = spawnSync('bun', [CLI_ENTRY, 'init', ...args], {
+    env: { ...process.env, BAREFOOT_INIT_VIA_CREATE: '1' },
+    encoding: 'utf-8',
+    cwd,
+  })
+  return {
+    exitCode: result.status,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  }
+}
+
+describe('bf init --list-adapters', () => {
+  test('prints every adapter id + the CSS library options and exits 0', () => {
+    const r = runInit(['--list-adapters'], mktmp())
+    expect(r.exitCode).toBe(0)
+    for (const id of ['hono', 'hono-node', 'echo', 'gin', 'chi', 'nethttp', 'mojo', 'xslate', 'csr']) {
+      expect(r.stdout).toContain(id)
+    }
+    expect(r.stdout).toContain('unocss')
+    expect(r.stdout).toContain('none')
+  })
+
+  test('works even when barefoot.config.ts already exists (handled before that guard)', () => {
+    const cwd = mktmp()
+    writeFileSync(path.join(cwd, 'barefoot.config.ts'), 'export default {}')
+    const r = runInit(['--list-adapters'], cwd)
+    expect(r.exitCode).toBe(0)
+    expect(r.stdout).toContain('hono')
+    expect(r.stderr).not.toContain('already exists')
+  })
+})
+
+describe('bf init --adapter <unknown> — language-alias hints', () => {
+  test('"go" points at the Go web-framework adapters', () => {
+    const r = runInit(['--adapter', 'go'], mktmp())
+    expect(r.exitCode).not.toBe(0)
+    expect(r.stderr).toContain('unknown adapter "go"')
+    expect(r.stderr).toContain('echo, gin, chi, nethttp')
+    expect(r.stderr).toContain('--adapter chi')
+  })
+
+  test('"golang" (near-miss) gets the same Go hint', () => {
+    const r = runInit(['--adapter', 'golang'], mktmp())
+    expect(r.exitCode).not.toBe(0)
+    expect(r.stderr).toContain('echo, gin, chi, nethttp')
+  })
+
+  test('"Go" (mixed case) still matches the hint', () => {
+    const r = runInit(['--adapter', 'Go'], mktmp())
+    expect(r.exitCode).not.toBe(0)
+    expect(r.stderr).toContain('echo, gin, chi, nethttp')
+  })
+
+  test('"perl" points at the Perl adapters', () => {
+    const r = runInit(['--adapter', 'perl'], mktmp())
+    expect(r.exitCode).not.toBe(0)
+    expect(r.stderr).toContain('unknown adapter "perl"')
+    expect(r.stderr).toContain('mojo, xslate')
+    expect(r.stderr).toContain('--adapter mojo')
+  })
+
+  test('an unrelated unknown value keeps the generic "Available: ..." error', () => {
+    const r = runInit(['--adapter', 'rust'], mktmp())
+    expect(r.exitCode).not.toBe(0)
+    expect(r.stderr).toContain('unknown adapter "rust"')
+    expect(r.stderr).toContain('Available: hono, hono-node, echo, gin, chi, nethttp, mojo, xslate, csr')
+    // No language-specific hint leaks in for a value that isn't one.
+    expect(r.stderr).not.toContain('web-framework adapters')
+  })
+})
+
+describe('bf init — non-interactive confirmation lines (--yes / explicit flags)', () => {
+  test('an explicit --adapter/--css pair prints the same "✔ ..." lines the interactive picker would', () => {
+    // `--css none` skips the registry probe entirely (no bundled
+    // components to fetch), so this scaffolds fully offline.
+    const cwd = mktmp()
+    const r = runInit(['--adapter', 'csr', '--css', 'none', '--name', 'flagtest'], cwd)
+    expect(r.exitCode).toBe(0)
+    expect(r.stdout).toContain('✔ Choose a framework or runtime CSR')
+    expect(r.stdout).toContain('✔ Choose a CSS library None')
+  })
+})

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -25,7 +25,7 @@ import {
   type AdapterTemplate,
 } from '../lib/templates'
 import { detectPackageManager, commandsFor, testRunnerFor, type PackageManager } from '../lib/pm'
-import { select, SelectCancelled } from '../lib/select'
+import { select, SelectCancelled, confirmationLabel } from '../lib/select'
 import { startSpinner } from '../lib/spinner'
 import { processCssHead, stripUnocssFromScript, stripUnoGitignore } from '../lib/css'
 import {
@@ -121,6 +121,13 @@ function parseFlags(args: string[]): InitFlags {
 // guaranteed to run, so we can't half-scaffold over a populated tree.
 const INIT_GATE_ENV = 'BAREFOOT_INIT_VIA_CREATE'
 
+// Prompt copy shared between the interactive `select()` call and the
+// non-interactive confirmation line printed when the choice is
+// resolved via flag / `--yes` default (see `printSelectConfirmation`
+// below) — keeping both paths' transcripts word-for-word identical.
+const ADAPTER_SELECT_MESSAGE = 'Choose a framework or runtime'
+const CSS_SELECT_MESSAGE = 'Choose a CSS library'
+
 export async function run(args: string[], ctx: CliContext): Promise<void> {
   if (process.env[INIT_GATE_ENV] !== '1') {
     console.error('`bf init` is internal — invoke it via `npm create barefootjs@latest`.')
@@ -130,6 +137,15 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
     console.error('  # or: bun create barefootjs')
     console.error('  # or: pnpm create barefootjs')
     process.exit(1)
+  }
+
+  // `--list-adapters` is a read-only lookup — handled before the
+  // config-exists guard below so it works anywhere (including inside
+  // an already-initialized project directory), but after the gate
+  // above so `bf init` stays strictly internal either way.
+  if (args.includes('--list-adapters')) {
+    printAdapterList()
+    process.exit(0)
   }
 
   const projectDir = process.cwd()
@@ -211,6 +227,18 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
   printAppNextSteps(projectDir, adapter)
 }
 
+// Targeted hints for common language-name inputs that aren't adapter
+// ids themselves — `--adapter go` / `--adapter perl` are the most
+// frequent "papercut" from docs/landing copy that talks about
+// language support ("Go", "Perl") without spelling out which
+// concrete adapter id to pass. Keyed lowercase; looked up
+// case-insensitively so `--adapter Go` / `--adapter GO` also hit.
+const LANGUAGE_ADAPTER_HINTS: Record<string, string> = {
+  go: 'Go apps use one of the Go web-framework adapters: echo, gin, chi, nethttp (e.g. --adapter chi)',
+  golang: 'Go apps use one of the Go web-framework adapters: echo, gin, chi, nethttp (e.g. --adapter chi)',
+  perl: 'Perl apps use one of the Perl adapters: mojo, xslate (e.g. --adapter mojo)',
+}
+
 // Resolve the adapter by precedence: explicit `--adapter` flag (validated)
 // > interactive selector when stdin is a TTY and 2+ adapters are
 // registered > the registry default. The selector itself short-circuits
@@ -219,10 +247,19 @@ export async function run(args: string[], ctx: CliContext): Promise<void> {
 async function resolveAdapter(flag: string | undefined): Promise<string> {
   if (flag) {
     if (!ADAPTERS[flag]) {
-      const known = Object.keys(ADAPTERS).join(', ')
-      console.error(`Error: unknown adapter "${flag}". Available: ${known}`)
+      const hint = LANGUAGE_ADAPTER_HINTS[flag.toLowerCase()]
+      if (hint) {
+        console.error(`Error: unknown adapter "${flag}". ${hint}`)
+      } else {
+        const known = Object.keys(ADAPTERS).join(', ')
+        console.error(`Error: unknown adapter "${flag}". Available: ${known}`)
+      }
       process.exit(1)
     }
+    // Non-interactive resolution (explicit flag, or `--yes`'s forwarded
+    // default) still gets a "✔ ..." confirmation line so the transcript
+    // shows what was chosen — same wording the interactive picker uses.
+    printSelectConfirmation(ADAPTER_SELECT_MESSAGE, ADAPTERS[flag])
     return flag
   }
   const options = Object.entries(ADAPTERS).map(([value, t]) => ({
@@ -234,7 +271,7 @@ async function resolveAdapter(flag: string | undefined): Promise<string> {
     // The internal term is "adapter" (matches `--adapter` and the
     // architecture docs), but new users don't have that vocabulary
     // yet — the prompt phrases the choice in user-facing terms.
-    return await select({ message: 'Choose a framework or runtime', options, defaultValue: DEFAULT_ADAPTER })
+    return await select({ message: ADAPTER_SELECT_MESSAGE, options, defaultValue: DEFAULT_ADAPTER })
   } catch (err) {
     bailOnSelectError(err)
   }
@@ -247,13 +284,46 @@ async function resolveCssLibrary(flag: string | undefined): Promise<string> {
       console.error(`Error: unknown CSS library "${flag}". Available: ${known}`)
       process.exit(1)
     }
+    printSelectConfirmation(CSS_SELECT_MESSAGE, CSS_LIBRARIES[flag])
     return flag
   }
   const options = Object.entries(CSS_LIBRARIES).map(([value, t]) => ({ value, label: t.label }))
   try {
-    return await select({ message: 'Choose a CSS library', options, defaultValue: DEFAULT_CSS_LIBRARY })
+    return await select({ message: CSS_SELECT_MESSAGE, options, defaultValue: DEFAULT_CSS_LIBRARY })
   } catch (err) {
     bailOnSelectError(err)
+  }
+}
+
+// Prints the same "✔ <message> <label>" confirmation `select()` renders
+// after an interactive pick (see select.ts), for choices resolved
+// without ever going through the prompt (an explicit flag, or `--yes`'s
+// forwarded defaults). Keeps the interactive and non-interactive
+// transcripts read identically. Colorized only in a TTY, matching the
+// rest of init's/create-barefootjs's output conventions.
+function printSelectConfirmation(message: string, opt: { label: string; shortLabel?: string }): void {
+  const label = confirmationLabel(opt)
+  const highlighted = process.stdout.isTTY ? `\x1b[1;32m${label}\x1b[0m` : label
+  console.log(`✔ ${message} ${highlighted}`)
+}
+
+// `--list-adapters` — a quick, offline way to discover valid `--adapter`
+// ids (and the CSS library options) without stumbling into the generic
+// "unknown adapter" error first. One line per entry, ids left-aligned
+// so labels line up in a column.
+function printAdapterList(): void {
+  const adapterIds = Object.keys(ADAPTERS)
+  const idWidth = Math.max(...adapterIds.map((id) => id.length))
+  console.log('Adapters (--adapter <id>):')
+  for (const id of adapterIds) {
+    console.log(`  ${id.padEnd(idWidth)}  ${ADAPTERS[id].label}`)
+  }
+  console.log('')
+  const cssIds = Object.keys(CSS_LIBRARIES)
+  const cssWidth = Math.max(...cssIds.map((id) => id.length))
+  console.log('CSS libraries (--css <id>):')
+  for (const id of cssIds) {
+    console.log(`  ${id.padEnd(cssWidth)}  ${CSS_LIBRARIES[id].label}`)
   }
 }
 

--- a/packages/cli/src/lib/select.ts
+++ b/packages/cli/src/lib/select.ts
@@ -40,6 +40,20 @@ export interface SelectOption<T extends string = string> {
   shortLabel?: string
 }
 
+/**
+ * Confirmation-line label for a picked option — prefers an explicit
+ * `shortLabel`, else strips a trailing parenthetical description
+ * ("Hono (Cloudflare Workers, ...)" → "Hono"). Exported so callers
+ * that resolve a choice *without* going through the interactive
+ * `select()` prompt (an explicit `--adapter`/`--css` flag, or `--yes`'s
+ * forwarded defaults) can still print the exact same
+ * "✔ <message> <label>" confirmation the interactive picker renders —
+ * keeping the interactive and non-interactive transcripts consistent.
+ */
+export function confirmationLabel(opt: { label: string; shortLabel?: string }): string {
+  return opt.shortLabel ?? opt.label.replace(/\s*\(.*\)$/, '')
+}
+
 export interface SelectArgs<T extends string = string> {
   message: string
   options: SelectOption<T>[]
@@ -145,7 +159,7 @@ export async function select<T extends string = string>(args: SelectArgs<T>): Pr
         // distinguishable ("Hono / Cloudflare Workers" vs.
         // "Hono / Node").
         const picked = args.options[cursor]
-        const shortLabel = picked.shortLabel ?? picked.label.replace(/\s*\(.*\)$/, '')
+        const shortLabel = confirmationLabel(picked)
         const totalLines = args.options.length + 1
         output.write(`\x1b[${totalLines}A`)
         for (let i = 0; i < totalLines; i++) {

--- a/packages/create-barefootjs/__tests__/scenario.test.ts
+++ b/packages/create-barefootjs/__tests__/scenario.test.ts
@@ -113,6 +113,9 @@ describe('Scenario: bun create barefootjs@latest --help', () => {
     expect(r.stdout).toContain('--adapter')
     // Both top-level flags are documented.
     expect(r.stdout).toMatch(/-y, --yes/)
+    // Points users at --list-adapters instead of hardcoding the id
+    // list (which would drift as adapters are added/removed).
+    expect(r.stdout).toContain('--list-adapters')
     expect(readdirSync(cwd)).toHaveLength(0)
   })
 
@@ -120,5 +123,47 @@ describe('Scenario: bun create barefootjs@latest --help', () => {
     const r = runCreate(['-h'], { cwd: mktmp() })
     expect(r.exitCode).toBe(0)
     expect(r.stdout).toContain('Usage:')
+  })
+})
+
+describe('Scenario: --list-adapters (#2122)', () => {
+  test('prints adapter ids and the CSS library options, exits 0, and creates nothing', () => {
+    const cwd = mktmp()
+    const r = runCreate(['--list-adapters'], { cwd })
+    expect(r.exitCode).toBe(0)
+    for (const id of ['hono', 'hono-node', 'echo', 'gin', 'chi', 'nethttp', 'mojo', 'xslate', 'csr']) {
+      expect(r.stdout).toContain(id)
+    }
+    expect(r.stdout).toContain('unocss')
+    expect(r.stdout).toContain('none')
+    // Handled before the directory/prompt flow — no "Target directory"
+    // confirmation, no project name prompt, nothing written to cwd.
+    expect(r.stdout).not.toContain('Target directory')
+    expect(readdirSync(cwd)).toHaveLength(0)
+  })
+})
+
+describe('Scenario: a failed init leaves no directory behind (#2122)', () => {
+  test('an unrecognized --adapter (e.g. a bare language name) removes the directory it created', () => {
+    const cwd = mktmp()
+    const r = runCreate(['go-app', '--', '--adapter', 'go'], { cwd })
+    expect(r.exitCode).not.toBe(0)
+    // The Go-specific alias hint from `bf init` reaches the user.
+    expect(r.stderr).toContain('unknown adapter "go"')
+    expect(r.stderr).toContain('echo, gin, chi, nethttp')
+    // No leftover empty "go-app" directory for the user to clean up.
+    expect(readdirSync(cwd)).toHaveLength(0)
+  })
+
+  test('a pre-existing empty directory is left alone (not removed) on failure', () => {
+    const cwd = mktmp()
+    const projectDir = path.join(cwd, 'go-app')
+    mkdirSync(projectDir)
+
+    const r = runCreate(['go-app', '--', '--adapter', 'go'], { cwd })
+    expect(r.exitCode).not.toBe(0)
+    // Directory pre-existed before this run, so it's never removed —
+    // only directories *created by this run* are cleaned up.
+    expect(existsSync(projectDir)).toBe(true)
   })
 })

--- a/packages/create-barefootjs/src/index.ts
+++ b/packages/create-barefootjs/src/index.ts
@@ -12,7 +12,7 @@
 //      flags. `--yes` short-circuits all prompts by forcing the
 //      adapter / css defaults too.
 
-import { existsSync, mkdirSync, readdirSync } from 'node:fs'
+import { existsSync, mkdirSync, readdirSync, rmSync } from 'node:fs'
 import { basename, resolve } from 'node:path'
 import { spawnSync } from 'node:child_process'
 import { createRequire } from 'node:module'
@@ -55,10 +55,12 @@ be prompted for one (defaults to "${DEFAULT_PROJECT_NAME}").
 Options:
   -y, --yes           Accept all defaults (project name "${DEFAULT_PROJECT_NAME}", adapter hono, css unocss).
                       Skips every prompt — useful for CI and dotfiles.
+  --list-adapters     Print every adapter id + CSS library option, then exit.
   -h, --help          Show this message.
 
 Forwarded to \`bf init\`:
-  --adapter <name>    Adapter to use (default: hono)
+  --adapter <name>    Adapter to use (default: hono). Run --list-adapters
+                      to see every adapter id.
   --css <name>        CSS setup to use: "unocss" (default) or "none"
                       ("none" = bring your own CSS: no UnoCSS, no UI
                       components, just the compiler output)
@@ -76,9 +78,39 @@ function fail(msg: string): never {
   process.exit(1)
 }
 
+// `require.resolve` is Node-specific. `create-barefootjs` is invoked
+// via `npm create barefootjs@latest` / `npx`, both of which are Node
+// processes today; the package is not designed to run on Workers,
+// Deno, or Bun-as-edge. Bun's Node-compat layer also supplies
+// `createRequire`, so this works there too.
+function resolveCliBin(): string {
+  try {
+    return require.resolve('@barefootjs/cli/dist/index.js')
+  } catch {
+    fail(
+      'unable to resolve @barefootjs/cli. ' +
+        'Reinstall create-barefootjs or report this if it persists.',
+    )
+  }
+}
+
 async function main(): Promise<void> {
   const args = process.argv.slice(2)
   if (args.includes('--help') || args.includes('-h')) usage()
+
+  // `--list-adapters` is a read-only lookup — handled before we prompt
+  // for (or create) anything so it never touches the filesystem. `bf
+  // init` owns the actual id list (single source of truth); we just
+  // spawn it with the sentinel env var and forward its output/exit
+  // code, same as the real scaffold path below.
+  if (args.includes('--list-adapters')) {
+    const cliBin = resolveCliBin()
+    const result = spawnSync('node', [cliBin, 'init', '--list-adapters'], {
+      stdio: 'inherit',
+      env: { ...process.env, BAREFOOT_INIT_VIA_CREATE: '1' },
+    })
+    process.exit(result.status ?? 1)
+  }
 
   // Banner + a blank padding line. The padding stays in place across
   // the prompt → confirmation transition: the interactive prompt fills
@@ -120,6 +152,10 @@ async function main(): Promise<void> {
   console.log(`✔ Target directory ${highlight(projectName)}`)
 
   const targetDir = resolve(process.cwd(), projectName)
+  // Tracked so a failed init below can clean up after itself — we only
+  // ever remove a directory *this run* created, never one that
+  // pre-existed (even if it was empty going in).
+  let createdTargetDir = false
   if (existsSync(targetDir)) {
     const entries = readdirSync(targetDir).filter((e) => !e.startsWith('.'))
     if (entries.length > 0) {
@@ -127,22 +163,10 @@ async function main(): Promise<void> {
     }
   } else {
     mkdirSync(targetDir, { recursive: true })
+    createdTargetDir = true
   }
 
-  // `require.resolve` is Node-specific. `create-barefootjs` is invoked
-  // via `npm create barefootjs@latest` / `npx`, both of which are Node
-  // processes today; the package is not designed to run on Workers,
-  // Deno, or Bun-as-edge. Bun's Node-compat layer also supplies
-  // `createRequire`, so this works there too.
-  let cliBin: string
-  try {
-    cliBin = require.resolve('@barefootjs/cli/dist/index.js')
-  } catch {
-    fail(
-      'unable to resolve @barefootjs/cli. ' +
-        'Reinstall create-barefootjs or report this if it persists.',
-    )
-  }
+  const cliBin = resolveCliBin()
 
   // `--name` gets the last path segment, sanitized later by init —
   // multi-segment inputs like "foo/bar/bazz" would otherwise leak
@@ -178,7 +202,24 @@ async function main(): Promise<void> {
     },
   })
 
-  process.exit(result.status ?? 1)
+  const status = result.status ?? 1
+  // A failed init otherwise leaves an empty directory behind — the
+  // user has to notice and `rmdir` it themselves before retrying.
+  // Clean it up automatically, but only when we're sure it's safe:
+  // this run created the directory (never one that pre-existed) and
+  // init didn't get far enough to write anything into it.
+  if (status !== 0 && createdTargetDir) {
+    try {
+      if (existsSync(targetDir) && readdirSync(targetDir).length === 0) {
+        rmSync(targetDir, { recursive: true })
+      }
+    } catch {
+      // Best-effort cleanup — never mask the original init failure
+      // with a secondary cleanup error.
+    }
+  }
+
+  process.exit(status)
 }
 
 main().catch((err) => {


### PR DESCRIPTION
> [!NOTE]
> **Stacked PR (2/3)** — stack order (bottom → top): #2146 → **#2144** → #2145. Base is `claude/github-issue-2123-scaffold-pinning`; merge #2146 first. This PR's own diff is only the adapter-discovery changes.

Closes #2122 (part of the #2125 onboarding umbrella).

Docs and the landing page talk about "Go" / "Perl", but the CLI speaks framework-adapter ids (`echo`/`gin`/`chi`/`nethttp`, `mojo`/`xslate`) — so the obvious first try (`--adapter go`) dead-ends, there was no way to list valid values, and a failed init left an empty directory behind.

## Changes

- **Language-alias hints** — `--adapter go` / `golang` / `perl` (case-insensitive) now print a targeted error naming the concrete adapter ids to pick from (e.g. "Go apps use one of the Go web-framework adapters: echo, gin, chi, nethttp (e.g. --adapter chi)") instead of the generic unknown-adapter list. Still exits 1 — no silent defaulting.
- **`--list-adapters`** — supported in both `create-barefootjs` and `bf init`: prints every adapter id + label and the CSS library options, exits 0. In `create-barefootjs` it's handled before any prompt or directory creation; the adapter registry stays the single source of truth in the CLI (the wrapper forwards to `bf init --list-adapters`). `--help` now points at it instead of hardcoding an id list that would drift.
- **Cleanup on failed init** — `create-barefootjs` tracks whether it created the target directory; if the spawned init exits non-zero and the directory is still empty, it's removed. Pre-existing or non-empty directories are never touched.
- **Self-documenting `--yes` / flags** — non-interactive adapter/css resolution now prints the same `✔ Choose a framework or runtime <label>` / `✔ Choose a CSS library <label>` confirmation lines the interactive picker renders (shared `confirmationLabel()` in `select.ts` so the wording can't drift).

## Tests

- New `packages/cli/src/__tests__/init-flags.test.ts`: `--list-adapters` output/exit code (including inside an already-initialized dir), go/golang/Go/perl hints, generic fallback for unrelated unknowns, non-interactive confirmation lines (offline via `--adapter csr --css none`).
- Extended `packages/create-barefootjs/__tests__/scenario.test.ts`: `--list-adapters` creates nothing and exits 0; failed `--adapter go` run leaves no directory behind; a pre-existing empty directory survives a failed run.
- `bun test packages/cli packages/create-barefootjs`: 1263 pass, 0 fail (1321 at the top of the stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xkd8GuNpavMbknvKs6czSM