### PR TITLE
[stack 1/3] Pin @barefootjs/* scaffold deps to the CLI version, add wrangler devDependency (#2123)

### DIFF
--- a/.changeset/scaffold-pin-versions-wrangler.md
+++ b/.changeset/scaffold-pin-versions-wrangler.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/cli": patch
+---
+
+Scaffold reproducibility: `@barefootjs/*` dependencies in generated `package.json` are now pinned to `^<CLI version>` at scaffold time instead of `"latest"`, and the Hono scaffold adds `wrangler` as a pinned devDependency invoked directly from `node_modules/.bin` (no more unpinned `npx wrangler` download on first `npm run dev`).

--- a/packages/cli/src/__tests__/init-scaffold-deps.test.ts
+++ b/packages/cli/src/__tests__/init-scaffold-deps.test.ts
@@ -1,0 +1,114 @@
+// Scaffold reproducibility (#2123):
+//   1. `@barefootjs/*` deps/devDeps are pinned to `^<CLI_VERSION>` at
+//      scaffold time, not left at the `'latest'` sentinel the adapter
+//      templates carry (see `pinBarefootDeps` in `../commands/init.ts`).
+//      Two teammates scaffolding a week apart — or a bad publish —
+//      would otherwise land on different `@barefootjs/*` versions.
+//   2. The Hono adapter's `wrangler` is a real devDependency invoked
+//      directly from `node_modules/.bin`, not an unpinned `npx`/`bunx`/
+//      `pnpm dlx`/`yarn dlx wrangler` on every `dev`/`deploy` run.
+//
+// We spawn the real CLI entry (mirrors `./init-gate.test.ts`) with
+// `--css none` so the scaffold completes without touching the network
+// (the UI-registry pre-flight probe is skipped entirely for `--css
+// none` — see the comment above `probeRegistry`'s call site in
+// `../commands/init.ts`).
+
+import { describe, test, expect } from 'bun:test'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import { tmpdir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+
+const CLI_ENTRY = path.join(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '..',
+  'index.ts',
+)
+const CLI_PACKAGE_JSON = path.join(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '..',
+  '..',
+  'package.json',
+)
+
+function mktmp(): string {
+  return mkdtempSync(path.join(tmpdir(), 'bf-init-scaffold-deps-test-'))
+}
+
+interface ScaffoldPkgJson {
+  scripts: Record<string, string>
+  dependencies: Record<string, string>
+  devDependencies: Record<string, string>
+}
+
+function scaffold(adapter: string): ScaffoldPkgJson {
+  const cwd = mktmp()
+  const result = spawnSync(
+    'bun',
+    [CLI_ENTRY, 'init', '--name', 'scaffold-deps-test', '--adapter', adapter, '--css', 'none'],
+    {
+      env: { ...process.env, BAREFOOT_INIT_VIA_CREATE: '1' },
+      encoding: 'utf-8',
+      cwd,
+    },
+  )
+  if (result.status !== 0) {
+    throw new Error(`scaffold failed (exit ${result.status}):\n${result.stderr}`)
+  }
+  const raw = readFileSync(path.join(cwd, 'package.json'), 'utf-8')
+  return JSON.parse(raw) as ScaffoldPkgJson
+}
+
+describe('scaffolded package.json pins @barefootjs/* deps to the CLI version (#2123)', () => {
+  test('dependencies + devDependencies match ^<cli package.json version>, never "latest"', () => {
+    const { version: cliVersion } = JSON.parse(readFileSync(CLI_PACKAGE_JSON, 'utf-8')) as {
+      version: string
+    }
+    const pkg = scaffold('hono')
+    const allDeps = { ...pkg.dependencies, ...pkg.devDependencies }
+
+    const barefootDeps = Object.entries(allDeps).filter(([name]) => name.startsWith('@barefootjs/'))
+    // Sanity: the adapter actually contributes some @barefootjs/* deps,
+    // otherwise the assertions below would vacuously pass.
+    expect(barefootDeps.length).toBeGreaterThan(0)
+    for (const [name, value] of barefootDeps) {
+      expect(value).toBe(`^${cliVersion}`)
+    }
+
+    // No dependency anywhere (barefootjs or otherwise) should carry the
+    // unpinned sentinel through to a real scaffold.
+    for (const value of Object.values(allDeps)) {
+      expect(value).not.toBe('latest')
+    }
+  })
+
+  test('non-@barefootjs/* deps (hono, typescript, ...) pass through untouched', () => {
+    const pkg = scaffold('hono')
+    expect(pkg.dependencies.hono).toBe('^4.6.0')
+    expect(pkg.devDependencies.typescript).toBe('^5.6.0')
+  })
+})
+
+describe('hono scaffold pins wrangler as a devDependency and invokes it directly (#2123)', () => {
+  test('wrangler is a devDependency, not resolved via npx/bunx/dlx', () => {
+    const pkg = scaffold('hono')
+    expect(pkg.devDependencies.wrangler).toBeTruthy()
+    expect(pkg.devDependencies.wrangler).not.toBe('latest')
+
+    // The dev/deploy scripts call `wrangler` straight from
+    // node_modules/.bin (package.json scripts do this automatically) —
+    // no package-manager dlx wrapper, which would otherwise force an
+    // unpinned download on the first run.
+    expect(pkg.scripts.dev).toContain('wrangler dev --live-reload')
+    expect(pkg.scripts.deploy).toContain('wrangler deploy')
+    for (const script of [pkg.scripts.dev, pkg.scripts.deploy]) {
+      expect(script).not.toContain('npx wrangler')
+      expect(script).not.toContain('bunx wrangler')
+      expect(script).not.toContain('pnpm dlx wrangler')
+      expect(script).not.toContain('yarn dlx wrangler')
+      expect(script).not.toContain('deno x npm:wrangler')
+    }
+  })
+})

--- a/packages/cli/src/__tests__/init-scaffold-deps.test.ts
+++ b/packages/cli/src/__tests__/init-scaffold-deps.test.ts
@@ -20,6 +20,7 @@ import { mkdtempSync, readFileSync } from 'node:fs'
 import path from 'node:path'
 import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
+import { ADAPTERS } from '../lib/templates'
 
 const CLI_ENTRY = path.join(
   fileURLToPath(new URL('.', import.meta.url)),
@@ -85,9 +86,13 @@ describe('scaffolded package.json pins @barefootjs/* deps to the CLI version (#2
   })
 
   test('non-@barefootjs/* deps (hono, typescript, ...) pass through untouched', () => {
+    // Assert against the adapter template's own values rather than
+    // hardcoding version strings here — a routine hono/typescript bump
+    // in the template shouldn't fail this test; only a pass-through
+    // regression (the pin rewriting deps it must not touch) should.
     const pkg = scaffold('hono')
-    expect(pkg.dependencies.hono).toBe('^4.6.0')
-    expect(pkg.devDependencies.typescript).toBe('^5.6.0')
+    expect(pkg.dependencies.hono).toBe(ADAPTERS.hono.dependencies.hono)
+    expect(pkg.devDependencies.typescript).toBe(ADAPTERS.hono.devDependencies.typescript)
   })
 })
 

--- a/packages/cli/src/__tests__/templates.test.ts
+++ b/packages/cli/src/__tests__/templates.test.ts
@@ -544,6 +544,50 @@ describe('adapter registry', () => {
     // PM-specific entries (today: `@types/bun` when bun) onto this.
     expect(hono.devDependencies['@types/bun']).toBeUndefined()
   })
+
+  test('hono adapter pins wrangler as a devDependency and invokes it bare (#2123)', () => {
+    // Before #2123, `dev`/`deploy` wrapped wrangler in
+    // `commandsFor(pm).exec(...)` (`npx wrangler` / `bunx wrangler` /
+    // `pnpm dlx wrangler`) and wrangler was absent from
+    // devDependencies — so the very first `<pm> run dev` paused to
+    // download an unpinned wrangler. Now it's a real devDependency
+    // and the scripts call it directly; package.json scripts resolve
+    // `node_modules/.bin` automatically, so no dlx wrapper is needed.
+    const hono = ADAPTERS.hono
+    expect(hono.devDependencies.wrangler).toBeTruthy()
+    expect(hono.devDependencies.wrangler).not.toBe('latest')
+
+    // Scripts are now plain strings (no PM-specific dlx rendering
+    // needed), and call `wrangler` bare.
+    expect(typeof hono.scripts.dev).toBe('string')
+    expect(typeof hono.scripts.deploy).toBe('string')
+    expect(hono.scripts.dev).toContain('wrangler dev --live-reload')
+    expect(hono.scripts.deploy).toContain('wrangler deploy')
+    for (const script of [hono.scripts.dev, hono.scripts.deploy]) {
+      expect(script as string).not.toContain('npx wrangler')
+      expect(script as string).not.toContain('bunx wrangler')
+      expect(script as string).not.toContain('dlx wrangler')
+    }
+  })
+
+  test('every adapter keeps the \'latest\' sentinel on @barefootjs/* deps in the static template', () => {
+    // The adapter map is the *unsubstituted* template — `bf init`
+    // (`pinBarefootDeps` in `../commands/init.ts`) is what swaps
+    // `'latest'` for `^<CLI_VERSION>` at scaffold time (#2123). This
+    // pins the other half of that contract: every adapter still
+    // carries the sentinel here, so a future edit that accidentally
+    // hardcodes a version in one adapter's template silently
+    // reintroduces the version-skew bug the central substitution
+    // fixes.
+    for (const adapter of Object.values(ADAPTERS)) {
+      const allDeps = { ...adapter.dependencies, ...adapter.devDependencies }
+      const barefootDeps = Object.entries(allDeps).filter(([name]) => name.startsWith('@barefootjs/'))
+      expect(barefootDeps.length).toBeGreaterThan(0)
+      for (const [, value] of barefootDeps) {
+        expect(value).toBe('latest')
+      }
+    }
+  })
 })
 
 describe('CSS library registry', () => {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -54,7 +54,16 @@ function readCliVersion(): string {
   const bundledPkgJsonPath = path.resolve(path.dirname(thisFile), '../package.json')
   const devPkgJsonPath = path.resolve(path.dirname(thisFile), '../../package.json')
   const pkgJsonPath = existsSync(bundledPkgJsonPath) ? bundledPkgJsonPath : devPkgJsonPath
-  const { version } = JSON.parse(readFileSync(pkgJsonPath, 'utf-8')) as { version: string }
+  const { version } = JSON.parse(readFileSync(pkgJsonPath, 'utf-8')) as { version?: unknown }
+  // Validate before use: a missing/empty `version` would otherwise
+  // silently scaffold `"@barefootjs/*": "^undefined"`. Fail loudly and
+  // name the file read so a broken CLI package is diagnosable.
+  if (typeof version !== 'string' || version.length === 0) {
+    throw new Error(
+      `Could not read the CLI's own version from ${pkgJsonPath} — ` +
+        'cannot pin @barefootjs/* scaffold dependencies.',
+    )
+  }
   return version
 }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -12,8 +12,9 @@
 // carrying both `paths` (consumed by registry tooling) and the build
 // options.
 
-import { existsSync, mkdirSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
 import path from 'path'
+import { fileURLToPath } from 'node:url'
 import type { CliContext } from '../context'
 import { addFromRegistry } from './add'
 import {
@@ -32,6 +33,56 @@ import {
   SHARED_COUNTER_BARE_TEST_TSX,
   UNOCSS_DEV_DEPENDENCIES,
 } from '../lib/adapters/shared'
+
+const thisFile = fileURLToPath(import.meta.url)
+
+// The CLI's own version — used to pin `@barefootjs/*` scaffold deps to
+// a real version instead of the `'latest'` sentinel every adapter
+// template carries (see `pinBarefootDeps` below). All `@barefootjs/*`
+// packages publish in lockstep with `@barefootjs/cli`, so its own
+// version is authoritative for the whole set.
+//
+// Two candidate locations, tried in order — the same bundled/dev split
+// used by `../lib/tokens.ts` and `../commands/guide.ts`:
+//   1. Bundled (published CLI): esbuild inlines every module into a
+//      single `dist/index.js` (see scripts/build.mjs), which sits
+//      directly under the package root, so package.json is one `..` up.
+//   2. Dev/unbundled (e.g. tests spawning `bun src/index.ts` directly,
+//      per `../__tests__/init-gate.test.ts`): this file is
+//      `src/commands/init.ts`, two levels under the package root.
+function readCliVersion(): string {
+  const bundledPkgJsonPath = path.resolve(path.dirname(thisFile), '../package.json')
+  const devPkgJsonPath = path.resolve(path.dirname(thisFile), '../../package.json')
+  const pkgJsonPath = existsSync(bundledPkgJsonPath) ? bundledPkgJsonPath : devPkgJsonPath
+  const { version } = JSON.parse(readFileSync(pkgJsonPath, 'utf-8')) as { version: string }
+  return version
+}
+
+const CLI_VERSION = readCliVersion()
+
+// Substitutes the `'latest'` sentinel every adapter template's
+// `dependencies` / `devDependencies` map carries for `@barefootjs/*`
+// packages (see e.g. `../lib/adapters/hono.ts`) with `^<CLI_VERSION>`.
+// Adapter templates keep the sentinel — rather than hardcoding a
+// version per adapter — so this one substitution point is the only
+// place that has to change when the version-pinning strategy changes.
+//
+// Without this, two teammates scaffolding a week apart would get
+// different `@barefootjs/*` versions (no lockfile exists yet at
+// scaffold time), and a bad publish — like the accidental
+// `@barefootjs/cli@1.0.0` release — would propagate into every new
+// scaffold instantly instead of only when a maintainer deliberately
+// bumps the pin. Non-`@barefootjs/*` deps (hono, wrangler, typescript,
+// ...) are returned unchanged.
+function pinBarefootDeps(deps: Record<string, string>): Record<string, string> {
+  const pinned: Record<string, string> = {}
+  for (const [name, version] of Object.entries(deps)) {
+    pinned[name] = name.startsWith('@barefootjs/') && version === 'latest'
+      ? `^${CLI_VERSION}`
+      : version
+  }
+  return pinned
+}
 
 interface InitFlags {
   name?: string
@@ -331,8 +382,10 @@ async function scaffoldApp(
   // package.json — merge adapter scripts/deps with a sensible default.
   const pkgJsonPath = path.join(projectDir, 'package.json')
   // Resolve adapter scripts. Function values render against the
-  // detected PM so `dev` / `deploy` quote the right dlx form
-  // (`bunx wrangler` vs. `npx wrangler` vs. `pnpm dlx wrangler` etc.).
+  // detected PM for the rare command that genuinely differs per PM
+  // (e.g. `<pm> install`) — see the `AdapterScriptValue` doc in
+  // `../lib/templates.ts`. Most adapter tools (e.g. Hono's `wrangler`)
+  // are devDependencies invoked bare instead, so they don't need this.
   // (`pm` was resolved earlier so the file-substitution loop and
   // tsconfig's bun-types entry both see the same value.)
   const resolvedAdapterScripts: Record<string, string> = {}
@@ -380,8 +433,10 @@ async function scaffoldApp(
       // without manual migration. See `testRunnerFor` in `../lib/pm.ts`.
       test: runner.scriptValue,
     },
-    dependencies: { ...adapter.dependencies },
-    devDependencies: { ...adapterDevDeps, ...pmDevDeps },
+    // `@barefootjs/*` entries are pinned from the `'latest'` sentinel to
+    // `^<CLI_VERSION>` here — see `pinBarefootDeps` above.
+    dependencies: pinBarefootDeps({ ...adapter.dependencies }),
+    devDependencies: pinBarefootDeps({ ...adapterDevDeps, ...pmDevDeps }),
   }
   if (!existsSync(pkgJsonPath)) {
     writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + '\n')

--- a/packages/cli/src/lib/adapters/hono.ts
+++ b/packages/cli/src/lib/adapters/hono.ts
@@ -8,7 +8,6 @@
 // "instantly deployable" first impression.
 
 import type { AdapterTemplate } from '../templates'
-import { commandsFor } from '../pm'
 import {
   buildGitignore,
   COMPONENTS_MANIFEST_SEED,
@@ -202,12 +201,13 @@ export const HONO_ADAPTER: AdapterTemplate = {
     '.gitignore': HONO_GITIGNORE,
   },
   scripts: {
-    dev: (pm) =>
-      `concurrently -k -n build,uno,server -c blue,magenta,green "bf build --watch" "unocss --watch" "${commandsFor(pm).exec(
-        'wrangler dev --live-reload',
-      )}"`,
+    // `wrangler` is a devDependency below, so package.json scripts
+    // resolve it straight from `node_modules/.bin` — no `npx`/`bunx`/
+    // `pnpm dlx` wrapper needed (and no unpinned download on first
+    // `<pm> run dev`, since the version is pinned in devDependencies).
+    dev: 'concurrently -k -n build,uno,server -c blue,magenta,green "bf build --watch" "unocss --watch" "wrangler dev --live-reload"',
     build: 'bf build && unocss',
-    deploy: (pm) => `bf build && unocss && ${commandsFor(pm).exec('wrangler deploy')}`,
+    deploy: 'bf build && unocss && wrangler deploy',
   },
   deploy: {
     target: 'Cloudflare Workers',
@@ -237,6 +237,11 @@ export const HONO_ADAPTER: AdapterTemplate = {
     // type package.
     concurrently: '^9.0.0',
     typescript: '^5.6.0',
+    // Pinned so `<pm> run dev` / `<pm> run deploy` resolve a known
+    // `wrangler` from `node_modules/.bin` instead of pausing on an
+    // unpinned download the first time they run (see the `scripts`
+    // comment above — this is what makes the bare invocation safe).
+    wrangler: '^4.0.0',
   },
   prereqWarnings: () => [],
 }

--- a/packages/cli/src/lib/templates.ts
+++ b/packages/cli/src/lib/templates.ts
@@ -18,8 +18,13 @@ import type { PackageManager } from './pm'
 /**
  * A package-manager-aware script value. Plain strings are emitted
  * verbatim; functions are evaluated against the detected PM so the
- * generated `package.json` quotes the right command (`bunx wrangler`
- * vs. `npx wrangler` vs. `pnpm dlx wrangler` vs. `yarn dlx wrangler`).
+ * generated `package.json` quotes the right PM-specific command. Tools
+ * an adapter depends on directly (e.g. Hono's `wrangler`) should be
+ * added to `devDependencies` and invoked bare in the script string —
+ * package.json scripts resolve `node_modules/.bin` automatically, so
+ * no `npx`/`bunx`/`pnpm dlx`/`yarn dlx` wrapper (and no unpinned
+ * first-run download) is needed. Reach for a function value only when
+ * the command genuinely differs per PM (e.g. `<pm> install`).
  */
 export type AdapterScriptValue = string | ((pm: PackageManager) => string)
 


### PR DESCRIPTION
> [!NOTE]
> **Stacked PR (1/3)** — stack order (bottom → top): **#2146** → #2144 → #2145. This is the base of the stack (targets `main`); merge it first. #2147 is independent of the stack.

Closes #2123 (part of the #2125 onboarding umbrella).

Generated scaffolds pinned every `@barefootjs/*` package to `"latest"` (silent drift between installs, and a bad publish — like the accidental `@barefootjs/cli@1.0.0` release — would propagate into every new scaffold instantly), and the Hono scaffold ran wrangler through bare `npx` without declaring it as a dependency (surprise unpinned download on first `npm run dev`, broken offline first runs).

## Changes

- **Version pinning at scaffold time** — adapter templates keep the `'latest'` sentinel; `scaffoldApp()` in `packages/cli/src/commands/init.ts` now substitutes it with `^<CLI version>` for any `@barefootjs/*` dependency when assembling the generated `package.json` (all `@barefootjs/*` packages publish in lockstep, so the CLI's own version is authoritative). `readCliVersion()` handles both the bundled `dist/index.js` layout and the unbundled dev/test layout, mirroring the existing pattern in `lib/tokens.ts` / `commands/guide.ts`, and fails loudly (naming the file read) if the version field is missing. Non-`@barefootjs` deps are untouched.
- **wrangler as a pinned devDependency** — the Hono adapter adds `wrangler: '^4.0.0'` to `devDependencies` and its `dev`/`deploy` scripts invoke `wrangler` directly (package.json scripts resolve `node_modules/.bin`), replacing the PM-aware `npx`/`bunx`/`pnpm dlx` wrapping. The scripts collapse from functions to plain strings; stale doc comments about the dlx form updated (`AdapterScriptValue` in `templates.ts`). No other adapter used a dlx-wrapped tool.

## Tests

- New `packages/cli/src/__tests__/init-scaffold-deps.test.ts` — spawns the real CLI offline (`--css none`) and asserts the scaffolded `package.json`: `@barefootjs/*` deps equal `^<version>` read live from the CLI's package.json, no `'latest'` values remain, non-`@barefootjs` deps pass through (asserted against the adapter template's own values, not hardcoded strings), `wrangler` is a devDependency, and `dev`/`deploy` contain no `npx`/`bunx`/`dlx` prefix.
- `templates.test.ts` — hono has a pinned `wrangler` devDependency and plain-string scripts; every adapter's template still carries the `'latest'` sentinel (guards against reintroducing per-adapter hardcoded versions).
- `bun test packages/cli packages/create-barefootjs`: 1257 pass, 0 fail (1321 at the top of the stack). Also manually verified `readCliVersion()` from both a built `dist/index.js` bundle and the unbundled source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xkd8GuNpavMbknvKs6czSM