### PR TITLE
DialogTrigger asChild: document the pattern and warn on nested-button misuse (#2127)

### DIFF
--- a/packages/adapter-tests/fixtures/__snapshots__/command.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/command.client.js
@@ -2783,12 +2783,28 @@ export function initDialogTrigger(__scope, _p = {}) {
   const __scopeId = __scope.getAttribute('bf-s')
 
   const dialogTriggerClasses = 'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-[invalid]:ring-destructive/20 dark:aria-[invalid]:ring-destructive/40 aria-[invalid]:border-destructive touch-action-manipulation bg-primary text-primary-foreground hover:bg-primary/90 h-9 px-4 py-2 has-[>svg]:px-3'
+  const warnIfMisusedTrigger = (el, componentName) => {
+  const interactiveSelector = 'button, [role="button"], a[href]'
+  const hasNestedInteractive = el.querySelector(interactiveSelector) != null
+  const isEmpty = Array.from(el.childNodes).every(
+    (node) => node.nodeType === Node.TEXT_NODE && !node.textContent?.trim()
+  )
+  const siblingIsInteractive = isEmpty && (el.nextElementSibling?.matches(interactiveSelector) ?? false)
+
+  if (hasNestedInteractive || siblingIsInteractive) {
+    console.warn(
+      `[barefootjs] ${componentName} rendered an empty trigger next to an interactive element — did you nest a <button>/<Button> inside it? Use <${componentName} asChild> to adopt your own element.`
+    )
+  }
+}
   const handleMount = (el) => {
     const ctx = useContext(DialogContext)
 
     el.addEventListener('click', () => {
       ctx.onOpenChange(!ctx.open())
     })
+
+    if (!_p.asChild) warnIfMisusedTrigger(el, 'DialogTrigger')
   }
 
   const [_s1, _s0] = $(__scope, 's1', 's0')

--- a/packages/adapter-tests/fixtures/__snapshots__/command.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/command.client.js
@@ -2791,9 +2791,13 @@ export function initDialogTrigger(__scope, _p = {}) {
   )
   const siblingIsInteractive = isEmpty && (el.nextElementSibling?.matches(interactiveSelector) ?? false)
 
-  if (hasNestedInteractive || siblingIsInteractive) {
+  if (hasNestedInteractive) {
     console.warn(
-      `[barefootjs] ${componentName} rendered an empty trigger next to an interactive element — did you nest a <button>/<Button> inside it? Use <${componentName} asChild> to adopt your own element.`
+      `[barefootjs] ${componentName} contains a nested interactive element (<button>, <a href>, or [role="button"]) inside the trigger's own <button> — nested interactive elements don't work reliably. Use <${componentName} asChild> to adopt your element instead.`
+    )
+  } else if (siblingIsInteractive) {
+    console.warn(
+      `[barefootjs] ${componentName} rendered an empty trigger followed by an interactive element — this is what the HTML parser produces from a <button>/<Button> nested inside the trigger. Use <${componentName} asChild> to adopt your element instead.`
     )
   }
 }

--- a/packages/adapter-tests/fixtures/__snapshots__/command.dialog.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/command.dialog.ssr.tsx
@@ -22,7 +22,12 @@ interface DialogProps {
 interface DialogTriggerProps extends ButtonHTMLAttributes {
   /** Whether disabled */
   disabled?: boolean
-  /** Render child element as trigger instead of built-in button */
+  /**
+   * Render the child element as the trigger instead of DialogTrigger's own `<button>`.
+   * Required whenever `children` is itself an interactive element (e.g. `<Button>`) —
+   * without it, DialogTrigger renders its own `<button>` around the child, the HTML
+   * parser auto-closes the nested `<button>`, and the dialog silently never opens.
+   */
   asChild?: boolean
   /** Button content */
   children?: Child
@@ -79,7 +84,12 @@ interface DialogProps {
 interface DialogTriggerProps extends ButtonHTMLAttributes {
   /** Whether disabled */
   disabled?: boolean
-  /** Render child element as trigger instead of built-in button */
+  /**
+   * Render the child element as the trigger instead of DialogTrigger's own `<button>`.
+   * Required whenever `children` is itself an interactive element (e.g. `<Button>`) —
+   * without it, DialogTrigger renders its own `<button>` around the child, the HTML
+   * parser auto-closes the nested `<button>`, and the dialog silently never opens.
+   */
   asChild?: boolean
   /** Button content */
   children?: Child
@@ -146,7 +156,12 @@ interface DialogProps {
 interface DialogTriggerProps extends ButtonHTMLAttributes {
   /** Whether disabled */
   disabled?: boolean
-  /** Render child element as trigger instead of built-in button */
+  /**
+   * Render the child element as the trigger instead of DialogTrigger's own `<button>`.
+   * Required whenever `children` is itself an interactive element (e.g. `<Button>`) —
+   * without it, DialogTrigger renders its own `<button>` around the child, the HTML
+   * parser auto-closes the nested `<button>`, and the dialog silently never opens.
+   */
   asChild?: boolean
   /** Button content */
   children?: Child
@@ -213,7 +228,12 @@ interface DialogProps {
 interface DialogTriggerProps extends ButtonHTMLAttributes {
   /** Whether disabled */
   disabled?: boolean
-  /** Render child element as trigger instead of built-in button */
+  /**
+   * Render the child element as the trigger instead of DialogTrigger's own `<button>`.
+   * Required whenever `children` is itself an interactive element (e.g. `<Button>`) —
+   * without it, DialogTrigger renders its own `<button>` around the child, the HTML
+   * parser auto-closes the nested `<button>`, and the dialog silently never opens.
+   */
   asChild?: boolean
   /** Button content */
   children?: Child
@@ -280,7 +300,12 @@ interface DialogProps {
 interface DialogTriggerProps extends ButtonHTMLAttributes {
   /** Whether disabled */
   disabled?: boolean
-  /** Render child element as trigger instead of built-in button */
+  /**
+   * Render the child element as the trigger instead of DialogTrigger's own `<button>`.
+   * Required whenever `children` is itself an interactive element (e.g. `<Button>`) —
+   * without it, DialogTrigger renders its own `<button>` around the child, the HTML
+   * parser auto-closes the nested `<button>`, and the dialog silently never opens.
+   */
   asChild?: boolean
   /** Button content */
   children?: Child

--- a/packages/adapter-tests/fixtures/__snapshots__/dialog.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/dialog.client.js
@@ -31,9 +31,13 @@ export function initDialogTrigger(__scope, _p = {}) {
   )
   const siblingIsInteractive = isEmpty && (el.nextElementSibling?.matches(interactiveSelector) ?? false)
 
-  if (hasNestedInteractive || siblingIsInteractive) {
+  if (hasNestedInteractive) {
     console.warn(
-      `[barefootjs] ${componentName} rendered an empty trigger next to an interactive element — did you nest a <button>/<Button> inside it? Use <${componentName} asChild> to adopt your own element.`
+      `[barefootjs] ${componentName} contains a nested interactive element (<button>, <a href>, or [role="button"]) inside the trigger's own <button> — nested interactive elements don't work reliably. Use <${componentName} asChild> to adopt your element instead.`
+    )
+  } else if (siblingIsInteractive) {
+    console.warn(
+      `[barefootjs] ${componentName} rendered an empty trigger followed by an interactive element — this is what the HTML parser produces from a <button>/<Button> nested inside the trigger. Use <${componentName} asChild> to adopt your element instead.`
     )
   }
 }

--- a/packages/adapter-tests/fixtures/__snapshots__/dialog.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/dialog.client.js
@@ -23,12 +23,28 @@ export function initDialogTrigger(__scope, _p = {}) {
   const __scopeId = __scope.getAttribute('bf-s')
 
   const dialogTriggerClasses = 'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-[invalid]:ring-destructive/20 dark:aria-[invalid]:ring-destructive/40 aria-[invalid]:border-destructive touch-action-manipulation bg-primary text-primary-foreground hover:bg-primary/90 h-9 px-4 py-2 has-[>svg]:px-3'
+  const warnIfMisusedTrigger = (el, componentName) => {
+  const interactiveSelector = 'button, [role="button"], a[href]'
+  const hasNestedInteractive = el.querySelector(interactiveSelector) != null
+  const isEmpty = Array.from(el.childNodes).every(
+    (node) => node.nodeType === Node.TEXT_NODE && !node.textContent?.trim()
+  )
+  const siblingIsInteractive = isEmpty && (el.nextElementSibling?.matches(interactiveSelector) ?? false)
+
+  if (hasNestedInteractive || siblingIsInteractive) {
+    console.warn(
+      `[barefootjs] ${componentName} rendered an empty trigger next to an interactive element — did you nest a <button>/<Button> inside it? Use <${componentName} asChild> to adopt your own element.`
+    )
+  }
+}
   const handleMount = (el) => {
     const ctx = useContext(DialogContext)
 
     el.addEventListener('click', () => {
       ctx.onOpenChange(!ctx.open())
     })
+
+    if (!_p.asChild) warnIfMisusedTrigger(el, 'DialogTrigger')
   }
 
   const [_s1, _s0] = $(__scope, 's1', 's0')

--- a/packages/adapter-tests/fixtures/__snapshots__/dialog.dialog.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/dialog.dialog.ssr.tsx
@@ -22,7 +22,12 @@ interface DialogProps {
 interface DialogTriggerProps extends ButtonHTMLAttributes {
   /** Whether disabled */
   disabled?: boolean
-  /** Render child element as trigger instead of built-in button */
+  /**
+   * Render the child element as the trigger instead of DialogTrigger's own `<button>`.
+   * Required whenever `children` is itself an interactive element (e.g. `<Button>`) —
+   * without it, DialogTrigger renders its own `<button>` around the child, the HTML
+   * parser auto-closes the nested `<button>`, and the dialog silently never opens.
+   */
   asChild?: boolean
   /** Button content */
   children?: Child
@@ -79,7 +84,12 @@ interface DialogProps {
 interface DialogTriggerProps extends ButtonHTMLAttributes {
   /** Whether disabled */
   disabled?: boolean
-  /** Render child element as trigger instead of built-in button */
+  /**
+   * Render the child element as the trigger instead of DialogTrigger's own `<button>`.
+   * Required whenever `children` is itself an interactive element (e.g. `<Button>`) —
+   * without it, DialogTrigger renders its own `<button>` around the child, the HTML
+   * parser auto-closes the nested `<button>`, and the dialog silently never opens.
+   */
   asChild?: boolean
   /** Button content */
   children?: Child
@@ -146,7 +156,12 @@ interface DialogProps {
 interface DialogTriggerProps extends ButtonHTMLAttributes {
   /** Whether disabled */
   disabled?: boolean
-  /** Render child element as trigger instead of built-in button */
+  /**
+   * Render the child element as the trigger instead of DialogTrigger's own `<button>`.
+   * Required whenever `children` is itself an interactive element (e.g. `<Button>`) —
+   * without it, DialogTrigger renders its own `<button>` around the child, the HTML
+   * parser auto-closes the nested `<button>`, and the dialog silently never opens.
+   */
   asChild?: boolean
   /** Button content */
   children?: Child
@@ -213,7 +228,12 @@ interface DialogProps {
 interface DialogTriggerProps extends ButtonHTMLAttributes {
   /** Whether disabled */
   disabled?: boolean
-  /** Render child element as trigger instead of built-in button */
+  /**
+   * Render the child element as the trigger instead of DialogTrigger's own `<button>`.
+   * Required whenever `children` is itself an interactive element (e.g. `<Button>`) —
+   * without it, DialogTrigger renders its own `<button>` around the child, the HTML
+   * parser auto-closes the nested `<button>`, and the dialog silently never opens.
+   */
   asChild?: boolean
   /** Button content */
   children?: Child
@@ -280,7 +300,12 @@ interface DialogProps {
 interface DialogTriggerProps extends ButtonHTMLAttributes {
   /** Whether disabled */
   disabled?: boolean
-  /** Render child element as trigger instead of built-in button */
+  /**
+   * Render the child element as the trigger instead of DialogTrigger's own `<button>`.
+   * Required whenever `children` is itself an interactive element (e.g. `<Button>`) —
+   * without it, DialogTrigger renders its own `<button>` around the child, the HTML
+   * parser auto-closes the nested `<button>`, and the dialog silently never opens.
+   */
   asChild?: boolean
   /** Button content */
   children?: Child

--- a/packages/adapter-tests/fixtures/__snapshots__/dropdown-menu.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/dropdown-menu.client.js
@@ -2785,6 +2785,20 @@ export function initDropdownMenuTrigger(__scope, _p = {}) {
   const __scopeId = __scope.getAttribute('bf-s')
 
   const dropdownMenuTriggerClasses = 'inline-flex items-center disabled:pointer-events-none disabled:opacity-50'
+  const warnIfMisusedTrigger = (el, componentName) => {
+  const interactiveSelector = 'button, [role="button"], a[href]'
+  const hasNestedInteractive = el.querySelector(interactiveSelector) != null
+  const isEmpty = Array.from(el.childNodes).every(
+    (node) => node.nodeType === Node.TEXT_NODE && !node.textContent?.trim()
+  )
+  const siblingIsInteractive = isEmpty && (el.nextElementSibling?.matches(interactiveSelector) ?? false)
+
+  if (hasNestedInteractive || siblingIsInteractive) {
+    console.warn(
+      `[barefootjs] ${componentName} rendered an empty trigger next to an interactive element — did you nest a <button>/<Button> inside it? Use <${componentName} asChild> to adopt your own element.`
+    )
+  }
+}
   const handleMount = (el) => {
     const ctx = useContext(DropdownMenuContext)
 
@@ -2795,6 +2809,8 @@ export function initDropdownMenuTrigger(__scope, _p = {}) {
     el.addEventListener('click', () => {
       ctx.onOpenChange(!ctx.open())
     })
+
+    if (!_p.asChild) warnIfMisusedTrigger(el, 'DropdownMenuTrigger')
   }
 
   const [_s1, _s0] = $(__scope, 's1', 's0')

--- a/packages/adapter-tests/fixtures/__snapshots__/dropdown-menu.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/dropdown-menu.client.js
@@ -2793,9 +2793,13 @@ export function initDropdownMenuTrigger(__scope, _p = {}) {
   )
   const siblingIsInteractive = isEmpty && (el.nextElementSibling?.matches(interactiveSelector) ?? false)
 
-  if (hasNestedInteractive || siblingIsInteractive) {
+  if (hasNestedInteractive) {
     console.warn(
-      `[barefootjs] ${componentName} rendered an empty trigger next to an interactive element — did you nest a <button>/<Button> inside it? Use <${componentName} asChild> to adopt your own element.`
+      `[barefootjs] ${componentName} contains a nested interactive element (<button>, <a href>, or [role="button"]) inside the trigger's own <button> — nested interactive elements don't work reliably. Use <${componentName} asChild> to adopt your element instead.`
+    )
+  } else if (siblingIsInteractive) {
+    console.warn(
+      `[barefootjs] ${componentName} rendered an empty trigger followed by an interactive element — this is what the HTML parser produces from a <button>/<Button> nested inside the trigger. Use <${componentName} asChild> to adopt your element instead.`
     )
   }
 }

--- a/packages/adapter-tests/fixtures/__snapshots__/dropdown-menu.dropdown-menu.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/dropdown-menu.dropdown-menu.ssr.tsx
@@ -20,7 +20,12 @@ interface DropdownMenuProps extends HTMLBaseAttributes {
 interface DropdownMenuTriggerProps extends ButtonHTMLAttributes {
   /** Whether disabled */
   disabled?: boolean
-  /** Render child element as trigger instead of built-in button */
+  /**
+   * Render the child element as the trigger instead of DropdownMenuTrigger's own
+   * `<button>`. Required whenever `children` is itself an interactive element
+   * (e.g. `<Button>`) — without it, the nested `<button>` gets auto-closed by the
+   * HTML parser and the menu silently never opens.
+   */
   asChild?: boolean
   /** Trigger content (any element: button, avatar, icon, etc.) */
   children?: Child
@@ -107,7 +112,12 @@ interface DropdownMenuProps extends HTMLBaseAttributes {
 interface DropdownMenuTriggerProps extends ButtonHTMLAttributes {
   /** Whether disabled */
   disabled?: boolean
-  /** Render child element as trigger instead of built-in button */
+  /**
+   * Render the child element as the trigger instead of DropdownMenuTrigger's own
+   * `<button>`. Required whenever `children` is itself an interactive element
+   * (e.g. `<Button>`) — without it, the nested `<button>` gets auto-closed by the
+   * HTML parser and the menu silently never opens.
+   */
   asChild?: boolean
   /** Trigger content (any element: button, avatar, icon, etc.) */
   children?: Child
@@ -204,7 +214,12 @@ interface DropdownMenuProps extends HTMLBaseAttributes {
 interface DropdownMenuTriggerProps extends ButtonHTMLAttributes {
   /** Whether disabled */
   disabled?: boolean
-  /** Render child element as trigger instead of built-in button */
+  /**
+   * Render the child element as the trigger instead of DropdownMenuTrigger's own
+   * `<button>`. Required whenever `children` is itself an interactive element
+   * (e.g. `<Button>`) — without it, the nested `<button>` gets auto-closed by the
+   * HTML parser and the menu silently never opens.
+   */
   asChild?: boolean
   /** Trigger content (any element: button, avatar, icon, etc.) */
   children?: Child
@@ -301,7 +316,12 @@ interface DropdownMenuProps extends HTMLBaseAttributes {
 interface DropdownMenuTriggerProps extends ButtonHTMLAttributes {
   /** Whether disabled */
   disabled?: boolean
-  /** Render child element as trigger instead of built-in button */
+  /**
+   * Render the child element as the trigger instead of DropdownMenuTrigger's own
+   * `<button>`. Required whenever `children` is itself an interactive element
+   * (e.g. `<Button>`) — without it, the nested `<button>` gets auto-closed by the
+   * HTML parser and the menu silently never opens.
+   */
   asChild?: boolean
   /** Trigger content (any element: button, avatar, icon, etc.) */
   children?: Child
@@ -398,7 +418,12 @@ interface DropdownMenuProps extends HTMLBaseAttributes {
 interface DropdownMenuTriggerProps extends ButtonHTMLAttributes {
   /** Whether disabled */
   disabled?: boolean
-  /** Render child element as trigger instead of built-in button */
+  /**
+   * Render the child element as the trigger instead of DropdownMenuTrigger's own
+   * `<button>`. Required whenever `children` is itself an interactive element
+   * (e.g. `<Button>`) — without it, the nested `<button>` gets auto-closed by the
+   * HTML parser and the menu silently never opens.
+   */
   asChild?: boolean
   /** Trigger content (any element: button, avatar, icon, etc.) */
   children?: Child

--- a/packages/adapter-tests/fixtures/__snapshots__/popover.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/popover.client.js
@@ -33,9 +33,13 @@ export function initPopoverTrigger(__scope, _p = {}) {
   )
   const siblingIsInteractive = isEmpty && (el.nextElementSibling?.matches(interactiveSelector) ?? false)
 
-  if (hasNestedInteractive || siblingIsInteractive) {
+  if (hasNestedInteractive) {
     console.warn(
-      `[barefootjs] ${componentName} rendered an empty trigger next to an interactive element — did you nest a <button>/<Button> inside it? Use <${componentName} asChild> to adopt your own element.`
+      `[barefootjs] ${componentName} contains a nested interactive element (<button>, <a href>, or [role="button"]) inside the trigger's own <button> — nested interactive elements don't work reliably. Use <${componentName} asChild> to adopt your element instead.`
+    )
+  } else if (siblingIsInteractive) {
+    console.warn(
+      `[barefootjs] ${componentName} rendered an empty trigger followed by an interactive element — this is what the HTML parser produces from a <button>/<Button> nested inside the trigger. Use <${componentName} asChild> to adopt your element instead.`
     )
   }
 }

--- a/packages/adapter-tests/fixtures/__snapshots__/popover.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/popover.client.js
@@ -25,6 +25,20 @@ export function initPopoverTrigger(__scope, _p = {}) {
   const __scopeId = __scope.getAttribute('bf-s')
 
   const popoverTriggerClasses = 'inline-flex items-center disabled:pointer-events-none disabled:opacity-50'
+  const warnIfMisusedTrigger = (el, componentName) => {
+  const interactiveSelector = 'button, [role="button"], a[href]'
+  const hasNestedInteractive = el.querySelector(interactiveSelector) != null
+  const isEmpty = Array.from(el.childNodes).every(
+    (node) => node.nodeType === Node.TEXT_NODE && !node.textContent?.trim()
+  )
+  const siblingIsInteractive = isEmpty && (el.nextElementSibling?.matches(interactiveSelector) ?? false)
+
+  if (hasNestedInteractive || siblingIsInteractive) {
+    console.warn(
+      `[barefootjs] ${componentName} rendered an empty trigger next to an interactive element — did you nest a <button>/<Button> inside it? Use <${componentName} asChild> to adopt your own element.`
+    )
+  }
+}
   const handleMount = (el) => {
     const ctx = useContext(PopoverContext)
 
@@ -35,6 +49,8 @@ export function initPopoverTrigger(__scope, _p = {}) {
     el.addEventListener('click', () => {
       ctx.onOpenChange(!ctx.open())
     })
+
+    if (!_p.asChild) warnIfMisusedTrigger(el, 'PopoverTrigger')
   }
 
   const [_s1, _s0] = $(__scope, 's1', 's0')

--- a/packages/adapter-tests/fixtures/__snapshots__/popover.popover.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/popover.popover.ssr.tsx
@@ -16,7 +16,12 @@ interface PopoverProps extends HTMLBaseAttributes {
 interface PopoverTriggerProps extends ButtonHTMLAttributes {
   /** Whether disabled */
   disabled?: boolean
-  /** Render child element as trigger instead of built-in button */
+  /**
+   * Render the child element as the trigger instead of PopoverTrigger's own
+   * `<button>`. Required whenever `children` is itself an interactive element
+   * (e.g. `<Button>`) — without it, the nested `<button>` gets auto-closed by the
+   * HTML parser and the popover silently never opens.
+   */
   asChild?: boolean
   /** Trigger content */
   children?: Child

--- a/site/ui/pages/components/dialog.tsx
+++ b/site/ui/pages/components/dialog.tsx
@@ -246,7 +246,7 @@ const dialogTriggerProps: PropDefinition[] = [
     name: 'asChild',
     type: 'boolean',
     defaultValue: 'false',
-    description: 'Render child element as trigger instead of built-in button.',
+    description: 'Render child element as trigger instead of built-in button. Required when the child is itself interactive (e.g. a <Button>) — otherwise the nested button gets auto-closed by the parser and the dialog silently never opens.',
   },
 ]
 

--- a/ui/components/ui/alert-dialog/index.tsx
+++ b/ui/components/ui/alert-dialog/index.tsx
@@ -148,9 +148,13 @@ function warnIfMisusedTrigger(el: HTMLElement, componentName: string): void {
   )
   const siblingIsInteractive = isEmpty && (el.nextElementSibling?.matches(interactiveSelector) ?? false)
 
-  if (hasNestedInteractive || siblingIsInteractive) {
+  if (hasNestedInteractive) {
     console.warn(
-      `[barefootjs] ${componentName} rendered an empty trigger next to an interactive element — did you nest a <button>/<Button> inside it? Use <${componentName} asChild> to adopt your own element.`
+      `[barefootjs] ${componentName} contains a nested interactive element (<button>, <a href>, or [role="button"]) inside the trigger's own <button> — nested interactive elements don't work reliably. Use <${componentName} asChild> to adopt your element instead.`
+    )
+  } else if (siblingIsInteractive) {
+    console.warn(
+      `[barefootjs] ${componentName} rendered an empty trigger followed by an interactive element — this is what the HTML parser produces from a <button>/<Button> nested inside the trigger. Use <${componentName} asChild> to adopt your element instead.`
     )
   }
 }

--- a/ui/components/ui/alert-dialog/index.tsx
+++ b/ui/components/ui/alert-dialog/index.tsx
@@ -36,6 +36,16 @@
  *   </AlertDialogContent>
  * </AlertDialog>
  * ```
+ *
+ * @example Styled trigger (asChild)
+ * ```tsx
+ * // Wrapping a <Button> inside AlertDialogTrigger requires asChild. Without it,
+ * // AlertDialogTrigger renders its OWN <button>, the HTML parser auto-closes the
+ * // nested <button>, and the alert dialog silently never opens.
+ * <AlertDialogTrigger asChild>
+ *   <Button variant="destructive">Delete</Button>
+ * </AlertDialogTrigger>
+ * ```
  */
 
 import { createContext, useContext, createEffect, createPortal, isSSRPortal } from '@barefootjs/client'
@@ -119,12 +129,44 @@ function AlertDialog(props: AlertDialogProps) {
 }
 
 /**
+ * Detects the classic shadcn/ui migration mistake: wrapping an interactive
+ * element (e.g. `<Button>`) inside a non-asChild *Trigger. The Trigger renders
+ * its own `<button>` around it, so the HTML parser auto-closes the nested
+ * `<button>` while parsing — the outer trigger ends up EMPTY with the inner
+ * element as its next sibling instead of its child. Click wiring lands on the
+ * empty outer button, so the visible inner element does nothing.
+ * For DOM trees built without going through the HTML parser (e.g. programmatic
+ * DOM construction), the nested element can instead survive as an actual
+ * descendant, so both shapes are checked.
+ * See https://github.com/piconic-ai/barefootjs/issues/2127.
+ */
+function warnIfMisusedTrigger(el: HTMLElement, componentName: string): void {
+  const interactiveSelector = 'button, [role="button"], a[href]'
+  const hasNestedInteractive = el.querySelector(interactiveSelector) != null
+  const isEmpty = Array.from(el.childNodes).every(
+    (node) => node.nodeType === Node.TEXT_NODE && !node.textContent?.trim()
+  )
+  const siblingIsInteractive = isEmpty && (el.nextElementSibling?.matches(interactiveSelector) ?? false)
+
+  if (hasNestedInteractive || siblingIsInteractive) {
+    console.warn(
+      `[barefootjs] ${componentName} rendered an empty trigger next to an interactive element — did you nest a <button>/<Button> inside it? Use <${componentName} asChild> to adopt your own element.`
+    )
+  }
+}
+
+/**
  * Props for AlertDialogTrigger component.
  */
 interface AlertDialogTriggerProps extends ButtonHTMLAttributes {
   /** Whether disabled */
   disabled?: boolean
-  /** Render child element as trigger instead of built-in button */
+  /**
+   * Render the child element as the trigger instead of AlertDialogTrigger's own
+   * `<button>`. Required whenever `children` is itself an interactive element
+   * (e.g. `<Button>`) — without it, the nested `<button>` gets auto-closed by the
+   * HTML parser and the alert dialog silently never opens.
+   */
   asChild?: boolean
   /** Button content */
   children?: Child
@@ -132,6 +174,9 @@ interface AlertDialogTriggerProps extends ButtonHTMLAttributes {
 
 /**
  * Button that triggers the alert dialog to open.
+ *
+ * @param props.asChild - Render child as trigger. Required when `children` is an
+ *   interactive element like `<Button>` — see AlertDialogTriggerProps.asChild for why.
  */
 function AlertDialogTrigger(props: AlertDialogTriggerProps) {
   const handleMount = (el: HTMLElement) => {
@@ -140,6 +185,8 @@ function AlertDialogTrigger(props: AlertDialogTriggerProps) {
     el.addEventListener('click', () => {
       ctx.onOpenChange(!ctx.open())
     })
+
+    if (!props.asChild) warnIfMisusedTrigger(el, 'AlertDialogTrigger')
   }
 
   if (props.asChild) {

--- a/ui/components/ui/dialog/index.tsx
+++ b/ui/components/ui/dialog/index.tsx
@@ -34,6 +34,16 @@
  *   </DialogContent>
  * </Dialog>
  * ```
+ *
+ * @example Styled trigger (asChild)
+ * ```tsx
+ * // Wrapping a <Button> (or any element) inside DialogTrigger requires asChild.
+ * // Without it, DialogTrigger renders its OWN <button>, the HTML parser auto-closes
+ * // the nested <button>, and the dialog silently never opens.
+ * <DialogTrigger asChild>
+ *   <Button variant="outline">Open Dialog</Button>
+ * </DialogTrigger>
+ * ```
  */
 
 import { createContext, useContext, createEffect, createPortal, isSSRPortal } from '@barefootjs/client'
@@ -123,12 +133,44 @@ function Dialog(props: DialogProps) {
 const DialogRoot = Dialog
 
 /**
+ * Detects the classic shadcn/ui migration mistake: wrapping an interactive
+ * element (e.g. `<Button>`) inside a non-asChild *Trigger. The Trigger renders
+ * its own `<button>` around it, so the HTML parser auto-closes the nested
+ * `<button>` while parsing — the outer trigger ends up EMPTY with the inner
+ * element as its next sibling instead of its child. Click wiring lands on the
+ * empty outer button, so the visible inner element does nothing.
+ * For DOM trees built without going through the HTML parser (e.g. programmatic
+ * DOM construction), the nested element can instead survive as an actual
+ * descendant, so both shapes are checked.
+ * See https://github.com/piconic-ai/barefootjs/issues/2127.
+ */
+function warnIfMisusedTrigger(el: HTMLElement, componentName: string): void {
+  const interactiveSelector = 'button, [role="button"], a[href]'
+  const hasNestedInteractive = el.querySelector(interactiveSelector) != null
+  const isEmpty = Array.from(el.childNodes).every(
+    (node) => node.nodeType === Node.TEXT_NODE && !node.textContent?.trim()
+  )
+  const siblingIsInteractive = isEmpty && (el.nextElementSibling?.matches(interactiveSelector) ?? false)
+
+  if (hasNestedInteractive || siblingIsInteractive) {
+    console.warn(
+      `[barefootjs] ${componentName} rendered an empty trigger next to an interactive element — did you nest a <button>/<Button> inside it? Use <${componentName} asChild> to adopt your own element.`
+    )
+  }
+}
+
+/**
  * Props for DialogTrigger component.
  */
 interface DialogTriggerProps extends ButtonHTMLAttributes {
   /** Whether disabled */
   disabled?: boolean
-  /** Render child element as trigger instead of built-in button */
+  /**
+   * Render the child element as the trigger instead of DialogTrigger's own `<button>`.
+   * Required whenever `children` is itself an interactive element (e.g. `<Button>`) —
+   * without it, DialogTrigger renders its own `<button>` around the child, the HTML
+   * parser auto-closes the nested `<button>`, and the dialog silently never opens.
+   */
   asChild?: boolean
   /** Button content */
   children?: Child
@@ -139,7 +181,8 @@ interface DialogTriggerProps extends ButtonHTMLAttributes {
  * Reads open state from context and toggles via onOpenChange.
  *
  * @param props.disabled - Whether disabled
- * @param props.asChild - Render child as trigger
+ * @param props.asChild - Render child as trigger. Required when `children` is an
+ *   interactive element like `<Button>` — see DialogTriggerProps.asChild for why.
  */
 function DialogTrigger(props: DialogTriggerProps) {
   const handleMount = (el: HTMLElement) => {
@@ -148,6 +191,8 @@ function DialogTrigger(props: DialogTriggerProps) {
     el.addEventListener('click', () => {
       ctx.onOpenChange(!ctx.open())
     })
+
+    if (!props.asChild) warnIfMisusedTrigger(el, 'DialogTrigger')
   }
 
   if (props.asChild) {

--- a/ui/components/ui/dialog/index.tsx
+++ b/ui/components/ui/dialog/index.tsx
@@ -37,7 +37,7 @@
  *
  * @example Styled trigger (asChild)
  * ```tsx
- * // Wrapping a <Button> (or any element) inside DialogTrigger requires asChild.
+ * // Wrapping a <Button> (or any interactive element) inside DialogTrigger requires asChild.
  * // Without it, DialogTrigger renders its OWN <button>, the HTML parser auto-closes
  * // the nested <button>, and the dialog silently never opens.
  * <DialogTrigger asChild>
@@ -152,9 +152,13 @@ function warnIfMisusedTrigger(el: HTMLElement, componentName: string): void {
   )
   const siblingIsInteractive = isEmpty && (el.nextElementSibling?.matches(interactiveSelector) ?? false)
 
-  if (hasNestedInteractive || siblingIsInteractive) {
+  if (hasNestedInteractive) {
     console.warn(
-      `[barefootjs] ${componentName} rendered an empty trigger next to an interactive element — did you nest a <button>/<Button> inside it? Use <${componentName} asChild> to adopt your own element.`
+      `[barefootjs] ${componentName} contains a nested interactive element (<button>, <a href>, or [role="button"]) inside the trigger's own <button> — nested interactive elements don't work reliably. Use <${componentName} asChild> to adopt your element instead.`
+    )
+  } else if (siblingIsInteractive) {
+    console.warn(
+      `[barefootjs] ${componentName} rendered an empty trigger followed by an interactive element — this is what the HTML parser produces from a <button>/<Button> nested inside the trigger. Use <${componentName} asChild> to adopt your element instead.`
     )
   }
 }

--- a/ui/components/ui/drawer/index.tsx
+++ b/ui/components/ui/drawer/index.tsx
@@ -174,9 +174,13 @@ function warnIfMisusedTrigger(el: HTMLElement, componentName: string): void {
   )
   const siblingIsInteractive = isEmpty && (el.nextElementSibling?.matches(interactiveSelector) ?? false)
 
-  if (hasNestedInteractive || siblingIsInteractive) {
+  if (hasNestedInteractive) {
     console.warn(
-      `[barefootjs] ${componentName} rendered an empty trigger next to an interactive element — did you nest a <button>/<Button> inside it? Use <${componentName} asChild> to adopt your own element.`
+      `[barefootjs] ${componentName} contains a nested interactive element (<button>, <a href>, or [role="button"]) inside the trigger's own <button> — nested interactive elements don't work reliably. Use <${componentName} asChild> to adopt your element instead.`
+    )
+  } else if (siblingIsInteractive) {
+    console.warn(
+      `[barefootjs] ${componentName} rendered an empty trigger followed by an interactive element — this is what the HTML parser produces from a <button>/<Button> nested inside the trigger. Use <${componentName} asChild> to adopt your element instead.`
     )
   }
 }

--- a/ui/components/ui/drawer/index.tsx
+++ b/ui/components/ui/drawer/index.tsx
@@ -38,6 +38,16 @@
  *   </DrawerContent>
  * </Drawer>
  * ```
+ *
+ * @example Styled trigger (asChild)
+ * ```tsx
+ * // Wrapping a <Button> inside DrawerTrigger requires asChild. Without it,
+ * // DrawerTrigger renders its OWN <button>, the HTML parser auto-closes the
+ * // nested <button>, and the drawer silently never opens.
+ * <DrawerTrigger asChild>
+ *   <Button variant="outline">Open Drawer</Button>
+ * </DrawerTrigger>
+ * ```
  */
 
 import { createContext, useContext, createEffect, createPortal, isSSRPortal } from '@barefootjs/client'
@@ -145,12 +155,44 @@ function Drawer(props: DrawerProps) {
 }
 
 /**
+ * Detects the classic shadcn/ui migration mistake: wrapping an interactive
+ * element (e.g. `<Button>`) inside a non-asChild *Trigger. The Trigger renders
+ * its own `<button>` around it, so the HTML parser auto-closes the nested
+ * `<button>` while parsing — the outer trigger ends up EMPTY with the inner
+ * element as its next sibling instead of its child. Click wiring lands on the
+ * empty outer button, so the visible inner element does nothing.
+ * For DOM trees built without going through the HTML parser (e.g. programmatic
+ * DOM construction), the nested element can instead survive as an actual
+ * descendant, so both shapes are checked.
+ * See https://github.com/piconic-ai/barefootjs/issues/2127.
+ */
+function warnIfMisusedTrigger(el: HTMLElement, componentName: string): void {
+  const interactiveSelector = 'button, [role="button"], a[href]'
+  const hasNestedInteractive = el.querySelector(interactiveSelector) != null
+  const isEmpty = Array.from(el.childNodes).every(
+    (node) => node.nodeType === Node.TEXT_NODE && !node.textContent?.trim()
+  )
+  const siblingIsInteractive = isEmpty && (el.nextElementSibling?.matches(interactiveSelector) ?? false)
+
+  if (hasNestedInteractive || siblingIsInteractive) {
+    console.warn(
+      `[barefootjs] ${componentName} rendered an empty trigger next to an interactive element — did you nest a <button>/<Button> inside it? Use <${componentName} asChild> to adopt your own element.`
+    )
+  }
+}
+
+/**
  * Props for DrawerTrigger component.
  */
 interface DrawerTriggerProps extends ButtonHTMLAttributes {
   /** Whether disabled */
   disabled?: boolean
-  /** Render child element as trigger instead of built-in button */
+  /**
+   * Render the child element as the trigger instead of DrawerTrigger's own
+   * `<button>`. Required whenever `children` is itself an interactive element
+   * (e.g. `<Button>`) — without it, the nested `<button>` gets auto-closed by the
+   * HTML parser and the drawer silently never opens.
+   */
   asChild?: boolean
   /** Button content */
   children?: Child
@@ -161,7 +203,8 @@ interface DrawerTriggerProps extends ButtonHTMLAttributes {
  * Reads open state from context and toggles via onOpenChange.
  *
  * @param props.disabled - Whether disabled
- * @param props.asChild - Render child as trigger
+ * @param props.asChild - Render child as trigger. Required when `children` is an
+ *   interactive element like `<Button>` — see DrawerTriggerProps.asChild for why.
  */
 function DrawerTrigger(props: DrawerTriggerProps) {
   const handleMount = (el: HTMLElement) => {
@@ -170,6 +213,8 @@ function DrawerTrigger(props: DrawerTriggerProps) {
     el.addEventListener('click', () => {
       ctx.onOpenChange(!ctx.open())
     })
+
+    if (!props.asChild) warnIfMisusedTrigger(el, 'DrawerTrigger')
   }
 
   if (props.asChild) {

--- a/ui/components/ui/dropdown-menu/index.tsx
+++ b/ui/components/ui/dropdown-menu/index.tsx
@@ -174,9 +174,13 @@ function warnIfMisusedTrigger(el: HTMLElement, componentName: string): void {
   )
   const siblingIsInteractive = isEmpty && (el.nextElementSibling?.matches(interactiveSelector) ?? false)
 
-  if (hasNestedInteractive || siblingIsInteractive) {
+  if (hasNestedInteractive) {
     console.warn(
-      `[barefootjs] ${componentName} rendered an empty trigger next to an interactive element — did you nest a <button>/<Button> inside it? Use <${componentName} asChild> to adopt your own element.`
+      `[barefootjs] ${componentName} contains a nested interactive element (<button>, <a href>, or [role="button"]) inside the trigger's own <button> — nested interactive elements don't work reliably. Use <${componentName} asChild> to adopt your element instead.`
+    )
+  } else if (siblingIsInteractive) {
+    console.warn(
+      `[barefootjs] ${componentName} rendered an empty trigger followed by an interactive element — this is what the HTML parser produces from a <button>/<Button> nested inside the trigger. Use <${componentName} asChild> to adopt your element instead.`
     )
   }
 }

--- a/ui/components/ui/dropdown-menu/index.tsx
+++ b/ui/components/ui/dropdown-menu/index.tsx
@@ -34,6 +34,16 @@
  *   </DropdownMenuContent>
  * </DropdownMenu>
  * ```
+ *
+ * @example Styled trigger (asChild)
+ * ```tsx
+ * // Wrapping a <Button> inside DropdownMenuTrigger requires asChild. Without it,
+ * // DropdownMenuTrigger renders its OWN <button>, the HTML parser auto-closes the
+ * // nested <button>, and the menu silently never opens.
+ * <DropdownMenuTrigger asChild>
+ *   <Button variant="outline">Open Menu</Button>
+ * </DropdownMenuTrigger>
+ * ```
  */
 
 import { createContext, useContext, createSignal, createMemo, createEffect, createPortal, isSSRPortal, findSiblingSlot } from '@barefootjs/client'
@@ -145,12 +155,44 @@ function DropdownMenu(props: DropdownMenuProps) {
 }
 
 /**
+ * Detects the classic shadcn/ui migration mistake: wrapping an interactive
+ * element (e.g. `<Button>`) inside a non-asChild *Trigger. The Trigger renders
+ * its own `<button>` around it, so the HTML parser auto-closes the nested
+ * `<button>` while parsing — the outer trigger ends up EMPTY with the inner
+ * element as its next sibling instead of its child. Click wiring lands on the
+ * empty outer button, so the visible inner element does nothing.
+ * For DOM trees built without going through the HTML parser (e.g. programmatic
+ * DOM construction), the nested element can instead survive as an actual
+ * descendant, so both shapes are checked.
+ * See https://github.com/piconic-ai/barefootjs/issues/2127.
+ */
+function warnIfMisusedTrigger(el: HTMLElement, componentName: string): void {
+  const interactiveSelector = 'button, [role="button"], a[href]'
+  const hasNestedInteractive = el.querySelector(interactiveSelector) != null
+  const isEmpty = Array.from(el.childNodes).every(
+    (node) => node.nodeType === Node.TEXT_NODE && !node.textContent?.trim()
+  )
+  const siblingIsInteractive = isEmpty && (el.nextElementSibling?.matches(interactiveSelector) ?? false)
+
+  if (hasNestedInteractive || siblingIsInteractive) {
+    console.warn(
+      `[barefootjs] ${componentName} rendered an empty trigger next to an interactive element — did you nest a <button>/<Button> inside it? Use <${componentName} asChild> to adopt your own element.`
+    )
+  }
+}
+
+/**
  * Props for DropdownMenuTrigger component.
  */
 interface DropdownMenuTriggerProps extends ButtonHTMLAttributes {
   /** Whether disabled */
   disabled?: boolean
-  /** Render child element as trigger instead of built-in button */
+  /**
+   * Render the child element as the trigger instead of DropdownMenuTrigger's own
+   * `<button>`. Required whenever `children` is itself an interactive element
+   * (e.g. `<Button>`) — without it, the nested `<button>` gets auto-closed by the
+   * HTML parser and the menu silently never opens.
+   */
   asChild?: boolean
   /** Trigger content (any element: button, avatar, icon, etc.) */
   children?: Child
@@ -161,7 +203,8 @@ interface DropdownMenuTriggerProps extends ButtonHTMLAttributes {
  * Reads open state from context and toggles via onOpenChange.
  *
  * @param props.disabled - Whether disabled
- * @param props.asChild - Render child as trigger
+ * @param props.asChild - Render child as trigger. Required when `children` is an
+ *   interactive element like `<Button>` — see DropdownMenuTriggerProps.asChild for why.
  */
 function DropdownMenuTrigger(props: DropdownMenuTriggerProps) {
   const handleMount = (el: HTMLElement) => {
@@ -174,6 +217,8 @@ function DropdownMenuTrigger(props: DropdownMenuTriggerProps) {
     el.addEventListener('click', () => {
       ctx.onOpenChange(!ctx.open())
     })
+
+    if (!props.asChild) warnIfMisusedTrigger(el, 'DropdownMenuTrigger')
   }
 
   if (props.asChild) {

--- a/ui/components/ui/hover-card/index.tsx
+++ b/ui/components/ui/hover-card/index.tsx
@@ -33,8 +33,8 @@
  *
  * @example Styled trigger (asChild)
  * ```tsx
- * // asChild adopts the child element directly (no wrapping span styling) —
- * // useful when the trigger needs to be an existing styled component, e.g. Avatar.
+ * // asChild swaps the styled trigger wrapper for a neutral display:contents span,
+ * // so the child keeps its own layout/styling — e.g. an existing Avatar component.
  * <HoverCardTrigger asChild>
  *   <Avatar>
  *     <AvatarImage src="/user.png" alt="@username" />
@@ -128,9 +128,10 @@ function HoverCard(props: HoverCardProps) {
  */
 interface HoverCardTriggerProps extends HTMLBaseAttributes {
   /**
-   * Render the child element as the trigger instead of wrapping it in
-   * HoverCardTrigger's own `<span>`. Use this when the child already carries its
-   * own semantics/styling (e.g. an `<a>` or `<Avatar>`) so no extra wrapper is added.
+   * Render the wrapper as a neutral `display:contents` span instead of
+   * HoverCardTrigger's styled inline-flex `<span>`, so the child renders with its
+   * own layout/styling untouched. Use this when the child already carries its own
+   * semantics/styling (e.g. an `<a>` or `<Avatar>`).
    */
   asChild?: boolean
   /** Trigger content */

--- a/ui/components/ui/hover-card/index.tsx
+++ b/ui/components/ui/hover-card/index.tsx
@@ -30,6 +30,17 @@
  *   </HoverCardContent>
  * </HoverCard>
  * ```
+ *
+ * @example Styled trigger (asChild)
+ * ```tsx
+ * // asChild adopts the child element directly (no wrapping span styling) —
+ * // useful when the trigger needs to be an existing styled component, e.g. Avatar.
+ * <HoverCardTrigger asChild>
+ *   <Avatar>
+ *     <AvatarImage src="/user.png" alt="@username" />
+ *   </Avatar>
+ * </HoverCardTrigger>
+ * ```
  */
 
 import { createContext, useContext, createEffect, createPortal, isSSRPortal, findSiblingSlot } from '@barefootjs/client'
@@ -116,7 +127,11 @@ function HoverCard(props: HoverCardProps) {
  * Props for HoverCardTrigger component.
  */
 interface HoverCardTriggerProps extends HTMLBaseAttributes {
-  /** Whether to render child element as trigger */
+  /**
+   * Render the child element as the trigger instead of wrapping it in
+   * HoverCardTrigger's own `<span>`. Use this when the child already carries its
+   * own semantics/styling (e.g. an `<a>` or `<Avatar>`) so no extra wrapper is added.
+   */
   asChild?: boolean
   /** Trigger content */
   children?: Child

--- a/ui/components/ui/popover/index.preview.tsx
+++ b/ui/components/ui/popover/index.preview.tsx
@@ -2,16 +2,14 @@
 "use client"
 
 import { createSignal } from '@barefootjs/client'
-import { Popover, PopoverTrigger, PopoverContent, PopoverClose } from '../popover'
+import { Popover, PopoverTrigger, PopoverContent } from '../popover'
 
 export function Default() {
   const [open, setOpen] = createSignal(false)
 
   return (
     <Popover open={open()} onOpenChange={setOpen}>
-      <PopoverTrigger>
-        <button>Open</button>
-      </PopoverTrigger>
+      <PopoverTrigger>Open</PopoverTrigger>
       <PopoverContent>
         <p>Popover content here.</p>
       </PopoverContent>

--- a/ui/components/ui/popover/index.tsx
+++ b/ui/components/ui/popover/index.tsx
@@ -20,13 +20,21 @@
  * const [open, setOpen] = createSignal(false)
  *
  * <Popover open={open()} onOpenChange={setOpen}>
- *   <PopoverTrigger>
- *     <button>Open</button>
- *   </PopoverTrigger>
+ *   <PopoverTrigger>Open</PopoverTrigger>
  *   <PopoverContent>
  *     <p>Popover content here.</p>
  *   </PopoverContent>
  * </Popover>
+ * ```
+ *
+ * @example Styled trigger (asChild)
+ * ```tsx
+ * // Wrapping a <Button> inside PopoverTrigger requires asChild. Without it,
+ * // PopoverTrigger renders its OWN <button>, the HTML parser auto-closes the
+ * // nested <button>, and the popover silently never opens.
+ * <PopoverTrigger asChild>
+ *   <Button variant="outline">Open</Button>
+ * </PopoverTrigger>
  * ```
  */
 
@@ -91,12 +99,44 @@ function Popover(props: PopoverProps) {
 }
 
 /**
+ * Detects the classic shadcn/ui migration mistake: wrapping an interactive
+ * element (e.g. `<Button>`) inside a non-asChild *Trigger. The Trigger renders
+ * its own `<button>` around it, so the HTML parser auto-closes the nested
+ * `<button>` while parsing — the outer trigger ends up EMPTY with the inner
+ * element as its next sibling instead of its child. Click wiring lands on the
+ * empty outer button, so the visible inner element does nothing.
+ * For DOM trees built without going through the HTML parser (e.g. programmatic
+ * DOM construction), the nested element can instead survive as an actual
+ * descendant, so both shapes are checked.
+ * See https://github.com/piconic-ai/barefootjs/issues/2127.
+ */
+function warnIfMisusedTrigger(el: HTMLElement, componentName: string): void {
+  const interactiveSelector = 'button, [role="button"], a[href]'
+  const hasNestedInteractive = el.querySelector(interactiveSelector) != null
+  const isEmpty = Array.from(el.childNodes).every(
+    (node) => node.nodeType === Node.TEXT_NODE && !node.textContent?.trim()
+  )
+  const siblingIsInteractive = isEmpty && (el.nextElementSibling?.matches(interactiveSelector) ?? false)
+
+  if (hasNestedInteractive || siblingIsInteractive) {
+    console.warn(
+      `[barefootjs] ${componentName} rendered an empty trigger next to an interactive element — did you nest a <button>/<Button> inside it? Use <${componentName} asChild> to adopt your own element.`
+    )
+  }
+}
+
+/**
  * Props for PopoverTrigger component.
  */
 interface PopoverTriggerProps extends ButtonHTMLAttributes {
   /** Whether disabled */
   disabled?: boolean
-  /** Render child element as trigger instead of built-in button */
+  /**
+   * Render the child element as the trigger instead of PopoverTrigger's own
+   * `<button>`. Required whenever `children` is itself an interactive element
+   * (e.g. `<Button>`) — without it, the nested `<button>` gets auto-closed by the
+   * HTML parser and the popover silently never opens.
+   */
   asChild?: boolean
   /** Trigger content */
   children?: Child
@@ -107,7 +147,8 @@ interface PopoverTriggerProps extends ButtonHTMLAttributes {
  * Reads open state from context and toggles via onOpenChange.
  *
  * @param props.disabled - Whether disabled
- * @param props.asChild - Render child as trigger
+ * @param props.asChild - Render child as trigger. Required when `children` is an
+ *   interactive element like `<Button>` — see PopoverTriggerProps.asChild for why.
  */
 function PopoverTrigger(props: PopoverTriggerProps) {
   const handleMount = (el: HTMLElement) => {
@@ -120,6 +161,8 @@ function PopoverTrigger(props: PopoverTriggerProps) {
     el.addEventListener('click', () => {
       ctx.onOpenChange(!ctx.open())
     })
+
+    if (!props.asChild) warnIfMisusedTrigger(el, 'PopoverTrigger')
   }
 
   if (props.asChild) {

--- a/ui/components/ui/popover/index.tsx
+++ b/ui/components/ui/popover/index.tsx
@@ -118,9 +118,13 @@ function warnIfMisusedTrigger(el: HTMLElement, componentName: string): void {
   )
   const siblingIsInteractive = isEmpty && (el.nextElementSibling?.matches(interactiveSelector) ?? false)
 
-  if (hasNestedInteractive || siblingIsInteractive) {
+  if (hasNestedInteractive) {
     console.warn(
-      `[barefootjs] ${componentName} rendered an empty trigger next to an interactive element — did you nest a <button>/<Button> inside it? Use <${componentName} asChild> to adopt your own element.`
+      `[barefootjs] ${componentName} contains a nested interactive element (<button>, <a href>, or [role="button"]) inside the trigger's own <button> — nested interactive elements don't work reliably. Use <${componentName} asChild> to adopt your element instead.`
+    )
+  } else if (siblingIsInteractive) {
+    console.warn(
+      `[barefootjs] ${componentName} rendered an empty trigger followed by an interactive element — this is what the HTML parser produces from a <button>/<Button> nested inside the trigger. Use <${componentName} asChild> to adopt your element instead.`
     )
   }
 }

--- a/ui/components/ui/sheet/index.tsx
+++ b/ui/components/ui/sheet/index.tsx
@@ -176,9 +176,13 @@ function warnIfMisusedTrigger(el: HTMLElement, componentName: string): void {
   )
   const siblingIsInteractive = isEmpty && (el.nextElementSibling?.matches(interactiveSelector) ?? false)
 
-  if (hasNestedInteractive || siblingIsInteractive) {
+  if (hasNestedInteractive) {
     console.warn(
-      `[barefootjs] ${componentName} rendered an empty trigger next to an interactive element — did you nest a <button>/<Button> inside it? Use <${componentName} asChild> to adopt your own element.`
+      `[barefootjs] ${componentName} contains a nested interactive element (<button>, <a href>, or [role="button"]) inside the trigger's own <button> — nested interactive elements don't work reliably. Use <${componentName} asChild> to adopt your element instead.`
+    )
+  } else if (siblingIsInteractive) {
+    console.warn(
+      `[barefootjs] ${componentName} rendered an empty trigger followed by an interactive element — this is what the HTML parser produces from a <button>/<Button> nested inside the trigger. Use <${componentName} asChild> to adopt your element instead.`
     )
   }
 }

--- a/ui/components/ui/sheet/index.tsx
+++ b/ui/components/ui/sheet/index.tsx
@@ -36,6 +36,16 @@
  *   </SheetContent>
  * </Sheet>
  * ```
+ *
+ * @example Styled trigger (asChild)
+ * ```tsx
+ * // Wrapping a <Button> inside SheetTrigger requires asChild. Without it,
+ * // SheetTrigger renders its OWN <button>, the HTML parser auto-closes the
+ * // nested <button>, and the sheet silently never opens.
+ * <SheetTrigger asChild>
+ *   <Button variant="outline">Open Sheet</Button>
+ * </SheetTrigger>
+ * ```
  */
 
 import { createContext, useContext, createEffect, createPortal, isSSRPortal } from '@barefootjs/client'
@@ -147,12 +157,44 @@ function Sheet(props: SheetProps) {
 }
 
 /**
+ * Detects the classic shadcn/ui migration mistake: wrapping an interactive
+ * element (e.g. `<Button>`) inside a non-asChild *Trigger. The Trigger renders
+ * its own `<button>` around it, so the HTML parser auto-closes the nested
+ * `<button>` while parsing — the outer trigger ends up EMPTY with the inner
+ * element as its next sibling instead of its child. Click wiring lands on the
+ * empty outer button, so the visible inner element does nothing.
+ * For DOM trees built without going through the HTML parser (e.g. programmatic
+ * DOM construction), the nested element can instead survive as an actual
+ * descendant, so both shapes are checked.
+ * See https://github.com/piconic-ai/barefootjs/issues/2127.
+ */
+function warnIfMisusedTrigger(el: HTMLElement, componentName: string): void {
+  const interactiveSelector = 'button, [role="button"], a[href]'
+  const hasNestedInteractive = el.querySelector(interactiveSelector) != null
+  const isEmpty = Array.from(el.childNodes).every(
+    (node) => node.nodeType === Node.TEXT_NODE && !node.textContent?.trim()
+  )
+  const siblingIsInteractive = isEmpty && (el.nextElementSibling?.matches(interactiveSelector) ?? false)
+
+  if (hasNestedInteractive || siblingIsInteractive) {
+    console.warn(
+      `[barefootjs] ${componentName} rendered an empty trigger next to an interactive element — did you nest a <button>/<Button> inside it? Use <${componentName} asChild> to adopt your own element.`
+    )
+  }
+}
+
+/**
  * Props for SheetTrigger component.
  */
 interface SheetTriggerProps extends ButtonHTMLAttributes {
   /** Whether disabled */
   disabled?: boolean
-  /** Render child element as trigger instead of built-in button */
+  /**
+   * Render the child element as the trigger instead of SheetTrigger's own
+   * `<button>`. Required whenever `children` is itself an interactive element
+   * (e.g. `<Button>`) — without it, the nested `<button>` gets auto-closed by the
+   * HTML parser and the sheet silently never opens.
+   */
   asChild?: boolean
   /** Button content */
   children?: Child
@@ -163,7 +205,8 @@ interface SheetTriggerProps extends ButtonHTMLAttributes {
  * Reads open state from context and toggles via onOpenChange.
  *
  * @param props.disabled - Whether disabled
- * @param props.asChild - Render child as trigger
+ * @param props.asChild - Render child as trigger. Required when `children` is an
+ *   interactive element like `<Button>` — see SheetTriggerProps.asChild for why.
  */
 function SheetTrigger(props: SheetTriggerProps) {
   const handleMount = (el: HTMLElement) => {
@@ -172,6 +215,8 @@ function SheetTrigger(props: SheetTriggerProps) {
     el.addEventListener('click', () => {
       ctx.onOpenChange(!ctx.open())
     })
+
+    if (!props.asChild) warnIfMisusedTrigger(el, 'SheetTrigger')
   }
 
   if (props.asChild) {

--- a/ui/meta/alert-dialog.json
+++ b/ui/meta/alert-dialog.json
@@ -52,7 +52,7 @@
           "name": "asChild",
           "type": "boolean",
           "required": false,
-          "description": "Render child element as trigger instead of built-in button"
+          "description": "Render the child element as the trigger instead of AlertDialogTrigger's own `<button>`. Required whenever `children` is itself an interactive element (e.g. `<Button>`) — without it, the nested `<button>` gets auto-closed by the HTML parser and the alert dialog silently never opens."
         },
         {
           "name": "children",
@@ -174,10 +174,14 @@
     {
       "title": "Basic alert dialog",
       "code": "const [open, setOpen] = createSignal(false)\n\n<AlertDialog open={open()} onOpenChange={setOpen}>\n  <AlertDialogTrigger>Delete</AlertDialogTrigger>\n  <AlertDialogOverlay />\n  <AlertDialogContent ariaLabelledby=\"alert-title\" ariaDescribedby=\"alert-desc\">\n    <AlertDialogHeader>\n      <AlertDialogTitle id=\"alert-title\">Are you sure?</AlertDialogTitle>\n      <AlertDialogDescription id=\"alert-desc\">\n        This action cannot be undone.\n      </AlertDialogDescription>\n    </AlertDialogHeader>\n    <AlertDialogFooter>\n      <AlertDialogCancel>Cancel</AlertDialogCancel>\n      <AlertDialogAction>Continue</AlertDialogAction>\n    </AlertDialogFooter>\n  </AlertDialogContent>\n</AlertDialog>"
+    },
+    {
+      "title": "Styled trigger (asChild)",
+      "code": "// Wrapping a <Button> inside AlertDialogTrigger requires asChild. Without it,\n// AlertDialogTrigger renders its OWN <button>, the HTML parser auto-closes the\n// nested <button>, and the alert dialog silently never opens.\n<AlertDialogTrigger asChild>\n  <Button variant=\"destructive\">Delete</Button>\n</AlertDialogTrigger>"
     }
   ],
   "accessibility": {
-    "role": "alertdialog, dialog",
+    "role": "alertdialog, button, dialog",
     "ariaAttributes": [
       "aria-modal",
       "aria-labelledby",

--- a/ui/meta/dialog.json
+++ b/ui/meta/dialog.json
@@ -52,7 +52,7 @@
           "name": "asChild",
           "type": "boolean",
           "required": false,
-          "description": "Render child element as trigger instead of built-in button"
+          "description": "Render the child element as the trigger instead of DialogTrigger's own `<button>`. Required whenever `children` is itself an interactive element (e.g. `<Button>`) — without it, DialogTrigger renders its own `<button>` around the child, the HTML parser auto-closes the nested `<button>`, and the dialog silently never opens."
         },
         {
           "name": "children",
@@ -168,10 +168,14 @@
     {
       "title": "Basic dialog",
       "code": "const [open, setOpen] = createSignal(false)\n\n<Dialog open={open()} onOpenChange={setOpen}>\n  <DialogTrigger>Open Dialog</DialogTrigger>\n  <DialogOverlay />\n  <DialogContent ariaLabelledby=\"dialog-title\">\n    <DialogHeader>\n      <DialogTitle id=\"dialog-title\">Dialog Title</DialogTitle>\n      <DialogDescription>Dialog description here.</DialogDescription>\n    </DialogHeader>\n    <DialogFooter>\n      <DialogClose>Cancel</DialogClose>\n      <Button onClick={handleAction}>Confirm</Button>\n    </DialogFooter>\n  </DialogContent>\n</Dialog>"
+    },
+    {
+      "title": "Styled trigger (asChild)",
+      "code": "// Wrapping a <Button> (or any element) inside DialogTrigger requires asChild.\n// Without it, DialogTrigger renders its OWN <button>, the HTML parser auto-closes\n// the nested <button>, and the dialog silently never opens.\n<DialogTrigger asChild>\n  <Button variant=\"outline\">Open Dialog</Button>\n</DialogTrigger>"
     }
   ],
   "accessibility": {
-    "role": "dialog",
+    "role": "dialog, button",
     "ariaAttributes": [
       "aria-modal",
       "aria-labelledby",

--- a/ui/meta/dialog.json
+++ b/ui/meta/dialog.json
@@ -171,7 +171,7 @@
     },
     {
       "title": "Styled trigger (asChild)",
-      "code": "// Wrapping a <Button> (or any element) inside DialogTrigger requires asChild.\n// Without it, DialogTrigger renders its OWN <button>, the HTML parser auto-closes\n// the nested <button>, and the dialog silently never opens.\n<DialogTrigger asChild>\n  <Button variant=\"outline\">Open Dialog</Button>\n</DialogTrigger>"
+      "code": "// Wrapping a <Button> (or any interactive element) inside DialogTrigger requires asChild.\n// Without it, DialogTrigger renders its OWN <button>, the HTML parser auto-closes\n// the nested <button>, and the dialog silently never opens.\n<DialogTrigger asChild>\n  <Button variant=\"outline\">Open Dialog</Button>\n</DialogTrigger>"
     }
   ],
   "accessibility": {

--- a/ui/meta/drawer.json
+++ b/ui/meta/drawer.json
@@ -52,7 +52,7 @@
           "name": "asChild",
           "type": "boolean",
           "required": false,
-          "description": "Render child element as trigger instead of built-in button"
+          "description": "Render the child element as the trigger instead of DrawerTrigger's own `<button>`. Required whenever `children` is itself an interactive element (e.g. `<Button>`) — without it, the nested `<button>` gets auto-closed by the HTML parser and the drawer silently never opens."
         },
         {
           "name": "children",
@@ -167,10 +167,14 @@
     {
       "title": "Basic drawer",
       "code": "const [open, setOpen] = createSignal(false)\n\n<Drawer open={open()} onOpenChange={setOpen}>\n  <DrawerTrigger>Open Drawer</DrawerTrigger>\n  <DrawerOverlay />\n  <DrawerContent direction=\"bottom\" ariaLabelledby=\"drawer-title\">\n    <DrawerHandle />\n    <DrawerHeader>\n      <DrawerTitle id=\"drawer-title\">Drawer Title</DrawerTitle>\n      <DrawerDescription>Drawer description here.</DrawerDescription>\n    </DrawerHeader>\n    <DrawerFooter>\n      <DrawerClose>Close</DrawerClose>\n    </DrawerFooter>\n  </DrawerContent>\n</Drawer>"
+    },
+    {
+      "title": "Styled trigger (asChild)",
+      "code": "// Wrapping a <Button> inside DrawerTrigger requires asChild. Without it,\n// DrawerTrigger renders its OWN <button>, the HTML parser auto-closes the\n// nested <button>, and the drawer silently never opens.\n<DrawerTrigger asChild>\n  <Button variant=\"outline\">Open Drawer</Button>\n</DrawerTrigger>"
     }
   ],
   "accessibility": {
-    "role": "dialog",
+    "role": "dialog, button",
     "ariaAttributes": [
       "aria-modal",
       "aria-labelledby",

--- a/ui/meta/dropdown-menu.json
+++ b/ui/meta/dropdown-menu.json
@@ -46,7 +46,7 @@
           "name": "asChild",
           "type": "boolean",
           "required": false,
-          "description": "Render child element as trigger instead of built-in button"
+          "description": "Render the child element as the trigger instead of DropdownMenuTrigger's own `<button>`. Required whenever `children` is itself an interactive element (e.g. `<Button>`) — without it, the nested `<button>` gets auto-closed by the HTML parser and the menu silently never opens."
         },
         {
           "name": "children",
@@ -270,10 +270,14 @@
     {
       "title": "Basic dropdown menu",
       "code": "const [open, setOpen] = createSignal(false)\n\n<DropdownMenu open={open()} onOpenChange={setOpen}>\n  <DropdownMenuTrigger>\n    <span>Open Menu</span>\n  </DropdownMenuTrigger>\n  <DropdownMenuContent>\n    <DropdownMenuLabel>My Account</DropdownMenuLabel>\n    <DropdownMenuSeparator />\n    <DropdownMenuItem onSelect={() => {}}>Settings</DropdownMenuItem>\n    <DropdownMenuItem onSelect={() => {}}>Log out</DropdownMenuItem>\n  </DropdownMenuContent>\n</DropdownMenu>"
+    },
+    {
+      "title": "Styled trigger (asChild)",
+      "code": "// Wrapping a <Button> inside DropdownMenuTrigger requires asChild. Without it,\n// DropdownMenuTrigger renders its OWN <button>, the HTML parser auto-closes the\n// nested <button>, and the menu silently never opens.\n<DropdownMenuTrigger asChild>\n  <Button variant=\"outline\">Open Menu</Button>\n</DropdownMenuTrigger>"
     }
   ],
   "accessibility": {
-    "role": "menu, menuitem, menuitemcheckbox, group, menuitemradio, separator",
+    "role": "menu, menuitem, button, menuitemcheckbox, group, menuitemradio, separator",
     "ariaAttributes": [
       "aria-expanded",
       "aria-haspopup",

--- a/ui/meta/hover-card.json
+++ b/ui/meta/hover-card.json
@@ -54,7 +54,7 @@
           "name": "asChild",
           "type": "boolean",
           "required": false,
-          "description": "Render the child element as the trigger instead of wrapping it in HoverCardTrigger's own `<span>`. Use this when the child already carries its own semantics/styling (e.g. an `<a>` or `<Avatar>`) so no extra wrapper is added."
+          "description": "Render the wrapper as a neutral `display:contents` span instead of HoverCardTrigger's styled inline-flex `<span>`, so the child renders with its own layout/styling untouched. Use this when the child already carries its own semantics/styling (e.g. an `<a>` or `<Avatar>`)."
         },
         {
           "name": "children",
@@ -96,7 +96,7 @@
     },
     {
       "title": "Styled trigger (asChild)",
-      "code": "// asChild adopts the child element directly (no wrapping span styling) —\n// useful when the trigger needs to be an existing styled component, e.g. Avatar.\n<HoverCardTrigger asChild>\n  <Avatar>\n    <AvatarImage src=\"/user.png\" alt=\"@username\" />\n  </Avatar>\n</HoverCardTrigger>"
+      "code": "// asChild swaps the styled trigger wrapper for a neutral display:contents span,\n// so the child keeps its own layout/styling — e.g. an existing Avatar component.\n<HoverCardTrigger asChild>\n  <Avatar>\n    <AvatarImage src=\"/user.png\" alt=\"@username\" />\n  </Avatar>\n</HoverCardTrigger>"
     }
   ],
   "accessibility": {

--- a/ui/meta/hover-card.json
+++ b/ui/meta/hover-card.json
@@ -54,7 +54,7 @@
           "name": "asChild",
           "type": "boolean",
           "required": false,
-          "description": "Whether to render child element as trigger"
+          "description": "Render the child element as the trigger instead of wrapping it in HoverCardTrigger's own `<span>`. Use this when the child already carries its own semantics/styling (e.g. an `<a>` or `<Avatar>`) so no extra wrapper is added."
         },
         {
           "name": "children",
@@ -93,6 +93,10 @@
     {
       "title": "Basic hover card",
       "code": "const [open, setOpen] = createSignal(false)\n\n<HoverCard open={open()} onOpenChange={setOpen}>\n  <HoverCardTrigger>\n    <a href=\"#\">@username</a>\n  </HoverCardTrigger>\n  <HoverCardContent>\n    <p>User profile information</p>\n  </HoverCardContent>\n</HoverCard>"
+    },
+    {
+      "title": "Styled trigger (asChild)",
+      "code": "// asChild adopts the child element directly (no wrapping span styling) —\n// useful when the trigger needs to be an existing styled component, e.g. Avatar.\n<HoverCardTrigger asChild>\n  <Avatar>\n    <AvatarImage src=\"/user.png\" alt=\"@username\" />\n  </Avatar>\n</HoverCardTrigger>"
     }
   ],
   "accessibility": {

--- a/ui/meta/popover.json
+++ b/ui/meta/popover.json
@@ -46,7 +46,7 @@
           "name": "asChild",
           "type": "boolean",
           "required": false,
-          "description": "Render child element as trigger instead of built-in button"
+          "description": "Render the child element as the trigger instead of PopoverTrigger's own `<button>`. Required whenever `children` is itself an interactive element (e.g. `<Button>`) — without it, the nested `<button>` gets auto-closed by the HTML parser and the popover silently never opens."
         },
         {
           "name": "children",
@@ -96,10 +96,15 @@
   "examples": [
     {
       "title": "Basic popover",
-      "code": "const [open, setOpen] = createSignal(false)\n\n<Popover open={open()} onOpenChange={setOpen}>\n  <PopoverTrigger>\n    <button>Open</button>\n  </PopoverTrigger>\n  <PopoverContent>\n    <p>Popover content here.</p>\n  </PopoverContent>\n</Popover>"
+      "code": "const [open, setOpen] = createSignal(false)\n\n<Popover open={open()} onOpenChange={setOpen}>\n  <PopoverTrigger>Open</PopoverTrigger>\n  <PopoverContent>\n    <p>Popover content here.</p>\n  </PopoverContent>\n</Popover>"
+    },
+    {
+      "title": "Styled trigger (asChild)",
+      "code": "// Wrapping a <Button> inside PopoverTrigger requires asChild. Without it,\n// PopoverTrigger renders its OWN <button>, the HTML parser auto-closes the\n// nested <button>, and the popover silently never opens.\n<PopoverTrigger asChild>\n  <Button variant=\"outline\">Open</Button>\n</PopoverTrigger>"
     }
   ],
   "accessibility": {
+    "role": "button",
     "ariaAttributes": [
       "aria-expanded"
     ],

--- a/ui/meta/sheet.json
+++ b/ui/meta/sheet.json
@@ -52,7 +52,7 @@
           "name": "asChild",
           "type": "boolean",
           "required": false,
-          "description": "Render child element as trigger instead of built-in button"
+          "description": "Render the child element as the trigger instead of SheetTrigger's own `<button>`. Required whenever `children` is itself an interactive element (e.g. `<Button>`) — without it, the nested `<button>` gets auto-closed by the HTML parser and the sheet silently never opens."
         },
         {
           "name": "children",
@@ -176,10 +176,14 @@
     {
       "title": "Basic sheet",
       "code": "const [open, setOpen] = createSignal(false)\n\n<Sheet open={open()} onOpenChange={setOpen}>\n  <SheetTrigger>Open Sheet</SheetTrigger>\n  <SheetOverlay />\n  <SheetContent side=\"right\" ariaLabelledby=\"sheet-title\">\n    <SheetHeader>\n      <SheetTitle id=\"sheet-title\">Sheet Title</SheetTitle>\n      <SheetDescription>Sheet description here.</SheetDescription>\n    </SheetHeader>\n    <SheetFooter>\n      <SheetClose>Close</SheetClose>\n    </SheetFooter>\n  </SheetContent>\n</Sheet>"
+    },
+    {
+      "title": "Styled trigger (asChild)",
+      "code": "// Wrapping a <Button> inside SheetTrigger requires asChild. Without it,\n// SheetTrigger renders its OWN <button>, the HTML parser auto-closes the\n// nested <button>, and the sheet silently never opens.\n<SheetTrigger asChild>\n  <Button variant=\"outline\">Open Sheet</Button>\n</SheetTrigger>"
     }
   ],
   "accessibility": {
-    "role": "dialog",
+    "role": "dialog, button",
     "ariaAttributes": [
       "aria-modal",
       "aria-labelledby",


### PR DESCRIPTION
Closes #2127 (part of the #2125 onboarding umbrella).

Coming from shadcn/ui, wrapping a styled `<Button>` in `DialogTrigger` without `asChild` silently breaks the dialog: the trigger renders its own `<button>`, the HTML parser auto-closes the nested one, click wiring lands on an empty element, and nothing opens — no error, no warning. Implements suggestions 1 and 2 from the issue (not 3 — no default-behavior change).

## Changes

**Docs (suggestion 1)** — added an `@example Styled trigger (asChild)` JSDoc block and enriched the `asChild` prop docs (when it's required and why) on the seven components sharing the pattern: dialog, alert-dialog, drawer, sheet, dropdown-menu, popover, hover-card. Regenerated `ui/meta/*.json` so `bf docs <component>` surfaces the new examples (verified). Bonus find: Popover's own "Basic popover" example exhibited the exact bug (`<PopoverTrigger><button>…` without `asChild`) — fixed, and its preview regenerated via `bf gen preview`. Also clarified the `asChild` prop description on the site's Dialog reference page.

**Hydration-time warning (suggestion 2)** — the six Triggers whose non-asChild branch renders its own `<button>` (Dialog, AlertDialog, Drawer, Sheet, DropdownMenu, Popover) now call a `warnIfMisusedTrigger()` helper at mount: it warns when the trigger contains a nested `button/[role="button"]/a[href]`, or is empty with such an element as its next sibling (the shape the parser's auto-close produces). HoverCard is docs-only — its default branch wraps children in a `<span>`, so the footgun doesn't apply and the heuristic would false-positive on its documented `<a href>` default usage.

The parser-collapse assumption and the heuristic were verified in a real Chromium browser (happy-dom doesn't reproduce the auto-close quirk): nested-button and nested-anchor misuse warn; text triggers, icon children, and the asChild path don't.

## Tests

- `bun test ui/components`: 1240 pass, 0 fail (all component IR tests, including the six touched Triggers).
- No new E2E test: the console-warning behavior was verified directly in Chromium; the repo's e2e dev server currently fails to boot on an unrelated pre-existing issue (`Cannot find module '@/components/home-showcase'`).

## Notes

- Accordion/Collapsible triggers share the code shape and could get the same warning later; left out to match the issue's component list.
- No changeset: changes are in `ui/` registry components and site docs, not published `packages/*` source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xkd8GuNpavMbknvKs6czSM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xkd8GuNpavMbknvKs6czSM)_