### PR TITLE
ci: notify Packagist after split-mirror push & rename jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@
 #
 # Native runtimes:
 #   - cpan-release publishes Perl dists that correspond to bumped npm packages.
-#   - pypi-release / rubygems-release / crates-release / packagist-release
+#   - pypi-release / rubygems-release / crates-release / packagist-*-release
 #     follow the same pattern for first-party Python, Ruby, Rust, and PHP
 #     runtimes: when the corresponding adapter package is published by
 #     Changesets, build/test the native runtime and publish it with registry
@@ -243,7 +243,7 @@ jobs:
           cargo test
           cargo publish --dry-run
           cargo publish
-  packagist-release:
+  packagist-twig-release:
     needs: release
     if: needs.release.outputs.published == 'true' && contains(fromJSON(needs.release.outputs.publishedPackages).*.name, '@barefootjs/twig')
     runs-on: ubuntu-latest
@@ -384,12 +384,12 @@ jobs:
             "https://packagist.org/api/update-package?username=${PACKAGIST_USERNAME}" \
             -d '{"repository":{"url":"https://packagist.org/packages/barefootjs/blade"}}'
 
-  # Mirrors packagist-release's shape for the engine-agnostic PHP runtime
+  # Mirrors packagist-twig-release's shape for the engine-agnostic PHP runtime
   # package (packages/adapter-php, Composer name barefootjs/php) --
   # gated on @barefootjs/php (not @barefootjs/twig) being the package
   # Changesets just published, since the runtime and the Twig backend are
   # versioned/published independently.
-  packagist-runtime-release:
+  packagist-php-release:
     needs: release
     if: needs.release.outputs.published == 'true' && contains(fromJSON(needs.release.outputs.publishedPackages).*.name, '@barefootjs/php')
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,6 +304,17 @@ jobs:
           git push --force "$remote" "v${version}"
           git worktree remove "$split_dir" --force
 
+      - name: Notify Packagist
+        env:
+          PACKAGIST_USERNAME: ${{ vars.PACKAGIST_USERNAME || 'barefootjs' }}
+          PACKAGIST_API_TOKEN: ${{ secrets.PACKAGIST_API_TOKEN }}
+        run: |
+          curl -sSf -XPOST \
+            -H 'Content-Type: application/json' \
+            -H "API-Token: ${PACKAGIST_API_TOKEN}" \
+            "https://packagist.org/api/update-package?username=${PACKAGIST_USERNAME}" \
+            -d '{"repository":{"url":"https://packagist.org/packages/barefootjs/twig"}}'
+
   packagist-blade-release:
     needs: release
     if: needs.release.outputs.published == 'true' && contains(fromJSON(needs.release.outputs.publishedPackages).*.name, '@barefootjs/blade')
@@ -362,6 +373,16 @@ jobs:
           git push --force "$remote" "v${version}"
           git worktree remove "$split_dir" --force
 
+      - name: Notify Packagist
+        env:
+          PACKAGIST_USERNAME: ${{ vars.PACKAGIST_USERNAME || 'barefootjs' }}
+          PACKAGIST_API_TOKEN: ${{ secrets.PACKAGIST_API_TOKEN }}
+        run: |
+          curl -sSf -XPOST \
+            -H 'Content-Type: application/json' \
+            -H "API-Token: ${PACKAGIST_API_TOKEN}" \
+            "https://packagist.org/api/update-package?username=${PACKAGIST_USERNAME}" \
+            -d '{"repository":{"url":"https://packagist.org/packages/barefootjs/blade"}}'
 
   # Mirrors packagist-release's shape for the engine-agnostic PHP runtime
   # package (packages/adapter-php, Composer name barefootjs/php) --
@@ -411,3 +432,14 @@ jobs:
           git push --force "$remote" php-runtime-release-shared:main
           git tag -f "v${version}" php-runtime-release-shared
           git push --force "$remote" "v${version}"
+
+      - name: Notify Packagist
+        env:
+          PACKAGIST_USERNAME: ${{ vars.PACKAGIST_USERNAME || 'barefootjs' }}
+          PACKAGIST_API_TOKEN: ${{ secrets.PACKAGIST_API_TOKEN }}
+        run: |
+          curl -sSf -XPOST \
+            -H 'Content-Type: application/json' \
+            -H "API-Token: ${PACKAGIST_API_TOKEN}" \
+            "https://packagist.org/api/update-package?username=${PACKAGIST_USERNAME}" \
+            -d '{"repository":{"url":"https://packagist.org/packages/barefootjs/php"}}'


### PR DESCRIPTION
## Summary

- Add a "Notify Packagist" step to all three Packagist release jobs so packages auto-update on Packagist when new versions are pushed to the split-mirror repositories.
- Uses the Packagist update-package API with `PACKAGIST_API_TOKEN` (secret, already configured) and `PACKAGIST_USERNAME` (repository variable, defaults to `barefootjs`).
- Resolves the "This package is not auto-updated" warning on Packagist for `barefootjs/twig`, `barefootjs/blade`, and `barefootjs/php`.
- Rename jobs for clarity: `packagist-release` → `packagist-twig-release`, `packagist-runtime-release` → `packagist-php-release`.

## Packages affected

| Job | Packagist package |
|-----|------------------|
| `packagist-twig-release` | `barefootjs/twig` |
| `packagist-blade-release` | `barefootjs/blade` |
| `packagist-php-release` | `barefootjs/php` |

## Prerequisites

- `PACKAGIST_API_TOKEN` secret — already set.
- (Optional) `PACKAGIST_USERNAME` repository variable — defaults to `barefootjs` if not set.