### PR TITLE
chore: add mise.toml for runtime management + regenerate stale Go components.go

### DIFF
--- a/integrations/chi/components.go
+++ b/integrations/chi/components.go
@@ -195,7 +195,7 @@ type PropsStyleChildProps struct {
 	Scripts *bf.ScriptCollector `json:"-"`
 	Value int `json:"value"`
 	Label string `json:"label"`
-	DisplayValue interface{} `json:"displayValue"`
+	DisplayValue int `json:"displayValue"`
 }
 
 // DestructuredStyleChildInput is the user-facing input type.
@@ -218,7 +218,7 @@ type DestructuredStyleChildProps struct {
 	Scripts *bf.ScriptCollector `json:"-"`
 	Value interface{} `json:"value"`
 	Label interface{} `json:"label"`
-	DisplayValue interface{} `json:"displayValue"`
+	DisplayValue int `json:"displayValue"`
 }
 
 // PropsReactivityComparisonInput is the user-facing input type.
@@ -449,7 +449,7 @@ type PageShellProps struct {
 	BfMount string `json:"-"`
 	BfDataKey string `json:"-"`
 	Scripts *bf.ScriptCollector `json:"-"`
-	Children interface{} `json:"children"`
+	Children interface{} `json:"-"`
 	ReaderToolbarSlot0 ReaderToolbarProps `json:"-"`
 }
 
@@ -535,7 +535,7 @@ type PostListProps struct {
 	Tags []string `json:"tags"`
 	Base string `json:"base"`
 	Params map[string]interface{} `json:"params"`
-	Visible map[string]interface{} `json:"visible"`
+	Visible []Item `json:"visible"`
 	Root string `json:"-"`
 	PostListItems []PostListItemProps `json:"-"`
 }

--- a/integrations/echo/components.go
+++ b/integrations/echo/components.go
@@ -195,7 +195,7 @@ type PropsStyleChildProps struct {
 	Scripts *bf.ScriptCollector `json:"-"`
 	Value int `json:"value"`
 	Label string `json:"label"`
-	DisplayValue interface{} `json:"displayValue"`
+	DisplayValue int `json:"displayValue"`
 }
 
 // DestructuredStyleChildInput is the user-facing input type.
@@ -218,7 +218,7 @@ type DestructuredStyleChildProps struct {
 	Scripts *bf.ScriptCollector `json:"-"`
 	Value interface{} `json:"value"`
 	Label interface{} `json:"label"`
-	DisplayValue interface{} `json:"displayValue"`
+	DisplayValue int `json:"displayValue"`
 }
 
 // PropsReactivityComparisonInput is the user-facing input type.
@@ -449,7 +449,7 @@ type PageShellProps struct {
 	BfMount string `json:"-"`
 	BfDataKey string `json:"-"`
 	Scripts *bf.ScriptCollector `json:"-"`
-	Children interface{} `json:"children"`
+	Children interface{} `json:"-"`
 	ReaderToolbarSlot0 ReaderToolbarProps `json:"-"`
 }
 
@@ -535,7 +535,7 @@ type PostListProps struct {
 	Tags []string `json:"tags"`
 	Base string `json:"base"`
 	Params map[string]interface{} `json:"params"`
-	Visible map[string]interface{} `json:"visible"`
+	Visible []Item `json:"visible"`
 	Root string `json:"-"`
 	PostListItems []PostListItemProps `json:"-"`
 }

--- a/integrations/gin/components.go
+++ b/integrations/gin/components.go
@@ -195,7 +195,7 @@ type PropsStyleChildProps struct {
 	Scripts *bf.ScriptCollector `json:"-"`
 	Value int `json:"value"`
 	Label string `json:"label"`
-	DisplayValue interface{} `json:"displayValue"`
+	DisplayValue int `json:"displayValue"`
 }
 
 // DestructuredStyleChildInput is the user-facing input type.
@@ -218,7 +218,7 @@ type DestructuredStyleChildProps struct {
 	Scripts *bf.ScriptCollector `json:"-"`
 	Value interface{} `json:"value"`
 	Label interface{} `json:"label"`
-	DisplayValue interface{} `json:"displayValue"`
+	DisplayValue int `json:"displayValue"`
 }
 
 // PropsReactivityComparisonInput is the user-facing input type.
@@ -449,7 +449,7 @@ type PageShellProps struct {
 	BfMount string `json:"-"`
 	BfDataKey string `json:"-"`
 	Scripts *bf.ScriptCollector `json:"-"`
-	Children interface{} `json:"children"`
+	Children interface{} `json:"-"`
 	ReaderToolbarSlot0 ReaderToolbarProps `json:"-"`
 }
 
@@ -535,7 +535,7 @@ type PostListProps struct {
 	Tags []string `json:"tags"`
 	Base string `json:"base"`
 	Params map[string]interface{} `json:"params"`
-	Visible map[string]interface{} `json:"visible"`
+	Visible []Item `json:"visible"`
 	Root string `json:"-"`
 	PostListItems []PostListItemProps `json:"-"`
 }

--- a/integrations/nethttp/components.go
+++ b/integrations/nethttp/components.go
@@ -195,7 +195,7 @@ type PropsStyleChildProps struct {
 	Scripts *bf.ScriptCollector `json:"-"`
 	Value int `json:"value"`
 	Label string `json:"label"`
-	DisplayValue interface{} `json:"displayValue"`
+	DisplayValue int `json:"displayValue"`
 }
 
 // DestructuredStyleChildInput is the user-facing input type.
@@ -218,7 +218,7 @@ type DestructuredStyleChildProps struct {
 	Scripts *bf.ScriptCollector `json:"-"`
 	Value interface{} `json:"value"`
 	Label interface{} `json:"label"`
-	DisplayValue interface{} `json:"displayValue"`
+	DisplayValue int `json:"displayValue"`
 }
 
 // PropsReactivityComparisonInput is the user-facing input type.
@@ -449,7 +449,7 @@ type PageShellProps struct {
 	BfMount string `json:"-"`
 	BfDataKey string `json:"-"`
 	Scripts *bf.ScriptCollector `json:"-"`
-	Children interface{} `json:"children"`
+	Children interface{} `json:"-"`
 	ReaderToolbarSlot0 ReaderToolbarProps `json:"-"`
 }
 
@@ -535,7 +535,7 @@ type PostListProps struct {
 	Tags []string `json:"tags"`
 	Base string `json:"base"`
 	Params map[string]interface{} `json:"params"`
-	Visible map[string]interface{} `json:"visible"`
+	Visible []Item `json:"visible"`
 	Root string `json:"-"`
 	PostListItems []PostListItemProps `json:"-"`
 }

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,51 @@
+# Runtime toolchain for BarefootJS.
+#
+# Versions are kept in sync with CI so local builds/tests match what runs in
+# GitHub Actions. Update these together with the corresponding workflow pins.
+#
+# Note: TypeScript is NOT a mise tool — it ships as the `typescript` dev
+# dependency and runs on bun/node.
+
+[tools]
+bun    = "1.3.14"  # .github/actions/setup-bun (default bun-version)
+node   = "22"      # actions/setup-node node-version: '22'
+go     = "1.25.6"  # go.mod: go 1.25.6 (integrations/*, adapter-go-template)
+rust   = "stable"  # dtolnay/rust-toolchain stable (integrations/axum, adapter-rust)
+ruby   = "3.3"     # ruby/setup-ruby ruby-version: '3.3' (integrations/rails, sinatra, adapter-erb)
+python = "3.12"    # actions/setup-python python-version: '3.12' (ci-python)
+
+# Composer is distributed as a self-contained phar. The `github` backend fetches
+# composer.phar straight from the composer/composer GitHub releases (with GitHub
+# artifact attestation verification) — no plugin, no PHP needed at install time.
+# `bin = "composer"` exposes the asset as `composer` (not `composer.phar`) so the
+# build scripts' bare `composer install` resolves.
+[tools."github:composer/composer"]
+version = "latest"
+bin = "composer"
+
+# PHP is a prebuilt static binary from static-php-cli (https://static-php.dev),
+# pulled via mise's built-in `http` backend — no third-party mise plugin and no
+# source build (which on macOS needs autoconf/automake/re2c/bison + GD/iconv/...
+# system libraries and per-machine configure paths, i.e. not reproducible).
+#
+# The full patch version is pinned and every platform's checksum is pinned, so
+# the install is byte-for-byte reproducible and integrity-verified even though
+# static-php.dev serves the binaries over a plain CDN.
+#
+# CI does not use this entry: the PHP test workflows (ci-php, ci-blade) use the
+# PHP/Composer preinstalled on the ubuntu-latest runner, and the release workflow
+# uses shivammathur/setup-php. This entry is for local `bun run build` / working
+# on the PHP adapters (adapter-php, adapter-blade, adapter-twig, integrations/
+# blade, integrations/php).
+#
+# To bump: pick a version listed under https://dl.static-php.dev/static-php-cli/bulk/
+# and refresh each checksum with:
+#   curl -fsSL <url> | shasum -a 256
+[tools."http:php"]
+version = "8.2.32"
+
+[tools."http:php".platforms]
+macos-arm64 = { url = "https://dl.static-php.dev/static-php-cli/bulk/php-8.2.32-cli-macos-aarch64.tar.gz", checksum = "sha256:3c1c359fe943aaaeb1168933b8e4b1597120c106d33bd66395fac403b6ab3ace" }
+macos-x64   = { url = "https://dl.static-php.dev/static-php-cli/bulk/php-8.2.32-cli-macos-x86_64.tar.gz",  checksum = "sha256:c8a0b022baea7c853c31d6f47b9f3ddaec132771e51afa050f03a406592990bb" }
+linux-arm64 = { url = "https://dl.static-php.dev/static-php-cli/bulk/php-8.2.32-cli-linux-aarch64.tar.gz", checksum = "sha256:e94cc88f535f4e20a931093bbd36aa74b1b48f4121954aa6d7310912a8aad26e" }
+linux-x64   = { url = "https://dl.static-php.dev/static-php-cli/bulk/php-8.2.32-cli-linux-x86_64.tar.gz",  checksum = "sha256:866532d2b463ff256d063432d529e966cc53e4a039109ccbfc4ee4dc51d649f1" }


### PR DESCRIPTION
## Summary

Two related build-reproducibility fixes:

1. **Add `mise.toml`** declaring every runtime the monorepo needs — `bun`, `node`, `go`, `rust`, `ruby`, `php`, `python`, plus `composer` — each pinned to the version used in CI. This fixes `bun run build` failing with `composer: command not found` when the PHP/Blade integrations build, and gives contributors a one-command (`mise install`) toolchain that matches GitHub Actions. **Fully declarative, no third-party mise plugin, no source build.**

2. **Regenerate the four Go `components.go` artifacts** that had drifted from ~215 later compiler commits refining prop type inference (a spurious diff on every `bun run build`). The regenerated output is stricter and **deterministic** (verified by a clean rebuild after clearing `.buildcache.json`).

## How PHP + Composer are provided (supply-chain notes)

Both are pulled with mise's built-in backends — no plugin executes on the machine:

- **Composer** — `github:composer/composer`: `composer.phar` straight from the composer/composer GitHub releases, with **GitHub artifact attestation verification**. `bin = "composer"` exposes it as `composer`.
- **PHP** — `http:php`: a **prebuilt static binary** from [static-php-cli](https://static-php.dev) via the http backend. The full patch version (`8.2.32`) and **every platform's sha256 are pinned**, so the install is byte-for-byte reproducible and integrity-verified even over a plain CDN.

Alternatives that were rejected:
- *Default mise php plugin (source build)* — on macOS needs `autoconf`/`automake`/`re2c`/`bison` **plus** GD/iconv/… system libraries and per-machine `configure` paths → not reproducible.
- *A third-party prebuilt-php mise plugin* — rejected on supply-chain grounds (solo maintainer, replaces the global php plugin, runs install-time code, unsigned CDN binaries).

This entry is local-only. CI does not use it: the PHP test workflows (`ci-php`, `ci-blade`) use the PHP/Composer preinstalled on the `ubuntu-latest` runner, and `release.yml` uses `shivammathur/setup-php`.

## Version pins (source of truth: CI / go.mod)

| runtime | version | source |
|---|---|---|
| bun | 1.3.14 | `setup-bun` |
| node | 22 | `setup-node` |
| go | 1.25.6 | `go.mod` (module minimum) |
| rust | stable | `dtolnay/rust-toolchain` |
| ruby | 3.3 | `setup-ruby` |
| php | 8.2.32 | prebuilt static, checksum-pinned |
| python | 3.12 | `setup-python` |
| composer | latest | github backend, attestation-verified |

## Go type refinements (all four integrations, identical)

| field | before | after |
|---|---|---|
| `DisplayValue` | `interface{}` | `int` |
| `Visible` | `map[string]interface{}` | `[]Item` |
| `Children` | `json:"children"` | `json:"-"` (slot) |

## Verification (macOS arm64)

- `mise install` resolves all tools; `http:php@8.2.32` installs as a prebuilt static binary (no compile) with the extensions illuminate/view + twig need (mbstring, tokenizer, xml, dom, iconv, openssl, …).
- Bare `composer` resolves (attestation verified) and `composer install` succeeds on the static php (adapter-php autoloader generated).
- Clean rebuild after clearing the build cache reproduces the committed Go output byte-for-byte across all four integrations; `go build ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)