### PR TITLE
fix(jsx): resolve declared types for required primitive destructured props (#2150)

### DIFF
--- a/.changeset/fix-destructured-prop-types.md
+++ b/.changeset/fix-destructured-prop-types.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Resolve declared types for required primitive destructured props. `{ value }: { value: number }` now carries its `number` type through the IR instead of degrading to `unknown`, so typed adapters (Go) emit a concrete field (`Value int`) rather than `interface{}` plus an unchecked scalar assertion (`in.Value.(int)`) that could panic on a non-int caller. Scope is deliberately narrow — only required primitive members resolve; optional members and arrays/objects stay `unknown` to preserve existing attribute-omission and interface{}-based lowering. Fixes #2150.

--- a/integrations/chi/components.go
+++ b/integrations/chi/components.go
@@ -203,8 +203,8 @@ type DestructuredStyleChildInput struct {
 	ScopeID string // Optional: if empty, random ID is generated
 	BfParent string // Optional: parent scope id
 	BfMount string // Optional: slot id in parent
-	Value interface{}
-	Label interface{}
+	Value int
+	Label string
 }
 
 // DestructuredStyleChildProps is the props type for the DestructuredStyleChild component.
@@ -216,8 +216,8 @@ type DestructuredStyleChildProps struct {
 	BfMount string `json:"-"`
 	BfDataKey string `json:"-"`
 	Scripts *bf.ScriptCollector `json:"-"`
-	Value interface{} `json:"value"`
-	Label interface{} `json:"label"`
+	Value int `json:"value"`
+	Label string `json:"label"`
 	DisplayValue int `json:"displayValue"`
 }
 
@@ -801,7 +801,7 @@ func NewDestructuredStyleChildProps(in DestructuredStyleChildInput) Destructured
 		BfMount: in.BfMount,
 		Value: in.Value,
 		Label: in.Label,
-		DisplayValue: in.Value.(int) * 10,
+		DisplayValue: in.Value * 10,
 	}
 }
 

--- a/integrations/echo/components.go
+++ b/integrations/echo/components.go
@@ -203,8 +203,8 @@ type DestructuredStyleChildInput struct {
 	ScopeID string // Optional: if empty, random ID is generated
 	BfParent string // Optional: parent scope id
 	BfMount string // Optional: slot id in parent
-	Value interface{}
-	Label interface{}
+	Value int
+	Label string
 }
 
 // DestructuredStyleChildProps is the props type for the DestructuredStyleChild component.
@@ -216,8 +216,8 @@ type DestructuredStyleChildProps struct {
 	BfMount string `json:"-"`
 	BfDataKey string `json:"-"`
 	Scripts *bf.ScriptCollector `json:"-"`
-	Value interface{} `json:"value"`
-	Label interface{} `json:"label"`
+	Value int `json:"value"`
+	Label string `json:"label"`
 	DisplayValue int `json:"displayValue"`
 }
 
@@ -801,7 +801,7 @@ func NewDestructuredStyleChildProps(in DestructuredStyleChildInput) Destructured
 		BfMount: in.BfMount,
 		Value: in.Value,
 		Label: in.Label,
-		DisplayValue: in.Value.(int) * 10,
+		DisplayValue: in.Value * 10,
 	}
 }
 

--- a/integrations/gin/components.go
+++ b/integrations/gin/components.go
@@ -203,8 +203,8 @@ type DestructuredStyleChildInput struct {
 	ScopeID string // Optional: if empty, random ID is generated
 	BfParent string // Optional: parent scope id
 	BfMount string // Optional: slot id in parent
-	Value interface{}
-	Label interface{}
+	Value int
+	Label string
 }
 
 // DestructuredStyleChildProps is the props type for the DestructuredStyleChild component.
@@ -216,8 +216,8 @@ type DestructuredStyleChildProps struct {
 	BfMount string `json:"-"`
 	BfDataKey string `json:"-"`
 	Scripts *bf.ScriptCollector `json:"-"`
-	Value interface{} `json:"value"`
-	Label interface{} `json:"label"`
+	Value int `json:"value"`
+	Label string `json:"label"`
 	DisplayValue int `json:"displayValue"`
 }
 
@@ -801,7 +801,7 @@ func NewDestructuredStyleChildProps(in DestructuredStyleChildInput) Destructured
 		BfMount: in.BfMount,
 		Value: in.Value,
 		Label: in.Label,
-		DisplayValue: in.Value.(int) * 10,
+		DisplayValue: in.Value * 10,
 	}
 }
 

--- a/integrations/nethttp/components.go
+++ b/integrations/nethttp/components.go
@@ -203,8 +203,8 @@ type DestructuredStyleChildInput struct {
 	ScopeID string // Optional: if empty, random ID is generated
 	BfParent string // Optional: parent scope id
 	BfMount string // Optional: slot id in parent
-	Value interface{}
-	Label interface{}
+	Value int
+	Label string
 }
 
 // DestructuredStyleChildProps is the props type for the DestructuredStyleChild component.
@@ -216,8 +216,8 @@ type DestructuredStyleChildProps struct {
 	BfMount string `json:"-"`
 	BfDataKey string `json:"-"`
 	Scripts *bf.ScriptCollector `json:"-"`
-	Value interface{} `json:"value"`
-	Label interface{} `json:"label"`
+	Value int `json:"value"`
+	Label string `json:"label"`
 	DisplayValue int `json:"displayValue"`
 }
 
@@ -801,7 +801,7 @@ func NewDestructuredStyleChildProps(in DestructuredStyleChildInput) Destructured
 		BfMount: in.BfMount,
 		Value: in.Value,
 		Label: in.Label,
-		DisplayValue: in.Value.(int) * 10,
+		DisplayValue: in.Value * 10,
 	}
 }
 

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -987,10 +987,10 @@ function Box({ label }: { label: string }) {
 `
       const { types } = compileAndGenerate(source)
       // The condition prop and the value reference resolve to `in.<Field>`,
-      // the static key is preserved. (The analyzer surfaces these
-      // destructured props as `unknown`/`interface{}`, so the condition
-      // routes through `bf.Truthy` for a faithful JS truthiness test.)
-      expect(types).toContain('if bf.Truthy(in.Label) {')
+      // the static key is preserved. `label` is a required primitive, so the
+      // analyzer resolves it to `string` (issue #2150) and the field-typed
+      // condition is a faithful `!= ""` truthiness test rather than reflection.
+      expect(types).toContain('if in.Label != "" {')
       expect(types).toContain('return map[string]any{"data-label": in.Label}')
     })
 

--- a/packages/jsx/src/__tests__/props-destructuring.test.ts
+++ b/packages/jsx/src/__tests__/props-destructuring.test.ts
@@ -278,3 +278,113 @@ describe('Props Destructuring Warning (BF043)', () => {
     expect(propsWarnings).toHaveLength(0)
   })
 })
+
+describe('Destructured props keep their declared types (BF043 fixture #2150)', () => {
+  const typeOf = (ctx: ReturnType<typeof analyzeComponent>, name: string) =>
+    ctx.propsParams.find((p) => p.name === name)?.type
+
+  test('resolves scalar member types from a type-alias annotation', () => {
+    const source = `
+      type Props = {
+        value: number
+        label: string
+      }
+
+      export function Component({ value, label }: Props) {
+        return <div>{label}: {value}</div>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Component.tsx')
+
+    expect(typeOf(ctx, 'value')).toEqual({ kind: 'primitive', primitive: 'number', raw: 'number' })
+    expect(typeOf(ctx, 'label')).toEqual({ kind: 'primitive', primitive: 'string', raw: 'string' })
+  })
+
+  test('resolves member types from an inline type literal', () => {
+    const source = `
+      export function Component({ value }: { value: number }) {
+        return <div>{value}</div>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Component.tsx')
+
+    expect(typeOf(ctx, 'value')).toEqual({ kind: 'primitive', primitive: 'number', raw: 'number' })
+  })
+
+  test('resolves member types from an interface annotation', () => {
+    const source = `
+      interface Props {
+        value: number
+      }
+
+      export function Component({ value }: Props) {
+        return <div>{value}</div>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Component.tsx')
+
+    expect(typeOf(ctx, 'value')).toEqual({ kind: 'primitive', primitive: 'number', raw: 'number' })
+  })
+
+  test('keys the lookup on the source property name for aliased bindings', () => {
+    const source = `
+      type Props = { value: number }
+
+      export function Component({ value: v }: Props) {
+        return <div>{v}</div>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Component.tsx')
+
+    // The local binding is 'v', but its type comes from the 'value' member.
+    expect(typeOf(ctx, 'v')).toEqual({ kind: 'primitive', primitive: 'number', raw: 'number' })
+  })
+
+  test('falls back to unknown when the param has no type annotation', () => {
+    const source = `
+      export function Component({ value }) {
+        return <div>{value}</div>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Component.tsx')
+
+    expect(typeOf(ctx, 'value')).toEqual({ kind: 'unknown', raw: 'unknown' })
+  })
+
+  // Deliberate scope: only required primitives are resolved. Optional and
+  // non-primitive members stay `unknown` so typed adapters keep their existing
+  // interface{}-based lowering (attribute omission, bf_flat/spread/bf_json).
+  test('leaves OPTIONAL members as unknown (preserves nillable omission)', () => {
+    const source = `
+      type Props = { value?: number }
+
+      export function Component({ value }: Props) {
+        return <div>{value}</div>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Component.tsx')
+
+    expect(typeOf(ctx, 'value')).toEqual({ kind: 'unknown', raw: 'unknown' })
+  })
+
+  test('leaves NON-primitive members (arrays/objects) as unknown', () => {
+    const source = `
+      type Props = { rows: number[][]; meta: { id: string } }
+
+      export function Component({ rows, meta }: Props) {
+        return <div>{rows.length}{meta.id}</div>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Component.tsx')
+
+    expect(typeOf(ctx, 'rows')).toEqual({ kind: 'unknown', raw: 'unknown' })
+    expect(typeOf(ctx, 'meta')).toEqual({ kind: 'unknown', raw: 'unknown' })
+  })
+})

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -3011,6 +3011,12 @@ function extractProps(param: ts.ParameterDeclaration, ctx: AnalyzerContext): voi
       hasIgnoreDirective: ignored,
     }
 
+    // Resolve each destructured binding's declared type from the param's type
+    // annotation, so `{ value }: Props` keeps the same per-prop TypeInfo as the
+    // `props: Props` path instead of degrading to `unknown` (which typed
+    // adapters emit as `interface{}` + an unchecked assertion). See issue #2150.
+    const memberTypes = param.type ? collectMemberTypes(param.type, ctx) : null
+
     for (const element of param.name.elements) {
       if (ts.isBindingElement(element) && ts.isIdentifier(element.name)) {
         const localName = element.name.text
@@ -3022,10 +3028,19 @@ function extractProps(param: ts.ParameterDeclaration, ctx: AnalyzerContext): voi
           continue
         }
 
+        // Aliased bindings (`{ value: v }`) take their type from the source
+        // property name, not the local alias.
+        const sourcePropName =
+          element.propertyName && ts.isIdentifier(element.propertyName)
+            ? element.propertyName.text
+            : localName
+        const resolvedType: TypeInfo =
+          memberTypes?.get(sourcePropName) ?? { kind: 'unknown', raw: 'unknown' }
+
         const defaultContainsArrow = element.initializer ? nodeContainsArrow(element.initializer) : false
         ctx.propsParams.push({
           name: localName,
-          type: { kind: 'unknown', raw: 'unknown' },
+          type: resolvedType,
           optional: !!element.initializer,
           defaultValue,
           defaultContainsArrow: defaultContainsArrow || undefined,
@@ -3106,6 +3121,64 @@ function collectKeysFromMembers(
     }
   }
   return keys
+}
+
+/**
+ * Build a property-name -> resolved TypeInfo map from a props type annotation,
+ * for destructured params (`{ value }: Props`) so they carry the same per-prop
+ * types the props-object path (`props: Props`) already resolves. Returns null
+ * for external/unresolvable types.
+ *
+ * Scope (deliberately narrow — targets the panic in issue #2150):
+ * - Only REQUIRED members are resolved. Optional members (`value?: T`) are left
+ *   out so they keep degrading to `unknown` -> `interface{}`: typed adapters
+ *   rely on that nillable field to omit an unset optional attribute
+ *   (`{{if ne .X nil}}` in Go), which a concrete zero value could not express.
+ * - Only PRIMITIVE members (string/number/boolean) are resolved. Those are the
+ *   types that otherwise produce an unchecked scalar assertion (`in.X.(int)`)
+ *   that panics. Arrays/objects/functions are left as `unknown` because typed
+ *   adapters lower them through interface{}-based helpers (`bf_flat`, spread,
+ *   `bf_json`); giving them concrete types would break that lowering and is a
+ *   larger, separate change.
+ */
+function collectMemberTypes(
+  typeNode: ts.TypeNode,
+  ctx: AnalyzerContext
+): Map<string, TypeInfo> | null {
+  const isResolvablePrimitive = (info: TypeInfo): boolean =>
+    info.kind === 'primitive' &&
+    (info.primitive === 'string' || info.primitive === 'number' || info.primitive === 'boolean')
+
+  const fromMembers = (members: ts.NodeArray<ts.TypeElement>): Map<string, TypeInfo> => {
+    const map = new Map<string, TypeInfo>()
+    for (const member of members) {
+      if (ts.isPropertySignature(member) && member.name && member.type && !member.questionToken) {
+        const info = typeNodeToTypeInfo(member.type, ctx.sourceFile)
+        if (info && isResolvablePrimitive(info)) {
+          map.set(member.name.getText(ctx.sourceFile), info)
+        }
+      }
+    }
+    return map
+  }
+
+  if (ts.isTypeLiteralNode(typeNode)) {
+    return fromMembers(typeNode.members)
+  }
+
+  if (ts.isTypeReferenceNode(typeNode)) {
+    const typeName = typeNode.typeName.getText(ctx.sourceFile)
+    const typeDecl = findTypeDeclaration(typeName, ctx.sourceFile)
+    if (!typeDecl) return null
+    if (ts.isInterfaceDeclaration(typeDecl)) {
+      return fromMembers(typeDecl.members)
+    }
+    if (ts.isTypeAliasDeclaration(typeDecl) && ts.isTypeLiteralNode(typeDecl.type)) {
+      return fromMembers(typeDecl.type.members)
+    }
+  }
+
+  return null
 }
 
 /**


### PR DESCRIPTION
Fixes #2150.

## Problem

`extractProps` pushed every object-destructure binding (`{ value }: Props`) with a hardcoded `unknown` type, never resolving it against the parameter's type annotation — unlike the `props: Props` path, which resolves each member. Typed adapters then emitted the field as `interface{}` and compensated with an **unchecked scalar assertion** (`in.Value.(int) * 10` in Go) that panics for any non-int caller. The same `PropsStyleChildProps` is shared by `PropsStyleChild` (correct, `int`) and `DestructuredStyleChild` (buggy, `interface{}`).

## Fix

`analyzer.ts`: resolve each destructured binding's type from the annotation via a new `collectMemberTypes` helper (mirrors `extractPropsFromType`, keyed for lookup; aliased `{ value: v }` keys on the source property name). The Go adapter needs no change — once `propsParams[].type` carries the resolved primitive, `typeInfoToGo` emits `int`/`string` and the constructor drops the assertion.

### Deliberately narrow scope (fixes the panic without regressions)

- **Required only.** Optional members (`value?: T`) stay `unknown` so typed adapters keep the nillable field they use to omit an unset optional attribute (`{{if ne .X nil}}` in Go) — a concrete zero value (`0`, `""`) can't express "absent".
- **Primitives only** (string/number/boolean). Arrays/objects stay `unknown` because typed adapters lower them through interface{}-based helpers (`bf_flat`, spread, `bf_json`); typing those is a larger, separate change. (Verified: typing a destructured `number[][]` broke `.flat()` Go codegen — hence the boundary.)

## Result (generated Go, all four integrations)

```diff
 type DestructuredStyleChildInput struct {
-	Value interface{}
-	Label interface{}
+	Value int
+	Label string
 }
 func NewDestructuredStyleChildProps(in DestructuredStyleChildInput) DestructuredStyleChildProps {
-	DisplayValue: in.Value.(int) * 10,   // panics if in.Value is not an int
+	DisplayValue: in.Value * 10,
 }
```

## Tests

- New analyzer unit tests: type resolution (type-alias / inline literal / interface / aliased binding) + scope pins (optional and non-primitive members stay `unknown`).
- Updated one go-template conditional-spread test whose required `string` prop now uses a typed `!= ""` truthiness check instead of `bf.Truthy` reflection (a correct refinement).

## Verification

- `go build ./...` passes for all four integrations; the unchecked `.(int)` assertion is gone.
- No new test failures across jsx, go-template, full adapter conformance, client runtime, and UI component suites. (The 5 checker-path and 9 Carousel conformance failures observed are pre-existing on `main` — confirmed by stashing this change and re-running.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## E2E (real browser)

- `integrations/chi` reactive-props Playwright suite: **15/15 passed** (chromium, against the Go SSR server auto-started by Playwright). This drives the exact changed path — `DestructuredStyleChild` renders its computed `in.Value * 10` as `10` and stays static while the `props.value` sibling updates reactively (20 → 30). chi is representative of all four Go integrations (identical generated component code + shared spec).