### PR TITLE
chore: add new adapter packages to npm PUBLISHABLE list

### DIFF
--- a/scripts/changeset-publish.ts
+++ b/scripts/changeset-publish.ts
@@ -43,6 +43,12 @@ const PUBLISHABLE = [
   'packages/adapter-perl',
   'packages/adapter-xslate',
   'packages/adapter-mojolicious',
+  'packages/adapter-erb',
+  'packages/adapter-jinja',
+  'packages/adapter-php',
+  'packages/adapter-twig',
+  'packages/adapter-blade',
+  'packages/adapter-rust',
   'packages/cli',
   'packages/create-barefootjs',
 ]


### PR DESCRIPTION
## Summary

- Add 6 adapter packages to the `PUBLISHABLE` list in `scripts/changeset-publish.ts` so they are included in automated npm releases via Changesets
- Packages added: `adapter-erb` (Ruby), `adapter-jinja` (Python), `adapter-php` (PHP shared runtime), `adapter-twig` (PHP), `adapter-blade` (PHP), `adapter-rust`
- `adapter-php` is ordered before `adapter-twig`/`adapter-blade` to respect dependency order
- OIDC Trusted Publishers have been manually configured on npmjs.com for all six packages

## Context

These packages were already created in the monorepo with CI workflows and native registry release jobs (PyPI, RubyGems, crates.io, Packagist) configured in `release.yml`, but were not yet in the `PUBLISHABLE` list — so Changesets never published them to npm, and the downstream native registry jobs never triggered.

Initial manual `npm publish` has been completed for all six packages, and OIDC Trusted Publishing is now configured, so automated releases can proceed.


---
_Generated by [Claude Code](https://claude.ai/code/session_013yDtzDeFVWrq5tQrZiGNCw)_