### PR TITLE
fix(site): include integrations globs in UnoCSS build scan

### DIFF
--- a/site/core/build.ts
+++ b/site/core/build.ts
@@ -275,9 +275,15 @@ await Bun.write(resolve(DIST_STATIC_DIR, 'globals.css'), combinedCSS)
 console.log('Generated: dist/static/globals.css (tokens + globals + landing)')
 
 // ── 5. Generate UnoCSS ───────────────────────────────────────
+// Scan globs come from uno.config.ts (content.filesystem) so the config is
+// the single source of truth — a page dir added there is picked up here too.
+// The CLI doesn't read content.filesystem itself, so pass them as arguments.
 console.log('\nGenerating UnoCSS...')
+const { default: unoConfig } = await import('./uno.config')
+const unoGlobs = unoConfig.content?.filesystem
+if (!unoGlobs?.length) throw new Error('uno.config.ts must define content.filesystem globs')
 const unoProc = Bun.spawn(
-  ['bunx', 'unocss', './renderer.tsx', './landing/**/*.tsx', './components/**/*.tsx', './dist/**/*.tsx', '../shared/components/**/*.tsx', '-o', 'dist/uno.css'],
+  ['bunx', 'unocss', ...unoGlobs, '-o', 'dist/uno.css'],
   { cwd: ROOT_DIR, stdout: 'inherit', stderr: 'inherit' }
 )
 await unoProc.exited


### PR DESCRIPTION
## Problem

https://barefootjs.dev/integrations renders unstyled — the list spans the full viewport with no centering, padding, or heading size.

## Cause

`site/core/build.ts` invokes the UnoCSS CLI with a hardcoded glob list that duplicated `uno.config.ts`'s `content.filesystem` but was missing `./integrations/**/*.tsx`. Utilities used only on that page (`max-w-3xl`, `mx-auto` pairing, `py-16`, `text-3xl`, `mb-8`, `list-none`, `last:border-b-0`) were never emitted into the deployed `uno.css`. Classes that happened to appear in other scanned files (`font-semibold`, `text-sm`, `border-b`) still worked, which is why the page was only partially broken.

## Fix

`build.ts` now imports `uno.config.ts` and passes its `content.filesystem` globs to the CLI, making the config the single source of truth so the two lists can't drift again (the UnoCSS CLI doesn't read `content.filesystem` on its own — it requires positional patterns).

## Verification

- Reproduced: generating CSS with the old pattern list confirms the classes above are missing; with the config-derived list all are present.
- Ran the full site build, started the server, and screenshotted `/integrations` with Playwright — the page now renders centered with correct spacing and heading size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSWgVLXAsJ8QiZewifUVBX

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSWgVLXAsJ8QiZewifUVBX)_