### PR TITLE
feat(integrations): add Laravel example on the Blade adapter

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -27,6 +27,7 @@
     "barefootjs-h3-example",
     "barefootjs-hono-jsx-example",
     "barefootjs-integrations-shared",
+    "barefootjs-laravel-example",
     "barefootjs-mojolicious-example",
     "barefootjs-php-example",
     "barefootjs-rails-example",

--- a/.github/workflows/ci-blade.yml
+++ b/.github/workflows/ci-blade.yml
@@ -11,6 +11,7 @@ on:
       - 'packages/adapter-blade/**'
       - 'packages/adapter-tests/**'
       - 'integrations/blade/**'
+      - 'integrations/laravel/**'
       - '.github/workflows/ci-blade.yml'
   pull_request:
     paths:
@@ -21,6 +22,7 @@ on:
       - 'packages/adapter-blade/**'
       - 'packages/adapter-tests/**'
       - 'integrations/blade/**'
+      - 'integrations/laravel/**'
       - '.github/workflows/ci-blade.yml'
 
 permissions:
@@ -114,4 +116,56 @@ jobs:
         with:
           name: playwright-report-integrations-blade
           path: integrations/blade/playwright-report/
+          retention-days: 30
+
+  # Same compiled templates + PHP runtime as e2e-blade, exercised through the
+  # hand-trimmed Laravel app (integrations/laravel) instead of the plain-PHP
+  # built-in server — the framework-glue half of the pair, like rails is to
+  # sinatra. `bun run build` in the integration runs `composer install`
+  # (laravel/framework from Packagist) with the runner's preinstalled
+  # PHP/Composer, same as the adapter jobs above.
+  e2e-laravel:
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build packages
+        run: |
+          bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/client' build
+          bun run --filter '@barefootjs/blade' build
+
+      - name: Build integrations/laravel
+        run: cd integrations/laravel && bun run build
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          # Key on package.json (committed, deterministic) — not bun.lock
+          # which is gitignored and re-solved per run.
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/package.json') }}
+
+      - name: Install Playwright browser binaries
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: bunx playwright install chromium
+
+      - name: Run integrations/laravel E2E tests
+        run: cd integrations/laravel && bun run test:e2e
+
+      - name: Upload Playwright report (integrations/laravel)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report-integrations-laravel
+          path: integrations/laravel/playwright-report/
           retention-days: 30

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,7 @@ on:
           - integrations-php
           - integrations-django
           - integrations-blade
+          - integrations-laravel
 
 permissions:
   contents: read
@@ -779,5 +780,44 @@ jobs:
       # ubuntu-latest ships with a running Docker daemon by default.
       - name: Deploy to Cloudflare Workers
         run: cd integrations/blade && bunx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+  deploy-integrations-laravel:
+    if: >-
+      github.event_name == 'workflow_dispatch' && (github.event.inputs.site == 'all' || github.event.inputs.site == 'integrations' || github.event.inputs.site == 'integrations-laravel')
+      || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
+      # Wrangler 4.x shells out to Node and requires v22+. The runner's
+      # default Node 20 makes `bunx wrangler deploy` exit immediately.
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build packages
+        run: |
+          bun run --filter '@barefootjs/jsx' build
+          bun run --filter '@barefootjs/client' build
+          bun run --filter '@barefootjs/blade' build
+
+      - name: Build integration
+        run: cd integrations/laravel && bun run build
+
+      # wrangler deploy builds the Cloudflare Container image from the
+      # integration's Dockerfile, which needs Docker on the runner.
+      # ubuntu-latest ships with a running Docker daemon by default.
+      - name: Deploy to Cloudflare Workers
+        run: cd integrations/laravel && bunx wrangler deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ dist
 # Cloudflare Workers artifacts
 integrations/*/public
 integrations/*/.wrangler
+# ...but Laravel's public/ is real source (the framework's HTTP entry point),
+# not a wrangler artifact
+!integrations/laravel/public
 
 # air (Go live-reload) tmp dir + the host-binary built by `go run .`
 integrations/echo/tmp/
@@ -31,6 +34,9 @@ coverage
 
 # logs
 logs
+# ...but Laravel's storage/logs must exist for the framework's file log
+# channel (only its .gitignore placeholder is tracked)
+!integrations/laravel/storage/logs
 _.log
 report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -274,6 +274,23 @@ services:
       # its vendor/ dir) -- that target must exist in the container too.
       - ./packages/adapter-php:/workspace/packages/adapter-php
 
+  laravel:
+    build:
+      context: .
+      dockerfile: integrations/laravel/Dockerfile.dev
+    working_dir: /workspace/integrations/laravel
+    environment:
+      BASE_PATH: /integrations/laravel
+      APP_ENV: development
+      PORT: "3016"
+    volumes:
+      # vendor/ (laravel/framework + the composer autoloader over the staged
+      # lib/ runtime copies) is bind-mounted from the host build -- run
+      # `bun run build` in integrations/laravel first. Unlike blade there is
+      # no workspace-package autoload fallback: laravel/framework exists only
+      # in this integration's own vendor/.
+      - ./integrations/laravel:/workspace/integrations/laravel
+
   site-core:
     build:
       context: .

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -22,6 +22,7 @@ same JSX components on a different stack:
 | `php` | PHP / built-in server (Twig) | 3013 | container |
 | `django` | Python / Django (Jinja2) | 3014 | container |
 | `blade` | PHP / built-in server (Blade) | 3015 | container |
+| `laravel` | PHP / Laravel (`artisan serve`, Blade) | 3016 | container |
 | `csr` | TypeScript (no SSR) | 3002 | host (manual) |
 
 Plus `site/core` (the docs / landing / catalog site) on internal port 4001
@@ -59,6 +60,7 @@ host:                                  containers (docker compose):
                                          - php          (php built-in server)
                                          - django       (python + runserver autoreload)
                                          - blade        (php built-in server)
+                                         - laravel      (php artisan serve)
                                          - site-core    (bun + Hono)
 ```
 
@@ -82,6 +84,7 @@ The proxy routes by path prefix:
 :4000/integrations/php/*         → php service
 :4000/integrations/django/*      → django service
 :4000/integrations/blade/*       → blade service
+:4000/integrations/laravel/*     → laravel service
 :4000/*                          → site-core (landing / docs / catalog)
 ```
 
@@ -140,7 +143,7 @@ The same env var pattern works for `H3_TARGET`, `ELYSIA_TARGET`,
 `ECHO_TARGET`, `GIN_TARGET`, `CHI_TARGET`, `NETHTTP_TARGET`,
 `MOJOLICIOUS_TARGET`, `XSLATE_TARGET`, `FLASK_TARGET`, `FASTAPI_TARGET`,
 `SINATRA_TARGET`, `RAILS_TARGET`, `AXUM_TARGET`, `PHP_TARGET`,
-`DJANGO_TARGET`, `BLADE_TARGET`, and `SITE_CORE_TARGET`.
+`DJANGO_TARGET`, `BLADE_TARGET`, `LARAVEL_TARGET`, and `SITE_CORE_TARGET`.
 
 ### Why dev images are separate from `Dockerfile`
 
@@ -156,7 +159,8 @@ The TypeScript adapters (`hono`, `h3`, `elysia`) have **no production
 `wrangler deploy` (Elysia uses its official Cloudflare adapter). The Go
 adapters (`echo`, `gin`, `chi`, `nethttp`), the Perl adapters
 (`mojolicious`, `xslate`), the Python adapters (`flask`, `fastapi`,
-`django`), the Ruby examples (`sinatra`, `rails`), and the Rust adapter
+`django`), the Ruby examples (`sinatra`, `rails`), the PHP examples
+(`php`, `blade`, `laravel`), and the Rust adapter
 (`axum`) ship a
 production container image (`Dockerfile`) deployed as a Cloudflare
 Container. Every adapter still has a `Dockerfile.dev` for the local
@@ -167,7 +171,11 @@ SAME `@barefootjs/erb` compiler + Ruby runtime; they differ only in the web
 framework glue around it — Sinatra's routing DSL + Rack builder vs. a
 hand-trimmed Rails app (routing + controllers, no ActiveRecord / asset
 pipeline). This mirrors the two Perl examples (`mojolicious`, `xslate`)
-coexisting on one adapter family.
+coexisting on one adapter family, and the two Blade examples (`blade`,
+`laravel`) on `@barefootjs/blade` — plain PHP's built-in server with a
+standalone `illuminate/view` stack vs. a hand-trimmed Laravel app (routing +
+controllers, no Eloquent / asset pipeline) whose own view factory the
+BarefootJS Blade backend reuses.
 
 Each Go adapter is its own Cloudflare Worker + Container, routed on the
 `barefootjs.dev` zone via its `wrangler.toml` (e.g.

--- a/integrations/laravel/Dockerfile
+++ b/integrations/laravel/Dockerfile
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1
+#
+# Build & runtime image for the Laravel example, intended to be executed inside
+# a Cloudflare Container. Requires `bun run build` to have been run on the host
+# first so dist/ (templates, client JS, styles), lib/ (BarefootJS PHP runtime
+# source), vendor/ (composer install, incl. laravel/framework) and
+# composer.lock exist alongside the app.
+
+FROM php:8.4-cli
+RUN useradd -m -r -s /bin/false app
+WORKDIR /app
+
+COPY artisan composer.json composer.lock ./
+COPY bootstrap ./bootstrap
+COPY config ./config
+COPY routes ./routes
+COPY public ./public
+COPY app ./app
+COPY storage ./storage
+COPY lib ./lib
+COPY dist ./dist
+COPY vendor ./vendor
+
+# Laravel writes its package-discovery cache under bootstrap/cache and the
+# compiled Blade templates under storage/framework/views at runtime.
+RUN chown -R app:app storage bootstrap/cache
+
+ENV BASE_PATH=/integrations/laravel
+ENV APP_ENV=production
+# No writable log file in the container; the framework's stderr channel goes
+# to the container logs instead (the default `stack`->`single` channel would
+# write storage/logs/laravel.log).
+ENV LOG_CHANNEL=stderr
+# The Cloudflare Container worker probes defaultPort 8080 (container.ts);
+# without this the app falls back to its dev port 3016 and never comes up.
+ENV PORT=8080
+EXPOSE 8080
+USER app
+# `artisan serve` is the same PHP built-in server integrations/blade runs
+# (with Laravel's request handling in front); PHP_CLI_SERVER_WORKERS gives it
+# a small worker pool so the SSE stream (/api/ai-chat) doesn't stall other
+# in-flight requests -- see App\Support\TodoStore's docstring.
+CMD ["sh", "-c", "PHP_CLI_SERVER_WORKERS=8 php artisan serve --host=0.0.0.0 --port=${PORT}"]

--- a/integrations/laravel/Dockerfile.dev
+++ b/integrations/laravel/Dockerfile.dev
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+#
+# Development image for the Laravel integration. The app source and the
+# host-built dist/ + lib/ + vendor/ are bind-mounted in. Requires a host-side
+# `bun run build` (which runs `composer install`) first: unlike
+# integrations/blade there is no workspace-package autoload fallback, because
+# laravel/framework only exists in this integration's own vendor/.
+#
+# There is no reloader to restart (unlike Rails' rerun): PHP re-executes the
+# app fresh on every request, and the framework's Blade CompilerEngine
+# recompiles a view whenever its source mtime is newer than its compiled
+# cache file (see config/view.php), so edits to PHP source or the compiled
+# templates are picked up on the very next request with no restart needed.
+
+FROM php:8.4-cli
+
+WORKDIR /workspace/integrations/laravel
+
+EXPOSE 3016
+
+ENV BASE_PATH=/integrations/laravel
+ENV PORT=3016
+
+CMD ["sh", "-c", "PHP_CLI_SERVER_WORKERS=8 php artisan serve --host=0.0.0.0 --port=${PORT}"]

--- a/integrations/laravel/app/Http/Controllers/AiChatController.php
+++ b/integrations/laravel/app/Http/Controllers/AiChatController.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Support\ExampleApp;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+/**
+ * Char-by-char SSE stream for the AI chat demo. `response()->stream()` (not
+ * Laravel 12's `eventStream()`, whose StreamedEvent envelope is a different
+ * wire format from the plain `data: "<char>"` frames the shared
+ * AIChatInteractive island expects) writes each character with a 30ms delay;
+ * the built-in server's worker pool (PHP_CLI_SERVER_WORKERS=8) keeps the
+ * blocking loop from stalling other in-flight requests, exactly as in
+ * integrations/blade.
+ */
+final class AiChatController extends Controller
+{
+    public function stream(): StreamedResponse
+    {
+        $text = ExampleApp::AI_RESPONSES[array_rand(ExampleApp::AI_RESPONSES)];
+        return response()->stream(function () use ($text): void {
+            // Turn off every buffering layer PHP itself might apply so each
+            // `echo` actually reaches the socket before the next 30ms sleep.
+            while (ob_get_level() > 0) {
+                ob_end_flush();
+            }
+            ini_set('output_buffering', 'off');
+            ini_set('zlib.output_compression', false);
+            foreach (preg_split('//u', $text, -1, PREG_SPLIT_NO_EMPTY) as $ch) {
+                echo 'data: ' . json_encode($ch) . "\n\n";
+                flush();
+                usleep(30_000);
+            }
+            echo "data: [DONE]\n\n";
+            flush();
+        }, 200, [
+            'Content-Type' => 'text/event-stream',
+            'Cache-Control' => 'no-cache',
+            // Nginx/Cloudflare-style intermediaries buffer proxied responses
+            // by default, which would defeat the whole point of streaming;
+            // this header is a no-op when there is no such proxy in front
+            // (e.g. local dev) and load-bearing when there is.
+            'X-Accel-Buffering' => 'no',
+        ]);
+    }
+}

--- a/integrations/laravel/app/Http/Controllers/BlogController.php
+++ b/integrations/laravel/app/Http/Controllers/BlogController.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Support\ExampleApp;
+use Barefoot\BarefootJS;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+/**
+ * Blog -- the @barefootjs/router showcase. No server JSX: each page is
+ * composed in PHP from individually-rendered island templates
+ * (ExampleApp::blogIsland), all sharing one request-scoped script collector
+ * (`$root`). Port of integrations/blade's blog routes; see that file's blog
+ * section docstring for the searchParams() SSR seeding rationale (#2076).
+ */
+final class BlogController extends Controller
+{
+    public function index(Request $request): Response
+    {
+        $backend = ExampleApp::backend();
+        $root = new BarefootJS(null, ['backend' => $backend]);
+        ExampleApp::newScriptCollector($root);
+        $base = ExampleApp::base() . '/blog';
+        $sort = ExampleApp::asSortKey($request->query('sort'));
+        $tag = (string) $request->query('tag', '');
+        $items = ExampleApp::blogData()['listItems'];
+        $postList = ExampleApp::blogIsland(
+            $root,
+            'PostList',
+            // Client props (-> bf-p): `visible()` re-derives from these on
+            // every `searchParams()` change, so they must reach the client.
+            ['items' => $items, 'tags' => ExampleApp::blogData()['allTags'], 'base' => $base],
+            [
+                // SSR-only derived values -- what the static extractor cannot
+                // supply; see integrations/blade's blog section docstring.
+                'params' => ['sort' => $sort, 'tag' => $tag],
+                'visible' => $items,
+                'sortClass' => 'sort',
+                'root' => $base,
+                'tagClass' => 'tag',
+            ],
+            ['post_list_item' => 'PostListItem'],
+        );
+        $now = ExampleApp::blogIsland($root, 'NowPlaying', [], ['Math' => ['min' => 0]]);
+        $title = $tag !== '' ? "#{$tag} \u{2014} Barefoot Blog" : 'Barefoot Blog \u{2014} Latest posts';
+        return response(ExampleApp::blogPage($root, $title, $base, $postList . $now));
+    }
+
+    public function post(string $slug): Response
+    {
+        $backend = ExampleApp::backend();
+        // Sort newest-first (the index's default display order) so the
+        // article pager walks down the list the reader is browsing; the
+        // corpus is authored oldest-first.
+        $posts = ExampleApp::blogData()['posts'];
+        usort($posts, static fn ($a, $b) => strcmp($b['date'], $a['date']));
+        $idx = null;
+        foreach ($posts as $i => $p) {
+            if ($p['slug'] === $slug) {
+                $idx = $i;
+                break;
+            }
+        }
+        if ($idx === null) {
+            return response('Not Found', 404)->header('Content-Type', 'text/plain');
+        }
+        $p = $posts[$idx];
+        $prevPost = $idx > 0 ? $posts[$idx - 1] : null;
+        $nextPost = $idx < count($posts) - 1 ? $posts[$idx + 1] : null;
+        $base = ExampleApp::base() . '/blog';
+        $root = new BarefootJS(null, ['backend' => $backend]);
+        ExampleApp::newScriptCollector($root);
+        // The whole article is the shared <PostArticle> island; the
+        // interactive widgets are its nested children (NowPlaying needs Math
+        // seeded).
+        $content = ExampleApp::blogIsland(
+            $root,
+            'PostArticle',
+            [
+                'slug' => $p['slug'], 'title' => $p['title'], 'date' => $p['date'],
+                'tags' => $p['tags'], 'body' => $p['body'],
+                'position' => $idx + 1, 'total' => count($posts), 'base' => $base,
+                'prevSlug' => $prevPost['slug'] ?? null,
+                'prevTitle' => $prevPost['title'] ?? null,
+                'nextSlug' => $nextPost['slug'] ?? null,
+                'nextTitle' => $nextPost['title'] ?? null,
+            ],
+            [],
+            [
+                'like_button' => 'LikeButton',
+                'reading_timer' => 'ReadingTimer',
+                'now_playing' => ['NowPlaying', ['Math' => ['min' => 0]]],
+            ],
+        );
+        return response(ExampleApp::blogPage($root, "{$p['title']} \u{2014} Barefoot Blog", $base, $content));
+    }
+}

--- a/integrations/laravel/app/Http/Controllers/Concerns/BarefootHelper.php
+++ b/integrations/laravel/app/Http/Controllers/Concerns/BarefootHelper.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Concerns;
+
+use App\Support\ExampleApp;
+use Barefoot\BarefootJS;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Cookie;
+
+/**
+ * The Laravel-idiomatic seam for turning a BarefootJS component into a full
+ * HTML page -- the counterpart of integrations/rails'
+ * app/controllers/concerns/barefoot_helper.rb. Used from the base Controller,
+ * it wraps:
+ *   * per-request runtime creation + child-renderer registration
+ *   * the shared page/layout string builder (see the Blade-layout note below)
+ *   * the `bf_session` cookie helpers the todo store keys off
+ *
+ * --- Blade layouts vs. a shared layout-string helper -----------------------
+ * We deliberately do NOT wrap pages in a Blade layout (`@extends` /
+ * `{{ $slot }}`), even though this app has a perfectly good view factory.
+ * Every page's interactive markup is already a fully-rendered HTML string
+ * produced by BladeBackend::render_named; the only remaining job is to wrap
+ * it in a <!DOCTYPE html> document. Running that pre-rendered,
+ * hydration-critical markup back through a Blade layout would buy nothing
+ * (there is no per-page view logic to express) while adding a real hazard:
+ * every interpolation would need `{!! !!}` or the `bf-*` hydration attributes
+ * and inline scripts get re-escaped. A plain PHP heredoc is the simplest
+ * thing that is guaranteed correct, and it keeps this example structurally
+ * parallel to integrations/blade so the diff between the two PHP integrations
+ * is "framework glue only" -- the same rationale integrations/rails documents
+ * for skipping ActionView.
+ */
+trait BarefootHelper
+{
+    /**
+     * Build a per-request runtime, register child renderers, render the
+     * component template, and wrap the result in the page layout. Port of
+     * integrations/blade's render_component (same signature, camelCased).
+     */
+    protected function renderComponent(
+        string $component,
+        ?string $title = null,
+        string $heading = '',
+        array $children = [],
+        array $signalInit = [],
+        array $props = [],
+        array $stash = [],
+        string $extraCss = '',
+        ?string $back = null
+    ): string {
+        $backend = ExampleApp::backend();
+        $bf = new BarefootJS(null, ['backend' => $backend]);
+        ExampleApp::newScriptCollector($bf);
+        $scopeId = $component . '_' . ExampleApp::randSuffix();
+        $bf->_scope_id($scopeId);
+        if ($props) {
+            $bf->_props($props);
+        }
+
+        foreach ($children as $childSlot => $childTemplate) {
+            $childInit = $signalInit[$childSlot] ?? null;
+            $renderer = function (array $childProps, ?BarefootJS $caller = null) use ($backend, $bf, $scopeId, $childTemplate, $childInit) {
+                $childBf = new BarefootJS(null, ['backend' => $backend]);
+                // Loop children carry no `_bf_slot`; fall back to template +
+                // suffix so each instance gets a distinct scope id (client JS
+                // finds children by scope). Slot children pin to
+                // <parent>_<slot>.
+                $slotId = $childProps['_bf_slot'] ?? null;
+                unset($childProps['_bf_slot']);
+                $childBf->_scope_id($slotId !== null ? "{$scopeId}_{$slotId}" : $childTemplate . '_' . ExampleApp::randSuffix());
+                $childBf->_is_child(true);
+                // Share the parent's script collector so a child's
+                // register_script de-dupes against the page's existing
+                // <script> set (see ExampleApp::newScriptCollector).
+                ExampleApp::shareScriptCollector($bf, $childBf);
+                $extra = $childInit !== null ? $childInit($childProps) : [];
+                return $backend->render_named($childTemplate, $childBf, array_merge($childProps, $extra));
+            };
+            $bf->register_child_renderer($childSlot, $renderer);
+        }
+
+        $ctx = array_merge(ExampleApp::stashFromSsrDefaults($component, $props), $stash);
+        $body = $backend->render_named($component, $bf, $ctx);
+        return $this->layout(
+            title: $title ?? "{$component} - BarefootJS",
+            heading: $heading,
+            body: $body,
+            scripts: $bf->scripts(),
+            extraCss: $extraCss,
+            back: $back,
+        );
+    }
+
+    protected function layout(string $title, string $heading, string $body, string $scripts, string $extraCss = '', ?string $back = null): string
+    {
+        $base = ExampleApp::base();
+        $headingHtml = $heading !== '' ? "<h1>{$heading}</h1>" : '';
+        // Subpages link back to the example list (base()/); the list page
+        // itself passes back='' to suppress the link (the header breadcrumb
+        // already navigates up to /integrations).
+        $backHref = $back ?? "{$base}/";
+        $backHtml = $backHref !== '' ? '<p><a href="' . $backHref . '">&larr; Back</a></p>' : '';
+        return <<<HTML
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{$title}</title>
+    <link rel="stylesheet" href="{$base}/styles/tokens.css">
+    <link rel="stylesheet" href="{$base}/styles/layout.css">
+    <link rel="stylesheet" href="{$base}/styles/components.css">
+    <link rel="stylesheet" href="{$base}/styles/todo-app.css">
+    {$extraCss}
+</head>
+<body>
+    <header class="bf-header">
+        <div class="bf-header-inner">
+            <a href="https://barefootjs.dev" class="bf-header-logo" aria-label="BarefootJS">
+                <span class="bf-header-logo-img" role="img" aria-hidden="true"></span>
+            </a>
+            <div class="bf-header-sep"></div>
+            <nav class="bf-header-crumbs" aria-label="Breadcrumb">
+                <a href="/integrations" class="bf-header-link">Integrations</a>
+                <span class="bf-header-crumb-sep" aria-hidden="true">/</span>
+                <span class="bf-header-current" aria-current="page">Laravel</span>
+            </nav>
+        </div>
+    </header>
+    {$headingHtml}
+    <div id="app">{$body}</div>
+    {$backHtml}
+    {$scripts}
+</body>
+</html>
+HTML;
+    }
+
+    // -----------------------------------------------------------------------
+    // Session cookie helpers -- port of integrations/blade's
+    // resolve_session_id / set_session_cookie using Laravel's request/response
+    // cookie API. The cookie is set RAW (EncryptCookies is removed from the
+    // web group, see bootstrap/app.php) so it stays the same plain opaque id
+    // every other integration uses.
+    // -----------------------------------------------------------------------
+
+    /** @return array{0: string, 1: bool} `[sid, is_new_cookie]`; the caller
+     * attaches the cookie to its response only when a new id was minted. */
+    protected function resolveSessionId(Request $request): array
+    {
+        $sid = $request->cookies->get(ExampleApp::SESSION_COOKIE);
+        if (is_string($sid) && preg_match('/^[a-f0-9]{32}$/', $sid)) {
+            return [$sid, false];
+        }
+        return [bin2hex(random_bytes(16)), true];
+    }
+
+    protected function sessionCookie(string $sid): Cookie
+    {
+        $base = ExampleApp::base();
+        return cookie(
+            name: ExampleApp::SESSION_COOKIE,
+            value: $sid,
+            minutes: intdiv(ExampleApp::SESSION_TTL_SEC, 60),
+            path: $base !== '' ? $base : '/',
+            secure: false,
+            httpOnly: true,
+            sameSite: 'lax',
+        );
+    }
+}

--- a/integrations/laravel/app/Http/Controllers/Controller.php
+++ b/integrations/laravel/app/Http/Controllers/Controller.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Concerns\BarefootHelper;
+
+abstract class Controller
+{
+    use BarefootHelper;
+}

--- a/integrations/laravel/app/Http/Controllers/PagesController.php
+++ b/integrations/laravel/app/Http/Controllers/PagesController.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Support\ExampleApp;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+/**
+ * The static-ish page group: the example index plus every non-todo, non-blog
+ * component demo. Each action is a 1:1 port of the matching
+ * integrations/blade route (same compiled templates, same stash/props), the
+ * way integrations/rails' PagesController ports the Sinatra routes.
+ */
+final class PagesController extends Controller
+{
+    public function index(): Response
+    {
+        $base = ExampleApp::base();
+        $body = <<<HTML
+<p>This example renders the same shared JSX components with Blade under a
+hand-trimmed Laravel app (routing + controllers only, no Eloquent / asset
+pipeline). Rendering goes through @barefootjs/blade's PHP runtime wired onto
+this app's own Blade view factory.</p>
+<ul>
+    <li><a href="{$base}/counter">Counter</a></li>
+    <li><a href="{$base}/toggle">Toggle</a></li>
+    <li><a href="{$base}/todos">Todo (@client)</a></li>
+    <li><a href="{$base}/todos-ssr">Todo (no @client markers)</a></li>
+    <li><a href="{$base}/ai-chat">AI Chat (SSE Streaming)</a></li>
+    <li><a href="{$base}/blog">Blog (@barefootjs/router - partial navigation)</a></li>
+</ul>
+HTML;
+        return response($this->layout(
+            title: 'BarefootJS + Laravel Example',
+            heading: 'BarefootJS + Laravel Example',
+            body: $body,
+            scripts: '',
+            back: '',
+        ));
+    }
+
+    public function counter(): Response
+    {
+        return response($this->renderComponent('Counter', heading: 'Counter Component'));
+    }
+
+    public function toggle(): Response
+    {
+        $items = [
+            ['label' => 'Setting 1', 'defaultOn' => true],
+            ['label' => 'Setting 2', 'defaultOn' => false],
+            ['label' => 'Setting 3', 'defaultOn' => false],
+        ];
+        return response($this->renderComponent(
+            'Toggle',
+            heading: 'Toggle Component',
+            children: ['toggle_item' => 'ToggleItem'],
+            props: ['toggleItems' => $items],
+            stash: ['toggleItems' => $items],
+        ));
+    }
+
+    public function form(): Response
+    {
+        return response($this->renderComponent('Form', heading: 'Form Example', props: [], stash: ['accepted' => false]));
+    }
+
+    public function reactiveProps(): Response
+    {
+        return response($this->renderComponent(
+            'ReactiveProps',
+            heading: 'Reactive Props Test',
+            children: ['reactive_child' => 'ReactiveChild'],
+            props: [],
+            stash: ['count' => 0, 'doubled' => 0],
+        ));
+    }
+
+    /**
+     * Not in the home page's headline route list, but required: the shared
+     * `reactive-props.spec.ts` e2e suite has a "Props Access" describe block
+     * that navigates to `${baseUrl}/props-reactivity` -- see
+     * integrations/shared/e2e/reactive-props.spec.ts. No signalInit override
+     * needed: PropsStyleChild / DestructuredStyleChild's compiled templates
+     * already derive `displayValue` in-template.
+     */
+    public function propsReactivity(): Response
+    {
+        return response($this->renderComponent(
+            'PropsReactivityComparison',
+            heading: 'Props Reactivity Comparison',
+            children: [
+                'props_style_child' => 'PropsStyleChild',
+                'destructured_style_child' => 'DestructuredStyleChild',
+            ],
+            props: [],
+            stash: ['count' => 1],
+        ));
+    }
+
+    public function conditionalReturn(Request $request): Response
+    {
+        $variant = str_ends_with($request->path(), '-link') ? 'link' : '';
+        return response($this->renderComponent(
+            'ConditionalReturn',
+            heading: 'Conditional Return Example' . ($variant !== '' ? ' (Link)' : ''),
+            props: ['variant' => $variant],
+            stash: ['variant' => $variant, 'count' => 0],
+        ));
+    }
+
+    public function portal(): Response
+    {
+        return response($this->renderComponent('PortalExample', heading: 'Portal Example', props: [], stash: ['open' => false]));
+    }
+
+    public function aiChat(): Response
+    {
+        $base = ExampleApp::base();
+        return response($this->renderComponent(
+            'AIChatInteractive',
+            title: 'AI Chat -- SSE Streaming (Laravel)',
+            heading: 'AI Chat -- SSE Streaming',
+            stash: ['messages' => [], 'input' => '', 'streamingText' => '', 'isStreaming' => false],
+            extraCss: "<link rel=\"stylesheet\" href=\"{$base}/styles/ai-chat.css\">",
+        ));
+    }
+}

--- a/integrations/laravel/app/Http/Controllers/TodosController.php
+++ b/integrations/laravel/app/Http/Controllers/TodosController.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Support\ExampleApp;
+use App\Support\TodoStore;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Symfony\Component\HttpFoundation\Response as BaseResponse;
+
+/**
+ * Todo pages (with/without @client markers) + the session-cookie REST API.
+ * Port of integrations/blade's todo routes; the store is the same
+ * file-backed, flock-guarded JSON store (see App\Support\TodoStore for why
+ * an in-memory array doesn't survive `PHP_CLI_SERVER_WORKERS=8`).
+ */
+final class TodosController extends Controller
+{
+    public function index(Request $request, ?string $ssr = null): Response
+    {
+        [$sid, $minted] = $this->resolveSessionId($request);
+        $state = TodoStore::read($sid);
+        $todos = $state['todos'];
+        $done = count(array_filter($todos, static fn ($t) => $t['done']));
+        $component = $ssr !== null ? 'TodoAppSSR' : 'TodoApp';
+        $response = response($this->renderComponent(
+            $component,
+            children: ['todo_item' => 'TodoItem'],
+            props: ['initialTodos' => $todos],
+            stash: ['todos' => $todos, 'newText' => '', 'filter' => 'all', 'doneCount' => $done],
+        ));
+        return $this->withSessionCookie($response, $sid, $minted);
+    }
+
+    // --- todo REST API ---
+
+    public function apiIndex(Request $request): BaseResponse
+    {
+        [$sid, $minted] = $this->resolveSessionId($request);
+        $state = TodoStore::read($sid);
+        return $this->withSessionCookie(response()->json($state['todos']), $sid, $minted);
+    }
+
+    public function apiCreate(Request $request): BaseResponse
+    {
+        [$sid, $minted] = $this->resolveSessionId($request);
+        $body = $request->json()->all();
+        $todo = TodoStore::with($sid, static function (array $state) use ($body) {
+            $newTodo = ['id' => $state['next_id'], 'text' => $body['text'] ?? null, 'done' => false, 'editing' => false];
+            $state['todos'][] = $newTodo;
+            $state['next_id']++;
+            return [$state, $newTodo];
+        });
+        return $this->withSessionCookie(response()->json($todo, 201), $sid, $minted);
+    }
+
+    public function apiUpdate(Request $request, int $id): BaseResponse
+    {
+        [$sid, $minted] = $this->resolveSessionId($request);
+        $body = $request->json()->all();
+        $todo = TodoStore::with($sid, static function (array $state) use ($id, $body) {
+            foreach ($state['todos'] as &$t) {
+                if ($t['id'] !== $id) {
+                    continue;
+                }
+                if (array_key_exists('text', $body)) {
+                    $t['text'] = $body['text'];
+                }
+                if (array_key_exists('done', $body)) {
+                    $t['done'] = (bool) $body['done'];
+                }
+                return [$state, $t];
+            }
+            return [$state, null];
+        });
+        $response = $todo === null
+            ? response()->json(['error' => 'not found'], 404)
+            : response()->json($todo);
+        return $this->withSessionCookie($response, $sid, $minted);
+    }
+
+    public function apiDestroy(Request $request, int $id): BaseResponse
+    {
+        [$sid] = $this->resolveSessionId($request);
+        TodoStore::with($sid, static function (array $state) use ($id) {
+            $state['todos'] = array_values(array_filter($state['todos'], static fn ($t) => $t['id'] !== $id));
+            return [$state, null];
+        });
+        return response()->noContent();
+    }
+
+    public function apiReset(Request $request): BaseResponse
+    {
+        [$sid, $minted] = $this->resolveSessionId($request);
+        TodoStore::with($sid, static fn (array $state) => [['todos' => ExampleApp::seedTodos(), 'next_id' => 4], null]);
+        return $this->withSessionCookie(response('ok')->header('Content-Type', 'text/plain'), $sid, $minted);
+    }
+
+    /** Attach the raw `bf_session` cookie only when a new id was minted
+     * (mirrors integrations/blade's `if ($minted) set_session_cookie(...)`
+     * call sites). */
+    private function withSessionCookie(BaseResponse $response, string $sid, bool $minted): BaseResponse
+    {
+        if ($minted) {
+            $response->headers->setCookie($this->sessionCookie($sid));
+        }
+        return $response;
+    }
+}

--- a/integrations/laravel/app/Providers/BarefootServiceProvider.php
+++ b/integrations/laravel/app/Providers/BarefootServiceProvider.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use Barefoot\BladeBackend;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Container wiring for the BarefootJS runtime -- the Laravel-idiomatic
+ * counterpart of integrations/blade's top-of-index.php `$backend`
+ * construction.
+ *
+ * One BladeBackend renders every component from dist/templates, wired onto
+ * THIS app's own view factory (config/view.php points its paths there) via
+ * the `factory` option BladeBackend documents for "integrations that already
+ * run a full Laravel application and want to reuse its view Factory". Unlike
+ * the plain-PHP sibling there is no standalone illuminate/view stack to
+ * assemble: the framework's ViewServiceProvider has already registered the
+ * `blade` engine, the FileViewFinder, and the compiled-template cache under
+ * storage/framework/views.
+ */
+final class BarefootServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->singleton(BladeBackend::class, static fn ($app) => new BladeBackend([
+            'factory' => $app['view'],
+        ]));
+    }
+}

--- a/integrations/laravel/app/Support/ExampleApp.php
+++ b/integrations/laravel/app/Support/ExampleApp.php
@@ -1,0 +1,333 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use Barefoot\BarefootJS;
+use Barefoot\BladeBackend;
+
+/**
+ * Request-independent BarefootJS glue -- the Laravel counterpart of
+ * integrations/rails' `ExampleApp` module (config/initializers/example_app.rb):
+ * constants + the pure render helpers, namespaced so nothing leaks into the
+ * app's controllers. The request-facing seams (renderComponent, layout, the
+ * session cookie) live in the BarefootHelper controller concern; the split
+ * mirrors the Rails example, which itself mirrors the plain-PHP/Blade
+ * example's top-level functions vs route bodies.
+ *
+ * Everything here is a 1:1 port of integrations/blade/index.php's section of
+ * the same name (same adapter, same compiled templates, same manifest
+ * semantics) -- only the framework glue around it differs, so the two PHP
+ * integrations can be diffed side by side the way sinatra/rails can.
+ */
+final class ExampleApp
+{
+    public const SESSION_COOKIE = 'bf_session';
+    public const SESSION_TTL_SEC = 60 * 60 * 24 * 30;
+
+    public const BLOG_SORT_KEYS = ['date', 'title', 'tag'];
+
+    /** AI Chat dummy responses (streamed char-by-char over SSE). */
+    public const AI_RESPONSES = [
+        '[Dummy response] This text is streaming one character at a time via SSE. In production, replace /api/ai-chat with a real LLM API.',
+        '[Dummy response] BarefootJS compiles JSX to Blade templates + client JS. Signals drive reactivity on any backend.',
+        '[Dummy response] SSE (Server-Sent Events) lets the server push data to the client over a single HTTP connection.',
+        '[Dummy response] The Blade backend reuses this Laravel app\'s own view factory -- `php artisan serve` streams each character with a 30ms delay.',
+        '[Dummy response] Out-of-Order Streaming SSR and interactive SSE streaming are two different features of BarefootJS.',
+    ];
+
+    /**
+     * URL prefix the app is mounted under. Defaults to /integrations/laravel
+     * so the app is deploy-ready for barefootjs.dev/integrations/laravel.
+     * `getenv` (not the `env()` helper) for parity with the sibling PHP
+     * integrations, and because this is read at route-registration time.
+     */
+    public static function base(): string
+    {
+        return rtrim(getenv('BASE_PATH') ?: '/integrations/laravel', '/');
+    }
+
+    public static function backend(): BladeBackend
+    {
+        return app(BladeBackend::class);
+    }
+
+    /**
+     * The build manifest -- a plain build artifact (dist/templates/manifest.json),
+     * not adapter internals -- lists each component's `ssrDefaults`: the set of
+     * signal/memo names an optional-prop-derived initial value needs BOUND (to
+     * the real prop or to `null`) in the render context. This integration's
+     * shared components aren't manifest-registered under `ui/*` (see
+     * BarefootHelper::renderComponent's manual child wiring, mirroring
+     * integrations/blade), so root-level renders derive the stash themselves
+     * via stashFromSsrDefaults().
+     *
+     * PHP's cli-server resets statics per request, so this (and blogData) is
+     * a per-request lazy read -- the same cost point as integrations/blade
+     * reading it at the top of index.php.
+     */
+    public static function manifest(): array
+    {
+        static $manifest = null;
+        if ($manifest === null) {
+            $path = base_path('dist/templates/manifest.json');
+            $manifest = is_file($path) ? (json_decode((string) file_get_contents($path), true) ?: []) : [];
+        }
+        return $manifest;
+    }
+
+    /**
+     * The blog post corpus -- generated at build time by
+     * scripts/gen-blog-data.ts from ../shared/blog/posts.ts (the single TS
+     * source of truth the JS adapters import directly; this PHP server reads
+     * the JSON mirror instead).
+     */
+    public static function blogData(): array
+    {
+        static $data = null;
+        if ($data === null) {
+            $path = base_path('dist/blog-data.json');
+            $data = is_file($path)
+                ? (json_decode((string) file_get_contents($path), true) ?: ['posts' => [], 'listItems' => [], 'allTags' => []])
+                : ['posts' => [], 'listItems' => [], 'allTags' => []];
+        }
+        return $data;
+    }
+
+    public static function seedTodos(): array
+    {
+        return [
+            ['id' => 1, 'text' => 'Setup project', 'done' => false, 'editing' => false],
+            ['id' => 2, 'text' => 'Create components', 'done' => false, 'editing' => false],
+            ['id' => 3, 'text' => 'Write tests', 'done' => true, 'editing' => false],
+        ];
+    }
+
+    public static function randSuffix(): string
+    {
+        return substr(bin2hex(random_bytes(4)), 0, 6);
+    }
+
+    /** Mirrors PostList's `asSortKey`: an unknown/absent `?sort=` falls back
+     * to 'date' so the SSR row order always matches a valid post-hydration
+     * state. */
+    public static function asSortKey(?string $raw): string
+    {
+        return in_array($raw, self::BLOG_SORT_KEYS, true) ? $raw : 'date';
+    }
+
+    /**
+     * Port of BarefootJS::deriveStashFromDefaults for root-level renders (see
+     * manifest()'s docstring for why root renders need their own copy instead
+     * of getting it via `register_components_from_manifest`). Same
+     * always-BIND-the-prop-or-null contract integrations/blade documents on
+     * its stash_from_ssr_defaults -- PHP's `??` coalesces silently for an
+     * entirely undefined variable, but the seeded arithmetic must still see
+     * the SAME value as every other adapter.
+     */
+    public static function stashFromSsrDefaults(string $component, array $props): array
+    {
+        $entry = self::manifest()[$component] ?? [];
+        $defaults = $entry['ssrDefaults'] ?? [];
+        $extra = [];
+        foreach ($defaults as $name => $d) {
+            if (!is_array($d)) {
+                $extra[$name] = $d;
+                continue;
+            }
+            $propName = $d['propName'] ?? null;
+            if ($propName !== null && array_key_exists($propName, $props) && $props[$propName] !== null) {
+                $extra[$name] = $props[$propName];
+            } else {
+                $extra[$name] = $d['value'] ?? null;
+            }
+        }
+        return $extra;
+    }
+
+    /**
+     * Root-level script collector. Plain PHP arrays are copy-on-write VALUES;
+     * `ArrayObject` gives the runtime's `_scripts()`/`_script_seen()`
+     * accessors real shared-reference semantics so sibling islands see each
+     * other's registered `<script>` tags -- see integrations/blade's
+     * new_script_collector docstring for the full rationale (this is a
+     * verbatim port).
+     */
+    public static function newScriptCollector(BarefootJS $bf): void
+    {
+        $bf->_scripts(new \ArrayObject());
+        $bf->_script_seen(new \ArrayObject());
+    }
+
+    public static function shareScriptCollector(BarefootJS $from, BarefootJS $to): void
+    {
+        $to->_scripts($from->_scripts());
+        $to->_script_seen($from->_script_seen());
+    }
+
+    // -------------------------------------------------------------------
+    // Blog -- the @barefootjs/router showcase. Ports of integrations/blade's
+    // register_blog_child / blog_island / blog_page; see that file's blog
+    // section docstring for the searchParams() SSR seeding rationale.
+    // -------------------------------------------------------------------
+
+    /** Register a renderer for a flat (non-`ui/*`) child component from the
+     * build manifest (`post_list_item` -> PostListItem, `reader_toolbar` ->
+     * ReaderToolbar): a fresh child scope chained off the caller's slot, the
+     * shared script collector + renderer registry, and the manifest's
+     * ssrDefaults seeded (caller prop wins). */
+    public static function registerBlogChild(BarefootJS $parentBf, string $slot, string $component, array $extraSeed = []): void
+    {
+        $backend = self::backend();
+        $entry = self::manifest()[$component] ?? null;
+        if ($entry === null) {
+            return;
+        }
+        $hasDefaults = array_key_exists('ssrDefaults', $entry);
+
+        $renderer = function (array $props, ?BarefootJS $caller = null) use ($backend, $parentBf, $component, $hasDefaults, $extraSeed) {
+            $host = $caller ?? $parentBf;
+            $hostScope = $host->_scope_id();
+            $child = new BarefootJS(null, ['backend' => $backend]);
+            $slotId = $props['_bf_slot'] ?? null;
+            unset($props['_bf_slot']);
+            $dataKey = $props['key'] ?? null;
+            unset($props['key']);
+            if ($dataKey !== null) {
+                $child->_data_key($dataKey);
+            }
+            $child->_scope_id($slotId !== null ? "{$hostScope}_{$slotId}" : $component . '_' . self::randSuffix());
+            $child->_is_child(true);
+            if ($slotId !== null) {
+                $child->_bf_parent($hostScope);
+                $child->_bf_mount($slotId);
+            }
+            $child->_child_renderers($parentBf->_child_renderers());
+            self::shareScriptCollector($parentBf, $child);
+            $extra = $hasDefaults ? self::stashFromSsrDefaults($component, $props) : [];
+            return $backend->render_named($component, $child, array_merge($extra, $extraSeed, $props));
+        };
+
+        $parentBf->register_child_renderer($slot, $renderer);
+    }
+
+    /**
+     * Render one top-level island to an HTML string, sharing `$root`'s script
+     * collector + renderer registry so islands compose into one page.
+     *
+     *   $props    -- client props (-> bf-p, so the client hydration sees them,
+     *                AND template vars)
+     *   $extra    -- SSR-only template vars (derived memo / getter values not
+     *                lowered)
+     *   $children -- slot key -> child template name, OR slot key -> [template,
+     *                extraSeed] for the one case (now_playing) that needs both
+     */
+    public static function blogIsland(BarefootJS $root, string $component, array $props = [], array $extra = [], array $children = []): string
+    {
+        $backend = self::backend();
+        $bf = new BarefootJS(null, ['backend' => $backend]);
+        $bf->_scope_id($component . '_' . self::randSuffix());
+        if ($props) {
+            $bf->_props($props);
+        }
+        self::shareScriptCollector($root, $bf);
+        $bf->_child_renderers($root->_child_renderers());
+        foreach ($children as $slot => $spec) {
+            if (is_array($spec)) {
+                [$templateName, $seed] = $spec;
+            } else {
+                $templateName = $spec;
+                $seed = [];
+            }
+            self::registerBlogChild($bf, $slot, $templateName, $seed);
+        }
+        $seed = self::stashFromSsrDefaults($component, $props);
+        return $backend->render_named($component, $bf, array_merge($seed, $props, $extra));
+    }
+
+    /** Assemble the region-shell page around already-rendered content HTML.
+     * `$root` is the request-scoped runtime whose script collector the content
+     * islands (and the shell islands rendered here) all share. */
+    public static function blogPage(BarefootJS $root, string $title, string $base, string $contentHtml): string
+    {
+        $BASE = self::base();
+        $static = "{$BASE}/client";
+        $theme = self::blogIsland($root, 'ThemeToggle');
+        $sidebar = self::blogIsland($root, 'Sidebar');
+        $shell = self::blogIsland(
+            $root,
+            'PageShell',
+            [],                                                     // no client props
+            ['children' => $root->backend->mark_raw($contentHtml)], // SSR-only: page content
+            ['reader_toolbar' => 'ReaderToolbar'],
+        );
+        $importMap = json_encode([
+            'imports' => [
+                '@barefootjs/client' => "{$static}/barefoot.js",
+                '@barefootjs/client/runtime' => "{$static}/barefoot.js",
+                '@barefootjs/client/reactive' => "{$static}/barefoot.js",
+            ],
+        ]);
+        $scripts = $root->scripts();
+        $escTitle = htmlspecialchars($title, ENT_QUOTES);
+        return <<<HTML
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{$escTitle}</title>
+<script type="importmap">{$importMap}</script>
+<link rel="stylesheet" href="{$BASE}/styles/blog.css">
+</head>
+<body>
+<header class="shell">
+<a class="shell-brand" href="{$base}">\u{1F4F0} Barefoot Blog</a>
+<div class="shell-island">{$theme}</div>
+</header>
+<div class="layout">
+<aside bf-region="nav:0">{$sidebar}</aside>
+<main>{$shell}</main>
+</div>
+{$scripts}
+<script type="module" src="{$static}/router-entry.js"></script>
+</body>
+</html>
+HTML;
+    }
+
+    // -------------------------------------------------------------------
+    // Static assets: dist/client + dist/styles, mounted under base(). Served
+    // by explicit routes (routes/web.php) because the URL path
+    // (client/...) doesn't match the filesystem path (dist/client/...) --
+    // same rationale as integrations/blade's serve_static_file, expressed as
+    // a Laravel response.
+    // -------------------------------------------------------------------
+    public const STATIC_MIME_TYPES = [
+        'js' => 'text/javascript; charset=utf-8',
+        'mjs' => 'text/javascript; charset=utf-8',
+        'css' => 'text/css; charset=utf-8',
+        'map' => 'application/json; charset=utf-8',
+        'svg' => 'image/svg+xml',
+        'png' => 'image/png',
+        'json' => 'application/json; charset=utf-8',
+    ];
+
+    public static function serveStaticFile(string $root, string $relative)
+    {
+        // Reject traversal outside $root (`..`, absolute paths).
+        $normalized = str_replace('\\', '/', $relative);
+        if ($normalized === '' || str_contains($normalized, '..') || str_starts_with($normalized, '/')) {
+            return response('Not Found', 404)->header('Content-Type', 'text/plain');
+        }
+        $path = $root . '/' . $normalized;
+        if (!is_file($path)) {
+            return response('Not Found', 404)->header('Content-Type', 'text/plain');
+        }
+        $ext = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+        return response()->file($path, [
+            'Content-Type' => self::STATIC_MIME_TYPES[$ext] ?? 'application/octet-stream',
+        ]);
+    }
+}

--- a/integrations/laravel/app/Support/TodoStore.php
+++ b/integrations/laravel/app/Support/TodoStore.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * Per-session file-backed todo storage -- verbatim port of
+ * integrations/blade/index.php's session-store section, for the same reason:
+ * `php artisan serve` is the SAME PHP built-in server run with
+ * `PHP_CLI_SERVER_WORKERS=8` (see package.json / the Dockerfiles), i.e. 8
+ * separate worker PROCESSES with their own memory, round-robining requests.
+ * An in-memory array (what the threaded-Puma Rails example uses) would make a
+ * browser's todo list flicker between completely different lists depending on
+ * which worker answered. So the store is a small JSON file per session id
+ * (keyed by the `bf_session` cookie) under the system temp dir, guarded by
+ * `flock()` so concurrent requests to the SAME session (even across worker
+ * processes) still serialize correctly. No LRU eviction: this is a demo,
+ * files are tiny, and OS temp dirs get reaped independently.
+ */
+final class TodoStore
+{
+    private static function dir(): string
+    {
+        $dir = sys_get_temp_dir() . '/barefootjs-laravel-sessions';
+        if (!is_dir($dir)) {
+            mkdir($dir, 0700, true);
+        }
+        return $dir;
+    }
+
+    private static function file(string $sid): string
+    {
+        // Session ids are minted hex-only (see BarefootHelper), but guard
+        // against a hostile/garbled cookie value reaching the filesystem
+        // path anyway.
+        $safe = preg_replace('/[^a-zA-Z0-9]/', '', $sid);
+        return self::dir() . '/' . $safe . '.json';
+    }
+
+    /**
+     * Read-modify-write a session's `{todos, next_id}` state under an
+     * exclusive lock: `$mutator` receives the current state array and must
+     * return `[$newState, $result]`; `$result` is returned to the caller.
+     * Opens with `c+` (create-if-missing, don't truncate) so the lock covers
+     * the seed-on-first-access case too.
+     */
+    public static function with(string $sid, callable $mutator)
+    {
+        $fh = fopen(self::file($sid), 'c+');
+        if ($fh === false) {
+            throw new \RuntimeException('failed to open session store');
+        }
+        try {
+            flock($fh, LOCK_EX);
+            $raw = stream_get_contents($fh);
+            $state = ($raw !== false && $raw !== '') ? json_decode($raw, true) : null;
+            if (!is_array($state) || !isset($state['todos'], $state['next_id'])) {
+                $state = ['todos' => ExampleApp::seedTodos(), 'next_id' => 4];
+            }
+            [$state, $result] = $mutator($state);
+            ftruncate($fh, 0);
+            rewind($fh);
+            fwrite($fh, json_encode($state));
+            fflush($fh);
+            return $result;
+        } finally {
+            flock($fh, LOCK_UN);
+            fclose($fh);
+        }
+    }
+
+    /** Shared-lock read-only accessor for routes that only need the current
+     * todo list (GET /todos, GET /api/todos) -- avoids taking the exclusive
+     * lock `with` needs for a read-modify-write cycle. */
+    public static function read(string $sid): array
+    {
+        $path = self::file($sid);
+        if (!is_file($path)) {
+            // First visit: seed + persist under the exclusive lock, then return.
+            return self::with($sid, static fn (array $s) => [$s, $s]);
+        }
+        $fh = fopen($path, 'r');
+        if ($fh === false) {
+            return ['todos' => ExampleApp::seedTodos(), 'next_id' => 4];
+        }
+        flock($fh, LOCK_SH);
+        $raw = stream_get_contents($fh);
+        flock($fh, LOCK_UN);
+        fclose($fh);
+        $state = json_decode((string) $raw, true);
+        return (is_array($state) && isset($state['todos'], $state['next_id']))
+            ? $state
+            : ['todos' => ExampleApp::seedTodos(), 'next_id' => 4];
+    }
+}

--- a/integrations/laravel/artisan
+++ b/integrations/laravel/artisan
@@ -1,0 +1,30 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Stock Laravel 12 artisan entry point, plus the same "runtime not found"
+ * guidance integrations/blade's index.php prints: unlike the plain-PHP
+ * sibling there is NO workspace-package autoload fallback here --
+ * laravel/framework itself only exists in this directory's vendor/, so a
+ * `composer install` (run as part of `bun run build`) must have happened
+ * before anything (including `php artisan serve`) can boot.
+ */
+
+use Symfony\Component\Console\Input\ArgvInput;
+
+define('LARAVEL_START', microtime(true));
+
+if (!is_file(__DIR__.'/vendor/autoload.php')) {
+    fwrite(STDERR, "Laravel + BarefootJS runtime not found. Run `bun run build` (or `composer install` after "
+        ."`bun run scripts/assemble-deps.ts`) in integrations/laravel first.\n");
+    exit(1);
+}
+
+// Register the Composer autoloader...
+require __DIR__.'/vendor/autoload.php';
+
+// Bootstrap Laravel and handle the command...
+$status = (require_once __DIR__.'/bootstrap/app.php')
+    ->handleCommand(new ArgvInput);
+
+exit($status);

--- a/integrations/laravel/barefoot.config.ts
+++ b/integrations/laravel/barefoot.config.ts
@@ -1,0 +1,20 @@
+import { createConfig } from '@barefootjs/blade/build'
+
+const basePath = process.env.BASE_PATH ?? '/integrations/laravel'
+const clientBase = `${basePath}/client/`
+
+// Same compile setup as integrations/blade (the plain-PHP sibling on the same
+// @barefootjs/blade adapter) -- only the mount point differs. Blog (the
+// @barefootjs/router showcase) is wired up the same way; see #2076 for the
+// searchParams() SSR support that made it possible for the Jinja/Twig
+// adapters.
+export default createConfig({
+  components: ['../shared/components', '../shared/blog'],
+  outDir: 'dist',
+  minify: true,
+  bundleEntries: [{ entry: 'client/router-entry.ts', outfile: 'router-entry.js' }],
+  adapterOptions: {
+    clientJsBasePath: clientBase,
+    barefootJsPath: `${clientBase}barefoot.js`,
+  },
+})

--- a/integrations/laravel/bootstrap/app.php
+++ b/integrations/laravel/bootstrap/app.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Configuration\Exceptions;
+use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
+
+/**
+ * Hand-trimmed Laravel boot -- the PHP counterpart of integrations/rails'
+ * config/application.rb: keep routing + controllers + the view layer, strip
+ * the stateful HTTP middleware this showcase doesn't use. There is no
+ * database, no mail, no queue and no asset pipeline in play; client assets
+ * are the host-built dist/ files served by explicit routes (see
+ * routes/web.php).
+ */
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(
+        web: __DIR__.'/../routes/web.php',
+    )
+    ->withMiddleware(function (Middleware $middleware): void {
+        $middleware->web(remove: [
+            // The only cookie is the plain opaque `bf_session` id every other
+            // integration sets raw (the client never reads it; the server
+            // regex-validates it) -- encrypting it here would break parity
+            // with the shared session-cookie shape AND drag in an APP_KEY
+            // requirement nothing else needs.
+            EncryptCookies::class,
+            // No server-side session state: the todo store keys off the
+            // bf_session cookie directly (see App\Support\TodoStore). Laravel
+            // sessions would need a driver + storage this example doesn't
+            // have. ShareErrorsFromSession depends on StartSession.
+            StartSession::class,
+            ShareErrorsFromSession::class,
+            // Stateless JSON API + hydration showcase -- no CSRF tokens
+            // (mirrors integrations/rails' `skip_forgery_protection`; the
+            // plain-PHP/Twig/Blade siblings have no forgery protection at
+            // all).
+            ValidateCsrfToken::class,
+        ]);
+    })
+    ->withExceptions(function (Exceptions $exceptions): void {
+        //
+    })
+    ->create();

--- a/integrations/laravel/bootstrap/cache/.gitignore
+++ b/integrations/laravel/bootstrap/cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/integrations/laravel/bootstrap/providers.php
+++ b/integrations/laravel/bootstrap/providers.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    App\Providers\BarefootServiceProvider::class,
+];

--- a/integrations/laravel/client/router-entry.ts
+++ b/integrations/laravel/client/router-entry.ts
@@ -1,0 +1,24 @@
+/**
+ * Client bootstrap for the blog (Laravel integration).
+ *
+ * Loaded once per page as a module `<script>`. It:
+ *   1. installs the client-runtime seams the router re-hydrates / disposes
+ *      through (`setupStreaming` → `window.__bf_hydrate_within` +
+ *      `window.__bf_dispose_within`),
+ *   2. starts the router.
+ *
+ * Same-route `?sort=` / `?tag=` navigations become reactive `searchParams()`
+ * updates (no region swap) with no extra wiring here: the router pushes the new
+ * query through the `window.__bf_pushSearch` seam, which `@barefootjs/client`'s
+ * `searchParams()` installs lazily the first time an island reads it.
+ *
+ * `@barefootjs/client*` is left external in the bundle and resolved through the
+ * page's import map to the SAME `barefoot.js` the compiled islands use — so
+ * there is a single reactive runtime instance and `searchParams()` drives the
+ * islands' effects.
+ */
+import { setupStreaming } from '@barefootjs/client/runtime'
+import { startRouter } from '@barefootjs/router'
+
+setupStreaming()
+startRouter()

--- a/integrations/laravel/composer.json
+++ b/integrations/laravel/composer.json
@@ -1,0 +1,27 @@
+{
+    "name": "barefootjs/laravel-example",
+    "description": "BarefootJS + Laravel example (Blade adapter). See scripts/assemble-deps.ts for how the Barefoot\\ runtime + Blade backend autoload below is staged.",
+    "type": "project",
+    "private": true,
+    "license": "MIT",
+    "require": {
+        "php": ">=8.2",
+        "laravel/framework": "^12.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/",
+            "Barefoot\\": [
+                "lib/barefootjs-php/src/",
+                "lib/barefootjs-blade/src/"
+            ]
+        },
+        "files": [
+            "lib/barefootjs-blade/src/naming.php"
+        ]
+    },
+    "minimum-stability": "stable",
+    "config": {
+        "sort-packages": true
+    }
+}

--- a/integrations/laravel/config/view.php
+++ b/integrations/laravel/config/view.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Point the app's OWN view factory at the BarefootJS build output: `bf build`
+ * (see barefoot.config.ts) compiles the shared JSX into *.blade.php templates
+ * under dist/templates, and `Barefoot\BladeBackend` reuses this factory (see
+ * App\Providers\BarefootServiceProvider) instead of wiring up a standalone
+ * illuminate/view stack the way integrations/blade does.
+ *
+ * The framework's CompilerEngine compares each view's mtime against its
+ * compiled cache file and recompiles on mismatch, so the default compiled
+ * path below is correct in both dev (edits from `bun run build:watch` render
+ * on the next request) and production (a warm compiled-template cache
+ * survives across requests) -- the same no-DEV-switch rationale documented on
+ * integrations/blade's `$backend` construction.
+ */
+return [
+    'paths' => [base_path('dist/templates')],
+    'compiled' => env('VIEW_COMPILED_PATH', realpath(storage_path('framework/views')) ?: storage_path('framework/views')),
+];

--- a/integrations/laravel/container.ts
+++ b/integrations/laravel/container.ts
@@ -1,0 +1,23 @@
+/**
+ * Worker shim that forwards every request under /integrations/laravel/* to
+ * the Laravel app running inside a Cloudflare Container.
+ */
+
+import { Container } from '@cloudflare/containers'
+
+type Env = {
+  LARAVEL_CONTAINER: DurableObjectNamespace
+}
+
+export class LaravelContainer extends Container<Env> {
+  defaultPort = 8080
+  sleepAfter = '10m'
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const id = env.LARAVEL_CONTAINER.idFromName('singleton')
+    const stub = env.LARAVEL_CONTAINER.get(id) as unknown as { fetch: typeof fetch }
+    return stub.fetch(request)
+  },
+} satisfies ExportedHandler<Env>

--- a/integrations/laravel/e2e/ai-chat.spec.ts
+++ b/integrations/laravel/e2e/ai-chat.spec.ts
@@ -1,0 +1,9 @@
+/**
+ * AI Chat E2E tests for Laravel example
+ *
+ * Uses shared test suite from integrations/shared/e2e
+ */
+
+import { aiChatTests } from '../../shared/e2e/ai-chat.spec'
+
+aiChatTests('http://localhost:3016/integrations/laravel')

--- a/integrations/laravel/e2e/blog-ssr.spec.ts
+++ b/integrations/laravel/e2e/blog-ssr.spec.ts
@@ -1,0 +1,3 @@
+import { blogSsrTests } from '../../shared/e2e/blog-ssr.spec'
+
+blogSsrTests('http://localhost:3016/integrations/laravel/blog')

--- a/integrations/laravel/e2e/blog.spec.ts
+++ b/integrations/laravel/e2e/blog.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect, type Page } from '@playwright/test'
+
+// The blog routes are mounted under the integration's base path. Same specs as
+// the Hono / Text::Xslate references (integrations/hono/e2e/blog.spec.ts,
+// integrations/xslate/e2e/blog.spec.ts, integrations/flask/e2e/blog.spec.ts);
+// only the mount point differs -- the shared blog islands are base-path
+// aware. Adapter-local (not a shared suite), like the rest of this
+// integration's e2e specs.
+const BLOG = '/integrations/laravel/blog'
+
+// Tag a live node with an identity marker; read it back to tell a surviving
+// node (region kept) from a freshly rendered one (region swapped).
+const mark = (page: Page, sel: string) =>
+  page.$eval(sel, (el) => {
+    ;(el as unknown as { __mark?: string }).__mark = 'KEEP'
+  })
+const marker = (page: Page, sel: string) =>
+  page.$eval(sel, (el) => (el as unknown as { __mark?: string }).__mark).catch(() => null)
+
+test('v0.5: sort/tag is a query-only update with no region swap', async ({ page }) => {
+  await page.goto(BLOG, { waitUntil: 'networkidle' })
+  await expect(page.locator('.sortable-list li')).toHaveCount(10)
+  await mark(page, '.content') // the list root — a region swap would replace it
+  await page.click('.controls a.sort:has-text("title")')
+  await page.waitForTimeout(150)
+  const first = await page.locator('.sortable-list li:first-child .item-link').innerText()
+  expect(first[0] === 'A' || first[0] === 'B').toBe(true)
+  expect(await marker(page, '.content')).toBe('KEEP') // not swapped
+  expect(page.url()).toContain('sort=title')
+})
+
+test('v0: clicking a post swaps the content region; shell + theme persist', async ({ page }) => {
+  await page.goto(BLOG, { waitUntil: 'networkidle' })
+  await page.click('.toggle')
+  const theme = await page.getAttribute('html', 'data-theme')
+  await page.click('.sortable-list li:first-child .item-link')
+  await page.waitForSelector('.island.like', { timeout: 3000 })
+  expect(await page.locator('.island.like').count()).toBe(1)
+  expect(await page.getAttribute('html', 'data-theme')).toBe(theme) // shell never reloaded
+  await page.click('.island.like')
+  expect(await page.locator('.island.like .v').innerText()).toBe('1')
+})
+
+test('v1: data-bf-permanent keeps the player live across a post→post swap', async ({ page }) => {
+  test.setTimeout(15000)
+  await page.goto(BLOG, { waitUntil: 'networkidle' })
+  await page.click('.sortable-list li:first-child .item-link')
+  await page.waitForSelector('.now-playing-bar', { timeout: 3000 })
+  await page.click('.now-playing-bar .np-toggle') // ▶ play
+  await page.waitForTimeout(900)
+  const before = Number(await page.locator('.now-playing-bar .np-time').innerText())
+  expect(before).toBeGreaterThan(0.4)
+  await mark(page, '[data-bf-permanent="now-playing"]')
+  await page.click('.pager a.pager-link[href*="/posts/"]')
+  await page.waitForTimeout(400)
+  expect(await marker(page, '[data-bf-permanent="now-playing"]')).toBe('KEEP') // same live node
+  expect(Number(await page.locator('.now-playing-bar .np-time').innerText())).toBeGreaterThanOrEqual(before)
+  expect(Number(await page.locator('.island.timer .v').innerText())).toBeLessThan(0.5) // unmarked timer reset
+  // post → index ("← All posts"): the player is also data-bf-permanent on the
+  // list, so the same live node survives returning to the index — not reset.
+  const elapsed = Number(await page.locator('.now-playing-bar .np-time').innerText())
+  await page.click('.post .back')
+  await page.waitForSelector('.sortable-list li', { timeout: 3000 })
+  expect(await marker(page, '[data-bf-permanent="now-playing"]')).toBe('KEEP') // same live node on the index
+  expect(Number(await page.locator('.now-playing-bar .np-time').innerText())).toBeGreaterThanOrEqual(elapsed)
+})
+
+test('v2 sibling: the sidebar region persists while content swaps', async ({ page }) => {
+  await page.goto(BLOG, { waitUntil: 'networkidle' })
+  await page.click('.sidebar-pin')
+  await page.click('.sidebar-pin')
+  expect(await page.locator('.sidebar-pin .v').innerText()).toBe('2')
+  await mark(page, 'aside[bf-region] .sidebar')
+  await page.click('.sortable-list li:first-child .item-link')
+  await page.waitForSelector('.island.like', { timeout: 3000 })
+  expect(await page.locator('.sidebar-pin .v').innerText()).toBe('2') // state survived
+  expect(await marker(page, 'aside[bf-region] .sidebar')).toBe('KEEP') // same node
+})
+
+test('v2 nested: the outer toolbar region persists while the inner content swaps', async ({ page }) => {
+  await page.goto(BLOG, { waitUntil: 'networkidle' })
+  await page.click('.reader-toolbar .rt-btn[aria-label="larger"]')
+  await page.click('.reader-toolbar .rt-btn[aria-label="larger"]')
+  expect(await page.locator('.reader-toolbar .v').innerText()).toBe('3')
+  await mark(page, '.reader-toolbar')
+  await page.click('.sortable-list li:first-child .item-link')
+  await page.waitForSelector('.island.like', { timeout: 3000 })
+  expect(await page.locator('.reader-toolbar .v').innerText()).toBe('3') // outer region kept
+  expect(await marker(page, '.reader-toolbar')).toBe('KEEP') // same node
+})

--- a/integrations/laravel/e2e/conditional-return.spec.ts
+++ b/integrations/laravel/e2e/conditional-return.spec.ts
@@ -1,0 +1,9 @@
+/**
+ * ConditionalReturn E2E tests for Laravel example
+ *
+ * Uses shared test suite from integrations/shared/e2e
+ */
+
+import { conditionalReturnTests } from '../../shared/e2e/conditional-return.spec'
+
+conditionalReturnTests('http://localhost:3016/integrations/laravel')

--- a/integrations/laravel/e2e/counter.spec.ts
+++ b/integrations/laravel/e2e/counter.spec.ts
@@ -1,0 +1,9 @@
+/**
+ * Counter E2E tests for Laravel example
+ *
+ * Uses shared test suite from integrations/shared/e2e
+ */
+
+import { counterTests } from '../../shared/e2e/counter.spec'
+
+counterTests('http://localhost:3016/integrations/laravel')

--- a/integrations/laravel/e2e/form.spec.ts
+++ b/integrations/laravel/e2e/form.spec.ts
@@ -1,0 +1,9 @@
+/**
+ * Form E2E tests for Laravel example
+ *
+ * Uses shared test suite from integrations/shared/e2e
+ */
+
+import { formTests } from '../../shared/e2e/form.spec'
+
+formTests('http://localhost:3016/integrations/laravel')

--- a/integrations/laravel/e2e/portal.spec.ts
+++ b/integrations/laravel/e2e/portal.spec.ts
@@ -1,0 +1,9 @@
+/**
+ * Portal E2E tests for Laravel example
+ *
+ * Uses shared test suite from integrations/shared/e2e
+ */
+
+import { portalTests } from '../../shared/e2e/portal.spec'
+
+portalTests('http://localhost:3016/integrations/laravel')

--- a/integrations/laravel/e2e/reactive-props.spec.ts
+++ b/integrations/laravel/e2e/reactive-props.spec.ts
@@ -1,0 +1,9 @@
+/**
+ * ReactiveProps E2E tests for Laravel example
+ *
+ * Uses shared test suite from integrations/shared/e2e
+ */
+
+import { reactivePropsTests } from '../../shared/e2e/reactive-props.spec'
+
+reactivePropsTests('http://localhost:3016/integrations/laravel')

--- a/integrations/laravel/e2e/todo-app-ssr.spec.ts
+++ b/integrations/laravel/e2e/todo-app-ssr.spec.ts
@@ -1,0 +1,9 @@
+/**
+ * TodoAppSSR E2E tests for Laravel example
+ *
+ * Tests TodoApp without @client markers
+ */
+
+import { todoAppTests } from '../../shared/e2e/todo-app.spec'
+
+todoAppTests('http://localhost:3016/integrations/laravel', '/todos-ssr')

--- a/integrations/laravel/e2e/todo-app.spec.ts
+++ b/integrations/laravel/e2e/todo-app.spec.ts
@@ -1,0 +1,9 @@
+/**
+ * TodoApp E2E tests for Laravel example
+ *
+ * Uses shared test suite from integrations/shared/e2e
+ */
+
+import { todoAppTests } from '../../shared/e2e/todo-app.spec'
+
+todoAppTests('http://localhost:3016/integrations/laravel')

--- a/integrations/laravel/e2e/toggle.spec.ts
+++ b/integrations/laravel/e2e/toggle.spec.ts
@@ -1,0 +1,9 @@
+/**
+ * Toggle E2E tests for Laravel example
+ *
+ * Uses shared test suite from integrations/shared/e2e
+ */
+
+import { toggleTests } from '../../shared/e2e/toggle.spec'
+
+toggleTests('http://localhost:3016/integrations/laravel')

--- a/integrations/laravel/package.json
+++ b/integrations/laravel/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "barefootjs-laravel-example",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "bun run ../../packages/cli/src/index.ts build && bun run scripts/gen-blog-data.ts && bun run scripts/assemble-deps.ts && composer install --no-interaction --no-progress",
+    "build:watch": "bun run ../../packages/cli/src/index.ts build --watch",
+    "dev": "PHP_CLI_SERVER_WORKERS=8 BASE_PATH=/integrations/laravel php artisan serve --host=0.0.0.0 --port=3016",
+    "deploy": "bun run build && wrangler deploy",
+    "test:e2e": "bunx playwright test",
+    "test:e2e:ui": "bunx playwright test --ui",
+    "clean": "rm -rf dist lib vendor composer.lock storage/framework/views/*.php"
+  },
+  "dependencies": {
+    "@barefootjs/client": "workspace:*",
+    "@barefootjs/router": "workspace:*"
+  },
+  "devDependencies": {
+    "@barefootjs/jsx": "workspace:*",
+    "@barefootjs/blade": "workspace:*",
+    "@cloudflare/containers": "^0.3.2",
+    "@cloudflare/workers-types": "^4",
+    "@playwright/test": "^1.41.0",
+    "bun-types": "^1.1.0",
+    "wrangler": "^4"
+  }
+}

--- a/integrations/laravel/playwright.config.ts
+++ b/integrations/laravel/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 5000,
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  // Use single worker to avoid conflicts with shared server state (/api/todos/reset)
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3016',
+    trace: 'on-first-retry',
+    launchOptions: { executablePath: process.env.PW_EXECUTABLE_PATH || undefined },
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    // Run the test server in production mode (template cache warm, no debug
+    // overhead) -- mirrors integrations/blade's rationale for running e2e
+    // against a production-shaped server rather than dev mode. `artisan
+    // serve` is the same PHP built-in server; PHP_CLI_SERVER_WORKERS gives
+    // it a worker pool so the SSE stream doesn't stall other requests.
+    command:
+      'PHP_CLI_SERVER_WORKERS=8 APP_ENV=production BASE_PATH=/integrations/laravel php artisan serve --host=0.0.0.0 --port=3016',
+    url: 'http://localhost:3016/integrations/laravel/',
+    reuseExistingServer: !process.env.CI,
+    timeout: 30000,
+  },
+})

--- a/integrations/laravel/public/index.php
+++ b/integrations/laravel/public/index.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Stock Laravel 12 HTTP entry point, plus the same "runtime not found" guard
+ * integrations/blade's index.php has (see artisan's docstring for why there
+ * is no workspace-package autoload fallback in this integration).
+ */
+
+use Illuminate\Http\Request;
+
+define('LARAVEL_START', microtime(true));
+
+if (!is_file(__DIR__.'/../vendor/autoload.php')) {
+    http_response_code(500);
+    header('Content-Type: text/plain');
+    echo "Laravel + BarefootJS runtime not found. Run `bun run build` (or `composer install` after "
+        ."`bun run scripts/assemble-deps.ts`) in integrations/laravel first.\n";
+    exit(1);
+}
+
+// Register the Composer autoloader...
+require __DIR__.'/../vendor/autoload.php';
+
+// Bootstrap Laravel and handle the request...
+(require_once __DIR__.'/../bootstrap/app.php')
+    ->handleRequest(Request::capture());

--- a/integrations/laravel/routes/web.php
+++ b/integrations/laravel/routes/web.php
@@ -1,0 +1,69 @@
+<?php
+
+use App\Http\Controllers\AiChatController;
+use App\Http\Controllers\BlogController;
+use App\Http\Controllers\PagesController;
+use App\Http\Controllers\TodosController;
+use App\Support\ExampleApp;
+use Illuminate\Support\Facades\Route;
+
+/**
+ * Routes are defined UNDER the base prefix (unlike integrations/rails, where
+ * config.ru strips it before the framework's router runs): `php artisan
+ * serve` receives the full /integrations/laravel/* path, so the prefix lives
+ * here -- the Laravel-router equivalent of integrations/blade's `$BASE`
+ * dispatch. Same route table shape as that file (and the Twig/Flask/Xslate
+ * references before it) so the ports can be diffed side by side.
+ */
+
+$base = ExampleApp::base();
+
+// A bare-root request redirects into the base path (mirrors
+// integrations/blade's `/` -> `{$BASE}/` redirect).
+if ($base !== '') {
+    Route::redirect('/', "{$base}/", 302);
+}
+
+Route::prefix($base)->group(function (): void {
+    // --- static assets: dist/client + dist/styles, mounted under the base
+    // path. Explicit routes because the URL path (client/...) doesn't match
+    // the filesystem path (dist/client/...).
+    Route::get('client/{path}', static fn (string $path) => ExampleApp::serveStaticFile(base_path('dist/client'), $path))
+        ->where('path', '.*');
+    Route::get('styles/{path}', static fn (string $path) => ExampleApp::serveStaticFile(base_path('dist/styles'), $path))
+        ->where('path', '.*');
+
+    // --- component demo pages ---
+    Route::get('/', [PagesController::class, 'index']);
+    Route::get('counter', [PagesController::class, 'counter']);
+    Route::get('toggle', [PagesController::class, 'toggle']);
+    Route::get('form', [PagesController::class, 'form']);
+    Route::get('reactive-props', [PagesController::class, 'reactiveProps']);
+    Route::get('props-reactivity', [PagesController::class, 'propsReactivity']);
+    Route::get('conditional-return', [PagesController::class, 'conditionalReturn']);
+    Route::get('conditional-return-link', [PagesController::class, 'conditionalReturn']);
+    Route::get('portal', [PagesController::class, 'portal']);
+    Route::get('ai-chat', [PagesController::class, 'aiChat']);
+
+    // --- AI chat SSE stream ---
+    Route::get('api/ai-chat', [AiChatController::class, 'stream']);
+
+    // --- todo pages (with/without @client markers) + the session-cookie
+    // REST API. `todos-ssr` reuses the same action with an `ssr` route
+    // default (mirrors integrations/rails' `defaults: { ssr: '1' }`).
+    Route::get('todos', [TodosController::class, 'index']);
+    Route::get('todos-ssr', [TodosController::class, 'index'])->defaults('ssr', '1');
+    Route::get('api/todos', [TodosController::class, 'apiIndex']);
+    Route::post('api/todos', [TodosController::class, 'apiCreate']);
+    Route::post('api/todos/reset', [TodosController::class, 'apiReset']);
+    Route::put('api/todos/{id}', [TodosController::class, 'apiUpdate'])->whereNumber('id');
+    Route::delete('api/todos/{id}', [TodosController::class, 'apiDestroy'])->whereNumber('id');
+
+    // --- blog: the @barefootjs/router showcase ---
+    Route::get('blog', [BlogController::class, 'index']);
+    Route::get('blog/posts/{slug}', [BlogController::class, 'post']);
+});
+
+// Plain-text 404 for anything else (mirrors integrations/blade's fallthrough;
+// Laravel's default HTML error page would be noise for the API routes).
+Route::fallback(static fn () => response('Not Found', 404)->header('Content-Type', 'text/plain'));

--- a/integrations/laravel/scripts/assemble-deps.ts
+++ b/integrations/laravel/scripts/assemble-deps.ts
@@ -1,0 +1,47 @@
+/**
+ * Post-build step that stages the PHP BarefootJS runtime SOURCE and shared
+ * styles under the Laravel example directory so the same layout works in
+ * local dev and inside the container image.
+ *
+ *   ./lib/barefootjs-php/src   ← packages/adapter-php/src (engine-agnostic
+ *                    runtime: `Barefoot\BarefootJS`, `Evaluator`,
+ *                    `SearchParams`, `Json` -- plain PHP source, no vendor/
+ *                    or tests/ copied, only what a consuming app needs).
+ *   ./lib/barefootjs-blade/src ← packages/adapter-blade/php/src (the Blade
+ *                    backend: `Barefoot\BladeBackend` + `naming.php`).
+ *   ./dist/styles              ← integrations/shared/styles (design-system
+ *                    stylesheets).
+ *
+ * Composer wiring (see composer.json in this directory): identical to
+ * integrations/blade's -- `psr-4` autoload entries (plus the `naming.php`
+ * `files` entry) point at the two copies this script stages, and
+ * laravel/framework comes straight from Packagist (it brings illuminate/view
+ * with it, so unlike the plain-PHP sibling there is no separate
+ * illuminate/view requirement). `composer install` (the last step of
+ * `bun run build`) produces a single self-contained `vendor/autoload.php`
+ * covering the runtime classes, the Blade backend, AND the framework -- the
+ * simplest wiring that survives being copied wholesale into a Docker image
+ * with no reference back to the monorepo. There is no workspace autoload
+ * fallback here (nothing in the monorepo vendors laravel/framework), which
+ * is why artisan/public/index.php hard-fail with a "run `bun run build`"
+ * hint when vendor/ is missing.
+ */
+
+import { cp, mkdir, rm } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const ROOT = join(HERE, '..')
+
+async function mirror(src: string, dest: string) {
+  await rm(dest, { recursive: true, force: true })
+  await mkdir(dirname(dest), { recursive: true })
+  await cp(src, dest, { recursive: true })
+  console.log(`Copied ${src} → ${dest.replace(ROOT + '/', '')}`)
+}
+
+await mirror(join(ROOT, '../../packages/adapter-php/src'), join(ROOT, 'lib', 'barefootjs-php', 'src'))
+await mirror(join(ROOT, '../../packages/adapter-blade/php/src'), join(ROOT, 'lib', 'barefootjs-blade', 'src'))
+
+await mirror(join(ROOT, '../shared/styles'), join(ROOT, 'dist/styles'))

--- a/integrations/laravel/scripts/gen-blog-data.ts
+++ b/integrations/laravel/scripts/gen-blog-data.ts
@@ -1,0 +1,26 @@
+/**
+ * Emit `dist/blog-data.json` for the Laravel blog routes.
+ *
+ * The shared blog islands (`../shared/blog/*`) are authored in TS and compiled
+ * to Blade templates by `bf build`, but the *data* the index/post routes
+ * render (the post corpus, the derived list items with their pre-rendered
+ * `meta`, the tag set) lives in `../shared/blog/posts.ts` — TS the PHP
+ * server can't import. Rather than hand-transcribe the corpus into PHP
+ * (fragile, and the kind of duplication the showcase explicitly avoids), this
+ * build step imports the single source of truth and writes it as JSON that
+ * App\Support\ExampleApp reads at request time. The TS adapters import
+ * `posts.ts` directly; the Laravel app reads this JSON — both stay in sync
+ * with one authored corpus.
+ */
+import { mkdir, writeFile } from 'node:fs/promises'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { posts, listItems, allTags } from '../../shared/blog/posts'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(HERE, '..')
+const OUT = resolve(ROOT, 'dist/blog-data.json')
+
+await mkdir(dirname(OUT), { recursive: true })
+await writeFile(OUT, JSON.stringify({ posts, listItems, allTags }, null, 0))
+console.log(`Generated: dist/blog-data.json (${posts.length} posts)`)

--- a/integrations/laravel/storage/framework/views/.gitignore
+++ b/integrations/laravel/storage/framework/views/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/integrations/laravel/storage/logs/.gitignore
+++ b/integrations/laravel/storage/logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/integrations/laravel/tsconfig.json
+++ b/integrations/laravel/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ESNext",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["bun-types", "@cloudflare/workers-types"]
+  },
+  "include": ["*.ts", "*.tsx", "e2e/**/*.ts", "scripts/**/*.ts"],
+  "exclude": ["node_modules", "dist", "lib", "vendor"]
+}

--- a/integrations/laravel/wrangler.toml
+++ b/integrations/laravel/wrangler.toml
@@ -1,0 +1,31 @@
+name = "barefootjs-laravel-example"
+main = "container.ts"
+compatibility_date = "2025-01-01"
+compatibility_flags = ["nodejs_compat"]
+
+[[containers]]
+class_name = "LaravelContainer"
+image = "./Dockerfile"
+max_instances = 1
+
+[[durable_objects.bindings]]
+name = "LARAVEL_CONTAINER"
+class_name = "LaravelContainer"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["LaravelContainer"]
+
+# Two patterns: `/integrations/laravel/*` matches /integrations/laravel/...
+# but not the bare /integrations/laravel, so add the no-slash variant
+# explicitly.
+[[routes]]
+pattern = "barefootjs.dev/integrations/laravel"
+zone_name = "barefootjs.dev"
+
+[[routes]]
+pattern = "barefootjs.dev/integrations/laravel/*"
+zone_name = "barefootjs.dev"
+
+[vars]
+BASE_PATH = "/integrations/laravel"

--- a/scripts/dev-all.ts
+++ b/scripts/dev-all.ts
@@ -19,6 +19,7 @@
  *   :4000/integrations/php/*         → php service
  *   :4000/integrations/django/*      → django service
  *   :4000/integrations/blade/*       → blade service
+ *   :4000/integrations/laravel/*     → laravel service
  *   :4000/*                          → site-core service
  *
  * Designed to run inside the dev docker-compose network where service names
@@ -59,6 +60,7 @@ const routes: readonly Route[] = [
   { prefix: '/integrations/php',         target: process.env.PHP_TARGET         ?? 'http://php:3013',         label: 'PHP (Twig)' },
   { prefix: '/integrations/django',      target: process.env.DJANGO_TARGET      ?? 'http://django:3014',      label: 'Django (Python)' },
   { prefix: '/integrations/blade',       target: process.env.BLADE_TARGET       ?? 'http://blade:3015',       label: 'Blade (PHP)' },
+  { prefix: '/integrations/laravel',     target: process.env.LARAVEL_TARGET     ?? 'http://laravel:3016',     label: 'Laravel (PHP)' },
 ] as const
 
 const DEFAULT_TARGET = process.env.SITE_CORE_TARGET ?? 'http://site-core:4001'

--- a/site/core/integrations/routes.tsx
+++ b/site/core/integrations/routes.tsx
@@ -36,6 +36,7 @@ const ADAPTERS: Adapter[] = [
   { slug: 'axum',        name: 'Axum',         language: 'Rust' },
   { slug: 'php',         name: 'Twig',        language: 'PHP' },
   { slug: 'blade',       name: 'Blade',       language: 'PHP' },
+  { slug: 'laravel',     name: 'Laravel',     language: 'PHP' },
 ]
 
 function IntegrationsIndex() {
@@ -64,7 +65,7 @@ export function createIntegrationsApp() {
     c.render(<IntegrationsIndex />, {
       title: 'Integrations — BarefootJS',
       description:
-        'Same JSX components running on Hono, h3 and Elysia (TypeScript), Echo, Gin, Chi and net/http (Go), Flask and FastAPI (Python), Sinatra and Rails (Ruby), Mojolicious and Text::Xslate (Perl), Axum (Rust), and Twig and Blade (PHP).',
+        'Same JSX components running on Hono, h3 and Elysia (TypeScript), Echo, Gin, Chi and net/http (Go), Flask and FastAPI (Python), Sinatra and Rails (Ruby), Mojolicious and Text::Xslate (Perl), Axum (Rust), and Twig, Blade and Laravel (PHP).',
     }),
   )
 


### PR DESCRIPTION
## Summary

Adds `integrations/laravel` to the integrations catalog — the framework-glue sibling of `integrations/blade` on `@barefootjs/blade`, the way `integrations/rails` is to `integrations/sinatra` on `@barefootjs/erb`.

- **Hand-trimmed Laravel 12 app** (routing + controllers only): `bootstrap/app.php` strips the stateful web middleware (`EncryptCookies`, `StartSession`, `ShareErrorsFromSession`, `ValidateCsrfToken`) with the same per-removal rationale `integrations/rails`' `config/application.rb` documents. No Eloquent, no asset pipeline; client assets are the host-built `dist/` served by explicit routes.
- **`BladeBackend` reuses the app's own view factory** via the `factory` option that `packages/adapter-blade/php/src/BladeBackend.php` explicitly documents for "integrations that already run a full Laravel application" (wired in `App\Providers\BarefootServiceProvider`; `config/view.php` points the factory at the compiled `dist/templates`). The plain-PHP sibling assembles a standalone illuminate/view stack instead — that difference *is* the point of the pair.
- **Same route table / same compiled templates** as `integrations/blade` (counter, toggle, form, reactive-props, props-reactivity, conditional-return(-link), portal, AI-chat SSE, todos ± `@client` markers + REST API, and the `@barefootjs/router` blog showcase), so the two PHP integrations diff side-by-side as "framework glue only".
- Serve stack is `php artisan serve` (the same PHP built-in server) on port **3016**, mounted at `/integrations/laravel`; the todo store reuses blade's file-backed `flock()` JSON store since `PHP_CLI_SERVER_WORKERS=8` means separate worker processes.

## Wiring

- `docker-compose.yml` service + `scripts/dev-all.ts` proxy route (`LARAVEL_TARGET`), `integrations/README.md` tables
- Site integrations catalog entry (`site/core/integrations/routes.tsx`) — the landing demo output was already labeled `laravel` (`generate-demo-outputs.ts`); this adds the missing live app behind it
- CI: `ci-blade.yml` gains `integrations/laravel/**` trigger paths and an `e2e-laravel` job; `deploy.yml` gains `deploy-integrations-laravel` (Cloudflare Container, mirroring blade's)
- `.changeset/config.json` ignore entry; `.gitignore` negations for Laravel's `public/` and `storage/logs` (matched by the wrangler `public` artifact pattern and the global `logs` pattern)

## Testing

- `bun run build` in `integrations/laravel` (bf build → blog data → assemble-deps → `composer install`, Laravel 12.62 / PHP 8.4)
- All **104 Playwright e2e specs pass** (the same shared suites the blade example imports: counter, toggle, form, todo ±SSR, reactive props, conditional return, portal, AI-chat SSE, blog + blog-SSR) against the production-mode `artisan serve`
- Manual smoke: bare-root redirect, all pages 200, static assets, todo REST roundtrip (raw `bf_session` cookie, PUT/DELETE/reset), char-by-char SSE stream, plain-text 404 fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZFqqDmkzqVGZGouNPT1CT

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZFqqDmkzqVGZGouNPT1CT)_