### PR TITLE
ci: stop checkout credentials from shadowing the Packagist split push token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,6 +252,13 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
+          # The split push authenticates via PHP_SPLIT_REPO_TOKEN embedded in
+          # the remote URL. checkout's persisted GITHUB_TOKEN is injected as an
+          # http.extraheader Authorization header on every github.com request,
+          # which preempts the 401 challenge that URL credentials answer — so
+          # the push would authenticate as github-actions[bot] (no access to
+          # the split repos) and fail with 403.
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 # v2
@@ -324,6 +331,13 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
+          # The split push authenticates via PHP_SPLIT_REPO_TOKEN embedded in
+          # the remote URL. checkout's persisted GITHUB_TOKEN is injected as an
+          # http.extraheader Authorization header on every github.com request,
+          # which preempts the 401 challenge that URL credentials answer — so
+          # the push would authenticate as github-actions[bot] (no access to
+          # the split repos) and fail with 403.
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 # v2
@@ -398,6 +412,13 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
+          # The split push authenticates via PHP_SPLIT_REPO_TOKEN embedded in
+          # the remote URL. checkout's persisted GITHUB_TOKEN is injected as an
+          # http.extraheader Authorization header on every github.com request,
+          # which preempts the 401 challenge that URL credentials answer — so
+          # the push would authenticate as github-actions[bot] (no access to
+          # the split repos) and fail with 403.
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 # v2


### PR DESCRIPTION
## Problem

The three `packagist-*-release` jobs in the initial 0.18.0 release run ([28862138064](https://github.com/piconic-ai/barefootjs/actions/runs/28862138064)) failed with:

```
remote: Permission to piconic-ai/barefootjs-{php,blade,twig}.git denied to github-actions[bot].
fatal: unable to access '...': The requested URL returned error: 403
```

The failure persisted on re-run even with `PHP_SPLIT_REPO_TOKEN` configured, and the error identifies **github-actions[bot]** — not the PAT's user — as the rejected identity.

## Cause

`actions/checkout` (default `persist-credentials: true`) installs the workflow `GITHUB_TOKEN` as an `http.extraheader` Authorization header applied to every `github.com` request from the repo directory (including worktrees, via `includeIf.gitdir`). Because that header is sent proactively, the server never issues the 401 challenge that would activate the PAT embedded in the split-push remote URL (`https://x-access-token:${PHP_SPLIT_REPO_TOKEN}@github.com/...`). The push therefore authenticates as github-actions[bot], which has no write access to the split mirror repos, and gets 403.

## Fix

Set `persist-credentials: false` on the checkout step of the three Packagist jobs. Checkout itself still authenticates normally during fetch; nothing after checkout touches `origin`, and the split push carries its own credentials in the remote URL.

No other jobs are affected — the remaining release jobs don't push to GitHub with an alternate token (the `release` job intentionally relies on the persisted credentials for `git push`).

## Verification

- `git subtree split` / `git worktree` operations in these jobs are purely local, so removing persisted credentials cannot break them.
- YAML validated; the `with:` block change is identical across the three jobs.
- Real verification requires the next release run (or re-run of the failed jobs after this lands on `main`, since the workflow runs from `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYeRbFoKYKVUkXU1y88mJM

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYeRbFoKYKVUkXU1y88mJM)_