### PR TITLE
release: crate version sync, registry READMEs, OIDC for PyPI/crates.io/RubyGems

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,6 +174,12 @@ jobs:
     if: needs.release.outputs.published == 'true' && contains(fromJSON(needs.release.outputs.publishedPackages).*.name, '@barefootjs/jinja')
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Publishes via PyPI Trusted Publishing (OIDC): the `barefootjs` project on
+    # PyPI trusts this repo + release.yml, so no long-lived PYPI_API_TOKEN is
+    # involved. Managed at pypi.org → barefootjs → Manage → Publishing.
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -182,11 +188,8 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Build, test, and publish Python runtime to PyPI
+      - name: Build and test Python runtime
         working-directory: packages/adapter-jinja/python
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
           test -f pyproject.toml
           version=$(jq -r '.version' ../package.json)
@@ -195,7 +198,11 @@ jobs:
           python -m pytest
           python -m build
           python -m twine check dist/*
-          python -m twine upload --non-interactive dist/*
+
+      - name: Publish Python runtime to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          packages-dir: packages/adapter-jinja/python/dist
 
   rubygems-release:
     needs: release
@@ -235,14 +242,30 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Sync crate version from @barefootjs/rust
+        working-directory: packages/adapter-rust/runtime
+        # Cargo.toml carries a placeholder version (crates.io shipped 0.1.0 on
+        # the initial release because nothing stamped it). The crate must ship
+        # at the @barefootjs/rust version resolved by changesets, so write it
+        # in before publishing. Not committed back: unlike the Perl sync (which
+        # pushes to main from the cpan-release job), a second job pushing to
+        # main would race it; `--allow-dirty` below tolerates the working-tree
+        # edit instead.
+        run: |
+          version=$(jq -r '.version' ../package.json)
+          test -n "$version"
+          test "$version" != "null"
+          sed -i "0,/^version = \".*\"/s//version = \"${version}\"/" Cargo.toml
+          grep -Fxq "version = \"${version}\"" Cargo.toml
+
       - name: Build, test, and publish Rust runtime to crates.io
         working-directory: packages/adapter-rust/runtime
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           cargo test
-          cargo publish --dry-run
-          cargo publish
+          cargo publish --dry-run --allow-dirty
+          cargo publish --allow-dirty
   packagist-twig-release:
     needs: release
     if: needs.release.outputs.published == 'true' && contains(fromJSON(needs.release.outputs.publishedPackages).*.name, '@barefootjs/twig')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,6 +234,12 @@ jobs:
     if: needs.release.outputs.published == 'true' && contains(fromJSON(needs.release.outputs.publishedPackages).*.name, '@barefootjs/rust')
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Publishes via crates.io Trusted Publishing (OIDC): the `barefootjs` crate
+    # trusts this repo + release.yml, so no long-lived CARGO_REGISTRY_TOKEN is
+    # involved. Managed at crates.io → barefootjs → Settings → Trusted Publishing.
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -258,10 +264,14 @@ jobs:
           sed -i "0,/^version = \".*\"/s//version = \"${version}\"/" Cargo.toml
           grep -Fxq "version = \"${version}\"" Cargo.toml
 
+      - name: Authenticate with crates.io
+        id: crates-auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1
+
       - name: Build, test, and publish Rust runtime to crates.io
         working-directory: packages/adapter-rust/runtime
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-auth.outputs.token }}
         run: |
           cargo test
           cargo publish --dry-run --allow-dirty

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,6 +209,12 @@ jobs:
     if: needs.release.outputs.published == 'true' && contains(fromJSON(needs.release.outputs.publishedPackages).*.name, '@barefootjs/erb')
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Publishes via RubyGems Trusted Publishing (OIDC): the barefoot_js gem
+    # trusts this repo + release.yml, so no long-lived RUBYGEMS_API_KEY is
+    # involved. Managed at rubygems.org → barefoot_js → Trusted publishers.
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -218,10 +224,13 @@ jobs:
           ruby-version: '3.3'
           bundler-cache: false
 
+      - name: Authenticate with RubyGems
+        # No inputs → trusted-publisher mode; exports a temporary
+        # GEM_HOST_API_KEY for the `gem push` below.
+        uses: rubygems/configure-rubygems-credentials@dc5a8d8553e6ee01fc26761a49e99e733d17954a # v2.1.0
+
       - name: Build, test, and publish Ruby runtime to RubyGems
         working-directory: packages/adapter-erb
-        env:
-          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
         run: |
           gemspec=$(find . -maxdepth 1 -name '*.gemspec' -print -quit)
           test -n "$gemspec"

--- a/packages/adapter-erb/README.md
+++ b/packages/adapter-erb/README.md
@@ -1,0 +1,32 @@
+# barefoot_js
+
+Ruby runtime for [BarefootJS](https://barefootjs.dev/) marked templates, targeting ERB.
+
+[BarefootJS](https://github.com/piconic-ai/barefootjs) is a fine-grained reactive TSX compiler: you write components in TSX, and the compiler emits templates for your backend's template engine plus the client-side JS that hydrates them. This gem is the server half for Ruby — it renders the `.erb` templates produced by the `@barefootjs/erb` adapter.
+
+## Installation
+
+```sh
+gem install barefoot_js
+```
+
+## Usage
+
+Every compiled `.erb` template receives a `BarefootJS::Context` as the `bf` local. The context is engine-agnostic; everything that depends on how a template is rendered is delegated to a pluggable backend (`BarefootJS::Backend::Erb` is the ERB reference implementation):
+
+```ruby
+require 'barefoot_js'
+
+bf = BarefootJS::Context.new(backend)
+```
+
+Values are JSON-shaped Ruby data with symbol hash keys throughout (props, env hashes, array-of-hash records).
+
+## Documentation
+
+- [barefootjs.dev](https://barefootjs.dev/) — core documentation
+- [GitHub: piconic-ai/barefootjs](https://github.com/piconic-ai/barefootjs) — monorepo (this gem lives at `packages/adapter-erb`)
+
+## License
+
+MIT

--- a/packages/adapter-erb/barefoot_js.gemspec
+++ b/packages/adapter-erb/barefoot_js.gemspec
@@ -17,8 +17,9 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 3.1'
 
-  s.files = Dir['lib/**/*.rb']
+  s.files = Dir['lib/**/*.rb'] + %w[README.md]
 
+  s.metadata['documentation_uri'] = 'https://barefootjs.dev'
   s.metadata['source_code_uri'] = 'https://github.com/piconic-ai/barefootjs/tree/main/packages/adapter-erb'
   s.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/packages/adapter-jinja/python/README.md
+++ b/packages/adapter-jinja/python/README.md
@@ -1,0 +1,43 @@
+# barefootjs
+
+Python runtime for [BarefootJS](https://barefootjs.dev/) marked templates, targeting [Jinja2](https://jinja.palletsprojects.com/).
+
+[BarefootJS](https://github.com/piconic-ai/barefootjs) is a fine-grained reactive TSX compiler: you write components in TSX, and the compiler emits templates for your backend's template engine plus the client-side JS that hydrates them. This package is the server half for Python — it renders the `.jinja` templates produced by the `@barefootjs/jinja` adapter.
+
+## Installation
+
+```sh
+pip install barefootjs
+```
+
+The only dependency is `jinja2`; everything else is stdlib.
+
+## Quick start
+
+Generated `.jinja` templates call the `BarefootJS` instance as a `bf` object (`{{ bf.scope_attr() }}`, `{{ bf.json(x) }}`, `{{ bf.spread_attrs(bag) }}`):
+
+```python
+from barefootjs import BarefootJS, JinjaBackend
+
+backend = JinjaBackend(paths=["templates"])
+bf = BarefootJS(None, {"backend": backend})
+html = backend.render_named("counter", bf, {"count": 0})
+```
+
+## Package layout
+
+| Module | Role |
+|--------|------|
+| `runtime.py` | the engine-agnostic `bf` object |
+| `evaluator.py` | ParsedExpr evaluator for the `*_eval` helpers |
+| `search_params.py` | `searchParams()` SSR reader |
+| `backend_jinja.py` | the Jinja2 engine backend |
+
+## Documentation
+
+- [barefootjs.dev](https://barefootjs.dev/) — core documentation
+- [GitHub: piconic-ai/barefootjs](https://github.com/piconic-ai/barefootjs) — monorepo (this package lives at `packages/adapter-jinja/python`)
+
+## License
+
+MIT

--- a/packages/adapter-jinja/python/pyproject.toml
+++ b/packages/adapter-jinja/python/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "barefootjs"
 dynamic = ["version"]
 description = "Python runtime for the @barefootjs/jinja adapter"
+readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.10"
 authors = [{ name = "kobaken", email = "kentafly88@gmail.com" }]

--- a/packages/adapter-rust/runtime/Cargo.toml
+++ b/packages/adapter-rust/runtime/Cargo.toml
@@ -1,9 +1,14 @@
 [package]
 name = "barefootjs"
+# Placeholder — the crates-release job stamps the @barefootjs/rust version
+# resolved by changesets over this value before `cargo publish`.
 version = "0.1.0"
 edition = "2021"
 description = "Rust runtime for BarefootJS marked templates (minijinja adapter)."
 license = "MIT"
+readme = "README.md"
+homepage = "https://barefootjs.dev"
+repository = "https://github.com/piconic-ai/barefootjs"
 
 [lib]
 name = "barefootjs"

--- a/packages/adapter-rust/runtime/README.md
+++ b/packages/adapter-rust/runtime/README.md
@@ -1,0 +1,34 @@
+# barefootjs
+
+Rust runtime for [BarefootJS](https://barefootjs.dev/) marked templates, targeting [minijinja](https://crates.io/crates/minijinja).
+
+[BarefootJS](https://github.com/piconic-ai/barefootjs) is a fine-grained reactive TSX compiler: you write components in TSX, and the compiler emits templates for your backend's template engine plus the client-side JS that hydrates them. This crate is the server half for Rust — it renders the templates produced by the `@barefootjs/rust` adapter.
+
+## Installation
+
+```sh
+cargo add barefootjs
+```
+
+## Usage
+
+Build a minijinja environment over the compiled template directory with `backend_minijinja::build_environment`, create a root `BfInstance` for the render (`BfInstance::root`), then render a named component template with `backend_minijinja::render_named`. `load_manifest` / `register_components_from_manifest` wire up the component manifest emitted by the compiler, and a `bf-render` binary is included for rendering from the command line.
+
+Key modules:
+
+| Module | Role |
+|--------|------|
+| `runtime` | the engine-agnostic `bf` object (`BfInstance`, `RenderSession`) |
+| `backend_minijinja` | the minijinja engine backend |
+| `evaluator` | ParsedExpr evaluator for the `*_eval` helpers |
+| `manifest` | component manifest loading and registration |
+| `search_params` | `searchParams()` SSR reader |
+
+## Documentation
+
+- [barefootjs.dev](https://barefootjs.dev/) — core documentation
+- [GitHub: piconic-ai/barefootjs](https://github.com/piconic-ai/barefootjs) — monorepo (this crate lives at `packages/adapter-rust/runtime`)
+
+## License
+
+MIT


### PR DESCRIPTION
Follow-ups from the initial 0.18.0 release (run [28862138064](https://github.com/piconic-ai/barefootjs/actions/runs/28862138064)):

## 1. Sync the crates.io version from `@barefootjs/rust`

crates.io shipped **0.1.0** while every other registry shipped 0.18.0, because `Cargo.toml` pins a placeholder version and nothing stamps the changesets-resolved version over it (Perl has `scripts/sync-perl-versions.ts`; Rust had no equivalent). Worse, the next release would have *failed* — `cargo publish` rejects re-publishing an existing version.

The new `Sync crate version` step in `crates-release` writes the `@barefootjs/rust` version from `packages/adapter-rust/package.json` into `Cargo.toml` before publishing, then asserts the write landed. The edit stays in the job (with `cargo publish --allow-dirty`) rather than being committed back to `main`, because a second parallel job pushing to `main` would race the Perl sync push in `cpan-release`. The sed was dry-run against the current `Cargo.toml` (first-match-only; dependency `version =` keys are not at line start).

## 2. READMEs for PyPI, crates.io, and RubyGems

All three registry pages rendered empty (twine warned `long_description missing`, cargo warned `manifest has no documentation, homepage or repository`). Added per-registry READMEs and wired them up:

- `packages/adapter-jinja/python/README.md` + `readme = "README.md"` in `pyproject.toml`
- `packages/adapter-rust/runtime/README.md` + `readme`/`homepage`/`repository` in `Cargo.toml`
- `packages/adapter-erb/README.md` + gemspec `files` and `documentation_uri`

`gem build` verified locally — the README is included in the built gem's file list.

## 3. Trusted Publishing (OIDC) for PyPI, crates.io, and RubyGems

All three registries now trust `piconic-ai/barefootjs` + `release.yml` (configured registry-side by @kfly8), so the long-lived registry secrets are dropped and each job gets an explicit least-privilege `permissions` block (`id-token: write`, `contents: read`):

- **PyPI**: publish via `pypa/gh-action-pypi-publish` (SHA-pinned v1.14.0) instead of twine + `PYPI_API_TOKEN`. Build/test/`twine check` stay in a separate step.
- **crates.io**: `rust-lang/crates-io-auth-action` (SHA-pinned v1) exchanges the OIDC token for a temporary registry token consumed by `cargo publish`, replacing `CARGO_REGISTRY_TOKEN`.
- **RubyGems**: `rubygems/configure-rubygems-credentials` (SHA-pinned v2.1.0, trusted-publisher mode) exports a temporary `GEM_HOST_API_KEY` for `gem push`, replacing `RUBYGEMS_API_KEY`.

Once merged, the `PYPI_API_TOKEN`, `CARGO_REGISTRY_TOKEN`, and `RUBYGEMS_API_KEY` secrets can all be deleted.

> **Note:** the PyPI/crates.io/RubyGems publishers are assumed to be configured *without* a GitHub environment name; if one was set registry-side, the corresponding job needs an `environment:` key.

## Verification

- `release.yml` YAML-parsed; both TOML files parsed
- The version-sync sed dry-run produced `version = "0.18.0"` and the `grep -Fxq` guard passed
- `gem build barefoot_js.gemspec` succeeds and packages the README
- The publish paths themselves can only be exercised by the next real release run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYeRbFoKYKVUkXU1y88mJM