### PR TITLE
fix(erb): symbolize manifest propName in derive_vars_from_defaults (#2157)

### DIFF
--- a/.changeset/erb-runtime-symbol-propname.md
+++ b/.changeset/erb-runtime-symbol-propname.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/erb": patch
+---
+
+Fix `BarefootJS::Context.derive_vars_from_defaults` in the published Ruby runtime looking up caller props with a String `propName` (as JSON manifests parse it) against symbol-keyed runtime prop hashes (`JSON.parse(..., symbolize_names: true)`; compiled templates pass `{ children: ... }` literals) -- `props.key?("children")` was always false, so `register_components_from_manifest` silently fell back to the static `ssrDefaults` value for every manifest-registered child component, e.g. a Counter's three `<Button>` slots rendering with empty `children`. `propName` is now symbolized before the lookup (#2157).

--- a/packages/adapter-erb/lib/barefoot_js.rb
+++ b/packages/adapter-erb/lib/barefoot_js.rb
@@ -324,12 +324,14 @@ module BarefootJS
           extra[name] = props.key?(name) ? props[name] : d[:value]
           next
         end
-        # `propName` rides in from the JSON manifest as a String, but every
-        # runtime prop hash is symbol-keyed (`JSON.parse(..., symbolize_names:
-        # true)`; compiled templates pass `{ children: ... }` literals) --
-        # `props.key?(prop_name)` with a String would always miss, silently
-        # falling back to the static default for every manifest-registered
-        # child (e.g. `children` rendering empty) (#2157).
+        # `propName` rides in from the JSON manifest as a String -- JSON has
+        # no symbol type, and the manifest's `symbolize_names: true` parse
+        # only symbolizes hash KEYS, never string values. Runtime prop
+        # hashes, meanwhile, are symbol-keyed because compiled ERB templates
+        # pass `{ children: ... }` literals, so `props.key?(prop_name)` with
+        # the String would always miss, silently falling back to the static
+        # default for every manifest-registered child (e.g. `children`
+        # rendering empty) (#2157).
         prop_name = d[:propName]&.to_sym
         extra[name] =
           if !prop_name.nil? && props.key?(prop_name) && !props[prop_name].nil?

--- a/packages/adapter-erb/lib/barefoot_js.rb
+++ b/packages/adapter-erb/lib/barefoot_js.rb
@@ -324,7 +324,13 @@ module BarefootJS
           extra[name] = props.key?(name) ? props[name] : d[:value]
           next
         end
-        prop_name = d[:propName]
+        # `propName` rides in from the JSON manifest as a String, but every
+        # runtime prop hash is symbol-keyed (`JSON.parse(..., symbolize_names:
+        # true)`; compiled templates pass `{ children: ... }` literals) --
+        # `props.key?(prop_name)` with a String would always miss, silently
+        # falling back to the static default for every manifest-registered
+        # child (e.g. `children` rendering empty) (#2157).
+        prop_name = d[:propName]&.to_sym
         extra[name] =
           if !prop_name.nil? && props.key?(prop_name) && !props[prop_name].nil?
             props[prop_name]

--- a/packages/adapter-erb/test/derive_vars_from_defaults_test.rb
+++ b/packages/adapter-erb/test/derive_vars_from_defaults_test.rb
@@ -2,7 +2,6 @@
 
 require 'minitest/autorun'
 require 'tmpdir'
-require 'fileutils'
 require 'barefoot_js'
 require 'barefoot_js/backend/erb'
 

--- a/packages/adapter-erb/test/derive_vars_from_defaults_test.rb
+++ b/packages/adapter-erb/test/derive_vars_from_defaults_test.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'tmpdir'
+require 'fileutils'
+require 'barefoot_js'
+require 'barefoot_js/backend/erb'
+
+# Regression coverage for #2157: `derive_vars_from_defaults` looked up caller
+# props with `props.key?(prop_name)` where `prop_name = d[:propName]` is a
+# String straight out of the JSON manifest (`JSON.parse(json,
+# symbolize_names: true)` symbolizes HASH KEYS only, never string VALUES),
+# while every runtime prop hash is symbol-keyed (compiled templates pass
+# `{ children: ... }` literals; `register_components_from_manifest` builds
+# its `props` the same way). `props.key?("children")` against a
+# `{ children: ... }`-shaped hash is therefore always false, so every
+# manifest-registered child component silently fell back to its static
+# default -- e.g. a `<Button>` slot's `children` rendering empty.
+class DeriveVarsFromDefaultsTest < Minitest::Test
+  # ---------------------------------------------------------------------
+  # Unit: derive_vars_from_defaults directly
+  # ---------------------------------------------------------------------
+
+  # The issue's minimal proof: a defaults entry shaped exactly like a
+  # manifest-parsed `ssrDefaults` value (String `propName`, symbol keys on
+  # the entry hash itself) must still resolve against a symbol-keyed props
+  # hash. This is RED without the `&.to_sym` fix.
+  def test_string_prop_name_resolves_against_symbol_keyed_props
+    defaults = { children: { propName: 'children', value: nil } }
+    props = { children: '+1' }
+
+    extra = BarefootJS::Context.send(:derive_vars_from_defaults, defaults, props)
+
+    assert_equal '+1', extra[:children]
+  end
+
+  def test_caller_prop_present_but_nil_falls_back_to_default_value
+    defaults = { label: { propName: 'label', value: 'Static' } }
+    props = { label: nil }
+
+    extra = BarefootJS::Context.send(:derive_vars_from_defaults, defaults, props)
+
+    assert_equal 'Static', extra[:label]
+  end
+
+  def test_prop_name_present_but_props_missing_key_falls_back_to_default_value
+    defaults = { label: { propName: 'label', value: 'Static' } }
+    props = {}
+
+    extra = BarefootJS::Context.send(:derive_vars_from_defaults, defaults, props)
+
+    assert_equal 'Static', extra[:label]
+  end
+
+  def test_entry_without_prop_name_always_uses_static_value
+    # signal / memo locals have no caller-supplied prop to read at all --
+    # the manifest entry omits `propName` and the static value always wins,
+    # even when `props` happens to hold a same-named key.
+    defaults = { count: { value: 0 } }
+    props = { count: 999 }
+
+    extra = BarefootJS::Context.send(:derive_vars_from_defaults, defaults, props)
+
+    assert_equal 0, extra[:count]
+  end
+
+  def test_non_hash_entry_is_used_as_a_raw_static_value
+    defaults = { flag: true }
+    props = { flag: false }
+
+    extra = BarefootJS::Context.send(:derive_vars_from_defaults, defaults, props)
+
+    assert_equal true, extra[:flag]
+  end
+
+  def test_rest_props_entry_passes_through_the_callers_bag
+    defaults = { rest: { isRestProps: true, value: {} } }
+    props = { rest: { data_foo: 'bar' } }
+
+    extra = BarefootJS::Context.send(:derive_vars_from_defaults, defaults, props)
+
+    assert_equal({ data_foo: 'bar' }, extra[:rest])
+  end
+
+  def test_rest_props_entry_falls_back_to_static_value_when_absent
+    defaults = { rest: { isRestProps: true, value: {} } }
+    props = {}
+
+    extra = BarefootJS::Context.send(:derive_vars_from_defaults, defaults, props)
+
+    assert_equal({}, extra[:rest])
+  end
+
+  # ---------------------------------------------------------------------
+  # End-to-end: register_components_from_manifest + real ERB rendering
+  # ---------------------------------------------------------------------
+  #
+  # Reproduces the reported symptom directly: a manifest-registered child
+  # component (`ui/button/index`) whose `ssrDefaults` maps `children` back
+  # to the caller's `children` prop must render the CALLER's children, not
+  # the static `nil` default.
+  def test_manifest_registered_child_renders_caller_children_through_real_erb
+    Dir.mktmpdir do |dir|
+      # register_components_from_manifest strips the `templates/` prefix
+      # and `.erb` suffix off `markedTemplate` before asking the backend to
+      # load it, so the on-disk file sits directly under `dir` as
+      # `button.erb` (see barefoot_js.rb:258).
+      File.write(File.join(dir, 'button.erb'), '<%= v[:children] %>')
+
+      backend = BarefootJS::Backend::Erb.new(path: dir)
+      bf = BarefootJS::Context.new(backend)
+      bf._scope_id('root')
+
+      # Hand-built exactly as `JSON.parse(manifest_json, symbolize_names:
+      # true)` would produce: entry-hash keys are symbols, but
+      # `ssrDefaults`'s `propName` VALUE stays a String -- JSON has no
+      # symbol type, and `symbolize_names` only affects hash keys.
+      manifest = {
+        :"ui/button/index" => {
+          markedTemplate: 'templates/button.erb',
+          ssrDefaults: {
+            children: { propName: 'children', value: nil },
+          },
+        },
+      }
+
+      bf.register_components_from_manifest(manifest)
+
+      html = bf.render_child('button', { _bf_slot: 's4', children: '+1' })
+
+      assert_includes html, '+1'
+    end
+  end
+end


### PR DESCRIPTION
Fixes #2157.

## Problem

On the documented Ruby setup path — `bf.register_components_from_manifest(MANIFEST)` + `BACKEND.render_named(...)` — every manifest-registered child component rendered its `children` (and any other `propName`-mapped prop) as the static default. A Counter's three `<Button>` slots rendered **empty**.

Root cause: `BarefootJS::Context.derive_vars_from_defaults` looked up caller props with `props.key?(prop_name)` where `prop_name = d[:propName]` is a **String** straight out of the JSON manifest (`symbolize_names: true` only symbolizes hash keys, never string values), while every runtime prop hash is **symbol-keyed** (compiled ERB templates pass `{ children: ... }` literals). The lookup never matched, so the caller's real value was always discarded in favor of the static default (`nil`).

## Fix

`prop_name = d[:propName]&.to_sym` — one line in `packages/adapter-erb/lib/barefoot_js.rb`, with a comment pinning the String-vs-symbol constraint.

## Regression coverage

New `packages/adapter-erb/test/derive_vars_from_defaults_test.rb` (minitest, stdlib-only, runs in ci-erb):

- **Unit**: the issue's minimal proof — a manifest-shaped defaults entry (String `propName`) against symbol-keyed props resolves the caller's value. Red without the fix.
- **Unit**: nil caller prop → static default; missing key → static default; `propName`-less signal/memo locals → static value; `isRestProps` passthrough (both present and absent).
- **End-to-end**: `register_components_from_manifest` + real `Backend::Erb` over a temp template dir, `render_child('button', { _bf_slot: 's4', children: '+1' })` → output contains `+1`. This is the exact production registry path the monorepo integrations bypass (they hand-register child renderers), which is why the bug was only visible in the published gem. Also red without the fix.

Verified locally: new test fails 2/8 with the fix reverted, 8/8 green with it; full ERB minitest suite and `bun test packages/adapter-erb` (389 pass) green.

## Notes

- Python (`derive_stash_from_defaults`, string-keyed dicts), Perl, and Rust (`BTreeMap`) runtimes don't share this failure mode — their prop maps are string-keyed.
- A follow-up PR stacks the #2158 render-stage conformance suite on top of this fix, including aligning the ERB test harness with this production path so the whole in-tree corpus catches this bug class.
- Changeset included (`@barefootjs/erb` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuFiQiCJGSp2inWdjrXPz2

---
_Generated by [Claude Code](https://claude.ai/code/session_01RuFiQiCJGSp2inWdjrXPz2)_