### PR TITLE
Add blade adapter to the compat matrix (site/core landing page)

### DIFF
--- a/.github/workflows/ci-compat.yml
+++ b/.github/workflows/ci-compat.yml
@@ -58,10 +58,11 @@ jobs:
           bun run --filter '@barefootjs/jsx' build
           bun run --filter '@barefootjs/client' build
           # packages/compat (the compat engine + `bun run compat:lock`)
-          # imports every workspace adapter. These 7 have `main`/`exports`
+          # imports every workspace adapter. These 8 have `main`/`exports`
           # pointing at `./dist/index.js` (unlike @barefootjs/hono and
           # @barefootjs/jsx, which resolve via `./src/index.ts`), so they
           # MUST be built before anything imports them (see #2099).
+          bun run --filter '@barefootjs/blade' build
           bun run --filter '@barefootjs/erb' build
           bun run --filter '@barefootjs/go-template' build
           bun run --filter '@barefootjs/jinja' build

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@barefootjs/adapter-tests": "workspace:*",
+    "@barefootjs/blade": "workspace:*",
     "@barefootjs/erb": "workspace:*",
     "@barefootjs/go-template": "workspace:*",
     "@barefootjs/hono": "workspace:*",

--- a/packages/compat/src/adapter-registry.ts
+++ b/packages/compat/src/adapter-registry.ts
@@ -8,11 +8,11 @@
 // that list instead of adapter-tests.
 //
 // This package is repo-internal (`private: true`, never published) and
-// declares all 8 adapters as `devDependencies` — see
+// declares all 9 adapters as `devDependencies` — see
 // packages/compat/package.json. Adapters are still dynamic-imported
 // rather than statically imported, so a package that fails to resolve
 // (e.g. unbuilt dist) degrades to a reported skip instead of a hard
-// crash, keeping the loader total. The monorepo always has all 8
+// crash, keeping the loader total. The monorepo always has all 9
 // installed, so a run from this repo loads every adapter.
 
 import type { ConformancePins, TemplateAdapter } from '@barefootjs/jsx'
@@ -24,6 +24,7 @@ interface CompatAdapterSpec {
 
 // Sorted by package name.
 const COMPAT_ADAPTERS: CompatAdapterSpec[] = [
+  { pkg: '@barefootjs/blade', className: 'BladeAdapter' },
   { pkg: '@barefootjs/erb', className: 'ErbAdapter' },
   { pkg: '@barefootjs/go-template', className: 'GoTemplateAdapter' },
   { pkg: '@barefootjs/hono', className: 'HonoAdapter' },

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -3,6 +3,7 @@
   "knownLimitationLabel": "https://github.com/piconic-ai/barefootjs/labels/known-limitation",
   "adapters": [
     "hono",
+    "blade",
     "erb",
     "go-template",
     "jinja",
@@ -14,6 +15,9 @@
   "components": {
     "accordion": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -42,6 +46,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -66,6 +73,9 @@
     },
     "alert-dialog": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -94,6 +104,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -118,6 +131,9 @@
     },
     "avatar": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -146,6 +162,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -170,6 +189,9 @@
     },
     "breadcrumb": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -198,6 +220,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -222,6 +247,9 @@
     },
     "button-group": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -250,6 +278,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -274,6 +305,9 @@
     },
     "card": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -302,6 +336,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -326,6 +363,9 @@
     },
     "chart": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -354,6 +394,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -378,6 +421,9 @@
     },
     "collapsible": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -406,6 +452,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -430,6 +479,9 @@
     },
     "command": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -458,6 +510,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -482,6 +537,9 @@
     },
     "data-table": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -510,6 +568,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -534,6 +595,9 @@
     },
     "dialog": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -562,6 +626,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -586,6 +653,9 @@
     },
     "drawer": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -614,6 +684,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -638,6 +711,9 @@
     },
     "empty": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -666,6 +742,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -690,6 +769,9 @@
     },
     "hover-card": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -718,6 +800,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -742,6 +827,9 @@
     },
     "input": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -770,6 +858,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -794,6 +885,9 @@
     },
     "input-otp": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -822,6 +916,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -846,6 +943,9 @@
     },
     "kbd": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -874,6 +974,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -898,6 +1001,9 @@
     },
     "menubar": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -926,6 +1032,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -950,6 +1059,9 @@
     },
     "navigation-menu": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -978,6 +1090,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -1002,6 +1117,9 @@
     },
     "popover": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -1030,6 +1148,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -1054,6 +1175,9 @@
     },
     "progress": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -1082,6 +1206,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -1106,6 +1233,9 @@
     },
     "resizable": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -1134,6 +1264,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -1158,6 +1291,9 @@
     },
     "select": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -1186,6 +1322,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -1210,6 +1349,9 @@
     },
     "sheet": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -1238,6 +1380,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -1262,6 +1407,9 @@
     },
     "skeleton": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -1290,6 +1438,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -1314,6 +1465,9 @@
     },
     "slot": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -1342,6 +1496,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -1366,6 +1523,9 @@
     },
     "switch": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -1394,6 +1554,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -1418,6 +1581,9 @@
     },
     "tabs": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -1446,6 +1612,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -1470,6 +1639,9 @@
     },
     "toast": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -1498,6 +1670,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -1522,6 +1697,9 @@
     },
     "toggle-group": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {
@@ -1550,6 +1728,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -1576,6 +1757,9 @@
       "hono": {
         "ok": true
       },
+      "blade": {
+        "ok": true
+      },
       "erb": {
         "ok": true
       },
@@ -1600,6 +1784,9 @@
     },
     "xyflow": {
       "hono": {
+        "ok": true
+      },
+      "blade": {
         "ok": true
       },
       "erb": {


### PR DESCRIPTION
## What

The site/core landing page's proof matrix — **"N components × M adapters, verified in CI"** — renders straight from `ui/compat.lock.json`. `@barefootjs/blade` existed as an adapter package but was never registered in the compat engine, so blade was missing from the matrix (it read "62 components × 8 adapters").

This registers blade so the matrix now reports **62 components × 9 adapters** (558/558 cells compiling clean).

## Changes

- **`packages/compat/src/adapter-registry.ts`** — add `@barefootjs/blade` → `BladeAdapter` to `COMPAT_ADAPTERS` (sorted by package name); bump the "all 8 adapters" comments to 9.
- **`packages/compat/package.json`** — declare the `@barefootjs/blade` workspace devDependency.
- **`.github/workflows/ci-compat.yml`** — build `@barefootjs/blade`'s dist before the compat run (like the other dist-resolved adapters), and bump the "These 7" comment to 8.
- **`ui/compat.lock.json`** — regenerated via `bun run compat:lock`; adds the `blade` column and a `blade` cell for all 62 components.

The `MatrixSection` heading in `site/core/landing/components/sections.tsx` is derived from `compat.adapters.length`, so it updates to "9 adapters" automatically with no source change. The hero input/output demo already offered blade (`laravel`).

## Verification

- `bun run compat:lock` → `62 component(s) × 9 adapter(s) = 558 cell(s) (558 ok, 0 with diagnostics)`
- `bun test packages/compat` → 79 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RcVYF5S3zP1HzGGHPKzYPw)_