### PR TITLE
ci: make Packagist re-crawl best-effort when PACKAGIST_API_TOKEN is unset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -358,6 +358,17 @@ jobs:
           PACKAGIST_USERNAME: ${{ vars.PACKAGIST_USERNAME || 'barefootjs' }}
           PACKAGIST_API_TOKEN: ${{ secrets.PACKAGIST_API_TOKEN }}
         run: |
+          # The split push above is the substantive publish step — the mirror
+          # repo now carries the new commit + tag, and Packagist picks that up
+          # via its GitHub webhook or periodic crawl. This call only asks for an
+          # *immediate* re-crawl and needs an account API token. Treat it as
+          # best-effort: if the secret isn't configured, warn and skip rather
+          # than failing an otherwise-successful release. A present-but-rejected
+          # token still fails the step (curl -sSf), so real auth errors surface.
+          if [ -z "${PACKAGIST_API_TOKEN}" ]; then
+            echo "::warning::PACKAGIST_API_TOKEN is unset; skipping the immediate Packagist re-crawl for barefootjs/twig. The mirror push succeeded, so Packagist will update on its next crawl. Set the secret (and register the package once at packagist.org) to trigger updates immediately."
+            exit 0
+          fi
           curl -sSf -XPOST \
             -H 'Content-Type: application/json' \
             -H "API-Token: ${PACKAGIST_API_TOKEN}" \
@@ -434,6 +445,11 @@ jobs:
           PACKAGIST_USERNAME: ${{ vars.PACKAGIST_USERNAME || 'barefootjs' }}
           PACKAGIST_API_TOKEN: ${{ secrets.PACKAGIST_API_TOKEN }}
         run: |
+          # Best-effort immediate re-crawl; see the Twig job for the rationale.
+          if [ -z "${PACKAGIST_API_TOKEN}" ]; then
+            echo "::warning::PACKAGIST_API_TOKEN is unset; skipping the immediate Packagist re-crawl for barefootjs/blade. The mirror push succeeded, so Packagist will update on its next crawl. Set the secret (and register the package once at packagist.org) to trigger updates immediately."
+            exit 0
+          fi
           curl -sSf -XPOST \
             -H 'Content-Type: application/json' \
             -H "API-Token: ${PACKAGIST_API_TOKEN}" \
@@ -501,6 +517,11 @@ jobs:
           PACKAGIST_USERNAME: ${{ vars.PACKAGIST_USERNAME || 'barefootjs' }}
           PACKAGIST_API_TOKEN: ${{ secrets.PACKAGIST_API_TOKEN }}
         run: |
+          # Best-effort immediate re-crawl; see the Twig job for the rationale.
+          if [ -z "${PACKAGIST_API_TOKEN}" ]; then
+            echo "::warning::PACKAGIST_API_TOKEN is unset; skipping the immediate Packagist re-crawl for barefootjs/php. The mirror push succeeded, so Packagist will update on its next crawl. Set the secret (and register the package once at packagist.org) to trigger updates immediately."
+            exit 0
+          fi
           curl -sSf -XPOST \
             -H 'Content-Type: application/json' \
             -H "API-Token: ${PACKAGIST_API_TOKEN}" \


### PR DESCRIPTION
## What the latest release run showed (0.18.1, [run 28877625519](https://github.com/piconic-ai/barefootjs/actions/runs/28877625519))

Good news first: the OIDC migrations all worked — **PyPI, crates.io, RubyGems, JSR, CPAN, npm all published successfully**, and the crate version sync shipped 0.18.1 (no more 0.1.0). The `persist-credentials: false` fix also worked: the split push now authenticates as the PAT owner (`kfly8`) instead of `github-actions[bot]`.

The three Packagist jobs still fail, but for **two distinct reasons** — and only one is fixable in the workflow:

### A. Twig — push succeeded, `Notify Packagist` 403 *(this PR)*
The Twig split push landed the new commit + tag on `barefootjs-twig`. The follow-up `Notify Packagist` step then 403'd because `PACKAGIST_API_TOKEN` is unset — curl sent an empty `API-Token` header. That failed the whole job even though the substantive publish (the mirror push) had already succeeded.

### B. Blade & PHP — split push 403 *(needs a token-scope change, not code)*
```
remote: Permission to piconic-ai/barefootjs-blade.git denied to kfly8.
remote: Permission to piconic-ai/barefootjs-php.git denied to kfly8.
```
Same `PHP_SPLIT_REPO_TOKEN`, same code path as Twig — but Twig pushes fine and these two don't. That means the token can write to `barefootjs-twig` but **not** to `barefootjs-blade` / `barefootjs-php`. This is a repository-scope gap on the fine-grained PAT, not a workflow bug, so it can't be fixed here.

## What this PR changes

Guards each of the three `Notify Packagist` steps: if `PACKAGIST_API_TOKEN` is empty, emit a `::warning::` and `exit 0` instead of curling with an empty token. The mirror push already carries the new commit + tag, so Packagist updates on its next crawl / GitHub webhook regardless. A **present-but-rejected** token still fails the step (`curl -sSf`), so genuine auth errors are never swallowed.

Effect on the next release: the Twig job goes green (push succeeds, notify skips with a warning). Blade/PHP still fail at the push step until item B below is done — which is correct, because that step's actual work genuinely failed.

## Follow-up actions required outside this PR (settings, not code)

1. **Grant `PHP_SPLIT_REPO_TOKEN` write access to all three mirror repos.** The fine-grained PAT currently reaches only `barefootjs-twig`; add `barefootjs-blade` and `barefootjs-php` with **Contents: Read and write** (or regenerate it selecting all three). This unblocks reason B.
2. **Set the `PACKAGIST_API_TOKEN` secret** (currently empty) if you want immediate re-crawls. Optional — without it, releases now stay green and Packagist updates on its own schedule.
3. **Register the packages on Packagist once**: submit `barefootjs/twig`, `barefootjs/blade`, `barefootjs/php` at https://packagist.org/packages/submit (first release only; afterwards the webhook/crawl keeps them current).

## Verification
- `release.yml` YAML-parsed.
- The guard is a plain `[ -z "$VAR" ]` check under `bash -e`; the existing `curl -sSf` path is unchanged when the token is present.
- The real publish paths can only be exercised by the next release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYeRbFoKYKVUkXU1y88mJM

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYeRbFoKYKVUkXU1y88mJM)_