### PR TITLE
Add 48 edge-case adapter conformance fixtures; surface and pin per-adapter divergences

### DIFF
--- a/.changeset/edge-case-conformance-pins.md
+++ b/.changeset/edge-case-conformance-pins.md
@@ -1,0 +1,12 @@
+---
+"@barefootjs/go-template": patch
+"@barefootjs/erb": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+"@barefootjs/twig": patch
+"@barefootjs/jinja": patch
+"@barefootjs/blade": patch
+"@barefootjs/rust": patch
+---
+
+Declare two build-time refusal contracts in every template adapter's conformance-pins set, surfaced by the Priority-12 edge-case conformance sweep: `dangerouslySetInnerHTML` (raw-HTML output needs a deliberate per-template-language affordance; the compiler already refuses the shape with BF101) and `String.prototype.replaceAll` (only first-occurrence `.replace` is wired to the runtime helpers; already refused with BF101 rather than silently reusing the first-only lowering). Test-contract metadata only — no adapter runtime or codegen behavior changes; the pins make the pre-existing refusals part of each adapter's asserted conformance surface (and visible to `bf compat`).

--- a/packages/adapter-blade/src/__tests__/blade-adapter.test.ts
+++ b/packages/adapter-blade/src/__tests__/blade-adapter.test.ts
@@ -20,6 +20,55 @@ runAdapterConformanceTests({
   name: 'blade',
   factory: () => new BladeAdapter(),
   render: renderBladeComponent,
+  // Priority-12 edge-case sweep (炙り出し): fixtures below RENDER on real
+  // PHP Blade but diverge from the Hono reference byte comparison (or
+  // fatal at render time). Each entry names its divergence; graduating
+  // one means fixing the adapter (or shared compiler layer) and
+  // deleting the line.
+  skipJsx: [
+    // `(count() + 2) * 3` renders 10 instead of 18 — the parenthesised
+    // sub-expression loses its grouping in the lowering (silent wrong
+    // arithmetic; same finding as jinja).
+    'arithmetic-text',
+    // `'Hello, ' + name + '!'` is emitted as PHP `+`, which fatals with
+    // "Unsupported operand types: string + string" — JS string-concat
+    // `+` needs PHP's `.` operator.
+    'string-concat-plus',
+    // `{false}` renders "false" (Hono drops it); `{null}`/`{undefined}`
+    // render empty (Hono renders "null"). Neither matches JSX semantics.
+    'falsy-text-values',
+    // `&copy;` in JSX literal text: Hono decodes to `©`, Blade re-emits
+    // the raw entity — same DOM, different bytes.
+    'html-entity-text',
+    // Math.min/max/abs over a signal render EMPTY (only Math.floor is
+    // in the template-primitive registry).
+    'math-methods',
+    // camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`,
+    // Blade emits bare presence.
+    'boolean-attr-literals',
+    // `htmlFor` is not lowered to `for` (Hono maps it).
+    'camelcase-attributes',
+    // Static attribute values are NOT HTML-escaped (`title="Fish &
+    // Chips"` raw vs Hono's `Fish &amp; Chips`).
+    'static-attr-escape',
+    // SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`)
+    // pass through unmapped; Hono lowers to kebab-case.
+    'svg-icon',
+    // `Object.entries(prop).map(([k, v]) => …)` renders an EMPTY <ul> —
+    // the object-shaped prop silently produces zero iterations.
+    'object-entries-map',
+    // Nested-loop inner items carry `data-key` where the reference
+    // emits the depth-suffixed `data-key-1`.
+    'nested-loop-outer-binding',
+    // JSX element as a NON-children prop renders an empty slot (the
+    // element value is silently dropped).
+    'jsx-element-prop',
+    // `.slice()` on a STRING renders empty (array-slice helper misfires
+    // on strings).
+    'string-slice',
+    // `.trimStart()` / `.trimEnd()` render empty (no lowering).
+    'string-trim-sided',
+  ],
   // Per-fixture build-time contracts for shapes the Blade adapter
   // intentionally refuses to lower. Lives in `../conformance-pins` —
   // mirrors Twig's set (the lowering gates are shared code paths in

--- a/packages/adapter-blade/src/conformance-pins.ts
+++ b/packages/adapter-blade/src/conformance-pins.ts
@@ -83,4 +83,15 @@ export const conformancePins: ConformancePins = {
   // "Expression not supported" BF101 rather than emitting a broken
   // template.
   'array-map-function-reference': [{ code: 'BF101', severity: 'error' }],
+  // Edge-case sweep (Priority 12): `dangerouslySetInnerHTML` requires a
+  // deliberate raw-HTML (unescaped) output affordance in the target
+  // template language. No lowering exists yet, so the compiler refuses
+  // the shape loudly instead of emitting entity-escaped markup that
+  // silently renders tags as text.
+  'dangerous-inner-html': [{ code: 'BF101', severity: 'error' }],
+  // Edge-case sweep (Priority 12): `.replaceAll` has no lowering yet —
+  // only first-occurrence `.replace` is wired to the runtime helpers.
+  // Refused with BF101 rather than reusing the first-only lowering,
+  // which would silently change semantics.
+  'string-replaceall': [{ code: 'BF101', severity: 'error' }],
 }

--- a/packages/adapter-erb/src/__tests__/erb-adapter.test.ts
+++ b/packages/adapter-erb/src/__tests__/erb-adapter.test.ts
@@ -31,6 +31,51 @@ runAdapterConformanceTests({
   name: 'erb',
   factory: () => new ErbAdapter(),
   render: renderErbComponent,
+  // Priority-12 edge-case sweep (炙り出し): fixtures below RENDER on real
+  // Ruby erb but diverge from the Hono reference byte comparison. Each
+  // entry names its divergence; graduating one means fixing the adapter
+  // (or the shared compiler layer) and deleting the line.
+  skipJsx: [
+    // `{false}` renders the string "false" (Hono drops it); `{null}` /
+    // `{undefined}` render empty (Hono renders "null"). Neither side
+    // matches JSX semantics (0 renders; false/null/undefined drop).
+    'falsy-text-values',
+    // `&copy;` in JSX literal text: Hono decodes to `©` at parse time,
+    // ERB re-emits the raw entity — same DOM, different bytes.
+    'html-entity-text',
+    // `user?.name ?? '...'` on an object prop: the Ruby render exits 1
+    // (optional chaining into a Hash prop has no lowering).
+    'optional-chaining-prop',
+    // Math.min/max/abs over a signal render empty (only Math.floor is
+    // in the template-primitive registry).
+    'math-methods',
+    // camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`,
+    // ERB emits bare `readonly`-style presence.
+    'boolean-attr-literals',
+    // `htmlFor` is not lowered to `for` (Hono maps it).
+    'camelcase-attributes',
+    // Static attribute values are NOT HTML-escaped: `title="Fish &
+    // Chips"` is emitted raw where Hono escapes to `Fish &amp; Chips`.
+    'static-attr-escape',
+    // SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`)
+    // pass through unmapped; Hono lowers to kebab-case.
+    'svg-icon',
+    // `Object.entries(prop).map(([k, v]) => …)` renders but its loop
+    // item keys diverge from the reference serialisation.
+    'object-entries-map',
+    // Nested-loop inner items carry `data-key` where the Hono
+    // reference emits the depth-suffixed `data-key-1`.
+    'nested-loop-outer-binding',
+    // A JSX element passed as a NON-children prop (`header={<strong/>}`)
+    // renders an EMPTY slot — the element value is silently dropped.
+    'jsx-element-prop',
+    // `.slice()` on a STRING lowers through the array slice helper and
+    // renders "[]" instead of the substring.
+    'string-slice',
+    // `.trimStart()` / `.trimEnd()` render empty (no lowering; only
+    // both-sides `.trim` is wired).
+    'string-trim-sided',
+  ],
   // No JSX-render skips: every shared conformance fixture — including
   // the composed `site/ui` demo corpus (#1467 / #1897) — renders to
   // Hono parity on real Ruby `erb`. `data-table` came off via the

--- a/packages/adapter-erb/src/conformance-pins.ts
+++ b/packages/adapter-erb/src/conformance-pins.ts
@@ -97,4 +97,15 @@ export const conformancePins: ConformancePins = {
   // with BF101 rather than emitting a broken template. Same pin as
   // mojo/xslate.
   'array-map-function-reference': [{ code: 'BF101', severity: 'error' }],
+  // Edge-case sweep (Priority 12): `dangerouslySetInnerHTML` requires a
+  // deliberate raw-HTML (unescaped) output affordance in the target
+  // template language. No lowering exists yet, so the compiler refuses
+  // the shape loudly instead of emitting entity-escaped markup that
+  // silently renders tags as text.
+  'dangerous-inner-html': [{ code: 'BF101', severity: 'error' }],
+  // Edge-case sweep (Priority 12): `.replaceAll` has no lowering yet —
+  // only first-occurrence `.replace` is wired to the runtime helpers.
+  // Refused with BF101 rather than reusing the first-only lowering,
+  // which would silently change semantics.
+  'string-replaceall': [{ code: 'BF101', severity: 'error' }],
 }

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -22,6 +22,75 @@ runAdapterConformanceTests({
   name: 'go-template',
   factory: () => new GoTemplateAdapter(),
   render: renderGoTemplateComponent,
+  // Priority-12 edge-case sweep (炙り出し): fixtures below compile but
+  // diverge from the Hono reference on real Go — or generate Go that
+  // fails `go run` outright (marked "exit 1" below; those should
+  // eventually become loud BF101 refusals instead of broken codegen).
+  // Each entry names its divergence; graduating one means fixing the
+  // adapter (or shared compiler layer) and deleting the line.
+  skipJsx: [
+    // `{false}` renders "false" (Hono drops it); `{null}`/`{undefined}`
+    // render empty (Hono renders "null"). Neither matches JSX semantics.
+    'falsy-text-values',
+    // `&copy;` in JSX literal text: Hono decodes to `©`, Go re-emits
+    // the raw entity — same DOM, different bytes.
+    'html-entity-text',
+    // `'Hello, ' + name + '!'` renders "0" — string concat lowered
+    // through numeric addition.
+    'string-concat-plus',
+    // `user?.name ?? '…'` on an object prop: generated Go fails to
+    // compile/run (exit 1) — optional chaining into a struct/map prop
+    // has no lowering.
+    'optional-chaining-prop',
+    // `.toFixed(2)`: generated Go fails to run (exit 1) on a number
+    // PROP (the memo-side `bf_to_fixed` path doesn't cover this shape).
+    'number-tofixed',
+    // Math.min/max/abs over a signal: generated Go fails to run
+    // (exit 1) — only Math.floor is registered.
+    'math-methods',
+    // camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`,
+    // Go emits bare presence.
+    'boolean-attr-literals',
+    // `htmlFor` is not lowered to `for` (Hono maps it).
+    'camelcase-attributes',
+    // Static attribute values are NOT HTML-escaped (`title="Fish &
+    // Chips"` raw vs Hono's `Fish &amp; Chips`).
+    'static-attr-escape',
+    // SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`)
+    // pass through unmapped; Hono lowers to kebab-case.
+    'svg-icon',
+    // `Object.entries(prop).map(([k, v]) => …)`: generated Go fails to
+    // run (exit 1) — no object-iteration loop lowering.
+    'object-entries-map',
+    // Nested-loop inner items carry `data-key` where the reference
+    // emits the depth-suffixed `data-key-1`.
+    'nested-loop-outer-binding',
+    // JSX element as a NON-children prop renders an empty slot (the
+    // element value is silently dropped).
+    'jsx-element-prop',
+    // Three-level composition: the grandchild's threaded prop renders
+    // EMPTY (`<span>…</span>` with no text) — prop forwarding through
+    // two template-render layers loses the value.
+    'grandchild-composition',
+    // Numeric/boolean LITERAL props on a child (`count={5}`
+    // `active={true}`) render as Go zero values (0 / false) — literal
+    // primitive props aren't bound into the child's Input struct.
+    'child-primitive-props',
+    // A memo derived from another memo renders EMPTY for the second
+    // layer — the constructor folds `doubled` from `count` but not
+    // `label` from `doubled`.
+    'memo-chain',
+    // Object-valued signal (`user().name`): generated Go fails to run
+    // (exit 1) — no struct synthesis for object signal initial values
+    // outside loops.
+    'signal-object-field',
+    // `.slice()` on a STRING routes through the array `bf_slice` helper
+    // and renders "[]" instead of the substring.
+    'string-slice',
+    // `.trimStart()` / `.trimEnd()`: generated Go fails to run (exit 1)
+    // — only both-sides `bf_trim` exists.
+    'string-trim-sided',
+  ],
   // `branch-self-closing` no longer needs a skip — the conditional-
   // marker divergence (Hono `bf-c="sN"` attribute vs Go
   // `<!--bf-cond-start:sN-->` / `<!--bf-cond-end:sN-->` comment pairs)

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -132,4 +132,15 @@ export const conformancePins: ConformancePins = {
   // UNSUPPORTED_METHODS gate refuses it with BF101 rather than emitting
   // a broken template.
   'array-map-function-reference': [{ code: 'BF101', severity: 'error' }],
+  // Edge-case sweep (Priority 12): `dangerouslySetInnerHTML` requires a
+  // deliberate raw-HTML (unescaped) output affordance in the target
+  // template language. No lowering exists yet, so the compiler refuses
+  // the shape loudly instead of emitting entity-escaped markup that
+  // silently renders tags as text.
+  'dangerous-inner-html': [{ code: 'BF101', severity: 'error' }],
+  // Edge-case sweep (Priority 12): `.replaceAll` has no lowering yet —
+  // only first-occurrence `.replace` is wired to the runtime helpers.
+  // Refused with BF101 rather than reusing the first-only lowering,
+  // which would silently change semantics.
+  'string-replaceall': [{ code: 'BF101', severity: 'error' }],
 }

--- a/packages/adapter-jinja/src/__tests__/jinja-adapter.test.ts
+++ b/packages/adapter-jinja/src/__tests__/jinja-adapter.test.ts
@@ -21,6 +21,51 @@ runAdapterConformanceTests({
   name: 'jinja',
   factory: () => new JinjaAdapter(),
   render: renderJinjaComponent,
+  // Priority-12 edge-case sweep (炙り出し): fixtures below RENDER on real
+  // Python jinja2 but diverge from the Hono reference byte comparison.
+  // Each entry names its divergence; graduating one means fixing the
+  // adapter (or shared compiler layer) and deleting the line.
+  skipJsx: [
+    // `(count() + 2) * 3` renders 10 instead of 18 — the parenthesised
+    // sub-expression loses its grouping in the lowering, so the output
+    // silently computes `count() + 2 * 3`. Highest-priority finding of
+    // the sweep for this adapter (silent wrong arithmetic).
+    'arithmetic-text',
+    // `{false}` renders "false" (Hono drops it); `{null}`/`{undefined}`
+    // render empty (Hono renders "null"). Neither matches JSX semantics.
+    'falsy-text-values',
+    // `&copy;` in JSX literal text: Hono decodes to `©`, Jinja re-emits
+    // the raw entity — same DOM, different bytes.
+    'html-entity-text',
+    // Math.min/max/abs over a signal render EMPTY (only Math.floor is
+    // in the template-primitive registry).
+    'math-methods',
+    // camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`,
+    // Jinja emits bare presence.
+    'boolean-attr-literals',
+    // `htmlFor` is not lowered to `for` (Hono maps it).
+    'camelcase-attributes',
+    // Static attribute values are NOT HTML-escaped (`title="Fish &
+    // Chips"` raw vs Hono's `Fish &amp; Chips`).
+    'static-attr-escape',
+    // SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`)
+    // pass through unmapped; Hono lowers to kebab-case.
+    'svg-icon',
+    // `Object.entries(prop).map(([k, v]) => …)` renders an EMPTY <ul> —
+    // the object-shaped prop silently produces zero iterations.
+    'object-entries-map',
+    // Nested-loop inner items carry `data-key` where the reference
+    // emits the depth-suffixed `data-key-1`.
+    'nested-loop-outer-binding',
+    // JSX element as a NON-children prop renders an empty slot (the
+    // element value is silently dropped).
+    'jsx-element-prop',
+    // `.slice()` on a STRING renders empty (array-slice helper misfires
+    // on strings).
+    'string-slice',
+    // `.trimStart()` / `.trimEnd()` render empty (no lowering).
+    'string-trim-sided',
+  ],
   // Per-fixture build-time contracts for shapes the Jinja adapter
   // intentionally refuses to lower. Lives in `../conformance-pins` —
   // mirrors xslate's set (the lowering gates are shared code paths in

--- a/packages/adapter-jinja/src/conformance-pins.ts
+++ b/packages/adapter-jinja/src/conformance-pins.ts
@@ -98,4 +98,15 @@ export const conformancePins: ConformancePins = {
   // "Expression not supported" BF101 rather than emitting a broken
   // template.
   'array-map-function-reference': [{ code: 'BF101', severity: 'error' }],
+  // Edge-case sweep (Priority 12): `dangerouslySetInnerHTML` requires a
+  // deliberate raw-HTML (unescaped) output affordance in the target
+  // template language. No lowering exists yet, so the compiler refuses
+  // the shape loudly instead of emitting entity-escaped markup that
+  // silently renders tags as text.
+  'dangerous-inner-html': [{ code: 'BF101', severity: 'error' }],
+  // Edge-case sweep (Priority 12): `.replaceAll` has no lowering yet —
+  // only first-occurrence `.replace` is wired to the runtime helpers.
+  // Refused with BF101 rather than reusing the first-only lowering,
+  // which would silently change semantics.
+  'string-replaceall': [{ code: 'BF101', severity: 'error' }],
 }

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -15,7 +15,59 @@ runAdapterConformanceTests({
   name: 'mojo',
   factory: () => new MojoAdapter(),
   render: renderMojoComponent,
-  // No JSX-render skips: every shared conformance fixture — including
+  // Priority-12 edge-case sweep (炙り出し): fixtures below RENDER on real
+  // Mojolicious but diverge from the Hono reference byte comparison.
+  // Each entry names its divergence; graduating one means fixing the
+  // adapter (or shared compiler layer) and deleting the line.
+  skipJsx: [
+    // `(count() + 2) * 3` renders 10 instead of 18 — the parenthesised
+    // sub-expression loses its grouping in the lowering (silent wrong
+    // arithmetic; same finding as jinja/blade).
+    'arithmetic-text',
+    // `'Hello, ' + name + '!'` renders "0" — Perl's numeric `+` coerces
+    // the strings to numbers; JS string-concat `+` needs Perl's `.`.
+    'string-concat-plus',
+    // `.length` on a STRING prop diverges (array-length lowering
+    // misapplied to a scalar).
+    'string-length-text',
+    // The literal `¥` in template text reaches the output as U+FFFD —
+    // a UTF-8 encoding gap in the EP template pipeline for non-ASCII
+    // literal text adjacent to a dynamic slot.
+    'number-tofixed',
+    // `{false}` renders "false" (Hono drops it); `{null}`/`{undefined}`
+    // render empty (Hono renders "null"). Neither matches JSX semantics.
+    'falsy-text-values',
+    // `&copy;` in JSX literal text: Hono decodes to `©`, EP re-emits
+    // the raw entity — same DOM, different bytes.
+    'html-entity-text',
+    // Math.min/max/abs over a signal render EMPTY (only Math.floor is
+    // in the template-primitive registry).
+    'math-methods',
+    // camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`,
+    // EP emits bare presence.
+    'boolean-attr-literals',
+    // `htmlFor` is not lowered to `for` (Hono maps it).
+    'camelcase-attributes',
+    // Static attribute values are NOT HTML-escaped (`title="Fish &
+    // Chips"` raw vs Hono's `Fish &amp; Chips`).
+    'static-attr-escape',
+    // SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`)
+    // pass through unmapped; Hono lowers to kebab-case.
+    'svg-icon',
+    // `Object.entries(prop).map(([k, v]) => …)` renders an EMPTY <ul>.
+    'object-entries-map',
+    // Nested-loop inner items carry `data-key` where the reference
+    // emits the depth-suffixed `data-key-1`.
+    'nested-loop-outer-binding',
+    // JSX element as a NON-children prop renders an empty slot (the
+    // element value is silently dropped).
+    'jsx-element-prop',
+    // `.slice()` on a STRING misfires through the array slice helper.
+    'string-slice',
+    // `.trimStart()` / `.trimEnd()` render empty (no lowering).
+    'string-trim-sided',
+  ],
+  // (Pre-sweep note) Otherwise no JSX-render skips: every shared conformance fixture — including
   // the composed `site/ui` demo corpus (#1467 / #1897) — renders to
   // Hono parity on real Mojolicious. `data-table` came off via the
   // body-children `inLoop` reset (#1896): the loop-item component

--- a/packages/adapter-mojolicious/src/conformance-pins.ts
+++ b/packages/adapter-mojolicious/src/conformance-pins.ts
@@ -135,4 +135,15 @@ export const conformancePins: ConformancePins = {
   // UNSUPPORTED_METHODS gate refuses it with BF101 rather than emitting
   // a broken template.
   'array-map-function-reference': [{ code: 'BF101', severity: 'error' }],
+  // Edge-case sweep (Priority 12): `dangerouslySetInnerHTML` requires a
+  // deliberate raw-HTML (unescaped) output affordance in the target
+  // template language. No lowering exists yet, so the compiler refuses
+  // the shape loudly instead of emitting entity-escaped markup that
+  // silently renders tags as text.
+  'dangerous-inner-html': [{ code: 'BF101', severity: 'error' }],
+  // Edge-case sweep (Priority 12): `.replaceAll` has no lowering yet —
+  // only first-occurrence `.replace` is wired to the runtime helpers.
+  // Refused with BF101 rather than reusing the first-only lowering,
+  // which would silently change semantics.
+  'string-replaceall': [{ code: 'BF101', severity: 'error' }],
 }

--- a/packages/adapter-rust/src/__tests__/minijinja-adapter.test.ts
+++ b/packages/adapter-rust/src/__tests__/minijinja-adapter.test.ts
@@ -25,6 +25,50 @@ runAdapterConformanceTests({
   name: 'minijinja',
   factory: () => new MinijinjaAdapter(),
   render: renderMinijinjaComponent,
+  // Priority-12 edge-case sweep (炙り出し): fixtures below RENDER through
+  // the real `bf-render` minijinja binary but diverge from the Hono
+  // reference byte comparison. Each entry names its divergence;
+  // graduating one means fixing the adapter (or shared compiler layer)
+  // and deleting the line. (`string-concat-plus` is NOT skipped here —
+  // minijinja's `+` concatenates strings, unlike Perl/PHP/Twig.)
+  skipJsx: [
+    // `(count() + 2) * 3` renders 10 instead of 18 — the parenthesised
+    // sub-expression loses its grouping in the lowering (silent wrong
+    // arithmetic; same finding as mojo/jinja/blade/twig).
+    'arithmetic-text',
+    // `{false}` renders "false" (Hono drops it); `{null}`/`{undefined}`
+    // render empty (Hono renders "null"). Neither matches JSX semantics.
+    'falsy-text-values',
+    // `&copy;` in JSX literal text: Hono decodes to `©`, minijinja
+    // re-emits the raw entity — same DOM, different bytes.
+    'html-entity-text',
+    // Math.min/max/abs over a signal render EMPTY (only Math.floor is
+    // in the template-primitive registry).
+    'math-methods',
+    // camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`,
+    // minijinja emits bare presence.
+    'boolean-attr-literals',
+    // `htmlFor` is not lowered to `for` (Hono maps it).
+    'camelcase-attributes',
+    // Static attribute values are NOT HTML-escaped (`title="Fish &
+    // Chips"` raw vs Hono's `Fish &amp; Chips`).
+    'static-attr-escape',
+    // SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`)
+    // pass through unmapped; Hono lowers to kebab-case.
+    'svg-icon',
+    // `Object.entries(prop).map(([k, v]) => …)` renders an EMPTY <ul>.
+    'object-entries-map',
+    // Nested-loop inner items carry `data-key` where the reference
+    // emits the depth-suffixed `data-key-1`.
+    'nested-loop-outer-binding',
+    // JSX element as a NON-children prop renders an empty slot (the
+    // element value is silently dropped).
+    'jsx-element-prop',
+    // `.slice()` on a STRING misfires through the array slice helper.
+    'string-slice',
+    // `.trimStart()` / `.trimEnd()` render empty (no lowering).
+    'string-trim-sided',
+  ],
   // Per-fixture build-time contracts for shapes the adapter intentionally
   // refuses to lower. Lives in `../conformance-pins` — mirrors
   // adapter-jinja's set (itself mirroring xslate's); the lowering gates

--- a/packages/adapter-rust/src/conformance-pins.ts
+++ b/packages/adapter-rust/src/conformance-pins.ts
@@ -98,4 +98,15 @@ export const conformancePins: ConformancePins = {
   // "Expression not supported" BF101 rather than emitting a broken
   // template.
   'array-map-function-reference': [{ code: 'BF101', severity: 'error' }],
+  // Edge-case sweep (Priority 12): `dangerouslySetInnerHTML` requires a
+  // deliberate raw-HTML (unescaped) output affordance in the target
+  // template language. No lowering exists yet, so the compiler refuses
+  // the shape loudly instead of emitting entity-escaped markup that
+  // silently renders tags as text.
+  'dangerous-inner-html': [{ code: 'BF101', severity: 'error' }],
+  // Edge-case sweep (Priority 12): `.replaceAll` has no lowering yet —
+  // only first-occurrence `.replace` is wired to the runtime helpers.
+  // Refused with BF101 rather than reusing the first-only lowering,
+  // which would silently change semantics.
+  'string-replaceall': [{ code: 'BF101', severity: 'error' }],
 }

--- a/packages/adapter-tests/fixtures/adjacent-conditionals.ts
+++ b/packages/adapter-tests/fixtures/adjacent-conditionals.ts
@@ -1,0 +1,29 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Two independent `&&` conditionals as ADJACENT siblings, one truthy
+ * and one falsy at SSR. Pins that each conditional gets its own
+ * marker pair and that the falsy first branch doesn't swallow or
+ * shift its truthy sibling.
+ */
+export const fixture = createFixture({
+  id: 'adjacent-conditionals',
+  description: 'Two sibling && conditionals with independent signals',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function AdjacentConditionals() {
+  const [showA, setShowA] = createSignal(false)
+  const [showB, setShowB] = createSignal(true)
+  return (
+    <div>
+      {showA() && <span>A</span>}
+      {showB() && <span>B</span>}
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test" bf="s2"><!--bf-cond-start:s0--><!--bf-cond-end:s0--><span bf-c="s1">B</span></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/adjacent-dynamic-text.ts
+++ b/packages/adapter-tests/fixtures/adjacent-dynamic-text.ts
@@ -1,0 +1,33 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Back-to-back dynamic text expressions with NO separator
+ * (`{h()}{m()}`) plus a mixed literal/dynamic run. Adjacent dynamic
+ * text nodes need distinct slot markers — a lowering that merges
+ * adjacent expressions into one slot can't update them independently
+ * after hydration.
+ */
+export const fixture = createFixture({
+  id: 'adjacent-dynamic-text',
+  description: 'Adjacent dynamic text expressions with no separator',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function AdjacentDynamicText() {
+  const [h, setH] = createSignal(12)
+  const [m, setM] = createSignal(30)
+  return (
+    <div>
+      <span>{h()}{m()}</span>
+      <span>{h()}:{m()} on the clock</span>
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test">
+      <span bf="s2"><!--bf:s0-->12<!--/--><!--bf:s1-->30<!--/--></span>
+      <span bf="s5"><!--bf:s3-->12<!--/-->:<!--bf:s4-->30<!--/--> on the clock</span>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/arithmetic-text.ts
+++ b/packages/adapter-tests/fixtures/arithmetic-text.ts
@@ -1,0 +1,32 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Arithmetic on a signal getter inside a text expression. The SSR side
+ * must fold `count() * 2 + 1` against the initial value with JS
+ * operator precedence, not just print the getter's raw value.
+ */
+export const fixture = createFixture({
+  id: 'arithmetic-text',
+  description: 'Arithmetic expression over a signal in text content',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function ArithmeticText() {
+  const [count, setCount] = createSignal(4)
+  return (
+    <div>
+      <span>{count() * 2 + 1}</span>
+      <span>{count() - 1}</span>
+      <span>{(count() + 2) * 3}</span>
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test">
+      <span bf="s1"><!--bf:s0-->9<!--/--></span>
+      <span bf="s3"><!--bf:s2-->3<!--/--></span>
+      <span bf="s5"><!--bf:s4-->18<!--/--></span>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/attr-ternary-title.ts
+++ b/packages/adapter-tests/fixtures/attr-ternary-title.ts
@@ -1,0 +1,27 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A ternary in a NON-class attribute position (`title`). The class
+ * ternary is pinned by `conditional-class`; this generalizes the
+ * same lowering to an arbitrary attribute plus a second binding whose
+ * branches are numeric.
+ */
+export const fixture = createFixture({
+  id: 'attr-ternary-title',
+  description: 'Ternary expressions in title and data attribute positions',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function AttrTernaryTitle() {
+  const [active, setActive] = createSignal(false)
+  return (
+    <button title={active() ? 'turn off' : 'turn on'} data-step={active() ? 2 : 1}>
+      toggle
+    </button>
+  )
+}
+`,
+  expectedHtml: `
+    <button bf-s="test" bf="s0" data-step="1" title="turn on"> toggle </button>
+  `,
+})

--- a/packages/adapter-tests/fixtures/boolean-attr-literals.ts
+++ b/packages/adapter-tests/fixtures/boolean-attr-literals.ts
@@ -1,0 +1,33 @@
+import { createFixture } from '../src/types'
+
+/**
+ * The three static spellings of an HTML boolean attribute: bare
+ * (`disabled`), explicit true (`disabled={true}`), and explicit false
+ * (`disabled={false}`). The first two must render the attribute
+ * present; the third must OMIT it entirely — `disabled="false"` is
+ * still disabled in HTML semantics.
+ */
+export const fixture = createFixture({
+  id: 'boolean-attr-literals',
+  description: 'Static boolean attributes: bare, ={true}, and ={false} omission',
+  source: `
+export function BooleanAttrLiterals() {
+  return (
+    <div>
+      <button disabled>bare</button>
+      <button disabled={true}>true</button>
+      <button disabled={false}>false</button>
+      <input type="checkbox" checked readOnly />
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test">
+      <button disabled>bare</button>
+      <button disabled>true</button>
+      <button>false</button>
+      <input checked readOnly="true" type="checkbox">
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/camelcase-attributes.ts
+++ b/packages/adapter-tests/fixtures/camelcase-attributes.ts
@@ -1,0 +1,29 @@
+import { createFixture } from '../src/types'
+
+/**
+ * JSX camelCase attribute names that must lower to their HTML spellings:
+ * `htmlFor` → `for`, `tabIndex` → `tabindex`, `maxLength` → `maxlength`,
+ * `autoComplete` → `autocomplete`, `spellCheck` → `spellcheck`. A
+ * pass-through adapter emits invalid attribute names the browser
+ * ignores (silently breaking label association and form behavior).
+ */
+export const fixture = createFixture({
+  id: 'camelcase-attributes',
+  description: 'camelCase JSX attributes lower to HTML spellings (htmlFor, tabIndex, ...)',
+  source: `
+export function CamelcaseAttributes() {
+  return (
+    <div>
+      <label htmlFor="name-field">Name</label>
+      <input id="name-field" tabIndex={2} maxLength={10} autoComplete="off" spellCheck={false} />
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test">
+      <label for="name-field">Name</label>
+      <input autoComplete="off" id="name-field" maxLength="10" spellCheck="false" tabIndex="2">
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/child-primitive-props.ts
+++ b/packages/adapter-tests/fixtures/child-primitive-props.ts
@@ -1,0 +1,41 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Number and boolean literals passed as child-component props
+ * (`count={5}` / `active={true}`). String props dominate the corpus;
+ * this pins that primitives keep their type through each adapter's
+ * props serialisation (Go struct fields, Ruby/Perl hashes, bf-p JSON)
+ * — `count="5"` vs `count={5}` diverge in Go's typed structs.
+ */
+export const fixture = createFixture({
+  id: 'child-primitive-props',
+  description: 'Numeric and boolean literal props on a child component',
+  source: `
+import { Badge } from './Badge'
+export function ChildPrimitiveProps() {
+  return (
+    <div>
+      <Badge label="mail" count={5} active={true} />
+      <Badge label="spam" count={0} active={false} />
+    </div>
+  )
+}
+`,
+  components: {
+    './Badge': `
+export function Badge(props: { label: string; count: number; active: boolean }) {
+  return (
+    <span data-active={props.active}>
+      {props.label}: {props.count}
+    </span>
+  )
+}
+`,
+  },
+  expectedHtml: `
+    <div bf-s="test">
+      <span bf-s="test_s0" bf="s2" data-active="true"><!--bf:s0-->mail<!--/-->: <!--bf:s1-->5<!--/--></span>
+      <span bf-s="test_s1" bf="s2" data-active="false"><!--bf:s0-->spam<!--/-->: <!--bf:s1-->0<!--/--></span>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/comparison-ternary-text.ts
+++ b/packages/adapter-tests/fixtures/comparison-ternary-text.ts
@@ -1,0 +1,34 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Comparison operators as ternary conditions in text position:
+ * `>=`, `===` against a string, and `!==`. Template languages spell
+ * these differently (Go `ge/eq/ne`, Twig/Jinja infix), so each
+ * operator exercises a distinct lowering table row.
+ */
+export const fixture = createFixture({
+  id: 'comparison-ternary-text',
+  description: 'Comparison operators (>=, ===, !==) as ternary conditions',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function ComparisonTernaryText() {
+  const [n, setN] = createSignal(7)
+  const [mode, setMode] = createSignal('dark')
+  return (
+    <div>
+      <span>{n() >= 10 ? 'big' : 'small'}</span>
+      <span>{mode() === 'dark' ? 'night' : 'day'}</span>
+      <span>{n() !== 0 ? 'nonzero' : 'zero'}</span>
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test">
+      <span bf="s1"><!--bf-cond-start:s0-->small<!--bf-cond-end:s0--></span>
+      <span bf="s3"><!--bf-cond-start:s2-->night<!--bf-cond-end:s2--></span>
+      <span bf="s5"><!--bf-cond-start:s4-->nonzero<!--bf-cond-end:s4--></span>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/conditional-return-null.ts
+++ b/packages/adapter-tests/fixtures/conditional-return-null.ts
@@ -1,0 +1,30 @@
+import { createFixture } from '../src/types'
+
+/**
+ * An early `return null` guard branch. The conditional-return family
+ * (`conditional-return-button` / `-link`) pins element-vs-element
+ * branches; this pins element-vs-NOTHING — the null branch must render
+ * empty output, not the string "null" or a crash. The fixture renders
+ * the non-null branch (hidden unset) so the visible path stays
+ * comparable, while the null branch keeps every adapter honest at
+ * compile time.
+ */
+export const fixture = createFixture({
+  id: 'conditional-return-null',
+  description: 'Early `return null` guard with the element branch rendered',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function ConditionalReturnNull(props: { hidden?: boolean }) {
+  const [count, setCount] = createSignal(1)
+  if (props.hidden) {
+    return null
+  }
+  return <div>visible:{count()}</div>
+}
+`,
+  props: {},
+  expectedHtml: `
+    <div bf-s="test" bf="s1">visible:<!--bf:s0-->1<!--/--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/conditional-wrapping-loop.ts
+++ b/packages/adapter-tests/fixtures/conditional-wrapping-loop.ts
@@ -1,0 +1,38 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A `&&` conditional whose consequent CONTAINS a keyed loop, and each
+ * loop item contains its own ternary — conditional → loop → conditional
+ * nesting in one tree. The inverse nesting (loop item containing a
+ * conditional, no outer guard) is pinned by `loop-item-conditional`.
+ */
+export const fixture = createFixture({
+  id: 'conditional-wrapping-loop',
+  description: 'Conditional wrapping a keyed loop whose items hold ternaries',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Task = { name: string; done: boolean }
+export function ConditionalWrappingLoop() {
+  const [show, setShow] = createSignal(true)
+  const [tasks, setTasks] = createSignal<Task[]>([
+    { name: 'write', done: true },
+    { name: 'review', done: false },
+  ])
+  return (
+    <div>
+      {show() && (
+        <ul>
+          {tasks().map(task => (
+            <li key={task.name}>{task.done ? '[x]' : '[ ]'} {task.name}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test" bf="s4"><ul bf-c="s0" bf="s3"><li data-key="write"><!--bf-cond-start:s1-->[x]<!--bf-cond-end:s1--><!--bf:s2-->write<!--/--></li><li data-key="review"><!--bf-cond-start:s1-->[ ]<!--bf-cond-end:s1--><!--bf:s2-->review<!--/--></li></ul></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/custom-element-tag.ts
+++ b/packages/adapter-tests/fixtures/custom-element-tag.ts
@@ -1,0 +1,28 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A hyphenated custom-element tag with a static and a dynamic
+ * attribute. Custom elements are lowercase-with-hyphen — an adapter
+ * whose tag validation only knows the HTML element list, or whose
+ * component-vs-element split keys on something other than the leading
+ * character, mis-lowers this.
+ */
+export const fixture = createFixture({
+  id: 'custom-element-tag',
+  description: 'Hyphenated custom element with static and signal-bound attributes',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function CustomElementTag() {
+  const [theme, setTheme] = createSignal('light')
+  return (
+    <my-widget widget-id="w1" theme={theme()}>
+      <span>slotted</span>
+    </my-widget>
+  )
+}
+`,
+  expectedHtml: `
+    <my-widget bf-s="test" bf="s0" theme="light" widget-id="w1"><span>slotted</span></my-widget>
+  `,
+})

--- a/packages/adapter-tests/fixtures/dangerous-inner-html.ts
+++ b/packages/adapter-tests/fixtures/dangerous-inner-html.ts
@@ -1,0 +1,22 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `dangerouslySetInnerHTML` — raw HTML injection, the one place where
+ * output must NOT be escaped. Every adapter needs a deliberate
+ * unescape affordance (Go `template.HTML`, Ruby `html_safe`-style raw,
+ * Twig `|raw`); an adapter with no such affordance must refuse loudly
+ * rather than emit the markup entity-escaped (which silently renders
+ * tags as text).
+ */
+export const fixture = createFixture({
+  id: 'dangerous-inner-html',
+  description: 'dangerouslySetInnerHTML renders raw, unescaped markup',
+  source: `
+export function DangerousInnerHtml() {
+  return <div dangerouslySetInnerHTML={{ __html: '<b>bold</b> &amp; safe' }} />
+}
+`,
+  expectedHtml: `
+    <div bf-s="test"><b>bold</b> &amp; safe</div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/data-aria-values.ts
+++ b/packages/adapter-tests/fixtures/data-aria-values.ts
@@ -1,0 +1,25 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `data-*` / `aria-*` value typing: `data-count={0}` must render "0"
+ * (NOT be dropped as falsy, and NOT canonicalise to "false"),
+ * `aria-hidden={true}` must render the string "true" (ARIA booleans
+ * are tri-state strings, not HTML boolean attributes), and a numeric
+ * `aria-level` renders its digits.
+ */
+export const fixture = createFixture({
+  id: 'data-aria-values',
+  description: 'data-*/aria-* value typing: numeric zero, ARIA string-booleans',
+  source: `
+export function DataAriaValues() {
+  return (
+    <div data-count={0} data-active={true} aria-hidden={true}>
+      <h2 aria-level={3} aria-disabled={false}>heading</h2>
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div aria-hidden="true" bf-s="test" data-active="true" data-count="0"><h2 aria-disabled="false" aria-level="3">heading</h2></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/deep-nesting.ts
+++ b/packages/adapter-tests/fixtures/deep-nesting.ts
@@ -1,0 +1,39 @@
+import { createFixture } from '../src/types'
+
+/**
+ * An eight-level-deep static element chain with the only dynamic slot
+ * at the leaf. Pins path-based slot addressing through deep static
+ * structure — off-by-one child-index math anywhere along the walk
+ * surfaces here as a wrong or missing marker.
+ */
+export const fixture = createFixture({
+  id: 'deep-nesting',
+  description: 'Dynamic slot at the leaf of an 8-level static element chain',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function DeepNesting() {
+  const [depth, setDepth] = createSignal(8)
+  return (
+    <div>
+      <section>
+        <article>
+          <div>
+            <ul>
+              <li>
+                <p>
+                  <span>deep {depth()}</span>
+                </p>
+              </li>
+            </ul>
+          </div>
+        </article>
+      </section>
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test"><section><article><div><ul><li><p><span bf="s1">deep <!--bf:s0-->8<!--/--></span></p></li></ul></div></article></section></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/else-if-chain.ts
+++ b/packages/adapter-tests/fixtures/else-if-chain.ts
@@ -1,0 +1,38 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A three-way if / else-if / else conditional-return chain. The
+ * two-branch form is pinned by `if-statement`; the else-if link is a
+ * distinct IRIfStatement shape (alternate is itself a conditional).
+ *
+ * KNOWN BUG pinned by this fixture (surfaced by the Priority-12 sweep):
+ * the `else if` branch is silently DROPPED at SSR branch selection.
+ * `props.level === 'high'` correctly renders the first branch, but
+ * `level: 'mid'` falls through to the final else ("low:") instead of
+ * the else-if consequent ("mid:") — on the Hono reference and every
+ * template adapter alike. The `expectedHtml` below therefore pins the
+ * CURRENT (buggy) fallthrough so the cross-adapter comparison stays
+ * meaningful; when the compiler learns else-if selection, regenerate it
+ * (the snapshot will flip to "mid:").
+ */
+export const fixture = createFixture({
+  id: 'else-if-chain',
+  description: 'if / else-if / else conditional returns pick the right branch',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function ElseIfChain(props: { level?: string }) {
+  const [count, setCount] = createSignal(0)
+  if (props.level === 'high') {
+    return <strong>high:{count()}</strong>
+  } else if (props.level === 'mid') {
+    return <em>mid:{count()}</em>
+  }
+  return <span>low:{count()}</span>
+}
+`,
+  props: { level: 'mid' },
+  expectedHtml: `
+    <span bf-s="test" bf="s1">low:<!--bf:s0-->0<!--/--></span>
+  `,
+})

--- a/packages/adapter-tests/fixtures/empty-list-branch.ts
+++ b/packages/adapter-tests/fixtures/empty-list-branch.ts
@@ -1,0 +1,31 @@
+import { createFixture } from '../src/types'
+
+/**
+ * The canonical empty-state shape: `items().length === 0` ternary
+ * choosing between an empty-state element and a `.map()` list. Both a
+ * conditional and a loop hang off the same signal; the initial value
+ * is non-empty so the loop branch renders at SSR.
+ */
+export const fixture = createFixture({
+  id: 'empty-list-branch',
+  description: 'length === 0 ternary between empty-state and .map() list',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function EmptyListBranch() {
+  const [items, setItems] = createSignal(['alpha', 'beta'])
+  return (
+    <div>
+      {items().length === 0 ? (
+        <p>No items</p>
+      ) : (
+        <ul>{items().map(item => <li key={item}>{item}</li>)}</ul>
+      )}
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test" bf="s3"><ul bf-c="s0" bf="s2"><li data-key="alpha"><!--bf:s1-->alpha<!--/--></li><li data-key="beta"><!--bf:s1-->beta<!--/--></li></ul></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/falsy-text-values.ts
+++ b/packages/adapter-tests/fixtures/falsy-text-values.ts
@@ -1,0 +1,38 @@
+import { createFixture } from '../src/types'
+
+/**
+ * JSX falsy-rendering semantics for literal expression children.
+ *
+ * React/Solid semantics: `0` renders as text "0"; `false`, `null`,
+ * `undefined`, and `''` render nothing. An adapter that stringifies
+ * naively (Go's `fmt.Sprint(false)` → "false", Ruby's `nil.to_s` → "",
+ * Python's `str(None)` → "None") diverges visibly here.
+ */
+export const fixture = createFixture({
+  id: 'falsy-text-values',
+  description: 'Falsy literal children: 0 renders, false/null/undefined/empty-string do not',
+  source: `
+export function FalsyTextValues() {
+  return (
+    <div>
+      <span>{0}</span>
+      <span>{false}</span>
+      <span>{null}</span>
+      <span>{undefined}</span>
+      <span>{''}</span>
+      <span>{1}</span>
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test">
+      <span>0</span>
+      <span></span>
+      <span>null</span>
+      <span>null</span>
+      <span></span>
+      <span>1</span>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/grandchild-composition.ts
+++ b/packages/adapter-tests/fixtures/grandchild-composition.ts
@@ -1,0 +1,38 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Three-level component composition (Parent → Child → Grandchild)
+ * threading one prop down every level. Two-level composition is
+ * pinned by `child-component`; the third level exercises transitive
+ * child-shape registration and nested scope-id derivation.
+ */
+export const fixture = createFixture({
+  id: 'grandchild-composition',
+  description: 'Three-level composition threading a prop through each level',
+  source: `
+import { Middle } from './Middle'
+export function GrandchildComposition() {
+  return (
+    <div>
+      <Middle label="threaded" />
+    </div>
+  )
+}
+`,
+  components: {
+    './Middle': `
+import { Leaf } from './Leaf'
+export function Middle(props: { label: string }) {
+  return <section><Leaf text={props.label} /></section>
+}
+`,
+    './Leaf': `
+export function Leaf(props: { text: string }) {
+  return <span>{props.text}</span>
+}
+`,
+  },
+  expectedHtml: `
+    <div bf-s="test"><section bf-s="test_s0"><span bf-s="test_s0_s0" bf="s1"><!--bf:s0-->threaded<!--/--></span></section></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/html-entity-text.ts
+++ b/packages/adapter-tests/fixtures/html-entity-text.ts
@@ -1,0 +1,32 @@
+import { createFixture } from '../src/types'
+
+/**
+ * HTML character references written in JSX literal text. JSX decodes
+ * entities at parse time (`&amp;` → `&`, `&lt;` → `<`, `&copy;` → `©`,
+ * `&nbsp;` → U+00A0), and each adapter must then RE-escape the decoded
+ * characters for its own HTML emission. An adapter that passes the
+ * entity text through raw double-escapes (`&amp;amp;`); one that skips
+ * re-escaping emits a parse-corrupting `<`.
+ */
+export const fixture = createFixture({
+  id: 'html-entity-text',
+  description: 'HTML entities in JSX literal text decode then re-escape correctly',
+  source: `
+export function HtmlEntityText() {
+  return (
+    <div>
+      <span>Fish &amp; Chips</span>
+      <span>a &lt; b &gt; c</span>
+      <span>&copy; 2026</span>
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test">
+      <span>Fish &amp; Chips</span>
+      <span>a &lt; b &gt; c</span>
+      <span>© 2026</span>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -300,6 +300,60 @@ import { fixture as reduceRightConcat } from './methods/reduce-right-concat'
 import { fixture as arrayEntries } from './methods/array-entries'
 import { fixture as arrayKeys } from './methods/array-keys'
 import { fixture as arrayValues } from './methods/array-values'
+// Priority 12: Edge-case sweep (adapter-coverage 炙り出し). Broad probes
+// for JSX semantics the corpus didn't yet pin — falsy children, JSX
+// comments/whitespace/entities, unicode, expression operators, attribute
+// name/typing rules, SVG/custom elements, loop/conditional nestings,
+// composition depth, and string-method gaps. Shapes an adapter can't
+// lower are pinned per-adapter (skipJsx / conformance-pins), never here.
+import { fixture as falsyTextValues } from './falsy-text-values'
+import { fixture as jsxCommentChild } from './jsx-comment-child'
+import { fixture as jsxTextWhitespace } from './jsx-text-whitespace'
+import { fixture as unicodeText } from './unicode-text'
+import { fixture as htmlEntityText } from './html-entity-text'
+import { fixture as arithmeticText } from './arithmetic-text'
+import { fixture as comparisonTernaryText } from './comparison-ternary-text'
+import { fixture as unaryNotBinding } from './unary-not-binding'
+import { fixture as stringConcatPlus } from './string-concat-plus'
+import { fixture as templateLiteralMultiInterp } from './template-literal-multi-interp'
+import { fixture as optionalChainingProp } from './optional-chaining-prop'
+import { fixture as numberToFixed } from './number-tofixed'
+import { fixture as mathMethods } from './math-methods'
+import { fixture as stringLengthText } from './string-length-text'
+import { fixture as booleanAttrLiterals } from './boolean-attr-literals'
+import { fixture as camelcaseAttributes } from './camelcase-attributes'
+import { fixture as staticAttrEscape } from './static-attr-escape'
+import { fixture as svgIcon } from './svg-icon'
+import { fixture as customElementTag } from './custom-element-tag'
+import { fixture as dataAriaValues } from './data-aria-values'
+import { fixture as attrTernaryTitle } from './attr-ternary-title'
+import { fixture as logicalAndChain } from './logical-and-chain'
+import { fixture as emptyListBranch } from './empty-list-branch'
+import { fixture as adjacentConditionals } from './adjacent-conditionals'
+import { fixture as conditionalWrappingLoop } from './conditional-wrapping-loop'
+import { fixture as elseIfChain } from './else-if-chain'
+import { fixture as inlineArrayMap } from './inline-array-map'
+import { fixture as objectEntriesMap } from './object-entries-map'
+import { fixture as mapKeyIndex } from './map-key-index'
+import { fixture as nestedLoopOuterBinding } from './nested-loop-outer-binding'
+import { fixture as conditionalReturnNull } from './conditional-return-null'
+import { fixture as jsxElementProp } from './jsx-element-prop'
+import { fixture as grandchildComposition } from './grandchild-composition'
+import { fixture as childPrimitiveProps } from './child-primitive-props'
+import { fixture as preWhitespace } from './pre-whitespace'
+import { fixture as tableDynamicRows } from './table-dynamic-rows'
+import { fixture as adjacentDynamicText } from './adjacent-dynamic-text'
+import { fixture as memoChain } from './memo-chain'
+import { fixture as signalObjectField } from './signal-object-field'
+import { fixture as nestedFragments } from './nested-fragments'
+import { fixture as deepNesting } from './deep-nesting'
+import { fixture as signalAttrAndText } from './signal-attr-and-text'
+import { fixture as selectOptionSelected } from './select-option-selected'
+import { fixture as dangerousInnerHtml } from './dangerous-inner-html'
+import { fixture as multilineAttrValue } from './multiline-attr-value'
+import { fixture as stringSlice } from './methods/string-slice'
+import { fixture as stringReplaceAll } from './methods/string-replaceall'
+import { fixture as stringTrimSided } from './methods/string-trim-sided'
 
 import type { JSXFixture } from '../src/types'
 
@@ -515,4 +569,53 @@ export const jsxFixtures: JSXFixture[] = [
   arrayEntries,
   arrayKeys,
   arrayValues,
+  // Priority 12: Edge-case sweep (adapter-coverage 炙り出し).
+  falsyTextValues,
+  jsxCommentChild,
+  jsxTextWhitespace,
+  unicodeText,
+  htmlEntityText,
+  arithmeticText,
+  comparisonTernaryText,
+  unaryNotBinding,
+  stringConcatPlus,
+  templateLiteralMultiInterp,
+  optionalChainingProp,
+  numberToFixed,
+  mathMethods,
+  stringLengthText,
+  booleanAttrLiterals,
+  camelcaseAttributes,
+  staticAttrEscape,
+  svgIcon,
+  customElementTag,
+  dataAriaValues,
+  attrTernaryTitle,
+  logicalAndChain,
+  emptyListBranch,
+  adjacentConditionals,
+  conditionalWrappingLoop,
+  elseIfChain,
+  inlineArrayMap,
+  objectEntriesMap,
+  mapKeyIndex,
+  nestedLoopOuterBinding,
+  conditionalReturnNull,
+  jsxElementProp,
+  grandchildComposition,
+  childPrimitiveProps,
+  preWhitespace,
+  tableDynamicRows,
+  adjacentDynamicText,
+  memoChain,
+  signalObjectField,
+  nestedFragments,
+  deepNesting,
+  signalAttrAndText,
+  selectOptionSelected,
+  dangerousInnerHtml,
+  multilineAttrValue,
+  stringSlice,
+  stringReplaceAll,
+  stringTrimSided,
 ]

--- a/packages/adapter-tests/fixtures/inline-array-map.ts
+++ b/packages/adapter-tests/fixtures/inline-array-map.ts
@@ -1,0 +1,30 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `.map()` over an INLINE array literal (`{['a','b','c'].map(...)}`)
+ * — no signal, no prop, no const binding. The loop array is an
+ * expression with no name, so any lowering that resolves the loop
+ * source by identifier lookup has nothing to look up.
+ */
+export const fixture = createFixture({
+  id: 'inline-array-map',
+  description: '.map() directly over an inline array literal',
+  source: `
+export function InlineArrayMap() {
+  return (
+    <ul>
+      {['alpha', 'beta', 'gamma'].map(name => (
+        <li key={name}>{name}</li>
+      ))}
+    </ul>
+  )
+}
+`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s1">
+      <li data-key="alpha"><!--bf:s0-->alpha<!--/--></li>
+      <li data-key="beta"><!--bf:s0-->beta<!--/--></li>
+      <li data-key="gamma"><!--bf:s0-->gamma<!--/--></li>
+    </ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/jsx-comment-child.ts
+++ b/packages/adapter-tests/fixtures/jsx-comment-child.ts
@@ -1,0 +1,33 @@
+import { createFixture } from '../src/types'
+
+/**
+ * JSX comment children (`{/* ... *&#8205;/}`) must render nothing — no
+ * empty text node, no comment marker, no whitespace artifact — and
+ * must not disturb the slot numbering of surrounding dynamic children.
+ */
+export const fixture = createFixture({
+  id: 'jsx-comment-child',
+  description: 'JSX expression-container comments render nothing',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function JsxCommentChild() {
+  const [count, setCount] = createSignal(3)
+  return (
+    <div>
+      {/* leading comment */}
+      <span>before</span>
+      {/* middle comment */}
+      <span>{count()}</span>
+      {/* trailing comment */}
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test">
+      <span>before</span>
+      <span bf="s1"><!--bf:s0-->3<!--/--></span>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/jsx-element-prop.ts
+++ b/packages/adapter-tests/fixtures/jsx-element-prop.ts
@@ -1,0 +1,41 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A JSX element passed as a NON-children prop (`header={<strong/>}`)
+ * alongside regular children — the slot/render-prop-lite pattern.
+ * Template backends must materialize the prop-valued JSX into the
+ * child's template or refuse loudly; silently stringifying the element
+ * object is the failure mode this pins against.
+ */
+export const fixture = createFixture({
+  id: 'jsx-element-prop',
+  description: 'JSX element as a non-children prop value (header slot)',
+  source: `
+import { Card } from './Card'
+export function JsxElementProp() {
+  return (
+    <Card header={<strong>Title</strong>}>
+      <p>body text</p>
+    </Card>
+  )
+}
+`,
+  components: {
+    './Card': `
+export function Card(props: { header?: any; children?: any }) {
+  return (
+    <section>
+      <header>{props.header}</header>
+      <div>{props.children}</div>
+    </section>
+  )
+}
+`,
+  },
+  expectedHtml: `
+    <section bf-s="test_s0">
+      <header bf="s1"><!--bf:s0--><strong bf-s="test">Title</strong><!--/--></header>
+      <div><p>body text</p></div>
+    </section>
+  `,
+})

--- a/packages/adapter-tests/fixtures/jsx-text-whitespace.ts
+++ b/packages/adapter-tests/fixtures/jsx-text-whitespace.ts
@@ -1,0 +1,29 @@
+import { createFixture } from '../src/types'
+
+/**
+ * JSX whitespace semantics: multi-line text is trimmed and joined,
+ * `{' '}` forces an explicit space between inline elements, and
+ * significant interior spaces inside a text run are preserved.
+ */
+export const fixture = createFixture({
+  id: 'jsx-text-whitespace',
+  description: 'Explicit {" "} joiners and multi-line text trimming',
+  source: `
+export function JsxTextWhitespace() {
+  return (
+    <p>
+      <strong>bold</strong>{' '}
+      <em>italic</em>{' '}
+      plain text run
+    </p>
+  )
+}
+`,
+  expectedHtml: `
+    <p bf-s="test">
+      <strong>bold</strong>
+      <em>italic</em>
+       plain text run 
+    </p>
+  `,
+})

--- a/packages/adapter-tests/fixtures/logical-and-chain.ts
+++ b/packages/adapter-tests/fixtures/logical-and-chain.ts
@@ -1,0 +1,25 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A multi-operand `&&` chain guarding one JSX element
+ * (`a() && b() && <el/>`). The condition side is a compound boolean,
+ * not a single getter — pins that the conditional lowering takes the
+ * WHOLE left-hand chain as the guard rather than only the first
+ * operand.
+ */
+export const fixture = createFixture({
+  id: 'logical-and-chain',
+  description: 'Chained a() && b() && <element/> conditional',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function LogicalAndChain() {
+  const [ready, setReady] = createSignal(true)
+  const [visible, setVisible] = createSignal(false)
+  return <div>{ready() && visible() && <span>both on</span>}</div>
+}
+`,
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><!--bf-cond-start:s0--><!--bf-cond-end:s0--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/map-key-index.ts
+++ b/packages/adapter-tests/fixtures/map-key-index.ts
@@ -1,0 +1,32 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Keying a loop by the map INDEX (`key={i}`) while the body renders
+ * the item — index-as-key is the most common escape hatch in real
+ * code. `map-with-index` pins index-in-body; this pins index-in-key.
+ */
+export const fixture = createFixture({
+  id: 'map-key-index',
+  description: 'Loop keyed by map index rather than an item field',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function MapKeyIndex() {
+  const [steps, setSteps] = createSignal(['unpack', 'plug in', 'enjoy'])
+  return (
+    <ol>
+      {steps().map((step, i) => (
+        <li key={i}>{step}</li>
+      ))}
+    </ol>
+  )
+}
+`,
+  expectedHtml: `
+    <ol bf-s="test" bf="s1">
+      <li data-key="0"><!--bf:s0-->unpack<!--/--></li>
+      <li data-key="1"><!--bf:s0-->plug in<!--/--></li>
+      <li data-key="2"><!--bf:s0-->enjoy<!--/--></li>
+    </ol>
+  `,
+})

--- a/packages/adapter-tests/fixtures/math-methods.ts
+++ b/packages/adapter-tests/fixtures/math-methods.ts
@@ -1,0 +1,35 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Well-known `Math.*` builtins over a signal: `min`, `max`, `abs`,
+ * `floor`. These route through the identifier-path template-primitive
+ * registry on template adapters (see `templatePrimitives`), so each
+ * call is a registry-coverage probe.
+ */
+export const fixture = createFixture({
+  id: 'math-methods',
+  description: 'Math.min/max/abs/floor over a signal in text content',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function MathMethods() {
+  const [n, setN] = createSignal(-7.6)
+  return (
+    <div>
+      <span>{Math.min(n(), 10)}</span>
+      <span>{Math.max(n(), 0)}</span>
+      <span>{Math.abs(n())}</span>
+      <span>{Math.floor(n())}</span>
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test">
+      <span bf="s1"><!--bf:s0-->-7.6<!--/--></span>
+      <span bf="s3"><!--bf:s2-->0<!--/--></span>
+      <span bf="s5"><!--bf:s4-->7.6<!--/--></span>
+      <span bf="s7"><!--bf:s6-->-8<!--/--></span>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/memo-chain.ts
+++ b/packages/adapter-tests/fixtures/memo-chain.ts
@@ -1,0 +1,34 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A memo depending on another memo (`total` → `doubled` → signal).
+ * The single-memo case is pinned by `memo`; the chain pins the SSR
+ * initial-value fold through TWO derivation layers — each adapter's
+ * constructor/template must compute `doubled` from `count`, then
+ * `label` from `doubled`, in dependency order.
+ */
+export const fixture = createFixture({
+  id: 'memo-chain',
+  description: 'Memo derived from another memo SSR-computes both layers',
+  source: `
+'use client'
+import { createSignal, createMemo } from '@barefootjs/client'
+export function MemoChain() {
+  const [count, setCount] = createSignal(3)
+  const doubled = createMemo(() => count() * 2)
+  const label = createMemo(() => doubled() + 1)
+  return (
+    <div>
+      <span>{doubled()}</span>
+      <span>{label()}</span>
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test">
+      <span bf="s1"><!--bf:s0-->6<!--/--></span>
+      <span bf="s3"><!--bf:s2-->7<!--/--></span>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/methods/string-replaceall.ts
+++ b/packages/adapter-tests/fixtures/methods/string-replaceall.ts
@@ -1,0 +1,24 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `String.prototype.replaceAll(search, replacement)` — the all-
+ * occurrences sibling of the #1448 `string-replace` fixture (which
+ * pins first-occurrence-only semantics). Backends whose native
+ * replace is global by default (Go strings.ReplaceAll, PHP
+ * str_replace, Ruby gsub) trivially pass; the risk is an adapter
+ * reusing its first-only `replace` lowering.
+ */
+export const fixture = createFixture({
+  id: 'string-replaceall',
+  description: '.replaceAll replaces every occurrence, not just the first',
+  source: `
+function StringReplaceAll({ path }: { path: string }) {
+  return <div>{path.replaceAll('/', ' > ')}</div>
+}
+export { StringReplaceAll }
+`,
+  props: { path: 'a/b/c' },
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><!--bf:s0-->a &gt; b &gt; c<!--/--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/methods/string-slice.ts
+++ b/packages/adapter-tests/fixtures/methods/string-slice.ts
@@ -1,0 +1,32 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `String.prototype.slice(start, end)` — the STRING sibling of the
+ * #1448 `array-slice` fixture. String slicing is a different runtime
+ * surface in most backends (Go substring vs `bf_slice` on slices,
+ * Ruby `[a...b]`, PHP `substr`), so array coverage doesn't imply it.
+ * Includes the negative-start form (`slice(-4)`), which naive
+ * substring lowerings get wrong.
+ */
+export const fixture = createFixture({
+  id: 'string-slice',
+  description: '.slice(start, end) and .slice(-n) on a string prop',
+  source: `
+function StringSlice({ word }: { word: string }) {
+  return (
+    <div>
+      <span>{word.slice(0, 4)}</span>
+      <span>{word.slice(-4)}</span>
+    </div>
+  )
+}
+export { StringSlice }
+`,
+  props: { word: 'barefootjs' },
+  expectedHtml: `
+    <div bf-s="test">
+      <span bf="s1"><!--bf:s0-->bare<!--/--></span>
+      <span bf="s3"><!--bf:s2-->otjs<!--/--></span>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/methods/string-trim-sided.ts
+++ b/packages/adapter-tests/fixtures/methods/string-trim-sided.ts
@@ -1,0 +1,29 @@
+import { createFixture } from '../../src/types'
+
+/**
+ * `trimStart()` / `trimEnd()` — the one-sided siblings of the #1448
+ * `string-trim` fixture. Bracketed output makes a both-sides trim (or
+ * a wrong-side trim) fail visibly.
+ */
+export const fixture = createFixture({
+  id: 'string-trim-sided',
+  description: '.trimStart() and .trimEnd() strip only their own side',
+  source: `
+function StringTrimSided({ value }: { value: string }) {
+  return (
+    <div>
+      <span>[{value.trimStart()}]</span>
+      <span>[{value.trimEnd()}]</span>
+    </div>
+  )
+}
+export { StringTrimSided }
+`,
+  props: { value: '  mid  ' },
+  expectedHtml: `
+    <div bf-s="test">
+      <span bf="s1">[<!--bf:s0-->mid <!--/-->]</span>
+      <span bf="s3">[<!--bf:s2--> mid<!--/-->]</span>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/multiline-attr-value.ts
+++ b/packages/adapter-tests/fixtures/multiline-attr-value.ts
@@ -1,0 +1,28 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A long static `class` attribute written across MULTIPLE SOURCE
+ * LINES inside one string, plus a template-literal class with a
+ * leading/trailing space around the interpolation. Pins whitespace
+ * fidelity inside attribute values (the inter-tag collapse in the
+ * normalizer does not touch intra-attribute spaces).
+ */
+export const fixture = createFixture({
+  id: 'multiline-attr-value',
+  description: 'Class strings with interior spaces and interpolation spacing',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function MultilineAttrValue() {
+  const [tone, setTone] = createSignal('info')
+  return (
+    <div className={\`alert alert-\${tone()} shadow\`}>
+      <span className="icon  gap">note</span>
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test" bf="s0" class="alert alert-info shadow"><span class="icon gap">note</span></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/nested-fragments.ts
+++ b/packages/adapter-tests/fixtures/nested-fragments.ts
@@ -1,0 +1,35 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A fragment nested INSIDE another fragment, with a dynamic slot in
+ * the inner one. Fragment flattening must recurse — an adapter that
+ * only unwraps one level leaves a phantom grouping node (or drops the
+ * inner children).
+ */
+export const fixture = createFixture({
+  id: 'nested-fragments',
+  description: 'Fragment inside fragment flattens recursively',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function NestedFragments() {
+  const [n, setN] = createSignal(5)
+  return (
+    <>
+      <span>first</span>
+      <>
+        <span>inner</span>
+        <span>{n()}</span>
+      </>
+      <span>last</span>
+    </>
+  )
+}
+`,
+  expectedHtml: `
+    <span>first</span>
+    <span>inner</span>
+    <span bf="s1"><!--bf:s0-->5<!--/--></span>
+    <span>last</span>
+  `,
+})

--- a/packages/adapter-tests/fixtures/nested-loop-outer-binding.ts
+++ b/packages/adapter-tests/fixtures/nested-loop-outer-binding.ts
@@ -1,0 +1,45 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A nested loop whose INNER body reads the OUTER loop binding
+ * (`group.name` inside the `items` map). `map-nested` pins plain
+ * nesting; this pins cross-scope variable capture — template
+ * languages with per-loop context stacks (Go's `.`-rebinding, Twig's
+ * loop scope) must alias the outer binding to survive the inner loop.
+ */
+export const fixture = createFixture({
+  id: 'nested-loop-outer-binding',
+  description: 'Inner loop body reads the outer loop variable',
+  source: `
+type Group = { name: string; items: string[] }
+function NestedLoopOuterBinding({ groups }: { groups: Group[] }) {
+  return (
+    <ul>
+      {groups.map(group => (
+        <li key={group.name}>
+          {group.items.map(item => (
+            <span key={item}>{group.name}/{item} </span>
+          ))}
+        </li>
+      ))}
+    </ul>
+  )
+}
+export { NestedLoopOuterBinding }
+`,
+  props: {
+    groups: [
+      { name: 'fruits', items: ['apple', 'plum'] },
+      { name: 'nuts', items: ['pecan'] },
+    ],
+  },
+  expectedHtml: `
+    <ul bf-s="test" bf="s3">
+      <li bf="s2" data-key="fruits">
+        <span data-key-1="apple"><!--bf:s0-->fruits<!--/-->/<!--bf:s1-->apple<!--/--></span>
+        <span data-key-1="plum"><!--bf:s0-->fruits<!--/-->/<!--bf:s1-->plum<!--/--></span>
+      </li>
+      <li bf="s2" data-key="nuts"><span data-key-1="pecan"><!--bf:s0-->nuts<!--/-->/<!--bf:s1-->pecan<!--/--></span></li>
+    </ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/number-tofixed.ts
+++ b/packages/adapter-tests/fixtures/number-tofixed.ts
@@ -1,0 +1,20 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `Number.prototype.toFixed(digits)` in text position — the canonical
+ * price-formatting shape. Rounds AND pads: 19.5 → "19.50".
+ */
+export const fixture = createFixture({
+  id: 'number-tofixed',
+  description: '.toFixed(2) formats a numeric prop with rounding and zero-padding',
+  source: `
+function NumberToFixed({ price }: { price: number }) {
+  return <div>¥{price.toFixed(2)}</div>
+}
+export { NumberToFixed }
+`,
+  props: { price: 19.5 },
+  expectedHtml: `
+    <div bf-s="test" bf="s1">¥<!--bf:s0-->19.50<!--/--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/object-entries-map.ts
+++ b/packages/adapter-tests/fixtures/object-entries-map.ts
@@ -1,0 +1,32 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `Object.entries(props.obj).map(([k, v]) => ...)` DIRECTLY in JSX —
+ * iterating an object-shaped prop rather than an array. Combines a
+ * well-known builtin (Object.entries) with a tuple destructure in the
+ * loop param. Backends whose loop lowering only knows arrays must
+ * either lower to their native map-iteration form or refuse loudly.
+ */
+export const fixture = createFixture({
+  id: 'object-entries-map',
+  description: 'Object.entries(prop).map with tuple destructure',
+  source: `
+function ObjectEntriesMap({ counts }: { counts: Record<string, number> }) {
+  return (
+    <ul>
+      {Object.entries(counts).map(([word, n]) => (
+        <li key={word}>{word}: {n}</li>
+      ))}
+    </ul>
+  )
+}
+export { ObjectEntriesMap }
+`,
+  props: { counts: { apple: 3, banana: 5 } },
+  expectedHtml: `
+    <ul bf-s="test" bf="s2">
+      <li data-key="apple"><!--bf:s0-->apple<!--/-->: <!--bf:s1-->3<!--/--></li>
+      <li data-key="banana"><!--bf:s0-->banana<!--/-->: <!--bf:s1-->5<!--/--></li>
+    </ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/optional-chaining-prop.ts
+++ b/packages/adapter-tests/fixtures/optional-chaining-prop.ts
@@ -1,0 +1,30 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Optional chaining (`?.`) into an object-valued prop, with a `??`
+ * fallback. One access hits a present object, the other a missing one,
+ * so both the short-circuit and the happy path render in one fixture.
+ */
+export const fixture = createFixture({
+  id: 'optional-chaining-prop',
+  description: 'Optional chaining into an object prop with nullish fallback',
+  source: `
+type User = { name: string }
+function OptionalChainingProp({ user, owner }: { user?: User; owner?: User }) {
+  return (
+    <div>
+      <span>{user?.name ?? 'anonymous'}</span>
+      <span>{owner?.name ?? 'nobody'}</span>
+    </div>
+  )
+}
+export { OptionalChainingProp }
+`,
+  props: { user: { name: 'Ada' } },
+  expectedHtml: `
+    <div bf-s="test">
+      <span bf="s1"><!--bf:s0-->Ada<!--/--></span>
+      <span bf="s3"><!--bf:s2-->nobody<!--/--></span>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/pre-whitespace.ts
+++ b/packages/adapter-tests/fixtures/pre-whitespace.ts
@@ -1,0 +1,26 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `<pre>` / `<code>` content where interior whitespace is meaningful.
+ * The conformance normalizer collapses whitespace on BOTH sides, so
+ * this can't pin exact newlines — what it does pin is that adapters
+ * don't inject template-syntax artifacts (block delimiters, extra
+ * indentation actions) into a whitespace-sensitive element, and that a
+ * dynamic expression inside `<pre>` still gets its slot markers.
+ */
+export const fixture = createFixture({
+  id: 'pre-whitespace',
+  description: '<pre>/<code> with interior spacing and a dynamic slot',
+  source: `
+function PreWhitespace({ snippet }: { snippet: string }) {
+  return (
+    <pre><code>const x = 1;  {snippet}</code></pre>
+  )
+}
+export { PreWhitespace }
+`,
+  props: { snippet: 'const y = 2;' },
+  expectedHtml: `
+    <pre bf-s="test"><code bf="s1">const x = 1; <!--bf:s0-->const y = 2;<!--/--></code></pre>
+  `,
+})

--- a/packages/adapter-tests/fixtures/select-option-selected.ts
+++ b/packages/adapter-tests/fixtures/select-option-selected.ts
@@ -1,0 +1,33 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `<select>` whose `<option>`s derive `selected` from a comparison
+ * against a signal (`selected={value() === 'b'}`). `selected` is an
+ * HTML boolean attribute driven per-option by an equality test — the
+ * false options must OMIT it, and only the matching option carries it.
+ */
+export const fixture = createFixture({
+  id: 'select-option-selected',
+  description: 'Per-option selected={value() === ...} boolean derivation',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function SelectOptionSelected() {
+  const [value, setValue] = createSignal('b')
+  return (
+    <select>
+      <option value="a" selected={value() === 'a'}>Alpha</option>
+      <option value="b" selected={value() === 'b'}>Beta</option>
+      <option value="c" selected={value() === 'c'}>Gamma</option>
+    </select>
+  )
+}
+`,
+  expectedHtml: `
+    <select bf-s="test">
+      <option bf="s0" value="a">Alpha</option>
+      <option bf="s1" selected value="b">Beta</option>
+      <option bf="s2" value="c">Gamma</option>
+    </select>
+  `,
+})

--- a/packages/adapter-tests/fixtures/signal-attr-and-text.ts
+++ b/packages/adapter-tests/fixtures/signal-attr-and-text.ts
@@ -1,0 +1,23 @@
+import { createFixture } from '../src/types'
+
+/**
+ * ONE signal bound to an attribute and a text slot on the SAME
+ * element. The two bindings need independent lowering (attribute
+ * interpolation vs text slot markers) fed by one dependency — a
+ * binding table keyed only by signal name collapses them.
+ */
+export const fixture = createFixture({
+  id: 'signal-attr-and-text',
+  description: 'Same signal feeding an attribute and a text slot on one element',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function SignalAttrAndText() {
+  const [status, setStatus] = createSignal('idle')
+  return <output data-status={status()}>{status()}</output>
+}
+`,
+  expectedHtml: `
+    <output bf-s="test" bf="s1" data-status="idle"><!--bf:s0-->idle<!--/--></output>
+  `,
+})

--- a/packages/adapter-tests/fixtures/signal-object-field.ts
+++ b/packages/adapter-tests/fixtures/signal-object-field.ts
@@ -1,0 +1,29 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A signal holding an OBJECT, with member reads (`user().name`) in
+ * text and attribute positions. Scalar signals dominate the corpus;
+ * this pins the object-valued signal's SSR baking (Go needs a struct
+ * or map for the field, dynamic languages a hash) and the member
+ * access lowering off a getter call.
+ */
+export const fixture = createFixture({
+  id: 'signal-object-field',
+  description: 'Object-valued signal with member reads in text and attributes',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type User = { name: string; role: string }
+export function SignalObjectField() {
+  const [user, setUser] = createSignal<User>({ name: 'Ada', role: 'admin' })
+  return (
+    <div data-role={user().role}>
+      <span>{user().name}</span>
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test" bf="s2" data-role="admin"><span bf="s1"><!--bf:s0-->Ada<!--/--></span></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/static-attr-escape.ts
+++ b/packages/adapter-tests/fixtures/static-attr-escape.ts
@@ -1,0 +1,30 @@
+import { createFixture } from '../src/types'
+
+/**
+ * HTML-metacharacters inside STATIC attribute values (the dynamic-value
+ * escape path is pinned by text-escape / #1692). `&` and `<` in a
+ * title, and a query string with `&` in an href, must escape without
+ * double-escaping across every adapter's template syntax.
+ */
+export const fixture = createFixture({
+  id: 'static-attr-escape',
+  description: 'Static attribute values containing & and < escape exactly once',
+  source: `
+export function StaticAttrEscape() {
+  return (
+    <div>
+      <span title="Fish & Chips">meta</span>
+      <a href="/search?a=1&b=2">link</a>
+      <span data-note="a < b">less-than</span>
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test">
+      <span title="Fish &amp; Chips">meta</span>
+      <a href="/search?a=1&amp;b=2">link</a>
+      <span data-note="a &lt; b">less-than</span>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/string-concat-plus.ts
+++ b/packages/adapter-tests/fixtures/string-concat-plus.ts
@@ -1,0 +1,22 @@
+import { createFixture } from '../src/types'
+
+/**
+ * String concatenation with the `+` operator (not a template literal).
+ * Backends whose `+` is numeric-only (Perl, PHP) must lower this to
+ * their string-concat operator (`.`), so the shape can't share the
+ * arithmetic `+` lowering.
+ */
+export const fixture = createFixture({
+  id: 'string-concat-plus',
+  description: 'String concatenation via the + operator',
+  source: `
+function StringConcatPlus({ name }: { name: string }) {
+  return <div>{'Hello, ' + name + '!'}</div>
+}
+export { StringConcatPlus }
+`,
+  props: { name: 'Ada' },
+  expectedHtml: `
+    <div bf-s="test" bf="s1"><!--bf:s0-->Hello, Ada!<!--/--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/string-length-text.ts
+++ b/packages/adapter-tests/fixtures/string-length-text.ts
@@ -1,0 +1,21 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `.length` of a STRING prop (the array `.length` lowering is pinned
+ * elsewhere; string length is a distinct accessor in most template
+ * backends — Go `len`, Ruby `.length`, Perl `length()`, PHP `strlen`).
+ */
+export const fixture = createFixture({
+  id: 'string-length-text',
+  description: 'String .length in text content',
+  source: `
+function StringLengthText({ word }: { word: string }) {
+  return <div>{word.length} chars in {word}</div>
+}
+export { StringLengthText }
+`,
+  props: { word: 'barefoot' },
+  expectedHtml: `
+    <div bf-s="test" bf="s2"><!--bf:s0-->8<!--/--> chars in <!--bf:s1-->barefoot<!--/--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/svg-icon.ts
+++ b/packages/adapter-tests/fixtures/svg-icon.ts
@@ -1,0 +1,30 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Inline SVG with camelCase presentation attributes. Unlike HTML
+ * attributes, SVG's `viewBox` / `strokeWidth` / `strokeLinecap` map to
+ * case-SENSITIVE (`viewBox`) or kebab-case (`stroke-width`,
+ * `stroke-linecap`) forms — a lowercasing pass that's correct for HTML
+ * (`tabIndex` → `tabindex`) corrupts `viewBox`, and a pass-through
+ * leaves `strokeWidth` unrecognized by the SVG renderer.
+ */
+export const fixture = createFixture({
+  id: 'svg-icon',
+  description: 'Inline SVG: viewBox casing and camelCase → kebab-case presentation attrs',
+  source: `
+export function SvgIcon() {
+  return (
+    <svg viewBox="0 0 24 24" width="24" height="24" fill="none">
+      <circle cx="12" cy="12" r="10" strokeWidth={2} />
+      <path d="M8 12l3 3 5-6" strokeLinecap="round" />
+    </svg>
+  )
+}
+`,
+  expectedHtml: `
+    <svg bf-s="test" fill="none" height="24" viewBox="0 0 24 24" width="24">
+      <circle cx="12" cy="12" r="10" stroke-width="2"></circle>
+      <path d="M8 12l3 3 5-6" stroke-linecap="round"></path>
+    </svg>
+  `,
+})

--- a/packages/adapter-tests/fixtures/table-dynamic-rows.ts
+++ b/packages/adapter-tests/fixtures/table-dynamic-rows.ts
@@ -1,0 +1,57 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A full `<table>` structure (caption/thead/tbody/th/td) with a keyed
+ * row loop and a dynamic cell. Table elements have strict content
+ * models — a stray wrapper `<div>` or comment marker in the wrong
+ * place gets re-parented by the HTML parser, so hydration markers
+ * must land inside cells, not between `<tr>`s. (`data-table` covers
+ * the composed site/ui component; this is the minimal-element probe.)
+ */
+export const fixture = createFixture({
+  id: 'table-dynamic-rows',
+  description: 'Table with keyed row loop and dynamic cells',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Row = { name: string; qty: number }
+export function TableDynamicRows() {
+  const [rows, setRows] = createSignal<Row[]>([
+    { name: 'bolt', qty: 12 },
+    { name: 'nut', qty: 9 },
+  ])
+  return (
+    <table>
+      <caption>stock</caption>
+      <thead>
+        <tr><th>name</th><th>qty</th></tr>
+      </thead>
+      <tbody>
+        {rows().map(row => (
+          <tr key={row.name}>
+            <td>{row.name}</td>
+            <td>{row.qty}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+`,
+  expectedHtml: `
+    <table bf-s="test">
+      <caption>stock</caption>
+      <thead><tr><th>name</th><th>qty</th></tr></thead>
+      <tbody bf="s2">
+        <tr data-key="bolt">
+          <td><!--bf:s0-->bolt<!--/--></td>
+          <td><!--bf:s1-->12<!--/--></td>
+        </tr>
+        <tr data-key="nut">
+          <td><!--bf:s0-->nut<!--/--></td>
+          <td><!--bf:s1-->9<!--/--></td>
+        </tr>
+      </tbody>
+    </table>
+  `,
+})

--- a/packages/adapter-tests/fixtures/template-literal-multi-interp.ts
+++ b/packages/adapter-tests/fixtures/template-literal-multi-interp.ts
@@ -1,0 +1,25 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A template literal with several interpolations and literal segments
+ * between them, in text position. Pins segment/interpolation
+ * interleaving (leading literal, back-to-back interpolations, trailing
+ * literal) in one expression.
+ */
+export const fixture = createFixture({
+  id: 'template-literal-multi-interp',
+  description: 'Template literal with multiple interpolations in text content',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function TemplateLiteralMultiInterp(props: { greeting?: string }) {
+  const [name, setName] = createSignal('World')
+  const [punct, setPunct] = createSignal('!')
+  return <p>{\`\${props.greeting ?? 'Hello'}, \${name()}\${punct()} bye\`}</p>
+}
+`,
+  props: { greeting: 'Hi' },
+  expectedHtml: `
+    <p bf-s="test" bf="s1"><!--bf:s0-->Hi, World! bye<!--/--></p>
+  `,
+})

--- a/packages/adapter-tests/fixtures/unary-not-binding.ts
+++ b/packages/adapter-tests/fixtures/unary-not-binding.ts
@@ -1,0 +1,31 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Logical negation of a signal in both an attribute binding
+ * (`disabled={!enabled()}`) and a conditional (`{!enabled() && ...}`).
+ * Pins that `!` lowers as a real boolean negation, not string
+ * truthiness, in each template language.
+ */
+export const fixture = createFixture({
+  id: 'unary-not-binding',
+  description: 'Unary ! negation in attribute and conditional positions',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function UnaryNotBinding() {
+  const [enabled, setEnabled] = createSignal(false)
+  return (
+    <div>
+      <button disabled={!enabled()}>Go</button>
+      {!enabled() && <span>disabled hint</span>}
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test" bf="s2">
+      <button bf="s0" disabled>Go</button>
+      <span bf-c="s1">disabled hint</span>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/unicode-text.ts
+++ b/packages/adapter-tests/fixtures/unicode-text.ts
@@ -1,0 +1,31 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Non-ASCII output: multi-byte text (Japanese), emoji (astral-plane
+ * code points), and a non-ASCII attribute value must survive each
+ * adapter's template encoding and its backend's string handling
+ * (Go/Ruby/Perl/PHP/Python source-file escaping) byte-identically.
+ */
+export const fixture = createFixture({
+  id: 'unicode-text',
+  description: 'Multi-byte text, emoji, and non-ASCII attribute values',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function UnicodeText() {
+  const [label, setLabel] = createSignal('こんにちは')
+  return (
+    <div title="日本語タイトル">
+      <span>{label()}</span>
+      <span>🎉 émojis &amp; accents: café</span>
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test" title="日本語タイトル">
+      <span bf="s1"><!--bf:s0-->こんにちは<!--/--></span>
+      <span>🎉 émojis &amp; accents: café</span>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
+++ b/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
@@ -203,6 +203,46 @@ describe('CSR Conformance Tests', () => {
     // `region-boundary` JSX conformance test; only the CSR parity is
     // out of scope here. Same SSR-only-marker divergence as the entries above.
     'region-boundary',
+    // Priority-12 edge-case sweep: SSR/CSR divergences inside the
+    // Hono + client pipeline itself, surfaced by the new fixtures. Each
+    // entry is a REAL divergence (not a harness artifact) — the skip
+    // documents it until the compiler/runtime reconciles the two paths:
+    //   - `falsy-text-values`: CSR stringifies `{false}` → "false" while
+    //     SSR drops it; SSR renders `{null}`/`{undefined}` → "null" while
+    //     CSR drops them. Both sides also disagree with JSX semantics
+    //     (0 renders; false/null/undefined render nothing).
+    'falsy-text-values',
+    //   - `html-entity-text`: `&copy;` in JSX literal text is decoded to
+    //     `©` by SSR but passed through as the raw entity by the CSR
+    //     template string (same DOM after parse, different bytes).
+    'html-entity-text',
+    //   - `boolean-attr-literals`: `readOnly` (camelCase alias of a
+    //     boolean attr) SSRs as `readOnly="true"` but CSRs as bare
+    //     `readOnly` — the boolean-attribute canonicalisation in
+    //     `normalizeHTML` only covers the lowercase spellings.
+    'boolean-attr-literals',
+    //   - `static-attr-escape`: static attribute values are HTML-escaped
+    //     by Hono SSR (`Fish &amp; Chips`) but emitted RAW by the CSR
+    //     template literal (`Fish & Chips`).
+    'static-attr-escape',
+    //   - `object-entries-map` / `nested-loop-outer-binding`: nested/
+    //     tuple-destructure loops emit `data-key`/`data-key-1` depth
+    //     suffixes differently between the SSR snapshot and template-eval.
+    'object-entries-map',
+    'nested-loop-outer-binding',
+    //   - `jsx-element-prop`: a JSX element passed as a NON-children prop
+    //     reaches the CSR insert as an escaped STRING (with the
+    //     `__BF_PARENT_SCOPE__` placeholder still embedded) instead of
+    //     real markup.
+    'jsx-element-prop',
+    //   - `grandchild-composition`: the third composition level reuses the
+    //     parent's scope id (`test_s0`) in CSR instead of deriving
+    //     `test_s0_s0` as SSR does.
+    'grandchild-composition',
+    //   - `nested-fragments`: a multi-root fragment attaches `bf-s` to its
+    //     first element in CSR, while SSR carries the scope on a
+    //     `<!--bf-scope:...-->` comment the normalizer strips.
+    'nested-fragments',
   ])
 
   for (const fixture of jsxFixtures) {

--- a/packages/adapter-tests/src/__tests__/divergences.test.ts
+++ b/packages/adapter-tests/src/__tests__/divergences.test.ts
@@ -51,13 +51,26 @@ function isNumSentinel(value: unknown): boolean {
 
 /**
  * Recursively finds every file named `vector-divergences.json` under
- * `dir`, skipping `node_modules`, `dist`, and hidden directories
- * (dotfiles). Returns absolute paths.
+ * `dir`, skipping `node_modules`, `dist`, `vendor`, and hidden
+ * directories (dotfiles). Returns absolute paths.
+ *
+ * `vendor` matters: the PHP adapters' documented setup
+ * (`composer install --working-dir packages/adapter-{twig,blade}/php`)
+ * vendors `barefootjs/php` as a path-repository SYMLINK back to
+ * `packages/adapter-php`, so without the skip the walk re-discovers
+ * adapter-php's declaration file "inside" adapter-twig/adapter-blade
+ * and the uniqueness + same-package assertions below false-fail on any
+ * checkout where the PHP render deps are actually installed.
  */
 function findDivergenceFiles(dir: string): string[] {
   const found: string[] = []
   for (const entry of readdirSync(dir)) {
-    if (entry === 'node_modules' || entry === 'dist' || entry.startsWith('.')) continue
+    if (
+      entry === 'node_modules' ||
+      entry === 'dist' ||
+      entry === 'vendor' ||
+      entry.startsWith('.')
+    ) continue
     const full = join(dir, entry)
     const stat = statSync(full)
     if (stat.isDirectory()) {

--- a/packages/adapter-tests/src/__tests__/indent-html.test.ts
+++ b/packages/adapter-tests/src/__tests__/indent-html.test.ts
@@ -42,6 +42,15 @@ describe('indentHTML', () => {
     expect(result).toContain('<span bf="s1"><span bf="s0">0</span></span>')
   })
 
+  test('hyphenated custom-element tags survive tokenization', () => {
+    // Regression: the tokenizer's tag-name class lacked `-`, so
+    // `<my-widget …>` fell through to TEXT with its `<` dropped,
+    // corrupting generated fixture HTML (custom-element-tag fixture).
+    const html = '<my-widget theme="light" widget-id="w1"><span>slotted</span></my-widget>'
+    const result = indentHTML(html)
+    expect(normalizeExpectedHtml(result)).toBe(html)
+  })
+
   test('nested single-child chain stays on one line', () => {
     const html = '<span bf="s1"><span bf="s0">Hello</span></span>'
     const result = indentHTML(html)

--- a/packages/adapter-tests/src/__tests__/ssr-hydration-contract.test.ts
+++ b/packages/adapter-tests/src/__tests__/ssr-hydration-contract.test.ts
@@ -104,6 +104,12 @@ const statelessFixtures = new Set([
   'conditional-return-button',
   'todo-app',
   'ai-chat',
+  // Priority-12 edge-case sweep: same one-side-renders-less divergence as
+  // `conditional-return-button` above — the three-branch if/else-if/else
+  // chain's client JS wires marker ids for EVERY branch, but the SSR HTML
+  // (rendered with `level: 'mid'`… normalised to the low branch) carries
+  // only the rendered branch's ids.
+  'else-if-chain',
   // #1448 Tier B — iteration shape fixtures are prop-based components
   // without signals. SSR renders them fully; no client JS is emitted.
   'array-entries',

--- a/packages/adapter-tests/src/indent-html.ts
+++ b/packages/adapter-tests/src/indent-html.ts
@@ -23,7 +23,12 @@ interface Token {
  */
 function tokenize(html: string): Token[] {
   const tokens: Token[] = []
-  const re = /<!--[\s\S]*?-->|<\/([a-zA-Z][a-zA-Z0-9]*)>|<([a-zA-Z][a-zA-Z0-9]*)(\s[^>]*)?>|[^<]+/g
+  // Tag names allow interior hyphens (custom elements: `<my-widget>`).
+  // Without `-` in the name class the open/close alternatives fail to
+  // match a hyphenated tag, the unmatched `<` is silently dropped by the
+  // scanner, and the tag body re-tokenizes as TEXT — corrupting the
+  // emitted fixture HTML (surfaced by the `custom-element-tag` fixture).
+  const re = /<!--[\s\S]*?-->|<\/([a-zA-Z][a-zA-Z0-9-]*)>|<([a-zA-Z][a-zA-Z0-9-]*)(\s[^>]*)?>|[^<]+/g
   let match: RegExpExecArray | null
 
   while ((match = re.exec(html)) !== null) {

--- a/packages/adapter-twig/src/__tests__/twig-adapter.test.ts
+++ b/packages/adapter-twig/src/__tests__/twig-adapter.test.ts
@@ -20,6 +20,51 @@ runAdapterConformanceTests({
   name: 'twig',
   factory: () => new TwigAdapter(),
   render: renderTwigComponent,
+  // Priority-12 edge-case sweep (炙り出し): fixtures below RENDER on real
+  // PHP Twig but diverge from the Hono reference byte comparison. Each
+  // entry names its divergence; graduating one means fixing the adapter
+  // (or shared compiler layer) and deleting the line.
+  skipJsx: [
+    // `(count() + 2) * 3` renders 10 instead of 18 — the parenthesised
+    // sub-expression loses its grouping in the lowering (silent wrong
+    // arithmetic; same finding as mojo/jinja/blade).
+    'arithmetic-text',
+    // `'Hello, ' + name + '!'` lowers through Twig's numeric `+`
+    // instead of `~` string concat — same class as blade's PHP `+`.
+    'string-concat-plus',
+    // `{false}` renders "false" (Hono drops it); `{null}`/`{undefined}`
+    // render empty (Hono renders "null"). Neither matches JSX semantics.
+    'falsy-text-values',
+    // `&copy;` in JSX literal text: Hono decodes to `©`, Twig re-emits
+    // the raw entity — same DOM, different bytes.
+    'html-entity-text',
+    // Math.min/max/abs over a signal render EMPTY (only Math.floor is
+    // in the template-primitive registry).
+    'math-methods',
+    // camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`,
+    // Twig emits bare presence.
+    'boolean-attr-literals',
+    // `htmlFor` is not lowered to `for` (Hono maps it).
+    'camelcase-attributes',
+    // Static attribute values are NOT HTML-escaped (`title="Fish &
+    // Chips"` raw vs Hono's `Fish &amp; Chips`).
+    'static-attr-escape',
+    // SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`)
+    // pass through unmapped; Hono lowers to kebab-case.
+    'svg-icon',
+    // `Object.entries(prop).map(([k, v]) => …)` renders an EMPTY <ul>.
+    'object-entries-map',
+    // Nested-loop inner items carry `data-key` where the reference
+    // emits the depth-suffixed `data-key-1`.
+    'nested-loop-outer-binding',
+    // JSX element as a NON-children prop renders an empty slot (the
+    // element value is silently dropped).
+    'jsx-element-prop',
+    // `.slice()` on a STRING misfires through the array slice helper.
+    'string-slice',
+    // `.trimStart()` / `.trimEnd()` render empty (no lowering).
+    'string-trim-sided',
+  ],
   // Per-fixture build-time contracts for shapes the Twig adapter
   // intentionally refuses to lower. Lives in `../conformance-pins` —
   // mirrors Jinja's set (the lowering gates are shared code paths in

--- a/packages/adapter-twig/src/conformance-pins.ts
+++ b/packages/adapter-twig/src/conformance-pins.ts
@@ -83,4 +83,15 @@ export const conformancePins: ConformancePins = {
   // "Expression not supported" BF101 rather than emitting a broken
   // template.
   'array-map-function-reference': [{ code: 'BF101', severity: 'error' }],
+  // Edge-case sweep (Priority 12): `dangerouslySetInnerHTML` requires a
+  // deliberate raw-HTML (unescaped) output affordance in the target
+  // template language. No lowering exists yet, so the compiler refuses
+  // the shape loudly instead of emitting entity-escaped markup that
+  // silently renders tags as text.
+  'dangerous-inner-html': [{ code: 'BF101', severity: 'error' }],
+  // Edge-case sweep (Priority 12): `.replaceAll` has no lowering yet —
+  // only first-occurrence `.replace` is wired to the runtime helpers.
+  // Refused with BF101 rather than reusing the first-only lowering,
+  // which would silently change semantics.
+  'string-replaceall': [{ code: 'BF101', severity: 'error' }],
 }

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -23,7 +23,52 @@ runAdapterConformanceTests({
   name: 'xslate',
   factory: () => new XslateAdapter(),
   render: renderXslateComponent,
-  // No JSX-render skips: every shared conformance fixture — including
+  // Priority-12 edge-case sweep (炙り出し): fixtures below RENDER on real
+  // Text::Xslate but diverge from the Hono reference byte comparison.
+  // Each entry names its divergence; graduating one means fixing the
+  // adapter (or shared compiler layer) and deleting the line.
+  skipJsx: [
+    // `(count() + 2) * 3` renders 10 instead of 18 — the parenthesised
+    // sub-expression loses its grouping in the lowering (silent wrong
+    // arithmetic; same finding as mojo/jinja/blade).
+    'arithmetic-text',
+    // `'Hello, ' + name + '!'` numeric-coerces through Perl's `+`
+    // (needs `.` / `~` concat) — same finding as mojo.
+    'string-concat-plus',
+    // `{false}` renders "false" (Hono drops it); `{null}`/`{undefined}`
+    // render empty (Hono renders "null"). Neither matches JSX semantics.
+    'falsy-text-values',
+    // `&copy;` in JSX literal text: Hono decodes to `©`, Kolon re-emits
+    // the raw entity — same DOM, different bytes.
+    'html-entity-text',
+    // Math.min/max/abs over a signal render EMPTY (only Math.floor is
+    // in the template-primitive registry).
+    'math-methods',
+    // camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`,
+    // Kolon emits bare presence.
+    'boolean-attr-literals',
+    // `htmlFor` is not lowered to `for` (Hono maps it).
+    'camelcase-attributes',
+    // Static attribute values are NOT HTML-escaped (`title="Fish &
+    // Chips"` raw vs Hono's `Fish &amp; Chips`).
+    'static-attr-escape',
+    // SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`)
+    // pass through unmapped; Hono lowers to kebab-case.
+    'svg-icon',
+    // `Object.entries(prop).map(([k, v]) => …)` renders an EMPTY <ul>.
+    'object-entries-map',
+    // Nested-loop inner items carry `data-key` where the reference
+    // emits the depth-suffixed `data-key-1`.
+    'nested-loop-outer-binding',
+    // JSX element as a NON-children prop renders an empty slot (the
+    // element value is silently dropped).
+    'jsx-element-prop',
+    // `.slice()` on a STRING misfires through the array slice helper.
+    'string-slice',
+    // `.trimStart()` / `.trimEnd()` render empty (no lowering).
+    'string-trim-sided',
+  ],
+  // (Pre-sweep note) Otherwise no JSX-render skips: every shared conformance fixture — including
   // the composed `site/ui` demo corpus (#1467 / #1897) — renders to
   // Hono parity on real Text::Xslate. `data-table` came off via the
   // body-children `inLoop` reset (#1896): the loop-item component

--- a/packages/adapter-xslate/src/conformance-pins.ts
+++ b/packages/adapter-xslate/src/conformance-pins.ts
@@ -109,4 +109,15 @@ export const conformancePins: ConformancePins = {
   // UNSUPPORTED_METHODS gate refuses it with BF101 rather than emitting
   // a broken template.
   'array-map-function-reference': [{ code: 'BF101', severity: 'error' }],
+  // Edge-case sweep (Priority 12): `dangerouslySetInnerHTML` requires a
+  // deliberate raw-HTML (unescaped) output affordance in the target
+  // template language. No lowering exists yet, so the compiler refuses
+  // the shape loudly instead of emitting entity-escaped markup that
+  // silently renders tags as text.
+  'dangerous-inner-html': [{ code: 'BF101', severity: 'error' }],
+  // Edge-case sweep (Priority 12): `.replaceAll` has no lowering yet —
+  // only first-occurrence `.replace` is wired to the runtime helpers.
+  // Refused with BF101 rather than reusing the first-only lowering,
+  // which would silently change semantics.
+  'string-replaceall': [{ code: 'BF101', severity: 'error' }],
 }


### PR DESCRIPTION
# Priority-12 edge-case sweep (炙り出し)

Broadens the shared JSX conformance corpus with **48 new fixtures** targeting shapes the corpus didn't pin, then runs every adapter against them on **real backends** (Go 1.25.6, Ruby erb, Perl Mojolicious + Text::Xslate, PHP Twig + Blade, Python jinja2, Rust minijinja) and pins each divergence **per adapter** — `skipJsx` for render-level divergences, `conformance-pins` for build-time refusals — never in the shared corpus.

## New fixture coverage

- **JSX text semantics**: falsy children (`{0}`/`{false}`/`{null}`/`{undefined}`/`{''}`), `{/* comments */}`, `{' '}` joiners, HTML entities in literal text, unicode/emoji/multi-byte text
- **Expressions**: arithmetic with parentheses, comparison ternaries (`>=`, `===`, `!==`), unary `!`, string `+` concat, multi-interpolation template literals, optional chaining into object props, `Math.min/max/abs/floor`, `.toFixed(2)`, string `.length`
- **Attributes**: boolean spellings (bare / `={true}` / `={false}` omission), camelCase → HTML lowering (`htmlFor`, `tabIndex`, …), static-value escaping (`&`, `<`), SVG presentation attrs (`viewBox`, `strokeWidth`), hyphenated custom elements, `data-*`/`aria-*` value typing, non-class attr ternaries
- **Conditionals/loops**: `&&` chains, empty-list branch, adjacent conditionals, conditional→loop→ternary nesting, if/else-if/else chains, inline array-literal `.map`, `Object.entries(...).map(([k,v])…)`, index keys, nested-loop outer-binding capture
- **Composition**: `return null` guard, **JSX element as a non-children prop**, three-level prop threading, numeric/boolean literal props
- **Structure**: `<pre>`, `<table>` with keyed rows, adjacent dynamic text slots, memo-of-memo, object-valued signals, nested fragments, 8-level deep nesting, `<select>` option selection, `dangerouslySetInnerHTML`
- **String methods** (`methods/`): `slice` (incl. negative), `replaceAll`, `trimStart`/`trimEnd`

All 48 render on the Hono reference and every suite is green with the pins in place (verified locally on all 9 adapters + CSR/marker/hydration-contract layers).

## Notable findings surfaced

1. **`else if` branch dropped at SSR branch selection** (`else-if-chain`): `level: 'mid'` renders the final else branch on Hono and every template adapter alike. First `if` works; the else-if link is skipped. Snapshot pins today's fallthrough with a KNOWN BUG docstring.
2. **Parenthesised arithmetic loses grouping** on mojo/xslate/twig/jinja/blade/minijinja: `(count() + 2) * 3` renders `10` instead of `18` — silent wrong arithmetic. (ERB and Go get it right.)
3. **JS string `+` lowered numerically** on Perl/PHP/Go backends: renders `0` (mojo/xslate/go), fatals `string + string` (blade), numeric `+` (twig).
4. **JSX element as a non-children prop is silently dropped** by every template adapter (empty slot), and reaches the CSR insert as an escaped string with the `__BF_PARENT_SCOPE__` placeholder leaked.
5. **Static attribute values are not HTML-escaped** by any template adapter (`title="Fish & Chips"` emitted raw; Hono escapes).
6. **Falsy-children semantics disagree everywhere**: Hono SSR renders `{null}`/`{undefined}` as the text `null` but drops `{false}`; template adapters render `{false}` as `false` but drop null/undefined; CSR does a third thing. None match JSX semantics (0 renders; false/null/undefined drop).
7. **camelCase attr aliases unmapped** on template adapters (`htmlFor`, SVG `strokeWidth`/`strokeLinecap`; `readOnly` boolean typing diverges on Hono too).
8. **`Object.entries(...).map` renders an empty list** on template adapters (silent zero iterations; generated Go doesn't compile).
9. **Go-specific**: memo-of-memo folds only the first layer; numeric/boolean literal child props bind as zero values; three-level prop threading renders the leaf empty; 6 fixtures generate Go that fails `go run` (should become loud BF101s).
10. **Mojo-specific**: non-ASCII literal text adjacent to a dynamic slot corrupts to U+FFFD (`¥` in `number-tofixed`).
11. **String-method typing**: `.slice`/`.trimStart`/`.trimEnd` on **strings** misroute through array helpers (renders `[]`) or render empty.

## Infra fixes (surfaced by the sweep itself)

- `indentHTML` tokenizer: tag-name regex lacked `-`, so `<my-widget>`'s `<` was silently dropped, corrupting generated fixture HTML (+ regression test).
- `divergences.test.ts` walker now skips composer `vendor/` — the PHP adapters' documented `composer install` creates a path-repo **symlink** back to `packages/adapter-php`, which double-counted the declaration file on any checkout with PHP render deps installed.

## Follow-ups

Each skip/pin comment names its divergence class inline. Suggested tracking issues (can file on request): else-if branch selection; paren-grouping loss in the shared EP/Jinja-family expression lowering; string-vs-array method dispatch; static-attribute escaping; camelCase attribute mapping table; JSX-valued props (lower or refuse loudly); falsy-children semantics alignment; template-adapter `Object.entries` iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ZXzQWvSKLUUrTAZ3vph1j

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZXzQWvSKLUUrTAZ3vph1j)_