### PR TITLE
Publish render-level conformance divergences on the compatibility matrix

### DIFF
--- a/.changeset/render-divergences-declarations.md
+++ b/.changeset/render-divergences-declarations.md
@@ -1,0 +1,13 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+"@barefootjs/erb": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+"@barefootjs/twig": patch
+"@barefootjs/jinja": patch
+"@barefootjs/blade": patch
+"@barefootjs/rust": patch
+---
+
+Publish each template adapter's render-level conformance divergences as a machine-readable `renderDivergences` export (new `RenderDivergences` type in `@barefootjs/jsx`) — the render-level sibling of `conformancePins`. The Priority-12 edge-case sweep (#2168) skipped fixtures that render differently from the Hono reference via per-test-file `skipJsx` literals, which made the docs compatibility matrix look all-green while divergences were only visible in test-file comments. Each adapter now declares those fixtures (with a one-line rationale) in `src/render-divergences.ts`; its conformance suite derives `skipJsx` from the same object so the published declaration and the test skips cannot drift, and `packages/compat` publishes both pins and render divergences in a new `fixtureDivergences` section of `ui/compat.lock.json`, rendered honestly on the docs compatibility-matrix page. No adapter runtime or codegen behavior changes.

--- a/.changeset/scaffold-workers-types-v5.md
+++ b/.changeset/scaffold-workers-types-v5.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/cli": patch
+---
+
+Fix fresh Hono/Cloudflare scaffolds failing `npm install` with ERESOLVE: wrangler 4.108.0 moved its `peerOptional @cloudflare/workers-types` to `^5.20260706.1`, conflicting with the template's `^4.20250101.0` pin (bun tolerates the mismatch; npm does not — caught by the smoke-publish CI gate). The `bf init` / create-barefootjs Hono template now pins `@cloudflare/workers-types@^5.20260706.1`; v5 still ships a root `index.d.ts`, so the generated tsconfig's `"types"` entry resolves unchanged.

--- a/packages/adapter-blade/src/__tests__/blade-adapter.test.ts
+++ b/packages/adapter-blade/src/__tests__/blade-adapter.test.ts
@@ -15,60 +15,19 @@ import { runAdapterConformanceTests } from '@barefootjs/adapter-tests'
 import { BladeAdapter } from '../adapter'
 import { renderBladeComponent, BladeNotAvailableError } from '../test-render'
 import { conformancePins } from '../conformance-pins'
+import { renderDivergences } from '../render-divergences'
 
 runAdapterConformanceTests({
   name: 'blade',
   factory: () => new BladeAdapter(),
   render: renderBladeComponent,
-  // Priority-12 edge-case sweep (炙り出し): fixtures below RENDER on real
-  // PHP Blade but diverge from the Hono reference byte comparison (or
-  // fatal at render time). Each entry names its divergence; graduating
-  // one means fixing the adapter (or shared compiler layer) and
-  // deleting the line.
-  skipJsx: [
-    // `(count() + 2) * 3` renders 10 instead of 18 — the parenthesised
-    // sub-expression loses its grouping in the lowering (silent wrong
-    // arithmetic; same finding as jinja).
-    'arithmetic-text',
-    // `'Hello, ' + name + '!'` is emitted as PHP `+`, which fatals with
-    // "Unsupported operand types: string + string" — JS string-concat
-    // `+` needs PHP's `.` operator.
-    'string-concat-plus',
-    // `{false}` renders "false" (Hono drops it); `{null}`/`{undefined}`
-    // render empty (Hono renders "null"). Neither matches JSX semantics.
-    'falsy-text-values',
-    // `&copy;` in JSX literal text: Hono decodes to `©`, Blade re-emits
-    // the raw entity — same DOM, different bytes.
-    'html-entity-text',
-    // Math.min/max/abs over a signal render EMPTY (only Math.floor is
-    // in the template-primitive registry).
-    'math-methods',
-    // camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`,
-    // Blade emits bare presence.
-    'boolean-attr-literals',
-    // `htmlFor` is not lowered to `for` (Hono maps it).
-    'camelcase-attributes',
-    // Static attribute values are NOT HTML-escaped (`title="Fish &
-    // Chips"` raw vs Hono's `Fish &amp; Chips`).
-    'static-attr-escape',
-    // SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`)
-    // pass through unmapped; Hono lowers to kebab-case.
-    'svg-icon',
-    // `Object.entries(prop).map(([k, v]) => …)` renders an EMPTY <ul> —
-    // the object-shaped prop silently produces zero iterations.
-    'object-entries-map',
-    // Nested-loop inner items carry `data-key` where the reference
-    // emits the depth-suffixed `data-key-1`.
-    'nested-loop-outer-binding',
-    // JSX element as a NON-children prop renders an empty slot (the
-    // element value is silently dropped).
-    'jsx-element-prop',
-    // `.slice()` on a STRING renders empty (array-slice helper misfires
-    // on strings).
-    'string-slice',
-    // `.trimStart()` / `.trimEnd()` render empty (no lowering).
-    'string-trim-sided',
-  ],
+  // Priority-12 edge-case sweep (炙り出し, #2168): render-level
+  // divergences are declared in `../render-divergences` (exported from the
+  // package index and published to `ui/compat.lock.json` / the docs
+  // compatibility-matrix page by `packages/compat`). Deriving the skip
+  // list from that object keeps the public declaration and these test
+  // skips from drifting; each entry's rationale lives there.
+  skipJsx: Object.keys(renderDivergences),
   // Per-fixture build-time contracts for shapes the Blade adapter
   // intentionally refuses to lower. Lives in `../conformance-pins` —
   // mirrors Twig's set (the lowering gates are shared code paths in

--- a/packages/adapter-blade/src/index.ts
+++ b/packages/adapter-blade/src/index.ts
@@ -7,3 +7,4 @@
 export { BladeAdapter, bladeAdapter } from './adapter/index.ts'
 export type { BladeAdapterOptions } from './adapter/index.ts'
 export { conformancePins } from './conformance-pins.ts'
+export { renderDivergences } from './render-divergences.ts'

--- a/packages/adapter-blade/src/render-divergences.ts
+++ b/packages/adapter-blade/src/render-divergences.ts
@@ -1,0 +1,46 @@
+/**
+ * Render-level divergences against the shared conformance corpus
+ * (Priority-12 edge-case sweep, #2168): fixtures that COMPILE clean on
+ * this adapter but whose rendered output diverges from the Hono
+ * reference on real PHP Blade (or fatals at render time).
+ *
+ * Consumed by this package's conformance test (its `skipJsx` set is
+ * derived from these keys, so the skip list and this declaration can't
+ * drift) and by `packages/compat`, which publishes the entries in the
+ * fixture-divergences section of `ui/compat.lock.json` — surfaced on
+ * the docs compatibility-matrix page. Graduating an entry means fixing
+ * the adapter (or the shared compiler layer) and deleting the line.
+ */
+
+import type { RenderDivergences } from '@barefootjs/jsx'
+
+export const renderDivergences: RenderDivergences = {
+  'arithmetic-text':
+    '`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)',
+  'string-concat-plus':
+    '`\'Hello, \' + name` is emitted as PHP `+`, which fatals with "Unsupported operand types: string + string" — needs PHP\'s `.` concat',
+  'falsy-text-values':
+    '`{false}` renders "false" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders "null") — neither side matches JSX semantics',
+  'html-entity-text':
+    '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
+  'math-methods':
+    'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
+  'boolean-attr-literals':
+    'camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`, this adapter emits bare presence',
+  'camelcase-attributes':
+    '`htmlFor` is not lowered to `for` (Hono maps it)',
+  'static-attr-escape':
+    'static attribute values are not HTML-escaped (`title="Fish & Chips"` emitted raw; Hono escapes)',
+  'svg-icon':
+    'SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case',
+  'object-entries-map':
+    '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
+  'nested-loop-outer-binding':
+    'nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`',
+  'jsx-element-prop':
+    'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
+  'string-slice':
+    '`.slice()` on a STRING renders empty (array-slice helper misfires on strings)',
+  'string-trim-sided':
+    '`.trimStart()` / `.trimEnd()` render empty (no lowering)',
+}

--- a/packages/adapter-erb/src/__tests__/erb-adapter.test.ts
+++ b/packages/adapter-erb/src/__tests__/erb-adapter.test.ts
@@ -26,56 +26,19 @@ import { ErbAdapter } from '../adapter'
 import { renderErbComponent, ErbNotAvailableError } from '../test-render'
 import { compileJSX, type ComponentIR } from '@barefootjs/jsx'
 import { conformancePins } from '../conformance-pins'
+import { renderDivergences } from '../render-divergences'
 
 runAdapterConformanceTests({
   name: 'erb',
   factory: () => new ErbAdapter(),
   render: renderErbComponent,
-  // Priority-12 edge-case sweep (炙り出し): fixtures below RENDER on real
-  // Ruby erb but diverge from the Hono reference byte comparison. Each
-  // entry names its divergence; graduating one means fixing the adapter
-  // (or the shared compiler layer) and deleting the line.
-  skipJsx: [
-    // `{false}` renders the string "false" (Hono drops it); `{null}` /
-    // `{undefined}` render empty (Hono renders "null"). Neither side
-    // matches JSX semantics (0 renders; false/null/undefined drop).
-    'falsy-text-values',
-    // `&copy;` in JSX literal text: Hono decodes to `©` at parse time,
-    // ERB re-emits the raw entity — same DOM, different bytes.
-    'html-entity-text',
-    // `user?.name ?? '...'` on an object prop: the Ruby render exits 1
-    // (optional chaining into a Hash prop has no lowering).
-    'optional-chaining-prop',
-    // Math.min/max/abs over a signal render empty (only Math.floor is
-    // in the template-primitive registry).
-    'math-methods',
-    // camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`,
-    // ERB emits bare `readonly`-style presence.
-    'boolean-attr-literals',
-    // `htmlFor` is not lowered to `for` (Hono maps it).
-    'camelcase-attributes',
-    // Static attribute values are NOT HTML-escaped: `title="Fish &
-    // Chips"` is emitted raw where Hono escapes to `Fish &amp; Chips`.
-    'static-attr-escape',
-    // SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`)
-    // pass through unmapped; Hono lowers to kebab-case.
-    'svg-icon',
-    // `Object.entries(prop).map(([k, v]) => …)` renders but its loop
-    // item keys diverge from the reference serialisation.
-    'object-entries-map',
-    // Nested-loop inner items carry `data-key` where the Hono
-    // reference emits the depth-suffixed `data-key-1`.
-    'nested-loop-outer-binding',
-    // A JSX element passed as a NON-children prop (`header={<strong/>}`)
-    // renders an EMPTY slot — the element value is silently dropped.
-    'jsx-element-prop',
-    // `.slice()` on a STRING lowers through the array slice helper and
-    // renders "[]" instead of the substring.
-    'string-slice',
-    // `.trimStart()` / `.trimEnd()` render empty (no lowering; only
-    // both-sides `.trim` is wired).
-    'string-trim-sided',
-  ],
+  // Priority-12 edge-case sweep (炙り出し, #2168): render-level
+  // divergences are declared in `../render-divergences` (exported from the
+  // package index and published to `ui/compat.lock.json` / the docs
+  // compatibility-matrix page by `packages/compat`). Deriving the skip
+  // list from that object keeps the public declaration and these test
+  // skips from drifting; each entry's rationale lives there.
+  skipJsx: Object.keys(renderDivergences),
   // No JSX-render skips: every shared conformance fixture — including
   // the composed `site/ui` demo corpus (#1467 / #1897) — renders to
   // Hono parity on real Ruby `erb`. `data-table` came off via the

--- a/packages/adapter-erb/src/index.ts
+++ b/packages/adapter-erb/src/index.ts
@@ -7,3 +7,4 @@
 export { ErbAdapter, erbAdapter } from './adapter/index.ts'
 export type { ErbAdapterOptions } from './adapter/index.ts'
 export { conformancePins } from './conformance-pins.ts'
+export { renderDivergences } from './render-divergences.ts'

--- a/packages/adapter-erb/src/render-divergences.ts
+++ b/packages/adapter-erb/src/render-divergences.ts
@@ -1,0 +1,44 @@
+/**
+ * Render-level divergences against the shared conformance corpus
+ * (Priority-12 edge-case sweep, #2168): fixtures that COMPILE clean on
+ * this adapter but whose rendered output diverges from the Hono
+ * reference on real Ruby erb (or fails at render time).
+ *
+ * Consumed by this package's conformance test (its `skipJsx` set is
+ * derived from these keys, so the skip list and this declaration can't
+ * drift) and by `packages/compat`, which publishes the entries in the
+ * fixture-divergences section of `ui/compat.lock.json` — surfaced on
+ * the docs compatibility-matrix page. Graduating an entry means fixing
+ * the adapter (or the shared compiler layer) and deleting the line.
+ */
+
+import type { RenderDivergences } from '@barefootjs/jsx'
+
+export const renderDivergences: RenderDivergences = {
+  'falsy-text-values':
+    '`{false}` renders "false" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders "null") — neither side matches JSX semantics',
+  'html-entity-text':
+    '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
+  'optional-chaining-prop':
+    '`user?.name ?? …` on an object prop: the Ruby render exits 1 (optional chaining into a Hash prop has no lowering)',
+  'math-methods':
+    'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
+  'boolean-attr-literals':
+    'camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`, this adapter emits bare presence',
+  'camelcase-attributes':
+    '`htmlFor` is not lowered to `for` (Hono maps it)',
+  'static-attr-escape':
+    'static attribute values are not HTML-escaped (`title="Fish & Chips"` emitted raw; Hono escapes)',
+  'svg-icon':
+    'SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case',
+  'object-entries-map':
+    '`Object.entries(prop).map(([k, v]) => …)` renders but its loop item keys diverge from the reference serialisation',
+  'nested-loop-outer-binding':
+    'nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`',
+  'jsx-element-prop':
+    'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
+  'string-slice':
+    '`.slice()` on a STRING lowers through the array slice helper and renders "[]" instead of the substring',
+  'string-trim-sided':
+    '`.trimStart()` / `.trimEnd()` render empty (no lowering; only both-sides `.trim` is wired)',
+}

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -17,80 +17,19 @@ import {
   type IRExpression,
 } from '@barefootjs/jsx'
 import { conformancePins } from '../conformance-pins'
+import { renderDivergences } from '../render-divergences'
 
 runAdapterConformanceTests({
   name: 'go-template',
   factory: () => new GoTemplateAdapter(),
   render: renderGoTemplateComponent,
-  // Priority-12 edge-case sweep (炙り出し): fixtures below compile but
-  // diverge from the Hono reference on real Go — or generate Go that
-  // fails `go run` outright (marked "exit 1" below; those should
-  // eventually become loud BF101 refusals instead of broken codegen).
-  // Each entry names its divergence; graduating one means fixing the
-  // adapter (or shared compiler layer) and deleting the line.
-  skipJsx: [
-    // `{false}` renders "false" (Hono drops it); `{null}`/`{undefined}`
-    // render empty (Hono renders "null"). Neither matches JSX semantics.
-    'falsy-text-values',
-    // `&copy;` in JSX literal text: Hono decodes to `©`, Go re-emits
-    // the raw entity — same DOM, different bytes.
-    'html-entity-text',
-    // `'Hello, ' + name + '!'` renders "0" — string concat lowered
-    // through numeric addition.
-    'string-concat-plus',
-    // `user?.name ?? '…'` on an object prop: generated Go fails to
-    // compile/run (exit 1) — optional chaining into a struct/map prop
-    // has no lowering.
-    'optional-chaining-prop',
-    // `.toFixed(2)`: generated Go fails to run (exit 1) on a number
-    // PROP (the memo-side `bf_to_fixed` path doesn't cover this shape).
-    'number-tofixed',
-    // Math.min/max/abs over a signal: generated Go fails to run
-    // (exit 1) — only Math.floor is registered.
-    'math-methods',
-    // camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`,
-    // Go emits bare presence.
-    'boolean-attr-literals',
-    // `htmlFor` is not lowered to `for` (Hono maps it).
-    'camelcase-attributes',
-    // Static attribute values are NOT HTML-escaped (`title="Fish &
-    // Chips"` raw vs Hono's `Fish &amp; Chips`).
-    'static-attr-escape',
-    // SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`)
-    // pass through unmapped; Hono lowers to kebab-case.
-    'svg-icon',
-    // `Object.entries(prop).map(([k, v]) => …)`: generated Go fails to
-    // run (exit 1) — no object-iteration loop lowering.
-    'object-entries-map',
-    // Nested-loop inner items carry `data-key` where the reference
-    // emits the depth-suffixed `data-key-1`.
-    'nested-loop-outer-binding',
-    // JSX element as a NON-children prop renders an empty slot (the
-    // element value is silently dropped).
-    'jsx-element-prop',
-    // Three-level composition: the grandchild's threaded prop renders
-    // EMPTY (`<span>…</span>` with no text) — prop forwarding through
-    // two template-render layers loses the value.
-    'grandchild-composition',
-    // Numeric/boolean LITERAL props on a child (`count={5}`
-    // `active={true}`) render as Go zero values (0 / false) — literal
-    // primitive props aren't bound into the child's Input struct.
-    'child-primitive-props',
-    // A memo derived from another memo renders EMPTY for the second
-    // layer — the constructor folds `doubled` from `count` but not
-    // `label` from `doubled`.
-    'memo-chain',
-    // Object-valued signal (`user().name`): generated Go fails to run
-    // (exit 1) — no struct synthesis for object signal initial values
-    // outside loops.
-    'signal-object-field',
-    // `.slice()` on a STRING routes through the array `bf_slice` helper
-    // and renders "[]" instead of the substring.
-    'string-slice',
-    // `.trimStart()` / `.trimEnd()`: generated Go fails to run (exit 1)
-    // — only both-sides `bf_trim` exists.
-    'string-trim-sided',
-  ],
+  // Priority-12 edge-case sweep (炙り出し, #2168): render-level
+  // divergences are declared in `../render-divergences` (exported from the
+  // package index and published to `ui/compat.lock.json` / the docs
+  // compatibility-matrix page by `packages/compat`). Deriving the skip
+  // list from that object keeps the public declaration and these test
+  // skips from drifting; each entry's rationale lives there.
+  skipJsx: Object.keys(renderDivergences),
   // `branch-self-closing` no longer needs a skip — the conditional-
   // marker divergence (Hono `bf-c="sN"` attribute vs Go
   // `<!--bf-cond-start:sN-->` / `<!--bf-cond-end:sN-->` comment pairs)

--- a/packages/adapter-go-template/src/index.ts
+++ b/packages/adapter-go-template/src/index.ts
@@ -7,3 +7,4 @@
 export { GoTemplateAdapter, goTemplateAdapter } from './adapter/index.ts'
 export type { GoTemplateAdapterOptions } from './adapter/index.ts'
 export { conformancePins } from './conformance-pins.ts'
+export { renderDivergences } from './render-divergences.ts'

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -1,0 +1,58 @@
+/**
+ * Render-level divergences against the shared conformance corpus
+ * (Priority-12 edge-case sweep, #2168): fixtures that COMPILE clean on
+ * this adapter but whose rendered output diverges from the Hono
+ * reference on real Go — or whose generated Go fails `go run` outright
+ * (marked "exit 1" below; those should eventually become loud BF101
+ * refusals instead of broken codegen).
+ *
+ * Consumed by this package's conformance test (its `skipJsx` set is
+ * derived from these keys, so the skip list and this declaration can't
+ * drift) and by `packages/compat`, which publishes the entries in the
+ * fixture-divergences section of `ui/compat.lock.json` — surfaced on
+ * the docs compatibility-matrix page. Graduating an entry means fixing
+ * the adapter (or the shared compiler layer) and deleting the line.
+ */
+
+import type { RenderDivergences } from '@barefootjs/jsx'
+
+export const renderDivergences: RenderDivergences = {
+  'falsy-text-values':
+    '`{false}` renders "false" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders "null") — neither side matches JSX semantics',
+  'html-entity-text':
+    '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
+  'string-concat-plus':
+    "`'Hello, ' + name` renders \"0\" — JS string-concat `+` lowered through numeric addition",
+  'optional-chaining-prop':
+    '`user?.name ?? …` on an object prop: generated Go fails to run (exit 1) — optional chaining into a struct/map prop has no lowering',
+  'number-tofixed':
+    '`.toFixed(2)` on a number PROP: generated Go fails to run (exit 1)',
+  'math-methods':
+    'Math.min/max/abs over a signal: generated Go fails to run (exit 1) — only Math.floor is registered',
+  'boolean-attr-literals':
+    'camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`, this adapter emits bare presence',
+  'camelcase-attributes':
+    '`htmlFor` is not lowered to `for` (Hono maps it)',
+  'static-attr-escape':
+    'static attribute values are not HTML-escaped (`title="Fish & Chips"` emitted raw; Hono escapes)',
+  'svg-icon':
+    'SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case',
+  'object-entries-map':
+    '`Object.entries(prop).map(([k, v]) => …)`: generated Go fails to run (exit 1) — no object-iteration loop lowering',
+  'nested-loop-outer-binding':
+    'nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`',
+  'jsx-element-prop':
+    'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
+  'grandchild-composition':
+    "three-level composition: the grandchild's threaded prop renders EMPTY — prop forwarding through two template-render layers loses the value",
+  'child-primitive-props':
+    'numeric/boolean LITERAL props on a child (`count={5}` `active={true}`) render as Go zero values (0 / false)',
+  'memo-chain':
+    'a memo derived from another memo renders EMPTY for the second layer — the constructor folds only one derivation level',
+  'signal-object-field':
+    'object-valued signal (`user().name`): generated Go fails to run (exit 1) — no struct synthesis outside loops',
+  'string-slice':
+    '`.slice()` on a STRING routes through the array `bf_slice` helper and renders "[]" instead of the substring',
+  'string-trim-sided':
+    '`.trimStart()` / `.trimEnd()`: generated Go fails to run (exit 1) — only both-sides `bf_trim` exists',
+}

--- a/packages/adapter-jinja/src/__tests__/jinja-adapter.test.ts
+++ b/packages/adapter-jinja/src/__tests__/jinja-adapter.test.ts
@@ -16,56 +16,19 @@ import { runAdapterConformanceTests } from '@barefootjs/adapter-tests'
 import { JinjaAdapter } from '../adapter'
 import { renderJinjaComponent, PythonNotAvailableError } from '../test-render'
 import { conformancePins } from '../conformance-pins'
+import { renderDivergences } from '../render-divergences'
 
 runAdapterConformanceTests({
   name: 'jinja',
   factory: () => new JinjaAdapter(),
   render: renderJinjaComponent,
-  // Priority-12 edge-case sweep (炙り出し): fixtures below RENDER on real
-  // Python jinja2 but diverge from the Hono reference byte comparison.
-  // Each entry names its divergence; graduating one means fixing the
-  // adapter (or shared compiler layer) and deleting the line.
-  skipJsx: [
-    // `(count() + 2) * 3` renders 10 instead of 18 — the parenthesised
-    // sub-expression loses its grouping in the lowering, so the output
-    // silently computes `count() + 2 * 3`. Highest-priority finding of
-    // the sweep for this adapter (silent wrong arithmetic).
-    'arithmetic-text',
-    // `{false}` renders "false" (Hono drops it); `{null}`/`{undefined}`
-    // render empty (Hono renders "null"). Neither matches JSX semantics.
-    'falsy-text-values',
-    // `&copy;` in JSX literal text: Hono decodes to `©`, Jinja re-emits
-    // the raw entity — same DOM, different bytes.
-    'html-entity-text',
-    // Math.min/max/abs over a signal render EMPTY (only Math.floor is
-    // in the template-primitive registry).
-    'math-methods',
-    // camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`,
-    // Jinja emits bare presence.
-    'boolean-attr-literals',
-    // `htmlFor` is not lowered to `for` (Hono maps it).
-    'camelcase-attributes',
-    // Static attribute values are NOT HTML-escaped (`title="Fish &
-    // Chips"` raw vs Hono's `Fish &amp; Chips`).
-    'static-attr-escape',
-    // SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`)
-    // pass through unmapped; Hono lowers to kebab-case.
-    'svg-icon',
-    // `Object.entries(prop).map(([k, v]) => …)` renders an EMPTY <ul> —
-    // the object-shaped prop silently produces zero iterations.
-    'object-entries-map',
-    // Nested-loop inner items carry `data-key` where the reference
-    // emits the depth-suffixed `data-key-1`.
-    'nested-loop-outer-binding',
-    // JSX element as a NON-children prop renders an empty slot (the
-    // element value is silently dropped).
-    'jsx-element-prop',
-    // `.slice()` on a STRING renders empty (array-slice helper misfires
-    // on strings).
-    'string-slice',
-    // `.trimStart()` / `.trimEnd()` render empty (no lowering).
-    'string-trim-sided',
-  ],
+  // Priority-12 edge-case sweep (炙り出し, #2168): render-level
+  // divergences are declared in `../render-divergences` (exported from the
+  // package index and published to `ui/compat.lock.json` / the docs
+  // compatibility-matrix page by `packages/compat`). Deriving the skip
+  // list from that object keeps the public declaration and these test
+  // skips from drifting; each entry's rationale lives there.
+  skipJsx: Object.keys(renderDivergences),
   // Per-fixture build-time contracts for shapes the Jinja adapter
   // intentionally refuses to lower. Lives in `../conformance-pins` —
   // mirrors xslate's set (the lowering gates are shared code paths in

--- a/packages/adapter-jinja/src/index.ts
+++ b/packages/adapter-jinja/src/index.ts
@@ -7,3 +7,4 @@
 export { JinjaAdapter, jinjaAdapter } from './adapter/index.ts'
 export type { JinjaAdapterOptions } from './adapter/index.ts'
 export { conformancePins } from './conformance-pins.ts'
+export { renderDivergences } from './render-divergences.ts'

--- a/packages/adapter-jinja/src/render-divergences.ts
+++ b/packages/adapter-jinja/src/render-divergences.ts
@@ -1,0 +1,44 @@
+/**
+ * Render-level divergences against the shared conformance corpus
+ * (Priority-12 edge-case sweep, #2168): fixtures that COMPILE clean on
+ * this adapter but whose rendered output diverges from the Hono
+ * reference on real Python jinja2.
+ *
+ * Consumed by this package's conformance test (its `skipJsx` set is
+ * derived from these keys, so the skip list and this declaration can't
+ * drift) and by `packages/compat`, which publishes the entries in the
+ * fixture-divergences section of `ui/compat.lock.json` — surfaced on
+ * the docs compatibility-matrix page. Graduating an entry means fixing
+ * the adapter (or the shared compiler layer) and deleting the line.
+ */
+
+import type { RenderDivergences } from '@barefootjs/jsx'
+
+export const renderDivergences: RenderDivergences = {
+  'arithmetic-text':
+    '`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)',
+  'falsy-text-values':
+    '`{false}` renders "false" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders "null") — neither side matches JSX semantics',
+  'html-entity-text':
+    '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
+  'math-methods':
+    'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
+  'boolean-attr-literals':
+    'camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`, this adapter emits bare presence',
+  'camelcase-attributes':
+    '`htmlFor` is not lowered to `for` (Hono maps it)',
+  'static-attr-escape':
+    'static attribute values are not HTML-escaped (`title="Fish & Chips"` emitted raw; Hono escapes)',
+  'svg-icon':
+    'SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case',
+  'object-entries-map':
+    '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
+  'nested-loop-outer-binding':
+    'nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`',
+  'jsx-element-prop':
+    'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
+  'string-slice':
+    '`.slice()` on a STRING renders empty (array-slice helper misfires on strings)',
+  'string-trim-sided':
+    '`.trimStart()` / `.trimEnd()` render empty (no lowering)',
+}

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -10,63 +10,19 @@ import { runAdapterConformanceTests } from '@barefootjs/adapter-tests'
 import { renderMojoComponent, PerlNotAvailableError } from '../test-render'
 import { compileJSX, type ComponentIR } from '@barefootjs/jsx'
 import { conformancePins } from '../conformance-pins'
+import { renderDivergences } from '../render-divergences'
 
 runAdapterConformanceTests({
   name: 'mojo',
   factory: () => new MojoAdapter(),
   render: renderMojoComponent,
-  // Priority-12 edge-case sweep (炙り出し): fixtures below RENDER on real
-  // Mojolicious but diverge from the Hono reference byte comparison.
-  // Each entry names its divergence; graduating one means fixing the
-  // adapter (or shared compiler layer) and deleting the line.
-  skipJsx: [
-    // `(count() + 2) * 3` renders 10 instead of 18 — the parenthesised
-    // sub-expression loses its grouping in the lowering (silent wrong
-    // arithmetic; same finding as jinja/blade).
-    'arithmetic-text',
-    // `'Hello, ' + name + '!'` renders "0" — Perl's numeric `+` coerces
-    // the strings to numbers; JS string-concat `+` needs Perl's `.`.
-    'string-concat-plus',
-    // `.length` on a STRING prop diverges (array-length lowering
-    // misapplied to a scalar).
-    'string-length-text',
-    // The literal `¥` in template text reaches the output as U+FFFD —
-    // a UTF-8 encoding gap in the EP template pipeline for non-ASCII
-    // literal text adjacent to a dynamic slot.
-    'number-tofixed',
-    // `{false}` renders "false" (Hono drops it); `{null}`/`{undefined}`
-    // render empty (Hono renders "null"). Neither matches JSX semantics.
-    'falsy-text-values',
-    // `&copy;` in JSX literal text: Hono decodes to `©`, EP re-emits
-    // the raw entity — same DOM, different bytes.
-    'html-entity-text',
-    // Math.min/max/abs over a signal render EMPTY (only Math.floor is
-    // in the template-primitive registry).
-    'math-methods',
-    // camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`,
-    // EP emits bare presence.
-    'boolean-attr-literals',
-    // `htmlFor` is not lowered to `for` (Hono maps it).
-    'camelcase-attributes',
-    // Static attribute values are NOT HTML-escaped (`title="Fish &
-    // Chips"` raw vs Hono's `Fish &amp; Chips`).
-    'static-attr-escape',
-    // SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`)
-    // pass through unmapped; Hono lowers to kebab-case.
-    'svg-icon',
-    // `Object.entries(prop).map(([k, v]) => …)` renders an EMPTY <ul>.
-    'object-entries-map',
-    // Nested-loop inner items carry `data-key` where the reference
-    // emits the depth-suffixed `data-key-1`.
-    'nested-loop-outer-binding',
-    // JSX element as a NON-children prop renders an empty slot (the
-    // element value is silently dropped).
-    'jsx-element-prop',
-    // `.slice()` on a STRING misfires through the array slice helper.
-    'string-slice',
-    // `.trimStart()` / `.trimEnd()` render empty (no lowering).
-    'string-trim-sided',
-  ],
+  // Priority-12 edge-case sweep (炙り出し, #2168): render-level
+  // divergences are declared in `../render-divergences` (exported from the
+  // package index and published to `ui/compat.lock.json` / the docs
+  // compatibility-matrix page by `packages/compat`). Deriving the skip
+  // list from that object keeps the public declaration and these test
+  // skips from drifting; each entry's rationale lives there.
+  skipJsx: Object.keys(renderDivergences),
   // (Pre-sweep note) Otherwise no JSX-render skips: every shared conformance fixture — including
   // the composed `site/ui` demo corpus (#1467 / #1897) — renders to
   // Hono parity on real Mojolicious. `data-table` came off via the

--- a/packages/adapter-mojolicious/src/index.ts
+++ b/packages/adapter-mojolicious/src/index.ts
@@ -7,3 +7,4 @@
 export { MojoAdapter, mojoAdapter } from './adapter/index.ts'
 export type { MojoAdapterOptions } from './adapter/index.ts'
 export { conformancePins } from './conformance-pins.ts'
+export { renderDivergences } from './render-divergences.ts'

--- a/packages/adapter-mojolicious/src/render-divergences.ts
+++ b/packages/adapter-mojolicious/src/render-divergences.ts
@@ -1,0 +1,50 @@
+/**
+ * Render-level divergences against the shared conformance corpus
+ * (Priority-12 edge-case sweep, #2168): fixtures that COMPILE clean on
+ * this adapter but whose rendered output diverges from the Hono
+ * reference on real Mojolicious.
+ *
+ * Consumed by this package's conformance test (its `skipJsx` set is
+ * derived from these keys, so the skip list and this declaration can't
+ * drift) and by `packages/compat`, which publishes the entries in the
+ * fixture-divergences section of `ui/compat.lock.json` — surfaced on
+ * the docs compatibility-matrix page. Graduating an entry means fixing
+ * the adapter (or the shared compiler layer) and deleting the line.
+ */
+
+import type { RenderDivergences } from '@barefootjs/jsx'
+
+export const renderDivergences: RenderDivergences = {
+  'arithmetic-text':
+    '`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)',
+  'string-concat-plus':
+    "`'Hello, ' + name` renders \"0\" — Perl's numeric `+` coerces the strings; JS string-concat `+` needs Perl's `.`",
+  'string-length-text':
+    '`.length` on a STRING prop diverges (array-length lowering misapplied to a scalar)',
+  'number-tofixed':
+    'the literal `¥` in template text reaches the output as U+FFFD — a UTF-8 encoding gap for non-ASCII literal text adjacent to a dynamic slot',
+  'falsy-text-values':
+    '`{false}` renders "false" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders "null") — neither side matches JSX semantics',
+  'html-entity-text':
+    '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
+  'math-methods':
+    'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
+  'boolean-attr-literals':
+    'camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`, this adapter emits bare presence',
+  'camelcase-attributes':
+    '`htmlFor` is not lowered to `for` (Hono maps it)',
+  'static-attr-escape':
+    'static attribute values are not HTML-escaped (`title="Fish & Chips"` emitted raw; Hono escapes)',
+  'svg-icon':
+    'SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case',
+  'object-entries-map':
+    '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
+  'nested-loop-outer-binding':
+    'nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`',
+  'jsx-element-prop':
+    'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
+  'string-slice':
+    '`.slice()` on a STRING misfires through the array slice helper',
+  'string-trim-sided':
+    '`.trimStart()` / `.trimEnd()` render empty (no lowering)',
+}

--- a/packages/adapter-rust/src/__tests__/minijinja-adapter.test.ts
+++ b/packages/adapter-rust/src/__tests__/minijinja-adapter.test.ts
@@ -20,55 +20,19 @@ import { runAdapterConformanceTests } from '@barefootjs/adapter-tests'
 import { MinijinjaAdapter } from '../adapter'
 import { renderMinijinjaComponent, RustNotAvailableError } from '../test-render'
 import { conformancePins } from '../conformance-pins'
+import { renderDivergences } from '../render-divergences'
 
 runAdapterConformanceTests({
   name: 'minijinja',
   factory: () => new MinijinjaAdapter(),
   render: renderMinijinjaComponent,
-  // Priority-12 edge-case sweep (炙り出し): fixtures below RENDER through
-  // the real `bf-render` minijinja binary but diverge from the Hono
-  // reference byte comparison. Each entry names its divergence;
-  // graduating one means fixing the adapter (or shared compiler layer)
-  // and deleting the line. (`string-concat-plus` is NOT skipped here —
-  // minijinja's `+` concatenates strings, unlike Perl/PHP/Twig.)
-  skipJsx: [
-    // `(count() + 2) * 3` renders 10 instead of 18 — the parenthesised
-    // sub-expression loses its grouping in the lowering (silent wrong
-    // arithmetic; same finding as mojo/jinja/blade/twig).
-    'arithmetic-text',
-    // `{false}` renders "false" (Hono drops it); `{null}`/`{undefined}`
-    // render empty (Hono renders "null"). Neither matches JSX semantics.
-    'falsy-text-values',
-    // `&copy;` in JSX literal text: Hono decodes to `©`, minijinja
-    // re-emits the raw entity — same DOM, different bytes.
-    'html-entity-text',
-    // Math.min/max/abs over a signal render EMPTY (only Math.floor is
-    // in the template-primitive registry).
-    'math-methods',
-    // camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`,
-    // minijinja emits bare presence.
-    'boolean-attr-literals',
-    // `htmlFor` is not lowered to `for` (Hono maps it).
-    'camelcase-attributes',
-    // Static attribute values are NOT HTML-escaped (`title="Fish &
-    // Chips"` raw vs Hono's `Fish &amp; Chips`).
-    'static-attr-escape',
-    // SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`)
-    // pass through unmapped; Hono lowers to kebab-case.
-    'svg-icon',
-    // `Object.entries(prop).map(([k, v]) => …)` renders an EMPTY <ul>.
-    'object-entries-map',
-    // Nested-loop inner items carry `data-key` where the reference
-    // emits the depth-suffixed `data-key-1`.
-    'nested-loop-outer-binding',
-    // JSX element as a NON-children prop renders an empty slot (the
-    // element value is silently dropped).
-    'jsx-element-prop',
-    // `.slice()` on a STRING misfires through the array slice helper.
-    'string-slice',
-    // `.trimStart()` / `.trimEnd()` render empty (no lowering).
-    'string-trim-sided',
-  ],
+  // Priority-12 edge-case sweep (炙り出し, #2168): render-level
+  // divergences are declared in `../render-divergences` (exported from the
+  // package index and published to `ui/compat.lock.json` / the docs
+  // compatibility-matrix page by `packages/compat`). Deriving the skip
+  // list from that object keeps the public declaration and these test
+  // skips from drifting; each entry's rationale lives there.
+  skipJsx: Object.keys(renderDivergences),
   // Per-fixture build-time contracts for shapes the adapter intentionally
   // refuses to lower. Lives in `../conformance-pins` — mirrors
   // adapter-jinja's set (itself mirroring xslate's); the lowering gates

--- a/packages/adapter-rust/src/index.ts
+++ b/packages/adapter-rust/src/index.ts
@@ -10,3 +10,4 @@
 export { MinijinjaAdapter, minijinjaAdapter } from './adapter/index.ts'
 export type { MinijinjaAdapterOptions } from './adapter/index.ts'
 export { conformancePins } from './conformance-pins.ts'
+export { renderDivergences } from './render-divergences.ts'

--- a/packages/adapter-rust/src/render-divergences.ts
+++ b/packages/adapter-rust/src/render-divergences.ts
@@ -1,0 +1,46 @@
+/**
+ * Render-level divergences against the shared conformance corpus
+ * (Priority-12 edge-case sweep, #2168): fixtures that COMPILE clean on
+ * this adapter but whose rendered output diverges from the Hono
+ * reference through the real `bf-render` minijinja binary.
+ * (`string-concat-plus` is NOT here — minijinja's `+` concatenates
+ * strings, unlike Perl/PHP/Twig.)
+ *
+ * Consumed by this package's conformance test (its `skipJsx` set is
+ * derived from these keys, so the skip list and this declaration can't
+ * drift) and by `packages/compat`, which publishes the entries in the
+ * fixture-divergences section of `ui/compat.lock.json` — surfaced on
+ * the docs compatibility-matrix page. Graduating an entry means fixing
+ * the adapter (or the shared compiler layer) and deleting the line.
+ */
+
+import type { RenderDivergences } from '@barefootjs/jsx'
+
+export const renderDivergences: RenderDivergences = {
+  'arithmetic-text':
+    '`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)',
+  'falsy-text-values':
+    '`{false}` renders "false" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders "null") — neither side matches JSX semantics',
+  'html-entity-text':
+    '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
+  'math-methods':
+    'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
+  'boolean-attr-literals':
+    'camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`, this adapter emits bare presence',
+  'camelcase-attributes':
+    '`htmlFor` is not lowered to `for` (Hono maps it)',
+  'static-attr-escape':
+    'static attribute values are not HTML-escaped (`title="Fish & Chips"` emitted raw; Hono escapes)',
+  'svg-icon':
+    'SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case',
+  'object-entries-map':
+    '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
+  'nested-loop-outer-binding':
+    'nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`',
+  'jsx-element-prop':
+    'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
+  'string-slice':
+    '`.slice()` on a STRING renders empty (array-slice helper misfires on strings)',
+  'string-trim-sided':
+    '`.trimStart()` / `.trimEnd()` render empty (no lowering)',
+}

--- a/packages/adapter-twig/src/__tests__/twig-adapter.test.ts
+++ b/packages/adapter-twig/src/__tests__/twig-adapter.test.ts
@@ -15,56 +15,19 @@ import { runAdapterConformanceTests } from '@barefootjs/adapter-tests'
 import { TwigAdapter } from '../adapter'
 import { renderTwigComponent, TwigNotAvailableError } from '../test-render'
 import { conformancePins } from '../conformance-pins'
+import { renderDivergences } from '../render-divergences'
 
 runAdapterConformanceTests({
   name: 'twig',
   factory: () => new TwigAdapter(),
   render: renderTwigComponent,
-  // Priority-12 edge-case sweep (炙り出し): fixtures below RENDER on real
-  // PHP Twig but diverge from the Hono reference byte comparison. Each
-  // entry names its divergence; graduating one means fixing the adapter
-  // (or shared compiler layer) and deleting the line.
-  skipJsx: [
-    // `(count() + 2) * 3` renders 10 instead of 18 — the parenthesised
-    // sub-expression loses its grouping in the lowering (silent wrong
-    // arithmetic; same finding as mojo/jinja/blade).
-    'arithmetic-text',
-    // `'Hello, ' + name + '!'` lowers through Twig's numeric `+`
-    // instead of `~` string concat — same class as blade's PHP `+`.
-    'string-concat-plus',
-    // `{false}` renders "false" (Hono drops it); `{null}`/`{undefined}`
-    // render empty (Hono renders "null"). Neither matches JSX semantics.
-    'falsy-text-values',
-    // `&copy;` in JSX literal text: Hono decodes to `©`, Twig re-emits
-    // the raw entity — same DOM, different bytes.
-    'html-entity-text',
-    // Math.min/max/abs over a signal render EMPTY (only Math.floor is
-    // in the template-primitive registry).
-    'math-methods',
-    // camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`,
-    // Twig emits bare presence.
-    'boolean-attr-literals',
-    // `htmlFor` is not lowered to `for` (Hono maps it).
-    'camelcase-attributes',
-    // Static attribute values are NOT HTML-escaped (`title="Fish &
-    // Chips"` raw vs Hono's `Fish &amp; Chips`).
-    'static-attr-escape',
-    // SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`)
-    // pass through unmapped; Hono lowers to kebab-case.
-    'svg-icon',
-    // `Object.entries(prop).map(([k, v]) => …)` renders an EMPTY <ul>.
-    'object-entries-map',
-    // Nested-loop inner items carry `data-key` where the reference
-    // emits the depth-suffixed `data-key-1`.
-    'nested-loop-outer-binding',
-    // JSX element as a NON-children prop renders an empty slot (the
-    // element value is silently dropped).
-    'jsx-element-prop',
-    // `.slice()` on a STRING misfires through the array slice helper.
-    'string-slice',
-    // `.trimStart()` / `.trimEnd()` render empty (no lowering).
-    'string-trim-sided',
-  ],
+  // Priority-12 edge-case sweep (炙り出し, #2168): render-level
+  // divergences are declared in `../render-divergences` (exported from the
+  // package index and published to `ui/compat.lock.json` / the docs
+  // compatibility-matrix page by `packages/compat`). Deriving the skip
+  // list from that object keeps the public declaration and these test
+  // skips from drifting; each entry's rationale lives there.
+  skipJsx: Object.keys(renderDivergences),
   // Per-fixture build-time contracts for shapes the Twig adapter
   // intentionally refuses to lower. Lives in `../conformance-pins` —
   // mirrors Jinja's set (the lowering gates are shared code paths in

--- a/packages/adapter-twig/src/index.ts
+++ b/packages/adapter-twig/src/index.ts
@@ -7,3 +7,4 @@
 export { TwigAdapter, twigAdapter } from './adapter/index.ts'
 export type { TwigAdapterOptions } from './adapter/index.ts'
 export { conformancePins } from './conformance-pins.ts'
+export { renderDivergences } from './render-divergences.ts'

--- a/packages/adapter-twig/src/render-divergences.ts
+++ b/packages/adapter-twig/src/render-divergences.ts
@@ -1,0 +1,46 @@
+/**
+ * Render-level divergences against the shared conformance corpus
+ * (Priority-12 edge-case sweep, #2168): fixtures that COMPILE clean on
+ * this adapter but whose rendered output diverges from the Hono
+ * reference on real PHP Twig.
+ *
+ * Consumed by this package's conformance test (its `skipJsx` set is
+ * derived from these keys, so the skip list and this declaration can't
+ * drift) and by `packages/compat`, which publishes the entries in the
+ * fixture-divergences section of `ui/compat.lock.json` — surfaced on
+ * the docs compatibility-matrix page. Graduating an entry means fixing
+ * the adapter (or the shared compiler layer) and deleting the line.
+ */
+
+import type { RenderDivergences } from '@barefootjs/jsx'
+
+export const renderDivergences: RenderDivergences = {
+  'arithmetic-text':
+    '`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)',
+  'string-concat-plus':
+    "`'Hello, ' + name` lowers through Twig's numeric `+` instead of `~` string concat",
+  'falsy-text-values':
+    '`{false}` renders "false" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders "null") — neither side matches JSX semantics',
+  'html-entity-text':
+    '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
+  'math-methods':
+    'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
+  'boolean-attr-literals':
+    'camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`, this adapter emits bare presence',
+  'camelcase-attributes':
+    '`htmlFor` is not lowered to `for` (Hono maps it)',
+  'static-attr-escape':
+    'static attribute values are not HTML-escaped (`title="Fish & Chips"` emitted raw; Hono escapes)',
+  'svg-icon':
+    'SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case',
+  'object-entries-map':
+    '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
+  'nested-loop-outer-binding':
+    'nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`',
+  'jsx-element-prop':
+    'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
+  'string-slice':
+    '`.slice()` on a STRING misfires through the array slice helper',
+  'string-trim-sided':
+    '`.trimStart()` / `.trimEnd()` render empty (no lowering)',
+}

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -18,56 +18,19 @@ import { XslateAdapter } from '../adapter'
 import { renderXslateComponent, XslateNotAvailableError } from '../test-render'
 import { compileJSX, type ComponentIR } from '@barefootjs/jsx'
 import { conformancePins } from '../conformance-pins'
+import { renderDivergences } from '../render-divergences'
 
 runAdapterConformanceTests({
   name: 'xslate',
   factory: () => new XslateAdapter(),
   render: renderXslateComponent,
-  // Priority-12 edge-case sweep (炙り出し): fixtures below RENDER on real
-  // Text::Xslate but diverge from the Hono reference byte comparison.
-  // Each entry names its divergence; graduating one means fixing the
-  // adapter (or shared compiler layer) and deleting the line.
-  skipJsx: [
-    // `(count() + 2) * 3` renders 10 instead of 18 — the parenthesised
-    // sub-expression loses its grouping in the lowering (silent wrong
-    // arithmetic; same finding as mojo/jinja/blade).
-    'arithmetic-text',
-    // `'Hello, ' + name + '!'` numeric-coerces through Perl's `+`
-    // (needs `.` / `~` concat) — same finding as mojo.
-    'string-concat-plus',
-    // `{false}` renders "false" (Hono drops it); `{null}`/`{undefined}`
-    // render empty (Hono renders "null"). Neither matches JSX semantics.
-    'falsy-text-values',
-    // `&copy;` in JSX literal text: Hono decodes to `©`, Kolon re-emits
-    // the raw entity — same DOM, different bytes.
-    'html-entity-text',
-    // Math.min/max/abs over a signal render EMPTY (only Math.floor is
-    // in the template-primitive registry).
-    'math-methods',
-    // camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`,
-    // Kolon emits bare presence.
-    'boolean-attr-literals',
-    // `htmlFor` is not lowered to `for` (Hono maps it).
-    'camelcase-attributes',
-    // Static attribute values are NOT HTML-escaped (`title="Fish &
-    // Chips"` raw vs Hono's `Fish &amp; Chips`).
-    'static-attr-escape',
-    // SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`)
-    // pass through unmapped; Hono lowers to kebab-case.
-    'svg-icon',
-    // `Object.entries(prop).map(([k, v]) => …)` renders an EMPTY <ul>.
-    'object-entries-map',
-    // Nested-loop inner items carry `data-key` where the reference
-    // emits the depth-suffixed `data-key-1`.
-    'nested-loop-outer-binding',
-    // JSX element as a NON-children prop renders an empty slot (the
-    // element value is silently dropped).
-    'jsx-element-prop',
-    // `.slice()` on a STRING misfires through the array slice helper.
-    'string-slice',
-    // `.trimStart()` / `.trimEnd()` render empty (no lowering).
-    'string-trim-sided',
-  ],
+  // Priority-12 edge-case sweep (炙り出し, #2168): render-level
+  // divergences are declared in `../render-divergences` (exported from the
+  // package index and published to `ui/compat.lock.json` / the docs
+  // compatibility-matrix page by `packages/compat`). Deriving the skip
+  // list from that object keeps the public declaration and these test
+  // skips from drifting; each entry's rationale lives there.
+  skipJsx: Object.keys(renderDivergences),
   // (Pre-sweep note) Otherwise no JSX-render skips: every shared conformance fixture — including
   // the composed `site/ui` demo corpus (#1467 / #1897) — renders to
   // Hono parity on real Text::Xslate. `data-table` came off via the

--- a/packages/adapter-xslate/src/index.ts
+++ b/packages/adapter-xslate/src/index.ts
@@ -7,3 +7,4 @@
 export { XslateAdapter, xslateAdapter } from './adapter/index.ts'
 export type { XslateAdapterOptions } from './adapter/index.ts'
 export { conformancePins } from './conformance-pins.ts'
+export { renderDivergences } from './render-divergences.ts'

--- a/packages/adapter-xslate/src/render-divergences.ts
+++ b/packages/adapter-xslate/src/render-divergences.ts
@@ -1,0 +1,46 @@
+/**
+ * Render-level divergences against the shared conformance corpus
+ * (Priority-12 edge-case sweep, #2168): fixtures that COMPILE clean on
+ * this adapter but whose rendered output diverges from the Hono
+ * reference on real Text::Xslate.
+ *
+ * Consumed by this package's conformance test (its `skipJsx` set is
+ * derived from these keys, so the skip list and this declaration can't
+ * drift) and by `packages/compat`, which publishes the entries in the
+ * fixture-divergences section of `ui/compat.lock.json` — surfaced on
+ * the docs compatibility-matrix page. Graduating an entry means fixing
+ * the adapter (or the shared compiler layer) and deleting the line.
+ */
+
+import type { RenderDivergences } from '@barefootjs/jsx'
+
+export const renderDivergences: RenderDivergences = {
+  'arithmetic-text':
+    '`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)',
+  'string-concat-plus':
+    "`'Hello, ' + name` numeric-coerces through Perl's `+` (needs `.`/`~` concat)",
+  'falsy-text-values':
+    '`{false}` renders "false" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders "null") — neither side matches JSX semantics',
+  'html-entity-text':
+    '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
+  'math-methods':
+    'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
+  'boolean-attr-literals':
+    'camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`, this adapter emits bare presence',
+  'camelcase-attributes':
+    '`htmlFor` is not lowered to `for` (Hono maps it)',
+  'static-attr-escape':
+    'static attribute values are not HTML-escaped (`title="Fish & Chips"` emitted raw; Hono escapes)',
+  'svg-icon':
+    'SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case',
+  'object-entries-map':
+    '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
+  'nested-loop-outer-binding':
+    'nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`',
+  'jsx-element-prop':
+    'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
+  'string-slice':
+    '`.slice()` on a STRING misfires through the array slice helper',
+  'string-trim-sided':
+    '`.trimStart()` / `.trimEnd()` render empty (no lowering)',
+}

--- a/packages/cli/src/lib/adapters/hono.ts
+++ b/packages/cli/src/lib/adapters/hono.ts
@@ -231,7 +231,14 @@ export const HONO_ADAPTER: AdapterTemplate = {
   devDependencies: {
     ...UNOCSS_DEV_DEPENDENCIES,
     '@barefootjs/cli': 'latest',
-    '@cloudflare/workers-types': '^4.20250101.0',
+    // Must track wrangler's `peerOptional @cloudflare/workers-types`
+    // MAJOR: wrangler 4.108.0 moved it to `^5.20260706.1`, and with the
+    // v4 pin every fresh scaffold's `npm install` fails with ERESOLVE
+    // (bun tolerates the mismatch; npm does not — CI's smoke-publish
+    // caught it). v5 still ships a root `index.d.ts`, so the generated
+    // tsconfig's `"types": ["@cloudflare/workers-types", ...]` entry
+    // resolves unchanged.
+    '@cloudflare/workers-types': '^5.20260706.1',
     // `@barefootjs/test` powers `renderToTest()` — the canonical
     // millisecond IR test the docs (and `bf gen test`) point new users
     // at. Without it the scaffold's `test` script is a no-op and any

--- a/packages/compat/src/__tests__/render-divergences.test.ts
+++ b/packages/compat/src/__tests__/render-divergences.test.ts
@@ -1,0 +1,75 @@
+// The consistency gate for `renderDivergences` — the render-level sibling
+// of compat-pins.test.ts. Every entry an adapter package declares must:
+//
+//  (a) point at a real fixture in the shared corpus (catches stale
+//      entries left behind after a fixture is renamed/removed),
+//  (b) NOT overlap that adapter's `conformancePins` — a fixture is either
+//      refused at build time (pin) or renders divergently (this list),
+//      never both on one adapter (the render skip would be unreachable
+//      in its conformance suite), and
+//  (c) actually COMPILE clean on that adapter (no error-severity
+//      diagnostics) when compiled the way the conformance suite compiles
+//      it — a render-divergence entry whose fixture stops compiling
+//      belongs in `conformancePins` instead, and this test forces that
+//      migration rather than letting the docs page mislabel the gap.
+//
+// Same relative `jsxFixtures` import precedent as compat-pins.test.ts.
+
+import { describe, test, expect } from 'bun:test'
+import { jsxFixtures } from '../../../adapter-tests/fixtures'
+import { loadCompatAdapters } from '../adapter-registry'
+import { compileForCompat } from '../engine'
+
+const { loaded } = await loadCompatAdapters()
+
+describe('renderDivergences consistency', () => {
+  for (const adapter of loaded) {
+    describe(adapter.id, () => {
+      const fixtureIds = Object.keys(adapter.renderDivergences)
+
+      if (fixtureIds.length === 0) {
+        test('declares no render divergences', () => {
+          expect(fixtureIds).toEqual([])
+        })
+        return
+      }
+
+      test('no fixture is both pinned and render-divergent', () => {
+        const overlap = fixtureIds.filter(id => id in adapter.pins)
+        expect(overlap).toEqual([])
+      })
+
+      for (const fixtureId of fixtureIds) {
+        test(`[${fixtureId}] exists in the corpus and compiles clean`, () => {
+          const fixture = jsxFixtures.find(f => f.id === fixtureId)
+          if (!fixture) {
+            throw new Error(
+              `stale render-divergence: adapter '${adapter.id}' declares fixture '${fixtureId}', which does not exist in jsxFixtures`,
+            )
+          }
+
+          const reason = adapter.renderDivergences[fixtureId]
+          expect(typeof reason).toBe('string')
+          expect(reason.length).toBeGreaterThan(0)
+
+          const instance = adapter.factory()
+          const errors = compileForCompat(
+            fixture.source,
+            'component.tsx',
+            instance,
+            'conformance',
+            fixture.components,
+          )
+          const errorSeverity = errors.filter(e => e.severity === 'error')
+          if (errorSeverity.length > 0) {
+            const seen = errorSeverity.map(e => `${e.severity}/${e.code}`).join(', ')
+            throw new Error(
+              `render-divergence '${fixtureId}' on '${adapter.id}' no longer compiles clean (${seen}) — ` +
+                `move it to conformancePins (build-time refusal) instead`,
+            )
+          }
+        })
+      }
+    })
+  }
+})

--- a/packages/compat/src/adapter-registry.ts
+++ b/packages/compat/src/adapter-registry.ts
@@ -15,7 +15,7 @@
 // crash, keeping the loader total. The monorepo always has all 9
 // installed, so a run from this repo loads every adapter.
 
-import type { ConformancePins, TemplateAdapter } from '@barefootjs/jsx'
+import type { ConformancePins, RenderDivergences, TemplateAdapter } from '@barefootjs/jsx'
 
 interface CompatAdapterSpec {
   pkg: string
@@ -48,6 +48,13 @@ export interface LoadedCompatAdapter {
   factory: () => TemplateAdapter
   /** The package's exported `conformancePins`, or `{}` when it exports none. */
   pins: ConformancePins
+  /**
+   * The package's exported `renderDivergences` (fixtures that compile
+   * clean but render differently from the Hono reference on the
+   * adapter's real backend — see the type's docstring in
+   * `@barefootjs/jsx`), or `{}` when it exports none.
+   */
+  renderDivergences: RenderDivergences
 }
 
 export interface SkippedCompatAdapter {
@@ -85,6 +92,7 @@ export async function loadCompatAdapters(): Promise<{
     }
 
     const pins = (mod.conformancePins as ConformancePins | undefined) ?? {}
+    const renderDivergences = (mod.renderDivergences as RenderDivergences | undefined) ?? {}
     // One throwaway instance just to read `.name` — the real per-compile
     // instances always come from `factory()` below.
     const probe = new AdapterClass()
@@ -93,6 +101,7 @@ export async function loadCompatAdapters(): Promise<{
       pkg: spec.pkg,
       factory: () => new AdapterClass(),
       pins,
+      renderDivergences,
     })
   }
 

--- a/packages/compat/src/cli.ts
+++ b/packages/compat/src/cli.ts
@@ -32,7 +32,7 @@ import { fileURLToPath } from 'node:url'
 import path from 'path'
 import { loadCompatAdapters } from './adapter-registry'
 import { buildCompatCell, compileForCompat, type CompatCell } from './engine'
-import { buildCompatReport, formatCompatJson, formatCompatMarkdown, type CompatReport } from './report'
+import { buildCompatReport, buildFixtureDivergences, formatCompatJson, formatCompatMarkdown, type CompatReport } from './report'
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..')
 const COMPONENTS_DIR = path.join(REPO_ROOT, 'ui/components/ui')
@@ -219,7 +219,18 @@ async function main(): Promise<void> {
     cells[target.name] = row
   }
 
-  const report = buildCompatReport(cells)
+  // Fixture-level divergences (render honesty section, #2168): every
+  // adapter's declared `conformancePins` (build-time refusals) +
+  // `renderDivergences` (renders but diverges from the Hono reference),
+  // published alongside the component matrix so the docs
+  // compatibility-matrix page reports render-level gaps instead of
+  // showing only the all-green compile story. `jsxFixtures` is imported
+  // relatively (same precedent as `compat-pins.test.ts` — it isn't part
+  // of adapter-tests' public export map) purely for the corpus total.
+  const { jsxFixtures } = await import('../../adapter-tests/fixtures')
+  const fixtureDivergences = buildFixtureDivergences(loaded, jsxFixtures.length)
+
+  const report = buildCompatReport(cells, fixtureDivergences)
   const text = jsonFlag ? formatCompatJson(report) : formatCompatMarkdown(report)
 
   if (outPath) {

--- a/packages/compat/src/report.ts
+++ b/packages/compat/src/report.ts
@@ -20,6 +20,42 @@ export interface CompatReportCell {
   diagnostics?: CompatCell['diagnostics']
 }
 
+/**
+ * One fixture × adapter divergence cell in the fixture-divergences
+ * section. Two kinds:
+ *
+ * - `'refusal'` — the adapter refuses the shape at BUILD time with the
+ *   listed diagnostic codes (from the package's `conformancePins`).
+ * - `'render'` — the fixture COMPILES clean but its rendered output
+ *   diverges from the Hono reference on the adapter's real backend
+ *   (from the package's `renderDivergences`); `reason` is the
+ *   one-line description.
+ */
+export interface FixtureDivergenceCell {
+  kind: 'refusal' | 'render'
+  /** Diagnostic codes for refusals (sorted), e.g. `["BF101"]`. */
+  codes?: string[]
+  /** Known-limitation issue URLs for refusals (sorted, deduped). */
+  issues?: string[]
+  /** One-line divergence description for render-kind cells. */
+  reason?: string
+}
+
+export const FIXTURE_DIVERGENCES_NOTE =
+  'Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered ' +
+  'through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed ' +
+  'here diverge on at least one adapter — either refused loudly at build time (conformancePins) or ' +
+  'rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance ' +
+  'suite until fixed). Fixtures absent from this table render to reference parity on every adapter.'
+
+export interface FixtureDivergences {
+  note: string
+  /** Total shared-corpus fixture count, for the "N of M clean" summary. */
+  totalFixtures: number
+  /** Fixture id → adapter id → divergence cell. Clean cells are omitted. */
+  fixtures: Record<string, Record<string, FixtureDivergenceCell>>
+}
+
 export interface CompatReport {
   note: string
   knownLimitationLabel: string
@@ -27,6 +63,62 @@ export interface CompatReport {
   adapters: string[]
   /** Component name → adapter id → cell. */
   components: Record<string, Record<string, CompatReportCell>>
+  /** Fixture-level divergences (build-time refusals + render divergences). */
+  fixtureDivergences: FixtureDivergences
+}
+
+/**
+ * Assemble the deterministic fixture-divergences section from each
+ * adapter's declared `conformancePins` + `renderDivergences`. Sorted
+ * fixture ids, sorted adapter keys within each fixture, sorted codes /
+ * issue URLs — same byte-stability contract as the component matrix.
+ */
+export function buildFixtureDivergences(
+  adapters: ReadonlyArray<{
+    id: string
+    pins: Record<string, ReadonlyArray<{ code: string; severity: 'error' | 'warning'; issue?: string }>>
+    renderDivergences: Record<string, string>
+  }>,
+  totalFixtures: number,
+): FixtureDivergences {
+  const byFixture = new Map<string, Map<string, FixtureDivergenceCell>>()
+  const cellsOf = (fixtureId: string): Map<string, FixtureDivergenceCell> => {
+    let m = byFixture.get(fixtureId)
+    if (!m) {
+      m = new Map()
+      byFixture.set(fixtureId, m)
+    }
+    return m
+  }
+
+  for (const adapter of adapters) {
+    for (const [fixtureId, pins] of Object.entries(adapter.pins)) {
+      const codes = [...new Set(pins.map(p => p.code))].sort()
+      const issues = [...new Set(pins.flatMap(p => (p.issue ? [p.issue] : [])))].sort()
+      const cell: FixtureDivergenceCell = { kind: 'refusal', codes }
+      if (issues.length > 0) cell.issues = issues
+      cellsOf(fixtureId).set(adapter.id, cell)
+    }
+    for (const [fixtureId, reason] of Object.entries(adapter.renderDivergences)) {
+      // A fixture can't be both refused and render-divergent on ONE
+      // adapter — pins win if an adapter ever declares both (the render
+      // skip would be unreachable in its conformance suite anyway).
+      if (cellsOf(fixtureId).has(adapter.id)) continue
+      cellsOf(fixtureId).set(adapter.id, { kind: 'render', reason })
+    }
+  }
+
+  const fixtures: FixtureDivergences['fixtures'] = {}
+  for (const fixtureId of [...byFixture.keys()].sort()) {
+    const row: Record<string, FixtureDivergenceCell> = {}
+    const cells = byFixture.get(fixtureId)!
+    for (const adapterId of [...cells.keys()].sort()) {
+      row[adapterId] = cells.get(adapterId)!
+    }
+    fixtures[fixtureId] = row
+  }
+
+  return { note: FIXTURE_DIVERGENCES_NOTE, totalFixtures, fixtures }
 }
 
 /**
@@ -36,7 +128,10 @@ export interface CompatReport {
  * the union of columns actually present, so a caller that only ran a
  * subset of adapters still gets a valid, ordered report.
  */
-export function buildCompatReport(cells: Record<string, Record<string, CompatCell>>): CompatReport {
+export function buildCompatReport(
+  cells: Record<string, Record<string, CompatCell>>,
+  fixtureDivergences?: FixtureDivergences,
+): CompatReport {
   const adapterIds = new Set<string>()
   for (const row of Object.values(cells)) {
     for (const id of Object.keys(row)) adapterIds.add(id)
@@ -61,7 +156,14 @@ export function buildCompatReport(cells: Record<string, Record<string, CompatCel
     components[name] = row
   }
 
-  return { note: COMPAT_NOTE, knownLimitationLabel: KNOWN_LIMITATION_LABEL, adapters, components }
+  return {
+    note: COMPAT_NOTE,
+    knownLimitationLabel: KNOWN_LIMITATION_LABEL,
+    adapters,
+    components,
+    fixtureDivergences:
+      fixtureDivergences ?? { note: FIXTURE_DIVERGENCES_NOTE, totalFixtures: 0, fixtures: {} },
+  }
 }
 
 /** Lock-file JSON: 2-space indent, trailing newline. */
@@ -111,6 +213,35 @@ export function formatCompatMarkdown(report: CompatReport): string {
   for (const code of [...issuesByCode.keys()].sort()) {
     const urls = [...issuesByCode.get(code)!].sort()
     lines.push(`- \`${code}\`: ${urls.length > 0 ? urls.join(', ') : report.knownLimitationLabel}`)
+  }
+
+  // Fixture-level divergences (render honesty section). Rendered only
+  // when the report carries entries — the section is keyed by fixture,
+  // with each adapter's refusal codes or a `≠` render-divergence marker.
+  const fixtureIds = Object.keys(report.fixtureDivergences?.fixtures ?? {})
+  if (fixtureIds.length > 0) {
+    const fd = report.fixtureDivergences
+    lines.push('')
+    lines.push('Fixture divergences (conformance corpus):')
+    lines.push('')
+    lines.push(fd.note)
+    lines.push('')
+    lines.push(`${fixtureIds.length} of ${fd.totalFixtures} fixtures diverge on at least one adapter.`)
+    lines.push('')
+    lines.push(`| fixture | ${report.adapters.join(' | ')} |`)
+    lines.push(`| --- | ${report.adapters.map(() => '---').join(' | ')} |`)
+    for (const fixtureId of fixtureIds.sort()) {
+      const row = fd.fixtures[fixtureId]
+      const cellText = report.adapters.map(id => {
+        const cell = row[id]
+        if (!cell) return '✓'
+        return cell.kind === 'refusal' ? (cell.codes ?? []).join(', ') : '≠'
+      })
+      lines.push(`| ${fixtureId} | ${cellText.join(' | ')} |`)
+    }
+    lines.push('')
+    lines.push('`≠` = compiles clean but the rendered output diverges from the Hono reference')
+    lines.push('(see each adapter package’s `render-divergences.ts` for the per-fixture rationale).')
   }
 
   return lines.join('\n') + '\n'

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -55,6 +55,7 @@ export type {
   CompilerError,
   ConformancePin,
   ConformancePins,
+  RenderDivergences,
 } from './types.ts'
 
 // Analyzer

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -1766,6 +1766,21 @@ export interface ConformancePin {
 /** Keyed by shared-fixture id (`JSXFixture.id`). */
 export type ConformancePins = Record<string, ReadonlyArray<ConformancePin>>
 
+/**
+ * Render-level divergences an adapter declares against the shared
+ * conformance corpus (packages/adapter-tests): fixtures that COMPILE
+ * clean but whose rendered output diverges from the Hono reference on
+ * the adapter's real backend. The machine-readable sibling of
+ * `ConformancePins` (which covers compile-time refusals): consumed by
+ * the adapter's own conformance test (as its `skipJsx` set — the test
+ * file derives the skip list from this object so the two can't drift)
+ * and by `packages/compat` (the fixture-divergences section of
+ * `ui/compat.lock.json`, rendered on the docs compatibility-matrix
+ * page). Keyed by shared-fixture id; the value is a one-line
+ * human-readable description of the divergence.
+ */
+export type RenderDivergences = Record<string, string>
+
 // =============================================================================
 // Compile Options & Results
 // =============================================================================

--- a/site/core/pages/compat-matrix.tsx
+++ b/site/core/pages/compat-matrix.tsx
@@ -32,11 +32,26 @@ interface CompatCell {
   diagnostics?: CompatDiagnostic[]
 }
 
+interface FixtureDivergenceCell {
+  kind: 'refusal' | 'render'
+  codes?: string[]
+  issues?: string[]
+  reason?: string
+}
+
+interface FixtureDivergences {
+  note: string
+  totalFixtures: number
+  fixtures: Record<string, Record<string, FixtureDivergenceCell>>
+}
+
 interface CompatLock {
   note: string
   knownLimitationLabel: string
   adapters: string[]
   components: Record<string, Record<string, CompatCell>>
+  /** Optional: locks generated before #2168's render-honesty section lack it. */
+  fixtureDivergences?: FixtureDivergences
 }
 
 const compat = lock as CompatLock
@@ -122,11 +137,90 @@ function buildLegend(): string {
     .join('\n')
 }
 
+/**
+ * Render one fixture-divergence cell: refusal cells show their diagnostic
+ * codes (linked to the tracking issue when one exists), render-divergence
+ * cells show a `≠` marker (detail lives in the per-fixture list below the
+ * table — 9 columns of prose would be unreadable).
+ */
+function fixtureCellMarkdown(cell: FixtureDivergenceCell | undefined): string {
+  if (!cell) return '✓'
+  if (cell.kind === 'refusal') {
+    const codes = cell.codes ?? []
+    const firstIssue = cell.issues?.[0]
+    const label = codes.join(', ') || 'refused'
+    return firstIssue ? `[${label}](${firstIssue})` : label
+  }
+  return '≠'
+}
+
+/**
+ * Per-fixture detail list: adapters sharing an identical reason string are
+ * grouped onto one line, so the common "same divergence everywhere" case
+ * reads as a single sentence instead of nine copies.
+ */
+function buildFixtureDetails(fd: FixtureDivergences): string {
+  const blocks: string[] = []
+  for (const fixtureId of Object.keys(fd.fixtures).sort()) {
+    const row = fd.fixtures[fixtureId]
+    const byText = new Map<string, string[]>()
+    for (const adapterId of Object.keys(row).sort()) {
+      const cell = row[adapterId]
+      const text =
+        cell.kind === 'refusal'
+          ? `refused at build time with ${(cell.codes ?? []).map((c) => `\`${c}\``).join(', ')}`
+          : (cell.reason ?? 'rendered output diverges from the Hono reference')
+      const adapters = byText.get(text) ?? []
+      adapters.push(adapterId)
+      byText.set(text, adapters)
+    }
+    const lines = [...byText.entries()].map(
+      ([text, adapters]) => `  - ${adapters.map((a) => `\`${a}\``).join(', ')} — ${escapeCell(text)}`,
+    )
+    blocks.push(`- **\`${fixtureId}\`**\n${lines.join('\n')}`)
+  }
+  return blocks.join('\n')
+}
+
+/** The render-honesty section: fixture × adapter divergence table + detail list. */
+function buildFixtureSection(): string {
+  const fd = compat.fixtureDivergences
+  if (!fd || Object.keys(fd.fixtures).length === 0) return ''
+
+  const fixtureIds = Object.keys(fd.fixtures).sort()
+  const adapters = compat.adapters
+  const cleanCount = fd.totalFixtures - fixtureIds.length
+
+  const header = `| Fixture | ${adapters.join(' | ')} |`
+  const divider = `| --- | ${adapters.map(() => '---').join(' | ')} |`
+  const rows = fixtureIds.map((id) => {
+    const cells = adapters.map((adapter) => fixtureCellMarkdown(fd.fixtures[id]?.[adapter]))
+    return `| \`${escapeCell(id)}\` | ${cells.join(' | ')} |`
+  })
+
+  return `
+## Render Conformance (fixture corpus)
+
+The component matrix above is **compile-time only**. This section reports the **render-level** state honestly: the shared conformance corpus (\`packages/adapter-tests\`) is rendered through every adapter's real backend (Go, Ruby, Perl, PHP, Python, Rust) and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (\`conformancePins\`) or rendering differently from the reference (\`renderDivergences\`, skipped in that adapter's conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.
+
+**${cleanCount} / ${fd.totalFixtures} fixtures render to reference parity on every adapter.** The ${fixtureIds.length} below diverge on at least one:
+
+${[header, divider, ...rows].join('\n')}
+
+\`✓\` renders to reference parity · \`≠\` compiles clean but the rendered output diverges (skipped in that adapter's conformance suite until fixed) · a diagnostic code means the adapter refuses the shape loudly at build time.
+
+### Divergence details
+
+${buildFixtureDetails(fd)}
+`
+}
+
 function buildMarkdown(): string {
   const componentNames = Object.keys(compat.components).sort()
   const summary = buildSummary(componentNames)
   const table = buildTable(componentNames)
   const legend = buildLegend()
+  const fixtureSection = buildFixtureSection()
 
   return `# ${TITLE}
 
@@ -143,10 +237,10 @@ ${table}
 Each diagnostic code below links to the known-limitation issue(s) tracking it. Codes with no linked issue fall back to the repo-wide [\`known-limitation\`](${compat.knownLimitationLabel}) label.
 
 ${legend}
-
+${fixtureSection}
 ## Data Source
 
-This table is generated from the committed [\`ui/compat.lock.json\`](https://github.com/piconic-ai/barefootjs/blob/main/ui/compat.lock.json), regenerated with \`bun run compat:lock\` and drift-checked in CI. Tracked limitations carry the [\`known-limitation\`](${compat.knownLimitationLabel}) label.
+This table is generated from the committed [\`ui/compat.lock.json\`](https://github.com/piconic-ai/barefootjs/blob/main/ui/compat.lock.json), regenerated with \`bun run compat:lock\` and drift-checked in CI. Render-level divergences are declared per adapter in \`packages/adapter-*/src/render-divergences.ts\` (each adapter's conformance suite derives its skip list from the same declaration, so this page and the tests cannot drift apart). Tracked limitations carry the [\`known-limitation\`](${compat.knownLimitationLabel}) label.
 `
 }
 

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1811,5 +1811,1073 @@
         "ok": true
       }
     }
+  },
+  "fixtureDivergences": {
+    "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
+    "totalFixtures": 236,
+    "fixtures": {
+      "arithmetic-text": {
+        "blade": {
+          "kind": "render",
+          "reason": "`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)"
+        },
+        "jinja": {
+          "kind": "render",
+          "reason": "`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)"
+        },
+        "minijinja": {
+          "kind": "render",
+          "reason": "`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)"
+        },
+        "mojolicious": {
+          "kind": "render",
+          "reason": "`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)"
+        },
+        "twig": {
+          "kind": "render",
+          "reason": "`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)"
+        },
+        "xslate": {
+          "kind": "render",
+          "reason": "`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)"
+        }
+      },
+      "array-map-function-reference": {
+        "blade": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "erb": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "go-template": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "jinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "minijinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "mojolicious": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "twig": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "xslate": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        }
+      },
+      "boolean-attr-literals": {
+        "blade": {
+          "kind": "render",
+          "reason": "camelCase boolean alias `readOnly`: Hono SSRs `readOnly=\"true\"`, this adapter emits bare presence"
+        },
+        "erb": {
+          "kind": "render",
+          "reason": "camelCase boolean alias `readOnly`: Hono SSRs `readOnly=\"true\"`, this adapter emits bare presence"
+        },
+        "go-template": {
+          "kind": "render",
+          "reason": "camelCase boolean alias `readOnly`: Hono SSRs `readOnly=\"true\"`, this adapter emits bare presence"
+        },
+        "jinja": {
+          "kind": "render",
+          "reason": "camelCase boolean alias `readOnly`: Hono SSRs `readOnly=\"true\"`, this adapter emits bare presence"
+        },
+        "minijinja": {
+          "kind": "render",
+          "reason": "camelCase boolean alias `readOnly`: Hono SSRs `readOnly=\"true\"`, this adapter emits bare presence"
+        },
+        "mojolicious": {
+          "kind": "render",
+          "reason": "camelCase boolean alias `readOnly`: Hono SSRs `readOnly=\"true\"`, this adapter emits bare presence"
+        },
+        "twig": {
+          "kind": "render",
+          "reason": "camelCase boolean alias `readOnly`: Hono SSRs `readOnly=\"true\"`, this adapter emits bare presence"
+        },
+        "xslate": {
+          "kind": "render",
+          "reason": "camelCase boolean alias `readOnly`: Hono SSRs `readOnly=\"true\"`, this adapter emits bare presence"
+        }
+      },
+      "camelcase-attributes": {
+        "blade": {
+          "kind": "render",
+          "reason": "`htmlFor` is not lowered to `for` (Hono maps it)"
+        },
+        "erb": {
+          "kind": "render",
+          "reason": "`htmlFor` is not lowered to `for` (Hono maps it)"
+        },
+        "go-template": {
+          "kind": "render",
+          "reason": "`htmlFor` is not lowered to `for` (Hono maps it)"
+        },
+        "jinja": {
+          "kind": "render",
+          "reason": "`htmlFor` is not lowered to `for` (Hono maps it)"
+        },
+        "minijinja": {
+          "kind": "render",
+          "reason": "`htmlFor` is not lowered to `for` (Hono maps it)"
+        },
+        "mojolicious": {
+          "kind": "render",
+          "reason": "`htmlFor` is not lowered to `for` (Hono maps it)"
+        },
+        "twig": {
+          "kind": "render",
+          "reason": "`htmlFor` is not lowered to `for` (Hono maps it)"
+        },
+        "xslate": {
+          "kind": "render",
+          "reason": "`htmlFor` is not lowered to `for` (Hono maps it)"
+        }
+      },
+      "child-primitive-props": {
+        "go-template": {
+          "kind": "render",
+          "reason": "numeric/boolean LITERAL props on a child (`count={5}` `active={true}`) render as Go zero values (0 / false)"
+        }
+      },
+      "dangerous-inner-html": {
+        "blade": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "erb": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "go-template": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "jinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "minijinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "mojolicious": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "twig": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "xslate": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        }
+      },
+      "falsy-text-values": {
+        "blade": {
+          "kind": "render",
+          "reason": "`{false}` renders \"false\" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders \"null\") — neither side matches JSX semantics"
+        },
+        "erb": {
+          "kind": "render",
+          "reason": "`{false}` renders \"false\" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders \"null\") — neither side matches JSX semantics"
+        },
+        "go-template": {
+          "kind": "render",
+          "reason": "`{false}` renders \"false\" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders \"null\") — neither side matches JSX semantics"
+        },
+        "jinja": {
+          "kind": "render",
+          "reason": "`{false}` renders \"false\" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders \"null\") — neither side matches JSX semantics"
+        },
+        "minijinja": {
+          "kind": "render",
+          "reason": "`{false}` renders \"false\" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders \"null\") — neither side matches JSX semantics"
+        },
+        "mojolicious": {
+          "kind": "render",
+          "reason": "`{false}` renders \"false\" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders \"null\") — neither side matches JSX semantics"
+        },
+        "twig": {
+          "kind": "render",
+          "reason": "`{false}` renders \"false\" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders \"null\") — neither side matches JSX semantics"
+        },
+        "xslate": {
+          "kind": "render",
+          "reason": "`{false}` renders \"false\" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders \"null\") — neither side matches JSX semantics"
+        }
+      },
+      "filter-nested-callback-predicate": {
+        "blade": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2038"
+          ]
+        },
+        "go-template": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2038"
+          ]
+        },
+        "jinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2038"
+          ]
+        },
+        "minijinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2038"
+          ]
+        },
+        "twig": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2038"
+          ]
+        },
+        "xslate": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2038"
+          ]
+        }
+      },
+      "filter-nested-find-predicate": {
+        "blade": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2038"
+          ]
+        },
+        "erb": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2038"
+          ]
+        },
+        "go-template": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2038"
+          ]
+        },
+        "jinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2038"
+          ]
+        },
+        "minijinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2038"
+          ]
+        },
+        "mojolicious": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2038"
+          ]
+        },
+        "twig": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2038"
+          ]
+        },
+        "xslate": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2038"
+          ]
+        }
+      },
+      "grandchild-composition": {
+        "go-template": {
+          "kind": "render",
+          "reason": "three-level composition: the grandchild's threaded prop renders EMPTY — prop forwarding through two template-render layers loses the value"
+        }
+      },
+      "html-entity-text": {
+        "blade": {
+          "kind": "render",
+          "reason": "`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes"
+        },
+        "erb": {
+          "kind": "render",
+          "reason": "`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes"
+        },
+        "go-template": {
+          "kind": "render",
+          "reason": "`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes"
+        },
+        "jinja": {
+          "kind": "render",
+          "reason": "`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes"
+        },
+        "minijinja": {
+          "kind": "render",
+          "reason": "`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes"
+        },
+        "mojolicious": {
+          "kind": "render",
+          "reason": "`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes"
+        },
+        "twig": {
+          "kind": "render",
+          "reason": "`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes"
+        },
+        "xslate": {
+          "kind": "render",
+          "reason": "`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes"
+        }
+      },
+      "jsx-element-prop": {
+        "blade": {
+          "kind": "render",
+          "reason": "a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped"
+        },
+        "erb": {
+          "kind": "render",
+          "reason": "a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped"
+        },
+        "go-template": {
+          "kind": "render",
+          "reason": "a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped"
+        },
+        "jinja": {
+          "kind": "render",
+          "reason": "a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped"
+        },
+        "minijinja": {
+          "kind": "render",
+          "reason": "a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped"
+        },
+        "mojolicious": {
+          "kind": "render",
+          "reason": "a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped"
+        },
+        "twig": {
+          "kind": "render",
+          "reason": "a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped"
+        },
+        "xslate": {
+          "kind": "render",
+          "reason": "a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped"
+        }
+      },
+      "math-methods": {
+        "blade": {
+          "kind": "render",
+          "reason": "Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)"
+        },
+        "erb": {
+          "kind": "render",
+          "reason": "Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)"
+        },
+        "go-template": {
+          "kind": "render",
+          "reason": "Math.min/max/abs over a signal: generated Go fails to run (exit 1) — only Math.floor is registered"
+        },
+        "jinja": {
+          "kind": "render",
+          "reason": "Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)"
+        },
+        "minijinja": {
+          "kind": "render",
+          "reason": "Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)"
+        },
+        "mojolicious": {
+          "kind": "render",
+          "reason": "Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)"
+        },
+        "twig": {
+          "kind": "render",
+          "reason": "Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)"
+        },
+        "xslate": {
+          "kind": "render",
+          "reason": "Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)"
+        }
+      },
+      "memo-chain": {
+        "go-template": {
+          "kind": "render",
+          "reason": "a memo derived from another memo renders EMPTY for the second layer — the constructor folds only one derivation level"
+        }
+      },
+      "nested-loop-outer-binding": {
+        "blade": {
+          "kind": "render",
+          "reason": "nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`"
+        },
+        "erb": {
+          "kind": "render",
+          "reason": "nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`"
+        },
+        "go-template": {
+          "kind": "render",
+          "reason": "nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`"
+        },
+        "jinja": {
+          "kind": "render",
+          "reason": "nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`"
+        },
+        "minijinja": {
+          "kind": "render",
+          "reason": "nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`"
+        },
+        "mojolicious": {
+          "kind": "render",
+          "reason": "nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`"
+        },
+        "twig": {
+          "kind": "render",
+          "reason": "nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`"
+        },
+        "xslate": {
+          "kind": "render",
+          "reason": "nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`"
+        }
+      },
+      "number-tofixed": {
+        "go-template": {
+          "kind": "render",
+          "reason": "`.toFixed(2)` on a number PROP: generated Go fails to run (exit 1)"
+        },
+        "mojolicious": {
+          "kind": "render",
+          "reason": "the literal `¥` in template text reaches the output as U+FFFD — a UTF-8 encoding gap for non-ASCII literal text adjacent to a dynamic slot"
+        }
+      },
+      "object-entries-map": {
+        "blade": {
+          "kind": "render",
+          "reason": "`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations"
+        },
+        "erb": {
+          "kind": "render",
+          "reason": "`Object.entries(prop).map(([k, v]) => …)` renders but its loop item keys diverge from the reference serialisation"
+        },
+        "go-template": {
+          "kind": "render",
+          "reason": "`Object.entries(prop).map(([k, v]) => …)`: generated Go fails to run (exit 1) — no object-iteration loop lowering"
+        },
+        "jinja": {
+          "kind": "render",
+          "reason": "`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations"
+        },
+        "minijinja": {
+          "kind": "render",
+          "reason": "`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations"
+        },
+        "mojolicious": {
+          "kind": "render",
+          "reason": "`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations"
+        },
+        "twig": {
+          "kind": "render",
+          "reason": "`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations"
+        },
+        "xslate": {
+          "kind": "render",
+          "reason": "`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations"
+        }
+      },
+      "optional-chaining-prop": {
+        "erb": {
+          "kind": "render",
+          "reason": "`user?.name ?? …` on an object prop: the Ruby render exits 1 (optional chaining into a Hash prop has no lowering)"
+        },
+        "go-template": {
+          "kind": "render",
+          "reason": "`user?.name ?? …` on an object prop: generated Go fails to run (exit 1) — optional chaining into a struct/map prop has no lowering"
+        }
+      },
+      "signal-object-field": {
+        "go-template": {
+          "kind": "render",
+          "reason": "object-valued signal (`user().name`): generated Go fails to run (exit 1) — no struct synthesis outside loops"
+        }
+      },
+      "static-array-children": {
+        "blade": {
+          "kind": "refusal",
+          "codes": [
+            "BF103"
+          ]
+        },
+        "erb": {
+          "kind": "refusal",
+          "codes": [
+            "BF103"
+          ]
+        },
+        "go-template": {
+          "kind": "refusal",
+          "codes": [
+            "BF103"
+          ]
+        },
+        "jinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF103"
+          ]
+        },
+        "minijinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF103"
+          ]
+        },
+        "mojolicious": {
+          "kind": "refusal",
+          "codes": [
+            "BF103"
+          ]
+        },
+        "twig": {
+          "kind": "refusal",
+          "codes": [
+            "BF103"
+          ]
+        },
+        "xslate": {
+          "kind": "refusal",
+          "codes": [
+            "BF103"
+          ]
+        }
+      },
+      "static-array-from-props": {
+        "blade": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "erb": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2087"
+          ]
+        },
+        "go-template": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "jinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2087"
+          ]
+        },
+        "minijinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2087"
+          ]
+        },
+        "mojolicious": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "twig": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "xslate": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        }
+      },
+      "static-array-from-props-with-component": {
+        "blade": {
+          "kind": "refusal",
+          "codes": [
+            "BF101",
+            "BF103"
+          ]
+        },
+        "erb": {
+          "kind": "refusal",
+          "codes": [
+            "BF101",
+            "BF103"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2087"
+          ]
+        },
+        "go-template": {
+          "kind": "refusal",
+          "codes": [
+            "BF101",
+            "BF103"
+          ]
+        },
+        "jinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF101",
+            "BF103"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2087"
+          ]
+        },
+        "minijinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF101",
+            "BF103"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2087"
+          ]
+        },
+        "mojolicious": {
+          "kind": "refusal",
+          "codes": [
+            "BF101",
+            "BF103"
+          ]
+        },
+        "twig": {
+          "kind": "refusal",
+          "codes": [
+            "BF101",
+            "BF103"
+          ]
+        },
+        "xslate": {
+          "kind": "refusal",
+          "codes": [
+            "BF101",
+            "BF103"
+          ]
+        }
+      },
+      "static-attr-escape": {
+        "blade": {
+          "kind": "render",
+          "reason": "static attribute values are not HTML-escaped (`title=\"Fish & Chips\"` emitted raw; Hono escapes)"
+        },
+        "erb": {
+          "kind": "render",
+          "reason": "static attribute values are not HTML-escaped (`title=\"Fish & Chips\"` emitted raw; Hono escapes)"
+        },
+        "go-template": {
+          "kind": "render",
+          "reason": "static attribute values are not HTML-escaped (`title=\"Fish & Chips\"` emitted raw; Hono escapes)"
+        },
+        "jinja": {
+          "kind": "render",
+          "reason": "static attribute values are not HTML-escaped (`title=\"Fish & Chips\"` emitted raw; Hono escapes)"
+        },
+        "minijinja": {
+          "kind": "render",
+          "reason": "static attribute values are not HTML-escaped (`title=\"Fish & Chips\"` emitted raw; Hono escapes)"
+        },
+        "mojolicious": {
+          "kind": "render",
+          "reason": "static attribute values are not HTML-escaped (`title=\"Fish & Chips\"` emitted raw; Hono escapes)"
+        },
+        "twig": {
+          "kind": "render",
+          "reason": "static attribute values are not HTML-escaped (`title=\"Fish & Chips\"` emitted raw; Hono escapes)"
+        },
+        "xslate": {
+          "kind": "render",
+          "reason": "static attribute values are not HTML-escaped (`title=\"Fish & Chips\"` emitted raw; Hono escapes)"
+        }
+      },
+      "string-concat-plus": {
+        "blade": {
+          "kind": "render",
+          "reason": "`'Hello, ' + name` is emitted as PHP `+`, which fatals with \"Unsupported operand types: string + string\" — needs PHP's `.` concat"
+        },
+        "go-template": {
+          "kind": "render",
+          "reason": "`'Hello, ' + name` renders \"0\" — JS string-concat `+` lowered through numeric addition"
+        },
+        "mojolicious": {
+          "kind": "render",
+          "reason": "`'Hello, ' + name` renders \"0\" — Perl's numeric `+` coerces the strings; JS string-concat `+` needs Perl's `.`"
+        },
+        "twig": {
+          "kind": "render",
+          "reason": "`'Hello, ' + name` lowers through Twig's numeric `+` instead of `~` string concat"
+        },
+        "xslate": {
+          "kind": "render",
+          "reason": "`'Hello, ' + name` numeric-coerces through Perl's `+` (needs `.`/`~` concat)"
+        }
+      },
+      "string-length-text": {
+        "mojolicious": {
+          "kind": "render",
+          "reason": "`.length` on a STRING prop diverges (array-length lowering misapplied to a scalar)"
+        }
+      },
+      "string-replaceall": {
+        "blade": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "erb": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "go-template": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "jinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "minijinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "mojolicious": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "twig": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        },
+        "xslate": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ]
+        }
+      },
+      "string-slice": {
+        "blade": {
+          "kind": "render",
+          "reason": "`.slice()` on a STRING renders empty (array-slice helper misfires on strings)"
+        },
+        "erb": {
+          "kind": "render",
+          "reason": "`.slice()` on a STRING lowers through the array slice helper and renders \"[]\" instead of the substring"
+        },
+        "go-template": {
+          "kind": "render",
+          "reason": "`.slice()` on a STRING routes through the array `bf_slice` helper and renders \"[]\" instead of the substring"
+        },
+        "jinja": {
+          "kind": "render",
+          "reason": "`.slice()` on a STRING renders empty (array-slice helper misfires on strings)"
+        },
+        "minijinja": {
+          "kind": "render",
+          "reason": "`.slice()` on a STRING renders empty (array-slice helper misfires on strings)"
+        },
+        "mojolicious": {
+          "kind": "render",
+          "reason": "`.slice()` on a STRING misfires through the array slice helper"
+        },
+        "twig": {
+          "kind": "render",
+          "reason": "`.slice()` on a STRING misfires through the array slice helper"
+        },
+        "xslate": {
+          "kind": "render",
+          "reason": "`.slice()` on a STRING misfires through the array slice helper"
+        }
+      },
+      "string-trim-sided": {
+        "blade": {
+          "kind": "render",
+          "reason": "`.trimStart()` / `.trimEnd()` render empty (no lowering)"
+        },
+        "erb": {
+          "kind": "render",
+          "reason": "`.trimStart()` / `.trimEnd()` render empty (no lowering; only both-sides `.trim` is wired)"
+        },
+        "go-template": {
+          "kind": "render",
+          "reason": "`.trimStart()` / `.trimEnd()`: generated Go fails to run (exit 1) — only both-sides `bf_trim` exists"
+        },
+        "jinja": {
+          "kind": "render",
+          "reason": "`.trimStart()` / `.trimEnd()` render empty (no lowering)"
+        },
+        "minijinja": {
+          "kind": "render",
+          "reason": "`.trimStart()` / `.trimEnd()` render empty (no lowering)"
+        },
+        "mojolicious": {
+          "kind": "render",
+          "reason": "`.trimStart()` / `.trimEnd()` render empty (no lowering)"
+        },
+        "twig": {
+          "kind": "render",
+          "reason": "`.trimStart()` / `.trimEnd()` render empty (no lowering)"
+        },
+        "xslate": {
+          "kind": "render",
+          "reason": "`.trimStart()` / `.trimEnd()` render empty (no lowering)"
+        }
+      },
+      "svg-icon": {
+        "blade": {
+          "kind": "render",
+          "reason": "SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case"
+        },
+        "erb": {
+          "kind": "render",
+          "reason": "SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case"
+        },
+        "go-template": {
+          "kind": "render",
+          "reason": "SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case"
+        },
+        "jinja": {
+          "kind": "render",
+          "reason": "SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case"
+        },
+        "minijinja": {
+          "kind": "render",
+          "reason": "SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case"
+        },
+        "mojolicious": {
+          "kind": "render",
+          "reason": "SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case"
+        },
+        "twig": {
+          "kind": "render",
+          "reason": "SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case"
+        },
+        "xslate": {
+          "kind": "render",
+          "reason": "SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case"
+        }
+      },
+      "todo-app": {
+        "blade": {
+          "kind": "refusal",
+          "codes": [
+            "BF103"
+          ]
+        },
+        "erb": {
+          "kind": "refusal",
+          "codes": [
+            "BF103"
+          ]
+        },
+        "go-template": {
+          "kind": "refusal",
+          "codes": [
+            "BF103"
+          ]
+        },
+        "jinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF103"
+          ]
+        },
+        "minijinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF103"
+          ]
+        },
+        "mojolicious": {
+          "kind": "refusal",
+          "codes": [
+            "BF103"
+          ]
+        },
+        "twig": {
+          "kind": "refusal",
+          "codes": [
+            "BF103"
+          ]
+        },
+        "xslate": {
+          "kind": "refusal",
+          "codes": [
+            "BF103"
+          ]
+        }
+      },
+      "todo-app-ssr": {
+        "blade": {
+          "kind": "refusal",
+          "codes": [
+            "BF103"
+          ]
+        },
+        "erb": {
+          "kind": "refusal",
+          "codes": [
+            "BF103"
+          ]
+        },
+        "go-template": {
+          "kind": "refusal",
+          "codes": [
+            "BF103"
+          ]
+        },
+        "jinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF103"
+          ]
+        },
+        "minijinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF103"
+          ]
+        },
+        "mojolicious": {
+          "kind": "refusal",
+          "codes": [
+            "BF103"
+          ]
+        },
+        "twig": {
+          "kind": "refusal",
+          "codes": [
+            "BF103"
+          ]
+        },
+        "xslate": {
+          "kind": "refusal",
+          "codes": [
+            "BF103"
+          ]
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
# Compatibility Matrix (follow-up to #2168)

The docs [compatibility-matrix page](https://barefootjs.dev/docs/advanced/compatibility-matrix) reads **all-green** because it only reports compile-time state (`ui/compat.lock.json`), while #2168's render-level divergences live as `skipJsx` literals inside each adapter's *test file* — invisible on the site. This makes the skips visible, honestly.

## What changed

- **New `RenderDivergences` type in `@barefootjs/jsx`** — the render-level sibling of `ConformancePins`: fixture id → one-line divergence reason.
- **Each template adapter declares its divergences in `src/render-divergences.ts`**, exported from the package index. Its conformance test now derives `skipJsx: Object.keys(renderDivergences)` from the *same object*, so the published declaration and the test skips cannot drift apart.
- **`packages/compat` publishes a `fixtureDivergences` section in `ui/compat.lock.json`**: fixture × adapter → build-time refusal codes (`conformancePins`) or render-divergence reason (`renderDivergences`), plus the corpus total (236 fixtures).
- **New consistency gate** (`packages/compat/src/__tests__/render-divergences.test.ts`, mirroring `compat-pins.test.ts`): fails on stale fixture ids, on pin/render overlap on one adapter, and on entries whose fixture stops compiling clean (those must migrate to `conformancePins`).
- **The docs page renders the new section**: an honest summary — **205 / 236 fixtures render to reference parity on every adapter; 31 diverge on at least one** — followed by a fixture × adapter table (`✓` parity / `≠` render divergence / diagnostic code for build-time refusals) and per-fixture divergence details grouped by identical reason.

## Verified

- `bun test packages/compat` green (220 + the new gate)
- `erb` (475) and `jinja` (500) conformance suites green with the derived skip lists
- `bun run compat:lock` regenerated deterministically; site builds and both page routes (`/advanced/compatibility-matrix` and `.md`) render the new section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ZXzQWvSKLUUrTAZ3vph1j

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZXzQWvSKLUUrTAZ3vph1j)_