### PR TITLE
Fold JSX render-nothing literals in Phase 1 (divergence stack 1/N)

### DIFF
--- a/.changeset/fold-render-nothing-literals.md
+++ b/.changeset/fold-render-nothing-literals.md
@@ -1,0 +1,13 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+"@barefootjs/erb": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+"@barefootjs/twig": patch
+"@barefootjs/jinja": patch
+"@barefootjs/blade": patch
+"@barefootjs/rust": patch
+---
+
+Fold the JSX render-nothing literals in Phase 1: `{null}`, `{undefined}`, `{true}`, and `{false}` in child position now produce NO IR node, matching JSX semantics (`{0}` still renders "0"). Previously the literal fell through to the scalar-expression fallback and each backend stringified it its own way — the Hono reference rendered the text "null" for `{null}` while template adapters rendered "false" for `{false}` (the `falsy-text-values` divergence from the Priority-12 sweep). With the fold living in the IR producer, every adapter — including CSR client JS — agrees by construction; the fixture graduates from every adapter's `renderDivergences` declaration and the CSR skip list.

--- a/packages/adapter-blade/src/render-divergences.ts
+++ b/packages/adapter-blade/src/render-divergences.ts
@@ -19,8 +19,6 @@ export const renderDivergences: RenderDivergences = {
     '`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)',
   'string-concat-plus':
     '`\'Hello, \' + name` is emitted as PHP `+`, which fatals with "Unsupported operand types: string + string" — needs PHP\'s `.` concat',
-  'falsy-text-values':
-    '`{false}` renders "false" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders "null") — neither side matches JSX semantics',
   'html-entity-text':
     '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
   'math-methods':

--- a/packages/adapter-erb/src/render-divergences.ts
+++ b/packages/adapter-erb/src/render-divergences.ts
@@ -15,8 +15,6 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
-  'falsy-text-values':
-    '`{false}` renders "false" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders "null") — neither side matches JSX semantics',
   'html-entity-text':
     '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
   'optional-chaining-prop':

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -17,8 +17,6 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
-  'falsy-text-values':
-    '`{false}` renders "false" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders "null") — neither side matches JSX semantics',
   'html-entity-text':
     '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
   'string-concat-plus':

--- a/packages/adapter-jinja/src/render-divergences.ts
+++ b/packages/adapter-jinja/src/render-divergences.ts
@@ -17,8 +17,6 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 export const renderDivergences: RenderDivergences = {
   'arithmetic-text':
     '`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)',
-  'falsy-text-values':
-    '`{false}` renders "false" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders "null") — neither side matches JSX semantics',
   'html-entity-text':
     '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
   'math-methods':

--- a/packages/adapter-mojolicious/src/render-divergences.ts
+++ b/packages/adapter-mojolicious/src/render-divergences.ts
@@ -23,8 +23,6 @@ export const renderDivergences: RenderDivergences = {
     '`.length` on a STRING prop diverges (array-length lowering misapplied to a scalar)',
   'number-tofixed':
     'the literal `¥` in template text reaches the output as U+FFFD — a UTF-8 encoding gap for non-ASCII literal text adjacent to a dynamic slot',
-  'falsy-text-values':
-    '`{false}` renders "false" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders "null") — neither side matches JSX semantics',
   'html-entity-text':
     '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
   'math-methods':

--- a/packages/adapter-rust/src/render-divergences.ts
+++ b/packages/adapter-rust/src/render-divergences.ts
@@ -19,8 +19,6 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 export const renderDivergences: RenderDivergences = {
   'arithmetic-text':
     '`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)',
-  'falsy-text-values':
-    '`{false}` renders "false" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders "null") — neither side matches JSX semantics',
   'html-entity-text':
     '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
   'math-methods':

--- a/packages/adapter-tests/fixtures/falsy-text-values.ts
+++ b/packages/adapter-tests/fixtures/falsy-text-values.ts
@@ -4,9 +4,14 @@ import { createFixture } from '../src/types'
  * JSX falsy-rendering semantics for literal expression children.
  *
  * React/Solid semantics: `0` renders as text "0"; `false`, `null`,
- * `undefined`, and `''` render nothing. An adapter that stringifies
- * naively (Go's `fmt.Sprint(false)` → "false", Ruby's `nil.to_s` → "",
- * Python's `str(None)` → "None") diverges visibly here.
+ * `undefined`, and `''` render nothing. Since #2171 the render-nothing
+ * literals (`null` / `undefined` / `true` / `false`) are folded away in
+ * Phase 1 (`jsx-to-ir`'s `isRenderNothingLiteral`), so the IR carries
+ * no node for them and every adapter agrees by construction — this
+ * fixture pins that the fold holds end-to-end on every backend.
+ * (Pre-#2171 each adapter stringified the literal its own way: the
+ * Hono reference emitted the text "null", template backends emitted
+ * "false" for `{false}` — the original Priority-12 divergence.)
  */
 export const fixture = createFixture({
   id: 'falsy-text-values',
@@ -29,8 +34,8 @@ export function FalsyTextValues() {
     <div bf-s="test">
       <span>0</span>
       <span></span>
-      <span>null</span>
-      <span>null</span>
+      <span></span>
+      <span></span>
       <span></span>
       <span>1</span>
     </div>

--- a/packages/adapter-tests/scripts/regen-expected-html.ts
+++ b/packages/adapter-tests/scripts/regen-expected-html.ts
@@ -1,0 +1,37 @@
+/**
+ * Regenerate `expectedHtml` for SPECIFIC fixture ids from the Hono
+ * reference — the targeted sibling of `generate-expected-html.ts`
+ * (which regenerates the whole corpus AND the shared-component
+ * snapshots). Use this when a compiler change alters the reference
+ * output of a handful of fixtures:
+ *
+ *   bun run packages/adapter-tests/scripts/regen-expected-html.ts <id> [<id>…]
+ */
+import { HonoAdapter } from '@barefootjs/hono/adapter'
+import { renderHonoComponent } from '@barefootjs/hono/test-render'
+import { normalizeHTML } from '../src/jsx-runner'
+import { indentHTML } from '../src/indent-html'
+import { jsxFixtures } from '../fixtures'
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const ids = new Set(process.argv.slice(2))
+const FIXTURES_DIR = resolve(import.meta.dir, '../fixtures')
+for (const fixture of jsxFixtures) {
+  if (!ids.has(fixture.id)) continue
+  const html = await renderHonoComponent({
+    source: fixture.source,
+    adapter: new HonoAdapter(),
+    props: fixture.props,
+    components: fixture.components,
+  })
+  const block = `  expectedHtml: \`${indentHTML(normalizeHTML(html))}\`,`
+  for (const sub of ['', 'methods']) {
+    const p = sub ? resolve(FIXTURES_DIR, sub, `${fixture.id}.ts`) : resolve(FIXTURES_DIR, `${fixture.id}.ts`)
+    if (!existsSync(p)) continue
+    let content = readFileSync(p, 'utf-8')
+    content = content.replace(/  expectedHtml: `[^`]*`,/s, block)
+    writeFileSync(p, content)
+    console.log('✓', fixture.id)
+  }
+}

--- a/packages/adapter-tests/scripts/regen-expected-html.ts
+++ b/packages/adapter-tests/scripts/regen-expected-html.ts
@@ -6,19 +6,57 @@
  * output of a handful of fixtures:
  *
  *   bun run packages/adapter-tests/scripts/regen-expected-html.ts <id> [<id>…]
+ *
+ * Fails loudly (non-zero exit) when invoked without ids, when an id
+ * doesn't exist in the corpus, when its fixture file can't be located,
+ * or when the file carries no inline `expectedHtml:` block to replace
+ * (snapshot-backed shared fixtures keep their expected output in
+ * `__snapshots__/`, not inline — regenerate those with
+ * `scripts/snapshot.ts` instead).
  */
 import { HonoAdapter } from '@barefootjs/hono/adapter'
 import { renderHonoComponent } from '@barefootjs/hono/test-render'
 import { normalizeHTML } from '../src/jsx-runner'
 import { indentHTML } from '../src/indent-html'
 import { jsxFixtures } from '../fixtures'
-import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
-const ids = new Set(process.argv.slice(2))
 const FIXTURES_DIR = resolve(import.meta.dir, '../fixtures')
-for (const fixture of jsxFixtures) {
-  if (!ids.has(fixture.id)) continue
+// Keep in sync with generate-expected-html.ts's FIXTURE_SUBDIRS.
+const FIXTURE_SUBDIRS = ['', 'methods']
+
+function resolveFixturePath(id: string): string | null {
+  for (const sub of FIXTURE_SUBDIRS) {
+    const candidate = sub
+      ? resolve(FIXTURES_DIR, sub, `${id}.ts`)
+      : resolve(FIXTURES_DIR, `${id}.ts`)
+    if (existsSync(candidate)) return candidate
+  }
+  return null
+}
+
+const ids = process.argv.slice(2)
+if (ids.length === 0) {
+  console.error('usage: regen-expected-html.ts <fixture-id> [<fixture-id>…]')
+  process.exit(1)
+}
+
+let failed = false
+for (const id of ids) {
+  const fixture = jsxFixtures.find(f => f.id === id)
+  if (!fixture) {
+    console.error(`✗ ${id}: not in the jsxFixtures corpus (typo, or not registered in fixtures/index.ts?)`)
+    failed = true
+    continue
+  }
+  const filePath = resolveFixturePath(id)
+  if (!filePath) {
+    console.error(`✗ ${id}: fixture file not found under ${FIXTURE_SUBDIRS.map(s => s || '.').join(', ')}`)
+    failed = true
+    continue
+  }
+
   const html = await renderHonoComponent({
     source: fixture.source,
     adapter: new HonoAdapter(),
@@ -26,12 +64,17 @@ for (const fixture of jsxFixtures) {
     components: fixture.components,
   })
   const block = `  expectedHtml: \`${indentHTML(normalizeHTML(html))}\`,`
-  for (const sub of ['', 'methods']) {
-    const p = sub ? resolve(FIXTURES_DIR, sub, `${fixture.id}.ts`) : resolve(FIXTURES_DIR, `${fixture.id}.ts`)
-    if (!existsSync(p)) continue
-    let content = readFileSync(p, 'utf-8')
-    content = content.replace(/  expectedHtml: `[^`]*`,/s, block)
-    writeFileSync(p, content)
-    console.log('✓', fixture.id)
+
+  const content = readFileSync(filePath, 'utf-8')
+  if (!/  expectedHtml: `[^`]*`,/s.test(content)) {
+    console.error(
+      `✗ ${id}: no inline expectedHtml block in ${filePath} — snapshot-backed fixtures regenerate via scripts/snapshot.ts`,
+    )
+    failed = true
+    continue
   }
+  writeFileSync(filePath, content.replace(/  expectedHtml: `[^`]*`,/s, block))
+  console.log('✓', id)
 }
+
+if (failed) process.exit(1)

--- a/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
+++ b/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
@@ -207,11 +207,8 @@ describe('CSR Conformance Tests', () => {
     // Hono + client pipeline itself, surfaced by the new fixtures. Each
     // entry is a REAL divergence (not a harness artifact) — the skip
     // documents it until the compiler/runtime reconciles the two paths:
-    //   - `falsy-text-values`: CSR stringifies `{false}` → "false" while
-    //     SSR drops it; SSR renders `{null}`/`{undefined}` → "null" while
-    //     CSR drops them. Both sides also disagree with JSX semantics
-    //     (0 renders; false/null/undefined render nothing).
-    'falsy-text-values',
+    //   (`falsy-text-values` graduated — #2171 folds the render-nothing
+    //   literals in Phase 1, so SSR and CSR now agree by construction.)
     //   - `html-entity-text`: `&copy;` in JSX literal text is decoded to
     //     `©` by SSR but passed through as the raw entity by the CSR
     //     template string (same DOM after parse, different bytes).

--- a/packages/adapter-twig/src/render-divergences.ts
+++ b/packages/adapter-twig/src/render-divergences.ts
@@ -19,8 +19,6 @@ export const renderDivergences: RenderDivergences = {
     '`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)',
   'string-concat-plus':
     "`'Hello, ' + name` lowers through Twig's numeric `+` instead of `~` string concat",
-  'falsy-text-values':
-    '`{false}` renders "false" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders "null") — neither side matches JSX semantics',
   'html-entity-text':
     '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
   'math-methods':

--- a/packages/adapter-xslate/src/render-divergences.ts
+++ b/packages/adapter-xslate/src/render-divergences.ts
@@ -19,8 +19,6 @@ export const renderDivergences: RenderDivergences = {
     '`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)',
   'string-concat-plus':
     "`'Hello, ' + name` numeric-coerces through Perl's `+` (needs `.`/`~` concat)",
-  'falsy-text-values':
-    '`{false}` renders "false" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders "null") — neither side matches JSX semantics',
   'html-entity-text':
     '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
   'math-methods':

--- a/packages/jsx/src/__tests__/render-nothing-literals.test.ts
+++ b/packages/jsx/src/__tests__/render-nothing-literals.test.ts
@@ -1,0 +1,93 @@
+/**
+ * JSX render-nothing literal folding (#2171).
+ *
+ * Per JSX semantics, `{null}` / `{undefined}` / `{true}` / `{false}` in
+ * child position render NOTHING, while `{0}` renders "0" and `{''}`
+ * renders the empty string. Historically the literals fell through to
+ * the scalar IRExpression fallback and each adapter stringified them
+ * its own way (Hono emitted the text "null" for `{null}`; the template
+ * adapters emitted "false" for `{false}`) — the Priority-12 sweep's
+ * `falsy-text-values` fixture pinned that three-way divergence. Folding
+ * in Phase 1 means the IR simply carries no node for these children,
+ * so every adapter agrees by construction.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { analyzeComponent } from '../analyzer'
+import { jsxToIR } from '../jsx-to-ir'
+import type { IRElement, IRNode } from '../types'
+
+function irFor(source: string): IRNode {
+  const analyzer = analyzeComponent(source, 'test.tsx')
+  const ir = jsxToIR(analyzer)
+  if (!ir) throw new Error('no IR produced')
+  return ir
+}
+
+function childrenOf(ir: IRNode): IRNode[] {
+  return (ir as IRElement).children ?? []
+}
+
+describe('render-nothing literal children fold in Phase 1', () => {
+  test.each(['null', 'undefined', 'true', 'false'])(
+    '{%s} child produces no IR node',
+    (literal) => {
+      const ir = irFor(`
+        export function C() {
+          return <div><span>a</span>{${literal}}<span>b</span></div>
+        }
+      `)
+      const children = childrenOf(ir)
+      expect(children).toHaveLength(2)
+      expect(children.every(c => c.type === 'element')).toBe(true)
+    },
+  )
+
+  test('transparently wrapped spellings fold too', () => {
+    for (const wrapped of ['(null)', 'null as unknown', 'undefined!']) {
+      const ir = irFor(`
+        export function C() {
+          return <div>{${wrapped}}</div>
+        }
+      `)
+      expect(childrenOf(ir)).toHaveLength(0)
+    }
+  })
+
+  test('{0} and {""} still produce expression children', () => {
+    const ir = irFor(`
+      export function C() {
+        return <div>{0}{''}</div>
+      }
+    `)
+    const children = childrenOf(ir)
+    expect(children).toHaveLength(2)
+    expect(children.every(c => c.type === 'expression')).toBe(true)
+  })
+
+  test('a dynamic expression that may evaluate to null is NOT folded', () => {
+    const ir = irFor(`
+      export function C(props: { name?: string }) {
+        return <div>{props.name}</div>
+      }
+    `)
+    expect(childrenOf(ir)).toHaveLength(1)
+    expect(childrenOf(ir)[0].type).toBe('expression')
+  })
+
+  test('conditional null branches keep their existing handling', () => {
+    // `cond ? <a/> : null` routes through the conditional transformer,
+    // not the JSX-child scalar path — the fold must not disturb it.
+    const ir = irFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function C() {
+        const [show] = createSignal(false)
+        return <div>{show() ? <span>on</span> : null}</div>
+      }
+    `)
+    const children = childrenOf(ir)
+    expect(children).toHaveLength(1)
+    expect(children[0].type).toBe('conditional')
+  })
+})

--- a/packages/jsx/src/__tests__/render-nothing-literals.test.ts
+++ b/packages/jsx/src/__tests__/render-nothing-literals.test.ts
@@ -75,6 +75,21 @@ describe('render-nothing literal children fold in Phase 1', () => {
     expect(childrenOf(ir)[0].type).toBe('expression')
   })
 
+  test('a SHADOWED `undefined` binding is not folded (renders the value)', () => {
+    // `const undefined = …` is lint-hostile but legal JS — the shadowed
+    // binding's value must render, so the fold checks the binding
+    // environment before treating the identifier as the global.
+    const ir = irFor(`
+      export function C() {
+        const undefined = 'shadowed'
+        return <div>{undefined}</div>
+      }
+    `)
+    const children = childrenOf(ir)
+    expect(children).toHaveLength(1)
+    expect(children[0].type).toBe('expression')
+  })
+
   test('conditional null branches keep their existing handling', () => {
     // `cond ? <a/> : null` routes through the conditional transformer,
     // not the JSX-child scalar path — the fold must not disturb it.

--- a/packages/jsx/src/free-refs.ts
+++ b/packages/jsx/src/free-refs.ts
@@ -397,6 +397,19 @@ function resolveFreeRefsInternal(
  * through a local constant are recursively expanded so the consumer sees
  * the constant's *kind composition*, not just the local name.
  */
+/**
+ * Whether `name` is bound by anything in the environment — an import, a
+ * local const/function, a prop param, a signal/memo, or an active loop
+ * param. Used by Phase 1's render-nothing-literal fold to distinguish
+ * the global `undefined` (renders nothing per JSX semantics) from a
+ * shadowed local binding named `undefined` (legal, if inadvisable — the
+ * shadowed VALUE must render). Cheap: the binding map is memoized per
+ * environment.
+ */
+export function isNameBound(name: string, env: BindingEnvironment): boolean {
+  return buildBindingMap(env).has(name)
+}
+
 export function resolveFreeRefs(
   node: ts.Node,
   env: BindingEnvironment

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -44,7 +44,7 @@ import {
   rewriteBarePropRefs as rewriteBarePropRefsCore,
   collectAstPropRefs,
 } from './prop-rewrite.ts'
-import { resolveFreeRefs, type BindingEnvironment } from './free-refs.ts'
+import { resolveFreeRefs, isNameBound as isNameBoundInEnv, type BindingEnvironment } from './free-refs.ts'
 import { computeFileScope } from './ir-to-client-js/component-scope.ts'
 import { extractFreeIdentifiersFromNode, initializerShapeContainsJsx } from './analyzer.ts'
 import { iterateJsTokens, replaceInExprContexts } from './scanner/js-scanner.ts'
@@ -1525,8 +1525,14 @@ function transformChildren(
  * here (`0` renders "0"; `''` renders empty by stringification), and a
  * dynamic expression that EVALUATES to null is a runtime concern the
  * client runtime / adapters own, not a compile-time fold.
+ *
+ * `undefined` is an Identifier, not a keyword, and CAN be legally
+ * shadowed (`const undefined = 1` — lint-hostile but valid JS); the
+ * shadowed binding's VALUE must render, so the identifier only folds
+ * when nothing in the binding environment (imports, locals, props,
+ * signals, memos, active loop params) binds the name.
  */
-function isRenderNothingLiteral(expr: ts.Expression): boolean {
+function isRenderNothingLiteral(expr: ts.Expression, ctx: TransformContext): boolean {
   let e = expr
   while (
     ts.isParenthesizedExpression(e) ||
@@ -1540,7 +1546,9 @@ function isRenderNothingLiteral(expr: ts.Expression): boolean {
     e.kind === ts.SyntaxKind.NullKeyword ||
     e.kind === ts.SyntaxKind.TrueKeyword ||
     e.kind === ts.SyntaxKind.FalseKeyword ||
-    (ts.isIdentifier(e) && e.text === 'undefined')
+    (ts.isIdentifier(e) &&
+      e.text === 'undefined' &&
+      !isNameBoundInEnv('undefined', makeBindingEnv(ctx)))
   )
 }
 
@@ -1613,7 +1621,7 @@ function transformExpressionInner(
   // `{null}`, template adapters emitted "false" for `{false}`). The
   // conditional-branch path (`cond ? <a/> : null`) is NOT routed
   // through here and keeps its own null-branch handling.
-  if (isRenderNothingLiteral(expr)) {
+  if (isRenderNothingLiteral(expr, ctx)) {
     return null
   }
 

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1517,6 +1517,33 @@ function transformChildren(
 // Text Transformation
 // =============================================================================
 
+/**
+ * True for the literals that render NOTHING in JSX child position per
+ * JSX semantics: `null`, `undefined`, `true`, `false` — including
+ * transparently wrapped spellings (`{(null)}`, `{null as any}`,
+ * `{undefined!}`). Deliberately narrow: `0`, `NaN`, and `''` are NOT
+ * here (`0` renders "0"; `''` renders empty by stringification), and a
+ * dynamic expression that EVALUATES to null is a runtime concern the
+ * client runtime / adapters own, not a compile-time fold.
+ */
+function isRenderNothingLiteral(expr: ts.Expression): boolean {
+  let e = expr
+  while (
+    ts.isParenthesizedExpression(e) ||
+    ts.isAsExpression(e) ||
+    ts.isSatisfiesExpression(e) ||
+    ts.isNonNullExpression(e)
+  ) {
+    e = e.expression
+  }
+  return (
+    e.kind === ts.SyntaxKind.NullKeyword ||
+    e.kind === ts.SyntaxKind.TrueKeyword ||
+    e.kind === ts.SyntaxKind.FalseKeyword ||
+    (ts.isIdentifier(e) && e.text === 'undefined')
+  )
+}
+
 function transformText(node: ts.JsxText, ctx: TransformContext): IRText | null {
   // Normalize whitespace (React-like behavior)
   const text = node.text.replace(/\s+/g, ' ')
@@ -1575,6 +1602,20 @@ function transformExpressionInner(
   // check below (JSX-constant inlining, the shared dispatcher, the
   // scalar fallback's `ctx.getJS`) sees the untagged template literal.
   expr = tryDesugarInterleaveTaggedTemplate(expr, ctx)
+
+  // JSX render-nothing literals (#2171): `{null}` / `{undefined}` /
+  // `{true}` / `{false}` in child position render NOTHING per JSX
+  // semantics (`{0}` and `{''}` still render their stringification).
+  // Folding here — Phase 1, before any adapter sees the node — is what
+  // makes every backend agree: previously the literal fell through to
+  // the scalar IRExpression fallback and each adapter stringified it
+  // its own way (the Hono reference emitted the text "null" for
+  // `{null}`, template adapters emitted "false" for `{false}`). The
+  // conditional-branch path (`cond ? <a/> : null`) is NOT routed
+  // through here and keeps its own null-branch handling.
+  if (isRenderNothingLiteral(expr)) {
+    return null
+  }
 
   // Check for bare signal/memo identifier (BF044)
   checkBareSignalOrMemoIdentifier(expr, ctx)

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2016,40 +2016,6 @@
           ]
         }
       },
-      "falsy-text-values": {
-        "blade": {
-          "kind": "render",
-          "reason": "`{false}` renders \"false\" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders \"null\") — neither side matches JSX semantics"
-        },
-        "erb": {
-          "kind": "render",
-          "reason": "`{false}` renders \"false\" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders \"null\") — neither side matches JSX semantics"
-        },
-        "go-template": {
-          "kind": "render",
-          "reason": "`{false}` renders \"false\" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders \"null\") — neither side matches JSX semantics"
-        },
-        "jinja": {
-          "kind": "render",
-          "reason": "`{false}` renders \"false\" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders \"null\") — neither side matches JSX semantics"
-        },
-        "minijinja": {
-          "kind": "render",
-          "reason": "`{false}` renders \"false\" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders \"null\") — neither side matches JSX semantics"
-        },
-        "mojolicious": {
-          "kind": "render",
-          "reason": "`{false}` renders \"false\" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders \"null\") — neither side matches JSX semantics"
-        },
-        "twig": {
-          "kind": "render",
-          "reason": "`{false}` renders \"false\" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders \"null\") — neither side matches JSX semantics"
-        },
-        "xslate": {
-          "kind": "render",
-          "reason": "`{false}` renders \"false\" (Hono drops it); `{null}`/`{undefined}` render empty (Hono renders \"null\") — neither side matches JSX semantics"
-        }
-      },
       "filter-nested-callback-predicate": {
         "blade": {
           "kind": "refusal",


### PR DESCRIPTION
# Divergence-resolution stack 1/N — falsy literal children

First PR of the divergence-resolution stack (fixing the render divergences published on the [compatibility matrix](https://barefootjs.dev/docs/advanced/compatibility-matrix), #2168/#2170). Per the adapter-architecture spec's first principle — **"the IR carries the semantics; adapters emit from it"** — each PR in the stack fixes a divergence class in the shared layer, never per-adapter.

## What

`{null}` / `{undefined}` / `{true}` / `{false}` in JSX child position render **nothing** per JSX semantics (`{0}` still renders `"0"`). Previously these literals fell through `jsx-to-ir`'s scalar `IRExpression` fallback and every backend stringified them its own way:

- Hono reference: `{null}` → the text `null` (!)
- Template adapters: `{false}` → the text `false`
- CSR: a third behavior

## How

The fold lives in the IR producer (`transformExpressionInner`), before the scalar fallback: `isRenderNothingLiteral` drops the literal — including transparently wrapped spellings (`{(null)}`, `{null as any}`, `{undefined!}`) — so the IR carries no node for it and **every adapter, including CSR client JS, agrees by construction**. Zero adapter code changed for the behavior. The conditional-branch path (`cond ? <a/> : null`) is not routed through this fold and keeps its existing null-branch handling (pinned by a test).

## Graduations

- `falsy-text-values` removed from **all 8** adapters' `renderDivergences` declarations and the CSR skip list
- `ui/compat.lock.json`: 31 → **30** divergent fixtures
- `expectedHtml` regenerated to the JSX-semantics output (new `regen-expected-html.ts <id>` targeted regeneration utility included)

## Verified

- New compiler unit suite `render-nothing-literals.test.ts` (8 tests: the four literals, wrapped spellings, `{0}`/`{''}` NOT folded, dynamic expressions NOT folded, conditional branches untouched)
- Full `packages/jsx` unit suite (2,363 tests), all 9 adapter conformance suites on real backends (Go 1.25.6 / Ruby / Perl ×2 / PHP ×2 / Python / Rust), adapter-tests + compat — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ZXzQWvSKLUUrTAZ3vph1j