### PR TITLE
Normalize intrinsic attribute names in Phase 1 (divergence stack 2/N)

### DIFF
--- a/.changeset/normalize-intrinsic-attr-names.md
+++ b/.changeset/normalize-intrinsic-attr-names.md
@@ -1,0 +1,16 @@
+---
+"@barefootjs/shared": patch
+"@barefootjs/jsx": patch
+"@barefootjs/client": patch
+"@barefootjs/go-template": patch
+"@barefootjs/erb": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+"@barefootjs/twig": patch
+"@barefootjs/jinja": patch
+"@barefootjs/blade": patch
+"@barefootjs/rust": patch
+"@barefootjs/hono": patch
+---
+
+Normalize intrinsic-element attribute names ONCE in Phase 1: `IRAttribute.name` now carries the HTML/SVG attribute name, so every adapter emits it verbatim. The shared `dom-prop` classifier grows an `HTML_CAMEL_ALIASES` table (React-style camelCase → HTML: `tabIndex` → `tabindex`, `maxLength` → `maxlength`, `autoComplete` → `autocomplete`, `readOnly` → the boolean `readonly`, `spellCheck` → the enumerated `spellcheck`, …) consulted by both `toHTMLAttrName` (now applied in `jsx-to-ir`'s `processAttributes`) and `toHTMLAttrNameRuntime` (spread paths). Previously each adapter mapped at most `className` → `class` itself and every other alias leaked into the emitted HTML as an unknown attribute the browser ignores — `htmlFor` never became `for` (broken label association on template backends), `readOnly` rendered as `readOnly="true"` vs bare presence depending on backend, and SVG `strokeWidth`/`strokeLinecap` passed through unmapped. Component props (`IRProp`) keep the user's API names; unknown names (`data-*`, custom-element attributes, `viewBox`-style case-sensitive SVG XML names) pass through unchanged. The `camelcase-attributes`, `svg-icon`, and `boolean-attr-literals` fixtures graduate from every adapter's `renderDivergences` declaration and the CSR skip list.

--- a/packages/adapter-blade/src/render-divergences.ts
+++ b/packages/adapter-blade/src/render-divergences.ts
@@ -23,14 +23,8 @@ export const renderDivergences: RenderDivergences = {
     '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
   'math-methods':
     'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
-  'boolean-attr-literals':
-    'camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`, this adapter emits bare presence',
-  'camelcase-attributes':
-    '`htmlFor` is not lowered to `for` (Hono maps it)',
   'static-attr-escape':
     'static attribute values are not HTML-escaped (`title="Fish & Chips"` emitted raw; Hono escapes)',
-  'svg-icon':
-    'SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case',
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
   'nested-loop-outer-binding':

--- a/packages/adapter-erb/src/render-divergences.ts
+++ b/packages/adapter-erb/src/render-divergences.ts
@@ -21,14 +21,8 @@ export const renderDivergences: RenderDivergences = {
     '`user?.name ?? …` on an object prop: the Ruby render exits 1 (optional chaining into a Hash prop has no lowering)',
   'math-methods':
     'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
-  'boolean-attr-literals':
-    'camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`, this adapter emits bare presence',
-  'camelcase-attributes':
-    '`htmlFor` is not lowered to `for` (Hono maps it)',
   'static-attr-escape':
     'static attribute values are not HTML-escaped (`title="Fish & Chips"` emitted raw; Hono escapes)',
-  'svg-icon':
-    'SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case',
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders but its loop item keys diverge from the reference serialisation',
   'nested-loop-outer-binding':

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -27,14 +27,8 @@ export const renderDivergences: RenderDivergences = {
     '`.toFixed(2)` on a number PROP: generated Go fails to run (exit 1)',
   'math-methods':
     'Math.min/max/abs over a signal: generated Go fails to run (exit 1) — only Math.floor is registered',
-  'boolean-attr-literals':
-    'camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`, this adapter emits bare presence',
-  'camelcase-attributes':
-    '`htmlFor` is not lowered to `for` (Hono maps it)',
   'static-attr-escape':
     'static attribute values are not HTML-escaped (`title="Fish & Chips"` emitted raw; Hono escapes)',
-  'svg-icon':
-    'SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case',
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)`: generated Go fails to run (exit 1) — no object-iteration loop lowering',
   'nested-loop-outer-binding':

--- a/packages/adapter-hono/src/adapter/hono-adapter.ts
+++ b/packages/adapter-hono/src/adapter/hono-adapter.ts
@@ -1132,7 +1132,15 @@ export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderC
       // mismatch where the server renders an attribute the client would
       // re-derive on mount. #1966
       if (attr.clientOnly) continue
-      const lowered = emitAttrValue(attr.value, this.elementAttrEmitter, attr.name)
+      // The IR carries the canonical HTML attribute name (#2172:
+      // `processAttributes` normalizes `className`→`class`, `htmlFor`→
+      // `for`, camelCase aliases → lowercase). This adapter's target
+      // language is JSX typed against `@barefootjs/jsx` html-types,
+      // whose vocabulary is those same lowercase HTML names with ONE
+      // JSX-ism: `className` (`class?: never`, #773). Map it back at
+      // emit — the JSX-language equivalent of Go emitting `{{.X}}`.
+      const jsxName = attr.name === 'class' ? 'className' : attr.name
+      const lowered = emitAttrValue(attr.value, this.elementAttrEmitter, jsxName)
       if (lowered) parts.push(lowered)
     }
 

--- a/packages/adapter-jinja/src/render-divergences.ts
+++ b/packages/adapter-jinja/src/render-divergences.ts
@@ -21,14 +21,8 @@ export const renderDivergences: RenderDivergences = {
     '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
   'math-methods':
     'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
-  'boolean-attr-literals':
-    'camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`, this adapter emits bare presence',
-  'camelcase-attributes':
-    '`htmlFor` is not lowered to `for` (Hono maps it)',
   'static-attr-escape':
     'static attribute values are not HTML-escaped (`title="Fish & Chips"` emitted raw; Hono escapes)',
-  'svg-icon':
-    'SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case',
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
   'nested-loop-outer-binding':

--- a/packages/adapter-mojolicious/src/render-divergences.ts
+++ b/packages/adapter-mojolicious/src/render-divergences.ts
@@ -27,14 +27,8 @@ export const renderDivergences: RenderDivergences = {
     '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
   'math-methods':
     'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
-  'boolean-attr-literals':
-    'camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`, this adapter emits bare presence',
-  'camelcase-attributes':
-    '`htmlFor` is not lowered to `for` (Hono maps it)',
   'static-attr-escape':
     'static attribute values are not HTML-escaped (`title="Fish & Chips"` emitted raw; Hono escapes)',
-  'svg-icon':
-    'SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case',
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
   'nested-loop-outer-binding':

--- a/packages/adapter-rust/src/render-divergences.ts
+++ b/packages/adapter-rust/src/render-divergences.ts
@@ -23,14 +23,8 @@ export const renderDivergences: RenderDivergences = {
     '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
   'math-methods':
     'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
-  'boolean-attr-literals':
-    'camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`, this adapter emits bare presence',
-  'camelcase-attributes':
-    '`htmlFor` is not lowered to `for` (Hono maps it)',
   'static-attr-escape':
     'static attribute values are not HTML-escaped (`title="Fish & Chips"` emitted raw; Hono escapes)',
-  'svg-icon':
-    'SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case',
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
   'nested-loop-outer-binding':

--- a/packages/adapter-tests/fixtures/__snapshots__/accordion.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/accordion.client.js
@@ -46,7 +46,7 @@ export function initCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -152,7 +152,7 @@ export function initChevronDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -258,7 +258,7 @@ export function initChevronUpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -364,7 +364,7 @@ export function initChevronLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -470,7 +470,7 @@ export function initChevronRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -576,7 +576,7 @@ export function initXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -682,7 +682,7 @@ export function initPlusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -788,7 +788,7 @@ export function initMinusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -894,7 +894,7 @@ export function initSunIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1000,7 +1000,7 @@ export function initMoonIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1106,7 +1106,7 @@ export function initMonitorIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1212,7 +1212,7 @@ export function initCopyIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1318,7 +1318,7 @@ export function initClipboardIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1424,7 +1424,7 @@ export function initClipboardCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1530,7 +1530,7 @@ export function initMenuIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1636,7 +1636,7 @@ export function initArrowLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1742,7 +1742,7 @@ export function initArrowRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1848,7 +1848,7 @@ export function initArrowUpDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1931,7 +1931,7 @@ export function initEllipsisIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1970,7 +1970,7 @@ export function initGitHubIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","class","aria-hidden"])
 
 }
 
@@ -2009,7 +2009,7 @@ export function initSettingsIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2048,7 +2048,7 @@ export function initGlobeIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2087,7 +2087,7 @@ export function initLogOutIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2126,7 +2126,7 @@ export function initCircleHelpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2165,7 +2165,7 @@ export function initSearchIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2204,7 +2204,7 @@ export function initCircleCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2243,7 +2243,7 @@ export function initCircleXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2282,7 +2282,7 @@ export function initTriangleAlertIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2321,7 +2321,7 @@ export function initInfoIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2360,7 +2360,7 @@ export function initCalendarIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2399,7 +2399,7 @@ export function initGripVerticalIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2461,7 +2461,7 @@ export function initLoaderCircleIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2544,7 +2544,7 @@ export function initPanelLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2624,7 +2624,7 @@ export function initIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 
   // Reactive child component props
@@ -2777,7 +2777,7 @@ export function initAccordion(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
 }
 

--- a/packages/adapter-tests/fixtures/__snapshots__/button.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/button.client.js
@@ -65,7 +65,7 @@ export function initButton(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","variant","size","asChild","children"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","variant","size","asChild","children","class"])
 
 
   // Reactive child component props

--- a/packages/adapter-tests/fixtures/__snapshots__/carousel.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/carousel.client.js
@@ -46,7 +46,7 @@ export function initCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -152,7 +152,7 @@ export function initChevronDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -258,7 +258,7 @@ export function initChevronUpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -364,7 +364,7 @@ export function initChevronLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -470,7 +470,7 @@ export function initChevronRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -576,7 +576,7 @@ export function initXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -682,7 +682,7 @@ export function initPlusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -788,7 +788,7 @@ export function initMinusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -894,7 +894,7 @@ export function initSunIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1000,7 +1000,7 @@ export function initMoonIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1106,7 +1106,7 @@ export function initMonitorIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1212,7 +1212,7 @@ export function initCopyIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1318,7 +1318,7 @@ export function initClipboardIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1424,7 +1424,7 @@ export function initClipboardCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1530,7 +1530,7 @@ export function initMenuIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1636,7 +1636,7 @@ export function initArrowLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1742,7 +1742,7 @@ export function initArrowRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1848,7 +1848,7 @@ export function initArrowUpDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1931,7 +1931,7 @@ export function initEllipsisIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1970,7 +1970,7 @@ export function initGitHubIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","class","aria-hidden"])
 
 }
 
@@ -2009,7 +2009,7 @@ export function initSettingsIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2048,7 +2048,7 @@ export function initGlobeIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2087,7 +2087,7 @@ export function initLogOutIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2126,7 +2126,7 @@ export function initCircleHelpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2165,7 +2165,7 @@ export function initSearchIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2204,7 +2204,7 @@ export function initCircleCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2243,7 +2243,7 @@ export function initCircleXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2282,7 +2282,7 @@ export function initTriangleAlertIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2321,7 +2321,7 @@ export function initInfoIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2360,7 +2360,7 @@ export function initCalendarIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2399,7 +2399,7 @@ export function initGripVerticalIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2461,7 +2461,7 @@ export function initLoaderCircleIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2544,7 +2544,7 @@ export function initPanelLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2624,7 +2624,7 @@ export function initIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 
   // Reactive child component props

--- a/packages/adapter-tests/fixtures/__snapshots__/checkbox.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/checkbox.client.js
@@ -46,7 +46,7 @@ export function initCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -152,7 +152,7 @@ export function initChevronDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -258,7 +258,7 @@ export function initChevronUpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -364,7 +364,7 @@ export function initChevronLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -470,7 +470,7 @@ export function initChevronRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -576,7 +576,7 @@ export function initXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -682,7 +682,7 @@ export function initPlusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -788,7 +788,7 @@ export function initMinusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -894,7 +894,7 @@ export function initSunIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1000,7 +1000,7 @@ export function initMoonIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1106,7 +1106,7 @@ export function initMonitorIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1212,7 +1212,7 @@ export function initCopyIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1318,7 +1318,7 @@ export function initClipboardIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1424,7 +1424,7 @@ export function initClipboardCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1530,7 +1530,7 @@ export function initMenuIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1636,7 +1636,7 @@ export function initArrowLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1742,7 +1742,7 @@ export function initArrowRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1848,7 +1848,7 @@ export function initArrowUpDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1931,7 +1931,7 @@ export function initEllipsisIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1970,7 +1970,7 @@ export function initGitHubIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","class","aria-hidden"])
 
 }
 
@@ -2009,7 +2009,7 @@ export function initSettingsIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2048,7 +2048,7 @@ export function initGlobeIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2087,7 +2087,7 @@ export function initLogOutIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2126,7 +2126,7 @@ export function initCircleHelpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2165,7 +2165,7 @@ export function initSearchIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2204,7 +2204,7 @@ export function initCircleCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2243,7 +2243,7 @@ export function initCircleXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2282,7 +2282,7 @@ export function initTriangleAlertIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2321,7 +2321,7 @@ export function initInfoIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2360,7 +2360,7 @@ export function initCalendarIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2399,7 +2399,7 @@ export function initGripVerticalIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2461,7 +2461,7 @@ export function initLoaderCircleIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2544,7 +2544,7 @@ export function initPanelLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2624,7 +2624,7 @@ export function initIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 
   // Reactive child component props

--- a/packages/adapter-tests/fixtures/__snapshots__/combobox.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/combobox.client.js
@@ -46,7 +46,7 @@ export function initCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -152,7 +152,7 @@ export function initChevronDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -258,7 +258,7 @@ export function initChevronUpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -364,7 +364,7 @@ export function initChevronLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -470,7 +470,7 @@ export function initChevronRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -576,7 +576,7 @@ export function initXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -682,7 +682,7 @@ export function initPlusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -788,7 +788,7 @@ export function initMinusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -894,7 +894,7 @@ export function initSunIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1000,7 +1000,7 @@ export function initMoonIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1106,7 +1106,7 @@ export function initMonitorIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1212,7 +1212,7 @@ export function initCopyIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1318,7 +1318,7 @@ export function initClipboardIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1424,7 +1424,7 @@ export function initClipboardCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1530,7 +1530,7 @@ export function initMenuIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1636,7 +1636,7 @@ export function initArrowLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1742,7 +1742,7 @@ export function initArrowRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1848,7 +1848,7 @@ export function initArrowUpDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1931,7 +1931,7 @@ export function initEllipsisIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1970,7 +1970,7 @@ export function initGitHubIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","class","aria-hidden"])
 
 }
 
@@ -2009,7 +2009,7 @@ export function initSettingsIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2048,7 +2048,7 @@ export function initGlobeIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2087,7 +2087,7 @@ export function initLogOutIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2126,7 +2126,7 @@ export function initCircleHelpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2165,7 +2165,7 @@ export function initSearchIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2204,7 +2204,7 @@ export function initCircleCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2243,7 +2243,7 @@ export function initCircleXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2282,7 +2282,7 @@ export function initTriangleAlertIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2321,7 +2321,7 @@ export function initInfoIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2360,7 +2360,7 @@ export function initCalendarIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2399,7 +2399,7 @@ export function initGripVerticalIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2461,7 +2461,7 @@ export function initLoaderCircleIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2544,7 +2544,7 @@ export function initPanelLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2624,7 +2624,7 @@ export function initIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 
   // Reactive child component props
@@ -3292,7 +3292,7 @@ export function initComboboxSeparator(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","data-slot","role"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","data-slot","role","class"])
 
 }
 

--- a/packages/adapter-tests/fixtures/__snapshots__/command.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/command.client.js
@@ -46,7 +46,7 @@ export function initCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -152,7 +152,7 @@ export function initChevronDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -258,7 +258,7 @@ export function initChevronUpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -364,7 +364,7 @@ export function initChevronLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -470,7 +470,7 @@ export function initChevronRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -576,7 +576,7 @@ export function initXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -682,7 +682,7 @@ export function initPlusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -788,7 +788,7 @@ export function initMinusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -894,7 +894,7 @@ export function initSunIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1000,7 +1000,7 @@ export function initMoonIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1106,7 +1106,7 @@ export function initMonitorIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1212,7 +1212,7 @@ export function initCopyIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1318,7 +1318,7 @@ export function initClipboardIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1424,7 +1424,7 @@ export function initClipboardCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1530,7 +1530,7 @@ export function initMenuIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1636,7 +1636,7 @@ export function initArrowLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1742,7 +1742,7 @@ export function initArrowRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1848,7 +1848,7 @@ export function initArrowUpDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1931,7 +1931,7 @@ export function initEllipsisIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1970,7 +1970,7 @@ export function initGitHubIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","class","aria-hidden"])
 
 }
 
@@ -2009,7 +2009,7 @@ export function initSettingsIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2048,7 +2048,7 @@ export function initGlobeIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2087,7 +2087,7 @@ export function initLogOutIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2126,7 +2126,7 @@ export function initCircleHelpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2165,7 +2165,7 @@ export function initSearchIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2204,7 +2204,7 @@ export function initCircleCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2243,7 +2243,7 @@ export function initCircleXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2282,7 +2282,7 @@ export function initTriangleAlertIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2321,7 +2321,7 @@ export function initInfoIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2360,7 +2360,7 @@ export function initCalendarIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2399,7 +2399,7 @@ export function initGripVerticalIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2461,7 +2461,7 @@ export function initLoaderCircleIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2544,7 +2544,7 @@ export function initPanelLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2624,7 +2624,7 @@ export function initIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 
   // Reactive child component props
@@ -2985,7 +2985,7 @@ export function initDialogHeader(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","class"])
 
 }
 
@@ -3010,7 +3010,7 @@ export function initDialogTitle(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","id","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","id","children","data-slot","class"])
 
 }
 
@@ -3035,7 +3035,7 @@ export function initDialogDescription(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","id","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","id","children","data-slot","class"])
 
 }
 
@@ -3058,7 +3058,7 @@ export function initDialogFooter(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","class"])
 
 }
 
@@ -3250,7 +3250,7 @@ export function initCommandList(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","role"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","role","class"])
 
 }
 
@@ -3429,7 +3429,7 @@ export function initCommandSeparator(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","data-slot","role"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","data-slot","role","class"])
 
 }
 
@@ -3452,7 +3452,7 @@ export function initCommandShortcut(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","class"])
 
 }
 
@@ -3536,7 +3536,7 @@ export function initKbd(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","asChild","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","asChild","children","data-slot","class"])
 
 
   // Reactive child component props
@@ -3572,7 +3572,7 @@ export function initKbdGroup(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","asChild","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","asChild","children","data-slot","class"])
 
 
   // Reactive child component props
@@ -3626,7 +3626,7 @@ export function initButton(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","variant","size","asChild","children"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","variant","size","asChild","children","class"])
 
 
   // Reactive child component props

--- a/packages/adapter-tests/fixtures/__snapshots__/data-table.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/data-table.client.js
@@ -17,7 +17,7 @@ export function initTable(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
 }
 
@@ -40,7 +40,7 @@ export function initTableHeader(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
 }
 
@@ -63,7 +63,7 @@ export function initTableBody(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
 }
 
@@ -86,7 +86,7 @@ export function initTableFooter(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
 }
 
@@ -109,7 +109,7 @@ export function initTableRow(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
 }
 
@@ -132,7 +132,7 @@ export function initTableHead(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
 }
 
@@ -155,7 +155,7 @@ export function initTableCell(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
 }
 
@@ -178,7 +178,7 @@ export function initTableCaption(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
 }
 
@@ -230,7 +230,7 @@ export function initCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -336,7 +336,7 @@ export function initChevronDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -442,7 +442,7 @@ export function initChevronUpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -548,7 +548,7 @@ export function initChevronLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -654,7 +654,7 @@ export function initChevronRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -760,7 +760,7 @@ export function initXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -866,7 +866,7 @@ export function initPlusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -972,7 +972,7 @@ export function initMinusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1078,7 +1078,7 @@ export function initSunIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1184,7 +1184,7 @@ export function initMoonIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1290,7 +1290,7 @@ export function initMonitorIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1396,7 +1396,7 @@ export function initCopyIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1502,7 +1502,7 @@ export function initClipboardIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1608,7 +1608,7 @@ export function initClipboardCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1714,7 +1714,7 @@ export function initMenuIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1820,7 +1820,7 @@ export function initArrowLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1926,7 +1926,7 @@ export function initArrowRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2032,7 +2032,7 @@ export function initArrowUpDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2115,7 +2115,7 @@ export function initEllipsisIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2154,7 +2154,7 @@ export function initGitHubIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","class","aria-hidden"])
 
 }
 
@@ -2193,7 +2193,7 @@ export function initSettingsIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2232,7 +2232,7 @@ export function initGlobeIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2271,7 +2271,7 @@ export function initLogOutIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2310,7 +2310,7 @@ export function initCircleHelpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2349,7 +2349,7 @@ export function initSearchIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2388,7 +2388,7 @@ export function initCircleCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2427,7 +2427,7 @@ export function initCircleXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2466,7 +2466,7 @@ export function initTriangleAlertIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2505,7 +2505,7 @@ export function initInfoIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2544,7 +2544,7 @@ export function initCalendarIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2583,7 +2583,7 @@ export function initGripVerticalIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2645,7 +2645,7 @@ export function initLoaderCircleIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2728,7 +2728,7 @@ export function initPanelLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2808,7 +2808,7 @@ export function initIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 
   // Reactive child component props
@@ -3004,7 +3004,7 @@ export function initDataTableColumnHeader(__scope, _p = {}) {
     }
   })
 
-  if (_s6) applyRestAttrs(_s6, _p, ["title","sorted","onSort","className","data-slot","type"])
+  if (_s6) applyRestAttrs(_s6, _p, ["title","sorted","onSort","className","data-slot","type","class"])
 
   if (_s6) _s6.addEventListener('click', onSort)
 
@@ -3050,7 +3050,7 @@ export function initDataTablePagination(__scope, _p = {}) {
     }
   })
 
-  if (_s4) applyRestAttrs(_s4, _p, ["canPrev","canNext","onPrev","onNext","children","className","data-slot"])
+  if (_s4) applyRestAttrs(_s4, _p, ["canPrev","canNext","onPrev","onNext","children","className","data-slot","class"])
 
   if (_s1) _s1.addEventListener('click', onPrev)
   if (_s3) _s3.addEventListener('click', onNext)

--- a/packages/adapter-tests/fixtures/__snapshots__/dialog.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/dialog.client.js
@@ -225,7 +225,7 @@ export function initDialogHeader(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","class"])
 
 }
 
@@ -250,7 +250,7 @@ export function initDialogTitle(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","id","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","id","children","data-slot","class"])
 
 }
 
@@ -275,7 +275,7 @@ export function initDialogDescription(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","id","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","id","children","data-slot","class"])
 
 }
 
@@ -298,7 +298,7 @@ export function initDialogFooter(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","class"])
 
 }
 

--- a/packages/adapter-tests/fixtures/__snapshots__/dropdown-menu.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/dropdown-menu.client.js
@@ -46,7 +46,7 @@ export function initCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -152,7 +152,7 @@ export function initChevronDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -258,7 +258,7 @@ export function initChevronUpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -364,7 +364,7 @@ export function initChevronLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -470,7 +470,7 @@ export function initChevronRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -576,7 +576,7 @@ export function initXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -682,7 +682,7 @@ export function initPlusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -788,7 +788,7 @@ export function initMinusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -894,7 +894,7 @@ export function initSunIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1000,7 +1000,7 @@ export function initMoonIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1106,7 +1106,7 @@ export function initMonitorIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1212,7 +1212,7 @@ export function initCopyIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1318,7 +1318,7 @@ export function initClipboardIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1424,7 +1424,7 @@ export function initClipboardCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1530,7 +1530,7 @@ export function initMenuIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1636,7 +1636,7 @@ export function initArrowLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1742,7 +1742,7 @@ export function initArrowRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1848,7 +1848,7 @@ export function initArrowUpDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1931,7 +1931,7 @@ export function initEllipsisIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1970,7 +1970,7 @@ export function initGitHubIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","class","aria-hidden"])
 
 }
 
@@ -2009,7 +2009,7 @@ export function initSettingsIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2048,7 +2048,7 @@ export function initGlobeIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2087,7 +2087,7 @@ export function initLogOutIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2126,7 +2126,7 @@ export function initCircleHelpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2165,7 +2165,7 @@ export function initSearchIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2204,7 +2204,7 @@ export function initCircleCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2243,7 +2243,7 @@ export function initCircleXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2282,7 +2282,7 @@ export function initTriangleAlertIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2321,7 +2321,7 @@ export function initInfoIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2360,7 +2360,7 @@ export function initCalendarIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2399,7 +2399,7 @@ export function initGripVerticalIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2461,7 +2461,7 @@ export function initLoaderCircleIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2544,7 +2544,7 @@ export function initPanelLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2624,7 +2624,7 @@ export function initIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 
   // Reactive child component props
@@ -3338,7 +3338,7 @@ export function initDropdownMenuLabel(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
 }
 
@@ -3360,7 +3360,7 @@ export function initDropdownMenuSeparator(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","data-slot","role"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","data-slot","role","class"])
 
 }
 
@@ -3383,7 +3383,7 @@ export function initDropdownMenuShortcut(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
 }
 
@@ -3404,7 +3404,7 @@ export function initDropdownMenuGroup(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","role"])
+  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","role","class"])
 
 }
 

--- a/packages/adapter-tests/fixtures/__snapshots__/input.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/input.client.js
@@ -21,7 +21,7 @@ export function initInput(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","type","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","type","data-slot","class"])
 
 }
 

--- a/packages/adapter-tests/fixtures/__snapshots__/kbd.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/kbd.client.js
@@ -47,7 +47,7 @@ export function initKbd(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","asChild","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","asChild","children","data-slot","class"])
 
 
   // Reactive child component props
@@ -83,7 +83,7 @@ export function initKbdGroup(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","asChild","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","asChild","children","data-slot","class"])
 
 
   // Reactive child component props

--- a/packages/adapter-tests/fixtures/__snapshots__/label.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/label.client.js
@@ -18,7 +18,7 @@ export function initLabel(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","class"])
 
 }
 

--- a/packages/adapter-tests/fixtures/__snapshots__/pagination.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/pagination.client.js
@@ -46,7 +46,7 @@ export function initCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -152,7 +152,7 @@ export function initChevronDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -258,7 +258,7 @@ export function initChevronUpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -364,7 +364,7 @@ export function initChevronLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -470,7 +470,7 @@ export function initChevronRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -576,7 +576,7 @@ export function initXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -682,7 +682,7 @@ export function initPlusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -788,7 +788,7 @@ export function initMinusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -894,7 +894,7 @@ export function initSunIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1000,7 +1000,7 @@ export function initMoonIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1106,7 +1106,7 @@ export function initMonitorIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1212,7 +1212,7 @@ export function initCopyIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1318,7 +1318,7 @@ export function initClipboardIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1424,7 +1424,7 @@ export function initClipboardCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1530,7 +1530,7 @@ export function initMenuIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1636,7 +1636,7 @@ export function initArrowLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1742,7 +1742,7 @@ export function initArrowRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1848,7 +1848,7 @@ export function initArrowUpDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1931,7 +1931,7 @@ export function initEllipsisIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1970,7 +1970,7 @@ export function initGitHubIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","class","aria-hidden"])
 
 }
 
@@ -2009,7 +2009,7 @@ export function initSettingsIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2048,7 +2048,7 @@ export function initGlobeIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2087,7 +2087,7 @@ export function initLogOutIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2126,7 +2126,7 @@ export function initCircleHelpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2165,7 +2165,7 @@ export function initSearchIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2204,7 +2204,7 @@ export function initCircleCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2243,7 +2243,7 @@ export function initCircleXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2282,7 +2282,7 @@ export function initTriangleAlertIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2321,7 +2321,7 @@ export function initInfoIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2360,7 +2360,7 @@ export function initCalendarIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2399,7 +2399,7 @@ export function initGripVerticalIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2461,7 +2461,7 @@ export function initLoaderCircleIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2544,7 +2544,7 @@ export function initPanelLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2624,7 +2624,7 @@ export function initIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 
   // Reactive child component props
@@ -2775,7 +2775,7 @@ export function initPagination(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","children","role","aria-label","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","children","role","aria-label","data-slot","class"])
 
 }
 
@@ -2796,7 +2796,7 @@ export function initPaginationContent(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","class"])
 
 }
 
@@ -2817,7 +2817,7 @@ export function initPaginationItem(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","class"])
 
 }
 
@@ -2887,7 +2887,7 @@ export function initPaginationPrevious(__scope, _p = {}) {
     }
   })
 
-  if (_s1) applyRestAttrs(_s1, _p, ["className","children","aria-label","data-slot"])
+  if (_s1) applyRestAttrs(_s1, _p, ["className","children","aria-label","data-slot","class"])
 
 
   // Initialize child components with props
@@ -2933,7 +2933,7 @@ export function initPaginationNext(__scope, _p = {}) {
     }
   })
 
-  if (_s1) applyRestAttrs(_s1, _p, ["className","children","aria-label","data-slot"])
+  if (_s1) applyRestAttrs(_s1, _p, ["className","children","aria-label","data-slot","class"])
 
 
   // Initialize child components with props
@@ -2969,7 +2969,7 @@ export function initPaginationEllipsis(__scope, _p = {}) {
     }
   })
 
-  if (_s1) applyRestAttrs(_s1, _p, ["className","aria-hidden","data-slot"])
+  if (_s1) applyRestAttrs(_s1, _p, ["className","aria-hidden","data-slot","class"])
 
 
   // Initialize child components with props

--- a/packages/adapter-tests/fixtures/__snapshots__/select.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/select.client.js
@@ -46,7 +46,7 @@ export function initCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -152,7 +152,7 @@ export function initChevronDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -258,7 +258,7 @@ export function initChevronUpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -364,7 +364,7 @@ export function initChevronLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -470,7 +470,7 @@ export function initChevronRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -576,7 +576,7 @@ export function initXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -682,7 +682,7 @@ export function initPlusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -788,7 +788,7 @@ export function initMinusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -894,7 +894,7 @@ export function initSunIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1000,7 +1000,7 @@ export function initMoonIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1106,7 +1106,7 @@ export function initMonitorIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1212,7 +1212,7 @@ export function initCopyIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1318,7 +1318,7 @@ export function initClipboardIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1424,7 +1424,7 @@ export function initClipboardCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1530,7 +1530,7 @@ export function initMenuIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1636,7 +1636,7 @@ export function initArrowLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1742,7 +1742,7 @@ export function initArrowRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1848,7 +1848,7 @@ export function initArrowUpDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1931,7 +1931,7 @@ export function initEllipsisIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1970,7 +1970,7 @@ export function initGitHubIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","class","aria-hidden"])
 
 }
 
@@ -2009,7 +2009,7 @@ export function initSettingsIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2048,7 +2048,7 @@ export function initGlobeIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2087,7 +2087,7 @@ export function initLogOutIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2126,7 +2126,7 @@ export function initCircleHelpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2165,7 +2165,7 @@ export function initSearchIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2204,7 +2204,7 @@ export function initCircleCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2243,7 +2243,7 @@ export function initCircleXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2282,7 +2282,7 @@ export function initTriangleAlertIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2321,7 +2321,7 @@ export function initInfoIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2360,7 +2360,7 @@ export function initCalendarIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2399,7 +2399,7 @@ export function initGripVerticalIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2461,7 +2461,7 @@ export function initLoaderCircleIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2544,7 +2544,7 @@ export function initPanelLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2624,7 +2624,7 @@ export function initIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 
   // Reactive child component props
@@ -3148,7 +3148,7 @@ export function initSelectGroup(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","role"])
+  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","role","class"])
 
 }
 
@@ -3171,7 +3171,7 @@ export function initSelectLabel(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
 }
 
@@ -3193,7 +3193,7 @@ export function initSelectSeparator(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","data-slot","role"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","data-slot","role","class"])
 
 }
 

--- a/packages/adapter-tests/fixtures/__snapshots__/tabs.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/tabs.client.js
@@ -20,7 +20,7 @@ export function initTabs(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","value","defaultValue","children","data-slot","data-value"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","value","defaultValue","children","data-slot","data-value","class"])
 
 }
 
@@ -43,7 +43,7 @@ export function initTabsList(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","role"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","role","class"])
 
 }
 

--- a/packages/adapter-tests/fixtures/__snapshots__/textarea.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/textarea.client.js
@@ -38,7 +38,7 @@ export function initTextarea(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","placeholder","value","disabled","readonly","error","describedBy","rows","onInput","onChange","onBlur","onFocus","data-slot","aria-invalid"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","placeholder","value","disabled","readonly","error","describedBy","rows","onInput","onChange","onBlur","onFocus","data-slot","class","aria-invalid"])
 
   if (_s0) _s0.addEventListener('input', onInput)
   if (_s0) _s0.addEventListener('change', onChange)

--- a/packages/adapter-tests/fixtures/__snapshots__/tooltip.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/tooltip.client.js
@@ -158,7 +158,7 @@ export function initButton(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","variant","size","asChild","children"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","variant","size","asChild","children","class"])
 
 
   // Reactive child component props

--- a/packages/adapter-tests/fixtures/boolean-attr-literals.ts
+++ b/packages/adapter-tests/fixtures/boolean-attr-literals.ts
@@ -27,7 +27,7 @@ export function BooleanAttrLiterals() {
       <button disabled>bare</button>
       <button disabled>true</button>
       <button>false</button>
-      <input checked readOnly="true" type="checkbox">
+      <input checked readonly type="checkbox">
     </div>
   `,
 })

--- a/packages/adapter-tests/fixtures/camelcase-attributes.ts
+++ b/packages/adapter-tests/fixtures/camelcase-attributes.ts
@@ -23,7 +23,7 @@ export function CamelcaseAttributes() {
   expectedHtml: `
     <div bf-s="test">
       <label for="name-field">Name</label>
-      <input autoComplete="off" id="name-field" maxLength="10" spellCheck="false" tabIndex="2">
+      <input autocomplete="off" id="name-field" maxlength="10" spellcheck="false" tabindex="2">
     </div>
   `,
 })

--- a/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
+++ b/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
@@ -213,11 +213,9 @@ describe('CSR Conformance Tests', () => {
     //     `©` by SSR but passed through as the raw entity by the CSR
     //     template string (same DOM after parse, different bytes).
     'html-entity-text',
-    //   - `boolean-attr-literals`: `readOnly` (camelCase alias of a
-    //     boolean attr) SSRs as `readOnly="true"` but CSRs as bare
-    //     `readOnly` — the boolean-attribute canonicalisation in
-    //     `normalizeHTML` only covers the lowercase spellings.
-    'boolean-attr-literals',
+    //   (`boolean-attr-literals` graduated — #2172 normalizes intrinsic
+    //   attribute names in Phase 1, so `readOnly` reaches both SSR and
+    //   CSR as the BOOLEAN_ATTRS member `readonly`.)
     //   - `static-attr-escape`: static attribute values are HTML-escaped
     //     by Hono SSR (`Fish &amp; Chips`) but emitted RAW by the CSR
     //     template literal (`Fish & Chips`).

--- a/packages/adapter-twig/src/render-divergences.ts
+++ b/packages/adapter-twig/src/render-divergences.ts
@@ -23,14 +23,8 @@ export const renderDivergences: RenderDivergences = {
     '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
   'math-methods':
     'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
-  'boolean-attr-literals':
-    'camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`, this adapter emits bare presence',
-  'camelcase-attributes':
-    '`htmlFor` is not lowered to `for` (Hono maps it)',
   'static-attr-escape':
     'static attribute values are not HTML-escaped (`title="Fish & Chips"` emitted raw; Hono escapes)',
-  'svg-icon':
-    'SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case',
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
   'nested-loop-outer-binding':

--- a/packages/adapter-xslate/src/render-divergences.ts
+++ b/packages/adapter-xslate/src/render-divergences.ts
@@ -23,14 +23,8 @@ export const renderDivergences: RenderDivergences = {
     '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
   'math-methods':
     'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
-  'boolean-attr-literals':
-    'camelCase boolean alias `readOnly`: Hono SSRs `readOnly="true"`, this adapter emits bare presence',
-  'camelcase-attributes':
-    '`htmlFor` is not lowered to `for` (Hono maps it)',
   'static-attr-escape':
     'static attribute values are not HTML-escaped (`title="Fish & Chips"` emitted raw; Hono escapes)',
-  'svg-icon':
-    'SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case',
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
   'nested-loop-outer-binding':

--- a/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
+++ b/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
@@ -3090,7 +3090,7 @@ export function initExample(__scope, _p = {}) {
   initChild('DialogTrigger', _s0, { asChild: true })
 }
 
-hydrate('Example', { init: initExample, template: (_p) => \`<div>\${renderChild('DialogTrigger', {asChild: true, children: \`<span role="button" \${(0) != null ? 'tabIndex="' + escapeAttr(0) + '"' : ''}>Open</span>\`}, undefined, 's0')}</div>\` })
+hydrate('Example', { init: initExample, template: (_p) => \`<div>\${renderChild('DialogTrigger', {asChild: true, children: \`<span role="button" \${(0) != null ? 'tabindex="' + escapeAttr(0) + '"' : ''}>Open</span>\`}, undefined, 's0')}</div>\` })
 export function Example(_p, __bfKey) { return createComponent('Example', _p, __bfKey) }"
 `;
 

--- a/packages/jsx/src/__tests__/ir-const-resolution.test.ts
+++ b/packages/jsx/src/__tests__/ir-const-resolution.test.ts
@@ -26,7 +26,7 @@ function findClassNameValue(node: IRNode): AttrValue | null {
   if (node.type === 'element') {
     const el = node as IRElement
     for (const attr of el.attrs) {
-      if (attr.name === 'className') return attr.value
+      if (attr.name === 'class') return attr.value
     }
     for (const child of el.children) {
       const v = findClassNameValue(child)

--- a/packages/jsx/src/__tests__/ir-provider.test.ts
+++ b/packages/jsx/src/__tests__/ir-provider.test.ts
@@ -83,8 +83,8 @@ describe('Context.Provider JSX', () => {
       contextName: 'Ctx',
       valueProp: { name: 'value', value: { kind: 'expression', expr: '{ active, setActive }' } },
       children: [
-        { type: 'element', tag: 'div', attrs: [{ name: 'className', value: { kind: 'literal', value: 'tabs-header' } }] },
-        { type: 'element', tag: 'div', attrs: [{ name: 'className', value: { kind: 'literal', value: 'tabs-body' } }] },
+        { type: 'element', tag: 'div', attrs: [{ name: 'class', value: { kind: 'literal', value: 'tabs-header' } }] },
+        { type: 'element', tag: 'div', attrs: [{ name: 'class', value: { kind: 'literal', value: 'tabs-body' } }] },
       ],
     })
   })

--- a/packages/jsx/src/__tests__/tagged-template-interleave.test.ts
+++ b/packages/jsx/src/__tests__/tagged-template-interleave.test.ts
@@ -41,7 +41,7 @@ function classAttrValue(source: string, filename = 'TagDemo.tsx') {
   expect(ir).not.toBeNull()
   expect(ir!.type).toBe('element')
   const el = ir as IRElement
-  const attr = el.attrs.find(a => a.name === 'className')
+  const attr = el.attrs.find(a => a.name === 'class')
   expect(attr).toBeDefined()
   return attr!.value
 }
@@ -256,7 +256,7 @@ describe('tagged-template interleave-tag recognition (#2092)', () => {
     const ir = jsxToIR(ctx)
     expect(ir).not.toBeNull()
     const el = ir as IRElement
-    const attr = el.attrs.find(a => a.name === 'className')
+    const attr = el.attrs.find(a => a.name === 'class')
     expect(attr).toBeDefined()
     // The desugar still applies (the client-only directive doesn't block
     // recognition — it's read independently from the original node), and

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -48,6 +48,7 @@ import { resolveFreeRefs, isNameBound as isNameBoundInEnv, type BindingEnvironme
 import { computeFileScope } from './ir-to-client-js/component-scope.ts'
 import { extractFreeIdentifiersFromNode, initializerShapeContainsJsx } from './analyzer.ts'
 import { iterateJsTokens, replaceInExprContexts } from './scanner/js-scanner.ts'
+import { toHTMLAttrName } from '@barefootjs/shared'
 
 // =============================================================================
 // Transform Context
@@ -4066,13 +4067,13 @@ function processAttributes(
 
     if (!ts.isJsxAttribute(attr)) continue
 
-    const name = attr.name.getText(ctx.sourceFile)
+    const rawName = attr.name.getText(ctx.sourceFile)
 
     // ref is captured separately (not pushed into `attrs`) because it never
     // appears in the rendered HTML — it's a compile-time binding from the
     // JSX call site to the runtime DOM element, surfaced via the IRElement
     // `ref` field for the client-JS emitter.
-    if (name === 'ref') {
+    if (rawName === 'ref') {
       if (attr.initializer && ts.isJsxExpression(attr.initializer) && attr.initializer.expression) {
         reportJsxBranchLocalInCallback(attr.initializer.expression, ctx)
         ref = ctx.getJS(attr.initializer.expression)
@@ -4084,19 +4085,32 @@ function processAttributes(
     // they're wired up at hydration time (delegated event registration) and
     // must not leak into rendered HTML. The DOM event name is lowercase
     // (`click`, not `Click`), so strip the `on` prefix and downcase.
-    if (/^on[A-Z]/.test(name)) {
+    if (/^on[A-Z]/.test(rawName)) {
       if (attr.initializer && ts.isJsxExpression(attr.initializer) && attr.initializer.expression) {
-        const eventName = name.slice(2).toLowerCase()
+        const eventName = rawName.slice(2).toLowerCase()
         reportJsxBranchLocalInCallback(attr.initializer.expression, ctx)
         events.push({
           name: eventName,
-          originalAttr: name,
+          originalAttr: rawName,
           handler: ctx.getJS(attr.initializer.expression),
           loc: getSourceLocation(attr, ctx.sourceFile, ctx.filePath),
         })
       }
       continue
     }
+
+    // Normalize the JSX prop spelling to the HTML/SVG attribute name ONCE,
+    // here in Phase 1, so IRAttribute.name is already the name every
+    // adapter emits verbatim (#2172): React-style HTML camelCase aliases
+    // lower (`htmlFor` → `for`, `tabIndex` → `tabindex`, `readOnly` →
+    // the BOOLEAN_ATTRS member `readonly`), SVG presentation attrs
+    // kebab-case (`strokeWidth` → `stroke-width`), case-sensitive SVG XML
+    // names (`viewBox`) and everything unknown (`data-*`, custom-element
+    // attrs) pass through. Previously each adapter re-derived (at most)
+    // `className` → `class` itself and every other alias leaked into the
+    // emitted HTML as an unknown attribute the browser ignores. Intrinsic
+    // elements only — component props (IRProp) keep the user's API names.
+    const name = toHTMLAttrName(rawName)
 
     let value = getAttributeValue(attr, ctx)
     let clientOnly: boolean | undefined

--- a/packages/shared/src/__tests__/dom-prop.test.ts
+++ b/packages/shared/src/__tests__/dom-prop.test.ts
@@ -106,12 +106,27 @@ describe('toHTMLAttrName (compile-time)', () => {
     expect(toHTMLAttrName('strokeWidth')).toBe('stroke-width')
   })
 
-  test('tabIndex passes through (no generic kebab)', () => {
-    expect(toHTMLAttrName('tabIndex')).toBe('tabIndex')
+  // #2172: HTML camelCase aliases resolve through HTML_CAMEL_ALIASES —
+  // these are known HTML attributes with a defined lowercase spelling,
+  // NOT the generic kebab conversion (which stays data-*/aria-* only).
+  test('tabIndex lowers to tabindex (HTML alias table)', () => {
+    expect(toHTMLAttrName('tabIndex')).toBe('tabindex')
   })
 
-  test('autoFocus passes through (no generic kebab)', () => {
-    expect(toHTMLAttrName('autoFocus')).toBe('autoFocus')
+  test('autoFocus lowers to autofocus (HTML alias table)', () => {
+    expect(toHTMLAttrName('autoFocus')).toBe('autofocus')
+  })
+
+  test('readOnly lowers to the BOOLEAN_ATTRS member readonly', () => {
+    expect(toHTMLAttrName('readOnly')).toBe('readonly')
+  })
+
+  test('spellCheck lowers to the enumerated (non-boolean) spellcheck', () => {
+    expect(toHTMLAttrName('spellCheck')).toBe('spellcheck')
+  })
+
+  test('unknown camelCase names still pass through unchanged', () => {
+    expect(toHTMLAttrName('myCustomAttr')).toBe('myCustomAttr')
   })
 })
 
@@ -144,12 +159,16 @@ describe('toHTMLAttrNameRuntime', () => {
     expect(toHTMLAttrNameRuntime('ariaLabel')).toBe('aria-label')
   })
 
-  test('tabIndex passes through (no kebab)', () => {
-    expect(toHTMLAttrNameRuntime('tabIndex')).toBe('tabIndex')
+  test('tabIndex lowers to tabindex (HTML alias table, #2172)', () => {
+    expect(toHTMLAttrNameRuntime('tabIndex')).toBe('tabindex')
   })
 
-  test('autoFocus passes through (no kebab)', () => {
-    expect(toHTMLAttrNameRuntime('autoFocus')).toBe('autoFocus')
+  test('autoFocus lowers to autofocus (HTML alias table, #2172)', () => {
+    expect(toHTMLAttrNameRuntime('autoFocus')).toBe('autofocus')
+  })
+
+  test('unknown camelCase names still pass through unchanged', () => {
+    expect(toHTMLAttrNameRuntime('myCustomAttr')).toBe('myCustomAttr')
   })
 })
 

--- a/packages/shared/src/__tests__/dom-prop.test.ts
+++ b/packages/shared/src/__tests__/dom-prop.test.ts
@@ -167,6 +167,14 @@ describe('toHTMLAttrNameRuntime', () => {
     expect(toHTMLAttrNameRuntime('autoFocus')).toBe('autofocus')
   })
 
+  test('readOnly lowers to the boolean attr spelling readonly (HTML alias table, #2172)', () => {
+    expect(toHTMLAttrNameRuntime('readOnly')).toBe('readonly')
+  })
+
+  test('spellCheck lowers to the enumerated attr spelling spellcheck (HTML alias table, #2172)', () => {
+    expect(toHTMLAttrNameRuntime('spellCheck')).toBe('spellcheck')
+  })
+
   test('unknown camelCase names still pass through unchanged', () => {
     expect(toHTMLAttrNameRuntime('myCustomAttr')).toBe('myCustomAttr')
   })

--- a/packages/shared/src/dom-prop.ts
+++ b/packages/shared/src/dom-prop.ts
@@ -73,6 +73,79 @@ const SVG_CAMEL_TO_KEBAB: Readonly<Record<string, string>> = {
 }
 
 /**
+ * HTML attributes written in React-style camelCase in JSX that map to a
+ * lowercase (or hyphenated) HTML attribute name. Mirrors React DOM's
+ * HTML attribute aliases. `className` / `htmlFor` are handled before
+ * this table (they predate it); everything here is a plain rename —
+ * value semantics are untouched (`readOnly` becomes the BOOLEAN_ATTRS
+ * member `readonly`; `spellCheck` stays the *enumerated* — NOT boolean
+ * — `spellcheck`).
+ *
+ * Consumed by `toHTMLAttrName` (compile-time Phase 1: `processAttributes`
+ * normalizes IRAttribute.name so adapters emit the HTML name as-is) and
+ * by `toHTMLAttrNameRuntime` (runtime spread paths). Names NOT in this
+ * table pass through unchanged, so `data-*`, `aria-*`, and custom-element
+ * attributes are never rewritten.
+ */
+const HTML_CAMEL_ALIASES: Readonly<Record<string, string>> = {
+  acceptCharset: 'accept-charset',
+  accessKey: 'accesskey',
+  allowFullScreen: 'allowfullscreen',
+  autoCapitalize: 'autocapitalize',
+  autoComplete: 'autocomplete',
+  autoCorrect: 'autocorrect',
+  autoFocus: 'autofocus',
+  autoPlay: 'autoplay',
+  cellPadding: 'cellpadding',
+  cellSpacing: 'cellspacing',
+  charSet: 'charset',
+  colSpan: 'colspan',
+  contentEditable: 'contenteditable',
+  controlsList: 'controlslist',
+  crossOrigin: 'crossorigin',
+  dateTime: 'datetime',
+  dirName: 'dirname',
+  encType: 'enctype',
+  enterKeyHint: 'enterkeyhint',
+  fetchPriority: 'fetchpriority',
+  formAction: 'formaction',
+  formEncType: 'formenctype',
+  formMethod: 'formmethod',
+  formNoValidate: 'formnovalidate',
+  formTarget: 'formtarget',
+  frameBorder: 'frameborder',
+  hrefLang: 'hreflang',
+  httpEquiv: 'http-equiv',
+  imageSizes: 'imagesizes',
+  imageSrcSet: 'imagesrcset',
+  inputMode: 'inputmode',
+  itemID: 'itemid',
+  itemProp: 'itemprop',
+  itemRef: 'itemref',
+  itemScope: 'itemscope',
+  itemType: 'itemtype',
+  marginHeight: 'marginheight',
+  marginWidth: 'marginwidth',
+  maxLength: 'maxlength',
+  minLength: 'minlength',
+  noModule: 'nomodule',
+  noValidate: 'novalidate',
+  playsInline: 'playsinline',
+  popoverTarget: 'popovertarget',
+  popoverTargetAction: 'popovertargetaction',
+  radioGroup: 'radiogroup',
+  readOnly: 'readonly',
+  referrerPolicy: 'referrerpolicy',
+  rowSpan: 'rowspan',
+  spellCheck: 'spellcheck',
+  srcDoc: 'srcdoc',
+  srcLang: 'srclang',
+  srcSet: 'srcset',
+  tabIndex: 'tabindex',
+  useMap: 'usemap',
+}
+
+/**
  * SVG XML attribute names that are case-sensitive and MUST stay in camelCase.
  *
  * These are distinct from the CSS-style presentation attrs above: `viewBox`
@@ -169,6 +242,8 @@ export function classifyDOMProp(key: string): DOMPropClassification {
 export function toHTMLAttrName(key: string): string {
   if (key === 'className') return 'class'
   if (key === 'htmlFor')   return 'for'
+  const htmlAlias = HTML_CAMEL_ALIASES[key]
+  if (htmlAlias !== undefined) return htmlAlias
   const svgKebab = SVG_CAMEL_TO_KEBAB[key]
   if (svgKebab !== undefined) return svgKebab
   return key
@@ -178,13 +253,17 @@ export function toHTMLAttrName(key: string): string {
  * Runtime variant of attribute name mapping that additionally applies
  * camelCase→kebab conversion for `data-*` and `aria-*` convenience
  * props (e.g. `dataTestId` → `data-test-id`) and preserves SVG XML
- * attribute casing. All other non-SVG keys pass through unchanged —
- * standard HTML attributes like `tabIndex` and `autoFocus` must not
- * be kebab-cased (`tab-index` / `auto-focus` are not valid attrs).
+ * attribute casing. HTML camelCase aliases resolve through the same
+ * `HTML_CAMEL_ALIASES` table as the compile-time variant (`tabIndex` →
+ * `tabindex`); generic kebab-casing still applies ONLY to `data-*` /
+ * `aria-*` — an unknown camelCase key passes through unchanged rather
+ * than being guessed into a hyphenated non-attribute.
  */
 export function toHTMLAttrNameRuntime(key: string): string {
   if (key === 'className') return 'class'
   if (key === 'htmlFor')   return 'for'
+  const htmlAlias = HTML_CAMEL_ALIASES[key]
+  if (htmlAlias !== undefined) return htmlAlias
   const svgKebab = SVG_CAMEL_TO_KEBAB[key]
   if (svgKebab !== undefined) return svgKebab
   if (SVG_XML_CAMEL_ATTRS.has(key)) return key

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1892,74 +1892,6 @@
           ]
         }
       },
-      "boolean-attr-literals": {
-        "blade": {
-          "kind": "render",
-          "reason": "camelCase boolean alias `readOnly`: Hono SSRs `readOnly=\"true\"`, this adapter emits bare presence"
-        },
-        "erb": {
-          "kind": "render",
-          "reason": "camelCase boolean alias `readOnly`: Hono SSRs `readOnly=\"true\"`, this adapter emits bare presence"
-        },
-        "go-template": {
-          "kind": "render",
-          "reason": "camelCase boolean alias `readOnly`: Hono SSRs `readOnly=\"true\"`, this adapter emits bare presence"
-        },
-        "jinja": {
-          "kind": "render",
-          "reason": "camelCase boolean alias `readOnly`: Hono SSRs `readOnly=\"true\"`, this adapter emits bare presence"
-        },
-        "minijinja": {
-          "kind": "render",
-          "reason": "camelCase boolean alias `readOnly`: Hono SSRs `readOnly=\"true\"`, this adapter emits bare presence"
-        },
-        "mojolicious": {
-          "kind": "render",
-          "reason": "camelCase boolean alias `readOnly`: Hono SSRs `readOnly=\"true\"`, this adapter emits bare presence"
-        },
-        "twig": {
-          "kind": "render",
-          "reason": "camelCase boolean alias `readOnly`: Hono SSRs `readOnly=\"true\"`, this adapter emits bare presence"
-        },
-        "xslate": {
-          "kind": "render",
-          "reason": "camelCase boolean alias `readOnly`: Hono SSRs `readOnly=\"true\"`, this adapter emits bare presence"
-        }
-      },
-      "camelcase-attributes": {
-        "blade": {
-          "kind": "render",
-          "reason": "`htmlFor` is not lowered to `for` (Hono maps it)"
-        },
-        "erb": {
-          "kind": "render",
-          "reason": "`htmlFor` is not lowered to `for` (Hono maps it)"
-        },
-        "go-template": {
-          "kind": "render",
-          "reason": "`htmlFor` is not lowered to `for` (Hono maps it)"
-        },
-        "jinja": {
-          "kind": "render",
-          "reason": "`htmlFor` is not lowered to `for` (Hono maps it)"
-        },
-        "minijinja": {
-          "kind": "render",
-          "reason": "`htmlFor` is not lowered to `for` (Hono maps it)"
-        },
-        "mojolicious": {
-          "kind": "render",
-          "reason": "`htmlFor` is not lowered to `for` (Hono maps it)"
-        },
-        "twig": {
-          "kind": "render",
-          "reason": "`htmlFor` is not lowered to `for` (Hono maps it)"
-        },
-        "xslate": {
-          "kind": "render",
-          "reason": "`htmlFor` is not lowered to `for` (Hono maps it)"
-        }
-      },
       "child-primitive-props": {
         "go-template": {
           "kind": "render",
@@ -2708,40 +2640,6 @@
         "xslate": {
           "kind": "render",
           "reason": "`.trimStart()` / `.trimEnd()` render empty (no lowering)"
-        }
-      },
-      "svg-icon": {
-        "blade": {
-          "kind": "render",
-          "reason": "SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case"
-        },
-        "erb": {
-          "kind": "render",
-          "reason": "SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case"
-        },
-        "go-template": {
-          "kind": "render",
-          "reason": "SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case"
-        },
-        "jinja": {
-          "kind": "render",
-          "reason": "SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case"
-        },
-        "minijinja": {
-          "kind": "render",
-          "reason": "SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case"
-        },
-        "mojolicious": {
-          "kind": "render",
-          "reason": "SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case"
-        },
-        "twig": {
-          "kind": "render",
-          "reason": "SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case"
-        },
-        "xslate": {
-          "kind": "render",
-          "reason": "SVG camelCase presentation attrs (`strokeWidth`, `strokeLinecap`) pass through unmapped; Hono lowers to kebab-case"
         }
       },
       "todo-app": {


### PR DESCRIPTION
# Divergence-resolution stack 2/N — attribute-name normalization

**Stacked on #2171** (base: `claude/divergence-a-falsy-children`). Same principle: the IR carries the semantics; adapters emit from it.

## What

`IRAttribute.name` now carries the canonical HTML/SVG attribute name, normalized **once** in Phase 1 (`processAttributes`), so every adapter emits it verbatim. Previously each adapter re-derived at most `className` → `class` itself, and every other alias leaked into the emitted HTML as an unknown attribute the browser ignores:

- `htmlFor` never became `for` on template backends → broken label association
- `readOnly` rendered as `readOnly="true"` (Hono) vs bare presence (template backends) — neither the valid boolean `readonly`
- SVG `strokeWidth` / `strokeLinecap` passed through unmapped
- `tabIndex` / `maxLength` / `autoComplete` / `spellCheck` leaked camelCase

## How

- The shared `dom-prop` classifier (`@barefootjs/shared`) grows an `HTML_CAMEL_ALIASES` table (React-style camelCase → HTML lowercase, ~55 entries), consulted by both `toHTMLAttrName` (now applied in Phase 1) and `toHTMLAttrNameRuntime` (runtime spread paths) — one source of truth for compile time and runtime.
- SVG presentation attrs already in `SVG_CAMEL_TO_KEBAB` now reach template backends too; case-sensitive SVG XML names (`viewBox`) and unknown names (`data-*`, custom-element attrs) pass through unchanged. Component props (`IRProp`) keep the user's API names.
- **One deliberate adapter-side mapping remains**: the Hono adapter maps `class` → `className` at JSX attribute emit, because its target language is JSX typed against `@barefootjs/jsx` html-types, whose vocabulary is exactly the lowercase HTML names plus the single JSX-ism `className` (`class?: never`, #773). That's target-language emission — the JSX equivalent of Go emitting `{{.X}}` — and the pre-existing #773 contract tests pin it.

## Graduations

- `camelcase-attributes`, `svg-icon`, `boolean-attr-literals` removed from **all 8** adapters' `renderDivergences` and the CSR skip list
- `ui/compat.lock.json`: 30 → **27** divergent fixtures
- `expectedHtml` regenerated: `readonly` bare boolean, lowercase aliases (`autocomplete` / `maxlength` / `spellcheck="false"` / `tabindex`)

## Verified

Full `packages/jsx` (2,363), `packages/shared` + `packages/client` (452), all 9 adapter conformance suites on real backends, adapter-tests (incl. the #773 marked-template contract) + compat — all green. Tests that asserted the raw JSX spelling in the IR updated (`className` → `class`), one client-JS snapshot (`tabindex`), and dom-prop unit tests extended for the alias table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ZXzQWvSKLUUrTAZ3vph1j

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZXzQWvSKLUUrTAZ3vph1j)_