### PR TITLE
Preserve source grouping in family binary emitters (divergence stack 3/N)

### DIFF
--- a/.changeset/preserve-binary-grouping.md
+++ b/.changeset/preserve-binary-grouping.md
@@ -1,0 +1,11 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/jinja": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+"@barefootjs/twig": patch
+"@barefootjs/blade": patch
+"@barefootjs/rust": patch
+---
+
+Preserve source grouping when re-emitting binary expressions as infix template text. `(count() + 2) * 3` parses into an unambiguous `ParsedExpr` tree, but the EP/Jinja-family emitters joined operands textually (`l op r`), re-exposing the text to the target language's precedence — the SSR output silently computed `count + 2 * 3` (10 instead of 18) on Mojolicious, Text::Xslate, Twig, Jinja, Blade, and minijinja (ERB and Go already parenthesized). The grouping decision now lives in the shared layer as `groupBinaryOperand` (exported from `@barefootjs/jsx`): a compound operand (binary/logical/conditional) is parenthesized, leaf operands stay unwrapped so existing simple emissions are byte-identical. The `arithmetic-text` fixture graduates from those six adapters' `renderDivergences` declarations.

--- a/packages/adapter-blade/src/adapter/expr/emitters.ts
+++ b/packages/adapter-blade/src/adapter/expr/emitters.ts
@@ -82,7 +82,7 @@
  *      entry point `_renderBladeFilterExprPublic`.
  */
 
-import {
+import { groupBinaryOperand,
   type ParsedExprEmitter,
   type HigherOrderMethod,
   type ArrayMethod,
@@ -208,8 +208,11 @@ export class BladeFilterEmitter implements ParsedExprEmitter {
   }
 
   binary(op: string, left: ParsedExpr, right: ParsedExpr, emit: (e: ParsedExpr) => string): string {
-    const l = emit(left)
-    const r = emit(right)
+    // Preserve source grouping: a compound operand re-emitted as infix
+    // text is otherwise re-parsed under THIS language's precedence —
+    // `(count() + 2) * 3` would silently become `count + 2 * 3` (#2173).
+    const l = groupBinaryOperand(left, emit(left))
+    const r = groupBinaryOperand(right, emit(right))
     // See the file header, divergence 8: PHP's `==`/`!=`/`===`/`!==` are
     // NEVER emitted for JS `===`/`!==`. `$bf->eq`/`$bf->neq` are the one
     // shared JS-strict-equality implementation.
@@ -405,8 +408,11 @@ export class BladeTopLevelEmitter implements ParsedExprEmitter {
   }
 
   binary(op: string, left: ParsedExpr, right: ParsedExpr, emit: (e: ParsedExpr) => string): string {
-    const l = emit(left)
-    const r = emit(right)
+    // Preserve source grouping: a compound operand re-emitted as infix
+    // text is otherwise re-parsed under THIS language's precedence —
+    // `(count() + 2) * 3` would silently become `count + 2 * 3` (#2173).
+    const l = groupBinaryOperand(left, emit(left))
+    const r = groupBinaryOperand(right, emit(right))
     // See the file header, divergence 8: PHP's `==`/`!=`/`===`/`!==` are
     // NEVER emitted for JS `===`/`!==`.
     if (op === '===') return `$bf->eq(${l}, ${r})`

--- a/packages/adapter-blade/src/render-divergences.ts
+++ b/packages/adapter-blade/src/render-divergences.ts
@@ -15,8 +15,6 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
-  'arithmetic-text':
-    '`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)',
   'string-concat-plus':
     '`\'Hello, \' + name` is emitted as PHP `+`, which fatals with "Unsupported operand types: string + string" — needs PHP\'s `.` concat',
   'html-entity-text':

--- a/packages/adapter-jinja/src/adapter/expr/emitters.ts
+++ b/packages/adapter-jinja/src/adapter/expr/emitters.ts
@@ -48,7 +48,7 @@
  *      entry point `_renderJinjaFilterExprPublic`.
  */
 
-import {
+import { groupBinaryOperand,
   type ParsedExprEmitter,
   type HigherOrderMethod,
   type ArrayMethod,
@@ -175,8 +175,11 @@ export class JinjaFilterEmitter implements ParsedExprEmitter {
   }
 
   binary(op: string, left: ParsedExpr, right: ParsedExpr, emit: (e: ParsedExpr) => string): string {
-    const l = emit(left)
-    const r = emit(right)
+    // Preserve source grouping: a compound operand re-emitted as infix
+    // text is otherwise re-parsed under THIS language's precedence —
+    // `(count() + 2) * 3` would silently become `count + 2 * 3` (#2173).
+    const l = groupBinaryOperand(left, emit(left))
+    const r = groupBinaryOperand(right, emit(right))
     // Jinja's `==` / `!=` are value-equality operators that compare strings
     // and numbers correctly — unlike Perl's numeric `==` (which the Mojo
     // adapter must steer around with `eq`/`ne`). Same reasoning as Kolon.
@@ -378,8 +381,11 @@ export class JinjaTopLevelEmitter implements ParsedExprEmitter {
   }
 
   binary(op: string, left: ParsedExpr, right: ParsedExpr, emit: (e: ParsedExpr) => string): string {
-    const l = emit(left)
-    const r = emit(right)
+    // Preserve source grouping: a compound operand re-emitted as infix
+    // text is otherwise re-parsed under THIS language's precedence —
+    // `(count() + 2) * 3` would silently become `count + 2 * 3` (#2173).
+    const l = groupBinaryOperand(left, emit(left))
+    const r = groupBinaryOperand(right, emit(right))
     // Jinja's `==` / `!=` handle both strings and numbers (unlike Perl's
     // numeric `==`), so all equality comparisons stay on `==` / `!=`.
     const opMap: Record<string, string> = {

--- a/packages/adapter-jinja/src/render-divergences.ts
+++ b/packages/adapter-jinja/src/render-divergences.ts
@@ -15,8 +15,6 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
-  'arithmetic-text':
-    '`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)',
   'html-entity-text':
     '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
   'math-methods':

--- a/packages/adapter-mojolicious/src/adapter/expr/emitters.ts
+++ b/packages/adapter-mojolicious/src/adapter/expr/emitters.ts
@@ -11,7 +11,7 @@
  *     adapter only through the narrow `MojoEmitContext` seam.
  */
 
-import {
+import { groupBinaryOperand,
   type ParsedExprEmitter,
   type HigherOrderMethod,
   type ArrayMethod,
@@ -141,8 +141,11 @@ export class MojoFilterEmitter implements ParsedExprEmitter {
   }
 
   binary(op: string, left: ParsedExpr, right: ParsedExpr, emit: (e: ParsedExpr) => string): string {
-    const l = emit(left)
-    const r = emit(right)
+    // Preserve source grouping: a compound operand re-emitted as infix
+    // text is otherwise re-parsed under THIS language's precedence —
+    // `(count() + 2) * 3` would silently become `count + 2 * 3` (#2173).
+    const l = groupBinaryOperand(left, emit(left))
+    const r = groupBinaryOperand(right, emit(right))
     // String equality: `eq`/`ne` when EITHER operand is string-typed — a string
     // literal, a string signal getter, or a string prop. Numeric `==`/`!=`
     // would coerce both sides to 0 and match unrelated non-numeric strings (#1672).
@@ -389,8 +392,11 @@ export class MojoTopLevelEmitter implements ParsedExprEmitter {
   }
 
   binary(op: string, left: ParsedExpr, right: ParsedExpr, emit: (e: ParsedExpr) => string): string {
-    const l = emit(left)
-    const r = emit(right)
+    // Preserve source grouping: a compound operand re-emitted as infix
+    // text is otherwise re-parsed under THIS language's precedence —
+    // `(count() + 2) * 3` would silently become `count + 2 * 3` (#2173).
+    const l = groupBinaryOperand(left, emit(left))
+    const r = groupBinaryOperand(right, emit(right))
     // String equality: `eq`/`ne` when EITHER operand is string-typed — a string
     // literal (`role() === 'admin'`), a string signal getter (`sel()`), or a
     // string prop (`props.x`). Falling back to numeric `==`/`!=` would make

--- a/packages/adapter-mojolicious/src/render-divergences.ts
+++ b/packages/adapter-mojolicious/src/render-divergences.ts
@@ -15,8 +15,6 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
-  'arithmetic-text':
-    '`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)',
   'string-concat-plus':
     "`'Hello, ' + name` renders \"0\" — Perl's numeric `+` coerces the strings; JS string-concat `+` needs Perl's `.`",
   'string-length-text':

--- a/packages/adapter-rust/src/adapter/expr/emitters.ts
+++ b/packages/adapter-rust/src/adapter/expr/emitters.ts
@@ -48,7 +48,7 @@
  *      entry point `_renderJinjaFilterExprPublic`.
  */
 
-import {
+import { groupBinaryOperand,
   type ParsedExprEmitter,
   type HigherOrderMethod,
   type ArrayMethod,
@@ -175,8 +175,11 @@ export class JinjaFilterEmitter implements ParsedExprEmitter {
   }
 
   binary(op: string, left: ParsedExpr, right: ParsedExpr, emit: (e: ParsedExpr) => string): string {
-    const l = emit(left)
-    const r = emit(right)
+    // Preserve source grouping: a compound operand re-emitted as infix
+    // text is otherwise re-parsed under THIS language's precedence —
+    // `(count() + 2) * 3` would silently become `count + 2 * 3` (#2173).
+    const l = groupBinaryOperand(left, emit(left))
+    const r = groupBinaryOperand(right, emit(right))
     // Jinja's `==` / `!=` are value-equality operators that compare strings
     // and numbers correctly — unlike Perl's numeric `==` (which the Mojo
     // adapter must steer around with `eq`/`ne`). Same reasoning as Kolon.
@@ -378,8 +381,11 @@ export class JinjaTopLevelEmitter implements ParsedExprEmitter {
   }
 
   binary(op: string, left: ParsedExpr, right: ParsedExpr, emit: (e: ParsedExpr) => string): string {
-    const l = emit(left)
-    const r = emit(right)
+    // Preserve source grouping: a compound operand re-emitted as infix
+    // text is otherwise re-parsed under THIS language's precedence —
+    // `(count() + 2) * 3` would silently become `count + 2 * 3` (#2173).
+    const l = groupBinaryOperand(left, emit(left))
+    const r = groupBinaryOperand(right, emit(right))
     // Jinja's `==` / `!=` handle both strings and numbers (unlike Perl's
     // numeric `==`), so all equality comparisons stay on `==` / `!=`.
     const opMap: Record<string, string> = {

--- a/packages/adapter-rust/src/render-divergences.ts
+++ b/packages/adapter-rust/src/render-divergences.ts
@@ -17,8 +17,6 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
-  'arithmetic-text':
-    '`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)',
   'html-entity-text':
     '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
   'math-methods':

--- a/packages/adapter-twig/src/adapter/expr/emitters.ts
+++ b/packages/adapter-twig/src/adapter/expr/emitters.ts
@@ -59,7 +59,7 @@
  *      entry point `_renderTwigFilterExprPublic`.
  */
 
-import {
+import { groupBinaryOperand,
   type ParsedExprEmitter,
   type HigherOrderMethod,
   type ArrayMethod,
@@ -187,8 +187,11 @@ export class TwigFilterEmitter implements ParsedExprEmitter {
   }
 
   binary(op: string, left: ParsedExpr, right: ParsedExpr, emit: (e: ParsedExpr) => string): string {
-    const l = emit(left)
-    const r = emit(right)
+    // Preserve source grouping: a compound operand re-emitted as infix
+    // text is otherwise re-parsed under THIS language's precedence —
+    // `(count() + 2) * 3` would silently become `count + 2 * 3` (#2173).
+    const l = groupBinaryOperand(left, emit(left))
+    const r = groupBinaryOperand(right, emit(right))
     // See the file header, divergence 4: Twig's `==`/`!=` are PHP loose
     // equality — NEVER emit them for JS `===`/`!==`. `bf.eq`/`bf.neq` are
     // the one shared JS-strict-equality implementation.
@@ -384,8 +387,11 @@ export class TwigTopLevelEmitter implements ParsedExprEmitter {
   }
 
   binary(op: string, left: ParsedExpr, right: ParsedExpr, emit: (e: ParsedExpr) => string): string {
-    const l = emit(left)
-    const r = emit(right)
+    // Preserve source grouping: a compound operand re-emitted as infix
+    // text is otherwise re-parsed under THIS language's precedence —
+    // `(count() + 2) * 3` would silently become `count + 2 * 3` (#2173).
+    const l = groupBinaryOperand(left, emit(left))
+    const r = groupBinaryOperand(right, emit(right))
     // See the file header, divergence 4: Twig's `==`/`!=` are PHP loose
     // equality — NEVER emit them for JS `===`/`!==`.
     if (op === '===') return `bf.eq(${l}, ${r})`

--- a/packages/adapter-twig/src/render-divergences.ts
+++ b/packages/adapter-twig/src/render-divergences.ts
@@ -15,8 +15,6 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
-  'arithmetic-text':
-    '`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)',
   'string-concat-plus':
     "`'Hello, ' + name` lowers through Twig's numeric `+` instead of `~` string concat",
   'html-entity-text':

--- a/packages/adapter-xslate/src/adapter/expr/emitters.ts
+++ b/packages/adapter-xslate/src/adapter/expr/emitters.ts
@@ -11,7 +11,7 @@
  *     the adapter only through the narrow `XslateEmitContext` seam.
  */
 
-import {
+import { groupBinaryOperand,
   type ParsedExprEmitter,
   type HigherOrderMethod,
   type ArrayMethod,
@@ -130,8 +130,11 @@ export class XslateFilterEmitter implements ParsedExprEmitter {
   }
 
   binary(op: string, left: ParsedExpr, right: ParsedExpr, emit: (e: ParsedExpr) => string): string {
-    const l = emit(left)
-    const r = emit(right)
+    // Preserve source grouping: a compound operand re-emitted as infix
+    // text is otherwise re-parsed under THIS language's precedence —
+    // `(count() + 2) * 3` would silently become `count + 2 * 3` (#2173).
+    const l = groupBinaryOperand(left, emit(left))
+    const r = groupBinaryOperand(right, emit(right))
     // Kolon's `==` / `!=` are value-equality operators that compare strings
     // and numbers correctly — unlike Perl's numeric `==` (which the Mojo
     // adapter must steer around with `eq`/`ne`). Kolon has no `eq`/`ne`
@@ -322,8 +325,11 @@ export class XslateTopLevelEmitter implements ParsedExprEmitter {
   }
 
   binary(op: string, left: ParsedExpr, right: ParsedExpr, emit: (e: ParsedExpr) => string): string {
-    const l = emit(left)
-    const r = emit(right)
+    // Preserve source grouping: a compound operand re-emitted as infix
+    // text is otherwise re-parsed under THIS language's precedence —
+    // `(count() + 2) * 3` would silently become `count + 2 * 3` (#2173).
+    const l = groupBinaryOperand(left, emit(left))
+    const r = groupBinaryOperand(right, emit(right))
     // Kolon's `==` / `!=` are value-equality operators handling both strings
     // and numbers (unlike Perl's numeric `==`, which the Mojo adapter must
     // route around with `eq`/`ne`). Kolon has no `eq`/`ne` operator, so all

--- a/packages/adapter-xslate/src/render-divergences.ts
+++ b/packages/adapter-xslate/src/render-divergences.ts
@@ -15,8 +15,6 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
-  'arithmetic-text':
-    '`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)',
   'string-concat-plus':
     "`'Hello, ' + name` numeric-coerces through Perl's `+` (needs `.`/`~` concat)",
   'html-entity-text':

--- a/packages/jsx/src/adapters/parsed-expr-emitter.ts
+++ b/packages/jsx/src/adapters/parsed-expr-emitter.ts
@@ -207,6 +207,26 @@ export interface ParsedExprEmitter {
  * a TS compile error here — and, transitively, in every adapter that
  * hasn't extended its `ParsedExprEmitter` implementation.
  */
+/**
+ * Wrap an emitted binary/logical/ternary OPERAND in parentheses so the
+ * source grouping the `ParsedExpr` tree encodes survives infix
+ * re-emission (#2173). `(count() + 2) * 3` parses as
+ * `binary{*, binary{+}, 3}` — the tree is unambiguous, but an emitter
+ * that joins operands textually (`${l} ${op} ${r}`) re-exposes the
+ * text to the TARGET language's precedence, silently computing
+ * `count + 2 * 3`. Grouping is decided here, in the shared layer
+ * (the semantics), so adapters just call this on each operand — no
+ * per-language precedence table needed: parenthesizing a compound
+ * operand is universally valid, and leaf operands (identifiers,
+ * literals, calls, members) stay unwrapped so simple emissions remain
+ * byte-identical.
+ */
+export function groupBinaryOperand(operand: ParsedExpr, emitted: string): string {
+  return operand.kind === 'binary' || operand.kind === 'logical' || operand.kind === 'conditional'
+    ? `(${emitted})`
+    : emitted
+}
+
 export function emitParsedExpr(expr: ParsedExpr, emitter: ParsedExprEmitter): string {
   const emit = (child: ParsedExpr): string => emitParsedExpr(child, emitter)
   switch (expr.kind) {

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -85,7 +85,7 @@ export type {
 export { JsxAdapter } from './adapters/jsx-adapter.ts'
 export type { JsxAdapterConfig } from './adapters/jsx-adapter.ts'
 export { rewriteImportsForTemplate } from './adapters/template-imports.ts'
-export { emitParsedExpr } from './adapters/parsed-expr-emitter.ts'
+export { emitParsedExpr, groupBinaryOperand } from './adapters/parsed-expr-emitter.ts'
 export type { ParsedExprEmitter, HigherOrderMethod, ArrayMethod, SortMethod, LiteralType } from './adapters/parsed-expr-emitter.ts'
 export { importsSearchParams, searchParamsLocalNames, envSignalLocalNames, envSignalReaderFor, ENV_SIGNAL_READERS, queryHrefLocalNames, matchSearchParamsMethodCall } from './adapters/env-signal.ts'
 export type { EnvSignalReader } from './adapters/env-signal.ts'

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1816,32 +1816,6 @@
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
     "totalFixtures": 236,
     "fixtures": {
-      "arithmetic-text": {
-        "blade": {
-          "kind": "render",
-          "reason": "`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)"
-        },
-        "jinja": {
-          "kind": "render",
-          "reason": "`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)"
-        },
-        "minijinja": {
-          "kind": "render",
-          "reason": "`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)"
-        },
-        "mojolicious": {
-          "kind": "render",
-          "reason": "`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)"
-        },
-        "twig": {
-          "kind": "render",
-          "reason": "`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)"
-        },
-        "xslate": {
-          "kind": "render",
-          "reason": "`(count() + 2) * 3` renders 10 instead of 18 — the parenthesised sub-expression loses its grouping (silent wrong arithmetic)"
-        }
-      },
       "array-map-function-reference": {
         "blade": {
           "kind": "refusal",


### PR DESCRIPTION
# Divergence-resolution stack 3/N — binary-expression grouping

**Stacked on #2172** (base: `claude/divergence-c-attr-names`).

## What

`(count() + 2) * 3` parses into an unambiguous `ParsedExpr` tree — `binary{*, binary{+}, 3}` — but the EP/Jinja-family emitters joined operands textually (`l op r`), re-exposing the emitted text to the **target language's** precedence. SSR silently computed `count + 2 * 3` (**10 instead of 18**) on Mojolicious, Text::Xslate, Twig, Jinja, Blade, and minijinja. ERB and Go already parenthesized. This was the `arithmetic-text` divergence — the sweep's highest-priority finding for these adapters (silent wrong arithmetic).

## How

The grouping decision lives in the shared layer: `groupBinaryOperand` (in `parsed-expr-emitter.ts`, exported from `@barefootjs/jsx`) parenthesizes a **compound** operand (binary / logical / conditional) and leaves leaf operands (identifiers, literals, calls, members) unwrapped. Each family adapter's two `binary()` emitters route both operands through it — no per-language precedence table, and simple emissions stay byte-identical (**zero golden churn** across all six adapters' unit suites).

## Graduations

- `arithmetic-text` removed from the six adapters' `renderDivergences` declarations
- `ui/compat.lock.json`: 27 → **26** divergent fixtures

## Verified

All 9 adapter conformance suites on real backends, adapter-tests + compat + full jsx unit suites — all green (3,707 shared+jsx tests, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ZXzQWvSKLUUrTAZ3vph1j

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZXzQWvSKLUUrTAZ3vph1j)_