### PR TITLE
ci: fix Packagist notify auth (Bearer header + token-owner username)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -355,14 +355,23 @@ jobs:
 
       - name: Notify Packagist
         env:
-          PACKAGIST_USERNAME: ${{ vars.PACKAGIST_USERNAME || 'barefootjs' }}
+          # Packagist authenticates as the account that OWNS the API token, so
+          # this must be that user's login (kfly8) — NOT the "barefootjs"
+          # vendor namespace. A username/token-owner mismatch is rejected with
+          # 403. Override via the PACKAGIST_USERNAME repo variable if the token
+          # owner ever changes.
+          PACKAGIST_USERNAME: ${{ vars.PACKAGIST_USERNAME || 'kfly8' }}
           PACKAGIST_API_TOKEN: ${{ secrets.PACKAGIST_API_TOKEN }}
         run: |
-          curl -sSf -XPOST \
+          # Packagist's documented auth is a Bearer header of the form
+          # "username:token" (https://packagist.org/apidoc). The "API-Token"
+          # header this used before is not recognized, so every request went
+          # out unauthenticated and 403'd regardless of the token.
+          curl -sSf -X POST \
             -H 'Content-Type: application/json' \
-            -H "API-Token: ${PACKAGIST_API_TOKEN}" \
-            "https://packagist.org/api/update-package?username=${PACKAGIST_USERNAME}" \
-            -d '{"repository":{"url":"https://packagist.org/packages/barefootjs/twig"}}'
+            -H "Authorization: Bearer ${PACKAGIST_USERNAME}:${PACKAGIST_API_TOKEN}" \
+            'https://packagist.org/api/update-package' \
+            -d '{"repository":"https://packagist.org/packages/barefootjs/twig"}'
 
   packagist-blade-release:
     needs: release
@@ -431,14 +440,17 @@ jobs:
 
       - name: Notify Packagist
         env:
-          PACKAGIST_USERNAME: ${{ vars.PACKAGIST_USERNAME || 'barefootjs' }}
+          # See the Twig job: username must be the API token's owner (kfly8),
+          # not the "barefootjs" vendor namespace.
+          PACKAGIST_USERNAME: ${{ vars.PACKAGIST_USERNAME || 'kfly8' }}
           PACKAGIST_API_TOKEN: ${{ secrets.PACKAGIST_API_TOKEN }}
         run: |
-          curl -sSf -XPOST \
+          # See the Twig job: Packagist wants a Bearer "username:token" header.
+          curl -sSf -X POST \
             -H 'Content-Type: application/json' \
-            -H "API-Token: ${PACKAGIST_API_TOKEN}" \
-            "https://packagist.org/api/update-package?username=${PACKAGIST_USERNAME}" \
-            -d '{"repository":{"url":"https://packagist.org/packages/barefootjs/blade"}}'
+            -H "Authorization: Bearer ${PACKAGIST_USERNAME}:${PACKAGIST_API_TOKEN}" \
+            'https://packagist.org/api/update-package' \
+            -d '{"repository":"https://packagist.org/packages/barefootjs/blade"}'
 
   # Mirrors packagist-twig-release's shape for the engine-agnostic PHP runtime
   # package (packages/adapter-php, Composer name barefootjs/php) --
@@ -498,11 +510,14 @@ jobs:
 
       - name: Notify Packagist
         env:
-          PACKAGIST_USERNAME: ${{ vars.PACKAGIST_USERNAME || 'barefootjs' }}
+          # See the Twig job: username must be the API token's owner (kfly8),
+          # not the "barefootjs" vendor namespace.
+          PACKAGIST_USERNAME: ${{ vars.PACKAGIST_USERNAME || 'kfly8' }}
           PACKAGIST_API_TOKEN: ${{ secrets.PACKAGIST_API_TOKEN }}
         run: |
-          curl -sSf -XPOST \
+          # See the Twig job: Packagist wants a Bearer "username:token" header.
+          curl -sSf -X POST \
             -H 'Content-Type: application/json' \
-            -H "API-Token: ${PACKAGIST_API_TOKEN}" \
-            "https://packagist.org/api/update-package?username=${PACKAGIST_USERNAME}" \
-            -d '{"repository":{"url":"https://packagist.org/packages/barefootjs/php"}}'
+            -H "Authorization: Bearer ${PACKAGIST_USERNAME}:${PACKAGIST_API_TOKEN}" \
+            'https://packagist.org/api/update-package' \
+            -d '{"repository":"https://packagist.org/packages/barefootjs/php"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -355,18 +355,11 @@ jobs:
 
       - name: Notify Packagist
         env:
-          # Packagist authenticates as the account that OWNS the API token, so
-          # this must be that user's login (kfly8) — NOT the "barefootjs"
-          # vendor namespace. A username/token-owner mismatch is rejected with
-          # 403. Override via the PACKAGIST_USERNAME repo variable if the token
-          # owner ever changes.
+          # Must be the API token's owner, not the "barefootjs" vendor namespace.
           PACKAGIST_USERNAME: ${{ vars.PACKAGIST_USERNAME || 'kfly8' }}
           PACKAGIST_API_TOKEN: ${{ secrets.PACKAGIST_API_TOKEN }}
         run: |
-          # Packagist's documented auth is a Bearer header of the form
-          # "username:token" (https://packagist.org/apidoc). The "API-Token"
-          # header this used before is not recognized, so every request went
-          # out unauthenticated and 403'd regardless of the token.
+          # Bearer "username:token" auth per https://packagist.org/apidoc.
           curl -sSf -X POST \
             -H 'Content-Type: application/json' \
             -H "Authorization: Bearer ${PACKAGIST_USERNAME}:${PACKAGIST_API_TOKEN}" \
@@ -440,12 +433,9 @@ jobs:
 
       - name: Notify Packagist
         env:
-          # See the Twig job: username must be the API token's owner (kfly8),
-          # not the "barefootjs" vendor namespace.
           PACKAGIST_USERNAME: ${{ vars.PACKAGIST_USERNAME || 'kfly8' }}
           PACKAGIST_API_TOKEN: ${{ secrets.PACKAGIST_API_TOKEN }}
         run: |
-          # See the Twig job: Packagist wants a Bearer "username:token" header.
           curl -sSf -X POST \
             -H 'Content-Type: application/json' \
             -H "Authorization: Bearer ${PACKAGIST_USERNAME}:${PACKAGIST_API_TOKEN}" \
@@ -510,12 +500,9 @@ jobs:
 
       - name: Notify Packagist
         env:
-          # See the Twig job: username must be the API token's owner (kfly8),
-          # not the "barefootjs" vendor namespace.
           PACKAGIST_USERNAME: ${{ vars.PACKAGIST_USERNAME || 'kfly8' }}
           PACKAGIST_API_TOKEN: ${{ secrets.PACKAGIST_API_TOKEN }}
         run: |
-          # See the Twig job: Packagist wants a Bearer "username:token" header.
           curl -sSf -X POST \
             -H 'Content-Type: application/json' \
             -H "Authorization: Bearer ${PACKAGIST_USERNAME}:${PACKAGIST_API_TOKEN}" \


### PR DESCRIPTION
## Why the `Notify Packagist` step kept 403'ing

Even after `PACKAGIST_API_TOKEN` was set (to kfly8's Safe token), the step still failed with `curl: (22) 403`. The job's `env:` echo was the smoking gun:

```
PACKAGIST_USERNAME: barefootjs
PACKAGIST_API_TOKEN: ***
```

Two independent bugs, both producing 403:

### 1. Wrong auth method (primary cause)
Packagist's documented API ([packagist.org/apidoc](https://packagist.org/apidoc)) authenticates with:
```
Authorization: Bearer <username>:<token>
```
The step instead sent an `API-Token:` header, which Packagist does **not** recognize — so every request went out **unauthenticated** and 403'd. This is why the original empty-token run and the later token-set run failed identically: the header was never the right mechanism, so the token value was irrelevant.

### 2. Wrong username
Packagist authenticates as the **account that owns the token** — `kfly8`. The call used `username=barefootjs`, which is the Composer **vendor namespace** (`barefootjs/twig`), not a Packagist account. Even a run with the secret populated logged `PACKAGIST_USERNAME: barefootjs` and 403'd.

(The `PACKAGIST_USERNAME=kfly8` repo variable that was set didn't take effect on the "re-run failed jobs" — the env still showed `barefootjs`, the old fallback. Defaulting to `kfly8` in the workflow makes it work without depending on the variable.)

## Change

All three notify steps (twig / blade / php):
- Auth via `Authorization: Bearer ${PACKAGIST_USERNAME}:${PACKAGIST_API_TOKEN}`.
- POST to the bare `https://packagist.org/api/update-package` endpoint (dropped the `?username=` query param).
- Documented body form `{"repository":"<url>"}` (was the nested `{"repository":{"url":...}}`).
- Default `PACKAGIST_USERNAME` to `kfly8` (the token owner), still overridable via the `vars.PACKAGIST_USERNAME` repo variable.

The Safe token is the correct token for this endpoint — no change needed there.

## Status of the wider Packagist release

- Mirror repos now exist and the split push succeeds for all three (the `PHP_SPLIT_REPO_TOKEN` scope issue is resolved). ✅
- This PR fixes the remaining `Notify Packagist` 403. After merge + the next release run, all three PHP packages should update on Packagist, provided `PACKAGIST_API_TOKEN` stays set.

## Verification
- `release.yml` YAML-parsed; all three blocks converted; the old `API-Token:` header no longer appears anywhere.
- The live call can only be exercised by the next release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYeRbFoKYKVUkXU1y88mJM

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYeRbFoKYKVUkXU1y88mJM)_