### PR TITLE
Decode JSX entities in Phase 1, escape static content on emit (divergence stack 5/N)

### DIFF
--- a/.changeset/decode-entities-escape-static.md
+++ b/.changeset/decode-entities-escape-static.md
@@ -1,0 +1,15 @@
+---
+"@barefootjs/shared": patch
+"@barefootjs/jsx": patch
+"@barefootjs/jinja": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+"@barefootjs/twig": patch
+"@barefootjs/blade": patch
+"@barefootjs/rust": patch
+"@barefootjs/erb": patch
+"@barefootjs/go-template": patch
+"@barefootjs/hono": patch
+---
+
+Decode JSX character references in Phase 1 and escape static content on emit. JSX defines `&copy;` in literal text (and in quoted attribute values) as the character `©` — Babel, esbuild, and TypeScript's JSX emit all decode at parse time — but the compiler carried the RAW source text through the IR, so every template adapter re-emitted the undecoded entity (`html-entity-text` divergence) and none escaped HTML metacharacters in static attribute values (`static-attr-escape`: `title="Fish & Chips"` reached the output unescaped). Phase 1 now decodes via the new `decodeEntities` (`@barefootjs/shared`; numeric references fully, named references from a curated table — unknown names degrade consistently on every backend), so `IRText.value` and static attribute values carry the semantics. Emission escapes per context: the eight template adapters and the client-JS `innerHTML` template builders route static text and attribute values through the shared `escapeHtml` (`& < > "`), and the Hono adapter re-encodes for JSX source (adding `{`/`}`). Both fixtures graduate from all eight adapters' `renderDivergences` declarations and from the CSR conformance skip list.

--- a/packages/adapter-blade/src/adapter/blade-adapter.ts
+++ b/packages/adapter-blade/src/adapter/blade-adapter.ts
@@ -292,7 +292,7 @@ import {
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr, isExplicitStringCall } from './boolean-result.ts'
 import type { ParsedExpr, LoweringMatcher } from '@barefootjs/jsx'
-import { BF_SLOT, BF_COND, BF_REGION } from '@barefootjs/shared'
+import { BF_SLOT, BF_COND, BF_REGION, escapeHtml } from '@barefootjs/shared'
 
 import type { BladeRenderCtx } from './lib/types.ts'
 import { BLADE_PRIMITIVE_EMIT_MAP } from './lib/constants.ts'
@@ -550,7 +550,9 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
   }
 
   emitText(node: IRText): string {
-    return node.value
+    // IRText carries the entity-DECODED value (Phase 1 decodes JSX
+    // character references); re-escape for direct HTML emission.
+    return escapeHtml(node.value)
   }
 
   emitExpression(node: IRExpression): string {
@@ -1291,7 +1293,7 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
    * AttrValue lowering for intrinsic-element attributes (Blade).
    */
   private readonly elementAttrEmitter: AttrValueEmitter = {
-    emitLiteral: (value, name) => `${name}="${value.value}"`,
+    emitLiteral: (value, name) => `${name}="${escapeHtml(value.value)}"`,
     emitExpression: (value, name) => {
       // `style={{ … }}` object literal → a CSS string with dynamic values
       // interpolated, instead of refusing the bare object with BF101 (#1322).

--- a/packages/adapter-blade/src/render-divergences.ts
+++ b/packages/adapter-blade/src/render-divergences.ts
@@ -15,12 +15,8 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
-  'html-entity-text':
-    '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
   'math-methods':
     'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
-  'static-attr-escape':
-    'static attribute values are not HTML-escaped (`title="Fish & Chips"` emitted raw; Hono escapes)',
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
   'nested-loop-outer-binding':

--- a/packages/adapter-erb/src/adapter/erb-adapter.ts
+++ b/packages/adapter-erb/src/adapter/erb-adapter.ts
@@ -91,7 +91,7 @@ import {
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr, isExplicitStringCall } from './boolean-result.ts'
 import type { ParsedExpr, LoweringMatcher, LoopBindingPathSegment } from '@barefootjs/jsx'
-import { BF_SLOT, BF_COND, BF_REGION } from '@barefootjs/shared'
+import { BF_SLOT, BF_COND, BF_REGION, escapeHtml } from '@barefootjs/shared'
 
 import type { ErbRenderCtx } from './lib/types.ts'
 import { ERB_PRIMITIVE_EMIT_MAP } from './lib/constants.ts'
@@ -499,7 +499,9 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
   }
 
   emitText(node: IRText): string {
-    return node.value
+    // IRText carries the entity-DECODED value (Phase 1 decodes JSX
+    // character references); re-escape for direct HTML emission.
+    return escapeHtml(node.value)
   }
 
   emitExpression(node: IRExpression): string {
@@ -1227,7 +1229,7 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
    * Routed through the shared dispatcher.
    */
   private readonly elementAttrEmitter: AttrValueEmitter = {
-    emitLiteral: (value, name) => `${name}="${value.value}"`,
+    emitLiteral: (value, name) => `${name}="${escapeHtml(value.value)}"`,
     emitExpression: (value, name) => {
       // `style={{ … }}` object literal → a CSS string with dynamic values
       // interpolated, instead of refusing the bare object with BF101.

--- a/packages/adapter-erb/src/render-divergences.ts
+++ b/packages/adapter-erb/src/render-divergences.ts
@@ -15,14 +15,10 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
-  'html-entity-text':
-    '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
   'optional-chaining-prop':
     '`user?.name ?? …` on an object prop: the Ruby render exits 1 (optional chaining into a Hash prop has no lowering)',
   'math-methods':
     'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
-  'static-attr-escape':
-    'static attribute values are not HTML-escaped (`title="Fish & Chips"` emitted raw; Hono escapes)',
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders but its loop item keys diverge from the reference serialisation',
   'nested-loop-outer-binding':

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -68,7 +68,7 @@ import {
   computeSsrSeedPlan,
 } from '@barefootjs/jsx'
 import { findInterpolationEnd } from '@barefootjs/jsx/scanner'
-import { BF_REGION } from '@barefootjs/shared'
+import { BF_REGION, escapeHtml } from '@barefootjs/shared'
 
 import {
   GO_IDENTIFIER,
@@ -2579,7 +2579,9 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   emitText(node: IRText): string {
-    return node.value
+    // IRText carries the entity-DECODED value (Phase 1 decodes JSX
+    // character references); re-escape for direct HTML emission.
+    return escapeHtml(node.value)
   }
 
   emitExpression(node: IRExpression): string {
@@ -5181,7 +5183,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * doesn't share a contract with the intrinsic-attribute one.
    */
   private readonly elementAttrEmitter: AttrValueEmitter = {
-    emitLiteral: (value, name) => `${name}="${value.value}"`,
+    emitLiteral: (value, name) => `${name}="${escapeHtml(value.value)}"`,
     emitExpression: (value, name) => {
       // `style={{ … }}` object literal → a CSS string with dynamic values
       // interpolated, instead of refusing the bare object with BF101.

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -17,8 +17,6 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
-  'html-entity-text':
-    '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
   'string-concat-plus':
     "`'Hello, ' + name` renders \"0\" — JS string-concat `+` lowered through numeric addition",
   'optional-chaining-prop':
@@ -27,8 +25,6 @@ export const renderDivergences: RenderDivergences = {
     '`.toFixed(2)` on a number PROP: generated Go fails to run (exit 1)',
   'math-methods':
     'Math.min/max/abs over a signal: generated Go fails to run (exit 1) — only Math.floor is registered',
-  'static-attr-escape':
-    'static attribute values are not HTML-escaped (`title="Fish & Chips"` emitted raw; Hono escapes)',
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)`: generated Go fails to run (exit 1) — no object-iteration loop lowering',
   'nested-loop-outer-binding':

--- a/packages/adapter-hono/src/adapter/hono-adapter.ts
+++ b/packages/adapter-hono/src/adapter/hono-adapter.ts
@@ -47,7 +47,7 @@ type HonoRenderCtx = {
   isInsideLoop?: boolean
   isLoopItemRoot?: boolean
 }
-import { BF_SCOPE, BF_HOST, BF_AT, BF_ROOT, BF_PROPS, BF_REGION } from '@barefootjs/shared'
+import { BF_SCOPE, BF_HOST, BF_AT, BF_ROOT, BF_PROPS, BF_REGION, escapeHtml } from '@barefootjs/shared'
 
 export interface HonoAdapterOptions {
   /**
@@ -731,7 +731,13 @@ export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderC
   }
 
   private renderText(text: IRText): string {
-    return text.value
+    // IRText carries the entity-DECODED value (Phase 1 decodes JSX
+    // character references). Re-encode for JSX SOURCE text: the shared
+    // HTML escape covers `< > & "` (the JSX parser decodes them right
+    // back; raw `'` is legal JSX text), and `{`/`}` — JSX expression delimiters with no named
+    // entity — go numeric. Rendering then re-escapes with Hono's own
+    // set, so output bytes match the pre-decode pipeline.
+    return escapeHtml(text.value).replace(/\{/g, '&#123;').replace(/\}/g, '&#125;')
   }
 
   renderExpression(expr: IRExpression): string {
@@ -1076,7 +1082,10 @@ export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderC
    * AttrValue kind becomes a TS compile error here (#1290 step 2).
    */
   private readonly elementAttrEmitter: AttrValueEmitter = {
-    emitLiteral: (value, name) => `${name}="${value.value}"`,
+    // The decoded static value re-encodes for the JSX attr string (the
+    // JSX parser decodes entities in quoted attribute values, so the
+    // runtime sees the decoded string and escapes it on render).
+    emitLiteral: (value, name) => `${name}="${escapeHtml(value.value)}"`,
     emitExpression: (value, name) => {
       // Boolean attrs / presence-folded expressions: pass `undefined` when
       // falsy so Hono omits the attribute. Wrap in parens to keep `??`
@@ -1106,9 +1115,11 @@ export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderC
   private readonly componentPropEmitter: AttrValueEmitter = {
     emitLiteral: (value, name) =>
       // IR-authoritative string literal: `<X fill="var(--c)" />`.
-      // Emitting verbatim is what distinguishes a CSS-shaped value
-      // (`var(...)`, `url(...)`, `calc(...)`) from a JS expression.
-      `${name}="${value.value}"`,
+      // Emitting as a plain JSX attr string (not a JS expression) is what
+      // distinguishes a CSS-shaped value (`var(...)`, `url(...)`,
+      // `calc(...)`) from a JS expression. The decoded value re-encodes
+      // so the JSX parser hands the component the same decoded string.
+      `${name}="${escapeHtml(value.value)}"`,
     emitExpression: (value, name) => `${name}={${value.expr}}`,
     emitBooleanAttr: (_value, name) => name,
     emitBooleanShorthand: (_value, name) => name,

--- a/packages/adapter-jinja/src/adapter/jinja-adapter.ts
+++ b/packages/adapter-jinja/src/adapter/jinja-adapter.ts
@@ -143,7 +143,7 @@ import {
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr, isExplicitStringCall } from './boolean-result.ts'
 import type { ParsedExpr, LoweringMatcher } from '@barefootjs/jsx'
-import { BF_SLOT, BF_COND, BF_REGION } from '@barefootjs/shared'
+import { BF_SLOT, BF_COND, BF_REGION, escapeHtml } from '@barefootjs/shared'
 
 import type { JinjaRenderCtx } from './lib/types.ts'
 import { JINJA_PRIMITIVE_EMIT_MAP } from './lib/constants.ts'
@@ -401,7 +401,9 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
   }
 
   emitText(node: IRText): string {
-    return node.value
+    // IRText carries the entity-DECODED value (Phase 1 decodes JSX
+    // character references); re-escape for direct HTML emission.
+    return escapeHtml(node.value)
   }
 
   emitExpression(node: IRExpression): string {
@@ -1132,7 +1134,7 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
    * AttrValue lowering for intrinsic-element attributes (Jinja).
    */
   private readonly elementAttrEmitter: AttrValueEmitter = {
-    emitLiteral: (value, name) => `${name}="${value.value}"`,
+    emitLiteral: (value, name) => `${name}="${escapeHtml(value.value)}"`,
     emitExpression: (value, name) => {
       // `style={{ … }}` object literal → a CSS string with dynamic values
       // interpolated, instead of refusing the bare object with BF101 (#1322).

--- a/packages/adapter-jinja/src/render-divergences.ts
+++ b/packages/adapter-jinja/src/render-divergences.ts
@@ -15,12 +15,8 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
-  'html-entity-text':
-    '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
   'math-methods':
     'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
-  'static-attr-escape':
-    'static attribute values are not HTML-escaped (`title="Fish & Chips"` emitted raw; Hono escapes)',
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
   'nested-loop-outer-binding':

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -62,7 +62,7 @@ import {
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr } from './boolean-result.ts'
 import type { ParsedExpr, LoweringMatcher } from '@barefootjs/jsx'
-import { BF_SLOT, BF_COND, BF_REGION } from '@barefootjs/shared'
+import { BF_SLOT, BF_COND, BF_REGION, escapeHtml } from '@barefootjs/shared'
 
 import type { MojoRenderCtx } from './lib/types.ts'
 import { MOJO_PRIMITIVE_EMIT_MAP } from './lib/constants.ts'
@@ -478,7 +478,9 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
   }
 
   emitText(node: IRText): string {
-    return node.value
+    // IRText carries the entity-DECODED value (Phase 1 decodes JSX
+    // character references); re-escape for direct HTML emission.
+    return escapeHtml(node.value)
   }
 
   emitExpression(node: IRExpression): string {
@@ -1178,7 +1180,7 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
    * template). Routed through the shared dispatcher (#1290 step 2).
    */
   private readonly elementAttrEmitter: AttrValueEmitter = {
-    emitLiteral: (value, name) => `${name}="${value.value}"`,
+    emitLiteral: (value, name) => `${name}="${escapeHtml(value.value)}"`,
     emitExpression: (value, name) => {
       // `style={{ … }}` object literal → a CSS string with dynamic values
       // interpolated, instead of refusing the bare object with BF101 (#1322).

--- a/packages/adapter-mojolicious/src/render-divergences.ts
+++ b/packages/adapter-mojolicious/src/render-divergences.ts
@@ -19,12 +19,8 @@ export const renderDivergences: RenderDivergences = {
     '`.length` on a STRING prop diverges (array-length lowering misapplied to a scalar)',
   'number-tofixed':
     'the literal `¥` in template text reaches the output as U+FFFD — a UTF-8 encoding gap for non-ASCII literal text adjacent to a dynamic slot',
-  'html-entity-text':
-    '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
   'math-methods':
     'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
-  'static-attr-escape':
-    'static attribute values are not HTML-escaped (`title="Fish & Chips"` emitted raw; Hono escapes)',
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
   'nested-loop-outer-binding':

--- a/packages/adapter-mojolicious/src/render-divergences.ts
+++ b/packages/adapter-mojolicious/src/render-divergences.ts
@@ -17,8 +17,6 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 export const renderDivergences: RenderDivergences = {
   'string-length-text':
     '`.length` on a STRING prop diverges (array-length lowering misapplied to a scalar)',
-  'number-tofixed':
-    'the literal `¥` in template text reaches the output as U+FFFD — a UTF-8 encoding gap for non-ASCII literal text adjacent to a dynamic slot',
   'math-methods':
     'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
   'object-entries-map':

--- a/packages/adapter-mojolicious/src/test-render.ts
+++ b/packages/adapter-mojolicious/src/test-render.ts
@@ -240,6 +240,11 @@ export async function renderMojoComponent(options: RenderOptions): Promise<strin
 use strict;
 use warnings;
 use utf8;
+# The template is read through :utf8, so $output holds decoded wide
+# characters; without a matching layer on STDOUT Perl emits them as
+# latin-1 bytes and the harness reads U+FFFD (©/¥ mangling). A real
+# Mojolicious response encodes on the way out — this is harness-only.
+binmode STDOUT, ':encoding(UTF-8)';
 
 use lib '${LIB_DIR}', '${PERL_CORE_LIB_DIR}';
 use Mojolicious;

--- a/packages/adapter-rust/src/adapter/minijinja-adapter.ts
+++ b/packages/adapter-rust/src/adapter/minijinja-adapter.ts
@@ -168,7 +168,7 @@ import {
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr, isExplicitStringCall } from './boolean-result.ts'
 import type { ParsedExpr, LoweringMatcher, LoopBindingPathSegment } from '@barefootjs/jsx'
-import { BF_SLOT, BF_COND, BF_REGION } from '@barefootjs/shared'
+import { BF_SLOT, BF_COND, BF_REGION, escapeHtml } from '@barefootjs/shared'
 
 import type { JinjaRenderCtx } from './lib/types.ts'
 import { JINJA_PRIMITIVE_EMIT_MAP } from './lib/constants.ts'
@@ -449,7 +449,9 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
   }
 
   emitText(node: IRText): string {
-    return node.value
+    // IRText carries the entity-DECODED value (Phase 1 decodes JSX
+    // character references); re-escape for direct HTML emission.
+    return escapeHtml(node.value)
   }
 
   emitExpression(node: IRExpression): string {
@@ -1175,7 +1177,7 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
    * AttrValue lowering for intrinsic-element attributes (Jinja).
    */
   private readonly elementAttrEmitter: AttrValueEmitter = {
-    emitLiteral: (value, name) => `${name}="${value.value}"`,
+    emitLiteral: (value, name) => `${name}="${escapeHtml(value.value)}"`,
     emitExpression: (value, name) => {
       // `style={{ … }}` object literal → a CSS string with dynamic values
       // interpolated, instead of refusing the bare object with BF101 (#1322).

--- a/packages/adapter-rust/src/render-divergences.ts
+++ b/packages/adapter-rust/src/render-divergences.ts
@@ -17,12 +17,8 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
-  'html-entity-text':
-    '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
   'math-methods':
     'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
-  'static-attr-escape':
-    'static attribute values are not HTML-escaped (`title="Fish & Chips"` emitted raw; Hono escapes)',
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
   'nested-loop-outer-binding':

--- a/packages/adapter-tests/fixtures/__snapshots__/accordion.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/accordion.client.js
@@ -46,7 +46,7 @@ export function initCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -152,7 +152,7 @@ export function initChevronDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -258,7 +258,7 @@ export function initChevronUpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -364,7 +364,7 @@ export function initChevronLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -470,7 +470,7 @@ export function initChevronRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -576,7 +576,7 @@ export function initXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -682,7 +682,7 @@ export function initPlusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -788,7 +788,7 @@ export function initMinusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -894,7 +894,7 @@ export function initSunIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1000,7 +1000,7 @@ export function initMoonIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1106,7 +1106,7 @@ export function initMonitorIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1212,7 +1212,7 @@ export function initCopyIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1318,7 +1318,7 @@ export function initClipboardIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1424,7 +1424,7 @@ export function initClipboardCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1530,7 +1530,7 @@ export function initMenuIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1636,7 +1636,7 @@ export function initArrowLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1742,7 +1742,7 @@ export function initArrowRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1848,7 +1848,7 @@ export function initArrowUpDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1931,7 +1931,7 @@ export function initEllipsisIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1970,7 +1970,7 @@ export function initGitHubIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","class","aria-hidden"])
 
 }
 
@@ -2009,7 +2009,7 @@ export function initSettingsIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2048,7 +2048,7 @@ export function initGlobeIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2087,7 +2087,7 @@ export function initLogOutIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2126,7 +2126,7 @@ export function initCircleHelpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2165,7 +2165,7 @@ export function initSearchIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2204,7 +2204,7 @@ export function initCircleCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2243,7 +2243,7 @@ export function initCircleXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2282,7 +2282,7 @@ export function initTriangleAlertIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2321,7 +2321,7 @@ export function initInfoIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2360,7 +2360,7 @@ export function initCalendarIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2399,7 +2399,7 @@ export function initGripVerticalIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2461,7 +2461,7 @@ export function initLoaderCircleIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2544,7 +2544,7 @@ export function initPanelLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2624,7 +2624,7 @@ export function initIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 
   // Reactive child component props
@@ -2777,7 +2777,7 @@ export function initAccordion(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
 }
 

--- a/packages/adapter-tests/fixtures/__snapshots__/button.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/button.client.js
@@ -65,7 +65,7 @@ export function initButton(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","variant","size","asChild","children"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","variant","size","asChild","children","class"])
 
 
   // Reactive child component props

--- a/packages/adapter-tests/fixtures/__snapshots__/carousel.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/carousel.client.js
@@ -46,7 +46,7 @@ export function initCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -152,7 +152,7 @@ export function initChevronDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -258,7 +258,7 @@ export function initChevronUpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -364,7 +364,7 @@ export function initChevronLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -470,7 +470,7 @@ export function initChevronRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -576,7 +576,7 @@ export function initXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -682,7 +682,7 @@ export function initPlusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -788,7 +788,7 @@ export function initMinusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -894,7 +894,7 @@ export function initSunIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1000,7 +1000,7 @@ export function initMoonIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1106,7 +1106,7 @@ export function initMonitorIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1212,7 +1212,7 @@ export function initCopyIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1318,7 +1318,7 @@ export function initClipboardIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1424,7 +1424,7 @@ export function initClipboardCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1530,7 +1530,7 @@ export function initMenuIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1636,7 +1636,7 @@ export function initArrowLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1742,7 +1742,7 @@ export function initArrowRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1848,7 +1848,7 @@ export function initArrowUpDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1931,7 +1931,7 @@ export function initEllipsisIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1970,7 +1970,7 @@ export function initGitHubIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","class","aria-hidden"])
 
 }
 
@@ -2009,7 +2009,7 @@ export function initSettingsIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2048,7 +2048,7 @@ export function initGlobeIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2087,7 +2087,7 @@ export function initLogOutIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2126,7 +2126,7 @@ export function initCircleHelpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2165,7 +2165,7 @@ export function initSearchIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2204,7 +2204,7 @@ export function initCircleCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2243,7 +2243,7 @@ export function initCircleXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2282,7 +2282,7 @@ export function initTriangleAlertIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2321,7 +2321,7 @@ export function initInfoIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2360,7 +2360,7 @@ export function initCalendarIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2399,7 +2399,7 @@ export function initGripVerticalIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2461,7 +2461,7 @@ export function initLoaderCircleIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2544,7 +2544,7 @@ export function initPanelLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2624,7 +2624,7 @@ export function initIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 
   // Reactive child component props

--- a/packages/adapter-tests/fixtures/__snapshots__/checkbox.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/checkbox.client.js
@@ -46,7 +46,7 @@ export function initCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -152,7 +152,7 @@ export function initChevronDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -258,7 +258,7 @@ export function initChevronUpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -364,7 +364,7 @@ export function initChevronLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -470,7 +470,7 @@ export function initChevronRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -576,7 +576,7 @@ export function initXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -682,7 +682,7 @@ export function initPlusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -788,7 +788,7 @@ export function initMinusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -894,7 +894,7 @@ export function initSunIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1000,7 +1000,7 @@ export function initMoonIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1106,7 +1106,7 @@ export function initMonitorIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1212,7 +1212,7 @@ export function initCopyIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1318,7 +1318,7 @@ export function initClipboardIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1424,7 +1424,7 @@ export function initClipboardCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1530,7 +1530,7 @@ export function initMenuIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1636,7 +1636,7 @@ export function initArrowLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1742,7 +1742,7 @@ export function initArrowRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1848,7 +1848,7 @@ export function initArrowUpDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1931,7 +1931,7 @@ export function initEllipsisIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1970,7 +1970,7 @@ export function initGitHubIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","class","aria-hidden"])
 
 }
 
@@ -2009,7 +2009,7 @@ export function initSettingsIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2048,7 +2048,7 @@ export function initGlobeIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2087,7 +2087,7 @@ export function initLogOutIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2126,7 +2126,7 @@ export function initCircleHelpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2165,7 +2165,7 @@ export function initSearchIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2204,7 +2204,7 @@ export function initCircleCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2243,7 +2243,7 @@ export function initCircleXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2282,7 +2282,7 @@ export function initTriangleAlertIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2321,7 +2321,7 @@ export function initInfoIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2360,7 +2360,7 @@ export function initCalendarIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2399,7 +2399,7 @@ export function initGripVerticalIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2461,7 +2461,7 @@ export function initLoaderCircleIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2544,7 +2544,7 @@ export function initPanelLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2624,7 +2624,7 @@ export function initIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 
   // Reactive child component props

--- a/packages/adapter-tests/fixtures/__snapshots__/combobox.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/combobox.client.js
@@ -46,7 +46,7 @@ export function initCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -152,7 +152,7 @@ export function initChevronDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -258,7 +258,7 @@ export function initChevronUpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -364,7 +364,7 @@ export function initChevronLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -470,7 +470,7 @@ export function initChevronRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -576,7 +576,7 @@ export function initXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -682,7 +682,7 @@ export function initPlusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -788,7 +788,7 @@ export function initMinusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -894,7 +894,7 @@ export function initSunIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1000,7 +1000,7 @@ export function initMoonIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1106,7 +1106,7 @@ export function initMonitorIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1212,7 +1212,7 @@ export function initCopyIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1318,7 +1318,7 @@ export function initClipboardIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1424,7 +1424,7 @@ export function initClipboardCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1530,7 +1530,7 @@ export function initMenuIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1636,7 +1636,7 @@ export function initArrowLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1742,7 +1742,7 @@ export function initArrowRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1848,7 +1848,7 @@ export function initArrowUpDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1931,7 +1931,7 @@ export function initEllipsisIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1970,7 +1970,7 @@ export function initGitHubIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","class","aria-hidden"])
 
 }
 
@@ -2009,7 +2009,7 @@ export function initSettingsIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2048,7 +2048,7 @@ export function initGlobeIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2087,7 +2087,7 @@ export function initLogOutIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2126,7 +2126,7 @@ export function initCircleHelpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2165,7 +2165,7 @@ export function initSearchIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2204,7 +2204,7 @@ export function initCircleCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2243,7 +2243,7 @@ export function initCircleXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2282,7 +2282,7 @@ export function initTriangleAlertIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2321,7 +2321,7 @@ export function initInfoIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2360,7 +2360,7 @@ export function initCalendarIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2399,7 +2399,7 @@ export function initGripVerticalIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2461,7 +2461,7 @@ export function initLoaderCircleIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2544,7 +2544,7 @@ export function initPanelLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2624,7 +2624,7 @@ export function initIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 
   // Reactive child component props
@@ -3292,7 +3292,7 @@ export function initComboboxSeparator(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","data-slot","role"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","data-slot","role","class"])
 
 }
 

--- a/packages/adapter-tests/fixtures/__snapshots__/command.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/command.client.js
@@ -46,7 +46,7 @@ export function initCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -152,7 +152,7 @@ export function initChevronDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -258,7 +258,7 @@ export function initChevronUpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -364,7 +364,7 @@ export function initChevronLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -470,7 +470,7 @@ export function initChevronRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -576,7 +576,7 @@ export function initXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -682,7 +682,7 @@ export function initPlusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -788,7 +788,7 @@ export function initMinusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -894,7 +894,7 @@ export function initSunIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1000,7 +1000,7 @@ export function initMoonIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1106,7 +1106,7 @@ export function initMonitorIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1212,7 +1212,7 @@ export function initCopyIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1318,7 +1318,7 @@ export function initClipboardIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1424,7 +1424,7 @@ export function initClipboardCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1530,7 +1530,7 @@ export function initMenuIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1636,7 +1636,7 @@ export function initArrowLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1742,7 +1742,7 @@ export function initArrowRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1848,7 +1848,7 @@ export function initArrowUpDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1931,7 +1931,7 @@ export function initEllipsisIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1970,7 +1970,7 @@ export function initGitHubIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","class","aria-hidden"])
 
 }
 
@@ -2009,7 +2009,7 @@ export function initSettingsIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2048,7 +2048,7 @@ export function initGlobeIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2087,7 +2087,7 @@ export function initLogOutIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2126,7 +2126,7 @@ export function initCircleHelpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2165,7 +2165,7 @@ export function initSearchIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2204,7 +2204,7 @@ export function initCircleCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2243,7 +2243,7 @@ export function initCircleXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2282,7 +2282,7 @@ export function initTriangleAlertIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2321,7 +2321,7 @@ export function initInfoIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2360,7 +2360,7 @@ export function initCalendarIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2399,7 +2399,7 @@ export function initGripVerticalIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2461,7 +2461,7 @@ export function initLoaderCircleIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2544,7 +2544,7 @@ export function initPanelLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2624,7 +2624,7 @@ export function initIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 
   // Reactive child component props
@@ -2985,7 +2985,7 @@ export function initDialogHeader(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","class"])
 
 }
 
@@ -3010,7 +3010,7 @@ export function initDialogTitle(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","id","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","id","children","data-slot","class"])
 
 }
 
@@ -3035,7 +3035,7 @@ export function initDialogDescription(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","id","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","id","children","data-slot","class"])
 
 }
 
@@ -3058,7 +3058,7 @@ export function initDialogFooter(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","class"])
 
 }
 
@@ -3250,7 +3250,7 @@ export function initCommandList(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","role"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","role","class"])
 
 }
 
@@ -3429,7 +3429,7 @@ export function initCommandSeparator(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","data-slot","role"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","data-slot","role","class"])
 
 }
 
@@ -3452,7 +3452,7 @@ export function initCommandShortcut(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","class"])
 
 }
 
@@ -3536,7 +3536,7 @@ export function initKbd(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","asChild","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","asChild","children","data-slot","class"])
 
 
   // Reactive child component props
@@ -3572,7 +3572,7 @@ export function initKbdGroup(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","asChild","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","asChild","children","data-slot","class"])
 
 
   // Reactive child component props
@@ -3626,7 +3626,7 @@ export function initButton(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","variant","size","asChild","children"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","variant","size","asChild","children","class"])
 
 
   // Reactive child component props

--- a/packages/adapter-tests/fixtures/__snapshots__/data-table.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/data-table.client.js
@@ -17,7 +17,7 @@ export function initTable(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
 }
 
@@ -40,7 +40,7 @@ export function initTableHeader(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
 }
 
@@ -63,7 +63,7 @@ export function initTableBody(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
 }
 
@@ -86,7 +86,7 @@ export function initTableFooter(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
 }
 
@@ -109,7 +109,7 @@ export function initTableRow(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
 }
 
@@ -132,7 +132,7 @@ export function initTableHead(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
 }
 
@@ -155,7 +155,7 @@ export function initTableCell(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
 }
 
@@ -178,7 +178,7 @@ export function initTableCaption(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
 }
 
@@ -230,7 +230,7 @@ export function initCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -336,7 +336,7 @@ export function initChevronDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -442,7 +442,7 @@ export function initChevronUpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -548,7 +548,7 @@ export function initChevronLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -654,7 +654,7 @@ export function initChevronRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -760,7 +760,7 @@ export function initXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -866,7 +866,7 @@ export function initPlusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -972,7 +972,7 @@ export function initMinusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1078,7 +1078,7 @@ export function initSunIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1184,7 +1184,7 @@ export function initMoonIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1290,7 +1290,7 @@ export function initMonitorIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1396,7 +1396,7 @@ export function initCopyIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1502,7 +1502,7 @@ export function initClipboardIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1608,7 +1608,7 @@ export function initClipboardCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1714,7 +1714,7 @@ export function initMenuIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1820,7 +1820,7 @@ export function initArrowLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1926,7 +1926,7 @@ export function initArrowRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2032,7 +2032,7 @@ export function initArrowUpDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2115,7 +2115,7 @@ export function initEllipsisIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2154,7 +2154,7 @@ export function initGitHubIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","class","aria-hidden"])
 
 }
 
@@ -2193,7 +2193,7 @@ export function initSettingsIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2232,7 +2232,7 @@ export function initGlobeIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2271,7 +2271,7 @@ export function initLogOutIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2310,7 +2310,7 @@ export function initCircleHelpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2349,7 +2349,7 @@ export function initSearchIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2388,7 +2388,7 @@ export function initCircleCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2427,7 +2427,7 @@ export function initCircleXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2466,7 +2466,7 @@ export function initTriangleAlertIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2505,7 +2505,7 @@ export function initInfoIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2544,7 +2544,7 @@ export function initCalendarIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2583,7 +2583,7 @@ export function initGripVerticalIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2645,7 +2645,7 @@ export function initLoaderCircleIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2728,7 +2728,7 @@ export function initPanelLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2808,7 +2808,7 @@ export function initIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 
   // Reactive child component props
@@ -3004,7 +3004,7 @@ export function initDataTableColumnHeader(__scope, _p = {}) {
     }
   })
 
-  if (_s6) applyRestAttrs(_s6, _p, ["title","sorted","onSort","className","data-slot","type"])
+  if (_s6) applyRestAttrs(_s6, _p, ["title","sorted","onSort","className","data-slot","type","class"])
 
   if (_s6) _s6.addEventListener('click', onSort)
 
@@ -3050,7 +3050,7 @@ export function initDataTablePagination(__scope, _p = {}) {
     }
   })
 
-  if (_s4) applyRestAttrs(_s4, _p, ["canPrev","canNext","onPrev","onNext","children","className","data-slot"])
+  if (_s4) applyRestAttrs(_s4, _p, ["canPrev","canNext","onPrev","onNext","children","className","data-slot","class"])
 
   if (_s1) _s1.addEventListener('click', onPrev)
   if (_s3) _s3.addEventListener('click', onNext)

--- a/packages/adapter-tests/fixtures/__snapshots__/dialog.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/dialog.client.js
@@ -225,7 +225,7 @@ export function initDialogHeader(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","class"])
 
 }
 
@@ -250,7 +250,7 @@ export function initDialogTitle(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","id","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","id","children","data-slot","class"])
 
 }
 
@@ -275,7 +275,7 @@ export function initDialogDescription(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","id","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","id","children","data-slot","class"])
 
 }
 
@@ -298,7 +298,7 @@ export function initDialogFooter(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","class"])
 
 }
 

--- a/packages/adapter-tests/fixtures/__snapshots__/dropdown-menu.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/dropdown-menu.client.js
@@ -46,7 +46,7 @@ export function initCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -152,7 +152,7 @@ export function initChevronDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -258,7 +258,7 @@ export function initChevronUpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -364,7 +364,7 @@ export function initChevronLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -470,7 +470,7 @@ export function initChevronRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -576,7 +576,7 @@ export function initXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -682,7 +682,7 @@ export function initPlusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -788,7 +788,7 @@ export function initMinusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -894,7 +894,7 @@ export function initSunIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1000,7 +1000,7 @@ export function initMoonIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1106,7 +1106,7 @@ export function initMonitorIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1212,7 +1212,7 @@ export function initCopyIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1318,7 +1318,7 @@ export function initClipboardIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1424,7 +1424,7 @@ export function initClipboardCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1530,7 +1530,7 @@ export function initMenuIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1636,7 +1636,7 @@ export function initArrowLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1742,7 +1742,7 @@ export function initArrowRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1848,7 +1848,7 @@ export function initArrowUpDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1931,7 +1931,7 @@ export function initEllipsisIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1970,7 +1970,7 @@ export function initGitHubIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","class","aria-hidden"])
 
 }
 
@@ -2009,7 +2009,7 @@ export function initSettingsIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2048,7 +2048,7 @@ export function initGlobeIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2087,7 +2087,7 @@ export function initLogOutIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2126,7 +2126,7 @@ export function initCircleHelpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2165,7 +2165,7 @@ export function initSearchIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2204,7 +2204,7 @@ export function initCircleCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2243,7 +2243,7 @@ export function initCircleXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2282,7 +2282,7 @@ export function initTriangleAlertIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2321,7 +2321,7 @@ export function initInfoIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2360,7 +2360,7 @@ export function initCalendarIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2399,7 +2399,7 @@ export function initGripVerticalIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2461,7 +2461,7 @@ export function initLoaderCircleIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2544,7 +2544,7 @@ export function initPanelLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2624,7 +2624,7 @@ export function initIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 
   // Reactive child component props
@@ -3338,7 +3338,7 @@ export function initDropdownMenuLabel(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
 }
 
@@ -3360,7 +3360,7 @@ export function initDropdownMenuSeparator(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","data-slot","role"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","data-slot","role","class"])
 
 }
 
@@ -3383,7 +3383,7 @@ export function initDropdownMenuShortcut(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
 }
 
@@ -3404,7 +3404,7 @@ export function initDropdownMenuGroup(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","role"])
+  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","role","class"])
 
 }
 

--- a/packages/adapter-tests/fixtures/__snapshots__/input.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/input.client.js
@@ -21,7 +21,7 @@ export function initInput(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","type","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","type","data-slot","class"])
 
 }
 

--- a/packages/adapter-tests/fixtures/__snapshots__/kbd.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/kbd.client.js
@@ -47,7 +47,7 @@ export function initKbd(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","asChild","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","asChild","children","data-slot","class"])
 
 
   // Reactive child component props
@@ -83,7 +83,7 @@ export function initKbdGroup(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","asChild","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","asChild","children","data-slot","class"])
 
 
   // Reactive child component props

--- a/packages/adapter-tests/fixtures/__snapshots__/label.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/label.client.js
@@ -18,7 +18,7 @@ export function initLabel(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","class"])
 
 }
 

--- a/packages/adapter-tests/fixtures/__snapshots__/pagination.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/pagination.client.js
@@ -46,7 +46,7 @@ export function initCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -152,7 +152,7 @@ export function initChevronDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -258,7 +258,7 @@ export function initChevronUpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -364,7 +364,7 @@ export function initChevronLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -470,7 +470,7 @@ export function initChevronRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -576,7 +576,7 @@ export function initXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -682,7 +682,7 @@ export function initPlusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -788,7 +788,7 @@ export function initMinusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -894,7 +894,7 @@ export function initSunIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1000,7 +1000,7 @@ export function initMoonIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1106,7 +1106,7 @@ export function initMonitorIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1212,7 +1212,7 @@ export function initCopyIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1318,7 +1318,7 @@ export function initClipboardIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1424,7 +1424,7 @@ export function initClipboardCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1530,7 +1530,7 @@ export function initMenuIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1636,7 +1636,7 @@ export function initArrowLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1742,7 +1742,7 @@ export function initArrowRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1848,7 +1848,7 @@ export function initArrowUpDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1931,7 +1931,7 @@ export function initEllipsisIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1970,7 +1970,7 @@ export function initGitHubIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","class","aria-hidden"])
 
 }
 
@@ -2009,7 +2009,7 @@ export function initSettingsIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2048,7 +2048,7 @@ export function initGlobeIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2087,7 +2087,7 @@ export function initLogOutIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2126,7 +2126,7 @@ export function initCircleHelpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2165,7 +2165,7 @@ export function initSearchIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2204,7 +2204,7 @@ export function initCircleCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2243,7 +2243,7 @@ export function initCircleXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2282,7 +2282,7 @@ export function initTriangleAlertIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2321,7 +2321,7 @@ export function initInfoIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2360,7 +2360,7 @@ export function initCalendarIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2399,7 +2399,7 @@ export function initGripVerticalIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2461,7 +2461,7 @@ export function initLoaderCircleIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2544,7 +2544,7 @@ export function initPanelLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2624,7 +2624,7 @@ export function initIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 
   // Reactive child component props
@@ -2775,7 +2775,7 @@ export function initPagination(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","children","role","aria-label","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","children","role","aria-label","data-slot","class"])
 
 }
 
@@ -2796,7 +2796,7 @@ export function initPaginationContent(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","class"])
 
 }
 
@@ -2817,7 +2817,7 @@ export function initPaginationItem(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","class"])
 
 }
 
@@ -2887,7 +2887,7 @@ export function initPaginationPrevious(__scope, _p = {}) {
     }
   })
 
-  if (_s1) applyRestAttrs(_s1, _p, ["className","children","aria-label","data-slot"])
+  if (_s1) applyRestAttrs(_s1, _p, ["className","children","aria-label","data-slot","class"])
 
 
   // Initialize child components with props
@@ -2933,7 +2933,7 @@ export function initPaginationNext(__scope, _p = {}) {
     }
   })
 
-  if (_s1) applyRestAttrs(_s1, _p, ["className","children","aria-label","data-slot"])
+  if (_s1) applyRestAttrs(_s1, _p, ["className","children","aria-label","data-slot","class"])
 
 
   // Initialize child components with props
@@ -2969,7 +2969,7 @@ export function initPaginationEllipsis(__scope, _p = {}) {
     }
   })
 
-  if (_s1) applyRestAttrs(_s1, _p, ["className","aria-hidden","data-slot"])
+  if (_s1) applyRestAttrs(_s1, _p, ["className","aria-hidden","data-slot","class"])
 
 
   // Initialize child components with props

--- a/packages/adapter-tests/fixtures/__snapshots__/select.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/select.client.js
@@ -46,7 +46,7 @@ export function initCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -152,7 +152,7 @@ export function initChevronDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -258,7 +258,7 @@ export function initChevronUpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -364,7 +364,7 @@ export function initChevronLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -470,7 +470,7 @@ export function initChevronRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -576,7 +576,7 @@ export function initXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -682,7 +682,7 @@ export function initPlusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -788,7 +788,7 @@ export function initMinusIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -894,7 +894,7 @@ export function initSunIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1000,7 +1000,7 @@ export function initMoonIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1106,7 +1106,7 @@ export function initMonitorIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1212,7 +1212,7 @@ export function initCopyIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1318,7 +1318,7 @@ export function initClipboardIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1424,7 +1424,7 @@ export function initClipboardCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1530,7 +1530,7 @@ export function initMenuIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1636,7 +1636,7 @@ export function initArrowLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1742,7 +1742,7 @@ export function initArrowRightIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1848,7 +1848,7 @@ export function initArrowUpDownIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1931,7 +1931,7 @@ export function initEllipsisIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -1970,7 +1970,7 @@ export function initGitHubIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","class","aria-hidden"])
 
 }
 
@@ -2009,7 +2009,7 @@ export function initSettingsIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2048,7 +2048,7 @@ export function initGlobeIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2087,7 +2087,7 @@ export function initLogOutIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2126,7 +2126,7 @@ export function initCircleHelpIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2165,7 +2165,7 @@ export function initSearchIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2204,7 +2204,7 @@ export function initCircleCheckIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2243,7 +2243,7 @@ export function initCircleXIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2282,7 +2282,7 @@ export function initTriangleAlertIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2321,7 +2321,7 @@ export function initInfoIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2360,7 +2360,7 @@ export function initCalendarIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2399,7 +2399,7 @@ export function initGripVerticalIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2461,7 +2461,7 @@ export function initLoaderCircleIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2544,7 +2544,7 @@ export function initPanelLeftIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 }
 
@@ -2624,7 +2624,7 @@ export function initIcon(__scope, _p = {}) {
     }
   })
 
-  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","aria-hidden"])
+  if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 
   // Reactive child component props
@@ -3148,7 +3148,7 @@ export function initSelectGroup(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","role"])
+  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","role","class"])
 
 }
 
@@ -3171,7 +3171,7 @@ export function initSelectLabel(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot"])
+  if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
 }
 
@@ -3193,7 +3193,7 @@ export function initSelectSeparator(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","data-slot","role"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","data-slot","role","class"])
 
 }
 

--- a/packages/adapter-tests/fixtures/__snapshots__/tabs.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/tabs.client.js
@@ -20,7 +20,7 @@ export function initTabs(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","value","defaultValue","children","data-slot","data-value"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","value","defaultValue","children","data-slot","data-value","class"])
 
 }
 
@@ -43,7 +43,7 @@ export function initTabsList(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","role"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","role","class"])
 
 }
 

--- a/packages/adapter-tests/fixtures/__snapshots__/textarea.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/textarea.client.js
@@ -38,7 +38,7 @@ export function initTextarea(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","placeholder","value","disabled","readonly","error","describedBy","rows","onInput","onChange","onBlur","onFocus","data-slot","aria-invalid"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","placeholder","value","disabled","readonly","error","describedBy","rows","onInput","onChange","onBlur","onFocus","data-slot","class","aria-invalid"])
 
   if (_s0) _s0.addEventListener('input', onInput)
   if (_s0) _s0.addEventListener('change', onChange)

--- a/packages/adapter-tests/fixtures/__snapshots__/tooltip.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/tooltip.client.js
@@ -158,7 +158,7 @@ export function initButton(__scope, _p = {}) {
     }
   })
 
-  if (_s0) applyRestAttrs(_s0, _p, ["className","variant","size","asChild","children"])
+  if (_s0) applyRestAttrs(_s0, _p, ["className","variant","size","asChild","children","class"])
 
 
   // Reactive child component props

--- a/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
+++ b/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
@@ -209,17 +209,14 @@ describe('CSR Conformance Tests', () => {
     // documents it until the compiler/runtime reconciles the two paths:
     //   (`falsy-text-values` graduated — #2171 folds the render-nothing
     //   literals in Phase 1, so SSR and CSR now agree by construction.)
-    //   - `html-entity-text`: `&copy;` in JSX literal text is decoded to
-    //     `©` by SSR but passed through as the raw entity by the CSR
-    //     template string (same DOM after parse, different bytes).
-    'html-entity-text',
+    //   (`html-entity-text` graduated — Phase 1 decodes JSX character
+    //   references, and the CSR template builder re-escapes static text
+    //   for its innerHTML context, so SSR and CSR agree by construction.)
     //   (`boolean-attr-literals` graduated — #2172 normalizes intrinsic
     //   attribute names in Phase 1, so `readOnly` reaches both SSR and
     //   CSR as the BOOLEAN_ATTRS member `readonly`.)
-    //   - `static-attr-escape`: static attribute values are HTML-escaped
-    //     by Hono SSR (`Fish &amp; Chips`) but emitted RAW by the CSR
-    //     template literal (`Fish & Chips`).
-    'static-attr-escape',
+    //   (`static-attr-escape` graduated — the CSR template builder now
+    //   HTML-escapes static attribute values like the SSR side.)
     //   - `object-entries-map` / `nested-loop-outer-binding`: nested/
     //     tuple-destructure loops emit `data-key`/`data-key-1` depth
     //     suffixes differently between the SSR snapshot and template-eval.

--- a/packages/adapter-twig/src/adapter/twig-adapter.ts
+++ b/packages/adapter-twig/src/adapter/twig-adapter.ts
@@ -198,7 +198,7 @@ import {
 } from '@barefootjs/jsx'
 import { isAriaBooleanAttr, isBooleanResultExpr, isExplicitStringCall } from './boolean-result.ts'
 import type { ParsedExpr, LoweringMatcher } from '@barefootjs/jsx'
-import { BF_SLOT, BF_COND, BF_REGION } from '@barefootjs/shared'
+import { BF_SLOT, BF_COND, BF_REGION, escapeHtml } from '@barefootjs/shared'
 
 import type { TwigRenderCtx } from './lib/types.ts'
 import { TWIG_PRIMITIVE_EMIT_MAP } from './lib/constants.ts'
@@ -452,7 +452,9 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
   }
 
   emitText(node: IRText): string {
-    return node.value
+    // IRText carries the entity-DECODED value (Phase 1 decodes JSX
+    // character references); re-escape for direct HTML emission.
+    return escapeHtml(node.value)
   }
 
   emitExpression(node: IRExpression): string {
@@ -1177,7 +1179,7 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
    * AttrValue lowering for intrinsic-element attributes (Twig).
    */
   private readonly elementAttrEmitter: AttrValueEmitter = {
-    emitLiteral: (value, name) => `${name}="${value.value}"`,
+    emitLiteral: (value, name) => `${name}="${escapeHtml(value.value)}"`,
     emitExpression: (value, name) => {
       // `style={{ … }}` object literal → a CSS string with dynamic values
       // interpolated, instead of refusing the bare object with BF101 (#1322).

--- a/packages/adapter-twig/src/render-divergences.ts
+++ b/packages/adapter-twig/src/render-divergences.ts
@@ -15,12 +15,8 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
-  'html-entity-text':
-    '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
   'math-methods':
     'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
-  'static-attr-escape':
-    'static attribute values are not HTML-escaped (`title="Fish & Chips"` emitted raw; Hono escapes)',
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
   'nested-loop-outer-binding':

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -77,7 +77,7 @@ import {
 import { isAriaBooleanAttr, isBooleanResultExpr } from './boolean-result.ts'
 import ts from 'typescript'
 import type { ParsedExpr, LoweringMatcher } from '@barefootjs/jsx'
-import { BF_SLOT, BF_COND, BF_REGION } from '@barefootjs/shared'
+import { BF_SLOT, BF_COND, BF_REGION, escapeHtml } from '@barefootjs/shared'
 
 import type { XslateRenderCtx } from './lib/types.ts'
 import { XSLATE_PRIMITIVE_EMIT_MAP } from './lib/constants.ts'
@@ -375,7 +375,9 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
   }
 
   emitText(node: IRText): string {
-    return node.value
+    // IRText carries the entity-DECODED value (Phase 1 decodes JSX
+    // character references); re-escape for direct HTML emission.
+    return escapeHtml(node.value)
   }
 
   emitExpression(node: IRExpression): string {
@@ -1085,7 +1087,7 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
    * AttrValue lowering for intrinsic-element attributes (Kolon).
    */
   private readonly elementAttrEmitter: AttrValueEmitter = {
-    emitLiteral: (value, name) => `${name}="${value.value}"`,
+    emitLiteral: (value, name) => `${name}="${escapeHtml(value.value)}"`,
     emitExpression: (value, name) => {
       // `style={{ … }}` object literal → a CSS string with dynamic values
       // interpolated, instead of refusing the bare object with BF101 (#1322).

--- a/packages/adapter-xslate/src/render-divergences.ts
+++ b/packages/adapter-xslate/src/render-divergences.ts
@@ -15,12 +15,8 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
-  'html-entity-text':
-    '`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes',
   'math-methods':
     'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
-  'static-attr-escape':
-    'static attribute values are not HTML-escaped (`title="Fish & Chips"` emitted raw; Hono escapes)',
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
   'nested-loop-outer-binding':

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -10,7 +10,7 @@ import { nameForRegistryRef } from './component-scope.ts'
 import { assertNever } from './walker.ts'
 import { buildSignalMemoEnv, csrSubstitute, applyPropsRewrite, type CsrEnv } from './csr-substitute.ts'
 import type { ClientJsContext } from './types.ts'
-import { BF_PARENT_SCOPE_PLACEHOLDER, BF_SCOPE } from '@barefootjs/shared'
+import { BF_PARENT_SCOPE_PLACEHOLDER, BF_SCOPE, escapeHtml } from '@barefootjs/shared'
 import { buildLoopChainExpr } from '../loop-chain.ts'
 
 /**
@@ -313,7 +313,7 @@ function renderTemplateAttrPart(
     case 'boolean-attr':
       return attrName
     case 'literal':
-      return `${attrName}="${v.value}"`
+      return `${attrName}="${escapeHtml(v.value)}"`
     case 'expression': {
       const valExpr = wrap(v.expr)
       return templateAttrExpr(attrName, valExpr, v.presenceOrUndefined)
@@ -550,7 +550,9 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: Set<string>, lo
     }
 
     case 'text':
-      return node.value
+      // IRText carries the entity-DECODED value; this string is parsed
+      // as HTML (template.innerHTML), so re-escape for the HTML parser.
+      return escapeHtml(node.value)
 
     case 'expression':
       if (node.expr === 'null' || node.expr === 'undefined') return ''
@@ -757,7 +759,7 @@ export function buildLoopSkeletonTemplate(node: IRNode, safe: LoopSkeletonSafeSl
         const v = a.value
         switch (v.kind) {
           case 'literal':
-            attrParts.push(`${toHtmlAttrName(a.name)}="${v.value}"`)
+            attrParts.push(`${toHtmlAttrName(a.name)}="${escapeHtml(v.value)}"`)
             break
           case 'boolean-attr':
             attrParts.push(toHtmlAttrName(a.name))
@@ -796,7 +798,9 @@ export function buildLoopSkeletonTemplate(node: IRNode, safe: LoopSkeletonSafeSl
     }
 
     case 'text':
-      return node.value
+      // IRText carries the entity-DECODED value; this string is parsed
+      // as HTML (template.innerHTML), so re-escape for the HTML parser.
+      return escapeHtml(node.value)
 
     case 'expression':
       if (node.expr === 'null' || node.expr === 'undefined') return ''
@@ -870,7 +874,9 @@ export function irToPlaceholderTemplate(node: IRNode, restSpreadNames?: Set<stri
     }
 
     case 'text':
-      return node.value
+      // IRText carries the entity-DECODED value; this string is parsed
+      // as HTML (template.innerHTML), so re-escape for the HTML parser.
+      return escapeHtml(node.value)
 
     case 'expression':
       if (node.expr === 'null' || node.expr === 'undefined') return ''
@@ -1228,7 +1234,7 @@ function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): str
                 return templateAttrExpr(keyName, transformExpr(tmplStr))
               }
               case 'literal':
-                return `${keyName}="${v.value}"`
+                return `${keyName}="${escapeHtml(v.value)}"`
               default:
                 return ''
             }
@@ -1238,7 +1244,7 @@ function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): str
             case 'boolean-attr':
               return attrName
             case 'literal':
-              return `${attrName}="${v.value}"`
+              return `${attrName}="${escapeHtml(v.value)}"`
             case 'expression':
               return templateAttrExpr(attrName, transformExpr(v.expr, v.templateExpr), v.presenceOrUndefined)
             case 'template': {
@@ -1269,7 +1275,9 @@ function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): str
     }
 
     case 'text':
-      return node.value
+      // IRText carries the entity-DECODED value; this string is parsed
+      // as HTML (template.innerHTML), so re-escape for the HTML parser.
+      return escapeHtml(node.value)
 
     case 'expression':
       if (node.expr === 'null' || node.expr === 'undefined') return ''
@@ -1806,7 +1814,7 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
             case 'boolean-attr':
               return attrName
             case 'literal':
-              return `${attrName}="${v.value}"`
+              return `${attrName}="${escapeHtml(v.value)}"`
             case 'expression':
               return templateAttrExpr(attrName, transformExpr(v.expr, v.templateExpr), v.presenceOrUndefined)
             case 'template': {
@@ -1837,7 +1845,9 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
     }
 
     case 'text':
-      return node.value
+      // IRText carries the entity-DECODED value; this string is parsed
+      // as HTML (template.innerHTML), so re-escape for the HTML parser.
+      return escapeHtml(node.value)
 
     case 'expression':
       if (node.expr === 'null' || node.expr === 'undefined') return ''

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -48,7 +48,7 @@ import { resolveFreeRefs, isNameBound as isNameBoundInEnv, type BindingEnvironme
 import { computeFileScope } from './ir-to-client-js/component-scope.ts'
 import { extractFreeIdentifiersFromNode, initializerShapeContainsJsx } from './analyzer.ts'
 import { iterateJsTokens, replaceInExprContexts } from './scanner/js-scanner.ts'
-import { toHTMLAttrName } from '@barefootjs/shared'
+import { toHTMLAttrName, decodeEntities } from '@barefootjs/shared'
 
 // =============================================================================
 // Transform Context
@@ -1563,7 +1563,12 @@ function transformText(node: ts.JsxText, ctx: TransformContext): IRText | null {
 
   return {
     type: 'text',
-    value: text,
+    // JSX decodes character references at parse time (`&copy;` IS the
+    // text `©`), so the IR carries the DECODED value — the semantics —
+    // and each adapter re-escapes for its own emission context.
+    // Decode AFTER whitespace normalization: `&nbsp;` yields U+00A0,
+    // which `\s+` would otherwise collapse into a plain space.
+    value: decodeEntities(text),
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
   }
 }
@@ -4157,9 +4162,12 @@ function getAttributeValue(attr: ts.JsxAttribute, ctx: TransformContext): AttrVa
     return AttrValueOf.booleanAttr()
   }
 
-  // String literal: <div id="main" />
+  // String literal: <div id="main" />. JSX decodes character references
+  // in quoted attribute values just like in text children, so the IR
+  // carries the decoded string (`title="Fish &amp; Chips"` IS the value
+  // `Fish & Chips`); adapters re-escape on emit.
   if (ts.isStringLiteral(attr.initializer)) {
-    return AttrValueOf.literal(attr.initializer.text)
+    return AttrValueOf.literal(decodeEntities(attr.initializer.text))
   }
 
   // Expression: <div class={className} />

--- a/packages/shared/src/__tests__/html-entities.test.ts
+++ b/packages/shared/src/__tests__/html-entities.test.ts
@@ -1,0 +1,54 @@
+import { describe, test, expect } from 'bun:test'
+import { decodeEntities, escapeHtml } from '../html-entities'
+
+describe('decodeEntities', () => {
+  test('escaping-set names decode', () => {
+    expect(decodeEntities('Fish &amp; Chips')).toBe('Fish & Chips')
+    expect(decodeEntities('a &lt; b &gt; c')).toBe('a < b > c')
+    expect(decodeEntities('&quot;x&quot; &apos;y&apos;')).toBe(`"x" 'y'`)
+  })
+
+  test('common typographic names decode', () => {
+    expect(decodeEntities('&copy; 2026')).toBe('© 2026')
+    expect(decodeEntities('1&nbsp;000')).toBe('1 000')
+    expect(decodeEntities('A&hellip;')).toBe('A…')
+    expect(decodeEntities('&euro;5 / &pound;4 / &yen;3')).toBe('€5 / £4 / ¥3')
+  })
+
+  test('numeric decimal and hex references decode', () => {
+    expect(decodeEntities('&#169;')).toBe('©')
+    expect(decodeEntities('&#xA9;')).toBe('©')
+    expect(decodeEntities('&#x1F600;')).toBe('😀')
+  })
+
+  test('unknown / malformed references stay verbatim', () => {
+    expect(decodeEntities('&unknownname;')).toBe('&unknownname;')
+    expect(decodeEntities('a & b')).toBe('a & b')
+    expect(decodeEntities('&amp')).toBe('&amp')
+    // Lone surrogate / out-of-range code points are refused, not
+    // replaced with garbage.
+    expect(decodeEntities('&#xD800;')).toBe('&#xD800;')
+    expect(decodeEntities('&#x110000;')).toBe('&#x110000;')
+  })
+
+  test('double-escaped input decodes exactly one level', () => {
+    expect(decodeEntities('&amp;copy;')).toBe('&copy;')
+  })
+})
+
+describe('escapeHtml', () => {
+  test('escapes & < > " and leaves the rest', () => {
+    expect(escapeHtml('Fish & Chips')).toBe('Fish &amp; Chips')
+    expect(escapeHtml('a < b > c')).toBe('a &lt; b &gt; c')
+    expect(escapeHtml('say "hi"')).toBe('say &quot;hi&quot;')
+    expect(escapeHtml("it's © fine")).toBe("it's © fine")
+  })
+
+  test('decode → escape round-trips the entity text', () => {
+    expect(escapeHtml(decodeEntities('Fish &amp; Chips'))).toBe('Fish &amp; Chips')
+    expect(escapeHtml(decodeEntities('a &lt; b'))).toBe('a &lt; b')
+    // Named references outside the escape set stay decoded — the
+    // literal character is the canonical emission (`©`, not `&copy;`).
+    expect(escapeHtml(decodeEntities('&copy; 2026'))).toBe('© 2026')
+  })
+})

--- a/packages/shared/src/html-entities.ts
+++ b/packages/shared/src/html-entities.ts
@@ -1,0 +1,123 @@
+/**
+ * HTML character-reference decoding and escaping for STATIC template
+ * content.
+ *
+ * JSX decodes character references at parse time: `<span>Fish &amp;
+ * Chips</span>` means the TEXT `Fish & Chips`, and `&copy;` means `©`
+ * (Babel/esbuild/TypeScript's JSX emit all decode). Phase 1
+ * (`jsx-to-ir`) applies `decodeEntities` once so `IRText.value` and
+ * static attribute values carry the DECODED text — the semantics —
+ * and every adapter re-escapes for its own emission context
+ * (`escapeHtml` for HTML template output; the Hono adapter
+ * re-encodes for JSX source). An adapter that emitted the raw entity
+ * text passed `&copy;` through as bytes while the reference decoded it
+ * (the `html-entity-text` divergence), and one that skipped
+ * re-escaping emitted a parse-corrupting `<`.
+ *
+ * The named table is the curated set below, not the full HTML5 list
+ * (~2,200 names): an unknown name (`&foo;`) is left as raw text, so
+ * BOTH the reference adapter and the template adapters receive the
+ * same undecoded string from the IR and stay byte-identical — the
+ * degradation is consistent, exactly how a browser treats an unknown
+ * reference. Numeric references (`&#169;` / `&#xA9;`) decode fully.
+ */
+
+/**
+ * Named character references JSX authors actually write in literal
+ * text. `amp`/`lt`/`gt`/`quot`/`apos` are the escaping set itself;
+ * the rest are the common typographic/symbol names.
+ */
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+  copy: '©',
+  reg: '®',
+  trade: '™',
+  deg: '°',
+  plusmn: '±',
+  times: '×',
+  divide: '÷',
+  middot: '·',
+  bull: '•',
+  hellip: '…',
+  ndash: '–',
+  mdash: '—',
+  lsquo: '‘',
+  rsquo: '’',
+  ldquo: '“',
+  rdquo: '”',
+  laquo: '«',
+  raquo: '»',
+  sect: '§',
+  para: '¶',
+  dagger: '†',
+  Dagger: '‡',
+  euro: '€',
+  pound: '£',
+  yen: '¥',
+  cent: '¢',
+  sup1: '¹',
+  sup2: '²',
+  sup3: '³',
+  frac12: '½',
+  frac14: '¼',
+  frac34: '¾',
+  larr: '←',
+  uarr: '↑',
+  rarr: '→',
+  darr: '↓',
+  harr: '↔',
+  minus: '−',
+  infin: '∞',
+  ne: '≠',
+  le: '≤',
+  ge: '≥',
+}
+
+/**
+ * Decode HTML character references in JSX literal text / static
+ * attribute values: numeric decimal (`&#169;`), numeric hex
+ * (`&#xA9;`), and the curated named set above. Anything unrecognized
+ * (unknown name, malformed numeric, bare `&`) is left verbatim.
+ */
+export function decodeEntities(text: string): string {
+  return text.replace(/&(#[xX]?[0-9a-fA-F]+|[a-zA-Z][a-zA-Z0-9]*);/g, (match, body: string) => {
+    if (body[0] === '#') {
+      const isHex = body[1] === 'x' || body[1] === 'X'
+      const digits = body.slice(isHex ? 2 : 1)
+      if (!isHex && !/^[0-9]+$/.test(digits)) return match
+      const code = parseInt(digits, isHex ? 16 : 10)
+      // Reject out-of-range / lone-surrogate code points rather than
+      // producing replacement garbage — leave the reference raw.
+      if (!Number.isFinite(code) || code > 0x10ffff || (code >= 0xd800 && code <= 0xdfff)) {
+        return match
+      }
+      return String.fromCodePoint(code)
+    }
+    return NAMED_ENTITIES[body] ?? match
+  })
+}
+
+/**
+ * Escape decoded static text for direct HTML emission: `&` `<` `>`
+ * `"` to their named forms. Used for BOTH text nodes and double-quoted
+ * attribute values — one set, no context-dependent under-escaping.
+ *
+ * `'` is deliberately NOT escaped: the reference (Hono JSX) escapes it
+ * as `&#39;`, but raw `'` is valid everywhere outside single-quoted
+ * attributes (which no adapter emits), and the conformance harness's
+ * `normalizeHTML` canonicalises the raw and entity forms to one
+ * spelling on both sides — so leaving apostrophes raw keeps every
+ * existing template byte-stable instead of rewriting all prose text.
+ */
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -41,6 +41,7 @@ export {
   BOOLEAN_ATTRS,
 } from './dom-prop.ts'
 export type { DOMPropKind, DOMPropClassification } from './dom-prop.ts'
+export { decodeEntities, escapeHtml } from './html-entities.ts'
 
 export type {
   ProfilerEvent,

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2170,10 +2170,6 @@
         "go-template": {
           "kind": "render",
           "reason": "`.toFixed(2)` on a number PROP: generated Go fails to run (exit 1)"
-        },
-        "mojolicious": {
-          "kind": "render",
-          "reason": "the literal `¥` in template text reaches the output as U+FFFD — a UTF-8 encoding gap for non-ASCII literal text adjacent to a dynamic slot"
         }
       },
       "object-entries-map": {

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2058,40 +2058,6 @@
           "reason": "three-level composition: the grandchild's threaded prop renders EMPTY — prop forwarding through two template-render layers loses the value"
         }
       },
-      "html-entity-text": {
-        "blade": {
-          "kind": "render",
-          "reason": "`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes"
-        },
-        "erb": {
-          "kind": "render",
-          "reason": "`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes"
-        },
-        "go-template": {
-          "kind": "render",
-          "reason": "`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes"
-        },
-        "jinja": {
-          "kind": "render",
-          "reason": "`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes"
-        },
-        "minijinja": {
-          "kind": "render",
-          "reason": "`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes"
-        },
-        "mojolicious": {
-          "kind": "render",
-          "reason": "`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes"
-        },
-        "twig": {
-          "kind": "render",
-          "reason": "`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes"
-        },
-        "xslate": {
-          "kind": "render",
-          "reason": "`&copy;` in JSX literal text: Hono decodes to `©`, this adapter re-emits the raw entity — same DOM, different bytes"
-        }
-      },
       "jsx-element-prop": {
         "blade": {
           "kind": "render",
@@ -2434,40 +2400,6 @@
             "BF101",
             "BF103"
           ]
-        }
-      },
-      "static-attr-escape": {
-        "blade": {
-          "kind": "render",
-          "reason": "static attribute values are not HTML-escaped (`title=\"Fish & Chips\"` emitted raw; Hono escapes)"
-        },
-        "erb": {
-          "kind": "render",
-          "reason": "static attribute values are not HTML-escaped (`title=\"Fish & Chips\"` emitted raw; Hono escapes)"
-        },
-        "go-template": {
-          "kind": "render",
-          "reason": "static attribute values are not HTML-escaped (`title=\"Fish & Chips\"` emitted raw; Hono escapes)"
-        },
-        "jinja": {
-          "kind": "render",
-          "reason": "static attribute values are not HTML-escaped (`title=\"Fish & Chips\"` emitted raw; Hono escapes)"
-        },
-        "minijinja": {
-          "kind": "render",
-          "reason": "static attribute values are not HTML-escaped (`title=\"Fish & Chips\"` emitted raw; Hono escapes)"
-        },
-        "mojolicious": {
-          "kind": "render",
-          "reason": "static attribute values are not HTML-escaped (`title=\"Fish & Chips\"` emitted raw; Hono escapes)"
-        },
-        "twig": {
-          "kind": "render",
-          "reason": "static attribute values are not HTML-escaped (`title=\"Fish & Chips\"` emitted raw; Hono escapes)"
-        },
-        "xslate": {
-          "kind": "render",
-          "reason": "static attribute values are not HTML-escaped (`title=\"Fish & Chips\"` emitted raw; Hono escapes)"
         }
       },
       "string-concat-plus": {


### PR DESCRIPTION
# Divergence-resolution stack 5/N — character references and static escaping

Follows #2176 (merged). Same principle: the IR carries the semantics; adapters emit from it.

## What

Two divergence classes shared by ALL eight template adapters:

- **`html-entity-text`** — JSX defines `&copy;` in literal text as the character `©` (Babel, esbuild, and TypeScript's JSX emit all decode at parse time), but the compiler carried the raw source text through the IR, so every template adapter re-emitted the undecoded entity while the Hono reference rendered the decoded character.
- **`static-attr-escape`** — static attribute values reached the output unescaped (`title="Fish & Chips"` emitted raw; the reference escapes).

## How

- **Phase 1 decodes once**: new `decodeEntities` in `@barefootjs/shared` (numeric references fully; named references from a curated table — an unknown name stays raw and degrades identically on every backend, matching browser behavior for unknown references). `IRText.value` and static attribute values now carry the decoded semantics.
- **Emission escapes per context**: the eight template adapters' `emitText` / element `emitLiteral` and the client-JS `innerHTML` template builders (5 text arms + 5 attr-literal arms in `html-template.ts`) route through the shared `escapeHtml` (`& < > "`). Apostrophes stay raw — the harness's `normalizeHTML` already canonicalises the raw and entity forms, so existing templates stay byte-stable. The Hono adapter re-encodes for JSX source (same set plus `{`/`}`, which have no named reference); the JSX parser decodes them back, so rendered bytes are unchanged. `JSON.stringify`-context sites (component props, `textContent` updates) correctly keep the decoded value with no HTML escaping.
- **Mojo harness fix**: the conformance render script read templates through `:utf8` but printed to STDOUT without a matching layer, so `©`/`¥` left Perl as latin-1 bytes and surfaced as U+FFFD. A real Mojolicious response encodes on the way out — harness-only. `binmode STDOUT, ':encoding(UTF-8)'` fixes it.

## Graduations

- `html-entity-text` and `static-attr-escape` leave all eight adapters' `renderDivergences` declarations and the CSR conformance skip list (SSR and CSR now agree by construction).
- `number-tofixed` graduates on Mojolicious — its only symptom was the harness's mangled `¥`.
- `ui/compat.lock.json`: 17 divergence entries removed.

## Verified

Full sequential verification on real backends, all green (0 fail): jinja 507, mojolicious 693 (re-run after the harness fix), xslate 508, twig 507, blade 507, rust 507, erb 481, go-template 718, hono 579, adapter-tests 1,190 (including the two newly un-skipped CSR fixtures), compat 558/558 cells ok, `packages/jsx` 2,364 with zero snapshot churn, `packages/shared` 58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ZXzQWvSKLUUrTAZ3vph1j

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZXzQWvSKLUUrTAZ3vph1j)_