### PR TITLE
Dispatch string .length to Perl length() in the Mojo emitter (divergence stack 6/N)

### DIFF
--- a/.changeset/mojo-string-length-dispatch.md
+++ b/.changeset/mojo-string-length-dispatch.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/mojolicious": patch
+---
+
+Dispatch `.length` on receiver type in the Mojolicious top-level emitter. A `.length` access lowered unconditionally to Perl's array form `scalar(@{$x})`, which dereferences the value as an array ref and returns 0 for a scalar string — so `word.length` on a `string` prop rendered `0` instead of the character count. The emitter now emits Perl's scalar `length($x)` when the receiver is string-typed (a known string prop/getter via `isStringTypedOperand`, or a bare identifier bound to one via the `_isStringValueName` witness the `eq`/concat lowering already consults) and keeps `scalar(@{...})` for array receivers. The `string-length-text` fixture graduates from Mojolicious's `renderDivergences`.

--- a/packages/adapter-mojolicious/src/adapter/expr/emitters.ts
+++ b/packages/adapter-mojolicious/src/adapter/expr/emitters.ts
@@ -338,7 +338,22 @@ export class MojoTopLevelEmitter implements ParsedExprEmitter {
       if (staticValue !== null) return staticValue
     }
     const obj = emit(object)
-    if (property === 'length') return `scalar(@{${obj}})`
+    if (property === 'length') {
+      // `.length` dispatches on receiver type: a STRING receiver needs
+      // Perl's scalar `length($x)`, while the array lowering
+      // `scalar(@{$x})` dereferences the value as an array ref and
+      // returns 0 for a scalar string (the `string-length-text`
+      // divergence). The receiver is string-typed when it's a known
+      // string prop/getter (`isStringTypedOperand`) or a bare
+      // identifier bound to one — the same `_isStringValueName` witness
+      // the `eq`/concat lowering already consults.
+      const isStr = (e: ParsedExpr) => isStringTypedOperand(e, n => this.ctx._isStringValueName(n))
+      const isStringReceiver =
+        isStr(object) ||
+        (object.kind === 'identifier' && this.ctx._isStringValueName(object.name))
+      if (isStringReceiver) return `length(${obj})`
+      return `scalar(@{${obj}})`
+    }
     return `${obj}->{${property}}`
   }
 

--- a/packages/adapter-mojolicious/src/render-divergences.ts
+++ b/packages/adapter-mojolicious/src/render-divergences.ts
@@ -15,8 +15,6 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
-  'string-length-text':
-    '`.length` on a STRING prop diverges (array-length lowering misapplied to a scalar)',
   'math-methods':
     'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
   'object-entries-map':

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2404,12 +2404,6 @@
           "reason": "`'Hello, ' + name` renders \"0\" — JS string-concat `+` lowered through numeric addition"
         }
       },
-      "string-length-text": {
-        "mojolicious": {
-          "kind": "render",
-          "reason": "`.length` on a STRING prop diverges (array-length lowering misapplied to a scalar)"
-        }
-      },
       "string-replaceall": {
         "blade": {
           "kind": "refusal",


### PR DESCRIPTION
# Divergence-resolution stack 6/N — string `.length` receiver dispatch (Mojolicious)

Follows #2179 (merged). Same principle: the IR carries the semantics; adapters emit from it.

## What

`word.length` on a `string` prop rendered **`0`** on Mojolicious. The top-level `member()` emitter lowered `.length` unconditionally to Perl's array form `scalar(@{$x})`, which dereferences a scalar string as an array ref and yields `0` instead of the character count. This was the `string-length-text` divergence (Mojolicious was the only adapter carrying it — Go's `len` and Python's `bf.length` already branch on receiver type).

## How

`.length` now dispatches on receiver type: a string-typed receiver emits Perl's scalar `length($x)`; an array receiver keeps `scalar(@{$x})`. The receiver is string-typed when it's a known string prop/getter (the shared `isStringTypedOperand`) or a bare identifier bound to one — using the same `_isStringValueName` witness the adapter's `eq`/concat lowering already consults (no new type machinery). The filter-context `member()` emitter is already gated to array-shaped receivers, so only the top-level path needed the split.

Verified by compiling both shapes:

```
word.length  (string prop)  → length($word)
items.length (array prop)   → scalar(@{$items})
```

## Graduations

- `string-length-text` leaves Mojolicious's `renderDivergences`.
- `ui/compat.lock.json`: the entry is removed (it was Mojo-only, so the whole fixture key disappears).

## Verified

Full Mojolicious conformance suite on real Perl — 694 tests, 0 fail (the `string-length-text` fixture now runs instead of skips). `compat` 558/558 cells ok.

## Scope note

This is the first, smallest unit of the string-method divergence class. The remaining members — `string-slice`, `string-trim-sided` (`trimStart`/`trimEnd`), and `string-replaceall` — require new IR union members, parse arms, per-adapter emitter cases, and new runtime helpers across the Go/Python/Perl/Rust/PHP/Ruby runtimes, so they'll land as separate stacked PRs. `.length` is a `member`-access semantic with no runtime changes, so it stands alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZXzQWvSKLUUrTAZ3vph1j)_