### PR TITLE
Dispatch .slice() to a string branch in every runtime helper (divergence stack 7/N)

### DIFF
--- a/.changeset/string-slice-runtime-dispatch.md
+++ b/.changeset/string-slice-runtime-dispatch.md
@@ -1,0 +1,14 @@
+---
+"@barefootjs/jinja": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+"@barefootjs/twig": patch
+"@barefootjs/blade": patch
+"@barefootjs/rust": patch
+"@barefootjs/erb": patch
+"@barefootjs/go-template": patch
+"@barefootjs/perl": patch
+"@barefootjs/php": patch
+---
+
+Dispatch `.slice()` to a string branch in every backend's runtime helper. `word.slice(0, 4)` on a `string` prop rendered empty (Go/Ruby/Perl/PHP/Rust) or `[]` (Python/Perl EP text) instead of the substring — the adapter can't disambiguate a string receiver from an array receiver at compile time (both lower through the same `bf_slice`/`bf.slice` call), so the compiled template already emits the correct polymorphic call; only the runtime helper itself needed a string branch, the same way `.includes()` already dispatches on the runtime value's type. Negative start (`slice(-4)`), an absent end (`slice(4)`), out-of-range clamping, and multi-byte characters (indexed by code point, not byte offset) all match the JS reference. New golden-vector cases (`packages/adapter-tests/vectors/cases.ts`) pin the string-receiver shape across every runtime that consumes the shared corpus (Go, Perl, Python, Ruby, PHP), plus a matching Rust test. The `string-slice` fixture graduates from all eight template adapters' `renderDivergences` declarations.

--- a/packages/adapter-blade/src/render-divergences.ts
+++ b/packages/adapter-blade/src/render-divergences.ts
@@ -23,8 +23,6 @@ export const renderDivergences: RenderDivergences = {
     'nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`',
   'jsx-element-prop':
     'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
-  'string-slice':
-    '`.slice()` on a STRING renders empty (array-slice helper misfires on strings)',
   'string-trim-sided':
     '`.trimStart()` / `.trimEnd()` render empty (no lowering)',
 }

--- a/packages/adapter-erb/lib/barefoot_js.rb
+++ b/packages/adapter-erb/lib/barefoot_js.rb
@@ -563,13 +563,22 @@ module BarefootJS
       out
     end
 
-    # `Array.prototype.slice(start, end?)`. Mirrors the Go/Perl `bf_slice` /
-    # `slice` arithmetic so adapter output stays symmetric.
+    # `Array.prototype.slice(start, end?)` AND `String.prototype.slice`
+    # (the `string-slice` divergence) -- the adapter emits the same
+    # `bf_slice` call for both receiver shapes (it can't disambiguate
+    # string vs. array at compile time), so this dispatches on Ruby
+    # class, mirroring `includes` above. Mirrors the Go/Perl `bf_slice`
+    # / `slice` arithmetic so adapter output stays symmetric.
+    # `String#length` / `#[]` already index by character (not byte) for
+    # a UTF-8-encoded string, matching JS except for astral-plane input
+    # (the same divergence boundary every other adapter's pad/trim
+    # helpers already accept).
     def slice(recv, start, end_ = nil)
-      return [] unless recv.is_a?(Array)
+      return [] unless recv.is_a?(Array) || recv.is_a?(String)
 
+      empty = recv.is_a?(String) ? '' : []
       len = recv.length
-      return [] if len.zero?
+      return empty if len.zero?
 
       s = start.nil? ? 0 : start.to_i
       s = len + s if s.negative?
@@ -581,7 +590,7 @@ module BarefootJS
       e = 0 if e.negative?
       e = len if e > len
 
-      return [] if s >= e
+      return empty if s >= e
 
       recv[s...e]
     end

--- a/packages/adapter-erb/src/render-divergences.ts
+++ b/packages/adapter-erb/src/render-divergences.ts
@@ -25,8 +25,6 @@ export const renderDivergences: RenderDivergences = {
     'nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`',
   'jsx-element-prop':
     'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
-  'string-slice':
-    '`.slice()` on a STRING lowers through the array slice helper and renders "[]" instead of the substring',
   'string-trim-sided':
     '`.trimStart()` / `.trimEnd()` render empty (no lowering; only both-sides `.trim` is wired)',
 }

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -1221,27 +1221,17 @@ func Concat(a, b any) []any {
 	return append(left, right...)
 }
 
-// Slice carves out a sub-range from `items`. Lowers
-// `Array.prototype.slice(start, end?)` (#1448 Tier A). The variadic
-// `end` arg lets Go template's call dispatcher pass either 2 or 3
-// arguments; an absent end means "to length".
+// clampSliceRange normalizes JS `.slice(start, end?)` bounds against a
+// receiver of `length` elements (runes, for the string branch of
+// `Slice` below; array elements, for the array branch) — shared so
+// both branches clamp identically.
 //
 // JS-compat clamping:
 //   - start < 0          → length + start  (e.g. -1 = last index)
 //   - end < 0            → length + end
 //   - start < 0 after clamp → 0
 //   - end > length       → length
-//   - start >= end       → empty slice (no panic)
-//
-// Non-array receivers return an empty `[]any`.
-func Slice(items any, start int, end ...int) []any {
-	v := reflect.ValueOf(items)
-	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
-		return []any{}
-	}
-	length := v.Len()
-
-	// Normalise start (negative = from end).
+func clampSliceRange(length, start int, end []int) (int, int) {
 	if start < 0 {
 		start = length + start
 	}
@@ -1252,7 +1242,6 @@ func Slice(items any, start int, end ...int) []any {
 		start = length
 	}
 
-	// Normalise end (optional; absent = length).
 	stop := length
 	if len(end) > 0 {
 		stop = end[0]
@@ -1266,13 +1255,46 @@ func Slice(items any, start int, end ...int) []any {
 			stop = length
 		}
 	}
+	return start, stop
+}
 
-	if start >= stop {
-		return []any{}
+// Slice carves out a sub-range from `items`. Lowers
+// `Array.prototype.slice(start, end?)` (#1448 Tier A) AND
+// `String.prototype.slice(start, end?)` (the `string-slice`
+// divergence) — the adapter emits the same `bf_slice` call for both
+// receiver shapes (it can't disambiguate string vs. array at compile
+// time), so this helper dispatches at runtime on `reflect.Kind()`,
+// mirroring `Includes` above. The variadic `end` arg lets Go
+// template's call dispatcher pass either 2 or 3 arguments; an absent
+// end means "to length".
+//
+// String length/positions are measured in runes, not UTF-16 code
+// units — the same divergence boundary `padTo` already accepts
+// (differs from JS only for astral-plane input). `start >= end`
+// (after clamping) returns an empty result for either receiver.
+//
+// Any other receiver kind returns an empty `[]any`.
+func Slice(items any, start int, end ...int) any {
+	v := reflect.ValueOf(items)
+
+	if v.Kind() == reflect.String {
+		runes := []rune(v.String())
+		s, e := clampSliceRange(len(runes), start, end)
+		if s >= e {
+			return ""
+		}
+		return string(runes[s:e])
 	}
 
-	out := make([]any, 0, stop-start)
-	for i := start; i < stop; i++ {
+	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
+		return []any{}
+	}
+	s, e := clampSliceRange(v.Len(), start, end)
+	if s >= e {
+		return []any{}
+	}
+	out := make([]any, 0, e-s)
+	for i := s; i < e; i++ {
 		out = append(out, v.Index(i).Interface())
 	}
 	return out

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -474,40 +474,68 @@ func TestSlice(t *testing.T) {
 	items := []string{"a", "b", "c", "d", "e"}
 
 	// 2-arg form.
-	got := Slice(items, 1, 3)
+	got := Slice(items, 1, 3).([]any)
 	if len(got) != 2 || got[0] != "b" || got[1] != "c" {
 		t.Errorf("Slice(items, 1, 3) = %v, want [b c]", got)
 	}
 
 	// 1-arg form (`end` absent = length).
-	got = Slice(items, 2)
+	got = Slice(items, 2).([]any)
 	if len(got) != 3 || got[0] != "c" || got[2] != "e" {
 		t.Errorf("Slice(items, 2) = %v, want [c d e]", got)
 	}
 
 	// Negative-index normalisation.
-	got = Slice(items, -2)
+	got = Slice(items, -2).([]any)
 	if len(got) != 2 || got[0] != "d" || got[1] != "e" {
 		t.Errorf("Slice(items, -2) = %v, want [d e]", got)
 	}
-	got = Slice(items, 0, -1)
+	got = Slice(items, 0, -1).([]any)
 	if len(got) != 4 || got[3] != "d" {
 		t.Errorf("Slice(items, 0, -1) = %v, want [a b c d]", got)
 	}
 
 	// Clamping (out-of-bounds + start >= end).
-	got = Slice(items, 100)
+	got = Slice(items, 100).([]any)
 	if len(got) != 0 {
 		t.Errorf("Slice(items, 100) = %v, want []", got)
 	}
-	got = Slice(items, 3, 1)
+	got = Slice(items, 3, 1).([]any)
 	if len(got) != 0 {
 		t.Errorf("Slice(items, 3, 1) = %v, want []", got)
 	}
 
-	// Non-array receiver.
-	if got := Slice("not an array", 0, 2); len(got) != 0 {
-		t.Errorf("Slice(scalar, 0, 2) = %v, want []", got)
+	// Non-array, non-string receiver: empty-array fallback.
+	if got := Slice(42, 0, 2).([]any); len(got) != 0 {
+		t.Errorf("Slice(42, 0, 2) = %v, want []", got)
+	}
+}
+
+// `String.prototype.slice(start, end?)` lowering — the `string-slice`
+// divergence (a string receiver used to fall into the array branch
+// and return an empty `[]any`). Mirrors `TestSlice` shape-for-shape
+// with a string receiver instead of a slice.
+func TestSlice_String(t *testing.T) {
+	word := "barefootjs"
+
+	if got := Slice(word, 0, 4); got != "bare" {
+		t.Errorf("Slice(%q, 0, 4) = %v, want %q", word, got, "bare")
+	}
+	// Negative start.
+	if got := Slice(word, -4); got != "otjs" {
+		t.Errorf("Slice(%q, -4) = %v, want %q", word, got, "otjs")
+	}
+	// Zero-arg-end (`end` absent = length).
+	if got := Slice(word, 4); got != "footjs" {
+		t.Errorf("Slice(%q, 4) = %v, want %q", word, got, "footjs")
+	}
+	// Clamping (start >= end).
+	if got := Slice(word, 5, 2); got != "" {
+		t.Errorf("Slice(%q, 5, 2) = %v, want empty string", word, got)
+	}
+	// Multi-byte runes: index by code point, not byte offset.
+	if got := Slice("héllo", 0, 2); got != "hé" {
+		t.Errorf(`Slice("héllo", 0, 2) = %v, want "hé"`, got)
 	}
 }
 

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -39,8 +39,6 @@ export const renderDivergences: RenderDivergences = {
     'a memo derived from another memo renders EMPTY for the second layer — the constructor folds only one derivation level',
   'signal-object-field':
     'object-valued signal (`user().name`): generated Go fails to run (exit 1) — no struct synthesis outside loops',
-  'string-slice':
-    '`.slice()` on a STRING routes through the array `bf_slice` helper and renders "[]" instead of the substring',
   'string-trim-sided':
     '`.trimStart()` / `.trimEnd()`: generated Go fails to run (exit 1) — only both-sides `bf_trim` exists',
 }

--- a/packages/adapter-jinja/python/barefootjs/runtime.py
+++ b/packages/adapter-jinja/python/barefootjs/runtime.py
@@ -935,7 +935,7 @@ class BarefootJS:
 
     def slice(self, recv: Any, start: Any, end: Any) -> Any:
         # `Array.prototype.slice(start, end?)` AND `String.prototype.slice`
-        # (the `string-slice` divergence, #2168) -- the adapter emits the
+        # (the `string-slice` divergence, #2182) -- the adapter emits the
         # same `bf.slice(recv, start, end)` call for both receiver shapes
         # (it can't disambiguate string vs. array at compile time), so
         # this dispatches on the Python type, mirroring `includes` above.

--- a/packages/adapter-jinja/python/barefootjs/runtime.py
+++ b/packages/adapter-jinja/python/barefootjs/runtime.py
@@ -933,12 +933,20 @@ class BarefootJS:
             out.extend(b)
         return out
 
-    def slice(self, recv: Any, start: Any, end: Any) -> list:
-        if not isinstance(recv, list):
+    def slice(self, recv: Any, start: Any, end: Any) -> Any:
+        # `Array.prototype.slice(start, end?)` AND `String.prototype.slice`
+        # (the `string-slice` divergence, #2168) -- the adapter emits the
+        # same `bf.slice(recv, start, end)` call for both receiver shapes
+        # (it can't disambiguate string vs. array at compile time), so
+        # this dispatches on the Python type, mirroring `includes` above.
+        # `str` and `list` share slicing semantics (`recv[s:e]`) and
+        # `len()`, so one clamp computation serves both; `str` indexing
+        # is by Unicode code point already, matching JS except for
+        # astral-plane input (the same divergence boundary every other
+        # adapter's pad/trim helpers already accept).
+        if not isinstance(recv, (list, str)):
             return []
         length = len(recv)
-        if length == 0:
-            return []
         s = start if start is not None else 0
         if s < 0:
             s = length + s
@@ -950,8 +958,8 @@ class BarefootJS:
         e = max(e, 0)
         e = min(e, length)
         if s >= e:
-            return []
-        return list(recv[s:e])
+            return recv[0:0]
+        return recv[s:e] if isinstance(recv, str) else list(recv[s:e])
 
     def reverse(self, recv: Any) -> list:
         if not isinstance(recv, list):

--- a/packages/adapter-jinja/python/tests/test_template_primitives.py
+++ b/packages/adapter-jinja/python/tests/test_template_primitives.py
@@ -158,6 +158,18 @@ class TemplatePrimitivesTest(unittest.TestCase):
         out.append("mutated")
         self.assertEqual(src, ["a", "b", "c"])
 
+    def test_slice_string_receiver(self):
+        # The `string-slice` divergence (#2182): a string receiver used
+        # to fall through the array-only branch and return an empty
+        # list instead of a substring.
+        word = "barefootjs"
+        self.assertEqual(self.bf.slice(word, 0, 4), "bare")
+        self.assertEqual(self.bf.slice(word, -4, None), "otjs")
+        self.assertEqual(self.bf.slice(word, 4, None), "footjs")
+        self.assertEqual(self.bf.slice(word, 5, 2), "")
+        # Multi-byte: index by character, not byte.
+        self.assertEqual(self.bf.slice("héllo", 0, 2), "hé")
+
     def test_reverse_mutation_isolation(self):
         self.assertEqual(self.bf.reverse(["a", "b", "c"]), ["c", "b", "a"])
         self.assertEqual(self.bf.reverse([]), [])

--- a/packages/adapter-jinja/src/render-divergences.ts
+++ b/packages/adapter-jinja/src/render-divergences.ts
@@ -23,8 +23,6 @@ export const renderDivergences: RenderDivergences = {
     'nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`',
   'jsx-element-prop':
     'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
-  'string-slice':
-    '`.slice()` on a STRING renders empty (array-slice helper misfires on strings)',
   'string-trim-sided':
     '`.trimStart()` / `.trimEnd()` render empty (no lowering)',
 }

--- a/packages/adapter-mojolicious/src/render-divergences.ts
+++ b/packages/adapter-mojolicious/src/render-divergences.ts
@@ -23,8 +23,6 @@ export const renderDivergences: RenderDivergences = {
     'nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`',
   'jsx-element-prop':
     'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
-  'string-slice':
-    '`.slice()` on a STRING misfires through the array slice helper',
   'string-trim-sided':
     '`.trimStart()` / `.trimEnd()` render empty (no lowering)',
 }

--- a/packages/adapter-perl/lib/BarefootJS.pm
+++ b/packages/adapter-perl/lib/BarefootJS.pm
@@ -800,22 +800,39 @@ sub concat ($self, $a, $b) {
     return \@out;
 }
 
-# `Array.prototype.slice(start, end?)` — carves out a sub-range
-# into a new ARRAY ref. Mirrors the Go `bf_slice` arithmetic so
-# adapter output stays symmetric:
+# `Array.prototype.slice(start, end?)` AND `String.prototype.slice`
+# (the `string-slice` divergence) — carves out a sub-range. The
+# adapter emits the same call for both receiver shapes (it can't
+# disambiguate string vs. array at compile time), so this dispatches
+# at runtime on `ref($recv)`, mirroring `includes` above. Mirrors the
+# Go `bf_slice` arithmetic so adapter output stays symmetric:
 #   - start < 0          → length + start  (e.g. -1 = last index)
 #   - end < 0            → length + end
 #   - start < 0 after clamp → 0
 #   - end > length       → length
 #   - start >= end       → empty
 #   - end undef          → "to length"
-# Non-array receivers return an empty ARRAY ref.
+# String length/positions are characters (`use utf8` is active), not
+# bytes. Any other receiver returns an empty ARRAY ref.
 
 sub slice ($self, $recv, $start, $end) {
+    if (!ref($recv) && defined $recv) {
+        my $len = CORE::length($recv);
+        my ($s, $e) = _clamp_slice_range($len, $start, $end);
+        return '' if $s >= $e;
+        return substr($recv, $s, $e - $s);
+    }
     return [] unless ref($recv) eq 'ARRAY';
     my $len = scalar @$recv;
     return [] if $len == 0;
 
+    my ($s, $e) = _clamp_slice_range($len, $start, $end);
+    return [] if $s >= $e;
+    return [ @{$recv}[$s .. $e - 1] ];
+}
+
+# Shared bounds arithmetic for both `slice` branches above.
+sub _clamp_slice_range ($len, $start, $end) {
     my $s = $start // 0;
     $s = $len + $s if $s < 0;
     $s = 0    if $s < 0;
@@ -826,8 +843,7 @@ sub slice ($self, $recv, $start, $end) {
     $e = 0    if $e < 0;
     $e = $len if $e > $len;
 
-    return [] if $s >= $e;
-    return [ @{$recv}[$s .. $e - 1] ];
+    return ($s, $e);
 }
 
 # `Array.prototype.reverse()` / `Array.prototype.toReversed()` —

--- a/packages/adapter-perl/t/template_primitives.t
+++ b/packages/adapter-perl/t/template_primitives.t
@@ -189,7 +189,7 @@ subtest 'concat — merges two arrays into a new array ref' => sub {
 # into a new ARRAY ref (#1448 Tier A). Mirrors the Go `bf_slice`
 # JS-compat semantics: negative-index normalisation, out-of-bounds
 # clamping, `start >= end` returns empty, undef `end` means "to
-# length". Non-array receivers return an empty ARRAY ref.
+# length". Non-array, non-string receivers return an empty ARRAY ref.
 subtest 'slice — array sub-range with negative-index + clamping' => sub {
     my $arr = ['a', 'b', 'c', 'd', 'e'];
 
@@ -213,13 +213,29 @@ subtest 'slice — array sub-range with negative-index + clamping' => sub {
     # Edge cases.
     is $bf->slice([],     0, undef), [],                   'empty array → empty';
     is $bf->slice(undef,  0, undef), [],                   'undef receiver → empty';
-    is $bf->slice('scalar', 0, undef), [],                 'scalar receiver → empty';
+    is $bf->slice({foo => 1}, 0, undef), [],                'hashref receiver → empty (not array, not string)';
 
     # Mutation isolation.
     my $src = ['a', 'b', 'c'];
     my $out = $bf->slice($src, 0, 2);
     push @$out, 'mutated';
     is $src, ['a', 'b', 'c'], 'source unchanged after mutating slice result';
+};
+
+# `String.prototype.slice(start, end?)` — the `string-slice`
+# divergence (#2182): a scalar receiver used to fall through the
+# array-only branch above and return an empty ARRAY ref instead of a
+# substring. Mirrors the array subtest's shape with a string receiver.
+subtest 'slice — string sub-range with negative-index + clamping' => sub {
+    my $word = 'barefootjs';
+
+    is $bf->slice($word, 0, 4),      'bare',   'start+end carves the prefix';
+    is $bf->slice($word, -4, undef), 'otjs',   'negative start counts from the end';
+    is $bf->slice($word, 4, undef),  'footjs', 'undef end → to length';
+    is $bf->slice($word, 5, 2),      '',       'start > end → empty string';
+
+    # Multi-byte: index by character, not byte.
+    is $bf->slice('héllo', 0, 2), 'hé', 'multi-byte characters count as one unit each';
 };
 
 # `Array.prototype.reverse()` / `Array.prototype.toReversed()` —

--- a/packages/adapter-php/src/BarefootJS.php
+++ b/packages/adapter-php/src/BarefootJS.php
@@ -914,9 +914,23 @@ final class BarefootJS
         return $out;
     }
 
-    /** `Array.prototype.slice(start, end?)`. */
-    public function slice($recv, $start, $end): array
+    /** `Array.prototype.slice(start, end?)` AND `String.prototype.slice`
+     * (the `string-slice` divergence) -- the adapter emits the same
+     * `slice(recv, start, end)` call for both receiver shapes (it can't
+     * disambiguate string vs. array at compile time), so this dispatches
+     * on the receiver's PHP type, mirroring `includes` above. String
+     * length/positions use `mb_strlen`/`mb_substr` (UTF-8 code points,
+     * not bytes), matching this runtime's other string helpers. */
+    public function slice($recv, $start, $end)
     {
+        if (is_string($recv)) {
+            $len = mb_strlen($recv, 'UTF-8');
+            [$s, $e] = $this->clampSliceRange($len, $start, $end);
+            if ($s >= $e) {
+                return '';
+            }
+            return mb_substr($recv, (int) $s, (int) ($e - $s), 'UTF-8');
+        }
         if (!Evaluator::isJsArray($recv)) {
             return [];
         }
@@ -925,6 +939,16 @@ final class BarefootJS
         if ($len === 0) {
             return [];
         }
+        [$s, $e] = $this->clampSliceRange($len, $start, $end);
+        if ($s >= $e) {
+            return [];
+        }
+        return array_slice($arr, (int) $s, (int) ($e - $s));
+    }
+
+    /** Shared bounds arithmetic for both `slice` branches above. */
+    private function clampSliceRange(int $len, $start, $end): array
+    {
         $s = $start ?? 0;
         if ($s < 0) {
             $s += $len;
@@ -937,10 +961,7 @@ final class BarefootJS
         }
         $e = max($e, 0);
         $e = min($e, $len);
-        if ($s >= $e) {
-            return [];
-        }
-        return array_slice($arr, (int) $s, (int) ($e - $s));
+        return [$s, $e];
     }
 
     public function reverse($recv): array

--- a/packages/adapter-php/tests/test_template_primitives.php
+++ b/packages/adapter-php/tests/test_template_primitives.php
@@ -188,6 +188,19 @@ bf_test('slice mutation isolation and clamping', function () use ($bf) {
     bf_assert_eq($src, ['a', 'b', 'c']);
 });
 
+bf_test('slice string receiver', function () use ($bf) {
+    // The `string-slice` divergence (#2182): a string receiver used to
+    // fall through the array-only branch and return an empty array
+    // instead of a substring.
+    $word = 'barefootjs';
+    bf_assert_eq($bf->slice($word, 0, 4), 'bare');
+    bf_assert_eq($bf->slice($word, -4, null), 'otjs');
+    bf_assert_eq($bf->slice($word, 4, null), 'footjs');
+    bf_assert_eq($bf->slice($word, 5, 2), '');
+    // Multi-byte: index by character, not byte.
+    bf_assert_eq($bf->slice('héllo', 0, 2), 'hé');
+});
+
 bf_test('reverse mutation isolation', function () use ($bf) {
     bf_assert_eq($bf->reverse(['a', 'b', 'c']), ['c', 'b', 'a']);
     bf_assert_eq($bf->reverse([]), []);

--- a/packages/adapter-rust/runtime/src/runtime.rs
+++ b/packages/adapter-rust/runtime/src/runtime.rs
@@ -166,6 +166,34 @@ fn char_slice_to(s: &str, n: usize) -> String {
     s.chars().take(n).collect()
 }
 
+/// `[start, end)` range slice by Unicode scalar value (`char`), not
+/// byte offset -- shared by `slice`'s string branch. Matches JS except
+/// for astral-plane input, the same divergence boundary `char_len` /
+/// `char_slice_from` / `char_slice_to` already accept.
+fn char_slice_range(s: &str, start: usize, end: usize) -> String {
+    if start >= end {
+        return String::new();
+    }
+    s.chars().skip(start).take(end - start).collect()
+}
+
+/// Clamp JS `.slice(start, end?)` bounds against a receiver of
+/// `length` elements -- shared by `slice`'s array and string branches
+/// below.
+fn clamp_slice_range(length: i64, start: &JsValue, end: &JsValue) -> (i64, i64) {
+    let mut s = if matches!(start, JsValue::Null) { 0 } else { num::to_f64(start) as i64 };
+    if s < 0 {
+        s += length;
+    }
+    s = s.clamp(0, length);
+    let mut e = if matches!(end, JsValue::Null) { length } else { num::to_f64(end) as i64 };
+    if e < 0 {
+        e += length;
+    }
+    e = e.clamp(0, length);
+    (s, e)
+}
+
 // ---------------------------------------------------------------------------
 // spread_attrs support (JSX intrinsic-element spread, #1407).
 // ---------------------------------------------------------------------------
@@ -1351,7 +1379,18 @@ pub fn concat(a: &JsValue, b: &JsValue) -> JsValue {
     JsValue::Array(out)
 }
 
+/// `Array.prototype.slice(start, end?)` AND `String.prototype.slice`
+/// (the `string-slice` divergence) -- the adapter emits the same
+/// `bf.slice(recv, start, end)` call for both receiver shapes (it
+/// can't disambiguate string vs. array at compile time), so this
+/// dispatches on `recv`'s `JsValue` variant, mirroring `includes` /
+/// `length` above.
 pub fn slice(recv: &JsValue, start: &JsValue, end: &JsValue) -> JsValue {
+    if let JsValue::String(s) = recv {
+        let length = char_len(s) as i64;
+        let (s_idx, e_idx) = clamp_slice_range(length, start, end);
+        return JsValue::String(char_slice_range(s, s_idx as usize, e_idx as usize));
+    }
     let items = match recv.as_array() {
         Some(a) => a,
         None => return JsValue::Array(Vec::new()),
@@ -1360,16 +1399,7 @@ pub fn slice(recv: &JsValue, start: &JsValue, end: &JsValue) -> JsValue {
     if length == 0 {
         return JsValue::Array(Vec::new());
     }
-    let mut s = if matches!(start, JsValue::Null) { 0 } else { num::to_f64(start) as i64 };
-    if s < 0 {
-        s += length;
-    }
-    s = s.clamp(0, length);
-    let mut e = if matches!(end, JsValue::Null) { length } else { num::to_f64(end) as i64 };
-    if e < 0 {
-        e += length;
-    }
-    e = e.clamp(0, length);
+    let (s, e) = clamp_slice_range(length, start, end);
     if s >= e {
         return JsValue::Array(Vec::new());
     }

--- a/packages/adapter-rust/runtime/tests/template_primitives.rs
+++ b/packages/adapter-rust/runtime/tests/template_primitives.rs
@@ -169,6 +169,20 @@ fn slice_mutation_isolation_and_clamping() {
     assert_eq!(src, arr(vec![s("a"), s("b"), s("c")]));
 }
 
+/// The `string-slice` divergence (#2182): a string receiver used to
+/// fall through the array-only branch and return an empty array
+/// instead of a substring.
+#[test]
+fn slice_string_receiver() {
+    let word = s("barefootjs");
+    assert_eq!(runtime::slice(&word, &n(0.0), &n(4.0)), s("bare"));
+    assert_eq!(runtime::slice(&word, &n(-4.0), &JsValue::Null), s("otjs"));
+    assert_eq!(runtime::slice(&word, &n(4.0), &JsValue::Null), s("footjs"));
+    assert_eq!(runtime::slice(&word, &n(5.0), &n(2.0)), s(""));
+    // Multi-byte: index by character, not byte.
+    assert_eq!(runtime::slice(&s("héllo"), &n(0.0), &n(2.0)), s("hé"));
+}
+
 #[test]
 fn reverse_mutation_isolation() {
     assert_eq!(runtime::reverse(&arr(vec![s("a"), s("b"), s("c")])), arr(vec![s("c"), s("b"), s("a")]));

--- a/packages/adapter-rust/src/render-divergences.ts
+++ b/packages/adapter-rust/src/render-divergences.ts
@@ -25,8 +25,6 @@ export const renderDivergences: RenderDivergences = {
     'nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`',
   'jsx-element-prop':
     'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
-  'string-slice':
-    '`.slice()` on a STRING renders empty (array-slice helper misfires on strings)',
   'string-trim-sided':
     '`.trimStart()` / `.trimEnd()` render empty (no lowering)',
 }

--- a/packages/adapter-tests/vectors/cases.ts
+++ b/packages/adapter-tests/vectors/cases.ts
@@ -356,7 +356,7 @@ export const cases: HelperCase[] = [
   { fn: 'slice', args: [[1, 2, 3, 4], 2, 1], note: 'start past end yields []' },
   { fn: 'slice', args: [[1, 2, 3, 4], 0, 99], note: 'end clamps to length' },
 
-  // String receiver (the `string-slice` divergence, #2168): the adapter
+  // String receiver (the `string-slice` divergence, #2182): the adapter
   // can't disambiguate a string from an array at compile time, so the
   // backend helper must dispatch on the runtime value's type the same
   // way `includes` already does.

--- a/packages/adapter-tests/vectors/cases.ts
+++ b/packages/adapter-tests/vectors/cases.ts
@@ -53,7 +53,7 @@ export const reference: Record<string, (...args: never[]) => unknown> = {
   index_of: (a: unknown[], x: unknown) => a.indexOf(x),
   last_index_of: (a: unknown[], x: unknown) => a.lastIndexOf(x),
   concat: (a: unknown[], b: unknown[]) => a.concat(b),
-  slice: (a: unknown[], start: number, end?: number) => a.slice(start, end),
+  slice: (a: string | unknown[], start: number, end?: number) => a.slice(start, end),
   reverse: (a: unknown[]) => [...a].reverse(),
   // Depth -1 is the compiled Infinity sentinel (spec entry).
   flat: (a: unknown[], depth: number) => a.flat(depth === -1 ? Infinity : depth),
@@ -355,6 +355,16 @@ export const cases: HelperCase[] = [
   { fn: 'slice', args: [[1, 2, 3, 4], 0, -1], note: 'negative end drops the tail' },
   { fn: 'slice', args: [[1, 2, 3, 4], 2, 1], note: 'start past end yields []' },
   { fn: 'slice', args: [[1, 2, 3, 4], 0, 99], note: 'end clamps to length' },
+
+  // String receiver (the `string-slice` divergence, #2168): the adapter
+  // can't disambiguate a string from an array at compile time, so the
+  // backend helper must dispatch on the runtime value's type the same
+  // way `includes` already does.
+  { fn: 'slice', args: ['barefootjs', 0, 4], note: 'string: start and end' },
+  { fn: 'slice', args: ['barefootjs', -4], note: 'string: negative start counts from the end' },
+  { fn: 'slice', args: ['barefootjs', 4], note: 'string: start only runs to the end' },
+  { fn: 'slice', args: ['barefootjs', 5, 2], note: 'string: start past end yields empty string' },
+  { fn: 'slice', args: ['héllo', 0, 2], note: 'string: multi-byte characters count as one unit each' },
 
   { fn: 'reverse', args: [[1, 2, 3]], note: 'basic reversal' },
   { fn: 'reverse', args: [[]], note: 'empty array' },

--- a/packages/adapter-tests/vectors/vectors.json
+++ b/packages/adapter-tests/vectors/vectors.json
@@ -1481,6 +1481,54 @@
       "note": "end clamps to length"
     },
     {
+      "fn": "slice",
+      "args": [
+        "barefootjs",
+        0,
+        4
+      ],
+      "expect": "bare",
+      "note": "string: start and end"
+    },
+    {
+      "fn": "slice",
+      "args": [
+        "barefootjs",
+        -4
+      ],
+      "expect": "otjs",
+      "note": "string: negative start counts from the end"
+    },
+    {
+      "fn": "slice",
+      "args": [
+        "barefootjs",
+        4
+      ],
+      "expect": "footjs",
+      "note": "string: start only runs to the end"
+    },
+    {
+      "fn": "slice",
+      "args": [
+        "barefootjs",
+        5,
+        2
+      ],
+      "expect": "",
+      "note": "string: start past end yields empty string"
+    },
+    {
+      "fn": "slice",
+      "args": [
+        "héllo",
+        0,
+        2
+      ],
+      "expect": "hé",
+      "note": "string: multi-byte characters count as one unit each"
+    },
+    {
       "fn": "reverse",
       "args": [
         [

--- a/packages/adapter-twig/src/render-divergences.ts
+++ b/packages/adapter-twig/src/render-divergences.ts
@@ -23,8 +23,6 @@ export const renderDivergences: RenderDivergences = {
     'nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`',
   'jsx-element-prop':
     'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
-  'string-slice':
-    '`.slice()` on a STRING misfires through the array slice helper',
   'string-trim-sided':
     '`.trimStart()` / `.trimEnd()` render empty (no lowering)',
 }

--- a/packages/adapter-xslate/src/render-divergences.ts
+++ b/packages/adapter-xslate/src/render-divergences.ts
@@ -23,8 +23,6 @@ export const renderDivergences: RenderDivergences = {
     'nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`',
   'jsx-element-prop':
     'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
-  'string-slice':
-    '`.slice()` on a STRING misfires through the array slice helper',
   'string-trim-sided':
     '`.trimStart()` / `.trimEnd()` render empty (no lowering)',
 }

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2454,40 +2454,6 @@
           ]
         }
       },
-      "string-slice": {
-        "blade": {
-          "kind": "render",
-          "reason": "`.slice()` on a STRING renders empty (array-slice helper misfires on strings)"
-        },
-        "erb": {
-          "kind": "render",
-          "reason": "`.slice()` on a STRING lowers through the array slice helper and renders \"[]\" instead of the substring"
-        },
-        "go-template": {
-          "kind": "render",
-          "reason": "`.slice()` on a STRING routes through the array `bf_slice` helper and renders \"[]\" instead of the substring"
-        },
-        "jinja": {
-          "kind": "render",
-          "reason": "`.slice()` on a STRING renders empty (array-slice helper misfires on strings)"
-        },
-        "minijinja": {
-          "kind": "render",
-          "reason": "`.slice()` on a STRING renders empty (array-slice helper misfires on strings)"
-        },
-        "mojolicious": {
-          "kind": "render",
-          "reason": "`.slice()` on a STRING misfires through the array slice helper"
-        },
-        "twig": {
-          "kind": "render",
-          "reason": "`.slice()` on a STRING misfires through the array slice helper"
-        },
-        "xslate": {
-          "kind": "render",
-          "reason": "`.slice()` on a STRING misfires through the array slice helper"
-        }
-      },
       "string-trim-sided": {
         "blade": {
           "kind": "render",


### PR DESCRIPTION
# Divergence-resolution stack 7/N — `.slice()` on a string

Follows #2181 (merged). Same principle: the IR carries the semantics; adapters emit from it.

## What

`word.slice(0, 4)` on a `string` prop rendered empty (Go/Ruby/Perl/PHP/Rust) or `[]`-shaped output (Python/Perl's Kolon text form) on every template adapter instead of the substring. `.slice()` exists on both `Array.prototype` and `String.prototype` in JS, and the compiler has no TS type inference — it can't disambiguate the receiver at parse time, so `word.slice(0, 4)` and `items.slice(0, 4)` produce the identical IR node.

## How

Turns out **no adapter or IR change was needed at all** — every adapter already emits the same polymorphic `bf_slice`/`bf.slice(recv, start, end)` call for both receiver shapes (confirmed by reading each adapter's emitter before touching anything). The bug lived entirely in the runtime helpers, which only ever handled the array branch and returned an empty array for anything else.

The fix mirrors the existing `.includes()` precedent (which already dispatches on the runtime value's type — Go `reflect.Kind()`, Python `isinstance`, etc.): each runtime's `slice` helper now branches on the receiver's actual type at call time and does a proper substring for a string receiver, with the same JS-compat clamping (negative start counts from the end, an absent end means "to length", out-of-range clamps, multi-byte characters indexed by code point not byte offset — the same divergence boundary already accepted for pad/trim on non-BMP input).

Touched exactly 6 runtimes (not 8 — Mojolicious and Text::Xslate share `@barefootjs/perl`'s `BarefootJS.pm`; Twig and Blade share `@barefootjs/php`'s `BarefootJS.php`):
- Go (`bf.go`): `Slice`'s return type widens from `[]any` to `any`; string branch measures/indexes by rune.
- Perl (`adapter-perl/lib/BarefootJS.pm`, shared by Mojo + Xslate): `ref($recv)` dispatch, `substr`/`length` under `use utf8`.
- Python (`adapter-jinja`): `str`/`list` share native slicing (`recv[s:e]`) and `len()`, so one clamp computation serves both types directly.
- Ruby (`adapter-erb`): same unification — `String#[]`/`Array#[]` share range-indexing syntax.
- PHP (`adapter-php`, shared by Twig + Blade): `mb_strlen`/`mb_substr` under explicit UTF-8, matching this runtime's other string helpers.
- Rust (`adapter-rust`): new `char_slice_range`/`clamp_slice_range` helpers shared with the array branch.

## Golden vectors

Added 5 new `slice` cases to the shared corpus (`packages/adapter-tests/vectors/cases.ts` → `vectors.json`, regenerated) covering the string receiver: start+end, negative start, absent end, start-past-end, and multi-byte input. These run against Go, Perl, Python, Ruby, and PHP via the existing cross-language harness, plus a matching Rust vector test — so every runtime that touches this method is pinned against the same JS-computed expectations, not just the one template-adapter fixture.

## Graduations

- `string-slice` removed from all eight template adapters' `renderDivergences` declarations.
- `ui/compat.lock.json`: 8 entries removed (all under the `string-slice` fixture key).

## Verified

Full sequential verification on real backends, all green (0 fail): jinja 508, mojolicious 680, xslate 509, twig 508, blade 508, rust 508, erb 482, go-template 719, hono 579, adapter-tests 1,190, compat 558/558 cells ok. Golden-vector suites re-run directly on each runtime: Go `go test` (including the widened `TestSlice`/new `TestSlice_String`), Perl `helper_vectors.t` (263 assertions), Python `pytest` (262 subtests), Ruby `helper_vectors_test.rb` (263 runs), PHP `test_helper_vectors.php` (263 cases), Rust `cargo test --test helper_vectors`.

## Scope note

This is the smallest unit of the string-method divergence class (task 2 of 3). `string-trim-sided` (`trimStart`/`trimEnd`) and `string-replaceall` have no array-method ambiguity to resolve but DO need new `ArrayMethod` IR union members, parser arms, and per-adapter emitter cases (unlike `.slice()`, which needed none of that) — they'll land as separate stacked PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZXzQWvSKLUUrTAZ3vph1j)_