### PR TITLE
Support String.prototype.replaceAll with a string pattern (divergence stack 8/N)

### DIFF
--- a/.changeset/scaffold-workers-types-v4-rollback.md
+++ b/.changeset/scaffold-workers-types-v4-rollback.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/cli": patch
+---
+
+Fix fresh Hono/Cloudflare scaffolds failing `npm install` with ERESOLVE again: wrangler 4.108.0 (which had moved its `peerOptional @cloudflare/workers-types` to `^5.20260706.1`) was deprecated by its publisher the same day it shipped ("causing deployment failures in CI ... downgrade to 4.107.1"). npm's resolver skips a deprecated version when satisfying a semver range, so `wrangler: '^4.0.0'` now resolves back to `4.107.1`, which peers on `^4.20260702.1` — conflicting with the `^5.20260706.1` pin from the previous fix (bun tolerates the mismatch; npm does not — caught by the smoke-publish CI gate). The `bf init` / create-barefootjs Hono template now pins `@cloudflare/workers-types@^4.20260702.1` again, matching whichever wrangler version npm actually resolves rather than whichever version last shipped upstream. Verified end-to-end with `bun run scripts/smoke-publish.mjs` (full pack + scaffold + `npm install` + `npm run build`/`test`).

--- a/.changeset/string-replaceall.md
+++ b/.changeset/string-replaceall.md
@@ -1,0 +1,17 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/jinja": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+"@barefootjs/twig": patch
+"@barefootjs/blade": patch
+"@barefootjs/rust": patch
+"@barefootjs/erb": patch
+"@barefootjs/go-template": patch
+"@barefootjs/perl": patch
+"@barefootjs/php": patch
+---
+
+Support `String.prototype.replaceAll(pattern, replacement)` with a string pattern. Previously refused at compile time with BF101 (no lowering existed); the string-pattern form now lowers through a new `replaceAll` `ArrayMethod` IR member — parsed with the same arity/regex/object-literal gates as `.replace` (a regex-literal pattern stays refused, matching `.replace`'s deferred-form treatment) — to a dedicated all-occurrences helper on every backend: Go `bf_replace_all` (`strings.ReplaceAll`), the shared Perl runtime's `replace_all` (Mojolicious + Text::Xslate, index/substr loop keeping the replacement literal), Python's `bf.replace_all` (native `str.replace`, already global by default), Ruby's `bf.replace_all` (an index/splice loop — deliberately not `String#gsub`, which interprets `\1`/`\&` backreferences in the replacement even for a literal pattern), the shared PHP runtime's `replace_all` (`str_replace`, with the empty-pattern case hand-rolled since PHP's `str_replace("")` is a no-op unlike JS), and Rust's `bf.replace_all` (native `str::replace`, already global by default).
+
+A dedicated helper, not the existing `.replace` lowering with a flag — reusing the first-occurrence helper would have silently truncated the replacement to one match. New golden-vector cases (`packages/adapter-tests/vectors/cases.ts` → `vectors.json`) mirror `.replace`'s cases with a multi-occurrence receiver as the flagship, catching that exact swapped-lowering bug on every runtime that consumes the shared corpus (Go, Perl, Python, Ruby, PHP) plus a matching Rust vector. The `string-replaceall` fixture graduates from a BF101 refusal to a passing render on all eight template adapters.

--- a/packages/adapter-blade/src/adapter/expr/array-method.ts
+++ b/packages/adapter-blade/src/adapter/expr/array-method.ts
@@ -125,6 +125,16 @@ export function renderArrayMethod(
       const newS = emit(args[1])
       return `$bf->replace(${recv}, ${oldS}, ${newS})`
     }
+    case 'replaceAll': {
+      // `.replaceAll(old, new)` — string-pattern form, EVERY occurrence,
+      // via the dedicated `$bf->replace_all` helper (not `$bf->replace`
+      // with a flag) — the regex-pattern form is refused upstream at
+      // the parser, same as `.replace`. See #2182.
+      const recv = emit(object)
+      const oldS = emit(args[0])
+      const newS = emit(args[1])
+      return `$bf->replace_all(${recv}, ${oldS}, ${newS})`
+    }
     case 'repeat': {
       const recv = emit(object)
       const count = args.length === 0 ? '0' : emit(args[0])

--- a/packages/adapter-blade/src/conformance-pins.ts
+++ b/packages/adapter-blade/src/conformance-pins.ts
@@ -89,9 +89,4 @@ export const conformancePins: ConformancePins = {
   // the shape loudly instead of emitting entity-escaped markup that
   // silently renders tags as text.
   'dangerous-inner-html': [{ code: 'BF101', severity: 'error' }],
-  // Edge-case sweep (Priority 12): `.replaceAll` has no lowering yet —
-  // only first-occurrence `.replace` is wired to the runtime helpers.
-  // Refused with BF101 rather than reusing the first-only lowering,
-  // which would silently change semantics.
-  'string-replaceall': [{ code: 'BF101', severity: 'error' }],
 }

--- a/packages/adapter-erb/lib/barefoot_js.rb
+++ b/packages/adapter-erb/lib/barefoot_js.rb
@@ -750,6 +750,35 @@ module BarefootJS
       s[0...idx] + n + s[(idx + o.length)..]
     end
 
+    # `String.prototype.replaceAll(pattern, replacement)` -- string-pattern
+    # form only (#2182), replacing EVERY occurrence (the all-occurrences
+    # sibling of `replace` above). Deliberately NOT `String#gsub`: Ruby's
+    # `gsub` interprets `\1` / `\&` backreference syntax in the replacement
+    # even for a literal string pattern (`"abc".gsub("b", "\\1")` -> "ac",
+    # not the literal "\1"), which would diverge from `.replace`'s literal
+    # splice above and from the other backends' literal treatment. The
+    # index/splice loop keeps the replacement literal, matching `replace`.
+    # An empty pattern inserts at every boundary, including before the
+    # first and after the last character (`"abc".replaceAll("", "X")` ->
+    # "XaXbXcX"), matching JS.
+    def replace_all(recv, pattern, replacement)
+      s = recv.nil? ? '' : string(recv)
+      o = pattern.nil? ? '' : string(pattern)
+      n = replacement.nil? ? '' : string(replacement)
+      return ([''] + s.chars + ['']).join(n) if o.empty?
+
+      out = ''
+      pos = 0
+      loop do
+        idx = s.index(o, pos)
+        break if idx.nil?
+
+        out += s[pos...idx] + n
+        pos = idx + o.length
+      end
+      out + s[pos..]
+    end
+
     # `queryHref(base, { ... })` (#2042) -- build "base?k=v&..." from a flat
     # list of (guard, key, value) triples. A pair is included iff its guard
     # is truthy AND its value is a non-empty string. A value may instead be

--- a/packages/adapter-erb/lib/barefoot_js.rb
+++ b/packages/adapter-erb/lib/barefoot_js.rb
@@ -767,16 +767,19 @@ module BarefootJS
       n = replacement.nil? ? '' : string(replacement)
       return ([''] + s.chars + ['']).join(n) if o.empty?
 
-      out = ''
+      # `+''` (not the frozen `''` literal under frozen_string_literal)
+      # so `<<` can append in place instead of `+=` reallocating a new
+      # string each iteration (quadratic for long inputs / many matches).
+      out = +''
       pos = 0
       loop do
         idx = s.index(o, pos)
         break if idx.nil?
 
-        out += s[pos...idx] + n
+        out << s[pos...idx] << n
         pos = idx + o.length
       end
-      out + s[pos..]
+      out << s[pos..]
     end
 
     # `queryHref(base, { ... })` (#2042) -- build "base?k=v&..." from a flat

--- a/packages/adapter-erb/src/adapter/expr/array-method.ts
+++ b/packages/adapter-erb/src/adapter/expr/array-method.ts
@@ -178,6 +178,19 @@ export function renderArrayMethod(
       const newS = emit(args[1])
       return `bf.replace(${recv}, ${oldS}, ${newS})`
     }
+    case 'replaceAll': {
+      // `.replaceAll(old, new)` — string-pattern form, EVERY occurrence,
+      // via the dedicated `bf.replace_all` helper (NOT Ruby's `gsub`,
+      // which interprets `\1` / `\&` backreference syntax in the
+      // replacement even for a literal string pattern — that would
+      // diverge from `.replace`'s literal splice above). The
+      // regex-pattern form is refused upstream at the parser, same as
+      // `.replace`. See #2182.
+      const recv = emit(object)
+      const oldS = emit(args[0])
+      const newS = emit(args[1])
+      return `bf.replace_all(${recv}, ${oldS}, ${newS})`
+    }
     case 'repeat': {
       // `.repeat(n)` — string repeated `n` times. The `bf.repeat` helper
       // wraps Ruby's `*` string-repeat operator with the same

--- a/packages/adapter-erb/src/conformance-pins.ts
+++ b/packages/adapter-erb/src/conformance-pins.ts
@@ -103,9 +103,4 @@ export const conformancePins: ConformancePins = {
   // the shape loudly instead of emitting entity-escaped markup that
   // silently renders tags as text.
   'dangerous-inner-html': [{ code: 'BF101', severity: 'error' }],
-  // Edge-case sweep (Priority 12): `.replaceAll` has no lowering yet —
-  // only first-occurrence `.replace` is wired to the runtime helpers.
-  // Refused with BF101 rather than reusing the first-only lowering,
-  // which would silently change semantics.
-  'string-replaceall': [{ code: 'BF101', severity: 'error' }],
 }

--- a/packages/adapter-erb/test/helper_vectors_test.rb
+++ b/packages/adapter-erb/test/helper_vectors_test.rb
@@ -85,6 +85,7 @@ class HelperVectorsTest < Minitest::Test
     'starts_with' => ->(*a) { BF.starts_with(*a) },
     'ends_with' => ->(*a) { BF.ends_with(*a) },
     'replace' => ->(*a) { BF.replace(*a) },
+    'replace_all' => ->(*a) { BF.replace_all(*a) },
     'repeat' => ->(*a) { BF.repeat(*a) },
     'pad_start' => ->(*a) { BF.pad_start(*a) },
     'pad_end' => ->(*a) { BF.pad_end(*a) },

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -44,6 +44,7 @@ func FuncMap() template.FuncMap {
 		"bf_starts_with": StartsWith,
 		"bf_ends_with":   EndsWith,
 		"bf_replace":     Replace,
+		"bf_replace_all": ReplaceAll,
 		"bf_repeat":      Repeat,
 		"bf_pad_start":   PadStart,
 		"bf_pad_end":     PadEnd,
@@ -838,15 +839,23 @@ func EndsWith(s, suffix string, endPosition ...int) bool {
 
 // Replace lowers the string-pattern form of `String.prototype.replace`
 // (#1448 Tier B). JS replaces only the FIRST occurrence for a string
-// pattern, so the count is 1 (`strings.Replace` with n=1; n<0 would
-// replace all — that's `.replaceAll`, still refused). The replacement
-// is treated literally: unlike JS, special replacement patterns like
-// `$&` / `$1` are NOT interpreted (Go and Perl agree on literal
-// replacement, keeping the two template adapters byte-equal; this
-// diverges from the Hono/CSR JS path only for replacement strings that
-// contain `$`-patterns, which are rare in template position).
+// pattern, so the count is 1 (`strings.Replace` with n=1; `ReplaceAll`
+// below is the every-occurrence sibling, `.replaceAll`, #2182). The
+// replacement is treated literally: unlike JS, special replacement
+// patterns like `$&` / `$1` are NOT interpreted (Go and Perl agree on
+// literal replacement, keeping the two template adapters byte-equal;
+// this diverges from the Hono/CSR JS path only for replacement strings
+// that contain `$`-patterns, which are rare in template position).
 func Replace(s, old, new string) string {
 	return strings.Replace(s, old, new, 1)
+}
+
+// ReplaceAll lowers the string-pattern form of
+// `String.prototype.replaceAll` (#2182): every occurrence, via
+// `strings.ReplaceAll` (equivalent to `strings.Replace` with n=-1).
+// Same literal-replacement caveat as `Replace` above.
+func ReplaceAll(s, old, new string) string {
+	return strings.ReplaceAll(s, old, new)
 }
 
 // Repeat lowers `String.prototype.repeat(n)` (#1448 Tier B): the

--- a/packages/adapter-go-template/runtime/vectors_test.go
+++ b/packages/adapter-go-template/runtime/vectors_test.go
@@ -84,8 +84,9 @@ var vectorBindings = map[string]func(args []any) any{
 		}
 		return EndsWith(args[0].(string), args[1].(string))
 	},
-	"replace": func(args []any) any { return Replace(args[0].(string), args[1].(string), args[2].(string)) },
-	"repeat":  func(args []any) any { return Repeat(args[0].(string), args[1].(int)) },
+	"replace":     func(args []any) any { return Replace(args[0].(string), args[1].(string), args[2].(string)) },
+	"replace_all": func(args []any) any { return ReplaceAll(args[0].(string), args[1].(string), args[2].(string)) },
+	"repeat":      func(args []any) any { return Repeat(args[0].(string), args[1].(int)) },
 	"pad_start": func(args []any) any {
 		if len(args) > 2 {
 			return PadStart(args[0].(string), args[1].(int), args[2].(string))

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -3557,6 +3557,16 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         const newS = emit(args[1])
         return `bf_replace ${wrapIfMultiToken(recv)} ${wrapIfMultiToken(oldS)} ${wrapIfMultiToken(newS)}`
       }
+      case 'replaceAll': {
+        // `.replaceAll(old, new)` — string-pattern form, EVERY occurrence, via
+        // `bf_replace_all` (`strings.ReplaceAll`). A dedicated helper, not
+        // `bf_replace` with a different n — the regex-pattern form is refused
+        // upstream at the parser, same as `.replace`.
+        const recv = emit(object)
+        const oldS = emit(args[0])
+        const newS = emit(args[1])
+        return `bf_replace_all ${wrapIfMultiToken(recv)} ${wrapIfMultiToken(oldS)} ${wrapIfMultiToken(newS)}`
+      }
       case 'repeat': {
         // `.repeat(n)` — string repeated `n` times. `bf_repeat` clamps a negative
         // count to "" instead of letting `strings.Repeat` panic. No argument is

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -138,9 +138,4 @@ export const conformancePins: ConformancePins = {
   // the shape loudly instead of emitting entity-escaped markup that
   // silently renders tags as text.
   'dangerous-inner-html': [{ code: 'BF101', severity: 'error' }],
-  // Edge-case sweep (Priority 12): `.replaceAll` has no lowering yet —
-  // only first-occurrence `.replace` is wired to the runtime helpers.
-  // Refused with BF101 rather than reusing the first-only lowering,
-  // which would silently change semantics.
-  'string-replaceall': [{ code: 'BF101', severity: 'error' }],
 }

--- a/packages/adapter-jinja/python/barefootjs/runtime.py
+++ b/packages/adapter-jinja/python/barefootjs/runtime.py
@@ -1084,6 +1084,19 @@ class BarefootJS:
             return s
         return s[:i] + n + s[i + len(o) :]
 
+    def replace_all(self, recv: Any, pattern: Any, replacement: Any) -> str:
+        """`String.prototype.replaceAll(pattern, replacement)`, string-pattern
+        form only (#2182) -- every occurrence, the all-occurrences sibling of
+        `replace` above. Python's own `str.replace(old, new)` (no count arg)
+        is already global by default, including the empty-pattern-inserts-
+        at-every-boundary edge case (`"abc".replace("", "X")` -> "XaXbXcX"),
+        so it needs no hand-rolled loop the way the other runtimes' first-
+        occurrence-only native replace does."""
+        s = _scalar_or_empty(recv)
+        o = js_string(pattern)
+        n = js_string(replacement)
+        return s.replace(o, n)
+
     def query(self, base: Any, *triples: Any) -> str:
         """`queryHref(base, {...})` (#2042) -- build `"$base?k=v&..."` from a
         flat list of (guard, key, value) triples. A pair is included iff its

--- a/packages/adapter-jinja/python/tests/test_helper_vectors.py
+++ b/packages/adapter-jinja/python/tests/test_helper_vectors.py
@@ -124,6 +124,7 @@ BINDINGS = {
     "starts_with": lambda *a: bf.starts_with(*a),
     "ends_with": lambda *a: bf.ends_with(*a),
     "replace": lambda *a: bf.replace(*a),
+    "replace_all": lambda *a: bf.replace_all(*a),
     "repeat": lambda *a: bf.repeat(*a),
     "pad_start": lambda *a: bf.pad_start(*a),
     "pad_end": lambda *a: bf.pad_end(*a),

--- a/packages/adapter-jinja/src/adapter/expr/array-method.ts
+++ b/packages/adapter-jinja/src/adapter/expr/array-method.ts
@@ -126,6 +126,16 @@ export function renderArrayMethod(
       const newS = emit(args[1])
       return `bf.replace(${recv}, ${oldS}, ${newS})`
     }
+    case 'replaceAll': {
+      // `.replaceAll(old, new)` — string-pattern form, EVERY occurrence,
+      // via the dedicated `bf.replace_all` helper (not `bf.replace` with
+      // a flag) — the regex-pattern form is refused upstream at the
+      // parser, same as `.replace`. See #2182.
+      const recv = emit(object)
+      const oldS = emit(args[0])
+      const newS = emit(args[1])
+      return `bf.replace_all(${recv}, ${oldS}, ${newS})`
+    }
     case 'repeat': {
       const recv = emit(object)
       const count = args.length === 0 ? '0' : emit(args[0])

--- a/packages/adapter-jinja/src/conformance-pins.ts
+++ b/packages/adapter-jinja/src/conformance-pins.ts
@@ -104,9 +104,4 @@ export const conformancePins: ConformancePins = {
   // the shape loudly instead of emitting entity-escaped markup that
   // silently renders tags as text.
   'dangerous-inner-html': [{ code: 'BF101', severity: 'error' }],
-  // Edge-case sweep (Priority 12): `.replaceAll` has no lowering yet —
-  // only first-occurrence `.replace` is wired to the runtime helpers.
-  // Refused with BF101 rather than reusing the first-only lowering,
-  // which would silently change semantics.
-  'string-replaceall': [{ code: 'BF101', severity: 'error' }],
 }

--- a/packages/adapter-mojolicious/src/adapter/expr/array-method.ts
+++ b/packages/adapter-mojolicious/src/adapter/expr/array-method.ts
@@ -195,6 +195,16 @@ export function renderArrayMethod(
       const newS = emit(args[1])
       return `bf->replace(${recv}, ${oldS}, ${newS})`
     }
+    case 'replaceAll': {
+      // `.replaceAll(old, new)` — string-pattern form, EVERY occurrence,
+      // via the dedicated `bf->replace_all` helper (not `bf->replace`
+      // with a flag) — the regex-pattern form is refused upstream at
+      // the parser, same as `.replace`. See #2182.
+      const recv = emit(object)
+      const oldS = emit(args[0])
+      const newS = emit(args[1])
+      return `bf->replace_all(${recv}, ${oldS}, ${newS})`
+    }
     case 'repeat': {
       // `.repeat(n)` — string repeated `n` times. The `bf->repeat`
       // helper wraps Perl's `x` operator with the same negative-count

--- a/packages/adapter-mojolicious/src/conformance-pins.ts
+++ b/packages/adapter-mojolicious/src/conformance-pins.ts
@@ -141,9 +141,4 @@ export const conformancePins: ConformancePins = {
   // the shape loudly instead of emitting entity-escaped markup that
   // silently renders tags as text.
   'dangerous-inner-html': [{ code: 'BF101', severity: 'error' }],
-  // Edge-case sweep (Priority 12): `.replaceAll` has no lowering yet —
-  // only first-occurrence `.replace` is wired to the runtime helpers.
-  // Refused with BF101 rather than reusing the first-only lowering,
-  // which would silently change semantics.
-  'string-replaceall': [{ code: 'BF101', severity: 'error' }],
 }

--- a/packages/adapter-perl/lib/BarefootJS.pm
+++ b/packages/adapter-perl/lib/BarefootJS.pm
@@ -1137,6 +1137,33 @@ sub replace ($self, $recv, $pattern, $replacement) {
     return substr($s, 0, $i) . $n . substr($s, $i + CORE::length($o));
 }
 
+# `String.prototype.replaceAll(pattern, replacement)` — string-pattern
+# form only (#2182), replacing EVERY occurrence (the all-occurrences
+# sibling of `replace` above). Same literal-splice approach (no regex
+# metacharacters, no `$1`/`$&` interpolation) as `replace`, looped
+# forward from each match's end. An empty pattern inserts the
+# replacement at every boundary, including before the first and after
+# the last character (`"abc".replaceAll("", "X")` -> "XaXbXcX"),
+# matching JS.
+
+sub replace_all ($self, $recv, $pattern, $replacement) {
+    my $s = defined $recv && !ref($recv) ? "$recv" : '';
+    my $o = defined $pattern ? "$pattern" : '';
+    my $n = defined $replacement ? "$replacement" : '';
+    return CORE::join($n, '', split(//, $s), '') if $o eq '';
+    my $out = '';
+    my $pos = 0;
+    my $olen = CORE::length($o);
+    while (1) {
+        my $i = index($s, $o, $pos);
+        last if $i < 0;
+        $out .= substr($s, $pos, $i - $pos) . $n;
+        $pos = $i + $olen;
+    }
+    $out .= substr($s, $pos);
+    return $out;
+}
+
 # `queryHref(base, { … })` (#2042) — build `"$base?k=v&…"` from a flat list of
 # (guard, key, value) triples. A pair is included iff its guard is truthy AND
 # its value is a non-empty string, mirroring the client `queryHref`'s `if

--- a/packages/adapter-perl/t/helper_vectors.t
+++ b/packages/adapter-perl/t/helper_vectors.t
@@ -98,6 +98,7 @@ my %bindings = (
     starts_with => sub { $bf->starts_with(@_) },
     ends_with   => sub { $bf->ends_with(@_) },
     replace     => sub { $bf->replace(@_) },
+    replace_all => sub { $bf->replace_all(@_) },
     repeat      => sub { $bf->repeat(@_) },
     pad_start   => sub { $bf->pad_start(@_) },
     pad_end     => sub { $bf->pad_end(@_) },

--- a/packages/adapter-php/src/BarefootJS.php
+++ b/packages/adapter-php/src/BarefootJS.php
@@ -1229,6 +1229,29 @@ final class BarefootJS
         return substr($s, 0, $i) . $n . substr($s, $i + strlen($o));
     }
 
+    /** `String.prototype.replaceAll(pattern, replacement)` -- string-pattern
+     * form only (#2182), replacing EVERY occurrence (the all-occurrences
+     * sibling of `replace` above). A non-empty pattern uses PHP's own
+     * `str_replace`, which is global-by-default and treats both the pattern
+     * and the replacement literally (no backreference interpolation) --
+     * matching JS. PHP's `str_replace("", ...)` is a no-op, unlike JS,
+     * which inserts the replacement at every boundary (including before
+     * the first and after the last character,
+     * `"abc".replaceAll("", "X")` -> "XaXbXcX") -- so the empty pattern is
+     * special-cased with `mb_str_split` (UTF-8 code points, matching this
+     * runtime's other string helpers). */
+    public function replace_all($recv, $pattern, $replacement): string
+    {
+        $s = $this->scalarOrEmpty($recv);
+        $o = $this->string($pattern);
+        $n = $this->string($replacement);
+        if ($o === '') {
+            $chars = $s === '' ? [] : mb_str_split($s, 1, 'UTF-8');
+            return implode($n, array_merge([''], $chars, ['']));
+        }
+        return str_replace($o, $n, $s);
+    }
+
     /** `queryHref(base, {...})` (#2042) -- build `"$base?k=v&..."` from a
      * flat (guard, key, value) triple sequence. A pair is included iff its
      * guard is JS-truthy AND its value is a non-empty string; an array value

--- a/packages/adapter-php/tests/test_helper_vectors.php
+++ b/packages/adapter-php/tests/test_helper_vectors.php
@@ -153,6 +153,7 @@ function bfv_call(BarefootJS $bf, string $fn, array $args)
         case 'starts_with': return $bf->starts_with(...$args);
         case 'ends_with': return $bf->ends_with(...$args);
         case 'replace': return $bf->replace(...$args);
+        case 'replace_all': return $bf->replace_all(...$args);
         case 'repeat': return $bf->repeat(...$args);
         case 'pad_start': return $bf->pad_start(...$args);
         case 'pad_end': return $bf->pad_end(...$args);

--- a/packages/adapter-rust/runtime/src/runtime.rs
+++ b/packages/adapter-rust/runtime/src/runtime.rs
@@ -1227,6 +1227,7 @@ impl Object for BfInstance {
             "starts_with" => Ok(MjValue::from(starts_with(a(0), a(1), a(2)))),
             "ends_with" => Ok(MjValue::from(ends_with(a(0), a(1), a(2)))),
             "replace" => Ok(MjValue::from(replace(a(0), a(1), a(2)))),
+            "replace_all" => Ok(MjValue::from(replace_all(a(0), a(1), a(2)))),
             "query" => Ok(MjValue::from(query(a(0), &js_args[1..]))),
             "repeat" => Ok(MjValue::from(repeat(a(0), a(1)))),
             "pad_start" => Ok(MjValue::from(pad(&scalar_or_empty(a(0)), a(1), a(2), true))),
@@ -1516,6 +1517,20 @@ pub fn replace(recv: &JsValue, pattern: &JsValue, replacement: &JsValue) -> Stri
         None => s,
         Some(byte_idx) => format!("{}{}{}", &s[..byte_idx], n, &s[byte_idx + o.len()..]),
     }
+}
+
+/// `String.prototype.replaceAll(pattern, replacement)`, string-pattern
+/// form only (#2182) -- every occurrence, the all-occurrences sibling
+/// of `replace` above. Rust's own `str::replace` (no count arg) is
+/// already global by default, including the empty-pattern-inserts-at-
+/// every-boundary edge case (`"abc".replace("", "X")` -> "XaXbXcX"),
+/// so it needs no hand-rolled loop the way `replace_all` on the
+/// backends whose native replace is first-occurrence-only does.
+pub fn replace_all(recv: &JsValue, pattern: &JsValue, replacement: &JsValue) -> String {
+    let s = scalar_or_empty(recv);
+    let o = js_string(pattern);
+    let n = js_string(replacement);
+    s.replace(&o, &n)
 }
 
 /// `queryHref(base, {...})` (#2042) -- build `"$base?k=v&..."` from a flat

--- a/packages/adapter-rust/runtime/tests/helper_vectors.rs
+++ b/packages/adapter-rust/runtime/tests/helper_vectors.rs
@@ -126,6 +126,7 @@ fn call_binding(fn_name: &str, args: &[JsValue]) -> Option<JsValue> {
         "starts_with" => JsValue::Bool(runtime::starts_with(&a(0), &a(1), &a(2))),
         "ends_with" => JsValue::Bool(runtime::ends_with(&a(0), &a(1), &a(2))),
         "replace" => JsValue::String(runtime::replace(&a(0), &a(1), &a(2))),
+        "replace_all" => JsValue::String(runtime::replace_all(&a(0), &a(1), &a(2))),
         "repeat" => JsValue::String(runtime::repeat(&a(0), &a(1))),
         "pad_start" => JsValue::String(runtime::pad(&runtime::js_string(&a(0)), &a(1), &a(2), true)),
         "pad_end" => JsValue::String(runtime::pad(&runtime::js_string(&a(0)), &a(1), &a(2), false)),

--- a/packages/adapter-rust/src/adapter/expr/array-method.ts
+++ b/packages/adapter-rust/src/adapter/expr/array-method.ts
@@ -126,6 +126,16 @@ export function renderArrayMethod(
       const newS = emit(args[1])
       return `bf.replace(${recv}, ${oldS}, ${newS})`
     }
+    case 'replaceAll': {
+      // `.replaceAll(old, new)` — string-pattern form, EVERY occurrence,
+      // via the dedicated `bf.replace_all` helper (not `bf.replace`
+      // with a flag) — the regex-pattern form is refused upstream at
+      // the parser, same as `.replace`. See #2182.
+      const recv = emit(object)
+      const oldS = emit(args[0])
+      const newS = emit(args[1])
+      return `bf.replace_all(${recv}, ${oldS}, ${newS})`
+    }
     case 'repeat': {
       const recv = emit(object)
       const count = args.length === 0 ? '0' : emit(args[0])

--- a/packages/adapter-rust/src/conformance-pins.ts
+++ b/packages/adapter-rust/src/conformance-pins.ts
@@ -104,9 +104,4 @@ export const conformancePins: ConformancePins = {
   // the shape loudly instead of emitting entity-escaped markup that
   // silently renders tags as text.
   'dangerous-inner-html': [{ code: 'BF101', severity: 'error' }],
-  // Edge-case sweep (Priority 12): `.replaceAll` has no lowering yet —
-  // only first-occurrence `.replace` is wired to the runtime helpers.
-  // Refused with BF101 rather than reusing the first-only lowering,
-  // which would silently change semantics.
-  'string-replaceall': [{ code: 'BF101', severity: 'error' }],
 }

--- a/packages/adapter-tests/vectors/cases.ts
+++ b/packages/adapter-tests/vectors/cases.ts
@@ -43,6 +43,7 @@ export const reference: Record<string, (...args: never[]) => unknown> = {
   starts_with: (s: string, prefix: string, position?: number) => s.startsWith(prefix, position),
   ends_with: (s: string, suffix: string, endPosition?: number) => s.endsWith(suffix, endPosition),
   replace: (s: string, pattern: string, replacement: string) => s.replace(pattern, replacement),
+  replace_all: (s: string, pattern: string, replacement: string) => s.replaceAll(pattern, replacement),
   repeat: (s: string, n: number) => s.repeat(n),
   pad_start: (s: string, target: number, pad?: string) => s.padStart(target, pad),
   pad_end: (s: string, target: number, pad?: string) => s.padEnd(target, pad),
@@ -296,6 +297,17 @@ export const cases: HelperCase[] = [
   { fn: 'replace', args: ['abc', '', 'X'], note: 'empty pattern inserts at the front' },
   { fn: 'replace', args: ['a.b.c', '.', '-'], note: 'pattern is literal, not regex' },
   { fn: 'replace', args: ['abc', 'b', ''], note: 'empty replacement deletes' },
+
+  // `replace_all` mirrors `replace`'s cases with a MULTI-OCCURRENCE
+  // receiver as the flagship: a backend that reuses its first-only
+  // `replace` helper here would produce 'X-b-a' instead of 'X-b-X',
+  // so the case catches a swapped lowering the single-occurrence
+  // `string-replaceall` fixture alone could not.
+  { fn: 'replace_all', args: ['a-b-a', 'a', 'X'], note: 'every occurrence, not just the first' },
+  { fn: 'replace_all', args: ['abc', 'z', 'X'], note: 'pattern not found leaves receiver unchanged' },
+  { fn: 'replace_all', args: ['abc', '', 'X'], note: 'empty pattern inserts at every boundary' },
+  { fn: 'replace_all', args: ['a.b.c', '.', '-'], note: 'pattern is literal, not regex' },
+  { fn: 'replace_all', args: ['abc', 'b', ''], note: 'empty replacement deletes' },
 
   { fn: 'repeat', args: ['ab', 3], note: 'basic repetition' },
   { fn: 'repeat', args: ['x', 0], note: 'zero count is empty' },

--- a/packages/adapter-tests/vectors/vectors.json
+++ b/packages/adapter-tests/vectors/vectors.json
@@ -887,6 +887,56 @@
       "note": "empty replacement deletes"
     },
     {
+      "fn": "replace_all",
+      "args": [
+        "a-b-a",
+        "a",
+        "X"
+      ],
+      "expect": "X-b-X",
+      "note": "every occurrence, not just the first"
+    },
+    {
+      "fn": "replace_all",
+      "args": [
+        "abc",
+        "z",
+        "X"
+      ],
+      "expect": "abc",
+      "note": "pattern not found leaves receiver unchanged"
+    },
+    {
+      "fn": "replace_all",
+      "args": [
+        "abc",
+        "",
+        "X"
+      ],
+      "expect": "XaXbXcX",
+      "note": "empty pattern inserts at every boundary"
+    },
+    {
+      "fn": "replace_all",
+      "args": [
+        "a.b.c",
+        ".",
+        "-"
+      ],
+      "expect": "a-b-c",
+      "note": "pattern is literal, not regex"
+    },
+    {
+      "fn": "replace_all",
+      "args": [
+        "abc",
+        "b",
+        ""
+      ],
+      "expect": "ac",
+      "note": "empty replacement deletes"
+    },
+    {
       "fn": "repeat",
       "args": [
         "ab",

--- a/packages/adapter-twig/src/adapter/expr/array-method.ts
+++ b/packages/adapter-twig/src/adapter/expr/array-method.ts
@@ -125,6 +125,16 @@ export function renderArrayMethod(
       const newS = emit(args[1])
       return `bf.replace(${recv}, ${oldS}, ${newS})`
     }
+    case 'replaceAll': {
+      // `.replaceAll(old, new)` — string-pattern form, EVERY occurrence,
+      // via the dedicated `bf.replace_all` helper (not `bf.replace` with
+      // a flag) — the regex-pattern form is refused upstream at the
+      // parser, same as `.replace`. See #2182.
+      const recv = emit(object)
+      const oldS = emit(args[0])
+      const newS = emit(args[1])
+      return `bf.replace_all(${recv}, ${oldS}, ${newS})`
+    }
     case 'repeat': {
       const recv = emit(object)
       const count = args.length === 0 ? '0' : emit(args[0])

--- a/packages/adapter-twig/src/conformance-pins.ts
+++ b/packages/adapter-twig/src/conformance-pins.ts
@@ -89,9 +89,4 @@ export const conformancePins: ConformancePins = {
   // the shape loudly instead of emitting entity-escaped markup that
   // silently renders tags as text.
   'dangerous-inner-html': [{ code: 'BF101', severity: 'error' }],
-  // Edge-case sweep (Priority 12): `.replaceAll` has no lowering yet —
-  // only first-occurrence `.replace` is wired to the runtime helpers.
-  // Refused with BF101 rather than reusing the first-only lowering,
-  // which would silently change semantics.
-  'string-replaceall': [{ code: 'BF101', severity: 'error' }],
 }

--- a/packages/adapter-xslate/src/adapter/expr/array-method.ts
+++ b/packages/adapter-xslate/src/adapter/expr/array-method.ts
@@ -124,6 +124,16 @@ export function renderArrayMethod(
       const newS = emit(args[1])
       return `$bf.replace(${recv}, ${oldS}, ${newS})`
     }
+    case 'replaceAll': {
+      // `.replaceAll(old, new)` — string-pattern form, EVERY occurrence,
+      // via the dedicated `$bf.replace_all` helper (not `$bf.replace`
+      // with a flag) — the regex-pattern form is refused upstream at
+      // the parser, same as `.replace`. See #2182.
+      const recv = emit(object)
+      const oldS = emit(args[0])
+      const newS = emit(args[1])
+      return `$bf.replace_all(${recv}, ${oldS}, ${newS})`
+    }
     case 'repeat': {
       const recv = emit(object)
       const count = args.length === 0 ? '0' : emit(args[0])

--- a/packages/adapter-xslate/src/conformance-pins.ts
+++ b/packages/adapter-xslate/src/conformance-pins.ts
@@ -115,9 +115,4 @@ export const conformancePins: ConformancePins = {
   // the shape loudly instead of emitting entity-escaped markup that
   // silently renders tags as text.
   'dangerous-inner-html': [{ code: 'BF101', severity: 'error' }],
-  // Edge-case sweep (Priority 12): `.replaceAll` has no lowering yet —
-  // only first-occurrence `.replace` is wired to the runtime helpers.
-  // Refused with BF101 rather than reusing the first-only lowering,
-  // which would silently change semantics.
-  'string-replaceall': [{ code: 'BF101', severity: 'error' }],
 }

--- a/packages/cli/src/lib/adapters/hono.ts
+++ b/packages/cli/src/lib/adapters/hono.ts
@@ -232,13 +232,16 @@ export const HONO_ADAPTER: AdapterTemplate = {
     ...UNOCSS_DEV_DEPENDENCIES,
     '@barefootjs/cli': 'latest',
     // Must track wrangler's `peerOptional @cloudflare/workers-types`
-    // MAJOR: wrangler 4.108.0 moved it to `^5.20260706.1`, and with the
-    // v4 pin every fresh scaffold's `npm install` fails with ERESOLVE
-    // (bun tolerates the mismatch; npm does not — CI's smoke-publish
-    // caught it). v5 still ships a root `index.d.ts`, so the generated
-    // tsconfig's `"types": ["@cloudflare/workers-types", ...]` entry
-    // resolves unchanged.
-    '@cloudflare/workers-types': '^5.20260706.1',
+    // (bun tolerates a mismatch; npm does not — CI's smoke-publish
+    // gate catches it). wrangler 4.108.0 briefly moved this to
+    // `^5.20260706.1`, but upstream deprecated that release the same
+    // day ("causing deployment failures in CI ... downgrade to
+    // 4.107.1") — npm's resolver skips a deprecated version when
+    // satisfying a range, so `wrangler: '^4.0.0'` (below) resolves
+    // back to 4.107.1, which still peers on
+    // `^4.20260702.1`. Track whichever wrangler actually resolves,
+    // not whichever last shipped upstream.
+    '@cloudflare/workers-types': '^4.20260702.1',
     // `@barefootjs/test` powers `renderToTest()` — the canonical
     // millisecond IR test the docs (and `bf gen test`) point new users
     // at. Without it the scaffold's `test` script is a no-op and any

--- a/packages/jsx/src/adapters/parsed-expr-emitter.ts
+++ b/packages/jsx/src/adapters/parsed-expr-emitter.ts
@@ -72,6 +72,7 @@ export type ArrayMethod =
   | 'startsWith'
   | 'endsWith'
   | 'replace'
+  | 'replaceAll'
   | 'repeat'
   | 'padStart'
   | 'padEnd'

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -93,6 +93,7 @@ export type ParsedExpr =
         | 'startsWith'
         | 'endsWith'
         | 'replace'
+        | 'replaceAll'
         | 'repeat'
         | 'padStart'
         | 'padEnd'
@@ -345,18 +346,17 @@ const UNSUPPORTED_METHODS = new Set([
   // `startsWith` / `endsWith` are no longer here — both lower via the
   // `array-method` IR + `bf_starts_with` / `bf_ends_with` (Go) and
   // `bf->starts_with` / `bf->ends_with` (Mojo). See #1448 Tier B.
-  // `replace` is no longer here — the string-pattern form lowers via
-  // the `array-method` IR + `bf_replace` (Go) / `bf->replace` (Mojo);
-  // the regex-pattern form is refused at the parse arm below (it would
-  // need the per-adapter regex-flavour decision). `replaceAll` stays
-  // refused. See #1448 Tier B.
+  // `replace` / `replaceAll` are no longer here — the string-pattern
+  // form of each lowers via the `array-method` IR + `bf_replace` /
+  // `bf_replace_all` (Go) / `bf->replace` / `bf->replace_all` (Mojo);
+  // the regex-pattern form of EITHER is refused at the parse arm below
+  // (it would need the per-adapter regex-flavour decision).
   // `repeat` is no longer here — `String.prototype.repeat(n)` lowers via
   // the `array-method` IR + `bf_repeat` (Go) / `bf->repeat` (Mojo).
   // See #1448 Tier B.
   // `padStart` / `padEnd` are no longer here — both lower via the
   // `array-method` IR + `bf_pad_start` / `bf_pad_end` (Go) and
   // `bf->pad_start` / `bf->pad_end` (Mojo). See #1448 Tier B.
-  'replaceAll',
   'charAt', 'charCodeAt', 'codePointAt', 'normalize',
   'substring', 'substr', 'match', 'matchAll', 'search',
 ])
@@ -954,19 +954,25 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
       // refused: `isSupported` maps a regex-pattern `.replace` to the
       // deferred-form BF101 reason — the Perl `s///` vs Go
       // `regexp.ReplaceAllString` flavour gap is the open design
-      // question in #1448. `replaceAll` stays refused entirely.
+      // question in #1448. `.replaceAll(pattern, replacement)` shares
+      // this arm (#2182 follow-up): same arity/regex/object-literal
+      // gates, only the `method` tag and its runtime helper differ —
+      // `bf_replace_all` (Go, `strings.ReplaceAll`) / `bf->replace_all`
+      // (Mojo) replace EVERY occurrence, where `.replace`'s helpers
+      // replace only the first.
       //
       // Full JS arity: a third+ argument is ignored (the adapter reads
       // only the pattern + replacement). The one- and zero-argument
       // forms are refused: JS coerces the missing replacement (and
       // pattern) to the literal string "undefined", a degenerate result
       // (mirrors the `.includes()` / `.startsWith()` zero-arg refusal).
-      if (callee.property === 'replace') {
+      if (callee.property === 'replace' || callee.property === 'replaceAll') {
+        const method = callee.property
         if (args.length < 2) {
           return {
             kind: 'unsupported',
             raw,
-            reason: `\`.replace(${args.length === 0 ? '' : 'pattern'})\` needs both a pattern and a replacement — JS coerces the missing argument to the string "undefined", a degenerate result. Pass both arguments, or pre-compute the value before the template.`,
+            reason: `\`.${method}(${args.length === 0 ? '' : 'pattern'})\` needs both a pattern and a replacement — JS coerces the missing argument to the string "undefined", a degenerate result. Pass both arguments, or pre-compute the value before the template.`,
           }
         }
         // A regex-literal pattern is the deferred form (the Perl `s///`
@@ -980,7 +986,7 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
         // any template use with the deferred-form reason.
         const patternNode = node.arguments[0]
         if (patternNode && ts.isRegularExpressionLiteral(patternNode)) {
-          return { kind: 'array-method', method: 'replace', object: callee.object, args }
+          return { kind: 'array-method', method, object: callee.object, args }
         }
         // Treat an object-literal argument like `unsupported` — a `.replace`
         // with an object pattern/replacement isn't lowerable, same as before
@@ -995,7 +1001,7 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
           const reason = badArg.kind === 'unsupported' ? badArg.reason : 'Unsupported syntax: ObjectLiteralExpression'
           return { kind: 'unsupported', raw, reason }
         }
-        return { kind: 'array-method', method: 'replace', object: callee.object, args }
+        return { kind: 'array-method', method, object: callee.object, args }
       }
       // `.repeat(n)` — string → string (the receiver concatenated `n`
       // times). Go uses `bf_repeat` (`strings.Repeat`, clamping a
@@ -2236,15 +2242,16 @@ function checkSupport(expr: ParsedExpr): SupportResult {
     }
 
     case 'array-method': {
-      // A regex-pattern `.replace` is carried structurally (a `regex` first
-      // arg) but is the deferred form (#1448) — no template language lowers it.
-      // Refuse with the dedicated reason rather than the generic standalone-regex
-      // message, preserving the diagnostic the parser used to emit directly.
-      if (expr.method === 'replace' && expr.args[0]?.kind === 'regex') {
+      // A regex-pattern `.replace` / `.replaceAll` is carried structurally
+      // (a `regex` first arg) but is the deferred form (#1448) — no
+      // template language lowers it. Refuse with the dedicated reason
+      // rather than the generic standalone-regex message, preserving the
+      // diagnostic the parser used to emit directly.
+      if ((expr.method === 'replace' || expr.method === 'replaceAll') && expr.args[0]?.kind === 'regex') {
         return {
           supported: false,
           reason:
-            'String.prototype.replace supports only a string pattern + string replacement (the regex form is deferred); use a string pattern or wrap the expression in /* @client */',
+            `String.prototype.${expr.method} supports only a string pattern + string replacement (the regex form is deferred); use a string pattern or wrap the expression in /* @client */`,
         }
       }
       const objSupport = checkSupport(expr.object)

--- a/spec/template-helpers.md
+++ b/spec/template-helpers.md
@@ -202,6 +202,12 @@ occurrence; empty pattern inserts at the front. Vectors avoid
 `$`-containing replacements (JS interprets replacement patterns;
 template lowerings treat the replacement literally).
 
+### replace_all
+
+JS `.replaceAll(pattern, replacement)`, string-pattern form, EVERY
+occurrence — the all-occurrences sibling of `replace` above. Same
+literal-replacement caveat (no `$`-pattern interpretation).
+
 ### repeat
 
 JS `.repeat(n)` for integer `n ≥ 0` (`0` → `""`). Negative counts

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2404,56 +2404,6 @@
           "reason": "`'Hello, ' + name` renders \"0\" — JS string-concat `+` lowered through numeric addition"
         }
       },
-      "string-replaceall": {
-        "blade": {
-          "kind": "refusal",
-          "codes": [
-            "BF101"
-          ]
-        },
-        "erb": {
-          "kind": "refusal",
-          "codes": [
-            "BF101"
-          ]
-        },
-        "go-template": {
-          "kind": "refusal",
-          "codes": [
-            "BF101"
-          ]
-        },
-        "jinja": {
-          "kind": "refusal",
-          "codes": [
-            "BF101"
-          ]
-        },
-        "minijinja": {
-          "kind": "refusal",
-          "codes": [
-            "BF101"
-          ]
-        },
-        "mojolicious": {
-          "kind": "refusal",
-          "codes": [
-            "BF101"
-          ]
-        },
-        "twig": {
-          "kind": "refusal",
-          "codes": [
-            "BF101"
-          ]
-        },
-        "xslate": {
-          "kind": "refusal",
-          "codes": [
-            "BF101"
-          ]
-        }
-      },
       "string-trim-sided": {
         "blade": {
           "kind": "render",


### PR DESCRIPTION
# Divergence-resolution stack 8/N — `.replaceAll()` with a string pattern

Follows #2182 (merged). Same principle: the IR carries the semantics; adapters emit from it.

## What

`.replaceAll(pattern, replacement)` was refused at compile time with BF101 on every adapter — no backend had an all-occurrences lowering, only `.replace`'s first-occurrence form. Unlike `.slice()` (stack 7/N), this is not a receiver-type ambiguity: `.replaceAll` has no `Array.prototype` equivalent, so there's nothing to disambiguate — it just had no lowering path at all.

## How

New `replaceAll` `ArrayMethod` IR union member (`packages/jsx/src/expression-parser.ts` + `packages/jsx/src/adapters/parsed-expr-emitter.ts`), added as a sibling to the existing `replace` member (matching the `padStart`/`padEnd` and `startsWith`/`endsWith` precedent of separate members over a shared member + flag). The parser arm is shared with `.replace` (same arity gate, same regex-literal-stays-refused treatment, same object-literal rejection) — un-refused from `UNSUPPORTED_METHODS`.

Each backend gets a **dedicated** all-occurrences helper, not `.replace` with a flag — reusing the first-occurrence lowering would have silently truncated the replacement to one match:

- **Go**: `bf_replace_all` (`strings.ReplaceAll`) — Go's native replace defaults to first-occurrence, same as every other backend here.
- **Perl** (`adapter-perl`, shared by Mojolicious + Text::Xslate): `replace_all`, an index/substr loop keeping both pattern and replacement literal — matching `.replace`'s existing approach.
- **Python** (`adapter-jinja`): `bf.replace_all` — Python's native `str.replace` (no count arg) is already global by default, including the empty-pattern-inserts-at-every-boundary edge case, so no loop needed.
- **Ruby** (`adapter-erb`): `bf.replace_all`, an index/splice loop — **deliberately not `String#gsub`**, which interprets `\1` / `\&` backreference syntax in the replacement even for a literal string pattern (`"abc".gsub("b", "\\1")` → `"ac"`, not the literal `"\1"`) — verified empirically before choosing this approach.
- **PHP** (`adapter-php`, shared by Twig + Blade): `replace_all` via `str_replace` (global by default, literal), with the empty-pattern case hand-rolled via `mb_str_split` since PHP's `str_replace("")` is a no-op, unlike JS.
- **Rust** (`adapter-rust`): `bf.replace_all` — native `str::replace` is already global by default, same shape as Python.

## Golden vectors

Added 5 new `replace_all` cases to the shared corpus (`packages/adapter-tests/vectors/cases.ts` → `vectors.json`, regenerated), mirroring `.replace`'s cases but with a **multi-occurrence receiver as the flagship** (`'a-b-a'.replaceAll('a', 'X')` → `'X-b-X'`) — a backend that reused its first-only `replace` helper here would produce `'X-b-a'` instead, and this case catches it. These run against Go, Perl, Python, Ruby, and PHP via the existing cross-language harness, plus a matching Rust vector test.

## Graduations

- `string-replaceall` graduates from a BF101 compile-time refusal to a passing render on all eight template adapters (removed from each adapter's `conformance-pins.ts`).
- `ui/compat.lock.json`: the `string-replaceall` fixture key is removed entirely (was refusal-kind on all 8 adapters).

## Verified

Full sequential verification on real backends, all green (0 fail): jinja 508, mojolicious 680, xslate 509, twig 508, blade 508, rust 508, erb 482, go-template 719, hono 579, adapter-tests 1,190, compat 558/558 cells ok, `packages/jsx` 2,364 (zero snapshot churn). Golden-vector suites re-run directly on each runtime with the new `replace_all` cases: Go `go test` (267 vectors total), Perl `helper_vectors.t` (267), Python `pytest` (267 subtests), Ruby `helper_vectors_test.rb` (268 runs), PHP `test_helper_vectors.php` (268 cases), Rust `cargo test --test helper_vectors`.

## Scope note

This is task 3 of 3 in the string-method divergence class. `string-trim-sided` (`trimStart`/`trimEnd`) is the remaining unit — new `ArrayMethod` union members, parser arms, and per-adapter emitter cases, same shape as this PR, landing next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZXzQWvSKLUUrTAZ3vph1j)_