### PR TITLE
Fix nested-loop data-key depth suffix across all 8 template adapters (render-divergences 1/N)

### DIFF
--- a/.changeset/nested-loop-data-key-depth.md
+++ b/.changeset/nested-loop-data-key-depth.md
@@ -1,0 +1,19 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/jinja": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+"@barefootjs/twig": patch
+"@barefootjs/blade": patch
+"@barefootjs/rust": patch
+"@barefootjs/erb": patch
+"@barefootjs/go-template": patch
+---
+
+Fix nested-loop `data-key` attributes to carry the depth suffix (`data-key-1`, `data-key-2`, ...) that the Hono/JS reference already emits for a `.map()` nested inside another `.map()`. Both the CSR client-JS path (`ir-to-client-js`'s `loopDepth` recursion counter) and the Hono SSR adapter (a `loopKeyStack`) already derived this independently at render time; the eight template (non-JS) adapters had no such mechanism at all and always emitted plain `data-key` regardless of nesting, so an inner loop's items were indistinguishable from the outer loop's for client-side reconciliation.
+
+`IRLoop` gains a `depth` field (0 = outermost), computed once in Phase 1 (`jsx-to-ir.ts`, a `ctx.loopDepth` counter incremented/decremented in lockstep with `ctx.loopParams` around each `.map()` callback) — the single IR-computed source of truth every adapter now reads instead of re-deriving nesting depth on its own. Each of the eight adapters threads the loop's own `depth` through its `renderLoop`/`renderAttributes` call (a per-adapter save/restore field mirroring the existing `inLoop` boolean), so `key` → `data-key`/`data-key-N` matches `keyAttrName()` in `ir-to-client-js/utils.ts` exactly.
+
+Also fixes a related, previously-undiscovered Jinja bug this fixture exposed: the adapter's member-access emitter lowered `obj.field` through Jinja's `.` (attribute-then-item) resolution, so a dict-shaped JS object with a field literally named `items`/`keys`/`values`/`get`/... resolved to Python's *built-in dict method* of the same name instead of the field's value (`group.items` → `TypeError: 'builtin_function_or_method' object is not iterable`). Both Jinja member-access emitters now lower to bracket/item access (`obj['field']`, Jinja's `getitem`, key-first), which cannot collide with a dict method name.
+
+`nested-loop-outer-binding` graduates from a render divergence to a passing render on all eight template adapters.

--- a/packages/adapter-blade/src/adapter/blade-adapter.ts
+++ b/packages/adapter-blade/src/adapter/blade-adapter.ts
@@ -357,6 +357,14 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
   private errors: CompilerError[] = []
   private inLoop: boolean = false
   /**
+   * `IRLoop.depth` of the loop currently being rendered (save/restore
+   * around `renderChildren(loop.children)`, mirroring `inLoop` above).
+   * `renderAttributes` reads this to derive the `key` → `data-key`/
+   * `data-key-N` suffix — the depth is IR-computed (jsx-to-ir.ts), not
+   * re-derived here (#2168 nested-loop-outer-binding).
+   */
+  private currentLoopKeyDepth = 0
+  /**
    * SolidJS-style props identifier (`function(props: P)`) and the
    * analyzer-extracted prop names. Stashed at `generate()` entry so the
    * per-attribute `emitSpread` callback can build a propsObject spread bag as
@@ -952,10 +960,13 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
 
     const prevInLoop = this.inLoop
     this.inLoop = true
+    const prevLoopKeyDepth = this.currentLoopKeyDepth
+    this.currentLoopKeyDepth = loop.depth
     // Re-render children now that inLoop is set (so nested components use the
     // loop-child naming convention). renderedChildren above was computed with
     // the previous flag; recompute under the loop flag.
     const childrenUnderLoop = this.renderChildren(loop.children)
+    this.currentLoopKeyDepth = prevLoopKeyDepth
     this.inLoop = prevInLoop
     void renderedChildren
 
@@ -1499,7 +1510,10 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
       // Rewrite JSX special-prop names to their HTML-attribute counterparts.
       let attrName: string
       if (attr.name === 'className') attrName = 'class'
-      else if (attr.name === 'key') attrName = 'data-key'
+      else if (attr.name === 'key') {
+        const depth = this.currentLoopKeyDepth
+        attrName = depth > 0 ? `data-key-${depth}` : 'data-key'
+      }
       else attrName = attr.name
       const lowered = emitAttrValue(attr.value, this.elementAttrEmitter, attrName)
       if (lowered) parts.push(lowered)

--- a/packages/adapter-blade/src/render-divergences.ts
+++ b/packages/adapter-blade/src/render-divergences.ts
@@ -19,8 +19,6 @@ export const renderDivergences: RenderDivergences = {
     'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
-  'nested-loop-outer-binding':
-    'nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`',
   'jsx-element-prop':
     'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
 }

--- a/packages/adapter-erb/src/adapter/erb-adapter.ts
+++ b/packages/adapter-erb/src/adapter/erb-adapter.ts
@@ -178,6 +178,14 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
   private errors: CompilerError[] = []
   private inLoop: boolean = false
   /**
+   * `IRLoop.depth` of the loop currently being rendered (save/restore
+   * around `renderChildren(loop.children)`, mirroring `inLoop` above).
+   * `renderAttributes` reads this to derive the `key` → `data-key`/
+   * `data-key-N` suffix — the depth is IR-computed (jsx-to-ir.ts), not
+   * re-derived here (#2168 nested-loop-outer-binding).
+   */
+  private currentLoopKeyDepth = 0
+  /**
    * SolidJS-style props identifier (`function(props: P)`) and the
    * analyzer-extracted prop names. Stashed at `generate()` entry so the
    * per-attribute `emitSpread` callback can build a propsObject spread bag
@@ -908,7 +916,10 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
     }
     const prevInLoop = this.inLoop
     this.inLoop = true
+    const prevLoopKeyDepth = this.currentLoopKeyDepth
+    this.currentLoopKeyDepth = loop.depth
     const renderedChildren = this.renderChildren(loop.children)
+    this.currentLoopKeyDepth = prevLoopKeyDepth
     this.inLoop = prevInLoop
 
     // Whole-item conditional: prepend an always-present
@@ -1452,7 +1463,10 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
       // attribute-emit time.
       let attrName: string
       if (attr.name === 'className') attrName = 'class'
-      else if (attr.name === 'key') attrName = 'data-key'
+      else if (attr.name === 'key') {
+        const depth = this.currentLoopKeyDepth
+        attrName = depth > 0 ? `data-key-${depth}` : 'data-key'
+      }
       else attrName = attr.name
       const lowered = emitAttrValue(attr.value, this.elementAttrEmitter, attrName)
       if (lowered) parts.push(lowered)

--- a/packages/adapter-erb/src/render-divergences.ts
+++ b/packages/adapter-erb/src/render-divergences.ts
@@ -21,8 +21,6 @@ export const renderDivergences: RenderDivergences = {
     'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders but its loop item keys diverge from the reference serialisation',
-  'nested-loop-outer-binding':
-    'nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`',
   'jsx-element-prop':
     'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
 }

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -226,6 +226,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   private inLoop: boolean = false
   private loopParamStack: string[] = []
   /**
+   * Stack of `IRLoop.depth` values (innermost last), pushed/popped around
+   * `renderChildren(loop.children)` in `renderLoop`. `renderAttributes`
+   * reads the top of this stack to derive the `key` → `data-key`/
+   * `data-key-N` suffix — the depth is IR-computed (jsx-to-ir.ts), not
+   * re-derived here; this stack only threads that value down to the
+   * loop body's root element (#2168 nested-loop-outer-binding).
+   */
+  private loopKeyDepthStack: number[] = []
+  /**
    * Per-loop: true when the body renders the bare range value (scalar-item
    * inline-literal loop), so the `bf_tmpl` companion is fed `.BfLoopItem` (the
    * wrapper's synthetic scalar field) instead of `.`. Innermost last.
@@ -4941,7 +4950,9 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       this.scalarLiteralLoopGoType(loop.arrayParsed, loop.itemType) !== null,
     )
     this.loopWrapperStack.push(!!loop.childComponent)
+    this.loopKeyDepthStack.push(loop.depth)
     const children = this.renderChildren(loop.children)
+    this.loopKeyDepthStack.pop()
     this.loopWrapperStack.pop()
     this.loopScalarItemStack.pop()
     // Build the per-item anchor marker while the loop param is still on the
@@ -5386,10 +5397,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       // Rewrite JSX special-prop names to their HTML-attribute counterparts. The
       // Go template adapter has no JSX runtime to strip `key` / emit `data-key`,
       // so the rewrite happens at attribute-emit time. Mirror of the `key`
-      // branch in `ir-to-client-js/html-template.ts`.
+      // branch in `ir-to-client-js/html-template.ts`. The depth-suffix (plain
+      // `data-key` at the outermost loop, `data-key-N` N levels deep) comes
+      // from `IRLoop.depth` via `loopKeyDepthStack`, not re-derived here.
       let attrName: string
       if (attr.name === 'className') attrName = 'class'
-      else if (attr.name === 'key') attrName = 'data-key'
+      else if (attr.name === 'key') {
+        const depth = this.loopKeyDepthStack.at(-1) ?? 0
+        attrName = depth > 0 ? `data-key-${depth}` : 'data-key'
+      }
       else attrName = attr.name
       const lowered = emitAttrValue(attr.value, this.elementAttrEmitter, attrName)
       if (lowered) parts.push(lowered)

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -37,4 +37,6 @@ export const renderDivergences: RenderDivergences = {
     'a memo derived from another memo renders EMPTY for the second layer — the constructor folds only one derivation level',
   'signal-object-field':
     'object-valued signal (`user().name`): generated Go fails to run (exit 1) — no struct synthesis outside loops',
+  'nested-loop-triple-depth':
+    'a THIRD level of nested .map() renders every item field EMPTY (key values and text content alike), though the data-key/-1/-2 suffix naming itself is correct — Go loop-scope binding only reaches two levels deep',
 }

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -27,8 +27,6 @@ export const renderDivergences: RenderDivergences = {
     'Math.min/max/abs over a signal: generated Go fails to run (exit 1) — only Math.floor is registered',
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)`: generated Go fails to run (exit 1) — no object-iteration loop lowering',
-  'nested-loop-outer-binding':
-    'nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`',
   'jsx-element-prop':
     'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
   'grandchild-composition':

--- a/packages/adapter-jinja/src/adapter/expr/emitters.ts
+++ b/packages/adapter-jinja/src/adapter/expr/emitters.ts
@@ -149,8 +149,16 @@ export class JinjaFilterEmitter implements ParsedExprEmitter {
     if (property === 'length') {
       return `bf.length(${emit(object)})`
     }
-    // Attribute / dict-key access — Jinja `.` resolves both transparently.
-    return `${emit(object)}.${property}`
+    // Bracket/item access, NOT `.` attribute access: Jinja's default
+    // `getattr` semantics try a Python ATTRIBUTE first, falling back to a
+    // dict key only if no such attribute exists — so `group.items` (a
+    // dict key from the JS object) instead resolves to the built-in bound
+    // method `dict.items`, raising "not iterable" downstream instead of
+    // returning the key's value. `[...]` compiles through Jinja's
+    // `getitem`, which tries the KEY first, sidestepping any built-in
+    // dict method name (items/keys/values/get/pop/update/...) that would
+    // otherwise shadow a same-named JS object field.
+    return `${emit(object)}['${escapeJinjaSingleQuoted(property)}']`
   }
 
   indexAccess(object: ParsedExpr, index: ParsedExpr, emit: (e: ParsedExpr) => string): string {
@@ -331,8 +339,13 @@ export class JinjaTopLevelEmitter implements ParsedExprEmitter {
     const obj = emit(object)
     // `.length` → `bf.length` (array count or string char count, JS-compat).
     if (property === 'length') return `bf.length(${obj})`
-    // Jinja `.` access works for both dicts and objects.
-    return `${obj}.${property}`
+    // Bracket/item access, NOT `.` attribute access — see the sibling
+    // `JinjaFilterEmitter.member()` for why: Jinja's `.` tries a Python
+    // ATTRIBUTE first, so a dict key that happens to share a name with a
+    // built-in dict method (`items`, `keys`, `values`, `get`, ...) resolves
+    // to the bound method instead of the value. `[...]` (Jinja `getitem`)
+    // tries the key first.
+    return `${obj}['${escapeJinjaSingleQuoted(property)}']`
   }
 
   indexAccess(object: ParsedExpr, index: ParsedExpr, emit: (e: ParsedExpr) => string): string {

--- a/packages/adapter-jinja/src/adapter/jinja-adapter.ts
+++ b/packages/adapter-jinja/src/adapter/jinja-adapter.ts
@@ -207,6 +207,14 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
   private errors: CompilerError[] = []
   private inLoop: boolean = false
   /**
+   * `IRLoop.depth` of the loop currently being rendered (save/restore
+   * around `renderChildren(loop.children)`, mirroring `inLoop` above).
+   * `renderAttributes` reads this to derive the `key` → `data-key`/
+   * `data-key-N` suffix — the depth is IR-computed (jsx-to-ir.ts), not
+   * re-derived here (#2168 nested-loop-outer-binding).
+   */
+  private currentLoopKeyDepth = 0
+  /**
    * SolidJS-style props identifier (`function(props: P)`) and the
    * analyzer-extracted prop names. Stashed at `generate()` entry so the
    * per-attribute `emitSpread` callback can build a propsObject spread bag as
@@ -804,10 +812,13 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
 
     const prevInLoop = this.inLoop
     this.inLoop = true
+    const prevLoopKeyDepth = this.currentLoopKeyDepth
+    this.currentLoopKeyDepth = loop.depth
     // Re-render children now that inLoop is set (so nested components use the
     // loop-child naming convention). renderedChildren above was computed with
     // the previous flag; recompute under the loop flag.
     const childrenUnderLoop = this.renderChildren(loop.children)
+    this.currentLoopKeyDepth = prevLoopKeyDepth
     this.inLoop = prevInLoop
     void renderedChildren
 
@@ -1339,7 +1350,10 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
       // Rewrite JSX special-prop names to their HTML-attribute counterparts.
       let attrName: string
       if (attr.name === 'className') attrName = 'class'
-      else if (attr.name === 'key') attrName = 'data-key'
+      else if (attr.name === 'key') {
+        const depth = this.currentLoopKeyDepth
+        attrName = depth > 0 ? `data-key-${depth}` : 'data-key'
+      }
       else attrName = attr.name
       const lowered = emitAttrValue(attr.value, this.elementAttrEmitter, attrName)
       if (lowered) parts.push(lowered)

--- a/packages/adapter-jinja/src/render-divergences.ts
+++ b/packages/adapter-jinja/src/render-divergences.ts
@@ -19,8 +19,6 @@ export const renderDivergences: RenderDivergences = {
     'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
-  'nested-loop-outer-binding':
-    'nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`',
   'jsx-element-prop':
     'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
 }

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -166,6 +166,14 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
   private errors: CompilerError[] = []
   private inLoop: boolean = false
   /**
+   * `IRLoop.depth` of the loop currently being rendered (save/restore
+   * around `renderChildren(loop.children)`, mirroring `inLoop` above).
+   * `renderAttributes` reads this to derive the `key` → `data-key`/
+   * `data-key-N` suffix — the depth is IR-computed (jsx-to-ir.ts), not
+   * re-derived here (#2168 nested-loop-outer-binding).
+   */
+  private currentLoopKeyDepth = 0
+  /**
    * SolidJS-style props identifier (`function(props: P)`) and the
    * analyzer-extracted prop names. Stashed at `generate()` entry so
    * the per-attribute `emitSpread` callback can build a propsObject
@@ -858,7 +866,10 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     }
     const prevInLoop = this.inLoop
     this.inLoop = true
+    const prevLoopKeyDepth = this.currentLoopKeyDepth
+    this.currentLoopKeyDepth = loop.depth
     const renderedChildren = this.renderChildren(loop.children)
+    this.currentLoopKeyDepth = prevLoopKeyDepth
     this.inLoop = prevInLoop
 
     // Whole-item conditional (#1665): prepend an always-present
@@ -1442,7 +1453,10 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       // rewrite happens at attribute-emit time.
       let attrName: string
       if (attr.name === 'className') attrName = 'class'
-      else if (attr.name === 'key') attrName = 'data-key'
+      else if (attr.name === 'key') {
+        const depth = this.currentLoopKeyDepth
+        attrName = depth > 0 ? `data-key-${depth}` : 'data-key'
+      }
       else attrName = attr.name
       const lowered = emitAttrValue(attr.value, this.elementAttrEmitter, attrName)
       if (lowered) parts.push(lowered)

--- a/packages/adapter-mojolicious/src/render-divergences.ts
+++ b/packages/adapter-mojolicious/src/render-divergences.ts
@@ -19,8 +19,6 @@ export const renderDivergences: RenderDivergences = {
     'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
-  'nested-loop-outer-binding':
-    'nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`',
   'jsx-element-prop':
     'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
 }

--- a/packages/adapter-rust/src/adapter/minijinja-adapter.ts
+++ b/packages/adapter-rust/src/adapter/minijinja-adapter.ts
@@ -255,6 +255,14 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
   private errors: CompilerError[] = []
   private inLoop: boolean = false
   /**
+   * `IRLoop.depth` of the loop currently being rendered (save/restore
+   * around `renderChildren(loop.children)`, mirroring `inLoop` above).
+   * `renderAttributes` reads this to derive the `key` → `data-key`/
+   * `data-key-N` suffix — the depth is IR-computed (jsx-to-ir.ts), not
+   * re-derived here (#2168 nested-loop-outer-binding).
+   */
+  private currentLoopKeyDepth = 0
+  /**
    * SolidJS-style props identifier (`function(props: P)`) and the
    * analyzer-extracted prop names. Stashed at `generate()` entry so the
    * per-attribute `emitSpread` callback can build a propsObject spread bag as
@@ -845,10 +853,13 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
 
     const prevInLoop = this.inLoop
     this.inLoop = true
+    const prevLoopKeyDepth = this.currentLoopKeyDepth
+    this.currentLoopKeyDepth = loop.depth
     // Re-render children now that inLoop is set (so nested components use the
     // loop-child naming convention). renderedChildren above was computed with
     // the previous flag; recompute under the loop flag.
     const childrenUnderLoop = this.renderChildren(loop.children)
+    this.currentLoopKeyDepth = prevLoopKeyDepth
     this.inLoop = prevInLoop
     void renderedChildren
 
@@ -1382,7 +1393,10 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
       // Rewrite JSX special-prop names to their HTML-attribute counterparts.
       let attrName: string
       if (attr.name === 'className') attrName = 'class'
-      else if (attr.name === 'key') attrName = 'data-key'
+      else if (attr.name === 'key') {
+        const depth = this.currentLoopKeyDepth
+        attrName = depth > 0 ? `data-key-${depth}` : 'data-key'
+      }
       else attrName = attr.name
       const lowered = emitAttrValue(attr.value, this.elementAttrEmitter, attrName)
       if (lowered) parts.push(lowered)

--- a/packages/adapter-rust/src/render-divergences.ts
+++ b/packages/adapter-rust/src/render-divergences.ts
@@ -21,8 +21,6 @@ export const renderDivergences: RenderDivergences = {
     'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
-  'nested-loop-outer-binding':
-    'nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`',
   'jsx-element-prop':
     'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
 }

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -336,6 +336,8 @@ import { fixture as inlineArrayMap } from './inline-array-map'
 import { fixture as objectEntriesMap } from './object-entries-map'
 import { fixture as mapKeyIndex } from './map-key-index'
 import { fixture as nestedLoopOuterBinding } from './nested-loop-outer-binding'
+import { fixture as nestedLoopTripleDepth } from './nested-loop-triple-depth'
+import { fixture as siblingLoopsKeyIsolation } from './sibling-loops-key-isolation'
 import { fixture as conditionalReturnNull } from './conditional-return-null'
 import { fixture as jsxElementProp } from './jsx-element-prop'
 import { fixture as grandchildComposition } from './grandchild-composition'
@@ -600,6 +602,8 @@ export const jsxFixtures: JSXFixture[] = [
   objectEntriesMap,
   mapKeyIndex,
   nestedLoopOuterBinding,
+  nestedLoopTripleDepth,
+  siblingLoopsKeyIsolation,
   conditionalReturnNull,
   jsxElementProp,
   grandchildComposition,

--- a/packages/adapter-tests/fixtures/nested-loop-triple-depth.ts
+++ b/packages/adapter-tests/fixtures/nested-loop-triple-depth.ts
@@ -1,0 +1,56 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A `.map()` nested THREE deep (`nested-loop-outer-binding` pins two
+ * levels). Pins the `data-key-2` suffix specifically — a depth-suffix
+ * mechanism that only handles one level of nesting (`data-key` /
+ * `data-key-1`, hard-coded rather than counting) would pass the
+ * two-level fixture but fail here.
+ */
+export const fixture = createFixture({
+  id: 'nested-loop-triple-depth',
+  description: 'Three levels of nested .map() pin the data-key-2 suffix',
+  source: `
+type Leaf = { id: string }
+type Branch = { id: string; leaves: Leaf[] }
+type Tree = { id: string; branches: Branch[] }
+function NestedLoopTripleDepth({ trees }: { trees: Tree[] }) {
+  return (
+    <div>
+      {trees.map(tree => (
+        <section key={tree.id}>
+          {tree.branches.map(branch => (
+            <article key={branch.id}>
+              {branch.leaves.map(leaf => (
+                <span key={leaf.id}>{leaf.id}</span>
+              ))}
+            </article>
+          ))}
+        </section>
+      ))}
+    </div>
+  )
+}
+export { NestedLoopTripleDepth }
+`,
+  props: {
+    trees: [
+      {
+        id: 't1',
+        branches: [
+          { id: 'b1', leaves: [{ id: 'l1' }, { id: 'l2' }] },
+        ],
+      },
+    ],
+  },
+  expectedHtml: `
+    <div bf-s="test" bf="s3">
+      <section bf="s2" data-key="t1">
+        <article bf="s1" data-key-1="b1">
+          <span data-key-2="l1"><!--bf:s0-->l1<!--/--></span>
+          <span data-key-2="l2"><!--bf:s0-->l2<!--/--></span>
+        </article>
+      </section>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/nested-loop-triple-depth.ts
+++ b/packages/adapter-tests/fixtures/nested-loop-triple-depth.ts
@@ -44,13 +44,6 @@ export { NestedLoopTripleDepth }
     ],
   },
   expectedHtml: `
-    <div bf-s="test" bf="s3">
-      <section bf="s2" data-key="t1">
-        <article bf="s1" data-key-1="b1">
-          <span data-key-2="l1"><!--bf:s0-->l1<!--/--></span>
-          <span data-key-2="l2"><!--bf:s0-->l2<!--/--></span>
-        </article>
-      </section>
-    </div>
+    <div bf-s="test" bf="s3"><section bf="s2" data-key="t1"><article bf="s1" data-key-1="b1"><span data-key-2="l1"><!--bf:s0-->l1<!--/--></span><span data-key-2="l2"><!--bf:s0-->l2<!--/--></span></article></section></div>
   `,
 })

--- a/packages/adapter-tests/fixtures/sibling-loops-key-isolation.ts
+++ b/packages/adapter-tests/fixtures/sibling-loops-key-isolation.ts
@@ -1,0 +1,47 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Two independent `.map()` calls as SIBLINGS under the same parent
+ * (neither nested inside the other). Pins that a per-adapter
+ * save/restore around the first loop's `data-key` depth doesn't leak
+ * into the second — both must render plain `data-key` (depth 0), not
+ * have the second incorrectly inherit a stale depth from the first.
+ */
+export const fixture = createFixture({
+  id: 'sibling-loops-key-isolation',
+  description: 'Two sibling top-level loops each render plain data-key',
+  source: `
+function SiblingLoopsKeyIsolation({ fruits, veggies }: { fruits: string[]; veggies: string[] }) {
+  return (
+    <div>
+      <ul>
+        {fruits.map(f => (
+          <li key={f}>{f}</li>
+        ))}
+      </ul>
+      <ul>
+        {veggies.map(v => (
+          <li key={v}>{v}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+export { SiblingLoopsKeyIsolation }
+`,
+  props: {
+    fruits: ['apple', 'plum'],
+    veggies: ['carrot'],
+  },
+  expectedHtml: `
+    <div bf-s="test">
+      <ul bf="s1">
+        <li data-key="apple"><!--bf:s0-->apple<!--/--></li>
+        <li data-key="plum"><!--bf:s0-->plum<!--/--></li>
+      </ul>
+      <ul bf="s3">
+        <li data-key="carrot"><!--bf:s2-->carrot<!--/--></li>
+      </ul>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/sibling-loops-key-isolation.ts
+++ b/packages/adapter-tests/fixtures/sibling-loops-key-isolation.ts
@@ -39,9 +39,7 @@ export { SiblingLoopsKeyIsolation }
         <li data-key="apple"><!--bf:s0-->apple<!--/--></li>
         <li data-key="plum"><!--bf:s0-->plum<!--/--></li>
       </ul>
-      <ul bf="s3">
-        <li data-key="carrot"><!--bf:s2-->carrot<!--/--></li>
-      </ul>
+      <ul bf="s3"><li data-key="carrot"><!--bf:s2-->carrot<!--/--></li></ul>
     </div>
   `,
 })

--- a/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
+++ b/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
@@ -37,6 +37,10 @@ describe('CSR Conformance Tests', () => {
     // lambda, so the post-init DOM shape is verified by the runtime regression
     // in `packages/client/__tests__/runtime/static-loop-csr-materialize.test.ts`.
     'static-array-from-props',
+    // Same reason as `static-array-from-props` — both `fruits` and
+    // `veggies` are direct prop arrays, materialized at init time via the
+    // clone-and-insert fallback, not available at template-eval scope.
+    'sibling-loops-key-isolation',
     // #1268: same reason as `static-array-from-props` — the childComponent
     // variant also materialises children at init time via the clone-and-
     // insert fallback, not at template-eval time. CSR coverage lives in
@@ -222,6 +226,10 @@ describe('CSR Conformance Tests', () => {
     //     suffixes differently between the SSR snapshot and template-eval.
     'object-entries-map',
     'nested-loop-outer-binding',
+    // Same class as `nested-loop-outer-binding` above, one level deeper —
+    // the SSR snapshot and template-eval disagree on nested data-key
+    // depth suffixes the same way.
+    'nested-loop-triple-depth',
     //   - `jsx-element-prop`: a JSX element passed as a NON-children prop
     //     reaches the CSR insert as an escaped STRING (with the
     //     `__BF_PARENT_SCOPE__` placeholder still embedded) instead of

--- a/packages/adapter-twig/src/adapter/twig-adapter.ts
+++ b/packages/adapter-twig/src/adapter/twig-adapter.ts
@@ -257,6 +257,14 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
   private errors: CompilerError[] = []
   private inLoop: boolean = false
   /**
+   * `IRLoop.depth` of the loop currently being rendered (save/restore
+   * around `renderChildren(loop.children)`, mirroring `inLoop` above).
+   * `renderAttributes` reads this to derive the `key` → `data-key`/
+   * `data-key-N` suffix — the depth is IR-computed (jsx-to-ir.ts), not
+   * re-derived here (#2168 nested-loop-outer-binding).
+   */
+  private currentLoopKeyDepth = 0
+  /**
    * SolidJS-style props identifier (`function(props: P)`) and the
    * analyzer-extracted prop names. Stashed at `generate()` entry so the
    * per-attribute `emitSpread` callback can build a propsObject spread bag as
@@ -852,10 +860,13 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
 
     const prevInLoop = this.inLoop
     this.inLoop = true
+    const prevLoopKeyDepth = this.currentLoopKeyDepth
+    this.currentLoopKeyDepth = loop.depth
     // Re-render children now that inLoop is set (so nested components use the
     // loop-child naming convention). renderedChildren above was computed with
     // the previous flag; recompute under the loop flag.
     const childrenUnderLoop = this.renderChildren(loop.children)
+    this.currentLoopKeyDepth = prevLoopKeyDepth
     this.inLoop = prevInLoop
     void renderedChildren
 
@@ -1386,7 +1397,10 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
       // Rewrite JSX special-prop names to their HTML-attribute counterparts.
       let attrName: string
       if (attr.name === 'className') attrName = 'class'
-      else if (attr.name === 'key') attrName = 'data-key'
+      else if (attr.name === 'key') {
+        const depth = this.currentLoopKeyDepth
+        attrName = depth > 0 ? `data-key-${depth}` : 'data-key'
+      }
       else attrName = attr.name
       const lowered = emitAttrValue(attr.value, this.elementAttrEmitter, attrName)
       if (lowered) parts.push(lowered)

--- a/packages/adapter-twig/src/render-divergences.ts
+++ b/packages/adapter-twig/src/render-divergences.ts
@@ -19,8 +19,6 @@ export const renderDivergences: RenderDivergences = {
     'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
-  'nested-loop-outer-binding':
-    'nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`',
   'jsx-element-prop':
     'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
 }

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -177,6 +177,14 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
   private errors: CompilerError[] = []
   private inLoop: boolean = false
   /**
+   * `IRLoop.depth` of the loop currently being rendered (save/restore
+   * around `renderChildren(loop.children)`, mirroring `inLoop` above).
+   * `renderAttributes` reads this to derive the `key` → `data-key`/
+   * `data-key-N` suffix — the depth is IR-computed (jsx-to-ir.ts), not
+   * re-derived here (#2168 nested-loop-outer-binding).
+   */
+  private currentLoopKeyDepth = 0
+  /**
    * SolidJS-style props identifier (`function(props: P)`) and the
    * analyzer-extracted prop names. Stashed at `generate()` entry so the
    * per-attribute `emitSpread` callback can build a propsObject spread bag as
@@ -771,10 +779,13 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
 
     const prevInLoop = this.inLoop
     this.inLoop = true
+    const prevLoopKeyDepth = this.currentLoopKeyDepth
+    this.currentLoopKeyDepth = loop.depth
     // Re-render children now that inLoop is set (so nested components use the
     // loop-child naming convention). renderedChildren above was computed with
     // the previous flag; recompute under the loop flag.
     const childrenUnderLoop = this.renderChildren(loop.children)
+    this.currentLoopKeyDepth = prevLoopKeyDepth
     this.inLoop = prevInLoop
     void renderedChildren
 
@@ -1287,7 +1298,10 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
       // Rewrite JSX special-prop names to their HTML-attribute counterparts.
       let attrName: string
       if (attr.name === 'className') attrName = 'class'
-      else if (attr.name === 'key') attrName = 'data-key'
+      else if (attr.name === 'key') {
+        const depth = this.currentLoopKeyDepth
+        attrName = depth > 0 ? `data-key-${depth}` : 'data-key'
+      }
       else attrName = attr.name
       const lowered = emitAttrValue(attr.value, this.elementAttrEmitter, attrName)
       if (lowered) parts.push(lowered)

--- a/packages/adapter-xslate/src/render-divergences.ts
+++ b/packages/adapter-xslate/src/render-divergences.ts
@@ -19,8 +19,6 @@ export const renderDivergences: RenderDivergences = {
     'Math.min/max/abs over a signal render empty (only Math.floor is in the template-primitive registry)',
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
-  'nested-loop-outer-binding':
-    'nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`',
   'jsx-element-prop':
     'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
 }

--- a/packages/jsx/src/__tests__/ir-walker.test.ts
+++ b/packages/jsx/src/__tests__/ir-walker.test.ts
@@ -53,6 +53,7 @@ function loop(children: IRNode[]): IRNode {
     markerId: 'l0',
     loc,
     isStaticArray: false,
+    depth: 0,
   }
 }
 

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -82,6 +82,17 @@ interface TransformContext {
   _destructuredPropNames?: Set<string> | null
   /** Active loop parameter names for slotId assignment to loop-param-dependent expressions */
   loopParams: Set<string>
+  /**
+   * Count of enclosing `.map()` loops (0 = outermost), incremented/
+   * decremented in lockstep with entering/leaving `transformMapCall`.
+   * Unlike `loopParams` (a name Set that can gain several entries for
+   * ONE loop level via destructuring), this is a plain per-level
+   * counter — the single source of truth `IRLoop.depth` is stamped
+   * from, so every adapter's `data-key`/`data-key-N` suffix derives
+   * from one IR-computed value instead of each adapter re-deriving
+   * nesting depth its own way (#2168 nested-loop-outer-binding).
+   */
+  loopDepth: number
   /** Counter for async boundary IDs (a0, a1, ...) */
   asyncIdCounter: number
   /** Counter for <Region> structural index (0, 1, ...) within a file. */
@@ -395,6 +406,7 @@ function createTransformContext(analyzer: AnalyzerContext): TransformContext {
     isRoot: true,
     insideComponentChildren: false,
     loopParams: new Set(),
+    loopDepth: 0,
     patterns: {
       signals: analyzer.signals.map(s => ({
         getter: s.getter,
@@ -3251,6 +3263,10 @@ function transformMapCall(
   // Capture nesting depth before we register this map's own params.
   // ctx.loopParams is populated by the *outer* map; if non-empty we are inside one.
   const isNested = ctx.loopParams.size > 0
+  // This loop's own depth (0 = outermost) is however many enclosing
+  // loops are already active, captured before `ctx.loopDepth` below is
+  // bumped for THIS loop's own descendants.
+  const depth = ctx.loopDepth
 
   const propAccess = node.expression as ts.PropertyAccessExpression
   const mapSource = propAccess.expression
@@ -3509,6 +3525,7 @@ function transformMapCall(
       ctx.loopParams.add(param)
     }
     if (index) ctx.loopParams.add(index)
+    ctx.loopDepth++
 
     // Logical control flow (`cond && <X/>`, `a ?? themeLogo()`) as the map
     // body. This is not a JSX literal, ternary, or block, so without this
@@ -3631,6 +3648,7 @@ function transformMapCall(
       ctx.loopParams.delete(param)
     }
     if (index) ctx.loopParams.delete(index)
+    ctx.loopDepth--
   }
 
   // If no JSX children were found (e.g., callback returns a function call),
@@ -3749,6 +3767,7 @@ function transformMapCall(
     sortComparator,
     chainOrder,
     iterationShape,
+    depth,
     clientOnly: isClientOnly || undefined,
     mapPreamble,
     templateMapPreamble,

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -575,6 +575,19 @@ export interface IRLoop {
   iterationShape?: 'entries' | 'keys'
 
   /**
+   * Count of enclosing `.map()` loops (0 = outermost, 1 = nested one
+   * level deep, ...). Adapters use this to derive the loop body's
+   * `key`/`data-key` attribute suffix — `depth > 0 ? 'data-key-' +
+   * depth : 'data-key'` — matching `keyAttrName()` in
+   * `ir-to-client-js/utils.ts`, which the CSR path and the Hono SSR
+   * adapter each already derive independently (a recursion counter and
+   * a push/pop stack respectively). Before this field, the 8 template
+   * (non-JS) adapters had no depth awareness at all and always emitted
+   * plain `data-key` on nested-loop items (#2168 nested-loop-outer-binding).
+   */
+  depth: number
+
+  /**
    * When true, loop should be evaluated on client side only.
    * SSR adapters should skip rendering and output placeholder markers.
    */

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 236,
+    "totalFixtures": 238,
     "fixtures": {
       "array-map-function-reference": {
         "blade": {
@@ -2130,6 +2130,12 @@
         "go-template": {
           "kind": "render",
           "reason": "a memo derived from another memo renders EMPTY for the second layer — the constructor folds only one derivation level"
+        }
+      },
+      "nested-loop-triple-depth": {
+        "go-template": {
+          "kind": "render",
+          "reason": "a THIRD level of nested .map() renders every item field EMPTY (key values and text content alike), though the data-key/-1/-2 suffix naming itself is correct — Go loop-scope binding only reaches two levels deep"
         }
       },
       "number-tofixed": {

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2132,40 +2132,6 @@
           "reason": "a memo derived from another memo renders EMPTY for the second layer — the constructor folds only one derivation level"
         }
       },
-      "nested-loop-outer-binding": {
-        "blade": {
-          "kind": "render",
-          "reason": "nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`"
-        },
-        "erb": {
-          "kind": "render",
-          "reason": "nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`"
-        },
-        "go-template": {
-          "kind": "render",
-          "reason": "nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`"
-        },
-        "jinja": {
-          "kind": "render",
-          "reason": "nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`"
-        },
-        "minijinja": {
-          "kind": "render",
-          "reason": "nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`"
-        },
-        "mojolicious": {
-          "kind": "render",
-          "reason": "nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`"
-        },
-        "twig": {
-          "kind": "render",
-          "reason": "nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`"
-        },
-        "xslate": {
-          "kind": "render",
-          "reason": "nested-loop inner items carry `data-key` where the reference emits the depth-suffixed `data-key-1`"
-        }
-      },
       "number-tofixed": {
         "go-template": {
           "kind": "render",


### PR DESCRIPTION
## Render-divergences resolution 1/N — `nested-loop-outer-binding`

New effort (distinct from the earlier string-method divergence class, #2182/#2183/#2184). Goal: resolve every remaining compatibility gap listed in each adapter's `render-divergences.ts`, then update the compatibility-matrix docs. Same principle: the IR carries the semantics; adapters emit from it.

## What

The Hono/JS reference emits a depth-suffixed `data-key-1`/`data-key-2`/... on a `.map()` nested inside another `.map()`. The 8 template (non-JS) adapters had no depth awareness at all and always emitted plain `data-key` regardless of nesting — an inner loop's items were indistinguishable from the outer loop's for client-side reconciliation.

This was one of 4 divergences shared identically across all 8 template adapters found by a parallel investigation sweep this session (the other 3 — `math-methods`, `object-entries-map`, `jsx-element-prop` — are separate upcoming PRs). Per an Opus architecture consult, this is the cleanest of the four (a pure IR field addition, no new per-adapter emission logic needed) and is sequenced first since the other loop-related fix (`object-entries-map`) should build on the same depth field.

## How

- **`IRLoop.depth`** (new field, 0 = outermost): computed once in Phase 1 (`packages/jsx/src/jsx-to-ir.ts`) via a `ctx.loopDepth` counter incremented/decremented in lockstep with the existing `ctx.loopParams` around each `.map()` callback. Both the CSR client-JS path (`ir-to-client-js`'s own `loopDepth` recursion counter) and the Hono SSR adapter (`loopKeyStack`) already derive this independently at render time — this is the first time it's a first-class IR value instead of re-derived ad hoc.
- Each of the 8 template adapters threads the loop's own `depth` through its `renderLoop` → `renderAttributes` call via a save/restore field mirroring the existing `inLoop` boolean, so `key` → `data-key`/`data-key-N` matches `keyAttrName()` in `ir-to-client-js/utils.ts` exactly.

## A previously-undiscovered Jinja bug

Removing the divergence pin for this fixture on Jinja surfaced a real, separate bug this fixture happened to expose: member access lowered through Jinja's `.` (attribute-then-item resolution), so a dict field literally named `items`/`keys`/`values`/`get`/... resolved to Python's *built-in dict method* of the same name instead of the field's value (`group.items` → `TypeError: 'builtin_function_or_method' object is not iterable`). Both Jinja member-access emitters (`JinjaFilterEmitter` and `JinjaTopLevelEmitter` in `packages/adapter-jinja/src/adapter/expr/emitters.ts`) now lower to bracket/item access (`obj['field']`, Jinja's `getitem`, key-first) instead — verified against the FULL Jinja conformance suite (510 pass, up from 509, 0 new fail) to confirm no regression from this broader change.

## Verified

Full sequential verification on real backends, all green:
- `packages/jsx`: 2337 pass, 0 fail
- Each of the 8 adapters individually: go-template 721 (via a locally-cached `GOTOOLCHAIN=go1.25.6` toolchain — this sandbox's system Go is 1.24.7 and the generated-template `go.mod` requires 1.25+; without it the Go render test silently skips), jinja 510, mojolicious 682, xslate 511, twig 510, blade 510, rust 510, erb 485
- `adapter-tests`: 1190 pass
- `hono`: 579 pass
- `bun run lint`: clean

## Graduation

`nested-loop-outer-binding` graduates from a render divergence to a passing render on all 8 template adapters. `ui/compat.lock.json` regenerated after a full `bun run build` (the checked-out `dist/` predated this session's earlier merges) — the fixture's entire key is removed, 558/558 cells ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_017ZXzQWvSKLUUrTAZ3vph1j)_