### PR TITLE
Support JSX element as a non-children prop (named slot) across all 8 template adapters

### DIFF
--- a/.changeset/jsx-element-prop-named-slots.md
+++ b/.changeset/jsx-element-prop-named-slots.md
@@ -1,0 +1,22 @@
+---
+"@barefootjs/jinja": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+"@barefootjs/twig": patch
+"@barefootjs/blade": patch
+"@barefootjs/rust": patch
+"@barefootjs/erb": patch
+"@barefootjs/go-template": patch
+"@barefootjs/perl": patch
+---
+
+Support a JSX element passed as a non-`children` prop (`<Card header={<strong>Title</strong>}>`, the slot / render-prop-lite pattern) on all 8 template adapters. Every adapter already had a mechanism to forward the reserved `children` slot from a parent template into a child render (a captured buffer slice, a `{% set %}` block, a Kolon macro, a Go struct field, ...); named JSX-valued props reuse that exact same mechanism, keyed by the prop's own name instead of `children`, rather than inventing a new shared capture path.
+
+- **Go**: bakes the value the same way real children are baked (`extractTextChildren` / `extractHtmlChildren`, falling back to `extractScopedHtmlChildren` when the root needs the parent's runtime scope id) and emits it as its own struct field.
+- **Jinja / Twig / Rust (minijinja)**: a `{% set captureName %}...{% endset %}` block per named slot, passed as a dict/hash entry.
+- **Text::Xslate**: a Kolon `macro NAME -> () { ... }` per named slot, called immediately in the hash literal.
+- **Blade**: a PHP output-buffering capture (`ob_start()` / `ob_get_clean()`), wrapped in `$bf->backend->mark_raw(...)` so the child's `{{ }}` doesn't re-escape it.
+- **Mojolicious / Text::Xslate (Perl)**: a `begin %>...<% end` capture (Mojo) / immediate macro call (Xslate) passed into `render_child`'s named-arg list. The shared `BarefootJS.pm` runtime's `render_child` now materializes *every* prop value (previously only the reserved `children` key) — a no-op for any value that isn't a captured CODE ref, so this generalizes safely to both backends.
+- **ERB**: the same output-buffer-slice capture already used for `children`, but ERB's `<%=` (unlike every other adapter's template tag) has no built-in "safe string" wrapper it can bypass escaping on for a read-back, so the runtime gains one: a new `BarefootJS::SafeString` marker class, returned by `Backend::Erb#mark_raw` (previously an identity no-op) and recognized by `Context#h` to skip re-escaping already-finished HTML forwarded across a parent/child template boundary.
+
+`jsx-element-prop` graduates from a render divergence to a passing render on all 8 template adapters.

--- a/packages/adapter-blade/src/__tests__/blade-adapter-unit.test.ts
+++ b/packages/adapter-blade/src/__tests__/blade-adapter-unit.test.ts
@@ -385,6 +385,27 @@ export function C(props: { count: number }) {
   })
 })
 
+describe('BladeAdapter - named-slot capture identifier safety (#2168 jsx-element-prop)', () => {
+  // A JSX-valued prop under a hyphenated name (`data-slot`, a valid JSX
+  // attribute name) must not leak into the capture variable — `bladeIdent`
+  // only guards reserved words, not non-identifier characters like `-`, so
+  // a name-derived variable would emit invalid PHP. The capture variable is
+  // purely counter-based (never derived from the prop name); the hash KEY
+  // passed to `render_child` still carries the real name, quoted via
+  // `bladeHashKey`.
+  test('a hyphenated prop name does not appear in the capture variable', () => {
+    const { template } = compileAndGenerate(`
+function Card(props) { return null }
+export function Parent() {
+  return <Card data-slot={<strong>Title</strong>}>text</Card>
+}
+`)
+    expect(template).toContain('@php($bf_prop_0 = $bf->backend->mark_raw(')
+    expect(template).toContain("'data-slot' => $bf_prop_0")
+    expect(template).not.toContain('$bf_prop_data')
+  })
+})
+
 // #2038 nested-callback-predicate loudness is pinned at the shared
 // conformance layer (workstream C): `filter-nested-callback-predicate` /
 // `filter-nested-find-predicate` (BF101 via `expectedDiagnostics`) and

--- a/packages/adapter-blade/src/adapter/blade-adapter.ts
+++ b/packages/adapter-blade/src/adapter/blade-adapter.ts
@@ -1127,11 +1127,30 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
     type Segment = { kind: 'entries'; parts: string[] } | { kind: 'spread'; expr: string }
     const segments: Segment[] = [{ kind: 'entries', parts: [] }]
     const currentEntries = () => this.componentPropSegmentEntries(segments)
+    // Named JSX-valued props OTHER than the reserved `children`
+    // (`header={<strong>Title</strong>}`, #2168 jsx-element-prop) each get
+    // their own output-buffering capture, prepended to the final returned
+    // string below — same mechanism as the reserved children capture,
+    // just keyed by the prop's own name instead of `children`.
+    const namedSlotCaptures: string[] = []
 
     for (const p of comp.props) {
       // Skip callback props (onXxx) and `ref` — both are client-only for
       // SSR (Hono renders neither; the client JS wires them at hydration).
       if ((p.name.match(/^on[A-Z]/) || p.name === 'ref') && p.value.kind === 'expression') continue
+      if (p.value.kind === 'jsx-children' && p.name !== 'children') {
+        const prevInLoop = this.inLoop
+        this.inLoop = false
+        const slotBody = this.renderChildren(p.value.children)
+        this.inLoop = prevInLoop
+        const captureVar = bladeVar(`bf_prop_${p.name}_${comp.slotId ?? 'c' + this.childrenCaptureCounter++}`)
+        namedSlotCaptures.push(
+          `@php(ob_start())\n${slotBody}\n` +
+          `@php(${captureVar} = $bf->backend->mark_raw(preg_replace('/\\n\\z/', '', ob_get_clean(), 1)))`,
+        )
+        currentEntries().push(`${bladeHashKey(p.name)} => ${captureVar}`)
+        continue
+      }
       if (p.value.kind === 'spread') {
         const trimmed = p.value.expr.trim()
         // SolidJS-style props identifier (`function(props: P)`) has no
@@ -1206,6 +1225,7 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
       currentEntries().push(`${bladeHashKey('children')} => ${captureVar}`)
       const dict = this.combineComponentPropSegments(segments)
       return (
+        namedSlotCaptures.join('') +
         `@php(ob_start())\n${childrenBody}\n` +
         `@php(${captureVar} = $bf->backend->mark_raw(preg_replace('/\\n\\z/', '', ob_get_clean(), 1)))` +
         `{!! $bf->render_child('${tplName}', ${dict}) !!}`
@@ -1214,7 +1234,7 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
 
     const isEmpty = segments.every(s => s.kind === 'entries' && s.parts.length === 0)
     const dictEntries = isEmpty ? '' : `, ${this.combineComponentPropSegments(segments)}`
-    return `{!! $bf->render_child('${tplName}'${dictEntries}) !!}`
+    return `${namedSlotCaptures.join('')}{!! $bf->render_child('${tplName}'${dictEntries}) !!}`
   }
 
   private childrenCaptureCounter = 0

--- a/packages/adapter-blade/src/adapter/blade-adapter.ts
+++ b/packages/adapter-blade/src/adapter/blade-adapter.ts
@@ -1143,7 +1143,14 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
         this.inLoop = false
         const slotBody = this.renderChildren(p.value.children)
         this.inLoop = prevInLoop
-        const captureVar = bladeVar(`bf_prop_${p.name}_${comp.slotId ?? 'c' + this.childrenCaptureCounter++}`)
+        // Purely counter-based — NOT derived from `p.name` or `comp.slotId`.
+        // A JSX prop name can contain characters (`data-slot`) `bladeIdent`
+        // doesn't sanitize (it only guards reserved words), producing an
+        // invalid PHP variable name; `comp.slotId` alone would also collide
+        // across two named-slot props on the same component invocation
+        // (unlike the reserved children slot, there's only ever one of
+        // those per invocation).
+        const captureVar = bladeVar(`bf_prop_${this.childrenCaptureCounter++}`)
         namedSlotCaptures.push(
           `@php(ob_start())\n${slotBody}\n` +
           `@php(${captureVar} = $bf->backend->mark_raw(preg_replace('/\\n\\z/', '', ob_get_clean(), 1)))`,

--- a/packages/adapter-blade/src/render-divergences.ts
+++ b/packages/adapter-blade/src/render-divergences.ts
@@ -17,6 +17,4 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 export const renderDivergences: RenderDivergences = {
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
-  'jsx-element-prop':
-    'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
 }

--- a/packages/adapter-erb/lib/barefoot_js.rb
+++ b/packages/adapter-erb/lib/barefoot_js.rb
@@ -25,6 +25,18 @@ require 'barefoot_js/search_params'
 # runtime carries -- a Ruby `true`/`false` IS a boolean, distinguishable
 # from `0`/`1` for free.
 module BarefootJS
+  # Marker wrapper for a string that is ALREADY finished HTML and must not
+  # be re-escaped by `Context#h` -- e.g. a named-slot / children capture
+  # (`renderComponent`'s output-buffer slice) forwarded from a parent
+  # template into a child's vars Hash. Stdlib ERB's `<%=` has no built-in
+  # "safe string" concept the way Twig's `Markup` or Kolon's `mark_raw`
+  # do, so the escape decision that elsewhere falls out of the template
+  # engine has to be carried on the VALUE itself here; see
+  # `Backend::Erb#mark_raw`, which is what actually wraps a string in this
+  # class.
+  class SafeString < String
+  end
+
   # Context is the `bf` object every compiled `.erb` template receives as a
   # local. One instance per render (root or child); `render_child` /
   # `register_components_from_manifest` construct a fresh child instance
@@ -391,8 +403,13 @@ module BarefootJS
     # HTML-escaping helper for text interpolation (`<%= bf.h(expr) %>` --
     # stdlib ERB does not auto-escape). JS-style stringification via
     # `string` (numbers per JS Number#toString, nil -> "", booleans ->
-    # "true"/"false"), then HTML-escaped.
+    # "true"/"false"), then HTML-escaped. A `SafeString` (already-finished
+    # HTML forwarded from a parent's capture -- see that class's docstring)
+    # passes through unescaped, matching Twig/Blade/Kolon's safe-string
+    # bypass on their own auto-escaping `{{ }}`/`<: :>` output tags.
     def h(value)
+      return value if value.is_a?(SafeString)
+
       html_escape(string(value))
     end
 

--- a/packages/adapter-erb/lib/barefoot_js/backend/erb.rb
+++ b/packages/adapter-erb/lib/barefoot_js/backend/erb.rb
@@ -13,15 +13,25 @@ module BarefootJS
     # operations the runtime delegates to, targeting Ruby stdlib ERB:
     #
     #   encode_json(data)            -> JSON string (injectable encoder)
-    #   mark_raw(str)                -> identity (ERB has no "safe string"
-    #                                    wrapper type -- ERB's own `<%=` is
-    #                                    NOT auto-escaping, so the compiled
-    #                                    templates that need escaping call
-    #                                    `bf.h(...)` explicitly; `mark_raw`
-    #                                    only exists so runtime helpers that
-    #                                    already produce finished HTML --
-    #                                    e.g. spread_attrs -- share one
-    #                                    interface with the Kolon/EP ports)
+    #   mark_raw(str)                -> wraps in BarefootJS::SafeString --
+    #                                    ERB's own `<%=` is NOT auto-escaping,
+    #                                    so most compiled templates call
+    #                                    `bf.h(...)` explicitly instead of
+    #                                    relying on a safe-string bypass; the
+    #                                    wrapper exists for the one path that
+    #                                    DOES need one -- a named-slot /
+    #                                    children value captured in a parent
+    #                                    template and forwarded into a
+    #                                    child's vars Hash, where the child
+    #                                    reads it back through the generic
+    #                                    `bf.h(...)` text-expression path
+    #                                    (`Context#h` unwraps SafeString to
+    #                                    skip re-escaping) -- and so that
+    #                                    runtime helpers which already
+    #                                    produce finished HTML (e.g.
+    #                                    spread_attrs) share one
+    #                                    `backend.mark_raw(...)` interface
+    #                                    with the Kolon/EP ports
     #   materialize(value)           -> resolve a captured-children value
     #                                    to a string
     #   render_named(name, bf, vars) -> render `<name>.erb` with `bf` and
@@ -58,13 +68,12 @@ module BarefootJS
         @json_encoder.call(data)
       end
 
-      # ERB has no "already-safe" string wrapper the way Kolon's `mark_raw`
-      # or Mojo::ByteStream do -- stdlib ERB's `<%=` never auto-escapes, so
-      # there is nothing to opt out of. Identity, kept only so runtime
-      # helpers (`spread_attrs`) share one `backend.mark_raw(...)` call
-      # shape across every BarefootJS backend port.
+      # See the class docstring's `mark_raw` entry: wraps in
+      # `BarefootJS::SafeString` so `Context#h` recognises and skips
+      # re-escaping already-finished HTML forwarded across a
+      # parent/child template boundary.
       def mark_raw(str)
-        str
+        BarefootJS::SafeString.new(str.to_s)
       end
 
       # JSX children captured by the adapter's buffer-slice capture

--- a/packages/adapter-erb/src/__tests__/erb-adapter.test.ts
+++ b/packages/adapter-erb/src/__tests__/erb-adapter.test.ts
@@ -304,3 +304,24 @@ export { Slot }
     expect(template).toMatch(/\*\*v\[:rest\]/)
   })
 })
+
+describe('ErbAdapter - named-slot capture identifier safety (#2168 jsx-element-prop)', () => {
+  // A JSX-valued prop under a hyphenated name (`data-slot`, a valid JSX
+  // attribute name) must not leak into the buffer-slice capture's local
+  // variables — Ruby local variable names can't contain `-`. The capture
+  // suffix is purely counter-based (never derived from the prop name); the
+  // hash KEY passed to `render_child` still carries the real name, quoted
+  // via `rubySymbolKey`.
+  test('a hyphenated prop name does not appear in the capture variables', () => {
+    const { template } = compileAndGenerate(`
+function Card(props) { return null }
+export function Parent() {
+  return <Card data-slot={<strong>Title</strong>}>text</Card>
+}
+`)
+    expect(template).toContain('__bf_len_0 = _erbout.length')
+    expect(template).toContain('__bf_prop_0 = bf.backend.mark_raw(__bf_praw_0)')
+    expect(template).toContain('"data-slot": __bf_prop_0')
+    expect(template).not.toContain('bf_prop_data')
+  })
+})

--- a/packages/adapter-erb/src/adapter/erb-adapter.ts
+++ b/packages/adapter-erb/src/adapter/erb-adapter.ts
@@ -1108,10 +1108,40 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
 
   renderComponent(comp: IRComponent): string {
     const propParts: string[] = []
+    // Named JSX-valued props OTHER than the reserved `children`
+    // (`header={<strong>Title</strong>}`, #2168 jsx-element-prop) each get
+    // their own buffer-slice capture, prepended to the final returned
+    // string below — same mechanism as the reserved children capture,
+    // just keyed by the prop's own name instead of `children`. Unlike the
+    // reserved `children` value (which the child template reads back
+    // through a structural bypass, `isChildrenValueExpr`), a named slot
+    // is read by the child through the GENERIC `bf.h(v[:name])`
+    // text-expression path — there's no name to special-case there, since
+    // any prop name is possible. So the captured HTML is wrapped in
+    // `bf.backend.mark_raw(...)` here (`BarefootJS::SafeString`,
+    // `barefoot_js.rb`) and `Context#h` unwraps it to skip re-escaping —
+    // giving ERB the same "value carries its own safety" bypass Twig's
+    // `Markup` / Kolon's `mark_raw` get from their auto-escaping `{{ }}`.
+    const namedSlotCaptures: string[] = []
     for (const p of comp.props) {
       // Skip callback props (onXxx) and `ref` — both are client-only for
       // SSR (Hono renders neither; the client JS wires them at hydration).
       if ((p.name.match(/^on[A-Z]/) || p.name === 'ref') && p.value.kind === 'expression') continue
+      if (p.value.kind === 'jsx-children' && p.name !== 'children') {
+        const prevInLoop = this.inLoop
+        this.inLoop = false
+        const slotBody = this.renderChildren(p.value.children)
+        this.inLoop = prevInLoop
+        const suffix = `${p.name}_${comp.slotId ?? 'c' + this.childrenCaptureCounter++}`
+        const lenVar = `__bf_len_${suffix}`
+        const rawVar = `__bf_praw_${suffix}`
+        const capVar = `__bf_prop_${suffix}`
+        namedSlotCaptures.push(
+          `<% ${lenVar} = _erbout.length %>${slotBody}<% ${rawVar} = _erbout.slice!(${lenVar}..); ${capVar} = bf.backend.mark_raw(${rawVar}) %>`,
+        )
+        propParts.push(`${rubySymbolKey(p.name)} ${capVar}`)
+        continue
+      }
       const lowered = emitAttrValue(p.value, this.componentPropEmitter, p.name)
       if (lowered) propParts.push(lowered)
     }
@@ -1151,10 +1181,10 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
       const lenVar = `__bf_len_${suffix}`
       const capVar = `__bf_children_${suffix}`
       const propsHash = `{ ${[...propParts, `children: ${capVar}`].join(', ')} }`
-      return `<% ${lenVar} = _erbout.length %>${childrenBody}<% ${capVar} = _erbout.slice!(${lenVar}..) %><%= bf.render_child('${tplName}', ${propsHash}) %>`
+      return `${namedSlotCaptures.join('')}<% ${lenVar} = _erbout.length %>${childrenBody}<% ${capVar} = _erbout.slice!(${lenVar}..) %><%= bf.render_child('${tplName}', ${propsHash}) %>`
     }
     const propsHash = propParts.length > 0 ? `{ ${propParts.join(', ')} }` : '{}'
-    return `<%= bf.render_child('${tplName}', ${propsHash}) %>`
+    return `${namedSlotCaptures.join('')}<%= bf.render_child('${tplName}', ${propsHash}) %>`
   }
 
   private childrenCaptureCounter = 0

--- a/packages/adapter-erb/src/adapter/erb-adapter.ts
+++ b/packages/adapter-erb/src/adapter/erb-adapter.ts
@@ -1132,7 +1132,13 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
         this.inLoop = false
         const slotBody = this.renderChildren(p.value.children)
         this.inLoop = prevInLoop
-        const suffix = `${p.name}_${comp.slotId ?? 'c' + this.childrenCaptureCounter++}`
+        // Purely counter-based — NOT derived from `p.name` or `comp.slotId`.
+        // A JSX prop name can contain characters (`data-slot`) that aren't
+        // valid in a Ruby local variable name, and `comp.slotId` alone
+        // would collide across two named-slot props on the same component
+        // invocation (unlike the reserved children slot, there's only ever
+        // one of those per invocation).
+        const suffix = `${this.childrenCaptureCounter++}`
         const lenVar = `__bf_len_${suffix}`
         const rawVar = `__bf_praw_${suffix}`
         const capVar = `__bf_prop_${suffix}`

--- a/packages/adapter-erb/src/render-divergences.ts
+++ b/packages/adapter-erb/src/render-divergences.ts
@@ -19,6 +19,4 @@ export const renderDivergences: RenderDivergences = {
     '`user?.name ?? …` on an object prop: the Ruby render exits 1 (optional chaining into a Hash prop has no lowering)',
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders but its loop item keys diverge from the reference serialisation',
-  'jsx-element-prop':
-    'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
 }

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -1390,7 +1390,40 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
             break
           }
           case 'jsx-children':
-            // Handled below via `child.childrenText` / `child.childrenHtml`.
+            // The RESERVED children slot (`comp.children.length > 0 ? comp.children
+            // : jsxChildrenPropNodes(...)`) is handled below via
+            // `child.childrenText` / `child.childrenHtml` and must not be
+            // re-emitted here. A JSX-valued prop under any OTHER name
+            // (`header={<strong>Title</strong>}`, #2168 jsx-element-prop) is a
+            // named slot — bake it the same way real children are baked
+            // (`extractTextChildren` / `extractHtmlChildren`) and emit it as
+            // its own struct field, mirroring the `Children` field's
+            // text-vs-HTML branching just below.
+            if (prop.name !== 'children') {
+              const text = this.extractTextChildren(prop.value.children)
+              if (text !== null) {
+                emitChildField(prop.name, JSON.stringify(text))
+              } else {
+                const html = this.extractHtmlChildren(prop.value.children)
+                if (html !== null) {
+                  this.state.usesHtmlTemplate = true
+                  emitChildField(prop.name, `template.HTML(${JSON.stringify(html)})`)
+                } else {
+                  // The value's root needs the PARENT's runtime scope id
+                  // (`<strong>` hoisted from the call site inherits the
+                  // caller's `bf-s`, not a bake-time constant) — same
+                  // needsScope case `childrenScopedHtmlExpr` handles for
+                  // the reserved children slot. The returned string is
+                  // already a Go concatenation expression (`"..." +
+                  // scopeID + "..."`), not a literal to re-quote.
+                  const scopedHtml = this.extractScopedHtmlChildren(prop.value.children)
+                  if (scopedHtml !== null) {
+                    this.state.usesHtmlTemplate = true
+                    emitChildField(prop.name, `template.HTML(${scopedHtml})`)
+                  }
+                }
+              }
+            }
             break
         }
       }

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -27,8 +27,6 @@ export const renderDivergences: RenderDivergences = {
     'Math.min/max/abs/floor over a signal render "0" for every value — the fractional initial value (-7.6) types the signal field as Go `int` (zero value), not `float64`. `Math.min`/`Math.max`/`Math.abs` ARE now correctly registered/lowered (this is the same root cause as `number-tofixed`, not a registry gap: `typeInfoToGo`\'s `kind: \'primitive\'` branch hard-codes any TS `number` to Go `int` and never consults the literal value, unlike the `kind: \'unknown\'` branch\'s `inferTypeFromValue` fallback)',
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)`: generated Go fails to run (exit 1) — no object-iteration loop lowering',
-  'jsx-element-prop':
-    'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
   'grandchild-composition':
     "three-level composition: the grandchild's threaded prop renders EMPTY — prop forwarding through two template-render layers loses the value",
   'child-primitive-props':

--- a/packages/adapter-jinja/src/__tests__/jinja-adapter-unit.test.ts
+++ b/packages/adapter-jinja/src/__tests__/jinja-adapter-unit.test.ts
@@ -383,6 +383,27 @@ export function C(props: { count: number }) {
   })
 })
 
+describe('JinjaAdapter - named-slot capture identifier safety (#2168 jsx-element-prop)', () => {
+  // A JSX-valued prop under a hyphenated name (`data-slot`, a valid JSX
+  // attribute name) must not leak into the `{% set %}` capture variable's
+  // identifier — Jinja variable names can't contain `-`. The capture
+  // identifier is purely counter-based (never derived from the prop name);
+  // the hash KEY passed to `render_child` still carries the real name,
+  // quoted via `jinjaHashKey`.
+  test('a hyphenated prop name does not appear in the capture variable', () => {
+    const { template } = compileAndGenerate(`
+function Card(props) { return null }
+export function Parent() {
+  return <Card data-slot={<strong>Title</strong>}>text</Card>
+}
+`)
+    expect(template).toContain('{% set bf_prop_0 %}')
+    expect(template).toContain("'data-slot': bf_prop_0")
+    expect(template).not.toContain('data-slot %}')
+    expect(template).not.toContain('data-slot_')
+  })
+})
+
 // #2038 nested-callback-predicate loudness is pinned at the shared
 // conformance layer (workstream C): `filter-nested-callback-predicate` /
 // `filter-nested-find-predicate` (BF101 via `expectedDiagnostics`) and

--- a/packages/adapter-jinja/src/adapter/jinja-adapter.ts
+++ b/packages/adapter-jinja/src/adapter/jinja-adapter.ts
@@ -1003,7 +1003,13 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
         this.inLoop = false
         const slotBody = this.renderChildren(p.value.children)
         this.inLoop = prevInLoop
-        const captureName = `bf_prop_${p.name}_${comp.slotId ?? 'c' + this.childrenCaptureCounter++}`
+        // Purely counter-based — NOT derived from `p.name` or `comp.slotId`.
+        // A JSX prop name can contain characters (`data-slot`) that aren't a
+        // valid Jinja `{% set %}` target, and `comp.slotId` alone would
+        // collide across two named-slot props on the same component
+        // invocation (unlike the reserved children slot, there's only ever
+        // one of those per invocation).
+        const captureName = `bf_prop_${this.childrenCaptureCounter++}`
         namedSlotSetBlocks.push(`{% set ${captureName} %}${slotBody}{% endset %}`)
         currentEntries().push(`${jinjaHashKey(p.name)}: ${captureName}`)
         continue

--- a/packages/adapter-jinja/src/adapter/jinja-adapter.ts
+++ b/packages/adapter-jinja/src/adapter/jinja-adapter.ts
@@ -987,11 +987,27 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
     type Segment = { kind: 'entries'; parts: string[] } | { kind: 'spread'; expr: string }
     const segments: Segment[] = [{ kind: 'entries', parts: [] }]
     const currentEntries = () => this.componentPropSegmentEntries(segments)
+    // Named JSX-valued props OTHER than the reserved `children`
+    // (`header={<strong>Title</strong>}`, #2168 jsx-element-prop) each get
+    // their own `{% set %}` capture, prepended to the final returned
+    // string below — same mechanism as the reserved children capture,
+    // just keyed by the prop's own name instead of `children`.
+    const namedSlotSetBlocks: string[] = []
 
     for (const p of comp.props) {
       // Skip callback props (onXxx) and `ref` — both are client-only for
       // SSR (Hono renders neither; the client JS wires them at hydration).
       if ((p.name.match(/^on[A-Z]/) || p.name === 'ref') && p.value.kind === 'expression') continue
+      if (p.value.kind === 'jsx-children' && p.name !== 'children') {
+        const prevInLoop = this.inLoop
+        this.inLoop = false
+        const slotBody = this.renderChildren(p.value.children)
+        this.inLoop = prevInLoop
+        const captureName = `bf_prop_${p.name}_${comp.slotId ?? 'c' + this.childrenCaptureCounter++}`
+        namedSlotSetBlocks.push(`{% set ${captureName} %}${slotBody}{% endset %}`)
+        currentEntries().push(`${jinjaHashKey(p.name)}: ${captureName}`)
+        continue
+      }
       if (p.value.kind === 'spread') {
         const trimmed = p.value.expr.trim()
         // SolidJS-style props identifier (`function(props: P)`) has no
@@ -1055,12 +1071,12 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
       const captureName = `bf_children_${comp.slotId ?? 'c' + this.childrenCaptureCounter++}`
       currentEntries().push(`${jinjaHashKey('children')}: ${captureName}`)
       const dict = this.combineComponentPropSegments(segments)
-      return `{% set ${captureName} %}${childrenBody}{% endset %}{{ bf.render_child('${tplName}', ${dict}) | safe }}`
+      return `${namedSlotSetBlocks.join('')}{% set ${captureName} %}${childrenBody}{% endset %}{{ bf.render_child('${tplName}', ${dict}) | safe }}`
     }
 
     const isEmpty = segments.every(s => s.kind === 'entries' && s.parts.length === 0)
     const dictEntries = isEmpty ? '' : `, ${this.combineComponentPropSegments(segments)}`
-    return `{{ bf.render_child('${tplName}'${dictEntries}) | safe }}`
+    return `${namedSlotSetBlocks.join('')}{{ bf.render_child('${tplName}'${dictEntries}) | safe }}`
   }
 
   private childrenCaptureCounter = 0

--- a/packages/adapter-jinja/src/render-divergences.ts
+++ b/packages/adapter-jinja/src/render-divergences.ts
@@ -17,6 +17,4 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 export const renderDivergences: RenderDivergences = {
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
-  'jsx-element-prop':
-    'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
 }

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -1902,3 +1902,23 @@ export function C() {
     expect(deferred.template).not.toContain('data-x')
   })
 })
+
+describe('MojoAdapter - named-slot capture identifier safety (#2168 jsx-element-prop)', () => {
+  // A JSX-valued prop under a hyphenated name (`data-slot`, a valid JSX
+  // attribute name) must not leak into the `begin %>...<% end` capture
+  // variable — Perl variable tokens can't contain `-`. The capture
+  // variable is purely counter-based (never derived from the prop name);
+  // the hash KEY passed to `render_child` still carries the real name,
+  // quoted via `perlHashKey`.
+  test('a hyphenated prop name does not appear in the capture variable', () => {
+    const { template } = compileAndGenerate(`
+function Card(props) { return null }
+export function Parent() {
+  return <Card data-slot={<strong>Title</strong>}>text</Card>
+}
+`)
+    expect(template).toContain('<% my $bf_prop_0 = begin %>')
+    expect(template).toContain("'data-slot' => $bf_prop_0")
+    expect(template).not.toContain('$bf_prop_data')
+  })
+})

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1081,7 +1081,13 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
         this.inLoop = false
         const slotBody = this.renderChildren(p.value.children)
         this.inLoop = prevInLoop
-        const varName = `$bf_prop_${p.name}_${comp.slotId ?? 'c' + this.childrenCaptureCounter++}`
+        // Purely counter-based — NOT derived from `p.name` or `comp.slotId`.
+        // A JSX prop name can contain characters (`data-slot`) that aren't a
+        // valid Perl variable token, and `comp.slotId` alone would collide
+        // across two named-slot props on the same component invocation
+        // (unlike the reserved children slot, there's only ever one of
+        // those per invocation).
+        const varName = `$bf_prop_${this.childrenCaptureCounter++}`
         namedSlotCaptures.push(`<% my ${varName} = begin %>${slotBody}<% end %>`)
         propParts.push(`${perlHashKey(p.name)} => ${varName}`)
         continue

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -1062,10 +1062,30 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
 
   renderComponent(comp: IRComponent): string {
     const propParts: string[] = []
+    // Named JSX-valued props OTHER than the reserved `children`
+    // (`header={<strong>Title</strong>}`, #2168 jsx-element-prop) get the
+    // same `begin %>…<% end` capture as the reserved children slot below,
+    // just keyed by the prop's own name. `render_child` (BarefootJS.pm)
+    // materializes every prop value that's a CODE ref — not only
+    // `children` — into the Mojo::ByteStream the capture block produces,
+    // so the child's read of the slot back out (`<%= $header %>`) sees an
+    // already-safe ByteStream and Mojo::Template's auto-escape passes it
+    // through unescaped, the same way it already does for `children`.
+    const namedSlotCaptures: string[] = []
     for (const p of comp.props) {
       // Skip callback props (onXxx) and `ref` — both are client-only for
       // SSR (Hono renders neither; the client JS wires them at hydration).
       if ((p.name.match(/^on[A-Z]/) || p.name === 'ref') && p.value.kind === 'expression') continue
+      if (p.value.kind === 'jsx-children' && p.name !== 'children') {
+        const prevInLoop = this.inLoop
+        this.inLoop = false
+        const slotBody = this.renderChildren(p.value.children)
+        this.inLoop = prevInLoop
+        const varName = `$bf_prop_${p.name}_${comp.slotId ?? 'c' + this.childrenCaptureCounter++}`
+        namedSlotCaptures.push(`<% my ${varName} = begin %>${slotBody}<% end %>`)
+        propParts.push(`${perlHashKey(p.name)} => ${varName}`)
+        continue
+      }
       const lowered = emitAttrValue(p.value, this.componentPropEmitter, p.name)
       if (lowered) propParts.push(lowered)
     }
@@ -1103,9 +1123,9 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       const childrenBody = this.renderChildren(effectiveChildren)
       this.inLoop = prevInLoop
       const varName = `$bf_children_${comp.slotId ?? 'c' + this.childrenCaptureCounter++}`
-      return `<% my ${varName} = begin %>${childrenBody}<% end %><%== bf->render_child('${tplName}'${propsStr}, children => ${varName}) %>`
+      return `${namedSlotCaptures.join('')}<% my ${varName} = begin %>${childrenBody}<% end %><%== bf->render_child('${tplName}'${propsStr}, children => ${varName}) %>`
     }
-    return `<%== bf->render_child('${tplName}'${propsStr}) %>`
+    return `${namedSlotCaptures.join('')}<%== bf->render_child('${tplName}'${propsStr}) %>`
   }
 
   private childrenCaptureCounter = 0

--- a/packages/adapter-mojolicious/src/render-divergences.ts
+++ b/packages/adapter-mojolicious/src/render-divergences.ts
@@ -17,6 +17,4 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 export const renderDivergences: RenderDivergences = {
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
-  'jsx-element-prop':
-    'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
 }

--- a/packages/adapter-perl/lib/BarefootJS.pm
+++ b/packages/adapter-perl/lib/BarefootJS.pm
@@ -303,16 +303,17 @@ sub render_child ($self, $name, @args) {
     # Template languages whose method calls can't splat a hash into positional
     # args (Text::Xslate Kolon, Template Toolkit) pass one hashref instead.
     my %props = (@args == 1 && ref $args[0] eq 'HASH') ? %{ $args[0] } : @args;
-    # JSX children come in via the engine's children-capture mechanism
-    # (Mojo's `begin %>...<% end`, which produces a CODE ref returning a
-    # Mojo::ByteStream). Materialize it through the backend before handing
-    # the props to the child renderer so the child template sees
-    # `$children` as already-rendered HTML. Guard on `exists` so a
-    # childless invocation (`bf->render_child('counter')`) doesn't gain a
-    # spurious `children => undef` key — preserving the historical "only
-    # touch children when present" behaviour.
-    $props{children} = $self->backend->materialize($props{children})
-        if exists $props{children};
+    # JSX children AND any other named JSX-valued slot (`header={<strong/>}`,
+    # #2168 jsx-element-prop) come in via the engine's children-capture
+    # mechanism (Mojo's `begin %>...<% end`, which produces a CODE ref
+    # returning a Mojo::ByteStream). Materialize every prop value through
+    # the backend before handing the props to the child renderer, so the
+    # child template sees each slot as already-rendered HTML rather than a
+    # bare CODE ref — `materialize` is a no-op for a value that isn't a
+    # CODE ref (see e.g. `BarefootJS::Backend::Mojo::materialize`), so this
+    # is safe to apply unconditionally rather than naming `children`
+    # specifically.
+    $props{$_} = $self->backend->materialize($props{$_}) for keys %props;
     # Renderer contract (#1897): the renderer is invoked with TWO
     # arguments — the props hashref and the INVOKING instance. A renderer
     # registered on the root may be called from a nested child render

--- a/packages/adapter-rust/src/__tests__/minijinja-adapter-unit.test.ts
+++ b/packages/adapter-rust/src/__tests__/minijinja-adapter-unit.test.ts
@@ -385,6 +385,27 @@ export function C(props: { count: number }) {
   })
 })
 
+describe('MinijinjaAdapter - named-slot capture identifier safety (#2168 jsx-element-prop)', () => {
+  // A JSX-valued prop under a hyphenated name (`data-slot`, a valid JSX
+  // attribute name) must not leak into the `{% set %}` capture variable's
+  // identifier — minijinja variable names can't contain `-`. The capture
+  // identifier is purely counter-based (never derived from the prop name);
+  // the hash KEY passed to `render_child` still carries the real name,
+  // quoted via `minijinjaHashKey`.
+  test('a hyphenated prop name does not appear in the capture variable', () => {
+    const { template } = compileAndGenerate(`
+function Card(props) { return null }
+export function Parent() {
+  return <Card data-slot={<strong>Title</strong>}>text</Card>
+}
+`)
+    expect(template).toContain('{% set bf_prop_0 %}')
+    expect(template).toContain("'data-slot': bf_prop_0")
+    expect(template).not.toContain('data-slot %}')
+    expect(template).not.toContain('data-slot_')
+  })
+})
+
 // #2038 nested-callback-predicate loudness is pinned at the shared
 // conformance layer (workstream C): `filter-nested-callback-predicate` /
 // `filter-nested-find-predicate` (BF101 via `expectedDiagnostics`) and

--- a/packages/adapter-rust/src/adapter/minijinja-adapter.ts
+++ b/packages/adapter-rust/src/adapter/minijinja-adapter.ts
@@ -1030,11 +1030,27 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
     type Segment = { kind: 'entries'; parts: string[] } | { kind: 'spread'; expr: string }
     const segments: Segment[] = [{ kind: 'entries', parts: [] }]
     const currentEntries = () => this.componentPropSegmentEntries(segments)
+    // Named JSX-valued props OTHER than the reserved `children`
+    // (`header={<strong>Title</strong>}`, #2168 jsx-element-prop) each get
+    // their own `{% set %}` capture, prepended to the final returned
+    // string below — same mechanism as the reserved children capture,
+    // just keyed by the prop's own name instead of `children`.
+    const namedSlotSetBlocks: string[] = []
 
     for (const p of comp.props) {
       // Skip callback props (onXxx) and `ref` — both are client-only for
       // SSR (Hono renders neither; the client JS wires them at hydration).
       if ((p.name.match(/^on[A-Z]/) || p.name === 'ref') && p.value.kind === 'expression') continue
+      if (p.value.kind === 'jsx-children' && p.name !== 'children') {
+        const prevInLoop = this.inLoop
+        this.inLoop = false
+        const slotBody = this.renderChildren(p.value.children)
+        this.inLoop = prevInLoop
+        const captureName = `bf_prop_${p.name}_${comp.slotId ?? 'c' + this.childrenCaptureCounter++}`
+        namedSlotSetBlocks.push(`{% set ${captureName} %}${slotBody}{% endset %}`)
+        currentEntries().push(`${minijinjaHashKey(p.name)}: ${captureName}`)
+        continue
+      }
       if (p.value.kind === 'spread') {
         const trimmed = p.value.expr.trim()
         // SolidJS-style props identifier (`function(props: P)`) has no
@@ -1098,12 +1114,12 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
       const captureName = `bf_children_${comp.slotId ?? 'c' + this.childrenCaptureCounter++}`
       currentEntries().push(`${minijinjaHashKey('children')}: ${captureName}`)
       const dict = this.combineComponentPropSegments(segments)
-      return `{% set ${captureName} %}${childrenBody}{% endset %}{{ bf.render_child('${tplName}', ${dict}) | safe }}`
+      return `${namedSlotSetBlocks.join('')}{% set ${captureName} %}${childrenBody}{% endset %}{{ bf.render_child('${tplName}', ${dict}) | safe }}`
     }
 
     const isEmpty = segments.every(s => s.kind === 'entries' && s.parts.length === 0)
     const dictEntries = isEmpty ? '' : `, ${this.combineComponentPropSegments(segments)}`
-    return `{{ bf.render_child('${tplName}'${dictEntries}) | safe }}`
+    return `${namedSlotSetBlocks.join('')}{{ bf.render_child('${tplName}'${dictEntries}) | safe }}`
   }
 
   private childrenCaptureCounter = 0

--- a/packages/adapter-rust/src/adapter/minijinja-adapter.ts
+++ b/packages/adapter-rust/src/adapter/minijinja-adapter.ts
@@ -1046,7 +1046,13 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
         this.inLoop = false
         const slotBody = this.renderChildren(p.value.children)
         this.inLoop = prevInLoop
-        const captureName = `bf_prop_${p.name}_${comp.slotId ?? 'c' + this.childrenCaptureCounter++}`
+        // Purely counter-based — NOT derived from `p.name` or `comp.slotId`.
+        // A JSX prop name can contain characters (`data-slot`) that aren't a
+        // valid minijinja `{% set %}` target, and `comp.slotId` alone would
+        // collide across two named-slot props on the same component
+        // invocation (unlike the reserved children slot, there's only ever
+        // one of those per invocation).
+        const captureName = `bf_prop_${this.childrenCaptureCounter++}`
         namedSlotSetBlocks.push(`{% set ${captureName} %}${slotBody}{% endset %}`)
         currentEntries().push(`${minijinjaHashKey(p.name)}: ${captureName}`)
         continue

--- a/packages/adapter-rust/src/render-divergences.ts
+++ b/packages/adapter-rust/src/render-divergences.ts
@@ -19,6 +19,4 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 export const renderDivergences: RenderDivergences = {
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
-  'jsx-element-prop':
-    'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
 }

--- a/packages/adapter-twig/src/__tests__/twig-adapter-unit.test.ts
+++ b/packages/adapter-twig/src/__tests__/twig-adapter-unit.test.ts
@@ -381,6 +381,27 @@ export function C(props: { count: number }) {
   })
 })
 
+describe('TwigAdapter - named-slot capture identifier safety (#2168 jsx-element-prop)', () => {
+  // A JSX-valued prop under a hyphenated name (`data-slot`, a valid JSX
+  // attribute name) must not leak into the `{% set %}` capture variable's
+  // identifier — Twig variable names can't contain `-`. The capture
+  // identifier is purely counter-based (never derived from the prop name);
+  // the hash KEY passed to `render_child` still carries the real name,
+  // quoted via `twigHashKey`.
+  test('a hyphenated prop name does not appear in the capture variable', () => {
+    const { template } = compileAndGenerate(`
+function Card(props) { return null }
+export function Parent() {
+  return <Card data-slot={<strong>Title</strong>}>text</Card>
+}
+`)
+    expect(template).toContain('{% set bf_prop_0 %}')
+    expect(template).toContain("'data-slot': bf_prop_0")
+    expect(template).not.toContain('data-slot %}')
+    expect(template).not.toContain('data-slot_')
+  })
+})
+
 // #2038 nested-callback-predicate loudness is pinned at the shared
 // conformance layer (workstream C): `filter-nested-callback-predicate` /
 // `filter-nested-find-predicate` (BF101 via `expectedDiagnostics`) and

--- a/packages/adapter-twig/src/adapter/twig-adapter.ts
+++ b/packages/adapter-twig/src/adapter/twig-adapter.ts
@@ -1021,11 +1021,27 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
     type Segment = { kind: 'entries'; parts: string[] } | { kind: 'spread'; expr: string }
     const segments: Segment[] = [{ kind: 'entries', parts: [] }]
     const currentEntries = () => this.componentPropSegmentEntries(segments)
+    // Named JSX-valued props OTHER than the reserved `children`
+    // (`header={<strong>Title</strong>}`, #2168 jsx-element-prop) each get
+    // their own `{% set %}` capture, prepended to the final returned
+    // string below — same mechanism as the reserved children capture,
+    // just keyed by the prop's own name instead of `children`.
+    const namedSlotSetBlocks: string[] = []
 
     for (const p of comp.props) {
       // Skip callback props (onXxx) and `ref` — both are client-only for
       // SSR (Hono renders neither; the client JS wires them at hydration).
       if ((p.name.match(/^on[A-Z]/) || p.name === 'ref') && p.value.kind === 'expression') continue
+      if (p.value.kind === 'jsx-children' && p.name !== 'children') {
+        const prevInLoop = this.inLoop
+        this.inLoop = false
+        const slotBody = this.renderChildren(p.value.children)
+        this.inLoop = prevInLoop
+        const captureName = `bf_prop_${p.name}_${comp.slotId ?? 'c' + this.childrenCaptureCounter++}`
+        namedSlotSetBlocks.push(`{% set ${captureName} %}${slotBody}{% endset %}`)
+        currentEntries().push(`${twigHashKey(p.name)}: ${captureName}`)
+        continue
+      }
       if (p.value.kind === 'spread') {
         const trimmed = p.value.expr.trim()
         // SolidJS-style props identifier (`function(props: P)`) has no
@@ -1100,12 +1116,12 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
       const captureName = `bf_children_${comp.slotId ?? 'c' + this.childrenCaptureCounter++}`
       currentEntries().push(`${twigHashKey('children')}: ${captureName}`)
       const dict = this.combineComponentPropSegments(segments)
-      return `{% set ${captureName} %}${childrenBody}{% endset %}{{ bf.render_child('${tplName}', ${dict}) | raw }}`
+      return `${namedSlotSetBlocks.join('')}{% set ${captureName} %}${childrenBody}{% endset %}{{ bf.render_child('${tplName}', ${dict}) | raw }}`
     }
 
     const isEmpty = segments.every(s => s.kind === 'entries' && s.parts.length === 0)
     const dictEntries = isEmpty ? '' : `, ${this.combineComponentPropSegments(segments)}`
-    return `{{ bf.render_child('${tplName}'${dictEntries}) | raw }}`
+    return `${namedSlotSetBlocks.join('')}{{ bf.render_child('${tplName}'${dictEntries}) | raw }}`
   }
 
   private childrenCaptureCounter = 0

--- a/packages/adapter-twig/src/adapter/twig-adapter.ts
+++ b/packages/adapter-twig/src/adapter/twig-adapter.ts
@@ -1037,7 +1037,13 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
         this.inLoop = false
         const slotBody = this.renderChildren(p.value.children)
         this.inLoop = prevInLoop
-        const captureName = `bf_prop_${p.name}_${comp.slotId ?? 'c' + this.childrenCaptureCounter++}`
+        // Purely counter-based — NOT derived from `p.name` or `comp.slotId`.
+        // A JSX prop name can contain characters (`data-slot`) that aren't a
+        // valid Twig variable name, and `comp.slotId` alone would collide
+        // across two named-slot props on the same component invocation
+        // (unlike the reserved children slot, there's only ever one of
+        // those per invocation).
+        const captureName = `bf_prop_${this.childrenCaptureCounter++}`
         namedSlotSetBlocks.push(`{% set ${captureName} %}${slotBody}{% endset %}`)
         currentEntries().push(`${twigHashKey(p.name)}: ${captureName}`)
         continue

--- a/packages/adapter-twig/src/render-divergences.ts
+++ b/packages/adapter-twig/src/render-divergences.ts
@@ -17,6 +17,4 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 export const renderDivergences: RenderDivergences = {
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
-  'jsx-element-prop':
-    'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
 }

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -396,6 +396,26 @@ export { A }
   })
 })
 
+describe('XslateAdapter - named-slot capture identifier safety (#2168 jsx-element-prop)', () => {
+  // A JSX-valued prop under a hyphenated name (`data-slot`, a valid JSX
+  // attribute name) must not leak into the Kolon macro's identifier — Kolon
+  // macro names can't contain `-`. The macro name is purely counter-based
+  // (never derived from the prop name); the hash KEY passed to
+  // `render_child` still carries the real name, quoted via `kolonHashKey`.
+  test('a hyphenated prop name does not appear in the macro name', () => {
+    const { template } = compileAndGenerate(`
+function Card(props) { return null }
+export function Parent() {
+  return <Card data-slot={<strong>Title</strong>}>text</Card>
+}
+`)
+    expect(template).toContain('<: macro bf_prop_0 -> ()')
+    expect(template).toContain("'data-slot' => bf_prop_0()")
+    expect(template).not.toContain('data-slot -> ()')
+    expect(template).not.toContain('data-slot_')
+  })
+})
+
 // #2038 nested-callback-predicate loudness is pinned at the shared
 // conformance layer: `filter-nested-callback-predicate` /
 // `filter-nested-find-predicate` (BF101 via `expectedDiagnostics` above) and

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -961,9 +961,15 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
         this.inLoop = false
         const slotBody = this.renderChildren(p.value.children)
         this.inLoop = prevInLoop
-        const macroName = `bf_prop_${p.name}_${comp.slotId ?? 'c' + this.childrenCaptureCounter++}`
+        // Purely counter-based — NOT derived from `p.name` or `comp.slotId`.
+        // A JSX prop name can contain characters (`data-slot`) that aren't a
+        // valid Kolon macro identifier, and `comp.slotId` alone would
+        // collide across two named-slot props on the same component
+        // invocation (unlike the reserved children slot, there's only ever
+        // one of those per invocation).
+        const macroName = `bf_prop_${this.childrenCaptureCounter++}`
         namedSlotMacros.push(`<: macro ${macroName} -> () { :>${slotBody}<: } :>`)
-        currentEntries().push(`${p.name} => ${macroName}()`)
+        currentEntries().push(`${kolonHashKey(p.name)} => ${macroName}()`)
         continue
       }
       if (p.value.kind === 'spread') {

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -945,11 +945,27 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     type Segment = { kind: 'entries'; parts: string[] } | { kind: 'spread'; expr: string }
     const segments: Segment[] = [{ kind: 'entries', parts: [] }]
     const currentEntries = () => this.componentPropSegmentEntries(segments)
+    // Named JSX-valued props OTHER than the reserved `children`
+    // (`header={<strong>Title</strong>}`, #2168 jsx-element-prop) each get
+    // their own macro, prepended to the final returned string below —
+    // same mechanism as the reserved children macro, just keyed by the
+    // prop's own name instead of `children`.
+    const namedSlotMacros: string[] = []
 
     for (const p of comp.props) {
       // Skip callback props (onXxx) and `ref` — both are client-only for
       // SSR (Hono renders neither; the client JS wires them at hydration).
       if ((p.name.match(/^on[A-Z]/) || p.name === 'ref') && p.value.kind === 'expression') continue
+      if (p.value.kind === 'jsx-children' && p.name !== 'children') {
+        const prevInLoop = this.inLoop
+        this.inLoop = false
+        const slotBody = this.renderChildren(p.value.children)
+        this.inLoop = prevInLoop
+        const macroName = `bf_prop_${p.name}_${comp.slotId ?? 'c' + this.childrenCaptureCounter++}`
+        namedSlotMacros.push(`<: macro ${macroName} -> () { :>${slotBody}<: } :>`)
+        currentEntries().push(`${p.name} => ${macroName}()`)
+        continue
+      }
       if (p.value.kind === 'spread') {
         const trimmed = p.value.expr.trim()
         // SolidJS-style props identifier (`function(props: P)`) has no
@@ -1009,12 +1025,12 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
       const macroName = `bf_children_${comp.slotId ?? 'c' + this.childrenCaptureCounter++}`
       currentEntries().push(`children => ${macroName}()`)
       const dict = this.combineComponentPropSegments(segments)
-      return `<: macro ${macroName} -> () { :>${childrenBody}<: } :><: $bf.render_child('${tplName}', ${dict}) | mark_raw :>`
+      return `${namedSlotMacros.join('')}<: macro ${macroName} -> () { :>${childrenBody}<: } :><: $bf.render_child('${tplName}', ${dict}) | mark_raw :>`
     }
 
     const isEmpty = segments.every(s => s.kind === 'entries' && s.parts.length === 0)
     const hashEntries = isEmpty ? '' : `, ${this.combineComponentPropSegments(segments)}`
-    return `<: $bf.render_child('${tplName}'${hashEntries}) | mark_raw :>`
+    return `${namedSlotMacros.join('')}<: $bf.render_child('${tplName}'${hashEntries}) | mark_raw :>`
   }
 
   private childrenCaptureCounter = 0

--- a/packages/adapter-xslate/src/render-divergences.ts
+++ b/packages/adapter-xslate/src/render-divergences.ts
@@ -17,6 +17,4 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 export const renderDivergences: RenderDivergences = {
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations',
-  'jsx-element-prop':
-    'a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped',
 }

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2058,40 +2058,6 @@
           "reason": "three-level composition: the grandchild's threaded prop renders EMPTY — prop forwarding through two template-render layers loses the value"
         }
       },
-      "jsx-element-prop": {
-        "blade": {
-          "kind": "render",
-          "reason": "a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped"
-        },
-        "erb": {
-          "kind": "render",
-          "reason": "a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped"
-        },
-        "go-template": {
-          "kind": "render",
-          "reason": "a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped"
-        },
-        "jinja": {
-          "kind": "render",
-          "reason": "a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped"
-        },
-        "minijinja": {
-          "kind": "render",
-          "reason": "a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped"
-        },
-        "mojolicious": {
-          "kind": "render",
-          "reason": "a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped"
-        },
-        "twig": {
-          "kind": "render",
-          "reason": "a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped"
-        },
-        "xslate": {
-          "kind": "render",
-          "reason": "a JSX element passed as a NON-children prop renders an empty slot — the element value is silently dropped"
-        }
-      },
       "math-methods": {
         "go-template": {
           "kind": "render",


### PR DESCRIPTION
## Summary

Fixes the `jsx-element-prop` render divergence (#2168 sweep) on all 8 template adapters: a JSX element passed as a non-`children` prop (`<Card header={<strong>Title</strong>}>` — the slot / render-prop-lite pattern) previously rendered an empty slot or dropped the value silently.

- Every adapter already has a mechanism to forward the reserved `children` slot from a parent template into a child render (a captured buffer slice, a `{% set %}` block, a Kolon macro, a Go struct field, ...). This PR reuses that exact same mechanism for a JSX-valued prop under any OTHER name, keyed by the prop's own name instead of `children` — no new shared capture path invented.
- **Go**: bakes the value the same way real children are baked (`extractTextChildren` / `extractHtmlChildren`, falling back to `extractScopedHtmlChildren` when the root needs the parent's runtime scope id) and emits it as its own struct field.
- **Jinja / Twig / Rust (minijinja)**: a `{% set captureName %}...{% endset %}` block per named slot, passed as a dict/hash entry.
- **Text::Xslate**: a Kolon `macro NAME -> () { ... }` per named slot, called immediately in the hash literal.
- **Blade**: a PHP output-buffering capture (`ob_start()` / `ob_get_clean()`), wrapped in `$bf->backend->mark_raw(...)`.
- **Mojolicious**: a `begin %>...<% end` capture passed into `render_child`'s named-arg list. The shared `BarefootJS.pm` runtime's `render_child` now materializes *every* prop value (previously only the reserved `children` key) — a no-op for any value that isn't a captured CODE ref, so this generalizes safely to Text::Xslate too.
- **ERB**: the same output-buffer-slice capture already used for `children`, but ERB's `<%=` (unlike every other adapter's template tag) has no built-in "safe string" wrapper to bypass escaping on read-back — so the runtime gains one: a new `BarefootJS::SafeString` marker class, returned by `Backend::Erb#mark_raw` (previously an identity no-op) and recognized by `Context#h` to skip re-escaping already-forwarded HTML.

`jsx-element-prop` graduates from a render divergence to a passing render on all 8 template adapters; `ui/compat.lock.json` and the divergence declarations are updated accordingly.

Stacked on #2186 (math-methods).

## Test plan

- [x] `bun run build` (full monorepo) + `GOTOOLCHAIN=go1.25.6 bun run compat:lock` — clean diff, only `jsx-element-prop` entries removed
- [x] Go adapter suite (real `go test` via `GOTOOLCHAIN=go1.25.6`): 725 pass, 0 fail
- [x] Jinja adapter suite (real Jinja2): 516 pass, 0 fail
- [x] Text::Xslate adapter suite (real Xslate): 517 pass, 0 fail
- [x] Twig adapter suite (real Twig): 516 pass, 0 fail
- [x] Blade adapter suite (real Blade): 516 pass, 0 fail
- [x] Rust (minijinja) adapter suite (real `bf-render` binary): 516 pass, 0 fail
- [x] ERB adapter suite (real stdlib ERB): 490 pass, 2 skip, 0 fail, plus full Ruby unit-test suite (`test/*.rb`)
- [x] Mojolicious adapter suite (real Mojolicious): 687 pass, 15 skip, 0 fail, plus full Perl unit-test suite (`t/*.t`)
- [x] `bun run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_017ZXzQWvSKLUUrTAZ3vph1j)_