### PR TITLE
Fix optional-chaining-prop divergence on Go and ERB

### DIFF
--- a/.changeset/optional-chaining-prop.md
+++ b/.changeset/optional-chaining-prop.md
@@ -18,6 +18,6 @@ Go and ERB act on the flag:
 - **Go**: an `optional` access routes through the runtime's existing nil-safe reflection getter (`bf_get`/`getFieldValue`, `bf.go`) instead of a literal `.Field` dot-chain, which panics evaluating a field on a nil interface/pointer (`nil pointer evaluating interface {}.Name`).
 - **ERB**: an `optional` access emits Ruby's native safe-navigation form (`obj&.[](:key)`) instead of plain `obj[:key]`, which raises `NoMethodError` on a `nil` receiver.
 
-Both routes only guard the single hop actually written with `?.` — a following plain `.c` after an optional `a?.b` is not (yet) short-circuited, matching JS's whole-chain semantics; see the `member` variant's docstring.
+Both routes only guard the single hop actually written with `?.` — a following plain `.c` after an optional `a?.b` is not (yet) short-circuited, so this does not yet match JS's whole-chain short-circuit semantics; see the `member` variant's docstring.
 
 `optional-chaining-prop` graduates from a render divergence to a passing render on both adapters.

--- a/.changeset/optional-chaining-prop.md
+++ b/.changeset/optional-chaining-prop.md
@@ -1,0 +1,23 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/jinja": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+"@barefootjs/twig": patch
+"@barefootjs/blade": patch
+"@barefootjs/rust": patch
+"@barefootjs/erb": patch
+"@barefootjs/go-template": patch
+---
+
+Fix `user?.name ?? '…'` (optional chaining into an object-shaped prop) failing at render time on the Go and Ruby ERB adapters.
+
+The shared `ParsedExpr` `member` variant gains an `optional: boolean` field, set from the source `?.` token (`ts.isPropertyAccessExpression`/`ts.isElementAccessExpression`'s `questionDotToken`) and threaded through every rewrite/copy site so it survives destructure and callback-body rewrites. `ParsedExprEmitter.member()` now receives this flag; six of the eight adapters (Jinja, Twig, minijinja, Text::Xslate, Blade, Mojolicious) ignore it outright because their existing member-access lowering is already null-safe by construction — Jinja/Twig/minijinja/Xslate's `[]`/`.` accessor swallows a `None`/`undef` receiver, and Blade already routes every access through the null-safe `data_get()` helper.
+
+Go and ERB act on the flag:
+- **Go**: an `optional` access routes through the runtime's existing nil-safe reflection getter (`bf_get`/`getFieldValue`, `bf.go`) instead of a literal `.Field` dot-chain, which panics evaluating a field on a nil interface/pointer (`nil pointer evaluating interface {}.Name`).
+- **ERB**: an `optional` access emits Ruby's native safe-navigation form (`obj&.[](:key)`) instead of plain `obj[:key]`, which raises `NoMethodError` on a `nil` receiver.
+
+Both routes only guard the single hop actually written with `?.` — a following plain `.c` after an optional `a?.b` is not (yet) short-circuited, matching JS's whole-chain semantics; see the `member` variant's docstring.
+
+`optional-chaining-prop` graduates from a render divergence to a passing render on both adapters.

--- a/packages/adapter-blade/src/adapter/expr/emitters.ts
+++ b/packages/adapter-blade/src/adapter/expr/emitters.ts
@@ -176,7 +176,7 @@ export class BladeFilterEmitter implements ParsedExprEmitter {
     return String(value)
   }
 
-  member(object: ParsedExpr, property: string, _computed: boolean, emit: (e: ParsedExpr) => string): string {
+  member(object: ParsedExpr, property: string, _computed: boolean, _optional: boolean, emit: (e: ParsedExpr) => string): string {
     // `.length` — route through `$bf->length` (handles both array element
     // count and string char count, JS-compatibly).
     if (property === 'length') {
@@ -346,7 +346,7 @@ export class BladeTopLevelEmitter implements ParsedExprEmitter {
     return String(value)
   }
 
-  member(object: ParsedExpr, property: string, _computed: boolean, emit: (e: ParsedExpr) => string): string {
+  member(object: ParsedExpr, property: string, _computed: boolean, _optional: boolean, emit: (e: ParsedExpr) => string): string {
     // `props.x` flattens to the bare context var the SSR caller binds each
     // prop to (props arrive as individual top-level context entries, not a
     // nested `props` hash).

--- a/packages/adapter-erb/src/adapter/expr/emitters.ts
+++ b/packages/adapter-erb/src/adapter/expr/emitters.ts
@@ -123,11 +123,19 @@ export class ErbFilterEmitter implements ParsedExprEmitter {
     return String(value)
   }
 
-  member(object: ParsedExpr, property: string, _computed: boolean, emit: (e: ParsedExpr) => string): string {
+  member(object: ParsedExpr, property: string, _computed: boolean, optional: boolean, emit: (e: ParsedExpr) => string): string {
     // `.length` needs no special higher-order form here — see the file
     // docstring's simplification (2): `.select { ... }.length` just works
     // in Ruby, unlike Perl's anonymous-arrayref `scalar(@{...})` detour.
     if (property === 'length') return `${emit(object)}.length`
+    // A `?.`-written access (`user?.name`, #2168 optional-chaining-prop):
+    // Ruby's own `nil[:key]` raises `NoMethodError` (unlike Hash#[] on a
+    // present Hash) — `&.` is Ruby's native safe-navigation operator, and
+    // `&.[](...)` is its explicit-method form for indexing rather than a
+    // dotted method call. Only guards the single written `?.` hop, not a
+    // JS-style whole-chain short-circuit — see the `ParsedExpr` `member`
+    // variant's docstring for the multi-hop caveat.
+    if (optional) return `${emit(object)}&.[](${rubySymbolLiteral(property)})`
     return `${emit(object)}[${rubySymbolLiteral(property)}]`
   }
 
@@ -323,7 +331,7 @@ export class ErbTopLevelEmitter implements ParsedExprEmitter {
     return String(value)
   }
 
-  member(object: ParsedExpr, property: string, _computed: boolean, emit: (e: ParsedExpr) => string): string {
+  member(object: ParsedExpr, property: string, _computed: boolean, optional: boolean, emit: (e: ParsedExpr) => string): string {
     // `props.x` flattens to the `v[:x]` the ERB SSR caller seeds each prop
     // under (props arrive as vars-Hash entries, not a nested `props` Hash).
     if (object.kind === 'identifier' && object.name === 'props') {
@@ -339,6 +347,11 @@ export class ErbTopLevelEmitter implements ParsedExprEmitter {
     }
     const obj = emit(object)
     if (property === 'length') return `${obj}.length`
+    // A `?.`-written access (`user?.name`, #2168 optional-chaining-prop):
+    // see `ErbFilterEmitter.member()`'s comment above for why `&.[](...)`
+    // (not a dotted `&.name`) is the right safe-nav form for a Hash-keyed
+    // prop, and for the single-hop caveat.
+    if (optional) return `${obj}&.[](${rubySymbolLiteral(property)})`
     return `${obj}[${rubySymbolLiteral(property)}]`
   }
 

--- a/packages/adapter-erb/src/render-divergences.ts
+++ b/packages/adapter-erb/src/render-divergences.ts
@@ -15,8 +15,6 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
-  'optional-chaining-prop':
-    '`user?.name ?? …` on an object prop: the Ruby render exits 1 (optional chaining into a Hash prop has no lowering)',
   'object-entries-map':
     '`Object.entries(prop).map(([k, v]) => …)` renders but its loop item keys diverge from the reference serialisation',
 }

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -3070,6 +3070,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     object: ParsedExpr,
     property: string,
     _computed: boolean,
+    optional: boolean,
     emit: (e: ParsedExpr) => string,
   ): string {
     // .length on a `.filter(...)` callback call → len (bf_filter ...)
@@ -3160,6 +3161,21 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
     const obj = emit(object)
     if (property === 'length') return `len ${obj}`
+    // A `?.`-written access (`user?.name`, #2168 optional-chaining-prop):
+    // a plain `.Field` dot-chain panics evaluating a field on a nil
+    // interface/pointer (`nil pointer evaluating interface {}.Name`), so
+    // route through the runtime's existing nil-safe reflection-based
+    // getter instead — `bf_get`/`getFieldValue` (bf.go), already used for
+    // map-rooted context chains above, guards the nil case and returns Go
+    // `nil` (which `or`/`bf.truthy?`-style fallbacks treat as falsy) —
+    // unlike that map-rooted call site, this passes the Go-cased field
+    // name (`goFieldNameForKey`), matching `getFieldValue`'s struct-branch
+    // exact-match fast path. Only guards the single written `?.` hop, not
+    // a JS-style whole-chain short-circuit — see the `ParsedExpr` `member`
+    // variant's docstring for the multi-hop caveat.
+    if (optional) {
+      return `bf_get ${wrapIfMultiToken(obj)} ${JSON.stringify(goFieldNameForKey(property))}`
+    }
     return `${obj}.${goFieldNameForKey(property)}`
   }
 

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -19,8 +19,6 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 export const renderDivergences: RenderDivergences = {
   'string-concat-plus':
     "`'Hello, ' + name` renders \"0\" — JS string-concat `+` lowered through numeric addition",
-  'optional-chaining-prop':
-    '`user?.name ?? …` on an object prop: generated Go fails to run (exit 1) — optional chaining into a struct/map prop has no lowering',
   'number-tofixed':
     '`.toFixed(2)` on a number PROP: generated Go fails to run (exit 1)',
   'math-methods':

--- a/packages/adapter-jinja/src/adapter/expr/emitters.ts
+++ b/packages/adapter-jinja/src/adapter/expr/emitters.ts
@@ -141,7 +141,7 @@ export class JinjaFilterEmitter implements ParsedExprEmitter {
     return String(value)
   }
 
-  member(object: ParsedExpr, property: string, _computed: boolean, emit: (e: ParsedExpr) => string): string {
+  member(object: ParsedExpr, property: string, _computed: boolean, _optional: boolean, emit: (e: ParsedExpr) => string): string {
     // `.length` — route through `bf.length` (handles both array element
     // count and string char count, JS-compatibly). Jinja's builtin
     // `|length` filter also faults trying to match JS semantics for every
@@ -321,7 +321,7 @@ export class JinjaTopLevelEmitter implements ParsedExprEmitter {
     return String(value)
   }
 
-  member(object: ParsedExpr, property: string, _computed: boolean, emit: (e: ParsedExpr) => string): string {
+  member(object: ParsedExpr, property: string, _computed: boolean, _optional: boolean, emit: (e: ParsedExpr) => string): string {
     // `props.x` flattens to the bare context var the SSR caller binds each
     // prop to (props arrive as individual top-level context entries, not a
     // nested `props` dict).

--- a/packages/adapter-mojolicious/src/adapter/expr/emitters.ts
+++ b/packages/adapter-mojolicious/src/adapter/expr/emitters.ts
@@ -105,7 +105,7 @@ export class MojoFilterEmitter implements ParsedExprEmitter {
     return String(value)
   }
 
-  member(object: ParsedExpr, property: string, _computed: boolean, emit: (e: ParsedExpr) => string): string {
+  member(object: ParsedExpr, property: string, _computed: boolean, _optional: boolean, emit: (e: ParsedExpr) => string): string {
     // `.length` on a higher-order result (e.g.
     // `x.tags.filter(t => t.active).length > 0` inside the outer
     // filter predicate, #1443). The higher-order emit produces an
@@ -322,7 +322,7 @@ export class MojoTopLevelEmitter implements ParsedExprEmitter {
     return String(value)
   }
 
-  member(object: ParsedExpr, property: string, _computed: boolean, emit: (e: ParsedExpr) => string): string {
+  member(object: ParsedExpr, property: string, _computed: boolean, _optional: boolean, emit: (e: ParsedExpr) => string): string {
     // `props.x` flattens to the bare `$x` the Mojo SSR caller binds each
     // prop to (props arrive as individual `my $x = ...` vars, not a
     // `$props` hashref).

--- a/packages/adapter-rust/src/adapter/expr/emitters.ts
+++ b/packages/adapter-rust/src/adapter/expr/emitters.ts
@@ -141,7 +141,7 @@ export class JinjaFilterEmitter implements ParsedExprEmitter {
     return String(value)
   }
 
-  member(object: ParsedExpr, property: string, _computed: boolean, emit: (e: ParsedExpr) => string): string {
+  member(object: ParsedExpr, property: string, _computed: boolean, _optional: boolean, emit: (e: ParsedExpr) => string): string {
     // `.length` — route through `bf.length` (handles both array element
     // count and string char count, JS-compatibly). Jinja's builtin
     // `|length` filter also faults trying to match JS semantics for every
@@ -313,7 +313,7 @@ export class JinjaTopLevelEmitter implements ParsedExprEmitter {
     return String(value)
   }
 
-  member(object: ParsedExpr, property: string, _computed: boolean, emit: (e: ParsedExpr) => string): string {
+  member(object: ParsedExpr, property: string, _computed: boolean, _optional: boolean, emit: (e: ParsedExpr) => string): string {
     // `props.x` flattens to the bare context var the SSR caller binds each
     // prop to (props arrive as individual top-level context entries, not a
     // nested `props` dict).

--- a/packages/adapter-tests/fixtures/nested-loop-triple-depth.ts
+++ b/packages/adapter-tests/fixtures/nested-loop-triple-depth.ts
@@ -44,13 +44,6 @@ export { NestedLoopTripleDepth }
     ],
   },
   expectedHtml: `
-    <div bf-s="test" bf="s3">
-      <section bf="s2" data-key="t1">
-        <article bf="s1" data-key-1="b1">
-          <span data-key-2="l1"><!--bf:s0-->l1<!--/--></span>
-          <span data-key-2="l2"><!--bf:s0-->l2<!--/--></span>
-        </article>
-      </section>
-    </div>
+    <div bf-s="test" bf="s3"><section bf="s2" data-key="t1"><article bf="s1" data-key-1="b1"><span data-key-2="l1"><!--bf:s0-->l1<!--/--></span><span data-key-2="l2"><!--bf:s0-->l2<!--/--></span></article></section></div>
   `,
 })

--- a/packages/adapter-tests/fixtures/sibling-loops-key-isolation.ts
+++ b/packages/adapter-tests/fixtures/sibling-loops-key-isolation.ts
@@ -39,9 +39,7 @@ export { SiblingLoopsKeyIsolation }
         <li data-key="apple"><!--bf:s0-->apple<!--/--></li>
         <li data-key="plum"><!--bf:s0-->plum<!--/--></li>
       </ul>
-      <ul bf="s3">
-        <li data-key="carrot"><!--bf:s2-->carrot<!--/--></li>
-      </ul>
+      <ul bf="s3"><li data-key="carrot"><!--bf:s2-->carrot<!--/--></li></ul>
     </div>
   `,
 })

--- a/packages/adapter-tests/vectors/eval-vectors.json
+++ b/packages/adapter-tests/vectors/eval-vectors.json
@@ -113,7 +113,8 @@
             "name": "item"
           },
           "property": "price",
-          "computed": false
+          "computed": false,
+          "optional": false
         }
       },
       "env": {
@@ -358,7 +359,8 @@
             "name": "item"
           },
           "property": "done",
-          "computed": false
+          "computed": false,
+          "optional": false
         }
       },
       "env": {
@@ -381,7 +383,8 @@
             "name": "item"
           },
           "property": "done",
-          "computed": false
+          "computed": false,
+          "optional": false
         }
       },
       "env": {
@@ -509,7 +512,8 @@
             "name": "item"
           },
           "property": "id",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "right": {
           "kind": "literal",
@@ -538,7 +542,8 @@
             "name": "item"
           },
           "property": "id",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "right": {
           "kind": "literal",
@@ -567,7 +572,8 @@
             "name": "item"
           },
           "property": "id",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "right": {
           "kind": "literal",
@@ -596,7 +602,8 @@
             "name": "item"
           },
           "property": "status",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "right": {
           "kind": "literal",
@@ -624,7 +631,8 @@
             "name": "item"
           },
           "property": "done",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "right": {
           "kind": "binary",
@@ -636,7 +644,8 @@
               "name": "item"
             },
             "property": "priority",
-            "computed": false
+            "computed": false,
+            "optional": false
           },
           "right": {
             "kind": "literal",
@@ -667,7 +676,8 @@
             "name": "item"
           },
           "property": "done",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "right": {
           "kind": "binary",
@@ -679,7 +689,8 @@
               "name": "item"
             },
             "property": "priority",
-            "computed": false
+            "computed": false,
+            "optional": false
           },
           "right": {
             "kind": "literal",
@@ -710,7 +721,8 @@
             "name": "item"
           },
           "property": "label",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "right": {
           "kind": "literal",
@@ -738,7 +750,8 @@
             "name": "item"
           },
           "property": "label",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "right": {
           "kind": "literal",
@@ -766,7 +779,8 @@
             "name": "item"
           },
           "property": "qty",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "right": {
           "kind": "literal",
@@ -795,7 +809,8 @@
             "name": "item"
           },
           "property": "qty",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "right": {
           "kind": "literal",
@@ -824,7 +839,8 @@
             "name": "item"
           },
           "property": "missing",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "right": {
           "kind": "literal",
@@ -850,7 +866,8 @@
             "name": "item"
           },
           "property": "n",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "consequent": {
           "kind": "literal",
@@ -882,7 +899,8 @@
             "name": "item"
           },
           "property": "s",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "consequent": {
           "kind": "literal",
@@ -1036,10 +1054,12 @@
             "name": "item"
           },
           "property": "a",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "property": "b",
-        "computed": false
+        "computed": false,
+        "optional": false
       },
       "env": {
         "item": {
@@ -1060,7 +1080,8 @@
           "name": "item"
         },
         "property": "missing",
-        "computed": false
+        "computed": false,
+        "optional": false
       },
       "env": {
         "item": {}
@@ -1079,10 +1100,12 @@
             "name": "item"
           },
           "property": "tags",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "property": "length",
-        "computed": false
+        "computed": false,
+        "optional": false
       },
       "env": {
         "item": {
@@ -1107,10 +1130,12 @@
             "name": "item"
           },
           "property": "name",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "property": "length",
-        "computed": false
+        "computed": false,
+        "optional": false
       },
       "env": {
         "item": {
@@ -1203,7 +1228,8 @@
                 "name": "item"
               },
               "property": "id",
-              "computed": false
+              "computed": false,
+              "optional": false
             }
           },
           {
@@ -1219,7 +1245,8 @@
                 "name": "item"
               },
               "property": "name",
-              "computed": false
+              "computed": false,
+              "optional": false
             }
           }
         ]
@@ -1279,7 +1306,8 @@
               "name": "item"
             },
             "property": "a",
-            "computed": false
+            "computed": false,
+            "optional": false
           },
           {
             "kind": "member",
@@ -1288,7 +1316,8 @@
               "name": "item"
             },
             "property": "b",
-            "computed": false
+            "computed": false,
+            "optional": false
           }
         ]
       },
@@ -1320,7 +1349,8 @@
                 "name": "item"
               },
               "property": "id",
-              "computed": false
+              "computed": false,
+              "optional": false
             }
           },
           {
@@ -1337,7 +1367,8 @@
                   "name": "item"
                 },
                 "property": "n",
-                "computed": false
+                "computed": false,
+                "optional": false
               },
               "right": {
                 "kind": "literal",
@@ -1373,7 +1404,8 @@
             "name": "Math"
           },
           "property": "max",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "args": [
           {
@@ -1404,7 +1436,8 @@
             "name": "Math"
           },
           "property": "min",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "args": [
           {
@@ -1440,7 +1473,8 @@
             "name": "Math"
           },
           "property": "abs",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "args": [
           {
@@ -1466,7 +1500,8 @@
             "name": "Math"
           },
           "property": "floor",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "args": [
           {
@@ -1476,7 +1511,8 @@
               "name": "item"
             },
             "property": "x",
-            "computed": false
+            "computed": false,
+            "optional": false
           }
         ]
       },
@@ -1499,7 +1535,8 @@
             "name": "Math"
           },
           "property": "ceil",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "args": [
           {
@@ -1509,7 +1546,8 @@
               "name": "item"
             },
             "property": "x",
-            "computed": false
+            "computed": false,
+            "optional": false
           }
         ]
       },
@@ -1532,7 +1570,8 @@
             "name": "Math"
           },
           "property": "round",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "args": [
           {
@@ -1542,7 +1581,8 @@
               "name": "item"
             },
             "property": "x",
-            "computed": false
+            "computed": false,
+            "optional": false
           }
         ]
       },
@@ -1565,7 +1605,8 @@
             "name": "Math"
           },
           "property": "round",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "args": [
           {
@@ -1575,7 +1616,8 @@
               "name": "item"
             },
             "property": "x",
-            "computed": false
+            "computed": false,
+            "optional": false
           }
         ]
       },
@@ -1603,7 +1645,8 @@
               "name": "item"
             },
             "property": "n",
-            "computed": false
+            "computed": false,
+            "optional": false
           }
         ]
       },
@@ -1631,7 +1674,8 @@
               "name": "item"
             },
             "property": "s",
-            "computed": false
+            "computed": false,
+            "optional": false
           }
         ]
       },
@@ -1659,7 +1703,8 @@
               "name": "item"
             },
             "property": "s",
-            "computed": false
+            "computed": false,
+            "optional": false
           }
         ]
       },
@@ -1683,7 +1728,8 @@
             "name": "item"
           },
           "property": "tags",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "args": [
           {
@@ -1716,7 +1762,8 @@
             "name": "item"
           },
           "property": "tags",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "args": [
           {
@@ -1800,7 +1847,8 @@
             "name": "item"
           },
           "property": "tags",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "args": [
           {
@@ -1839,7 +1887,8 @@
               "name": "item"
             },
             "property": "price",
-            "computed": false
+            "computed": false,
+            "optional": false
           },
           "right": {
             "kind": "member",
@@ -1848,7 +1897,8 @@
               "name": "item"
             },
             "property": "qty",
-            "computed": false
+            "computed": false,
+            "optional": false
           }
         }
       },
@@ -1874,7 +1924,8 @@
             "name": "a"
           },
           "property": "price",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "right": {
           "kind": "member",
@@ -1883,7 +1934,8 @@
             "name": "b"
           },
           "property": "price",
-          "computed": false
+          "computed": false,
+          "optional": false
         }
       },
       "env": {
@@ -1909,7 +1961,8 @@
             "name": "item"
           },
           "property": "qty",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "right": {
           "kind": "literal",
@@ -1943,10 +1996,12 @@
                 "name": "item"
               },
               "property": "tags",
-              "computed": false
+              "computed": false,
+              "optional": false
             },
             "property": "length",
-            "computed": false
+            "computed": false,
+            "optional": false
           },
           "right": {
             "kind": "literal",
@@ -1962,7 +2017,8 @@
             "name": "item"
           },
           "property": "active",
-          "computed": false
+          "computed": false,
+          "optional": false
         }
       },
       "env": {
@@ -1988,7 +2044,8 @@
             "name": "item"
           },
           "property": "tags",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "args": [
           {
@@ -2022,7 +2079,8 @@
             "name": "item"
           },
           "property": "tags",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "args": []
       },
@@ -2049,7 +2107,8 @@
             "name": "item"
           },
           "property": "tags",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "args": [
           {
@@ -2079,7 +2138,8 @@
             "name": "item"
           },
           "property": "tags",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "args": [
           {
@@ -2114,10 +2174,12 @@
               "name": "item"
             },
             "property": "tags",
-            "computed": false
+            "computed": false,
+            "optional": false
           },
           "property": "map",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "args": [
           {
@@ -2168,10 +2230,12 @@
               "name": "item"
             },
             "property": "tags",
-            "computed": false
+            "computed": false,
+            "optional": false
           },
           "property": "map",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "args": [
           {
@@ -2225,10 +2289,12 @@
               "name": "item"
             },
             "property": "tags",
-            "computed": false
+            "computed": false,
+            "optional": false
           },
           "property": "map",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "args": [
           {
@@ -2246,7 +2312,8 @@
                   "name": "t"
                 },
                 "property": "n",
-                "computed": false
+                "computed": false,
+                "optional": false
               },
               "right": {
                 "kind": "literal",
@@ -2293,10 +2360,12 @@
               "name": "item"
             },
             "property": "tags",
-            "computed": false
+            "computed": false,
+            "optional": false
           },
           "property": "filter",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "args": [
           {
@@ -2314,7 +2383,8 @@
                   "name": "t"
                 },
                 "property": "active",
-                "computed": false
+                "computed": false,
+                "optional": false
               },
               "right": {
                 "kind": "binary",
@@ -2326,7 +2396,8 @@
                     "name": "t"
                   },
                   "property": "n",
-                  "computed": false
+                  "computed": false,
+                  "optional": false
                 },
                 "right": {
                   "kind": "literal",
@@ -2383,10 +2454,12 @@
                   "name": "item"
                 },
                 "property": "tags",
-                "computed": false
+                "computed": false,
+                "optional": false
               },
               "property": "filter",
-              "computed": false
+              "computed": false,
+              "optional": false
             },
             "args": [
               {
@@ -2401,13 +2474,15 @@
                     "name": "t"
                   },
                   "property": "active",
-                  "computed": false
+                  "computed": false,
+                  "optional": false
                 }
               }
             ]
           },
           "property": "length",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "right": {
           "kind": "literal",
@@ -2449,10 +2524,12 @@
                   "name": "item"
                 },
                 "property": "tags",
-                "computed": false
+                "computed": false,
+                "optional": false
               },
               "property": "filter",
-              "computed": false
+              "computed": false,
+              "optional": false
             },
             "args": [
               {
@@ -2467,13 +2544,15 @@
                     "name": "t"
                   },
                   "property": "active",
-                  "computed": false
+                  "computed": false,
+                  "optional": false
                 }
               }
             ]
           },
           "property": "length",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "right": {
           "kind": "literal",
@@ -2513,10 +2592,12 @@
                 "name": "item"
               },
               "property": "posts",
-              "computed": false
+              "computed": false,
+              "optional": false
             },
             "property": "map",
-            "computed": false
+            "computed": false,
+            "optional": false
           },
           "args": [
             {
@@ -2538,10 +2619,12 @@
                         "name": "p"
                       },
                       "property": "tags",
-                      "computed": false
+                      "computed": false,
+                      "optional": false
                     },
                     "property": "map",
-                    "computed": false
+                    "computed": false,
+                    "optional": false
                   },
                   "args": [
                     {
@@ -2617,10 +2700,12 @@
               "name": "item"
             },
             "property": "tags",
-            "computed": false
+            "computed": false,
+            "optional": false
           },
           "property": "map",
-          "computed": false
+          "computed": false,
+          "optional": false
         },
         "args": [
           {
@@ -2639,7 +2724,8 @@
                   "name": "t"
                 },
                 "property": "n",
-                "computed": false
+                "computed": false,
+                "optional": false
               },
               "right": {
                 "kind": "identifier",

--- a/packages/adapter-twig/src/adapter/expr/emitters.ts
+++ b/packages/adapter-twig/src/adapter/expr/emitters.ts
@@ -153,7 +153,7 @@ export class TwigFilterEmitter implements ParsedExprEmitter {
     return String(value)
   }
 
-  member(object: ParsedExpr, property: string, _computed: boolean, emit: (e: ParsedExpr) => string): string {
+  member(object: ParsedExpr, property: string, _computed: boolean, _optional: boolean, emit: (e: ParsedExpr) => string): string {
     // `.length` — route through `bf.length` (handles both array element
     // count and string char count, JS-compatibly). Twig's builtin
     // `|length` filter also faults trying to match JS semantics for every
@@ -326,7 +326,7 @@ export class TwigTopLevelEmitter implements ParsedExprEmitter {
     return String(value)
   }
 
-  member(object: ParsedExpr, property: string, _computed: boolean, emit: (e: ParsedExpr) => string): string {
+  member(object: ParsedExpr, property: string, _computed: boolean, _optional: boolean, emit: (e: ParsedExpr) => string): string {
     // `props.x` flattens to the bare context var the SSR caller binds each
     // prop to (props arrive as individual top-level context entries, not a
     // nested `props` hash).

--- a/packages/adapter-xslate/src/adapter/expr/emitters.ts
+++ b/packages/adapter-xslate/src/adapter/expr/emitters.ts
@@ -94,7 +94,7 @@ export class XslateFilterEmitter implements ParsedExprEmitter {
     return String(value)
   }
 
-  member(object: ParsedExpr, property: string, _computed: boolean, emit: (e: ParsedExpr) => string): string {
+  member(object: ParsedExpr, property: string, _computed: boolean, _optional: boolean, emit: (e: ParsedExpr) => string): string {
     // `.length` — route through `$bf.length` (handles both array element
     // count and string char count, JS-compatibly). Kolon's builtin `.size()`
     // is array-only and faults on a string.
@@ -263,7 +263,7 @@ export class XslateTopLevelEmitter implements ParsedExprEmitter {
     return String(value)
   }
 
-  member(object: ParsedExpr, property: string, _computed: boolean, emit: (e: ParsedExpr) => string): string {
+  member(object: ParsedExpr, property: string, _computed: boolean, _optional: boolean, emit: (e: ParsedExpr) => string): string {
     // `props.x` flattens to the bare `$x` the SSR caller binds each prop to
     // (props arrive as individual top-level vars, not a `$props` hashref).
     if (object.kind === 'identifier' && object.name === 'props') {

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -1230,6 +1230,7 @@ describe('expression-parser', () => {
         object: { kind: 'identifier', name: 'x' },
         property: 'done',
         computed: false,
+        optional: false,
       })
     })
 

--- a/packages/jsx/src/__tests__/expression-parser.test.ts
+++ b/packages/jsx/src/__tests__/expression-parser.test.ts
@@ -70,6 +70,43 @@ describe('expression-parser', () => {
       expect(result.kind).toBe('member')
       if (result.kind === 'member') {
         expect(result.property).toBe('name')
+        expect(result.optional).toBe(false)
+      }
+    })
+
+    // #2168 optional-chaining-prop: `optional` must reflect the source `?.`
+    // token exactly — set on the one written hop, `false` everywhere else
+    // (a plain `.`/`[]` access, including a literal-index computed access).
+    test('parses optional chaining (?.) into `member.optional`', () => {
+      const dotResult = parseExpression('user?.name')
+      expect(dotResult.kind).toBe('member')
+      if (dotResult.kind === 'member') {
+        expect(dotResult.property).toBe('name')
+        expect(dotResult.computed).toBe(false)
+        expect(dotResult.optional).toBe(true)
+      }
+
+      const stringKeyResult = parseExpression("obj?.['key']")
+      expect(stringKeyResult.kind).toBe('member')
+      if (stringKeyResult.kind === 'member') {
+        expect(stringKeyResult.property).toBe('key')
+        expect(stringKeyResult.computed).toBe(true)
+        expect(stringKeyResult.optional).toBe(true)
+      }
+
+      const numericIndexResult = parseExpression('arr?.[0]')
+      expect(numericIndexResult.kind).toBe('member')
+      if (numericIndexResult.kind === 'member') {
+        expect(numericIndexResult.property).toBe('0')
+        expect(numericIndexResult.computed).toBe(true)
+        expect(numericIndexResult.optional).toBe(true)
+      }
+
+      // Non-optional literal-index access stays `optional: false`.
+      const plainIndexResult = parseExpression('arr[0]')
+      expect(plainIndexResult.kind).toBe('member')
+      if (plainIndexResult.kind === 'member') {
+        expect(plainIndexResult.optional).toBe(false)
       }
     })
 

--- a/packages/jsx/src/__tests__/materialize-getter-calls.test.ts
+++ b/packages/jsx/src/__tests__/materialize-getter-calls.test.ts
@@ -43,6 +43,7 @@ describe('materializeGetterCalls', () => {
           object: { kind: 'identifier', name: 'p' },
           property: 'tags',
           computed: false,
+          optional: false,
         },
         args: [{ kind: 'identifier', name: 'tag' }],
       },

--- a/packages/jsx/src/adapters/parsed-expr-emitter.ts
+++ b/packages/jsx/src/adapters/parsed-expr-emitter.ts
@@ -114,10 +114,16 @@ export interface ParsedExprEmitter {
   identifier(name: string): string
   literal(value: string | number | boolean | null, literalType: LiteralType): string
   call(callee: ParsedExpr, args: ParsedExpr[], emit: (e: ParsedExpr) => string): string
+  // `optional` is true for a `?.`-written access (`user?.name`); see the
+  // `ParsedExpr` `member` variant's docstring in `expression-parser.ts`
+  // for the single-hop caveat. Every adapter's `member()` implementation
+  // that doesn't need it (its lowering is already null-safe) is free to
+  // ignore the parameter.
   member(
     object: ParsedExpr,
     property: string,
     computed: boolean,
+    optional: boolean,
     emit: (e: ParsedExpr) => string,
   ): string
   // Element access with a non-literal index (`arr[index]`). The index
@@ -291,7 +297,7 @@ export function emitParsedExpr(expr: ParsedExpr, emitter: ParsedExprEmitter): st
       return emitter.call(expr.callee, expr.args, emit)
     }
     case 'member':
-      return emitter.member(expr.object, expr.property, expr.computed, emit)
+      return emitter.member(expr.object, expr.property, expr.computed, expr.optional, emit)
     case 'index-access':
       return emitter.indexAccess(expr.object, expr.index, emit)
     case 'binary':

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -25,7 +25,21 @@ export type ParsedExpr =
   // canonical form in `value`.
   | { kind: 'literal'; value: string | number | boolean | null; literalType: 'string' | 'number' | 'boolean' | 'null'; raw?: string }
   | { kind: 'call'; callee: ParsedExpr; args: ParsedExpr[] }
-  | { kind: 'member'; object: ParsedExpr; property: string; computed: boolean }
+  // `optional` is true for a `?.`-written access (`user?.name`,
+  // `arr?.[0]`) — the ONE hop that was actually optional-chained in JS
+  // source; a plain `.`/`[]` access is `false`. Adapters whose member
+  // lowering is already null-safe by construction (e.g. Jinja's `[]`
+  // subscript swallows a `None` receiver, Blade's `data_get` helper)
+  // ignore this field entirely; Go and ERB (whose native `.` access
+  // panics/raises on a nil/undefined receiver) route an `optional: true`
+  // access through a defensive form (`bf_get`, Ruby `&.`) instead. NOTE:
+  // this does NOT reproduce JS's whole-chain short-circuit for a
+  // MULTI-hop chain (`a?.b.c` also guards `.c` in JS once `a` is
+  // nullish) — only the single hop written with `?.` is marked; a
+  // following plain `.c` on a possibly-nullish `a?.b` is a known,
+  // untracked limitation on Go/ERB (not exercised by the current
+  // `optional-chaining-prop` fixture, which is single-hop only).
+  | { kind: 'member'; object: ParsedExpr; property: string; computed: boolean; optional: boolean }
   // Element access with a NON-literal index (`selected()[index]`,
   // `rows[i + 1]`). A literal-index access (`arr[0]`, `obj['key']`)
   // stays a `member` (computed) since the key is statically known and
@@ -1090,7 +1104,7 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
     const property = node.name.text
 
     // Return as normal member - filter.length is handled in adapter
-    return { kind: 'member', object, property, computed: false }
+    return { kind: 'member', object, property, computed: false, optional: !!node.questionDotToken }
   }
 
   // Element access: items[0], obj['key']
@@ -1106,10 +1120,10 @@ function convertNode(node: ts.Node, raw: string): ParsedExpr {
     }
     // For simple number/string access, store as property
     if (ts.isNumericLiteral(argNode)) {
-      return { kind: 'member', object, property: argNode.text, computed: true }
+      return { kind: 'member', object, property: argNode.text, computed: true, optional: !!node.questionDotToken }
     }
     if (ts.isStringLiteral(argNode)) {
-      return { kind: 'member', object, property: argNode.text, computed: true }
+      return { kind: 'member', object, property: argNode.text, computed: true, optional: !!node.questionDotToken }
     }
     // Variable / expression index (`selected()[index]`, `rows[i + 1]`):
     // carry the index as its own ParsedExpr so the adapter can lower it
@@ -2081,7 +2095,7 @@ function substituteDestructuredFields(
         // one-hop chain identical to the pre-#1530 shape.
         let node: ParsedExpr = { kind: 'identifier', name: syntheticParam }
         for (const segment of entry.path) {
-          node = { kind: 'member', object: node, property: segment, computed: false }
+          node = { kind: 'member', object: node, property: segment, computed: false, optional: false }
         }
         // Default value (#1531): wrap the accessor in `?? <default>` so
         // a missing field falls back to the user-supplied literal /
@@ -2106,9 +2120,10 @@ function substituteDestructuredFields(
             object: { kind: 'identifier', name: syntheticParam },
             property: e.property,
             computed: false,
+            optional: e.optional,
           }
         }
-        return { kind: 'member', object: walk(e.object), property: e.property, computed: e.computed }
+        return { kind: 'member', object: walk(e.object), property: e.property, computed: e.computed, optional: e.optional }
       case 'index-access':
         return { kind: 'index-access', object: walk(e.object), index: walk(e.index) }
       case 'binary':
@@ -2912,7 +2927,7 @@ function inlineBinding(
       case 'call':
         return { kind: 'call', callee: walk(e.callee, enclosing), args: e.args.map(a => walk(a, enclosing)) }
       case 'member':
-        return { kind: 'member', object: walk(e.object, enclosing), property: e.property, computed: e.computed }
+        return { kind: 'member', object: walk(e.object, enclosing), property: e.property, computed: e.computed, optional: e.optional }
       case 'index-access':
         return { kind: 'index-access', object: walk(e.object, enclosing), index: walk(e.index, enclosing) }
       case 'binary':
@@ -3300,7 +3315,7 @@ export function materializeGetterCalls(expr: ParsedExpr, names: ReadonlySet<stri
         alternate: rw(expr.alternate),
       }
     case 'member':
-      return { kind: 'member', object: rw(expr.object), property: expr.property, computed: expr.computed }
+      return { kind: 'member', object: rw(expr.object), property: expr.property, computed: expr.computed, optional: expr.optional }
     case 'index-access':
       return { kind: 'index-access', object: rw(expr.object), index: rw(expr.index) }
     case 'template-literal':

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2116,16 +2116,6 @@
           "reason": "`Object.entries(prop).map(([k, v]) => …)` renders an EMPTY list — the object-shaped prop silently produces zero iterations"
         }
       },
-      "optional-chaining-prop": {
-        "erb": {
-          "kind": "render",
-          "reason": "`user?.name ?? …` on an object prop: the Ruby render exits 1 (optional chaining into a Hash prop has no lowering)"
-        },
-        "go-template": {
-          "kind": "render",
-          "reason": "`user?.name ?? …` on an object prop: generated Go fails to run (exit 1) — optional chaining into a struct/map prop has no lowering"
-        }
-      },
       "signal-object-field": {
         "go-template": {
           "kind": "render",


### PR DESCRIPTION
## Summary

Fixes the `optional-chaining-prop` render divergence (#2168 sweep) on 2 of 8 template adapters: `user?.name ?? 'anonymous'` on an optional object-shaped prop previously exited/raised at render time on Go and Ruby ERB.

- `?.`'s "guard the nil receiver" semantics were discarded entirely at parse time — `ts.isPropertyAccessExpression`'s `questionDotToken` was never read, so `user?.name` and `user.name` produced the identical `ParsedExpr` shape. This happened to work on 6 adapters by accident of their host language/helper semantics (Jinja/Twig/minijinja/Xslate's generic `[]`/`.` accessor already swallows a nil/undef receiver; Blade already routes every member access through the null-safe `data_get()` helper), but Go's literal `.Field` dot-chain panics on a nil interface/pointer, and Ruby's `obj[:key]` raises `NoMethodError` on nil.
- Added an `optional: boolean` field to the shared `member` `ParsedExpr` variant (set from the `?.` token, threaded through every rewrite/copy site so it survives destructure and callback-body rewrites) and to the `ParsedExprEmitter.member()` interface — a required field, so every adapter's implementation had to be visited.
- **Go**: an `optional` access routes through the runtime's existing nil-safe reflection getter (`bf_get`/`getFieldValue`, `bf.go`, already used for map-rooted context chains) instead of a literal `.Field` dot-chain.
- **ERB**: an `optional` access emits Ruby's native safe-navigation form (`obj&.[](:key)`) instead of plain `obj[:key]`.
- The other 6 adapters (Jinja, Twig, minijinja, Xslate, Blade, Mojolicious) accept-and-ignore the new parameter — no behavior change, since their existing lowering is already null-safe.
- Scoped to the single `?.`-written hop, matching the current fixture — does not (yet) propagate JS's whole-chain short-circuit through a following plain `.` hop (`a?.b.c`); noted as a known limitation on the `ParsedExpr` docstring.
- Design reviewed with Opus before implementation (alternative considered and rejected: making the defensive form the *unconditional* default for all Go/ERB member access — rejected because the runtime's nil-safe getter also does fuzzy case-insensitive key resolution, so routing every access through it would mask genuine wrong-field-name bugs and change key-resolution order for the non-optional case).

`optional-chaining-prop` graduates from a render divergence to a passing render on both adapters; `ui/compat.lock.json` and the divergence declarations are updated accordingly.

Stacked on #2187 (jsx-element-prop).

## Test plan

- [x] `bun run build` (full monorepo, to refresh adapter `dist/` bundles) + `GOTOOLCHAIN=go1.25.6 bun run compat:lock` — clean diff, only `optional-chaining-prop` entries removed
- [x] Go adapter suite (real `go run` via `GOTOOLCHAIN=go1.25.6`): 726 pass, 0 fail (re-confirmed after an earlier transient run showed unrelated flaky timeouts under load — reproduced clean twice)
- [x] ERB adapter suite (real stdlib ERB): 492 pass, 2 skip, 0 fail
- [x] Jinja / Twig / Rust (minijinja) / Text::Xslate / Blade / Mojolicious adapter suites (real backends): all green, unchanged pass counts
- [x] Shared `@barefootjs/jsx` package suite: 2336 pass, 25 skip, 2 todo, 0 fail (two golden-shape assertions updated for the new `optional` field)
- [x] `bun run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZXzQWvSKLUUrTAZ3vph1j)_