### PR TITLE
fix(jsx): thread .map() index param through list-item event delegation (#2189)

### DIFF
--- a/.changeset/event-delegation-index-param.md
+++ b/.changeset/event-delegation-index-param.md
@@ -1,0 +1,13 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/jinja": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+"@barefootjs/twig": patch
+"@barefootjs/blade": patch
+"@barefootjs/rust": patch
+"@barefootjs/erb": patch
+"@barefootjs/go-template": patch
+---
+
+Thread the `.map()` index param through the list-item event-delegation dispatcher. When a delegated handler closed over the callback's index (`items().map((item, i) => <button onClick={() => handle(i)} />)`), `bf build` lowered the per-item handler into a single delegated listener that re-derived the *item* from `data-key`/DOM position but dropped the *index* — so `i` was a dangling reference and the handler threw `ReferenceError: i is not defined` the first time it fired (item-property access like `item.id` worked because that was re-derived). The dispatcher now re-derives the index from the same runtime source the item comes from — `arr.findIndex(...)` for keyed lookups, the already-computed DOM position for the index-based lookups — and binds it under the user's param name. Output is unchanged for handlers that don't reference the index.

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -335,6 +335,7 @@ import { fixture as elseIfChain } from './else-if-chain'
 import { fixture as inlineArrayMap } from './inline-array-map'
 import { fixture as objectEntriesMap } from './object-entries-map'
 import { fixture as mapKeyIndex } from './map-key-index'
+import { fixture as mapIndexHandler } from './map-index-handler'
 import { fixture as nestedLoopOuterBinding } from './nested-loop-outer-binding'
 import { fixture as nestedLoopTripleDepth } from './nested-loop-triple-depth'
 import { fixture as siblingLoopsKeyIsolation } from './sibling-loops-key-isolation'
@@ -601,6 +602,7 @@ export const jsxFixtures: JSXFixture[] = [
   inlineArrayMap,
   objectEntriesMap,
   mapKeyIndex,
+  mapIndexHandler,
   nestedLoopOuterBinding,
   nestedLoopTripleDepth,
   siblingLoopsKeyIsolation,

--- a/packages/adapter-tests/fixtures/map-index-handler.ts
+++ b/packages/adapter-tests/fixtures/map-index-handler.ts
@@ -17,28 +17,22 @@ export function MapIndexHandler() {
     { id: 10, label: 'a' },
     { id: 20, label: 'b' },
   ])
-  const [selected, setSelected] = createSignal(-1)
+  const [, setActive] = createSignal(0)
   return (
-    <div>
-      <p>selected: {selected()}</p>
-      <ul>
-        {items().map((item, i) => (
-          <li key={item.id}>
-            <button onClick={() => setSelected(i)}>{item.label}</button>
-          </li>
-        ))}
-      </ul>
-    </div>
+    <ul>
+      {items().map((item, i) => (
+        <li key={item.id}>
+          <button onClick={() => setActive(i)}>{item.label}</button>
+        </li>
+      ))}
+    </ul>
   )
 }
 `,
   expectedHtml: `
-    <div bf-s="test">
-      <p bf="s1">selected: <!--bf:s0-->-1<!--/--></p>
-      <ul bf="s4">
-        <li data-key="10"><button bf="s3"><!--bf:s2-->a<!--/--></button></li>
-        <li data-key="20"><button bf="s3"><!--bf:s2-->b<!--/--></button></li>
-      </ul>
-    </div>
+    <ul bf-s="test" bf="s2">
+      <li data-key="10"><button bf="s1"><!--bf:s0-->a<!--/--></button></li>
+      <li data-key="20"><button bf="s1"><!--bf:s0-->b<!--/--></button></li>
+    </ul>
   `,
 })

--- a/packages/adapter-tests/fixtures/map-index-handler.ts
+++ b/packages/adapter-tests/fixtures/map-index-handler.ts
@@ -1,0 +1,44 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A list-item click handler that closes over the `.map()` index param (#2189).
+ * Pins that a keyed loop whose delegated handler reads the index compiles and
+ * renders consistently across adapters and CSR. The index-binding runtime
+ * behavior is exercised in the client e2e test.
+ */
+export const fixture = createFixture({
+  id: 'map-index-handler',
+  description: 'List-item click handler reading the map index param',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function MapIndexHandler() {
+  const [items] = createSignal([
+    { id: 10, label: 'a' },
+    { id: 20, label: 'b' },
+  ])
+  const [selected, setSelected] = createSignal(-1)
+  return (
+    <div>
+      <p>selected: {selected()}</p>
+      <ul>
+        {items().map((item, i) => (
+          <li key={item.id}>
+            <button onClick={() => setSelected(i)}>{item.label}</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test">
+      <p bf="s1">selected: <!--bf:s0-->-1<!--/--></p>
+      <ul bf="s4">
+        <li data-key="10"><button bf="s3"><!--bf:s2-->a<!--/--></button></li>
+        <li data-key="20"><button bf="s3"><!--bf:s2-->b<!--/--></button></li>
+      </ul>
+    </div>
+  `,
+})

--- a/packages/client/__tests__/runtime/event-delegation-index-param-e2e.test.ts
+++ b/packages/client/__tests__/runtime/event-delegation-index-param-e2e.test.ts
@@ -1,13 +1,8 @@
 /**
- * End-to-end runtime test for #2189: a delegated list-item handler that closes
- * over the `.map()` index param.
- *
- * `items().map((item, i) => <button onClick={() => setClicked(i)} />)` lowers to
- * a single delegated `click` listener on the container. Before the fix that
- * dispatcher re-derived the *item* from `data-key` but dropped the *index*, so
- * `i` was a dangling reference and the click threw
- * `ReferenceError: i is not defined`. This mounts the real compiled output in a
- * DOM, clicks a row, and asserts the handler ran with the correct index.
+ * End-to-end runtime test for #2189: a delegated list-item handler closing over
+ * the `.map()` index param. Mounts the real compiled output in a DOM, clicks a
+ * row, and asserts the handler ran with the correct index (before the fix the
+ * dispatcher dropped the index and the click threw `ReferenceError`).
  */
 import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
 import { GlobalRegistrator } from '@happy-dom/global-registrator'

--- a/packages/client/__tests__/runtime/event-delegation-index-param-e2e.test.ts
+++ b/packages/client/__tests__/runtime/event-delegation-index-param-e2e.test.ts
@@ -1,0 +1,122 @@
+/**
+ * End-to-end runtime test for #2189: a delegated list-item handler that closes
+ * over the `.map()` index param.
+ *
+ * `items().map((item, i) => <button onClick={() => setClicked(i)} />)` lowers to
+ * a single delegated `click` listener on the container. Before the fix that
+ * dispatcher re-derived the *item* from `data-key` but dropped the *index*, so
+ * `i` was a dangling reference and the click threw
+ * `ReferenceError: i is not defined`. This mounts the real compiled output in a
+ * DOM, clicks a row, and asserts the handler ran with the correct index.
+ */
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import { compileJSX } from '../../../jsx/src/compiler'
+import { TestAdapter } from '../../../jsx/src/adapters/test-adapter'
+import { writeFileSync, mkdtempSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') GlobalRegistrator.register()
+})
+
+const adapter = new TestAdapter()
+
+async function mount(source: string, filename: string, name: string): Promise<HTMLElement> {
+  const result = compileJSX(source, filename, { adapter })
+  const errors = result.errors.filter((e) => e.severity === 'error')
+  if (errors.length > 0) {
+    throw new Error(`Compile errors in ${filename}:\n${errors.map((e) => `${e.code}: ${e.message}`).join('\n')}`)
+  }
+  const clientJs = result.files.find((f) => f.type === 'clientJs')?.content
+  if (!clientJs) throw new Error('No client JS emitted')
+  const runtimePath = join(__dirname, '../../src/runtime/index.ts')
+  const rewritten = clientJs
+    .replace(/from\s+['"]@barefootjs\/client\/runtime['"]/g, `from '${runtimePath}'`)
+    .replace(/^import '\/\* @bf-child:\w+ \*\/'\n/gm, '')
+  const dir = mkdtempSync(join(tmpdir(), 'bf-2189-'))
+  const file = join(dir, `${filename.replace(/\W/g, '_')}.mjs`)
+  writeFileSync(file, rewritten)
+  await import(file)
+  const { createComponent } = await import(runtimePath)
+  const el = createComponent(name, {}) as HTMLElement
+  document.body.appendChild(el)
+  return el
+}
+
+describe('#2189 — delegated handler closing over the .map() index', () => {
+  beforeEach(() => { document.body.innerHTML = '' })
+
+  test('clicking a row runs the index handler with the correct index (no ReferenceError)', async () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      interface Item { id: number }
+      export function IndexHandler() {
+        const [items] = createSignal<Item[]>([{ id: 10 }, { id: 20 }, { id: 30 }])
+        const [clicked, setClicked] = createSignal(-1)
+        return (
+          <div>
+            <p>{clicked()}</p>
+            <ul>
+              {items().map((item, i) => (
+                <li key={item.id}>
+                  <button onClick={() => setClicked(i)}>{item.id}</button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )
+      }
+    `
+    const el = await mount(source, 'IndexHandler.tsx', 'IndexHandler')
+    const p = el.querySelector('p')!
+    expect(p.textContent).toBe('-1')
+
+    const buttons = Array.from(el.querySelectorAll('button'))
+    expect(buttons).toHaveLength(3)
+
+    // Click the SECOND row — its index is 1.
+    buttons[1].dispatchEvent(new window.Event('click', { bubbles: true }))
+    expect(p.textContent).toBe('1')
+
+    // Click the THIRD row — its index is 2.
+    buttons[2].dispatchEvent(new window.Event('click', { bubbles: true }))
+    expect(p.textContent).toBe('2')
+
+    // Click the FIRST row — its index is 0.
+    buttons[0].dispatchEvent(new window.Event('click', { bubbles: true }))
+    expect(p.textContent).toBe('0')
+  })
+
+  test('index and item property can be used together in one handler', async () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      interface Item { id: number }
+      export function IndexAndItem() {
+        const [items] = createSignal<Item[]>([{ id: 10 }, { id: 20 }, { id: 30 }])
+        const [out, setOut] = createSignal('')
+        return (
+          <div>
+            <p>{out()}</p>
+            <ul>
+              {items().map((item, i) => (
+                <li key={item.id}>
+                  <button onClick={() => setOut(item.id + ':' + i)}>{item.id}</button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )
+      }
+    `
+    const el = await mount(source, 'IndexAndItem.tsx', 'IndexAndItem')
+    const p = el.querySelector('p')!
+    const buttons = Array.from(el.querySelectorAll('button'))
+
+    buttons[2].dispatchEvent(new window.Event('click', { bubbles: true }))
+    expect(p.textContent).toBe('30:2')
+  })
+})

--- a/packages/jsx/src/__tests__/event-delegation-index-param.test.ts
+++ b/packages/jsx/src/__tests__/event-delegation-index-param.test.ts
@@ -1,18 +1,9 @@
 /**
- * BarefootJS Compiler — delegated handlers may close over the `.map()` index
- * param (#2189).
- *
- * When a list-item event handler references the `.map((item, i) => ...)` index
- * parameter, the compiler lowers the per-item handler into a single delegated
- * listener on the container. That dispatcher re-derives the item from
- * `data-key` / DOM position but historically dropped the index, so the handler
- * closure referenced a dangling `i` and threw `ReferenceError: i is not
- * defined` the first time it fired.
- *
- * Fix (#2189): re-derive the index at dispatch time from the same runtime
- * source the item comes from — `arr.findIndex(...)` for keyed lookups, the
- * already-computed DOM position for the index shapes — and bind it under the
- * user's param name so the reference resolves.
+ * Delegated handlers closing over the `.map((item, i) => ...)` index param
+ * (#2189). The dispatcher re-derives the index at dispatch time and binds it
+ * under the user's name, so a handler like `() => handle(i)` no longer throws
+ * `ReferenceError: i is not defined`. Gating is byte-for-byte free of churn
+ * when the handler doesn't reference the index.
  */
 
 import { describe, test, expect } from 'bun:test'
@@ -83,6 +74,33 @@ describe('delegated handler closing over the .map() index (#2189)', () => {
 
     // Nothing references `i`, so the dispatcher must not emit an index binding.
     expect(content).not.toContain('const i = items().findIndex')
+    expect(content).toContain('(() => handle(item.id))(__bfEvt)')
+  })
+
+  test('index named like a property is not bound when only the property is used', () => {
+    // Index param `id` shadows nothing here — the handler reads `item.id`, a
+    // property, not the index. Gating is AST-based (free identifiers), so no
+    // spurious binding is emitted.
+    const content = clientJsFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      interface Item { id: number; label: string }
+      export function Repro() {
+        const [items] = createSignal<Item[]>([])
+        const handle = (n: number) => { console.log(n) }
+        return (
+          <ul>
+            {items().map((item, id) => (
+              <li key={item.id}>
+                <button onClick={() => handle(item.id)}>{item.label}</button>
+              </li>
+            ))}
+          </ul>
+        )
+      }
+    `)
+
+    expect(content).not.toContain('.findIndex(')
     expect(content).toContain('(() => handle(item.id))(__bfEvt)')
   })
 

--- a/packages/jsx/src/__tests__/event-delegation-index-param.test.ts
+++ b/packages/jsx/src/__tests__/event-delegation-index-param.test.ts
@@ -1,0 +1,112 @@
+/**
+ * BarefootJS Compiler — delegated handlers may close over the `.map()` index
+ * param (#2189).
+ *
+ * When a list-item event handler references the `.map((item, i) => ...)` index
+ * parameter, the compiler lowers the per-item handler into a single delegated
+ * listener on the container. That dispatcher re-derives the item from
+ * `data-key` / DOM position but historically dropped the index, so the handler
+ * closure referenced a dangling `i` and threw `ReferenceError: i is not
+ * defined` the first time it fired.
+ *
+ * Fix (#2189): re-derive the index at dispatch time from the same runtime
+ * source the item comes from — `arr.findIndex(...)` for keyed lookups, the
+ * already-computed DOM position for the index shapes — and bind it under the
+ * user's param name so the reference resolves.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function clientJsFor(source: string): string {
+  const result = compileJSX(source, 'Repro.tsx', { adapter })
+  expect(result.errors).toHaveLength(0)
+  const clientJs = result.files.find(f => f.type === 'clientJs')
+  expect(clientJs).toBeDefined()
+  return clientJs!.content
+}
+
+describe('delegated handler closing over the .map() index (#2189)', () => {
+  test('keyed loop: index is re-derived via findIndex and bound', () => {
+    const content = clientJsFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      interface Item { id: number; label: string }
+      export function Repro() {
+        const [items] = createSignal<Item[]>([])
+        const handle = (index: number) => { console.log(index) }
+        return (
+          <ul>
+            {items().map((item, i) => (
+              <li key={item.id}>
+                <button onClick={() => handle(i)}>{item.label}</button>
+              </li>
+            ))}
+          </ul>
+        )
+      }
+    `)
+
+    // The index param `i` must be bound inside the delegation dispatcher.
+    expect(content).toContain('const i = items().findIndex(item => String(item.id) === key)')
+    // ...and the handler is still invoked with the synthetic event.
+    expect(content).toContain('(() => handle(i))(__bfEvt)')
+    // No dangling reference: `i` is declared before the handler call runs.
+    const idxDecl = content.indexOf('const i = items().findIndex')
+    const idxCall = content.indexOf('handle(i))(__bfEvt)')
+    expect(idxDecl).toBeGreaterThanOrEqual(0)
+    expect(idxCall).toBeGreaterThan(idxDecl)
+  })
+
+  test('index binding is omitted when no handler references the index', () => {
+    const content = clientJsFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      interface Item { id: number; label: string }
+      export function Repro() {
+        const [items] = createSignal<Item[]>([])
+        const handle = (id: number) => { console.log(id) }
+        return (
+          <ul>
+            {items().map((item, i) => (
+              <li key={item.id}>
+                <button onClick={() => handle(item.id)}>{item.label}</button>
+              </li>
+            ))}
+          </ul>
+        )
+      }
+    `)
+
+    // Nothing references `i`, so the dispatcher must not emit an index binding.
+    expect(content).not.toContain('const i = items().findIndex')
+    expect(content).toContain('(() => handle(item.id))(__bfEvt)')
+  })
+
+  test('index param also works alongside item access in the same handler', () => {
+    const content = clientJsFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      interface Item { id: number; label: string }
+      export function Repro() {
+        const [items] = createSignal<Item[]>([])
+        const handle = (id: number, index: number) => { console.log(id, index) }
+        return (
+          <ul>
+            {items().map((item, i) => (
+              <li key={item.id}>
+                <button onClick={() => handle(item.id, i)}>{item.label}</button>
+              </li>
+            ))}
+          </ul>
+        )
+      }
+    `)
+
+    expect(content).toContain('const i = items().findIndex(item => String(item.id) === key)')
+    expect(content).toContain('handle(item.id, i))(__bfEvt)')
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-event-delegation.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-event-delegation.ts
@@ -34,6 +34,7 @@ export function buildDynamicLoopDelegationPlan(
       param: elem.param,
       paramBindings: elem.paramBindings,
       key: elem.key,
+      index: elem.index,
       mapPreamble: elem.mapPreamble ?? null,
     }),
   }
@@ -58,6 +59,7 @@ export function buildBranchLoopDelegationPlan(
       param: loop.param,
       paramBindings: loop.paramBindings,
       key: loop.key,
+      index: loop.index,
       mapPreamble: loop.mapPreamble ?? null,
     }),
   }
@@ -86,6 +88,7 @@ export function buildStaticArrayDelegationPlan(
       param: elem.param,
       mapPreamble: elem.mapPreamble ?? null,
       offset: elem.offset ?? null,
+      indexParam: elem.index ?? null,
     },
   }
 }
@@ -99,6 +102,7 @@ function buildKeyedOrIndexLookup(args: {
   param: string
   paramBindings: TopLevelLoop['paramBindings']
   key: string | null
+  index: string | null
   mapPreamble: string | null
 }): ItemLookup {
   const hasBindings = (args.paramBindings?.length ?? 0) > 0
@@ -116,6 +120,7 @@ function buildKeyedOrIndexLookup(args: {
       keyWithItem,
       mapPreamble: args.mapPreamble,
       hasBindings,
+      indexParam: args.index,
     }
   }
   return {
@@ -124,6 +129,7 @@ function buildKeyedOrIndexLookup(args: {
     param: args.param,
     mapPreamble: args.mapPreamble,
     hasBindings,
+    indexParam: args.index,
   }
 }
 

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/event-delegation.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/event-delegation.ts
@@ -52,10 +52,9 @@ export interface KeyedItemLookup {
   /** Loop param identifier (or destructure pattern text — used as receiver name only). */
   param: string
   /**
-   * Loop index param name (e.g. `i` from `.map((item, i) => ...)`), or `null`
-   * when the callback declares no index. When a delegated handler closes over
-   * this name, the stringifier re-derives the index at dispatch time
-   * (`arr.findIndex(...)`) and binds it so the reference resolves (#2189).
+   * Loop index param name (e.g. `i` from `.map((item, i) => ...)`), or `null`.
+   * When a delegated handler closes over it, the stringifier re-derives the
+   * index at dispatch time and binds it so the reference resolves (#2189).
    */
   indexParam: string | null
   /** Destructured-binding metadata. Determines TDZ-safe `__bfLoopItem` shape (#951). */

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/event-delegation.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/event-delegation.ts
@@ -51,6 +51,13 @@ export interface KeyedItemLookup {
   arrayExpr: string
   /** Loop param identifier (or destructure pattern text — used as receiver name only). */
   param: string
+  /**
+   * Loop index param name (e.g. `i` from `.map((item, i) => ...)`), or `null`
+   * when the callback declares no index. When a delegated handler closes over
+   * this name, the stringifier re-derives the index at dispatch time
+   * (`arr.findIndex(...)`) and binds it so the reference resolves (#2189).
+   */
+  indexParam: string | null
   /** Destructured-binding metadata. Determines TDZ-safe `__bfLoopItem` shape (#951). */
   paramBindings: TopLevelLoop['paramBindings']
   /**
@@ -72,6 +79,8 @@ export interface DynamicIndexItemLookup {
   param: string
   mapPreamble: string | null
   hasBindings: boolean
+  /** Loop index param name — see `KeyedItemLookup.indexParam` (#2189). */
+  indexParam: string | null
 }
 
 export interface StaticIndexItemLookup {
@@ -79,6 +88,8 @@ export interface StaticIndexItemLookup {
   arrayExpr: string
   param: string
   mapPreamble: string | null
+  /** Loop index param name — see `KeyedItemLookup.indexParam` (#2189). */
+  indexParam: string | null
   /**
    * Offset of the loop's items past its preceding container siblings. Its
    * terms are subtracted from the DOM child index to recover the array index,

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/event-delegation.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/event-delegation.ts
@@ -33,7 +33,7 @@
  */
 
 import { toDomEventName, varSlotId, substituteLoopBindings, buildLoopChildIndexSubtraction, DATA_KEY, keyAttrName } from '../../utils.ts'
-import { extractIdentifiers } from '../../identifiers.ts'
+import { extractFreeIdentifiersFromText } from '../../csr-substitute.ts'
 import type {
   EventDelegationPlan,
   KeyedItemLookup,
@@ -62,28 +62,15 @@ function withTurn(call: string, componentName: string | undefined, childSlotId: 
 }
 
 /**
- * Build the `const <indexParam> = <indexExpr>` binding line for a delegated
- * handler that closes over the loop's index param (#2189).
- *
- * The `.map((item, i) => ...)` index only lives inside the SSR/mapArray
- * template closure — the runtime delegation dispatcher re-derives the item
- * from `data-key`/DOM position but historically dropped the index, so a
- * handler like `() => handle(i)` threw `ReferenceError: i is not defined`.
- * We re-derive the index from the same runtime source the item comes from
- * (`arr.findIndex(...)` for keyed lookups, the already-computed `idx`/`__idx`
- * for the index shapes) and bind it under the user's param name.
- *
- * Returns `null` — emit nothing — when there is no index param, when the
- * handler never references it (so unaffected loops keep byte-for-byte output),
- * or when the user's index name already equals the in-scope index variable
- * (`idx`/`__idx`), which would make the binding a redeclaring self-alias.
+ * Bind the loop index under the user's param name for a delegated handler that
+ * closes over it (#2189). Returns `null` when there is no index param, the
+ * handler doesn't reference it (so unaffected loops keep byte-for-byte output),
+ * or the name already equals the in-scope index var (a self-alias). Uses AST
+ * free identifiers, not a token match, so `item.id` (property) doesn't count.
  */
 function indexBindingLine(handler: string, indexParam: string | null, indexExpr: string): string | null {
-  if (!indexParam) return null
-  const referenced = new Set<string>()
-  extractIdentifiers(handler, referenced)
-  if (!referenced.has(indexParam)) return null
-  if (indexParam === indexExpr) return null
+  if (!indexParam || indexParam === indexExpr) return null
+  if (!extractFreeIdentifiersFromText(handler).has(indexParam)) return null
   return `const ${indexParam} = ${indexExpr}`
 }
 
@@ -194,7 +181,6 @@ function emitKeyedLookup(
   const outerGuard = hasBindings ? '__bfLoopItem' : param
   const allParams = [outerGuard, ...ev.nestedLoops.map(n => n.param)]
   if (mapPreamble) ls.push(`      ${mapPreamble}`)
-  // Outer-loop index — re-derived from the outer key (#2189).
   const idxLine = indexBindingLine(ev.handler, indexParam, `${arrayExpr}.findIndex(item => String(${keyWithItem}) === outerKey)`)
   if (idxLine) ls.push(`      if (${allParams.join(' && ')}) { ${idxLine}; ${handlerCall} }`)
   else ls.push(`      if (${allParams.join(' && ')}) ${handlerCall}`)
@@ -207,8 +193,6 @@ function emitDynamicIndexLookup(
   lookup: DynamicIndexItemLookup,
 ): void {
   const { arrayExpr, param, mapPreamble, hasBindings, indexParam } = lookup
-  // `idx` is the DOM/array position — alias it to the user's index param when
-  // a handler closes over it (#2189).
   const idxLine = indexBindingLine(ev.handler, indexParam, 'idx')
   ls.push(`      const li = ${varSlotId(ev.childSlotId)}El.closest('li, [bf-i]')`)
   ls.push(`      if (li && li.parentElement) {`)
@@ -238,8 +222,6 @@ function emitStaticIndexLookup(
   containerVar: string,
 ): void {
   const { arrayExpr, param, mapPreamble, offset, indexParam } = lookup
-  // `__idx` is the recovered array index — alias it to the user's index param
-  // when a handler closes over it (#2189).
   const idxLine = indexBindingLine(ev.handler, indexParam, '__idx')
   ls.push(`      let __el = ${varSlotId(ev.childSlotId)}El`)
   ls.push(`      while (__el.parentElement && __el.parentElement !== ${containerVar}) __el = __el.parentElement`)

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/event-delegation.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/event-delegation.ts
@@ -33,6 +33,7 @@
  */
 
 import { toDomEventName, varSlotId, substituteLoopBindings, buildLoopChildIndexSubtraction, DATA_KEY, keyAttrName } from '../../utils.ts'
+import { extractIdentifiers } from '../../identifiers.ts'
 import type {
   EventDelegationPlan,
   KeyedItemLookup,
@@ -58,6 +59,32 @@ function withTurn(call: string, componentName: string | undefined, childSlotId: 
   if (!componentName) return call
   const id = JSON.stringify(`${componentName}#handler:${childSlotId}:${eventName}`)
   return `beginTurn(${id}); try { ${call} } finally { endTurn() }`
+}
+
+/**
+ * Build the `const <indexParam> = <indexExpr>` binding line for a delegated
+ * handler that closes over the loop's index param (#2189).
+ *
+ * The `.map((item, i) => ...)` index only lives inside the SSR/mapArray
+ * template closure — the runtime delegation dispatcher re-derives the item
+ * from `data-key`/DOM position but historically dropped the index, so a
+ * handler like `() => handle(i)` threw `ReferenceError: i is not defined`.
+ * We re-derive the index from the same runtime source the item comes from
+ * (`arr.findIndex(...)` for keyed lookups, the already-computed `idx`/`__idx`
+ * for the index shapes) and bind it under the user's param name.
+ *
+ * Returns `null` — emit nothing — when there is no index param, when the
+ * handler never references it (so unaffected loops keep byte-for-byte output),
+ * or when the user's index name already equals the in-scope index variable
+ * (`idx`/`__idx`), which would make the binding a redeclaring self-alias.
+ */
+function indexBindingLine(handler: string, indexParam: string | null, indexExpr: string): string | null {
+  if (!indexParam) return null
+  const referenced = new Set<string>()
+  extractIdentifiers(handler, referenced)
+  if (!referenced.has(indexParam)) return null
+  if (indexParam === indexExpr) return null
+  return `const ${indexParam} = ${indexExpr}`
 }
 
 export function stringifyEventDelegation(lines: string[], plan: EventDelegationPlan): void {
@@ -112,10 +139,11 @@ function emitKeyedLookup(
   handlerCall: string,
   lookup: KeyedItemLookup,
 ): void {
-  const { arrayExpr, param, keyWithItem, mapPreamble, hasBindings } = lookup
+  const { arrayExpr, param, keyWithItem, mapPreamble, hasBindings, indexParam } = lookup
 
   if (ev.nestedLoops.length === 0) {
     // Single-level keyed lookup.
+    const idxLine = indexBindingLine(ev.handler, indexParam, `${arrayExpr}.findIndex(item => String(${keyWithItem}) === key)`)
     ls.push(`      const li = ${varSlotId(ev.childSlotId)}El.closest('[${DATA_KEY}]')`)
     ls.push(`      if (li) {`)
     ls.push(`        const key = li.getAttribute('${DATA_KEY}')`)
@@ -125,12 +153,14 @@ function emitKeyedLookup(
       ls.push(`        if (__bfLoopItem) {`)
       ls.push(`          const ${param} = __bfLoopItem`)
       if (mapPreamble) ls.push(`          ${mapPreamble}`)
+      if (idxLine) ls.push(`          ${idxLine}`)
       ls.push(`          ${handlerCall}`)
       ls.push(`        }`)
     } else {
       ls.push(`        const ${param} = ${arrayExpr}.find(item => String(${keyWithItem}) === key)`)
       if (mapPreamble) ls.push(`        ${mapPreamble}`)
-      ls.push(`        if (${param}) ${handlerCall}`)
+      if (idxLine) ls.push(`        if (${param}) { ${idxLine}; ${handlerCall} }`)
+      else ls.push(`        if (${param}) ${handlerCall}`)
     }
     ls.push(`      }`)
     return
@@ -164,7 +194,10 @@ function emitKeyedLookup(
   const outerGuard = hasBindings ? '__bfLoopItem' : param
   const allParams = [outerGuard, ...ev.nestedLoops.map(n => n.param)]
   if (mapPreamble) ls.push(`      ${mapPreamble}`)
-  ls.push(`      if (${allParams.join(' && ')}) ${handlerCall}`)
+  // Outer-loop index — re-derived from the outer key (#2189).
+  const idxLine = indexBindingLine(ev.handler, indexParam, `${arrayExpr}.findIndex(item => String(${keyWithItem}) === outerKey)`)
+  if (idxLine) ls.push(`      if (${allParams.join(' && ')}) { ${idxLine}; ${handlerCall} }`)
+  else ls.push(`      if (${allParams.join(' && ')}) ${handlerCall}`)
 }
 
 function emitDynamicIndexLookup(
@@ -173,7 +206,10 @@ function emitDynamicIndexLookup(
   handlerCall: string,
   lookup: DynamicIndexItemLookup,
 ): void {
-  const { arrayExpr, param, mapPreamble, hasBindings } = lookup
+  const { arrayExpr, param, mapPreamble, hasBindings, indexParam } = lookup
+  // `idx` is the DOM/array position — alias it to the user's index param when
+  // a handler closes over it (#2189).
+  const idxLine = indexBindingLine(ev.handler, indexParam, 'idx')
   ls.push(`      const li = ${varSlotId(ev.childSlotId)}El.closest('li, [bf-i]')`)
   ls.push(`      if (li && li.parentElement) {`)
   ls.push(`        const idx = Array.from(li.parentElement.children).indexOf(li)`)
@@ -182,12 +218,14 @@ function emitDynamicIndexLookup(
     ls.push(`        if (__bfLoopItem) {`)
     ls.push(`          const ${param} = __bfLoopItem`)
     if (mapPreamble) ls.push(`          ${mapPreamble}`)
+    if (idxLine) ls.push(`          ${idxLine}`)
     ls.push(`          ${handlerCall}`)
     ls.push(`        }`)
   } else {
     ls.push(`        const ${param} = ${arrayExpr}[idx]`)
     if (mapPreamble) ls.push(`        ${mapPreamble}`)
-    ls.push(`        if (${param}) ${handlerCall}`)
+    if (idxLine) ls.push(`        if (${param}) { ${idxLine}; ${handlerCall} }`)
+    else ls.push(`        if (${param}) ${handlerCall}`)
   }
   ls.push(`      }`)
 }
@@ -199,7 +237,10 @@ function emitStaticIndexLookup(
   lookup: StaticIndexItemLookup,
   containerVar: string,
 ): void {
-  const { arrayExpr, param, mapPreamble, offset } = lookup
+  const { arrayExpr, param, mapPreamble, offset, indexParam } = lookup
+  // `__idx` is the recovered array index — alias it to the user's index param
+  // when a handler closes over it (#2189).
+  const idxLine = indexBindingLine(ev.handler, indexParam, '__idx')
   ls.push(`      let __el = ${varSlotId(ev.childSlotId)}El`)
   ls.push(`      while (__el.parentElement && __el.parentElement !== ${containerVar}) __el = __el.parentElement`)
   ls.push(`      if (__el.parentElement === ${containerVar}) {`)
@@ -207,6 +248,7 @@ function emitStaticIndexLookup(
   ls.push(`        const __idx = Array.from(${containerVar}.children).indexOf(__el)${idxOffset}`)
   ls.push(`        const ${param} = ${arrayExpr}[__idx]`)
   if (mapPreamble) ls.push(`        ${mapPreamble}`)
-  ls.push(`        if (${param}) ${handlerCall}`)
+  if (idxLine) ls.push(`        if (${param}) { ${idxLine}; ${handlerCall} }`)
+  else ls.push(`        if (${param}) ${handlerCall}`)
   ls.push(`      }`)
 }

--- a/packages/jsx/src/ir-to-client-js/csr-substitute.ts
+++ b/packages/jsx/src/ir-to-client-js/csr-substitute.ts
@@ -323,7 +323,7 @@ export function applyPropsRewrite(text: string, propsObjectName: string | null):
   return text.replace(new RegExp(`\\b${propsObjectName}\\.`, 'g'), `${PROPS_PARAM}.`)
 }
 
-function extractFreeIdentifiersFromText(text: string): Set<string> {
+export function extractFreeIdentifiersFromText(text: string): Set<string> {
   if (!text || text.trim().length === 0) return new Set()
   const sf = ts.createSourceFile(
     '__free_ids__.ts',

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 238,
+    "totalFixtures": 239,
     "fixtures": {
       "array-map-function-reference": {
         "blade": {


### PR DESCRIPTION
## Summary

Fixes #2189.

When a delegated list-item handler closed over the `.map((item, i) => ...)` **index** param, the compiled client bundle threw `ReferenceError: i is not defined` the first time the handler fired. `bf build` lowers the per-item handler into a single delegated `click` listener that re-derives the **item** from `data-key`/DOM position but historically dropped the **index** — so the handler closure referenced a dangling `i`. Item-property access (`item.id`) worked because that was re-derived; the positional index had no equivalent re-derivation.

```tsx
{items().map((item, i) => (
  <li key={item.id}>
    <button onClick={() => handle(i)}>{item.label}</button>  {/* i was dangling */}
  </li>
))}
```

## Approach

Per the compiler's "IR carries the info, the emitter emits it" design (the `ItemLookup` **plan** holds the info, the **stringifier** emits), the fix threads the loop's index-param name into the plan and re-derives the index at dispatch time from the **same runtime source the item comes from**:

- **keyed lookup** → `arr.findIndex(item => String(key) === key)`
- **dynamic-index / static-index lookup** → the already-computed DOM position (`idx` / `__idx`), aliased to the user's param name

The binding is **gated on the handler actually referencing the index**, so loops whose handlers don't use the index keep byte-for-byte identical output — no churn to existing conformance fixtures.

Generated dispatcher (keyed):

```js
const item = items().find(item => String(item.id) === key)
if (item) { const i = items().findIndex(item => String(item.id) === key); (() => handle(i))(__bfEvt) }
```

## Changes

- `plan/event-delegation.ts` — add `indexParam` to the three `ItemLookup` variants.
- `plan/build-event-delegation.ts` — populate `indexParam` from the loop's `index` (top-level, branch-scoped, and static-array delegation plans).
- `stringify/event-delegation.ts` — new `indexBindingLine` helper; emit the index binding in every lookup shape when the handler closes over it.

## Testing

- **Compiler unit** (`packages/jsx/.../event-delegation-index-param.test.ts`) — pins the generated `findIndex` binding, verifies it is declared before the handler call, and confirms output is unchanged when no handler references the index.
- **End-to-end runtime** (`packages/client/.../event-delegation-index-param-e2e.test.ts`) — mounts the real compiled output in a DOM, clicks rows, and asserts the handler runs with the correct index (0/1/2) and alongside item access. Verified to **fail** against the old codegen.
- No regressions: delegation-focused jsx suite (40/40), CSR conformance (187/187), client runtime (288/288). The 9 pre-existing carousel cross-adapter SSR failures are unrelated (fail identically on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLH9SkKb1iVpUmvcKrypj7)_