### PR TITLE
Make evaluator Number() string coercion JS-faithful on Go and Ruby

### DIFF
--- a/.changeset/eval-number-string-coercion.md
+++ b/.changeset/eval-number-string-coercion.md
@@ -1,0 +1,11 @@
+---
+"@barefootjs/go-template": patch
+"@barefootjs/erb": patch
+---
+
+Make the `ParsedExpr` evaluator's `Number()` / ToNumber string coercion JS-faithful on the Go and Ruby backends, closing two divergences from the JS reference (the evaluator subset allows none). Both surface when a `map` / `filter` / `sort` / `reduce` callback body coerces a string field, e.g. `.filter(x => Number(x.code) > 0)`.
+
+- **Ruby (`@barefootjs/erb`)** — `Number("5.")` **raised** `ArgumentError` (Ruby's `Float()` rejects a trailing decimal point), aborting SSR with a 500 where JS returns `5`. `parse_numeric_string` now normalizes a `.` not followed by a digit (`"5."` → `"5"`, `"5.e3"` → `"5e3"`) before converting, and wraps the conversion so a coercion can never raise (falls back to `NaN`). The accepted grammar is unchanged.
+- **Go (`@barefootjs/go-template`)** — `evalToNumber` delegated to `strconv.ParseFloat`, which **over-accepts** forms JS's `Number()` rejects: underscore digit separators (`"1_000"` → `1000`, JS `NaN`) and hex-float syntax (`"0x1p4"` → `16`, JS `NaN`), and turned decimal overflow into `NaN` (`"1e1000"`, JS `Infinity`). It now gates on the JS decimal `StringToNumber` grammar (anchored regexp: sign, integer/fraction digits, exponent — ASCII digits only), handles the exact `Infinity` / `+Infinity` / `-Infinity` spellings, and passes `strconv.ErrRange` results (±Inf) through instead of discarding them. Radix-prefixed integer strings (`0x` / `0o` / `0b`) remain `NaN`, unchanged (the documented radix-divergence region shared with the other backends).
+
+Ten `Number(...)` cases pinning the decimal numeric-string grammar (leading/trailing dot, sign, exponent, whitespace, underscore rejection, hex-float rejection, overflow → ±Infinity) are added to the shared evaluator vector corpus (`eval-vectors.json`), so all five evaluator backends (Go, Ruby, Perl, Python, PHP) are held to JS parity here going forward.

--- a/packages/adapter-erb/lib/barefoot_js/evaluator.rb
+++ b/packages/adapter-erb/lib/barefoot_js/evaluator.rb
@@ -188,7 +188,20 @@ module BarefootJS
       return Float::INFINITY if t == 'Infinity' || t == '+Infinity'
       return -Float::INFINITY if t == '-Infinity'
       return Integer(t, 16) if t =~ HEX_STRING_RE
-      return Float(t) if t =~ NUMERIC_STRING_RE
+
+      if t =~ NUMERIC_STRING_RE
+        # Ruby's Float() rejects a trailing decimal point ("5.", "5.e3"),
+        # while JS's Number() accepts it (treating the fractional part as
+        # empty). Strip a "." that isn't followed by a digit before
+        # converting, so the accepted grammar stays identical to JS but the
+        # conversion itself never raises.
+        normalized = t.sub(/\.(?=\z|[eE])/, '')
+        begin
+          return Float(normalized)
+        rescue ArgumentError, TypeError
+          return Float::NAN
+        end
+      end
 
       Float::NAN
     end

--- a/packages/adapter-go-template/runtime/eval.go
+++ b/packages/adapter-go-template/runtime/eval.go
@@ -2,8 +2,10 @@ package bf
 
 import (
 	"encoding/json"
+	"errors"
 	"math"
 	"reflect"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -304,6 +306,13 @@ func evalJoin(obj any, sep string) string {
 // null/"" → NaN) for SSR-survival reasons that do not apply to the evaluator.
 // ---------------------------------------------------------------------------
 
+// jsDecimalNumberRe matches the JS StringToNumber decimal numeric literal
+// grammar (ASCII digits only): optional sign, then integer/fraction digits,
+// then an optional exponent. It deliberately excludes underscore digit
+// separators, radix prefixes (0x/0o/0b), and hex-float forms — none of which
+// are valid JS decimal numeric literals.
+var jsDecimalNumberRe = regexp.MustCompile(`^[+-]?(?:[0-9]+\.?[0-9]*|\.[0-9]+)(?:[eE][+-]?[0-9]+)?$`)
+
 func evalToNumber(v any) float64 {
 	switch x := v.(type) {
 	case nil:
@@ -318,19 +327,40 @@ func evalToNumber(v any) float64 {
 		if t == "" {
 			return 0
 		}
-		// Decimal / exponent / "Infinity" numeric strings parse JS-faithfully
-		// (ParseFloat handles these, matching the Perl evaluator). The
-		// radix-prefixed forms JS Number() also accepts ("0x10" / "0o17" /
-		// "0b101") are a documented divergence region: they yield NaN here, as
-		// they do in the Perl evaluator (looks_like_number is false for them),
-		// so Go==Perl while differing from the JS reference. Template data
-		// carries JSON numbers, not radix-string literals, so this never
-		// arises in practice.
-		f, err := strconv.ParseFloat(t, 64)
-		if err != nil {
+		// Exact JS Infinity spellings (case-sensitive, no other aliases like
+		// "infinity"/"inf" are valid JS numeric strings).
+		switch t {
+		case "Infinity", "+Infinity":
+			return math.Inf(1)
+		case "-Infinity":
+			return math.Inf(-1)
+		}
+		// Decimal / exponent numeric strings parse JS-faithfully, including
+		// overflow: strconv.ParseFloat rejects underscores, hex-floats, and
+		// non-canonical "inf"/"nan" spellings via the anchored decimal-grammar
+		// gate below, so those correctly yield NaN. The radix-prefixed forms
+		// JS Number() also accepts ("0x10" / "0o17" / "0b101") are a
+		// documented divergence region: they fail the decimal grammar (a
+		// leading "0x"/"0o"/"0b" is not a valid decimal literal) and yield
+		// NaN here, as they do in the Perl evaluator (looks_like_number is
+		// false for them), so Go==Perl while differing from the JS
+		// reference. Template data carries JSON numbers, not radix-string
+		// literals, so this never arises in practice.
+		if !jsDecimalNumberRe.MatchString(t) {
 			return math.NaN()
 		}
-		return f
+		f, err := strconv.ParseFloat(t, 64)
+		if err == nil {
+			return f
+		}
+		if errors.Is(err, strconv.ErrRange) {
+			// ParseFloat still returns the correctly-signed ±Inf (or a
+			// subnormal) as its best-effort value on overflow/underflow;
+			// JS Number() on an overflowing decimal literal yields ±Infinity
+			// (e.g. "1e1000" -> +Infinity), so surface that value as-is.
+			return f
+		}
+		return math.NaN()
 	default:
 		if evalIsNumeric(v) {
 			return toFloat64(v)

--- a/packages/adapter-tests/vectors/eval-cases.ts
+++ b/packages/adapter-tests/vectors/eval-cases.ts
@@ -115,6 +115,27 @@ export const evalCases: EvalCase[] = [
   { src: 'Number(item.s)', env: { item: { s: '3.14' } }, note: 'Number() parses a numeric string' },
   { src: 'Boolean(item.s)', env: { item: { s: '' } }, note: 'Boolean() of an empty string is false' },
 
+  // ----- Number() string coercion: the JS decimal StringToNumber grammar ---
+  // These pin the numeric-string grammar edges each backend must reproduce
+  // byte-for-byte with JS `Number(s)`. Two backends diverged here before
+  // being fixed: the Ruby evaluator RAISED on a trailing-dot string
+  // (`"5."` — aborting SSR) instead of returning 5, and the Go evaluator
+  // OVER-accepted forms JS rejects (underscore separators, hex-float
+  // `0x…p…` syntax) and turned decimal overflow into NaN. The valid decimal
+  // grammar (leading/trailing dot, sign, exponent, whitespace) must parse;
+  // anything outside it — underscores, hex-floats, trailing junk — is NaN;
+  // and a decimal that overflows the double range is ±Infinity, never NaN.
+  { src: 'Number(item.s)', env: { item: { s: '5.' } }, note: 'Number: a trailing decimal point is valid (→ 5), and must not raise' },
+  { src: 'Number(item.s)', env: { item: { s: '.5' } }, note: 'Number: a leading decimal point is valid (→ 0.5)' },
+  { src: 'Number(item.s)', env: { item: { s: '+7' } }, note: 'Number: a leading plus sign parses' },
+  { src: 'Number(item.s)', env: { item: { s: '1e3' } }, note: 'Number: exponent notation parses' },
+  { src: 'Number(item.s)', env: { item: { s: '  42  ' } }, note: 'Number: surrounding ASCII whitespace is trimmed' },
+  { src: 'Number(item.s)', env: { item: { s: '12px' } }, note: 'Number: trailing non-numeric junk is NaN' },
+  { src: 'Number(item.s)', env: { item: { s: '1_000' } }, note: 'Number: underscore digit separators are NOT valid in JS strings (→ NaN)' },
+  { src: 'Number(item.s)', env: { item: { s: '0x1p4' } }, note: 'Number: hex-float syntax is not a valid JS numeric string (→ NaN)' },
+  { src: 'Number(item.s)', env: { item: { s: '1e1000' } }, note: 'Number: a decimal literal that overflows the double range is Infinity, not NaN' },
+  { src: 'Number(item.s)', env: { item: { s: '-1e1000' } }, note: 'Number: negative decimal overflow is -Infinity' },
+
   // ----- array-method: includes --------------------------------------------
   { src: "item.tags.includes('go')", env: { item: { tags: ['perl', 'go'] } }, note: 'array .includes: hit' },
   { src: "item.tags.includes('rust')", env: { item: { tags: ['perl', 'go'] } }, note: 'array .includes: miss' },

--- a/packages/adapter-tests/vectors/eval-vectors.json
+++ b/packages/adapter-tests/vectors/eval-vectors.json
@@ -1717,6 +1717,306 @@
       "note": "Boolean() of an empty string is false"
     },
     {
+      "src": "Number(item.s)",
+      "expr": {
+        "kind": "call",
+        "callee": {
+          "kind": "identifier",
+          "name": "Number"
+        },
+        "args": [
+          {
+            "kind": "member",
+            "object": {
+              "kind": "identifier",
+              "name": "item"
+            },
+            "property": "s",
+            "computed": false,
+            "optional": false
+          }
+        ]
+      },
+      "env": {
+        "item": {
+          "s": "5."
+        }
+      },
+      "expect": 5,
+      "note": "Number: a trailing decimal point is valid (→ 5), and must not raise"
+    },
+    {
+      "src": "Number(item.s)",
+      "expr": {
+        "kind": "call",
+        "callee": {
+          "kind": "identifier",
+          "name": "Number"
+        },
+        "args": [
+          {
+            "kind": "member",
+            "object": {
+              "kind": "identifier",
+              "name": "item"
+            },
+            "property": "s",
+            "computed": false,
+            "optional": false
+          }
+        ]
+      },
+      "env": {
+        "item": {
+          "s": ".5"
+        }
+      },
+      "expect": 0.5,
+      "note": "Number: a leading decimal point is valid (→ 0.5)"
+    },
+    {
+      "src": "Number(item.s)",
+      "expr": {
+        "kind": "call",
+        "callee": {
+          "kind": "identifier",
+          "name": "Number"
+        },
+        "args": [
+          {
+            "kind": "member",
+            "object": {
+              "kind": "identifier",
+              "name": "item"
+            },
+            "property": "s",
+            "computed": false,
+            "optional": false
+          }
+        ]
+      },
+      "env": {
+        "item": {
+          "s": "+7"
+        }
+      },
+      "expect": 7,
+      "note": "Number: a leading plus sign parses"
+    },
+    {
+      "src": "Number(item.s)",
+      "expr": {
+        "kind": "call",
+        "callee": {
+          "kind": "identifier",
+          "name": "Number"
+        },
+        "args": [
+          {
+            "kind": "member",
+            "object": {
+              "kind": "identifier",
+              "name": "item"
+            },
+            "property": "s",
+            "computed": false,
+            "optional": false
+          }
+        ]
+      },
+      "env": {
+        "item": {
+          "s": "1e3"
+        }
+      },
+      "expect": 1000,
+      "note": "Number: exponent notation parses"
+    },
+    {
+      "src": "Number(item.s)",
+      "expr": {
+        "kind": "call",
+        "callee": {
+          "kind": "identifier",
+          "name": "Number"
+        },
+        "args": [
+          {
+            "kind": "member",
+            "object": {
+              "kind": "identifier",
+              "name": "item"
+            },
+            "property": "s",
+            "computed": false,
+            "optional": false
+          }
+        ]
+      },
+      "env": {
+        "item": {
+          "s": "  42  "
+        }
+      },
+      "expect": 42,
+      "note": "Number: surrounding ASCII whitespace is trimmed"
+    },
+    {
+      "src": "Number(item.s)",
+      "expr": {
+        "kind": "call",
+        "callee": {
+          "kind": "identifier",
+          "name": "Number"
+        },
+        "args": [
+          {
+            "kind": "member",
+            "object": {
+              "kind": "identifier",
+              "name": "item"
+            },
+            "property": "s",
+            "computed": false,
+            "optional": false
+          }
+        ]
+      },
+      "env": {
+        "item": {
+          "s": "12px"
+        }
+      },
+      "expect": {
+        "$num": "NaN"
+      },
+      "note": "Number: trailing non-numeric junk is NaN"
+    },
+    {
+      "src": "Number(item.s)",
+      "expr": {
+        "kind": "call",
+        "callee": {
+          "kind": "identifier",
+          "name": "Number"
+        },
+        "args": [
+          {
+            "kind": "member",
+            "object": {
+              "kind": "identifier",
+              "name": "item"
+            },
+            "property": "s",
+            "computed": false,
+            "optional": false
+          }
+        ]
+      },
+      "env": {
+        "item": {
+          "s": "1_000"
+        }
+      },
+      "expect": {
+        "$num": "NaN"
+      },
+      "note": "Number: underscore digit separators are NOT valid in JS strings (→ NaN)"
+    },
+    {
+      "src": "Number(item.s)",
+      "expr": {
+        "kind": "call",
+        "callee": {
+          "kind": "identifier",
+          "name": "Number"
+        },
+        "args": [
+          {
+            "kind": "member",
+            "object": {
+              "kind": "identifier",
+              "name": "item"
+            },
+            "property": "s",
+            "computed": false,
+            "optional": false
+          }
+        ]
+      },
+      "env": {
+        "item": {
+          "s": "0x1p4"
+        }
+      },
+      "expect": {
+        "$num": "NaN"
+      },
+      "note": "Number: hex-float syntax is not a valid JS numeric string (→ NaN)"
+    },
+    {
+      "src": "Number(item.s)",
+      "expr": {
+        "kind": "call",
+        "callee": {
+          "kind": "identifier",
+          "name": "Number"
+        },
+        "args": [
+          {
+            "kind": "member",
+            "object": {
+              "kind": "identifier",
+              "name": "item"
+            },
+            "property": "s",
+            "computed": false,
+            "optional": false
+          }
+        ]
+      },
+      "env": {
+        "item": {
+          "s": "1e1000"
+        }
+      },
+      "expect": {
+        "$num": "Infinity"
+      },
+      "note": "Number: a decimal literal that overflows the double range is Infinity, not NaN"
+    },
+    {
+      "src": "Number(item.s)",
+      "expr": {
+        "kind": "call",
+        "callee": {
+          "kind": "identifier",
+          "name": "Number"
+        },
+        "args": [
+          {
+            "kind": "member",
+            "object": {
+              "kind": "identifier",
+              "name": "item"
+            },
+            "property": "s",
+            "computed": false,
+            "optional": false
+          }
+        ]
+      },
+      "env": {
+        "item": {
+          "s": "-1e1000"
+        }
+      },
+      "expect": {
+        "$num": "-Infinity"
+      },
+      "note": "Number: negative decimal overflow is -Infinity"
+    },
+    {
       "src": "item.tags.includes('go')",
       "expr": {
         "kind": "array-method",


### PR DESCRIPTION
## Summary

The `ParsedExpr` evaluator subset (used for `map` / `filter` / `sort` / `reduce` / `find` callback bodies) is **JS-normative and allows no per-backend divergence** — every backend must reproduce the JS reference exactly. I built a divergence probe that feeds candidate callback-body expressions through the real compiler `parseExpression` + the JS reference evaluator and replays them against all five backend evaluators (Go, Ruby, Perl, Python, PHP). It surfaced two genuine divergences on the `Number()` / string→number coercion path, both reachable from real components like `.filter(x => Number(x.code) > 0)`:

- **Ruby (`@barefootjs/erb`) — crash-on-render.** `Number("5.")` **raised** `ArgumentError` (Ruby's `Float()` rejects a trailing decimal point), aborting SSR with a 500 where JS returns `5`. `parse_numeric_string` now normalizes a `.` not followed by a digit (`"5."` → `"5"`, `"5.e3"` → `"5e3"`) before converting, and wraps the conversion so a string coercion can **never** raise (falls back to `NaN`). The accepted grammar is unchanged.
- **Go (`@barefootjs/go-template`) — silent wrong value.** `evalToNumber` delegated to `strconv.ParseFloat`, which **over-accepts** forms JS's `Number()` rejects — underscore digit separators (`"1_000"` → `1000`, JS `NaN`) and hex-float syntax (`"0x1p4"` → `16`, JS `NaN`) — and turned decimal overflow into `NaN` (`"1e1000"`, JS `Infinity`). It now gates on the JS decimal `StringToNumber` grammar (anchored regexp, ASCII digits only), handles the exact `Infinity` / `+Infinity` / `-Infinity` spellings, and passes `strconv.ErrRange` results (±Inf) through. Radix-prefixed integer strings (`0x` / `0o` / `0b`) remain `NaN`, unchanged — the documented radix-divergence region shared with the other backends.

Perl, Python, and PHP were already JS-faithful on this surface (they gate with a numeric-string regexp before converting), so no change was needed there.

## Conformance tests added

Ten `Number(...)` cases pinning the JS decimal numeric-string grammar are added to the shared evaluator vector corpus (`eval-cases.ts` → regenerated `eval-vectors.json`), so all five evaluator backends are held to JS parity here going forward:

| Input | Expect | Pins |
|---|---|---|
| `"5."` | `5` | Ruby no longer raises on a trailing dot |
| `".5"` | `0.5` | leading dot |
| `"+7"` | `7` | leading sign |
| `"1e3"` | `1000` | exponent |
| `"  42  "` | `42` | surrounding whitespace trimmed |
| `"12px"` | `NaN` | trailing junk |
| `"1_000"` | `NaN` | Go no longer accepts underscore separators |
| `"0x1p4"` | `NaN` | Go no longer accepts hex-float syntax |
| `"1e1000"` | `Infinity` | Go overflow → ±Infinity, not NaN |
| `"-1e1000"` | `-Infinity` | negative overflow |

## Verification

- All five backend evaluator conformance suites pass on the regenerated corpus (93 cases): Go `TestEvalVectors`, Ruby `eval_vectors_test.rb`, Perl `t/eval_vectors.t`, Python `test_eval_vectors.py`, PHP `test_eval_vectors.php`.
- `eval-vectors.json` freshness test passes (`packages/adapter-tests/src/__tests__/eval-vectors.test.ts`).
- Full Go runtime package (`go test ./...`) and full Ruby test dir pass.
- The 9 pre-existing `Carousel cross-adapter SSR render conformance` failures in the adapter-tests suite are unrelated to this change (they fail identically on the base commit with these changes stashed).

## Scope notes (findings intentionally not fixed here)

The probe also confirmed several divergences that the spec **already documents as deliberate limitations**, so they are out of scope for this PR:

- String `.length` on non-ASCII text (UTF-16 code units in JS vs code points / bytes across hosts) — `spec/template-helpers.md` scopes string ops to the "ASCII domain."
- Float→string precision for inexact binary fractions (e.g. `0.1 + 0.2`) on Perl — documented in `spec/compiler.md` as a known reduce/sort divergence.
- `Number()` of radix-**integer** strings (`0x1F` / `0b101` / `0o17`) → `NaN` — the documented radix-divergence region (kept consistent across backends).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHEM9PUssUM5WLQoRCPfY7)_