### PR TITLE
fix(cli): accept both workers-types majors in the Hono scaffold (fix smoke ERESOLVE)

### DIFF
--- a/.changeset/scaffold-workers-types-dual-major.md
+++ b/.changeset/scaffold-workers-types-dual-major.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/cli": patch
+---
+
+Stop fresh Hono/Cloudflare scaffolds from failing `npm install` with ERESOLVE whenever wrangler flips which `@cloudflare/workers-types` major it peers on. wrangler has bounced between `^4` (4.107.1) and `^5` (4.108.0 deprecated same-day, then 4.110.0) across recent point releases, and each flip broke the scaffold's single-major pin (bun tolerates the mismatch; npm does not — caught by the smoke-publish CI gate). The `bf init` / create-barefootjs Hono template now pins `@cloudflare/workers-types` to `^4.20260702.1 || ^5.20260708.1`, so npm installs whichever major the resolved wrangler actually peers on — v5 today, v4 automatically if a deprecation falls back to a v4-peering wrangler — with no ERESOLVE either way. Verified end-to-end against both wrangler 4.110.0 (peers v5) and 4.107.1 (peers v4).

--- a/packages/cli/src/lib/adapters/hono.ts
+++ b/packages/cli/src/lib/adapters/hono.ts
@@ -231,17 +231,16 @@ export const HONO_ADAPTER: AdapterTemplate = {
   devDependencies: {
     ...UNOCSS_DEV_DEPENDENCIES,
     '@barefootjs/cli': 'latest',
-    // Must track wrangler's `peerOptional @cloudflare/workers-types`
-    // (bun tolerates a mismatch; npm does not — CI's smoke-publish
-    // gate catches it). wrangler 4.108.0 briefly moved this to
-    // `^5.20260706.1`, but upstream deprecated that release the same
-    // day ("causing deployment failures in CI ... downgrade to
-    // 4.107.1") — npm's resolver skips a deprecated version when
-    // satisfying a range, so `wrangler: '^4.0.0'` (below) resolves
-    // back to 4.107.1, which still peers on
-    // `^4.20260702.1`. Track whichever wrangler actually resolves,
-    // not whichever last shipped upstream.
-    '@cloudflare/workers-types': '^4.20260702.1',
+    // Must satisfy wrangler's `peerOptional @cloudflare/workers-types`
+    // (bun tolerates a mismatch; npm does not — CI's smoke-publish gate
+    // catches it). Upstream keeps flip-flopping which major it peers on:
+    // 4.107.1 peers `^4.20260702.1`; 4.108.0 moved to `^5.20260706.1` and
+    // was deprecated same-day; 4.110.0 (which `^4.0.0` resolves to today)
+    // peers `^5.20260708.1`. Rather than chase whichever version last
+    // shipped, accept BOTH majors so npm installs whichever the resolved
+    // wrangler actually peers on — v5 when it wants v5, v4 after a
+    // deprecation falls back to a v4-peering wrangler. No ERESOLVE either way.
+    '@cloudflare/workers-types': '^4.20260702.1 || ^5.20260708.1',
     // `@barefootjs/test` powers `renderToTest()` — the canonical
     // millisecond IR test the docs (and `bf gen test`) point new users
     // at. Without it the scaffold's `test` script is a no-op and any


### PR DESCRIPTION
## Summary

Fixes the repo-wide `smoke` CI failure: fresh Hono/Cloudflare scaffolds fail `npm install` with `ERESOLVE` whenever `wrangler` flips which `@cloudflare/workers-types` **major** it peers on.

`wrangler`'s `peerOptional @cloudflare/workers-types` has bounced across recent point releases:
- `4.107.1` → peers `^4.20260702.1`
- `4.108.0` → moved to `^5.20260706.1`, deprecated the same day
- `4.110.0` (what `wrangler: ^4.0.0` resolves to today) → peers `^5.20260708.1`

Each flip broke the scaffold's single-major pin. bun tolerates the mismatch; npm does not — and the smoke-publish gate catches it, turning `smoke` red on `main` and every open PR.

## Fix

Pin `@cloudflare/workers-types` in the `bf init` / `create-barefootjs` Hono template to a **dual-major range**:

```
- '@cloudflare/workers-types': '^4.20260702.1',
+ '@cloudflare/workers-types': '^4.20260702.1 || ^5.20260708.1',
```

npm then installs whichever major the *resolved* wrangler actually peers on — no more chasing whichever version last shipped:
- wrangler peers v5 → npm installs `5.20260708.1`
- a deprecation falls back to a v4-peering wrangler → npm installs `4.20260702.1`

Either way, no `ERESOLVE`.

## Verification

- `bun run scripts/smoke-publish.mjs` → **All smoke steps passed** (the "Wire tarballs" `npm install` that previously ERESOLVE'd now installs 168 packages cleanly; `bf build`, `npm run build`, `npm test` all green).
- Direct `npm install` repro against both `wrangler@4.110.0` (resolves workers-types v5) and `wrangler@4.107.1` (resolves v4) — both succeed.
- `packages/cli` templates test: 141 pass / 0 fail.

Changed files: `packages/cli/src/lib/adapters/hono.ts` (the pin + updated rationale comment) and a changeset. No test asserted the version string, so none needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLH9SkKb1iVpUmvcKrypj7)_