### PR TITLE
Fix string-concat-plus divergence on Go template adapter

### DIFF
--- a/.changeset/string-concat-plus.md
+++ b/.changeset/string-concat-plus.md
@@ -1,0 +1,13 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Fix `'Hello, ' + name` rendering `"0"` on the Go template adapter.
+
+Go's `html/template` has no native infix `+` at all — `binary()` always lowers JS `+` through a runtime call, `bf_add`, which coerces both operands to `float64` unconditionally. A string operand's `toFloat64` is `0`, so `'Hello, ' + name + '!'` computed `0 + 0 = 0` regardless of the actual strings.
+
+JS `+` is addition only when both operands are numeric; it's concatenation the moment either side is a string. `binary()` (and the two other `case '+'` sites that independently re-derive the same lowering — a filter predicate's own `binary` case and a condition expression's `binary` case) now check `isStringConcatBinary` (the shared helper already consumed by Blade/Mojolicious/Twig/Xslate for the same JS `+` ambiguity) before falling to `bf_add`, routing to a new `bf_concat_str` runtime helper instead when either operand is string-typed.
+
+`isStringConcatBinary` needs an `isStringName` predicate — whether a bare identifier holds a string value — which the Go adapter didn't have. Added `collectStringValueNames` (`props/prop-classes.ts`, ported from the Blade/Jinja-family adapters' own copy of the same function) and wired it into `CompileState.stringValueNames`.
+
+`string-concat-plus` graduates from a render divergence to a passing render.

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -26,14 +26,15 @@ import (
 func FuncMap() template.FuncMap {
 	return template.FuncMap{
 		// Arithmetic
-		"bf_add": Add,
-		"bf_sub": Sub,
-		"bf_mul": Mul,
-		"bf_div": Div,
-		"bf_mod": Mod,
-		"bf_neg": Neg,
-		"bf_min": Min,
-		"bf_max": Max,
+		"bf_add":        Add,
+		"bf_concat_str": ConcatStr,
+		"bf_sub":        Sub,
+		"bf_mul":        Mul,
+		"bf_div":        Div,
+		"bf_mod":        Mod,
+		"bf_neg":        Neg,
+		"bf_min":        Min,
+		"bf_max":        Max,
 
 		// String
 		"bf_lower":       Lower,
@@ -678,6 +679,16 @@ func Add(a, b any) any {
 		return int(result)
 	}
 	return result
+}
+
+// ConcatStr returns a and b concatenated as strings — the string-typed half
+// of JS `+` (#2168 string-concat-plus). JS `+` is addition when BOTH
+// operands are numeric and concatenation when EITHER is a string; `Add`
+// (above) covers the numeric case, this covers the string one — `Add`
+// itself can't (`toFloat64` returns 0 for a string operand, so `'Hello, ' +
+// name` silently rendered "0" before this existed).
+func ConcatStr(a, b any) string {
+	return toString(a) + toString(b)
 }
 
 // Sub returns a - b. Supports int and float64.

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -66,6 +66,7 @@ import {
   prepareLoweringMatchers,
   envSignalReaderFor,
   computeSsrSeedPlan,
+  isStringConcatBinary,
 } from '@barefootjs/jsx'
 import { findInterpolationEnd } from '@barefootjs/jsx/scanner'
 import { BF_REGION, escapeHtml } from '@barefootjs/shared'
@@ -126,6 +127,7 @@ import { resolveBlockBodyMemoModuleConst } from "./memo/memo-value.ts"
 import { computeMemoInitialValue, computeMemoInitialValueOrNull, filterArmEarlierSiblingRefs } from "./memo/memo-compute.ts"
 import { collectSpreadSlots, buildSpreadInitializer } from "./spread/spread-codegen.ts"
 import { buildPropTypeOverrides, resolvePropGoType, collectNillablePropNames } from "./props/prop-types.ts"
+import { collectStringValueNames } from "./props/prop-classes.ts"
 
 export type { GoTemplateAdapterOptions } from "./lib/types.ts"
 
@@ -340,6 +342,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     this.state.pendingChildrenDefines = []
     this.primeCompileState(ir)
     this.state.nillablePropNames = collectNillablePropNames(this.emitCtx, ir)
+    this.state.stringValueNames = collectStringValueNames(ir)
 
     // Surface loop-body usages of sibling-imported components (see
     // `checkImportedLoopChildComponents`). The barefoot CLI compiles a
@@ -3218,6 +3221,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       case '<=':
         return `le ${wl} ${wr}`
       case '+':
+        // JS `+` with a string-typed operand is CONCATENATION, not addition
+        // — Go's `bf_add` coerces both sides through `toFloat64` (#2168
+        // string-concat-plus: `'Hello, ' + name` rendered "0", since a
+        // string operand's `toFloat64` is 0). `html/template` has no infix
+        // `+` at all, so both directions are a runtime call; route through
+        // `bf_concat_str` when either operand is string-typed.
+        if (isStringConcatBinary(op, left, right, n => this._isStringValueName(n))) {
+          return `bf_concat_str ${wl} ${wr}`
+        }
         return `bf_add ${wl} ${wr}`
       case '-':
         return `bf_sub ${wl} ${wr}`
@@ -3230,6 +3242,13 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       default:
         return `${l} ${op} ${r}`
     }
+  }
+
+  /** Whether `name` (a signal getter or prop) holds a string value — drives
+   *  `isStringConcatBinary`'s string-vs-numeric `+` decision (#2168
+   *  string-concat-plus). */
+  private _isStringValueName(name: string): boolean {
+    return this.state.stringValueNames.has(name)
   }
 
   unary(op: string, argument: ParsedExpr, emit: (e: ParsedExpr) => string): string {
@@ -4142,6 +4161,13 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
           case '<=':
             return `le ${left} ${right}`
           case '+':
+            // See `binary()`'s `case '+'` above — same string-vs-numeric `+`
+            // decision, applied to a filter predicate's own `left`/`right`
+            // ParsedExpr (not `emit`'s rendered strings, so it can inspect
+            // their structure).
+            if (isStringConcatBinary(expr.op, expr.left, expr.right, n => this._isStringValueName(n))) {
+              return `bf_concat_str ${left} ${right}`
+            }
             return `bf_add ${left} ${right}`
           case '-':
             return `bf_sub ${left} ${right}`
@@ -4706,7 +4732,16 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
           case '<=':
             result = `le ${left} ${right}`; break
           case '+':
-            result = `bf_add ${left} ${right}`; break
+            // See `binary()`'s `case '+'` above — same string-vs-numeric `+`
+            // decision, applied to this condition's own `left`/`right`
+            // ParsedExpr (not the rendered `left`/`right` strings, so it can
+            // inspect their structure).
+            if (isStringConcatBinary(expr.op, expr.left, expr.right, n => this._isStringValueName(n))) {
+              result = `bf_concat_str ${left} ${right}`
+            } else {
+              result = `bf_add ${left} ${right}`
+            }
+            break
           case '-':
             result = `bf_sub ${left} ${right}`; break
           case '*':

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -4184,14 +4184,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
           case '<=':
             return `le ${left} ${right}`
           case '+':
-            // See `binary()`'s `case '+'` above — same string-vs-numeric `+`
-            // decision, applied to a filter predicate's own `left`/`right`
-            // ParsedExpr (not `emit`'s rendered strings, so it can inspect
-            // their structure).
-            if (isStringConcatBinary(expr.op, expr.left, expr.right, n => this._isStringValueName(n))) {
-              return `bf_concat_str ${left} ${right}`
-            }
-            return `bf_add ${left} ${right}`
+            return this._emitPlus(expr.left, expr.right, left, right)
           case '-':
             return `bf_sub ${left} ${right}`
           case '*':
@@ -4755,16 +4748,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
           case '<=':
             result = `le ${left} ${right}`; break
           case '+':
-            // See `binary()`'s `case '+'` above — same string-vs-numeric `+`
-            // decision, applied to this condition's own `left`/`right`
-            // ParsedExpr (not the rendered `left`/`right` strings, so it can
-            // inspect their structure).
-            if (isStringConcatBinary(expr.op, expr.left, expr.right, n => this._isStringValueName(n))) {
-              result = `bf_concat_str ${left} ${right}`
-            } else {
-              result = `bf_add ${left} ${right}`
-            }
-            break
+            result = this._emitPlus(expr.left, expr.right, left, right); break
           case '-':
             result = `bf_sub ${left} ${right}`; break
           case '*':

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -3221,16 +3221,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       case '<=':
         return `le ${wl} ${wr}`
       case '+':
-        // JS `+` with a string-typed operand is CONCATENATION, not addition
-        // — Go's `bf_add` coerces both sides through `toFloat64` (#2168
-        // string-concat-plus: `'Hello, ' + name` rendered "0", since a
-        // string operand's `toFloat64` is 0). `html/template` has no infix
-        // `+` at all, so both directions are a runtime call; route through
-        // `bf_concat_str` when either operand is string-typed.
-        if (isStringConcatBinary(op, left, right, n => this._isStringValueName(n))) {
-          return `bf_concat_str ${wl} ${wr}`
-        }
-        return `bf_add ${wl} ${wr}`
+        return this._emitPlus(left, right, wl, wr)
       case '-':
         return `bf_sub ${wl} ${wr}`
       case '*':
@@ -3242,6 +3233,38 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       default:
         return `${l} ${op} ${r}`
     }
+  }
+
+  /**
+   * JS `+` with a string-typed operand is CONCATENATION, not addition — Go's
+   * `bf_add` coerces both sides through `toFloat64` (#2168
+   * string-concat-plus: `'Hello, ' + name` rendered "0", since a string
+   * operand's `toFloat64` is 0). `html/template` has no infix `+` at all, so
+   * both directions are a runtime call; route through `bf_concat_str` when
+   * either operand is string-typed.
+   *
+   * Shared by all THREE `case '+':` sites in this file (`binary()` here, the
+   * filter-predicate emitter's own `binary` case, and the condition-
+   * expression emitter's own `binary` case) — each recurses over its own
+   * `ParsedExpr` tree with its own rendered-operand strings, but the
+   * string-vs-numeric decision itself must stay identical everywhere so the
+   * three never drift out of sync (a Copilot review comment on #2197 flagged
+   * exactly this risk when they were three independent inline checks).
+   * Callers pass their own `leftExpr`/`rightExpr` (the raw `ParsedExpr` nodes
+   * `isStringConcatBinary` inspects) and `leftRendered`/`rightRendered` (the
+   * already-emitted, already-wrapped/parenthesised operand text for THIS
+   * call site's Go form).
+   */
+  private _emitPlus(
+    leftExpr: ParsedExpr,
+    rightExpr: ParsedExpr,
+    leftRendered: string,
+    rightRendered: string,
+  ): string {
+    if (isStringConcatBinary('+', leftExpr, rightExpr, n => this._isStringValueName(n))) {
+      return `bf_concat_str ${leftRendered} ${rightRendered}`
+    }
+    return `bf_add ${leftRendered} ${rightRendered}`
   }
 
   /** Whether `name` (a signal getter or prop) holds a string value — drives

--- a/packages/adapter-go-template/src/adapter/lib/compile-state.ts
+++ b/packages/adapter-go-template/src/adapter/lib/compile-state.ts
@@ -137,6 +137,14 @@ export class CompileState {
    */
   nillablePropNames: Set<string> = new Set()
 
+  /**
+   * String-typed signal getter / prop names (#2168 string-concat-plus).
+   * Feeds `isStringName` for `isStringConcatBinary`, which decides whether a
+   * JS `+` operand chain is string concatenation rather than numeric
+   * addition — see `collectStringValueNames` (`props/prop-classes.ts`).
+   */
+  stringValueNames: Set<string> = new Set()
+
   /** Component root scope element(s) — each carries `data-key` for a keyed loop
    *  item. */
   rootScopeNodes: Set<IRNode> = new Set()

--- a/packages/adapter-go-template/src/adapter/props/prop-classes.ts
+++ b/packages/adapter-go-template/src/adapter/props/prop-classes.ts
@@ -1,0 +1,45 @@
+/**
+ * Prop classification for the Go template adapter.
+ *
+ * Ported from `packages/adapter-blade/src/adapter/props/prop-classes.ts` (itself
+ * ported from Jinja) — ONE function: string-typed signal/prop names, needed to
+ * decide `+` string-concat vs numeric addition (#2168 string-concat-plus). Pure
+ * function over `ir.metadata`; no adapter instance state.
+ */
+
+import type { ComponentIR, TypeInfo } from '@barefootjs/jsx'
+
+/** True when `type` is the `string` primitive. */
+function isStringTypeInfo(type: TypeInfo): boolean {
+  return type.kind === 'primitive' && type.primitive === 'string'
+}
+
+/** True when `initialValue` is a bare string-literal expression. */
+function isBareStringLiteral(initialValue: string | undefined): boolean {
+  if (!initialValue) return false
+  const v = initialValue.trim()
+  return (v.startsWith("'") && v.endsWith("'")) || (v.startsWith('"') && v.endsWith('"'))
+}
+
+/**
+ * String-typed signals and props. A signal is string-typed when its inferred
+ * type is `string` (or, defensively, when its initial value is a bare string
+ * literal); a prop when its annotated type is `string`. Drives `isStringName`
+ * for `isStringConcatBinary` — the shared helper (`@barefootjs/jsx`) that
+ * decides whether a JS `+` is string concatenation rather than numeric
+ * addition (Go's `html/template` has no native `+` at all; `binary()` always
+ * emits a runtime call, `bf_add` for addition or `bf_concat_str` for
+ * concatenation — see `go-template-adapter.ts`'s `binary()`).
+ */
+export function collectStringValueNames(ir: ComponentIR): Set<string> {
+  const names = new Set<string>()
+  for (const s of ir.metadata.signals) {
+    if (isStringTypeInfo(s.type) || isBareStringLiteral(s.initialValue)) {
+      names.add(s.getter)
+    }
+  }
+  for (const p of ir.metadata.propsParams) {
+    if (isStringTypeInfo(p.type)) names.add(p.name)
+  }
+  return names
+}

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -17,8 +17,6 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
-  'string-concat-plus':
-    "`'Hello, ' + name` renders \"0\" — JS string-concat `+` lowered through numeric addition",
   'grandchild-composition':
     "three-level composition: the grandchild's threaded prop renders EMPTY — prop forwarding through two template-render layers loses the value",
   'child-primitive-props':

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2252,12 +2252,6 @@
           ]
         }
       },
-      "string-concat-plus": {
-        "go-template": {
-          "kind": "render",
-          "reason": "`'Hello, ' + name` renders \"0\" — JS string-concat `+` lowered through numeric addition"
-        }
-      },
       "todo-app": {
         "blade": {
           "kind": "refusal",


### PR DESCRIPTION
## Summary

Fixes the `string-concat-plus` render divergence (#2168 sweep) on the Go template adapter: `'Hello, ' + name + '!'` rendered `"0"` instead of the concatenated string.

### Root cause

Go's `html/template` has no native infix `+` operator at all, so `binary()` always lowers JS `+` through a runtime call, `bf_add`, which coerces both operands to `float64` unconditionally (`toFloat64`). A string operand's `toFloat64` is `0`, so `'Hello, ' + name + '!'` computed `0 + 0 = 0` regardless of the actual string values.

JS `+` is addition only when both operands are numeric — it's concatenation the moment either side is a string.

### Changes

- `binary()` (and the two other `case '+'` sites in the same file that independently re-derive the same JS-`+`-lowering logic — the filter-predicate emitter and the condition-expression emitter, each recursing over its own `ParsedExpr` tree) now check `isStringConcatBinary` before falling to `bf_add`. This is the SAME shared helper (`@barefootjs/jsx`) already consumed by the Blade/Mojolicious/Twig/Xslate adapters for this identical JS `+` ambiguity — no new IR/compiler-level mechanism needed, per `spec/compiler.md`'s adapter-emits-only principle.
- New Go runtime helper `bf_concat_str` (`ConcatStr` in `bf.go`) — string concatenation via the existing `toString` coercion, registered in the FuncMap alongside `bf_add`.
- `isStringConcatBinary` needs an `isStringName` predicate (whether a bare identifier holds a string value), which the Go adapter didn't have. Added `collectStringValueNames` (`packages/adapter-go-template/src/adapter/props/prop-classes.ts`) — ported from the Blade/Jinja-family adapters' own copy of the identical function (an established per-adapter-copy pattern in this codebase, not yet unified into a shared module) — and wired it into a new `CompileState.stringValueNames` field, populated once per `generate()` call alongside the existing `nillablePropNames`.

`string-concat-plus` graduates from a render divergence to a passing render; `ui/compat.lock.json` and the divergence declaration are updated accordingly (558/558 cells ok).

## Test plan

- [x] Full `@barefootjs/go-template` package suite with real `go run` (`GOTOOLCHAIN=go1.25.6 bun test`): 732 pass, 0 fail (includes the previously-skipped fixture now passing)
- [x] `bun run build` (full monorepo rebuild) + `GOTOOLCHAIN=go1.25.6 bun run compat:lock`: clean diff, only the `string-concat-plus` entry removed, 558/558 cells ok
- [x] `bun run lint`
- [x] `gofmt` on the modified runtime file

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_017ZXzQWvSKLUUrTAZ3vph1j)_