### PR TITLE
Fix grandchild-composition divergence on Go template adapter

### DIFF
--- a/.changeset/grandchild-composition.md
+++ b/.changeset/grandchild-composition.md
@@ -1,0 +1,13 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Fix a prop re-forwarded through a nested child-component invocation (`<Leaf text={props.label} />` inside `Middle`, itself invoked from `Parent`) rendering EMPTY on the Go template adapter — three-level composition (Parent → Middle → Leaf) lost the threaded value at the second hop.
+
+`emitStaticChildInstances` builds each nested child instance's `<Child>Input{...}` struct literal from the parent's own JSX attributes. A LITERAL attribute value (`<Middle label="threaded" />`) bakes straight to a Go string literal — this is why two-level composition with a literal prop already worked. A bare passthrough of the CALLER's own prop (`text={props.label}`, or the destructured form `text={label}`) is different: it's an `expression`-kind attribute value with no `.parts` (those only exist for template-literal/lookup shapes), so it fell to `resolveDynamicPropValue`, which only recognized a signal/memo getter call (`foo()`) or a `getter() === 'lit'` comparison — never a bare identifier or `props.X` member access. Neither pattern matched, so the field was silently omitted from the struct literal entirely, leaving it at Go's zero value (`""`) instead of erroring.
+
+`resolveDynamicPropValue` now recognizes an EXACT bare `<name>` or `props.<name>` reference (no `??`/`||` fallback suffix — that isn't a pure passthrough) whose name matches one of the current component's own declared props, and resolves it to `in.<Field>` — the current component's own Input struct field for that same prop, i.e. a direct passthrough.
+
+`grandchild-composition` graduates from a render divergence to a passing render.
+
+Note: a SEPARATE, unrelated CSR/hydration-side divergence for this same fixture (`grandchild-composition`'s client-JS scope-id derivation reusing the parent's scope id instead of deriving its own, in `packages/adapter-tests/src/__tests__/csr-conformance.test.ts`) is NOT addressed here — this fix is scoped to the Go SSR render-divergence only.

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -2427,13 +2427,31 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // /`||` suffix — qualifies; a fallback-bearing expression isn't a pure
     // passthrough and must keep falling through to `null` rather than
     // silently dropping the fallback.
+    //
+    // Guarded against a LOCAL const/helper shadowing a propsParam's name
+    // (`const label = compute(); ... text={label}` inside a component whose
+    // OWN prop is also called `label`) — that bare `label` means the local,
+    // not the prop, and must keep falling through to `null` rather than
+    // being misresolved to `in.Label`.
     const propsObjectName = this.state.propsObjectName
-    const bareIdentifier = /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(expr) ? expr : null
-    const barePropAccess = propsObjectName
-      ? new RegExp(`^${propsObjectName}\\.([a-zA-Z_][a-zA-Z0-9_]*)$`).exec(expr)?.[1] ?? null
-      : null
+    const identifierPattern = /^[a-zA-Z_][a-zA-Z0-9_]*$/
+    const bareIdentifier = identifierPattern.test(expr) ? expr : null
+    // Plain prefix/suffix check rather than an `expr`-interpolated `RegExp`:
+    // `propsObjectName` is an arbitrary identifier and could itself contain
+    // regex metacharacters (e.g. `$props`), which would silently build a
+    // malformed pattern instead of erroring.
+    const barePropAccess =
+      propsObjectName &&
+      expr.startsWith(`${propsObjectName}.`) &&
+      identifierPattern.test(expr.slice(propsObjectName.length + 1))
+        ? expr.slice(propsObjectName.length + 1)
+        : null
     const passthroughName = bareIdentifier ?? barePropAccess
-    if (passthroughName && propsParams.some(p => p.name === passthroughName)) {
+    const shadowedByLocal =
+      passthroughName !== null &&
+      (this.state.localConstants.some(c => c.name === passthroughName) ||
+        this.state.localHelperNames.has(passthroughName))
+    if (passthroughName && !shadowedByLocal && propsParams.some(p => p.name === passthroughName)) {
       return `in.${capitalizeFieldName(passthroughName)}`
     }
 

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -2434,7 +2434,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // not the prop, and must keep falling through to `null` rather than
     // being misresolved to `in.Label`.
     const propsObjectName = this.state.propsObjectName
-    const identifierPattern = /^[a-zA-Z_][a-zA-Z0-9_]*$/
+    // `$` is a valid JS/TS identifier character (Copilot review, #2198) —
+    // without it, a passthrough like `text={$label}` or `text={props.$label}`
+    // never matches either shape below and silently falls through to `null`.
+    const identifierPattern = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/
     const bareIdentifier = identifierPattern.test(expr) ? expr : null
     // Plain prefix/suffix check rather than an `expr`-interpolated `RegExp`:
     // `propsObjectName` is an arbitrary identifier and could itself contain
@@ -2447,9 +2450,27 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         ? expr.slice(propsObjectName.length + 1)
         : null
     const passthroughName = bareIdentifier ?? barePropAccess
+    // A `localConstants` entry sharing this name is a genuine SHADOW only
+    // when it's an independent local — NOT when it's the analyzer's own
+    // body-level destructure alias (`const { label } = props`, expanded to
+    // a `localConstants` entry named `label` valued exactly `props.label`,
+    // #1138/analyzer.ts `collectConstant`). That alias IS the same prop
+    // value, so a bare `label` reference is still a pure passthrough
+    // (Copilot review, #2198 — the earlier blanket "any `localConstants`
+    // match blocks it" check wrongly reintroduced the omitted-field bug for
+    // exactly this common destructured-body pattern). A `?? default`-bearing
+    // alias value does NOT match the exact-string check below, so it's
+    // correctly still treated as a shadow (a fallback-bearing local isn't a
+    // pure passthrough either — same reasoning as the outer `??`/`||` guard
+    // above).
+    const localConst = this.state.localConstants.find(c => c.name === passthroughName)
+    const isPropsDestructureAlias =
+      localConst !== undefined &&
+      propsObjectName !== null &&
+      localConst.value === `${propsObjectName}.${passthroughName}`
     const shadowedByLocal =
       passthroughName !== null &&
-      (this.state.localConstants.some(c => c.name === passthroughName) ||
+      ((localConst !== undefined && !isPropsDestructureAlias) ||
         this.state.localHelperNames.has(passthroughName))
     if (passthroughName && !shadowedByLocal && propsParams.some(p => p.name === passthroughName)) {
       return `in.${capitalizeFieldName(passthroughName)}`

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -2416,6 +2416,27 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       }
     }
 
+    // A bare passthrough of the CALLER's own prop — `text={props.label}`
+    // forwarding into a nested child-component invocation (or the
+    // destructured form, `text={label}`) — #2168 grandchild-composition: a
+    // prop re-forwarded through a second component layer matched neither
+    // pattern above (not a getter call, not a literal — that's `case
+    // 'literal'` above this function entirely) and fell through to `null`,
+    // silently OMITTING the field so Go's zero value applied instead of the
+    // threaded value. Only an EXACT `props.<name>` / bare `<name>` — no `??`
+    // /`||` suffix — qualifies; a fallback-bearing expression isn't a pure
+    // passthrough and must keep falling through to `null` rather than
+    // silently dropping the fallback.
+    const propsObjectName = this.state.propsObjectName
+    const bareIdentifier = /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(expr) ? expr : null
+    const barePropAccess = propsObjectName
+      ? new RegExp(`^${propsObjectName}\\.([a-zA-Z_][a-zA-Z0-9_]*)$`).exec(expr)?.[1] ?? null
+      : null
+    const passthroughName = bareIdentifier ?? barePropAccess
+    if (passthroughName && propsParams.some(p => p.name === passthroughName)) {
+      return `in.${capitalizeFieldName(passthroughName)}`
+    }
+
     return null
   }
 

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -17,8 +17,6 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
-  'grandchild-composition':
-    "three-level composition: the grandchild's threaded prop renders EMPTY — prop forwarding through two template-render layers loses the value",
   'child-primitive-props':
     'numeric/boolean LITERAL props on a child (`count={5}` `active={true}`) render as Go zero values (0 / false)',
   'memo-chain':

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2052,12 +2052,6 @@
           ]
         }
       },
-      "grandchild-composition": {
-        "go-template": {
-          "kind": "render",
-          "reason": "three-level composition: the grandchild's threaded prop renders EMPTY — prop forwarding through two template-render layers loses the value"
-        }
-      },
       "memo-chain": {
         "go-template": {
           "kind": "render",


### PR DESCRIPTION
## Summary

Fixes the `grandchild-composition` render divergence (#2168 sweep) on the Go template adapter: a three-level composition (`Parent → Middle → Leaf`) that threads one prop through every level rendered the grandchild's (`Leaf`'s) text EMPTY instead of the threaded value.

```tsx
// Parent
&lt;Middle label="threaded" /&gt;

// Middle
function Middle(props: { label: string }) {
  return &lt;section&gt;&lt;Leaf text={props.label} /&gt;&lt;/section&gt;
}

// Leaf
function Leaf(props: { text: string }) {
  return &lt;span&gt;{props.text}&lt;/span&gt;
}
```

### Root cause

`emitStaticChildInstances` (`go-template-adapter.ts`) builds each nested child component instance's `<Child>Input{...}` Go struct literal from the parent's own JSX attributes. A LITERAL attribute value (`<Middle label="threaded" />`) bakes straight to a Go string literal — this is why two-level composition with a literal prop (the existing `child-component` fixture) already passed; it never exercises the broken path at all.

A bare passthrough of the CALLER's own prop (`text={props.label}`, or the destructured form `text={label}`) is different: it's an `expression`-kind attribute value with no `.parts` (those only exist for template-literal / bracket-lookup shapes), so it fell to `resolveDynamicPropValue`, which only recognized two shapes — a signal/memo getter call (`foo()`) or a `getter() === 'lit'` comparison. A bare `props.label` member access matches neither, so the field was silently OMITTED from the struct literal entirely — nothing errors, the field just defaults to Go's zero value (`""`).

### Fix

`resolveDynamicPropValue` now recognizes an EXACT bare `<name>` or `props.<name>` reference — deliberately no `??`/`||` fallback suffix, since a fallback-bearing expression isn't a pure passthrough and dropping the fallback silently would be its own bug — whose name matches one of the CURRENT component's own declared props, and resolves it to `in.<Field>`: the current component's own Input struct field for that same prop, i.e. a direct passthrough of the caller's value.

`grandchild-composition` graduates from a render divergence to a passing render; `ui/compat.lock.json` and the divergence declaration are updated accordingly (558/558 cells ok).

**Out of scope**: a separate, unrelated CSR/hydration-side divergence for this same fixture (client-JS scope-id derivation reusing the parent's scope id instead of deriving its own — `packages/adapter-tests/src/__tests__/csr-conformance.test.ts`) is NOT addressed here; this fix is scoped to the Go SSR render divergence only.

## Test plan

- [x] Full `@barefootjs/go-template` package suite with real `go run` (`GOTOOLCHAIN=go1.25.6 bun test`): 732 pass, 0 fail (includes the previously-skipped fixture now passing)
- [x] Full `@barefootjs/jsx` package suite (unaffected by this change, sanity check): 2342 pass, 0 fail
- [x] `bun run build` (full monorepo rebuild) + `GOTOOLCHAIN=go1.25.6 bun run compat:lock`: clean diff, only the `grandchild-composition` entry removed, 558/558 cells ok
- [x] `bun run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_017ZXzQWvSKLUUrTAZ3vph1j)_