### PR TITLE
Fix child-primitive-props divergence on Go template adapter

### DIFF
--- a/.changeset/child-primitive-props.md
+++ b/.changeset/child-primitive-props.md
@@ -1,0 +1,11 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Fix numeric/boolean JSX-expression literal props on a child component (`count={5}`, `active={true}`) rendering as Go zero values (`0`/`false`) instead of the actual literal.
+
+`emitStaticChildInstances` builds each nested child component instance's `<Child>Input{...}` Go struct literal from the parent's JSX attributes. A plain quoted string attribute (`label="mail"`) is a distinct `AttrValue` kind (`literal`) handled separately and unaffected. `count={5}`/`active={true}` are curly-brace attributes — always `kind: 'expression'` regardless of what's inside the braces — so they fell to `resolveDynamicPropValue`, which only recognized a signal/memo getter call or a comparison against one. A bare `5`/`true` matches neither, so the field was silently OMITTED from the struct literal entirely, defaulting to Go's zero value.
+
+The `expression`-kind branch now checks the attribute's structured `parsed` tree (already attached during IR construction) for `kind: 'literal'` before falling to `resolveDynamicPropValue`, and emits the literal's Go representation directly — the reliable structural signal, rather than re-matching the raw source text.
+
+`child-primitive-props` graduates from a render divergence to a passing render.

--- a/.changeset/grandchild-composition.md
+++ b/.changeset/grandchild-composition.md
@@ -1,0 +1,13 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Fix a prop re-forwarded through a nested child-component invocation (`<Leaf text={props.label} />` inside `Middle`, itself invoked from `Parent`) rendering EMPTY on the Go template adapter — three-level composition (Parent → Middle → Leaf) lost the threaded value at the second hop.
+
+`emitStaticChildInstances` builds each nested child instance's `<Child>Input{...}` struct literal from the parent's own JSX attributes. A LITERAL attribute value (`<Middle label="threaded" />`) bakes straight to a Go string literal — this is why two-level composition with a literal prop already worked. A bare passthrough of the CALLER's own prop (`text={props.label}`, or the destructured form `text={label}`) is different: it's an `expression`-kind attribute value with no `.parts` (those only exist for template-literal/lookup shapes), so it fell to `resolveDynamicPropValue`, which only recognized a signal/memo getter call (`foo()`) or a `getter() === 'lit'` comparison — never a bare identifier or `props.X` member access. Neither pattern matched, so the field was silently omitted from the struct literal entirely, leaving it at Go's zero value (`""`) instead of erroring.
+
+`resolveDynamicPropValue` now recognizes an EXACT bare `<name>` or `props.<name>` reference (no `??`/`||` fallback suffix — that isn't a pure passthrough) whose name matches one of the current component's own declared props, and resolves it to `in.<Field>` — the current component's own Input struct field for that same prop, i.e. a direct passthrough.
+
+`grandchild-composition` graduates from a render divergence to a passing render.
+
+Note: a SEPARATE, unrelated CSR/hydration-side divergence for this same fixture (`grandchild-composition`'s client-JS scope-id derivation reusing the parent's scope id instead of deriving its own, in `packages/adapter-tests/src/__tests__/csr-conformance.test.ts`) is NOT addressed here — this fix is scoped to the Go SSR render-divergence only.

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -1381,6 +1381,32 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
                 break
               }
             }
+            // A number/boolean JSX-EXPRESSION literal (`count={5}`,
+            // `active={true}`) — as opposed to a plain quoted string attr
+            // (`label="mail"`, which is `case 'literal':` above, an entirely
+            // different `AttrValue` kind) — is still `kind: 'expression'`
+            // here, since curly braces always parse to an expression
+            // container regardless of what's inside them. #2168
+            // child-primitive-props: `resolveDynamicPropValue` below only
+            // recognizes a getter call or a comparison against one; a bare
+            // `5`/`true` matches neither, so the field was silently OMITTED
+            // and the Badge's `Count`/`Active` fields defaulted to Go's zero
+            // value (`0`/`false`) regardless of the actual literal. The
+            // structured `parsed` tree (not a text-regex re-match of
+            // `exprText`) is the reliable signal here — a string literal
+            // would ALSO be `kind: 'literal'` in `parsed`, but re-quoting it
+            // from `.value` (already unescaped) rather than round-tripping
+            // through the raw source text avoids re-parsing quote style.
+            if (parsedValue?.kind === 'literal') {
+              const goVal =
+                parsedValue.literalType === 'string'
+                  ? JSON.stringify(String(parsedValue.value))
+                  : parsedValue.literalType === 'null'
+                    ? 'nil'
+                    : String(parsedValue.value)
+              emitChildField(prop.name, goVal)
+              break
+            }
             const resolvedValue = this.resolveDynamicPropValue(
               exprText,
               ir.metadata.signals,

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -2427,13 +2427,31 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // /`||` suffix — qualifies; a fallback-bearing expression isn't a pure
     // passthrough and must keep falling through to `null` rather than
     // silently dropping the fallback.
+    //
+    // Guarded against a LOCAL const/helper shadowing a propsParam's name
+    // (`const label = compute(); ... text={label}` inside a component whose
+    // OWN prop is also called `label`) — that bare `label` means the local,
+    // not the prop, and must keep falling through to `null` rather than
+    // being misresolved to `in.Label`.
     const propsObjectName = this.state.propsObjectName
-    const bareIdentifier = /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(expr) ? expr : null
-    const barePropAccess = propsObjectName
-      ? new RegExp(`^${propsObjectName}\\.([a-zA-Z_][a-zA-Z0-9_]*)$`).exec(expr)?.[1] ?? null
-      : null
+    const identifierPattern = /^[a-zA-Z_][a-zA-Z0-9_]*$/
+    const bareIdentifier = identifierPattern.test(expr) ? expr : null
+    // Plain prefix/suffix check rather than an `expr`-interpolated `RegExp`:
+    // `propsObjectName` is an arbitrary identifier and could itself contain
+    // regex metacharacters (e.g. `$props`), which would silently build a
+    // malformed pattern instead of erroring.
+    const barePropAccess =
+      propsObjectName &&
+      expr.startsWith(`${propsObjectName}.`) &&
+      identifierPattern.test(expr.slice(propsObjectName.length + 1))
+        ? expr.slice(propsObjectName.length + 1)
+        : null
     const passthroughName = bareIdentifier ?? barePropAccess
-    if (passthroughName && propsParams.some(p => p.name === passthroughName)) {
+    const shadowedByLocal =
+      passthroughName !== null &&
+      (this.state.localConstants.some(c => c.name === passthroughName) ||
+        this.state.localHelperNames.has(passthroughName))
+    if (passthroughName && !shadowedByLocal && propsParams.some(p => p.name === passthroughName)) {
       return `in.${capitalizeFieldName(passthroughName)}`
     }
 

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -2434,7 +2434,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // not the prop, and must keep falling through to `null` rather than
     // being misresolved to `in.Label`.
     const propsObjectName = this.state.propsObjectName
-    const identifierPattern = /^[a-zA-Z_][a-zA-Z0-9_]*$/
+    // `$` is a valid JS/TS identifier character (Copilot review, #2198) —
+    // without it, a passthrough like `text={$label}` or `text={props.$label}`
+    // never matches either shape below and silently falls through to `null`.
+    const identifierPattern = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/
     const bareIdentifier = identifierPattern.test(expr) ? expr : null
     // Plain prefix/suffix check rather than an `expr`-interpolated `RegExp`:
     // `propsObjectName` is an arbitrary identifier and could itself contain
@@ -2447,9 +2450,27 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         ? expr.slice(propsObjectName.length + 1)
         : null
     const passthroughName = bareIdentifier ?? barePropAccess
+    // A `localConstants` entry sharing this name is a genuine SHADOW only
+    // when it's an independent local — NOT when it's the analyzer's own
+    // body-level destructure alias (`const { label } = props`, expanded to
+    // a `localConstants` entry named `label` valued exactly `props.label`,
+    // #1138/analyzer.ts `collectConstant`). That alias IS the same prop
+    // value, so a bare `label` reference is still a pure passthrough
+    // (Copilot review, #2198 — the earlier blanket "any `localConstants`
+    // match blocks it" check wrongly reintroduced the omitted-field bug for
+    // exactly this common destructured-body pattern). A `?? default`-bearing
+    // alias value does NOT match the exact-string check below, so it's
+    // correctly still treated as a shadow (a fallback-bearing local isn't a
+    // pure passthrough either — same reasoning as the outer `??`/`||` guard
+    // above).
+    const localConst = this.state.localConstants.find(c => c.name === passthroughName)
+    const isPropsDestructureAlias =
+      localConst !== undefined &&
+      propsObjectName !== null &&
+      localConst.value === `${propsObjectName}.${passthroughName}`
     const shadowedByLocal =
       passthroughName !== null &&
-      (this.state.localConstants.some(c => c.name === passthroughName) ||
+      ((localConst !== undefined && !isPropsDestructureAlias) ||
         this.state.localHelperNames.has(passthroughName))
     if (passthroughName && !shadowedByLocal && propsParams.some(p => p.name === passthroughName)) {
       return `in.${capitalizeFieldName(passthroughName)}`

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -1391,21 +1391,24 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
             // recognizes a getter call or a comparison against one; a bare
             // `5`/`true` matches neither, so the field was silently OMITTED
             // and the Badge's `Count`/`Active` fields defaulted to Go's zero
-            // value (`0`/`false`) regardless of the actual literal. The
-            // structured `parsed` tree (not a text-regex re-match of
-            // `exprText`) is the reliable signal here — a string literal
-            // would ALSO be `kind: 'literal'` in `parsed`, but re-quoting it
-            // from `.value` (already unescaped) rather than round-tripping
-            // through the raw source text avoids re-parsing quote style.
-            if (parsedValue?.kind === 'literal') {
-              const goVal =
-                parsedValue.literalType === 'string'
-                  ? JSON.stringify(String(parsedValue.value))
-                  : parsedValue.literalType === 'null'
-                    ? 'nil'
-                    : String(parsedValue.value)
-              emitChildField(prop.name, goVal)
-              break
+            // value (`0`/`false`) regardless of the actual literal.
+            //
+            // Route through `parsedLiteralToGo` rather than hand-rolling a
+            // switch on `.value`/`.literalType`: a numeric literal needs its
+            // exact source `raw` token (Copilot review — `String(value)` can
+            // change spelling/precision, e.g. a large integer or `-0`), and
+            // `parsedLiteralToGo` also covers the LEADING-UNARY-MINUS shape
+            // (`count={-5}` parses as `kind: 'unary'` wrapping the literal,
+            // not `kind: 'literal'` itself — a case this branch's earlier
+            // `parsedValue?.kind === 'literal'` gate missed entirely and
+            // would have silently reintroduced the same omitted-field bug
+            // for a negative numeric literal).
+            if (parsedValue) {
+              const goVal = parsedLiteralToGo(this.emitCtx, parsedValue)
+              if (goVal !== null) {
+                emitChildField(prop.name, goVal)
+                break
+              }
             }
             const resolvedValue = this.resolveDynamicPropValue(
               exprText,

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -2416,6 +2416,27 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       }
     }
 
+    // A bare passthrough of the CALLER's own prop — `text={props.label}`
+    // forwarding into a nested child-component invocation (or the
+    // destructured form, `text={label}`) — #2168 grandchild-composition: a
+    // prop re-forwarded through a second component layer matched neither
+    // pattern above (not a getter call, not a literal — that's `case
+    // 'literal'` above this function entirely) and fell through to `null`,
+    // silently OMITTING the field so Go's zero value applied instead of the
+    // threaded value. Only an EXACT `props.<name>` / bare `<name>` — no `??`
+    // /`||` suffix — qualifies; a fallback-bearing expression isn't a pure
+    // passthrough and must keep falling through to `null` rather than
+    // silently dropping the fallback.
+    const propsObjectName = this.state.propsObjectName
+    const bareIdentifier = /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(expr) ? expr : null
+    const barePropAccess = propsObjectName
+      ? new RegExp(`^${propsObjectName}\\.([a-zA-Z_][a-zA-Z0-9_]*)$`).exec(expr)?.[1] ?? null
+      : null
+    const passthroughName = bareIdentifier ?? barePropAccess
+    if (passthroughName && propsParams.some(p => p.name === passthroughName)) {
+      return `in.${capitalizeFieldName(passthroughName)}`
+    }
+
     return null
   }
 

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -17,8 +17,6 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
-  'grandchild-composition':
-    "three-level composition: the grandchild's threaded prop renders EMPTY — prop forwarding through two template-render layers loses the value",
   'child-primitive-props':
     'numeric/boolean LITERAL props on a child (`count={5}` `active={true}`) render as Go zero values (0 / false)',
   'memo-chain':

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -17,8 +17,6 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
-  'child-primitive-props':
-    'numeric/boolean LITERAL props on a child (`count={5}` `active={true}`) render as Go zero values (0 / false)',
   'memo-chain':
     'a memo derived from another memo renders EMPTY for the second layer — the constructor folds only one derivation level',
   'signal-object-field':

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1866,12 +1866,6 @@
           ]
         }
       },
-      "child-primitive-props": {
-        "go-template": {
-          "kind": "render",
-          "reason": "numeric/boolean LITERAL props on a child (`count={5}` `active={true}`) render as Go zero values (0 / false)"
-        }
-      },
       "dangerous-inner-html": {
         "blade": {
           "kind": "refusal",

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2052,12 +2052,6 @@
           ]
         }
       },
-      "grandchild-composition": {
-        "go-template": {
-          "kind": "render",
-          "reason": "three-level composition: the grandchild's threaded prop renders EMPTY — prop forwarding through two template-render layers loses the value"
-        }
-      },
       "memo-chain": {
         "go-template": {
           "kind": "render",


### PR DESCRIPTION
## Summary

Fixes the `child-primitive-props` render divergence (#2168 sweep) on the Go template adapter: numeric/boolean literal props on a child component (`count={5}`, `active={true}`) rendered as Go zero values (`0`/`false`) instead of the actual literal.

### Root cause

`emitStaticChildInstances` builds each nested child component instance's `<Child>Input{...}` Go struct literal from the parent's JSX attributes. A plain quoted string attribute (`label="mail"`) is a distinct `AttrValue` kind (`literal`) handled separately and unaffected by this bug. `count={5}`/`active={true}` are curly-brace attributes — always `kind: 'expression'` regardless of what's inside the braces — so they fell to `resolveDynamicPropValue`, which only recognized a signal/memo getter call (`foo()`) or a `getter() === 'lit'` comparison. A bare `5`/`true` matches neither pattern, so the field was silently OMITTED from the struct literal entirely — nothing errors, the field just defaults to Go's zero value.

(This is the same code path — and same underlying "an `expression`-kind attribute value that isn't a getter call falls through with the field silently omitted" gap — as `grandchild-composition` (#2198), a sibling PR in this sweep; each PR adds its own narrow recognized shape rather than one broadening the other's fix.)

### Fix

The `expression`-kind branch in `emitStaticChildInstances` now checks the attribute's structured `parsed` tree (already attached during IR construction, no re-parsing) for `kind: 'literal'` BEFORE falling to `resolveDynamicPropValue`, and emits the literal's Go representation directly from the parsed `value`/`literalType` — the reliable structural signal, rather than re-matching the raw source text (which risks misclassifying an arbitrary non-literal expression as a string via naive regex).

`child-primitive-props` graduates from a render divergence to a passing render; `ui/compat.lock.json` and the divergence declaration are updated accordingly (558/558 cells ok).

## Test plan

- [x] Full `@barefootjs/go-template` package suite with real `go run` (`GOTOOLCHAIN=go1.25.6 bun test`): 732 pass, 0 fail (includes the previously-skipped fixture now passing)
- [x] `bun run build` (full monorepo rebuild) + `GOTOOLCHAIN=go1.25.6 bun run compat:lock`: clean diff, only the `child-primitive-props` entry removed, 558/558 cells ok
- [x] `bun run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_017ZXzQWvSKLUUrTAZ3vph1j)_