### PR TITLE
Fix nested-loop-triple-depth divergence: test-harness bug, not adapter

### DIFF
--- a/.changeset/nested-loop-triple-depth.md
+++ b/.changeset/nested-loop-triple-depth.md
@@ -1,0 +1,13 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Fix `nested-loop-triple-depth`'s render divergence — but the root cause was in the Go adapter's TEST HARNESS, not the adapter's actual codegen.
+
+The divergence's own description ("Go loop-scope binding only reaches two levels deep") was incorrect. The Go template adapter's real loop-scope binding (`loopParamStack` in `go-template-adapter.ts`, and the corresponding `{{range $_, $var := .Field}}` nesting it emits) is a plain unbounded stack with no depth limit, and generates fully correct Go template code at any nesting depth — verified directly.
+
+The actual bug lived in `packages/adapter-go-template/src/test-render.ts`, the conformance-test harness that bakes a fixture's runtime `props` into Go source for `go run`. `goMapLiteralFromObject`'s key capitalization used a naive first-letter-uppercase (`k.charAt(0).toUpperCase() + k.slice(1)`) instead of the Go-initialism-aware `capitalizeFieldName` the real adapter codegen uses everywhere else (`id` → `ID`, not `Id`). Since Go's `html/template` does a case-sensitive map/field lookup, a fixture keyed on `id` (as this one is: `tree.id`, `branch.id`, `leaf.id`) baked a literal keyed `"Id"` that the template's `{{.ID}}` lookup could never match — rendering every level's key AND text content empty, at ANY nesting depth (not specifically the third), which a from-scratch repro confirmed. It happened to surface first on this fixture, and happened to look depth-related, only because the sibling 2-level fixture's key field (`name`) isn't a Go initialism and so was capitalized identically either way.
+
+Fixed the harness's naive capitalizer at all three call sites that had it (`goMapLiteralFromObject`'s nested-object-key path, `buildGoPropsInit`'s top-level prop-field path, and the rest-bag field-name path) to use `capitalizeFieldName`, already imported in the file and already used correctly by the neighboring `goStructLiteral`.
+
+**No real end-user Go output is affected by this fix** — the actual `@barefootjs/go-template` compiler codegen (what a real project's `bf build` emits) was never wrong; only this package's own test-render harness's ad hoc runtime-prop injection mis-modeled the adapter's actual field-naming convention. `nested-loop-triple-depth` graduates from a render divergence to a passing render.

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -17,6 +17,4 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
-  'nested-loop-triple-depth':
-    'a THIRD level of nested .map() renders every item field EMPTY (key values and text content alike), though the data-key/-1/-2 suffix naming itself is correct — Go loop-scope binding only reaches two levels deep',
 }

--- a/packages/adapter-go-template/src/test-render.ts
+++ b/packages/adapter-go-template/src/test-render.ts
@@ -572,9 +572,7 @@ function buildGoPropsInit(
   // in struct literal of type InputInput`. (#1467 Phase 2b)
   const declaredParams = new Set((ir?.metadata.propsParams ?? []).map(p => p.name))
   const restPropsName = ir?.metadata.restPropsName ?? null
-  const restBagField = restPropsName
-    ? restPropsName.charAt(0).toUpperCase() + restPropsName.slice(1)
-    : null
+  const restBagField = restPropsName ? capitalizeFieldName(restPropsName) : null
 
   const lines: string[] = []
   const restBagEntries: Array<[string, unknown]> = []
@@ -594,8 +592,9 @@ function buildGoPropsInit(
       restBagEntries.push([key, value])
       continue
     }
-    // Capitalize first letter for Go field name
-    const goField = key.charAt(0).toUpperCase() + key.slice(1)
+    // Same Go-initialism-aware capitalizer as the real adapter (`id` → `ID`,
+    // not the naive `Id`) — see `goMapLiteralFromObject`'s identical fix.
+    const goField = capitalizeFieldName(key)
     if (typeof value === 'string') {
       lines.push(`\t\t${goField}: "${value}",`)
     } else if (typeof value === 'number') {
@@ -766,7 +765,14 @@ function goMapLiteralFromObject(
 ): string {
   const entries: string[] = []
   for (const [k, v] of Object.entries(obj)) {
-    const emittedKey = capitalizeKeys ? k.charAt(0).toUpperCase() + k.slice(1) : k
+    // `capitalizeFieldName` (not a naive first-letter uppercase) — #2168
+    // nested-loop-triple-depth: a naive capitalize disagrees with the real
+    // adapter's Go-initialism-aware field naming for a key like `id`
+    // (naive → "Id", adapter's generated struct/template field → "ID"),
+    // so the harness baked a literal the template's `{{.ID}}` lookup could
+    // never match — the fixture's rendered fields came back empty at
+    // EVERY nesting depth for this reason, not because of any depth limit.
+    const emittedKey = capitalizeKeys ? capitalizeFieldName(k) : k
     const key = JSON.stringify(emittedKey)
     if (typeof v === 'string') entries.push(`${key}: "${v.replace(/"/g, '\\"')}"`)
     else if (typeof v === 'number') entries.push(`${key}: ${v}`)

--- a/packages/adapter-go-template/src/test-render.ts
+++ b/packages/adapter-go-template/src/test-render.ts
@@ -9,7 +9,7 @@ import { compileJSX } from '@barefootjs/jsx'
 import type { TemplateAdapter, ComponentIR } from '@barefootjs/jsx'
 import { GoTemplateAdapter } from './adapter/go-template-adapter.ts'
 import { deduplicateGoTypes } from './build.ts'
-import { capitalizeFieldName } from './adapter/lib/go-naming.ts'
+import { capitalizeFieldName, goFieldNameForKey } from './adapter/lib/go-naming.ts'
 import { mkdir, rm } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
@@ -728,7 +728,11 @@ function goTypedMapSliceLiteralFromArray(arr: unknown[], elemType: string): stri
 function goStructLiteral(obj: Record<string, unknown>, typeName: string): string {
   const fields: string[] = []
   for (const [k, v] of Object.entries(obj)) {
-    const goField = capitalizeFieldName(k)
+    // `goFieldNameForKey`, not the bare `capitalizeFieldName` — a data-driven
+    // key here can be non-identifier-shaped (`'data-x'`), and the real
+    // adapter's own struct-literal baking (`parsed-literal-to-go.ts`)
+    // sanitizes those to `DataX`, not `Data-x` (Copilot review, #2202).
+    const goField = goFieldNameForKey(k)
     if (typeof v === 'string') fields.push(`${goField}: "${v.replace(/"/g, '\\"')}"`)
     else if (typeof v === 'number' || typeof v === 'boolean') fields.push(`${goField}: ${v}`)
     else if (v === null) fields.push(`${goField}: nil`)
@@ -765,14 +769,19 @@ function goMapLiteralFromObject(
 ): string {
   const entries: string[] = []
   for (const [k, v] of Object.entries(obj)) {
-    // `capitalizeFieldName` (not a naive first-letter uppercase) — #2168
-    // nested-loop-triple-depth: a naive capitalize disagrees with the real
-    // adapter's Go-initialism-aware field naming for a key like `id`
-    // (naive → "Id", adapter's generated struct/template field → "ID"),
-    // so the harness baked a literal the template's `{{.ID}}` lookup could
-    // never match — the fixture's rendered fields came back empty at
-    // EVERY nesting depth for this reason, not because of any depth limit.
-    const emittedKey = capitalizeKeys ? capitalizeFieldName(k) : k
+    // `goFieldNameForKey`, not a naive first-letter uppercase and not the
+    // bare `capitalizeFieldName` — #2168 nested-loop-triple-depth: a naive
+    // capitalize disagrees with the real adapter's Go-initialism-aware
+    // field naming for a key like `id` (naive → "Id", adapter's generated
+    // struct/template field → "ID"), so the harness baked a literal the
+    // template's `{{.ID}}` lookup could never match — the fixture's
+    // rendered fields came back empty at EVERY nesting depth for this
+    // reason, not because of any depth limit. `capitalizeFieldName` alone
+    // fixes the initialism case but still mis-bakes a non-identifier key
+    // (`'data-x'` → `"Data-x"`, not the adapter's own `"DataX"` —
+    // Copilot review, #2202); `goFieldNameForKey` is what the real adapter
+    // uses for exactly this key-to-Go-field sanitization.
+    const emittedKey = capitalizeKeys ? goFieldNameForKey(k) : k
     const key = JSON.stringify(emittedKey)
     if (typeof v === 'string') entries.push(`${key}: "${v.replace(/"/g, '\\"')}"`)
     else if (typeof v === 'number') entries.push(`${key}: ${v}`)

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2046,12 +2046,6 @@
           ]
         }
       },
-      "nested-loop-triple-depth": {
-        "go-template": {
-          "kind": "render",
-          "reason": "a THIRD level of nested .map() renders every item field EMPTY (key values and text content alike), though the data-key/-1/-2 suffix naming itself is correct — Go loop-scope binding only reaches two levels deep"
-        }
-      },
       "static-array-children": {
         "blade": {
           "kind": "refusal",


### PR DESCRIPTION
## Summary

Fixes the `nested-loop-triple-depth` render divergence (#2168 sweep, the last one in this sweep) — but the root cause turned out to be in the Go adapter's **test harness**, not its actual codegen.

### The divergence's own description was wrong

"Go loop-scope binding only reaches two levels deep" — I verified directly that this is not true. `loopParamStack` (`go-template-adapter.ts`) is a plain unbounded array, pushed/popped once per loop regardless of nesting depth, and the `{{range $_, $var := .Field}}` nesting it drives is fully correct Go template code at any depth. I confirmed the generated template for the 3-level fixture is exactly the shape you'd hand-write:
```gotemplate
{{range $_, $tree := .Trees}}<section data-key="{{.ID}}" ...>
  {{range $_, $branch := .Branches}}<article data-key-1="{{.ID}}" ...>
    {{range $_, $leaf := .Leaves}}<span data-key-2="{{.ID}}">{{.ID}}</span>{{end}}
  </article>{{end}}
</section>{{end}}
```

### Actual root cause: a test-harness key-capitalization mismatch

`packages/adapter-go-template/src/test-render.ts` — the conformance-test harness that bakes a fixture's runtime `props` into Go source so `go run` can execute it — has its own `goMapLiteralFromObject` helper for baking nested-object props. Its key capitalization used a naive `k.charAt(0).toUpperCase() + k.slice(1)` instead of the Go-initialism-aware `capitalizeFieldName` the REAL adapter codegen uses everywhere else (`id` → `ID`, not `Id`).

Since Go's `html/template` does case-sensitive map/field lookups, a fixture keyed on `id` (as this one is throughout — `tree.id`, `branch.id`, `leaf.id`) baked a test literal keyed `"Id"` that the template's `{{.ID}}` field access could never match against — rendering every level's key value AND its text content empty. This has **nothing to do with nesting depth**: a from-scratch depth-1 repro with an `id` field reproduces the identical bug. It surfaced first (and only) on this fixture, and looked depth-specific, purely because the sibling 2-level fixture's key field (`name`) isn't a Go initialism, so naive and initialism-aware capitalization happen to produce the same result for it.

### Fix

Replaced the harness's naive capitalizer with `capitalizeFieldName` (already imported in the file, already used correctly by the neighboring `goStructLiteral`) at all three call sites that had it: `goMapLiteralFromObject`'s nested-object-key path, `buildGoPropsInit`'s top-level prop-field path, and the rest-bag field-name path.

**No real end-user Go output is affected** — the actual compiler codegen a real project's `bf build` emits was never wrong; only this package's own test-render harness's ad hoc runtime-prop injection mis-modeled the adapter's real field-naming convention.

`nested-loop-triple-depth` graduates from a render divergence to a passing render; `ui/compat.lock.json` and the divergence declaration are updated accordingly (558/558 cells ok) — this is the **last** entry in the Go adapter's `render-divergences.ts` for this sweep (#2168).

## Test plan

- [x] Full `@barefootjs/go-template` package suite with real `go run` (`GOTOOLCHAIN=go1.25.6 bun test`): 732 pass, 0 fail (includes the previously-skipped fixture now passing, and confirms the harness fix causes no regressions across the other ~700 fixtures that also go through `buildGoPropsInit`/`goMapLiteralFromObject`)
- [x] `bun run build` (full monorepo rebuild) + `GOTOOLCHAIN=go1.25.6 bun run compat:lock`: clean diff, only the `nested-loop-triple-depth` entry removed, 558/558 cells ok
- [x] `bun run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_017ZXzQWvSKLUUrTAZ3vph1j)_