### PR TITLE
Point landing page Docs nav links to /docs/introduction

### DIFF
--- a/site/core/landing/components/lp-chrome.tsx
+++ b/site/core/landing/components/lp-chrome.tsx
@@ -19,7 +19,7 @@ export function LpHeader({ uiHref = 'https://ui.barefootjs.dev' }: { uiHref?: st
           <span className="lp-logo-icon"><LogoIcon /></span>
         </a>
         <nav className="lp-nav-links" aria-label="Main">
-          <a href="/docs">Docs</a>
+          <a href="/docs/introduction">Docs</a>
           <a href={uiHref}>Components</a>
           <a href="/integrations">Integrations</a>
           <a href="https://github.com/piconic-ai/barefootjs">Source</a>
@@ -35,7 +35,7 @@ export function LpFooter({ uiHref = 'https://ui.barefootjs.dev' }: { uiHref?: st
     <footer className="lp-footer">
       <div className="lp-wrap lp-foot-row">
         <div>
-          <a href="/docs">Docs</a>
+          <a href="/docs/introduction">Docs</a>
           <a href={uiHref}>Components</a>
           <a href="/integrations">Integrations</a>
           <a href="/docs/advanced/compatibility-matrix">Compatibility</a>


### PR DESCRIPTION
## Summary
- The landing page header and footer "Docs" nav links pointed at the bare `/docs` route; both now point to `/docs/introduction` (https://barefootjs.dev/docs/introduction), matching where the docs sidebar itself already resolves the root path.

## Test plan
- [x] Manual grep confirmed no other real site-navigation links pointed at bare `/docs` (remaining `/docs` hits are component demo/example content, not real navigation, and were left untouched).


---
_Generated by [Claude Code](https://claude.ai/code/session_015GKybjiiNZ5PhKqohkUBU4)_