### PR TITLE
Fix #2205: conformance harness never registers sibling templates for loop-body components

### DIFF
--- a/.changeset/sibling-templates-conformance-harness.md
+++ b/.changeset/sibling-templates-conformance-harness.md
@@ -1,0 +1,12 @@
+---
+"@barefootjs/blade": patch
+"@barefootjs/erb": patch
+"@barefootjs/go-template": patch
+"@barefootjs/jinja": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/rust": patch
+"@barefootjs/twig": patch
+"@barefootjs/xslate": patch
+---
+
+Fix the conformance test harness (`test-render.ts`, `conformance-pins.ts`, `render-divergences.ts`) to pass `siblingTemplatesRegistered: true` when rendering fixtures with sibling components, matching `bf build`'s real semantics. This was a test-only gap — no adapter runtime or codegen behavior changes — that spuriously refused `static-array-children`, `todo-app`, and `todo-app-ssr` with `BF103` in the conformance suite even though the shape works in real usage (#2205).

--- a/packages/adapter-blade/src/conformance-pins.ts
+++ b/packages/adapter-blade/src/conformance-pins.ts
@@ -11,15 +11,15 @@
 import type { ConformancePins } from '@barefootjs/jsx'
 
 export const conformancePins: ConformancePins = {
-  // Sibling-imported child component in a loop body: emits a
-  // cross-template call needing separate registration. BF103 makes
-  // the requirement loud (same as Jinja).
-  'static-array-children': [{ code: 'BF103', severity: 'error' }],
-  // TodoApp / TodoAppSSR import `TodoItem` from a sibling file and
-  // call it inside a keyed `.map`. Same BF103 (imported child in
-  // `.map`) as Jinja.
-  'todo-app': [{ code: 'BF103', severity: 'error' }],
-  'todo-app-ssr': [{ code: 'BF103', severity: 'error' }],
+  // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
+  // harness now passes `siblingTemplatesRegistered: true` for fixtures with
+  // sibling `components`, matching `bf build`'s real semantics, so the
+  // BF103 loop-body cross-template check no longer fires spuriously.
+  // `static-array-children` similarly no longer hits BF103, but now hits a
+  // DIFFERENT, pre-existing, orthogonal gap: `items` is a function-scope
+  // local const whose array-literal initializer the adapter's loop-source
+  // gate refuses to bind (only string-derived locals resolve) — see #2208.
+  'static-array-children': [{ code: 'BF101', severity: 'error' }],
   // The `([emoji, users]) => …` array-destructure param itself now lowers
   // (#2087 Phase B — see the destructure comment below), but the loop
   // ARRAY is a function-scope computed const (`const entries =
@@ -28,12 +28,10 @@ export const conformancePins: ConformancePins = {
   // check and policy as Jinja / ERB) instead of silently iterating zero
   // times over an unbound name.
   'static-array-from-props': [{ code: 'BF101', severity: 'error' }],
-  // Both BF103 (imported child) and BF101 (computed local-const loop
-  // array, as above) fire.
-  'static-array-from-props-with-component': [
-    { code: 'BF103', severity: 'error' },
-    { code: 'BF101', severity: 'error' },
-  ],
+  // BF101 (computed local-const loop array, as above) fires; BF103
+  // (imported child in the loop body) no longer does now that the
+  // conformance harness passes `siblingTemplatesRegistered: true` (#2205).
+  'static-array-from-props-with-component': [{ code: 'BF101', severity: 'error' }],
   // #2087 Phase B: every `.map()` destructure shape in the shared corpus
   // now lowers on Blade via an `@php(...)` local built from the binding's
   // structured `segments` path (`bladeLoopBindingAccessor` in

--- a/packages/adapter-blade/src/conformance-pins.ts
+++ b/packages/adapter-blade/src/conformance-pins.ts
@@ -14,7 +14,9 @@ export const conformancePins: ConformancePins = {
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the
-  // BF103 loop-body cross-template check no longer fires spuriously.
+  // BF103 loop-body cross-template check no longer fires spuriously. (Both
+  // fixtures are still skipped on this adapter via `render-divergences.ts`
+  // — #2209 — for an unrelated signal-seeding gap.)
   // `static-array-children` similarly no longer hits BF103, but now hits a
   // DIFFERENT, pre-existing, orthogonal gap: `items` is a function-scope
   // local const whose array-literal initializer the adapter's loop-source

--- a/packages/adapter-blade/src/conformance-pins.ts
+++ b/packages/adapter-blade/src/conformance-pins.ts
@@ -21,7 +21,9 @@ export const conformancePins: ConformancePins = {
   // DIFFERENT, pre-existing, orthogonal gap: `items` is a function-scope
   // local const whose array-literal initializer the adapter's loop-source
   // gate refuses to bind (only string-derived locals resolve) — see #2208.
-  'static-array-children': [{ code: 'BF101', severity: 'error' }],
+  'static-array-children': [
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2208' },
+  ],
   // The `([emoji, users]) => …` array-destructure param itself now lowers
   // (#2087 Phase B — see the destructure comment below), but the loop
   // ARRAY is a function-scope computed const (`const entries =

--- a/packages/adapter-blade/src/render-divergences.ts
+++ b/packages/adapter-blade/src/render-divergences.ts
@@ -14,4 +14,13 @@
 
 import type { RenderDivergences } from '@barefootjs/jsx'
 
-export const renderDivergences: RenderDivergences = {}
+export const renderDivergences: RenderDivergences = {
+  // TodoApp seeds its `todos` signal from `(props.initialTodos ??
+  // []).map(t => ({ ...t, editing: false }))` — a compound expression this
+  // harness's signal-init seeding can't evaluate, so `todos` seeds empty
+  // and `<ul class="todo-list">` renders with no `<li>`s. Orthogonal to
+  // #2205 (sibling template registration, which these fixtures now
+  // compile cleanly under): a test-harness signal-seeding gap.
+  'todo-app': 'https://github.com/piconic-ai/barefootjs/issues/2209',
+  'todo-app-ssr': 'https://github.com/piconic-ai/barefootjs/issues/2209',
+}

--- a/packages/adapter-blade/src/test-render.ts
+++ b/packages/adapter-blade/src/test-render.ts
@@ -157,14 +157,14 @@ export async function renderBladeComponent(options: RenderOptions): Promise<stri
     }
   }
 
-  // Compile parent source. `siblingTemplatesRegistered: true` matches this
-  // harness's real behavior — every sibling child template is registered
+  // Compile parent source. `siblingTemplatesRegistered: Boolean(components)`
+  // matches this harness's real behavior — every sibling child template is registered
   // alongside the parent before rendering, so a loop-body cross-template
   // call resolves at render time (#2205).
   const result = compileJSX(source, 'component.tsx', {
     adapter,
     outputIR: true,
-    siblingTemplatesRegistered: true,
+    siblingTemplatesRegistered: Boolean(components),
   })
 
   const errors = result.errors.filter(e => e.severity === 'error')

--- a/packages/adapter-blade/src/test-render.ts
+++ b/packages/adapter-blade/src/test-render.ts
@@ -157,8 +157,15 @@ export async function renderBladeComponent(options: RenderOptions): Promise<stri
     }
   }
 
-  // Compile parent source.
-  const result = compileJSX(source, 'component.tsx', { adapter, outputIR: true })
+  // Compile parent source. `siblingTemplatesRegistered: true` matches this
+  // harness's real behavior — every sibling child template is registered
+  // alongside the parent before rendering, so a loop-body cross-template
+  // call resolves at render time (#2205).
+  const result = compileJSX(source, 'component.tsx', {
+    adapter,
+    outputIR: true,
+    siblingTemplatesRegistered: true,
+  })
 
   const errors = result.errors.filter(e => e.severity === 'error')
   if (errors.length > 0) {

--- a/packages/adapter-erb/src/conformance-pins.ts
+++ b/packages/adapter-erb/src/conformance-pins.ts
@@ -22,7 +22,9 @@ export const conformancePins: ConformancePins = {
   // DIFFERENT, pre-existing, orthogonal gap: `items` is a function-scope
   // local const whose array-literal initializer the adapter's loop-source
   // gate refuses to bind (only string-derived locals resolve) — see #2208.
-  'static-array-children': [{ code: 'BF101', severity: 'error' }],
+  'static-array-children': [
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2208' },
+  ],
   // `static-array-from-props` / `static-array-from-props-with-component`:
   // the `.map(([emoji, users]) => …)` / `.map(([id, t]) => …)` callback is
   // a plain array-index destructure (the `.filter(...)` runs on a

--- a/packages/adapter-erb/src/conformance-pins.ts
+++ b/packages/adapter-erb/src/conformance-pins.ts
@@ -12,16 +12,17 @@
 import type { ConformancePins } from '@barefootjs/jsx'
 
 export const conformancePins: ConformancePins = {
-  // Sibling-imported child component in a loop body: emits a
-  // cross-template call needing separate registration. BF103 makes
-  // the requirement loud (same as mojo).
-  'static-array-children': [{ code: 'BF103', severity: 'error' }],
-  // TodoApp / TodoAppSSR import `TodoItem` from a sibling file and
-  // call it inside a keyed `.map`. Same BF103 surface as the
-  // synthetic `static-array-children` above — pinned at adapter
-  // level so the shared-component corpus stays adapter-neutral.
-  'todo-app': [{ code: 'BF103', severity: 'error' }],
-  'todo-app-ssr': [{ code: 'BF103', severity: 'error' }],
+  // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
+  // harness now passes `siblingTemplatesRegistered: true` for fixtures with
+  // sibling `components`, matching `bf build`'s real semantics, so the
+  // BF103 loop-body cross-template check no longer fires spuriously. (Both
+  // fixtures are still skipped on this adapter via `render-divergences.ts`
+  // — #2209 — for an unrelated signal-seeding gap.)
+  // `static-array-children` similarly no longer hits BF103, but now hits a
+  // DIFFERENT, pre-existing, orthogonal gap: `items` is a function-scope
+  // local const whose array-literal initializer the adapter's loop-source
+  // gate refuses to bind (only string-derived locals resolve) — see #2208.
+  'static-array-children': [{ code: 'BF101', severity: 'error' }],
   // `static-array-from-props` / `static-array-from-props-with-component`:
   // the `.map(([emoji, users]) => …)` / `.map(([id, t]) => …)` callback is
   // a plain array-index destructure (the `.filter(...)` runs on a
@@ -45,8 +46,9 @@ export const conformancePins: ConformancePins = {
   'static-array-from-props': [
     { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2087' },
   ],
+  // BF103 (imported child in the loop body) no longer fires now that the
+  // conformance harness passes `siblingTemplatesRegistered: true` (#2205).
   'static-array-from-props-with-component': [
-    { code: 'BF103', severity: 'error' },
     { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2087' },
   ],
   // #2087 Phase B: `isLowerableLoopDestructure` now admits every fixed-

--- a/packages/adapter-erb/src/render-divergences.ts
+++ b/packages/adapter-erb/src/render-divergences.ts
@@ -14,4 +14,13 @@
 
 import type { RenderDivergences } from '@barefootjs/jsx'
 
-export const renderDivergences: RenderDivergences = {}
+export const renderDivergences: RenderDivergences = {
+  // TodoApp seeds its `todos` signal from `(props.initialTodos ??
+  // []).map(t => ({ ...t, editing: false }))` — a compound expression this
+  // harness's `evaluateSignalInit` can't parse, so `todos` seeds as `nil`
+  // and the Ruby render crashes (`undefined method 'length' for nil`).
+  // Orthogonal to #2205 (sibling template registration, which these
+  // fixtures now pass cleanly): a test-harness signal-seeding gap.
+  'todo-app': 'https://github.com/piconic-ai/barefootjs/issues/2209',
+  'todo-app-ssr': 'https://github.com/piconic-ai/barefootjs/issues/2209',
+}

--- a/packages/adapter-erb/src/test-render.ts
+++ b/packages/adapter-erb/src/test-render.ts
@@ -151,8 +151,15 @@ export async function renderErbComponent(options: RenderOptions): Promise<string
     }
   }
 
-  // Compile parent source.
-  const result = compileJSX(source, 'component.tsx', { adapter, outputIR: true })
+  // Compile parent source. `siblingTemplatesRegistered: true` matches this
+  // harness's real behavior — every sibling child template is registered
+  // alongside the parent before rendering, so a loop-body cross-template
+  // call resolves at render time (#2205).
+  const result = compileJSX(source, 'component.tsx', {
+    adapter,
+    outputIR: true,
+    siblingTemplatesRegistered: true,
+  })
 
   const errors = result.errors.filter(e => e.severity === 'error')
   if (errors.length > 0) {

--- a/packages/adapter-erb/src/test-render.ts
+++ b/packages/adapter-erb/src/test-render.ts
@@ -151,14 +151,14 @@ export async function renderErbComponent(options: RenderOptions): Promise<string
     }
   }
 
-  // Compile parent source. `siblingTemplatesRegistered: true` matches this
-  // harness's real behavior — every sibling child template is registered
+  // Compile parent source. `siblingTemplatesRegistered: Boolean(components)`
+  // matches this harness's real behavior — every sibling child template is registered
   // alongside the parent before rendering, so a loop-body cross-template
   // call resolves at render time (#2205).
   const result = compileJSX(source, 'component.tsx', {
     adapter,
     outputIR: true,
-    siblingTemplatesRegistered: true,
+    siblingTemplatesRegistered: Boolean(components),
   })
 
   const errors = result.errors.filter(e => e.severity === 'error')

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -27,7 +27,9 @@ export const conformancePins: ConformancePins = {
   // local const whose array-literal initializer the adapter's loop-source
   // gate refuses to bind (only string-derived locals resolve to a
   // generated struct field) — see #2208.
-  'static-array-children': [{ code: 'BF101', severity: 'error' }],
+  'static-array-children': [
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2208' },
+  ],
   // `([emoji, users]) => ...` is an array-index tuple destructure — #2087
   // Phase B's widened gate now admits this shape (`destructure-array-index-in-map`
   // exercises the same `segments`-based lowering). The remaining refusal here

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -15,19 +15,16 @@ export const conformancePins: ConformancePins = {
   // `style={{ … }}` object literal now lowers to a CSS string with dynamic
   // values interpolated (`background-color:{{.Color}};padding:8px`) via
   // `tryLowerStyleObject` (#1322).
-  // Sibling-imported child component inside a loop body: the adapter
-  // emits `{{template "X" .}}` which only resolves if the user has
-  // compiled the sibling file and registered the template on the
-  // same instance. BF103 makes that requirement loud. (The barefoot
-  // CLI passes `siblingTemplatesRegistered: true` so CLI builds
-  // suppress the diagnostic — see compileJSX `siblingTemplatesRegistered`.)
-  'static-array-children': [{ code: 'BF103', severity: 'error' }],
-  // TodoApp / TodoAppSSR import `TodoItem` from a sibling file and
-  // call it inside a keyed `.map`. Same BF103 surface as
-  // `static-array-children` above — pinned at adapter level so the
-  // shared-component corpus stays adapter-neutral.
-  'todo-app': [{ code: 'BF103', severity: 'error' }],
-  'todo-app-ssr': [{ code: 'BF103', severity: 'error' }],
+  // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
+  // harness now passes `siblingTemplatesRegistered: true` for fixtures with
+  // sibling `components`, matching `bf build`'s real semantics, so the
+  // BF103 loop-body cross-template check no longer fires spuriously.
+  // `static-array-children` similarly no longer hits BF103, but now hits a
+  // DIFFERENT, pre-existing, orthogonal gap: `items` is a function-scope
+  // local const whose array-literal initializer the adapter's loop-source
+  // gate refuses to bind (only string-derived locals resolve to a
+  // generated struct field) — see #2208.
+  'static-array-children': [{ code: 'BF101', severity: 'error' }],
   // `([emoji, users]) => ...` is an array-index tuple destructure — #2087
   // Phase B's widened gate now admits this shape (`destructure-array-index-in-map`
   // exercises the same `segments`-based lowering). The remaining refusal here
@@ -40,13 +37,11 @@ export const conformancePins: ConformancePins = {
   // array bound to such a const. See the `renderLoop` comment at the check
   // site; Jinja / ERB apply the same narrow check for the same reason.
   'static-array-from-props': [{ code: 'BF101', severity: 'error' }],
-  // Same computed-const array as above, plus the pre-existing BF103 (a
-  // sibling-imported child component used inside the loop body) — the
-  // destructure param itself no longer contributes a diagnostic.
-  'static-array-from-props-with-component': [
-    { code: 'BF103', severity: 'error' },
-    { code: 'BF101', severity: 'error' },
-  ],
+  // Same computed-const array as above — the destructure param itself no
+  // longer contributes a diagnostic, and BF103 (sibling-imported child
+  // component in the loop body) no longer fires either now that the
+  // conformance harness passes `siblingTemplatesRegistered: true` (#2205).
+  'static-array-from-props-with-component': [{ code: 'BF101', severity: 'error' }],
   // (`style-3-signals` graduated alongside `style-object-dynamic` — see note
   // above; the `style={{ … }}` object now lowers to a CSS string.)
   // (`tagged-template-classname` graduated by #2092 — the tag resolves

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -19,6 +19,9 @@ export const conformancePins: ConformancePins = {
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the
   // BF103 loop-body cross-template check no longer fires spuriously.
+  // (`todo-app-ssr` is still skipped on this adapter via
+  // `render-divergences.ts` — #2209 — for an unrelated signal-seeding gap;
+  // `todo-app`'s pre-hydration empty render is unaffected.)
   // `static-array-children` similarly no longer hits BF103, but now hits a
   // DIFFERENT, pre-existing, orthogonal gap: `items` is a function-scope
   // local const whose array-literal initializer the adapter's loop-source

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -17,4 +17,14 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
+  // TodoAppSSR (no `/* @client */` markers — the loop must render server-
+  // side) seeds its `todos` signal from `(props.initialTodos ??
+  // []).map(t => ({ ...t, editing: false }))`. This harness's signal-init
+  // seeding can't evaluate that compound expression, so `todos` seeds
+  // empty and `<ul class="todo-list">` renders with no `<li>`s. Orthogonal
+  // to #2205 (sibling template registration, which this fixture now
+  // compiles cleanly under): a test-harness signal-seeding gap. `todo-app`
+  // (client-hydrated variant) is unaffected — its initial empty SSR list
+  // is the correct pre-hydration render.
+  'todo-app-ssr': 'https://github.com/piconic-ai/barefootjs/issues/2209',
 }

--- a/packages/adapter-go-template/src/test-render.ts
+++ b/packages/adapter-go-template/src/test-render.ts
@@ -157,8 +157,15 @@ export async function renderGoTemplateComponent(options: RenderOptions): Promise
     }
   }
 
-  // Compile parent source
-  const result = compileJSX(source, 'component.tsx', { adapter, outputIR: true })
+  // Compile parent source. `siblingTemplatesRegistered: true` matches this
+  // harness's real behavior — every sibling child template is concatenated
+  // into `tmplContent` and parsed onto one `*template.Template` instance
+  // below, so a loop-body cross-template call resolves at render time (#2205).
+  const result = compileJSX(source, 'component.tsx', {
+    adapter,
+    outputIR: true,
+    siblingTemplatesRegistered: true,
+  })
 
   const errors = result.errors.filter(e => e.severity === 'error')
   if (errors.length > 0) {

--- a/packages/adapter-go-template/src/test-render.ts
+++ b/packages/adapter-go-template/src/test-render.ts
@@ -157,14 +157,14 @@ export async function renderGoTemplateComponent(options: RenderOptions): Promise
     }
   }
 
-  // Compile parent source. `siblingTemplatesRegistered: true` matches this
-  // harness's real behavior — every sibling child template is concatenated
+  // Compile parent source. `siblingTemplatesRegistered: Boolean(components)`
+  // matches this harness's real behavior — every sibling child template is concatenated
   // into `tmplContent` and parsed onto one `*template.Template` instance
   // below, so a loop-body cross-template call resolves at render time (#2205).
   const result = compileJSX(source, 'component.tsx', {
     adapter,
     outputIR: true,
-    siblingTemplatesRegistered: true,
+    siblingTemplatesRegistered: Boolean(components),
   })
 
   const errors = result.errors.filter(e => e.severity === 'error')

--- a/packages/adapter-jinja/src/conformance-pins.ts
+++ b/packages/adapter-jinja/src/conformance-pins.ts
@@ -11,15 +11,17 @@
 import type { ConformancePins } from '@barefootjs/jsx'
 
 export const conformancePins: ConformancePins = {
-  // Sibling-imported child component in a loop body: emits a
-  // cross-template call needing separate registration. BF103 makes
-  // the requirement loud (same as xslate).
-  'static-array-children': [{ code: 'BF103', severity: 'error' }],
-  // TodoApp / TodoAppSSR import `TodoItem` from a sibling file and
-  // call it inside a keyed `.map`. Same BF103 (imported child in
-  // `.map`) as xslate.
-  'todo-app': [{ code: 'BF103', severity: 'error' }],
-  'todo-app-ssr': [{ code: 'BF103', severity: 'error' }],
+  // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
+  // harness now passes `siblingTemplatesRegistered: true` for fixtures with
+  // sibling `components`, matching `bf build`'s real semantics, so the
+  // BF103 loop-body cross-template check no longer fires spuriously. (Both
+  // fixtures are still skipped on this adapter via `render-divergences.ts`
+  // — #2209 — for an unrelated signal-seeding gap.)
+  // `static-array-children` similarly no longer hits BF103, but now hits a
+  // DIFFERENT, pre-existing, orthogonal gap: `items` is a function-scope
+  // local const whose array-literal initializer the adapter's loop-source
+  // gate refuses to bind (only string-derived locals resolve) — see #2208.
+  'static-array-children': [{ code: 'BF101', severity: 'error' }],
   // #2087 Phase A/B widened the destructure gate (`isLowerableLoopDestructure`)
   // to admit array-index / nested-path fixed bindings, so the
   // `([emoji, users]) => ...` / `([id, t]) => ...` params in these two
@@ -44,10 +46,10 @@ export const conformancePins: ConformancePins = {
   'static-array-from-props': [
     { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2087' },
   ],
-  // Both BF103 (imported child) and BF101 (unresolvable computed loop
-  // array, see above) fire.
+  // BF101 (unresolvable computed loop array, see above) fires; BF103
+  // (imported child in the loop body) no longer does now that the
+  // conformance harness passes `siblingTemplatesRegistered: true` (#2205).
   'static-array-from-props-with-component': [
-    { code: 'BF103', severity: 'error' },
     { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2087' },
   ],
   // Rest-destructure / structured-path `.map()` callbacks (#2087 Phase B):

--- a/packages/adapter-jinja/src/conformance-pins.ts
+++ b/packages/adapter-jinja/src/conformance-pins.ts
@@ -21,7 +21,9 @@ export const conformancePins: ConformancePins = {
   // DIFFERENT, pre-existing, orthogonal gap: `items` is a function-scope
   // local const whose array-literal initializer the adapter's loop-source
   // gate refuses to bind (only string-derived locals resolve) — see #2208.
-  'static-array-children': [{ code: 'BF101', severity: 'error' }],
+  'static-array-children': [
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2208' },
+  ],
   // #2087 Phase A/B widened the destructure gate (`isLowerableLoopDestructure`)
   // to admit array-index / nested-path fixed bindings, so the
   // `([emoji, users]) => ...` / `([id, t]) => ...` params in these two

--- a/packages/adapter-jinja/src/render-divergences.ts
+++ b/packages/adapter-jinja/src/render-divergences.ts
@@ -14,4 +14,14 @@
 
 import type { RenderDivergences } from '@barefootjs/jsx'
 
-export const renderDivergences: RenderDivergences = {}
+export const renderDivergences: RenderDivergences = {
+  // TodoApp seeds its `todos` signal from `(props.initialTodos ??
+  // []).map(t => ({ ...t, editing: false }))` — a compound expression this
+  // harness's `evaluateSignalInit` can't parse, so `todos` seeds as
+  // unset and Jinja's tolerant-Undefined handling silently iterates zero
+  // times (`<ul class="todo-list">` renders empty). Orthogonal to #2205
+  // (sibling template registration, which these fixtures now pass
+  // cleanly): a test-harness signal-seeding gap.
+  'todo-app': 'https://github.com/piconic-ai/barefootjs/issues/2209',
+  'todo-app-ssr': 'https://github.com/piconic-ai/barefootjs/issues/2209',
+}

--- a/packages/adapter-jinja/src/test-render.ts
+++ b/packages/adapter-jinja/src/test-render.ts
@@ -125,14 +125,14 @@ export async function renderJinjaComponent(options: RenderOptions): Promise<stri
     }
   }
 
-  // Compile parent source. `siblingTemplatesRegistered: true` matches this
-  // harness's real behavior — every sibling child template is registered
+  // Compile parent source. `siblingTemplatesRegistered: Boolean(components)`
+  // matches this harness's real behavior — every sibling child template is registered
   // alongside the parent before rendering, so a loop-body cross-template
   // call resolves at render time (#2205).
   const result = compileJSX(source, 'component.tsx', {
     adapter,
     outputIR: true,
-    siblingTemplatesRegistered: true,
+    siblingTemplatesRegistered: Boolean(components),
   })
 
   const errors = result.errors.filter(e => e.severity === 'error')

--- a/packages/adapter-jinja/src/test-render.ts
+++ b/packages/adapter-jinja/src/test-render.ts
@@ -125,8 +125,15 @@ export async function renderJinjaComponent(options: RenderOptions): Promise<stri
     }
   }
 
-  // Compile parent source.
-  const result = compileJSX(source, 'component.tsx', { adapter, outputIR: true })
+  // Compile parent source. `siblingTemplatesRegistered: true` matches this
+  // harness's real behavior — every sibling child template is registered
+  // alongside the parent before rendering, so a loop-body cross-template
+  // call resolves at render time (#2205).
+  const result = compileJSX(source, 'component.tsx', {
+    adapter,
+    outputIR: true,
+    siblingTemplatesRegistered: true,
+  })
 
   const errors = result.errors.filter(e => e.severity === 'error')
   if (errors.length > 0) {

--- a/packages/adapter-mojolicious/src/conformance-pins.ts
+++ b/packages/adapter-mojolicious/src/conformance-pins.ts
@@ -9,17 +9,15 @@
 import type { ConformancePins } from '@barefootjs/jsx'
 
 export const conformancePins: ConformancePins = {
-  // Sibling-imported child component in a loop body: Mojo emits
-  // a cross-template call that needs separate registration. BF103
-  // makes the requirement loud. (The barefoot CLI passes
-  // `siblingTemplatesRegistered: true` so CLI builds suppress it.)
-  'static-array-children': [{ code: 'BF103', severity: 'error' }],
-  // TodoApp / TodoAppSSR import `TodoItem` from a sibling file and
-  // call it inside a keyed `.map`. Same BF103 surface as the
-  // synthetic `static-array-children` above — pinned at adapter
-  // level so the shared-component corpus stays adapter-neutral.
-  'todo-app': [{ code: 'BF103', severity: 'error' }],
-  'todo-app-ssr': [{ code: 'BF103', severity: 'error' }],
+  // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
+  // harness now passes `siblingTemplatesRegistered: true` for fixtures with
+  // sibling `components`, matching `bf build`'s real semantics, so the
+  // BF103 loop-body cross-template check no longer fires spuriously.
+  // `static-array-children` similarly no longer hits BF103, but now hits a
+  // DIFFERENT, pre-existing, orthogonal gap: `items` is a function-scope
+  // local const whose array-literal initializer the adapter's loop-source
+  // gate refuses to bind (only string-derived locals resolve) — see #2208.
+  'static-array-children': [{ code: 'BF101', severity: 'error' }],
   // `([emoji, users]) => ...` / `([id, t]) => ...` are plain array-index
   // (tuple) destructures, no rest — #2087 Phase B's `segments`-walking
   // accessor lowers both to `$__bf_item->[0]` / `$__bf_item->[1]` `my`
@@ -32,12 +30,11 @@ export const conformancePins: ConformancePins = {
   // check in `renderLoop`. This was always true; it was simply
   // unreachable before because BF104 refused the destructure shape first.
   'static-array-from-props': [{ code: 'BF101', severity: 'error' }],
-  // Both BF103 (sibling-imported `<Tag>` child component) and the BF101
-  // above fire; BF104 no longer does (see above).
-  'static-array-from-props-with-component': [
-    { code: 'BF103', severity: 'error' },
-    { code: 'BF101', severity: 'error' },
-  ],
+  // The BF101 above fires; BF104 no longer does (see above), and BF103
+  // (sibling-imported `<Tag>` child component in the loop body) no longer
+  // does either now that the conformance harness passes
+  // `siblingTemplatesRegistered: true` (#2205).
+  'static-array-from-props-with-component': [{ code: 'BF101', severity: 'error' }],
   // #1310 / #2087: rest destructure in .map() callback. All four shapes
   // now lower via #2087 Phase B's `segments`-walking accessor:
   //   - object-rest read via member access (`rest-destructure-object-in-map`):

--- a/packages/adapter-mojolicious/src/conformance-pins.ts
+++ b/packages/adapter-mojolicious/src/conformance-pins.ts
@@ -19,7 +19,9 @@ export const conformancePins: ConformancePins = {
   // DIFFERENT, pre-existing, orthogonal gap: `items` is a function-scope
   // local const whose array-literal initializer the adapter's loop-source
   // gate refuses to bind (only string-derived locals resolve) — see #2208.
-  'static-array-children': [{ code: 'BF101', severity: 'error' }],
+  'static-array-children': [
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2208' },
+  ],
   // `([emoji, users]) => ...` / `([id, t]) => ...` are plain array-index
   // (tuple) destructures, no rest — #2087 Phase B's `segments`-walking
   // accessor lowers both to `$__bf_item->[0]` / `$__bf_item->[1]` `my`

--- a/packages/adapter-mojolicious/src/conformance-pins.ts
+++ b/packages/adapter-mojolicious/src/conformance-pins.ts
@@ -12,7 +12,9 @@ export const conformancePins: ConformancePins = {
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the
-  // BF103 loop-body cross-template check no longer fires spuriously.
+  // BF103 loop-body cross-template check no longer fires spuriously. (Both
+  // fixtures are still skipped on this adapter via `render-divergences.ts`
+  // — #2209 — for an unrelated signal-seeding gap.)
   // `static-array-children` similarly no longer hits BF103, but now hits a
   // DIFFERENT, pre-existing, orthogonal gap: `items` is a function-scope
   // local const whose array-literal initializer the adapter's loop-source

--- a/packages/adapter-mojolicious/src/render-divergences.ts
+++ b/packages/adapter-mojolicious/src/render-divergences.ts
@@ -14,4 +14,13 @@
 
 import type { RenderDivergences } from '@barefootjs/jsx'
 
-export const renderDivergences: RenderDivergences = {}
+export const renderDivergences: RenderDivergences = {
+  // TodoApp seeds its `todos` signal from `(props.initialTodos ??
+  // []).map(t => ({ ...t, editing: false }))` — a compound expression this
+  // harness's signal-init seeding can't evaluate, so `todos` seeds empty
+  // and `<ul class="todo-list">` renders with no `<li>`s. Orthogonal to
+  // #2205 (sibling template registration, which these fixtures now
+  // compile cleanly under): a test-harness signal-seeding gap.
+  'todo-app': 'https://github.com/piconic-ai/barefootjs/issues/2209',
+  'todo-app-ssr': 'https://github.com/piconic-ai/barefootjs/issues/2209',
+}

--- a/packages/adapter-mojolicious/src/test-render.ts
+++ b/packages/adapter-mojolicious/src/test-render.ts
@@ -136,8 +136,15 @@ export async function renderMojoComponent(options: RenderOptions): Promise<strin
     }
   }
 
-  // Compile parent source
-  const result = compileJSX(source, 'component.tsx', { adapter, outputIR: true })
+  // Compile parent source. `siblingTemplatesRegistered: true` matches this
+  // harness's real behavior — every sibling child template is registered
+  // alongside the parent before rendering, so a loop-body cross-template
+  // call resolves at render time (#2205).
+  const result = compileJSX(source, 'component.tsx', {
+    adapter,
+    outputIR: true,
+    siblingTemplatesRegistered: true,
+  })
 
   const errors = result.errors.filter(e => e.severity === 'error')
   if (errors.length > 0) {

--- a/packages/adapter-mojolicious/src/test-render.ts
+++ b/packages/adapter-mojolicious/src/test-render.ts
@@ -136,14 +136,14 @@ export async function renderMojoComponent(options: RenderOptions): Promise<strin
     }
   }
 
-  // Compile parent source. `siblingTemplatesRegistered: true` matches this
-  // harness's real behavior — every sibling child template is registered
+  // Compile parent source. `siblingTemplatesRegistered: Boolean(components)`
+  // matches this harness's real behavior — every sibling child template is registered
   // alongside the parent before rendering, so a loop-body cross-template
   // call resolves at render time (#2205).
   const result = compileJSX(source, 'component.tsx', {
     adapter,
     outputIR: true,
-    siblingTemplatesRegistered: true,
+    siblingTemplatesRegistered: Boolean(components),
   })
 
   const errors = result.errors.filter(e => e.severity === 'error')

--- a/packages/adapter-rust/src/conformance-pins.ts
+++ b/packages/adapter-rust/src/conformance-pins.ts
@@ -12,15 +12,17 @@
 import type { ConformancePins } from '@barefootjs/jsx'
 
 export const conformancePins: ConformancePins = {
-  // Sibling-imported child component in a loop body: emits a
-  // cross-template call needing separate registration. BF103 makes
-  // the requirement loud (same as xslate).
-  'static-array-children': [{ code: 'BF103', severity: 'error' }],
-  // TodoApp / TodoAppSSR import `TodoItem` from a sibling file and
-  // call it inside a keyed `.map`. Same BF103 (imported child in
-  // `.map`) as xslate.
-  'todo-app': [{ code: 'BF103', severity: 'error' }],
-  'todo-app-ssr': [{ code: 'BF103', severity: 'error' }],
+  // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
+  // harness now passes `siblingTemplatesRegistered: true` for fixtures with
+  // sibling `components`, matching `bf build`'s real semantics, so the
+  // BF103 loop-body cross-template check no longer fires spuriously. (Both
+  // fixtures are still skipped on this adapter via `render-divergences.ts`
+  // — #2209 — for an unrelated signal-seeding gap.)
+  // `static-array-children` similarly no longer hits BF103, but now hits a
+  // DIFFERENT, pre-existing, orthogonal gap: `items` is a function-scope
+  // local const whose array-literal initializer the adapter's loop-source
+  // gate refuses to bind (only string-derived locals resolve) — see #2208.
+  'static-array-children': [{ code: 'BF101', severity: 'error' }],
   // The `([emoji, users]) => ...` / `([id, t]) => ...` params in these two
   // fixtures no longer trip BF104 — the destructure itself now lowers
   // cleanly to a native `{% set %}` accessor (#2087 Phase B). But both
@@ -44,10 +46,10 @@ export const conformancePins: ConformancePins = {
   'static-array-from-props': [
     { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2087' },
   ],
-  // Both BF103 (imported child) and BF101 (unresolvable computed loop
-  // array, see above) fire.
+  // BF101 (unresolvable computed loop array, see above) fires; BF103
+  // (imported child in the loop body) no longer does now that the
+  // conformance harness passes `siblingTemplatesRegistered: true` (#2205).
   'static-array-from-props-with-component': [
-    { code: 'BF103', severity: 'error' },
     { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2087' },
   ],
   // Rest-destructure `.map()` callbacks (#2087 Phase B): every shape now

--- a/packages/adapter-rust/src/conformance-pins.ts
+++ b/packages/adapter-rust/src/conformance-pins.ts
@@ -22,7 +22,9 @@ export const conformancePins: ConformancePins = {
   // DIFFERENT, pre-existing, orthogonal gap: `items` is a function-scope
   // local const whose array-literal initializer the adapter's loop-source
   // gate refuses to bind (only string-derived locals resolve) — see #2208.
-  'static-array-children': [{ code: 'BF101', severity: 'error' }],
+  'static-array-children': [
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2208' },
+  ],
   // The `([emoji, users]) => ...` / `([id, t]) => ...` params in these two
   // fixtures no longer trip BF104 — the destructure itself now lowers
   // cleanly to a native `{% set %}` accessor (#2087 Phase B). But both

--- a/packages/adapter-rust/src/render-divergences.ts
+++ b/packages/adapter-rust/src/render-divergences.ts
@@ -16,4 +16,14 @@
 
 import type { RenderDivergences } from '@barefootjs/jsx'
 
-export const renderDivergences: RenderDivergences = {}
+export const renderDivergences: RenderDivergences = {
+  // TodoApp seeds its `todos` signal from `(props.initialTodos ??
+  // []).map(t => ({ ...t, editing: false }))` — a compound expression this
+  // harness's `evaluateSignalInit` can't parse, so `todos` seeds as
+  // unset and minijinja's tolerant-Undefined handling silently iterates
+  // zero times (`<ul class="todo-list">` renders empty). Orthogonal to
+  // #2205 (sibling template registration, which these fixtures now pass
+  // cleanly): a test-harness signal-seeding gap.
+  'todo-app': 'https://github.com/piconic-ai/barefootjs/issues/2209',
+  'todo-app-ssr': 'https://github.com/piconic-ai/barefootjs/issues/2209',
+}

--- a/packages/adapter-rust/src/test-render.ts
+++ b/packages/adapter-rust/src/test-render.ts
@@ -170,14 +170,14 @@ export async function renderMinijinjaComponent(options: RenderOptions): Promise<
     }
   }
 
-  // Compile parent source. `siblingTemplatesRegistered: true` matches this
-  // harness's real behavior — every sibling child template is registered
+  // Compile parent source. `siblingTemplatesRegistered: Boolean(components)`
+  // matches this harness's real behavior — every sibling child template is registered
   // alongside the parent before rendering, so a loop-body cross-template
   // call resolves at render time (#2205).
   const result = compileJSX(source, 'component.tsx', {
     adapter,
     outputIR: true,
-    siblingTemplatesRegistered: true,
+    siblingTemplatesRegistered: Boolean(components),
   })
 
   const errors = result.errors.filter(e => e.severity === 'error')

--- a/packages/adapter-rust/src/test-render.ts
+++ b/packages/adapter-rust/src/test-render.ts
@@ -170,8 +170,15 @@ export async function renderMinijinjaComponent(options: RenderOptions): Promise<
     }
   }
 
-  // Compile parent source.
-  const result = compileJSX(source, 'component.tsx', { adapter, outputIR: true })
+  // Compile parent source. `siblingTemplatesRegistered: true` matches this
+  // harness's real behavior — every sibling child template is registered
+  // alongside the parent before rendering, so a loop-body cross-template
+  // call resolves at render time (#2205).
+  const result = compileJSX(source, 'component.tsx', {
+    adapter,
+    outputIR: true,
+    siblingTemplatesRegistered: true,
+  })
 
   const errors = result.errors.filter(e => e.severity === 'error')
   if (errors.length > 0) {

--- a/packages/adapter-tests/src/jsx-runner.ts
+++ b/packages/adapter-tests/src/jsx-runner.ts
@@ -413,6 +413,11 @@ function collectFixtureDiagnostics(args: {
   // instance, so cross-template calls from a loop body resolve at render
   // time. Without this, `checkImportedLoopChildComponents` fires BF103 for
   // every adapter even though the shape works in real usage (#2205).
+  // Assumes every relative import the fixture's source makes is present in
+  // `components` — a fixture that imports a sibling NOT provided there
+  // would have its legitimate BF103 suppressed here too, surfacing instead
+  // as a murkier render-time "missing template" error. Such a fixture is
+  // broken by construction regardless, so this isn't gated further.
   const siblingTemplatesRegistered = Boolean(args.components)
   if (args.components) {
     for (const [filename, childSource] of Object.entries(args.components)) {

--- a/packages/adapter-tests/src/jsx-runner.ts
+++ b/packages/adapter-tests/src/jsx-runner.ts
@@ -408,11 +408,18 @@ function collectFixtureDiagnostics(args: {
   adapter: TemplateAdapter
 }): CompilerError[] {
   const all: CompilerError[] = []
+  // Mirrors `bf build`'s real semantics (packages/compat/src/engine.ts): a
+  // fixture with sibling `components` compiles them onto one template
+  // instance, so cross-template calls from a loop body resolve at render
+  // time. Without this, `checkImportedLoopChildComponents` fires BF103 for
+  // every adapter even though the shape works in real usage (#2205).
+  const siblingTemplatesRegistered = Boolean(args.components)
   if (args.components) {
     for (const [filename, childSource] of Object.entries(args.components)) {
       const r = compileJSX(childSource.trimStart(), filename, {
         adapter: args.adapter,
         outputIR: true,
+        siblingTemplatesRegistered,
       })
       all.push(...r.errors)
     }
@@ -420,6 +427,7 @@ function collectFixtureDiagnostics(args: {
   const result = compileJSX(args.source.trimStart(), 'component.tsx', {
     adapter: args.adapter,
     outputIR: true,
+    siblingTemplatesRegistered,
   })
   all.push(...result.errors)
   return all

--- a/packages/adapter-twig/src/conformance-pins.ts
+++ b/packages/adapter-twig/src/conformance-pins.ts
@@ -11,15 +11,15 @@
 import type { ConformancePins } from '@barefootjs/jsx'
 
 export const conformancePins: ConformancePins = {
-  // Sibling-imported child component in a loop body: emits a
-  // cross-template call needing separate registration. BF103 makes
-  // the requirement loud (same as Jinja).
-  'static-array-children': [{ code: 'BF103', severity: 'error' }],
-  // TodoApp / TodoAppSSR import `TodoItem` from a sibling file and
-  // call it inside a keyed `.map`. Same BF103 (imported child in
-  // `.map`) as Jinja.
-  'todo-app': [{ code: 'BF103', severity: 'error' }],
-  'todo-app-ssr': [{ code: 'BF103', severity: 'error' }],
+  // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
+  // harness now passes `siblingTemplatesRegistered: true` for fixtures with
+  // sibling `components`, matching `bf build`'s real semantics, so the
+  // BF103 loop-body cross-template check no longer fires spuriously.
+  // `static-array-children` similarly no longer hits BF103, but now hits a
+  // DIFFERENT, pre-existing, orthogonal gap: `items` is a function-scope
+  // local const whose array-literal initializer the adapter's loop-source
+  // gate refuses to bind (only string-derived locals resolve) — see #2208.
+  'static-array-children': [{ code: 'BF101', severity: 'error' }],
   // The `([emoji, users]) => …` array-destructure param itself now lowers
   // (#2087 Phase B — see the destructure comment below), but the loop
   // ARRAY is a function-scope computed const (`const entries =
@@ -28,12 +28,10 @@ export const conformancePins: ConformancePins = {
   // check and policy as Jinja / ERB) instead of silently iterating zero
   // times over an unbound name.
   'static-array-from-props': [{ code: 'BF101', severity: 'error' }],
-  // Both BF103 (imported child) and BF101 (computed local-const loop
-  // array, as above) fire.
-  'static-array-from-props-with-component': [
-    { code: 'BF103', severity: 'error' },
-    { code: 'BF101', severity: 'error' },
-  ],
+  // BF101 (computed local-const loop array, as above) fires; BF103
+  // (imported child in the loop body) no longer does now that the
+  // conformance harness passes `siblingTemplatesRegistered: true` (#2205).
+  'static-array-from-props-with-component': [{ code: 'BF101', severity: 'error' }],
   // #2087 Phase B: every `.map()` destructure shape in the shared corpus
   // now lowers on Twig via a `{% set %}` local built from the binding's
   // structured `segments` path (`twigLoopBindingAccessor` in

--- a/packages/adapter-twig/src/conformance-pins.ts
+++ b/packages/adapter-twig/src/conformance-pins.ts
@@ -14,7 +14,9 @@ export const conformancePins: ConformancePins = {
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the
-  // BF103 loop-body cross-template check no longer fires spuriously.
+  // BF103 loop-body cross-template check no longer fires spuriously. (Both
+  // fixtures are still skipped on this adapter via `render-divergences.ts`
+  // — #2209 — for an unrelated signal-seeding gap.)
   // `static-array-children` similarly no longer hits BF103, but now hits a
   // DIFFERENT, pre-existing, orthogonal gap: `items` is a function-scope
   // local const whose array-literal initializer the adapter's loop-source

--- a/packages/adapter-twig/src/conformance-pins.ts
+++ b/packages/adapter-twig/src/conformance-pins.ts
@@ -21,7 +21,9 @@ export const conformancePins: ConformancePins = {
   // DIFFERENT, pre-existing, orthogonal gap: `items` is a function-scope
   // local const whose array-literal initializer the adapter's loop-source
   // gate refuses to bind (only string-derived locals resolve) — see #2208.
-  'static-array-children': [{ code: 'BF101', severity: 'error' }],
+  'static-array-children': [
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2208' },
+  ],
   // The `([emoji, users]) => …` array-destructure param itself now lowers
   // (#2087 Phase B — see the destructure comment below), but the loop
   // ARRAY is a function-scope computed const (`const entries =

--- a/packages/adapter-twig/src/render-divergences.ts
+++ b/packages/adapter-twig/src/render-divergences.ts
@@ -14,4 +14,13 @@
 
 import type { RenderDivergences } from '@barefootjs/jsx'
 
-export const renderDivergences: RenderDivergences = {}
+export const renderDivergences: RenderDivergences = {
+  // TodoApp seeds its `todos` signal from `(props.initialTodos ??
+  // []).map(t => ({ ...t, editing: false }))` — a compound expression this
+  // harness's signal-init seeding can't evaluate, so `todos` seeds empty
+  // and `<ul class="todo-list">` renders with no `<li>`s. Orthogonal to
+  // #2205 (sibling template registration, which these fixtures now
+  // compile cleanly under): a test-harness signal-seeding gap.
+  'todo-app': 'https://github.com/piconic-ai/barefootjs/issues/2209',
+  'todo-app-ssr': 'https://github.com/piconic-ai/barefootjs/issues/2209',
+}

--- a/packages/adapter-twig/src/test-render.ts
+++ b/packages/adapter-twig/src/test-render.ts
@@ -156,14 +156,14 @@ export async function renderTwigComponent(options: RenderOptions): Promise<strin
     }
   }
 
-  // Compile parent source. `siblingTemplatesRegistered: true` matches this
-  // harness's real behavior — every sibling child template is registered
+  // Compile parent source. `siblingTemplatesRegistered: Boolean(components)`
+  // matches this harness's real behavior — every sibling child template is registered
   // alongside the parent before rendering, so a loop-body cross-template
   // call resolves at render time (#2205).
   const result = compileJSX(source, 'component.tsx', {
     adapter,
     outputIR: true,
-    siblingTemplatesRegistered: true,
+    siblingTemplatesRegistered: Boolean(components),
   })
 
   const errors = result.errors.filter(e => e.severity === 'error')

--- a/packages/adapter-twig/src/test-render.ts
+++ b/packages/adapter-twig/src/test-render.ts
@@ -156,8 +156,15 @@ export async function renderTwigComponent(options: RenderOptions): Promise<strin
     }
   }
 
-  // Compile parent source.
-  const result = compileJSX(source, 'component.tsx', { adapter, outputIR: true })
+  // Compile parent source. `siblingTemplatesRegistered: true` matches this
+  // harness's real behavior — every sibling child template is registered
+  // alongside the parent before rendering, so a loop-body cross-template
+  // call resolves at render time (#2205).
+  const result = compileJSX(source, 'component.tsx', {
+    adapter,
+    outputIR: true,
+    siblingTemplatesRegistered: true,
+  })
 
   const errors = result.errors.filter(e => e.severity === 'error')
   if (errors.length > 0) {

--- a/packages/adapter-xslate/src/conformance-pins.ts
+++ b/packages/adapter-xslate/src/conformance-pins.ts
@@ -9,17 +9,15 @@
 import type { ConformancePins } from '@barefootjs/jsx'
 
 export const conformancePins: ConformancePins = {
-  // Sibling-imported child component in a loop body: emits a
-  // cross-template call needing separate registration. BF103 makes
-  // the requirement loud (same as mojo).
-  'static-array-children': [{ code: 'BF103', severity: 'error' }],
-  // TodoApp / TodoAppSSR import `TodoItem` from a sibling file and
-  // call it inside a keyed `.map`. With the standalone-filter fix in
-  // place these reach the SAME BF103 (imported child in `.map`) as
-  // mojo — NOT BF101 — confirming the `.filter(...)` chain itself now
-  // lowers and the only remaining gate is the imported-child one.
-  'todo-app': [{ code: 'BF103', severity: 'error' }],
-  'todo-app-ssr': [{ code: 'BF103', severity: 'error' }],
+  // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
+  // harness now passes `siblingTemplatesRegistered: true` for fixtures with
+  // sibling `components`, matching `bf build`'s real semantics, so the
+  // BF103 loop-body cross-template check no longer fires spuriously.
+  // `static-array-children` similarly no longer hits BF103, but now hits a
+  // DIFFERENT, pre-existing, orthogonal gap: `items` is a function-scope
+  // local const whose array-literal initializer the adapter's loop-source
+  // gate refuses to bind (only string-derived locals resolve) — see #2208.
+  'static-array-children': [{ code: 'BF101', severity: 'error' }],
   // `([emoji, users]) => ...` / `([id, t]) => ...` are plain array-index
   // (tuple) destructures, no rest — #2087 Phase B's `segments`-walking
   // accessor lowers both to `$__bf_item[0]` / `$__bf_item[1]` `: my` locals
@@ -32,12 +30,11 @@ export const conformancePins: ConformancePins = {
   // simply unreachable before because BF104 refused the destructure shape
   // first.
   'static-array-from-props': [{ code: 'BF101', severity: 'error' }],
-  // Both BF103 (sibling-imported `<Tag>` child component) and the BF101
-  // above fire; BF104 no longer does (see above).
-  'static-array-from-props-with-component': [
-    { code: 'BF103', severity: 'error' },
-    { code: 'BF101', severity: 'error' },
-  ],
+  // The BF101 above fires; BF104 no longer does (see above), and BF103
+  // (sibling-imported `<Tag>` child component in the loop body) no longer
+  // does either now that the conformance harness passes
+  // `siblingTemplatesRegistered: true` (#2205).
+  'static-array-from-props-with-component': [{ code: 'BF101', severity: 'error' }],
   // #1310 / #2087: rest destructure in .map() callback. All four shapes now
   // lower via #2087 Phase B's `segments`-walking accessor:
   //   - object-rest read via member access (`rest-destructure-object-in-map`):

--- a/packages/adapter-xslate/src/conformance-pins.ts
+++ b/packages/adapter-xslate/src/conformance-pins.ts
@@ -12,7 +12,9 @@ export const conformancePins: ConformancePins = {
   // `todo-app` / `todo-app-ssr` no longer pinned (#2205) — the conformance
   // harness now passes `siblingTemplatesRegistered: true` for fixtures with
   // sibling `components`, matching `bf build`'s real semantics, so the
-  // BF103 loop-body cross-template check no longer fires spuriously.
+  // BF103 loop-body cross-template check no longer fires spuriously. (Both
+  // fixtures are still skipped on this adapter via `render-divergences.ts`
+  // — #2209 — for an unrelated signal-seeding gap.)
   // `static-array-children` similarly no longer hits BF103, but now hits a
   // DIFFERENT, pre-existing, orthogonal gap: `items` is a function-scope
   // local const whose array-literal initializer the adapter's loop-source

--- a/packages/adapter-xslate/src/conformance-pins.ts
+++ b/packages/adapter-xslate/src/conformance-pins.ts
@@ -19,7 +19,9 @@ export const conformancePins: ConformancePins = {
   // DIFFERENT, pre-existing, orthogonal gap: `items` is a function-scope
   // local const whose array-literal initializer the adapter's loop-source
   // gate refuses to bind (only string-derived locals resolve) — see #2208.
-  'static-array-children': [{ code: 'BF101', severity: 'error' }],
+  'static-array-children': [
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2208' },
+  ],
   // `([emoji, users]) => ...` / `([id, t]) => ...` are plain array-index
   // (tuple) destructures, no rest — #2087 Phase B's `segments`-walking
   // accessor lowers both to `$__bf_item[0]` / `$__bf_item[1]` `: my` locals

--- a/packages/adapter-xslate/src/render-divergences.ts
+++ b/packages/adapter-xslate/src/render-divergences.ts
@@ -14,4 +14,13 @@
 
 import type { RenderDivergences } from '@barefootjs/jsx'
 
-export const renderDivergences: RenderDivergences = {}
+export const renderDivergences: RenderDivergences = {
+  // TodoApp seeds its `todos` signal from `(props.initialTodos ??
+  // []).map(t => ({ ...t, editing: false }))` — a compound expression this
+  // harness's signal-init seeding can't evaluate, so `todos` seeds empty
+  // and `<ul class="todo-list">` renders with no `<li>`s. Orthogonal to
+  // #2205 (sibling template registration, which these fixtures now
+  // compile cleanly under): a test-harness signal-seeding gap.
+  'todo-app': 'https://github.com/piconic-ai/barefootjs/issues/2209',
+  'todo-app-ssr': 'https://github.com/piconic-ai/barefootjs/issues/2209',
+}

--- a/packages/adapter-xslate/src/test-render.ts
+++ b/packages/adapter-xslate/src/test-render.ts
@@ -135,8 +135,15 @@ export async function renderXslateComponent(options: RenderOptions): Promise<str
     }
   }
 
-  // Compile parent source.
-  const result = compileJSX(source, 'component.tsx', { adapter, outputIR: true })
+  // Compile parent source. `siblingTemplatesRegistered: true` matches this
+  // harness's real behavior — every sibling child template is registered
+  // alongside the parent before rendering, so a loop-body cross-template
+  // call resolves at render time (#2205).
+  const result = compileJSX(source, 'component.tsx', {
+    adapter,
+    outputIR: true,
+    siblingTemplatesRegistered: true,
+  })
 
   const errors = result.errors.filter(e => e.severity === 'error')
   if (errors.length > 0) {

--- a/packages/adapter-xslate/src/test-render.ts
+++ b/packages/adapter-xslate/src/test-render.ts
@@ -135,14 +135,14 @@ export async function renderXslateComponent(options: RenderOptions): Promise<str
     }
   }
 
-  // Compile parent source. `siblingTemplatesRegistered: true` matches this
-  // harness's real behavior — every sibling child template is registered
+  // Compile parent source. `siblingTemplatesRegistered: Boolean(components)`
+  // matches this harness's real behavior — every sibling child template is registered
   // alongside the parent before rendering, so a loop-body cross-template
   // call resolves at render time (#2205).
   const result = compileJSX(source, 'component.tsx', {
     adapter,
     outputIR: true,
-    siblingTemplatesRegistered: true,
+    siblingTemplatesRegistered: Boolean(components),
   })
 
   const errors = result.errors.filter(e => e.severity === 'error')

--- a/packages/compat/src/__tests__/compat-engine.test.ts
+++ b/packages/compat/src/__tests__/compat-engine.test.ts
@@ -43,11 +43,19 @@ describe('compileForCompat', () => {
 
     const cell = buildCompatCell(errors, goTemplatePins)
     expect(cell.ok).toBe(false)
+    // `issues` is the UNION of every issue URL any BF101 pin carries on
+    // this adapter (buildCompatCell attributes by code, not by fixture —
+    // see its docstring) — #2038 (this shape, nested filter callback) and
+    // #2208 (a different BF101 shape, the static-array-children loop-source
+    // gate) both surface here even though this test only exercises #2038's.
     expect(cell.diagnostics).toEqual([
       {
         code: 'BF101',
         severity: 'error',
-        issues: ['https://github.com/piconic-ai/barefootjs/issues/2038'],
+        issues: [
+          'https://github.com/piconic-ai/barefootjs/issues/2038',
+          'https://github.com/piconic-ai/barefootjs/issues/2208',
+        ],
       },
     ])
   })

--- a/packages/compat/src/engine.ts
+++ b/packages/compat/src/engine.ts
@@ -31,8 +31,10 @@ export const COMPILE_THREW_CODE = 'COMPILE_THREW'
  *   Used by the `bun run compat` CLI against real ui/ components.
  * - `'conformance'` — mirrors `collectFixtureDiagnostics`
  *   (packages/adapter-tests/src/jsx-runner.ts) exactly: any `components`
- *   children are compiled first (each with `{ adapter, outputIR: true }`),
- *   then the entry with the same options, concatenating every error.
+ *   children are compiled first (each with `{ adapter, outputIR: true,
+ *   siblingTemplatesRegistered }`), then the entry with the same options,
+ *   concatenating every error. `siblingTemplatesRegistered` is true iff
+ *   `components` is present, matching `bf build`'s real semantics (#2205).
  *   Used by the pin-consistency test to replay the adapter conformance
  *   suite's own compile shape.
  *
@@ -52,13 +54,22 @@ export function compileForCompat(
   try {
     if (mode === 'conformance') {
       const all: CompilerError[] = []
+      const siblingTemplatesRegistered = Boolean(components)
       if (components) {
         for (const [filename, childSource] of Object.entries(components)) {
-          const childResult = compileJSX(childSource.trimStart(), filename, { adapter, outputIR: true })
+          const childResult = compileJSX(childSource.trimStart(), filename, {
+            adapter,
+            outputIR: true,
+            siblingTemplatesRegistered,
+          })
           all.push(...childResult.errors)
         }
       }
-      const result = compileJSX(source.trimStart(), filePath, { adapter, outputIR: true })
+      const result = compileJSX(source.trimStart(), filePath, {
+        adapter,
+        outputIR: true,
+        siblingTemplatesRegistered,
+      })
       all.push(...result.errors)
       return all
     }

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2051,48 +2051,72 @@
           "kind": "refusal",
           "codes": [
             "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2208"
           ]
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2208"
           ]
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2208"
           ]
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2208"
           ]
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2208"
           ]
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2208"
           ]
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2208"
           ]
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2208"
           ]
         }
       },

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2050,49 +2050,49 @@
         "blade": {
           "kind": "refusal",
           "codes": [
-            "BF103"
+            "BF101"
           ]
         },
         "erb": {
           "kind": "refusal",
           "codes": [
-            "BF103"
+            "BF101"
           ]
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
-            "BF103"
+            "BF101"
           ]
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
-            "BF103"
+            "BF101"
           ]
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
-            "BF103"
+            "BF101"
           ]
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
-            "BF103"
+            "BF101"
           ]
         },
         "twig": {
           "kind": "refusal",
           "codes": [
-            "BF103"
+            "BF101"
           ]
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
-            "BF103"
+            "BF101"
           ]
         }
       },
@@ -2159,15 +2159,13 @@
         "blade": {
           "kind": "refusal",
           "codes": [
-            "BF101",
-            "BF103"
+            "BF101"
           ]
         },
         "erb": {
           "kind": "refusal",
           "codes": [
-            "BF101",
-            "BF103"
+            "BF101"
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2087"
@@ -2176,15 +2174,13 @@
         "go-template": {
           "kind": "refusal",
           "codes": [
-            "BF101",
-            "BF103"
+            "BF101"
           ]
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
-            "BF101",
-            "BF103"
+            "BF101"
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2087"
@@ -2193,8 +2189,7 @@
         "minijinja": {
           "kind": "refusal",
           "codes": [
-            "BF101",
-            "BF103"
+            "BF101"
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2087"
@@ -2203,123 +2198,84 @@
         "mojolicious": {
           "kind": "refusal",
           "codes": [
-            "BF101",
-            "BF103"
+            "BF101"
           ]
         },
         "twig": {
           "kind": "refusal",
           "codes": [
-            "BF101",
-            "BF103"
+            "BF101"
           ]
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
-            "BF101",
-            "BF103"
+            "BF101"
           ]
         }
       },
       "todo-app": {
         "blade": {
-          "kind": "refusal",
-          "codes": [
-            "BF103"
-          ]
+          "kind": "render",
+          "reason": "https://github.com/piconic-ai/barefootjs/issues/2209"
         },
         "erb": {
-          "kind": "refusal",
-          "codes": [
-            "BF103"
-          ]
-        },
-        "go-template": {
-          "kind": "refusal",
-          "codes": [
-            "BF103"
-          ]
+          "kind": "render",
+          "reason": "https://github.com/piconic-ai/barefootjs/issues/2209"
         },
         "jinja": {
-          "kind": "refusal",
-          "codes": [
-            "BF103"
-          ]
+          "kind": "render",
+          "reason": "https://github.com/piconic-ai/barefootjs/issues/2209"
         },
         "minijinja": {
-          "kind": "refusal",
-          "codes": [
-            "BF103"
-          ]
+          "kind": "render",
+          "reason": "https://github.com/piconic-ai/barefootjs/issues/2209"
         },
         "mojolicious": {
-          "kind": "refusal",
-          "codes": [
-            "BF103"
-          ]
+          "kind": "render",
+          "reason": "https://github.com/piconic-ai/barefootjs/issues/2209"
         },
         "twig": {
-          "kind": "refusal",
-          "codes": [
-            "BF103"
-          ]
+          "kind": "render",
+          "reason": "https://github.com/piconic-ai/barefootjs/issues/2209"
         },
         "xslate": {
-          "kind": "refusal",
-          "codes": [
-            "BF103"
-          ]
+          "kind": "render",
+          "reason": "https://github.com/piconic-ai/barefootjs/issues/2209"
         }
       },
       "todo-app-ssr": {
         "blade": {
-          "kind": "refusal",
-          "codes": [
-            "BF103"
-          ]
+          "kind": "render",
+          "reason": "https://github.com/piconic-ai/barefootjs/issues/2209"
         },
         "erb": {
-          "kind": "refusal",
-          "codes": [
-            "BF103"
-          ]
+          "kind": "render",
+          "reason": "https://github.com/piconic-ai/barefootjs/issues/2209"
         },
         "go-template": {
-          "kind": "refusal",
-          "codes": [
-            "BF103"
-          ]
+          "kind": "render",
+          "reason": "https://github.com/piconic-ai/barefootjs/issues/2209"
         },
         "jinja": {
-          "kind": "refusal",
-          "codes": [
-            "BF103"
-          ]
+          "kind": "render",
+          "reason": "https://github.com/piconic-ai/barefootjs/issues/2209"
         },
         "minijinja": {
-          "kind": "refusal",
-          "codes": [
-            "BF103"
-          ]
+          "kind": "render",
+          "reason": "https://github.com/piconic-ai/barefootjs/issues/2209"
         },
         "mojolicious": {
-          "kind": "refusal",
-          "codes": [
-            "BF103"
-          ]
+          "kind": "render",
+          "reason": "https://github.com/piconic-ai/barefootjs/issues/2209"
         },
         "twig": {
-          "kind": "refusal",
-          "codes": [
-            "BF103"
-          ]
+          "kind": "render",
+          "reason": "https://github.com/piconic-ai/barefootjs/issues/2209"
         },
         "xslate": {
-          "kind": "refusal",
-          "codes": [
-            "BF103"
-          ]
+          "kind": "render",
+          "reason": "https://github.com/piconic-ai/barefootjs/issues/2209"
         }
       }
     }


### PR DESCRIPTION
Fixes #2205. First in a stack of 5 PRs resolving #2204's sub-issues.

## Problem

`collectFixtureDiagnostics` (`packages/adapter-tests/src/jsx-runner.ts`) and each of the 8 non-Hono adapters' `test-render.ts` never passed `siblingTemplatesRegistered: true` when compiling a fixture with sibling `components`. Real `bf build` usage (and `bun run compat`) always sets this flag — the CLI compiles a source directory onto one template instance, so a loop-body cross-template call (Go: `{{template "X" .}}` and each adapter's equivalent) resolves fine. The conformance harness never did, so `static-array-children`, `todo-app`, and `todo-app-ssr` spuriously refused with `BF103` on all 8 adapters.

## Fix

- `collectFixtureDiagnostics` now passes `siblingTemplatesRegistered: true` for both the parent and sibling child compiles when a fixture declares `components`.
- `packages/compat/src/engine.ts`'s `compileForCompat('conformance')` mode — a near-duplicate of `collectFixtureDiagnostics` used by `packages/compat`'s own consistency tests — got the identical fix (missed in the first pass, caught by CI's `render-divergences.test.ts`).
- Each adapter's `test-render.ts` now passes `siblingTemplatesRegistered: true` on its parent `compileJSX` call — matching what the harness's own rendering setup already does structurally (concatenating / registering every sibling template before executing).
- Removed the now-stale `BF103` `conformance-pins.ts` entries for the 3 fixtures across all 8 adapters.

## Fallout (pre-existing gaps this unmasked, now tracked separately)

Silencing the spurious `BF103` let these fixtures reach real compilation/render for the first time, surfacing two **pre-existing, orthogonal** gaps that were previously hidden behind the early `BF103` refusal:

1. **#2208** — `static-array-children` (and `static-array-from-props-with-component`) now hit a genuine `BF101`: a named local array-literal const can't bind as a loop source on any of the 8 adapters (only string-derived locals or module-scope consts can). Pinned as `BF101` instead of `BF103` in `conformance-pins.ts`.
2. **#2209** — `todo-app`/`todo-app-ssr` render incorrectly on **7 of the 8 adapters** (all but go-template's `todo-app` variant): their `test-render.ts` harness can't seed a signal initialized from `(props.initialTodos ?? []).map(t => ({ ...t, editing: false }))` (a compound expression their `evaluateSignalInit`-style regex evaluator can't parse), so `todos` seeds empty/nil. ERB crashes at render time; the rest silently render an empty list. Tracked via `render-divergences.ts` on `blade`, `erb`, `jinja`, `mojolicious`, `rust`, `twig`, `xslate` (both fixtures) and `go-template` (`todo-app-ssr` only — `todo-app`'s pre-hydration empty render is correct there).
   - Initial local-sandbox testing (no `go`/`php`/`perl` toolchains available) under-counted this gap to 3 adapters; CI's real toolchains revealed the true scope, and this PR + issue #2209 were updated accordingly.

## Testing

- `bun test packages/adapter-{go-template,blade,erb,jinja,rust,mojolicious,twig,xslate}/src/__tests__` — all green after `bun run build`.
- `bun test packages/compat/src/__tests__` — all green (95 pass).
- `bunx biome check` on all touched files — clean.
- Verified the 9-fixture "Carousel cross-adapter" failure in `adapter-tests` is a pre-existing, unrelated module-resolution issue (reproduces identically on `main` before this change).
- CI (which has the real `go`/`php`/`perl` toolchains) caught two gaps this sandbox couldn't: a missed `siblingTemplatesRegistered` propagation in `packages/compat/src/engine.ts`, and the true scope of #2209. Both fixed in follow-up commits on this PR.

## Review plan

Per the tracking issue's review workflow: Fable review first, fix-up, then GitHub Copilot review, then merge readiness.
