### PR TITLE
Fix #2163: exercise real JS `+` string concat in counter-buttons fixture

### DIFF
--- a/packages/adapter-tests/fixtures/counter-buttons.ts
+++ b/packages/adapter-tests/fixtures/counter-buttons.ts
@@ -45,15 +45,15 @@ export function Counter() {
 }
 `,
   components: {
-    // Class composition uses a template literal, NOT string `+`: every
-    // adapter has a dedicated template-literal concat lowering, whereas
-    // JS binary `+` currently lowers to the target language's numeric
-    // `+` — a PHP fatal on Twig/Blade at render time despite compiling
-    // clean (tracked separately, #2163). This fixture deliberately
-    // stays inside every adapter's supported envelope.
+    // Class composition uses JS binary `+` (not a template literal) —
+    // exercising #2163's fix: `isStringConcatBinary` detects the
+    // string-literal `'btn '` operand and lowers `+` to each target's
+    // string-concat operator (Twig `~`, Blade/PHP `.`) instead of its
+    // numeric `+`, which used to compile clean but fatal at PHP render
+    // time (`Unsupported operand types: string + string`).
     './button.tsx': `
 export function Button({ children, className = '', onClick }: { children?: unknown; className?: string; onClick?: () => void }) {
-  return <button className={\`btn \${className}\`} onClick={onClick}>{children}</button>
+  return <button className={'btn ' + className} onClick={onClick}>{children}</button>
 }
 `,
   },


### PR DESCRIPTION
Fixes #2163. Second in the #2204 sub-issue PR stack (stacked on #2210 / the #2205 fix).

## Finding

The compiler-side fix for #2163 (JS binary `+` with a string-typed operand lowering to Twig's `~` / Blade's `.` concat operator instead of the numeric `+` that fatals at PHP render time) **already landed on `main`** via PR #2176 (`isStringConcatBinary` / `isStringTypedOperand` in `packages/jsx/src/adapters/parsed-expr-emitter.ts`, consumed by both `packages/adapter-twig/src/adapter/expr/emitters.ts` and `packages/adapter-blade/src/adapter/expr/emitters.ts`).

However, the `counter-buttons` conformance fixture (`packages/adapter-tests/fixtures/counter-buttons.ts`) — the exact fixture the issue's own repro section names — still used the **template-literal workaround** (`` className={`btn ${className}`} ``) instead of the shape the issue actually reports (`className={'btn ' + className}`). So the fix, while present in the compiler, was never exercised end-to-end by this fixture.

## Change

Swap the workaround back to the real JS `+` shape the issue describes, per its own repro instructions ("Swap the template literal back to `'btn ' + className`... run the tests").

## Testing

- `bun test packages/adapter-tests/src/__tests__/render-contract.test.ts` — 6 pass.
- `bun test packages/adapter-twig/src/__tests__` (real PHP + Twig via `composer install`) — 518 pass, 0 fail.
- `bun test packages/adapter-blade/src/__tests__` (real PHP + Blade via `composer install`) — 518 pass, 0 fail.
- `bun test packages/{adapter-erb,adapter-jinja,adapter-rust}/src/__tests__ -t counter-buttons` — pass on real ruby/python/rust toolchains.
- go-template / mojolicious / xslate skip real rendering in this sandbox (missing `go`/`perl` toolchains) but compile clean.
- `bun run compat:lock` — no diff (fixture isn't part of the `ui/` component matrix).
- No changeset needed — `@barefootjs/adapter-tests` is a private, changeset-ignored package.

## Review plan

Fable review first, then GitHub Copilot review, per the #2204 stack's review workflow.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BVexA8EQoTekDDLJnNQBYM)_