### PR TITLE
perf: createSelector — O(changed) selection primitive (#2143 gap 5)

### DIFF
--- a/.changeset/create-selector-primitive.md
+++ b/.changeset/create-selector-primitive.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/client": patch
+"@barefootjs/jsx": patch
+"@barefootjs/adapter-hono": patch
+---
+
+Perf: new `createSelector(source, fn?)` primitive (SolidJS-compatible, #2143 gap 5) — an O(changed) selection accessor for `class={isSelected(row.id) ? ... : ...}` patterns. Each row's effect subscribes to its own key instead of the raw signal, so a selection change re-runs two effects (deselected + selected row) regardless of list size. The returned accessor is `Reactive<>`-branded, so the existing type-based reactivity analysis recognises `isSelected(row.id)` with no analyzer changes beyond registering the export and a `needsTypeBasedDetection` trigger for bare selector usage outside `.map()`. `@barefootjs/adapter-hono` gains the matching SSR client-shim stub.

--- a/benchmarks/apps/barefoot/components/Bench.tsx
+++ b/benchmarks/apps/barefoot/components/Bench.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { createSignal } from '@barefootjs/client'
+import { createSignal, createSelector } from '@barefootjs/client'
 
 // Row-data generator inlined from benchmarks/apps/shared/data.ts (krausest
 // js-framework-benchmark parity — same adjectives/colours/nouns, same
@@ -68,6 +68,7 @@ function buildData(count: number): RowData[] {
 function Bench() {
   const [rows, setRows] = createSignal<RowData[]>([])
   const [selected, setSelected] = createSignal<number>(0)
+  const isSelected = createSelector(selected)
 
   const run = () => {
     setSelected(0)
@@ -127,7 +128,7 @@ function Bench() {
       <table className="table">
         <tbody id="tbody">
           {rows().map(row => (
-            <tr key={row.id} className={selected() === row.id ? 'danger' : ''}>
+            <tr key={row.id} className={isSelected(row.id) ? 'danger' : ''}>
               <td className="col-md-1">{row.id}</td>
               <td className="col-md-4">
                 <a className="lbl" onClick={() => select(row.id)}>{row.label}</a>

--- a/packages/adapter-hono/src/client-shim.ts
+++ b/packages/adapter-hono/src/client-shim.ts
@@ -127,6 +127,12 @@ export function createSignal<T>(_initial?: T): never {
 export function createMemo<T>(_fn: () => T): never {
   return calledAtSSR('createMemo')
 }
+export function createSelector<T, U = T>(
+  _source: () => T,
+  _fn?: (key: U, value: T) => boolean,
+): never {
+  return calledAtSSR('createSelector')
+}
 export function createEffect(_fn: () => void): never {
   return calledAtSSR('createEffect')
 }

--- a/packages/client/__tests__/reactive.test.ts
+++ b/packages/client/__tests__/reactive.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test'
-import { createSignal, createMemo, createEffect, onCleanup, onMount, batch } from '../src/reactive'
+import { createSignal, createMemo, createSelector, createEffect, createRoot, onCleanup, onMount, batch, untrack } from '../src/reactive'
 
 describe('createSignal', () => {
   test('returns initial value', () => {
@@ -667,5 +667,132 @@ describe('batch', () => {
     expect(a()).toBe(10)
     expect(b()).toBe(20)
     expect(c()).toBe(30)
+  })
+})
+
+describe('createSelector', () => {
+  test('O(changed): only old-key and new-key subscribers re-run', () => {
+    const [selected, setSelected] = createSignal(1)
+    const isSelected = createSelector(selected)
+    const runs: Record<number, number> = {}
+    const seen: Record<number, boolean> = {}
+    for (const id of [1, 2, 3, 4, 5]) {
+      createEffect(() => {
+        runs[id] = (runs[id] ?? 0) + 1
+        seen[id] = isSelected(id)
+      })
+    }
+    expect(seen).toEqual({ 1: true, 2: false, 3: false, 4: false, 5: false })
+    expect(runs).toEqual({ 1: 1, 2: 1, 3: 1, 4: 1, 5: 1 })
+
+    setSelected(3)
+    // Only key 1 (deselected) and key 3 (selected) re-ran.
+    expect(runs).toEqual({ 1: 2, 2: 1, 3: 2, 4: 1, 5: 1 })
+    expect(seen).toEqual({ 1: false, 2: false, 3: true, 4: false, 5: false })
+
+    setSelected(3) // no-op write: signal bails, nothing runs
+    expect(runs).toEqual({ 1: 2, 2: 1, 3: 2, 4: 1, 5: 1 })
+  })
+
+  test('batched writes dispatch once through PendingEffects', () => {
+    const [selected, setSelected] = createSignal(0)
+    const isSelected = createSelector(selected)
+    let runsA = 0
+    createEffect(() => { runsA++; isSelected(1) })
+    batch(() => {
+      setSelected(1)
+      setSelected(2)
+      setSelected(1)
+    })
+    // initial + one flush (1 was false before batch, true after — flipped once)
+    expect(runsA).toBe(2)
+  })
+
+  test('disposal prunes subscription (no leak, no dispatch to disposed)', () => {
+    const [selected, setSelected] = createSignal(0)
+    const isSelected = createSelector(selected)
+    let runs = 0
+    let dispose!: () => void
+    createRoot(d => {
+      dispose = d
+      createEffect(() => { runs++; isSelected(7) })
+    })
+    expect(runs).toBe(1)
+    dispose()
+    setSelected(7)
+    expect(runs).toBe(1)
+  })
+
+  test('re-run that stops reading a key unsubscribes it', () => {
+    const [selected, setSelected] = createSignal(0)
+    const [mode, setMode] = createSignal<'a' | 'b'>('a')
+    const isSelected = createSelector(selected)
+    let runs = 0
+    createEffect(() => {
+      runs++
+      if (mode() === 'a') isSelected(1)
+    })
+    expect(runs).toBe(1)
+    setMode('b')     // re-run, no longer reads key 1
+    expect(runs).toBe(2)
+    setSelected(1)   // key 1 flipped — but nobody subscribes anymore
+    expect(runs).toBe(2)
+  })
+
+  test('custom comparator (range selection)', () => {
+    const [range, setRange] = createSignal<[number, number]>([1, 3])
+    const inRange = createSelector<[number, number], number>(range, (k, [lo, hi]) => k >= lo && k <= hi)
+    const runs: Record<number, number> = {}
+    const seen: Record<number, boolean> = {}
+    for (const id of [1, 2, 3, 4, 5]) {
+      createEffect(() => { runs[id] = (runs[id] ?? 0) + 1; seen[id] = inRange(id) })
+    }
+    expect(seen).toEqual({ 1: true, 2: true, 3: true, 4: false, 5: false })
+    setRange([3, 4])
+    // flipped: 1,2 (out), 4 (in). 3 and 5 unchanged.
+    expect(runs).toEqual({ 1: 2, 2: 2, 3: 1, 4: 2, 5: 1 })
+  })
+
+  test('untracked read does not subscribe', () => {
+    const [selected, setSelected] = createSignal(0)
+    const isSelected = createSelector(selected)
+    let runs = 0
+    createEffect(() => { runs++; untrack(() => isSelected(9)) })
+    setSelected(9)
+    expect(runs).toBe(1)
+  })
+
+  test('re-run that switches keys is only subscribed to its most recent key', () => {
+    const [selected, setSelected] = createSignal(0)
+    const [key, setKey] = createSignal(1)
+    const isSelected = createSelector(selected)
+    let runs = 0
+    createEffect(() => { runs++; isSelected(key()) })
+    expect(runs).toBe(1)
+    setKey(2)        // re-run reads key 2 — cleanup must drop the key-1 subscription
+    expect(runs).toBe(2)
+    setSelected(1)   // flips key 1 only: nobody subscribed anymore
+    expect(runs).toBe(2)
+    setSelected(2)   // flips key 2: the effect's current subscription fires
+    expect(runs).toBe(3)
+  })
+
+  test('subscriber disposing another subscriber mid-dispatch is safe (collect-then-run)', () => {
+    // A custom comparator can flip several keys in one sweep. The first
+    // dispatched subscriber disposes the second — the `toRun` Set snapshot
+    // must tolerate that (runEffect's disposed guard), same as signal.set()'s
+    // subscriber-snapshot dispatch.
+    const [range, setRange] = createSignal<[number, number]>([0, 0])
+    const inRange = createSelector<[number, number], number>(range, (k, [lo, hi]) => k >= lo && k <= hi)
+    let disposeOther!: () => void
+    let runs1 = 0
+    let runs2 = 0
+    createRoot(d => { disposeOther = d; createEffect(() => { runs2++; inRange(2) }) })
+    createEffect(() => { runs1++; inRange(1); if (runs1 > 1) disposeOther() })
+    setRange([1, 2]) // flips keys 1 AND 2; subscriber 1 disposes subscriber 2 mid-sweep
+    expect(runs1).toBe(2)
+    setRange([0, 0]) // flips both again; the disposed subscriber must stay dead
+    expect(runs2).toBeLessThanOrEqual(2)
+    expect(runs1).toBe(3)
   })
 })

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -6,6 +6,7 @@ export {
   createEffect,
   createDisposableEffect,
   createMemo,
+  createSelector,
   createRoot,
   onCleanup,
   onMount,

--- a/packages/client/src/reactive.ts
+++ b/packages/client/src/reactive.ts
@@ -734,6 +734,86 @@ export function createMemo<T>(fn: () => T, __bfId?: string): Memo<T> {
   return value
 }
 
+/**
+ * O(changed) selection primitive (SolidJS-compatible `createSelector`).
+ *
+ * `class={selected() === row.id ? 'danger' : ''}` subscribes every row to the
+ * one `selected` signal — O(rows) effect runs per selection change. The
+ * selector inverts the fan-out: each row's effect subscribes to its OWN key,
+ * and an internal effect tracking `source()` dispatches only the keys whose
+ * `fn(key, value)` result actually flipped — two effect runs per selection
+ * change (deselected row + selected row) regardless of list size.
+ *
+ * The returned accessor is `Reactive<>`-branded, so the compiler's
+ * type-based reactivity analysis recognises `isSelected(row.id)` as a
+ * reactive expression exactly like a signal/memo read.
+ *
+ * @example
+ * const [selected, setSelected] = createSignal<number>(0)
+ * const isSelected = createSelector(selected)
+ * // inside a loop body:
+ * //   <tr class={isSelected(row.id) ? 'danger' : ''}>
+ */
+export function createSelector<T, U = T>(
+  source: () => T,
+  fn: (key: U, value: T) => boolean = ((key: U, value: T) => (key as unknown) === (value as unknown)) as (key: U, value: T) => boolean,
+): Reactive<(key: U) => boolean> {
+  // Per-key subscriber sets, created lazily on first tracked read of a key
+  // and self-pruned to empty via onCleanup — keys from replaced list items
+  // (e.g. clear + recreate cycles) don't accumulate.
+  const subs = new Map<U, Set<EffectContext>>()
+  let value: T
+
+  createEffect(() => {
+    const newValue = source()
+    const oldValue = value
+    value = newValue
+    // Collect-then-run: a re-running subscriber unsubscribes and immediately
+    // re-subscribes its key (onCleanup below), which deletes and re-inserts
+    // Map entries. A live Map iterator REVISITS a key deleted and re-added
+    // during iteration, so dispatching inline would re-flip the same key
+    // forever. Finish the sweep over `subs` first, then dispatch — this also
+    // gives the same fixed-at-dispatch-time semantics as a signal write's
+    // subscriber snapshot. The Set dedupes an effect subscribed to several
+    // flipped keys (possible with a custom `fn`), matching PendingEffects.
+    let toRun: Set<EffectContext> | null = null
+    for (const [key, keySubs] of subs) {
+      if (fn(key, newValue) !== fn(key, oldValue)) {
+        if (BatchDepth > 0) {
+          for (const effect of keySubs) PendingEffects.add(effect)
+        } else {
+          if (!toRun) toRun = new Set()
+          for (const effect of keySubs) toRun.add(effect)
+        }
+      }
+    }
+    if (toRun) {
+      for (const effect of toRun) runEffect(effect)
+    }
+  })
+
+  const selector = (key: U): boolean => {
+    const listener = Listener
+    if (listener) {
+      let keySubs = subs.get(key)
+      if (!keySubs) {
+        keySubs = new Set()
+        subs.set(key, keySubs)
+      }
+      keySubs.add(listener)
+      // Runs on both re-run and disposal of the subscribing effect; a re-run
+      // that still reads this key immediately re-subscribes.
+      onCleanup(() => {
+        keySubs.delete(listener)
+        if (keySubs.size === 0) subs.delete(key)
+      })
+    }
+    return fn(key, value)
+  }
+
+  return selector as Reactive<(key: U) => boolean>
+}
+
 
 // ---------------------------------------------------------------------------
 // Request-scoped environment signals (router v0.5, spec/router.md "The wedge")

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -13,6 +13,7 @@ export {
   createEffect,
   createDisposableEffect,
   createMemo,
+  createSelector,
   createRoot,
   onCleanup,
   onMount,

--- a/packages/jsx/src/__tests__/create-selector.test.ts
+++ b/packages/jsx/src/__tests__/create-selector.test.ts
@@ -1,0 +1,110 @@
+/**
+ * `createSelector` compiler recognition (perf, #2143 gap 5).
+ *
+ * `createSelector`'s returned accessor is `Reactive<(key) => boolean>`
+ * branded exactly like a signal/memo getter, so the existing type-based
+ * reactivity analyzer (`reactivity-checker.ts`) recognises a call like
+ * `isSelected(row.id)` as reactive with no analyzer changes — the callee's
+ * type carries the brand, not the call's return type. These tests pin:
+ *   - the classic js-framework-benchmark row compiles with `isSelected(row.id)`
+ *     wired to a single per-row `createEffect` (not the legacy
+ *     `selected() === row.id` shape, which would still work but subscribes
+ *     every row to the raw signal)
+ *   - the loop-param accessor wrap applies only to the call ARGUMENT
+ *     (`row.id` -> `row().id`), leaving the `isSelected` callee untouched
+ *   - the hoisted skeleton fast path (#2223) still fires for a selector-driven
+ *     attr, since it's covered by a loop-child reactive-attr effect like any
+ *     other dynamic attribute
+ *   - `createSelector` is pulled into the runtime import line
+ *   - the attr is auto-deferred out of the SSR-mirror `template:` lambda
+ *     (mechanism #1638, same as `@barefootjs/form` accessors) — pinned as
+ *     documented behavior, not a regression: full SSR parity for selector
+ *     calls is a known follow-up, not in scope here
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function compile(source: string, filename: string): { clientJs: string; template: string; errors: readonly { severity: string }[] } {
+  const result = compileJSX(source, filename, { adapter })
+  const clientJs = result.files.find(f => f.type === 'clientJs')
+  const template = result.files.find(f => f.type === 'markedTemplate')
+  return { clientJs: clientJs?.content ?? '', template: template?.content ?? '', errors: result.errors }
+}
+
+describe('createSelector (perf, #2143 gap 5)', () => {
+  test('isSelected(row.id) in a loop body compiles to one per-row createEffect', () => {
+    const source = `
+      'use client'
+      import { createSignal, createSelector } from '@barefootjs/client'
+
+      interface RowData { id: number; label: string }
+
+      export function Bench() {
+        const [rows, setRows] = createSignal<RowData[]>([])
+        const [selected, setSelected] = createSignal<number>(0)
+        const isSelected = createSelector(selected)
+        return (
+          <table>
+            <tbody>
+              {rows().map(row => (
+                <tr key={row.id} className={isSelected(row.id) ? 'danger' : ''}></tr>
+              ))}
+            </tbody>
+          </table>
+        )
+      }
+    `
+    const { clientJs, errors } = compile(source, 'Bench.tsx')
+    expect(errors.filter(e => e.severity === 'error')).toHaveLength(0)
+
+    // Loop-param wrap applies to the call ARGUMENT only.
+    expect(clientJs).toContain('isSelected(row().id)')
+    // The callee itself is never rewritten to an accessor call.
+    expect(clientJs).not.toContain('isSelected()(')
+
+    // Exactly one createEffect wraps the selector-driven class attribute —
+    // not the O(rows) `selected() === row.id` shape.
+    const effectCount = (clientJs.match(/createEffect\(/g) ?? []).length
+    expect(effectCount).toBe(1)
+    expect(clientJs).not.toContain('selected() ===')
+
+    // The hoisted skeleton fast path (#2223) still fires: a single-line
+    // renderItem clones from a once-per-loop template.
+    expect(clientJs).toMatch(/const __tpl_\w+ = document\.createElement\('template'\)/)
+
+    // createSelector is pulled into the runtime import line.
+    expect(clientJs).toMatch(/import \{[^}]*\bcreateSelector\b[^}]*\} from '@barefootjs\/client\/runtime'/)
+  })
+
+  test('selector-driven attr is deferred out of the SSR-mirror template lambda (documented, not a regression)', () => {
+    const source = `
+      'use client'
+      import { createSignal, createSelector } from '@barefootjs/client'
+
+      interface RowData { id: number; label: string }
+
+      export function Bench() {
+        const [rows, setRows] = createSignal<RowData[]>([])
+        const [selected, setSelected] = createSignal<number>(0)
+        const isSelected = createSelector(selected)
+        return (
+          <ul>
+            {rows().map(row => (
+              <li key={row.id} className={isSelected(row.id) ? 'danger' : ''}>{row.label}</li>
+            ))}
+          </ul>
+        )
+      }
+    `
+    const { clientJs } = compile(source, 'BenchDefer.tsx')
+    const csrMirror = clientJs.slice(clientJs.indexOf('hydrate('))
+    // The class attribute never appears as a literal `class="..."` write in
+    // the SSR-mirror template string — it's covered entirely by the
+    // per-row createEffect, matching the documented auto-defer mechanism.
+    expect(csrMirror).not.toMatch(/class="danger"/)
+  })
+})

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -50,6 +50,11 @@ export function needsTypeBasedDetection(source: string): boolean {
   if (REACTIVE_BRAND_PACKAGES.some(pkg => source.includes(pkg))) return true
   // BF023/BF024 nullable-key check needs getTypeAtLocation() on the key expression.
   if (/\.map\s*\(/.test(source)) return true
+  // createSelector's returned accessor is Reactive<>-branded like a library
+  // accessor above — a selector call outside any `.map()` (no loop in the
+  // file at all) would otherwise skip the TypeChecker entirely and miss the
+  // brand.
+  if (source.includes('createSelector')) return true
   return false
 }
 
@@ -1828,6 +1833,7 @@ function collectLocalDeclarations(root: ts.Node): Set<string> {
 // and are emitted by the compiler for 'use client' components.
 const CLIENT_EXPORTS = new Set([
   'createSignal', 'createEffect', 'createDisposableEffect', 'createMemo',
+  'createSelector',
   'createRoot', 'onCleanup', 'onMount', 'untrack', 'batch', 'splitProps',
   'forwardProps', 'unwrap', '__slot',
   'createContext', 'useContext', 'provideContext',


### PR DESCRIPTION
## Summary

Addresses gap #5 of #2143 ("Selection fan-out pattern"): the idiomatic `class={selected() === row.id ? 'danger' : ''}` pattern subscribes **every** row to the raw `selected` signal — an O(rows) effect fan-out per selection change. This adds a SolidJS-compatible `createSelector(source, fn?)` primitive that inverts the fan-out to O(changed).

- `packages/client/src/reactive.ts`: `createSelector` — each row's effect subscribes to its **own key** (via the returned accessor), and an internal effect tracking `source()` dispatches only the keys whose `fn(key, value)` result actually flipped (two effects per selection change — deselected + selected row — regardless of list size). Dispatch is **collect-then-run**: the affected `EffectContext`s are gathered across the whole `subs` map first, then run — dispatching inline during the sweep would livelock, since a re-running subscriber's `onCleanup`/resubscribe mutates the same `Map` a live iterator is walking. Per-key subscriber sets self-prune to zero via `onCleanup`, so replaced list items (clear + recreate cycles) don't leak.
- The returned accessor is `Reactive<(key) => boolean>`-branded exactly like a signal/memo getter, so the compiler's existing type-based reactivity analyzer (`reactivity-checker.ts`) recognizes `isSelected(row.id)` as reactive with **zero changes to the analyzer's core logic** — confirmed by compiling real fixtures end to end (loop-param wrap applies only to the call argument, the hoisted-skeleton fast path from #2223 still fires, SSR auto-defers the attr via the existing #1638 mechanism). Two small additions were still needed: `createSelector` registered in `CLIENT_EXPORTS` (`analyzer.ts`) and a `needsTypeBasedDetection` trigger for selector usage outside any `.map()` (the existing `.map()` trigger already covers the common in-loop case).
- `packages/adapter-hono/src/client-shim.ts`: matching throwing stub, mirroring `createMemo`'s convention.
- `benchmarks/apps/barefoot/components/Bench.tsx`: now uses `createSelector` for its `select` op, mirroring `benchmarks/apps/solid/src/main.tsx` — the only pipeline-verified perf evidence, matching how gap #1 (#2223) was measured. `benchmarks/ssr/apps/barefoot`'s SSR bench app is **deliberately left on the old pattern** — SSR auto-defer would break its output-parity assertions.

Planning, correctness verification, and code review were done by an independent model pass (Fable) per this repo's convention, including hands-on verification (compiling real fixtures, running real test suites) rather than just reading code — it found and fixed a real infinite-loop bug in an earlier draft (dispatching inline during the `subs` map sweep), added two test cases (key-switch across re-runs, disposal during dispatch), and added the changeset.

## Why the O(changed) claim isn't primarily a wall-clock number

At 1,000 rows both O(rows) and O(1) dispatch are fast enough to be noise-dominated (the issue itself notes `select` was already "fine" at 1.1–1.3x vanilla). The real evidence is the **dispatch-count assertions** in `packages/client/__tests__/reactive.test.ts` — e.g. selecting row 3 after row 1 (out of 5 subscribed rows) re-runs exactly 2 effects, not 5; a custom range-comparator test flips exactly the keys whose membership changed. This is a stronger, more direct proof of the asymptotic-scaling claim than a millisecond timing at a fixed, small N.

## Benchmarks

- `bun benchmarks/apps/barefoot/smoke.ts`: 15/15 pass (including selection: exactly one `tr.danger`, correct row).
- `bun benchmarks/runner/bench-dom.ts` (full run): `select` 1.12x vanilla / 1.04x Solid — consistent with the pre-existing baseline, no regression.
- SSR and reactive-primitive benchmarks unaffected (out of scope for this gap).

## Test plan

- [x] `packages/client/__tests__/reactive.test.ts` — new `createSelector` describe block: O(changed) dispatch counts, batched-write dedup, disposal pruning, key-switch-across-re-runs, custom comparator, untracked reads, disposal during dispatch (53 tests in file, 0 fail)
- [x] `packages/jsx/src/__tests__/create-selector.test.ts` — pins the compiled codegen shape (loop-param wrap on the argument only, single per-row `createEffect`, hoisted-skeleton fast path still fires, SSR-mirror auto-defer)
- [x] `bun test packages/client packages/jsx packages/adapter-hono packages/adapter-tests` — all green except a **pre-existing, order-dependent failure** in `packages/adapter-hono/src/__tests__/request-env.test.tsx` (9 tests) — confirmed unrelated to this change by reproducing the identical failure on a pristine `origin/main` worktree with the same combined test-file set, before committing
- [x] Independent correctness review (Fable), hands-on: compiled fixtures, ran suites, added 2 test cases + the changeset

Closes gap #5 of #2143. Gaps #2 (reactive-primitive micro-deltas), #3 (SSR payload size), and #4 (shipped-JS last mile) remain open follow-ups on that issue.


---
_Generated by [Claude Code](https://claude.ai/code/session_01T6otrszJytVCcByL1epezB)_