### PR TITLE
Fix static nested-loop index param ReferenceError in child-component props (#2231)

### DIFF
--- a/.changeset/static-inner-loop-index-param.md
+++ b/.changeset/static-inner-loop-index-param.md
@@ -1,0 +1,11 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix #2231: a FULLY-STATIC (module-const array, not a signal or a prop) nested loop's inner `.map((sub, i) => ...)` index param, referenced in a child-component prop, no longer throws `ReferenceError: i is not defined` at hydration.
+
+Follow-up to #2218 (PR #2230), which fixed the reactive (`mapArray`) and branch-arm paths via `loopKeyFn` + the renderItem alias — this family never goes through either, so it needed its own fix. The `inner-loop-nested` shape (`build-static-array-child-init.ts`) hardcoded the synthetic `__innerIdx` as the inner `forEach`'s second param, so a declared-and-referenced index name like `i` compiled to `get label() { return i }` with `i` unbound — `initChild`'s first read of that prop getter threw at hydration. `component-rooted-inner-loop` (#1725) declared no index params at all, leaving both outer and inner index names unbound the same way.
+
+The fix emits the user's declared index name directly as the `forEach`'s second param — the same idiom the outer loop has always used (`elem.index || '__idx'`) — instead of a synthetic placeholder. No alias binding is needed: `forEach` supplies the real array index positionally.
+
+Byte stability: loops that declare no index param keep byte-for-byte identical output (`__innerIdx` fallback for `inner-loop-nested`, bare single-param `forEach` heads for `component-rooted-inner-loop`). `inner-loop-nested` loops that DO declare an index see the `forEach` param renamed from `__innerIdx` to the user's name, and the child-offset expression (`__ic.children[...]`) follows it — a behavior-neutral rename, not a semantic change.

--- a/packages/client/__tests__/runtime/static-inner-loop-index-param-e2e.test.ts
+++ b/packages/client/__tests__/runtime/static-inner-loop-index-param-e2e.test.ts
@@ -1,0 +1,183 @@
+/**
+ * End-to-end runtime test for #2231: a FULLY-STATIC (module-const array,
+ * not a signal or a prop) nested loop's inner `.map((sub, i) => ...)` index
+ * param, referenced in a CHILD COMPONENT's prop, used to throw
+ * `ReferenceError: i is not defined` at hydration time.
+ *
+ * Follow-up to #2218 (fixed the reactive `mapArray` / branch-arm paths via
+ * `loopKeyFn` + the renderItem alias) — this covers the *static-array*
+ * child-init family (`plan/build-static-array-child-init.ts` /
+ * `stringify/static-array-child-init.ts`), which #2218 never reached because
+ * fully-static loops don't go through `mapArray` at all: the outer/inner
+ * `forEach` bodies here only call `initChild(name, el, props)` to wire up
+ * already-rendered child-component scopes.
+ *
+ * Root cause: the `inner-loop-nested` shape hardcoded the synthetic
+ * `__innerIdx` as the inner `forEach`'s second param, so a user-declared
+ * index name like `i` was never bound — `initChild`'s `get label() { return
+ * String(i) }` prop getter threw `ReferenceError: i is not defined` the
+ * first time the runtime's `createEffect` read it.
+ *
+ * Harness notes (see `initChild`'s selector — `buildCompSelector` in
+ * `packages/jsx/src/ir-to-client-js/control-flow/shared.ts`): the
+ * `[bf-h="…"][bf-m="…"]` / `[bf-s$="_s…"]` selectors this code path
+ * searches for are only produced by REAL server-rendered markup — the
+ * `renderChild(...)` helper used by the CSR *materialize* template (as
+ * exercised by `static-loop-csr-materialize.test.ts` / the plain
+ * `createComponent(name, {})` pattern in `nested-loop-index-param-e2e.test.ts`)
+ * stamps a random per-call scope id when called without a `slotSuffix`
+ * (`component.ts` `renderChild`), which this family's compiled forEach
+ * calls never pass. A `createComponent`-only mount was tried first and
+ * does NOT reach `initChild` for this shape (`qsaChildScope` finds no
+ * match, so the getter is never invoked, and the pre-fix build passes
+ * silently — a false negative). So, like `issue-1725-hydration.test.ts`
+ * (the sibling #1725 fix for this same family), this test renders REAL
+ * SSR HTML via the Hono adapter — which stamps parent-anchored `bf-s`
+ * values matching the selector — then runs the real `hydrate` walk so
+ * `initChild`'s prop-getter closures actually execute.
+ */
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import { compileJSX } from '../../../jsx/src/compiler'
+import { TestAdapter } from '../../../jsx/src/adapters/test-adapter'
+import { renderHonoComponent } from '../../../adapter-hono/src/test-render'
+import { HonoAdapter } from '../../../adapter-hono/src/adapter/hono-adapter'
+import { writeFileSync, mkdtempSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') GlobalRegistrator.register()
+})
+
+const adapter = new TestAdapter()
+const runtimePath = join(__dirname, '../../src/runtime/index.ts')
+
+const CELL = `'use client'
+export function Cell(props: { label: string }) {
+  return <span>{props.label}</span>
+}`
+
+function reproSource(): string {
+  // The inner `.map()` sits inside a `<div class="subs">` wrapper rather
+  // than directly in the group item root. This isn't cosmetic: with the
+  // inner loop hanging directly off the group root, that root's own
+  // reactive-attribute slot id happens to collide with `Cell`'s
+  // independently-numbered template-root slot id, so
+  // `__outerEl.querySelector('[bf="s1"]')` — the inner-container lookup —
+  // matches the group root's own child span instead of an inner-loop
+  // container, `__ic.children[i]` comes back empty, and `initChild` is
+  // never reached at all (a false negative, not a #2231 pin). The wrapper
+  // gives the inner loop its own container slot id, distinct from any
+  // child component's internal slot numbering, so `initChild('Cell', …)`
+  // — and the broken `get label() { return String(i) }` getter — actually
+  // runs.
+  return `'use client'
+import { Cell } from './Cell'
+const OUTER = [
+  { id: 1, subs: [{ id: 11 }, { id: 12 }] },
+  { id: 2, subs: [{ id: 21 }] },
+]
+export function Repro() {
+  return (
+    <div>
+      {OUTER.map((o) => (
+        <div key={o.id} data-group={o.id}>
+          <div class="subs">
+            {o.subs.map((sub, i) => (
+              <Cell key={sub.id} label={String(i)} />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}`
+}
+
+/** Compile a component's client JS with imports re-anchored to the live runtime. */
+function clientJsFor(source: string, filename: string): string {
+  const result = compileJSX(source, filename, { adapter })
+  const errors = result.errors.filter(e => e.severity === 'error')
+  if (errors.length > 0) {
+    throw new Error(`Compile errors in ${filename}:\n${errors.map(e => `${e.code}: ${e.message}`).join('\n')}`)
+  }
+  const clientJs = result.files.find(f => f.type === 'clientJs')?.content
+  if (!clientJs) throw new Error(`No client JS for ${filename}`)
+  return clientJs
+    .replace(/from\s+['"]@barefootjs\/client\/runtime['"]/g, `from '${runtimePath}'`)
+    .replace(/^import '\/\* @bf-child:\w+ \*\/'\n/gm, '')
+}
+
+async function setupHydration(): Promise<{ hydrate: () => void }> {
+  // Register Cell + Repro defs (template + init) with the runtime. Each
+  // module is imported separately so their (overlapping) runtime import
+  // lines don't collide in one module scope.
+  const dir = mkdtempSync(join(tmpdir(), 'bf-2231-'))
+  const modules: Array<[string, string, string]> = [
+    [CELL, 'Cell.tsx', 'Cell'],
+    [reproSource(), 'Repro.tsx', 'Repro'],
+  ]
+  for (const [source, filename, name] of modules) {
+    const file = join(dir, `${name}.mjs`)
+    writeFileSync(file, clientJsFor(source, filename))
+    await import(file)
+  }
+
+  // Real SSR HTML (Hono adapter) — same markup a server would send, with
+  // deterministic parent-anchored `bf-s` values on the `Cell` scopes that
+  // `initChild`'s selector can actually find.
+  const ssrHtml = await renderHonoComponent({
+    adapter: new HonoAdapter(),
+    source: reproSource(),
+    components: { './Cell.tsx': CELL },
+    // Root scope must carry a `Name_` prefix so the hydration walk resolves
+    // it to the registered `Repro` def (`scopeName` splits on the first `_`).
+    props: { __instanceId: 'Repro_test' },
+  })
+  document.body.innerHTML = ssrHtml
+
+  // The `hydrate()` calls during module import already scheduled (and,
+  // after the awaits, drained) a walk against the then-empty body.
+  // Re-trigger a walk now that the SSR markup is in place, then drain it
+  // synchronously — this is where `initChild('Cell', …)` runs for real and,
+  // pre-fix, is where `ReferenceError: i is not defined` throws.
+  const { rehydrateAll, flushHydration } = await import(runtimePath)
+  return {
+    hydrate: () => {
+      rehydrateAll()
+      flushHydration()
+    },
+  }
+}
+
+describe('#2231 — static nested-loop index param referenced in a child-component prop', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('hydration does not throw, and the inner index renders per-group Cell labels', async () => {
+    const { hydrate } = await setupHydration()
+
+    // Pre-fix, this call threw synchronously: `initChild`'s
+    // `get label() { return String(i) }` closure read an unbound `i` the
+    // first time `createEffect` evaluated it. This is the pin — it fails
+    // with `ReferenceError: i is not defined` without the compiler fix.
+    expect(() => hydrate()).not.toThrow()
+
+    const group1 = document.querySelector('[data-group="1"]')
+    const group2 = document.querySelector('[data-group="2"]')
+    expect(group1).not.toBeNull()
+    expect(group2).not.toBeNull()
+
+    const group1Labels = Array.from(group1!.querySelectorAll('span')).map(s => s.textContent)
+    const group2Labels = Array.from(group2!.querySelectorAll('span')).map(s => s.textContent)
+
+    // Group 1 has two subs -> inner index resets to 0 for each outer item.
+    expect(group1Labels).toEqual(['0', '1'])
+    // Group 2 has one sub -> index also starts fresh at 0 (not a running
+    // total across groups), proving the bound `i` is the real forEach index
+    // and not some other unrelated in-scope value.
+    expect(group2Labels).toEqual(['0'])
+  })
+})

--- a/packages/jsx/src/__tests__/static-array-inner-loop-index-param.test.ts
+++ b/packages/jsx/src/__tests__/static-array-inner-loop-index-param.test.ts
@@ -1,0 +1,180 @@
+/**
+ * A FULLY-STATIC nested loop's inner `.map((item, i) => ...)` index param
+ * referenced in a child-component prop (#2231). Follow-up to #2218, which
+ * fixed the reactive (`mapArray`) and branch-arm paths — this covers the
+ * static-array child-init family (`plan/build-static-array-child-init.ts` /
+ * `stringify/static-array-child-init.ts`), which those fixes didn't reach
+ * because it never goes through `loopKeyFn` or the renderItem alias.
+ *
+ * Root cause: the `inner-loop-nested` shape hardcoded the synthetic
+ * `__innerIdx` as the inner `forEach`'s index param, and the
+ * `component-rooted-inner-loop` shape (#1725) declared no index params at
+ * all — so a prop getter like `get label() { return i }` threw
+ * `ReferenceError: i is not defined` on `initChild`'s first prop read at
+ * hydration.
+ *
+ * Fix: emit the user's declared index name directly as the `forEach` index
+ * param — the same idiom the outer loop has always used (`elem.index ||
+ * '__idx'`). No alias binding is needed because `forEach` supplies the real
+ * array index positionally. Loops that declare no index keep byte-identical
+ * output (`__innerIdx` fallback for `inner-loop-nested`, bare single-param
+ * heads for `component-rooted-inner-loop`).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function clientJsFor(source: string): string {
+  const result = compileJSX(source, 'Repro.tsx', { adapter })
+  expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+  const clientJs = result.files.find(f => f.type === 'clientJs')
+  expect(clientJs).toBeDefined()
+  return clientJs!.content
+}
+
+describe('static inner-loop index param in child-component props (#2231)', () => {
+  test('inner-loop-nested: the inner forEach binds the user index name', () => {
+    const content = clientJsFor(`
+      'use client'
+      import { Cell } from './cell'
+      const OUTER = [
+        { id: 1, subs: [{ id: 11 }, { id: 12 }] },
+        { id: 2, subs: [{ id: 21 }] },
+      ]
+      export function Repro() {
+        return (
+          <div>
+            {OUTER.map((o, oi) => (
+              <div key={o.id}>
+                {o.subs.map((sub, i) => (
+                  <Cell key={sub.id} label={i} outerPos={oi} />
+                ))}
+              </div>
+            ))}
+          </div>
+        )
+      }
+    `)
+
+    // The inner forEach's index param is the user's name, so the prop
+    // getters `return i` / `return oi` resolve.
+    expect(content).toContain('o.subs.forEach((sub, i) => {')
+    // The inner element offset indexes with the same (renamed) param.
+    expect(content).toContain('__ic.children[i]')
+    expect(content).toContain('get label() { return i }')
+    expect(content).toContain('get outerPos() { return oi }')
+    expect(content).not.toContain('__innerIdx')
+  })
+
+  test('inner-loop-nested: no declared index keeps the synthetic __innerIdx (byte stability)', () => {
+    const content = clientJsFor(`
+      'use client'
+      import { Cell } from './cell'
+      const OUTER = [
+        { id: 1, subs: [{ id: 11 }, { id: 12 }] },
+      ]
+      export function Repro() {
+        return (
+          <div>
+            {OUTER.map((o) => (
+              <div key={o.id}>
+                {o.subs.map((sub) => (
+                  <Cell key={sub.id} label={sub.id} />
+                ))}
+              </div>
+            ))}
+          </div>
+        )
+      }
+    `)
+
+    expect(content).toContain('o.subs.forEach((sub, __innerIdx) => {')
+    expect(content).toContain('__ic.children[__innerIdx]')
+  })
+
+  test('component-rooted-inner-loop: outer AND inner index params are bound', () => {
+    const content = clientJsFor(`
+      'use client'
+      import { Card, Cell } from './cell'
+      const OUTER = [
+        { id: 1, subs: [{ id: 11 }, { id: 12 }] },
+      ]
+      export function Repro2() {
+        return (
+          <div>
+            {OUTER.map((o, oi) => (
+              <Card key={o.id}>
+                {o.subs.map((sub, i) => (
+                  <Cell key={sub.id} label={i} outerPos={oi} />
+                ))}
+              </Card>
+            ))}
+          </div>
+        )
+      }
+    `)
+
+    // Document-order zip: both forEach heads carry the declared index names.
+    expect(content).toContain('OUTER.forEach((o, oi) => {')
+    expect(content).toContain('o.subs.forEach((sub, i) => {')
+    expect(content).toContain('get label() { return i }')
+    expect(content).toContain('get outerPos() { return oi }')
+  })
+
+  test('component-rooted-inner-loop: no declared index keeps bare single-param heads (byte stability)', () => {
+    const content = clientJsFor(`
+      'use client'
+      import { Card, Cell } from './cell'
+      const OUTER = [
+        { id: 1, subs: [{ id: 11 }] },
+      ]
+      export function Repro2() {
+        return (
+          <div>
+            {OUTER.map((o) => (
+              <Card key={o.id}>
+                {o.subs.map((sub) => (
+                  <Cell key={sub.id} label={sub.id} />
+                ))}
+              </Card>
+            ))}
+          </div>
+        )
+      }
+    `)
+
+    expect(content).toContain('OUTER.forEach((o) => {')
+    expect(content).toContain('o.subs.forEach((sub) => {')
+  })
+
+  test('index named like a property access is not confused (item.i stays untouched)', () => {
+    const content = clientJsFor(`
+      'use client'
+      import { Cell } from './cell'
+      const OUTER = [
+        { id: 1, subs: [{ id: 11, i: 'a' }] },
+      ]
+      export function Repro() {
+        return (
+          <div>
+            {OUTER.map((o) => (
+              <div key={o.id}>
+                {o.subs.map((sub) => (
+                  <Cell key={sub.id} label={sub.i} />
+                ))}
+              </div>
+            ))}
+          </div>
+        )
+      }
+    `)
+
+    // No index declared → synthetic param; the `sub.i` property access is
+    // untouched (this fix renames the forEach param, never rewrites bodies).
+    expect(content).toContain('o.subs.forEach((sub, __innerIdx) => {')
+    expect(content).toContain('get label() { return sub.i }')
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/plan/build-static-array-child-init.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/build-static-array-child-init.ts
@@ -124,6 +124,11 @@ function buildInnerLoopNestedPlan(
   innerComps: readonly IRLoopChildComponent[],
 ): InnerLoopNestedInitPlan {
   const outerIndexParam = elem.index || '__idx'
+  // The user's declared inner index name, falling back to the synthetic
+  // `__innerIdx` — same idiom as the outer `elem.index || '__idx'` above.
+  // Hardcoding the synthetic name left a referenced user index unbound and
+  // `initChild`'s prop getters threw `ReferenceError` at hydration (#2231).
+  const innerIndexParam = innerLoop.index || '__innerIdx'
   const comps: InnerLoopComp[] = innerComps.map(comp => ({
     componentName: comp.name,
     selector: buildCompSelector(comp),
@@ -141,7 +146,8 @@ function buildInnerLoopNestedPlan(
     innerContainerSlotId: innerLoop.containerSlotId ?? null,
     innerArrayExpr: innerLoop.array,
     innerParam: innerLoop.param,
-    innerOffsetExpr: buildLoopChildIndexExpr('__innerIdx', innerLoop.offset),
+    innerIndexParam,
+    innerOffsetExpr: buildLoopChildIndexExpr(innerIndexParam, innerLoop.offset),
     innerPreludeStatements: innerLoop.mapPreamble ? [innerLoop.mapPreamble] : [],
     depth: innerLoop.depth,
     comps,
@@ -179,9 +185,14 @@ function buildComponentRootedInnerLoopPlan(
     containerVar: `_${varSlotId(elem.slotId)}`,
     outerArrayExpr: elem.array,
     outerParam: elem.param,
+    // Declared index names only (#2231) — the zip shape never indexes by
+    // position, so there's no synthetic fallback and index-less loops keep
+    // byte-identical output.
+    outerIndexParam: elem.index,
     outerPreludeStatements: elem.mapPreamble ? [elem.mapPreamble] : [],
     innerArrayExpr: innerLoop.array,
     innerParam: innerLoop.param,
+    innerIndexParam: innerLoop.index,
     innerPreludeStatements: innerLoop.mapPreamble ? [innerLoop.mapPreamble] : [],
     depth: innerLoop.depth,
     comps,

--- a/packages/jsx/src/ir-to-client-js/plan/static-array-child-init.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/static-array-child-init.ts
@@ -122,7 +122,16 @@ export interface InnerLoopNestedInitPlan {
   innerContainerSlotId: string | null
   innerArrayExpr: string
   innerParam: string
-  /** Inner offset — `__innerIdx` plus any sibling-offset terms. */
+  /**
+   * Inner index parameter identifier — the user's declared `.map((item, i)
+   * => ...)` index name, or the synthetic `__innerIdx` when the callback
+   * declares none (#2231). Emitted as the inner `forEach`'s second param so
+   * prop getters that close over the index resolve it (previously the
+   * synthetic name was hardcoded and a referenced user index threw
+   * `ReferenceError` from `initChild`'s first prop read).
+   */
+  innerIndexParam: string
+  /** Inner offset — `innerIndexParam` plus any sibling-offset terms. */
   innerOffsetExpr: string
   /**
    * Inner `.map()` callback preamble locals, emitted after the
@@ -161,11 +170,21 @@ export interface ComponentRootedInnerLoopInitPlan {
   /** Outer loop's array expression. */
   outerArrayExpr: string
   outerParam: string
+  /**
+   * Outer `.map()` index param name, or `null` when the callback declares
+   * none (#2231). Unlike `inner-loop-nested`, this shape needs no synthetic
+   * fallback — the document-order zip never indexes by position — so the
+   * param is appended to the `forEach` head only when declared, keeping
+   * index-less loops byte-identical.
+   */
+  outerIndexParam: string | null
   /** Outer `.map()` callback preamble locals (#1064). */
   outerPreludeStatements: PreludeStatements
   /** Inner loop's array expression (references the outer param). */
   innerArrayExpr: string
   innerParam: string
+  /** Inner `.map()` index param name, or `null` — see `outerIndexParam` (#2231). */
+  innerIndexParam: string | null
   /** Inner `.map()` callback preamble locals (#1064). */
   innerPreludeStatements: PreludeStatements
   /** Depth used in the leading comment line. */

--- a/packages/jsx/src/ir-to-client-js/stringify/static-array-child-init.ts
+++ b/packages/jsx/src/ir-to-client-js/stringify/static-array-child-init.ts
@@ -36,7 +36,7 @@
  *     <i>    if (!__outerEl) return
  *     <i>    <outerPreludeStatements*>   // raw outer preamble (#1064)
  *     <i>    const __ic = <innerContainer-or-outerEl>
- *     <i>    <innerArr>.forEach((<innerParam>, __innerIdx) => {
+ *     <i>    <innerArr>.forEach((<innerParam>, <innerIdx>) => {
  *     <i>      const __innerEl = __ic.children[<innerOffset>]
  *     <i>      if (!__innerEl) return
  *     <i>      <innerPreludeStatements*>   // raw inner preamble (#1064)
@@ -137,6 +137,7 @@ function emitInnerLoopNested(lines: string[], plan: InnerLoopNestedInitPlan): vo
     innerContainerSlotId,
     innerArrayExpr,
     innerParam,
+    innerIndexParam,
     innerOffsetExpr,
     innerPreludeStatements,
     depth,
@@ -157,7 +158,7 @@ function emitInnerLoopNested(lines: string[], plan: InnerLoopNestedInitPlan): vo
   } else {
     lines.push(`      const __ic = __outerEl`)
   }
-  lines.push(`      ${innerArrayExpr}.forEach((${innerParam}, __innerIdx) => {`)
+  lines.push(`      ${innerArrayExpr}.forEach((${innerParam}, ${innerIndexParam}) => {`)
   lines.push(`        const __innerEl = __ic.children[${innerOffsetExpr}]`)
   lines.push(`        if (!__innerEl) return`)
   // Inner `.map()` callback preamble — must precede the per-component
@@ -186,9 +187,9 @@ function emitInnerLoopNested(lines: string[], plan: InnerLoopNestedInitPlan): vo
  *   <i>if (<container>) {
  *   <i>  const <scopes_c> = qsaChildScopes(<container>, <selector_c>)   // per comp
  *   <i>  let <cursor_c> = 0
- *   <i>  <outerArr>.forEach((<outerParam>) => {
+ *   <i>  <outerArr>.forEach((<outerParam>[, <outerIdx>]) => {
  *   <i>    <outerPreludeStatements*>
- *   <i>    <innerArr>.forEach((<innerParam>) => {
+ *   <i>    <innerArr>.forEach((<innerParam>[, <innerIdx>]) => {
  *   <i>      <innerPreludeStatements*>
  *   <i>      const <compEl_c> = <scopes_c>[<cursor_c>++]              // per comp
  *   <i>      if (<compEl_c>) initChild('<name>', <compEl_c>, <props>)
@@ -206,9 +207,11 @@ function emitComponentRootedInnerLoop(lines: string[], plan: ComponentRootedInne
     containerVar,
     outerArrayExpr,
     outerParam,
+    outerIndexParam,
     outerPreludeStatements,
     innerArrayExpr,
     innerParam,
+    innerIndexParam,
     innerPreludeStatements,
     depth,
     comps,
@@ -226,11 +229,13 @@ function emitComponentRootedInnerLoop(lines: string[], plan: ComponentRootedInne
     lines.push(`    const ${scopesVar(i)} = qsaChildScopes(${containerVar}, ${comp.selector})`)
     lines.push(`    let ${cursorVar(i)} = 0`)
   })
-  lines.push(`    ${outerArrayExpr}.forEach((${outerParam}) => {`)
+  // Declared index names are appended to the forEach heads (#2231);
+  // index-less loops keep the bare single-param head byte-identical.
+  lines.push(`    ${outerArrayExpr}.forEach((${outerParam}${outerIndexParam ? `, ${outerIndexParam}` : ''}) => {`)
   for (const stmt of outerPreludeStatements) {
     lines.push(`      ${stmt}`)
   }
-  lines.push(`      ${innerArrayExpr}.forEach((${innerParam}) => {`)
+  lines.push(`      ${innerArrayExpr}.forEach((${innerParam}${innerIndexParam ? `, ${innerIndexParam}` : ''}) => {`)
   for (const stmt of innerPreludeStatements) {
     lines.push(`        ${stmt}`)
   }


### PR DESCRIPTION
Fixes #2231.

## Problem

The fully-static nested-loop child-init family (outer AND inner arrays are static module consts, loop bodies contain child components) never bound the inner `.map()` callback's declared index name. Repro shape (issue #2231): a module-const `OUTER` array mapped to elements, whose inner `o.subs.map((sub, i) => ...)` renders a `Cell` child component with `key={sub.id}` and `label={i}`.

That compiled to `get label() { return i }` with `i` unbound — `initChild`'s first prop read threw `ReferenceError: i is not defined` at hydration and the component never initialised. A silent runtime crash with no compile diagnostic.

Follow-up to #2218 (PR #2230), which fixed the reactive (`mapArray`) and branch-arm paths. This family (`plan/build-static-array-child-init.ts` / `stringify/static-array-child-init.ts`) never goes through `loopKeyFn` or the renderItem alias, so it needed its own threading.

## Root cause

- The `inner-loop-nested` shape hardcoded the synthetic `__innerIdx` as the inner `forEach` index param, ignoring `NestedLoop.index` (available since #2230).
- The `component-rooted-inner-loop` shape (#1725, document-order zip) declared no index params at all — both the outer and inner index names were unbound.

## Fix

Emit the user's declared index name directly as the `forEach` second param — the same idiom the outer loop has always used (`elem.index || '__idx'` in `single-comp`/`outer-nested`). No alias binding is needed because `forEach` supplies the real array index positionally.

- `inner-loop-nested`: inner forEach param becomes `innerLoop.index || '__innerIdx'`; the child-offset expression (`__ic.children[...]`) follows the same name.
- `component-rooted-inner-loop`: outer/inner index names are appended to the forEach heads only when declared (the zip never indexes by position, so no synthetic fallback is needed).

Loops that declare no index keep byte-for-byte identical output (pinned by tests). Loops that declare one see only the (behavior-neutral) param rename.

## Tests

- `packages/jsx/src/__tests__/static-array-inner-loop-index-param.test.ts` — 5 tests: both shapes with a referenced index (verified failing pre-fix), byte-stability pins for index-less loops in both shapes, and a property-access collision guard (`sub.i` untouched).
- `packages/client/__tests__/runtime/static-inner-loop-index-param-e2e.test.ts` — renders real SSR HTML via the Hono adapter, then hydrates, so `initChild`'s prop getters actually execute (a `createComponent`-only mount never reaches `initChild` for this family and passes silently even pre-fix). Verified red pre-fix / green post-fix.
- Full `packages/jsx` suite: 2461 pass, 0 fail; `packages/client`: 415 pass; `tsc --noEmit` clean for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxCtWVr3LBPEPsaK9b5kdD