### PR TITLE
Fix SVG namespace for inner-loop and CSR-materialize template clones (#2219)

### DIFF
--- a/.changeset/inner-loop-svg-namespace.md
+++ b/.changeset/inner-loop-svg-namespace.md
@@ -1,0 +1,9 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix #2219: an inner reactive `.map()` whose item root is an SVG element (`<line>`, `<circle>`, ...) no longer renders invisibly. `template.innerHTML` always parses in the HTML namespace, so a bare SVG-rooted item cloned as an `HTMLUnknownElement` — present in the DOM, but never drawn by the SVG renderer, with no error.
+
+The fix wraps SVG-rooted item templates in a synthetic `<svg>` and descends one extra level (`.firstElementChild.firstElementChild`) before cloning — the same `templateRootIsSvg` idiom the top-level (#135/#1088) and branch-arm paths already used, now applied to the inner-loop reactive clone (`stringify/inner-loop.ts`, the issue's root cause). While auditing sibling clone sites for the same bug class, the static-loop CSR-materialize single-root and multi-root clones (`stringify/loop.ts`, the #1247 path) turned out to have the identical gap and are fixed alongside it.
+
+HTML-rooted templates keep byte-for-byte identical output; only SVG-rooted item templates — previously broken and invisible — change.

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -340,6 +340,7 @@ import { fixture as mapIndexHandler } from './map-index-handler'
 import { fixture as nestedMapIndexKey } from './nested-map-index-key'
 import { fixture as nestedLoopOuterBinding } from './nested-loop-outer-binding'
 import { fixture as nestedLoopTripleDepth } from './nested-loop-triple-depth'
+import { fixture as svgInnerLoop } from './svg-inner-loop'
 import { fixture as siblingLoopsKeyIsolation } from './sibling-loops-key-isolation'
 import { fixture as conditionalReturnNull } from './conditional-return-null'
 import { fixture as jsxElementProp } from './jsx-element-prop'
@@ -610,6 +611,7 @@ export const jsxFixtures: JSXFixture[] = [
   nestedMapIndexKey,
   nestedLoopOuterBinding,
   nestedLoopTripleDepth,
+  svgInnerLoop,
   siblingLoopsKeyIsolation,
   conditionalReturnNull,
   jsxElementProp,

--- a/packages/adapter-tests/fixtures/svg-inner-loop.ts
+++ b/packages/adapter-tests/fixtures/svg-inner-loop.ts
@@ -1,0 +1,68 @@
+import { createFixture } from '../src/types'
+
+/**
+ * An inner reactive `.map()` rendering SVG elements (`<line>`) whose ITEMS
+ * live inside an outer reactive loop of `<svg>` containers (#2219, fixed in
+ * PR #2233). `svg-icon` pins a single static `<svg>`; `fragment-loop-children`
+ * pins a single-level loop *inside* one static `<svg>`; this pins the
+ * doubly-nested shape that actually threw: an outer `sheets().map()` whose
+ * body is itself an `<svg key={...}>`, containing an inner `s.ticks.map()`
+ * whose body is a bare SVG leaf (`<line key={...}>`). Both loop levels
+ * require `key` (BF024 for the inner map, BF023 for the outer).
+ *
+ * This fixture pins cross-adapter SSR / CSR-template markup parity only
+ * (byte-identical HTML/template output across adapters, including
+ * `viewBox`'s case-sensitive casing surviving nested-loop codegen). The
+ * runtime bug itself — freshly-CREATED `<line>` items cloning as
+ * `HTMLUnknownElement` instead of `SVGLineElement` because the inner loop's
+ * `template.innerHTML` parse never got the `<svg>` namespace wrap — can't be
+ * regression-pinned here: `csr-conformance.test.ts` only evaluates the
+ * compiled `template()` lambda's static markup and never executes the
+ * `mapArray` renderItem clone IIFE where the bug lived. That's covered by
+ * `packages/client/__tests__/runtime/inner-loop-svg-namespace-e2e.test.ts`,
+ * which mounts real compiled client JS in happy-dom and asserts
+ * `namespaceURI` on freshly-created `<line>` elements.
+ *
+ * The signal is explicitly typed (`createSignal<Sheet[]>`) — required for
+ * the Go adapter, whose SSR data context bakes an object-array signal
+ * initial value only against a concrete local struct (`parsedLiteralToGo`
+ * defers object literals inside an untyped `[]interface{}` to `nil`, which
+ * renders an empty container). Initial data is non-empty (two sheets, one
+ * with two ticks, one with one) so SSR actually exercises the inner loop
+ * rather than only pinning the empty-array shape.
+ */
+export const fixture = createFixture({
+  id: 'svg-inner-loop',
+  description: 'Inner reactive .map() of SVG leaves inside an outer reactive loop of <svg> containers',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Sheet = { id: number; ticks: number[] }
+export function SvgInnerLoop() {
+  const [sheets] = createSignal<Sheet[]>([
+    { id: 1, ticks: [10, 20] },
+    { id: 2, ticks: [30] },
+  ])
+  return (
+    <div>
+      {sheets().map((sheet) => (
+        <svg key={sheet.id} viewBox="0 0 100 100">
+          {sheet.ticks.map((y) => (
+            <line key={y} x1="0" x2="100" y1={y} y2={y} />
+          ))}
+        </svg>
+      ))}
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test" bf="s2">
+      <svg bf="s1" data-key="1" viewBox="0 0 100 100">
+        <line bf="s0" data-key-1="10" x1="0" x2="100" y1="10" y2="10"></line>
+        <line bf="s0" data-key-1="20" x1="0" x2="100" y1="20" y2="20"></line>
+      </svg>
+      <svg bf="s1" data-key="2" viewBox="0 0 100 100"><line bf="s0" data-key-1="30" x1="0" x2="100" y1="30" y2="30"></line></svg>
+    </div>
+  `,
+})

--- a/packages/client/__tests__/runtime/inner-loop-svg-namespace-e2e.test.ts
+++ b/packages/client/__tests__/runtime/inner-loop-svg-namespace-e2e.test.ts
@@ -1,0 +1,143 @@
+/**
+ * End-to-end runtime test for #2219: an inner reactive `.map()` callback
+ * whose item root is an SVG element (`<line>`, `<circle>`, ...) cloned via
+ * `template.innerHTML` in the HTML namespace — the element existed in the
+ * DOM but rendered nothing, silently, because `template.innerHTML` always
+ * parses in the HTML namespace and a bare `<line>` root clones as an
+ * `HTMLUnknownElement` instead of an `SVGLineElement`.
+ *
+ * Confirmed with a standalone happy-dom sanity check before writing this
+ * test: `template.innerHTML = '<line/>'` clones with
+ * `namespaceURI === 'http://www.w3.org/1999/xhtml'` (HTMLUnknownElement),
+ * while `template.innerHTML = '<svg><line/></svg>'` followed by
+ * `.firstElementChild.firstElementChild` clones with
+ * `namespaceURI === 'http://www.w3.org/2000/svg'` (SVGLineElement) — so
+ * happy-dom faithfully reproduces the parsing bug this fix addresses.
+ *
+ * Mounts the real compiled output in a DOM (not just template-eval — see
+ * `packages/adapter-tests/src/__tests__/csr-conformance.test.ts`, which only
+ * evaluates the `template()` lambda and can't reach this bug) with an empty
+ * initial signal and appends after mount, forcing `mapArray` to CREATE the
+ * inner `<line>` elements via the renderItem clone IIFE (the code path fixed
+ * in `stringify/inner-loop.ts`) rather than hydrating pre-existing SSR
+ * markup.
+ */
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import { compileJSX } from '../../../jsx/src/compiler'
+import { TestAdapter } from '../../../jsx/src/adapters/test-adapter'
+import { writeFileSync, mkdtempSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') GlobalRegistrator.register()
+})
+
+const adapter = new TestAdapter()
+
+async function mount(source: string, filename: string, name: string): Promise<HTMLElement> {
+  const result = compileJSX(source, filename, { adapter })
+  const errors = result.errors.filter((e) => e.severity === 'error')
+  if (errors.length > 0) {
+    throw new Error(`Compile errors in ${filename}:\n${errors.map((e) => `${e.code}: ${e.message}`).join('\n')}`)
+  }
+  const clientJs = result.files.find((f) => f.type === 'clientJs')?.content
+  if (!clientJs) throw new Error('No client JS emitted')
+  const runtimePath = join(__dirname, '../../src/runtime/index.ts')
+  const rewritten = clientJs
+    .replace(/from\s+['"]@barefootjs\/client\/runtime['"]/g, `from '${runtimePath}'`)
+    .replace(/^import '\/\* @bf-child:\w+ \*\/'\n/gm, '')
+  const dir = mkdtempSync(join(tmpdir(), 'bf-2219-'))
+  const file = join(dir, `${filename.replace(/\W/g, '_')}.mjs`)
+  writeFileSync(file, rewritten)
+  await import(file)
+  const { createComponent } = await import(runtimePath)
+  const el = createComponent(name, {}) as HTMLElement
+  document.body.appendChild(el)
+  return el
+}
+
+const SVG_NS = 'http://www.w3.org/2000/svg'
+
+describe('#2219 — inner reactive loop with an SVG element root', () => {
+  beforeEach(() => { document.body.innerHTML = '' })
+
+  test('freshly-created <line> items added to an already-mounted <svg> parse in the SVG namespace', async () => {
+    // The outer sheet (and its <svg> root) exists from the initial signal
+    // value with an EMPTY ticks array, so the outer item's own baked
+    // template embeds zero inner <line> elements — the initial mount does
+    // not exercise the inner-loop clone path (an outer item created fresh
+    // bakes its *initial* inner items into its own already-svg-wrapped
+    // template string, which bypasses `stringify/inner-loop.ts` entirely;
+    // see the sibling test below for that scenario). Adding ticks to the
+    // EXISTING sheet afterwards forces the inner reactive `mapArray` to
+    // find no `__existing` match and CREATE each <line> via the
+    // `stringify/inner-loop.ts` renderItem clone IIFE — the code path #2219
+    // actually fixed.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      interface Sheet { id: number; ticks: number[] }
+      export function Repro() {
+        const [sheets, setSheets] = createSignal<Sheet[]>([{ id: 1, ticks: [] }])
+        return (
+          <div onClick={() => setSheets(prev => prev.map(s => ({ ...s, ticks: [10, 20, 30] })))}>
+            {sheets().map((s) => (
+              <svg key={s.id} viewBox="0 0 100 100">
+                {s.ticks.map((y) => (
+                  <line key={y} x1="0" x2="100" y1={y} y2={y} stroke="black" />
+                ))}
+              </svg>
+            ))}
+          </div>
+        )
+      }
+    `
+    const el = await mount(source, 'SvgInnerLoopRepro.tsx', 'Repro')
+    // The outer <svg> exists already, but with zero <line> children.
+    expect(el.querySelectorAll('svg')).toHaveLength(1)
+    expect(el.querySelectorAll('line')).toHaveLength(0)
+
+    el.dispatchEvent(new window.Event('click', { bubbles: true }))
+
+    const lines = Array.from(el.querySelectorAll('line'))
+    expect(lines).toHaveLength(3)
+    for (const line of lines) {
+      expect(line.namespaceURI).toBe(SVG_NS)
+      expect(line.constructor.name).toBe('SVGLineElement')
+    }
+  })
+
+  test('appending more ticks to an existing sheet creates further SVG-namespaced <line> items', async () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      interface Sheet { id: number; ticks: number[] }
+      export function Repro() {
+        const [sheets, setSheets] = createSignal<Sheet[]>([{ id: 1, ticks: [10] }])
+        return (
+          <div onClick={() => setSheets(prev => prev.map(s => ({ ...s, ticks: [...s.ticks, 20, 30] })))}>
+            {sheets().map((s) => (
+              <svg key={s.id} viewBox="0 0 100 100">
+                {s.ticks.map((y) => (
+                  <line key={y} x1="0" x2="100" y1={y} y2={y} stroke="black" />
+                ))}
+              </svg>
+            ))}
+          </div>
+        )
+      }
+    `
+    const el = await mount(source, 'SvgInnerLoopAppendRepro.tsx', 'Repro')
+    expect(el.querySelectorAll('line')).toHaveLength(1)
+
+    el.dispatchEvent(new window.Event('click', { bubbles: true }))
+
+    const lines = Array.from(el.querySelectorAll('line'))
+    expect(lines).toHaveLength(3)
+    for (const line of lines) {
+      expect(line.namespaceURI).toBe(SVG_NS)
+    }
+  })
+})

--- a/packages/jsx/src/__tests__/inner-loop-svg-namespace.test.ts
+++ b/packages/jsx/src/__tests__/inner-loop-svg-namespace.test.ts
@@ -1,0 +1,188 @@
+/**
+ * SVG-rooted loop item templates cloned via `template.innerHTML` (#2219).
+ *
+ * `template.innerHTML` parses in the HTML namespace, so an inner reactive
+ * loop whose item root is an SVG element (`<line>`, `<circle>`, ...) cloned
+ * as an `HTMLUnknownElement` — present in the DOM but never drawn by the
+ * SVG renderer, with no error. The top-level loop path has wrapped these
+ * templates in a synthetic `<svg>` since #135/#1088 (`templateRootIsSvg` /
+ * `emitTemplateCloneInline` in `stringify/template-parse.ts`) and the
+ * branch-arm path since its plan-ification, but the inner-loop reactive
+ * clone (`stringify/inner-loop.ts`) and the static-loop CSR materialize
+ * clones (#1247, `stringify/loop.ts`) parsed bare and stayed in the wrong
+ * namespace.
+ *
+ * The fix mirrors the established wrap: parse `<svg>${template}</svg>` and
+ * descend one extra level (`.firstElementChild.firstElementChild`).
+ * HTML-rooted templates keep byte-identical output.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function clientJsFor(source: string): string {
+  const result = compileJSX(source, 'Repro.tsx', { adapter })
+  expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+  const clientJs = result.files.find(f => f.type === 'clientJs')
+  expect(clientJs).toBeDefined()
+  return clientJs!.content
+}
+
+describe('inner reactive loop with an SVG element root (#2219)', () => {
+  test('SVG-rooted inner item clones inside a synthetic <svg> wrap', () => {
+    const content = clientJsFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      interface Sheet { id: number; ticks: number[] }
+      export function Repro() {
+        const [sheets] = createSignal<Sheet[]>([])
+        return (
+          <div>
+            {sheets().map((s) => (
+              <svg key={s.id} viewBox="0 0 100 100">
+                {s.ticks.map((y) => (
+                  <line key={y} x1="0" x2="100" y1={y} y2={y} stroke="black" />
+                ))}
+              </svg>
+            ))}
+          </div>
+        )
+      }
+    `)
+
+    // The inner renderItem clone parses inside `<svg>...</svg>` and descends
+    // one extra level to reach the real `<line>` root.
+    expect(content).toMatch(/__t\.innerHTML = `<svg><line /)
+    expect(content).toContain('return __t.content.firstElementChild.firstElementChild.cloneNode(true)')
+  })
+
+  test('HTML-rooted inner item keeps the bare clone byte-identical', () => {
+    const content = clientJsFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      interface Group { id: number; items: string[] }
+      export function Repro() {
+        const [groups] = createSignal<Group[]>([])
+        return (
+          <ul>
+            {groups().map((g) => (
+              <li key={g.id}>
+                {g.items.map((t) => (
+                  <span key={t}>{t}</span>
+                ))}
+              </li>
+            ))}
+          </ul>
+        )
+      }
+    `)
+
+    expect(content).toMatch(/__t\.innerHTML = `<span /)
+    expect(content).toContain('return __t.content.firstElementChild.cloneNode(true)')
+    // No synthetic wrap anywhere in the inner clone.
+    expect(content).not.toContain('`<svg><span')
+  })
+
+  test('conditional inner body whose branches are all SVG wraps too (#1088 shape)', () => {
+    const content = clientJsFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      interface Sheet { id: number; ticks: number[] }
+      export function Repro() {
+        const [sheets] = createSignal<Sheet[]>([])
+        return (
+          <div>
+            {sheets().map((s) => (
+              <svg key={s.id}>
+                {s.ticks.map((y) => (
+                  y > 50
+                    ? <line key={y} y1={y} y2={y} />
+                    : <circle key={y} cy={y} r="1" />
+                ))}
+              </svg>
+            ))}
+          </div>
+        )
+      }
+    `)
+
+    // Both branches are SVG roots, so the interpolated conditional template
+    // still gets the wrap (templateRootIsSvg recurses into the branches).
+    expect(content).toMatch(/__t\.innerHTML = `<svg>\$\{/)
+    expect(content).toContain('return __t.content.firstElementChild.firstElementChild.cloneNode(true)')
+  })
+})
+
+describe('static-loop CSR materialize with an SVG element root (#2219, #1247 path)', () => {
+  test('SVG-rooted materialize clone wraps and descends the extra level', () => {
+    const content = clientJsFor(`
+      'use client'
+      type Props = { ticks: Record<string, number> }
+      export function Repro(props: Props) {
+        const entries = Object.entries(props.ticks ?? {}).filter(([, y]) => y > 0)
+        return (
+          <svg viewBox="0 0 100 100">
+            {entries.map(([id, y]) => (
+              <line key={id} x1="0" x2="100" y1={y} y2={y} />
+            ))}
+          </svg>
+        )
+      }
+    `)
+
+    // Materialize branch present (unsafe prop-derived array, #1247) ...
+    expect(content).toMatch(/if \(!__iterEl\)/)
+    // ... and its template parse is namespace-aware.
+    expect(content).toMatch(/__tpl\.innerHTML = `<svg><line /)
+    expect(content).toContain('const __cloned = __tpl.content.firstElementChild.firstElementChild')
+  })
+
+  test('multi-root (fragment) SVG materialize iterates the wrap one level down', () => {
+    const content = clientJsFor(`
+      'use client'
+      type Props = { ticks: Record<string, number> }
+      export function Repro(props: Props) {
+        const entries = Object.entries(props.ticks ?? {}).filter(([, y]) => y > 0)
+        return (
+          <svg viewBox="0 0 100 100">
+            {entries.map(([id, y]) => (
+              <>
+                <line key={id} x1="0" x2="100" y1={y} y2={y} />
+                <text x="0" y={y}>{id}</text>
+              </>
+            ))}
+          </svg>
+        )
+      }
+    `)
+
+    expect(content).toMatch(/__mtpl\.innerHTML = `<svg><line /)
+    // Sibling iteration starts inside the synthetic wrap.
+    expect(content).toContain('let __sib = __mtpl.content.firstElementChild.firstElementChild')
+  })
+
+  test('HTML-rooted materialize clone keeps the bare parse byte-identical', () => {
+    const content = clientJsFor(`
+      'use client'
+      type Props = { reactions: Record<string, string[]> }
+      export function Repro(props: Props) {
+        const entries = Object.entries(props.reactions ?? {}).filter(([, users]) => users.length > 0)
+        return (
+          <div>
+            {entries.map(([emoji, users]) => (
+              <button key={emoji} type="button">{emoji}: {String(users.length)}</button>
+            ))}
+          </div>
+        )
+      }
+    `)
+
+    expect(content).toMatch(/if \(!__iterEl\)/)
+    expect(content).toMatch(/__tpl\.innerHTML = `<button /)
+    expect(content).toContain('const __cloned = __tpl.content.firstElementChild')
+    expect(content).not.toContain('`<svg>')
+  })
+})

--- a/packages/jsx/src/__tests__/inner-loop-svg-namespace.test.ts
+++ b/packages/jsx/src/__tests__/inner-loop-svg-namespace.test.ts
@@ -116,6 +116,34 @@ describe('inner reactive loop with an SVG element root (#2219)', () => {
   })
 })
 
+describe('reactive multi-root fragment with an <svg>-container first root (#2233 review)', () => {
+  test('emitMultiRootTemplateCloneLines skips the wrap for <svg>-first fragments', () => {
+    const content = clientJsFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      interface Chart { id: number; r: number }
+      export function Repro() {
+        const [charts] = createSignal<Chart[]>([])
+        return (
+          <div>
+            {charts().map((c) => (
+              <>
+                <svg key={c.id} viewBox="0 0 10 10"><circle r={c.r} /></svg>
+                <span>{c.id}</span>
+              </>
+            ))}
+          </div>
+        )
+      }
+    `)
+
+    // The multi-root clone parses the fragment bare — no synthetic wrap —
+    // so the HTML <span> sibling stays in the HTML namespace.
+    expect(content).not.toContain('`<svg><svg')
+    expect(content).toContain('__tpl.content.firstElementChild.cloneNode(true)')
+  })
+})
+
 describe('static-loop CSR materialize with an SVG element root (#2219, #1247 path)', () => {
   test('SVG-rooted materialize clone wraps and descends the extra level', () => {
     const content = clientJsFor(`
@@ -162,6 +190,35 @@ describe('static-loop CSR materialize with an SVG element root (#2219, #1247 pat
     expect(content).toMatch(/__mtpl\.innerHTML = `<svg><line /)
     // Sibling iteration starts inside the synthetic wrap.
     expect(content).toContain('let __sib = __mtpl.content.firstElementChild.firstElementChild')
+  })
+
+  test('<svg>-container-first fragment is NOT over-wrapped (#2233 review)', () => {
+    // An <svg> CONTAINER parses into the correct namespace bare — the HTML
+    // parser enters foreign content on its own. Wrapping the whole fragment
+    // would drag the HTML <span> sibling into the SVG namespace instead.
+    const content = clientJsFor(`
+      'use client'
+      type Props = { charts: Record<string, number> }
+      export function Repro(props: Props) {
+        const entries = Object.entries(props.charts ?? {}).filter(([, v]) => v > 0)
+        return (
+          <div>
+            {entries.map(([id, v]) => (
+              <>
+                <svg key={id} viewBox="0 0 10 10"><circle r={v} /></svg>
+                <span>{id}</span>
+              </>
+            ))}
+          </div>
+        )
+      }
+    `)
+
+    expect(content).toMatch(/__mtpl\.innerHTML = `<svg /)
+    expect(content).not.toContain('`<svg><svg')
+    // Sibling iteration starts at the template content directly (no wrap).
+    expect(content).toContain('let __sib = __mtpl.content.firstElementChild')
+    expect(content).not.toContain('let __sib = __mtpl.content.firstElementChild.firstElementChild')
   })
 
   test('HTML-rooted materialize clone keeps the bare parse byte-identical', () => {

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/inner-loop.ts
@@ -33,7 +33,7 @@
 import { keyAttrName, profileBindingId } from '../../utils.ts'
 import { emitComponentAndEventSetup } from '../shared.ts'
 import { emitAttrUpdate } from '../../emit-reactive.ts'
-import { emitMultiRootTemplateCloneLines } from './template-parse.ts'
+import { emitMultiRootTemplateCloneLines, templateRootIsSvg } from './template-parse.ts'
 import { emitLoopChildRefs } from './loop.ts'
 import type {
   InnerLoopPlan,
@@ -82,7 +82,16 @@ function emitReactive(lines: string[], inner: InnerLoopPlan, indent: string, pc:
     lines.push(`${innerIndent}  __innerEl${uid}.__bfExtras = __innerExtras${uid}`)
     lines.push(`${indent}  }`)
   } else {
-    lines.push(`${indent}  let __innerEl${uid} = __existing ?? (() => { const __t = document.createElement('template'); __t.innerHTML = \`${emit.wrappedTemplate}\`; return __t.content.firstElementChild.cloneNode(true) })()`)
+    // SVG-rooted item templates must parse inside a synthetic `<svg>` wrap
+    // (#2219): `template.innerHTML` parses in the HTML namespace, so a bare
+    // `<line>`/`<circle>` root clones as an HTMLUnknownElement and the SVG
+    // renderer silently draws nothing. Mirrors `templateRootIsSvg` handling
+    // on the top-level (#135/#1088) and branch-arm paths; HTML-rooted
+    // templates keep byte-identical output.
+    const isSvg = templateRootIsSvg(emit.wrappedTemplate)
+    const innerHtml = isSvg ? `<svg>${emit.wrappedTemplate}</svg>` : emit.wrappedTemplate
+    const childPath = isSvg ? '.firstElementChild.firstElementChild' : '.firstElementChild'
+    lines.push(`${indent}  let __innerEl${uid} = __existing ?? (() => { const __t = document.createElement('template'); __t.innerHTML = \`${innerHtml}\`; return __t.content${childPath}.cloneNode(true) })()`)
   }
   if (emit.wrappedKey) {
     lines.push(`${indent}  __innerEl${uid}.setAttribute('${keyAttrName(inner.keyDepth)}', String(${emit.wrappedKey}))`)

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
@@ -27,7 +27,7 @@
 import { emitRefCall, varSlotId, profileBindingId } from '../../utils.ts'
 import { emitAttrUpdate } from '../../emit-reactive.ts'
 import { stringifyReactiveEffects } from './reactive-effects.ts'
-import { emitTemplateCloneInline, emitLoopItemElementSetup, emitHoistedTemplateDecl, hoistedCloneExpr, templateRootIsSvg } from './template-parse.ts'
+import { emitTemplateCloneInline, emitLoopItemElementSetup, emitHoistedTemplateDecl, hoistedCloneExpr, templateRootIsSvg, multiRootTemplateNeedsSvgWrap } from './template-parse.ts'
 import { buildSkeletonPathPlan, type SkeletonPathPlan } from './skeleton-paths.ts'
 import { stringifyComponentLoop } from './component-loop.ts'
 import { stringifyCompositeLoop } from './composite-loop.ts'
@@ -319,8 +319,12 @@ export function stringifyStaticLoop(lines: string[], plan: StaticLoopPlan): void
     // descend one extra level (#2219) — `template.innerHTML` alone parses in
     // the HTML namespace and the materialized elements would never draw.
     // Mirrors `templateRootIsSvg` handling on the reactive clone paths;
-    // HTML-rooted templates keep byte-identical output.
-    const isSvg = templateRootIsSvg(csrMaterialize.itemTemplate)
+    // HTML-rooted templates keep byte-identical output. Multi-root fragments
+    // use the fragment-aware predicate so an `<svg>`-container-first fragment
+    // isn't over-wrapped (#2233 Copilot review).
+    const isSvg = csrMaterialize.bodyIsMultiRoot
+      ? multiRootTemplateNeedsSvgWrap(csrMaterialize.itemTemplate)
+      : templateRootIsSvg(csrMaterialize.itemTemplate)
     const itemHtml = isSvg ? `<svg>${csrMaterialize.itemTemplate}</svg>` : csrMaterialize.itemTemplate
     if (csrMaterialize.bodyIsMultiRoot) {
       // Multi-root: clone every top-level sibling of the per-item template and

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
@@ -27,7 +27,7 @@
 import { emitRefCall, varSlotId, profileBindingId } from '../../utils.ts'
 import { emitAttrUpdate } from '../../emit-reactive.ts'
 import { stringifyReactiveEffects } from './reactive-effects.ts'
-import { emitTemplateCloneInline, emitLoopItemElementSetup, emitHoistedTemplateDecl, hoistedCloneExpr } from './template-parse.ts'
+import { emitTemplateCloneInline, emitLoopItemElementSetup, emitHoistedTemplateDecl, hoistedCloneExpr, templateRootIsSvg } from './template-parse.ts'
 import { buildSkeletonPathPlan, type SkeletonPathPlan } from './skeleton-paths.ts'
 import { stringifyComponentLoop } from './component-loop.ts'
 import { stringifyCompositeLoop } from './composite-loop.ts'
@@ -315,15 +315,22 @@ export function stringifyStaticLoop(lines: string[], plan: StaticLoopPlan): void
   lines.push(`      let __iterEl = ${containerVar}.children[${childIndexExpr}]`)
   if (csrMaterialize) {
     lines.push(`      if (!__iterEl) {`)
+    // SVG-rooted item templates parse inside a synthetic `<svg>` wrap and
+    // descend one extra level (#2219) — `template.innerHTML` alone parses in
+    // the HTML namespace and the materialized elements would never draw.
+    // Mirrors `templateRootIsSvg` handling on the reactive clone paths;
+    // HTML-rooted templates keep byte-identical output.
+    const isSvg = templateRootIsSvg(csrMaterialize.itemTemplate)
+    const itemHtml = isSvg ? `<svg>${csrMaterialize.itemTemplate}</svg>` : csrMaterialize.itemTemplate
     if (csrMaterialize.bodyIsMultiRoot) {
       // Multi-root: clone every top-level sibling of the per-item template and
       // insert them in order. `__iterEl` is the first root (the one reactive
       // bindings attach to); the rest land alongside it via insertBefore.
       lines.push(`        const __mtpl = document.createElement('template')`)
-      lines.push(`        __mtpl.innerHTML = \`${csrMaterialize.itemTemplate}\``)
+      lines.push(`        __mtpl.innerHTML = \`${itemHtml}\``)
       lines.push(`        const __anchor = ${containerVar}.children[${childIndexExpr}] ?? null`)
       lines.push(`        let __first = null`)
-      lines.push(`        let __sib = __mtpl.content.firstElementChild`)
+      lines.push(`        let __sib = __mtpl.content${isSvg ? '.firstElementChild' : ''}.firstElementChild`)
       lines.push(`        while (__sib) {`)
       lines.push(`          const __next = __sib.nextElementSibling`)
       lines.push(`          const __cloned = __sib.cloneNode(true)`)
@@ -334,8 +341,8 @@ export function stringifyStaticLoop(lines: string[], plan: StaticLoopPlan): void
       lines.push(`        __iterEl = __first`)
     } else {
       lines.push(`        const __tpl = document.createElement('template')`)
-      lines.push(`        __tpl.innerHTML = \`${csrMaterialize.itemTemplate}\``)
-      lines.push(`        const __cloned = __tpl.content.firstElementChild`)
+      lines.push(`        __tpl.innerHTML = \`${itemHtml}\``)
+      lines.push(`        const __cloned = __tpl.content${isSvg ? '.firstElementChild' : ''}.firstElementChild`)
       lines.push(`        if (__cloned) {`)
       lines.push(`          const __anchor = ${containerVar}.children[${childIndexExpr}] ?? null`)
       lines.push(`          ${containerVar}.insertBefore(__cloned, __anchor)`)

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/template-parse.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/template-parse.ts
@@ -83,6 +83,30 @@ export function templateRootIsSvg(template: string): boolean {
 }
 
 /**
+ * Wrap decision for MULTI-ROOT (fragment) templates, where the synthetic
+ * `<svg>` wrap swallows every sibling root at once (#2233 Copilot review).
+ *
+ * `templateRootIsSvg` inspects only the FIRST root tag. For single-root
+ * templates that's exact, but a fragment whose first root is an `<svg>`
+ * CONTAINER (`<><svg/><span/></>`) doesn't need the wrap at all — the
+ * HTML parser enters foreign content at `<svg>` on its own — and wrapping
+ * would drag the HTML siblings into the SVG namespace (`<span>` becomes an
+ * SVGUnknownElement, silently undrawn). So `<svg>`-first fragments skip
+ * the wrap; only leaf-rooted fragments (`<line>`, `<circle>`, ...) get it.
+ *
+ * Known edge (degenerate, pre-existing): an `<svg>`-first fragment with
+ * SVG-LEAF siblings (`<><svg/><line/></>`) leaves the bare leaf siblings
+ * in the HTML namespace — exactly the pre-#2219 behavior. Deciding that
+ * shape correctly needs a scan of every top-level root tag; not worth the
+ * parser until a real component hits it.
+ */
+export function multiRootTemplateNeedsSvgWrap(template: string): boolean {
+  const m = stripLeadingNonContent(template).match(/^<\s*([A-Za-z][A-Za-z0-9-]*)/)
+  if (m && m[1].toLowerCase() === 'svg') return false
+  return templateRootIsSvg(template)
+}
+
+/**
  * Strip leading whitespace and HTML comment markers (`<!-- ... -->`) so
  * that a branch like `<!--bf-cond-start:s0-->${...}<!--bf-cond-end:s0-->`
  * is inspected at its first content node — the inner `${...}`.
@@ -269,7 +293,7 @@ export function emitMultiRootTemplateCloneLines(
   varEl: string,
   varExtras: string,
 ): string[] {
-  const isSvg = templateRootIsSvg(template)
+  const isSvg = multiRootTemplateNeedsSvgWrap(template)
   // Wrap in `<svg>` so the parser walks into SVG foreign content; we then
   // descend one level to pick up the per-item roots.
   const innerHtmlExpr = isSvg ? `\`<svg>${template}</svg>\`` : `\`${template}\``

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 242,
+    "totalFixtures": 243,
     "fixtures": {
       "dangerous-inner-html-dynamic": {
         "blade": {


### PR DESCRIPTION
Fixes #2219.

## Problem

An inner reactive loop whose item root is an SVG element (`line`, `circle`, `rect`, ...) renders in the wrong DOM namespace and is silently invisible: `template.innerHTML` parses in the HTML namespace, so the cloned item root is an `HTMLUnknownElement` — present in the DOM, never drawn, no error.

Real-world case (from the issue): per-sheet fold/cut tick marks rendered as SVG lines from an inner `.map()`; combined with #2218 this blocked moving PrintSheets off its `innerHTML` workaround.

## Root cause

The top-level loop path has wrapped SVG-rooted templates in a synthetic `svg` wrapper since #135/#1088 (`templateRootIsSvg` / `emitTemplateCloneInline` in `stringify/template-parse.ts`), and the branch-arm path mirrors it — but the inner-loop reactive clone (`stringify/inner-loop.ts`) parsed the bare template. Auditing every `createElement('template')` site turned up two more bare clones on the static-loop CSR self-heal path (#1247, `stringify/loop.ts`): the single-root and multi-root materialize branches.

## Fix

Apply the established idiom at all three sites: parse the template inside the synthetic `svg` wrapper and descend one extra level (`.firstElementChild.firstElementChild`). The wrap decision reuses `templateRootIsSvg`, so the #1088 conditional-body shape (all branches SVG) is covered too.

Existing variable names are preserved — **HTML-rooted templates keep byte-for-byte identical output**; only SVG-rooted templates (previously broken and invisible) change.

**Copilot review follow-up** (addressed in `2c6c5a21`): `templateRootIsSvg` inspects only the first root tag, so a multi-root fragment whose first root is an `svg` CONTAINER with HTML siblings would have been over-wrapped, dragging the siblings into the SVG namespace. Added the fragment-aware `multiRootTemplateNeedsSvgWrap` (skip the wrap when the first root is `svg` — the HTML parser enters foreign content there on its own) and applied it at both multi-root call sites, including the pre-existing `emitMultiRootTemplateCloneLines` helper, which carried the same latent first-tag heuristic since #1212. The degenerate mixed shape (`svg`-first fragment with SVG-leaf siblings) keeps pre-#2219 behavior and is documented on the predicate.

## Tests

- `packages/jsx/src/__tests__/inner-loop-svg-namespace.test.ts` — 8 tests: SVG-rooted inner reactive loop (wrap + double descend), all-SVG conditional body (#1088 shape), materialize single-root and fragment multi-root, `svg`-container-first fragment no-wrap pins for both multi-root call sites, and HTML byte-stability pins. Verified red pre-fix (3 fail) / green post-fix.
- `packages/client/__tests__/runtime/inner-loop-svg-namespace-e2e.test.ts` — happy-dom runtime test asserting `namespaceURI` on freshly-created inner elements (happy-dom faithfully reproduces the HTML-namespace parsing bug — verified before writing). The test appends ticks to an existing sheet after mount to force `__existing` misses, since a brand-new outer item bakes its initial inner items into the already-wrapped outer template and would never exercise the fixed clone. Verified red against the pre-fix stringifiers / green with the fix.
- `packages/adapter-tests/fixtures/svg-inner-loop.ts` — cross-adapter conformance fixture pinning SSR / CSR-template markup parity for SVG emitted from nested loops, including case-sensitive `viewBox`. `expectedHtml` generated against the live Hono reference; compat.lock totalFixtures 242 → 243 with no new divergence entries (hono, go via real `go run`, erb, jinja, rust/minijinja all pass at reference parity).
- Full `packages/jsx` suite: 2469 pass, 0 fail (150 snapshots — byte stability); `packages/client`: 417 pass; CSR conformance: 192 pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxCtWVr3LBPEPsaK9b5kdD