### PR TITLE
Fix scope-blind literal-const inlining vs loop-param shadowing across Twig-family adapters (#2221)

### DIFF
--- a/.changeset/const-inline-loop-shadowing.md
+++ b/.changeset/const-inline-loop-shadowing.md
@@ -1,0 +1,14 @@
+---
+"@barefootjs/twig": patch
+"@barefootjs/jinja": patch
+"@barefootjs/blade": patch
+"@barefootjs/xslate": patch
+"@barefootjs/rust": patch
+"@barefootjs/mojolicious": patch
+---
+
+Fix #2221: every Twig-family adapter's `_resolveLiteralConst` (Mojolicious: `resolveLiteralConst`) is a flat name lookup against `ir.metadata.localConstants` with no notion of AST scope — it inlined an outer same-file const's literal value even at an occurrence that is actually an enclosing `.map()`/`.filter()` loop callback's own (shadowing) parameter of the same name, so every iteration rendered the same hard-coded literal instead of the per-item value. Twig, Jinja, Blade, Xslate, and Rust (minijinja) are guarded with the same coarse `collectLoopBoundNames` exclusion #2212 already established for `collectStringValueNames`: a name any loop binds anywhere in the component never inlines, falling back to the bare identifier — coarse (a genuinely non-shadowed same-named const elsewhere in the component also stops inlining) but safe.
+
+Mojolicious's own `resolveLiteralConst` / `resolveStaticRecordLiteral` were already immune — they consult a *live*, ref-counted `loopBoundNames` map that `renderLoop` populates/depopulates as it descends/ascends into each loop body (#1749), which is scope-precise rather than coarse, so no change was needed there. The actual gap found in that adapter was a sibling call site: `emitSpread`'s bare-identifier local-const resolution (`{...attrs}` forwarding a function-scope conditional-object const's hashref, #checkbox/icon) read `localConstants` directly with no loop-shadowing guard at all. Fixed with the same `loopBoundNames` guard as its neighboring call sites.
+
+Not fixed here (reported, tracked separately): a `key={name}` (or any bare-identifier JSX attribute value) shadowed by an enclosing loop param of the same name is folded to the OUTER const's literal at IR-generation time (`tryResolveIdentifierAsTemplateLiteral` → `findLocalConst` in `packages/jsx/src/jsx-to-ir.ts`), before any adapter runs — this affects every adapter, including Hono's native JSX re-emission, and needs a shared-compiler fix rather than a per-adapter guard. The Go template adapter has its own independent instance of this issue's bug class in `convertExpressionToGo`'s bare-identifier fast path (`packages/adapter-go-template/src/adapter/go-template-adapter.ts`), which lacks the loop-shadowing guards its sibling `resolveModuleStringConst`/`resolveModuleNumericConst` already have. The Twig-family's `_resolveStaticRecordLiteral` / `lookupStaticRecordLiteral` (module-scope object-literal consts, e.g. `variantClasses.ghost`) have the identical unguarded flat-lookup hazard when the object name itself is loop-bound (confirmed reproducible on Twig). None of these are fixed in this patch.

--- a/packages/adapter-blade/src/__tests__/blade-adapter-unit.test.ts
+++ b/packages/adapter-blade/src/__tests__/blade-adapter-unit.test.ts
@@ -406,6 +406,71 @@ export function Parent() {
   })
 })
 
+// #2221: `_resolveLiteralConst` is a flat name lookup against
+// `ir.metadata.localConstants` with no notion of AST scope — it used to
+// substitute an outer const's literal value even at an occurrence that is
+// actually an enclosing loop callback's own (shadowing) parameter, so every
+// iteration rendered the same hard-coded literal. Guarded with the same
+// coarse `collectLoopBoundNames` exclusion as #2212: any name a loop binds
+// anywhere in the component never inlines, falling back to the bare
+// identifier.
+describe('BladeAdapter - const inlining vs loop-param shadowing (#2221)', () => {
+  test('a loop param shadowing an outer literal const emits the identifier, not the const value', () => {
+    const { template } = compileAndGenerate(`
+function Widget() {
+  const label: string = 'x'
+  return <ul>{[2, 5].map((label) => <li key={label}>{1 + label}</li>)}</ul>
+}
+`)
+    // The loop body must reference the per-iteration loop var...
+    expect(template).toContain('1 + $label')
+    // ...never the outer const's hard-coded value.
+    expect(template).not.toContain("1 + 'x'")
+  })
+
+  test('a numeric const shadowed by a loop param emits the identifier too', () => {
+    const { template } = compileAndGenerate(`
+function Widget() {
+  const count = 7
+  return <ul>{[2, 5].map((count) => <li key={count}>{1 + count}</li>)}</ul>
+}
+`)
+    expect(template).toContain('1 + $count')
+    expect(template).not.toContain('1 + 7')
+  })
+
+  test('a literal const NOT shadowed by any loop still inlines (#1897 pin)', () => {
+    const { template } = compileAndGenerate(`
+function Widget({ values }: { values: number[] }) {
+  const totalPages = 5
+  return <div>
+    <p>Page 1 of {1 + totalPages}</p>
+    <ul>{values.map((v) => <li key={v}>{v}</li>)}</ul>
+  </div>
+}
+`)
+    expect(template).toContain('1 + 5')
+  })
+
+  // The accepted coarse-exclusion trade-off (same as #2212): a name that is
+  // loop-bound ANYWHERE in the component never inlines, even at a genuinely
+  // non-shadowed occurrence outside the loop — the bare identifier is
+  // emitted instead of the value.
+  test('a const referenced outside the loop whose name is loop-bound elsewhere falls back to the identifier (accepted trade-off)', () => {
+    const { template } = compileAndGenerate(`
+function Widget({ values }: { values: number[] }) {
+  const label: string = 'x'
+  return <div>
+    <p>{1 + label}</p>
+    <ul>{values.map((label) => <li key={label}>{2 + label}</li>)}</ul>
+  </div>
+}
+`)
+    expect(template).not.toContain("1 + 'x'")
+    expect(template).toContain('2 + $label')
+  })
+})
+
 // #2038 nested-callback-predicate loudness is pinned at the shared
 // conformance layer (workstream C): `filter-nested-callback-predicate` /
 // `filter-nested-find-predicate` (BF101 via `expectedDiagnostics`) and

--- a/packages/adapter-blade/src/adapter/blade-adapter.ts
+++ b/packages/adapter-blade/src/adapter/blade-adapter.ts
@@ -2003,8 +2003,19 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
    * single-quoted string literal (`const totalPages = 5`, #1897
    * pagination) — function-scope consts never reach the per-render
    * context, so a bare reference would resolve to an undefined variable.
+   *
+   * The lookup is a flat name match with no notion of AST scope, so a
+   * name that any loop callback binds as its item/index param never
+   * inlines (#2221) — the occurrence may be the loop's own (shadowing)
+   * binding, and substituting the outer const's value there renders every
+   * iteration with the same hard-coded literal. Coarse (a genuinely
+   * non-shadowed same-named const elsewhere in the component also stops
+   * inlining, falling back to the bare identifier) but safe — the same
+   * trade-off as #2212's `collectLoopBoundNames` use in
+   * `collectStringValueNames`.
    */
   private _resolveLiteralConst(name: string): string | null {
+    if (this.staticLoopSourceBoundNames.has(name)) return null
     const c = (this.localConstants ?? []).find(lc => lc.name === name)
     if (c?.value === undefined) return null
     const v = c.value.trim()

--- a/packages/adapter-jinja/src/__tests__/jinja-adapter-unit.test.ts
+++ b/packages/adapter-jinja/src/__tests__/jinja-adapter-unit.test.ts
@@ -409,3 +409,69 @@ export function Parent() {
 // `filter-nested-find-predicate` (BF101 via `expectedDiagnostics`) and
 // `filter-nested-callback-predicate-client` (the `/* @client */` suppression
 // twin, which must render clean).
+
+// #2221: `_resolveLiteralConst` is a flat name lookup against
+// `ir.metadata.localConstants` with no notion of AST scope — it used to
+// substitute an outer const's literal value even at an occurrence that is
+// actually an enclosing loop callback's own (shadowing) parameter, so every
+// iteration rendered the same hard-coded literal. Guarded with the same
+// coarse `collectLoopBoundNames` exclusion as #2212: any name a loop binds
+// anywhere in the component never inlines, falling back to the bare
+// identifier. SSR-only tests for the same #2222 reason as the #2212
+// describe below.
+describe('JinjaAdapter - const inlining vs loop-param shadowing (#2221)', () => {
+  test('a loop param shadowing an outer literal const emits the identifier, not the const value', () => {
+    const { template } = compileAndGenerate(`
+function Widget() {
+  const label: string = 'x'
+  return <ul>{[2, 5].map((label) => <li key={label}>{1 + label}</li>)}</ul>
+}
+`)
+    // The loop body must reference the per-iteration loop var...
+    expect(template).toContain('1 + label')
+    // ...never the outer const's hard-coded value.
+    expect(template).not.toContain("1 + 'x'")
+  })
+
+  test('a numeric const shadowed by a loop param emits the identifier too', () => {
+    const { template } = compileAndGenerate(`
+function Widget() {
+  const count = 7
+  return <ul>{[2, 5].map((count) => <li key={count}>{1 + count}</li>)}</ul>
+}
+`)
+    expect(template).toContain('1 + count')
+    expect(template).not.toContain('1 + 7')
+  })
+
+  test('a literal const NOT shadowed by any loop still inlines (#1897 pin)', () => {
+    const { template } = compileAndGenerate(`
+function Widget({ values }: { values: number[] }) {
+  const totalPages = 5
+  return <div>
+    <p>Page 1 of {1 + totalPages}</p>
+    <ul>{values.map((v) => <li key={v}>{v}</li>)}</ul>
+  </div>
+}
+`)
+    expect(template).toContain('1 + 5')
+  })
+
+  // The accepted coarse-exclusion trade-off (same as #2212): a name that is
+  // loop-bound ANYWHERE in the component never inlines, even at a genuinely
+  // non-shadowed occurrence outside the loop — the bare identifier is
+  // emitted instead of the value.
+  test('a const referenced outside the loop whose name is loop-bound elsewhere falls back to the identifier (accepted trade-off)', () => {
+    const { template } = compileAndGenerate(`
+function Widget({ values }: { values: number[] }) {
+  const label: string = 'x'
+  return <div>
+    <p>{1 + label}</p>
+    <ul>{values.map((label) => <li key={label}>{2 + label}</li>)}</ul>
+  </div>
+}
+`)
+    expect(template).not.toContain("1 + 'x'")
+    expect(template).toContain('2 + label')
+  })
+})

--- a/packages/adapter-jinja/src/adapter/jinja-adapter.ts
+++ b/packages/adapter-jinja/src/adapter/jinja-adapter.ts
@@ -1820,8 +1820,19 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
    * single-quoted string literal (`const totalPages = 5`, #1897
    * pagination) — function-scope consts never reach the per-render
    * context, so a bare reference would resolve to Undefined.
+   *
+   * The lookup is a flat name match with no notion of AST scope, so a
+   * name that any loop callback binds as its item/index param never
+   * inlines (#2221) — the occurrence may be the loop's own (shadowing)
+   * binding, and substituting the outer const's value there renders every
+   * iteration with the same hard-coded literal. Coarse (a genuinely
+   * non-shadowed same-named const elsewhere in the component also stops
+   * inlining, falling back to the bare identifier) but safe — the same
+   * trade-off as #2212's `collectLoopBoundNames` use in
+   * `collectStringValueNames`.
    */
   private _resolveLiteralConst(name: string): string | null {
+    if (this.staticLoopSourceBoundNames.has(name)) return null
     const c = (this.localConstants ?? []).find(lc => lc.name === name)
     if (c?.value === undefined) return null
     const v = c.value.trim()

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -195,6 +195,109 @@ function Box({ other }: { other?: object }) {
   })
 })
 
+// #2221: same class of hazard as the Twig-family `_resolveLiteralConst`
+// flat-lookup bug, but this adapter's story is different. `resolveLiteralConst`
+// / `resolveStaticRecordLiteral` (mojo-adapter.ts) already guard against it —
+// they consult `loopBoundNames`, a LIVE ref-counted map that
+// `renderLoop` populates/depopulates as it descends/ascends into each loop
+// body (#1749), not a static whole-component set like the Twig family's
+// `collectLoopBoundNames(ir)`. That makes the guard scope-PRECISE rather
+// than coarse: a name loop-bound only inside one loop still inlines fine
+// at a genuinely separate, non-shadowed occurrence elsewhere in the
+// component (see the third test below) — the Twig-family's documented
+// coarse trade-off (a same-named const anywhere else in the component also
+// stops inlining) does not apply here. So no `staticLoopSourceBoundNames`
+// field was added; the existing live tracking already covers this call
+// site and is strictly more precise.
+//
+// The ONE actual gap found: `emitSpread`'s bare-identifier local-const
+// spread resolution (mojo-adapter.ts, the `this.localConstants.find(...)`
+// call keyed by `trimmed`, `{...attrs}` → `{ … }` hashref, #checkbox/icon)
+// read `this.localConstants` directly with no `loopBoundNames` guard at
+// all — a loop param named the same as an outer conditional-object const
+// (`.map((attrs) => <li {...attrs} />)` shadowing `const attrs = cond ?
+// {…} : {}`) incorrectly forwarded the outer object's literal hashref
+// instead of falling through to the per-iteration `$attrs` value. Fixed
+// with the same `loopBoundNames` guard as the other two call sites.
+//
+// Not covered here (upstream, shared-compiler hazard, out of this
+// package's scope): `key={label}` shadowed by an enclosing loop param of
+// the same name is folded to the OUTER const's literal at IR-generation
+// time (`tryResolveIdentifierAsTemplateLiteral` → `findLocalConst` in
+// `packages/jsx/src/jsx-to-ir.ts`), before any adapter runs — so this
+// adapter (and every other adapter, including Hono's native JSX
+// re-emission) still renders a `key`/`data-key` value shadowed this way
+// as the outer literal, unconditionally, every iteration.
+describe('MojoAdapter - const inlining vs loop-param shadowing (#2221)', () => {
+  test('a loop param shadowing an outer literal const emits the identifier, not the const value', () => {
+    const { template } = compileAndGenerate(`
+function Widget() {
+  const label: string = 'x'
+  return <ul>{[2, 5].map((label) => <li key={label}>{1 + label}</li>)}</ul>
+}
+`)
+    expect(template).toContain('1 + $label')
+    expect(template).not.toContain("1 + 'x'")
+  })
+
+  test('a numeric const shadowed by a loop param emits the identifier too', () => {
+    const { template } = compileAndGenerate(`
+function Widget() {
+  const count = 7
+  return <ul>{[2, 5].map((count) => <li key={count}>{1 + count}</li>)}</ul>
+}
+`)
+    expect(template).toContain('1 + $count')
+    expect(template).not.toContain('1 + 7')
+  })
+
+  test('a literal const NOT shadowed by any loop still inlines (#1897 pin)', () => {
+    const { template } = compileAndGenerate(`
+function Widget({ values }: { values: number[] }) {
+  const totalPages = 5
+  return <div>
+    <p>Page 1 of {1 + totalPages}</p>
+    <ul>{values.map((v) => <li key={v}>{v}</li>)}</ul>
+  </div>
+}
+`)
+    expect(template).toContain('1 + 5')
+  })
+
+  // Unlike the Twig-family's coarse-but-safe `collectLoopBoundNames(ir)`
+  // exclusion, this adapter's LIVE `loopBoundNames` tracking is scoped to
+  // the actual render position: a name loop-bound ONLY inside the `.map`
+  // callback still inlines correctly at a separate, non-shadowed
+  // occurrence outside the loop — no accepted trade-off here.
+  test('a const referenced outside the loop whose name is loop-bound elsewhere still inlines (more precise than Twig family)', () => {
+    const { template } = compileAndGenerate(`
+function Widget({ values }: { values: number[] }) {
+  const label: string = 'x'
+  return <div>
+    <p>{1 + label}</p>
+    <ul>{values.map((label) => <li key={label}>{2 + label}</li>)}</ul>
+  </div>
+}
+`)
+    expect(template).toContain("1 + 'x'")
+    expect(template).toContain('2 + $label')
+  })
+
+  // The actual gap this issue found in this adapter: `emitSpread`'s
+  // bare-identifier local-const resolution (`{...attrs}` → the outer
+  // conditional object's hashref) had no `loopBoundNames` guard.
+  test('a loop param shadowing an outer conditional-object const spread emits the loop var, not the outer hashref', () => {
+    const { template } = compileAndGenerate(`
+function Widget({ items }: { items: object[] }) {
+  const attrs = true ? { 'data-on': 'outer' } : {}
+  return <ul>{items.map((attrs) => <li {...attrs} />)}</ul>
+}
+`)
+    expect(template).toContain('bf->spread_attrs($attrs)')
+    expect(template).not.toContain("'data-on' => 'outer'")
+  })
+})
+
 describe('MojoAdapter - Record<staticKeys,scalar>[propKey] spread value (#checkbox icon)', () => {
   // `const sizeMap: Record<IconSize, number> = { sm: 16, ... }` indexed by
   // a prop inside a conditional-spread object value lowers to an inline

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -421,6 +421,14 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
    * quoted string literal (`const totalPages = 5`, #1897 pagination) —
    * function-scope consts never reach the per-render stash, so a bare
    * `$totalPages` faults under strict mode.
+   *
+   * The `loopBoundNames` guard also covers the #2221 hazard (a loop
+   * callback's own param shadowing this outer const's name): unlike the
+   * Twig-family adapters' coarse, whole-component `collectLoopBoundNames(ir)`
+   * static set, this adapter's `loopBoundNames` is a LIVE ref-counted map
+   * `renderLoop` populates/depopulates as it descends/ascends into each
+   * loop body (#1749) — so it's already scope-precise for this call site;
+   * no separate `staticLoopSourceBoundNames`-style field is needed here.
    */
   private resolveLiteralConst(name: string): string | null {
     if (this.loopBoundNames?.has?.(name)) return null
@@ -1461,7 +1469,15 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       // initializer text and route through the same conditional-spread
       // lowering. Only function-scope (`!isModule`) consts whose value is
       // NOT itself a bare identifier (loop guard) are considered.
-      if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(trimmed)) {
+      //
+      // `loopBoundNames` guard (#2221): an enclosing `.map()` callback's
+      // own param can shadow this outer const's name (`.map((sizeAttrs)
+      // => <li {...sizeAttrs} />)`) — without the guard this forwarded
+      // the OUTER const's hashref at every iteration instead of the
+      // per-item `$sizeAttrs` value. Same live ref-counted map
+      // `resolveLiteralConst` / `resolveStaticRecordLiteral` already
+      // consult for this hazard class (#1749).
+      if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(trimmed) && !this.loopBoundNames.has(trimmed)) {
         const localConst = this.localConstants.find(
           c => c.name === trimmed && !c.isModule,
         )

--- a/packages/adapter-rust/src/__tests__/minijinja-adapter-unit.test.ts
+++ b/packages/adapter-rust/src/__tests__/minijinja-adapter-unit.test.ts
@@ -411,3 +411,68 @@ export function Parent() {
 // `filter-nested-find-predicate` (BF101 via `expectedDiagnostics`) and
 // `filter-nested-callback-predicate-client` (the `/* @client */` suppression
 // twin, which must render clean).
+
+// #2221: `_resolveLiteralConst` is a flat name lookup against
+// `ir.metadata.localConstants` with no notion of AST scope — it used to
+// substitute an outer const's literal value even at an occurrence that is
+// actually an enclosing loop callback's own (shadowing) parameter, so every
+// iteration rendered the same hard-coded literal. Guarded with the same
+// coarse `collectLoopBoundNames` exclusion as #2212: any name a loop binds
+// anywhere in the component never inlines, falling back to the bare
+// identifier.
+describe('MinijinjaAdapter - const inlining vs loop-param shadowing (#2221)', () => {
+  test('a loop param shadowing an outer literal const emits the identifier, not the const value', () => {
+    const { template } = compileAndGenerate(`
+function Widget() {
+  const label: string = 'x'
+  return <ul>{[2, 5].map((label) => <li key={label}>{1 + label}</li>)}</ul>
+}
+`)
+    // The loop body must reference the per-iteration loop var...
+    expect(template).toContain('1 + label')
+    // ...never the outer const's hard-coded value.
+    expect(template).not.toContain("1 + 'x'")
+  })
+
+  test('a numeric const shadowed by a loop param emits the identifier too', () => {
+    const { template } = compileAndGenerate(`
+function Widget() {
+  const count = 7
+  return <ul>{[2, 5].map((count) => <li key={count}>{1 + count}</li>)}</ul>
+}
+`)
+    expect(template).toContain('1 + count')
+    expect(template).not.toContain('1 + 7')
+  })
+
+  test('a literal const NOT shadowed by any loop still inlines (#1897 pin)', () => {
+    const { template } = compileAndGenerate(`
+function Widget({ values }: { values: number[] }) {
+  const totalPages = 5
+  return <div>
+    <p>Page 1 of {1 + totalPages}</p>
+    <ul>{values.map((v) => <li key={v}>{v}</li>)}</ul>
+  </div>
+}
+`)
+    expect(template).toContain('1 + 5')
+  })
+
+  // The accepted coarse-exclusion trade-off (same as #2212): a name that is
+  // loop-bound ANYWHERE in the component never inlines, even at a genuinely
+  // non-shadowed occurrence outside the loop — the bare identifier is
+  // emitted instead of the value.
+  test('a const referenced outside the loop whose name is loop-bound elsewhere falls back to the identifier (accepted trade-off)', () => {
+    const { template } = compileAndGenerate(`
+function Widget({ values }: { values: number[] }) {
+  const label: string = 'x'
+  return <div>
+    <p>{1 + label}</p>
+    <ul>{values.map((label) => <li key={label}>{2 + label}</li>)}</ul>
+  </div>
+}
+`)
+    expect(template).not.toContain("1 + 'x'")
+    expect(template).toContain('2 + label')
+  })
+})

--- a/packages/adapter-rust/src/adapter/minijinja-adapter.ts
+++ b/packages/adapter-rust/src/adapter/minijinja-adapter.ts
@@ -1875,8 +1875,19 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
    * single-quoted string literal (`const totalPages = 5`, #1897
    * pagination) — function-scope consts never reach the per-render
    * context, so a bare reference would resolve to Undefined.
+   *
+   * The lookup is a flat name match with no notion of AST scope, so a
+   * name that any loop callback binds as its item/index param never
+   * inlines (#2221) — the occurrence may be the loop's own (shadowing)
+   * binding, and substituting the outer const's value there renders every
+   * iteration with the same hard-coded literal. Coarse (a genuinely
+   * non-shadowed same-named const elsewhere in the component also stops
+   * inlining, falling back to the bare identifier) but safe — the same
+   * trade-off as #2212's `collectLoopBoundNames` use in
+   * `collectStringValueNames`.
    */
   private _resolveLiteralConst(name: string): string | null {
+    if (this.staticLoopSourceBoundNames.has(name)) return null
     const c = (this.localConstants ?? []).find(lc => lc.name === name)
     if (c?.value === undefined) return null
     const v = c.value.trim()

--- a/packages/adapter-twig/src/__tests__/twig-adapter-unit.test.ts
+++ b/packages/adapter-twig/src/__tests__/twig-adapter-unit.test.ts
@@ -408,6 +408,72 @@ export function Parent() {
 // `filter-nested-callback-predicate-client` (the `/* @client */` suppression
 // twin, which must render clean).
 
+// #2221: `_resolveLiteralConst` is a flat name lookup against
+// `ir.metadata.localConstants` with no notion of AST scope — it used to
+// substitute an outer const's literal value even at an occurrence that is
+// actually an enclosing loop callback's own (shadowing) parameter, so every
+// iteration rendered the same hard-coded literal. Guarded with the same
+// coarse `collectLoopBoundNames` exclusion as #2212: any name a loop binds
+// anywhere in the component never inlines, falling back to the bare
+// identifier. SSR-only tests for the same #2222 reason as the #2212
+// describe below.
+describe('TwigAdapter - const inlining vs loop-param shadowing (#2221)', () => {
+  test('a loop param shadowing an outer literal const emits the identifier, not the const value', () => {
+    const { template } = compileAndGenerate(`
+function Widget() {
+  const label: string = 'x'
+  return <ul>{[2, 5].map((label) => <li key={label}>{1 + label}</li>)}</ul>
+}
+`)
+    // The loop body must reference the per-iteration loop var...
+    expect(template).toContain('1 + label')
+    // ...never the outer const's hard-coded value.
+    expect(template).not.toContain("1 + 'x'")
+  })
+
+  test('a numeric const shadowed by a loop param emits the identifier too', () => {
+    const { template } = compileAndGenerate(`
+function Widget() {
+  const count = 7
+  return <ul>{[2, 5].map((count) => <li key={count}>{1 + count}</li>)}</ul>
+}
+`)
+    expect(template).toContain('1 + count')
+    expect(template).not.toContain('1 + 7')
+  })
+
+  test('a literal const NOT shadowed by any loop still inlines (#1897 pin)', () => {
+    const { template } = compileAndGenerate(`
+function Widget({ values }: { values: number[] }) {
+  const totalPages = 5
+  return <div>
+    <p>Page 1 of {1 + totalPages}</p>
+    <ul>{values.map((v) => <li key={v}>{v}</li>)}</ul>
+  </div>
+}
+`)
+    expect(template).toContain('1 + 5')
+  })
+
+  // The accepted coarse-exclusion trade-off (same as #2212): a name that is
+  // loop-bound ANYWHERE in the component never inlines, even at a genuinely
+  // non-shadowed occurrence outside the loop — the bare identifier is
+  // emitted instead of the value.
+  test('a const referenced outside the loop whose name is loop-bound elsewhere falls back to the identifier (accepted trade-off)', () => {
+    const { template } = compileAndGenerate(`
+function Widget({ values }: { values: number[] }) {
+  const label: string = 'x'
+  return <div>
+    <p>{1 + label}</p>
+    <ul>{values.map((label) => <li key={label}>{2 + label}</li>)}</ul>
+  </div>
+}
+`)
+    expect(template).not.toContain("1 + 'x'")
+    expect(template).toContain('2 + label')
+  })
+})
+
 // Fable review (#2212): a loop callback's own param can shadow an outer
 // string-typed prop/const of the same name — `collectLoopBoundNames`
 // excludes every such name from `collectStringValueNames` so the shadowed

--- a/packages/adapter-twig/src/adapter/twig-adapter.ts
+++ b/packages/adapter-twig/src/adapter/twig-adapter.ts
@@ -1873,8 +1873,19 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
    * single-quoted string literal (`const totalPages = 5`, #1897
    * pagination) — function-scope consts never reach the per-render
    * context, so a bare reference would resolve to Undefined.
+   *
+   * The lookup is a flat name match with no notion of AST scope, so a
+   * name that any loop callback binds as its item/index param never
+   * inlines (#2221) — the occurrence may be the loop's own (shadowing)
+   * binding, and substituting the outer const's value there renders every
+   * iteration with the same hard-coded literal. Coarse (a genuinely
+   * non-shadowed same-named const elsewhere in the component also stops
+   * inlining, falling back to the bare identifier) but safe — the same
+   * trade-off as #2212's `collectLoopBoundNames` use in
+   * `collectStringValueNames`.
    */
   private _resolveLiteralConst(name: string): string | null {
+    if (this.staticLoopSourceBoundNames.has(name)) return null
     const c = (this.localConstants ?? []).find(lc => lc.name === name)
     if (c?.value === undefined) return null
     const v = c.value.trim()

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -421,3 +421,68 @@ export function Parent() {
 // `filter-nested-find-predicate` (BF101 via `expectedDiagnostics` above) and
 // `filter-nested-callback-predicate-client` (the `/* @client */` suppression
 // twin, which must render clean).
+
+// #2221: `_resolveLiteralConst` is a flat name lookup against
+// `ir.metadata.localConstants` with no notion of AST scope — it used to
+// substitute an outer const's literal value even at an occurrence that is
+// actually an enclosing loop callback's own (shadowing) parameter, so every
+// iteration rendered the same hard-coded literal. Guarded with the same
+// coarse `collectLoopBoundNames` exclusion as #2212: any name a loop binds
+// anywhere in the component never inlines, falling back to the bare
+// identifier.
+describe('XslateAdapter - const inlining vs loop-param shadowing (#2221)', () => {
+  test('a loop param shadowing an outer literal const emits the identifier, not the const value', () => {
+    const { template } = compileAndGenerate(`
+function Widget() {
+  const label: string = 'x'
+  return <ul>{[2, 5].map((label) => <li key={label}>{1 + label}</li>)}</ul>
+}
+`)
+    // The loop body must reference the per-iteration loop var...
+    expect(template).toContain('1 + $label')
+    // ...never the outer const's hard-coded value.
+    expect(template).not.toContain("1 + 'x'")
+  })
+
+  test('a numeric const shadowed by a loop param emits the identifier too', () => {
+    const { template } = compileAndGenerate(`
+function Widget() {
+  const count = 7
+  return <ul>{[2, 5].map((count) => <li key={count}>{1 + count}</li>)}</ul>
+}
+`)
+    expect(template).toContain('1 + $count')
+    expect(template).not.toContain('1 + 7')
+  })
+
+  test('a literal const NOT shadowed by any loop still inlines (#1897 pin)', () => {
+    const { template } = compileAndGenerate(`
+function Widget({ values }: { values: number[] }) {
+  const totalPages = 5
+  return <div>
+    <p>Page 1 of {1 + totalPages}</p>
+    <ul>{values.map((v) => <li key={v}>{v}</li>)}</ul>
+  </div>
+}
+`)
+    expect(template).toContain('1 + 5')
+  })
+
+  // The accepted coarse-exclusion trade-off (same as #2212): a name that is
+  // loop-bound ANYWHERE in the component never inlines, even at a genuinely
+  // non-shadowed occurrence outside the loop — the bare identifier is
+  // emitted instead of the value.
+  test('a const referenced outside the loop whose name is loop-bound elsewhere falls back to the identifier (accepted trade-off)', () => {
+    const { template } = compileAndGenerate(`
+function Widget({ values }: { values: number[] }) {
+  const label: string = 'x'
+  return <div>
+    <p>{1 + label}</p>
+    <ul>{values.map((label) => <li key={label}>{2 + label}</li>)}</ul>
+  </div>
+}
+`)
+    expect(template).not.toContain("1 + 'x'")
+    expect(template).toContain('2 + $label')
+  })
+})

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -1744,8 +1744,19 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
    * single-quoted string literal (`const totalPages = 5`, #1897
    * pagination) — function-scope consts never reach the per-render
    * stash, so a bare `$totalPages` renders empty.
+   *
+   * The lookup is a flat name match with no notion of AST scope, so a
+   * name that any loop callback binds as its item/index param never
+   * inlines (#2221) — the occurrence may be the loop's own (shadowing)
+   * binding, and substituting the outer const's value there renders every
+   * iteration with the same hard-coded literal. Coarse (a genuinely
+   * non-shadowed same-named const elsewhere in the component also stops
+   * inlining, falling back to the bare identifier) but safe — the same
+   * trade-off as #2212's `collectLoopBoundNames` use in
+   * `collectStringValueNames`.
    */
   private _resolveLiteralConst(name: string): string | null {
+    if (this.staticLoopSourceBoundNames.has(name)) return null
     const c = (this.localConstants ?? []).find(lc => lc.name === name)
     if (c?.value === undefined) return null
     const v = c.value.trim()


### PR DESCRIPTION
Fixes #2221. First PR of a stacked series for #2221 → #2222 → #2224 → #2228.

## Problem

Every Twig-family adapter (Twig, Jinja, Blade, Xslate, minijinja/Rust, Mojolicious) inlines a same-file local const's literal value wherever the identifier is referenced, via a flat `_resolveLiteralConst(name)` lookup against `ir.metadata.localConstants` with no notion of AST scope. An occurrence that is actually shadowed by an enclosing `.map()`/`.filter()` callback's own parameter of the same name gets the outer const's hard-coded value substituted in — every iteration renders the same literal instead of the per-item value.

## Fix

Guard `_resolveLiteralConst` with the same coarse-but-safe `collectLoopBoundNames` exclusion already accepted for #2212: any name a loop callback binds anywhere in the component never inlines, falling back to the bare identifier — which the engine's own for-loop binding resolves correctly at the shadowed occurrences. Applied to Twig (reference), Jinja, Blade, Xslate, and Rust (minijinja), each with a 4-test describe verified red pre-guard (3 fail / 1 pass) and green post-guard.

**Mojolicious divergence**: its `resolveLiteralConst` / `resolveStaticRecordLiteral` were already immune — they consult a live, ref-counted `loopBoundNames` map that `renderLoop` maintains while descending loop bodies (#1749), which is scope-*precise* rather than coarse (pinned with a test: a name loop-bound only inside one loop still inlines outside it). The actual gap there was a sibling call site: `emitSpread`'s bare-identifier local-const resolution had no shadowing guard at all — fixed with the same `loopBoundNames` guard as its neighbors, plus a regression test.

Accepted trade-off (same as #2212, pinned by tests in the five coarse-guarded adapters): a genuinely non-shadowed same-named const elsewhere in the component also stops inlining. The other `_resolveLiteralConst` call site — the BF101 loop-array gate — is unaffected: array-valued consts never resolved there anyway.

## Same-class hazards confirmed during the sweep, tracked separately (not fixed here)

- #2235 — shared jsx-to-ir attribute fold (`key={name}` baked to the outer const's literal at IR time; affects every adapter incl. Hono)
- #2236 — Go `convertExpressionToGo` bare-identifier fast path (Go was explicitly out of #2221's scope)
- #2237 — Twig-family `_resolveStaticRecordLiteral` for module-scope object consts

## Tests

Per-adapter unit tests (4 each on the coarse-guarded five; 3 on Mojolicious incl. the scope-precision pin and the `emitSpread` regression). Full suites: twig 542 / jinja 532 / blade 532 / xslate 533 / rust 532 / mojolicious 698 pass, 0 fail (PHP/Perl render layers NotAvailable-skip in this sandbox as usual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxCtWVr3LBPEPsaK9b5kdD