### PR TITLE
Fix CSR codegen loop-param shadowing: template arrays + prop/const substitution (#2222)

### DIFF
--- a/.changeset/csr-loop-param-shadowing.md
+++ b/.changeset/csr-loop-param-shadowing.md
@@ -1,0 +1,16 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix #2222: fixes two bugs in the generated `hydrate(...)` `template:` lambda (a module-scope arrow, not a closure over `init`'s destructured locals).
+
+1. A `.map()` loop whose array source is a destructured prop threw `ReferenceError: <name> is not defined` in the CSR template — both the plain-`.map()` fallback and the simple-`filter().map()` path built `IRLoop.templateArray` from a bare `array =` assignment instead of going through `setArray`, so the `_p.`-rewritten form the chained paths already produce never made it into the template lambda.
+
+2. Inside a loop callback body, prop/const substitution was scope-blind: an outer destructured prop or an inlinable const's literal could get substituted at an occurrence that is actually the loop's own shadowing parameter (`values.map((label) => <li key={label}>{1 + label}</li>)` where `label` also names an outer prop or const). Fixed in three places, each scope-accurate rather than a coarse whole-component exclusion:
+   - `rewriteBarePropRefs` now filters prop names out of `ctx.loopParams` (the transform position's live loop-param set, including destructured binding names and the index param) before rewriting bare identifiers to `_p.<name>`.
+   - `generateCsrTemplateWithOpts`'s `loop` case now accumulates `loopBoundNames` per nesting level and filters them out of the child recursion's `csrEnv`, so an inlinable const / signal / memo never substitutes at a loop-shadowed occurrence.
+   - `tryResolveIdentifierAsTemplateLiteral` (the IR-level const-literal fold used for e.g. `key={label}`) now guards on `ctx.loopParams`, so a loop-shadowed identifier is never baked to the outer const's literal — this fold runs at IR build time, so the fix applies to every adapter, not just CSR.
+
+Adds the cross-adapter conformance fixture `loop-param-shadows-outer-name` (`packages/adapter-tests/fixtures/`), which #2212/#2222 previously could not add because CSR threw on this shape before either fix landed. It passes on every adapter except Go, which has its own, unrelated shadowing bug in `convertExpressionToGo`'s `+`-operator type resolution (tracked as #2236 and declared as a `renderDivergences` skip, not fixed here).
+
+Scope note: this is the loop-shadow slice of #2235 (whole-component const-shadowing on SSR adapters is #2221, already fixed) and does not touch #2236 (Go operator-type shadowing) or #2237 (record-literal shadowing), both still open.

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -17,6 +17,21 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
+  // `loop-param-shadows-outer-name` (#2212/#2221/#2222 cross-adapter
+  // fixture): `convertExpressionToGo` picks the `+` operator's Go helper
+  // (`bf_add` numeric vs `bf_concat_str` string) by looking up the
+  // identifier's declared TYPE — and for `1 + label` inside
+  // `.map((label) => ...)`, it resolves `label`'s type against the OUTER
+  // `label: string` prop the loop param shadows, instead of the loop's
+  // actual element type (`number`, from `values: number[]`). Emits
+  // `bf_concat_str` (`"1" + "1"` → `"11"`) instead of `bf_add`
+  // (`1 + 1` → `2`). Same bare-identifier/shadowing bug class as
+  // #2221/#2222, but in Go's SSR type-inference-for-operator-selection
+  // path (`convertExpressionToGo`), which those shared-compiler fixes
+  // don't touch. Tracked as its own known limitation — see
+  // https://github.com/piconic-ai/barefootjs/issues/2236.
+  'loop-param-shadows-outer-name':
+    'BF-2236: convertExpressionToGo resolves a loop-param-shadowed identifier\'s type against the shadowed OUTER binding when choosing the `+` operator helper, emitting bf_concat_str (string concat) instead of bf_add (numeric addition)',
   // `todo-app-ssr` no longer diverges (#2209). Two parts: (1) `.Todos`
   // (the loop's DATUM slice) is already seeded straight from the caller's
   // Input — the constructor derives it from `initialTodos`, and `[]Todo`

--- a/packages/adapter-tests/fixtures/__snapshots__/toggle-shared.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/toggle-shared.client.js
@@ -51,5 +51,5 @@ export function initToggle(__scope, _p = {}) {
 
 }
 
-hydrate('Toggle', { init: initToggle, template: (_p) => `<div class="settings-panel" style="padding: 16px; border: 1px solid #ddd; border-radius: 8px;" bf="s1"><h3 style="margin-top: 0;">Settings</h3><!--bf-loop:l0-->${toggleItems.map((item) => `${renderChild('ToggleItem__69f56292', {label: item.label, defaultOn: item.defaultOn}, item.label)}`).join('')}<!--bf-/loop:l0--></div>` })
+hydrate('Toggle', { init: initToggle, template: (_p) => `<div class="settings-panel" style="padding: 16px; border: 1px solid #ddd; border-radius: 8px;" bf="s1"><h3 style="margin-top: 0;">Settings</h3><!--bf-loop:l0-->${_p.toggleItems.map((item) => `${renderChild('ToggleItem__69f56292', {label: item.label, defaultOn: item.defaultOn}, item.label)}`).join('')}<!--bf-/loop:l0--></div>` })
 export function Toggle(_p, __bfKey) { return createComponent('Toggle', _p, __bfKey) }

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -361,6 +361,12 @@ import { fixture as multilineAttrValue } from './multiline-attr-value'
 import { fixture as stringSlice } from './methods/string-slice'
 import { fixture as stringReplaceAll } from './methods/string-replaceall'
 import { fixture as stringTrimSided } from './methods/string-trim-sided'
+// #2212/#2221/#2222: cross-adapter conformance for a `.map()` callback
+// param shadowing an outer destructured prop, with the loop's array
+// source itself a destructured prop — couldn't be added until both the
+// CSR `setArray` fallback fix (#2222 bug 1) and the scope-accurate
+// prop/const shadowing fixes (#2221, #2222 bug 2) landed.
+import { fixture as loopParamShadowsOuterName } from './loop-param-shadows-outer-name'
 
 import type { JSXFixture } from '../src/types'
 
@@ -632,4 +638,5 @@ export const jsxFixtures: JSXFixture[] = [
   stringSlice,
   stringReplaceAll,
   stringTrimSided,
+  loopParamShadowsOuterName,
 ]

--- a/packages/adapter-tests/fixtures/loop-param-shadows-outer-name.ts
+++ b/packages/adapter-tests/fixtures/loop-param-shadows-outer-name.ts
@@ -1,0 +1,60 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A `.map()` callback param shadowing an outer destructured prop, where the
+ * loop's array source is ITSELF a destructured prop (#2222; the const-shadow
+ * half of the same bug class is #2221). Before the fix this combined shape
+ * was untestable in this harness at all: the plain-`.map()` fallback skipped
+ * `setArray`, so the hydrate `template:` lambda referenced the bare
+ * destructured `values` and threw `ReferenceError: values is not defined`
+ * before hydration ever reached the shadowing bug — see #2212's "Discovery
+ * context" for why this fixture couldn't be added until both landed. Now
+ * that all three fixes are in place, this fixture pins:
+ *
+ *   - bug 1: `values.map(...)` (the plain fallback, not a chained
+ *     `filter().map()`) lowers to `_p.values.map(...)` in the CSR
+ *     template, not a bare `values.map(...)`.
+ *   - bug 2 (prop-shadow half of #2235): the callback param `label`
+ *     shadows the outer destructured `label` prop. Outside the loop,
+ *     `<p>{label + suffix}</p>` keeps BOTH the `_p.label` prop rewrite AND
+ *     the `suffix` const inline. Inside the loop, `key={label}` and
+ *     `{1 + label}` use the loop's own bound value at each index — never
+ *     `_p.label`, and never baked to a stale outer value.
+ *
+ * Props are non-empty (`label`, `values`) so SSR renders real prop-driven
+ * text/markup and the CSR template evaluates the loop body against real
+ * data, not just `[]`.
+ */
+export const fixture = createFixture({
+  id: 'loop-param-shadows-outer-name',
+  description: '.map() callback param shadows an outer destructured prop, with the array itself sourced from a destructured prop (#2212, #2221, #2222)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function LoopParamShadowsOuterName({ label, values }: { label: string; values: number[] }) {
+  const suffix = '!'
+  const [n, setN] = createSignal(0)
+  return (
+    <div data-n={n()} onClick={() => setN(n() + 1)}>
+      <p>{label + suffix}</p>
+      <ul>
+        {values.map((label) => (
+          <li key={label}>{1 + label}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+`,
+  props: { label: 'Item', values: [1, 2, 3] },
+  expectedHtml: `
+    <div bf-s="test" bf="s5" data-n="0">
+      <p bf="s1"><!--bf:s0-->Item!<!--/--></p>
+      <ul bf="s4">
+        <li bf="s3" data-key="1"><!--bf:s2-->2<!--/--></li>
+        <li bf="s3" data-key="2"><!--bf:s2-->3<!--/--></li>
+        <li bf="s3" data-key="3"><!--bf:s2-->4<!--/--></li>
+      </ul>
+    </div>
+  `,
+})

--- a/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
+++ b/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
@@ -5548,3 +5548,4 @@ export function initCounter(__scope, _p = {}) {
 hydrate('Counter', { init: initCounter, template: (_p) => \`<button bf="s1"> Count: <!--bf:s0-->\${escapeText((0))}<!--/--></button>\` })
 export function Counter(_p, __bfKey) { return createComponent('Counter', _p, __bfKey) }"
 `;
+`;

--- a/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
+++ b/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
@@ -4703,7 +4703,7 @@ export function initTodoList(__scope, _p = {}) {
 
 }
 
-hydrate('TodoList', { init: initTodoList, template: (_p) => \`<ul bf="s1"><!--bf-loop:l0-->\${items.map((item) => \`\${renderChild('TodoItem', {}, item.id)}\`).join('')}<!--bf-/loop:l0--></ul>\` })
+hydrate('TodoList', { init: initTodoList, template: (_p) => \`<ul bf="s1"><!--bf-loop:l0-->\${_p.items.map((item) => \`\${renderChild('TodoItem', {}, item.id)}\`).join('')}<!--bf-/loop:l0--></ul>\` })
 export function TodoList(_p, __bfKey) { return createComponent('TodoList', _p, __bfKey) }"
 `;
 
@@ -5547,5 +5547,4 @@ export function initCounter(__scope, _p = {}) {
 
 hydrate('Counter', { init: initCounter, template: (_p) => \`<button bf="s1"> Count: <!--bf:s0-->\${escapeText((0))}<!--/--></button>\` })
 export function Counter(_p, __bfKey) { return createComponent('Counter', _p, __bfKey) }"
-`;
 `;

--- a/packages/jsx/src/__tests__/csr-template-loop-shadowing.test.ts
+++ b/packages/jsx/src/__tests__/csr-template-loop-shadowing.test.ts
@@ -166,6 +166,32 @@ describe('hydrate template: loop param shadowing an outer name (#2222 bug 2)', (
     expect(tpl).not.toContain('1 + _p.name')
   })
 
+  test('a Unicode loop param shadowing a const is still guarded (#2238 Copilot review)', () => {
+    const tpl = templateLambda(clientJsFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Widget6({ values }: { values: number[] }) {
+        const \u03c0: string = 'x'
+        const [n, setN] = createSignal(0)
+        return (
+          <div data-n={n()} onClick={() => setN(n() + 1)}>
+            <p>{\u03c0}</p>
+            <ul>
+              {values.map((\u03c0) => (
+                <li key={\u03c0}>{1 + \u03c0}</li>
+              ))}
+            </ul>
+          </div>
+        )
+      }
+    `))
+
+    // The Unicode param must be recognised as a bare identifier (not a
+    // destructure pattern), so the const never substitutes in the body.
+    expect(tpl).toContain('1 + \u03c0')
+    expect(tpl).not.toContain("1 + ('x')")
+  })
+
   test('a non-shadowing prop used inside the loop still rewrites to _p.<name>', () => {
     const tpl = templateLambda(clientJsFor(`
       'use client'

--- a/packages/jsx/src/__tests__/csr-template-loop-shadowing.test.ts
+++ b/packages/jsx/src/__tests__/csr-template-loop-shadowing.test.ts
@@ -1,0 +1,188 @@
+/**
+ * CSR/client-JS codegen vs loop-param shadowing (#2222).
+ *
+ * Two related bugs in the `hydrate(...)` `template:` lambda (a
+ * module-scope arrow, sibling to `initXxx` — NOT a closure over init's
+ * destructured locals):
+ *
+ * 1. When the loop's array source is a destructured prop, the lambda
+ *    referenced the bare destructured name (`values.map(...)`) instead of
+ *    `_p.values` — `ReferenceError: values is not defined` at runtime.
+ *    Root cause: `transformMapCall`'s plain-`.map()` fallback and the
+ *    simple-`filter().map()` path bypassed `setArray`, so
+ *    `IRLoop.templateArray` (the `_p.`-rewritten form the chained paths
+ *    already produce) stayed `undefined`.
+ *
+ * 2. Inside a loop callback body in that same lambda, prop/const
+ *    substitution was scope-blind: an outer destructured prop
+ *    (`_p.label`) or an inlinable const's literal got substituted at an
+ *    occurrence that is actually the loop's own shadowing parameter.
+ *    Same bug class as #2221, different code paths:
+ *      - prop-shadow: `rewriteBarePropRefs` (IR build) collected prop
+ *        refs from the expression node alone, never seeing the enclosing
+ *        loop binding. Fixed scope-accurately via `ctx.loopParams` — the
+ *        transform position's live loop-param set (includes destructured
+ *        binding names and the index param).
+ *      - const-shadow: `irToComponentTemplateWithOpts`'s `transformExpr`
+ *        regex-inlined `inlinableConstants` across the whole expression
+ *        text. Fixed by threading the enclosing loops' bound names
+ *        through `TemplateOptions` and skipping those names.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function clientJsFor(source: string): string {
+  const result = compileJSX(source, 'Repro.tsx', { adapter })
+  expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+  const clientJs = result.files.find(f => f.type === 'clientJs')
+  expect(clientJs).toBeDefined()
+  return clientJs!.content
+}
+
+function templateLambda(content: string): string {
+  const line = content.split('\n').find(l => l.includes('hydrate('))
+  expect(line).toBeDefined()
+  return line!
+}
+
+describe('hydrate template: destructured-prop loop array source (#2222 bug 1)', () => {
+  test('plain .map() over a destructured prop references _p.<name>', () => {
+    const tpl = templateLambda(clientJsFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Widget({ values }: { values: number[] }) {
+        const [n, setN] = createSignal(0)
+        return (
+          <ul data-n={n()} onClick={() => setN(n() + 1)}>
+            {values.map((v) => (
+              <li key={v}>{v * 2}</li>
+            ))}
+          </ul>
+        )
+      }
+    `))
+
+    expect(tpl).toContain('_p.values.map((v)')
+    expect(tpl).not.toContain('{values.map')
+  })
+
+  test('simple filter().map() over a destructured prop references _p.<name>', () => {
+    const tpl = templateLambda(clientJsFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Widget({ values }: { values: number[] }) {
+        const [n, setN] = createSignal(0)
+        return (
+          <ul data-n={n()} onClick={() => setN(n() + 1)}>
+            {values.filter((v) => v > 0).map((v) => (
+              <li key={v}>{v * 2}</li>
+            ))}
+          </ul>
+        )
+      }
+    `))
+
+    expect(tpl).toContain('_p.values')
+    expect(tpl).not.toMatch(/[^.]\bvalues\.filter/)
+  })
+})
+
+describe('hydrate template: loop param shadowing an outer name (#2222 bug 2)', () => {
+  test('prop-shadow: the loop body uses the param, not _p.<name>; outside the loop keeps _p.<name>', () => {
+    const tpl = templateLambda(clientJsFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Widget2({ label, values }: { label: string; values: number[] }) {
+        const [n, setN] = createSignal(0)
+        return (
+          <div data-n={n()} onClick={() => setN(n() + 1)}>
+            <p>{label}</p>
+            <ul>
+              {values.map((label) => (
+                <li key={label}>{1 + label}</li>
+              ))}
+            </ul>
+          </div>
+        )
+      }
+    `))
+
+    // Outside the loop: the prop rewrite applies.
+    expect(tpl).toContain('escapeText(_p.label)')
+    // Inside the loop: the shadowing param must survive untouched.
+    expect(tpl).toContain('escapeText(1 + label)')
+    expect(tpl).not.toContain('1 + _p.label')
+    expect(tpl).not.toContain('data-key="${_p.label}"')
+  })
+
+  test('const-shadow: the loop body uses the param, not the inlined literal; outside the loop keeps the inline', () => {
+    const tpl = templateLambda(clientJsFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Widget3({ values }: { values: number[] }) {
+        const label: string = 'x'
+        const [n, setN] = createSignal(0)
+        return (
+          <div data-n={n()} onClick={() => setN(n() + 1)}>
+            <p>{label}</p>
+            <ul>
+              {values.map((label) => (
+                <li key={label}>{1 + label}</li>
+              ))}
+            </ul>
+          </div>
+        )
+      }
+    `))
+
+    // Outside the loop: const inlining still applies.
+    expect(tpl).toContain("${('x')}")
+    // Inside the loop: the shadowing param must survive untouched.
+    expect(tpl).toContain('escapeText(1 + label)')
+    expect(tpl).not.toContain("1 + ('x')")
+    expect(tpl).not.toContain('data-key="${`x`}"')
+  })
+
+  test('destructured loop param shadowing a prop is guarded via paramBindings names', () => {
+    const tpl = templateLambda(clientJsFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Widget4({ name, rows }: { name: string; rows: { name: number }[] }) {
+        const [n, setN] = createSignal(0)
+        return (
+          <ul data-n={n()} onClick={() => setN(n() + 1)}>
+            {rows.map(({ name }) => (
+              <li key={name}>{1 + name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `))
+
+    expect(tpl).not.toContain('1 + _p.name')
+  })
+
+  test('a non-shadowing prop used inside the loop still rewrites to _p.<name>', () => {
+    const tpl = templateLambda(clientJsFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Widget5({ prefix, values }: { prefix: string; values: number[] }) {
+        const [n, setN] = createSignal(0)
+        return (
+          <ul data-n={n()} onClick={() => setN(n() + 1)}>
+            {values.map((v) => (
+              <li key={v}>{prefix + v}</li>
+            ))}
+          </ul>
+        )
+      }
+    `))
+
+    // A prop NOT shadowed by the loop param keeps its rewrite inside the body.
+    expect(tpl).toContain('_p.prefix + v')
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -1325,6 +1325,20 @@ export interface TemplateOptions {
   csrEnv?: CsrEnv
   insideLoop?: boolean
   loopDepth?: number
+  /**
+   * Names bound by the ENCLOSING loops' callback params (item / index /
+   * destructured binding names), accumulated by the `loop` case as the
+   * recursion descends (#2222). Inside a loop body, `csrSubstitute`
+   * receives each expression in isolation — no enclosing arrow text — so
+   * its own bound-name tracking can't see the loop binding; the `loop`
+   * case instead filters these names out of the child recursion's
+   * `csrEnv`, so an inlinable const / signal / memo whose name is
+   * shadowed by a loop param never substitutes at the shadowed
+   * occurrence. Scope-accurate per nesting level (the CURRENT level's
+   * own `transformExpr` — e.g. the loop's array-source expression —
+   * keeps the unfiltered env).
+   */
+  loopBoundNames?: ReadonlySet<string>
   /** Emit `bf-s` placeholder on scoped elements inside a jsx-children prop (#1320). */
   inHoistedChildren?: boolean
   /**
@@ -2178,7 +2192,33 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
     }
 
     case 'loop': {
-      let childTemplate = node.children.map(recurseInLoop).join('')
+      // Accumulate this loop's callback-bound names and filter them out
+      // of the child recursion's substitution env (#2222): an inlinable
+      // const / signal / memo whose name the callback shadows must never
+      // substitute inside the body. Destructured callbacks contribute
+      // their individual binding names; a raw pattern-text `param` that
+      // isn't a bare identifier (the BF025 fallback shapes) contributes
+      // nothing — conservatively unfiltered rather than mis-filtered.
+      const boundHere = new Set(opts.loopBoundNames ?? [])
+      if (node.paramBindings && node.paramBindings.length > 0) {
+        for (const b of node.paramBindings) boundHere.add(b.name)
+      } else if (/^[A-Za-z_$][\w$]*$/.test(node.param)) {
+        boundHere.add(node.param)
+      }
+      if (node.index) boundHere.add(node.index)
+      const childEnv: CsrEnv = {
+        ...env,
+        substitutions: new Map([...env.substitutions].filter(([name]) => !boundHere.has(name))),
+      }
+      const recurseInLoopBody = (n: IRNode): string => generateCsrTemplateWithOpts(n, {
+        ...opts,
+        insideLoop: true,
+        loopDepth: loopDepth + 1,
+        inHoistedChildren: false,
+        loopBoundNames: boundHere,
+        csrEnv: childEnv,
+      })
+      let childTemplate = node.children.map(recurseInLoopBody).join('')
       // Whole-item conditional loops (#1665): prepend the per-item
       // `<!--bf-loop-i:KEY-->` anchor so `mapArrayAnchored` can track items
       // that render no element. Mirrors the `irToHtmlTemplate` loop case.
@@ -2212,7 +2252,7 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
       if (node.flatMapCallback) {
         let body = node.flatMapCallback.templateBody ?? node.flatMapCallback.body
         for (const frag of node.flatMapCallback.fragments) {
-          const renderedIr = recurseInLoop(frag.ir)
+          const renderedIr = recurseInLoopBody(frag.ir)
           body = body.replace(frag.placeholder, `\`${renderedIr}\``)
         }
         body = applyPropsRewrite(body, propsObjectName ?? null)

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -2196,13 +2196,16 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
       // of the child recursion's substitution env (#2222): an inlinable
       // const / signal / memo whose name the callback shadows must never
       // substitute inside the body. Destructured callbacks contribute
-      // their individual binding names; a raw pattern-text `param` that
-      // isn't a bare identifier (the BF025 fallback shapes) contributes
-      // nothing — conservatively unfiltered rather than mis-filtered.
+      // their individual binding names; a raw pattern-text `param` (the
+      // BF025 fallback shapes, detected by the same leading-`[`/`{` check
+      // `destructureLoopParam` uses — NOT an ASCII-identifier regex, which
+      // would drop Unicode param names like `π` and re-enable the shadow
+      // bug for that body) contributes nothing — conservatively
+      // unfiltered rather than mis-filtered.
       const boundHere = new Set(opts.loopBoundNames ?? [])
       if (node.paramBindings && node.paramBindings.length > 0) {
         for (const b of node.paramBindings) boundHere.add(b.name)
-      } else if (/^[A-Za-z_$][\w$]*$/.test(node.param)) {
+      } else if (!node.param.startsWith('[') && !node.param.startsWith('{')) {
         boundHere.add(node.param)
       }
       if (node.index) boundHere.add(node.index)

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -291,8 +291,21 @@ function exprHasFunctionCalls(expr: ts.Expression): boolean {
  * Returns undefined if no rewriting is needed (SolidJS-style or no props).
  */
 function rewriteBarePropRefs(text: string, expr: ts.Node, ctx: TransformContext): string | undefined {
-  const propNames = getDestructuredPropNames(ctx)
+  let propNames = getDestructuredPropNames(ctx)
   if (!propNames) return undefined
+  // #2222: a name bound as an enclosing loop callback's item/index param
+  // refers to the loop binding, not the prop, at THIS transform position —
+  // `ctx.loopParams` is the live loop-param set (destructured binding
+  // names and the index included), maintained by `transformMapCall` as it
+  // enters/leaves each callback, so this guard is scope-accurate rather
+  // than the coarse whole-component exclusion the SSR adapters use
+  // (#2221). Filter into a fresh set — `getDestructuredPropNames` caches
+  // its set on ctx and must not be mutated.
+  if (ctx.loopParams.size > 0) {
+    const filtered = new Set([...propNames].filter(n => !ctx.loopParams.has(n)))
+    if (filtered.size === 0) return undefined
+    propNames = filtered
+  }
   // #1425: union any prop refs that `expr` reaches via branch-local
   // text substitution. The AST walk in `rewriteBarePropRefsCore`
   // sees only `expr`'s original AST, so a prop ref introduced via
@@ -3634,14 +3647,19 @@ function transformMapCall(
           setArray(innerSort.array)
         }
       } else {
-        // Simple filter().map()
-        array = ctx.getJS(filterInfo.array)
-        arrayExpr = filterInfo.array
+        // Simple filter().map(). `setArray` (not a bare `array =`
+        // assignment) so `templateArray` carries the `_p.`-rewritten form —
+        // the module-scope `template:` lambda can't see init's destructured
+        // prop locals, and a bare destructured name there threw
+        // `ReferenceError` at runtime (#2222).
+        setArray(filterInfo.array)
       }
     }
   } else {
-    array = ctx.getJS(chainSource)
-    arrayExpr = chainSource
+    // Plain `.map()` fallback — same `setArray` requirement as above
+    // (#2222): this is the most common loop shape and was the primary
+    // repro for the bare-destructured-name ReferenceError.
+    setArray(chainSource)
   }
 
   // Get callback function
@@ -4778,6 +4796,14 @@ function tryResolveIdentifierAsTemplateLiteral(
   ident: ts.Identifier,
   ctx: TransformContext,
 ): IRTemplatePart[] | null {
+  // #2222/#2235: at this transform position the identifier may be an
+  // enclosing loop callback's own (shadowing) parameter — folding the
+  // outer const's literal into the IR here bakes the same hard-coded
+  // value into EVERY adapter's output (e.g. `key={label}` inside
+  // `.map((label) => ...)` becoming a constant duplicate key).
+  // `ctx.loopParams` is the live loop-param set (destructured binding
+  // names and index included), so the guard is scope-accurate.
+  if (ctx.loopParams.has(ident.text)) return null
   const constInfo = findLocalConst(ident.text, ctx.analyzer)
   if (!constInfo) return null
   const ast = parseConstInitializer(constInfo)

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 243,
+    "totalFixtures": 244,
     "fixtures": {
       "dangerous-inner-html-dynamic": {
         "blade": {
@@ -2018,6 +2018,12 @@
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2038"
           ]
+        }
+      },
+      "loop-param-shadows-outer-name": {
+        "go-template": {
+          "kind": "render",
+          "reason": "BF-2236: convertExpressionToGo resolves a loop-param-shadowed identifier's type against the shadowed OUTER binding when choosing the `+` operator helper, emitting bf_concat_str (string concat) instead of bf_add (numeric addition)"
         }
       },
       "static-array-from-props": {


### PR DESCRIPTION
Fixes #2222. Second PR of the stacked series #2221 (#2234) → **#2222** → #2224 → #2228. **Base is the #2234 branch** — merge that first; this diff shows only the #2222 work.

## Problem

Two related bugs in `ir-to-client-js` CSR codegen for components where a `.map()`/`.filter()` callback param shadows (or just coexists near) an outer destructured prop or const:

1. **Bare destructured name in the hydrate `template:` lambda**: the lambda is a module-scope arrow, not a closure over `initXxx`'s destructured locals — when the loop source array is a destructured prop it referenced the bare name (`values.map(...)`) → `ReferenceError: values is not defined` at runtime.
2. **Scope-blind prop/const substitution inside loop callback bodies** in that same lambda: an outer prop (`_p.label`) or an inlinable const's literal got substituted at an occurrence that is actually the loop's own shadowing parameter. Same bug class as #2221, different code paths.

## Fix

1. `transformMapCall`'s plain-`.map()` fallback and simple-`filter().map()` path bypassed `setArray`, leaving `IRLoop.templateArray` (the `_p.`-rewritten form the chained sort/filter paths always produced) undefined. Both now go through `setArray`.
2. `rewriteBarePropRefs` now filters out names in `ctx.loopParams` — the transform position's **live** loop-param set (destructured binding names and index included) — so the guard is scope-accurate, unlike the coarse whole-component exclusion the SSR adapters use (#2221/#2234).
3. `generateCsrTemplateWithOpts`'s `loop` case accumulates `loopBoundNames` per nesting level and filters them out of the child recursion's `csrEnv`, so inlinable consts / signals / memos never substitute at a loop-shadowed occurrence (`csrSubstitute` sees each expression in isolation and can't know the enclosing binding). The current level's own expressions — e.g. the loop's array source — keep the unfiltered env.
4. **Bonus (the loop-shadow slice of #2235)**: `tryResolveIdentifierAsTemplateLiteral` now guards on `ctx.loopParams`, so the IR-level attribute fold no longer bakes `key={label}`'s outer-const literal into the IR for every adapter (constant duplicate keys, including on Hono).

## Tests

- `packages/jsx/src/__tests__/csr-template-loop-shadowing.test.ts` — 6 tests (verified red pre-fix: 5 fail / 1 pass): both bypassed array paths, prop-shadow, const-shadow, destructured-param shadow, non-shadowing control.
- `packages/adapter-tests/fixtures/loop-param-shadows-outer-name.ts` — the cross-adapter fixture #2212/#2222 explicitly could not add before (Hono/CSR was broken for these shapes independent of adapter changes).
- CSR conformance + Hono: 785 pass, 0 fail. Full `packages/jsx` suite green.

## Untouched (tracked separately)

Non-loop-shadow slices of #2235; Go's #2236; Twig-family record-literal #2237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxCtWVr3LBPEPsaK9b5kdD

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxCtWVr3LBPEPsaK9b5kdD)_