### PR TITLE
Guard record-literal member lookup against loop-param shadowing (#2237)

### DIFF
--- a/.changeset/record-literal-loop-shadowing.md
+++ b/.changeset/record-literal-loop-shadowing.md
@@ -1,0 +1,11 @@
+---
+"@barefootjs/twig": patch
+"@barefootjs/jinja": patch
+"@barefootjs/blade": patch
+"@barefootjs/xslate": patch
+"@barefootjs/rust": patch
+---
+
+Fix #2237: every Twig-family adapter's `_resolveStaticRecordLiteral` (`IDENT.key` lookup on a module-scope object-literal const, e.g. `variantClasses.ghost` — #1896/#1897) is a flat name lookup on `objectName` against `ir.metadata.localConstants` with no notion of AST scope — the record-literal sibling of #2221's `_resolveLiteralConst` bug. It inlined an outer same-file const's member value even at an occurrence that is actually an enclosing `.map()`/`.filter()` loop callback's own (shadowing) parameter of the same name, so every iteration rendered the same hard-coded literal instead of the per-item value. Twig, Jinja, Blade, Xslate, and Rust (minijinja) are guarded with the same coarse `staticLoopSourceBoundNames` exclusion #2221 already established for `_resolveLiteralConst`: an object name any loop binds anywhere in the component never inlines its member lookups, falling back to the bare member expression — coarse (a genuinely non-shadowed same-named const elsewhere in the component also stops inlining) but safe.
+
+Mojolicious's `resolveStaticRecordLiteral` was already immune — flagged as such in the #2221 sweep and confirmed here with a compile repro plus a regression pin (no code change needed): it consults the same *live*, ref-counted `loopBoundNames` map that `resolveLiteralConst` and `renderLoop` already use (#1749), which is scope-precise rather than coarse, so a name loop-bound only inside one loop still inlines its member lookup correctly outside it.

--- a/packages/adapter-blade/src/__tests__/blade-adapter-unit.test.ts
+++ b/packages/adapter-blade/src/__tests__/blade-adapter-unit.test.ts
@@ -471,6 +471,61 @@ function Widget({ values }: { values: number[] }) {
   })
 })
 
+// #2237: `_resolveStaticRecordLiteral` (`IDENT.key` on a module-scope
+// object-literal const, e.g. `variantClasses.ghost` — #1896/#1897) is a
+// flat name lookup on `objectName` with no notion of AST scope, the
+// record-literal sibling of #2221's `_resolveLiteralConst` bug. It used to
+// substitute the outer const's member value even at an occurrence that is
+// actually an enclosing loop callback's own (shadowing) parameter, so every
+// iteration rendered the same hard-coded literal instead of the per-item
+// value. Guarded with the same coarse `staticLoopSourceBoundNames`
+// exclusion as #2221: any name a loop binds anywhere in the component
+// never inlines, falling back to the bare `data_get($cfg, 'x')` member
+// expression.
+describe('BladeAdapter - record-literal member lookup vs loop-param shadowing (#2237)', () => {
+  test('a loop param shadowing an outer module object const emits the member access, not the outer literal', () => {
+    const { template } = compileAndGenerate(`
+const cfg = { x: 'outer-lit' }
+function Widget({ rows }: { rows: number[] }) {
+  return <ul>{rows.map((cfg) => <li key={cfg.x}>{cfg.x}</li>)}</ul>
+}
+`)
+    // The loop body must reference the per-iteration member access...
+    expect(template).toContain("bf->string(data_get($cfg, 'x'))")
+    // ...never the outer const's hard-coded value.
+    expect(template).not.toContain("bf->string('outer-lit')")
+  })
+
+  test('a module object const NOT shadowed by any loop still inlines (variantClasses.ghost shape, #1896/#1897 pin)', () => {
+    const { template } = compileAndGenerate(`
+const variantClasses = { solid: 'bg-solid', ghost: 'bg-ghost' }
+function Widget({ variant }: { variant: 'solid' | 'ghost' }) {
+  return <div>{variantClasses.ghost}</div>
+}
+`)
+    expect(template).toContain("bf->string('bg-ghost')")
+  })
+
+  // The accepted coarse-exclusion trade-off (same as #2221/#2212): an
+  // object name that is loop-bound ANYWHERE in the component never
+  // inlines its member lookups, even at a genuinely non-shadowed
+  // occurrence outside the loop — the bare member expression is emitted
+  // instead of the value.
+  test('a record member referenced outside the loop whose object name is loop-bound elsewhere falls back to the member expression (accepted trade-off)', () => {
+    const { template } = compileAndGenerate(`
+const cfg = { x: 'outer-lit' }
+function Widget({ rows }: { rows: number[] }) {
+  return <div>
+    <p>{cfg.x}</p>
+    <ul>{rows.map((cfg) => <li key={cfg.x}>{cfg.x}</li>)}</ul>
+  </div>
+}
+`)
+    expect(template).not.toContain("bf->string('outer-lit')")
+    expect(template).toContain("bf->string(data_get($cfg, 'x'))")
+  })
+})
+
 // #2038 nested-callback-predicate loudness is pinned at the shared
 // conformance layer (workstream C): `filter-nested-callback-predicate` /
 // `filter-nested-find-predicate` (BF101 via `expectedDiagnostics`) and

--- a/packages/adapter-blade/src/__tests__/blade-adapter-unit.test.ts
+++ b/packages/adapter-blade/src/__tests__/blade-adapter-unit.test.ts
@@ -486,7 +486,7 @@ describe('BladeAdapter - record-literal member lookup vs loop-param shadowing (#
   test('a loop param shadowing an outer module object const emits the member access, not the outer literal', () => {
     const { template } = compileAndGenerate(`
 const cfg = { x: 'outer-lit' }
-function Widget({ rows }: { rows: number[] }) {
+function Widget({ rows }: { rows: { x: string }[] }) {
   return <ul>{rows.map((cfg) => <li key={cfg.x}>{cfg.x}</li>)}</ul>
 }
 `)
@@ -514,7 +514,7 @@ function Widget({ variant }: { variant: 'solid' | 'ghost' }) {
   test('a record member referenced outside the loop whose object name is loop-bound elsewhere falls back to the member expression (accepted trade-off)', () => {
     const { template } = compileAndGenerate(`
 const cfg = { x: 'outer-lit' }
-function Widget({ rows }: { rows: number[] }) {
+function Widget({ rows }: { rows: { x: string }[] }) {
   return <div>
     <p>{cfg.x}</p>
     <ul>{rows.map((cfg) => <li key={cfg.x}>{cfg.x}</li>)}</ul>

--- a/packages/adapter-blade/src/adapter/blade-adapter.ts
+++ b/packages/adapter-blade/src/adapter/blade-adapter.ts
@@ -2025,7 +2025,22 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
     return null
   }
 
+  /**
+   * Resolve `IDENT.key` where `IDENT` is a module-scope object-literal const
+   * (`variantClasses.ghost`, #1896/#1897) to the looked-up scalar.
+   *
+   * The lookup is a flat name match on `objectName` with no notion of AST
+   * scope, so an enclosing loop callback's own param of the same name
+   * (`.map((cfg) => <li>{cfg.x}</li>)` shadowing a module `const cfg = {…}`)
+   * still resolved to the OUTER const's member value at every iteration
+   * (#2237) — the sibling hazard to #2221's `_resolveLiteralConst`. Same
+   * coarse-but-safe `staticLoopSourceBoundNames` guard: any name a loop
+   * binds anywhere in the component never inlines, falling back to the bare
+   * `data_get($cfg, 'x')` member expression (which a Blade `@foreach`
+   * binds correctly at the shadowed occurrences).
+   */
   private _resolveStaticRecordLiteral(objectName: string, key: string): string | null {
+    if (this.staticLoopSourceBoundNames.has(objectName)) return null
     const hit = lookupStaticRecordLiteral(objectName, key, this.localConstants)
     if (!hit) return null
     return hit.kind === 'number'

--- a/packages/adapter-jinja/src/__tests__/jinja-adapter-unit.test.ts
+++ b/packages/adapter-jinja/src/__tests__/jinja-adapter-unit.test.ts
@@ -490,7 +490,7 @@ describe('JinjaAdapter - record-literal member lookup vs loop-param shadowing (#
   test('a loop param shadowing an outer module object const emits the member access, not the outer literal', () => {
     const { template } = compileAndGenerate(`
 const cfg = { x: 'outer-lit' }
-function Widget({ rows }: { rows: number[] }) {
+function Widget({ rows }: { rows: { x: string }[] }) {
   return <ul>{rows.map((cfg) => <li key={cfg.x}>{cfg.x}</li>)}</ul>
 }
 `)
@@ -518,7 +518,7 @@ function Widget({ variant }: { variant: 'solid' | 'ghost' }) {
   test('a record member referenced outside the loop whose object name is loop-bound elsewhere falls back to the member expression (accepted trade-off)', () => {
     const { template } = compileAndGenerate(`
 const cfg = { x: 'outer-lit' }
-function Widget({ rows }: { rows: number[] }) {
+function Widget({ rows }: { rows: { x: string }[] }) {
   return <div>
     <p>{cfg.x}</p>
     <ul>{rows.map((cfg) => <li key={cfg.x}>{cfg.x}</li>)}</ul>

--- a/packages/adapter-jinja/src/__tests__/jinja-adapter-unit.test.ts
+++ b/packages/adapter-jinja/src/__tests__/jinja-adapter-unit.test.ts
@@ -475,3 +475,57 @@ function Widget({ values }: { values: number[] }) {
     expect(template).toContain('2 + label')
   })
 })
+
+// #2237: `_resolveStaticRecordLiteral` (`IDENT.key` on a module-scope
+// object-literal const, e.g. `variantClasses.ghost` — #1896/#1897) is a
+// flat name lookup on `objectName` with no notion of AST scope, the
+// record-literal sibling of #2221's `_resolveLiteralConst` bug. It used to
+// substitute the outer const's member value even at an occurrence that is
+// actually an enclosing loop callback's own (shadowing) parameter, so every
+// iteration rendered the same hard-coded literal instead of the per-item
+// value. Guarded with the same coarse `staticLoopSourceBoundNames`
+// exclusion as #2221: any name a loop binds anywhere in the component
+// never inlines, falling back to the bare `cfg['x']` member expression.
+describe('JinjaAdapter - record-literal member lookup vs loop-param shadowing (#2237)', () => {
+  test('a loop param shadowing an outer module object const emits the member access, not the outer literal', () => {
+    const { template } = compileAndGenerate(`
+const cfg = { x: 'outer-lit' }
+function Widget({ rows }: { rows: number[] }) {
+  return <ul>{rows.map((cfg) => <li key={cfg.x}>{cfg.x}</li>)}</ul>
+}
+`)
+    // The loop body must reference the per-iteration member access...
+    expect(template).toContain("bf.string(cfg['x'])")
+    // ...never the outer const's hard-coded value.
+    expect(template).not.toContain("bf.string('outer-lit')")
+  })
+
+  test('a module object const NOT shadowed by any loop still inlines (variantClasses.ghost shape, #1896/#1897 pin)', () => {
+    const { template } = compileAndGenerate(`
+const variantClasses = { solid: 'bg-solid', ghost: 'bg-ghost' }
+function Widget({ variant }: { variant: 'solid' | 'ghost' }) {
+  return <div>{variantClasses.ghost}</div>
+}
+`)
+    expect(template).toContain("bf.string('bg-ghost')")
+  })
+
+  // The accepted coarse-exclusion trade-off (same as #2221/#2212): an
+  // object name that is loop-bound ANYWHERE in the component never
+  // inlines its member lookups, even at a genuinely non-shadowed
+  // occurrence outside the loop — the bare member expression is emitted
+  // instead of the value.
+  test('a record member referenced outside the loop whose object name is loop-bound elsewhere falls back to the member expression (accepted trade-off)', () => {
+    const { template } = compileAndGenerate(`
+const cfg = { x: 'outer-lit' }
+function Widget({ rows }: { rows: number[] }) {
+  return <div>
+    <p>{cfg.x}</p>
+    <ul>{rows.map((cfg) => <li key={cfg.x}>{cfg.x}</li>)}</ul>
+  </div>
+}
+`)
+    expect(template).not.toContain("bf.string('outer-lit')")
+    expect(template).toContain("bf.string(cfg['x'])")
+  })
+})

--- a/packages/adapter-jinja/src/adapter/jinja-adapter.ts
+++ b/packages/adapter-jinja/src/adapter/jinja-adapter.ts
@@ -1842,7 +1842,22 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
     return null
   }
 
+  /**
+   * Resolve `IDENT.key` where `IDENT` is a module-scope object-literal const
+   * (`variantClasses.ghost`, #1896/#1897) to the looked-up scalar.
+   *
+   * The lookup is a flat name match on `objectName` with no notion of AST
+   * scope, so an enclosing loop callback's own param of the same name
+   * (`.map((cfg) => <li>{cfg.x}</li>)` shadowing a module `const cfg = {…}`)
+   * still resolved to the OUTER const's member value at every iteration
+   * (#2237) — the sibling hazard to #2221's `_resolveLiteralConst`. Same
+   * coarse-but-safe `staticLoopSourceBoundNames` guard: any name a loop
+   * binds anywhere in the component never inlines, falling back to the bare
+   * `cfg['x']` member expression (which a Jinja for-loop binds correctly
+   * at the shadowed occurrences).
+   */
   private _resolveStaticRecordLiteral(objectName: string, key: string): string | null {
+    if (this.staticLoopSourceBoundNames.has(objectName)) return null
     const hit = lookupStaticRecordLiteral(objectName, key, this.localConstants)
     if (!hit) return null
     return hit.kind === 'number'

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -314,7 +314,7 @@ describe('MojoAdapter - record-literal member lookup vs loop-param shadowing (#2
   test('a loop param shadowing an outer module object const emits the member access, not the outer literal', () => {
     const { template } = compileAndGenerate(`
 const cfg = { x: 'outer-lit' }
-function Widget({ rows }: { rows: number[] }) {
+function Widget({ rows }: { rows: { x: string }[] }) {
   return <ul>{rows.map((cfg) => <li key={cfg.x}>{cfg.x}</li>)}</ul>
 }
 `)
@@ -343,7 +343,7 @@ function Widget({ variant }: { variant: 'solid' | 'ghost' }) {
   test('an object name loop-bound only inside the loop still inlines its member lookup outside it (more precise than Twig family)', () => {
     const { template } = compileAndGenerate(`
 const cfg = { x: 'outer-lit' }
-function Widget({ rows }: { rows: number[] }) {
+function Widget({ rows }: { rows: { x: string }[] }) {
   return <div>
     <p>{cfg.x}</p>
     <ul>{rows.map((cfg) => <li key={cfg.x}>{cfg.x}</li>)}</ul>
@@ -1566,7 +1566,7 @@ describe('MojoAdapter - #1448 Tier C .flat(depth?)', () => {
   function emitFlat(expr: string): string {
     const a = new MojoAdapter()
     const ir = compileToIR(`
-function C({ rows }: { rows: number[][] }) {
+function C({ rows }: { rows: { x: string }[][] }) {
   return <div>{${expr}}</div>
 }
 export { C }

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -298,6 +298,63 @@ function Widget({ items }: { items: object[] }) {
   })
 })
 
+// #2237: the record-literal sibling of #2221's `resolveLiteralConst` bug —
+// `resolveStaticRecordLiteral` (`IDENT.key` on a module-scope object-literal
+// const, e.g. `variantClasses.ghost` — #1896/#1897) is confirmed reproducible
+// on the Twig-family adapters (flat `objectName` lookup with no notion of AST
+// scope, so an enclosing loop callback's own param of the same name resolved
+// to the OUTER const's member value at every iteration). This adapter's
+// `resolveStaticRecordLiteral` already guards against it (mojo-adapter.ts:
+// `if (this.loopBoundNames?.has?.(objectName)) return null`) — the same LIVE,
+// ref-counted `loopBoundNames` map `resolveLiteralConst` consults (#1749),
+// scope-precise rather than the Twig family's coarse whole-component set.
+// Pinned here (mirroring the #2221 scope-precision pin above) rather than
+// fixed, since no code change was needed.
+describe('MojoAdapter - record-literal member lookup vs loop-param shadowing (#2237)', () => {
+  test('a loop param shadowing an outer module object const emits the member access, not the outer literal', () => {
+    const { template } = compileAndGenerate(`
+const cfg = { x: 'outer-lit' }
+function Widget({ rows }: { rows: number[] }) {
+  return <ul>{rows.map((cfg) => <li key={cfg.x}>{cfg.x}</li>)}</ul>
+}
+`)
+    // The loop body must reference the per-iteration member access...
+    expect(template).toContain('$cfg->{x}')
+    // ...never the outer const's hard-coded value.
+    expect(template).not.toContain("'outer-lit'")
+  })
+
+  test('a module object const NOT shadowed by any loop still inlines (variantClasses.ghost shape, #1896/#1897 pin)', () => {
+    const { template } = compileAndGenerate(`
+const variantClasses = { solid: 'bg-solid', ghost: 'bg-ghost' }
+function Widget({ variant }: { variant: 'solid' | 'ghost' }) {
+  return <div>{variantClasses.ghost}</div>
+}
+`)
+    expect(template).toContain("'bg-ghost'")
+  })
+
+  // Unlike the Twig-family's coarse-but-safe `staticLoopSourceBoundNames`
+  // exclusion, this adapter's LIVE `loopBoundNames` tracking is scoped to
+  // the actual render position: an object name loop-bound ONLY inside the
+  // `.map` callback still inlines its member lookup correctly at a
+  // separate, non-shadowed occurrence outside the loop — no accepted
+  // trade-off here.
+  test('an object name loop-bound only inside the loop still inlines its member lookup outside it (more precise than Twig family)', () => {
+    const { template } = compileAndGenerate(`
+const cfg = { x: 'outer-lit' }
+function Widget({ rows }: { rows: number[] }) {
+  return <div>
+    <p>{cfg.x}</p>
+    <ul>{rows.map((cfg) => <li key={cfg.x}>{cfg.x}</li>)}</ul>
+  </div>
+}
+`)
+    expect(template).toContain("<p><%= 'outer-lit' %></p>")
+    expect(template).toContain('$cfg->{x}')
+  })
+})
+
 describe('MojoAdapter - Record<staticKeys,scalar>[propKey] spread value (#checkbox icon)', () => {
   // `const sizeMap: Record<IconSize, number> = { sm: 16, ... }` indexed by
   // a prop inside a conditional-spread object value lowers to an inline

--- a/packages/adapter-rust/src/__tests__/minijinja-adapter-unit.test.ts
+++ b/packages/adapter-rust/src/__tests__/minijinja-adapter-unit.test.ts
@@ -491,7 +491,7 @@ describe('MinijinjaAdapter - record-literal member lookup vs loop-param shadowin
   test('a loop param shadowing an outer module object const emits the member access, not the outer literal', () => {
     const { template } = compileAndGenerate(`
 const cfg = { x: 'outer-lit' }
-function Widget({ rows }: { rows: number[] }) {
+function Widget({ rows }: { rows: { x: string }[] }) {
   return <ul>{rows.map((cfg) => <li key={cfg.x}>{cfg.x}</li>)}</ul>
 }
 `)
@@ -519,7 +519,7 @@ function Widget({ variant }: { variant: 'solid' | 'ghost' }) {
   test('a record member referenced outside the loop whose object name is loop-bound elsewhere falls back to the member expression (accepted trade-off)', () => {
     const { template } = compileAndGenerate(`
 const cfg = { x: 'outer-lit' }
-function Widget({ rows }: { rows: number[] }) {
+function Widget({ rows }: { rows: { x: string }[] }) {
   return <div>
     <p>{cfg.x}</p>
     <ul>{rows.map((cfg) => <li key={cfg.x}>{cfg.x}</li>)}</ul>

--- a/packages/adapter-rust/src/__tests__/minijinja-adapter-unit.test.ts
+++ b/packages/adapter-rust/src/__tests__/minijinja-adapter-unit.test.ts
@@ -476,3 +476,57 @@ function Widget({ values }: { values: number[] }) {
     expect(template).toContain('2 + label')
   })
 })
+
+// #2237: `_resolveStaticRecordLiteral` (`IDENT.key` on a module-scope
+// object-literal const, e.g. `variantClasses.ghost` — #1896/#1897) is a
+// flat name lookup on `objectName` with no notion of AST scope, the
+// record-literal sibling of #2221's `_resolveLiteralConst` bug. It used to
+// substitute the outer const's member value even at an occurrence that is
+// actually an enclosing loop callback's own (shadowing) parameter, so every
+// iteration rendered the same hard-coded literal instead of the per-item
+// value. Guarded with the same coarse `staticLoopSourceBoundNames`
+// exclusion as #2221: any name a loop binds anywhere in the component
+// never inlines, falling back to the bare `cfg.x` member expression.
+describe('MinijinjaAdapter - record-literal member lookup vs loop-param shadowing (#2237)', () => {
+  test('a loop param shadowing an outer module object const emits the member access, not the outer literal', () => {
+    const { template } = compileAndGenerate(`
+const cfg = { x: 'outer-lit' }
+function Widget({ rows }: { rows: number[] }) {
+  return <ul>{rows.map((cfg) => <li key={cfg.x}>{cfg.x}</li>)}</ul>
+}
+`)
+    // The loop body must reference the per-iteration member access...
+    expect(template).toContain('bf.string(cfg.x)')
+    // ...never the outer const's hard-coded value.
+    expect(template).not.toContain("bf.string('outer-lit')")
+  })
+
+  test('a module object const NOT shadowed by any loop still inlines (variantClasses.ghost shape, #1896/#1897 pin)', () => {
+    const { template } = compileAndGenerate(`
+const variantClasses = { solid: 'bg-solid', ghost: 'bg-ghost' }
+function Widget({ variant }: { variant: 'solid' | 'ghost' }) {
+  return <div>{variantClasses.ghost}</div>
+}
+`)
+    expect(template).toContain("bf.string('bg-ghost')")
+  })
+
+  // The accepted coarse-exclusion trade-off (same as #2221/#2212): an
+  // object name that is loop-bound ANYWHERE in the component never
+  // inlines its member lookups, even at a genuinely non-shadowed
+  // occurrence outside the loop — the bare member expression is emitted
+  // instead of the value.
+  test('a record member referenced outside the loop whose object name is loop-bound elsewhere falls back to the member expression (accepted trade-off)', () => {
+    const { template } = compileAndGenerate(`
+const cfg = { x: 'outer-lit' }
+function Widget({ rows }: { rows: number[] }) {
+  return <div>
+    <p>{cfg.x}</p>
+    <ul>{rows.map((cfg) => <li key={cfg.x}>{cfg.x}</li>)}</ul>
+  </div>
+}
+`)
+    expect(template).not.toContain("bf.string('outer-lit')")
+    expect(template).toContain('bf.string(cfg.x)')
+  })
+})

--- a/packages/adapter-rust/src/adapter/minijinja-adapter.ts
+++ b/packages/adapter-rust/src/adapter/minijinja-adapter.ts
@@ -1897,7 +1897,22 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
     return null
   }
 
+  /**
+   * Resolve `IDENT.key` where `IDENT` is a module-scope object-literal const
+   * (`variantClasses.ghost`, #1896/#1897) to the looked-up scalar.
+   *
+   * The lookup is a flat name match on `objectName` with no notion of AST
+   * scope, so an enclosing loop callback's own param of the same name
+   * (`.map((cfg) => <li>{cfg.x}</li>)` shadowing a module `const cfg = {…}`)
+   * still resolved to the OUTER const's member value at every iteration
+   * (#2237) — the sibling hazard to #2221's `_resolveLiteralConst`. Same
+   * coarse-but-safe `staticLoopSourceBoundNames` guard: any name a loop
+   * binds anywhere in the component never inlines, falling back to the bare
+   * `cfg.x` member expression (which a minijinja `for` loop binds correctly
+   * at the shadowed occurrences).
+   */
   private _resolveStaticRecordLiteral(objectName: string, key: string): string | null {
+    if (this.staticLoopSourceBoundNames.has(objectName)) return null
     const hit = lookupStaticRecordLiteral(objectName, key, this.localConstants)
     if (!hit) return null
     return hit.kind === 'number'

--- a/packages/adapter-twig/src/__tests__/twig-adapter-unit.test.ts
+++ b/packages/adapter-twig/src/__tests__/twig-adapter-unit.test.ts
@@ -488,7 +488,7 @@ describe('TwigAdapter - record-literal member lookup vs loop-param shadowing (#2
   test('a loop param shadowing an outer module object const emits the member access, not the outer literal', () => {
     const { template } = compileAndGenerate(`
 const cfg = { x: 'outer-lit' }
-function Widget({ rows }: { rows: number[] }) {
+function Widget({ rows }: { rows: { x: string }[] }) {
   return <ul>{rows.map((cfg) => <li key={cfg.x}>{cfg.x}</li>)}</ul>
 }
 `)
@@ -516,7 +516,7 @@ function Widget({ variant }: { variant: 'solid' | 'ghost' }) {
   test('a record member referenced outside the loop whose object name is loop-bound elsewhere falls back to the member expression (accepted trade-off)', () => {
     const { template } = compileAndGenerate(`
 const cfg = { x: 'outer-lit' }
-function Widget({ rows }: { rows: number[] }) {
+function Widget({ rows }: { rows: { x: string }[] }) {
   return <div>
     <p>{cfg.x}</p>
     <ul>{rows.map((cfg) => <li key={cfg.x}>{cfg.x}</li>)}</ul>

--- a/packages/adapter-twig/src/__tests__/twig-adapter-unit.test.ts
+++ b/packages/adapter-twig/src/__tests__/twig-adapter-unit.test.ts
@@ -474,6 +474,60 @@ function Widget({ values }: { values: number[] }) {
   })
 })
 
+// #2237: `_resolveStaticRecordLiteral` (`IDENT.key` on a module-scope
+// object-literal const, e.g. `variantClasses.ghost` — #1896/#1897) is a
+// flat name lookup on `objectName` with no notion of AST scope, the
+// record-literal sibling of #2221's `_resolveLiteralConst` bug. It used to
+// substitute the outer const's member value even at an occurrence that is
+// actually an enclosing loop callback's own (shadowing) parameter, so every
+// iteration rendered the same hard-coded literal instead of the per-item
+// value. Guarded with the same coarse `staticLoopSourceBoundNames`
+// exclusion as #2221: any name a loop binds anywhere in the component
+// never inlines, falling back to the bare `cfg.x` member expression.
+describe('TwigAdapter - record-literal member lookup vs loop-param shadowing (#2237)', () => {
+  test('a loop param shadowing an outer module object const emits the member access, not the outer literal', () => {
+    const { template } = compileAndGenerate(`
+const cfg = { x: 'outer-lit' }
+function Widget({ rows }: { rows: number[] }) {
+  return <ul>{rows.map((cfg) => <li key={cfg.x}>{cfg.x}</li>)}</ul>
+}
+`)
+    // The loop body must reference the per-iteration member access...
+    expect(template).toContain('bf.string(cfg.x)')
+    // ...never the outer const's hard-coded value.
+    expect(template).not.toContain("bf.string('outer-lit')")
+  })
+
+  test('a module object const NOT shadowed by any loop still inlines (variantClasses.ghost shape, #1896/#1897 pin)', () => {
+    const { template } = compileAndGenerate(`
+const variantClasses = { solid: 'bg-solid', ghost: 'bg-ghost' }
+function Widget({ variant }: { variant: 'solid' | 'ghost' }) {
+  return <div>{variantClasses.ghost}</div>
+}
+`)
+    expect(template).toContain("bf.string('bg-ghost')")
+  })
+
+  // The accepted coarse-exclusion trade-off (same as #2221/#2212): an
+  // object name that is loop-bound ANYWHERE in the component never
+  // inlines its member lookups, even at a genuinely non-shadowed
+  // occurrence outside the loop — the bare member expression is emitted
+  // instead of the value.
+  test('a record member referenced outside the loop whose object name is loop-bound elsewhere falls back to the member expression (accepted trade-off)', () => {
+    const { template } = compileAndGenerate(`
+const cfg = { x: 'outer-lit' }
+function Widget({ rows }: { rows: number[] }) {
+  return <div>
+    <p>{cfg.x}</p>
+    <ul>{rows.map((cfg) => <li key={cfg.x}>{cfg.x}</li>)}</ul>
+  </div>
+}
+`)
+    expect(template).not.toContain("bf.string('outer-lit')")
+    expect(template).toContain('bf.string(cfg.x)')
+  })
+})
+
 // Fable review (#2212): a loop callback's own param can shadow an outer
 // string-typed prop/const of the same name — `collectLoopBoundNames`
 // excludes every such name from `collectStringValueNames` so the shadowed

--- a/packages/adapter-twig/src/adapter/twig-adapter.ts
+++ b/packages/adapter-twig/src/adapter/twig-adapter.ts
@@ -1895,7 +1895,22 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
     return null
   }
 
+  /**
+   * Resolve `IDENT.key` where `IDENT` is a module-scope object-literal const
+   * (`variantClasses.ghost`, #1896/#1897) to the looked-up scalar.
+   *
+   * The lookup is a flat name match on `objectName` with no notion of AST
+   * scope, so an enclosing loop callback's own param of the same name
+   * (`.map((cfg) => <li>{cfg.x}</li>)` shadowing a module `const cfg = {…}`)
+   * still resolved to the OUTER const's member value at every iteration
+   * (#2237) — the sibling hazard to #2221's `_resolveLiteralConst`. Same
+   * coarse-but-safe `staticLoopSourceBoundNames` guard: any name a loop
+   * binds anywhere in the component never inlines, falling back to the bare
+   * `cfg.x` member expression (which a Twig for-loop binds correctly at the
+   * shadowed occurrences).
+   */
   private _resolveStaticRecordLiteral(objectName: string, key: string): string | null {
+    if (this.staticLoopSourceBoundNames.has(objectName)) return null
     const hit = lookupStaticRecordLiteral(objectName, key, this.localConstants)
     if (!hit) return null
     return hit.kind === 'number'

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -486,3 +486,57 @@ function Widget({ values }: { values: number[] }) {
     expect(template).toContain('2 + $label')
   })
 })
+
+// #2237: `_resolveStaticRecordLiteral` (`IDENT.key` on a module-scope
+// object-literal const, e.g. `variantClasses.ghost` — #1896/#1897) is a
+// flat name lookup on `objectName` with no notion of AST scope, the
+// record-literal sibling of #2221's `_resolveLiteralConst` bug. It used to
+// substitute the outer const's member value even at an occurrence that is
+// actually an enclosing loop callback's own (shadowing) parameter, so every
+// iteration rendered the same hard-coded literal instead of the per-item
+// value. Guarded with the same coarse `staticLoopSourceBoundNames`
+// exclusion as #2221: any name a loop binds anywhere in the component
+// never inlines, falling back to the bare `$cfg.x` member expression.
+describe('XslateAdapter - record-literal member lookup vs loop-param shadowing (#2237)', () => {
+  test('a loop param shadowing an outer module object const emits the member access, not the outer literal', () => {
+    const { template } = compileAndGenerate(`
+const cfg = { x: 'outer-lit' }
+function Widget({ rows }: { rows: number[] }) {
+  return <ul>{rows.map((cfg) => <li key={cfg.x}>{cfg.x}</li>)}</ul>
+}
+`)
+    // The loop body must reference the per-iteration member access...
+    expect(template).toContain('<: $cfg.x :>')
+    // ...never the outer const's hard-coded value.
+    expect(template).not.toContain("<: 'outer-lit' :>")
+  })
+
+  test('a module object const NOT shadowed by any loop still inlines (variantClasses.ghost shape, #1896/#1897 pin)', () => {
+    const { template } = compileAndGenerate(`
+const variantClasses = { solid: 'bg-solid', ghost: 'bg-ghost' }
+function Widget({ variant }: { variant: 'solid' | 'ghost' }) {
+  return <div>{variantClasses.ghost}</div>
+}
+`)
+    expect(template).toContain("<: 'bg-ghost' :>")
+  })
+
+  // The accepted coarse-exclusion trade-off (same as #2221/#2212): an
+  // object name that is loop-bound ANYWHERE in the component never
+  // inlines its member lookups, even at a genuinely non-shadowed
+  // occurrence outside the loop — the bare member expression is emitted
+  // instead of the value.
+  test('a record member referenced outside the loop whose object name is loop-bound elsewhere falls back to the member expression (accepted trade-off)', () => {
+    const { template } = compileAndGenerate(`
+const cfg = { x: 'outer-lit' }
+function Widget({ rows }: { rows: number[] }) {
+  return <div>
+    <p>{cfg.x}</p>
+    <ul>{rows.map((cfg) => <li key={cfg.x}>{cfg.x}</li>)}</ul>
+  </div>
+}
+`)
+    expect(template).not.toContain("<: 'outer-lit' :>")
+    expect(template).toContain('<: $cfg.x :>')
+  })
+})

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -501,7 +501,7 @@ describe('XslateAdapter - record-literal member lookup vs loop-param shadowing (
   test('a loop param shadowing an outer module object const emits the member access, not the outer literal', () => {
     const { template } = compileAndGenerate(`
 const cfg = { x: 'outer-lit' }
-function Widget({ rows }: { rows: number[] }) {
+function Widget({ rows }: { rows: { x: string }[] }) {
   return <ul>{rows.map((cfg) => <li key={cfg.x}>{cfg.x}</li>)}</ul>
 }
 `)
@@ -529,7 +529,7 @@ function Widget({ variant }: { variant: 'solid' | 'ghost' }) {
   test('a record member referenced outside the loop whose object name is loop-bound elsewhere falls back to the member expression (accepted trade-off)', () => {
     const { template } = compileAndGenerate(`
 const cfg = { x: 'outer-lit' }
-function Widget({ rows }: { rows: number[] }) {
+function Widget({ rows }: { rows: { x: string }[] }) {
   return <div>
     <p>{cfg.x}</p>
     <ul>{rows.map((cfg) => <li key={cfg.x}>{cfg.x}</li>)}</ul>

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -1766,7 +1766,22 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     return null
   }
 
+  /**
+   * Resolve `IDENT.key` where `IDENT` is a module-scope object-literal const
+   * (`variantClasses.ghost`, #1896/#1897) to the looked-up scalar.
+   *
+   * The lookup is a flat name match on `objectName` with no notion of AST
+   * scope, so an enclosing loop callback's own param of the same name
+   * (`.map((cfg) => <li>{cfg.x}</li>)` shadowing a module `const cfg = {…}`)
+   * still resolved to the OUTER const's member value at every iteration
+   * (#2237) — the sibling hazard to #2221's `_resolveLiteralConst`. Same
+   * coarse-but-safe `staticLoopSourceBoundNames` guard: any name a loop
+   * binds anywhere in the component never inlines, falling back to the bare
+   * `$cfg.x` member expression (which an Xslate `: for` loop binds
+   * correctly at the shadowed occurrences).
+   */
   private _resolveStaticRecordLiteral(objectName: string, key: string): string | null {
+    if (this.staticLoopSourceBoundNames.has(objectName)) return null
     const hit = lookupStaticRecordLiteral(objectName, key, this.localConstants)
     if (!hit) return null
     return hit.kind === 'number'


### PR DESCRIPTION
Fixes #2237. Fifth PR of the stacked series (#2221 → #2222 → #2224 → #2228 → **#2237** → #2236 planned next).

## Problem

`_resolveStaticRecordLiteral` / `lookupStaticRecordLiteral` (each Twig-family adapter) inline `objectName.key` member reads of a static **module-scope** object-literal const (e.g. `variantClasses.ghost`). The lookup is a flat name match on `objectName` with no notion of AST scope, so an occurrence where the object name is actually an enclosing `.map()` callback's own parameter still got the OUTER const's member value substituted in — every iteration rendered the same literal. Confirmed on all five Twig-family adapters with the issue's repro (module `const cfg = { x: 'outer-lit' }` + `rows.map((cfg) => <li>{cfg.x}</li>)`).

The record-literal sibling of #2221 (PR #2234), which covered the scalar-literal `_resolveLiteralConst` path only — this member-lookup path is reachable exclusively for module-scope consts (the helper filters `c.isModule`), so #2234's function-scope guard never fired here.

## Fix

The same one-line `staticLoopSourceBoundNames` guard as PR #2234, at the top of `_resolveStaticRecordLiteral` in Twig, Jinja, Blade, Xslate, and Rust (minijinja), with the same coarse-but-safe trade-off (a name any loop binds anywhere in the component never inlines). The fallback emits the bare member expression, which each engine's own loop binding resolves correctly at the shadowed occurrence: Twig `cfg.x`, Jinja `cfg['x']`, Blade `data_get($cfg, 'x')`, Xslate `$cfg.x`, minijinja `cfg.x`.

**Mojolicious**: already immune — its `resolveStaticRecordLiteral` consults the live, ref-counted `loopBoundNames` map (#1749). Pinned with tests (including the scope-precision case: an object name loop-bound only inside one loop still inlines outside it); no code change.

## Tests

3-test describes per adapter (shadowed occurrence emits the member access; non-shadowed module object const still inlines; the accepted coarse trade-off), each verified red pre-guard (2 fail / 1 pass) and green post-guard, plus the 3 Mojolicious pins.

Full suites: twig 547 / jinja 539 / blade 539 / xslate 540 / rust 539 / mojolicious 705 pass, 0 fail (pre-existing PHP/Perl NotAvailable-skips only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxCtWVr3LBPEPsaK9b5kdD

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxCtWVr3LBPEPsaK9b5kdD)_