### PR TITLE
Go: guard const inlining and string-type resolution against loop-param shadowing (#2236)

### DIFF
--- a/.changeset/go-const-shadowing.md
+++ b/.changeset/go-const-shadowing.md
@@ -1,0 +1,44 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Fix #2236: two independent Go template adapter gaps in loop-param-shadowing
+resolution, both previously flagged as "not fixed" tracked residuals in the
+#2221/#2212 changesets.
+
+Slice A: `convertExpressionToGo`'s bare-identifier fast path (the
+"inline a function-scope literal const" shortcut, e.g. `totalPages`) is a
+string-keyed check over the raw JS source text, reached directly by call
+sites like attribute emission (`key={count}` → `data-key`) that never go
+through `identifier()` — the `ParsedExprEmitter` method that already carries
+loop-shadow guards (`loopParamStack` / `isOuterLoopParam`, mirrored from
+`resolveModuleStringConst` / `resolveModuleNumericConst`). A `.map((count) =>
+...)` callback param shadowing an outer `const count = 7` got the OUTER
+literal inlined at the `data-key` position even though the text position
+(which does go through `identifier()`) correctly resolved to the per-item
+value. Guarded with the same loop-shadow checks the sibling resolvers use;
+unlike the Twig-family's coarse `collectLoopBoundNames` trade-off, Go's guard
+is scope-precise (it consults the live `loopParamStack`), so a const whose
+name is loop-bound elsewhere in the component still inlines correctly at a
+genuinely non-shadowed occurrence outside any loop.
+
+Slice B: Go's own `collectStringValueNames` (`prop-classes.ts`) was ported
+from Blade before #2212 added the `collectLoopBoundNames` exclusion, so it
+lacked the loop-bound-name subtraction every other adapter's prop-classes.ts
+has. An outer string-typed prop/signal shadowed by a `.map()` callback param
+of the same name still poisoned the shadowed occurrence's type resolution —
+`1 + label` inside `values.map((label) => ...)` (with an outer `label:
+string` prop) emitted `bf_concat_str` (string concat, "1" + "1" → "11")
+instead of `bf_add` (numeric addition, 1 + 1 → 2). Fixed by porting the full
+#2212 shape the sibling adapters carry: same-file local consts join the
+string set (so an outer `{label + suffix}` with `suffix = '!'` still
+classifies as concat via its other operand once `label` is subtracted) and
+loop-bound names are excluded via `collectLoopBoundNames`. The exclusion is
+the accepted #2212 coarse trade-off (a flat, component-wide name set), not
+scope-precise like slice A: a genuinely non-shadowed occurrence outside the
+loop, whose name happens to be loop-bound elsewhere, also falls back to
+numeric `bf_add`. Safe (never silently-wrong string output), just imprecise.
+
+With both fixed, the shared `loop-param-shadows-outer-name` conformance
+fixture (#2212/#2221/#2222) now renders at reference parity on Go — its
+`render-divergences.ts` entry is removed.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -4398,6 +4398,25 @@ export function List() {
     expect(template).not.toContain('{{7}}')
   })
 
+  test('slice A: a DESTRUCTURED callback binding shadowing an outer const resolves to the binding accessor (#2242 Copilot review)', () => {
+    // Destructured callbacks push '' onto loopParamStack and track their
+    // binding names only in loopBindingStack — the fast-path guard must
+    // scan that stack too, or the outer `const id = 7` inlines at both
+    // the key and text positions.
+    const { template } = compileAndGenerate(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function List() {
+  const id = 7
+  const [items] = createSignal<{ id: number }[]>([{ id: 2 }, { id: 5 }])
+  return <ul>{items().map(({ id }) => <li key={id}>{id}</li>)}</ul>
+}
+`)
+    expect(template).toContain('data-key="{{$__bf_item0.ID}}"')
+    expect(template).toContain('{{$__bf_item0.ID}}{{bfTextEnd}}')
+    expect(template).not.toContain('{{7}}')
+  })
+
   test('slice B: `1 + label` inside the loop that shadows an outer string prop lowers to bf_add, not bf_concat_str', () => {
     const { template } = compileAndGenerate(`
 'use client'

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -4349,3 +4349,188 @@ export function Nested({ groups }: { groups: { label: string }[][] }) {
     expect(template).not.toContain('{{"Alpha"}}')
   })
 })
+
+// #2236: two independent loop-param-shadowing gaps, both distinct from the
+// #2224 static-array unroll above (this describe exercises the DYNAMIC
+// (signal-driven) `{{range}}` path, where a real per-iteration `.` context
+// exists — #2224's baked/unrolled loops are a different code path entirely).
+//
+// Slice A: `convertExpressionToGo`'s bare-identifier fast path (the
+// "inline a function-scope literal const" shortcut, e.g. `totalPages`) is a
+// STRING-KEYED check over the raw JS source text reached directly by call
+// sites like attribute emission (`key={count}` → `data-key`) — it never
+// goes through `identifier()` (the `ParsedExprEmitter` method), which
+// already carries the loop-shadow guards (`loopParamStack` /
+// `isOuterLoopParam`, mirrored from `resolveModuleStringConst` /
+// `resolveModuleNumericConst`). So a `.map((count) => ...)` callback param
+// that shadows an outer `const count = 7` got the OUTER literal inlined at
+// the `data-key` position even though the text position (which DOES go
+// through `identifier()`) correctly resolved to the per-item value.
+//
+// Slice B: Go's `collectStringValueNames` (prop-classes.ts) was ported from
+// Blade BEFORE #2212 added the local-const inclusion + `collectLoopBoundNames`
+// exclusion, so an outer string-typed prop/signal whose name is shadowed by a
+// `.map()` callback param still poisoned the shadowed occurrence's type
+// resolution — `1 + label` inside `values.map((label) => ...)` (with an outer
+// `label: string` prop) emitted `bf_concat_str` (string concat) instead of
+// `bf_add` (numeric addition). The full #2212 shape is ported: same-file
+// local consts join the set (so an outer `{label + suffix}` with
+// `suffix = '!'` still classifies as concat via its OTHER operand once
+// `label` is subtracted — the exact `loop-param-shadows-outer-name` fixture
+// shape) and loop-bound names are excluded.
+describe('GoTemplateAdapter - const/type resolution vs loop-param shadowing (#2236)', () => {
+  test('slice A: data-key inside a dynamic (signal-driven) loop uses the loop value, not the outer const', () => {
+    const { template } = compileAndGenerate(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function List() {
+  const count = 7
+  const [nums] = createSignal<number[]>([2, 5])
+  return <ul>{nums().map((count) => <li key={count}>{count * 3}</li>)}</ul>
+}
+`)
+    // The range establishes a real per-iteration dot context — both the
+    // `data-key` attribute and the text position must resolve the shadowed
+    // `count` through it.
+    expect(template).toContain('{{range $_, $count := .Nums}}<li data-key="{{.}}">')
+    expect(template).toContain('{{bf_mul . 3}}')
+    // Never the outer `const count = 7` literal.
+    expect(template).not.toContain('{{7}}')
+  })
+
+  test('slice B: `1 + label` inside the loop that shadows an outer string prop lowers to bf_add, not bf_concat_str', () => {
+    const { template } = compileAndGenerate(`
+'use client'
+export function Labels({ label, values }: { label: string; values: number[] }) {
+  return <ul>{values.map((label) => <li key={label}>{1 + label}</li>)}</ul>
+}
+`)
+    expect(template).toContain('{{bf_add 1 .}}')
+    expect(template).not.toContain('bf_concat_str')
+  })
+
+  test('regression pin: a const inlined OUTSIDE any loop still inlines (slice A must not over-guard)', () => {
+    const { template } = compileAndGenerate(`
+export function Foo() {
+  const total = 5
+  return <div data-key={total}>{total}</div>
+}
+`)
+    expect(template).toContain('data-key="{{5}}"')
+    expect(template).toContain('{{5}}</div>')
+  })
+
+  test('regression pin: a genuinely string-typed `+` OUTSIDE the loop still lowers to bf_concat_str (slice B must not over-guard)', () => {
+    const { template } = compileAndGenerate(`
+export function Foo({ label }: { label: string }) {
+  const suffix = '!'
+  return <p>{label + suffix}</p>
+}
+`)
+    expect(template).toContain('bf_concat_str .Label .Suffix')
+  })
+
+  test('local-const operand carries the concat classification when the prop operand is coarsely excluded (fixture shape)', () => {
+    // The `loop-param-shadows-outer-name` fixture's combined shape: `label`
+    // is loop-bound below, so the coarse exclusion strips it from the string
+    // set — the OUTER `{label + suffix}` must then classify as concat via
+    // its `suffix = '!'` local-const operand (the #2212 local-const
+    // inclusion), or it would fall back to `bf_add` and render `0`.
+    const { template } = compileAndGenerate(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function Both({ label, values }: { label: string; values: number[] }) {
+  const suffix = '!'
+  const [n, setN] = createSignal(0)
+  return (
+    <div data-n={n()} onClick={() => setN(n() + 1)}>
+      <p>{label + suffix}</p>
+      <ul>{values.map((label) => <li key={label}>{1 + label}</li>)}</ul>
+    </div>
+  )
+}
+`)
+    // Outside the loop: still string concat, carried by the const operand.
+    expect(template).toContain('bf_concat_str .Label .Suffix')
+    // Inside the loop: the shadowed occurrence stays numeric.
+    expect(template).toContain('{{bf_add 1 .}}')
+  })
+
+  // Go's slice-A guard is scope-PRECISE: it consults the live
+  // `loopParamStack`, not a flat component-wide name set, so a const whose
+  // name is loop-bound ELSEWHERE in the component still inlines at an
+  // occurrence that is genuinely outside any loop. This is a real point of
+  // divergence from the Twig-family adapters' coarse `collectLoopBoundNames`
+  // trade-off — pinned here so a future "fix" doesn't accidentally coarsen
+  // Go's precise guard to match them.
+  test('slice A guard is scope-precise: a name that is loop-bound elsewhere still inlines outside the loop', () => {
+    const { template } = compileAndGenerate(`
+export function Foo({ items }: { items: number[] }) {
+  const count = 9
+  return <div>
+    <p data-key={count}>{count}</p>
+    <ul>{items.map(count => <li key={count}>{count}</li>)}</ul>
+  </div>
+}
+`)
+    // Outside the loop, `count` still resolves to the outer literal `9`.
+    expect(template).toContain('data-key="{{9}}"')
+    // Inside the loop, the shadowed occurrence still resolves to the loop
+    // value, not the outer literal.
+    expect(template).toContain('{{range $_, $count := .Items}}<li data-key="{{.}}">')
+  })
+
+  // Slice B's guard, by contrast, is the coarse #2212 trade-off (a flat,
+  // scope-blind `Set<string>` with the loop-bound name subtracted
+  // component-wide): a genuinely non-shadowed occurrence OUTSIDE the loop,
+  // whose name happens to be loop-bound elsewhere, also loses its
+  // string-typed classification and falls back to numeric `bf_add`. This is
+  // the accepted, already-documented residual (same as Blade's #2212
+  // comment) — the suppressed case is safe (numeric fallback, never
+  // silently-wrong string output), just imprecise.
+  test('slice B guard is coarse (accepted #2212 trade-off): a string prop shadowed elsewhere loses bf_concat_str even outside the loop', () => {
+    const { template } = compileAndGenerate(`
+export function Foo({ count, arr }: { count: string; arr: number[] }) {
+  return <div>
+    <p>{1 + count}</p>
+    <ul>{arr.map((count) => <li key={count}>{count}</li>)}</ul>
+  </div>
+}
+`)
+    // Coarse trade-off: falls back to numeric bf_add outside the loop too,
+    // even though this occurrence of `count` is the genuinely string-typed
+    // outer prop, not shadowed.
+    expect(template).toContain('bf_add 1 .Count')
+    expect(template).not.toContain('bf_concat_str')
+  })
+
+  test('end-to-end via real `go run`: shadowed const/type resolution renders correct HTML', async () => {
+    try {
+      const html = await renderGoTemplateComponent({
+        source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function List() {
+  const count = 7
+  const [nums] = createSignal<number[]>([2, 5])
+  return <ul>{nums().map((count) => <li key={count}>{count * 3}</li>)}</ul>
+}
+`,
+        adapter: new GoTemplateAdapter(),
+        props: {},
+      })
+      // The outer `const count = 7` must never leak into the rendered
+      // per-item output — each `<li>` carries its OWN loop value (2, 5),
+      // not the constant 7.
+      expect(html).toContain('<li data-key="2"><!--bf:s0-->6<!--/--></li>')
+      expect(html).toContain('<li data-key="5"><!--bf:s0-->15<!--/--></li>')
+      expect(html).not.toContain('data-key="7"')
+    } catch (err) {
+      if (err instanceof GoNotAvailableError) {
+        console.log('Skipping #2236 e2e: go command not found')
+        return
+      }
+      throw err
+    }
+  })
+})

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -4624,12 +4624,18 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // `const count = 7`, the occurrence inside the loop body must resolve to
     // the range value (via the normal parse-and-lower fallthrough), not the
     // outer literal. Mirrors the guard in `resolveModuleStringConst` /
-    // `resolveModuleNumericConst`.
+    // `resolveModuleNumericConst`, PLUS the `loopBindingStack` scan
+    // `identifier()` leads with: a DESTRUCTURED callback (`.map(({ id }) =>
+    // ...)`) pushes `''` onto `loopParamStack` and tracks its binding names
+    // only in `loopBindingStack`, so without this the fast path still
+    // inlined an outer `const id = 7` at the shadowed occurrence (#2242
+    // Copilot review).
     const isLoopShadowed =
       (this.loopParamStack.length > 0 &&
         this.loopParamStack[this.loopParamStack.length - 1] === trimmed) ||
       this.loopVarRefCount.has(trimmed) ||
-      this.isOuterLoopParam(trimmed)
+      this.isOuterLoopParam(trimmed) ||
+      this.loopBindingStack.some(bindings => bindings.has(trimmed))
     if (!isLoopShadowed && /^[A-Za-z_$][\w$]*$/.test(trimmed)) {
       const litConst = (this.state.localConstants ?? []).find(c => c.name === trimmed)
       if (litConst?.value !== undefined) {

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -4616,7 +4616,21 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // the generic lowering would reference a nonexistent `.TotalPages` field).
     // Only pure numeric / single-quoted-string initializers qualify; anything
     // else may be runtime-dependent.
-    if (/^[A-Za-z_$][\w$]*$/.test(trimmed)) {
+    //
+    // #2236: this is a string-keyed fast path over `jsExpr` reached directly
+    // by call sites like attribute emission (`key={count}` → `data-key`) that
+    // never go through `identifier()`'s loop-shadow guards below — so it must
+    // carry its OWN guard. When `.map((count) => ...)` shadows the outer
+    // `const count = 7`, the occurrence inside the loop body must resolve to
+    // the range value (via the normal parse-and-lower fallthrough), not the
+    // outer literal. Mirrors the guard in `resolveModuleStringConst` /
+    // `resolveModuleNumericConst`.
+    const isLoopShadowed =
+      (this.loopParamStack.length > 0 &&
+        this.loopParamStack[this.loopParamStack.length - 1] === trimmed) ||
+      this.loopVarRefCount.has(trimmed) ||
+      this.isOuterLoopParam(trimmed)
+    if (!isLoopShadowed && /^[A-Za-z_$][\w$]*$/.test(trimmed)) {
       const litConst = (this.state.localConstants ?? []).find(c => c.name === trimmed)
       if (litConst?.value !== undefined) {
         const v = litConst.value.trim()

--- a/packages/adapter-go-template/src/adapter/props/prop-classes.ts
+++ b/packages/adapter-go-template/src/adapter/props/prop-classes.ts
@@ -7,7 +7,7 @@
  * function over `ir.metadata`; no adapter instance state.
  */
 
-import type { ComponentIR, TypeInfo } from '@barefootjs/jsx'
+import { collectLoopBoundNames, type ComponentIR, type TypeInfo } from '@barefootjs/jsx'
 
 /** True when `type` is the `string` primitive. */
 function isStringTypeInfo(type: TypeInfo): boolean {
@@ -22,14 +22,33 @@ function isBareStringLiteral(initialValue: string | undefined): boolean {
 }
 
 /**
- * String-typed signals and props. A signal is string-typed when its inferred
- * type is `string` (or, defensively, when its initial value is a bare string
- * literal); a prop when its annotated type is `string`. Drives `isStringName`
- * for `isStringConcatBinary` — the shared helper (`@barefootjs/jsx`) that
- * decides whether a JS `+` is string concatenation rather than numeric
- * addition (Go's `html/template` has no native `+` at all; `binary()` always
- * emits a runtime call, `bf_add` for addition or `bf_concat_str` for
- * concatenation — see `go-template-adapter.ts`'s `binary()`).
+ * String-typed signals, props, and same-file local consts (#2212, ported
+ * here for #2236). A signal is string-typed when its inferred type is
+ * `string` (or, defensively, when its initial value is a bare string
+ * literal); a prop when its annotated type is `string`; a local const the
+ * same way. Drives `isStringName` for `isStringConcatBinary` — the shared
+ * helper (`@barefootjs/jsx`) that decides whether a JS `+` is string
+ * concatenation rather than numeric addition (Go's `html/template` has no
+ * native `+` at all; `binary()` always emits a runtime call, `bf_add` for
+ * addition or `bf_concat_str` for concatenation — see
+ * `go-template-adapter.ts`'s `binary()`). Local consts matter for exactly
+ * the shadowing shape this exclusion exists for: with a loop-bound `label`
+ * subtracted, an outer `{label + suffix}` (where `suffix = '!'`) must
+ * still classify as string concat via its OTHER operand, or it would fall
+ * back to `bf_add` and render `0`.
+ *
+ * Excludes any name bound as a `.map()`/`.filter()` loop callback's item or
+ * index parameter ANYWHERE in the component (#2212, ported here for #2236):
+ * this lookup is a flat, scope-blind `Set<string>` with no notion of a loop
+ * param shadowing an outer string-typed binding of the same name
+ * (`values.map((label) => 1 + label)` inside a component that also has a
+ * string `label` prop) — left unguarded, that shadowed `label` would be
+ * misdetected as string-typed and `1 + label` would silently lower to
+ * `bf_concat_str` instead of staying numeric `bf_add`. Subtracting loop-bound
+ * names is coarse (it also suppresses a genuinely non-shadowed same-named
+ * string elsewhere in the component) but safe: the suppressed case just
+ * falls back to today's numeric `bf_add` — the same, already-accepted
+ * residual as an unresolvable operand — never silently-wrong output.
  */
 export function collectStringValueNames(ir: ComponentIR): Set<string> {
   const names = new Set<string>()
@@ -41,5 +60,11 @@ export function collectStringValueNames(ir: ComponentIR): Set<string> {
   for (const p of ir.metadata.propsParams) {
     if (isStringTypeInfo(p.type)) names.add(p.name)
   }
+  for (const c of ir.metadata.localConstants) {
+    if ((c.type !== null && isStringTypeInfo(c.type)) || isBareStringLiteral(c.value)) {
+      names.add(c.name)
+    }
+  }
+  for (const bound of collectLoopBoundNames(ir)) names.delete(bound)
   return names
 }

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -17,21 +17,6 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
-  // `loop-param-shadows-outer-name` (#2212/#2221/#2222 cross-adapter
-  // fixture): `convertExpressionToGo` picks the `+` operator's Go helper
-  // (`bf_add` numeric vs `bf_concat_str` string) by looking up the
-  // identifier's declared TYPE — and for `1 + label` inside
-  // `.map((label) => ...)`, it resolves `label`'s type against the OUTER
-  // `label: string` prop the loop param shadows, instead of the loop's
-  // actual element type (`number`, from `values: number[]`). Emits
-  // `bf_concat_str` (`"1" + "1"` → `"11"`) instead of `bf_add`
-  // (`1 + 1` → `2`). Same bare-identifier/shadowing bug class as
-  // #2221/#2222, but in Go's SSR type-inference-for-operator-selection
-  // path (`convertExpressionToGo`), which those shared-compiler fixes
-  // don't touch. Tracked as its own known limitation — see
-  // https://github.com/piconic-ai/barefootjs/issues/2236.
-  'loop-param-shadows-outer-name':
-    'BF-2236: convertExpressionToGo resolves a loop-param-shadowed identifier\'s type against the shadowed OUTER binding when choosing the `+` operator helper, emitting bf_concat_str (string concat) instead of bf_add (numeric addition)',
   // `todo-app-ssr` no longer diverges (#2209). Two parts: (1) `.Todos`
   // (the loop's DATUM slice) is already seeded straight from the caller's
   // Input — the constructor derives it from `initialTodos`, and `[]Todo`

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2020,12 +2020,6 @@
           ]
         }
       },
-      "loop-param-shadows-outer-name": {
-        "go-template": {
-          "kind": "render",
-          "reason": "BF-2236: convertExpressionToGo resolves a loop-param-shadowed identifier's type against the shadowed OUTER binding when choosing the `+` operator helper, emitting bf_concat_str (string concat) instead of bf_add (numeric addition)"
-        }
-      },
       "static-array-from-props": {
         "blade": {
           "kind": "refusal",


### PR DESCRIPTION
Fixes #2236. Sixth PR of the stacked series (#2221 → #2222 → #2224 → #2228 → #2237 → **#2236**).

## Problem

Two independent instances of the loop-param shadowing bug class in the Go template adapter:

**Slice A — const inlining.** `convertExpressionToGo`'s bare-identifier fast path is a string-keyed check over raw source text, reached DIRECTLY by attribute emission (`key={count}` → `data-key`), so it bypasses the `ParsedExprEmitter.identifier()` guards the text position goes through. A dynamic loop `nums().map((count) => <li key={count}>{count * 3}</li>)` with an outer `const count = 7` emitted `data-key="{{7}}"` for every iteration (the text position was already correct: `bf_mul . 3`).

**Slice B — string-type resolution** (the sharper diagnosis from PR #2238's fixture divergence). Go's own `collectStringValueNames` (`props/prop-classes.ts`) was ported from Blade BEFORE #2212, missing both halves of that fix: the `collectLoopBoundNames` exclusion — so `{1 + label}` under a shadowing loop param resolved `label`'s type against the OUTER `label: string` prop and emitted `bf_concat_str 1 .` (rendering "12"/"13" instead of 3/4) — and the string-typed local-const inclusion, without which adding the exclusion alone regressed the fixture's outer `{label + suffix}` concat to `bf_add` (rendering 0). Both halves mirrored from Blade's `prop-classes.ts`.

## Guards

- Slice A: the same `loopParamStack` / `loopVarRefCount` / `isOuterLoopParam` checks the sibling resolvers (`resolveModuleStringConst` / `resolveModuleNumericConst`) already use — **scope-precise**: a const whose name is loop-bound elsewhere still inlines outside the loop (pinned by test). The shadowed occurrence falls through to the parse-and-lower path and emits the dot form.
- Slice B: the coarse whole-component exclusion accepted for #2212 — the trade-off divergence vs slice A's precision is pinned honestly in comments and a test.

## Payoff

The `loop-param-shadows-outer-name` render divergence declared in PR #2238 (pointing at this issue) is **removed** — the fixture now renders at reference parity via real `go run` (`Item!` outer text + `2/3/4` loop items). The compat.lock diff is exactly that entry's removal (558/558 cells still ok).

## Tests

8-test `#2236` describe in the Go adapter suite: both slices red pre-fix / green post-fix, non-shadowed regression pins (const inlining and string `+` outside loops unchanged), the scope-precision vs coarse-trade-off pins, the fixture-shape local-const concat pin, and an end-to-end real `go run` render.

Suites: go-template **779 pass / 0 fail**, adapter-tests **1233 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxCtWVr3LBPEPsaK9b5kdD

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxCtWVr3LBPEPsaK9b5kdD)_