### PR TITLE
Pin the #2235 attribute-fold fix across every adapter backend

### DIFF
--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -368,6 +368,7 @@ import { fixture as stringTrimSided } from './methods/string-trim-sided'
 // CSR `setArray` fallback fix (#2222 bug 1) and the scope-accurate
 // prop/const shadowing fixes (#2221, #2222 bug 2) landed.
 import { fixture as loopParamShadowsOuterName } from './loop-param-shadows-outer-name'
+import { fixture as loopParamShadowsConstKey } from './loop-param-shadows-const-key'
 
 import type { JSXFixture } from '../src/types'
 
@@ -641,4 +642,5 @@ export const jsxFixtures: JSXFixture[] = [
   stringReplaceAll,
   stringTrimSided,
   loopParamShadowsOuterName,
+  loopParamShadowsConstKey,
 ]

--- a/packages/adapter-tests/fixtures/loop-param-shadows-const-key.ts
+++ b/packages/adapter-tests/fixtures/loop-param-shadows-const-key.ts
@@ -1,0 +1,48 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A `.map()` callback param shadowing a LOCAL LITERAL CONST, referenced as
+ * the loop's `key` and in the item text (#2235 — the exact issue repro).
+ *
+ * The key position is special: `tryResolveIdentifierAsTemplateLiteral` →
+ * `findLocalConst` folds a bare-identifier attribute value to the const's
+ * literal at IR-GENERATION time, before any adapter runs — so pre-fix,
+ * EVERY adapter (including Hono's native JSX re-emission) baked
+ * `key="x"` / `data-key="x"` into each iteration: duplicate keys and a
+ * broken reconciliation identity, with no error. The sibling fixture
+ * `loop-param-shadows-outer-name` pins the PROP-shadow half of the bug
+ * class; this one pins the const-shadow half at the attribute position
+ * (its text-position half is pinned per-adapter by the #2221 unit tests).
+ *
+ * Deliberately NO outside-the-loop reference to the const: the Twig
+ * family's coarse #2221 guard suppresses inlining for a loop-bound name
+ * at non-shadowed occurrences too (rendering empty where the scope-precise
+ * backends render 'x') — that accepted trade-off is pinned per-adapter by
+ * the #2221 unit tests and would otherwise force divergence declarations
+ * here for behavior that is working as designed.
+ */
+export const fixture = createFixture({
+  id: 'loop-param-shadows-const-key',
+  description: '.map() callback param shadows a local literal const used as key + text (#2235)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function LoopParamShadowsConstKey({ rows }: { rows: number[] }) {
+  const label: string = 'x'
+  const [n, setN] = createSignal(0)
+  return (
+    <div data-n={n()} onClick={() => setN(n() + 1)}>
+      <ul>
+        {rows.map((label) => (
+          <li key={label}>{label}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+`,
+  props: { rows: [10, 20] },
+  expectedHtml: `
+    <div bf-s="test" bf="s2" data-n="0"><ul bf="s1"><li data-key="10"><!--bf:s0-->10<!--/--></li><li data-key="20"><!--bf:s0-->20<!--/--></li></ul></div>
+  `,
+})

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 245,
+    "totalFixtures": 246,
     "fixtures": {
       "dangerous-inner-html-dynamic": {
         "blade": {


### PR DESCRIPTION
Fixes #2235. Seventh and final PR of the stacked series (#2221 → #2222 → #2224 → #2228 → #2237 → #2236 → **#2235**).

## Context

#2235's defect — `tryResolveIdentifierAsTemplateLiteral` → `findLocalConst` folding a bare-identifier JSX attribute (`key={label}`) to an outer const's literal at IR-generation time even when an enclosing loop param shadows it — was **fixed in PR #2238** as part of the #2222 work (the fold now guards on `ctx.loopParams`, the transform position's live loop-param set). But #2238 only pinned the CSR hydrate template; the fold runs before any adapter, and the issue's report was specifically about every adapter (including Hono's native JSX re-emission baking `key={`x`}` — a constant duplicate key per iteration) receiving the baked literal.

## This PR

Adds the cross-adapter conformance fixture `loop-param-shadows-const-key` — the issue's exact repro (`const label: string = 'x'` + `rows.map((label) => <li key={label}>{label}</li>)`) — pinning the fix where it matters:

- Hono reference emits `key={label}` (the loop param), verified along with CSR-template conformance.
- Go renders `data-key="{{.}}"` per item via real `go run` (needs #2236's guards, hence the stack position).
- Twig / Jinja / Blade / ERB / Rust (minijinja) all render at reference parity (`data-key="10"` / `"20"` with per-item text).

The fixture deliberately has NO outside-the-loop const reference: the Twig family's coarse #2221 guard renders empty at non-shadowed occurrences of a loop-bound name by design (that accepted trade-off is pinned per-adapter by the #2221 unit tests), and including it here would force divergence declarations for working-as-designed behavior.

compat.lock: totalFixtures 245 → 246, no divergence entries. Fixture-only change — no published package source touched, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxCtWVr3LBPEPsaK9b5kdD

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxCtWVr3LBPEPsaK9b5kdD)_