### PR TITLE
Backfill conformance fixtures for #2228/#2237; fix the Go record-member shadowing gap they exposed

### DIFF
--- a/.changeset/go-record-member-shadowing.md
+++ b/.changeset/go-record-member-shadowing.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Fix the record-member sibling of #2236's bare-identifier gap, found by the new `loop-param-shadows-record-const` conformance fixture: `resolveStaticRecordLiteralIndex` (the fast path resolving `IDENT['key']` / `IDENT.key` against a module-scope object-literal const, e.g. the icon registry's `strokePaths['chevron-down']`) had no loop-shadowing guard, so `rows.map((cfg) => cfg.x)` under a module `const cfg = { x: 'outer-lit' }` baked `outer-lit` into every iteration of the SSR template. The guard is the same scope-precise check the bare-identifier fast path got in #2236 (now factored into a shared `isLoopShadowedName`, including the `loopBindingStack` scan for destructured callbacks); the shadowed occurrence falls through to the generic lowering and resolves the member through the loop binding (`{{.X}}`). Non-shadowed module record lookups are unchanged.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -4417,6 +4417,22 @@ export function List() {
     expect(template).not.toContain('{{7}}')
   })
 
+  test('record-member fast path: a module object const shadowed by the callback param resolves per-item (loop-param-shadows-record-const fixture)', () => {
+    // resolveStaticRecordLiteralIndex covers IDENT['key'] AND IDENT.key —
+    // the record-member sibling of the bare-identifier gap above. Without
+    // the isLoopShadowedName guard it baked {{"outer-lit"}} into every
+    // iteration.
+    const { template } = compileAndGenerate(`
+const cfg = { x: 'outer-lit' }
+export function List({ rows }: { rows: { id: number; x: string }[] }) {
+  return <ul>{rows.map((cfg) => <li key={cfg.id}>{cfg.x}</li>)}</ul>
+}
+`)
+    expect(template).toContain('{{range $_, $cfg := .Rows}}')
+    expect(template).toContain('{{.X}}')
+    expect(template).not.toContain('outer-lit')
+  })
+
   test('slice B: `1 + label` inside the loop that shadows an outer string prop lowers to bf_add, not bf_concat_str', () => {
     const { template } = compileAndGenerate(`
 'use client'

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -4623,20 +4623,8 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // carry its OWN guard. When `.map((count) => ...)` shadows the outer
     // `const count = 7`, the occurrence inside the loop body must resolve to
     // the range value (via the normal parse-and-lower fallthrough), not the
-    // outer literal. Mirrors the guard in `resolveModuleStringConst` /
-    // `resolveModuleNumericConst`, PLUS the `loopBindingStack` scan
-    // `identifier()` leads with: a DESTRUCTURED callback (`.map(({ id }) =>
-    // ...)`) pushes `''` onto `loopParamStack` and tracks its binding names
-    // only in `loopBindingStack`, so without this the fast path still
-    // inlined an outer `const id = 7` at the shadowed occurrence (#2242
-    // Copilot review).
-    const isLoopShadowed =
-      (this.loopParamStack.length > 0 &&
-        this.loopParamStack[this.loopParamStack.length - 1] === trimmed) ||
-      this.loopVarRefCount.has(trimmed) ||
-      this.isOuterLoopParam(trimmed) ||
-      this.loopBindingStack.some(bindings => bindings.has(trimmed))
-    if (!isLoopShadowed && /^[A-Za-z_$][\w$]*$/.test(trimmed)) {
+    // outer literal.
+    if (!this.isLoopShadowedName(trimmed) && /^[A-Za-z_$][\w$]*$/.test(trimmed)) {
       const litConst = (this.state.localConstants ?? []).find(c => c.name === trimmed)
       if (litConst?.value !== undefined) {
         const v = litConst.value.trim()
@@ -4708,6 +4696,26 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   /**
+   * Whether `name` at the CURRENT emission position is bound by an enclosing
+   * loop callback — its item param (`loopParamStack` top), an outer loop's
+   * range variable, a hoisted loop var, or a destructured binding name
+   * (`loopBindingStack`, which is the ONLY place destructured callbacks
+   * record their names; they push `''` onto `loopParamStack`). Shared by the
+   * string-keyed fast paths (#2236, #2242 Copilot review) that resolve raw
+   * `jsExpr` text before `identifier()`'s own guards can see it. Mirrors the
+   * checks in `resolveModuleStringConst` / `resolveModuleNumericConst`.
+   */
+  private isLoopShadowedName(name: string): boolean {
+    return (
+      (this.loopParamStack.length > 0 &&
+        this.loopParamStack[this.loopParamStack.length - 1] === name) ||
+      this.loopVarRefCount.has(name) ||
+      this.isOuterLoopParam(name) ||
+      this.loopBindingStack.some(bindings => bindings.has(name))
+    )
+  }
+
+  /**
    * Resolve `IDENT['key']` / `IDENT["key"]` where `IDENT` is a module-scope
    * object-literal const and the key is a string literal — a compile-time-static
    * lookup (the icon registry's `strokePaths['chevron-down']`). Returns the
@@ -4724,6 +4732,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       // ordinary props/locals never match.
       /^([A-Za-z_$][\w$]*)\.([A-Za-z_$][\w$]*)$/.exec(jsExpr)
     if (!m) return null
+    // The base name may be an enclosing loop callback's own (shadowing)
+    // param (`rows.map((cfg) => cfg.x)` under a module `const cfg = {...}`)
+    // — the record-member sibling of the #2236 bare-identifier gap, found
+    // by the loop-param-shadows-record-const fixture. Fall through to the
+    // generic lowering, which resolves the member through the loop binding.
+    if (this.isLoopShadowedName(m[1])) return null
     const key = m[2] ?? m[3]
     const constInfo = (this.state.localConstants ?? []).find(
       c => c.name === m[1] && c.isModule,

--- a/packages/adapter-tests/fixtures/filter-wrapper-props-reachable.ts
+++ b/packages/adapter-tests/fixtures/filter-wrapper-props-reachable.ts
@@ -45,11 +45,10 @@ import { createFixture } from '../src/types'
  * rendering raises `NoMethodError: undefined method '[]' for nil`. Same
  * masking story as #2228 itself: `todo-app-ssr`'s `'all'`-default filter
  * never evaluates the `t.done`-referencing branches, so this ERB gap has
- * never fired in production either. It's untracked (no issue exists yet)
- * and out of scope for this backfill (#2228/#2237), so this fixture
- * routes around it — via the same-name predicate/loop param — rather
- * than declaring a divergence for a bug this PR isn't fixing; flagged in
- * the PR description for follow-up.
+ * never fired in production either. Tracked as #2245 and out of scope
+ * for this backfill (#2228/#2237), so this fixture routes around it —
+ * via the same-name predicate/loop param — rather than declaring a
+ * divergence for a bug this PR isn't fixing.
  *
  * Pre-#2240 this 500s on real Go (`can't evaluate field Done in type
  * FilterWrapperPropsReachableTodoRowProps`); post-#2240 it renders only

--- a/packages/adapter-tests/fixtures/filter-wrapper-props-reachable.ts
+++ b/packages/adapter-tests/fixtures/filter-wrapper-props-reachable.ts
@@ -1,0 +1,103 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A `.filter(pred).map(todo => <Child todo={todo}/>)` loop over a
+ * SAME-FILE child component (#2228, PR #2240), with the filter's
+ * REACHABLE branch actually taken.
+ *
+ * On Go, a loop whose body is a single child component ranges the
+ * WRAPPER `<Child>Props` slice (`.TodoRows`, #2130), not the raw datum
+ * slice — so the `{{if}}` gating each item's inclusion sees the wrapper
+ * struct as its dot context, and the filter predicate's `todo.done` must
+ * qualify through the prop that forwards the loop param verbatim
+ * (`todo={todo}` → `.Todo.Done`), not lower to a bare `.Done`. That bug
+ * shipped silently in production because `todo-app-ssr`'s `filter`
+ * signal defaults to `'all'`, which short-circuits the buggy predicate
+ * branch away entirely — `html/template` resolves struct fields at
+ * EXECUTE time, so a branch that's never taken never 500s.
+ *
+ * This fixture makes the branch reachable by defaulting `filter` to
+ * `'active'` (never `'all'`), so `!todo.done` runs on every render. It
+ * mirrors the shape of the `#2228` regression unit tests
+ * (`GoTemplateAdapter - filter predicate qualifies through wrapper-slice
+ * datum field (#2228)` in `go-template-adapter.test.ts`) — same signal
+ * shape (`createSignal<Todo[]>(props.initialTodos ?? [])`), same
+ * ternary-folded (block-body) predicate, same `key={todo.id} todo={todo}`
+ * child call — except the child (`TodoRow`) is declared in the SAME file
+ * instead of imported from a sibling module (so this harness's plain
+ * `source` compile, with no `components:` sibling file, doesn't trip the
+ * BF103 cross-template-registration refusal an imported child would need
+ * `siblingTemplatesRegistered` to suppress), AND the `.filter()` callback's
+ * own param is named `todo` — matching the `.map()` param — rather than
+ * the unit test's `t`.
+ *
+ * That last deviation is deliberate, not cosmetic: the unit test's
+ * `filter(t => …).map(todo => …)` naming (lifted verbatim from
+ * `TodoAppSSR.tsx`) reproduces #2228 on Go identically either way, since
+ * Go's fix keys off which PROP forwards the loop param, not the filter
+ * callback's own parameter name — but it ALSO trips a separate, unrelated
+ * bug on the ERB adapter: `ErbFilterEmitter.identifier()`
+ * (`packages/adapter-erb/src/adapter/expr/emitters.ts`) resolves a filter
+ * predicate's identifiers by comparing against the LOOP's (map's) param
+ * name, not the filter callback's OWN param — so when the two are named
+ * differently, a bare reference to the filter's own param (`t.done`)
+ * lowers to `v[:t][:done]`, an undefined Ruby hash key, and real ERB
+ * rendering raises `NoMethodError: undefined method '[]' for nil`. Same
+ * masking story as #2228 itself: `todo-app-ssr`'s `'all'`-default filter
+ * never evaluates the `t.done`-referencing branches, so this ERB gap has
+ * never fired in production either. It's untracked (no issue exists yet)
+ * and out of scope for this backfill (#2228/#2237), so this fixture
+ * routes around it — via the same-name predicate/loop param — rather
+ * than declaring a divergence for a bug this PR isn't fixing; flagged in
+ * the PR description for follow-up.
+ *
+ * Pre-#2240 this 500s on real Go (`can't evaluate field Done in type
+ * FilterWrapperPropsReachableTodoRowProps`); post-#2240 it renders only
+ * the not-done todos, at reference parity with Hono. `initialTodos` is
+ * non-empty with a mix of done/not-done so the filtered-out item (id 1)
+ * and the two kept items (ids 2, 3) are both visible in `expectedHtml`.
+ */
+export const fixture = createFixture({
+  id: 'filter-wrapper-props-reachable',
+  description: '.filter(todo => !todo.done).map(todo => <Child todo={todo}/>) with a non-\'all\' default filter reaches the wrapper-Props datum-field qualification (#2228)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+type Todo = { id: number; text: string; done: boolean }
+type Filter = 'all' | 'active'
+
+function TodoRow(props: { todo: Todo }) {
+  return <li>{props.todo.text}</li>
+}
+
+export function FilterWrapperPropsReachable(props: { initialTodos?: Todo[] }) {
+  const [todos] = createSignal<Todo[]>(props.initialTodos ?? [])
+  const [filter] = createSignal<Filter>('active')
+  return (
+    <ul>
+      {todos().filter(todo => {
+        const f = filter()
+        if (f === 'active') return !todo.done
+        return true
+      }).map(todo => (
+        <TodoRow key={todo.id} todo={todo} />
+      ))}
+    </ul>
+  )
+}
+`,
+  props: {
+    initialTodos: [
+      { id: 1, text: 'Eat breakfast', done: true },
+      { id: 2, text: 'Write tests', done: false },
+      { id: 3, text: 'Ship code', done: false },
+    ],
+  },
+  expectedHtml: `
+    <ul bf-s="test" bf="s1">
+      <li bf-s="TodoRow_*" bf="s1" data-key="2"><!--bf:s0-->Write tests<!--/--></li>
+      <li bf-s="TodoRow_*" bf="s1" data-key="3"><!--bf:s0-->Ship code<!--/--></li>
+    </ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -369,6 +369,14 @@ import { fixture as stringTrimSided } from './methods/string-trim-sided'
 // prop/const shadowing fixes (#2221, #2222 bug 2) landed.
 import { fixture as loopParamShadowsOuterName } from './loop-param-shadows-outer-name'
 import { fixture as loopParamShadowsConstKey } from './loop-param-shadows-const-key'
+// #2228 (PR #2240): filter-predicate wrapper-Props datum-field
+// qualification, made reachable by a non-'all' default filter (a
+// same-file child component avoids the BF103 sibling-import refusal).
+import { fixture as filterWrapperPropsReachable } from './filter-wrapper-props-reachable'
+// #2237 (PR #2241): a `.map()` callback param shadows a module-scope
+// object const; every Twig-family adapter used to bake the const's
+// literal into each iteration instead of reading the loop's own item.
+import { fixture as loopParamShadowsRecordConst } from './loop-param-shadows-record-const'
 
 import type { JSXFixture } from '../src/types'
 
@@ -643,4 +651,6 @@ export const jsxFixtures: JSXFixture[] = [
   stringTrimSided,
   loopParamShadowsOuterName,
   loopParamShadowsConstKey,
+  filterWrapperPropsReachable,
+  loopParamShadowsRecordConst,
 ]

--- a/packages/adapter-tests/fixtures/loop-param-shadows-record-const.ts
+++ b/packages/adapter-tests/fixtures/loop-param-shadows-record-const.ts
@@ -33,18 +33,13 @@ import { createFixture } from '../src/types'
  * this same pattern — was NOT touched by #2237 (whose fix only shipped
  * for the five template-string adapters above) and is a genuinely
  * separate code path from the bare-identifier `isLoopShadowed` guard
- * Go's own #2236/#2242 fixes hardened. Verified directly (compileJSX +
- * GoTemplateAdapter.generate over this exact source): the emitted
- * `markedTemplate` bakes `{{"outer-lit"}}` into the loop body regardless
- * of the range item, so real `go run` renders `'outer-lit'` for every
- * row instead of each row's own `x` — a genuine render-level divergence
- * from the Hono reference. This is the SAME bug class as #2237 but an
- * un-triaged instance on a sixth adapter, not a known-limitation with an
- * issue URL to point a `renderDivergences` docstring at — so it is
- * intentionally left UNDECLARED here rather than papered over with a
- * fabricated rationale. The go-template real-render conformance test
- * for this fixture id is expected to fail until a tracking issue exists
- * and either the bug is fixed or the divergence is declared against it.
+ * Go's own #2236/#2242 fixes hardened. Adding this fixture exposed it:
+ * the emitted `markedTemplate` baked `{{"outer-lit"}}` into the loop
+ * body regardless of the range item. FIXED in the same PR that added
+ * this fixture (PR #2246): `resolveStaticRecordLiteralIndex` now guards
+ * via the shared `isLoopShadowedName`, so Go renders each row's own `x`
+ * at reference parity like every other adapter — no divergence
+ * declaration needed.
  */
 export const fixture = createFixture({
   id: 'loop-param-shadows-record-const',

--- a/packages/adapter-tests/fixtures/loop-param-shadows-record-const.ts
+++ b/packages/adapter-tests/fixtures/loop-param-shadows-record-const.ts
@@ -1,0 +1,75 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A `.map()` callback param shadowing a module-scope OBJECT-LITERAL
+ * const, referenced via property access inside the loop body (#2237 —
+ * the record-literal sibling of `loop-param-shadows-const-key`'s
+ * primitive-literal case).
+ *
+ * `_resolveStaticRecordLiteral`-family lookups (`objectName.key` /
+ * `objectName['key']` over a module object-literal const, e.g.
+ * `variantClasses.ghost`) resolve `objectName` by a flat name lookup
+ * against `ir.metadata.localConstants` with no notion of AST scope, so
+ * pre-fix EVERY Twig-family adapter inlined the OUTER const's member
+ * value even at an occurrence that is actually an enclosing `.map()`
+ * callback's own (shadowing) parameter — every iteration rendered the
+ * same hard-coded `'outer-lit'` instead of the per-item value. Fixed for
+ * Twig, Jinja, Blade, Xslate, and Rust (minijinja) by guarding the
+ * lookup against `staticLoopSourceBoundNames` (same coarse exclusion
+ * #2221 established for the primitive-const case); Mojolicious was
+ * already immune (its resolver consults the live, scope-precise
+ * `loopBoundNames` map, #1749).
+ *
+ * Deliberately NO outside-the-loop reference to `cfg` (same rationale as
+ * `loop-param-shadows-const-key`): the Twig family's coarse guard
+ * suppresses inlining for a loop-bound name at non-shadowed occurrences
+ * too, which is an accepted per-adapter trade-off pinned by the #2237
+ * unit tests, not something this fixture should force a divergence
+ * declaration for.
+ *
+ * KNOWN GO GAP (untracked, not declared here): Go's equivalent lookup —
+ * `resolveStaticRecordLiteralIndex` in `go-template-adapter.ts`, which
+ * covers BOTH the bracket-string-literal and property-access forms of
+ * this same pattern — was NOT touched by #2237 (whose fix only shipped
+ * for the five template-string adapters above) and is a genuinely
+ * separate code path from the bare-identifier `isLoopShadowed` guard
+ * Go's own #2236/#2242 fixes hardened. Verified directly (compileJSX +
+ * GoTemplateAdapter.generate over this exact source): the emitted
+ * `markedTemplate` bakes `{{"outer-lit"}}` into the loop body regardless
+ * of the range item, so real `go run` renders `'outer-lit'` for every
+ * row instead of each row's own `x` — a genuine render-level divergence
+ * from the Hono reference. This is the SAME bug class as #2237 but an
+ * un-triaged instance on a sixth adapter, not a known-limitation with an
+ * issue URL to point a `renderDivergences` docstring at — so it is
+ * intentionally left UNDECLARED here rather than papered over with a
+ * fabricated rationale. The go-template real-render conformance test
+ * for this fixture id is expected to fail until a tracking issue exists
+ * and either the bug is fixed or the divergence is declared against it.
+ */
+export const fixture = createFixture({
+  id: 'loop-param-shadows-record-const',
+  description: '.map() callback param shadows a module-scope object-literal const, read via property access inside the loop (#2237)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+const cfg = { x: 'outer-lit' }
+
+export function LoopParamShadowsRecordConst({ rows }: { rows: { id: number; x: string }[] }) {
+  const [n, setN] = createSignal(0)
+  return (
+    <div data-n={n()} onClick={() => setN(n() + 1)}>
+      <ul>
+        {rows.map((cfg) => (
+          <li key={cfg.id}>{cfg.x}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+`,
+  props: { rows: [{ id: 1, x: 'alpha' }, { id: 2, x: 'beta' }] },
+  expectedHtml: `
+    <div bf-s="test" bf="s2" data-n="0"><ul bf="s1"><li data-key="1"><!--bf:s0-->alpha<!--/--></li><li data-key="2"><!--bf:s0-->beta<!--/--></li></ul></div>
+  `,
+})

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 246,
+    "totalFixtures": 248,
     "fixtures": {
       "dangerous-inner-html-dynamic": {
         "blade": {


### PR DESCRIPTION
Eighth PR of the stacked series — a conformance-corpus audit found two fixes from earlier in the stack pinned by unit tests only. Backfilling them immediately paid off: **the fixtures exposed two previously-unknown bugs**, one fixed here, one filed.

## New fixtures

**`filter-wrapper-props-reachable`** (pins #2228 / PR #2240). The existing `todo-app-ssr` corpus could never reach the wrapper-Props filter-predicate branch: its `filter` signal defaults to `'all'`, and Go `and`/`or` short-circuit evaluation eliminates the buggy branch at SSR time — which is exactly why #2228 shipped silently. This fixture uses a non-`'all'` default (`createSignal<'active' | 'all'>('active')`) so the predicate is reachable: the emitted Go template must qualify through the datum field (`{{if or … (not .Todo.Done)}}`) and real `go run` renders the filtered list at reference parity.

**`loop-param-shadows-record-const`** (pins #2237 / PR #2241). Module-scope `const cfg = { x: 'outer-lit' }` shadowed by the `.map()` callback param, member-read inside the loop. All Twig-family adapters render per-item values post-#2241.

## Bugs the fixtures found

1. **Go `resolveStaticRecordLiteralIndex` had no loop-shadow guard** — the record-member sibling of #2236's bare-identifier gap (`IDENT['key']` / `IDENT.key` fast path), baking `{{"outer-lit"}}` into every iteration. **Fixed here**: the same scope-precise check as #2236 (including the destructured-callback `loopBindingStack` scan), factored into a shared `isLoopShadowedName` used by both fast paths, plus a unit pin. Changeset: patch `@barefootjs/go-template`.
2. **ERB filter-predicate identifier lowering keys off the map callback's param, not the filter callback's own** — `filter(t => …).map(todo => …)` raises `NoMethodError` in real Ruby the moment the predicate is reachable (masked by the same `'all'`-default story). Filed as #2245; the fixture uses matching callback names so it pins #2228 without depending on that fix.

## Verification

Both fixtures render at reference parity on CSR + Hono, Go (real `go run`), Twig + Blade (real PHP after `composer install`), Jinja (real Python), ERB (real Ruby), Rust/minijinja; Mojolicious/Xslate NotAvailable-skip as usual. compat.lock: totalFixtures 246 → 248, no divergence entries. Go suite green including the previously-red record-const render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxCtWVr3LBPEPsaK9b5kdD

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxCtWVr3LBPEPsaK9b5kdD)_