### PR TITLE
ERB: match filter-predicate identifiers against the predicate's own param (#2245)

### DIFF
--- a/.changeset/erb-filter-predicate-param-name.md
+++ b/.changeset/erb-filter-predicate-param-name.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/erb": patch
+---
+
+Fix #2245: a `filter().map()` loop whose filter and map callbacks name their params differently (e.g. `todos.filter(t => t.done).map(todo => ...)`, the exact `TodoAppSSR.tsx` shape) no longer raises `NoMethodError: undefined method '[]' for nil` at real Ruby render time. `ErbFilterEmitter` used to match a filter predicate's identifiers against the LOOP's (map callback's) param instead of the filter callback's OWN param, so a differently-named filter param lowered to an unseeded `v[:name]` vars-Hash read; it now matches against the filter's own param while still emitting the loop's actual bound Ruby local (`ErbFilterEmitter`'s new `renderParamAs`). Masked in the shipped corpus by `todo-app-ssr`'s `'all'`-default filter short-circuiting the buggy predicate branch away — pinned by the new `filter-param-name-differs` cross-adapter fixture and ERB adapter unit tests.

--- a/packages/adapter-erb/src/__tests__/erb-adapter.test.ts
+++ b/packages/adapter-erb/src/__tests__/erb-adapter.test.ts
@@ -305,6 +305,127 @@ export { Slot }
   })
 })
 
+describe('ErbAdapter - filter().map() predicate matches the FILTER param, not the loop param (#2245)', () => {
+  // `todos.filter(t => t.done).map(todo => ...)`: the predicate's own `t`
+  // used to be matched against the LOOP's (map's) param `todo` inside
+  // `ErbFilterEmitter.identifier()`, so every reference to `t` inside the
+  // predicate fell to the `v[:t]` vars-Hash fallback instead of resolving
+  // to the loop-bound `todo` local — `v[:t]` is never seeded, and real
+  // Ruby raises `NoMethodError: undefined method '[]' for nil` on
+  // `v[:t][:done]` at render time (masked in the shipped `todo-app-ssr`
+  // corpus by its `'all'`-default filter short-circuiting the buggy
+  // branch away — see `filter-wrapper-props-reachable`'s docstring).
+  const DIFFERENTLY_NAMED_SOURCE = `
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+type Todo = { id: number; text: string; done: boolean }
+
+export function TodoList(props: { initialTodos?: Todo[] }) {
+  const [todos] = createSignal<Todo[]>(props.initialTodos ?? [])
+  return (
+    <ul>
+      {todos().filter(t => !t.done).map(todo => (
+        <li key={todo.id}>{todo.text}</li>
+      ))}
+    </ul>
+  )
+}
+`
+
+  function compileToIR(source: string): ComponentIR {
+    const result = compileJSX(source.trimStart(), 'test.tsx', {
+      adapter: new ErbAdapter(),
+      outputIR: true,
+    })
+    const irFile = result.files.find(f => f.type === 'ir')
+    if (!irFile) throw new Error('No IR output')
+    return JSON.parse(irFile.content) as ComponentIR
+  }
+
+  test('predicate reference lowers through the loop-bound local, never the filter-param vars-Hash fallback', () => {
+    const ir = compileToIR(DIFFERENTLY_NAMED_SOURCE)
+    const { template } = new ErbAdapter().generate(ir)
+    // The loop-gating `<if>` must reference the loop's actual bound Ruby
+    // local (`todo[:done]`, from the MAP callback's param)...
+    expect(template).toContain('todo[:done]')
+    // ...never the filter callback's own param name resolved as an
+    // (unseeded) vars-Hash key — the literal pre-fix bug.
+    expect(template).not.toContain('v[:t]')
+  })
+
+  test('same-named filter/map params render byte-identically to the pre-#2245 form (regression pin)', () => {
+    const sameNamedSource = DIFFERENTLY_NAMED_SOURCE.replace(
+      'filter(t => !t.done)',
+      'filter(todo => !todo.done)',
+    )
+    const ir = compileToIR(sameNamedSource)
+    const { template } = new ErbAdapter().generate(ir)
+    expect(template).toContain('<%- if bf.truthy?(!bf.truthy?(todo[:done])) -%>')
+  })
+
+  test('real Ruby render: reachable predicate on differently-named params renders correctly (pre-fix NoMethodError pin)', async () => {
+    // `filter` defaults to `'active'` (never `'all'`) so the predicate
+    // branch referencing `t.done` is actually REACHABLE at render time —
+    // an `'all'`-style short-circuiting default is exactly what hid this
+    // bug in the shipped `todo-app-ssr` fixture. Block-body predicate
+    // (folded to one expression by #2040's `foldBlockToExpr` +
+    // `predicateTernaryToLogical`) matches the real `TodoAppSSR.tsx` shape.
+    const source = `
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+type Todo = { id: number; text: string; done: boolean }
+type Filter = 'all' | 'active'
+
+export function TodoList(props: { initialTodos?: Todo[] }) {
+  const [todos] = createSignal<Todo[]>(props.initialTodos ?? [])
+  const [filter] = createSignal<Filter>('active')
+  return (
+    <ul>
+      {todos().filter(t => {
+        const f = filter()
+        if (f === 'active') return !t.done
+        return true
+      }).map(todo => (
+        <li key={todo.id}>{todo.text}</li>
+      ))}
+    </ul>
+  )
+}
+`
+    let html: string
+    try {
+      html = await renderErbComponent({
+        source: source.trimStart(),
+        adapter: new ErbAdapter(),
+        props: {
+          initialTodos: [
+            { id: 1, text: 'Eat breakfast', done: true },
+            { id: 2, text: 'Write tests', done: false },
+          ],
+        },
+      })
+    } catch (err) {
+      if (err instanceof ErbNotAvailableError) {
+        console.log('Skipping #2245 filter-param e2e: ruby/erb not available')
+        return
+      }
+      throw err
+    }
+    // Pre-fix: real Ruby raises `NoMethodError: undefined method '[]' for
+    // nil` evaluating `v[:t][:done]` — `renderErbComponent` surfaces that
+    // as a thrown "ruby render failed" error, so a `NoMethodError` string
+    // anywhere in a caught error would fail this test outright rather than
+    // reaching these assertions. Post-fix: only the not-done todo (id 2)
+    // survives the 'active' filter.
+    expect(html).not.toContain('Eat breakfast')
+    expect(html).toContain('Write tests')
+    expect(html).toContain('data-key="2"')
+    expect(html).not.toContain('data-key="1"')
+  })
+})
+
 describe('ErbAdapter - named-slot capture identifier safety (#2168 jsx-element-prop)', () => {
   // A JSX-valued prop under a hyphenated name (`data-slot`, a valid JSX
   // attribute name) must not leak into the buffer-slice capture's local

--- a/packages/adapter-erb/src/adapter/erb-adapter.ts
+++ b/packages/adapter-erb/src/adapter/erb-adapter.ts
@@ -1090,14 +1090,31 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
     if (loop.filterPredicate) {
       let filterCond: string
       if (loop.filterPredicate.predicate) {
-        // The loop's own (possibly destructure-adjusted) param name IS the
-        // filter predicate's parameter for rendering purposes — pass it
-        // straight through as the filter emitter's bound param. Ruby's
-        // named-block-param model makes the Mojo original's regex
-        // `$filterParam → $loopParam` rename unnecessary here: the emitter
-        // just renders every reference to the predicate's own arrow
-        // parameter AS `param` from the start.
-        filterCond = this.renderRubyFilterExpr(loop.filterPredicate.predicate, param)
+        // The filter predicate's identifiers were parsed against the
+        // FILTER callback's own param (`loop.filterPredicate.param`), which
+        // can differ from the loop's rendered Ruby local (`param`, the MAP
+        // callback's param) whenever the two are named differently —
+        // `todos.filter(t => t.done).map(todo => ...)` (#2245). Ruby's
+        // named-block-param model means there's no Mojo-style regex
+        // `$filterParam → $loopParam` TEXT rewrite to do, but the
+        // DISTINCTION it encoded still matters: match identifiers against
+        // the filter's own param, while EMITTING the loop's actual bound
+        // local — `ErbFilterEmitter`'s `renderParamAs` carries that split.
+        // `filterPredicate.param` is only ever a bare identifier in
+        // practice (`extractFilterPredicate` in jsx-to-ir.ts refuses a
+        // destructured filter param outright, leaving `filterPredicate`
+        // unset entirely rather than populating it with pattern text — see
+        // its docstring), but guard defensively instead of relying on that
+        // invariant: a pattern-text param (leading `[`/`{` — the same
+        // prefix check `destructureLoopParam`/#2238 use, NOT an identifier
+        // regex, which would misclassify a Unicode param name) falls back
+        // to `param`, matching pre-#2245 behavior byte-for-byte.
+        const filterOwnParam = loop.filterPredicate.param
+        const matchParam =
+          filterOwnParam && !filterOwnParam.startsWith('[') && !filterOwnParam.startsWith('{')
+            ? filterOwnParam
+            : param
+        filterCond = this.renderRubyFilterExpr(loop.filterPredicate.predicate, matchParam, undefined, rubyLocal(param))
       } else {
         filterCond = 'true'
       }
@@ -1619,6 +1636,14 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
     expr: ParsedExpr,
     param: string,
     localVarMap: Map<string, string> = new Map(),
+    // See `ErbFilterEmitter`'s constructor docstring (#2245): the Ruby
+    // local to EMIT for a reference to `param`, when it differs from
+    // `param` itself (the loop-gating call site passes the filter
+    // callback's own param as `param` — the name to MATCH — and this as
+    // the loop's actual bound local). Every other caller omits it, so
+    // `ErbFilterEmitter`'s own default (`rubyLocal(param)`) applies and
+    // match/render stay the same value, unchanged from before #2245.
+    renderParamAs?: string,
   ): string {
     return emitParsedExpr(
       expr,
@@ -1628,6 +1653,7 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
         n => this.isLoopBoundName(n),
         n => this._isStringValueName(n),
         (message, reason) => this._recordExprBF101(message, reason),
+        renderParamAs,
       ),
     )
   }

--- a/packages/adapter-erb/src/adapter/expr/emitters.ts
+++ b/packages/adapter-erb/src/adapter/expr/emitters.ts
@@ -106,10 +106,23 @@ export class ErbFilterEmitter implements ParsedExprEmitter {
     // construction stays possible without an adapter; a missing hook keeps
     // the old silent-degrade emit.
     private readonly onUnsupported?: (message: string, reason?: string) => void,
+    // The Ruby local to EMIT for a reference matching `this.param` — as
+    // opposed to `this.param` itself, which is only the name to MATCH.
+    // These two are the SAME value everywhere in this file except the
+    // `filter().map()` loop-gating `<if>` (erb-adapter.ts's `renderLoop`,
+    // #2245): `todos.filter(t => t.done).map(todo => ...)` parses the
+    // predicate against the filter callback's OWN param (`t`), but the
+    // Ruby local actually bound by the loop is the MAP callback's param
+    // (`todo`) — Ruby has no per-callback block scope there (unlike the
+    // real nested `.select { |t| ... }` block `callbackMethod` below
+    // builds, where match and render are naturally the same param).
+    // Defaults to `rubyLocal(this.param)`, i.e. every other construction
+    // site is unaffected.
+    private readonly renderParamAs: string = rubyLocal(param),
   ) {}
 
   identifier(name: string): string {
-    if (name === this.param) return rubyLocal(this.param)
+    if (name === this.param) return this.renderParamAs
     const signal = this.localVarMap.get(name)
     if (signal) return `v[${rubySymbolLiteral(signal)}]`
     if (this.isLoopBoundOuter(name)) return rubyLocal(name)

--- a/packages/adapter-tests/fixtures/filter-param-name-differs.ts
+++ b/packages/adapter-tests/fixtures/filter-param-name-differs.ts
@@ -1,0 +1,80 @@
+import { createFixture } from '../src/types'
+
+/**
+ * The un-routed-around twin of `filter-wrapper-props-reachable` (#2228).
+ * Same shape — `.filter(predicate).map(todo => <Child todo={todo}/>)` over
+ * a SAME-FILE child component, filter defaulting to `'active'` (never
+ * `'all'`) so the predicate branch is actually REACHABLE — except this
+ * fixture uses the ORIGINAL, un-routed-around param naming lifted verbatim
+ * from `TodoAppSSR.tsx`: `filter(t => ...)` for the filter callback,
+ * `map(todo => ...)` for the map callback.
+ *
+ * `filter-wrapper-props-reachable` deliberately renamed its filter
+ * callback's param to `todo` (matching the map callback) to dodge a
+ * SEPARATE, ERB-only bug tracked as #2245: `ErbFilterEmitter.identifier()`
+ * (`packages/adapter-erb/src/adapter/expr/emitters.ts`) matched a filter
+ * predicate's identifiers against the LOOP's (map's) own param, not the
+ * filter callback's OWN param — so a differently-named filter param (`t`)
+ * lowered every reference to `t` in the predicate to the unseeded
+ * `v[:t]` vars-Hash fallback instead of the loop-bound `todo` local, and
+ * real Ruby raised `NoMethodError: undefined method '[]' for nil` at
+ * render time. Masked in production the same way #2228 was: `todo-app-ssr`'s
+ * `'all'`-default filter short-circuits the `t.done`-referencing branch
+ * away entirely.
+ *
+ * #2245 fixed `ErbFilterEmitter` (`renderParamAs`, defaulting to
+ * `rubyLocal(param)` everywhere except the `filter().map()` loop-gating
+ * `<if>`, which now matches identifiers against the filter's own param
+ * while EMITTING the loop's actual bound Ruby local) — so this fixture
+ * pins the now-FIXED behavior with the un-routed-around naming
+ * `filter-wrapper-props-reachable` had to avoid. Both fixtures otherwise
+ * co-exercise the same #2228 Go wrapper-Props datum-field qualification
+ * (`todo={todo}` forwards the MAP callback's own param, which is what Go's
+ * fix keys off — untouched by which name the filter callback happens to
+ * use).
+ */
+export const fixture = createFixture({
+  id: 'filter-param-name-differs',
+  description:
+    '.filter(t => !t.done).map(todo => <Child todo={todo}/>) with differently-named filter/map params and a reachable (non-\'all\'-default) predicate (#2245)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+type Todo = { id: number; text: string; done: boolean }
+type Filter = 'all' | 'active'
+
+function TodoRow(props: { todo: Todo }) {
+  return <li>{props.todo.text}</li>
+}
+
+export function FilterParamNameDiffers(props: { initialTodos?: Todo[] }) {
+  const [todos] = createSignal<Todo[]>(props.initialTodos ?? [])
+  const [filter] = createSignal<Filter>('active')
+  return (
+    <ul>
+      {todos().filter(t => {
+        const f = filter()
+        if (f === 'active') return !t.done
+        return true
+      }).map(todo => (
+        <TodoRow key={todo.id} todo={todo} />
+      ))}
+    </ul>
+  )
+}
+`,
+  props: {
+    initialTodos: [
+      { id: 1, text: 'Eat breakfast', done: true },
+      { id: 2, text: 'Write tests', done: false },
+      { id: 3, text: 'Ship code', done: false },
+    ],
+  },
+  expectedHtml: `
+    <ul bf-s="test" bf="s1">
+      <li bf-s="TodoRow_*" bf="s1" data-key="2"><!--bf:s0-->Write tests<!--/--></li>
+      <li bf-s="TodoRow_*" bf="s1" data-key="3"><!--bf:s0-->Ship code<!--/--></li>
+    </ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/filter-wrapper-props-reachable.ts
+++ b/packages/adapter-tests/fixtures/filter-wrapper-props-reachable.ts
@@ -48,7 +48,11 @@ import { createFixture } from '../src/types'
  * never fired in production either. Tracked as #2245 and out of scope
  * for this backfill (#2228/#2237), so this fixture routes around it —
  * via the same-name predicate/loop param — rather than declaring a
- * divergence for a bug this PR isn't fixing.
+ * divergence for a bug this PR isn't fixing. #2245 is now fixed and
+ * pinned by this fixture's un-routed-around twin, `filter-param-name-
+ * differs` (`./filter-param-name-differs.ts`), which keeps the original
+ * differently-named `t`/`todo` params and asserts the fixed behavior
+ * directly instead of routing around it.
  *
  * Pre-#2240 this 500s on real Go (`can't evaluate field Done in type
  * FilterWrapperPropsReachableTodoRowProps`); post-#2240 it renders only

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -373,6 +373,11 @@ import { fixture as loopParamShadowsConstKey } from './loop-param-shadows-const-
 // qualification, made reachable by a non-'all' default filter (a
 // same-file child component avoids the BF103 sibling-import refusal).
 import { fixture as filterWrapperPropsReachable } from './filter-wrapper-props-reachable'
+// #2245: the un-routed-around twin of `filterWrapperPropsReachable` above —
+// same shape, but keeps the filter/map callbacks' ORIGINALLY differently-
+// named params (`t` / `todo`) instead of renaming to dodge the ERB-only
+// `ErbFilterEmitter` ID-matching bug that naming previously routed around.
+import { fixture as filterParamNameDiffers } from './filter-param-name-differs'
 // #2237 (PR #2241): a `.map()` callback param shadows a module-scope
 // object const; every Twig-family adapter used to bake the const's
 // literal into each iteration instead of reading the loop's own item.
@@ -652,5 +657,6 @@ export const jsxFixtures: JSXFixture[] = [
   loopParamShadowsOuterName,
   loopParamShadowsConstKey,
   filterWrapperPropsReachable,
+  filterParamNameDiffers,
   loopParamShadowsRecordConst,
 ]

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 248,
+    "totalFixtures": 249,
     "fixtures": {
       "dangerous-inner-html-dynamic": {
         "blade": {


### PR DESCRIPTION
Fixes #2245 — the bug the `filter-wrapper-props-reachable` fixture (PR #2246) discovered and had to route around.

## Problem

`renderRubyFilterExpr`'s loop-gating call site passed the LOOP's (map callback's) `param` as the `ErbFilterEmitter`'s bound param, on the documented — and incorrect — assumption that Ruby's named-block-param model made the Mojo original's `filterParam → loopParam` rename unnecessary. That holds only when the filter and map callbacks happen to share a name. With `todos().filter(t => …).map(todo => …)` (the exact `TodoAppSSR.tsx` shape), the predicate's own `t` never matches in `identifier()` and falls to the `v[:t]` hash-key fallback → `nil[:done]` → **`NoMethodError: undefined method '[]' for nil`** in real Ruby, the moment the predicate branch is reachable. Masked in the shipped corpus by `todo-app-ssr`'s `'all'` default via short-circuit — the same masking story as #2228.

## Fix

Match against the predicate's OWN param (`loop.filterPredicate.param`, when it isn't destructure-pattern text — the leading-`[`/`{` check per the #2238 idiom, not an ASCII identifier regex) and render it as the loop's Ruby local, via a new default-valued `renderParamAs` on `ErbFilterEmitter` — the semantic equivalent of Mojo's rename. When the filter param is absent or a pattern, behavior is byte-identical to today.

**Call-site audit**: the nested-callback emitter and the `.find()`/`.some()`/`.every()` predicate lowerings are correct as-is — each binds its own arrow's param as the emitted Ruby block variable, so match-name = render-name there; the default-valued parameter leaves them byte-for-byte unchanged.

## Tests

- `#2245` describe in the ERB suite: the differently-named shape verified red pre-fix — including an end-to-end real-Ruby render raising the exact `NoMethodError` — and green post-fix (renders only the not-done todo); same-named-params byte-stability pin.
- New cross-adapter fixture **`filter-param-name-differs`** — the un-routed-around twin of `filter-wrapper-props-reachable` (differently-named `t`/`todo` params, reachable non-`'all'` predicate). Reference parity on CSR + Hono, Go (real `go run`), Twig, Jinja, Blade, ERB (real Ruby), Rust/minijinja; Mojolicious/Xslate NotAvailable-skip. `filter-wrapper-props-reachable`'s docstring now points at the twin instead of "routes around #2245".
- compat.lock: totalFixtures 248 → 249, no divergence entries. Changeset: patch `@barefootjs/erb`.
- Suites: adapter-erb **518 pass / 0 fail**, adapter-tests **1253 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxCtWVr3LBPEPsaK9b5kdD

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxCtWVr3LBPEPsaK9b5kdD)_