### PR TITLE
Add data-point oracle conformance suite (subset-conformance roadmap 1)

### DIFF
--- a/.changeset/go-test-render-string-escaping.md
+++ b/.changeset/go-test-render-string-escaping.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Fix `test-render`'s prop-to-Go-literal string emission: string props were interpolated into the generated `main.go` with quote-only (or no) escaping, so a `"`, backslash, or newline in a prop value broke the render harness at Go compile time. All four emission sites now share `goStringLit` (`JSON.stringify`, whose escapes are a subset of Go's interpreted-string-literal escapes). Found by the data-point oracle conformance pilot (`spec/subset-conformance.md`): the `html-in-label` adversarial point passes on real Go after the fix.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -119,6 +119,16 @@ runAdapterConformanceTests({
     // (#1897) data-table no longer skipped — loop body children + wrapper
     // struct + block-body memo baking render correctly on Go.
   ]),
+  skipDataPoints: new Set<string>([
+    // #2248 — optional scalar props lower to non-pointer zero-valued Go
+    // fields, so `??` cannot distinguish "absent" from `''`/`0` at render
+    // time: JS keeps `''`/`0` (not nullish), Go falls back to the default.
+    // `both-absent` and `html-in-label` pass; only the zero-value-shaped
+    // points diverge. Remove these entries as the acceptance test for the
+    // nillable-lowering fix.
+    'nullish-coalescing-text:empty-label',
+    'nullish-coalescing-text:zero-size',
+  ]),
   onRenderError: (err, id) => {
     if (err instanceof GoNotAvailableError) {
       console.log(`Skipping [${id}]: ${err.message}`)

--- a/packages/adapter-go-template/src/test-render.ts
+++ b/packages/adapter-go-template/src/test-render.ts
@@ -699,7 +699,7 @@ function buildGoPropsInit(
     // not the naive `Id`) — see `goMapLiteralFromObject`'s identical fix.
     const goField = capitalizeFieldName(key)
     if (typeof value === 'string') {
-      lines.push(`\t\t${goField}: "${value}",`)
+      lines.push(`\t\t${goField}: ${goStringLit(value)},`)
     } else if (typeof value === 'number') {
       lines.push(`\t\t${goField}: ${value},`)
     } else if (typeof value === 'boolean') {
@@ -828,6 +828,20 @@ function goTypedMapSliceLiteralFromArray(arr: unknown[], elemType: string): stri
  * names. Only the keys the caller supplied are set, so an omitted optional prop
  * (e.g. `defaultOn` on the third toggle item) takes the Go zero value. (#1297)
  */
+/**
+ * Emit a JS string as a Go interpreted string literal. JSON string
+ * escaping is a subset of Go's (`\"`, `\\`, `\n`, `\uXXXX` are all valid
+ * Go escapes), so `JSON.stringify` is a correct emitter — unlike the
+ * previous quote-only `.replace(/"/g, '\\"')`, it also survives
+ * backslashes, newlines, and control characters (data-point conformance
+ * caught the quote case: a `"` in a string prop broke the generated
+ * `main.go` at compile time). Lone surrogates emit as `\uDXXX`, which Go
+ * rejects — acceptable until a fixture needs malformed-UTF-16 props.
+ */
+function goStringLit(v: string): string {
+  return JSON.stringify(v)
+}
+
 function goStructLiteral(obj: Record<string, unknown>, typeName: string): string {
   const fields: string[] = []
   for (const [k, v] of Object.entries(obj)) {
@@ -836,7 +850,7 @@ function goStructLiteral(obj: Record<string, unknown>, typeName: string): string
     // adapter's own struct-literal baking (`parsed-literal-to-go.ts`)
     // sanitizes those to `DataX`, not `Data-x` (Copilot review, #2202).
     const goField = goFieldNameForKey(k)
-    if (typeof v === 'string') fields.push(`${goField}: "${v.replace(/"/g, '\\"')}"`)
+    if (typeof v === 'string') fields.push(`${goField}: ${goStringLit(v)}`)
     else if (typeof v === 'number' || typeof v === 'boolean') fields.push(`${goField}: ${v}`)
     else if (v === null) fields.push(`${goField}: nil`)
     else if (Array.isArray(v)) fields.push(`${goField}: ${goArrayLiteralFromArray(v)}`)
@@ -848,7 +862,7 @@ function goStructLiteral(obj: Record<string, unknown>, typeName: string): string
 function goArrayLiteralFromArray(arr: unknown[]): string {
   const entries: string[] = []
   for (const v of arr) {
-    if (typeof v === 'string') entries.push(`"${v.replace(/"/g, '\\"')}"`)
+    if (typeof v === 'string') entries.push(goStringLit(v))
     else if (typeof v === 'number') entries.push(String(v))
     else if (typeof v === 'boolean') entries.push(String(v))
     else if (v === null) entries.push('nil')
@@ -886,7 +900,7 @@ function goMapLiteralFromObject(
     // uses for exactly this key-to-Go-field sanitization.
     const emittedKey = capitalizeKeys ? goFieldNameForKey(k) : k
     const key = JSON.stringify(emittedKey)
-    if (typeof v === 'string') entries.push(`${key}: "${v.replace(/"/g, '\\"')}"`)
+    if (typeof v === 'string') entries.push(`${key}: ${goStringLit(v)}`)
     else if (typeof v === 'number') entries.push(`${key}: ${v}`)
     else if (typeof v === 'boolean') entries.push(`${key}: ${v}`)
     else if (v === null) entries.push(`${key}: nil`)

--- a/packages/adapter-tests/fixtures/nullish-coalescing-text.ts
+++ b/packages/adapter-tests/fixtures/nullish-coalescing-text.ts
@@ -12,6 +12,16 @@ export function NullishCoalescingText(props: { label?: string; size?: number }) 
 }
 `,
   props: { label: 'Custom', size: 5 },
+  // Oracle conformance pilot (spec/subset-conformance.md, roadmap 1).
+  // `??` is the classic divergence surface: '' and 0 are nullish-KEPT
+  // in JS (unlike `||`), which a backend lowering that models optional
+  // props as zero-values cannot distinguish from "absent".
+  dataPoints: [
+    { name: 'both-absent', props: {} },
+    { name: 'empty-label', props: { label: '' } },
+    { name: 'zero-size', props: { size: 0 } },
+    { name: 'html-in-label', props: { label: '<b>&"quote' } },
+  ],
   expectedHtml: `
     <div bf-s="test">
       <span bf="s1"><!--bf:s0-->Custom<!--/--></span>

--- a/packages/adapter-tests/src/data-point-conformance.ts
+++ b/packages/adapter-tests/src/data-point-conformance.ts
@@ -1,0 +1,148 @@
+/**
+ * Oracle conformance over multiplied evaluation points
+ * (`spec/subset-conformance.md`, roadmap stage 1).
+ *
+ * A marked template is a function from data to HTML; the fixture's
+ * primary `props`/`expectedHtml` pair observes exactly one point of it.
+ * This suite re-renders each fixture that declares `dataPoints` at every
+ * additional point, through BOTH the adapter under test and the live JS
+ * reference render (the canonical reference implementation — the Hono
+ * pipeline), and asserts the normalized HTML is identical. No expected
+ * output is stored for data points: the oracle computes it at test time,
+ * so it cannot drift.
+ *
+ * Gate ordering: data points prove nothing when the basic shape is
+ * already broken, so each fixture's points run only after its primary
+ * render matches `expectedHtml` (the hand-written smoke point, which
+ * doubles as the human pin against oracle-and-adapter agreeing on the
+ * same bug). A failed gate is reported by the JSX conformance suite —
+ * the point tests then no-op instead of duplicating the failure.
+ *
+ * Skips follow the established discipline: a typed
+ * `${fixtureId}:${pointName}` set, each entry commented with the
+ * follow-up `known-limitation` issue.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { HonoAdapter } from '@barefootjs/hono/adapter'
+import { renderHonoComponent } from '@barefootjs/hono/test-render'
+import type { TemplateAdapter } from '../../jsx/src/types'
+import { jsxFixtures } from '../fixtures'
+import type { JSXFixture } from './types'
+import {
+  normalizeHTML,
+  stripConditionalMarkersForCrossAdapter,
+  type RenderOptions,
+} from './jsx-runner'
+
+export interface RunDataPointConformanceOptions {
+  /** Short lowercase label used in `describe` headings. */
+  name: string
+  /** Fresh-instance factory, one adapter per render. */
+  factory: () => TemplateAdapter
+  /** The adapter's real render pipeline (same as the JSX suite). */
+  render: (opts: RenderOptions) => Promise<string>
+  /** Same renderer-unavailable escape hatch as the JSX suite. */
+  onRenderError?: (err: Error, fixtureId: string) => boolean
+  /**
+   * Fixture ids excluded wholesale — fixtures this adapter already
+   * skips in the JSX suite or refuses via `expectedDiagnostics`
+   * (their primary point cannot gate anything).
+   */
+  skipFixtures: ReadonlySet<string>
+  /**
+   * Per-point opt-outs, keyed `${fixtureId}:${pointName}`. Each entry
+   * must carry a comment naming the divergence and its follow-up
+   * `known-limitation` issue.
+   */
+  skipDataPoints?: ReadonlySet<string>
+}
+
+type GateResult = 'pass' | 'fail' | 'unavailable'
+
+function canonical(html: string): string {
+  return stripConditionalMarkersForCrossAdapter(normalizeHTML(html))
+}
+
+function renderOptions(fixture: JSXFixture, adapter: TemplateAdapter, props: Record<string, unknown> | undefined): RenderOptions {
+  return {
+    source: fixture.source,
+    adapter,
+    // Same prop-mutation isolation as the JSX suite: a fixture source
+    // that mutates its props (`.sort()`, `.reverse()`) must not poison
+    // the shared fixture object across renders.
+    props: props !== undefined ? structuredClone(props) : undefined,
+    components: fixture.components,
+    componentModules: fixture.componentModules,
+    componentName: fixture.componentName,
+  }
+}
+
+export function runDataPointConformance(opts: RunDataPointConformanceOptions): void {
+  const fixtures = jsxFixtures.filter(
+    f => (f.dataPoints?.length ?? 0) > 0 && !opts.skipFixtures.has(f.id),
+  )
+  if (fixtures.length === 0) return
+
+  describe('data-point conformance (oracle)', () => {
+    for (const fixture of fixtures) {
+      describe(`[${fixture.id}]`, () => {
+        // One gate render per fixture, shared by its point tests. The
+        // promise is created lazily so a fully-skipped fixture never
+        // renders.
+        let gate: Promise<GateResult> | undefined
+        const runGate = (): Promise<GateResult> => {
+          gate ??= (async () => {
+            let html: string
+            try {
+              html = await opts.render(renderOptions(fixture, opts.factory(), fixture.props))
+            } catch (err) {
+              if (opts.onRenderError?.(err as Error, fixture.id)) return 'unavailable'
+              throw err
+            }
+            // `expectedHtml` presence is enforced by `createFixture` for
+            // fixtures declaring dataPoints.
+            return canonical(html) === canonical(fixture.expectedHtml as string) ? 'pass' : 'fail'
+          })()
+          return gate
+        }
+
+        for (const point of fixture.dataPoints ?? []) {
+          if (opts.skipDataPoints?.has(`${fixture.id}:${point.name}`)) continue
+
+          test(
+            `point '${point.name}' matches the JS reference render`,
+            async () => {
+              const gateResult = await runGate()
+              if (gateResult === 'unavailable') return
+              if (gateResult === 'fail') {
+                // The primary smoke point failed — reported loudly by
+                // the JSX conformance suite for this fixture; adversarial
+                // points prove nothing on a broken base shape.
+                console.warn(
+                  `[${opts.name}] ${fixture.id}: primary expectedHtml mismatch — ` +
+                    `data point '${point.name}' gated (see JSX conformance failure)`,
+                )
+                return
+              }
+
+              let adapterHtml: string
+              try {
+                adapterHtml = await opts.render(renderOptions(fixture, opts.factory(), point.props))
+              } catch (err) {
+                if (opts.onRenderError?.(err as Error, fixture.id)) return
+                throw err
+              }
+              const oracleHtml = await renderHonoComponent(
+                renderOptions(fixture, new HonoAdapter(), point.props),
+              )
+
+              expect(canonical(adapterHtml)).toBe(canonical(oracleHtml))
+            },
+            30_000,
+          )
+        }
+      })
+    }
+  })
+}

--- a/packages/adapter-tests/src/index.ts
+++ b/packages/adapter-tests/src/index.ts
@@ -6,7 +6,9 @@
 
 export { runJSXConformanceTests, normalizeHTML, stripConditionalMarkersForCrossAdapter } from './jsx-runner'
 export { createFixture, normalizeExpectedHtml } from './types'
-export type { JSXFixture, ExpectedDiagnostic } from './types'
+export type { JSXFixture, JSXDataPoint, ExpectedDiagnostic } from './types'
+export { runDataPointConformance } from './data-point-conformance'
+export type { RunDataPointConformanceOptions } from './data-point-conformance'
 export { indentHTML } from './indent-html'
 export type { RunJSXConformanceOptions, RenderOptions } from './jsx-runner'
 export { runConformanceSuite } from './conformance'

--- a/packages/adapter-tests/src/run-adapter-conformance.ts
+++ b/packages/adapter-tests/src/run-adapter-conformance.ts
@@ -26,6 +26,7 @@ import { describe, test, expect } from 'bun:test'
 import type { TemplateAdapter } from '../../jsx/src/types'
 import { runJSXConformanceTests, type RenderOptions } from './jsx-runner'
 import { runConformanceSuite } from './conformance'
+import { runDataPointConformance } from './data-point-conformance'
 import { runMarkerConformance } from './marker-conformance'
 import type { ExpectedDiagnostic } from './types'
 import {
@@ -90,6 +91,16 @@ export interface RunAdapterConformanceOptions {
    * so adding a new adapter doesn't touch any fixture file.
    */
   expectedDiagnostics?: Record<string, ReadonlyArray<ExpectedDiagnostic>>
+  /**
+   * Data points (`spec/subset-conformance.md`) whose oracle comparison
+   * is consciously diverging on this adapter, keyed
+   * `${fixtureId}:${pointName}`. Each entry should be paired with a
+   * comment naming the divergence and the follow-up `known-limitation`
+   * issue; missing entries default to "skip nothing". Fixtures already
+   * in `skipJsx` / `expectedDiagnostics` are excluded wholesale — their
+   * primary point cannot gate anything.
+   */
+  skipDataPoints?: ReadonlySet<string>
 }
 
 export function runAdapterConformanceTests(
@@ -121,6 +132,18 @@ export function runAdapterConformanceTests(
     name: opts.name,
     factory: opts.factory,
     skipFixtures: opts.skipMarkerConformance,
+  })
+
+  runDataPointConformance({
+    name: opts.name,
+    factory: opts.factory,
+    render: opts.render,
+    onRenderError: opts.onRenderError,
+    skipFixtures: new Set([
+      ...(opts.skipJsx ?? []),
+      ...Object.keys(opts.expectedDiagnostics ?? {}),
+    ]),
+    skipDataPoints: opts.skipDataPoints,
   })
 
   if (opts.skipRenderContract) return

--- a/packages/adapter-tests/src/types.ts
+++ b/packages/adapter-tests/src/types.ts
@@ -82,6 +82,27 @@ export type InteractionStep =
   | { type: 'drag'; selector: string; deltaX?: number; deltaY?: number }
 
 /**
+ * An additional evaluation point for oracle conformance
+ * (`spec/subset-conformance.md`). A marked template is a *function* from
+ * data to HTML; the fixture's primary `props`/`expectedHtml` pair observes
+ * one point of it. Each data point re-renders the fixture with adversarial
+ * props and compares the adapter's output against the live JS reference
+ * render — no hand-written expectation.
+ *
+ * Props must stay inside the JSON data domain (validated by
+ * `createFixture`): finite numbers, strings, booleans, `null`, arrays,
+ * plain objects. To express "optional prop absent", omit the key —
+ * `undefined` is not JSON-representable across backends. Catalogued rich
+ * types (`Date`) join the domain in a later roadmap stage.
+ */
+export interface JSXDataPoint {
+  /** Short unique name within the fixture, e.g. `'empty-label'`. */
+  name: string
+  /** Props for this evaluation point (JSON data domain only). */
+  props: Record<string, unknown>
+}
+
+/**
  * A JSX fixture defines a component source and optional props for rendering.
  * Used by the JSX conformance runner to compile and render across adapters.
  *
@@ -119,6 +140,14 @@ export interface JSXFixture {
   componentName?: string
   /** Props to pass when rendering (optional) */
   props?: Record<string, unknown>
+  /**
+   * Additional evaluation points for oracle conformance
+   * (`spec/subset-conformance.md`). Gated behind the primary
+   * `expectedHtml` smoke point: they only run when the fixture's primary
+   * render matches, so a fixture declaring `dataPoints` must also declare
+   * `expectedHtml` (enforced by `createFixture`).
+   */
+  dataPoints?: ReadonlyArray<JSXDataPoint>
   /** Expected normalized HTML output (generated from reference Hono adapter) */
   expectedHtml?: string
   /**
@@ -190,10 +219,61 @@ export function normalizeExpectedHtml(html: string): string {
 }
 
 /**
+ * Assert a data-point prop value stays inside the JSON data domain
+ * (`spec/subset-conformance.md`): finite numbers, strings, booleans,
+ * `null`, arrays, and plain objects. Everything else — `undefined`,
+ * `NaN`/`Infinity`, functions, `Date`, class instances — cannot cross
+ * the host-language boundary and fails loudly at fixture-definition
+ * time rather than as a confusing render divergence.
+ */
+function assertJsonDomain(fixtureId: string, pointName: string, value: unknown, path: string): void {
+  const fail = (why: string): never => {
+    throw new Error(
+      `[${fixtureId}] dataPoint '${pointName}': props${path} ${why} — ` +
+        `outside the JSON data domain (see spec/subset-conformance.md). ` +
+        `Omit the key to express an absent optional prop.`,
+    )
+  }
+  if (value === null) return
+  switch (typeof value) {
+    case 'string':
+    case 'boolean':
+      return
+    case 'number':
+      if (!Number.isFinite(value)) fail(`is a non-finite number (${value})`)
+      return
+    case 'undefined':
+      fail('is undefined')
+      return
+    case 'object':
+      break
+    default:
+      fail(`is a ${typeof value}`)
+      return
+  }
+  if (Array.isArray(value)) {
+    value.forEach((v, i) => assertJsonDomain(fixtureId, pointName, v, `${path}[${i}]`))
+    return
+  }
+  const proto = Object.getPrototypeOf(value)
+  if (proto !== Object.prototype && proto !== null) {
+    const ctor = (value as object).constructor?.name ?? 'unknown'
+    fail(
+      `is a ${ctor} instance${ctor === 'Date' ? ' (Date joins the catalogued data domain in a later roadmap stage)' : ''}`,
+    )
+  }
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    assertJsonDomain(fixtureId, pointName, v, `${path}.${k}`)
+  }
+}
+
+/**
  * Create a JSXFixture with automatic source trimming.
  * Strips leading newline from template literals so source
  * can be written with a natural indentation style.
  * Normalizes expectedHtml by collapsing whitespace.
+ * Validates `dataPoints` (JSON data domain, unique names, and the
+ * primary `expectedHtml` smoke point they are gated behind).
  */
 export function createFixture(input: {
   id: string
@@ -203,6 +283,7 @@ export function createFixture(input: {
   componentModules?: Record<string, string>
   componentName?: string
   props?: Record<string, unknown>
+  dataPoints?: ReadonlyArray<JSXDataPoint>
   expectedHtml?: string
   expectedClientJs?: string
   interactions?: ReadonlyArray<InteractionStep>
@@ -217,6 +298,23 @@ export function createFixture(input: {
   const normalizedExpectedHtml = input.expectedHtml
     ? normalizeExpectedHtml(input.expectedHtml)
     : undefined
+  if (input.dataPoints && input.dataPoints.length > 0) {
+    if (!input.expectedHtml) {
+      throw new Error(
+        `[${input.id}] dataPoints require expectedHtml: the primary point is the ` +
+          `smoke test and human pin the oracle points are gated behind ` +
+          `(spec/subset-conformance.md).`,
+      )
+    }
+    const seen = new Set<string>()
+    for (const point of input.dataPoints) {
+      if (seen.has(point.name)) {
+        throw new Error(`[${input.id}] duplicate dataPoint name '${point.name}'`)
+      }
+      seen.add(point.name)
+      assertJsonDomain(input.id, point.name, point.props, '')
+    }
+  }
   return {
     ...input,
     source: input.source.trimStart(),

--- a/spec/subset-conformance.md
+++ b/spec/subset-conformance.md
@@ -177,8 +177,8 @@ convention as `spec/adapter-architecture.md`):
 |-----------|--------|-----|
 | Normative subset | `ParsedExpr` union + exhaustive adapter switches (drift-defence); array-method / sort-comparator catalogues; builtin lowering registry; BF021/BF101 loud-refusal policy + growing-only rule (`spec/compiler.md`); `/* @client */` escape | Pieces are scattered across spec/types/catalogues with no single normative declaration; `ParsedExpr` lacks `object-literal` (adapter-architecture Roadmap A); the boundary is not fully loud — the Date silent passthrough proves unknown-type method calls pass undiagnosed; the data-domain axiom exists only in this document |
 | Canonical reference (JS render) | Hono/JS render is the *de facto* reference: snapshot generation renders expectations through it; `referenceAdapter`/`referenceRender` HTML-diff suite exists; determinism landed (#1494) | No *declaration* of canonical status (`referenceAdapter` is optional — the reference is still positioned as one adapter among eleven); oracle comparison runs at one evaluation point per fixture, not live × multiple data points |
-| Shared conformance | `run-adapter-conformance.ts` single mandatory entry point ("forgot to wire the suite" is impossible); 182 fixtures + marker conformance + template primitives + render contract; real-backend execution with `normalizeHTML`; `props` injection | No `dataPoints` suite (evaluation-point multiplication unimplemented); no type-derived adversarial value catalogue; no PR-vs-nightly tiering |
-| Declared skips | Typed skip sets (`skipJsx`, `skipTemplatePrimitives`, `skipMarkerConformance`, `expectedDiagnostics`) with issue-link discipline; `known-limitation` label; `@barefootjs/compat` component×adapter compile matrix (`compat.lock.json`) | No generated `kind × axis × adapter` support matrix; no fixture frontmatter declaring exercised kinds/axes (so a coverage map has no denominator); `skipDataPoints` undefined until the suite lands |
+| Shared conformance | `run-adapter-conformance.ts` single mandatory entry point ("forgot to wire the suite" is impossible); 182 fixtures + marker conformance + template primitives + render contract; real-backend execution with `normalizeHTML`; `props` injection; **the `dataPoints` oracle suite (roadmap 1)** — gate-ordered, live-oracle, JSON-domain-validated, piloted on `nullish-coalescing-text` (found #2248 and a Go harness string-escaping bug on its first run) | No type-derived adversarial value catalogue; no PR-vs-nightly tiering; adversarial points exist on one pilot fixture only |
+| Declared skips | Typed skip sets (`skipJsx`, `skipTemplatePrimitives`, `skipMarkerConformance`, `expectedDiagnostics`, and now `skipDataPoints` — first entries pin #2248 on the Go adapter) with issue-link discipline; `known-limitation` label; `@barefootjs/compat` component×adapter compile matrix (`compat.lock.json`) | No generated `kind × axis × adapter` support matrix; no fixture frontmatter declaring exercised kinds/axes (so a coverage map has no denominator) |
 
 Cross-cutting gap: the change-time coupling rule (subset extensions merge
 only with fixtures in the same PR) is not yet written into any contribution
@@ -188,7 +188,10 @@ convention.
 
 1. **Schema + gate + live oracle** — `dataPoints` on `createFixture`, the
    gate-ordered suite in `run-adapter-conformance.ts`, JSON-domain values
-   only.
+   only. **Landed.** The pilot's first run validated the design: it
+   surfaced a genuine `??` zero-value divergence on Go (#2248, pinned via
+   `skipDataPoints`) and a Go render-harness string-escaping bug (fixed),
+   while ERB / Jinja / Rust passed all points on real backends.
 2. **Hand-written adversarial points** across existing fixtures, prioritized
    by the frontmatter/axis map as it lands.
 3. **Type-derived value catalogue** from `TypeInfo`.


### PR DESCRIPTION
## Summary

Implements roadmap stage 1 of `spec/subset-conformance.md` (#2244): evaluation-point multiplication against the live JS reference render.

- **`dataPoints` on `createFixture`** — adversarial props per fixture, validated at definition time against the JSON data domain (finite numbers, strings, booleans, `null`, arrays, plain objects; `undefined`/`NaN`/`Date`/functions fail loudly with a pointer to the spec). Declaring `dataPoints` requires `expectedHtml` — the primary smoke point they are gated behind.
- **`runDataPointConformance`** (new shared suite, wired through `run-adapter-conformance.ts`'s single mandatory entry point) — renders each point through the adapter's real pipeline AND the live Hono reference render, asserting `normalizeHTML`-canonical equality. No stored expectations for data points: the oracle computes them at test time, so they cannot drift.
- **Gate ordering** — points run only when the fixture's primary render matches `expectedHtml`; a failed gate no-ops the points (the JSX suite already reports the primary failure loudly).
- **`skipDataPoints`** — typed `${fixtureId}:${pointName}` per-adapter opt-outs with the established issue-link discipline.

## Pilot findings (first run of the suite)

Pilot fixture `nullish-coalescing-text` with points `both-absent` / `empty-label` (`''`) / `zero-size` (`0`) / `html-in-label` (`<b>&"quote`):

1. **Genuine Go divergence → #2248**: optional scalar props lower to zero-valued Go fields, so `??` cannot distinguish absent from `''`/`0` (JS keeps `''`/`0`; Go falls back to the default). Pinned via `skipDataPoints`; removing the entries is the acceptance test for the fix.
2. **Go render-harness bug (fixed here)**: string props were interpolated into the generated `main.go` with quote-only or no escaping — a `"` in a prop broke the harness at Go compile time. All four emission sites now share `goStringLit` (`JSON.stringify`, whose escapes are a subset of Go interpreted-string-literal escapes). Changeset included (`@barefootjs/go-template` patch).
3. ERB, Jinja, and Rust (minijinja) pass all four points on real backends; Twig/Blade/Xslate/Mojo take the existing `onRenderError` unavailable path locally and will exercise for real in their CI jobs.

## Verification

- Full Go adapter suite on real Go 1.25.6: **746 pass / 0 fail** (also proves the escaping change is byte-safe across the whole corpus).
- Hono adapter suite: +4 tests, all pass.
- `bun test packages/adapter-tests`: the only failures are the carousel cross-adapter tests, which fail identically on a clean tree in this environment (missing Perl modules / Go toolchain version) — unrelated.
- Spec live-record (`Current state` / roadmap) updated in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1T4R1R6FKPGTFyYn1ppBa

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1T4R1R6FKPGTFyYn1ppBa)_