### PR TITLE
Fix changeset package name: @barefootjs/adapter-hono → @barefootjs/hono

### DIFF
--- a/.changeset/create-selector-primitive.md
+++ b/.changeset/create-selector-primitive.md
@@ -1,7 +1,7 @@
 ---
 "@barefootjs/client": patch
 "@barefootjs/jsx": patch
-"@barefootjs/adapter-hono": patch
+"@barefootjs/hono": patch
 ---
 
-Perf: new `createSelector(source, fn?)` primitive (SolidJS-compatible, #2143 gap 5) — an O(changed) selection accessor for `class={isSelected(row.id) ? ... : ...}` patterns. Each row's effect subscribes to its own key instead of the raw signal, so a selection change re-runs two effects (deselected + selected row) regardless of list size. The returned accessor is `Reactive<>`-branded, so the existing type-based reactivity analysis recognises `isSelected(row.id)` with no analyzer changes beyond registering the export and a `needsTypeBasedDetection` trigger for bare selector usage outside `.map()`. `@barefootjs/adapter-hono` gains the matching SSR client-shim stub.
+Perf: new `createSelector(source, fn?)` primitive (SolidJS-compatible, #2143 gap 5) — an O(changed) selection accessor for `class={isSelected(row.id) ? ... : ...}` patterns. Each row's effect subscribes to its own key instead of the raw signal, so a selection change re-runs two effects (deselected + selected row) regardless of list size. The returned accessor is `Reactive<>`-branded, so the existing type-based reactivity analysis recognises `isSelected(row.id)` with no analyzer changes beyond registering the export and a `needsTypeBasedDetection` trigger for bare selector usage outside `.map()`. `@barefootjs/hono` gains the matching SSR client-shim stub.


### PR DESCRIPTION
## Summary

The release workflow is failing at `bunx changeset version` ([failing run](https://github.com/piconic-ai/barefootjs/actions/runs/29227218663/job/86743749976)):

```
🦋 error Error: Found changeset create-selector-primitive for package @barefootjs/adapter-hono which is not in the workspace
```

`.changeset/create-selector-primitive.md` (merged in #2244) referenced the package by its **directory name** (`packages/adapter-hono`), but the actual package name in `packages/adapter-hono/package.json` is `@barefootjs/hono`. Since the name can't be resolved to a workspace package, every release run fails deterministically — retrying does not help.

## Changes

- `.changeset/create-selector-primitive.md`: change the frontmatter entry `"@barefootjs/adapter-hono": patch` to `"@barefootjs/hono": patch`
- Also update the same package name mention in the changeset body, since it ends up in the published CHANGELOG

## Verification

- `@barefootjs/hono` is the name declared in `packages/adapter-hono/package.json`, and it is not in the `ignore` list of `.changeset/config.json`, so `changeset version` can resolve it
- The other two entries (`@barefootjs/client`, `@barefootjs/jsx`) match their package names and are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ucq2uTXKMvr2zttNF4Gd2b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ucq2uTXKMvr2zttNF4Gd2b)_