### PR TITLE
Fix #2248: real nullish semantics for `??`-consumed optional scalar props on Go

### DIFF
--- a/.changeset/go-nullish-optional-props.md
+++ b/.changeset/go-nullish-optional-props.md
@@ -1,0 +1,13 @@
+---
+"@barefootjs/go-template": minor
+---
+
+Fix #2248: JS `??` on an optional scalar prop now carries real nullish semantics on Go. An optional `string`/`number`/`boolean` prop consumed by `??` (with a non-zero-equivalent fallback and no destructure default) lowers to the adapter's established nillable `interface{}` representation, so "absent" is distinguishable from an explicit `''`/`0`/`false` at render time:
+
+- Template position: `{{bf_nullish .Label "Default"}}` (new runtime helper — falls back on nil only) replaces the truthiness-based `{{or …}}`, which collapsed a present-but-empty `""` into the fallback.
+- Signal seeds (`createSignal(props.size ?? 1)`): the constructor hoist checks `if in.Size != nil` instead of `if size == 0`, so an explicit `Size: 0` input is honoured (JS `0 ?? 1` is `0`). Numeric props coerce through new exported `bf.ToInt` / `bf.ToFloat64` (an untyped `Size: 3` literal boxes as `int` even for a float64-shaped prop); string/bool assert directly.
+- The flipped props join the existing nillable behaviours (bare-attribute omission on nil) by construction, and assignment ergonomics are unchanged — plain literals assign into `interface{}` fields.
+
+Generated-code API note: for exactly these props the `XxxInput` / `XxxProps` struct fields change from a concrete scalar type to `interface{}`. Props with a destructure default (`{ className = '' }`) or a zero-equivalent fallback (`?? ''` / `?? 0` / `?? false`, where nullish and truthiness semantics coincide) keep their concrete types.
+
+Found and verified by the data-point oracle conformance suite: the Go adapter's `skipDataPoints` entries for `nullish-coalescing-text` are removed, and all four adversarial points now match the JS reference render on real Go.

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -25,6 +25,11 @@ import (
 //	tmpl := template.New("").Funcs(bf.FuncMap())
 func FuncMap() template.FuncMap {
 	return template.FuncMap{
+		// Nullish coalescing (#2248): JS `??` semantics — fall back only on
+		// nil, keeping present-but-falsy values (`""`, `0`, `false`) that
+		// Go's truthiness-based `or` would replace.
+		"bf_nullish": Nullish,
+
 		// Arithmetic
 		"bf_add":        Add,
 		"bf_concat_str": ConcatStr,
@@ -2932,6 +2937,34 @@ func setPortalsOnSingle(child interface{}, collector *PortalCollector) {
 		}
 	}
 }
+
+// Nullish implements JS `??` for template use (`bf_nullish`, #2248): returns
+// fallback iff v is nil (untyped nil or a nil pointer/map/slice boxed in the
+// interface), otherwise v — so present-but-falsy `""`/`0`/`false` are KEPT,
+// unlike the truthiness-based template `or`.
+func Nullish(v, fallback any) any {
+	if v == nil {
+		return fallback
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Ptr, reflect.Map, reflect.Slice, reflect.Interface, reflect.Func, reflect.Chan:
+		if rv.IsNil() {
+			return fallback
+		}
+	}
+	return v
+}
+
+// ToInt exposes the runtime's numeric coercion for generated constructors
+// (#2248): a nillable-lowered numeric prop arrives as `interface{}`, and an
+// untyped Go literal (`Size: 3`) boxes as int even when the prop is
+// float64-shaped — a direct type assertion would panic where JS accepts the
+// number. Non-numeric values coerce to 0, matching the helpers' behaviour.
+func ToInt(v any) int { return toInt(v) }
+
+// ToFloat64 is ToInt's float64 counterpart — see ToInt.
+func ToFloat64(v any) float64 { return toFloat64(v) }
 
 // =============================================================================
 // Internal Helpers

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -119,16 +119,10 @@ runAdapterConformanceTests({
     // (#1897) data-table no longer skipped — loop body children + wrapper
     // struct + block-body memo baking render correctly on Go.
   ]),
-  skipDataPoints: new Set<string>([
-    // #2248 — optional scalar props lower to non-pointer zero-valued Go
-    // fields, so `??` cannot distinguish "absent" from `''`/`0` at render
-    // time: JS keeps `''`/`0` (not nullish), Go falls back to the default.
-    // `both-absent` and `html-in-label` pass; only the zero-value-shaped
-    // points diverge. Remove these entries as the acceptance test for the
-    // nillable-lowering fix.
-    'nullish-coalescing-text:empty-label',
-    'nullish-coalescing-text:zero-size',
-  ]),
+  // No `skipDataPoints`: the #2248 `??` zero-value divergence is fixed —
+  // `??`-consumed optional scalar props lower to nillable `interface{}`
+  // fields, `bf_nullish` carries JS nullish semantics in the template, and
+  // the constructor seeds via a nil check instead of a zero check.
   onRenderError: (err, id) => {
     if (err instanceof GoNotAvailableError) {
       console.log(`Skipping [${id}]: ${err.message}`)
@@ -516,9 +510,13 @@ export function Counter(props: { initial?: number }) {
       expect(result.types).toBeDefined()
       const types = result.types!
 
-      // Hoist: `initial := in.Initial` + zero-check + fallback assign.
-      expect(types).toContain('initial := in.Initial')
-      expect(types).toMatch(/if initial == 0 \{\s*initial = 99\s*\}/)
+      // #2248: the `??`-consumed optional scalar lowers to the nillable
+      // `interface{}` representation, and the hoist applies the fallback on
+      // NIL — not on the zero value — so an explicit `Initial: 0` input is
+      // honoured (JS `0 ?? 99` is 0).
+      expect(types).toContain('Initial interface{}')
+      expect(types).toContain('var initial int = 99')
+      expect(types).toMatch(/if in\.Initial != nil \{\s*initial = bf\.ToInt\(in\.Initial\)\s*\}/)
 
       // Prop, signal, and memo all reference the hoisted variable.
       expect(types).toContain('Initial: initial,')
@@ -563,8 +561,11 @@ export function Label(props: { label?: string }) {
 `)
       const result = adapter.generate(ir)
       const types = result.types!
-      expect(types).toContain('label := in.Label')
-      expect(types).toMatch(/if label == ""\s*\{\s*label = "Default"\s*\}/)
+      // #2248: nil-checked, not zero-checked — an explicit `Label: ""` input
+      // stays empty (JS `'' ?? 'Default'` is `''`).
+      expect(types).toContain('Label interface{}')
+      expect(types).toContain('var label string = "Default"')
+      expect(types).toMatch(/if in\.Label != nil \{\s*label = in\.Label\.\(string\)\s*\}/)
       expect(types).toContain('Label: label,')
       // Signal name `text` differs from prop name `label`, so the
       // signal field gets its own entry that resolves through the
@@ -572,12 +573,12 @@ export function Label(props: { label?: string }) {
       expect(types).toContain('Text: label,')
     })
 
-    test('hoists `props.X ?? true` against the bool zero (#1423 review)', () => {
-      // Bool-true falls through the same hoist path as int / string —
-      // the asymmetry is documented (caller can't thread "explicit
-      // false" through because Go's bool zero IS false), but emitting
-      // a hoisted local matches the int case's shape so a derived
-      // memo can inherit it.
+    test('hoists `props.X ?? true` against nil (#1423 review, #2248)', () => {
+      // Bool-true falls through the same hoist path as int / string.
+      // Since #2248 the nillable lowering makes "explicit false"
+      // representable: the interface{} field is nil only when the caller
+      // omitted the prop, so `Checked: false` survives (JS
+      // `false ?? true` is false).
       const adapter = new GoTemplateAdapter()
       const ir = compileToIR(`
 "use client"
@@ -590,8 +591,9 @@ export function Check(props: { checked?: boolean }) {
 `)
       const result = adapter.generate(ir)
       const types = result.types!
-      expect(types).toContain('checked := in.Checked')
-      expect(types).toMatch(/if checked == false\s*\{\s*checked = true\s*\}/)
+      expect(types).toContain('Checked interface{}')
+      expect(types).toContain('var checked bool = true')
+      expect(types).toMatch(/if in\.Checked != nil \{\s*checked = in\.Checked\.\(bool\)\s*\}/)
       expect(types).toContain('Checked: checked,')
       expect(types).toContain('C: checked,')
     })
@@ -3641,8 +3643,9 @@ export function C(props: Props) {
     const template = result.files?.find(f => f.path.endsWith('.tmpl'))?.content ?? ''
     // The `{}` fallback lowers to the safe `""` Go string sentinel — never the
     // `[UNSUPPORTED: …]` marker text, which would break `text/template` parsing
-    // once spliced as an `or` operand.
-    expect(template).toContain('{{or .Config ""}}')
+    // once spliced as an operand. Since #2248, `??` on a nillable prop emits
+    // the nil-testing `bf_nullish` instead of the truthiness-based `or`.
+    expect(template).toContain('{{bf_nullish .Config ""}}')
     expect(template).not.toContain('UNSUPPORTED')
   })
 

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -119,10 +119,6 @@ runAdapterConformanceTests({
     // (#1897) data-table no longer skipped — loop body children + wrapper
     // struct + block-body memo baking render correctly on Go.
   ]),
-  // No `skipDataPoints`: the #2248 `??` zero-value divergence is fixed —
-  // `??`-consumed optional scalar props lower to nillable `interface{}`
-  // fields, `bf_nullish` carries JS nullish semantics in the template, and
-  // the constructor seeds via a nil check instead of a zero check.
   onRenderError: (err, id) => {
     if (err instanceof GoNotAvailableError) {
       console.log(`Skipping [${id}]: ${err.message}`)
@@ -510,10 +506,8 @@ export function Counter(props: { initial?: number }) {
       expect(result.types).toBeDefined()
       const types = result.types!
 
-      // #2248: the `??`-consumed optional scalar lowers to the nillable
-      // `interface{}` representation, and the hoist applies the fallback on
-      // NIL — not on the zero value — so an explicit `Initial: 0` input is
-      // honoured (JS `0 ?? 99` is 0).
+      // The fallback applies only when the prop is ABSENT: an explicit
+      // `Initial: 0` is honoured (JS `0 ?? 99` is `0`, #2248).
       expect(types).toContain('Initial interface{}')
       expect(types).toContain('var initial int = 99')
       expect(types).toMatch(/if in\.Initial != nil \{\s*initial = bf\.ToInt\(in\.Initial\)\s*\}/)
@@ -561,8 +555,8 @@ export function Label(props: { label?: string }) {
 `)
       const result = adapter.generate(ir)
       const types = result.types!
-      // #2248: nil-checked, not zero-checked — an explicit `Label: ""` input
-      // stays empty (JS `'' ?? 'Default'` is `''`).
+      // An explicit `Label: ""` input stays empty (JS `'' ?? 'Default'` is
+      // `''`, #2248).
       expect(types).toContain('Label interface{}')
       expect(types).toContain('var label string = "Default"')
       expect(types).toMatch(/if in\.Label != nil \{\s*label = in\.Label\.\(string\)\s*\}/)
@@ -574,11 +568,10 @@ export function Label(props: { label?: string }) {
     })
 
     test('hoists `props.X ?? true` against nil (#1423 review, #2248)', () => {
-      // Bool-true falls through the same hoist path as int / string.
-      // Since #2248 the nillable lowering makes "explicit false"
-      // representable: the interface{} field is nil only when the caller
-      // omitted the prop, so `Checked: false` survives (JS
-      // `false ?? true` is false).
+      // Bool-true falls through the same hoist path as int / string. The
+      // interface{} field is nil only when the caller omitted the prop, so
+      // an explicit `Checked: false` survives (JS `false ?? true` is
+      // `false`).
       const adapter = new GoTemplateAdapter()
       const ir = compileToIR(`
 "use client"
@@ -3643,8 +3636,8 @@ export function C(props: Props) {
     const template = result.files?.find(f => f.path.endsWith('.tmpl'))?.content ?? ''
     // The `{}` fallback lowers to the safe `""` Go string sentinel — never the
     // `[UNSUPPORTED: …]` marker text, which would break `text/template` parsing
-    // once spliced as an operand. Since #2248, `??` on a nillable prop emits
-    // the nil-testing `bf_nullish` instead of the truthiness-based `or`.
+    // once spliced as an operand. `??` on a nillable prop lowers to the
+    // nil-testing `bf_nullish` (#2248), equally valid template syntax.
     expect(template).toContain('{{bf_nullish .Config ""}}')
     expect(template).not.toContain('UNSUPPORTED')
   })

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -3591,8 +3591,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * while its emitted struct field is the concrete alias type. On such a
    * concrete field "absent" is invisible (the zero value), so the
    * truthiness-based `or` is the correct approximation and `bf_nullish`
-   * would wrongly KEEP the zero value (the tooltip placement-classes
-   * regression). Requiring `nullishConsumedPropNames` membership pins the
+   * would wrongly KEEP the zero value (e.g. Tooltip's
+   * `placementClasses[props.placement ?? 'top']` would resolve to no
+   * class for an omitted placement). Requiring `nullishConsumedPropNames`
+   * membership pins the
    * gate to props the `??` analysis actually saw — the same set that drives
    * the `interface{}` flip in `resolvePropGoType`.
    */

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -135,7 +135,7 @@ import { lowerCtorExpr } from "./memo/ctor-lowering.ts"
 import { resolveBlockBodyMemoModuleConst } from "./memo/memo-value.ts"
 import { computeMemoInitialValue, computeMemoInitialValueOrNull, filterArmEarlierSiblingRefs } from "./memo/memo-compute.ts"
 import { collectSpreadSlots, buildSpreadInitializer } from "./spread/spread-codegen.ts"
-import { buildPropTypeOverrides, resolvePropGoType, collectNillablePropNames } from "./props/prop-types.ts"
+import { buildPropTypeOverrides, resolvePropGoType, collectNillablePropNames, collectNullishConsumedPropNames, NULLISH_SCALAR_GO_TYPES } from "./props/prop-types.ts"
 import { collectStringValueNames } from "./props/prop-classes.ts"
 
 export type { GoTemplateAdapterOptions } from "./lib/types.ts"
@@ -416,6 +416,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     this.state.templateVarCounter = 0
     this.state.pendingChildrenDefines = []
     this.primeCompileState(ir)
+    // Ordering: the nullish-consumed set feeds `resolvePropGoType`'s
+    // interface{} flip (#2248), and `collectNillablePropNames` is itself
+    // derived from `resolvePropGoType` — so populate it first.
+    this.state.nullishConsumedPropNames = collectNullishConsumedPropNames(this.emitCtx, ir)
     this.state.nillablePropNames = collectNillablePropNames(this.emitCtx, ir)
     this.state.stringValueNames = collectStringValueNames(ir)
 
@@ -1213,10 +1217,26 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // from an omitted field, so it also fires on the type's zero value.
     const propFallbackVars = this.collectPropFallbackVars(ir)
     for (const [, info] of propFallbackVars) {
-      lines.push(`\t${info.varName} := in.${info.fieldName}`)
-      lines.push(`\tif ${info.varName} == ${info.zeroLiteral} {`)
-      lines.push(`\t\t${info.varName} = ${info.goFallback}`)
-      lines.push(`\t}`)
+      if (info.assertType) {
+        // Nillable-lowered prop (#2248): the `interface{}` field makes
+        // "absent" (nil) distinguishable from an explicit `''`/`0`/`false`,
+        // so the fallback applies ONLY on nil — JS `??` semantics. Numbers
+        // coerce through the runtime (an untyped `Size: 3` literal boxes as
+        // int even into a float64-shaped prop); string/bool assert directly.
+        const deref =
+          info.assertType === 'int' ? `bf.ToInt(in.${info.fieldName})`
+          : info.assertType === 'float64' ? `bf.ToFloat64(in.${info.fieldName})`
+          : `in.${info.fieldName}.(${info.assertType})`
+        lines.push(`\tvar ${info.varName} ${info.assertType} = ${info.goFallback}`)
+        lines.push(`\tif in.${info.fieldName} != nil {`)
+        lines.push(`\t\t${info.varName} = ${deref}`)
+        lines.push(`\t}`)
+      } else {
+        lines.push(`\t${info.varName} := in.${info.fieldName}`)
+        lines.push(`\tif ${info.varName} == ${info.zeroLiteral} {`)
+        lines.push(`\t\t${info.varName} = ${info.goFallback}`)
+        lines.push(`\t}`)
+      }
     }
     if (propFallbackVars.size > 0) lines.push('')
 
@@ -2715,6 +2735,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       localTaken.add(`${nested.name.charAt(0).toLowerCase()}${nested.name.slice(1)}s`)
     }
 
+    const propTypeOverrides = buildPropTypeOverrides(this.emitCtx, ir)
     for (const signal of ir.metadata.signals) {
       const match = this.extractPropFallback(signal.initialValue)
       if (!match) continue
@@ -2724,6 +2745,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       // A destructure default already wins via applyGoFallback below.
       if (goPropDefault(param.defaultValue) !== null) continue
       const fieldName = capitalizeFieldName(match.propName)
+      // A `??`-consumed optional scalar lowered to `interface{}` (#2248) —
+      // detected off the SAME `resolvePropGoType` pipeline the struct
+      // generators use, so this can't drift from the emitted field type. The
+      // concrete pre-flip type is what the hoisted local materializes as.
+      const concreteType = propTypeOverrides.get(param.name) ?? typeInfoToGo(this.emitCtx, param.type, param.defaultValue)
+      const nullishLowered =
+        NULLISH_SCALAR_GO_TYPES.has(concreteType) &&
+        resolvePropGoType(this.emitCtx, param, propTypeOverrides) === 'interface{}'
       // Pick the zero literal based on the fallback's literal shape. Bool
       // fallbacks (`?? true`) hoist against the `false` zero — the same Go-zero
       // conflation the int / string cases accept: the caller can't distinguish
@@ -2742,8 +2771,16 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       // (`?? 0`, `?? ''`, `?? false`, `?? 0.0`). Compare against the computed
       // zeroLiteral so spelling variants like `0.0` collapse to the same skip
       // as `0`.
-      if (match.goFallback === zeroLiteral) continue
-      if (zeroLiteral === '0' && Number(match.goFallback) === 0) continue
+      //
+      // NOT a no-op for a nillable-lowered prop (#2248): its `interface{}`
+      // field can be nil, and the typed hoisted local is what downstream
+      // consumers (`Count: size`, memo env maps) assign from — a nil
+      // interface into a concrete field is a compile error, so the local
+      // must exist even when the fallback equals the zero value.
+      if (!nullishLowered) {
+        if (match.goFallback === zeroLiteral) continue
+        if (zeroLiteral === '0' && Number(match.goFallback) === 0) continue
+      }
       // The JSX-side identifier is the natural local name; suffix with `_` if it
       // collides with a Go keyword or a local we already emit.
       let varName = match.propName
@@ -2751,7 +2788,13 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         varName += '_'
       }
       localTaken.add(varName)
-      result.set(match.propName, { varName, fieldName, goFallback: match.goFallback, zeroLiteral })
+      result.set(match.propName, {
+        varName,
+        fieldName,
+        goFallback: match.goFallback,
+        zeroLiteral,
+        ...(nullishLowered ? { assertType: concreteType } : {}),
+      })
     }
     return result
   }
@@ -3526,7 +3569,50 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     const wrapLeft = wrapIfMultiToken(emit(left))
     const wrapRight = wrapIfMultiToken(emit(right))
     if (op === '&&') return `and ${wrapLeft} ${wrapRight}`
+    // `??` on a nillable prop needs true JS nullish semantics (#2248): Go's
+    // `or` is truthiness-based, so `{{or .Label "Default"}}` falls back on a
+    // present-but-empty `""` — JS `??` keeps it. `bf_nullish` tests nil-ness
+    // only. Non-nillable operands keep `or`: their concrete Go type can't
+    // represent "absent" at all, so `or` and `??` are indistinguishable there.
+    if (op === '??' && this.nillablePropNameOf(left) !== null) {
+      return `bf_nullish ${wrapLeft} ${wrapRight}`
+    }
     return `or ${wrapLeft} ${wrapRight}`
+  }
+
+  /**
+   * The nillable-prop name a `??` left operand refers to, or null. Matches
+   * the two prop-reference shapes (`label` destructured, `props.label`
+   * object-style) against `nullishConsumedPropNames ∩ nillablePropNames`.
+   *
+   * The intersection matters: `nillablePropNames` alone OVERAPPROXIMATES —
+   * it is collected before local type aliases are registered, so an
+   * alias-typed prop (`placement?: TooltipPlacement`) can sit in the set
+   * while its emitted struct field is the concrete alias type. On such a
+   * concrete field "absent" is invisible (the zero value), so the
+   * truthiness-based `or` is the correct approximation and `bf_nullish`
+   * would wrongly KEEP the zero value (the tooltip placement-classes
+   * regression). Requiring `nullishConsumedPropNames` membership pins the
+   * gate to props the `??` analysis actually saw — the same set that drives
+   * the `interface{}` flip in `resolvePropGoType`.
+   */
+  private nillablePropNameOf(expr: ParsedExpr): string | null {
+    let name: string | null = null
+    if (expr.kind === 'identifier') {
+      name = expr.name
+    } else if (
+      expr.kind === 'member' &&
+      !expr.computed &&
+      expr.object.kind === 'identifier' &&
+      expr.object.name === this.state.propsObjectName
+    ) {
+      name = expr.property
+    }
+    return name !== null &&
+      this.state.nullishConsumedPropNames.has(name) &&
+      this.state.nillablePropNames.has(name)
+      ? name
+      : null
   }
 
   // JSX-level ternaries (`{expr ? a : b}`) are handled at the IR level as

--- a/packages/adapter-go-template/src/adapter/lib/compile-state.ts
+++ b/packages/adapter-go-template/src/adapter/lib/compile-state.ts
@@ -147,6 +147,16 @@ export class CompileState {
   nillablePropNames: Set<string> = new Set()
 
   /**
+   * OPTIONAL prop names consumed nullish-sensitively (`??` left operand in a
+   * parsed expression tree, or a signal's `props.X ?? <literal>` seed) —
+   * #2248. Consulted by `resolvePropGoType` to flip an optional scalar to the
+   * nillable `interface{}` representation, so it MUST be populated before the
+   * first `resolvePropGoType` call of a compile (see `generate()`'s ordering
+   * against `collectNillablePropNames`).
+   */
+  nullishConsumedPropNames: Set<string> = new Set()
+
+  /**
    * String-typed signal getter / prop names (#2168 string-concat-plus).
    * Feeds `isStringName` for `isStringConcatBinary`, which decides whether a
    * JS `+` operand chain is string concatenation rather than numeric

--- a/packages/adapter-go-template/src/adapter/lib/types.ts
+++ b/packages/adapter-go-template/src/adapter/lib/types.ts
@@ -140,6 +140,15 @@ export interface PropFallbackVar {
   goFallback: string
   /** Go zero literal for the prop's type (`0`, `""`, etc.). */
   zeroLiteral: string
+  /**
+   * Set when the prop lowered to the nillable `interface{}` representation
+   * (#2248): the concrete scalar Go type (`string`/`int`/`float64`/`bool`)
+   * the constructor materializes the hoisted local as. Presence switches
+   * the emission from the zero-value check (`if v == 0`) to a nil check
+   * (`if in.X != nil`), which is what makes an explicit `''`/`0` input
+   * distinguishable from an absent one.
+   */
+  assertType?: string
 }
 
 /**

--- a/packages/adapter-go-template/src/adapter/props/prop-types.ts
+++ b/packages/adapter-go-template/src/adapter/props/prop-types.ts
@@ -107,6 +107,98 @@ function collectToFixedPropNames(root: IRNode): Set<string> {
 }
 
 /**
+ * Concrete scalar Go types eligible for the nullish (`??`) nillable flip in
+ * `resolvePropGoType`. Only these can round-trip through an `interface{}`
+ * field and back via a constructor type assertion / `bf.ToInt`-style
+ * coercion (see the fallback-var emission in `generateNewPropsFunction`).
+ */
+export const NULLISH_SCALAR_GO_TYPES: ReadonlySet<string> = new Set(['string', 'int', 'float64', 'bool'])
+
+/**
+ * Names of OPTIONAL props consumed nullish-sensitively — the left operand of
+ * a `??` anywhere in the component's parsed expression trees, or a signal's
+ * `props.X ?? <literal>` initial value (#2248).
+ *
+ * Why this matters: JS `??` falls back only on `null`/`undefined`, keeping
+ * `''`/`0`/`false`. A Go zero-valued scalar field cannot represent "absent",
+ * so a `??`-consumed optional scalar must lower to the adapter's established
+ * nillable representation (`interface{}`) for the distinction to exist at
+ * render time. `resolvePropGoType` applies that flip using this set.
+ *
+ * The IR walk is generic (any nested object/array is descended, so parsed
+ * trees inside expressions, conditions, attributes, and loops are all seen)
+ * and the match is shape-precise: `identifier` left (destructured props) or
+ * `<propsObject>.<name>` member left. KNOWN LIMITATION (same class as
+ * `collectToFixedPropNames`): an `identifier` left shadowed by a same-named
+ * loop/callback param is misattributed to the prop — the flip is then merely
+ * unnecessary, not incorrect.
+ */
+export function collectNullishConsumedPropNames(ctx: GoEmitContext, ir: ComponentIR): Set<string> {
+  const names = new Set<string>()
+  // A destructure default (`{ className = '' }`) means the binding is never
+  // nullish in JS — the default already applied — so such props never need
+  // the nillable flip (and `applyGoFallback`'s concrete-typed baking relies
+  // on them staying concrete).
+  const optionalParams = new Set(
+    ir.metadata.propsParams.filter(p => p.optional && p.defaultValue == null).map(p => p.name),
+  )
+  if (optionalParams.size === 0) return names
+
+  const propsObject = ctx.state.propsObjectName
+  const propNameOfLeft = (left: ParsedExpr): string | null => {
+    if (left.kind === 'identifier') return left.name
+    if (
+      left.kind === 'member' &&
+      !left.computed &&
+      left.object.kind === 'identifier' &&
+      left.object.name === propsObject
+    ) {
+      return left.property
+    }
+    return null
+  }
+
+  // `?? <zero-equivalent literal>` (`?? ''`, `?? 0`, `?? false`) is the one
+  // shape where nullish and truthiness semantics coincide — nil and the zero
+  // value both land on the same output — so it earns no flip. Only a
+  // fallback the zero value must NOT collapse into makes the distinction
+  // observable.
+  const isZeroEquivalentLiteral = (right: ParsedExpr): boolean =>
+    right.kind === 'literal' &&
+    (right.value === '' || right.value === false || right.value === null ||
+      (right.literalType === 'number' && Number(right.value) === 0))
+
+  const walk = (node: unknown): void => {
+    if (!node || typeof node !== 'object') return
+    if (Array.isArray(node)) {
+      for (const item of node) walk(item)
+      return
+    }
+    const rec = node as Record<string, unknown>
+    if (rec.kind === 'logical' && rec.op === '??' && rec.left && rec.right) {
+      const propName = propNameOfLeft(rec.left as ParsedExpr)
+      if (propName && optionalParams.has(propName) && !isZeroEquivalentLiteral(rec.right as ParsedExpr)) {
+        names.add(propName)
+      }
+    }
+    for (const value of Object.values(rec)) walk(value)
+  }
+  walk(ir.root)
+
+  // Signal seeds (`createSignal(props.X ?? 1)`) live in metadata, not the
+  // tree — reuse the seam's existing `props.X ?? <literal>` recognizer. The
+  // zero-equivalent exclusion matches on the Go-formatted fallback literal.
+  for (const signal of ir.metadata.signals) {
+    const match = ctx.extractPropFallback(signal.initialValue)
+    if (!match || !optionalParams.has(match.propName)) continue
+    const f = match.goFallback
+    if (f === '""' || f === 'false' || f === 'nil' || Number(f) === 0) continue
+    names.add(match.propName)
+  }
+  return names
+}
+
+/**
  * Resolve a prop param's Go struct-field type using the SAME logic
  * `generatePropsStruct` / `generateInputStruct` use: a `propTypeOverrides` entry
  * wins, otherwise `typeInfoToGo(param.type, param.defaultValue)`. Factored out so
@@ -130,6 +222,33 @@ export function resolvePropGoType(
   // (`placement?: 'top' | 'right' | …`), which must stay their scalar Go type.
   if (param.optional && ctx.state.localStructFields.has(base)) {
     return 'map[string]interface{}'
+  }
+  // An OPTIONAL scalar prop consumed by `??` lowers to `interface{}` (#2248):
+  // a zero-valued `string`/`int` field cannot distinguish "absent" from
+  // `''`/`0`, so JS nullish semantics (which KEEP `''`/`0`) are unexpressible
+  // on the concrete type. `interface{}` is the adapter's established nillable
+  // representation; the `??` template lowering then tests nil-ness via
+  // `bf_nullish` and the constructor seeds via a nil check + assertion.
+  // Assignment ergonomics are unchanged (plain literals assign into
+  // `interface{}`), and the prop joins the existing nillable behaviours
+  // (bare-attribute omission) by construction.
+  //
+  // Gated to `kind: 'primitive'` — a string-union prop
+  // (`placement?: 'top' | 'bottom'`) must stay its scalar Go type (the same
+  // invariant the struct-map gate above documents): the union-typed
+  // class-composition lowerings key off the concrete type, AND the flip
+  // would buy nothing — the zero value (`""`) is never a legal union
+  // member, so the zero-check already coincides with nullish semantics for
+  // every valid input. (A literal-number union containing 0 would be the
+  // exception; none exists in the corpus and the conflation is the
+  // documented pre-#2248 trade-off there.)
+  if (
+    param.optional &&
+    param.type.kind === 'primitive' &&
+    ctx.state.nullishConsumedPropNames.has(param.name) &&
+    NULLISH_SCALAR_GO_TYPES.has(base)
+  ) {
+    return 'interface{}'
   }
   return base
 }

--- a/spec/subset-conformance.md
+++ b/spec/subset-conformance.md
@@ -177,8 +177,8 @@ convention as `spec/adapter-architecture.md`):
 |-----------|--------|-----|
 | Normative subset | `ParsedExpr` union + exhaustive adapter switches (drift-defence); array-method / sort-comparator catalogues; builtin lowering registry; BF021/BF101 loud-refusal policy + growing-only rule (`spec/compiler.md`); `/* @client */` escape | Pieces are scattered across spec/types/catalogues with no single normative declaration; `ParsedExpr` lacks `object-literal` (adapter-architecture Roadmap A); the boundary is not fully loud — the Date silent passthrough proves unknown-type method calls pass undiagnosed; the data-domain axiom exists only in this document |
 | Canonical reference (JS render) | Hono/JS render is the *de facto* reference: snapshot generation renders expectations through it; `referenceAdapter`/`referenceRender` HTML-diff suite exists; determinism landed (#1494) | No *declaration* of canonical status (`referenceAdapter` is optional — the reference is still positioned as one adapter among eleven); oracle comparison runs at one evaluation point per fixture, not live × multiple data points |
-| Shared conformance | `run-adapter-conformance.ts` single mandatory entry point ("forgot to wire the suite" is impossible); 182 fixtures + marker conformance + template primitives + render contract; real-backend execution with `normalizeHTML`; `props` injection; **the `dataPoints` oracle suite (roadmap 1)** — gate-ordered, live-oracle, JSON-domain-validated, piloted on `nullish-coalescing-text` (found #2248 and a Go harness string-escaping bug on its first run) | No type-derived adversarial value catalogue; no PR-vs-nightly tiering; adversarial points exist on one pilot fixture only |
-| Declared skips | Typed skip sets (`skipJsx`, `skipTemplatePrimitives`, `skipMarkerConformance`, `expectedDiagnostics`, and now `skipDataPoints` — first entries pin #2248 on the Go adapter) with issue-link discipline; `known-limitation` label; `@barefootjs/compat` component×adapter compile matrix (`compat.lock.json`) | No generated `kind × axis × adapter` support matrix; no fixture frontmatter declaring exercised kinds/axes (so a coverage map has no denominator) |
+| Shared conformance | `run-adapter-conformance.ts` single mandatory entry point ("forgot to wire the suite" is impossible); 182 fixtures + marker conformance + template primitives + render contract; real-backend execution with `normalizeHTML`; `props` injection; **the `dataPoints` oracle suite (roadmap 1)** — gate-ordered, live-oracle, JSON-domain-validated, piloted on `nullish-coalescing-text` (found #2248 — since fixed via nillable lowering + `bf_nullish` — and a Go harness string-escaping bug on its first run) | No type-derived adversarial value catalogue; no PR-vs-nightly tiering; adversarial points exist on one pilot fixture only |
+| Declared skips | Typed skip sets (`skipJsx`, `skipTemplatePrimitives`, `skipMarkerConformance`, `expectedDiagnostics`, and now `skipDataPoints` — its first entries pinned #2248 on the Go adapter until the fix landed and removed them, completing one full ledger round-trip) with issue-link discipline; `known-limitation` label; `@barefootjs/compat` component×adapter compile matrix (`compat.lock.json`) | No generated `kind × axis × adapter` support matrix; no fixture frontmatter declaring exercised kinds/axes (so a coverage map has no denominator) |
 
 Cross-cutting gap: the change-time coupling rule (subset extensions merge
 only with fixtures in the same PR) is not yet written into any contribution
@@ -189,9 +189,11 @@ convention.
 1. **Schema + gate + live oracle** — `dataPoints` on `createFixture`, the
    gate-ordered suite in `run-adapter-conformance.ts`, JSON-domain values
    only. **Landed.** The pilot's first run validated the design: it
-   surfaced a genuine `??` zero-value divergence on Go (#2248, pinned via
-   `skipDataPoints`) and a Go render-harness string-escaping bug (fixed),
-   while ERB / Jinja / Rust passed all points on real backends.
+   surfaced a genuine `??` zero-value divergence on Go (#2248 — pinned via
+   `skipDataPoints`, then fixed by the nillable `interface{}` lowering +
+   `bf_nullish`, which removed the pins) and a Go render-harness
+   string-escaping bug (fixed), while ERB / Jinja / Rust passed all points
+   on real backends.
 2. **Hand-written adversarial points** across existing fixtures, prioritized
    by the frontmatter/axis map as it lands.
 3. **Type-derived value catalogue** from `TypeInfo`.


### PR DESCRIPTION
## Summary

Stacked on #2249 (the data-point oracle conformance suite, which found this bug). Fixes #2248.

JS `??` falls back only on `null`/`undefined`, keeping `''`/`0`/`false` — but the Go adapter lowered optional scalar props to zero-valued concrete fields, making "absent" and `''`/`0` indistinguishable at render time: `{{or .Label "Default"}}` collapsed a present-but-empty `''` into the fallback, and the constructor's `if size == 0` overrode an explicit `0`.

## The fix

Extends the adapter's established nillable representation (`interface{}`) instead of inventing a new one:

- **`resolvePropGoType`** flips an optional **primitive** scalar prop consumed by `??` to `interface{}`. Deliberately narrow, with each exclusion earning its keep:
  - *zero-equivalent fallbacks* (`?? ''` / `?? 0` / `?? false`): nullish and truthiness semantics coincide — no flip;
  - *destructure defaults* (`{ className = '' }`): the binding is never nullish in JS — and `applyGoFallback`'s concrete-typed baking relies on staying concrete;
  - *union-alias props* (`placement?: TooltipPlacement`): the zero value is never a legal union member, so the zero check already matches nullish semantics, and the class-composition lowerings key off the concrete type.
- **Template `??`** on such a prop emits the new nil-testing **`bf_nullish`** runtime helper instead of truthiness-based `or`. The gate requires `nullishConsumed ∩ nillable` — `nillablePropNames` alone overapproximates (it's collected before local type aliases register), and `bf_nullish` on a concrete field wrongly *keeps* the zero value. That exact regression (tooltip placement classes vanishing) was caught during verification and is documented on the gate.
- **Constructor hoist** seeds via `if in.Size != nil` with a typed local; numerics coerce through new exported `bf.ToInt` / `bf.ToFloat64` (an untyped `Size: 3` literal boxes as `int` even for a float64-shaped prop), string/bool assert directly.

Generated-code API note: only the flipped props' `Input`/`Props` struct fields change from a concrete scalar type to `interface{}` (plain literals still assign fine). Changeset included (`@barefootjs/go-template` minor).

## Acceptance & verification

- The Go adapter's `skipDataPoints` entries are **removed** — the acceptance test named in #2248 — and all four `nullish-coalescing-text` adversarial points match the JS reference render on real Go 1.25.6.
- Contract pins updated: #1423 hoist shapes (now nil-checked; "explicit false is unrepresentable" note corrected), #2087 `?? {}` sentinel (`or` → `bf_nullish`).
- Full `packages/adapter-go-template` run: **793 pass / 1 skip / 0 fail** on real Go; Go runtime unit tests pass (`go test ./...`); `tsgo --noEmit` clean.
- Checked-in generated code in `integrations/echo` does not drift: every `??` in the shared integration components is zero-equivalent (`?? 0`, `?? false`, `?? ''`) or array-typed — outside the flip.
- Spec live-record updated: the `skipDataPoints` ledger completed one full round-trip (pinned → fixed → pins removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1T4R1R6FKPGTFyYn1ppBa

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1T4R1R6FKPGTFyYn1ppBa)_