### PR TITLE
Add first wave of adversarial data points across 8 conformance fixtures (roadmap 2)

### DIFF
--- a/.changeset/mojo-test-render-null-prop.md
+++ b/.changeset/mojo-test-render-null-prop.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/mojolicious": patch
+---
+
+Fix `test-render`'s prop materialization for explicit-null props: `typeof null === 'object'` fell through every emission branch, so a `user: null` prop never declared its template var and `Mojo::Template`'s strict mode aborted with "Global symbol requires explicit package name" before the `//` fallback could apply. Null props now declare `my $x = undef`, matching how absent optional params are seeded. Found by the data-point oracle conformance suite (`optional-chaining-prop:null-user`).

--- a/packages/adapter-blade/src/__tests__/blade-adapter.test.ts
+++ b/packages/adapter-blade/src/__tests__/blade-adapter.test.ts
@@ -50,6 +50,11 @@ runAdapterConformanceTests({
     // Same `/* @client */` keyed-map elision (data-table).
     'data-table',
   ]),
+  skipDataPoints: new Set<string>([
+    // #2255 — PHP mb_strlen counts codepoints; JS counts UTF-16 code
+    // units, so a surrogate-pair character is 2 in JS, 1 here.
+    'string-length-text:astral',
+  ]),
   onRenderError: (err, id) => {
     if (err instanceof BladeNotAvailableError) {
       console.log(`Skipping [${id}]: ${err.message}`)

--- a/packages/adapter-erb/src/__tests__/erb-adapter.test.ts
+++ b/packages/adapter-erb/src/__tests__/erb-adapter.test.ts
@@ -70,6 +70,11 @@ runAdapterConformanceTests({
     // #1467 Phase 2e: same `/* @client */` keyed-map elision (data-table).
     'data-table',
   ]),
+  skipDataPoints: new Set<string>([
+    // #2255 — Ruby String#length counts codepoints; JS counts UTF-16
+    // code units, so a surrogate-pair character is 2 in JS, 1 here.
+    'string-length-text:astral',
+  ]),
   onRenderError: (err, id) => {
     if (err instanceof ErbNotAvailableError) {
       console.log(`Skipping [${id}]: ${err.message}`)

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -119,6 +119,16 @@ runAdapterConformanceTests({
     // (#1897) data-table no longer skipped — loop body children + wrapper
     // struct + block-body memo baking render correctly on Go.
   ]),
+  skipDataPoints: new Set<string>([
+    // #2255 — Go `len` counts bytes; JS counts UTF-16 code units
+    // ('日本語' is 3 in JS, 9 here; '👍' is 2 in JS, 4 here).
+    'string-length-text:multibyte',
+    'string-length-text:astral',
+    // #2256 — the nullish gate covers only BARE nillable prop refs; a
+    // member-access left operand (`user?.name ?? '…'`) still lowers to
+    // the truthiness `or`, so a present-but-empty member falls back.
+    'optional-chaining-prop:empty-name',
+  ]),
   onRenderError: (err, id) => {
     if (err instanceof GoNotAvailableError) {
       console.log(`Skipping [${id}]: ${err.message}`)

--- a/packages/adapter-jinja/src/__tests__/jinja-adapter.test.ts
+++ b/packages/adapter-jinja/src/__tests__/jinja-adapter.test.ts
@@ -51,6 +51,11 @@ runAdapterConformanceTests({
     // Same `/* @client */` keyed-map elision (data-table).
     'data-table',
   ]),
+  skipDataPoints: new Set<string>([
+    // #2255 — Python len() counts codepoints; JS counts UTF-16 code
+    // units, so a surrogate-pair character is 2 in JS, 1 here.
+    'string-length-text:astral',
+  ]),
   onRenderError: (err, id) => {
     if (err instanceof PythonNotAvailableError) {
       console.log(`Skipping [${id}]: ${err.message}`)

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -59,6 +59,11 @@ runAdapterConformanceTests({
     // #1467 Phase 2e: same `/* @client */` keyed-map elision (data-table).
     'data-table',
   ]),
+  skipDataPoints: new Set<string>([
+    // #2255 — Perl length() counts codepoints under utf8; JS counts
+    // UTF-16 code units, so a surrogate-pair character is 2 in JS, 1 here.
+    'string-length-text:astral',
+  ]),
   onRenderError: (err, id) => {
     if (err instanceof PerlNotAvailableError) {
       console.log(`Skipping [${id}]: ${err.message}`)

--- a/packages/adapter-mojolicious/src/test-render.ts
+++ b/packages/adapter-mojolicious/src/test-render.ts
@@ -583,7 +583,15 @@ function buildPerlProps(
   if (props) {
     for (const [key, value] of Object.entries(props)) {
       if (routedKeys.has(key)) continue
-      if (typeof value === 'string') {
+      if (value === null) {
+        // An explicit-null prop must still DECLARE the template var —
+        // `typeof null === 'object'` fails every branch below, so the key
+        // emitted nothing and `Mojo::Template`'s `vars => 1` never ran
+        // `my $user`, tripping Perl's strict-mode "Global symbol requires
+        // explicit package name" before the `//` fallback could apply
+        // (data-point conformance, optional-chaining-prop:null-user).
+        entries.push(`${key} => undef`)
+      } else if (typeof value === 'string') {
         entries.push(`${key} => '${value.replace(/'/g, "\\'")}'`)
       } else if (typeof value === 'number') {
         entries.push(`${key} => ${value}`)

--- a/packages/adapter-rust/src/__tests__/minijinja-adapter.test.ts
+++ b/packages/adapter-rust/src/__tests__/minijinja-adapter.test.ts
@@ -56,6 +56,11 @@ runAdapterConformanceTests({
     // Same `/* @client */` keyed-map elision (data-table).
     'data-table',
   ]),
+  skipDataPoints: new Set<string>([
+    // #2255 — minijinja's length counts chars (codepoints); JS counts
+    // UTF-16 code units, so a surrogate-pair character is 2 in JS, 1 here.
+    'string-length-text:astral',
+  ]),
   onRenderError: (err, id) => {
     if (err instanceof RustNotAvailableError) {
       console.log(`Skipping [${id}]: ${err.message}`)

--- a/packages/adapter-tests/fixtures/else-if-chain.ts
+++ b/packages/adapter-tests/fixtures/else-if-chain.ts
@@ -32,6 +32,14 @@ export function ElseIfChain(props: { level?: string }) {
 }
 `,
   props: { level: 'mid' },
+  // Branch selection parity per level value. The oracle carries the
+  // pinned else-if fallthrough bug identically (see the docstring), so
+  // these points assert cross-adapter AGREEMENT, not correctness.
+  dataPoints: [
+    { name: 'high', props: { level: 'high' } },
+    { name: 'absent', props: {} },
+    { name: 'empty-level', props: { level: '' } },
+  ],
   expectedHtml: `
     <span bf-s="test" bf="s1">low:<!--bf:s0-->0<!--/--></span>
   `,

--- a/packages/adapter-tests/fixtures/logical-or-jsx.ts
+++ b/packages/adapter-tests/fixtures/logical-or-jsx.ts
@@ -21,6 +21,13 @@ export function LogicalOrJsx(props: { label?: string }) {
 }
 `,
   props: {},
+  // `||` is truthiness-based in JS too: '' takes the JSX fallback
+  // (unlike `??`, which keeps it — see nullish-coalescing-text).
+  dataPoints: [
+    { name: 'empty-label', props: { label: '' } },
+    { name: 'with-label', props: { label: 'Hi' } },
+    { name: 'html-label', props: { label: '<b>&"bold' } },
+  ],
   expectedHtml: `
     <div bf-s="test" bf="s1"><span bf-c="s0">Fallback</span></div>
   `,

--- a/packages/adapter-tests/fixtures/number-tofixed.ts
+++ b/packages/adapter-tests/fixtures/number-tofixed.ts
@@ -14,6 +14,16 @@ function NumberToFixed({ price }: { price: number }) {
 export { NumberToFixed }
 `,
   props: { price: 19.5 },
+  // Float-formatting parity: zero-pad (0 → "0.00", 7 → "7.00"), and
+  // rounding where the decimal spelling is not exactly representable
+  // (19.995 is stored as 19.99499… so JS toFixed(2) says "19.99" — a
+  // formatter that rounds the decimal spelling would say "20.00").
+  dataPoints: [
+    { name: 'zero', props: { price: 0 } },
+    { name: 'integer', props: { price: 7 } },
+    { name: 'repr-boundary', props: { price: 19.995 } },
+    { name: 'large', props: { price: 1234567.891 } },
+  ],
   expectedHtml: `
     <div bf-s="test" bf="s1">¥<!--bf:s0-->19.50<!--/--></div>
   `,

--- a/packages/adapter-tests/fixtures/optional-chaining-prop.ts
+++ b/packages/adapter-tests/fixtures/optional-chaining-prop.ts
@@ -21,6 +21,16 @@ function OptionalChainingProp({ user, owner }: { user?: User; owner?: User }) {
 export { OptionalChainingProp }
 `,
   props: { user: { name: 'Ada' } },
+  // Probes `?.` short-circuit and `??` member-fallback at every presence
+  // combination: both objects present, both absent, an explicit null
+  // object, and a present object whose member is '' (kept by `??` —
+  // not nullish).
+  dataPoints: [
+    { name: 'both-present', props: { user: { name: 'Ada' }, owner: { name: 'Bob' } } },
+    { name: 'both-absent', props: {} },
+    { name: 'null-user', props: { user: null } },
+    { name: 'empty-name', props: { user: { name: '' } } },
+  ],
   expectedHtml: `
     <div bf-s="test">
       <span bf="s1"><!--bf:s0-->Ada<!--/--></span>

--- a/packages/adapter-tests/fixtures/props-static.ts
+++ b/packages/adapter-tests/fixtures/props-static.ts
@@ -9,6 +9,16 @@ export function PropsStatic({ label, count }: { label: string; count: number }) 
 }
 `,
   props: { label: 'Items', count: 10 },
+  // Escaping and number-rendering parity on the plainest prop
+  // interpolation: markup must arrive escaped, entities must not be
+  // double-escaped, and 0 / negative counts render as JS spells them.
+  dataPoints: [
+    { name: 'markup-label', props: { label: '<script>alert(1)</script>', count: 1 } },
+    { name: 'entity-mix', props: { label: `&"'<>`, count: 1 } },
+    { name: 'unicode', props: { label: '日本語🎉', count: 1 } },
+    { name: 'zero-count', props: { label: 'Items', count: 0 } },
+    { name: 'negative-count', props: { label: 'Items', count: -5 } },
+  ],
   expectedHtml: `
     <div bf-s="test">
       <span bf="s1"><!--bf:s0-->Items<!--/--></span>

--- a/packages/adapter-tests/fixtures/string-concat-plus.ts
+++ b/packages/adapter-tests/fixtures/string-concat-plus.ts
@@ -16,6 +16,12 @@ function StringConcatPlus({ name }: { name: string }) {
 export { StringConcatPlus }
 `,
   props: { name: 'Ada' },
+  // Concat parity with empty and markup-bearing operands — a backend
+  // whose `.`/`+` coerces or escapes differently shows up here.
+  dataPoints: [
+    { name: 'empty', props: { name: '' } },
+    { name: 'markup', props: { name: '<i>&' } },
+  ],
   expectedHtml: `
     <div bf-s="test" bf="s1"><!--bf:s0-->Hello, Ada!<!--/--></div>
   `,

--- a/packages/adapter-tests/fixtures/string-length-text.ts
+++ b/packages/adapter-tests/fixtures/string-length-text.ts
@@ -15,6 +15,14 @@ function StringLengthText({ word }: { word: string }) {
 export { StringLengthText }
 `,
   props: { word: 'barefoot' },
+  // JS `.length` counts UTF-16 code units: '日本語' is 3 (a byte-based
+  // `len` would say 9), '👍' is 2 (a surrogate pair — codepoint-based
+  // counts would say 1). The oracle pins the JS answer.
+  dataPoints: [
+    { name: 'empty', props: { word: '' } },
+    { name: 'multibyte', props: { word: '日本語' } },
+    { name: 'astral', props: { word: '👍' } },
+  ],
   expectedHtml: `
     <div bf-s="test" bf="s2"><!--bf:s0-->8<!--/--> chars in <!--bf:s1-->barefoot<!--/--></div>
   `,

--- a/packages/adapter-tests/fixtures/template-literal-multi-interp.ts
+++ b/packages/adapter-tests/fixtures/template-literal-multi-interp.ts
@@ -19,6 +19,14 @@ export function TemplateLiteralMultiInterp(props: { greeting?: string }) {
 }
 `,
   props: { greeting: 'Hi' },
+  // `??` INSIDE a template literal is a distinct lowering path from
+  // text-position `??`: absent falls back, but a present-but-empty ''
+  // must be kept (JS nullish), and markup must arrive escaped.
+  dataPoints: [
+    { name: 'absent', props: {} },
+    { name: 'empty-greeting', props: { greeting: '' } },
+    { name: 'markup-greeting', props: { greeting: '<b>&' } },
+  ],
   expectedHtml: `
     <p bf-s="test" bf="s1"><!--bf:s0-->Hi, World! bye<!--/--></p>
   `,

--- a/packages/adapter-twig/src/__tests__/twig-adapter.test.ts
+++ b/packages/adapter-twig/src/__tests__/twig-adapter.test.ts
@@ -50,6 +50,12 @@ runAdapterConformanceTests({
     // Same `/* @client */` keyed-map elision (data-table).
     'data-table',
   ]),
+  skipDataPoints: new Set<string>([
+    // #2255 — Twig's length filter counts codepoints (mb-based); JS
+    // counts UTF-16 code units, so a surrogate-pair character is 2 in
+    // JS, 1 here.
+    'string-length-text:astral',
+  ]),
   onRenderError: (err, id) => {
     if (err instanceof TwigNotAvailableError) {
       console.log(`Skipping [${id}]: ${err.message}`)

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -63,6 +63,11 @@ runAdapterConformanceTests({
     // #1467 Phase 2e: same `/* @client */` keyed-map elision (data-table).
     'data-table',
   ]),
+  skipDataPoints: new Set<string>([
+    // #2255 — Perl length() counts codepoints under utf8; JS counts
+    // UTF-16 code units, so a surrogate-pair character is 2 in JS, 1 here.
+    'string-length-text:astral',
+  ]),
   onRenderError: (err, id) => {
     if (err instanceof XslateNotAvailableError) {
       console.log(`Skipping [${id}]: ${err.message}`)

--- a/spec/subset-conformance.md
+++ b/spec/subset-conformance.md
@@ -199,9 +199,11 @@ convention.
    fixtures × 27 points across the escaping / `||`-vs-`??` / `?.`-member /
    string-`.length` / `toFixed`-rounding / template-literal-`??` /
    branch-boundary axes. Findings: #2255 (`.length` is UTF-16 code units in
-   JS — bytes on Go, codepoints on ERB/Jinja/Rust) and #2256 (the Go
-   nullish gate covers only bare prop refs; member-access left operands
-   still lower to `or`), both pinned via `skipDataPoints`. Notable passes:
+   JS — bytes on Go, codepoints everywhere else; astral input diverges on
+   all eight non-Hono adapters), #2256 (the Go nullish gate covers only
+   bare prop refs; member-access left operands still lower to `or`), both
+   pinned via `skipDataPoints`, plus a Mojo render-harness bug (explicit
+   `null` props never declared their template var — fixed). Notable passes:
    `toFixed` representation-boundary rounding and template-literal `??`
    match the oracle on every locally-runnable backend.
 3. **Type-derived value catalogue** from `TypeInfo`.

--- a/spec/subset-conformance.md
+++ b/spec/subset-conformance.md
@@ -177,7 +177,7 @@ convention as `spec/adapter-architecture.md`):
 |-----------|--------|-----|
 | Normative subset | `ParsedExpr` union + exhaustive adapter switches (drift-defence); array-method / sort-comparator catalogues; builtin lowering registry; BF021/BF101 loud-refusal policy + growing-only rule (`spec/compiler.md`); `/* @client */` escape | Pieces are scattered across spec/types/catalogues with no single normative declaration; `ParsedExpr` lacks `object-literal` (adapter-architecture Roadmap A); the boundary is not fully loud — the Date silent passthrough proves unknown-type method calls pass undiagnosed; the data-domain axiom exists only in this document |
 | Canonical reference (JS render) | Hono/JS render is the *de facto* reference: snapshot generation renders expectations through it; `referenceAdapter`/`referenceRender` HTML-diff suite exists; determinism landed (#1494) | No *declaration* of canonical status (`referenceAdapter` is optional — the reference is still positioned as one adapter among eleven); oracle comparison runs at one evaluation point per fixture, not live × multiple data points |
-| Shared conformance | `run-adapter-conformance.ts` single mandatory entry point ("forgot to wire the suite" is impossible); 182 fixtures + marker conformance + template primitives + render contract; real-backend execution with `normalizeHTML`; `props` injection; **the `dataPoints` oracle suite (roadmap 1)** — gate-ordered, live-oracle, JSON-domain-validated, piloted on `nullish-coalescing-text` (found #2248 — since fixed via nillable lowering + `bf_nullish` — and a Go harness string-escaping bug on its first run) | No type-derived adversarial value catalogue; no PR-vs-nightly tiering; adversarial points exist on one pilot fixture only |
+| Shared conformance | `run-adapter-conformance.ts` single mandatory entry point ("forgot to wire the suite" is impossible); 182 fixtures + marker conformance + template primitives + render contract; real-backend execution with `normalizeHTML`; `props` injection; **the `dataPoints` oracle suite (roadmap 1)** — gate-ordered, live-oracle, JSON-domain-validated, piloted on `nullish-coalescing-text` (found #2248 — since fixed via nillable lowering + `bf_nullish` — and a Go harness string-escaping bug on its first run) | No type-derived adversarial value catalogue; no PR-vs-nightly tiering; adversarial points cover 9 fixtures (~31 points) — the long tail of the 182-fixture corpus awaits the frontmatter/axis map for prioritization |
 | Declared skips | Typed skip sets (`skipJsx`, `skipTemplatePrimitives`, `skipMarkerConformance`, `expectedDiagnostics`, and now `skipDataPoints` — its first entries pinned #2248 on the Go adapter until the fix landed and removed them, completing one full ledger round-trip) with issue-link discipline; `known-limitation` label; `@barefootjs/compat` component×adapter compile matrix (`compat.lock.json`) | No generated `kind × axis × adapter` support matrix; no fixture frontmatter declaring exercised kinds/axes (so a coverage map has no denominator) |
 
 Cross-cutting gap: the change-time coupling rule (subset extensions merge
@@ -195,7 +195,15 @@ convention.
    string-escaping bug (fixed), while ERB / Jinja / Rust passed all points
    on real backends.
 2. **Hand-written adversarial points** across existing fixtures, prioritized
-   by the frontmatter/axis map as it lands.
+   by the frontmatter/axis map as it lands. **First wave landed**: 8 more
+   fixtures × 27 points across the escaping / `||`-vs-`??` / `?.`-member /
+   string-`.length` / `toFixed`-rounding / template-literal-`??` /
+   branch-boundary axes. Findings: #2255 (`.length` is UTF-16 code units in
+   JS — bytes on Go, codepoints on ERB/Jinja/Rust) and #2256 (the Go
+   nullish gate covers only bare prop refs; member-access left operands
+   still lower to `or`), both pinned via `skipDataPoints`. Notable passes:
+   `toFixed` representation-boundary rounding and template-literal `??`
+   match the oracle on every locally-runnable backend.
 3. **Type-derived value catalogue** from `TypeInfo`.
 4. **Date**: passthrough closure, then the catalogue plugin (UTC + ISO
    scope), envelope transport in the harness.


### PR DESCRIPTION
## Summary

Roadmap stage 2 of `spec/subset-conformance.md`: spread hand-written oracle evaluation points beyond the pilot — 8 fixtures, 27 new points, one fixture per divergence axis:

| Axis | Fixture | Points |
|---|---|---|
| Escaping (text) | `props-static`, `string-concat-plus` | `<script>`, `&"'<>`, unicode+emoji, empty/markup operands |
| Truthiness vs nullish | `logical-or-jsx` | `''` takes the `\|\|` JSX fallback (unlike `??`) |
| `?.` + member `??` | `optional-chaining-prop` | both-present / both-absent / `null` object / present-but-empty member |
| String `.length` | `string-length-text` | `''` / `'日本語'` / `'👍'` (UTF-16 semantics) |
| Float formatting | `number-tofixed` | zero-pad, `19.995` representation boundary, large |
| Template-literal `??` | `template-literal-multi-interp` | absent / empty-kept / markup |
| Branch selection | `else-if-chain` | per-level agreement (incl. the pinned else-if fallthrough) |
| Numbers in text | `props-static` | `0`, negative |

## Findings (filed + pinned per the skip discipline)

- **#2255** — JS `String.length` counts UTF-16 code units; no adapter implements that. Go's byte `len` diverges on any multibyte input (`日本語` → 9 vs 3); ERB/Jinja/Rust codepoint counts diverge on astral input (`👍` → 1 vs 2). Pinned on all four.
- **#2256** — the #2252 nullish gate covers only bare nillable prop refs: `user?.name ?? '…'` still lowers to truthiness `or`, so a present-but-empty member wrongly falls back on Go. Pinned; sibling of #2254.

Notable **passes**: the `toFixed` representation-boundary rounding (`19.995` → `"19.99"`) and template-literal `??` match the oracle on every locally-runnable backend.

## Verification

- Data-point suites green with declared skips on Go (real 1.25.6), ERB, Jinja, Rust (real backends), and Hono (oracle self-consistency): 28–31 points per adapter, 0 fail.
- Twig / Blade / Xslate / Mojolicious are not runnable locally — their CI jobs pin their columns; expected divergence: PHP byte `strlen` / Perl codepoint `length` on the #2255 rows. I'm watching CI and will add per-observation skips referencing #2255 if they surface.
- Spec live-record updated (roadmap 2 first wave, current-state gap now the corpus long tail awaiting the frontmatter/axis map).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1T4R1R6FKPGTFyYn1ppBa

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1T4R1R6FKPGTFyYn1ppBa)_