### PR TITLE
Analyzer: resolve TypeInfo and optionality for destructured optional props (#2259)

### DIFF
--- a/.changeset/destructured-optional-props.md
+++ b/.changeset/destructured-optional-props.md
@@ -15,3 +15,5 @@ Destructured optional props keep their TypeInfo and optional flag (#2259). `{ si
 The Go adapter additionally recognises the destructured `x ?? <literal>` signal seed (matched structurally on the signal's `ParsedExpr`), so the #2248/#2252 hoisted-fallback/nillable machinery now fires for destructured components instead of seeding the signal with a literal zero, and an optional no-default scalar consumed as a bare omittable attribute (`rows={rows}`) takes the same `interface{}` flip so the `{{if ne .X nil}}` omission guard keeps firing now that the field would otherwise resolve concrete.
 
 The dynamic-template adapters (ERB / Jinja / Mojolicious / Rust / Twig / Blade / Xslate) widen `collectNullableOptionalProps` to declared-optional primitives, keeping Hono-style attribute omission for optional props that previously arrived untyped — this also extends the omission guard to props-object-style optional primitives, matching the reference render.
+
+Known output change on Go: a destructured optional scalar consumed as a bare TEXT expression now renders its zero value when absent (the pre-existing props-object behavior) instead of empty — tracked as #2267.

--- a/.changeset/destructured-optional-props.md
+++ b/.changeset/destructured-optional-props.md
@@ -1,0 +1,17 @@
+---
+"@barefootjs/jsx": minor
+"@barefootjs/go-template": minor
+"@barefootjs/erb": patch
+"@barefootjs/jinja": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/rust": patch
+"@barefootjs/twig": patch
+"@barefootjs/blade": patch
+"@barefootjs/xslate": patch
+---
+
+Destructured optional props keep their TypeInfo and optional flag (#2259). `{ size }: { size?: number }` now resolves in `propsParams` exactly like the props-object style: primitive members carry their concrete type, every member carries `optional` derived from the type's `?` (or a destructure default), and generated export signatures render the `?` again. The client JS no longer synthesizes a zero default when extracting a defaultless optional prop — the binding stays `undefined` when absent, matching JS destructuring semantics and the SSR seed.
+
+The Go adapter additionally recognises the destructured `x ?? <literal>` signal seed (matched structurally on the signal's `ParsedExpr`), so the #2248/#2252 hoisted-fallback/nillable machinery now fires for destructured components instead of seeding the signal with a literal zero, and an optional no-default scalar consumed as a bare omittable attribute (`rows={rows}`) takes the same `interface{}` flip so the `{{if ne .X nil}}` omission guard keeps firing now that the field would otherwise resolve concrete.
+
+The dynamic-template adapters (ERB / Jinja / Mojolicious / Rust / Twig / Blade / Xslate) widen `collectNullableOptionalProps` to declared-optional primitives, keeping Hono-style attribute omission for optional props that previously arrived untyped — this also extends the omission guard to props-object-style optional primitives, matching the reference render.

--- a/packages/adapter-blade/src/adapter/props/prop-classes.ts
+++ b/packages/adapter-blade/src/adapter/props/prop-classes.ts
@@ -24,10 +24,9 @@ export function collectBooleanTypedProps(ir: ComponentIR): Set<string> {
 }
 
 /**
- * Bare references to presence-uncertain no-default props — non-primitive
- * or declared optional (#2259; pre-#2259 destructured optionals arrived as
- * `unknown` and the type test alone covered them) — (e.g.
- * textarea's `rows`) are `null` when omitted → guarded with
+ * Bare references to presence-uncertain no-default props (non-primitive
+ * typed OR declared optional, #2259 — e.g. textarea's `rows`) are
+ * `null` when omitted → guarded with
  * `is defined and is not null` in `emitExpression`. See the
  * `nullableOptionalProps` field docstring in `blade-adapter.ts`.
  */

--- a/packages/adapter-blade/src/adapter/props/prop-classes.ts
+++ b/packages/adapter-blade/src/adapter/props/prop-classes.ts
@@ -24,7 +24,9 @@ export function collectBooleanTypedProps(ir: ComponentIR): Set<string> {
 }
 
 /**
- * Bare references to optional, no-default, non-primitive props (e.g.
+ * Bare references to presence-uncertain no-default props — non-primitive
+ * or declared optional (#2259; pre-#2259 destructured optionals arrived as
+ * `unknown` and the type test alone covered them) — (e.g.
  * textarea's `rows`) are `null` when omitted → guarded with
  * `is defined and is not null` in `emitExpression`. See the
  * `nullableOptionalProps` field docstring in `blade-adapter.ts`.
@@ -36,7 +38,7 @@ export function collectNullableOptionalProps(ir: ComponentIR): Set<string> {
         p =>
           p.defaultValue === undefined &&
           !p.isRest &&
-          p.type?.kind !== 'primitive',
+          (p.type?.kind !== 'primitive' || p.optional),
       )
       .map(p => p.name),
   )

--- a/packages/adapter-erb/src/adapter/props/prop-classes.ts
+++ b/packages/adapter-erb/src/adapter/props/prop-classes.ts
@@ -47,8 +47,7 @@ export function collectBooleanTypedProps(ir: ComponentIR): Set<string> {
  * concrete-primitive prop (`string`/`number`/`boolean`) is excluded — the
  * caller always supplies it, matching the Go adapter's unconditional
  * concrete fields — but an OPTIONAL primitive is presence-uncertain and
- * stays guarded (#2259; pre-#2259 these arrived as `unknown` and were
- * guarded by the type test alone).
+ * stays guarded (#2259).
  */
 export function collectNullableOptionalProps(ir: ComponentIR): Set<string> {
   return new Set(

--- a/packages/adapter-erb/src/adapter/props/prop-classes.ts
+++ b/packages/adapter-erb/src/adapter/props/prop-classes.ts
@@ -43,10 +43,12 @@ export function collectBooleanTypedProps(ir: ComponentIR): Set<string> {
  * omission). A prop WITH a destructure default (`value = ''`) is never
  * `nil` in the body and must stay unconditional, so it is excluded. Mirrors
  * the Go adapter's nillable-field guard: there the witness is the resolved
- * `interface{}` field type; here it is the absence of a default. Excludes
- * concrete-primitive types (`string`/`number`/`boolean`) to match the Go
- * adapter's scope, which guards only nillable fields and leaves concrete
- * fields unconditional.
+ * `interface{}` field type; here it is the absence of a default. A REQUIRED
+ * concrete-primitive prop (`string`/`number`/`boolean`) is excluded — the
+ * caller always supplies it, matching the Go adapter's unconditional
+ * concrete fields — but an OPTIONAL primitive is presence-uncertain and
+ * stays guarded (#2259; pre-#2259 these arrived as `unknown` and were
+ * guarded by the type test alone).
  */
 export function collectNullableOptionalProps(ir: ComponentIR): Set<string> {
   return new Set(
@@ -55,7 +57,7 @@ export function collectNullableOptionalProps(ir: ComponentIR): Set<string> {
         p =>
           p.defaultValue === undefined &&
           !p.isRest &&
-          p.type?.kind !== 'primitive',
+          (p.type?.kind !== 'primitive' || p.optional),
       )
       .map(p => p.name),
   )

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -670,6 +670,48 @@ export function Counter({ size }: { size?: number }) {
       expect(types).toContain('Count: in.Size,')
     })
 
+    test('negative fallback (`?? -1`) hoists in both prop styles (#2259 review)', () => {
+      // `-1` parses as unary minus around a number literal, not a literal —
+      // the structural seed match must reconstruct the sign, in the
+      // props-object form (where it preempts the regex path) and the
+      // destructured form alike.
+      for (const [params, ref] of [
+        ['props: { size?: number }', 'props.size'],
+        ['{ size }: { size?: number }', 'size'],
+      ]) {
+        const adapter = new GoTemplateAdapter()
+        const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+export function Counter(${params}) {
+  const [count, setCount] = createSignal(${ref} ?? -1)
+  return <div>{count()}</div>
+}
+`, adapter)
+        const types = adapter.generate(ir).types!
+        expect(types).toContain('Size interface{}')
+        expect(types).toContain('var size int = -1')
+        expect(types).toContain('Count: size,')
+      }
+    })
+
+    test('string fallback with quotes survives the structural match unmangled (#2259 review)', () => {
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+export function Label({ label }: { label?: string }) {
+  const [text, setText] = createSignal(label ?? 'say "hi"')
+  return <div>{text()}</div>
+}
+`, adapter)
+      const types = adapter.generate(ir).types!
+      expect(types).toContain('var label string = "say \\"hi\\""')
+      expect(types).not.toContain('\\\\')
+    })
+
     test('destructure DEFAULT keeps the concrete-typed applyGoFallback baking (#2259)', () => {
       // `{ size = 5 }` never sees a nullish binding in JS (the default
       // already applied), so it must stay excluded from the nillable flip

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -144,6 +144,11 @@ runAdapterConformanceTests({
     // the contract's shallow copy.
     'array-flat-dynamic-depth:gen:depth:zero',
     'array-flat-dynamic-depth:gen:depth:negative',
+    // #2266 — asChild=true with plain-text children: the Slot define
+    // dereferences `.Children.Props.Children`, which hard-errors on a
+    // string child (`can't evaluate field Props in type interface {}`).
+    'button:gen:asChild:true',
+    'kbd:gen:asChild:true',
   ]),
   onRenderError: (err, id) => {
     if (err instanceof GoNotAvailableError) {
@@ -617,6 +622,75 @@ export function Check(props: { checked?: boolean }) {
       expect(types).toContain('C: checked,')
     })
 
+    test('hoists the DESTRUCTURED `x ?? N` seed via signal.parsed (#2259)', () => {
+      // Destructured components have no `propsObjectName`, so the seed's
+      // prop reference is a bare identifier — matched structurally on the
+      // signal's ParsedExpr, then routed through the same nullish flip +
+      // hoisted-var machinery as `props.size ?? 1` (#2248/#2252 parity).
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+export function Counter({ size }: { size?: number }) {
+  const [count, setCount] = createSignal(size ?? 1)
+  return <div>{count()}</div>
+}
+`)
+      const result = adapter.generate(ir)
+      const types = result.types!
+      expect(types).toContain('Size interface{}')
+      expect(types).toContain('var size int = 1')
+      expect(types).toMatch(/if in\.Size != nil \{\s*size = bf\.ToInt\(in\.Size\)\s*\}/)
+      expect(types).toContain('Size: size,')
+      expect(types).toContain('Count: size,')
+    })
+
+    test('destructured `x ?? 0` stays concrete and seeds the prop directly (#2259)', () => {
+      // A zero-equivalent fallback earns no nillable flip (nil and the Go
+      // zero value land on the same output), so the field keeps its scalar
+      // type and the signal seeds straight off the input — NOT the literal
+      // `0` the pre-#2259 lowering emitted for the unrecognized identifier
+      // form.
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+export function Counter({ size }: { size?: number }) {
+  const [count, setCount] = createSignal(size ?? 0)
+  return <div>{count()}</div>
+}
+`)
+      const result = adapter.generate(ir)
+      const types = result.types!
+      expect(types).toContain('Size int')
+      expect(types).not.toContain('Size interface{}')
+      expect(types).toContain('Size: in.Size,')
+      expect(types).toContain('Count: in.Size,')
+    })
+
+    test('destructure DEFAULT keeps the concrete-typed applyGoFallback baking (#2259)', () => {
+      // `{ size = 5 }` never sees a nullish binding in JS (the default
+      // already applied), so it must stay excluded from the nillable flip
+      // and keep the zero-check baking on the concrete field.
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+export function Counter({ size = 5 }: { size?: number }) {
+  const [count, setCount] = createSignal(size)
+  return <div>{count()}</div>
+}
+`)
+      const result = adapter.generate(ir)
+      const types = result.types!
+      expect(types).toContain('Size int')
+      expect(types).not.toContain('Size interface{}')
+      expect(types).toContain('Size: func() int { if in.Size == 0 { return 5 }; return in.Size }(),')
+    })
+
     test('skips hoist for zero-equivalent string and float fallbacks (#1423 review)', () => {
       // The skip predicate compares the Go fallback against the
       // type's zero literal — covers `?? ''` (string) and `?? 0.0`
@@ -1010,10 +1084,13 @@ function Box({ describedBy }: { describedBy?: string }) {
       // Template emission is unchanged from the proven {...props} path.
       expect(template).toContain('{{bf_spread_attrs .Spread_0}}')
       // The bag value is a conditional map built in NewBoxProps. The
-      // prop type is unresolved (interface{}), so the condition routes
-      // through `bf.Truthy` for a faithful JS `Boolean(x)` test.
+      // optional prop resolves to a concrete `string` (#2259) — it is
+      // consumed only inside the spread condition, not as a bare attr, so
+      // no nillable flip — and the field-typed condition is a faithful
+      // `!= ""` truthiness test rather than reflection: JS string
+      // truthiness IS non-emptiness, and an absent prop zeroes to `""`.
       expect(types).toContain('Spread_0: func() map[string]any {')
-      expect(types).toContain('if bf.Truthy(in.DescribedBy) {')
+      expect(types).toContain('if in.DescribedBy != "" {')
       expect(types).toContain('return map[string]any{"aria-describedby": in.DescribedBy}')
       expect(types).toContain('return map[string]any{}')
     })

--- a/packages/adapter-go-template/src/adapter/emit-context.ts
+++ b/packages/adapter-go-template/src/adapter/emit-context.ts
@@ -41,14 +41,23 @@ export interface GoEmitContext {
     preParsed?: ParsedExpr,
   ): { condition: string; preamble: string }
 
-  /** Extract the prop name from a `props.X ?? …` initial value, or null. */
-  extractPropNameFromInitialValue(initialValue: string): string | null
+  /**
+   * Extract the prop name from a `props.X ?? …` initial value — or, given
+   * `preParsed` in a destructured component, an `x ?? …` identifier form —
+   * or null. Callers validate the name against `propsParams`.
+   */
+  extractPropNameFromInitialValue(initialValue: string, preParsed?: ParsedExpr): string | null
 
   /**
-   * Parse a signal-time initial value `props.X ?? <literal>` into the source
-   * prop name and the Go-formatted fallback, or null when it isn't that shape.
+   * Parse a signal-time initial value `props.X ?? <literal>` (or the
+   * destructured `x ?? <literal>` form when `preParsed` is given) into the
+   * source prop name and the Go-formatted fallback, or null when it isn't
+   * that shape. Callers validate the name against `propsParams`.
    */
-  extractPropFallback(initialValue: string): { propName: string; goFallback: string } | null
+  extractPropFallback(
+    initialValue: string,
+    preParsed?: ParsedExpr,
+  ): { propName: string; goFallback: string } | null
 
   /**
    * Inline a module string const by name as a Go double-quoted literal

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -135,7 +135,7 @@ import { lowerCtorExpr } from "./memo/ctor-lowering.ts"
 import { resolveBlockBodyMemoModuleConst } from "./memo/memo-value.ts"
 import { computeMemoInitialValue, computeMemoInitialValueOrNull, filterArmEarlierSiblingRefs } from "./memo/memo-compute.ts"
 import { collectSpreadSlots, buildSpreadInitializer } from "./spread/spread-codegen.ts"
-import { buildPropTypeOverrides, resolvePropGoType, collectNillablePropNames, collectNullishConsumedPropNames, NULLISH_SCALAR_GO_TYPES } from "./props/prop-types.ts"
+import { buildPropTypeOverrides, resolvePropGoType, collectNillablePropNames, collectNullishConsumedPropNames, collectOmittableAttrConsumedPropNames, NULLISH_SCALAR_GO_TYPES } from "./props/prop-types.ts"
 import { collectStringValueNames } from "./props/prop-classes.ts"
 
 export type { GoTemplateAdapterOptions } from "./lib/types.ts"
@@ -224,8 +224,9 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       this.convertExpressionToGo(jsExpr, out, preParsed),
     convertConditionToGo: (jsCondition, preParsed) =>
       this.convertConditionToGo(jsCondition, preParsed),
-    extractPropNameFromInitialValue: (initialValue) => this.extractPropNameFromInitialValue(initialValue),
-    extractPropFallback: (initialValue) => this.extractPropFallback(initialValue),
+    extractPropNameFromInitialValue: (initialValue, preParsed) =>
+      this.extractPropNameFromInitialValue(initialValue, preParsed),
+    extractPropFallback: (initialValue, preParsed) => this.extractPropFallback(initialValue, preParsed),
     resolveModuleStringConst: (name) => this.resolveModuleStringConst(name),
   }
 
@@ -416,10 +417,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     this.state.templateVarCounter = 0
     this.state.pendingChildrenDefines = []
     this.primeCompileState(ir)
-    // Ordering: the nullish-consumed set feeds `resolvePropGoType`'s
-    // interface{} flip (#2248), and `collectNillablePropNames` is itself
-    // derived from `resolvePropGoType` — so populate it first.
+    // Ordering: the nullish-consumed and attr-consumed sets feed
+    // `resolvePropGoType`'s interface{} flip (#2248/#2259), and
+    // `collectNillablePropNames` is itself derived from `resolvePropGoType`
+    // — so populate them first.
     this.state.nullishConsumedPropNames = collectNullishConsumedPropNames(this.emitCtx, ir)
+    this.state.omittableAttrConsumedPropNames = collectOmittableAttrConsumedPropNames(this.emitCtx, ir)
     this.state.nillablePropNames = collectNillablePropNames(this.emitCtx, ir)
     this.state.stringValueNames = collectStringValueNames(ir)
 
@@ -1345,7 +1348,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       if (propFieldNames.has(fieldName)) continue
       // `props.X ?? N` reuses the hoisted fallback var so signal and memo share
       // one value.
-      const fallbackMatch = this.extractPropFallback(signal.initialValue)
+      const fallbackMatch = this.extractPropFallback(signal.initialValue, signal.parsed)
       const hoisted = fallbackMatch ? propFallbackVars.get(fallbackMatch.propName) : undefined
       if (hoisted) {
         lines.push(`\t\t${fieldName}: ${hoisted.varName},`)
@@ -2737,7 +2740,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
     const propTypeOverrides = buildPropTypeOverrides(this.emitCtx, ir)
     for (const signal of ir.metadata.signals) {
-      const match = this.extractPropFallback(signal.initialValue)
+      const match = this.extractPropFallback(signal.initialValue, signal.parsed)
       if (!match) continue
       if (result.has(match.propName)) continue
       const param = ir.metadata.propsParams.find(p => p.name === match.propName)
@@ -2800,15 +2803,54 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   /**
-   * Parse a signal-time initial value of the form `props.X ?? <literal>` into
-   * the source prop name and the Go-formatted fallback. Returns null when the
-   * expression isn't a `??` against a property access on `propsObjectName`, or
-   * the fallback isn't a simple literal `goPropDefault` can translate.
+   * Parse a signal-time initial value of the form `props.X ?? <literal>` —
+   * or, for destructured components, `x ?? <literal>` — into the source prop
+   * name and the Go-formatted fallback. Returns null when the expression
+   * isn't that shape or the fallback isn't a simple literal `goPropDefault`
+   * can translate.
+   *
+   * `preParsed` (the signal's best-effort `ParsedExpr`) is matched
+   * structurally when available; the regex handles only the props-object
+   * member form for callers without a tree (memo computations). A bare
+   * identifier can shadow a same-named prop (loop/callback params — the
+   * `collectNullishConsumedPropNames` limitation class), so every caller
+   * validates the returned name against `ir.metadata.propsParams`.
    *
    * Keeps the original prop reference (not just the resolved value) so
    * caller-supplied non-zero inputs are honoured.
    */
-  private extractPropFallback(initialValue: string): { propName: string; goFallback: string } | null {
+  private extractPropFallback(
+    initialValue: string,
+    preParsed?: ParsedExpr,
+  ): { propName: string; goFallback: string } | null {
+    if (preParsed) {
+      if (preParsed.kind !== 'logical' || preParsed.op !== '??') return null
+      const left = preParsed.left
+      const propName =
+        left.kind === 'identifier' && !this.state.propsObjectName
+          ? left.name
+          : left.kind === 'member' &&
+              !left.computed &&
+              left.object.kind === 'identifier' &&
+              left.object.name === this.state.propsObjectName
+            ? left.property
+            : null
+      if (!propName) return null
+      const lit = preParsed.right
+      if (lit.kind !== 'literal') return null
+      // Reconstruct the literal's source text for `goPropDefault` — `raw` is
+      // only populated for numbers; strings carry the unquoted value.
+      const fallbackSource =
+        lit.literalType === 'string'
+          ? JSON.stringify(lit.value)
+          : lit.literalType === 'number'
+            ? (lit.raw ?? String(lit.value))
+            : String(lit.value)
+      const goFallback = goPropDefault(fallbackSource)
+      if (goFallback === null) return null
+      return { propName, goFallback }
+    }
+
     if (!this.state.propsObjectName) return null
     const trimmed = initialValue.trim()
     const name = this.state.propsObjectName
@@ -2825,9 +2867,22 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   /**
    * Extract the prop name from a signal's `props.xxx`-pattern initialValue,
    * e.g. `"props.initial ?? 0"` → `"initial"`, `"props.checked"` → `"checked"`.
+   * For destructured components (`propsObjectName` null) the same shapes are
+   * matched structurally on `preParsed` with an identifier left operand
+   * (`size ?? 0` → `"size"`); callers validate the name against
+   * `propsParams`, which filters shadowing locals.
    */
-  private extractPropNameFromInitialValue(initialValue: string): string | null {
-    if (!this.state.propsObjectName) return null
+  private extractPropNameFromInitialValue(initialValue: string, preParsed?: ParsedExpr): string | null {
+    if (!this.state.propsObjectName) {
+      if (
+        preParsed?.kind === 'logical' &&
+        (preParsed.op === '??' || preParsed.op === '||') &&
+        preParsed.left.kind === 'identifier'
+      ) {
+        return preParsed.left.name
+      }
+      return null
+    }
     const trimmed = initialValue.trim()
     const name = this.state.propsObjectName
 

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -407,6 +407,19 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     }
     this.state.loweringMatchers = prepareLoweringMatchers(ir.metadata)
     augmentInheritedPropAccesses(ir)
+    // The consumed-prop sets feed `resolvePropGoType`'s interface{} flips
+    // (#2248/#2259) and `collectNillablePropNames` is derived from
+    // `resolvePropGoType`, which also consults the local type tables — so
+    // build the tables first and populate all three HERE, where both entry
+    // points share them. Computing them only in `generate()` left the
+    // standalone `generateTypes()` entry (sibling IRs in the conformance
+    // harness) resolving structs against another component's sets, and
+    // `generate()` itself computing nillability against the PREVIOUS
+    // compile's type tables.
+    this.buildLocalTypeTables(ir, ir.metadata.componentName)
+    this.state.nullishConsumedPropNames = collectNullishConsumedPropNames(this.emitCtx, ir)
+    this.state.omittableAttrConsumedPropNames = collectOmittableAttrConsumedPropNames(this.emitCtx, ir)
+    this.state.nillablePropNames = collectNillablePropNames(this.emitCtx, ir)
   }
 
   /** Generate template output for a component. */
@@ -417,13 +430,6 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     this.state.templateVarCounter = 0
     this.state.pendingChildrenDefines = []
     this.primeCompileState(ir)
-    // Ordering: the nullish-consumed and attr-consumed sets feed
-    // `resolvePropGoType`'s interface{} flip (#2248/#2259), and
-    // `collectNillablePropNames` is itself derived from `resolvePropGoType`
-    // — so populate them first.
-    this.state.nullishConsumedPropNames = collectNullishConsumedPropNames(this.emitCtx, ir)
-    this.state.omittableAttrConsumedPropNames = collectOmittableAttrConsumedPropNames(this.emitCtx, ir)
-    this.state.nillablePropNames = collectNillablePropNames(this.emitCtx, ir)
     this.state.stringValueNames = collectStringValueNames(ir)
 
     // Surface loop-body usages of sibling-imported components (see
@@ -2823,34 +2829,11 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     initialValue: string,
     preParsed?: ParsedExpr,
   ): { propName: string; goFallback: string } | null {
-    if (preParsed) {
-      if (preParsed.kind !== 'logical' || preParsed.op !== '??') return null
-      const left = preParsed.left
-      const propName =
-        left.kind === 'identifier' && !this.state.propsObjectName
-          ? left.name
-          : left.kind === 'member' &&
-              !left.computed &&
-              left.object.kind === 'identifier' &&
-              left.object.name === this.state.propsObjectName
-            ? left.property
-            : null
-      if (!propName) return null
-      const lit = preParsed.right
-      if (lit.kind !== 'literal') return null
-      // Reconstruct the literal's source text for `goPropDefault` — `raw` is
-      // only populated for numbers; strings carry the unquoted value.
-      const fallbackSource =
-        lit.literalType === 'string'
-          ? JSON.stringify(lit.value)
-          : lit.literalType === 'number'
-            ? (lit.raw ?? String(lit.value))
-            : String(lit.value)
-      const goFallback = goPropDefault(fallbackSource)
-      if (goFallback === null) return null
-      return { propName, goFallback }
-    }
+    const structural = preParsed ? this.extractPropFallbackFromParsed(preParsed) : null
+    if (structural) return structural
 
+    // Regex fallback for callers without a tree (memo computation strings)
+    // and for props-object shapes the structural match doesn't model.
     if (!this.state.propsObjectName) return null
     const trimmed = initialValue.trim()
     const name = this.state.propsObjectName
@@ -2862,6 +2845,45 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     const goFallback = goPropDefault(m[2].trim())
     if (goFallback === null) return null
     return { propName: m[1], goFallback }
+  }
+
+  /** Structural half of {@link extractPropFallback}. */
+  private extractPropFallbackFromParsed(
+    preParsed: ParsedExpr,
+  ): { propName: string; goFallback: string } | null {
+    if (preParsed.kind !== 'logical' || preParsed.op !== '??') return null
+    const left = preParsed.left
+    const propName =
+      left.kind === 'identifier' && !this.state.propsObjectName
+        ? left.name
+        : left.kind === 'member' &&
+            !left.computed &&
+            left.object.kind === 'identifier' &&
+            left.object.name === this.state.propsObjectName
+          ? left.property
+          : null
+    if (!propName) return null
+    // A negative fallback (`?? -1`) parses as unary minus around a number
+    // literal, not a literal.
+    let right = preParsed.right
+    let negate = ''
+    if (right.kind === 'unary' && right.op === '-') {
+      negate = '-'
+      right = right.argument
+    }
+    if (right.kind !== 'literal') return null
+    if (negate && right.literalType !== 'number') return null
+    // A string fallback is already the decoded value — quote it directly;
+    // routing it through `goPropDefault` would strip JSON.stringify's outer
+    // quotes and escape the body a second time (`"` → `\\\"`).
+    if (right.literalType === 'string') {
+      return { propName, goFallback: JSON.stringify(right.value) }
+    }
+    // Numbers keep their source spelling when available (`raw` is only
+    // populated for numbers); booleans/null stringify losslessly.
+    const goFallback = goPropDefault(negate + (right.raw ?? String(right.value)))
+    if (goFallback === null) return null
+    return { propName, goFallback }
   }
 
   /**

--- a/packages/adapter-go-template/src/adapter/lib/compile-state.ts
+++ b/packages/adapter-go-template/src/adapter/lib/compile-state.ts
@@ -157,6 +157,14 @@ export class CompileState {
   nullishConsumedPropNames: Set<string> = new Set()
 
   /**
+   * OPTIONAL no-default prop names consumed as a BARE omittable-attribute
+   * value (`rows={rows}`) — #2259. Same `resolvePropGoType` flip and same
+   * populate-before-first-resolve ordering as `nullishConsumedPropNames`:
+   * the attribute-omission guard (`{{if ne .X nil}}`) needs a nillable field.
+   */
+  omittableAttrConsumedPropNames: Set<string> = new Set()
+
+  /**
    * String-typed signal getter / prop names (#2168 string-concat-plus).
    * Feeds `isStringName` for `isStringConcatBinary`, which decides whether a
    * JS `+` operand chain is string concatenation rather than numeric

--- a/packages/adapter-go-template/src/adapter/props/prop-types.ts
+++ b/packages/adapter-go-template/src/adapter/props/prop-types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ComponentIR, IRMetadata, IRNode, ParsedExpr } from '@barefootjs/jsx'
+import { isBooleanAttr } from '@barefootjs/jsx'
 
 import type { GoEmitContext } from '../emit-context.ts'
 import { typeInfoToGo } from '../type/type-codegen.ts'
@@ -20,7 +21,7 @@ export function buildPropTypeOverrides(ctx: GoEmitContext, ir: ComponentIR): Map
   const overrides = new Map<string, string>()
   for (const signal of ir.metadata.signals) {
     const propNames = [signal.initialValue]
-    const extracted = ctx.extractPropNameFromInitialValue(signal.initialValue)
+    const extracted = ctx.extractPropNameFromInitialValue(signal.initialValue, signal.parsed)
     if (extracted) propNames.push(extracted)
 
     for (const propName of propNames) {
@@ -189,12 +190,65 @@ export function collectNullishConsumedPropNames(ctx: GoEmitContext, ir: Componen
   // tree — reuse the seam's existing `props.X ?? <literal>` recognizer. The
   // zero-equivalent exclusion matches on the Go-formatted fallback literal.
   for (const signal of ir.metadata.signals) {
-    const match = ctx.extractPropFallback(signal.initialValue)
+    const match = ctx.extractPropFallback(signal.initialValue, signal.parsed)
     if (!match || !optionalParams.has(match.propName)) continue
     const f = match.goFallback
     if (f === '""' || f === 'false' || f === 'nil' || Number(f) === 0) continue
     names.add(match.propName)
   }
+  return names
+}
+
+/**
+ * Names of OPTIONAL no-default props consumed as the BARE value of an
+ * omittable attribute (`rows={rows}` / `rows={props.rows}`) anywhere in the
+ * component's element tree.
+ *
+ * Why this matters: Hono omits an attribute whose value is `undefined`, and
+ * the adapter's `emitExpression` mirrors that with a `{{if ne .X nil}}` guard
+ * — which needs a nillable field to test. A concrete scalar field would
+ * render the zero value (`rows="0"`) instead of dropping the attribute, so
+ * these props take the same `interface{}` flip as `??` consumption
+ * (`resolvePropGoType`). The match mirrors `emitExpression`'s guard branch:
+ * bare identifiers / `<propsObject>.<name>` only, skipping `class`/`style`
+ * (own lowerings) and boolean/presence attrs (truthiness-tested, where a nil
+ * and a zero value already coincide). Same shadowing caveat as
+ * `collectNullishConsumedPropNames`: a same-named loop/callback param can
+ * misattribute, making the flip merely unnecessary, not incorrect.
+ */
+export function collectOmittableAttrConsumedPropNames(ctx: GoEmitContext, ir: ComponentIR): Set<string> {
+  const names = new Set<string>()
+  const optionalParams = new Set(
+    ir.metadata.propsParams.filter(p => p.optional && p.defaultValue == null).map(p => p.name),
+  )
+  if (optionalParams.size === 0) return names
+
+  const propsObject = ctx.state.propsObjectName
+  const walk = (node: unknown): void => {
+    if (!node || typeof node !== 'object') return
+    if (Array.isArray(node)) {
+      for (const item of node) walk(item)
+      return
+    }
+    const rec = node as Record<string, unknown>
+    if (rec.type === 'element' && Array.isArray(rec.attrs)) {
+      for (const attr of rec.attrs as Array<{ name: string; value: Record<string, unknown> }>) {
+        if (attr.name === 'class' || attr.name === 'className' || attr.name === 'style') continue
+        if (isBooleanAttr(attr.name)) continue
+        if (attr.value?.kind !== 'expression' || attr.value.presenceOrUndefined) continue
+        const bareId = String(attr.value.expr ?? '').trim()
+        const propName =
+          propsObject && bareId.startsWith(`${propsObject}.`)
+            ? bareId.slice(propsObject.length + 1)
+            : bareId
+        if (/^[A-Za-z_$][\w$]*$/.test(propName) && optionalParams.has(propName)) {
+          names.add(propName)
+        }
+      }
+    }
+    for (const value of Object.values(rec)) walk(value)
+  }
+  walk(ir.root)
   return names
 }
 
@@ -242,10 +296,14 @@ export function resolvePropGoType(
   // every valid input. (A literal-number union containing 0 would be the
   // exception; none exists in the corpus and the conflation is the
   // documented pre-#2248 trade-off there.)
+  // A bare-attribute consumption (`rows={rows}`) takes the same flip (#2259):
+  // attribute omission for an absent optional needs a nil to test — see
+  // `collectOmittableAttrConsumedPropNames`.
   if (
     param.optional &&
     param.type.kind === 'primitive' &&
-    ctx.state.nullishConsumedPropNames.has(param.name) &&
+    (ctx.state.nullishConsumedPropNames.has(param.name) ||
+      ctx.state.omittableAttrConsumedPropNames.has(param.name)) &&
     NULLISH_SCALAR_GO_TYPES.has(base)
   ) {
     return 'interface{}'

--- a/packages/adapter-go-template/src/adapter/value/value-lowering.ts
+++ b/packages/adapter-go-template/src/adapter/value/value-lowering.ts
@@ -32,7 +32,7 @@ export function convertInitialValue(
     }
   }
 
-  const propName = ctx.extractPropNameFromInitialValue(value)
+  const propName = ctx.extractPropNameFromInitialValue(value, preParsed)
   if (propName && propsParams?.some(p => p.name === propName)) {
     return `in.${capitalizeFieldName(propName)}`
   }

--- a/packages/adapter-jinja/src/adapter/props/prop-classes.ts
+++ b/packages/adapter-jinja/src/adapter/props/prop-classes.ts
@@ -24,10 +24,9 @@ export function collectBooleanTypedProps(ir: ComponentIR): Set<string> {
 }
 
 /**
- * Bare references to presence-uncertain no-default props — non-primitive
- * or declared optional (#2259; pre-#2259 destructured optionals arrived as
- * `unknown` and the type test alone covered them) — (e.g.
- * textarea's `rows`) are `None` when omitted → guarded with
+ * Bare references to presence-uncertain no-default props (non-primitive
+ * typed OR declared optional, #2259 — e.g. textarea's `rows`) are
+ * `None` when omitted → guarded with
  * `is defined and is not none` in `emitExpression`. See the
  * `nullableOptionalProps` field docstring in `jinja-adapter.ts`.
  */

--- a/packages/adapter-jinja/src/adapter/props/prop-classes.ts
+++ b/packages/adapter-jinja/src/adapter/props/prop-classes.ts
@@ -24,7 +24,9 @@ export function collectBooleanTypedProps(ir: ComponentIR): Set<string> {
 }
 
 /**
- * Bare references to optional, no-default, non-primitive props (e.g.
+ * Bare references to presence-uncertain no-default props — non-primitive
+ * or declared optional (#2259; pre-#2259 destructured optionals arrived as
+ * `unknown` and the type test alone covered them) — (e.g.
  * textarea's `rows`) are `None` when omitted → guarded with
  * `is defined and is not none` in `emitExpression`. See the
  * `nullableOptionalProps` field docstring in `jinja-adapter.ts`.
@@ -36,7 +38,7 @@ export function collectNullableOptionalProps(ir: ComponentIR): Set<string> {
         p =>
           p.defaultValue === undefined &&
           !p.isRest &&
-          p.type?.kind !== 'primitive',
+          (p.type?.kind !== 'primitive' || p.optional),
       )
       .map(p => p.name),
   )

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -75,6 +75,11 @@ runAdapterConformanceTests({
     // shallow-copy contract.
     'array-flat-dynamic-depth:gen:depth:zero',
     'array-flat-dynamic-depth:gen:depth:negative',
+    // #2266 — asChild=true with plain-text children breaks the Slot
+    // rendering path (same class as the Go Slot define; observed on the
+    // real-Perl CI run).
+    'button:gen:asChild:true',
+    'kbd:gen:asChild:true',
   ]),
   onRenderError: (err, id) => {
     if (err instanceof PerlNotAvailableError) {

--- a/packages/adapter-mojolicious/src/adapter/props/prop-classes.ts
+++ b/packages/adapter-mojolicious/src/adapter/props/prop-classes.ts
@@ -47,11 +47,11 @@ export function collectBooleanTypedProps(ir: ComponentIR): Set<string> {
  * resolved `interface{}` field type; here it is the absence of a default (the
  * analyzer reports `rows` — a `TextareaHTMLAttributes` member destructured
  * without a default — as no-default, `type.kind: 'unknown'`).
- * Excludes concrete-primitive types (`string`/`number`/`boolean`) to match
- * the Go adapter's scope, which guards only `interface{}` (nillable) fields
- * and leaves concrete fields unconditional. So a required, no-default
- * `string` prop still emits `attr=""` like Hono, and only nillable
- * (`unknown`/object/array) no-default props guard.
+ * A REQUIRED concrete-primitive prop (`string`/`number`/`boolean`) is
+ * excluded — the caller always supplies it, so it emits `attr=""` like Hono
+ * — but an OPTIONAL primitive is presence-uncertain and stays guarded
+ * (#2259; pre-#2259 destructured optionals arrived as `unknown` and the
+ * type test alone covered them).
  */
 export function collectNullableOptionalProps(ir: ComponentIR): Set<string> {
   return new Set(
@@ -60,7 +60,7 @@ export function collectNullableOptionalProps(ir: ComponentIR): Set<string> {
         p =>
           p.defaultValue === undefined &&
           !p.isRest &&
-          p.type?.kind !== 'primitive',
+          (p.type?.kind !== 'primitive' || p.optional),
       )
       .map(p => p.name),
   )

--- a/packages/adapter-mojolicious/src/adapter/props/prop-classes.ts
+++ b/packages/adapter-mojolicious/src/adapter/props/prop-classes.ts
@@ -50,8 +50,7 @@ export function collectBooleanTypedProps(ir: ComponentIR): Set<string> {
  * A REQUIRED concrete-primitive prop (`string`/`number`/`boolean`) is
  * excluded — the caller always supplies it, so it emits `attr=""` like Hono
  * — but an OPTIONAL primitive is presence-uncertain and stays guarded
- * (#2259; pre-#2259 destructured optionals arrived as `unknown` and the
- * type test alone covered them).
+ * (#2259).
  */
 export function collectNullableOptionalProps(ir: ComponentIR): Set<string> {
   return new Set(

--- a/packages/adapter-rust/src/adapter/props/prop-classes.ts
+++ b/packages/adapter-rust/src/adapter/props/prop-classes.ts
@@ -24,7 +24,9 @@ export function collectBooleanTypedProps(ir: ComponentIR): Set<string> {
 }
 
 /**
- * Bare references to optional, no-default, non-primitive props (e.g.
+ * Bare references to presence-uncertain no-default props — non-primitive
+ * or declared optional (#2259; pre-#2259 destructured optionals arrived as
+ * `unknown` and the type test alone covered them) — (e.g.
  * textarea's `rows`) are `None` when omitted → guarded with
  * `is defined and is not none` in `emitExpression`. See the
  * `nullableOptionalProps` field docstring in `minijinja-adapter.ts`.
@@ -36,7 +38,7 @@ export function collectNullableOptionalProps(ir: ComponentIR): Set<string> {
         p =>
           p.defaultValue === undefined &&
           !p.isRest &&
-          p.type?.kind !== 'primitive',
+          (p.type?.kind !== 'primitive' || p.optional),
       )
       .map(p => p.name),
   )

--- a/packages/adapter-rust/src/adapter/props/prop-classes.ts
+++ b/packages/adapter-rust/src/adapter/props/prop-classes.ts
@@ -24,10 +24,9 @@ export function collectBooleanTypedProps(ir: ComponentIR): Set<string> {
 }
 
 /**
- * Bare references to presence-uncertain no-default props — non-primitive
- * or declared optional (#2259; pre-#2259 destructured optionals arrived as
- * `unknown` and the type test alone covered them) — (e.g.
- * textarea's `rows`) are `None` when omitted → guarded with
+ * Bare references to presence-uncertain no-default props (non-primitive
+ * typed OR declared optional, #2259 — e.g. textarea's `rows`) are
+ * `None` when omitted → guarded with
  * `is defined and is not none` in `emitExpression`. See the
  * `nullableOptionalProps` field docstring in `minijinja-adapter.ts`.
  */

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -2480,6 +2480,22 @@
         "condition"
       ]
     },
+    "nullish-coalescing-destructured": {
+      "kinds": [
+        "call",
+        "identifier",
+        "literal",
+        "logical"
+      ],
+      "axes": [
+        "literal:number",
+        "literal:string",
+        "logical:??"
+      ],
+      "contexts": [
+        "text"
+      ]
+    },
     "nullish-coalescing-jsx": {
       "kinds": [
         "binary",
@@ -4026,12 +4042,12 @@
     "array-method": 62,
     "arrow": 55,
     "binary": 67,
-    "call": 154,
+    "call": 155,
     "conditional": 18,
-    "identifier": 231,
+    "identifier": 232,
     "index-access": 12,
-    "literal": 193,
-    "logical": 40,
+    "literal": 194,
+    "logical": 41,
     "member": 115,
     "object-literal": 41,
     "template-literal": 27,
@@ -4075,10 +4091,10 @@
     "binary:>=": 1,
     "literal:boolean": 37,
     "literal:null": 22,
-    "literal:number": 84,
-    "literal:string": 137,
+    "literal:number": 85,
+    "literal:string": 138,
     "logical:&&": 7,
-    "logical:??": 36,
+    "logical:??": 37,
     "logical:||": 12,
     "member:computed": 8,
     "member:optional": 1,

--- a/packages/adapter-tests/fixtures/__snapshots__/accordion.accordion.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/accordion.accordion.ssr.tsx
@@ -76,7 +76,7 @@ interface AccordionContentProps extends HTMLBaseAttributes {
 
 export type { AccordionProps, AccordionItemProps, AccordionTriggerProps, AccordionContentProps }
 
-export function Accordion({ children, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: AccordionPropsWithHydration) {
+export function Accordion({ children, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: AccordionPropsWithHydration = {} as AccordionPropsWithHydration) {
   const __scopeId = __instanceId || `Accordion_${Math.random().toString(36).slice(2, 8)}`
   const accordionClasses = 'w-full'
 

--- a/packages/adapter-tests/fixtures/__snapshots__/accordion.icon.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/accordion.icon.ssr.tsx
@@ -512,7 +512,7 @@ type IconPropsWithHydration = { name: IconName } & IconProps & {
   "data-key"?: string | number
 }
 
-export function CheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CheckIconPropsWithHydration) {
+export function CheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CheckIconPropsWithHydration = {} as CheckIconPropsWithHydration) {
   const __scopeId = __instanceId || `CheckIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -556,7 +556,7 @@ export function CheckIcon({ size, className = '', __instanceId, __bfScope: _bfSc
   )
 }
 
-export function ChevronDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronDownIconPropsWithHydration) {
+export function ChevronDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronDownIconPropsWithHydration = {} as ChevronDownIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronDownIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -600,7 +600,7 @@ export function ChevronDownIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function ChevronUpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronUpIconPropsWithHydration) {
+export function ChevronUpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronUpIconPropsWithHydration = {} as ChevronUpIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronUpIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -644,7 +644,7 @@ export function ChevronUpIcon({ size, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function ChevronLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronLeftIconPropsWithHydration) {
+export function ChevronLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronLeftIconPropsWithHydration = {} as ChevronLeftIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronLeftIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -688,7 +688,7 @@ export function ChevronLeftIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function ChevronRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronRightIconPropsWithHydration) {
+export function ChevronRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronRightIconPropsWithHydration = {} as ChevronRightIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronRightIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -732,7 +732,7 @@ export function ChevronRightIcon({ size, className = '', __instanceId, __bfScope
   )
 }
 
-export function XIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: XIconPropsWithHydration) {
+export function XIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: XIconPropsWithHydration = {} as XIconPropsWithHydration) {
   const __scopeId = __instanceId || `XIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -776,7 +776,7 @@ export function XIcon({ size, className = '', __instanceId, __bfScope: _bfScope,
   )
 }
 
-export function PlusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PlusIconPropsWithHydration) {
+export function PlusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PlusIconPropsWithHydration = {} as PlusIconPropsWithHydration) {
   const __scopeId = __instanceId || `PlusIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -820,7 +820,7 @@ export function PlusIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function MinusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MinusIconPropsWithHydration) {
+export function MinusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MinusIconPropsWithHydration = {} as MinusIconPropsWithHydration) {
   const __scopeId = __instanceId || `MinusIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -864,7 +864,7 @@ export function MinusIcon({ size, className = '', __instanceId, __bfScope: _bfSc
   )
 }
 
-export function SunIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SunIconPropsWithHydration) {
+export function SunIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SunIconPropsWithHydration = {} as SunIconPropsWithHydration) {
   const __scopeId = __instanceId || `SunIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -908,7 +908,7 @@ export function SunIcon({ size, className = '', __instanceId, __bfScope: _bfScop
   )
 }
 
-export function MoonIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MoonIconPropsWithHydration) {
+export function MoonIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MoonIconPropsWithHydration = {} as MoonIconPropsWithHydration) {
   const __scopeId = __instanceId || `MoonIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -952,7 +952,7 @@ export function MoonIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function MonitorIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MonitorIconPropsWithHydration) {
+export function MonitorIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MonitorIconPropsWithHydration = {} as MonitorIconPropsWithHydration) {
   const __scopeId = __instanceId || `MonitorIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -996,7 +996,7 @@ export function MonitorIcon({ size, className = '', __instanceId, __bfScope: _bf
   )
 }
 
-export function CopyIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CopyIconPropsWithHydration) {
+export function CopyIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CopyIconPropsWithHydration = {} as CopyIconPropsWithHydration) {
   const __scopeId = __instanceId || `CopyIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1040,7 +1040,7 @@ export function CopyIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function ClipboardIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardIconPropsWithHydration) {
+export function ClipboardIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardIconPropsWithHydration = {} as ClipboardIconPropsWithHydration) {
   const __scopeId = __instanceId || `ClipboardIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1084,7 +1084,7 @@ export function ClipboardIcon({ size, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function ClipboardCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardCheckIconPropsWithHydration) {
+export function ClipboardCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardCheckIconPropsWithHydration = {} as ClipboardCheckIconPropsWithHydration) {
   const __scopeId = __instanceId || `ClipboardCheckIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1128,7 +1128,7 @@ export function ClipboardCheckIcon({ size, className = '', __instanceId, __bfSco
   )
 }
 
-export function MenuIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MenuIconPropsWithHydration) {
+export function MenuIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MenuIconPropsWithHydration = {} as MenuIconPropsWithHydration) {
   const __scopeId = __instanceId || `MenuIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1172,7 +1172,7 @@ export function MenuIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function ArrowLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowLeftIconPropsWithHydration) {
+export function ArrowLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowLeftIconPropsWithHydration = {} as ArrowLeftIconPropsWithHydration) {
   const __scopeId = __instanceId || `ArrowLeftIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1216,7 +1216,7 @@ export function ArrowLeftIcon({ size, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function ArrowRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowRightIconPropsWithHydration) {
+export function ArrowRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowRightIconPropsWithHydration = {} as ArrowRightIconPropsWithHydration) {
   const __scopeId = __instanceId || `ArrowRightIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1260,7 +1260,7 @@ export function ArrowRightIcon({ size, className = '', __instanceId, __bfScope: 
   )
 }
 
-export function ArrowUpDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowUpDownIconPropsWithHydration) {
+export function ArrowUpDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowUpDownIconPropsWithHydration = {} as ArrowUpDownIconPropsWithHydration) {
   const __scopeId = __instanceId || `ArrowUpDownIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1304,7 +1304,7 @@ export function ArrowUpDownIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function EllipsisIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: EllipsisIconPropsWithHydration) {
+export function EllipsisIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: EllipsisIconPropsWithHydration = {} as EllipsisIconPropsWithHydration) {
   const __scopeId = __instanceId || `EllipsisIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1325,7 +1325,7 @@ export function EllipsisIcon({ size, className = '', __instanceId, __bfScope: _b
   )
 }
 
-export function GitHubIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GitHubIconPropsWithHydration) {
+export function GitHubIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GitHubIconPropsWithHydration = {} as GitHubIconPropsWithHydration) {
   const __scopeId = __instanceId || `GitHubIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1346,7 +1346,7 @@ export function GitHubIcon({ size, className = '', __instanceId, __bfScope: _bfS
   )
 }
 
-export function SettingsIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SettingsIconPropsWithHydration) {
+export function SettingsIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SettingsIconPropsWithHydration = {} as SettingsIconPropsWithHydration) {
   const __scopeId = __instanceId || `SettingsIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1367,7 +1367,7 @@ export function SettingsIcon({ size, className = '', __instanceId, __bfScope: _b
   )
 }
 
-export function GlobeIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GlobeIconPropsWithHydration) {
+export function GlobeIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GlobeIconPropsWithHydration = {} as GlobeIconPropsWithHydration) {
   const __scopeId = __instanceId || `GlobeIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1388,7 +1388,7 @@ export function GlobeIcon({ size, className = '', __instanceId, __bfScope: _bfSc
   )
 }
 
-export function LogOutIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LogOutIconPropsWithHydration) {
+export function LogOutIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LogOutIconPropsWithHydration = {} as LogOutIconPropsWithHydration) {
   const __scopeId = __instanceId || `LogOutIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1409,7 +1409,7 @@ export function LogOutIcon({ size, className = '', __instanceId, __bfScope: _bfS
   )
 }
 
-export function CircleHelpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleHelpIconPropsWithHydration) {
+export function CircleHelpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleHelpIconPropsWithHydration = {} as CircleHelpIconPropsWithHydration) {
   const __scopeId = __instanceId || `CircleHelpIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1430,7 +1430,7 @@ export function CircleHelpIcon({ size, className = '', __instanceId, __bfScope: 
   )
 }
 
-export function SearchIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SearchIconPropsWithHydration) {
+export function SearchIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SearchIconPropsWithHydration = {} as SearchIconPropsWithHydration) {
   const __scopeId = __instanceId || `SearchIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1451,7 +1451,7 @@ export function SearchIcon({ size, className = '', __instanceId, __bfScope: _bfS
   )
 }
 
-export function CircleCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleCheckIconPropsWithHydration) {
+export function CircleCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleCheckIconPropsWithHydration = {} as CircleCheckIconPropsWithHydration) {
   const __scopeId = __instanceId || `CircleCheckIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1472,7 +1472,7 @@ export function CircleCheckIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function CircleXIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleXIconPropsWithHydration) {
+export function CircleXIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleXIconPropsWithHydration = {} as CircleXIconPropsWithHydration) {
   const __scopeId = __instanceId || `CircleXIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1493,7 +1493,7 @@ export function CircleXIcon({ size, className = '', __instanceId, __bfScope: _bf
   )
 }
 
-export function TriangleAlertIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TriangleAlertIconPropsWithHydration) {
+export function TriangleAlertIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TriangleAlertIconPropsWithHydration = {} as TriangleAlertIconPropsWithHydration) {
   const __scopeId = __instanceId || `TriangleAlertIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1514,7 +1514,7 @@ export function TriangleAlertIcon({ size, className = '', __instanceId, __bfScop
   )
 }
 
-export function InfoIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: InfoIconPropsWithHydration) {
+export function InfoIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: InfoIconPropsWithHydration = {} as InfoIconPropsWithHydration) {
   const __scopeId = __instanceId || `InfoIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1535,7 +1535,7 @@ export function InfoIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function CalendarIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CalendarIconPropsWithHydration) {
+export function CalendarIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CalendarIconPropsWithHydration = {} as CalendarIconPropsWithHydration) {
   const __scopeId = __instanceId || `CalendarIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1556,7 +1556,7 @@ export function CalendarIcon({ size, className = '', __instanceId, __bfScope: _b
   )
 }
 
-export function GripVerticalIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GripVerticalIconPropsWithHydration) {
+export function GripVerticalIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GripVerticalIconPropsWithHydration = {} as GripVerticalIconPropsWithHydration) {
   const __scopeId = __instanceId || `GripVerticalIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1577,7 +1577,7 @@ export function GripVerticalIcon({ size, className = '', __instanceId, __bfScope
   )
 }
 
-export function LoaderCircleIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LoaderCircleIconPropsWithHydration) {
+export function LoaderCircleIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LoaderCircleIconPropsWithHydration = {} as LoaderCircleIconPropsWithHydration) {
   const __scopeId = __instanceId || `LoaderCircleIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1621,7 +1621,7 @@ export function LoaderCircleIcon({ size, className = '', __instanceId, __bfScope
   )
 }
 
-export function PanelLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PanelLeftIconPropsWithHydration) {
+export function PanelLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PanelLeftIconPropsWithHydration = {} as PanelLeftIconPropsWithHydration) {
   const __scopeId = __instanceId || `PanelLeftIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,

--- a/packages/adapter-tests/fixtures/__snapshots__/button.slot.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/button.slot.ssr.tsx
@@ -22,7 +22,7 @@ type SlotPropsWithHydration = SlotProps & {
 
 export type { SlotProps }
 
-export function Slot({ children, className, __instanceId, __bfScope: _bfScope, __bfChild: _bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": _dataKey, ...props }: SlotPropsWithHydration) {
+export function Slot({ children, className, __instanceId, __bfScope: _bfScope, __bfChild: _bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": _dataKey, ...props }: SlotPropsWithHydration = {} as SlotPropsWithHydration) {
   const __scopeId = __instanceId || `Slot_${Math.random().toString(36).slice(2, 8)}`
   function isValidElement(element: unknown): element is { tag: unknown; props: Record<string, unknown> } {
   return !!(element && typeof element === 'object' && 'tag' in element && 'props' in element)

--- a/packages/adapter-tests/fixtures/__snapshots__/carousel.icon.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/carousel.icon.ssr.tsx
@@ -512,7 +512,7 @@ type IconPropsWithHydration = { name: IconName } & IconProps & {
   "data-key"?: string | number
 }
 
-export function CheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CheckIconPropsWithHydration) {
+export function CheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CheckIconPropsWithHydration = {} as CheckIconPropsWithHydration) {
   const __scopeId = __instanceId || `CheckIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -556,7 +556,7 @@ export function CheckIcon({ size, className = '', __instanceId, __bfScope: _bfSc
   )
 }
 
-export function ChevronDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronDownIconPropsWithHydration) {
+export function ChevronDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronDownIconPropsWithHydration = {} as ChevronDownIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronDownIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -600,7 +600,7 @@ export function ChevronDownIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function ChevronUpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronUpIconPropsWithHydration) {
+export function ChevronUpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronUpIconPropsWithHydration = {} as ChevronUpIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronUpIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -644,7 +644,7 @@ export function ChevronUpIcon({ size, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function ChevronLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronLeftIconPropsWithHydration) {
+export function ChevronLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronLeftIconPropsWithHydration = {} as ChevronLeftIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronLeftIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -688,7 +688,7 @@ export function ChevronLeftIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function ChevronRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronRightIconPropsWithHydration) {
+export function ChevronRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronRightIconPropsWithHydration = {} as ChevronRightIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronRightIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -732,7 +732,7 @@ export function ChevronRightIcon({ size, className = '', __instanceId, __bfScope
   )
 }
 
-export function XIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: XIconPropsWithHydration) {
+export function XIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: XIconPropsWithHydration = {} as XIconPropsWithHydration) {
   const __scopeId = __instanceId || `XIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -776,7 +776,7 @@ export function XIcon({ size, className = '', __instanceId, __bfScope: _bfScope,
   )
 }
 
-export function PlusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PlusIconPropsWithHydration) {
+export function PlusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PlusIconPropsWithHydration = {} as PlusIconPropsWithHydration) {
   const __scopeId = __instanceId || `PlusIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -820,7 +820,7 @@ export function PlusIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function MinusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MinusIconPropsWithHydration) {
+export function MinusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MinusIconPropsWithHydration = {} as MinusIconPropsWithHydration) {
   const __scopeId = __instanceId || `MinusIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -864,7 +864,7 @@ export function MinusIcon({ size, className = '', __instanceId, __bfScope: _bfSc
   )
 }
 
-export function SunIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SunIconPropsWithHydration) {
+export function SunIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SunIconPropsWithHydration = {} as SunIconPropsWithHydration) {
   const __scopeId = __instanceId || `SunIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -908,7 +908,7 @@ export function SunIcon({ size, className = '', __instanceId, __bfScope: _bfScop
   )
 }
 
-export function MoonIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MoonIconPropsWithHydration) {
+export function MoonIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MoonIconPropsWithHydration = {} as MoonIconPropsWithHydration) {
   const __scopeId = __instanceId || `MoonIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -952,7 +952,7 @@ export function MoonIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function MonitorIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MonitorIconPropsWithHydration) {
+export function MonitorIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MonitorIconPropsWithHydration = {} as MonitorIconPropsWithHydration) {
   const __scopeId = __instanceId || `MonitorIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -996,7 +996,7 @@ export function MonitorIcon({ size, className = '', __instanceId, __bfScope: _bf
   )
 }
 
-export function CopyIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CopyIconPropsWithHydration) {
+export function CopyIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CopyIconPropsWithHydration = {} as CopyIconPropsWithHydration) {
   const __scopeId = __instanceId || `CopyIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1040,7 +1040,7 @@ export function CopyIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function ClipboardIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardIconPropsWithHydration) {
+export function ClipboardIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardIconPropsWithHydration = {} as ClipboardIconPropsWithHydration) {
   const __scopeId = __instanceId || `ClipboardIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1084,7 +1084,7 @@ export function ClipboardIcon({ size, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function ClipboardCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardCheckIconPropsWithHydration) {
+export function ClipboardCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardCheckIconPropsWithHydration = {} as ClipboardCheckIconPropsWithHydration) {
   const __scopeId = __instanceId || `ClipboardCheckIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1128,7 +1128,7 @@ export function ClipboardCheckIcon({ size, className = '', __instanceId, __bfSco
   )
 }
 
-export function MenuIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MenuIconPropsWithHydration) {
+export function MenuIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MenuIconPropsWithHydration = {} as MenuIconPropsWithHydration) {
   const __scopeId = __instanceId || `MenuIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1172,7 +1172,7 @@ export function MenuIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function ArrowLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowLeftIconPropsWithHydration) {
+export function ArrowLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowLeftIconPropsWithHydration = {} as ArrowLeftIconPropsWithHydration) {
   const __scopeId = __instanceId || `ArrowLeftIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1216,7 +1216,7 @@ export function ArrowLeftIcon({ size, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function ArrowRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowRightIconPropsWithHydration) {
+export function ArrowRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowRightIconPropsWithHydration = {} as ArrowRightIconPropsWithHydration) {
   const __scopeId = __instanceId || `ArrowRightIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1260,7 +1260,7 @@ export function ArrowRightIcon({ size, className = '', __instanceId, __bfScope: 
   )
 }
 
-export function ArrowUpDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowUpDownIconPropsWithHydration) {
+export function ArrowUpDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowUpDownIconPropsWithHydration = {} as ArrowUpDownIconPropsWithHydration) {
   const __scopeId = __instanceId || `ArrowUpDownIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1304,7 +1304,7 @@ export function ArrowUpDownIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function EllipsisIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: EllipsisIconPropsWithHydration) {
+export function EllipsisIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: EllipsisIconPropsWithHydration = {} as EllipsisIconPropsWithHydration) {
   const __scopeId = __instanceId || `EllipsisIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1325,7 +1325,7 @@ export function EllipsisIcon({ size, className = '', __instanceId, __bfScope: _b
   )
 }
 
-export function GitHubIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GitHubIconPropsWithHydration) {
+export function GitHubIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GitHubIconPropsWithHydration = {} as GitHubIconPropsWithHydration) {
   const __scopeId = __instanceId || `GitHubIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1346,7 +1346,7 @@ export function GitHubIcon({ size, className = '', __instanceId, __bfScope: _bfS
   )
 }
 
-export function SettingsIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SettingsIconPropsWithHydration) {
+export function SettingsIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SettingsIconPropsWithHydration = {} as SettingsIconPropsWithHydration) {
   const __scopeId = __instanceId || `SettingsIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1367,7 +1367,7 @@ export function SettingsIcon({ size, className = '', __instanceId, __bfScope: _b
   )
 }
 
-export function GlobeIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GlobeIconPropsWithHydration) {
+export function GlobeIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GlobeIconPropsWithHydration = {} as GlobeIconPropsWithHydration) {
   const __scopeId = __instanceId || `GlobeIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1388,7 +1388,7 @@ export function GlobeIcon({ size, className = '', __instanceId, __bfScope: _bfSc
   )
 }
 
-export function LogOutIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LogOutIconPropsWithHydration) {
+export function LogOutIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LogOutIconPropsWithHydration = {} as LogOutIconPropsWithHydration) {
   const __scopeId = __instanceId || `LogOutIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1409,7 +1409,7 @@ export function LogOutIcon({ size, className = '', __instanceId, __bfScope: _bfS
   )
 }
 
-export function CircleHelpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleHelpIconPropsWithHydration) {
+export function CircleHelpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleHelpIconPropsWithHydration = {} as CircleHelpIconPropsWithHydration) {
   const __scopeId = __instanceId || `CircleHelpIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1430,7 +1430,7 @@ export function CircleHelpIcon({ size, className = '', __instanceId, __bfScope: 
   )
 }
 
-export function SearchIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SearchIconPropsWithHydration) {
+export function SearchIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SearchIconPropsWithHydration = {} as SearchIconPropsWithHydration) {
   const __scopeId = __instanceId || `SearchIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1451,7 +1451,7 @@ export function SearchIcon({ size, className = '', __instanceId, __bfScope: _bfS
   )
 }
 
-export function CircleCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleCheckIconPropsWithHydration) {
+export function CircleCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleCheckIconPropsWithHydration = {} as CircleCheckIconPropsWithHydration) {
   const __scopeId = __instanceId || `CircleCheckIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1472,7 +1472,7 @@ export function CircleCheckIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function CircleXIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleXIconPropsWithHydration) {
+export function CircleXIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleXIconPropsWithHydration = {} as CircleXIconPropsWithHydration) {
   const __scopeId = __instanceId || `CircleXIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1493,7 +1493,7 @@ export function CircleXIcon({ size, className = '', __instanceId, __bfScope: _bf
   )
 }
 
-export function TriangleAlertIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TriangleAlertIconPropsWithHydration) {
+export function TriangleAlertIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TriangleAlertIconPropsWithHydration = {} as TriangleAlertIconPropsWithHydration) {
   const __scopeId = __instanceId || `TriangleAlertIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1514,7 +1514,7 @@ export function TriangleAlertIcon({ size, className = '', __instanceId, __bfScop
   )
 }
 
-export function InfoIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: InfoIconPropsWithHydration) {
+export function InfoIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: InfoIconPropsWithHydration = {} as InfoIconPropsWithHydration) {
   const __scopeId = __instanceId || `InfoIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1535,7 +1535,7 @@ export function InfoIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function CalendarIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CalendarIconPropsWithHydration) {
+export function CalendarIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CalendarIconPropsWithHydration = {} as CalendarIconPropsWithHydration) {
   const __scopeId = __instanceId || `CalendarIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1556,7 +1556,7 @@ export function CalendarIcon({ size, className = '', __instanceId, __bfScope: _b
   )
 }
 
-export function GripVerticalIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GripVerticalIconPropsWithHydration) {
+export function GripVerticalIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GripVerticalIconPropsWithHydration = {} as GripVerticalIconPropsWithHydration) {
   const __scopeId = __instanceId || `GripVerticalIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1577,7 +1577,7 @@ export function GripVerticalIcon({ size, className = '', __instanceId, __bfScope
   )
 }
 
-export function LoaderCircleIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LoaderCircleIconPropsWithHydration) {
+export function LoaderCircleIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LoaderCircleIconPropsWithHydration = {} as LoaderCircleIconPropsWithHydration) {
   const __scopeId = __instanceId || `LoaderCircleIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1621,7 +1621,7 @@ export function LoaderCircleIcon({ size, className = '', __instanceId, __bfScope
   )
 }
 
-export function PanelLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PanelLeftIconPropsWithHydration) {
+export function PanelLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PanelLeftIconPropsWithHydration = {} as PanelLeftIconPropsWithHydration) {
   const __scopeId = __instanceId || `PanelLeftIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,

--- a/packages/adapter-tests/fixtures/__snapshots__/checkbox.icon.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/checkbox.icon.ssr.tsx
@@ -512,7 +512,7 @@ type IconPropsWithHydration = { name: IconName } & IconProps & {
   "data-key"?: string | number
 }
 
-export function CheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CheckIconPropsWithHydration) {
+export function CheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CheckIconPropsWithHydration = {} as CheckIconPropsWithHydration) {
   const __scopeId = __instanceId || `CheckIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -556,7 +556,7 @@ export function CheckIcon({ size, className = '', __instanceId, __bfScope: _bfSc
   )
 }
 
-export function ChevronDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronDownIconPropsWithHydration) {
+export function ChevronDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronDownIconPropsWithHydration = {} as ChevronDownIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronDownIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -600,7 +600,7 @@ export function ChevronDownIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function ChevronUpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronUpIconPropsWithHydration) {
+export function ChevronUpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronUpIconPropsWithHydration = {} as ChevronUpIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronUpIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -644,7 +644,7 @@ export function ChevronUpIcon({ size, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function ChevronLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronLeftIconPropsWithHydration) {
+export function ChevronLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronLeftIconPropsWithHydration = {} as ChevronLeftIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronLeftIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -688,7 +688,7 @@ export function ChevronLeftIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function ChevronRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronRightIconPropsWithHydration) {
+export function ChevronRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronRightIconPropsWithHydration = {} as ChevronRightIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronRightIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -732,7 +732,7 @@ export function ChevronRightIcon({ size, className = '', __instanceId, __bfScope
   )
 }
 
-export function XIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: XIconPropsWithHydration) {
+export function XIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: XIconPropsWithHydration = {} as XIconPropsWithHydration) {
   const __scopeId = __instanceId || `XIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -776,7 +776,7 @@ export function XIcon({ size, className = '', __instanceId, __bfScope: _bfScope,
   )
 }
 
-export function PlusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PlusIconPropsWithHydration) {
+export function PlusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PlusIconPropsWithHydration = {} as PlusIconPropsWithHydration) {
   const __scopeId = __instanceId || `PlusIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -820,7 +820,7 @@ export function PlusIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function MinusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MinusIconPropsWithHydration) {
+export function MinusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MinusIconPropsWithHydration = {} as MinusIconPropsWithHydration) {
   const __scopeId = __instanceId || `MinusIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -864,7 +864,7 @@ export function MinusIcon({ size, className = '', __instanceId, __bfScope: _bfSc
   )
 }
 
-export function SunIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SunIconPropsWithHydration) {
+export function SunIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SunIconPropsWithHydration = {} as SunIconPropsWithHydration) {
   const __scopeId = __instanceId || `SunIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -908,7 +908,7 @@ export function SunIcon({ size, className = '', __instanceId, __bfScope: _bfScop
   )
 }
 
-export function MoonIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MoonIconPropsWithHydration) {
+export function MoonIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MoonIconPropsWithHydration = {} as MoonIconPropsWithHydration) {
   const __scopeId = __instanceId || `MoonIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -952,7 +952,7 @@ export function MoonIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function MonitorIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MonitorIconPropsWithHydration) {
+export function MonitorIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MonitorIconPropsWithHydration = {} as MonitorIconPropsWithHydration) {
   const __scopeId = __instanceId || `MonitorIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -996,7 +996,7 @@ export function MonitorIcon({ size, className = '', __instanceId, __bfScope: _bf
   )
 }
 
-export function CopyIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CopyIconPropsWithHydration) {
+export function CopyIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CopyIconPropsWithHydration = {} as CopyIconPropsWithHydration) {
   const __scopeId = __instanceId || `CopyIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1040,7 +1040,7 @@ export function CopyIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function ClipboardIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardIconPropsWithHydration) {
+export function ClipboardIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardIconPropsWithHydration = {} as ClipboardIconPropsWithHydration) {
   const __scopeId = __instanceId || `ClipboardIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1084,7 +1084,7 @@ export function ClipboardIcon({ size, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function ClipboardCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardCheckIconPropsWithHydration) {
+export function ClipboardCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardCheckIconPropsWithHydration = {} as ClipboardCheckIconPropsWithHydration) {
   const __scopeId = __instanceId || `ClipboardCheckIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1128,7 +1128,7 @@ export function ClipboardCheckIcon({ size, className = '', __instanceId, __bfSco
   )
 }
 
-export function MenuIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MenuIconPropsWithHydration) {
+export function MenuIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MenuIconPropsWithHydration = {} as MenuIconPropsWithHydration) {
   const __scopeId = __instanceId || `MenuIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1172,7 +1172,7 @@ export function MenuIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function ArrowLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowLeftIconPropsWithHydration) {
+export function ArrowLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowLeftIconPropsWithHydration = {} as ArrowLeftIconPropsWithHydration) {
   const __scopeId = __instanceId || `ArrowLeftIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1216,7 +1216,7 @@ export function ArrowLeftIcon({ size, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function ArrowRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowRightIconPropsWithHydration) {
+export function ArrowRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowRightIconPropsWithHydration = {} as ArrowRightIconPropsWithHydration) {
   const __scopeId = __instanceId || `ArrowRightIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1260,7 +1260,7 @@ export function ArrowRightIcon({ size, className = '', __instanceId, __bfScope: 
   )
 }
 
-export function ArrowUpDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowUpDownIconPropsWithHydration) {
+export function ArrowUpDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowUpDownIconPropsWithHydration = {} as ArrowUpDownIconPropsWithHydration) {
   const __scopeId = __instanceId || `ArrowUpDownIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1304,7 +1304,7 @@ export function ArrowUpDownIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function EllipsisIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: EllipsisIconPropsWithHydration) {
+export function EllipsisIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: EllipsisIconPropsWithHydration = {} as EllipsisIconPropsWithHydration) {
   const __scopeId = __instanceId || `EllipsisIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1325,7 +1325,7 @@ export function EllipsisIcon({ size, className = '', __instanceId, __bfScope: _b
   )
 }
 
-export function GitHubIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GitHubIconPropsWithHydration) {
+export function GitHubIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GitHubIconPropsWithHydration = {} as GitHubIconPropsWithHydration) {
   const __scopeId = __instanceId || `GitHubIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1346,7 +1346,7 @@ export function GitHubIcon({ size, className = '', __instanceId, __bfScope: _bfS
   )
 }
 
-export function SettingsIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SettingsIconPropsWithHydration) {
+export function SettingsIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SettingsIconPropsWithHydration = {} as SettingsIconPropsWithHydration) {
   const __scopeId = __instanceId || `SettingsIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1367,7 +1367,7 @@ export function SettingsIcon({ size, className = '', __instanceId, __bfScope: _b
   )
 }
 
-export function GlobeIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GlobeIconPropsWithHydration) {
+export function GlobeIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GlobeIconPropsWithHydration = {} as GlobeIconPropsWithHydration) {
   const __scopeId = __instanceId || `GlobeIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1388,7 +1388,7 @@ export function GlobeIcon({ size, className = '', __instanceId, __bfScope: _bfSc
   )
 }
 
-export function LogOutIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LogOutIconPropsWithHydration) {
+export function LogOutIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LogOutIconPropsWithHydration = {} as LogOutIconPropsWithHydration) {
   const __scopeId = __instanceId || `LogOutIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1409,7 +1409,7 @@ export function LogOutIcon({ size, className = '', __instanceId, __bfScope: _bfS
   )
 }
 
-export function CircleHelpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleHelpIconPropsWithHydration) {
+export function CircleHelpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleHelpIconPropsWithHydration = {} as CircleHelpIconPropsWithHydration) {
   const __scopeId = __instanceId || `CircleHelpIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1430,7 +1430,7 @@ export function CircleHelpIcon({ size, className = '', __instanceId, __bfScope: 
   )
 }
 
-export function SearchIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SearchIconPropsWithHydration) {
+export function SearchIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SearchIconPropsWithHydration = {} as SearchIconPropsWithHydration) {
   const __scopeId = __instanceId || `SearchIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1451,7 +1451,7 @@ export function SearchIcon({ size, className = '', __instanceId, __bfScope: _bfS
   )
 }
 
-export function CircleCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleCheckIconPropsWithHydration) {
+export function CircleCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleCheckIconPropsWithHydration = {} as CircleCheckIconPropsWithHydration) {
   const __scopeId = __instanceId || `CircleCheckIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1472,7 +1472,7 @@ export function CircleCheckIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function CircleXIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleXIconPropsWithHydration) {
+export function CircleXIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleXIconPropsWithHydration = {} as CircleXIconPropsWithHydration) {
   const __scopeId = __instanceId || `CircleXIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1493,7 +1493,7 @@ export function CircleXIcon({ size, className = '', __instanceId, __bfScope: _bf
   )
 }
 
-export function TriangleAlertIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TriangleAlertIconPropsWithHydration) {
+export function TriangleAlertIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TriangleAlertIconPropsWithHydration = {} as TriangleAlertIconPropsWithHydration) {
   const __scopeId = __instanceId || `TriangleAlertIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1514,7 +1514,7 @@ export function TriangleAlertIcon({ size, className = '', __instanceId, __bfScop
   )
 }
 
-export function InfoIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: InfoIconPropsWithHydration) {
+export function InfoIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: InfoIconPropsWithHydration = {} as InfoIconPropsWithHydration) {
   const __scopeId = __instanceId || `InfoIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1535,7 +1535,7 @@ export function InfoIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function CalendarIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CalendarIconPropsWithHydration) {
+export function CalendarIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CalendarIconPropsWithHydration = {} as CalendarIconPropsWithHydration) {
   const __scopeId = __instanceId || `CalendarIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1556,7 +1556,7 @@ export function CalendarIcon({ size, className = '', __instanceId, __bfScope: _b
   )
 }
 
-export function GripVerticalIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GripVerticalIconPropsWithHydration) {
+export function GripVerticalIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GripVerticalIconPropsWithHydration = {} as GripVerticalIconPropsWithHydration) {
   const __scopeId = __instanceId || `GripVerticalIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1577,7 +1577,7 @@ export function GripVerticalIcon({ size, className = '', __instanceId, __bfScope
   )
 }
 
-export function LoaderCircleIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LoaderCircleIconPropsWithHydration) {
+export function LoaderCircleIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LoaderCircleIconPropsWithHydration = {} as LoaderCircleIconPropsWithHydration) {
   const __scopeId = __instanceId || `LoaderCircleIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1621,7 +1621,7 @@ export function LoaderCircleIcon({ size, className = '', __instanceId, __bfScope
   )
 }
 
-export function PanelLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PanelLeftIconPropsWithHydration) {
+export function PanelLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PanelLeftIconPropsWithHydration = {} as PanelLeftIconPropsWithHydration) {
   const __scopeId = __instanceId || `PanelLeftIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,

--- a/packages/adapter-tests/fixtures/__snapshots__/combobox.icon.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/combobox.icon.ssr.tsx
@@ -512,7 +512,7 @@ type IconPropsWithHydration = { name: IconName } & IconProps & {
   "data-key"?: string | number
 }
 
-export function CheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CheckIconPropsWithHydration) {
+export function CheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CheckIconPropsWithHydration = {} as CheckIconPropsWithHydration) {
   const __scopeId = __instanceId || `CheckIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -556,7 +556,7 @@ export function CheckIcon({ size, className = '', __instanceId, __bfScope: _bfSc
   )
 }
 
-export function ChevronDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronDownIconPropsWithHydration) {
+export function ChevronDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronDownIconPropsWithHydration = {} as ChevronDownIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronDownIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -600,7 +600,7 @@ export function ChevronDownIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function ChevronUpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronUpIconPropsWithHydration) {
+export function ChevronUpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronUpIconPropsWithHydration = {} as ChevronUpIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronUpIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -644,7 +644,7 @@ export function ChevronUpIcon({ size, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function ChevronLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronLeftIconPropsWithHydration) {
+export function ChevronLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronLeftIconPropsWithHydration = {} as ChevronLeftIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronLeftIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -688,7 +688,7 @@ export function ChevronLeftIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function ChevronRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronRightIconPropsWithHydration) {
+export function ChevronRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronRightIconPropsWithHydration = {} as ChevronRightIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronRightIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -732,7 +732,7 @@ export function ChevronRightIcon({ size, className = '', __instanceId, __bfScope
   )
 }
 
-export function XIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: XIconPropsWithHydration) {
+export function XIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: XIconPropsWithHydration = {} as XIconPropsWithHydration) {
   const __scopeId = __instanceId || `XIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -776,7 +776,7 @@ export function XIcon({ size, className = '', __instanceId, __bfScope: _bfScope,
   )
 }
 
-export function PlusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PlusIconPropsWithHydration) {
+export function PlusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PlusIconPropsWithHydration = {} as PlusIconPropsWithHydration) {
   const __scopeId = __instanceId || `PlusIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -820,7 +820,7 @@ export function PlusIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function MinusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MinusIconPropsWithHydration) {
+export function MinusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MinusIconPropsWithHydration = {} as MinusIconPropsWithHydration) {
   const __scopeId = __instanceId || `MinusIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -864,7 +864,7 @@ export function MinusIcon({ size, className = '', __instanceId, __bfScope: _bfSc
   )
 }
 
-export function SunIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SunIconPropsWithHydration) {
+export function SunIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SunIconPropsWithHydration = {} as SunIconPropsWithHydration) {
   const __scopeId = __instanceId || `SunIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -908,7 +908,7 @@ export function SunIcon({ size, className = '', __instanceId, __bfScope: _bfScop
   )
 }
 
-export function MoonIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MoonIconPropsWithHydration) {
+export function MoonIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MoonIconPropsWithHydration = {} as MoonIconPropsWithHydration) {
   const __scopeId = __instanceId || `MoonIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -952,7 +952,7 @@ export function MoonIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function MonitorIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MonitorIconPropsWithHydration) {
+export function MonitorIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MonitorIconPropsWithHydration = {} as MonitorIconPropsWithHydration) {
   const __scopeId = __instanceId || `MonitorIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -996,7 +996,7 @@ export function MonitorIcon({ size, className = '', __instanceId, __bfScope: _bf
   )
 }
 
-export function CopyIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CopyIconPropsWithHydration) {
+export function CopyIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CopyIconPropsWithHydration = {} as CopyIconPropsWithHydration) {
   const __scopeId = __instanceId || `CopyIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1040,7 +1040,7 @@ export function CopyIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function ClipboardIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardIconPropsWithHydration) {
+export function ClipboardIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardIconPropsWithHydration = {} as ClipboardIconPropsWithHydration) {
   const __scopeId = __instanceId || `ClipboardIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1084,7 +1084,7 @@ export function ClipboardIcon({ size, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function ClipboardCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardCheckIconPropsWithHydration) {
+export function ClipboardCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardCheckIconPropsWithHydration = {} as ClipboardCheckIconPropsWithHydration) {
   const __scopeId = __instanceId || `ClipboardCheckIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1128,7 +1128,7 @@ export function ClipboardCheckIcon({ size, className = '', __instanceId, __bfSco
   )
 }
 
-export function MenuIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MenuIconPropsWithHydration) {
+export function MenuIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MenuIconPropsWithHydration = {} as MenuIconPropsWithHydration) {
   const __scopeId = __instanceId || `MenuIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1172,7 +1172,7 @@ export function MenuIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function ArrowLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowLeftIconPropsWithHydration) {
+export function ArrowLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowLeftIconPropsWithHydration = {} as ArrowLeftIconPropsWithHydration) {
   const __scopeId = __instanceId || `ArrowLeftIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1216,7 +1216,7 @@ export function ArrowLeftIcon({ size, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function ArrowRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowRightIconPropsWithHydration) {
+export function ArrowRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowRightIconPropsWithHydration = {} as ArrowRightIconPropsWithHydration) {
   const __scopeId = __instanceId || `ArrowRightIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1260,7 +1260,7 @@ export function ArrowRightIcon({ size, className = '', __instanceId, __bfScope: 
   )
 }
 
-export function ArrowUpDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowUpDownIconPropsWithHydration) {
+export function ArrowUpDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowUpDownIconPropsWithHydration = {} as ArrowUpDownIconPropsWithHydration) {
   const __scopeId = __instanceId || `ArrowUpDownIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1304,7 +1304,7 @@ export function ArrowUpDownIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function EllipsisIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: EllipsisIconPropsWithHydration) {
+export function EllipsisIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: EllipsisIconPropsWithHydration = {} as EllipsisIconPropsWithHydration) {
   const __scopeId = __instanceId || `EllipsisIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1325,7 +1325,7 @@ export function EllipsisIcon({ size, className = '', __instanceId, __bfScope: _b
   )
 }
 
-export function GitHubIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GitHubIconPropsWithHydration) {
+export function GitHubIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GitHubIconPropsWithHydration = {} as GitHubIconPropsWithHydration) {
   const __scopeId = __instanceId || `GitHubIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1346,7 +1346,7 @@ export function GitHubIcon({ size, className = '', __instanceId, __bfScope: _bfS
   )
 }
 
-export function SettingsIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SettingsIconPropsWithHydration) {
+export function SettingsIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SettingsIconPropsWithHydration = {} as SettingsIconPropsWithHydration) {
   const __scopeId = __instanceId || `SettingsIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1367,7 +1367,7 @@ export function SettingsIcon({ size, className = '', __instanceId, __bfScope: _b
   )
 }
 
-export function GlobeIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GlobeIconPropsWithHydration) {
+export function GlobeIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GlobeIconPropsWithHydration = {} as GlobeIconPropsWithHydration) {
   const __scopeId = __instanceId || `GlobeIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1388,7 +1388,7 @@ export function GlobeIcon({ size, className = '', __instanceId, __bfScope: _bfSc
   )
 }
 
-export function LogOutIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LogOutIconPropsWithHydration) {
+export function LogOutIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LogOutIconPropsWithHydration = {} as LogOutIconPropsWithHydration) {
   const __scopeId = __instanceId || `LogOutIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1409,7 +1409,7 @@ export function LogOutIcon({ size, className = '', __instanceId, __bfScope: _bfS
   )
 }
 
-export function CircleHelpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleHelpIconPropsWithHydration) {
+export function CircleHelpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleHelpIconPropsWithHydration = {} as CircleHelpIconPropsWithHydration) {
   const __scopeId = __instanceId || `CircleHelpIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1430,7 +1430,7 @@ export function CircleHelpIcon({ size, className = '', __instanceId, __bfScope: 
   )
 }
 
-export function SearchIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SearchIconPropsWithHydration) {
+export function SearchIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SearchIconPropsWithHydration = {} as SearchIconPropsWithHydration) {
   const __scopeId = __instanceId || `SearchIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1451,7 +1451,7 @@ export function SearchIcon({ size, className = '', __instanceId, __bfScope: _bfS
   )
 }
 
-export function CircleCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleCheckIconPropsWithHydration) {
+export function CircleCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleCheckIconPropsWithHydration = {} as CircleCheckIconPropsWithHydration) {
   const __scopeId = __instanceId || `CircleCheckIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1472,7 +1472,7 @@ export function CircleCheckIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function CircleXIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleXIconPropsWithHydration) {
+export function CircleXIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleXIconPropsWithHydration = {} as CircleXIconPropsWithHydration) {
   const __scopeId = __instanceId || `CircleXIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1493,7 +1493,7 @@ export function CircleXIcon({ size, className = '', __instanceId, __bfScope: _bf
   )
 }
 
-export function TriangleAlertIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TriangleAlertIconPropsWithHydration) {
+export function TriangleAlertIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TriangleAlertIconPropsWithHydration = {} as TriangleAlertIconPropsWithHydration) {
   const __scopeId = __instanceId || `TriangleAlertIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1514,7 +1514,7 @@ export function TriangleAlertIcon({ size, className = '', __instanceId, __bfScop
   )
 }
 
-export function InfoIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: InfoIconPropsWithHydration) {
+export function InfoIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: InfoIconPropsWithHydration = {} as InfoIconPropsWithHydration) {
   const __scopeId = __instanceId || `InfoIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1535,7 +1535,7 @@ export function InfoIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function CalendarIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CalendarIconPropsWithHydration) {
+export function CalendarIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CalendarIconPropsWithHydration = {} as CalendarIconPropsWithHydration) {
   const __scopeId = __instanceId || `CalendarIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1556,7 +1556,7 @@ export function CalendarIcon({ size, className = '', __instanceId, __bfScope: _b
   )
 }
 
-export function GripVerticalIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GripVerticalIconPropsWithHydration) {
+export function GripVerticalIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GripVerticalIconPropsWithHydration = {} as GripVerticalIconPropsWithHydration) {
   const __scopeId = __instanceId || `GripVerticalIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1577,7 +1577,7 @@ export function GripVerticalIcon({ size, className = '', __instanceId, __bfScope
   )
 }
 
-export function LoaderCircleIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LoaderCircleIconPropsWithHydration) {
+export function LoaderCircleIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LoaderCircleIconPropsWithHydration = {} as LoaderCircleIconPropsWithHydration) {
   const __scopeId = __instanceId || `LoaderCircleIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1621,7 +1621,7 @@ export function LoaderCircleIcon({ size, className = '', __instanceId, __bfScope
   )
 }
 
-export function PanelLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PanelLeftIconPropsWithHydration) {
+export function PanelLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PanelLeftIconPropsWithHydration = {} as PanelLeftIconPropsWithHydration) {
   const __scopeId = __instanceId || `PanelLeftIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,

--- a/packages/adapter-tests/fixtures/__snapshots__/command.button.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/command.button.ssr.tsx
@@ -40,7 +40,7 @@ type ButtonPropsWithHydration = ButtonProps & {
 
 export type { ButtonVariant, ButtonSize, ButtonProps }
 
-export function Button({ className = '', variant = 'default', size = 'default', asChild = false, children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ButtonPropsWithHydration) {
+export function Button({ className = '', variant = 'default', size = 'default', asChild = false, children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ButtonPropsWithHydration = {} as ButtonPropsWithHydration) {
   const __scopeId = __instanceId || `Button_${Math.random().toString(36).slice(2, 8)}`
 
   // Serialize props for client hydration

--- a/packages/adapter-tests/fixtures/__snapshots__/command.command.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/command.command.ssr.tsx
@@ -320,7 +320,7 @@ export function CommandInput(__allProps: CommandInputProps & { __instanceId?: st
   )
 }
 
-export function CommandList({ className = '', children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CommandListPropsWithHydration) {
+export function CommandList({ className = '', children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CommandListPropsWithHydration = {} as CommandListPropsWithHydration) {
   const __scopeId = __instanceId || `CommandList_${Math.random().toString(36).slice(2, 8)}`
   const commandListClasses = 'max-h-[300px] overflow-y-auto overflow-x-hidden'
 
@@ -399,7 +399,7 @@ export function CommandSeparator({ className = '', __instanceId, __bfScope: _bfS
   )
 }
 
-export function CommandShortcut({ className = '', children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CommandShortcutPropsWithHydration) {
+export function CommandShortcut({ className = '', children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CommandShortcutPropsWithHydration = {} as CommandShortcutPropsWithHydration) {
   const __scopeId = __instanceId || `CommandShortcut_${Math.random().toString(36).slice(2, 8)}`
   const commandShortcutClasses = 'ml-auto text-xs tracking-widest text-muted-foreground'
 

--- a/packages/adapter-tests/fixtures/__snapshots__/command.dialog.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/command.dialog.ssr.tsx
@@ -427,7 +427,7 @@ export function DialogContent(__allProps: DialogContentProps & { __instanceId?: 
   )
 }
 
-export function DialogHeader({ className = '', children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: DialogHeaderPropsWithHydration) {
+export function DialogHeader({ className = '', children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: DialogHeaderPropsWithHydration = {} as DialogHeaderPropsWithHydration) {
   const __scopeId = __instanceId || `DialogHeader_${Math.random().toString(36).slice(2, 8)}`
   const dialogHeaderClasses = 'flex flex-col gap-2 text-center sm:text-left'
 
@@ -442,7 +442,7 @@ export function DialogHeader({ className = '', children, __instanceId, __bfScope
   )
 }
 
-export function DialogTitle({ className = '', id, children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: DialogTitlePropsWithHydration) {
+export function DialogTitle({ className = '', id, children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: DialogTitlePropsWithHydration = {} as DialogTitlePropsWithHydration) {
   const __scopeId = __instanceId || `DialogTitle_${Math.random().toString(36).slice(2, 8)}`
   const dialogTitleClasses = 'text-lg leading-none font-semibold'
 
@@ -458,7 +458,7 @@ export function DialogTitle({ className = '', id, children, __instanceId, __bfSc
   )
 }
 
-export function DialogDescription({ className = '', id, children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: DialogDescriptionPropsWithHydration) {
+export function DialogDescription({ className = '', id, children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: DialogDescriptionPropsWithHydration = {} as DialogDescriptionPropsWithHydration) {
   const __scopeId = __instanceId || `DialogDescription_${Math.random().toString(36).slice(2, 8)}`
   const dialogDescriptionClasses = 'text-muted-foreground text-sm'
 
@@ -474,7 +474,7 @@ export function DialogDescription({ className = '', id, children, __instanceId, 
   )
 }
 
-export function DialogFooter({ className = '', children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: DialogFooterPropsWithHydration) {
+export function DialogFooter({ className = '', children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: DialogFooterPropsWithHydration = {} as DialogFooterPropsWithHydration) {
   const __scopeId = __instanceId || `DialogFooter_${Math.random().toString(36).slice(2, 8)}`
   const dialogFooterClasses = 'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end'
 

--- a/packages/adapter-tests/fixtures/__snapshots__/command.icon.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/command.icon.ssr.tsx
@@ -512,7 +512,7 @@ type IconPropsWithHydration = { name: IconName } & IconProps & {
   "data-key"?: string | number
 }
 
-export function CheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CheckIconPropsWithHydration) {
+export function CheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CheckIconPropsWithHydration = {} as CheckIconPropsWithHydration) {
   const __scopeId = __instanceId || `CheckIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -556,7 +556,7 @@ export function CheckIcon({ size, className = '', __instanceId, __bfScope: _bfSc
   )
 }
 
-export function ChevronDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronDownIconPropsWithHydration) {
+export function ChevronDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronDownIconPropsWithHydration = {} as ChevronDownIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronDownIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -600,7 +600,7 @@ export function ChevronDownIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function ChevronUpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronUpIconPropsWithHydration) {
+export function ChevronUpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronUpIconPropsWithHydration = {} as ChevronUpIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronUpIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -644,7 +644,7 @@ export function ChevronUpIcon({ size, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function ChevronLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronLeftIconPropsWithHydration) {
+export function ChevronLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronLeftIconPropsWithHydration = {} as ChevronLeftIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronLeftIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -688,7 +688,7 @@ export function ChevronLeftIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function ChevronRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronRightIconPropsWithHydration) {
+export function ChevronRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronRightIconPropsWithHydration = {} as ChevronRightIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronRightIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -732,7 +732,7 @@ export function ChevronRightIcon({ size, className = '', __instanceId, __bfScope
   )
 }
 
-export function XIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: XIconPropsWithHydration) {
+export function XIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: XIconPropsWithHydration = {} as XIconPropsWithHydration) {
   const __scopeId = __instanceId || `XIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -776,7 +776,7 @@ export function XIcon({ size, className = '', __instanceId, __bfScope: _bfScope,
   )
 }
 
-export function PlusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PlusIconPropsWithHydration) {
+export function PlusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PlusIconPropsWithHydration = {} as PlusIconPropsWithHydration) {
   const __scopeId = __instanceId || `PlusIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -820,7 +820,7 @@ export function PlusIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function MinusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MinusIconPropsWithHydration) {
+export function MinusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MinusIconPropsWithHydration = {} as MinusIconPropsWithHydration) {
   const __scopeId = __instanceId || `MinusIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -864,7 +864,7 @@ export function MinusIcon({ size, className = '', __instanceId, __bfScope: _bfSc
   )
 }
 
-export function SunIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SunIconPropsWithHydration) {
+export function SunIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SunIconPropsWithHydration = {} as SunIconPropsWithHydration) {
   const __scopeId = __instanceId || `SunIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -908,7 +908,7 @@ export function SunIcon({ size, className = '', __instanceId, __bfScope: _bfScop
   )
 }
 
-export function MoonIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MoonIconPropsWithHydration) {
+export function MoonIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MoonIconPropsWithHydration = {} as MoonIconPropsWithHydration) {
   const __scopeId = __instanceId || `MoonIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -952,7 +952,7 @@ export function MoonIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function MonitorIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MonitorIconPropsWithHydration) {
+export function MonitorIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MonitorIconPropsWithHydration = {} as MonitorIconPropsWithHydration) {
   const __scopeId = __instanceId || `MonitorIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -996,7 +996,7 @@ export function MonitorIcon({ size, className = '', __instanceId, __bfScope: _bf
   )
 }
 
-export function CopyIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CopyIconPropsWithHydration) {
+export function CopyIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CopyIconPropsWithHydration = {} as CopyIconPropsWithHydration) {
   const __scopeId = __instanceId || `CopyIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1040,7 +1040,7 @@ export function CopyIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function ClipboardIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardIconPropsWithHydration) {
+export function ClipboardIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardIconPropsWithHydration = {} as ClipboardIconPropsWithHydration) {
   const __scopeId = __instanceId || `ClipboardIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1084,7 +1084,7 @@ export function ClipboardIcon({ size, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function ClipboardCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardCheckIconPropsWithHydration) {
+export function ClipboardCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardCheckIconPropsWithHydration = {} as ClipboardCheckIconPropsWithHydration) {
   const __scopeId = __instanceId || `ClipboardCheckIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1128,7 +1128,7 @@ export function ClipboardCheckIcon({ size, className = '', __instanceId, __bfSco
   )
 }
 
-export function MenuIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MenuIconPropsWithHydration) {
+export function MenuIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MenuIconPropsWithHydration = {} as MenuIconPropsWithHydration) {
   const __scopeId = __instanceId || `MenuIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1172,7 +1172,7 @@ export function MenuIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function ArrowLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowLeftIconPropsWithHydration) {
+export function ArrowLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowLeftIconPropsWithHydration = {} as ArrowLeftIconPropsWithHydration) {
   const __scopeId = __instanceId || `ArrowLeftIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1216,7 +1216,7 @@ export function ArrowLeftIcon({ size, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function ArrowRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowRightIconPropsWithHydration) {
+export function ArrowRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowRightIconPropsWithHydration = {} as ArrowRightIconPropsWithHydration) {
   const __scopeId = __instanceId || `ArrowRightIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1260,7 +1260,7 @@ export function ArrowRightIcon({ size, className = '', __instanceId, __bfScope: 
   )
 }
 
-export function ArrowUpDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowUpDownIconPropsWithHydration) {
+export function ArrowUpDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowUpDownIconPropsWithHydration = {} as ArrowUpDownIconPropsWithHydration) {
   const __scopeId = __instanceId || `ArrowUpDownIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1304,7 +1304,7 @@ export function ArrowUpDownIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function EllipsisIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: EllipsisIconPropsWithHydration) {
+export function EllipsisIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: EllipsisIconPropsWithHydration = {} as EllipsisIconPropsWithHydration) {
   const __scopeId = __instanceId || `EllipsisIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1325,7 +1325,7 @@ export function EllipsisIcon({ size, className = '', __instanceId, __bfScope: _b
   )
 }
 
-export function GitHubIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GitHubIconPropsWithHydration) {
+export function GitHubIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GitHubIconPropsWithHydration = {} as GitHubIconPropsWithHydration) {
   const __scopeId = __instanceId || `GitHubIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1346,7 +1346,7 @@ export function GitHubIcon({ size, className = '', __instanceId, __bfScope: _bfS
   )
 }
 
-export function SettingsIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SettingsIconPropsWithHydration) {
+export function SettingsIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SettingsIconPropsWithHydration = {} as SettingsIconPropsWithHydration) {
   const __scopeId = __instanceId || `SettingsIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1367,7 +1367,7 @@ export function SettingsIcon({ size, className = '', __instanceId, __bfScope: _b
   )
 }
 
-export function GlobeIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GlobeIconPropsWithHydration) {
+export function GlobeIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GlobeIconPropsWithHydration = {} as GlobeIconPropsWithHydration) {
   const __scopeId = __instanceId || `GlobeIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1388,7 +1388,7 @@ export function GlobeIcon({ size, className = '', __instanceId, __bfScope: _bfSc
   )
 }
 
-export function LogOutIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LogOutIconPropsWithHydration) {
+export function LogOutIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LogOutIconPropsWithHydration = {} as LogOutIconPropsWithHydration) {
   const __scopeId = __instanceId || `LogOutIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1409,7 +1409,7 @@ export function LogOutIcon({ size, className = '', __instanceId, __bfScope: _bfS
   )
 }
 
-export function CircleHelpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleHelpIconPropsWithHydration) {
+export function CircleHelpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleHelpIconPropsWithHydration = {} as CircleHelpIconPropsWithHydration) {
   const __scopeId = __instanceId || `CircleHelpIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1430,7 +1430,7 @@ export function CircleHelpIcon({ size, className = '', __instanceId, __bfScope: 
   )
 }
 
-export function SearchIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SearchIconPropsWithHydration) {
+export function SearchIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SearchIconPropsWithHydration = {} as SearchIconPropsWithHydration) {
   const __scopeId = __instanceId || `SearchIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1451,7 +1451,7 @@ export function SearchIcon({ size, className = '', __instanceId, __bfScope: _bfS
   )
 }
 
-export function CircleCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleCheckIconPropsWithHydration) {
+export function CircleCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleCheckIconPropsWithHydration = {} as CircleCheckIconPropsWithHydration) {
   const __scopeId = __instanceId || `CircleCheckIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1472,7 +1472,7 @@ export function CircleCheckIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function CircleXIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleXIconPropsWithHydration) {
+export function CircleXIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleXIconPropsWithHydration = {} as CircleXIconPropsWithHydration) {
   const __scopeId = __instanceId || `CircleXIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1493,7 +1493,7 @@ export function CircleXIcon({ size, className = '', __instanceId, __bfScope: _bf
   )
 }
 
-export function TriangleAlertIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TriangleAlertIconPropsWithHydration) {
+export function TriangleAlertIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TriangleAlertIconPropsWithHydration = {} as TriangleAlertIconPropsWithHydration) {
   const __scopeId = __instanceId || `TriangleAlertIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1514,7 +1514,7 @@ export function TriangleAlertIcon({ size, className = '', __instanceId, __bfScop
   )
 }
 
-export function InfoIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: InfoIconPropsWithHydration) {
+export function InfoIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: InfoIconPropsWithHydration = {} as InfoIconPropsWithHydration) {
   const __scopeId = __instanceId || `InfoIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1535,7 +1535,7 @@ export function InfoIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function CalendarIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CalendarIconPropsWithHydration) {
+export function CalendarIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CalendarIconPropsWithHydration = {} as CalendarIconPropsWithHydration) {
   const __scopeId = __instanceId || `CalendarIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1556,7 +1556,7 @@ export function CalendarIcon({ size, className = '', __instanceId, __bfScope: _b
   )
 }
 
-export function GripVerticalIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GripVerticalIconPropsWithHydration) {
+export function GripVerticalIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GripVerticalIconPropsWithHydration = {} as GripVerticalIconPropsWithHydration) {
   const __scopeId = __instanceId || `GripVerticalIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1577,7 +1577,7 @@ export function GripVerticalIcon({ size, className = '', __instanceId, __bfScope
   )
 }
 
-export function LoaderCircleIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LoaderCircleIconPropsWithHydration) {
+export function LoaderCircleIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LoaderCircleIconPropsWithHydration = {} as LoaderCircleIconPropsWithHydration) {
   const __scopeId = __instanceId || `LoaderCircleIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1621,7 +1621,7 @@ export function LoaderCircleIcon({ size, className = '', __instanceId, __bfScope
   )
 }
 
-export function PanelLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PanelLeftIconPropsWithHydration) {
+export function PanelLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PanelLeftIconPropsWithHydration = {} as PanelLeftIconPropsWithHydration) {
   const __scopeId = __instanceId || `PanelLeftIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,

--- a/packages/adapter-tests/fixtures/__snapshots__/command.kbd.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/command.kbd.ssr.tsx
@@ -73,7 +73,7 @@ type KbdGroupPropsWithHydration = KbdGroupProps & {
 
 export type { KbdProps, KbdGroupProps }
 
-export function Kbd({ className = '', asChild = false, children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: KbdPropsWithHydration) {
+export function Kbd({ className = '', asChild = false, children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: KbdPropsWithHydration = {} as KbdPropsWithHydration) {
   const __scopeId = __instanceId || `Kbd_${Math.random().toString(36).slice(2, 8)}`
 
   // Serialize props for client hydration
@@ -93,7 +93,7 @@ export function Kbd({ className = '', asChild = false, children, __instanceId, _
   )
 }
 
-export function KbdGroup({ className = '', asChild = false, children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: KbdGroupPropsWithHydration) {
+export function KbdGroup({ className = '', asChild = false, children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: KbdGroupPropsWithHydration = {} as KbdGroupPropsWithHydration) {
   const __scopeId = __instanceId || `KbdGroup_${Math.random().toString(36).slice(2, 8)}`
 
   // Serialize props for client hydration

--- a/packages/adapter-tests/fixtures/__snapshots__/command.slot.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/command.slot.ssr.tsx
@@ -22,7 +22,7 @@ type SlotPropsWithHydration = SlotProps & {
 
 export type { SlotProps }
 
-export function Slot({ children, className, __instanceId, __bfScope: _bfScope, __bfChild: _bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": _dataKey, ...props }: SlotPropsWithHydration) {
+export function Slot({ children, className, __instanceId, __bfScope: _bfScope, __bfChild: _bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": _dataKey, ...props }: SlotPropsWithHydration = {} as SlotPropsWithHydration) {
   const __scopeId = __instanceId || `Slot_${Math.random().toString(36).slice(2, 8)}`
   function isValidElement(element: unknown): element is { tag: unknown; props: Record<string, unknown> } {
   return !!(element && typeof element === 'object' && 'tag' in element && 'props' in element)

--- a/packages/adapter-tests/fixtures/__snapshots__/data-table.icon.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/data-table.icon.ssr.tsx
@@ -512,7 +512,7 @@ type IconPropsWithHydration = { name: IconName } & IconProps & {
   "data-key"?: string | number
 }
 
-export function CheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CheckIconPropsWithHydration) {
+export function CheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CheckIconPropsWithHydration = {} as CheckIconPropsWithHydration) {
   const __scopeId = __instanceId || `CheckIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -556,7 +556,7 @@ export function CheckIcon({ size, className = '', __instanceId, __bfScope: _bfSc
   )
 }
 
-export function ChevronDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronDownIconPropsWithHydration) {
+export function ChevronDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronDownIconPropsWithHydration = {} as ChevronDownIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronDownIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -600,7 +600,7 @@ export function ChevronDownIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function ChevronUpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronUpIconPropsWithHydration) {
+export function ChevronUpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronUpIconPropsWithHydration = {} as ChevronUpIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronUpIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -644,7 +644,7 @@ export function ChevronUpIcon({ size, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function ChevronLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronLeftIconPropsWithHydration) {
+export function ChevronLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronLeftIconPropsWithHydration = {} as ChevronLeftIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronLeftIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -688,7 +688,7 @@ export function ChevronLeftIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function ChevronRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronRightIconPropsWithHydration) {
+export function ChevronRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronRightIconPropsWithHydration = {} as ChevronRightIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronRightIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -732,7 +732,7 @@ export function ChevronRightIcon({ size, className = '', __instanceId, __bfScope
   )
 }
 
-export function XIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: XIconPropsWithHydration) {
+export function XIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: XIconPropsWithHydration = {} as XIconPropsWithHydration) {
   const __scopeId = __instanceId || `XIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -776,7 +776,7 @@ export function XIcon({ size, className = '', __instanceId, __bfScope: _bfScope,
   )
 }
 
-export function PlusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PlusIconPropsWithHydration) {
+export function PlusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PlusIconPropsWithHydration = {} as PlusIconPropsWithHydration) {
   const __scopeId = __instanceId || `PlusIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -820,7 +820,7 @@ export function PlusIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function MinusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MinusIconPropsWithHydration) {
+export function MinusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MinusIconPropsWithHydration = {} as MinusIconPropsWithHydration) {
   const __scopeId = __instanceId || `MinusIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -864,7 +864,7 @@ export function MinusIcon({ size, className = '', __instanceId, __bfScope: _bfSc
   )
 }
 
-export function SunIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SunIconPropsWithHydration) {
+export function SunIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SunIconPropsWithHydration = {} as SunIconPropsWithHydration) {
   const __scopeId = __instanceId || `SunIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -908,7 +908,7 @@ export function SunIcon({ size, className = '', __instanceId, __bfScope: _bfScop
   )
 }
 
-export function MoonIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MoonIconPropsWithHydration) {
+export function MoonIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MoonIconPropsWithHydration = {} as MoonIconPropsWithHydration) {
   const __scopeId = __instanceId || `MoonIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -952,7 +952,7 @@ export function MoonIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function MonitorIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MonitorIconPropsWithHydration) {
+export function MonitorIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MonitorIconPropsWithHydration = {} as MonitorIconPropsWithHydration) {
   const __scopeId = __instanceId || `MonitorIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -996,7 +996,7 @@ export function MonitorIcon({ size, className = '', __instanceId, __bfScope: _bf
   )
 }
 
-export function CopyIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CopyIconPropsWithHydration) {
+export function CopyIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CopyIconPropsWithHydration = {} as CopyIconPropsWithHydration) {
   const __scopeId = __instanceId || `CopyIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1040,7 +1040,7 @@ export function CopyIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function ClipboardIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardIconPropsWithHydration) {
+export function ClipboardIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardIconPropsWithHydration = {} as ClipboardIconPropsWithHydration) {
   const __scopeId = __instanceId || `ClipboardIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1084,7 +1084,7 @@ export function ClipboardIcon({ size, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function ClipboardCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardCheckIconPropsWithHydration) {
+export function ClipboardCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardCheckIconPropsWithHydration = {} as ClipboardCheckIconPropsWithHydration) {
   const __scopeId = __instanceId || `ClipboardCheckIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1128,7 +1128,7 @@ export function ClipboardCheckIcon({ size, className = '', __instanceId, __bfSco
   )
 }
 
-export function MenuIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MenuIconPropsWithHydration) {
+export function MenuIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MenuIconPropsWithHydration = {} as MenuIconPropsWithHydration) {
   const __scopeId = __instanceId || `MenuIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1172,7 +1172,7 @@ export function MenuIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function ArrowLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowLeftIconPropsWithHydration) {
+export function ArrowLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowLeftIconPropsWithHydration = {} as ArrowLeftIconPropsWithHydration) {
   const __scopeId = __instanceId || `ArrowLeftIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1216,7 +1216,7 @@ export function ArrowLeftIcon({ size, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function ArrowRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowRightIconPropsWithHydration) {
+export function ArrowRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowRightIconPropsWithHydration = {} as ArrowRightIconPropsWithHydration) {
   const __scopeId = __instanceId || `ArrowRightIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1260,7 +1260,7 @@ export function ArrowRightIcon({ size, className = '', __instanceId, __bfScope: 
   )
 }
 
-export function ArrowUpDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowUpDownIconPropsWithHydration) {
+export function ArrowUpDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowUpDownIconPropsWithHydration = {} as ArrowUpDownIconPropsWithHydration) {
   const __scopeId = __instanceId || `ArrowUpDownIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1304,7 +1304,7 @@ export function ArrowUpDownIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function EllipsisIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: EllipsisIconPropsWithHydration) {
+export function EllipsisIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: EllipsisIconPropsWithHydration = {} as EllipsisIconPropsWithHydration) {
   const __scopeId = __instanceId || `EllipsisIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1325,7 +1325,7 @@ export function EllipsisIcon({ size, className = '', __instanceId, __bfScope: _b
   )
 }
 
-export function GitHubIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GitHubIconPropsWithHydration) {
+export function GitHubIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GitHubIconPropsWithHydration = {} as GitHubIconPropsWithHydration) {
   const __scopeId = __instanceId || `GitHubIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1346,7 +1346,7 @@ export function GitHubIcon({ size, className = '', __instanceId, __bfScope: _bfS
   )
 }
 
-export function SettingsIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SettingsIconPropsWithHydration) {
+export function SettingsIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SettingsIconPropsWithHydration = {} as SettingsIconPropsWithHydration) {
   const __scopeId = __instanceId || `SettingsIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1367,7 +1367,7 @@ export function SettingsIcon({ size, className = '', __instanceId, __bfScope: _b
   )
 }
 
-export function GlobeIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GlobeIconPropsWithHydration) {
+export function GlobeIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GlobeIconPropsWithHydration = {} as GlobeIconPropsWithHydration) {
   const __scopeId = __instanceId || `GlobeIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1388,7 +1388,7 @@ export function GlobeIcon({ size, className = '', __instanceId, __bfScope: _bfSc
   )
 }
 
-export function LogOutIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LogOutIconPropsWithHydration) {
+export function LogOutIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LogOutIconPropsWithHydration = {} as LogOutIconPropsWithHydration) {
   const __scopeId = __instanceId || `LogOutIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1409,7 +1409,7 @@ export function LogOutIcon({ size, className = '', __instanceId, __bfScope: _bfS
   )
 }
 
-export function CircleHelpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleHelpIconPropsWithHydration) {
+export function CircleHelpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleHelpIconPropsWithHydration = {} as CircleHelpIconPropsWithHydration) {
   const __scopeId = __instanceId || `CircleHelpIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1430,7 +1430,7 @@ export function CircleHelpIcon({ size, className = '', __instanceId, __bfScope: 
   )
 }
 
-export function SearchIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SearchIconPropsWithHydration) {
+export function SearchIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SearchIconPropsWithHydration = {} as SearchIconPropsWithHydration) {
   const __scopeId = __instanceId || `SearchIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1451,7 +1451,7 @@ export function SearchIcon({ size, className = '', __instanceId, __bfScope: _bfS
   )
 }
 
-export function CircleCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleCheckIconPropsWithHydration) {
+export function CircleCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleCheckIconPropsWithHydration = {} as CircleCheckIconPropsWithHydration) {
   const __scopeId = __instanceId || `CircleCheckIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1472,7 +1472,7 @@ export function CircleCheckIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function CircleXIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleXIconPropsWithHydration) {
+export function CircleXIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleXIconPropsWithHydration = {} as CircleXIconPropsWithHydration) {
   const __scopeId = __instanceId || `CircleXIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1493,7 +1493,7 @@ export function CircleXIcon({ size, className = '', __instanceId, __bfScope: _bf
   )
 }
 
-export function TriangleAlertIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TriangleAlertIconPropsWithHydration) {
+export function TriangleAlertIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TriangleAlertIconPropsWithHydration = {} as TriangleAlertIconPropsWithHydration) {
   const __scopeId = __instanceId || `TriangleAlertIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1514,7 +1514,7 @@ export function TriangleAlertIcon({ size, className = '', __instanceId, __bfScop
   )
 }
 
-export function InfoIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: InfoIconPropsWithHydration) {
+export function InfoIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: InfoIconPropsWithHydration = {} as InfoIconPropsWithHydration) {
   const __scopeId = __instanceId || `InfoIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1535,7 +1535,7 @@ export function InfoIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function CalendarIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CalendarIconPropsWithHydration) {
+export function CalendarIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CalendarIconPropsWithHydration = {} as CalendarIconPropsWithHydration) {
   const __scopeId = __instanceId || `CalendarIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1556,7 +1556,7 @@ export function CalendarIcon({ size, className = '', __instanceId, __bfScope: _b
   )
 }
 
-export function GripVerticalIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GripVerticalIconPropsWithHydration) {
+export function GripVerticalIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GripVerticalIconPropsWithHydration = {} as GripVerticalIconPropsWithHydration) {
   const __scopeId = __instanceId || `GripVerticalIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1577,7 +1577,7 @@ export function GripVerticalIcon({ size, className = '', __instanceId, __bfScope
   )
 }
 
-export function LoaderCircleIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LoaderCircleIconPropsWithHydration) {
+export function LoaderCircleIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LoaderCircleIconPropsWithHydration = {} as LoaderCircleIconPropsWithHydration) {
   const __scopeId = __instanceId || `LoaderCircleIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1621,7 +1621,7 @@ export function LoaderCircleIcon({ size, className = '', __instanceId, __bfScope
   )
 }
 
-export function PanelLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PanelLeftIconPropsWithHydration) {
+export function PanelLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PanelLeftIconPropsWithHydration = {} as PanelLeftIconPropsWithHydration) {
   const __scopeId = __instanceId || `PanelLeftIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,

--- a/packages/adapter-tests/fixtures/__snapshots__/data-table.table.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/data-table.table.ssr.tsx
@@ -428,7 +428,7 @@ type TableCaptionPropsWithHydration = TableCaptionProps & {
 
 export type { TableProps, TableHeaderProps, TableBodyProps, TableFooterProps, TableRowProps, TableHeadProps, TableCellProps, TableCaptionProps }
 
-export function Table({ children, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TablePropsWithHydration) {
+export function Table({ children, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TablePropsWithHydration = {} as TablePropsWithHydration) {
   const __scopeId = __instanceId || `Table_${Math.random().toString(36).slice(2, 8)}`
   const tableClasses = 'w-full caption-bottom border-collapse text-sm'
 
@@ -443,7 +443,7 @@ export function Table({ children, className = '', __instanceId, __bfScope: _bfSc
   )
 }
 
-export function TableHeader({ children, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TableHeaderPropsWithHydration) {
+export function TableHeader({ children, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TableHeaderPropsWithHydration = {} as TableHeaderPropsWithHydration) {
   const __scopeId = __instanceId || `TableHeader_${Math.random().toString(36).slice(2, 8)}`
   const tableHeaderClasses = '[&_tr]:border-b'
 
@@ -458,7 +458,7 @@ export function TableHeader({ children, className = '', __instanceId, __bfScope:
   )
 }
 
-export function TableBody({ children, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TableBodyPropsWithHydration) {
+export function TableBody({ children, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TableBodyPropsWithHydration = {} as TableBodyPropsWithHydration) {
   const __scopeId = __instanceId || `TableBody_${Math.random().toString(36).slice(2, 8)}`
   const tableBodyClasses = '[&_tr:last-child]:border-0'
 
@@ -473,7 +473,7 @@ export function TableBody({ children, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function TableFooter({ children, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TableFooterPropsWithHydration) {
+export function TableFooter({ children, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TableFooterPropsWithHydration = {} as TableFooterPropsWithHydration) {
   const __scopeId = __instanceId || `TableFooter_${Math.random().toString(36).slice(2, 8)}`
   const tableFooterClasses = 'bg-muted/50 border-t font-medium [&>tr]:last:border-b-0'
 
@@ -488,7 +488,7 @@ export function TableFooter({ children, className = '', __instanceId, __bfScope:
   )
 }
 
-export function TableRow({ children, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TableRowPropsWithHydration) {
+export function TableRow({ children, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TableRowPropsWithHydration = {} as TableRowPropsWithHydration) {
   const __scopeId = __instanceId || `TableRow_${Math.random().toString(36).slice(2, 8)}`
   const tableRowClasses = 'hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors'
 
@@ -503,7 +503,7 @@ export function TableRow({ children, className = '', __instanceId, __bfScope: _b
   )
 }
 
-export function TableHead({ children, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TableHeadPropsWithHydration) {
+export function TableHead({ children, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TableHeadPropsWithHydration = {} as TableHeadPropsWithHydration) {
   const __scopeId = __instanceId || `TableHead_${Math.random().toString(36).slice(2, 8)}`
   const tableHeadClasses = 'text-foreground h-10 px-2 text-left align-middle font-medium [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]'
 
@@ -518,7 +518,7 @@ export function TableHead({ children, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function TableCell({ children, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TableCellPropsWithHydration) {
+export function TableCell({ children, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TableCellPropsWithHydration = {} as TableCellPropsWithHydration) {
   const __scopeId = __instanceId || `TableCell_${Math.random().toString(36).slice(2, 8)}`
   const tableCellClasses = 'p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]'
 
@@ -533,7 +533,7 @@ export function TableCell({ children, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function TableCaption({ children, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TableCaptionPropsWithHydration) {
+export function TableCaption({ children, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TableCaptionPropsWithHydration = {} as TableCaptionPropsWithHydration) {
   const __scopeId = __instanceId || `TableCaption_${Math.random().toString(36).slice(2, 8)}`
   const tableCaptionClasses = 'text-muted-foreground mt-4 text-sm'
 

--- a/packages/adapter-tests/fixtures/__snapshots__/dialog.dialog.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/dialog.dialog.ssr.tsx
@@ -427,7 +427,7 @@ export function DialogContent(__allProps: DialogContentProps & { __instanceId?: 
   )
 }
 
-export function DialogHeader({ className = '', children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: DialogHeaderPropsWithHydration) {
+export function DialogHeader({ className = '', children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: DialogHeaderPropsWithHydration = {} as DialogHeaderPropsWithHydration) {
   const __scopeId = __instanceId || `DialogHeader_${Math.random().toString(36).slice(2, 8)}`
   const dialogHeaderClasses = 'flex flex-col gap-2 text-center sm:text-left'
 
@@ -442,7 +442,7 @@ export function DialogHeader({ className = '', children, __instanceId, __bfScope
   )
 }
 
-export function DialogTitle({ className = '', id, children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: DialogTitlePropsWithHydration) {
+export function DialogTitle({ className = '', id, children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: DialogTitlePropsWithHydration = {} as DialogTitlePropsWithHydration) {
   const __scopeId = __instanceId || `DialogTitle_${Math.random().toString(36).slice(2, 8)}`
   const dialogTitleClasses = 'text-lg leading-none font-semibold'
 
@@ -458,7 +458,7 @@ export function DialogTitle({ className = '', id, children, __instanceId, __bfSc
   )
 }
 
-export function DialogDescription({ className = '', id, children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: DialogDescriptionPropsWithHydration) {
+export function DialogDescription({ className = '', id, children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: DialogDescriptionPropsWithHydration = {} as DialogDescriptionPropsWithHydration) {
   const __scopeId = __instanceId || `DialogDescription_${Math.random().toString(36).slice(2, 8)}`
   const dialogDescriptionClasses = 'text-muted-foreground text-sm'
 
@@ -474,7 +474,7 @@ export function DialogDescription({ className = '', id, children, __instanceId, 
   )
 }
 
-export function DialogFooter({ className = '', children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: DialogFooterPropsWithHydration) {
+export function DialogFooter({ className = '', children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: DialogFooterPropsWithHydration = {} as DialogFooterPropsWithHydration) {
   const __scopeId = __instanceId || `DialogFooter_${Math.random().toString(36).slice(2, 8)}`
   const dialogFooterClasses = 'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end'
 

--- a/packages/adapter-tests/fixtures/__snapshots__/dropdown-menu.dropdown-menu.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/dropdown-menu.dropdown-menu.ssr.tsx
@@ -707,7 +707,7 @@ export function DropdownMenuSubContent(__allProps: DropdownMenuSubContentProps &
   )
 }
 
-export function DropdownMenuLabel({ children, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: DropdownMenuLabelPropsWithHydration) {
+export function DropdownMenuLabel({ children, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: DropdownMenuLabelPropsWithHydration = {} as DropdownMenuLabelPropsWithHydration) {
   const __scopeId = __instanceId || `DropdownMenuLabel_${Math.random().toString(36).slice(2, 8)}`
   const dropdownMenuLabelClasses = 'px-2 py-1.5 text-sm font-semibold text-foreground'
 
@@ -736,7 +736,7 @@ export function DropdownMenuSeparator({ className = '', __instanceId, __bfScope:
   )
 }
 
-export function DropdownMenuShortcut({ children, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: DropdownMenuShortcutPropsWithHydration) {
+export function DropdownMenuShortcut({ children, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: DropdownMenuShortcutPropsWithHydration = {} as DropdownMenuShortcutPropsWithHydration) {
   const __scopeId = __instanceId || `DropdownMenuShortcut_${Math.random().toString(36).slice(2, 8)}`
   const dropdownMenuShortcutClasses = 'ml-auto text-xs tracking-widest text-muted-foreground'
 
@@ -751,7 +751,7 @@ export function DropdownMenuShortcut({ children, className = '', __instanceId, _
   )
 }
 
-export function DropdownMenuGroup({ children, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: DropdownMenuGroupPropsWithHydration) {
+export function DropdownMenuGroup({ children, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: DropdownMenuGroupPropsWithHydration = {} as DropdownMenuGroupPropsWithHydration) {
   const __scopeId = __instanceId || `DropdownMenuGroup_${Math.random().toString(36).slice(2, 8)}`
 
   // Serialize props for client hydration

--- a/packages/adapter-tests/fixtures/__snapshots__/dropdown-menu.icon.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/dropdown-menu.icon.ssr.tsx
@@ -512,7 +512,7 @@ type IconPropsWithHydration = { name: IconName } & IconProps & {
   "data-key"?: string | number
 }
 
-export function CheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CheckIconPropsWithHydration) {
+export function CheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CheckIconPropsWithHydration = {} as CheckIconPropsWithHydration) {
   const __scopeId = __instanceId || `CheckIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -556,7 +556,7 @@ export function CheckIcon({ size, className = '', __instanceId, __bfScope: _bfSc
   )
 }
 
-export function ChevronDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronDownIconPropsWithHydration) {
+export function ChevronDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronDownIconPropsWithHydration = {} as ChevronDownIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronDownIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -600,7 +600,7 @@ export function ChevronDownIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function ChevronUpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronUpIconPropsWithHydration) {
+export function ChevronUpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronUpIconPropsWithHydration = {} as ChevronUpIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronUpIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -644,7 +644,7 @@ export function ChevronUpIcon({ size, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function ChevronLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronLeftIconPropsWithHydration) {
+export function ChevronLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronLeftIconPropsWithHydration = {} as ChevronLeftIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronLeftIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -688,7 +688,7 @@ export function ChevronLeftIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function ChevronRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronRightIconPropsWithHydration) {
+export function ChevronRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronRightIconPropsWithHydration = {} as ChevronRightIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronRightIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -732,7 +732,7 @@ export function ChevronRightIcon({ size, className = '', __instanceId, __bfScope
   )
 }
 
-export function XIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: XIconPropsWithHydration) {
+export function XIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: XIconPropsWithHydration = {} as XIconPropsWithHydration) {
   const __scopeId = __instanceId || `XIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -776,7 +776,7 @@ export function XIcon({ size, className = '', __instanceId, __bfScope: _bfScope,
   )
 }
 
-export function PlusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PlusIconPropsWithHydration) {
+export function PlusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PlusIconPropsWithHydration = {} as PlusIconPropsWithHydration) {
   const __scopeId = __instanceId || `PlusIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -820,7 +820,7 @@ export function PlusIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function MinusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MinusIconPropsWithHydration) {
+export function MinusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MinusIconPropsWithHydration = {} as MinusIconPropsWithHydration) {
   const __scopeId = __instanceId || `MinusIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -864,7 +864,7 @@ export function MinusIcon({ size, className = '', __instanceId, __bfScope: _bfSc
   )
 }
 
-export function SunIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SunIconPropsWithHydration) {
+export function SunIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SunIconPropsWithHydration = {} as SunIconPropsWithHydration) {
   const __scopeId = __instanceId || `SunIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -908,7 +908,7 @@ export function SunIcon({ size, className = '', __instanceId, __bfScope: _bfScop
   )
 }
 
-export function MoonIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MoonIconPropsWithHydration) {
+export function MoonIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MoonIconPropsWithHydration = {} as MoonIconPropsWithHydration) {
   const __scopeId = __instanceId || `MoonIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -952,7 +952,7 @@ export function MoonIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function MonitorIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MonitorIconPropsWithHydration) {
+export function MonitorIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MonitorIconPropsWithHydration = {} as MonitorIconPropsWithHydration) {
   const __scopeId = __instanceId || `MonitorIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -996,7 +996,7 @@ export function MonitorIcon({ size, className = '', __instanceId, __bfScope: _bf
   )
 }
 
-export function CopyIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CopyIconPropsWithHydration) {
+export function CopyIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CopyIconPropsWithHydration = {} as CopyIconPropsWithHydration) {
   const __scopeId = __instanceId || `CopyIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1040,7 +1040,7 @@ export function CopyIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function ClipboardIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardIconPropsWithHydration) {
+export function ClipboardIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardIconPropsWithHydration = {} as ClipboardIconPropsWithHydration) {
   const __scopeId = __instanceId || `ClipboardIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1084,7 +1084,7 @@ export function ClipboardIcon({ size, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function ClipboardCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardCheckIconPropsWithHydration) {
+export function ClipboardCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardCheckIconPropsWithHydration = {} as ClipboardCheckIconPropsWithHydration) {
   const __scopeId = __instanceId || `ClipboardCheckIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1128,7 +1128,7 @@ export function ClipboardCheckIcon({ size, className = '', __instanceId, __bfSco
   )
 }
 
-export function MenuIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MenuIconPropsWithHydration) {
+export function MenuIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MenuIconPropsWithHydration = {} as MenuIconPropsWithHydration) {
   const __scopeId = __instanceId || `MenuIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1172,7 +1172,7 @@ export function MenuIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function ArrowLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowLeftIconPropsWithHydration) {
+export function ArrowLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowLeftIconPropsWithHydration = {} as ArrowLeftIconPropsWithHydration) {
   const __scopeId = __instanceId || `ArrowLeftIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1216,7 +1216,7 @@ export function ArrowLeftIcon({ size, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function ArrowRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowRightIconPropsWithHydration) {
+export function ArrowRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowRightIconPropsWithHydration = {} as ArrowRightIconPropsWithHydration) {
   const __scopeId = __instanceId || `ArrowRightIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1260,7 +1260,7 @@ export function ArrowRightIcon({ size, className = '', __instanceId, __bfScope: 
   )
 }
 
-export function ArrowUpDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowUpDownIconPropsWithHydration) {
+export function ArrowUpDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowUpDownIconPropsWithHydration = {} as ArrowUpDownIconPropsWithHydration) {
   const __scopeId = __instanceId || `ArrowUpDownIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1304,7 +1304,7 @@ export function ArrowUpDownIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function EllipsisIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: EllipsisIconPropsWithHydration) {
+export function EllipsisIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: EllipsisIconPropsWithHydration = {} as EllipsisIconPropsWithHydration) {
   const __scopeId = __instanceId || `EllipsisIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1325,7 +1325,7 @@ export function EllipsisIcon({ size, className = '', __instanceId, __bfScope: _b
   )
 }
 
-export function GitHubIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GitHubIconPropsWithHydration) {
+export function GitHubIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GitHubIconPropsWithHydration = {} as GitHubIconPropsWithHydration) {
   const __scopeId = __instanceId || `GitHubIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1346,7 +1346,7 @@ export function GitHubIcon({ size, className = '', __instanceId, __bfScope: _bfS
   )
 }
 
-export function SettingsIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SettingsIconPropsWithHydration) {
+export function SettingsIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SettingsIconPropsWithHydration = {} as SettingsIconPropsWithHydration) {
   const __scopeId = __instanceId || `SettingsIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1367,7 +1367,7 @@ export function SettingsIcon({ size, className = '', __instanceId, __bfScope: _b
   )
 }
 
-export function GlobeIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GlobeIconPropsWithHydration) {
+export function GlobeIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GlobeIconPropsWithHydration = {} as GlobeIconPropsWithHydration) {
   const __scopeId = __instanceId || `GlobeIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1388,7 +1388,7 @@ export function GlobeIcon({ size, className = '', __instanceId, __bfScope: _bfSc
   )
 }
 
-export function LogOutIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LogOutIconPropsWithHydration) {
+export function LogOutIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LogOutIconPropsWithHydration = {} as LogOutIconPropsWithHydration) {
   const __scopeId = __instanceId || `LogOutIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1409,7 +1409,7 @@ export function LogOutIcon({ size, className = '', __instanceId, __bfScope: _bfS
   )
 }
 
-export function CircleHelpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleHelpIconPropsWithHydration) {
+export function CircleHelpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleHelpIconPropsWithHydration = {} as CircleHelpIconPropsWithHydration) {
   const __scopeId = __instanceId || `CircleHelpIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1430,7 +1430,7 @@ export function CircleHelpIcon({ size, className = '', __instanceId, __bfScope: 
   )
 }
 
-export function SearchIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SearchIconPropsWithHydration) {
+export function SearchIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SearchIconPropsWithHydration = {} as SearchIconPropsWithHydration) {
   const __scopeId = __instanceId || `SearchIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1451,7 +1451,7 @@ export function SearchIcon({ size, className = '', __instanceId, __bfScope: _bfS
   )
 }
 
-export function CircleCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleCheckIconPropsWithHydration) {
+export function CircleCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleCheckIconPropsWithHydration = {} as CircleCheckIconPropsWithHydration) {
   const __scopeId = __instanceId || `CircleCheckIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1472,7 +1472,7 @@ export function CircleCheckIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function CircleXIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleXIconPropsWithHydration) {
+export function CircleXIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleXIconPropsWithHydration = {} as CircleXIconPropsWithHydration) {
   const __scopeId = __instanceId || `CircleXIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1493,7 +1493,7 @@ export function CircleXIcon({ size, className = '', __instanceId, __bfScope: _bf
   )
 }
 
-export function TriangleAlertIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TriangleAlertIconPropsWithHydration) {
+export function TriangleAlertIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TriangleAlertIconPropsWithHydration = {} as TriangleAlertIconPropsWithHydration) {
   const __scopeId = __instanceId || `TriangleAlertIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1514,7 +1514,7 @@ export function TriangleAlertIcon({ size, className = '', __instanceId, __bfScop
   )
 }
 
-export function InfoIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: InfoIconPropsWithHydration) {
+export function InfoIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: InfoIconPropsWithHydration = {} as InfoIconPropsWithHydration) {
   const __scopeId = __instanceId || `InfoIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1535,7 +1535,7 @@ export function InfoIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function CalendarIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CalendarIconPropsWithHydration) {
+export function CalendarIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CalendarIconPropsWithHydration = {} as CalendarIconPropsWithHydration) {
   const __scopeId = __instanceId || `CalendarIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1556,7 +1556,7 @@ export function CalendarIcon({ size, className = '', __instanceId, __bfScope: _b
   )
 }
 
-export function GripVerticalIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GripVerticalIconPropsWithHydration) {
+export function GripVerticalIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GripVerticalIconPropsWithHydration = {} as GripVerticalIconPropsWithHydration) {
   const __scopeId = __instanceId || `GripVerticalIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1577,7 +1577,7 @@ export function GripVerticalIcon({ size, className = '', __instanceId, __bfScope
   )
 }
 
-export function LoaderCircleIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LoaderCircleIconPropsWithHydration) {
+export function LoaderCircleIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LoaderCircleIconPropsWithHydration = {} as LoaderCircleIconPropsWithHydration) {
   const __scopeId = __instanceId || `LoaderCircleIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1621,7 +1621,7 @@ export function LoaderCircleIcon({ size, className = '', __instanceId, __bfScope
   )
 }
 
-export function PanelLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PanelLeftIconPropsWithHydration) {
+export function PanelLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PanelLeftIconPropsWithHydration = {} as PanelLeftIconPropsWithHydration) {
   const __scopeId = __instanceId || `PanelLeftIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,

--- a/packages/adapter-tests/fixtures/__snapshots__/kbd.slot.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/kbd.slot.ssr.tsx
@@ -22,7 +22,7 @@ type SlotPropsWithHydration = SlotProps & {
 
 export type { SlotProps }
 
-export function Slot({ children, className, __instanceId, __bfScope: _bfScope, __bfChild: _bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": _dataKey, ...props }: SlotPropsWithHydration) {
+export function Slot({ children, className, __instanceId, __bfScope: _bfScope, __bfChild: _bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": _dataKey, ...props }: SlotPropsWithHydration = {} as SlotPropsWithHydration) {
   const __scopeId = __instanceId || `Slot_${Math.random().toString(36).slice(2, 8)}`
   function isValidElement(element: unknown): element is { tag: unknown; props: Record<string, unknown> } {
   return !!(element && typeof element === 'object' && 'tag' in element && 'props' in element)

--- a/packages/adapter-tests/fixtures/__snapshots__/pagination.icon.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/pagination.icon.ssr.tsx
@@ -512,7 +512,7 @@ type IconPropsWithHydration = { name: IconName } & IconProps & {
   "data-key"?: string | number
 }
 
-export function CheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CheckIconPropsWithHydration) {
+export function CheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CheckIconPropsWithHydration = {} as CheckIconPropsWithHydration) {
   const __scopeId = __instanceId || `CheckIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -556,7 +556,7 @@ export function CheckIcon({ size, className = '', __instanceId, __bfScope: _bfSc
   )
 }
 
-export function ChevronDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronDownIconPropsWithHydration) {
+export function ChevronDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronDownIconPropsWithHydration = {} as ChevronDownIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronDownIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -600,7 +600,7 @@ export function ChevronDownIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function ChevronUpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronUpIconPropsWithHydration) {
+export function ChevronUpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronUpIconPropsWithHydration = {} as ChevronUpIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronUpIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -644,7 +644,7 @@ export function ChevronUpIcon({ size, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function ChevronLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronLeftIconPropsWithHydration) {
+export function ChevronLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronLeftIconPropsWithHydration = {} as ChevronLeftIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronLeftIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -688,7 +688,7 @@ export function ChevronLeftIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function ChevronRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronRightIconPropsWithHydration) {
+export function ChevronRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronRightIconPropsWithHydration = {} as ChevronRightIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronRightIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -732,7 +732,7 @@ export function ChevronRightIcon({ size, className = '', __instanceId, __bfScope
   )
 }
 
-export function XIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: XIconPropsWithHydration) {
+export function XIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: XIconPropsWithHydration = {} as XIconPropsWithHydration) {
   const __scopeId = __instanceId || `XIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -776,7 +776,7 @@ export function XIcon({ size, className = '', __instanceId, __bfScope: _bfScope,
   )
 }
 
-export function PlusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PlusIconPropsWithHydration) {
+export function PlusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PlusIconPropsWithHydration = {} as PlusIconPropsWithHydration) {
   const __scopeId = __instanceId || `PlusIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -820,7 +820,7 @@ export function PlusIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function MinusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MinusIconPropsWithHydration) {
+export function MinusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MinusIconPropsWithHydration = {} as MinusIconPropsWithHydration) {
   const __scopeId = __instanceId || `MinusIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -864,7 +864,7 @@ export function MinusIcon({ size, className = '', __instanceId, __bfScope: _bfSc
   )
 }
 
-export function SunIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SunIconPropsWithHydration) {
+export function SunIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SunIconPropsWithHydration = {} as SunIconPropsWithHydration) {
   const __scopeId = __instanceId || `SunIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -908,7 +908,7 @@ export function SunIcon({ size, className = '', __instanceId, __bfScope: _bfScop
   )
 }
 
-export function MoonIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MoonIconPropsWithHydration) {
+export function MoonIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MoonIconPropsWithHydration = {} as MoonIconPropsWithHydration) {
   const __scopeId = __instanceId || `MoonIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -952,7 +952,7 @@ export function MoonIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function MonitorIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MonitorIconPropsWithHydration) {
+export function MonitorIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MonitorIconPropsWithHydration = {} as MonitorIconPropsWithHydration) {
   const __scopeId = __instanceId || `MonitorIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -996,7 +996,7 @@ export function MonitorIcon({ size, className = '', __instanceId, __bfScope: _bf
   )
 }
 
-export function CopyIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CopyIconPropsWithHydration) {
+export function CopyIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CopyIconPropsWithHydration = {} as CopyIconPropsWithHydration) {
   const __scopeId = __instanceId || `CopyIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1040,7 +1040,7 @@ export function CopyIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function ClipboardIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardIconPropsWithHydration) {
+export function ClipboardIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardIconPropsWithHydration = {} as ClipboardIconPropsWithHydration) {
   const __scopeId = __instanceId || `ClipboardIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1084,7 +1084,7 @@ export function ClipboardIcon({ size, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function ClipboardCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardCheckIconPropsWithHydration) {
+export function ClipboardCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardCheckIconPropsWithHydration = {} as ClipboardCheckIconPropsWithHydration) {
   const __scopeId = __instanceId || `ClipboardCheckIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1128,7 +1128,7 @@ export function ClipboardCheckIcon({ size, className = '', __instanceId, __bfSco
   )
 }
 
-export function MenuIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MenuIconPropsWithHydration) {
+export function MenuIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MenuIconPropsWithHydration = {} as MenuIconPropsWithHydration) {
   const __scopeId = __instanceId || `MenuIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1172,7 +1172,7 @@ export function MenuIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function ArrowLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowLeftIconPropsWithHydration) {
+export function ArrowLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowLeftIconPropsWithHydration = {} as ArrowLeftIconPropsWithHydration) {
   const __scopeId = __instanceId || `ArrowLeftIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1216,7 +1216,7 @@ export function ArrowLeftIcon({ size, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function ArrowRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowRightIconPropsWithHydration) {
+export function ArrowRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowRightIconPropsWithHydration = {} as ArrowRightIconPropsWithHydration) {
   const __scopeId = __instanceId || `ArrowRightIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1260,7 +1260,7 @@ export function ArrowRightIcon({ size, className = '', __instanceId, __bfScope: 
   )
 }
 
-export function ArrowUpDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowUpDownIconPropsWithHydration) {
+export function ArrowUpDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowUpDownIconPropsWithHydration = {} as ArrowUpDownIconPropsWithHydration) {
   const __scopeId = __instanceId || `ArrowUpDownIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1304,7 +1304,7 @@ export function ArrowUpDownIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function EllipsisIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: EllipsisIconPropsWithHydration) {
+export function EllipsisIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: EllipsisIconPropsWithHydration = {} as EllipsisIconPropsWithHydration) {
   const __scopeId = __instanceId || `EllipsisIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1325,7 +1325,7 @@ export function EllipsisIcon({ size, className = '', __instanceId, __bfScope: _b
   )
 }
 
-export function GitHubIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GitHubIconPropsWithHydration) {
+export function GitHubIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GitHubIconPropsWithHydration = {} as GitHubIconPropsWithHydration) {
   const __scopeId = __instanceId || `GitHubIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1346,7 +1346,7 @@ export function GitHubIcon({ size, className = '', __instanceId, __bfScope: _bfS
   )
 }
 
-export function SettingsIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SettingsIconPropsWithHydration) {
+export function SettingsIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SettingsIconPropsWithHydration = {} as SettingsIconPropsWithHydration) {
   const __scopeId = __instanceId || `SettingsIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1367,7 +1367,7 @@ export function SettingsIcon({ size, className = '', __instanceId, __bfScope: _b
   )
 }
 
-export function GlobeIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GlobeIconPropsWithHydration) {
+export function GlobeIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GlobeIconPropsWithHydration = {} as GlobeIconPropsWithHydration) {
   const __scopeId = __instanceId || `GlobeIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1388,7 +1388,7 @@ export function GlobeIcon({ size, className = '', __instanceId, __bfScope: _bfSc
   )
 }
 
-export function LogOutIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LogOutIconPropsWithHydration) {
+export function LogOutIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LogOutIconPropsWithHydration = {} as LogOutIconPropsWithHydration) {
   const __scopeId = __instanceId || `LogOutIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1409,7 +1409,7 @@ export function LogOutIcon({ size, className = '', __instanceId, __bfScope: _bfS
   )
 }
 
-export function CircleHelpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleHelpIconPropsWithHydration) {
+export function CircleHelpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleHelpIconPropsWithHydration = {} as CircleHelpIconPropsWithHydration) {
   const __scopeId = __instanceId || `CircleHelpIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1430,7 +1430,7 @@ export function CircleHelpIcon({ size, className = '', __instanceId, __bfScope: 
   )
 }
 
-export function SearchIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SearchIconPropsWithHydration) {
+export function SearchIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SearchIconPropsWithHydration = {} as SearchIconPropsWithHydration) {
   const __scopeId = __instanceId || `SearchIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1451,7 +1451,7 @@ export function SearchIcon({ size, className = '', __instanceId, __bfScope: _bfS
   )
 }
 
-export function CircleCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleCheckIconPropsWithHydration) {
+export function CircleCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleCheckIconPropsWithHydration = {} as CircleCheckIconPropsWithHydration) {
   const __scopeId = __instanceId || `CircleCheckIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1472,7 +1472,7 @@ export function CircleCheckIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function CircleXIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleXIconPropsWithHydration) {
+export function CircleXIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleXIconPropsWithHydration = {} as CircleXIconPropsWithHydration) {
   const __scopeId = __instanceId || `CircleXIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1493,7 +1493,7 @@ export function CircleXIcon({ size, className = '', __instanceId, __bfScope: _bf
   )
 }
 
-export function TriangleAlertIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TriangleAlertIconPropsWithHydration) {
+export function TriangleAlertIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TriangleAlertIconPropsWithHydration = {} as TriangleAlertIconPropsWithHydration) {
   const __scopeId = __instanceId || `TriangleAlertIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1514,7 +1514,7 @@ export function TriangleAlertIcon({ size, className = '', __instanceId, __bfScop
   )
 }
 
-export function InfoIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: InfoIconPropsWithHydration) {
+export function InfoIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: InfoIconPropsWithHydration = {} as InfoIconPropsWithHydration) {
   const __scopeId = __instanceId || `InfoIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1535,7 +1535,7 @@ export function InfoIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function CalendarIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CalendarIconPropsWithHydration) {
+export function CalendarIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CalendarIconPropsWithHydration = {} as CalendarIconPropsWithHydration) {
   const __scopeId = __instanceId || `CalendarIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1556,7 +1556,7 @@ export function CalendarIcon({ size, className = '', __instanceId, __bfScope: _b
   )
 }
 
-export function GripVerticalIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GripVerticalIconPropsWithHydration) {
+export function GripVerticalIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GripVerticalIconPropsWithHydration = {} as GripVerticalIconPropsWithHydration) {
   const __scopeId = __instanceId || `GripVerticalIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1577,7 +1577,7 @@ export function GripVerticalIcon({ size, className = '', __instanceId, __bfScope
   )
 }
 
-export function LoaderCircleIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LoaderCircleIconPropsWithHydration) {
+export function LoaderCircleIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LoaderCircleIconPropsWithHydration = {} as LoaderCircleIconPropsWithHydration) {
   const __scopeId = __instanceId || `LoaderCircleIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1621,7 +1621,7 @@ export function LoaderCircleIcon({ size, className = '', __instanceId, __bfScope
   )
 }
 
-export function PanelLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PanelLeftIconPropsWithHydration) {
+export function PanelLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PanelLeftIconPropsWithHydration = {} as PanelLeftIconPropsWithHydration) {
   const __scopeId = __instanceId || `PanelLeftIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,

--- a/packages/adapter-tests/fixtures/__snapshots__/pagination.pagination.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/pagination.pagination.ssr.tsx
@@ -125,7 +125,7 @@ type PaginationEllipsisPropsWithHydration = PaginationEllipsisProps & {
 
 export type { PaginationLinkProps }
 
-export function Pagination({ className = '', children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PaginationPropsWithHydration) {
+export function Pagination({ className = '', children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PaginationPropsWithHydration = {} as PaginationPropsWithHydration) {
   const __scopeId = __instanceId || `Pagination_${Math.random().toString(36).slice(2, 8)}`
 
   // Serialize props for client hydration
@@ -139,7 +139,7 @@ export function Pagination({ className = '', children, __instanceId, __bfScope: 
   )
 }
 
-export function PaginationContent({ className = '', children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PaginationContentPropsWithHydration) {
+export function PaginationContent({ className = '', children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PaginationContentPropsWithHydration = {} as PaginationContentPropsWithHydration) {
   const __scopeId = __instanceId || `PaginationContent_${Math.random().toString(36).slice(2, 8)}`
 
   // Serialize props for client hydration
@@ -153,7 +153,7 @@ export function PaginationContent({ className = '', children, __instanceId, __bf
   )
 }
 
-export function PaginationItem({ className = '', children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PaginationItemPropsWithHydration) {
+export function PaginationItem({ className = '', children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PaginationItemPropsWithHydration = {} as PaginationItemPropsWithHydration) {
   const __scopeId = __instanceId || `PaginationItem_${Math.random().toString(36).slice(2, 8)}`
 
   // Serialize props for client hydration
@@ -188,7 +188,7 @@ export function PaginationLink(__allProps: PaginationLinkProps & { __instanceId?
   )
 }
 
-export function PaginationPrevious({ className = '', children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PaginationPreviousPropsWithHydration) {
+export function PaginationPrevious({ className = '', children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PaginationPreviousPropsWithHydration = {} as PaginationPreviousPropsWithHydration) {
   const __scopeId = __instanceId || `PaginationPrevious_${Math.random().toString(36).slice(2, 8)}`
   const buttonBaseClasses = 'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]'
   const variantClasses = {
@@ -210,7 +210,7 @@ export function PaginationPrevious({ className = '', children, __instanceId, __b
   )
 }
 
-export function PaginationNext({ className = '', children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PaginationNextPropsWithHydration) {
+export function PaginationNext({ className = '', children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PaginationNextPropsWithHydration = {} as PaginationNextPropsWithHydration) {
   const __scopeId = __instanceId || `PaginationNext_${Math.random().toString(36).slice(2, 8)}`
   const buttonBaseClasses = 'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]'
   const variantClasses = {

--- a/packages/adapter-tests/fixtures/__snapshots__/select.icon.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/select.icon.ssr.tsx
@@ -512,7 +512,7 @@ type IconPropsWithHydration = { name: IconName } & IconProps & {
   "data-key"?: string | number
 }
 
-export function CheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CheckIconPropsWithHydration) {
+export function CheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CheckIconPropsWithHydration = {} as CheckIconPropsWithHydration) {
   const __scopeId = __instanceId || `CheckIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -556,7 +556,7 @@ export function CheckIcon({ size, className = '', __instanceId, __bfScope: _bfSc
   )
 }
 
-export function ChevronDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronDownIconPropsWithHydration) {
+export function ChevronDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronDownIconPropsWithHydration = {} as ChevronDownIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronDownIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -600,7 +600,7 @@ export function ChevronDownIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function ChevronUpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronUpIconPropsWithHydration) {
+export function ChevronUpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronUpIconPropsWithHydration = {} as ChevronUpIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronUpIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -644,7 +644,7 @@ export function ChevronUpIcon({ size, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function ChevronLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronLeftIconPropsWithHydration) {
+export function ChevronLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronLeftIconPropsWithHydration = {} as ChevronLeftIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronLeftIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -688,7 +688,7 @@ export function ChevronLeftIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function ChevronRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronRightIconPropsWithHydration) {
+export function ChevronRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ChevronRightIconPropsWithHydration = {} as ChevronRightIconPropsWithHydration) {
   const __scopeId = __instanceId || `ChevronRightIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -732,7 +732,7 @@ export function ChevronRightIcon({ size, className = '', __instanceId, __bfScope
   )
 }
 
-export function XIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: XIconPropsWithHydration) {
+export function XIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: XIconPropsWithHydration = {} as XIconPropsWithHydration) {
   const __scopeId = __instanceId || `XIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -776,7 +776,7 @@ export function XIcon({ size, className = '', __instanceId, __bfScope: _bfScope,
   )
 }
 
-export function PlusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PlusIconPropsWithHydration) {
+export function PlusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PlusIconPropsWithHydration = {} as PlusIconPropsWithHydration) {
   const __scopeId = __instanceId || `PlusIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -820,7 +820,7 @@ export function PlusIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function MinusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MinusIconPropsWithHydration) {
+export function MinusIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MinusIconPropsWithHydration = {} as MinusIconPropsWithHydration) {
   const __scopeId = __instanceId || `MinusIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -864,7 +864,7 @@ export function MinusIcon({ size, className = '', __instanceId, __bfScope: _bfSc
   )
 }
 
-export function SunIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SunIconPropsWithHydration) {
+export function SunIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SunIconPropsWithHydration = {} as SunIconPropsWithHydration) {
   const __scopeId = __instanceId || `SunIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -908,7 +908,7 @@ export function SunIcon({ size, className = '', __instanceId, __bfScope: _bfScop
   )
 }
 
-export function MoonIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MoonIconPropsWithHydration) {
+export function MoonIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MoonIconPropsWithHydration = {} as MoonIconPropsWithHydration) {
   const __scopeId = __instanceId || `MoonIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -952,7 +952,7 @@ export function MoonIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function MonitorIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MonitorIconPropsWithHydration) {
+export function MonitorIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MonitorIconPropsWithHydration = {} as MonitorIconPropsWithHydration) {
   const __scopeId = __instanceId || `MonitorIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -996,7 +996,7 @@ export function MonitorIcon({ size, className = '', __instanceId, __bfScope: _bf
   )
 }
 
-export function CopyIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CopyIconPropsWithHydration) {
+export function CopyIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CopyIconPropsWithHydration = {} as CopyIconPropsWithHydration) {
   const __scopeId = __instanceId || `CopyIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1040,7 +1040,7 @@ export function CopyIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function ClipboardIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardIconPropsWithHydration) {
+export function ClipboardIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardIconPropsWithHydration = {} as ClipboardIconPropsWithHydration) {
   const __scopeId = __instanceId || `ClipboardIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1084,7 +1084,7 @@ export function ClipboardIcon({ size, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function ClipboardCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardCheckIconPropsWithHydration) {
+export function ClipboardCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ClipboardCheckIconPropsWithHydration = {} as ClipboardCheckIconPropsWithHydration) {
   const __scopeId = __instanceId || `ClipboardCheckIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1128,7 +1128,7 @@ export function ClipboardCheckIcon({ size, className = '', __instanceId, __bfSco
   )
 }
 
-export function MenuIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MenuIconPropsWithHydration) {
+export function MenuIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: MenuIconPropsWithHydration = {} as MenuIconPropsWithHydration) {
   const __scopeId = __instanceId || `MenuIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1172,7 +1172,7 @@ export function MenuIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function ArrowLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowLeftIconPropsWithHydration) {
+export function ArrowLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowLeftIconPropsWithHydration = {} as ArrowLeftIconPropsWithHydration) {
   const __scopeId = __instanceId || `ArrowLeftIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1216,7 +1216,7 @@ export function ArrowLeftIcon({ size, className = '', __instanceId, __bfScope: _
   )
 }
 
-export function ArrowRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowRightIconPropsWithHydration) {
+export function ArrowRightIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowRightIconPropsWithHydration = {} as ArrowRightIconPropsWithHydration) {
   const __scopeId = __instanceId || `ArrowRightIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1260,7 +1260,7 @@ export function ArrowRightIcon({ size, className = '', __instanceId, __bfScope: 
   )
 }
 
-export function ArrowUpDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowUpDownIconPropsWithHydration) {
+export function ArrowUpDownIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ArrowUpDownIconPropsWithHydration = {} as ArrowUpDownIconPropsWithHydration) {
   const __scopeId = __instanceId || `ArrowUpDownIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1304,7 +1304,7 @@ export function ArrowUpDownIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function EllipsisIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: EllipsisIconPropsWithHydration) {
+export function EllipsisIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: EllipsisIconPropsWithHydration = {} as EllipsisIconPropsWithHydration) {
   const __scopeId = __instanceId || `EllipsisIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1325,7 +1325,7 @@ export function EllipsisIcon({ size, className = '', __instanceId, __bfScope: _b
   )
 }
 
-export function GitHubIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GitHubIconPropsWithHydration) {
+export function GitHubIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GitHubIconPropsWithHydration = {} as GitHubIconPropsWithHydration) {
   const __scopeId = __instanceId || `GitHubIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1346,7 +1346,7 @@ export function GitHubIcon({ size, className = '', __instanceId, __bfScope: _bfS
   )
 }
 
-export function SettingsIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SettingsIconPropsWithHydration) {
+export function SettingsIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SettingsIconPropsWithHydration = {} as SettingsIconPropsWithHydration) {
   const __scopeId = __instanceId || `SettingsIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1367,7 +1367,7 @@ export function SettingsIcon({ size, className = '', __instanceId, __bfScope: _b
   )
 }
 
-export function GlobeIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GlobeIconPropsWithHydration) {
+export function GlobeIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GlobeIconPropsWithHydration = {} as GlobeIconPropsWithHydration) {
   const __scopeId = __instanceId || `GlobeIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1388,7 +1388,7 @@ export function GlobeIcon({ size, className = '', __instanceId, __bfScope: _bfSc
   )
 }
 
-export function LogOutIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LogOutIconPropsWithHydration) {
+export function LogOutIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LogOutIconPropsWithHydration = {} as LogOutIconPropsWithHydration) {
   const __scopeId = __instanceId || `LogOutIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1409,7 +1409,7 @@ export function LogOutIcon({ size, className = '', __instanceId, __bfScope: _bfS
   )
 }
 
-export function CircleHelpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleHelpIconPropsWithHydration) {
+export function CircleHelpIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleHelpIconPropsWithHydration = {} as CircleHelpIconPropsWithHydration) {
   const __scopeId = __instanceId || `CircleHelpIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1430,7 +1430,7 @@ export function CircleHelpIcon({ size, className = '', __instanceId, __bfScope: 
   )
 }
 
-export function SearchIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SearchIconPropsWithHydration) {
+export function SearchIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SearchIconPropsWithHydration = {} as SearchIconPropsWithHydration) {
   const __scopeId = __instanceId || `SearchIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1451,7 +1451,7 @@ export function SearchIcon({ size, className = '', __instanceId, __bfScope: _bfS
   )
 }
 
-export function CircleCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleCheckIconPropsWithHydration) {
+export function CircleCheckIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleCheckIconPropsWithHydration = {} as CircleCheckIconPropsWithHydration) {
   const __scopeId = __instanceId || `CircleCheckIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1472,7 +1472,7 @@ export function CircleCheckIcon({ size, className = '', __instanceId, __bfScope:
   )
 }
 
-export function CircleXIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleXIconPropsWithHydration) {
+export function CircleXIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CircleXIconPropsWithHydration = {} as CircleXIconPropsWithHydration) {
   const __scopeId = __instanceId || `CircleXIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1493,7 +1493,7 @@ export function CircleXIcon({ size, className = '', __instanceId, __bfScope: _bf
   )
 }
 
-export function TriangleAlertIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TriangleAlertIconPropsWithHydration) {
+export function TriangleAlertIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TriangleAlertIconPropsWithHydration = {} as TriangleAlertIconPropsWithHydration) {
   const __scopeId = __instanceId || `TriangleAlertIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1514,7 +1514,7 @@ export function TriangleAlertIcon({ size, className = '', __instanceId, __bfScop
   )
 }
 
-export function InfoIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: InfoIconPropsWithHydration) {
+export function InfoIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: InfoIconPropsWithHydration = {} as InfoIconPropsWithHydration) {
   const __scopeId = __instanceId || `InfoIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1535,7 +1535,7 @@ export function InfoIcon({ size, className = '', __instanceId, __bfScope: _bfSco
   )
 }
 
-export function CalendarIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CalendarIconPropsWithHydration) {
+export function CalendarIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: CalendarIconPropsWithHydration = {} as CalendarIconPropsWithHydration) {
   const __scopeId = __instanceId || `CalendarIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1556,7 +1556,7 @@ export function CalendarIcon({ size, className = '', __instanceId, __bfScope: _b
   )
 }
 
-export function GripVerticalIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GripVerticalIconPropsWithHydration) {
+export function GripVerticalIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: GripVerticalIconPropsWithHydration = {} as GripVerticalIconPropsWithHydration) {
   const __scopeId = __instanceId || `GripVerticalIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1577,7 +1577,7 @@ export function GripVerticalIcon({ size, className = '', __instanceId, __bfScope
   )
 }
 
-export function LoaderCircleIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LoaderCircleIconPropsWithHydration) {
+export function LoaderCircleIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: LoaderCircleIconPropsWithHydration = {} as LoaderCircleIconPropsWithHydration) {
   const __scopeId = __instanceId || `LoaderCircleIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,
@@ -1621,7 +1621,7 @@ export function LoaderCircleIcon({ size, className = '', __instanceId, __bfScope
   )
 }
 
-export function PanelLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PanelLeftIconPropsWithHydration) {
+export function PanelLeftIcon({ size, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: PanelLeftIconPropsWithHydration = {} as PanelLeftIconPropsWithHydration) {
   const __scopeId = __instanceId || `PanelLeftIcon_${Math.random().toString(36).slice(2, 8)}`
   const sizeMap = {
   sm: 16,

--- a/packages/adapter-tests/fixtures/__snapshots__/select.select.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/select.select.ssr.tsx
@@ -324,7 +324,7 @@ export function SelectItem(__allProps: SelectItemProps & { __instanceId?: string
   )
 }
 
-export function SelectGroup({ children, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SelectGroupPropsWithHydration) {
+export function SelectGroup({ children, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SelectGroupPropsWithHydration = {} as SelectGroupPropsWithHydration) {
   const __scopeId = __instanceId || `SelectGroup_${Math.random().toString(36).slice(2, 8)}`
 
   // Serialize props for client hydration
@@ -338,7 +338,7 @@ export function SelectGroup({ children, className = '', __instanceId, __bfScope:
   )
 }
 
-export function SelectLabel({ children, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SelectLabelPropsWithHydration) {
+export function SelectLabel({ children, className = '', __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: SelectLabelPropsWithHydration = {} as SelectLabelPropsWithHydration) {
   const __scopeId = __instanceId || `SelectLabel_${Math.random().toString(36).slice(2, 8)}`
   const selectLabelClasses = 'px-2 py-1.5 text-sm font-semibold text-foreground'
 

--- a/packages/adapter-tests/fixtures/__snapshots__/tabs.tabs.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/tabs.tabs.ssr.tsx
@@ -129,7 +129,7 @@ interface TabsContentProps extends HTMLBaseAttributes {
 
 export type { TabsProps, TabsListProps, TabsTriggerProps, TabsContentProps }
 
-export function Tabs({ className = '', value, defaultValue, children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TabsPropsWithHydration) {
+export function Tabs({ className = '', value, defaultValue, children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TabsPropsWithHydration = {} as TabsPropsWithHydration) {
   const __scopeId = __instanceId || `Tabs_${Math.random().toString(36).slice(2, 8)}`
   const tabsClasses = 'flex flex-col gap-2 w-full'
 
@@ -146,7 +146,7 @@ export function Tabs({ className = '', value, defaultValue, children, __instance
   )
 }
 
-export function TabsList({ className = '', children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TabsListPropsWithHydration) {
+export function TabsList({ className = '', children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: TabsListPropsWithHydration = {} as TabsListPropsWithHydration) {
   const __scopeId = __instanceId || `TabsList_${Math.random().toString(36).slice(2, 8)}`
   const tabsListClasses = 'bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]'
 

--- a/packages/adapter-tests/fixtures/__snapshots__/tooltip.button.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/tooltip.button.ssr.tsx
@@ -40,7 +40,7 @@ type ButtonPropsWithHydration = ButtonProps & {
 
 export type { ButtonVariant, ButtonSize, ButtonProps }
 
-export function Button({ className = '', variant = 'default', size = 'default', asChild = false, children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ButtonPropsWithHydration) {
+export function Button({ className = '', variant = 'default', size = 'default', asChild = false, children, __instanceId, __bfScope: _bfScope, __bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": __dataKey, ...props }: ButtonPropsWithHydration = {} as ButtonPropsWithHydration) {
   const __scopeId = __instanceId || `Button_${Math.random().toString(36).slice(2, 8)}`
 
   // Serialize props for client hydration

--- a/packages/adapter-tests/fixtures/__snapshots__/tooltip.slot.ssr.tsx
+++ b/packages/adapter-tests/fixtures/__snapshots__/tooltip.slot.ssr.tsx
@@ -22,7 +22,7 @@ type SlotPropsWithHydration = SlotProps & {
 
 export type { SlotProps }
 
-export function Slot({ children, className, __instanceId, __bfScope: _bfScope, __bfChild: _bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": _dataKey, ...props }: SlotPropsWithHydration) {
+export function Slot({ children, className, __instanceId, __bfScope: _bfScope, __bfChild: _bfChild, __bfParentProps, __bfParent, __bfMount, "data-key": _dataKey, ...props }: SlotPropsWithHydration = {} as SlotPropsWithHydration) {
   const __scopeId = __instanceId || `Slot_${Math.random().toString(36).slice(2, 8)}`
   function isValidElement(element: unknown): element is { tag: unknown; props: Record<string, unknown> } {
   return !!(element && typeof element === 'object' && 'tag' in element && 'props' in element)

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -132,6 +132,7 @@ import { fixture as eventHandlers } from './event-handlers'
 import { fixture as defaultProps } from './default-props'
 import { fixture as untypedPropsReads } from './untyped-props-reads'
 import { fixture as nullishCoalescingText } from './nullish-coalescing-text'
+import { fixture as nullishCoalescingDestructured } from './nullish-coalescing-destructured'
 import { fixture as nullishCoalescingJsx } from './nullish-coalescing-jsx'
 import { fixture as logicalOrJsx } from './logical-or-jsx'
 import { fixture as branchSelfClosing } from './branch-self-closing'
@@ -470,6 +471,7 @@ export const jsxFixtures: JSXFixture[] = [
   defaultProps,
   untypedPropsReads,
   nullishCoalescingText,
+  nullishCoalescingDestructured,
   nullishCoalescingJsx,
   logicalOrJsx,
   branchSelfClosing,

--- a/packages/adapter-tests/fixtures/nullish-coalescing-destructured.ts
+++ b/packages/adapter-tests/fixtures/nullish-coalescing-destructured.ts
@@ -1,0 +1,39 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Destructured twin of `nullish-coalescing-text` (#2259): the same `??`
+ * signal seed and text fallback, consumed through destructured bindings
+ * (`{ label, size }`) instead of a props object. Destructured optionals
+ * used to lose their TypeInfo and optional flag in `propsParams`, so the
+ * SSR seed lowerings keyed on `param.optional` (#2252's nillable flip and
+ * the hoisted fallback var on Go) never fired — the Go constructor seeded
+ * the signal with a literal `0` regardless of the caller's input.
+ */
+export const fixture = createFixture({
+  id: 'nullish-coalescing-destructured',
+  description: 'Nullish coalescing over destructured optional props seeds SSR correctly',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function NullishCoalescingDestructured({ label, size }: { label?: string; size?: number }) {
+  const [count, setCount] = createSignal(size ?? 1)
+  return <div><span>{label ?? 'Default'}</span><span>{count()}</span></div>
+}
+`,
+  props: { label: 'Custom', size: 5 },
+  // `''` and `0` are nullish-KEPT in JS; `absent` must take the fallback.
+  // The zero/empty points are the ones a zero-valued struct field cannot
+  // distinguish from "absent" — exactly what the nillable lowering exists
+  // to express.
+  dataPoints: [
+    { name: 'both-absent', props: {} },
+    { name: 'empty-label', props: { label: '' } },
+    { name: 'zero-size', props: { size: 0 } },
+  ],
+  expectedHtml: `
+    <div bf-s="test">
+      <span bf="s1"><!--bf:s0-->Custom<!--/--></span>
+      <span bf="s3"><!--bf:s2-->5<!--/--></span>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/generated-data-points.json
+++ b/packages/adapter-tests/generated-data-points.json
@@ -184,6 +184,38 @@
       }
     }
   ],
+  "branch-local-filter-join": [
+    {
+      "name": "gen:on:true",
+      "props": {
+        "on": true
+      }
+    },
+    {
+      "name": "gen:on:false",
+      "props": {
+        "on": false
+      }
+    },
+    {
+      "name": "gen:label:empty",
+      "props": {
+        "label": ""
+      }
+    },
+    {
+      "name": "gen:label:markup",
+      "props": {
+        "label": "<b>&\"'</b>"
+      }
+    },
+    {
+      "name": "gen:label:multibyte",
+      "props": {
+        "label": "日本語"
+      }
+    }
+  ],
   "button": [
     {
       "name": "gen:className:absent",
@@ -209,6 +241,37 @@
         "variant": "secondary",
         "className": "",
         "children": "Click me",
+        "__instanceId": "Button_test"
+      }
+    },
+    {
+      "name": "gen:asChild:true",
+      "props": {
+        "variant": "secondary",
+        "size": "sm",
+        "className": "",
+        "children": "Click me",
+        "__instanceId": "Button_test",
+        "asChild": true
+      }
+    },
+    {
+      "name": "gen:asChild:false",
+      "props": {
+        "variant": "secondary",
+        "size": "sm",
+        "className": "",
+        "children": "Click me",
+        "__instanceId": "Button_test",
+        "asChild": false
+      }
+    },
+    {
+      "name": "gen:children:absent",
+      "props": {
+        "variant": "secondary",
+        "size": "sm",
+        "className": "",
         "__instanceId": "Button_test"
       }
     }
@@ -580,6 +643,31 @@
         "children": "K",
         "__instanceId": "Kbd_test"
       }
+    },
+    {
+      "name": "gen:asChild:true",
+      "props": {
+        "className": "",
+        "children": "K",
+        "__instanceId": "Kbd_test",
+        "asChild": true
+      }
+    },
+    {
+      "name": "gen:asChild:false",
+      "props": {
+        "className": "",
+        "children": "K",
+        "__instanceId": "Kbd_test",
+        "asChild": false
+      }
+    },
+    {
+      "name": "gen:children:absent",
+      "props": {
+        "className": "",
+        "__instanceId": "Kbd_test"
+      }
     }
   ],
   "label": [
@@ -587,6 +675,29 @@
       "name": "gen:className:absent",
       "props": {
         "children": "Email",
+        "__instanceId": "Label_test"
+      }
+    },
+    {
+      "name": "gen:className:markup",
+      "props": {
+        "className": "<b>&\"'</b>",
+        "children": "Email",
+        "__instanceId": "Label_test"
+      }
+    },
+    {
+      "name": "gen:className:multibyte",
+      "props": {
+        "className": "日本語",
+        "children": "Email",
+        "__instanceId": "Label_test"
+      }
+    },
+    {
+      "name": "gen:children:absent",
+      "props": {
+        "className": "",
         "__instanceId": "Label_test"
       }
     }
@@ -637,6 +748,62 @@
           2,
           3
         ]
+      }
+    }
+  ],
+  "nullish-coalescing-destructured": [
+    {
+      "name": "gen:label:absent",
+      "props": {
+        "size": 5
+      }
+    },
+    {
+      "name": "gen:label:empty",
+      "props": {
+        "label": "",
+        "size": 5
+      }
+    },
+    {
+      "name": "gen:label:markup",
+      "props": {
+        "label": "<b>&\"'</b>",
+        "size": 5
+      }
+    },
+    {
+      "name": "gen:label:multibyte",
+      "props": {
+        "label": "日本語",
+        "size": 5
+      }
+    },
+    {
+      "name": "gen:size:absent",
+      "props": {
+        "label": "Custom"
+      }
+    },
+    {
+      "name": "gen:size:zero",
+      "props": {
+        "label": "Custom",
+        "size": 0
+      }
+    },
+    {
+      "name": "gen:size:negative",
+      "props": {
+        "label": "Custom",
+        "size": -7
+      }
+    },
+    {
+      "name": "gen:size:large",
+      "props": {
+        "label": "Custom",
+        "size": 1234567890
       }
     }
   ],
@@ -1475,6 +1642,56 @@
         "placeholder": "Type your message here.",
         "className": "",
         "__instanceId": "Textarea_test"
+      }
+    },
+    {
+      "name": "gen:error:true",
+      "props": {
+        "placeholder": "Type your message here.",
+        "className": "",
+        "value": "",
+        "__instanceId": "Textarea_test",
+        "error": true
+      }
+    },
+    {
+      "name": "gen:error:false",
+      "props": {
+        "placeholder": "Type your message here.",
+        "className": "",
+        "value": "",
+        "__instanceId": "Textarea_test",
+        "error": false
+      }
+    },
+    {
+      "name": "gen:describedBy:empty",
+      "props": {
+        "placeholder": "Type your message here.",
+        "className": "",
+        "value": "",
+        "__instanceId": "Textarea_test",
+        "describedBy": ""
+      }
+    },
+    {
+      "name": "gen:describedBy:markup",
+      "props": {
+        "placeholder": "Type your message here.",
+        "className": "",
+        "value": "",
+        "__instanceId": "Textarea_test",
+        "describedBy": "<b>&\"'</b>"
+      }
+    },
+    {
+      "name": "gen:describedBy:multibyte",
+      "props": {
+        "placeholder": "Type your message here.",
+        "className": "",
+        "value": "",
+        "__instanceId": "Textarea_test",
+        "describedBy": "日本語"
       }
     }
   ],

--- a/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
+++ b/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
@@ -243,6 +243,11 @@ describe('CSR Conformance Tests', () => {
     //     first element in CSR, while SSR carries the scope on a
     //     `<!--bf-scope:...-->` comment the normalizer strips.
     'nested-fragments',
+    // #2265 (same class as #2222 Bug 1, signal-initial-value position):
+    // the module-scope `template:` arrow interpolates the bare destructured
+    // name (`${escapeText((size ?? 1))}`) it can't see —
+    // `ReferenceError: size is not defined` at template-eval time.
+    'nullish-coalescing-destructured',
   ])
 
   for (const fixture of jsxFixtures) {

--- a/packages/adapter-tests/src/__tests__/generated-data-points.test.ts
+++ b/packages/adapter-tests/src/__tests__/generated-data-points.test.ts
@@ -43,8 +43,6 @@ describe('generated-data-points artifact', () => {
 })
 
 describe('generateDataPointsForFixture', () => {
-  // Props-object style: the one the analyzer fully resolves (see the
-  // destructured pin below / #2259).
   const fixture = createFixture({
     id: 'catalog-unit-probe',
     description: 'generator contract probe',
@@ -92,13 +90,10 @@ export function Probe(props: { label: string; size?: number; on?: boolean }) {
     expect(generateDataPointsForFixture(gateless)).toEqual([])
   })
 
-  test('destructured optional props generate nothing (#2259 pin)', () => {
-    // The analyzer loses TypeInfo + the optional flag for destructured
-    // optionals, so the catalogue has nothing to derive from. This pin
-    // flips when #2259 lands — delete it and regen the artifact then.
+  test('destructured optional props generate the same points as the object style (#2259)', () => {
     const destructured = createFixture({
       id: 'catalog-unit-destructured',
-      description: 'destructured optional resolution gap',
+      description: 'destructured optional resolution',
       source: `
 export function D({ label, size }: { label: string; size?: number }) {
   return <div>{label}{size ?? 0}</div>
@@ -107,9 +102,29 @@ export function D({ label, size }: { label: string; size?: number }) {
       props: { label: 'Hello', size: 5 },
       expectedHtml: '<div bf-s="test">placeholder</div>',
     })
+    const byName = new Map(generateDataPointsForFixture(destructured).map(p => [p.name, p.props]))
+    expect(byName.get('gen:size:absent')).toEqual({ label: 'Hello' })
+    expect(byName.get('gen:size:zero')).toEqual({ label: 'Hello', size: 0 })
+    expect(byName.get('gen:label:empty')).toEqual({ label: '', size: 5 })
+  })
+
+  test('destructured optional NON-primitives get an absent point despite unknown type (#2259)', () => {
+    // Type resolution stays primitive-only, but the optional flag is now
+    // collected for every member — `absent` derives from it alone.
+    const destructured = createFixture({
+      id: 'catalog-unit-destructured-nonprimitive',
+      description: 'optional flag without type resolution',
+      source: `
+type Todo = { id: number }
+export function D({ items }: { items?: Todo[] }) {
+  return <div>{(items ?? []).length}</div>
+}
+`,
+      props: { items: [{ id: 1 }] },
+      expectedHtml: '<div bf-s="test">placeholder</div>',
+    })
     const names = generateDataPointsForFixture(destructured).map(p => p.name)
-    expect(names.some(n => n.startsWith('gen:size:'))).toBe(false)
-    expect(names).toContain('gen:label:empty')
+    expect(names).toContain('gen:items:absent')
   })
 
   test('declared points dedupe generated duplicates by value', () => {

--- a/packages/adapter-tests/src/adversarial-catalog.ts
+++ b/packages/adapter-tests/src/adversarial-catalog.ts
@@ -31,12 +31,11 @@
  * - union / object / interface / function-typed props — value synthesis
  *   needs member enumeration (unions) or required-field construction
  *   (objects);
- * - `Date` — joins the data domain in roadmap stage 4;
- * - DESTRUCTURED optional props (#2259) — the analyzer currently loses
- *   their TypeInfo and optional flag (`{ size }: { size?: number }` →
- *   `unknown`/`optional: false`), so nothing can be derived; the
- *   props-object style resolves fully. When #2259 lands, the freshness
- *   test will demand a regen that widens the artifact automatically.
+ * - `Date` — joins the data domain in roadmap stage 4.
+ *
+ * (Destructured optional props were a v1 exclusion — the analyzer lost
+ * their TypeInfo and optional flag; #2259 restored parity with the
+ * props-object style, widening the artifact to destructured components.)
  */
 
 import { compileJSX } from '@barefootjs/jsx'

--- a/packages/adapter-tests/src/adversarial-catalog.ts
+++ b/packages/adapter-tests/src/adversarial-catalog.ts
@@ -32,10 +32,6 @@
  *   needs member enumeration (unions) or required-field construction
  *   (objects);
  * - `Date` — joins the data domain in roadmap stage 4.
- *
- * (Destructured optional props were a v1 exclusion — the analyzer lost
- * their TypeInfo and optional flag; #2259 restored parity with the
- * props-object style, widening the artifact to destructured components.)
  */
 
 import { compileJSX } from '@barefootjs/jsx'

--- a/packages/adapter-twig/src/adapter/props/prop-classes.ts
+++ b/packages/adapter-twig/src/adapter/props/prop-classes.ts
@@ -24,7 +24,9 @@ export function collectBooleanTypedProps(ir: ComponentIR): Set<string> {
 }
 
 /**
- * Bare references to optional, no-default, non-primitive props (e.g.
+ * Bare references to presence-uncertain no-default props — non-primitive
+ * or declared optional (#2259; pre-#2259 destructured optionals arrived as
+ * `unknown` and the type test alone covered them) — (e.g.
  * textarea's `rows`) are `null` when omitted → guarded with
  * `is defined and is not null` in `emitExpression`. See the
  * `nullableOptionalProps` field docstring in `twig-adapter.ts`.
@@ -36,7 +38,7 @@ export function collectNullableOptionalProps(ir: ComponentIR): Set<string> {
         p =>
           p.defaultValue === undefined &&
           !p.isRest &&
-          p.type?.kind !== 'primitive',
+          (p.type?.kind !== 'primitive' || p.optional),
       )
       .map(p => p.name),
   )

--- a/packages/adapter-twig/src/adapter/props/prop-classes.ts
+++ b/packages/adapter-twig/src/adapter/props/prop-classes.ts
@@ -24,10 +24,9 @@ export function collectBooleanTypedProps(ir: ComponentIR): Set<string> {
 }
 
 /**
- * Bare references to presence-uncertain no-default props — non-primitive
- * or declared optional (#2259; pre-#2259 destructured optionals arrived as
- * `unknown` and the type test alone covered them) — (e.g.
- * textarea's `rows`) are `null` when omitted → guarded with
+ * Bare references to presence-uncertain no-default props (non-primitive
+ * typed OR declared optional, #2259 — e.g. textarea's `rows`) are
+ * `null` when omitted → guarded with
  * `is defined and is not null` in `emitExpression`. See the
  * `nullableOptionalProps` field docstring in `twig-adapter.ts`.
  */

--- a/packages/adapter-xslate/src/adapter/props/prop-classes.ts
+++ b/packages/adapter-xslate/src/adapter/props/prop-classes.ts
@@ -25,10 +25,9 @@ export function collectBooleanTypedProps(ir: ComponentIR): Set<string> {
 }
 
 /**
- * Bare references to presence-uncertain no-default props — non-primitive
- * or declared optional (#2259; pre-#2259 destructured optionals arrived as
- * `unknown` and the type test alone covered them) — (e.g.
- * textarea's `rows`) are `undef` when omitted → `defined`-guarded in
+ * Bare references to presence-uncertain no-default props (non-primitive
+ * typed OR declared optional, #2259 — e.g. textarea's `rows`) are
+ * `undef` when omitted → `defined`-guarded in
  * `emitExpression`. See the `nullableOptionalProps` field docstring.
  */
 export function collectNullableOptionalProps(ir: ComponentIR): Set<string> {

--- a/packages/adapter-xslate/src/adapter/props/prop-classes.ts
+++ b/packages/adapter-xslate/src/adapter/props/prop-classes.ts
@@ -25,7 +25,9 @@ export function collectBooleanTypedProps(ir: ComponentIR): Set<string> {
 }
 
 /**
- * Bare references to optional, no-default, non-primitive props (e.g.
+ * Bare references to presence-uncertain no-default props — non-primitive
+ * or declared optional (#2259; pre-#2259 destructured optionals arrived as
+ * `unknown` and the type test alone covered them) — (e.g.
  * textarea's `rows`) are `undef` when omitted → `defined`-guarded in
  * `emitExpression`. See the `nullableOptionalProps` field docstring.
  */
@@ -36,7 +38,7 @@ export function collectNullableOptionalProps(ir: ComponentIR): Set<string> {
         p =>
           p.defaultValue === undefined &&
           !p.isRest &&
-          p.type?.kind !== 'primitive',
+          (p.type?.kind !== 'primitive' || p.optional),
       )
       .map(p => p.name),
   )

--- a/packages/jsx/src/__tests__/client-js-generation.test.ts
+++ b/packages/jsx/src/__tests__/client-js-generation.test.ts
@@ -2725,4 +2725,44 @@ describe('Client JS generation', () => {
       expect(js).toMatch(/items\(\)\.filter\([^)]+\)\.find\(/)
     })
   })
+
+  describe('defaultless optional prop extraction (#2259)', () => {
+    // `{ size }: { size?: number }` binds `undefined` when the prop is
+    // absent — `createSignal(size ?? 1)` must see it. A synthesized
+    // primitive default (`_p.size ?? 0`) would hydrate the signal to 0
+    // where SSR seeded the `?? 1` fallback.
+    test('emits plain extraction, not a zero default', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/client'
+
+        export function Probe({ label, size }: { label: string; size?: number }) {
+          const [count, setCount] = createSignal(size ?? 1)
+          return <div onClick={() => setCount(count() + 1)}>{label}{count()}</div>
+        }
+      `
+      const result = compileJSX(source, 'Probe.tsx', { adapter })
+      expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+      const js = result.files.find(f => f.type === 'clientJs')!.content
+      expect(js).toContain('const size = _p.size')
+      expect(js).not.toContain('_p.size ?? 0')
+    })
+
+    // A destructure default still wins over plain extraction.
+    test('keeps the destructure default when one exists', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/client'
+
+        export function Probe({ size = 5 }: { size?: number }) {
+          const [count, setCount] = createSignal(size)
+          return <div onClick={() => setCount(count() + 1)}>{count()}</div>
+        }
+      `
+      const result = compileJSX(source, 'Probe.tsx', { adapter })
+      expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+      const js = result.files.find(f => f.type === 'clientJs')!.content
+      expect(js).toContain('const size = _p.size ?? 5')
+    })
+  })
 })

--- a/packages/jsx/src/__tests__/props-destructuring.test.ts
+++ b/packages/jsx/src/__tests__/props-destructuring.test.ts
@@ -356,21 +356,74 @@ describe('Destructured props keep their declared types (BF043 fixture #2150)', (
     expect(typeOf(ctx, 'value')).toEqual({ kind: 'unknown', raw: 'unknown' })
   })
 
-  // Deliberate scope: only required primitives are resolved. Optional and
-  // non-primitive members stay `unknown` so typed adapters keep their existing
-  // interface{}-based lowering (attribute omission, bf_flat/spread/bf_json).
-  test('leaves OPTIONAL members as unknown (preserves nillable omission)', () => {
+  // #2259: optional primitives resolve type AND optionality, same as the
+  // props-object path — pre-#2259 they were skipped wholesale so typed
+  // adapters kept a nillable interface{} field; #2252's nullish-flip
+  // machinery now supplies the absent representation where it matters.
+  test('resolves OPTIONAL primitive members with optional: true (#2259)', () => {
     const source = `
-      type Props = { value?: number }
+      type Props = { label: string; size?: number; on?: boolean }
 
-      export function Component({ value }: Props) {
-        return <div>{value}</div>
+      export function Component({ label, size, on }: Props) {
+        return <div>{label}{size ?? 0}{on ? 'y' : 'n'}</div>
       }
     `
 
     const ctx = analyzeComponent(source, 'Component.tsx')
 
-    expect(typeOf(ctx, 'value')).toEqual({ kind: 'unknown', raw: 'unknown' })
+    const param = (name: string) => ctx.propsParams.find((p) => p.name === name)
+    expect(param('label')).toMatchObject({
+      type: { kind: 'primitive', primitive: 'string' },
+      optional: false,
+    })
+    expect(param('size')).toMatchObject({
+      type: { kind: 'primitive', primitive: 'number' },
+      optional: true,
+    })
+    expect(param('on')).toMatchObject({
+      type: { kind: 'primitive', primitive: 'boolean' },
+      optional: true,
+    })
+  })
+
+  // A non-primitive optional keeps `unknown` (interface{}-based lowering)
+  // but still reports the type's `?` — the adversarial catalogue derives
+  // absent points from `optional` alone.
+  test('marks OPTIONAL non-primitive members optional while keeping unknown type (#2259)', () => {
+    const source = `
+      type Todo = { id: number }
+      type Props = { items?: Todo[] }
+
+      export function Component({ items }: Props) {
+        return <div>{(items ?? []).length}</div>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Component.tsx')
+
+    expect(ctx.propsParams.find((p) => p.name === 'items')).toMatchObject({
+      type: { kind: 'unknown', raw: 'unknown' },
+      optional: true,
+    })
+  })
+
+  // A destructure default and the type's `?` both mean "caller may omit";
+  // the default keeps `defaultValue` so adapters bake it (and the Go
+  // nullish flip keeps excluding defaulted props).
+  test('keeps defaultValue alongside optional for `{ size = 5 }` (#2259)', () => {
+    const source = `
+      export function Component({ size = 5 }: { size?: number }) {
+        return <div>{size}</div>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Component.tsx')
+
+    expect(ctx.propsParams.find((p) => p.name === 'size')).toMatchObject({
+      type: { kind: 'primitive', primitive: 'number' },
+      optional: true,
+      defaultValue: '5',
+    })
   })
 
   test('leaves NON-primitive members (arrays/objects) as unknown', () => {

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -3040,14 +3040,16 @@ function extractProps(param: ts.ParameterDeclaration, ctx: AnalyzerContext): voi
           element.propertyName && ts.isIdentifier(element.propertyName)
             ? element.propertyName.text
             : localName
-        const resolvedType: TypeInfo =
-          memberTypes?.get(sourcePropName) ?? { kind: 'unknown', raw: 'unknown' }
+        const member = memberTypes?.get(sourcePropName)
+        const resolvedType: TypeInfo = member?.type ?? { kind: 'unknown', raw: 'unknown' }
 
         const defaultContainsArrow = element.initializer ? nodeContainsArrow(element.initializer) : false
         ctx.propsParams.push({
           name: localName,
           type: resolvedType,
-          optional: !!element.initializer,
+          // The type's `?` and a destructure default (`{ x = 1 }`) both mean
+          // the caller may omit the prop.
+          optional: !!member?.optional || !!element.initializer,
           defaultValue,
           defaultContainsArrow: defaultContainsArrow || undefined,
         })
@@ -3130,18 +3132,22 @@ function collectKeysFromMembers(
 }
 
 /**
- * Build a property-name -> resolved TypeInfo map from a props type annotation,
- * for destructured params (`{ value }: Props`) so they carry the same per-prop
- * types the props-object path (`props: Props`) already resolves. Returns null
- * for external/unresolvable types.
+ * Build a property-name -> { type, optional } map from a props type
+ * annotation, for destructured params (`{ value }: Props`) so they carry the
+ * same per-prop TypeInfo and optionality the props-object path
+ * (`props: Props`) already resolves (#2150, #2259). Returns null for
+ * external/unresolvable types.
  *
- * Scope (deliberately narrow — targets the panic in issue #2150):
- * - Only REQUIRED members are resolved. Optional members (`value?: T`) are left
- *   out so they keep degrading to `unknown` -> `interface{}`: typed adapters
- *   rely on that nillable field to omit an unset optional attribute
- *   (`{{if ne .X nil}}` in Go), which a concrete zero value could not express.
- * - Only PRIMITIVE members (string/number/boolean) are resolved. Those are the
- *   types that otherwise produce an unchecked scalar assertion (`in.X.(int)`)
+ * Scope:
+ * - Optionality is collected for EVERY member — it feeds the type's `?` into
+ *   `propsParams[].optional` alongside a destructure default. (Pre-#2259,
+ *   optional members were skipped entirely so they'd degrade to `unknown` ->
+ *   `interface{}` and typed adapters could omit an unset optional attribute
+ *   via that nillable field; #2252's nullish-flip machinery now provides the
+ *   absent representation where it is semantically observable, so the blanket
+ *   guard is no longer needed.)
+ * - Only PRIMITIVE members (string/number/boolean) resolve a type. Those are
+ *   the types that otherwise produce an unchecked scalar assertion (`in.X.(int)`)
  *   that panics. Arrays/objects/functions are left as `unknown` because typed
  *   adapters lower them through interface{}-based helpers (`bf_flat`, spread,
  *   `bf_json`); giving them concrete types would break that lowering and is a
@@ -3150,19 +3156,22 @@ function collectKeysFromMembers(
 function collectMemberTypes(
   typeNode: ts.TypeNode,
   ctx: AnalyzerContext
-): Map<string, TypeInfo> | null {
+): Map<string, { type: TypeInfo | null; optional: boolean }> | null {
   const isResolvablePrimitive = (info: TypeInfo): boolean =>
     info.kind === 'primitive' &&
     (info.primitive === 'string' || info.primitive === 'number' || info.primitive === 'boolean')
 
-  const fromMembers = (members: ts.NodeArray<ts.TypeElement>): Map<string, TypeInfo> => {
-    const map = new Map<string, TypeInfo>()
+  const fromMembers = (
+    members: ts.NodeArray<ts.TypeElement>
+  ): Map<string, { type: TypeInfo | null; optional: boolean }> => {
+    const map = new Map<string, { type: TypeInfo | null; optional: boolean }>()
     for (const member of members) {
-      if (ts.isPropertySignature(member) && member.name && member.type && !member.questionToken) {
-        const info = typeNodeToTypeInfo(member.type, ctx.sourceFile)
-        if (info && isResolvablePrimitive(info)) {
-          map.set(member.name.getText(ctx.sourceFile), info)
-        }
+      if (ts.isPropertySignature(member) && member.name) {
+        const info = member.type ? typeNodeToTypeInfo(member.type, ctx.sourceFile) : null
+        map.set(member.name.getText(ctx.sourceFile), {
+          type: info && isResolvablePrimitive(info) ? info : null,
+          optional: !!member.questionToken,
+        })
       }
     }
     return map

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -3140,12 +3140,11 @@ function collectKeysFromMembers(
  *
  * Scope:
  * - Optionality is collected for EVERY member — it feeds the type's `?` into
- *   `propsParams[].optional` alongside a destructure default. (Pre-#2259,
- *   optional members were skipped entirely so they'd degrade to `unknown` ->
- *   `interface{}` and typed adapters could omit an unset optional attribute
- *   via that nillable field; #2252's nullish-flip machinery now provides the
- *   absent representation where it is semantically observable, so the blanket
- *   guard is no longer needed.)
+ *   `propsParams[].optional` alongside a destructure default. Optional
+ *   members resolve like required ones: typed adapters no longer need them
+ *   degraded to `unknown` -> `interface{}` for attribute omission, because
+ *   #2252's nullish-flip machinery supplies the nillable representation
+ *   exactly where absence is semantically observable (#2259).
  * - Only PRIMITIVE members (string/number/boolean) resolve a type. Those are
  *   the types that otherwise produce an unchecked scalar assertion (`in.X.(int)`)
  *   that panics. Arrays/objects/functions are left as `unknown` because typed

--- a/packages/jsx/src/ir-to-client-js/phases/props-extraction.ts
+++ b/packages/jsx/src/ir-to-client-js/phases/props-extraction.ts
@@ -9,7 +9,6 @@
  *   - prop has property/index access     → `?? {}`  (skipped when the
  *                                            prop is a conditional guard
  *                                            so falsy values stay falsy)
- *   - prop is optional with type info    → `?? <inferred default>`
  *   - otherwise                          → no default
  *
  * Skipped entirely when the component uses an opaque props object name
@@ -20,7 +19,7 @@
 import type { PropUsage } from '../../types.ts'
 import { propHasPropertyAccess } from '../compute-prop-usage.ts'
 import type { ClientJsContext } from '../types.ts'
-import { inferDefaultValue, PROPS_PARAM } from '../utils.ts'
+import { PROPS_PARAM } from '../utils.ts'
 
 export function emitPropsExtraction(
   lines: string[],
@@ -53,14 +52,11 @@ export function emitPropsExtraction(
       lines.push(`  const ${propName} = ${PROPS_PARAM}.${propName} ?? []`)
     } else if (propHasPropertyAccess(usage) && !propsUsedAsConditions.has(propName)) {
       lines.push(`  const ${propName} = ${PROPS_PARAM}.${propName} ?? {}`)
-    } else if (prop?.optional && prop?.type) {
-      const inferredDefault = inferDefaultValue(prop.type)
-      if (inferredDefault !== 'undefined') {
-        lines.push(`  const ${propName} = ${PROPS_PARAM}.${propName} ?? ${inferredDefault}`)
-      } else {
-        lines.push(`  const ${propName} = ${PROPS_PARAM}.${propName}`)
-      }
     } else {
+      // No synthesized default for a defaultless optional (`{ size }:
+      // { size?: number }`): the JS binding is `undefined` when absent, and
+      // a zero default would diverge from SSR (`size ?? 1` seeds 1
+      // server-side; a `_p.size ?? 0` extraction would hydrate to 0).
       lines.push(`  const ${propName} = ${PROPS_PARAM}.${propName}`)
     }
   }

--- a/spec/subset-conformance.md
+++ b/spec/subset-conformance.md
@@ -198,7 +198,7 @@ convention as `spec/adapter-architecture.md`):
 |-----------|--------|-----|
 | Normative subset | `ParsedExpr` union + exhaustive adapter switches (drift-defence); array-method / sort-comparator catalogues; builtin lowering registry; BF021/BF101 loud-refusal policy + growing-only rule (`spec/compiler.md`); `/* @client */` escape | Pieces are scattered across spec/types/catalogues with no single normative declaration; `ParsedExpr` lacks `object-literal` (adapter-architecture Roadmap A); the boundary is not fully loud — the Date silent passthrough proves unknown-type method calls pass undiagnosed; the data-domain axiom exists only in this document |
 | Canonical reference (JS render) | Hono/JS render is the *de facto* reference: snapshot generation renders expectations through it; `referenceAdapter`/`referenceRender` HTML-diff suite exists; determinism landed (#1494) | No *declaration* of canonical status (`referenceAdapter` is optional — the reference is still positioned as one adapter among eleven); oracle comparison runs at one evaluation point per fixture, not live × multiple data points |
-| Shared conformance | `run-adapter-conformance.ts` single mandatory entry point ("forgot to wire the suite" is impossible); 182 fixtures + marker conformance + template primitives + render contract; real-backend execution with `normalizeHTML`; `props` injection; **the `dataPoints` oracle suite (roadmap 1)** — gate-ordered, live-oracle, JSON-domain-validated, piloted on `nullish-coalescing-text` (found #2248 — since fixed via nillable lowering + `bf_nullish` — and a Go harness string-escaping bug on its first run) | No PR-vs-nightly tiering (the catalogue added ~200 real-backend renders per adapter job); catalogue exclusions await their unblockers (destructured optionals → #2259, unions/objects → member enumeration, floats → #2168-class, `Date` → roadmap 4) |
+| Shared conformance | `run-adapter-conformance.ts` single mandatory entry point ("forgot to wire the suite" is impossible); 182 fixtures + marker conformance + template primitives + render contract; real-backend execution with `normalizeHTML`; `props` injection; **the `dataPoints` oracle suite (roadmap 1)** — gate-ordered, live-oracle, JSON-domain-validated, piloted on `nullish-coalescing-text` (found #2248 — since fixed via nillable lowering + `bf_nullish` — and a Go harness string-escaping bug on its first run) | No PR-vs-nightly tiering (the catalogue added ~200 real-backend renders per adapter job); catalogue exclusions await their unblockers (unions/objects → member enumeration, floats → #2168-class, `Date` → roadmap 4 — destructured optionals graduated: #2259 restored analyzer parity and the catalogue now derives for them) |
 | Declared skips | Typed skip sets (`skipJsx`, `skipTemplatePrimitives`, `skipMarkerConformance`, `expectedDiagnostics`, and now `skipDataPoints` — its first entries pinned #2248 on the Go adapter until the fix landed and removed them, completing one full ledger round-trip) with issue-link discipline; `known-limitation` label; `@barefootjs/compat` component×adapter compile matrix (`compat.lock.json`) | No generated `kind × axis × adapter` support matrix yet — but its fixture-side half now exists: the computed coverage ledger (`coverage-map.json` + `PARSED_EXPR_KINDS` registry + freshness/floor meta-tests) supplies the kind/axis denominators; joining them against per-adapter pass/skip is the remaining work |
 
 Cross-cutting gap: the change-time coupling rule (subset extensions merge
@@ -242,8 +242,14 @@ convention.
    Hono drops the property, Go emits ZgotmplZ, ERB/Jinja/Rust keep it
    escaped), #2262 (dynamic `.flat` depth 0/negative violates the
    documented coercion contract on Go/ERB), and #2259 (the analyzer
-   loses TypeInfo and optionality for destructured optional props, so
-   nothing can be derived for them).
+   lost TypeInfo and optionality for destructured optional props, so
+   nothing could be derived for them — since fixed: destructured
+   optionals resolve like the props-object style, the Go adapter's
+   #2252 nillable-flip and hoisted-seed machinery recognises the
+   destructured `x ?? <literal>` seed via the signal's `ParsedExpr`,
+   and the catalogue widened to destructured components; the
+   `nullish-coalescing-destructured` fixture pins the SSR seed, with
+   its CSR-template gap tracked as #2265).
 4. **Date**: passthrough closure, then the catalogue plugin (UTC + ISO
    scope), envelope transport in the harness.
 

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 249,
+    "totalFixtures": 250,
     "fixtures": {
       "dangerous-inner-html-dynamic": {
         "blade": {


### PR DESCRIPTION
Closes #2259.

## What

`{ label, size, on }: { label: string; size?: number; on?: boolean }` now resolves in `ir.metadata.propsParams` exactly like the props-object style: `size`/`on` carry `primitive` TypeInfo and `optional: true` (derived from the type's `?` OR a destructure default), instead of degrading to `unknown`/`optional: false`.

## Why the fix is wider than the analyzer

The `unknown → interface{}` degradation was load-bearing in three places, all verified empirically and covered here:

1. **Client JS hydration** — the analyzer fix made a previously-dead branch live in `emitPropsExtraction` that would have synthesized `const size = _p.size ?? 0`, hydrating `createSignal(size ?? 1)` to 0 where SSR seeds 1. The branch is removed; a defaultless optional extracts plainly.
2. **Go SSR seed (#2252 interplay)** — worse than the issue suspected: `extractPropFallback` only matched the props-object member form, so a destructured `createSignal(size ?? 1)` seeded the Go constructor with a literal `0` even at the primary data point. The seed recognizers now match the destructured identifier form structurally via the signal's `ParsedExpr` (regex kept as the parsed-less fallback), routing destructured seeds through the #2248 hoisted-fallback/nillable machinery. The structural match handles negative fallbacks (unary-minus trees) and quotes string fallbacks directly (review findings — the naive reconstruction silently dropped `?? -1` hoists and double-escaped `?? 'say "hi"'`).
3. **Attribute omission** — typed adapters keyed Hono-style attribute omission on the accidental nillable representation. Go now flips an optional no-default scalar consumed as a bare omittable attribute to `interface{}` (`collectOmittableAttrConsumedPropNames`), and the seven dynamic adapters widen `collectNullableOptionalProps` to declared-optional primitives, so `rows={rows}` keeps dropping the attribute when the caller omits the prop — and the same guard now also covers the props-object style, matching the reference render.

The Go adapter additionally populates the consumed-prop sets and local type tables in `primeCompileState`, shared by `generate()` and the standalone `generateTypes()` entry — previously sibling `generateTypes()` calls resolved structs against another component's sets.

## Conformance

- New fixture `nullish-coalescing-destructured` (destructured twin of `nullish-coalescing-text`) pins the SSR seed at absent/zero/empty points. Its CSR-conformance entry is skipped pending #2265 (pre-existing #2222-class bug in signal-initial-value position, filed during this work).
- The type-derived catalogue now derives for destructured components: regen adds 27 points across 6 fixtures; the `#2259 pin` test in `generated-data-points.test.ts` graduated to positive coverage (including absent points for optional non-primitives).
- New divergences found by the widened catalogue, pinned per the skip discipline: #2266 (Go: `asChild=true` with plain-text children hard-errors the Slot define — `skipDataPoints` on button/kbd) and #2267 (Go: absent optional scalar in bare TEXT position renders the zero value — pre-existing props-object behavior now shared by the destructured style; noted in the changeset).
- `spec/subset-conformance.md` live record updated (#2259 graduated from the catalogue exclusions).

## Verification (all local backends green)

packages/jsx (2480), ui/components IR (1235), adapter-tests incl. CSR + freshness (1269), Go full incl. real-backend conformance + data points (1041), Hono (869), ERB (772), Jinja (803), Rust (803), Mojolicious (967), Blade (803), Xslate (802), Twig (green on rerun after one load flake). `tsgo` builds of all 9 changed packages pass. CLI failures reproduce at baseline HEAD (environmental). Twig/Blade/Xslate/Mojo real-backend runs are CI's to confirm.

Changeset: `@barefootjs/jsx` minor, `@barefootjs/go-template` minor, the seven dynamic adapters patch.

Design and pre-push reviews by a second model pass (fable); both MUST findings fixed with regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPphqdnM3RqvHv8QgGG6TR

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPphqdnM3RqvHv8QgGG6TR)_