### PR TITLE
Fix #2254: Go `??` nullish gate now applies in condition position

### DIFF
--- a/.changeset/go-nullish-condition-position.md
+++ b/.changeset/go-nullish-condition-position.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Fix #2254: Go's `??` nullish gate now applies in **condition position** (ternary tests / `{{if}}` paths, reached via `convertConditionToGo`), not just plain expression-interpolation positions.
+
+`renderConditionExpr`'s `logical` case unconditionally emitted Go's truthiness-based `or` for both `&&` and `??`, so a nillable-lowered optional prop's present-but-empty value (`''`/`0`/`false`) wrongly fell back to the `??` default when tested in a condition — e.g. `(props.label ?? 'Default') === 'Default' ? <A/> : <B/>` rendered `<A/>` for `label=""`, diverging from JS (which keeps `''` since it's present, not nullish). The sibling `logical()` emitter (used for other expression positions) already routed nillable operands through the nil-testing `bf_nullish` helper since #2248/#2252; this brings the condition-position emitter in line with it via the same `nillablePropNameOf` gate.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -4697,3 +4697,81 @@ export function List() {
     }
   })
 })
+
+// #2254: `??` in CONDITION position (ternaries/`{{if}}` via
+// `convertConditionToGo` → `renderConditionExpr`'s `logical` case) still
+// emitted Go's truthiness-based `or` even for a nillable-lowered prop, so a
+// present-but-empty (`''`) value wrongly fell back to the `??` default —
+// diverging from JS, where `??` only falls back on null/undefined. The
+// sibling `logical()` emitter (used for non-condition expression positions,
+// e.g. plain interpolation) already routed nillable operands through
+// `bf_nullish` since #2248/#2252; this brings the condition-position
+// emitter in line with it.
+describe('GoTemplateAdapter - #2254 `??` in condition position on a nillable prop', () => {
+  test('ternary test comparing `props.label ?? "Default"` lowers to bf_nullish, not or', () => {
+    const adapter = new GoTemplateAdapter()
+    const result = compileJSX(`
+"use client"
+type Props = { label?: string }
+export function C(props: Props) {
+  return <div>{(props.label ?? 'Default') === 'Default' ? <span>fallback</span> : <span>set</span>}</div>
+}
+`.trimStart(), 'test.tsx', { adapter })
+    expect(result.errors ?? []).toEqual([])
+    const template = result.files?.find(f => f.path.endsWith('.tmpl'))?.content ?? ''
+    expect(template).toContain('bf_nullish .Label "Default"')
+    expect(template).not.toContain('or .Label "Default"')
+  })
+
+  test('end-to-end via real `go run`: a present-but-empty label does NOT take the ?? default branch', async () => {
+    try {
+      const html = await renderGoTemplateComponent({
+        source: `
+'use client'
+type Props = { label?: string }
+export function C(props: Props) {
+  return <div>{(props.label ?? 'Default') === 'Default' ? <span>fallback</span> : <span>set</span>}</div>
+}
+`,
+        adapter: new GoTemplateAdapter(),
+        props: { label: '' },
+      })
+      // JS: '' ?? 'Default' keeps '' (present, not nullish) → '' === 'Default'
+      // is false → the "set" branch renders. The pre-fix `or` lowering would
+      // truthiness-fallback the empty string to 'Default' and wrongly render
+      // "fallback" instead.
+      expect(html).toContain('>set</span>')
+      expect(html).not.toContain('>fallback</span>')
+    } catch (err) {
+      if (err instanceof GoNotAvailableError) {
+        console.log('Skipping #2254 e2e: go command not found')
+        return
+      }
+      throw err
+    }
+  })
+
+  test('an omitted label DOES take the ?? default branch', async () => {
+    try {
+      const html = await renderGoTemplateComponent({
+        source: `
+'use client'
+type Props = { label?: string }
+export function C(props: Props) {
+  return <div>{(props.label ?? 'Default') === 'Default' ? <span>fallback</span> : <span>set</span>}</div>
+}
+`,
+        adapter: new GoTemplateAdapter(),
+        props: {},
+      })
+      expect(html).toContain('>fallback</span>')
+      expect(html).not.toContain('>set</span>')
+    } catch (err) {
+      if (err instanceof GoNotAvailableError) {
+        console.log('Skipping #2254 e2e: go command not found')
+        return
+      }
+      throw err
+    }
+  })
+})

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -4775,3 +4775,56 @@ export function C(props: Props) {
     }
   })
 })
+
+// Review finding on #2271 (the #2254 fix): `renderConditionExpr`'s `logical`
+// case wrapped operands via `needsParens` (AST-kind-based — only
+// `logical`/`unary`/`conditional`), missing any OTHER multi-token rendering
+// (`len .X`, `bf_add a b`, a call). Unwrapped, Go's `and`/`or`/`bf_nullish`
+// (all prefix builtins) parse a multi-token operand as extra sibling args
+// instead of one operand. Switched to `wrapIfMultiToken` (whitespace-based,
+// on the rendered string), matching the main `logical()` emitter.
+describe('GoTemplateAdapter - condition-position logical operand wrapping (#2271 review)', () => {
+  test('a `.length` (member → "len .X") operand of `&&` inside a ternary TEST is parenthesized', () => {
+    // A bare `{cond && <Elem/>}` is recognized as JSX conditional-rendering
+    // shorthand and its test is extracted directly, never reaching
+    // `renderConditionExpr`'s `logical` case as a literal `&&` node — so the
+    // `&&` must be nested inside an explicit ternary test to exercise it.
+    const adapter = new GoTemplateAdapter()
+    const result = compileJSX(`
+"use client"
+type Item = { id: number }
+export function C({ items, enabled }: { items: Item[]; enabled: boolean }) {
+  return <div>{(items.length && enabled) ? <span>on</span> : <span>off</span>}</div>
+}
+`.trimStart(), 'test.tsx', { adapter })
+    expect(result.errors ?? []).toEqual([])
+    const template = result.files?.find(f => f.path.endsWith('.tmpl'))?.content ?? ''
+    // `and (len .Items) .Enabled` — NOT the broken 3-sibling-arg
+    // `and len .Items .Enabled` a bare `needsParens` miss would produce.
+    expect(template).toContain('and (len .Items) .Enabled')
+  })
+
+  test('end-to-end via real `go run`: the multi-token `&&` ternary-test operand compiles and renders correctly', async () => {
+    try {
+      const html = await renderGoTemplateComponent({
+        source: `
+'use client'
+type Item = { id: number }
+export function C({ items, enabled }: { items: Item[]; enabled: boolean }) {
+  return <div>{(items.length && enabled) ? <span>on</span> : <span>off</span>}</div>
+}
+`,
+        adapter: new GoTemplateAdapter(),
+        props: { items: [{ id: 1 }], enabled: true },
+      })
+      expect(html).toContain('>on</span>')
+      expect(html).not.toContain('>off</span>')
+    } catch (err) {
+      if (err instanceof GoNotAvailableError) {
+        console.log('Skipping #2271 review e2e: go command not found')
+        return
+      }
+      throw err
+    }
+  })
+})

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -4470,11 +4470,6 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     return this.renderFilterExpr(pred, param, new Map(), datumField ?? undefined)
   }
 
-  /** Whether an expression needs parentheses when used in and/or. */
-  private needsParens(expr: ParsedExpr): boolean {
-    return expr.kind === 'logical' || expr.kind === 'unary' || expr.kind === 'conditional'
-  }
-
   /**
    * Split a rendered template block into preamble + final expression.
    * The last `{{...}}` must be a variable reference (`$bf_rN` or
@@ -5312,8 +5307,15 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         const leftResult = this.renderConditionExpr(expr.left)
         const rightResult = this.renderConditionExpr(expr.right)
         const preamble = leftResult.preamble + rightResult.preamble
-        const wrapLeft = this.needsParens(expr.left) ? `(${leftResult.expr})` : leftResult.expr
-        const wrapRight = this.needsParens(expr.right) ? `(${rightResult.expr})` : rightResult.expr
+        // `wrapIfMultiToken` (whitespace-based, on the RENDERED string) — not
+        // `needsParens` (AST-kind-based, only `logical`/`unary`/`conditional`)
+        // — matches the main `logical()` emitter's own wrapping. `needsParens`
+        // misses any other multi-token rendering (`len .X`, `bf_add a b`,
+        // `.SearchParams.Get "k"`), which `and`/`or`/`bf_nullish` (all prefix
+        // builtins) would otherwise parse as extra sibling args instead of one
+        // operand.
+        const wrapLeft = wrapIfMultiToken(leftResult.expr)
+        const wrapRight = wrapIfMultiToken(rightResult.expr)
         // `??` on a nillable prop needs true JS nullish semantics (#2254,
         // sibling of #2248/#2252's fix for text-expression/signal-seed
         // positions): Go's `or` is truthiness-based, so a present-but-empty

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -5314,9 +5314,18 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         const preamble = leftResult.preamble + rightResult.preamble
         const wrapLeft = this.needsParens(expr.left) ? `(${leftResult.expr})` : leftResult.expr
         const wrapRight = this.needsParens(expr.right) ? `(${rightResult.expr})` : rightResult.expr
+        // `??` on a nillable prop needs true JS nullish semantics (#2254,
+        // sibling of #2248/#2252's fix for text-expression/signal-seed
+        // positions): Go's `or` is truthiness-based, so a present-but-empty
+        // `""`/`0`/`false` operand wrongly falls back. `bf_nullish` tests
+        // nil-ness only. Mirrors the `logical()` emitter's own gate (used
+        // for non-condition expression positions) — same
+        // `nullishConsumed ∩ nillable` check via `nillablePropNameOf`.
         const result = expr.op === '&&'
           ? `and ${wrapLeft} ${wrapRight}`
-          : `or ${wrapLeft} ${wrapRight}`
+          : expr.op === '??' && this.nillablePropNameOf(expr.left) !== null
+            ? `bf_nullish ${wrapLeft} ${wrapRight}`
+            : `or ${wrapLeft} ${wrapRight}`
         return { preamble, expr: result }
       }
 


### PR DESCRIPTION
## Summary

- **#2254** — Go's `??` nullish gate now applies in **condition position** (ternary tests / `{{if}}` paths, reached via `convertConditionToGo`), not just plain expression-interpolation positions. `renderConditionExpr`'s `logical` case unconditionally emitted Go's truthiness-based `or` for both `&&` and `??`, so a nillable-lowered optional prop's present-but-empty value (`''`/`0`/`false`) wrongly fell back to the `??` default when tested in a condition — e.g. `(props.label ?? 'Default') === 'Default' ? <A/> : <B/>` rendered `<A/>` for `label=""`, diverging from JS. The sibling `logical()` emitter (used for other expression positions) already routed nillable operands through the nil-testing `bf_nullish` helper since #2248/#2252; this brings the condition-position emitter in line with it via the same `nillablePropNameOf` gate.

Also closed as already-fixed-but-not-auto-linked from the prior merged PR (#2269):
- #2256 — Go `??` nullish for a member-access left operand
- #2265 — CSR `template:` fallback arrow `ReferenceError` on a destructured signal-seed prop
- #2267 — Go bare-text optional scalar prop rendering its zero value instead of empty

## Test plan

- [x] Compiler unit test pinning the issue's exact repro at the codegen-string level (`bf_nullish` not `or`)
- [x] Real `go run` end-to-end test: present-but-empty label keeps the "set" branch; omitted label takes the "fallback" branch
- [x] Confirmed the new tests fail without the fix (reverted the adapter change, reran)
- [x] Full `bun test packages/adapter-go-template` package suite: 1065 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011XwkcCbAxUwzWGaa8j3MZQ)_