### PR TITLE
Fix #2272: graduate remaining #2260/#2261/#2262 pins on Blade/Twig/Xslate/Mojolicious

### DIFF
--- a/.changeset/graduate-blade-twig-xslate-mojo-pins.md
+++ b/.changeset/graduate-blade-twig-xslate-mojo-pins.md
@@ -1,0 +1,15 @@
+---
+"@barefootjs/blade": patch
+"@barefootjs/twig": patch
+"@barefootjs/xslate": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/perl": patch
+---
+
+Fix #2272: graduate the remaining catalogue pins on Blade, Twig, Xslate, and Mojolicious.
+
+- **#2260** (controlled/derived boolean SSR seeds) — Blade and Twig (PHP) and Xslate and Mojolicious (Perl, via the shared `BarefootJS.pm` runtime) already picked up the shared-layer `freeIdentifiers()` fix from the original #2260 landing; their `toggle`/`switch`/`checkbox` `skipDataPoints` pins were simply never removed. Verified against real conformance runs — no code changes needed for this part.
+- **#2261** (dynamic style value sanitization) — Xslate's `style-object-dynamic` pin was likewise a leftover: the adapter and shared Perl runtime were already fixed when #2261 landed across all 8 adapters, but this one pin was missed.
+- **#2262** (`.flat(dynamicDepth)` stringification) — Mojolicious's `.join()` lowering called Perl's native `join()` builtin directly on the dereferenced array, bypassing the shared runtime's `join` method entirely; a nested-array element (e.g. `.flat(0)`'s shallow copy) stringified to its Perl memory address (`ARRAY(0x...)`) instead of JS's recursive comma-join. Now routes through `bf->join(...)`, matching Xslate's existing `$bf.join(...)` routing. The shared Perl runtime's own `string()`/`join()` methods also gained the same recursive-array-stringification fix Go/ERB already had (`.flat`'s shallow copy stringified via `Array.prototype.toString`'s `join(',')` semantics, applied recursively), since neither previously handled a nested ARRAY-ref element at all.
+
+Removes every remaining `toggle:gen:pressed:true` / `switch:gen:checked:true` / `checkbox:gen:checked:true` / `style-object-dynamic:gen:color:markup` / `array-flat-dynamic-depth:gen:depth:zero` / `array-flat-dynamic-depth:gen:depth:negative` pin across the four adapters — all four `skipDataPoints` sets are now empty.

--- a/packages/adapter-blade/src/__tests__/blade-adapter.test.ts
+++ b/packages/adapter-blade/src/__tests__/blade-adapter.test.ts
@@ -50,13 +50,7 @@ runAdapterConformanceTests({
     // Same `/* @client */` keyed-map elision (data-table).
     'data-table',
   ]),
-  skipDataPoints: new Set<string>([
-    // #2260 — controlled boolean props: the SSR seed evaluates only the
-    // static fallback of `props.X ?? internal()` chains.
-    'toggle:gen:pressed:true',
-    'switch:gen:checked:true',
-    'checkbox:gen:checked:true',
-  ]),
+  skipDataPoints: new Set<string>(),
   onRenderError: (err, id) => {
     if (err instanceof BladeNotAvailableError) {
       console.log(`Skipping [${id}]: ${err.message}`)

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -59,17 +59,7 @@ runAdapterConformanceTests({
     // #1467 Phase 2e: same `/* @client */` keyed-map elision (data-table).
     'data-table',
   ]),
-  skipDataPoints: new Set<string>([
-    // #2260 — controlled boolean props: the SSR seed evaluates only the
-    // static fallback of `props.X ?? internal()` chains.
-    'toggle:gen:pressed:true',
-    'switch:gen:checked:true',
-    'checkbox:gen:checked:true',
-    // #2262 — dynamic `.flat` depth 0/negative violates the documented
-    // shallow-copy contract.
-    'array-flat-dynamic-depth:gen:depth:zero',
-    'array-flat-dynamic-depth:gen:depth:negative',
-  ]),
+  skipDataPoints: new Set<string>(),
   onRenderError: (err, id) => {
     if (err instanceof PerlNotAvailableError) {
       console.log(`Skipping [${id}]: ${err.message}`)
@@ -915,7 +905,7 @@ export function C() {
     // filter, `.join`) hit a separate refusal gate and the chain
     // emitted BF101 — making the scaffold `<Button>` / `<Card>`
     // unusable on Mojo. The fix lowers all three to Embedded Perl
-    // (`join(' ', @{[grep { $_ } @{[...]}]})`), unblocking the
+    // (`bf->join([grep { $_ } @{[...]}], ' ')`), unblocking the
     // registry surface. The #1421 recursion guard stays in place
     // as defence in depth for other unsupported shapes, but this
     // specific chain no longer reaches the loop because the parser
@@ -938,7 +928,7 @@ export { Slot }
     )
     expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
     const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
-    expect(template).toContain(`join(' ', @{[grep { $_ } @{[$className]}]})`)
+    expect(template).toContain(`bf->join([grep { $_ } @{[$className]}], ' ')`)
   })
 
   test('lowers .includes(x) on an array prop via bf->includes(...) (#1448 Tier A)', () => {
@@ -1168,7 +1158,7 @@ export { A }`, 'A.tsx', { adapter })
 export { A }`, 'A.tsx', { adapter })
     expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
     const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
-    expect(template).toContain("join(' ', @{bf->reverse($items)})")
+    expect(template).toContain("bf->join(bf->reverse($items), ' ')")
     expect(template).not.toContain('$bf->reverse')
   })
 
@@ -1180,7 +1170,7 @@ export { A }`, 'A.tsx', { adapter })
 export { A }`, 'A.tsx', { adapter })
     expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
     const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
-    expect(template).toContain("join(' ', @{bf->reverse($items)})")
+    expect(template).toContain("bf->join(bf->reverse($items), ' ')")
   })
 
   test('lowers .slice(start, end).join(\' \') via bf->slice + join (#1448 Tier A)', () => {
@@ -1192,7 +1182,7 @@ export { A }`, 'A.tsx', { adapter })
 export { A }`, 'A.tsx', { adapter })
     expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
     const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
-    expect(template).toContain("join(' ', @{bf->slice($items, 1, 3)})")
+    expect(template).toContain("bf->join(bf->slice($items, 1, 3), ' ')")
     expect(template).not.toContain('$bf->slice')
   })
 
@@ -1206,7 +1196,7 @@ export { A }`, 'A.tsx', { adapter })
 export { A }`, 'A.tsx', { adapter })
     expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
     const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
-    expect(template).toContain("join(' ', @{bf->slice($items, 2, undef)})")
+    expect(template).toContain("bf->join(bf->slice($items, 2, undef), ' ')")
   })
 
   test('lowers .concat(other).join(\' \') via bf->concat + join (#1448 Tier A)', () => {
@@ -1222,7 +1212,7 @@ export { A }`, 'A.tsx', { adapter })
 export { A }`, 'A.tsx', { adapter })
     expect(result.errors?.filter(e => e.code === 'BF101') ?? []).toEqual([])
     const template = result.files.find(f => f.path.endsWith('.html.ep'))?.content ?? ''
-    expect(template).toContain("join(' ', @{bf->concat($left, $right)})")
+    expect(template).toContain("bf->join(bf->concat($left, $right), ' ')")
     expect(template).not.toContain('$bf->concat')
   })
 
@@ -1484,10 +1474,10 @@ describe('MojoAdapter - #1448 Tier A/B fixture-driven lowering pins', () => {
     { fixture: arraySliceFixture,       expect: 'bf->slice($items, 1, 3)' },
     // #1448 full-arity — zero-arg defaults.
     { fixture: arraySliceCopyFixture,   expect: 'bf->slice($items, 0, undef)' },
-    { fixture: arrayJoinDefaultFixture, expect: `join(',', @{$items})` },
+    { fixture: arrayJoinDefaultFixture, expect: `bf->join($items, ',')` },
     // `.at()` → index 0; `.concat()` → the receiver (shallow copy).
     { fixture: arrayAtDefaultFixture,   expect: 'bf->at($items, 0)' },
-    { fixture: arrayConcatCopyFixture,  expect: `join('|', @{$items})` },
+    { fixture: arrayConcatCopyFixture,  expect: `bf->join($items, '|')` },
     { fixture: arrayReverseFixture,     expect: 'bf->reverse($items)' },
     // .toReversed shares the helper with .reverse — pinning both
     // routings catches a future divergence between them.
@@ -1497,7 +1487,7 @@ describe('MojoAdapter - #1448 Tier A/B fixture-driven lowering pins', () => {
     { fixture: stringTrimFixture,       expect: 'bf->trim($value)' },
     // #1448 Tier B — string → array. `.split(',')` lowers to
     // `bf->split`, here chained into `.join('|')` so the array ref is
-    // observable (`join('|', @{bf->split($value, ',')})`).
+    // observable (`bf->join(bf->split($value, ','), '|')`).
     { fixture: stringSplitFixture,      expect: `bf->split($value, ',')` },
     { fixture: stringSplitLimitFixture, expect: `bf->split($value, ',', 2)` },
     // #1448 Tier B — string → boolean at condition position (`% if`).
@@ -1687,7 +1677,7 @@ export { C }
   // projects each element (no flatten) and composes through `.join`.
   test('.map(t => `#${t}`).join(" ") emits bf->map_eval composed into join', () => {
     const t = emitMap("tags.map(t => `#${t}`).join(' ')")
-    expect(t).toContain(`join(' ', @{bf->map_eval($tags,`)
+    expect(t).toContain(`bf->join(bf->map_eval($tags,`)
     expect(t).toContain(`"kind":"template-literal"`)
   })
 

--- a/packages/adapter-mojolicious/src/adapter/expr/array-method.ts
+++ b/packages/adapter-mojolicious/src/adapter/expr/array-method.ts
@@ -35,14 +35,20 @@ export function renderArrayMethod(
 ): string {
   switch (method) {
     case 'join': {
-      // arr.join(sep) → join(sep, @{arr}). The default `${obj}->{join}`
-      // hash-lookup fallback would emit invalid Perl, which is why the
-      // IR carves out a dedicated method node instead of routing
-      // through the generic call dispatcher. `.join()` defaults the
-      // separator to `,` (JS) and ignores any extra argument.
+      // arr.join(sep) → bf->join(arr, sep), NOT Perl's native `join`
+      // builtin directly on `@{arr}` — a nested-array element (e.g.
+      // `.flat(0)`'s shallow copy) would stringify to its Perl memory
+      // address ("ARRAY(0x...)") under native `join`'s scalar coercion
+      // instead of JS's recursive comma-join (#2262/#2272). `bf->join`
+      // (BarefootJS.pm) routes each element through `string()` first.
+      // The default `${obj}->{join}` hash-lookup fallback would emit
+      // invalid Perl, which is why the IR carves out a dedicated method
+      // node instead of routing through the generic call dispatcher.
+      // `.join()` defaults the separator to `,` (JS) and ignores any
+      // extra argument.
       const obj = emit(object)
       const sep = args.length >= 1 ? emit(args[0]) : `','`
-      return `join(${sep}, @{${obj}})`
+      return `bf->join(${obj}, ${sep})`
     }
     case 'includes': {
       // Both `arr.includes(x)` and `str.includes(sub)` route here —

--- a/packages/adapter-mojolicious/src/conformance-pins.ts
+++ b/packages/adapter-mojolicious/src/conformance-pins.ts
@@ -88,7 +88,7 @@ export const conformancePins: ConformancePins = {
   // below for the shared `/* @client */` keyed-map slot-id elision
   // contract (same as `todo-app`), not a render or BF101 gap.
   // #1443: `[a, b].filter(Boolean).join(' ')` (the registry Slot's
-  // shape) now lowers to `join(' ', @{[grep { $_ } @{[$a, $b]}]})`.
+  // shape) now lowers to `bf->join([grep { $_ } @{[$a, $b]}], ' ')`.
   // No BF101 expected — pinned positively via the
   // `branch-local-filter-join` template-output test below.
   //

--- a/packages/adapter-perl/lib/BarefootJS.pm
+++ b/packages/adapter-perl/lib/BarefootJS.pm
@@ -583,7 +583,15 @@ sub string ($self, $value) {
     # an unset prop doesn't surface as a literal "undefined" / "null"
     # in user-facing HTML — same divergence the Go adapter documents
     # for `bf_string`.
-    return defined $value ? "$value" : '';
+    return '' unless defined $value;
+    # JS `Array.prototype.toString` is `this.join(',')`, applied
+    # recursively — a bare `"$value"` interpolation would otherwise
+    # stringify an ARRAY ref as its Perl memory address
+    # ("ARRAY(0x...)") instead of the JS comma-join. Reached via
+    # `.flat(0)`'s shallow copy stringified afterwards (#2262, shared
+    # with Mojolicious/Xslate via this runtime).
+    return CORE::join(',', map { $self->string($_) } @$value) if ref($value) eq 'ARRAY';
+    return "$value";
 }
 
 sub number ($self, $value) {
@@ -755,7 +763,11 @@ sub uc ($self, $s) { return defined $s ? CORE::uc($s) : '' }
 sub join ($self, $recv, $sep = undef) {
     return '' unless ref($recv) eq 'ARRAY';
     $sep //= ',';
-    return CORE::join($sep, map { defined $_ ? $_ : '' } @$recv);
+    # Each element routes through `string()` (JS `String(v)`), not a bare
+    # defined-check, so a nested-array element (e.g. `.flat(0)`'s shallow
+    # copy, #2262) gets the recursive JS comma-join instead of stringifying
+    # to a Perl ARRAY ref's memory address.
+    return CORE::join($sep, map { $self->string($_) } @$recv);
 }
 
 # `.length` — JS works on BOTH arrays (element count) and strings; Kolon's

--- a/packages/adapter-twig/src/__tests__/twig-adapter.test.ts
+++ b/packages/adapter-twig/src/__tests__/twig-adapter.test.ts
@@ -50,13 +50,7 @@ runAdapterConformanceTests({
     // Same `/* @client */` keyed-map elision (data-table).
     'data-table',
   ]),
-  skipDataPoints: new Set<string>([
-    // #2260 — controlled boolean props: the SSR seed evaluates only the
-    // static fallback of `props.X ?? internal()` chains.
-    'toggle:gen:pressed:true',
-    'switch:gen:checked:true',
-    'checkbox:gen:checked:true',
-  ]),
+  skipDataPoints: new Set<string>(),
   onRenderError: (err, id) => {
     if (err instanceof TwigNotAvailableError) {
       console.log(`Skipping [${id}]: ${err.message}`)

--- a/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
+++ b/packages/adapter-xslate/src/__tests__/xslate-adapter.test.ts
@@ -63,20 +63,7 @@ runAdapterConformanceTests({
     // #1467 Phase 2e: same `/* @client */` keyed-map elision (data-table).
     'data-table',
   ]),
-  skipDataPoints: new Set<string>([
-    // #2260 — controlled boolean props: the SSR seed evaluates only the
-    // static fallback of `props.X ?? internal()` chains.
-    'toggle:gen:pressed:true',
-    'switch:gen:checked:true',
-    'checkbox:gen:checked:true',
-    // #2261 — invalid dynamic CSS value kept (escaped) where the oracle
-    // drops the property.
-    'style-object-dynamic:gen:color:markup',
-    // #2262 — dynamic `.flat` depth 0/negative violates the documented
-    // shallow-copy contract (shared with the Mojo Perl runtime).
-    'array-flat-dynamic-depth:gen:depth:zero',
-    'array-flat-dynamic-depth:gen:depth:negative',
-  ]),
+  skipDataPoints: new Set<string>(),
   onRenderError: (err, id) => {
     if (err instanceof XslateNotAvailableError) {
       console.log(`Skipping [${id}]: ${err.message}`)


### PR DESCRIPTION
## Summary

- **#2260** (controlled/derived boolean SSR seeds) — Blade, Twig, and Xslate's `toggle`/`switch`/`checkbox` `skipDataPoints` pins were pure leftovers: the shared-layer fix already landed and these pins were simply never removed. Verified via real conformance runs before deleting; no code changes needed.
- **#2261** (dynamic style value sanitization) — Xslate's `style-object-dynamic` pin was likewise a leftover from the original #2261 landing (which covered all 8 adapters, but missed removing this one test pin).
- **#2262** (`.flat(dynamicDepth)` stringification) — Mojolicious's pins were a **real gap**: its `.join()` lowering called Perl's native `join()` builtin directly on the dereferenced array, bypassing the shared `BarefootJS.pm` runtime's own `join()` method entirely. A nested-array element (e.g. `.flat(0)`'s shallow copy) stringified to its Perl memory address (`ARRAY(0x...)`) instead of JS's recursive comma-join. Now routes through `bf->join(...)`, matching Xslate's existing `$bf.join(...)` routing. The shared Perl runtime's `string()`/`join()` methods also gained the recursive-array-stringification fix Go/ERB already carry for #2262.

Updated ~8 pinned-string test assertions in `mojo-adapter.test.ts` that asserted the old `join(sep, @{...})` codegen shape.

All four adapters' `skipDataPoints` sets are now empty.

## Test plan

- [x] `bun test packages/adapter-blade`, `packages/adapter-twig`, `packages/adapter-xslate`, `packages/adapter-mojolicious` (full package suites) — all clean
- [x] Perl core suite (`prove -lv t/`, 475 tests) — clean
- [x] Confirmed Mojolicious's flat-depth data points actually failed before the fix (`ARRAY(0x...)` in rendered output) and pass after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011XwkcCbAxUwzWGaa8j3MZQ)_