### PR TITLE
Fix #2273: refuse method calls on host rich-typed props (BF021)

### DIFF
--- a/.changeset/close-date-passthrough-refusal.md
+++ b/.changeset/close-date-passthrough-refusal.md
@@ -1,0 +1,14 @@
+---
+"@barefootjs/jsx": minor
+---
+
+Fix #2273: refuse a method call on a prop typed as a built-in host rich type (`Date`, `Map`, `Set`, `URL`, …) with no catalogued lowering, instead of silently transliterating it into template syntax that dies at request time.
+
+`Date` props (and the other host rich types) previously lowered as an opaque passthrough: `createdAt.toISOString()` compiled cleanly and rendered correctly on Hono/CSR, but on the SSR text-template adapters transliterated verbatim into the target syntax (a Go template method-value panic, a Jinja `AttributeError`, …) — a failure only visible once someone actually rendered the page. `checkRichTypeMethodCalls` (`packages/jsx/src/rich-type-refusal.ts`) closes that gap at compile time: it walks every expression position the compiler already lowers into a template and refuses with BF021 as soon as a call's receiver is provably a host rich type (`Date`, `Map`, `Set`, `WeakMap`, `WeakSet`, `URL`, `URLSearchParams`, `RegExp`, `Promise`, `Error`, `Symbol`, `BigInt`, `Function`) with no catalogued lowering. Verified against the full 2500+-unit `packages/jsx` suite and the `ui/components` corpus with zero false positives — the refusal only fires when `rich-type-evidence.ts`'s type resolution can *prove* the receiver's type from `propsType`/`typeDefinitions`; any receiver it can't prove a type for (signal getter results, untyped/generic receivers, computed access, …) is silently allowed through, matching the existing BF021 filter/sort-comparator refusal's conservative-by-construction design.
+
+Two exemptions keep the escape hatches intact:
+
+- `/* @client */` opts the expression out of SSR lowering, same as every other BF021 shape.
+- A call a registered lowering plugin claims (`lowering-registry.ts`, #2057) is exempt — cataloguing an individual rich-type API (e.g. `Date.prototype.toISOString`) is a plugin's job, not a change to this refusal. That catalogue is tracked separately as #2274.
+
+All nine adapters' `conformance-pins.ts` now pin the new `date-method-uncatalogued` fixture to `{ code: 'BF021', severity: 'error' }` — including Hono, since the refusal runs ahead of `adapter.generate()` and applies even to adapters whose own runtime could otherwise evaluate the call.

--- a/.changeset/close-date-passthrough-refusal.md
+++ b/.changeset/close-date-passthrough-refusal.md
@@ -1,5 +1,14 @@
 ---
 "@barefootjs/jsx": minor
+"@barefootjs/hono": patch
+"@barefootjs/go-template": patch
+"@barefootjs/jinja": patch
+"@barefootjs/rust": patch
+"@barefootjs/twig": patch
+"@barefootjs/blade": patch
+"@barefootjs/erb": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
 ---
 
 Fix #2273: refuse a method call on a prop typed as a built-in host rich type (`Date`, `Map`, `Set`, `URL`, …) with no catalogued lowering, instead of silently transliterating it into template syntax that dies at request time.

--- a/docs/core/advanced/error-codes.md
+++ b/docs/core/advanced/error-codes.md
@@ -163,6 +163,42 @@ const byPrice = (a, b) => a.price - b.price
 ))}
 ```
 
+#### Host rich-typed prop method calls (#2273)
+
+**Trigger:** A method call on a prop provably typed as a built-in host rich
+type — `Date`, `Map`, `Set`, `WeakMap`, `WeakSet`, `URL`, `URLSearchParams`,
+`RegExp`, `Promise`, `Error`, `Symbol`, `BigInt`, `Function` — with no
+catalogued lowering.
+
+```tsx
+// ❌ BF021 — Date.prototype.toISOString has no catalogued lowering
+function Post({ createdAt }: { createdAt: Date }) {
+  return <div>{createdAt.toISOString()}</div>
+}
+```
+
+The receiver's type must be provable from the component's declared props
+(destructured prop, `props.x` member chain, loop item field, `Date | null`
+union) — an untyped, generic, or call-result receiver (`d().toISOString()`
+where `d` is a signal) has no evidence and is not flagged.
+
+#### Workaround
+
+```tsx
+// ✅ Defer to the client
+{/* @client */ createdAt.toISOString()}
+
+// ✅ Or pre-compute server-side
+function Post({ createdAt }: { createdAt: Date }) {
+  const iso = createdAt.toISOString()
+  return <div>{iso}</div>
+}
+```
+
+The `iso` variant works because the method call now happens in component-body
+scope (an init statement), not in a template-lowered position — the compiler
+never has to translate `.toISOString()` into the target template's syntax.
+
 ### BF023 — Missing Key in List
 
 **Trigger:** `.map()` loop without `key` prop.

--- a/docs/core/advanced/error-codes.md
+++ b/docs/core/advanced/error-codes.md
@@ -188,16 +188,18 @@ where `d` is a signal) has no evidence and is not flagged.
 // ✅ Defer to the client
 {/* @client */ createdAt.toISOString()}
 
-// ✅ Or pre-compute server-side
-function Post({ createdAt }: { createdAt: Date }) {
-  const iso = createdAt.toISOString()
-  return <div>{iso}</div>
+// ✅ Or format in the backend and pass a string prop
+function Post({ createdAt }: { createdAt: string }) {
+  return <div>{createdAt}</div>
 }
 ```
 
-The `iso` variant works because the method call now happens in component-body
-scope (an init statement), not in a template-lowered position — the compiler
-never has to translate `.toISOString()` into the target template's syntax.
+The string-prop variant moves the formatting to where full language power
+already exists — the backend that populates the template data (Go handler,
+Rails controller, …) formats the `Date` and passes the finished string. Note
+that a component-body local (`const iso = createdAt.toISOString()`) is NOT a
+workaround: it lowers to a template variable whose value the template
+backend cannot compute, and dies at render time the same way.
 
 ### BF023 — Missing Key in List
 

--- a/packages/adapter-blade/src/conformance-pins.ts
+++ b/packages/adapter-blade/src/conformance-pins.ts
@@ -86,4 +86,10 @@ export const conformancePins: ConformancePins = {
   // A dynamic/signal-derived value still refuses with BF101 — see the
   // `dangerous-inner-html-dynamic` fixture/pin below (tracked: #2215).
   'dangerous-inner-html-dynamic': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2215' }],
+  // #2273: a method call on a prop typed as a built-in host rich type
+  // (Date, Map, …) has no catalogued lowering in any adapter — this is a
+  // compiler-level refusal (`checkRichTypeMethodCalls`, wired ahead of
+  // `adapter.generate()`), not an adapter-specific gap, so it is pinned
+  // identically across every adapter package including Hono.
+  'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2273' }],
 }

--- a/packages/adapter-blade/src/conformance-pins.ts
+++ b/packages/adapter-blade/src/conformance-pins.ts
@@ -91,5 +91,5 @@ export const conformancePins: ConformancePins = {
   // compiler-level refusal (`checkRichTypeMethodCalls`, wired ahead of
   // `adapter.generate()`), not an adapter-specific gap, so it is pinned
   // identically across every adapter package including Hono.
-  'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2273' }],
+  'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2274' }],
 }

--- a/packages/adapter-erb/src/conformance-pins.ts
+++ b/packages/adapter-erb/src/conformance-pins.ts
@@ -103,4 +103,10 @@ export const conformancePins: ConformancePins = {
   // A dynamic/signal-derived value still refuses with BF101 — see the
   // `dangerous-inner-html-dynamic` fixture/pin below (tracked: #2215).
   'dangerous-inner-html-dynamic': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2215' }],
+  // #2273: a method call on a prop typed as a built-in host rich type
+  // (Date, Map, …) has no catalogued lowering in any adapter — this is a
+  // compiler-level refusal (`checkRichTypeMethodCalls`, wired ahead of
+  // `adapter.generate()`), not an adapter-specific gap, so it is pinned
+  // identically across every adapter package including Hono.
+  'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2273' }],
 }

--- a/packages/adapter-erb/src/conformance-pins.ts
+++ b/packages/adapter-erb/src/conformance-pins.ts
@@ -108,5 +108,5 @@ export const conformancePins: ConformancePins = {
   // compiler-level refusal (`checkRichTypeMethodCalls`, wired ahead of
   // `adapter.generate()`), not an adapter-specific gap, so it is pinned
   // identically across every adapter package including Hono.
-  'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2273' }],
+  'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2274' }],
 }

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -142,5 +142,5 @@ export const conformancePins: ConformancePins = {
   // compiler-level refusal (`checkRichTypeMethodCalls`, wired ahead of
   // `adapter.generate()`), not an adapter-specific gap, so it is pinned
   // identically across every adapter package including Hono.
-  'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2273' }],
+  'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2274' }],
 }

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -137,4 +137,10 @@ export const conformancePins: ConformancePins = {
   // A dynamic/signal-derived value still refuses with BF101 — see the
   // `dangerous-inner-html-dynamic` fixture/pin below (tracked: #2215).
   'dangerous-inner-html-dynamic': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2215' }],
+  // #2273: a method call on a prop typed as a built-in host rich type
+  // (Date, Map, …) has no catalogued lowering in any adapter — this is a
+  // compiler-level refusal (`checkRichTypeMethodCalls`, wired ahead of
+  // `adapter.generate()`), not an adapter-specific gap, so it is pinned
+  // identically across every adapter package including Hono.
+  'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2273' }],
 }

--- a/packages/adapter-hono/src/conformance-pins.ts
+++ b/packages/adapter-hono/src/conformance-pins.ts
@@ -1,13 +1,18 @@
 /**
  * Per-fixture build-time contracts for shapes the Hono adapter
  * intentionally refuses to lower. Hono's SSR runtime is JS — its
- * `acceptsTemplateCall` is broad enough to cover every conformance case,
- * so this adapter currently has no pins. Kept as a module (rather than
- * omitted) for uniformity with the other 7 adapter packages: consumed by
- * this package's own conformance test (as `expectedDiagnostics`) and by
- * `bf compat` (issue-URL attribution).
+ * `acceptsTemplateCall` is broad enough to cover every adapter-specific
+ * lowering gap, so this package's only pin is the one refusal that is
+ * NOT adapter-specific: a method call on a host rich-typed prop (Date,
+ * Map, …) with no catalogued lowering refuses with BF021 at the
+ * compiler layer (`checkRichTypeMethodCalls`), ahead of and independent
+ * of `adapter.generate()` — even Hono's native JS evaluation never sees
+ * the call (#2273). Consumed by this package's own conformance test (as
+ * `expectedDiagnostics`) and by `bf compat` (issue-URL attribution).
  */
 
 import type { ConformancePins } from '@barefootjs/jsx'
 
-export const conformancePins: ConformancePins = {}
+export const conformancePins: ConformancePins = {
+  'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2273' }],
+}

--- a/packages/adapter-hono/src/conformance-pins.ts
+++ b/packages/adapter-hono/src/conformance-pins.ts
@@ -14,5 +14,5 @@
 import type { ConformancePins } from '@barefootjs/jsx'
 
 export const conformancePins: ConformancePins = {
-  'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2273' }],
+  'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2274' }],
 }

--- a/packages/adapter-jinja/src/conformance-pins.ts
+++ b/packages/adapter-jinja/src/conformance-pins.ts
@@ -103,4 +103,10 @@ export const conformancePins: ConformancePins = {
   // A dynamic/signal-derived value still refuses with BF101 — see the
   // `dangerous-inner-html-dynamic` fixture/pin below (tracked: #2215).
   'dangerous-inner-html-dynamic': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2215' }],
+  // #2273: a method call on a prop typed as a built-in host rich type
+  // (Date, Map, …) has no catalogued lowering in any adapter — this is a
+  // compiler-level refusal (`checkRichTypeMethodCalls`, wired ahead of
+  // `adapter.generate()`), not an adapter-specific gap, so it is pinned
+  // identically across every adapter package including Hono.
+  'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2273' }],
 }

--- a/packages/adapter-jinja/src/conformance-pins.ts
+++ b/packages/adapter-jinja/src/conformance-pins.ts
@@ -108,5 +108,5 @@ export const conformancePins: ConformancePins = {
   // compiler-level refusal (`checkRichTypeMethodCalls`, wired ahead of
   // `adapter.generate()`), not an adapter-specific gap, so it is pinned
   // identically across every adapter package including Hono.
-  'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2273' }],
+  'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2274' }],
 }

--- a/packages/adapter-mojolicious/src/conformance-pins.ts
+++ b/packages/adapter-mojolicious/src/conformance-pins.ts
@@ -144,5 +144,5 @@ export const conformancePins: ConformancePins = {
   // compiler-level refusal (`checkRichTypeMethodCalls`, wired ahead of
   // `adapter.generate()`), not an adapter-specific gap, so it is pinned
   // identically across every adapter package including Hono.
-  'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2273' }],
+  'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2274' }],
 }

--- a/packages/adapter-mojolicious/src/conformance-pins.ts
+++ b/packages/adapter-mojolicious/src/conformance-pins.ts
@@ -139,4 +139,10 @@ export const conformancePins: ConformancePins = {
   // A dynamic/signal-derived value still refuses with BF101 — see the
   // `dangerous-inner-html-dynamic` fixture/pin below (tracked: #2215).
   'dangerous-inner-html-dynamic': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2215' }],
+  // #2273: a method call on a prop typed as a built-in host rich type
+  // (Date, Map, …) has no catalogued lowering in any adapter — this is a
+  // compiler-level refusal (`checkRichTypeMethodCalls`, wired ahead of
+  // `adapter.generate()`), not an adapter-specific gap, so it is pinned
+  // identically across every adapter package including Hono.
+  'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2273' }],
 }

--- a/packages/adapter-rust/src/conformance-pins.ts
+++ b/packages/adapter-rust/src/conformance-pins.ts
@@ -103,4 +103,10 @@ export const conformancePins: ConformancePins = {
   // A dynamic/signal-derived value still refuses with BF101 — see the
   // `dangerous-inner-html-dynamic` fixture/pin below (tracked: #2215).
   'dangerous-inner-html-dynamic': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2215' }],
+  // #2273: a method call on a prop typed as a built-in host rich type
+  // (Date, Map, …) has no catalogued lowering in any adapter — this is a
+  // compiler-level refusal (`checkRichTypeMethodCalls`, wired ahead of
+  // `adapter.generate()`), not an adapter-specific gap, so it is pinned
+  // identically across every adapter package including Hono.
+  'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2273' }],
 }

--- a/packages/adapter-rust/src/conformance-pins.ts
+++ b/packages/adapter-rust/src/conformance-pins.ts
@@ -108,5 +108,5 @@ export const conformancePins: ConformancePins = {
   // compiler-level refusal (`checkRichTypeMethodCalls`, wired ahead of
   // `adapter.generate()`), not an adapter-specific gap, so it is pinned
   // identically across every adapter package including Hono.
-  'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2273' }],
+  'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2274' }],
 }

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -1458,6 +1458,17 @@
         "text"
       ]
     },
+    "date-method-uncatalogued": {
+      "kinds": [
+        "call",
+        "identifier",
+        "member"
+      ],
+      "axes": [],
+      "contexts": [
+        "text"
+      ]
+    },
     "deep-nesting": {
       "kinds": [
         "call",
@@ -4051,13 +4062,13 @@
     "array-method": 62,
     "arrow": 55,
     "binary": 67,
-    "call": 155,
+    "call": 156,
     "conditional": 18,
-    "identifier": 233,
+    "identifier": 234,
     "index-access": 12,
     "literal": 194,
     "logical": 41,
-    "member": 115,
+    "member": 116,
     "object-literal": 41,
     "template-literal": 27,
     "unary": 22,

--- a/packages/adapter-tests/fixtures/date-method-uncatalogued.ts
+++ b/packages/adapter-tests/fixtures/date-method-uncatalogued.ts
@@ -1,0 +1,21 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A method call on a `Date`-typed prop with no catalogued lowering
+ * (`toLocaleDateString` — locale/format-argument formatting stays
+ * permanently uncatalogued; #2273). Every adapter shares the same
+ * compiler-level BF021 refusal ahead of `adapter.generate()`, so this
+ * fixture is pinned identically across all nine adapters' own
+ * `conformance-pins.ts` (including Hono, whose real-JS runtime could
+ * otherwise evaluate the call) rather than being adapter-specific.
+ */
+export const fixture = createFixture({
+  id: 'date-method-uncatalogued',
+  description: 'Method call on a Date-typed prop refuses with BF021 (no catalogued lowering)',
+  source: `
+export function DateMethodUncatalogued({ createdAt }: { createdAt: Date }) {
+  return <div>{createdAt.toLocaleDateString()}</div>
+}
+`,
+  props: { createdAt: '2024-01-01T00:00:00.000Z' },
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -384,6 +384,7 @@ import { fixture as filterParamNameDiffers } from './filter-param-name-differs'
 // object const; every Twig-family adapter used to bake the const's
 // literal into each iteration instead of reading the loop's own item.
 import { fixture as loopParamShadowsRecordConst } from './loop-param-shadows-record-const'
+import { fixture as dateMethodUncatalogued } from './date-method-uncatalogued'
 
 import type { JSXFixture } from '../src/types'
 
@@ -663,4 +664,5 @@ export const jsxFixtures: JSXFixture[] = [
   filterWrapperPropsReachable,
   filterParamNameDiffers,
   loopParamShadowsRecordConst,
+  dateMethodUncatalogued,
 ]

--- a/packages/adapter-tests/scripts/generate-expected-html.ts
+++ b/packages/adapter-tests/scripts/generate-expected-html.ts
@@ -8,6 +8,7 @@
  */
 
 import { HonoAdapter } from '@barefootjs/hono/adapter'
+import { conformancePins as honoConformancePins } from '@barefootjs/hono'
 import { renderHonoComponent } from '@barefootjs/hono/test-render'
 import { normalizeHTML } from '../src/jsx-runner'
 import { indentHTML } from '../src/indent-html'
@@ -71,6 +72,14 @@ async function main() {
     }
     if (SKIP_AUTO_UPDATE.has(fixture.id)) {
       console.log(`⚠ Skipped (hand-curated): ${fixture.id}`)
+      skipped++
+      continue
+    }
+    // A fixture the REFERENCE adapter refuses at compile time has no
+    // renderable HTML to generate — its contract is the diagnostic,
+    // asserted by the conformance runner's expectedDiagnostics path.
+    if (honoConformancePins[fixture.id]?.length) {
+      console.log(`⚠ Skipped (diagnostics-pinned on the reference adapter): ${fixture.id}`)
       skipped++
       continue
     }

--- a/packages/adapter-twig/src/conformance-pins.ts
+++ b/packages/adapter-twig/src/conformance-pins.ts
@@ -86,4 +86,10 @@ export const conformancePins: ConformancePins = {
   // A dynamic/signal-derived value still refuses with BF101 — see the
   // `dangerous-inner-html-dynamic` fixture/pin below (tracked: #2215).
   'dangerous-inner-html-dynamic': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2215' }],
+  // #2273: a method call on a prop typed as a built-in host rich type
+  // (Date, Map, …) has no catalogued lowering in any adapter — this is a
+  // compiler-level refusal (`checkRichTypeMethodCalls`, wired ahead of
+  // `adapter.generate()`), not an adapter-specific gap, so it is pinned
+  // identically across every adapter package including Hono.
+  'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2273' }],
 }

--- a/packages/adapter-twig/src/conformance-pins.ts
+++ b/packages/adapter-twig/src/conformance-pins.ts
@@ -91,5 +91,5 @@ export const conformancePins: ConformancePins = {
   // compiler-level refusal (`checkRichTypeMethodCalls`, wired ahead of
   // `adapter.generate()`), not an adapter-specific gap, so it is pinned
   // identically across every adapter package including Hono.
-  'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2273' }],
+  'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2274' }],
 }

--- a/packages/adapter-xslate/src/conformance-pins.ts
+++ b/packages/adapter-xslate/src/conformance-pins.ts
@@ -118,5 +118,5 @@ export const conformancePins: ConformancePins = {
   // compiler-level refusal (`checkRichTypeMethodCalls`, wired ahead of
   // `adapter.generate()`), not an adapter-specific gap, so it is pinned
   // identically across every adapter package including Hono.
-  'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2273' }],
+  'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2274' }],
 }

--- a/packages/adapter-xslate/src/conformance-pins.ts
+++ b/packages/adapter-xslate/src/conformance-pins.ts
@@ -113,4 +113,10 @@ export const conformancePins: ConformancePins = {
   // A dynamic/signal-derived value still refuses with BF101 — see the
   // `dangerous-inner-html-dynamic` fixture/pin below (tracked: #2215).
   'dangerous-inner-html-dynamic': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2215' }],
+  // #2273: a method call on a prop typed as a built-in host rich type
+  // (Date, Map, …) has no catalogued lowering in any adapter — this is a
+  // compiler-level refusal (`checkRichTypeMethodCalls`, wired ahead of
+  // `adapter.generate()`), not an adapter-specific gap, so it is pinned
+  // identically across every adapter package including Hono.
+  'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2273' }],
 }

--- a/packages/jsx/src/__tests__/rich-type-method-refusal.test.ts
+++ b/packages/jsx/src/__tests__/rich-type-method-refusal.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Rich-type method-call refusal (BF021, #2273).
+ *
+ * A method call on a prop typed as a built-in host rich type (`Date`,
+ * `Map`, …) has no catalogued lowering in any adapter — left unchecked it
+ * transliterates into the target template's own syntax and dies at request
+ * time. `checkRichTypeMethodCalls` (rich-type-refusal.ts) is wired into
+ * `compileJSX` (not the bare analyzer/jsxToIR pipeline other BF021 tests in
+ * this directory use), so these tests go through `compileJSX` directly.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { ErrorCodes } from '../errors'
+import { TestAdapter } from '../adapters/test-adapter'
+import { registerLoweringPlugin, __resetLoweringPluginsForTest, getLoweringPlugins, type LoweringPlugin } from '../lowering-registry'
+
+const adapter = new TestAdapter()
+
+function bf021(source: string, filePath = 'Test.tsx') {
+  const result = compileJSX(source, filePath, { adapter })
+  return result.errors.filter((e) => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+}
+
+describe('rich-type method-call refusal — fires (BF021)', () => {
+  test('inline-destructured Date in text position', () => {
+    const errors = bf021(`
+      export function Foo({ createdAt }: { createdAt: Date }) {
+        return <div>{createdAt.toISOString()}</div>
+      }
+    `)
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toContain("'.toISOString()'")
+    expect(errors[0].message).toContain("'createdAt'")
+    expect(errors[0].message).toContain("'Date'")
+  })
+
+  test('props-object member chain in attribute position', () => {
+    const errors = bf021(`
+      export function Foo(props: { d: Date }) {
+        return <div data-year={props.d.getUTCFullYear()} />
+      }
+    `)
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toContain("'.getUTCFullYear()'")
+    expect(errors[0].message).toContain("'props.d'")
+    expect(errors[0].message).toContain("'Date'")
+  })
+
+  test('named interface Props Date field (typeDefinitions deref)', () => {
+    const errors = bf021(`
+      interface Props { createdAt: Date }
+      export function Foo({ createdAt }: Props) {
+        return <div>{createdAt.getFullYear()}</div>
+      }
+    `)
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toContain("'.getFullYear()'")
+    expect(errors[0].message).toContain("'createdAt'")
+    expect(errors[0].message).toContain("'Date'")
+  })
+
+  test('optional-chained call', () => {
+    const errors = bf021(`
+      export function Foo({ d }: { d: Date | undefined }) {
+        return <div>{d?.toISOString()}</div>
+      }
+    `)
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toContain("'.toISOString()'")
+  })
+
+  test('Date | null union resolves to Date', () => {
+    const errors = bf021(`
+      export function Foo({ d }: { d: Date | null }) {
+        return <div>{d.toISOString()}</div>
+      }
+    `)
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toContain("'Date'")
+  })
+
+  test('loop-item member (items.map(i => i.at.getTime()))', () => {
+    const errors = bf021(`
+      export function Foo({ items }: { items: { at: Date }[] }) {
+        return <ul>{items.map(i => <li>{i.at.getTime()}</li>)}</ul>
+      }
+    `)
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toContain("'.getTime()'")
+    expect(errors[0].message).toContain("'i.at'")
+    expect(errors[0].message).toContain("'Date'")
+  })
+
+  test('Date in component-prop position', () => {
+    const errors = bf021(`
+      function Bar(props: { value: string }) {
+        return <div>{props.value}</div>
+      }
+      export function Foo({ createdAt }: { createdAt: Date }) {
+        return <Bar value={createdAt.toISOString()} />
+      }
+    `)
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toContain("'.toISOString()'")
+    expect(errors[0].message).toContain("'createdAt'")
+  })
+
+  test('Map.get() (broad host-type list)', () => {
+    const errors = bf021(`
+      export function Foo({ m }: { m: Map<string, string> }) {
+        return <div>{m.get('x')}</div>
+      }
+    `)
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toContain("'.get()'")
+    expect(errors[0].message).toContain("'Map'")
+  })
+
+  test('diagnostic carries the @client suggestion', () => {
+    const errors = bf021(`
+      export function Foo({ createdAt }: { createdAt: Date }) {
+        return <div>{createdAt.toISOString()}</div>
+      }
+    `)
+    expect(errors[0].severity).toBe('error')
+    expect(errors[0].suggestion?.message).toContain('@client')
+  })
+})
+
+describe('rich-type method-call refusal — silent (no BF021)', () => {
+  test('/* @client */-prefixed Date call', () => {
+    const errors = bf021(`
+      export function Foo({ createdAt }: { createdAt: Date }) {
+        return <div>{/* @client */ createdAt.toISOString()}</div>
+      }
+    `)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('string method on string prop', () => {
+    const errors = bf021(`
+      export function Foo({ s }: { s: string }) {
+        return <div>{s.toUpperCase()}</div>
+      }
+    `)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('array method on array prop', () => {
+    const errors = bf021(`
+      export function Foo({ items }: { items: string[] }) {
+        return <div>{items.join(',')}</div>
+      }
+    `)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('untyped receiver (no type annotation)', () => {
+    const errors = bf021(`
+      export function Foo({ d }) {
+        return <div>{d.toISOString()}</div>
+      }
+    `)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('generic type-parameter receiver', () => {
+    const errors = bf021(`
+      export function Foo<T>({ d }: { d: T }) {
+        return <div>{d.toISOString()}</div>
+      }
+    `)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('imported named type receiver', () => {
+    const errors = bf021(`
+      import type { Widget } from './widget'
+      export function Foo({ w }: { w: Widget }) {
+        return <div>{w.render()}</div>
+      }
+    `)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('signal getter call result (d().toISOString())', () => {
+    const errors = bf021(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Foo() {
+        const [d, setD] = createSignal(new Date())
+        return <div>{d().toISOString()}</div>
+      }
+    `)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('local-function call (not a member call on the receiver)', () => {
+    const errors = bf021(`
+      function formatDate(x: Date): string { return x.toString() }
+      export function Foo({ createdAt }: { createdAt: Date }) {
+        return <div>{formatDate(createdAt)}</div>
+      }
+    `)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('.length non-call access', () => {
+    const errors = bf021(`
+      export function Foo({ items }: { items: string[] }) {
+        return <div>{items.length}</div>
+      }
+    `)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('in-file interface Date shadow', () => {
+    const errors = bf021(`
+      interface Date { iso: string }
+      export function Foo({ d }: { d: Date }) {
+        return <div>{d.toISOString()}</div>
+      }
+    `)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('registry-claimed call is exempt (#2274 seam)', () => {
+    const samplePlugin: LoweringPlugin = {
+      name: 'sample-date-lowering',
+      prepare: () => (callee, _args) =>
+        callee.kind === 'member' && !callee.computed && callee.property === 'toISOString'
+          ? { kind: 'helper-call', helper: 'isoDate', args: [] }
+          : null,
+    }
+    registerLoweringPlugin(samplePlugin)
+    try {
+      const errors = bf021(`
+        export function Foo({ createdAt }: { createdAt: Date }) {
+          return <div>{createdAt.toISOString()}</div>
+        }
+      `)
+      expect(errors).toHaveLength(0)
+    } finally {
+      __resetLoweringPluginsForTest(getLoweringPlugins().filter((p) => p.name !== 'sample-date-lowering'))
+    }
+  })
+})

--- a/packages/jsx/src/__tests__/rich-type-method-refusal.test.ts
+++ b/packages/jsx/src/__tests__/rich-type-method-refusal.test.ts
@@ -88,8 +88,44 @@ describe('rich-type method-call refusal — fires (BF021)', () => {
     `)
     expect(errors).toHaveLength(1)
     expect(errors[0].message).toContain("'.getTime()'")
-    expect(errors[0].message).toContain("'i.at'")
+    // A loop item is prop-DERIVED but not itself a prop — the message must
+    // not call it one (only bare / props-object receivers earn "prop").
+    expect(errors[0].message).toContain("on 'i.at'")
+    expect(errors[0].message).not.toContain("prop 'i.at'")
     expect(errors[0].message).toContain("'Date'")
+  })
+
+  test('renamed destructured prop ({ createdAt: c })', () => {
+    const errors = bf021(`
+      export function Foo({ createdAt: c }: { createdAt: Date }) {
+        return <div>{c.toISOString()}</div>
+      }
+    `)
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toContain("'.toISOString()'")
+    expect(errors[0].message).toContain("prop 'c'")
+    expect(errors[0].message).toContain("'Date'")
+  })
+
+  test('conditional-branch call without @client', () => {
+    const errors = bf021(`
+      export function Foo({ d }: { d: Date | null }) {
+        return <div>{d && <span>{d.toISOString()}</span>}</div>
+      }
+    `)
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toContain("'.toISOString()'")
+  })
+
+  test('two distinct receivers at the same expression report separately', () => {
+    const errors = bf021(`
+      export function Foo({ a, b }: { a: Date; b: Date }) {
+        return <div>{a.getTime() + b.getTime()}</div>
+      }
+    `)
+    expect(errors).toHaveLength(2)
+    expect(errors[0].message).toContain("prop 'a'")
+    expect(errors[1].message).toContain("prop 'b'")
   })
 
   test('Date in component-prop position', () => {
@@ -133,6 +169,25 @@ describe('rich-type method-call refusal — silent (no BF021)', () => {
     const errors = bf021(`
       export function Foo({ createdAt }: { createdAt: Date }) {
         return <div>{/* @client */ createdAt.toISOString()}</div>
+      }
+    `)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('/* @client */-wrapped conditional branch', () => {
+    const errors = bf021(`
+      export function Foo({ d }: { d: Date | null }) {
+        return <div>{/* @client */ d && <span>{d.toISOString()}</span>}</div>
+      }
+    `)
+    expect(errors).toHaveLength(0)
+  })
+
+  test('module const sharing a propsType field name (object-props mode)', () => {
+    const errors = bf021(`
+      const version = 'v1'
+      export function Foo(props: { version: Map<string, string> }) {
+        return <div>{version.toUpperCase()}</div>
       }
     `)
     expect(errors).toHaveLength(0)

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -3068,6 +3068,8 @@ function extractProps(param: ts.ParameterDeclaration, ctx: AnalyzerContext): voi
           optional: !!member?.optional || !!element.initializer,
           defaultValue,
           defaultContainsArrow: defaultContainsArrow || undefined,
+          // Only aliased bindings carry the source key — see ParamInfo.sourceName.
+          ...(sourcePropName !== localName && { sourceName: sourcePropName }),
         })
       }
     }

--- a/packages/jsx/src/compiler.ts
+++ b/packages/jsx/src/compiler.ts
@@ -24,6 +24,7 @@ import { applyCssLayerPrefix } from './css-layer-prefixer.ts'
 import { preprocessInlineJsxCallbacks } from './preprocess-inline-jsx-callbacks.ts'
 import { extractSsrDefaults } from './ssr-defaults.ts'
 import { computeSsrSeedPlan } from './ssr-seed-plan.ts'
+import { checkRichTypeMethodCalls } from './rich-type-refusal.ts'
 
 /**
  * Extended compile options with required adapter
@@ -137,6 +138,7 @@ function compileMultipleComponents(
     }
 
     componentIR.metadata.clientAnalysis = analyzeClientNeeds(componentIR)
+    checkRichTypeMethodCalls(componentIR.root, componentIR.metadata, errors)
 
     if (options.cssLayerPrefix) {
       applyCssLayerPrefix(componentIR, options.cssLayerPrefix)
@@ -615,6 +617,7 @@ export function compileJSX(
 
   // Pre-compute client JS analysis for adapter optimization
   componentIR.metadata.clientAnalysis = analyzeClientNeeds(componentIR)
+  checkRichTypeMethodCalls(componentIR.root, componentIR.metadata, errors)
 
   // Cross-file @client signal sources: identify which import sources
   // need `.client.js` path rewriting in the client bundle.

--- a/packages/jsx/src/rich-type-evidence.ts
+++ b/packages/jsx/src/rich-type-evidence.ts
@@ -20,6 +20,17 @@ import type { ParsedExpr } from './expression-parser.ts'
  * this point — the adapters have no structural representation for `Date`,
  * `Map`, etc., only for the primitives/arrays/plain-objects the IR already
  * lowers. Names only (no generic args) — compare against `baseTypeName`.
+ *
+ * Two shapes deliberately escape this catalogue (conservative misses, not
+ * bugs — a miss only skips a refusal, never misdiagnoses):
+ *   - keyword-typed `bigint` / `symbol` annotations lower to
+ *     `{ kind: 'unknown' }` in `typeNodeToTypeInfo` (only the object-form
+ *     `BigInt` / `Symbol` type references reach `kind: 'interface'` and
+ *     match here);
+ *   - a local alias of a host type (`type Timestamp = Date`) resolves to
+ *     the alias NAME — `derefNamedType` only fills in `properties` from a
+ *     declaration, it never rewrites `raw` to the alias target — so the
+ *     catalogue lookup sees `Timestamp`, not `Date`.
  */
 export const HOST_RICH_TYPE_NAMES: ReadonlySet<string> = new Set([
   'Date',
@@ -48,7 +59,7 @@ export function baseTypeName(raw: string): string {
   return (idx === -1 ? raw : raw.slice(0, idx)).trim()
 }
 
-type EvidenceMetadata = Pick<IRMetadata, 'propsType' | 'propsObjectName' | 'typeDefinitions'>
+type EvidenceMetadata = Pick<IRMetadata, 'propsType' | 'propsObjectName' | 'propsParams' | 'typeDefinitions'>
 
 /**
  * Collapse a union to its single non-nullish arm (`Date | null` → `Date`),
@@ -107,11 +118,11 @@ function lookupProperty(objType: TypeInfo | null, propName: string, meta: Eviden
 
 /**
  * Resolve the TypeInfo of a receiver expression, using only propsType /
- * typeDefinitions and the caller-supplied local bindings. `bindings` maps a
- * name to its known type — or explicitly to `null` for a shadow the caller
- * has proven carries no evidence (e.g. an arrow param, a loop item whose
- * array type isn't known). A `bindings` hit always wins over the props
- * fallback, matching JS lexical shadowing.
+ * propsParams / typeDefinitions and the caller-supplied local bindings.
+ * `bindings` maps a name to its known type — or explicitly to `null` for a
+ * shadow the caller has proven carries no evidence (e.g. an arrow param, a
+ * loop item whose array type isn't known). A `bindings` hit always wins over
+ * the props fallback, matching JS lexical shadowing.
  *
  * Only two `ParsedExpr` shapes carry evidence: a bare identifier and a
  * non-computed member access. Everything else (calls, computed/index
@@ -124,8 +135,21 @@ export function resolveReceiverType(
 ): TypeInfo | null {
   if (expr.kind === 'identifier') {
     if (bindings.has(expr.name)) return stripUnion(bindings.get(expr.name) ?? null)
-    if (meta.propsObjectName !== null && expr.name === meta.propsObjectName) return stripUnion(meta.propsType)
-    return lookupProperty(meta.propsType, expr.name, meta)
+    if (meta.propsObjectName !== null) {
+      // Object-props mode: props are only reachable through the props object,
+      // so a bare identifier is never a prop — treating every name that
+      // happens to match a propsType field as one would misattribute module
+      // consts / imports that share a field's name.
+      return expr.name === meta.propsObjectName ? stripUnion(meta.propsType) : null
+    }
+    // Destructured mode: only a declared param binding is a prop (membership
+    // via propsParams, which carries LOCAL names — including rename targets).
+    // The TYPE must come from propsType.properties keyed by the SOURCE prop
+    // name: propsParams' own `type` degrades to `unknown` for non-primitive
+    // props (`collectMemberTypes`' primitives-only gate).
+    const param = meta.propsParams.find((p) => p.name === expr.name && !p.isRest)
+    if (!param) return null
+    return lookupProperty(meta.propsType, param.sourceName ?? param.name, meta)
   }
   if (expr.kind === 'member' && !expr.computed) {
     const objType = resolveReceiverType(expr.object, meta, bindings)

--- a/packages/jsx/src/rich-type-evidence.ts
+++ b/packages/jsx/src/rich-type-evidence.ts
@@ -1,0 +1,135 @@
+/**
+ * Type-evidence resolution for the rich-type method-call refusal (#2273).
+ *
+ * `resolveReceiverType` answers one question: "what TypeScript type, if any,
+ * does this `ParsedExpr` evaluate to?" — using only the structured metadata
+ * already collected at IR-build time (`propsType` / `typeDefinitions`), never
+ * a fresh type-checker pass. It is deliberately conservative: any receiver
+ * shape it doesn't recognize (a call result, computed access, a local not in
+ * `bindings`, …) resolves to `null` ("no evidence"), which the caller must
+ * treat as "don't flag" rather than "flag as unknown". A false negative here
+ * only misses a refusal; a false positive would incorrectly block valid code.
+ */
+
+import type { IRMetadata, PropertyInfo, TypeInfo } from './types.ts'
+import type { ParsedExpr } from './expression-parser.ts'
+
+/**
+ * Built-in JS/TS types whose instance methods have no catalogued lowering
+ * (spec/subset-conformance.md). A prop typed as one of these is opaque past
+ * this point — the adapters have no structural representation for `Date`,
+ * `Map`, etc., only for the primitives/arrays/plain-objects the IR already
+ * lowers. Names only (no generic args) — compare against `baseTypeName`.
+ */
+export const HOST_RICH_TYPE_NAMES: ReadonlySet<string> = new Set([
+  'Date',
+  'Map',
+  'Set',
+  'WeakMap',
+  'WeakSet',
+  'URL',
+  'URLSearchParams',
+  'RegExp',
+  'Promise',
+  'Error',
+  'Symbol',
+  'BigInt',
+  'Function',
+])
+
+/**
+ * Strip generic type arguments from a `TypeInfo.raw` string (`Map<string,
+ * string>` → `Map`) so a parametrized host type still matches the bare-name
+ * catalogue above. `raw` is source-verbatim (`typeNodeToTypeInfo`), so this
+ * is a plain substring split on the first `<` — not a type-syntax parse.
+ */
+export function baseTypeName(raw: string): string {
+  const idx = raw.indexOf('<')
+  return (idx === -1 ? raw : raw.slice(0, idx)).trim()
+}
+
+type EvidenceMetadata = Pick<IRMetadata, 'propsType' | 'propsObjectName' | 'typeDefinitions'>
+
+/**
+ * Collapse a union to its single non-nullish arm (`Date | null` → `Date`),
+ * recursively, so an optional rich-typed prop still carries evidence. A
+ * union with more than one non-nullish arm has no single answer and is left
+ * as-is (its `kind` is `'union'`, which never matches the `'interface'`
+ * check callers gate on).
+ */
+function isNullishArm(t: TypeInfo): boolean {
+  if (t.kind === 'primitive' && (t.primitive === 'null' || t.primitive === 'undefined')) return true
+  // `null` as a type annotation is a `ts.LiteralTypeNode` (not the
+  // `NullKeyword` `typeNodeToTypeInfo`'s primitive switch checks for), so it
+  // falls through to `{ kind: 'unknown', raw: 'null' }` there — a pre-existing
+  // gap in that shared helper, out of scope to fix here. Match on `raw` too
+  // so `Date | null` still strips down to `Date`.
+  return t.kind === 'unknown' && (t.raw === 'null' || t.raw === 'undefined')
+}
+
+function stripUnion(type: TypeInfo | null): TypeInfo | null {
+  if (!type || type.kind !== 'union' || !type.unionTypes) return type
+  const nonNullish = type.unionTypes.filter((t) => !isNullishArm(t))
+  return nonNullish.length === 1 ? stripUnion(nonNullish[0]) : type
+}
+
+/**
+ * Resolve a named type (`{ kind: 'interface', raw: 'Props' }`) that carries
+ * no inline `properties` to its declaration's field list via
+ * `metadata.typeDefinitions`. A type already carrying properties (an inline
+ * object literal type, or a type resolved from `tsTypeToTypeInfo`) is
+ * returned unchanged — this only fills in the gap left by a *named*
+ * reference, which `typeNodeToTypeInfo` intentionally resolves to
+ * `{ kind: 'interface', raw }` with no member walk of its own.
+ */
+function derefNamedType(type: TypeInfo, meta: EvidenceMetadata): TypeInfo {
+  if (type.kind !== 'interface') return type
+  if (type.properties && type.properties.length > 0) return type
+  const name = baseTypeName(type.raw)
+  const def = meta.typeDefinitions.find((d) => d.name === name)
+  if (!def?.properties) return type
+  return { ...type, properties: def.properties }
+}
+
+/**
+ * Resolve one property's type off an object-shaped receiver type, deref'ing
+ * a named type first (`Props.createdAt`) and stripping a nullable union off
+ * the result (`Date | null` field). Returns `null` when the receiver has no
+ * evidence, or the property isn't found on it.
+ */
+function lookupProperty(objType: TypeInfo | null, propName: string, meta: EvidenceMetadata): TypeInfo | null {
+  const stripped = stripUnion(objType)
+  if (!stripped) return null
+  const deref = derefNamedType(stripped, meta)
+  const prop = deref.properties?.find((p: PropertyInfo) => p.name === propName)
+  return prop ? stripUnion(prop.type) : null
+}
+
+/**
+ * Resolve the TypeInfo of a receiver expression, using only propsType /
+ * typeDefinitions and the caller-supplied local bindings. `bindings` maps a
+ * name to its known type — or explicitly to `null` for a shadow the caller
+ * has proven carries no evidence (e.g. an arrow param, a loop item whose
+ * array type isn't known). A `bindings` hit always wins over the props
+ * fallback, matching JS lexical shadowing.
+ *
+ * Only two `ParsedExpr` shapes carry evidence: a bare identifier and a
+ * non-computed member access. Everything else (calls, computed/index
+ * access, literals, …) resolves to `null` — see the module doc.
+ */
+export function resolveReceiverType(
+  expr: ParsedExpr,
+  meta: EvidenceMetadata,
+  bindings: ReadonlyMap<string, TypeInfo | null>,
+): TypeInfo | null {
+  if (expr.kind === 'identifier') {
+    if (bindings.has(expr.name)) return stripUnion(bindings.get(expr.name) ?? null)
+    if (meta.propsObjectName !== null && expr.name === meta.propsObjectName) return stripUnion(meta.propsType)
+    return lookupProperty(meta.propsType, expr.name, meta)
+  }
+  if (expr.kind === 'member' && !expr.computed) {
+    const objType = resolveReceiverType(expr.object, meta, bindings)
+    return lookupProperty(objType, expr.property, meta)
+  }
+  return null
+}

--- a/packages/jsx/src/rich-type-refusal.ts
+++ b/packages/jsx/src/rich-type-refusal.ts
@@ -1,0 +1,280 @@
+/**
+ * Rich-type method-call refusal (#2273).
+ *
+ * A method call on a prop typed as a built-in "host rich type" (`Date`,
+ * `Map`, …) has no catalogued lowering — no adapter can emit `.toISOString()`
+ * into a template. Left unchecked, such a call transliterates into the
+ * target template's own dot-call syntax and dies at request time (a Go
+ * template `.CreatedAt.ToISOString` panic, a Jinja `AttributeError`, …),
+ * once per adapter, only once someone renders the page. This module makes
+ * that gap loud at compile time instead: `checkRichTypeMethodCalls` walks
+ * every expression position the compiler already treats as template-lowered
+ * and pushes BF021 for any call this build has no evidence a lowering plugin
+ * (or `/* @client *\/`) will handle.
+ *
+ * Deliberately conservative in both directions:
+ *   - `resolveReceiverType` (rich-type-evidence.ts) returns `null` — no
+ *     opinion — for any receiver shape it can't prove a type for, so an
+ *     untyped / generic / call-result receiver is silently allowed through
+ *     rather than misdiagnosed.
+ *   - A `/* @client *\/` node is skipped entirely (its expression already
+ *     opts out of SSR lowering), and a call a registered lowering plugin
+ *     claims (`prepareLoweringMatchers`) is exempt — the seam #2274 and
+ *     later plugins use to catalogue a rich-type API without touching this
+ *     module.
+ */
+
+import type {
+  IRNode,
+  IRMetadata,
+  CompilerError,
+  SourceLocation,
+  TypeInfo,
+  AttrValue,
+  IRTemplatePart,
+} from './types.ts'
+import type { ParsedExpr } from './expression-parser.ts'
+import { parseExpression } from './expression-parser.ts'
+import { prepareLoweringMatchers, type LoweringMatcher } from './lowering-registry.ts'
+import { ErrorCodes } from './errors.ts'
+import { resolveReceiverType, baseTypeName, HOST_RICH_TYPE_NAMES } from './rich-type-evidence.ts'
+
+type Bindings = ReadonlyMap<string, TypeInfo | null>
+const EMPTY_BINDINGS: Bindings = new Map()
+
+/**
+ * Walk `root` looking for a method call on a host rich-typed receiver with
+ * no catalogued lowering, pushing BF021 into `errors` for each one found.
+ * Mirrors `attachParsedExpressions`' tree coverage (jsx-to-ir.ts) so every
+ * position that reaches a template gets checked, but reads `.parsed` rather
+ * than attaching it, and additionally skips anything under `/* @client *\/`.
+ */
+export function checkRichTypeMethodCalls(root: IRNode, metadata: IRMetadata, errors: CompilerError[]): void {
+  const matchers = prepareLoweringMatchers(metadata)
+  const seen = new Set<string>()
+  walkNode(root, metadata, EMPTY_BINDINGS, matchers, errors, seen)
+}
+
+function isLoweringClaimed(matchers: readonly LoweringMatcher[], callee: ParsedExpr, args: readonly ParsedExpr[]): boolean {
+  return matchers.some((m) => m(callee, args) !== null)
+}
+
+/** Best-effort dotted-path text for the diagnostic message's `prop '<path>'`. */
+function describeReceiverPath(expr: ParsedExpr): string {
+  if (expr.kind === 'identifier') return expr.name
+  if (expr.kind === 'member' && !expr.computed) return `${describeReceiverPath(expr.object)}.${expr.property}`
+  return '<expression>'
+}
+
+function pushDiagnostic(
+  errors: CompilerError[],
+  seen: Set<string>,
+  loc: SourceLocation,
+  method: string,
+  receiverPath: string,
+  typeName: string,
+): void {
+  const key = `${loc.start.line}:${loc.start.column}:${method}`
+  if (seen.has(key)) return
+  seen.add(key)
+  errors.push({
+    code: ErrorCodes.UNSUPPORTED_JSX_PATTERN,
+    severity: 'error',
+    message: `Expression cannot be compiled to marked template: method '.${method}()' on prop '${receiverPath}' of host type '${typeName}' has no catalogued lowering.`,
+    loc,
+    suggestion: {
+      message: 'Add /* @client */ to evaluate this expression on the client only, or pre-compute the value server-side.',
+    },
+  })
+}
+
+/**
+ * Recurse a parsed expression tree, checking every `call` node along the way
+ * and descending into every sub-expression (so a rich-type call nested
+ * inside a larger expression — a template literal interpolation, an object
+ * literal value, an arrow body, …) is still found. `bindings` carries local
+ * type evidence (loop item / arrow param shadows) down into the recursion.
+ */
+function checkExpr(
+  expr: ParsedExpr,
+  loc: SourceLocation,
+  meta: IRMetadata,
+  bindings: Bindings,
+  matchers: readonly LoweringMatcher[],
+  errors: CompilerError[],
+  seen: Set<string>,
+): void {
+  const recurse = (e: ParsedExpr, b: Bindings = bindings) => checkExpr(e, loc, meta, b, matchers, errors, seen)
+
+  switch (expr.kind) {
+    case 'call': {
+      if (expr.callee.kind === 'member') {
+        const receiverType = resolveReceiverType(expr.callee.object, meta, bindings)
+        if (receiverType && receiverType.kind === 'interface') {
+          const typeName = baseTypeName(receiverType.raw)
+          const inFileShadow = meta.typeDefinitions.some((d) => d.name === typeName)
+          if (HOST_RICH_TYPE_NAMES.has(typeName) && !inFileShadow && !isLoweringClaimed(matchers, expr.callee, expr.args)) {
+            pushDiagnostic(errors, seen, loc, expr.callee.property, describeReceiverPath(expr.callee.object), typeName)
+          }
+        }
+      }
+      recurse(expr.callee)
+      for (const arg of expr.args) recurse(arg)
+      break
+    }
+    case 'member':
+      recurse(expr.object)
+      break
+    case 'index-access':
+      recurse(expr.object)
+      recurse(expr.index)
+      break
+    case 'binary':
+      recurse(expr.left)
+      recurse(expr.right)
+      break
+    case 'unary':
+      recurse(expr.argument)
+      break
+    case 'conditional':
+      recurse(expr.test)
+      recurse(expr.consequent)
+      recurse(expr.alternate)
+      break
+    case 'logical':
+      recurse(expr.left)
+      recurse(expr.right)
+      break
+    case 'template-literal':
+      for (const part of expr.parts) if (part.type === 'expression') recurse(part.expr)
+      break
+    case 'arrow': {
+      const shadowed = new Map(bindings)
+      for (const param of expr.params) shadowed.set(param, null)
+      recurse(expr.body, shadowed)
+      break
+    }
+    case 'array-literal':
+      for (const el of expr.elements) recurse(el)
+      break
+    case 'object-literal':
+      for (const prop of expr.properties) recurse(prop.value)
+      break
+    case 'array-method':
+      recurse(expr.object)
+      for (const arg of expr.args) recurse(arg)
+      break
+    case 'identifier':
+    case 'literal':
+    case 'regex':
+    case 'unsupported':
+      break
+  }
+}
+
+/** `IRTemplatePart.ternary.condition` / `.lookup.key` carry no attached parse (unlike every other position here), so parse on demand. */
+function walkTemplateParts(
+  parts: readonly IRTemplatePart[],
+  loc: SourceLocation,
+  meta: IRMetadata,
+  bindings: Bindings,
+  matchers: readonly LoweringMatcher[],
+  errors: CompilerError[],
+  seen: Set<string>,
+): void {
+  for (const part of parts) {
+    if (part.type === 'ternary') {
+      const trimmed = part.condition.trim()
+      if (trimmed) checkExpr(parseExpression(trimmed), loc, meta, bindings, matchers, errors, seen)
+    } else if (part.type === 'lookup') {
+      const trimmed = part.key.trim()
+      if (trimmed) checkExpr(parseExpression(trimmed), loc, meta, bindings, matchers, errors, seen)
+    }
+  }
+}
+
+function walkAttrValue(
+  value: AttrValue,
+  clientOnly: boolean | undefined,
+  loc: SourceLocation,
+  meta: IRMetadata,
+  bindings: Bindings,
+  matchers: readonly LoweringMatcher[],
+  errors: CompilerError[],
+  seen: Set<string>,
+): void {
+  if (clientOnly) return
+  if (value.kind === 'expression') {
+    if (value.parsed) checkExpr(value.parsed, loc, meta, bindings, matchers, errors, seen)
+    if (value.parts) walkTemplateParts(value.parts, loc, meta, bindings, matchers, errors, seen)
+  } else if (value.kind === 'spread') {
+    if (value.parsed) checkExpr(value.parsed, loc, meta, bindings, matchers, errors, seen)
+  } else if (value.kind === 'template') {
+    walkTemplateParts(value.parts, loc, meta, bindings, matchers, errors, seen)
+  }
+}
+
+function walkNode(
+  node: IRNode,
+  meta: IRMetadata,
+  bindings: Bindings,
+  matchers: readonly LoweringMatcher[],
+  errors: CompilerError[],
+  seen: Set<string>,
+): void {
+  if (node.type === 'expression') {
+    if (!node.clientOnly && node.parsed) checkExpr(node.parsed, node.loc, meta, bindings, matchers, errors, seen)
+  } else if (node.type === 'conditional') {
+    if (!node.clientOnly && node.parsedCondition) checkExpr(node.parsedCondition, node.loc, meta, bindings, matchers, errors, seen)
+  } else if (node.type === 'if-statement') {
+    if (node.parsedCondition) checkExpr(node.parsedCondition, node.loc, meta, bindings, matchers, errors, seen)
+  }
+
+  if (node.type === 'element') {
+    for (const attr of node.attrs) walkAttrValue(attr.value, attr.clientOnly, node.loc, meta, bindings, matchers, errors, seen)
+  } else if (node.type === 'component') {
+    for (const prop of node.props) walkAttrValue(prop.value, prop.clientOnly, node.loc, meta, bindings, matchers, errors, seen)
+  } else if (node.type === 'provider') {
+    walkAttrValue(node.valueProp.value, node.valueProp.clientOnly, node.loc, meta, bindings, matchers, errors, seen)
+  }
+
+  switch (node.type) {
+    case 'element':
+    case 'component':
+    case 'fragment':
+    case 'provider':
+      for (const child of node.children) walkNode(child, meta, bindings, matchers, errors, seen)
+      break
+    case 'async':
+      walkNode(node.fallback, meta, bindings, matchers, errors, seen)
+      for (const child of node.children) walkNode(child, meta, bindings, matchers, errors, seen)
+      break
+    case 'loop': {
+      if (node.clientOnly) break
+      if (node.arrayParsed) checkExpr(node.arrayParsed, node.loc, meta, bindings, matchers, errors, seen)
+      const loopBindings = new Map(bindings)
+      const arrayType = node.arrayParsed ? resolveReceiverType(node.arrayParsed, meta, bindings) : null
+      loopBindings.set(node.param, arrayType?.kind === 'array' ? arrayType.elementType ?? null : null)
+      if (node.index) loopBindings.set(node.index, null)
+      for (const child of node.children) walkNode(child, meta, loopBindings, matchers, errors, seen)
+      if (node.childComponent) {
+        for (const child of node.childComponent.children) walkNode(child, meta, loopBindings, matchers, errors, seen)
+      }
+      for (const nested of node.nestedComponents ?? []) {
+        for (const child of nested.children) walkNode(child, meta, loopBindings, matchers, errors, seen)
+      }
+      for (const frag of node.flatMapCallback?.fragments ?? []) {
+        walkNode(frag.ir, meta, loopBindings, matchers, errors, seen)
+      }
+      break
+    }
+    case 'conditional':
+      walkNode(node.whenTrue, meta, bindings, matchers, errors, seen)
+      walkNode(node.whenFalse, meta, bindings, matchers, errors, seen)
+      break
+    case 'if-statement':
+      walkNode(node.consequent, meta, bindings, matchers, errors, seen)
+      if (node.alternate) walkNode(node.alternate, meta, bindings, matchers, errors, seen)
+      break
+  }
+}

--- a/packages/jsx/src/rich-type-refusal.ts
+++ b/packages/jsx/src/rich-type-refusal.ts
@@ -50,6 +50,10 @@ const EMPTY_BINDINGS: Bindings = new Map()
  * than attaching it, and additionally skips anything under `/* @client *\/`.
  */
 export function checkRichTypeMethodCalls(root: IRNode, metadata: IRMetadata, errors: CompilerError[]): void {
+  // Every evidence chain roots at propsType (bare prop, props.x, loop item of
+  // a prop array) — with no props type there is nothing to prove, so skip the
+  // walk (and the matcher preparation / on-demand template-part parses).
+  if (!metadata.propsType) return
   const matchers = prepareLoweringMatchers(metadata)
   const seen = new Set<string>()
   walkNode(root, metadata, EMPTY_BINDINGS, matchers, errors, seen)
@@ -59,11 +63,24 @@ function isLoweringClaimed(matchers: readonly LoweringMatcher[], callee: ParsedE
   return matchers.some((m) => m(callee, args) !== null)
 }
 
-/** Best-effort dotted-path text for the diagnostic message's `prop '<path>'`. */
+/** Best-effort dotted-path text for the diagnostic message's receiver description. */
 function describeReceiverPath(expr: ParsedExpr): string {
   if (expr.kind === 'identifier') return expr.name
   if (expr.kind === 'member' && !expr.computed) return `${describeReceiverPath(expr.object)}.${expr.property}`
   return '<expression>'
+}
+
+/**
+ * Whether the receiver path roots at a prop (bare destructured prop or a
+ * `props.x` chain) rather than a locally-bound name (loop item, arrow param).
+ * Decides whether the diagnostic may call the receiver a "prop" — a loop
+ * item's `i.at` is prop-DERIVED but not itself a prop, and naming it one
+ * would misdirect the fix toward the props type.
+ */
+function receiverRootIsProp(expr: ParsedExpr, bindings: Bindings): boolean {
+  let root = expr
+  while (root.kind === 'member' && !root.computed) root = root.object
+  return root.kind === 'identifier' && !bindings.has(root.name)
 }
 
 function pushDiagnostic(
@@ -72,15 +89,17 @@ function pushDiagnostic(
   loc: SourceLocation,
   method: string,
   receiverPath: string,
+  isProp: boolean,
   typeName: string,
 ): void {
-  const key = `${loc.start.line}:${loc.start.column}:${method}`
+  const key = `${loc.start.line}:${loc.start.column}:${receiverPath}.${method}`
   if (seen.has(key)) return
   seen.add(key)
+  const receiver = isProp ? `prop '${receiverPath}'` : `'${receiverPath}'`
   errors.push({
     code: ErrorCodes.UNSUPPORTED_JSX_PATTERN,
     severity: 'error',
-    message: `Expression cannot be compiled to marked template: method '.${method}()' on prop '${receiverPath}' of host type '${typeName}' has no catalogued lowering.`,
+    message: `Expression cannot be compiled to marked template: method '.${method}()' on ${receiver} of host type '${typeName}' has no catalogued lowering.`,
     loc,
     suggestion: {
       message: 'Add /* @client */ to evaluate this expression on the client only, or pre-compute the value server-side.',
@@ -114,7 +133,15 @@ function checkExpr(
           const typeName = baseTypeName(receiverType.raw)
           const inFileShadow = meta.typeDefinitions.some((d) => d.name === typeName)
           if (HOST_RICH_TYPE_NAMES.has(typeName) && !inFileShadow && !isLoweringClaimed(matchers, expr.callee, expr.args)) {
-            pushDiagnostic(errors, seen, loc, expr.callee.property, describeReceiverPath(expr.callee.object), typeName)
+            pushDiagnostic(
+              errors,
+              seen,
+              loc,
+              expr.callee.property,
+              describeReceiverPath(expr.callee.object),
+              receiverRootIsProp(expr.callee.object, bindings),
+              typeName,
+            )
           }
         }
       }
@@ -269,6 +296,10 @@ function walkNode(
       break
     }
     case 'conditional':
+      // A clientOnly conditional's branches never reach any template (the
+      // whole expression defers to hydrate), so walking them would flag calls
+      // whose own suggested remediation — /* @client */ — is already applied.
+      if (node.clientOnly) break
       walkNode(node.whenTrue, meta, bindings, matchers, errors, seen)
       walkNode(node.whenFalse, meta, bindings, matchers, errors, seen)
       break

--- a/packages/jsx/src/rich-type-refusal.ts
+++ b/packages/jsx/src/rich-type-refusal.ts
@@ -258,11 +258,11 @@ function walkNode(
   }
 
   if (node.type === 'element') {
-    for (const attr of node.attrs) walkAttrValue(attr.value, attr.clientOnly, node.loc, meta, bindings, matchers, errors, seen)
+    for (const attr of node.attrs) walkAttrValue(attr.value, attr.clientOnly, attr.loc, meta, bindings, matchers, errors, seen)
   } else if (node.type === 'component') {
-    for (const prop of node.props) walkAttrValue(prop.value, prop.clientOnly, node.loc, meta, bindings, matchers, errors, seen)
+    for (const prop of node.props) walkAttrValue(prop.value, prop.clientOnly, prop.loc, meta, bindings, matchers, errors, seen)
   } else if (node.type === 'provider') {
-    walkAttrValue(node.valueProp.value, node.valueProp.clientOnly, node.loc, meta, bindings, matchers, errors, seen)
+    walkAttrValue(node.valueProp.value, node.valueProp.clientOnly, node.valueProp.loc, meta, bindings, matchers, errors, seen)
   }
 
   switch (node.type) {

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -90,6 +90,15 @@ export interface ParamInfo {
   defaultContainsArrow?: boolean
   /** When true, the parameter is a rest spread (`...args`) — emit must prepend `...`. */
   isRest?: boolean
+  /**
+   * Source property name for an aliased destructured prop (`{ createdAt: c }`
+   * → name: 'c', sourceName: 'createdAt'). Set ONLY when the binding renames —
+   * an un-aliased binding leaves it unset so existing IR shapes/snapshots are
+   * untouched. Consumers keying into `propsType.properties` must use
+   * `sourceName ?? name` (the param's own `type` degrades to `unknown` for
+   * non-primitive props — `collectMemberTypes`' primitives-only gate).
+   */
+  sourceName?: string
 }
 
 // =============================================================================

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -954,7 +954,7 @@ error[BF021]: Expression cannot be compiled to marked template: method '.toISOSt
    = help: Add /* @client */ to evaluate this expression on the client only, or pre-compute the value server-side.
 ```
 
-The refusal is deliberately conservative — it only fires when the receiver's type is **provable** from the component's own `propsType` / `typeDefinitions` (a destructured prop, a `props.x` member chain, a loop item's field, with union-of-nullable stripped: `Date | null` → `Date`). Any receiver shape it can't prove a type for — a signal getter's call result (`d().toISOString()`), an untyped or generic-parameter (`T`) receiver, a computed/index access — resolves to "no evidence" and is silently allowed through, never misdiagnosed. Two exemptions:
+The refusal is deliberately conservative — it only fires when the receiver's type is **provable** from the component's own `propsType` / `typeDefinitions` (a destructured prop, a `props.x` member chain, a loop item's field, with union-of-nullable stripped: `Date | null` → `Date`). Any receiver shape it can't prove a type for — a signal getter's call result (`d().toISOString()`), an untyped or generic-parameter (`T`) receiver, a computed/index access — resolves to "no evidence" and is silently allowed through, never misdiagnosed. Three exemptions:
 
 - **`/* @client */`** — the expression already opts out of SSR lowering, exactly as for the filter/sort BF021 shapes above.
 - **A registered lowering plugin claims the call** — `checkRichTypeMethodCalls` checks the same `matchLoweringCall` seam every adapter's call lowering goes through (`lowering-registry.ts`, #2057). Cataloguing a rich-type API (e.g. a `Date.toISOString()` → ISO-string lowering) is a plugin, not a change to this module — see #2274.

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -817,7 +817,7 @@ symbol of each JSX tag through to the resolver; tracked as a follow-up.
 | BF001 | Missing 'use client' directive |
 | BF003 | Client component importing server component |
 | BF011 | Module-level reactive declaration without `/* @client */` |
-| BF021 | Unsupported JSX pattern (e.g., filter predicate or sort comparator too complex for template compilation) |
+| BF021 | Unsupported JSX pattern (e.g., filter predicate or sort comparator too complex for template compilation; method call on a host rich-typed prop with no catalogued lowering, #2273) |
 | BF023 | Missing `key` attribute in `.map()` loop — root JSX element has no `key` prop |
 | BF024 | Missing `key` attribute in nested `.map()` loop — inner loop root JSX element has no `key` prop |
 | BF025 | Unsupported destructure shape in `.map()` callback (computed property key — rest elements have been supported since #1244/#1309) |
@@ -938,6 +938,27 @@ The accumulator must be the binary expression's left operand (`acc + x`, not `x 
 When `@client` is present, the compiler skips template generation for that expression without emitting an error.
 
 This applies equally to **attribute bindings**, not just child/text expressions: `data-x={/* @client */ pred(item)}` defers the attribute to hydration. The adapters omit a `clientOnly` attribute from SSR (so the unsupported-expression lowering is never reached → no BF101/BF102), and the client runtime sets/patches it in a mount effect. This makes the BF102 remediation accurate for components whose reactive state is expressed purely as attributes (the Calendar case in #1966 / #1467).
+
+### Method calls on host rich-typed props (BF021, #2273)
+
+A method call on a prop typed as a built-in **host rich type** — `Date`, `Map`, `Set`, `WeakMap`, `WeakSet`, `URL`, `URLSearchParams`, `RegExp`, `Promise`, `Error`, `Symbol`, `BigInt`, `Function` — has no catalogued lowering in any adapter: there is no structural IR representation for `Date.prototype.toISOString` the way there is for a plain object field or an `Array.prototype` method. Left unchecked, such a call used to transliterate verbatim into the target template's own dot-call syntax and die at request time (a Go template method-value panic, a Jinja `AttributeError`, …) — once per adapter, only once someone actually rendered the page. `checkRichTypeMethodCalls` (`packages/jsx/src/rich-type-refusal.ts`) closes that gap at compile time instead, refusing with BF021 as soon as the receiver's declared type is provably one of the host types above:
+
+```
+error[BF021]: Expression cannot be compiled to marked template: method '.toISOString()' on prop 'createdAt' of host type 'Date' has no catalogued lowering.
+
+  --> src/components/Post.tsx:3:22
+   |
+ 3 |   return <div>{createdAt.toISOString()}</div>
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: Add /* @client */ to evaluate this expression on the client only, or pre-compute the value server-side.
+```
+
+The refusal is deliberately conservative — it only fires when the receiver's type is **provable** from the component's own `propsType` / `typeDefinitions` (a destructured prop, a `props.x` member chain, a loop item's field, with union-of-nullable stripped: `Date | null` → `Date`). Any receiver shape it can't prove a type for — a signal getter's call result (`d().toISOString()`), an untyped or generic-parameter (`T`) receiver, a computed/index access — resolves to "no evidence" and is silently allowed through, never misdiagnosed. Two exemptions:
+
+- **`/* @client */`** — the expression already opts out of SSR lowering, exactly as for the filter/sort BF021 shapes above.
+- **A registered lowering plugin claims the call** — `checkRichTypeMethodCalls` checks the same `matchLoweringCall` seam every adapter's call lowering goes through (`lowering-registry.ts`, #2057). Cataloguing a rich-type API (e.g. a `Date.toISOString()` → ISO-string lowering) is a plugin, not a change to this module — see #2274.
+- **An in-file type declaration shadows the host name** (`interface Date { … }` in the same file) — the local declaration wins; only a same-file shadow is recognized, not an imported type that happens to reuse the name.
 
 ### Known limitations — methods that don't lower to the template adapters
 

--- a/spec/subset-conformance.md
+++ b/spec/subset-conformance.md
@@ -166,19 +166,31 @@ single fixture cannot witness.
 
 ## Date: first catalogued rich type
 
-Current state (verified 2026-07): `Date` props are a **silent passthrough** —
-no diagnostic; the prop lowers to `interface{}` (Go), and method calls are
-transliterated mechanically (`createdAt.toISOString()` →
-`{{.CreatedAt.ToISOString}}`), which fails at Go render time while CSR renders
-correctly. This violates principle 2 (loud boundary) and is the motivating
-specimen for this document.
+Original state (verified 2026-07, before #2273): `Date` props were a **silent
+passthrough** — no diagnostic; the prop lowered to `interface{}` (Go), and
+method calls were transliterated mechanically (`createdAt.toISOString()` →
+`{{.CreatedAt.ToISOString}}`), which failed at Go render time while CSR
+rendered correctly. This violated principle 2 (loud boundary) and was the
+motivating specimen for this document.
+
+Current state (#2273): a method call on a prop provably typed as `Date` (or
+any other host rich type — `Map`, `Set`, `URL`, …) with no catalogued
+lowering now refuses at compile time with BF021 instead of silently
+transliterating. The prop itself still lowers to `interface{}` (Go) /
+untyped elsewhere when not method-called — only the specific "method call
+with no lowering" shape is closed. Cataloguing individual methods (the
+"Catalogue via the lowering-plugin registry" bullet below) is unaffected
+follow-up work (#2274): closing the passthrough and cataloguing methods are
+separate, independently-landable steps.
 
 Target design:
 
 - **Close the passthrough first**: a method call on a prop whose type has no
   known lowering becomes a diagnostic (BF021 class; may stage through a
   warning if the accidental "mirror-method host type" contract turns out to
-  have users).
+  have users). **Landed** (#2273): `checkRichTypeMethodCalls`
+  (`packages/jsx/src/rich-type-refusal.ts`) refuses at compile time — see
+  "Current state" below.
 - **Catalogue via the lowering-plugin registry**
   (`packages/jsx/src/lowering-registry.ts`) as a default-applied builtin —
   backend-neutral `LoweringNode` per catalogued method, rendered natively by
@@ -196,7 +208,7 @@ convention as `spec/adapter-architecture.md`):
 
 | Component | Landed | Gap |
 |-----------|--------|-----|
-| Normative subset | `ParsedExpr` union + exhaustive adapter switches (drift-defence); array-method / sort-comparator catalogues; builtin lowering registry; BF021/BF101 loud-refusal policy + growing-only rule (`spec/compiler.md`); `/* @client */` escape | Pieces are scattered across spec/types/catalogues with no single normative declaration; `ParsedExpr` lacks `object-literal` (adapter-architecture Roadmap A); the boundary is not fully loud — the Date silent passthrough proves unknown-type method calls pass undiagnosed; the data-domain axiom exists only in this document |
+| Normative subset | `ParsedExpr` union + exhaustive adapter switches (drift-defence); array-method / sort-comparator catalogues; builtin lowering registry; BF021/BF101 loud-refusal policy + growing-only rule (`spec/compiler.md`); `/* @client */` escape; **the Date silent-passthrough hole is closed** — a method call on a prop provably typed as a host rich type (`Date`, `Map`, …) with no catalogued lowering now refuses with BF021 at compile time instead of passing undiagnosed (`checkRichTypeMethodCalls`, #2273) | Pieces are scattered across spec/types/catalogues with no single normative declaration; `ParsedExpr` lacks `object-literal` (adapter-architecture Roadmap A); the data-domain axiom exists only in this document |
 | Canonical reference (JS render) | Hono/JS render is the *de facto* reference: snapshot generation renders expectations through it; `referenceAdapter`/`referenceRender` HTML-diff suite exists; determinism landed (#1494) | No *declaration* of canonical status (`referenceAdapter` is optional — the reference is still positioned as one adapter among eleven); oracle comparison runs at one evaluation point per fixture, not live × multiple data points |
 | Shared conformance | `run-adapter-conformance.ts` single mandatory entry point ("forgot to wire the suite" is impossible); 182 fixtures + marker conformance + template primitives + render contract; real-backend execution with `normalizeHTML`; `props` injection; **the `dataPoints` oracle suite (roadmap 1)** — gate-ordered, live-oracle, JSON-domain-validated, piloted on `nullish-coalescing-text` (found #2248 — since fixed via nillable lowering + `bf_nullish` — and a Go harness string-escaping bug on its first run) | No PR-vs-nightly tiering (the catalogue added ~200 real-backend renders per adapter job); catalogue exclusions await their unblockers (unions/objects → member enumeration, floats → #2168-class, `Date` → roadmap 4 — destructured optionals graduated: #2259 restored analyzer parity and the catalogue now derives for them) |
 | Declared skips | Typed skip sets (`skipJsx`, `skipTemplatePrimitives`, `skipMarkerConformance`, `expectedDiagnostics`, and now `skipDataPoints` — its first entries pinned #2248 on the Go adapter until the fix landed and removed them, completing one full ledger round-trip) with issue-link discipline; `known-limitation` label; `@barefootjs/compat` component×adapter compile matrix (`compat.lock.json`) | No generated `kind × axis × adapter` support matrix yet — but its fixture-side half now exists: the computed coverage ledger (`coverage-map.json` + `PARSED_EXPR_KINDS` registry + freshness/floor meta-tests) supplies the kind/axis denominators; joining them against per-adapter pass/skip is the remaining work |

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 251,
+    "totalFixtures": 252,
     "fixtures": {
       "dangerous-inner-html-dynamic": {
         "blade": {
@@ -1887,6 +1887,89 @@
           ],
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2215"
+          ]
+        }
+      },
+      "date-method-uncatalogued": {
+        "blade": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2274"
+          ]
+        },
+        "erb": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2274"
+          ]
+        },
+        "go-template": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2274"
+          ]
+        },
+        "hono": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2274"
+          ]
+        },
+        "jinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2274"
+          ]
+        },
+        "minijinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2274"
+          ]
+        },
+        "mojolicious": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2274"
+          ]
+        },
+        "twig": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2274"
+          ]
+        },
+        "xslate": {
+          "kind": "refusal",
+          "codes": [
+            "BF021"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2274"
           ]
         }
       },


### PR DESCRIPTION
## Summary

PR-A of the #2273→#2274 stack. Fixes #2273: a method call on a prop whose type resolves to a host rich type (`Date`, `Map`, `Set`, `URL`, … — closed 13-name list, in-file shadows exempt) with no lowering-registry claim now refuses with **BF021** at compile time, instead of silently transliterating into templates that die at request time (`{{.CreatedAt.ToISOString}}` on `interface{}`) while CSR works.

Design (Fable design agent, ratified): a Phase-1 IR post-pass in the shared compiler layer — one implementation, all adapters including Hono (one normative subset; "works on Hono" is exactly the fidelity trap the subset spec exists to avoid). Predicate: `call` with `member` callee × receiver TypeInfo resolves to a listed host type × `matchLoweringCall` declines. **Empirically zero false positives across 717 compiled units** (251 fixtures + 62 ui components + 356 site/integrations files) — even the maximal any-interface-receiver rule fires nowhere in-repo, hence straight to `error` with no staged warning.

- `rich-type-evidence.ts` — receiver-type resolver (props-object / destructured / renamed destructure via new additive `ParamInfo.sourceName`; loop-item element types; `Date | null` union stripping) shared with #2274's plugin so exemption and firing scope can never drift.
- `rich-type-refusal.ts` — the walk (mirrors `attachParsedExpressions` coverage), `/* @client */` escape honored on expressions, attrs, props, loops AND conditional branches.
- Registry carve-out proven by unit test: a plugin claiming the call exempts with zero edits here — #2274 only adds entries.
- `date-method-uncatalogued` conformance fixture (`toLocaleDateString`, permanently out of catalogue) pinned BF021 in all nine adapters' `conformance-pins.ts` (issue field → #2274, the live tracker).

Second commit applies a Fable review's findings: 2 confirmed-by-execution MUST-FIXes (`@client` on conditional branches didn't silence; bare-identifier evidence false-positived on non-prop bindings sharing a prop field name), sibling-diagnostic dedupe, adapter changeset entries, a false workaround claim in error-codes.md, and a `!propsType` early-out.

## Verification

- `rich-type-method-refusal.test.ts`: 25 pass (8 FIRES / 13 SILENT / dedupe / registry-exemption / message shape).
- Full `packages/jsx`: 2506 pass / 0 fail (150 snapshots byte-identical — `sourceName` is additive).
- `ui/components/`: 1240 pass / 0 fail; all nine adapter conformance suites 0 fail (run isolated; parallel-run timeouts were CPU contention, verified clean).
- coverage-map / generated-data-points freshness green; `tsgo --noEmit -p packages/jsx` clean.

## Notes for review

- The one policy call: BF021 fires when compiling for Hono too (per issue text + spec principle 2). Veto here changes placement materially (adapter-layer BF101) — say the word before #2274 lands on top.
- Follow-ups the design flagged (will file on merge): `$date` envelope for client hydration of Date props; loop-item Date members stay refused post-#2274 (matcher context limitation); bare `{createdAt}` interpolation stringification divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1T4R1R6FKPGTFyYn1ppBa

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1T4R1R6FKPGTFyYn1ppBa)_