### PR TITLE
Fix #2282: loop-child reactive text falls back to AST-flag classification

### DIFF
--- a/.changeset/nested-loop-text-ast-flag-fallback.md
+++ b/.changeset/nested-loop-text-ast-flag-fallback.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix #2282: loop-child reactive text now falls back to the Solid-style AST-flag classification, matching the loop-child reactive attribute path (#1673) and the top-level text path. Previously, a loop-item text expression read through a helper the string-level `classifyReactivity` heuristic couldn't see through (e.g. `labelAt(i)` where `const labelAt = (i) => labels()[i]`) silently kept its SSR value forever — no `createEffect` update, no console error — while a sibling reactive `className`/`style` on the same element kept updating correctly.

--- a/packages/jsx/src/__tests__/nested-loop-reactive-attrs.test.ts
+++ b/packages/jsx/src/__tests__/nested-loop-reactive-attrs.test.ts
@@ -342,4 +342,60 @@ describe('reactive attributes inside a nested .map() body (#135)', () => {
     expect(content).toMatch(/createEffect\(\(\) => \{[\s\S]*?\.textContent = String\(panel\(\)\.text\)/)
     expect(content).toContain("setAttribute('class'")
   })
+
+  test('reactive text child of a triple-nested inner loop read through an opaque helper gets an update effect (#2282)', () => {
+    // #2264 fixed the case where `classifyReactivity` proves the text
+    // reactive via the loop-param path (bare `panel.text`). It left a
+    // sibling gap: `collectLoopChildReactiveTexts` had no Solid-style
+    // AST-flag fallback, so a text read through an opaque helper the
+    // classifier can't see through (`labelAt(pi)` where `const labelAt =
+    // (i) => labels()[i]`) still silently dropped its update effect — while
+    // `collectLoopChildReactiveAttrs` already had that fallback (#1673,
+    // see `reactive-attrs-in-map.test.ts`), so the sibling `className`
+    // effect on the SAME element kept working. Reported as #2282 ("child
+    // inlined into a parent island drops the innermost reactive text
+    // effect"); the issue's own literal `{panel.text}` repro snippet
+    // doesn't reproduce it (that shape is exactly what #2264 already
+    // fixed) — this test pins the actual asymmetry root-caused during
+    // investigation, using the opaque-helper shape that does reproduce.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      type Panel = { id: number; cls: string }
+      type Band = { id: string; panels: Panel[] }
+      type Page = { id: string; bands: Band[] }
+
+      export function Doc2() {
+        const [pages] = createSignal<Page[]>([])
+        const [labels] = createSignal<string[]>([])
+        const labelAt = (i: number) => labels()[i]
+        return (
+          <div>
+            {pages().map(page => (
+              <div key={page.id}>
+                {page.bands.map(band => (
+                  <div key={band.id}>
+                    {band.panels.map((panel, pi) => (
+                      <div key={panel.id} className={panel.cls}>{labelAt(pi)}</div>
+                    ))}
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        )
+      }
+    `
+    const result = compileJSX(source, 'Doc2.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+    const content = result.files.find((f) => f.type === 'clientJs')!.content
+
+    // The helper call must appear inside a createEffect alongside the
+    // textContent write — `labelAt(` also appears in the static template
+    // clone, so asserting it independently would pass even with the
+    // effect missing (the exact regression here).
+    expect(content).toMatch(/createEffect\(\(\) => \{[\s\S]*?\.textContent = String\(labelAt\(pi\)\)/)
+    expect(content).toContain("setAttribute('class'")
+  })
 })

--- a/packages/jsx/src/ir-to-client-js/reactivity.ts
+++ b/packages/jsx/src/ir-to-client-js/reactivity.ts
@@ -529,8 +529,19 @@ export function collectLoopChildReactiveTexts(
       const originFreeIds = freeIdsFromRefs(n.origin?.freeRefs)
       const expanded = expandConstantForReactivity(n.expr, ctx, originFreeIds)
       // Include if expression reads signals OR references the loop parameter
-      // (loop param becomes a signal accessor via per-item signals).
-      if (classifyReactivity(expanded.expr, ctx, loopParam, loopParamBindings, expanded.freeIds).kind === 'none') return
+      // (loop param becomes a signal accessor via per-item signals). Falls
+      // back to the Solid-style AST-flag wrap decision — mirroring
+      // `collectLoopChildReactiveAttrs`'s `callsReactiveGetters` /
+      // `hasFunctionCalls` fallback (#1673) and the top-level text path's
+      // `decideWrapFromAstFlags` gate (`collectElements`'s `expression`
+      // handler) — so a loop-item text read through an opaque helper
+      // (`textAt(i)` where `const textAt = (i) => rows()[i]`, which
+      // `classifyReactivity` can't see through) still gets an update
+      // effect instead of silently freezing at its SSR value (#2282).
+      const reactive =
+        classifyReactivity(expanded.expr, ctx, loopParam, loopParamBindings, expanded.freeIds).kind !== 'none'
+        || decideWrapFromAstFlags(n).wrap
+      if (!reactive) return
       texts.push({
         slotId: n.slotId,
         expression: expanded.expr,


### PR DESCRIPTION
## Summary

- Fixes #2282: the innermost reactive text child of a nested `.map()` could silently freeze at its SSR value while a sibling reactive `className`/`style` on the same element kept updating.
- Root cause: `collectLoopChildReactiveTexts` (`packages/jsx/src/ir-to-client-js/reactivity.ts`) gated collection purely on `classifyReactivity`, a string-level heuristic that only recognizes known signal getters, memo names, prop names, and direct loop-param references. It had no Solid-style AST-flag fallback — unlike its sibling `collectLoopChildReactiveAttrs` (which already falls back to `callsReactiveGetters`/`hasFunctionCalls`, added for #1673) and the top-level (non-loop) text path, which gates on `decideWrapFromAstFlags`.
- A loop-item text read through a helper the string heuristic can't see through (e.g. `labelAt(i)` where `const labelAt = (i) => labels()[i]`) silently kept its SSR value forever instead of getting a `createEffect` update, with no console error.
- Fix: `collectLoopChildReactiveTexts` now also falls back to `decideWrapFromAstFlags(n).wrap` — the same AST-flag fallback the attribute path already uses — so a loop-item text read the string classifier can't prove reactive still gets wired up.

Note: the issue's own literal `{panel.text}` repro snippet doesn't reproduce this specific defect — that shape is already proven reactive via the loop-param path (`classifyReactivity` returns `kind: 'loop-param'`) and was unaffected. This fix targets the asymmetry an investigation traced the reported symptom to (attribute effect survives, text effect silently drops — exact signature match), most likely triggered by a more complex text expression than the repro's simplified `panel.text`.

A parallel gap was investigated in the analogous `collectBranchTextEffects` (conditional-branch text), but a test built to reproduce it passed even without any change — Phase 1's `isReactiveExpression`/`isReactiveOrigin` already proves reactivity through local helper calls in that path, so `n.reactive` was already true and the existing gate already worked. That speculative change was reverted; this PR only contains the verified fix.

## Test plan

- [x] Added a regression test to `packages/jsx/src/__tests__/nested-loop-reactive-attrs.test.ts` (`#2282`) using a triple-nested `.map()` (mirroring the `#2264` shape) with an opaque-helper text expression at the innermost level plus a sibling reactive `className`; asserts both effects are emitted.
- [x] Verified the new test fails without the fix (reverted `reactivity.ts` only, reran — text effect assertion fails, class effect assertion still passes) and passes with it.
- [x] `bun test packages/jsx/src/__tests__/nested-loop-reactive-attrs.test.ts` — 8/8 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0117TE94b7Hb71DcQ23yfoRR)_