### PR TITLE
Fix #2283: trace imports referenced only from module-level helper functions

### DIFF
--- a/.changeset/fix-module-helper-import-tracing.md
+++ b/.changeset/fix-module-helper-import-tracing.md
@@ -1,0 +1,9 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix #2283: trace imports referenced only from module-level helper functions in the client-JS inliner.
+
+The final import-usage scan ran before module-level constant/function bodies were substituted into the generated code, so an import used only inside a module-level helper (e.g. a pure helper extracted to module scope that calls a relative-import function) was invisible to the scan and silently dropped — producing a runtime `ReferenceError` in the browser even though `bf build`, `tsc`, and vitest all stayed green. Imports referenced from component-body closures were unaffected, since their code was already part of the scanned text.
+
+Module-level declarations are now substituted first, so the usage scan sees the full generated code (including module-level helper bodies) before deciding which imports to keep.

--- a/.changeset/fix-module-helper-import-tracing.md
+++ b/.changeset/fix-module-helper-import-tracing.md
@@ -7,3 +7,5 @@ Fix #2283: trace imports referenced only from module-level helper functions in t
 The final import-usage scan ran before module-level constant/function bodies were substituted into the generated code, so an import used only inside a module-level helper (e.g. a pure helper extracted to module scope that calls a relative-import function) was invisible to the scan and silently dropped — producing a runtime `ReferenceError` in the browser even though `bf build`, `tsc`, and vitest all stayed green. Imports referenced from component-body closures were unaffected, since their code was already part of the scanned text.
 
 Module-level declarations are now substituted first, so the usage scan sees the full generated code (including module-level helper bodies) before deciding which imports to keep.
+
+The placeholder substitutions also now use the `String.replace` replacer-function form, so a helper body or import path containing a literal `$&`/`$1`/`$$` sequence is spliced in verbatim instead of being reinterpreted as a replacement pattern.

--- a/packages/jsx/src/__tests__/client-js-generation.test.ts
+++ b/packages/jsx/src/__tests__/client-js-generation.test.ts
@@ -1192,6 +1192,35 @@ describe('Client JS generation', () => {
       // otherwise the browser throws `ReferenceError: computeSheetGeometry is not defined`.
       expect(content).toContain("import { computeSheetGeometry } from '../src/lib/sheetGeometry'")
     })
+
+    test('module-level helper body containing a literal "$&" is spliced in verbatim', () => {
+      // A plain-string second argument to String.replace() specially
+      // interprets `$&`/`$1`/`$$` — the placeholder-substitution step must
+      // use the replacer-function form so a helper body containing one of
+      // these sequences isn't corrupted (piconic-ai/barefootjs#2286 review).
+      const source = `
+        'use client'
+        import { createMemo } from '@barefootjs/client'
+
+        function formatMoney(amount: number) {
+          return '$&' + amount
+        }
+
+        export function Price(props: { amount: number }) {
+          const label = createMemo(() => formatMoney(props.amount))
+          return <div>{label()}</div>
+        }
+      `
+
+      const result = compileJSX(source, 'Price.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      const content = clientJs!.content
+
+      expect(content).toContain("'$&' + amount")
+    })
   })
 
   describe('child component value/boolean prop binding', () => {

--- a/packages/jsx/src/__tests__/client-js-generation.test.ts
+++ b/packages/jsx/src/__tests__/client-js-generation.test.ts
@@ -1162,6 +1162,36 @@ describe('Client JS generation', () => {
       expect(basicErrorCount).toBe(1) // only inside computeError body
       expect(isDuplicateCount).toBe(1) // only inside computeError body
     })
+
+    test('import used only inside a module-level helper is traced into the client bundle (#2283)', () => {
+      const source = `
+        'use client'
+        import { createMemo } from '@barefootjs/client'
+        import { computeSheetGeometry } from '../src/lib/sheetGeometry'
+
+        function buildSheetVMs(count: number) {
+          return computeSheetGeometry(count)
+        }
+
+        export function PrintSheets(props: { count: number }) {
+          const sheets = createMemo(() => buildSheetVMs(props.count))
+          return <div>{sheets()}</div>
+        }
+      `
+
+      const result = compileJSX(source, 'PrintSheets.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      const content = clientJs!.content
+
+      // The helper's body (which references the import) must be emitted...
+      expect(content).toContain('computeSheetGeometry(count)')
+      // ...and the import that body depends on must be traced and emitted too,
+      // otherwise the browser throws `ReferenceError: computeSheetGeometry is not defined`.
+      expect(content).toContain("import { computeSheetGeometry } from '../src/lib/sheetGeometry'")
+    })
   })
 
   describe('child component value/boolean prop binding', () => {

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -99,16 +99,20 @@ export function generateInitFunction(
   let generatedCode = rewritePropsObjectRef(lines.join('\n'), ctx.propsObjectName)
   generatedCode += '\n' + hydrateLine
 
-  const allImportLines = resolveFinalImports(generatedCode, ir, localImportPrefixes)
+  // Substitute module-level declarations BEFORE import detection: a
+  // module-level helper's body (e.g. `buildSheetVMs` calling
+  // `computeSheetGeometry`) only exists in `moduleConstantsCode`, so
+  // scanning `generatedCode` first would miss any import referenced
+  // only from that body and silently drop it (#2283).
   const moduleConstantsCode = emitModuleLevelDeclarations(
     classification.moduleLevelConstants,
     classification.moduleLevelFunctions,
     classification.moduleLevelSignals,
     classification.moduleLevelMemos,
   )
+  const codeWithModuleConstants = generatedCode.replace(MODULE_CONSTANTS_PLACEHOLDER, moduleConstantsCode)
+  const allImportLines = resolveFinalImports(codeWithModuleConstants, ir, localImportPrefixes)
 
-  return generatedCode
-    .replace(IMPORT_PLACEHOLDER, allImportLines)
-    .replace(MODULE_CONSTANTS_PLACEHOLDER, moduleConstantsCode)
+  return codeWithModuleConstants.replace(IMPORT_PLACEHOLDER, allImportLines)
 }
 

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -110,9 +110,12 @@ export function generateInitFunction(
     classification.moduleLevelSignals,
     classification.moduleLevelMemos,
   )
-  const codeWithModuleConstants = generatedCode.replace(MODULE_CONSTANTS_PLACEHOLDER, moduleConstantsCode)
+  // Replacer-function form: a plain replacement string would let literal
+  // `$&`/`$1`/`$$` sequences in user helper bodies or import paths be
+  // reinterpreted by `String.replace`'s special-pattern handling.
+  const codeWithModuleConstants = generatedCode.replace(MODULE_CONSTANTS_PLACEHOLDER, () => moduleConstantsCode)
   const allImportLines = resolveFinalImports(codeWithModuleConstants, ir, localImportPrefixes)
 
-  return codeWithModuleConstants.replace(IMPORT_PLACEHOLDER, allImportLines)
+  return codeWithModuleConstants.replace(IMPORT_PLACEHOLDER, () => allImportLines)
 }
 


### PR DESCRIPTION
## Summary

Fixes #2283: the client-JS inliner copied a module-level helper function's body into the compiled bundle but did not trace the relative/external imports that helper used — the browser then threw `ReferenceError: X is not defined` at runtime, while `bf build`, `tsc --noEmit`, and vitest all stayed green.

**Root cause**: in `generateInitFunction` (`packages/jsx/src/ir-to-client-js/generate-init.ts`), the final import-usage scan (`resolveFinalImports`) ran against `generatedCode` *before* `MODULE_CONSTANTS_PLACEHOLDER` was substituted with the actual module-level constant/function bodies (`moduleConstantsCode`). A helper's body — the only place an import used exclusively by a module-level helper appears — wasn't part of the scanned text yet, so the regex-based usage check in `collectExternalImports` never matched and the import was silently dropped. Imports referenced from component-body closures were unaffected, since that code was already part of `generatedCode` at scan time.

**Fix**: reorder so module-level declarations are substituted into the code first, then the import-usage scan runs against the fully-substituted code, then the import placeholder is replaced.

## Changes

- `packages/jsx/src/ir-to-client-js/generate-init.ts` — reorder `emitModuleLevelDeclarations` before `resolveFinalImports`, and scan the module-constants-substituted code for import usage.
- `packages/jsx/src/__tests__/client-js-generation.test.ts` — regression test: a module-level helper function whose body calls a relative import, referenced only from inside a `createMemo`, now correctly emits both the helper body and the import line.
- `.changeset/fix-module-helper-import-tracing.md` — patch changeset for `@barefootjs/jsx`.

## Test plan

- [x] New regression test passes: `bun test packages/jsx/src/__tests__/client-js-generation.test.ts`
- [x] Full `packages/jsx/src` test suite run — no new failures (5 pre-existing unrelated failures in `primitive-resolver-all.test.ts` / `primitive-resolver-alias.test.ts`, confirmed present on `main` too via `git stash`).
- [x] Verified compiled output directly: `computeSheetGeometry` (an import used only inside a module-level helper) now appears in the emitted `import { ... } from '...'` line alongside the helper's body.

## Note for maintainers

While reviewing this fix, a separate pre-existing (not introduced by this PR) latent issue was flagged: `generate-init.ts`'s final placeholder substitutions use `String.replace(pattern, replacementString)`, which interprets `$&`, `$1`, `$$`, etc. specially in the replacement string. Since generated code (import paths, helper bodies) flows into those replacements, a user helper body containing a literal `$`-sequence could theoretically corrupt output. This is out of scope for #2283 and unrelated to import tracing — flagging here in case a maintainer wants to file a follow-up issue.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CXmaY9Qy99d9Dgec51TKvn)_