### PR TITLE
Add #2274: Date as the first catalogued rich type

### DIFF
--- a/.changeset/date-catalogue.md
+++ b/.changeset/date-catalogue.md
@@ -1,0 +1,16 @@
+---
+"@barefootjs/jsx": minor
+"@barefootjs/go-template": patch
+"@barefootjs/erb": patch
+"@barefootjs/jinja": patch
+"@barefootjs/php": patch
+"@barefootjs/perl": patch
+"@barefootjs/rust": patch
+---
+
+Add #2274: a `date` catalogue entry lowering a zero-arg `Date.prototype` method call on a `Date`-typed prop (`createdAt.toISOString()`, `updatedAt.getUTCFullYear()`, …) to a backend-neutral `helper-call` LoweringNode instead of refusing it as an uncatalogued rich-type method call (#2273's `checkRichTypeMethodCalls` now exempts it).
+
+- `@barefootjs/jsx`: `date-lowering.ts` registers the `date` builtin lowering plugin recognizing `getUTCFullYear` / `getUTCMonth` / `getUTCDate` / `getUTCHours` / `getUTCMinutes` / `getUTCSeconds` / `getTime` / `toISOString`; the analyzer widens a destructured `Date`-typed prop's rich-type evidence so the plugin (and the #2273 refusal) can see through the destructure.
+- `@barefootjs/go-template`, `@barefootjs/erb`, `@barefootjs/jinja`, `@barefootjs/php`, `@barefootjs/perl`, `@barefootjs/rust`: each runtime gains a `date(recv, op)` helper (`bf_date` / `bf.date` / `BarefootJS::Date` / `barefootjs.date`) accepting either the backend's own native date/time value or an ISO-8601 string, normalizing both to the same instant before dispatching `op` — pinned against the JS-normative golden vectors (epoch 0, a pre-1970 instant, a leap day, and the four-digit-year boundary). `getUTCMonth` is 0-based, matching JS; every accessor and `getTime` render as an integer; `toISOString` always renders millisecond precision, UTC.
+
+The Rust runtime additionally gains a hand-rolled proleptic-Gregorian calendar (`date.rs`, Hinnant's `civil_from_days`/`days_from_civil`) and a `JsValue::Date`/`minijinja::Value` native receiver shape — no new crate dependency.

--- a/packages/adapter-erb/lib/barefoot_js.rb
+++ b/packages/adapter-erb/lib/barefoot_js.rb
@@ -493,7 +493,21 @@ module BarefootJS
     # sub-second remainder (Ruby normalizes `Time`'s internal rational),
     # even for a pre-epoch instant, so integer division here stays exact.
     def date(recv, op)
-      t = (recv.is_a?(Time) ? recv : Time.iso8601(recv.to_s)).utc
+      # A nil or unparseable receiver degrades to the zero value the
+      # Go / Rust / Perl helpers document (empty string for toISOString,
+      # 0 otherwise), rather than raising mid-render.
+      t =
+        if recv.is_a?(Time)
+          recv
+        else
+          begin
+            Time.iso8601(recv.to_s)
+          rescue ArgumentError
+            nil
+          end
+        end
+      return (op == 'toISOString' ? '' : 0) if t.nil?
+      t = t.utc
       case op
       when 'getUTCFullYear' then t.year
       when 'getUTCMonth' then t.mon - 1

--- a/packages/adapter-erb/lib/barefoot_js.rb
+++ b/packages/adapter-erb/lib/barefoot_js.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'set'
+require 'time'
 require 'barefoot_js/evaluator'
 require 'barefoot_js/search_params'
 
@@ -479,6 +480,31 @@ module BarefootJS
     def abs(value)
       n = number(value)
       nan_number?(n) ? n : n.abs
+    end
+
+    # `date(recv, op)` -- zero-arg `Date.prototype` method lowering (#2274,
+    # spec entry "date"). `recv` arrives as either this runtime's own `Time`
+    # or an ISO-8601 String (a template prop may carry either depending on
+    # how the host populated it), so both normalize through `Time.iso8601`
+    # / `#utc` to the same instant before dispatch. `#mon` is 1-based in
+    # Ruby; only `getUTCMonth` subtracts 1 to match JS's 0-based month.
+    # `getTime` sums whole milliseconds from `tv_sec`/`tv_nsec` rather than
+    # rounding a Float ms value -- `tv_nsec` is always the non-negative
+    # sub-second remainder (Ruby normalizes `Time`'s internal rational),
+    # even for a pre-epoch instant, so integer division here stays exact.
+    def date(recv, op)
+      t = (recv.is_a?(Time) ? recv : Time.iso8601(recv.to_s)).utc
+      case op
+      when 'getUTCFullYear' then t.year
+      when 'getUTCMonth' then t.mon - 1
+      when 'getUTCDate' then t.day
+      when 'getUTCHours' then t.hour
+      when 'getUTCMinutes' then t.min
+      when 'getUTCSeconds' then t.sec
+      when 'getTime' then (t.tv_sec * 1000) + (t.tv_nsec / 1_000_000)
+      when 'toISOString' then t.strftime('%Y-%m-%dT%H:%M:%S.%LZ')
+      else 0
+      end
     end
 
     # -----------------------------------------------------------------

--- a/packages/adapter-erb/test/helper_vectors_test.rb
+++ b/packages/adapter-erb/test/helper_vectors_test.rb
@@ -81,6 +81,7 @@ class HelperVectorsTest < Minitest::Test
     'max' => ->(a, b) { BF.max(a, b) },
     'abs' => ->(v) { BF.abs(v) },
     'to_fixed' => ->(*a) { BF.to_fixed(*a) },
+    'date' => ->(recv, op) { BF.date(recv, op) },
 
     'lower' => ->(s) { BF.lc(s) },
     'upper' => ->(s) { BF.uc(s) },

--- a/packages/adapter-erb/test/helper_vectors_test.rb
+++ b/packages/adapter-erb/test/helper_vectors_test.rb
@@ -3,6 +3,7 @@
 require 'minitest/autorun'
 require 'json'
 require 'set'
+require 'time'
 require 'barefoot_js'
 
 # Golden helper vectors generated from the JS reference implementations
@@ -48,6 +49,19 @@ class HelperVectorsTest < Minitest::Test
     # via a looks_like_number probe -- one comparison covers every probe
     # shape here without a cross-type false positive.
     ->(item) { item.is_a?(Hash) && item[key] == value }
+  end
+
+  # Materializes the `{"$date": "<ISO>"}` native-date arg sentinel (#2288)
+  # into a real `Time`, so `date`'s native-receiver branch (not just its
+  # ISO-string branch) is exercised -- recurses through arrays/hashes the
+  # same shape `normalize_arg` walks in the Perl port, since a vector's
+  # `args` may nest the sentinel inside a higher-order projection payload.
+  def self.materialize_arg(v)
+    return v.map { |x| materialize_arg(x) } if v.is_a?(Array)
+    return Time.iso8601(v[:"$date"]) if v.is_a?(Hash) && v.keys == [:"$date"]
+    return v.transform_values { |x| materialize_arg(x) } if v.is_a?(Hash)
+
+    v
   end
 
   # One binding per canonical helper id in the spec catalogue, bound to the
@@ -200,7 +214,7 @@ class HelperVectorsTest < Minitest::Test
         refute_nil bind, "no Ruby binding for helper '#{fn}' -- add it to BINDINGS in #{__FILE__}"
         next unless bind
 
-        args = vector_case[:args]
+        args = vector_case[:args].map { |a| self.class.materialize_arg(a) }
         got = nil
         err = nil
         begin

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 	"unicode"
 	"unicode/utf8"
 )
@@ -63,6 +64,10 @@ func FuncMap() template.FuncMap {
 		// (include, key, value) triples → "base?k=v&…", mirroring a
 		// URLSearchParams builder with guarded `.set()` calls.
 		"bf_query": Query,
+
+		// Date method lowering (#2274, spec entry "date"): the lowering
+		// target for a zero-arg call on a Date-typed prop.
+		"bf_date": Date,
 
 		// JSON / numeric primitives — JS-compat callees registered on
 		// the Go adapter's `templatePrimitives` map (#1188).
@@ -252,6 +257,77 @@ func Query(base string, triples ...any) string {
 		b.WriteString(formEscape(p.val))
 	}
 	return base + b.String()
+}
+
+// Date implements the `date` helper (spec/template-helpers.md, #2274) — the
+// lowering target for a zero-arg call on a Date-typed prop
+// (`createdAt.toISOString()`). recv accepts the runtime's own `time.Time` /
+// `*time.Time` (however the host framework populated the prop) OR an
+// ISO-8601 string (the wire form a JSON-sourced prop arrives as); either is
+// normalized to UTC before dispatching op, matching the client `Date`'s own
+// instant semantics regardless of which shape reaches this helper. A nil /
+// unparsable receiver yields this runtime's zero value for the requested op
+// (0 for every numeric accessor, "" for toISOString) rather than panicking
+// mid-render — the same tolerance `String`/`Number` already extend to a nil
+// prop. `getUTCMonth` subtracts 1: Go's `time.Month` is 1-based, JS's is not
+// (spec entry "date" is explicit that JS wins here).
+func Date(recv any, op string) any {
+	t, ok := toTime(recv)
+	if !ok {
+		if op == "toISOString" {
+			return ""
+		}
+		return 0
+	}
+	t = t.UTC()
+	switch op {
+	case "getUTCFullYear":
+		return t.Year()
+	case "getUTCMonth":
+		return int(t.Month()) - 1
+	case "getUTCDate":
+		return t.Day()
+	case "getUTCHours":
+		return t.Hour()
+	case "getUTCMinutes":
+		return t.Minute()
+	case "getUTCSeconds":
+		return t.Second()
+	case "getTime":
+		return t.UnixMilli()
+	case "toISOString":
+		return t.Format("2006-01-02T15:04:05.000Z")
+	default:
+		return 0
+	}
+}
+
+// toTime normalizes a `Date` helper receiver to a `time.Time`: the runtime's
+// own `time.Time` / `*time.Time`, or an ISO-8601 string parsed with
+// `time.RFC3339Nano` (accepts both the `Z`-suffixed and numeric-offset
+// forms, and any sub-second precision — including the millisecond precision
+// every value this runtime itself ever produces via `toISOString` above).
+// Anything else (nil, an unparsable string, an unrelated type) reports !ok
+// so `Date` can apply its documented zero-value fallback instead of
+// panicking.
+func toTime(recv any) (time.Time, bool) {
+	switch v := recv.(type) {
+	case time.Time:
+		return v, true
+	case *time.Time:
+		if v == nil {
+			return time.Time{}, false
+		}
+		return *v, true
+	case string:
+		t, err := time.Parse(time.RFC3339Nano, v)
+		if err != nil {
+			return time.Time{}, false
+		}
+		return t, true
+	default:
+		return time.Time{}, false
+	}
 }
 
 // asStringSlice reports whether v is a query *array* value and, if so, returns

--- a/packages/adapter-go-template/runtime/vectors_test.go
+++ b/packages/adapter-go-template/runtime/vectors_test.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 // vectorsPath points at the golden vectors generated from the JS
@@ -324,6 +325,18 @@ func normalizeVectorValue(v any) any {
 				case "-Infinity":
 					return math.Inf(-1)
 				}
+			}
+			// Native-date arg sentinel (#2288): {"$date": "<ISO>"},
+			// materialized into the runtime's own time.Time so Date()'s
+			// native-receiver branch (not just its string branch) is
+			// exercised. Parse failure panics rather than silently
+			// falling through to the zero-value branch under test.
+			if s, ok := x["$date"].(string); ok {
+				t, err := time.Parse(time.RFC3339Nano, s)
+				if err != nil {
+					panic(err)
+				}
+				return t
 			}
 		}
 		for k := range x {

--- a/packages/adapter-go-template/runtime/vectors_test.go
+++ b/packages/adapter-go-template/runtime/vectors_test.go
@@ -132,6 +132,7 @@ var vectorBindings = map[string]func(args []any) any{
 		return NewSearchParams(args[0].(string)).Get(args[1].(string))
 	},
 	"query":      func(args []any) any { return Query(args[0].(string), args[1:]...) },
+	"date":       func(args []any) any { return Date(args[0], args[1].(string)) },
 	"every":      func(args []any) any { return Every(args[0], args[1].(string)) },
 	"some":       func(args []any) any { return Some(args[0], args[1].(string)) },
 	"filter":     func(args []any) any { return Filter(args[0], args[1].(string), args[2]) },

--- a/packages/adapter-jinja/python/barefootjs/runtime.py
+++ b/packages/adapter-jinja/python/barefootjs/runtime.py
@@ -70,6 +70,7 @@ site below):
 
 from __future__ import annotations
 
+import datetime
 import functools
 import math
 import re
@@ -471,6 +472,12 @@ def _numeric_value(v: Any) -> float:
     if isinstance(v, str):
         return parse_number_literal(v) if looks_like_number(v) else 0.0
     return 0.0
+
+
+# Epoch anchor for `date()`'s `getTime` -- an aware UTC `datetime` so
+# subtraction from any other aware `datetime` (any tzinfo) yields the correct
+# instant delta regardless of the operand's own offset.
+_DATE_EPOCH = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
 
 
 def _derive_stash_from_defaults(defaults: dict, props: dict) -> dict:
@@ -892,6 +899,44 @@ class BarefootJS:
         """`Math.abs()` (#2168 math-methods)."""
         n = js_number(value)
         return n if _is_nan(n) else abs(n)
+
+    def date(self, recv: Any, op: str) -> Any:
+        """`date(recv, op)` -- zero-arg `Date.prototype` method lowering
+        (#2274, spec entry "date"). `recv` arrives as either this runtime's
+        own `datetime` or an ISO-8601 string (a template prop may carry
+        either depending on how the host populated it); `datetime.
+        fromisoformat` accepts the `Z` UTC suffix directly (Python 3.11+).
+        A naive `datetime` is treated as already-UTC (this runtime never
+        produces one); an aware one converts via `astimezone` so a
+        non-UTC-offset input still dispatches against the right instant.
+        `.month` is 1-based in Python; only `getUTCMonth` subtracts 1 to
+        match JS's 0-based month. `getTime` divides the exact `timedelta`
+        from the epoch by a 1ms `timedelta` (floor division on an exact
+        `timedelta` ratio) rather than rounding a float ms value, so a
+        pre-epoch instant stays exact."""
+        dt = recv if isinstance(recv, datetime.datetime) else datetime.datetime.fromisoformat(str(recv))
+        dt = dt.replace(tzinfo=datetime.timezone.utc) if dt.tzinfo is None else dt.astimezone(datetime.timezone.utc)
+        if op == "getUTCFullYear":
+            return dt.year
+        if op == "getUTCMonth":
+            return dt.month - 1
+        if op == "getUTCDate":
+            return dt.day
+        if op == "getUTCHours":
+            return dt.hour
+        if op == "getUTCMinutes":
+            return dt.minute
+        if op == "getUTCSeconds":
+            return dt.second
+        if op == "getTime":
+            return (dt - _DATE_EPOCH) // datetime.timedelta(milliseconds=1)
+        if op == "toISOString":
+            return (
+                f"{dt.year:04d}-{dt.month:02d}-{dt.day:02d}T"
+                f"{dt.hour:02d}:{dt.minute:02d}:{dt.second:02d}."
+                f"{dt.microsecond // 1000:03d}Z"
+            )
+        return 0
 
     # -----------------------------------------------------------------
     # Array / String method helpers (#1448 Tier A)

--- a/packages/adapter-jinja/python/barefootjs/runtime.py
+++ b/packages/adapter-jinja/python/barefootjs/runtime.py
@@ -904,17 +904,30 @@ class BarefootJS:
         """`date(recv, op)` -- zero-arg `Date.prototype` method lowering
         (#2274, spec entry "date"). `recv` arrives as either this runtime's
         own `datetime` or an ISO-8601 string (a template prop may carry
-        either depending on how the host populated it); `datetime.
-        fromisoformat` accepts the `Z` UTC suffix directly (Python 3.11+).
-        A naive `datetime` is treated as already-UTC (this runtime never
-        produces one); an aware one converts via `astimezone` so a
-        non-UTC-offset input still dispatches against the right instant.
-        `.month` is 1-based in Python; only `getUTCMonth` subtracts 1 to
-        match JS's 0-based month. `getTime` divides the exact `timedelta`
-        from the epoch by a 1ms `timedelta` (floor division on an exact
-        `timedelta` ratio) rather than rounding a float ms value, so a
-        pre-epoch instant stays exact."""
-        dt = recv if isinstance(recv, datetime.datetime) else datetime.datetime.fromisoformat(str(recv))
+        either depending on how the host populated it). A naive `datetime`
+        is treated as already-UTC (this runtime never produces one); an
+        aware one converts via `astimezone` so a non-UTC-offset input still
+        dispatches against the right instant. `.month` is 1-based in
+        Python; only `getUTCMonth` subtracts 1 to match JS's 0-based month.
+        `getTime` divides the exact `timedelta` from the epoch by a 1ms
+        `timedelta` (floor division on an exact `timedelta` ratio) rather
+        than rounding a float ms value, so a pre-epoch instant stays
+        exact."""
+        if isinstance(recv, datetime.datetime):
+            dt = recv
+        else:
+            # `fromisoformat` only learned the bare `Z` suffix in 3.11 but
+            # accepts an explicit `+00:00` offset since 3.7, so a `>=3.10`
+            # install parses the same string once rewritten. A nil or
+            # unparseable receiver degrades to the zero value the Go / Rust
+            # / Perl helpers document, not a render-time crash.
+            s = str(recv)
+            if s.endswith("Z"):
+                s = s[:-1] + "+00:00"
+            try:
+                dt = datetime.datetime.fromisoformat(s)
+            except ValueError:
+                return "" if op == "toISOString" else 0
         dt = dt.replace(tzinfo=datetime.timezone.utc) if dt.tzinfo is None else dt.astimezone(datetime.timezone.utc)
         if op == "getUTCFullYear":
             return dt.year

--- a/packages/adapter-jinja/python/tests/test_helper_vectors.py
+++ b/packages/adapter-jinja/python/tests/test_helper_vectors.py
@@ -23,6 +23,7 @@ monorepo checkout), matching the Perl/Go harnesses' `skip_all` policy.
 from __future__ import annotations
 
 import builtins
+import datetime
 import json
 import math
 import os
@@ -87,6 +88,22 @@ def _bind_reduce(recv, op, key_kind, key, rtype, init, direction):
         recv,
         {"op": op, "key_kind": key_kind, "key": key, "type": rtype, "init": seed, "direction": direction},
     )
+
+
+def _materialize_arg(v):
+    """Materializes the `{"$date": "<ISO>"}` native-date arg sentinel
+    (#2288) into a real `datetime`, so `date`'s native-receiver branch (not
+    just its ISO-string branch) is exercised. Recurses through lists/dicts
+    the same shape the Perl port's `normalize_arg` walks, since a vector's
+    `args` may nest the sentinel inside a higher-order projection payload."""
+    if isinstance(v, list):
+        return [_materialize_arg(x) for x in v]
+    if isinstance(v, dict) and list(v) == ["$date"]:
+        s = v["$date"]
+        return datetime.datetime.fromisoformat(s[:-1] + "+00:00" if s.endswith("Z") else s)
+    if isinstance(v, dict):
+        return {k: _materialize_arg(x) for k, x in v.items()}
+    return v
 
 
 def _bind_flat_map_tuple(recv, *flat):
@@ -241,7 +258,8 @@ class HelperVectorsTest(unittest.TestCase):
         seen_declarations = set()
 
         for case in doc["cases"]:
-            fn, note, args, expect = case["fn"], case["note"], case["args"], case["expect"]
+            fn, note, expect = case["fn"], case["note"], case["expect"]
+            args = [_materialize_arg(a) for a in case["args"]]
             key = f"{fn}/{note}"
             with self.subTest(key=key):
                 if fn in UNSUPPORTED:

--- a/packages/adapter-jinja/python/tests/test_helper_vectors.py
+++ b/packages/adapter-jinja/python/tests/test_helper_vectors.py
@@ -121,6 +121,7 @@ BINDINGS = {
     "max": bf.max,
     "abs": bf.abs,
     "to_fixed": lambda *a: bf.to_fixed(*a),
+    "date": lambda recv, op: bf.date(recv, op),
     "lower": bf.lc,
     "upper": bf.uc,
     "trim": bf.trim,

--- a/packages/adapter-perl/lib/BarefootJS.pm
+++ b/packages/adapter-perl/lib/BarefootJS.pm
@@ -700,9 +700,13 @@ sub date ($self, $recv, $op) {
 # `BarefootJS::Date` (unwraps `epoch_ms` directly) or an ISO-8601 string
 # (`YYYY-MM-DDTHH:MM:SS[.sss]Z`, the exact shape every ISO string this
 # runtime itself ever produces via `toISOString` above, and the shape the
-# golden vectors exercise). `Time::Local::timegm` (core, like `POSIX`)
-# converts the broken-down UTC fields to epoch SECONDS correctly across the
-# full pre-1970/post-2038 range on a 64-bit `time_t` build; the optional
+# golden vectors exercise). `Time::Local::timegm_modern` (core since
+# Time::Local 1.27, like `POSIX`) converts the broken-down UTC fields to
+# epoch SECONDS correctly across the full pre-1970/post-2038 range on a
+# 64-bit `time_t` build; unlike the legacy `timegm`, it takes `$y` as a
+# literal calendar year with no two-digit-year windowing heuristic — the
+# regex above always captures a 4-digit year, so that heuristic would only
+# ever be a latent footgun here, never a real branch. The optional
 # millisecond group defaults to 0. Returns `undef` for anything else
 # (unparsable string, wrong type) so `date` can apply its documented
 # zero-value fallback instead of dying mid-render.
@@ -714,7 +718,7 @@ sub _date_epoch_ms ($recv) {
     return undef unless defined $recv;
     return undef unless $recv =~ /\A(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{3}))?Z\z/;
     my ($y, $mon, $day, $h, $min, $s, $ms) = ($1, $2, $3, $4, $5, $6, $7 // 0);
-    my $epoch_s = Time::Local::timegm($s, $min, $h, $day, $mon - 1, $y);
+    my $epoch_s = Time::Local::timegm_modern($s, $min, $h, $day, $mon - 1, $y);
     return $epoch_s * 1000 + $ms;
 }
 

--- a/packages/adapter-perl/lib/BarefootJS.pm
+++ b/packages/adapter-perl/lib/BarefootJS.pm
@@ -7,6 +7,7 @@ use feature 'signatures';
 no warnings 'experimental::signatures';
 
 use POSIX ();
+use Time::Local ();
 use Scalar::Util qw(looks_like_number weaken);
 use BarefootJS::Evaluator ();
 
@@ -660,6 +661,61 @@ sub abs ($self, $value) {
     my $n = $self->number($value);
     return $n if _is_nan($n);
     return CORE::abs($n);
+}
+
+# `date($recv, $op)` -- zero-arg `Date.prototype` method lowering (#2274,
+# spec entry "date"). `$recv` arrives as either a `BarefootJS::Date` (this
+# runtime's own epoch-ms wrapper, below) or an ISO-8601 string (a template
+# prop may carry either depending on how the host populated it); both
+# normalize to a single epoch-ms integer via `_date_epoch_ms` before
+# dispatch. `gmtime`'s `mon` field (index 4) is ALREADY 0-based in Perl
+# (unlike every other backend's native month accessor), so — uniquely among
+# this catalogue's ports — `getUTCMonth` needs NO -1. `getTime` is the exact
+# epoch-ms integer already carried by `$recv`/parsed from the string, so it
+# needs no float rounding even for a pre-epoch instant.
+sub date ($self, $recv, $op) {
+    my $ms = _date_epoch_ms($recv);
+    return $op eq 'toISOString' ? '' : 0 unless defined $ms;
+    return $ms if $op eq 'getTime';
+
+    # Floor (not truncate) toward -Infinity: Perl's `/` truncates toward
+    # zero, which would round a negative ms value (e.g. -14182939877) up to
+    # the wrong whole second (-14182939 instead of -14182940).
+    my $sec = POSIX::floor($ms / 1000);
+    my $msec = $ms - ($sec * 1000);
+    my @t = gmtime($sec);    # (sec,min,hour,mday,mon,year,...) -- mon is 0-based
+
+    return $t[5] + 1900 if $op eq 'getUTCFullYear';
+    return $t[4]        if $op eq 'getUTCMonth';    # already 0-based, no -1
+    return $t[3]         if $op eq 'getUTCDate';
+    return $t[2]         if $op eq 'getUTCHours';
+    return $t[1]         if $op eq 'getUTCMinutes';
+    return $t[0]         if $op eq 'getUTCSeconds';
+    return POSIX::strftime('%Y-%m-%dT%H:%M:%S', @t) . sprintf('.%03dZ', $msec)
+        if $op eq 'toISOString';
+    return 0;
+}
+
+# Normalizes a `date()` receiver to a single epoch-ms integer: a
+# `BarefootJS::Date` (unwraps `epoch_ms` directly) or an ISO-8601 string
+# (`YYYY-MM-DDTHH:MM:SS[.sss]Z`, the exact shape every ISO string this
+# runtime itself ever produces via `toISOString` above, and the shape the
+# golden vectors exercise). `Time::Local::timegm` (core, like `POSIX`)
+# converts the broken-down UTC fields to epoch SECONDS correctly across the
+# full pre-1970/post-2038 range on a 64-bit `time_t` build; the optional
+# millisecond group defaults to 0. Returns `undef` for anything else
+# (unparsable string, wrong type) so `date` can apply its documented
+# zero-value fallback instead of dying mid-render.
+sub _date_epoch_ms ($recv) {
+    if (ref($recv) eq 'BarefootJS::Date') {
+        return $recv->{epoch_ms};
+    }
+    return undef if ref($recv);
+    return undef unless defined $recv;
+    return undef unless $recv =~ /\A(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{3}))?Z\z/;
+    my ($y, $mon, $day, $h, $min, $s, $ms) = ($1, $2, $3, $4, $5, $6, $7 // 0);
+    my $epoch_s = Time::Local::timegm($s, $min, $h, $day, $mon - 1, $y);
+    return $epoch_s * 1000 + $ms;
 }
 
 # ---------------------------------------------------------------------------
@@ -1791,6 +1847,24 @@ sub spread_attrs ($self, $bag) {
     # returns a Mojo::ByteStream).
     return $self->backend->mark_raw(CORE::join(' ', @parts));
 }
+
+# ---------------------------------------------------------------------------
+# BarefootJS::Date -- this runtime's native date/time type, holding a single
+# epoch-ms integer. Exists so a Perl host can hand `date()` (above) a real
+# typed value instead of always going through the ISO-8601 string half of
+# the helper's contract (mirrors the Go runtime's `time.Time` / the Ruby
+# runtime's `Time` as the "native" receiver shape in spec/template-helpers.md
+# "date"). Deliberately minimal: one field, one constructor -- this is a
+# value wrapper, not a full calendar API.
+# ---------------------------------------------------------------------------
+package BarefootJS::Date;
+
+sub new {
+    my ($class, $epoch_ms) = @_;
+    return bless { epoch_ms => $epoch_ms }, $class;
+}
+
+package BarefootJS;
 
 1;
 __END__

--- a/packages/adapter-perl/lib/BarefootJS.pm
+++ b/packages/adapter-perl/lib/BarefootJS.pm
@@ -853,8 +853,8 @@ sub is_element ($self, $v) {
     return 0 unless ref($v) eq 'HASH';
     my ($has_tag, $has_props) = (0, 0);
     for my $key (keys %$v) {
-        $has_tag = 1 if lc($key) eq 'tag';
-        $has_props = 1 if lc($key) eq 'props';
+        $has_tag = 1 if CORE::lc($key) eq 'tag';
+        $has_props = 1 if CORE::lc($key) eq 'props';
     }
     return ($has_tag && $has_props) ? 1 : 0;
 }

--- a/packages/adapter-perl/t/helper_vectors.t
+++ b/packages/adapter-perl/t/helper_vectors.t
@@ -264,11 +264,20 @@ done_testing;
 # Production Perl template data has no boolean type — the adapters pass
 # 1/0 where JS has true/false — so JSON::PP boolean objects in vector
 # ARGS are lowered to 1/0 before reaching a binding. Expects keep their
-# boolean identity (vector_ok compares those by truthiness).
+# boolean identity (vector_ok compares those by truthiness). A HASH whose
+# only key is `$date` is the native-date arg sentinel (#2288): materialize
+# it into a `BarefootJS::Date` (reusing `_date_epoch_ms`'s own ISO parse,
+# rather than re-deriving epoch-ms here) so `date()`'s native-receiver
+# branch is exercised, not just its ISO-string branch.
 sub normalize_arg {
     my ($v) = @_;
     return [ map { normalize_arg($_) } @$v ] if ref $v eq 'ARRAY';
-    return { map { $_ => normalize_arg($v->{$_}) } keys %$v } if ref $v eq 'HASH';
+    if (ref $v eq 'HASH') {
+        my @keys = keys %$v;
+        return BarefootJS::Date->new(BarefootJS::_date_epoch_ms($v->{'$date'}))
+            if @keys == 1 && $keys[0] eq '$date';
+        return { map { $_ => normalize_arg($v->{$_}) } @keys };
+    }
     return JSON::PP::is_bool($v) ? ($v ? 1 : 0) : $v;
 }
 

--- a/packages/adapter-perl/t/helper_vectors.t
+++ b/packages/adapter-perl/t/helper_vectors.t
@@ -91,6 +91,7 @@ my %bindings = (
     max    => sub { $bf->max($_[0], $_[1]) },
     abs    => sub { $bf->abs($_[0]) },
     to_fixed => sub { $bf->to_fixed(@_) },
+    date     => sub { $bf->date($_[0], $_[1]) },
 
     # The Mojo renderer emits native lc()/uc(); Xslate emits $bf.lc /
     # $bf.uc. The helper methods wrap CORE::lc/uc, so binding them

--- a/packages/adapter-php/src/BarefootJS.php
+++ b/packages/adapter-php/src/BarefootJS.php
@@ -725,9 +725,24 @@ final class BarefootJS
      */
     public function date($recv, string $op)
     {
-        $d = $recv instanceof \DateTimeInterface
-            ? \DateTimeImmutable::createFromInterface($recv)
-            : new \DateTimeImmutable($this->string($recv));
+        // A nil or unparseable receiver degrades to the zero value the
+        // Go / Rust / Perl helpers document (empty string for toISOString,
+        // 0 otherwise). Without this an empty string would silently become
+        // `new DateTimeImmutable('')` = the current time (non-deterministic
+        // render), and a malformed string would throw mid-render.
+        if ($recv instanceof \DateTimeInterface) {
+            $d = \DateTimeImmutable::createFromInterface($recv);
+        } else {
+            $s = $this->string($recv);
+            if ($s === '') {
+                return $op === 'toISOString' ? '' : 0;
+            }
+            try {
+                $d = new \DateTimeImmutable($s);
+            } catch (\Exception $e) {
+                return $op === 'toISOString' ? '' : 0;
+            }
+        }
         $d = $d->setTimezone(new \DateTimeZone('UTC'));
         switch ($op) {
             case 'getUTCFullYear': return (int) $d->format('Y');

--- a/packages/adapter-php/src/BarefootJS.php
+++ b/packages/adapter-php/src/BarefootJS.php
@@ -739,7 +739,12 @@ final class BarefootJS
             }
             try {
                 $d = new \DateTimeImmutable($s);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
+                // \Throwable, not \Exception: a malformed string throws
+                // DateMalformedStringException (an Exception), but under
+                // Xdebug the exception's dynamic-property enrichment raises
+                // a bare Error (not an Exception) on PHP >= 8.2 — degrade
+                // on any Throwable so the render survives either way.
                 return $op === 'toISOString' ? '' : 0;
             }
         }

--- a/packages/adapter-php/src/BarefootJS.php
+++ b/packages/adapter-php/src/BarefootJS.php
@@ -707,6 +707,41 @@ final class BarefootJS
         return is_nan($n) ? $n : abs($n);
     }
 
+    /**
+     * `date($recv, $op)` -- zero-arg `Date.prototype` method lowering
+     * (#2274, spec entry "date"). `$recv` arrives as either this runtime's
+     * own `\DateTimeInterface` or an ISO-8601 string (a template prop may
+     * carry either depending on how the host populated it); both normalize
+     * to a UTC `DateTimeImmutable` before dispatch. PHP's month accessor
+     * (`n`) is 1-based; only `getUTCMonth` subtracts 1 to match JS's
+     * 0-based month. `getTime` sums whole milliseconds from
+     * `getTimestamp()` (whole seconds) and `format('v')` -- the ALWAYS
+     * non-negative 0-999 sub-second remainder PHP's `DateTime` already
+     * normalizes, even for a pre-epoch instant -- rather than
+     * `format('Uv')`, which string-CONCATENATES `U` and `v` and produces a
+     * garbage value for a negative timestamp (verified against a live PHP
+     * 8.4 interpreter: `(new DateTimeImmutable('1969-07-20T20:17:40.123Z'))
+     * ->format('Uv')` is `"-14182940123"`, not the correct `-14182939877`).
+     */
+    public function date($recv, string $op)
+    {
+        $d = $recv instanceof \DateTimeInterface
+            ? \DateTimeImmutable::createFromInterface($recv)
+            : new \DateTimeImmutable($this->string($recv));
+        $d = $d->setTimezone(new \DateTimeZone('UTC'));
+        switch ($op) {
+            case 'getUTCFullYear': return (int) $d->format('Y');
+            case 'getUTCMonth': return (int) $d->format('n') - 1;
+            case 'getUTCDate': return (int) $d->format('j');
+            case 'getUTCHours': return (int) $d->format('H');
+            case 'getUTCMinutes': return (int) $d->format('i');
+            case 'getUTCSeconds': return (int) $d->format('s');
+            case 'getTime': return ($d->getTimestamp() * 1000) + (int) $d->format('v');
+            case 'toISOString': return $d->format('Y-m-d\TH:i:s.v\Z');
+            default: return 0;
+        }
+    }
+
     // -----------------------------------------------------------------
     // Array / String method helpers (#1448 Tier A)
     // -----------------------------------------------------------------

--- a/packages/adapter-php/tests/test_helper_vectors.php
+++ b/packages/adapter-php/tests/test_helper_vectors.php
@@ -126,6 +126,23 @@ function bfv_bind_reduce(BarefootJS $bf, $recv, $op, $keyKind, $key, $rtype, $in
 }
 
 /**
+ * Materializes the `{"$date": "<ISO>"}` native-date arg sentinel (#2288)
+ * into a real DateTimeImmutable, so `date`'s native-receiver branch (not
+ * just its ISO-string branch) is exercised. Recurses through arrays the
+ * same shape the Perl port's normalize_arg walks, since a vector's `args`
+ * may nest the sentinel inside a higher-order projection payload.
+ */
+function bfv_materialize(array $args): array
+{
+    return array_map(function ($a) {
+        if (is_array($a) && array_keys($a) === ['$date']) {
+            return new \DateTimeImmutable($a['$date']);
+        }
+        return is_array($a) ? bfv_materialize($a) : $a;
+    }, $args);
+}
+
+/**
  * Dispatch one vector case's `fn` to the exact runtime call shape a
  * compiled template would emit. Throws for helper ids with no PHP binding
  * (fail loudly rather than silently skip) and lets underlying runtime
@@ -286,7 +303,7 @@ $seenDeclarations = [];
 foreach ($doc['cases'] as $case) {
     $fn = $case['fn'];
     $note = $case['note'];
-    $args = $case['args'];
+    $args = bfv_materialize($case['args']);
     $expect = $case['expect'];
     $key = "{$fn}/{$note}";
 

--- a/packages/adapter-php/tests/test_helper_vectors.php
+++ b/packages/adapter-php/tests/test_helper_vectors.php
@@ -150,6 +150,7 @@ function bfv_call(BarefootJS $bf, string $fn, array $args)
         case 'max': return $bf->max($args[0], $args[1]);
         case 'abs': return $bf->abs($args[0]);
         case 'to_fixed': return $bf->to_fixed(...$args);
+        case 'date': return $bf->date($args[0], $args[1]);
         case 'lower': return $bf->lc($args[0]);
         case 'upper': return $bf->uc($args[0]);
         case 'trim': return $bf->trim($args[0]);

--- a/packages/adapter-rust/runtime/src/date.rs
+++ b/packages/adapter-rust/runtime/src/date.rs
@@ -1,0 +1,196 @@
+//! `date(recv, op)` -- zero-arg `Date.prototype` method lowering
+//! (spec/template-helpers.md "date", #2274). `recv` is either this
+//! runtime's own [`JsValue::Date`] (an epoch-millisecond `i64`) or an
+//! ISO-8601 `String` (a template prop may carry either depending on how
+//! the host populated it) -- both normalize to a single epoch-ms integer
+//! via [`epoch_ms_of`] before dispatch.
+//!
+//! No `chrono` (or any other date crate) is a dependency of this crate --
+//! see the design doc's fixed dependency list, the same constraint
+//! `num.rs`'s numeric-string grammar docstring cites for avoiding `regex`.
+//! Calendar <-> day-count conversion is Howard Hinnant's `civil_from_days`
+//! / `days_from_civil` (public-domain algorithm,
+//! <http://howardhinnant.github.io/date_algorithms.html>), correct for the
+//! full proleptic-Gregorian range this catalogue's vectors exercise
+//! (epoch 0, a pre-1970 instant, a leap day, and a four-digit-year
+//! boundary). Every division that must floor (not truncate) toward
+//! -Infinity for a negative dividend uses `div_euclid`/`rem_euclid`
+//! explicitly rather than plain `/`/`%` (which truncate toward zero in
+//! Rust) -- the one correctness trap this port must not reproduce.
+
+use crate::num::JsValue;
+
+const MS_PER_DAY: i64 = 86_400_000;
+
+/// Hinnant `days_from_civil`: (proleptic-Gregorian y/m/d) -> days since the
+/// Unix epoch (1970-01-01). `m` is 1-based (January = 1).
+fn days_from_civil(y: i64, m: i64, d: i64) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = y.div_euclid(400);
+    let yoe = y.rem_euclid(400); // [0, 399]
+    let mp = if m > 2 { m - 3 } else { m + 9 }; // [0, 11], Mar=0 .. Feb=11
+    let doy = (153 * mp + 2).div_euclid(5) + d - 1; // [0, 365]
+    let doe = yoe * 365 + yoe.div_euclid(4) - yoe.div_euclid(100) + doy; // [0, 146096]
+    era * 146_097 + doe - 719_468
+}
+
+/// Hinnant `civil_from_days`: days since the Unix epoch -> (y, m, d), `m`
+/// 1-based. Inverse of [`days_from_civil`].
+fn civil_from_days(z: i64) -> (i64, i64, i64) {
+    let z = z + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097); // [0, 146096], always non-negative
+    // `doe` (and everything derived from it below) stays within [0,
+    // 146096] for the rest of this function, so plain truncating `/`
+    // already equals floor division here -- only the two extractions above
+    // (on a value that CAN be negative) need `div_euclid`.
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365; // [0, 399]
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11]
+    let d = doy - (153 * mp + 2) / 5 + 1; // [1, 31]
+    let m = if mp < 10 { mp + 3 } else { mp - 9 }; // [1, 12]
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}
+
+/// Parse the exact ISO-8601 shape this catalogue's contract uses --
+/// `YYYY-MM-DDTHH:MM:SS(.mmm)?Z`, always UTC (a bare `Z`, no numeric
+/// offset) -- into epoch milliseconds. This is the one shape every string
+/// the golden vectors pass in uses, and the one shape [`format_iso8601`]
+/// below ever produces, so a fixed-width positional parse (no `regex`
+/// crate in this crate's dependency set) covers the full contract without
+/// a general-purpose date-string grammar.
+pub fn parse_iso8601(s: &str) -> Option<i64> {
+    let b = s.as_bytes();
+    let has_ms = match b.len() {
+        20 => false,
+        24 => true,
+        _ => return None,
+    };
+    if b[4] != b'-' || b[7] != b'-' || b[10] != b'T' || b[13] != b':' || b[16] != b':' {
+        return None;
+    }
+    if has_ms && b[19] != b'.' {
+        return None;
+    }
+    if b[b.len() - 1] != b'Z' {
+        return None;
+    }
+    let year: i64 = s.get(0..4)?.parse().ok()?;
+    let month: i64 = s.get(5..7)?.parse().ok()?;
+    let day: i64 = s.get(8..10)?.parse().ok()?;
+    let hour: i64 = s.get(11..13)?.parse().ok()?;
+    let minute: i64 = s.get(14..16)?.parse().ok()?;
+    let second: i64 = s.get(17..19)?.parse().ok()?;
+    let ms: i64 = if has_ms { s.get(20..23)?.parse().ok()? } else { 0 };
+    if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+        return None;
+    }
+    if hour > 23 || minute > 59 || second > 60 {
+        return None;
+    }
+    let days = days_from_civil(year, month, day);
+    Some(days * MS_PER_DAY + hour * 3_600_000 + minute * 60_000 + second * 1000 + ms)
+}
+
+/// The inverse of [`parse_iso8601`]: epoch milliseconds -> the exact JS
+/// `Date.prototype.toISOString` shape (always millisecond precision,
+/// always UTC).
+pub fn format_iso8601(ms: i64) -> String {
+    let days = ms.div_euclid(MS_PER_DAY);
+    let ms_of_day = ms.rem_euclid(MS_PER_DAY); // always [0, 86_399_999]
+    let (y, m, d) = civil_from_days(days);
+    let hour = ms_of_day / 3_600_000;
+    let minute = (ms_of_day / 60_000) % 60;
+    let second = (ms_of_day / 1000) % 60;
+    let msec = ms_of_day % 1000;
+    format!("{y:04}-{m:02}-{d:02}T{hour:02}:{minute:02}:{second:02}.{msec:03}Z")
+}
+
+/// Normalize a `date()` receiver to a single epoch-ms integer: this
+/// runtime's own [`JsValue::Date`] unwraps directly; an ISO-8601
+/// [`JsValue::String`] parses via [`parse_iso8601`]. Anything else (the
+/// receiver contract's only two accepted shapes are not met) is `None`,
+/// letting [`date`] apply its documented zero-value fallback.
+pub fn epoch_ms_of(recv: &JsValue) -> Option<i64> {
+    match recv {
+        JsValue::Date(ms) => Some(*ms),
+        JsValue::String(s) => parse_iso8601(s),
+        _ => None,
+    }
+}
+
+/// Dispatch one of the zero-arg `Date.prototype` ops the compiler's
+/// lowering plugin recognizes against an already-normalized epoch-ms
+/// instant. Every accessor and `getTime` render as an INTEGER (a whole
+/// `f64`, never fractional) -- `civil_from_days`'s inputs/outputs are all
+/// exact integers, so no rounding is possible here regardless of how far
+/// `ms` sits from the epoch. `getUTCMonth` is 0-based, matching JS (NOT
+/// `civil_from_days`'s own 1-based `m`, hence the `- 1`).
+pub fn date_op(ms: i64, op: &str) -> JsValue {
+    match op {
+        "getTime" => return JsValue::Number(ms as f64),
+        "toISOString" => return JsValue::String(format_iso8601(ms)),
+        _ => {}
+    }
+    let days = ms.div_euclid(MS_PER_DAY);
+    let ms_of_day = ms.rem_euclid(MS_PER_DAY);
+    let (y, m, d) = civil_from_days(days);
+    match op {
+        "getUTCFullYear" => JsValue::Number(y as f64),
+        "getUTCMonth" => JsValue::Number((m - 1) as f64),
+        "getUTCDate" => JsValue::Number(d as f64),
+        "getUTCHours" => JsValue::Number((ms_of_day / 3_600_000) as f64),
+        "getUTCMinutes" => JsValue::Number(((ms_of_day / 60_000) % 60) as f64),
+        "getUTCSeconds" => JsValue::Number(((ms_of_day / 1000) % 60) as f64),
+        _ => JsValue::Number(0.0),
+    }
+}
+
+/// `date(recv, op)` -- the full helper: normalize `recv` (native
+/// [`JsValue::Date`] or ISO-8601 string) then dispatch `op`. An
+/// unrecognized receiver shape falls back to `toTime`'s documented
+/// zero-value contract (mirrors the Go runtime's `Date`/`toTime` fallback
+/// pair): `''` for `toISOString`, `0` for every accessor/`getTime`.
+pub fn date(recv: &JsValue, op: &str) -> JsValue {
+    match epoch_ms_of(recv) {
+        Some(ms) => date_op(ms, op),
+        None if op == "toISOString" => JsValue::String(String::new()),
+        None => JsValue::Number(0.0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_epoch_0() {
+        let ms = parse_iso8601("1970-01-01T00:00:00.000Z").unwrap();
+        assert_eq!(ms, 0);
+        assert_eq!(format_iso8601(ms), "1970-01-01T00:00:00.000Z");
+    }
+
+    #[test]
+    fn round_trips_pre_1970() {
+        let ms = parse_iso8601("1969-07-20T20:17:40.123Z").unwrap();
+        assert_eq!(ms, -14_182_939_877);
+        assert_eq!(format_iso8601(ms), "1969-07-20T20:17:40.123Z");
+    }
+
+    #[test]
+    fn round_trips_leap_day() {
+        let ms = parse_iso8601("2024-02-29T23:59:59.999Z").unwrap();
+        assert_eq!(format_iso8601(ms), "2024-02-29T23:59:59.999Z");
+        assert_eq!(date_op(ms, "getUTCMonth"), JsValue::Number(1.0));
+        assert_eq!(date_op(ms, "getUTCDate"), JsValue::Number(29.0));
+    }
+
+    #[test]
+    fn round_trips_far_future() {
+        let ms = parse_iso8601("9999-12-31T23:59:59.999Z").unwrap();
+        assert_eq!(format_iso8601(ms), "9999-12-31T23:59:59.999Z");
+        assert_eq!(date_op(ms, "getUTCFullYear"), JsValue::Number(9999.0));
+    }
+}

--- a/packages/adapter-rust/runtime/src/evaluator.rs
+++ b/packages/adapter-rust/runtime/src/evaluator.rs
@@ -306,6 +306,14 @@ pub fn to_number(v: &JsValue) -> f64 {
             }
         }
         JsValue::Array(_) | JsValue::Object(_) => f64::NAN,
+        // Unreachable in practice: this evaluator only ever sees `JsValue`s
+        // decoded from a `serde_json::Value` ParsedExpr tree or produced by
+        // its own arithmetic, and JSON can't spell a `Date` (see the `num`
+        // module docstring) -- kept exhaustive rather than `unreachable!()`
+        // since `JsValue` is a shared, cross-module enum. `valueOf`-style
+        // (matches `runtime::js_number`'s `JsValue::Date` arm) for
+        // consistency if that ever changes.
+        JsValue::Date(ms) => *ms as f64,
     }
 }
 
@@ -335,6 +343,10 @@ pub fn to_string(v: &JsValue) -> String {
             .collect::<Vec<_>>()
             .join(","),
         JsValue::Object(_) => "[object Object]".to_string(),
+        // Unreachable in practice -- see `to_number`'s `JsValue::Date` arm
+        // above. `toISOString` is the one Date->string shape this
+        // catalogue defines (matches `runtime::js_string`).
+        JsValue::Date(ms) => crate::date::format_iso8601(*ms),
     }
 }
 
@@ -345,6 +357,10 @@ pub fn truthy(v: &JsValue) -> bool {
         JsValue::Number(n) => !n.is_nan() && *n != 0.0, // nonzero and not NaN
         JsValue::String(s) => !s.is_empty(),          // incl. the truthy "0"
         JsValue::Array(_) | JsValue::Object(_) => true,
+        // Unreachable in practice -- see `to_number`'s `JsValue::Date` arm
+        // above. A JS Date object is always truthy, like every other
+        // object.
+        JsValue::Date(_) => true,
     }
 }
 

--- a/packages/adapter-rust/runtime/src/lib.rs
+++ b/packages/adapter-rust/runtime/src/lib.rs
@@ -7,6 +7,7 @@
 //! documented divergences.
 
 pub mod backend_minijinja;
+pub mod date;
 pub mod evaluator;
 pub mod manifest;
 pub mod num;

--- a/packages/adapter-rust/runtime/src/num.rs
+++ b/packages/adapter-rust/runtime/src/num.rs
@@ -94,6 +94,16 @@ pub enum JsValue {
     /// contract for free, in one place, rather than re-sorting at the
     /// JSON-encoding boundary.
     Object(BTreeMap<String, JsValue>),
+    /// This runtime's own native `Date` receiver shape for `date()`'s
+    /// zero-arg method lowering (spec/template-helpers.md "date", #2274) --
+    /// a signed epoch-MILLISECOND integer (never a float), so a pre-1970
+    /// instant round-trips exactly with no rounding risk. The other half of
+    /// `date()`'s receiver contract, an ISO-8601 `String`, needs no
+    /// dedicated variant since [`JsValue::String`] already carries it; see
+    /// `date::epoch_ms_of`. JSON can't spell this type (`from_json` never
+    /// produces one); `to_json` renders it via its `toISOString` form,
+    /// matching JS `JSON.stringify(date)`.
+    Date(i64),
 }
 
 impl JsValue {
@@ -159,6 +169,9 @@ impl JsValue {
             JsValue::Object(o) => {
                 JsonValue::Object(o.iter().map(|(k, v)| (k.clone(), v.to_json())).collect())
             }
+            // Matches JS `JSON.stringify(date)`, which calls the date's own
+            // `toJSON` -> `toISOString`.
+            JsValue::Date(ms) => JsonValue::String(crate::date::format_iso8601(*ms)),
         }
     }
 }

--- a/packages/adapter-rust/runtime/src/runtime.rs
+++ b/packages/adapter-rust/runtime/src/runtime.rs
@@ -43,9 +43,10 @@
 //!     operator it emits.
 
 use crate::backend_minijinja;
+use crate::date;
 use crate::evaluator;
 use crate::num::{self, JsValue};
-use minijinja::value::{from_args, Enumerator, Kwargs, Object, Value as MjValue, ValueKind};
+use minijinja::value::{from_args, Enumerator, Kwargs, Object, ObjectRepr, Value as MjValue, ValueKind};
 use minijinja::{Error, ErrorKind, State};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::{Arc, Mutex};
@@ -111,6 +112,11 @@ pub fn js_string(v: &JsValue) -> String {
             .collect::<Vec<_>>()
             .join(","),
         JsValue::Object(_) => "[object Object]".to_string(),
+        // No JS `Date.prototype.toString()` port (that format -- e.g. "Fri
+        // Jul 20 1969 20:17:40 GMT+0000" -- is out of this catalogue's
+        // scope, #2274); `toISOString` is the one Date->string shape the
+        // spec defines, so a bare `bf.string(date)` uses it too.
+        JsValue::Date(ms) => date::format_iso8601(*ms),
     }
 }
 
@@ -125,6 +131,9 @@ pub fn js_number(v: &JsValue) -> f64 {
         JsValue::Number(n) => *n,
         JsValue::String(s) => if num::looks_like_number(s) { num::parse_number_literal(s) } else { f64::NAN },
         JsValue::Array(_) | JsValue::Object(_) => f64::NAN,
+        // `Number(date)` mirrors JS `Date`'s default `valueOf` coercion:
+        // the epoch-ms count itself.
+        JsValue::Date(ms) => *ms as f64,
     }
 }
 
@@ -137,6 +146,7 @@ pub fn js_truthy(v: &JsValue) -> bool {
         JsValue::Number(n) => !n.is_nan() && *n != 0.0, // not NaN, not zero
         JsValue::String(s) => !s.is_empty(),          // incl. the JS-truthy "0"
         JsValue::Array(_) | JsValue::Object(_) => true,
+        JsValue::Date(_) => true, // a JS Date object is always truthy
     }
 }
 
@@ -440,13 +450,13 @@ fn is_numeric_like(v: &JsValue) -> bool {
         JsValue::Null | JsValue::Bool(_) => false,
         JsValue::Number(_) => true,
         JsValue::String(s) => num::looks_like_number(s),
-        JsValue::Array(_) | JsValue::Object(_) => false,
+        JsValue::Array(_) | JsValue::Object(_) | JsValue::Date(_) => false,
     }
 }
 
 fn numeric_value(v: &JsValue) -> f64 {
     match v {
-        JsValue::Null | JsValue::Array(_) | JsValue::Object(_) => 0.0,
+        JsValue::Null | JsValue::Array(_) | JsValue::Object(_) | JsValue::Date(_) => 0.0,
         JsValue::Bool(b) => if *b { 1.0 } else { 0.0 },
         JsValue::Number(n) => *n,
         JsValue::String(s) => if num::looks_like_number(s) { num::parse_number_literal(s) } else { 0.0 },
@@ -1075,6 +1085,14 @@ impl BfInstance {
 // ---------------------------------------------------------------------------
 
 pub fn mj_to_js(v: &MjValue) -> JsValue {
+    // A `JsDate`-wrapped native Date prop (see that struct's docstring)
+    // isn't a Seq/Map/Iterable, so it would otherwise fall into the
+    // catch-all `_ => JsValue::Null` below, silently losing the receiver
+    // `date()` needs -- checked first, ahead of the generic `v.kind()`
+    // dispatch.
+    if let Some(d) = v.downcast_object_ref::<JsDate>() {
+        return JsValue::Date(d.0);
+    }
     match v.kind() {
         ValueKind::Undefined | ValueKind::None => JsValue::Null,
         ValueKind::Bool => JsValue::Bool(v.is_true()),
@@ -1148,6 +1166,39 @@ pub fn js_to_mj(v: &JsValue) -> MjValue {
             let map: BTreeMap<String, MjValue> = o.iter().map(|(k, v)| (k.clone(), js_to_mj(v))).collect();
             MjValue::from(map)
         }
+        JsValue::Date(ms) => MjValue::from_object(JsDate(*ms)),
+    }
+}
+
+/// This runtime's own native "Date" value, wrapped as a minijinja
+/// `Object` so a host can seed a template var with a real Date-typed
+/// receiver instead of always going through `date()`'s ISO-8601-string
+/// contract half (spec/template-helpers.md "date", #2274; mirrors the Go
+/// runtime's `time.Time` / the Ruby runtime's `Time` as the "native"
+/// receiver shape). Carries nothing but the epoch-ms integer
+/// `JsValue::Date` already carries -- `mj_to_js`/`js_to_mj` above
+/// round-trip it losslessly via `downcast_object_ref`/`from_object`.
+#[derive(Debug)]
+struct JsDate(i64);
+
+impl Object for JsDate {
+    fn repr(self: &Arc<Self>) -> ObjectRepr {
+        ObjectRepr::Plain
+    }
+
+    // A JS `Date` object is always truthy, like every other object.
+    fn is_true(self: &Arc<Self>) -> bool {
+        true
+    }
+
+    fn render(self: &Arc<Self>, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result
+    where
+        Self: Sized + 'static,
+    {
+        // `toISOString` is the one Date->string shape this catalogue
+        // defines (see `js_string`'s `JsValue::Date` arm); a bare
+        // interpolation of a native Date value uses the same shape.
+        write!(f, "{}", date::format_iso8601(self.0))
     }
 }
 
@@ -1272,6 +1323,13 @@ impl Object for BfInstance {
             "max" => Ok(MjValue::from(num::js_max(js_number(a(0)), js_number(a(1))))),
             "abs" => Ok(MjValue::from(num::js_abs(js_number(a(0))))),
             "to_fixed" => Ok(MjValue::from(num::to_fixed(js_number(a(0)), num::to_f64(a(1)) as i32))),
+            // `date(recv, op)` -- zero-arg `Date.prototype` method
+            // lowering (spec/template-helpers.md "date", #2274). `recv` is
+            // either a `JsDate`-wrapped native receiver (already converted
+            // to `JsValue::Date` by `mj_to_js` above) or an ISO-8601
+            // string; `date::date` normalizes and dispatches both. `op`
+            // stays a plain string arg, never routed through `js_number`.
+            "date" => Ok(js_to_mj(&date::date(a(0), a(1).as_str().unwrap_or("")))),
 
             // -- Array / string method helpers (#1448 Tier A) ------------------
             "includes" => Ok(MjValue::from(includes(a(0), a(1)))),

--- a/packages/adapter-rust/runtime/tests/helper_vectors.rs
+++ b/packages/adapter-rust/runtime/tests/helper_vectors.rs
@@ -45,6 +45,31 @@ fn obj(v: &JsValue, key: &str) -> JsValue {
     v.as_object().and_then(|m| m.get(key)).cloned().unwrap_or(JsValue::Null)
 }
 
+/// Materializes the `{"$date": "<ISO>"}` native-date arg sentinel (#2288)
+/// into this runtime's own `JsValue::Date`, so `date()`'s native-receiver
+/// branch (not just its ISO-string branch) is exercised. Recurses through
+/// arrays/objects the same shape the Perl port's `normalize_arg` walks,
+/// since a vector's `args` may nest the sentinel inside a higher-order
+/// projection payload. Panics on an unparseable `$date` string -- the
+/// corpus is generated from a fixed set of known-good ISO instants, so a
+/// parse failure here means the harness itself is broken, not the case
+/// under test.
+fn materialize_arg(v: &JsonValue) -> JsValue {
+    if let Some(o) = v.as_object() {
+        if let Some(iso) = o.get("$date").and_then(|d| d.as_str()) {
+            if o.len() == 1 {
+                let ms = date::parse_iso8601(iso).unwrap_or_else(|| panic!("materialize_arg: invalid $date {iso:?}"));
+                return JsValue::Date(ms);
+            }
+        }
+        return JsValue::Object(o.iter().map(|(k, x)| (k.clone(), materialize_arg(x))).collect());
+    }
+    if let Some(a) = v.as_array() {
+        return JsValue::Array(a.iter().map(materialize_arg).collect());
+    }
+    JsValue::from_json(v)
+}
+
 /// Mirrors `test_helper_vectors.py`'s `_truthy_pred`.
 fn truthy_pred(item: &JsValue, field: &str) -> bool {
     runtime::js_truthy(&obj(item, field))
@@ -305,7 +330,7 @@ fn helper_vectors_match_js_reference_or_declared_divergence() {
         let note = case["note"].as_str().unwrap();
         let key = format!("{fn_name}/{note}");
         let raw_args = case["args"].as_array().cloned().unwrap_or_default();
-        let args: Vec<JsValue> = raw_args.iter().map(JsValue::from_json).collect();
+        let args: Vec<JsValue> = raw_args.iter().map(materialize_arg).collect();
         let expect = &case["expect"];
 
         if let Some(reason) = div_file.unsupported.get(fn_name) {

--- a/packages/adapter-rust/runtime/tests/helper_vectors.rs
+++ b/packages/adapter-rust/runtime/tests/helper_vectors.rs
@@ -24,6 +24,7 @@
 //! `tests/vector-divergences.json`.
 
 use barefootjs::backend_minijinja;
+use barefootjs::date;
 use barefootjs::num::{self, JsValue};
 use barefootjs::runtime;
 use barefootjs::SearchParams;
@@ -123,6 +124,7 @@ fn call_binding(fn_name: &str, args: &[JsValue]) -> Option<JsValue> {
             let digits = if args.len() > 1 { num::to_f64(&a(1)) as i32 } else { 0 };
             JsValue::String(num::to_fixed(runtime::js_number(&a(0)), digits))
         }
+        "date" => date::date(&a(0), a(1).as_str().unwrap_or("")),
         "lower" => JsValue::String(runtime::js_string(&a(0)).to_lowercase()),
         "upper" => JsValue::String(runtime::js_string(&a(0)).to_uppercase()),
         "trim" => JsValue::String(runtime::trim(&a(0))),
@@ -237,6 +239,11 @@ fn py_truthy(v: &JsValue) -> bool {
         JsValue::String(s) => !s.is_empty(),
         JsValue::Array(a) => !a.is_empty(),
         JsValue::Object(o) => !o.is_empty(),
+        // Unreachable: no binding in this file ever returns a
+        // `JsValue::Date` (`date()` itself always returns `Number` or
+        // `String`, per its own return type) -- kept exhaustive since
+        // `JsValue` is a shared enum.
+        JsValue::Date(_) => true,
     }
 }
 

--- a/packages/adapter-tests/vectors/README.md
+++ b/packages/adapter-tests/vectors/README.md
@@ -38,6 +38,15 @@ bun run generate:eval-vectors
   arrays/objects thereof.
 - A non-finite number in an `expect` value uses the reserved sentinel
   `{"$num": "NaN" | "Infinity" | "-Infinity"}`.
+- A native-date `args` value uses the reserved sentinel `{"$date":
+  "<ISO-8601>"}` (the `date` helper's cases only, #2288). Each
+  harness materializes it into its own native date/time type (Go
+  `time.Time`, Ruby `Time`, Python `datetime`, PHP
+  `DateTimeImmutable`, Perl `BarefootJS::Date`, Rust
+  `JsValue::Date`) before binding — exercising `date()`'s
+  native-receiver branch, not just its ISO-string branch. Its
+  `expect` is identical to the equivalent plain-ISO-string case,
+  since both receiver shapes dispatch against the same instant.
 - JS `undefined` in an `expect` value encodes as `null` (backends have
   a single absent value).
 - `args` (and the evaluator's `env`) must stay finite — non-finite

--- a/packages/adapter-tests/vectors/cases.ts
+++ b/packages/adapter-tests/vectors/cases.ts
@@ -77,13 +77,22 @@ export const reference: Record<string, (...args: never[]) => unknown> = {
   arr: (...elements: unknown[]) => elements,
   filter_truthy: (a: unknown[]) => a.filter(Boolean),
 
-  // `Date` method lowering (#2274, spec entry "date"): the receiver arrives
-  // as an ISO-8601 string in the vectors (the JSON-encodable form the
-  // string-accepting half of the helper's contract exercises); the
-  // reference constructs the real `Date` and dispatches the named zero-arg
-  // method, so every backend is held to genuine JS `Date` semantics
-  // (including the pre-1970 / leap-day / far-future edge instants below).
-  date: (recv: string, op: string) => (new Date(recv) as unknown as Record<string, () => unknown>)[op](),
+  // `Date` method lowering (#2274, spec entry "date"). recv is an ISO-8601
+  // string OR a `{"$date": "<ISO>"}` envelope that each harness materializes
+  // into its NATIVE date type (both dispatch against the same instant). A nil
+  // or unparseable receiver degrades to the helper's documented zero value
+  // ('' for toISOString, 0 otherwise) — the server-side tolerance every
+  // backend implements, now oracle-normative so the corpus pins it.
+  date: (recv: unknown, op: string) => {
+    const raw =
+      recv !== null && typeof recv === 'object' && '$date' in recv
+        ? (recv as { $date: string }).$date
+        : recv
+    if (raw === null || raw === undefined) return op === 'toISOString' ? '' : 0
+    const d = new Date(raw as string)
+    if (Number.isNaN(d.getTime())) return op === 'toISOString' ? '' : 0
+    return (d as unknown as Record<string, () => unknown>)[op]()
+  },
 
   // searchParams() env-signal reader (#1922). The reference is the real
   // URLSearchParams.get the client runtime uses, so the template backends'
@@ -496,6 +505,60 @@ export const cases: HelperCase[] = [
   { fn: 'date', args: ['9999-12-31T23:59:59.999Z', 'getUTCSeconds'], note: 'far-future instant: getUTCSeconds' },
   { fn: 'date', args: ['9999-12-31T23:59:59.999Z', 'getTime'], note: 'far-future instant: getTime at the four-digit-year boundary' },
   { fn: 'date', args: ['9999-12-31T23:59:59.999Z', 'toISOString'], note: 'far-future instant: toISOString round-trips the instant' },
+
+  // Same 4×8 grid, receiver in the `{"$date": "<ISO>"}` envelope each
+  // harness materializes into its NATIVE date type (#2288) — every backend's
+  // native-typed branch (Go time.Time, Ruby Time, Python datetime, PHP
+  // DateTimeInterface, Perl BarefootJS::Date, Rust JsValue::Date) dispatches
+  // against the same instant as its string-receiver sibling above, so the
+  // expects are identical; only the receiver shape differs.
+  { fn: 'date', args: [{ $date: '1970-01-01T00:00:00.000Z' }, 'getUTCFullYear'], note: 'native epoch 0: getUTCFullYear' },
+  { fn: 'date', args: [{ $date: '1970-01-01T00:00:00.000Z' }, 'getUTCMonth'], note: 'native epoch 0: getUTCMonth' },
+  { fn: 'date', args: [{ $date: '1970-01-01T00:00:00.000Z' }, 'getUTCDate'], note: 'native epoch 0: getUTCDate' },
+  { fn: 'date', args: [{ $date: '1970-01-01T00:00:00.000Z' }, 'getUTCHours'], note: 'native epoch 0: getUTCHours' },
+  { fn: 'date', args: [{ $date: '1970-01-01T00:00:00.000Z' }, 'getUTCMinutes'], note: 'native epoch 0: getUTCMinutes' },
+  { fn: 'date', args: [{ $date: '1970-01-01T00:00:00.000Z' }, 'getUTCSeconds'], note: 'native epoch 0: getUTCSeconds' },
+  { fn: 'date', args: [{ $date: '1970-01-01T00:00:00.000Z' }, 'getTime'], note: 'native epoch 0: getTime' },
+  { fn: 'date', args: [{ $date: '1970-01-01T00:00:00.000Z' }, 'toISOString'], note: 'native epoch 0: toISOString' },
+
+  { fn: 'date', args: [{ $date: '1969-07-20T20:17:40.123Z' }, 'getUTCFullYear'], note: 'native pre-1970 instant: getUTCFullYear' },
+  { fn: 'date', args: [{ $date: '1969-07-20T20:17:40.123Z' }, 'getUTCMonth'], note: 'native pre-1970 instant: getUTCMonth' },
+  { fn: 'date', args: [{ $date: '1969-07-20T20:17:40.123Z' }, 'getUTCDate'], note: 'native pre-1970 instant: getUTCDate' },
+  { fn: 'date', args: [{ $date: '1969-07-20T20:17:40.123Z' }, 'getUTCHours'], note: 'native pre-1970 instant: getUTCHours' },
+  { fn: 'date', args: [{ $date: '1969-07-20T20:17:40.123Z' }, 'getUTCMinutes'], note: 'native pre-1970 instant: getUTCMinutes' },
+  { fn: 'date', args: [{ $date: '1969-07-20T20:17:40.123Z' }, 'getUTCSeconds'], note: 'native pre-1970 instant: getUTCSeconds' },
+  { fn: 'date', args: [{ $date: '1969-07-20T20:17:40.123Z' }, 'getTime'], note: 'native pre-1970 instant: getTime is negative with a nonzero-ms floor-division trap' },
+  { fn: 'date', args: [{ $date: '1969-07-20T20:17:40.123Z' }, 'toISOString'], note: 'native pre-1970 instant: toISOString' },
+
+  { fn: 'date', args: [{ $date: '2024-02-29T23:59:59.999Z' }, 'getUTCFullYear'], note: 'native leap day: getUTCFullYear' },
+  { fn: 'date', args: [{ $date: '2024-02-29T23:59:59.999Z' }, 'getUTCMonth'], note: 'native leap day: getUTCMonth' },
+  { fn: 'date', args: [{ $date: '2024-02-29T23:59:59.999Z' }, 'getUTCDate'], note: 'native leap day: getUTCDate is 29' },
+  { fn: 'date', args: [{ $date: '2024-02-29T23:59:59.999Z' }, 'getUTCHours'], note: 'native leap day: getUTCHours at the last hour of the day' },
+  { fn: 'date', args: [{ $date: '2024-02-29T23:59:59.999Z' }, 'getUTCMinutes'], note: 'native leap day: getUTCMinutes' },
+  { fn: 'date', args: [{ $date: '2024-02-29T23:59:59.999Z' }, 'getUTCSeconds'], note: 'native leap day: getUTCSeconds' },
+  { fn: 'date', args: [{ $date: '2024-02-29T23:59:59.999Z' }, 'getTime'], note: 'native leap day: getTime' },
+  { fn: 'date', args: [{ $date: '2024-02-29T23:59:59.999Z' }, 'toISOString'], note: 'native leap day: toISOString' },
+
+  { fn: 'date', args: [{ $date: '9999-12-31T23:59:59.999Z' }, 'getUTCFullYear'], note: 'native far-future instant: getUTCFullYear' },
+  { fn: 'date', args: [{ $date: '9999-12-31T23:59:59.999Z' }, 'getUTCMonth'], note: 'native far-future instant: getUTCMonth' },
+  { fn: 'date', args: [{ $date: '9999-12-31T23:59:59.999Z' }, 'getUTCDate'], note: 'native far-future instant: getUTCDate' },
+  { fn: 'date', args: [{ $date: '9999-12-31T23:59:59.999Z' }, 'getUTCHours'], note: 'native far-future instant: getUTCHours' },
+  { fn: 'date', args: [{ $date: '9999-12-31T23:59:59.999Z' }, 'getUTCMinutes'], note: 'native far-future instant: getUTCMinutes' },
+  { fn: 'date', args: [{ $date: '9999-12-31T23:59:59.999Z' }, 'getUTCSeconds'], note: 'native far-future instant: getUTCSeconds' },
+  { fn: 'date', args: [{ $date: '9999-12-31T23:59:59.999Z' }, 'getTime'], note: 'native far-future instant: getTime at the four-digit-year boundary' },
+  { fn: 'date', args: [{ $date: '9999-12-31T23:59:59.999Z' }, 'toISOString'], note: 'native far-future instant: toISOString' },
+
+  // Nil/malformed receiver fallback (#2288): every backend's `date()`
+  // degrades to the zero value instead of crashing mid-render or (worse)
+  // silently defaulting to "now" — this was implemented on all six backends
+  // but pinned by no vector until now.
+  { fn: 'date', args: [null, 'toISOString'], note: 'nil receiver: toISOString degrades to empty string' },
+  { fn: 'date', args: [null, 'getTime'], note: 'nil receiver: getTime degrades to 0' },
+  { fn: 'date', args: [null, 'getUTCFullYear'], note: 'nil receiver: accessor degrades to 0' },
+  { fn: 'date', args: [null, 'getUTCMonth'], note: 'nil receiver: second accessor degrades to 0' },
+  { fn: 'date', args: ['not-a-date', 'toISOString'], note: 'malformed receiver: toISOString degrades to empty string' },
+  { fn: 'date', args: ['not-a-date', 'getTime'], note: 'malformed receiver: getTime degrades to 0' },
+  { fn: 'date', args: ['not-a-date', 'getUTCFullYear'], note: 'malformed receiver: accessor degrades to 0' },
 
   { fn: 'every', args: [[{ done: true }, { done: true }], 'done'], note: 'all truthy fields' },
   { fn: 'every', args: [[{ done: true }, { done: false }], 'done'], note: 'one falsy field fails' },

--- a/packages/adapter-tests/vectors/cases.ts
+++ b/packages/adapter-tests/vectors/cases.ts
@@ -77,6 +77,14 @@ export const reference: Record<string, (...args: never[]) => unknown> = {
   arr: (...elements: unknown[]) => elements,
   filter_truthy: (a: unknown[]) => a.filter(Boolean),
 
+  // `Date` method lowering (#2274, spec entry "date"): the receiver arrives
+  // as an ISO-8601 string in the vectors (the JSON-encodable form the
+  // string-accepting half of the helper's contract exercises); the
+  // reference constructs the real `Date` and dispatches the named zero-arg
+  // method, so every backend is held to genuine JS `Date` semantics
+  // (including the pre-1970 / leap-day / far-future edge instants below).
+  date: (recv: string, op: string) => (new Date(recv) as unknown as Record<string, () => unknown>)[op](),
+
   // searchParams() env-signal reader (#1922). The reference is the real
   // URLSearchParams.get the client runtime uses, so the template backends'
   // per-request readers (Go bf.SearchParams.Get / Perl
@@ -447,6 +455,47 @@ export const cases: HelperCase[] = [
   { fn: 'filter_truthy', args: [[0, 1, '', 2, null, 'a']], note: 'drops the JS falsy set' },
   { fn: 'filter_truthy', args: [['x', 'y']], note: 'all truthy passes through' },
   { fn: 'filter_truthy', args: [[0, '', null]], note: 'all falsy yields []' },
+
+  // `date(recv, op)` (#2274) — near-full grid of the 8 catalogued zero-arg
+  // ops across 4 pinned instants: the Unix epoch, a pre-1970 instant with a
+  // nonzero millisecond component (the floor-division trap a naive
+  // negative-epoch/1000 truncation gets wrong), a leap day, and a
+  // four-digit-year-boundary far-future instant.
+  { fn: 'date', args: ['1970-01-01T00:00:00.000Z', 'getUTCFullYear'], note: 'epoch 0: getUTCFullYear' },
+  { fn: 'date', args: ['1970-01-01T00:00:00.000Z', 'getUTCMonth'], note: 'epoch 0: getUTCMonth is 0-based (January)' },
+  { fn: 'date', args: ['1970-01-01T00:00:00.000Z', 'getUTCDate'], note: 'epoch 0: getUTCDate' },
+  { fn: 'date', args: ['1970-01-01T00:00:00.000Z', 'getUTCHours'], note: 'epoch 0: getUTCHours' },
+  { fn: 'date', args: ['1970-01-01T00:00:00.000Z', 'getUTCMinutes'], note: 'epoch 0: getUTCMinutes' },
+  { fn: 'date', args: ['1970-01-01T00:00:00.000Z', 'getUTCSeconds'], note: 'epoch 0: getUTCSeconds' },
+  { fn: 'date', args: ['1970-01-01T00:00:00.000Z', 'getTime'], note: 'epoch 0: getTime is exactly 0' },
+  { fn: 'date', args: ['1970-01-01T00:00:00.000Z', 'toISOString'], note: 'epoch 0: toISOString round-trips the instant' },
+
+  { fn: 'date', args: ['1969-07-20T20:17:40.123Z', 'getUTCFullYear'], note: 'pre-1970 instant: getUTCFullYear' },
+  { fn: 'date', args: ['1969-07-20T20:17:40.123Z', 'getUTCMonth'], note: 'pre-1970 instant: getUTCMonth' },
+  { fn: 'date', args: ['1969-07-20T20:17:40.123Z', 'getUTCDate'], note: 'pre-1970 instant: getUTCDate' },
+  { fn: 'date', args: ['1969-07-20T20:17:40.123Z', 'getUTCHours'], note: 'pre-1970 instant: getUTCHours' },
+  { fn: 'date', args: ['1969-07-20T20:17:40.123Z', 'getUTCMinutes'], note: 'pre-1970 instant: getUTCMinutes' },
+  { fn: 'date', args: ['1969-07-20T20:17:40.123Z', 'getUTCSeconds'], note: 'pre-1970 instant: getUTCSeconds' },
+  { fn: 'date', args: ['1969-07-20T20:17:40.123Z', 'getTime'], note: 'pre-1970 instant: getTime is negative with a nonzero-ms floor-division trap' },
+  { fn: 'date', args: ['1969-07-20T20:17:40.123Z', 'toISOString'], note: 'pre-1970 instant: toISOString round-trips the instant' },
+
+  { fn: 'date', args: ['2024-02-29T23:59:59.999Z', 'getUTCFullYear'], note: 'leap day: getUTCFullYear' },
+  { fn: 'date', args: ['2024-02-29T23:59:59.999Z', 'getUTCMonth'], note: 'leap day: getUTCMonth is 0-based (February)' },
+  { fn: 'date', args: ['2024-02-29T23:59:59.999Z', 'getUTCDate'], note: 'leap day: getUTCDate is 29' },
+  { fn: 'date', args: ['2024-02-29T23:59:59.999Z', 'getUTCHours'], note: 'leap day: getUTCHours at the last hour of the day' },
+  { fn: 'date', args: ['2024-02-29T23:59:59.999Z', 'getUTCMinutes'], note: 'leap day: getUTCMinutes' },
+  { fn: 'date', args: ['2024-02-29T23:59:59.999Z', 'getUTCSeconds'], note: 'leap day: getUTCSeconds' },
+  { fn: 'date', args: ['2024-02-29T23:59:59.999Z', 'getTime'], note: 'leap day: getTime' },
+  { fn: 'date', args: ['2024-02-29T23:59:59.999Z', 'toISOString'], note: 'leap day: toISOString round-trips the instant' },
+
+  { fn: 'date', args: ['9999-12-31T23:59:59.999Z', 'getUTCFullYear'], note: 'far-future instant: getUTCFullYear' },
+  { fn: 'date', args: ['9999-12-31T23:59:59.999Z', 'getUTCMonth'], note: 'far-future instant: getUTCMonth is 0-based (December)' },
+  { fn: 'date', args: ['9999-12-31T23:59:59.999Z', 'getUTCDate'], note: 'far-future instant: getUTCDate' },
+  { fn: 'date', args: ['9999-12-31T23:59:59.999Z', 'getUTCHours'], note: 'far-future instant: getUTCHours' },
+  { fn: 'date', args: ['9999-12-31T23:59:59.999Z', 'getUTCMinutes'], note: 'far-future instant: getUTCMinutes' },
+  { fn: 'date', args: ['9999-12-31T23:59:59.999Z', 'getUTCSeconds'], note: 'far-future instant: getUTCSeconds' },
+  { fn: 'date', args: ['9999-12-31T23:59:59.999Z', 'getTime'], note: 'far-future instant: getTime at the four-digit-year boundary' },
+  { fn: 'date', args: ['9999-12-31T23:59:59.999Z', 'toISOString'], note: 'far-future instant: toISOString round-trips the instant' },
 
   { fn: 'every', args: [[{ done: true }, { done: true }], 'done'], note: 'all truthy fields' },
   { fn: 'every', args: [[{ done: true }, { done: false }], 'done'], note: 'one falsy field fails' },

--- a/packages/adapter-tests/vectors/vectors.json
+++ b/packages/adapter-tests/vectors/vectors.json
@@ -2192,6 +2192,294 @@
       "note": "all falsy yields []"
     },
     {
+      "fn": "date",
+      "args": [
+        "1970-01-01T00:00:00.000Z",
+        "getUTCFullYear"
+      ],
+      "expect": 1970,
+      "note": "epoch 0: getUTCFullYear"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "1970-01-01T00:00:00.000Z",
+        "getUTCMonth"
+      ],
+      "expect": 0,
+      "note": "epoch 0: getUTCMonth is 0-based (January)"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "1970-01-01T00:00:00.000Z",
+        "getUTCDate"
+      ],
+      "expect": 1,
+      "note": "epoch 0: getUTCDate"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "1970-01-01T00:00:00.000Z",
+        "getUTCHours"
+      ],
+      "expect": 0,
+      "note": "epoch 0: getUTCHours"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "1970-01-01T00:00:00.000Z",
+        "getUTCMinutes"
+      ],
+      "expect": 0,
+      "note": "epoch 0: getUTCMinutes"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "1970-01-01T00:00:00.000Z",
+        "getUTCSeconds"
+      ],
+      "expect": 0,
+      "note": "epoch 0: getUTCSeconds"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "1970-01-01T00:00:00.000Z",
+        "getTime"
+      ],
+      "expect": 0,
+      "note": "epoch 0: getTime is exactly 0"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "1970-01-01T00:00:00.000Z",
+        "toISOString"
+      ],
+      "expect": "1970-01-01T00:00:00.000Z",
+      "note": "epoch 0: toISOString round-trips the instant"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "1969-07-20T20:17:40.123Z",
+        "getUTCFullYear"
+      ],
+      "expect": 1969,
+      "note": "pre-1970 instant: getUTCFullYear"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "1969-07-20T20:17:40.123Z",
+        "getUTCMonth"
+      ],
+      "expect": 6,
+      "note": "pre-1970 instant: getUTCMonth"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "1969-07-20T20:17:40.123Z",
+        "getUTCDate"
+      ],
+      "expect": 20,
+      "note": "pre-1970 instant: getUTCDate"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "1969-07-20T20:17:40.123Z",
+        "getUTCHours"
+      ],
+      "expect": 20,
+      "note": "pre-1970 instant: getUTCHours"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "1969-07-20T20:17:40.123Z",
+        "getUTCMinutes"
+      ],
+      "expect": 17,
+      "note": "pre-1970 instant: getUTCMinutes"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "1969-07-20T20:17:40.123Z",
+        "getUTCSeconds"
+      ],
+      "expect": 40,
+      "note": "pre-1970 instant: getUTCSeconds"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "1969-07-20T20:17:40.123Z",
+        "getTime"
+      ],
+      "expect": -14182939877,
+      "note": "pre-1970 instant: getTime is negative with a nonzero-ms floor-division trap"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "1969-07-20T20:17:40.123Z",
+        "toISOString"
+      ],
+      "expect": "1969-07-20T20:17:40.123Z",
+      "note": "pre-1970 instant: toISOString round-trips the instant"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "2024-02-29T23:59:59.999Z",
+        "getUTCFullYear"
+      ],
+      "expect": 2024,
+      "note": "leap day: getUTCFullYear"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "2024-02-29T23:59:59.999Z",
+        "getUTCMonth"
+      ],
+      "expect": 1,
+      "note": "leap day: getUTCMonth is 0-based (February)"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "2024-02-29T23:59:59.999Z",
+        "getUTCDate"
+      ],
+      "expect": 29,
+      "note": "leap day: getUTCDate is 29"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "2024-02-29T23:59:59.999Z",
+        "getUTCHours"
+      ],
+      "expect": 23,
+      "note": "leap day: getUTCHours at the last hour of the day"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "2024-02-29T23:59:59.999Z",
+        "getUTCMinutes"
+      ],
+      "expect": 59,
+      "note": "leap day: getUTCMinutes"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "2024-02-29T23:59:59.999Z",
+        "getUTCSeconds"
+      ],
+      "expect": 59,
+      "note": "leap day: getUTCSeconds"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "2024-02-29T23:59:59.999Z",
+        "getTime"
+      ],
+      "expect": 1709251199999,
+      "note": "leap day: getTime"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "2024-02-29T23:59:59.999Z",
+        "toISOString"
+      ],
+      "expect": "2024-02-29T23:59:59.999Z",
+      "note": "leap day: toISOString round-trips the instant"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "9999-12-31T23:59:59.999Z",
+        "getUTCFullYear"
+      ],
+      "expect": 9999,
+      "note": "far-future instant: getUTCFullYear"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "9999-12-31T23:59:59.999Z",
+        "getUTCMonth"
+      ],
+      "expect": 11,
+      "note": "far-future instant: getUTCMonth is 0-based (December)"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "9999-12-31T23:59:59.999Z",
+        "getUTCDate"
+      ],
+      "expect": 31,
+      "note": "far-future instant: getUTCDate"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "9999-12-31T23:59:59.999Z",
+        "getUTCHours"
+      ],
+      "expect": 23,
+      "note": "far-future instant: getUTCHours"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "9999-12-31T23:59:59.999Z",
+        "getUTCMinutes"
+      ],
+      "expect": 59,
+      "note": "far-future instant: getUTCMinutes"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "9999-12-31T23:59:59.999Z",
+        "getUTCSeconds"
+      ],
+      "expect": 59,
+      "note": "far-future instant: getUTCSeconds"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "9999-12-31T23:59:59.999Z",
+        "getTime"
+      ],
+      "expect": 253402300799999,
+      "note": "far-future instant: getTime at the four-digit-year boundary"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "9999-12-31T23:59:59.999Z",
+        "toISOString"
+      ],
+      "expect": "9999-12-31T23:59:59.999Z",
+      "note": "far-future instant: toISOString round-trips the instant"
+    },
+    {
       "fn": "every",
       "args": [
         [

--- a/packages/adapter-tests/vectors/vectors.json
+++ b/packages/adapter-tests/vectors/vectors.json
@@ -2480,6 +2480,421 @@
       "note": "far-future instant: toISOString round-trips the instant"
     },
     {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "1970-01-01T00:00:00.000Z"
+        },
+        "getUTCFullYear"
+      ],
+      "expect": 1970,
+      "note": "native epoch 0: getUTCFullYear"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "1970-01-01T00:00:00.000Z"
+        },
+        "getUTCMonth"
+      ],
+      "expect": 0,
+      "note": "native epoch 0: getUTCMonth"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "1970-01-01T00:00:00.000Z"
+        },
+        "getUTCDate"
+      ],
+      "expect": 1,
+      "note": "native epoch 0: getUTCDate"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "1970-01-01T00:00:00.000Z"
+        },
+        "getUTCHours"
+      ],
+      "expect": 0,
+      "note": "native epoch 0: getUTCHours"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "1970-01-01T00:00:00.000Z"
+        },
+        "getUTCMinutes"
+      ],
+      "expect": 0,
+      "note": "native epoch 0: getUTCMinutes"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "1970-01-01T00:00:00.000Z"
+        },
+        "getUTCSeconds"
+      ],
+      "expect": 0,
+      "note": "native epoch 0: getUTCSeconds"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "1970-01-01T00:00:00.000Z"
+        },
+        "getTime"
+      ],
+      "expect": 0,
+      "note": "native epoch 0: getTime"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "1970-01-01T00:00:00.000Z"
+        },
+        "toISOString"
+      ],
+      "expect": "1970-01-01T00:00:00.000Z",
+      "note": "native epoch 0: toISOString"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "1969-07-20T20:17:40.123Z"
+        },
+        "getUTCFullYear"
+      ],
+      "expect": 1969,
+      "note": "native pre-1970 instant: getUTCFullYear"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "1969-07-20T20:17:40.123Z"
+        },
+        "getUTCMonth"
+      ],
+      "expect": 6,
+      "note": "native pre-1970 instant: getUTCMonth"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "1969-07-20T20:17:40.123Z"
+        },
+        "getUTCDate"
+      ],
+      "expect": 20,
+      "note": "native pre-1970 instant: getUTCDate"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "1969-07-20T20:17:40.123Z"
+        },
+        "getUTCHours"
+      ],
+      "expect": 20,
+      "note": "native pre-1970 instant: getUTCHours"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "1969-07-20T20:17:40.123Z"
+        },
+        "getUTCMinutes"
+      ],
+      "expect": 17,
+      "note": "native pre-1970 instant: getUTCMinutes"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "1969-07-20T20:17:40.123Z"
+        },
+        "getUTCSeconds"
+      ],
+      "expect": 40,
+      "note": "native pre-1970 instant: getUTCSeconds"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "1969-07-20T20:17:40.123Z"
+        },
+        "getTime"
+      ],
+      "expect": -14182939877,
+      "note": "native pre-1970 instant: getTime is negative with a nonzero-ms floor-division trap"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "1969-07-20T20:17:40.123Z"
+        },
+        "toISOString"
+      ],
+      "expect": "1969-07-20T20:17:40.123Z",
+      "note": "native pre-1970 instant: toISOString"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "2024-02-29T23:59:59.999Z"
+        },
+        "getUTCFullYear"
+      ],
+      "expect": 2024,
+      "note": "native leap day: getUTCFullYear"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "2024-02-29T23:59:59.999Z"
+        },
+        "getUTCMonth"
+      ],
+      "expect": 1,
+      "note": "native leap day: getUTCMonth"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "2024-02-29T23:59:59.999Z"
+        },
+        "getUTCDate"
+      ],
+      "expect": 29,
+      "note": "native leap day: getUTCDate is 29"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "2024-02-29T23:59:59.999Z"
+        },
+        "getUTCHours"
+      ],
+      "expect": 23,
+      "note": "native leap day: getUTCHours at the last hour of the day"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "2024-02-29T23:59:59.999Z"
+        },
+        "getUTCMinutes"
+      ],
+      "expect": 59,
+      "note": "native leap day: getUTCMinutes"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "2024-02-29T23:59:59.999Z"
+        },
+        "getUTCSeconds"
+      ],
+      "expect": 59,
+      "note": "native leap day: getUTCSeconds"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "2024-02-29T23:59:59.999Z"
+        },
+        "getTime"
+      ],
+      "expect": 1709251199999,
+      "note": "native leap day: getTime"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "2024-02-29T23:59:59.999Z"
+        },
+        "toISOString"
+      ],
+      "expect": "2024-02-29T23:59:59.999Z",
+      "note": "native leap day: toISOString"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "9999-12-31T23:59:59.999Z"
+        },
+        "getUTCFullYear"
+      ],
+      "expect": 9999,
+      "note": "native far-future instant: getUTCFullYear"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "9999-12-31T23:59:59.999Z"
+        },
+        "getUTCMonth"
+      ],
+      "expect": 11,
+      "note": "native far-future instant: getUTCMonth"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "9999-12-31T23:59:59.999Z"
+        },
+        "getUTCDate"
+      ],
+      "expect": 31,
+      "note": "native far-future instant: getUTCDate"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "9999-12-31T23:59:59.999Z"
+        },
+        "getUTCHours"
+      ],
+      "expect": 23,
+      "note": "native far-future instant: getUTCHours"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "9999-12-31T23:59:59.999Z"
+        },
+        "getUTCMinutes"
+      ],
+      "expect": 59,
+      "note": "native far-future instant: getUTCMinutes"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "9999-12-31T23:59:59.999Z"
+        },
+        "getUTCSeconds"
+      ],
+      "expect": 59,
+      "note": "native far-future instant: getUTCSeconds"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "9999-12-31T23:59:59.999Z"
+        },
+        "getTime"
+      ],
+      "expect": 253402300799999,
+      "note": "native far-future instant: getTime at the four-digit-year boundary"
+    },
+    {
+      "fn": "date",
+      "args": [
+        {
+          "$date": "9999-12-31T23:59:59.999Z"
+        },
+        "toISOString"
+      ],
+      "expect": "9999-12-31T23:59:59.999Z",
+      "note": "native far-future instant: toISOString"
+    },
+    {
+      "fn": "date",
+      "args": [
+        null,
+        "toISOString"
+      ],
+      "expect": "",
+      "note": "nil receiver: toISOString degrades to empty string"
+    },
+    {
+      "fn": "date",
+      "args": [
+        null,
+        "getTime"
+      ],
+      "expect": 0,
+      "note": "nil receiver: getTime degrades to 0"
+    },
+    {
+      "fn": "date",
+      "args": [
+        null,
+        "getUTCFullYear"
+      ],
+      "expect": 0,
+      "note": "nil receiver: accessor degrades to 0"
+    },
+    {
+      "fn": "date",
+      "args": [
+        null,
+        "getUTCMonth"
+      ],
+      "expect": 0,
+      "note": "nil receiver: second accessor degrades to 0"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "not-a-date",
+        "toISOString"
+      ],
+      "expect": "",
+      "note": "malformed receiver: toISOString degrades to empty string"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "not-a-date",
+        "getTime"
+      ],
+      "expect": 0,
+      "note": "malformed receiver: getTime degrades to 0"
+    },
+    {
+      "fn": "date",
+      "args": [
+        "not-a-date",
+        "getUTCFullYear"
+      ],
+      "expect": 0,
+      "note": "malformed receiver: accessor degrades to 0"
+    },
+    {
       "fn": "every",
       "args": [
         [

--- a/packages/jsx/src/__tests__/date-lowering.test.ts
+++ b/packages/jsx/src/__tests__/date-lowering.test.ts
@@ -1,0 +1,188 @@
+/**
+ * `Date` lowering plugin (#2274) — the first catalogued rich-type lowering
+ * built on top of the #2273 refusal seam. Covers the matcher's own
+ * recognition rules directly (mirrors `query-href-recognition.test.ts`'s
+ * `metadata()` extraction), plus the BF021-exemption integration promised by
+ * `rich-type-refusal.ts`'s module doc: a call the registry claims must not
+ * also fire BF021, while an un-catalogued Date method on the same receiver
+ * still does.
+ */
+import { describe, test, expect, afterEach } from 'bun:test'
+import { compileJSX, type ComponentIR } from '../index'
+import { TestAdapter } from '../adapters/test-adapter'
+import { parseExpression, type ParsedExpr } from '../expression-parser'
+import { datePlugin, DATE_METHODS } from '../date-lowering'
+import { registerLoweringPlugin, __resetLoweringPluginsForTest, getLoweringPlugins } from '../lowering-registry'
+import { ErrorCodes } from '../errors'
+
+function metadata(src: string): ComponentIR['metadata'] {
+  const result = compileJSX(src.trimStart(), 'T.tsx', { adapter: new TestAdapter(), outputIR: true })
+  const ir = JSON.parse(result.files.find((f) => f.type === 'ir')!.content) as ComponentIR
+  return ir.metadata
+}
+
+/** Parse a call expression source and return its callee + args, the exact
+ * shape a `LoweringMatcher` receives. */
+function callParts(expr: string): { callee: ParsedExpr; args: ParsedExpr[] } {
+  const parsed = parseExpression(expr)
+  if (parsed.kind !== 'call') throw new Error(`expected a call expression, got ${parsed.kind}`)
+  return { callee: parsed.callee, args: parsed.args }
+}
+
+describe('DATE_METHODS catalogue', () => {
+  test('is exactly the 8 zero-arg Date.prototype accessors the spec entry names', () => {
+    expect([...DATE_METHODS].sort()).toEqual(
+      [
+        'getUTCFullYear',
+        'getUTCMonth',
+        'getUTCDate',
+        'getUTCHours',
+        'getUTCMinutes',
+        'getUTCSeconds',
+        'getTime',
+        'toISOString',
+      ].sort(),
+    )
+  })
+})
+
+describe('datePlugin matcher recognition (#2274)', () => {
+  test('props-object member chain (props.createdAt.toISOString()) matches', () => {
+    const md = metadata(`
+      export function Foo(props: { createdAt: Date }) {
+        return <div>{props.createdAt.toISOString()}</div>
+      }
+    `)
+    const matcher = datePlugin.prepare(md)
+    expect(matcher).not.toBeNull()
+    const { callee, args } = callParts('props.createdAt.toISOString()')
+    expect(matcher!(callee, args)).toEqual({
+      kind: 'helper-call',
+      helper: 'date',
+      args: [(callee as { object: ParsedExpr }).object, { kind: 'literal', value: 'toISOString', literalType: 'string' }],
+    })
+  })
+
+  test('destructured Date prop (createdAt.getUTCFullYear()) matches', () => {
+    const md = metadata(`
+      export function Foo({ createdAt }: { createdAt: Date }) {
+        return <div>{createdAt.getUTCFullYear()}</div>
+      }
+    `)
+    const matcher = datePlugin.prepare(md)
+    expect(matcher).not.toBeNull()
+    const { callee, args } = callParts('createdAt.getUTCFullYear()')
+    expect(matcher!(callee, args)).toEqual({
+      kind: 'helper-call',
+      helper: 'date',
+      args: [(callee as { object: ParsedExpr }).object, { kind: 'literal', value: 'getUTCFullYear', literalType: 'string' }],
+    })
+  })
+
+  test('renamed destructured Date prop ({ createdAt: c }) resolves via the source name', () => {
+    const md = metadata(`
+      export function Foo({ createdAt: c }: { createdAt: Date }) {
+        return <div>{c.getTime()}</div>
+      }
+    `)
+    const matcher = datePlugin.prepare(md)
+    expect(matcher).not.toBeNull()
+    const { callee, args } = callParts('c.getTime()')
+    expect(matcher!(callee, args)).toEqual({
+      kind: 'helper-call',
+      helper: 'date',
+      args: [(callee as { object: ParsedExpr }).object, { kind: 'literal', value: 'getTime', literalType: 'string' }],
+    })
+  })
+
+  test('#2274: destructured Date prop now carries a real propsParams TypeInfo (analyzer widening)', () => {
+    // Pre-widening this degraded to { kind: 'unknown', raw: 'unknown' }
+    // (analyzer.ts's #2150 primitives-only gate) — resolveReceiverType's
+    // destructured path reads the type from propsType, not propsParams, so
+    // the widening isn't load-bearing for the matcher above, but propsParams
+    // is itself observable IR metadata this plugin's existence is meant to
+    // unlock (see analyzer.ts's docstring on `isResolvablePrimitive`).
+    const md = metadata(`
+      export function Foo({ createdAt }: { createdAt: Date }) {
+        return <div>{createdAt.toISOString()}</div>
+      }
+    `)
+    const param = md.propsParams.find((p) => p.name === 'createdAt')
+    expect(param?.type.kind).toBe('interface')
+    expect(param?.type.raw).toBe('Date')
+  })
+
+  test('toLocaleDateString is not a catalogued method — declines (falls back to BF021)', () => {
+    const md = metadata(`
+      export function Foo({ createdAt }: { createdAt: Date }) {
+        return <div>{createdAt.toLocaleDateString()}</div>
+      }
+    `)
+    const matcher = datePlugin.prepare(md)
+    expect(matcher).not.toBeNull() // Date IS reachable — the gate stays active …
+    const { callee, args } = callParts('createdAt.toLocaleDateString()')
+    expect(matcher!(callee, args)).toBeNull() // … but this specific method declines.
+  })
+
+  test('a catalogued method name called with an argument declines (zero-arg only)', () => {
+    const md = metadata(`
+      export function Foo({ createdAt }: { createdAt: Date }) {
+        return <div>{createdAt.getTime()}</div>
+      }
+    `)
+    const matcher = datePlugin.prepare(md)
+    expect(matcher).not.toBeNull()
+    const { callee, args } = callParts('createdAt.getTime(1)')
+    expect(matcher!(callee, args)).toBeNull()
+  })
+
+  test('a non-Date receiver never activates the plugin (prepare declines entirely)', () => {
+    const md = metadata(`
+      export function Foo({ createdAt }: { createdAt: string }) {
+        return <div>{createdAt.toUpperCase()}</div>
+      }
+    `)
+    expect(datePlugin.prepare(md)).toBeNull()
+  })
+
+  test('a component with no props type at all never activates the plugin', () => {
+    const md = metadata(`
+      export function Foo() {
+        return <div>static</div>
+      }
+    `)
+    expect(datePlugin.prepare(md)).toBeNull()
+  })
+})
+
+describe('BF021 exemption via the real datePlugin (#2274 seam)', () => {
+  afterEach(() => {
+    __resetLoweringPluginsForTest(getLoweringPlugins().filter((p) => p.name !== 'date'))
+  })
+
+  function bf021Count(source: string): number {
+    registerLoweringPlugin(datePlugin)
+    const result = compileJSX(source.trimStart(), 'Test.tsx', { adapter: new TestAdapter() })
+    return result.errors.filter((e) => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN).length
+  }
+
+  test('a catalogued call the plugin claims fires zero BF021', () => {
+    expect(
+      bf021Count(`
+        export function Foo({ createdAt }: { createdAt: Date }) {
+          return <div>{createdAt.toISOString()}</div>
+        }
+      `),
+    ).toBe(0)
+  })
+
+  test('an un-catalogued Date method on the same prop still fires BF021', () => {
+    expect(
+      bf021Count(`
+        export function Foo({ createdAt }: { createdAt: Date }) {
+          return <div>{createdAt.toLocaleDateString()}</div>
+        }
+      `),
+    ).toBe(1)
+  })
+})

--- a/packages/jsx/src/__tests__/rich-type-method-refusal.test.ts
+++ b/packages/jsx/src/__tests__/rich-type-method-refusal.test.ts
@@ -7,15 +7,35 @@
  * time. `checkRichTypeMethodCalls` (rich-type-refusal.ts) is wired into
  * `compileJSX` (not the bare analyzer/jsxToIR pipeline other BF021 tests in
  * this directory use), so these tests go through `compileJSX` directly.
+ *
+ * This suite intentionally exercises the refusal against an EMPTY plugin
+ * registry (only the "registry-claimed call is exempt" test opts a plugin
+ * back in, and cleans up after itself) — `Date`/`Map`/… calls here must
+ * still have no catalogued lowering for the fires/silent split below to mean
+ * anything. `bun test` runs every file in one process, and a sibling file
+ * that imports the package entry (`../index`) registers the real built-ins
+ * (`queryHref`, `date`, #2274) as a global side effect — including `date`,
+ * which legitimately claims `.toISOString()`. Snapshot + clear + restore
+ * around the whole file so this suite's result never depends on which other
+ * test files happened to run first in the same process.
  */
 
-import { describe, test, expect } from 'bun:test'
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test'
 import { compileJSX } from '../compiler'
 import { ErrorCodes } from '../errors'
 import { TestAdapter } from '../adapters/test-adapter'
 import { registerLoweringPlugin, __resetLoweringPluginsForTest, getLoweringPlugins, type LoweringPlugin } from '../lowering-registry'
 
 const adapter = new TestAdapter()
+
+let savedPlugins: readonly LoweringPlugin[]
+beforeAll(() => {
+  savedPlugins = getLoweringPlugins()
+  __resetLoweringPluginsForTest([])
+})
+afterAll(() => {
+  __resetLoweringPluginsForTest(savedPlugins)
+})
 
 function bf021(source: string, filePath = 'Test.tsx') {
   const result = compileJSX(source, filePath, { adapter })

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -24,6 +24,8 @@ import {
   collectReactiveGetterNames,
 } from './analyzer-context.ts'
 import { createError, createWarning, ErrorCodes } from './errors.ts'
+import { baseTypeName } from './rich-type-evidence.ts'
+import { CATALOGUED_RICH_TYPE_NAMES } from './date-lowering.ts'
 import path from 'node:path'
 import fs from 'node:fs'
 
@@ -3174,9 +3176,24 @@ function collectMemberTypes(
   typeNode: ts.TypeNode,
   ctx: AnalyzerContext
 ): Map<string, { type: TypeInfo | null; optional: boolean }> | null {
+  // #2150 originally restricted this gate to string/number/boolean only,
+  // because a non-primitive TypeInfo here used to mean "the typed adapters
+  // will emit an unchecked scalar assertion (`in.X.(int)`) that panics" for
+  // a shape the template layer has no representation for. That reasoning
+  // does NOT extend to a rich type with a CATALOGUED lowering (#2274: `Date`
+  // → the `date` helper): its propsParams TypeInfo is consumed only as
+  // call-site evidence for `resolveReceiverType` (rich-type-evidence.ts) —
+  // never emitted as a concrete field type (`typeInfoToGo`'s `interface`
+  // case falls through to `interface{}` for an unbacked host name exactly
+  // as `unknown` already did) — so there is no assertion to panic. Gating on
+  // `CATALOGUED_RICH_TYPE_NAMES` specifically (not `HOST_RICH_TYPE_NAMES`
+  // wholesale) keeps an un-catalogued rich type (`Map`, `Set`, …) at
+  // `unknown`, i.e. avoids resurrecting the #2150 mistake for a shape no
+  // lowering plugin exists for yet.
   const isResolvablePrimitive = (info: TypeInfo): boolean =>
-    info.kind === 'primitive' &&
-    (info.primitive === 'string' || info.primitive === 'number' || info.primitive === 'boolean')
+    (info.kind === 'primitive' &&
+      (info.primitive === 'string' || info.primitive === 'number' || info.primitive === 'boolean')) ||
+    (info.kind === 'interface' && CATALOGUED_RICH_TYPE_NAMES.has(baseTypeName(info.raw)))
 
   const fromMembers = (
     members: ts.NodeArray<ts.TypeElement>

--- a/packages/jsx/src/builtin-lowering-plugins.ts
+++ b/packages/jsx/src/builtin-lowering-plugins.ts
@@ -16,6 +16,7 @@ import type { LoweringPlugin } from './lowering-registry.ts'
 import { registerLoweringPlugin } from './lowering-registry.ts'
 import { queryHrefLocalNames } from './adapters/env-signal.ts'
 import { matchQueryHrefCall } from './query-href-lowering.ts'
+import { datePlugin } from './date-lowering.ts'
 
 /**
  * `queryHref(base, { … })` — the pure URL-query builder (#2042). Its runtime
@@ -41,7 +42,7 @@ export const queryHrefPlugin: LoweringPlugin = {
 }
 
 /** Every plugin the compiler ships and applies by default. */
-export const BUILTIN_LOWERING_PLUGINS: readonly LoweringPlugin[] = [queryHrefPlugin]
+export const BUILTIN_LOWERING_PLUGINS: readonly LoweringPlugin[] = [queryHrefPlugin, datePlugin]
 
 /**
  * Register the built-in plugins into the shared registry. Called for its side

--- a/packages/jsx/src/date-lowering.ts
+++ b/packages/jsx/src/date-lowering.ts
@@ -1,0 +1,117 @@
+/**
+ * `Date` lowering plugin (#2274) — the first catalogued entry in the rich-type
+ * lowering seam #2273 left open (`rich-type-refusal.ts`'s module doc: "the
+ * seam #2274 and later plugins use to catalogue a rich-type API without
+ * touching this module"). A zero-arg call to one of `DATE_METHODS` on a
+ * receiver resolved (via `resolveReceiverType`) to a `Date`-typed prop lowers
+ * to a backend-neutral `helper-call` node on the `date` helper
+ * (`date(recv, op)`, spec/template-helpers.md); every adapter already renders
+ * `helper-call` generically (#2069), so no adapter-specific code is needed
+ * here — only the runtime `date` helper each backend ships.
+ *
+ * v1 scope is deliberately prop-rooted only: the matcher resolves receivers
+ * with `EMPTY_BINDINGS` (no loop-item / arrow-param context), mirroring
+ * `rich-type-refusal.ts`'s own top-level walk. A loop item's `.toISOString()`
+ * therefore stays BF021-refused rather than silently falling back to a
+ * generic (and wrong) lowering — widening to loop bindings is a deliberate
+ * future step, not an oversight.
+ */
+
+import type { IRMetadata, TypeInfo } from './types.ts'
+import type { ParsedExpr } from './expression-parser.ts'
+import type { LoweringNode, LoweringPlugin } from './lowering-registry.ts'
+import { resolveReceiverType, baseTypeName, stripUnion, derefNamedType } from './rich-type-evidence.ts'
+
+/**
+ * Host rich-type names (`rich-type-evidence.ts`'s `HOST_RICH_TYPE_NAMES`)
+ * that additionally have a catalogued lowering — currently just `Date`.
+ * `analyzer.ts`'s `collectMemberTypes` widening keys off this set (not
+ * `HOST_RICH_TYPE_NAMES` wholesale) so a destructured prop only gets a real
+ * TypeInfo when a plugin actually exists to consume it; adding a future
+ * lowering (`Map`, …) is a one-line addition here, not a second gate to keep
+ * in sync.
+ */
+export const CATALOGUED_RICH_TYPE_NAMES: ReadonlySet<string> = new Set(['Date'])
+
+/** Zero-arg `Date.prototype` methods the `date` helper catalogues (spec/template-helpers.md). */
+export const DATE_METHODS: ReadonlySet<string> = new Set([
+  'getUTCFullYear',
+  'getUTCMonth',
+  'getUTCDate',
+  'getUTCHours',
+  'getUTCMinutes',
+  'getUTCSeconds',
+  'getTime',
+  'toISOString',
+])
+
+type Bindings = ReadonlyMap<string, TypeInfo | null>
+const EMPTY_BINDINGS: Bindings = new Map()
+
+/**
+ * Whether `type` (or a property reachable from it through non-array,
+ * non-computed member chains) can ever resolve to a `Date` — the same
+ * receiver shapes `resolveReceiverType` walks for an actual call site. Used
+ * only as `prepare`'s cheap activation gate: a `false` here must never miss a
+ * receiver the matcher could later prove Date-typed (that would silently drop
+ * the lowering and mis-flag BF021), so this over-approximates by recursing
+ * into every nested object-shaped property, not just direct ones.
+ *
+ * `seen` guards a self-referential named type (`interface Tree { self: Tree
+ * }`) from an infinite walk; keyed by the type's own name so two distinct
+ * properties of the SAME named type aren't short-circuited against each
+ * other.
+ */
+function typeReachesDate(type: TypeInfo | null, meta: IRMetadata, seen: Set<string>): boolean {
+  const stripped = stripUnion(type)
+  if (!stripped) return false
+  // `kind: 'object'` is an INLINE type literal (`{ createdAt: Date }` — the
+  // shape `propsType` itself takes for the common case) and already carries
+  // `properties` directly; `kind: 'interface'` is a NAMED reference (`Date`
+  // itself, or a local `interface Props { … }`) that needs the Date-name
+  // check plus `derefNamedType` to reach its member list. Anything else
+  // (primitive/array/union/…) is a dead end.
+  if (stripped.kind === 'interface') {
+    const name = baseTypeName(stripped.raw)
+    if (name === 'Date') return true
+    if (seen.has(name)) return false
+    seen.add(name)
+  } else if (stripped.kind !== 'object') {
+    return false
+  }
+  const deref = derefNamedType(stripped, meta)
+  if (!deref.properties) return false
+  return deref.properties.some((p) => typeReachesDate(p.type, meta, seen))
+}
+
+/**
+ * `datePlugin`'s matcher: recognises `<Date-typed receiver>.<method>()` per
+ * the module doc, or declines (null) for anything else — a non-member
+ * callee, a non-catalogued method name, a call with arguments (every
+ * catalogued method is zero-arg on `Date.prototype`), or a receiver that
+ * doesn't resolve to `Date` (unknown, a different host rich type, or a
+ * same-named local `typeDefinitions` entry shadowing the built-in — mirrors
+ * `rich-type-refusal.ts`'s `inFileShadow` check).
+ */
+function matchDateCall(callee: ParsedExpr, args: readonly ParsedExpr[], metadata: IRMetadata): LoweringNode | null {
+  if (callee.kind !== 'member' || callee.computed) return null
+  if (args.length !== 0 || !DATE_METHODS.has(callee.property)) return null
+  const receiverType = resolveReceiverType(callee.object, metadata, EMPTY_BINDINGS)
+  if (!receiverType || receiverType.kind !== 'interface') return null
+  const typeName = baseTypeName(receiverType.raw)
+  if (typeName !== 'Date') return null
+  if (metadata.typeDefinitions.some((d) => d.name === typeName)) return null
+  return {
+    kind: 'helper-call',
+    helper: 'date',
+    args: [callee.object, { kind: 'literal', value: callee.property, literalType: 'string' }],
+  }
+}
+
+export const datePlugin: LoweringPlugin = {
+  name: 'date',
+  prepare(metadata) {
+    if (!metadata.propsType || !typeReachesDate(metadata.propsType, metadata, new Set())) return null
+    return (callee, args) => matchDateCall(callee, args, metadata)
+  },
+}

--- a/packages/jsx/src/rich-type-evidence.ts
+++ b/packages/jsx/src/rich-type-evidence.ts
@@ -78,7 +78,7 @@ function isNullishArm(t: TypeInfo): boolean {
   return t.kind === 'unknown' && (t.raw === 'null' || t.raw === 'undefined')
 }
 
-function stripUnion(type: TypeInfo | null): TypeInfo | null {
+export function stripUnion(type: TypeInfo | null): TypeInfo | null {
   if (!type || type.kind !== 'union' || !type.unionTypes) return type
   const nonNullish = type.unionTypes.filter((t) => !isNullishArm(t))
   return nonNullish.length === 1 ? stripUnion(nonNullish[0]) : type
@@ -93,7 +93,7 @@ function stripUnion(type: TypeInfo | null): TypeInfo | null {
  * reference, which `typeNodeToTypeInfo` intentionally resolves to
  * `{ kind: 'interface', raw }` with no member walk of its own.
  */
-function derefNamedType(type: TypeInfo, meta: EvidenceMetadata): TypeInfo {
+export function derefNamedType(type: TypeInfo, meta: EvidenceMetadata): TypeInfo {
   if (type.kind !== 'interface') return type
   if (type.properties && type.properties.length > 0) return type
   const name = baseTypeName(type.raw)

--- a/spec/template-helpers.md
+++ b/spec/template-helpers.md
@@ -308,6 +308,13 @@ recognizes; every accessor and `getTime` render as an **integer**
 always millisecond precision (`.SSSZ`), always UTC. `getUTCMonth` is
 **0-based**, matching JS (`new Date('2024-01-01').getUTCMonth()` →
 `0`), not the 1-based convention several host date libraries use.
+A `nil`/unset or unparseable `recv` is normative, not a per-backend
+tolerance: it degrades to the documented zero value — `''` for
+`toISOString`, `0` for every accessor and `getTime` — rather than
+crashing mid-render or (for `new Date(null)`-style behavior) silently
+resolving to "now". The golden vectors pin this fallback, plus a
+native-typed `recv` (the backend's own date/time type, not the
+ISO-8601 string form), for every backend (#2288).
 
 ### Higher-order: canonical projection form
 

--- a/spec/template-helpers.md
+++ b/spec/template-helpers.md
@@ -291,6 +291,24 @@ Array-literal lowering `[a, b, …]` — variadic construction in order.
 JS `arr.filter(Boolean)`: keeps elements truthy under `Boolean(x)` —
 note the string `"0"` is truthy in JS.
 
+### date
+
+`date(recv, op)` — the lowering target for a zero-arg call on a
+`Date`-typed prop (`createdAt.toISOString()`, #2274). JS reference
+semantics: `(d, op) => (d instanceof Date ? d : new Date(d))[op]()`.
+`recv` accepts either the backend's own native date/time type or an
+ISO-8601 string — a template value may arrive as either depending on
+how the host framework populated props, so the helper normalizes
+both to the same instant before dispatching `op`. `op` is one of
+`getUTCFullYear` / `getUTCMonth` / `getUTCDate` / `getUTCHours` /
+`getUTCMinutes` / `getUTCSeconds` / `getTime` / `toISOString` — the
+zero-arg `Date.prototype` subset the compiler's lowering plugin
+recognizes; every accessor and `getTime` render as an **integer**
+(no decimal point), and `toISOString` renders the exact JS shape —
+always millisecond precision (`.SSSZ`), always UTC. `getUTCMonth` is
+**0-based**, matching JS (`new Date('2024-01-01').getUTCMonth()` →
+`0`), not the 1-based convention several host date libraries use.
+
 ### Higher-order: canonical projection form
 
 Closures can't ride in JSON, so higher-order entries use the compiled


### PR DESCRIPTION
## Summary

Roadmap stage 4 of `spec/subset-conformance.md`, stacked on the merged #2273 refusal. A zero-arg `Date.prototype` method call on a `Date`-typed prop now lowers to a backend-neutral `helper-call` LoweringNode instead of being refused as an uncatalogued rich-type method — closing the loop the #2273 refusal opened: **the catalogue opens holes in a closed wall.**

- **Shared layer**: `date-lowering.ts` registers a default-applied builtin plugin (like `queryHref`) recognizing `getUTCFullYear` / `getUTCMonth` / `getUTCDate` / `getUTCHours` / `getUTCMinutes` / `getUTCSeconds` / `getTime` / `toISOString` (zero-arg only). The analyzer widens a destructured `Date`-typed prop's rich-type evidence so both the plugin and the #2273 refusal see through the destructure. Adapters need no per-API branch — they already render `helper-call` nodes.
- **Six runtime helpers** — `date(recv, op)` accepting the backend's native date type OR an ISO-8601 string: Go `bf_date`, Ruby, Python, PHP (shared twig+blade), Perl (shared xslate+mojo), Rust. `getUTCMonth` is 0-based per JS (−1 on every backend whose native month is 1-based; Perl `gmtime` is already 0-based). `toISOString` always renders UTC millisecond precision. Rust hand-rolls a proleptic-Gregorian calendar (Hinnant civil-from-days, `div_euclid`/`rem_euclid` for pre-1970) with a native `JsValue::Date`, **no new crate dependency**.
- Out of catalogue, still refused via #2273: local-TZ accessors, `toLocale*`, `Invalid Date`.

## Verification (all green, local)

- **All six backend golden-vector harnesses pass** (Go/Ruby/Python/PHP/Perl/Rust), pinned against JS-normative instants: epoch 0, a pre-1970 instant with nonzero ms (the floor-division trap), a leap day, year 9999.
- `packages/jsx` date-lowering + rich-type refusal: 36 pass — `toISOString` on a Date prop is now exempt, `toLocaleDateString` still refused.
- Hono conformance 776 / 0 fail; Go conformance 1025 / 0 fail (shared-layer widening doesn't perturb existing rendering).
- `generated-data-points` + `coverage-map` freshness green; `tsgo --noEmit -p packages/jsx` clean.

The remaining 5 adapters' full conformance suites (erb/jinja/twig/blade/xslate/mojo/rust) run in CI here — their vector harnesses already pass and the corpus has no Date fixtures yet, so they exercise unchanged rendering.

## Notes

- No Date **fixture** with data points yet — that's PR-C (envelope transport + `assertJsonDomain` admitting Date + adversarial Date rows). This PR is catalogue + runtimes + vectors only, so it lands green without harness envelope work.
- Implementation was completed in an isolated worktree after the first attempt stalled on Perl test tooling; the Perl helper uses core `Test::More`, no `Test2::V0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1T4R1R6FKPGTFyYn1ppBa

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1T4R1R6FKPGTFyYn1ppBa)_