### PR TITLE
Close #2292: apply the Date lowering on the client-JS (CSR) path

### DIFF
--- a/.changeset/client-date-lowering.md
+++ b/.changeset/client-date-lowering.md
@@ -1,0 +1,25 @@
+---
+"@barefootjs/client": minor
+"@barefootjs/jsx": minor
+---
+
+Close #2292: apply the catalogued `Date` lowering (#2274) on the client-JS
+(CSR) path, not just SSR. A `Date`-typed prop's zero-arg accessor call
+(`createdAt.toISOString()`, `createdAt.getUTCFullYear()`, …) now works after
+hydration instead of throwing.
+
+- `@barefootjs/client` gains a `date(recv, op)` runtime helper (importable
+  from `@barefootjs/client/runtime`), the client counterpart to every SSR
+  adapter's `date` helper. `recv` tolerates a real `Date` OR the ISO-8601
+  string a Date-typed prop arrives as post-hydration (props are JSON
+  round-tripped with no type-aware revival); a nil/unparseable receiver
+  degrades to the documented zero value (`''` for `toISOString`, else `0`)
+  rather than throwing. Semantics match the SSR runtimes byte-for-byte
+  (0-based `getUTCMonth`, UTC millisecond `toISOString`).
+- `@barefootjs/jsx`: the client emitter now lowers the same calls
+  `datePlugin` lowers on the SSR side — reusing the exact `datePlugin`
+  matcher (not a re-implementation), so SSR and CSR stay in parity — on both
+  the static template path (`jsx-to-ir.ts`) and the reactive
+  `createEffect` path (`ir-to-client-js/emit-reactive.ts`), emitting
+  `date(<recv>, "<op>")` and auto-importing the runtime helper. A call
+  lowers on the client iff it lowers on the server.

--- a/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
+++ b/packages/adapter-tests/src/__tests__/csr-conformance.test.ts
@@ -243,15 +243,6 @@ describe('CSR Conformance Tests', () => {
     //     first element in CSR, while SSR carries the scope on a
     //     `<!--bf-scope:...-->` comment the normalizer strips.
     'nested-fragments',
-    // #2292 (known-limitation): the `Date` catalogued lowering (#2274) is
-    // applied on the SSR/template side only — `ir-to-client-js` emits the
-    // raw `_p.createdAt.toISOString()` call, and the hydration payload
-    // delivers the `Date` prop as its ISO STRING (JSON `toJSON`), so the
-    // CSR path throws `toISOString is not a function`. SSR is correct on
-    // every adapter (oracle data-point conformance); client-JS Date support
-    // is tracked separately.
-    //   https://github.com/piconic-ai/barefootjs/issues/2292
-    'date-catalogued',
   ])
 
   for (const fixture of jsxFixtures) {

--- a/packages/adapter-tests/src/csr-render.ts
+++ b/packages/adapter-tests/src/csr-render.ts
@@ -306,6 +306,20 @@ function styleToCss(value) {
   }
   return parts.join(';') || null
 }
+// Mirror @barefootjs/client/runtime/date.ts: the catalogued \`Date\` lowering
+// (#2274/#2292) helper. \`recv\` is a real Date OR the ISO-string form a
+// Date-typed prop arrives as post-hydration/JSON; a nil or unparseable
+// receiver degrades to the zero value instead of throwing. The harness
+// strips imports and stubs the runtime itself (like escapeAttr/spreadAttrs
+// above), so \`date(...)\` calls in generated template/init code need this
+// mock or every date-catalogued fixture fails with "date is not defined".
+function date(recv, op) {
+  const zero = op === 'toISOString' ? '' : 0
+  if (recv === null || recv === undefined) return zero
+  const d = recv instanceof Date ? recv : new Date(recv)
+  if (Number.isNaN(d.getTime())) return zero
+  return d[op]()
+}
 
 // --- Execute client JS (registers templates via hydrate()) ---
 ${strippedCode}

--- a/packages/client/__tests__/runtime/date.test.ts
+++ b/packages/client/__tests__/runtime/date.test.ts
@@ -1,0 +1,86 @@
+import { describe, test, expect } from 'bun:test'
+import { date } from '../../src/runtime/date'
+
+// Pinned against the same instants the golden oracle vectors use
+// (`packages/adapter-tests/vectors/cases.ts`, the `date:` reference fn) so
+// the client helper stays in byte-for-byte parity with every SSR backend's
+// `date()` runtime helper.
+const INSTANTS = {
+  epoch: '1970-01-01T00:00:00.000Z',
+  preEpoch: '1969-07-20T20:17:40.123Z',
+  leapDay: '2024-02-29T23:59:59.999Z',
+  farFuture: '9999-12-31T23:59:59.999Z',
+} as const
+
+const EXPECTED = {
+  epoch: {
+    getUTCFullYear: 1970, getUTCMonth: 0, getUTCDate: 1,
+    getUTCHours: 0, getUTCMinutes: 0, getUTCSeconds: 0,
+    getTime: 0, toISOString: '1970-01-01T00:00:00.000Z',
+  },
+  preEpoch: {
+    getUTCFullYear: 1969, getUTCMonth: 6, getUTCDate: 20,
+    getUTCHours: 20, getUTCMinutes: 17, getUTCSeconds: 40,
+    getTime: new Date('1969-07-20T20:17:40.123Z').getTime(),
+    toISOString: '1969-07-20T20:17:40.123Z',
+  },
+  leapDay: {
+    getUTCFullYear: 2024, getUTCMonth: 1, getUTCDate: 29,
+    getUTCHours: 23, getUTCMinutes: 59, getUTCSeconds: 59,
+    getTime: new Date('2024-02-29T23:59:59.999Z').getTime(),
+    toISOString: '2024-02-29T23:59:59.999Z',
+  },
+  farFuture: {
+    getUTCFullYear: 9999, getUTCMonth: 11, getUTCDate: 31,
+    getUTCHours: 23, getUTCMinutes: 59, getUTCSeconds: 59,
+    getTime: new Date('9999-12-31T23:59:59.999Z').getTime(),
+    toISOString: '9999-12-31T23:59:59.999Z',
+  },
+} as const
+
+describe('date runtime helper', () => {
+  for (const [label, iso] of Object.entries(INSTANTS)) {
+    const expected = EXPECTED[label as keyof typeof EXPECTED]
+    for (const [op, want] of Object.entries(expected)) {
+      test(`${label}: ${op} — Date input`, () => {
+        expect(date(new Date(iso), op)).toBe(want)
+      })
+      test(`${label}: ${op} — ISO string input`, () => {
+        expect(date(iso, op)).toBe(want)
+      })
+    }
+  }
+
+  describe('nil / malformed receiver fallback', () => {
+    test('null receiver: toISOString degrades to empty string', () => {
+      expect(date(null, 'toISOString')).toBe('')
+    })
+    test('null receiver: getTime degrades to 0', () => {
+      expect(date(null, 'getTime')).toBe(0)
+    })
+    test('null receiver: getUTCFullYear degrades to 0', () => {
+      expect(date(null, 'getUTCFullYear')).toBe(0)
+    })
+    test('undefined receiver: toISOString degrades to empty string', () => {
+      expect(date(undefined, 'toISOString')).toBe('')
+    })
+    test('undefined receiver: getTime degrades to 0', () => {
+      expect(date(undefined, 'getTime')).toBe(0)
+    })
+    test('malformed string receiver: toISOString degrades to empty string', () => {
+      expect(date('not-a-date', 'toISOString')).toBe('')
+    })
+    test('malformed string receiver: getTime degrades to 0', () => {
+      expect(date('not-a-date', 'getTime')).toBe(0)
+    })
+    test('malformed string receiver: getUTCFullYear degrades to 0', () => {
+      expect(date('not-a-date', 'getUTCFullYear')).toBe(0)
+    })
+    test('NaN Date instance: toISOString degrades to empty string', () => {
+      expect(date(new Date('not-a-date'), 'toISOString')).toBe('')
+    })
+    test('NaN Date instance: getTime degrades to 0', () => {
+      expect(date(new Date('not-a-date'), 'getTime')).toBe(0)
+    })
+  })
+})

--- a/packages/client/src/runtime/date.ts
+++ b/packages/client/src/runtime/date.ts
@@ -1,0 +1,30 @@
+/**
+ * Client-side runtime for the catalogued `Date` lowering (#2274, #2292).
+ *
+ * The compiler lowers a Date-typed prop's zero-arg accessor call
+ * (`createdAt.toISOString()`, matched by `datePlugin` /
+ * `DATE_METHODS` in `packages/jsx/src/date-lowering.ts`) to
+ * `date(recv, "op")` on every backend. Each backend's `date` runtime
+ * helper must agree byte-for-byte on the dispatched value — the shared
+ * oracle is the `date` reference function in
+ * `packages/adapter-tests/vectors/cases.ts`.
+ *
+ * The CLIENT receiver shape differs from the SSR/oracle one: props are
+ * JSON round-tripped with no type-aware revival
+ * (`packages/client/src/runtime/hydrate.ts` `parseProps`), so a
+ * `Date`-typed prop arrives at hydration as its `toJSON()` ISO string,
+ * not a real `Date` instance. `recv` is therefore either:
+ *   - a real `Date` (e.g. a value constructed client-side), or
+ *   - an ISO-8601 string (the hydrated-prop case).
+ * (No `{$date: ...}` envelope — that shape is test/oracle-only, never a
+ * runtime value.) Both are coerced via `new Date(recv)`; a nil or
+ * unparseable receiver degrades to the same zero value every backend
+ * documents ('' for toISOString, 0 otherwise) instead of throwing.
+ */
+export function date(recv: unknown, op: string): string | number {
+  const zero = op === 'toISOString' ? '' : 0
+  if (recv === null || recv === undefined) return zero
+  const d = recv instanceof Date ? recv : new Date(recv as string | number)
+  if (Number.isNaN(d.getTime())) return zero
+  return (d as unknown as Record<string, () => string | number>)[op]()
+}

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -103,6 +103,7 @@ export { styleToCss } from './style.ts'
 
 // Runtime helpers
 export { findScope, find, $, $c, $t, qsa, qsaChildScope, qsaChildScopes, cssEscape, tAfter } from './query.ts'
+export { date } from './date.ts'
 export { hydrate, rehydrateAll, rehydrateScope, disposeScope, flushHydration, getRegisteredDef } from './hydrate.ts'
 export { registerComponent, getComponentInit, initChild, upsertChild } from './registry.ts'
 export { insert, type BranchConfig, type BranchTemplateResult } from './insert.ts'

--- a/packages/jsx/src/__tests__/date-lowering.test.ts
+++ b/packages/jsx/src/__tests__/date-lowering.test.ts
@@ -186,3 +186,47 @@ describe('BF021 exemption via the real datePlugin (#2274 seam)', () => {
     ).toBe(1)
   })
 })
+
+describe('client-JS lowering (#2292)', () => {
+  function clientJs(src: string): string {
+    const result = compileJSX(src.trimStart(), 'T.tsx', { adapter: new TestAdapter() })
+    return result.files.find((f) => f.type === 'clientJs')!.content
+  }
+
+  test('lowers a Date-typed prop accessor call to the date() runtime helper', () => {
+    const js = clientJs(`
+      export function Foo({ createdAt }: { createdAt: Date }) {
+        return <div>{createdAt.toISOString()}</div>
+      }
+    `)
+    expect(js).toContain('date(_p.createdAt, "toISOString")')
+    // auto-imported from the runtime barrel (imports.ts RUNTIME_IMPORT_CANDIDATES)
+    expect(js).toMatch(/import\s*\{[^}]*\bdate\b[^}]*\}\s*from\s*'@barefootjs\/client\/runtime'/)
+  })
+
+  test('leaves a non-Date receiver method call raw (parity: only what datePlugin claims)', () => {
+    const js = clientJs(`
+      export function Foo({ label }: { label: string }) {
+        return <div>{label.toUpperCase()}</div>
+      }
+    `)
+    expect(js).not.toContain('date(')
+    expect(js).toContain('toUpperCase()')
+  })
+
+  test('protects a template-literal static segment that matches the call text (#2294)', () => {
+    // The real call is in the ${…} interpolation; an identical-looking run
+    // of text sits in the static segment. Template-aware string protection
+    // must keep the non-global .replace from rewriting the static text
+    // before the real call site (Copilot review).
+    const js = clientJs(`
+      export function Foo({ createdAt }: { createdAt: Date }) {
+        return <div>{\`createdAt.toISOString() = \${createdAt.toISOString()}\`}</div>
+      }
+    `)
+    // the real (interpolated) call is lowered
+    expect(js).toContain('date(_p.createdAt, "toISOString")')
+    // the static segment is preserved verbatim, not rewritten to date(...)
+    expect(js).toContain('createdAt.toISOString() = ')
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/emit-reactive.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-reactive.ts
@@ -9,7 +9,7 @@ import type { AttrMeta, IRMetadata } from '../types.ts'
 import { isBooleanAttr } from '../html-constants.ts'
 import type { ClientJsContext } from './types.ts'
 import { toHtmlAttrName, varSlotId, PROPS_PARAM } from './utils.ts'
-import { createTemplateAwareStringProtector, createStringProtector } from './html-template.ts'
+import { createTemplateAwareStringProtector } from './html-template.ts'
 import { datePlugin, DATE_METHODS } from '../date-lowering.ts'
 import { tsNodeToParsedExpr } from '../expression-parser.ts'
 import type { LoweringMatcher } from '../lowering-registry.ts'
@@ -173,7 +173,11 @@ function lowerDateCallsInReactiveExpr(expr: string, matcher: LoweringMatcher | n
   visit(root)
   if (candidates.length === 0) return expr
 
-  const { protect, restore } = createStringProtector()
+  // Template-aware: protect quoted strings AND template-literal static
+  // segments (leaving `${…}` interpolations exposed) so the non-global
+  // `.replace` can't rewrite a backtick constant that coincidentally
+  // matches the call text before the real call site (Copilot review, #2294).
+  const { protect, restore } = createTemplateAwareStringProtector()
   let result = protect(expr)
   for (const call of candidates) {
     const propAccess = call.expression as ts.PropertyAccessExpression

--- a/packages/jsx/src/ir-to-client-js/emit-reactive.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-reactive.ts
@@ -4,11 +4,15 @@
  * client-only expressions, and reactive component prop bindings.
  */
 
-import type { AttrMeta } from '../types.ts'
+import ts from 'typescript'
+import type { AttrMeta, IRMetadata } from '../types.ts'
 import { isBooleanAttr } from '../html-constants.ts'
 import type { ClientJsContext } from './types.ts'
 import { toHtmlAttrName, varSlotId, PROPS_PARAM } from './utils.ts'
-import { createTemplateAwareStringProtector } from './html-template.ts'
+import { createTemplateAwareStringProtector, createStringProtector } from './html-template.ts'
+import { datePlugin, DATE_METHODS } from '../date-lowering.ts'
+import { tsNodeToParsedExpr } from '../expression-parser.ts'
+import type { LoweringMatcher } from '../lowering-registry.ts'
 
 /**
  * Profile mode (#1690, SR3/SR4): the id appended to a DOM-binding effect so the
@@ -95,8 +99,100 @@ export function rewriteDestructuredPropsInExpr(expr: string, ctx: ClientJsContex
   return restore(result)
 }
 
+/**
+ * Bind `datePlugin`'s matcher (#2292) for this component's reactive-text
+ * emission. Reads the same four `EvidenceMetadata` fields
+ * (`rich-type-evidence.ts`) `jsx-to-ir.ts`'s `getDateLoweringMatcher` reads
+ * off the analyzer for the STATIC template path, so a prop-method call
+ * re-evaluated inside a `createEffect` lowers to the `date` helper under
+ * the exact same evidence the static template and every SSR adapter use.
+ * `ctx.propsType` is optional on `ClientJsContext` (threaded through only
+ * for this purpose, `index.ts`'s `createContext`); a context predating
+ * #2292 — or a hand-built test fixture — simply carries no Date evidence,
+ * so this returns null and callers emit the expression unchanged.
+ */
+function getReactiveDateLoweringMatcher(ctx: ClientJsContext): LoweringMatcher | null {
+  if (!ctx.propsType) return null
+  const metadataSlice: Pick<IRMetadata, 'propsType' | 'propsObjectName' | 'propsParams' | 'typeDefinitions'> = {
+    propsType: ctx.propsType,
+    propsObjectName: ctx.propsObjectName,
+    propsParams: ctx.propsParams,
+    typeDefinitions: ctx.typeDefinitions ?? [],
+  }
+  return datePlugin.prepare(metadataSlice as unknown as IRMetadata)
+}
+
+/**
+ * Reactive-path counterpart to `jsx-to-ir.ts`'s `lowerDateCalls` (#2292):
+ * without this, a Date-typed prop's catalogued accessor call re-evaluated
+ * inside `createEffect` (the Solid-style wrap-by-default fallback for any
+ * expression containing a function call, #937) still called the RAW
+ * `.toISOString()` / etc. on the hydrated STRING prop value and threw —
+ * the static template alone wasn't enough to fix hydration.
+ *
+ * `expr` here (`IRExpression.expr`, threaded through
+ * `ctx.dynamicElements`) is ALREADY the bare-identifier source form the
+ * SAME `createEffect` body closes over via the destructured-prop shim
+ * (`const createdAt = _p.createdAt ?? {}` at the top of `init()`) — so
+ * unlike the static-template path, the receiver does NOT need a `_p.`
+ * prefix: swapping the raw call for `date(<receiver>, "<op>")` is enough.
+ *
+ * No live `ts.Node` survives into this phase (`expr` is a plain string),
+ * so this re-parses it fresh via `ts.createSourceFile` — the same
+ * technique `expression-parser.ts`'s `parseExpression` uses — rather than
+ * a regex scan (per CLAUDE.md's structural-parsing rule): every candidate
+ * span comes from walking the freshly-parsed AST, and `matcher(...)` is
+ * the SAME `datePlugin` matcher the static path and every SSR adapter
+ * bind, so a call lowers here iff it would lower there too.
+ */
+function lowerDateCallsInReactiveExpr(expr: string, matcher: LoweringMatcher | null): string {
+  if (!matcher) return expr
+  let sourceFile: ts.SourceFile
+  try {
+    sourceFile = ts.createSourceFile('__reactive_expr__.ts', `(${expr});`, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS)
+  } catch {
+    return expr
+  }
+  const stmt = sourceFile.statements[0]
+  if (!stmt || !ts.isExpressionStatement(stmt)) return expr
+  const root = ts.isParenthesizedExpression(stmt.expression) ? stmt.expression.expression : stmt.expression
+
+  const candidates: ts.CallExpression[] = []
+  const visit = (n: ts.Node): void => {
+    if (
+      ts.isCallExpression(n) &&
+      n.arguments.length === 0 &&
+      ts.isPropertyAccessExpression(n.expression) &&
+      !n.expression.questionDotToken &&
+      DATE_METHODS.has(n.expression.name.text)
+    ) {
+      candidates.push(n)
+    }
+    ts.forEachChild(n, visit)
+  }
+  visit(root)
+  if (candidates.length === 0) return expr
+
+  const { protect, restore } = createStringProtector()
+  let result = protect(expr)
+  for (const call of candidates) {
+    const propAccess = call.expression as ts.PropertyAccessExpression
+    const node = matcher(tsNodeToParsedExpr(propAccess), [])
+    if (!node || node.kind !== 'helper-call' || node.helper !== 'date') continue
+    const op = propAccess.name.text
+    const receiverText = propAccess.expression.getText(sourceFile)
+    const matchText = call.getText(sourceFile)
+    // Replacer-function form: a `$` sequence in `receiverText` would
+    // otherwise be reinterpreted as a `String.replace` pattern token and
+    // corrupt the output (repo precedent, #2285).
+    result = result.replace(matchText, () => `date(${receiverText}, "${op}")`)
+  }
+  return restore(result)
+}
+
 /** Emit createEffect blocks that update text nodes for reactive expressions. */
 export function emitDynamicTextUpdates(lines: string[], ctx: ClientJsContext): void {
+  const dateLoweringMatcher = getReactiveDateLoweringMatcher(ctx)
   // Group elements by expression to consolidate effects with same dependencies
   const byExpression = new Map<string, typeof ctx.dynamicElements>()
   for (const elem of ctx.dynamicElements) {
@@ -107,7 +203,8 @@ export function emitDynamicTextUpdates(lines: string[], ctx: ClientJsContext): v
     byExpression.get(key)!.push(elem)
   }
 
-  for (const [expr, elems] of byExpression) {
+  for (const [rawExpr, elems] of byExpression) {
+    const expr = lowerDateCallsInReactiveExpr(rawExpr, dateLoweringMatcher)
     // Separate conditional vs non-conditional elements
     const conditionalElems = elems.filter(e => e.insideConditional)
     const normalElems = elems.filter(e => !e.insideConditional)

--- a/packages/jsx/src/ir-to-client-js/imports.ts
+++ b/packages/jsx/src/ir-to-client-js/imports.ts
@@ -17,6 +17,10 @@ export const RUNTIME_IMPORT_CANDIDATES = [
   'tAfter',
   // Profile mode (#1690, SR3) — turn-boundary markers around event handlers.
   'beginTurn', 'endTurn',
+  // Catalogued `Date` lowering (#2274/#2292) — the client counterpart to
+  // every SSR adapter's `date` runtime helper (`date-lowering.ts`'s
+  // `datePlugin`).
+  'date',
 ] as const
 
 /** @deprecated Use RUNTIME_IMPORT_CANDIDATES */

--- a/packages/jsx/src/ir-to-client-js/index.ts
+++ b/packages/jsx/src/ir-to-client-js/index.ts
@@ -175,6 +175,8 @@ function createContext(
     propsParams: ir.metadata.propsParams,
     propsObjectName: ir.metadata.propsObjectName,
     restPropsName: ir.metadata.restPropsName,
+    propsType: ir.metadata.propsType,
+    typeDefinitions: ir.metadata.typeDefinitions,
 
     interactiveElements: [],
     dynamicElements: [],

--- a/packages/jsx/src/ir-to-client-js/types.ts
+++ b/packages/jsx/src/ir-to-client-js/types.ts
@@ -20,6 +20,8 @@ import type {
   ParamInfo,
   CompilerError,
   ImportInfo,
+  TypeInfo,
+  TypeDefinition,
 } from '../types.ts'
 import type { CsrInlinabilityMap } from './csr-substitute.ts'
 import type { SkeletonSlotPaths } from './html-template.ts'
@@ -67,6 +69,19 @@ export interface ClientJsContext {
   propsParams: ParamInfo[]
   propsObjectName: string | null
   restPropsName: string | null
+  /**
+   * Threaded through (alongside `propsParams` above) so the reactive-effect
+   * emitter can bind its own `datePlugin` matcher (#2292) — see
+   * `emit-reactive.ts`'s `getReactiveDateLoweringMatcher`. Mirrors the
+   * `EvidenceMetadata` slice (`rich-type-evidence.ts`) the SSR adapters and
+   * `jsx-to-ir.ts`'s static-template lowering both consult; nothing else in
+   * this file reads a Date-typed prop's shape. Optional (rather than a hard
+   * requirement alongside `propsParams`) so existing hand-built
+   * `ClientJsContext` test fixtures that predate #2292 keep type-checking
+   * without every call site listing these two fields.
+   */
+  propsType?: TypeInfo | null
+  typeDefinitions?: TypeDefinition[]
 
   // Collected elements
   interactiveElements: InteractiveElement[]

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -47,7 +47,7 @@ import {
 } from './prop-rewrite.ts'
 import { resolveFreeRefs, isNameBound as isNameBoundInEnv, type BindingEnvironment } from './free-refs.ts'
 import { computeFileScope } from './ir-to-client-js/component-scope.ts'
-import { createStringProtector } from './ir-to-client-js/html-template.ts'
+import { createTemplateAwareStringProtector } from './ir-to-client-js/html-template.ts'
 import { datePlugin, DATE_METHODS } from './date-lowering.ts'
 import type { LoweringMatcher } from './lowering-registry.ts'
 import { extractFreeIdentifiersFromNode, initializerShapeContainsJsx } from './analyzer.ts'
@@ -356,10 +356,13 @@ function getDateLoweringMatcher(ctx: TransformContext): LoweringMatcher | null {
  * that one sub-node — which strips only type syntax — is guaranteed
  * byte-identical to its raw source slice, and thus guaranteed to appear
  * verbatim as a contiguous substring of `text` regardless of unrelated
- * type-stripping elsewhere in the enclosing expression. String-literal
- * spans in `text` are protected first (`createStringProtector`) so a
- * coincidentally-identical string constant can never be mistaken for a
- * call site.
+ * type-stripping elsewhere in the enclosing expression. String spans in
+ * `text` are protected first (`createTemplateAwareStringProtector` — both
+ * quoted strings AND template-literal *static* segments, leaving `${…}`
+ * interpolations exposed) so a coincidentally-identical string constant —
+ * e.g. a backtick `` `createdAt.toISOString()` `` sitting before the real
+ * call — can never be mistaken for a call site by the non-global
+ * `.replace`.
  */
 function lowerDateCalls(text: string, expr: ts.Node, ctx: TransformContext): string {
   const matcher = getDateLoweringMatcher(ctx)
@@ -381,7 +384,7 @@ function lowerDateCalls(text: string, expr: ts.Node, ctx: TransformContext): str
   visit(expr)
   if (candidates.length === 0) return text
 
-  const { protect, restore } = createStringProtector()
+  const { protect, restore } = createTemplateAwareStringProtector()
   let result = protect(text)
   for (const call of candidates) {
     const propAccess = call.expression as ts.PropertyAccessExpression

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -30,6 +30,7 @@ import {
   type SourceLocation,
   type TypeInfo,
   type OriginInfo,
+  type IRMetadata,
   isReactiveOrigin,
   AttrValueOf,
 } from './types.ts'
@@ -46,6 +47,9 @@ import {
 } from './prop-rewrite.ts'
 import { resolveFreeRefs, isNameBound as isNameBoundInEnv, type BindingEnvironment } from './free-refs.ts'
 import { computeFileScope } from './ir-to-client-js/component-scope.ts'
+import { createStringProtector } from './ir-to-client-js/html-template.ts'
+import { datePlugin, DATE_METHODS } from './date-lowering.ts'
+import type { LoweringMatcher } from './lowering-registry.ts'
 import { extractFreeIdentifiersFromNode, initializerShapeContainsJsx } from './analyzer.ts'
 import { iterateJsTokens, replaceInExprContexts } from './scanner/js-scanner.ts'
 import { toHTMLAttrName, decodeEntities } from '@barefootjs/shared'
@@ -164,6 +168,13 @@ interface TransformContext {
    * aliased `import { Async as Boundary }` maps `<Boundary>` to the built-in.
    */
   _clientBuiltinTags?: Map<string, ClientBuiltinTag>
+  /**
+   * Cached `datePlugin` matcher (#2292), bound once to this component's
+   * metadata. `undefined` = not yet computed; `null` = computed and
+   * inactive (this component's props never reach a `Date`, `datePlugin`'s
+   * own `prepare` gate). See `getDateLoweringMatcher`.
+   */
+  _dateLoweringMatcher?: LoweringMatcher | null
 }
 
 /**
@@ -286,13 +297,124 @@ function exprHasFunctionCalls(expr: ts.Expression): boolean {
 }
 
 /**
+ * Bind (and cache on `ctx`) `datePlugin`'s matcher (#2292) for this
+ * component. Reuses the SAME `LoweringPlugin` the SSR adapters bind via
+ * `prepareLoweringMatchers` — not a re-implementation of its receiver-type
+ * resolution — so a call lowers on the client iff `datePlugin` would lower
+ * it on the SSR path (parity is mandatory per #2292).
+ *
+ * `datePlugin.prepare` only reads `propsType` / `propsObjectName` /
+ * `propsParams` / `typeDefinitions` off its `IRMetadata` parameter (see
+ * `rich-type-evidence.ts`'s `EvidenceMetadata` — the `Pick` of exactly
+ * those four fields). `ctx.analyzer` carries live, fully-populated values
+ * for all four by the time any expression is transformed (analysis runs
+ * to completion before `jsxToIR`'s AST walk begins), so a slice of just
+ * those fields is sufficient — the cast bridges that narrower shape to
+ * the wider `IRMetadata` parameter type every lowering plugin declares.
+ */
+function getDateLoweringMatcher(ctx: TransformContext): LoweringMatcher | null {
+  if (ctx._dateLoweringMatcher === undefined) {
+    const a = ctx.analyzer
+    const metadataSlice: Pick<IRMetadata, 'propsType' | 'propsObjectName' | 'propsParams' | 'typeDefinitions'> = {
+      propsType: a.propsType,
+      propsObjectName: a.propsObjectName,
+      propsParams: a.propsParams,
+      typeDefinitions: a.typeDefinitions,
+    }
+    ctx._dateLoweringMatcher = datePlugin.prepare(metadataSlice as unknown as IRMetadata)
+  }
+  return ctx._dateLoweringMatcher
+}
+
+/**
+ * Client-side counterpart to `datePlugin` (#2274 was SSR-only; #2292
+ * closes the gap). The client emitter (`ir-to-client-js/`) emits raw,
+ * prop-rewritten source strings and never consults the lowering registry
+ * (its module doc) — so left alone, a Date-typed prop's catalogued
+ * accessor call leaks through as `_p.createdAt.toISOString()`, which
+ * throws at hydration: props are JSON round-tripped with no type-aware
+ * revival (`hydrate.ts`'s `parseProps`), so the prop arrives as its ISO
+ * string, not a `Date` instance.
+ *
+ * Walks `expr`'s AST for zero-arg calls to a `DATE_METHODS` name (a cheap
+ * syntactic pre-filter) and confirms each candidate against the SAME
+ * `datePlugin` matcher the SSR adapters use, via `tsNodeToParsedExpr` —
+ * the identical receiver-type resolution, not a re-implementation, so a
+ * call lowers here iff it would lower on the SSR path. A match splices
+ * `date(<receiver>, "<op>")` in place of the raw call; `imports.ts`'s
+ * `detectUsedImports` regex-scans the emitted `date(` call against
+ * `RUNTIME_IMPORT_CANDIDATES` to auto-import the runtime helper.
+ *
+ * The splice is a plain (non-global) text `.replace` per candidate, run
+ * in AST (left-to-right, source) order — not a JS-parsing regex, since
+ * every candidate span comes from walking `expr`'s real AST first. This
+ * is safe specifically because any call the matcher accepts has, by
+ * construction, no TS-only syntax anywhere in its own span: the matcher
+ * only resolves evidence through a bare identifier or a non-computed
+ * member chain (`resolveReceiverType`'s two supported `ParsedExpr`
+ * shapes), and the call itself takes zero arguments. So `ctx.getJS` of
+ * that one sub-node — which strips only type syntax — is guaranteed
+ * byte-identical to its raw source slice, and thus guaranteed to appear
+ * verbatim as a contiguous substring of `text` regardless of unrelated
+ * type-stripping elsewhere in the enclosing expression. String-literal
+ * spans in `text` are protected first (`createStringProtector`) so a
+ * coincidentally-identical string constant can never be mistaken for a
+ * call site.
+ */
+function lowerDateCalls(text: string, expr: ts.Node, ctx: TransformContext): string {
+  const matcher = getDateLoweringMatcher(ctx)
+  if (!matcher) return text
+
+  const candidates: ts.CallExpression[] = []
+  function visit(n: ts.Node) {
+    if (
+      ts.isCallExpression(n) &&
+      n.arguments.length === 0 &&
+      ts.isPropertyAccessExpression(n.expression) &&
+      !n.expression.questionDotToken &&
+      DATE_METHODS.has(n.expression.name.text)
+    ) {
+      candidates.push(n)
+    }
+    ts.forEachChild(n, visit)
+  }
+  visit(expr)
+  if (candidates.length === 0) return text
+
+  const { protect, restore } = createStringProtector()
+  let result = protect(text)
+  for (const call of candidates) {
+    const propAccess = call.expression as ts.PropertyAccessExpression
+    const node = matcher(tsNodeToParsedExpr(propAccess), [])
+    if (!node || node.kind !== 'helper-call' || node.helper !== 'date') continue
+    const op = propAccess.name.text
+    const receiverText = ctx.getJS(propAccess.expression)
+    const matchText = ctx.getJS(call)
+    // Replacer-function form: a `$` sequence in `receiverText` (a prop named
+    // `$1`, say) would otherwise be reinterpreted as a `String.replace`
+    // pattern token and corrupt the output (repo precedent, #2285).
+    result = result.replace(matchText, () => `date(${receiverText}, "${op}")`)
+  }
+  return restore(result)
+}
+
+/**
  * Rewrite bare destructured prop references in expression text.
  * Thin wrapper that caches prop names on ctx and delegates to the shared core.
  * Returns undefined if no rewriting is needed (SolidJS-style or no props).
  */
 function rewriteBarePropRefs(text: string, expr: ts.Node, ctx: TransformContext): string | undefined {
+  // #2292: lower a Date-typed prop's catalogued accessor call BEFORE the
+  // bare-prop-name rewrite below, so the receiver identifier still picks
+  // up the usual `_p.` prefix (destructured mode) or falls through to the
+  // CSR template emitter's separate `props.` → `_p.` rewrite
+  // (`html-template.ts`'s `transformExpr`, props-object mode). Runs
+  // unconditionally — ahead of the `propNames` gate — because Date
+  // evidence comes from `ctx.analyzer.propsType`, independent of whether
+  // this component destructures its props.
+  const dateLowered = lowerDateCalls(text, expr, ctx)
   let propNames = getDestructuredPropNames(ctx)
-  if (!propNames) return undefined
+  if (!propNames) return dateLowered === text ? undefined : dateLowered
   // #2222: a name bound as an enclosing loop callback's item/index param
   // refers to the loop binding, not the prop, at THIS transform position —
   // `ctx.loopParams` is the live loop-param set (destructured binding
@@ -303,7 +425,7 @@ function rewriteBarePropRefs(text: string, expr: ts.Node, ctx: TransformContext)
   // its set on ctx and must not be mutated.
   if (ctx.loopParams.size > 0) {
     const filtered = new Set([...propNames].filter(n => !ctx.loopParams.has(n)))
-    if (filtered.size === 0) return undefined
+    if (filtered.size === 0) return dateLowered === text ? undefined : dateLowered
     propNames = filtered
   }
   // #1425: union any prop refs that `expr` reaches via branch-local
@@ -316,7 +438,7 @@ function rewriteBarePropRefs(text: string, expr: ts.Node, ctx: TransformContext)
   // `_branchScopePropDeps` at branch entry; here we just walk `expr`
   // for references to those locals and union the matching dep sets.
   const extraPropRefs = collectBranchLocalPropRefsViaSubstitution(expr, ctx)
-  return rewriteBarePropRefsCore(text, expr, propNames, extraPropRefs)
+  return rewriteBarePropRefsCore(dateLowered, expr, propNames, extraPropRefs)
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #2292. The catalogued `Date` lowering (#2274) rendered **SSR only**. The client-JS emitter (`ir-to-client-js/`) emits raw, prop-rewritten source and never consulted the lowering registry, so a `Date`-typed prop's `createdAt.toISOString()` leaked through as `_p.createdAt.toISOString()` and threw at hydration — props are JSON round-tripped with no type-aware revival, so the prop arrives as an ISO **string**, not a `Date`.

This closes the loop so the neutral `date` lowering is truly universal (SSR **and** CSR).

- **New `@barefootjs/client` runtime helper `date(recv, op)`** — the client counterpart to every SSR adapter's `date` helper. `recv` tolerates a real `Date` **or** the ISO-8601 string a Date-typed prop arrives as post-hydration; a nil/unparseable receiver degrades to the documented zero value (`''` for `toISOString`, else `0`) instead of throwing. Semantics match the SSR runtimes byte-for-byte (0-based `getUTCMonth`, UTC millisecond `toISOString`).
- **Client-side lowering** — the client emitter now lowers the **same** calls `datePlugin` lowers on SSR, **reusing the exact `datePlugin` matcher** (not a re-implementation) so SSR and CSR stay in parity: a call lowers on the client iff it lowers on the server. Applied on both the static template path (`jsx-to-ir.ts`) and the reactive `createEffect` path (`ir-to-client-js/emit-reactive.ts`), emitting `date(<recv>, "<op>")` and auto-importing the helper via `RUNTIME_IMPORT_CANDIDATES`. The AST is the source of truth (TS `CallExpression` walk + span-derived splice, replacer-function form — no regex JS parsing).
- **`date-catalogued` is no longer CSR-skipped** — it exercises both client paths (the `createEffect` fallback wraps any function-call expression, so `createdAt.toISOString()` hits the reactive path too).

## Verification (all local, green)

- Client `date` helper units: **74 pass** — every op, for a `Date` input **and** an ISO-string input, at the epoch / pre-1970 nonzero-ms / leap-day / year-9999 instants, plus nil/NaN fallback.
- CSR conformance: `date-catalogued` **passes** (was skipped); full suite **201 pass / 0 fail** (was 200).
- SSR unchanged: Hono `date-catalogued` (8) and `data-domain` (7) green.
- jsx compiler suite: **2479 pass / 0 fail**; `tsgo --noEmit` clean.
- Emitted client JS: `import { …, date, … } from '@barefootjs/client/runtime'` and `date(_p.createdAt, "toISOString")` — parity with the SSR adapters' `bf.date(recv, "toISOString")`.

## Notes

- Design + review + verification by independent Opus passes; implementation followed the #2274 neutral-lowering discipline (reuse `datePlugin`, never a bespoke recognizer).
- `datePlugin` is prop-rooted in v1 (loop-item / signal receivers stay BF021-refused), so this change is scoped to the same prop-rooted surface on the client — no widening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1T4R1R6FKPGTFyYn1ppBa)_