### PR TITLE
Add #2275: kind × axis × adapter support matrix

### DIFF
--- a/.github/workflows/ci-compat.yml
+++ b/.github/workflows/ci-compat.yml
@@ -6,10 +6,12 @@ on:
     paths:
       - 'ui/components/**'
       - 'ui/compat.lock.json'
+      - 'ui/support-matrix.lock.json'
       - 'packages/jsx/**'
       - 'packages/client/**'
       - 'packages/cli/**'
       - 'packages/compat/**'
+      - 'packages/adapter-tests/coverage-map.json'
       - 'packages/adapter-erb/**'
       - 'packages/adapter-go-template/**'
       - 'packages/adapter-hono/**'
@@ -23,10 +25,12 @@ on:
     paths:
       - 'ui/components/**'
       - 'ui/compat.lock.json'
+      - 'ui/support-matrix.lock.json'
       - 'packages/jsx/**'
       - 'packages/client/**'
       - 'packages/cli/**'
       - 'packages/compat/**'
+      - 'packages/adapter-tests/coverage-map.json'
       - 'packages/adapter-erb/**'
       - 'packages/adapter-go-template/**'
       - 'packages/adapter-hono/**'
@@ -90,5 +94,15 @@ jobs:
         run: |
           if ! git diff --exit-code -- ui/compat.lock.json; then
             echo "::error::ui/compat.lock.json is out of date. Run 'bun run compat:lock' locally and commit the result."
+            exit 1
+          fi
+
+      - name: Regenerate support matrix lockfile
+        run: bun run support-matrix:lock
+
+      - name: Check support matrix for drift
+        run: |
+          if ! git diff --exit-code -- ui/support-matrix.lock.json; then
+            echo "::error::ui/support-matrix.lock.json is out of date. Run 'bun run support-matrix:lock' locally and commit the result."
             exit 1
           fi

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "meta:extract": "bun run packages/cli/src/index.ts meta extract",
     "compat": "bun run packages/compat/src/cli.ts",
     "compat:lock": "bun run packages/compat/src/cli.ts --all --json --out ui/compat.lock.json",
+    "support-matrix:lock": "bun run packages/compat/src/support-matrix-cli.ts",
     "bf": "bun run packages/cli/src/index.ts",
     "lint": "biome check",
     "prepare": "simple-git-hooks"

--- a/packages/compat/__tests__/support-matrix.test.ts
+++ b/packages/compat/__tests__/support-matrix.test.ts
@@ -1,0 +1,155 @@
+// Pins the `coverage-map.json` × adapter-pins join in `support-matrix.ts`
+// against small synthetic input (no real fixtures/adapters involved), plus
+// a freshness gate mirroring `packages/adapter-tests/src/__tests__/coverage-map.test.ts`:
+// `computeSupportMatrix()` must be deterministic across calls, and the
+// committed `ui/support-matrix.lock.json` must equal a fresh
+// `formatSupportMatrixJson(await computeSupportMatrix())`. CI additionally
+// gates on `git diff --exit-code -- ui/support-matrix.lock.json` after
+// regenerating (`.github/workflows/ci-compat.yml`) — this in-test check is
+// defense so `bun test` alone catches drift too.
+
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { PARSED_EXPR_KINDS } from '@barefootjs/jsx'
+import {
+  buildSupportMatrix,
+  computeSupportMatrix,
+  formatSupportMatrixJson,
+  type SupportMatrixAdapterInput,
+  type SupportMatrixCoverageMap,
+} from '../src/support-matrix'
+
+const LOCK_PATH = resolve(import.meta.dir, '../../../ui/support-matrix.lock.json')
+
+/**
+ * Three synthetic fixtures: `f1` exercises `call` + `literal:string`,
+ * `f2` exercises only `call`, `f3` exercises only `literal:string`. No
+ * other `PARSED_EXPR_KINDS` entry (e.g. `identifier`, `regex`) is
+ * exercised by anything here — those stay at `total: 0` in the report,
+ * exactly like the real `regex` row.
+ */
+function syntheticCoverage(): SupportMatrixCoverageMap {
+  return {
+    fixtures: {
+      f1: { kinds: ['call'], axes: ['literal:string'] },
+      f2: { kinds: ['call'], axes: [] },
+      f3: { kinds: [], axes: ['literal:string'] },
+    },
+    kindCounts: { call: 2 },
+    axisCounts: { 'literal:string': 2 },
+    uncoveredKinds: ['regex'],
+  }
+}
+
+/**
+ * Three synthetic adapters, deliberately given non-alphabetical / non-hono-
+ * first ids (`zeta`, `hono`, `alpha`) to pin the column-ordering contract
+ * too. `hono` pins `f1` with three diagnostics: two carrying issue URLs
+ * (one duplicated, to pin dedup) in reverse sort order (to pin the sort),
+ * and one carrying no issue (to pin that a pin can still gap a fixture
+ * with an empty issues contribution). `alpha` declares no pins but a
+ * `renderDivergences` entry for `f3` (to pin that render-divergence-only
+ * gaps carry `issues: []`, since that map has no issue field at all).
+ * `zeta` declares neither, so every cell on it is clean.
+ */
+function syntheticAdapters(): SupportMatrixAdapterInput[] {
+  return [
+    { id: 'zeta', pins: {}, renderDivergences: {} },
+    {
+      id: 'hono',
+      pins: {
+        f1: [
+          { code: 'BF1', severity: 'error', issue: 'https://example.com/issues/2' },
+          { code: 'BF2', severity: 'error', issue: 'https://example.com/issues/1' },
+          { code: 'BF3', severity: 'warning', issue: 'https://example.com/issues/1' },
+          { code: 'BF4', severity: 'warning' },
+        ],
+      },
+      renderDivergences: {},
+    },
+    { id: 'alpha', pins: {}, renderDivergences: { f3: 'renders differently from the reference' } },
+  ]
+}
+
+describe('buildSupportMatrix (synthetic join)', () => {
+  const report = buildSupportMatrix(syntheticCoverage(), syntheticAdapters())
+
+  test('adapter columns: hono first, then alphabetical', () => {
+    expect(report.adapters).toEqual(['hono', 'alpha', 'zeta'])
+  })
+
+  test('kinds cover every PARSED_EXPR_KINDS entry, sorted', () => {
+    expect(Object.keys(report.kinds)).toEqual([...PARSED_EXPR_KINDS].sort())
+  })
+
+  test('a covered kind: total + ratio + gap drill-down', () => {
+    const call = report.kinds.call
+    expect(call.total).toBe(2) // f1, f2
+
+    // zeta: no pins/divergences anywhere — fully clean.
+    expect(call.cells.zeta).toEqual({ pass: 2, total: 2 })
+
+    // alpha: no pins on f1/f2 either — clean, even though it has an
+    // unrelated renderDivergence on f3 (which doesn't exercise `call`).
+    expect(call.cells.alpha).toEqual({ pass: 2, total: 2 })
+
+    // hono: f1 gapped via pins, f2 clean. Issues dedup+sorted.
+    expect(call.cells.hono).toEqual({
+      pass: 1,
+      total: 2,
+      gaps: [{ fixture: 'f1', issues: ['https://example.com/issues/1', 'https://example.com/issues/2'] }],
+    })
+  })
+
+  test('an axis: total + ratio + render-divergence gap with no issue URL', () => {
+    const axis = report.axes['literal:string']
+    expect(axis.total).toBe(2) // f1, f3
+
+    // zeta: clean.
+    expect(axis.cells.zeta).toEqual({ pass: 2, total: 2 })
+
+    // hono: f1 gapped via pins (same fixture, same issues as the `call` case).
+    expect(axis.cells.hono).toEqual({
+      pass: 1,
+      total: 2,
+      gaps: [{ fixture: 'f1', issues: ['https://example.com/issues/1', 'https://example.com/issues/2'] }],
+    })
+
+    // alpha: f3 gapped via renderDivergences only — no issue URL available.
+    expect(axis.cells.alpha).toEqual({
+      pass: 1,
+      total: 2,
+      gaps: [{ fixture: 'f3', issues: [] }],
+    })
+  })
+
+  test('an uncovered construct reports total: 0 with no gaps, for every adapter', () => {
+    // `identifier` isn't exercised by any synthetic fixture — same shape
+    // the real matrix gives `regex` (packages/adapter-tests/coverage-map.json's
+    // uncoveredKinds).
+    const identifier = report.kinds.identifier
+    expect(identifier.total).toBe(0)
+    for (const adapterId of report.adapters) {
+      expect(identifier.cells[adapterId]).toEqual({ pass: 0, total: 0 })
+    }
+  })
+
+  test('axes are exactly coverage.axisCounts keys (no uncovered-axis row)', () => {
+    expect(Object.keys(report.axes)).toEqual(['literal:string'])
+  })
+})
+
+describe('support matrix freshness', () => {
+  test('computeSupportMatrix() is deterministic across calls', async () => {
+    const a = await computeSupportMatrix()
+    const b = await computeSupportMatrix()
+    expect(a).toEqual(b)
+  })
+
+  test('committed ui/support-matrix.lock.json matches a fresh computeSupportMatrix()', async () => {
+    const committed = readFileSync(LOCK_PATH, 'utf8')
+    const fresh = formatSupportMatrixJson(await computeSupportMatrix())
+    expect(fresh).toBe(committed)
+  })
+})

--- a/packages/compat/src/report.ts
+++ b/packages/compat/src/report.ts
@@ -14,6 +14,19 @@ export const COMPAT_NOTE =
 
 export const KNOWN_LIMITATION_LABEL = 'https://github.com/piconic-ai/barefootjs/labels/known-limitation'
 
+/**
+ * The compat determinism contract's adapter-column ordering: `hono`
+ * (the reference adapter) always leads, the remainder sorts alphabetically
+ * by code-unit (never `localeCompare` — see the module docstring). Shared
+ * by `buildCompatReport` and `packages/compat/src/support-matrix.ts` so
+ * both committed lockfiles agree on column order.
+ */
+export function compareAdapterIds(a: string, b: string): number {
+  if (a === 'hono') return b === 'hono' ? 0 : -1
+  if (b === 'hono') return 1
+  return a < b ? -1 : a > b ? 1 : 0
+}
+
 /** A `CompatCell` as it appears in the report: `diagnostics` omitted entirely when empty. */
 export interface CompatReportCell {
   ok: boolean
@@ -139,11 +152,7 @@ export function buildCompatReport(
   // `hono` is the reference adapter — the conformance suite compares every
   // other adapter's render against it — so it always leads the columns;
   // the remainder stays alphabetical.
-  const adapters = [...adapterIds].sort((a, b) => {
-    if (a === 'hono') return b === 'hono' ? 0 : -1
-    if (b === 'hono') return 1
-    return a < b ? -1 : a > b ? 1 : 0
-  })
+  const adapters = [...adapterIds].sort(compareAdapterIds)
 
   const components: CompatReport['components'] = {}
   for (const name of Object.keys(cells).sort()) {

--- a/packages/compat/src/support-matrix-cli.ts
+++ b/packages/compat/src/support-matrix-cli.ts
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+// @barefootjs/compat support-matrix generator — writes the deterministic
+// `kind × axis × adapter` construct-support JSON to `ui/support-matrix.lock.json`.
+//
+// Invocation: `bun run packages/compat/src/support-matrix-cli.ts` (or via
+// the root `support-matrix:lock` script). CI regenerates it and diffs —
+// see `.github/workflows/ci-compat.yml`. Modeled on `cli.ts`'s
+// `compat:lock` path (`--all --json --out ui/compat.lock.json`), but this
+// artifact has no component/adapter selection to do — it's always the
+// full join over the committed coverage map, so there's no flag surface.
+
+import { writeFileSync } from 'fs'
+import { fileURLToPath } from 'node:url'
+import path from 'path'
+import { computeSupportMatrix, formatSupportMatrixJson } from './support-matrix'
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..')
+const OUT_PATH = path.join(REPO_ROOT, 'ui/support-matrix.lock.json')
+
+async function main(): Promise<void> {
+  const report = await computeSupportMatrix()
+  writeFileSync(OUT_PATH, formatSupportMatrixJson(report))
+
+  const kindCount = Object.keys(report.kinds).length
+  const axisCount = Object.keys(report.axes).length
+  console.error(
+    `Wrote support matrix → ${OUT_PATH} (${report.adapters.length} adapters, ${kindCount} kinds, ${axisCount} axes)`,
+  )
+}
+
+if (import.meta.main) {
+  await main()
+}

--- a/packages/compat/src/support-matrix.ts
+++ b/packages/compat/src/support-matrix.ts
@@ -1,0 +1,201 @@
+// @barefootjs/compat — construct support matrix (`kind × axis × adapter`).
+//
+// Mirrors the compat.lock.json pipeline (packages/compat/src/report.ts +
+// cli.ts) but answers a different question: not "does this whole
+// COMPONENT compile clean on adapter A" but "of the fixtures that
+// exercise construct C (a ParsedExpr kind, or a finer-grained axis like
+// `binary:===`), how many are clean on adapter A".
+//
+// IMPORTANT — attribution semantics (why this isn't a binary pass/fail):
+// `ConformancePins` / `RenderDivergences` are FIXTURE-granular — a pin
+// says "fixture X is gapped on adapter A", not "construct C is gapped on
+// adapter A". A gapped fixture is usually a complex component that
+// incidentally exercises many common kinds/axes alongside the one
+// construct it exists to pin down. So attributing a gap to every
+// construct the fixture happens to touch would make nearly every common
+// construct (identifier, literal:string, ...) look broken on every
+// adapter, when in reality only one fixture's specific shape is pinned.
+// The fix is to report a RATIO (`pass / total` covering fixtures) plus a
+// `gaps` drill-down naming exactly which fixtures are gapped and which
+// tracking issues cover them — never collapse that back into a binary
+// per-cell verdict.
+//
+// Denominators come from `packages/adapter-tests/coverage-map.json` (the
+// committed kind/axis/fixture ledger — see that package's
+// `src/coverage-map.ts` for how it's computed and its own freshness
+// gate). Numerators come from `loadCompatAdapters()` (the same registry
+// `report.ts`/`cli.ts` use for the component matrix).
+
+import { PARSED_EXPR_KINDS } from '@barefootjs/jsx'
+import coverageMapJson from '../../adapter-tests/coverage-map.json' with { type: 'json' }
+import { loadCompatAdapters } from './adapter-registry'
+import { compareAdapterIds, KNOWN_LIMITATION_LABEL } from './report'
+
+export const SUPPORT_MATRIX_NOTE =
+  'Construct-level support, derived from the same fixture-granular conformancePins/renderDivergences as ' +
+  'the compat matrix. Pins are attributed to a FIXTURE, not to a construct — a gapped fixture is usually a ' +
+  'complex component that incidentally exercises many common kinds/axes alongside the one shape it exists ' +
+  'to pin down. Read each cell as a pass/total RATIO over the fixtures that exercise that construct, never ' +
+  'as a binary verdict: a construct can show a healthy ratio (e.g. 250/253) with a handful of gapped ' +
+  'fixtures — those are real, just narrow. Per-fixture detail for a gap lives in the `gaps` array (and in ' +
+  'the full compat matrix, ui/compat.lock.json); the known-limitation label below is the per-issue source ' +
+  'of truth for anything without a linked tracking issue.'
+
+/** Minimal shape read from `packages/adapter-tests/coverage-map.json`. */
+export interface SupportMatrixCoverageMap {
+  fixtures: Record<string, { kinds: readonly string[]; axes: readonly string[] }>
+  kindCounts: Record<string, number>
+  axisCounts: Record<string, number>
+  uncoveredKinds: readonly string[]
+}
+
+/** The subset of `LoadedCompatAdapter` the join needs — kept narrow for the unit test's synthetic fixtures. */
+export interface SupportMatrixAdapterInput {
+  id: string
+  pins: Record<string, ReadonlyArray<{ code: string; severity: 'error' | 'warning'; issue?: string }>>
+  renderDivergences: Record<string, string>
+}
+
+/** One fixture gapped on one adapter for one construct, with its (deduped, sorted) tracking-issue URLs. */
+export interface SupportMatrixGap {
+  fixture: string
+  issues: string[]
+}
+
+/** `pass`/`total` over the fixtures that exercise this construct on this adapter; `gaps` omitted when empty. */
+export interface SupportMatrixCell {
+  pass: number
+  total: number
+  gaps?: SupportMatrixGap[]
+}
+
+/** One construct's (kind or axis) total covering-fixture count and its per-adapter cells. */
+export interface SupportMatrixConstruct {
+  total: number
+  cells: Record<string, SupportMatrixCell>
+}
+
+export interface SupportMatrixReport {
+  note: string
+  knownLimitationLabel: string
+  /** Adapter ids (matrix columns): `hono` first (reference adapter), then alphabetical. */
+  adapters: string[]
+  kinds: Record<string, SupportMatrixConstruct>
+  axes: Record<string, SupportMatrixConstruct>
+}
+
+const byCodeUnit = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0)
+
+/** Fixture ids (sorted) whose coverage-map entry lists `construct` in the given field. */
+function coveringFixtureIds(
+  coverage: SupportMatrixCoverageMap,
+  construct: string,
+  field: 'kinds' | 'axes',
+): string[] {
+  const ids: string[] = []
+  for (const fixtureId of Object.keys(coverage.fixtures)) {
+    if (coverage.fixtures[fixtureId][field].includes(construct)) ids.push(fixtureId)
+  }
+  return ids.sort(byCodeUnit)
+}
+
+/**
+ * A fixture is "gapped" on an adapter when its id is a key of that
+ * adapter's `pins` (compile-time refusal) OR `renderDivergences`
+ * (render-level divergence) — the same union `report.ts`'s
+ * `buildFixtureDivergences` uses for the render-honesty section. Issues
+ * are the pinned diagnostics' `issue` URLs (dedup+sorted); a
+ * render-divergence-only gap carries no issue URL (that map has no
+ * `issue` field), so `issues` is `[]` in that case.
+ */
+function gapsFor(coveringIds: string[], adapter: SupportMatrixAdapterInput): SupportMatrixGap[] {
+  const gaps: SupportMatrixGap[] = []
+  for (const fixtureId of coveringIds) {
+    const pins = adapter.pins[fixtureId]
+    const isDivergent = fixtureId in adapter.renderDivergences
+    if (!pins && !isDivergent) continue
+    const issues = pins ? [...new Set(pins.flatMap(p => (p.issue ? [p.issue] : [])))].sort(byCodeUnit) : []
+    gaps.push({ fixture: fixtureId, issues })
+  }
+  return gaps
+}
+
+function buildCell(coveringIds: string[], adapter: SupportMatrixAdapterInput): SupportMatrixCell {
+  const gaps = gapsFor(coveringIds, adapter)
+  const cell: SupportMatrixCell = { pass: coveringIds.length - gaps.length, total: coveringIds.length }
+  if (gaps.length > 0) cell.gaps = gaps
+  return cell
+}
+
+function buildConstruct(
+  coverage: SupportMatrixCoverageMap,
+  construct: string,
+  field: 'kinds' | 'axes',
+  adapterIds: string[],
+  adapterById: Map<string, SupportMatrixAdapterInput>,
+): SupportMatrixConstruct {
+  const coveringIds = coveringFixtureIds(coverage, construct, field)
+  const cells: Record<string, SupportMatrixCell> = {}
+  for (const adapterId of adapterIds) {
+    cells[adapterId] = buildCell(coveringIds, adapterById.get(adapterId)!)
+  }
+  return { total: coveringIds.length, cells }
+}
+
+/**
+ * Pure join: `coverage-map.json` (denominators) × adapter pins/render-
+ * divergences (numerators) → the `SupportMatrixReport` shape. Separated
+ * from `computeSupportMatrix` (which supplies the real committed
+ * coverage map + `loadCompatAdapters()`) so the unit test can pin the
+ * join logic against small synthetic input without depending on the
+ * real fixture corpus or built adapter packages.
+ *
+ * Kinds are every entry in `PARSED_EXPR_KINDS` (the full compiler-side
+ * registry, sorted) — including kinds with zero covering fixtures (e.g.
+ * `regex`, `coverage.uncoveredKinds`), so the matrix stays complete
+ * against the registry rather than silently dropping uncovered rows.
+ * Axes are every key of `coverage.axisCounts` (there's no equivalent
+ * "uncovered axis" registry to complete against).
+ */
+export function buildSupportMatrix(
+  coverage: SupportMatrixCoverageMap,
+  adapters: ReadonlyArray<SupportMatrixAdapterInput>,
+): SupportMatrixReport {
+  const adapterIds = adapters.map(a => a.id).sort(compareAdapterIds)
+  const adapterById = new Map(adapters.map(a => [a.id, a]))
+
+  const kinds: Record<string, SupportMatrixConstruct> = {}
+  for (const kind of [...PARSED_EXPR_KINDS].sort(byCodeUnit)) {
+    kinds[kind] = buildConstruct(coverage, kind, 'kinds', adapterIds, adapterById)
+  }
+
+  const axes: Record<string, SupportMatrixConstruct> = {}
+  for (const axis of Object.keys(coverage.axisCounts).sort(byCodeUnit)) {
+    axes[axis] = buildConstruct(coverage, axis, 'axes', adapterIds, adapterById)
+  }
+
+  return {
+    note: SUPPORT_MATRIX_NOTE,
+    knownLimitationLabel: KNOWN_LIMITATION_LABEL,
+    adapters: adapterIds,
+    kinds,
+    axes,
+  }
+}
+
+/**
+ * Real-input entry point: the committed `coverage-map.json` joined
+ * against every adapter `loadCompatAdapters()` resolves. Adapters it
+ * can't resolve are silently skipped (same degrade-to-skip contract as
+ * `loadCompatAdapters` itself) — the monorepo always has all 9
+ * installed, so a run from this repo covers every adapter.
+ */
+export async function computeSupportMatrix(): Promise<SupportMatrixReport> {
+  const { loaded } = await loadCompatAdapters()
+  return buildSupportMatrix(coverageMapJson as SupportMatrixCoverageMap, loaded)
+}
+
+/** Lock-file JSON: 2-space indent, trailing newline — same contract as `formatCompatJson`. */
+export function formatSupportMatrixJson(report: SupportMatrixReport): string {
+  return JSON.stringify(report, null, 2) + '\n'
+}

--- a/packages/compat/tsconfig.json
+++ b/packages/compat/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+    "types": ["bun", "node"],
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "__tests__/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/site/core/pages/compat-matrix.tsx
+++ b/site/core/pages/compat-matrix.tsx
@@ -95,8 +95,13 @@ function escapeCell(text: string): string {
  * below (per gapped cell) so both link formats stay identical.
  */
 function formatIssueLinks(issues: string[], fallbackLabel: string): string {
-  if (issues.length === 0) return `[known limitation](${fallbackLabel})`
-  return issues.map((url) => `[#${url.split('/').pop()}](${url})`).join(', ')
+  // Dedupe + code-unit sort HERE (matching the lockfiles' issue ordering) so
+  // both callers are deterministic from one place: `collectLegend` feeds
+  // Set-insertion-ordered URLs, and the construct-support cells feed already-
+  // flattened gap URLs — neither is pre-sorted at the call site.
+  const unique = [...new Set(issues)].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+  if (unique.length === 0) return `[known limitation](${fallbackLabel})`
+  return unique.map((url) => `[#${url.split('/').pop()}](${url})`).join(', ')
 }
 
 /** Render one matrix cell as a Markdown fragment. */
@@ -262,7 +267,10 @@ function supportCellMarkdown(cell: SupportMatrixCell | undefined): string {
   const ratio = `${cell.pass}/${cell.total}`
   const gaps = cell.gaps ?? []
   if (gaps.length === 0) return ratio
-  const issues = [...new Set(gaps.flatMap((gap) => gap.issues))].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+  // `formatIssueLinks` dedupes + sorts, so just flatten every gapped
+  // fixture's issues here (several fixtures gapped by the same diagnostic
+  // repeat its URL — the helper collapses them).
+  const issues = gaps.flatMap((gap) => gap.issues)
   return `${ratio} (${formatIssueLinks(issues, supportMatrix.knownLimitationLabel)})`
 }
 

--- a/site/core/pages/compat-matrix.tsx
+++ b/site/core/pages/compat-matrix.tsx
@@ -16,6 +16,7 @@ import type { Hono } from 'hono'
 import { renderMarkdown } from '../lib/markdown'
 import { getDocsNavLinks } from '../lib/navigation'
 import lock from '../../../ui/compat.lock.json' with { type: 'json' }
+import supportMatrixLock from '../../../ui/support-matrix.lock.json' with { type: 'json' }
 
 const SLUG = 'advanced/compatibility-matrix'
 const TITLE = 'Compatibility Matrix'
@@ -56,8 +57,46 @@ interface CompatLock {
 
 const compat = lock as CompatLock
 
+/** One `kind` or `axis` construct's covering-fixture total and its per-adapter cells (`ui/support-matrix.lock.json`). */
+interface SupportMatrixGap {
+  fixture: string
+  issues: string[]
+}
+
+interface SupportMatrixCell {
+  pass: number
+  total: number
+  gaps?: SupportMatrixGap[]
+}
+
+interface SupportMatrixConstruct {
+  total: number
+  cells: Record<string, SupportMatrixCell>
+}
+
+interface SupportMatrixLock {
+  note: string
+  knownLimitationLabel: string
+  adapters: string[]
+  kinds: Record<string, SupportMatrixConstruct>
+  axes: Record<string, SupportMatrixConstruct>
+}
+
+const supportMatrix = supportMatrixLock as SupportMatrixLock
+
 function escapeCell(text: string): string {
   return text.replace(/\|/g, '\\|')
+}
+
+/**
+ * Deduped, sorted issue URLs as `#NNNN` links, falling back to the repo-
+ * wide known-limitation label when none exist. Shared by `buildLegend`
+ * (compat matrix, per diagnostic code) and the construct-support section
+ * below (per gapped cell) so both link formats stay identical.
+ */
+function formatIssueLinks(issues: string[], fallbackLabel: string): string {
+  if (issues.length === 0) return `[known limitation](${fallbackLabel})`
+  return issues.map((url) => `[#${url.split('/').pop()}](${url})`).join(', ')
 }
 
 /** Render one matrix cell as a Markdown fragment. */
@@ -129,10 +168,7 @@ function buildLegend(): string {
   return entries
     .map(({ code, severity, issues }) => {
       const label = severity === 'warning' ? `⚠ \`${code}\`` : `\`${code}\``
-      const links = issues.length > 0
-        ? issues.map((url) => `[#${url.split('/').pop()}](${url})`).join(', ')
-        : `[known limitation](${compat.knownLimitationLabel})`
-      return `- ${label} — ${links}`
+      return `- ${label} — ${formatIssueLinks(issues, compat.knownLimitationLabel)}`
     })
     .join('\n')
 }
@@ -215,12 +251,67 @@ ${buildFixtureDetails(fd)}
 `
 }
 
+/**
+ * Render one construct-support cell as `pass/total`, plus linked tracking
+ * issues when the construct has gaps on this adapter. Deduped across every
+ * gapped fixture in the cell — a common case is several fixtures gapped by
+ * the same pinned diagnostic, which would otherwise repeat its issue link.
+ */
+function supportCellMarkdown(cell: SupportMatrixCell | undefined): string {
+  if (!cell) return '?'
+  const ratio = `${cell.pass}/${cell.total}`
+  const gaps = cell.gaps ?? []
+  if (gaps.length === 0) return ratio
+  const issues = [...new Set(gaps.flatMap((gap) => gap.issues))].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+  return `${ratio} (${formatIssueLinks(issues, supportMatrix.knownLimitationLabel)})`
+}
+
+/** One `construct × adapter` table — shared by the "By kind" and "By axis" tables. */
+function buildSupportTable(records: Record<string, SupportMatrixConstruct>): string {
+  const adapters = supportMatrix.adapters
+  const names = Object.keys(records).sort()
+  const header = `| Construct | ${adapters.join(' | ')} |`
+  const divider = `| --- | ${adapters.map(() => '---').join(' | ')} |`
+  const rows = names.map((name) => {
+    const cells = adapters.map((adapter) => supportCellMarkdown(records[name]?.cells[adapter]))
+    return `| \`${escapeCell(name)}\` | ${cells.join(' | ')} |`
+  })
+  return [header, divider, ...rows].join('\n')
+}
+
+/**
+ * Construct-level drill-down: every `ParsedExpr` kind (`identifier`,
+ * `call`, `literal`, ...) and every finer-grained axis within a kind
+ * (`binary:===`, `literal:string`, `array-method:includes`, ...) against
+ * the shared conformance corpus. Complements the component matrix above —
+ * that one answers "does this whole component compile clean", this one
+ * answers "of the fixtures that exercise construct X, how many are clean".
+ */
+function buildSupportMatrixSection(): string {
+  return `
+## Construct Support (kind × axis)
+
+${supportMatrix.note}
+
+**Read this as a ratio, not a binary.** \`conformancePins\` and \`renderDivergences\` are attributed to a whole **fixture** (a component), not to the individual construct — a gapped fixture is usually a complex component that happens to exercise many common kinds and axes alongside the one shape it exists to pin down. A construct showing \`137/138\` has exactly one gapped fixture contributing to it, not 137 broken cases. A construct with \`total: 0\` (currently just \`regex\`) has no fixture exercising it yet.
+
+### By kind
+
+${buildSupportTable(supportMatrix.kinds)}
+
+### By axis
+
+${buildSupportTable(supportMatrix.axes)}
+`
+}
+
 function buildMarkdown(): string {
   const componentNames = Object.keys(compat.components).sort()
   const summary = buildSummary(componentNames)
   const table = buildTable(componentNames)
   const legend = buildLegend()
   const fixtureSection = buildFixtureSection()
+  const supportMatrixSection = buildSupportMatrixSection()
 
   return `# ${TITLE}
 
@@ -238,9 +329,12 @@ Each diagnostic code below links to the known-limitation issue(s) tracking it. C
 
 ${legend}
 ${fixtureSection}
+${supportMatrixSection}
 ## Data Source
 
 This table is generated from the committed [\`ui/compat.lock.json\`](https://github.com/piconic-ai/barefootjs/blob/main/ui/compat.lock.json), regenerated with \`bun run compat:lock\` and drift-checked in CI. Render-level divergences are declared per adapter in \`packages/adapter-*/src/render-divergences.ts\` (each adapter's conformance suite derives its skip list from the same declaration, so this page and the tests cannot drift apart). Tracked limitations carry the [\`known-limitation\`](${compat.knownLimitationLabel}) label.
+
+The construct-support section above is generated from the committed [\`ui/support-matrix.lock.json\`](https://github.com/piconic-ai/barefootjs/blob/main/ui/support-matrix.lock.json), regenerated with \`bun run support-matrix:lock\` and drift-checked in CI alongside the component matrix.
 `
 }
 

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1,0 +1,4262 @@
+{
+  "note": "Construct-level support, derived from the same fixture-granular conformancePins/renderDivergences as the compat matrix. Pins are attributed to a FIXTURE, not to a construct — a gapped fixture is usually a complex component that incidentally exercises many common kinds/axes alongside the one shape it exists to pin down. Read each cell as a pass/total RATIO over the fixtures that exercise that construct, never as a binary verdict: a construct can show a healthy ratio (e.g. 250/253) with a handful of gapped fixtures — those are real, just narrow. Per-fixture detail for a gap lives in the `gaps` array (and in the full compat matrix, ui/compat.lock.json); the known-limitation label below is the per-issue source of truth for anything without a linked tracking issue.",
+  "knownLimitationLabel": "https://github.com/piconic-ai/barefootjs/labels/known-limitation",
+  "adapters": [
+    "hono",
+    "blade",
+    "erb",
+    "go-template",
+    "jinja",
+    "minijinja",
+    "mojolicious",
+    "twig",
+    "xslate"
+  ],
+  "kinds": {
+    "array-literal": {
+      "total": 54,
+      "cells": {
+        "hono": {
+          "pass": 54,
+          "total": 54
+        },
+        "blade": {
+          "pass": 52,
+          "total": 54,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "erb": {
+          "pass": 53,
+          "total": 54,
+          "gaps": [
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "go-template": {
+          "pass": 52,
+          "total": 54,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "jinja": {
+          "pass": 52,
+          "total": 54,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "minijinja": {
+          "pass": 52,
+          "total": 54,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "mojolicious": {
+          "pass": 53,
+          "total": 54,
+          "gaps": [
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "twig": {
+          "pass": 52,
+          "total": 54,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "xslate": {
+          "pass": 52,
+          "total": 54,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "array-method": {
+      "total": 62,
+      "cells": {
+        "hono": {
+          "pass": 62,
+          "total": 62
+        },
+        "blade": {
+          "pass": 62,
+          "total": 62
+        },
+        "erb": {
+          "pass": 62,
+          "total": 62
+        },
+        "go-template": {
+          "pass": 62,
+          "total": 62
+        },
+        "jinja": {
+          "pass": 62,
+          "total": 62
+        },
+        "minijinja": {
+          "pass": 62,
+          "total": 62
+        },
+        "mojolicious": {
+          "pass": 62,
+          "total": 62
+        },
+        "twig": {
+          "pass": 62,
+          "total": 62
+        },
+        "xslate": {
+          "pass": 62,
+          "total": 62
+        }
+      }
+    },
+    "arrow": {
+      "total": 55,
+      "cells": {
+        "hono": {
+          "pass": 55,
+          "total": 55
+        },
+        "blade": {
+          "pass": 53,
+          "total": 55,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "erb": {
+          "pass": 54,
+          "total": 55,
+          "gaps": [
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "go-template": {
+          "pass": 53,
+          "total": 55,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "jinja": {
+          "pass": 53,
+          "total": 55,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "minijinja": {
+          "pass": 53,
+          "total": 55,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "mojolicious": {
+          "pass": 54,
+          "total": 55,
+          "gaps": [
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "twig": {
+          "pass": 53,
+          "total": 55,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "xslate": {
+          "pass": 53,
+          "total": 55,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "binary": {
+      "total": 67,
+      "cells": {
+        "hono": {
+          "pass": 67,
+          "total": 67
+        },
+        "blade": {
+          "pass": 64,
+          "total": 67,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "erb": {
+          "pass": 65,
+          "total": 67,
+          "gaps": [
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "go-template": {
+          "pass": 64,
+          "total": 67,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "jinja": {
+          "pass": 64,
+          "total": 67,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "minijinja": {
+          "pass": 64,
+          "total": 67,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "mojolicious": {
+          "pass": 65,
+          "total": 67,
+          "gaps": [
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "twig": {
+          "pass": 64,
+          "total": 67,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "xslate": {
+          "pass": 64,
+          "total": 67,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        }
+      }
+    },
+    "call": {
+      "total": 157,
+      "cells": {
+        "hono": {
+          "pass": 156,
+          "total": 157,
+          "gaps": [
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2274"
+              ]
+            }
+          ]
+        },
+        "blade": {
+          "pass": 152,
+          "total": 157,
+          "gaps": [
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2274"
+              ]
+            },
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "erb": {
+          "pass": 153,
+          "total": 157,
+          "gaps": [
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2274"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "go-template": {
+          "pass": 152,
+          "total": 157,
+          "gaps": [
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2274"
+              ]
+            },
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "jinja": {
+          "pass": 152,
+          "total": 157,
+          "gaps": [
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2274"
+              ]
+            },
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "minijinja": {
+          "pass": 152,
+          "total": 157,
+          "gaps": [
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2274"
+              ]
+            },
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "mojolicious": {
+          "pass": 153,
+          "total": 157,
+          "gaps": [
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2274"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "twig": {
+          "pass": 152,
+          "total": 157,
+          "gaps": [
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2274"
+              ]
+            },
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "xslate": {
+          "pass": 152,
+          "total": 157,
+          "gaps": [
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2274"
+              ]
+            },
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        }
+      }
+    },
+    "conditional": {
+      "total": 18,
+      "cells": {
+        "hono": {
+          "pass": 18,
+          "total": 18
+        },
+        "blade": {
+          "pass": 18,
+          "total": 18
+        },
+        "erb": {
+          "pass": 18,
+          "total": 18
+        },
+        "go-template": {
+          "pass": 18,
+          "total": 18
+        },
+        "jinja": {
+          "pass": 18,
+          "total": 18
+        },
+        "minijinja": {
+          "pass": 18,
+          "total": 18
+        },
+        "mojolicious": {
+          "pass": 18,
+          "total": 18
+        },
+        "twig": {
+          "pass": 18,
+          "total": 18
+        },
+        "xslate": {
+          "pass": 18,
+          "total": 18
+        }
+      }
+    },
+    "identifier": {
+      "total": 235,
+      "cells": {
+        "hono": {
+          "pass": 234,
+          "total": 235,
+          "gaps": [
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2274"
+              ]
+            }
+          ]
+        },
+        "blade": {
+          "pass": 229,
+          "total": 235,
+          "gaps": [
+            {
+              "fixture": "dangerous-inner-html-dynamic",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2215"
+              ]
+            },
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2274"
+              ]
+            },
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "erb": {
+          "pass": 230,
+          "total": 235,
+          "gaps": [
+            {
+              "fixture": "dangerous-inner-html-dynamic",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2215"
+              ]
+            },
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2274"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "go-template": {
+          "pass": 229,
+          "total": 235,
+          "gaps": [
+            {
+              "fixture": "dangerous-inner-html-dynamic",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2215"
+              ]
+            },
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2274"
+              ]
+            },
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "jinja": {
+          "pass": 229,
+          "total": 235,
+          "gaps": [
+            {
+              "fixture": "dangerous-inner-html-dynamic",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2215"
+              ]
+            },
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2274"
+              ]
+            },
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "minijinja": {
+          "pass": 229,
+          "total": 235,
+          "gaps": [
+            {
+              "fixture": "dangerous-inner-html-dynamic",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2215"
+              ]
+            },
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2274"
+              ]
+            },
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "mojolicious": {
+          "pass": 230,
+          "total": 235,
+          "gaps": [
+            {
+              "fixture": "dangerous-inner-html-dynamic",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2215"
+              ]
+            },
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2274"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "twig": {
+          "pass": 229,
+          "total": 235,
+          "gaps": [
+            {
+              "fixture": "dangerous-inner-html-dynamic",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2215"
+              ]
+            },
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2274"
+              ]
+            },
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "xslate": {
+          "pass": 229,
+          "total": 235,
+          "gaps": [
+            {
+              "fixture": "dangerous-inner-html-dynamic",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2215"
+              ]
+            },
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2274"
+              ]
+            },
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        }
+      }
+    },
+    "index-access": {
+      "total": 12,
+      "cells": {
+        "hono": {
+          "pass": 12,
+          "total": 12
+        },
+        "blade": {
+          "pass": 12,
+          "total": 12
+        },
+        "erb": {
+          "pass": 12,
+          "total": 12
+        },
+        "go-template": {
+          "pass": 12,
+          "total": 12
+        },
+        "jinja": {
+          "pass": 12,
+          "total": 12
+        },
+        "minijinja": {
+          "pass": 12,
+          "total": 12
+        },
+        "mojolicious": {
+          "pass": 12,
+          "total": 12
+        },
+        "twig": {
+          "pass": 12,
+          "total": 12
+        },
+        "xslate": {
+          "pass": 12,
+          "total": 12
+        }
+      }
+    },
+    "literal": {
+      "total": 194,
+      "cells": {
+        "hono": {
+          "pass": 194,
+          "total": 194
+        },
+        "blade": {
+          "pass": 193,
+          "total": 194,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "erb": {
+          "pass": 193,
+          "total": 194,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "go-template": {
+          "pass": 193,
+          "total": 194,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "jinja": {
+          "pass": 193,
+          "total": 194,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "minijinja": {
+          "pass": 193,
+          "total": 194,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "mojolicious": {
+          "pass": 193,
+          "total": 194,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "twig": {
+          "pass": 193,
+          "total": 194,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "xslate": {
+          "pass": 193,
+          "total": 194,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        }
+      }
+    },
+    "logical": {
+      "total": 41,
+      "cells": {
+        "hono": {
+          "pass": 41,
+          "total": 41
+        },
+        "blade": {
+          "pass": 40,
+          "total": 41,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            }
+          ]
+        },
+        "erb": {
+          "pass": 40,
+          "total": 41,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "go-template": {
+          "pass": 40,
+          "total": 41,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            }
+          ]
+        },
+        "jinja": {
+          "pass": 40,
+          "total": 41,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "minijinja": {
+          "pass": 40,
+          "total": 41,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "mojolicious": {
+          "pass": 40,
+          "total": 41,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            }
+          ]
+        },
+        "twig": {
+          "pass": 40,
+          "total": 41,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            }
+          ]
+        },
+        "xslate": {
+          "pass": 40,
+          "total": 41,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            }
+          ]
+        }
+      }
+    },
+    "member": {
+      "total": 117,
+      "cells": {
+        "hono": {
+          "pass": 116,
+          "total": 117,
+          "gaps": [
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2274"
+              ]
+            }
+          ]
+        },
+        "blade": {
+          "pass": 112,
+          "total": 117,
+          "gaps": [
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2274"
+              ]
+            },
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "erb": {
+          "pass": 113,
+          "total": 117,
+          "gaps": [
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2274"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "go-template": {
+          "pass": 112,
+          "total": 117,
+          "gaps": [
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2274"
+              ]
+            },
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "jinja": {
+          "pass": 112,
+          "total": 117,
+          "gaps": [
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2274"
+              ]
+            },
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "minijinja": {
+          "pass": 112,
+          "total": 117,
+          "gaps": [
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2274"
+              ]
+            },
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "mojolicious": {
+          "pass": 113,
+          "total": 117,
+          "gaps": [
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2274"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "twig": {
+          "pass": 112,
+          "total": 117,
+          "gaps": [
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2274"
+              ]
+            },
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "xslate": {
+          "pass": 112,
+          "total": 117,
+          "gaps": [
+            {
+              "fixture": "date-method-uncatalogued",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2274"
+              ]
+            },
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        }
+      }
+    },
+    "object-literal": {
+      "total": 41,
+      "cells": {
+        "hono": {
+          "pass": 41,
+          "total": 41
+        },
+        "blade": {
+          "pass": 39,
+          "total": 41,
+          "gaps": [
+            {
+              "fixture": "dangerous-inner-html-dynamic",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2215"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            }
+          ]
+        },
+        "erb": {
+          "pass": 39,
+          "total": 41,
+          "gaps": [
+            {
+              "fixture": "dangerous-inner-html-dynamic",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2215"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "go-template": {
+          "pass": 39,
+          "total": 41,
+          "gaps": [
+            {
+              "fixture": "dangerous-inner-html-dynamic",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2215"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            }
+          ]
+        },
+        "jinja": {
+          "pass": 39,
+          "total": 41,
+          "gaps": [
+            {
+              "fixture": "dangerous-inner-html-dynamic",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2215"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "minijinja": {
+          "pass": 39,
+          "total": 41,
+          "gaps": [
+            {
+              "fixture": "dangerous-inner-html-dynamic",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2215"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "mojolicious": {
+          "pass": 39,
+          "total": 41,
+          "gaps": [
+            {
+              "fixture": "dangerous-inner-html-dynamic",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2215"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            }
+          ]
+        },
+        "twig": {
+          "pass": 39,
+          "total": 41,
+          "gaps": [
+            {
+              "fixture": "dangerous-inner-html-dynamic",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2215"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            }
+          ]
+        },
+        "xslate": {
+          "pass": 39,
+          "total": 41,
+          "gaps": [
+            {
+              "fixture": "dangerous-inner-html-dynamic",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2215"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            }
+          ]
+        }
+      }
+    },
+    "regex": {
+      "total": 0,
+      "cells": {
+        "hono": {
+          "pass": 0,
+          "total": 0
+        },
+        "blade": {
+          "pass": 0,
+          "total": 0
+        },
+        "erb": {
+          "pass": 0,
+          "total": 0
+        },
+        "go-template": {
+          "pass": 0,
+          "total": 0
+        },
+        "jinja": {
+          "pass": 0,
+          "total": 0
+        },
+        "minijinja": {
+          "pass": 0,
+          "total": 0
+        },
+        "mojolicious": {
+          "pass": 0,
+          "total": 0
+        },
+        "twig": {
+          "pass": 0,
+          "total": 0
+        },
+        "xslate": {
+          "pass": 0,
+          "total": 0
+        }
+      }
+    },
+    "template-literal": {
+      "total": 27,
+      "cells": {
+        "hono": {
+          "pass": 27,
+          "total": 27
+        },
+        "blade": {
+          "pass": 27,
+          "total": 27
+        },
+        "erb": {
+          "pass": 27,
+          "total": 27
+        },
+        "go-template": {
+          "pass": 27,
+          "total": 27
+        },
+        "jinja": {
+          "pass": 27,
+          "total": 27
+        },
+        "minijinja": {
+          "pass": 27,
+          "total": 27
+        },
+        "mojolicious": {
+          "pass": 27,
+          "total": 27
+        },
+        "twig": {
+          "pass": 27,
+          "total": 27
+        },
+        "xslate": {
+          "pass": 27,
+          "total": 27
+        }
+      }
+    },
+    "unary": {
+      "total": 22,
+      "cells": {
+        "hono": {
+          "pass": 22,
+          "total": 22
+        },
+        "blade": {
+          "pass": 21,
+          "total": 22,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "erb": {
+          "pass": 22,
+          "total": 22
+        },
+        "go-template": {
+          "pass": 21,
+          "total": 22,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "jinja": {
+          "pass": 21,
+          "total": 22,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "minijinja": {
+          "pass": 21,
+          "total": 22,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "mojolicious": {
+          "pass": 22,
+          "total": 22
+        },
+        "twig": {
+          "pass": 21,
+          "total": 22,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "xslate": {
+          "pass": 21,
+          "total": 22,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "unsupported": {
+      "total": 21,
+      "cells": {
+        "hono": {
+          "pass": 21,
+          "total": 21
+        },
+        "blade": {
+          "pass": 19,
+          "total": 21,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "erb": {
+          "pass": 19,
+          "total": 21,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "go-template": {
+          "pass": 19,
+          "total": 21,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "jinja": {
+          "pass": 19,
+          "total": 21,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "minijinja": {
+          "pass": 19,
+          "total": 21,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "mojolicious": {
+          "pass": 19,
+          "total": 21,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "twig": {
+          "pass": 19,
+          "total": 21,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "xslate": {
+          "pass": 19,
+          "total": 21,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            },
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        }
+      }
+    }
+  },
+  "axes": {
+    "array-method:at": {
+      "total": 2,
+      "cells": {
+        "hono": {
+          "pass": 2,
+          "total": 2
+        },
+        "blade": {
+          "pass": 2,
+          "total": 2
+        },
+        "erb": {
+          "pass": 2,
+          "total": 2
+        },
+        "go-template": {
+          "pass": 2,
+          "total": 2
+        },
+        "jinja": {
+          "pass": 2,
+          "total": 2
+        },
+        "minijinja": {
+          "pass": 2,
+          "total": 2
+        },
+        "mojolicious": {
+          "pass": 2,
+          "total": 2
+        },
+        "twig": {
+          "pass": 2,
+          "total": 2
+        },
+        "xslate": {
+          "pass": 2,
+          "total": 2
+        }
+      }
+    },
+    "array-method:concat": {
+      "total": 2,
+      "cells": {
+        "hono": {
+          "pass": 2,
+          "total": 2
+        },
+        "blade": {
+          "pass": 2,
+          "total": 2
+        },
+        "erb": {
+          "pass": 2,
+          "total": 2
+        },
+        "go-template": {
+          "pass": 2,
+          "total": 2
+        },
+        "jinja": {
+          "pass": 2,
+          "total": 2
+        },
+        "minijinja": {
+          "pass": 2,
+          "total": 2
+        },
+        "mojolicious": {
+          "pass": 2,
+          "total": 2
+        },
+        "twig": {
+          "pass": 2,
+          "total": 2
+        },
+        "xslate": {
+          "pass": 2,
+          "total": 2
+        }
+      }
+    },
+    "array-method:endsWith": {
+      "total": 2,
+      "cells": {
+        "hono": {
+          "pass": 2,
+          "total": 2
+        },
+        "blade": {
+          "pass": 2,
+          "total": 2
+        },
+        "erb": {
+          "pass": 2,
+          "total": 2
+        },
+        "go-template": {
+          "pass": 2,
+          "total": 2
+        },
+        "jinja": {
+          "pass": 2,
+          "total": 2
+        },
+        "minijinja": {
+          "pass": 2,
+          "total": 2
+        },
+        "mojolicious": {
+          "pass": 2,
+          "total": 2
+        },
+        "twig": {
+          "pass": 2,
+          "total": 2
+        },
+        "xslate": {
+          "pass": 2,
+          "total": 2
+        }
+      }
+    },
+    "array-method:flat": {
+      "total": 4,
+      "cells": {
+        "hono": {
+          "pass": 4,
+          "total": 4
+        },
+        "blade": {
+          "pass": 4,
+          "total": 4
+        },
+        "erb": {
+          "pass": 4,
+          "total": 4
+        },
+        "go-template": {
+          "pass": 4,
+          "total": 4
+        },
+        "jinja": {
+          "pass": 4,
+          "total": 4
+        },
+        "minijinja": {
+          "pass": 4,
+          "total": 4
+        },
+        "mojolicious": {
+          "pass": 4,
+          "total": 4
+        },
+        "twig": {
+          "pass": 4,
+          "total": 4
+        },
+        "xslate": {
+          "pass": 4,
+          "total": 4
+        }
+      }
+    },
+    "array-method:includes": {
+      "total": 12,
+      "cells": {
+        "hono": {
+          "pass": 12,
+          "total": 12
+        },
+        "blade": {
+          "pass": 12,
+          "total": 12
+        },
+        "erb": {
+          "pass": 12,
+          "total": 12
+        },
+        "go-template": {
+          "pass": 12,
+          "total": 12
+        },
+        "jinja": {
+          "pass": 12,
+          "total": 12
+        },
+        "minijinja": {
+          "pass": 12,
+          "total": 12
+        },
+        "mojolicious": {
+          "pass": 12,
+          "total": 12
+        },
+        "twig": {
+          "pass": 12,
+          "total": 12
+        },
+        "xslate": {
+          "pass": 12,
+          "total": 12
+        }
+      }
+    },
+    "array-method:indexOf": {
+      "total": 1,
+      "cells": {
+        "hono": {
+          "pass": 1,
+          "total": 1
+        },
+        "blade": {
+          "pass": 1,
+          "total": 1
+        },
+        "erb": {
+          "pass": 1,
+          "total": 1
+        },
+        "go-template": {
+          "pass": 1,
+          "total": 1
+        },
+        "jinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "minijinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "mojolicious": {
+          "pass": 1,
+          "total": 1
+        },
+        "twig": {
+          "pass": 1,
+          "total": 1
+        },
+        "xslate": {
+          "pass": 1,
+          "total": 1
+        }
+      }
+    },
+    "array-method:join": {
+      "total": 36,
+      "cells": {
+        "hono": {
+          "pass": 36,
+          "total": 36
+        },
+        "blade": {
+          "pass": 36,
+          "total": 36
+        },
+        "erb": {
+          "pass": 36,
+          "total": 36
+        },
+        "go-template": {
+          "pass": 36,
+          "total": 36
+        },
+        "jinja": {
+          "pass": 36,
+          "total": 36
+        },
+        "minijinja": {
+          "pass": 36,
+          "total": 36
+        },
+        "mojolicious": {
+          "pass": 36,
+          "total": 36
+        },
+        "twig": {
+          "pass": 36,
+          "total": 36
+        },
+        "xslate": {
+          "pass": 36,
+          "total": 36
+        }
+      }
+    },
+    "array-method:lastIndexOf": {
+      "total": 1,
+      "cells": {
+        "hono": {
+          "pass": 1,
+          "total": 1
+        },
+        "blade": {
+          "pass": 1,
+          "total": 1
+        },
+        "erb": {
+          "pass": 1,
+          "total": 1
+        },
+        "go-template": {
+          "pass": 1,
+          "total": 1
+        },
+        "jinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "minijinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "mojolicious": {
+          "pass": 1,
+          "total": 1
+        },
+        "twig": {
+          "pass": 1,
+          "total": 1
+        },
+        "xslate": {
+          "pass": 1,
+          "total": 1
+        }
+      }
+    },
+    "array-method:padEnd": {
+      "total": 1,
+      "cells": {
+        "hono": {
+          "pass": 1,
+          "total": 1
+        },
+        "blade": {
+          "pass": 1,
+          "total": 1
+        },
+        "erb": {
+          "pass": 1,
+          "total": 1
+        },
+        "go-template": {
+          "pass": 1,
+          "total": 1
+        },
+        "jinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "minijinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "mojolicious": {
+          "pass": 1,
+          "total": 1
+        },
+        "twig": {
+          "pass": 1,
+          "total": 1
+        },
+        "xslate": {
+          "pass": 1,
+          "total": 1
+        }
+      }
+    },
+    "array-method:padStart": {
+      "total": 1,
+      "cells": {
+        "hono": {
+          "pass": 1,
+          "total": 1
+        },
+        "blade": {
+          "pass": 1,
+          "total": 1
+        },
+        "erb": {
+          "pass": 1,
+          "total": 1
+        },
+        "go-template": {
+          "pass": 1,
+          "total": 1
+        },
+        "jinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "minijinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "mojolicious": {
+          "pass": 1,
+          "total": 1
+        },
+        "twig": {
+          "pass": 1,
+          "total": 1
+        },
+        "xslate": {
+          "pass": 1,
+          "total": 1
+        }
+      }
+    },
+    "array-method:repeat": {
+      "total": 1,
+      "cells": {
+        "hono": {
+          "pass": 1,
+          "total": 1
+        },
+        "blade": {
+          "pass": 1,
+          "total": 1
+        },
+        "erb": {
+          "pass": 1,
+          "total": 1
+        },
+        "go-template": {
+          "pass": 1,
+          "total": 1
+        },
+        "jinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "minijinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "mojolicious": {
+          "pass": 1,
+          "total": 1
+        },
+        "twig": {
+          "pass": 1,
+          "total": 1
+        },
+        "xslate": {
+          "pass": 1,
+          "total": 1
+        }
+      }
+    },
+    "array-method:replace": {
+      "total": 1,
+      "cells": {
+        "hono": {
+          "pass": 1,
+          "total": 1
+        },
+        "blade": {
+          "pass": 1,
+          "total": 1
+        },
+        "erb": {
+          "pass": 1,
+          "total": 1
+        },
+        "go-template": {
+          "pass": 1,
+          "total": 1
+        },
+        "jinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "minijinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "mojolicious": {
+          "pass": 1,
+          "total": 1
+        },
+        "twig": {
+          "pass": 1,
+          "total": 1
+        },
+        "xslate": {
+          "pass": 1,
+          "total": 1
+        }
+      }
+    },
+    "array-method:replaceAll": {
+      "total": 1,
+      "cells": {
+        "hono": {
+          "pass": 1,
+          "total": 1
+        },
+        "blade": {
+          "pass": 1,
+          "total": 1
+        },
+        "erb": {
+          "pass": 1,
+          "total": 1
+        },
+        "go-template": {
+          "pass": 1,
+          "total": 1
+        },
+        "jinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "minijinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "mojolicious": {
+          "pass": 1,
+          "total": 1
+        },
+        "twig": {
+          "pass": 1,
+          "total": 1
+        },
+        "xslate": {
+          "pass": 1,
+          "total": 1
+        }
+      }
+    },
+    "array-method:reverse": {
+      "total": 1,
+      "cells": {
+        "hono": {
+          "pass": 1,
+          "total": 1
+        },
+        "blade": {
+          "pass": 1,
+          "total": 1
+        },
+        "erb": {
+          "pass": 1,
+          "total": 1
+        },
+        "go-template": {
+          "pass": 1,
+          "total": 1
+        },
+        "jinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "minijinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "mojolicious": {
+          "pass": 1,
+          "total": 1
+        },
+        "twig": {
+          "pass": 1,
+          "total": 1
+        },
+        "xslate": {
+          "pass": 1,
+          "total": 1
+        }
+      }
+    },
+    "array-method:slice": {
+      "total": 4,
+      "cells": {
+        "hono": {
+          "pass": 4,
+          "total": 4
+        },
+        "blade": {
+          "pass": 4,
+          "total": 4
+        },
+        "erb": {
+          "pass": 4,
+          "total": 4
+        },
+        "go-template": {
+          "pass": 4,
+          "total": 4
+        },
+        "jinja": {
+          "pass": 4,
+          "total": 4
+        },
+        "minijinja": {
+          "pass": 4,
+          "total": 4
+        },
+        "mojolicious": {
+          "pass": 4,
+          "total": 4
+        },
+        "twig": {
+          "pass": 4,
+          "total": 4
+        },
+        "xslate": {
+          "pass": 4,
+          "total": 4
+        }
+      }
+    },
+    "array-method:split": {
+      "total": 2,
+      "cells": {
+        "hono": {
+          "pass": 2,
+          "total": 2
+        },
+        "blade": {
+          "pass": 2,
+          "total": 2
+        },
+        "erb": {
+          "pass": 2,
+          "total": 2
+        },
+        "go-template": {
+          "pass": 2,
+          "total": 2
+        },
+        "jinja": {
+          "pass": 2,
+          "total": 2
+        },
+        "minijinja": {
+          "pass": 2,
+          "total": 2
+        },
+        "mojolicious": {
+          "pass": 2,
+          "total": 2
+        },
+        "twig": {
+          "pass": 2,
+          "total": 2
+        },
+        "xslate": {
+          "pass": 2,
+          "total": 2
+        }
+      }
+    },
+    "array-method:startsWith": {
+      "total": 3,
+      "cells": {
+        "hono": {
+          "pass": 3,
+          "total": 3
+        },
+        "blade": {
+          "pass": 3,
+          "total": 3
+        },
+        "erb": {
+          "pass": 3,
+          "total": 3
+        },
+        "go-template": {
+          "pass": 3,
+          "total": 3
+        },
+        "jinja": {
+          "pass": 3,
+          "total": 3
+        },
+        "minijinja": {
+          "pass": 3,
+          "total": 3
+        },
+        "mojolicious": {
+          "pass": 3,
+          "total": 3
+        },
+        "twig": {
+          "pass": 3,
+          "total": 3
+        },
+        "xslate": {
+          "pass": 3,
+          "total": 3
+        }
+      }
+    },
+    "array-method:toFixed": {
+      "total": 2,
+      "cells": {
+        "hono": {
+          "pass": 2,
+          "total": 2
+        },
+        "blade": {
+          "pass": 2,
+          "total": 2
+        },
+        "erb": {
+          "pass": 2,
+          "total": 2
+        },
+        "go-template": {
+          "pass": 2,
+          "total": 2
+        },
+        "jinja": {
+          "pass": 2,
+          "total": 2
+        },
+        "minijinja": {
+          "pass": 2,
+          "total": 2
+        },
+        "mojolicious": {
+          "pass": 2,
+          "total": 2
+        },
+        "twig": {
+          "pass": 2,
+          "total": 2
+        },
+        "xslate": {
+          "pass": 2,
+          "total": 2
+        }
+      }
+    },
+    "array-method:toLowerCase": {
+      "total": 4,
+      "cells": {
+        "hono": {
+          "pass": 4,
+          "total": 4
+        },
+        "blade": {
+          "pass": 4,
+          "total": 4
+        },
+        "erb": {
+          "pass": 4,
+          "total": 4
+        },
+        "go-template": {
+          "pass": 4,
+          "total": 4
+        },
+        "jinja": {
+          "pass": 4,
+          "total": 4
+        },
+        "minijinja": {
+          "pass": 4,
+          "total": 4
+        },
+        "mojolicious": {
+          "pass": 4,
+          "total": 4
+        },
+        "twig": {
+          "pass": 4,
+          "total": 4
+        },
+        "xslate": {
+          "pass": 4,
+          "total": 4
+        }
+      }
+    },
+    "array-method:toReversed": {
+      "total": 1,
+      "cells": {
+        "hono": {
+          "pass": 1,
+          "total": 1
+        },
+        "blade": {
+          "pass": 1,
+          "total": 1
+        },
+        "erb": {
+          "pass": 1,
+          "total": 1
+        },
+        "go-template": {
+          "pass": 1,
+          "total": 1
+        },
+        "jinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "minijinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "mojolicious": {
+          "pass": 1,
+          "total": 1
+        },
+        "twig": {
+          "pass": 1,
+          "total": 1
+        },
+        "xslate": {
+          "pass": 1,
+          "total": 1
+        }
+      }
+    },
+    "array-method:toUpperCase": {
+      "total": 1,
+      "cells": {
+        "hono": {
+          "pass": 1,
+          "total": 1
+        },
+        "blade": {
+          "pass": 1,
+          "total": 1
+        },
+        "erb": {
+          "pass": 1,
+          "total": 1
+        },
+        "go-template": {
+          "pass": 1,
+          "total": 1
+        },
+        "jinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "minijinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "mojolicious": {
+          "pass": 1,
+          "total": 1
+        },
+        "twig": {
+          "pass": 1,
+          "total": 1
+        },
+        "xslate": {
+          "pass": 1,
+          "total": 1
+        }
+      }
+    },
+    "array-method:trim": {
+      "total": 1,
+      "cells": {
+        "hono": {
+          "pass": 1,
+          "total": 1
+        },
+        "blade": {
+          "pass": 1,
+          "total": 1
+        },
+        "erb": {
+          "pass": 1,
+          "total": 1
+        },
+        "go-template": {
+          "pass": 1,
+          "total": 1
+        },
+        "jinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "minijinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "mojolicious": {
+          "pass": 1,
+          "total": 1
+        },
+        "twig": {
+          "pass": 1,
+          "total": 1
+        },
+        "xslate": {
+          "pass": 1,
+          "total": 1
+        }
+      }
+    },
+    "array-method:trimEnd": {
+      "total": 1,
+      "cells": {
+        "hono": {
+          "pass": 1,
+          "total": 1
+        },
+        "blade": {
+          "pass": 1,
+          "total": 1
+        },
+        "erb": {
+          "pass": 1,
+          "total": 1
+        },
+        "go-template": {
+          "pass": 1,
+          "total": 1
+        },
+        "jinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "minijinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "mojolicious": {
+          "pass": 1,
+          "total": 1
+        },
+        "twig": {
+          "pass": 1,
+          "total": 1
+        },
+        "xslate": {
+          "pass": 1,
+          "total": 1
+        }
+      }
+    },
+    "array-method:trimStart": {
+      "total": 1,
+      "cells": {
+        "hono": {
+          "pass": 1,
+          "total": 1
+        },
+        "blade": {
+          "pass": 1,
+          "total": 1
+        },
+        "erb": {
+          "pass": 1,
+          "total": 1
+        },
+        "go-template": {
+          "pass": 1,
+          "total": 1
+        },
+        "jinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "minijinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "mojolicious": {
+          "pass": 1,
+          "total": 1
+        },
+        "twig": {
+          "pass": 1,
+          "total": 1
+        },
+        "xslate": {
+          "pass": 1,
+          "total": 1
+        }
+      }
+    },
+    "binary:!=": {
+      "total": 2,
+      "cells": {
+        "hono": {
+          "pass": 2,
+          "total": 2
+        },
+        "blade": {
+          "pass": 2,
+          "total": 2
+        },
+        "erb": {
+          "pass": 2,
+          "total": 2
+        },
+        "go-template": {
+          "pass": 2,
+          "total": 2
+        },
+        "jinja": {
+          "pass": 2,
+          "total": 2
+        },
+        "minijinja": {
+          "pass": 2,
+          "total": 2
+        },
+        "mojolicious": {
+          "pass": 2,
+          "total": 2
+        },
+        "twig": {
+          "pass": 2,
+          "total": 2
+        },
+        "xslate": {
+          "pass": 2,
+          "total": 2
+        }
+      }
+    },
+    "binary:!==": {
+      "total": 9,
+      "cells": {
+        "hono": {
+          "pass": 9,
+          "total": 9
+        },
+        "blade": {
+          "pass": 9,
+          "total": 9
+        },
+        "erb": {
+          "pass": 9,
+          "total": 9
+        },
+        "go-template": {
+          "pass": 9,
+          "total": 9
+        },
+        "jinja": {
+          "pass": 9,
+          "total": 9
+        },
+        "minijinja": {
+          "pass": 9,
+          "total": 9
+        },
+        "mojolicious": {
+          "pass": 9,
+          "total": 9
+        },
+        "twig": {
+          "pass": 9,
+          "total": 9
+        },
+        "xslate": {
+          "pass": 9,
+          "total": 9
+        }
+      }
+    },
+    "binary:*": {
+      "total": 9,
+      "cells": {
+        "hono": {
+          "pass": 9,
+          "total": 9
+        },
+        "blade": {
+          "pass": 9,
+          "total": 9
+        },
+        "erb": {
+          "pass": 9,
+          "total": 9
+        },
+        "go-template": {
+          "pass": 9,
+          "total": 9
+        },
+        "jinja": {
+          "pass": 9,
+          "total": 9
+        },
+        "minijinja": {
+          "pass": 9,
+          "total": 9
+        },
+        "mojolicious": {
+          "pass": 9,
+          "total": 9
+        },
+        "twig": {
+          "pass": 9,
+          "total": 9
+        },
+        "xslate": {
+          "pass": 9,
+          "total": 9
+        }
+      }
+    },
+    "binary:+": {
+      "total": 17,
+      "cells": {
+        "hono": {
+          "pass": 17,
+          "total": 17
+        },
+        "blade": {
+          "pass": 16,
+          "total": 17,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "erb": {
+          "pass": 16,
+          "total": 17,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "go-template": {
+          "pass": 16,
+          "total": 17,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "jinja": {
+          "pass": 16,
+          "total": 17,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "minijinja": {
+          "pass": 16,
+          "total": 17,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "mojolicious": {
+          "pass": 16,
+          "total": 17,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "twig": {
+          "pass": 16,
+          "total": 17,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "xslate": {
+          "pass": 16,
+          "total": 17,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        }
+      }
+    },
+    "binary:-": {
+      "total": 11,
+      "cells": {
+        "hono": {
+          "pass": 11,
+          "total": 11
+        },
+        "blade": {
+          "pass": 11,
+          "total": 11
+        },
+        "erb": {
+          "pass": 11,
+          "total": 11
+        },
+        "go-template": {
+          "pass": 11,
+          "total": 11
+        },
+        "jinja": {
+          "pass": 11,
+          "total": 11
+        },
+        "minijinja": {
+          "pass": 11,
+          "total": 11
+        },
+        "mojolicious": {
+          "pass": 11,
+          "total": 11
+        },
+        "twig": {
+          "pass": 11,
+          "total": 11
+        },
+        "xslate": {
+          "pass": 11,
+          "total": 11
+        }
+      }
+    },
+    "binary:/": {
+      "total": 1,
+      "cells": {
+        "hono": {
+          "pass": 1,
+          "total": 1
+        },
+        "blade": {
+          "pass": 1,
+          "total": 1
+        },
+        "erb": {
+          "pass": 1,
+          "total": 1
+        },
+        "go-template": {
+          "pass": 1,
+          "total": 1
+        },
+        "jinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "minijinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "mojolicious": {
+          "pass": 1,
+          "total": 1
+        },
+        "twig": {
+          "pass": 1,
+          "total": 1
+        },
+        "xslate": {
+          "pass": 1,
+          "total": 1
+        }
+      }
+    },
+    "binary:<": {
+      "total": 1,
+      "cells": {
+        "hono": {
+          "pass": 1,
+          "total": 1
+        },
+        "blade": {
+          "pass": 1,
+          "total": 1
+        },
+        "erb": {
+          "pass": 1,
+          "total": 1
+        },
+        "go-template": {
+          "pass": 1,
+          "total": 1
+        },
+        "jinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "minijinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "mojolicious": {
+          "pass": 1,
+          "total": 1
+        },
+        "twig": {
+          "pass": 1,
+          "total": 1
+        },
+        "xslate": {
+          "pass": 1,
+          "total": 1
+        }
+      }
+    },
+    "binary:===": {
+      "total": 30,
+      "cells": {
+        "hono": {
+          "pass": 30,
+          "total": 30
+        },
+        "blade": {
+          "pass": 28,
+          "total": 30,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "erb": {
+          "pass": 29,
+          "total": 30,
+          "gaps": [
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "go-template": {
+          "pass": 28,
+          "total": 30,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "jinja": {
+          "pass": 28,
+          "total": 30,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "minijinja": {
+          "pass": 28,
+          "total": 30,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "mojolicious": {
+          "pass": 29,
+          "total": 30,
+          "gaps": [
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "twig": {
+          "pass": 28,
+          "total": 30,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "xslate": {
+          "pass": 28,
+          "total": 30,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            },
+            {
+              "fixture": "filter-nested-find-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "binary:>": {
+      "total": 11,
+      "cells": {
+        "hono": {
+          "pass": 11,
+          "total": 11
+        },
+        "blade": {
+          "pass": 11,
+          "total": 11
+        },
+        "erb": {
+          "pass": 11,
+          "total": 11
+        },
+        "go-template": {
+          "pass": 11,
+          "total": 11
+        },
+        "jinja": {
+          "pass": 11,
+          "total": 11
+        },
+        "minijinja": {
+          "pass": 11,
+          "total": 11
+        },
+        "mojolicious": {
+          "pass": 11,
+          "total": 11
+        },
+        "twig": {
+          "pass": 11,
+          "total": 11
+        },
+        "xslate": {
+          "pass": 11,
+          "total": 11
+        }
+      }
+    },
+    "binary:>=": {
+      "total": 1,
+      "cells": {
+        "hono": {
+          "pass": 1,
+          "total": 1
+        },
+        "blade": {
+          "pass": 1,
+          "total": 1
+        },
+        "erb": {
+          "pass": 1,
+          "total": 1
+        },
+        "go-template": {
+          "pass": 1,
+          "total": 1
+        },
+        "jinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "minijinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "mojolicious": {
+          "pass": 1,
+          "total": 1
+        },
+        "twig": {
+          "pass": 1,
+          "total": 1
+        },
+        "xslate": {
+          "pass": 1,
+          "total": 1
+        }
+      }
+    },
+    "literal:boolean": {
+      "total": 37,
+      "cells": {
+        "hono": {
+          "pass": 37,
+          "total": 37
+        },
+        "blade": {
+          "pass": 37,
+          "total": 37
+        },
+        "erb": {
+          "pass": 37,
+          "total": 37
+        },
+        "go-template": {
+          "pass": 37,
+          "total": 37
+        },
+        "jinja": {
+          "pass": 37,
+          "total": 37
+        },
+        "minijinja": {
+          "pass": 37,
+          "total": 37
+        },
+        "mojolicious": {
+          "pass": 37,
+          "total": 37
+        },
+        "twig": {
+          "pass": 37,
+          "total": 37
+        },
+        "xslate": {
+          "pass": 37,
+          "total": 37
+        }
+      }
+    },
+    "literal:null": {
+      "total": 22,
+      "cells": {
+        "hono": {
+          "pass": 22,
+          "total": 22
+        },
+        "blade": {
+          "pass": 22,
+          "total": 22
+        },
+        "erb": {
+          "pass": 22,
+          "total": 22
+        },
+        "go-template": {
+          "pass": 22,
+          "total": 22
+        },
+        "jinja": {
+          "pass": 22,
+          "total": 22
+        },
+        "minijinja": {
+          "pass": 22,
+          "total": 22
+        },
+        "mojolicious": {
+          "pass": 22,
+          "total": 22
+        },
+        "twig": {
+          "pass": 22,
+          "total": 22
+        },
+        "xslate": {
+          "pass": 22,
+          "total": 22
+        }
+      }
+    },
+    "literal:number": {
+      "total": 85,
+      "cells": {
+        "hono": {
+          "pass": 85,
+          "total": 85
+        },
+        "blade": {
+          "pass": 85,
+          "total": 85
+        },
+        "erb": {
+          "pass": 85,
+          "total": 85
+        },
+        "go-template": {
+          "pass": 85,
+          "total": 85
+        },
+        "jinja": {
+          "pass": 85,
+          "total": 85
+        },
+        "minijinja": {
+          "pass": 85,
+          "total": 85
+        },
+        "mojolicious": {
+          "pass": 85,
+          "total": 85
+        },
+        "twig": {
+          "pass": 85,
+          "total": 85
+        },
+        "xslate": {
+          "pass": 85,
+          "total": 85
+        }
+      }
+    },
+    "literal:string": {
+      "total": 138,
+      "cells": {
+        "hono": {
+          "pass": 138,
+          "total": 138
+        },
+        "blade": {
+          "pass": 137,
+          "total": 138,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "erb": {
+          "pass": 137,
+          "total": 138,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "go-template": {
+          "pass": 137,
+          "total": 138,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "jinja": {
+          "pass": 137,
+          "total": 138,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "minijinja": {
+          "pass": 137,
+          "total": 138,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "mojolicious": {
+          "pass": 137,
+          "total": 138,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "twig": {
+          "pass": 137,
+          "total": 138,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        },
+        "xslate": {
+          "pass": 137,
+          "total": 138,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props-with-component",
+              "issues": []
+            }
+          ]
+        }
+      }
+    },
+    "logical:&&": {
+      "total": 7,
+      "cells": {
+        "hono": {
+          "pass": 7,
+          "total": 7
+        },
+        "blade": {
+          "pass": 7,
+          "total": 7
+        },
+        "erb": {
+          "pass": 7,
+          "total": 7
+        },
+        "go-template": {
+          "pass": 7,
+          "total": 7
+        },
+        "jinja": {
+          "pass": 7,
+          "total": 7
+        },
+        "minijinja": {
+          "pass": 7,
+          "total": 7
+        },
+        "mojolicious": {
+          "pass": 7,
+          "total": 7
+        },
+        "twig": {
+          "pass": 7,
+          "total": 7
+        },
+        "xslate": {
+          "pass": 7,
+          "total": 7
+        }
+      }
+    },
+    "logical:??": {
+      "total": 37,
+      "cells": {
+        "hono": {
+          "pass": 37,
+          "total": 37
+        },
+        "blade": {
+          "pass": 36,
+          "total": 37,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            }
+          ]
+        },
+        "erb": {
+          "pass": 36,
+          "total": 37,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "go-template": {
+          "pass": 36,
+          "total": 37,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            }
+          ]
+        },
+        "jinja": {
+          "pass": 36,
+          "total": 37,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "minijinja": {
+          "pass": 36,
+          "total": 37,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2087"
+              ]
+            }
+          ]
+        },
+        "mojolicious": {
+          "pass": 36,
+          "total": 37,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            }
+          ]
+        },
+        "twig": {
+          "pass": 36,
+          "total": 37,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            }
+          ]
+        },
+        "xslate": {
+          "pass": 36,
+          "total": 37,
+          "gaps": [
+            {
+              "fixture": "static-array-from-props",
+              "issues": []
+            }
+          ]
+        }
+      }
+    },
+    "logical:||": {
+      "total": 12,
+      "cells": {
+        "hono": {
+          "pass": 12,
+          "total": 12
+        },
+        "blade": {
+          "pass": 12,
+          "total": 12
+        },
+        "erb": {
+          "pass": 12,
+          "total": 12
+        },
+        "go-template": {
+          "pass": 12,
+          "total": 12
+        },
+        "jinja": {
+          "pass": 12,
+          "total": 12
+        },
+        "minijinja": {
+          "pass": 12,
+          "total": 12
+        },
+        "mojolicious": {
+          "pass": 12,
+          "total": 12
+        },
+        "twig": {
+          "pass": 12,
+          "total": 12
+        },
+        "xslate": {
+          "pass": 12,
+          "total": 12
+        }
+      }
+    },
+    "member:computed": {
+      "total": 8,
+      "cells": {
+        "hono": {
+          "pass": 8,
+          "total": 8
+        },
+        "blade": {
+          "pass": 8,
+          "total": 8
+        },
+        "erb": {
+          "pass": 8,
+          "total": 8
+        },
+        "go-template": {
+          "pass": 8,
+          "total": 8
+        },
+        "jinja": {
+          "pass": 8,
+          "total": 8
+        },
+        "minijinja": {
+          "pass": 8,
+          "total": 8
+        },
+        "mojolicious": {
+          "pass": 8,
+          "total": 8
+        },
+        "twig": {
+          "pass": 8,
+          "total": 8
+        },
+        "xslate": {
+          "pass": 8,
+          "total": 8
+        }
+      }
+    },
+    "member:optional": {
+      "total": 1,
+      "cells": {
+        "hono": {
+          "pass": 1,
+          "total": 1
+        },
+        "blade": {
+          "pass": 1,
+          "total": 1
+        },
+        "erb": {
+          "pass": 1,
+          "total": 1
+        },
+        "go-template": {
+          "pass": 1,
+          "total": 1
+        },
+        "jinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "minijinja": {
+          "pass": 1,
+          "total": 1
+        },
+        "mojolicious": {
+          "pass": 1,
+          "total": 1
+        },
+        "twig": {
+          "pass": 1,
+          "total": 1
+        },
+        "xslate": {
+          "pass": 1,
+          "total": 1
+        }
+      }
+    },
+    "unary:!": {
+      "total": 14,
+      "cells": {
+        "hono": {
+          "pass": 14,
+          "total": 14
+        },
+        "blade": {
+          "pass": 13,
+          "total": 14,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "erb": {
+          "pass": 14,
+          "total": 14
+        },
+        "go-template": {
+          "pass": 13,
+          "total": 14,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "jinja": {
+          "pass": 13,
+          "total": 14,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "minijinja": {
+          "pass": 13,
+          "total": 14,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "mojolicious": {
+          "pass": 14,
+          "total": 14
+        },
+        "twig": {
+          "pass": 13,
+          "total": 14,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        },
+        "xslate": {
+          "pass": 13,
+          "total": 14,
+          "gaps": [
+            {
+              "fixture": "filter-nested-callback-predicate",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2038"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "unary:-": {
+      "total": 11,
+      "cells": {
+        "hono": {
+          "pass": 11,
+          "total": 11
+        },
+        "blade": {
+          "pass": 11,
+          "total": 11
+        },
+        "erb": {
+          "pass": 11,
+          "total": 11
+        },
+        "go-template": {
+          "pass": 11,
+          "total": 11
+        },
+        "jinja": {
+          "pass": 11,
+          "total": 11
+        },
+        "minijinja": {
+          "pass": 11,
+          "total": 11
+        },
+        "mojolicious": {
+          "pass": 11,
+          "total": 11
+        },
+        "twig": {
+          "pass": 11,
+          "total": 11
+        },
+        "xslate": {
+          "pass": 11,
+          "total": 11
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #2275 — the last coverage-bookkeeping piece of `spec/subset-conformance.md`. Both halves of the join already existed; this joins them:

- **Denominators** — `packages/adapter-tests/coverage-map.json` (per-fixture `kinds` / `axes`).
- **Numerators** — each adapter's `conformancePins` / `renderDivergences` (via `loadCompatAdapters()`).

Output is a committed `ui/support-matrix.lock.json`, published on the docs compatibility-matrix page and held by a CI drift gate — the same pipeline shape as `ui/compat.lock.json`.

## The attribution decision (why ratios, not binary)

A pin marks a **fixture** gapped, not a construct. A gapped fixture is usually a complex component that incidentally exercises many common kinds/axes alongside the one shape it exists to pin down — so a binary "partial/full" roll-up would paint nearly every construct (`identifier`, `literal:string`, …) broken on every adapter, when only one fixture's specific shape is pinned.

So each cell is a **pass/total ratio** over the fixtures exercising that construct, plus a `gaps` drill-down naming the gapped fixtures and their tracking issues:

- `array-method` → 62/62 on every adapter (clean).
- `literal:string` → 138 total; `hono` 138/138, every other adapter 137/138 (one gapped fixture — the ratio makes it self-evidently "supported, one edge case").
- `hono`'s `call` → 156/157, the one gap `date-method-uncatalogued` linking #2274 (a real compiler-level BF021 refusal, represented honestly rather than special-cased away).
- `regex` → total 0 (uncovered kind, kept for completeness against `PARSED_EXPR_KINDS`).

"Does adapter X support construct Y, and where is that tracked?" becomes a lookup.

## Changes

- `packages/compat/src/support-matrix.ts` — pure `buildSupportMatrix()` join + `computeSupportMatrix()` over the committed coverage map + `loadCompatAdapters()`; `SUPPORT_MATRIX_NOTE` documents the fixture-granular attribution.
- `packages/compat/src/support-matrix-cli.ts` + `support-matrix:lock` script → `ui/support-matrix.lock.json` (deterministic; same JSON contract as `compat.lock`).
- `packages/compat/src/report.ts` — extract `compareAdapterIds()` so both lockfiles share column order (behavior-preserving; `compat.lock` regenerates with zero drift).
- `.github/workflows/ci-compat.yml` — regen + `git diff --exit-code` drift gate; watch the new lockfile and `coverage-map.json`.
- `site/core/pages/compat-matrix.tsx` — new `## Construct Support (kind × axis)` section (by-kind + by-axis tables, ratio cells, linked issues, ratio-not-binary explainer).
- `packages/compat/__tests__/support-matrix.test.ts` — pins the join logic (ratio, gap drill-down, issue dedup/sort, ordering, uncovered-construct shape) + committed-lockfile freshness.

## Verification (local)

- `support-matrix:lock` deterministic (regen twice → no drift); `compat.lock` also regenerates with no drift.
- `bun test packages/compat`: 80 pass / 0 fail.
- `tsgo --noEmit -p packages/compat`: clean.
- Docs page renders (status 200) with the new section and both tables.

`@barefootjs/compat` and the docs site are in the changeset ignore list and `ui/` is not a package, so no changeset is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1T4R1R6FKPGTFyYn1ppBa)_