### PR TITLE
Add #2276: change-time coupling rule in CLAUDE.md + array-method floor test

### DIFF
--- a/.changeset/array-method-floor.md
+++ b/.changeset/array-method-floor.md
@@ -1,0 +1,13 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Add #2276: the change-time coupling rule (a subset extension merges only with
+fixtures in the same PR) is now written into `CLAUDE.md`, and its
+catalogue-half mechanical backstop lands for `array-method`. `@barefootjs/jsx`
+exports `ARRAY_METHOD_NAMES` — the positive registry of catalogued
+`array-method` names, exhaustiveness-pinned against the `array-method` union
+(adding a method without listing it fails to compile, mirroring
+`PARSED_EXPR_KINDS`). The coverage-ledger floor test then requires every
+listed method to have a covering fixture (or a documented allowlist entry),
+so a new catalogued array-method can't ship without conformance coverage.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,8 @@ Quick decision guide:
 
 Tracked limitations across the compiler, adapters, and runtime live under the [`known-limitation`](https://github.com/piconic-ai/barefootjs/labels/known-limitation) label — that label URL is the source of truth. Adapter-internal declarations (`skipJsx`, `skipFixtures`, `expectedDiagnostics`) carry a docstring pointer back to the per-issue URL.
 
+**A subset extension merges only with fixtures in the same PR** (`spec/subset-conformance.md`'s change-time coupling rule — TC39's stage-4 analogue). Widening what the compiler accepts — a new `ParsedExpr` kind or field, a catalogue entry (an `array-method` member, a sort-comparator form), or a builtin lowering plugin — means adding at least one conformance fixture (`packages/adapter-tests/fixtures/`) that exercises it in the **same** PR; the feature and its coverage land together, never in separate steps. The *kind* and *array-method-catalogue* halves are mechanically backstopped — a new `PARSED_EXPR_KINDS` member or `array-method` union method fails its exhaustiveness pin (`expression-parser.ts`), then a coverage-ledger floor test (`coverage-map.test.ts`) demands a covering fixture or a documented allowlist exclusion. Other extensions — a builtin lowering plugin, a sort-comparator form — have no positive registry to floor-test against, so for those this written rule is the **only** backstop — do not skip it.
+
 Workflow for editing a UI component:
 1. Run `bun run bf docs <component>` (and `bf debug graph <component>` if `"use client"`) for the API surface.
 2. Add or update the IR test (red).

--- a/packages/adapter-tests/src/__tests__/coverage-map.test.ts
+++ b/packages/adapter-tests/src/__tests__/coverage-map.test.ts
@@ -42,7 +42,7 @@ const UNCOVERED_KIND_ALLOWLIST: Record<string, string> = {
  * `ARRAY_METHOD_NAMES` has a covering fixture. A method that gains a fixture
  * while listed here becomes STALE and fails the no-stale test until deleted.
  */
-const UNCOVERED_ARRAY_METHOD_ALLOWLIST: Record<string, string> = {}
+const UNCOVERED_ARRAY_METHOD_ALLOWLIST: Partial<Record<(typeof ARRAY_METHOD_NAMES)[number], string>> = {}
 
 const MAP_PATH = resolve(import.meta.dir, '../../coverage-map.json')
 

--- a/packages/adapter-tests/src/__tests__/coverage-map.test.ts
+++ b/packages/adapter-tests/src/__tests__/coverage-map.test.ts
@@ -19,7 +19,7 @@
 import { describe, test, expect } from 'bun:test'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { PARSED_EXPR_KINDS } from '@barefootjs/jsx'
+import { PARSED_EXPR_KINDS, ARRAY_METHOD_NAMES } from '@barefootjs/jsx'
 import { computeCoverageMap } from '../coverage-map'
 
 /**
@@ -34,6 +34,15 @@ const UNCOVERED_KIND_ALLOWLIST: Record<string, string> = {
   // regex falls through to `unsupported` at parse time.
   regex: 'no fixture exercises the trailing-slash String.replace pattern',
 }
+
+/**
+ * Catalogued `array-method` names allowed to stay uncovered, each with the
+ * reason — the catalogue-half floor's counterpart to
+ * `UNCOVERED_KIND_ALLOWLIST`. Empty today: every method in
+ * `ARRAY_METHOD_NAMES` has a covering fixture. A method that gains a fixture
+ * while listed here becomes STALE and fails the no-stale test until deleted.
+ */
+const UNCOVERED_ARRAY_METHOD_ALLOWLIST: Record<string, string> = {}
 
 const MAP_PATH = resolve(import.meta.dir, '../../coverage-map.json')
 
@@ -74,6 +83,27 @@ describe('coverage ledger', () => {
   test('no stale allowlist entries (covered kinds must graduate)', () => {
     const stale = Object.keys(UNCOVERED_KIND_ALLOWLIST).filter(
       kind => (recomputed.kindCounts[kind] ?? 0) > 0,
+    )
+    expect(stale).toEqual([])
+  })
+
+  // Catalogue-half floor (#2276): every catalogued `array-method` name is
+  // exercised by ≥1 fixture, or carries a documented exclusion. Mirrors the
+  // kind floor — the mechanical backstop for the change-time coupling rule
+  // on the largest catalogue, since (unlike kinds) an `array-method`
+  // variant has no exhaustive adapter switch that would otherwise force it.
+  test('every catalogued array-method is exercised by ≥1 fixture or documented uncovered', () => {
+    const holes = ARRAY_METHOD_NAMES.filter(
+      method =>
+        !recomputed.axisCounts[`array-method:${method}`] &&
+        !(method in UNCOVERED_ARRAY_METHOD_ALLOWLIST),
+    )
+    expect(holes).toEqual([])
+  })
+
+  test('no stale array-method allowlist entries (covered methods must graduate)', () => {
+    const stale = Object.keys(UNCOVERED_ARRAY_METHOD_ALLOWLIST).filter(
+      method => (recomputed.axisCounts[`array-method:${method}`] ?? 0) > 0,
     )
     expect(stale).toEqual([])
   })

--- a/packages/jsx/src/expression-parser.ts
+++ b/packages/jsx/src/expression-parser.ts
@@ -187,6 +187,53 @@ const _kindRegistryIsExhaustive: MissingFromKindRegistry extends never ? true : 
 void _kindRegistryIsExhaustive
 
 /**
+ * Runtime registry of the catalogued `array-method` names — the positive
+ * counterpart to `UNSUPPORTED_METHODS`'s negative gate, and the denominator
+ * the coverage ledger's array-method floor test (`coverage-map.test.ts`)
+ * requires a covering fixture for. This is the catalogue half of the
+ * change-time coupling rule (`spec/subset-conformance.md` / `CLAUDE.md`):
+ * the exhaustiveness pin below makes adding a method to the `array-method`
+ * union without listing it here a compile error, and the floor test then
+ * makes shipping a listed method with no fixture a test failure.
+ */
+export const ARRAY_METHOD_NAMES = [
+  'join',
+  'includes',
+  'indexOf',
+  'lastIndexOf',
+  'at',
+  'concat',
+  'slice',
+  'reverse',
+  'toReversed',
+  'toLowerCase',
+  'toUpperCase',
+  'trim',
+  'trimStart',
+  'trimEnd',
+  'toFixed',
+  'split',
+  'startsWith',
+  'endsWith',
+  'replace',
+  'replaceAll',
+  'repeat',
+  'padStart',
+  'padEnd',
+  'flat',
+] as const satisfies ReadonlyArray<Extract<ParsedExpr, { kind: 'array-method' }>['method']>
+
+// Exhaustiveness pin: adding a method to the `array-method` union (either
+// variant) without listing it in `ARRAY_METHOD_NAMES` fails to compile here
+// (same drift defence as `PARSED_EXPR_KINDS`).
+type MissingFromArrayMethodRegistry = Exclude<
+  Extract<ParsedExpr, { kind: 'array-method' }>['method'],
+  (typeof ARRAY_METHOD_NAMES)[number]
+>
+const _arrayMethodRegistryIsExhaustive: MissingFromArrayMethodRegistry extends never ? true : never = true
+void _arrayMethodRegistryIsExhaustive
+
+/**
  * One property of an `object-literal` `ParsedExpr`. The key is the
  * resolved (non-computed) property name — for `{ a: 1 }` and shorthand
  * `{ a }` it is `a`; for `{ 'a-b': 1 }` it is `a-b`. Computed keys

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -322,7 +322,7 @@ export { ErrorCodes, createError, formatError, generateCodeFrame } from './error
 // Expression Parser
 export { parseExpression, tsNodeToParsedExpr, asCallbackMethodCall, CALLBACK_METHODS, sortComparatorFromArrow, serializeParsedExpr, freeVarsInBody, freeIdentifiers, materializeGetterCalls, isSupported, exprToString, stringifyParsedExpr, identifierPath, parseBlockBody, parseBlockBodyTolerant, foldBlockToExpr, predicateTernaryToLogical, containsHigherOrder, extractArrowBodyExpression, parseStyleObjectEntries, hasUnsafeStyleValue, parseProviderObjectLiteral, type ProviderObjectMember, type FoldBlockOptions } from './expression-parser.ts'
 export type { StyleObjectEntry } from './expression-parser.ts'
-export { PARSED_EXPR_KINDS } from './expression-parser.ts'
+export { PARSED_EXPR_KINDS, ARRAY_METHOD_NAMES } from './expression-parser.ts'
 export type { ParsedExpr, ObjectLiteralProperty, ParsedStatement, SortComparator, SortKey, FlatDepth, SupportLevel, SupportResult, TemplatePart } from './expression-parser.ts'
 export { buildLoopChainExpr } from './loop-chain.ts'
 export type { LoopChainInputs } from './loop-chain.ts'

--- a/spec/subset-conformance.md
+++ b/spec/subset-conformance.md
@@ -213,9 +213,15 @@ convention as `spec/adapter-architecture.md`):
 | Shared conformance | `run-adapter-conformance.ts` single mandatory entry point ("forgot to wire the suite" is impossible); 182 fixtures + marker conformance + template primitives + render contract; real-backend execution with `normalizeHTML`; `props` injection; **the `dataPoints` oracle suite (roadmap 1)** — gate-ordered, live-oracle, JSON-domain-validated, piloted on `nullish-coalescing-text` (found #2248 — since fixed via nillable lowering + `bf_nullish` — and a Go harness string-escaping bug on its first run) | No PR-vs-nightly tiering (the catalogue added ~200 real-backend renders per adapter job); catalogue exclusions await their unblockers (unions/objects → member enumeration, floats → #2168-class) — `Date` graduated (#2274, the first catalogued rich type: SSR lowering, oracle data points, and client-JS lowering all landed) and destructured optionals graduated (#2259, analyzer parity restored), so the catalogue now derives for both |
 | Declared skips | Typed skip sets (`skipJsx`, `skipTemplatePrimitives`, `skipMarkerConformance`, `expectedDiagnostics`, and now `skipDataPoints` — its first entries pinned #2248 on the Go adapter until the fix landed and removed them, completing one full ledger round-trip) with issue-link discipline; `known-limitation` label; `@barefootjs/compat` component×adapter compile matrix (`compat.lock.json`); and the generated `kind × axis × adapter` support matrix (`support-matrix.lock.json`, #2275) — the coverage ledger (`coverage-map.json` + `PARSED_EXPR_KINDS` registry + freshness/floor meta-tests) supplies the kind/axis denominators, joined against each adapter's pins/divergences, published on the docs compatibility-matrix page and held by a CI drift gate | Attribution is fixture-granular — a construct's `pass/total` counts the fixtures that exercise it (pins are per-fixture, not per-construct), so the ratio, not a binary verdict, is the queryable signal |
 
-Cross-cutting gap: the change-time coupling rule (subset extensions merge
-only with fixtures in the same PR) is not yet written into any contribution
-convention.
+Cross-cutting: the change-time coupling rule (subset extensions merge only
+with fixtures in the same PR) is written into `CLAUDE.md`'s Testing section
+(#2276) so agent-driven PRs pick it up automatically. Its *kind* and
+*array-method-catalogue* halves are additionally enforced mechanically
+(the `PARSED_EXPR_KINDS` and `ARRAY_METHOD_NAMES` exhaustiveness pins + the
+coverage-ledger floor tests, which demand a covering fixture or a documented
+allowlist entry); other extensions — a builtin lowering plugin, a
+sort-comparator form — have no positive registry to floor-test against, so
+for those the written rule is the only backstop.
 
 ## Roadmap
 


### PR DESCRIPTION
## Summary

Closes #2276. **Stacked on #2296** (base branch `claude/spec-currency-tidy`) — review/merge that one first.

Writes `spec/subset-conformance.md`'s change-time coupling rule — *a subset extension (new `ParsedExpr` kind or field, catalogue entry, builtin lowering) merges only with fixtures in the same PR*, TC39's stage-4 analogue — into `CLAUDE.md`'s Testing section, so agent-driven PRs pick it up automatically, and flips the spec's "not yet written into any contribution convention" line.

## The mechanical backstop (the issue's open evaluation)

#2276 asked whether a cheap meta-test can cover the catalogue half or whether the written rule suffices. Finding: the *kind* half was already backstopped (`PARSED_EXPR_KINDS` exhaustiveness pin → coverage-ledger floor test), and the largest catalogue — `array-method` — can get the **same** backstop cheaply, because its method union is closed and every member is already covered:

- `@barefootjs/jsx` now exports **`ARRAY_METHOD_NAMES`**, the positive registry of catalogued array-method names, **exhaustiveness-pinned** against `Extract<ParsedExpr, { kind: 'array-method' }>['method']` (adding a method to the union without listing it fails to compile — mirrors `PARSED_EXPR_KINDS`).
- A new coverage-ledger floor test requires every listed method to have a covering fixture, or a documented `UNCOVERED_ARRAY_METHOD_ALLOWLIST` entry. The allowlist is **empty** today — all 24 methods are covered, so it lands green.

Other extensions (builtin lowering plugins, sort-comparator forms) have no positive registry / coverage signal to floor-test against, so for those the written rule remains the only backstop — documented as such in `CLAUDE.md`.

## Verification

- `tsgo --noEmit -p packages/jsx`: clean (the exhaustiveness pin compiles → `ARRAY_METHOD_NAMES` exactly matches the union, both directions).
- `bun test coverage-map.test.ts`: 5 pass (the 2 new array-method floor tests + the 3 existing kind ones).

Changeset: `@barefootjs/jsx` patch (new `ARRAY_METHOD_NAMES` export).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1T4R1R6FKPGTFyYn1ppBa)_