### PR TITLE
Add #2277: adversarial catalogue synthesis for union- and object-typed props

### DIFF
--- a/.changeset/union-object-catalogue.md
+++ b/.changeset/union-object-catalogue.md
@@ -1,0 +1,11 @@
+---
+"@barefootjs/go-template": patch
+"@barefootjs/rust": patch
+---
+
+Pin `object-catalogued` (#2277) as a render divergence on the two typed
+struct backends. An inline object-typed prop's nested member access
+(`props.cfg.id`) renders empty on Go and Rust because the inline object type
+doesn't synthesize a named struct/typed field — tracked as #2299. The
+object-synthesis data points still run the oracle comparison on Hono and
+every dynamic backend (Ruby/Python/PHP/Perl).

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -17,6 +17,14 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
+  // `object-catalogued` (#2277): an inline object-typed prop (`cfg: { id:
+  // number; label?: string }`) doesn't synthesize a named Go struct, so the
+  // `Cfg` field is untyped and `.Cfg.Id` / `.Cfg.Label` render empty. The
+  // object-synthesis data points still run the oracle on the dynamic
+  // backends + Hono; graduating means giving an inline object prop a real
+  // struct so nested member access resolves.
+  // https://github.com/piconic-ai/barefootjs/issues/2299
+  'object-catalogued': 'inline object-prop member access renders empty (untyped Cfg field) — #2299',
   // `todo-app-ssr` no longer diverges (#2209). Two parts: (1) `.Todos`
   // (the loop's DATUM slice) is already seeded straight from the caller's
   // Input — the constructor derives it from `initialTodos`, and `[]Todo`

--- a/packages/adapter-rust/src/render-divergences.ts
+++ b/packages/adapter-rust/src/render-divergences.ts
@@ -17,6 +17,12 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
+  // `object-catalogued` (#2277): same typed-backend gap as Go — an inline
+  // object-typed prop's nested member access (`props.cfg.id`) renders empty
+  // through the `bf-render` minijinja binary. The object-synthesis data
+  // points still run the oracle on the dynamic backends + Hono.
+  // https://github.com/piconic-ai/barefootjs/issues/2299
+  'object-catalogued': 'inline object-prop member access renders empty — #2299',
   // `todo-app` / `todo-app-ssr` no longer diverge (#2209) — the shared
   // `evaluateSignalInit` (`@barefootjs/jsx`, sandboxed real-JS evaluation
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -2575,6 +2575,16 @@
         "text"
       ]
     },
+    "object-catalogued": {
+      "kinds": [
+        "identifier",
+        "member"
+      ],
+      "axes": [],
+      "contexts": [
+        "text"
+      ]
+    },
     "object-entries-map": {
       "kinds": [
         "identifier"
@@ -4041,6 +4051,17 @@
         "text"
       ]
     },
+    "union-catalogued": {
+      "kinds": [
+        "identifier",
+        "member"
+      ],
+      "axes": [],
+      "contexts": [
+        "attribute",
+        "text"
+      ]
+    },
     "untyped-props-reads": {
       "kinds": [
         "array-literal",
@@ -4075,11 +4096,11 @@
     "binary": 67,
     "call": 157,
     "conditional": 18,
-    "identifier": 235,
+    "identifier": 237,
     "index-access": 12,
     "literal": 194,
     "logical": 41,
-    "member": 117,
+    "member": 119,
     "object-literal": 41,
     "template-literal": 27,
     "unary": 22,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -386,6 +386,11 @@ import { fixture as filterParamNameDiffers } from './filter-param-name-differs'
 import { fixture as loopParamShadowsRecordConst } from './loop-param-shadows-record-const'
 import { fixture as dateMethodUncatalogued } from './date-method-uncatalogued'
 import { fixture as dateCatalogued } from './date-catalogued'
+// #2277: the union- and object-typed catalogue extensions to the
+// type-derived adversarial catalogue (`adversarial-catalog.ts`), mirroring
+// the landed Date catalogue work above.
+import { fixture as unionCatalogued } from './union-catalogued'
+import { fixture as objectCatalogued } from './object-catalogued'
 
 import type { JSXFixture } from '../src/types'
 
@@ -667,4 +672,6 @@ export const jsxFixtures: JSXFixture[] = [
   loopParamShadowsRecordConst,
   dateMethodUncatalogued,
   dateCatalogued,
+  unionCatalogued,
+  objectCatalogued,
 ]

--- a/packages/adapter-tests/fixtures/object-catalogued.ts
+++ b/packages/adapter-tests/fixtures/object-catalogued.ts
@@ -1,0 +1,40 @@
+import { createFixture } from '../src/types'
+
+/**
+ * The catalogued object type (#2277) as a data-point prop: `cfg: { id:
+ * number; label?: string }`, one required and one optional field, both
+ * rendered in text position. Uses `props: Type` (not destructured) for the
+ * same reason `union-catalogued.ts` does — the full object `TypeInfo`
+ * (with `.properties`) only resolves down the props-object path;
+ * `collectMemberTypes` degrades a destructured object-typed member to
+ * `unknown`.
+ *
+ * `cfg` is required, so the type-derived catalogue
+ * (`adversarial-catalog.ts`) contributes:
+ * - `gen:cfg:object:minimal` — `{ id: 0 }`, `label` omitted (required
+ *   fields only);
+ * - `gen:cfg:object:+label` — `{ id: 0, label: '' }`, the optional
+ *   field's "present" variant.
+ */
+export const fixture = createFixture({
+  id: 'object-catalogued',
+  description: 'Object-typed prop ({ id: number; label?: string }) rendering its fields',
+  source: `
+function ConfigObject(props: { cfg: { id: number; label?: string } }) {
+  return (
+    <div>
+      <span>{props.cfg.id}</span>
+      <span>{props.cfg.label}</span>
+    </div>
+  )
+}
+export { ConfigObject }
+`,
+  props: { cfg: { id: 1, label: 'x' } },
+  expectedHtml: `
+    <div bf-s="test">
+      <span bf="s1"><!--bf:s0-->1<!--/--></span>
+      <span bf="s3"><!--bf:s2-->x<!--/--></span>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/union-catalogued.ts
+++ b/packages/adapter-tests/fixtures/union-catalogued.ts
@@ -1,0 +1,41 @@
+import { createFixture } from '../src/types'
+
+/**
+ * The catalogued union type (#2277) as a data-point prop: a string-literal
+ * union (`'top' | 'right' | 'bottom'`) rendered directly in both a `class`
+ * attribute and a text node, so every synthesized member (`gen:placement:
+ * union:<member>`) is compared against the JS reference on each adapter.
+ *
+ * Uses `props: Type` (not destructured) so the compiler resolves the FULL
+ * union `TypeInfo` — a destructured `{ placement }: Props` binding degrades
+ * non-primitive members to `kind:'unknown'` via `collectMemberTypes`, so
+ * the catalogue would synthesize nothing (see `adversarial-catalog.ts`'s
+ * `PropParamType` docstring; the destructured-union gap is tracked
+ * separately).
+ *
+ * Kept to a direct union render — NOT the `placementClasses[props.placement]`
+ * `Record<Union, string>` class-composition pattern the issue also names —
+ * so this fixture cleanly probes union *value synthesis* on every adapter.
+ * The class-composition surface is a separate, divergence-prone lowering
+ * (a function-local const `Record` indexed by a union prop currently fails
+ * to render on the Go adapter, #2300) and is out of this fixture's scope.
+ *
+ * `placement` is required (no `?`), so the catalogue contributes one
+ * `gen:placement:union:<member>` point per literal member — `right` /
+ * `bottom` (`top` reproduces the primary props and is deduped) — with no
+ * `absent` point (that's only emitted for an optional prop).
+ */
+export const fixture = createFixture({
+  id: 'union-catalogued',
+  description: 'Union-typed prop rendered in class + text position, one point per member',
+  source: `
+function PlacementUnion(props: { placement: 'top' | 'right' | 'bottom' }) {
+  return <div class={props.placement}>{props.placement}</div>
+}
+export { PlacementUnion }
+`,
+  props: { placement: 'top' },
+  expectedHtml: `
+    <div bf-s="test" bf="s1" class="top"><!--bf:s0-->top<!--/--></div>
+  `,
+})

--- a/packages/adapter-tests/generated-data-points.json
+++ b/packages/adapter-tests/generated-data-points.json
@@ -925,6 +925,25 @@
       }
     }
   ],
+  "object-catalogued": [
+    {
+      "name": "gen:cfg:object:minimal",
+      "props": {
+        "cfg": {
+          "id": 0
+        }
+      }
+    },
+    {
+      "name": "gen:cfg:object:+label",
+      "props": {
+        "cfg": {
+          "id": 0,
+          "label": ""
+        }
+      }
+    }
+  ],
   "pre-whitespace": [
     {
       "name": "gen:snippet:empty",
@@ -1815,6 +1834,20 @@
       "props": {
         "className": "",
         "__instanceId": "Toggle_test"
+      }
+    }
+  ],
+  "union-catalogued": [
+    {
+      "name": "gen:placement:union:right",
+      "props": {
+        "placement": "right"
+      }
+    },
+    {
+      "name": "gen:placement:union:bottom",
+      "props": {
+        "placement": "bottom"
       }
     }
   ]

--- a/packages/adapter-tests/src/__tests__/generated-data-points.test.ts
+++ b/packages/adapter-tests/src/__tests__/generated-data-points.test.ts
@@ -141,3 +141,81 @@ export function D({ items }: { items?: Todo[] }) {
     expect(names).toContain('gen:a:markup')
   })
 })
+
+/**
+ * Union- and object-typed synthesis (#2277) — mirrors the Date catalogue's
+ * own probe (`data-domain.test.ts`). Both probes use `props: Type` (not
+ * destructured): only that path resolves the full `TypeInfo` (`unionTypes`
+ * / `properties`) the catalogue reads — `collectMemberTypes`'
+ * primitives-only gate degrades a destructured non-primitive member to
+ * `unknown` (see `union-catalogued.ts` / `object-catalogued.ts`'s
+ * docstrings).
+ */
+describe('union catalogue synthesis (#2277)', () => {
+  const fixture = createFixture({
+    id: 'catalog-unit-union',
+    description: 'union catalogue probe',
+    source: `
+function Probe(props: { placement?: 'top' | 'right' | 'bottom' }) {
+  return <div>{props.placement}</div>
+}
+export { Probe }
+`,
+    props: { placement: 'top' },
+    expectedHtml: '<div bf-s="test">placeholder</div>',
+  })
+  const points = generateDataPointsForFixture(fixture)
+  const byName = new Map(points.map(p => [p.name, p.props]))
+
+  test('emits one gen:<param>:union:<member> point per literal member', () => {
+    expect(byName.get('gen:placement:union:right')).toEqual({ placement: 'right' })
+    expect(byName.get('gen:placement:union:bottom')).toEqual({ placement: 'bottom' })
+    // 'top' reproduces the primary props verbatim — deduped, not a bug.
+    expect(byName.has('gen:placement:union:top')).toBe(false)
+  })
+
+  test('optional union prop also gets the absent point', () => {
+    const absent = byName.get('gen:placement:absent')
+    expect(absent).toEqual({})
+    expect(Object.hasOwn(absent as object, 'placement')).toBe(false)
+  })
+
+  test('every generated point is JSON-clean (round-trips unchanged)', () => {
+    for (const [, props] of byName) {
+      expect(JSON.parse(JSON.stringify(props))).toEqual(props)
+    }
+  })
+})
+
+describe('object catalogue synthesis (#2277)', () => {
+  const fixture = createFixture({
+    id: 'catalog-unit-object',
+    description: 'object catalogue probe',
+    source: `
+function Probe(props: { cfg: { id: number; label?: string } }) {
+  return <div>{props.cfg.id}</div>
+}
+export { Probe }
+`,
+    props: { cfg: { id: 5, label: 'hi' } },
+    expectedHtml: '<div bf-s="test">placeholder</div>',
+  })
+  const points = generateDataPointsForFixture(fixture)
+  const byName = new Map(points.map(p => [p.name, p.props]))
+
+  test('emits object:minimal — required fields only, optionals omitted', () => {
+    const minimal = byName.get('gen:cfg:object:minimal') as { cfg: Record<string, unknown> } | undefined
+    expect(minimal).toEqual({ cfg: { id: 0 } })
+    expect(Object.hasOwn(minimal!.cfg, 'label')).toBe(false)
+  })
+
+  test('emits one object:+<field> point per optional field', () => {
+    expect(byName.get('gen:cfg:object:+label')).toEqual({ cfg: { id: 0, label: '' } })
+  })
+
+  test('every generated point is JSON-clean (round-trips unchanged)', () => {
+    for (const [, props] of byName) {
+      expect(JSON.parse(JSON.stringify(props))).toEqual(props)
+    }
+  })
+})

--- a/packages/adapter-tests/src/adversarial-catalog.ts
+++ b/packages/adapter-tests/src/adversarial-catalog.ts
@@ -28,15 +28,23 @@
  *   the harness, not as a semantic divergence;
  * - astral-plane strings — pinned per-adapter by hand (#2255); the
  *   catalogue stays BMP so a new string prop doesn't mint eight skips;
- * - union / object / interface / function-typed props — value synthesis
- *   needs member enumeration (unions) or required-field construction
- *   (objects).
+ * - function-typed props — no value to synthesize (a function can't cross
+ *   the JSON data domain);
+ * - a non-literal union (e.g. a member typed as bare `string`) or a
+ *   required object field with no good default (`unknown`, a function) —
+ *   see `parseLiteralRaw` / `leafValue`'s `UNSYNTHESIZABLE` sentinel.
  *
  * The catalogued rich type `Date` (#2274) IS synthesized: a `Date`-typed
  * param yields the same adversarial instants as the golden-vector grid,
  * carried as `{ $date: ISO }` envelopes (a `Date` cannot survive the
  * committed JSON artifact) that `data-point-conformance.ts` materializes
  * back into a `Date` before each render leg.
+ *
+ * Union- and object-typed props (#2277) ARE synthesized too: a
+ * literal-string/boolean/null/numeric union member yields one point per
+ * member (capped — see `UNION_MEMBER_CAP`); an object/interface type yields
+ * a required-fields-only "minimal" point plus one "present" variant per
+ * optional field (one field at a time, no cross-product).
  */
 
 import { compileJSX } from '@barefootjs/jsx'
@@ -52,18 +60,35 @@ interface CatalogValue {
   value: unknown | typeof ABSENT
 }
 
+/**
+ * Matches the IR's `TypeInfo` shape (structurally) — widened for #2277 to
+ * also carry `unionTypes` (union members) and `properties` (object/interface
+ * fields), the same two fields `TypeInfo` itself declares
+ * (`packages/jsx/src/types.ts`). Kept as its own interface (not `TypeInfo`
+ * imported directly) because the catalogue only reads a handful of fields
+ * and structural matching is what the rest of this module already relies on.
+ */
+interface PropParamType {
+  kind: string
+  primitive?: string
+  /** Original TS type string; for a `Date` prop this is `'Date'`. */
+  raw?: string
+  /** Union members (`kind: 'union'`) — mirrors `TypeInfo.unionTypes`. */
+  unionTypes?: PropParamType[]
+  /**
+   * Object/interface fields (`kind: 'object'`, or `kind: 'interface'` for a
+   * resolved local interface) — mirrors `TypeInfo.properties`.
+   */
+  properties?: Array<{ name: string; type: PropParamType; optional: boolean }>
+}
+
 /** Matches the IR's `ParamInfo`/`TypeInfo` shapes (structurally). */
 interface PropParam {
   name: string
   optional: boolean
   isRest?: boolean
   defaultValue?: string
-  type: {
-    kind: string
-    primitive?: string
-    /** Original TS type string; for a `Date` prop this is `'Date'`. */
-    raw?: string
-  }
+  type: PropParamType
 }
 
 /** Strip any generic arguments from a raw type string (`Foo<Bar>` → `Foo`). */
@@ -91,6 +116,138 @@ function toDateEnvelopes(value: unknown): unknown {
     )
   }
   return value
+}
+
+/**
+ * Cap on how many union members get their own catalogue point (#2277). A
+ * wide literal-string union (a day-of-week / locale-code / status-enum
+ * type) would otherwise mint one `gen:` point per member and dominate the
+ * generated corpus for a single prop. Above the cap, a deterministic
+ * first-6/last-6 sample is kept instead — both ends of the declared order,
+ * which is where a boundary regression (first/last case handled specially
+ * in a `switch`) is most likely to show up.
+ */
+const UNION_MEMBER_CAP = 12
+
+/**
+ * Parse a union member's `raw` TS type string (e.g. `"'top'"`, `'true'`,
+ * `'42'`) into the JS literal value it denotes. This is NOT a TS/JS syntax
+ * parse of source code — `raw` here is a short, self-contained data string
+ * (a single literal-type spelling out of `TypeInfo.unionTypes[].raw`), not
+ * a program to parse, so a small regex-driven check is fine.
+ *
+ * Returns `{ ok: false }` for a non-literal member (a bare `string`,
+ * `number`, an object/interface member, etc.) — there is no single value
+ * to synthesize for those, so the caller skips them and the member stays
+ * uncovered (v1 scope, same as a whole non-literal union does today).
+ */
+function parseLiteralRaw(raw: string): { ok: true; value: string | number | boolean | null } | { ok: false } {
+  const trimmed = raw.trim()
+  if (trimmed.length >= 2) {
+    const quote = trimmed[0]
+    if ((quote === "'" || quote === '"') && trimmed[trimmed.length - 1] === quote) {
+      return { ok: true, value: trimmed.slice(1, -1) }
+    }
+  }
+  if (trimmed === 'true') return { ok: true, value: true }
+  if (trimmed === 'false') return { ok: true, value: false }
+  if (trimmed === 'null') return { ok: true, value: null }
+  if (/^-?\d+(\.\d+)?$/.test(trimmed)) return { ok: true, value: Number(trimmed) }
+  return { ok: false }
+}
+
+/**
+ * Short, stable slug for a union member's catalogue tag. A safe
+ * `[a-zA-Z0-9_-]+` string value is used directly (readable point names like
+ * `gen:placement:union:top`); anything else (numbers, booleans, null, or a
+ * string with characters that would make an awkward tag) falls back to the
+ * member's declared index.
+ */
+function unionMemberTag(value: string | number | boolean | null, index: number): string {
+  if (typeof value === 'string' && /^[a-zA-Z0-9_-]+$/.test(value)) return value
+  return String(index)
+}
+
+/**
+ * Sentinel meaning "this shape can't be synthesized safely" — propagated up
+ * from `leafValue`/`synthesizeMinimal` when a REQUIRED field has no good
+ * default (an `unknown`/function-typed field, or a union with zero
+ * parseable literal members). A half-valid object — every field but one
+ * defaulted — would be worse than no generated point at all: it could
+ * silently exercise a lowering with a bogus value for a field the fixture
+ * never intended to vary. The caller drops the whole object instead.
+ */
+const UNSYNTHESIZABLE = Symbol('unsynthesizable')
+
+/** Cap on nested-object recursion depth (#2277) — mirrors the wide-union cap's
+ * purpose: bound the work for a pathological deeply-nested prop type rather
+ * than recursing arbitrarily. A field still nested at the cap gets `{}`
+ * (an empty object is JSON-clean and doesn't force the whole point to be
+ * dropped) instead of `UNSYNTHESIZABLE`. */
+const OBJECT_DEPTH_CAP = 3
+
+/**
+ * A minimal, JSON-clean leaf value for a single field's `TypeInfo`, used to
+ * populate a required object field (or an optional field's "present"
+ * variant). Recurses into nested objects up to `OBJECT_DEPTH_CAP`. Returns
+ * `UNSYNTHESIZABLE` for a type with no good default — see the sentinel's
+ * docstring.
+ */
+function leafValue(type: PropParamType, depth: number): unknown | typeof UNSYNTHESIZABLE {
+  if (type.kind === 'primitive') {
+    switch (type.primitive) {
+      case 'string':
+        return ''
+      case 'number':
+        return 0
+      case 'boolean':
+        return false
+      case 'null':
+      case 'undefined':
+        return null
+      default:
+        return UNSYNTHESIZABLE
+    }
+  }
+  if (type.kind === 'array') return []
+  if (type.kind === 'interface' && type.raw && baseTypeName(type.raw) === 'Date') {
+    return { $date: '1970-01-01T00:00:00.000Z' }
+  }
+  if (type.kind === 'union' && type.unionTypes) {
+    for (const member of type.unionTypes) {
+      if (!member.raw) continue
+      const parsed = parseLiteralRaw(member.raw)
+      if (parsed.ok) return parsed.value
+    }
+    return UNSYNTHESIZABLE
+  }
+  if ((type.kind === 'object' || type.kind === 'interface') && type.properties) {
+    if (depth >= OBJECT_DEPTH_CAP) return {}
+    return synthesizeMinimal(type.properties, depth + 1)
+  }
+  return UNSYNTHESIZABLE
+}
+
+/**
+ * Build the minimal object for a set of fields: every REQUIRED field gets a
+ * `leafValue`; optional fields are OMITTED (the "present" variant is added
+ * separately, one field at a time — see the `object:+<field>` points in
+ * `catalogValuesFor`). Returns `UNSYNTHESIZABLE` if any required field
+ * can't be synthesized, so the caller emits no object points at all rather
+ * than a half-valid value.
+ */
+function synthesizeMinimal(
+  properties: Array<{ name: string; type: PropParamType; optional: boolean }>,
+  depth: number,
+): Record<string, unknown> | typeof UNSYNTHESIZABLE {
+  const out: Record<string, unknown> = {}
+  for (const prop of properties) {
+    if (prop.optional) continue
+    const value = leafValue(prop.type, depth)
+    if (value === UNSYNTHESIZABLE) return UNSYNTHESIZABLE
+    out[prop.name] = value
+  }
+  return out
 }
 
 function catalogValuesFor(param: PropParam): CatalogValue[] {
@@ -131,6 +288,48 @@ function catalogValuesFor(param: PropParam): CatalogValue[] {
       { tag: 'leap-day', value: { $date: '2024-02-29T12:00:00.000Z' } },
       { tag: 'year-9999', value: { $date: '9999-12-31T23:59:59.999Z' } },
     )
+  } else if (param.type.kind === 'union' && param.type.unionTypes) {
+    // Catalogued rich type (#2277). Each parseable literal member (string /
+    // boolean / null / numeric) becomes its own point; a non-literal member
+    // (a bare `string`, an object arm, …) is skipped — it has no single
+    // value to synthesize, so it stays uncovered (v1 scope).
+    const parsed: Array<{ index: number; value: string | number | boolean | null }> = []
+    param.type.unionTypes.forEach((member, index) => {
+      if (!member.raw) return
+      const result = parseLiteralRaw(member.raw)
+      if (result.ok) parsed.push({ index, value: result.value })
+    })
+    // Wide-union cap: first 6 + last 6 by declared index (see
+    // UNION_MEMBER_CAP's docstring).
+    const sampled = parsed.length > UNION_MEMBER_CAP ? [...parsed.slice(0, 6), ...parsed.slice(-6)] : parsed
+    const usedTags = new Set<string>()
+    for (const { index, value } of sampled) {
+      let tag = unionMemberTag(value, index)
+      if (usedTags.has(tag)) tag = `${tag}-${index}` // defensive: keep tags unique within the param
+      usedTags.add(tag)
+      values.push({ tag: `union:${tag}`, value })
+    }
+  } else if (
+    (param.type.kind === 'object' || param.type.kind === 'interface') &&
+    param.type.properties &&
+    !(param.type.raw && baseTypeName(param.type.raw) === 'Date')
+  ) {
+    // Catalogued rich type (#2277). `synthesizeMinimal` builds the
+    // required-fields-only shape; each OPTIONAL field additionally gets a
+    // "present" variant (one field at a time — no cross-product). If the
+    // minimal shape itself can't be synthesized (a required field with no
+    // good default), emit nothing for this param rather than a half-valid
+    // object.
+    const minimal = synthesizeMinimal(param.type.properties, 0)
+    if (minimal !== UNSYNTHESIZABLE) {
+      values.push({ tag: 'object:minimal', value: minimal })
+      for (const prop of param.type.properties) {
+        if (!prop.optional) continue
+        const presentValue = leafValue(prop.type, 0)
+        if (presentValue === UNSYNTHESIZABLE) continue
+        values.push({ tag: `object:+${prop.name}`, value: { ...minimal, [prop.name]: presentValue } })
+      }
+    }
   }
   return values
 }

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 253,
+    "totalFixtures": 255,
     "fixtures": {
       "dangerous-inner-html-dynamic": {
         "blade": {
@@ -2101,6 +2101,16 @@
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2038"
           ]
+        }
+      },
+      "object-catalogued": {
+        "go-template": {
+          "kind": "render",
+          "reason": "inline object-prop member access renders empty (untyped Cfg field) — #2299"
+        },
+        "minijinja": {
+          "kind": "render",
+          "reason": "inline object-prop member access renders empty — #2299"
         }
       },
       "static-array-from-props": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -830,11 +830,11 @@
       }
     },
     "identifier": {
-      "total": 235,
+      "total": 237,
       "cells": {
         "hono": {
-          "pass": 234,
-          "total": 235,
+          "pass": 236,
+          "total": 237,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -845,8 +845,8 @@
           ]
         },
         "blade": {
-          "pass": 229,
-          "total": 235,
+          "pass": 231,
+          "total": 237,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -883,8 +883,8 @@
           ]
         },
         "erb": {
-          "pass": 230,
-          "total": 235,
+          "pass": 232,
+          "total": 237,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -919,8 +919,8 @@
           ]
         },
         "go-template": {
-          "pass": 229,
-          "total": 235,
+          "pass": 230,
+          "total": 237,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -947,6 +947,10 @@
               ]
             },
             {
+              "fixture": "object-catalogued",
+              "issues": []
+            },
+            {
               "fixture": "static-array-from-props",
               "issues": []
             },
@@ -957,8 +961,8 @@
           ]
         },
         "jinja": {
-          "pass": 229,
-          "total": 235,
+          "pass": 231,
+          "total": 237,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -999,8 +1003,8 @@
           ]
         },
         "minijinja": {
-          "pass": 229,
-          "total": 235,
+          "pass": 230,
+          "total": 237,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1027,6 +1031,10 @@
               ]
             },
             {
+              "fixture": "object-catalogued",
+              "issues": []
+            },
+            {
               "fixture": "static-array-from-props",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2087"
@@ -1041,8 +1049,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 230,
-          "total": 235,
+          "pass": 232,
+          "total": 237,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1073,8 +1081,8 @@
           ]
         },
         "twig": {
-          "pass": 229,
-          "total": 235,
+          "pass": 231,
+          "total": 237,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1111,8 +1119,8 @@
           ]
         },
         "xslate": {
-          "pass": 229,
-          "total": 235,
+          "pass": 231,
+          "total": 237,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1382,11 +1390,11 @@
       }
     },
     "member": {
-      "total": 117,
+      "total": 119,
       "cells": {
         "hono": {
-          "pass": 116,
-          "total": 117,
+          "pass": 118,
+          "total": 119,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1397,8 +1405,8 @@
           ]
         },
         "blade": {
-          "pass": 112,
-          "total": 117,
+          "pass": 114,
+          "total": 119,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1429,8 +1437,8 @@
           ]
         },
         "erb": {
-          "pass": 113,
-          "total": 117,
+          "pass": 115,
+          "total": 119,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1459,8 +1467,8 @@
           ]
         },
         "go-template": {
-          "pass": 112,
-          "total": 117,
+          "pass": 113,
+          "total": 119,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1481,6 +1489,10 @@
               ]
             },
             {
+              "fixture": "object-catalogued",
+              "issues": []
+            },
+            {
               "fixture": "static-array-from-props",
               "issues": []
             },
@@ -1491,8 +1503,8 @@
           ]
         },
         "jinja": {
-          "pass": 112,
-          "total": 117,
+          "pass": 114,
+          "total": 119,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1527,8 +1539,8 @@
           ]
         },
         "minijinja": {
-          "pass": 112,
-          "total": 117,
+          "pass": 113,
+          "total": 119,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1549,6 +1561,10 @@
               ]
             },
             {
+              "fixture": "object-catalogued",
+              "issues": []
+            },
+            {
               "fixture": "static-array-from-props",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2087"
@@ -1563,8 +1579,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 113,
-          "total": 117,
+          "pass": 115,
+          "total": 119,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1589,8 +1605,8 @@
           ]
         },
         "twig": {
-          "pass": 112,
-          "total": 117,
+          "pass": 114,
+          "total": 119,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1621,8 +1637,8 @@
           ]
         },
         "xslate": {
-          "pass": 112,
-          "total": 117,
+          "pass": 114,
+          "total": 119,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",


### PR DESCRIPTION
## Summary

Closes #2277 — the last documented v1 exclusion in `adversarial-catalog.ts`. Extends the type-derived adversarial catalogue past the scalar/array/Date table to **union-** and **object-typed** props.

- **Union**: each parseable literal member (string / boolean / null / numeric, read from `TypeInfo.unionTypes[].raw`) → one `gen:<prop>:union:<member>` point; first-6/last-6 sample above `UNION_MEMBER_CAP` (12).
- **Object / interface**: `synthesizeMinimal` builds a required-fields-only value from `TypeInfo.properties` (leaf scalars, nested objects to `OBJECT_DEPTH_CAP`, Date leaves as `{$date}` envelopes) → `object:minimal` + one `object:+<field>` "present" variant per optional field (one at a time). A required field with no good default drops the whole object (`UNSYNTHESIZABLE`) rather than emit a half-valid point. All values stay JSON-clean, so they round-trip `generated-data-points.json` and pass freshness.

## Fixtures (same PR — the #2276 change-time coupling rule)

- `union-catalogued` — `'top'|'right'|'bottom'` rendered directly in class + text.
- `object-catalogued` — `{ id: number; label?: string }`.

Both use `props: Type` (not destructured): `collectMemberTypes` degrades a destructured non-primitive member to `unknown`, so the full union/object `TypeInfo` only resolves down the props-object path (a separate, pre-existing gap noted in the fixture docstrings).

## Phase-B divergence triage (issue-prescribed skip discipline)

The new fixtures probed real, divergence-prone surfaces and found two — filed + pinned:

- **#2299** — `object-catalogued` renders **empty on the typed struct backends** (Go, Rust): an inline object prop gets no named struct, so `.cfg.id` doesn't resolve. Pinned as a render divergence on Go + Rust; the object-synthesis data points still run the oracle on **Hono + every dynamic backend** (Ruby/Python verified locally; PHP/Perl expected same and confirmed in CI).
- **#2300** — the class-composition surface the issue names (`placementClasses[union]`) fails to render on Go (a function-local const `Record` indexed by a union prop). Kept **out** of `union-catalogued` so it probes value synthesis cleanly on every adapter; recorded for a future fix.

## Verification (local)

- `generated-data-points.test.ts`: 15 pass (freshness + new union/object unit tests).
- `coverage-map.test.ts`: 5 pass (freshness + kind + array-method floors).
- Union renders clean on Go / ERB / Jinja / Hono; object passes the oracle on Hono / ERB / Jinja and is pinned on Go / Rust.
- Regenerated `coverage-map.json`, `generated-data-points.json`, `support-matrix.lock.json`, `compat.lock.json` (adapters rebuilt first so the lockfiles match CI).

Changeset: `@barefootjs/go-template` + `@barefootjs/rust` patch (the two render-divergence pins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1T4R1R6FKPGTFyYn1ppBa)_