### PR TITLE
Fix #2299: inline-object-typed prop member access renders empty on Go

### DIFF
--- a/.changeset/typed-object-member-access.md
+++ b/.changeset/typed-object-member-access.md
@@ -1,0 +1,14 @@
+---
+"@barefootjs/go-template": patch
+"@barefootjs/rust": patch
+---
+
+Fix #2299: an inline-object-typed prop's nested member access
+(`props.cfg.id` where `cfg: { id: number }`) now renders correctly on the
+typed struct backends instead of empty. The inline object type bakes as an
+untyped map (`map[string]interface{}` on Go), so an exact-case dot path
+(`.Cfg.ID`) missed the JS-cased map key. The Go adapter now routes such a
+chain through the case-tolerant `bf_get` runtime getter; Rust already
+rendered it correctly. The `object-catalogued` render divergence is removed
+from both adapters, so the object-synthesis data points now run the oracle
+comparison on every backend.

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -355,6 +355,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   private primeCompileState(ir: ComponentIR): void {
     this.state.propsObjectName = ir.metadata.propsObjectName
     this.state.restPropsName = ir.metadata.restPropsName ?? null
+    // Inline-object-typed props (`cfg: { id: number }`) bake as
+    // `map[string]interface{}`; `member()` routes a nested access on them
+    // through `bf_get` rather than an exact-case dot path (#2299).
+    this.state.objectTypedPropNames = new Set(
+      (ir.metadata.propsParams ?? [])
+        .filter(p => p.type.kind === 'object')
+        .map(p => p.name),
+    )
     this.state.moduleStringConsts = this.collectModuleStringConsts(ir.metadata.localConstants)
     this.state.localConstants = ir.metadata.localConstants ?? []
     // #2208 fable review: every name a `.map()`/`.filter()` loop callback
@@ -658,6 +666,25 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       return this.isMapRootedContextChain(node.object)
     }
     return false
+  }
+
+  /**
+   * True when `node` is a non-computed member chain rooted in an
+   * inline-object-typed prop (`props.cfg` where `cfg: { id: number }`, an
+   * `objectTypedPropNames` entry — #2299). Such a prop is a
+   * `map[string]interface{}` Input field, so a nested `.id` must go through
+   * the case-tolerant `bf_get` (like `isMapRootedContextChain`), not an
+   * exact-case dot path that would `MapIndex("ID")` a JS-cased-`"id"` map and
+   * render empty. Recurses: once map-rooted, every further hop reads off an
+   * `interface{}` value with no static struct, so it stays map-rooted.
+   */
+  private isMapRootedPropChain(node: ParsedExpr): boolean {
+    if (node.kind !== 'member' || node.computed) return false
+    const obj = node.object
+    if (obj.kind === 'identifier' && obj.name === this.state.propsObjectName) {
+      return this.state.objectTypedPropNames.has(node.property)
+    }
+    return this.isMapRootedPropChain(obj)
   }
 
   /** Go type for a context-consumer field, from its `createContext` default's type. */
@@ -3574,6 +3601,16 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // variant's docstring for the multi-hop caveat.
     if (optional) {
       return `bf_get ${wrapIfMultiToken(obj)} ${JSON.stringify(goFieldNameForKey(property))}`
+    }
+    // A plain member access rooted in an inline-object-typed prop
+    // (`props.cfg.id`, #2299) reads off a `map[string]interface{}` field:
+    // route through the case-tolerant `bf_get` with the JS-cased key (the map
+    // is baked with source-cased keys), not the exact-case `.Cfg.ID` dot path
+    // below that would `MapIndex("ID")` a `"id"` map and render empty. Placed
+    // after the `length`/`optional` special cases so it only intercepts the
+    // otherwise-untyped dot access.
+    if (this.isMapRootedPropChain(object)) {
+      return `bf_get ${wrapIfMultiToken(obj)} ${JSON.stringify(property)}`
     }
     return `${obj}.${goFieldNameForKey(property)}`
   }

--- a/packages/adapter-go-template/src/adapter/lib/compile-state.ts
+++ b/packages/adapter-go-template/src/adapter/lib/compile-state.ts
@@ -96,6 +96,16 @@ export class CompileState {
   contextConsumers: ContextConsumer[] = []
 
   /**
+   * Names of props whose type is an inline object literal (`cfg: { id:
+   * number }`) — they lower to a `map[string]interface{}` Input field
+   * (`typeInfoToGo`'s 'object' case), not a named struct, so a nested member
+   * access (`props.cfg.id`) must route through the case-tolerant `bf_get`
+   * runtime getter instead of an exact-case Go-template dot path (#2299). See
+   * `member()`'s `isMapRootedPropChain` branch.
+   */
+  objectTypedPropNames: Set<string> = new Set()
+
+  /**
    * Local binding names the request-scoped `searchParams()` env signal is
    * imported under (handles `import { searchParams as sp }`).
    */

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -17,14 +17,6 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
-  // `object-catalogued` (#2277): an inline object-typed prop (`cfg: { id:
-  // number; label?: string }`) doesn't synthesize a named Go struct, so the
-  // `Cfg` field is untyped and `.Cfg.Id` / `.Cfg.Label` render empty. The
-  // object-synthesis data points still run the oracle on the dynamic
-  // backends + Hono; graduating means giving an inline object prop a real
-  // struct so nested member access resolves.
-  // https://github.com/piconic-ai/barefootjs/issues/2299
-  'object-catalogued': 'inline object-prop member access renders empty (untyped Cfg field) — #2299',
   // `todo-app-ssr` no longer diverges (#2209). Two parts: (1) `.Todos`
   // (the loop's DATUM slice) is already seeded straight from the caller's
   // Input — the constructor derives it from `initialTodos`, and `[]Todo`

--- a/packages/adapter-rust/src/render-divergences.ts
+++ b/packages/adapter-rust/src/render-divergences.ts
@@ -17,12 +17,6 @@
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
-  // `object-catalogued` (#2277): same typed-backend gap as Go — an inline
-  // object-typed prop's nested member access (`props.cfg.id`) renders empty
-  // through the `bf-render` minijinja binary. The object-synthesis data
-  // points still run the oracle on the dynamic backends + Hono.
-  // https://github.com/piconic-ai/barefootjs/issues/2299
-  'object-catalogued': 'inline object-prop member access renders empty — #2299',
   // `todo-app` / `todo-app-ssr` no longer diverge (#2209) — the shared
   // `evaluateSignalInit` (`@barefootjs/jsx`, sandboxed real-JS evaluation
   // instead of a fixed regex-shape catalogue) now correctly seeds `todos`

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2103,16 +2103,6 @@
           ]
         }
       },
-      "object-catalogued": {
-        "go-template": {
-          "kind": "render",
-          "reason": "inline object-prop member access renders empty (untyped Cfg field) — #2299"
-        },
-        "minijinja": {
-          "kind": "render",
-          "reason": "inline object-prop member access renders empty — #2299"
-        }
-      },
       "static-array-from-props": {
         "blade": {
           "kind": "refusal",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -919,7 +919,7 @@
           ]
         },
         "go-template": {
-          "pass": 230,
+          "pass": 231,
           "total": 237,
           "gaps": [
             {
@@ -945,10 +945,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2038"
               ]
-            },
-            {
-              "fixture": "object-catalogued",
-              "issues": []
             },
             {
               "fixture": "static-array-from-props",
@@ -1003,7 +999,7 @@
           ]
         },
         "minijinja": {
-          "pass": 230,
+          "pass": 231,
           "total": 237,
           "gaps": [
             {
@@ -1029,10 +1025,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2038"
               ]
-            },
-            {
-              "fixture": "object-catalogued",
-              "issues": []
             },
             {
               "fixture": "static-array-from-props",
@@ -1467,7 +1459,7 @@
           ]
         },
         "go-template": {
-          "pass": 113,
+          "pass": 114,
           "total": 119,
           "gaps": [
             {
@@ -1487,10 +1479,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2038"
               ]
-            },
-            {
-              "fixture": "object-catalogued",
-              "issues": []
             },
             {
               "fixture": "static-array-from-props",
@@ -1539,7 +1527,7 @@
           ]
         },
         "minijinja": {
-          "pass": 113,
+          "pass": 114,
           "total": 119,
           "gaps": [
             {
@@ -1559,10 +1547,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2038"
               ]
-            },
-            {
-              "fixture": "object-catalogued",
-              "issues": []
             },
             {
               "fixture": "static-array-from-props",


### PR DESCRIPTION
## Summary

Fixes #2299. An inline-object-typed prop (`cfg: { id: number; label?: string }`) bakes as a `map[string]interface{}` Input field on Go — not a named struct — so an exact-case Go-template dot path (`.Cfg.ID`) missed the JS-cased map key `"id"` and `props.cfg.id` rendered empty. Rust already rendered it correctly through the `bf-render` minijinja binary.

## Changes

- **`go-template-adapter.ts`**: `member()` now recognises a non-computed member chain rooted in an inline-object-typed prop (`isMapRootedPropChain`, mirroring the existing `isMapRootedContextChain`) and routes it through the case-tolerant `bf_get` runtime getter with the JS-cased key. Placed after the `length`/`optional` special cases so it only intercepts the otherwise-untyped dot access.
- **`compile-state.ts`**: new `objectTypedPropNames` set, primed in `primeCompileState` from `propsParams` where `type.kind === 'object'` (inline object literal → map; a named `interface` stays a real struct and is unaffected).
- **`render-divergences.ts`** (go-template + rust): the `object-catalogued` (#2277) render divergence is removed from both adapters, so the object-synthesis data points now run the oracle comparison on every backend.
- **`ui/compat.lock.json` / `ui/support-matrix.lock.json`**: regenerated (go-template & minijinja each +1 pass).
- Changeset added (patch for both adapters — `render-divergences.ts` is published src).

## Verification

- go-template conformance: **1087 pass / 0 fail** (real Go on PATH, 552s)
- rust conformance: **834 pass / 0 fail** (freshly rebuilt `bf-render`)
- compat: **80 pass / 0 fail**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1T4R1R6FKPGTFyYn1ppBa)_