### PR TITLE
Fix #2300: bare class={record[key]} renders empty on typed/strict backends

### DIFF
--- a/.changeset/local-record-union-index.md
+++ b/.changeset/local-record-union-index.md
@@ -4,9 +4,10 @@
 
 Fix #2300: a bare `class={record[key]}` attribute — a local const `Record`
 indexed by a prop, written directly as the attribute value rather than inside
-a template literal — now renders on every backend. The analyzer lifts it into
-the same `lookup` IR part the `${record[key]}` template-literal form already
-produces, so it flows through the shared, already-working lookup path instead
+a template literal — now renders on every backend. The JSX→IR transform
+(`jsx-to-ir.ts`) lifts it into the same `lookup` IR part the `${record[key]}`
+template-literal form already produces, so it flows through the shared,
+already-working lookup path instead
 of a raw index access that the typed / strict backends (Go, minijinja, ERB,
 Jinja) mishandled for a function-local const — it is not a prop field, so
 those emitted an unpopulated `.Record` / nil lookup and the class rendered

--- a/.changeset/local-record-union-index.md
+++ b/.changeset/local-record-union-index.md
@@ -1,0 +1,15 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix #2300: a bare `class={record[key]}` attribute — a local const `Record`
+indexed by a prop, written directly as the attribute value rather than inside
+a template literal — now renders on every backend. The analyzer lifts it into
+the same `lookup` IR part the `${record[key]}` template-literal form already
+produces, so it flows through the shared, already-working lookup path instead
+of a raw index access that the typed / strict backends (Go, minijinja, ERB,
+Jinja) mishandled for a function-local const — it is not a prop field, so
+those emitted an unpopulated `.Record` / nil lookup and the class rendered
+empty (or, on ERB, raised). `record-index-lookup` (the template-literal form)
+already proved every adapter renders the `lookup` part correctly. Covered by
+the new `local-record-union-index` conformance fixture.

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -2101,6 +2101,16 @@
         "text"
       ]
     },
+    "local-record-union-index": {
+      "kinds": [
+        "literal",
+        "object-literal"
+      ],
+      "axes": [
+        "literal:string"
+      ],
+      "contexts": []
+    },
     "logical-and": {
       "kinds": [
         "call",
@@ -4098,10 +4108,10 @@
     "conditional": 18,
     "identifier": 237,
     "index-access": 12,
-    "literal": 194,
+    "literal": 195,
     "logical": 41,
     "member": 119,
-    "object-literal": 41,
+    "object-literal": 42,
     "template-literal": 27,
     "unary": 22,
     "unsupported": 21
@@ -4144,7 +4154,7 @@
     "literal:boolean": 37,
     "literal:null": 22,
     "literal:number": 85,
-    "literal:string": 138,
+    "literal:string": 139,
     "logical:&&": 7,
     "logical:??": 37,
     "logical:||": 12,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -163,6 +163,7 @@ import { fixture as staticArrayFromPropsWithComponent } from './static-array-fro
 import { fixture as booleanDynamicAttr } from './boolean-dynamic-attr'
 import { fixture as childComponentInit } from './child-component-init'
 import { fixture as reactivePropBinding } from './reactive-prop-binding'
+import { fixture as localRecordUnionIndex } from './local-record-union-index'
 import { fixture as recordIndexLookup } from './record-index-lookup'
 import { fixture as recordIndexLookupViaChildProp } from './record-index-lookup-via-child-prop'
 // Priority 9: Provider / Async (IR-kind coverage, #1252 Phase 0)
@@ -506,6 +507,7 @@ export const jsxFixtures: JSXFixture[] = [
   booleanDynamicAttr,
   childComponentInit,
   reactivePropBinding,
+  localRecordUnionIndex,
   recordIndexLookup,
   recordIndexLookupViaChildProp,
   // Priority 9: Provider / Async (IR-kind coverage, #1252 Phase 0)

--- a/packages/adapter-tests/fixtures/local-record-union-index.ts
+++ b/packages/adapter-tests/fixtures/local-record-union-index.ts
@@ -1,0 +1,41 @@
+import { createFixture } from '../src/types'
+
+// #2300: a FUNCTION-LOCAL const `Record` indexed by a union-typed prop,
+// used directly as an element's class value (not inside a template literal,
+// and keyed by an object-style `props.placement` rather than a destructured
+// binding). This is the class-composition surface the #2277
+// `union-catalogued` fixture deliberately left out of scope (it kept to a
+// direct `class={props.placement}` render to probe union value synthesis
+// cleanly).
+//
+// On the typed struct backend (Go) this used to fail: the adapter lowered
+// `placementClasses[props.placement]` to `{{index .PlacementClasses .Placement}}`
+// but never declared or populated a `PlacementClasses` field — the
+// function-local const `Record` is not a prop, and the string-typed
+// derived-const path skips a non-string (object-literal) value — so Go raised
+// `can't evaluate field PlacementClasses in type PlacementUnionProps`. The
+// fix bakes the const `Record` as a populated `map[string]string` field so the
+// `index` lookup resolves. The `dataPoints` exercise every union arm so the
+// oracle comparison covers each key of the map.
+export const fixture = createFixture({
+  id: 'local-record-union-index',
+  description: 'Function-local const Record indexed by a union prop, used as a class value',
+  source: `
+export function PlacementUnion(props: { placement: 'top' | 'right' | 'bottom' }) {
+  const placementClasses: Record<'top' | 'right' | 'bottom', string> = {
+    top: 'placement-top',
+    right: 'placement-right',
+    bottom: 'placement-bottom',
+  }
+  return <div className={placementClasses[props.placement]}>hi</div>
+}
+`,
+  props: { placement: 'top' },
+  expectedHtml: `
+    <div bf-s="test" bf="s0" class="placement-top">hi</div>
+  `,
+  dataPoints: [
+    { name: 'placement-right', props: { placement: 'right' } },
+    { name: 'placement-bottom', props: { placement: 'bottom' } },
+  ],
+})

--- a/packages/adapter-tests/fixtures/local-record-union-index.ts
+++ b/packages/adapter-tests/fixtures/local-record-union-index.ts
@@ -1,22 +1,22 @@
 import { createFixture } from '../src/types'
 
 // #2300: a FUNCTION-LOCAL const `Record` indexed by a union-typed prop,
-// used directly as an element's class value (not inside a template literal,
-// and keyed by an object-style `props.placement` rather than a destructured
-// binding). This is the class-composition surface the #2277
-// `union-catalogued` fixture deliberately left out of scope (it kept to a
+// used directly as an element's class value — a BARE `class={record[key]}`,
+// not wrapped in a template literal. This is the class-composition surface the
+// #2277 `union-catalogued` fixture deliberately left out of scope (it kept to a
 // direct `class={props.placement}` render to probe union value synthesis
 // cleanly).
 //
-// On the typed struct backend (Go) this used to fail: the adapter lowered
-// `placementClasses[props.placement]` to `{{index .PlacementClasses .Placement}}`
-// but never declared or populated a `PlacementClasses` field — the
-// function-local const `Record` is not a prop, and the string-typed
-// derived-const path skips a non-string (object-literal) value — so Go raised
-// `can't evaluate field PlacementClasses in type PlacementUnionProps`. The
-// fix bakes the const `Record` as a populated `map[string]string` field so the
-// `index` lookup resolves. The `dataPoints` exercise every union arm so the
-// oracle comparison covers each key of the map.
+// This used to render empty (or error) on the typed / strict backends (Go,
+// minijinja, ERB, Jinja): the analyzer left the bare form as a raw index
+// access, which those backends treated as a prop-field reference to a field
+// that was never declared (Go raised `can't evaluate field PlacementClasses`).
+// The `${record[key]}` template-literal form already lifts into a structured
+// `lookup` IR part every adapter renders correctly; the fix routes the bare
+// form through that same path, so `class={record[key]}` and
+// `class={`${record[key]}`}` compile identically on every backend (on Go the
+// `lookup` renders as a case chain over the union arms). The `dataPoints`
+// exercise every union arm so the oracle comparison covers each case.
 export const fixture = createFixture({
   id: 'local-record-union-index',
   description: 'Function-local const Record indexed by a union prop, used as a class value',

--- a/packages/jsx/src/__tests__/hydrate-template.test.ts
+++ b/packages/jsx/src/__tests__/hydrate-template.test.ts
@@ -201,13 +201,18 @@ describe('hydrate() template generation for signal-bearing components', () => {
     // Icon is used as a child → gets CSR fallback with template
     expect(content).toMatch(/hydrate\('Icon',.*template:/)
 
-    // String literals 'size-4', 'size-6', 'size-8' must NOT be corrupted
-    // by the constant `size` being inlined into them
-    expect(content).toContain("'size-4'")
-    expect(content).toContain("'size-6'")
-    expect(content).toContain("'size-8'")
+    // String literals size-4/6/8 must NOT be corrupted by the constant `size`
+    // being inlined into them. A bare `class={sizeClasses[size]}` is now lifted
+    // into the same `lookup` part the `${sizeClasses[size]}` template-literal
+    // form produces (#2300), so the record inlines as a JSON-serialized object
+    // (`{"sm": "size-4", …}[size]`) with double-quoted values — the literals
+    // stay intact, which is exactly what this guard checks.
+    expect(content).toContain('"size-4"')
+    expect(content).toContain('"size-6"')
+    expect(content).toContain('"size-8"')
     // The word 'size' inside 'size-4' should not be replaced with the constant value
     expect(content).not.toMatch(/'\(props\.size/)
+    expect(content).not.toMatch(/"\(props\.size/)
   })
 
   test('block-body memo with local decls: wraps body in IIFE instead of dropping decls', () => {

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -4618,6 +4618,35 @@ function getAttributeValue(attr: ts.JsxAttribute, ctx: TransformContext): AttrVa
       }
     }
 
+    // Bare `class={record[key]}` (#2300): an element access whose base is a
+    // local const object-literal `Record` indexed by a prop, written directly
+    // as the attribute value rather than inside a template literal. Lift it
+    // into the SAME `lookup` part the `${record[key]}` template-literal form
+    // produces (`tryResolveTemplateSpanFromConst` handles both), so every
+    // adapter renders it through the shared, already-working lookup path
+    // instead of a raw index-access that the typed / strict backends (Go,
+    // minijinja, ERB, Jinja) mishandle for a function-local const — it is not
+    // a prop field, so those emit an unpopulated `.Record`/nil lookup and the
+    // class renders empty (or errors). `tryResolveTemplateSpanFromConst`
+    // returns null for anything but the `IDENT[KEY]` → all-string-`Record`
+    // shape, so any other element access falls through to the bare-expression
+    // path unchanged.
+    // Only a DYNAMIC key qualifies (a prop reference, the #2300 shape). A
+    // static string / numeric literal key (`paths['icon']`) stays on the
+    // bare-expression path — the adapters already resolve a constant-key index,
+    // and it must remain a plain `expression` attr (jsx-to-ir regression pin),
+    // not a single-case `lookup`.
+    if (
+      ts.isElementAccessExpression(expr) &&
+      !ts.isStringLiteralLike(expr.argumentExpression) &&
+      !ts.isNumericLiteral(expr.argumentExpression)
+    ) {
+      const parts = tryResolveTemplateSpanFromConst(expr, ctx)
+      if (parts) {
+        return AttrValueOf.template(parts)
+      }
+    }
+
     // `className={classes}` where `classes` is a local const bound to
     // a template literal — resolve the template literal here and let
     // adapters render the structured form. This is the cva-style

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -4618,16 +4618,18 @@ function getAttributeValue(attr: ts.JsxAttribute, ctx: TransformContext): AttrVa
       }
     }
 
-    // Bare `class={record[key]}` (#2300): an element access whose base is a
+    // Bare `attr={record[key]}` (#2300): an element access whose base is a
     // local const object-literal `Record` indexed by a prop, written directly
-    // as the attribute value rather than inside a template literal. Lift it
+    // as ANY string-attribute value rather than inside a template literal
+    // (`class={record[key]}` is the motivating class-composition case, but this
+    // is attribute-agnostic — it fires for any qualifying attribute). Lift it
     // into the SAME `lookup` part the `${record[key]}` template-literal form
     // produces (`tryResolveTemplateSpanFromConst` handles both), so every
     // adapter renders it through the shared, already-working lookup path
     // instead of a raw index-access that the typed / strict backends (Go,
     // minijinja, ERB, Jinja) mishandle for a function-local const — it is not
     // a prop field, so those emit an unpopulated `.Record`/nil lookup and the
-    // class renders empty (or errors). `tryResolveTemplateSpanFromConst`
+    // value renders empty (or errors). `tryResolveTemplateSpanFromConst`
     // returns null for anything but the `IDENT[KEY]` → all-string-`Record`
     // shape, so any other element access falls through to the bare-expression
     // path unchanged.

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 255,
+    "totalFixtures": 256,
     "fixtures": {
       "dangerous-inner-html-dynamic": {
         "blade": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1192,15 +1192,15 @@
       }
     },
     "literal": {
-      "total": 194,
+      "total": 195,
       "cells": {
         "hono": {
-          "pass": 194,
-          "total": 194
+          "pass": 195,
+          "total": 195
         },
         "blade": {
-          "pass": 193,
-          "total": 194,
+          "pass": 194,
+          "total": 195,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1209,8 +1209,8 @@
           ]
         },
         "erb": {
-          "pass": 193,
-          "total": 194,
+          "pass": 194,
+          "total": 195,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1221,8 +1221,8 @@
           ]
         },
         "go-template": {
-          "pass": 193,
-          "total": 194,
+          "pass": 194,
+          "total": 195,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1231,8 +1231,8 @@
           ]
         },
         "jinja": {
-          "pass": 193,
-          "total": 194,
+          "pass": 194,
+          "total": 195,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1243,8 +1243,8 @@
           ]
         },
         "minijinja": {
-          "pass": 193,
-          "total": 194,
+          "pass": 194,
+          "total": 195,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1255,8 +1255,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 193,
-          "total": 194,
+          "pass": 194,
+          "total": 195,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1265,8 +1265,8 @@
           ]
         },
         "twig": {
-          "pass": 193,
-          "total": 194,
+          "pass": 194,
+          "total": 195,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1275,8 +1275,8 @@
           ]
         },
         "xslate": {
-          "pass": 193,
-          "total": 194,
+          "pass": 194,
+          "total": 195,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1655,15 +1655,15 @@
       }
     },
     "object-literal": {
-      "total": 41,
+      "total": 42,
       "cells": {
         "hono": {
-          "pass": 41,
-          "total": 41
+          "pass": 42,
+          "total": 42
         },
         "blade": {
-          "pass": 39,
-          "total": 41,
+          "pass": 40,
+          "total": 42,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1678,8 +1678,8 @@
           ]
         },
         "erb": {
-          "pass": 39,
-          "total": 41,
+          "pass": 40,
+          "total": 42,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1696,8 +1696,8 @@
           ]
         },
         "go-template": {
-          "pass": 39,
-          "total": 41,
+          "pass": 40,
+          "total": 42,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1712,8 +1712,8 @@
           ]
         },
         "jinja": {
-          "pass": 39,
-          "total": 41,
+          "pass": 40,
+          "total": 42,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1730,8 +1730,8 @@
           ]
         },
         "minijinja": {
-          "pass": 39,
-          "total": 41,
+          "pass": 40,
+          "total": 42,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1748,8 +1748,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 39,
-          "total": 41,
+          "pass": 40,
+          "total": 42,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1764,8 +1764,8 @@
           ]
         },
         "twig": {
-          "pass": 39,
-          "total": 41,
+          "pass": 40,
+          "total": 42,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1780,8 +1780,8 @@
           ]
         },
         "xslate": {
-          "pass": 39,
-          "total": 41,
+          "pass": 40,
+          "total": 42,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -3775,15 +3775,15 @@
       }
     },
     "literal:string": {
-      "total": 138,
+      "total": 139,
       "cells": {
         "hono": {
-          "pass": 138,
-          "total": 138
+          "pass": 139,
+          "total": 139
         },
         "blade": {
-          "pass": 137,
-          "total": 138,
+          "pass": 138,
+          "total": 139,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3792,8 +3792,8 @@
           ]
         },
         "erb": {
-          "pass": 137,
-          "total": 138,
+          "pass": 138,
+          "total": 139,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3804,8 +3804,8 @@
           ]
         },
         "go-template": {
-          "pass": 137,
-          "total": 138,
+          "pass": 138,
+          "total": 139,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3814,8 +3814,8 @@
           ]
         },
         "jinja": {
-          "pass": 137,
-          "total": 138,
+          "pass": 138,
+          "total": 139,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3826,8 +3826,8 @@
           ]
         },
         "minijinja": {
-          "pass": 137,
-          "total": 138,
+          "pass": 138,
+          "total": 139,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3838,8 +3838,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 137,
-          "total": 138,
+          "pass": 138,
+          "total": 139,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3848,8 +3848,8 @@
           ]
         },
         "twig": {
-          "pass": 137,
-          "total": 138,
+          "pass": 138,
+          "total": 139,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3858,8 +3858,8 @@
           ]
         },
         "xslate": {
-          "pass": 137,
-          "total": 138,
+          "pass": 138,
+          "total": 139,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",


### PR DESCRIPTION
## Summary

Fixes #2300. **Stacked on #2304 (#2299)** — base is `claude/typed-object-member-access-2299`; review/merge that first.

A bare `class={placementClasses[props.placement]}` — a local const `Record` indexed by a prop, written directly as the attribute value rather than inside a template literal — rendered **empty** (or errored) on the typed / strict backends. Discovered while building this fixture: the gap affects **Go, minijinja (Rust), ERB, and Jinja**; `blade`/`twig`/`xslate`/`mojolicious`/`hono` already handled it.

## Root cause & fix

The `${record[key]}` **template-literal** form already lifts into a structured `lookup` IR part that every adapter renders correctly (`record-index-lookup` proves it). The **bare** form was left as a raw `index-access` expression, which the typed backends treated as a prop-field reference (`.PlacementClasses`) — an unpopulated/nil lookup → empty class (Go raised `can't evaluate field`).

The fix is a single shared-layer change in `packages/jsx/src/jsx-to-ir.ts`: a **dynamic-key** element access whose base resolves to an all-string const `Record` is lifted into the same `lookup` part, so `class={record[key]}` and `` class={`${record[key]}`} `` now compile identically on every backend. A **static** string/numeric literal key (`paths['icon']`) is deliberately left on the bare-expression path (jsx-to-ir regression pin).

No adapter code changes and no render divergences — one fix, all nine backends correct.

## Changes

- **`packages/jsx/src/jsx-to-ir.ts`**: lift bare dynamic-key const-`Record` index → `lookup` part.
- **`packages/adapter-tests/fixtures/local-record-union-index.ts`** (new) + registration: covers every union arm via `dataPoints`.
- **`hydrate-template.test.ts` / `jsx-to-ir.test.ts`**: regression pins updated for the unified lowering (the bare form now emits the same inlined `lookup` client JS the template-literal form always did; static-key stays an `expression`).
- **coverage-map.json / compat.lock.json / support-matrix.lock.json**: regenerated (fixture passes on all 9 adapters, +1 pass each, no divergence).
- Changeset (`@barefootjs/jsx` patch).

## Verification

- jsx compiler unit tests: **2523 pass / 0 fail**
- adapter-tests (Hono + CSR conformance + coverage/data-point freshness): green
- Fixture renders correctly on all 9 adapters (go, rust, blade, erb, jinja, mojolicious, twig, xslate, hono)
- Go full conformance: pass
- compat: 558 ok / 0 diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1T4R1R6FKPGTFyYn1ppBa)_