### PR TITLE
Fix #2305: declare BarefootJS runtime version floor in backend cpanfiles

### DIFF
--- a/.changeset/perl-backend-runtime-floor.md
+++ b/.changeset/perl-backend-runtime-floor.md
@@ -1,0 +1,14 @@
+---
+"@barefootjs/xslate": patch
+"@barefootjs/mojolicious": patch
+---
+
+Fix #2305: the Xslate and Mojolicious CPAN dists declared `requires
+'BarefootJS'` without a version floor (Xslate) or with a stale one
+(Mojolicious, 0.15.0), so CPAN testers with an older BarefootJS runtime
+failed at render time with `Can't locate object method "scope_comment_end"`
+(added in 0.21.0). Both cpanfiles now require BarefootJS 0.21.0, and
+`scripts/sync-perl-versions.ts` bumps the floor to the dist's own version on
+every release — the Perl dists ship from one fixed changeset group, so the
+same-version floor always exists on CPAN and the declaration can never fall
+behind the runtime methods that generated templates call.

--- a/packages/adapter-mojolicious/cpanfile
+++ b/packages/adapter-mojolicious/cpanfile
@@ -1,8 +1,7 @@
 requires 'perl', '5.020';
-# Floor kept in lockstep with this dist's own version by
-# scripts/sync-perl-versions.ts — templates compiled by @barefootjs/mojolicious
-# call same-release BarefootJS runtime methods (e.g. scope_comment_end,
-# added in 0.21.0), so an older installed BarefootJS fails at render time.
+# Not hand-maintained: scripts/sync-perl-versions.ts pins this to the dist's
+# own release. A looser floor breaks at render time — generated templates
+# call same-release BarefootJS runtime methods.
 requires 'BarefootJS', '0.21.0';
 requires 'Mojolicious', '9.0';
 

--- a/packages/adapter-mojolicious/cpanfile
+++ b/packages/adapter-mojolicious/cpanfile
@@ -1,5 +1,9 @@
 requires 'perl', '5.020';
-requires 'BarefootJS', '0.15.0';
+# Floor kept in lockstep with this dist's own version by
+# scripts/sync-perl-versions.ts — templates compiled by @barefootjs/mojolicious
+# call same-release BarefootJS runtime methods (e.g. scope_comment_end,
+# added in 0.21.0), so an older installed BarefootJS fails at render time.
+requires 'BarefootJS', '0.21.0';
 requires 'Mojolicious', '9.0';
 
 on 'test' => sub {

--- a/packages/adapter-xslate/cpanfile
+++ b/packages/adapter-xslate/cpanfile
@@ -1,8 +1,7 @@
 requires 'perl', '5.020';
-# Floor kept in lockstep with this dist's own version by
-# scripts/sync-perl-versions.ts — templates compiled by @barefootjs/xslate
-# call same-release BarefootJS runtime methods (e.g. scope_comment_end,
-# added in 0.21.0), so an older installed BarefootJS fails at render time.
+# Not hand-maintained: scripts/sync-perl-versions.ts pins this to the dist's
+# own release. A looser floor breaks at render time — generated templates
+# call same-release BarefootJS runtime methods.
 requires 'BarefootJS', '0.21.0';
 requires 'Text::Xslate', '3.4.0';
 # JSON::PP is a core module (default encoder).

--- a/packages/adapter-xslate/cpanfile
+++ b/packages/adapter-xslate/cpanfile
@@ -1,5 +1,9 @@
 requires 'perl', '5.020';
-requires 'BarefootJS';
+# Floor kept in lockstep with this dist's own version by
+# scripts/sync-perl-versions.ts — templates compiled by @barefootjs/xslate
+# call same-release BarefootJS runtime methods (e.g. scope_comment_end,
+# added in 0.21.0), so an older installed BarefootJS fails at render time.
+requires 'BarefootJS', '0.21.0';
 requires 'Text::Xslate', '3.4.0';
 # JSON::PP is a core module (default encoder).
 

--- a/scripts/sync-perl-versions.ts
+++ b/scripts/sync-perl-versions.ts
@@ -10,6 +10,14 @@
 //   2. Update `our $VERSION` in every Perl module listed under `modules`.
 //   3. Insert the versioned entry immediately after {{$NEXT}} in Changes,
 //      keeping the placeholder in place for the next release cycle.
+//   4. Bump the version floor of each cpanfile dependency listed under
+//      `cpanfileRequires` to the same release. The backend dists render
+//      templates that call same-release BarefootJS runtime methods, so an
+//      unversioned (or stale) `requires 'BarefootJS'` lets CPAN install
+//      against an older runtime that lacks them — see #2305, where
+//      BarefootJS-Backend-Xslate 0.21.0 failed on testers with a BarefootJS
+//      that predated scope_comment_end. All Perl dists ship from one fixed
+//      changeset group, so the same-version floor always exists on CPAN.
 
 import { readFileSync, writeFileSync } from 'fs';
 import { fileURLToPath } from 'url';
@@ -17,7 +25,14 @@ import { join } from 'path';
 
 const ROOT = fileURLToPath(new URL('..', import.meta.url));
 
-const PACKAGES = [
+interface PerlPackage {
+  dir: string;
+  modules: string[];
+  /** cpanfile deps whose version floor tracks this dist's own release. */
+  cpanfileRequires?: string[];
+}
+
+const PACKAGES: PerlPackage[] = [
   {
     dir: 'packages/adapter-perl',
     modules: [
@@ -32,12 +47,14 @@ const PACKAGES = [
       'lib/BarefootJS/Backend/Mojo.pm',
       'lib/Mojolicious/Plugin/BarefootJS/DevReload.pm',
     ],
+    cpanfileRequires: ['BarefootJS'],
   },
   {
     dir: 'packages/adapter-xslate',
     modules: [
       'lib/BarefootJS/Backend/Xslate.pm',
     ],
+    cpanfileRequires: ['BarefootJS'],
   },
 ];
 
@@ -72,6 +89,24 @@ for (const pkg of PACKAGES) {
       writeFileSync(modulePath, updated);
       console.log(`Updated $VERSION → ${version} in ${mod}`);
     }
+  }
+
+  // Keep cpanfile dependency floors in lockstep with the release, so a dist
+  // can never declare a BarefootJS older than the runtime methods its
+  // generated templates call (#2305).
+  if (pkg.cpanfileRequires?.length) {
+    const cpanfilePath = join(pkgDir, 'cpanfile');
+    let cpanfile = readFileSync(cpanfilePath, 'utf8');
+    for (const dep of pkg.cpanfileRequires) {
+      const pattern = new RegExp(`^requires '${dep}'.*;$`, 'm');
+      if (!pattern.test(cpanfile)) {
+        console.warn(`[warn] requires '${dep}' not found in ${pkg.dir}/cpanfile — skipping`);
+        continue;
+      }
+      cpanfile = cpanfile.replace(pattern, `requires '${dep}', '${version}';`);
+      console.log(`Updated cpanfile requires ${dep} → ${version} in ${pkg.dir}`);
+    }
+    writeFileSync(cpanfilePath, cpanfile);
   }
 
   // Insert the versioned entry immediately after {{$NEXT}}, keeping the

--- a/scripts/sync-perl-versions.ts
+++ b/scripts/sync-perl-versions.ts
@@ -10,14 +10,10 @@
 //   2. Update `our $VERSION` in every Perl module listed under `modules`.
 //   3. Insert the versioned entry immediately after {{$NEXT}} in Changes,
 //      keeping the placeholder in place for the next release cycle.
-//   4. Bump the version floor of each cpanfile dependency listed under
-//      `cpanfileRequires` to the same release. The backend dists render
-//      templates that call same-release BarefootJS runtime methods, so an
-//      unversioned (or stale) `requires 'BarefootJS'` lets CPAN install
-//      against an older runtime that lacks them — see #2305, where
-//      BarefootJS-Backend-Xslate 0.21.0 failed on testers with a BarefootJS
-//      that predated scope_comment_end. All Perl dists ship from one fixed
-//      changeset group, so the same-version floor always exists on CPAN.
+//   4. Pin each cpanfile dependency listed under `cpanfileRequires` to the
+//      same release. Never loosen this: generated templates call
+//      same-release BarefootJS runtime methods (#2305), and the fixed
+//      changeset group guarantees the same-version dist exists on CPAN.
 
 import { readFileSync, writeFileSync } from 'fs';
 import { fileURLToPath } from 'url';
@@ -91,9 +87,7 @@ for (const pkg of PACKAGES) {
     }
   }
 
-  // Keep cpanfile dependency floors in lockstep with the release, so a dist
-  // can never declare a BarefootJS older than the runtime methods its
-  // generated templates call (#2305).
+  // Pin cpanfile dependency floors to this release (step 4 above).
   if (pkg.cpanfileRequires?.length) {
     const cpanfilePath = join(pkgDir, 'cpanfile');
     let cpanfile = readFileSync(cpanfilePath, 'utf8');


### PR DESCRIPTION
Fixes #2305.

## Problem

BarefootJS-Backend-Xslate 0.21.0 failed on CPAN testers ([report](https://www.cpantesters.org/cpan/report/12279dc8-8150-11f1-a7ab-ef5e4d21b42f)) with:

```
Can't locate object method "scope_comment_end" via package "BarefootJS"
```

`t/render.t` — like any template compiled by the 0.21.0 Xslate adapter — calls `$bf.scope_comment_end()`, which was added to the BarefootJS Perl runtime in 0.21.0 (ea50cdc, #2289). But the dist's cpanfile declared `requires 'BarefootJS';` with **no version floor**, so testers with an older BarefootJS already installed never upgraded and hit the missing method at render time — exactly the "insufficient dependency declaration" the issue suspected.

The Mojolicious backend has the same latent bug: its floor was a stale `0.15.0` while its `t/scope_comment.t` also calls `scope_comment_end`.

## Fix

- `packages/adapter-xslate/cpanfile`, `packages/adapter-mojolicious/cpanfile`: require `BarefootJS` `0.21.0` (the release that introduced `scope_comment_end`).
- `scripts/sync-perl-versions.ts`: new `cpanfileRequires` config — on every release the script now bumps the declared floor to the dist's own version, alongside the existing `$VERSION`/`Changes` sync. Since all Perl dists ship from one fixed changeset group, the same-version floor always exists on CPAN, and the declaration can never fall behind the runtime methods that generated templates call — preventing this class of failure from recurring.
- Changeset (patch for `@barefootjs/xslate` and `@barefootjs/mojolicious`) so the corrected metadata ships to CPAN in the next release.

## Verification

Simulated a release locally (bumped the three package.json versions to 0.21.1 and ran `bun scripts/sync-perl-versions.ts`): both cpanfiles' `requires 'BarefootJS'` lines were rewritten to `0.21.1` along with the usual `$VERSION`/`Changes` updates, then reverted the simulation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5JULTb2GSoAbZ7drKdtyv

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5JULTb2GSoAbZ7drKdtyv)_