### PR TITLE
Fix #2302: fragment child's own slots and a parent's collision-numbered slots both fail to resolve

### DIFF
--- a/.changeset/fragment-nested-slot-resolution.md
+++ b/.changeset/fragment-nested-slot-resolution.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/client": patch
+---
+
+Fix #2302 (a gap left by the #2289/#2293 fix): a fragment-rooted child component's own `$`/`$t` queries failed to resolve any slot nested inside one of the fragment's top-level siblings (e.g. `<header><select>`), because `find()`'s comment-scope acceptance check rejected any candidate with a `bf-s`-attributed ancestor — which every fragment child mounted inside a normal parent island always has. Separately, a *parent's* own slot search could wrongly claim a descendant that actually belonged to a nested fragment child's coincidentally same-numbered slot (e.g. a parent's `bf="s5"` collapse button vs. the fragment child's own unrelated `bf="s5"` element), because `belongsToScope()`'s `.closest('[bf-s]')` walk has no element to stop at for a fragment child's comment-anchored scope. Both are now resolved by bounding the search to the actual `<!--bf-scope:...-->` … `<!--bf-/scope:...-->` sibling range instead of relying on `.closest('[bf-s]')` alone.

--- a/packages/client/__tests__/runtime/fragment-child-init.test.ts
+++ b/packages/client/__tests__/runtime/fragment-child-init.test.ts
@@ -31,6 +31,25 @@ function mountParentWithFragmentChild(parentId: string): void {
     '</div>'
 }
 
+/**
+ * Same shape as `mountParentWithFragmentChild`, but the child's `bf="s1"`
+ * slot sits one level inside the fragment's first top-level sibling (e.g.
+ * `<header><button>` instead of a bare top-level `<button>`) — mirrors
+ * piconic-ai/sora's `AppHeader` component (#2302), where every internal
+ * slot is nested inside `<header>`/`<div popover>` rather than being a
+ * direct child of the fragment itself.
+ */
+function mountParentWithNestedFragmentChild(parentId: string): void {
+  document.body.innerHTML =
+    `<div bf-s="${parentId}" bf-r="">` +
+    '<span bf="s1"><!--bf:s0-->0<!--/--></span>' +
+    `<!--bf-scope:${parentId}_s2|h=${parentId}|m=s2|{"label":"add"}-->` +
+    '<header><button bf="s1"><!--bf:s0-->add<!--/--></button></header>' +
+    '<p>hint</p>' +
+    `<!--bf-/scope:${parentId}_s2-->` +
+    '</div>'
+}
+
 describe('fragment-rooted child hydration (#2289)', () => {
   beforeEach(() => {
     document.body.innerHTML = ''
@@ -105,6 +124,127 @@ describe('fragment-rooted child hydration (#2289)', () => {
     expect(document.querySelector('span')!.textContent).toContain('1')
     // Getter prop is live: the child's text effect re-ran with the new value.
     expect(button.textContent).toContain('add:1')
+  })
+
+  test('$ resolves a slot nested inside one of the fragment child\'s top-level siblings (#2302)', async () => {
+    const { $, $c } = await import('../../src/runtime/query.ts')
+
+    mountParentWithNestedFragmentChild('ParentNest_abc')
+    const parentScope = document.querySelector('[bf-s="ParentNest_abc"]')!
+
+    const [child] = $c(parentScope, 's2')
+    expect(child).not.toBeNull()
+    expect(child!.tagName).toBe('HEADER')
+
+    // Before the #2302 fix, `.closest('[bf-s]')` from the nested <button>
+    // always found the parent island's own bf-s element and rejected the
+    // candidate, so this returned null — no listener was ever attached.
+    const [slot] = $(child!, 's1')
+    expect(slot).not.toBeNull()
+    expect(slot!.tagName).toBe('BUTTON')
+  })
+
+  test('callback prop reaches a slot nested inside the fragment child (#2302)', async () => {
+    const { hydrate, flushHydration } = await import('../../src/runtime/hydrate.ts')
+    const { initChild } = await import('../../src/runtime/registry.ts')
+    const { $, $t, $c } = await import('../../src/runtime/query.ts')
+    const { createSignal, createEffect } = await import('../../src/reactive.ts')
+    const { __bfText } = await import('../../src/runtime/index.ts')
+
+    mountParentWithNestedFragmentChild('ParentNest_abc')
+
+    // ChildFragNest.client.js (compiled shape): slot is one level inside
+    // the fragment's <header>, mirroring AppHeader's <header><select>/
+    // <header><button> nesting.
+    function initChildFragNest(__scope: Element, _p: Record<string, unknown> = {}) {
+      if (!__scope) return
+      const [_s1] = $(__scope, 's1')
+      const [_s0] = $t(__scope, 's0')
+      let __anchor_s0: Text | null = _s0 as Text | null
+      createEffect(() => {
+        __anchor_s0 = __bfText(__anchor_s0, (_p as { label?: unknown }).label) as Text | null
+      })
+      if (_s1) _s1.addEventListener('click', () => (_p as { onClick: () => void }).onClick())
+    }
+    hydrate('ChildFragNest', {
+      init: initChildFragNest,
+      template: (_p) => `<header><button bf="s1"><!--bf:s0-->${_p.label}<!--/--></button></header><p>hint</p>`,
+      comment: true,
+    })
+
+    function initParentNest(__scope: Element) {
+      if (!__scope) return
+      const [count, setCount] = createSignal(0)
+      const [_s0] = $t(__scope, 's0')
+      const [_s2] = $c(__scope, 's2')
+      let __anchor_s0: Text | null = _s0 as Text | null
+      createEffect(() => {
+        __anchor_s0 = __bfText(__anchor_s0, count()) as Text | null
+      })
+      initChild('ChildFragNest', _s2, {
+        get label() { return `add:${count()}` },
+        onClick: () => setCount((c: number) => c + 1),
+      })
+    }
+    hydrate('ParentNest', { init: initParentNest, template: () => '<div></div>' })
+
+    flushHydration()
+
+    const button = document.querySelector('button')!
+    button.click()
+
+    // Before the #2302 fix, `_s1` above resolved to null, so no listener
+    // was ever attached — this click would silently do nothing.
+    expect(document.querySelector('span')!.textContent).toContain('1')
+    expect(button.textContent).toContain('add:1')
+  })
+
+  test("a parent's own slot search doesn't reach into a nested fragment child's coincidentally-numbered slot (#2302)", async () => {
+    const { hydrate, flushHydration } = await import('../../src/runtime/hydrate.ts')
+    const { $, $c } = await import('../../src/runtime/query.ts')
+    const { createEffect } = await import('../../src/reactive.ts')
+
+    // Mirrors piconic-ai/sora's App + AppHeader: App's own `bf="s5"` element
+    // (the sidebar-collapse button) sits AFTER a fragment-rooted AppHeader
+    // child whose OWN internal numbering coincidentally also uses `bf="s5"`
+    // (the info-button) for something unrelated, nested one level inside
+    // <header>. Slot ids are local to each component's own template, so
+    // this collision is normal — only scope-boundary resolution keeps them
+    // apart.
+    document.body.innerHTML =
+      '<div bf-s="ParentCollide_abc" bf-r="">' +
+      '<!--bf-scope:ParentCollide_abc_s0|h=ParentCollide_abc|m=s0-->' +
+      '<header><button bf="s5" aria-label="child">i</button></header>' +
+      '<!--bf-/scope:ParentCollide_abc_s0-->' +
+      '<button bf="s5" aria-label="parent">collapse</button>' +
+      '</div>'
+
+    // ParentCollide.client.js (compiled shape): the parent's own `$()` for
+    // its regular slots runs BEFORE `$c()` resolves (and registers) the
+    // fragment child's scope — the actual compiled order (#2302's root
+    // cause: at the time `$('s5')` runs, the child's comment scope isn't
+    // in commentScopeRegistry yet, so registry-based detection can't help).
+    function initParentCollide(__scope: Element) {
+      if (!__scope) return
+      const [_s5] = $(__scope, 's5')
+      $c(__scope, 's0')
+      createEffect(() => {
+        if (_s5) _s5.setAttribute('aria-expanded', 'true')
+      })
+    }
+    hydrate('ParentCollide', { init: initParentCollide, template: () => '<div></div>' })
+    flushHydration()
+
+    const parentButton = document.querySelector('[aria-label="parent"]')!
+    const childButton = document.querySelector('[aria-label="child"]')!
+
+    // Before the fix, `closest('[bf-s]')` from the child button walked past
+    // <header> (no bf-s of its own) straight to the ParentCollide root, so
+    // `belongsToScope` wrongly matched it — `_s5` resolved to whichever
+    // bf="s5" element querySelectorAll found first (document order: the
+    // child's), and `aria-expanded` landed on the wrong button.
+    expect(parentButton.getAttribute('aria-expanded')).toBe('true')
+    expect(childButton.getAttribute('aria-expanded')).toBeNull()
   })
 
   test('initChild queues until the child module registers (parent-first load order)', async () => {

--- a/packages/client/src/runtime/query.ts
+++ b/packages/client/src/runtime/query.ts
@@ -8,7 +8,7 @@
 
 import { commentScopeRegistry, getCommentScopeBoundary } from './scope.ts'
 import { hydratedScopes } from './hydration-state.ts'
-import { BF_SCOPE, BF_SLOT, BF_PORTAL_OWNER, BF_PARENT_OWNED_PREFIX, BF_SCOPE_COMMENT_PREFIX } from '@barefootjs/shared'
+import { BF_SCOPE, BF_SLOT, BF_PORTAL_OWNER, BF_PARENT_OWNED_PREFIX, BF_SCOPE_COMMENT_PREFIX, BF_SCOPE_COMMENT_END_PREFIX } from '@barefootjs/shared'
 
 /** CSS attribute-value escape with a fallback for environments lacking CSS.escape. */
 export const cssEscape: (s: string) => string =
@@ -222,7 +222,59 @@ function belongsToScope(element: Element, scope: Element): boolean {
 
   // Check if nearest scope matches
   const nearestScope = element.closest(`[${BF_SCOPE}]`)
-  return nearestScope === scope
+  if (nearestScope !== scope) return false
+
+  // A fragment-rooted child mounted between `element` and `scope` has no
+  // `bf-s` element of its own (#2302) — `closest()` walks straight past it
+  // to `scope`, so a slot search on `scope` can wrongly claim a descendant
+  // that actually belongs to that nested child's comment scope. Reject it.
+  return !isInsideNestedCommentScope(element, scope)
+}
+
+/**
+ * True if some ancestor of `element` (strictly below `scope`) is a
+ * top-level node of a fragment-rooted child's `<!--bf-scope:...-->` range —
+ * i.e. `element` structurally belongs to a nested child component even
+ * though that child has no `bf-s`-attributed element for `.closest()` to
+ * stop at, and regardless of whether `commentScopeRegistry` has registered
+ * it yet (a parent's own slot lookups can run before its child-scope
+ * lookups register the child, #2302).
+ */
+function isInsideNestedCommentScope(element: Element, scope: Element): boolean {
+  let current: Node = element
+  while (current !== scope) {
+    const parent: Node | null = current.parentNode
+    if (!parent) return false
+    if (isTopLevelCommentScopeNode(current)) return true
+    current = parent
+  }
+  return false
+}
+
+/**
+ * True if `node` falls inside a `<!--bf-scope:...-->` … `<!--bf-/scope:...-->`
+ * range among its own siblings — i.e. `node` is (or is inside) a top-level
+ * element of a fragment-rooted child mounted as `node`'s sibling. Single
+ * left-to-right pass over the sibling list with a nesting depth counter, so
+ * a nested child's own begin/end pair doesn't prematurely close an outer
+ * one. Missing end markers (older SSR output) leave depth un-decremented,
+ * matching `getCommentScopeBoundary`'s legacy end-of-parent fallback.
+ */
+function isTopLevelCommentScopeNode(node: Node): boolean {
+  const parent = node.parentNode
+  if (!parent) return false
+  let depth = 0
+  let sib: Node | null = parent.firstChild
+  while (sib) {
+    if (sib === node) return depth > 0
+    if (sib.nodeType === Node.COMMENT_NODE) {
+      const value = (sib as Comment).nodeValue ?? ''
+      if (value.startsWith(BF_SCOPE_COMMENT_PREFIX)) depth++
+      else if (value.startsWith(BF_SCOPE_COMMENT_END_PREFIX) && depth > 0) depth--
+    }
+    sib = sib.nextSibling
+  }
+  return false
 }
 
 /**
@@ -271,10 +323,16 @@ export function find(
     if (ignoreScope) return candidate
     if (commentInfo) {
       // Comment scope: top-level siblings in the comment range are always
-      // accepted (even if they have bf-s, like proxy elements). Descendants
-      // are accepted only if not inside a nested bf-s scope.
+      // accepted (even if they have bf-s, like proxy elements). A descendant
+      // nested inside one of those siblings is accepted unless a *nested*
+      // child scope sits between it and this one — i.e. its nearest bf-s
+      // ancestor falls within this comment's own sibling range. An ancestor
+      // bf-s element outside that range doesn't disqualify the candidate:
+      // a fragment-root child mounted inside a normal parent island always
+      // has one, and `.closest()` alone can't tell the two apart (#2302).
       if (candidate.parentElement === commentInfo.commentNode.parentElement) return candidate
-      if (!candidate.closest(`[${BF_SCOPE}]`)) return candidate
+      const nearestScope = candidate.closest(`[${BF_SCOPE}]`)
+      if (!nearestScope || !isInCommentScopeRange(nearestScope, commentInfo.commentNode)) return candidate
     } else {
       if (belongsToScope(candidate, scope)) return candidate
     }


### PR DESCRIPTION
Fixes #2302.

## Problem

#2289 (fixed by #2293, 0.21.0) made `initChild` correctly resolve a fragment-root child's own scope and deliver live props. Downstream verification (piconic-ai/sora's `AppHeader.tsx`, a `<header>` + `<div popover>` fragment) found the original symptom (frozen UI, dead callbacks, zero console errors) still fully reproduced — the #2293 fix was necessary but not sufficient. Two separate bugs remained in `packages/client/src/runtime/query.ts`, both variants of the same root cause: `.closest('[bf-s]')` cannot detect a comment-anchored scope boundary, because a fragment child has no `bf-s`-attributed element for it to stop at.

### Bug 1 — a fragment child's own `$`/`$t` queries

`find()`'s comment-scope branch accepted a candidate only if it had **no** `bf-s`-attributed ancestor at all:

```ts
if (!candidate.closest(`[${BF_SCOPE}]`)) return candidate
```

Every fragment-root child is normally mounted inside a `bf-s`-attributed parent island, so this is never true for anything nested one level inside the fragment's own top-level siblings (e.g. AppHeader's `<header><select>`). Every such slot resolved to `null`, silently dropping its event listener/reactive binding — no throw, no console error, because the compiled output always guards with `if (_sN) { ... }`.

### Bug 2 — a parent's own slot search reaching into a nested fragment child

`belongsToScope()` (used by a *parent's* own non-comment-scope slot search) accepts a candidate if its nearest `bf-s` ancestor is the parent's own scope:

```ts
const nearestScope = element.closest(`[${BF_SCOPE}]`)
return nearestScope === scope
```

Since a fragment child has no `bf-s` element of its own, `.closest()` walks straight past it to the *parent's* root — so a parent's slot search can wrongly claim a descendant that actually belongs to a nested fragment child's coincidentally same-numbered slot (slot ids are local to each component's own template, so collisions are normal). In `AppHeader`, the parent App's own `bf="s5"` (sidebar-collapse button) search matched AppHeader's unrelated internal `bf="s5"` (info-button) instead, spuriously writing `aria-expanded`/`aria-label` onto it — the exact "misattached aria binding" symptom originally reported in #2289.

## Fix

Both branches now bound the search to the actual `<!--bf-scope:...--> … <!--bf-/scope:...-->` sibling range instead of relying on `.closest('[bf-s]')` alone:

- `find()`'s comment-scope branch reuses the existing `isInCommentScopeRange` helper (already used correctly by `$t`'s `commentBelongsToScope` — this bug was an inconsistency between `$`'s and `$t`'s comment-scope logic).
- `belongsToScope()` gains `isInsideNestedCommentScope`, a single left-to-right pass over the sibling list with a nesting-depth counter (mirrors `getCommentScopeBoundary`'s legacy end-of-parent fallback for HTML without the end marker).

## Tests

Extended `packages/client/__tests__/runtime/fragment-child-init.test.ts`:
- `$` resolves a slot nested inside one of the fragment child's top-level siblings (#2302)
- callback prop reaches a slot nested inside the fragment child (#2302)
- a parent's own slot search doesn't reach into a nested fragment child's coincidentally-numbered slot (#2302)

All three verified red without the fix, green with it. Full `packages/client/` + `packages/adapter-tests/` suite: 1807 pass, 0 fail.

## Downstream verification

Re-tested with piconic-ai/sora's `AppHeader.tsx` restored to its original JSX Fragment root (no `<div>` wrapper workaround), linked against this branch's built `@barefootjs/client`. Verified in a real browser: language switch, popover open/close, narrow-viewport reopen button, clear-all button, and the `aria-expanded` misattachment — all correct, zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)