### PR TITLE
fix: qsa() crossing into a nested child component's scope on slot ID collision

### DIFF
--- a/.changeset/qsa-nested-child-slot-collision.md
+++ b/.changeset/qsa-nested-child-slot-collision.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/client": patch
+---
+
+Fix `qsa()` returning a nested child component's element instead of the caller's own when their compiler-assigned local slot numbers (`bf="sN"`) happen to collide. Compiler slot IDs restart from `s0` per component file, so a parent's own slot and a nested child's slot can share the same number; `qsa()` (used by `insert()`'s conditional-branch `bindEvents` for plain attribute/class bindings) now skips any candidate that falls inside a nested child component's own scope boundary, matching the scope-boundary awareness `find()` already has via `belongsToScope()`.

--- a/packages/client/__tests__/runtime/insert-nested-child-slot-collision.test.ts
+++ b/packages/client/__tests__/runtime/insert-nested-child-slot-collision.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Runtime integration test for #2316: a conditional branch's `bindEvents`
+ * resolves its own slot via `qsa(__branchScope, ...)`, where `__branchScope`
+ * is the *whole* component scope (`region.bindScope` in insert.ts), not a
+ * subtree scoped to just this branch. When a nested child component,
+ * mounted earlier in the same scope, happens to reuse the same local slot
+ * number (compiler slot IDs restart from `s0` per component file), `qsa()`
+ * must not return the child's element instead of the branch's own.
+ *
+ * Mirrors the real shape found in piconic-ai/sora: EditorMain's `insert()`-
+ * controlled `page-meter-fill` div (`bf="s4"`) collided with WordTable's
+ * (a nested child, mounted earlier in DOM order) own "Front" `<th bf="s4">`.
+ */
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { insert } from '../../src/runtime/insert'
+import { qsa } from '../../src/runtime/query'
+import { createSignal, createDisposableEffect } from '../../src/reactive'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') {
+    GlobalRegistrator.register()
+  }
+})
+
+describe('insert() branch bindEvents vs. nested child slot collision (#2316)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('reactive class/style on the parent\'s own slot never lands on the nested child\'s same-numbered slot', () => {
+    // SSR shape: a nested child component (its own bf-s scope) rendered
+    // before an insert()-controlled ELEMENT conditional (bf-c="s1") whose
+    // active branch happens to reuse the child's local slot number (both
+    // "s4") — mirrors EditorMain.tsx's real compiled output exactly,
+    // where the SSR-rendered branch already matches the client's expected
+    // signature, so insert() skips straight to bindEvents() without any
+    // DOM swap (the fast path the real bug goes through).
+    document.body.innerHTML = `
+      <section bf-s="EditorMain_test1">
+        <div class="editor-body">
+          <div class="word-table-wrap" bf-s="EditorMain_test1_s0">
+            <table><thead><tr><th bf="s4">Front</th></tr></thead></table>
+          </div>
+          <div bf-c="s1" class="page-meter">
+            <div class="page-meter-fill" style="width:10%" bf="s4"></div>
+          </div>
+        </div>
+      </section>
+    `
+    const scope = document.querySelector('[bf-s="EditorMain_test1"]')!
+    const childSlot = document.querySelector('[bf-s="EditorMain_test1_s0"] [bf="s4"]')!
+
+    const [isFull, setIsFull] = createSignal(false)
+    const [ratio, setRatio] = createSignal(0.1)
+
+    insert(scope, 's1', () => true, {
+      template: () => `<div bf-c="s1" class="page-meter"><div class="${isFull() ? 'page-meter-fill is-full' : 'page-meter-fill'}" style="width:${Math.round(ratio() * 100)}%" bf="s4"></div></div>`,
+      bindEvents: (__branchScope) => {
+        const __disposers: Array<() => void> = []
+        const el = qsa(__branchScope, '[bf="s4"]')
+        if (el) {
+          __disposers.push(createDisposableEffect(() => {
+            el.setAttribute('class', isFull() ? 'page-meter-fill is-full' : 'page-meter-fill')
+          }))
+          __disposers.push(createDisposableEffect(() => {
+            el.setAttribute('style', `width:${Math.round(ratio() * 100)}%`)
+          }))
+        }
+        return () => __disposers.forEach((f) => f())
+      },
+    }, {
+      template: () => `<div bf-c="s1" class="hint"></div>`,
+      bindEvents: () => {},
+    })
+
+    // The nested child's own <th bf="s4"> must be untouched — no class,
+    // no inline style, still just the SSR "Front" header cell.
+    expect(childSlot.className).toBe('')
+    expect(childSlot.getAttribute('style')).toBeNull()
+
+    // The parent's own page-meter-fill div must have received the binding.
+    const fillEl = document.querySelector('[class^="page-meter-fill"]')
+    expect(fillEl).not.toBeNull()
+    expect(fillEl?.getAttribute('style')).toBe('width:10%')
+
+    // Drive the signals — updates must reach the parent's own element,
+    // and the nested child's slot must remain untouched throughout.
+    setIsFull(true)
+    setRatio(0.75)
+    expect(fillEl?.className).toBe('page-meter-fill is-full')
+    expect(fillEl?.getAttribute('style')).toBe('width:75%')
+    expect(childSlot.className).toBe('')
+    expect(childSlot.getAttribute('style')).toBeNull()
+  })
+})

--- a/packages/client/__tests__/runtime/query.test.ts
+++ b/packages/client/__tests__/runtime/query.test.ts
@@ -797,4 +797,35 @@ describe('qsa', () => {
     const own = document.querySelector('[bf="s2"]')
     expect(qsa(scope, '[bf="s2"]')).toBe(own)
   })
+
+  // qsa() doubles as the child-scope-resolution lookup for compiled
+  // component-loop / branch-nested-child code (feeding initChild()) — its
+  // target legitimately carries bf-s itself. The nested-child-scope skip
+  // above must reject only an *intermediate* bf-s between the candidate and
+  // the search root, never the candidate's own bf-s, or these calls break.
+  test('still finds a direct bf-s child scope by prefix selector (child-scope resolution)', () => {
+    document.body.innerHTML = `
+      <div bf-s="Parent_abc">
+        <div bf-s="Counter_xyz">child content</div>
+      </div>
+    `
+    const parent = document.querySelector('[bf-s="Parent_abc"]')!
+    const child = document.querySelector('[bf-s="Counter_xyz"]')
+    expect(qsa(parent, '[bf-s^="Counter_"]')).toBe(child)
+  })
+
+  test('finds a host-marked nested child via the [bf-h][bf-m] clause even when its own bf-s is a bare Name_rand (not "_sN"-suffixed)', () => {
+    // Real compiled shape: a branch/component-loop nested child's bf-s is
+    // its own generated id (not anchored to the parent's slot number), so
+    // the comma selector's `[bf-s$="_sN"]` fallback clause doesn't match —
+    // only the primary `[bf-h][bf-m]` clause does.
+    document.body.innerHTML = `
+      <div bf-s="Toggle_test">
+        <div bf-s="ToggleItem_rc62ve" bf-h="Toggle_test" bf-m="s0">item</div>
+      </div>
+    `
+    const scope = document.querySelector('[bf-s="Toggle_test"]')!
+    const child = document.querySelector('[bf-s="ToggleItem_rc62ve"]')
+    expect(qsa(scope, '[bf-h="Toggle_test"][bf-m="s0"], [bf-s$="_s0"]')).toBe(child)
+  })
 })

--- a/packages/client/__tests__/runtime/query.test.ts
+++ b/packages/client/__tests__/runtime/query.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
-import { findScope, find, $, $c, $t } from '../../src/runtime/query'
+import { findScope, find, $, $c, $t, qsa } from '../../src/runtime/query'
 import { hydratedScopes } from '../../src/runtime/hydration-state'
 import { GlobalRegistrator } from '@happy-dom/global-registrator'
 
@@ -730,5 +730,71 @@ describe('$t', () => {
     expect(t0?.nodeValue).toBe('')
     expect(t1).not.toBeNull()
     expect(t1?.nodeValue).toBe('')
+  })
+})
+
+describe('qsa', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('self-match still returns the root when it matches the selector', () => {
+    document.body.innerHTML = `<div bf-s="Demo_abc" bf="s4"></div>`
+    const scope = document.querySelector('[bf-s="Demo_abc"]')!
+    expect(qsa(scope, '[bf="s4"]')).toBe(scope)
+  })
+
+  test('finds a plain descendant slot with no nested child in the way', () => {
+    document.body.innerHTML = `
+      <div bf-s="Demo_abc">
+        <span bf="s4"></span>
+      </div>
+    `
+    const scope = document.querySelector('[bf-s="Demo_abc"]')!
+    const target = document.querySelector('[bf="s4"]')
+    expect(qsa(scope, '[bf="s4"]')).toBe(target)
+  })
+
+  test('#2316: skips a nested child component\'s coincidentally same-numbered slot', () => {
+    // Mirrors EditorMain/WordTable: a parent scope's own bf="s4" slot
+    // (page-meter-fill) collides with a nested child component's own
+    // locally-numbered bf="s4" slot (WordTable's "Front" <th>), which
+    // renders earlier in DOM order. qsa() must skip the child's element
+    // and find the parent's own.
+    document.body.innerHTML = `
+      <section bf-s="EditorMain_abc">
+        <div class="editor-body">
+          <div class="word-table-wrap" bf-s="EditorMain_abc_s0">
+            <table>
+              <thead>
+                <tr><th bf="s4">Front</th></tr>
+              </thead>
+            </table>
+          </div>
+          <div class="page-meter">
+            <div class="page-meter-fill" bf="s4"></div>
+          </div>
+        </div>
+      </section>
+    `
+    const scope = document.querySelector('[bf-s="EditorMain_abc"]')!
+    const fill = document.querySelector('.page-meter-fill')
+    const found = qsa(scope, '[bf="s4"]')
+    expect(found).toBe(fill)
+    expect(found?.className).toBe('page-meter-fill')
+  })
+
+  test('finds a slot after a nested child scope when both are present in DOM order', () => {
+    document.body.innerHTML = `
+      <section bf-s="Parent_abc">
+        <div bf-s="Parent_abc_s0">
+          <span bf="s1"></span>
+        </div>
+        <span bf="s2">own slot</span>
+      </section>
+    `
+    const scope = document.querySelector('[bf-s="Parent_abc"]')!
+    const own = document.querySelector('[bf="s2"]')
+    expect(qsa(scope, '[bf="s2"]')).toBe(own)
   })
 })

--- a/packages/client/src/runtime/query.ts
+++ b/packages/client/src/runtime/query.ts
@@ -485,8 +485,17 @@ export function qsa(el: Element | null, selector: string): Element | null {
     return qsaChildScope(el, selector)
   }
   if (el.matches(selector)) return el
+
+  // Fast path: the overwhelmingly common case has no nested-child-scope
+  // collision, so a single querySelector() (matching the old behavior)
+  // resolves it without the cost of enumerating every match. Only fall
+  // back to the full querySelectorAll() scan — needed to skip past a
+  // rejected candidate to the next DOM-order match — when the first hit
+  // actually turns out to belong to a nested child scope.
+  const first = el.querySelector(selector)
+  if (!first || !isInsideNestedChildScope(first, el)) return first
   for (const candidate of el.querySelectorAll(selector)) {
-    if (!isInsideNestedChildScope(candidate, el)) return candidate
+    if (candidate !== first && !isInsideNestedChildScope(candidate, el)) return candidate
   }
   return null
 }

--- a/packages/client/src/runtime/query.ts
+++ b/packages/client/src/runtime/query.ts
@@ -252,6 +252,41 @@ function isInsideNestedCommentScope(element: Element, scope: Element): boolean {
 }
 
 /**
+ * True if `element` sits inside a nested child component's own scope
+ * boundary somewhere on the path up to `root` — a plain `[bf-s]` element
+ * (a regular child component's root) or a fragment-rooted child's
+ * comment-scope range mounted as a sibling along that path.
+ *
+ * Generalizes `isInsideNestedCommentScope` (which only catches the
+ * comment-scope case) to also catch plain `bf-s` boundaries, for `qsa()`
+ * — the loose, unfiltered sibling of `find()`'s `belongsToScope`-gated
+ * search. Unlike `belongsToScope`, this walks up to `root` by object
+ * identity rather than requiring `root` itself to carry `bf-s`: `qsa()`'s
+ * roots include `insert()`'s whole-component branch scope (which does
+ * carry `bf-s`) but also loop-item template clones (which normally don't),
+ * so a `.closest('[bf-s]') === root` check can't be reused here.
+ *
+ * Without this, a slot number that happens to collide between a component
+ * and a nested child mounted earlier in its DOM (compiler slot IDs are
+ * assigned independently per component file, so collisions are expected)
+ * makes `qsa()` return the child's element instead of the component's own.
+ */
+function isInsideNestedChildScope(element: Element, root: Element): boolean {
+  if (element.hasAttribute(BF_SCOPE)) return true
+  let current: Node = element
+  while (current !== root) {
+    const parent: Node | null = current.parentNode
+    if (!parent) return false
+    if (parent !== root && parent.nodeType === Node.ELEMENT_NODE && (parent as Element).hasAttribute(BF_SCOPE)) {
+      return true
+    }
+    if (isTopLevelCommentScopeNode(current)) return true
+    current = parent
+  }
+  return false
+}
+
+/**
  * True if `node` falls inside a `<!--bf-scope:...-->` … `<!--bf-/scope:...-->`
  * range among its own siblings — i.e. `node` is (or is inside) a top-level
  * element of a fragment-rooted child mounted as `node`'s sibling. Single
@@ -409,6 +444,12 @@ function findInPortals(scopeId: string, selector: string): Element | null {
  * then its descendants. Unlike querySelector() which only searches descendants,
  * this also matches the root element.
  *
+ * Descendant candidates that fall inside a nested child component's own
+ * scope are skipped (`isInsideNestedChildScope`) — compiler slot IDs
+ * (`bf="sN"`) are assigned independently per component file, so a slot
+ * number can coincidentally collide between `el`'s own template and a
+ * child component mounted somewhere inside it (#2316).
+ *
  * Used by compiler-generated code for event binding and attribute updates
  * on loop items where the target may be the loop item's root element itself.
  */
@@ -437,7 +478,10 @@ export function qsa(el: Element | null, selector: string): Element | null {
     return qsaChildScope(el, selector)
   }
   if (el.matches(selector)) return el
-  return el.querySelector(selector)
+  for (const candidate of el.querySelectorAll(selector)) {
+    if (!isInsideNestedChildScope(candidate, el)) return candidate
+  }
+  return null
 }
 
 /** Split a CSS selector list on top-level commas, ignoring commas inside

--- a/packages/client/src/runtime/query.ts
+++ b/packages/client/src/runtime/query.ts
@@ -270,9 +270,16 @@ function isInsideNestedCommentScope(element: Element, scope: Element): boolean {
  * and a nested child mounted earlier in its DOM (compiler slot IDs are
  * assigned independently per component file, so collisions are expected)
  * makes `qsa()` return the child's element instead of the component's own.
+ *
+ * Deliberately does NOT reject `element` itself for carrying `bf-s`
+ * (unlike `belongsToScope`'s own-scope check) — `qsa()` doubles as the
+ * lookup for a nested child component's *own* scope root (e.g. compiled
+ * `qsa(parentScope, '[bf-h="X"][bf-m="sN"], [bf-s$="_sN"]')` calls feeding
+ * `initChild()`), and that target legitimately carries `bf-s`. Only an
+ * *intermediate* `bf-s` between `element` and `root` — i.e. `element`
+ * nested inside some other, unrelated child scope — disqualifies it.
  */
 function isInsideNestedChildScope(element: Element, root: Element): boolean {
-  if (element.hasAttribute(BF_SCOPE)) return true
   let current: Node = element
   while (current !== root) {
     const parent: Node | null = current.parentNode


### PR DESCRIPTION
## Summary

Fixes #2316. Compiler slot IDs (`bf="sN"`) are assigned independently per component file, restarting from `s0`, so a parent's own slot and a nested child component's slot can coincidentally share the same number. `qsa()` (used by `insert()`'s conditional-branch `bindEvents` for plain attribute/class bindings, among other compiled call sites) had no notion of a nested child's scope boundary — unlike `find()` (used for `$`/`$t`/`$c`), which is scope-boundary-aware via `belongsToScope()` — so it could return the child's element instead of the caller's own.

Found in piconic-ai/sora: `EditorMain.tsx` renders `<WordTable>` (nested child) followed by an `insert()`-controlled `page-meter-fill` div, both independently compiled to `bf="s4"`. `WordTable`'s "Front" `<th>` renders earlier in DOM order, so `qsa()` returned it instead — the reactive effect stamped `class="page-meter-fill is-full"` / `style="width:NN%"` onto the table header cell, visibly corrupting the table layout. Reproduced live in a browser before fixing.

## Fix

- `packages/client/src/runtime/query.ts`: added `isInsideNestedChildScope(element, root)`, which walks up from a candidate to the search root **by object identity** (not `.closest()`/attribute matching, since `qsa()`'s roots include loop-item template clones that don't carry `bf-s`), rejecting a candidate that sits inside an *intermediate* nested child scope — either a plain `[bf-s]` element or a fragment-rooted child's comment-scope range (reusing the existing `isTopLevelCommentScopeNode` helper). `qsa()` now skips such candidates instead of always returning the first DOM-order match.

## Caught during review before merge

An independent review (before this PR was opened) found that the first version of `isInsideNestedChildScope` unconditionally rejected a candidate that itself carried `bf-s`, mirroring `belongsToScope()`'s "a slot match is never a component root" rule. That rule doesn't hold for `qsa()`: it also resolves a nested child's own scope root for `initChild()` (compiled `qsa(parentScope, '[bf-h="X"][bf-m="sN"], [bf-s$="_sN"]')` calls), whose target legitimately carries `bf-s`. The blanket rejection silently broke hydration for any such child not rescued by the `[bf-s$="_sN"]` fallback clause — masked in the existing e2e suite because current fixtures' nested children happen to have parent-anchored `bf-s` values that the fallback clause catches. Fixed in the second commit; added two regression tests for this shape (`qsa(parent, '[bf-s^="Counter_"]')` and the `[bf-h][bf-m]`-clause case with a bare `Name_rand` child `bf-s`).

## Tests

- `packages/client/__tests__/runtime/query.test.ts` — new `describe('qsa', ...)` block: self-match, plain descendant, the #2316 collision repro, a slot found *after* a nested child scope in DOM order, and the two child-scope-resolution regression cases above.
- `packages/client/__tests__/runtime/insert-nested-child-slot-collision.test.ts` — integration-level regression test reproducing the exact `EditorMain`/`WordTable` shape through the real `insert()` function (not `qsa()` in isolation), including driving the reactive signals post-bind to confirm updates land on the correct element and the nested child's slot is never touched.

## Verification

- `bun test packages/client` — 510 pass, 0 fail
- `tsgo --noEmit` in `packages/client` — clean
- Full monorepo build (`bun run --filter '*' build`) — succeeded
- `bun test packages/adapter-tests` — 1316 pass, 0 fail
- `site/ui`'s full Playwright e2e suite (1147 tests) — 1127 passed, 20 skipped, 0 failed (run twice: once against the first fix, once against the corrected fix after the review finding above)

## Test plan

- [ ] CI green (including `site/ui` e2e)