### PR TITLE
Repoint compat-matrix limitation tracking at open successor issues

### DIFF
--- a/.changeset/compat-matrix-successor-trackers.md
+++ b/.changeset/compat-matrix-successor-trackers.md
@@ -1,0 +1,12 @@
+---
+'@barefootjs/blade': patch
+'@barefootjs/erb': patch
+'@barefootjs/go-template': patch
+'@barefootjs/jinja': patch
+'@barefootjs/mojolicious': patch
+'@barefootjs/rust': patch
+'@barefootjs/twig': patch
+'@barefootjs/xslate': patch
+---
+
+Repoint conformance-pin tracking URLs at open successor issues (#2319, #2320, #2321) — the previous trackers (#2215, #2038, #2087) are closed. Metadata only: no diagnostic codes, severities, or refusal behavior change.

--- a/packages/adapter-blade/src/conformance-pins.ts
+++ b/packages/adapter-blade/src/conformance-pins.ts
@@ -29,11 +29,15 @@ export const conformancePins: ConformancePins = {
   // can't bind as a template variable — refused loudly with BF101 (same
   // check and policy as Jinja / ERB) instead of silently iterating zero
   // times over an unbound name.
-  'static-array-from-props': [{ code: 'BF101', severity: 'error' }],
+  'static-array-from-props': [
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2321' },
+  ],
   // BF101 (computed local-const loop array, as above) fires; BF103
   // (imported child in the loop body) no longer does now that the
   // conformance harness passes `siblingTemplatesRegistered: true` (#2205).
-  'static-array-from-props-with-component': [{ code: 'BF101', severity: 'error' }],
+  'static-array-from-props-with-component': [
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2321' },
+  ],
   // #2087 Phase B: every `.map()` destructure shape in the shared corpus
   // now lowers on Blade via an `@php(...)` local built from the binding's
   // structured `segments` path (`bladeLoopBindingAccessor` in
@@ -63,12 +67,12 @@ export const conformancePins: ConformancePins = {
   // lossy, same as Jinja. The `/* @client */` twin
   // (`filter-nested-callback-predicate-client`) has no pin here: it must
   // render clean on every adapter, which asserts the suppression contract.
-  // https://github.com/piconic-ai/barefootjs/issues/2038
+  // Faithful lowering tracked: https://github.com/piconic-ai/barefootjs/issues/2320 (successor to #2038)
   'filter-nested-callback-predicate': [
-    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2038' },
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' },
   ],
   'filter-nested-find-predicate': [
-    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2038' },
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' },
   ],
   // NB: TOP-LEVEL `.find` / `.findIndex` / `.findLast` / `.findLastIndex`
   // (text position) are NOT pinned here — like Jinja (unlike mojo, which
@@ -84,8 +88,8 @@ export const conformancePins: ConformancePins = {
   // `dangerouslySetInnerHTML={{ __html: '...' }}` is spliced directly into
   // the template as trusted raw text (`resolveDangerousInnerHtml`, #2207).
   // A dynamic/signal-derived value still refuses with BF101 — see the
-  // `dangerous-inner-html-dynamic` fixture/pin below (tracked: #2215).
-  'dangerous-inner-html-dynamic': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2215' }],
+  // `dangerous-inner-html-dynamic` fixture/pin below (tracked: #2319, successor to #2215).
+  'dangerous-inner-html-dynamic': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2319' }],
   // #2273: a method call on a prop typed as a built-in host rich type
   // (Date, Map, …) has no catalogued lowering in any adapter — this is a
   // compiler-level refusal (`checkRichTypeMethodCalls`, wired ahead of

--- a/packages/adapter-erb/src/conformance-pins.ts
+++ b/packages/adapter-erb/src/conformance-pins.ts
@@ -39,17 +39,17 @@ export const conformancePins: ConformancePins = {
   // destructure gate merely exposes — it reproduces identically with a
   // non-destructured param (verified) — not a destructure-lowering
   // limitation, so it is NOT part of #2087's scope. Tracked as its own
-  // gap under https://github.com/piconic-ai/barefootjs/issues/2087;
+  // gap under https://github.com/piconic-ai/barefootjs/issues/2321;
   // pinned honestly as BF101 (the adapter's own check, see `renderLoop`'s
   // "Loop array is a bare identifier..." comment) rather than faked as
   // BF104 or silently producing broken Ruby.
   'static-array-from-props': [
-    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2087' },
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2321' },
   ],
   // BF103 (imported child in the loop body) no longer fires now that the
   // conformance harness passes `siblingTemplatesRegistered: true` (#2205).
   'static-array-from-props-with-component': [
-    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2087' },
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2321' },
   ],
   // #2087 Phase B: `isLowerableLoopDestructure` now admits every fixed-
   // binding shape (any field/index depth — `destructure-array-index-in-map`,
@@ -69,9 +69,9 @@ export const conformancePins: ConformancePins = {
   // (`filter-nested-callback-predicate`) is NOT pinned: like mojo, ERB
   // lowers it to a real inline Ruby block predicate and must render to
   // Hono parity instead.
-  // https://github.com/piconic-ai/barefootjs/issues/2038
+  // Faithful lowering tracked: https://github.com/piconic-ai/barefootjs/issues/2320 (successor to #2038)
   'filter-nested-find-predicate': [
-    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2038' },
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' },
   ],
   // #1467 demo-corpus context providers (`radio-group`, `accordion`,
   // `dialog`, `popover`, `select`, `dropdown-menu`, `combobox`,
@@ -101,8 +101,8 @@ export const conformancePins: ConformancePins = {
   // `dangerouslySetInnerHTML={{ __html: '...' }}` is spliced directly into
   // the template as trusted raw text (`resolveDangerousInnerHtml`, #2207).
   // A dynamic/signal-derived value still refuses with BF101 — see the
-  // `dangerous-inner-html-dynamic` fixture/pin below (tracked: #2215).
-  'dangerous-inner-html-dynamic': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2215' }],
+  // `dangerous-inner-html-dynamic` fixture/pin below (tracked: #2319, successor to #2215).
+  'dangerous-inner-html-dynamic': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2319' }],
   // #2273: a method call on a prop typed as a built-in host rich type
   // (Date, Map, …) has no catalogued lowering in any adapter — this is a
   // compiler-level refusal (`checkRichTypeMethodCalls`, wired ahead of

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -41,12 +41,16 @@ export const conformancePins: ConformancePins = {
   // building loud, so `renderLoop` raises BF101 for a bare-identifier loop
   // array bound to such a const. See the `renderLoop` comment at the check
   // site; Jinja / ERB apply the same narrow check for the same reason.
-  'static-array-from-props': [{ code: 'BF101', severity: 'error' }],
+  'static-array-from-props': [
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2321' },
+  ],
   // Same computed-const array as above — the destructure param itself no
   // longer contributes a diagnostic, and BF103 (sibling-imported child
   // component in the loop body) no longer fires either now that the
   // conformance harness passes `siblingTemplatesRegistered: true` (#2205).
-  'static-array-from-props-with-component': [{ code: 'BF101', severity: 'error' }],
+  'static-array-from-props-with-component': [
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2321' },
+  ],
   // (`style-3-signals` graduated alongside `style-object-dynamic` — see note
   // above; the `style={{ … }}` object now lowers to a CSS string.)
   // (`tagged-template-classname` graduated by #2092 — the tag resolves
@@ -60,12 +64,12 @@ export const conformancePins: ConformancePins = {
   // instead of lossy. The `/* @client */` twin
   // (`filter-nested-callback-predicate-client`) has no pin here: it must
   // render clean on every adapter, which asserts the suppression contract.
-  // https://github.com/piconic-ai/barefootjs/issues/2038
+  // Faithful lowering tracked: https://github.com/piconic-ai/barefootjs/issues/2320 (successor to #2038)
   'filter-nested-callback-predicate': [
-    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2038' },
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' },
   ],
   'filter-nested-find-predicate': [
-    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2038' },
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' },
   ],
   // #1310 / #2087: rest destructure in .map() callback. `isLowerableLoopDestructure`
   // now admits every shape this fixture family exercises — each fixed/rest
@@ -135,8 +139,8 @@ export const conformancePins: ConformancePins = {
   // `dangerouslySetInnerHTML={{ __html: '...' }}` is spliced directly into
   // the template as trusted raw text (`resolveDangerousInnerHtml`, #2207).
   // A dynamic/signal-derived value still refuses with BF101 — see the
-  // `dangerous-inner-html-dynamic` fixture/pin below (tracked: #2215).
-  'dangerous-inner-html-dynamic': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2215' }],
+  // `dangerous-inner-html-dynamic` fixture/pin below (tracked: #2319, successor to #2215).
+  'dangerous-inner-html-dynamic': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2319' }],
   // #2273: a method call on a prop typed as a built-in host rich type
   // (Date, Map, …) has no catalogued lowering in any adapter — this is a
   // compiler-level refusal (`checkRichTypeMethodCalls`, wired ahead of

--- a/packages/adapter-jinja/src/conformance-pins.ts
+++ b/packages/adapter-jinja/src/conformance-pins.ts
@@ -42,15 +42,15 @@ export const conformancePins: ConformancePins = {
   // see the "Loop array `<name>` is a local computed value" diagnostic.
   // Fixing the underlying gap (computed-array-from-props as a loop
   // source) is out of scope for #2087; tracked as a follow-up at
-  // https://github.com/piconic-ai/barefootjs/issues/2087.
+  // https://github.com/piconic-ai/barefootjs/issues/2321.
   'static-array-from-props': [
-    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2087' },
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2321' },
   ],
   // BF101 (unresolvable computed loop array, see above) fires; BF103
   // (imported child in the loop body) no longer does now that the
   // conformance harness passes `siblingTemplatesRegistered: true` (#2205).
   'static-array-from-props-with-component': [
-    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2087' },
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2321' },
   ],
   // Rest-destructure / structured-path `.map()` callbacks (#2087 Phase B):
   // `isLowerableLoopDestructure` now admits fixed bindings at any
@@ -80,12 +80,12 @@ export const conformancePins: ConformancePins = {
   // lossy, same as xslate. The `/* @client */` twin
   // (`filter-nested-callback-predicate-client`) has no pin here: it must
   // render clean on every adapter, which asserts the suppression contract.
-  // https://github.com/piconic-ai/barefootjs/issues/2038
+  // Faithful lowering tracked: https://github.com/piconic-ai/barefootjs/issues/2320 (successor to #2038)
   'filter-nested-callback-predicate': [
-    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2038' },
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' },
   ],
   'filter-nested-find-predicate': [
-    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2038' },
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' },
   ],
   // NB: TOP-LEVEL `.find` / `.findIndex` / `.findLast` / `.findLastIndex`
   // (text position) are NOT pinned here — like xslate (unlike mojo, which
@@ -101,8 +101,8 @@ export const conformancePins: ConformancePins = {
   // `dangerouslySetInnerHTML={{ __html: '...' }}` is spliced directly into
   // the template as trusted raw text (`resolveDangerousInnerHtml`, #2207).
   // A dynamic/signal-derived value still refuses with BF101 — see the
-  // `dangerous-inner-html-dynamic` fixture/pin below (tracked: #2215).
-  'dangerous-inner-html-dynamic': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2215' }],
+  // `dangerous-inner-html-dynamic` fixture/pin below (tracked: #2319, successor to #2215).
+  'dangerous-inner-html-dynamic': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2319' }],
   // #2273: a method call on a prop typed as a built-in host rich type
   // (Date, Map, …) has no catalogued lowering in any adapter — this is a
   // compiler-level refusal (`checkRichTypeMethodCalls`, wired ahead of

--- a/packages/adapter-mojolicious/src/conformance-pins.ts
+++ b/packages/adapter-mojolicious/src/conformance-pins.ts
@@ -31,12 +31,16 @@ export const conformancePins: ConformancePins = {
   // bind as a template variable — see the dedicated `arrayConst` BF101
   // check in `renderLoop`. This was always true; it was simply
   // unreachable before because BF104 refused the destructure shape first.
-  'static-array-from-props': [{ code: 'BF101', severity: 'error' }],
+  'static-array-from-props': [
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2321' },
+  ],
   // The BF101 above fires; BF104 no longer does (see above), and BF103
   // (sibling-imported `<Tag>` child component in the loop body) no longer
   // does either now that the conformance harness passes
   // `siblingTemplatesRegistered: true` (#2205).
-  'static-array-from-props-with-component': [{ code: 'BF101', severity: 'error' }],
+  'static-array-from-props-with-component': [
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2321' },
+  ],
   // #1310 / #2087: rest destructure in .map() callback. All four shapes
   // now lower via #2087 Phase B's `segments`-walking accessor:
   //   - object-rest read via member access (`rest-destructure-object-in-map`):
@@ -64,9 +68,9 @@ export const conformancePins: ConformancePins = {
   // The nested `.some` sibling (`filter-nested-callback-predicate`) is
   // NOT pinned: Mojo lowers it to a real inline Perl `grep` and must
   // render to Hono parity instead.
-  // https://github.com/piconic-ai/barefootjs/issues/2038
+  // Faithful lowering tracked: https://github.com/piconic-ai/barefootjs/issues/2320 (successor to #2038)
   'filter-nested-find-predicate': [
-    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2038' },
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' },
   ],
   // #1467 demo-corpus context providers (`radio-group`, `accordion`,
   // `dialog`, `popover`, `select`, `dropdown-menu`, `combobox`,
@@ -137,8 +141,8 @@ export const conformancePins: ConformancePins = {
   // `dangerouslySetInnerHTML={{ __html: '...' }}` is spliced directly into
   // the template as trusted raw text (`resolveDangerousInnerHtml`, #2207).
   // A dynamic/signal-derived value still refuses with BF101 — see the
-  // `dangerous-inner-html-dynamic` fixture/pin below (tracked: #2215).
-  'dangerous-inner-html-dynamic': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2215' }],
+  // `dangerous-inner-html-dynamic` fixture/pin below (tracked: #2319, successor to #2215).
+  'dangerous-inner-html-dynamic': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2319' }],
   // #2273: a method call on a prop typed as a built-in host rich type
   // (Date, Map, …) has no catalogued lowering in any adapter — this is a
   // compiler-level refusal (`checkRichTypeMethodCalls`, wired ahead of

--- a/packages/adapter-rust/src/conformance-pins.ts
+++ b/packages/adapter-rust/src/conformance-pins.ts
@@ -42,15 +42,15 @@ export const conformancePins: ConformancePins = {
   // diagnostic (mirrors adapter-jinja's identical check). Fixing the
   // underlying gap (computed-array-from-props as a loop source) is out of
   // scope for #2087; tracked as a follow-up at
-  // https://github.com/piconic-ai/barefootjs/issues/2087.
+  // https://github.com/piconic-ai/barefootjs/issues/2321.
   'static-array-from-props': [
-    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2087' },
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2321' },
   ],
   // BF101 (unresolvable computed loop array, see above) fires; BF103
   // (imported child in the loop body) no longer does now that the
   // conformance harness passes `siblingTemplatesRegistered: true` (#2205).
   'static-array-from-props-with-component': [
-    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2087' },
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2321' },
   ],
   // Rest-destructure `.map()` callbacks (#2087 Phase B): every shape now
   // lowers natively — fixed bindings at any depth/shape via a chained
@@ -80,12 +80,12 @@ export const conformancePins: ConformancePins = {
   // lossy, same as xslate. The `/* @client */` twin
   // (`filter-nested-callback-predicate-client`) has no pin here: it must
   // render clean on every adapter, which asserts the suppression contract.
-  // https://github.com/piconic-ai/barefootjs/issues/2038
+  // Faithful lowering tracked: https://github.com/piconic-ai/barefootjs/issues/2320 (successor to #2038)
   'filter-nested-callback-predicate': [
-    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2038' },
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' },
   ],
   'filter-nested-find-predicate': [
-    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2038' },
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' },
   ],
   // NB: TOP-LEVEL `.find` / `.findIndex` / `.findLast` / `.findLastIndex`
   // (text position) are NOT pinned here — like xslate (unlike mojo, which
@@ -101,8 +101,8 @@ export const conformancePins: ConformancePins = {
   // `dangerouslySetInnerHTML={{ __html: '...' }}` is spliced directly into
   // the template as trusted raw text (`resolveDangerousInnerHtml`, #2207).
   // A dynamic/signal-derived value still refuses with BF101 — see the
-  // `dangerous-inner-html-dynamic` fixture/pin below (tracked: #2215).
-  'dangerous-inner-html-dynamic': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2215' }],
+  // `dangerous-inner-html-dynamic` fixture/pin below (tracked: #2319, successor to #2215).
+  'dangerous-inner-html-dynamic': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2319' }],
   // #2273: a method call on a prop typed as a built-in host rich type
   // (Date, Map, …) has no catalogued lowering in any adapter — this is a
   // compiler-level refusal (`checkRichTypeMethodCalls`, wired ahead of

--- a/packages/adapter-tests/fixtures/dangerous-inner-html-dynamic.ts
+++ b/packages/adapter-tests/fixtures/dangerous-inner-html-dynamic.ts
@@ -12,7 +12,7 @@ import { createFixture } from '../src/types'
  * supports a fully dynamic, even signal-reactive, `__html` — see
  * `packages/jsx/src/__tests__/dangerously-set-inner-html.test.ts` and
  * `compiler-stress-1244.test.ts`), so this is purely a template-adapter
- * gap. Tracked as a deliberate follow-up, not a bug: #2215.
+ * gap. Tracked as a deliberate follow-up, not a bug: #2319 (successor to #2215).
  */
 export const fixture = createFixture({
   id: 'dangerous-inner-html-dynamic',

--- a/packages/adapter-tests/fixtures/dangerous-inner-html.ts
+++ b/packages/adapter-tests/fixtures/dangerous-inner-html.ts
@@ -8,7 +8,7 @@ import { createFixture } from '../src/types'
  * that language's own template metacharacters), so this renders correctly
  * on every adapter, not just Hono. The DYNAMIC (non-literal) case is a
  * separate fixture — `dangerous-inner-html-dynamic` — which still refuses
- * with BF101 on every template adapter (tracked: #2215).
+ * with BF101 on every template adapter (tracked: #2319).
  */
 export const fixture = createFixture({
   id: 'dangerous-inner-html',

--- a/packages/adapter-tests/fixtures/filter-nested-callback-predicate.ts
+++ b/packages/adapter-tests/fixtures/filter-nested-callback-predicate.ts
@@ -16,6 +16,7 @@ import { createFixture } from '../src/types'
  *   - Go template / Xslate have no faithful nested form and now surface a
  *     loud BF101 (declared via those adapters' `expectedDiagnostics`)
  *     instead of the silent lossy lambda.
+ * Faithful SSR lowering for the nested callback is tracked in #2320.
  */
 export const fixture = createFixture({
   id: 'filter-nested-callback-predicate',

--- a/packages/adapter-tests/fixtures/filter-nested-find-predicate.ts
+++ b/packages/adapter-tests/fixtures/filter-nested-find-predicate.ts
@@ -11,6 +11,7 @@ import { createFixture } from '../src/types'
  *   - Hono / CSR evaluate JS natively and render the chain faithfully.
  *   - Go template / Mojo / Xslate surface a loud BF101 (declared via each
  *     adapter's `expectedDiagnostics`) instead of a silent lossy rewrite.
+ * Faithful SSR lowering for the nested callback is tracked in #2320.
  */
 export const fixture = createFixture({
   id: 'filter-nested-find-predicate',

--- a/packages/adapter-tests/fixtures/static-array-from-props-with-component.ts
+++ b/packages/adapter-tests/fixtures/static-array-from-props-with-component.ts
@@ -26,6 +26,8 @@ import { createFixture } from '../src/types'
  * param (`([id, t]) => ...`). Adapters that can't lower either
  * declare the matching diagnostics via `expectedDiagnostics` on
  * their own test file (#1266).
+ * The remaining template-adapter refusal (computed component-scope const as
+ * the loop source) is tracked in #2321.
  */
 export const fixture = createFixture({
   id: 'static-array-from-props-with-component',

--- a/packages/adapter-tests/fixtures/static-array-from-props.ts
+++ b/packages/adapter-tests/fixtures/static-array-from-props.ts
@@ -17,6 +17,8 @@ import { createFixture } from '../src/types'
  * surfaced as parse errors at request time. Adapters that refuse this
  * shape assert the corresponding diagnostic via `expectedDiagnostics`
  * on their own test file (#1266).
+ * The remaining template-adapter refusal (computed component-scope const as
+ * the loop source) is tracked in #2321.
  */
 export const fixture = createFixture({
   id: 'static-array-from-props',

--- a/packages/adapter-twig/src/conformance-pins.ts
+++ b/packages/adapter-twig/src/conformance-pins.ts
@@ -29,11 +29,15 @@ export const conformancePins: ConformancePins = {
   // can't bind as a template variable — refused loudly with BF101 (same
   // check and policy as Jinja / ERB) instead of silently iterating zero
   // times over an unbound name.
-  'static-array-from-props': [{ code: 'BF101', severity: 'error' }],
+  'static-array-from-props': [
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2321' },
+  ],
   // BF101 (computed local-const loop array, as above) fires; BF103
   // (imported child in the loop body) no longer does now that the
   // conformance harness passes `siblingTemplatesRegistered: true` (#2205).
-  'static-array-from-props-with-component': [{ code: 'BF101', severity: 'error' }],
+  'static-array-from-props-with-component': [
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2321' },
+  ],
   // #2087 Phase B: every `.map()` destructure shape in the shared corpus
   // now lowers on Twig via a `{% set %}` local built from the binding's
   // structured `segments` path (`twigLoopBindingAccessor` in
@@ -63,12 +67,12 @@ export const conformancePins: ConformancePins = {
   // lossy, same as Jinja. The `/* @client */` twin
   // (`filter-nested-callback-predicate-client`) has no pin here: it must
   // render clean on every adapter, which asserts the suppression contract.
-  // https://github.com/piconic-ai/barefootjs/issues/2038
+  // Faithful lowering tracked: https://github.com/piconic-ai/barefootjs/issues/2320 (successor to #2038)
   'filter-nested-callback-predicate': [
-    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2038' },
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' },
   ],
   'filter-nested-find-predicate': [
-    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2038' },
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' },
   ],
   // NB: TOP-LEVEL `.find` / `.findIndex` / `.findLast` / `.findLastIndex`
   // (text position) are NOT pinned here — like Jinja (unlike mojo, which
@@ -84,8 +88,8 @@ export const conformancePins: ConformancePins = {
   // `dangerouslySetInnerHTML={{ __html: '...' }}` is spliced directly into
   // the template as trusted raw text (`resolveDangerousInnerHtml`, #2207).
   // A dynamic/signal-derived value still refuses with BF101 — see the
-  // `dangerous-inner-html-dynamic` fixture/pin below (tracked: #2215).
-  'dangerous-inner-html-dynamic': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2215' }],
+  // `dangerous-inner-html-dynamic` fixture/pin below (tracked: #2319, successor to #2215).
+  'dangerous-inner-html-dynamic': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2319' }],
   // #2273: a method call on a prop typed as a built-in host rich type
   // (Date, Map, …) has no catalogued lowering in any adapter — this is a
   // compiler-level refusal (`checkRichTypeMethodCalls`, wired ahead of

--- a/packages/adapter-xslate/src/conformance-pins.ts
+++ b/packages/adapter-xslate/src/conformance-pins.ts
@@ -31,12 +31,16 @@ export const conformancePins: ConformancePins = {
   // `arrayConst` BF101 check in `renderLoop`. This was always true; it was
   // simply unreachable before because BF104 refused the destructure shape
   // first.
-  'static-array-from-props': [{ code: 'BF101', severity: 'error' }],
+  'static-array-from-props': [
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2321' },
+  ],
   // The BF101 above fires; BF104 no longer does (see above), and BF103
   // (sibling-imported `<Tag>` child component in the loop body) no longer
   // does either now that the conformance harness passes
   // `siblingTemplatesRegistered: true` (#2205).
-  'static-array-from-props-with-component': [{ code: 'BF101', severity: 'error' }],
+  'static-array-from-props-with-component': [
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2321' },
+  ],
   // #1310 / #2087: rest destructure in .map() callback. All four shapes now
   // lower via #2087 Phase B's `segments`-walking accessor:
   //   - object-rest read via member access (`rest-destructure-object-in-map`):
@@ -90,12 +94,12 @@ export const conformancePins: ConformancePins = {
   // Perl `grep`.) The `/* @client */` twin
   // (`filter-nested-callback-predicate-client`) has no pin here: it must
   // render clean on every adapter, which asserts the suppression contract.
-  // https://github.com/piconic-ai/barefootjs/issues/2038
+  // Faithful lowering tracked: https://github.com/piconic-ai/barefootjs/issues/2320 (successor to #2038)
   'filter-nested-callback-predicate': [
-    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2038' },
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' },
   ],
   'filter-nested-find-predicate': [
-    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2038' },
+    { code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' },
   ],
   // NB: TOP-LEVEL `.find` / `.findIndex` / `.findLast` / `.findLastIndex`
   // (text position) are NOT pinned here — unlike mojo (which refuses them),
@@ -111,8 +115,8 @@ export const conformancePins: ConformancePins = {
   // `dangerouslySetInnerHTML={{ __html: '...' }}` is spliced directly into
   // the template as trusted raw text (`resolveDangerousInnerHtml`, #2207).
   // A dynamic/signal-derived value still refuses with BF101 — see the
-  // `dangerous-inner-html-dynamic` fixture/pin below (tracked: #2215).
-  'dangerous-inner-html-dynamic': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2215' }],
+  // `dangerous-inner-html-dynamic` fixture/pin below (tracked: #2319, successor to #2215).
+  'dangerous-inner-html-dynamic': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2319' }],
   // #2273: a method call on a prop typed as a built-in host rich type
   // (Date, Map, …) has no catalogued lowering in any adapter — this is a
   // compiler-level refusal (`checkRichTypeMethodCalls`, wired ahead of

--- a/packages/compat/src/__tests__/compat-engine.test.ts
+++ b/packages/compat/src/__tests__/compat-engine.test.ts
@@ -45,19 +45,22 @@ describe('compileForCompat', () => {
     expect(cell.ok).toBe(false)
     // `issues` is the UNION of every issue URL any BF101 pin carries on
     // this adapter (buildCompatCell attributes by code, not by fixture —
-    // see its docstring) — #2038 (this shape, nested filter callback) and
-    // #2215 (dangerous-inner-html-dynamic, #2207's PR) surface here even
-    // though this test only exercises #2038's shape. #2208's
-    // `static-array-children` BF101 pin was removed (its loop-source gate
-    // now bakes a fully-static array-of-objects const directly) — see
-    // `go-template`'s `conformance-pins.ts`.
+    // see its docstring) — #2320 (this shape, nested filter callback,
+    // successor to #2038), #2319 (dangerous-inner-html-dynamic, successor
+    // to #2215), and #2321 (static-array-from-props computed loop source)
+    // all surface here even though this test only exercises the nested-
+    // filter-callback shape. #2208's `static-array-children` BF101 pin was
+    // removed (its loop-source gate now bakes a fully-static
+    // array-of-objects const directly) — see `go-template`'s
+    // `conformance-pins.ts`.
     expect(cell.diagnostics).toEqual([
       {
         code: 'BF101',
         severity: 'error',
         issues: [
-          'https://github.com/piconic-ai/barefootjs/issues/2038',
-          'https://github.com/piconic-ai/barefootjs/issues/2215',
+          'https://github.com/piconic-ai/barefootjs/issues/2319',
+          'https://github.com/piconic-ai/barefootjs/issues/2320',
+          'https://github.com/piconic-ai/barefootjs/issues/2321',
         ],
       },
     ])

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1823,7 +1823,7 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2215"
+            "https://github.com/piconic-ai/barefootjs/issues/2319"
           ]
         },
         "erb": {
@@ -1832,7 +1832,7 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2215"
+            "https://github.com/piconic-ai/barefootjs/issues/2319"
           ]
         },
         "go-template": {
@@ -1841,7 +1841,7 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2215"
+            "https://github.com/piconic-ai/barefootjs/issues/2319"
           ]
         },
         "jinja": {
@@ -1850,7 +1850,7 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2215"
+            "https://github.com/piconic-ai/barefootjs/issues/2319"
           ]
         },
         "minijinja": {
@@ -1859,7 +1859,7 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2215"
+            "https://github.com/piconic-ai/barefootjs/issues/2319"
           ]
         },
         "mojolicious": {
@@ -1868,7 +1868,7 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2215"
+            "https://github.com/piconic-ai/barefootjs/issues/2319"
           ]
         },
         "twig": {
@@ -1877,7 +1877,7 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2215"
+            "https://github.com/piconic-ai/barefootjs/issues/2319"
           ]
         },
         "xslate": {
@@ -1886,7 +1886,7 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2215"
+            "https://github.com/piconic-ai/barefootjs/issues/2319"
           ]
         }
       },
@@ -1980,7 +1980,7 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2038"
+            "https://github.com/piconic-ai/barefootjs/issues/2320"
           ]
         },
         "go-template": {
@@ -1989,7 +1989,7 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2038"
+            "https://github.com/piconic-ai/barefootjs/issues/2320"
           ]
         },
         "jinja": {
@@ -1998,7 +1998,7 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2038"
+            "https://github.com/piconic-ai/barefootjs/issues/2320"
           ]
         },
         "minijinja": {
@@ -2007,7 +2007,7 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2038"
+            "https://github.com/piconic-ai/barefootjs/issues/2320"
           ]
         },
         "twig": {
@@ -2016,7 +2016,7 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2038"
+            "https://github.com/piconic-ai/barefootjs/issues/2320"
           ]
         },
         "xslate": {
@@ -2025,7 +2025,7 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2038"
+            "https://github.com/piconic-ai/barefootjs/issues/2320"
           ]
         }
       },
@@ -2036,7 +2036,7 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2038"
+            "https://github.com/piconic-ai/barefootjs/issues/2320"
           ]
         },
         "erb": {
@@ -2045,7 +2045,7 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2038"
+            "https://github.com/piconic-ai/barefootjs/issues/2320"
           ]
         },
         "go-template": {
@@ -2054,7 +2054,7 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2038"
+            "https://github.com/piconic-ai/barefootjs/issues/2320"
           ]
         },
         "jinja": {
@@ -2063,7 +2063,7 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2038"
+            "https://github.com/piconic-ai/barefootjs/issues/2320"
           ]
         },
         "minijinja": {
@@ -2072,7 +2072,7 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2038"
+            "https://github.com/piconic-ai/barefootjs/issues/2320"
           ]
         },
         "mojolicious": {
@@ -2081,7 +2081,7 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2038"
+            "https://github.com/piconic-ai/barefootjs/issues/2320"
           ]
         },
         "twig": {
@@ -2090,7 +2090,7 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2038"
+            "https://github.com/piconic-ai/barefootjs/issues/2320"
           ]
         },
         "xslate": {
@@ -2099,7 +2099,7 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2038"
+            "https://github.com/piconic-ai/barefootjs/issues/2320"
           ]
         }
       },
@@ -2108,6 +2108,9 @@
           "kind": "refusal",
           "codes": [
             "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2321"
           ]
         },
         "erb": {
@@ -2116,13 +2119,16 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2087"
+            "https://github.com/piconic-ai/barefootjs/issues/2321"
           ]
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2321"
           ]
         },
         "jinja": {
@@ -2131,7 +2137,7 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2087"
+            "https://github.com/piconic-ai/barefootjs/issues/2321"
           ]
         },
         "minijinja": {
@@ -2140,25 +2146,34 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2087"
+            "https://github.com/piconic-ai/barefootjs/issues/2321"
           ]
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2321"
           ]
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2321"
           ]
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2321"
           ]
         }
       },
@@ -2167,6 +2182,9 @@
           "kind": "refusal",
           "codes": [
             "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2321"
           ]
         },
         "erb": {
@@ -2175,13 +2193,16 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2087"
+            "https://github.com/piconic-ai/barefootjs/issues/2321"
           ]
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2321"
           ]
         },
         "jinja": {
@@ -2190,7 +2211,7 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2087"
+            "https://github.com/piconic-ai/barefootjs/issues/2321"
           ]
         },
         "minijinja": {
@@ -2199,25 +2220,34 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2087"
+            "https://github.com/piconic-ai/barefootjs/issues/2321"
           ]
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2321"
           ]
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2321"
           ]
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2321"
           ]
         }
       }

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -27,13 +27,13 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -45,7 +45,7 @@
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -57,13 +57,13 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -75,13 +75,13 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -93,13 +93,13 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -111,7 +111,7 @@
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -123,13 +123,13 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -141,13 +141,13 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -209,13 +209,13 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -227,7 +227,7 @@
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -239,13 +239,13 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -257,13 +257,13 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -275,13 +275,13 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -293,7 +293,7 @@
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -305,13 +305,13 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -323,13 +323,13 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -350,18 +350,20 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -372,13 +374,13 @@
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -390,18 +392,20 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -412,19 +416,19 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -436,19 +440,19 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -460,12 +464,14 @@
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -476,18 +482,20 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -498,18 +506,20 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         }
@@ -543,22 +553,26 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             },
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -575,19 +589,19 @@
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -605,22 +619,26 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             },
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -637,25 +655,25 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -673,25 +691,25 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -709,16 +727,20 @@
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             },
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -735,22 +757,26 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             },
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -767,22 +793,26 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             },
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         }
@@ -851,7 +881,7 @@
             {
               "fixture": "dangerous-inner-html-dynamic",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2215"
+                "https://github.com/piconic-ai/barefootjs/issues/2319"
               ]
             },
             {
@@ -863,22 +893,26 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             },
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -889,7 +923,7 @@
             {
               "fixture": "dangerous-inner-html-dynamic",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2215"
+                "https://github.com/piconic-ai/barefootjs/issues/2319"
               ]
             },
             {
@@ -901,19 +935,19 @@
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -925,7 +959,7 @@
             {
               "fixture": "dangerous-inner-html-dynamic",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2215"
+                "https://github.com/piconic-ai/barefootjs/issues/2319"
               ]
             },
             {
@@ -937,22 +971,26 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             },
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -963,7 +1001,7 @@
             {
               "fixture": "dangerous-inner-html-dynamic",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2215"
+                "https://github.com/piconic-ai/barefootjs/issues/2319"
               ]
             },
             {
@@ -975,25 +1013,25 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -1005,7 +1043,7 @@
             {
               "fixture": "dangerous-inner-html-dynamic",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2215"
+                "https://github.com/piconic-ai/barefootjs/issues/2319"
               ]
             },
             {
@@ -1017,25 +1055,25 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -1047,7 +1085,7 @@
             {
               "fixture": "dangerous-inner-html-dynamic",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2215"
+                "https://github.com/piconic-ai/barefootjs/issues/2319"
               ]
             },
             {
@@ -1059,16 +1097,20 @@
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             },
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -1079,7 +1121,7 @@
             {
               "fixture": "dangerous-inner-html-dynamic",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2215"
+                "https://github.com/piconic-ai/barefootjs/issues/2319"
               ]
             },
             {
@@ -1091,22 +1133,26 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             },
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -1117,7 +1163,7 @@
             {
               "fixture": "dangerous-inner-html-dynamic",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2215"
+                "https://github.com/piconic-ai/barefootjs/issues/2319"
               ]
             },
             {
@@ -1129,22 +1175,26 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             },
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         }
@@ -1204,7 +1254,9 @@
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -1215,7 +1267,7 @@
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -1226,7 +1278,9 @@
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -1237,7 +1291,7 @@
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -1249,7 +1303,7 @@
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -1260,7 +1314,9 @@
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -1270,7 +1326,9 @@
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -1280,7 +1338,9 @@
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         }
@@ -1299,7 +1359,9 @@
           "gaps": [
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -1310,7 +1372,7 @@
             {
               "fixture": "static-array-from-props",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -1321,7 +1383,9 @@
           "gaps": [
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -1332,7 +1396,7 @@
             {
               "fixture": "static-array-from-props",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -1344,7 +1408,7 @@
             {
               "fixture": "static-array-from-props",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -1355,7 +1419,9 @@
           "gaps": [
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -1365,7 +1431,9 @@
           "gaps": [
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -1375,7 +1443,9 @@
           "gaps": [
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         }
@@ -1409,22 +1479,26 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             },
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -1441,19 +1515,19 @@
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -1471,22 +1545,26 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             },
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -1503,25 +1581,25 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -1539,25 +1617,25 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -1575,16 +1653,20 @@
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             },
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -1601,22 +1683,26 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             },
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -1633,22 +1719,26 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             },
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         }
@@ -1668,12 +1758,14 @@
             {
               "fixture": "dangerous-inner-html-dynamic",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2215"
+                "https://github.com/piconic-ai/barefootjs/issues/2319"
               ]
             },
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -1684,13 +1776,13 @@
             {
               "fixture": "dangerous-inner-html-dynamic",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2215"
+                "https://github.com/piconic-ai/barefootjs/issues/2319"
               ]
             },
             {
               "fixture": "static-array-from-props",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -1702,12 +1794,14 @@
             {
               "fixture": "dangerous-inner-html-dynamic",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2215"
+                "https://github.com/piconic-ai/barefootjs/issues/2319"
               ]
             },
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -1718,13 +1812,13 @@
             {
               "fixture": "dangerous-inner-html-dynamic",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2215"
+                "https://github.com/piconic-ai/barefootjs/issues/2319"
               ]
             },
             {
               "fixture": "static-array-from-props",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -1736,13 +1830,13 @@
             {
               "fixture": "dangerous-inner-html-dynamic",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2215"
+                "https://github.com/piconic-ai/barefootjs/issues/2319"
               ]
             },
             {
               "fixture": "static-array-from-props",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -1754,12 +1848,14 @@
             {
               "fixture": "dangerous-inner-html-dynamic",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2215"
+                "https://github.com/piconic-ai/barefootjs/issues/2319"
               ]
             },
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -1770,12 +1866,14 @@
             {
               "fixture": "dangerous-inner-html-dynamic",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2215"
+                "https://github.com/piconic-ai/barefootjs/issues/2319"
               ]
             },
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -1786,12 +1884,14 @@
             {
               "fixture": "dangerous-inner-html-dynamic",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2215"
+                "https://github.com/piconic-ai/barefootjs/issues/2319"
               ]
             },
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         }
@@ -1893,7 +1993,7 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -1909,7 +2009,7 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -1921,7 +2021,7 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -1933,7 +2033,7 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -1949,7 +2049,7 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -1961,7 +2061,7 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -1981,11 +2081,15 @@
           "gaps": [
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             },
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -1996,13 +2100,13 @@
             {
               "fixture": "static-array-from-props",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -2013,11 +2117,15 @@
           "gaps": [
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             },
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -2028,13 +2136,13 @@
             {
               "fixture": "static-array-from-props",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -2046,13 +2154,13 @@
             {
               "fixture": "static-array-from-props",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             },
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -2063,11 +2171,15 @@
           "gaps": [
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             },
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -2077,11 +2189,15 @@
           "gaps": [
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             },
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -2091,11 +2207,15 @@
           "gaps": [
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             },
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         }
@@ -3223,7 +3343,9 @@
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -3234,7 +3356,7 @@
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -3245,7 +3367,9 @@
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -3256,7 +3380,7 @@
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -3268,7 +3392,7 @@
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -3279,7 +3403,9 @@
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -3289,7 +3415,9 @@
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -3299,7 +3427,9 @@
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         }
@@ -3442,13 +3572,13 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -3460,7 +3590,7 @@
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -3472,13 +3602,13 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -3490,13 +3620,13 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -3508,13 +3638,13 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -3526,7 +3656,7 @@
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -3538,13 +3668,13 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -3556,13 +3686,13 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             },
             {
               "fixture": "filter-nested-find-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -3787,7 +3917,9 @@
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -3798,7 +3930,7 @@
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -3809,7 +3941,9 @@
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -3820,7 +3954,7 @@
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -3832,7 +3966,7 @@
             {
               "fixture": "static-array-from-props-with-component",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -3843,7 +3977,9 @@
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -3853,7 +3989,9 @@
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -3863,7 +4001,9 @@
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         }
@@ -3923,7 +4063,9 @@
           "gaps": [
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -3934,7 +4076,7 @@
             {
               "fixture": "static-array-from-props",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -3945,7 +4087,9 @@
           "gaps": [
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -3956,7 +4100,7 @@
             {
               "fixture": "static-array-from-props",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -3968,7 +4112,7 @@
             {
               "fixture": "static-array-from-props",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2087"
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
             }
           ]
@@ -3979,7 +4123,9 @@
           "gaps": [
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -3989,7 +4135,9 @@
           "gaps": [
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         },
@@ -3999,7 +4147,9 @@
           "gaps": [
             {
               "fixture": "static-array-from-props",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
             }
           ]
         }
@@ -4142,7 +4292,7 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -4158,7 +4308,7 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -4170,7 +4320,7 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -4182,7 +4332,7 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -4198,7 +4348,7 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]
@@ -4210,7 +4360,7 @@
             {
               "fixture": "filter-nested-callback-predicate",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2038"
+                "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
             }
           ]


### PR DESCRIPTION
## Why

The [compatibility matrix](https://barefootjs.dev/docs/advanced/compatibility-matrix)'s render-honesty rows (6 divergent fixtures) all attributed their refusals to issues that have since been **closed** (#2038, #2087, #2215), so the tracked limitations had no open tracker — violating the repo's known-limitation convention (pins carry a pointer to the per-issue URL of an open tracked limitation, and the `known-limitation` label URL is the source of truth).

None of the six rows is mechanically fixable in code — each refusal is a deliberate loud BF101/BF021 whose real fix needs a design decision. Those decisions are now captured in three successor trackers:

- #2319 — dynamic/signal-derived `dangerouslySetInnerHTML` on the 8 template adapters (successor to #2215, whose lowering bullet never landed)
- #2320 — faithful SSR lowering for nested higher-order callbacks in filter predicates (successor to #2038, whose landed scope was the loud refusal itself)
- #2321 — computed component-scope const as loop source (`static-array-from-props`; previously a placeholder attribution to #2087, explicitly out of that issue's destructure scope)

`date-method-uncatalogued` intentionally keeps its #2274 pointer: `toLocaleDateString` is permanently uncatalogued by design (#2273's closed wall), so that reference is rationale attribution, not a pending-fix tracker.

## What

- **8 adapter `conformance-pins.ts`**: swap the `issue:` URLs (2215→2319, 2038→2320, 2087→2321) and the associated tracking comments. The five adapters that pinned `static-array-from-props(-with-component)` with **no** issue attribution (blade, go-template, mojolicious, twig, xslate) now carry #2321 too, so the matrix attributes every cell consistently.
- **6 fixture docstrings** in `packages/adapter-tests/fixtures/`: point at the successor trackers.
- **`ui/compat.lock.json` / `ui/support-matrix.lock.json`**: regenerated (`bun run compat:lock` / `bun run support-matrix:lock`) — the docs page links now resolve to open issues.
- **`packages/compat/src/__tests__/compat-engine.test.ts`**: the pinned issue-URL union for the go-template BF101 cell updated (it now includes #2321 since the static-array pins gained attribution).

No behavioral change: diagnostics codes, severities, and every pinned refusal are untouched — this is tracking metadata only.

## Verification

- `bun test packages/compat` — 80 pass / 0 fail
- `bun test packages/adapter-tests` — 1316 pass / 0 fail
- `bun test packages/adapter-erb` (real-backend conformance incl. `expectedDiagnostics` from the pins) — 810 pass / 2 skip / 0 fail
- Lock regeneration is drift-free before and after (same command CI's `ci-compat.yml` gate runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dBKFhtumbPwjNZaU3LRpy

---
_Generated by [Claude Code](https://claude.ai/code/session_015dBKFhtumbPwjNZaU3LRpy)_