### PR TITLE
Add #2324 slice 2: literal-locale toLocaleDateString sugar over format_date

### DIFF
--- a/.changeset/tolocale-literal-sugar.md
+++ b/.changeset/tolocale-literal-sugar.md
@@ -1,0 +1,5 @@
+---
+'@barefootjs/jsx': minor
+---
+
+Literal-locale `toLocaleDateString` sugar (#2324 slice 2): `date.toLocaleDateString('ja-JP', { timeZone: 'UTC' })` on a `Date`-typed prop — with a compile-time-literal locale and an explicit `'UTC'`/`±HH:MM` timeZone — now compiles. The compiler resolves the locale's default date pattern once at build time and lowers to the existing `format_date` helper on the SSR path and to `formatDate(...)` on the client-JS path, so output is byte-identical across all backends and the browser with no runtime ICU anywhere. Implicit-environment shapes (zero-arg, locale-only, runtime locale, IANA zone names) keep refusing with BF021, whose message now points at the explicit-input forms.

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -1480,6 +1480,21 @@
         "text"
       ]
     },
+    "date-tolocale-literal": {
+      "kinds": [
+        "call",
+        "identifier",
+        "literal",
+        "member",
+        "object-literal"
+      ],
+      "axes": [
+        "literal:string"
+      ],
+      "contexts": [
+        "text"
+      ]
+    },
     "deep-nesting": {
       "kinds": [
         "call",
@@ -4117,14 +4132,14 @@
     "array-method": 62,
     "arrow": 55,
     "binary": 67,
-    "call": 158,
+    "call": 159,
     "conditional": 18,
-    "identifier": 238,
+    "identifier": 239,
     "index-access": 12,
-    "literal": 196,
+    "literal": 197,
     "logical": 41,
-    "member": 119,
-    "object-literal": 42,
+    "member": 120,
+    "object-literal": 43,
     "template-literal": 27,
     "unary": 22,
     "unsupported": 21
@@ -4167,7 +4182,7 @@
     "literal:boolean": 37,
     "literal:null": 22,
     "literal:number": 85,
-    "literal:string": 140,
+    "literal:string": 141,
     "logical:&&": 7,
     "logical:??": 37,
     "logical:||": 12,

--- a/packages/adapter-tests/fixtures/date-tolocale-literal.ts
+++ b/packages/adapter-tests/fixtures/date-tolocale-literal.ts
@@ -1,0 +1,54 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Literal-locale `toLocaleDateString` sugar (#2324 slice 2): a `Date`-typed
+ * prop's `.toLocaleDateString(<literal locale>, { timeZone: <literal> })`
+ * resolves the locale's default date pattern once at BUILD time and lowers
+ * to the same neutral `format_date` helper-call as `formatDate(...)` — so
+ * the template adapters render the frozen pattern with no runtime ICU,
+ * while Hono (evaluating real ECMA-402 against the same build-machine ICU)
+ * must agree byte-for-byte. The client JS is rewritten to
+ * `formatDate(recv, pattern, tz)` (#2292-style), which the CSR conformance
+ * side exercises.
+ *
+ * The zero-arg sibling stays refused — see `date-method-uncatalogued` —
+ * as do runtime locales and IANA zone names (implicit environment /
+ * host-tzdata coupling; `to-locale-date-lowering.ts` module doc).
+ *
+ * The base instant sits at 23:00Z so the `+09:00` cell crosses the date
+ * boundary forward. The type-derived adversarial grid contributes the
+ * epoch / pre-1970 / leap-day / year-9999 instants; `year-9999` × the
+ * `+09:00` cell lands in year 10000, pinning that no backend's date type
+ * caps out (the Python civil-from-days lesson from the `format-date`
+ * fixture).
+ */
+export const fixture = createFixture({
+  id: 'date-tolocale-literal',
+  description: 'toLocaleDateString with literal locale + timeZone compiles to the format_date helper',
+  source: `
+function DateToLocaleLiteral({ createdAt }: { createdAt: Date }) {
+  return (
+    <div>
+      <time>{createdAt.toLocaleDateString('en-US', { timeZone: 'UTC' })}</time>
+      <span>{createdAt.toLocaleDateString('ja-JP', { timeZone: '+09:00' })}</span>
+    </div>
+  )
+}
+export { DateToLocaleLiteral }
+`,
+  props: { createdAt: new Date('2024-01-01T23:00:00.000Z') },
+  dataPoints: [
+    // Early-morning instant: the +09:00 cell stays same-day while a
+    // midnight-boundary regression would show up in either cell.
+    { name: 'same-day-offset', props: { createdAt: new Date('2024-01-01T01:00:00.000Z') } },
+    // 15:00Z on a leap day: +09:00 crosses to March 1st while UTC stays
+    // on 02-29 — the two cells disagree on month AND day.
+    { name: 'leap-day-split', props: { createdAt: new Date('2024-02-29T15:00:00.000Z') } },
+  ],
+  expectedHtml: `
+    <div bf-s="test">
+      <time bf="s1"><!--bf:s0-->1/1/2024<!--/--></time>
+      <span bf="s3"><!--bf:s2-->2024/1/2<!--/--></span>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -388,6 +388,7 @@ import { fixture as loopParamShadowsRecordConst } from './loop-param-shadows-rec
 import { fixture as dateMethodUncatalogued } from './date-method-uncatalogued'
 import { fixture as dateCatalogued } from './date-catalogued'
 import { fixture as formatDate } from './format-date'
+import { fixture as dateToLocaleLiteral } from './date-tolocale-literal'
 // #2277: the union- and object-typed catalogue extensions to the
 // type-derived adversarial catalogue (`adversarial-catalog.ts`), mirroring
 // the landed Date catalogue work above.
@@ -676,6 +677,7 @@ export const jsxFixtures: JSXFixture[] = [
   dateMethodUncatalogued,
   dateCatalogued,
   formatDate,
+  dateToLocaleLiteral,
   unionCatalogued,
   objectCatalogued,
 ]

--- a/packages/adapter-tests/generated-data-points.json
+++ b/packages/adapter-tests/generated-data-points.json
@@ -522,6 +522,40 @@
       }
     }
   ],
+  "date-tolocale-literal": [
+    {
+      "name": "gen:createdAt:epoch",
+      "props": {
+        "createdAt": {
+          "$date": "1970-01-01T00:00:00.000Z"
+        }
+      }
+    },
+    {
+      "name": "gen:createdAt:pre-1970",
+      "props": {
+        "createdAt": {
+          "$date": "1969-07-20T20:17:40.123Z"
+        }
+      }
+    },
+    {
+      "name": "gen:createdAt:leap-day",
+      "props": {
+        "createdAt": {
+          "$date": "2024-02-29T12:00:00.000Z"
+        }
+      }
+    },
+    {
+      "name": "gen:createdAt:year-9999",
+      "props": {
+        "createdAt": {
+          "$date": "9999-12-31T23:59:59.999Z"
+        }
+      }
+    }
+  ],
   "default-props": [
     {
       "name": "gen:label:absent",

--- a/packages/jsx/src/__tests__/to-locale-date-lowering.test.ts
+++ b/packages/jsx/src/__tests__/to-locale-date-lowering.test.ts
@@ -96,6 +96,11 @@ describe('matchToLocaleDateStringCall accept/decline table', () => {
     expect(match(`createdAt.toLocaleDateString('ja-JP', { timeZone: 'Asia/Tokyo' })`)).toBeNull()
     // non-literal timeZone
     expect(match(`createdAt.toLocaleDateString('ja-JP', { timeZone: tz })`)).toBeNull()
+    // out-of-range fixed offsets: real toLocaleDateString throws RangeError
+    // on these, so lowering them would diverge from JS semantics
+    expect(match(`createdAt.toLocaleDateString('ja-JP', { timeZone: '+25:00' })`)).toBeNull()
+    expect(match(`createdAt.toLocaleDateString('ja-JP', { timeZone: '+99:99' })`)).toBeNull()
+    expect(match(`createdAt.toLocaleDateString('ja-JP', { timeZone: '-12:60' })`)).toBeNull()
     // options beyond timeZone: the name-table stage, not this slice
     expect(match(`createdAt.toLocaleDateString('ja-JP', { timeZone: 'UTC', month: 'long' })`)).toBeNull()
     expect(match(`createdAt.toLocaleDateString('ja-JP', { dateStyle: 'long' })`)).toBeNull()

--- a/packages/jsx/src/__tests__/to-locale-date-lowering.test.ts
+++ b/packages/jsx/src/__tests__/to-locale-date-lowering.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Literal-locale `toLocaleDateString` sugar (#2324 slice 2). Covers the
+ * build-time pattern derivation's structural gate, the matcher's
+ * accept/decline table (only the explicit-input literal shape lowers; every
+ * implicit-environment or runtime-value shape declines to BF021), the
+ * BF021-exemption round trip through the real registry, and the client-JS
+ * rewrite to `formatDate(recv, pattern, tz)` (mirrors
+ * `date-lowering.test.ts`'s #2292 section).
+ */
+import { describe, test, expect } from 'bun:test'
+import { compileJSX, type ComponentIR } from '../index'
+import { TestAdapter } from '../adapters/test-adapter'
+import { parseExpression, type ParsedExpr } from '../expression-parser'
+import {
+  resolveLocaleDatePattern,
+  matchToLocaleDateStringCall,
+  toLocaleDatePlugin,
+} from '../to-locale-date-lowering'
+import { ErrorCodes } from '../errors'
+
+function compile(src: string) {
+  return compileJSX(src.trimStart(), 'T.tsx', { adapter: new TestAdapter(), outputIR: true })
+}
+
+function metadata(src: string): ComponentIR['metadata'] {
+  const result = compile(src)
+  const ir = JSON.parse(result.files.find((f) => f.type === 'ir')!.content) as ComponentIR
+  return ir.metadata
+}
+
+function callParts(expr: string): { callee: ParsedExpr; args: ParsedExpr[] } {
+  const parsed = parseExpression(expr)
+  if (parsed.kind !== 'call') throw new Error(`expected a call expression, got ${parsed.kind}`)
+  return { callee: parsed.callee, args: parsed.args }
+}
+
+const DATE_PROP_SRC = `
+export function Foo({ createdAt }: { createdAt: Date }) {
+  return <div>{createdAt.toLocaleDateString('en-US', { timeZone: 'UTC' })}</div>
+}
+`
+
+describe('resolveLocaleDatePattern (build-time derivation)', () => {
+  test('derives numeric default patterns per locale', () => {
+    expect(resolveLocaleDatePattern('en-US')).toBe('M/D/YYYY')
+    expect(resolveLocaleDatePattern('ja-JP')).toBe('YYYY/M/D')
+    expect(resolveLocaleDatePattern('en-GB')).toBe('DD/MM/YYYY')
+  })
+
+  test('declines non-gregorian / non-latin-digit defaults (ar-SA) and invalid tags', () => {
+    expect(resolveLocaleDatePattern('ar-SA')).toBeNull()
+    expect(resolveLocaleDatePattern('not a locale !!')).toBeNull()
+  })
+})
+
+describe('matchToLocaleDateStringCall accept/decline table', () => {
+  const md = metadata(DATE_PROP_SRC)
+
+  function match(expr: string) {
+    const { callee, args } = callParts(expr)
+    return matchToLocaleDateStringCall(callee, args, md)
+  }
+
+  test('literal locale + literal UTC timeZone lowers to format_date with the frozen pattern', () => {
+    const node = match(`createdAt.toLocaleDateString('en-US', { timeZone: 'UTC' })`)
+    expect(node).toEqual({
+      kind: 'helper-call',
+      helper: 'format_date',
+      args: [
+        { kind: 'identifier', name: 'createdAt' },
+        { kind: 'literal', value: 'M/D/YYYY', literalType: 'string' },
+        { kind: 'literal', value: 'UTC', literalType: 'string' },
+      ],
+    })
+  })
+
+  test('a fixed ±HH:MM offset timeZone is admitted', () => {
+    const node = match(`createdAt.toLocaleDateString('ja-JP', { timeZone: '+09:00' })`)
+    expect(node).toMatchObject({
+      helper: 'format_date',
+      args: [
+        { kind: 'identifier', name: 'createdAt' },
+        { kind: 'literal', value: 'YYYY/M/D' },
+        { kind: 'literal', value: '+09:00' },
+      ],
+    })
+  })
+
+  test('implicit-environment and runtime-value shapes all decline', () => {
+    // zero-arg / locale-only: reads host locale and/or timezone
+    expect(match(`createdAt.toLocaleDateString()`)).toBeNull()
+    expect(match(`createdAt.toLocaleDateString('ja-JP')`)).toBeNull()
+    // non-literal locale: no build-time CLDR resolution
+    expect(match(`createdAt.toLocaleDateString(locale, { timeZone: 'UTC' })`)).toBeNull()
+    // IANA zone name: host-tzdata coupling
+    expect(match(`createdAt.toLocaleDateString('ja-JP', { timeZone: 'Asia/Tokyo' })`)).toBeNull()
+    // non-literal timeZone
+    expect(match(`createdAt.toLocaleDateString('ja-JP', { timeZone: tz })`)).toBeNull()
+    // options beyond timeZone: the name-table stage, not this slice
+    expect(match(`createdAt.toLocaleDateString('ja-JP', { timeZone: 'UTC', month: 'long' })`)).toBeNull()
+    expect(match(`createdAt.toLocaleDateString('ja-JP', { dateStyle: 'long' })`)).toBeNull()
+    // unrepresentable locale default
+    expect(match(`createdAt.toLocaleDateString('ar-SA', { timeZone: 'UTC' })`)).toBeNull()
+  })
+
+  test('a non-Date receiver never activates the plugin', () => {
+    const stringMd = metadata(`
+      export function Foo({ label }: { label: string }) {
+        return <div>{label}</div>
+      }
+    `)
+    expect(toLocaleDatePlugin.prepare(stringMd)).toBeNull()
+  })
+})
+
+describe('BF021 exemption round trip (#2273 seam)', () => {
+  test('the claimed literal shape compiles clean; the runtime-locale shape still fires BF021', () => {
+    const clean = compile(DATE_PROP_SRC)
+    expect(clean.errors.filter((e) => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)).toEqual([])
+
+    const refused = compile(`
+      export function Foo({ createdAt, locale }: { createdAt: Date; locale: string }) {
+        return <div>{createdAt.toLocaleDateString(locale, { timeZone: 'UTC' })}</div>
+      }
+    `)
+    const bf021 = refused.errors.filter((e) => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)
+    expect(bf021.length).toBeGreaterThan(0)
+    // the refusal now points at the explicit-input forms
+    expect(bf021[0].suggestion?.message).toContain('formatDate')
+  })
+
+  test('the zero-arg form (date-method-uncatalogued shape) still fires BF021', () => {
+    const refused = compile(`
+      export function Foo({ createdAt }: { createdAt: Date }) {
+        return <div>{createdAt.toLocaleDateString()}</div>
+      }
+    `)
+    expect(refused.errors.some((e) => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)).toBe(true)
+  })
+})
+
+describe('client-JS rewrite (#2292-style parity)', () => {
+  function clientJs(src: string): string {
+    const result = compileJSX(src.trimStart(), 'T.tsx', { adapter: new TestAdapter() })
+    return result.files.find((f) => f.type === 'clientJs')!.content
+  }
+
+  test('rewrites the literal shape to formatDate with the frozen pattern and auto-imports it', () => {
+    const js = clientJs(DATE_PROP_SRC)
+    expect(js).toContain('formatDate(_p.createdAt, "M/D/YYYY", "UTC")')
+    expect(js).toMatch(/import\s*\{[^}]*\bformatDate\b[^}]*\}\s*from\s*'@barefootjs\/client\/runtime'/)
+  })
+
+  test('rewrites inside a reactive effect for a signal-conditioned expression', () => {
+    const js = clientJs(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Foo({ createdAt }: { createdAt: Date }) {
+        const [suffix, setSuffix] = createSignal('')
+        return <div onClick={() => setSuffix('!')}>{createdAt.toLocaleDateString('ja-JP', { timeZone: '+09:00' }) + suffix()}</div>
+      }
+    `)
+    expect(js).toContain('formatDate(_p.createdAt, "YYYY/M/D", "+09:00")')
+    expect(js).not.toContain('toLocaleDateString')
+  })
+
+  test('leaves the declined runtime-locale shape raw', () => {
+    const js = clientJs(`
+      export function Foo({ createdAt, locale }: { createdAt: Date; locale: string }) {
+        return <div>{/* @client */ createdAt.toLocaleDateString(locale, { timeZone: 'UTC' })}</div>
+      }
+    `)
+    expect(js).toContain('toLocaleDateString(')
+    expect(js).not.toContain('formatDate(')
+  })
+})

--- a/packages/jsx/src/builtin-lowering-plugins.ts
+++ b/packages/jsx/src/builtin-lowering-plugins.ts
@@ -18,6 +18,7 @@ import { queryHrefLocalNames } from './adapters/env-signal.ts'
 import { matchQueryHrefCall } from './query-href-lowering.ts'
 import { datePlugin } from './date-lowering.ts'
 import { formatDatePlugin } from './format-date-lowering.ts'
+import { toLocaleDatePlugin } from './to-locale-date-lowering.ts'
 
 /**
  * `queryHref(base, { … })` — the pure URL-query builder (#2042). Its runtime
@@ -47,6 +48,7 @@ export const BUILTIN_LOWERING_PLUGINS: readonly LoweringPlugin[] = [
   queryHrefPlugin,
   datePlugin,
   formatDatePlugin,
+  toLocaleDatePlugin,
 ]
 
 /**

--- a/packages/jsx/src/date-lowering.ts
+++ b/packages/jsx/src/date-lowering.ts
@@ -62,7 +62,7 @@ const EMPTY_BINDINGS: Bindings = new Map()
  * properties of the SAME named type aren't short-circuited against each
  * other.
  */
-function typeReachesDate(type: TypeInfo | null, meta: IRMetadata, seen: Set<string>): boolean {
+export function typeReachesDate(type: TypeInfo | null, meta: IRMetadata, seen: Set<string>): boolean {
   const stripped = stripUnion(type)
   if (!stripped) return false
   // `kind: 'object'` is an INLINE type literal (`{ createdAt: Date }` — the

--- a/packages/jsx/src/ir-to-client-js/emit-reactive.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-reactive.ts
@@ -11,6 +11,7 @@ import type { ClientJsContext } from './types.ts'
 import { toHtmlAttrName, varSlotId, PROPS_PARAM } from './utils.ts'
 import { createTemplateAwareStringProtector } from './html-template.ts'
 import { datePlugin, DATE_METHODS } from '../date-lowering.ts'
+import { toLocaleDatePlugin } from '../to-locale-date-lowering.ts'
 import { tsNodeToParsedExpr } from '../expression-parser.ts'
 import type { LoweringMatcher } from '../lowering-registry.ts'
 
@@ -122,6 +123,80 @@ function getReactiveDateLoweringMatcher(ctx: ClientJsContext): LoweringMatcher |
   return datePlugin.prepare(metadataSlice as unknown as IRMetadata)
 }
 
+/** `getReactiveDateLoweringMatcher`'s twin for `toLocaleDatePlugin` (#2324 slice 2). */
+function getReactiveToLocaleMatcher(ctx: ClientJsContext): LoweringMatcher | null {
+  if (!ctx.propsType) return null
+  const metadataSlice: Pick<IRMetadata, 'propsType' | 'propsObjectName' | 'propsParams' | 'typeDefinitions'> = {
+    propsType: ctx.propsType,
+    propsObjectName: ctx.propsObjectName,
+    propsParams: ctx.propsParams,
+    typeDefinitions: ctx.typeDefinitions ?? [],
+  }
+  return toLocaleDatePlugin.prepare(metadataSlice as unknown as IRMetadata)
+}
+
+/**
+ * Reactive-path counterpart to `jsx-to-ir.ts`'s `lowerToLocaleDateCalls`
+ * (#2324 slice 2): rewrite a literal-locale `toLocaleDateString` call the
+ * SAME `toLocaleDatePlugin` matcher claims to `formatDate(recv, pattern,
+ * tz)` with the build-time-frozen pattern, for the same two reasons as the
+ * `date` rewrite above — the hydrated prop is an ISO STRING (a raw
+ * `.toLocaleDateString()` on it throws), and the client must render the
+ * frozen pattern, not the browser's own ICU output.
+ */
+function lowerToLocaleCallsInReactiveExpr(expr: string, matcher: LoweringMatcher | null): string {
+  if (!matcher) return expr
+  let sourceFile: ts.SourceFile
+  try {
+    sourceFile = ts.createSourceFile('__reactive_expr__.ts', `(${expr});`, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS)
+  } catch {
+    return expr
+  }
+  const stmt = sourceFile.statements[0]
+  if (!stmt || !ts.isExpressionStatement(stmt)) return expr
+  const root = ts.isParenthesizedExpression(stmt.expression) ? stmt.expression.expression : stmt.expression
+
+  const candidates: ts.CallExpression[] = []
+  const visit = (n: ts.Node): void => {
+    if (
+      ts.isCallExpression(n) &&
+      n.arguments.length === 2 &&
+      ts.isPropertyAccessExpression(n.expression) &&
+      !n.expression.questionDotToken &&
+      n.expression.name.text === 'toLocaleDateString'
+    ) {
+      candidates.push(n)
+    }
+    ts.forEachChild(n, visit)
+  }
+  visit(root)
+  if (candidates.length === 0) return expr
+
+  const { protect, restore, replaceProtectedCall } = createTemplateAwareStringProtector()
+  let result = protect(expr)
+  for (const call of candidates) {
+    const propAccess = call.expression as ts.PropertyAccessExpression
+    const node = matcher(
+      tsNodeToParsedExpr(propAccess),
+      call.arguments.map((a) => tsNodeToParsedExpr(a)),
+    )
+    if (!node || node.kind !== 'helper-call' || node.helper !== 'format_date') continue
+    const [, patternArg, tzArg] = node.args
+    if (patternArg?.kind !== 'literal' || tzArg?.kind !== 'literal') continue
+    const receiverText = propAccess.expression.getText(sourceFile)
+    const matchText = call.getText(sourceFile)
+    // The call text contains string literals (placeholders in the protected
+    // haystack) — go through the protector's stash-verified matcher, same
+    // as the static-path rewrite in jsx-to-ir.ts.
+    result = replaceProtectedCall(
+      result,
+      matchText,
+      () => `formatDate(${receiverText}, ${JSON.stringify(patternArg.value)}, ${JSON.stringify(tzArg.value)})`,
+    )
+  }
+  return restore(result)
+}
+
 /**
  * Reactive-path counterpart to `jsx-to-ir.ts`'s `lowerDateCalls` (#2292):
  * without this, a Date-typed prop's catalogued accessor call re-evaluated
@@ -197,6 +272,7 @@ function lowerDateCallsInReactiveExpr(expr: string, matcher: LoweringMatcher | n
 /** Emit createEffect blocks that update text nodes for reactive expressions. */
 export function emitDynamicTextUpdates(lines: string[], ctx: ClientJsContext): void {
   const dateLoweringMatcher = getReactiveDateLoweringMatcher(ctx)
+  const toLocaleMatcher = getReactiveToLocaleMatcher(ctx)
   // Group elements by expression to consolidate effects with same dependencies
   const byExpression = new Map<string, typeof ctx.dynamicElements>()
   for (const elem of ctx.dynamicElements) {
@@ -208,7 +284,10 @@ export function emitDynamicTextUpdates(lines: string[], ctx: ClientJsContext): v
   }
 
   for (const [rawExpr, elems] of byExpression) {
-    const expr = lowerDateCallsInReactiveExpr(rawExpr, dateLoweringMatcher)
+    const expr = lowerToLocaleCallsInReactiveExpr(
+      lowerDateCallsInReactiveExpr(rawExpr, dateLoweringMatcher),
+      toLocaleMatcher,
+    )
     // Separate conditional vs non-conditional elements
     const conditionalElems = elems.filter(e => e.insideConditional)
     const normalElems = elems.filter(e => !e.insideConditional)

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -75,21 +75,55 @@ export function splitTemplateInterpolations(inner: string): string[] {
 export function createTemplateAwareStringProtector(): {
   protect: (s: string) => string
   restore: (s: string) => string
+  replaceProtectedCall: (haystack: string, needle: string, replacement: () => string) => string
 } {
   const stash: string[] = []
   const save = (s: string) => { const i = stash.length; stash.push(s); return `__STRLIT_${i}__` }
+  const STRING_LIT_RE = /'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"/g
   const protect = (s: string): string => {
     s = s.replace(/`([^`]*)`/g, (_full, inner: string) => {
       const parts = splitTemplateInterpolations(inner)
       return '`' + parts.map(p => p.startsWith('${') ? p : save(p)).join('') + '`'
     })
-    s = s.replace(/'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"/g, m => save(m))
+    s = s.replace(STRING_LIT_RE, m => save(m))
     return s
   }
   const restore = (s: string): string => {
     return s.replace(/__STRLIT_(\d+)__/g, (_, i) => stash[Number(i)])
   }
-  return { protect, restore }
+  /**
+   * Replace one occurrence of `needle` (raw source text that may CONTAIN
+   * string literals, e.g. a `toLocaleDateString('en-US', { timeZone:
+   * 'UTC' })` call) inside an already-`protect`ed `haystack`. A plain
+   * `.replace(needle, …)` can't work there: the haystack's literals are
+   * `__STRLIT_i__` placeholders while the needle still carries quotes. The
+   * needle's literal segments become placeholder wildcards, and each
+   * candidate occurrence is verified against the stash CONTENT — so two
+   * same-shaped calls differing only in their literals (two locales in one
+   * expression) can't be cross-replaced, and a protected template-literal
+   * static segment (stashed wholesale) can never match (#2294's hazard
+   * class). Replaces the first verified occurrence only.
+   */
+  const replaceProtectedCall = (haystack: string, needle: string, replacement: () => string): string => {
+    const escape = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const litValues: string[] = []
+    let pattern = ''
+    let last = 0
+    for (const m of needle.matchAll(STRING_LIT_RE)) {
+      pattern += escape(needle.slice(last, m.index))
+      pattern += '__STRLIT_(\\d+)__'
+      litValues.push(m[0])
+      last = m.index + m[0].length
+    }
+    pattern += escape(needle.slice(last))
+    for (const m of haystack.matchAll(new RegExp(pattern, 'g'))) {
+      const verified = m.slice(1).every((idx, i) => stash[Number(idx)] === litValues[i])
+      if (!verified) continue
+      return haystack.slice(0, m.index) + replacement() + haystack.slice(m.index + m[0].length)
+    }
+    return haystack
+  }
+  return { protect, restore, replaceProtectedCall }
 }
 
 const VOID_ELEMENTS = new Set([

--- a/packages/jsx/src/ir-to-client-js/imports.ts
+++ b/packages/jsx/src/ir-to-client-js/imports.ts
@@ -21,6 +21,10 @@ export const RUNTIME_IMPORT_CANDIDATES = [
   // every SSR adapter's `date` runtime helper (`date-lowering.ts`'s
   // `datePlugin`).
   'date',
+  // Literal-locale `toLocaleDateString` sugar (#2324 slice 2) — the client
+  // rewrite targets `formatDate(recv, pattern, tz)`, so the emitted code
+  // needs the runtime export when the component didn't import it itself.
+  'formatDate',
 ] as const
 
 /** @deprecated Use RUNTIME_IMPORT_CANDIDATES */

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -49,6 +49,7 @@ import { resolveFreeRefs, isNameBound as isNameBoundInEnv, type BindingEnvironme
 import { computeFileScope } from './ir-to-client-js/component-scope.ts'
 import { createTemplateAwareStringProtector } from './ir-to-client-js/html-template.ts'
 import { datePlugin, DATE_METHODS } from './date-lowering.ts'
+import { toLocaleDatePlugin } from './to-locale-date-lowering.ts'
 import type { LoweringMatcher } from './lowering-registry.ts'
 import { extractFreeIdentifiersFromNode, initializerShapeContainsJsx } from './analyzer.ts'
 import { iterateJsTokens, replaceInExprContexts } from './scanner/js-scanner.ts'
@@ -175,6 +176,11 @@ interface TransformContext {
    * own `prepare` gate). See `getDateLoweringMatcher`.
    */
   _dateLoweringMatcher?: LoweringMatcher | null
+  /**
+   * Cached `toLocaleDatePlugin` matcher (#2324 slice 2), same lifecycle as
+   * `_dateLoweringMatcher`. See `getToLocaleDateLoweringMatcher`.
+   */
+  _toLocaleDateLoweringMatcher?: LoweringMatcher | null
 }
 
 /**
@@ -326,6 +332,21 @@ function getDateLoweringMatcher(ctx: TransformContext): LoweringMatcher | null {
   return ctx._dateLoweringMatcher
 }
 
+/** `getDateLoweringMatcher`'s twin for `toLocaleDatePlugin` (#2324 slice 2) — same metadata slice, same cache lifecycle. */
+function getToLocaleDateLoweringMatcher(ctx: TransformContext): LoweringMatcher | null {
+  if (ctx._toLocaleDateLoweringMatcher === undefined) {
+    const a = ctx.analyzer
+    const metadataSlice: Pick<IRMetadata, 'propsType' | 'propsObjectName' | 'propsParams' | 'typeDefinitions'> = {
+      propsType: a.propsType,
+      propsObjectName: a.propsObjectName,
+      propsParams: a.propsParams,
+      typeDefinitions: a.typeDefinitions,
+    }
+    ctx._toLocaleDateLoweringMatcher = toLocaleDatePlugin.prepare(metadataSlice as unknown as IRMetadata)
+  }
+  return ctx._toLocaleDateLoweringMatcher
+}
+
 /**
  * Client-side counterpart to `datePlugin` (#2274 was SSR-only; #2292
  * closes the gap). The client emitter (`ir-to-client-js/`) emits raw,
@@ -402,6 +423,63 @@ function lowerDateCalls(text: string, expr: ts.Node, ctx: TransformContext): str
 }
 
 /**
+ * `lowerDateCalls`' twin for the literal-locale `toLocaleDateString` sugar
+ * (#2324 slice 2). A call the SAME `toLocaleDatePlugin` matcher claims (so
+ * client and SSR lower under identical evidence, mandatory per #2292)
+ * rewrites to `formatDate(recv, "<pattern>", "<tz>")` — the pattern and tz
+ * literals come off the matched helper-call node, so the client renders the
+ * exact build-time-frozen pattern the templates render, and the ISO-string
+ * prop value the client actually holds post-hydration (no type-aware JSON
+ * revival) flows through `formatDate`'s string-receiver normalization
+ * instead of throwing on a raw `.toLocaleDateString()` string call.
+ */
+function lowerToLocaleDateCalls(text: string, expr: ts.Node, ctx: TransformContext): string {
+  const matcher = getToLocaleDateLoweringMatcher(ctx)
+  if (!matcher) return text
+
+  const candidates: ts.CallExpression[] = []
+  function visit(n: ts.Node) {
+    if (
+      ts.isCallExpression(n) &&
+      n.arguments.length === 2 &&
+      ts.isPropertyAccessExpression(n.expression) &&
+      !n.expression.questionDotToken &&
+      n.expression.name.text === 'toLocaleDateString'
+    ) {
+      candidates.push(n)
+    }
+    ts.forEachChild(n, visit)
+  }
+  visit(expr)
+  if (candidates.length === 0) return text
+
+  const { protect, restore, replaceProtectedCall } = createTemplateAwareStringProtector()
+  let result = protect(text)
+  for (const call of candidates) {
+    const propAccess = call.expression as ts.PropertyAccessExpression
+    const node = matcher(
+      tsNodeToParsedExpr(propAccess),
+      call.arguments.map((a) => tsNodeToParsedExpr(a)),
+    )
+    if (!node || node.kind !== 'helper-call' || node.helper !== 'format_date') continue
+    const [, patternArg, tzArg] = node.args
+    if (patternArg?.kind !== 'literal' || tzArg?.kind !== 'literal') continue
+    const receiverText = ctx.getJS(propAccess.expression)
+    const matchText = ctx.getJS(call)
+    // Unlike `lowerDateCalls`' zero-arg needle, this call text CONTAINS
+    // string literals, which the protected haystack holds as placeholders —
+    // so the replacement must go through the protector's stash-verified
+    // matcher rather than a plain `.replace`.
+    result = replaceProtectedCall(
+      result,
+      matchText,
+      () => `formatDate(${receiverText}, ${JSON.stringify(patternArg.value)}, ${JSON.stringify(tzArg.value)})`,
+    )
+  }
+  return restore(result)
+}
+
+/**
  * Rewrite bare destructured prop references in expression text.
  * Thin wrapper that caches prop names on ctx and delegates to the shared core.
  * Returns undefined if no rewriting is needed (SolidJS-style or no props).
@@ -415,7 +493,7 @@ function rewriteBarePropRefs(text: string, expr: ts.Node, ctx: TransformContext)
   // unconditionally — ahead of the `propNames` gate — because Date
   // evidence comes from `ctx.analyzer.propsType`, independent of whether
   // this component destructures its props.
-  const dateLowered = lowerDateCalls(text, expr, ctx)
+  const dateLowered = lowerToLocaleDateCalls(lowerDateCalls(text, expr, ctx), expr, ctx)
   let propNames = getDestructuredPropNames(ctx)
   if (!propNames) return dateLowered === text ? undefined : dateLowered
   // #2222: a name bound as an enclosing loop callback's item/index param

--- a/packages/jsx/src/rich-type-refusal.ts
+++ b/packages/jsx/src/rich-type-refusal.ts
@@ -96,13 +96,21 @@ function pushDiagnostic(
   if (seen.has(key)) return
   seen.add(key)
   const receiver = isProp ? `prop '${receiverPath}'` : `'${receiverPath}'`
+  // `toLocaleDateString` has a catalogued explicit-input form (#2324 slice
+  // 2) — point the fix at it instead of the generic escape hatches alone.
+  // The implicit-environment forms (zero-arg, locale-only, non-literal
+  // locale, IANA timeZone) stay refused by design.
+  const suggestion =
+    method === 'toLocaleDateString' && typeName === 'Date'
+      ? "Pass a literal locale and an explicit literal timeZone — .toLocaleDateString('ja-JP', { timeZone: 'UTC' }) (or a fixed '±HH:MM' offset) — to compile it to the format_date helper; for a runtime locale, resolve the pattern in your i18n layer and use formatDate(date, pattern, tz) from @barefootjs/client. Alternatively add /* @client */ or pre-compute server-side."
+      : 'Add /* @client */ to evaluate this expression on the client only, or pre-compute the value server-side.'
   errors.push({
     code: ErrorCodes.UNSUPPORTED_JSX_PATTERN,
     severity: 'error',
     message: `Expression cannot be compiled to marked template: method '.${method}()' on ${receiver} of host type '${typeName}' has no catalogued lowering.`,
     loc,
     suggestion: {
-      message: 'Add /* @client */ to evaluate this expression on the client only, or pre-compute the value server-side.',
+      message: suggestion,
     },
   })
 }

--- a/packages/jsx/src/to-locale-date-lowering.ts
+++ b/packages/jsx/src/to-locale-date-lowering.ts
@@ -1,0 +1,166 @@
+/**
+ * Literal-locale `toLocaleDateString` lowering plugin (#2324 slice 2 — the
+ * "upper layer" sugar over the `format_date` primitive).
+ *
+ * `createdAt.toLocaleDateString('ja-JP', { timeZone: 'UTC' })` on a
+ * `Date`-typed prop, with a **compile-time literal** locale and an explicit
+ * literal `timeZone`, resolves the locale's default date pattern ONCE at
+ * build time (via the build machine's own `Intl.DateTimeFormat`) and lowers
+ * to the exact same backend-neutral `helper-call` on `format_date` that
+ * `formatDate(date, pattern, tz)` produces. Consequences:
+ *
+ *   - no runtime ICU/CLDR on any backend — the CLDR lookup happens once, in
+ *     the compiler;
+ *   - SSR and (rewritten) client JS render from the same frozen pattern, so
+ *     output is byte-identical by construction;
+ *   - no locale allowlist: any locale whose default date format the
+ *     structural gate below can prove representable in the v1 token set is
+ *     admitted, and every other shape declines (→ BF021 via
+ *     `rich-type-refusal.ts`, whose gate exempts exactly what a registered
+ *     plugin claims).
+ *
+ * Deliberately NOT lowered (decline → loud BF021, never a silent guess):
+ *   - zero-arg / locale-only calls — they read the host's locale and/or
+ *     timezone, the implicit-environment hole #2273 closed;
+ *   - a non-literal locale (`props.locale`) — build-time CLDR resolution is
+ *     impossible; the app's i18n layer owns locale → pattern there, feeding
+ *     `formatDate` directly;
+ *   - an IANA `timeZone` name — couples output to the host's tzdata version
+ *     (only `'UTC'` and fixed `±HH:MM` offsets are deterministic);
+ *   - options beyond `timeZone` (`dateStyle`, `month: 'long'`, …) — the
+ *     name-table stage of #2324, not this slice;
+ *   - a locale whose default format needs anything beyond numeric
+ *     year/month/day in latin digits on the gregorian calendar (e.g.
+ *     `ar-SA`: islamic-umalqura calendar, arabic-indic digits).
+ */
+
+import type { IRMetadata } from './types.ts'
+import type { ParsedExpr } from './expression-parser.ts'
+import type { LoweringNode, LoweringPlugin } from './lowering-registry.ts'
+import { resolveReceiverType, baseTypeName } from './rich-type-evidence.ts'
+import { typeReachesDate } from './date-lowering.ts'
+
+/** `timeZone` literals the lowering admits: `'UTC'` or a fixed `±HH:MM` offset. */
+export const TO_LOCALE_TZ_RE = /^(?:UTC|[+-]\d{2}:\d{2})$/
+
+/**
+ * Probe instant for pattern derivation: 2001-02-03 UTC. Month and day are
+ * distinct single-digit values, so the rendered part text distinguishes both
+ * the field order (`M/D` vs `D.M`) and zero-padding (`02` → `MM`, `2` → `M`).
+ */
+const PROBE_UTC = new Date(Date.UTC(2001, 1, 3))
+
+/** Build-time cache: locale tag → derived pattern (or null = not representable). */
+const patternCache = new Map<string, string | null>()
+
+/**
+ * Resolve a locale literal to its default date pattern in the v1
+ * `format_date` token language (`YYYY`/`MM`/`M`/`DD`/`D` + literal text), or
+ * null when the locale's default format is not representable. The gate is
+ * structural, not an allowlist: the format must resolve to the gregorian
+ * calendar in latin digits and consist solely of numeric year/month/day
+ * parts (4-digit year) plus separator literals that cannot collide with the
+ * token alphabet. `en-US` → `M/D/YYYY`, `ja-JP` → `YYYY/M/D`, `en-GB` →
+ * `DD/MM/YYYY`, `de-DE` → `D.M.YYYY`; `ar-SA` (islamic-umalqura/arab) and
+ * any 2-digit-year or era/weekday-bearing default → null.
+ */
+export function resolveLocaleDatePattern(locale: string): string | null {
+  const cached = patternCache.get(locale)
+  if (cached !== undefined) return cached
+  const derived = derivePattern(locale)
+  patternCache.set(locale, derived)
+  return derived
+}
+
+function derivePattern(locale: string): string | null {
+  let parts: Intl.DateTimeFormatPart[]
+  try {
+    const dtf = new Intl.DateTimeFormat(locale, { timeZone: 'UTC' })
+    const resolved = dtf.resolvedOptions()
+    if (resolved.calendar !== 'gregory' || resolved.numberingSystem !== 'latn') return null
+    parts = dtf.formatToParts(PROBE_UTC)
+  } catch {
+    return null // invalid language tag
+  }
+  let pattern = ''
+  for (const part of parts) {
+    switch (part.type) {
+      case 'year':
+        if (part.value !== '2001') return null // 2-digit-year default has no v1 token
+        pattern += 'YYYY'
+        break
+      case 'month':
+        if (part.value === '2') pattern += 'M'
+        else if (part.value === '02') pattern += 'MM'
+        else return null // name/narrow month — the later name-table stage
+        break
+      case 'day':
+        if (part.value === '3') pattern += 'D'
+        else if (part.value === '03') pattern += 'DD'
+        else return null
+        break
+      case 'literal':
+        // A literal containing the token alphabet would be re-tokenized by
+        // the helper's scan; no real numeric-format separator does, but the
+        // gate must prove it rather than assume it.
+        if (/[YMD]/.test(part.value)) return null
+        pattern += part.value
+        break
+      default:
+        return null // era, weekday, dayPeriod, … — not representable
+    }
+  }
+  if (!pattern.includes('YYYY') || !/M/.test(pattern) || !/D/.test(pattern)) return null
+  return pattern
+}
+
+/**
+ * Recognise `<Date-typed prop>.toLocaleDateString(<locale literal>,
+ * { timeZone: <'UTC' | '±HH:MM' literal> })` per the module doc and return
+ * the `format_date` helper-call with the build-time-resolved pattern, or
+ * decline (null) for every other shape. Receiver evidence mirrors
+ * `date-lowering.ts`'s `matchDateCall` exactly (prop-rooted, `Date`-typed,
+ * no in-file type shadow, `EMPTY_BINDINGS`).
+ */
+export function matchToLocaleDateStringCall(
+  callee: ParsedExpr,
+  args: readonly ParsedExpr[],
+  metadata: IRMetadata,
+): LoweringNode | null {
+  if (callee.kind !== 'member' || callee.computed) return null
+  if (callee.property !== 'toLocaleDateString' || args.length !== 2) return null
+  const [locale, options] = args
+  if (locale.kind !== 'literal' || locale.literalType !== 'string') return null
+  if (options.kind !== 'object-literal' || options.properties.length !== 1) return null
+  const prop = options.properties[0]
+  if (prop.key !== 'timeZone') return null
+  if (prop.value.kind !== 'literal' || prop.value.literalType !== 'string') return null
+  const tz = String(prop.value.value)
+  if (!TO_LOCALE_TZ_RE.test(tz)) return null
+
+  const receiverType = resolveReceiverType(callee.object, metadata, new Map())
+  if (!receiverType || receiverType.kind !== 'interface') return null
+  const typeName = baseTypeName(receiverType.raw)
+  if (typeName !== 'Date') return null
+  if (metadata.typeDefinitions.some((d) => d.name === typeName)) return null
+
+  const pattern = resolveLocaleDatePattern(String(locale.value))
+  if (pattern === null) return null
+  return {
+    kind: 'helper-call',
+    helper: 'format_date',
+    args: [
+      callee.object,
+      { kind: 'literal', value: pattern, literalType: 'string' },
+      { kind: 'literal', value: tz, literalType: 'string' },
+    ],
+  }
+}
+
+export const toLocaleDatePlugin: LoweringPlugin = {
+  name: 'toLocaleDateString',
+  prepare(metadata) {
+    if (!metadata.propsType || !typeReachesDate(metadata.propsType, metadata, new Set())) return null
+    return (callee, args) => matchToLocaleDateStringCall(callee, args, metadata)
+  },
+}

--- a/packages/jsx/src/to-locale-date-lowering.ts
+++ b/packages/jsx/src/to-locale-date-lowering.ts
@@ -40,8 +40,17 @@ import type { LoweringNode, LoweringPlugin } from './lowering-registry.ts'
 import { resolveReceiverType, baseTypeName } from './rich-type-evidence.ts'
 import { typeReachesDate } from './date-lowering.ts'
 
-/** `timeZone` literals the lowering admits: `'UTC'` or a fixed `±HH:MM` offset. */
-export const TO_LOCALE_TZ_RE = /^(?:UTC|[+-]\d{2}:\d{2})$/
+/**
+ * `timeZone` literals the lowering admits: `'UTC'` or a fixed `±HH:MM`
+ * offset **within ECMA-402's valid offset range** (hours 00–23, minutes
+ * 00–59). An out-of-range shape like `'+25:00'` or `'+99:99'` must DECLINE
+ * (→ BF021), not lower: real `toLocaleDateString` throws a RangeError on
+ * it, so compiling it would render a nonsense offset on the template
+ * adapters while the JS-native path (Hono, and the pre-rewrite semantics
+ * the sugar stands in for) crashes — the exact divergence the sugar exists
+ * to rule out.
+ */
+export const TO_LOCALE_TZ_RE = /^(?:UTC|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/
 
 /**
  * Probe instant for pattern derivation: 2001-02-03 UTC. Month and day are

--- a/spec/template-helpers.md
+++ b/spec/template-helpers.md
@@ -347,6 +347,12 @@ arithmetic: shift the instant by the offset, then read UTC fields
 (the shifted UTC clock face is the local clock face at that offset),
 so a `+09:00` on `2024-01-01T23:00Z` renders `2024-01-02`.
 
+This helper is also the lowering target of the literal-locale
+`toLocaleDateString` sugar (#2324 slice 2): the compiler resolves a
+compile-time-literal locale's default date pattern once at build
+time and emits the same `format_date` call, so no new helper id is
+involved and no backend work follows from the sugar.
+
 ### Higher-order: canonical projection form
 
 Closures can't ride in JSON, so higher-order entries use the compiled

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 257,
+    "totalFixtures": 258,
     "fixtures": {
       "dangerous-inner-html-dynamic": {
         "blade": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -526,11 +526,11 @@
       }
     },
     "call": {
-      "total": 158,
+      "total": 159,
       "cells": {
         "hono": {
-          "pass": 157,
-          "total": 158,
+          "pass": 158,
+          "total": 159,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -541,8 +541,8 @@
           ]
         },
         "blade": {
-          "pass": 153,
-          "total": 158,
+          "pass": 154,
+          "total": 159,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -577,8 +577,8 @@
           ]
         },
         "erb": {
-          "pass": 154,
-          "total": 158,
+          "pass": 155,
+          "total": 159,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -607,8 +607,8 @@
           ]
         },
         "go-template": {
-          "pass": 153,
-          "total": 158,
+          "pass": 154,
+          "total": 159,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -643,8 +643,8 @@
           ]
         },
         "jinja": {
-          "pass": 153,
-          "total": 158,
+          "pass": 154,
+          "total": 159,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -679,8 +679,8 @@
           ]
         },
         "minijinja": {
-          "pass": 153,
-          "total": 158,
+          "pass": 154,
+          "total": 159,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -715,8 +715,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 154,
-          "total": 158,
+          "pass": 155,
+          "total": 159,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -745,8 +745,8 @@
           ]
         },
         "twig": {
-          "pass": 153,
-          "total": 158,
+          "pass": 154,
+          "total": 159,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -781,8 +781,8 @@
           ]
         },
         "xslate": {
-          "pass": 153,
-          "total": 158,
+          "pass": 154,
+          "total": 159,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -860,11 +860,11 @@
       }
     },
     "identifier": {
-      "total": 238,
+      "total": 239,
       "cells": {
         "hono": {
-          "pass": 237,
-          "total": 238,
+          "pass": 238,
+          "total": 239,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -875,8 +875,8 @@
           ]
         },
         "blade": {
-          "pass": 232,
-          "total": 238,
+          "pass": 233,
+          "total": 239,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -917,8 +917,8 @@
           ]
         },
         "erb": {
-          "pass": 233,
-          "total": 238,
+          "pass": 234,
+          "total": 239,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -953,8 +953,8 @@
           ]
         },
         "go-template": {
-          "pass": 232,
-          "total": 238,
+          "pass": 233,
+          "total": 239,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -995,8 +995,8 @@
           ]
         },
         "jinja": {
-          "pass": 232,
-          "total": 238,
+          "pass": 233,
+          "total": 239,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1037,8 +1037,8 @@
           ]
         },
         "minijinja": {
-          "pass": 232,
-          "total": 238,
+          "pass": 233,
+          "total": 239,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1079,8 +1079,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 233,
-          "total": 238,
+          "pass": 234,
+          "total": 239,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1115,8 +1115,8 @@
           ]
         },
         "twig": {
-          "pass": 232,
-          "total": 238,
+          "pass": 233,
+          "total": 239,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1157,8 +1157,8 @@
           ]
         },
         "xslate": {
-          "pass": 232,
-          "total": 238,
+          "pass": 233,
+          "total": 239,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1242,15 +1242,15 @@
       }
     },
     "literal": {
-      "total": 196,
+      "total": 197,
       "cells": {
         "hono": {
-          "pass": 196,
-          "total": 196
+          "pass": 197,
+          "total": 197
         },
         "blade": {
-          "pass": 195,
-          "total": 196,
+          "pass": 196,
+          "total": 197,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1261,8 +1261,8 @@
           ]
         },
         "erb": {
-          "pass": 195,
-          "total": 196,
+          "pass": 196,
+          "total": 197,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1273,8 +1273,8 @@
           ]
         },
         "go-template": {
-          "pass": 195,
-          "total": 196,
+          "pass": 196,
+          "total": 197,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1285,8 +1285,8 @@
           ]
         },
         "jinja": {
-          "pass": 195,
-          "total": 196,
+          "pass": 196,
+          "total": 197,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1297,8 +1297,8 @@
           ]
         },
         "minijinja": {
-          "pass": 195,
-          "total": 196,
+          "pass": 196,
+          "total": 197,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1309,8 +1309,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 195,
-          "total": 196,
+          "pass": 196,
+          "total": 197,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1321,8 +1321,8 @@
           ]
         },
         "twig": {
-          "pass": 195,
-          "total": 196,
+          "pass": 196,
+          "total": 197,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1333,8 +1333,8 @@
           ]
         },
         "xslate": {
-          "pass": 195,
-          "total": 196,
+          "pass": 196,
+          "total": 197,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1452,11 +1452,11 @@
       }
     },
     "member": {
-      "total": 119,
+      "total": 120,
       "cells": {
         "hono": {
-          "pass": 118,
-          "total": 119,
+          "pass": 119,
+          "total": 120,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1467,8 +1467,8 @@
           ]
         },
         "blade": {
-          "pass": 114,
-          "total": 119,
+          "pass": 115,
+          "total": 120,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1503,8 +1503,8 @@
           ]
         },
         "erb": {
-          "pass": 115,
-          "total": 119,
+          "pass": 116,
+          "total": 120,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1533,8 +1533,8 @@
           ]
         },
         "go-template": {
-          "pass": 114,
-          "total": 119,
+          "pass": 115,
+          "total": 120,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1569,8 +1569,8 @@
           ]
         },
         "jinja": {
-          "pass": 114,
-          "total": 119,
+          "pass": 115,
+          "total": 120,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1605,8 +1605,8 @@
           ]
         },
         "minijinja": {
-          "pass": 114,
-          "total": 119,
+          "pass": 115,
+          "total": 120,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1641,8 +1641,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 115,
-          "total": 119,
+          "pass": 116,
+          "total": 120,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1671,8 +1671,8 @@
           ]
         },
         "twig": {
-          "pass": 114,
-          "total": 119,
+          "pass": 115,
+          "total": 120,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1707,8 +1707,8 @@
           ]
         },
         "xslate": {
-          "pass": 114,
-          "total": 119,
+          "pass": 115,
+          "total": 120,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1745,15 +1745,15 @@
       }
     },
     "object-literal": {
-      "total": 42,
+      "total": 43,
       "cells": {
         "hono": {
-          "pass": 42,
-          "total": 42
+          "pass": 43,
+          "total": 43
         },
         "blade": {
-          "pass": 40,
-          "total": 42,
+          "pass": 41,
+          "total": 43,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1770,8 +1770,8 @@
           ]
         },
         "erb": {
-          "pass": 40,
-          "total": 42,
+          "pass": 41,
+          "total": 43,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1788,8 +1788,8 @@
           ]
         },
         "go-template": {
-          "pass": 40,
-          "total": 42,
+          "pass": 41,
+          "total": 43,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1806,8 +1806,8 @@
           ]
         },
         "jinja": {
-          "pass": 40,
-          "total": 42,
+          "pass": 41,
+          "total": 43,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1824,8 +1824,8 @@
           ]
         },
         "minijinja": {
-          "pass": 40,
-          "total": 42,
+          "pass": 41,
+          "total": 43,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1842,8 +1842,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 40,
-          "total": 42,
+          "pass": 41,
+          "total": 43,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1860,8 +1860,8 @@
           ]
         },
         "twig": {
-          "pass": 40,
-          "total": 42,
+          "pass": 41,
+          "total": 43,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1878,8 +1878,8 @@
           ]
         },
         "xslate": {
-          "pass": 40,
-          "total": 42,
+          "pass": 41,
+          "total": 43,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -3905,15 +3905,15 @@
       }
     },
     "literal:string": {
-      "total": 140,
+      "total": 141,
       "cells": {
         "hono": {
-          "pass": 140,
-          "total": 140
+          "pass": 141,
+          "total": 141
         },
         "blade": {
-          "pass": 139,
-          "total": 140,
+          "pass": 140,
+          "total": 141,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3924,8 +3924,8 @@
           ]
         },
         "erb": {
-          "pass": 139,
-          "total": 140,
+          "pass": 140,
+          "total": 141,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3936,8 +3936,8 @@
           ]
         },
         "go-template": {
-          "pass": 139,
-          "total": 140,
+          "pass": 140,
+          "total": 141,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3948,8 +3948,8 @@
           ]
         },
         "jinja": {
-          "pass": 139,
-          "total": 140,
+          "pass": 140,
+          "total": 141,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3960,8 +3960,8 @@
           ]
         },
         "minijinja": {
-          "pass": 139,
-          "total": 140,
+          "pass": 140,
+          "total": 141,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3972,8 +3972,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 139,
-          "total": 140,
+          "pass": 140,
+          "total": 141,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3984,8 +3984,8 @@
           ]
         },
         "twig": {
-          "pass": 139,
-          "total": 140,
+          "pass": 140,
+          "total": 141,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3996,8 +3996,8 @@
           ]
         },
         "xslate": {
-          "pass": 139,
-          "total": 140,
+          "pass": 140,
+          "total": 141,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",


### PR DESCRIPTION
## What

Second landing slice of #2324 — the **upper layer**: standard ECMA-402 surface over the `format_date` primitive that #2326 landed.

```tsx
function PostMeta({ createdAt }: { createdAt: Date }) {
  return <time>{createdAt.toLocaleDateString('ja-JP', { timeZone: 'UTC' })}</time>
}
```

With a **compile-time-literal locale** and an **explicit literal `timeZone`** (`'UTC'` or fixed `±HH:MM`), the compiler resolves the locale's default date pattern once at build time and lowers to the existing `format_date` helper-call. Consequences, per the issue's design:

- **No runtime ICU/CLDR on any backend, and no locale allowlist** — the gate is structural (`Intl.DateTimeFormat` `formatToParts` probe: gregorian calendar, latin digits, numeric 4-digit-year/month/day + separators only). `en-US` → `M/D/YYYY`, `ja-JP` → `YYYY/M/D`, `en-GB` → `DD/MM/YYYY`; `ar-SA` (islamic-umalqura/arab digits) and every era/month-name/2-digit-year default declines.
- **SSR and client render the same frozen pattern — byte-identical by construction.** The client-JS paths (static template + reactive effects, mirroring #2292's dual-path shape) rewrite the call to `formatDate(recv, pattern, tz)`. The rewrite is a correctness requirement independent of ICU parity: the hydrated prop is an ISO *string*, so the raw call would throw.
- **Zero adapter/backend changes** — the sugar reuses `format_date` verbatim; no new helper id, no runtime ports, no vector changes.

## What still refuses (by design, unchanged posture)

Zero-arg / locale-only (host locale/TZ read — the #2273 implicit-environment hole), **runtime locale** (`props.locale`: no build-time CLDR; the diagnostic now points at resolving the pattern in the app's i18n layer and calling `formatDate` — the responsibility split from #2324), **IANA zone names** (host-tzdata coupling), and options beyond `timeZone` (the month/weekday name-table stage). The `rich-type-refusal` gate needed **no changes**: it already exempts exactly what a registered lowering plugin claims. `date-method-uncatalogued` stays pinned BF021 on all 9 adapters.

## Implementation notes

- `to-locale-date-lowering.ts`: `toLocaleDatePlugin` (default-applied builtin, registered like `queryHref`/`date`/`formatDate`), `resolveLocaleDatePattern` (cached build-time probe), matcher with the accept/decline table above.
- Client rewrite via the shared plugin matcher in both `jsx-to-ir.ts` (static) and `emit-reactive.ts` (effects); `formatDate` added to `RUNTIME_IMPORT_CANDIDATES`.
- **New protector API `replaceProtectedCall`** (`html-template.ts`): unlike the zero-arg `date` rewrite, this call text *contains string literals*, which the protected haystack holds as `__STRLIT_i__` placeholders — a plain `.replace` can never match. The needle's literal segments become stash-**content-verified** wildcards, so two same-shaped calls differing only in their locale literals can't cross-replace, and protected template-literal static segments can never match (#2294's hazard class).
- Conformance fixture `date-tolocale-literal` (change-time coupling rule): `+09:00` cell crosses the date boundary; `leap-day-split` oracle point makes the two cells disagree on month *and* day; the type-derived grid's `year-9999` × `+09:00` lands in year 10000 (the Python civil-from-days case #2326 pinned). Hono — which evaluates real ECMA-402 against the same build-machine ICU the pattern was frozen from — must agree byte-for-byte, and does.

## Verification

- `bun test packages/jsx` 2568 / `packages/adapter-tests` 1326 (incl. CSR conformance of the rewritten client path) / `packages/adapter-hono` 924 / `packages/compat` 80 — all 0 fail
- New unit suite: pattern-derivation gate, full accept/decline table, BF021-exemption round trip, client-JS rewrite (static + reactive + declined-shape passthrough)
- `bun run lint` clean; compat + support-matrix locks regenerated (258 fixtures; `date-tolocale-literal` absent from the render-divergence table = reference parity on all 9 adapters)
- Full 8-adapter real-backend conformance in flight locally; CI runs the same suites
- Changeset: `@barefootjs/jsx` minor

Remaining #2324 stages (not this PR): month/weekday-name tokens (framework-owned tables), union-typed locale switch, named-TZ widening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dBKFhtumbPwjNZaU3LRpy

---
_Generated by [Claude Code](https://claude.ai/code/session_015dBKFhtumbPwjNZaU3LRpy)_