### PR TITLE
feat(compiler): cross-file + object-return reactive factory inlining, BF111/BF112 diagnostics (#2325)

### DIFF
--- a/.changeset/reactive-factory-cross-file-object-return.md
+++ b/.changeset/reactive-factory-cross-file-object-return.md
@@ -1,0 +1,12 @@
+---
+'@barefootjs/jsx': minor
+'@barefootjs/cli': patch
+---
+
+Reactive-factory helpers (#931 round 2, #2325): factories may now return a
+shorthand object literal (`return { count, setCount }`) destructured as
+`const { count } = factory(...)`, and may be imported from a relative path.
+New diagnostics: BF111 (property renames in factory object returns/destructures),
+BF112 (imported factory capturing helper-module bindings); BF110 now also covers
+reactive-looking object-destructure call sites that previously failed silently.
+CLI: dependency scanner tracks `.jsx`/`.js` relative imports for cache invalidation.

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -2798,6 +2798,19 @@
         "text"
       ]
     },
+    "reactive-factory-object-return": {
+      "kinds": [
+        "call",
+        "identifier",
+        "literal"
+      ],
+      "axes": [
+        "literal:number"
+      ],
+      "contexts": [
+        "text"
+      ]
+    },
     "reactive-prop-binding": {
       "kinds": [
         "call",
@@ -4132,11 +4145,11 @@
     "array-method": 62,
     "arrow": 55,
     "binary": 67,
-    "call": 159,
+    "call": 160,
     "conditional": 18,
-    "identifier": 239,
+    "identifier": 240,
     "index-access": 12,
-    "literal": 197,
+    "literal": 198,
     "logical": 41,
     "member": 120,
     "object-literal": 43,
@@ -4181,7 +4194,7 @@
     "binary:>=": 1,
     "literal:boolean": 37,
     "literal:null": 22,
-    "literal:number": 85,
+    "literal:number": 86,
     "literal:string": 141,
     "logical:&&": 7,
     "logical:??": 37,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -1,4 +1,13 @@
 import { fixture as counter } from './counter'
+// Same-file reactive-factory helpers (#931, #2325): a helper wrapping
+// createSignal in a shorthand-object return inlines pre-analysis, so the
+// compiled output — and thus every adapter's marked template — must be
+// byte-identical to counter.ts's hand-written createSignal call. This is
+// the cross-adapter proof that #2325's object-return inlining generalizes
+// (the compiler unit tests already cover it against a single test
+// adapter; this fixture is what actually exercises Hono / Go / PHP /
+// Django / Rust / Ruby / Perl / ... through the shared harness).
+import { fixture as reactiveFactoryObjectReturn } from './reactive-factory-object-return'
 // Shared-component corpus (#1466): fixture-hydrate fixtures lifted
 // from `integrations/shared/components/` also participate in
 // cross-adapter HTML conformance so the same .tsx is guaranteed to
@@ -399,6 +408,7 @@ import type { JSXFixture } from '../src/types'
 
 export const jsxFixtures: JSXFixture[] = [
   counter,
+  reactiveFactoryObjectReturn,
   counterShared,
   toggleShared,
   conditionalReturnButton,

--- a/packages/adapter-tests/fixtures/reactive-factory-object-return.ts
+++ b/packages/adapter-tests/fixtures/reactive-factory-object-return.ts
@@ -1,0 +1,24 @@
+import { createFixture } from '../src/types'
+
+export const fixture = createFixture({
+  id: 'reactive-factory-object-return',
+  description:
+    'Same-file reactive-factory helper returning a shorthand object (#2325) inlines to a plain signal, identically to counter.ts',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+function createCounter(initial: number) {
+  const [count, setCount] = createSignal(initial)
+  return { count, setCount }
+}
+
+export function Counter() {
+  const { count, setCount } = createCounter(0)
+  return <button onClick={() => setCount(n => n + 1)}>Count: {count()}</button>
+}
+`,
+  expectedHtml: `
+    <button bf-s="test" bf="s1">Count: <!--bf:s0-->0<!--/--></button>
+  `,
+})

--- a/packages/cli/src/__tests__/build-factory-invalidation.test.ts
+++ b/packages/cli/src/__tests__/build-factory-invalidation.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Build-cache invalidation for reactive-factory helper files (#2325).
+ *
+ * `collectRelativeImportDeps` records every relative import a component
+ * source references so an edit to an imported helper invalidates the
+ * importer's cache entry, not just edits to the component file itself. That
+ * scanner's extension probe list historically stopped at `.tsx`/`.ts` —
+ * missing `.jsx`/`.js` — while the analyzer's own `resolveRelativeImportToFile`
+ * (used to resolve cross-file reactive factories, #2325) already covers all
+ * four. This file pins the end-to-end consequence: a factory helper authored
+ * as plain `.ts` must be tracked as a dependency, so editing it triggers a
+ * real recompile of the importing component (not a stale cache hit) on the
+ * next build, while an untouched sibling component is still served from cache.
+ *
+ * Harness modeled on `build-manifest-components.test.ts` (`makeTmpDir`,
+ * `linkClientRuntime`, try/finally cleanup).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { build } from '../lib/build'
+import { loadCache } from '../lib/build-cache'
+import { TestAdapter } from '../../../jsx/src/adapters/test-adapter'
+import { mkdirSync, writeFileSync, rmSync, readFileSync, realpathSync, symlinkSync } from 'fs'
+import { resolve } from 'path'
+import { tmpdir } from 'os'
+
+function makeTmpDir(label: string) {
+  const dir = resolve(tmpdir(), `bf-test-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+  mkdirSync(dir, { recursive: true })
+  return realpathSync(dir)
+}
+
+/**
+ * Link the workspace `@barefootjs/client` into the throwaway project so the
+ * build can copy `barefoot.js` — without it the compiled client bundles'
+ * `../../barefoot.js` imports don't resolve on disk and the rebuild pass
+ * raises BF053, which is noise unrelated to what this file pins.
+ */
+function linkClientRuntime(projectDir: string) {
+  const scope = resolve(projectDir, 'node_modules/@barefootjs')
+  mkdirSync(scope, { recursive: true })
+  symlinkSync(resolve(import.meta.dir, '../../../client'), resolve(scope, 'client'))
+}
+
+// The factory helper, deliberately `.ts` — not `.tsx` — so `discoverComponentFiles`
+// (which only picks up `.tsx`) never treats it as its own component entry,
+// while the relative-import resolution (both the analyzer's cross-file
+// factory resolution and this file's `collectRelativeImportDeps` dep
+// scanner) still finds it.
+function hooksSource(initial: number): string {
+  return `import { createSignal } from '@barefootjs/client'
+
+export function createCounter() {
+  const [count, setCount] = createSignal(${initial})
+  return { count, setCount }
+}
+`
+}
+
+const COUNTER_SOURCE = `'use client'
+import { createCounter } from './hooks'
+
+export function Counter() {
+  const { count, setCount } = createCounter()
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}
+`
+
+// Untouched sibling — the cache-hit control.
+const SIBLING_SOURCE = `'use client'
+import { createSignal } from '@barefootjs/client'
+
+export function Sibling() {
+  const [value, setValue] = createSignal('sibling')
+  return <p onClick={() => setValue('clicked')}>{value()}</p>
+}
+`
+
+async function runBuild(projectDir: string, outDir: string) {
+  return build({
+    projectDir,
+    adapter: new TestAdapter(),
+    componentDirs: [resolve(projectDir, 'components')],
+    outDir,
+    minify: false,
+    contentHash: false,
+    clientOnly: true,
+  })
+}
+
+describe('build-cache invalidation for reactive-factory helper files (#2325)', () => {
+  test('editing a .ts factory helper invalidates only the importing component', async () => {
+    const projectDir = makeTmpDir('factory-invalidation-src')
+    const outDir = makeTmpDir('factory-invalidation-out')
+    try {
+      const componentsDir = resolve(projectDir, 'components')
+      mkdirSync(componentsDir, { recursive: true })
+      writeFileSync(resolve(componentsDir, 'hooks.ts'), hooksSource(0))
+      writeFileSync(resolve(componentsDir, 'Counter.tsx'), COUNTER_SOURCE)
+      writeFileSync(resolve(componentsDir, 'Sibling.tsx'), SIBLING_SOURCE)
+      linkClientRuntime(projectDir)
+
+      const first = await runBuild(projectDir, outDir)
+      expect(first.errorCount).toBe(0)
+      expect(first.compiledCount).toBe(2)
+
+      const counterClientJsPath = resolve(outDir, 'components/Counter.client.js')
+      const firstCounterJs = readFileSync(counterClientJsPath, 'utf8')
+      expect(firstCounterJs).toContain('createSignal(0)')
+
+      // The build-cache entry for Counter must record the helper file as a
+      // dependency — this is the #2325 fix under test (EXT_CANDIDATES now
+      // covers `.ts` via the same list the analyzer itself probes).
+      const cacheAfterFirst = await loadCache(outDir)
+      expect(cacheAfterFirst).not.toBeNull()
+      const counterEntry = cacheAfterFirst!.entries[resolve(componentsDir, 'Counter.tsx')]
+      expect(counterEntry).toBeDefined()
+      expect(Object.keys(counterEntry.deps)).toContain(resolve(componentsDir, 'hooks.ts'))
+
+      // Edit the helper only — neither component file changes.
+      writeFileSync(resolve(componentsDir, 'hooks.ts'), hooksSource(42))
+
+      const second = await runBuild(projectDir, outDir)
+      expect(second.errorCount).toBe(0)
+      // Counter recompiles (its dep changed); Sibling is untouched and
+      // served from cache.
+      expect(second.compiledCount).toBe(1)
+      expect(second.cachedCount).toBe(1)
+
+      const secondCounterJs = readFileSync(counterClientJsPath, 'utf8')
+      expect(secondCounterJs).toContain('createSignal(42)')
+      expect(secondCounterJs).not.toContain('createSignal(0)')
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+      rmSync(outDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -355,6 +355,26 @@ describe('collectRelativeImportDeps', () => {
     expect(deps).toEqual([resolve(testDir, 'foo.ts')])
     cleanup()
   })
+
+  // #2325: a factory-helper file authored as plain `.js`/`.jsx` (not
+  // `.tsx`/`.ts`) must be tracked as a dependency too, so editing it
+  // invalidates the importer's build-cache entry.
+  test('resolves `./foo` to ./foo.js when a file exists', async () => {
+    setup()
+    writeFileSync(resolve(testDir, 'foo.js'), 'export const x = 1')
+    const deps = await collectRelativeImportDeps(entry, `import { x } from './foo'`)
+    expect(deps).toEqual([resolve(testDir, 'foo.js')])
+    cleanup()
+  })
+
+  test('resolves `./dir` to ./dir/index.jsx when dir exists with an index file', async () => {
+    setup()
+    mkdirSync(resolve(testDir, 'dir'))
+    writeFileSync(resolve(testDir, 'dir/index.jsx'), 'export const x = 1')
+    const deps = await collectRelativeImportDeps(entry, `import { x } from './dir'`)
+    expect(deps).toEqual([resolve(testDir, 'dir/index.jsx')])
+    cleanup()
+  })
 })
 
 // ── vendorChunkFilename ──────────────────────────────────────────────────

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -1930,7 +1930,12 @@ export async function collectRelativeImportDeps(
   const baseDir = dirname(entryPath)
   const seen = new Set<string>()
   const results: string[] = []
-  const EXT_CANDIDATES = ['.tsx', '.ts', '/index.tsx', '/index.ts']
+  // Mirrors the analyzer's own `resolveRelativeImportToFile` probe list
+  // (packages/jsx/src/analyzer.ts) so a factory helper authored as `.jsx`/
+  // `.js` — not just `.tsx`/`.ts` — is tracked as a dependency too;
+  // otherwise editing such a helper wouldn't invalidate the importer's
+  // build-cache entry (#2325).
+  const EXT_CANDIDATES = ['.tsx', '.ts', '.jsx', '.js', '/index.tsx', '/index.ts', '/index.jsx', '/index.js']
 
   for (const match of sourceContent.matchAll(RELATIVE_IMPORT_SCAN_RE)) {
     const rel = match[1]

--- a/packages/jsx/src/__tests__/reactive-factory-cross-file.test.ts
+++ b/packages/jsx/src/__tests__/reactive-factory-cross-file.test.ts
@@ -146,4 +146,94 @@ export function Counter() {
     const result = compileJSX(consumerSource, consumerPath, { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
   })
+
+  test('non-relative import object-destructure emits BF110 (uninspectable-import heuristic)', () => {
+    const consumerSource = `'use client'
+import { useStore } from '@app/hooks'
+
+export function Comp() {
+  const { value, setValue } = useStore(0)
+  return <button onClick={() => setValue(value() + 1)}>{value()}</button>
+}
+`
+    const consumerPath = writeFixture('non-relative-consumer.tsx', consumerSource)
+
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    const bf110 = result.errors.find(e => e.code === 'BF110')
+    expect(bf110).toBeDefined()
+    expect(bf110!.message).toContain('useStore')
+  })
+
+  test('module-scope capture → BF112: helper-local function reference blocks inlining', () => {
+    writeFixture('hooks-capture.tsx', `'use client'
+import { createSignal } from '@barefootjs/client'
+
+const KEY = 'stored-value'
+
+function readStored() {
+  return KEY.length
+}
+
+export function useStoredCounter() {
+  const [count, setCount] = createSignal(readStored())
+  return { count, setCount }
+}
+`)
+    const consumerSource = `'use client'
+import { useStoredCounter } from './hooks-capture'
+
+export function Counter() {
+  const { count, setCount } = useStoredCounter()
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}
+`
+    const consumerPath = writeFixture('counter-capture.tsx', consumerSource)
+
+    const ctx = analyzeComponent(consumerSource, consumerPath, 'Counter')
+    expect(ctx.signals.length).toBe(0)
+
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    const bf112 = result.errors.find(e => e.code === 'BF112')
+    expect(bf112).toBeDefined()
+    expect(bf112!.message).toContain('readStored')
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    if (clientJs) {
+      expect(clientJs.content).not.toContain('readStored')
+    }
+  })
+
+  test('reactive-primitive-free helper: tuple destructure gets BF110, object destructure stays silent (cleanFactoryImports)', () => {
+    writeFixture('hooks-clean.tsx', `
+export function makePair(a: number, b: number) {
+  return [a, b] as const
+}
+export function makeConfig(a: number, b: number) {
+  return { a, b }
+}
+`)
+    const tupleConsumerSource = `'use client'
+import { makePair } from './hooks-clean'
+
+export function Pair() {
+  const [x, y] = makePair(1, 2)
+  return <p>{x} {y}</p>
+}
+`
+    const tupleConsumerPath = writeFixture('pair-consumer.tsx', tupleConsumerSource)
+    const tupleResult = compileJSX(tupleConsumerSource, tupleConsumerPath, { adapter })
+    expect(tupleResult.errors.find(e => e.code === 'BF110')).toBeDefined()
+
+    const objectConsumerSource = `'use client'
+import { makeConfig } from './hooks-clean'
+
+export function Config() {
+  const { a, b } = makeConfig(1, 2)
+  return <p>{a} {b}</p>
+}
+`
+    const objectConsumerPath = writeFixture('config-consumer.tsx', objectConsumerSource)
+    const objectResult = compileJSX(objectConsumerSource, objectConsumerPath, { adapter })
+    expect(objectResult.errors.find(e => e.code === 'BF110')).toBeUndefined()
+    expect(objectResult.errors.find(e => e.code === 'BF111')).toBeUndefined()
+  })
 })

--- a/packages/jsx/src/__tests__/reactive-factory-cross-file.test.ts
+++ b/packages/jsx/src/__tests__/reactive-factory-cross-file.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Cross-file reactive-factory resolution (#931 round 2, #2325).
+ *
+ * Context: `reactive-factory-inlining.test.ts` covers same-file factory
+ * helpers (`function createCounter() { ... }` defined in the same module as
+ * the component that calls it). Real-world factory helpers usually live in
+ * their own file (e.g. Sora's `useListStore`) and are imported — until this
+ * round, that shape silently fell through to the generic BF110 unrecognised-
+ * callee path (or worse, produced client JS with a dangling reference).
+ *
+ * This file pins `prescanImportedReactiveFactories`: resolving a factory
+ * defined in a relative-imported helper file, inlining its body at the
+ * call site exactly as a same-file factory would be, and provisioning the
+ * `createSignal` import from usage (not from the consumer's own imports —
+ * see C1 in the #2325 spec) so the consumer file never needs to import
+ * `@barefootjs/client` itself just to destructure a factory's result.
+ *
+ * Harness: `mkdtempSync`/`beforeAll`/`afterAll`/fixture-writing pattern from
+ * `cross-file-client-signal.test.ts`, combined with `analyzeComponent` /
+ * `compileJSX` / `TestAdapter` from `reactive-factory-inlining.test.ts` —
+ * cross-file resolution requires the consumer's real on-disk path so
+ * `resolveRelativeImportToFile` can find the helper file.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test'
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { analyzeComponent } from '../analyzer'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+let fixtureDir: string
+
+beforeAll(() => {
+  fixtureDir = mkdtempSync(path.join(tmpdir(), 'bf-factory-cross-file-'))
+})
+
+afterAll(() => {
+  rmSync(fixtureDir, { recursive: true, force: true })
+})
+
+function writeFixture(name: string, content: string): string {
+  const p = path.join(fixtureDir, name)
+  mkdirSync(path.dirname(p), { recursive: true })
+  writeFileSync(p, content, 'utf8')
+  return p
+}
+
+describe('Cross-file reactive factories (#2325)', () => {
+  test('cross-file tuple factory inlines and provisions the createSignal import (C1)', () => {
+    writeFixture('hooks-tuple.tsx', `'use client'
+import { createSignal } from '@barefootjs/client'
+
+export function createCounter(initial: number) {
+  const [count, setCount] = createSignal(initial)
+  return [count, setCount] as const
+}
+`)
+    // The consumer never imports @barefootjs/client itself — only the
+    // factory. Import provisioning must come from usage in the generated
+    // code, not from the consumer's own source-level imports.
+    const consumerSource = `'use client'
+import { createCounter } from './hooks-tuple'
+
+export function Counter() {
+  const [count, setCount] = createCounter(0)
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}
+`
+    const consumerPath = writeFixture('counter-tuple.tsx', consumerSource)
+
+    const ctx = analyzeComponent(consumerSource, consumerPath, 'Counter')
+    expect(ctx.signals.length).toBe(1)
+    expect(ctx.signals[0].getter).toBe('count')
+    expect(ctx.signals[0].setter).toBe('setCount')
+
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    expect(clientJs!.content).toMatch(/import\s*\{[^}]*createSignal[^}]*\}\s*from\s*'@barefootjs\/client\/runtime'/)
+    // The helper's own relative path must not leak into the output — its
+    // body was inlined, not imported.
+    expect(clientJs!.content).not.toContain('./hooks-tuple')
+  })
+
+  test('cross-file object-return factory + subset destructure (Sora useListStore shape)', () => {
+    writeFixture('hooks-object.tsx', `'use client'
+import { createSignal, createMemo } from '@barefootjs/client'
+
+export function useListStore(initial: string[]) {
+  const [items, setItems] = createSignal(initial)
+  const count = createMemo(() => items().length)
+  return { items, setItems, count }
+}
+`)
+    const consumerSource = `'use client'
+import { useListStore } from './hooks-object'
+
+export function ListSummary() {
+  const { items, count } = useListStore([])
+  return <p>{items().length} / {count()}</p>
+}
+`
+    const consumerPath = writeFixture('list-summary.tsx', consumerSource)
+
+    const ctx = analyzeComponent(consumerSource, consumerPath, 'ListSummary')
+    expect(ctx.signals.length).toBe(1)
+    expect(ctx.signals[0].getter).toBe('items')
+    expect(ctx.memos.length).toBe(1)
+    expect(ctx.memos[0].name).toBe('count')
+
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    expect(clientJs!.content).toContain('createSignal')
+  })
+
+  test('aliased cross-file factory import inlines under the local alias', () => {
+    writeFixture('hooks-alias.tsx', `'use client'
+import { createSignal } from '@barefootjs/client'
+
+export function useCounter(initial: number) {
+  const [count, setCount] = createSignal(initial)
+  return [count, setCount] as const
+}
+`)
+    const consumerSource = `'use client'
+import { useCounter as useC } from './hooks-alias'
+
+export function Counter() {
+  const [count, setCount] = useC(0)
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}
+`
+    const consumerPath = writeFixture('counter-alias.tsx', consumerSource)
+
+    const ctx = analyzeComponent(consumerSource, consumerPath, 'Counter')
+    expect(ctx.signals.length).toBe(1)
+    expect(ctx.signals[0].getter).toBe('count')
+
+    const result = compileJSX(consumerSource, consumerPath, { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+  })
+})

--- a/packages/jsx/src/__tests__/reactive-factory-inlining.test.ts
+++ b/packages/jsx/src/__tests__/reactive-factory-inlining.test.ts
@@ -349,4 +349,105 @@ describe('Object-return reactive factories (#2325)', () => {
     const result = compileJSX(source, 'Counter.tsx', { adapter })
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
   })
+
+  test('BF110: object destructure of an unknown imported callee emits a diagnostic', () => {
+    // Regression-locks the closed silent-failure hole: an unresolvable
+    // relative import whose name looks reactive-factory-shaped.
+    const source = `
+      'use client'
+      import { useExternal } from './external'
+
+      export function Gadget() {
+        const { value, setValue } = useExternal('key')
+        return <button onClick={() => setValue('x')}>{value()}</button>
+      }
+    `
+
+    const result = compileJSX(source, 'Gadget.tsx', { adapter })
+    const bf110 = result.errors.find(e => e.code === 'BF110')
+    expect(bf110).toBeDefined()
+    expect(bf110!.message).toContain('useExternal')
+  })
+
+  test('BF111: non-shorthand factory return emits a diagnostic, no inlining', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createCounter(initial: number) {
+        const [count, setCount] = createSignal(initial)
+        return { count: count, setCount }
+      }
+
+      export function Counter() {
+        const { count, setCount } = createCounter(0)
+        return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Counter.tsx')
+    expect(ctx.signals.length).toBe(0)
+
+    const result = compileJSX(source, 'Counter.tsx', { adapter })
+    const bf111 = result.errors.find(e => e.code === 'BF111')
+    expect(bf111).toBeDefined()
+  })
+
+  test('BF111: non-shorthand call-site destructure of a shorthand factory emits a diagnostic, no inlining', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createCounter(initial: number) {
+        const [count, setCount] = createSignal(initial)
+        return { count, setCount }
+      }
+
+      export function Counter() {
+        const { count: c, setCount } = createCounter(0)
+        return <button onClick={() => setCount(c() + 1)}>{c()}</button>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Counter.tsx')
+    expect(ctx.signals.length).toBe(0)
+
+    const result = compileJSX(source, 'Counter.tsx', { adapter })
+    const bf111 = result.errors.find(e => e.code === 'BF111')
+    expect(bf111).toBeDefined()
+  })
+
+  test('guard: plain-function object destructure is not flagged (false-positive guard)', () => {
+    const source = `
+      'use client'
+
+      function parseConfig() {
+        return { data: 42 }
+      }
+
+      export function Comp() {
+        const { data } = parseConfig()
+        return <p>{data}</p>
+      }
+    `
+
+    const result = compileJSX(source, 'Comp.tsx', { adapter })
+    expect(result.errors.find(e => e.code === 'BF110')).toBeUndefined()
+    expect(result.errors.find(e => e.code === 'BF111')).toBeUndefined()
+  })
+
+  test('guard: object destructure of a @barefootjs-scoped import is not flagged (false-positive guard)', () => {
+    const source = `
+      'use client'
+      import { loadItems } from '@barefootjs/something'
+
+      export function Comp() {
+        const { items } = loadItems()
+        return <p>{items}</p>
+      }
+    `
+
+    const result = compileJSX(source, 'Comp.tsx', { adapter })
+    expect(result.errors.find(e => e.code === 'BF110')).toBeUndefined()
+  })
 })

--- a/packages/jsx/src/__tests__/reactive-factory-inlining.test.ts
+++ b/packages/jsx/src/__tests__/reactive-factory-inlining.test.ts
@@ -417,6 +417,37 @@ describe('Object-return reactive factories (#2325)', () => {
     expect(bf111).toBeDefined()
   })
 
+  test('BF110 (not BF111): object destructure with a rename of a TUPLE-return factory reports the tuple mismatch', () => {
+    // A tuple-return factory destructured as an object is never valid,
+    // regardless of whether the object pattern is shorthand or uses a
+    // rename/default/rest element — it should always get the "this
+    // factory returns a tuple" BF110 message, not the shorthand-only
+    // BF111 guidance (which only makes sense for object-return factories).
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createCounter(initial: number) {
+        const [count, setCount] = createSignal(initial)
+        return [count, setCount] as const
+      }
+
+      export function Counter() {
+        const { count: c, setCount } = createCounter(0)
+        return <button onClick={() => setCount(c() + 1)}>{c()}</button>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Counter.tsx')
+    expect(ctx.signals.length).toBe(0)
+
+    const result = compileJSX(source, 'Counter.tsx', { adapter })
+    const bf110 = result.errors.find(e => e.code === 'BF110')
+    expect(bf110).toBeDefined()
+    expect(bf110!.message).toContain('returns a tuple')
+    expect(result.errors.find(e => e.code === 'BF111')).toBeUndefined()
+  })
+
   test('guard: plain-function object destructure is not flagged (false-positive guard)', () => {
     const source = `
       'use client'

--- a/packages/jsx/src/__tests__/reactive-factory-inlining.test.ts
+++ b/packages/jsx/src/__tests__/reactive-factory-inlining.test.ts
@@ -176,14 +176,26 @@ describe('Reactive factory inlining (#931)', () => {
   })
 
   test('non-tuple single-value destructure is NOT treated as a factory call', () => {
-    // Guard against false positives: `const { x } = obj()` should be left alone.
+    // Guard against false positives: `const { x } = obj()` should be left
+    // alone when `obj` is an ordinary (non-reactive) function.
+    //
+    // Correction (#2325): this fixture previously destructured `createSignal`
+    // itself with a TUPLE pattern (`const [count, setCount] = createSignal(0)`),
+    // which never exercised an object destructure at all — it was already
+    // covered by the `callee === 'createSignal'` skip in
+    // `validateReactiveFactoryCalls`. Rewritten to genuinely exercise the
+    // object-destructure path now that it performs real factory-shape
+    // dispatch (#2325 §4c).
     const source = `
       'use client'
-      import { createSignal } from '@barefootjs/client'
+
+      function getConfig() {
+        return { x: 1 }
+      }
 
       export function Comp() {
-        const [count, setCount] = createSignal(0)
-        return <p>{count()}</p>
+        const { x } = getConfig()
+        return <p>{x}</p>
       }
     `
 
@@ -191,5 +203,150 @@ describe('Reactive factory inlining (#931)', () => {
     expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
     const bf110 = result.errors.find(e => e.code === 'BF110')
     expect(bf110).toBeUndefined()
+  })
+})
+
+describe('Object-return reactive factories (#2325)', () => {
+  test('object-return factory: full destructure { count, setCount }', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createCounter(initial: number) {
+        const [count, setCount] = createSignal(initial)
+        return { count, setCount }
+      }
+
+      export function Counter() {
+        const { count, setCount } = createCounter(0)
+        return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Counter.tsx')
+    expect(ctx.signals.length).toBe(1)
+    expect(ctx.signals[0].getter).toBe('count')
+    expect(ctx.signals[0].setter).toBe('setCount')
+
+    const result = compileJSX(source, 'Counter.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    expect(clientJs!.content).toContain('createSignal')
+  })
+
+  test('object-return factory: subset destructure suffix-renames the undestructured setter (C4)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createCounter(initial: number) {
+        const [count, setCount] = createSignal(initial)
+        return { count, setCount }
+      }
+
+      export function Display() {
+        const { count } = createCounter(0)
+        return <p>{count()}</p>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Display.tsx')
+    expect(ctx.signals.length).toBe(1)
+    expect(ctx.signals[0].getter).toBe('count')
+
+    const result = compileJSX(source, 'Display.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')!.content
+    // The setter was never destructured — it must still be suffix-renamed
+    // (not left as a bare, unresolved `setCount`).
+    expect(clientJs).toMatch(/setCount_\w+/)
+  })
+
+  test('object-return factory: custom setter wrapper (localStorage-backed signal)', () => {
+    // Matches the createPersistentSignal shape from PR #930.
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createPersistentSignal(key: string, initial: string) {
+        const [v, setV] = createSignal(initial)
+        const setAndStore = (next: string) => {
+          setV(next)
+          localStorage.setItem(key, next)
+        }
+        return { v, setAndStore }
+      }
+
+      export function Store() {
+        const { v, setAndStore } = createPersistentSignal('k', 'hello')
+        return <button onClick={() => setAndStore('world')}>{v()}</button>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Store.tsx')
+    expect(ctx.signals.length).toBe(1)
+    expect(ctx.signals[0].getter).toBe('v')
+
+    const result = compileJSX(source, 'Store.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')!.content
+    expect(clientJs).toContain('createSignal')
+    expect(clientJs).toContain("localStorage.setItem('k'")
+  })
+
+  test('object-return factory: two subset-destructure call sites stay hygienic (C4)', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      function createPair(initial: number) {
+        const [count, setCount] = createSignal(initial)
+        return { count, setCount }
+      }
+
+      export function Two() {
+        const { count } = createPair(0)
+        const { setCount } = createPair(10)
+        return <p>{count()}</p>
+      }
+    `
+
+    const result = compileJSX(source, 'Two.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+    const clientJs = result.files.find(f => f.type === 'clientJs')!.content
+    expect(clientJs.match(/createSignal\(/g)?.length).toBe(2)
+    // Per-call-site-unique suffixed internal names: the first call site
+    // suffix-renames its undestructured `setCount`, the second suffix-
+    // renames its undestructured `count` — distinct call sites must not
+    // collide on either name.
+    expect(clientJs).toMatch(/setCount_bf\d+/)
+    expect(clientJs).toMatch(/count_bf\d+/)
+  })
+
+  test('object-return factory: mixed signal + memo body', () => {
+    const source = `
+      'use client'
+      import { createSignal, createMemo } from '@barefootjs/client'
+
+      function createCounter(initial: number) {
+        const [count, setCount] = createSignal(initial)
+        const double = createMemo(() => count() * 2)
+        return { count, setCount, double }
+      }
+
+      export function Counter() {
+        const { count, setCount, double } = createCounter(0)
+        return <button onClick={() => setCount(count() + 1)}>{double()}</button>
+      }
+    `
+
+    const ctx = analyzeComponent(source, 'Counter.tsx')
+    expect(ctx.signals.length).toBe(1)
+    expect(ctx.memos.length).toBe(1)
+    expect(ctx.memos[0].name).toBe('double')
+
+    const result = compileJSX(source, 'Counter.tsx', { adapter })
+    expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
   })
 })

--- a/packages/jsx/src/analyzer-context.ts
+++ b/packages/jsx/src/analyzer-context.ts
@@ -22,6 +22,7 @@ import type {
   ParamInfo,
   PropertyInfo,
   ReactiveFactoryInfo,
+  DeclinedReactiveFactory,
 } from './types.ts'
 import { type ExcludeRange, collectAllTypeRanges, reconstructWithoutTypes } from './strip-types.ts'
 
@@ -146,15 +147,26 @@ export interface AnalyzerContext {
   /** Maps multi-return JSX helper functions for conditional inlining at call sites. */
   jsxMultiReturnFunctions: Map<string, MultiReturnJsxInfo>
   /**
-   * Maps function names to reactive-factory info (#931). A reactive factory
-   * is a same-file helper whose body declares reactive primitives and
-   * returns a tuple of identifiers, e.g.
+   * Maps factory-call-site-local names to reactive-factory info (#931,
+   * #2325). A reactive factory is a helper whose body declares reactive
+   * primitives and returns a tuple or shorthand-object of identifiers, e.g.
    *   `function createCounter(initial) { const [c,s] = createSignal(initial); return [c, s] as const }`.
    * When a component destructures the result of a factory call, the factory
    * body is inlined at the call site so the compiler sees ordinary
-   * `createSignal` declarations.
+   * `createSignal` declarations. Populated by `analyzeComponent` from the
+   * factory prescan (same-file declarations plus relative-imported
+   * factories resolved by `prescanImportedReactiveFactories`); consumed by
+   * `validateReactiveFactoryCalls`.
    */
   reactiveFactories: Map<string, ReactiveFactoryInfo>
+  /** Factories recognized but declined for inlining, keyed by call-site-local name (#2325). */
+  declinedReactiveFactories: Map<string, DeclinedReactiveFactory>
+  /** Module-scope helpers (same-file or resolved import) whose body contains a
+   *  reactive primitive call but whose shape is not an inlinable factory. */
+  reactiveShapedHelpers: Set<string>
+  /** Imported destructured-callee names whose helper file was resolved, read,
+   *  and found reactive-free / factory-free — proven safe to leave alone. */
+  cleanFactoryImports: Set<string>
   /**
    * Intermediate `const s = createSignal(...)` tuples awaiting `s[0]`/`s[1]`
    * extraction. Flushed into `signals` at the end of visitComponentBody.
@@ -247,6 +259,9 @@ export function createAnalyzerContext(
     jsxFunctions: new Map(),
     jsxMultiReturnFunctions: new Map(),
     reactiveFactories: new Map(),
+    declinedReactiveFactories: new Map(),
+    reactiveShapedHelpers: new Set(),
+    cleanFactoryImports: new Set(),
     signalTupleRefs: new Map(),
 
     propsType: null,

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -7,7 +7,7 @@
  */
 
 import ts from 'typescript'
-import type { ImportSpecifier, TypeInfo, ParamInfo, ReactiveFactoryInfo, DeclinedReactiveFactory } from './types.ts'
+import type { ImportSpecifier, TypeInfo, ParamInfo, ReactiveFactoryInfo, DeclinedReactiveFactory, SourceLocation } from './types.ts'
 import { parseExpression, parseBlockBodyTolerant, foldBlockToExpr } from './expression-parser.ts'
 import { rewriteBarePropRefs } from './prop-rewrite.ts'
 import { incrementCounter } from './instrumentation.ts'
@@ -231,6 +231,15 @@ export function analyzeComponent(
 
   const ctx = createAnalyzerContext(sourceFile, filePath)
   ctx.checker = checker
+
+  // Reactive-factory prescan results (#931, #2325 cross-file + object-
+  // return round 2) — same-file and relative-imported factories, plus the
+  // declined / reactive-shaped buckets `validateReactiveFactoryCalls` uses
+  // to emit a specific diagnostic instead of the generic BF110.
+  ctx.reactiveFactories = prescan.factories
+  ctx.declinedReactiveFactories = prescan.declined
+  ctx.reactiveShapedHelpers = prescan.reactiveShaped
+  ctx.cleanFactoryImports = prescan.cleanFactoryImports
 
   // BF050 — surface "no shared Program supplied for type-based reactivity
   // classification" as a diagnostic so callers can fail strict builds
@@ -4292,10 +4301,36 @@ function escapeRegex(s: string): string {
 // =============================================================================
 
 /**
- * Scan a compiled component context for tuple-destructures whose callee is
- * neither `createSignal` / `createMemo` nor an inlinable reactive factory.
- * These are the silent-failure shapes that produced broken client JS prior
- * to factory inlining — emit BF110 so users get a clear message instead.
+ * Build the diagnostic for a call site whose callee was recognised but
+ * declined for inlining (#2325 — cross-file factories that rename their
+ * return properties, or capture their own module scope). BF112's wording is
+ * specific to module-scope capture; every other declined reason (currently
+ * only BF111 — non-shorthand return properties) shares BF111's generic
+ * "cannot be inlined: <detail>" phrasing, matching the wording used for the
+ * tuple call-site path.
+ */
+function declinedFactoryMessage(callee: string, d: DeclinedReactiveFactory): string {
+  if (d.code === 'BF112') {
+    return (
+      `Reactive factory '${callee}' references ${d.detail} from its own module ` +
+      `scope and cannot be inlined. Move the referenced helper(s) into this file, ` +
+      `pass them as factory arguments, or inline the factory here.`
+    )
+  }
+  return `Reactive factory '${callee}' cannot be inlined: ${d.detail}.`
+}
+
+/**
+ * Scan a compiled component context for destructures (tuple or object)
+ * whose callee is neither `createSignal` / `createMemo` nor an inlinable
+ * reactive factory. These are the silent-failure shapes that produced
+ * broken client JS prior to factory inlining — emit BF110 (unrecognised
+ * shape), BF111 (unsupported rename), or BF112 (module-scope capture) so
+ * users get a clear message instead.
+ *
+ * Only walks top-level component-body statements, matching the scope the
+ * inliner itself operates on (#931) — a factory call inside a nested block
+ * is out of scope for both inlining and this diagnostic.
  */
 export function validateReactiveFactoryCalls(ctx: AnalyzerContext): void {
   if (!ctx.componentNode) return
@@ -4307,42 +4342,193 @@ export function validateReactiveFactoryCalls(ctx: AnalyzerContext): void {
   for (const stmt of body.statements) {
     if (!ts.isVariableStatement(stmt)) continue
     for (const decl of stmt.declarationList.declarations) {
-      if (!ts.isArrayBindingPattern(decl.name)) continue
       if (!decl.initializer || !ts.isCallExpression(decl.initializer)) continue
       if (!ts.isIdentifier(decl.initializer.expression)) continue
       const callee = decl.initializer.expression.text
-      if (callee === 'createSignal' || callee === 'createMemo') continue
-      // Env-signal factories (`createSearchParams`, #2057) are `createSignal`-
-      // shaped and recognised structurally — a valid tuple destructure. Resolve
-      // via the same path as recognition (`resolveEnvSignalKey`) so an aliased
-      // import (`import { createSearchParams as csp }`) is accepted here too,
-      // rather than falling through to a spurious BF110.
-      if (resolveEnvSignalKey(decl.initializer, ctx)) continue
-      // Inlined factories were rewritten away before this analysis, so
-      // anything still matching the shape is a destructure of an
-      // unrecognised callee (imported helper, ad-hoc tuple fn, factory
-      // with arity mismatch).
-      ctx.errors.push(
-        createError(
-          ErrorCodes.UNRECOGNIZED_REACTIVE_FACTORY,
-          getSourceLocation(stmt, ctx.sourceFile, ctx.filePath),
-          {
+      const loc = getSourceLocation(stmt, ctx.sourceFile, ctx.filePath)
+
+      if (ts.isArrayBindingPattern(decl.name)) {
+        if (callee === 'createSignal' || callee === 'createMemo') continue
+        // Env-signal factories (`createSearchParams`, #2057) are `createSignal`-
+        // shaped and recognised structurally — a valid tuple destructure. Resolve
+        // via the same path as recognition (`resolveEnvSignalKey`) so an aliased
+        // import (`import { createSearchParams as csp }`) is accepted here too,
+        // rather than falling through to a spurious BF110.
+        if (resolveEnvSignalKey(decl.initializer, ctx)) continue
+
+        const declinedEntry = ctx.declinedReactiveFactories.get(callee)
+        if (declinedEntry) {
+          ctx.errors.push(createError(
+            declinedEntry.code === 'BF112'
+              ? ErrorCodes.REACTIVE_FACTORY_MODULE_CAPTURE
+              : ErrorCodes.REACTIVE_FACTORY_RENAME_UNSUPPORTED,
+            loc,
+            { severity: 'error', message: declinedFactoryMessage(callee, declinedEntry) }
+          ))
+          continue
+        }
+
+        const objectFactory = ctx.reactiveFactories.get(callee)
+        if (objectFactory && objectFactory.returnKind === 'object') {
+          ctx.errors.push(createError(ErrorCodes.UNRECOGNIZED_REACTIVE_FACTORY, loc, {
             severity: 'error',
             message:
-              `Tuple destructuring of '${callee}(...)': this helper is not a ` +
-              `recognised reactive factory (createSignal / createMemo / a ` +
-              `same-file helper that wraps them with a single \`return [a, b, ...]\`).`,
-            suggestion: {
+              `'${callee}' is a reactive factory that returns an object — destructure ` +
+              `it with a matching object pattern: const { ${objectFactory.returnTupleIdentifiers.join(', ')} } = ${callee}(...)`,
+          }))
+          continue
+        }
+
+        // Inlined factories were rewritten away before this analysis, so
+        // anything still matching the shape is a destructure of an
+        // unrecognised callee (imported helper, ad-hoc tuple fn, factory
+        // with arity mismatch).
+        ctx.errors.push(
+          createError(
+            ErrorCodes.UNRECOGNIZED_REACTIVE_FACTORY,
+            loc,
+            {
+              severity: 'error',
               message:
-                `Inline the createSignal call at the call site, or move the ` +
-                `helper into this file as a function that returns a tuple of ` +
-                `identifiers at its single exit point.`,
-            },
-          }
+                `Tuple destructuring of '${callee}(...)': this helper is not a ` +
+                `recognised reactive factory (createSignal / createMemo / a ` +
+                `same-file helper that wraps them with a single \`return [a, b, ...]\`).`,
+              suggestion: {
+                message:
+                  `Inline the createSignal call at the call site, or move the ` +
+                  `helper into this file as a function that returns a tuple of ` +
+                  `identifiers at its single exit point.`,
+              },
+            }
+          )
         )
-      )
+        continue
+      }
+
+      if (ts.isObjectBindingPattern(decl.name)) {
+        validateObjectFactoryDestructure(ctx, decl.name, callee, loc)
+      }
     }
   }
+}
+
+/**
+ * Object-destructure half of `validateReactiveFactoryCalls` (#2325). Split
+ * out so the tuple path above stays a straight read of the pre-#2325 logic
+ * (the tuple diagnostics are pinned by pre-existing tests) while this path
+ * covers the previously-silent object-destructure failure modes: an
+ * unrecognised callee, a tuple factory destructured as an object, a rename/
+ * default/rest destructure of a shorthand-only factory, an unknown
+ * property, a declined (BF111/BF112) factory, or an uninspectable import
+ * that looks reactive-factory-shaped by name.
+ */
+function validateObjectFactoryDestructure(
+  ctx: AnalyzerContext,
+  pattern: ts.ObjectBindingPattern,
+  callee: string,
+  loc: SourceLocation
+): void {
+  const factory = ctx.reactiveFactories.get(callee)
+  if (factory) {
+    const hasUnsupportedElement = pattern.elements.some(
+      el => !!el.propertyName || !!el.initializer || !!el.dotDotDotToken || !ts.isIdentifier(el.name)
+    )
+    if (hasUnsupportedElement) {
+      ctx.errors.push(createError(ErrorCodes.REACTIVE_FACTORY_RENAME_UNSUPPORTED, loc, {
+        severity: 'error',
+        message:
+          `Object destructure of reactive factory '${callee}' uses a property ` +
+          `rename, default, or rest element; only shorthand destructuring of ` +
+          `{ ${factory.returnTupleIdentifiers.join(', ')} } is supported.`,
+      }))
+      return
+    }
+
+    if (factory.returnKind === 'tuple') {
+      ctx.errors.push(createError(ErrorCodes.UNRECOGNIZED_REACTIVE_FACTORY, loc, {
+        severity: 'error',
+        message:
+          `'${callee}' is a reactive factory that returns a tuple — destructure ` +
+          `it positionally: const [${factory.returnTupleIdentifiers.join(', ')}] = ${callee}(...)`,
+      }))
+      return
+    }
+
+    const unknown = pattern.elements
+      .map(el => (ts.isIdentifier(el.name) ? el.name.text : ''))
+      .filter(name => name && !factory.returnTupleIdentifiers.includes(name))
+    if (unknown.length > 0) {
+      const label = unknown.length === 1 ? 'property' : 'properties'
+      ctx.errors.push(createError(ErrorCodes.UNRECOGNIZED_REACTIVE_FACTORY, loc, {
+        severity: 'error',
+        message:
+          `Object destructure of reactive factory '${callee}' references ${label} ` +
+          `'${unknown.join("', '")}' not present in its return { ${factory.returnTupleIdentifiers.join(', ')} }.`,
+      }))
+      return
+    }
+
+    // Shorthand object pattern that matches the factory's return shape —
+    // already inlined; nothing to report.
+    return
+  }
+
+  const declinedEntry = ctx.declinedReactiveFactories.get(callee)
+  if (declinedEntry) {
+    ctx.errors.push(createError(
+      declinedEntry.code === 'BF112'
+        ? ErrorCodes.REACTIVE_FACTORY_MODULE_CAPTURE
+        : ErrorCodes.REACTIVE_FACTORY_RENAME_UNSUPPORTED,
+      loc,
+      { severity: 'error', message: declinedFactoryMessage(callee, declinedEntry) }
+    ))
+    return
+  }
+
+  if (ctx.reactiveShapedHelpers.has(callee)) {
+    ctx.errors.push(createError(ErrorCodes.UNRECOGNIZED_REACTIVE_FACTORY, loc, {
+      severity: 'error',
+      message:
+        `Object destructure of '${callee}(...)': this helper wraps a reactive ` +
+        `primitive but does not match the inlinable factory shape (single ` +
+        '`return { a, b }` of shorthand identifiers at its one exit point).',
+    }))
+    return
+  }
+
+  // Proven non-reactive import (helper file resolved, read, and found to
+  // export nothing reactive-shaped under this name) — silent, correctly
+  // (C2: an ordinary object destructure must not become a false positive).
+  if (ctx.cleanFactoryImports.has(callee)) return
+
+  // Last resort: an import the compiler cannot inspect (non-relative or
+  // unresolvable path) whose name looks like a hook/factory. Name-based
+  // heuristic only — false negatives here fall through to silence, which
+  // matches this file's ordinary-object-destructure default (C2).
+  let matchedImportSource: string | null = null
+  for (const imp of ctx.imports) {
+    if (imp.isTypeOnly) continue
+    const spec = imp.specifiers.find(s => !s.isTypeOnly && (s.alias ?? s.name) === callee)
+    if (spec) {
+      matchedImportSource = imp.source
+      break
+    }
+  }
+  if (
+    matchedImportSource !== null &&
+    !matchedImportSource.startsWith('@barefootjs/') &&
+    /^(use|create)[A-Z]/.test(callee)
+  ) {
+    ctx.errors.push(createError(ErrorCodes.UNRECOGNIZED_REACTIVE_FACTORY, loc, {
+      severity: 'error',
+      message:
+        `Object destructure of imported '${callee}(...)': the compiler cannot ` +
+        `inspect this import (non-relative or unresolvable path), so if it wraps ` +
+        `createSignal/createMemo the destructured bindings will not be reactive. Move ` +
+        `the helper to a relative-imported file or inline its body.`,
+    }))
+  }
+  // Otherwise: ordinary object destructure of unrelated code — leave untouched (C2).
 }
 
 // =============================================================================

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -4085,6 +4085,12 @@ function prescanImportedReactiveFactories(
       }
     }
 
+    // Module-scope bindings the helper file declares — an inlined factory
+    // body must not reference any of these (#2325 §4h / BF112), since
+    // inlining moves the body into the component file where they don't
+    // exist.
+    const moduleBindings = collectHelperModuleValueBindings(helperSf)
+
     for (const spec of specs) {
       if (alreadyKnown(spec.local)) continue
 
@@ -4105,17 +4111,110 @@ function prescanImportedReactiveFactories(
         case 'declined':
           result.declined.set(spec.local, det.declined)
           break
-        case 'factory':
-          // Module-scope capture guard (BF112) lands in a follow-up commit
-          // (#2325 §4h) — at this point in the sequence a captured factory
-          // still inlines with a dangling reference to its helper-module
-          // scope, which is acceptable mid-sequence but not the final state.
-          det.info.sourceFilePath = resolved
-          result.factories.set(spec.local, det.info)
+        case 'factory': {
+          const offending = moduleCaptureCheck(fn, det.info, moduleBindings, fn.name!.text)
+          if (offending.length > 0) {
+            result.declined.set(spec.local, {
+              code: 'BF112',
+              detail: `'${offending.join("', '")}'`,
+              loc: det.info.loc,
+            })
+          } else {
+            det.info.sourceFilePath = resolved
+            result.factories.set(spec.local, det.info)
+          }
           break
+        }
       }
     }
   }
+}
+
+/**
+ * Value bindings at the helper file's module scope that an inlined factory
+ * body must not capture (#2325 §4h / BF112): top-level const/let/var,
+ * function/class/enum names, and value import specifiers — EXCEPT imports
+ * from '@barefootjs/client' / '@barefootjs/client/runtime'. Those are
+ * re-provisioned from usage by the client-JS emitter regardless of where
+ * the call that used them textually came from (`resolveFinalImports` /
+ * `detectUsedImports` regex-scan the *generated* code, not the consumer's
+ * source imports — see #2325 spec C1), so an inlined body calling
+ * `createSignal` is never a capture even though the helper file itself
+ * imports it. Type-only imports/declarations carry no runtime binding and
+ * are excluded.
+ */
+function collectHelperModuleValueBindings(sf: ts.SourceFile): Set<string> {
+  const names = new Set<string>()
+  for (const stmt of sf.statements) {
+    if (ts.isVariableStatement(stmt)) {
+      const out: string[] = []
+      for (const decl of stmt.declarationList.declarations) {
+        addBindingNames(decl.name, out)
+      }
+      for (const n of out) names.add(n)
+      continue
+    }
+    if (
+      (ts.isFunctionDeclaration(stmt) || ts.isClassDeclaration(stmt) || ts.isEnumDeclaration(stmt)) &&
+      stmt.name
+    ) {
+      names.add(stmt.name.text)
+      continue
+    }
+    if (ts.isImportDeclaration(stmt)) {
+      if (stmt.importClause?.isTypeOnly) continue
+      if (!ts.isStringLiteral(stmt.moduleSpecifier)) continue
+      const src = stmt.moduleSpecifier.text
+      if (src === '@barefootjs/client' || src === '@barefootjs/client/runtime') continue
+      if (stmt.importClause?.name) names.add(stmt.importClause.name.text)
+      const namedBindings = stmt.importClause?.namedBindings
+      if (namedBindings && ts.isNamedImports(namedBindings)) {
+        for (const el of namedBindings.elements) {
+          if (el.isTypeOnly) continue
+          names.add(el.name.text)
+        }
+      }
+      if (namedBindings && ts.isNamespaceImport(namedBindings)) {
+        names.add(namedBindings.name.text)
+      }
+    }
+  }
+  return names
+}
+
+/**
+ * Free identifiers of a reactive-factory body that resolve to bindings at
+ * its own module scope (#2325 §4h / BF112) — references the inlined body
+ * would silently lose once spliced into the component file. Returns the
+ * offending names sorted, for stable diagnostic text.
+ *
+ * Known accepted limitation: `extractFreeIdentifiersFromNode` only scope-
+ * tracks arrow-function parameters, not nested `function` declarations'
+ * parameters or nested-block declarations — a body-nested binding that
+ * happens to shadow a helper-module binding could false-positive into
+ * BF112. Acceptable: the failure direction is a loud build error on a rare
+ * shape, never a silent runtime break.
+ */
+function moduleCaptureCheck(
+  fn: ts.FunctionDeclaration,
+  info: ReactiveFactoryInfo,
+  moduleBindings: Set<string>,
+  selfName: string
+): string[] {
+  if (!fn.body) return []
+  const free = extractFreeIdentifiersFromNode(fn.body)
+  const exclude = new Set<string>(info.params)
+  for (const b of info.localBindings) exclude.add(b)
+  for (const r of info.returnTupleIdentifiers) exclude.add(r)
+  for (const p of REACTIVE_PRIMITIVES) exclude.add(p)
+  exclude.add(selfName)
+
+  const offending: string[] = []
+  for (const id of free) {
+    if (exclude.has(id)) continue
+    if (moduleBindings.has(id)) offending.push(id)
+  }
+  return offending.sort()
 }
 
 /**

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -3897,7 +3897,10 @@ interface PrescanResult {
  * the reactive-factory shape (single `return [a, b, ...]` / `return { a, b
  * }` exit + at least one reactive primitive call in the body). Returns a
  * map from factory name to its metadata, and the parsed source file for
- * call-site rewriting.
+ * call-site rewriting. Also resolves factories defined in a relative-
+ * imported helper file (#2325, see `prescanImportedReactiveFactories`) —
+ * every `analyzeComponent` caller gets cross-file resolution with no call-
+ * site changes elsewhere.
  */
 function prescanReactiveFactoriesInSource(
   source: string,
@@ -3937,7 +3940,182 @@ function prescanReactiveFactoriesInSource(
 
   ts.forEachChild(sourceFile, visitTop)
 
-  return { factories, declined, reactiveShaped, cleanFactoryImports, sourceFile }
+  const result: PrescanResult = { factories, declined, reactiveShaped, cleanFactoryImports, sourceFile }
+  prescanImportedReactiveFactories(sourceFile, filePath, result)
+  return result
+}
+
+/**
+ * Cross-file half of the factory prescan (#2325 round 2): resolve factories
+ * defined in a relative-imported helper file so `const { count } =
+ * createCounter(0)` inlines the same way whether `createCounter` lives in
+ * this file or in `./hooks`. Mutates `result`'s maps in place.
+ *
+ * Perf: gated on a candidate-callee set collected from the ALREADY-parsed
+ * entry AST (no regex over source text, per CONTRIBUTING.md's "never parse
+ * imports with regex" rule) — files with no tuple/object-destructured call
+ * at all skip every filesystem access below. A second cheap gate (does the
+ * helper file's raw text contain any `REACTIVE_PRIMITIVES` substring) skips
+ * the AST parse of helper files that plainly aren't reactive; this is a
+ * skip-gate over content, not an import parse, so it doesn't run afoul of
+ * that same rule.
+ *
+ * Name-collision precedence: a same-file factory/declined/reactive-shaped
+ * entry always wins over a same-named cross-file import — every write
+ * below is guarded on the name being unclaimed in all three buckets.
+ */
+function prescanImportedReactiveFactories(
+  entrySourceFile: ts.SourceFile,
+  filePath: string,
+  result: PrescanResult
+): void {
+  // 1. Candidate gate: names destructured (tuple or object) from a direct
+  //    call-expression initializer, anywhere in the file. Cheap AST walk,
+  //    no filesystem access.
+  const candidateCallees = new Set<string>()
+  function collectCandidates(node: ts.Node): void {
+    if (
+      ts.isVariableDeclaration(node) &&
+      (ts.isArrayBindingPattern(node.name) || ts.isObjectBindingPattern(node.name)) &&
+      node.initializer &&
+      ts.isCallExpression(node.initializer) &&
+      ts.isIdentifier(node.initializer.expression)
+    ) {
+      candidateCallees.add(node.initializer.expression.text)
+    }
+    ts.forEachChild(node, collectCandidates)
+  }
+  collectCandidates(entrySourceFile)
+  if (candidateCallees.size === 0) return
+
+  // 2. Relative imports whose named specifiers overlap the candidate set.
+  interface CandidateSpec {
+    /** Name exported from the helper file. */
+    exported: string
+    /** Local (call-site) binding name — the key every result map uses. */
+    local: string
+  }
+  const importsToCheck: { src: string; specs: CandidateSpec[] }[] = []
+  for (const stmt of entrySourceFile.statements) {
+    if (!ts.isImportDeclaration(stmt)) continue
+    if (!ts.isStringLiteral(stmt.moduleSpecifier)) continue
+    const src = stmt.moduleSpecifier.text
+    // Mirrors `scanImportedClientSignals`'s restriction to relative
+    // specifiers — non-relative (bare/aliased) imports resolve through
+    // bundler / tsconfig-paths configuration this layer doesn't consume.
+    if (!src.startsWith('./') && !src.startsWith('../')) continue
+    if (stmt.importClause?.isTypeOnly) continue
+    const namedBindings = stmt.importClause?.namedBindings
+    if (!namedBindings || !ts.isNamedImports(namedBindings)) continue
+
+    const specs: CandidateSpec[] = []
+    for (const el of namedBindings.elements) {
+      if (el.isTypeOnly) continue
+      const local = el.name.text
+      if (!candidateCallees.has(local)) continue
+      specs.push({ exported: (el.propertyName ?? el.name).text, local })
+    }
+    if (specs.length === 0) continue
+    importsToCheck.push({ src, specs })
+  }
+  if (importsToCheck.length === 0) return
+
+  for (const { src, specs } of importsToCheck) {
+    const resolved = resolveRelativeImportToFile(src, filePath)
+    // Unresolvable — left alone here; the name-heuristic BF110 branch in
+    // validateReactiveFactoryCalls handles it at validation time.
+    if (!resolved) continue
+
+    let content: string
+    try {
+      content = fs.readFileSync(resolved, 'utf8')
+    } catch {
+      continue
+    }
+
+    const alreadyKnown = (name: string): boolean =>
+      result.factories.has(name) || result.declined.has(name) || result.reactiveShaped.has(name)
+
+    // Cheap text-level skip-gate (not an import/JS parse — see docstring):
+    // a helper file with no reactive-primitive substring anywhere cannot
+    // define a reactive factory, so skip parsing it entirely.
+    const hasAnyPrimitiveText = [...REACTIVE_PRIMITIVES].some(p => content.includes(p))
+    if (!hasAnyPrimitiveText) {
+      for (const spec of specs) {
+        if (!alreadyKnown(spec.local)) result.cleanFactoryImports.add(spec.local)
+      }
+      continue
+    }
+
+    const helperSf = ts.createSourceFile(
+      resolved + '.prescan',
+      content,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TSX
+    )
+
+    // Map exported name -> module-scope FunctionDeclaration via the AST.
+    const localFns = new Map<string, ts.FunctionDeclaration>()
+    const exportedFns = new Map<string, ts.FunctionDeclaration>()
+    for (const stmt of helperSf.statements) {
+      if (ts.isFunctionDeclaration(stmt) && stmt.name && stmt.body) {
+        localFns.set(stmt.name.text, stmt)
+        const hasExportModifier = stmt.modifiers?.some(m => m.kind === ts.SyntaxKind.ExportKeyword) ?? false
+        const hasDefaultModifier = stmt.modifiers?.some(m => m.kind === ts.SyntaxKind.DefaultKeyword) ?? false
+        if (hasExportModifier && !hasDefaultModifier) {
+          exportedFns.set(stmt.name.text, stmt)
+        }
+      }
+    }
+    // `export { f }` / `export { f as g }` — keyed by the EXTERNAL export name.
+    for (const stmt of helperSf.statements) {
+      if (
+        ts.isExportDeclaration(stmt) &&
+        stmt.exportClause &&
+        ts.isNamedExports(stmt.exportClause) &&
+        !stmt.moduleSpecifier &&
+        !stmt.isTypeOnly
+      ) {
+        for (const el of stmt.exportClause.elements) {
+          if (el.isTypeOnly) continue
+          const fn = localFns.get((el.propertyName ?? el.name).text)
+          if (fn) exportedFns.set(el.name.text, fn)
+        }
+      }
+    }
+
+    for (const spec of specs) {
+      if (alreadyKnown(spec.local)) continue
+
+      const fn = exportedFns.get(spec.exported)
+      if (!fn) {
+        result.cleanFactoryImports.add(spec.local)
+        continue
+      }
+      const det = detectReactiveFactory(fn, helperSf, resolved)
+      if (!det) {
+        result.cleanFactoryImports.add(spec.local)
+        continue
+      }
+      switch (det.kind) {
+        case 'reactive-shaped':
+          result.reactiveShaped.add(spec.local)
+          break
+        case 'declined':
+          result.declined.set(spec.local, det.declined)
+          break
+        case 'factory':
+          // Module-scope capture guard (BF112) lands in a follow-up commit
+          // (#2325 §4h) — at this point in the sequence a captured factory
+          // still inlines with a dangling reference to its helper-module
+          // scope, which is acceptable mid-sequence but not the final state.
+          det.info.sourceFilePath = resolved
+          result.factories.set(spec.local, det.info)
+          break
+      }
+    }
+  }
 }
 
 /**

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -7,7 +7,7 @@
  */
 
 import ts from 'typescript'
-import type { ImportSpecifier, TypeInfo, ParamInfo, ReactiveFactoryInfo } from './types.ts'
+import type { ImportSpecifier, TypeInfo, ParamInfo, ReactiveFactoryInfo, DeclinedReactiveFactory } from './types.ts'
 import { parseExpression, parseBlockBodyTolerant, foldBlockToExpr } from './expression-parser.ts'
 import { rewriteBarePropRefs } from './prop-rewrite.ts'
 import { incrementCounter } from './instrumentation.ts'
@@ -3871,14 +3871,24 @@ export const REACTIVE_PRIMITIVES = new Set([
 
 interface PrescanResult {
   factories: Map<string, ReactiveFactoryInfo>
+  /** Factories recognized but declined for inlining (#2325). */
+  declined: Map<string, DeclinedReactiveFactory>
+  /** Module-scope helpers whose body wraps a reactive primitive but whose
+   *  shape is not an inlinable factory (#2325). */
+  reactiveShaped: Set<string>
+  /** Imported destructured-callee names whose helper file was resolved,
+   *  read, and found reactive-free / factory-free (#2325, filled by
+   *  `prescanImportedReactiveFactories`). */
+  cleanFactoryImports: Set<string>
   sourceFile: ts.SourceFile
 }
 
 /**
  * Scan a source string for module-level function declarations that match
- * the reactive-factory shape (single `return [a, b, ...]` exit + at least
- * one reactive primitive call in the body). Returns a map from factory
- * name to its metadata, and the parsed source file for call-site rewriting.
+ * the reactive-factory shape (single `return [a, b, ...]` / `return { a, b
+ * }` exit + at least one reactive primitive call in the body). Returns a
+ * map from factory name to its metadata, and the parsed source file for
+ * call-site rewriting.
  */
 function prescanReactiveFactoriesInSource(
   source: string,
@@ -3892,11 +3902,25 @@ function prescanReactiveFactoriesInSource(
     ts.ScriptKind.TSX
   )
   const factories = new Map<string, ReactiveFactoryInfo>()
+  const declined = new Map<string, DeclinedReactiveFactory>()
+  const reactiveShaped = new Set<string>()
+  const cleanFactoryImports = new Set<string>()
 
   function visitTop(node: ts.Node): void {
     if (ts.isFunctionDeclaration(node) && node.name && node.body) {
-      const info = detectReactiveFactory(node, sourceFile, filePath)
-      if (info) factories.set(node.name.text, info)
+      const det = detectReactiveFactory(node, sourceFile, filePath)
+      if (!det) return
+      switch (det.kind) {
+        case 'factory':
+          factories.set(node.name.text, det.info)
+          break
+        case 'declined':
+          declined.set(node.name.text, det.declined)
+          break
+        case 'reactive-shaped':
+          reactiveShaped.add(node.name.text)
+          break
+      }
     }
     // Not recursing into function bodies: factory helpers are at module
     // scope only for this round (issue #931 "In scope" §1).
@@ -3904,46 +3928,33 @@ function prescanReactiveFactoriesInSource(
 
   ts.forEachChild(sourceFile, visitTop)
 
-  return { factories, sourceFile }
+  return { factories, declined, reactiveShaped, cleanFactoryImports, sourceFile }
 }
+
+/**
+ * Classification result for a module-level function that might be a
+ * reactive-factory helper (#2325). `null` means the function has no
+ * reactive-primitive call anywhere in its body, so it isn't reactive-
+ * related at all — every other case implies at least one such call.
+ */
+type FactoryDetection =
+  | { kind: 'factory'; info: ReactiveFactoryInfo }
+  | { kind: 'declined'; declined: DeclinedReactiveFactory }
+  | { kind: 'reactive-shaped' } // wraps a reactive primitive but shape unsupported
+  | null
 
 function detectReactiveFactory(
   node: ts.FunctionDeclaration,
   sourceFile: ts.SourceFile,
   filePath: string
-): ReactiveFactoryInfo | null {
+): FactoryDetection {
   if (!node.body || !node.name) return null
 
-  // Require: exactly one top-level `return` whose argument is an array
-  // literal of plain identifiers (optionally wrapped in `as const` / parens).
-  let tupleReturn: ts.ArrayLiteralExpression | null = null
-  let returnCount = 0
-  for (const stmt of node.body.statements) {
-    if (!ts.isReturnStatement(stmt)) continue
-    returnCount++
-    if (!stmt.expression) return null
-    let expr: ts.Expression = stmt.expression
-    while (ts.isParenthesizedExpression(expr)) expr = expr.expression
-    // Accept `... as const` / `<const>...`
-    if (ts.isAsExpression(expr)) expr = expr.expression
-    if (ts.isTypeAssertionExpression(expr)) expr = expr.expression
-    if (!ts.isArrayLiteralExpression(expr)) return null
-    tupleReturn = expr
-  }
-  if (returnCount !== 1 || !tupleReturn) return null
-
-  // Every element must be a plain identifier (no spreads, computed,
-  // call expressions). Otherwise the caller-side rename would not be sound.
-  const returnTupleIdentifiers: string[] = []
-  for (const el of tupleReturn.elements) {
-    if (!ts.isIdentifier(el)) return null
-    returnTupleIdentifiers.push(el.text)
-  }
-  if (returnTupleIdentifiers.length === 0) return null
-
   // Body must contain at least one reactive primitive call so that the
-  // factory is actually the right thing to inline (not just a tuple-returning
-  // helper that happens to look similar).
+  // factory is actually the right thing to inline (not just a helper that
+  // happens to look similar). Checked FIRST: a function with zero reactive
+  // calls is not reactive-related in any way, so it is out of scope for
+  // every diagnostic below, not just "not a factory".
   let hasReactiveCall = false
   function checkForReactive(n: ts.Node): void {
     if (hasReactiveCall) return
@@ -3956,6 +3967,60 @@ function detectReactiveFactory(
   }
   checkForReactive(node.body)
   if (!hasReactiveCall) return null
+
+  const loc = getSourceLocation(node, sourceFile, filePath)
+
+  // Require exactly one top-level `return`, whose argument (after unwrapping
+  // parens / `as const` / type-assertion) is a tuple (array literal) or a
+  // shorthand-object literal.
+  let returnExpr: ts.Expression | null = null
+  let returnCount = 0
+  for (const stmt of node.body.statements) {
+    if (!ts.isReturnStatement(stmt)) continue
+    returnCount++
+    if (!stmt.expression) return { kind: 'reactive-shaped' }
+    let expr: ts.Expression = stmt.expression
+    while (ts.isParenthesizedExpression(expr)) expr = expr.expression
+    // Accept `... as const` / `<const>...`
+    if (ts.isAsExpression(expr)) expr = expr.expression
+    if (ts.isTypeAssertionExpression(expr)) expr = expr.expression
+    returnExpr = expr
+  }
+  if (returnCount !== 1 || !returnExpr) return { kind: 'reactive-shaped' }
+
+  const returnTupleIdentifiers: string[] = []
+  let returnKind: 'tuple' | 'object'
+
+  if (ts.isArrayLiteralExpression(returnExpr)) {
+    returnKind = 'tuple'
+    // Every element must be a plain identifier (no spreads, computed,
+    // call expressions). Otherwise the caller-side rename would not be sound.
+    for (const el of returnExpr.elements) {
+      if (!ts.isIdentifier(el)) return { kind: 'reactive-shaped' }
+      returnTupleIdentifiers.push(el.text)
+    }
+    if (returnTupleIdentifiers.length === 0) return { kind: 'reactive-shaped' }
+  } else if (ts.isObjectLiteralExpression(returnExpr)) {
+    returnKind = 'object'
+    const hasNonShorthand = returnExpr.properties.some(p => !ts.isShorthandPropertyAssignment(p))
+    if (hasNonShorthand) {
+      return {
+        kind: 'declined',
+        declined: {
+          code: 'BF111',
+          detail: `return object of '${node.name.text}' uses non-shorthand properties`,
+          loc,
+        },
+      }
+    }
+    for (const p of returnExpr.properties) {
+      // Every property already proven ts.isShorthandPropertyAssignment above.
+      returnTupleIdentifiers.push((p as ts.ShorthandPropertyAssignment).name.text)
+    }
+    if (returnTupleIdentifiers.length === 0) return { kind: 'reactive-shaped' }
+  } else {
+    return { kind: 'reactive-shaped' }
+  }
 
   // Collect local bindings in the factory body for identifier hygiene at
   // inlining time. Only direct-child declarations of the block are
@@ -3972,26 +4037,35 @@ function detectReactiveFactory(
   }
 
   // Serialize the body without the outer braces and without the return
-  // statement — the return tuple is dissolved into caller-named identifiers.
+  // statement — the return tuple/object is dissolved into caller-named
+  // identifiers.
   const bodyStatements = node.body.statements
     .filter(s => !ts.isReturnStatement(s))
     .map(s => s.getText(sourceFile))
     .join('\n')
 
-  const params = node.parameters.map(p => {
-    if (ts.isIdentifier(p.name)) return p.name.text
+  const params: string[] = []
+  for (const p of node.parameters) {
+    if (ts.isIdentifier(p.name)) {
+      params.push(p.name.text)
+      continue
+    }
     // Destructured params are uncommon for this helper shape and out of
-    // initial scope; return a placeholder so we can skip the factory.
-    return ''
-  })
-  if (params.some(p => p === '')) return null
+    // initial scope; the factory still wraps a reactive primitive, so
+    // classify it as reactive-shaped rather than silently ignoring it.
+    return { kind: 'reactive-shaped' }
+  }
 
   return {
-    params,
-    bodySource: bodyStatements,
-    returnTupleIdentifiers,
-    localBindings,
-    loc: getSourceLocation(node, sourceFile, filePath),
+    kind: 'factory',
+    info: {
+      params,
+      bodySource: bodyStatements,
+      returnTupleIdentifiers,
+      returnKind,
+      localBindings,
+      loc,
+    },
   }
 }
 
@@ -4052,16 +4126,33 @@ function rewriteFactoryCallsInSource(
   }
 
   function maybeRewriteDecl(stmt: ts.VariableStatement, decl: ts.VariableDeclaration): void {
-    if (!ts.isArrayBindingPattern(decl.name)) return
     if (!decl.initializer || !ts.isCallExpression(decl.initializer)) return
     if (!ts.isIdentifier(decl.initializer.expression)) return
     const factoryName = decl.initializer.expression.text
     const factory = factories.get(factoryName)
     if (!factory) return
 
+    if (ts.isArrayBindingPattern(decl.name)) {
+      if (factory.returnKind !== 'tuple') return
+      rewriteTupleDecl(stmt, decl.name, decl.initializer, factory)
+      return
+    }
+    if (ts.isObjectBindingPattern(decl.name)) {
+      if (factory.returnKind !== 'object') return
+      rewriteObjectDecl(stmt, decl.name, decl.initializer, factory)
+      return
+    }
+  }
+
+  function rewriteTupleDecl(
+    stmt: ts.VariableStatement,
+    pattern: ts.ArrayBindingPattern,
+    call: ts.CallExpression,
+    factory: ReactiveFactoryInfo
+  ): void {
     // Arity check — bail out on mismatch so the analyzer can report BF110
     // on the untouched source.
-    const elements = decl.name.elements
+    const elements = pattern.elements
     if (elements.length !== factory.returnTupleIdentifiers.length) return
 
     // Caller-side identifier names (one per tuple slot). Omitted slots
@@ -4073,17 +4164,74 @@ function rewriteFactoryCallsInSource(
       callerNames.push(el.name.text)
     }
 
-    const argTexts = decl.initializer.arguments.map(a => a.getText(sourceFile))
+    // Exclude params + every return-tuple identifier from suffix-renaming
+    // (they're renamed to caller names below instead).
+    const excludeFromSuffixRename = new Set<string>(factory.params)
+    for (const r of factory.returnTupleIdentifiers) excludeFromSuffixRename.add(r)
+
+    const renameReturnToCallerNames = new Map<string, string>()
+    for (let i = 0; i < factory.returnTupleIdentifiers.length; i++) {
+      renameReturnToCallerNames.set(factory.returnTupleIdentifiers[i], callerNames[i])
+    }
+
+    inlineFactoryCallAtSite(stmt, factory, call.arguments, excludeFromSuffixRename, renameReturnToCallerNames)
+  }
+
+  function rewriteObjectDecl(
+    stmt: ts.VariableStatement,
+    pattern: ts.ObjectBindingPattern,
+    call: ts.CallExpression,
+    factory: ReactiveFactoryInfo
+  ): void {
+    // Shorthand destructuring only (no renames/defaults/rest) of names the
+    // factory actually returns. Anything else bails so the analyzer can
+    // report BF110/BF111 on the untouched source. Subset destructures are
+    // allowed — a caller may destructure fewer than all returned names.
+    const destructured = new Set<string>()
+    for (const el of pattern.elements) {
+      if (el.dotDotDotToken) return
+      if (el.propertyName) return
+      if (el.initializer) return
+      if (!ts.isIdentifier(el.name)) return
+      if (!factory.returnTupleIdentifiers.includes(el.name.text)) return
+      destructured.add(el.name.text)
+    }
+
+    // Exclude params + the destructured names from suffix-renaming (caller
+    // name already equals the property name under shorthand, C4). Returned
+    // names the caller did NOT destructure are ordinary internal locals and
+    // DO get suffix-renamed — otherwise two subset calls of the same
+    // factory collide on the undestructured name.
+    const excludeFromSuffixRename = new Set<string>(factory.params)
+    for (const d of destructured) excludeFromSuffixRename.add(d)
+
+    // No return-name→caller-name rename step: identity under shorthand.
+    inlineFactoryCallAtSite(stmt, factory, call.arguments, excludeFromSuffixRename, null)
+  }
+
+  /**
+   * Shared inlining tail for both return shapes: suffix-rename internal
+   * bindings not in `excludeFromSuffixRename`, splice argument expressions
+   * in for parameters, optionally rename return identifiers to caller
+   * names (tuple path only — see C4 for why the object path passes null),
+   * and push the resulting edit for this call site.
+   */
+  function inlineFactoryCallAtSite(
+    stmt: ts.VariableStatement,
+    factory: ReactiveFactoryInfo,
+    args: ts.NodeArray<ts.Expression>,
+    excludeFromSuffixRename: Set<string>,
+    renameReturnToCallerNames: Map<string, string> | null
+  ): void {
+    const argTexts = args.map(a => a.getText(sourceFile))
     const thisCallIndex = callSiteIndex++
     const suffix = `_bf${thisCallIndex}`
 
     // Apply renames to the factory body source.
     let body = factory.bodySource
-    // 1. Suffix-rename internal bindings (exclude params + return tuple
-    //    + caller names to avoid collisions).
+    // 1. Suffix-rename internal bindings.
     const internalRenames = new Set<string>(factory.localBindings)
-    for (const p of factory.params) internalRenames.delete(p)
-    for (const r of factory.returnTupleIdentifiers) internalRenames.delete(r)
+    for (const ex of excludeFromSuffixRename) internalRenames.delete(ex)
     for (const name of internalRenames) {
       body = body.replace(new RegExp(`\\b${escapeRegex(name)}\\b`, 'g'), name + suffix)
     }
@@ -4098,11 +4246,11 @@ function rewriteFactoryCallsInSource(
       const wrapped = atomicArg.test(a.trim()) ? a.trim() : `(${a})`
       body = body.replace(new RegExp(`\\b${escapeRegex(p)}\\b`, 'g'), wrapped)
     }
-    // 3. Return tuple identifiers → caller destructure names.
-    for (let i = 0; i < factory.returnTupleIdentifiers.length; i++) {
-      const n = factory.returnTupleIdentifiers[i]
-      const caller = callerNames[i]
-      body = body.replace(new RegExp(`\\b${escapeRegex(n)}\\b`, 'g'), caller)
+    // 3. Return identifiers → caller destructure names (tuple path only).
+    if (renameReturnToCallerNames) {
+      for (const [n, caller] of renameReturnToCallerNames) {
+        body = body.replace(new RegExp(`\\b${escapeRegex(n)}\\b`, 'g'), caller)
+      }
     }
 
     edits.push({

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -4707,6 +4707,22 @@ function validateObjectFactoryDestructure(
 ): void {
   const factory = ctx.reactiveFactories.get(callee)
   if (factory) {
+    // Return-shape mismatch takes priority over element-form validation: a
+    // tuple-return factory destructured as an object is *never* valid,
+    // regardless of whether the object pattern happens to use shorthand or
+    // a rename/default/rest element — always point the caller at positional
+    // destructuring (BF110) instead of the shorthand-only guidance below
+    // (BF111), which only makes sense for genuinely object-return factories.
+    if (factory.returnKind === 'tuple') {
+      ctx.errors.push(createError(ErrorCodes.UNRECOGNIZED_REACTIVE_FACTORY, loc, {
+        severity: 'error',
+        message:
+          `'${callee}' is a reactive factory that returns a tuple — destructure ` +
+          `it positionally: const [${factory.returnTupleIdentifiers.join(', ')}] = ${callee}(...)`,
+      }))
+      return
+    }
+
     const hasUnsupportedElement = pattern.elements.some(
       el => !!el.propertyName || !!el.initializer || !!el.dotDotDotToken || !ts.isIdentifier(el.name)
     )
@@ -4717,16 +4733,6 @@ function validateObjectFactoryDestructure(
           `Object destructure of reactive factory '${callee}' uses a property ` +
           `rename, default, or rest element; only shorthand destructuring of ` +
           `{ ${factory.returnTupleIdentifiers.join(', ')} } is supported.`,
-      }))
-      return
-    }
-
-    if (factory.returnKind === 'tuple') {
-      ctx.errors.push(createError(ErrorCodes.UNRECOGNIZED_REACTIVE_FACTORY, loc, {
-        severity: 'error',
-        message:
-          `'${callee}' is a reactive factory that returns a tuple — destructure ` +
-          `it positionally: const [${factory.returnTupleIdentifiers.join(', ')}] = ${callee}(...)`,
       }))
       return
     }

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -87,6 +87,8 @@ export const ErrorCodes = {
 
   // Reactive factory errors (BF110-BF119)
   UNRECOGNIZED_REACTIVE_FACTORY: 'BF110',
+  REACTIVE_FACTORY_RENAME_UNSUPPORTED: 'BF111',
+  REACTIVE_FACTORY_MODULE_CAPTURE: 'BF112',
 } as const
 
 export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes]
@@ -165,6 +167,17 @@ const errorMessages: Record<ErrorCode, string> = {
 
   [ErrorCodes.UNRECOGNIZED_REACTIVE_FACTORY]:
     'Tuple destructuring of a non-reactive factory call. The compiler only recognizes createSignal / createMemo calls and same-file helpers that wrap them with a single `return [a, b]` exit.',
+
+  [ErrorCodes.REACTIVE_FACTORY_RENAME_UNSUPPORTED]:
+    'Reactive factory object return/destructure must use shorthand properties only. ' +
+    'Property renames (`{ lists: myLists }`), defaults, and rest elements are not ' +
+    'supported — destructure with the factory\'s own property names.',
+
+  [ErrorCodes.REACTIVE_FACTORY_MODULE_CAPTURE]:
+    'Imported reactive factory references bindings from its own module scope, so its ' +
+    'body cannot be inlined into the component file. Move those helpers into the ' +
+    'component file, pass them to the factory as parameters, or define the factory ' +
+    'in the component file.',
 }
 
 // =============================================================================

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -1474,14 +1474,37 @@ export interface ReactiveFactoryInfo {
    * return tuple removed. Identifiers are renamed at the call site.
    */
   bodySource: string
-  /** Identifier names inside the returned array literal, in order. */
+  /** Ordered return binding names (tuple elements or object shorthand property names). */
   returnTupleIdentifiers: string[]
+  /** Return shape: `[a, b] as const` (tuple) or `{ a, b }` shorthand object (#2325). */
+  returnKind: 'tuple' | 'object'
   /**
    * Names declared anywhere in the factory body (local bindings). Used by
    * the call-site inliner to apply unique-suffix renaming and keep
    * identifiers hygienic across repeat calls of the same factory.
    */
   localBindings: string[]
+  loc: SourceLocation
+  /**
+   * Absolute path of the defining file when the factory was resolved from a
+   * relative import (#2325). Undefined for same-file factories. Diagnostic
+   * detail only — name-collision precedence is enforced at merge time
+   * (local factories win), not by consulting this field.
+   */
+  sourceFilePath?: string
+}
+
+/**
+ * A helper that was recognized as a would-be reactive factory but declined
+ * for inlining (#2325). Recorded so validateReactiveFactoryCalls can emit
+ * the specific diagnostic (BF111 rename / BF112 module-scope capture) at
+ * the call site instead of the generic BF110.
+ */
+export interface DeclinedReactiveFactory {
+  code: 'BF111' | 'BF112'
+  /** Detail spliced into the call-site message (e.g. offending identifier list). */
+  detail: string
+  /** Definition site (in the helper file for cross-file declines). */
   loc: SourceLocation
 }
 

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 258,
+    "totalFixtures": 259,
     "fixtures": {
       "dangerous-inner-html-dynamic": {
         "blade": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -526,11 +526,11 @@
       }
     },
     "call": {
-      "total": 159,
+      "total": 160,
       "cells": {
         "hono": {
-          "pass": 158,
-          "total": 159,
+          "pass": 159,
+          "total": 160,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -541,8 +541,8 @@
           ]
         },
         "blade": {
-          "pass": 154,
-          "total": 159,
+          "pass": 155,
+          "total": 160,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -577,8 +577,8 @@
           ]
         },
         "erb": {
-          "pass": 155,
-          "total": 159,
+          "pass": 156,
+          "total": 160,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -607,8 +607,8 @@
           ]
         },
         "go-template": {
-          "pass": 154,
-          "total": 159,
+          "pass": 155,
+          "total": 160,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -643,8 +643,8 @@
           ]
         },
         "jinja": {
-          "pass": 154,
-          "total": 159,
+          "pass": 155,
+          "total": 160,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -679,8 +679,8 @@
           ]
         },
         "minijinja": {
-          "pass": 154,
-          "total": 159,
+          "pass": 155,
+          "total": 160,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -715,8 +715,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 155,
-          "total": 159,
+          "pass": 156,
+          "total": 160,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -745,8 +745,8 @@
           ]
         },
         "twig": {
-          "pass": 154,
-          "total": 159,
+          "pass": 155,
+          "total": 160,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -781,8 +781,8 @@
           ]
         },
         "xslate": {
-          "pass": 154,
-          "total": 159,
+          "pass": 155,
+          "total": 160,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -860,11 +860,11 @@
       }
     },
     "identifier": {
-      "total": 239,
+      "total": 240,
       "cells": {
         "hono": {
-          "pass": 238,
-          "total": 239,
+          "pass": 239,
+          "total": 240,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -875,8 +875,8 @@
           ]
         },
         "blade": {
-          "pass": 233,
-          "total": 239,
+          "pass": 234,
+          "total": 240,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -917,8 +917,8 @@
           ]
         },
         "erb": {
-          "pass": 234,
-          "total": 239,
+          "pass": 235,
+          "total": 240,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -953,8 +953,8 @@
           ]
         },
         "go-template": {
-          "pass": 233,
-          "total": 239,
+          "pass": 234,
+          "total": 240,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -995,8 +995,8 @@
           ]
         },
         "jinja": {
-          "pass": 233,
-          "total": 239,
+          "pass": 234,
+          "total": 240,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1037,8 +1037,8 @@
           ]
         },
         "minijinja": {
-          "pass": 233,
-          "total": 239,
+          "pass": 234,
+          "total": 240,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1079,8 +1079,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 234,
-          "total": 239,
+          "pass": 235,
+          "total": 240,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1115,8 +1115,8 @@
           ]
         },
         "twig": {
-          "pass": 233,
-          "total": 239,
+          "pass": 234,
+          "total": 240,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1157,8 +1157,8 @@
           ]
         },
         "xslate": {
-          "pass": 233,
-          "total": 239,
+          "pass": 234,
+          "total": 240,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1242,15 +1242,15 @@
       }
     },
     "literal": {
-      "total": 197,
+      "total": 198,
       "cells": {
         "hono": {
-          "pass": 197,
-          "total": 197
+          "pass": 198,
+          "total": 198
         },
         "blade": {
-          "pass": 196,
-          "total": 197,
+          "pass": 197,
+          "total": 198,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1261,8 +1261,8 @@
           ]
         },
         "erb": {
-          "pass": 196,
-          "total": 197,
+          "pass": 197,
+          "total": 198,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1273,8 +1273,8 @@
           ]
         },
         "go-template": {
-          "pass": 196,
-          "total": 197,
+          "pass": 197,
+          "total": 198,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1285,8 +1285,8 @@
           ]
         },
         "jinja": {
-          "pass": 196,
-          "total": 197,
+          "pass": 197,
+          "total": 198,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1297,8 +1297,8 @@
           ]
         },
         "minijinja": {
-          "pass": 196,
-          "total": 197,
+          "pass": 197,
+          "total": 198,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1309,8 +1309,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 196,
-          "total": 197,
+          "pass": 197,
+          "total": 198,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1321,8 +1321,8 @@
           ]
         },
         "twig": {
-          "pass": 196,
-          "total": 197,
+          "pass": 197,
+          "total": 198,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1333,8 +1333,8 @@
           ]
         },
         "xslate": {
-          "pass": 196,
-          "total": 197,
+          "pass": 197,
+          "total": 198,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3864,43 +3864,43 @@
       }
     },
     "literal:number": {
-      "total": 85,
+      "total": 86,
       "cells": {
         "hono": {
-          "pass": 85,
-          "total": 85
+          "pass": 86,
+          "total": 86
         },
         "blade": {
-          "pass": 85,
-          "total": 85
+          "pass": 86,
+          "total": 86
         },
         "erb": {
-          "pass": 85,
-          "total": 85
+          "pass": 86,
+          "total": 86
         },
         "go-template": {
-          "pass": 85,
-          "total": 85
+          "pass": 86,
+          "total": 86
         },
         "jinja": {
-          "pass": 85,
-          "total": 85
+          "pass": 86,
+          "total": 86
         },
         "minijinja": {
-          "pass": 85,
-          "total": 85
+          "pass": 86,
+          "total": 86
         },
         "mojolicious": {
-          "pass": 85,
-          "total": 85
+          "pass": 86,
+          "total": 86
         },
         "twig": {
-          "pass": 85,
-          "total": 85
+          "pass": 86,
+          "total": 86
         },
         "xslate": {
-          "pass": 85,
-          "total": 85
+          "pass": 86,
+          "total": 86
         }
       }
     },


### PR DESCRIPTION
## Summary

Closes #2325. Round 2 of #931 (#936): user-authored reactive-factory helpers now work in the two shapes real code actually uses — imported from their own file, and returning a named object instead of a positional tuple.

### What this PR does

- **(B) Object-return factories** — `return { count, setCount }` (property shorthand only) is now a valid factory return, destructured as `const { count } = factory(...)`. Subset destructures are supported; undestructured returned members are suffix-renamed for per-call-site hygiene. Property renames / defaults / rest decline with the new **BF111**.
- **Closes a live silent-failure hole**: object-destructured factory calls previously bypassed both the inliner and BF110 — reproducing the original #931 catastrophe (broken client JS, SSR ReferenceError, zero diagnostics). Reactive-looking object destructures now diagnose (BF110/BF111/BF112) instead of silently breaking. The trigger set is deliberately narrower than the tuple rule — ordinary object destructures of non-reactive calls are left untouched.
- **(A) Cross-file factories** — factories exported from a **relative-imported** file (`./`, `../`, aliased imports supported) are resolved via the existing `resolveRelativeImportToFile` + `ts.createSourceFile` path (no `ts.Program`; #987's build-time budget respected — gated so factory-free files pay ~nothing), detected with the same `detectReactiveFactory`, and inlined through the unchanged rewrite pipeline. Local factories win on name collision.
- **BF112** — an imported factory whose body captures bindings from its own module scope (e.g. reading a helper-file-local constant) declines with a build error instead of emitting a dangling reference.
- **CLI**: `collectRelativeImportDeps` now probes `.jsx`/`.js` (+ index variants), matching the analyzer's own resolution, so helper edits invalidate the importer's cache entry in watch/incremental builds.

### Not needed (verified during implementation)

- No import-provisioning machinery: the client-JS `@barefootjs/client/runtime` import line is usage-derived, so inlined `createSignal` calls are provisioned automatically — pinned by test.
- No new cache invalidation machinery: relative-imported helpers were already dep-tracked by the build cache; transitive helper deps are moot because BF112 declines factories that reach outside their own body.

### Out of scope (unchanged from the issue)

Non-relative/package imports (diagnosed via BF110, not silent), property renames (BF111), transitive factories, arrow-function-const factories.

## Test plan

- [x] `bun run --filter '@barefootjs/jsx' test` — new object-return cases in `reactive-factory-inlining.test.ts` and a new `reactive-factory-cross-file.test.ts` covering the #2325 matrix, including the cross-file + object-return combination.
- [x] `bun run --filter '@barefootjs/cli' test` — dep-scanner `.js`/`.jsx` rows + new `build-factory-invalidation.test.ts` (edit helper → dependent component recompiles, untouched sibling stays cached).
- [x] `tsc --noEmit -p packages/jsx/tsconfig.json` — clean.
- [x] `bun run build` (root) — diffed against a clean `main` build in an isolated worktree; identical pre-existing failures (composer not installed in this environment), unrelated to this change.
- [x] 5 pre-existing `@barefootjs/cli` test failures (macOS case-insensitive-filesystem artifacts in `resolve-source.test.ts`/`meta-loader.test.ts`) confirmed present on clean `main` via `git stash` before/after comparison — unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
