### PR TITLE
Fix #2327 (integrations re-sync + drift gate) and #2324 union stage (union-typed locale)

### DIFF
--- a/.changeset/tolocale-union-locale.md
+++ b/.changeset/tolocale-union-locale.md
@@ -1,0 +1,5 @@
+---
+'@barefootjs/jsx': minor
+---
+
+Union-typed runtime locale for the `toLocaleDateString` sugar (#2324's union stage): when the locale argument is a REQUIRED prop typed as a closed string-literal union (`locale: 'en-US' | 'ja-JP'`), every member's default date pattern resolves at build time and the pattern argument lowers to a ternary over the runtime value — runtime locale switching with zero runtime CLDR on any backend, on both the SSR and client-JS paths. Optional unions (undefined would read the host locale), open `string` locales, and unions with an unrepresentable member keep refusing with BF021.

--- a/.github/workflows/ci-go-template.yml
+++ b/.github/workflows/ci-go-template.yml
@@ -98,6 +98,26 @@ jobs:
       - name: Build integrations/echo
         run: cd integrations/echo && bun run build
 
+      # #2327: generated components.go must not drift from the compiler.
+      # `bun run build` regenerates into the working tree and the E2E below
+      # runs against that fresh output, so a stale COMMITTED file used to
+      # pass CI silently (how the #2267 interface{} flip went unregenerated
+      # for four integrations). chi/gin/nethttp are built here only to feed
+      # the drift check — echo carries the E2E coverage. Same gate pattern
+      # as ci-compat.yml's lockfile drift check.
+      - name: Build remaining Go integrations (drift-check inputs)
+        run: |
+          (cd integrations/chi && bun run build)
+          (cd integrations/gin && bun run build)
+          (cd integrations/nethttp && bun run build)
+
+      - name: Check generated components.go for drift
+        run: |
+          if ! git diff --exit-code -- integrations/chi/components.go integrations/echo/components.go integrations/gin/components.go integrations/nethttp/components.go; then
+            echo "::error::integrations/*/components.go are out of date. Run 'bun run build' in each Go integration and commit the result."
+            exit 1
+          fi
+
       - name: Download Go dependencies
         run: cd integrations/echo && go mod download
 

--- a/integrations/chi/components.go
+++ b/integrations/chi/components.go
@@ -467,9 +467,9 @@ type PostArticleInput struct {
 	Total int
 	Base string
 	PrevSlug string
-	PrevTitle string
+	PrevTitle interface{}
 	NextSlug string
-	NextTitle string
+	NextTitle interface{}
 }
 
 // PostArticleProps is the props type for the PostArticle component.
@@ -490,9 +490,9 @@ type PostArticleProps struct {
 	Total int `json:"total"`
 	Base string `json:"base"`
 	PrevSlug string `json:"prevSlug"`
-	PrevTitle string `json:"prevTitle"`
+	PrevTitle interface{} `json:"prevTitle"`
 	NextSlug string `json:"nextSlug"`
-	NextTitle string `json:"nextTitle"`
+	NextTitle interface{} `json:"nextTitle"`
 	LikeButtonSlot9 LikeButtonProps `json:"-"`
 	ReadingTimerSlot10 ReadingTimerProps `json:"-"`
 	NowPlayingSlot11 NowPlayingProps `json:"-"`

--- a/integrations/echo/components.go
+++ b/integrations/echo/components.go
@@ -467,9 +467,9 @@ type PostArticleInput struct {
 	Total int
 	Base string
 	PrevSlug string
-	PrevTitle string
+	PrevTitle interface{}
 	NextSlug string
-	NextTitle string
+	NextTitle interface{}
 }
 
 // PostArticleProps is the props type for the PostArticle component.
@@ -490,9 +490,9 @@ type PostArticleProps struct {
 	Total int `json:"total"`
 	Base string `json:"base"`
 	PrevSlug string `json:"prevSlug"`
-	PrevTitle string `json:"prevTitle"`
+	PrevTitle interface{} `json:"prevTitle"`
 	NextSlug string `json:"nextSlug"`
-	NextTitle string `json:"nextTitle"`
+	NextTitle interface{} `json:"nextTitle"`
 	LikeButtonSlot9 LikeButtonProps `json:"-"`
 	ReadingTimerSlot10 ReadingTimerProps `json:"-"`
 	NowPlayingSlot11 NowPlayingProps `json:"-"`

--- a/integrations/gin/components.go
+++ b/integrations/gin/components.go
@@ -467,9 +467,9 @@ type PostArticleInput struct {
 	Total int
 	Base string
 	PrevSlug string
-	PrevTitle string
+	PrevTitle interface{}
 	NextSlug string
-	NextTitle string
+	NextTitle interface{}
 }
 
 // PostArticleProps is the props type for the PostArticle component.
@@ -490,9 +490,9 @@ type PostArticleProps struct {
 	Total int `json:"total"`
 	Base string `json:"base"`
 	PrevSlug string `json:"prevSlug"`
-	PrevTitle string `json:"prevTitle"`
+	PrevTitle interface{} `json:"prevTitle"`
 	NextSlug string `json:"nextSlug"`
-	NextTitle string `json:"nextTitle"`
+	NextTitle interface{} `json:"nextTitle"`
 	LikeButtonSlot9 LikeButtonProps `json:"-"`
 	ReadingTimerSlot10 ReadingTimerProps `json:"-"`
 	NowPlayingSlot11 NowPlayingProps `json:"-"`

--- a/integrations/nethttp/components.go
+++ b/integrations/nethttp/components.go
@@ -467,9 +467,9 @@ type PostArticleInput struct {
 	Total int
 	Base string
 	PrevSlug string
-	PrevTitle string
+	PrevTitle interface{}
 	NextSlug string
-	NextTitle string
+	NextTitle interface{}
 }
 
 // PostArticleProps is the props type for the PostArticle component.
@@ -490,9 +490,9 @@ type PostArticleProps struct {
 	Total int `json:"total"`
 	Base string `json:"base"`
 	PrevSlug string `json:"prevSlug"`
-	PrevTitle string `json:"prevTitle"`
+	PrevTitle interface{} `json:"prevTitle"`
 	NextSlug string `json:"nextSlug"`
-	NextTitle string `json:"nextTitle"`
+	NextTitle interface{} `json:"nextTitle"`
 	LikeButtonSlot9 LikeButtonProps `json:"-"`
 	ReadingTimerSlot10 ReadingTimerProps `json:"-"`
 	NowPlayingSlot11 NowPlayingProps `json:"-"`

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -60,6 +60,7 @@ func FuncMap() template.FuncMap {
 		"bf_pad_start":   PadStart,
 		"bf_pad_end":     PadEnd,
 		"bf_string":      String,
+		"bf_ternary":     Ternary,
 
 		// URL query builder (#1897 PostList href helpers): conditional
 		// (include, key, value) triples → "base?k=v&…", mirroring a
@@ -1240,6 +1241,22 @@ func Join(items any, sep string) string {
 		parts[i] = toString(v.Index(i).Interface())
 	}
 	return strings.Join(parts, sep)
+}
+
+// Ternary returns a when cond is true, else b — the pipeline-position
+// counterpart of a template {{if}} action. Go templates have no
+// expression-level conditional, so a conditional value sitting in
+// ARGUMENT position (a lowering-node helper arg, e.g. the #2324 union
+// stage's locale→pattern ternary) cannot be emitted as an {{if}}
+// fragment; the adapter renders it as `(bf_ternary <cond> <a> <b>)`
+// instead. Both branches are evaluated (function-call semantics) —
+// fine for the value shapes the emitter feeds it, wrong for anything
+// with side effects, which template values never have.
+func Ternary(cond bool, a, b any) any {
+	if cond {
+		return a
+	}
+	return b
 }
 
 // String returns the string form of v. Mirrors JS `String(v)` for

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -592,6 +592,26 @@ export function Check(props: { checked?: boolean }) {
       expect(types).toContain('C: checked,')
     })
 
+    test('flips a bare TEXT-POSITION optional scalar prop to interface{} (#2267)', () => {
+      // The trigger nobody pinned directly until #2327: an optional
+      // no-default primitive consumed as bare `{props.X}` text (no `??`, no
+      // omittable attribute, no presence check) flips to interface{} so an
+      // absent prop renders '' like JS undefined instead of the Go zero
+      // value / `<no value>`. This is the exact shape behind
+      // integrations' PostArticle prevTitle/nextTitle — the regen drift
+      // #2327 tracked. The required sibling stays a concrete string.
+      const adapter = new GoTemplateAdapter()
+      const ir = compileToIR(`
+export function Pager(props: { prevSlug: string; prevTitle?: string }) {
+  return <div>{props.prevSlug ? <a>{props.prevTitle}</a> : ''}</div>
+}
+`)
+      const result = adapter.generate(ir)
+      const types = result.types!
+      expect(types).toContain('PrevTitle interface{}')
+      expect(types).toContain('PrevSlug string')
+    })
+
     test('hoists the DESTRUCTURED `x ?? N` seed via signal.parsed (#2259)', () => {
       // Destructured components have no `propsObjectName`, so the seed's
       // prop reference is a bare identifier — matched structurally on the

--- a/packages/adapter-go-template/src/__tests__/lowering-plugin.test.ts
+++ b/packages/adapter-go-template/src/__tests__/lowering-plugin.test.ts
@@ -162,4 +162,24 @@ export function P(props: { config: object }) {
     const { template } = generate(src)
     expect(template).not.toContain('bf_custom_serialize')
   })
+
+  test('a CONDITIONAL helper-call arg renders as pipeline-position bf_ternary, not an {{if}} action', () => {
+    // The #2324 union stage lowers a union-typed locale to a ternary
+    // pattern arg. Go templates have no expression-level conditional, and
+    // the generic emitter's `conditional` produces an `{{if}}…{{end}}`
+    // action FRAGMENT — a parse error inside a pipeline ("unexpected { in
+    // parenthesized pipeline", the exact CI failure this pins). Argument
+    // position must route through the bf_ternary runtime helper instead.
+    const src = `
+function P({ createdAt, locale }: { createdAt: Date; locale: 'en-US' | 'ja-JP' }) {
+  return <time>{createdAt.toLocaleDateString(locale, { timeZone: 'UTC' })}</time>
+}
+export { P }
+`
+    const { template } = generate(src)
+    expect(template).toContain(
+      'bf_format_date .CreatedAt (bf_ternary (eq (bf_string .Locale) "en-US") "M/D/YYYY" "YYYY/M/D") "UTC"',
+    )
+    expect(template).not.toContain('({{if')
+  })
 })

--- a/packages/adapter-go-template/src/adapter/expr/url-builder.ts
+++ b/packages/adapter-go-template/src/adapter/expr/url-builder.ts
@@ -113,8 +113,22 @@ function renderLoweringNode(ctx: GoEmitContext, node: LoweringNode): string | nu
   if (!helper) return null
   const lowerExpr = (n: ParsedExpr): string =>
     ctx.convertExpressionToGo(stringifyParsedExpr(n), undefined, n)
+  // A `conditional` in ARGUMENT position cannot go through the generic
+  // emitter: its `conditional` method renders an `{{if}}…{{end}}` action
+  // fragment (text position only), which is a parse error inside a
+  // pipeline ("unexpected { in parenthesized pipeline"). Render it as the
+  // pipeline-position `bf_ternary` runtime helper instead, recursing so a
+  // right-folded chain (the #2324 union stage's locale→pattern table)
+  // nests as `(bf_ternary <cond> <a> (bf_ternary …))`.
+  const lowerArg = (n: ParsedExpr): string => {
+    if (n.kind === 'conditional') {
+      const test = wrapIfMultiToken(lowerExpr(n.test))
+      return `(bf_ternary ${test} ${lowerArg(n.consequent)} ${lowerArg(n.alternate)})`
+    }
+    return wrapIfMultiToken(lowerExpr(n))
+  }
   if (node.kind === 'helper-call') {
-    const args = node.args.map(a => wrapIfMultiToken(lowerExpr(a)))
+    const args = node.args.map(a => lowerArg(a))
     return [helper, ...args].join(' ')
   }
   // guard-list — `queryHref`-shaped. Inclusion mirrors the client exactly, where

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -1495,6 +1495,21 @@
         "text"
       ]
     },
+    "date-tolocale-union": {
+      "kinds": [
+        "call",
+        "identifier",
+        "literal",
+        "member",
+        "object-literal"
+      ],
+      "axes": [
+        "literal:string"
+      ],
+      "contexts": [
+        "text"
+      ]
+    },
     "deep-nesting": {
       "kinds": [
         "call",
@@ -4145,14 +4160,14 @@
     "array-method": 62,
     "arrow": 55,
     "binary": 67,
-    "call": 160,
+    "call": 161,
     "conditional": 18,
-    "identifier": 240,
+    "identifier": 241,
     "index-access": 12,
-    "literal": 198,
+    "literal": 199,
     "logical": 41,
-    "member": 120,
-    "object-literal": 43,
+    "member": 121,
+    "object-literal": 44,
     "template-literal": 27,
     "unary": 22,
     "unsupported": 21
@@ -4195,7 +4210,7 @@
     "literal:boolean": 37,
     "literal:null": 22,
     "literal:number": 86,
-    "literal:string": 141,
+    "literal:string": 142,
     "logical:&&": 7,
     "logical:??": 37,
     "logical:||": 12,

--- a/packages/adapter-tests/fixtures/date-tolocale-union.ts
+++ b/packages/adapter-tests/fixtures/date-tolocale-union.ts
@@ -40,8 +40,6 @@ export { DateToLocaleUnion }
     { name: 'ja-jp-leap', props: { createdAt: new Date('2024-02-29T12:00:00.000Z'), locale: 'ja-JP' } },
   ],
   expectedHtml: `
-    <div bf-s="test">
-      <time bf="s1"><!--bf:s0-->3/5/2024<!--/--></time>
-    </div>
+    <div bf-s="test"><time bf="s1"><!--bf:s0-->3/5/2024<!--/--></time></div>
   `,
 })

--- a/packages/adapter-tests/fixtures/date-tolocale-union.ts
+++ b/packages/adapter-tests/fixtures/date-tolocale-union.ts
@@ -1,0 +1,47 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Union-typed locale `toLocaleDateString` (#2324's union stage): the locale
+ * argument is a RUNTIME value, but its TS type is a required closed
+ * string-literal union — so the compiler resolves every member's pattern at
+ * build time and lowers the pattern argument to a ternary over the runtime
+ * value, still with zero runtime CLDR on any backend. The client JS is
+ * rewritten to the same ternary `formatDate(...)` form.
+ *
+ * The base props render the `en-US` arm; the `ja-jp-arm` oracle point flips
+ * the locale prop so the OTHER branch of the lowered ternary is compared
+ * live against the JS reference render on every adapter — both arms of the
+ * pattern table are pinned, not just the one the frozen expectedHtml shows.
+ *
+ * Open `locale: string`, optional unions, and unions with an
+ * unrepresentable member (`'ar-SA'`) keep refusing — see
+ * `to-locale-date-lowering.ts`'s module doc and unit tests.
+ */
+export const fixture = createFixture({
+  id: 'date-tolocale-union',
+  description: 'toLocaleDateString with a union-typed runtime locale lowers to a build-time pattern ternary',
+  source: `
+function DateToLocaleUnion({ createdAt, locale }: { createdAt: Date; locale: 'en-US' | 'ja-JP' }) {
+  return (
+    <div>
+      <time>{createdAt.toLocaleDateString(locale, { timeZone: 'UTC' })}</time>
+    </div>
+  )
+}
+export { DateToLocaleUnion }
+`,
+  props: { createdAt: new Date('2024-03-05T12:00:00.000Z'), locale: 'en-US' },
+  dataPoints: [
+    // The other union arm: same instant, ja-JP pattern (YYYY/M/D).
+    { name: 'ja-jp-arm', props: { createdAt: new Date('2024-03-05T12:00:00.000Z'), locale: 'ja-JP' } },
+    // Both arms against a zero-padding-revealing instant (single-digit
+    // month AND day stay bare in both v1 patterns).
+    { name: 'en-us-leap', props: { createdAt: new Date('2024-02-29T12:00:00.000Z'), locale: 'en-US' } },
+    { name: 'ja-jp-leap', props: { createdAt: new Date('2024-02-29T12:00:00.000Z'), locale: 'ja-JP' } },
+  ],
+  expectedHtml: `
+    <div bf-s="test">
+      <time bf="s1"><!--bf:s0-->3/5/2024<!--/--></time>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -398,6 +398,7 @@ import { fixture as dateMethodUncatalogued } from './date-method-uncatalogued'
 import { fixture as dateCatalogued } from './date-catalogued'
 import { fixture as formatDate } from './format-date'
 import { fixture as dateToLocaleLiteral } from './date-tolocale-literal'
+import { fixture as dateToLocaleUnion } from './date-tolocale-union'
 // #2277: the union- and object-typed catalogue extensions to the
 // type-derived adversarial catalogue (`adversarial-catalog.ts`), mirroring
 // the landed Date catalogue work above.
@@ -688,6 +689,7 @@ export const jsxFixtures: JSXFixture[] = [
   dateCatalogued,
   formatDate,
   dateToLocaleLiteral,
+  dateToLocaleUnion,
   unionCatalogued,
   objectCatalogued,
 ]

--- a/packages/adapter-tests/generated-data-points.json
+++ b/packages/adapter-tests/generated-data-points.json
@@ -556,6 +556,35 @@
       }
     }
   ],
+  "date-tolocale-union": [
+    {
+      "name": "gen:createdAt:epoch",
+      "props": {
+        "createdAt": {
+          "$date": "1970-01-01T00:00:00.000Z"
+        },
+        "locale": "en-US"
+      }
+    },
+    {
+      "name": "gen:createdAt:pre-1970",
+      "props": {
+        "createdAt": {
+          "$date": "1969-07-20T20:17:40.123Z"
+        },
+        "locale": "en-US"
+      }
+    },
+    {
+      "name": "gen:createdAt:year-9999",
+      "props": {
+        "createdAt": {
+          "$date": "9999-12-31T23:59:59.999Z"
+        },
+        "locale": "en-US"
+      }
+    }
+  ],
   "default-props": [
     {
       "name": "gen:label:absent",

--- a/packages/jsx/src/__tests__/to-locale-date-lowering.test.ts
+++ b/packages/jsx/src/__tests__/to-locale-date-lowering.test.ts
@@ -118,6 +118,89 @@ describe('matchToLocaleDateStringCall accept/decline table', () => {
   })
 })
 
+describe('union-typed locale (#2324 union stage)', () => {
+  const UNION_SRC = `
+function Foo({ createdAt, locale }: { createdAt: Date; locale: 'en-US' | 'ja-JP' }) {
+  return <div>{createdAt.toLocaleDateString(locale, { timeZone: 'UTC' })}</div>
+}
+export { Foo }
+`
+
+  test('a required closed string-literal union lowers to a ternary pattern', () => {
+    const md = metadata(UNION_SRC)
+    const { callee, args } = callParts(`createdAt.toLocaleDateString(locale, { timeZone: 'UTC' })`)
+    expect(matchToLocaleDateStringCall(callee, args, md)).toEqual({
+      kind: 'helper-call',
+      helper: 'format_date',
+      args: [
+        { kind: 'identifier', name: 'createdAt' },
+        {
+          kind: 'conditional',
+          test: {
+            kind: 'binary',
+            op: '===',
+            left: { kind: 'identifier', name: 'locale' },
+            right: { kind: 'literal', value: 'en-US', literalType: 'string' },
+          },
+          consequent: { kind: 'literal', value: 'M/D/YYYY', literalType: 'string' },
+          alternate: { kind: 'literal', value: 'YYYY/M/D', literalType: 'string' },
+        },
+        { kind: 'literal', value: 'UTC', literalType: 'string' },
+      ],
+    })
+  })
+
+  test('members sharing one pattern collapse the ternary to a literal', () => {
+    const md = metadata(`
+function Foo({ createdAt, locale }: { createdAt: Date; locale: 'en-US' | 'en' }) {
+  return <div>{createdAt.toLocaleDateString(locale, { timeZone: 'UTC' })}</div>
+}
+export { Foo }
+`)
+    const { callee, args } = callParts(`createdAt.toLocaleDateString(locale, { timeZone: 'UTC' })`)
+    expect(matchToLocaleDateStringCall(callee, args, md)).toMatchObject({
+      helper: 'format_date',
+      args: [
+        { kind: 'identifier', name: 'createdAt' },
+        { kind: 'literal', value: 'M/D/YYYY' },
+        { kind: 'literal', value: 'UTC' },
+      ],
+    })
+  })
+
+  test('declines an OPTIONAL union prop (undefined would read the host locale)', () => {
+    const md = metadata(`
+function Foo({ createdAt, locale }: { createdAt: Date; locale?: 'en-US' | 'ja-JP' }) {
+  return <div>{/* @client */ createdAt.toLocaleDateString(locale ?? 'en-US', { timeZone: 'UTC' })}</div>
+}
+export { Foo }
+`)
+    const { callee, args } = callParts(`createdAt.toLocaleDateString(locale, { timeZone: 'UTC' })`)
+    expect(matchToLocaleDateStringCall(callee, args, md)).toBeNull()
+  })
+
+  test('declines a union containing an unrepresentable member', () => {
+    const md = metadata(`
+function Foo({ createdAt, locale }: { createdAt: Date; locale: 'en-US' | 'ar-SA' }) {
+  return <div>{/* @client */ createdAt.toLocaleDateString(locale, { timeZone: 'UTC' })}</div>
+}
+export { Foo }
+`)
+    const { callee, args } = callParts(`createdAt.toLocaleDateString(locale, { timeZone: 'UTC' })`)
+    expect(matchToLocaleDateStringCall(callee, args, md)).toBeNull()
+  })
+
+  test('compiles clean (no BF021) and rewrites client JS to a ternary formatDate', () => {
+    const result = compile(UNION_SRC)
+    expect(result.errors.filter((e) => e.code === ErrorCodes.UNSUPPORTED_JSX_PATTERN)).toEqual([])
+    const js = result.files.find((f) => f.type === 'clientJs')!.content
+    expect(js).toContain(
+      'formatDate(_p.createdAt, _p.locale === "en-US" ? "M/D/YYYY" : "YYYY/M/D", "UTC")',
+    )
+    expect(js).not.toContain('toLocaleDateString')
+  })
+})
+
 describe('BF021 exemption round trip (#2273 seam)', () => {
   test('the claimed literal shape compiles clean; the runtime-locale shape still fires BF021', () => {
     const clean = compile(DATE_PROP_SRC)

--- a/packages/jsx/src/__tests__/to-locale-date-lowering.test.ts
+++ b/packages/jsx/src/__tests__/to-locale-date-lowering.test.ts
@@ -168,6 +168,33 @@ export { Foo }
     })
   })
 
+  test('object-props mode: accepts props.<name>, declines a bare identifier (never a prop there)', () => {
+    const md = metadata(`
+export function Foo(props: { createdAt: Date; locale: 'en-US' | 'ja-JP' }) {
+  return <div>{props.createdAt.toLocaleDateString(props.locale, { timeZone: 'UTC' })}</div>
+}
+`)
+    const member = callParts(`props.createdAt.toLocaleDateString(props.locale, { timeZone: 'UTC' })`)
+    expect(matchToLocaleDateStringCall(member.callee, member.args, md)).toMatchObject({
+      helper: 'format_date',
+      args: [
+        expect.anything(),
+        { kind: 'conditional' },
+        { kind: 'literal', value: 'UTC' },
+      ],
+    })
+    // A bare `locale` identifier in object-props mode is a LOCAL binding,
+    // not the prop — even when a same-named prop exists (Copilot, #2331).
+    const bare = callParts(`props.createdAt.toLocaleDateString(locale, { timeZone: 'UTC' })`)
+    expect(matchToLocaleDateStringCall(bare.callee, bare.args, md)).toBeNull()
+  })
+
+  test('destructured mode: declines a props.<name> member (no props object exists)', () => {
+    const md = metadata(UNION_SRC)
+    const { callee, args } = callParts(`createdAt.toLocaleDateString(props.locale, { timeZone: 'UTC' })`)
+    expect(matchToLocaleDateStringCall(callee, args, md)).toBeNull()
+  })
+
   test('declines an OPTIONAL union prop (undefined would read the host locale)', () => {
     const md = metadata(`
 function Foo({ createdAt, locale }: { createdAt: Date; locale?: 'en-US' | 'ja-JP' }) {

--- a/packages/jsx/src/ir-to-client-js/emit-reactive.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-reactive.ts
@@ -11,7 +11,7 @@ import type { ClientJsContext } from './types.ts'
 import { toHtmlAttrName, varSlotId, PROPS_PARAM } from './utils.ts'
 import { createTemplateAwareStringProtector } from './html-template.ts'
 import { datePlugin, DATE_METHODS } from '../date-lowering.ts'
-import { toLocaleDatePlugin } from '../to-locale-date-lowering.ts'
+import { toLocaleDatePlugin, patternArgToClientJs } from '../to-locale-date-lowering.ts'
 import { tsNodeToParsedExpr } from '../expression-parser.ts'
 import type { LoweringMatcher } from '../lowering-registry.ts'
 
@@ -182,7 +182,9 @@ function lowerToLocaleCallsInReactiveExpr(expr: string, matcher: LoweringMatcher
     )
     if (!node || node.kind !== 'helper-call' || node.helper !== 'format_date') continue
     const [, patternArg, tzArg] = node.args
-    if (patternArg?.kind !== 'literal' || tzArg?.kind !== 'literal') continue
+    if (!patternArg || tzArg?.kind !== 'literal') continue
+    const patternJs = patternArgToClientJs(patternArg, call.arguments[0].getText(sourceFile))
+    if (patternJs === null) continue
     const receiverText = propAccess.expression.getText(sourceFile)
     const matchText = call.getText(sourceFile)
     // The call text contains string literals (placeholders in the protected
@@ -191,7 +193,7 @@ function lowerToLocaleCallsInReactiveExpr(expr: string, matcher: LoweringMatcher
     result = replaceProtectedCall(
       result,
       matchText,
-      () => `formatDate(${receiverText}, ${JSON.stringify(patternArg.value)}, ${JSON.stringify(tzArg.value)})`,
+      () => `formatDate(${receiverText}, ${patternJs}, ${JSON.stringify(tzArg.value)})`,
     )
   }
   return restore(result)

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -49,7 +49,7 @@ import { resolveFreeRefs, isNameBound as isNameBoundInEnv, type BindingEnvironme
 import { computeFileScope } from './ir-to-client-js/component-scope.ts'
 import { createTemplateAwareStringProtector } from './ir-to-client-js/html-template.ts'
 import { datePlugin, DATE_METHODS } from './date-lowering.ts'
-import { toLocaleDatePlugin } from './to-locale-date-lowering.ts'
+import { toLocaleDatePlugin, patternArgToClientJs } from './to-locale-date-lowering.ts'
 import type { LoweringMatcher } from './lowering-registry.ts'
 import { extractFreeIdentifiersFromNode, initializerShapeContainsJsx } from './analyzer.ts'
 import { iterateJsTokens, replaceInExprContexts } from './scanner/js-scanner.ts'
@@ -463,7 +463,9 @@ function lowerToLocaleDateCalls(text: string, expr: ts.Node, ctx: TransformConte
     )
     if (!node || node.kind !== 'helper-call' || node.helper !== 'format_date') continue
     const [, patternArg, tzArg] = node.args
-    if (patternArg?.kind !== 'literal' || tzArg?.kind !== 'literal') continue
+    if (!patternArg || tzArg?.kind !== 'literal') continue
+    const patternJs = patternArgToClientJs(patternArg, ctx.getJS(call.arguments[0]))
+    if (patternJs === null) continue
     const receiverText = ctx.getJS(propAccess.expression)
     const matchText = ctx.getJS(call)
     // Unlike `lowerDateCalls`' zero-arg needle, this call text CONTAINS
@@ -473,7 +475,7 @@ function lowerToLocaleDateCalls(text: string, expr: ts.Node, ctx: TransformConte
     result = replaceProtectedCall(
       result,
       matchText,
-      () => `formatDate(${receiverText}, ${JSON.stringify(patternArg.value)}, ${JSON.stringify(tzArg.value)})`,
+      () => `formatDate(${receiverText}, ${patternJs}, ${JSON.stringify(tzArg.value)})`,
     )
   }
   return restore(result)

--- a/packages/jsx/src/to-locale-date-lowering.ts
+++ b/packages/jsx/src/to-locale-date-lowering.ts
@@ -149,31 +149,39 @@ function unionMemberLiteral(member: TypeInfo): string | null {
 /**
  * Resolve a NON-literal `locale` argument to its closed set of string-literal
  * union members (#2324's union-typed-locale stage), or null to decline.
- * Admitted shapes: a bare identifier bound to a prop, or a
- * `props.<name>` member — both checkable for optionality against
- * `propsType.properties`, which matters because an OPTIONAL union prop can be
- * `undefined` at runtime, and real `toLocaleDateString(undefined, …)` falls
- * back to the HOST locale (the implicit-environment read this plugin exists
- * to rule out) while the lowered pattern table cannot. The prop must be
- * required and every union member a quoted string literal.
+ * Prop-rooting follows `resolveReceiverType`'s rules exactly, per props
+ * mode (Copilot review on #2331 — the looser first cut could mis-identify a
+ * same-named LOCAL binding as the prop):
+ *   - object-props mode (`propsObjectName` set): ONLY a
+ *     `<propsObjectName>.<name>` member — a bare identifier is never a prop
+ *     there;
+ *   - destructured mode: ONLY a bare identifier that is one of
+ *     `propsParams` (resolved through `sourceName` for aliased bindings) —
+ *     there is no props object to member-access.
+ * The prop must be REQUIRED (an optional union can be `undefined` at
+ * runtime, and real `toLocaleDateString(undefined, …)` falls back to the
+ * HOST locale — the implicit-environment read this plugin exists to rule
+ * out) and every union member a quoted string literal.
  */
 function resolveLocaleUnionMembers(locale: ParsedExpr, metadata: IRMetadata): string[] | null {
-  let propName: string | null = null
-  if (locale.kind === 'identifier') {
-    propName = locale.name
-  } else if (
-    locale.kind === 'member' &&
-    !locale.computed &&
-    locale.object.kind === 'identifier' &&
-    locale.object.name === (metadata.propsObjectName ?? 'props')
-  ) {
-    propName = locale.property
+  let sourcePropName: string | null = null
+  if (metadata.propsObjectName) {
+    if (
+      locale.kind === 'member' &&
+      !locale.computed &&
+      locale.object.kind === 'identifier' &&
+      locale.object.name === metadata.propsObjectName
+    ) {
+      sourcePropName = locale.property
+    }
+  } else if (locale.kind === 'identifier') {
+    const name = locale.name
+    const param = metadata.propsParams?.find((pp) => pp.name === name)
+    if (param) sourcePropName = param.sourceName ?? param.name
   }
-  if (!propName) return null
-  const target = propName
-  const prop = metadata.propsType?.properties?.find(
-    (p) => p.name === target || metadata.propsParams?.some((pp) => pp.name === target && (pp.sourceName ?? pp.name) === p.name),
-  )
+  if (!sourcePropName) return null
+  const target = sourcePropName
+  const prop = metadata.propsType?.properties?.find((p) => p.name === target)
   if (!prop || prop.optional) return null
   const type = prop.type
   if (type.kind !== 'union' || !type.unionTypes || type.unionTypes.length === 0) return null

--- a/packages/jsx/src/to-locale-date-lowering.ts
+++ b/packages/jsx/src/to-locale-date-lowering.ts
@@ -19,12 +19,21 @@
  *     `rich-type-refusal.ts`, whose gate exempts exactly what a registered
  *     plugin claims).
  *
+ * A NON-literal locale is admitted in exactly one shape (#2324's
+ * union-typed-locale stage): a REQUIRED prop whose TS type is a closed
+ * string-literal union (`locale: 'en-US' | 'ja-JP'`). Every member's pattern
+ * resolves at build time and the pattern argument lowers to a ternary over
+ * the runtime value — runtime locale switching, still zero runtime CLDR.
+ * The type IS the contract: TS keeps the runtime value inside the union.
+ *
  * Deliberately NOT lowered (decline → loud BF021, never a silent guess):
  *   - zero-arg / locale-only calls — they read the host's locale and/or
  *     timezone, the implicit-environment hole #2273 closed;
- *   - a non-literal locale (`props.locale`) — build-time CLDR resolution is
- *     impossible; the app's i18n layer owns locale → pattern there, feeding
- *     `formatDate` directly;
+ *   - an OPEN-typed runtime locale (`locale: string`) — build-time CLDR
+ *     resolution is impossible; the app's i18n layer owns locale → pattern
+ *     there, feeding `formatDate` directly. An OPTIONAL union prop also
+ *     declines: `undefined` at runtime makes real `toLocaleDateString` read
+ *     the host locale, which no frozen pattern table can reproduce;
  *   - an IANA `timeZone` name — couples output to the host's tzdata version
  *     (only `'UTC'` and fixed `±HH:MM` offsets are deterministic);
  *   - options beyond `timeZone` (`dateStyle`, `month: 'long'`, …) — the
@@ -34,7 +43,7 @@
  *     `ar-SA`: islamic-umalqura calendar, arabic-indic digits).
  */
 
-import type { IRMetadata } from './types.ts'
+import type { IRMetadata, TypeInfo } from './types.ts'
 import type { ParsedExpr } from './expression-parser.ts'
 import type { LoweringNode, LoweringPlugin } from './lowering-registry.ts'
 import { resolveReceiverType, baseTypeName } from './rich-type-evidence.ts'
@@ -131,6 +140,54 @@ function derivePattern(locale: string): string | null {
  * `date-lowering.ts`'s `matchDateCall` exactly (prop-rooted, `Date`-typed,
  * no in-file type shadow, `EMPTY_BINDINGS`).
  */
+/** A quoted string-literal union member's value, or null when the member is anything else. */
+function unionMemberLiteral(member: TypeInfo): string | null {
+  const m = /^'([^'\\]*)'$|^"([^"\\]*)"$/.exec(member.raw.trim())
+  return m ? (m[1] ?? m[2]) : null
+}
+
+/**
+ * Resolve a NON-literal `locale` argument to its closed set of string-literal
+ * union members (#2324's union-typed-locale stage), or null to decline.
+ * Admitted shapes: a bare identifier bound to a prop, or a
+ * `props.<name>` member — both checkable for optionality against
+ * `propsType.properties`, which matters because an OPTIONAL union prop can be
+ * `undefined` at runtime, and real `toLocaleDateString(undefined, …)` falls
+ * back to the HOST locale (the implicit-environment read this plugin exists
+ * to rule out) while the lowered pattern table cannot. The prop must be
+ * required and every union member a quoted string literal.
+ */
+function resolveLocaleUnionMembers(locale: ParsedExpr, metadata: IRMetadata): string[] | null {
+  let propName: string | null = null
+  if (locale.kind === 'identifier') {
+    propName = locale.name
+  } else if (
+    locale.kind === 'member' &&
+    !locale.computed &&
+    locale.object.kind === 'identifier' &&
+    locale.object.name === (metadata.propsObjectName ?? 'props')
+  ) {
+    propName = locale.property
+  }
+  if (!propName) return null
+  const target = propName
+  const prop = metadata.propsType?.properties?.find(
+    (p) => p.name === target || metadata.propsParams?.some((pp) => pp.name === target && (pp.sourceName ?? pp.name) === p.name),
+  )
+  if (!prop || prop.optional) return null
+  const type = prop.type
+  if (type.kind !== 'union' || !type.unionTypes || type.unionTypes.length === 0) return null
+  const members: string[] = []
+  for (const member of type.unionTypes) {
+    const value = unionMemberLiteral(member)
+    if (value === null) return null
+    members.push(value)
+  }
+  return members
+}
+
+const strLit = (value: string): ParsedExpr => ({ kind: 'literal', value, literalType: 'string' })
+
 export function matchToLocaleDateStringCall(
   callee: ParsedExpr,
   args: readonly ParsedExpr[],
@@ -139,7 +196,6 @@ export function matchToLocaleDateStringCall(
   if (callee.kind !== 'member' || callee.computed) return null
   if (callee.property !== 'toLocaleDateString' || args.length !== 2) return null
   const [locale, options] = args
-  if (locale.kind !== 'literal' || locale.literalType !== 'string') return null
   if (options.kind !== 'object-literal' || options.properties.length !== 1) return null
   const prop = options.properties[0]
   if (prop.key !== 'timeZone') return null
@@ -153,17 +209,67 @@ export function matchToLocaleDateStringCall(
   if (typeName !== 'Date') return null
   if (metadata.typeDefinitions.some((d) => d.name === typeName)) return null
 
-  const pattern = resolveLocaleDatePattern(String(locale.value))
-  if (pattern === null) return null
+  // Literal locale: resolve one pattern at build time.
+  if (locale.kind === 'literal' && locale.literalType === 'string') {
+    const pattern = resolveLocaleDatePattern(String(locale.value))
+    if (pattern === null) return null
+    return {
+      kind: 'helper-call',
+      helper: 'format_date',
+      args: [callee.object, strLit(pattern), strLit(tz)],
+    }
+  }
+
+  // Union-typed locale (#2324's union stage): a REQUIRED prop typed as a
+  // closed string-literal union resolves every member's pattern at build
+  // time and lowers the pattern argument to a right-folded ternary over the
+  // runtime locale value — runtime locale switching with zero runtime CLDR.
+  // (A TS-typed value can't leave the union, so the final alternate needs no
+  // guard; equal patterns collapse the ternary away entirely.)
+  const members = resolveLocaleUnionMembers(locale, metadata)
+  if (!members) return null
+  const patterns: string[] = []
+  for (const member of members) {
+    const pattern = resolveLocaleDatePattern(member)
+    if (pattern === null) return null
+    patterns.push(pattern)
+  }
+  let patternExpr: ParsedExpr = strLit(patterns[patterns.length - 1])
+  if (new Set(patterns).size > 1) {
+    for (let i = patterns.length - 2; i >= 0; i--) {
+      patternExpr = {
+        kind: 'conditional',
+        test: { kind: 'binary', op: '===', left: locale, right: strLit(members[i]) },
+        consequent: strLit(patterns[i]),
+        alternate: patternExpr,
+      }
+    }
+  }
   return {
     kind: 'helper-call',
     helper: 'format_date',
-    args: [
-      callee.object,
-      { kind: 'literal', value: pattern, literalType: 'string' },
-      { kind: 'literal', value: tz, literalType: 'string' },
-    ],
+    args: [callee.object, patternExpr, strLit(tz)],
   }
+}
+
+/**
+ * Render a matched node's PATTERN argument as client-JS text for the
+ * #2292-style rewrite sites (`jsx-to-ir.ts` / `emit-reactive.ts`). A literal
+ * pattern stringifies directly; the union stage's right-folded ternary
+ * re-serializes against `localeText` — the rewrite site's own source text
+ * for the locale argument, so downstream prop-prefix rewrites treat it like
+ * any other reference. Returns null for any shape this module didn't build
+ * (the caller then leaves the expression raw rather than guessing).
+ */
+export function patternArgToClientJs(patternArg: ParsedExpr, localeText: string): string | null {
+  if (patternArg.kind === 'literal') return JSON.stringify(patternArg.value)
+  if (patternArg.kind !== 'conditional') return null
+  const t = patternArg.test
+  if (t.kind !== 'binary' || t.op !== '===' || t.right.kind !== 'literal') return null
+  if (patternArg.consequent.kind !== 'literal') return null
+  const rest = patternArgToClientJs(patternArg.alternate, localeText)
+  if (rest === null) return null
+  return `${localeText} === ${JSON.stringify(t.right.value)} ? ${JSON.stringify(patternArg.consequent.value)} : ${rest}`
 }
 
 export const toLocaleDatePlugin: LoweringPlugin = {

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-level honesty section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. Fixtures listed here diverge on at least one adapter — either refused loudly at build time (conformancePins) or rendering differently from the reference (renderDivergences, skipped in that adapter’s conformance suite until fixed). Fixtures absent from this table render to reference parity on every adapter.",
-    "totalFixtures": 259,
+    "totalFixtures": 260,
     "fixtures": {
       "dangerous-inner-html-dynamic": {
         "blade": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -526,11 +526,11 @@
       }
     },
     "call": {
-      "total": 160,
+      "total": 161,
       "cells": {
         "hono": {
-          "pass": 159,
-          "total": 160,
+          "pass": 160,
+          "total": 161,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -541,8 +541,8 @@
           ]
         },
         "blade": {
-          "pass": 155,
-          "total": 160,
+          "pass": 156,
+          "total": 161,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -577,8 +577,8 @@
           ]
         },
         "erb": {
-          "pass": 156,
-          "total": 160,
+          "pass": 157,
+          "total": 161,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -607,8 +607,8 @@
           ]
         },
         "go-template": {
-          "pass": 155,
-          "total": 160,
+          "pass": 156,
+          "total": 161,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -643,8 +643,8 @@
           ]
         },
         "jinja": {
-          "pass": 155,
-          "total": 160,
+          "pass": 156,
+          "total": 161,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -679,8 +679,8 @@
           ]
         },
         "minijinja": {
-          "pass": 155,
-          "total": 160,
+          "pass": 156,
+          "total": 161,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -715,8 +715,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 156,
-          "total": 160,
+          "pass": 157,
+          "total": 161,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -745,8 +745,8 @@
           ]
         },
         "twig": {
-          "pass": 155,
-          "total": 160,
+          "pass": 156,
+          "total": 161,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -781,8 +781,8 @@
           ]
         },
         "xslate": {
-          "pass": 155,
-          "total": 160,
+          "pass": 156,
+          "total": 161,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -860,11 +860,11 @@
       }
     },
     "identifier": {
-      "total": 240,
+      "total": 241,
       "cells": {
         "hono": {
-          "pass": 239,
-          "total": 240,
+          "pass": 240,
+          "total": 241,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -875,8 +875,8 @@
           ]
         },
         "blade": {
-          "pass": 234,
-          "total": 240,
+          "pass": 235,
+          "total": 241,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -917,8 +917,8 @@
           ]
         },
         "erb": {
-          "pass": 235,
-          "total": 240,
+          "pass": 236,
+          "total": 241,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -953,8 +953,8 @@
           ]
         },
         "go-template": {
-          "pass": 234,
-          "total": 240,
+          "pass": 235,
+          "total": 241,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -995,8 +995,8 @@
           ]
         },
         "jinja": {
-          "pass": 234,
-          "total": 240,
+          "pass": 235,
+          "total": 241,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1037,8 +1037,8 @@
           ]
         },
         "minijinja": {
-          "pass": 234,
-          "total": 240,
+          "pass": 235,
+          "total": 241,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1079,8 +1079,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 235,
-          "total": 240,
+          "pass": 236,
+          "total": 241,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1115,8 +1115,8 @@
           ]
         },
         "twig": {
-          "pass": 234,
-          "total": 240,
+          "pass": 235,
+          "total": 241,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1157,8 +1157,8 @@
           ]
         },
         "xslate": {
-          "pass": 234,
-          "total": 240,
+          "pass": 235,
+          "total": 241,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1242,15 +1242,15 @@
       }
     },
     "literal": {
-      "total": 198,
+      "total": 199,
       "cells": {
         "hono": {
-          "pass": 198,
-          "total": 198
+          "pass": 199,
+          "total": 199
         },
         "blade": {
-          "pass": 197,
-          "total": 198,
+          "pass": 198,
+          "total": 199,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1261,8 +1261,8 @@
           ]
         },
         "erb": {
-          "pass": 197,
-          "total": 198,
+          "pass": 198,
+          "total": 199,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1273,8 +1273,8 @@
           ]
         },
         "go-template": {
-          "pass": 197,
-          "total": 198,
+          "pass": 198,
+          "total": 199,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1285,8 +1285,8 @@
           ]
         },
         "jinja": {
-          "pass": 197,
-          "total": 198,
+          "pass": 198,
+          "total": 199,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1297,8 +1297,8 @@
           ]
         },
         "minijinja": {
-          "pass": 197,
-          "total": 198,
+          "pass": 198,
+          "total": 199,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1309,8 +1309,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 197,
-          "total": 198,
+          "pass": 198,
+          "total": 199,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1321,8 +1321,8 @@
           ]
         },
         "twig": {
-          "pass": 197,
-          "total": 198,
+          "pass": 198,
+          "total": 199,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1333,8 +1333,8 @@
           ]
         },
         "xslate": {
-          "pass": 197,
-          "total": 198,
+          "pass": 198,
+          "total": 199,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -1452,11 +1452,11 @@
       }
     },
     "member": {
-      "total": 120,
+      "total": 121,
       "cells": {
         "hono": {
-          "pass": 119,
-          "total": 120,
+          "pass": 120,
+          "total": 121,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1467,8 +1467,8 @@
           ]
         },
         "blade": {
-          "pass": 115,
-          "total": 120,
+          "pass": 116,
+          "total": 121,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1503,8 +1503,8 @@
           ]
         },
         "erb": {
-          "pass": 116,
-          "total": 120,
+          "pass": 117,
+          "total": 121,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1533,8 +1533,8 @@
           ]
         },
         "go-template": {
-          "pass": 115,
-          "total": 120,
+          "pass": 116,
+          "total": 121,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1569,8 +1569,8 @@
           ]
         },
         "jinja": {
-          "pass": 115,
-          "total": 120,
+          "pass": 116,
+          "total": 121,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1605,8 +1605,8 @@
           ]
         },
         "minijinja": {
-          "pass": 115,
-          "total": 120,
+          "pass": 116,
+          "total": 121,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1641,8 +1641,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 116,
-          "total": 120,
+          "pass": 117,
+          "total": 121,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1671,8 +1671,8 @@
           ]
         },
         "twig": {
-          "pass": 115,
-          "total": 120,
+          "pass": 116,
+          "total": 121,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1707,8 +1707,8 @@
           ]
         },
         "xslate": {
-          "pass": 115,
-          "total": 120,
+          "pass": 116,
+          "total": 121,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1745,15 +1745,15 @@
       }
     },
     "object-literal": {
-      "total": 43,
+      "total": 44,
       "cells": {
         "hono": {
-          "pass": 43,
-          "total": 43
+          "pass": 44,
+          "total": 44
         },
         "blade": {
-          "pass": 41,
-          "total": 43,
+          "pass": 42,
+          "total": 44,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1770,8 +1770,8 @@
           ]
         },
         "erb": {
-          "pass": 41,
-          "total": 43,
+          "pass": 42,
+          "total": 44,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1788,8 +1788,8 @@
           ]
         },
         "go-template": {
-          "pass": 41,
-          "total": 43,
+          "pass": 42,
+          "total": 44,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1806,8 +1806,8 @@
           ]
         },
         "jinja": {
-          "pass": 41,
-          "total": 43,
+          "pass": 42,
+          "total": 44,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1824,8 +1824,8 @@
           ]
         },
         "minijinja": {
-          "pass": 41,
-          "total": 43,
+          "pass": 42,
+          "total": 44,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1842,8 +1842,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 41,
-          "total": 43,
+          "pass": 42,
+          "total": 44,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1860,8 +1860,8 @@
           ]
         },
         "twig": {
-          "pass": 41,
-          "total": 43,
+          "pass": 42,
+          "total": 44,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -1878,8 +1878,8 @@
           ]
         },
         "xslate": {
-          "pass": 41,
-          "total": 43,
+          "pass": 42,
+          "total": 44,
           "gaps": [
             {
               "fixture": "dangerous-inner-html-dynamic",
@@ -3905,15 +3905,15 @@
       }
     },
     "literal:string": {
-      "total": 141,
+      "total": 142,
       "cells": {
         "hono": {
-          "pass": 141,
-          "total": 141
+          "pass": 142,
+          "total": 142
         },
         "blade": {
-          "pass": 140,
-          "total": 141,
+          "pass": 141,
+          "total": 142,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3924,8 +3924,8 @@
           ]
         },
         "erb": {
-          "pass": 140,
-          "total": 141,
+          "pass": 141,
+          "total": 142,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3936,8 +3936,8 @@
           ]
         },
         "go-template": {
-          "pass": 140,
-          "total": 141,
+          "pass": 141,
+          "total": 142,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3948,8 +3948,8 @@
           ]
         },
         "jinja": {
-          "pass": 140,
-          "total": 141,
+          "pass": 141,
+          "total": 142,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3960,8 +3960,8 @@
           ]
         },
         "minijinja": {
-          "pass": 140,
-          "total": 141,
+          "pass": 141,
+          "total": 142,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3972,8 +3972,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 140,
-          "total": 141,
+          "pass": 141,
+          "total": 142,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3984,8 +3984,8 @@
           ]
         },
         "twig": {
-          "pass": 140,
-          "total": 141,
+          "pass": 141,
+          "total": 142,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -3996,8 +3996,8 @@
           ]
         },
         "xslate": {
-          "pass": 140,
-          "total": 141,
+          "pass": 141,
+          "total": 142,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",


### PR DESCRIPTION
Two mechanical items from the open trackers, plus one CI-caught Go fix.

## Commit 1 — Fix #2327: re-sync generated Go integration components + add drift gate

**Question 1 of #2327 answered — the `interface{}` widening is intended, not a regression.** `resolvePropGoType` (`packages/adapter-go-template/src/adapter/props/prop-types.ts`) deliberately flips an *optional, no-default, primitive* prop to `interface{}` under four consumption shapes; the one hitting `PostArticle`'s `prevTitle`/`nextTitle` is the **#2267 bare text-position trigger** (landed in `1c2b116`) — an absent optional renders `''` like JS `undefined` instead of the Go zero value / `<no value>`. The committed files simply predate it. **Behavior-preserving for this corpus**: the hosts' `blog_data.go` fields are concrete Go `string`s (never nil), so props JSON and SSR HTML are byte-identical before/after.

- Regenerate `integrations/{chi,echo,gin,nethttp}/components.go` (idempotent; `go build ./...` verified on chi). Diff = exactly the 8 field flips × 4 files.
- Pin the #2267 text-position trigger with a dedicated unit test — the only flip trigger with no direct coverage.
- Drift gate in `ci-go-template.yml`: build all four Go integrations, fail on `git diff` in their `components.go` (the E2E previously ran against the freshly regenerated tree, so stale committed files passed CI silently — how this drift survived four compiler changes).

Fixes #2327.

## Commit 2 — #2324 union stage: union-typed runtime locale for the `toLocaleDateString` sugar

```tsx
function PostMeta({ createdAt, locale }: { createdAt: Date; locale: 'en-US' | 'ja-JP' }) {
  return <time>{createdAt.toLocaleDateString(locale, { timeZone: 'UTC' })}</time>
}
```

A **required** prop typed as a **closed string-literal union** now lowers: every member's default pattern resolves at build time and the pattern argument becomes a right-folded ternary over the runtime value (`locale === 'en-US' ? 'M/D/YYYY' : 'YYYY/M/D'`) on both the SSR helper-call args and the client-JS rewrite — runtime locale switching with **zero runtime CLDR**, the stage #2324 sketched with the `renderToTest` union-semantics precedent (#2000). Equal member patterns collapse the ternary to a single literal.

Still refusing by design: **optional unions** (`undefined` at runtime makes real `toLocaleDateString` read the HOST locale — no frozen table can reproduce that), open `locale: string` (i18n layer → `formatDate`), unions with an unrepresentable member (`'ar-SA'`).

Conformance fixture `date-tolocale-union` (change-time coupling): base props render the `en-US` arm; oracle data points **flip the locale prop** so both ternary arms are compared live against the JS reference on every adapter.

Changeset: `@barefootjs/jsx` minor (commit 2 only).

## Commit 4 — Go: conditional helper-call args via pipeline `bf_ternary` (CI-caught)

The union ternary hit Go's one structural gap: templates have no expression-level conditional, and the generic emitter's `conditional` renders an `{{if}}…{{end}}` action fragment — valid in text position, a parse error inside a pipeline (`unexpected "{" in parenthesized pipeline`, the first CI run's failure; every other backend language has a native conditional expression and rendered the arg fine). `renderLoweringNode`'s helper-call arm now routes a `conditional` arg through the new `bf_ternary` runtime func — `(bf_ternary (eq (bf_string .Locale) "en-US") "M/D/YYYY" "YYYY/M/D")`, recursing for longer member chains. `bf_ternary` is Go-only pipeline glue (like `bf_string`), not a spec-catalogue value helper; pinned by an emitter unit test on the exact pipeline shape.

## Verification

- Commit 1: `bun test packages/adapter-go-template` green; regen idempotent
- Commits 2+4: jsx 2590, adapter-tests 1336 (CSR incl.), Hono 935 (both ternary arms via oracle points), compat 80, **go-template 1118 with a real go1.25 toolchain** (union fixture + both ternary-arm oracle points at reference parity) — all 0 fail; lint + gofmt clean; locks regenerated (260 fixtures, `date-tolocale-union` absent from the divergence table)
- (Commit 3 is the expected-html bot's whitespace normalization.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dBKFhtumbPwjNZaU3LRpy